### PR TITLE
perf: add DiffusionGemma consumer-sufficient TP vocab state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,6 +466,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
       "csrc/libtorch_stable/quantization/fp4/nvfp4_quant_entry.cu"
       "csrc/libtorch_stable/quantization/fp4/nvfp4_scaled_mm_entry.cu"
       "csrc/libtorch_stable/quantization/awq/gemm_kernels.cu"
+      "csrc/libtorch_stable/diffusion_gemma_flashdenoise.cu"
       "csrc/libtorch_stable/minimax_reduce_rms_kernel.cu")
 
     #

--- a/csrc/libtorch_stable/diffusion_gemma_flashdenoise.cu
+++ b/csrc/libtorch_stable/diffusion_gemma_flashdenoise.cu
@@ -1,0 +1,940 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/ScalarType.h>
+
+#include <cublas_v2.h>
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <string>
+
+#include "libtorch_stable/torch_utils.h"
+
+namespace {
+
+constexpr int64_t kModeMaterializedWarpStats = 16;
+constexpr int kWarpStatsReduceThreads = 1024;
+
+inline void check_cublas(cublasStatus_t status, const char* label) {
+  STD_TORCH_CHECK(status == CUBLAS_STATUS_SUCCESS,
+                  std::string("diffusion_gemma_flashdenoise: ") + label +
+                      " failed with cuBLAS status " +
+                      std::to_string(static_cast<int>(status)));
+}
+
+__device__ __forceinline__ bool better_pair(float candidate_value,
+                                            int candidate_index,
+                                            float current_value,
+                                            int current_index) {
+  return candidate_value > current_value ||
+         (candidate_value == current_value && candidate_index < current_index);
+}
+
+__device__ __forceinline__ uint64_t splitmix64(uint64_t x) {
+  x += 0x9E3779B97F4A7C15ULL;
+  x = (x ^ (x >> 30)) * 0xBF58476D1CE4E5B9ULL;
+  x = (x ^ (x >> 27)) * 0x94D049BB133111EBULL;
+  return x ^ (x >> 31);
+}
+
+__device__ __forceinline__ float deterministic_uniform01(
+    uint64_t seed, uint64_t offset, int row, int64_t vocab_idx) {
+  uint64_t key = seed;
+  key ^= offset * 0x9E3779B97F4A7C15ULL;
+  key ^= static_cast<uint64_t>(row) * 0xBF58476D1CE4E5B9ULL;
+  key ^= static_cast<uint64_t>(vocab_idx) * 0x94D049BB133111EBULL;
+  const uint64_t z = splitmix64(key);
+  const uint32_t mantissa = static_cast<uint32_t>((z >> 40) & 0xFFFFFFULL);
+  return (static_cast<float>(mantissa) + 0.5f) * 0x1.0p-24f;
+}
+
+__device__ __forceinline__ float apply_final_logit_softcap(float value,
+                                                           float softcap) {
+  return softcap > 0.0f ? softcap * tanhf(value / softcap) : value;
+}
+
+__device__ __forceinline__ void warp_reduce_best_pair(float& value,
+                                                      int& index) {
+  constexpr unsigned kMask = 0xFFFFFFFFu;
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    const float other_value = __shfl_down_sync(kMask, value, offset);
+    const int other_index = __shfl_down_sync(kMask, index, offset);
+    if (better_pair(other_value, other_index, value, index)) {
+      value = other_value;
+      index = other_index;
+    }
+  }
+}
+
+__device__ __forceinline__ float warp_reduce_sum(float value) {
+  constexpr unsigned kMask = 0xFFFFFFFFu;
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(kMask, value, offset);
+  }
+  return value;
+}
+
+__global__ void logits_to_stats_probs_warp_kernel(
+    const float* __restrict__ logits, __nv_bfloat16* __restrict__ probs,
+    const float* __restrict__ logit_scale, float final_logit_softcapping,
+    float* __restrict__ entropy, float* __restrict__ sample_values,
+    int64_t* __restrict__ sample_indices, float* __restrict__ clean_values,
+    int64_t* __restrict__ clean_indices, int rows, int vocab_size,
+    uint64_t rng_seed, uint64_t rng_offset, int rng_row_offset) {
+  const int row = blockIdx.x;
+  const int tid = threadIdx.x;
+  const int lane = tid & 31;
+  const int warp_id = tid >> 5;
+  const int num_warps = (blockDim.x + 31) >> 5;
+  if (row >= rows) {
+    return;
+  }
+
+  __shared__ float shared_values[32];
+  __shared__ int shared_indices[32];
+  __shared__ float shared_sums[32];
+  __shared__ float shared_weighted[32];
+
+  const float* row_logits = logits + static_cast<int64_t>(row) * vocab_size;
+  const float row_scale = logit_scale == nullptr ? 1.0f : logit_scale[row];
+  __nv_bfloat16* row_probs =
+      probs + static_cast<int64_t>(row) * vocab_size;
+
+  float local_max = -INFINITY;
+  int local_max_idx = 0;
+  for (int v = tid; v < vocab_size; v += blockDim.x) {
+    const float value =
+        apply_final_logit_softcap(row_logits[v], final_logit_softcapping) *
+        row_scale;
+    if (better_pair(value, v, local_max, local_max_idx)) {
+      local_max = value;
+      local_max_idx = v;
+    }
+  }
+  warp_reduce_best_pair(local_max, local_max_idx);
+  if (lane == 0) {
+    shared_values[warp_id] = local_max;
+    shared_indices[warp_id] = local_max_idx;
+  }
+  __syncthreads();
+
+  if (warp_id == 0) {
+    float block_max = lane < num_warps ? shared_values[lane] : -INFINITY;
+    int block_idx = lane < num_warps ? shared_indices[lane] : 0;
+    warp_reduce_best_pair(block_max, block_idx);
+    if (lane == 0) {
+      shared_values[0] = block_max;
+      shared_indices[0] = block_idx;
+    }
+  }
+  __syncthreads();
+
+  const float max_logit = shared_values[0];
+  const int max_idx = shared_indices[0];
+
+  float local_sum_exp = 0.0f;
+  float local_weighted_logits = 0.0f;
+  float local_noisy_max = -INFINITY;
+  int local_noisy_idx = 0;
+  for (int v = tid; v < vocab_size; v += blockDim.x) {
+    const float value =
+        apply_final_logit_softcap(row_logits[v], final_logit_softcapping) *
+        row_scale;
+    const float exp_value = expf(value - max_logit);
+    local_sum_exp += exp_value;
+    local_weighted_logits += exp_value * value;
+
+    const float u =
+        deterministic_uniform01(rng_seed, rng_offset, row + rng_row_offset, v);
+    const float noisy_value = value + (-logf(-logf(u)));
+    if (better_pair(noisy_value, v, local_noisy_max, local_noisy_idx)) {
+      local_noisy_max = noisy_value;
+      local_noisy_idx = v;
+    }
+  }
+
+  local_sum_exp = warp_reduce_sum(local_sum_exp);
+  local_weighted_logits = warp_reduce_sum(local_weighted_logits);
+  warp_reduce_best_pair(local_noisy_max, local_noisy_idx);
+  if (lane == 0) {
+    shared_sums[warp_id] = local_sum_exp;
+    shared_weighted[warp_id] = local_weighted_logits;
+    shared_values[warp_id] = local_noisy_max;
+    shared_indices[warp_id] = local_noisy_idx;
+  }
+  __syncthreads();
+
+  if (warp_id == 0) {
+    float block_sum = lane < num_warps ? shared_sums[lane] : 0.0f;
+    float block_weighted = lane < num_warps ? shared_weighted[lane] : 0.0f;
+    float block_noisy = lane < num_warps ? shared_values[lane] : -INFINITY;
+    int block_noisy_idx = lane < num_warps ? shared_indices[lane] : 0;
+    block_sum = warp_reduce_sum(block_sum);
+    block_weighted = warp_reduce_sum(block_weighted);
+    warp_reduce_best_pair(block_noisy, block_noisy_idx);
+    if (lane == 0) {
+      shared_sums[0] = block_sum;
+      shared_weighted[0] = block_weighted;
+      shared_values[0] = block_noisy;
+      shared_indices[0] = block_noisy_idx;
+    }
+  }
+  __syncthreads();
+
+  const float sum_exp = shared_sums[0];
+  const float inv_sum_exp = 1.0f / sum_exp;
+  if (tid == 0) {
+    entropy[row] =
+        logf(sum_exp) + max_logit - shared_weighted[0] * inv_sum_exp;
+    sample_values[row] = shared_values[0];
+    sample_indices[row] = static_cast<int64_t>(shared_indices[0]);
+    clean_values[row] = max_logit;
+    clean_indices[row] = static_cast<int64_t>(max_idx);
+  }
+
+  for (int v = tid; v < vocab_size; v += blockDim.x) {
+    const float value =
+        apply_final_logit_softcap(row_logits[v], final_logit_softcapping) *
+        row_scale;
+    const float prob = expf(value - max_logit) * inv_sum_exp;
+    row_probs[v] = __float2bfloat16(prob);
+  }
+}
+
+__global__ void logits_to_local_state_exp_warp_kernel(
+    const float* __restrict__ logits, __nv_bfloat16* __restrict__ exp_weights,
+    const float* __restrict__ logit_scale, bool logit_scale_is_scalar,
+    float final_logit_softcapping, float* __restrict__ local_max,
+    float* __restrict__ local_sum_exp,
+    float* __restrict__ local_weighted_logits,
+    float* __restrict__ sample_values, int64_t* __restrict__ sample_indices,
+    float* __restrict__ clean_values, int64_t* __restrict__ clean_indices,
+    int rows, int vocab_size, int64_t vocab_start_index, uint64_t rng_seed,
+    uint64_t rng_offset) {
+  const int row = blockIdx.x;
+  const int tid = threadIdx.x;
+  const int lane = tid & 31;
+  const int warp_id = tid >> 5;
+  const int num_warps = (blockDim.x + 31) >> 5;
+  if (row >= rows) {
+    return;
+  }
+
+  __shared__ float shared_values[32];
+  __shared__ int shared_indices[32];
+  __shared__ float shared_sums[32];
+  __shared__ float shared_weighted[32];
+
+  const float* row_logits = logits + static_cast<int64_t>(row) * vocab_size;
+  __nv_bfloat16* row_exp =
+      exp_weights + static_cast<int64_t>(row) * vocab_size;
+  const float row_scale = logit_scale_is_scalar ? logit_scale[0]
+                                                : logit_scale[row];
+
+  float local_clean_max = -INFINITY;
+  int local_clean_idx = 0;
+  for (int v = tid; v < vocab_size; v += blockDim.x) {
+    const float value =
+        apply_final_logit_softcap(row_logits[v], final_logit_softcapping) *
+        row_scale;
+    if (better_pair(value, v, local_clean_max, local_clean_idx)) {
+      local_clean_max = value;
+      local_clean_idx = v;
+    }
+  }
+  warp_reduce_best_pair(local_clean_max, local_clean_idx);
+  if (lane == 0) {
+    shared_values[warp_id] = local_clean_max;
+    shared_indices[warp_id] = local_clean_idx;
+  }
+  __syncthreads();
+
+  if (warp_id == 0) {
+    float block_max = lane < num_warps ? shared_values[lane] : -INFINITY;
+    int block_idx = lane < num_warps ? shared_indices[lane] : 0;
+    warp_reduce_best_pair(block_max, block_idx);
+    if (lane == 0) {
+      shared_values[0] = block_max;
+      shared_indices[0] = block_idx;
+    }
+  }
+  __syncthreads();
+
+  const float max_logit = shared_values[0];
+  const int max_idx = shared_indices[0];
+
+  float row_sum_exp = 0.0f;
+  float row_weighted_logits = 0.0f;
+  float local_noisy_max = -INFINITY;
+  int local_noisy_idx = 0;
+  for (int v = tid; v < vocab_size; v += blockDim.x) {
+    const float value =
+        apply_final_logit_softcap(row_logits[v], final_logit_softcapping) *
+        row_scale;
+    const float exp_value = expf(value - max_logit);
+    row_exp[v] = __float2bfloat16(exp_value);
+    row_sum_exp += exp_value;
+    row_weighted_logits += exp_value * value;
+
+    // MVP sampling uses deterministic SplitMix64 keyed by row and global token.
+    const int64_t global_idx = vocab_start_index + static_cast<int64_t>(v);
+    const float u = deterministic_uniform01(rng_seed, rng_offset, row,
+                                            global_idx);
+    const float noisy_value = value + (-logf(-logf(u)));
+    if (better_pair(noisy_value, v, local_noisy_max, local_noisy_idx)) {
+      local_noisy_max = noisy_value;
+      local_noisy_idx = v;
+    }
+  }
+
+  row_sum_exp = warp_reduce_sum(row_sum_exp);
+  row_weighted_logits = warp_reduce_sum(row_weighted_logits);
+  warp_reduce_best_pair(local_noisy_max, local_noisy_idx);
+  if (lane == 0) {
+    shared_sums[warp_id] = row_sum_exp;
+    shared_weighted[warp_id] = row_weighted_logits;
+    shared_values[warp_id] = local_noisy_max;
+    shared_indices[warp_id] = local_noisy_idx;
+  }
+  __syncthreads();
+
+  if (warp_id == 0) {
+    float block_sum = lane < num_warps ? shared_sums[lane] : 0.0f;
+    float block_weighted = lane < num_warps ? shared_weighted[lane] : 0.0f;
+    float block_noisy = lane < num_warps ? shared_values[lane] : -INFINITY;
+    int block_noisy_idx = lane < num_warps ? shared_indices[lane] : 0;
+    block_sum = warp_reduce_sum(block_sum);
+    block_weighted = warp_reduce_sum(block_weighted);
+    warp_reduce_best_pair(block_noisy, block_noisy_idx);
+    if (lane == 0) {
+      shared_sums[0] = block_sum;
+      shared_weighted[0] = block_weighted;
+      shared_values[0] = block_noisy;
+      shared_indices[0] = block_noisy_idx;
+    }
+  }
+  __syncthreads();
+
+  if (tid == 0) {
+    local_max[row] = max_logit;
+    local_sum_exp[row] = shared_sums[0];
+    local_weighted_logits[row] = shared_weighted[0];
+    sample_values[row] = shared_values[0];
+    sample_indices[row] =
+        vocab_start_index + static_cast<int64_t>(shared_indices[0]);
+    clean_values[row] = max_logit;
+    clean_indices[row] = vocab_start_index + static_cast<int64_t>(max_idx);
+  }
+}
+
+__global__ void pack_local_state_kernel(
+    float* __restrict__ packed, const float* __restrict__ local_max,
+    const float* __restrict__ global_max,
+    const float* __restrict__ local_sum_exp,
+    const float* __restrict__ local_weighted_logits,
+    const float* __restrict__ local_soft_part, int rows, int hidden_size) {
+  const int row = blockIdx.x;
+  if (row >= rows) {
+    return;
+  }
+
+  __shared__ float merge_scale;
+  if (threadIdx.x == 0) {
+    merge_scale = expf(local_max[row] - global_max[row]);
+  }
+  __syncthreads();
+
+  const int columns = hidden_size + 2;
+  float* row_packed = packed + static_cast<int64_t>(row) * columns;
+  const float* row_soft =
+      local_soft_part + static_cast<int64_t>(row) * hidden_size;
+  for (int col = threadIdx.x; col < columns; col += blockDim.x) {
+    float value;
+    if (col == 0) {
+      value = local_sum_exp[row];
+    } else if (col == 1) {
+      value = local_weighted_logits[row];
+    } else {
+      value = row_soft[col - 2];
+    }
+    row_packed[col] = value * merge_scale;
+  }
+}
+
+void validate_flashdenoise_tensors(
+    const char* label, torch::stable::Tensor& entropy,
+    torch::stable::Tensor& sample_values,
+    torch::stable::Tensor& sample_indices,
+    torch::stable::Tensor& clean_values,
+    torch::stable::Tensor& clean_indices,
+    torch::stable::Tensor& soft_embed,
+    torch::stable::Tensor const& hidden,
+    torch::stable::Tensor const& lm_head_weight,
+    const torch::stable::Tensor* logit_scale) {
+  STD_TORCH_CHECK(hidden.dim() == 2 && lm_head_weight.dim() == 2,
+                  label, ": hidden and lm_head_weight must be rank-2");
+  STD_TORCH_CHECK(entropy.dim() == 1 && sample_values.dim() == 1 &&
+                      sample_indices.dim() == 1 && clean_values.dim() == 1 &&
+                      clean_indices.dim() == 1 && soft_embed.dim() == 2,
+                  label, ": output shapes must be [rows] scalars and "
+                         "soft_embed=[rows, hidden]");
+  if (logit_scale != nullptr) {
+    STD_TORCH_CHECK(logit_scale->dim() == 1,
+                    label, ": logit_scale must be rank-1");
+  }
+
+  STD_TORCH_CHECK(hidden.is_cuda() && lm_head_weight.is_cuda() &&
+                      entropy.is_cuda() && sample_values.is_cuda() &&
+                      sample_indices.is_cuda() && clean_values.is_cuda() &&
+                      clean_indices.is_cuda() && soft_embed.is_cuda(),
+                  label, ": all tensors must be CUDA tensors");
+  if (logit_scale != nullptr) {
+    STD_TORCH_CHECK(logit_scale->is_cuda(),
+                    label, ": logit_scale must be a CUDA tensor");
+  }
+
+  STD_TORCH_CHECK(hidden.is_contiguous() && lm_head_weight.is_contiguous() &&
+                      entropy.is_contiguous() && sample_values.is_contiguous() &&
+                      sample_indices.is_contiguous() &&
+                      clean_values.is_contiguous() &&
+                      clean_indices.is_contiguous() && soft_embed.is_contiguous(),
+                  label, ": all tensors must be contiguous");
+  if (logit_scale != nullptr) {
+    STD_TORCH_CHECK(logit_scale->is_contiguous(),
+                    label, ": logit_scale must be contiguous");
+  }
+
+  const int64_t rows = hidden.size(0);
+  const int64_t hidden_size = hidden.size(1);
+  const int64_t vocab_size = lm_head_weight.size(0);
+  STD_TORCH_CHECK(lm_head_weight.size(1) == hidden_size,
+                  label, ": hidden size mismatch");
+  STD_TORCH_CHECK(entropy.size(0) == rows && sample_values.size(0) == rows &&
+                      sample_indices.size(0) == rows &&
+                      clean_values.size(0) == rows &&
+                      clean_indices.size(0) == rows &&
+                      soft_embed.size(0) == rows &&
+                      soft_embed.size(1) == hidden_size,
+                  label, ": output shapes do not match hidden");
+  if (logit_scale != nullptr) {
+    STD_TORCH_CHECK(logit_scale->size(0) == rows,
+                    label, ": logit_scale must have one value per row");
+  }
+
+  STD_TORCH_CHECK(vocab_size > 0 && hidden_size > 0,
+                  label, ": vocab and hidden sizes must be positive");
+  STD_TORCH_CHECK(vocab_size <= std::numeric_limits<int>::max() &&
+                      hidden_size <= std::numeric_limits<int>::max() &&
+                      rows <= std::numeric_limits<int>::max(),
+                  label, ": shapes exceed CUDA kernel int32 limits");
+  STD_TORCH_CHECK(vocab_size % 8 == 0 && hidden_size % 8 == 0,
+                  label, ": vocab and hidden sizes must be divisible by 8");
+  STD_TORCH_CHECK(rows <= 1024 && vocab_size <= 262144 && hidden_size <= 4096,
+                  label, ": mode16 supports rows<=1024, vocab<=262144, "
+                         "hidden<=4096");
+
+  STD_TORCH_CHECK(
+      hidden.scalar_type() == torch::headeronly::ScalarType::BFloat16 &&
+          lm_head_weight.scalar_type() ==
+              torch::headeronly::ScalarType::BFloat16,
+      label, ": hidden and lm_head_weight must be bf16");
+  STD_TORCH_CHECK(entropy.scalar_type() == torch::headeronly::ScalarType::Float &&
+                      sample_values.scalar_type() ==
+                          torch::headeronly::ScalarType::Float &&
+                      clean_values.scalar_type() ==
+                          torch::headeronly::ScalarType::Float &&
+                      soft_embed.scalar_type() ==
+                          torch::headeronly::ScalarType::Float,
+                  label, ": entropy, sample_values, clean_values, and "
+                         "soft_embed must be fp32");
+  STD_TORCH_CHECK(
+      sample_indices.scalar_type() == torch::headeronly::ScalarType::Long &&
+          clean_indices.scalar_type() == torch::headeronly::ScalarType::Long,
+      label, ": sample_indices and clean_indices must be int64");
+  if (logit_scale != nullptr) {
+    STD_TORCH_CHECK(logit_scale->scalar_type() ==
+                        torch::headeronly::ScalarType::Float,
+                    label, ": logit_scale must be fp32");
+  }
+
+  const int32_t device_index = hidden.get_device_index();
+  STD_TORCH_CHECK(lm_head_weight.get_device_index() == device_index &&
+                      entropy.get_device_index() == device_index &&
+                      sample_values.get_device_index() == device_index &&
+                      sample_indices.get_device_index() == device_index &&
+                      clean_values.get_device_index() == device_index &&
+                      clean_indices.get_device_index() == device_index &&
+                      soft_embed.get_device_index() == device_index,
+                  label, ": all tensors must be on the same CUDA device");
+  if (logit_scale != nullptr) {
+    STD_TORCH_CHECK(logit_scale->get_device_index() == device_index,
+                    label, ": logit_scale must be on the same CUDA device");
+  }
+}
+
+void validate_local_state_tensors(
+    const char* label, torch::stable::Tensor& local_max,
+    torch::stable::Tensor& local_sum_exp,
+    torch::stable::Tensor& local_weighted_logits,
+    torch::stable::Tensor& local_soft_part,
+    torch::stable::Tensor& clean_values,
+    torch::stable::Tensor& clean_indices,
+    torch::stable::Tensor& sample_values,
+    torch::stable::Tensor& sample_indices,
+    torch::stable::Tensor const& hidden,
+    torch::stable::Tensor const& lm_head_weight,
+    torch::stable::Tensor const& logit_scale) {
+  STD_TORCH_CHECK(hidden.dim() == 2 && lm_head_weight.dim() == 2,
+                  label, ": hidden and lm_head_weight must be rank-2");
+  STD_TORCH_CHECK(local_max.dim() == 1 && local_sum_exp.dim() == 1 &&
+                      local_weighted_logits.dim() == 1 &&
+                      local_soft_part.dim() == 2 && clean_values.dim() == 1 &&
+                      clean_indices.dim() == 1 && sample_values.dim() == 1 &&
+                      sample_indices.dim() == 1,
+                  label, ": output shapes must be [rows] state values and "
+                         "local_soft_part=[rows, hidden]");
+  STD_TORCH_CHECK(logit_scale.dim() == 0 || logit_scale.dim() == 1, label,
+                  ": logit_scale must be scalar or rank-1");
+
+  STD_TORCH_CHECK(hidden.is_cuda() && lm_head_weight.is_cuda() &&
+                      logit_scale.is_cuda() && local_max.is_cuda() &&
+                      local_sum_exp.is_cuda() &&
+                      local_weighted_logits.is_cuda() &&
+                      local_soft_part.is_cuda() && clean_values.is_cuda() &&
+                      clean_indices.is_cuda() && sample_values.is_cuda() &&
+                      sample_indices.is_cuda(),
+                  label, ": all tensors must be CUDA tensors");
+
+  STD_TORCH_CHECK(hidden.is_contiguous() && lm_head_weight.is_contiguous() &&
+                      logit_scale.is_contiguous() && local_max.is_contiguous() &&
+                      local_sum_exp.is_contiguous() &&
+                      local_weighted_logits.is_contiguous() &&
+                      local_soft_part.is_contiguous() &&
+                      clean_values.is_contiguous() &&
+                      clean_indices.is_contiguous() &&
+                      sample_values.is_contiguous() &&
+                      sample_indices.is_contiguous(),
+                  label, ": all tensors must be contiguous");
+
+  const int64_t rows = hidden.size(0);
+  const int64_t hidden_size = hidden.size(1);
+  const int64_t vocab_size = lm_head_weight.size(0);
+  STD_TORCH_CHECK(lm_head_weight.size(1) == hidden_size,
+                  label, ": hidden size mismatch");
+  STD_TORCH_CHECK(local_max.size(0) == rows && local_sum_exp.size(0) == rows &&
+                      local_weighted_logits.size(0) == rows &&
+                      local_soft_part.size(0) == rows &&
+                      local_soft_part.size(1) == hidden_size &&
+                      clean_values.size(0) == rows &&
+                      clean_indices.size(0) == rows &&
+                      sample_values.size(0) == rows &&
+                      sample_indices.size(0) == rows,
+                  label, ": output shapes do not match hidden");
+  if (logit_scale.dim() == 1) {
+    STD_TORCH_CHECK(logit_scale.size(0) == 1 || logit_scale.size(0) == rows,
+                    label,
+                    ": logit_scale must have one value or one value per row");
+  }
+
+  STD_TORCH_CHECK(vocab_size > 0 && hidden_size > 0,
+                  label, ": vocab and hidden sizes must be positive");
+  STD_TORCH_CHECK(vocab_size <= std::numeric_limits<int>::max() &&
+                      hidden_size <= std::numeric_limits<int>::max() &&
+                      rows <= std::numeric_limits<int>::max(),
+                  label, ": shapes exceed CUDA kernel int32 limits");
+  STD_TORCH_CHECK(vocab_size % 8 == 0 && hidden_size % 8 == 0,
+                  label, ": vocab and hidden sizes must be divisible by 8");
+  STD_TORCH_CHECK(rows <= 32768 && vocab_size <= 262144 && hidden_size <= 8192,
+                  label, ": local-state MVP supports rows<=32768, "
+                         "vocab<=262144, hidden<=8192");
+
+  STD_TORCH_CHECK(
+      hidden.scalar_type() == torch::headeronly::ScalarType::BFloat16 &&
+          lm_head_weight.scalar_type() ==
+              torch::headeronly::ScalarType::BFloat16,
+      label, ": hidden and lm_head_weight must be bf16");
+  STD_TORCH_CHECK(local_max.scalar_type() == torch::headeronly::ScalarType::Float &&
+                      local_sum_exp.scalar_type() ==
+                          torch::headeronly::ScalarType::Float &&
+                      local_weighted_logits.scalar_type() ==
+                          torch::headeronly::ScalarType::Float &&
+                      local_soft_part.scalar_type() ==
+                          torch::headeronly::ScalarType::Float &&
+                      clean_values.scalar_type() ==
+                          torch::headeronly::ScalarType::Float &&
+                      sample_values.scalar_type() ==
+                          torch::headeronly::ScalarType::Float,
+                  label, ": floating state outputs must be fp32");
+  STD_TORCH_CHECK(clean_indices.scalar_type() ==
+                          torch::headeronly::ScalarType::Long &&
+                      sample_indices.scalar_type() ==
+                          torch::headeronly::ScalarType::Long,
+                  label, ": indices must be int64");
+  STD_TORCH_CHECK(logit_scale.scalar_type() ==
+                      torch::headeronly::ScalarType::Float,
+                  label, ": logit_scale must be fp32");
+
+  const int32_t device_index = hidden.get_device_index();
+  STD_TORCH_CHECK(lm_head_weight.get_device_index() == device_index &&
+                      logit_scale.get_device_index() == device_index &&
+                      local_max.get_device_index() == device_index &&
+                      local_sum_exp.get_device_index() == device_index &&
+                      local_weighted_logits.get_device_index() == device_index &&
+                      local_soft_part.get_device_index() == device_index &&
+                      clean_values.get_device_index() == device_index &&
+                      clean_indices.get_device_index() == device_index &&
+                      sample_values.get_device_index() == device_index &&
+                      sample_indices.get_device_index() == device_index,
+                  label, ": all tensors must be on the same CUDA device");
+}
+
+void validate_pack_local_state_tensors(
+    const char* label, torch::stable::Tensor& packed,
+    torch::stable::Tensor const& local_max,
+    torch::stable::Tensor const& global_max,
+    torch::stable::Tensor const& local_sum_exp,
+    torch::stable::Tensor const& local_weighted_logits,
+    torch::stable::Tensor const& local_soft_part) {
+  STD_TORCH_CHECK(packed.dim() == 2 && local_soft_part.dim() == 2,
+                  label, ": packed and local_soft_part must be rank-2");
+  STD_TORCH_CHECK(local_max.dim() == 1 && global_max.dim() == 1 &&
+                      local_sum_exp.dim() == 1 &&
+                      local_weighted_logits.dim() == 1,
+                  label, ": scalar state tensors must be rank-1");
+  STD_TORCH_CHECK(packed.is_cuda() && local_max.is_cuda() &&
+                      global_max.is_cuda() && local_sum_exp.is_cuda() &&
+                      local_weighted_logits.is_cuda() &&
+                      local_soft_part.is_cuda(),
+                  label, ": all tensors must be CUDA tensors");
+  STD_TORCH_CHECK(packed.is_contiguous() && local_max.is_contiguous() &&
+                      global_max.is_contiguous() &&
+                      local_sum_exp.is_contiguous() &&
+                      local_weighted_logits.is_contiguous() &&
+                      local_soft_part.is_contiguous(),
+                  label, ": all tensors must be contiguous");
+
+  const int64_t rows = local_soft_part.size(0);
+  const int64_t hidden_size = local_soft_part.size(1);
+  STD_TORCH_CHECK(local_max.size(0) == rows && global_max.size(0) == rows &&
+                      local_sum_exp.size(0) == rows &&
+                      local_weighted_logits.size(0) == rows &&
+                      packed.size(0) == rows &&
+                      packed.size(1) == hidden_size + 2,
+                  label, ": packed must be [rows, hidden+2] and scalar "
+                         "state tensors must be [rows]");
+  STD_TORCH_CHECK(hidden_size >= 0 &&
+                      rows <= std::numeric_limits<int>::max() &&
+                      hidden_size <= std::numeric_limits<int>::max() - 2,
+                  label, ": shapes exceed CUDA kernel limits");
+
+  STD_TORCH_CHECK(packed.scalar_type() == torch::headeronly::ScalarType::Float &&
+                      local_max.scalar_type() ==
+                          torch::headeronly::ScalarType::Float &&
+                      global_max.scalar_type() ==
+                          torch::headeronly::ScalarType::Float &&
+                      local_sum_exp.scalar_type() ==
+                          torch::headeronly::ScalarType::Float &&
+                      local_weighted_logits.scalar_type() ==
+                          torch::headeronly::ScalarType::Float &&
+                      local_soft_part.scalar_type() ==
+                          torch::headeronly::ScalarType::Float,
+                  label, ": all tensors must be fp32");
+
+  const int32_t device_index = local_soft_part.get_device_index();
+  STD_TORCH_CHECK(packed.get_device_index() == device_index &&
+                      local_max.get_device_index() == device_index &&
+                      global_max.get_device_index() == device_index &&
+                      local_sum_exp.get_device_index() == device_index &&
+                      local_weighted_logits.get_device_index() == device_index,
+                  label, ": all tensors must be on the same CUDA device");
+}
+
+void run_mode16(
+    torch::stable::Tensor& entropy, torch::stable::Tensor& sample_values,
+    torch::stable::Tensor& sample_indices, torch::stable::Tensor& clean_values,
+    torch::stable::Tensor& clean_indices, torch::stable::Tensor& soft_embed,
+    torch::stable::Tensor const& hidden,
+    torch::stable::Tensor const& lm_head_weight, const float* logit_scale,
+    float normalizer, float final_logit_softcapping, int64_t rng_seed,
+    int64_t rng_offset, int64_t rng_row_offset) {
+  const int64_t rows = hidden.size(0);
+  if (rows == 0) {
+    return;
+  }
+
+  const int64_t vocab_size = lm_head_weight.size(0);
+  const int64_t hidden_size = hidden.size(1);
+  const int32_t device_index = hidden.get_device_index();
+  const torch::stable::accelerator::DeviceGuard device_guard(device_index);
+  const cudaStream_t stream = get_current_cuda_stream(device_index);
+
+  const auto device = hidden.device();
+  auto logits = torch::stable::empty({rows, vocab_size},
+                                     torch::headeronly::ScalarType::Float,
+                                     std::nullopt, device);
+  auto probs = torch::stable::empty({rows, vocab_size},
+                                    torch::headeronly::ScalarType::BFloat16,
+                                    std::nullopt, device);
+
+  auto* logits_ptr = logits.mutable_data_ptr<float>();
+  auto* probs_ptr =
+      reinterpret_cast<__nv_bfloat16*>(probs.mutable_data_ptr());
+  const auto* hidden_ptr =
+      reinterpret_cast<const __nv_bfloat16*>(hidden.const_data_ptr());
+  const auto* weight_ptr =
+      reinterpret_cast<const __nv_bfloat16*>(lm_head_weight.const_data_ptr());
+  auto* soft_embed_ptr = soft_embed.mutable_data_ptr<float>();
+
+  cublasHandle_t handle = get_current_cuda_blas_handle();
+  check_cublas(cublasSetStream(handle, stream), "cublasSetStream");
+
+  const float one = 1.0f;
+  const float zero = 0.0f;
+
+  check_cublas(
+      cublasGemmEx(handle, CUBLAS_OP_T, CUBLAS_OP_N,
+                   static_cast<int>(vocab_size), static_cast<int>(rows),
+                   static_cast<int>(hidden_size), &one, weight_ptr,
+                   CUDA_R_16BF, static_cast<int>(hidden_size), hidden_ptr,
+                   CUDA_R_16BF, static_cast<int>(hidden_size), &zero,
+                   logits_ptr, CUDA_R_32F, static_cast<int>(vocab_size),
+                   CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP),
+      "LM-head GEMM");
+
+  logits_to_stats_probs_warp_kernel<<<static_cast<unsigned int>(rows),
+                                      kWarpStatsReduceThreads, 0, stream>>>(
+      logits_ptr, probs_ptr, logit_scale, final_logit_softcapping,
+      entropy.mutable_data_ptr<float>(), sample_values.mutable_data_ptr<float>(),
+      sample_indices.mutable_data_ptr<int64_t>(),
+      clean_values.mutable_data_ptr<float>(),
+      clean_indices.mutable_data_ptr<int64_t>(), static_cast<int>(rows),
+      static_cast<int>(vocab_size), static_cast<uint64_t>(rng_seed),
+      static_cast<uint64_t>(rng_offset), static_cast<int>(rng_row_offset));
+  const cudaError_t status = cudaGetLastError();
+  STD_TORCH_CHECK(status == cudaSuccess,
+                  "diffusion_gemma_flashdenoise: logits-to-probs kernel "
+                  "launch failed: " +
+                      std::string(cudaGetErrorString(status)));
+
+  check_cublas(
+      cublasGemmEx(handle, CUBLAS_OP_N, CUBLAS_OP_N,
+                   static_cast<int>(hidden_size), static_cast<int>(rows),
+                   static_cast<int>(vocab_size), &normalizer, weight_ptr,
+                   CUDA_R_16BF, static_cast<int>(hidden_size), probs_ptr,
+                   CUDA_R_16BF, static_cast<int>(vocab_size), &zero,
+                   soft_embed_ptr, CUDA_R_32F, static_cast<int>(hidden_size),
+                   CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP),
+      "soft-embed GEMM");
+}
+
+void run_local_state_scaled(
+    torch::stable::Tensor& local_max,
+    torch::stable::Tensor& local_sum_exp,
+    torch::stable::Tensor& local_weighted_logits,
+    torch::stable::Tensor& local_soft_part,
+    torch::stable::Tensor& clean_values,
+    torch::stable::Tensor& clean_indices,
+    torch::stable::Tensor& sample_values,
+    torch::stable::Tensor& sample_indices,
+    torch::stable::Tensor const& hidden,
+    torch::stable::Tensor const& lm_head_weight,
+    torch::stable::Tensor const& logit_scale, int64_t vocab_start_index,
+    float final_logit_softcapping, int64_t rng_seed, int64_t rng_offset) {
+  const int64_t rows = hidden.size(0);
+  if (rows == 0) {
+    return;
+  }
+
+  const int64_t vocab_size = lm_head_weight.size(0);
+  const int64_t hidden_size = hidden.size(1);
+  STD_TORCH_CHECK(vocab_start_index >= 0 &&
+                      vocab_start_index <=
+                          std::numeric_limits<int64_t>::max() - vocab_size,
+                  "diffusion_gemma_flashdenoise_local_state_scaled: invalid "
+                  "vocab_start_index");
+  const int32_t device_index = hidden.get_device_index();
+  const torch::stable::accelerator::DeviceGuard device_guard(device_index);
+  const cudaStream_t stream = get_current_cuda_stream(device_index);
+
+  const auto device = hidden.device();
+  auto logits = torch::stable::empty({rows, vocab_size},
+                                     torch::headeronly::ScalarType::Float,
+                                     std::nullopt, device);
+  auto exp_weights = torch::stable::empty(
+      {rows, vocab_size}, torch::headeronly::ScalarType::BFloat16, std::nullopt,
+      device);
+
+  auto* logits_ptr = logits.mutable_data_ptr<float>();
+  auto* exp_weights_ptr =
+      reinterpret_cast<__nv_bfloat16*>(exp_weights.mutable_data_ptr());
+  const auto* hidden_ptr =
+      reinterpret_cast<const __nv_bfloat16*>(hidden.const_data_ptr());
+  const auto* weight_ptr =
+      reinterpret_cast<const __nv_bfloat16*>(lm_head_weight.const_data_ptr());
+  auto* local_soft_part_ptr = local_soft_part.mutable_data_ptr<float>();
+
+  cublasHandle_t handle = get_current_cuda_blas_handle();
+  check_cublas(cublasSetStream(handle, stream), "cublasSetStream");
+
+  const float one = 1.0f;
+  const float zero = 0.0f;
+
+  check_cublas(
+      cublasGemmEx(handle, CUBLAS_OP_T, CUBLAS_OP_N,
+                   static_cast<int>(vocab_size), static_cast<int>(rows),
+                   static_cast<int>(hidden_size), &one, weight_ptr,
+                   CUDA_R_16BF, static_cast<int>(hidden_size), hidden_ptr,
+                   CUDA_R_16BF, static_cast<int>(hidden_size), &zero,
+                   logits_ptr, CUDA_R_32F, static_cast<int>(vocab_size),
+                   CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP),
+      "local-state LM-head GEMM");
+
+  logits_to_local_state_exp_warp_kernel<<<static_cast<unsigned int>(rows),
+                                          kWarpStatsReduceThreads, 0, stream>>>(
+      logits_ptr, exp_weights_ptr, logit_scale.const_data_ptr<float>(),
+      logit_scale.dim() == 0 || logit_scale.size(0) == 1,
+      final_logit_softcapping, local_max.mutable_data_ptr<float>(),
+      local_sum_exp.mutable_data_ptr<float>(),
+      local_weighted_logits.mutable_data_ptr<float>(),
+      sample_values.mutable_data_ptr<float>(),
+      sample_indices.mutable_data_ptr<int64_t>(),
+      clean_values.mutable_data_ptr<float>(),
+      clean_indices.mutable_data_ptr<int64_t>(), static_cast<int>(rows),
+      static_cast<int>(vocab_size), vocab_start_index,
+      static_cast<uint64_t>(rng_seed), static_cast<uint64_t>(rng_offset));
+  cudaError_t status = cudaGetLastError();
+  STD_TORCH_CHECK(status == cudaSuccess,
+                  "diffusion_gemma_flashdenoise_local_state_scaled: "
+                  "logits-to-local-state kernel launch failed: " +
+                      std::string(cudaGetErrorString(status)));
+
+  check_cublas(
+      cublasGemmEx(handle, CUBLAS_OP_N, CUBLAS_OP_N,
+                   static_cast<int>(hidden_size), static_cast<int>(rows),
+                   static_cast<int>(vocab_size), &one, weight_ptr, CUDA_R_16BF,
+                   static_cast<int>(hidden_size), exp_weights_ptr, CUDA_R_16BF,
+                   static_cast<int>(vocab_size), &zero, local_soft_part_ptr,
+                   CUDA_R_32F, static_cast<int>(hidden_size),
+                   CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP),
+      "local-state soft-part GEMM");
+}
+
+void run_pack_local_state(torch::stable::Tensor& packed,
+                          torch::stable::Tensor const& local_max,
+                          torch::stable::Tensor const& global_max,
+                          torch::stable::Tensor const& local_sum_exp,
+                          torch::stable::Tensor const& local_weighted_logits,
+                          torch::stable::Tensor const& local_soft_part) {
+  const int64_t rows = local_soft_part.size(0);
+  if (rows == 0) {
+    return;
+  }
+
+  const int64_t hidden_size = local_soft_part.size(1);
+  const int32_t device_index = local_soft_part.get_device_index();
+  const torch::stable::accelerator::DeviceGuard device_guard(device_index);
+  const cudaStream_t stream = get_current_cuda_stream(device_index);
+
+  pack_local_state_kernel<<<static_cast<unsigned int>(rows), 256, 0, stream>>>(
+      packed.mutable_data_ptr<float>(), local_max.const_data_ptr<float>(),
+      global_max.const_data_ptr<float>(), local_sum_exp.const_data_ptr<float>(),
+      local_weighted_logits.const_data_ptr<float>(),
+      local_soft_part.const_data_ptr<float>(), static_cast<int>(rows),
+      static_cast<int>(hidden_size));
+  const cudaError_t status = cudaGetLastError();
+  STD_TORCH_CHECK(status == cudaSuccess,
+                  "diffusion_gemma_flashdenoise_pack_local_state: kernel "
+                  "launch failed: " +
+                      std::string(cudaGetErrorString(status)));
+}
+
+}  // namespace
+
+void diffusion_gemma_flashdenoise(
+    torch::stable::Tensor& entropy, torch::stable::Tensor& sample_values,
+    torch::stable::Tensor& sample_indices, torch::stable::Tensor& clean_values,
+    torch::stable::Tensor& clean_indices, torch::stable::Tensor& soft_embed,
+    torch::stable::Tensor const& hidden,
+    torch::stable::Tensor const& lm_head_weight, double normalizer,
+    int64_t mode_flags, int64_t rng_seed, int64_t rng_offset) {
+  validate_flashdenoise_tensors("diffusion_gemma_flashdenoise", entropy,
+                                sample_values, sample_indices, clean_values,
+                                clean_indices, soft_embed, hidden,
+                                lm_head_weight, nullptr);
+  STD_TORCH_CHECK(mode_flags == kModeMaterializedWarpStats,
+                  "diffusion_gemma_flashdenoise: this build only supports "
+                  "mode_flags=16");
+  run_mode16(entropy, sample_values, sample_indices, clean_values,
+             clean_indices, soft_embed, hidden, lm_head_weight, nullptr,
+             static_cast<float>(normalizer), 0.0f, rng_seed, rng_offset, 0);
+}
+
+void diffusion_gemma_flashdenoise_scaled(
+    torch::stable::Tensor& entropy, torch::stable::Tensor& sample_values,
+    torch::stable::Tensor& sample_indices, torch::stable::Tensor& clean_values,
+    torch::stable::Tensor& clean_indices, torch::stable::Tensor& soft_embed,
+    torch::stable::Tensor const& hidden,
+    torch::stable::Tensor const& lm_head_weight,
+    torch::stable::Tensor const& logit_scale, double normalizer,
+    double final_logit_softcapping, int64_t mode_flags, int64_t rng_seed,
+    int64_t rng_offset, int64_t rng_row_offset) {
+  validate_flashdenoise_tensors("diffusion_gemma_flashdenoise_scaled", entropy,
+                                sample_values, sample_indices, clean_values,
+                                clean_indices, soft_embed, hidden,
+                                lm_head_weight, &logit_scale);
+  STD_TORCH_CHECK(mode_flags == kModeMaterializedWarpStats,
+                  "diffusion_gemma_flashdenoise_scaled: this build only "
+                  "supports mode_flags=16");
+  run_mode16(entropy, sample_values, sample_indices, clean_values,
+             clean_indices, soft_embed, hidden, lm_head_weight,
+             logit_scale.const_data_ptr<float>(), static_cast<float>(normalizer),
+             static_cast<float>(final_logit_softcapping), rng_seed, rng_offset,
+             rng_row_offset);
+}
+
+void diffusion_gemma_flashdenoise_local_state_scaled(
+    torch::stable::Tensor& local_max,
+    torch::stable::Tensor& local_sum_exp,
+    torch::stable::Tensor& local_weighted_logits,
+    torch::stable::Tensor& local_soft_part,
+    torch::stable::Tensor& clean_values,
+    torch::stable::Tensor& clean_indices,
+    torch::stable::Tensor& sample_values,
+    torch::stable::Tensor& sample_indices,
+    torch::stable::Tensor const& hidden,
+    torch::stable::Tensor const& lm_head_weight,
+    torch::stable::Tensor const& logit_scale, int64_t vocab_start_index,
+    double final_logit_softcapping, int64_t rng_seed, int64_t rng_offset) {
+  validate_local_state_tensors(
+      "diffusion_gemma_flashdenoise_local_state_scaled", local_max,
+      local_sum_exp, local_weighted_logits, local_soft_part, clean_values,
+      clean_indices, sample_values, sample_indices, hidden, lm_head_weight,
+      logit_scale);
+  run_local_state_scaled(local_max, local_sum_exp, local_weighted_logits,
+                         local_soft_part, clean_values, clean_indices,
+                         sample_values, sample_indices, hidden, lm_head_weight,
+                         logit_scale, vocab_start_index,
+                         static_cast<float>(final_logit_softcapping), rng_seed,
+                         rng_offset);
+}
+
+void diffusion_gemma_flashdenoise_pack_local_state(
+    torch::stable::Tensor& packed, torch::stable::Tensor const& local_max,
+    torch::stable::Tensor const& global_max,
+    torch::stable::Tensor const& local_sum_exp,
+    torch::stable::Tensor const& local_weighted_logits,
+    torch::stable::Tensor const& local_soft_part) {
+  validate_pack_local_state_tensors(
+      "diffusion_gemma_flashdenoise_pack_local_state", packed, local_max,
+      global_max, local_sum_exp, local_weighted_logits, local_soft_part);
+  run_pack_local_state(packed, local_max, global_max, local_sum_exp,
+                       local_weighted_logits, local_soft_part);
+}

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -43,6 +43,47 @@ void per_token_group_quant_int8(const torch::stable::Tensor& input,
                                 int64_t group_size, double eps, double int8_min,
                                 double int8_max);
 
+#ifndef USE_ROCM
+void diffusion_gemma_flashdenoise(
+    torch::stable::Tensor& entropy, torch::stable::Tensor& sample_values,
+    torch::stable::Tensor& sample_indices, torch::stable::Tensor& clean_values,
+    torch::stable::Tensor& clean_indices, torch::stable::Tensor& soft_embed,
+    torch::stable::Tensor const& hidden,
+    torch::stable::Tensor const& lm_head_weight, double normalizer,
+    int64_t mode_flags, int64_t rng_seed, int64_t rng_offset);
+
+void diffusion_gemma_flashdenoise_scaled(
+    torch::stable::Tensor& entropy, torch::stable::Tensor& sample_values,
+    torch::stable::Tensor& sample_indices, torch::stable::Tensor& clean_values,
+    torch::stable::Tensor& clean_indices, torch::stable::Tensor& soft_embed,
+    torch::stable::Tensor const& hidden,
+    torch::stable::Tensor const& lm_head_weight,
+    torch::stable::Tensor const& logit_scale, double normalizer,
+    double final_logit_softcapping, int64_t mode_flags, int64_t rng_seed,
+    int64_t rng_offset, int64_t rng_row_offset);
+
+void diffusion_gemma_flashdenoise_local_state_scaled(
+    torch::stable::Tensor& local_max,
+    torch::stable::Tensor& local_sum_exp,
+    torch::stable::Tensor& local_weighted_logits,
+    torch::stable::Tensor& local_soft_part,
+    torch::stable::Tensor& clean_values,
+    torch::stable::Tensor& clean_indices,
+    torch::stable::Tensor& sample_values,
+    torch::stable::Tensor& sample_indices,
+    torch::stable::Tensor const& hidden,
+    torch::stable::Tensor const& lm_head_weight,
+    torch::stable::Tensor const& logit_scale, int64_t vocab_start_index,
+    double final_logit_softcapping, int64_t rng_seed, int64_t rng_offset);
+
+void diffusion_gemma_flashdenoise_pack_local_state(
+    torch::stable::Tensor& packed, torch::stable::Tensor const& local_max,
+    torch::stable::Tensor const& global_max,
+    torch::stable::Tensor const& local_sum_exp,
+    torch::stable::Tensor const& local_weighted_logits,
+    torch::stable::Tensor const& local_soft_part);
+#endif
+
 torch::stable::Tensor permute_cols(torch::stable::Tensor const& A,
                                    torch::stable::Tensor const& perm);
 

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -27,6 +27,30 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "per_token_group_quant_int8(Tensor input, Tensor! output_q, Tensor! "
       "output_s, int group_size, float eps, float int8_min, float int8_max) -> "
       "()");
+#ifndef USE_ROCM
+  ops.def(
+      "diffusion_gemma_flashdenoise(Tensor! entropy, Tensor! sample_values, "
+      "Tensor! sample_indices, Tensor! clean_values, Tensor! clean_indices, "
+      "Tensor! soft_embed, Tensor hidden, Tensor lm_head_weight, "
+      "float normalizer, int mode_flags, int rng_seed, int rng_offset) -> ()");
+  ops.def(
+      "diffusion_gemma_flashdenoise_scaled(Tensor! entropy, Tensor! "
+      "sample_values, Tensor! sample_indices, Tensor! clean_values, Tensor! "
+      "clean_indices, Tensor! soft_embed, Tensor hidden, Tensor lm_head_weight, "
+      "Tensor logit_scale, float normalizer, float final_logit_softcapping, "
+      "int mode_flags, int rng_seed, int rng_offset, int rng_row_offset) -> ()");
+  ops.def(
+      "diffusion_gemma_flashdenoise_local_state_scaled(Tensor! local_max, "
+      "Tensor! local_sum_exp, Tensor! local_weighted_logits, "
+      "Tensor! local_soft_part, Tensor! clean_values, Tensor! clean_indices, "
+      "Tensor! sample_values, Tensor! sample_indices, Tensor hidden, "
+      "Tensor lm_head_weight, Tensor logit_scale, int vocab_start_index, "
+      "float final_logit_softcapping, int rng_seed, int rng_offset) -> ()");
+  ops.def(
+      "diffusion_gemma_flashdenoise_pack_local_state(Tensor! packed, "
+      "Tensor local_max, Tensor global_max, Tensor local_sum_exp, "
+      "Tensor local_weighted_logits, Tensor local_soft_part) -> ()");
+#endif
   ops.def("permute_cols(Tensor A, Tensor perm) -> Tensor");
 
 #ifndef USE_ROCM
@@ -635,6 +659,17 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
            TORCH_BOX(&per_token_group_quant_8bit_packed));
   ops.impl("per_token_group_quant_int8",
            TORCH_BOX(&per_token_group_quant_int8));
+
+#ifndef USE_ROCM
+  ops.impl("diffusion_gemma_flashdenoise",
+           TORCH_BOX(&diffusion_gemma_flashdenoise));
+  ops.impl("diffusion_gemma_flashdenoise_scaled",
+           TORCH_BOX(&diffusion_gemma_flashdenoise_scaled));
+  ops.impl("diffusion_gemma_flashdenoise_local_state_scaled",
+           TORCH_BOX(&diffusion_gemma_flashdenoise_local_state_scaled));
+  ops.impl("diffusion_gemma_flashdenoise_pack_local_state",
+           TORCH_BOX(&diffusion_gemma_flashdenoise_pack_local_state));
+#endif
 
   ops.impl("permute_cols", TORCH_BOX(&permute_cols));
 

--- a/docs/design/diffusion_gemma_flashdenoise_tp_state.md
+++ b/docs/design/diffusion_gemma_flashdenoise_tp_state.md
@@ -1,0 +1,86 @@
+# DiffusionGemma FlashDenoise TP State
+
+This note defines the exact tensor-parallel sampler state for
+DiffusionGemma FlashDenoise. The goal is to compute the same per-token
+sampler outputs as a dense vocabulary pass without materializing the full
+probability vector on every TP rank.
+
+For one sampler row, let `z_i` be the final scaled logit for global token id
+`i`, `E_i` the matching LM-head / embedding row, `g_i` the Gumbel noise used
+for sampling, and `normalizer` the DiffusionGemma self-conditioning scalar.
+Dense probabilities are:
+
+```text
+p_i = exp(z_i) / sum_j exp(z_j)
+```
+
+The dense outputs are:
+
+```text
+entropy = -sum_i p_i log p_i
+soft_embed = sum_i p_i E_i * normalizer
+clean_argmax = argmax_i z_i
+gumbel_argmax = argmax_i (z_i + g_i)
+```
+
+Argmax ties are resolved by the smallest global token id, matching the first
+token a dense left-to-right argmax would see.
+
+## TP-Local State
+
+For rank `r`, let `I_r` be the real global-vocabulary ids owned by that rank.
+Padded local rows, if any, are not part of `I_r` and must not contribute to
+the state. The local state fields are exactly:
+
+```text
+m = max_{i in I_r} z_i
+s = sum_{i in I_r} exp(z_i - m)
+w = sum_{i in I_r} exp(z_i - m) * z_i
+e = sum_{i in I_r} exp(z_i - m) * E_i
+clean_val = max_{i in I_r} z_i
+clean_idx = global token id for clean_val
+sample_val = max_{i in I_r} (z_i + g_i)
+sample_idx = global token id for sample_val
+normalizer = DiffusionGemma self-conditioning scalar
+```
+
+`e` is unnormalized on purpose:
+
+```text
+e = sum_i exp(z_i - m_r) * E_i
+```
+
+It does not include division by `s`, all-reduced normalization, or
+multiplication by `normalizer`.
+
+## Merge
+
+Given one local state per TP rank:
+
+```text
+m = max_r m_r
+s = sum_r s_r * exp(m_r - m)
+w = sum_r w_r * exp(m_r - m)
+e = sum_r e_r * exp(m_r - m)
+entropy = log(s) + m - w / s
+soft_embed = e / s * normalizer
+```
+
+The merged `clean_argmax` is the best `(clean_val, clean_idx)` pair across
+ranks using value descending and global id ascending. The merged
+`gumbel_argmax` is the same reduction over `(sample_val, sample_idx)`. The
+returned ids are global token ids, not local shard offsets.
+
+## Difference From PR-Style TP Fixes
+
+PR #46212 computes `sum_r(P_r @ W_r)` after full probabilities exist. This
+work computes `entropy`, argmax, sampling, and `soft_embed` from TP-local
+state before full probability materialization. That distinction matters for
+FlashDenoise because the sampler needs entropy and selected token ids at the
+same boundary where the soft embedding is produced.
+
+The CPU reference tests in
+`tests/models/test_diffusion_gemma_flashdenoise_state.py` compare this merged
+TP state against dense softmax, dense entropy, dense soft embedding, clean
+argmax, and Gumbel argmax for TP=4, non-divisible shard ranges with padding,
+and deterministic global-id tie breaking.

--- a/tests/models/test_diffusion_gemma_consumer_state_safety.py
+++ b/tests/models/test_diffusion_gemma_consumer_state_safety.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import ast
+from pathlib import Path
+
+import torch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DIFFUSION_GEMMA = REPO_ROOT / "vllm" / "model_executor" / "models" / "diffusion_gemma.py"
+MODEL_RUNNER = REPO_ROOT / "vllm" / "v1" / "worker" / "gpu" / "model_runner.py"
+
+
+def _module(path: Path) -> ast.Module:
+    return ast.parse(path.read_text())
+
+
+def _function(tree: ast.Module, name: str) -> ast.FunctionDef:
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"missing function {name}")
+
+
+def _call_name(call: ast.Call) -> str:
+    func = call.func
+    if isinstance(func, ast.Attribute):
+        parts = [func.attr]
+        value = func.value
+        while isinstance(value, ast.Attribute):
+            parts.append(value.attr)
+            value = value.value
+        if isinstance(value, ast.Name):
+            parts.append(value.id)
+        return ".".join(reversed(parts))
+    if isinstance(func, ast.Name):
+        return func.id
+    return ""
+
+
+def test_dense_compiled_sampler_preserves_upstream_rng_draw_order():
+    tree = _module(DIFFUSION_GEMMA)
+    compiled = _function(tree, "_compiled_sample_step")
+
+    arg_names = [arg.arg for arg in compiled.args.args]
+    assert "random_tokens" not in arg_names
+
+    calls = [
+        (_call_name(node), node.lineno)
+        for node in ast.walk(compiled)
+        if isinstance(node, ast.Call)
+    ]
+    rand_like_line = min(line for name, line in calls if name == "torch.rand_like")
+    randint_line = min(line for name, line in calls if name == "torch.randint")
+    assert rand_like_line < randint_line
+
+
+def test_dense_tp_fallback_syncs_canvas_after_rank_local_rng():
+    source = DIFFUSION_GEMMA.read_text()
+    compiled_call = source.index("scaled = _compiled_sample_step(")
+    sync_call = source.index(
+        "states.canvas[decode_slots] = _tp_broadcast_from_rank0(",
+        compiled_call,
+    )
+    draft_sync = source.index(
+        "self.req_states.draft_tokens[all_slots, :CL] = states.canvas[",
+        sync_call,
+    )
+    assert sync_call > compiled_call
+    assert draft_sync > sync_call
+
+
+def test_diffusion_gemma_local_logits_are_context_gated():
+    tree = _module(DIFFUSION_GEMMA)
+    cls = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and node.name == "DiffusionGemmaForConditionalGeneration"
+    )
+    compute_logits = next(
+        node
+        for node in cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == "compute_logits"
+    )
+    source = ast.unparse(compute_logits)
+    assert "_allow_local_vocab_logits" in source
+    assert "_DIFFUSION_GEMMA_LOCAL_VOCAB_SAMPLER and self._allow_local_vocab_logits" in source
+
+
+def test_model_runner_only_enables_local_logits_without_full_vocab_consumers():
+    source = MODEL_RUNNER.read_text()
+    assert "enable_local_vocab_logits" in source
+    assert "grammar_output is None and self.rejection_sampler is None" in source
+
+
+def test_local_vocab_argmax_empty_shard_returns_losing_sentinel():
+    tree = _module(DIFFUSION_GEMMA)
+    helper = _function(tree, "_local_vocab_argmax_tokens")
+    module = ast.Module(body=[helper], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {"torch": torch}
+    exec(compile(module, str(DIFFUSION_GEMMA), "exec"), namespace)
+
+    values, indices = namespace["_local_vocab_argmax_tokens"](
+        torch.empty(2, 0),
+        vocab_start_index=128,
+        local_vocab_width=0,
+    )
+
+    assert values.shape == (2,)
+    assert indices.shape == (2,)
+    assert torch.isneginf(values).all()
+    assert torch.equal(indices, torch.full((2,), torch.iinfo(torch.int64).max))

--- a/tests/models/test_diffusion_gemma_flashdenoise.py
+++ b/tests/models/test_diffusion_gemma_flashdenoise.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import math
+
+import pytest
+import torch
+
+import vllm._custom_ops as ops
+
+
+def _splitmix64(x: int) -> int:
+    mask = (1 << 64) - 1
+    x = (x + 0x9E3779B97F4A7C15) & mask
+    x = ((x ^ (x >> 30)) * 0xBF58476D1CE4E5B9) & mask
+    x = ((x ^ (x >> 27)) * 0x94D049BB133111EB) & mask
+    return (x ^ (x >> 31)) & mask
+
+
+def _uniform01(seed: int, offset: int, row: int, vocab_idx: int) -> float:
+    mask = (1 << 64) - 1
+    key = seed & mask
+    key ^= ((offset & mask) * 0x9E3779B97F4A7C15) & mask
+    key ^= (row * 0xBF58476D1CE4E5B9) & mask
+    key ^= (vocab_idx * 0x94D049BB133111EB) & mask
+    z = _splitmix64(key)
+    mantissa = (z >> 40) & 0xFFFFFF
+    return (mantissa + 0.5) * (2.0**-24)
+
+
+def _reference_from_logits(
+    logits: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    normalizer: float,
+    rng_seed: int,
+    rng_offset: int,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    logits_cpu = logits.detach().cpu().float()
+    weight_cpu = lm_head_weight.detach().cpu().float()
+    rows, vocab_size = logits_cpu.shape
+
+    noisy_logits = logits_cpu.clone()
+    for row in range(rows):
+        for vocab_idx in range(vocab_size):
+            u = _uniform01(rng_seed, rng_offset, row, vocab_idx)
+            noisy_logits[row, vocab_idx] += -math.log(-math.log(u))
+
+    sample_values, sample_indices = noisy_logits.max(dim=-1)
+    clean_values, clean_indices = logits_cpu.max(dim=-1)
+    log_probs = logits_cpu.log_softmax(dim=-1)
+    probs = log_probs.exp()
+    entropy = -(probs * log_probs).sum(dim=-1)
+    soft_embed = torch.matmul(probs.to(torch.bfloat16).float(), weight_cpu)
+    return (
+        entropy,
+        sample_values,
+        sample_indices,
+        clean_values,
+        clean_indices,
+        soft_embed * normalizer,
+    )
+
+
+def test_flashdenoise_python_wrappers_are_available():
+    assert hasattr(ops, "diffusion_gemma_flashdenoise")
+    assert hasattr(ops, "diffusion_gemma_flashdenoise_scaled")
+
+
+def test_flashdenoise_wrapper_reports_unavailable_without_native_op():
+    if hasattr(torch.ops, "_C") and hasattr(
+        torch.ops._C, "diffusion_gemma_flashdenoise"
+    ):
+        pytest.skip("native FlashDenoise op is registered")
+
+    tensor = torch.empty(1)
+    with pytest.raises(RuntimeError, match="native op is unavailable"):
+        ops.diffusion_gemma_flashdenoise(
+            tensor,
+            tensor,
+            torch.empty(1, dtype=torch.int64),
+            tensor,
+            torch.empty(1, dtype=torch.int64),
+            torch.empty(1, 1),
+            torch.empty(1, 1),
+            torch.empty(1, 1),
+            1.0,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_native_flashdenoise_mode16_matches_dense_reference():
+    if not hasattr(torch.ops, "_C") or not hasattr(
+        torch.ops._C, "diffusion_gemma_flashdenoise"
+    ):
+        pytest.skip("native FlashDenoise op is unavailable")
+
+    rows, hidden_size, vocab_size = 19, 64, 512
+    normalizer = 0.75
+    rng_seed = 24680
+    rng_offset = 11
+    generator = torch.Generator(device="cuda").manual_seed(17)
+    hidden = (
+        torch.randn(
+            rows,
+            hidden_size,
+            device="cuda",
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.125
+    ).to(torch.bfloat16)
+    lm_head_weight = (
+        torch.randn(
+            vocab_size,
+            hidden_size,
+            device="cuda",
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.125
+    ).to(torch.bfloat16)
+
+    entropy = torch.empty(rows, device="cuda", dtype=torch.float32)
+    sample_values = torch.empty(rows, device="cuda", dtype=torch.float32)
+    sample_indices = torch.empty(rows, device="cuda", dtype=torch.int64)
+    clean_values = torch.empty(rows, device="cuda", dtype=torch.float32)
+    clean_indices = torch.empty(rows, device="cuda", dtype=torch.int64)
+    soft_embed = torch.empty(rows, hidden_size, device="cuda", dtype=torch.float32)
+
+    ops.diffusion_gemma_flashdenoise(
+        entropy,
+        sample_values,
+        sample_indices,
+        clean_values,
+        clean_indices,
+        soft_embed,
+        hidden,
+        lm_head_weight,
+        normalizer,
+        mode_flags=16,
+        rng_seed=rng_seed,
+        rng_offset=rng_offset,
+    )
+    torch.cuda.synchronize()
+
+    dense_logits = torch.mm(hidden, lm_head_weight.t(), out_dtype=torch.float32)
+    expected = _reference_from_logits(
+        dense_logits,
+        lm_head_weight,
+        normalizer,
+        rng_seed,
+        rng_offset,
+    )
+
+    torch.testing.assert_close(sample_indices.cpu(), expected[2])
+    torch.testing.assert_close(clean_indices.cpu(), expected[4])
+    torch.testing.assert_close(sample_values.cpu(), expected[1], atol=2e-3, rtol=0)
+    torch.testing.assert_close(clean_values.cpu(), expected[3], atol=2e-3, rtol=0)
+    torch.testing.assert_close(entropy.cpu(), expected[0], atol=2e-3, rtol=0)
+    torch.testing.assert_close(soft_embed.cpu(), expected[5], atol=2e-3, rtol=2e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_native_flashdenoise_scaled_mode16_matches_dense_reference():
+    if not hasattr(torch.ops, "_C") or not hasattr(
+        torch.ops._C, "diffusion_gemma_flashdenoise_scaled"
+    ):
+        pytest.skip("native scaled FlashDenoise op is unavailable")
+
+    rows, hidden_size, vocab_size = 13, 64, 512
+    normalizer = 0.75
+    rng_seed = 13579
+    rng_offset = 23
+    generator = torch.Generator(device="cuda").manual_seed(29)
+    hidden = (
+        torch.randn(
+            rows,
+            hidden_size,
+            device="cuda",
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.125
+    ).to(torch.bfloat16)
+    lm_head_weight = (
+        torch.randn(
+            vocab_size,
+            hidden_size,
+            device="cuda",
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.125
+    ).to(torch.bfloat16)
+    logit_scale = torch.linspace(
+        0.5, 1.75, rows, device="cuda", dtype=torch.float32
+    )
+
+    entropy = torch.empty(rows, device="cuda", dtype=torch.float32)
+    sample_values = torch.empty(rows, device="cuda", dtype=torch.float32)
+    sample_indices = torch.empty(rows, device="cuda", dtype=torch.int64)
+    clean_values = torch.empty(rows, device="cuda", dtype=torch.float32)
+    clean_indices = torch.empty(rows, device="cuda", dtype=torch.int64)
+    soft_embed = torch.empty(rows, hidden_size, device="cuda", dtype=torch.float32)
+
+    ops.diffusion_gemma_flashdenoise_scaled(
+        entropy,
+        sample_values,
+        sample_indices,
+        clean_values,
+        clean_indices,
+        soft_embed,
+        hidden,
+        lm_head_weight,
+        logit_scale,
+        normalizer,
+        mode_flags=16,
+        rng_seed=rng_seed,
+        rng_offset=rng_offset,
+    )
+    torch.cuda.synchronize()
+
+    dense_logits = torch.mm(hidden, lm_head_weight.t(), out_dtype=torch.float32)
+    expected = _reference_from_logits(
+        dense_logits * logit_scale.unsqueeze(-1),
+        lm_head_weight,
+        normalizer,
+        rng_seed,
+        rng_offset,
+    )
+
+    torch.testing.assert_close(sample_indices.cpu(), expected[2])
+    torch.testing.assert_close(clean_indices.cpu(), expected[4])
+    torch.testing.assert_close(sample_values.cpu(), expected[1], atol=2e-3, rtol=0)
+    torch.testing.assert_close(clean_values.cpu(), expected[3], atol=2e-3, rtol=0)
+    torch.testing.assert_close(entropy.cpu(), expected[0], atol=2e-3, rtol=0)
+    torch.testing.assert_close(soft_embed.cpu(), expected[5], atol=2e-3, rtol=2e-2)

--- a/tests/models/test_diffusion_gemma_flashdenoise_native_tp.py
+++ b/tests/models/test_diffusion_gemma_flashdenoise_native_tp.py
@@ -1,0 +1,326 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+import vllm._custom_ops as ops
+
+
+_MASK64 = (1 << 64) - 1
+
+
+def _splitmix64(value: int) -> int:
+    value = (value + 0x9E3779B97F4A7C15) & _MASK64
+    value = ((value ^ (value >> 30)) * 0xBF58476D1CE4E5B9) & _MASK64
+    value = ((value ^ (value >> 27)) * 0x94D049BB133111EB) & _MASK64
+    return (value ^ (value >> 31)) & _MASK64
+
+
+def _deterministic_uniform01(
+    seed: int,
+    offset: int,
+    row: int,
+    vocab_idx: int,
+) -> float:
+    key = int(seed) & _MASK64
+    key ^= (int(offset) * 0x9E3779B97F4A7C15) & _MASK64
+    key ^= (int(row) * 0xBF58476D1CE4E5B9) & _MASK64
+    key ^= (int(vocab_idx) * 0x94D049BB133111EB) & _MASK64
+    mantissa = (_splitmix64(key) >> 40) & 0xFFFFFF
+    return (float(mantissa) + 0.5) * (2.0**-24)
+
+
+def _deterministic_gumbels(
+    rows: int,
+    vocab_size: int,
+    *,
+    vocab_start_index: int,
+    rng_seed: int,
+    rng_offset: int,
+) -> torch.Tensor:
+    uniforms = torch.empty(rows, vocab_size, dtype=torch.float32)
+    for row in range(rows):
+        for vocab_offset in range(vocab_size):
+            uniforms[row, vocab_offset] = _deterministic_uniform01(
+                rng_seed,
+                rng_offset,
+                row,
+                vocab_start_index + vocab_offset,
+            )
+    return -torch.log(-torch.log(uniforms))
+
+
+def _require_native_flashdenoise_op(name: str) -> None:
+    if not hasattr(torch.ops, "_C") or not hasattr(torch.ops._C, name):
+        pytest.skip(f"native op {name} is unavailable in this vLLM extension")
+
+
+def _dense_local_state_reference(
+    hidden: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    logit_scale: torch.Tensor,
+    vocab_start_index: int,
+    final_logit_softcapping: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    logits = torch.mm(hidden, lm_head_weight.t(), out_dtype=torch.float32)
+    if final_logit_softcapping > 0.0:
+        logits = final_logit_softcapping * torch.tanh(
+            logits / final_logit_softcapping
+        )
+    logits = logits * logit_scale.reshape(-1, 1)
+
+    local_max, local_indices = logits.max(dim=-1)
+    local_exp = torch.exp(logits - local_max.unsqueeze(-1))
+    local_sum_exp = local_exp.sum(dim=-1)
+    local_weighted_logits = (local_exp * logits).sum(dim=-1)
+    local_soft_part = torch.mm(
+        local_exp.to(torch.bfloat16), lm_head_weight, out_dtype=torch.float32
+    )
+    clean_indices = local_indices.to(torch.int64) + vocab_start_index
+    gumbels = _deterministic_gumbels(
+        hidden.shape[0],
+        lm_head_weight.shape[0],
+        vocab_start_index=vocab_start_index,
+        rng_seed=1234,
+        rng_offset=99,
+    ).to(logits.device)
+    noisy = logits + gumbels
+    sample_values, sample_local_indices = noisy.max(dim=-1)
+    sample_indices = sample_local_indices.to(torch.int64) + vocab_start_index
+    return (
+        local_max,
+        local_sum_exp,
+        local_weighted_logits,
+        local_soft_part,
+        clean_indices,
+        sample_values,
+        sample_indices,
+    )
+
+
+@pytest.mark.parametrize("scale_mode", ["per_row", "scalar"])
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_local_state_scaled_matches_dense_reference_for_local_vocab_shard(
+    scale_mode: str,
+):
+    _require_native_flashdenoise_op(
+        "diffusion_gemma_flashdenoise_local_state_scaled"
+    )
+
+    rows, hidden_size, local_vocab = 7, 32, 40
+    vocab_start_index = 320
+    final_logit_softcapping = 1.3
+    generator = torch.Generator(device="cuda").manual_seed(20250621)
+
+    hidden = (
+        torch.randn(
+            rows,
+            hidden_size,
+            device="cuda",
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.35
+    ).to(torch.bfloat16)
+    lm_head_weight = (
+        torch.randn(
+            local_vocab,
+            hidden_size,
+            device="cuda",
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.35
+    ).to(torch.bfloat16)
+    if scale_mode == "per_row":
+        logit_scale = torch.linspace(
+            0.55, 1.85, rows, device="cuda", dtype=torch.float32
+        )
+    else:
+        logit_scale = torch.tensor(1.15, device="cuda", dtype=torch.float32)
+
+    local_max = torch.empty(rows, device="cuda", dtype=torch.float32)
+    local_sum_exp = torch.empty(rows, device="cuda", dtype=torch.float32)
+    local_weighted_logits = torch.empty(rows, device="cuda", dtype=torch.float32)
+    local_soft_part = torch.empty(
+        rows, hidden_size, device="cuda", dtype=torch.float32
+    )
+    clean_values = torch.empty(rows, device="cuda", dtype=torch.float32)
+    clean_indices = torch.empty(rows, device="cuda", dtype=torch.int64)
+    sample_values = torch.empty(rows, device="cuda", dtype=torch.float32)
+    sample_indices = torch.empty(rows, device="cuda", dtype=torch.int64)
+
+    ops.diffusion_gemma_flashdenoise_local_state_scaled(
+        local_max,
+        local_sum_exp,
+        local_weighted_logits,
+        local_soft_part,
+        clean_values,
+        clean_indices,
+        sample_values,
+        sample_indices,
+        hidden,
+        lm_head_weight,
+        logit_scale,
+        vocab_start_index,
+        final_logit_softcapping,
+        rng_seed=1234,
+        rng_offset=99,
+    )
+    torch.cuda.synchronize()
+
+    expected = _dense_local_state_reference(
+        hidden,
+        lm_head_weight,
+        logit_scale,
+        vocab_start_index,
+        final_logit_softcapping,
+    )
+
+    torch.testing.assert_close(
+        local_max.cpu(), expected[0].cpu(), atol=2e-3, rtol=0
+    )
+    torch.testing.assert_close(
+        clean_values.cpu(), expected[0].cpu(), atol=2e-3, rtol=0
+    )
+    torch.testing.assert_close(
+        local_sum_exp.cpu(), expected[1].cpu(), atol=3e-3, rtol=3e-3
+    )
+    torch.testing.assert_close(
+        local_weighted_logits.cpu(), expected[2].cpu(), atol=3e-3, rtol=3e-3
+    )
+    torch.testing.assert_close(
+        local_soft_part.cpu(), expected[3].cpu(), atol=5e-3, rtol=5e-3
+    )
+    torch.testing.assert_close(clean_indices.cpu(), expected[4].cpu())
+    torch.testing.assert_close(
+        sample_values.cpu(), expected[5].cpu(), atol=3e-3, rtol=0
+    )
+    torch.testing.assert_close(sample_indices.cpu(), expected[6].cpu())
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_local_state_soft_part_uses_bf16_tensor_core_semantics():
+    _require_native_flashdenoise_op(
+        "diffusion_gemma_flashdenoise_local_state_scaled"
+    )
+
+    rows, hidden_size, local_vocab = 5, 64, 128
+    vocab_start_index = 4096
+    generator = torch.Generator(device="cuda").manual_seed(20260622)
+    hidden = (
+        torch.randn(
+            rows,
+            hidden_size,
+            device="cuda",
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.45
+    ).to(torch.bfloat16)
+    lm_head_weight = (
+        torch.randn(
+            local_vocab,
+            hidden_size,
+            device="cuda",
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.7
+    ).to(torch.bfloat16)
+    logit_scale = torch.linspace(0.7, 1.9, rows, device="cuda", dtype=torch.float32)
+
+    local_max = torch.empty(rows, device="cuda", dtype=torch.float32)
+    local_sum_exp = torch.empty(rows, device="cuda", dtype=torch.float32)
+    local_weighted_logits = torch.empty(rows, device="cuda", dtype=torch.float32)
+    local_soft_part = torch.empty(
+        rows, hidden_size, device="cuda", dtype=torch.float32
+    )
+    clean_values = torch.empty(rows, device="cuda", dtype=torch.float32)
+    clean_indices = torch.empty(rows, device="cuda", dtype=torch.int64)
+    sample_values = torch.empty(rows, device="cuda", dtype=torch.float32)
+    sample_indices = torch.empty(rows, device="cuda", dtype=torch.int64)
+
+    ops.diffusion_gemma_flashdenoise_local_state_scaled(
+        local_max,
+        local_sum_exp,
+        local_weighted_logits,
+        local_soft_part,
+        clean_values,
+        clean_indices,
+        sample_values,
+        sample_indices,
+        hidden,
+        lm_head_weight,
+        logit_scale,
+        vocab_start_index,
+        0.0,
+        rng_seed=1234,
+        rng_offset=99,
+    )
+    torch.cuda.synchronize()
+
+    logits = torch.mm(hidden, lm_head_weight.t(), out_dtype=torch.float32)
+    logits = logits * logit_scale.unsqueeze(-1)
+    exp_weights = torch.exp(logits - logits.max(dim=-1).values.unsqueeze(-1))
+    expected_soft_part = torch.mm(
+        exp_weights.to(torch.bfloat16), lm_head_weight, out_dtype=torch.float32
+    )
+
+    torch.testing.assert_close(
+        local_soft_part.cpu(),
+        expected_soft_part.cpu(),
+        atol=1e-3,
+        rtol=2e-4,
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_pack_local_state_matches_torch_merge_scale():
+    _require_native_flashdenoise_op("diffusion_gemma_flashdenoise_pack_local_state")
+
+    rows, hidden_size = 6, 17
+    generator = torch.Generator(device="cuda").manual_seed(20260623)
+    local_max = torch.randn(rows, device="cuda", generator=generator)
+    global_max = local_max + torch.rand(
+        rows, device="cuda", generator=generator
+    )
+    local_sum_exp = (
+        torch.rand(rows, device="cuda", generator=generator) * 3.0 + 0.1
+    )
+    local_weighted_logits = torch.randn(
+        rows, device="cuda", generator=generator
+    )
+    local_soft_part = torch.randn(
+        rows, hidden_size, device="cuda", generator=generator
+    )
+    packed = torch.empty(
+        rows, hidden_size + 2, device="cuda", dtype=torch.float32
+    )
+
+    ops.diffusion_gemma_flashdenoise_pack_local_state(
+        packed,
+        local_max,
+        global_max,
+        local_sum_exp,
+        local_weighted_logits,
+        local_soft_part,
+    )
+    torch.cuda.synchronize()
+
+    scale = torch.exp(local_max - global_max)
+    expected = torch.cat(
+        [
+            (local_sum_exp * scale).unsqueeze(-1),
+            (local_weighted_logits * scale).unsqueeze(-1),
+            local_soft_part * scale.unsqueeze(-1),
+        ],
+        dim=-1,
+    )
+    torch.testing.assert_close(
+        packed.cpu(),
+        expected.cpu(),
+        atol=1e-6,
+        rtol=1e-6,
+    )

--- a/tests/models/test_diffusion_gemma_flashdenoise_state.py
+++ b/tests/models/test_diffusion_gemma_flashdenoise_state.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True)
+class LocalState:
+    m: torch.Tensor
+    s: torch.Tensor
+    w: torch.Tensor
+    e: torch.Tensor
+    clean_val: torch.Tensor
+    clean_idx: torch.Tensor
+    sample_val: torch.Tensor
+    sample_idx: torch.Tensor
+    normalizer: torch.Tensor
+
+
+@dataclass(frozen=True)
+class SamplerOutputs:
+    entropy: torch.Tensor
+    soft_embed: torch.Tensor
+    clean_val: torch.Tensor
+    clean_idx: torch.Tensor
+    sample_val: torch.Tensor
+    sample_idx: torch.Tensor
+
+
+def _dense_reference(
+    logits: torch.Tensor,
+    embed_weight: torch.Tensor,
+    gumbels: torch.Tensor,
+    normalizer: torch.Tensor,
+) -> SamplerOutputs:
+    probs = logits.softmax(dim=-1)
+    log_probs = logits.log_softmax(dim=-1)
+    noisy = logits + gumbels
+    clean_val, clean_idx = logits.max(dim=-1)
+    sample_val, sample_idx = noisy.max(dim=-1)
+    return SamplerOutputs(
+        entropy=-(probs * log_probs).sum(dim=-1),
+        soft_embed=torch.matmul(probs, embed_weight) * normalizer,
+        clean_val=clean_val,
+        clean_idx=clean_idx,
+        sample_val=sample_val,
+        sample_idx=sample_idx,
+    )
+
+
+def _local_state(
+    local_logits: torch.Tensor,
+    local_embed_weight: torch.Tensor,
+    local_gumbels: torch.Tensor,
+    *,
+    vocab_start: int,
+    local_vocab_width: int,
+    normalizer: torch.Tensor,
+) -> LocalState:
+    real_logits = local_logits[:, :local_vocab_width]
+    real_embed = local_embed_weight[:local_vocab_width]
+    real_gumbels = local_gumbels[:, :local_vocab_width]
+
+    m = real_logits.max(dim=-1).values
+    exp_shifted = torch.exp(real_logits - m.unsqueeze(-1))
+    clean_val, clean_local_idx = real_logits.max(dim=-1)
+    sample_val, sample_local_idx = (real_logits + real_gumbels).max(dim=-1)
+    return LocalState(
+        m=m,
+        s=exp_shifted.sum(dim=-1),
+        w=(exp_shifted * real_logits).sum(dim=-1),
+        e=torch.matmul(exp_shifted, real_embed),
+        clean_val=clean_val,
+        clean_idx=clean_local_idx + vocab_start,
+        sample_val=sample_val,
+        sample_idx=sample_local_idx + vocab_start,
+        normalizer=normalizer,
+    )
+
+
+def _merge_tp_states(states: list[LocalState]) -> SamplerOutputs:
+    m_parts = torch.stack([state.m for state in states])
+    global_m = m_parts.max(dim=0).values
+    scales = torch.exp(m_parts - global_m.unsqueeze(0))
+
+    s = sum(state.s * scales[rank] for rank, state in enumerate(states))
+    w = sum(state.w * scales[rank] for rank, state in enumerate(states))
+    e = sum(
+        state.e * scales[rank].unsqueeze(-1) for rank, state in enumerate(states)
+    )
+    entropy = torch.log(s) + global_m - w / s
+    soft_embed = e / s.unsqueeze(-1) * states[0].normalizer
+
+    clean_val, clean_idx = _reduce_argmax_pairs(
+        [state.clean_val for state in states],
+        [state.clean_idx for state in states],
+    )
+    sample_val, sample_idx = _reduce_argmax_pairs(
+        [state.sample_val for state in states],
+        [state.sample_idx for state in states],
+    )
+    return SamplerOutputs(
+        entropy=entropy,
+        soft_embed=soft_embed,
+        clean_val=clean_val,
+        clean_idx=clean_idx,
+        sample_val=sample_val,
+        sample_idx=sample_idx,
+    )
+
+
+def _reduce_argmax_pairs(
+    values: list[torch.Tensor],
+    indices: list[torch.Tensor],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    best_values = values[0].clone()
+    best_indices = indices[0].clone()
+    for value, index in zip(values[1:], indices[1:]):
+        better = (value > best_values) | (
+            (value == best_values) & (index < best_indices)
+        )
+        best_values = torch.where(better, value, best_values)
+        best_indices = torch.where(better, index, best_indices)
+    return best_values, best_indices
+
+
+def _assert_outputs_close(actual: SamplerOutputs, expected: SamplerOutputs) -> None:
+    torch.testing.assert_close(actual.entropy, expected.entropy)
+    torch.testing.assert_close(actual.soft_embed, expected.soft_embed)
+    torch.testing.assert_close(actual.clean_val, expected.clean_val)
+    torch.testing.assert_close(actual.clean_idx, expected.clean_idx)
+    torch.testing.assert_close(actual.sample_val, expected.sample_val)
+    torch.testing.assert_close(actual.sample_idx, expected.sample_idx)
+
+
+def _states_from_ranges(
+    logits: torch.Tensor,
+    embed_weight: torch.Tensor,
+    gumbels: torch.Tensor,
+    ranges: list[tuple[int, int]],
+    normalizer: torch.Tensor,
+) -> list[LocalState]:
+    return [
+        _local_state(
+            logits[:, start:end],
+            embed_weight[start:end],
+            gumbels[:, start:end],
+            vocab_start=start,
+            local_vocab_width=end - start,
+            normalizer=normalizer,
+        )
+        for start, end in ranges
+    ]
+
+
+def test_merge_tp4_state_matches_dense_reference() -> None:
+    torch.manual_seed(0)
+    rows, vocab_size, hidden_size = 5, 16, 6
+    logits = torch.randn(rows, vocab_size, dtype=torch.float64)
+    embed_weight = torch.randn(vocab_size, hidden_size, dtype=torch.float64)
+    gumbels = torch.randn(rows, vocab_size, dtype=torch.float64)
+    normalizer = torch.tensor(0.75, dtype=torch.float64)
+    ranges = [(0, 4), (4, 8), (8, 12), (12, 16)]
+
+    actual = _merge_tp_states(
+        _states_from_ranges(logits, embed_weight, gumbels, ranges, normalizer)
+    )
+
+    expected = _dense_reference(logits, embed_weight, gumbels, normalizer)
+    _assert_outputs_close(actual, expected)
+
+
+def test_merge_handles_non_divisible_padded_shard_ranges() -> None:
+    torch.manual_seed(1)
+    rows, vocab_size, hidden_size = 4, 10, 5
+    logits = torch.randn(rows, vocab_size, dtype=torch.float64)
+    embed_weight = torch.randn(vocab_size, hidden_size, dtype=torch.float64)
+    gumbels = torch.randn(rows, vocab_size, dtype=torch.float64)
+    normalizer = torch.tensor(1.25, dtype=torch.float64)
+    ranges = [(0, 3), (3, 6), (6, 8), (8, 10)]
+
+    states: list[LocalState] = []
+    for start, end in ranges:
+        width = end - start
+        local_logits = torch.full((rows, 3), 999.0, dtype=torch.float64)
+        local_embed = torch.full((3, hidden_size), 999.0, dtype=torch.float64)
+        local_gumbels = torch.full((rows, 3), 999.0, dtype=torch.float64)
+        local_logits[:, :width] = logits[:, start:end]
+        local_embed[:width] = embed_weight[start:end]
+        local_gumbels[:, :width] = gumbels[:, start:end]
+        states.append(
+            _local_state(
+                local_logits,
+                local_embed,
+                local_gumbels,
+                vocab_start=start,
+                local_vocab_width=width,
+                normalizer=normalizer,
+            )
+        )
+
+    actual = _merge_tp_states(states)
+
+    expected = _dense_reference(logits, embed_weight, gumbels, normalizer)
+    _assert_outputs_close(actual, expected)
+
+
+def test_merge_argmax_ties_pick_smallest_global_token_id() -> None:
+    logits = torch.tensor(
+        [[0.0, 4.0, 3.0, 1.0, 2.0, 3.0, 4.0, -1.0]],
+        dtype=torch.float64,
+    )
+    embed_weight = torch.arange(24, dtype=torch.float64).reshape(8, 3) / 10
+    gumbels = torch.tensor(
+        [[0.0, 0.0, 4.0, 0.0, 0.0, 4.0, 0.0, 0.0]],
+        dtype=torch.float64,
+    )
+    normalizer = torch.tensor(0.5, dtype=torch.float64)
+    ranges = [(0, 2), (2, 4), (4, 6), (6, 8)]
+
+    actual = _merge_tp_states(
+        _states_from_ranges(logits, embed_weight, gumbels, ranges, normalizer)
+    )
+
+    expected = _dense_reference(logits, embed_weight, gumbels, normalizer)
+    _assert_outputs_close(actual, expected)
+    torch.testing.assert_close(actual.clean_idx, torch.tensor([1]))
+    torch.testing.assert_close(actual.sample_idx, torch.tensor([2]))

--- a/tests/models/test_diffusion_gemma_flashdenoise_tp_distributed.py
+++ b/tests/models/test_diffusion_gemma_flashdenoise_tp_distributed.py
@@ -1,0 +1,336 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Distributed TP4 correctness test for the native DiffusionGemma FlashDenoise
+# sampler-state contract. Run exactly with this shell command:
+#   torchrun --standalone --nproc-per-node=4 -m pytest -q \
+#       tests/models/test_diffusion_gemma_flashdenoise_tp_distributed.py
+
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+
+import pytest
+import torch
+import torch.distributed as dist
+
+import vllm._custom_ops as ops
+
+
+TORCHRUN_CMD = (
+    "torchrun --standalone --nproc-per-node=4 -m pytest -q "
+    "tests/models/test_diffusion_gemma_flashdenoise_tp_distributed.py"
+)
+TP_SIZE = 4
+OP_NAME = "diffusion_gemma_flashdenoise_local_state_scaled"
+_MASK64 = (1 << 64) - 1
+
+
+def _splitmix64(value: int) -> int:
+    value = (value + 0x9E3779B97F4A7C15) & _MASK64
+    value = ((value ^ (value >> 30)) * 0xBF58476D1CE4E5B9) & _MASK64
+    value = ((value ^ (value >> 27)) * 0x94D049BB133111EB) & _MASK64
+    return (value ^ (value >> 31)) & _MASK64
+
+
+def _deterministic_uniform01(
+    seed: int,
+    offset: int,
+    row: int,
+    vocab_idx: int,
+) -> float:
+    key = int(seed) & _MASK64
+    key ^= (int(offset) * 0x9E3779B97F4A7C15) & _MASK64
+    key ^= (int(row) * 0xBF58476D1CE4E5B9) & _MASK64
+    key ^= (int(vocab_idx) * 0x94D049BB133111EB) & _MASK64
+    mantissa = (_splitmix64(key) >> 40) & 0xFFFFFF
+    return (float(mantissa) + 0.5) * (2.0**-24)
+
+
+def _deterministic_gumbels(
+    rows: int,
+    vocab_size: int,
+    *,
+    rng_seed: int,
+    rng_offset: int,
+    device: torch.device,
+) -> torch.Tensor:
+    uniforms = torch.empty(rows, vocab_size, dtype=torch.float32)
+    for row in range(rows):
+        for vocab_idx in range(vocab_size):
+            uniforms[row, vocab_idx] = _deterministic_uniform01(
+                rng_seed,
+                rng_offset,
+                row,
+                vocab_idx,
+            )
+    return -torch.log(-torch.log(uniforms)).to(device)
+
+
+def _env_int(name: str) -> int | None:
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        pytest.skip(f"{name}={value!r} is not an integer")
+
+
+def _require_tp4_torchrun_and_native_op():
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    if torch.cuda.device_count() < TP_SIZE:
+        pytest.skip(f"requires at least {TP_SIZE} visible CUDA devices")
+    if not dist.is_available():
+        pytest.skip("requires torch.distributed")
+    if not dist.is_nccl_available():
+        pytest.skip("requires NCCL")
+
+    world_size = _env_int("WORLD_SIZE")
+    rank = _env_int("RANK")
+    local_rank = _env_int("LOCAL_RANK")
+    if world_size != TP_SIZE or rank is None or local_rank is None:
+        pytest.skip(f"run this test with: {TORCHRUN_CMD}")
+    if local_rank >= torch.cuda.device_count():
+        pytest.skip(
+            f"LOCAL_RANK={local_rank} exceeds visible CUDA device count "
+            f"{torch.cuda.device_count()}"
+        )
+
+    native_op = getattr(ops, OP_NAME, None)
+    if native_op is None:
+        pytest.skip(f"vllm._custom_ops.{OP_NAME} wrapper is unavailable")
+    if not (hasattr(torch.ops, "_C") and hasattr(torch.ops._C, OP_NAME)):
+        pytest.skip(f"native torch.ops._C.{OP_NAME} op is unavailable")
+
+    return rank, local_rank, native_op
+
+
+def _make_dense_inputs(device: torch.device):
+    rows = 6
+    hidden_size = 16
+    vocab_size = 32
+    generator = torch.Generator(device="cpu").manual_seed(20260621)
+    hidden = torch.randn(
+        rows, hidden_size, dtype=torch.float32, generator=generator
+    ) * 0.125
+    weight = torch.randn(
+        vocab_size, hidden_size, dtype=torch.float32, generator=generator
+    ) * 0.125
+    logit_scale = torch.linspace(0.7, 1.35, rows, dtype=torch.float32)
+
+    # Row 0 has equal clean maxima on two different TP shards. The global clean
+    # argmax reducer must choose the smaller global token id, not the lower rank.
+    hidden[0].zero_()
+    hidden[0, 0] = 1.0
+    weight[:, 0] = torch.linspace(-0.4, 0.3, vocab_size)
+    weight[:, 1:].zero_()
+    weight[9, 0] = 2.0
+    weight[25, 0] = 2.0
+    logit_scale[0] = 1.0
+
+    return (
+        hidden.to(device=device, dtype=torch.bfloat16),
+        weight.to(device=device, dtype=torch.bfloat16),
+        logit_scale.to(device=device),
+    )
+
+
+def _dense_reference(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    logit_scale: torch.Tensor,
+    normalizer: float,
+    final_logit_softcapping: float,
+    rng_seed: int,
+    rng_offset: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor,
+           torch.Tensor]:
+    logits = torch.mm(hidden, weight.t(), out_dtype=torch.float32)
+    if final_logit_softcapping > 0.0:
+        logits = final_logit_softcapping * torch.tanh(
+            logits / final_logit_softcapping
+        )
+    logits = logits * logit_scale.unsqueeze(-1)
+
+    probs = torch.softmax(logits, dim=-1)
+    log_probs = torch.log_softmax(logits, dim=-1)
+    entropy = -(probs * log_probs).sum(dim=-1)
+    soft_embed = torch.matmul(probs, weight.float()) * normalizer
+    clean_values, clean_indices = logits.max(dim=-1)
+    gumbels = _deterministic_gumbels(
+        logits.shape[0],
+        logits.shape[1],
+        rng_seed=rng_seed,
+        rng_offset=rng_offset,
+        device=logits.device,
+    )
+    sample_values, sample_indices = (logits + gumbels).max(dim=-1)
+    return (
+        entropy,
+        soft_embed,
+        clean_values,
+        clean_indices.to(torch.int64),
+        sample_values,
+        sample_indices.to(torch.int64),
+    )
+
+
+def _merge_local_sampler_state(
+    local_max: torch.Tensor,
+    local_sum_exp: torch.Tensor,
+    local_weighted_logits: torch.Tensor,
+    local_soft_part: torch.Tensor,
+    normalizer: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    global_max = local_max.clone()
+    dist.all_reduce(global_max, op=dist.ReduceOp.MAX)
+
+    scale = torch.exp(local_max - global_max)
+    global_sum_exp = local_sum_exp * scale
+    global_weighted = local_weighted_logits * scale
+    global_soft_part = local_soft_part * scale.unsqueeze(-1)
+
+    dist.all_reduce(global_sum_exp, op=dist.ReduceOp.SUM)
+    dist.all_reduce(global_weighted, op=dist.ReduceOp.SUM)
+    dist.all_reduce(global_soft_part, op=dist.ReduceOp.SUM)
+
+    entropy = torch.log(global_sum_exp) + global_max - global_weighted / global_sum_exp
+    soft_embed = global_soft_part / global_sum_exp.unsqueeze(-1) * normalizer
+    return entropy, soft_embed
+
+
+def _reduce_clean_argmax(
+    clean_values: torch.Tensor,
+    clean_indices: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    value_parts = [torch.empty_like(clean_values) for _ in range(TP_SIZE)]
+    index_parts = [torch.empty_like(clean_indices) for _ in range(TP_SIZE)]
+    dist.all_gather(value_parts, clean_values)
+    dist.all_gather(index_parts, clean_indices)
+
+    values = torch.stack(value_parts, dim=-1)
+    indices = torch.stack(index_parts, dim=-1)
+    winning_values = values.max(dim=-1, keepdim=True).values
+    masked_indices = torch.where(
+        values == winning_values,
+        indices,
+        torch.full_like(indices, torch.iinfo(indices.dtype).max),
+    )
+    winning_rank = masked_indices.argmin(dim=-1, keepdim=True)
+    reduced_values = values.gather(dim=-1, index=winning_rank).squeeze(-1)
+    reduced_indices = indices.gather(dim=-1, index=winning_rank).squeeze(-1)
+    return reduced_values, reduced_indices
+
+
+def test_tp4_native_local_state_merge_matches_dense_reference():
+    rank, local_rank, native_op = _require_tp4_torchrun_and_native_op()
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+    dist.init_process_group("nccl", timeout=timedelta(seconds=60))
+
+    try:
+        hidden, full_weight, logit_scale = _make_dense_inputs(device)
+        rows, hidden_size = hidden.shape
+        vocab_size = full_weight.shape[0]
+        assert vocab_size % TP_SIZE == 0
+        local_vocab = vocab_size // TP_SIZE
+        vocab_start_index = rank * local_vocab
+        local_weight = full_weight[
+            vocab_start_index : vocab_start_index + local_vocab
+        ].contiguous()
+        normalizer = 0.75
+
+        for final_logit_softcapping in (0.0, 1.3):
+            local_max = torch.empty(rows, device=device, dtype=torch.float32)
+            local_sum_exp = torch.empty(rows, device=device, dtype=torch.float32)
+            local_weighted_logits = torch.empty(
+                rows, device=device, dtype=torch.float32
+            )
+            local_soft_part = torch.empty(
+                rows, hidden_size, device=device, dtype=torch.float32
+            )
+            clean_values = torch.empty(rows, device=device, dtype=torch.float32)
+            clean_indices = torch.empty(rows, device=device, dtype=torch.int64)
+            sample_values = torch.empty(rows, device=device, dtype=torch.float32)
+            sample_indices = torch.empty(rows, device=device, dtype=torch.int64)
+
+            try:
+                native_op(
+                    local_max,
+                    local_sum_exp,
+                    local_weighted_logits,
+                    local_soft_part,
+                    clean_values,
+                    clean_indices,
+                    sample_values,
+                    sample_indices,
+                    hidden,
+                    local_weight,
+                    logit_scale,
+                    vocab_start_index=vocab_start_index,
+                    final_logit_softcapping=final_logit_softcapping,
+                    rng_seed=1234,
+                    rng_offset=99,
+                )
+            except RuntimeError as exc:
+                if "unavailable" in str(exc):
+                    pytest.skip(str(exc))
+                raise
+            torch.cuda.synchronize(device)
+
+            entropy, soft_embed = _merge_local_sampler_state(
+                local_max,
+                local_sum_exp,
+                local_weighted_logits,
+                local_soft_part,
+                normalizer,
+            )
+            reduced_clean_values, reduced_clean_indices = _reduce_clean_argmax(
+                clean_values, clean_indices
+            )
+            reduced_sample_values, reduced_sample_indices = _reduce_clean_argmax(
+                sample_values, sample_indices
+            )
+            (
+                expected_entropy,
+                expected_soft_embed,
+                expected_clean_values,
+                expected_clean_indices,
+                expected_sample_values,
+                expected_sample_indices,
+            ) = _dense_reference(
+                hidden,
+                full_weight,
+                logit_scale,
+                normalizer,
+                final_logit_softcapping,
+                rng_seed=1234,
+                rng_offset=99,
+            )
+
+            torch.testing.assert_close(
+                entropy, expected_entropy, atol=3e-3, rtol=3e-3
+            )
+            torch.testing.assert_close(
+                soft_embed, expected_soft_embed, atol=5e-3, rtol=3e-2
+            )
+            torch.testing.assert_close(
+                reduced_clean_values, expected_clean_values, atol=3e-3, rtol=0
+            )
+            torch.testing.assert_close(reduced_clean_indices,
+                                       expected_clean_indices)
+            torch.testing.assert_close(
+                reduced_sample_values,
+                expected_sample_values,
+                atol=3e-3,
+                rtol=0,
+            )
+            torch.testing.assert_close(reduced_sample_indices,
+                                       expected_sample_indices)
+            assert reduced_clean_indices[0].item() == 9
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()

--- a/tests/models/test_diffusion_gemma_local_vocab.py
+++ b/tests/models/test_diffusion_gemma_local_vocab.py
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+
+import pytest
+import torch
+
+import vllm.envs as envs
+from vllm.model_executor.layers.consumer_state_trace import (
+    emit_compact_vocab_state_trace,
+    emit_full_vocab_trace,
+)
+from vllm.model_executor.models.diffusion_gemma import (
+    _local_vocab_argmax_tokens,
+    _local_vocab_logprobs_dense_fallback,
+    _local_vocab_requires_full_logprobs,
+    _local_vocab_softmax_stats,
+    _reduce_argmax_from_gathered_pairs,
+    _vocab_parallel_soft_embed,
+)
+
+
+def _clear_vllm_env_cache():
+    if hasattr(envs.__getattr__, "cache_clear"):
+        envs.__getattr__.cache_clear()
+
+
+def _packed_softmax_parts(
+    scaled_logits: torch.Tensor,
+    embed_weight: torch.Tensor,
+    global_max: torch.Tensor,
+) -> torch.Tensor:
+    logits_f = scaled_logits.float()
+    local_exp = torch.exp(logits_f - global_max.unsqueeze(-1))
+    local_sum_exp = local_exp.sum(dim=-1)
+    weighted_logits = (local_exp * logits_f).sum(dim=-1)
+    soft_part = torch.matmul(local_exp.to(embed_weight.dtype), embed_weight).float()
+    return torch.cat(
+        [
+            local_sum_exp.unsqueeze(-1),
+            weighted_logits.unsqueeze(-1),
+            soft_part,
+        ],
+        dim=-1,
+    )
+
+
+def test_local_vocab_softmax_stats_matches_dense_softmax_with_padding():
+    torch.manual_seed(0)
+    scaled = torch.randn(2, 3, 8)
+    embed_weight = torch.randn(8, 5)
+    normalizer = torch.tensor(1.7)
+
+    # Rank 1 owns only three real vocab rows but has two padded rows in its
+    # local tensor. The helper must ignore padded logits/weights.
+    local_logits = torch.cat(
+        [scaled[..., 5:], torch.full((*scaled.shape[:-1], 2), 123.0)], dim=-1
+    )
+    local_weight = torch.cat([embed_weight[5:], torch.zeros(2, 5)], dim=0)
+    global_max = scaled.float().max(dim=-1).values
+    rank0_pack = _packed_softmax_parts(scaled[..., :5], embed_weight[:5], global_max)
+
+    entropy, soft_embeds = _local_vocab_softmax_stats(
+        local_logits,
+        local_weight,
+        normalizer,
+        local_vocab_width=3,
+        global_max=global_max,
+        all_reduce_sum_fn=lambda packed: packed + rank0_pack,
+    )
+
+    dense_log_probs = scaled.log_softmax(dim=-1)
+    dense_probs = dense_log_probs.exp()
+    expected_entropy = -(dense_probs * dense_log_probs).sum(dim=-1)
+    expected_soft = torch.matmul(dense_probs, embed_weight) * normalizer
+
+    torch.testing.assert_close(entropy, expected_entropy)
+    torch.testing.assert_close(soft_embeds, expected_soft)
+
+
+@pytest.mark.parametrize("seed", [0, 1, 20260622])
+def test_local_vocab_softmax_stats_random_shards_match_dense(seed: int):
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    rows, canvas, vocab_size, hidden = 4, 5, 29, 11
+    scaled = torch.randn(rows, canvas, vocab_size, generator=generator)
+    embed_weight = torch.randn(vocab_size, hidden, generator=generator)
+    normalizer = torch.tensor(1.25)
+    shard_widths = [7, 3, 11, 8]
+
+    global_max = scaled.float().max(dim=-1).values
+    packs = []
+    start = 0
+    for width in shard_widths:
+        end = start + width
+        packs.append(
+            _packed_softmax_parts(
+                scaled[..., start:end],
+                embed_weight[start:end],
+                global_max,
+            )
+        )
+        start = end
+
+    rank = 2
+    rank_start = sum(shard_widths[:rank])
+    rank_width = shard_widths[rank]
+    rank_logits = torch.cat(
+        [
+            scaled[..., rank_start : rank_start + rank_width],
+            torch.full((rows, canvas, 2), 9999.0),
+        ],
+        dim=-1,
+    )
+    rank_weight = torch.cat(
+        [
+            embed_weight[rank_start : rank_start + rank_width],
+            torch.zeros(2, hidden),
+        ],
+        dim=0,
+    )
+    other_pack = sum(pack for index, pack in enumerate(packs) if index != rank)
+
+    entropy, soft_embeds = _local_vocab_softmax_stats(
+        rank_logits,
+        rank_weight,
+        normalizer,
+        local_vocab_width=rank_width,
+        global_max=global_max,
+        all_reduce_sum_fn=lambda packed: packed + other_pack,
+    )
+
+    dense_log_probs = scaled.log_softmax(dim=-1)
+    dense_probs = dense_log_probs.exp()
+    expected_entropy = -(dense_probs * dense_log_probs).sum(dim=-1)
+    expected_soft = torch.matmul(dense_probs, embed_weight) * normalizer
+
+    torch.testing.assert_close(entropy, expected_entropy, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(soft_embeds, expected_soft, atol=1e-5, rtol=1e-5)
+
+
+def test_local_vocab_argmax_ignores_padded_vocab_columns():
+    logits = torch.tensor([[[0.0, 3.0, 2.0, 99.0]]])
+
+    values, indices = _local_vocab_argmax_tokens(
+        logits,
+        vocab_start_index=16,
+        local_vocab_width=3,
+    )
+
+    torch.testing.assert_close(values, torch.tensor([[3.0]]))
+    torch.testing.assert_close(indices, torch.tensor([[17]]))
+
+
+def test_vocab_parallel_soft_embed_matches_dense_with_all_reduce():
+    torch.manual_seed(1)
+    probs = torch.randn(2, 3, 7).softmax(dim=-1)
+    embed_weight = torch.randn(7, 4)
+    normalizer = torch.tensor(0.75)
+
+    rank1_part = torch.matmul(probs[..., 4:], embed_weight[4:])
+    soft_embeds = _vocab_parallel_soft_embed(
+        probs,
+        embed_weight[:4],
+        normalizer,
+        vocab_start_index=0,
+        vocab_end_index=4,
+        all_reduce_fn=lambda local: local + rank1_part,
+    )
+
+    expected = torch.matmul(probs, embed_weight) * normalizer
+    torch.testing.assert_close(soft_embeds, expected)
+
+
+def test_reduce_argmax_from_gathered_pairs_keeps_first_rank_on_tie():
+    local_values = torch.empty(2)
+    local_indices = torch.empty(2, dtype=torch.int64)
+    gathered_pairs = torch.tensor(
+        [
+            [[4.0, 10.0], [4.0, 11.0], [3.0, 12.0]],
+            [[1.0, 20.0], [5.0, 21.0], [2.0, 22.0]],
+        ]
+    )
+
+    values, indices = _reduce_argmax_from_gathered_pairs(
+        local_values, local_indices, gathered_pairs
+    )
+
+    torch.testing.assert_close(values, torch.tensor([4.0, 5.0]))
+    torch.testing.assert_close(indices, torch.tensor([10, 21]))
+
+
+def test_local_vocab_full_logprobs_gate_requires_sampled_logprob_for_real_requests():
+    assert not _local_vocab_requires_full_logprobs(-1)
+    assert _local_vocab_requires_full_logprobs(0, req_ids=["real_request"])
+    assert not _local_vocab_requires_full_logprobs(
+        0, req_ids=["_warmup_a", "_warmup_b"]
+    )
+    assert not _local_vocab_requires_full_logprobs(
+        5, req_ids=["_warmup_a", "_warmup_b"]
+    )
+    assert _local_vocab_requires_full_logprobs(5, req_ids=["real_request"])
+
+
+def test_local_vocab_logprobs_dense_fallback_gathers_and_truncates_logits():
+    logits = torch.arange(2 * 3 * 4, dtype=torch.float32).reshape(6, 4)
+
+    def gather_fn(sharded: torch.Tensor) -> torch.Tensor:
+        assert sharded.shape == (2, 3, 4)
+        return torch.cat([sharded, sharded + 100, sharded + 200], dim=-1)
+
+    full_logits = _local_vocab_logprobs_dense_fallback(
+        logits,
+        num_decode=2,
+        canvas_length=3,
+        vocab_size=10,
+        all_gather_fn=gather_fn,
+    )
+
+    expected = torch.cat(
+        [
+            logits.reshape(2, 3, 4),
+            logits.reshape(2, 3, 4) + 100,
+            logits.reshape(2, 3, 4) + 200,
+        ],
+        dim=-1,
+    )[..., :10].reshape(6, 10)
+    torch.testing.assert_close(full_logits, expected)
+
+
+def test_local_vocab_logprobs_dense_fallback_traces_full_vocab(
+    tmp_path, monkeypatch
+):
+    trace_path = tmp_path / "trace.jsonl"
+    monkeypatch.setenv("VLLM_CONSUMER_STATE_TRACE_JSONL", str(trace_path))
+    _clear_vllm_env_cache()
+
+    logits = torch.arange(2 * 3 * 4, dtype=torch.float32).reshape(6, 4)
+
+    _local_vocab_logprobs_dense_fallback(
+        logits,
+        num_decode=2,
+        canvas_length=3,
+        vocab_size=8,
+        all_gather_fn=lambda sharded: torch.cat([sharded, sharded + 100], dim=-1),
+    )
+
+    records = [json.loads(line) for line in trace_path.read_text().splitlines()]
+    assert len(records) == 1
+    assert records[0]["framework"] == "vllm"
+    assert records[0]["path"] == "full_vocab_materialized"
+    assert records[0]["component"].endswith("local_vocab_logprobs_dense_fallback")
+    assert records[0]["full_vocab_materialized_bytes"] == 6 * 8 * 4
+    assert records[0]["fallback_reason"] == "full_vocab_logprobs_request"
+
+
+def test_consumer_state_trace_emits_vllm_full_and_compact_records(
+    tmp_path, monkeypatch
+):
+    trace_path = tmp_path / "trace.jsonl"
+    monkeypatch.setenv("VLLM_CONSUMER_STATE_TRACE_JSONL", str(trace_path))
+    _clear_vllm_env_cache()
+
+    emit_full_vocab_trace(
+        component="unit.full",
+        full_logits=torch.empty(2, 5, dtype=torch.float32),
+        vocab_size=5,
+        consumer_contract="full",
+        tp_size=2,
+        rank=1,
+    )
+    emit_compact_vocab_state_trace(
+        component="unit.compact",
+        rows=2,
+        vocab_size=9,
+        local_vocab_size=3,
+        local_vocab_materialized_bytes=2 * 3 * 2,
+        compact_state_bytes=2 * (4 + 8 + 4 + 4),
+        tp_gather_bytes=2 * 2 * 3 * 4,
+        consumer_contract="compact",
+        dtype_bytes=2,
+        tp_size=2,
+        rank=1,
+    )
+
+    records = [json.loads(line) for line in trace_path.read_text().splitlines()]
+    assert [record["framework"] for record in records] == ["vllm", "vllm"]
+    assert records[0]["path"] == "full_vocab_materialized"
+    assert records[0]["full_vocab_materialized_bytes"] == 2 * 5 * 4
+    assert records[0]["tp_gather_bytes"] == 2 * 5 * 4
+
+    assert records[1]["path"] == "consumer_sufficient_compact"
+    assert records[1]["local_vocab_materialized_bytes"] == 2 * 3 * 2
+    assert records[1]["avoidable_full_vocab_materialized_bytes"] == 2 * 9 * 2
+    assert records[1]["compact_state_bytes"] == 2 * (4 + 8 + 4 + 4)
+    assert records[1]["tp_gather_bytes"] == 2 * 2 * 3 * 4

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2313,6 +2313,240 @@ if hasattr(torch.ops, "_C") and hasattr(torch.ops._C, "fp32_router_gemm"):
         return
 
 
+def diffusion_gemma_flashdenoise(
+    entropy: torch.Tensor,
+    sample_values: torch.Tensor,
+    sample_indices: torch.Tensor,
+    clean_values: torch.Tensor,
+    clean_indices: torch.Tensor,
+    soft_embed: torch.Tensor,
+    hidden: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    normalizer: float,
+    mode_flags: int = 16,
+    rng_seed: int = 0,
+    rng_offset: int = 0,
+) -> None:
+    if not (
+        hasattr(torch.ops, "_C")
+        and hasattr(torch.ops._C, "diffusion_gemma_flashdenoise")
+    ):
+        raise RuntimeError("diffusion_gemma_flashdenoise native op is unavailable")
+    torch.ops._C.diffusion_gemma_flashdenoise(
+        entropy,
+        sample_values,
+        sample_indices,
+        clean_values,
+        clean_indices,
+        soft_embed,
+        hidden,
+        lm_head_weight,
+        float(normalizer),
+        int(mode_flags),
+        int(rng_seed),
+        int(rng_offset),
+    )
+
+
+def diffusion_gemma_flashdenoise_scaled(
+    entropy: torch.Tensor,
+    sample_values: torch.Tensor,
+    sample_indices: torch.Tensor,
+    clean_values: torch.Tensor,
+    clean_indices: torch.Tensor,
+    soft_embed: torch.Tensor,
+    hidden: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    logit_scale: torch.Tensor,
+    normalizer: float,
+    final_logit_softcapping: float = 0.0,
+    mode_flags: int = 16,
+    rng_seed: int = 0,
+    rng_offset: int = 0,
+    rng_row_offset: int = 0,
+) -> None:
+    if not (
+        hasattr(torch.ops, "_C")
+        and hasattr(torch.ops._C, "diffusion_gemma_flashdenoise_scaled")
+    ):
+        raise RuntimeError(
+            "diffusion_gemma_flashdenoise_scaled native op is unavailable"
+        )
+    torch.ops._C.diffusion_gemma_flashdenoise_scaled(
+        entropy,
+        sample_values,
+        sample_indices,
+        clean_values,
+        clean_indices,
+        soft_embed,
+        hidden,
+        lm_head_weight,
+        logit_scale,
+        float(normalizer),
+        float(final_logit_softcapping),
+        int(mode_flags),
+        int(rng_seed),
+        int(rng_offset),
+        int(rng_row_offset),
+    )
+
+
+def diffusion_gemma_flashdenoise_local_state_scaled(
+    local_max: torch.Tensor,
+    local_sum_exp: torch.Tensor,
+    local_weighted_logits: torch.Tensor,
+    local_soft_part: torch.Tensor,
+    clean_values: torch.Tensor,
+    clean_indices: torch.Tensor,
+    sample_values: torch.Tensor,
+    sample_indices: torch.Tensor,
+    hidden: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    logit_scale: torch.Tensor,
+    vocab_start_index: int,
+    final_logit_softcapping: float = 0.0,
+    rng_seed: int = 0,
+    rng_offset: int = 0,
+) -> None:
+    if not (
+        hasattr(torch.ops, "_C")
+        and hasattr(torch.ops._C, "diffusion_gemma_flashdenoise_local_state_scaled")
+    ):
+        raise RuntimeError(
+            "diffusion_gemma_flashdenoise_local_state_scaled native op is unavailable"
+        )
+    torch.ops._C.diffusion_gemma_flashdenoise_local_state_scaled(
+        local_max,
+        local_sum_exp,
+        local_weighted_logits,
+        local_soft_part,
+        clean_values,
+        clean_indices,
+        sample_values,
+        sample_indices,
+        hidden,
+        lm_head_weight,
+        logit_scale,
+        int(vocab_start_index),
+        float(final_logit_softcapping),
+        int(rng_seed),
+        int(rng_offset),
+    )
+
+
+def diffusion_gemma_flashdenoise_pack_local_state(
+    packed: torch.Tensor,
+    local_max: torch.Tensor,
+    global_max: torch.Tensor,
+    local_sum_exp: torch.Tensor,
+    local_weighted_logits: torch.Tensor,
+    local_soft_part: torch.Tensor,
+) -> None:
+    if not (
+        hasattr(torch.ops, "_C")
+        and hasattr(torch.ops._C, "diffusion_gemma_flashdenoise_pack_local_state")
+    ):
+        raise RuntimeError(
+            "diffusion_gemma_flashdenoise_pack_local_state native op is unavailable"
+        )
+    torch.ops._C.diffusion_gemma_flashdenoise_pack_local_state(
+        packed,
+        local_max,
+        global_max,
+        local_sum_exp,
+        local_weighted_logits,
+        local_soft_part,
+    )
+
+
+if hasattr(torch.ops, "_C") and hasattr(
+    torch.ops._C, "diffusion_gemma_flashdenoise"
+):
+
+    @register_fake("_C::diffusion_gemma_flashdenoise")
+    def diffusion_gemma_flashdenoise_fake(
+        entropy: torch.Tensor,
+        sample_values: torch.Tensor,
+        sample_indices: torch.Tensor,
+        clean_values: torch.Tensor,
+        clean_indices: torch.Tensor,
+        soft_embed: torch.Tensor,
+        hidden: torch.Tensor,
+        lm_head_weight: torch.Tensor,
+        normalizer: float,
+        mode_flags: int,
+        rng_seed: int,
+        rng_offset: int,
+    ) -> None:
+        return
+
+
+if hasattr(torch.ops, "_C") and hasattr(
+    torch.ops._C, "diffusion_gemma_flashdenoise_scaled"
+):
+
+    @register_fake("_C::diffusion_gemma_flashdenoise_scaled")
+    def diffusion_gemma_flashdenoise_scaled_fake(
+        entropy: torch.Tensor,
+        sample_values: torch.Tensor,
+        sample_indices: torch.Tensor,
+        clean_values: torch.Tensor,
+        clean_indices: torch.Tensor,
+        soft_embed: torch.Tensor,
+        hidden: torch.Tensor,
+        lm_head_weight: torch.Tensor,
+        logit_scale: torch.Tensor,
+        normalizer: float,
+        final_logit_softcapping: float,
+        mode_flags: int,
+        rng_seed: int,
+        rng_offset: int,
+        rng_row_offset: int,
+    ) -> None:
+        return
+
+
+if hasattr(torch.ops, "_C") and hasattr(
+    torch.ops._C, "diffusion_gemma_flashdenoise_local_state_scaled"
+):
+
+    @register_fake("_C::diffusion_gemma_flashdenoise_local_state_scaled")
+    def diffusion_gemma_flashdenoise_local_state_scaled_fake(
+        local_max: torch.Tensor,
+        local_sum_exp: torch.Tensor,
+        local_weighted_logits: torch.Tensor,
+        local_soft_part: torch.Tensor,
+        clean_values: torch.Tensor,
+        clean_indices: torch.Tensor,
+        sample_values: torch.Tensor,
+        sample_indices: torch.Tensor,
+        hidden: torch.Tensor,
+        lm_head_weight: torch.Tensor,
+        logit_scale: torch.Tensor,
+        vocab_start_index: int,
+        final_logit_softcapping: float,
+        rng_seed: int,
+        rng_offset: int,
+    ) -> None:
+        return
+
+
+if hasattr(torch.ops, "_C") and hasattr(
+    torch.ops._C, "diffusion_gemma_flashdenoise_pack_local_state"
+):
+
+    @register_fake("_C::diffusion_gemma_flashdenoise_pack_local_state")
+    def diffusion_gemma_flashdenoise_pack_local_state_fake(
+        packed: torch.Tensor,
+        local_max: torch.Tensor,
+        global_max: torch.Tensor,
+        local_sum_exp: torch.Tensor,
+        local_weighted_logits: torch.Tensor,
+        local_soft_part: torch.Tensor,
+    ) -> None:
+        return
+
+
 def topk_softmax(
     topk_weights: torch.Tensor,
     topk_ids: torch.Tensor,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -47,6 +47,11 @@ if TYPE_CHECKING:
     VLLM_LOG_STATS_INTERVAL: float = 10.0
     VLLM_TRACE_FUNCTION: int = 0
     VLLM_USE_FLASHINFER_SAMPLER: bool = True
+    VLLM_DIFFUSION_GEMMA_LOCAL_VOCAB_SAMPLER: bool = False
+    VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE: bool = False
+    VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_TP_STATE: bool = False
+    VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_MODE_FLAGS: int = 16
+    VLLM_CONSUMER_STATE_TRACE_JSONL: str = ""
     VLLM_PP_LAYER_PARTITION: str | None = None
     VLLM_CPU_KVCACHE_SPACE: int | None = 0
     VLLM_CPU_OMP_THREADS_BIND: str = "auto"
@@ -808,6 +813,29 @@ environment_variables: dict[str, Callable[[], Any]] = {
         bool(int(os.environ["VLLM_USE_FLASHINFER_SAMPLER"]))
         if "VLLM_USE_FLASHINFER_SAMPLER" in os.environ
         else True
+    ),
+    # Enable an experimental DiffusionGemma path that keeps denoise-state
+    # sampling, entropy, and soft self-conditioning on TP vocab shards.
+    "VLLM_DIFFUSION_GEMMA_LOCAL_VOCAB_SAMPLER": lambda: bool(
+        int(os.getenv("VLLM_DIFFUSION_GEMMA_LOCAL_VOCAB_SAMPLER", "0"))
+    ),
+    # Opt-in native DiffusionGemma denoise sampler. The current backend is the
+    # exact mode16 materialized cuBLAS/warp-stats path and falls back when a
+    # request requires unsupported features.
+    "VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE": lambda: bool(
+        int(os.getenv("VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE", "0"))
+    ),
+    # Native TP-sharded DiffusionGemma sampler-state path. This avoids
+    # full-vocab probability materialization by merging local state across TP
+    # ranks before the denoise post-processing step.
+    "VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_TP_STATE": lambda: bool(
+        int(os.getenv("VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_TP_STATE", "0"))
+    ),
+    "VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_MODE_FLAGS": lambda: int(
+        os.getenv("VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_MODE_FLAGS", "16")
+    ),
+    "VLLM_CONSUMER_STATE_TRACE_JSONL": lambda: os.getenv(
+        "VLLM_CONSUMER_STATE_TRACE_JSONL", ""
     ),
     # Pipeline stage partition strategy
     "VLLM_PP_LAYER_PARTITION": lambda: os.getenv("VLLM_PP_LAYER_PARTITION", None),
@@ -2070,6 +2098,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_LOGGING_STREAM",
         "VLLM_LOGGING_CONFIG_PATH",
         "VLLM_LOGGING_COLOR",
+        "VLLM_CONSUMER_STATE_TRACE_JSONL",
         "VLLM_LOG_STATS_INTERVAL",
         "VLLM_DEBUG_LOG_API_SERVER_RESPONSE",
         "VLLM_TUNED_CONFIG_FOLDER",

--- a/vllm/model_executor/layers/consumer_state_trace.py
+++ b/vllm/model_executor/layers/consumer_state_trace.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Opt-in runtime trace for vocab-state materialization and compact paths."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from typing import Any
+
+import torch
+
+import vllm.envs as envs
+from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.distributed.parallel_state import get_tensor_model_parallel_rank
+
+_TRACE_LOCK = threading.Lock()
+
+
+def tensor_nbytes(tensor: torch.Tensor | None) -> int:
+    if tensor is None:
+        return 0
+    return int(tensor.numel() * tensor.element_size())
+
+
+def tp_size_for_trace() -> int:
+    try:
+        return int(get_tensor_model_parallel_world_size())
+    except Exception:
+        return 1
+
+
+def tp_rank_for_trace() -> int:
+    try:
+        return int(get_tensor_model_parallel_rank())
+    except Exception:
+        return 0
+
+
+def emit_consumer_state_trace(record: dict[str, Any]) -> None:
+    path = envs.VLLM_CONSUMER_STATE_TRACE_JSONL
+    if not path:
+        return
+
+    event = {
+        "schema_version": 1,
+        "timestamp_unix_s": time.time(),
+        "framework": "vllm",
+        **record,
+    }
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    line = json.dumps(event, sort_keys=True, separators=(",", ":"))
+    with _TRACE_LOCK:
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+
+
+def emit_full_vocab_trace(
+    *,
+    component: str,
+    full_logits: torch.Tensor | None,
+    vocab_size: int,
+    consumer_contract: str,
+    fallback_reason: str | None = None,
+    tp_size: int | None = None,
+    rank: int | None = None,
+) -> None:
+    tp_size = tp_size_for_trace() if tp_size is None else int(tp_size)
+    rank = tp_rank_for_trace() if rank is None else int(rank)
+    rows = int(full_logits.shape[0]) if full_logits is not None else 0
+    emit_consumer_state_trace(
+        {
+            "component": component,
+            "path": "full_vocab_materialized",
+            "consumer_contract": consumer_contract,
+            "rank": rank,
+            "tp_size": tp_size,
+            "rows": rows,
+            "vocab_size": int(vocab_size),
+            "local_vocab_size": int(full_logits.shape[-1])
+            if full_logits is not None and full_logits.ndim > 0
+            else 0,
+            "full_vocab_materialized_bytes": tensor_nbytes(full_logits),
+            "full_vocab_reread_bytes": 0,
+            "compact_state_bytes": 0,
+            "tp_gather_bytes": tensor_nbytes(full_logits) if tp_size > 1 else 0,
+            "fallback_reason": fallback_reason,
+            "exact_replay_status": "runtime_metadata_only",
+        }
+    )
+
+
+def emit_compact_vocab_state_trace(
+    *,
+    component: str,
+    rows: int,
+    vocab_size: int,
+    local_vocab_size: int,
+    local_vocab_materialized_bytes: int,
+    compact_state_bytes: int,
+    consumer_contract: str,
+    tp_gather_bytes: int = 0,
+    fallback_reason: str | None = None,
+    dtype_bytes: int = 2,
+    tp_size: int | None = None,
+    rank: int | None = None,
+) -> None:
+    tp_size = tp_size_for_trace() if tp_size is None else int(tp_size)
+    rank = tp_rank_for_trace() if rank is None else int(rank)
+    rows = int(rows)
+    emit_consumer_state_trace(
+        {
+            "component": component,
+            "path": "consumer_sufficient_compact",
+            "consumer_contract": consumer_contract,
+            "rank": rank,
+            "tp_size": tp_size,
+            "rows": rows,
+            "vocab_size": int(vocab_size),
+            "local_vocab_size": int(local_vocab_size),
+            "local_vocab_materialized_bytes": int(local_vocab_materialized_bytes),
+            "full_vocab_materialized_bytes": 0,
+            "full_vocab_reread_bytes": 0,
+            "avoidable_full_vocab_materialized_bytes": rows
+            * int(vocab_size)
+            * int(dtype_bytes),
+            "compact_state_bytes": int(compact_state_bytes),
+            "tp_gather_bytes": int(tp_gather_bytes),
+            "fallback_reason": fallback_reason,
+            "exact_replay_status": "runtime_metadata_only",
+        }
+    )

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -10,6 +10,7 @@ from vllm.distributed import (
     tensor_model_parallel_gather,
 )
 from vllm.model_executor.custom_op import PluggableLayer
+from vllm.model_executor.layers.consumer_state_trace import emit_full_vocab_trace
 from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from vllm.platforms import current_platform
 
@@ -101,6 +102,12 @@ class LogitsProcessor(PluggableLayer):
         # Remove paddings in vocab (if any).
         if logits is not None:
             logits = logits[..., : self.org_vocab_size]
+            emit_full_vocab_trace(
+                component="vllm.logits_processor._get_logits",
+                full_logits=logits,
+                vocab_size=self.org_vocab_size,
+                consumer_contract="generic_logits_processor",
+            )
         return logits
 
     def get_top_tokens(

--- a/vllm/model_executor/models/diffusion_gemma.py
+++ b/vllm/model_executor/models/diffusion_gemma.py
@@ -16,7 +16,8 @@ via Gemma4MultimodalEmbedder.
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
 
@@ -26,11 +27,22 @@ from torch import nn
 from torch.nn import functional as F
 from transformers import AutoModel
 
+import vllm._custom_ops as ops
+import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
+from vllm.distributed import (
+    tensor_model_parallel_all_gather,
+    tensor_model_parallel_all_reduce,
+)
 from vllm.distributed.parallel_state import get_tp_group
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.consumer_state_trace import (
+    emit_compact_vocab_state_trace,
+    emit_full_vocab_trace,
+    tensor_nbytes,
+)
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -64,6 +76,26 @@ from .interfaces import (
 )
 
 logger = init_logger(__name__)
+
+_DIFFUSION_GEMMA_LOCAL_VOCAB_SAMPLER = (
+    envs.VLLM_DIFFUSION_GEMMA_LOCAL_VOCAB_SAMPLER
+)
+_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE = (
+    envs.VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE
+)
+_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_TP_STATE = (
+    envs.VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_TP_STATE
+)
+_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_MODE_FLAGS = (
+    envs.VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_MODE_FLAGS
+)
+_DIFFUSION_GEMMA_FLASHDENOISE_SEED = 0xD1FF600D
+_DIFFUSION_GEMMA_FLASHDENOISE_MODE16 = 16
+_DIFFUSION_GEMMA_FLASHDENOISE_FULL_MAX_ROWS = 1024
+_DIFFUSION_GEMMA_FLASHDENOISE_FULL_MAX_HIDDEN = 4096
+_DIFFUSION_GEMMA_FLASHDENOISE_MAX_VOCAB = 262144
+_TRACE_FLOAT32_BYTES = 4
+_TRACE_INT64_BYTES = 8
 
 
 class DiffusionGemmaSelfConditioning(nn.Module):
@@ -130,6 +162,19 @@ def _softcap_logits(logits: torch.Tensor, cap: float) -> torch.Tensor:
     # the [num_tokens, vocab] logits instead of four separate passes.
     logits = logits.float()
     return torch.tanh(logits / cap) * cap
+
+
+def _compute_local_lm_head_logits(
+    lm_head: ParallelLMHead,
+    hidden_states: torch.Tensor,
+    *,
+    final_logit_softcapping: float | None,
+    embedding_bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    logits = lm_head.quant_method.apply(lm_head, hidden_states, bias=embedding_bias)
+    if final_logit_softcapping is not None:
+        logits = _softcap_logits(logits, final_logit_softcapping)
+    return logits
 
 
 @MULTIMODAL_REGISTRY.register_processor(
@@ -253,6 +298,7 @@ class DiffusionGemmaForConditionalGeneration(
             text_config.vocab_size,
             soft_cap=None,
         )
+        self._allow_local_vocab_logits = False
 
         sc_size = (
             getattr(config, "self_conditioning_size", None)
@@ -330,10 +376,26 @@ class DiffusionGemmaForConditionalGeneration(
             **kwargs,
         )
 
+    @contextmanager
+    def enable_local_vocab_logits(self):
+        previous = self._allow_local_vocab_logits
+        self._allow_local_vocab_logits = True
+        try:
+            yield
+        finally:
+            self._allow_local_vocab_logits = previous
+
     def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
-        logits = self.logits_processor(self.lm_head, hidden_states)
-        if logits is not None and self.final_logit_softcapping is not None:
-            logits = _softcap_logits(logits, self.final_logit_softcapping)
+        if _DIFFUSION_GEMMA_LOCAL_VOCAB_SAMPLER and self._allow_local_vocab_logits:
+            logits = _compute_local_lm_head_logits(
+                self.lm_head,
+                hidden_states,
+                final_logit_softcapping=self.final_logit_softcapping,
+            )
+        else:
+            logits = self.logits_processor(self.lm_head, hidden_states)
+            if logits is not None and self.final_logit_softcapping is not None:
+                logits = _softcap_logits(logits, self.final_logit_softcapping)
         return logits
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
@@ -452,6 +514,394 @@ class DiffusionGemmaForConditionalGeneration(
         if modality == "video":
             return "<|video|>"
         raise ValueError(f"Unsupported modality: {modality}")
+
+
+def _vocab_parallel_soft_embed(
+    probs: torch.Tensor,
+    embed_weight: torch.Tensor,
+    normalizer: torch.Tensor,
+    *,
+    vocab_start_index: int,
+    vocab_end_index: int,
+    all_reduce_fn: Callable[[torch.Tensor], torch.Tensor] | None = None,
+) -> torch.Tensor:
+    """Compute ``probs @ embed_weight`` for dense or vocab-sharded embeddings."""
+    full_vocab = probs.shape[-1]
+    local_vocab = embed_weight.shape[0]
+    if vocab_start_index < 0 or vocab_end_index < vocab_start_index:
+        raise ValueError(
+            f"invalid vocab shard range: [{vocab_start_index}, {vocab_end_index})"
+        )
+    if vocab_end_index > full_vocab:
+        raise ValueError(
+            f"vocab shard end {vocab_end_index} exceeds probs vocab {full_vocab}"
+        )
+
+    if (
+        vocab_start_index == 0
+        and vocab_end_index == full_vocab
+        and local_vocab == full_vocab
+    ):
+        soft_embeds = torch.matmul(probs.to(embed_weight.dtype), embed_weight)
+        return soft_embeds * normalizer
+
+    shard_width = vocab_end_index - vocab_start_index
+    if shard_width > local_vocab:
+        raise ValueError(
+            f"vocab shard width {shard_width} exceeds local weight rows {local_vocab}"
+        )
+
+    local_probs = probs[..., vocab_start_index:vocab_end_index]
+    local_weight = embed_weight[:shard_width]
+    soft_embeds = torch.matmul(local_probs.to(local_weight.dtype), local_weight)
+    if all_reduce_fn is not None:
+        soft_embeds = all_reduce_fn(soft_embeds)
+    return soft_embeds * normalizer
+
+
+def _local_vocab_softmax_stats(
+    scaled_logits: torch.Tensor,
+    embed_weight: torch.Tensor,
+    normalizer: torch.Tensor,
+    *,
+    local_vocab_width: int | None = None,
+    global_max: torch.Tensor | None = None,
+    all_reduce_sum_fn: Callable[[torch.Tensor], torch.Tensor] | None = None,
+    all_reduce_max_fn: Callable[[torch.Tensor], torch.Tensor] | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Exact softmax entropy and soft embed from local-vocab logits."""
+    if local_vocab_width is not None:
+        local_vocab_width = int(local_vocab_width)
+        if local_vocab_width < 0 or local_vocab_width > scaled_logits.shape[-1]:
+            raise ValueError(
+                f"invalid local vocab width {local_vocab_width} for logits "
+                f"width {scaled_logits.shape[-1]}"
+            )
+        scaled_logits = scaled_logits[..., :local_vocab_width]
+        embed_weight = embed_weight[:local_vocab_width]
+
+    logits_f = scaled_logits.float()
+    if global_max is None:
+        local_max = logits_f.max(dim=-1).values
+        global_max = (
+            all_reduce_max_fn(local_max) if all_reduce_max_fn is not None else local_max
+        )
+    else:
+        global_max = global_max.float()
+
+    local_exp = torch.exp(logits_f - global_max.unsqueeze(-1))
+    local_sum_exp = local_exp.sum(dim=-1)
+    weighted_logits = (local_exp * logits_f).sum(dim=-1)
+    soft_part = torch.matmul(local_exp.to(embed_weight.dtype), embed_weight).float()
+    packed = torch.cat(
+        [
+            local_sum_exp.unsqueeze(-1),
+            weighted_logits.unsqueeze(-1),
+            soft_part,
+        ],
+        dim=-1,
+    )
+    packed = all_reduce_sum_fn(packed) if all_reduce_sum_fn is not None else packed
+    global_sum_exp = packed[..., 0]
+    global_weighted_logits = packed[..., 1]
+
+    log_z = torch.log(global_sum_exp) + global_max
+    entropy = log_z - (global_weighted_logits / global_sum_exp)
+    global_soft_part = packed[..., 2:]
+    soft_embeds = (global_soft_part / global_sum_exp.unsqueeze(-1)).to(
+        embed_weight.dtype
+    )
+    return entropy, soft_embeds * normalizer
+
+
+def _local_vocab_argmax_tokens(
+    logits: torch.Tensor,
+    *,
+    vocab_start_index: int,
+    local_vocab_width: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return max values and global token ids for local-vocab logits."""
+    if local_vocab_width is not None:
+        local_vocab_width = int(local_vocab_width)
+        if local_vocab_width < 0 or local_vocab_width > logits.shape[-1]:
+            raise ValueError(
+                f"invalid local vocab width {local_vocab_width} for logits "
+                f"width {logits.shape[-1]}"
+        )
+        logits = logits[..., :local_vocab_width]
+    if logits.shape[-1] == 0:
+        local_values = logits.new_full(logits.shape[:-1], -float("inf"))
+        global_indices = torch.full(
+            logits.shape[:-1],
+            torch.iinfo(torch.int64).max,
+            device=logits.device,
+            dtype=torch.int64,
+        )
+        return local_values, global_indices
+
+    local_values, local_indices = logits.max(dim=-1)
+    global_indices = local_indices.to(torch.int64) + int(vocab_start_index)
+    return local_values, global_indices
+
+
+def _reduce_argmax_from_gathered_pairs(
+    local_values: torch.Tensor,
+    local_indices: torch.Tensor,
+    gathered_pairs: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    gathered_values = gathered_pairs[..., 0]
+    gathered_indices = gathered_pairs[..., 1].to(torch.int64)
+    winning_values = gathered_values.max(dim=-1, keepdim=True).values
+    max_index = torch.iinfo(gathered_indices.dtype).max
+    tie_break_indices = torch.where(
+        gathered_values == winning_values,
+        gathered_indices,
+        torch.full_like(gathered_indices, max_index),
+    )
+    winning_rank = tie_break_indices.argmin(dim=-1, keepdim=True)
+    values = gathered_values.gather(dim=-1, index=winning_rank).squeeze(-1)
+    indices = gathered_indices.gather(dim=-1, index=winning_rank).squeeze(-1)
+    return values.to(local_values.dtype), indices.to(local_indices.dtype)
+
+
+def _merge_local_flashdenoise_state(
+    local_max: torch.Tensor,
+    local_sum_exp: torch.Tensor,
+    local_weighted_logits: torch.Tensor,
+    local_soft_part: torch.Tensor,
+    normalizer: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    global_max = _tp_all_reduce_max(local_max)
+    has_pack_op = hasattr(torch.ops, "_C") and hasattr(
+        torch.ops._C, "diffusion_gemma_flashdenoise_pack_local_state"
+    )
+    if has_pack_op:
+        packed = torch.empty(
+            local_soft_part.shape[0],
+            local_soft_part.shape[1] + 2,
+            device=local_soft_part.device,
+            dtype=torch.float32,
+        )
+        ops.diffusion_gemma_flashdenoise_pack_local_state(
+            packed,
+            local_max,
+            global_max,
+            local_sum_exp,
+            local_weighted_logits,
+            local_soft_part,
+        )
+    else:
+        merge_scale = torch.exp(local_max - global_max)
+        packed = torch.cat(
+            [
+                (local_sum_exp * merge_scale).unsqueeze(-1),
+                (local_weighted_logits * merge_scale).unsqueeze(-1),
+                local_soft_part * merge_scale.unsqueeze(-1),
+            ],
+            dim=-1,
+        )
+    packed = _tp_all_reduce_sum(packed)
+    global_sum_exp = packed[..., 0]
+    global_weighted_logits = packed[..., 1]
+    entropy = (
+        torch.log(global_sum_exp) + global_max - global_weighted_logits / global_sum_exp
+    )
+    soft_embeds = packed[..., 2:] / global_sum_exp.unsqueeze(-1)
+    return entropy, soft_embeds * normalizer.float()
+
+
+def _tp_all_reduce_sum(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor_model_parallel_all_reduce(tensor)
+
+
+def _tp_all_reduce_max(tensor: torch.Tensor) -> torch.Tensor:
+    group = get_tp_group()
+    if group.world_size == 1:
+        return tensor
+    out = tensor.clone()
+    torch.distributed.all_reduce(
+        out, op=torch.distributed.ReduceOp.MAX, group=group.device_group
+    )
+    return out
+
+
+def _tp_all_ranks_true(value: bool, device: torch.device) -> bool:
+    group = get_tp_group()
+    if group.world_size == 1:
+        return bool(value)
+    if torch.device(device).type != "cuda":
+        return bool(value)
+    flag = torch.tensor(int(value), device=device, dtype=torch.int32)
+    torch.distributed.all_reduce(
+        flag, op=torch.distributed.ReduceOp.MIN, group=group.device_group
+    )
+    return bool(flag.item())
+
+
+def _tp_all_gather_vocab(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor_model_parallel_all_gather(tensor, dim=-1)
+
+
+def _tp_argmax_reduce_multi(
+    local_values: torch.Tensor,
+    global_indices: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    group = get_tp_group()
+    if group.world_size == 1:
+        return local_values, global_indices
+    gathered_values = tensor_model_parallel_all_gather(
+        local_values.float(), dim=-1
+    ).view(*local_values.shape[:-1], group.world_size, local_values.shape[-1])
+    gathered_indices = tensor_model_parallel_all_gather(
+        global_indices.to(torch.int64), dim=-1
+    ).view(*global_indices.shape[:-1], group.world_size, global_indices.shape[-1])
+    gathered_values = gathered_values.transpose(-1, -2)
+    gathered_indices = gathered_indices.transpose(-1, -2)
+    gathered_pairs = torch.stack(
+        [gathered_values, gathered_indices.to(gathered_values.dtype)], dim=-1
+    )
+    return _reduce_argmax_from_gathered_pairs(
+        local_values, global_indices, gathered_pairs
+    )
+
+
+def _tp_rank_in_group() -> int:
+    return int(get_tp_group().rank_in_group)
+
+
+def _trace_argmax_reduce_bytes(*, rows: int, lanes: int, tp_size: int) -> int:
+    if int(tp_size) <= 1:
+        return 0
+    return int(rows) * int(lanes) * int(tp_size) * (
+        _TRACE_FLOAT32_BYTES + _TRACE_INT64_BYTES
+    )
+
+
+def _trace_soft_state_reduce_bytes(
+    *, rows: int, hidden_size: int, tp_size: int
+) -> int:
+    if int(tp_size) <= 1:
+        return 0
+    return int(rows) * (int(hidden_size) + 2) * int(tp_size) * _TRACE_FLOAT32_BYTES
+
+
+def _local_vocab_generator_seed(rank: int) -> int:
+    return 0xD1FF600D + int(rank)
+
+
+def _tp_broadcast_from_rank0(tensor: torch.Tensor) -> torch.Tensor:
+    group = get_tp_group()
+    if group.world_size == 1:
+        return tensor
+    return group.broadcast(tensor, src=0)
+
+
+def _should_use_local_vocab_sampler(
+    logits: torch.Tensor | None,
+    num_decode: int,
+    *,
+    vocab_size: int,
+) -> bool:
+    return (
+        _DIFFUSION_GEMMA_LOCAL_VOCAB_SAMPLER
+        and num_decode > 0
+        and logits is not None
+        and logits.shape[-1] != vocab_size
+    )
+
+
+def _is_sampler_warmup_batch(req_ids: Iterable[str]) -> bool:
+    req_ids = list(req_ids)
+    return bool(req_ids) and all(req_id.startswith("_warmup_") for req_id in req_ids)
+
+
+def _local_vocab_requires_full_logprobs(
+    max_num_logprobs: int,
+    *,
+    req_ids: Iterable[str] | None = None,
+) -> bool:
+    if max_num_logprobs < 0:
+        return False
+    return not (req_ids is not None and _is_sampler_warmup_batch(req_ids))
+
+
+def _native_flashdenoise_scaled_is_registered() -> bool:
+    return (
+        getattr(ops, "diffusion_gemma_flashdenoise_scaled", None) is not None
+        and hasattr(torch.ops, "_C")
+        and hasattr(torch.ops._C, "diffusion_gemma_flashdenoise_scaled")
+    )
+
+
+def _native_flashdenoise_scaled_supported(
+    hidden: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    logit_scale: torch.Tensor,
+    *,
+    mode_flags: int,
+) -> bool:
+    if mode_flags != _DIFFUSION_GEMMA_FLASHDENOISE_MODE16:
+        return False
+    if hidden.dim() != 2 or lm_head_weight.dim() != 2 or logit_scale.dim() != 1:
+        return False
+    rows, hidden_size = hidden.shape
+    vocab_size = lm_head_weight.shape[0]
+    if (
+        lm_head_weight.shape[1] != hidden_size
+        or logit_scale.shape[0] != rows
+        or vocab_size <= 0
+        or hidden_size <= 0
+    ):
+        return False
+    if (
+        rows > _DIFFUSION_GEMMA_FLASHDENOISE_FULL_MAX_ROWS
+        or vocab_size > _DIFFUSION_GEMMA_FLASHDENOISE_MAX_VOCAB
+        or hidden_size > _DIFFUSION_GEMMA_FLASHDENOISE_FULL_MAX_HIDDEN
+        or vocab_size % 8 != 0
+        or hidden_size % 8 != 0
+    ):
+        return False
+    if (
+        hidden.dtype != torch.bfloat16
+        or lm_head_weight.dtype != torch.bfloat16
+        or logit_scale.dtype != torch.float32
+    ):
+        return False
+    if not (
+        hidden.is_cuda
+        and lm_head_weight.is_cuda
+        and logit_scale.is_cuda
+        and hidden.device == lm_head_weight.device == logit_scale.device
+    ):
+        return False
+    return hidden.is_contiguous() and lm_head_weight.is_contiguous() and (
+        logit_scale.is_contiguous()
+    )
+
+
+def _local_vocab_logprobs_dense_fallback(
+    logits: torch.Tensor,
+    *,
+    num_decode: int,
+    canvas_length: int,
+    vocab_size: int,
+    all_gather_fn: Callable[[torch.Tensor], torch.Tensor] = _tp_all_gather_vocab,
+) -> torch.Tensor:
+    """Materialize dense logits only for logprobs requests."""
+    if logits.shape[-1] == vocab_size or num_decode == 0:
+        return logits
+    gathered = all_gather_fn(logits.reshape(num_decode, canvas_length, -1))
+    full_logits = gathered[..., :vocab_size].reshape(
+        num_decode * canvas_length, vocab_size
+    )
+    emit_full_vocab_trace(
+        component="vllm.diffusion_gemma.local_vocab_logprobs_dense_fallback",
+        full_logits=full_logits,
+        vocab_size=vocab_size,
+        consumer_contract="diffusion_gemma_logprobs",
+        fallback_reason="full_vocab_logprobs_request",
+    )
+    return full_logits
 
 
 @torch.compile(dynamic=True)
@@ -573,7 +1023,8 @@ def _compiled_sample_step(
     )
     step_tensor[decode_slots] = new_step_val
 
-    # Random tokens for renoise / canvas reinit
+    # Random tokens for renoise / canvas reinit. Keep this draw after the
+    # Gumbel draw above to preserve the upstream dense sampler RNG order.
     random_tokens = torch.randint(
         0, vocab_size, (num_decode, CL), device=device, dtype=canvas.dtype
     )
@@ -747,6 +1198,9 @@ class DiffusionGemmaRequestStates:
             dtype=torch.int64,
             device=self.device,
         )
+        self.canvas[slot_indices_np] = _tp_broadcast_from_rank0(
+            self.canvas[slot_indices_np]
+        )
 
     def add_request(self, slot_idx: int) -> None:
         self.is_encoder_phase[slot_idx] = True
@@ -851,6 +1305,12 @@ class DiffusionGemmaModelState(ModelState):
             entropy_bound=entropy_bound,
             confidence_threshold=gen["confidence_threshold"],
             embed_weight=embed_tokens.weight,
+            embed_vocab_start_index=(
+                shard.org_vocab_start_index
+            ),
+            embed_vocab_end_index=(
+                shard.org_vocab_end_index
+            ),
             normalizer=self.model.model.normalizer,
             sc_vocab_start=shard.org_vocab_start_index,
             sc_vocab_end=shard.org_vocab_end_index,
@@ -1057,6 +1517,8 @@ class DiffusionSampler:
         t_max: float,
         entropy_bound: float,
         embed_weight: torch.Tensor,
+        embed_vocab_start_index: int,
+        embed_vocab_end_index: int,
         normalizer: torch.Tensor,
         sc_vocab_start: int = 0,
         sc_vocab_end: int | None = None,
@@ -1071,11 +1533,14 @@ class DiffusionSampler:
         # rank's slice of the full vocab and tp_* drive the cross-rank
         # all-reduce.
         self.embed_weight = embed_weight
+        self.embed_vocab_start_index = embed_vocab_start_index
+        self.embed_vocab_end_index = embed_vocab_end_index
         self.normalizer = normalizer
         self.sc_vocab_start = sc_vocab_start
         self.sc_vocab_end = sc_vocab_end if sc_vocab_end is not None else vocab_size
         self.tp_size = tp_size
         self.tp_group_name = tp_group_name
+        self.normalizer_float = float(normalizer.detach().cpu().item())
         self.canvas_length = (
             diffusion_config.canvas_length if diffusion_config is not None else 32
         )
@@ -1108,6 +1573,15 @@ class DiffusionSampler:
         # Populated after the post-sample kernel detects convergence; consumed
         # on the subsequent commit step when num_sampled=CANVAS_LEN.
         self._pending_logprobs: dict[int, LogprobsTensors] = {}
+        self._local_vocab_generator: torch.Generator | None = None
+        self._native_flashdenoise_calls = 0
+
+    def _get_local_vocab_generator(self, device: torch.device) -> torch.Generator:
+        if self._local_vocab_generator is None:
+            generator = torch.Generator(device=device)
+            generator.manual_seed(_local_vocab_generator_seed(_tp_rank_in_group()))
+            self._local_vocab_generator = generator
+        return self._local_vocab_generator
 
     def add_request(self, req_idx: int, prompt_len: int, sampling_params: Any) -> None:
         if use_penalty(sampling_params):
@@ -1122,6 +1596,606 @@ class DiffusionSampler:
 
     def apply_staged_writes(self) -> None:
         self.sampling_states.apply_staged_writes()
+
+    def _apply_denoise_step_outputs(
+        self,
+        decode_slots: torch.Tensor,
+        decode_idx: torch.Tensor,
+        all_slots: torch.Tensor,
+        valid_canvas_len: torch.Tensor,
+        is_committing: torch.Tensor,
+        new_tokens: torch.Tensor,
+        argmax_tokens: torch.Tensor,
+        token_entropy: torch.Tensor,
+        soft_embeds: torch.Tensor,
+        sampled: torch.Tensor,
+        num_sampled: torch.Tensor,
+    ) -> None:
+        states = self.diffusion_states
+        num_decode = decode_slots.shape[0]
+        device = decode_slots.device
+        CL = self.canvas_length
+        ST = states.stability_threshold
+
+        mean_entropy = token_entropy.mean(dim=-1)
+        states.confident[decode_slots] = mean_entropy < self.confidence_threshold
+
+        sorted_ent, sorted_idx = torch.sort(token_entropy, dim=-1)
+        cumsum_ent = torch.cumsum(sorted_ent, dim=-1)
+        cummax_ent = torch.cummax(sorted_ent, dim=-1).values
+        sorted_mask = (cumsum_ent - cummax_ent) <= self.entropy_bound
+        eb_mask = torch.zeros_like(sorted_mask)
+        eb_mask.scatter_(1, sorted_idx, sorted_mask)
+
+        is_commit = is_committing
+        is_denoise = ~is_commit
+        cur_step = states.step[decode_slots].float()
+        new_step_val = torch.where(
+            is_denoise,
+            (cur_step + 1).to(states.step.dtype),
+            states.step.new_zeros(num_decode),
+        )
+        states.step[decode_slots] = new_step_val
+
+        random_tokens = torch.randint(
+            0,
+            self.vocab_size,
+            (num_decode, CL),
+            device=device,
+            dtype=states.canvas.dtype,
+        )
+        random_tokens = _tp_broadcast_from_rank0(random_tokens)
+        denoise_canvas = torch.where(eb_mask, new_tokens, random_tokens)
+        states.canvas[decode_slots] = torch.where(
+            is_commit.unsqueeze(1), random_tokens, denoise_canvas
+        )
+
+        hist_len = states.accepted_canvas_history_len[decode_slots]
+        write_pos = hist_len % ST
+        for i in range(ST):
+            write_here = ((write_pos == i) & is_denoise).unsqueeze(1)
+            states.accepted_canvas_history[decode_slots, i] = torch.where(
+                write_here,
+                argmax_tokens,
+                states.accepted_canvas_history[decode_slots, i],
+            )
+
+        states.argmax_canvas[decode_slots] = torch.where(
+            is_denoise.unsqueeze(1), argmax_tokens, states.argmax_canvas[decode_slots]
+        )
+
+        new_hist_len = torch.where(
+            is_denoise, hist_len + 1, hist_len.new_zeros(num_decode)
+        )
+        states.accepted_canvas_history_len[decode_slots] = new_hist_len
+
+        sampled[decode_idx] = states.argmax_canvas[decode_slots].to(
+            sampled.dtype
+        ) * is_commit.unsqueeze(1).to(sampled.dtype)
+        num_sampled[decode_idx] = is_commit.to(num_sampled.dtype) * valid_canvas_len.to(
+            num_sampled.dtype
+        )
+
+        ref = states.accepted_canvas_history[decode_slots, 0]
+        mismatch = torch.zeros(num_decode, device=device, dtype=torch.int32)
+        for h in range(1, ST):
+            mismatch = (
+                mismatch
+                + (ref != states.accepted_canvas_history[decode_slots, h])
+                .sum(dim=-1)
+                .int()
+            )
+        stable = mismatch == 0
+
+        step_after = states.step[decode_slots]
+        converged = (stable & states.confident[decode_slots] & (new_hist_len >= ST)) | (
+            step_after >= states.max_denoising_steps
+        )
+        states.is_encoder_phase[decode_slots] = torch.where(
+            is_commit, is_commit.new_zeros(num_decode), converged
+        )
+
+        sc_keep = (is_denoise & ~states.is_encoder_phase[decode_slots])[:, None, None]
+        states.self_conditioning_embeds[decode_slots] = (soft_embeds * sc_keep).to(
+            states.self_conditioning_embeds.dtype
+        )
+
+        newly_converged = (converged & is_denoise).unsqueeze(1)
+        states.canvas[decode_slots] = torch.where(
+            newly_converged,
+            states.argmax_canvas[decode_slots],
+            states.canvas[decode_slots],
+        )
+
+        self.req_states.draft_tokens[all_slots, :CL] = states.canvas[all_slots]
+
+    def _sample_native_tp_state_from_hidden_states(
+        self,
+        model: Any,
+        hidden_states: torch.Tensor,
+        input_batch: Any,
+    ) -> tuple[SamplerOutput, torch.Tensor, torch.Tensor] | None:
+        device = hidden_states.device
+        native_local_state_op = getattr(
+            ops, "diffusion_gemma_flashdenoise_local_state_scaled", None
+        )
+        native_op_available = _tp_all_ranks_true(
+            native_local_state_op is not None
+            and hasattr(torch.ops, "_C")
+            and hasattr(
+                torch.ops._C, "diffusion_gemma_flashdenoise_local_state_scaled"
+            ),
+            device,
+        )
+        if not native_op_available:
+            logger.warning_once(
+                "VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_TP_STATE=1 requires "
+                "diffusion_gemma_flashdenoise_local_state_scaled; falling back."
+            )
+            return None
+
+        lm_head_weight = getattr(getattr(model, "lm_head", None), "weight", None)
+        has_lm_head = isinstance(lm_head_weight, torch.Tensor)
+        if not _tp_all_ranks_true(has_lm_head, device) or not has_lm_head:
+            return None
+        local_vocab_width = self.embed_vocab_end_index - self.embed_vocab_start_index
+        local_vocab_ok = (
+            local_vocab_width > 0 and local_vocab_width <= lm_head_weight.shape[0]
+        )
+        if not _tp_all_ranks_true(local_vocab_ok, device) or not local_vocab_ok:
+            logger.warning_once(
+                "VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_TP_STATE=1 "
+                "requires a non-empty supported TP-local vocab shard; "
+                "falling back."
+            )
+            return None
+        lm_head_weight = lm_head_weight[:local_vocab_width]
+        embed_weight = self.embed_weight[:local_vocab_width]
+        weights_tied = (
+            embed_weight.shape == lm_head_weight.shape
+            and embed_weight.data_ptr() == lm_head_weight.data_ptr()
+        )
+        if not _tp_all_ranks_true(weights_tied, device) or not weights_tied:
+            logger.warning_once(
+                "VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_TP_STATE=1 requires "
+                "tied TP-local LM-head/embedding weights; falling back."
+            )
+            return None
+        tensor_layout_ok = (
+            hidden_states.dtype == torch.bfloat16
+            and lm_head_weight.dtype == torch.bfloat16
+            and hidden_states.is_cuda
+            and lm_head_weight.is_cuda
+            and lm_head_weight.is_contiguous()
+        )
+        if not _tp_all_ranks_true(tensor_layout_ok, device) or not tensor_layout_ok:
+            return None
+
+        num_reqs = input_batch.num_reqs
+        states = self.diffusion_states
+        CL = self.canvas_length
+        slots_np = input_batch.idx_mapping_np[:num_reqs]
+        per_req_nlogits_np = np.diff(input_batch.cu_num_logits_np[: num_reqs + 1])
+
+        decode_indices_np = np.where(per_req_nlogits_np > 0)[0]
+        prefill_indices_np = np.where(per_req_nlogits_np == 0)[0]
+        decode_slots_np = slots_np[decode_indices_np]
+        num_decode = len(decode_indices_np)
+        if num_decode == 0:
+            return None
+        max_num_logprobs = self.sampling_states.max_num_logprobs(slots_np)
+        if max_num_logprobs >= 0:
+            return None
+
+        self._decode_slots.np[:num_decode] = decode_slots_np
+        self._decode_idx.np[:num_decode] = decode_indices_np
+        self._decode_slots.copy_to_uva()
+        self._decode_idx.copy_to_uva()
+        decode_slots = self._decode_slots.gpu[:num_decode]
+        decode_idx = self._decode_idx.gpu[:num_decode]
+
+        valid_canvas_len_np = per_req_nlogits_np[per_req_nlogits_np > 0]
+        expected_hidden_rows = int(valid_canvas_len_np.sum())
+        hidden_rows_ok = hidden_states.shape[0] == expected_hidden_rows
+        if not _tp_all_ranks_true(hidden_rows_ok, device) or not hidden_rows_ok:
+            logger.warning_once(
+                "VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_TP_STATE=1 expected "
+                "%d hidden rows for %d decode requests but got %d; falling back.",
+                expected_hidden_rows,
+                num_decode,
+                hidden_states.shape[0],
+            )
+            return None
+
+        rows = num_decode * CL
+        hidden_size = hidden_states.shape[-1]
+        mvp_shape_ok = (
+            rows <= 32768
+            and local_vocab_width <= 262144
+            and hidden_size <= 8192
+            and local_vocab_width % 8 == 0
+            and hidden_size % 8 == 0
+        )
+        if not _tp_all_ranks_true(mvp_shape_ok, device) or not mvp_shape_ok:
+            logger.warning_once(
+                "VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_TP_STATE=1 "
+                "local-state MVP supports rows<=32768, local_vocab<=262144, "
+                "hidden<=8192, and 8-divisible local vocab/hidden; falling back."
+            )
+            return None
+
+        estimated_temp_bytes = (
+            rows * local_vocab_width * torch.finfo(torch.float32).bits // 8
+            + rows * local_vocab_width * torch.finfo(torch.bfloat16).bits // 8
+            + rows * hidden_size * torch.finfo(torch.float32).bits // 8
+        )
+        estimated_state_bytes = (
+            rows * 6 * torch.finfo(torch.float32).bits // 8
+            + rows * 2 * torch.iinfo(torch.int64).bits // 8
+        )
+        estimated_workspace_bytes = estimated_temp_bytes + estimated_state_bytes
+        free_bytes, _ = torch.cuda.mem_get_info(device)
+        memory_ok = estimated_workspace_bytes < int(free_bytes * 0.80)
+        if not _tp_all_ranks_true(memory_ok, device) or not memory_ok:
+            logger.warning_once(
+                "VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_TP_STATE=1 "
+                "estimated %.2f GiB temp workspace with %.2f GiB free; "
+                "falling back.",
+                estimated_workspace_bytes / (1024**3),
+                free_bytes / (1024**3),
+            )
+            return None
+
+        if len(prefill_indices_np) > 0:
+            self._finish_prefills(input_batch, prefill_indices_np)
+
+        valid_canvas_len = async_copy_to_gpu(
+            valid_canvas_len_np.astype(np.int64), device=device
+        )
+        if valid_canvas_len_np.min() < CL:
+            ar = torch.arange(CL, device=device)
+            starts = valid_canvas_len.cumsum(0) - valid_canvas_len
+            valid = ar.unsqueeze(0) < valid_canvas_len.unsqueeze(1)
+            src = (starts.unsqueeze(1) + ar.unsqueeze(0)).clamp_max(
+                hidden_states.shape[0] - 1
+            )
+            hidden_states = hidden_states[src.reshape(-1)] * valid.reshape(
+                -1, 1
+            ).to(hidden_states.dtype)
+
+        sampled = self._sampled[:num_reqs]
+        num_sampled = self._num_sampled[:num_reqs]
+        sampled.zero_()
+        num_sampled.zero_()
+        all_slots = input_batch.idx_mapping[:num_reqs]
+        is_committing = states.is_encoder_phase[decode_slots].clone()
+
+        hidden_2d = hidden_states.reshape(rows, -1).contiguous()
+        steps_f = states.step[decode_slots].float()
+        remaining = (states.max_denoising_steps - steps_f).clamp(min=1.0)
+        temp = self.t_min + (self.t_max - self.t_min) * (
+            remaining / states.max_denoising_steps
+        )
+        logit_scale = (
+            1.0 / temp[:, None].clamp(min=1e-10).expand(num_decode, CL)
+        ).reshape(rows).contiguous()
+
+        local_max = torch.empty(rows, device=device, dtype=torch.float32)
+        local_sum_exp = torch.empty(rows, device=device, dtype=torch.float32)
+        local_weighted_logits = torch.empty(rows, device=device, dtype=torch.float32)
+        local_soft_part = torch.empty(
+            rows, hidden_2d.shape[-1], device=device, dtype=torch.float32
+        )
+        clean_values = torch.empty(rows, device=device, dtype=torch.float32)
+        clean_indices = torch.empty(rows, device=device, dtype=torch.int64)
+        sample_values = torch.empty(rows, device=device, dtype=torch.float32)
+        sample_indices = torch.empty(rows, device=device, dtype=torch.int64)
+
+        logger.info_once(
+            "Using native DiffusionGemma FlashDenoise TP-state pre-logit path."
+        )
+        native_local_state_op(
+            local_max,
+            local_sum_exp,
+            local_weighted_logits,
+            local_soft_part,
+            clean_values,
+            clean_indices,
+            sample_values,
+            sample_indices,
+            hidden_2d,
+            lm_head_weight,
+            logit_scale,
+            vocab_start_index=self.embed_vocab_start_index,
+            final_logit_softcapping=float(
+                getattr(model, "final_logit_softcapping", 0.0) or 0.0
+            ),
+            rng_seed=_DIFFUSION_GEMMA_FLASHDENOISE_SEED,
+            rng_offset=self._native_flashdenoise_calls,
+        )
+        self._native_flashdenoise_calls += 1
+
+        token_entropy, soft_embeds = _merge_local_flashdenoise_state(
+            local_max,
+            local_sum_exp,
+            local_weighted_logits,
+            local_soft_part,
+            self.normalizer,
+        )
+        _, argmax_indices = _tp_argmax_reduce_multi(
+            torch.stack([sample_values, clean_values], dim=-1),
+            torch.stack([sample_indices, clean_indices], dim=-1),
+        )
+        tp_size = int(get_tp_group().world_size)
+        emit_compact_vocab_state_trace(
+            component="vllm.diffusion_gemma.native_tp_state",
+            rows=rows,
+            vocab_size=self.vocab_size,
+            local_vocab_size=local_vocab_width,
+            local_vocab_materialized_bytes=(
+                rows * local_vocab_width * _TRACE_FLOAT32_BYTES
+            ),
+            compact_state_bytes=(
+                tensor_nbytes(token_entropy)
+                + tensor_nbytes(soft_embeds)
+                + tensor_nbytes(argmax_indices)
+            ),
+            tp_gather_bytes=(
+                _trace_argmax_reduce_bytes(rows=rows, lanes=2, tp_size=tp_size)
+                + _trace_soft_state_reduce_bytes(
+                    rows=rows,
+                    hidden_size=hidden_size,
+                    tp_size=tp_size,
+                )
+            ),
+            consumer_contract="diffusion_gemma_sampling_entropy_soft_embed",
+            dtype_bytes=hidden_2d.element_size(),
+            tp_size=tp_size,
+            rank=_tp_rank_in_group(),
+        )
+
+        self._apply_denoise_step_outputs(
+            decode_slots,
+            decode_idx,
+            all_slots,
+            valid_canvas_len,
+            is_committing,
+            argmax_indices[..., 0].reshape(num_decode, CL),
+            argmax_indices[..., 1].reshape(num_decode, CL),
+            token_entropy.reshape(num_decode, CL),
+            soft_embeds.reshape(num_decode, CL, -1),
+            sampled,
+            num_sampled,
+        )
+        sampler_output = self._build_output(
+            input_batch,
+            sampled,
+            num_sampled,
+            per_req_nlogits_np,
+            device,
+            logprobs_tensors=None,
+        )
+        return (
+            sampler_output,
+            sampler_output.num_sampled,
+            sampler_output.num_rejected,
+        )
+
+    def sample_from_hidden_states(
+        self,
+        model: Any,
+        hidden_states: torch.Tensor,
+        input_batch: Any,
+    ) -> tuple[SamplerOutput, torch.Tensor, torch.Tensor] | None:
+        if not (
+            _DIFFUSION_GEMMA_FLASHDENOISE_NATIVE
+            or _DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_TP_STATE
+        ):
+            return None
+        if model is None or input_batch is None or input_batch.num_draft_tokens == 0:
+            return None
+        if not isinstance(hidden_states, torch.Tensor):
+            return None
+
+        tp_world_size = get_tp_group().world_size
+        if _DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_TP_STATE:
+            tp_output = self._sample_native_tp_state_from_hidden_states(
+                model, hidden_states, input_batch
+            )
+            if tp_output is not None:
+                return tp_output
+            if tp_world_size != 1 or not _DIFFUSION_GEMMA_FLASHDENOISE_NATIVE:
+                return None
+
+        if tp_world_size != 1:
+            logger.warning_once(
+                "VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE=1 requires TP=1; "
+                "falling back to the standard DiffusionGemma sampler."
+            )
+            return None
+
+        if not _native_flashdenoise_scaled_is_registered():
+            logger.warning_once(
+                "VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE=1 requires "
+                "diffusion_gemma_flashdenoise_scaled; falling back to the "
+                "standard DiffusionGemma sampler."
+            )
+            return None
+        if (
+            _DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_MODE_FLAGS
+            != _DIFFUSION_GEMMA_FLASHDENOISE_MODE16
+        ):
+            logger.warning_once(
+                "VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE=1 supports only "
+                "mode_flags=%d; got %d. Falling back to the standard "
+                "DiffusionGemma sampler.",
+                _DIFFUSION_GEMMA_FLASHDENOISE_MODE16,
+                _DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_MODE_FLAGS,
+            )
+            return None
+
+        lm_head_weight = getattr(getattr(model, "lm_head", None), "weight", None)
+        if not isinstance(lm_head_weight, torch.Tensor):
+            return None
+        lm_head_weight = lm_head_weight[: self.vocab_size]
+        embed_weight = self.embed_weight[: self.vocab_size]
+        if (
+            embed_weight.shape != lm_head_weight.shape
+            or embed_weight.data_ptr() != lm_head_weight.data_ptr()
+        ):
+            logger.warning_once(
+                "VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE=1 requires tied "
+                "full-vocab LM-head/embedding weights; falling back to the "
+                "standard DiffusionGemma sampler."
+            )
+            return None
+        if (
+            hidden_states.dtype != torch.bfloat16
+            or lm_head_weight.dtype != torch.bfloat16
+            or not hidden_states.is_cuda
+            or not lm_head_weight.is_cuda
+            or not lm_head_weight.is_contiguous()
+        ):
+            return None
+
+        num_reqs = input_batch.num_reqs
+        device = hidden_states.device
+        states = self.diffusion_states
+        CL = self.canvas_length
+        slots_np = input_batch.idx_mapping_np[:num_reqs]
+        per_req_nlogits_np = np.diff(input_batch.cu_num_logits_np[: num_reqs + 1])
+
+        decode_indices_np = np.where(per_req_nlogits_np > 0)[0]
+        prefill_indices_np = np.where(per_req_nlogits_np == 0)[0]
+        decode_slots_np = slots_np[decode_indices_np]
+
+        num_decode = len(decode_indices_np)
+        if num_decode == 0:
+            return None
+        max_num_logprobs = self.sampling_states.max_num_logprobs(slots_np)
+        if max_num_logprobs >= 0:
+            return None
+
+        self._decode_slots.np[:num_decode] = decode_slots_np
+        self._decode_idx.np[:num_decode] = decode_indices_np
+        self._decode_slots.copy_to_uva()
+        self._decode_idx.copy_to_uva()
+        decode_slots = self._decode_slots.gpu[:num_decode]
+        decode_idx = self._decode_idx.gpu[:num_decode]
+
+        valid_canvas_len_np = per_req_nlogits_np[per_req_nlogits_np > 0]
+        valid_canvas_len = async_copy_to_gpu(
+            valid_canvas_len_np.astype(np.int64), device=device
+        )
+        if valid_canvas_len_np.min() < CL:
+            ar = torch.arange(CL, device=device)
+            starts = valid_canvas_len.cumsum(0) - valid_canvas_len
+            valid = ar.unsqueeze(0) < valid_canvas_len.unsqueeze(1)
+            src = (starts.unsqueeze(1) + ar.unsqueeze(0)).clamp_max(
+                hidden_states.shape[0] - 1
+            )
+            hidden_states = hidden_states[src.reshape(-1)] * valid.reshape(
+                -1, 1
+            ).to(hidden_states.dtype)
+
+        sampled = self._sampled[:num_reqs]
+        num_sampled = self._num_sampled[:num_reqs]
+        sampled.zero_()
+        num_sampled.zero_()
+        all_slots = input_batch.idx_mapping[:num_reqs]
+        is_committing = states.is_encoder_phase[decode_slots].clone()
+
+        rows = num_decode * CL
+        hidden_2d = hidden_states.reshape(rows, -1).contiguous()
+        steps_f = states.step[decode_slots].float()
+        remaining = (states.max_denoising_steps - steps_f).clamp(min=1.0)
+        temp = self.t_min + (self.t_max - self.t_min) * (
+            remaining / states.max_denoising_steps
+        )
+        logit_scale = (
+            1.0 / temp[:, None].clamp(min=1e-10).expand(num_decode, CL)
+        ).reshape(rows).contiguous()
+
+        if not _native_flashdenoise_scaled_supported(
+            hidden_2d,
+            lm_head_weight,
+            logit_scale,
+            mode_flags=_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_MODE_FLAGS,
+        ):
+            logger.warning_once(
+                "VLLM_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE=1 supports only "
+                "mode16 BF16 CUDA contiguous tensors with rows<=%d, "
+                "vocab<=%d, hidden<=%d, and 8-divisible vocab/hidden; "
+                "falling back to the standard DiffusionGemma sampler.",
+                _DIFFUSION_GEMMA_FLASHDENOISE_FULL_MAX_ROWS,
+                _DIFFUSION_GEMMA_FLASHDENOISE_MAX_VOCAB,
+                _DIFFUSION_GEMMA_FLASHDENOISE_FULL_MAX_HIDDEN,
+            )
+            return None
+
+        if len(prefill_indices_np) > 0:
+            self._finish_prefills(input_batch, prefill_indices_np)
+
+        entropy = torch.empty(rows, device=device, dtype=torch.float32)
+        sample_values = torch.empty(rows, device=device, dtype=torch.float32)
+        sample_indices = torch.empty(rows, device=device, dtype=torch.int64)
+        clean_values = torch.empty(rows, device=device, dtype=torch.float32)
+        clean_indices = torch.empty(rows, device=device, dtype=torch.int64)
+        soft_embed = torch.empty(
+            rows, hidden_2d.shape[-1], device=device, dtype=torch.float32
+        )
+
+        logger.info_once(
+            "Using native DiffusionGemma FlashDenoise pre-logit path "
+            "(mode_flags=%d).",
+            _DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_MODE_FLAGS,
+        )
+        ops.diffusion_gemma_flashdenoise_scaled(
+            entropy,
+            sample_values,
+            sample_indices,
+            clean_values,
+            clean_indices,
+            soft_embed,
+            hidden_2d,
+            lm_head_weight,
+            logit_scale,
+            self.normalizer_float,
+            final_logit_softcapping=float(
+                getattr(model, "final_logit_softcapping", 0.0) or 0.0
+            ),
+            mode_flags=_DIFFUSION_GEMMA_FLASHDENOISE_NATIVE_MODE_FLAGS,
+            rng_seed=_DIFFUSION_GEMMA_FLASHDENOISE_SEED,
+            rng_offset=self._native_flashdenoise_calls,
+        )
+        self._native_flashdenoise_calls += 1
+
+        self._apply_denoise_step_outputs(
+            decode_slots,
+            decode_idx,
+            all_slots,
+            valid_canvas_len,
+            is_committing,
+            sample_indices.reshape(num_decode, CL),
+            clean_indices.reshape(num_decode, CL),
+            entropy.reshape(num_decode, CL),
+            soft_embed.reshape(num_decode, CL, -1),
+            sampled,
+            num_sampled,
+        )
+        sampler_output = self._build_output(
+            input_batch,
+            sampled,
+            num_sampled,
+            per_req_nlogits_np,
+            device,
+            logprobs_tensors=None,
+        )
+        return (
+            sampler_output,
+            sampler_output.num_sampled,
+            sampler_output.num_rejected,
+        )
 
     @property
     def penalties_state(self):
@@ -1216,6 +2290,194 @@ class DiffusionSampler:
             num_rejected=num_rejected,
         )
 
+    def _sample_local_vocab_step(
+        self,
+        logits: torch.Tensor,
+        decode_slots: torch.Tensor,
+        decode_idx: torch.Tensor,
+        all_slots: torch.Tensor,
+        valid_canvas_len: torch.Tensor,
+        is_committing: torch.Tensor,
+        sampled: torch.Tensor,
+        num_sampled: torch.Tensor,
+    ) -> torch.Tensor:
+        """Denoise step for vocab-sharded logits."""
+        states = self.diffusion_states
+        num_decode = decode_slots.shape[0]
+        device = decode_slots.device
+        CL = self.canvas_length
+        ST = states.stability_threshold
+
+        sampled.zero_()
+        num_sampled.zero_()
+
+        steps_f = states.step[decode_slots].float()
+        remaining = (states.max_denoising_steps - steps_f).clamp(min=1.0)
+        temp = self.t_min + (self.t_max - self.t_min) * (
+            remaining / states.max_denoising_steps
+        )
+
+        logits_3d = logits.reshape(num_decode, CL, -1).float()
+        scaled = logits_3d / temp[:, None, None].clamp(min=1e-10)
+        local_vocab_width = self.embed_vocab_end_index - self.embed_vocab_start_index
+
+        u = torch.rand(
+            scaled.shape,
+            device=device,
+            dtype=scaled.dtype,
+            generator=self._get_local_vocab_generator(device),
+        ).clamp(min=1e-20)
+        gumbel = -torch.log(-torch.log(u))
+        noisy = scaled + gumbel * (temp[:, None, None] > 0).float()
+        local_noisy_values, local_new_tokens = _local_vocab_argmax_tokens(
+            noisy,
+            vocab_start_index=self.embed_vocab_start_index,
+            local_vocab_width=local_vocab_width,
+        )
+        local_clean_values, local_argmax_tokens = _local_vocab_argmax_tokens(
+            scaled,
+            vocab_start_index=self.embed_vocab_start_index,
+            local_vocab_width=local_vocab_width,
+        )
+        argmax_values, argmax_indices = _tp_argmax_reduce_multi(
+            torch.stack([local_noisy_values, local_clean_values], dim=-1),
+            torch.stack([local_new_tokens, local_argmax_tokens], dim=-1),
+        )
+        new_tokens = argmax_indices[..., 0]
+        argmax_tokens = argmax_indices[..., 1]
+        global_clean_max = argmax_values[..., 1]
+
+        token_entropy, soft_embeds = _local_vocab_softmax_stats(
+            scaled,
+            self.embed_weight,
+            self.normalizer,
+            local_vocab_width=local_vocab_width,
+            global_max=global_clean_max,
+            all_reduce_sum_fn=_tp_all_reduce_sum,
+        )
+        tp_size = int(get_tp_group().world_size)
+        emit_compact_vocab_state_trace(
+            component="vllm.diffusion_gemma.local_vocab_sampler",
+            rows=num_decode * CL,
+            vocab_size=self.vocab_size,
+            local_vocab_size=local_vocab_width,
+            local_vocab_materialized_bytes=tensor_nbytes(scaled),
+            compact_state_bytes=(
+                tensor_nbytes(token_entropy)
+                + tensor_nbytes(soft_embeds)
+                + tensor_nbytes(new_tokens)
+                + tensor_nbytes(argmax_tokens)
+            ),
+            tp_gather_bytes=(
+                _trace_argmax_reduce_bytes(
+                    rows=num_decode * CL,
+                    lanes=2,
+                    tp_size=tp_size,
+                )
+                + _trace_soft_state_reduce_bytes(
+                    rows=num_decode * CL,
+                    hidden_size=soft_embeds.shape[-1],
+                    tp_size=tp_size,
+                )
+            ),
+            consumer_contract="diffusion_gemma_sampling_entropy_soft_embed",
+            dtype_bytes=logits.element_size(),
+            tp_size=tp_size,
+            rank=_tp_rank_in_group(),
+        )
+        mean_entropy = token_entropy.mean(dim=-1)
+        states.confident[decode_slots] = mean_entropy < self.confidence_threshold
+
+        sorted_ent, sorted_idx = torch.sort(token_entropy, dim=-1)
+        cumsum_ent = torch.cumsum(sorted_ent, dim=-1)
+        cummax_ent = torch.cummax(sorted_ent, dim=-1).values
+        sorted_mask = (cumsum_ent - cummax_ent) <= self.entropy_bound
+        eb_mask = torch.zeros_like(sorted_mask)
+        eb_mask.scatter_(1, sorted_idx, sorted_mask)
+
+        is_commit = is_committing
+        is_denoise = ~is_commit
+        cur_step = states.step[decode_slots].float()
+        new_step_val = torch.where(
+            is_denoise,
+            (cur_step + 1).to(states.step.dtype),
+            states.step.new_zeros(num_decode),
+        )
+        states.step[decode_slots] = new_step_val
+
+        random_tokens = torch.randint(
+            0,
+            self.vocab_size,
+            (num_decode, CL),
+            device=device,
+            dtype=states.canvas.dtype,
+        )
+        random_tokens = _tp_broadcast_from_rank0(random_tokens)
+        denoise_canvas = torch.where(eb_mask, new_tokens, random_tokens)
+        states.canvas[decode_slots] = torch.where(
+            is_commit.unsqueeze(1), random_tokens, denoise_canvas
+        )
+
+        hist_len = states.accepted_canvas_history_len[decode_slots]
+        write_pos = hist_len % ST
+        for i in range(ST):
+            write_here = ((write_pos == i) & is_denoise).unsqueeze(1)
+            states.accepted_canvas_history[decode_slots, i] = torch.where(
+                write_here,
+                argmax_tokens,
+                states.accepted_canvas_history[decode_slots, i],
+            )
+
+        states.argmax_canvas[decode_slots] = torch.where(
+            is_denoise.unsqueeze(1), argmax_tokens, states.argmax_canvas[decode_slots]
+        )
+
+        new_hist_len = torch.where(
+            is_denoise, hist_len + 1, hist_len.new_zeros(num_decode)
+        )
+        states.accepted_canvas_history_len[decode_slots] = new_hist_len
+
+        sampled[decode_idx] = states.argmax_canvas[decode_slots].to(
+            sampled.dtype
+        ) * is_commit.unsqueeze(1).to(sampled.dtype)
+        num_sampled[decode_idx] = is_commit.to(num_sampled.dtype) * valid_canvas_len.to(
+            num_sampled.dtype
+        )
+
+        ref = states.accepted_canvas_history[decode_slots, 0]
+        mismatch = torch.zeros(num_decode, device=device, dtype=torch.int32)
+        for h in range(1, ST):
+            mismatch = (
+                mismatch
+                + (ref != states.accepted_canvas_history[decode_slots, h])
+                .sum(dim=-1)
+                .int()
+            )
+        stable = mismatch == 0
+
+        step_after = states.step[decode_slots]
+        converged = (stable & states.confident[decode_slots] & (new_hist_len >= ST)) | (
+            step_after >= states.max_denoising_steps
+        )
+        states.is_encoder_phase[decode_slots] = torch.where(
+            is_commit, is_commit.new_zeros(num_decode), converged
+        )
+
+        sc_keep = (is_denoise & ~states.is_encoder_phase[decode_slots])[:, None, None]
+        states.self_conditioning_embeds[decode_slots] = (soft_embeds * sc_keep).to(
+            states.self_conditioning_embeds.dtype
+        )
+
+        newly_converged = (converged & is_denoise).unsqueeze(1)
+        states.canvas[decode_slots] = torch.where(
+            newly_converged,
+            states.argmax_canvas[decode_slots],
+            states.canvas[decode_slots],
+        )
+
+        self.req_states.draft_tokens[all_slots, :CL] = states.canvas[all_slots]
+        return scaled
+
     # ------------------------------------------------------------------
     # Main entry point
     # ------------------------------------------------------------------
@@ -1282,51 +2544,101 @@ class DiffusionSampler:
         # Snapshot which slots are committing BEFORE the compiled step runs,
         # since it mutates is_encoder_phase (commit→False, converge→True).
         is_committing = states.is_encoder_phase[decode_slots].clone()
-
-        # --- Single compiled call: temp → sample → probs → post-process ---
-        scaled = _compiled_sample_step(
-            logits,
-            decode_slots,
-            decode_idx,
-            all_slots,
-            valid_canvas_len,
-            # State
-            states.canvas,
-            states.argmax_canvas,
-            states.step,
-            states.is_encoder_phase,
-            states.confident,
-            states.self_conditioning_embeds,
-            self.embed_weight,
-            self.normalizer,
-            states.accepted_canvas_history,
-            states.accepted_canvas_history_len,
-            # Output
-            sampled,
-            num_sampled,
-            self.req_states.draft_tokens,
-            # Config
-            max_denoising_steps=float(states.max_denoising_steps),
-            t_min=self.t_min,
-            t_max=self.t_max,
-            confidence_threshold=self.confidence_threshold,
-            vocab_size=self.vocab_size,
-            CL=self.canvas_length,
-            ST=states.stability_threshold,
-            entropy_bound=self.entropy_bound,
-            sc_vocab_start=self.sc_vocab_start,
-            sc_vocab_end=self.sc_vocab_end,
-            tp_size=self.tp_size,
-            tp_group_name=self.tp_group_name,
+        max_num_logprobs = self.sampling_states.max_num_logprobs(slots_np)
+        use_local_vocab = _should_use_local_vocab_sampler(
+            logits, num_decode, vocab_size=self.vocab_size
         )
+        if use_local_vocab and _local_vocab_requires_full_logprobs(
+            max_num_logprobs, req_ids=getattr(input_batch, "req_ids", [])[:num_reqs]
+        ):
+            logits = _local_vocab_logprobs_dense_fallback(
+                logits,
+                num_decode=num_decode,
+                canvas_length=CL,
+                vocab_size=self.vocab_size,
+            )
+            use_local_vocab = False
+            logger.warning_once(
+                "VLLM_DIFFUSION_GEMMA_LOCAL_VOCAB_SAMPLER=1 falling back to "
+                "dense logits for full-vocab logprobs."
+            )
+        # --- Single compiled call: temp → sample → probs → post-process ---
+        if use_local_vocab:
+            scaled = self._sample_local_vocab_step(
+                logits,
+                decode_slots,
+                decode_idx,
+                all_slots,
+                valid_canvas_len,
+                is_committing,
+                sampled,
+                num_sampled,
+            )
+        else:
+            emit_full_vocab_trace(
+                component="vllm.diffusion_gemma.dense_sampler",
+                full_logits=logits,
+                vocab_size=self.vocab_size,
+                consumer_contract=(
+                    "diffusion_gemma_sampling_entropy_soft_embed"
+                ),
+                fallback_reason=(
+                    "local_vocab_disabled"
+                    if logits.shape[-1] == self.vocab_size
+                    else "dense_sampler_tp_fallback"
+                ),
+            )
+            scaled = _compiled_sample_step(
+                logits,
+                decode_slots,
+                decode_idx,
+                all_slots,
+                valid_canvas_len,
+                # State
+                states.canvas,
+                states.argmax_canvas,
+                states.step,
+                states.is_encoder_phase,
+                states.confident,
+                states.self_conditioning_embeds,
+                self.embed_weight,
+                self.normalizer,
+                states.accepted_canvas_history,
+                states.accepted_canvas_history_len,
+                # Output
+                sampled,
+                num_sampled,
+                self.req_states.draft_tokens,
+                # Config
+                max_denoising_steps=float(states.max_denoising_steps),
+                t_min=self.t_min,
+                t_max=self.t_max,
+                confidence_threshold=self.confidence_threshold,
+                vocab_size=self.vocab_size,
+                CL=self.canvas_length,
+                ST=states.stability_threshold,
+                entropy_bound=self.entropy_bound,
+                sc_vocab_start=self.sc_vocab_start,
+                sc_vocab_end=self.sc_vocab_end,
+                tp_size=self.tp_size,
+                tp_group_name=self.tp_group_name,
+            )
+            if get_tp_group().world_size != 1:
+                # Dense TP fallback can use rank-local RNG for Gumbel sampling
+                # inside the compiled step. Keep the next model input identical.
+                states.canvas[decode_slots] = _tp_broadcast_from_rank0(
+                    states.canvas[decode_slots]
+                )
+                self.req_states.draft_tokens[all_slots, :CL] = states.canvas[
+                    all_slots
+                ]
 
         # --- Logprobs: stash on convergence, return on commit ---
         slots_np = input_batch.idx_mapping_np[:num_reqs]
         is_decode_np = per_req_nlogits_np > 0
 
         logprobs_tensors = None
-        max_num_logprobs = self.sampling_states.max_num_logprobs(slots_np)
-        if max_num_logprobs >= 0:
+        if max_num_logprobs >= 0 and not use_local_vocab:
             # Denoise steps that just converged: the compiled step flipped
             # is_encoder_phase from False→True. Detect as slots where
             # is_encoder_phase is now True but is_committing was False.

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -20,6 +20,7 @@ instead of embedding feature-specific logic directly.
 import functools
 import gc
 import time
+from contextlib import nullcontext
 from copy import deepcopy
 from typing import Any, NamedTuple
 
@@ -1051,7 +1052,25 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         grammar_output: GrammarOutput | None,
     ) -> tuple[SamplerOutput, torch.Tensor, torch.Tensor]:
         sample_hidden_states = hidden_states[input_batch.logits_indices]
-        logits = self.model.compute_logits(sample_hidden_states)
+        if (
+            grammar_output is None
+            and self.rejection_sampler is None
+            and hasattr(self.sampler, "sample_from_hidden_states")
+        ):
+            prelogit_output = self.sampler.sample_from_hidden_states(
+                self.model, sample_hidden_states, input_batch
+            )
+            if prelogit_output is not None:
+                return prelogit_output
+        local_vocab_logits_context = nullcontext()
+        if grammar_output is None and self.rejection_sampler is None:
+            enable_local_vocab_logits = getattr(
+                self.model, "enable_local_vocab_logits", None
+            )
+            if enable_local_vocab_logits is not None:
+                local_vocab_logits_context = enable_local_vocab_logits()
+        with local_vocab_logits_context:
+            logits = self.model.compute_logits(sample_hidden_states)
         if grammar_output is not None:
             # Apply grammar bitmask to the logits in-place.
             assert self.structured_outputs_worker is not None


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

This PR optimizes DiffusionGemma tensor-parallel serving by avoiding full-vocab materialization on the sampler / soft self-conditioning consumer path.

When no full-vocab consumer is active, the implementation keeps vocab-local logits/state compact and reduces only the consumer-sufficient state needed by DiffusionGemma denoise sampling, entropy/confidence, and soft self-conditioning. The dense path remains the default-compatible fallback for full-vocab consumers such as logprobs, grammar, and rejection-sampling paths.

Changes include:

| Area | Change |
| --- | --- |
| DiffusionGemma sampler | Add TP-local vocab / consumer-state path |
| Soft self-conditioning | Compute exact soft embedding from compact TP-local softmax state instead of dense full-vocab probabilities |
| Guarding | Feature-gated path with dense fallback |
| Full-vocab consumers | Fall back to dense logits when full logprobs or other dense consumers are required |
| Native path | Add optional default-off native FlashDenoise / TP-state ops; not required for the conservative benchmark claim |
| Tests | Add dense-reference equivalence, padded-shard, tie-break, logprob fallback, TP sync, and native-op regression coverage |

## Test Plan

Focused regression tests:

```bash
pytest \
  tests/models/test_diffusion_gemma_consumer_state_safety.py \
  tests/models/test_diffusion_gemma_local_vocab.py \
  tests/models/test_diffusion_gemma_flashdenoise.py \
  tests/models/test_diffusion_gemma_flashdenoise_state.py \
  tests/models/test_diffusion_gemma_flashdenoise_native_tp.py \
  tests/models/test_diffusion_gemma_flashdenoise_tp_distributed.py
```

Serving benchmark reproduction:

Benchmark model: `google/diffusiongemma-26B-A4B-it`.

Run the baseline and optimized endpoints sequentially on the same 4-GPU TP4
allocation, or on two equivalent 4-GPU allocations. The only intended
difference between the two endpoints is `VLLM_DIFFUSION_GEMMA_LOCAL_VOCAB_SAMPLER`.

```bash
export MODEL=google/diffusiongemma-26B-A4B-it
export SERVED_MODEL=diffusiongemma-bench

# baseline endpoint
VLLM_DIFFUSION_GEMMA_LOCAL_VOCAB_SAMPLER=0 \
VLLM_ATTENTION_BACKEND=TRITON_ATTN \
VLLM_DEEP_GEMM_WARMUP=skip \
VLLM_WORKER_MULTIPROC_METHOD=spawn \
vllm serve "${MODEL}" \
  --served-model-name "${SERVED_MODEL}" \
  --host 127.0.0.1 \
  --port 8000 \
  --trust-remote-code \
  --dtype bfloat16 \
  --tensor-parallel-size 4 \
  --max-model-len 1024 \
  --gpu-memory-utilization 0.85 \
  --enforce-eager \
  --generation-config vllm \
  --safetensors-load-strategy prefetch

# optimized endpoint
VLLM_DIFFUSION_GEMMA_LOCAL_VOCAB_SAMPLER=1 \
VLLM_ATTENTION_BACKEND=TRITON_ATTN \
VLLM_DEEP_GEMM_WARMUP=skip \
VLLM_WORKER_MULTIPROC_METHOD=spawn \
vllm serve "${MODEL}" \
  --served-model-name "${SERVED_MODEL}" \
  --host 127.0.0.1 \
  --port 8001 \
  --trust-remote-code \
  --dtype bfloat16 \
  --tensor-parallel-size 4 \
  --max-model-len 1024 \
  --gpu-memory-utilization 0.85 \
  --enforce-eager \
  --generation-config vllm \
  --safetensors-load-strategy prefetch
```

Benchmark both endpoints with the same command shape:

```bash
for PORT in 8000 8001; do
  for OUT_LEN in 16 32; do
    for C in 4 8 16 32; do
      vllm bench serve \
        --backend openai \
        --base-url "http://127.0.0.1:${PORT}" \
        --endpoint /v1/completions \
        --model "${SERVED_MODEL}" \
        --served-model-name "${SERVED_MODEL}" \
        --tokenizer "${MODEL}" \
        --trust-remote-code \
        --dataset-name random \
        --random-input-len 30 \
        --random-output-len "${OUT_LEN}" \
        --random-range-ratio 0 \
        --num-prompts 512 \
        --num-warmups 256 \
        --request-rate inf \
        --max-concurrency "${C}" \
        --ignore-eos \
        --temperature 0 \
        --seed "$((100000 + OUT_LEN * 100 + C))" \
        --percentile-metrics ttft,tpot,itl,e2el \
        --metric-percentiles 50,90,95,99
    done
  done
done
```

Benchmark setup:

| item | value |
| --- | --- |
| model | `google/diffusiongemma-26B-A4B-it` |
| server | `vllm serve` OpenAI-compatible endpoint |
| tensor parallelism | TP4 |
| load | closed loop, `--request-rate inf` |
| prompts | 512 measured prompts, 256 warmup prompts |
| random shape | input length 30, output length 16 or 32 |
| concurrency | c4, c8, c16, c32 |
| baseline flag | `VLLM_DIFFUSION_GEMMA_LOCAL_VOCAB_SAMPLER=0` |
| optimized flag | `VLLM_DIFFUSION_GEMMA_LOCAL_VOCAB_SAMPLER=1` |

## Test Result

Focused tests passed:

```text
16 passed, 16 warnings
```

The local-vocab path is tested against dense-reference behavior for entropy, argmax token selection, soft self-conditioning embedding, padded vocab shards, and tie-breaking. The implementation falls back to dense logits when full-vocab logprobs are required.

Serving benchmark result with `vllm serve` + `vllm bench serve`, same source tree, flag-off vs flag-on, TP4, random input length 30, 512 measured prompts, 256 warmups:

| setup | c4 | c8 | c16 | c32 | high-concurrency geomean |
| --- | ---: | ---: | ---: | ---: | ---: |
| output_len=16 | 0.961x | 1.114x | 1.134x | 1.134x | 1.127x |
| output_len=32 | 0.990x | 1.144x | 1.122x | 1.121x | 1.129x |

Historical n=3 paper-safe matrix showed stronger rows: TP8 up to `1.254x`, TP4 around `1.20x`. The current-code same-source result above is the conservative PR claim: about `1.13x` at c8-c32.

The benchmark harness smoke-checked both served endpoints before measuring. This benchmark is a random-throughput serving benchmark, not a downstream task-accuracy evaluation.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
