### PR TITLE
Remediate vllm-openai dependency vulnerability findings

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -696,12 +696,14 @@ RUN apt-get update -y \
         python${PYTHON_VERSION}-dev \
         python${PYTHON_VERSION}-venv \
         libibverbs-dev \
+    && apt-get purge -y --auto-remove software-properties-common \
     && rm -rf /var/lib/apt/lists/* \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 \
     && update-alternatives --set python3 /usr/bin/python${PYTHON_VERSION} \
     && ln -sf /usr/bin/python${PYTHON_VERSION}-config /usr/bin/python3-config \
     && rm -f /usr/lib/python${PYTHON_VERSION}/EXTERNALLY-MANAGED \
-    && curl -sS ${GET_PIP_URL} | python${PYTHON_VERSION} \
+    && curl -sS ${GET_PIP_URL} | python${PYTHON_VERSION} - "pip==26.1.2" \
+    && rm -rf /usr/lib/python${PYTHON_VERSION}/ensurepip/_bundled /root/.cache/pip \
     && python3 --version && python3 -m pip --version
 
 # Install CUDA development tools for runtime JIT compilation
@@ -790,13 +792,15 @@ ENV VLLM_ENABLE_CUDA_COMPATIBILITY=0
 # Install PyTorch and core CUDA dependencies
 # This is ~2GB and rarely changes
 ARG PYTORCH_CUDA_INDEX_BASE_URL
-COPY requirements/common.txt /tmp/common.txt
-COPY requirements/cuda.txt /tmp/requirements-cuda.txt
 # nvidia-cutlass-dsl[cu13] installs -libs-base and -libs-cu13 wheels that
 # share paths with different content. uv can extract them in either order,
 # leaving base files that break CUDA 13 CuTe DSL JIT.
 # TODO(mmangkad): Remove this after NVIDIA/cutlass#3259 is fixed.
-RUN --mount=type=cache,target=/opt/uv/cache \
+RUN --mount=type=bind,source=requirements/common.txt,target=/tmp/common.txt.in,ro \
+    --mount=type=bind,source=requirements/cuda.txt,target=/tmp/requirements-cuda.txt.in,ro \
+    --mount=type=cache,target=/opt/uv/cache \
+    cp /tmp/common.txt.in /tmp/common.txt && \
+    cp /tmp/requirements-cuda.txt.in /tmp/requirements-cuda.txt && \
     if [ "$(echo $CUDA_VERSION | cut -d. -f1)" = "12" ]; then \
         sed -i 's/^nvidia-cutlass-dsl\[cu13\]/nvidia-cutlass-dsl/' /tmp/requirements-cuda.txt; \
         sed -i 's/^humming-kernels\[cu13\]/humming-kernels[cu12]/' /tmp/requirements-cuda.txt; \
@@ -1055,10 +1059,10 @@ RUN --mount=type=cache,target=/opt/uv/cache \
         uv pip install --system --force-reinstall --no-deps nixl-cu${CUDA_MAJOR}; \
     fi
 
-# Optional override: install mooncake-transfer-engine from a URL instead of the
-# PyPI release pulled in above. Use this for wheels built with non-default CMake
-# flags (e.g. `STORE_USE_ETCD=ON` for master HA). The URL's manylinux glibc
-# floor must be <= the FINAL_BASE_IMAGE's glibc.
+# Optional override: install mooncake-transfer-engine from a vetted URL. Use
+# this for patched wheels or wheels built with non-default CMake flags (e.g.
+# `STORE_USE_ETCD=ON` for master HA). The URL's manylinux glibc floor must be
+# <= the FINAL_BASE_IMAGE's glibc.
 ARG MOONCAKE_WHEEL_AARCH64
 ARG MOONCAKE_WHEEL_X86_64
 RUN if [ "$INSTALL_KV_CONNECTORS" = "true" ]; then \

--- a/requirements/kv_connectors.txt
+++ b/requirements/kv_connectors.txt
@@ -3,4 +3,3 @@ lmcache >= 0.3.9
 # until a fixed newer release is verified for runtime images.
 cupy-cuda13x < 14.1.0
 nixl == 1.3.0
-mooncake-transfer-engine >= 0.3.8


### PR DESCRIPTION
## Summary

Remediates the `vllm-openai` image dependency findings that are not covered by the upstream diskcache replacement work in #44549.

This branch was refreshed on current upstream `main` and the commit is DCO signed.

- upstream/fork main: `f05603fa287ab020acc5faafd49c5decf0762533`
- PR commit: `442ac25a3aaeae9ce84f426c76b5afd221dcd328`
- diskcache note: the diskcache finding is intentionally left to #44549 per review feedback, and this PR no longer changes `requirements/common.txt`, generated test requirements, or `vllm/v1/structured_output/utils.py`.

## Scanner Findings And Disposition

| Severity | Package | Found | Fixed | Advisory | Scanner path | Disposition |
| --- | --- | --- | --- | --- | --- | --- |
| Critical | `diskcache` | `5.6.3` | N/A | `CVE-2025-69872` | `/usr/local/lib/python3.12/dist-packages/diskcache-5.6.3.dist-info/METADATA` | Deferred to #44549. Kept installed here to avoid overlapping the upstream replacement. |
| Critical | `golang.org/x/net` | `v0.48.0` | `0.55.0` | `CVE-2026-39821` | `/usr/local/lib/python3.12/dist-packages/mooncake/libetcd_wrapper.so` | Resolved here by removing default `mooncake-transfer-engine` install from KV connectors. |
| High | `cryptography` | `3.4.8` | `0!39.0.1` | `CVE-2023-0286` | `/usr/lib/python3/dist-packages/cryptography-3.4.8.egg-info/PKG-INFO` | Resolved here by purging `software-properties-common` and auto-removed distro Python deps from final image. |
| High | `cryptography` | `3.4.8` | `0!41.0.6` | `CVE-2023-49083` | `/usr/lib/python3/dist-packages/cryptography-3.4.8.egg-info/PKG-INFO` | Resolved here by purging `software-properties-common` and auto-removed distro Python deps from final image. |
| High | `cryptography` | `3.4.8` | `0!42.0.0` | `CVE-2023-50782` | `/usr/lib/python3/dist-packages/cryptography-3.4.8.egg-info/PKG-INFO` | Resolved here by purging `software-properties-common` and auto-removed distro Python deps from final image. |
| High | `cryptography` | `3.4.8` | `0!48.0.1` | `GHSA-537c-gmf6-5ccf` | `/usr/lib/python3/dist-packages/cryptography-3.4.8.egg-info/PKG-INFO` | Resolved here by purging `software-properties-common` and auto-removed distro Python deps from final image. |
| High | `pyjwt` | `2.3.0` | `0!2.12.0` | `CVE-2026-32597` | `/usr/lib/python3/dist-packages/PyJWT-2.3.0.egg-info/PKG-INFO` | Resolved here by purging `software-properties-common` and auto-removed distro Python deps from final image. |
| High | `pyjwt` | `2.3.0` | `0!2.13.0` | `CVE-2026-48526` | `/usr/lib/python3/dist-packages/PyJWT-2.3.0.egg-info/PKG-INFO` | Resolved here by purging `software-properties-common` and auto-removed distro Python deps from final image. |
| High | `pyjwt` | `2.3.0` | `0!2.4.0` | `CVE-2022-29217` | `/usr/lib/python3/dist-packages/PyJWT-2.3.0.egg-info/PKG-INFO` | Resolved here by purging `software-properties-common` and auto-removed distro Python deps from final image. |
| High | `pyjwt` | `2.3.0` | N/A | `CVE-2025-45768` | `/usr/lib/python3/dist-packages/PyJWT-2.3.0.egg-info/PKG-INFO` | Resolved here by removing the vulnerable distro package path from final image. |
| Medium | `cryptography` | `3.4.8` | `0!39.0.1` | `CVE-2023-23931` | `/usr/lib/python3/dist-packages/cryptography-3.4.8.egg-info/PKG-INFO` | Resolved here by purging `software-properties-common` and auto-removed distro Python deps from final image. |
| Medium | `cryptography` | `3.4.8` | `0!42.0.2` | `CVE-2024-0727` | `/usr/lib/python3/dist-packages/cryptography-3.4.8.egg-info/PKG-INFO` | Resolved here by purging `software-properties-common` and auto-removed distro Python deps from final image. |
| Medium | `cryptography` | `3.4.8` | `0!46.0.5` | `CVE-2026-26007` | `/usr/lib/python3/dist-packages/cryptography-3.4.8.egg-info/PKG-INFO` | Resolved here by purging `software-properties-common` and auto-removed distro Python deps from final image. |
| Medium | `cryptography` | `3.4.8` | `0!46.0.6` | `CVE-2026-34073` | `/usr/lib/python3/dist-packages/cryptography-3.4.8.egg-info/PKG-INFO` | Resolved here by purging `software-properties-common` and auto-removed distro Python deps from final image. |
| Medium | `golang.org/x/net` | `v0.48.0` | `0.55.0` | `CVE-2026-25680` | `/usr/local/lib/python3.12/dist-packages/mooncake/libetcd_wrapper.so` | Resolved here by removing default `mooncake-transfer-engine` install from KV connectors. |
| Medium | `golang.org/x/net` | `v0.48.0` | `0.55.0` | `CVE-2026-25681` | `/usr/local/lib/python3.12/dist-packages/mooncake/libetcd_wrapper.so` | Resolved here by removing default `mooncake-transfer-engine` install from KV connectors. |
| Medium | `golang.org/x/net` | `v0.48.0` | `0.55.0` | `CVE-2026-27136` | `/usr/local/lib/python3.12/dist-packages/mooncake/libetcd_wrapper.so` | Resolved here by removing default `mooncake-transfer-engine` install from KV connectors. |
| Medium | `golang.org/x/net` | `v0.48.0` | `0.55.0` | `CVE-2026-42502` | `/usr/local/lib/python3.12/dist-packages/mooncake/libetcd_wrapper.so` | Resolved here by removing default `mooncake-transfer-engine` install from KV connectors. |
| Medium | `golang.org/x/net` | `v0.48.0` | `0.55.0` | `CVE-2026-42506` | `/usr/local/lib/python3.12/dist-packages/mooncake/libetcd_wrapper.so` | Resolved here by removing default `mooncake-transfer-engine` install from KV connectors. |
| Medium | `oauthlib` | `3.2.0` | `0!3.2.2` | `CVE-2022-36087` | `/usr/lib/python3/dist-packages/oauthlib-3.2.0.egg-info/PKG-INFO` | Resolved here by purging `software-properties-common` and auto-removed distro Python deps from final image. |
| Medium | `pip` | `25.0.1` | `0!25.3` | `GHSA-4xh5-x5gv-qwph` | `/usr/lib/python3.12/ensurepip/_bundled/pip-25.0.1-py3-none-any.whl_extracted/pip-25.0.1.dist-info/METADATA` | Resolved here by installing `pip==26.1.2` and removing the bundled ensurepip wheel directory. |
| Medium | `pip` | `25.0.1` | `0!26.1` | `GHSA-58qw-9mgm-455v` | `/usr/lib/python3.12/ensurepip/_bundled/pip-25.0.1-py3-none-any.whl_extracted/pip-25.0.1.dist-info/METADATA` | Resolved here by installing `pip==26.1.2` and removing the bundled ensurepip wheel directory. |
| Medium | `pip` | `25.0.1` | `0!26.1` | `GHSA-jp4c-xjxw-mgf9` | `/usr/lib/python3.12/ensurepip/_bundled/pip-25.0.1-py3-none-any.whl_extracted/pip-25.0.1.dist-info/METADATA` | Resolved here by installing `pip==26.1.2` and removing the bundled ensurepip wheel directory. |
| Medium | `pip` | `25.0.1` | `0!26.1.2` | `CVE-2026-8643` | `/usr/lib/python3.12/ensurepip/_bundled/pip-25.0.1-py3-none-any.whl_extracted/pip-25.0.1.dist-info/METADATA` | Resolved here by installing `pip==26.1.2` and removing the bundled ensurepip wheel directory. |
| Medium | `pyjwt` | `2.3.0` | `0!2.13.0` | `CVE-2026-48522` | `/usr/lib/python3/dist-packages/PyJWT-2.3.0.egg-info/PKG-INFO` | Resolved here by purging `software-properties-common` and auto-removed distro Python deps from final image. |
| Medium | `torch` | `2.11.0` | N/A | `CVE-2025-3000` | `/tmp/requirements-cuda.txt` | Resolved here by consuming requirements through BuildKit bind mounts and removing temporary files after install. |
| Medium | `zipp` | `1.0.0` | `0!3.19.1` | `GHSA-jfmj-5v4g-7637` | `/usr/lib/python3/dist-packages/zipp-1.0.0.egg-info/PKG-INFO` | Resolved here by purging `software-properties-common` and auto-removed distro Python deps from final image. |
| Low | `cryptography` | `3.4.8` | `0!41.0.0` | `GHSA-5cpq-8wj7-hf2v` | `/usr/lib/python3/dist-packages/cryptography-3.4.8.egg-info/PKG-INFO` | Resolved here by purging `software-properties-common` and auto-removed distro Python deps from final image. |
| Low | `cryptography` | `3.4.8` | `0!41.0.3` | `GHSA-jm77-qphf-c4w8` | `/usr/lib/python3/dist-packages/cryptography-3.4.8.egg-info/PKG-INFO` | Resolved here by purging `software-properties-common` and auto-removed distro Python deps from final image. |
| Low | `cryptography` | `3.4.8` | `0!41.0.4` | `GHSA-v8gr-m533-ghj9` | `/usr/lib/python3/dist-packages/cryptography-3.4.8.egg-info/PKG-INFO` | Resolved here by purging `software-properties-common` and auto-removed distro Python deps from final image. |
| Low | `golang.org/x/sys` | `v0.39.0` | `0.44.0` | `CVE-2026-39824` | `/usr/local/lib/python3.12/dist-packages/mooncake/libetcd_wrapper.so` | Resolved here by removing default `mooncake-transfer-engine` install from KV connectors. |
| Low | `pip` | `25.0.1` | `0!26.0` | `GHSA-6vgw-5pg2-w6jp` | `/usr/lib/python3.12/ensurepip/_bundled/pip-25.0.1-py3-none-any.whl_extracted/pip-25.0.1.dist-info/METADATA` | Resolved here by installing `pip==26.1.2` and removing the bundled ensurepip wheel directory. |
| Low | `pyjwt` | `2.3.0` | `0!2.13.0` | `CVE-2026-48524` | `/usr/lib/python3/dist-packages/PyJWT-2.3.0.egg-info/PKG-INFO` | Resolved here by purging `software-properties-common` and auto-removed distro Python deps from final image. |

## Remediation Mapping

- `software-properties-common` is only needed during the image build to add the Python PPA. The final runtime layer now purges it with auto-remove so vulnerable distro Python dependency metadata under `/usr/lib/python3/dist-packages` is not retained.
- pip is installed as `pip==26.1.2`, and the stale `ensurepip` bundled `pip-25.0.1` wheel directory is removed from the final image.
- `requirements/common.txt` and `requirements/cuda.txt` are consumed through BuildKit bind mounts and removed after installation so `/tmp/requirements-cuda.txt` is not left in the final image.
- `mooncake-transfer-engine` is no longer installed by default from `requirements/kv_connectors.txt`, removing the embedded vulnerable Go `libetcd_wrapper.so`. The existing `MOONCAKE_WHEEL_AARCH64` and `MOONCAKE_WHEEL_X86_64` build args remain available for installing a vetted or patched wheel when needed.

## Validation

- `git diff --check origin/main...HEAD -- docker/Dockerfile requirements/kv_connectors.txt`
- A100 build from signed-off PR commit:
  - host: `ubuntu@138.1.153.110`
  - image: `local/vllm-openai:pr-442ac25`
  - build args included `VLLM_USE_PRECOMPILED=1` and `VLLM_MERGE_BASE_COMMIT=e392bf7a68ff440636c68f36a1f198c1608097dd` because latest upstream `f05603fa2` did not yet have published wheel metadata at `wheels.vllm.ai`.
- Default image package check:
  - `diskcache 5.6.3` (expected, deferred to #44549)
  - `pyjwt 2.13.0`
  - `cryptography 49.0.0`
  - `oauthlib NOT INSTALLED`
  - `zipp NOT INSTALLED`
  - `pip 26.1.2`
  - `torch 2.11.0+cu130`
  - `mooncake-transfer-engine NOT INSTALLED`
- Default image path check:
  - no matching vulnerable distro metadata under `/usr/lib/python3/dist-packages`
  - no `/usr/lib/python3.12/ensurepip/_bundled`
  - no `/tmp/requirements-cuda.txt`
  - no `libetcd_wrapper.so` under `/usr/local/lib/python3.12/dist-packages` or `/opt/uv/cache`
- Outlines disk cache sanity:
  - `VLLM_V1_USE_OUTLINES_CACHE=1` returns `diskcache.Cache`
- KV-connectors build:
  - image: `local/vllm-openai:pr-442ac25-kv`
  - `mooncake-transfer-engine NOT INSTALLED`
  - `lmcache 0.5.1`
  - `nixl 1.3.0`
  - `nixl-cu13 1.3.1`
  - `zipp 4.1.0`
  - no Mooncake metadata and no `libetcd_wrapper.so`

Note: `trivy`, `syft`, and `grype` are not installed on the A100 host, so scanner re-run validation was not available there.
