### PR TITLE
[CI/Build] Regression test: CPU MoE activation table must not require a config context

### DIFF
--- a/tests/kernels/moe/test_cpu_fused_moe.py
+++ b/tests/kernels/moe/test_cpu_fused_moe.py
@@ -176,3 +176,28 @@ def test_cpu_fused_moe(
         torch.testing.assert_close(output, ref_output, atol=atol, rtol=rtol),
         f"{torch.max(torch.abs(output - ref_output))}",
     )
+
+
+def test_act_fn_table_needs_no_config_context(monkeypatch):
+    """Every _CPU_MOE_ACT_FN entry must be callable with NO vLLM config set.
+
+    The table is consulted at model *forward* time (engine warmup /
+    profile_run), outside any set_current_vllm_config() context. An entry
+    that lazily instantiates a CustomOp calls get_current_vllm_config() in
+    CustomOp.__init__ and crashes CPU MoE serving with "Current vLLM config
+    is not set". This class of bug regressed twice (#32368, fixed by #32777;
+    #45447, fixed by #45961) because the main test above runs under the
+    default_vllm_config fixture, which masks it. This test pins the whole
+    table: entries must be static methods or standalone functions.
+    """
+    import vllm.config.vllm as vllm_config_vllm
+
+    # Reproduce the failing condition exactly: no current config at call
+    # time (also shields against config-context leakage from other tests).
+    monkeypatch.setattr(vllm_config_vllm, "_current_vllm_config", None)
+
+    x = torch.randn(8, 32, dtype=torch.float32)
+    for act, fn in _CPU_MOE_ACT_FN.items():
+        out = fn(x)
+        # All entries are gated activations: last dim halves.
+        assert out.shape == (8, 16), act


### PR DESCRIPTION
## Purpose

Pin a bug class that has regressed twice. The entries of `_CPU_MOE_ACT_FN` (`vllm/model_executor/layers/fused_moe/cpu_fused_moe.py`) are called at model **forward** time (engine warmup / `profile_run`), outside any `set_current_vllm_config()` context. An entry that lazily instantiates a `CustomOp` calls `get_current_vllm_config()` in `CustomOp.__init__` and crashes CPU MoE serving with `Current vLLM config is not set`:

- #32368 → fixed by #32777 (made entries static/standalone, documented the rule in a comment)
- #45447 → fixed by #45961 (the SILU entry had regressed to a `SiluAndMul(...)`-constructing lambda)

Neither fix added a test, and the existing `test_cpu_fused_moe` runs under the `default_vllm_config` fixture — which masks exactly this condition. So the rule currently lives only in a comment, and it has already been broken twice.

## Changes

One test, `test_act_fn_table_needs_no_config_context`: iterates the whole table and calls every activation with `_current_vllm_config` explicitly monkeypatched to `None` (reproducing the warmup condition and shielding against config-context leakage from other tests in the same process). Asserts the gated-activation output shape. With the pre-#45961 SILU lambda, this test fails with the exact production error; on current main it passes.

## Test Plan

CPU-only suite (`tests/kernels/moe/test_cpu_fused_moe.py` module-skips off-CPU). Runs in the existing CPU test lane; no GPU needed. Draft until the CPU CI lane confirms.

Closes nothing by itself — #45447 is already fixed by #45961 and can be closed; this PR prevents the third regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)