### PR TITLE
Fix Transformers modeling backend usage stats

### DIFF
--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -689,8 +689,15 @@ def report_usage_stats(
         else None
     )
 
+    if model_config.using_transformers_backend():
+        backend_cls = model_config._model_info.architecture
+        # Show what was wrapped e.g. TransformersForCausalLM(Starcoder2ForCausalLM)
+        architecture = f"{backend_cls}({model_config.architectures[0]})"
+    else:
+        architecture = get_architecture_class_name(model_config)
+
     usage_message.report_usage(
-        get_architecture_class_name(model_config),
+        architecture,
         usage_context,
         extra_kvs={
             # Common configuration


### PR DESCRIPTION
Any use of the Transformers modeling backend previously obfuscated what was being wrapped. This PR fixes that so that:

- All usage of the Transfomers modeling backend is prefixed with the wrapper class (fixes entries in `_TRANSFORMERS_SUPPORTED_MODELS`)
- Models loaded with the fallback behaviour include the wrapped architecture in the name