### PR TITLE
[Core] Add primary-tier external pinning API for KV offload

### DIFF
--- a/tests/v1/kv_offload/tiering/test_factory.py
+++ b/tests/v1/kv_offload/tiering/test_factory.py
@@ -116,6 +116,36 @@ def test_register_new_tier_type():
     assert isinstance(tier, ExampleSecondaryTierManager)
 
 
+def test_create_tier_honors_required_primary_pinning():
+    class PinningSecondaryTier(ExampleSecondaryTierManager):
+        requires_primary_pinning = True
+
+        def __init__(self, *args, primary_pinning, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.primary_pinning = primary_pinning
+
+    SecondaryTierFactory._registry["pinning"] = lambda: PinningSecondaryTier
+    primary_kv_view, offloading_spec = _make_mock_args()
+    primary_pinning = object()
+
+    with pytest.raises(ValueError, match="enable_external_pinning=True"):
+        SecondaryTierFactory.create_secondary_tier(
+            {"type": "pinning"},
+            primary_kv_view,
+            offloading_spec,
+        )
+
+    tier = SecondaryTierFactory.create_secondary_tier(
+        {"type": "pinning"},
+        primary_kv_view,
+        offloading_spec,
+        primary_pinning=primary_pinning,
+    )
+
+    assert isinstance(tier, PinningSecondaryTier)
+    assert tier.primary_pinning is primary_pinning
+
+
 # ---------------------------------------------------------------------------
 # Error paths
 # ---------------------------------------------------------------------------

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -30,6 +30,8 @@ from vllm.v1.kv_offload.base import (
     ScheduleEndContext,
     make_offload_key,
 )
+from vllm.v1.kv_offload.tiering import manager as manager_module
+from vllm.v1.kv_offload.tiering import spec as spec_module
 from vllm.v1.kv_offload.tiering.base import (
     JobMetadata,
     JobResult,
@@ -37,6 +39,11 @@ from vllm.v1.kv_offload.tiering.base import (
 )
 from vllm.v1.kv_offload.tiering.example.manager import ExampleSecondaryTierManager
 from vllm.v1.kv_offload.tiering.factory import SecondaryTierFactory
+from vllm.v1.kv_offload.tiering.pinning import (
+    MemDescriptor,
+    PrimaryPinningAPI,
+    TransportEndpoint,
+)
 from vllm.v1.kv_offload.tiering.manager import (
     CPUPrimaryTierOffloadingManager,
     TieringOffloadingManager,
@@ -50,8 +57,11 @@ _MOCK_OFFLOADING_SPEC = MagicMock()
 def _mock_mmap_region(num_blocks: int, row_bytes: int = 16):
     """Create a mock SharedOffloadRegion for testing."""
     mock = MagicMock()
-    view = memoryview(torch.zeros((num_blocks, row_bytes), dtype=torch.int8).numpy())
+    arr = torch.zeros((num_blocks, row_bytes), dtype=torch.int8).numpy()
+    view = memoryview(arr)
     mock.create_kv_memoryview.return_value = view
+    mock.base_addr = arr.ctypes.data
+    mock.row_stride_bytes = row_bytes
     return mock
 
 
@@ -118,6 +128,47 @@ class MetricsSecondaryTierManager(SecondaryTierManager):
         return stats
 
 
+class FakeNixlAgent:
+    instances: list["FakeNixlAgent"] = []
+
+    def __init__(self, name, config):
+        self.name = name
+        self.config = config
+        self.register_memory_calls = []
+        self.deregister_memory_calls = []
+        FakeNixlAgent.instances.append(self)
+
+    def register_memory(self, descs, mem_type=None, backends=None):
+        registration = (descs, mem_type, backends)
+        self.register_memory_calls.append(registration)
+        return registration
+
+    def deregister_memory(self, registration):
+        self.deregister_memory_calls.append(registration)
+
+
+@pytest.fixture
+def fake_nixl(monkeypatch):
+    FakeNixlAgent.instances = []
+
+    def fake_agent_config(**kwargs):
+        return {"config": kwargs}
+
+    monkeypatch.setattr(manager_module.nixl_utils, "NixlWrapper", FakeNixlAgent)
+    monkeypatch.setattr(
+        manager_module.nixl_utils, "nixl_agent_config", fake_agent_config
+    )
+    return FakeNixlAgent
+
+
+def store_ready_blocks(
+    manager: CPUPrimaryTierOffloadingManager, keys: list[OffloadKey]
+) -> None:
+    result = manager.prepare_store(keys, _CTX)
+    assert result is not None
+    manager.complete_store(keys, _CTX, success=True)
+
+
 def test_tiering_spec_collects_secondary_metric_definitions(monkeypatch):
     monkeypatch.setitem(
         SecondaryTierFactory._registry,
@@ -170,6 +221,259 @@ def test_tiering_manager_aggregates_secondary_stats():
     second_stats = manager.get_stats()
     assert second_stats is not None
     assert MetricsSecondaryTierManager.MY_TIER_METRIC not in second_stats.data["data"]
+
+
+class TestCPUPrimaryTierExternalPinning:
+    def test_external_pinning_disabled_rejects_endpoint_and_pin(self):
+        primary_tier = CPUPrimaryTierOffloadingManager(
+            num_blocks=2, mmap_region=_mock_mmap_region(2)
+        )
+        pinning_api: PrimaryPinningAPI = primary_tier
+
+        with pytest.raises(RuntimeError, match="external pinning"):
+            pinning_api.get_transport_endpoint()
+        with pytest.raises(RuntimeError, match="external pinning"):
+            pinning_api.search_and_pin(to_keys([0]))
+
+    def test_external_pinning_initializes_endpoint_and_registers_mmap_once(
+        self, fake_nixl
+    ):
+        mock_region = _mock_mmap_region(3, row_bytes=32)
+        primary_tier = CPUPrimaryTierOffloadingManager(
+            num_blocks=3,
+            mmap_region=mock_region,
+            enable_external_pinning=True,
+        )
+
+        pinning_api: PrimaryPinningAPI = primary_tier
+        assert len(fake_nixl.instances) == 1
+        agent = fake_nixl.instances[0]
+        endpoint = pinning_api.get_transport_endpoint()
+        assert isinstance(endpoint, TransportEndpoint)
+        assert endpoint.name == agent.name
+        assert endpoint.end_point is agent
+        assert endpoint.info == "nixl"
+
+        view = primary_tier.get_kv_memoryview()
+        base_addr = view.obj.ctypes.data
+        assert agent.register_memory_calls == [
+            ([(base_addr, view.nbytes, 0, "")], "DRAM", None)
+        ]
+        primary_tier.shutdown()
+        assert agent.deregister_memory_calls == agent.register_memory_calls
+
+    def test_search_and_pin_ready_block_returns_descriptor_and_protects_eviction(
+        self, fake_nixl
+    ):
+        mock_region = _mock_mmap_region(2, row_bytes=32)
+        primary_tier = CPUPrimaryTierOffloadingManager(
+            num_blocks=2,
+            mmap_region=mock_region,
+            enable_external_pinning=True,
+        )
+        key = to_keys([1])[0]
+        store_ready_blocks(primary_tier, [key])
+        pinning_api: PrimaryPinningAPI = primary_tier
+
+        block = primary_tier._policy.get(key)
+        assert block is not None
+        assert block.ref_cnt == 0
+        assert key in primary_tier._policy.evictable_blocks
+        assert primary_tier._num_evictable_cache_blocks == 1
+
+        view = primary_tier.get_kv_memoryview()
+        sentinel = b"pin-me"
+        row_addr = mock_region.base_addr + block.block_id * mock_region.row_stride_bytes
+        view.obj[block.block_id, : len(sentinel)] = list(sentinel)
+
+        pin_result = pinning_api.search_and_pin([key])
+
+        assert pin_result is not None
+        pin_handle, descriptors = pin_result
+        assert pin_handle
+        assert len(descriptors) == 1
+        descriptor = descriptors[key]
+        assert isinstance(descriptor, MemDescriptor)
+        assert descriptor.end_point_name == pinning_api.get_transport_endpoint().name
+        assert descriptor.mem_type == "DRAM"
+        assert descriptor.addr == row_addr
+        assert descriptor.size == mock_region.row_stride_bytes
+        assert descriptor.device_Id == 0
+        assert descriptor.info == ""
+        assert bytes(view.obj[block.block_id, : len(sentinel)]) == sentinel
+        assert block.ref_cnt == 1
+        assert key not in primary_tier._policy.evictable_blocks
+        assert primary_tier._num_evictable_cache_blocks == 0
+
+        assert pinning_api.unpin(pin_handle) is True
+        assert block.ref_cnt == 0
+        assert key in primary_tier._policy.evictable_blocks
+        assert primary_tier._num_evictable_cache_blocks == 1
+        assert pinning_api.unpin(pin_handle) is False
+
+    def test_overlapping_pin_handles_preserve_refcounts(self, fake_nixl):
+        primary_tier = CPUPrimaryTierOffloadingManager(
+            num_blocks=3,
+            mmap_region=_mock_mmap_region(3),
+            enable_external_pinning=True,
+        )
+        keys = to_keys(range(3))
+        store_ready_blocks(primary_tier, keys)
+        pinning_api: PrimaryPinningAPI = primary_tier
+
+        first_handle, _ = pinning_api.search_and_pin(keys[:2])
+        second_handle, _ = pinning_api.search_and_pin(keys[1:])
+
+        blocks = [primary_tier._policy.get(key) for key in keys]
+        assert [block.ref_cnt for block in blocks if block is not None] == [1, 2, 1]
+
+        assert pinning_api.unpin(first_handle) is True
+        assert [block.ref_cnt for block in blocks if block is not None] == [0, 1, 1]
+        assert keys[0] in primary_tier._policy.evictable_blocks
+        assert keys[1] not in primary_tier._policy.evictable_blocks
+
+        assert pinning_api.unpin(second_handle) is True
+        assert [block.ref_cnt for block in blocks if block is not None] == [0, 0, 0]
+        assert all(key in primary_tier._policy.evictable_blocks for key in keys)
+
+    def test_search_and_pin_all_or_nothing_for_missing_and_not_ready_keys(
+        self, fake_nixl
+    ):
+        primary_tier = CPUPrimaryTierOffloadingManager(
+            num_blocks=3,
+            mmap_region=_mock_mmap_region(3),
+            enable_external_pinning=True,
+        )
+        ready_key, missing_key, pending_key = to_keys(range(3))
+        store_ready_blocks(primary_tier, [ready_key])
+        pinning_api: PrimaryPinningAPI = primary_tier
+
+        assert pinning_api.search_and_pin([ready_key, missing_key]) is None
+        ready_block = primary_tier._policy.get(ready_key)
+        assert ready_block is not None
+        assert ready_block.ref_cnt == 0
+        assert ready_key in primary_tier._policy.evictable_blocks
+
+        result = primary_tier.prepare_store([pending_key], _CTX)
+        assert result is not None
+        pending_block = primary_tier._policy.get(pending_key)
+        assert pending_block is not None
+        assert pending_block.ref_cnt == -1
+
+        assert pinning_api.search_and_pin([ready_key, pending_key]) is None
+        assert ready_block.ref_cnt == 0
+        assert pending_block.ref_cnt == -1
+        assert ready_key in primary_tier._policy.evictable_blocks
+
+    def test_reset_cache_fails_with_active_external_pins(self, fake_nixl):
+        primary_tier = CPUPrimaryTierOffloadingManager(
+            num_blocks=2,
+            mmap_region=_mock_mmap_region(2),
+            enable_external_pinning=True,
+        )
+        key = to_keys([0])[0]
+        store_ready_blocks(primary_tier, [key])
+        pinning_api: PrimaryPinningAPI = primary_tier
+        pin_handle, _ = pinning_api.search_and_pin([key])
+
+        with pytest.raises(RuntimeError, match="active external pins"):
+            primary_tier.reset_cache()
+
+        assert pinning_api.unpin(pin_handle) is True
+        primary_tier.reset_cache()
+        assert primary_tier.lookup(key, _CTX) is LookupResult.MISS
+
+    @pytest.mark.parametrize("cache_policy", ["lru", "arc"])
+    def test_pinned_block_survives_eviction_pressure(self, fake_nixl, cache_policy):
+        primary_tier = CPUPrimaryTierOffloadingManager(
+            num_blocks=2,
+            mmap_region=_mock_mmap_region(2),
+            cache_policy=cache_policy,
+            enable_external_pinning=True,
+        )
+        pinned_key, evictable_key, pressure_key = to_keys(range(3))
+        store_ready_blocks(primary_tier, [pinned_key, evictable_key])
+        pinning_api: PrimaryPinningAPI = primary_tier
+        pin_handle, _ = pinning_api.search_and_pin([pinned_key])
+
+        result = primary_tier.prepare_store([pressure_key], _CTX)
+        assert result is not None
+        assert result.evicted_keys == [evictable_key]
+        primary_tier.complete_store([pressure_key], _CTX, success=True)
+
+        pinned_block = primary_tier._policy.get(pinned_key)
+        assert pinned_block is not None
+        assert pinned_block.ref_cnt == 1
+        assert primary_tier.lookup(pinned_key, _CTX) is LookupResult.HIT
+        assert primary_tier.lookup(evictable_key, _CTX) is LookupResult.MISS
+        assert primary_tier.lookup(pressure_key, _CTX) is LookupResult.HIT
+
+        assert pinning_api.unpin(pin_handle) is True
+        assert pinned_block.ref_cnt == 0
+        assert primary_tier._num_evictable_cache_blocks == 2
+        assert not primary_tier._has_active_external_pins()
+
+
+def test_tiering_spec_passes_external_pinning_flag(monkeypatch):
+    class FakeSharedOffloadRegion:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    captured = {}
+    fake_primary = MagicMock()
+    fake_primary.enable_external_pinning = True
+    fake_primary.get_kv_memoryview.return_value = memoryview(
+        torch.zeros((1, 16), dtype=torch.int8).numpy()
+    )
+
+    def fake_primary_ctor(**kwargs):
+        captured.update(kwargs)
+        return fake_primary
+
+    fake_tiering_manager = object()
+    factory_captured = {}
+    fake_secondary = MagicMock()
+    fake_secondary.tier_type = "pinning"
+
+    def fake_create_secondary_tier(
+        tier_config, primary_kv_view, offloading_spec, primary_pinning=None
+    ):
+        factory_captured["tier_config"] = tier_config
+        factory_captured["primary_kv_view"] = primary_kv_view
+        factory_captured["offloading_spec"] = offloading_spec
+        factory_captured["primary_pinning"] = primary_pinning
+        return fake_secondary
+
+    monkeypatch.setattr(spec_module, "SharedOffloadRegion", FakeSharedOffloadRegion)
+    monkeypatch.setattr(
+        spec_module, "CPUPrimaryTierOffloadingManager", fake_primary_ctor
+    )
+    monkeypatch.setattr(
+        spec_module.SecondaryTierFactory,
+        "create_secondary_tier",
+        fake_create_secondary_tier,
+    )
+    monkeypatch.setattr(
+        spec_module, "TieringOffloadingManager", lambda **kwargs: fake_tiering_manager
+    )
+
+    spec = TieringOffloadingSpec.__new__(TieringOffloadingSpec)
+    spec._manager = None
+    spec.vllm_config = MagicMock()
+    spec.vllm_config.instance_id = "instance"
+    spec.num_blocks = 1
+    spec.kv_bytes_per_offloaded_block = 16
+    spec.cpu_page_size_per_worker = 16
+    spec.eviction_policy = "lru"
+    spec.kv_events_config = MagicMock()
+    spec.kv_events_config.enable_kv_cache_events = False
+    spec.extra_config = {"enable_external_pinning": True}
+    spec.secondary_tier_configs = [{"type": "pinning"}]
+    spec._scheduler_mmap = None
+
+    assert spec.get_manager() is fake_tiering_manager
+    assert captured["enable_external_pinning"] is True
+    assert factory_captured["primary_pinning"] is fake_primary
 
 
 class TestExampleSecondaryTierManager:

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -170,6 +170,17 @@ class SharedOffloadRegion:
         )
         return memoryview(np_arr)
 
+    @property
+    def base_addr(self) -> int:
+        """Base address of the mmap-backed KV buffer."""
+        assert self._base is not None
+        return int(self._base.data_ptr())
+
+    @property
+    def row_stride_bytes(self) -> int:
+        """Distance in bytes between adjacent primary-tier block rows."""
+        return self._row_stride
+
     def cleanup(self) -> None:
         if self.is_pinned and self._base is not None:
             if current_platform.is_cuda_alike():

--- a/vllm/v1/kv_offload/tiering/factory.py
+++ b/vllm/v1/kv_offload/tiering/factory.py
@@ -8,6 +8,7 @@ from vllm.v1.kv_offload.tiering.base import SecondaryTierManager
 
 if TYPE_CHECKING:
     from vllm.v1.kv_offload.base import OffloadingSpec
+    from vllm.v1.kv_offload.tiering.pinning import PrimaryPinningAPI
 
 
 class SecondaryTierFactory:
@@ -30,10 +31,18 @@ class SecondaryTierFactory:
         tier_config: dict,
         primary_kv_view: memoryview,
         offloading_spec: "OffloadingSpec",
+        primary_pinning: "PrimaryPinningAPI | None" = None,
     ) -> SecondaryTierManager:
         tier_cls = cls.get_tier_class(tier_config)
         config = tier_config.copy()
         tier_type = config.pop("type")
+        if getattr(tier_cls, "requires_primary_pinning", False):
+            if primary_pinning is None:
+                raise ValueError(
+                    f"Secondary tier {tier_type!r} requires "
+                    "enable_external_pinning=True"
+                )
+            config["primary_pinning"] = primary_pinning
         return tier_cls(
             offloading_spec=offloading_spec,
             primary_kv_view=primary_kv_view,

--- a/vllm/v1/kv_offload/tiering/manager.py
+++ b/vllm/v1/kv_offload/tiering/manager.py
@@ -20,12 +20,14 @@ Key Design Principles:
    protecting blocks from eviction until complete_read() is called
 """
 
+import uuid
 from collections.abc import Collection, Iterable, Sequence
 from dataclasses import dataclass, field
 
 import numpy as np
 from typing_extensions import override
 
+from vllm.distributed import nixl_utils
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
     OffloadingConnectorStats,
 )
@@ -49,6 +51,11 @@ from vllm.v1.kv_offload.tiering.base import (
     JobId,
     JobMetadata,
     SecondaryTierManager,
+)
+from vllm.v1.kv_offload.tiering.pinning import (
+    MemDescriptor,
+    PinHandle,
+    TransportEndpoint,
 )
 
 logger = init_logger(__name__)
@@ -87,6 +94,7 @@ class CPUPrimaryTierOffloadingManager(CPUOffloadingManager):
         mmap_region: SharedOffloadRegion,
         cache_policy: str = "lru",
         enable_events: bool = False,
+        enable_external_pinning: bool = False,
     ):
         super().__init__(
             num_blocks=num_blocks,
@@ -94,6 +102,7 @@ class CPUPrimaryTierOffloadingManager(CPUOffloadingManager):
             enable_events=enable_events,
         )
         self._mmap_region = mmap_region
+        self.enable_external_pinning = enable_external_pinning
         # read/write is for CPU<->secondary transfers,
         # load/store is for CPU<->GPU transfers.
         # These aliases avoid calling prepare_load inside a store path.
@@ -103,6 +112,133 @@ class CPUPrimaryTierOffloadingManager(CPUOffloadingManager):
         self.complete_write = self.complete_store
 
         self._kv_memoryview = mmap_region.create_kv_memoryview()
+
+        if self.enable_external_pinning:
+            self._init_external_pinning()
+
+    def _init_external_pinning(self) -> None:
+        self._kv_base_addr = self._mmap_region.base_addr
+        self._kv_row_stride = self._mmap_region.row_stride_bytes
+        self._pin_handles: dict[PinHandle, tuple[OffloadKey, ...]] = {}
+        self._transport_endpoint_info = "nixl"
+        self._transport_memory_registration: object | None = None
+
+        nixl_agent_cls = nixl_utils.NixlWrapper
+        if nixl_agent_cls is None:
+            raise RuntimeError("NIXL is required for external primary-tier pinning")
+
+        config_factory = nixl_utils.nixl_agent_config
+        agent_config = (
+            config_factory(num_threads=4, capture_telemetry=True)
+            if config_factory is not None
+            else None
+        )
+        endpoint_name = str(uuid.uuid4())
+        self._transport_endpoint_name = endpoint_name
+        self._transport_agent = nixl_agent_cls(endpoint_name, agent_config)
+        try:
+            self._transport_memory_registration = self._transport_agent.register_memory(
+                [(self._kv_base_addr, self._kv_memoryview.nbytes, 0, "")],
+                mem_type="DRAM",
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                "Failed to register primary-tier memory with NIXL"
+            ) from exc
+
+    def get_transport_endpoint(self) -> TransportEndpoint:
+        if not self.enable_external_pinning:
+            raise RuntimeError("external pinning is not enabled for this primary tier")
+        return TransportEndpoint(
+            name=self._transport_endpoint_name,
+            end_point=self._transport_agent,
+            info=self._transport_endpoint_info,
+        )
+
+    def search_and_pin(
+        self,
+        keys: Collection[OffloadKey],
+    ) -> tuple[PinHandle, dict[OffloadKey, MemDescriptor]] | None:
+        # The primary tier exposes one contiguous canonical memory row per key,
+        # including layouts that differ across attention heads. If that
+        # canonical form ever becomes split, MemDescriptor can become a list.
+        if not self.enable_external_pinning:
+            raise RuntimeError("external pinning is not enabled for this primary tier")
+
+        pin_keys = tuple(keys)
+
+        blocks = []
+        for key in pin_keys:
+            block = self._policy.get(key)
+            if block is None or not block.is_ready:
+                return None
+            blocks.append(block)
+
+        descriptors: dict[OffloadKey, MemDescriptor] = {}
+        for key, block in zip(pin_keys, blocks):
+            if block.ref_cnt == 0:
+                self._policy.mark_non_evictable(key)
+                self._num_evictable_cache_blocks -= 1
+                if self._num_evictable_cache_blocks < 0:
+                    raise RuntimeError(
+                        "primary-tier evictable block count became negative"
+                    )
+            block.ref_cnt += 1
+            descriptors[key] = self._make_mem_descriptor(block.block_id)
+
+        pin_handle = uuid.uuid4().hex
+        self._pin_handles[pin_handle] = pin_keys
+        return pin_handle, descriptors
+
+    def _make_mem_descriptor(self, block_id: int) -> MemDescriptor:
+        return MemDescriptor(
+            end_point_name=self._transport_endpoint_name,
+            mem_type="DRAM",
+            addr=self._kv_base_addr + block_id * self._kv_row_stride,
+            size=self._kv_row_stride,
+            device_Id=0,
+            info="",
+        )
+
+    def unpin(self, pin_handle: PinHandle) -> bool:
+        if not self.enable_external_pinning:
+            return False
+
+        keys = self._pin_handles.get(pin_handle)
+        if keys is None:
+            return False
+
+        blocks = []
+        for key in keys:
+            block = self._policy.get(key)
+            if block is None:
+                raise RuntimeError(f"Block {key!r} not found")
+            if block.ref_cnt <= 0:
+                raise RuntimeError(f"Block {key!r} ref_cnt is already 0")
+            blocks.append((key, block))
+
+        self._pin_handles.pop(pin_handle)
+        for key, block in blocks:
+            block.ref_cnt -= 1
+            if block.ref_cnt == 0:
+                self._num_evictable_cache_blocks += 1
+                self._policy.mark_evictable(key)
+        return True
+
+    def _has_active_external_pins(self) -> bool:
+        if not self.enable_external_pinning:
+            return False
+        return bool(self._pin_handles)
+
+    def _shutdown_external_pinning(self) -> None:
+        registration = self._transport_memory_registration
+        if registration is None:
+            return
+        try:
+            self._transport_agent.deregister_memory(registration)
+        except Exception as exc:
+            logger.warning("failed to deregister primary-tier memory: %s", exc)
+        self._transport_memory_registration = None
 
     def get_kv_memoryview(self) -> memoryview:
         """Return the memoryview over the primary tier's KV cache buffer.
@@ -114,7 +250,15 @@ class CPUPrimaryTierOffloadingManager(CPUOffloadingManager):
         return self._kv_memoryview
 
     @override
+    def reset_cache(self) -> None:
+        if self._has_active_external_pins():
+            raise RuntimeError("Cannot reset cache with active external pins")
+        super().reset_cache()
+
+    @override
     def shutdown(self) -> None:
+        if self.enable_external_pinning:
+            self._shutdown_external_pinning()
         super().shutdown()
         self._kv_memoryview.release()
         self._mmap_region.cleanup()
@@ -654,6 +798,9 @@ class TieringOffloadingManager(OffloadingManager):
         retained so those requests can continue after the reset; finished
         requests are finalized and removed.
         """
+        if self.primary_tier._has_active_external_pins():
+            raise RuntimeError("Cannot reset cache with active external pins")
+
         for tier in self.secondary_tiers:
             tier.drain_jobs()
         # All tier I/O has stopped; consume their completion notifications

--- a/vllm/v1/kv_offload/tiering/pinning.py
+++ b/vllm/v1/kv_offload/tiering/pinning.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Collection
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from vllm.v1.kv_offload.base import OffloadKey
+
+PinHandle = str
+
+
+@dataclass(frozen=True)
+class TransportEndpoint:
+    """In-process transport endpoint owned by the primary tier."""
+
+    name: str
+    end_point: Any
+    info: str = ""
+
+
+@dataclass(frozen=True)
+class MemDescriptor:
+    """Transport-addressable memory span for a pinned KV block."""
+
+    end_point_name: str
+    mem_type: str
+    addr: int
+    size: int
+    device_Id: int
+    info: str
+
+
+class PrimaryPinningAPI(Protocol):
+    """Primary-tier capability shared with components that pin KV blocks."""
+
+    def get_transport_endpoint(self) -> TransportEndpoint:
+        ...
+
+    def search_and_pin(
+        self, keys: Collection[OffloadKey]
+    ) -> tuple[PinHandle, dict[OffloadKey, MemDescriptor]] | None:
+        ...
+
+    def unpin(self, pin_handle: PinHandle) -> bool:
+        ...

--- a/vllm/v1/kv_offload/tiering/spec.py
+++ b/vllm/v1/kv_offload/tiering/spec.py
@@ -11,6 +11,8 @@ Configuration via kv_connector_extra_config:
   - block_size: (optional) Block size for offloaded blocks (default: GPU block size)
   - eviction_policy: (optional) Primary tier eviction policy: "lru" or
     "arc" (default: "lru")
+  - enable_external_pinning: (optional) Expose primary-tier DRAM through
+    an in-process transfer endpoint (default: False)
   - secondary_tiers: (optional) List of secondary tier configurations
     Each secondary tier config is a dict with:
       - type: (required) Type of secondary tier (e.g., "example", "storage", "network")
@@ -137,16 +139,25 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
                 num_blocks=self.num_blocks,
                 cache_policy=self.eviction_policy,  # type: ignore[arg-type]
                 enable_events=self.kv_events_config.enable_kv_cache_events,
+                enable_external_pinning=bool(
+                    self.extra_config.get("enable_external_pinning", False)
+                ),
                 mmap_region=scheduler_mmap,
             )
 
             # Create secondary tiers
             primary_kv_view = primary_tier.get_kv_memoryview()
+            primary_pinning = (
+                primary_tier if primary_tier.enable_external_pinning else None
+            )
             secondary_tiers = []
             for i, tier_config in enumerate(self.secondary_tier_configs):
                 try:
                     tier = SecondaryTierFactory.create_secondary_tier(
-                        tier_config, primary_kv_view, self
+                        tier_config,
+                        primary_kv_view,
+                        self,
+                        primary_pinning=primary_pinning,
                     )
                     secondary_tiers.append(tier)
                     logger.info(


### PR DESCRIPTION
## Purpose

Adds an opt-in external pinning API to the `TieringOffloadingSpec` primary CPU tier so framework-owned DRAM KV blocks can be exposed safely to secondary tiers.

This adds:

- `get_transport_endpoint()` to expose the primary tier's in-process transfer endpoint
- `search_and_pin(keys)` to find ready primary-tier blocks, increment their existing `ref_cnt`, and return transport-addressable descriptors
- `unpin(pin_handle)` to release a previous pin and restore evictability when refcounts return to zero
- one-time transfer-agent registration of the full primary-tier mmap region when `enable_external_pinning=True`
- optional secondary-tier factory/spec wiring so secondary tiers can explicitly request the primary pinning API

AI assistance was used in developing this PR. The submitted changes were reviewed by the human author.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/kv_offload/tiering/test_factory.py tests/v1/kv_offload/tiering/test_tiering_offloading.py -v

## Test Result
The PR tests passed. Additional functional validation was performed outside this PR’s test suite.