### PR TITLE
[ROCm][CI] Adding extract hs 2gpu

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1953,7 +1953,8 @@ steps:
 - label: Extract Hidden States Integration # TBD
   timeout_in_minutes: 180
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  agent_pool: mi300_1
+  agent_pool: mi300_2
+  num_gpus: 2
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/config/speculative.py

--- a/tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py
+++ b/tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py
@@ -12,6 +12,7 @@ from vllm import LLM, ModelRegistry, SamplingParams
 from vllm.distributed.kv_transfer.kv_connector.v1 import (
     example_hidden_states_connector,
 )
+from vllm.platforms import current_platform
 
 
 def get_and_check_output(output, expected_shape):
@@ -296,7 +297,7 @@ def test_extract_hidden_states_qwen35_hybrid_smoke(tmp_path):
         )
 
 
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(240 if current_platform.is_rocm() else 60)
 @multi_gpu_test(num_gpus=2)
 @create_new_process_for_each_test()
 def test_extract_hidden_states_tp2():


### PR DESCRIPTION
Updates the Extract Hidden States Integration CI job to request the 2-GPU MI300 pool and declare two GPUs. The underlying TP2 extraction test already requires two GPUs, so this aligns the Buildkite agent allocation with the test requirement. The TP2 test timeout is also increased on ROCm while preserving the existing shorter timeout on other platforms. This should reduce ROCm-only timeout failures without broadening the change outside this integration path.