### PR TITLE
[ModelRunner V2][BugFix] Free all model refs on shutdown

### DIFF
--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1555,6 +1555,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if hasattr(self, "kv_cache_config"):
             del self.kv_cache_config
         free_before_shutdown(self.vllm_config)
+        if hasattr(self, "model_state"):
+            del self.model_state
+        if getattr(self, "speculator", None) is not None:
+            self.speculator = None
         if hasattr(self, "model"):
             del self.model
 


### PR DESCRIPTION
There are some remaining references to the model that aren't cleared on shutdown meaning that memory might not be released.

Fixes CI failure https://buildkite.com/vllm/ci/builds/76036/list?jid=019f2439-b7d0-4fa7-868d-c2d44c78d50e&tab=output which started after https://github.com/vllm-project/vllm/pull/44443 that made MRV2 the default for all dense models.