### PR TITLE
[Bugfix][Spec Decode] Never silently override an explicitly configured speculative method

### DIFF
--- a/tests/config/test_speculative_method_resolution.py
+++ b/tests/config/test_speculative_method_resolution.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for speculative method resolution and validation.
+
+An explicitly configured `method` must never be silently overridden by
+checkpoint auto-detection, and mismatches must fail with actionable errors.
+See https://github.com/vllm-project/vllm/issues/47486.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from transformers import PretrainedConfig
+
+from vllm.config import SpeculativeConfig
+from vllm.transformers_utils.configs.eagle import EAGLEConfig
+
+
+def _spec_cfg(
+    method,
+    model="org/some-draft",
+    model_type="qwen2",
+    architectures=("Qwen2ForCausalLM",),
+    num_speculative_tokens=3,
+):
+    cfg = SpeculativeConfig.__new__(SpeculativeConfig)
+    cfg.method = method
+    cfg.num_speculative_tokens = num_speculative_tokens
+    draft = Mock()
+    draft.model = model
+    draft.architectures = list(architectures)
+    draft.hf_config = Mock(spec=["model_type", "architectures"])
+    draft.hf_config.model_type = model_type
+    draft.hf_config.architectures = list(architectures)
+    cfg.draft_model_config = draft
+    return cfg
+
+
+class TestDetection:
+    def test_name_hint_precedes_structural_matching_legacy_order(self):
+        # Legacy detection order is name-hints-first and is load-bearing:
+        # DeepSeek EAGLE heads are structurally MTP-typed and rely on the
+        # "eagle-" name hint to route to the eagle path.
+        cfg = _spec_cfg(
+            None,
+            model="eagle618/eagle-deepseek-v3-random",
+            model_type="deepseek_mtp",
+        )
+        assert cfg._detect_draft_method() == "eagle"
+
+    def test_mtp_from_model_type(self):
+        cfg = _spec_cfg(None, model_type="gemma4_mtp")
+        assert cfg._detect_draft_method() == "mtp"
+
+    def test_eagle_from_name_hint(self):
+        cfg = _spec_cfg(None, model="yuhuili/EAGLE-LLaMA3-Instruct-8B")
+        assert cfg._detect_draft_method() == "eagle"
+
+    def test_plain_causal_lm_is_undetected(self):
+        assert _spec_cfg(None)._detect_draft_method() is None
+
+
+class TestExplicitMethodIsNeverOverridden:
+    def test_dir_name_does_not_hijack_draft_model(self):
+        # GH #47486 bug 1: a path containing "eagle-" must not reroute an
+        # explicit method="draft_model" onto the eagle path.
+        cfg = _spec_cfg("draft_model", model="/models/my-eagle-draft")
+        cfg._resolve_draft_method(method_was_explicit=True)
+        assert cfg.method == "draft_model"
+
+    def test_explicit_medusa_with_mtp_checkpoint_raises(self):
+        # GH #47486 bug 2: previously silently converted to method="mtp".
+        cfg = _spec_cfg("medusa", model_type="gemma4_mtp")
+        with pytest.raises(ValueError, match="looks like a 'mtp' checkpoint"):
+            cfg._resolve_draft_method(method_was_explicit=True)
+
+    def test_explicit_draft_model_with_mtp_checkpoint_raises(self):
+        cfg = _spec_cfg("draft_model", model_type="deepseek_mtp")
+        with pytest.raises(ValueError, match="Use method='mtp'"):
+            cfg._resolve_draft_method(method_was_explicit=True)
+
+    def test_explicit_medusa_with_plain_checkpoint_names_the_checkpoint(self):
+        # GH #47486 bug 3: previously "Unsupported speculative method:
+        # 'medusa'", blaming the (supported) method instead of the checkpoint.
+        cfg = _spec_cfg("medusa")
+        with pytest.raises(ValueError, match="not recognized as any drafter"):
+            cfg._resolve_draft_method(method_was_explicit=True)
+
+    def test_explicit_eagle_with_mtp_typed_checkpoint_is_trusted(self):
+        # DeepSeek EAGLE heads legitimately carry an MTP model_type; explicit
+        # eagle must pass through (EAGLEConfig validates the config itself,
+        # e.g. rejecting vocab_size-less non-eagle heads actionably).
+        cfg = _spec_cfg("eagle", model="/models/ds-head", model_type="deepseek_mtp")
+        cfg._resolve_draft_method(method_was_explicit=True)
+        assert cfg.method == "eagle"
+
+    def test_explicit_eagle_with_medusa_checkpoint_raises(self):
+        cfg = _spec_cfg("eagle", model_type="medusa")
+        with pytest.raises(ValueError, match="looks like a 'medusa'"):
+            cfg._resolve_draft_method(method_was_explicit=True)
+
+    def test_explicit_eagle_with_plain_checkpoint_is_trusted(self):
+        # Eagle checkpoints are often structurally undetectable; an explicit
+        # eagle method with a non-drafter-typed config must pass through
+        # (downstream registry/EAGLEConfig checks handle invalid ones).
+        cfg = _spec_cfg("eagle")
+        cfg._resolve_draft_method(method_was_explicit=True)
+        assert cfg.method == "eagle"
+
+
+class TestAutoDetectionStillWorks:
+    def test_defaulted_method_adopts_mtp(self):
+        cfg = _spec_cfg("draft_model", model_type="gemma4_mtp")
+        cfg._resolve_draft_method(method_was_explicit=False)
+        assert cfg.method == "mtp"
+
+    def test_defaulted_method_adopts_eagle_name_hint(self):
+        cfg = _spec_cfg("draft_model", model="yuhuili/EAGLE-LLaMA3-Instruct-8B")
+        cfg._resolve_draft_method(method_was_explicit=False)
+        assert cfg.method == "eagle"
+
+    def test_defaulted_method_keeps_draft_model_for_plain_lm(self):
+        cfg = _spec_cfg("draft_model")
+        cfg._resolve_draft_method(method_was_explicit=False)
+        assert cfg.method == "draft_model"
+
+
+class TestEagleConfigGuard:
+    def test_missing_vocab_size_raises_actionable_error(self):
+        # GH #47486 bug 4: previously a raw AttributeError.
+        model = Mock(spec=["architectures", "model_type"])
+        model.architectures = ["Gemma4AssistantForCausalLM"]
+        model.model_type = "gemma4_assistant"
+        with pytest.raises(ValueError, match="vocab_size"):
+            EAGLEConfig(model=model, method="eagle")
+
+    def test_vocab_size_present_is_accepted(self):
+        model = PretrainedConfig(vocab_size=32000, architectures=["LlamaForCausalLM"])
+        cfg = EAGLEConfig(model=model, method="eagle")
+        assert cfg.truncated_vocab_size == 32000

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -636,6 +636,11 @@ class SpeculativeConfig:
         # default.
 
         # infer method from user args
+        # Record whether the user explicitly configured a method, before any
+        # normalization below. Auto-detection from the draft checkpoint may
+        # only fill in a missing method, never override an explicit one.
+        method_was_explicit = self.method is not None
+
         # Check if the model field contains a custom module path (e.g., 'pkg.Mod')
         if (
             self.model is not None
@@ -786,8 +791,11 @@ class SpeculativeConfig:
                 # lack a model_type key in config.json, so AutoConfig cannot
                 # detect them. When the method is explicitly "medusa", inject
                 # model_type so MedusaConfig.from_pretrained is used instead.
-                draft_hf_overrides: HfOverrides
-                if self.method == "medusa":
+                is_legacy_medusa = (
+                    self.method == "medusa" and not self._raw_config_has_model_type()
+                )
+                draft_hf_overrides: HfOverrides = SpeculativeConfig.hf_config_override
+                if is_legacy_medusa:
                     draft_hf_overrides = {"model_type": "medusa"}
                 else:
                     # Compose any callable hf_overrides set on the target so the
@@ -826,56 +834,17 @@ class SpeculativeConfig:
                 # omit vocab_size in config.json, so MedusaConfig falls back to
                 # its default (32001). Align with the target model's vocab size
                 # to avoid shape mismatches when loading LM-head weights.
-                if self.method == "medusa":
+                if is_legacy_medusa:
                     target_vocab = self.target_model_config.hf_config.vocab_size
                     draft_hf = self.draft_model_config.hf_config
                     if draft_hf.vocab_size != target_vocab:
                         draft_hf.vocab_size = target_vocab
                         draft_hf.truncated_vocab_size = target_vocab
 
-                # Automatically detect the method
-                if self.method in ("eagle", "eagle3", "dflash", "dspark"):
-                    pass
-                # examples:
-                # yuhuili/EAGLE-LLaMA3-Instruct-8B
-                # yuhuili/EAGLE3-LLaMA3.1-Instruct-8B
-                # AngelSlim/Qwen3-8B_eagle3
-                # deepseek-ai/dspark_qwen3_8b_block7
-                elif "eagle-" in self.draft_model_config.model.lower():
-                    self.method = "eagle"
-                elif "eagle3" in self.draft_model_config.model.lower():
-                    self.method = "eagle3"
-                elif "dflash" in self.draft_model_config.model.lower():
-                    self.method = "dflash"
-                elif (
-                    "dspark" in self.draft_model_config.model.lower()
-                    or "Qwen3DSparkModel" in self.draft_model_config.architectures
-                ):
-                    self.method = "dspark"
-                elif self.draft_model_config.hf_config.model_type == "medusa":
-                    self.method = "medusa"
-                elif self.draft_model_config.hf_config.model_type == "mlp_speculator":
-                    self.method = "mlp_speculator"
-                elif self.draft_model_config.hf_config.model_type in get_args(
-                    MTPModelTypes
-                ):
-                    self.method = "mtp"
-                    if (
-                        self.num_speculative_tokens > 1
-                        and self.draft_model_config.hf_config.model_type
-                        != "step3p5_mtp"
-                    ):
-                        logger.warning(
-                            "Enabling num_speculative_tokens > 1 will run "
-                            "multiple times of forward on same MTP layer"
-                            ",which may result in lower acceptance rate"
-                        )
-                elif self.method == "draft_model":
-                    pass
-                else:
-                    raise NotImplementedError(
-                        f"Unsupported speculative method: '{self.method}'"
-                    )
+                # Resolve the speculative method: honor an explicitly
+                # configured method (validating it against the draft
+                # checkpoint), otherwise auto-detect it.
+                self._resolve_draft_method(method_was_explicit)
 
                 # Replace hf_config for EAGLE draft_model
                 if self.method in ("eagle", "eagle3", "dflash"):
@@ -1153,6 +1122,116 @@ class SpeculativeConfig:
                 return None
             return AttentionBackendEnum[value.upper()]
         return value
+
+    def _raw_config_has_model_type(self) -> bool:
+        """Whether the draft checkpoint's raw config.json declares a
+        ``model_type``.
+
+        Old-format Medusa checkpoints (e.g. FasterDecoding/medusa-*) omit it,
+        and only those need the medusa ``model_type`` injection; checkpoints
+        that declare their own type must keep it so that method validation
+        can see what the checkpoint really is.
+        """
+        from transformers import PretrainedConfig
+
+        try:
+            config_dict, _ = PretrainedConfig.get_config_dict(
+                self.model,
+                revision=self.revision,
+                trust_remote_code=self.target_model_config.trust_remote_code,
+            )
+        except Exception:
+            return False
+        return "model_type" in config_dict
+
+    def _detect_draft_method(self) -> SpeculativeMethod | None:
+        """Best-effort detection of the speculative method implied by the
+        draft checkpoint, in the legacy detection order (name hints first).
+        """
+        # NOTE: this mirrors the legacy detection order exactly, with the
+        # name hints first: DeepSeek EAGLE heads are structurally MTP-typed
+        # (e.g. model_type="deepseek_mtp") and rely on the name hint to route
+        # to the eagle path.
+        model_name = self.draft_model_config.model.lower()
+        if "eagle-" in model_name:
+            return "eagle"
+        if "eagle3" in model_name:
+            return "eagle3"
+        if "dflash" in model_name:
+            return "dflash"
+        if "dspark" in model_name or "Qwen3DSparkModel" in (
+            self.draft_model_config.architectures or []
+        ):
+            return "dspark"
+        hf_config = self.draft_model_config.hf_config
+        model_type = getattr(hf_config, "model_type", None)
+        if model_type == "medusa":
+            return "medusa"
+        if model_type == "mlp_speculator":
+            return "mlp_speculator"
+        if model_type in get_args(MTPModelTypes):
+            return "mtp"
+        return None
+
+    def _method_mismatch_msg(self, detected: str | None) -> str:
+        hf_config = self.draft_model_config.hf_config
+        if detected is not None:
+            looks = f"looks like a {detected!r} checkpoint"
+            hint = f" Use method={detected!r} if that is what you intended."
+        else:
+            looks = (
+                "is not recognized as any drafter type (a plain causal LM "
+                "can be used with method='draft_model')"
+            )
+            hint = ""
+        return (
+            f"speculative_config requested method={self.method!r}, but the "
+            f"draft model {self.draft_model_config.model!r} {looks} "
+            f"(model_type={getattr(hf_config, 'model_type', None)!r}, "
+            f"architectures={getattr(hf_config, 'architectures', None)}). "
+            f"Pass a matching method or a matching draft checkpoint.{hint}"
+        )
+
+    def _resolve_draft_method(self, method_was_explicit: bool) -> None:
+        """Set or validate ``self.method`` against the draft checkpoint.
+
+        Auto-detection only applies when the user did not explicitly
+        configure a method; an explicitly configured method is validated
+        against the checkpoint and never silently overridden.
+        """
+        detected = self._detect_draft_method()
+
+        if not method_was_explicit:
+            # self.method defaulted to "draft_model"; adopt the detection.
+            if detected is not None:
+                self.method = detected
+        elif self.method in ("eagle", "eagle3", "dflash", "dspark"):
+            # Eagle-family checkpoints often cannot be detected structurally,
+            # and some legitimately carry an MTP model_type (e.g. DeepSeek
+            # EAGLE heads), so trust the explicit method; EAGLEConfig rejects
+            # incompatible configs with an actionable error. Only a
+            # structural medusa/mlp_speculator checkpoint can never work.
+            if detected in ("medusa", "mlp_speculator"):
+                raise ValueError(self._method_mismatch_msg(detected))
+        elif self.method == "draft_model":
+            # draft_model accepts any standalone causal LM, but a drafter
+            # head (medusa/mlp_speculator/mtp) cannot run standalone.
+            if detected in ("medusa", "mlp_speculator", "mtp"):
+                raise ValueError(self._method_mismatch_msg(detected))
+        elif self.method != detected:
+            # medusa / mlp_speculator / mtp were requested explicitly.
+            raise ValueError(self._method_mismatch_msg(detected))
+
+        if (
+            self.method == "mtp"
+            and self.num_speculative_tokens > 1
+            and self.draft_model_config.hf_config.model_type != "step3p5_mtp"
+        ):
+            logger.warning(
+                "Enabling num_speculative_tokens > 1 will run "
+                "multiple times of forward on same MTP layer"
+                ",which may result in lower acceptance rate"
+            )
 
     @model_validator(mode="after")
     def _verify_args(self) -> Self:

--- a/vllm/transformers_utils/configs/eagle.py
+++ b/vllm/transformers_utils/configs/eagle.py
@@ -33,6 +33,15 @@ class EAGLEConfig(PretrainedConfig):
         if self.model is None:
             self.truncated_vocab_size = None
         else:
+            if truncated_vocab_size is None and not hasattr(self.model, "vocab_size"):
+                raise ValueError(
+                    "The draft model config "
+                    f"({type(self.model).__name__}) does not define "
+                    "'vocab_size', so it does not look like an EAGLE draft "
+                    "checkpoint. If the draft model is a different drafter "
+                    "type (e.g. an MTP head), set the matching 'method' in "
+                    "speculative_config."
+                )
             self.truncated_vocab_size = (
                 self.model.vocab_size
                 if truncated_vocab_size is None


### PR DESCRIPTION
## Purpose

Fixes #47486.

`SpeculativeConfig.__post_init__` auto-detects the speculative method from the draft checkpoint, and for every method except the eagle family the detected method silently overrides an explicitly configured `method`. Path substrings participate in detection. The issue documents four failure modes, all reproduced on a clean v0.24.0 install:

1. A directory name containing `"eagle-"` hijacks an explicit `method="draft_model"` into the eagle path, ending in a confusing registry error.
2. An explicit `method="medusa"` (or `"draft_model"`) with an MTP-typed draft is silently converted to `method="mtp"`.
3. An explicit `method="medusa"` with a plain causal LM fails with `NotImplementedError: Unsupported speculative method: 'medusa'`, blaming the supported method instead of the mismatched checkpoint.
4. An explicit `method="eagle"` with a draft config lacking `vocab_size` crashes with a raw `AttributeError` inside `EAGLEConfig`.

This PR separates detection from resolution:

- Auto-detection (legacy order preserved, name hints first) applies only when the user did not set a method.
- An explicitly configured method is validated against the checkpoint; mismatches raise a `ValueError` naming both sides, e.g. `speculative_config requested method='medusa', but the draft model '...' looks like a 'mtp' checkpoint (model_type='gemma4_mtp', ...). Use method='mtp' if that is what you intended.`
- Explicit eagle-family methods remain trusted, since DeepSeek EAGLE heads legitimately carry an MTP `model_type`; only structurally medusa/mlp_speculator checkpoints are rejected there. `EAGLEConfig` now rejects draft configs without `vocab_size` with an actionable error instead of an `AttributeError`.
- The old-format Medusa `model_type` injection and vocab alignment (#41396) are preserved but gated on the raw config actually lacking a `model_type`, so typed checkpoints keep their real type for validation. The unconditional injection also crashed multimodal targets through `hf_config.vocab_size`.

**Design question for reviewers:** an explicit-method mismatch is a hard error in this PR. Configs that work today by accident (e.g. explicit `method="medusa"` with an MTP head, silently run as mtp) will now fail with a message naming the fix. If backward compatibility is preferred, this can be a `logger.warning` instead; happy to change it.

## Test Plan

New config-level unit tests (no GPU, no network):

```
pytest tests/config/test_speculative_method_resolution.py -v
```

Regression suites:

```
pytest tests/config/
pytest tests/test_config.py -k spec
pytest "tests/config/test_model_arch_config.py::test_draft_model_arch_config[eagle618/deepseek-v3-random-eagle618/eagle-deepseek-v3-random-True]"
pre-commit run --files vllm/config/speculative.py vllm/transformers_utils/configs/eagle.py tests/config/test_speculative_method_resolution.py
pre-commit run --hook-stage manual mypy-3.12 --files vllm/config/speculative.py vllm/transformers_utils/configs/eagle.py
```

End to end: the four config repros from #47486, plus old-format Medusa (`FasterDecoding/medusa-vicuna-7b-v1.3`) and auto-detect regressions (no method + MTP head resolves to mtp; no method + plain LM stays draft_model).

## Test Result

- 16/16 new unit tests pass; the DeepSeek eagle arch test (`eagle618/eagle-deepseek-v3-random`) passes.
- `tests/config/`: failure set identical to `main` (pre-existing environment failures only: gated repos, missing ray module). Zero regressions.
- `tests/test_config.py -k spec`: 7/7.
- All four issue repros now fail with actionable `ValueError`s; the hijack case is accepted as `draft_model`; old-format Medusa resolves to `medusa`; auto-detection is unchanged.
- pre-commit: all hooks pass, including the manual mypy hook on the changed files.

---

This PR includes AI-generated code (Claude), disclosed per the contributing guidelines; commits are DCO-signed and carry `Co-authored-by` attribution. All tests above were run as described.
