### PR TITLE
[Bugfix][KV Connector]: Async KV Connectors crash if xfer completes after request finisihed

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2483,7 +2483,10 @@ class Scheduler(SchedulerInterface):
                 self._free_blocks(self.requests[req_id])
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert req_id in self.requests
+            # The request may already have been freed in an earlier step; its
+            # blocks are released, so a late finished-send is a no-op.
+            if req_id not in self.requests:
+                continue
             self._free_blocks(self.requests[req_id])
 
     def _update_requests_with_invalid_blocks(


### PR DESCRIPTION
FIX #46240

A finished/aborted request can be surfaced in both finished_recving and finished_sending in the same scheduler step. The recving branch frees it (del self.requests[req_id]); the sending branch then trips `assert req_id in self.requests`, killing EngineCore (cascades across DP ranks). 




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

