### PR TITLE
[Core] Consume SleepModeBackend capability flags in the worker suspend/resume path

### DIFF
--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -5,9 +5,13 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+import torch
 
+import vllm.v1.worker.gpu_worker as gpu_worker_module
+from vllm.config import ParallelConfig
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.v1.worker import startup_plan
+from vllm.v1.worker.gpu_worker import Worker
 from vllm.v1.worker.startup_plan import (
     maybe_apply_startup_plan,
     maybe_save_startup_plan,
@@ -77,3 +81,95 @@ def test_startup_plan_apply_gate(plan_env):
     explicit = _plan_worker(kv_bytes=7 * GiB_bytes)
     maybe_apply_startup_plan(explicit)
     assert explicit.cache_config.kv_cache_memory_bytes == 7 * GiB_bytes
+
+
+# Suspend/resume: Worker.sleep refuses the configurations #46877's
+# communicator checkpoint hooks cannot cover (they own the lifecycle itself).
+
+
+class _StubSleepBackend:
+    """Flag defaults mirror the SleepModeBackend ABC (both False)."""
+
+    def __init__(self, events, comms=False, graphs=False):
+        self.events = events
+        self.preserves_communicators = lambda: comms
+        self.preserves_graphs_with_communicators = lambda: graphs
+
+    def suspend(self, level=1):
+        self.events.append("suspend")
+
+    def resume(self, tags=None):
+        self.events.append("resume")
+
+
+def _sleep_worker(backend, parallel_config=None):
+    worker = object.__new__(Worker)
+    worker._sleep_mode_backend = backend
+    worker._sleep_saved_buffers = {}
+    worker._sleep_rebuild_draft_metadata_buffers = False
+    worker.parallel_config = parallel_config or ParallelConfig()
+    worker.model_runner = SimpleNamespace(
+        model=SimpleNamespace(named_buffers=lambda: [("b", torch.zeros(1))]),
+        post_kv_cache_wake_up=lambda: None,
+    )
+    return worker
+
+
+@pytest.fixture
+def sleep_events(monkeypatch):
+    accel = gpu_worker_module.torch.accelerator
+    monkeypatch.setattr(accel, "synchronize", lambda: None)
+    monkeypatch.setattr(accel, "get_memory_info", lambda: (0, 0))
+    return []
+
+
+@pytest.mark.parametrize(
+    "parallel_config",
+    [ParallelConfig(tensor_parallel_size=2), ParallelConfig(data_parallel_size=2)],
+)
+def test_sleep_refuses_multi_process_without_communicator_support(
+    sleep_events, parallel_config
+):
+    # Level 2 with a named buffer: a raise after the bookkeeping would save it.
+    worker = _sleep_worker(_StubSleepBackend(sleep_events), parallel_config)
+    with pytest.raises(NotImplementedError, match="world_size_across_dp"):
+        worker.sleep(level=2)
+    assert sleep_events == []
+    assert worker._sleep_saved_buffers == {}
+
+
+def test_sleep_allows_single_process_without_communicator_support(sleep_events):
+    # world_size 1 has no device communicator to lose, so nothing to refuse.
+    _sleep_worker(_StubSleepBackend(sleep_events)).sleep(level=1)
+    assert sleep_events == ["suspend"]
+
+
+def test_sleep_allows_multi_process_when_communicators_are_preserved(sleep_events):
+    worker = _sleep_worker(
+        _StubSleepBackend(sleep_events, comms=True),
+        ParallelConfig(tensor_parallel_size=2),
+    )
+    worker.sleep(level=1)
+    assert sleep_events == ["suspend"]
+
+
+def test_full_checkpoint_lifecycle_calls_each_hook_once(sleep_events, monkeypatch):
+    """#46877 owns the checkpoint hooks; sleep/wake must not call them too.
+
+    Regression: an earlier revision called checkpoint_prepare_distributed_state
+    from sleep() while Worker.checkpoint_prepare already did, so the documented
+    orchestration produced prepare, prepare, suspend.
+    """
+    for name, label in [
+        ("checkpoint_prepare_distributed_state", "prepare"),
+        ("checkpoint_restore_distributed_state", "restore"),
+    ]:
+        monkeypatch.setattr(
+            gpu_worker_module, name, lambda label=label: sleep_events.append(label)
+        )
+    worker = _sleep_worker(_StubSleepBackend(sleep_events))
+    worker.checkpoint_prepare()
+    worker.sleep(level=1)
+    worker.wake_up()
+    worker.checkpoint_restore()
+    assert sleep_events == ["prepare", "suspend", "resume", "restore"]

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -190,6 +190,23 @@ class Worker(WorkerBase):
         return self._sleep_mode_backend
 
     def sleep(self, level: int = 1) -> None:
+        backend = self._get_sleep_mode_backend()
+        if (
+            not backend.preserves_communicators()
+            and self.parallel_config.world_size_across_dp > 1
+        ):
+            # Fail loudly before any state is destroyed. #46877 owns the
+            # checkpoint lifecycle itself; this only refuses the case it
+            # cannot cover, since the communicator hooks remain no-ops for
+            # NCCL pending an NCCLCheckpoint shim (RFC #34303).
+            raise NotImplementedError(
+                "This sleep-mode backend does not preserve communicators, "
+                "and multi-process suspend (world_size_across_dp="
+                f"{self.parallel_config.world_size_across_dp}) needs "
+                "checkpoint support in the comms library, which is still a "
+                "no-op for NCCL (RFC #34303)."
+            )
+
         torch.accelerator.synchronize()
         free_bytes_before_sleep = torch.accelerator.get_memory_info()[0]
 
@@ -205,7 +222,7 @@ class Worker(WorkerBase):
                 inner, "_build_fused_kv_buffers"
             )
 
-        self._get_sleep_mode_backend().suspend(level)
+        backend.suspend(level)
 
         torch.accelerator.synchronize()
         deadline = time.monotonic() + (5.0 if current_platform.is_rocm() else 0)


### PR DESCRIPTION
## Purpose

#44074 (merged) added the pluggable `SleepModeBackend` with four capability flags: `preserves_communicators`, `preserves_graphs_with_communicators`, `preserves_compiled_artifacts`, and `supports_durable_storage`. Nothing in the tree reads them. `Worker.sleep` still assumes the cumem world, where communicators survive a suspend untouched. The `preserves_communicators` docstring says "the executor must re-initialize them on resume". Nothing does.

RFC #34303 phases in checkpoint-style backends that break that assumption. The lineage is cuda-checkpoint and CRIU, in @elizabetht's #37921 and #37925. Restore of a multi-GPU vLLM server is unreliable across drivers today. NVIDIA/cuda-checkpoint#27 (open) reports TP=2 failing while 1 and 4 GPUs work. Later comments in that thread report driver-590 segfaults on 4xA100, TP=2 failing on 595.58.03, and a 2xH800 case. cuda-checkpoint also hangs on multi-process NCCL jobs, in NVIDIA/cuda-checkpoint#45 and #30.

## Non-duplication

#46877 (@galletas1712, merged 2026-07-26) owns the mechanism. It adds the communicator-owned `checkpoint_prepare` and `checkpoint_restore` hooks in `device_communicators`. It adds the `_groups` registry traversal. It adds the `checkpoint_prepare_distributed_state` and `checkpoint_restore_distributed_state` entry points on `Worker` and `AsyncLLM`.

This PR reimplements none of that. It adds the one thing the lifecycle cannot express: a refusal, before the suspend destroys any state, for the configuration those hooks do not cover. An earlier revision of this PR carried its own sequencing layer and also called the entry points from `sleep`. Both are gone.

## What this adds

One guard in `Worker.sleep`, before any state is destroyed. If the selected backend reports `preserves_communicators() == False` and `world_size_across_dp > 1`, the worker raises instead of suspending.

@galletas1712's note on #46877 states that the communicator hooks remain no-ops for NCCL communicators until an `NCCLCheckpoint` shim exists. Without the guard, a multi-process suspend under such a backend walks cleanly and leaves NCCL state live underneath.

The guard reads `world_size_across_dp` rather than `world_size`, because a TP=1 and DP>1 deployment is still multi-process. A single-process deployment is deliberately not refused. `GroupCoordinator` builds a device communicator only when `world_size > 1`, so a single process holds nothing for a checkpoint to lose.

The flag is a classmethod. The worker can read it before it tears anything down, so the refusal happens before the suspend rather than after a failed resume. No path exists where a backend suspends and then cannot wake.

## Behavior

Existing users see no change. The default cumem backend reports `preserves_communicators() == True`, so the refusal is unreachable on current configurations.

## Test Plan

`python -m pytest tests/v1/worker/test_gpu_worker.py -q`, folded into the existing file.

The refusal fires for TP>1 and for DP-only multi-process. Both cases call `sleep(level=2)` with a named model buffer, so a raise that arrived after the bookkeeping would trip the saved-buffer assertion. The refusal does not fire for a single-process deployment, or for a backend that preserves communicators. One test drives the full documented sequence, `checkpoint_prepare` then `sleep` then `wake_up` then `checkpoint_restore`, and asserts each hook runs exactly once.

## Test Result

`7 passed, 14 warnings in 0.66s`. That is 2 pre-existing startup-plan tests and 5 new cases. `ruff check` and `ruff format --check` pass on both touched files. No GPU behavior changes, so there is nothing to evaluate: every new branch is unreachable under the default backend.

## Open questions for reviewers

1. This PR deliberately does not read `preserves_graphs_with_communicators`. An earlier revision refused single-process sleep on that flag, which is a false positive. A single-process deployment holds no device communicator, so no captured graph can hold a stale one. Where should that flag be enforced instead? Graph validity is workload-dependent, so should the flag become instance-aware or capture-aware?
2. The guard is deliberately coarse. It reads configuration rather than inspecting the communicators in play, and it refuses every non-preserving multi-process backend until NCCL restore exists. It is a temporary floor, not a complete multi-process suspend and resume. If the refusal belongs on the shim side once `NCCLCheckpoint` lands, it deletes cleanly. I asked this on the review thread here.
3. An earlier revision also called `checkpoint_prepare_distributed_state` from `sleep`. `Worker.checkpoint_prepare` already calls it. Under the sequence #46877 describes, that produced prepare, prepare, suspend. I removed it. #46877 owns the lifecycle. This PR owns only the refusal, and the new lifecycle test locks that boundary.
4. Once discard and recapture of CUDA graphs exists, where should it live? One option is the worker, as a subset of `compile_or_warm_up_model`. Another is a reset API on the graph-capture manager.
