### PR TITLE
[Bugfix][Tool Parser] deepseek_v3: accept optional newline before JSON arguments

### DIFF
--- a/tests/tool_parsers/test_deepseekv3_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv3_tool_parser.py
@@ -2,13 +2,23 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import json
+
 import pytest
 
 from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
+from tests.tool_parsers.utils import run_tool_extraction
 from vllm.tokenizers import TokenizerLike, get_tokenizer
+
+NO_NEWLINE_TOOL_CALL_OUTPUT = (
+    "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function"
+    "<｜tool▁sep｜>get_weather```json\n"
+    '{"city": "Tokyo", "unit": "celsius"}\n'
+    "```<｜tool▁call▁end｜><｜tool▁calls▁end｜>"
+)
 
 
 class TestDeepSeekV3ToolParser(ToolParserTests):
@@ -90,3 +100,29 @@ class TestDeepSeekV3ToolParser(ToolParserTests):
                 ),
             },
         )
+
+    def test_no_newline_before_json_nonstreaming(self, tool_parser):
+        content, tool_calls = run_tool_extraction(
+            tool_parser, NO_NEWLINE_TOOL_CALL_OUTPUT, streaming=False
+        )
+
+        assert content is None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "get_weather"
+        assert json.loads(tool_calls[0].function.arguments) == {
+            "city": "Tokyo",
+            "unit": "celsius",
+        }
+
+    def test_no_newline_before_json_streaming(self, tool_parser):
+        content, tool_calls = run_tool_extraction(
+            tool_parser, NO_NEWLINE_TOOL_CALL_OUTPUT, streaming=True
+        )
+
+        assert content is None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "get_weather"
+        assert json.loads(tool_calls[0].function.arguments) == {
+            "city": "Tokyo",
+            "unit": "celsius",
+        }

--- a/vllm/tool_parsers/deepseekv3_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv3_tool_parser.py
@@ -47,15 +47,15 @@ class DeepSeekV3ToolParser(ToolParser):
         self.tool_call_end_token: str = "<｜tool▁call▁end｜>"
 
         self.tool_call_regex = re.compile(
-            r"<｜tool▁call▁begin｜>(?P<type>.*)<｜tool▁sep｜>(?P<function_name>.*)\n```json\n(?P<function_arguments>.*)\n```<｜tool▁call▁end｜>"
+            r"<｜tool▁call▁begin｜>(?P<type>.*)<｜tool▁sep｜>(?P<function_name>.*)\n?```json\n(?P<function_arguments>.*)\n```<｜tool▁call▁end｜>"
         )
 
         self.stream_tool_call_portion_regex = re.compile(
-            r"(?P<type>.*)<｜tool▁sep｜>(?P<function_name>.*)\n```json\n(?P<function_arguments>.*[^\n`])"
+            r"(?P<type>.*)<｜tool▁sep｜>(?P<function_name>.*)\n?```json\n(?P<function_arguments>.*[^\n`])"
         )
 
         self.stream_tool_call_name_regex = re.compile(
-            r"(?P<type>.*)<｜tool▁sep｜>(?P<function_name>.*)\n"
+            r"(?P<type>.*)<｜tool▁sep｜>(?P<function_name>.*?)(?:\n|```json)"
         )
 
         if not self.model_tokenizer:


### PR DESCRIPTION

## Purpose

This PR follows the compatibility pattern from PR #47311 , and makes deepseek_v3  parser to accept both the existing newline-separated form and the form where the JSON fence immediately follows the function name.
 
Now, DeepSeek-V3 tool parser only accepted this format:

```
  function_name
  ```json
  arguments
```

That means parser required newline between function name and ```json.

Occasionlly,  model may also emit valid-looking output like this, with no newline:

  ```text
  <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather```json
  {"city": "Tokyo", "unit": "celsius"}
  ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
  ```

  Important part:

```
  get_weather```json
```

There is no \n between get_weather and ```json.

This fix makes parser accept both forms incase that vLLM did not convert model output into OpenAI-compatible tool_calls :

```
  get_weather
  ```json
```
  and:

```
  get_weather```json
```



## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
