### PR TITLE
fix: reject routed experts capture for dense models

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,7 @@ import vllm.envs as envs
 from vllm.compilation.backends import VllmBackend
 from vllm.config import (
     CompilationConfig,
+    DeviceConfig,
     KernelConfig,
     ModelConfig,
     ParallelConfig,
@@ -329,6 +330,28 @@ def test_async_scheduling_with_pipeline_parallelism_is_allowed():
         ),
     )
     assert cfg.scheduler_config.async_scheduling is True
+
+
+def _make_config_for_return_routed_experts(is_moe: bool) -> VllmConfig:
+    cfg = VllmConfig(device_config=DeviceConfig(device="cpu"))
+    cfg.model_config = SimpleNamespace(
+        enable_return_routed_experts=True,
+        is_moe=is_moe,
+    )
+    return cfg
+
+
+def test_return_routed_experts_requires_moe_model():
+    cfg = _make_config_for_return_routed_experts(is_moe=False)
+
+    with pytest.raises(ValueError, match="only supported for MoE models"):
+        cfg._verify_return_routed_experts()
+
+
+def test_return_routed_experts_allows_moe_model():
+    cfg = _make_config_for_return_routed_experts(is_moe=True)
+
+    cfg._verify_return_routed_experts()
 
 
 @dataclass

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -864,6 +864,38 @@ class VllmConfig:
             "expandable_segments is automatically disabled)."
         )
 
+    def _verify_return_routed_experts(self) -> None:
+        if (
+            self.model_config is None
+            or not self.model_config.enable_return_routed_experts
+        ):
+            return
+
+        if not self.model_config.is_moe:
+            raise ValueError(
+                "--enable-return-routed-experts is only supported for MoE models."
+            )
+
+        if self.parallel_config.pipeline_parallel_size > 1:
+            raise ValueError(
+                "--enable-return-routed-experts is incompatible with "
+                "pipeline parallelism (PP > 1)."
+            )
+
+        # Incompatible with any KV connector — covers both PD disaggregation
+        # (kv_producer/kv_consumer: routing captured on P can't reach D) and
+        # single-instance KV offload/sharing (kv_both: slot_mapping semantics
+        # change when KV blocks live outside local GPU memory, breaking the
+        # slot-indexed routed_experts buffer).
+        if (
+            self.kv_transfer_config is not None
+            and self.kv_transfer_config.is_kv_transfer_instance
+        ):
+            raise ValueError(
+                "--enable-return-routed-experts is incompatible with KV "
+                "connectors (PD disaggregation, KV cache offload)."
+            )
+
     def __post_init__(self):
         """Verify configs are valid & consistent with each other."""
 
@@ -881,29 +913,7 @@ class VllmConfig:
 
             self.parallel_config.is_moe_model = self.model_config.is_moe
 
-        if (
-            self.model_config is not None
-            and self.model_config.enable_return_routed_experts
-        ):
-            if self.parallel_config.pipeline_parallel_size > 1:
-                raise ValueError(
-                    "--enable-return-routed-experts is incompatible with "
-                    "pipeline parallelism (PP > 1)."
-                )
-
-            # Incompatible with any KV connector — covers both PD disaggregation
-            # (kv_producer/kv_consumer: routing captured on P can't reach D) and
-            # single-instance KV offload/sharing (kv_both: slot_mapping semantics
-            # change when KV blocks live outside local GPU memory, breaking the
-            # slot-indexed routed_experts buffer).
-            if (
-                self.kv_transfer_config is not None
-                and self.kv_transfer_config.is_kv_transfer_instance
-            ):
-                raise ValueError(
-                    "--enable-return-routed-experts is incompatible with KV "
-                    "connectors (PD disaggregation, KV cache offload)."
-                )
+        self._verify_return_routed_experts()
 
         if self.lora_config is not None:
             self.lora_config.verify_with_model_config(self.model_config)


### PR DESCRIPTION
Fixes #42593.

  ### Purpose

  `--enable-return-routed-experts` is only valid for MoE models. On dense models, vLLM previously accepted the flag and failed later during routed experts capturer initialization
  with an internal `AttributeError` after model loading and KV cache setup.

  ### What changed

  - Added an early config validation check that rejects `--enable-return-routed-experts` when the selected model is not a MoE model.
  - Kept the existing pipeline-parallelism and KV connector incompatibility checks in the same validation path.
  - Added focused config tests for dense-model rejection and MoE-model acceptance.

  ### Why this is not duplicating an existing PR

  I checked the issue comments and searched open PRs for `#42593`, `enable-return-routed-experts`, `routed experts`, `non-MoE`, and `num_experts_per_tok`. There is no open PR
  covering this dense/non-MoE validation fix. Related open routed-experts PRs cover different areas such as PP capture, backend fallback, stats APIs, and KV connector behavior.

  ### Tests run

  - `python -m py_compile vllm/config/vllm.py tests/test_config.py`
  - `git diff --check`
  - `pytest -q tests/test_config.py::test_return_routed_experts_requires_moe_model tests/test_config.py::test_return_routed_experts_allows_moe_model`

  Result: focused pytest passed with `2 passed`.

  ### AI assistance disclosure

  This PR was prepared with OpenAI Codex assistance. I reviewed the changed lines and test results.