### PR TITLE
[Bugfix] Gemma-4 k_eq_v x compressed-tensors: propagate shard aliases

### DIFF
--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -3,6 +3,7 @@
 
 import inspect
 from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any
 
 import regex as re
@@ -240,6 +241,17 @@ class QuantizationConfig(ABC):
         # TODO (@kylesayrs): add implementations for all subclasses
         pass
 
+    def apply_checkpoint_shard_aliases(  # noqa: B027
+        self, aliases: dict[str, list[str]]
+    ):
+        """Extend ignore/target storage so entries naming a checkpoint shard
+        also cover its runtime clones.
+
+        Called before `apply_vllm_mapper`; aliases are in HF checkpoint name
+        space. Subclasses override to touch their own storage.
+        """
+        pass
+
     def maybe_update_config(  # noqa: B027
         self,
         model_name: str,
@@ -274,3 +286,25 @@ class QuantizationConfig(ABC):
             True if this config uses MXFP4 quantization, False otherwise
         """
         return False
+
+
+def extend_with_shard_aliases(
+    storage: list[str],
+    aliases: dict[str, list[str]],
+    matcher: Callable[[str, Iterable[str]], bool],
+) -> None:
+    """Append alias clones to `storage` for every alias src it already matches.
+
+    Shared by QuantizationConfig subclasses whose ignore lists differ only in
+    backing location. `matcher(src, storage)` returns True iff `storage` has an
+    entry equal to or regex-matching `src`.
+    """
+    additions: list[str] = []
+    for src, dsts in aliases.items():
+        if not matcher(src, storage):
+            continue
+        for dst in dsts:
+            if dst not in storage and dst not in additions:
+                additions.append(dst)
+    if additions:
+        storage.extend(additions)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -29,6 +29,7 @@ from vllm.model_executor.layers.quantization import QuantizationMethods
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
+    extend_with_shard_aliases,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_embedding import (  # noqa: E501
     CompressedTensorsEmbeddingWNA16Int,
@@ -54,6 +55,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.transform.linear
     get_linear_transform_schemes,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
+    check_equal_or_regex_match,
     find_matched_target,
     is_activation_quantization_format,
     should_ignore_layer,
@@ -146,6 +148,9 @@ class CompressedTensorsConfig(QuantizationConfig):
         self.ignore = _apply_list(self.ignore)
         if self.kv_cache_scheme is not None:
             self.kv_cache_scheme = _apply_dict(self.kv_cache_scheme)
+
+    def apply_checkpoint_shard_aliases(self, aliases: dict[str, list[str]]) -> None:
+        extend_with_shard_aliases(self.ignore, aliases, check_equal_or_regex_match)
 
     def get_quant_method(
         self,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -9,6 +9,7 @@ from compressed_tensors import CompressionFormat
 from compressed_tensors.quantization import QuantizationStrategy
 from torch.nn import Module
 
+from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8Static128BlockSym,
     kFp8StaticChannelSym,
@@ -19,6 +20,8 @@ from vllm.model_executor.parameter import (
     ChannelQuantScaleParameter,
     PerTensorScaleParameter,
 )
+
+logger = init_logger(__name__)
 
 # Maps quantization strategy to the corresponding scale parameter type.
 # Shared across compressed-tensor scheme classes (w8a16_fp8, w8a8_fp8, …).
@@ -73,23 +76,28 @@ def should_ignore_layer(
         ]
 
         # Layer should be ignored if shards are ignored.
-        should_ignore_layer = None
-        for shard_name in shard_names:
-            should_ignore_shard = check_equal_or_regex_match(
-                layer_name=shard_name, targets=ignore
+        shard_ignore_flags = [
+            check_equal_or_regex_match(layer_name=shard_name, targets=ignore)
+            for shard_name in shard_names
+        ]
+
+        if any(shard_ignore_flags) and not all(shard_ignore_flags):
+            # Fused layer can't mix schemes across shards; treat as ignored.
+            missing = tuple(
+                name
+                for name, flag in zip(shard_proj_names, shard_ignore_flags)
+                if not flag
             )
-
-            # If shard_idx=0, set layer ignore to match shard.
-            if should_ignore_layer is None:
-                should_ignore_layer = should_ignore_shard
-
-            # If shard_idx=1+ confirm scheme matches prior shards.
-            elif should_ignore_shard != should_ignore_layer:
-                raise ValueError(
-                    f"Found a different quantization schemes for "
-                    f"{shard_proj_names} in {layer_name}. vLLM "
-                    "requires all to use the same scheme."
-                )
+            logger.warning_once(
+                "Fused layer %s has mixed ignore state across shards %s "
+                "(%s not in ignore); treating as ignored.",
+                layer_name,
+                tuple(shard_proj_names),
+                missing,
+            )
+            should_ignore_layer = True
+        else:
+            should_ignore_layer = shard_ignore_flags[0] if shard_ignore_flags else False
 
     # Unfused layers like down_proj and o_proj will match
     # the safetensors checkpoint already.

--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -9,7 +9,6 @@ from compressed_tensors import CompressionFormat
 from compressed_tensors.quantization import QuantizationStrategy
 from torch.nn import Module
 
-from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8Static128BlockSym,
     kFp8StaticChannelSym,
@@ -20,8 +19,6 @@ from vllm.model_executor.parameter import (
     ChannelQuantScaleParameter,
     PerTensorScaleParameter,
 )
-
-logger = init_logger(__name__)
 
 # Maps quantization strategy to the corresponding scale parameter type.
 # Shared across compressed-tensor scheme classes (w8a16_fp8, w8a8_fp8, …).
@@ -82,22 +79,20 @@ def should_ignore_layer(
         ]
 
         if any(shard_ignore_flags) and not all(shard_ignore_flags):
-            # Fused layer can't mix schemes across shards; treat as ignored.
-            missing = tuple(
+            missing = [
                 name
                 for name, flag in zip(shard_proj_names, shard_ignore_flags)
                 if not flag
+            ]
+            raise ValueError(
+                f"Fused layer {layer_name}: shards "
+                f"{list(shard_proj_names)} have mixed ignore state "
+                f"({missing} not in `ignore`). Add the missing shard(s) to "
+                f"`ignore` if the recipe intended to skip the whole fused "
+                f"layer, or (for models with structural weight sharing "
+                f"between shards) implement `get_checkpoint_shard_aliases`."
             )
-            logger.warning_once(
-                "Fused layer %s has mixed ignore state across shards %s "
-                "(%s not in ignore); treating as ignored.",
-                layer_name,
-                tuple(shard_proj_names),
-                missing,
-            )
-            should_ignore_layer = True
-        else:
-            should_ignore_layer = shard_ignore_flags[0] if shard_ignore_flags else False
+        should_ignore_layer = shard_ignore_flags[0] if shard_ignore_flags else False
 
     # Unfused layers like down_proj and o_proj will match
     # the safetensors checkpoint already.

--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -19,6 +19,7 @@ from vllm.model_executor.layers.quantization import QuantizationMethods
 from vllm.model_executor.layers.quantization.base_config import (  # noqa: E501
     QuantizationConfig,
     QuantizeMethodBase,
+    extend_with_shard_aliases,
 )
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
 from vllm.model_executor.layers.quantization.quark.quark_moe import (  # noqa: E501
@@ -33,6 +34,7 @@ from vllm.model_executor.layers.quantization.quark.schemes import (
     QuarkW8A8Int8,
 )
 from vllm.model_executor.layers.quantization.quark.utils import (
+    check_equal_or_regex_match,
     deep_compare,
     should_ignore_layer,
 )
@@ -139,6 +141,11 @@ class QuarkConfig(QuantizationConfig):
                     quant_config_with_hf_to_vllm_mapper[k] = v
 
         self.quant_config = quant_config_with_hf_to_vllm_mapper
+
+    def apply_checkpoint_shard_aliases(self, aliases: dict[str, list[str]]) -> None:
+        exclude = self.quant_config.get("exclude") or []
+        self.quant_config["exclude"] = exclude
+        extend_with_shard_aliases(exclude, aliases, check_equal_or_regex_match)
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str

--- a/vllm/model_executor/layers/quantization/quark/utils.py
+++ b/vllm/model_executor/layers/quantization/quark/utils.py
@@ -8,10 +8,6 @@ from typing import Any
 import regex as re
 import torch
 
-from vllm.logger import init_logger
-
-logger = init_logger(__name__)
-
 
 def deep_compare(dict1: Any, dict2: Any) -> bool:
     if type(dict1) is not type(dict2):
@@ -59,22 +55,20 @@ def should_ignore_layer(
         ]
 
         if any(shard_ignore_flags) and not all(shard_ignore_flags):
-            # Fused layer can't mix schemes across shards; treat as ignored.
-            missing = tuple(
+            missing = [
                 name
                 for name, flag in zip(shard_proj_names, shard_ignore_flags)
                 if not flag
+            ]
+            raise ValueError(
+                f"Fused layer {layer_name}: shards "
+                f"{list(shard_proj_names)} have mixed ignore state "
+                f"({missing} not in `ignore`). Add the missing shard(s) to "
+                f"`ignore` if the recipe intended to skip the whole fused "
+                f"layer, or (for models with structural weight sharing "
+                f"between shards) implement `get_checkpoint_shard_aliases`."
             )
-            logger.warning_once(
-                "Fused layer %s has mixed ignore state across shards %s "
-                "(%s not in ignore); treating as ignored.",
-                layer_name,
-                tuple(shard_proj_names),
-                missing,
-            )
-            should_ignore_layer = True
-        else:
-            should_ignore_layer = shard_ignore_flags[0] if shard_ignore_flags else False
+        should_ignore_layer = shard_ignore_flags[0] if shard_ignore_flags else False
 
     # Unfused layers like down_proj and o_proj will match
     # the safetensors checkpoint already.

--- a/vllm/model_executor/layers/quantization/quark/utils.py
+++ b/vllm/model_executor/layers/quantization/quark/utils.py
@@ -8,6 +8,10 @@ from typing import Any
 import regex as re
 import torch
 
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
 
 def deep_compare(dict1: Any, dict2: Any) -> bool:
     if type(dict1) is not type(dict2):
@@ -49,23 +53,28 @@ def should_ignore_layer(
         ]
 
         # Layer should be ignored if shards are ignored.
-        should_ignore_layer = None
-        for shard_name in shard_names:
-            should_ignore_shard = check_equal_or_regex_match(
-                layer_name=shard_name, targets=ignore
+        shard_ignore_flags = [
+            check_equal_or_regex_match(layer_name=shard_name, targets=ignore)
+            for shard_name in shard_names
+        ]
+
+        if any(shard_ignore_flags) and not all(shard_ignore_flags):
+            # Fused layer can't mix schemes across shards; treat as ignored.
+            missing = tuple(
+                name
+                for name, flag in zip(shard_proj_names, shard_ignore_flags)
+                if not flag
             )
-
-            # If shard_idx=0, set layer ignore to match shard.
-            if should_ignore_layer is None:
-                should_ignore_layer = should_ignore_shard
-
-            # If shard_idx=1+ confirm scheme matches prior shards.
-            elif should_ignore_shard != should_ignore_layer:
-                raise ValueError(
-                    f"Found a different quantization schemes for "
-                    f"{shard_proj_names} in {layer_name}. vLLM "
-                    "requires all to use the same scheme."
-                )
+            logger.warning_once(
+                "Fused layer %s has mixed ignore state across shards %s "
+                "(%s not in ignore); treating as ignored.",
+                layer_name,
+                tuple(shard_proj_names),
+                missing,
+            )
+            should_ignore_layer = True
+        else:
+            should_ignore_layer = shard_ignore_flags[0] if shard_ignore_flags else False
 
     # Unfused layers like down_proj and o_proj will match
     # the safetensors checkpoint already.

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import torch
 from torch import nn
+from transformers import PretrainedConfig
 from typing_extensions import assert_never
 
 import vllm.envs as envs
@@ -53,7 +54,9 @@ def initialize_model(
         model_class, _ = get_model_architecture(model_config)
 
     if vllm_config.quant_config is not None:
-        configure_quant_config(vllm_config.quant_config, model_class)
+        configure_quant_config(
+            vllm_config.quant_config, model_class, model_config.hf_config
+        )
 
     signatures = inspect.signature(model_class.__init__)
     all_params = [param.name for param in signatures.parameters.values()]
@@ -282,24 +285,28 @@ class ParamMapping:
 
 
 def configure_quant_config(
-    quant_config: QuantizationConfig, model_class: type[nn.Module]
+    quant_config: QuantizationConfig,
+    model_class: type[nn.Module],
+    hf_config: PretrainedConfig,
 ):
     """
-    Pass packed_modules_mapping by reference to quant_config so that
-    quant_config can properly match fused modules
-
-    Note that model attributes are passed by reference to quant_config,
-    enabling them to be updated by model_class.__new__ (ex. chatglm, qwen)
-
-    Once the `SupportsQuant` mixin has been added to all models, this
-    function can be removed
+    Propagate model-declared checkpoint shard aliases into the quant config
+    (for `SupportsQuant` subclasses), then fall through to the legacy
+    hf_to_vllm_mapper / packed_modules_mapping compat shim for models not yet
+    migrated to `SupportsQuant`. The compat shim can be removed once every
+    model uses the mixin; the alias propagation stays.
     """
-    if not issubclass(model_class, SupportsQuant):
-        hf_to_vllm_mapper = getattr(model_class, "hf_to_vllm_mapper", None)
-        packed_mapping = getattr(model_class, "packed_modules_mapping", None)
+    if issubclass(model_class, SupportsQuant):
+        aliases = model_class.get_checkpoint_shard_aliases(hf_config)
+        if aliases:
+            quant_config.apply_checkpoint_shard_aliases(aliases)
+        return
 
-        # pass mappings by reference to quant_config
-        if hf_to_vllm_mapper is not None:
-            quant_config.apply_vllm_mapper(hf_to_vllm_mapper.get_unstacked_mapper())
-        if packed_mapping is not None:
-            quant_config.packed_modules_mapping = packed_mapping
+    hf_to_vllm_mapper = getattr(model_class, "hf_to_vllm_mapper", None)
+    packed_mapping = getattr(model_class, "packed_modules_mapping", None)
+
+    # pass mappings by reference to quant_config
+    if hf_to_vllm_mapper is not None:
+        quant_config.apply_vllm_mapper(hf_to_vllm_mapper.get_unstacked_mapper())
+    if packed_mapping is not None:
+        quant_config.packed_modules_mapping = packed_mapping

--- a/vllm/model_executor/models/diffusion_gemma.py
+++ b/vllm/model_executor/models/diffusion_gemma.py
@@ -35,7 +35,10 @@ from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
 )
-from vllm.model_executor.models.gemma4 import Gemma4Model
+from vllm.model_executor.models.gemma4 import (
+    Gemma4CheckpointAliasesMixin,
+    Gemma4Model,
+)
 from vllm.model_executor.models.gemma4_mm import (
     Gemma4DummyInputsBuilder,
     Gemma4ForConditionalGeneration,
@@ -60,7 +63,6 @@ from vllm.v1.worker.gpu.states import RequestState
 from .interfaces import (
     SupportsMultiModal,
     SupportsPP,
-    SupportsQuant,
 )
 
 logger = init_logger(__name__)
@@ -140,7 +142,7 @@ def _softcap_logits(logits: torch.Tensor, cap: float) -> torch.Tensor:
 class DiffusionGemmaForConditionalGeneration(
     nn.Module,
     SupportsMultiModal,
-    SupportsQuant,
+    Gemma4CheckpointAliasesMixin,
     SupportsPP,
 ):
     """DiffusionGemma for vLLM.

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -72,6 +72,7 @@ from .interfaces import (
     SupportsEagle3,
     SupportsLoRA,
     SupportsPP,
+    SupportsQuant,
 )
 from .utils import (
     AutoWeightsLoader,
@@ -213,6 +214,34 @@ def _get_text_config(config):
     if hasattr(config, "text_config"):
         return config.text_config
     return config
+
+
+def gemma4_checkpoint_shard_aliases(hf_config) -> dict[str, list[str]]:
+    # k_eq_v full_attention layers ship no v_proj (cloned from k at load);
+    # mirror in quant config. HF-space names.
+    text_config = _get_text_config(hf_config)
+    if not getattr(text_config, "attention_k_eq_v", False):
+        return {}
+    aliases: dict[str, list[str]] = {}
+    for idx, layer_type in enumerate(getattr(text_config, "layer_types", ())):
+        if layer_type != "full_attention":
+            continue
+        base = f"model.language_model.layers.{idx}.self_attn"
+        aliases[f"{base}.k_proj"] = [f"{base}.v_proj"]
+    return aliases
+
+
+class Gemma4CheckpointAliasesMixin(SupportsQuant):
+    """Registers Gemma-4 k_eq_v shard aliasing on the quant-config side.
+
+    Applied to every Gemma-4 wrapper (CausalLM, ConditionalGeneration,
+    DiffusionGemma) so `should_ignore_layer` sees v_proj entries for
+    layers whose checkpoints only carry k_proj.
+    """
+
+    @classmethod
+    def get_checkpoint_shard_aliases(cls, hf_config) -> dict[str, list[str]]:
+        return gemma4_checkpoint_shard_aliases(hf_config)
 
 
 class Gemma4MLP(nn.Module):
@@ -1499,7 +1528,12 @@ class Gemma4Model(nn.Module, EagleModelMixin):
 
 
 class Gemma4ForCausalLM(
-    nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts, SupportsEagle3
+    nn.Module,
+    SupportsLoRA,
+    SupportsPP,
+    Gemma4CheckpointAliasesMixin,
+    MixtureOfExperts,
+    SupportsEagle3,
 ):
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -40,7 +40,10 @@ from vllm.inputs import MultiModalDataDict
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import ReplicatedLinear
-from vllm.model_executor.models.gemma4 import Gemma4ForCausalLM
+from vllm.model_executor.models.gemma4 import (
+    Gemma4CheckpointAliasesMixin,
+    Gemma4ForCausalLM,
+)
 from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.model_executor.models.transformers.utils import recursive_replace_linear
 from vllm.multimodal import MULTIMODAL_REGISTRY
@@ -72,7 +75,6 @@ from .interfaces import (
     SupportsLoRA,
     SupportsMultiModal,
     SupportsPP,
-    SupportsQuant,
 )
 from .utils import (
     AutoWeightsLoader,
@@ -973,7 +975,7 @@ class Gemma4MultimodalEmbedder(nn.Module):
 class Gemma4ForConditionalGeneration(
     nn.Module,
     SupportsMultiModal,
-    SupportsQuant,
+    Gemma4CheckpointAliasesMixin,
     SupportsPP,
     SupportsLoRA,
     SupportsEagle3,

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -1038,6 +1038,17 @@ class SupportsQuant:
         if self.packed_modules_mapping is not None:
             self.quant_config.packed_modules_mapping.update(self.packed_modules_mapping)
 
+    @classmethod
+    def get_checkpoint_shard_aliases(cls, hf_config) -> dict[str, list[str]]:
+        """Return {checkpoint_shard: [runtime_clone_shards]} for shards
+        vLLM materializes at load time (e.g. Gemma-4 k_eq_v k->v cloning).
+
+        The framework calls this before backends consume the quant config and
+        propagates the aliases into the config's ignore/target storage.
+        Default returns {}; override in models with structural weight sharing.
+        """
+        return {}
+
 
 @runtime_checkable
 class SupportsRealtime(Protocol):


### PR DESCRIPTION
## Summary

Fixes #47473. Gemma-4's `attention_k_eq_v=True` full-attention layers have no `v_proj` in the checkpoint — vLLM clones `k_proj` into the `v_proj` slot at load time. llm-compressor writes ignore entries only for shards that exist, so partial-quantization recipes list `q_proj + k_proj` but no `v_proj`. `should_ignore_layer` sees mixed state across the fused `qkv_proj` shards and raises.

## Fix

Add optional classmethod `get_checkpoint_shard_aliases(hf_config)` on `SupportsQuant` (default `{}`) — declares which checkpoint shards have runtime clones. `configure_quant_config` calls it and extends the quant config's `ignore` storage before `apply_vllm_mapper` runs, so added entries ride the same HF→vLLM translation.

Gemma-4 registers the hook via `Gemma4CheckpointAliasesMixin`, applied to `Gemma4ForCausalLM`, `Gemma4ForConditionalGeneration`, and `DiffusionGemmaForConditionalGeneration`. `compressed_tensors` and `quark` override the base no-op `apply_checkpoint_shard_aliases` to touch their own ignore storage via a shared `extend_with_shard_aliases` helper.

Mixed-shard ignore state now means a genuine config error, so the raise stays but names both causes: add the missing shard(s) to `ignore`, or implement `get_checkpoint_shard_aliases` for structural weight sharing.

## Scope

**Out (follow-ups):** `config_groups.targets` propagation; `gemma4_mtp.py` (constructs k_eq_v attention but has no k→v cloning in `_weight_iterator`); other `QuantizationConfig` subclasses (inherit no-op base); consolidating the `should_ignore_layer` / `check_equal_or_regex_match` duplication between `compressed_tensors/utils.py` and `quark/utils.py`.

## Test plan

- [x] End-to-end reproduction on gemma-4-31B-it with a compressed-tensors config covering k_eq_v layer 5: before, `ValueError` at init; after, all 60 decoder layers construct and 58 GiB safetensors load 100%.
- [x] `pre-commit run --files <changed>` passes.

Init still fails afterwards in `determine_available_memory` with `RuntimeError: Not yet supported ScalarType 46` — torch stable-API issue in this dev build, orthogonal to this fix.

AI-assisted PR (AGENTS.md §1). I reviewed every changed line and ran the reproduction.