### PR TITLE
fix: avoid JSON constraints for native tool parsers

### DIFF
--- a/tests/tool_parsers/test_glm4_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm4_moe_tool_parser.py
@@ -11,6 +11,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionToolsParam,
     FunctionDefinition,
 )
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.tool_parsers import ToolParserManager
 from vllm.tool_parsers.glm47_moe_tool_parser import Glm47MoeModelToolParser
 
@@ -109,6 +110,48 @@ def _collect_tool_deltas(deltas: Any) -> dict[int, _CollectedToolDelta]:
 def test_glm45_uses_shared_glm47_parser():
     assert ToolParserManager.get_tool_parser("glm45") is Glm47MoeModelToolParser
     assert ToolParserManager.get_tool_parser("glm47") is Glm47MoeModelToolParser
+
+
+def test_glm_required_tool_choice_skips_generic_json_schema():
+    tools = _tools()
+    parser = _parser(tools)
+    request = ChatCompletionRequest(
+        model=MODEL,
+        messages=[],
+        tools=tools,
+        tool_choice="required",
+    )
+
+    parser.adjust_request(request)
+
+    assert request.structured_outputs is None
+    assert request.skip_special_tokens is False
+
+
+def test_glm_required_tool_choice_skips_responses_json_schema():
+    tools = [
+        {
+            "type": "function",
+            "name": "get_current_weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            },
+        }
+    ]
+    parser = _parser()
+    request = ResponsesRequest(
+        model=MODEL,
+        input=[{"role": "user", "content": "What is the weather in Beijing?"}],
+        tools=tools,
+        tool_choice="required",
+        stream=True,
+    )
+
+    parser.adjust_request(request)
+
+    assert request.text is None
+    assert request.skip_special_tokens is False
 
 
 def test_extract_tool_calls_with_glm45_newline_format():

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -11,11 +11,13 @@ from typing import Any
 from openai.types.responses import (
     ResponseFormatTextJSONSchemaConfig,
     ResponseTextConfig,
+    ToolChoiceFunction,
 )
 from openai.types.responses.function_tool import FunctionTool
 
 import vllm.envs as envs
 from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedToolChoiceParam,
     ChatCompletionRequest,
     ChatCompletionToolsParam,
 )
@@ -122,6 +124,16 @@ class ToolParser:
     ) -> ChatCompletionRequest | ResponsesRequest:
         # If there are no tools, return the request as is.
         if not request.tools:
+            return request
+
+        tool_choice = request.tool_choice
+        is_named_tool_choice = isinstance(
+            tool_choice, (ChatCompletionNamedToolChoiceParam, ToolChoiceFunction)
+        )
+        if (
+            not self.supports_required_and_named
+            and (tool_choice == "required" or is_named_tool_choice)
+        ):
             return request
 
         # Set structured output params when tool constraints are derived from


### PR DESCRIPTION
Fixes #47504.

  ## Purpose
  Fix GLM tool calling with `tool_choice="required"` so native XML/structural-tag tool parsers are not forced into the generic JSON structured-output path.

  ## What changed
  - Skip generic required/named tool-choice JSON schema injection when a tool parser declares `supports_required_and_named=False`.
  - Add GLM regression coverage for both Chat Completions and Responses required tool-choice requests.

  ## Why this is not duplicating an existing PR
  I checked the issue page and searched open PRs for `47504`, `GLM required structured_outputs ToolParser`, `supports_required_and_named required GLM`, and `tool_choice=required
  glm47`. I did not find an open PR covering this fix.

  ## Tests run and results
  - `python -m py_compile vllm/tool_parsers/abstract_tool_parser.py tests/tool_parsers/test_glm4_moe_tool_parser.py`
  - `git diff --check`
  - `python -m pytest tests/tool_parsers/test_glm4_moe_tool_parser.py tests/tool_use/test_gemma4_responses_adjust_request.py -q`

  Result: `16 passed`.

  ## AI assistance disclosure
  This PR was prepared with OpenAI Codex assistance. I reviewed the changed lines and test results.