### PR TITLE
[Spec Decode] Enable full CUDA graphs on padded DSpark

### DIFF
--- a/tests/v1/spec_decode/test_dspark_scheduler.py
+++ b/tests/v1/spec_decode/test_dspark_scheduler.py
@@ -1,0 +1,437 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only unit tests for the DSpark scheduler policy helpers.
+
+Covers the three torch-free / CPU-tensor pure functions extracted into
+``dspark/scheduler.py``: the uniform-length decision, the dynamic-SD table
+derivation, and the per-request width allocation. No GPU is touched.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.v1.worker.gpu.spec_decode.dspark.scheduler import (
+    OVERHEAD_C1_CLAMP,
+    READOUT_CADENCE,
+    DSparkScheduler,
+    allocate_widths,
+    derive_dynamic_sd_table,
+    schedule_uniform_length,
+)
+
+# --- schedule_uniform_length ------------------------------------------------
+
+
+def test_schedule_uniform_length_argmax_across_cliff():
+    # A shape-aware table with a hard cost cliff at L=4: the argmax must land
+    # just before it (L=3), not at gamma.
+    accept = [0.0, 0.7, 1.2, 1.5, 1.6, 1.65]
+    times_by_l = [[0.010], [0.011], [0.012], [0.013], [0.030], [0.031]]
+    best_l, _ = schedule_uniform_length(
+        accept, num_reqs=100, gamma=5, r_grid=[100], times_by_l=times_by_l
+    )
+    assert best_l == 3
+
+
+def test_schedule_uniform_length_per_token_overhead_flips_decision():
+    # Nearly flat GPU cost => a per-STEP overhead amortizes over deep L and pins
+    # gamma; a per-TOKEN overhead does not amortize and picks the shallow L that
+    # minimizes time-per-accepted-token. Same table, opposite decisions.
+    accept = [0.0, 1.0, 1.5, 1.8]
+    times_by_l = [[0.008], [0.010], [0.018], [0.030]]
+    kwargs = dict(
+        accept=accept, num_reqs=10, gamma=3, r_grid=[10], times_by_l=times_by_l
+    )
+
+    per_step_l, _ = schedule_uniform_length(**kwargs, overhead=(0.1, 0.0))
+    per_token_l, _ = schedule_uniform_length(**kwargs, overhead=(0.0, 1e-3))
+
+    assert per_step_l == 3  # folding overhead into c0 wrongly pins gamma
+    assert per_token_l == 1  # the correct per-token model trims
+    assert per_token_l != per_step_l
+
+
+def test_schedule_uniform_length_hysteresis():
+    # L=3 beats the incumbent L=2 by < 5%, so the default margin keeps L=2; a
+    # zero margin lets the challenger through.
+    accept = [0.0, 0.7, 1.2, 1.5, 1.6, 1.65]
+    times_by_l = [[0.010], [0.011], [0.012], [0.013], [0.030], [0.031]]
+    kwargs = dict(
+        accept=accept, num_reqs=100, gamma=5, r_grid=[100], times_by_l=times_by_l
+    )
+
+    kept, _ = schedule_uniform_length(**kwargs, current=2)  # default 0.05 margin
+    switched, _ = schedule_uniform_length(**kwargs, current=2, hysteresis=0.0)
+
+    assert kept == 2
+    assert switched == 3
+
+
+def test_schedule_uniform_length_returns_gamma_without_table():
+    accept = [0.0, 0.7, 1.2]
+    assert schedule_uniform_length(accept, 100, 2, None, None) == (2, 0.0)
+    assert schedule_uniform_length(accept, 100, 2, [], []) == (2, 0.0)
+
+
+# --- derive_dynamic_sd_table ------------------------------------------------
+
+
+def test_derive_dynamic_sd_table_ranges_and_collapse():
+    # Two small buckets both pick K=gamma (must collapse); the large bucket hits
+    # an eager cliff on every K>=1 and picks K=0.
+    r_grid = [8, 16, 256]
+    times_by_l = [
+        [0.010, 0.010, 0.010],  # K=0 baseline decode
+        [0.011, 0.011, 0.500],  # K=1 (eager on r=256)
+        [0.012, 0.012, 0.500],  # K=2
+        [0.013, 0.013, 0.500],  # K=3
+    ]
+    table = derive_dynamic_sd_table(r_grid, times_by_l, gamma=3, max_num_reqs=256)
+
+    assert table == [(1, 16, 3), (17, 256, 0)]
+
+    # Contiguous cover of 1..max_num_reqs with non-overlapping ranges.
+    assert table[0][0] == 1
+    assert table[-1][1] == 256
+    for (s0, e0, _), (s1, _, _) in zip(table, table[1:]):
+        assert s0 <= e0
+        assert s1 == e0 + 1
+    # Adjacent buckets were collapsed (no two consecutive rows share a K).
+    ks = [k for _, _, k in table]
+    assert all(a != b for a, b in zip(ks, ks[1:]))
+    # K=0 is a legal outcome.
+    assert 0 in ks
+
+
+# --- allocate_widths (CPU tensors) ------------------------------------------
+
+
+def _monotone_survivals() -> torch.Tensor:
+    # Each row non-increasing, mirroring a prefix-survival cumprod.
+    return torch.tensor(
+        [
+            [0.90, 0.80, 0.70, 0.60],
+            [0.50, 0.40, 0.30, 0.20],
+            [0.95, 0.50, 0.10, 0.05],
+        ]
+    )
+
+
+def _is_prefix(mask_row: torch.Tensor, keep: int) -> bool:
+    # Kept positions must be exactly the first `keep` entries.
+    expected = torch.arange(mask_row.numel()) < keep
+    return bool(torch.equal(mask_row, expected))
+
+
+def test_allocate_widths_budget_and_prefix_validity():
+    sv = _monotone_survivals()
+    cal_t = torch.ones(4)
+    keep = allocate_widths(sv, cal_t, num_reqs=3, length=4, tau=0.0, budget_frac=0.5)
+
+    # budget = int(3*4*0.5)+1 = 7 tokens; top-k threshold lands at 0.5.
+    assert keep.tolist() == [4, 1, 2]
+    assert int(keep.sum()) == 7  # budget respected exactly
+
+    # Monotone survivals => each kept set is a valid leading prefix.
+    th = 0.5
+    for r in range(sv.shape[0]):
+        assert _is_prefix(sv[r] >= th, int(keep[r]))
+
+
+def test_allocate_widths_full_budget_is_lossless():
+    sv = _monotone_survivals()
+    cal_t = torch.ones(4)
+    keep = allocate_widths(sv, cal_t, num_reqs=3, length=4, tau=0.0, budget_frac=1.0)
+    # budget >= number of candidates => every request keeps the full width.
+    assert keep.tolist() == [4, 4, 4]
+
+
+def test_allocate_widths_confidence_threshold():
+    sv = _monotone_survivals()
+    cal_t = torch.ones(4)
+    keep = allocate_widths(sv, cal_t, num_reqs=3, length=4, tau=0.6, budget_frac=1.0)
+    # Static tau on WIDTHS: count positions with survival >= 0.6 (a prefix).
+    assert keep.tolist() == [4, 0, 1]
+    for r in range(sv.shape[0]):
+        assert _is_prefix(sv[r] >= 0.6, int(keep[r]))
+
+
+# --- DSparkScheduler stateful core (CPU) ------------------------------------
+#
+# These drive the scheduler object itself on device="cpu". The CUDA path uses a
+# pinned host buffer + a torch.cuda.Event for its async survival readout; on CPU
+# the scheduler falls back to a pageable buffer and an always-ready readout
+# (self._is_cuda seam), so the online overhead regression, survival calibration,
+# and realized-survival accounting are exercisable without a GPU.
+
+
+def _make_scheduler(
+    gamma=3, max_num_reqs=8, tau=0.0, perreq=False, budget=1.0
+) -> DSparkScheduler:
+    spec = SimpleNamespace(
+        dspark_per_request=perreq,
+        dspark_confidence_threshold=tau,
+        dspark_budget_frac=budget,
+    )
+    return DSparkScheduler(spec, gamma, max_num_reqs, torch.device("cpu"))
+
+
+# --- begin_step online engine-overhead regression ---------------------------
+
+
+def _obs_overhead(sched, tokens, o, gpu_pred=0.005):
+    # Feed one overhead observation: with _surv_ema unset, begin_step only runs
+    # the regression, recording residual ``o`` against ``tokens``. Residual =
+    # (now - _last_t) - _last_gpu_pred, so pick now = _last_t + gpu_pred + o.
+    sched._last_t = 0.0
+    sched._last_gpu_pred = gpu_pred
+    sched._last_tokens = float(tokens)
+    sched.begin_step(gpu_pred + o, num_reqs=1)
+
+
+def test_begin_step_overhead_regression_converges():
+    sched = _make_scheduler(gamma=4)
+    c0_true, c1_true = 0.02, 3e-4
+    for i in range(40):
+        tokens = 10 + (i % 20) * 5  # 10..105, good leverage for the fit
+        _obs_overhead(sched, tokens, c0_true + c1_true * tokens)
+    # Exact linear residuals => least squares recovers (c0, c1).
+    assert sched._o_c1 == pytest.approx(c1_true, abs=2e-5)
+    assert sched._o_c0 == pytest.approx(c0_true, abs=2e-3)
+    assert 0.0 <= sched._o_c1 <= OVERHEAD_C1_CLAMP
+    assert sched._o_c0 >= 0.0
+
+
+def test_begin_step_overhead_outlier_gate():
+    sched = _make_scheduler(gamma=4)
+    for i in range(30):
+        tokens = 10 + (i % 20) * 5
+        _obs_overhead(sched, tokens, 0.02 + 3e-4 * tokens)
+    n_before = len(sched._o_samples)
+    c0_before, c1_before = sched._o_c0, sched._o_c1
+    # A residual above the 0.25s idle-gap gate is dropped: no sample, no refit.
+    _obs_overhead(sched, tokens=50, o=5.0)
+    assert len(sched._o_samples) == n_before
+    assert sched._o_c0 == c0_before
+    assert sched._o_c1 == c1_before
+
+
+def test_begin_step_overhead_c1_clamped_high():
+    sched = _make_scheduler(gamma=4)
+    # Steep slope over a small token range: residuals stay under the gate but
+    # cov/var exceeds the per-token slope clamp.
+    for i in range(30):
+        tokens = 1 + (i % 15)  # 1..15
+        _obs_overhead(sched, tokens, 0.005 + 0.01 * tokens)  # <= 0.155 < gate
+    assert sched._o_c1 == pytest.approx(OVERHEAD_C1_CLAMP)
+    assert sched._o_c0 >= 0.0
+
+
+def test_begin_step_overhead_c1_clamped_low():
+    sched = _make_scheduler(gamma=4)
+    # Anti-correlated residuals -> negative raw slope -> clamped up to 0.
+    for i in range(30):
+        tokens = 1 + (i % 15)
+        _obs_overhead(sched, tokens, 0.2 - 0.01 * tokens)  # 0.05..0.19
+    assert sched._o_c1 == 0.0
+
+
+# --- update_survival online calibration -------------------------------------
+
+
+def _drive_readout(sched, num_reqs=2):
+    # Push enough survival updates to launch (at _ema_ct == READOUT_CADENCE) and
+    # then consume one host readout of the currently-set accumulators. On CPU the
+    # readout is always ready, so CADENCE+1 calls suffice.
+    sv = torch.zeros(num_reqs, sched.gamma)
+    idx = torch.arange(num_reqs, dtype=torch.int32)
+    for _ in range(READOUT_CADENCE + 1):
+        sched.update_survival(sv, idx)
+
+
+def test_update_survival_calibration_blend():
+    sched = _make_scheduler(gamma=3)
+    sched._acc_counts = torch.tensor([80.0, 50.0, 20.0])
+    sched._obs_counts = torch.tensor([100.0, 100.0, 100.0])
+    sched._pred_counts = torch.tensor([40.0, 40.0, 40.0])
+    _drive_readout(sched)
+    # ratio = realized/predicted = [2.0, 1.25, 0.5]; cal = 0.8*1 + 0.2*ratio.
+    assert sched._cal == pytest.approx([1.2, 1.05, 0.9])
+
+
+def test_update_survival_calibration_min_obs_gate():
+    sched = _make_scheduler(gamma=3)
+    sched._acc_counts = torch.tensor([80.0, 50.0, 20.0])
+    sched._obs_counts = torch.tensor([100.0, 50.0, 100.0])  # pos1 below min-obs 64
+    sched._pred_counts = torch.tensor([40.0, 40.0, 40.0])
+    _drive_readout(sched)
+    assert sched._cal[1] == 1.0  # gated out -> unchanged
+    assert sched._cal[0] == pytest.approx(1.2)
+    assert sched._cal[2] == pytest.approx(0.9)
+
+
+def test_update_survival_calibration_ratio_clamp():
+    sched = _make_scheduler(gamma=2)
+    sched._acc_counts = torch.tensor([400.0, 2.0])  # raw ratios 10.0 and 0.05
+    sched._obs_counts = torch.tensor([100.0, 100.0])
+    sched._pred_counts = torch.tensor([40.0, 40.0])
+    _drive_readout(sched)
+    # 10.0 clamps to 4.0 -> 0.8 + 0.2*4 = 1.6; 0.05 clamps to 0.25 -> 0.85.
+    assert sched._cal[0] == pytest.approx(1.6)
+    assert sched._cal[1] == pytest.approx(0.85)
+
+
+# --- observe_verified realized-survival accounting --------------------------
+
+
+def test_observe_verified_counts_full_width_only():
+    sched = _make_scheduler(gamma=3, max_num_reqs=8)
+    sched.commit_length(3)  # _prev_sched_l > 0 so the observation runs
+    num_reqs = 4
+    idx = torch.tensor([0, 1, 2, 3], dtype=torch.int32)
+    prev_widths = torch.zeros(8, dtype=torch.int32)
+    prev_widths[:4] = torch.tensor([3, 3, 2, 3], dtype=torch.int32)
+    # Predicted prefix survival (req-state-indexed) feeding pred_counts.
+    sched._surv_state[0] = torch.tensor([0.9, 0.8, 0.7])
+    sched._surv_state[1] = torch.tensor([0.95, 0.9, 0.85])
+    sched._surv_state[2] = torch.tensor([0.6, 0.4, 0.2])
+    sched._surv_state[3] = torch.tensor([0.5, 0.5, 0.5])
+    # req0: width 3, full, accepted 2   -> observed [1,2,3], survived [1,2]
+    # req1: width 3, full, accepted 3   -> observed [1,2,3], survived [1,2,3]
+    # req2: width 2, full, accepted 1   -> observed [1,2]  (width respected)
+    # req3: width 3, SHORT (not full)   -> excluded entirely
+    num_sampled = torch.tensor([3, 4, 2, 1], dtype=torch.int32)
+    num_rejected = torch.tensor([1, 0, 1, 0], dtype=torch.int32)
+    sched.observe_verified(num_reqs, num_sampled, num_rejected, prev_widths, idx)
+
+    assert sched._obs_counts.tolist() == [3.0, 3.0, 2.0]
+    assert sched._acc_counts.tolist() == [3.0, 2.0, 1.0]
+    assert sched._pred_counts.tolist() == pytest.approx([2.45, 2.1, 1.55])
+
+
+def test_observe_verified_noop_without_prev_length():
+    sched = _make_scheduler(gamma=3, max_num_reqs=8)
+    # _prev_sched_l defaults to 0 -> observe_verified is a no-op.
+    idx = torch.tensor([0, 1], dtype=torch.int32)
+    prev_widths = torch.zeros(8, dtype=torch.int32)
+    num_sampled = torch.tensor([3, 3], dtype=torch.int32)
+    num_rejected = torch.tensor([0, 0], dtype=torch.int32)
+    sched.observe_verified(2, num_sampled, num_rejected, prev_widths, idx)
+    assert sched._acc_counts.sum().item() == 0.0
+    assert sched._obs_counts.sum().item() == 0.0
+
+
+# --- engine-side live re-derivation ------------------------------------------
+
+# Flat cost rows: T is width-independent, so throughput argmax follows
+# survival alone and longer drafts win while survival mass remains.
+_R_GRID = [1, 8, 64]
+_FLAT_T = [[10.0, 10.0, 10.0]] * 6  # L = 0..5
+
+
+def _make_rederivation(max_num_seqs=64, num_spec_tokens=5):
+    from vllm.v1.spec_decode.dynamic.utils import DSparkLiveRederivation
+
+    return DSparkLiveRederivation(_R_GRID, _FLAT_T, max_num_seqs, num_spec_tokens)
+
+
+def test_rederivation_seeds_prior_and_counters():
+    from vllm.v1.spec_decode.dynamic.utils import DEFAULT_SURVIVAL_PRIOR
+
+    red = _make_rederivation()
+    gamma = len(_FLAT_T) - 1
+    assert red._survival == list(DEFAULT_SURVIVAL_PRIOR[:gamma])
+    assert red._acc_counts == [0.0] * gamma
+    assert red._obs_counts == [0.0] * gamma
+
+
+def test_observe_acceptance_counts_positions():
+    red = _make_rederivation()
+    # 3 drafted, 2 accepted: positions 0-2 observed, 0-1 accepted.
+    assert red.observe(3, 2) is None  # below re-derive cadence
+    assert red._obs_counts == [1.0, 1.0, 1.0, 0.0, 0.0]
+    assert red._acc_counts == [1.0, 1.0, 0.0, 0.0, 0.0]
+
+
+def test_rederive_replaces_prior_with_measured_survival():
+    red = _make_rederivation()
+    # Uniform traffic: 5 drafted, 1 accepted -> position 0 survives every
+    # draft (1.0), positions 1-4 never do (0.0).
+    lookup = None
+    for _ in range(red.REDERIVE_DRAFTS):
+        lookup = red.observe(5, 1)
+    assert red._survival[0] == pytest.approx(1.0)
+    assert red._survival[1:] == pytest.approx([0.0] * 4)
+    # Lookup is rebuilt and indexable for batch sizes 0..max_num_seqs.
+    assert lookup is not None
+    assert len(lookup) >= 64
+    # Cadence counter reset; counters decayed, not cleared: drift tracking
+    # retains half the mass.
+    assert red._rederive_ct == 0
+    assert red._obs_counts[0] == pytest.approx(red.REDERIVE_DRAFTS * 0.5)
+
+
+def test_rederive_skips_positions_below_min_obs():
+    from vllm.v1.spec_decode.dynamic.utils import DEFAULT_SURVIVAL_PRIOR
+
+    red = _make_rederivation()
+    # All traffic drafts only 1 token: positions 1+ never reach the
+    # min-observation gate and must keep the prior.
+    for _ in range(red.REDERIVE_DRAFTS):
+        red.observe(1, 1)
+    assert red._survival[0] == pytest.approx(1.0)
+    assert red._survival[1:] == pytest.approx(list(DEFAULT_SURVIVAL_PRIOR[1:5]))
+
+
+# --- speculative-config dspark flag validation --------------------------------
+
+
+def _spec_config_kwargs(**overrides):
+    # No num_speculative_tokens/model: keeps __post_init__ off the draft-model
+    # resolution paths so construction reaches the trailing flag validation.
+    kwargs = dict(method="dspark")
+    kwargs.update(overrides)
+    return kwargs
+
+
+@pytest.mark.parametrize(
+    "flags,match",
+    [
+        (
+            dict(method="eagle", dspark_scheduler=True),
+            "require method='dspark'",
+        ),
+        (dict(dspark_per_request=True), "requires dspark_scheduler"),
+        (
+            dict(dspark_scheduler=True, dspark_pad_to_bucket=True),
+            "requires dspark_per_request",
+        ),
+        (
+            dict(dspark_confidence_threshold=0.5),
+            "requires dspark_scheduler",
+        ),
+        (
+            dict(dspark_scheduler=True, dspark_budget_frac=0.5),
+            "requires dspark_per_request",
+        ),
+        (
+            dict(
+                dspark_scheduler=True,
+                dspark_per_request=True,
+                dspark_budget_frac=0.0,
+            ),
+            r"in \(0, 1\]",
+        ),
+        (
+            dict(dspark_scheduler=True, dspark_confidence_threshold=1.5),
+            r"in \[0, 1\]",
+        ),
+    ],
+)
+def test_dspark_config_flag_validation(flags, match):
+    from vllm.config.speculative import SpeculativeConfig
+
+    with pytest.raises(ValueError, match=match):
+        SpeculativeConfig(**_spec_config_kwargs(**flags))

--- a/tests/v1/spec_decode/test_rejection_sampler_utils.py
+++ b/tests/v1/spec_decode/test_rejection_sampler_utils.py
@@ -412,3 +412,52 @@ def test_block_verification_accepts_at_least_as_many(num_speculative_steps: int)
         f"Block verification mean accepted length {mean_block:.4f} is worse "
         f"than standard {mean_standard:.4f}."
     )
+
+
+@pytest.mark.parametrize("temperature", [0.0, 0.6])
+def test_padded_draft_prefix_accepted(temperature: float):
+    """Padded speculation: real draft tokens up to a per-request valid length,
+    -1 pads after. Acceptance must stop at the first pad (recovery token
+    resampled there), and real prefix tokens must still be accepted normally.
+    """
+    torch.manual_seed(0)
+    device = "cuda"
+    K = 4
+    num_trials = 256
+
+    target_logits_1d = torch.randn(VOCAB_SIZE, device=device)
+    if temperature > 0:
+        target_logits_1d = target_logits_1d / temperature
+    # Draft == target so every real (non-pad) draft position is accepted:
+    # greedy accepts on argmax match; stochastic accepts since p(x) == q(x).
+    draft_logits_1d = target_logits_1d.clone()
+
+    inputs = _build_rejection_sample_inputs(
+        target_logits_1d,
+        draft_logits_1d,
+        K,
+        temperature=temperature,
+        num_trials=num_trials,
+    )
+    draft_sampled_2d = inputs["draft_sampled"].view(num_trials, K + 1)
+    if temperature == 0:
+        # Make the real drafts the target argmax so greedy accepts them.
+        draft_sampled_2d[:, 1:] = target_logits_1d.argmax()
+    # Request r keeps valid_len[r] real drafts, the rest are pads.
+    valid_len = torch.arange(num_trials, dtype=torch.int64, device=device) % (K + 1)
+    local_draft_pos = torch.arange(1, K + 1, device=device).unsqueeze(0)
+    draft_sampled_2d[:, 1:] = torch.where(
+        local_draft_pos <= valid_len.unsqueeze(1), draft_sampled_2d[:, 1:], -1
+    )
+
+    sampled, num_sampled = rejection_sample(**inputs, num_speculative_steps=K)
+
+    # Exactly the real prefix + one recovery/bonus token is sampled.
+    assert torch.equal(num_sampled.long(), valid_len + 1), (
+        f"num_sampled={num_sampled.tolist()[:12]} valid_len={valid_len.tolist()[:12]}"
+    )
+    # All sampled tokens are valid vocab ids (recovery token never reads pads).
+    for r in range(0, num_trials, 17):
+        n = int(num_sampled[r])
+        toks = sampled[r, :n]
+        assert (toks >= 0).all() and (toks < VOCAB_SIZE).all()

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -227,6 +227,43 @@ class SpeculativeConfig:
     synthetic_acceptance_rates. Only valid when rejection_sample_method is 'synthetic'.
     Mutually exclusive with synthetic_acceptance_rates."""
 
+    dspark_scheduler: bool = False
+    """Enable the DSpark hardware-aware confidence scheduler: adaptive
+    per-step verification width from the profiled cost table, online
+    engine-overhead estimate, and calibrated confidence-head survival.
+    Also captures FULL decode CUDA graphs at every verification width and,
+    when no num_speculative_tokens_per_batch_size is configured, auto-derives
+    the dynamic-SD batch-size table from the startup profile."""
+
+    dspark_per_request: bool = False
+    """DSpark: allocate per-request verification widths (paper Algorithm 1)
+    within the batch-level width budget via a global greedy over calibrated
+    prefix-survival probabilities. Requires dspark_scheduler."""
+
+    dspark_pad_to_bucket: bool = False
+    """DSpark: execute ragged per-request widths as a single uniform padded
+    forward at the scheduler-optimal width (pads route KV to the dummy slot
+    and are excluded from sampling), keeping FULL-graph execution. Requires
+    dspark_per_request."""
+
+    dspark_confidence_threshold: float = 0.0
+    """DSpark: per-request confidence threshold (0 disables). Requires
+    dspark_scheduler. This single knob drives two different mechanisms
+    depending on dspark_per_request:
+
+    - With dspark_per_request: it sets per-request VERIFICATION WIDTHS -- each
+      request keeps the prefix whose calibrated survival >= threshold.
+    - Without dspark_per_request: it masks drafts within the batch-uniform
+      width -- positions whose raw survival < threshold are force-rejected.
+
+    Primarily for acceptance-rate studies."""
+
+    dspark_budget_frac: float = 1.0
+    """DSpark: fraction of the batch verification-token budget the
+    per-request allocator may spend. 1.0 is lossless (equivalent to the
+    uniform batch width); lower values trade accepted tokens for higher
+    acceptance rates."""
+
     @staticmethod
     def _acceptance_length_to_rates(length: float, n: int) -> list[float]:
         """Mean acceptance length to unconditional per-position rates, using
@@ -572,6 +609,42 @@ class SpeculativeConfig:
 
         return hf_config
 
+    def _validate_dspark(self):
+        # Called at the end of __post_init__, once method is fully resolved.
+        if self.method != "dspark":
+            if (
+                self.dspark_scheduler
+                or self.dspark_per_request
+                or self.dspark_pad_to_bucket
+                or self.dspark_confidence_threshold != 0.0
+                or self.dspark_budget_frac != 1.0
+            ):
+                raise ValueError(
+                    f"dspark_* options require method='dspark' (got {self.method!r})."
+                )
+            return
+        if self.dspark_per_request and not self.dspark_scheduler:
+            raise ValueError("dspark_per_request requires dspark_scheduler=True.")
+        if self.dspark_pad_to_bucket and not self.dspark_per_request:
+            raise ValueError("dspark_pad_to_bucket requires dspark_per_request=True.")
+        if self.dspark_confidence_threshold > 0.0 and not self.dspark_scheduler:
+            raise ValueError(
+                "dspark_confidence_threshold requires dspark_scheduler=True."
+            )
+        if self.dspark_budget_frac < 1.0 and not self.dspark_per_request:
+            raise ValueError(
+                "dspark_budget_frac < 1.0 requires dspark_per_request=True."
+            )
+        if not 0.0 < self.dspark_budget_frac <= 1.0:
+            raise ValueError(
+                f"dspark_budget_frac must be in (0, 1], got {self.dspark_budget_frac}."
+            )
+        if not 0.0 <= self.dspark_confidence_threshold <= 1.0:
+            raise ValueError(
+                f"dspark_confidence_threshold must be in [0, 1], got "
+                f"{self.dspark_confidence_threshold}."
+            )
+
     def __post_init__(self):
         # Note: "method" is a new parameter that helps to extend the
         # configuration of non-model-based proposers, and the "model" parameter
@@ -904,6 +977,7 @@ class SpeculativeConfig:
                         self.target_parallel_config, self.draft_tensor_parallel_size
                     )
                 )
+        self._validate_dspark()
         return self
 
     def _validate_suffix_decoding(self):

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -776,6 +776,14 @@ class VllmConfig:
             or not self.compilation_config.cudagraph_mode.has_full_cudagraphs()
         ):
             return
+        if (
+            speculative_config.method == "dspark"
+            and speculative_config.dspark_scheduler
+        ):
+            # DSpark's scheduler captures FULL decode graphs at every width
+            # dynamic SD can schedule, so no downgrade is needed; without it
+            # the extra graphs are not captured and the downgrade applies.
+            return
 
         logger.warning_once(
             "Dynamic speculative decoding changes the target verification "
@@ -2062,7 +2070,13 @@ class VllmConfig:
             ):
                 unsupported.append(f"speculative method '{speculative_config.method}'")
 
-            if speculative_config.uses_dynamic_speculative_decoding():
+            # Dynamic SD on the V2 runner: the engine-side width control
+            # flows through the existing variable cu_num_logits plumbing;
+            # DSpark additionally keeps the trimmed verify graph-native.
+            if speculative_config.uses_dynamic_speculative_decoding() and not (
+                speculative_config.method == "dspark"
+                and speculative_config.dspark_scheduler
+            ):
                 unsupported.append("dynamic speculative decoding")
 
             # V2 EagleSpeculator does not support parallel_drafting (for P-Eagle).

--- a/vllm/model_executor/models/qwen3_dspark.py
+++ b/vllm/model_executor/models/qwen3_dspark.py
@@ -10,6 +10,9 @@ The parallel backbone is a standard Qwen3 decoder stack reused from the
 DFlash Qwen3 draft (see qwen3_dflash.py). DSpark adds:
   * ``markov_head``: low-rank V x r / r x V transition bias added to the base
     logits, sampled left-to-right by the speculator (the sequential stage).
+  * ``confidence_head``: per-position survival logit over
+    ``[hidden ; markov_embed(prev token)]``, used by the DSpark scheduler to
+    pick per-step draft lengths.
 
 DSparkMarkovHead is shared with the DSV4-style DSpark model.
 """
@@ -67,6 +70,22 @@ class DSparkMarkovHead(nn.Module):
         return logits_processor(self.markov_w2, markov_embed)
 
 
+class DSparkConfidenceHead(nn.Module):
+    """Per-position survival logit ``w . [h_k ; markov_embed(x_{k-1})] + b``.
+
+    Sigmoid of the output estimates the conditional probability that draft
+    position ``k`` survives target verification given all earlier block
+    tokens were accepted.
+    """
+
+    def __init__(self, hidden_size: int, markov_rank: int) -> None:
+        super().__init__()
+        self.proj = nn.Linear(hidden_size + markov_rank, 1, bias=True)
+
+    def forward(self, hidden: torch.Tensor, markov_embed: torch.Tensor) -> torch.Tensor:
+        return self.proj(torch.cat([hidden, markov_embed], dim=-1)).squeeze(-1)
+
+
 class Qwen3DSparkModel(DFlashQwen3Model):
     """DFlash Qwen3 backbone + DSpark Markov head."""
 
@@ -90,6 +109,12 @@ class Qwen3DSparkModel(DFlashQwen3Model):
             config.markov_rank,
             prefix=maybe_prefix(prefix, "markov_head"),
         )
+        if getattr(config, "enable_confidence_head", False):
+            self.confidence_head = DSparkConfidenceHead(
+                config.hidden_size, config.markov_rank
+            )
+        else:
+            self.confidence_head = None
 
 
 class Qwen3DSparkForCausalLM(DFlashQwen3ForCausalLM):
@@ -125,6 +150,10 @@ class Qwen3DSparkForCausalLM(DFlashQwen3ForCausalLM):
             )
         else:
             self.draft_id_to_target_id = None
+        if self.model.confidence_head is None:
+            # Signals to the DSpark scheduler that this checkpoint cannot
+            # provide survival estimates (load_draft_model guards on it).
+            self.compute_confidence = None
 
     def get_draft_kv_cache_layer_names(self) -> list[str]:
         return [layer.self_attn.attn.layer_name for layer in self.model.layers]
@@ -139,6 +168,11 @@ class Qwen3DSparkForCausalLM(DFlashQwen3ForCausalLM):
         if self.draft_id_to_target_id is None:
             return draft_ids
         return draft_ids + self.draft_id_to_target_id[draft_ids]
+
+    def compute_confidence(
+        self, hidden_states: torch.Tensor, markov_embed: torch.Tensor
+    ) -> torch.Tensor:
+        return self.model.confidence_head(hidden_states, markov_embed)
 
     def markov_embed(self, token_ids: torch.Tensor) -> torch.Tensor:
         return self.model.markov_head.embed(token_ids)
@@ -170,10 +204,11 @@ class Qwen3DSparkForCausalLM(DFlashQwen3ForCausalLM):
             process_eagle_weight(self, name)
 
         # mask_embedding is an unused placeholder param; DSpark masks via the vocab row.
-        # confidence_head is not wired into inference yet; skip its weights.
         # embed_tokens / lm_head are optional; when omitted they are shared from
         # the target by load_dspark_model, so skip the unloaded params here.
-        skip_substrs = ["mask_embedding", "confidence_head"]
+        skip_substrs = ["mask_embedding"]
+        if self.model.confidence_head is None:
+            skip_substrs.append("confidence_head")
         if not includes_embed_tokens:
             skip_substrs.append("embed_tokens")
         if not includes_lm_head:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -57,7 +57,10 @@ from vllm.v1.metrics.perf import ModelMetrics, PerfStats
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus, StreamingUpdate
-from vllm.v1.spec_decode.dynamic.utils import build_dynamic_sd_schedule_lookup
+from vllm.v1.spec_decode.dynamic.utils import (
+    DSparkLiveRederivation,
+    build_dynamic_sd_schedule_lookup,
+)
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
@@ -255,6 +258,8 @@ class Scheduler(SchedulerInterface):
                 # anchor itself is the first prediction position (no separate bonus
                 # query), so it needs exactly num_spec_tokens lookahead slots.
                 self.num_lookahead_tokens = self.num_spec_tokens
+                # Live dynamic-SD re-derivation, armed by set_dspark_cost_profile.
+                self._dspark_rederive: DSparkLiveRederivation | None = None
 
         # Create the KV cache manager.
         if hash_block_size is None:
@@ -1610,6 +1615,11 @@ class Scheduler(SchedulerInterface):
                     num_invalid_spec_tokens=scheduler_output.num_invalid_spec_tokens,
                     request_id=req_id,
                 )
+                rederive = getattr(self, "_dspark_rederive", None)
+                if rederive is not None:
+                    lookup = rederive.observe(num_draft_tokens, num_accepted)
+                    if lookup is not None:
+                        self.dynamic_sd_lookup = lookup
 
             # Free encoder inputs only after the step has actually executed.
             if request.has_encoder_inputs:
@@ -2298,6 +2308,17 @@ class Scheduler(SchedulerInterface):
             kv_connector_stats=connector_stats_payload,
             cudagraph_stats=cudagraph_stats,
             perf_stats=perf_stats,
+        )
+
+    def set_dspark_cost_profile(
+        self, r_grid: list[int], times_by_l: list[list[float]]
+    ) -> None:
+        """Arm live dynamic-SD re-derivation from realized acceptance."""
+        self._dspark_rederive = DSparkLiveRederivation(
+            r_grid,
+            times_by_l,
+            self.scheduler_config.max_num_seqs,
+            self.num_spec_tokens,
         )
 
     def make_spec_decoding_stats(

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -147,6 +147,43 @@ class EngineCore:
             kv_cache_config, vllm_config
         )
 
+        # DSpark: if no dynamic-SD table was configured, adopt the one the
+        # worker auto-derived from its startup cost profile, so scheduled
+        # verification widths always land on captured graph shapes.
+        spec_cfg = vllm_config.speculative_config
+        dspark_cost_profile = None
+        if (
+            spec_cfg is not None
+            and spec_cfg.method == "dspark"
+            and spec_cfg.dspark_scheduler
+            and spec_cfg.num_speculative_tokens_per_batch_size is None
+        ):
+            if vllm_config.parallel_config.world_size == 1:
+                tables = self.model_executor.collective_rpc(
+                    "get_dspark_dynamic_sd_table"
+                )
+                if tables and tables[0]:
+                    spec_cfg.num_speculative_tokens_per_batch_size = tables[0]
+                    logger.info(
+                        "DSpark: adopting auto-derived dynamic-SD table: %s",
+                        tables[0],
+                    )
+                    # Also hand over the raw cost profile: the schedule is
+                    # re-derived from realized acceptance at runtime.
+                    profiles = self.model_executor.collective_rpc(
+                        "get_dspark_cost_profile"
+                    )
+                    if profiles and profiles[0]:
+                        dspark_cost_profile = profiles[0]
+            else:
+                # Workers hold separate config copies under the multiproc
+                # executor, so the K-hint gate would not see the injected
+                # table; skip auto-adoption. (Broadcast: follow-up.)
+                logger.warning(
+                    "DSpark: auto-derived dynamic-SD table is only supported "
+                    "with a single worker (world_size==1); skipping."
+                )
+
         self.scheduler: SchedulerInterface = Scheduler(
             vllm_config=vllm_config,
             kv_cache_config=kv_cache_config,
@@ -156,6 +193,10 @@ class EngineCore:
             block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
         )
+        if dspark_cost_profile is not None and hasattr(
+            self.scheduler, "set_dspark_cost_profile"
+        ):
+            self.scheduler.set_dspark_cost_profile(*dspark_cost_profile)
         self.use_spec_decode = vllm_config.speculative_config is not None
         self.check_for_draft_tokens = (
             self.use_spec_decode or vllm_config.model_config.is_diffusion

--- a/vllm/v1/spec_decode/dynamic/utils.py
+++ b/vllm/v1/spec_decode/dynamic/utils.py
@@ -1,7 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
 DynamicSDSchedule = list[tuple[int, int, int]]
+
+# Prefix-survival prior seeding dynamic-SD derivation until realized
+# acceptance is measured (shape from DSpark-V4-Flash/Qwen3 measurements).
+DEFAULT_SURVIVAL_PRIOR = [0.78, 0.55, 0.37, 0.24, 0.16, 0.11, 0.08]
 
 
 def validate_and_normalize_dynamic_sd_schedule(
@@ -146,3 +154,116 @@ def build_dynamic_sd_schedule_lookup(
         )
 
     return dense_schedule
+
+
+def derive_dynamic_sd_schedule(
+    r_grid: list[int],
+    times_by_l: list[list[float]],
+    survival: list[float],
+    max_num_reqs: int,
+    overhead_c0: float = 0.003,
+    overhead_c1: float = 5e-5,
+) -> DynamicSDSchedule:
+    """Derive a batch-size -> K schedule from a profiled cost table.
+
+    ``times_by_l[k][i]`` is the step time at ``r_grid[i]`` requests for
+    verification width ``1+k``; ``survival`` is the per-position prefix
+    acceptance probability (a startup prior, or measured live). For each
+    request bucket pick the K maximizing expected tokens/sec, then collapse
+    adjacent equal-K buckets into inclusive ranges covering 1..max_num_reqs.
+    """
+    gamma = len(times_by_l) - 1
+    accept = [0.0]
+    run = 0.0
+    for s in survival[:gamma]:
+        run += s
+        accept.append(run)
+    while len(accept) < gamma + 1:
+        accept.append(accept[-1])
+    table: list[list[int]] = []
+    start = 1
+    for i, r in enumerate(r_grid):
+        best_k, best = gamma, -1.0
+        for k in range(gamma + 1):
+            t = times_by_l[k][i]
+            if t <= 0.0:
+                continue
+            tokens = r * (1.0 + accept[k])
+            tput = tokens / (t + overhead_c0 + overhead_c1 * tokens)
+            if tput > best:
+                best, best_k = tput, k
+        end = r if i < len(r_grid) - 1 else max_num_reqs
+        if table and table[-1][2] == best_k:
+            table[-1][1] = end
+        else:
+            table.append([start, end, best_k])
+        start = end + 1
+    return [tuple(row) for row in table]
+
+
+class DSparkLiveRederivation:
+    """Re-derives the dynamic-SD schedule from realized acceptance.
+
+    The worker's startup cost profile is static (hardware); the acceptance
+    curve is measured from live traffic, so the batch-size -> K schedule
+    tracks the actual workload with no prior/tuning dependence.
+    """
+
+    # Re-derive after this many observed drafts, updating positions with at
+    # least this many observations.
+    REDERIVE_DRAFTS = 16384
+    MIN_POSITION_OBS = 512.0
+
+    def __init__(
+        self,
+        r_grid: list[int],
+        times_by_l: list[list[float]],
+        max_num_seqs: int,
+        num_spec_tokens: int,
+    ) -> None:
+        gamma = len(times_by_l) - 1
+        self._cost_profile = (r_grid, times_by_l)
+        self._max_num_seqs = max_num_seqs
+        self._num_spec_tokens = num_spec_tokens
+        self._acc_counts = [0.0] * gamma
+        self._obs_counts = [0.0] * gamma
+        self._rederive_ct = 0
+        self._rederived_once = False
+        self._survival = list(DEFAULT_SURVIVAL_PRIOR[:gamma])
+        while len(self._survival) < gamma:
+            self._survival.append(self._survival[-1] * 0.7)
+
+    def observe(self, num_draft_tokens: int, num_accepted: int) -> list[int] | None:
+        """Account one verified draft; returns a new dense lookup on re-derive."""
+        obs, acc = self._obs_counts, self._acc_counts
+        gamma = len(obs)
+        for j in range(min(num_draft_tokens, gamma)):
+            obs[j] += 1.0
+        for j in range(min(num_accepted, gamma)):
+            acc[j] += 1.0
+        self._rederive_ct += 1
+        if self._rederive_ct < self.REDERIVE_DRAFTS:
+            return None
+        self._rederive_ct = 0
+        for j in range(gamma):
+            if obs[j] >= self.MIN_POSITION_OBS:
+                self._survival[j] = acc[j] / obs[j]
+            # Decay so the estimate keeps tracking workload drift.
+            obs[j] *= 0.5
+            acc[j] *= 0.5
+        r_grid, times_by_l = self._cost_profile
+        table = derive_dynamic_sd_schedule(
+            r_grid, times_by_l, self._survival, self._max_num_seqs
+        )
+        log = logger.debug if self._rederived_once else logger.info
+        self._rederived_once = True
+        log(
+            "DSpark dynamic-SD re-derived from live acceptance %s: %s",
+            [round(s, 2) for s in self._survival],
+            table,
+        )
+        return build_dynamic_sd_schedule_lookup(
+            table,
+            vllm_max_batch_size=self._max_num_seqs,
+            vllm_num_speculative_tokens=self._num_spec_tokens,
+        )

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -109,6 +109,13 @@ def get_uniform_token_count(
 
 
 class CudaGraphManager:
+    # Request-count buckets for extra uniform-decode FULL graph capture.
+    # DSpark cost-table profiling must measure exactly at these buckets
+    # (its ceiling-bucket lookup assumes r_grid == capture grid).
+    UNIFORM_DECODE_REQUEST_BUCKETS: tuple[int, ...] = (
+        1, 2, 4, 8, 16, 24, 32, 48, 64, 96, 128, 192, 256,
+    )  # fmt: skip
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -116,6 +123,7 @@ class CudaGraphManager:
         cudagraph_mode: CUDAGraphMode,
         decode_query_len: int,
         lora_capture_cases: list[int] | None = None,
+        extra_uniform_decode_lens: list[int] | None = None,
     ):
         self.vllm_config = vllm_config
         self.device = device
@@ -124,6 +132,15 @@ class CudaGraphManager:
         assert self.compilation_config is not None
         self.cudagraph_mode = cudagraph_mode
         self.decode_query_len = decode_query_len
+        # Extra uniform-decode query lengths to capture FULL graphs for
+        # (padded/variable-length speculation): a uniform batch at one of
+        # these lengths replays FULL instead of falling to PIECEWISE/eager.
+        self.extra_uniform_decode_lens = [
+            q
+            for q in (extra_uniform_decode_lens or [])
+            if q >= 1 and q != decode_query_len
+        ]
+        self._uniform_candidates: dict[int, list[BatchExecutionDescriptor]] = {}
 
         self.dp_size = vllm_config.parallel_config.data_parallel_size
         self.tp_size = vllm_config.parallel_config.tensor_parallel_size
@@ -235,6 +252,37 @@ class CudaGraphManager:
                 descs_by_mode[mixed_mode].append(desc)
                 descs_by_token_lora[(num_tokens, num_active_loras)].append(desc)
 
+        # Capture the decode routine at the extra query lengths over a coarse
+        # request grid so trimmed spec-decode batches stay on FULL graphs.
+        if separate_decode_routine and decode_mode and self.extra_uniform_decode_lens:
+            max_size = max(capture_sizes)
+            req_buckets = sorted(
+                {
+                    r
+                    for r in self.UNIFORM_DECODE_REQUEST_BUCKETS
+                    if r <= self.max_num_reqs
+                }
+                | {self.max_num_reqs}
+            )
+            for q, num_active_loras in product(
+                self.extra_uniform_decode_lens, self.lora_capture_cases
+            ):
+                for r in req_buckets:
+                    if r * q > max_size:
+                        break
+                    desc = BatchExecutionDescriptor(
+                        cg_mode=decode_mode,
+                        num_tokens=r * q,
+                        num_reqs=r,
+                        uniform_token_count=q,
+                        num_active_loras=num_active_loras,
+                    )
+                    descs_by_mode[decode_mode].append(desc)
+                    self._uniform_candidates.setdefault(q, []).append(desc)
+            # First-fit dispatch scans each per-q list in ascending token order.
+            for uniform_descs in self._uniform_candidates.values():
+                uniform_descs.sort(key=lambda d: d.num_tokens)
+
         if not descs_by_token_lora:
             return
 
@@ -339,6 +387,19 @@ class CudaGraphManager:
         """Find matching cudagraph descriptor from priority-ordered candidates."""
 
         effective_loras = self._resolve_effective_loras(num_active_loras)
+        if (
+            self._graphs_captured
+            and num_tokens > 0
+            and uniform_token_count is not None
+            and uniform_token_count in self._uniform_candidates
+        ):
+            # Uniform batch at an extra decode query length: first-fit the
+            # smallest captured FULL decode graph that fits (ascending order).
+            for desc in self._uniform_candidates[uniform_token_count]:
+                if desc.num_tokens >= num_tokens and _is_compatible(
+                    desc, num_reqs, num_tokens, uniform_token_count, effective_loras
+                ):
+                    return desc
         key = (num_tokens, effective_loras)
         if self._graphs_captured and num_tokens > 0 and key in self._candidates:
             for desc in self._candidates[key]:
@@ -396,6 +457,7 @@ class ModelCudaGraphManager(CudaGraphManager):
         cudagraph_mode: CUDAGraphMode,
         decode_query_len: int,
         lora_capture_cases: list[int] | None = None,
+        extra_uniform_decode_lens: list[int] | None = None,
     ):
         super().__init__(
             vllm_config,
@@ -403,6 +465,7 @@ class ModelCudaGraphManager(CudaGraphManager):
             cudagraph_mode,
             decode_query_len,
             lora_capture_cases=lora_capture_cases,
+            extra_uniform_decode_lens=extra_uniform_decode_lens,
         )
         self.hidden_states: torch.Tensor | None = None
         self.aux_hidden_states: list[torch.Tensor] = []

--- a/vllm/v1/worker/gpu/input_batch.py
+++ b/vllm/v1/worker/gpu/input_batch.py
@@ -99,6 +99,11 @@ class InputBatch:
     # [num_reqs] per-request prompt length, only populated for R-SWA.
     prompt_lens: torch.Tensor | None
 
+    # Padded speculation: the UNPADDED per-request query cumsum. When set,
+    # query_start_loc describes the padded layout (real tokens a prefix of
+    # each uniform span) and token accounting must use this tensor instead.
+    real_query_start_loc: torch.Tensor | None = None
+
     @classmethod
     def make_dummy(
         cls,
@@ -314,6 +319,7 @@ def _combine_sampled_and_draft_tokens_kernel(
     logits_indices_ptr,
     BLOCK_SIZE: tl.constexpr,
     NUM_NEW_SAMPLED_TOKENS: tl.constexpr = 1,
+    PREFIX_MODE: tl.constexpr = False,
 ):
     batch_idx = tl.program_id(0)
     req_state_idx = tl.load(idx_mapping_ptr + batch_idx)
@@ -324,10 +330,15 @@ def _combine_sampled_and_draft_tokens_kernel(
     num_logits = cu_num_logits_end - cu_num_logits_start
     num_draft_tokens = num_logits - NUM_NEW_SAMPLED_TOKENS
 
-    # Compute the logits indices.
+    # Compute the logits indices. In suffix mode (default) the real tokens
+    # occupy the END of the request's query span; in prefix mode (padded
+    # speculation: span is [real 1+n_draft | pads]) they occupy the START.
     block = tl.arange(0, BLOCK_SIZE)
     query_end = tl.load(query_start_loc_ptr + batch_idx + 1)
-    logits_start = query_end - num_logits
+    if PREFIX_MODE:
+        logits_start = tl.load(query_start_loc_ptr + batch_idx)
+    else:
+        logits_start = query_end - num_logits
     tl.store(
         logits_indices_ptr + cu_num_logits_start + block,
         logits_start + block,
@@ -343,7 +354,7 @@ def _combine_sampled_and_draft_tokens_kernel(
     if NUM_NEW_SAMPLED_TOKENS > 0:
         # Write the last sampled token ID to input_ids.
         last_token_id = tl.load(last_sampled_tokens_ptr + req_state_idx)
-        tl.store(input_ids_ptr + query_end - num_logits, last_token_id)
+        tl.store(input_ids_ptr + logits_start, last_token_id)
 
     # Write the draft tokens (if any) to input_ids.
     if num_draft_tokens > 0:
@@ -353,7 +364,7 @@ def _combine_sampled_and_draft_tokens_kernel(
             mask=mask,
         )
         tl.store(
-            input_ids_ptr + query_end - num_draft_tokens + block,
+            input_ids_ptr + logits_start + NUM_NEW_SAMPLED_TOKENS + block,
             draft_tokens,
             mask=mask,
         )
@@ -370,6 +381,7 @@ def combine_sampled_and_draft_tokens(
     cu_num_logits: torch.Tensor,
     num_logits: int,
     num_new_sampled_tokens: int = 1,  # excl accepted draft tokens, a.k.a bonus tokens
+    prefix_mode: bool = False,
 ) -> torch.Tensor:
     assert num_new_sampled_tokens in (0, 1), (
         f"num_new_sampled_tokens must be 0 or 1, got {num_new_sampled_tokens}"
@@ -395,6 +407,7 @@ def combine_sampled_and_draft_tokens(
         cu_num_logits,
         logits_indices,
         NUM_NEW_SAMPLED_TOKENS=num_new_sampled_tokens,
+        PREFIX_MODE=prefix_mode,
         # NOTE(woosuk): Add num_new_sampled_tokens to ensure the block covers the
         # last sampled token in addition to all draft tokens.
         BLOCK_SIZE=triton.next_power_of_2(

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -48,6 +48,7 @@ from vllm.tasks import SupportedTask
 from vllm.utils.math_utils import cdiv
 from vllm.utils.mem_utils import DeviceMemoryProfiler, format_gib
 from vllm.utils.torch_utils import PIN_MEMORY, STR_DTYPE_TO_TORCH_DTYPE
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
@@ -103,6 +104,7 @@ from vllm.v1.worker.gpu.sample.prompt_logprob import PromptLogprobsWorker
 from vllm.v1.worker.gpu.sample.sampler import Sampler
 from vllm.v1.worker.gpu.shutdown import free_before_shutdown
 from vllm.v1.worker.gpu.spec_decode import init_speculator
+from vllm.v1.worker.gpu.spec_decode.dspark.scheduler import derive_dynamic_sd_table
 from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
     set_eagle3_aux_hidden_state_layers,
 )
@@ -187,11 +189,20 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         # Speculative decoding.
         self.speculator = None
+        self._dspark_padbucket = False
+        self._dspark_dyn_sd_table: list[tuple[int, int, int]] | None = None
+        self._pad_q: int | None = None
         self.use_aux_hidden_state_outputs = False
         self.num_speculative_steps = vllm_config.num_speculative_tokens
         if self.speculative_config is not None:
             if self.is_last_pp_rank:
                 self.speculator = init_speculator(self.vllm_config, self.device)
+                # DSpark pad-to-bucket: pad ragged spec batches to a uniform
+                # width so they dispatch to that width's FULL graph.
+                self._dspark_padbucket = (
+                    self.speculative_config is not None
+                    and getattr(self.speculative_config, "dspark_pad_to_bucket", False)
+                )
 
             if self.speculative_config.method in ("eagle3", "dflash", "dspark"):
                 # Drafting may require auxiliary hidden states from target model outputs
@@ -464,6 +475,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             cudagraph_mode,
             decode_query_len=self.decode_query_len,
             lora_capture_cases=self.lora_capture_cases,
+            # Also capture FULL decode graphs at the trimmed verify widths
+            # DSpark's scheduler may emit (absent on other speculators).
+            extra_uniform_decode_lens=getattr(
+                self.speculator, "extra_uniform_decode_lens", None
+            ),
         )
         if self.speculator is not None:
             self.speculator.init_cudagraph_manager(cudagraph_mode)
@@ -681,6 +697,77 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         return 0
 
     @torch.inference_mode()
+    def _profile_dspark_cost_table(self) -> None:
+        """Build the DSpark scheduler's shape-aware cost table T(R, L).
+
+        Called once after CUDA graph capture (graphs warm, KV cache live): for
+        each verify length L in [0, gamma] and request count R, time a uniform
+        decode step at query length 1+L (forced via a temporary
+        decode_query_len). Timing the real dispatched shape captures the
+        FULL/PIECEWISE/eager cliffs a 1-D T(num_tokens) table cannot. The dummy
+        step always drafts full gamma, so the L=0 row slightly over-estimates
+        the true no-spec cost.
+        """
+        spec = self.speculator
+        if not getattr(spec, "dspark_scheduler_enabled", False):
+            return
+        gamma = self.num_speculative_steps
+        # Measure exactly at the capture buckets: runtime pads R up to the next
+        # captured bucket, so ceiling-bucket lookup gives the dispatched cost;
+        # interpolating across the FULL/eager cliff would underestimate it.
+        buckets = ModelCudaGraphManager.UNIFORM_DECODE_REQUEST_BUCKETS
+        r_grid = sorted(
+            {r for r in buckets if 1 <= r <= self.max_num_reqs} | {self.max_num_reqs}
+        )
+        saved_qlen = self.decode_query_len
+        times_by_l: list[list[float]] = []
+        try:
+            for length in range(gamma + 1):
+                q = 1 + length
+                self.decode_query_len = q
+                row: list[float] = []
+                for r in r_grid:
+                    nt = r * q
+                    if nt > self.max_num_tokens:
+                        row.append(row[-1] if row else 0.0)
+                        continue
+                    for _ in range(2):  # warmup
+                        self._dummy_run(nt, uniform_decode=True)
+                    torch.accelerator.synchronize()
+                    t0 = time.perf_counter()
+                    iters = 3
+                    for _ in range(iters):
+                        self._dummy_run(nt, uniform_decode=True)
+                    torch.accelerator.synchronize()
+                    row.append((time.perf_counter() - t0) / iters)
+                times_by_l.append(row)
+        finally:
+            self.decode_query_len = saved_qlen
+        spec.set_cost_table(r_grid, times_by_l)
+        self._dspark_cost_profile = (r_grid, times_by_l)
+        self._dspark_dyn_sd_table = derive_dynamic_sd_table(
+            r_grid, times_by_l, self.num_speculative_steps, self.max_num_reqs
+        )
+        logger.info(
+            "DSpark auto-derived dynamic-SD table (batch-size ranges -> K): %s",
+            self._dspark_dyn_sd_table,
+        )
+        logger.info(
+            "DSpark shape-aware cost table: r_grid=%s; T(R=%d) by L = %s ms",
+            r_grid,
+            r_grid[-1],
+            [round(times_by_l[L][-1] * 1e3, 1) for L in range(gamma + 1)],
+        )
+
+    def get_dspark_dynamic_sd_table(self) -> list[tuple[int, int, int]] | None:
+        return self._dspark_dyn_sd_table
+
+    def get_dspark_cost_profile(
+        self,
+    ) -> tuple[list[int], list[list[float]]] | None:
+        return getattr(self, "_dspark_cost_profile", None)
+
+    @torch.inference_mode()
     def capture_model(self) -> int:
         assert self.cudagraph_manager is not None
         if not self.cudagraph_manager.needs_capture():
@@ -712,6 +799,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             )
             if self.speculator is not None:
                 self.speculator.capture(attn_states)
+                self._profile_dspark_cost_table()
 
         end_time = time.perf_counter()
         end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
@@ -897,6 +985,20 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 idx_mapping, total_num_logits, cu_num_logits, max_expand_len
             )
 
+        # DSpark pad-to-bucket: run a ragged spec-decode batch at one uniform
+        # width (chosen pre-dispatch in execute_model). The padded layout
+        # drives positions/seq_lens/attention; cu_num_logits stays REAL (real
+        # tokens are a prefix of each span) for logits and token accounting.
+        real_query_start_loc = None
+        pad_q = getattr(self, "_pad_q", None)
+        self._pad_q = None
+        if pad_q is not None and num_draft_tokens_per_req is not None:
+            real_qsl_np = np.zeros(num_reqs + 1, dtype=np.int32)
+            np.cumsum(num_scheduled_tokens, out=real_qsl_np[1:])
+            real_query_start_loc = async_copy_to_gpu(real_qsl_np, device=self.device)
+            num_scheduled_tokens = np.full(num_reqs, pad_q, dtype=np.int32)
+            num_tokens = num_reqs * pad_q
+
         # Get query_start_loc.
         # num_reqs_padded is None for PIECEWISE graphs (no request padding needed)
         num_reqs_padded = batch_desc.num_reqs or num_reqs
@@ -962,7 +1064,17 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             cu_num_logits,
             total_num_logits,
             self.model_state.num_new_sampled_tokens_per_step,
+            prefix_mode=real_query_start_loc is not None,
         )
+        if real_query_start_loc is not None:
+            # Fill padded tails with the drafting mask token; pads are
+            # excluded from logits by the prefix-mode logits indices.
+            ids2d = self.input_buffers.input_ids[:num_tokens].view(num_reqs, pad_q)
+            real_lens = cu_num_logits[1:] - cu_num_logits[:-1]
+            pad_mask = torch.arange(
+                pad_q, device=self.device, dtype=torch.int32
+            ).unsqueeze(0) >= real_lens.unsqueeze(1)
+            ids2d.masked_fill_(pad_mask, self.speculator.parallel_drafting_token_id)
 
         # CPU upper bound on seq_lens; padded entries left at zero.
         num_computed_tokens_np = self.req_states.num_computed_tokens_np[idx_mapping_np]
@@ -999,6 +1111,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             num_draft_tokens_per_req=num_draft_tokens_per_req,
             query_start_loc=query_start_loc,
             query_start_loc_np=query_start_loc_np,
+            real_query_start_loc=real_query_start_loc,
             seq_lens=seq_lens,
             seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
             dcp_local_seq_lens=dcp_local_seq_lens,
@@ -1074,6 +1187,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 input_batch,
                 # Draft logits are needed for probabilistic rejection sampling.
                 self.speculator.draft_logits,
+                # DSpark confidence-threshold mode: positions beyond a
+                # request's valid count are pads to force-reject.
+                valid_draft_len=getattr(self.speculator, "valid_draft_len", None),
             )
 
         return sampler_output, sampler_output.num_sampled, sampler_output.num_rejected
@@ -1119,6 +1235,20 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         is_profile: bool = False,
     ) -> ModelRunnerOutput | IntermediateTensors | None:
         if not dummy_run:
+            # Dynamic SD: hand the speculator the engine-scheduled next-step
+            # width (K=0 skips the draft forward). Gated on the LIVE config --
+            # the table may be auto-injected after worker init via the shared
+            # config object -- and never written on the static path, where it
+            # would pin the worker-side scheduler to full gamma.
+            spec_cfg = self.vllm_config.speculative_config
+            if (
+                hasattr(self.speculator, "next_k_hint")
+                and spec_cfg is not None
+                and spec_cfg.uses_dynamic_speculative_decoding()
+            ):
+                self.speculator.next_k_hint = (
+                    scheduler_output.num_spec_tokens_to_schedule
+                )
             # Update the request states.
             self.update_pp_decode_requests()
             self.finish_requests(scheduler_output)
@@ -1136,6 +1266,30 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         num_toks = scheduler_output.total_num_scheduled_tokens
         max_query_len = max(scheduler_output.num_scheduled_tokens.values())
         uniform_tok_count = get_uniform_token_count(num_reqs, num_toks, max_query_len)
+
+        # DSpark pad-to-bucket: pad a ragged all-decode spec batch to uniform
+        # width max(1+l_r) so it dispatches to that width's FULL graph.
+        # Decided here (pre-dispatch); consumed by prepare_inputs.
+        self._pad_q = None
+        if (
+            self._dspark_padbucket
+            and not dummy_run
+            and uniform_tok_count is None
+            and scheduler_output.scheduled_spec_decode_tokens
+            and max_query_len <= self.decode_query_len
+            # DP ranks must replay the same graph shapes; a rank-local pad
+            # decision would diverge dispatch across ranks.
+            and self.dp_size == 1
+        ):
+            sched_drafts = scheduler_output.scheduled_spec_decode_tokens
+            all_decode = all(
+                n == 1 + len(sched_drafts.get(rid, ()))
+                for rid, n in scheduler_output.num_scheduled_tokens.items()
+            )
+            if all_decode:
+                self._pad_q = max_query_len
+                num_toks = num_reqs * max_query_len
+                uniform_tok_count = max_query_len
 
         num_active_loras = 0
         if self.lora_config:
@@ -1182,6 +1336,23 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 self.kv_cache_config,
                 self.req_states.num_computed_tokens.gpu,
             )
+            if input_batch.real_query_start_loc is not None:
+                # Pad positions overshoot the real sequence and may compute
+                # slots in unallocated pages: route their KV writes to the
+                # dummy slot.
+                npq = input_batch.num_tokens // input_batch.num_reqs
+                real_lens = (
+                    input_batch.cu_num_logits[1:] - input_batch.cu_num_logits[:-1]
+                )
+                pad_flat = (
+                    torch.arange(npq, device=self.device, dtype=torch.int32).unsqueeze(
+                        0
+                    )
+                    >= real_lens.unsqueeze(1)
+                ).reshape(-1)
+                slot_mappings[..., : input_batch.num_tokens].masked_fill_(
+                    pad_flat, PAD_SLOT_ID
+                )
 
             if self.lora_config:
                 # Activate LoRA adapters.
@@ -1449,7 +1620,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             sampler_output.sampled_token_ids,
             num_sampled,
             num_rejected,
-            input_batch.query_start_loc,
+            # Account computed tokens by the REAL layout (padded query lens
+            # would overcount).
+            input_batch.real_query_start_loc
+            if input_batch.real_query_start_loc is not None
+            else input_batch.query_start_loc,
         )
 
         if self.speculator is not None:
@@ -1476,14 +1651,25 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 self.sampler.sampling_states.seeds.gpu,
                 mm_inputs=mm_inputs,
             )
-            self.req_states.draft_tokens[input_batch.idx_mapping] = draft_tokens
+            # DSpark may trim the draft to a uniform L < num_speculative_steps
+            # per step: write the first L columns and propagate L as the verify
+            # length. L == full width is the unchanged fixed-gamma path.
+            n_draft = draft_tokens.shape[1]
+            self.req_states.draft_tokens[input_batch.idx_mapping, :n_draft] = (
+                draft_tokens
+            )
+        else:
+            n_draft = self.num_speculative_steps
 
         if self.num_speculative_steps > 0:
             # Spec-decode and diffusion LLMs both use draft tokens but the latter does
             # not have a speculator (i.e. self.speculator is None)
             self.draft_tokens_handler.set_draft_tokens(
                 input_batch,
-                self.req_states.draft_tokens[input_batch.idx_mapping],
+                self.req_states.draft_tokens[input_batch.idx_mapping, :n_draft],
+                # DSpark Algorithm-1 per-request lengths; absent/None on the
+                # uniform path.
+                lengths=getattr(self.speculator, "_perreq_batch_len", None),
             )
 
         # Post-step KV connector related operations.

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -271,6 +271,9 @@ class DFlashSpeculator(DraftModelSpeculator):
         is_profile: bool = False,
     ) -> torch.Tensor:
         num_reqs = input_batch.num_reqs
+        draft_len = self._schedule_draft_len(
+            input_batch, num_sampled, num_rejected, dummy_run
+        )
         num_target_tokens = input_batch.num_tokens
         num_query_tokens = num_reqs * self.num_query_per_req
         max_seq_len = input_batch.seq_lens_cpu_upper_bound[:num_reqs].max().item()
@@ -366,6 +369,11 @@ class DFlashSpeculator(DraftModelSpeculator):
             context_slots,
         )
 
+        if draft_len == 0:
+            # Scheduler gate: context KV was refreshed above but the draft
+            # forward is skipped -> empty draft, engine runs a normal decode.
+            return self._finalize_draft(input_batch, num_reqs, 0, dummy_run)
+
         # Every DFlash step has exactly num_query_per_req tokens, so we can use FULL CGs
         batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
             self.query_cudagraph_manager,
@@ -410,6 +418,26 @@ class DFlashSpeculator(DraftModelSpeculator):
                 cudagraph_runtime_mode=batch_desc.cg_mode,
             )
 
+        return self._finalize_draft(input_batch, num_reqs, draft_len, dummy_run)
+
+    def _schedule_draft_len(
+        self,
+        input_batch: InputBatch,
+        num_sampled: torch.Tensor,
+        num_rejected: torch.Tensor,
+        dummy_run: bool,
+    ) -> int:
+        """Pick this step's draft length; 0 skips the draft forward."""
+        return self.num_speculative_steps
+
+    def _finalize_draft(
+        self,
+        input_batch: InputBatch,
+        num_reqs: int,
+        draft_len: int,
+        dummy_run: bool,
+    ) -> torch.Tensor:
+        """Post-draft hook: trim/mask the draft block before returning it."""
         return self.draft_tokens[:num_reqs]
 
 
@@ -434,6 +462,7 @@ def _prepare_dflash_inputs_kernel(
     next_prefill_tokens_ptr,
     num_sampled_ptr,
     num_rejected_ptr,
+    cu_num_logits_ptr,
     # Block table for slot mapping lookup.
     block_table_ptr,
     block_table_stride,
@@ -448,6 +477,7 @@ def _prepare_dflash_inputs_kernel(
     SAMPLE_FROM_ANCHOR: tl.constexpr,
     PAD_SLOT_ID: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
+    HAS_REAL_LENS: tl.constexpr = False,
 ):
     req_idx = tl.program_id(0)
     block_idx = tl.program_id(1)
@@ -457,9 +487,17 @@ def _prepare_dflash_inputs_kernel(
     ctx_start = tl.load(target_query_start_loc_ptr + req_idx)
     ctx_end = tl.load(target_query_start_loc_ptr + req_idx + 1)
     num_ctx = ctx_end - ctx_start
+    span_len = num_ctx
+    if HAS_REAL_LENS:
+        # Padded speculation: the target span is padded to a uniform width
+        # with the real tokens as a PREFIX; the real length comes from
+        # cu_num_logits. All downstream indexing derives from num_ctx.
+        num_ctx = tl.load(cu_num_logits_ptr + req_idx + 1) - tl.load(
+            cu_num_logits_ptr + req_idx
+        )
 
     num_rejected = tl.load(num_rejected_ptr + req_idx)
-    valid_ctx_end = ctx_end - num_rejected
+    valid_ctx_end = ctx_start + num_ctx - num_rejected
 
     num_sampled = tl.load(num_sampled_ptr + req_idx)
     if num_sampled > 0:
@@ -489,6 +527,17 @@ def _prepare_dflash_inputs_kernel(
     ctx_slot = ctx_block_id * block_size + (ctx_pos % block_size)
     tl.store(out_context_positions_ptr + ctx_start + j, ctx_pos, mask=is_ctx)
     tl.store(out_context_slot_mapping_ptr + ctx_start + j, ctx_slot, mask=is_ctx)
+    if HAS_REAL_LENS:
+        # Neutralize the padded tail of the context arrays: stale entries from
+        # prior steps would otherwise write garbage draft-context KV into
+        # other requests' pages via precompute_and_store_context_kv.
+        is_pad_ctx = (j >= num_ctx) & (j < span_len)
+        tl.store(out_context_positions_ptr + ctx_start + j, 0, mask=is_pad_ctx)
+        tl.store(
+            out_context_slot_mapping_ptr + ctx_start + j,
+            PAD_SLOT_ID,
+            mask=is_pad_ctx,
+        )
 
     # --- Query positions / input_ids / slots ---
     query_pos = last_valid_pos + 1 + query_off
@@ -616,6 +665,7 @@ def prepare_dflash_inputs(
         next_prefill_tokens,
         num_sampled,
         num_rejected,
+        input_batch.cu_num_logits,
         block_table,
         block_table.stride(0),
         parallel_drafting_token_id,
@@ -628,4 +678,6 @@ def prepare_dflash_inputs(
         SAMPLE_FROM_ANCHOR=sample_from_anchor,
         PAD_SLOT_ID=PAD_SLOT_ID,
         BLOCK_SIZE=BLOCK_SIZE,
+        # Padded speculation: spans are padded, real lengths in cu_num_logits.
+        HAS_REAL_LENS=input_batch.real_query_start_loc is not None,
     )

--- a/vllm/v1/worker/gpu/spec_decode/dspark/scheduler.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/scheduler.py
@@ -1,0 +1,373 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DSpark hardware-aware confidence scheduler policy.
+
+Owns all scheduler state for the DSpark speculator: the shape-aware cost table,
+the online engine-overhead regression, the survival EMA + calibration, the
+hysteresis incumbent, and per-request width allocation. The speculator keeps
+only the GPU-graph-written survival buffer and the width plumbing the runner
+consumes, driving this policy through a thin method surface.
+"""
+
+import torch
+
+from vllm.config import SpeculativeConfig
+from vllm.v1.spec_decode.dynamic.utils import (
+    DEFAULT_SURVIVAL_PRIOR,
+    derive_dynamic_sd_schedule,
+)
+
+# Survival EMA: slow blend so the per-step length choice does not chase jitter.
+SURVIVAL_EMA_DECAY = 0.9
+SURVIVAL_EMA_GAIN = 0.1
+# Consume/launch the host survival readout every N steps (staleness-tolerant).
+READOUT_CADENCE = 4
+# Online calibration ratio EMA (realized/predicted survival).
+CALIBRATION_DECAY = 0.8
+CALIBRATION_GAIN = 0.2
+# Minimum observations in an interval before trusting a calibration update.
+CALIBRATION_MIN_OBS = 64.0
+# Clamp the realized/predicted ratio to reject noisy intervals.
+CALIBRATION_RATIO_MIN = 0.25
+CALIBRATION_RATIO_MAX = 4.0
+# Overhead regression ring: bounded sample history for the (c0, c1) fit.
+OVERHEAD_RING_SIZE = 129
+# Discard overhead residuals above this many seconds as idle-gap outliers.
+OVERHEAD_SAMPLE_GATE = 0.25
+# Minimum ring occupancy before the regression is meaningful.
+OVERHEAD_MIN_SAMPLES = 16
+# Cap the per-token overhead slope c1 (a physical sampler/detok upper bound).
+OVERHEAD_C1_CLAMP = 1e-3
+# Keep the incumbent length unless a challenger clears this relative margin.
+HYSTERESIS_MARGIN = 0.05
+# Prefix-survival prior (measured V4-Flash/Qwen3) seeding the dynamic-SD table;
+# online calibration corrects the runtime estimate, not this table.
+SURVIVAL_PRIOR = DEFAULT_SURVIVAL_PRIOR
+# Engine-overhead prior (per-step, per-token seconds) for the dynamic-SD table.
+DERIVATION_OVERHEAD_C0 = 0.003
+DERIVATION_OVERHEAD_C1 = 5e-5
+
+
+def schedule_uniform_length(
+    accept: list[float],
+    num_reqs: int,
+    gamma: int,
+    r_grid: list[int] | None,
+    times_by_l: list[list[float]] | None,
+    overhead: tuple[float, float] = (0.0, 0.0),
+    current: int | None = None,
+    hysteresis: float = HYSTERESIS_MARGIN,
+) -> tuple[int, float]:
+    """Hardware-aware per-step *uniform* verify length L in [0, gamma].
+
+    Picks the batch-uniform L maximizing accepted-tokens / step-time from
+    ``accept`` (``accept[L]`` = summed prefix-survival over the first L
+    positions) and the shape-aware cost table ``times_by_l[L][i]`` = step time
+    at ``r_grid[i]`` requests for verify query length ``1+L``. Each L is a
+    fixed CUDA-graph-captured shape; L=0 skips drafting; falls back to gamma
+    without a table. Shape-awareness matters: full-gamma verify replays the
+    fast FULL decode graph while a trimmed L may fall to PIECEWISE, and the
+    eager cutoff depends on (R, L) -- a 1-D T(num_tokens) expresses neither.
+
+    ``overhead`` is (c0, c1): per-step constant + per-generated-token cost.
+    Folding c1 into c0 would wrongly pin L at gamma.
+
+    Returns (best_l, predicted step time of best_l including overhead).
+    """
+    if not r_grid or not times_by_l:
+        return gamma, 0.0
+
+    def cost(length: int) -> float:
+        # Ceiling-bucket lookup, NOT interpolation: dispatch pads R up to the next
+        # captured bucket, so cost is a step function of R; interpolating smooths
+        # across the FULL-graph/eager cliff and underestimates eager shapes.
+        row = times_by_l[length]
+        for i, r in enumerate(r_grid):
+            if num_reqs <= r:
+                return row[i]
+        return row[-1] * (num_reqs / r_grid[-1])
+
+    c0, c1 = overhead
+    best_l, best_tput, best_cost = gamma, -1.0, 0.0
+    cur_tput, cur_cost = -1.0, 0.0
+    for length in range(gamma + 1):
+        c = cost(length)
+        if c <= 0.0:
+            continue
+        tokens = num_reqs * (1.0 + accept[length])
+        c += c0 + c1 * tokens
+        tput = tokens / c
+        if tput > best_tput:
+            best_tput, best_l, best_cost = tput, length, c
+        if length == current:
+            cur_tput, cur_cost = tput, c
+    # Hysteresis: re-evaluated at the current num_reqs so genuine load shifts
+    # still switch immediately, but survival-EMA jitter cannot flap the length.
+    if (
+        current is not None
+        and cur_tput > 0.0
+        and best_tput <= cur_tput * (1.0 + hysteresis)
+    ):
+        return current, cur_cost
+    return best_l, best_cost
+
+
+def derive_dynamic_sd_table(
+    r_grid: list[int],
+    times_by_l: list[list[float]],
+    gamma: int,
+    max_num_reqs: int,
+) -> list[tuple[int, int, int]]:
+    """Derive the dynamic-SD batch-size table from the startup profile:
+    per-bucket throughput-optimal K under the survival/overhead priors,
+    adjacent equal-K buckets collapsed (ceiling-bucket semantics matching
+    dispatch, so every scheduled K runs on a captured shape).
+    """
+    return derive_dynamic_sd_schedule(
+        r_grid,
+        times_by_l,
+        list(SURVIVAL_PRIOR[:gamma]),
+        max_num_reqs,
+        overhead_c0=DERIVATION_OVERHEAD_C0,
+        overhead_c1=DERIVATION_OVERHEAD_C1,
+    )
+
+
+def allocate_widths(
+    survival_view: torch.Tensor,
+    cal_t: torch.Tensor,
+    num_reqs: int,
+    length: int,
+    tau: float,
+    budget_frac: float,
+) -> torch.Tensor:
+    """Per-request keep lengths (paper Algorithm 1) via a global survival top-k.
+
+    With ``tau > 0`` returns a static confidence-threshold width; otherwise
+    distributes ``num_reqs*length*budget_frac`` tokens over the freshest
+    calibrated survivals. Survival is a cumprod, so thresholding yields
+    valid prefixes.
+    """
+    a = survival_view * cal_t
+    if tau > 0.0:
+        return (a >= tau).sum(dim=1, dtype=torch.int32)
+    a = a[:, :length]
+    budget = min(int(num_reqs * length * budget_frac) + 1, num_reqs * length)
+    flat = a.reshape(-1)
+    if budget < flat.numel():
+        th = torch.topk(flat, budget, sorted=False).values.min()
+        return (a >= th).sum(dim=1, dtype=torch.int32)
+    return torch.full((num_reqs,), length, dtype=torch.int32, device=a.device)
+
+
+class DSparkScheduler:
+    """Confidence-scheduler policy for the DSpark speculator (see module docstring)."""
+
+    def __init__(
+        self,
+        spec_config: SpeculativeConfig,
+        gamma: int,
+        max_num_reqs: int,
+        device: torch.device,
+    ):
+        self.gamma = gamma
+        self.device = device
+        # CPU-testability seam: on CPU use a pageable host buffer and an
+        # always-ready readout (copies are synchronous) so the stateful core is
+        # unit-testable without a GPU; the CUDA path is byte-identical.
+        self._is_cuda = device.type == "cuda"
+        self.perreq = spec_config.dspark_per_request
+        self.tau = spec_config.dspark_confidence_threshold
+        self._budget_frac = spec_config.dspark_budget_frac
+
+        # Shape-aware cost table T(R, L), installed after CUDA graph capture.
+        self._cost_r_grid: list[int] | None = None
+        self._cost_times_by_l: list[list[float]] | None = None
+
+        # Survival EMA: on-GPU accumulator + stale CPU readout consumed by decide.
+        self._surv_ema_t: torch.Tensor | None = None
+        self._surv_ema: list[float] | None = None
+        self._ema_ct = 0
+        # Host readout rows: [survival EMA; realized-acceptance counts; observation
+        # counts; predicted-survival sum]; the latter three feed online calibration.
+        self._surv_host = torch.empty(
+            4, gamma, dtype=torch.float32, pin_memory=self._is_cuda
+        )
+        self._surv_evt = torch.cuda.Event() if self._is_cuda else None
+        self._surv_inflight = False
+
+        # Calibration state (realized vs predicted survival over the same set).
+        self._acc_counts = torch.zeros(gamma, dtype=torch.float32, device=device)
+        self._obs_counts = torch.zeros(gamma, dtype=torch.float32, device=device)
+        self._pred_counts = torch.zeros(gamma, dtype=torch.float32, device=device)
+        self._surv_state = torch.zeros(
+            max_num_reqs, gamma, dtype=torch.float32, device=device
+        )
+        self._pos_arange = torch.arange(1, gamma + 1, dtype=torch.int32, device=device)
+        self._cal = [1.0] * gamma
+        self._cal_prev_acc = [0.0] * gamma
+        self._cal_prev_obs = [0.0] * gamma
+        self._cal_prev_pred = [0.0] * gamma
+        self._cal_t = torch.ones(gamma, dtype=torch.float32, device=device)
+
+        # Online engine-overhead regression O = c0 + c1 * generated_tokens over a
+        # ring of (tokens, residual) samples (median-free least squares).
+        self._o_c0 = 0.0
+        self._o_c1 = 0.0
+        self._o_samples: list[tuple[float, float]] = []
+        self._last_t: float | None = None
+        self._last_pred = 0.0
+        self._last_gpu_pred = 0.0
+        self._last_tokens = 0.0
+        # Hysteresis incumbent and last committed verify length.
+        self._last_l: int | None = None
+        self._prev_sched_l = 0
+
+    def set_cost_table(self, r_grid: list[int], times_by_l: list[list[float]]) -> None:
+        """Install the shape-aware cost table T(R, L) [seconds]."""
+        if r_grid and times_by_l and all(len(row) == len(r_grid) for row in times_by_l):
+            self._cost_r_grid = list(r_grid)
+            self._cost_times_by_l = [list(row) for row in times_by_l]
+
+    def observe_verified(
+        self,
+        num_reqs: int,
+        num_sampled: torch.Tensor,
+        num_rejected: torch.Tensor,
+        prev_widths: torch.Tensor,
+        idx_mapping: torch.Tensor,
+    ) -> None:
+        # Accumulate realized prefix survival from the step just verified: request
+        # r survived position j iff it accepted >= j draft tokens; position j was
+        # observed iff verified at its full scheduled width and j <= width_r.
+        if self._prev_sched_l <= 0:
+            return
+        prev = prev_widths[idx_mapping]
+        full = (num_sampled[:num_reqs] + num_rejected[:num_reqs]) == (1 + prev)
+        accepted = (num_sampled[:num_reqs] - 1).clamp_(min=0)
+        observed_j = (prev.unsqueeze(1) >= self._pos_arange) & full.unsqueeze(1)
+        surv_j = (accepted.unsqueeze(1) >= self._pos_arange) & observed_j
+        self._acc_counts += surv_j.sum(dim=0, dtype=torch.float32)
+        self._obs_counts += observed_j.sum(dim=0, dtype=torch.float32)
+        self._pred_counts += (self._surv_state[idx_mapping] * observed_j).sum(dim=0)
+
+    def begin_step(self, now: float, num_reqs: int) -> int:
+        """Observe engine overhead, then choose this step's uniform verify length."""
+        # Overhead observation: wall dt minus the prior step's GPU-only prediction,
+        # regressed against generated tokens (the O the GPU table cannot see).
+        if self._last_t is not None and self._last_gpu_pred > 0.0:
+            o = (now - self._last_t) - self._last_gpu_pred
+            if 0.0 <= o < OVERHEAD_SAMPLE_GATE:
+                self._o_samples.append((self._last_tokens, o))
+                if len(self._o_samples) > OVERHEAD_RING_SIZE:
+                    del self._o_samples[0]
+                if len(self._o_samples) >= OVERHEAD_MIN_SAMPLES:
+                    n = len(self._o_samples)
+                    mx = sum(x for x, _ in self._o_samples) / n
+                    my = sum(y for _, y in self._o_samples) / n
+                    var = sum((x - mx) ** 2 for x, _ in self._o_samples)
+                    if var > 1e-6:
+                        cov = sum((x - mx) * (y - my) for x, y in self._o_samples)
+                        self._o_c1 = min(max(cov / var, 0.0), OVERHEAD_C1_CLAMP)
+                    self._o_c0 = max(my - self._o_c1 * mx, 0.0)
+        self._last_t = now
+
+        length = self.gamma
+        if self._surv_ema is not None:
+            # accept[L] = expected accepted draft tokens/req (cumulative CALIBRATED
+            # prefix-survival over the first L positions).
+            accept = [0.0]
+            run = 0.0
+            for s, k in zip(self._surv_ema, self._cal):
+                run += min(s * k, 1.0)
+                accept.append(run)
+            length, self._last_pred = schedule_uniform_length(
+                accept,
+                num_reqs,
+                self.gamma,
+                self._cost_r_grid,
+                self._cost_times_by_l,
+                overhead=(self._o_c0, self._o_c1),
+                current=self._last_l,
+            )
+            self._last_l = length
+            self._last_tokens = num_reqs * (1.0 + accept[length])
+            self._last_gpu_pred = self._last_pred - (
+                self._o_c0 + self._o_c1 * self._last_tokens
+            )
+        return length
+
+    def skip_next_overhead_sample(self) -> None:
+        # Engine-forced width (dynamic SD): no GPU-cost prediction was made, so the
+        # next overhead observation has nothing to regress against.
+        self._last_gpu_pred = 0.0
+
+    def update_survival(
+        self, survival_batch_view: torch.Tensor, idx_mapping: torch.Tensor
+    ) -> None:
+        # EMA the drafted step's survival, consume any landed host readout (+ online
+        # calibration), launch the next readout on cadence, and persist predictions
+        # req-state-indexed for the next step's realized-vs-predicted accumulation.
+        m = survival_batch_view.mean(dim=0)
+        if self._surv_ema_t is None:
+            self._surv_ema_t = m.clone()
+        else:
+            self._surv_ema_t.mul_(SURVIVAL_EMA_DECAY).add_(m, alpha=SURVIVAL_EMA_GAIN)
+        self._ema_ct += 1
+        # On CPU the host copies are synchronous, so a launched readout is always
+        # ready; on CUDA this is exactly self._surv_evt.query() (byte-identical).
+        if self._surv_inflight and (not self._is_cuda or self._surv_evt.query()):
+            rows = self._surv_host.tolist()
+            self._surv_ema = rows[0]
+            cal_moved = False
+            for j in range(self.gamma):
+                d_obs = rows[2][j] - self._cal_prev_obs[j]
+                d_acc = rows[1][j] - self._cal_prev_acc[j]
+                d_pred = rows[3][j] - self._cal_prev_pred[j]
+                if d_obs >= CALIBRATION_MIN_OBS and d_pred > 1e-3:
+                    ratio = min(
+                        max(d_acc / d_pred, CALIBRATION_RATIO_MIN),
+                        CALIBRATION_RATIO_MAX,
+                    )
+                    self._cal[j] = (
+                        CALIBRATION_DECAY * self._cal[j] + CALIBRATION_GAIN * ratio
+                    )
+                    self._cal_prev_obs[j] = rows[2][j]
+                    self._cal_prev_acc[j] = rows[1][j]
+                    self._cal_prev_pred[j] = rows[3][j]
+                    cal_moved = True
+            if cal_moved:
+                self._cal_t.copy_(torch.tensor(self._cal, dtype=torch.float32))
+            self._surv_inflight = False
+        if not self._surv_inflight and self._ema_ct % READOUT_CADENCE == 0:
+            self._surv_host[0].copy_(self._surv_ema_t, non_blocking=True)
+            self._surv_host[1].copy_(self._acc_counts, non_blocking=True)
+            self._surv_host[2].copy_(self._obs_counts, non_blocking=True)
+            self._surv_host[3].copy_(self._pred_counts, non_blocking=True)
+            if self._is_cuda:
+                self._surv_evt.record()
+            self._surv_inflight = True
+        self._surv_state[idx_mapping] = survival_batch_view
+
+    def allocate(
+        self, survival_batch_view: torch.Tensor, num_reqs: int, length: int
+    ) -> torch.Tensor:
+        return allocate_widths(
+            survival_batch_view,
+            self._cal_t,
+            num_reqs,
+            length,
+            self.tau,
+            self._budget_frac,
+        )
+
+    def confidence_widths(
+        self, survival_batch_view: torch.Tensor, length: int
+    ) -> torch.Tensor:
+        # Static confidence-threshold prefix width (survival is a cumprod).
+        return (survival_batch_view[:, :length] >= self.tau).sum(
+            dim=1, dtype=torch.int32
+        )
+
+    def commit_length(self, length: int) -> None:
+        self._prev_sched_l = length

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -23,14 +23,17 @@ CUDA graphs (FULL, mirroring DFlash) cover the whole draft step: the parallel
 backbone forward AND the sequential Markov sampling.
 """
 
+import time
 from typing import Any
 
 import torch
 
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
+from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
 from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
+from vllm.v1.worker.gpu.spec_decode.dspark.scheduler import DSparkScheduler
 from vllm.v1.worker.gpu.spec_decode.dspark.utils import load_dspark_model
 
 
@@ -74,12 +77,59 @@ class DSparkSpeculator(DFlashSpeculator):
         self._d2t_scatter_index: torch.Tensor | None = None
         self._draft_scatter_buf: torch.Tensor | None = None
 
+        # Confidence head + hardware-aware scheduler (opt-in): adapts a
+        # per-step uniform verify length L; DSparkScheduler owns all policy
+        # state. Read at init so the confidence ops enter the draft graph.
+        spec_cfg = vllm_config.speculative_config
+        assert spec_cfg is not None
+        self._sched = spec_cfg.dspark_scheduler
+        self.dspark_scheduler_enabled = self._sched
+        if self._sched:
+            gamma = self.num_speculative_steps
+            self._survival = torch.zeros(
+                self.max_num_reqs, gamma, dtype=torch.float32, device=device
+            )
+            self._scheduler = DSparkScheduler(
+                spec_cfg, gamma, self.max_num_reqs, device
+            )
+            # Positions beyond valid_draft_len[r] are pads the rejection
+            # sampler force-rejects. Created only with a confidence threshold;
+            # otherwise the runner passes None and the mask path costs nothing.
+            self._tau = spec_cfg.dspark_confidence_threshold
+            self._perreq = spec_cfg.dspark_per_request
+            if self._tau > 0.0:
+                self.valid_draft_len = torch.full(
+                    (self.max_num_reqs,), gamma, dtype=torch.int32, device=device
+                )
+            # Dynamic SD: the runner writes the engine-scheduled next-step width
+            # here (0 -> skip drafting); the engine decision is authoritative.
+            self.next_k_hint: int | None = None
+            # Ask the runner to capture FULL decode graphs at every trimmed width
+            # 1+L (L in 0..gamma-1); 1+gamma is already the decode_query_len graph.
+            self.extra_uniform_decode_lens = list(range(1, gamma + 1))
+            # perreq_len is req-state-indexed; _perreq_batch_len is the batch-ordered
+            # view handed to the draft-tokens handler in the same step.
+            self.perreq_len = torch.zeros(
+                self.max_num_reqs, dtype=torch.int32, device=device
+            )
+            self._perreq_batch_len: torch.Tensor | None = None
+
+    def set_cost_table(self, r_grid: list[int], times_by_l: list[list[float]]) -> None:
+        """Install the shape-aware cost table T(R, L) on the scheduler policy."""
+        self._scheduler.set_cost_table(r_grid, times_by_l)
+
     def load_draft_model(
         self,
         target_model: torch.nn.Module,
         target_attn_layer_names: set[str],
     ) -> torch.nn.Module:
         model = load_dspark_model(target_model, self.vllm_config)
+        if self._sched and getattr(model, "compute_confidence", None) is None:
+            raise ValueError(
+                "dspark_scheduler requires a draft model with a confidence "
+                f"head; {type(model).__name__} does not implement "
+                "compute_confidence."
+            )
         # Reduced draft vocab: probabilistic rejection sampling indexes draft
         # logits by target id, so precompute the draft->target column map and a
         # scratch buffer to scatter logits into target vocab before sampling.
@@ -98,6 +148,78 @@ class DSparkSpeculator(DFlashSpeculator):
             )
         return model
 
+    def _schedule_draft_len(
+        self,
+        input_batch: InputBatch,
+        num_sampled: torch.Tensor,
+        num_rejected: torch.Tensor,
+        dummy_run: bool,
+    ) -> int:
+        # Pick this step's uniform verify length L in [0, gamma]: L < gamma
+        # trims the verify tail, L == 0 skips drafting. Observe realized
+        # survival from the just-verified step first, then decide.
+        if not self._sched or dummy_run:
+            return self.num_speculative_steps
+        now = time.perf_counter()
+        self._scheduler.observe_verified(
+            input_batch.num_reqs,
+            num_sampled,
+            num_rejected,
+            self.perreq_len,
+            input_batch.idx_mapping,
+        )
+        length = self._scheduler.begin_step(now, input_batch.num_reqs)
+        if self.next_k_hint is not None:
+            # Dynamic SD: the engine's scheduled width is authoritative.
+            length = min(self.next_k_hint, self.num_speculative_steps)
+            self._scheduler.skip_next_overhead_sample()
+        return length
+
+    def _finalize_draft(
+        self,
+        input_batch: InputBatch,
+        num_reqs: int,
+        draft_len: int,
+        dummy_run: bool,
+    ) -> torch.Tensor:
+        if not self._sched or dummy_run:
+            return self.draft_tokens[:num_reqs]
+        length = draft_len
+        if length == 0:
+            # Draft forward skipped -> empty draft; the engine runs a
+            # normal decode step for this batch.
+            self._scheduler.commit_length(0)
+            self.perreq_len[input_batch.idx_mapping] = 0
+            self._perreq_batch_len = None
+            return self.draft_tokens[:num_reqs, :0]
+        # The full block always runs under its captured graph, so survival is
+        # measured for all gamma positions; update the EMA, then allocate.
+        sv = self._survival[:num_reqs]
+        self._scheduler.update_survival(sv, input_batch.idx_mapping)
+        if self._perreq:
+            # Per-request allocation (paper Algorithm 1) within the batch
+            # width budget; ragged lengths cut the returned full-width block.
+            keep = self._scheduler.allocate(sv, num_reqs, length)
+            self.perreq_len[input_batch.idx_mapping] = keep
+            self._perreq_batch_len = keep
+            length = self.num_speculative_steps
+        elif self._tau > 0.0:
+            # Per-request confidence cutoff: keep each request's prefix while
+            # survival >= tau, pad the rest to the uniform width.
+            keep_len = self._scheduler.confidence_widths(sv, length)
+            pad = self._step_cols[:length].unsqueeze(0) >= keep_len.unsqueeze(1)
+            self.draft_tokens[:num_reqs, :length].masked_fill_(
+                pad, self.parallel_drafting_token_id
+            )
+            self.valid_draft_len[input_batch.idx_mapping] = keep_len
+        if not self._perreq:
+            self.perreq_len[input_batch.idx_mapping] = length
+            self._perreq_batch_len = None
+        self._scheduler.commit_length(length)
+        # Trim to the chosen verify length; with the multi-width FULL graphs
+        # captured, the trimmed verify replays FULL, else it falls to PIECEWISE.
+        return self.draft_tokens[:num_reqs, :length]
+
     def _sample_sequential(self, num_reqs: int, head_hidden: torch.Tensor) -> None:
         # Sequential Markov sampling over the backbone's output hidden states.
         n_spec = self.num_speculative_steps
@@ -115,10 +237,20 @@ class DSparkSpeculator(DFlashSpeculator):
         # Anchor (bonus) token per request = the input id at query offset 0,
         # read via the precomputed persistent index (fixed buffer for capture).
         prev = self.input_buffers.input_ids[self._anchor_idx[:num_reqs]]
+        # Per-position head hidden [num_reqs, n_spec, hidden] for the confidence head.
+        sh = sample_hidden.view(num_reqs, n_spec, -1) if self._sched else None
+        surv_run: torch.Tensor | None = None
 
         for i in range(n_spec):
             # Sequential stage: Markov bias from the previously sampled token.
             markov_embed = self.model.markov_embed(prev)
+            if self._sched:
+                # Confidence head -> per-position acceptance prob; cumulative product
+                # is the prefix-survival prob the scheduler turns into a verify length.
+                conf_i = self.model.compute_confidence(sh[:, i], markov_embed)
+                conf_i = conf_i.reshape(num_reqs).sigmoid()
+                surv_run = conf_i if surv_run is None else surv_run * conf_i
+                self._survival[:num_reqs, i] = surv_run
             bias = self.model.markov_bias(markov_embed)
             logits_i = base_logits[:, i] + bias
             if self.draft_logits is not None:

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -103,12 +103,22 @@ class RejectionSampler:
         logits: torch.Tensor,
         input_batch: InputBatch,
         draft_logits: torch.Tensor | None = None,
+        valid_draft_len: torch.Tensor | None = None,
     ) -> SamplerOutput:
         # NOTE(woosuk): We intentionally compute num_nans before sampling to make clear
         # that num_nans is computed before applying penalties and temperature.
         num_nans = get_num_nans(logits) if self.sampler.compute_nans else None
 
         draft_sampled = input_batch.input_ids[input_batch.logits_indices]
+        if valid_draft_len is not None:
+            # Draft position i (1-indexed) of request r is a pad iff
+            # i > valid_draft_len[r]; the -1 sentinel makes the kernel
+            # force-reject pads and resample at the first pad position.
+            keep = (
+                input_batch.expanded_local_pos
+                <= valid_draft_len[input_batch.expanded_idx_mapping]
+            )
+            draft_sampled = torch.where(keep, draft_sampled, -1)
         pos = input_batch.positions[input_batch.logits_indices]
         processed_logits = self.sampler.apply_sampling_params(
             logits,

--- a/vllm/v1/worker/gpu/spec_decode/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/utils.py
@@ -16,35 +16,58 @@ class DraftTokensHandler:
 
         self.req_ids: list[str] = []
         self.draft_tokens_np: np.ndarray | None = None
+        self.lengths_np: np.ndarray | None = None
         self.num_draft_tokens: int = 0
 
     def set_draft_tokens(
-        self, input_batch: InputBatch, draft_tokens: torch.Tensor
+        self,
+        input_batch: InputBatch,
+        draft_tokens: torch.Tensor,
+        lengths: torch.Tensor | None = None,
     ) -> None:
         self.req_ids = input_batch.req_ids
         self.num_draft_tokens = draft_tokens.shape[1]
-        if not input_batch.has_structured_output_reqs:
+        self.lengths_np = None
+        needs_copy = input_batch.has_structured_output_reqs or lengths is not None
+        if not needs_copy:
             # No draft token validation needs to be performed by
             # the scheduler for this batch.
             self.draft_tokens_np = None
             return
 
-        # For spec decoding + structured outputs, we must transfer the
-        # draft tokens back to the scheduler for grammar validation.
+        # For spec decoding + structured outputs (and for per-request draft
+        # lengths), transfer back to the scheduler asynchronously.
         current_stream = torch.cuda.current_stream(self.device)
         self.copy_stream.wait_stream(current_stream)
         with torch.cuda.stream(self.copy_stream):
-            self.draft_tokens_np = async_copy_to_np(draft_tokens)
-            # draft_tokens is a temporary allocation on the main stream and read here on
-            # copy_stream; without record_stream, the caching allocator may reuse its
-            # memory before the async copy executes.
-            draft_tokens.record_stream(self.copy_stream)
+            if input_batch.has_structured_output_reqs:
+                self.draft_tokens_np = async_copy_to_np(draft_tokens)
+                # draft_tokens is a temporary allocation on the main stream and
+                # read here on copy_stream; without record_stream, the caching
+                # allocator may reuse its memory before the async copy executes.
+                draft_tokens.record_stream(self.copy_stream)
+            else:
+                self.draft_tokens_np = None
+            if lengths is not None:
+                self.lengths_np = async_copy_to_np(lengths)
+                lengths.record_stream(self.copy_stream)
             self.copy_event.record()
 
     def get_draft_tokens(self) -> DraftTokenIds | None:
-        if self.draft_tokens_np is not None:
+        lengths = None
+        if self.lengths_np is not None or self.draft_tokens_np is not None:
             self.copy_event.synchronize()
-            draft_token_ids = self.draft_tokens_np.tolist()
+            if self.lengths_np is not None:
+                lengths = [int(n) for n in self.lengths_np]
+        if self.draft_tokens_np is not None:
+            rows = self.draft_tokens_np.tolist()
+            if lengths is not None:
+                draft_token_ids = [row[:n] for row, n in zip(rows, lengths)]
+            else:
+                draft_token_ids = rows
+        elif lengths is not None:
+            # Per-request draft counts; ids stay GPU-side (-1 placeholders).
+            draft_token_ids = [[-1] * n for n in lengths]
         else:
             # This case only happens when async scheduling is disabled.
             draft_token_ids = [[-1] * self.num_draft_tokens for _ in self.req_ids]

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -905,6 +905,16 @@ class Worker(WorkerBase):
     def get_model(self) -> nn.Module:
         return self.model_runner.get_model()
 
+    def get_dspark_dynamic_sd_table(self) -> list[tuple[int, int, int]] | None:
+        getter = getattr(self.model_runner, "get_dspark_dynamic_sd_table", None)
+        return getter() if getter is not None else None
+
+    def get_dspark_cost_profile(
+        self,
+    ) -> tuple[list[int], list[list[float]]] | None:
+        getter = getattr(self.model_runner, "get_dspark_cost_profile", None)
+        return getter() if getter is not None else None
+
     def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
         return self.model_runner.get_supported_tasks()
 


### PR DESCRIPTION
> Opened as draft pending one full-scale GPU validation pass; benchmark figures final.

## Purpose

DSpark (#46995) drafts a fixed `num_speculative_tokens` per step. Its confidence head (in [DSpark paper](https://arxiv.org/abs/2606.19348) used to schedule per-request draft lengths)  is effectively unused in vLLM today: under async scheduling the engine pre-books placeholder widths before worker results arrive, so worker-side truncation never takes effect, and variable-width drafting is incompatible with FULL CUDA graph capture, forcing piecewise graphs or a fixed uniform draft length.

This PR makes DSpark's confidence scheduling graph-native on the V2 GPU model runner. Everything is opt-in via `--speculative-config '{..., "dspark_scheduler": true}'`; with it unset there is zero behavior change.

**Relation to existing work:** #46995 (merged; this PR sits on top of it and #47093) adds fixed-γ drafting only; #46910 discussion explicitly deferred confidence/scheduling. #45953 enables Dynamic SD (#32374) on V2 with full CUDA graphs and overlaps with this PR's *capture infrastructure* (multi-width FULL capture, V2 dynamic-SD gate lift - same files: `config/vllm.py`, `cudagraph_utils.py`). The scheduler itself does not overlap: #45953 selects a batch-uniform k from DSD's goodput heuristic, while this PR schedules from the DSpark confidence head with a profiled hardware cost table, adds per-request widths executed via pad-to-bucket under a single FULL replay, and self-derives the width schedule from realized acceptance. Whichever lands second rebases its capture layer onto the first. Happy to coordinate (cc @ekagra-ranjan). #47131 (D-Cut) adds confidence-threshold draft pruning for DFlash post-draft; this PR's `dspark_confidence_threshold` covers the analogous DSpark masking but goes further.

## Design

1. **Multi-width FULL graph capture**: uniform-decode graphs are captured for every draft width q ∈ 1..1+γ over the shared request-bucket grid; at replay a per-step uniform width selects a captured graph (first-fit dispatch).
2. **Hardware-aware width selection**: a shape-aware cost table T(R, L) is profiled at startup (ceiling-bucket lookup; no interpolation across dispatch cliffs). Each step, per-position survival from the confidence head (online-calibrated against realized acceptance, zero-sync double-buffered readout) is combined with the cost table to pick the throughput-optimal uniform width, with hysteresis and a two-term engine-overhead model.
3. **Per-request allocation + pad-to-bucket** (`dspark_per_request`, `dspark_pad_to_bucket`): Algorithm 1 of the DSpark paper (global greedy over cumulative survival) allocates per-request widths under the selected bucket; the ragged batch is padded back to the uniform width before dispatch (prefix-mode token combine, pad slots to `PAD_SLOT_ID`), so per-request truncation runs under a single FULL graph replay. Naive pad-to-max measured −25%; bucket-constrained allocation recovers it.
4. **Engine width channel**: the existing dynamic-SD schedule (`num_speculative_tokens_per_batch_size`) is extended to V2 (the V1-only gate and the forced PIECEWISE downgrade are lifted for this path), and the worker drafts exactly the engine-scheduled width (K-hint), so drafted widths match engine-booked placeholder widths under async scheduling; K=0 skips the draft forward entirely.
5. **Live table self-derivation**: the worker ships its startup cost profile to the engine once (`collective_rpc`); the engine measures per-position acceptance from verification results and re-derives the width schedule every 16k drafts. No offline tuning or warm-up run; a survival prior covers the cold start.

New config fields (validated, dependency-chained): `dspark_scheduler`, `dspark_per_request`, `dspark_pad_to_bucket`, `dspark_confidence_threshold`, `dspark_budget_frac`.

Additionally, `qwen3_dspark` now loads the confidence head its checkpoints already ship (previously skipped as "not wired"), so the scheduler also works with Qwen3 DSpark drafts on small GPUs; `load_draft_model` fails fast with a clear error if `dspark_scheduler` is enabled for a draft model without a confidence head.

**Why one PR:** the scheduler is only useful if its decisions are graph-dispatchable, and multi-width capture is only useful with something deciding widths - the pieces are required for each other making this PR self-contained. Happy to split if preferred and coordinate for better implementation.

## Testing

GSM8K 5-shot (full 1319 questions, dspark_Qwen3_8b_block7, dspark_scheduler=true): 
> **87.6%** strict-match  matches the model's reference score; mean drafted width 5.01 (γ=7) confirms the scheduler was actively trimming, 3.05 accepted tokens/draft.

Unit (CPU, no GPU): `pytest tests/v1/spec_decode/test_dspark_scheduler.py -q`  **28 passed** (pure functions: table derivation, Algorithm-1 allocation, uniform-length selection; stateful core: calibration, hysteresis, overhead regression; engine live re-derivation; config validation).

v1 suite differential: every failure also reproduces on the base commit in the same environment (`ours-only: 0`) - all attributed to environment (offline HF hub, missing optional deps), none to this PR.

E2E (B300, DeepSeek-V4-Flash-DSpark): serves and completes requests with the scheduler on and off; sustained-load stability verified at N=350; K=0 idle path exercised. GPU smoke (RTX PRO 6000, Qwen3-8B + `dspark_qwen3_8b_block7`): scheduler **off** is bit-neutral through the new hooks (identical draft/accept counts); scheduler **on** runs end-to-end — cost table profiled at startup, confidence path live every step.

### Benchmarks

DeepSeek-V4-Flash-DSpark on 1×B300, async scheduling, T=1.0 (paper protocol), MAXTOK=128, six concurrency points. Baselines: no-spec, MTP-1, MTP-3, fixed DSpark γ=5 and γ=3 (best-tuned static config).

| tok/s | N=10 | N=100 | N=200 | N=250 | N=300 | N=350 |
|---|---|---|---|---|---|---|
| no-spec | 722 | 2872 | 4075 | 4802 | 4762 | 5760 |
| MTP-1 | 938 | 3413 | 4729 | 5285 | 3767 | 4682 |
| MTP-3 | 936 | 3030 | 3061 | 3403 | 4498 | 5008 |
| DSpark γ=5 | 1051 | 2271 | 3445 | 3941 | 4692 | 5103 |
| DSpark γ=3 | 1045 | 3398 | 3355 | 4406 | 5300 | 5846 |
| **ours** | 969 | 3154 | **4214** | **5490** | **5721** | 5677 |

- Beats the best static config (γ=3) by **+26% / +25% / +8%** at N=200/250/300; best overall at N=250–300.
- Behind at N≤100 (−7%): jagged small-R rows in the profiled cost table.
- Acceptance-rate reproduction of paper Fig. 5 (82–86% at τ=0.7) and load-adaptive budget restriction (Fig. 8 behavior) verified separately.
- Live self-derivation validated in a separate epoch: measured survival replaces the prior after ~16k drafts with no throughput regression vs γ=3 measured in the same sitting (mean ours/γ3 ratio 1.06 vs 1.07; run-to-run noise ±12% dominates).

 (6-config matrix):
<img width="1430" height="1430" alt="dspark_pr_bench" src="https://github.com/user-attachments/assets/0e84c031-c508-4879-bd1f-2f5ec67c2606" />


DSpark paper Fig. 5 reproduction:
<img width="1820" height="598" alt="dspark_fig5_vllm" src="https://github.com/user-attachments/assets/917aa93a-0aab-41b9-92fa-5d44c0f8a901" />


<details><summary>Launch commands</summary>
<p>

```bash
# Ours (scheduler + per-request + pad-to-bucket ride on dspark_scheduler=true defaults)
VLLM_USE_V2_MODEL_RUNNER=1 vllm serve deepseek-ai/DeepSeek-V4-Flash-DSpark \
    --trust-remote-code --kv-cache-dtype fp8_ds_mla \
    --compilation-config '{"max_cudagraph_capture_size":1536}' \
    --speculative-config '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic","dspark_scheduler":true}'

# Fixed-gamma baseline: same command without dspark_scheduler (zero behavior change path)
```

</p>
</details>

## AI assistance disclosure

This PR was developed with AI assistance (Claude). The submitting human has reviewed every changed line, run the tests above, and can defend the change end-to-end. Duplicate-work checks were performed before submission.
