### PR TITLE
[Quantization] Fix NVFP4 per-half global scale for fused gate_up_proj

### DIFF
--- a/tests/quantization/test_nvfp4_partition_rescale.py
+++ b/tests/quantization/test_nvfp4_partition_rescale.py
@@ -8,9 +8,6 @@ layers (e.g. gate_up_proj) have non-uniform weight_global_scale values.
 Run: pytest tests/quantization/test_nvfp4_partition_rescale.py -v
 """
 
-from unittest.mock import MagicMock
-
-import pytest
 import torch
 from torch.nn.parameter import Parameter
 
@@ -54,9 +51,7 @@ def _make_layer(logical_widths, weight_global_scale_values, use_a16=True):
 
     if not use_a16:
         layer.input_global_scale = Parameter(
-            torch.tensor(
-                [1.0] * len(logical_widths), dtype=torch.float32
-            ),
+            torch.tensor([1.0] * len(logical_widths), dtype=torch.float32),
             requires_grad=False,
         )
 

--- a/tests/quantization/test_nvfp4_partition_rescale.py
+++ b/tests/quantization/test_nvfp4_partition_rescale.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for NVFP4 per-partition output rescaling.
+
+Tests the rescale logic in CompressedTensorsW4A4Fp4 when fused linear
+layers (e.g. gate_up_proj) have non-uniform weight_global_scale values.
+
+Run: pytest tests/quantization/test_nvfp4_partition_rescale.py -v
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from torch.nn.parameter import Parameter
+
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w4a4_nvfp4 import (  # noqa: E501
+    CompressedTensorsW4A4Fp4,
+)
+
+
+class FakeKernel:
+    """Minimal stub that returns a fixed output tensor."""
+
+    def __init__(self, output: torch.Tensor):
+        self._output = output
+
+    def apply_weights(self, layer, x, bias=None):
+        out = self._output.clone()
+        if bias is not None:
+            out = out + bias
+        return out
+
+    def process_weights_after_loading(self, layer):
+        pass
+
+
+def _make_layer(logical_widths, weight_global_scale_values, use_a16=True):
+    """Build a minimal nn.Module that mimics a CT-loaded NVFP4 layer."""
+    layer = torch.nn.Module()
+    layer.logical_widths = logical_widths
+    total_out = sum(logical_widths)
+
+    layer.weight_packed = Parameter(
+        torch.zeros(total_out, 8, dtype=torch.uint8), requires_grad=False
+    )
+    layer.weight_global_scale = Parameter(
+        torch.tensor(weight_global_scale_values, dtype=torch.float32),
+        requires_grad=False,
+    )
+    layer.weight_scale = Parameter(
+        torch.ones(total_out, 1, dtype=torch.float32), requires_grad=False
+    )
+
+    if not use_a16:
+        layer.input_global_scale = Parameter(
+            torch.tensor(
+                [1.0] * len(logical_widths), dtype=torch.float32
+            ),
+            requires_grad=False,
+        )
+
+    return layer
+
+
+class TestNonUniformTwoPartitionRescale:
+    """Non-uniform two-partition layers should get per-partition rescaling."""
+
+    def test_numerical_recovery(self):
+        """Rescaled output matches per-partition independent GEMM."""
+        logical_widths = [2, 2]
+        # CT divisors: gate=100, up=200
+        layer = _make_layer(logical_widths, [100.0, 200.0])
+
+        fake_output = torch.tensor([[10.0, 20.0, 30.0, 40.0]])
+        scheme = CompressedTensorsW4A4Fp4(use_a16=True)
+        scheme.kernel = FakeKernel(fake_output)
+
+        scheme.process_weights_after_loading(layer)
+
+        assert layer._output_partition_rescale is not None
+        rescale = layer._output_partition_rescale.data
+        # base = min(100, 200) = 100
+        # gate rescale = 100/100 = 1.0, up rescale = 100/200 = 0.5
+        assert torch.allclose(rescale, torch.tensor([1.0, 1.0, 0.5, 0.5]))
+
+        x_dummy = torch.randn(1, 16)
+        out = scheme.apply_weights(layer, x_dummy)
+        expected = torch.tensor([[10.0, 20.0, 15.0, 20.0]])
+        assert torch.allclose(out, expected)
+
+    def test_bias_not_rescaled(self):
+        """Bias is added after rescaling, so it is not multiplied."""
+        logical_widths = [2, 2]
+        layer = _make_layer(logical_widths, [100.0, 200.0])
+
+        fake_output = torch.tensor([[10.0, 20.0, 30.0, 40.0]])
+        scheme = CompressedTensorsW4A4Fp4(use_a16=True)
+        scheme.kernel = FakeKernel(fake_output)
+
+        scheme.process_weights_after_loading(layer)
+
+        bias = torch.tensor([1.0, 1.0, 1.0, 1.0])
+        x_dummy = torch.randn(1, 16)
+        out = scheme.apply_weights(layer, x_dummy, bias=bias)
+        # [10*1+1, 20*1+1, 30*0.5+1, 40*0.5+1]
+        expected = torch.tensor([[11.0, 21.0, 16.0, 21.0]])
+        assert torch.allclose(out, expected)
+
+    def test_unequal_partition_widths(self):
+        """Non-equal partition widths should be handled correctly."""
+        logical_widths = [3, 5]
+        layer = _make_layer(logical_widths, [100.0, 200.0])
+
+        fake_output = torch.ones(1, 8) * 10.0
+        scheme = CompressedTensorsW4A4Fp4(use_a16=True)
+        scheme.kernel = FakeKernel(fake_output)
+
+        scheme.process_weights_after_loading(layer)
+
+        rescale = layer._output_partition_rescale.data
+        assert rescale.shape == (8,)
+        assert torch.allclose(rescale[:3], torch.tensor([1.0, 1.0, 1.0]))
+        assert torch.allclose(rescale[3:], torch.tensor([0.5] * 5))
+
+
+class TestUniformTwoPartition:
+    """Uniform two-partition layers should NOT get rescaling."""
+
+    def test_no_rescale_when_uniform(self):
+        logical_widths = [2, 2]
+        layer = _make_layer(logical_widths, [100.0, 100.0])
+
+        fake_output = torch.tensor([[10.0, 20.0, 30.0, 40.0]])
+        scheme = CompressedTensorsW4A4Fp4(use_a16=True)
+        scheme.kernel = FakeKernel(fake_output)
+
+        scheme.process_weights_after_loading(layer)
+
+        assert layer._output_partition_rescale is None
+
+        x_dummy = torch.randn(1, 16)
+        bias = torch.tensor([1.0, 1.0, 1.0, 1.0])
+        out = scheme.apply_weights(layer, x_dummy, bias=bias)
+        # Kernel receives bias directly
+        expected = torch.tensor([[11.0, 21.0, 31.0, 41.0]])
+        assert torch.allclose(out, expected)
+
+
+class TestThreePartitionUnaffected:
+    """Three-partition layers (e.g. QKV) should not enter rescale path."""
+
+    def test_qkv_no_rescale(self):
+        logical_widths = [4, 2, 2]
+        layer = _make_layer(logical_widths, [100.0, 120.0, 140.0])
+
+        fake_output = torch.ones(1, 8) * 10.0
+        scheme = CompressedTensorsW4A4Fp4(use_a16=True)
+        scheme.kernel = FakeKernel(fake_output)
+
+        scheme.process_weights_after_loading(layer)
+
+        assert layer._output_partition_rescale is None
+
+        # weight_global_scale should use max() = 140.0
+        assert torch.allclose(
+            layer.weight_global_scale,
+            torch.tensor(1.0 / 140.0),
+        )

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -97,46 +97,61 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
         layer.weight = layer.weight_packed
         del layer.weight_packed
 
-        # Handle per-half weight global scales for fused gate_up_proj layers.
-        # When gate_proj and up_proj have independent global scales (e.g. from
-        # llmcompressor with per-tensor observers), using a single max() would
-        # over-scale one half. We pre-compute a rescale vector instead.
-        ws2 = layer.weight_global_scale.data.float()
-        num_partitions = len(layer.logical_widths)
+        weight_global_scales = layer.weight_global_scale.detach().to(
+            torch.float32
+        )
+        has_non_uniform_scales = not torch.allclose(
+            weight_global_scales,
+            weight_global_scales[0].expand_as(weight_global_scales),
+        )
 
-        if num_partitions == 2 and not torch.allclose(ws2[0:1], ws2[1:2]):
-            # CT stores divisors: min(divisor) corresponds to max(absmax),
-            # which is the correct unified base for the fused GEMM alpha.
-            weight_global_scale = ws2.min().to(torch.float32)
-            gate_size = layer.logical_widths[0]
-            up_size = layer.logical_widths[1]
-            rescale = torch.ones(
-                gate_size + up_size,
+        output_partition_rescale = None
+
+        if len(layer.logical_widths) == 2 and has_non_uniform_scales:
+            # Use the minimum divisor as the common base so that all
+            # post-GEMM correction factors are <= 1.
+            base_divisor = weight_global_scales.min()
+
+            output_partition_rescale = torch.empty(
+                sum(layer.logical_widths),
                 dtype=torch.float32,
-                device=layer.weight_global_scale.device,
+                device=weight_global_scales.device,
             )
-            rescale[:gate_size] = ws2.min() / ws2[0]
-            rescale[gate_size:gate_size + up_size] = ws2.min() / ws2[1]
-            layer._per_half_rescale = Parameter(rescale, requires_grad=False)
-            logger.info(
-                "NVFP4 per-half scale detected: gate_s2=%.1f, up_s2=%.1f, "
-                "rescale factors=[%.4f, %.4f]",
-                ws2[0].item(),
-                ws2[1].item(),
-                rescale[0].item(),
-                rescale[gate_size].item(),
-            )
-        else:
-            if torch.unique(ws2).numel() != 1:
-                logger.warning_once(
-                    "In NVFP4 linear, the weight global scale is different"
-                    " for parallel layers (e.g. q_proj, k_proj, v_proj). This"
-                    " will likely result in reduced accuracy. Please verify the"
-                    " model accuracy. Consider using a checkpoint with a shared"
-                    " global NVFP4 scale for fused layers."
+            offset = 0
+            for width, partition_divisor in zip(
+                layer.logical_widths, weight_global_scales
+            ):
+                output_partition_rescale[offset:offset + width] = (
+                    base_divisor / partition_divisor
                 )
-            weight_global_scale = ws2.max().to(torch.float32)
-            layer._per_half_rescale = None
+                offset += width
+
+            logger.warning_once(
+                "Detected non-uniform NVFP4 weight global scales in a "
+                "two-partition fused linear layer. Applying per-partition "
+                "output rescaling."
+            )
+            logger.debug(
+                "NVFP4 partition scales=%s, rescale=%s",
+                weight_global_scales.tolist(),
+                output_partition_rescale.tolist(),
+            )
+
+            weight_global_scale = base_divisor
+        else:
+            if has_non_uniform_scales:
+                logger.warning_once(
+                    "In NVFP4 linear, the weight global scale differs "
+                    "across fused logical partitions. This may reduce "
+                    "model accuracy."
+                )
+            weight_global_scale = weight_global_scales.max()
+
+        layer._output_partition_rescale = (
+            Parameter(output_partition_rescale, requires_grad=False)
+            if output_partition_rescale is not None
+            else None
+        )
 
         # Process weight global scale (CT stores as divisors, i.e. 1/scale)
         layer.weight_global_scale = Parameter(
@@ -176,10 +191,10 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        rescale = getattr(layer, "_per_half_rescale", None)
+        rescale = getattr(layer, "_output_partition_rescale", None)
         if rescale is not None:
             out = self.kernel.apply_weights(layer=layer, x=x, bias=None)
-            out = out * rescale.to(out.dtype)
+            out = out * rescale.to(dtype=out.dtype)
             if bias is not None:
                 out = out + bias
             return out

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -97,18 +97,48 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
         layer.weight = layer.weight_packed
         del layer.weight_packed
 
-        # Check for mismatched weight global scales
-        if torch.unique(layer.weight_global_scale).numel() != 1:
-            logger.warning_once(
-                "In NVFP4 linear, the weight global scale is different"
-                " for parallel layers (e.g. q_proj, k_proj, v_proj). This "
-                " will likely result in reduced accuracy. Please verify the model"
-                " accuracy. Consider using a checkpoint with a shared global NVFP4"
-                " scale for fused layers."
+        # Handle per-half weight global scales for fused gate_up_proj layers.
+        # When gate_proj and up_proj have independent global scales (e.g. from
+        # llmcompressor with per-tensor observers), using a single max() would
+        # over-scale one half. We pre-compute a rescale vector instead.
+        ws2 = layer.weight_global_scale.data.float()
+        num_partitions = len(layer.logical_widths)
+
+        if num_partitions == 2 and not torch.allclose(ws2[0:1], ws2[1:2]):
+            # CT stores divisors: min(divisor) corresponds to max(absmax),
+            # which is the correct unified base for the fused GEMM alpha.
+            weight_global_scale = ws2.min().to(torch.float32)
+            gate_size = layer.logical_widths[0]
+            up_size = layer.logical_widths[1]
+            rescale = torch.ones(
+                gate_size + up_size,
+                dtype=torch.float32,
+                device=layer.weight_global_scale.device,
             )
+            rescale[:gate_size] = ws2.min() / ws2[0]
+            rescale[gate_size:gate_size + up_size] = ws2.min() / ws2[1]
+            layer._per_half_rescale = Parameter(rescale, requires_grad=False)
+            logger.info(
+                "NVFP4 per-half scale detected: gate_s2=%.1f, up_s2=%.1f, "
+                "rescale factors=[%.4f, %.4f]",
+                ws2[0].item(),
+                ws2[1].item(),
+                rescale[0].item(),
+                rescale[gate_size].item(),
+            )
+        else:
+            if torch.unique(ws2).numel() != 1:
+                logger.warning_once(
+                    "In NVFP4 linear, the weight global scale is different"
+                    " for parallel layers (e.g. q_proj, k_proj, v_proj). This"
+                    " will likely result in reduced accuracy. Please verify the"
+                    " model accuracy. Consider using a checkpoint with a shared"
+                    " global NVFP4 scale for fused layers."
+                )
+            weight_global_scale = ws2.max().to(torch.float32)
+            layer._per_half_rescale = None
 
         # Process weight global scale (CT stores as divisors, i.e. 1/scale)
-        weight_global_scale = layer.weight_global_scale.max().to(torch.float32)
         layer.weight_global_scale = Parameter(
             1.0 / weight_global_scale, requires_grad=False
         )
@@ -146,4 +176,11 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        rescale = getattr(layer, "_per_half_rescale", None)
+        if rescale is not None:
+            out = self.kernel.apply_weights(layer=layer, x=x, bias=None)
+            out = out * rescale.to(out.dtype)
+            if bias is not None:
+                out = out + bias
+            return out
         return self.kernel.apply_weights(layer=layer, x=x, bias=bias)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -97,9 +97,7 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
         layer.weight = layer.weight_packed
         del layer.weight_packed
 
-        weight_global_scales = layer.weight_global_scale.detach().to(
-            torch.float32
-        )
+        weight_global_scales = layer.weight_global_scale.detach().to(torch.float32)
         has_non_uniform_scales = not torch.allclose(
             weight_global_scales,
             weight_global_scales[0].expand_as(weight_global_scales),
@@ -121,7 +119,7 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
             for width, partition_divisor in zip(
                 layer.logical_widths, weight_global_scales
             ):
-                output_partition_rescale[offset:offset + width] = (
+                output_partition_rescale[offset : offset + width] = (
                     base_divisor / partition_divisor
                 )
                 offset += width


### PR DESCRIPTION
## Summary

In SwiGLU FFN, `gate_proj` (W1) and `up_proj` (W3) are fused into a single `gate_up_proj` matrix at inference time. NVFP4 quantization produces a per-tensor `weight_global_scale` (divisor) for each linear layer. When these two projections have different divisor values (non-uniform checkpoint, e.g. from llmcompressor with independent per-tensor observers), the current code merges them via `.max()`, which:

1. Picks the **largest divisor** (= smallest kernel multiplier) as the unified scale
2. Causes the partition with the smaller divisor to be **incorrectly scaled down**
3. **Breaks the gate/up ratio** that SwiGLU depends on, leading to accuracy degradation

Empirically, 33 out of 36 layers in a Qwen3-8B NVFP4 checkpoint have different gate vs up divisor values, with a max ratio of 2.14x.

## Changes

- **Detect** fused two-partition layers with non-uniform `weight_global_scale` via `len(logical_widths) == 2 && !allclose`
- **Pre-compute a rescale vector** in `process_weights_after_loading`: use `min(divisor)` as the unified base so that all post-GEMM correction factors are ≤ 1, then `rescale[partition_i] = base_divisor / partition_divisor`
- **Apply at runtime** in `apply_weights`: `out = kernel_gemm(x, w, unified_alpha); out = out * rescale` — a single broadcast multiply, no kernel modification needed
- **Non per-partition paths are unaffected**: layers with 3+ partitions (e.g. QKV), uniform-scale checkpoints, and legacy models all fall through to the original `.max()` logic

### Math

Let the checkpoint divisors be `s_0` and `s_1`. The kernel multiplier for each original projection is `1/s_i`. The fused kernel accepts one multiplier, so we choose `s_base = min(s_0, s_1)` and apply `r_i = s_base / s_i` after GEMM:

```
(acc_i / s_base) * (s_base / s_i) = acc_i / s_i
```

Choosing the minimum divisor keeps all correction factors at or below one, avoiding explicit amplification in the correction step. Note that compared to each partition using its own alpha directly in the GEMM epilogue, the additional cast and multiply may introduce minor rounding differences.

### Limitations

- This introduces one elementwise output rescaling operation per affected fused layer
- This patch only corrects weight global scales; non-uniform activation global scales cannot be exactly corrected after GEMM (the quantization grid loss is irreversible)
- The current implementation is intentionally limited to two-partition fused linears; the formula generalizes to N partitions but only gate/up has been validated

## Related

- [TokenSpeed PR #543](https://github.com/lightseekorg/tokenspeed/pull/543) — TRT-LLM side per-half support

## Test plan

Added unit tests in `tests/quantization/test_nvfp4_partition_rescale.py`:

- [x] Non-uniform two-partition numerical recovery (divisors 100 vs 200)
- [x] Bias is added after rescaling, not multiplied by rescale factor
- [x] Unequal partition widths (3+5) handled correctly
- [x] Uniform two-partition produces no rescale (`_output_partition_rescale is None`)
- [x] Three-partition (QKV) layers do not enter rescale path, use `.max()` as before