### PR TITLE
[ROCm][DSV4] Enable fused AITER mHC post+pre kernel for decode

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -23,6 +23,14 @@ try:
 except ImportError:
     pd = PlaceholderModule("pandas")
 
+# Upper token-count bound for using AITER's fused post+pre kernel. Above this we
+# fall back to unfused aiter (mhc_post + mhc_pre): on gfx950 the fused kernel
+# regresses ~14% in a bubble near m~=768 (aiter fuses up to m<1024), and this
+# also matches the max decode CUDA-graph size (512), so every captured decode
+# step fuses while larger mixed/prefill steps take the faster unfused path.
+AITER_MHC_FUSED_MAX_M = 512
+
+
 # fp8_dtype is not cached.
 # on ROCm the fp8_dtype always calls is_fp8_fnuz
 # which is a host op, so we cache it once here.
@@ -3088,6 +3096,78 @@ class rocm_aiter_ops:
             comb_res_mix.view(num_tokens, hc_mult, hc_mult),
         )
         return out.view_as(residual)
+
+    @staticmethod
+    def mhc_fused_post_pre(
+        x: torch.Tensor,
+        residual: torch.Tensor,
+        post_layer_mix: torch.Tensor,
+        comb_res_mix: torch.Tensor,
+        fn: torch.Tensor,
+        hc_scale: torch.Tensor,
+        hc_base: torch.Tensor,
+        rms_eps: float,
+        hc_pre_eps: float,
+        hc_sinkhorn_eps: float,
+        hc_post_mult_value: float,
+        sinkhorn_repeat: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Fused mHC post (layer N) + pre (layer N+1).
+
+        For m <= ``AITER_MHC_FUSED_MAX_M`` uses AITER's fused kernel; above that
+        (the gfx950 fused-kernel bubble and prefill/mixed steps) falls back to the
+        faster unfused aiter ``mhc_post`` + ``mhc_pre``. Either way returns
+        ``(next_residual, post_mix, comb_mix, layer_input)`` (AITER's fused call
+        returns ``(post_mix, comb_mix, layer_input, next_residual)``; we reorder).
+        """
+        hc_mult = residual.shape[-2]
+        hidden_size = residual.shape[-1]
+        outer_shape = residual.shape[:-2]
+        residual_flat = residual.view(-1, hc_mult, hidden_size)
+        num_tokens = residual_flat.shape[0]
+
+        if num_tokens == 0 or num_tokens > AITER_MHC_FUSED_MAX_M:
+            # Unfused aiter: post then next-layer pre (same 4-tuple contract).
+            next_residual = rocm_aiter_ops.mhc_post(
+                x, residual, post_layer_mix, comb_res_mix
+            )
+            post_mix, comb_mix, layer_input = rocm_aiter_ops.mhc_pre(
+                next_residual,
+                fn,
+                hc_scale,
+                hc_base,
+                rms_eps,
+                hc_pre_eps,
+                hc_sinkhorn_eps,
+                hc_post_mult_value,
+                sinkhorn_repeat,
+            )
+            return next_residual, post_mix, comb_mix, layer_input
+
+        from aiter.ops.mhc import mhc_fused_post_pre
+
+        # AITER's wrapper allocates without explicit device args; scope it.
+        with torch.device(residual_flat.device):
+            post_mix, comb_mix, layer_input, next_residual = mhc_fused_post_pre(
+                x.view(num_tokens, hidden_size),
+                residual_flat,
+                post_layer_mix.view(num_tokens, hc_mult, 1),
+                comb_res_mix.view(num_tokens, hc_mult, hc_mult),
+                fn,
+                hc_scale,
+                hc_base,
+                rms_eps,
+                hc_pre_eps,
+                hc_sinkhorn_eps,
+                hc_post_mult_value,
+                sinkhorn_repeat,
+            )
+        return (
+            next_residual.view(*outer_shape, hc_mult, hidden_size),
+            post_mix.view(*outer_shape, hc_mult, 1),
+            comb_mix.view(*outer_shape, hc_mult, hc_mult),
+            layer_input.view(*outer_shape, hidden_size),
+        )
 
 
 rocm_aiter_ops.register_ops_once()

--- a/vllm/model_executor/kernels/mhc/aiter.py
+++ b/vllm/model_executor/kernels/mhc/aiter.py
@@ -124,6 +124,84 @@ def _mhc_post_aiter_fake(
     return torch.empty_like(residual)
 
 
+def mhc_fused_post_pre_aiter(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    n_splits: int = 1,
+    tile_n: int = 1,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float = 0.0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fused mHC post + next-pre on AITER.
+
+    Returns ``(next_residual, post_mix, comb_mix, layer_input)``. The trailing
+    tilelang-only args (n_splits, tile_n, norm_weight, norm_eps) are accepted for
+    a uniform op signature but unused by AITER.
+    """
+    hidden_size = residual.shape[-1]
+    assert hidden_size % 256 == 0
+    from vllm._aiter_ops import rocm_aiter_ops
+
+    return rocm_aiter_ops.mhc_fused_post_pre(
+        x,
+        residual,
+        post_layer_mix,
+        comb_res_mix,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+        sinkhorn_repeat,
+    )
+
+
+def _mhc_fused_post_pre_aiter_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    n_splits: int = 1,
+    tile_n: int = 1,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float = 0.0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    hc_mult = residual.shape[-2]
+    hidden_size = residual.shape[-1]
+    outer_shape = residual.shape[:-2]
+    next_residual = torch.empty_like(residual)
+    post_mix = torch.empty(
+        *outer_shape, hc_mult, 1, dtype=torch.float32, device=residual.device
+    )
+    comb_mix = torch.empty(
+        *outer_shape, hc_mult, hc_mult, dtype=torch.float32, device=residual.device
+    )
+    layer_input = torch.empty(
+        *outer_shape, hidden_size, dtype=torch.bfloat16, device=residual.device
+    )
+    return next_residual, post_mix, comb_mix, layer_input
+
+
 direct_register_custom_op(
     op_name="mhc_pre_aiter",
     op_func=mhc_pre_aiter,
@@ -135,4 +213,10 @@ direct_register_custom_op(
     op_func=mhc_post_aiter,
     mutates_args=[],
     fake_impl=_mhc_post_aiter_fake,
+)
+direct_register_custom_op(
+    op_name="mhc_fused_post_pre_aiter",
+    op_func=mhc_fused_post_pre_aiter,
+    mutates_args=[],
+    fake_impl=_mhc_fused_post_pre_aiter_fake,
 )

--- a/vllm/model_executor/layers/mhc.py
+++ b/vllm/model_executor/layers/mhc.py
@@ -455,6 +455,28 @@ class MHCFusedPostPreOp(CustomOp):
         norm_weight: torch.Tensor | None = None,
         norm_eps: float = 0.0,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        # Priority: fused aiter (m<=512) -> unfused aiter (m>512, decided inside
+        # mhc_fused_post_pre_aiter) -> fused tilelang -> unfused torch reference.
+        hidden_size = residual.shape[-1]
+        if HAS_AITER_MHC and hidden_size % 256 == 0:
+            return torch.ops.vllm.mhc_fused_post_pre_aiter(
+                x,
+                residual,
+                post_layer_mix,
+                comb_res_mix,
+                fn,
+                hc_scale,
+                hc_base,
+                rms_eps,
+                hc_pre_eps,
+                hc_sinkhorn_eps,
+                hc_post_mult_value,
+                sinkhorn_repeat,
+                n_splits,
+                tile_n,
+                norm_weight,
+                norm_eps,
+            )
         if HAS_TILELANG_MHC:
             return torch.ops.vllm.mhc_fused_post_pre_tilelang(
                 x,

--- a/vllm/models/deepseek_v4/amd/model.py
+++ b/vllm/models/deepseek_v4/amd/model.py
@@ -304,8 +304,11 @@ class DeepseekV4DecoderLayer(nn.Module):
         self.mhc_pre = MHCPreOp()
         self.mhc_post = MHCPostOp()
         self.mhc_fused_post_pre = MHCFusedPostPreOp()
-        self.use_fused_mhc = HAS_TILELANG_MHC and not (
-            HAS_AITER_MHC and self.hidden_size % 256 == 0
+        # Prefer AITER's fused post+pre kernel when available; otherwise fall
+        # back to the tilelang fused path (only when the unfused aiter pre/post
+        # default is not in use).
+        self.use_fused_mhc = (HAS_AITER_MHC and self.hidden_size % 256 == 0) or (
+            HAS_TILELANG_MHC and not (HAS_AITER_MHC and self.hidden_size % 256 == 0)
         )
 
     def hc_pre(


### PR DESCRIPTION
## Summary

Follow-up to #43950, which made the **unfused** AITER mHC `pre`/`post` kernels the
default ROCm path for DeepSeek‑V4 and explicitly left the **fused** post+pre kernel
unused ("aiter provides unfused pre/post ops but no combined fused post+pre
alternative"). AITER does ship a fused `mhc_fused_post_pre` (it folds layer *N*'s
post-block and layer *N+1*'s pre-block into a single GEMM + sinkhorn), so this PR
wires it in and makes it the default for decode-sized batches on gfx950.

Changes:
- Add the `mhc_fused_post_pre_aiter` custom op (`vllm/_aiter_ops.py`,
  `vllm/model_executor/kernels/mhc/aiter.py`).
- Dispatch to it from `MHCFusedPostPreOp.forward_hip` and enable `use_fused_mhc`
  for the AITER path (`vllm/model_executor/layers/mhc.py`,
  `vllm/models/deepseek_v4/amd/model.py`).

## Selection logic

The mHC post+pre op resolves in this priority order:

```
fused AITER (m <= 512)  ->  unfused AITER (m > 512)  ->  fused TileLang  ->  torch reference
```

- **fused AITER (m ≤ 512):** AITER's `mhc_fused_post_pre` kernel.
- **unfused AITER (m > 512):** AITER `mhc_post` + `mhc_pre`. The split lives in
  `rocm_aiter_ops.mhc_fused_post_pre` via `AITER_MHC_FUSED_MAX_M = 512`. 512 is chosen
  because (a) it is the max decode CUDA-graph capture size, so every captured decode
  step fuses, and (b) on gfx950 the fused kernel regresses ~14% in a bubble near
  m≈768 (AITER's own wrapper only stops fusing at m ≥ 1024). Routing m > 512 to unfused
  avoids that bubble; its output is byte-identical to the unfused kernels, so mixed
  prefill/decode and prefill steps are unaffected.
- **fused TileLang / torch reference:** the existing fallbacks for non-AITER builds.
  (There is no dedicated Triton `mhc_post`/`mhc_pre`; Triton only backs `hc_head`, so
  the final reference tier is the torch decomposition.)

Return-order note: AITER returns `(post_mix, comb_mix, layer_input, next_residual)`
whereas the vLLM op contract is `(next_residual, post_mix, comb_mix, layer_input)`;
the wrapper reorders (getting this wrong silently produces garbage output).

## Performance

Measured on MI355X (gfx950) × 8, TP=8, DeepSeek‑V4‑Pro, full CUDA graphs, KV fp8,
AITER MoE. This is a **small decode-latency optimization** — honest numbers below.

Kernel microbenchmark (hidden=7168, hc_mult=4, sinkhorn=20): the fused kernel saves a
fixed ~4.3 µs/op (one fewer kernel launch), ~15% of the ~30 µs op for m ≤ 512; neutral
at m ≥ 1024; ~14% slower in the m≈768 bubble (now avoided by the cap).

End-to-end decode (short prompt, long generation), median TPOT, fused vs unfused
baseline (negative = fused faster):

| concurrency | TPOT Δ | notes |
|---:|---:|---|
| 1   | **−0.9%** | clean signal (deterministic single stream) |
| 32  | −0.6% | within run-to-run noise |
| 128 | +0.1% | within noise |
| 256 | +0.0% | within noise |

The per-token saving is ~constant (~0.2 ms/token), which is ~1% of TPOT at conc=1 and
a shrinking, sub-noise fraction as concurrency (and per-request TPOT jitter) grow. No
regression in decode or prefill; prefill (m ≥ 1024) is unchanged.

## Correctness / tests

- End-to-end gsm8k (LIMIT=100, `exact_match,strict-match`) on DeepSeek‑V4‑Pro, TP=8:
  fused default = **0.99** (unfused baseline ≈ 1.0; an earlier wiring with the wrong
  return order gave 0.0). Both the fused decode path (m ≤ 512) and the unfused
  fallback (m > 512, prefill) are exercised.
- Op-level parity: `mhc_fused_post_pre_aiter` vs unfused `mhc_post_aiter` +
  `mhc_pre_aiter` on identical inputs — `next_residual` bit-exact for all m; for m > 512
  every output byte-identical to the unfused baseline (0 diff); for m ≤ 512 within bf16
  tolerance.
- Existing mHC kernel unit tests still pass:
  `pytest tests/kernels/test_mhc_kernels.py -k "tilelang or hc_head"` → **43 passed,
  8 deselected in 51.57s**.
- `pre-commit`/ruff: clean on all changed files.

Note: like the merged AITER mHC support (#41946, #43950), the AITER mHC kernels are
validated end-to-end rather than by a Python kernel unit test — a torch GPU computation
immediately before an AITER mHC kernel can trip a pre-existing allocator-state-dependent
fault inside AITER (it affects the already-merged unfused `mhc_post`/`mhc_pre` kernels
too), so a `torch`-reference-vs-op microtest is not reliable for this path.

## Why this is not a duplicate

#43950 (merged) deliberately shipped only the unfused AITER pre/post and named the
fused post+pre as future work; no open PR wires the fused `mhc_fused_post_pre` kernel.
Related merged PRs (#41946 aiter mhc, #43679/#45931 TileLang mHC, #44692 big-fuse
bugfix) touch different kernels/paths.

## AI assistance

This change was developed with AI assistance (Claude). The human submitter has reviewed
every changed line and run the tests listed above.
