### PR TITLE
[ROCm][CI] Fix Kernels and Kernels attention test failures

### DIFF
--- a/tests/kernels/attention/test_rocm_aiter_mla_decode_metadata.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_decode_metadata.py
@@ -113,7 +113,7 @@ def _build_decode_metadata():
     # stub with the attribute is enough for metadata construction.
     layer_name = "placeholder"
     vllm_config.compilation_config.static_forward_context[layer_name] = (
-        types.SimpleNamespace(prefill_backend=None)
+        types.SimpleNamespace(prefill_backend=torch.empty((1,)))
     )
 
     init_workspace_manager(device)

--- a/tests/kernels/moe/test_ocp_mx_moe.py
+++ b/tests/kernels/moe/test_ocp_mx_moe.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import importlib.metadata
+import types
 from dataclasses import dataclass
 from importlib.util import find_spec
 
@@ -10,7 +11,7 @@ import torch
 from packaging import version
 
 from tests.kernels.moe.utils import check_accuracy
-from vllm._aiter_ops import is_aiter_found
+from vllm._aiter_ops import is_aiter_found, rocm_aiter_ops
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer
 
@@ -1247,6 +1248,7 @@ def test_rocm_mxfp4_moe_oracle(
     num_tokens: int,
     hidden_size: int,
     intermediate_size: int,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """
     Test ROCm MXFP4 MoE using oracle functions.
@@ -1268,6 +1270,7 @@ def test_rocm_mxfp4_moe_oracle(
     if config["requires_gfx950"] and not ROCM_GFX950:
         pytest.skip(f"Backend {backend_name} requires GFX950")
 
+    import vllm.distributed.parallel_state as ps
     from vllm.config import VllmConfig, set_current_vllm_config
     from vllm.model_executor.layers.fused_moe.activation import MoEActivation
     from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
@@ -1281,6 +1284,12 @@ def test_rocm_mxfp4_moe_oracle(
 
     # Initialize workspace manager (needed for modular kernels)
     init_workspace_manager(torch.accelerator.current_device_index())
+
+    # Set up the TP Group to prevent failure on should_use_cdna4_mx_scale_swizzle check
+    monkeypatch.setattr(ps, "_TP", types.SimpleNamespace(world_size=1))
+
+    # AITER must be enabled or aiter_mxfp4_w4a8_moe asserts before dispatch.
+    monkeypatch.setattr(rocm_aiter_ops, "_AITER_ENABLED", True)
 
     # Map string to enum
     backend = Mxfp4MoeBackend[backend_name]


### PR DESCRIPTION
## Purpose

This PR fixes failures on ROCm tests MI355 Kernels and Kernels Attention. The tests were failing due to a clone operation being attempted on the `prefill_backend` which was set to None for testing.

This PR also fixes a failure on the Kernels MoE test (`test_ocp_mx_moe.py`), which was failing due to the distributed environment not being initialized and an assertion failing due to `rocm_aiter_ops.is_enabled()` returning False. Note that the Kernels MoE test still fails due to other unrelated issues (e.g. accuracy tests failing).

## Test Plan

Run the CI pipeline on the modified tests.

## Test Result

MI355x Kernels and MI355x Kernels attention tests now pass. MI355x Kernels MoE still fail due to accuracy issues unrelated to these changes. (https://buildkite.com/vllm/amd-ci/builds/10422/list)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

