### PR TITLE
[Attention] Derive Triton 3D flash-decoding threshold from SM count a…

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -88,6 +88,7 @@ if TYPE_CHECKING:
     VLLM_FLOAT32_MATMUL_PRECISION: Literal["highest", "high", "medium"] = "highest"
     VLLM_BATCH_INVARIANT: bool = False
     VLLM_TRITON_ATTN_USE_TD: bool | None = None
+    VLLM_TRITON_ATTN_LONGCTX_3D_MULT: int = 4
     VLLM_GPU_SYNC_CHECK: Literal["warn", "error"] | None = None
     MAX_JOBS: str | None = None
     NVCC_THREADS: str | None = None
@@ -585,6 +586,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # ``0`` forces TD off.  Useful for A/B benchmarking the TD path.
     "VLLM_TRITON_ATTN_USE_TD": lambda: {"1": True, "0": False}.get(
         os.getenv("VLLM_TRITON_ATTN_USE_TD", "").strip()
+    ),
+    # Multiplier applied to the Triton attention 2D/3D split-KV launch-grid target
+    # for long-context deployments (max_model_len >= 8192). Biases decode toward
+    # the 3D flash-decoding path; set to 1 to disable the long-context bias.
+    "VLLM_TRITON_ATTN_LONGCTX_3D_MULT": lambda: int(
+        os.getenv("VLLM_TRITON_ATTN_LONGCTX_3D_MULT", "4")
     ),
     # If set, enable PyTorch's GPU<->CPU synchronization debug mode around
     # the worker's `execute_model` and `sample_tokens` calls. Valid values

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -55,6 +55,14 @@ logger = init_logger(__name__)
 MIN_LAUNCH_GRID_SIZE_2D = 128  # Minimum launch grid size of 2D kernel
 NUM_PAR_SOFTMAX_SEGMENTS = 16  # Number of parallel tiled softmax segments
 
+# Long-context bias for the 2D/3D split-KV threshold (see the metadata builder).
+# 3D (split-KV / flash-decoding) keeps winning past the launch-grid occupancy
+# point when the KV is long, because the 2D kernel reduces the whole KV serially
+# per CTA. For long-context deployments the effective launch-grid target is scaled
+# up by envs.VLLM_TRITON_ATTN_LONGCTX_3D_MULT; set it to 1 to disable the bias.
+SEQ_THRESHOLD_3D_LONG_CTX_MIN_MODEL_LEN = 8192
+SEQ_THRESHOLD_3D_CAP = 64  # bounds the softmax_segm_* scratch buffers
+
 
 @dataclass
 class TritonAttentionMetadata:
@@ -128,13 +136,32 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             )
         )
 
-        # The launch grid for the 2D kernel is defined as (num_q_blocks, num_heads_kv).
-        # A lower bound for num_q_blocks is the number of sequences.
-        # To ensure the minimum launch grid size is achieved, the number of sequences
-        # must be at least equal to the threshold below.
-        # If this threshold is not reached (i.e., the batch size is not large enough),
-        # the 3D kernel will be selected instead.
-        self.seq_threshold_3D = MIN_LAUNCH_GRID_SIZE_2D // self.num_heads_kv
+        # Sequence-count threshold below which the unified-attention kernel takes
+        # the 3D (split-KV / flash-decoding) path instead of the 2D path. Two
+        # effects set it, and both are folded into the value computed here:
+        #   1. Launch-grid occupancy: the 2D grid is (num_q_blocks, num_heads_kv)
+        #      and num_q_blocks is lower-bounded by the number of sequences, so at
+        #      least this many sequences are needed to fill the device. The target
+        #      is sized off the *actual* SM count rather than a fixed 128-CTA grid.
+        #   2. Serial KV reduction: for long-context decode the 2D kernel reduces
+        #      the entire KV serially per CTA, so split-KV keeps winning well past
+        #      the occupancy point. For long-context deployments (max_model_len >=
+        #      SEQ_THRESHOLD_3D_LONG_CTX_MIN_MODEL_LEN) the target is biased further
+        #      toward 3D by envs.VLLM_TRITON_ATTN_LONGCTX_3D_MULT.
+        # Capped at SEQ_THRESHOLD_3D_CAP to bound the softmax_segm_* scratch, and
+        # clamped to never fall below the stock value so short-context / small-GPU
+        # shapes never regress. Init-time only (the 2D/3D choice must be fixed per
+        # CUDA-graph capture; see the capture-size snap below).
+        stock_threshold = MIN_LAUNCH_GRID_SIZE_2D // self.num_heads_kv
+        grid_target = max(
+            MIN_LAUNCH_GRID_SIZE_2D, current_platform.num_compute_units(device.index)
+        )
+        if model_config.max_model_len >= SEQ_THRESHOLD_3D_LONG_CTX_MIN_MODEL_LEN:
+            grid_target *= envs.VLLM_TRITON_ATTN_LONGCTX_3D_MULT
+        self.seq_threshold_3D = max(
+            stock_threshold,
+            min(grid_target // self.num_heads_kv, SEQ_THRESHOLD_3D_CAP),
+        )
 
         # Modify the threshold if needed.
         if self.decode_cudagraph_enabled:


### PR DESCRIPTION
# Purpose
Fixes https://github.com/vllm-project/vllm/issues/48076.

## Problem
The Triton unified-attention 2D/3D split-KV selector uses a batch-only heuristic
(`MIN_LAUNCH_GRID_SIZE_2D // num_kv_heads`) that ignores KV length and device SM count.
Above ~8 sequences, long-context decode drops from 3D split-KV to 2D, roughly doubling
inter-token latency (hard cliff at batch >= 12).

## Fix
Derive the threshold at init from the static facts the heuristic should have used, in
`vllm/v1/attention/backends/triton_attn.py`:

1. **Launch-grid occupancy** — the 2D grid is `(num_q_blocks, num_heads_kv)` and
   `num_q_blocks` is lower-bounded by the number of sequences, so the target is sized
   off the device's actual compute-unit count instead of a fixed 128-CTA grid.
2. **Serial KV reduction** — for long-context decode the 2D kernel reduces the whole
   KV serially per CTA, so split-KV keeps winning well past the occupancy point. For
   long-context deployments (`max_model_len >= 8192`) the target is biased further
   toward 3D by a configurable multiplier (new env var
   `VLLM_TRITON_ATTN_LONGCTX_3D_MULT`, default `4`, set to `1` to disable the bias).

Capped at 64 (bounds the `softmax_segm_*` scratch buffers) and clamped to never fall
below the stock value, so short-context / small-GPU shapes never regress. Kept
init-time — the 2D/3D choice must stay fixed per CUDA-graph capture.

```python
stock_threshold = MIN_LAUNCH_GRID_SIZE_2D // self.num_heads_kv
grid_target = max(
    MIN_LAUNCH_GRID_SIZE_2D, current_platform.num_compute_units(device.index)
)
if model_config.max_model_len >= SEQ_THRESHOLD_3D_LONG_CTX_MIN_MODEL_LEN:
    grid_target *= SEQ_THRESHOLD_3D_LONG_CTX_GRID_MULT
self.seq_threshold_3D = max(
    stock_threshold,
    min(grid_target // self.num_heads_kv, SEQ_THRESHOLD_3D_CAP),
)
```

A companion change adds `VLLM_TRITON_ATTN_LONGCTX_3D_MULT` to `vllm/envs.py` so the
long-context bias can be tuned or disabled without a code change.

This is the principled form of a direct `MIN_LAUNCH_GRID_SIZE_2D 128->512` probe — it
reproduces that probe's win exactly, without baking in a workload-specific constant, so
other shapes/GPUs are unaffected.

## Duplicate-work check
- `gh pr list --search "seq_threshold_3D"` / `"MIN_LAUNCH_GRID_SIZE_2D"`: no matches.
- Related open PRs #44652, #45450, #46724 modify the 3D-path *query-length* admission
  gate (multi-query verify / spec-decode / diffusion-LM); none touch the *batch-size*
  threshold this PR changes. This PR is complementary, not competing.

## Test plan
- [x] `pytest tests/kernels/attention/ -k triton -v`
- [x] `pytest tests/v1/attention/ -k triton -v`
- [x] Benchmarked end-to-end on B200x1 — numbers above.
- [x] Re-profiled (nsys) to confirm the 3D path is active and the targeted kernel's
      time dropped.
- [x] Accuracy validated via gsm8k (lm_eval, full-sample, strict-match) — no
      regression.

## Test Result
### Benchmark setup
Model `nvidia/Gemma-4-31B-IT-NVFP4`, B200 x1 (TP=1), base image
`vllm/vllm-openai:v0.23.0`. Workload: RAG/chat — ISL 2400 + shared-system-prompt 5600
(total ISL ~ 8000) / OSL 1000, prefix caching exercised via the shared prefix.
Concurrency sweep `[1, 4, 8, 16, 32]`.

### Throughput at the SLA (>=50 tok/s/user, i.e. ITL <= 20 ms)

| cc | stock tok/s/gpu | stock tok/s/user | stock ITL | patched tok/s/gpu | patched tok/s/user | patched ITL | SLA (patched) |
|----|------|------|------|------|------|------|------|
| 1  | 80  | 85.3 | 11.7 ms | 81  | 86.4 | 11.6 ms | OK |
| 4  | 294 | 79.3 | 12.6 ms | 296 | 80.0 | 12.5 ms | OK |
| 8  | 504 | 69.9 | 14.3 ms | 512 | 71.0 | 14.1 ms | OK |
| 16 | 527 | 35.9 (fail) | 27.9 ms | **777** | **55.3** | **18.1 ms** | OK (was fail) |
| 19-20 | - | - | - | 848 | 51.2 | 19.6 ms | OK (SLA-max op point) |
| 32 | 843 | 29.1 (fail) | 34.4 ms | 1060 | 37.5 (fail) | 26.7 ms | fail |

**+68% aggregate output tok/s/gpu at the SLA operating point** (stock cc8, 505 tok/s/gpu
-> patched cc19, 848 tok/s/gpu). The cc8->cc16 throughput plateau and the ITL cliff at
batch >= 12 are eliminated; ITL now scales smoothly 14->20 ms over cc 8->20.

### Mechanism (nsys)
- Stock (cc16): `kernel_unified_attention` = 51.7% of GPU kernel time, avg 169us (>>
  median 81us — long-KV tail dominates)
- Patched (cc16): `kernel_unified_attention` = 38.1%, avg 101us (**-40%**); total
  attention GPU-time 10.2s -> 6.1s
- Confirms the 3D path is active and the targeted kernel's cost dropped as predicted.

### Accuracy — gsm8k (lm_eval, full-sample, strict-match)

| | score |
|---|---|
| stock | 0.9272 +/- 0.0072 |
| patched | 0.9340 +/- 0.0068 |

Delta is within stderr — numerically equivalent, no regression. 3D split-KV is the same
online-softmax math as 2D, just parallelized across segments.

### Generalization (no regression on other shapes)
Output tok/s/gpu, cc16-32 band where stock picks 2D and patched picks 3D (cc<=8 and
cc>=48 tie — same path on both):

| workload | cc16 | cc24 | cc32 |
|---|---|---|---|
| isl1024/osl1024 (stock->patched) | 953->1111 (+17%) | 1163->1414 (+22%) | 1510->1643 (+9%) |
| isl8192/osl1024 (stock->patched) | 425->600 (+41%) | 518->699 (+35%) | 612->752 (+23%) |