### PR TITLE
fix: return SSE content type from NIXL toy proxy

### DIFF
--- a/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py
+++ b/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py
@@ -248,7 +248,7 @@ async def _handle_completions(api: str, request: Request):
             ):
                 yield chunk
 
-        return StreamingResponse(generate_stream(), media_type="application/json")
+        return StreamingResponse(generate_stream(), media_type="text/event-stream")
 
     except Exception as e:
         import sys


### PR DESCRIPTION



## Purpose
Minor fix of the NIXL integration toy proxy streaming response content type.

The proxy forwards OpenAI-compatible streaming chunks in SSE format (`data: ...` / `data: [DONE]`). Returning them as `application/json` can make clients parse the raw `data:` lines as JSON, rather than treat them as event stream.

```
Failed to parse JSON string: 'data: {"id":"chatcmpl-d6879bf8-8bb7-4846-a94f-ff0861ffe3dc","object":"chat.completion.chunk","created":1783056954,"model":"Qwen/Qwen3-8B","choices":[{"index":
                      0,"delta":{"role":"assistant","content":""...' - JSONDecodeError('unexpected character: line 1 column 1 (char 0)') 
```

This PR changes the streaming response media type to `text/event-stream`, matching the SSE-framed response body and vLLM's OpenAI-compatible streaming endpoints (https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/chat_completion/api_router.py#L74).

## Test Plan

Start two PD disagg instances with the proxy,
Using `aiperf` for testing

```bash
#!/usr/bin/env bash
set -euo pipefail

bs=${bs:-16}
D_DP=${D_DP:-1}
P_DP=${P_DP:-1}
concurrency=${concurrency:-$((bs * D_DP))}
model_name=${model_name:-Qwen/Qwen3-8B}
url=${url:-http://localhost:8300}
isl=1000
osl=1000

aiperf profile \
    --model "${model_name}" \
    --tokenizer "${model_name}" \
    --endpoint-type chat \
    --endpoint /v1/chat/completions \
    --url "${url}" \
    --synthetic-input-tokens-mean "${isl}" \
    --synthetic-input-tokens-stddev 0 \
    --output-tokens-mean "${osl}" \
    --output-tokens-stddev 0 \
    --extra-inputs max_tokens:${osl} \
    --extra-inputs min_tokens:${osl} \
    --extra-inputs ignore_eos:true \
    --use-server-token-count \
    --streaming \
    --request-rate inf \
    --request-count $((concurrency * 14)) \
    --warmup-request-count $((concurrency * 2)) \
    --num-dataset-entries $((concurrency * 16)) \
    --random-seed 100 \
    --artifact-dir "res_disagg_isl${isl}_osl${osl}_bs${bs}_D_DP${D_DP}_P_DP${P_DP}_conc${concurrency}" \
    --profile-export-prefix profile_req_inf \
    --ui simple \
    --no-server-metrics \
    --concurrency "${concurrency}" \
    --prefill-concurrency "$((P_DP * 1))"
```


## Test Result

No errors when using `--streaming`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

