### PR TITLE
[Bugfix][SM120][MLA] Support FlashInfer packed sparse MLA decode

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -10,8 +10,9 @@ torchaudio==2.11.0
 torchvision==0.26.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 PyNvVideoCodec==2.1.0
 # FlashInfer should be updated together with the Dockerfile
-flashinfer-python==0.6.13
-flashinfer-cubin==0.6.13
+flashinfer-python[cu13]==0.6.14
+# flashinfer-cubin 0.6.14 is not published; use flashinfer-jit-cache cu130
+# in CUDA 13 images for prebuilt kernels.
 apache-tvm-ffi==0.1.9
 tilelang==0.1.9
 nvidia-cudnn-frontend>=1.19.1

--- a/tests/model_executor/layers/test_sparse_attn_indexer_deep_gemm.py
+++ b/tests/model_executor/layers/test_sparse_attn_indexer_deep_gemm.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+import vllm.model_executor.layers.sparse_attn_indexer as sparse_indexer
+from vllm.model_executor.layers.sparse_attn_indexer import SparseAttnIndexer
+from vllm.v1.attention.backend import AttentionCGSupport
+from vllm.v1.attention.backends.mla import indexer as mla_indexer
+
+
+def test_sparse_attn_indexer_allows_cuda_paged_mqa_fallback(
+    monkeypatch,
+) -> None:
+    assert hasattr(sparse_indexer, "is_deep_gemm_paged_mqa_supported")
+
+    monkeypatch.setattr(sparse_indexer.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(
+        sparse_indexer, "is_deep_gemm_paged_mqa_supported", lambda: False
+    )
+    monkeypatch.setattr(
+        SparseAttnIndexer,
+        "dispatch_forward",
+        lambda *_args, **_kwargs: lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        sparse_indexer,
+        "get_current_vllm_config",
+        lambda: SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                decode_context_parallel_size=1,
+                cp_kv_cache_interleave_size=1,
+            ),
+        ),
+    )
+
+    k_cache = SimpleNamespace(
+        prefix="test_k_cache",
+        kv_cache=torch.empty((1, 1, 1, 1), dtype=torch.uint8),
+    )
+
+    indexer = SparseAttnIndexer(
+        k_cache=k_cache,
+        quant_block_size=128,
+        scale_fmt="ue8m0",
+        topk_tokens=1,
+        head_dim=128,
+        max_model_len=16,
+        max_total_seq_len=16,
+        topk_indices_buffer=torch.empty((1, 1), dtype=torch.int32),
+    )
+
+    assert indexer.k_cache is k_cache
+
+
+def test_deepseek_v32_indexer_disables_cudagraph_for_cuda_fallback(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(mla_indexer.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(mla_indexer, "is_deep_gemm_paged_mqa_supported", lambda: False)
+
+    assert (
+        mla_indexer.DeepseekV32IndexerMetadataBuilder.get_cudagraph_support(
+            SimpleNamespace(), SimpleNamespace()
+        )
+        is AttentionCGSupport.NEVER
+    )
+
+    monkeypatch.setattr(mla_indexer, "is_deep_gemm_paged_mqa_supported", lambda: True)
+    assert (
+        mla_indexer.DeepseekV32IndexerMetadataBuilder.get_cudagraph_support(
+            SimpleNamespace(), SimpleNamespace()
+        )
+        is AttentionCGSupport.UNIFORM_BATCH
+    )

--- a/tests/utils/test_deep_gemm.py
+++ b/tests/utils/test_deep_gemm.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+import vllm.utils.deep_gemm as deep_gemm
+
+
+@pytest.mark.parametrize(
+    ("env_enabled", "has_module", "device_families", "expected"),
+    [
+        (True, True, {90}, True),
+        (True, True, {100}, True),
+        (True, True, {120}, False),
+        (False, True, {90}, False),
+        (True, False, {90}, False),
+    ],
+)
+def test_deep_gemm_paged_mqa_support_arch_gate(
+    monkeypatch,
+    env_enabled: bool,
+    has_module: bool,
+    device_families: set[int],
+    expected: bool,
+) -> None:
+    assert hasattr(deep_gemm, "is_deep_gemm_paged_mqa_supported")
+
+    monkeypatch.setattr(deep_gemm.envs, "VLLM_USE_DEEP_GEMM", env_enabled)
+    monkeypatch.setattr(deep_gemm, "has_deep_gemm", lambda: has_module)
+    monkeypatch.setattr(
+        deep_gemm.current_platform,
+        "is_device_capability_family",
+        lambda capability: capability in device_families,
+    )
+
+    deep_gemm.is_deep_gemm_paged_mqa_supported.cache_clear()
+
+    assert deep_gemm.is_deep_gemm_paged_mqa_supported() is expected

--- a/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
+++ b/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
@@ -7,10 +7,17 @@ from types import SimpleNamespace
 import torch
 
 from vllm.config import set_current_vllm_config
+from vllm.model_executor.layers.attention.mla_attention import (
+    _canonicalize_sparse_mla_kv_cache_dtype,
+)
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils import flashinfer as fi_utils
+from vllm.v1.attention.backends.mla import flashinfer_mla_sparse_sm120
 from vllm.v1.attention.backends.mla.flashinfer_mla_sparse import (
     FlashInferMLASparseSM120Backend,
+)
+from vllm.v1.attention.backends.mla.flashinfer_mla_sparse_sm120 import (
+    FlashInferMLASparseSM120Impl,
 )
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
@@ -35,6 +42,11 @@ def test_v32_glm_sm120_backend_accepts_glm_block_size(
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(fi_utils, "has_flashinfer_sparse_mla_sm120", lambda: True)
+    monkeypatch.setattr(
+        fi_utils,
+        "flashinfer_mla_decode_supports_kv_scale_format",
+        lambda: True,
+    )
 
     with set_current_vllm_config(_fake_vllm_config("glm4_moe")):
         invalid_reasons = FlashInferMLASparseSM120Backend.validate_configuration(
@@ -52,3 +64,126 @@ def test_v32_glm_sm120_backend_accepts_glm_block_size(
         )
 
     assert invalid_reasons == []
+
+
+def test_sm120_standard_fp8_cache_uses_packed_flashinfer_shape() -> None:
+    assert (
+        _canonicalize_sparse_mla_kv_cache_dtype(FlashInferMLASparseSM120Backend, "auto")
+        == "fp8_ds_mla"
+    )
+    assert (
+        _canonicalize_sparse_mla_kv_cache_dtype(
+            FlashInferMLASparseSM120Backend, "fp8_e4m3"
+        )
+        == "fp8_ds_mla"
+    )
+    assert FlashInferMLASparseSM120Backend.get_kv_cache_shape(
+        num_blocks=2,
+        block_size=64,
+        num_kv_heads=1,
+        head_size=576,
+        cache_dtype_str="fp8_e4m3",
+    ) == (2, 64, 576)
+    assert FlashInferMLASparseSM120Backend.get_kv_cache_shape(
+        num_blocks=2,
+        block_size=64,
+        num_kv_heads=1,
+        head_size=576,
+        cache_dtype_str="fp8_ds_mla",
+    ) == (2, 64, 656)
+
+
+def test_sm120_rejects_fp8_ds_mla_without_flashinfer_packed_support(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(fi_utils, "has_flashinfer_sparse_mla_sm120", lambda: True)
+    monkeypatch.setattr(
+        fi_utils,
+        "flashinfer_mla_decode_supports_kv_scale_format",
+        lambda: False,
+    )
+
+    with set_current_vllm_config(_fake_vllm_config("glm4_moe")):
+        invalid_reasons = FlashInferMLASparseSM120Backend.validate_configuration(
+            head_size=576,
+            dtype=torch.bfloat16,
+            kv_cache_dtype="fp8_ds_mla",
+            block_size=256,
+            use_mla=True,
+            has_sink=False,
+            use_sparse=True,
+            use_mm_prefix=False,
+            use_per_head_quant_scales=False,
+            device_capability=DeviceCapability(12, 0),
+            attn_type="decoder",
+        )
+
+    assert any("fp8_ds_mla" in reason for reason in invalid_reasons)
+
+
+def test_sm120_impl_passes_packed_sparse_mla_args(
+    monkeypatch,
+) -> None:
+    captured_kwargs = {}
+
+    def fake_decode(**kwargs):
+        captured_kwargs.update(kwargs)
+        return kwargs["out"]
+
+    monkeypatch.setattr(
+        fi_utils,
+        "flashinfer_mla_decode_supports_kv_scale_format",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        fi_utils,
+        "flashinfer_trtllm_batch_decode_with_kv_cache_mla",
+        fake_decode,
+    )
+    monkeypatch.setattr(
+        flashinfer_mla_sparse_sm120,
+        "_get_workspace_buffer",
+        lambda device: torch.empty((1,), device=device),
+    )
+    monkeypatch.setattr(
+        flashinfer_mla_sparse_sm120,
+        "triton_convert_req_index_to_global_index",
+        lambda *_args, **_kwargs: (
+            torch.zeros((1, 1), dtype=torch.int32),
+            torch.ones((1,), dtype=torch.int32),
+        ),
+    )
+
+    impl = object.__new__(FlashInferMLASparseSM120Impl)
+    impl.num_heads = 1
+    impl.scale = 1.0
+    impl.kv_lora_rank = 1
+    impl.qk_nope_head_dim = 1
+    impl.qk_rope_head_dim = 0
+    impl.kv_scale_format = "arbitrary_fp32"
+    impl.topk_indices_buffer = torch.zeros((1, 1), dtype=torch.int32)
+    impl._workspace_buffer = None
+    impl.kv_cache_dtype = "fp8_ds_mla"
+
+    q = torch.empty((1, 1), dtype=torch.bfloat16)
+    kv_cache = torch.zeros((1, 1), dtype=torch.uint8)
+    metadata = SimpleNamespace(
+        req_id_per_token=torch.zeros((1,), dtype=torch.int32),
+        block_table=torch.zeros((1, 1), dtype=torch.int32),
+        block_size=1,
+        topk_tokens=1,
+    )
+    layer = SimpleNamespace(_q_scale_float=2.0, _k_scale_float=3.0)
+
+    output, _ = impl.forward_mqa(q, kv_cache, metadata, layer=layer)
+
+    assert output.shape == (1, 1, 1)
+    assert output.dtype == torch.bfloat16
+    assert captured_kwargs["query"].dtype == torch.bfloat16
+    assert captured_kwargs["kv_cache"].dtype == torch.uint8
+    assert captured_kwargs["bmm1_scale"] == 1.0
+    assert captured_kwargs["bmm2_scale"] == 1.0
+    assert captured_kwargs["seq_lens"].shape == (1,)
+    assert captured_kwargs["seq_lens"].dtype == torch.int32
+    assert captured_kwargs["kv_scale_format"] == "arbitrary_fp32"
+    assert "backend" not in captured_kwargs

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -331,6 +331,7 @@ def _canonicalize_sparse_mla_kv_cache_dtype(
         "auto",
         "fp8",
         "fp8_e4m3",
+        "fp8_ds_mla",
     ):
         return "fp8_ds_mla"
     return kv_cache_dtype

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -21,9 +21,10 @@ from vllm.triton_utils import tl, triton
 from vllm.utils.deep_gemm import (
     fp8_fp4_mqa_logits,
     fp8_fp4_paged_mqa_logits,
-    has_deep_gemm,
+    is_deep_gemm_paged_mqa_supported,
 )
 from vllm.utils.import_utils import has_cutedsl
+from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import (
     LayerNameType,
     _encode_layer_name,
@@ -291,6 +292,89 @@ def kv_cache_as_quant_view(
     return kv_cache.unsqueeze(-2)
 
 
+def _fp8_mqa_logits_torch(
+    q_fp8: torch.Tensor,
+    kv: tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+) -> torch.Tensor:
+    k_fp8, k_scale = kv
+    q = q_fp8.to(torch.float32)
+    k = k_fp8.to(torch.float32) * k_scale.to(torch.float32).unsqueeze(-1)
+
+    kv_offsets = torch.arange(k.shape[0], device=q.device)
+    mask = (kv_offsets[None, :] >= cu_seqlen_ks[:, None]) & (
+        kv_offsets[None, :] < cu_seqlen_ke[:, None]
+    )
+    score = torch.einsum("mhd,nd->hmn", q, k)
+    logits = (score.relu() * weights.unsqueeze(-1).transpose(0, 1)).sum(dim=0)
+    return logits.masked_fill(~mask, float("-inf"))
+
+
+def _fp8_paged_mqa_logits_torch(
+    q_fp8: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    max_model_len: int,
+) -> torch.Tensor:
+    fp8_dtype = current_platform.fp8_dtype()
+    batch_size, next_n, _, dim = q_fp8.size()
+    block_size = kv_cache.shape[1]
+
+    kv_values = kv_cache[..., :dim].contiguous().view(fp8_dtype).to(torch.float32)
+    kv_scales = kv_cache[..., dim:].contiguous().view(torch.float32)
+    kv_values = kv_values * kv_scales
+    q = q_fp8.to(torch.float32)
+
+    logits = torch.full(
+        (batch_size * next_n, max_model_len),
+        float("-inf"),
+        device=q.device,
+        dtype=torch.float32,
+    )
+    for i in range(batch_size):
+        context_len = context_lens[i]
+        if context_len.ndim == 0:
+            context_len_i = int(context_len.item())
+            context_limit = torch.full(
+                (next_n,), context_len_i, dtype=torch.int32, device=q.device
+            )
+            q_offsets = torch.arange(
+                context_len_i - next_n, context_len_i, device=q.device
+            )
+        else:
+            context_limit = context_len.to(device=q.device, dtype=torch.int32)
+            q_offsets = context_limit - 1
+
+        weight_slice = (
+            weights[i * next_n : (i + 1) * next_n].transpose(0, 1).contiguous()
+        )
+        max_context_len = int(context_limit.max().item())
+        for block_rk in range(cdiv(max_context_len, block_size)):
+            block_idx = block_tables[i][block_rk]
+            k_block = kv_values[block_idx].squeeze(-2)
+            k_offsets = torch.arange(
+                block_rk * block_size,
+                (block_rk + 1) * block_size,
+                device=q.device,
+            )
+            causal_mask = (k_offsets[None, :] < context_limit[:, None]) & (
+                k_offsets[None, :] <= q_offsets[:, None]
+            )
+            score = torch.einsum("nhd,bd->hnb", q[i], k_block)
+            score = torch.where(causal_mask[None], score, float("-inf"))
+            score = score.relu() * weight_slice[..., None]
+            start = block_rk * block_size
+            logits[
+                i * next_n : (i + 1) * next_n,
+                start : start + block_size,
+            ] = score.sum(dim=0)
+    return logits
+
+
 @eager_break_during_capture
 def sparse_attn_indexer(
     hidden_states: torch.Tensor,
@@ -462,6 +546,22 @@ def sparse_attn_indexer(
                         cu_seqlen_ks,
                         cu_seqlen_ke,
                     )
+                elif (
+                    current_platform.is_cuda()
+                    and not is_deep_gemm_paged_mqa_supported()
+                ):
+                    if q_scale_slice is not None:
+                        raise RuntimeError(
+                            "CUDA sparse attention FP4 indexer requires "
+                            "DeepGEMM paged MQA logits support."
+                        )
+                    logits = _fp8_mqa_logits_torch(
+                        q_slice_cast,
+                        (k_quant_cast, k_scale_cast),
+                        weights[chunk.token_start : chunk.token_end],
+                        cu_seqlen_ks,
+                        cu_seqlen_ke,
+                    )
                 else:
                     logits = fp8_fp4_mqa_logits(
                         (q_slice_cast, q_scale_slice),
@@ -556,6 +656,20 @@ def sparse_attn_indexer(
                 seq_lens_xpu,
                 decode_metadata.block_table,
                 decode_metadata.schedule_metadata,
+                max_model_len,
+            )
+        elif current_platform.is_cuda() and not is_deep_gemm_paged_mqa_supported():
+            if padded_q_scale is not None:
+                raise RuntimeError(
+                    "CUDA sparse attention FP4 indexer requires DeepGEMM "
+                    "paged MQA logits support."
+                )
+            logits = _fp8_paged_mqa_logits_torch(
+                padded_q_quant_cast,
+                kv_cache,
+                weights[:num_padded_tokens],
+                seq_lens,
+                decode_metadata.block_table,
                 max_model_len,
             )
         else:
@@ -725,10 +839,15 @@ class SparseAttnIndexer(CustomOp):
         self.dcp_world_size = parallel_config.decode_context_parallel_size
         self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
         self.cp_kv_cache_interleave_size = parallel_config.cp_kv_cache_interleave_size
-        if current_platform.is_cuda() and not has_deep_gemm():
+        if (
+            current_platform.is_cuda()
+            and self.use_fp4_cache
+            and not is_deep_gemm_paged_mqa_supported()
+        ):
             raise RuntimeError(
-                "Sparse Attention Indexer CUDA op requires DeepGEMM support in "
-                "the current vLLM environment."
+                "Sparse Attention Indexer CUDA FP4 cache path requires "
+                "DeepGEMM paged MQA logits support in the current vLLM "
+                "environment."
             )
 
     def forward_native(

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -100,6 +100,19 @@ def is_deep_gemm_supported() -> bool:
 
 
 @functools.cache
+def is_deep_gemm_paged_mqa_supported() -> bool:
+    """Return `True` if DeepGEMM paged MQA logits support this platform."""
+    return (
+        envs.VLLM_USE_DEEP_GEMM
+        and has_deep_gemm()
+        and (
+            current_platform.is_device_capability_family(90)
+            or current_platform.is_device_capability_family(100)
+        )
+    )
+
+
+@functools.cache
 def is_deep_gemm_e8m0_used() -> bool:
     """Return `True` if vLLM is configured to use DeepGEMM "
     "E8M0 scale on a Hopper or Blackwell-class GPU.
@@ -732,6 +745,7 @@ __all__ = [
     "get_paged_mqa_logits_metadata",
     "per_block_cast_to_fp8",
     "is_deep_gemm_e8m0_used",
+    "is_deep_gemm_paged_mqa_supported",
     "is_deep_gemm_supported",
     "get_num_sms",
     "set_num_sms",

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -9,6 +9,7 @@ import contextlib
 import functools
 import importlib
 import importlib.util
+import inspect
 import os
 import shutil
 from collections.abc import Callable
@@ -230,6 +231,22 @@ def has_flashinfer_sparse_mla_sm120() -> bool:
         and callable(trtllm_batch_decode_with_kv_cache_mla)
         and callable(autotune)
     )
+
+
+@functools.cache
+def flashinfer_mla_decode_supports_kv_scale_format() -> bool:
+    """Return whether FlashInfer MLA decode accepts ``kv_scale_format``."""
+    if not has_flashinfer():
+        return False
+    try:
+        from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla
+    except ImportError:
+        return False
+    try:
+        signature = inspect.signature(trtllm_batch_decode_with_kv_cache_mla)
+    except (TypeError, ValueError):
+        return False
+    return "kv_scale_format" in signature.parameters
 
 
 @functools.cache
@@ -1031,6 +1048,7 @@ __all__ = [
     "flashinfer_convert_sf_to_mma_layout",
     "trtllm_fp4_block_scale_moe",
     "flashinfer_trtllm_batch_decode_with_kv_cache_mla",
+    "flashinfer_mla_decode_supports_kv_scale_format",
     "flashinfer_trtllm_batch_decode_sparse_mla_dsv4",
     "autotune",
     "has_flashinfer_moe",

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
@@ -187,12 +187,29 @@ class FlashInferMLASparseSM120Backend(_FlashInferMLASparseBackendBase):
         device_capability: DeviceCapability,
     ) -> str | None:
         from vllm.config import get_current_vllm_config
-        from vllm.utils.flashinfer import has_flashinfer_sparse_mla_sm120
+        from vllm.utils.flashinfer import (
+            flashinfer_mla_decode_supports_kv_scale_format,
+            has_flashinfer_sparse_mla_sm120,
+        )
 
         if not has_flashinfer_sparse_mla_sm120():
             return (
                 "FLASHINFER_MLA_SPARSE_SM120 requires FlashInfer's "
                 "sparse MLA decode API"
+            )
+        needs_packed_fp8_cache = kv_cache_dtype in (
+            "auto",
+            "fp8",
+            "fp8_e4m3",
+            "fp8_ds_mla",
+        )
+        if (
+            needs_packed_fp8_cache
+            and not flashinfer_mla_decode_supports_kv_scale_format()
+        ):
+            return (
+                "FLASHINFER_MLA_SPARSE_SM120 requires FlashInfer sparse MLA "
+                "decode support for fp8_ds_mla packed KV cache"
             )
         if dtype != torch.bfloat16:
             return "dtype not supported"
@@ -228,7 +245,7 @@ class FlashInferMLASparseSM120Backend(_FlashInferMLASparseBackendBase):
         head_size: int,
         cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
-        if cache_dtype_str in ("auto", "fp8", "fp8_e4m3", "fp8_ds_mla"):
+        if cache_dtype_str == "fp8_ds_mla":
             # fp8_ds_mla packed layout: 512 NoPE + 16 scales + 128 RoPE.
             return (num_blocks, block_size, 656)
         return (num_blocks, block_size, head_size)

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
@@ -88,12 +88,20 @@ class FlashInferMLASparseSM120Impl(SparseMLAAttentionImpl[FlashInferMLASparseMet
             if indexer is not None
             else mla_args.get("topk_indices_buffer")
         )
-        from vllm.utils.flashinfer import has_flashinfer_sparse_mla_sm120
+        from vllm.utils.flashinfer import (
+            flashinfer_mla_decode_supports_kv_scale_format,
+            has_flashinfer_sparse_mla_sm120,
+        )
 
         if not has_flashinfer_sparse_mla_sm120():
             raise RuntimeError(
                 "FLASHINFER_MLA_SPARSE_SM120 requires FlashInfer's "
                 "sparse MLA decode API."
+            )
+        if not flashinfer_mla_decode_supports_kv_scale_format():
+            raise RuntimeError(
+                "FLASHINFER_MLA_SPARSE_SM120 requires FlashInfer sparse MLA "
+                "decode support for fp8_ds_mla packed KV cache."
             )
         assert self.topk_indices_buffer is not None
 
@@ -115,20 +123,22 @@ class FlashInferMLASparseSM120Impl(SparseMLAAttentionImpl[FlashInferMLASparseMet
         assert self.topk_indices_buffer is not None
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
 
-        topk_indices_physical = cast(
-            torch.Tensor,
+        topk_indices_physical, seq_lens = cast(
+            tuple[torch.Tensor, torch.Tensor],
             triton_convert_req_index_to_global_index(
                 attn_metadata.req_id_per_token[:num_actual_toks],
                 attn_metadata.block_table,
                 topk_indices,
                 BLOCK_SIZE=attn_metadata.block_size,
                 NUM_TOPK_TOKENS=topk_indices.shape[1],
+                return_valid_counts=True,
             ),
         )
 
-        output = q.new_empty(
+        output = torch.empty(
             (num_actual_toks, self.num_heads, self.kv_lora_rank),
-            dtype=q.dtype,
+            dtype=torch.bfloat16,
+            device=q.device,
         )
 
         if self._workspace_buffer is None:
@@ -138,20 +148,22 @@ class FlashInferMLASparseSM120Impl(SparseMLAAttentionImpl[FlashInferMLASparseMet
             flashinfer_trtllm_batch_decode_with_kv_cache_mla,
         )
 
-        out = flashinfer_trtllm_batch_decode_with_kv_cache_mla(
-            query=q.unsqueeze(1),
-            kv_cache=kv_c_and_k_pe_cache.view(torch.uint8).unsqueeze(1),
-            workspace_buffer=self._workspace_buffer,
-            qk_nope_head_dim=self.qk_nope_head_dim,
-            kv_lora_rank=self.kv_lora_rank,
-            qk_rope_head_dim=self.qk_rope_head_dim,
-            block_tables=topk_indices_physical.unsqueeze(1),
-            seq_lens=None,
-            max_seq_len=attn_metadata.topk_tokens,
-            out=output.unsqueeze(1),
-            bmm1_scale=self.scale,
-            bmm2_scale=1.0,
-            sparse_mla_top_k=attn_metadata.topk_tokens,
-            kv_scale_format=self.kv_scale_format,
-        )
+        kwargs = {
+            "query": q.unsqueeze(1),
+            "kv_cache": kv_c_and_k_pe_cache.view(torch.uint8).unsqueeze(1),
+            "workspace_buffer": self._workspace_buffer,
+            "qk_nope_head_dim": self.qk_nope_head_dim,
+            "kv_lora_rank": self.kv_lora_rank,
+            "qk_rope_head_dim": self.qk_rope_head_dim,
+            "block_tables": topk_indices_physical.unsqueeze(1),
+            "seq_lens": seq_lens,
+            "max_seq_len": attn_metadata.topk_tokens,
+            "out": output.unsqueeze(1),
+            "bmm1_scale": self.scale,
+            "bmm2_scale": 1.0,
+            "sparse_mla_top_k": attn_metadata.topk_tokens,
+            "kv_scale_format": self.kv_scale_format,
+        }
+
+        out = flashinfer_trtllm_batch_decode_with_kv_cache_mla(**kwargs)
         return out.squeeze(1), None

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -12,7 +12,7 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.deep_gemm import (
     get_paged_mqa_logits_metadata,
-    has_deep_gemm,
+    is_deep_gemm_paged_mqa_supported,
 )
 from vllm.utils.math_utils import cdiv
 from vllm.utils.platform_utils import num_compute_units
@@ -246,6 +246,8 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         vllm_config: VllmConfig,
         kv_cache_spec: AttentionSpec,
     ) -> AttentionCGSupport:
+        if current_platform.is_cuda() and not is_deep_gemm_paged_mqa_supported():
+            return AttentionCGSupport.NEVER
         return AttentionCGSupport.UNIFORM_BATCH
 
     def __init__(self, *args, **kwargs):
@@ -723,8 +725,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             if seq_lens.dim() == 1:
                 seq_lens = seq_lens.unsqueeze(-1)
 
-            # DeepGEMM is required for the paged MQA logits on CUDA devices
-            if current_platform.is_cuda() and has_deep_gemm():
+            if current_platform.is_cuda() and is_deep_gemm_paged_mqa_supported():
                 self.scheduler_metadata_buffer[:] = get_paged_mqa_logits_metadata(
                     seq_lens,
                     self.kv_cache_spec.storage_block_size,


### PR DESCRIPTION
## Purpose

This PR fixes the released-wheel SM120 FlashInfer sparse MLA path used by GLM / Deepseek V3.2 style sparse MLA models with FP8 KV cache.

The current path can select the SM120 FlashInfer sparse MLA backend, but the decode API needs the packed `fp8_ds_mla` KV layout and `kv_scale_format` support. Separately, the sparse attention indexer only checked for the presence of DeepGEMM, so CUDA platforms where DeepGEMM paged MQA logits are not supported could still enter the wrong path or try to capture the torch fallback in CUDA graphs.

## Changes

- Update CUDA FlashInfer dependency to `flashinfer-python[cu13]==0.6.14` and document that CUDA 13 images should use `flashinfer-jit-cache` because `flashinfer-cubin 0.6.14` is not published.
- Canonicalize SM120 sparse MLA FP8 cache requests to `fp8_ds_mla`.
- Detect whether FlashInfer sparse MLA decode supports `kv_scale_format` and reject older FlashInfer builds explicitly.
- Pass packed uint8 KV cache, `seq_lens`, `bmm1_scale`, `bmm2_scale`, `sparse_mla_top_k`, and `kv_scale_format` to FlashInfer decode.
- Keep SM120 packed sparse MLA query inputs in BF16 instead of quantized query input.
- Add a DeepGEMM paged MQA capability helper and use it for indexer dispatch.
- Add an FP8 torch fallback for sparse attention indexer logits when DeepGEMM paged MQA is unavailable, while keeping FP4 indexer cache gated behind DeepGEMM support.
- Disable CUDA graph support for `DeepseekV32IndexerBackend` when the CUDA fallback path is active.
- Add targeted regression tests for the DeepGEMM capability helper, SM120 FlashInfer API gating/arguments, and sparse attention indexer fallback behavior.

## Duplicate-work check

I checked for related open PRs before opening this draft:

```bash
gh pr list --repo vllm-project/vllm --state open --search "FlashInfer SM120 sparse MLA" --limit 20
gh pr list --repo vllm-project/vllm --state open --search "fp8_ds_mla kv_scale_format" --limit 20
gh pr list --repo vllm-project/vllm --state open --search "DeepseekV32Indexer cudagraph SM120" --limit 20
gh pr list --repo vllm-project/vllm --state open --search "flashinfer 0.6.14 SM120" --limit 20
```

Nearest related PRs found:

- #46840 validates the SM120 sparse MLA top-k buffer path. It is related but does not update the packed `fp8_ds_mla` FlashInfer decode arguments, FlashInfer 0.6.14 dependency, or DeepGEMM paged MQA indexer fallback.
- #38476 adds a Triton sparse MLA backend/fallback. This PR keeps the FlashInfer SM120 sparse MLA backend and fixes its released FlashInfer 0.6.14 packed-KV path.
- #41834 is a broad DeepSeek V4 SM12x enablement branch. This PR is a narrower fix for the current main SM120 FlashInfer sparse MLA + Deepseek V3.2 indexer path.

I did not find an open PR that addresses this specific FlashInfer 0.6.14 packed sparse MLA decode and SM120 indexer fallback combination.

## Test Plan

Local formatting/static checks:

```bash
git diff --check
.venv/bin/pre-commit run --files \
  requirements/cuda.txt \
  vllm/utils/deep_gemm.py \
  vllm/utils/flashinfer.py \
  vllm/model_executor/layers/attention/mla_attention.py \
  vllm/model_executor/layers/sparse_attn_indexer.py \
  vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py \
  vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py \
  vllm/v1/attention/backends/mla/indexer.py \
  tests/utils/test_deep_gemm.py \
  tests/model_executor/layers/test_sparse_attn_indexer_deep_gemm.py \
  tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
```

Remote SM120 Docker tests in an image rebuilt from `vllm/vllm-openai:latest-0701` with this branch overlaid and FlashInfer dependencies updated:

```bash
/usr/bin/python3 -m pytest \
  tests/utils/test_deep_gemm.py \
  tests/model_executor/layers/test_sparse_attn_indexer_deep_gemm.py \
  tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py \
  -v
```

Remote image dependency validation:

```text
flashinfer-python 0.6.14
flashinfer-jit-cache 0.6.14+cu130
flashinfer-cubin MISSING
cuda-tile 1.4.0
```

Remote GLM-5.2-NVFP4 service smoke test:

```bash
vllm serve GLM-5.2-NVFP4 \
  --tensor-parallel-size 8 \
  --max-model-len 131072 \
  --served-model-name GLM-5.2 GLM-5.2-STQ glm-5.2 glm-5.2-stq \
  --enable-prefix-caching \
  --tool-call-parser glm47 \
  --reasoning-parser glm45 \
  --enable-auto-tool-choice \
  --trust-remote-code
```

Validated endpoints:

```bash
curl http://127.0.0.1:4142/health
curl http://127.0.0.1:4142/v1/models
curl http://127.0.0.1:4142/v1/chat/completions ...
```

## Test Result

Passed:

```text
git diff --check: passed
pre-commit run --files ...: passed
pytest target suite: 12 passed, 16 warnings in 1.84s
remote service /health: ok
remote /v1/models: returned all served model names with max_model_len=131072
remote /v1/chat/completions: returned a successful response with content "你好！"
```

The same model with its default `max_model_len=1048576` did not fit in available KV cache on the test machine. Reducing `--max-model-len` to `131072` gave `GPU KV cache size: 319,424 tokens` and `Maximum concurrency for 131,072 tokens per request: 2.44x`, after which the service-level smoke test passed.

## AI Assistance Disclosure

AI assistance was used to investigate the runtime failures, implement this patch, run remote validation, and draft this PR description. This PR is opened as a draft; a human submitter should review every changed line and be prepared to defend the change end-to-end before marking it ready for review.
