### PR TITLE
[Attention][TurboQuant] Preserve configured FlashAttention version

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -2219,19 +2219,6 @@ class EngineArgs:
                 self.attention_backend
             )
 
-        # TurboQuant requires FlashAttention 2 — FA3 boundary layers assert
-        # FlashAttentionImpl which fails with TurboQuantAttentionImpl.
-        if resolved_cache_dtype.startswith("turboquant_") and (
-            attention_config.flash_attn_version is None
-            or attention_config.flash_attn_version >= 3
-        ):
-            logger.warning(
-                "TurboQuant is not yet compatible with FlashAttention >= 3. "
-                "Overriding flash_attn_version to 2. To silence this "
-                "warning, pass --attention-config.flash_attn_version=2"
-            )
-            attention_config.flash_attn_version = 2
-
         # Mamba config overrides
         mamba_config = copy.deepcopy(self.mamba_config)
         # Convert string to enum if needed (CLI parsing returns a string)


### PR DESCRIPTION
## Summary

Allow TurboQuant KV cache configurations to use the configured/default FlashAttention version instead of forcing `flash_attn_version=2` whenever `kv_cache_dtype` starts with `turboquant_`.

The previous override downgraded the default or explicit FA3/FA4 setting to FA2 for TurboQuant. This PR removes that blanket downgrade. Users who need FA2 can still pass `--attention-config.flash_attn_version=2` explicitly.

This PR is intentionally narrow:

- It does not change TurboQuant cache layout.
- It does not change TurboQuant kernels.
- It does not force FA3; it only preserves the configured/default attention version.

## Evidence

Model: `Qwen3-4B-Instruct-2507`  
Main dtype: `kv_cache_dtype=turboquant_4bit_nc`  
Image: `vllm-openai:v0.21.0`  
GPU: NVIDIA H20, one GPU per serving/performance run

Runtime path confirmation from service logs:

- Baseline `tq_forced_fa2`: emitted `Overriding flash_attn_version to 2`, used `FlashAttention version 2`, and used the `TURBOQUANT` backend.
- Candidate `tq_fa3_allowed`: used `FlashAttention version 3` and the `TURBOQUANT` backend, with no forced-FA2 override warning.

Performance matrix: random prompts, output len 1024, max concurrency 1, 7 repeats.

| Input len | Median TTFT delta, FA3 vs forced FA2 | Median TPOT delta | Median total token throughput delta |
| ---: | ---: | ---: | ---: |
| 8192 | -12.60% | -0.75% | +1.79% |
| 16384 | -17.61% | -0.84% | +3.37% |
| 32768 | -13.69% | -1.18% | +4.23% |

Interpretation: the main benefit is in prefill/TTFT. In this repeat-7 rerun, TPOT is also roughly neutral to slightly better across the tested prompt lengths. This PR does not change decode kernels; the TPOT numbers are reported as an end-to-end serving observation, not as a decode-kernel optimization claim.

Quality / accuracy validation:

WikiText-2 PPL was evaluated with `vllm_prompt_logprobs`, `max_length=2048`, `stride=512`, `batch_size=16`, `dtype=bfloat16`, and `kv_cache_dtype=turboquant_4bit_nc`.

| Group | Status | Evaluated tokens | Windows | Mean NLL | WikiText-2 PPL |
| --- | ---: | ---: | ---: | ---: | ---: |
| forced FA2 | 1/1 scored | 299077 | 582 | 2.1945114954 | 8.9756153564 |
| FA3 allowed | 1/1 scored | 299077 | 582 | 2.1943576197 | 8.9742343331 |

PPL delta, FA3 allowed vs forced FA2: `-0.0013810233` (`-0.0154%`). Mean NLL delta: `-0.0001538757` (`-0.0070%`).

Supplementary task-level accuracy validation was also run on public math, instruction-following, and code benchmarks. This is not a vLLM CI gate; it is included here as a regression check for this PR.

| Benchmark | forced FA2 | FA3 allowed |
| --- | ---: | ---: |
| Overall | 1779 / 2360 = 75.3814% | 1790 / 2360 = 75.8475% |
| GSM8K | 1150 / 1319 = 87.1873% | 1155 / 1319 = 87.5663% |
| IFEval | 445 / 541 = 82.2551% | 445 / 541 = 82.2551% |
| LiveCodeBench v6 | 55 / 175 = 31.4286% | 59 / 175 = 33.7143% |
| MultiPL-E | 129 / 325 = 39.6923% | 131 / 325 = 40.3077% |

All task-level samples were scored successfully in both configurations: no unsupported, request-failed, or extraction-failed samples were observed.

Other TurboQuant dtype smoke coverage:

- `turboquant_3bit_nc`
- `turboquant_k3v4_nc`
- `turboquant_k8v4`

Each dtype was tested in both forced-FA2 and FA3-allowed modes with server startup plus one completion request. All returned non-empty completions.