### PR TITLE
[Bugfix][CPU][RISC-V] Fix VLEN detection for RVV attention path

### DIFF
--- a/cmake/cpu_extension.cmake
+++ b/cmake/cpu_extension.cmake
@@ -178,7 +178,10 @@ elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
     # Override with -DVLLM_RVV_VLEN=128 or -DVLLM_RVV_VLEN=256 for RVV.
     if(NOT DEFINED VLLM_RVV_VLEN)
         # Auto-detect: find the largest zvl<N>b in /proc/cpuinfo isa line.
-        if(EXISTS /proc/cpuinfo)
+        # Skip when cross-compiling — /proc/cpuinfo describes the build host.
+        if(CMAKE_CROSSCOMPILING)
+            message(STATUS "Cross-compiling: skipping VLEN auto-detection from /proc/cpuinfo")
+        elseif(EXISTS /proc/cpuinfo)
             file(READ /proc/cpuinfo _cpuinfo)
             set(_best 0)
             foreach(_n IN ITEMS 128 256 512 1024)
@@ -186,6 +189,13 @@ elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
                     set(_best ${_n})
                 endif()
             endforeach()
+            # Only VLEN=128 and VLEN=256 are supported by the RVV kernels.
+            if(_best GREATER 256)
+                message(WARNING
+                    "Detected VLEN=${_best} but only 128/256 are supported; "
+                    "clamping to 256")
+                set(_best 256)
+            endif()
             if(_best GREATER 0)
                 set(VLLM_RVV_VLEN ${_best})
             endif()

--- a/csrc/cpu/cpu_attn.cpp
+++ b/csrc/cpu/cpu_attn.cpp
@@ -13,7 +13,8 @@ static inline cpu_attention::Fp8KVCacheDataType parse_fp8_kv_dtype(
 
 bool cpu_attn_has_isa(const std::string& isa) {
   if (isa == "rvv") {
-#if defined(__riscv) && defined(__riscv_v_min_vlen) && __riscv_v_min_vlen == 128
+#if defined(__riscv) && defined(__riscv_v_min_vlen) && \
+    (__riscv_v_min_vlen == 128 || __riscv_v_min_vlen == 256)
     return true;
 #else
     return false;

--- a/vllm/v1/attention/backends/cpu_attn.py
+++ b/vllm/v1/attention/backends/cpu_attn.py
@@ -437,27 +437,24 @@ def _riscv_supports_rvv() -> bool:
     The RVV path is compiled whenever __riscv_v_min_vlen is defined, so
     we check that at least one supported zvl<N>b is advertised.
     """
+    # The C++ compile-time check is the ground truth: it knows which
+    # VLEN the binary was actually compiled for.  The cpuinfo check
+    # below is only a fast-path shortcut.
+    try:
+        import torch
+
+        if torch.ops._C.cpu_attn_has_isa("rvv"):
+            return True
+    except Exception:
+        pass
+
+    # Fallback: check /proc/cpuinfo for zvl128b/zvl256b.
     try:
         with open("/proc/cpuinfo") as f:
             cpuinfo = f.read()
     except OSError:
         return False
-    # If VLEN >= 512 is detected, the RVV kernel was not compiled.
-    if any(f"zvl{n}b" in cpuinfo for n in (512, 1024)):
-        return False
-
-    # zvl128b or zvl256b explicitly advertised -> RVV kernel available.
-    if any(f"zvl{n}b" in cpuinfo for n in (128, 256)):
-        return True
-
-    # No zvl<N>b flag at all (e.g. some hardware reports zve* without
-    # a VLEN hint).  Delegate to the C++ compile-time check instead.
-    try:
-        import torch
-
-        return torch.ops._C.cpu_attn_has_isa("rvv")
-    except Exception:
-        return False
+    return any(f"zvl{n}b" in cpuinfo for n in (128, 256))
 
 
 def _get_attn_isa(


### PR DESCRIPTION
## Purpose
Three bugs in the RISC-V VLEN detection chain caused the RVV-optimized attention kernel to be silently disabled or the build to fail:

1. cpu_attn_has_isa("rvv") only checked __riscv_v_min_vlen == 128, excluding VLEN=256 hardware (e.g. Spacemit X100). This is inconsistent with cpu_attn_rvv.hpp which supports both 128 and 256.

2. CMake VLEN auto-detection read /proc/cpuinfo unconditionally, which describes the build host — not the target — when cross-compiling. Skip auto-detection when CMAKE_CROSSCOMPILING.

3. CMake auto-detection could select VLEN=512 or 1024, which then triggers a #error in cpu_types_riscv_defs.hpp (only 128/256 are supported). Clamp the detected value to 256.

Additionally, the Python _riscv_supports_rvv() is restructured to prefer the C++ compile-time check (which is the ground truth for what the binary supports) over /proc/cpuinfo heuristics. This removes the overly aggressive rejection of VLEN>=512 hardware that runs a binary compiled for VLEN<=256.

Tested on Spacemit X100 (VLEN=256, no zvl<N>b in /proc/cpuinfo).

## Test Plan

## Test Result

Additionly, I used Claude Opus 4.6 to fix the bug and manually reviewed code