### PR TITLE
[Perf] Maintain persistent penalty statistics instead of per-step CPU rebuild in V1 sampler

### DIFF
--- a/tests/v1/sample/test_penalties_state.py
+++ b/tests/v1/sample/test_penalties_state.py
@@ -260,15 +260,114 @@ def test_slot_reuse_no_contamination(device):
 
 @pytest.mark.parametrize("device", DEVICES)
 def test_pool_growth(device):
-    """Growing past the initial capacity preserves existing statistics."""
+    """Filling many slots preserves every request's statistics."""
     rng = random.Random(21)
     device = torch.device(device)
     state = PenaltiesState(MAX_NUM_REQS, VOCAB_SIZE, device)
     rows = []
-    for i in range(30):  # > _INITIAL_POOL_SLOTS, forces two growths
+    for i in range(30):
         req = MirrorRequest(rng, with_penalties=True)
         rows.append(req)
         state.add_request(i, req.params, req.token_ids(), len(req.prompt))
         if i % 10 == 9:
             assert_apply_matches(state, rows, device, rng)
     assert_apply_matches(state, rows, device, rng)
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_multi_block_vocab_and_long_history(device):
+    """Cover the multi-block kernel paths: vocab spanning several apply
+    blocks (BLOCK_SIZE=8192) with sizes not divisible by 32, and histories
+    spanning several admission blocks (BLOCK_SIZE=1024)."""
+    rng = random.Random(11)
+    device = torch.device(device)
+    vocab_size = 32003
+    state = PenaltiesState(8, vocab_size, device)
+
+    reqs = []
+    for i in range(3):
+        req = MirrorRequest(rng, with_penalties=True)
+        req.prompt = [rng.randrange(vocab_size) for _ in range(5000)]
+        req.output = [rng.randrange(vocab_size) for _ in range(2500)]
+        reqs.append(req)
+        state.add_request(i, req.params, req.token_ids(), len(req.prompt))
+    slot_mapping = state.make_slot_mapping(len(reqs))
+
+    logits = torch.randn(len(reqs), vocab_size, dtype=torch.float32, device=device)
+    expected = logits.cpu().clone().float()
+    for i, req in enumerate(reqs):
+        counts = torch.bincount(
+            torch.tensor(req.output, dtype=torch.int64, device="cpu"),
+            minlength=vocab_size,
+        )
+        output_mask = counts > 0
+        prompt_mask = (
+            torch.bincount(
+                torch.tensor(req.prompt, dtype=torch.int64, device="cpu"),
+                minlength=vocab_size,
+            )
+            > 0
+        )
+        row = expected[i]
+        rep = req.params.repetition_penalty
+        if rep != 1.0:
+            penalized = prompt_mask | output_mask
+            scale = torch.where(
+                penalized,
+                torch.tensor(rep, device="cpu"),
+                torch.tensor(1.0, device="cpu"),
+            )
+            row *= torch.where(row > 0, 1.0 / scale, scale)
+        row -= req.params.frequency_penalty * counts
+        row -= req.params.presence_penalty * output_mask
+    rep_t, freq_t, pres_t = make_penalty_tensors(reqs, device)
+    state.apply(logits, slot_mapping, rep_t, freq_t, pres_t)
+    torch.testing.assert_close(logits.cpu(), expected, rtol=1e-5, atol=1e-4)
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_rebuild_row_after_history_rewind(device):
+    """KV-load-failure recovery: committed tokens are retroactively
+    discarded while the request stays alive; rebuild_row must purge them."""
+    rng = random.Random(31)
+    device = torch.device(device)
+    state = PenaltiesState(MAX_NUM_REQS, VOCAB_SIZE, device)
+    req = MirrorRequest(rng, with_penalties=True)
+    state.add_request(0, req.params, req.token_ids(), len(req.prompt))
+    slot_mapping = state.make_slot_mapping(1)
+
+    # Commit two steps of tokens.
+    committed = [rng.randrange(VOCAB_SIZE) for _ in range(8)]
+    sampled = torch.tensor([committed], dtype=torch.int64, device=device)
+    state.commit(sampled, slot_mapping, None)
+    req.output.extend(committed)
+
+    # Rewind the last 5 tokens (as the KV-load-failure path does), then
+    # rebuild from the surviving history.
+    del req.output[-5:]
+    state.rebuild_row(0, req.token_ids(), len(req.prompt))
+    assert_apply_matches(state, [req], device, rng)
+
+    # The row keeps working incrementally after the rebuild.
+    tok = rng.randrange(VOCAB_SIZE)
+    state.commit(
+        torch.tensor([[tok]], dtype=torch.int64, device=device), slot_mapping, None
+    )
+    req.output.append(tok)
+    assert_apply_matches(state, [req], device, rng)
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_disabled_state_is_inert(device):
+    """A disabled state (non-last PP rank) allocates nothing."""
+    rng = random.Random(41)
+    device = torch.device(device)
+    state = PenaltiesState(MAX_NUM_REQS, VOCAB_SIZE, device, enabled=False)
+    req = MirrorRequest(rng, with_penalties=True)
+    state.add_request(0, req.params, req.token_ids(), len(req.prompt))
+    assert state.capacity == 0
+    assert state.output_bin_counts is None
+    assert state.no_penalties
+    assert state.hold_for_profiling() is None
+    mapping = state.make_slot_mapping(1)
+    assert int(mapping[0]) == -1

--- a/tests/v1/sample/test_penalties_state.py
+++ b/tests/v1/sample/test_penalties_state.py
@@ -1,0 +1,274 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Alignment tests for the pooled penalties state.
+
+The reference implementation recomputes penalties from the full Python-side
+token histories (the semantics of the old per-step rebuild), so any divergence
+in the incremental bookkeeping (admission, commit, slot reuse, row moves,
+draft prefixes) shows up as a logits mismatch.
+"""
+
+import random
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.ops.penalties import PenaltiesState
+
+VOCAB_SIZE = 2048
+MAX_NUM_REQS = 64
+DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
+
+
+class MirrorRequest:
+    def __init__(self, rng: random.Random, with_penalties: bool):
+        self.prompt = [rng.randrange(VOCAB_SIZE) for _ in range(rng.randint(1, 50))]
+        self.output = [rng.randrange(VOCAB_SIZE) for _ in range(rng.randint(0, 30))]
+        if with_penalties:
+            self.params = SamplingParams(
+                repetition_penalty=rng.choice([1.0, 1.05, 1.5]),
+                frequency_penalty=rng.choice([0.0, 0.2, 1.1]),
+                presence_penalty=rng.choice([0.0, 0.5, -0.4]),
+            )
+            if not self.needs_penalties():
+                self.params.presence_penalty = 0.7
+        else:
+            self.params = SamplingParams()
+
+    def needs_penalties(self) -> bool:
+        return (
+            self.params.repetition_penalty != 1.0
+            or self.params.frequency_penalty != 0.0
+            or self.params.presence_penalty != 0.0
+        )
+
+    def token_ids(self) -> np.ndarray:
+        return np.array(self.prompt + self.output, dtype=np.int64)
+
+
+def reference_apply(
+    logits: torch.Tensor,
+    rows: list[MirrorRequest],
+    draft_prefixes: list[list[int]] | None = None,
+) -> torch.Tensor:
+    logits = logits.clone().float()
+    for i, req in enumerate(rows):
+        if not req.needs_penalties():
+            continue
+        output = list(req.output)
+        if draft_prefixes is not None:
+            output += draft_prefixes[i]
+        counts = torch.bincount(
+            torch.tensor(output, dtype=torch.int64, device="cpu"),
+            minlength=VOCAB_SIZE,
+        ).to(logits.device)
+        output_mask = counts > 0
+        prompt_mask = (
+            torch.bincount(
+                torch.tensor(req.prompt, dtype=torch.int64, device="cpu"),
+                minlength=VOCAB_SIZE,
+            ).to(logits.device)
+            > 0
+        )
+
+        row = logits[i]
+        rep = req.params.repetition_penalty
+        if rep != 1.0:
+            penalized = prompt_mask | output_mask
+            scale = torch.where(
+                penalized,
+                torch.tensor(rep, device=logits.device),
+                torch.tensor(1.0, device=logits.device),
+            )
+            row *= torch.where(row > 0, 1.0 / scale, scale)
+        row -= req.params.frequency_penalty * counts
+        row -= req.params.presence_penalty * output_mask
+    return logits
+
+
+def make_penalty_tensors(rows: list[MirrorRequest], device):
+    rep = torch.tensor(
+        [r.params.repetition_penalty for r in rows], dtype=torch.float32, device=device
+    )
+    freq = torch.tensor(
+        [r.params.frequency_penalty for r in rows], dtype=torch.float32, device=device
+    )
+    pres = torch.tensor(
+        [r.params.presence_penalty for r in rows], dtype=torch.float32, device=device
+    )
+    return rep, freq, pres
+
+
+def assert_apply_matches(
+    state: PenaltiesState,
+    rows: list[MirrorRequest],
+    device,
+    rng: random.Random,
+):
+    num_reqs = len(rows)
+    slot_mapping = state.make_slot_mapping(num_reqs)
+    logits = torch.randn(num_reqs, VOCAB_SIZE, dtype=torch.float32, device=device)
+    expected = reference_apply(logits.cpu(), rows)
+    rep, freq, pres = make_penalty_tensors(rows, device)
+    state.apply(logits, slot_mapping, rep, freq, pres)
+    torch.testing.assert_close(logits.cpu(), expected, rtol=1e-5, atol=1e-4)
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_random_episodes(device):
+    """Adds, removals, condense-style moves, swaps, commits across steps."""
+    rng = random.Random(1234)
+    device = torch.device(device)
+    state = PenaltiesState(MAX_NUM_REQS, VOCAB_SIZE, device)
+    rows: list[MirrorRequest] = []
+
+    def add_request(req: MirrorRequest):
+        rows.append(req)
+        state.add_request(len(rows) - 1, req.params, req.token_ids(), len(req.prompt))
+
+    for _ in range(4):
+        add_request(MirrorRequest(rng, with_penalties=rng.random() < 0.7))
+
+    for step in range(40):
+        # Random batch mutations, mirroring InputBatch behavior.
+        if rng.random() < 0.3 and len(rows) < MAX_NUM_REQS - 2:
+            add_request(MirrorRequest(rng, with_penalties=rng.random() < 0.7))
+        if rng.random() < 0.2 and len(rows) > 2:
+            # Remove + condense: last row moves into the gap.
+            victim = rng.randrange(len(rows))
+            last = len(rows) - 1
+            state.remove_row(victim)
+            if victim != last:
+                state.move_row(last, victim)
+                rows[victim] = rows[last]
+            rows.pop()
+        if rng.random() < 0.2 and len(rows) > 2:
+            i1, i2 = rng.sample(range(len(rows)), 2)
+            state.swap_rows(i1, i2)
+            rows[i1], rows[i2] = rows[i2], rows[i1]
+
+        assert_apply_matches(state, rows, device, rng)
+
+        # Commit this step's sampled tokens (with holes and discards).
+        num_reqs = len(rows)
+        num_sampled = rng.randint(1, 4)
+        sampled = torch.full((num_reqs, num_sampled), -1, dtype=torch.int64)
+        discard = torch.zeros(num_reqs, dtype=torch.bool)
+        for i, req in enumerate(rows):
+            if rng.random() < 0.1:
+                discard[i] = True
+                sampled[i, 0] = rng.randrange(VOCAB_SIZE)
+                continue
+            n_accept = rng.randint(0, num_sampled)
+            for j in range(n_accept):
+                tok = rng.randrange(VOCAB_SIZE)
+                sampled[i, j] = tok
+                req.output.append(tok)
+        slot_mapping = state.make_slot_mapping(num_reqs)
+        state.commit(sampled.to(device), slot_mapping, discard.to(device).int())
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_spec_decode_draft_and_bonus_rows(device):
+    """Expanded draft-verification rows and bonus rows see draft prefixes."""
+    rng = random.Random(99)
+    device = torch.device(device)
+    state = PenaltiesState(MAX_NUM_REQS, VOCAB_SIZE, device)
+    rows = [MirrorRequest(rng, with_penalties=i % 3 != 2) for i in range(6)]
+    for i, req in enumerate(rows):
+        state.add_request(i, req.params, req.token_ids(), len(req.prompt))
+
+    num_drafts = [rng.randint(0, 5) for _ in rows]
+    flat_drafts = []
+    starts = []
+    for k in num_drafts:
+        starts.append(len(flat_drafts))
+        flat_drafts.extend(rng.randrange(VOCAB_SIZE) for _ in range(k))
+    draft_token_ids = torch.tensor(flat_drafts, dtype=torch.int64, device=device)
+
+    slot_mapping = state.make_slot_mapping(len(rows))
+    rep, freq, pres = make_penalty_tensors(rows, device)
+
+    # Draft-verification rows: request i contributes num_drafts[i] rows;
+    # the row for draft position p sees drafts [0, p).
+    row_to_req, prefix_lens, draft_starts = [], [], []
+    expanded_rows, expanded_prefixes = [], []
+    for i, k in enumerate(num_drafts):
+        for p in range(k):
+            row_to_req.append(i)
+            prefix_lens.append(p)
+            draft_starts.append(starts[i])
+            expanded_rows.append(rows[i])
+            expanded_prefixes.append(flat_drafts[starts[i] : starts[i] + p])
+    logits = torch.randn(
+        len(row_to_req), VOCAB_SIZE, dtype=torch.float32, device=device
+    )
+    expected = reference_apply(logits.cpu(), expanded_rows, expanded_prefixes)
+    state.apply(
+        logits,
+        slot_mapping,
+        rep,
+        freq,
+        pres,
+        row_to_req=torch.tensor(row_to_req, dtype=torch.int32, device=device),
+        prefix_lens=torch.tensor(prefix_lens, dtype=torch.int32, device=device),
+        draft_token_ids=draft_token_ids,
+        draft_starts=torch.tensor(draft_starts, dtype=torch.int32, device=device),
+    )
+    torch.testing.assert_close(logits.cpu(), expected, rtol=1e-5, atol=1e-4)
+
+    # Bonus rows: one per request, sees all of its drafts.
+    logits = torch.randn(len(rows), VOCAB_SIZE, dtype=torch.float32, device=device)
+    expected = reference_apply(
+        logits.cpu(),
+        rows,
+        [flat_drafts[starts[i] : starts[i] + k] for i, k in enumerate(num_drafts)],
+    )
+    state.apply(
+        logits,
+        slot_mapping,
+        rep,
+        freq,
+        pres,
+        prefix_lens=torch.tensor(num_drafts, dtype=torch.int32, device=device),
+        draft_token_ids=draft_token_ids,
+        draft_starts=torch.tensor(starts, dtype=torch.int32, device=device),
+    )
+    torch.testing.assert_close(logits.cpu(), expected, rtol=1e-5, atol=1e-4)
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_slot_reuse_no_contamination(device):
+    """A recycled slot must not leak the previous request's statistics."""
+    rng = random.Random(7)
+    device = torch.device(device)
+    state = PenaltiesState(MAX_NUM_REQS, VOCAB_SIZE, device)
+
+    heavy = MirrorRequest(rng, with_penalties=True)
+    heavy.output = [42] * 100
+    state.add_request(0, heavy.params, heavy.token_ids(), len(heavy.prompt))
+    state.make_slot_mapping(1)
+    state.remove_row(0)
+
+    fresh = MirrorRequest(rng, with_penalties=True)
+    fresh.output = []
+    state.add_request(0, fresh.params, fresh.token_ids(), len(fresh.prompt))
+    assert_apply_matches(state, [fresh], device, rng)
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_pool_growth(device):
+    """Growing past the initial capacity preserves existing statistics."""
+    rng = random.Random(21)
+    device = torch.device(device)
+    state = PenaltiesState(MAX_NUM_REQS, VOCAB_SIZE, device)
+    rows = []
+    for i in range(30):  # > _INITIAL_POOL_SLOTS, forces two growths
+        req = MirrorRequest(rng, with_penalties=True)
+        rows.append(req)
+        state.add_request(i, req.params, req.token_ids(), len(req.prompt))
+        if i % 10 == 9:
+            assert_apply_matches(state, rows, device, rng)
+    assert_apply_matches(state, rows, device, rng)

--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -3,14 +3,17 @@
 from typing import Any
 from unittest.mock import Mock
 
+import numpy as np
 import pytest
 import torch
 import torch.nn.functional as F
 
 from tests.v1.sample.utils import create_allowed_token_ids
 from vllm.platforms import current_platform
+from vllm.sampling_params import SamplingParams
 from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.ops.penalties import PenaltiesState
 from vllm.v1.sample.rejection_sampler import (
     PLACEHOLDER_TOKEN_ID,
     RejectionSampler,
@@ -82,6 +85,7 @@ def create_sampling_metadata(
     repetition_penalties: list[float] | None = None,
     bad_words_token_ids: dict[int, list[list[int]]] | None = None,
     allowed_token_ids_mask: torch.Tensor | None = None,
+    vocab_size: int = 100,
 ) -> SamplingMetadata:
     """Create a v1 sampling metadata object with all_greedy set
     to the given value. Either all greedy or all random sampling
@@ -93,11 +97,29 @@ def create_sampling_metadata(
     else:
         assert temperature is not None
 
+    penalties_state = None
+    penalty_slot_mapping = None
     if any([frequency_penalties, presence_penalties, repetition_penalties]):
         no_penalties = False
 
         assert output_token_ids
         assert len(output_token_ids) > 0
+        assert prompt_token_ids is not None
+
+        num_reqs = len(output_token_ids)
+        penalties_state = PenaltiesState(
+            num_reqs, vocab_size, torch.device(DEVICE_TYPE)
+        )
+        for i in range(num_reqs):
+            params = SamplingParams(
+                frequency_penalty=frequency_penalties[i],
+                presence_penalty=presence_penalties[i],
+                repetition_penalty=repetition_penalties[i],
+            )
+            prompt = prompt_token_ids[i].cpu().numpy()
+            tokens = np.concatenate([prompt, output_token_ids[i]])
+            penalties_state.add_request(i, params, tokens, len(prompt))
+        penalty_slot_mapping = penalties_state.make_slot_mapping(num_reqs)
 
         frequency_penalties = torch.tensor(frequency_penalties, device=DEVICE_TYPE)
         presence_penalties = torch.tensor(presence_penalties, device=DEVICE_TYPE)
@@ -123,6 +145,8 @@ def create_sampling_metadata(
         repetition_penalties=repetition_penalties,
         output_token_ids=[] if output_token_ids is None else output_token_ids,
         spec_token_ids=[] if spec_token_ids is None else spec_token_ids,
+        penalties_state=penalties_state,
+        penalty_slot_mapping=penalty_slot_mapping,
         allowed_token_ids_mask=allowed_token_ids_mask,
         bad_words_token_ids={} if bad_words_token_ids is None else bad_words_token_ids,
         logitsprocs=LogitsProcessors(),

--- a/tests/v1/sample/test_sampler.py
+++ b/tests/v1/sample/test_sampler.py
@@ -7,10 +7,12 @@ import torch
 
 from tests.v1.sample.utils import create_allowed_token_ids
 from vllm.platforms import current_platform
+from vllm.sampling_params import SamplingParams
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.utils.torch_utils import make_tensor_with_pad
 from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.ops.penalties import PenaltiesState
 from vllm.v1.sample.sampler import Sampler
 
 PIN_MEMORY_AVAILABLE = is_pin_memory_available()
@@ -166,6 +168,26 @@ def _create_default_sampling_metadata(
     return fake_sampling_metadata
 
 
+def _install_penalties_state(metadata: SamplingMetadata, device: torch.device) -> None:
+    """Build the persistent penalty statistics the sampler now reads,
+    from the metadata's prompt/output token ids."""
+    batch_size = len(metadata.output_token_ids)
+    state = PenaltiesState(MAX_NUM_REQS, VOCAB_SIZE, device)
+    for i in range(batch_size):
+        params = SamplingParams(
+            presence_penalty=float(metadata.presence_penalties[i]),
+            frequency_penalty=float(metadata.frequency_penalties[i]),
+            repetition_penalty=float(metadata.repetition_penalties[i]),
+        )
+        # Recover the unpadded prompt (padded with VOCAB_SIZE).
+        prompt_row = metadata.prompt_token_ids[i]
+        prompt = prompt_row[prompt_row < VOCAB_SIZE].tolist()
+        tokens = np.array(prompt + metadata.output_token_ids[i], dtype=np.int64)
+        state.add_request(i, params, tokens, len(prompt))
+    metadata.penalties_state = state
+    metadata.penalty_slot_mapping = state.make_slot_mapping(batch_size)
+
+
 def _create_weighted_output_token_list(
     batch_size: int, vocab_size: int
 ) -> tuple[list[list[int]], list[list[int]]]:
@@ -222,10 +244,9 @@ def test_sampler_presence_penalty(
         batch_size, presence_penalty, torch.device(device)
     )
     sampling_metadata.no_penalties = False
+    _install_penalties_state(sampling_metadata, torch.device(device))
     sampler = Sampler()
-    logits = sampler.apply_penalties(
-        fake_logits, sampling_metadata, sampling_metadata.output_token_ids
-    )
+    logits = sampler.apply_penalties(fake_logits, sampling_metadata)
     logits = logits.cpu()
     for batch_idx in range(batch_size):
         # Since all tokens initially have the same logits, the non-penalized
@@ -276,10 +297,9 @@ def test_sampler_frequency_penalty(
     )
     sampling_metadata.output_token_ids = output_token_ids
     sampling_metadata.no_penalties = False
+    _install_penalties_state(sampling_metadata, torch.device(device))
     sampler = Sampler()
-    logits = sampler.apply_penalties(
-        fake_logits, sampling_metadata, sampling_metadata.output_token_ids
-    )
+    logits = sampler.apply_penalties(fake_logits, sampling_metadata)
     logits = logits.cpu()
     for batch_idx in range(batch_size):
         non_penalized_token_id = logits[batch_idx].argmax().item()
@@ -328,10 +348,9 @@ def test_sampler_repetition_penalty(
         batch_size, repetition_penalty, torch.device(device)
     )
     sampling_metadata.no_penalties = False
+    _install_penalties_state(sampling_metadata, torch.device(device))
     sampler = Sampler()
-    logits = sampler.apply_penalties(
-        fake_logits, sampling_metadata, sampling_metadata.output_token_ids
-    )
+    logits = sampler.apply_penalties(fake_logits, sampling_metadata)
     logits = logits.cpu()
     for batch_idx in range(batch_size):
         non_penalized_token_id = logits[batch_idx].argmax().item()

--- a/tests/v1/worker/test_gpu_input_batch.py
+++ b/tests/v1/worker/test_gpu_input_batch.py
@@ -10,7 +10,6 @@ import torch
 
 from vllm.platforms import current_platform
 from vllm.sampling_params import SamplingParams
-from vllm.utils.torch_utils import make_tensor_with_pad
 from vllm.v1.pool.metadata import PoolingMetadata
 from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -26,7 +25,18 @@ DEVICES = [f"{DEVICE_TYPE}:{i}" for i in range(min(current_platform.device_count
 MAX_NUM_PROMPT_TOKENS = 64
 
 
-def _compare_objs(obj1, obj2, skip: Sequence = ("logitsprocs", "batch_update_builder")):
+def _compare_objs(
+    obj1,
+    obj2,
+    # Penalty pool slot numbers depend on allocation order; equivalence of
+    # the underlying statistics is asserted via _assert_penalties_state.
+    skip: Sequence = (
+        "logitsprocs",
+        "batch_update_builder",
+        "penalties_state",
+        "penalty_slot_mapping",
+    ),
+):
     attrs = inspect.getmembers(obj1, lambda a: not (inspect.isroutine(a)))
     attr_names = set(
         [a[0] for a in attrs if not (a[0].startswith("__") and a[0].endswith("__"))]
@@ -151,12 +161,10 @@ def _construct_expected_sampling_metadata(
         else torch.tensor(top_k, dtype=torch.int, device=device),
         generators={},
         max_num_logprobs=0,
-        prompt_token_ids=make_tensor_with_pad(
-            prompt_token_ids,
-            pad=VOCAB_SIZE,
-            device=torch.device(device),
-            dtype=torch.int64,
-        ),
+        # Penalties no longer need per-step prompt/output token id tensors;
+        # they read the persistent PenaltiesState instead (asserted
+        # separately via _assert_penalties_state).
+        prompt_token_ids=None,
         frequency_penalties=torch.tensor(
             frequency_penalties, dtype=torch.float, device=device
         ),
@@ -166,7 +174,7 @@ def _construct_expected_sampling_metadata(
         repetition_penalties=torch.tensor(
             repetition_penalties, dtype=torch.float, device=device
         ),
-        output_token_ids=output_token_ids,
+        output_token_ids=[],
         spec_token_ids=[[] for _ in range(len(output_token_ids))],
         no_penalties=(
             all(x == 0 for x in presence_penalties)
@@ -290,9 +298,7 @@ def test_sampling_metadata_in_input_batch(device: str, batch_size: int):
         expected_sampling_metadata.repetition_penalties,
         sampling_metadata.repetition_penalties,
     )
-    assert torch.allclose(
-        expected_sampling_metadata.prompt_token_ids, sampling_metadata.prompt_token_ids
-    )
+    assert sampling_metadata.prompt_token_ids is None
     assert (
         expected_sampling_metadata.output_token_ids
         == sampling_metadata.output_token_ids
@@ -307,6 +313,51 @@ def test_sampling_metadata_in_input_batch(device: str, batch_size: int):
         expected_sampling_metadata.bad_words_token_ids
         == sampling_metadata.bad_words_token_ids
     )
+    _assert_penalties_state(input_batch, reqs, req_ids_retained, sampling_metadata)
+
+
+def _assert_penalties_state(
+    input_batch: InputBatch,
+    reqs: list[CachedRequestState],
+    req_ids_retained: set[str],
+    sampling_metadata: SamplingMetadata,
+) -> None:
+    """The pool statistics must equal a bincount of each retained request's
+    token history, whatever add/remove/condense/swap sequence produced the
+    current batch layout."""
+    state = input_batch.penalties_state
+    if sampling_metadata.no_penalties:
+        assert sampling_metadata.penalty_slot_mapping is None
+        return
+    slot_mapping = sampling_metadata.penalty_slot_mapping.cpu()
+    for req in reqs:
+        if req.req_id not in req_ids_retained:
+            continue
+        row = input_batch.req_id_to_index[req.req_id]
+        params = req.sampling_params
+        needs = (
+            params.presence_penalty != 0
+            or params.frequency_penalty != 0
+            or params.repetition_penalty != 1
+        )
+        slot = int(slot_mapping[row])
+        assert (slot >= 0) == needs
+        if not needs:
+            continue
+        counts = state.output_bin_counts[slot].cpu()
+        expected_counts = torch.bincount(
+            torch.tensor(req.output_token_ids, dtype=torch.int64, device="cpu"),
+            minlength=VOCAB_SIZE,
+        ).to(torch.int32)
+        assert torch.equal(counts[:VOCAB_SIZE], expected_counts)
+        packed = state.prompt_bin_mask[slot].cpu()
+        bits = (packed.unsqueeze(1) >> torch.arange(32, device="cpu")) & 1
+        prompt_mask = bits.reshape(-1)[:VOCAB_SIZE].bool()
+        expected_mask = torch.zeros(VOCAB_SIZE, dtype=torch.bool, device="cpu")
+        expected_mask[
+            torch.tensor(req.prompt_token_ids, dtype=torch.int64, device="cpu")
+        ] = True
+        assert torch.equal(prompt_mask, expected_mask)
 
 
 @pytest.mark.parametrize("device", DEVICES)
@@ -372,6 +423,11 @@ def test_swap_states_in_input_batch(device: str, batch_size: int, swap_list: lis
     ref_input_batch.refresh_metadata()
 
     _compare_objs(input_batch, ref_input_batch)
+    retained = {req.req_id for req in reqs}
+    _assert_penalties_state(input_batch, reqs, retained, input_batch.sampling_metadata)
+    _assert_penalties_state(
+        ref_input_batch, reqs, retained, ref_input_batch.sampling_metadata
+    )
 
 
 def _construct_pooling_request(req_id_suffix: int, pooling_params=None):

--- a/vllm/v1/sample/metadata.py
+++ b/vllm/v1/sample/metadata.py
@@ -4,12 +4,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import torch
 
 from vllm.v1.sample.logits_processor import LogitsProcessors
-from vllm.v1.sample.ops.penalties import PenaltiesState
 from vllm.v1.sample.thinking_budget_state import ThinkingBudgetStateHolder
+
+if TYPE_CHECKING:
+    from vllm.v1.sample.ops.penalties import PenaltiesState
 
 
 @dataclass

--- a/vllm/v1/sample/metadata.py
+++ b/vllm/v1/sample/metadata.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 import torch
 
 from vllm.v1.sample.logits_processor import LogitsProcessors
+from vllm.v1.sample.ops.penalties import PenaltiesState
 from vllm.v1.sample.thinking_budget_state import ThinkingBudgetStateHolder
 
 
@@ -48,8 +49,18 @@ class SamplingMetadata:
     # req_index -> list of token IDs to get logprobs for
     logprob_token_ids: dict[int, list[int]] | None = None
 
+    # Persistent penalty statistics and the batch-row -> pool-slot snapshot
+    # for this batch composition. Set iff `not no_penalties`.
+    penalties_state: PenaltiesState | None = None
+    penalty_slot_mapping: torch.Tensor | None = None
+
     # Speculative token ids
     spec_token_ids: list[list[int]] | None = None
+    # This step's flat draft token ids and their cumulative counts per
+    # request; set by the rejection sampler for the bonus-token sampling
+    # call so penalties can account for the drafts.
+    spec_draft_token_ids: torch.Tensor | None = None
+    spec_cu_num_draft_tokens: torch.Tensor | None = None
     # When non-None, use ``holder.has_tracked_requests()`` to see if this batch applies
     # thinking-token-budget logits (holder may exist with an empty tracking set).
     thinking_budget_state_holder: ThinkingBudgetStateHolder | None = None

--- a/vllm/v1/sample/ops/penalties.py
+++ b/vllm/v1/sample/ops/penalties.py
@@ -1,56 +1,533 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import numpy as np
 import torch
 
-from vllm.model_executor.layers.utils import apply_penalties
-from vllm.utils.torch_utils import PIN_MEMORY, make_tensor_with_pad
+from vllm.sampling_params import SamplingParams
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import cdiv
+
+_INITIAL_POOL_SLOTS = 8
 
 
-def apply_all_penalties(
-    logits: torch.Tensor,
-    prompt_token_ids: torch.Tensor,
-    presence_penalties: torch.Tensor,
-    frequency_penalties: torch.Tensor,
-    repetition_penalties: torch.Tensor,
-    output_token_ids: list[list[int]],
-) -> torch.Tensor:
-    """
-    Applies presence, frequency and repetition penalties to the logits.
-    """
-    _, vocab_size = logits.shape
-    output_tokens_t = _convert_to_tensors(output_token_ids, vocab_size, logits.device)
-
-    # In the async scheduling case, rows that won't have penalties applied may contain
-    # -1 placeholder token ids. We must replace these with valid token ids so that the
-    # scatter done in apply_penalties is valid.
-    # NOTE(nick): The penalties implementation is currently quite inefficient and
-    # will be reworked anyhow.
-    output_tokens_t.masked_fill_(output_tokens_t == -1, vocab_size)
-
-    return apply_penalties(
-        logits,
-        prompt_token_ids,
-        output_tokens_t,
-        presence_penalties,
-        frequency_penalties,
-        repetition_penalties,
+def params_need_penalties(sampling_params: SamplingParams) -> bool:
+    return (
+        sampling_params.repetition_penalty != 1.0
+        or sampling_params.frequency_penalty != 0.0
+        or sampling_params.presence_penalty != 0.0
     )
 
 
-def _convert_to_tensors(
-    output_token_ids: list[list[int]], vocab_size: int, device: torch.device
-) -> torch.Tensor:
+class PenaltiesState:
+    """Persistent per-request penalty statistics for the v1 GPU sampler.
+
+    Instead of rebuilding a padded [num_rows, max_output_len] token matrix on
+    the CPU every step (O(rows * max_len) per step, the source of multi-ms
+    stalls with long outputs), this keeps per-request vocab statistics on the
+    sampler device and updates them incrementally:
+
+    - ``output_bin_counts[slot, token]``: occurrence count of ``token`` in the
+      request's output so far (frequency penalty; ``>0`` for presence).
+    - ``prompt_bin_mask[slot, token // 32]``: packed bitmask of tokens that
+      appear in the prompt (repetition penalty).
+
+    Slots are pooled and only allocated for requests that actually use
+    penalties; ``row_to_slot`` maps batch rows to pool slots (-1 = row has no
+    penalties). Rows move within the batch (swap/condense) by updating the
+    mapping only; slot contents never move. The pool grows geometrically on
+    demand, so a batch with no penalty requests costs nothing.
+
+    Per-step costs: building the statistics is paid once at request admission
+    (O(seq_len) bincount); each step only commits the newly accepted tokens
+    (O(batch * spec_len) scatter) and applies penalties with a kernel that
+    reads the statistics in place. Draft tokens from the current step are
+    never committed; the apply kernel superimposes the per-row draft prefix
+    on the fly, which preserves rejection-sampling semantics.
     """
-    Convert the different list data structures to tensors.
-    """
-    output_tokens_tensor = make_tensor_with_pad(
-        output_token_ids,
-        # Use the value of vocab_size as a pad since we don't have a
-        # token_id of this value.
-        pad=vocab_size,
-        device="cpu",
-        dtype=torch.int64,
-        pin_memory=PIN_MEMORY,
+
+    def __init__(
+        self,
+        max_num_reqs: int,
+        vocab_size: int,
+        device: torch.device,
+    ):
+        self.max_num_reqs = max_num_reqs
+        self.vocab_size = vocab_size
+        self.device = device
+
+        # Batch row -> pool slot; -1 means the row has no penalties.
+        self.row_to_slot = np.full(max_num_reqs, -1, dtype=np.int32)
+        self.free_slots: list[int] = []
+        self.capacity = 0
+        # Lazily allocated on first penalty request:
+        # output_bin_counts: int32 [capacity, vocab_size]
+        # prompt_bin_mask:   int32 [capacity, cdiv(vocab_size, 32)]
+        self.output_bin_counts: torch.Tensor | None = None
+        self.prompt_bin_mask: torch.Tensor | None = None
+
+        # Admissions staged until the next make_slot_mapping() call:
+        # (slot, token_ids copy, prompt_len).
+        self._staged: list[tuple[int, np.ndarray, int]] = []
+
+    @property
+    def no_penalties(self) -> bool:
+        return self.capacity == len(self.free_slots) and not self._staged
+
+    def _ensure_capacity(self) -> None:
+        if self.free_slots:
+            return
+        new_capacity = max(_INITIAL_POOL_SLOTS, self.capacity * 2)
+        new_capacity = min(new_capacity, self.max_num_reqs)
+        assert new_capacity > self.capacity
+        counts = torch.zeros(
+            new_capacity, self.vocab_size, dtype=torch.int32, device=self.device
+        )
+        mask = torch.zeros(
+            new_capacity,
+            cdiv(self.vocab_size, 32),
+            dtype=torch.int32,
+            device=self.device,
+        )
+        if self.capacity > 0:
+            assert self.output_bin_counts is not None
+            assert self.prompt_bin_mask is not None
+            counts[: self.capacity] = self.output_bin_counts
+            mask[: self.capacity] = self.prompt_bin_mask
+        self.output_bin_counts = counts
+        self.prompt_bin_mask = mask
+        self.free_slots.extend(range(self.capacity, new_capacity))
+        self.capacity = new_capacity
+
+    def add_request(
+        self,
+        row: int,
+        sampling_params: SamplingParams,
+        token_ids: np.ndarray,
+        prompt_len: int,
+    ) -> None:
+        """Admit the request at ``row``.
+
+        ``token_ids`` holds the request's full token history so far
+        (prompt followed by any already-generated output, e.g. when resuming
+        after preemption); statistics are rebuilt from it.
+        """
+        assert self.row_to_slot[row] == -1, f"row {row} already has a slot"
+        if not params_need_penalties(sampling_params):
+            return
+        self._ensure_capacity()
+        slot = self.free_slots.pop()
+        self.row_to_slot[row] = slot
+        # Copy: the caller's array is a live view of the batch buffer.
+        self._staged.append((slot, token_ids.astype(np.int64), prompt_len))
+
+    def remove_row(self, row: int) -> None:
+        slot = self.row_to_slot[row]
+        if slot != -1:
+            self.row_to_slot[row] = -1
+            self.free_slots.append(int(slot))
+            self._staged = [s for s in self._staged if s[0] != slot]
+
+    def swap_rows(self, row1: int, row2: int) -> None:
+        self.row_to_slot[[row1, row2]] = self.row_to_slot[[row2, row1]]
+
+    def move_row(self, src: int, dst: int) -> None:
+        assert self.row_to_slot[dst] == -1, f"row {dst} still has a slot"
+        self.row_to_slot[dst] = self.row_to_slot[src]
+        self.row_to_slot[src] = -1
+
+    def make_slot_mapping(self, num_reqs: int) -> torch.Tensor:
+        """Flush staged admissions and snapshot row -> slot for the device.
+
+        Called when the batch composition changes (metadata refresh). Returns
+        a fresh tensor so kernels enqueued with an older snapshot are
+        unaffected by later changes.
+        """
+        self._flush_staged()
+        return torch.from_numpy(self.row_to_slot[:num_reqs].copy()).to(
+            self.device, non_blocking=True
+        )
+
+    def _flush_staged(self) -> None:
+        if not self._staged:
+            return
+        assert self.output_bin_counts is not None
+        assert self.prompt_bin_mask is not None
+        slots, token_arrays, prompt_lens = zip(*self._staged)
+        self._staged = []
+
+        slots_t = torch.tensor(slots, dtype=torch.int32, device=self.device)
+        # Zero on alloc: slots are recycled dirty.
+        slots_long = slots_t.long()
+        self.output_bin_counts.index_fill_(0, slots_long, 0)
+        self.prompt_bin_mask.index_fill_(0, slots_long, 0)
+
+        lens = [len(t) for t in token_arrays]
+        starts = np.zeros(len(lens) + 1, dtype=np.int64)
+        np.cumsum(lens, out=starts[1:])
+        flat = torch.from_numpy(np.concatenate(token_arrays)).to(
+            self.device, non_blocking=True
+        )
+        starts_t = torch.from_numpy(starts).to(self.device, non_blocking=True)
+        prompt_lens_t = torch.tensor(prompt_lens, dtype=torch.int64, device=self.device)
+        total_lens_t = torch.tensor(lens, dtype=torch.int64, device=self.device)
+
+        if self.device.type == "cpu":
+            self._bincount_native(slots_t, flat, starts_t, prompt_lens_t, total_lens_t)
+        else:
+            max_len = max(lens)
+            BLOCK_SIZE = 1024
+            _admission_bincount_kernel[(len(slots), cdiv(max_len, BLOCK_SIZE))](
+                slots_t,
+                flat,
+                starts_t,
+                prompt_lens_t,
+                total_lens_t,
+                self.prompt_bin_mask,
+                self.prompt_bin_mask.stride(0),
+                self.output_bin_counts,
+                self.output_bin_counts.stride(0),
+                self.vocab_size,
+                BLOCK_SIZE=BLOCK_SIZE,
+            )
+
+    def _bincount_native(
+        self,
+        slots: torch.Tensor,
+        flat_token_ids: torch.Tensor,
+        starts: torch.Tensor,
+        prompt_lens: torch.Tensor,
+        total_lens: torch.Tensor,
+    ) -> None:
+        assert self.output_bin_counts is not None
+        assert self.prompt_bin_mask is not None
+        packed_vocab = self.prompt_bin_mask.shape[1]
+        for i, slot in enumerate(slots.tolist()):
+            start = int(starts[i])
+            prompt_len = int(prompt_lens[i])
+            total_len = int(total_lens[i])
+            tokens = flat_token_ids[start : start + total_len]
+            valid = (tokens >= 0) & (tokens < self.vocab_size)
+            prompt_tokens = tokens[:prompt_len][valid[:prompt_len]]
+            present = torch.zeros(
+                packed_vocab * 32, dtype=torch.bool, device=self.device
+            )
+            present[prompt_tokens] = True
+            bits = present.view(packed_vocab, 32).int() << torch.arange(
+                32, dtype=torch.int32, device=self.device
+            )
+            self.prompt_bin_mask[slot] = bits.sum(dim=1, dtype=torch.int32)
+            output_tokens = tokens[prompt_len:][valid[prompt_len:]]
+            self.output_bin_counts[slot] = torch.bincount(
+                output_tokens, minlength=self.vocab_size
+            ).to(torch.int32)
+
+    def commit(
+        self,
+        sampled_token_ids: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        discard_mask: torch.Tensor | None,
+    ) -> None:
+        """Fold the step's accepted tokens into the statistics.
+
+        ``sampled_token_ids`` is the sampler's device output,
+        [num_reqs, num_sampled]; rejected/invalid positions hold negative or
+        >= vocab_size placeholders and are skipped, matching
+        ``RejectionSampler.parse_output``.
+        """
+        if self.no_penalties:
+            return
+        assert self.output_bin_counts is not None
+        num_reqs, num_sampled = sampled_token_ids.shape
+        if self.device.type == "cpu":
+            self._commit_native(sampled_token_ids, slot_mapping, discard_mask)
+            return
+        _commit_kernel[(num_reqs,)](
+            sampled_token_ids,
+            sampled_token_ids.stride(0),
+            slot_mapping,
+            discard_mask,
+            self.output_bin_counts,
+            self.output_bin_counts.stride(0),
+            self.vocab_size,
+            num_sampled,
+            HAS_DISCARD=discard_mask is not None,
+        )
+
+    def _commit_native(
+        self,
+        sampled_token_ids: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        discard_mask: torch.Tensor | None,
+    ) -> None:
+        assert self.output_bin_counts is not None
+        for req_idx, slot in enumerate(slot_mapping.tolist()):
+            if slot < 0:
+                continue
+            if discard_mask is not None and bool(discard_mask[req_idx]):
+                continue
+            tokens = sampled_token_ids[req_idx]
+            tokens = tokens[(tokens >= 0) & (tokens < self.vocab_size)]
+            self.output_bin_counts[slot] += torch.bincount(
+                tokens, minlength=self.vocab_size
+            ).to(torch.int32)
+
+    def apply(
+        self,
+        logits: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        repetition_penalties: torch.Tensor,
+        frequency_penalties: torch.Tensor,
+        presence_penalties: torch.Tensor,
+        row_to_req: torch.Tensor | None = None,
+        prefix_lens: torch.Tensor | None = None,
+        draft_token_ids: torch.Tensor | None = None,
+        draft_starts: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Apply penalties to ``logits`` in place.
+
+        ``row_to_req`` maps logits rows to request indices (identity when
+        None). ``prefix_lens``/``draft_starts`` describe, per row, how many of
+        the current step's draft tokens (a slice of flat ``draft_token_ids``)
+        to superimpose on the committed statistics: the row for draft
+        position p sees drafts [0, p), a bonus row sees all of them.
+        """
+        num_rows, vocab_size = logits.shape
+        assert vocab_size == self.vocab_size
+        assert self.output_bin_counts is not None
+        assert self.prompt_bin_mask is not None
+
+        if row_to_req is not None:
+            row_to_req_long = row_to_req.long()
+            slot_of_row = slot_mapping[row_to_req_long]
+            repetition_penalties = repetition_penalties[row_to_req_long]
+            frequency_penalties = frequency_penalties[row_to_req_long]
+            presence_penalties = presence_penalties[row_to_req_long]
+        else:
+            slot_of_row = slot_mapping
+
+        has_prefix = prefix_lens is not None
+        if has_prefix:
+            assert draft_token_ids is not None and draft_starts is not None
+        else:
+            # Unused; any tensor keeps the kernel signature uniform.
+            prefix_lens = slot_of_row
+            draft_token_ids = slot_of_row
+            draft_starts = slot_of_row
+
+        if self.device.type == "cpu":
+            return self._apply_native(
+                logits,
+                slot_of_row,
+                repetition_penalties,
+                frequency_penalties,
+                presence_penalties,
+                prefix_lens if has_prefix else None,
+                draft_token_ids,
+                draft_starts,
+            )
+
+        BLOCK_SIZE = 8192
+        _apply_penalties_kernel[(num_rows, cdiv(vocab_size, BLOCK_SIZE))](
+            logits,
+            logits.stride(0),
+            slot_of_row,
+            repetition_penalties,
+            frequency_penalties,
+            presence_penalties,
+            prefix_lens,
+            draft_token_ids,
+            draft_starts,
+            self.prompt_bin_mask,
+            self.prompt_bin_mask.stride(0),
+            self.output_bin_counts,
+            self.output_bin_counts.stride(0),
+            vocab_size,
+            HAS_PREFIX=has_prefix,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+        return logits
+
+    def _apply_native(
+        self,
+        logits: torch.Tensor,
+        slot_of_row: torch.Tensor,
+        repetition_penalties: torch.Tensor,
+        frequency_penalties: torch.Tensor,
+        presence_penalties: torch.Tensor,
+        prefix_lens: torch.Tensor | None,
+        draft_token_ids: torch.Tensor,
+        draft_starts: torch.Tensor,
+    ) -> torch.Tensor:
+        assert self.output_bin_counts is not None
+        assert self.prompt_bin_mask is not None
+        vocab_size = self.vocab_size
+        for row, slot in enumerate(slot_of_row.tolist()):
+            if slot < 0:
+                continue
+            counts = self.output_bin_counts[slot]
+            if prefix_lens is not None and int(prefix_lens[row]) > 0:
+                start = int(draft_starts[row])
+                prefix = draft_token_ids[start : start + int(prefix_lens[row])]
+                counts = counts + torch.bincount(
+                    prefix.long(), minlength=vocab_size
+                ).to(torch.int32)
+            output_mask = counts > 0
+
+            row_logits = logits[row]
+            rep = float(repetition_penalties[row])
+            if rep != 1.0:
+                packed = self.prompt_bin_mask[slot]
+                bits = (packed.unsqueeze(1) >> torch.arange(32, device=self.device)) & 1
+                prompt_mask = bits.reshape(-1)[:vocab_size].bool()
+                penalized = prompt_mask | output_mask
+                scale = torch.where(penalized, torch.full_like(row_logits, rep), 1.0)
+                row_logits *= torch.where(row_logits > 0, 1.0 / scale, scale)
+
+            row_logits -= float(frequency_penalties[row]) * counts
+            row_logits -= float(presence_penalties[row]) * output_mask
+        return logits
+
+
+@triton.jit
+def _admission_bincount_kernel(
+    slots_ptr,
+    flat_token_ids_ptr,
+    starts_ptr,
+    prompt_lens_ptr,
+    total_lens_ptr,
+    prompt_bin_mask_ptr,
+    prompt_bin_mask_stride,
+    output_bin_counts_ptr,
+    output_bin_counts_stride,
+    vocab_size,
+    BLOCK_SIZE: tl.constexpr,
+):
+    item_idx = tl.program_id(0)
+    block_idx = tl.program_id(1)
+    total_len = tl.load(total_lens_ptr + item_idx)
+    if block_idx * BLOCK_SIZE >= total_len:
+        return
+
+    slot = tl.load(slots_ptr + item_idx).to(tl.int64)
+    start = tl.load(starts_ptr + item_idx)
+    prompt_len = tl.load(prompt_lens_ptr + item_idx)
+
+    offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    tokens = tl.load(flat_token_ids_ptr + start + offsets, mask=offsets < total_len)
+    # Negative ids are async-scheduling placeholders; >= vocab_size cannot
+    # occur in committed history but is guarded for symmetry with commit.
+    valid = (offsets < total_len) & (tokens >= 0) & (tokens < vocab_size)
+
+    prompt_valid = valid & (offsets < prompt_len)
+    bit = tl.full((BLOCK_SIZE,), 1, tl.int32) << (tokens % 32)
+    tl.atomic_or(
+        prompt_bin_mask_ptr + slot * prompt_bin_mask_stride + tokens // 32,
+        bit,
+        mask=prompt_valid,
     )
-    return output_tokens_tensor.to(device, non_blocking=True)
+
+    output_valid = valid & (offsets >= prompt_len)
+    tl.atomic_add(
+        output_bin_counts_ptr + slot * output_bin_counts_stride + tokens,
+        1,
+        mask=output_valid,
+    )
+
+
+@triton.jit
+def _commit_kernel(
+    sampled_token_ids_ptr,
+    sampled_token_ids_stride,
+    slot_mapping_ptr,
+    discard_mask_ptr,
+    output_bin_counts_ptr,
+    output_bin_counts_stride,
+    vocab_size,
+    num_sampled,
+    HAS_DISCARD: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+    slot = tl.load(slot_mapping_ptr + req_idx).to(tl.int64)
+    if slot < 0:
+        return
+    # Nested on purpose: with HAS_DISCARD=False the mask pointer is null and
+    # must not be traced.
+    if HAS_DISCARD:  # noqa: SIM102
+        if tl.load(discard_mask_ptr + req_idx) != 0:
+            return
+    for i in tl.range(num_sampled):
+        token = tl.load(sampled_token_ids_ptr + req_idx * sampled_token_ids_stride + i)
+        if token >= 0 and token < vocab_size:
+            tl.atomic_add(
+                output_bin_counts_ptr + slot * output_bin_counts_stride + token,
+                1,
+            )
+
+
+@triton.jit
+def _apply_penalties_kernel(
+    logits_ptr,
+    logits_stride,
+    slot_of_row_ptr,
+    repetition_penalty_ptr,
+    frequency_penalty_ptr,
+    presence_penalty_ptr,
+    prefix_lens_ptr,
+    draft_token_ids_ptr,
+    draft_starts_ptr,
+    prompt_bin_mask_ptr,
+    prompt_bin_mask_stride,
+    output_bin_counts_ptr,
+    output_bin_counts_stride,
+    vocab_size,
+    HAS_PREFIX: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    slot = tl.load(slot_of_row_ptr + row_idx).to(tl.int64)
+    if slot < 0:
+        # Row without penalties: early return before touching logits.
+        return
+
+    rep_penalty = tl.load(repetition_penalty_ptr + row_idx)
+    freq_penalty = tl.load(frequency_penalty_ptr + row_idx)
+    pres_penalty = tl.load(presence_penalty_ptr + row_idx)
+
+    block_idx = tl.program_id(1)
+    block = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = block < vocab_size
+    logits = tl.load(logits_ptr + row_idx * logits_stride + block, mask=mask)
+    logits = logits.to(tl.float32)
+
+    output_counts = tl.load(
+        output_bin_counts_ptr + slot * output_bin_counts_stride + block,
+        mask=mask,
+        other=0,
+    )
+    if HAS_PREFIX:
+        # Superimpose this step's draft prefix without committing it.
+        prefix_len = tl.load(prefix_lens_ptr + row_idx)
+        draft_start = tl.load(draft_starts_ptr + row_idx)
+        for i in tl.range(prefix_len):
+            draft_token = tl.load(draft_token_ids_ptr + draft_start + i)
+            output_counts += (block == draft_token).to(tl.int32)
+    output_mask = output_counts > 0
+
+    if rep_penalty != 1.0:
+        packed_block = block_idx * BLOCK_SIZE // 32 + tl.arange(0, BLOCK_SIZE // 32)
+        packed = tl.load(
+            prompt_bin_mask_ptr + slot * prompt_bin_mask_stride + packed_block,
+            mask=packed_block < tl.cdiv(vocab_size, 32),
+            other=0,
+        )
+        prompt_bits = (packed[:, None] >> tl.arange(0, 32)[None, :]) & 1
+        prompt_mask = prompt_bits.to(tl.int1).reshape(BLOCK_SIZE)
+
+        scale = tl.where(prompt_mask | output_mask, rep_penalty, 1.0)
+        logits *= tl.where(logits > 0, 1.0 / scale, scale)
+
+    # OpenAI-API definitions of frequency/presence penalties.
+    logits -= freq_penalty * output_counts
+    logits -= pres_penalty * output_mask
+    tl.store(logits_ptr + row_idx * logits_stride + block, logits, mask=mask)

--- a/vllm/v1/sample/ops/penalties.py
+++ b/vllm/v1/sample/ops/penalties.py
@@ -8,8 +8,6 @@ from vllm.sampling_params import SamplingParams
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import cdiv
 
-_INITIAL_POOL_SLOTS = 8
-
 
 def params_need_penalties(sampling_params: SamplingParams) -> bool:
     return (
@@ -32,11 +30,13 @@ class PenaltiesState:
     - ``prompt_bin_mask[slot, token // 32]``: packed bitmask of tokens that
       appear in the prompt (repetition penalty).
 
-    Slots are pooled and only allocated for requests that actually use
-    penalties; ``row_to_slot`` maps batch rows to pool slots (-1 = row has no
-    penalties). Rows move within the batch (swap/condense) by updating the
-    mapping only; slot contents never move. The pool grows geometrically on
-    demand, so a batch with no penalty requests costs nothing.
+    Slots are pooled; ``row_to_slot`` maps batch rows to pool slots (-1 =
+    row has no penalties). Rows move within the batch (swap/condense) by
+    updating the mapping only; slot contents never move. The pool is
+    allocated in full on the first penalty request — never before — and its
+    memory is accounted for during memory profiling via
+    ``hold_for_profiling()``, so a deployment that never uses penalties
+    allocates nothing.
 
     Per-step costs: building the statistics is paid once at request admission
     (O(seq_len) bincount); each step only commits the newly accepted tokens
@@ -51,22 +51,26 @@ class PenaltiesState:
         max_num_reqs: int,
         vocab_size: int,
         device: torch.device,
+        enabled: bool = True,
     ):
         self.max_num_reqs = max_num_reqs
         self.vocab_size = vocab_size
         self.device = device
+        # Disabled on PP ranks that never sample; no statistics are kept.
+        self.enabled = enabled
 
         # Batch row -> pool slot; -1 means the row has no penalties.
         self.row_to_slot = np.full(max_num_reqs, -1, dtype=np.int32)
         self.free_slots: list[int] = []
         self.capacity = 0
-        # Lazily allocated on first penalty request:
-        # output_bin_counts: int32 [capacity, vocab_size]
-        # prompt_bin_mask:   int32 [capacity, cdiv(vocab_size, 32)]
+        # Allocated in full on the first penalty request (the memory is
+        # reserved by hold_for_profiling() during memory profiling):
+        # output_bin_counts: int32 [max_num_reqs, vocab_size]
+        # prompt_bin_mask:   int32 [max_num_reqs, cdiv(vocab_size, 32)]
         self.output_bin_counts: torch.Tensor | None = None
         self.prompt_bin_mask: torch.Tensor | None = None
 
-        # Admissions staged until the next make_slot_mapping() call:
+        # Admissions staged until the next flush:
         # (slot, token_ids copy, prompt_len).
         self._staged: list[tuple[int, np.ndarray, int]] = []
 
@@ -74,30 +78,34 @@ class PenaltiesState:
     def no_penalties(self) -> bool:
         return self.capacity == len(self.free_slots) and not self._staged
 
-    def _ensure_capacity(self) -> None:
-        if self.free_slots:
-            return
-        new_capacity = max(_INITIAL_POOL_SLOTS, self.capacity * 2)
-        new_capacity = min(new_capacity, self.max_num_reqs)
-        assert new_capacity > self.capacity
-        counts = torch.zeros(
-            new_capacity, self.vocab_size, dtype=torch.int32, device=self.device
+    def _pool_shapes(self) -> tuple[tuple[int, int], tuple[int, int]]:
+        return (
+            (self.max_num_reqs, self.vocab_size),
+            (self.max_num_reqs, cdiv(self.vocab_size, 32)),
         )
-        mask = torch.zeros(
-            new_capacity,
-            cdiv(self.vocab_size, 32),
-            dtype=torch.int32,
-            device=self.device,
+
+    def _allocate_pool(self) -> None:
+        counts_shape, mask_shape = self._pool_shapes()
+        self.output_bin_counts = torch.zeros(
+            counts_shape, dtype=torch.int32, device=self.device
         )
-        if self.capacity > 0:
-            assert self.output_bin_counts is not None
-            assert self.prompt_bin_mask is not None
-            counts[: self.capacity] = self.output_bin_counts
-            mask[: self.capacity] = self.prompt_bin_mask
-        self.output_bin_counts = counts
-        self.prompt_bin_mask = mask
-        self.free_slots.extend(range(self.capacity, new_capacity))
-        self.capacity = new_capacity
+        self.prompt_bin_mask = torch.zeros(
+            mask_shape, dtype=torch.int32, device=self.device
+        )
+        self.free_slots = list(range(self.max_num_reqs))
+        self.capacity = self.max_num_reqs
+
+    def hold_for_profiling(self) -> tuple[torch.Tensor, torch.Tensor] | None:
+        """Return pool-sized tensors for the caller to hold across the
+        memory-profiling dummy run, so the profiled peak accounts for the
+        pool that is otherwise allocated lazily at runtime."""
+        if not self.enabled or self.output_bin_counts is not None:
+            return None
+        counts_shape, mask_shape = self._pool_shapes()
+        return (
+            torch.zeros(counts_shape, dtype=torch.int32, device=self.device),
+            torch.zeros(mask_shape, dtype=torch.int32, device=self.device),
+        )
 
     def add_request(
         self,
@@ -113,13 +121,31 @@ class PenaltiesState:
         after preemption); statistics are rebuilt from it.
         """
         assert self.row_to_slot[row] == -1, f"row {row} already has a slot"
-        if not params_need_penalties(sampling_params):
+        if not self.enabled or not params_need_penalties(sampling_params):
             return
-        self._ensure_capacity()
+        if self.capacity == 0:
+            self._allocate_pool()
         slot = self.free_slots.pop()
         self.row_to_slot[row] = slot
         # Copy: the caller's array is a live view of the batch buffer.
         self._staged.append((slot, token_ids.astype(np.int64), prompt_len))
+
+    def rebuild_row(self, row: int, token_ids: np.ndarray, prompt_len: int) -> None:
+        """Rebuild the row's statistics from scratch.
+
+        Needed when already-committed output tokens are retroactively
+        discarded while the request stays alive (KV-load-failure recovery
+        rewinds the output history); the committed counts would otherwise
+        keep the discarded tokens forever. Flushes immediately: this path
+        does not necessarily change the batch composition, so no metadata
+        refresh (and thus no flush) may follow.
+        """
+        slot = self.row_to_slot[row]
+        if slot == -1:
+            return
+        self._staged = [s for s in self._staged if s[0] != slot]
+        self._staged.append((int(slot), token_ids.astype(np.int64), prompt_len))
+        self._flush_staged()
 
     def remove_row(self, row: int) -> None:
         slot = self.row_to_slot[row]
@@ -369,6 +395,9 @@ class PenaltiesState:
             if prefix_lens is not None and int(prefix_lens[row]) > 0:
                 start = int(draft_starts[row])
                 prefix = draft_token_ids[start : start + int(prefix_lens[row])]
+                # Match the kernel: out-of-range draft ids never match a
+                # vocab bin, so they contribute nothing.
+                prefix = prefix[(prefix >= 0) & (prefix < vocab_size)]
                 counts = counts + torch.bincount(
                     prefix.long(), minlength=vocab_size
                 ).to(torch.int32)

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -16,7 +16,6 @@ from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplerOutput
 from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.bad_words import apply_bad_words_with_drafts
-from vllm.v1.sample.ops.penalties import apply_all_penalties
 from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
 from vllm.v1.sample.sampler import Sampler
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
@@ -132,6 +131,8 @@ class RejectionSampler(nn.Module):
             sampling_metadata=replace(
                 sampling_metadata,
                 max_num_logprobs=-1,
+                spec_draft_token_ids=metadata.draft_token_ids,
+                spec_cu_num_draft_tokens=metadata.cu_num_draft_tokens,
             ),
             predict_bonus_token=True,
             # Override the logprobs mode to return logits because they are
@@ -289,14 +290,11 @@ class RejectionSampler(nn.Module):
         metadata: SpecDecodeMetadata,
     ) -> torch.Tensor:
         has_penalties = not sampling_metadata.no_penalties
-        any_penalties_or_bad_words = (
-            sampling_metadata.bad_words_token_ids or has_penalties
-        )
         holder = sampling_metadata.thinking_budget_state_holder
         needs_thinking = holder is not None and holder.has_tracked_requests()
 
         output_token_ids = sampling_metadata.output_token_ids
-        if any_penalties_or_bad_words or needs_thinking:
+        if sampling_metadata.bad_words_token_ids or needs_thinking:
             output_token_ids = self._combine_outputs_with_spec_tokens(
                 output_token_ids,
                 sampling_metadata.spec_token_ids,
@@ -318,7 +316,7 @@ class RejectionSampler(nn.Module):
                 device=logits.device, non_blocking=True
             )
             logits = self.apply_penalties(
-                logits, sampling_metadata, metadata, repeat_indices, output_token_ids
+                logits, sampling_metadata, metadata, repeat_indices
             )
 
             # Apply allowed token ids.
@@ -351,27 +349,35 @@ class RejectionSampler(nn.Module):
         sampling_metadata: SamplingMetadata,
         metadata: SpecDecodeMetadata,
         repeat_indices: torch.Tensor,
-        output_token_ids: list[list[int]],
     ) -> torch.Tensor:
         if sampling_metadata.no_penalties:
             return logits
 
-        assert sampling_metadata.prompt_token_ids is not None
+        state = sampling_metadata.penalties_state
+        slot_mapping = sampling_metadata.penalty_slot_mapping
+        assert state is not None and slot_mapping is not None
 
-        prompt_token_ids = sampling_metadata.prompt_token_ids[repeat_indices]
-        presence_penalties = sampling_metadata.presence_penalties[repeat_indices]
-        frequency_penalties = sampling_metadata.frequency_penalties[repeat_indices]
-        repetition_penalties = sampling_metadata.repetition_penalties[repeat_indices]
-
-        logits = apply_all_penalties(
-            logits,
-            prompt_token_ids,
-            presence_penalties,
-            frequency_penalties,
-            repetition_penalties,
-            output_token_ids,
+        # The row verifying draft position p sees this step's drafts [0, p).
+        cu = metadata.cu_num_draft_tokens
+        starts = torch.zeros_like(cu)
+        starts[1:] = cu[:-1]
+        row_starts = starts[repeat_indices.long()]
+        local_pos = (
+            torch.arange(logits.shape[0], device=logits.device, dtype=cu.dtype)
+            - row_starts
         )
-        return logits
+
+        return state.apply(
+            logits,
+            slot_mapping,
+            sampling_metadata.repetition_penalties,
+            sampling_metadata.frequency_penalties,
+            sampling_metadata.presence_penalties,
+            row_to_req=repeat_indices,
+            prefix_lens=local_pos,
+            draft_token_ids=metadata.draft_token_ids,
+            draft_starts=row_starts,
+        )
 
     @staticmethod
     def _combine_outputs_with_spec_tokens(

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -401,7 +401,9 @@ class Sampler(nn.Module):
             logits = processor.apply(logits)
 
         # Apply penalties (e.g., freq_penalties).
-        logits = self.apply_penalties(logits, sampling_metadata, predict_bonus_token)
+        logits = self.apply_penalties(
+            logits, sampling_metadata, predict_bonus_token=predict_bonus_token
+        )
         if holder is not None and holder.has_tracked_requests():
             holder.update_state(
                 output_token_ids,
@@ -419,6 +421,7 @@ class Sampler(nn.Module):
     def apply_penalties(
         logits: torch.Tensor,
         sampling_metadata: SamplingMetadata,
+        *,
         predict_bonus_token: bool = False,
     ) -> torch.Tensor:
         if sampling_metadata.no_penalties:

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -11,7 +11,6 @@ from vllm.v1.outputs import LogprobsTensors, SamplerOutput
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.bad_words import apply_bad_words
 from vllm.v1.sample.ops.logprobs import batched_count_greater_than
-from vllm.v1.sample.ops.penalties import apply_all_penalties
 from vllm.v1.sample.ops.topk_topp_sampler import TopKTopPSampler
 
 _SAMPLING_EPS = 1e-5
@@ -375,15 +374,12 @@ class Sampler(nn.Module):
         predict_bonus_token: bool,
     ) -> torch.Tensor:
         bad_words_token_ids = sampling_metadata.bad_words_token_ids
-        any_penalties_or_bad_words = (
-            bool(bad_words_token_ids) or not sampling_metadata.no_penalties
-        )
         holder = sampling_metadata.thinking_budget_state_holder
         needs_thinking_combine = holder is not None and holder.has_tracked_requests()
 
         output_token_ids = sampling_metadata.output_token_ids
         if predict_bonus_token and (
-            any_penalties_or_bad_words or needs_thinking_combine
+            bool(bad_words_token_ids) or needs_thinking_combine
         ):
             # Combine base outputs with spec tokens when speculative decoding
             # is enabled.
@@ -405,7 +401,7 @@ class Sampler(nn.Module):
             logits = processor.apply(logits)
 
         # Apply penalties (e.g., freq_penalties).
-        logits = self.apply_penalties(logits, sampling_metadata, output_token_ids)
+        logits = self.apply_penalties(logits, sampling_metadata, predict_bonus_token)
         if holder is not None and holder.has_tracked_requests():
             holder.update_state(
                 output_token_ids,
@@ -423,17 +419,32 @@ class Sampler(nn.Module):
     def apply_penalties(
         logits: torch.Tensor,
         sampling_metadata: SamplingMetadata,
-        output_token_ids: list[list[int]],
+        predict_bonus_token: bool = False,
     ) -> torch.Tensor:
         if sampling_metadata.no_penalties:
             return logits
 
-        assert sampling_metadata.prompt_token_ids is not None
-        return apply_all_penalties(
+        state = sampling_metadata.penalties_state
+        slot_mapping = sampling_metadata.penalty_slot_mapping
+        assert state is not None and slot_mapping is not None
+
+        prefix_lens = draft_token_ids = draft_starts = None
+        if predict_bonus_token and sampling_metadata.spec_draft_token_ids is not None:
+            # Bonus rows see all of the request's draft tokens for this step.
+            cu = sampling_metadata.spec_cu_num_draft_tokens
+            assert cu is not None
+            draft_starts = torch.zeros_like(cu)
+            draft_starts[1:] = cu[:-1]
+            prefix_lens = cu - draft_starts
+            draft_token_ids = sampling_metadata.spec_draft_token_ids
+
+        return state.apply(
             logits,
-            sampling_metadata.prompt_token_ids,
-            sampling_metadata.presence_penalties,
-            sampling_metadata.frequency_penalties,
+            slot_mapping,
             sampling_metadata.repetition_penalties,
-            output_token_ids,
+            sampling_metadata.frequency_penalties,
+            sampling_metadata.presence_penalties,
+            prefix_lens=prefix_lens,
+            draft_token_ids=draft_token_ids,
+            draft_starts=draft_starts,
         )

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -103,6 +103,7 @@ class InputBatch:
         max_num_blocks_per_req: list[int] | None = None,
         logitsprocs: LogitsProcessors | None = None,
         logitsprocs_need_output_token_ids: bool = False,
+        enable_penalties: bool = True,
         num_spec_tokens: int = 0,
         is_pooling_model: bool = False,
         cp_kv_cache_interleave_size: int = 1,
@@ -125,7 +126,9 @@ class InputBatch:
         self._req_ids: list[str | None] = []
         self.req_id_to_index: dict[str, int] = {}
 
-        self.penalties_state = PenaltiesState(max_num_reqs, vocab_size, device)
+        self.penalties_state = PenaltiesState(
+            max_num_reqs, vocab_size, device, enabled=enable_penalties
+        )
 
         # TODO(woosuk): This buffer could be too large if max_model_len is big.
         # Find a way to reduce the CPU memory usage.
@@ -411,10 +414,7 @@ class InputBatch:
             if sampling_params.repetition_penalty != 1.0:
                 self.repetition_penalties_reqs.add(req_id)
             self.penalties_state.add_request(
-                req_index,
-                sampling_params,
-                self.token_ids_cpu[req_index, :end_idx],
-                num_prompt_tokens,
+                req_index, sampling_params, *self._penalty_token_history(req_index)
             )
 
             # NOTE(woosuk): self.generators should not include the requests that
@@ -516,6 +516,25 @@ class InputBatch:
         self.token_ids_cpu[req_index, start_index:end_token_index] = spec_token_ids
         self.is_token_ids[req_index, start_index:end_token_index] = True
         cur_spec_token_ids.extend(spec_token_ids)
+
+    def _penalty_token_history(self, req_index: int) -> tuple[np.ndarray, int]:
+        """The request's committed token history and prompt length, as the
+        penalty statistics should see them."""
+        num_prompt_tokens = int(self.num_prompt_tokens[req_index])
+        end_idx = int(self.num_tokens_no_spec[req_index])
+        if not self.is_token_ids[req_index, :num_prompt_tokens].all():
+            # Prompt embeddings: (part of) the prompt region of
+            # token_ids_cpu is uninitialized, so no prompt bitmap can be
+            # built from it.
+            return self.token_ids_cpu[req_index, num_prompt_tokens:end_idx], 0
+        return self.token_ids_cpu[req_index, :end_idx], num_prompt_tokens
+
+    def rebuild_penalties_row(self, req_index: int) -> None:
+        """Rebuild the row's penalty statistics after its committed output
+        history was rewound (KV-load-failure recovery)."""
+        self.penalties_state.rebuild_row(
+            req_index, *self._penalty_token_history(req_index)
+        )
 
     def remove_request(self, req_id: str) -> int | None:
         """This method must always be followed by a call to condense().

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -24,6 +24,7 @@ from vllm.v1.sample.logits_processor import (
     MoveDirectionality,
 )
 from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.ops.penalties import PenaltiesState
 from vllm.v1.sample.thinking_budget_state import (
     maybe_create_thinking_budget_state_holder,
 )
@@ -123,6 +124,8 @@ class InputBatch:
 
         self._req_ids: list[str | None] = []
         self.req_id_to_index: dict[str, int] = {}
+
+        self.penalties_state = PenaltiesState(max_num_reqs, vocab_size, device)
 
         # TODO(woosuk): This buffer could be too large if max_model_len is big.
         # Find a way to reduce the CPU memory usage.
@@ -407,6 +410,12 @@ class InputBatch:
             )
             if sampling_params.repetition_penalty != 1.0:
                 self.repetition_penalties_reqs.add(req_id)
+            self.penalties_state.add_request(
+                req_index,
+                sampling_params,
+                self.token_ids_cpu[req_index, :end_idx],
+                num_prompt_tokens,
+            )
 
             # NOTE(woosuk): self.generators should not include the requests that
             # do not have their own generator.
@@ -550,6 +559,7 @@ class InputBatch:
         self.frequency_penalties_reqs.discard(req_id)
         self.presence_penalties_reqs.discard(req_id)
         self.repetition_penalties_reqs.discard(req_id)
+        self.penalties_state.remove_row(req_index)
         self.generators.pop(req_index, None)
         self.num_logprobs.pop(req_id, None)
         self.logprob_token_ids.pop(req_id, None)
@@ -659,6 +669,7 @@ class InputBatch:
             self.repetition_penalties_cpu[i2],
             self.repetition_penalties_cpu[i1],
         )
+        self.penalties_state.swap_rows(i1, i2)
         self.num_accepted_tokens_cpu[i1], self.num_accepted_tokens_cpu[i2] = (
             self.num_accepted_tokens_cpu[i2],
             self.num_accepted_tokens_cpu[i1],
@@ -784,6 +795,7 @@ class InputBatch:
             self.repetition_penalties_cpu[empty_index] = self.repetition_penalties_cpu[
                 last_req_index
             ]
+            self.penalties_state.move_row(last_req_index, empty_index)
             self.num_accepted_tokens_cpu[empty_index] = self.num_accepted_tokens_cpu[
                 last_req_index
             ]
@@ -842,6 +854,7 @@ class InputBatch:
         if not self.no_top_k:
             copy_slice(self.top_k_cpu_tensor, self.top_k, num_reqs)
 
+        penalty_slot_mapping = None
         if not self.no_penalties:
             # Since syncing these tensors is expensive only copy them
             # if necessary i.e. if there are requests which require
@@ -857,10 +870,10 @@ class InputBatch:
                 self.repetition_penalties,
                 num_reqs,
             )
+            penalty_slot_mapping = self.penalties_state.make_slot_mapping(num_reqs)
 
-        needs_prompt_token_ids = (
-            not self.no_penalties
-            or self.logits_processing_needs_token_ids[:num_reqs].any()
+        needs_prompt_token_ids = bool(
+            self.logits_processing_needs_token_ids[:num_reqs].any()
         )
         # The prompt tokens are used only for applying penalties or
         # step pooling during the sampling/pooling process.
@@ -882,8 +895,7 @@ class InputBatch:
             holder is not None and holder.has_tracked_requests()
         )
         needs_output_token_ids = (
-            not self.no_penalties
-            or bool(self.bad_words_token_ids)
+            bool(self.bad_words_token_ids)
             or self.logitsprocs_need_output_token_ids
             or thinking_budget_tracks_reqs
         )
@@ -928,6 +940,8 @@ class InputBatch:
             output_token_ids=output_token_ids,
             spec_token_ids=self.spec_token_ids,
             no_penalties=self.no_penalties,
+            penalties_state=None if self.no_penalties else self.penalties_state,
+            penalty_slot_mapping=penalty_slot_mapping,
             allowed_token_ids_mask=allowed_token_ids_mask,
             bad_words_token_ids=self.bad_words_token_ids,
             logitsprocs=self.logitsprocs,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3649,6 +3649,18 @@ class GPUModelRunner(
         num_sampled_tokens = sampler_output.sampled_token_ids.shape[0]
         sampled_token_ids = sampler_output.sampled_token_ids
         logprobs_tensors = sampler_output.logprobs_tensors
+
+        sampling_metadata = self.input_batch.sampling_metadata
+        if not sampling_metadata.no_penalties:
+            # Fold this step's accepted tokens into the persistent penalty
+            # statistics; placeholder/rejected ids and discarded rows are
+            # skipped inside.
+            assert sampling_metadata.penalty_slot_mapping is not None
+            self.input_batch.penalties_state.commit(
+                sampled_token_ids,
+                sampling_metadata.penalty_slot_mapping,
+                self.discard_request_mask.gpu[:num_sampled_tokens],
+            )
         invalid_req_indices = []
         logprobs_lists = None
         if not self.use_async_scheduling:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -704,6 +704,8 @@ class GPUModelRunner(
             is_pooling_model=self.is_pooling_model,
             cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
             reasoning_config=self.vllm_config.reasoning_config,
+            # Penalty statistics are only needed where sampling happens.
+            enable_penalties=get_pp_group().is_last_rank and not self.is_pooling_model,
         )
 
         # Separate cuda stream for overlapping transfer of sampled token ids from
@@ -1376,6 +1378,12 @@ class GPUModelRunner(
                 # Some output tokens were discarded due to a sync-KV-load
                 # failure, or output_token_ids was inflated by the optimistic
                 # extend above (async spec decode). Align the cached state.
+                # Discarded real tokens (as opposed to -1 optimistic
+                # placeholders, which were never committed) have already been
+                # folded into the penalty statistics and must be rebuilt out.
+                discarded_committed_tokens = any(
+                    t != -1 for t in req_state.output_token_ids[num_output_tokens:]
+                )
                 del req_state.output_token_ids[num_output_tokens:]
                 if req_index is not None:
                     end_idx = (
@@ -1383,6 +1391,8 @@ class GPUModelRunner(
                         + num_output_tokens
                     )
                     self.input_batch.num_tokens_no_spec[req_index] = end_idx
+                    if discarded_committed_tokens:
+                        self.input_batch.rebuild_penalties_row(req_index)
 
             # Update the block IDs.
             if not resumed_from_preemption:
@@ -6319,6 +6329,10 @@ class GPUModelRunner(
                         for i, output in enumerate(dummy_encoder_outputs):
                             self.encoder_cache[f"tmp_{i}"] = output
 
+        # Hold the fully-sized penalties pool across the dummy run so the
+        # profiled peak accounts for it; at runtime it is allocated lazily
+        # on the first penalty request.
+        penalties_reservation = self.input_batch.penalties_state.hold_for_profiling()
         # Add `is_profile` here to pre-allocate communication buffers
         hidden_states, last_hidden_states = self._dummy_run(
             self.max_num_tokens, is_profile=True
@@ -6331,7 +6345,7 @@ class GPUModelRunner(
         else:
             output = None
         self._sync_device()
-        del hidden_states, output
+        del hidden_states, output, penalties_reservation
         self.encoder_cache.clear()
         gc.collect()
 


### PR DESCRIPTION
## Purpose

The V1 model runner's sampler rebuilds a padded `[rows, max_output_len]` token id matrix on the CPU **every decode step** whenever any request in the batch uses presence/frequency/repetition penalties (`make_tensor_with_pad`: `np.full` + per-row copy + `pin_memory` + H2D, then a full re-bincount on the GPU). The cost is O(rows × max_output_len) per step and is set by the longest output history in the batch. The rejection sampler additionally copies the entire output history list once per draft position in `_combine_outputs_with_spec_tokens`, and the async-scheduling path takes a hard `async_copy_ready_event.synchronize()` every step to repair the CPU-side output lists first.

Measured on an RTX 5090 (Qwen3-4B + DFlash k=16, bs=4, `ignore_eos`, all three penalties set): the old path costs **6ms/step at 4k output history, growing linearly to 47ms/step at 28k** — every step, on the CPU critical path. In a DP deployment this is a per-step straggler: whichever rank holds the longest output stalls every other rank at the DP sync point (this is how we found it in production). The existing implementation notes this itself (`NOTE(nick): The penalties implementation is currently quite inefficient and will be reworked anyhow`).

This PR replaces the per-step rebuild with persistent per-request statistics (`PenaltiesState`):

- `output_bin_counts` (int32 `[max_num_reqs, vocab]`) and a packed `prompt_bin_mask` (int32 `[max_num_reqs, vocab/32]`) live on the sampler device.
- Statistics are built **once at request admission** (O(seq_len) bincount kernel; also covers resume-after-preemption), and each step only folds in the newly accepted tokens (O(batch × spec_len) scatter from the device-side sampled ids — the async `-1` placeholder special case disappears entirely, along with the per-step synchronize).
- The apply kernel (a close port of the V2 runner's `_penalties_kernel`) reads the statistics in place and superimposes the current step's draft prefix per row in registers: a normal row sees no drafts, the row verifying draft position p sees drafts `[0, p)`, and the bonus row sees all of them. Rejected drafts never touch the persistent counts. This also deletes `_combine_outputs_with_spec_tokens` from the rejection-sampler path (O(k × len) Python list copies per request per step).
- Slots are pooled with a row→slot indirection, so batch reordering (`swap_states`/`condense`) updates a small CPU array instead of moving statistics. The pool is allocated lazily in full on the first penalty request; an equally-sized reservation is held across the memory-profiling dummy run so the profiled peak accounts for it. A deployment that never uses penalties allocates nothing. Non-last PP ranks and pooling models keep the state disabled.
- When a request's committed output history is rewound while it stays in the batch (sync-KV-load-failure recovery), its statistics are rebuilt from the surviving history; `-1` optimistic placeholders (async spec decode) were never committed and don't trigger a rebuild.
- Each of the three kernels has a torch-native fallback used by the CPU backend (dispatch on device type).

### Relationship to the V2 runner implementation

`vllm/v1/worker/gpu/sample/penalties.py` (V2 runner) already uses the same idea, and the apply/bincount kernels here are close ports of it. They are not shared because the two runners have different request-state models: V2 keeps requests in stable slots with the full token history resident on the GPU, while the V1 `InputBatch` is a dense, reordering batch with a CPU-side history — hence the admission-time bincount and the row→slot page table here. The lazy full allocation + profiling reservation also addresses the memory concern flagged in V2's `TODO(woosuk)` (V2 allocates `[max_num_reqs, vocab]` unconditionally at init). Unifying both behind one implementation becomes natural once the V2 request-state model is the only one; meanwhile the V1 runner is still what runs for MoE models outside the default-V2 architecture list, hybrid models, ngram/dynamic speculative decoding, parallel-drafting EAGLE, EAGLE3+PP, DBO, elastic EP, logits-processor plugins, and every explicit `VLLM_USE_V2_MODEL_RUNNER=0` deployment.

### Not a duplicate

Checked open PRs/issues before starting:
- #41118 hits the same production symptom (TPOT regression with penalties + ~50k outputs) but optimizes the padding loop with JIT-compiled C++ — the O(rows × max_len) matrix is still rebuilt, pinned and re-bincounted every step. This PR removes the per-step rebuild altogether.
- #47224 optimizes the prompt-mask scatter on the GPU side; orthogonal.
- #34213 (draft) simplifies the V2-runner implementation only.

## Test Plan

```bash
pytest tests/v1/sample/test_penalties_state.py       # new: oracle alignment
pytest tests/v1/worker/test_gpu_input_batch.py
pytest tests/v1/sample/test_rejection_sampler.py
pytest tests/v1/sample/test_sampler.py
```

The new test file checks the pooled statistics against an independent reference (recomputing penalties from the full Python-side histories) across randomized add/remove/condense/swap/commit episodes, draft-verification and bonus rows, slot reuse, multi-block vocab/history shapes, history-rewind rebuild, and the disabled state — parameterized over CPU (native fallbacks) and CUDA (Triton kernels).

Additional validation performed:
- **Bit-exactness vs the old implementation**: random spec-decode cases evaluated through both the old `apply_all_penalties` path (from git history) and the new kernels — `max_diff = 0.0`, zero argmax flips.
- **In-engine statistics audit**: after a 300-token dflash generation with penalties, the pool's output counts match a bincount of the actual returned tokens exactly and the prompt bitmap matches the prompt token set (in-process engine, `VLLM_ENABLE_V1_MULTIPROCESSING=0`).

## Test Result

All listed suites pass on an RTX 5090 (134 passed) and locally on an RTX 5070 Ti.

### Performance

Per-step penalty CPU time on the sampler critical path (server-side instrumentation, Qwen3-4B + DFlash k=16, bs=4, all three penalties):

| output history | old (main) | this PR |
|---|---|---|
| 0–4k | 6.1 ms | 0.07 ms |
| 12–16k | 25.6 ms | 0.07 ms |
| 24–28k | **47.1 ms** | **0.07 ms** |

End-to-end A/B with acceptance rate pinned (`rejection_sample_method="synthetic"`, `synthetic_acceptance_length=3.0`, so GPU work is identical across all four runs; `VLLM_USE_V2_MODEL_RUNNER=0`; 4 concurrent requests × 28k output tokens):

| | penalties ON | penalties OFF |
|---|---|---|
| main | 368.5 s / 304.0 tok/s | 243.9 s / 459.3 tok/s |
| this PR | **258.3 s / 433.5 tok/s** | 243.6 s / 459.8 tok/s |

The penalty overhead drops from +51% to +6% of wall time (the remainder is the apply kernel itself); penalties-off numbers are unchanged.

---

AI assistance was used for this PR (Claude); the submitter has reviewed the changes and run the tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
