### PR TITLE
[Bugfix] Verify functional P2P before enabling MiniMax fused allreduce+RMSNorm

### DIFF
--- a/vllm/model_executor/layers/minimax_rms_norm/rms_norm_tp.py
+++ b/vllm/model_executor/layers/minimax_rms_norm/rms_norm_tp.py
@@ -295,6 +295,10 @@ class MiniMaxText01RMSNormTP(CustomOp):
 
         self.workspace = None
         if _MINIMAX_FUSED_AR_RMS_QK is not None and self.tp_world > 1:
+            from vllm.distributed.device_communicators.custom_all_reduce import (
+                _can_p2p,
+            )
+
             from .lamport_workspace import (
                 get_allreduce_workspace,
             )
@@ -304,13 +308,31 @@ class MiniMaxText01RMSNormTP(CustomOp):
             # available; on topologies where it is not (e.g. consumer PCIe cards
             # with P2P disabled in the driver), allocation raises. Fall back to
             # the eager allreduce + RMSNorm path instead of failing model load.
+            #
+            # Note that the driver may report P2P as available
+            # (can_device_access_peer() returns True and the IPC handle
+            # exchange succeeds) while actual peer writes silently never
+            # arrive. On such topologies the Lamport spin-wait loops forever
+            # waiting for flags that are never delivered, hanging startup with
+            # all ranks at 100% GPU. Guard with the same functional P2P write
+            # check used by the custom allreduce instead of trusting the
+            # driver's report.
             try:
-                self.workspace = get_allreduce_workspace(
-                    rank=self.tp_rank,
-                    world_size=self.tp_world,
-                    max_tokens=MINIMAX_QK_NORM_MAX_TOKEN_NUM,
-                    process_group=get_tp_group().cpu_group,
-                )
+                if not _can_p2p(self.tp_rank, self.tp_world):
+                    logger.warning_once(
+                        "MiniMax fused allreduce+RMSNorm disabled: functional "
+                        "P2P access check failed (the driver may report P2P "
+                        "as available even though peer writes do not work, "
+                        "e.g. on consumer PCIe multi-GPU boards). Falling "
+                        "back to the eager allreduce + RMSNorm path."
+                    )
+                else:
+                    self.workspace = get_allreduce_workspace(
+                        rank=self.tp_rank,
+                        world_size=self.tp_world,
+                        max_tokens=MINIMAX_QK_NORM_MAX_TOKEN_NUM,
+                        process_group=get_tp_group().cpu_group,
+                    )
             except Exception as e:
                 logger.warning_once(
                     "Failed to initialize MiniMax fused allreduce+RMSNorm "


### PR DESCRIPTION
## The problem

Serving MiniMax-M2 models with tensor parallelism on multi-GPU boxes whose driver **reports P2P as available but where peer writes silently never arrive** (a well-known failure mode on consumer PCIe multi-GPU rigs — see #2728) hangs forever at the end of server startup:

- All TP workers spin at 100% GPU utilization during `profile_run`.
- The EngineCore logs `No available shared memory broadcast block found in 60 seconds` every minute, indefinitely.
- The hang occurs in every execution mode — VLLM_COMPILE, `--enforce-eager`, with or without `--disable-custom-all-reduce` / `NCCL_P2P_DISABLE=1` — because the fused op sits in every attention layer.

py-spy (with `CUDA_LAUNCH_BLOCKING=1`) pins all ranks inside `_minimax_qk_norm_fusion`: the Lamport-based fused allreduce+RMSNorm kernel spin-waits for peer-written flags that are never delivered. The workspace initialization succeeds — `can_device_access_peer()` returns `True` and the CUDA IPC handle exchange works — so the existing allocation-failure fallback never triggers. On the affected machine, a `cuda:0 → cuda:1` copy of ones sums to **0.0**: the driver lies, data silently doesn't arrive. Bare NCCL is unaffected (it detects and routes around broken P2P), which makes this hang specific to the fused path and painful to diagnose: no error, no crash, just an eternal spin.

Observed on vLLM 0.24.0, torch 2.11, 8× sm_86 24 GB GPUs (PCIe topology, PHB/NODE), `MiniMax-M2.7-AWQ-4bit`, TP=8. Regression vs 0.19, which predates the fused kernel.

## The fix

Gate the Lamport workspace on the functional P2P write check (`gpu_p2p_access_check`) that custom allreduce already uses for exactly this driver failure mode, falling back to the documented eager allreduce+RMSNorm path. Verified on the affected 8-GPU host: startup completes and inference works with the fused path disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)