### PR TITLE
[CI][AMD] Allow git operations on previously created work trees

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -448,9 +448,11 @@ checkout="${BUILDKITE_BUILD_CHECKOUT_PATH:-}"
 if [[ -z "${checkout}" || ! -d "${checkout}" ]]; then
   checkout="."
 fi
-if git -C "${checkout}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+# Pass safe.directory per-command (-c) because buildkite runs will always fail
+# the next check on git 2.35.2+ due to mixed uses of root and buildkite-agent/uids.
+if git -c "safe.directory=${checkout}" -C "${checkout}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   vllm_standalone_merge_base="$(
-    git -C "${checkout}" merge-base HEAD origin/main 2>/dev/null || true
+    git -c "safe.directory=${checkout}" -C "${checkout}" merge-base HEAD origin/main 2>/dev/null || true
   )"
 fi
 if [[ -z "${vllm_standalone_merge_base}" ]]; then


### PR DESCRIPTION
The buildkite runs git checkout as root but the job command as a different user (e.g. buildkite-agent/uid=1001); git 2.35.2+ rejects the repo with "fatal: detected dubious ownership" unless the directory is explicitly allowed. This failure is specific to runs merging main and could not be reproduced with runs on main

Testing was confirmed with https://buildkite.com/organizations/vllm/pipelines/ci/builds/76199/jobs/019f27c2-c106-4cdc-adf4-a903ca433174/log

Previous failures were seen with https://buildkite.com/organizations/vllm/pipelines/ci/builds/76131/jobs/019f265d-bed2-4b38-91fd-9765a8c9aedb/log