### PR TITLE
[Bugfix] Coerce scalar tool call arguments and reject malformed JSON in _postprocess_messages

### DIFF
--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -18,6 +18,7 @@ from vllm.entrypoints.chat_utils import (
     parse_chat_messages,
     parse_chat_messages_async,
 )
+from vllm.exceptions import VLLMValidationError
 from vllm.inputs import MultiModalDataDict, MultiModalUUIDDict
 from vllm.multimodal.utils import (
     encode_audio_url,
@@ -2742,3 +2743,43 @@ def test_postprocess_messages_null_arguments_string():
     tool_calls = messages[0]["tool_calls"]
     assert tool_calls is not None
     assert tool_calls[0]["function"]["arguments"] == {}
+
+
+def _assistant_message_with_arguments(arguments: str) -> list[ConversationMessage]:
+    return [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_current_time", "arguments": arguments},
+                }
+            ],
+        }
+    ]
+
+
+@pytest.mark.parametrize("arguments", ['"escaped string"', "42", "true"])
+def test_postprocess_messages_scalar_arguments_string(arguments: str):
+    """arguments decoding to a JSON scalar must not reach the chat template.
+
+    json.loads('"escaped string"') returns a str, which causes Jinja2
+    templates that call tc.arguments.items() to raise
+    'str' object has no attribute 'items'. The function should coerce
+    scalars to {} instead.
+    """
+    messages = _assistant_message_with_arguments(arguments)
+    _postprocess_messages(messages)
+    tool_calls = messages[0]["tool_calls"]
+    assert tool_calls is not None
+    assert tool_calls[0]["function"]["arguments"] == {}
+
+
+def test_postprocess_messages_malformed_arguments_string():
+    """Malformed JSON in arguments must raise a validation error (400),
+    not an unhandled json.JSONDecodeError (500)."""
+    messages = _assistant_message_with_arguments('{"city": ')
+    with pytest.raises(VLLMValidationError):
+        _postprocess_messages(messages)

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1854,8 +1854,19 @@ def _postprocess_messages(messages: list[ConversationMessage]) -> None:
                 # if arguments is None or empty string, set to {}
                 if content := function.get("arguments"):
                     if not isinstance(content, (dict, list)):
-                        parsed = json.loads(content)
-                        function["arguments"] = parsed if parsed is not None else {}
+                        try:
+                            parsed = json.loads(content)
+                        except json.JSONDecodeError as e:
+                            raise VLLMValidationError(
+                                "assistant tool_calls function arguments must "
+                                "be a JSON object string.",
+                                parameter="tool_calls",
+                            ) from e
+                        # coerce scalars (null, str, numbers, bools) to {} so
+                        # templates that call arguments.items() don't crash
+                        function["arguments"] = (
+                            parsed if isinstance(parsed, (dict, list)) else {}
+                        )
                 else:
                     function["arguments"] = {}
 


### PR DESCRIPTION
## Purpose

Fixes #46328

An assistant message whose `tool_calls[].function.arguments` JSON-decodes to a scalar (e.g. `"\"escaped string\""`, the exact repro payload from the issue) was stored as-is by `_postprocess_messages`, so chat templates that call `arguments.items()` (GLM among others) crash with `'str' object has no attribute 'items'` and the server returns a 500. A malformed JSON string in `arguments` similarly raised an uncaught `json.JSONDecodeError` → 500.

This PR:
- coerces parsed JSON scalars (`str`/number/bool — and `null`, as before) to `{}`, the same treatment #43862 applied to the `"null"` case, so templates expecting dict arguments don't crash;
- raises `VLLMValidationError` (→ 400 with a clear message) for malformed JSON instead of an unhandled 500.

Dict and list arguments are preserved unchanged.

## Why this is not duplicating an existing PR

Checked before starting and again before opening this PR: the issue timeline has zero cross-referenced PRs, and `gh pr list --search "46328 in:body" --state all` returns empty. The related merged PR #43862 only handled `arguments="null"`; this covers the remaining non-dict cases plus malformed JSON.

## Test Plan

New unit tests in `tests/entrypoints/unit_tests/test_chat_utils.py`: parametrized scalar cases (`'"escaped string"'`, `"42"`, `"true"`) assert coercion to `{}`, and a malformed-JSON case asserts `VLLMValidationError`. Also verified the exact repro payload from #46328 end-to-end through `_postprocess_messages` and that dict arguments are preserved.

```
$ .venv/bin/python -m pytest tests/entrypoints/unit_tests/test_chat_utils.py -k "postprocess_messages" -v
5 passed, 61 deselected

$ pre-commit run --files vllm/entrypoints/chat_utils.py tests/entrypoints/unit_tests/test_chat_utils.py
ruff check / ruff format / mypy: Passed
```

## Test Result

All new and existing `postprocess_messages` tests pass on macOS CPU (source build, `VLLM_TARGET_DEVICE=cpu`).

---

This PR was authored with AI assistance (Claude Code); the diff was reviewed and the tests were run locally as described above.