### PR TITLE
[Frontend][Model] Add language control and metadata for Qwen3-ASR realtime ASR

### DIFF
--- a/docs/serving/online_serving/speech_to_text.md
+++ b/docs/serving/online_serving/speech_to_text.md
@@ -185,9 +185,18 @@ vocabulary.
 | Event | Description |
 | ----- | ----------- |
 | `session.created` | Connection established with session ID and timestamp |
-| `transcription.delta` | Incremental transcription text: `{"type": "transcription.delta", "delta": "text"}` |
-| `transcription.done` | Final transcription with usage stats |
+| `transcription.delta` | Incremental transcription text: `{"type": "transcription.delta", "delta": "text", "language": "en"}` |
+| `transcription.done` | Final transcription with usage stats: `{"type": "transcription.done", "text": "...", "usage": {...}, "language": "en"}` |
 | `error` | Error notification with message and optional code |
+
+The optional `language` field on `transcription.delta` / `transcription.done` is
+an ISO-639-1 code (e.g. `"en"`, `"zh"`) reporting the transcription language. In
+auto-detect mode it reflects the most recently detected segment language, so a
+mid-stream language switch is surfaced here; in forced mode it echoes the
+requested `language`. It is `null` when the model does not report a language.
+Models that emit internal segment scaffolding (e.g. Qwen3-ASR's
+`language <Name><asr_text>` preamble) have it stripped from `delta` and `text`,
+so the transcription stays clean in both auto and forced modes.
 
 #### Example Clients
 

--- a/docs/serving/online_serving/speech_to_text.md
+++ b/docs/serving/online_serving/speech_to_text.md
@@ -172,7 +172,13 @@ Audio must be sent as base64-encoded PCM16 audio at 16kHz sample rate, mono chan
 | ----- | ----------- |
 | `input_audio_buffer.append` | Send base64-encoded audio chunk: `{"type": "input_audio_buffer.append", "audio": "<base64>"}` |
 | `input_audio_buffer.commit` | Trigger transcription processing or end: `{"type": "input_audio_buffer.commit", "final": bool}` |
-| `session.update` | Configure session: `{"type": "session.update", "model": "model-name"}` |
+| `session.update` | Configure session: `{"type": "session.update", "model": "model-name", "language": "en", "prompt": "domain terms"}` |
+
+`session.update` requires `model`. The `language` and `prompt` fields are
+optional and are used by realtime transcription models that support them.
+`language` is an ISO-639-1 language code such as `"en"` or `"zh"`. `prompt` is
+optional text that guides transcription style, terminology, names, or domain
+vocabulary.
 
 ### Server → Client Events
 

--- a/examples/speech_to_text/realtime/openai_realtime_client.py
+++ b/examples/speech_to_text/realtime/openai_realtime_client.py
@@ -45,7 +45,14 @@ def audio_to_pcm16_base64(audio_path: str) -> str:
     return base64.b64encode(pcm16.tobytes()).decode("utf-8")
 
 
-async def realtime_transcribe(audio_path: str, host: str, port: int, model: str):
+async def realtime_transcribe(
+    audio_path: str,
+    host: str,
+    port: int,
+    model: str,
+    language: str | None = None,
+    prompt: str | None = None,
+):
     """
     Connect to the Realtime API and transcribe an audio file.
     """
@@ -60,8 +67,13 @@ async def realtime_transcribe(audio_path: str, host: str, port: int, model: str)
             print(f"Unexpected response: {response}")
             return
 
-        # Validate model
-        await ws.send(json.dumps({"type": "session.update", "model": model}))
+        # Validate model and optionally guide transcription.
+        session_update = {"type": "session.update", "model": model}
+        if language:
+            session_update["language"] = language
+        if prompt:
+            session_update["prompt"] = prompt
+        await ws.send(json.dumps(session_update))
 
         # Signal ready to start
         await ws.send(json.dumps({"type": "input_audio_buffer.commit"}))
@@ -115,7 +127,16 @@ def main(args):
         audio_path = str(AudioAsset("mary_had_lamb").get_local_path())
         print(f"No audio path provided, using default: {audio_path}")
 
-    asyncio.run(realtime_transcribe(audio_path, args.host, args.port, args.model))
+    asyncio.run(
+        realtime_transcribe(
+            audio_path,
+            args.host,
+            args.port,
+            args.model,
+            args.language,
+            args.prompt,
+        )
+    )
 
 
 if __name__ == "__main__":
@@ -145,6 +166,18 @@ if __name__ == "__main__":
         type=int,
         default=8000,
         help="vLLM server port (default: 8000)",
+    )
+    parser.add_argument(
+        "--language",
+        type=str,
+        default=None,
+        help="Optional ISO-639-1 language code to guide transcription.",
+    )
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default=None,
+        help="Optional transcription prompt for terms, names, or domain context.",
     )
     args = parser.parse_args()
     main(args)

--- a/examples/speech_to_text/realtime/openai_realtime_client.py
+++ b/examples/speech_to_text/realtime/openai_realtime_client.py
@@ -111,6 +111,8 @@ async def realtime_transcribe(
                 print(response["delta"], end="", flush=True)
             elif response["type"] == "transcription.done":
                 print(f"\n\nFinal transcription: {response['text']}")
+                if response.get("language"):
+                    print(f"Language: {response['language']}")
                 if response.get("usage"):
                     print(f"Usage: {response['usage']}")
                 break

--- a/tests/entrypoints/speech_to_text/realtime/test_qwen3_asr_realtime_output.py
+++ b/tests/entrypoints/speech_to_text/realtime/test_qwen3_asr_realtime_output.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.model_executor.models.interfaces import SupportsRealtime
+from vllm.model_executor.models.qwen3_asr_realtime import Qwen3ASRRealtimeGeneration
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+clean = Qwen3ASRRealtimeGeneration.clean_realtime_text
+
+
+def test_single_segment_is_stripped_and_language_detected() -> None:
+    assert clean("language English<asr_text>Hello there") == ("Hello there", "en")
+
+
+def test_multi_segment_last_language_wins() -> None:
+    text, lang = clean(
+        "language English<asr_text>Hello\nlanguage Chinese<asr_text>\u4f60\u597d"
+    )
+
+    assert (text, lang) == ("Hello\n\u4f60\u597d", "zh")
+    assert "<asr_text>" not in text
+
+
+def test_partial_language_name_is_withheld() -> None:
+    assert clean("language English<asr_text>Hi\nlanguage Chi") == ("Hi\n", "en")
+
+
+def test_partial_asr_text_tag_is_withheld() -> None:
+    assert clean("language English<asr_text>Hi\nlanguage Chinese<asr_te") == (
+        "Hi\n",
+        "en",
+    )
+
+
+def test_literal_language_word_in_speech_is_flushed() -> None:
+    assert clean("language English<asr_text>I study language models") == (
+        "I study language models",
+        "en",
+    )
+
+
+def test_forced_mode_stream_without_preamble_passthrough() -> None:
+    assert clean("Hello there") == ("Hello there", None)
+
+
+def test_default_hook_is_passthrough_for_other_models() -> None:
+    class _DummyRealtime(SupportsRealtime):
+        pass
+
+    raw = "language English<asr_text>untouched"
+    assert _DummyRealtime.clean_realtime_text(raw) == (raw, None)

--- a/tests/entrypoints/speech_to_text/realtime/test_qwen3_asr_realtime_prompt.py
+++ b/tests/entrypoints/speech_to_text/realtime/test_qwen3_asr_realtime_prompt.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.entrypoints.speech_to_text.realtime.protocol import RealtimeSessionConfig
+from vllm.model_executor.models.qwen3_asr_realtime import Qwen3ASRRealtimeGeneration
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+AUDIO_PLACEHOLDER = "<audio>"
+
+
+def test_qwen3_asr_realtime_default_prompt_is_unchanged() -> None:
+    prompt = Qwen3ASRRealtimeGeneration._get_realtime_prompt_template(
+        AUDIO_PLACEHOLDER,
+    )
+
+    assert prompt == (
+        f"<|im_start|>user\n{AUDIO_PLACEHOLDER}<|im_end|>\n<|im_start|>assistant\n"
+    )
+
+
+def test_qwen3_asr_realtime_language_uses_iso_code_mapping() -> None:
+    prompt = Qwen3ASRRealtimeGeneration._get_realtime_prompt_template(
+        AUDIO_PLACEHOLDER,
+        RealtimeSessionConfig(language="en"),
+    )
+
+    assert prompt == (
+        f"<|im_start|>user\n{AUDIO_PLACEHOLDER}<|im_end|>\n"
+        f"<|im_start|>assistant\nlanguage English<asr_text>"
+    )
+
+
+def test_qwen3_asr_realtime_prompt_adds_system_turn() -> None:
+    prompt = Qwen3ASRRealtimeGeneration._get_realtime_prompt_template(
+        AUDIO_PLACEHOLDER,
+        RealtimeSessionConfig(prompt="Santander Rewards"),
+    )
+
+    assert prompt == (
+        "<|im_start|>system\nSantander Rewards<|im_end|>\n"
+        f"<|im_start|>user\n{AUDIO_PLACEHOLDER}<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    )
+
+
+def test_qwen3_asr_realtime_prompt_sanitizes_user_text() -> None:
+    prompt = Qwen3ASRRealtimeGeneration._get_realtime_prompt_template(
+        AUDIO_PLACEHOLDER,
+        RealtimeSessionConfig(
+            language="zh",
+            prompt="<|im_start|>Santander<asr_text>Rewards<|im_end|>",
+        ),
+    )
+
+    assert prompt == (
+        "<|im_start|>system\nSantanderRewards<|im_end|>\n"
+        f"<|im_start|>user\n{AUDIO_PLACEHOLDER}<|im_end|>\n"
+        f"<|im_start|>assistant\nlanguage Chinese<asr_text>"
+    )
+
+
+def test_qwen3_asr_realtime_empty_values_are_noop() -> None:
+    prompt = Qwen3ASRRealtimeGeneration._get_realtime_prompt_template(
+        AUDIO_PLACEHOLDER,
+        RealtimeSessionConfig(language="", prompt=""),
+    )
+
+    assert prompt == (
+        f"<|im_start|>user\n{AUDIO_PLACEHOLDER}<|im_end|>\n<|im_start|>assistant\n"
+    )

--- a/tests/entrypoints/speech_to_text/realtime/test_realtime_protocol.py
+++ b/tests/entrypoints/speech_to_text/realtime/test_realtime_protocol.py
@@ -6,6 +6,8 @@ import pytest
 from vllm.entrypoints.speech_to_text.realtime.protocol import (
     RealtimeSessionConfig,
     SessionUpdate,
+    TranscriptionDelta,
+    TranscriptionDone,
 )
 
 pytestmark = pytest.mark.skip_global_cleanup
@@ -37,3 +39,19 @@ def test_realtime_session_config_defaults_are_noop() -> None:
 
     assert config.language is None
     assert config.prompt is None
+
+
+def test_transcription_delta_carries_optional_language() -> None:
+    assert TranscriptionDelta(delta="hi").language is None
+
+    event = TranscriptionDelta(delta="hi", language="en")
+    assert event.delta == "hi"
+    assert event.language == "en"
+
+
+def test_transcription_done_carries_optional_language() -> None:
+    assert TranscriptionDone(text="hi").language is None
+
+    event = TranscriptionDone(text="hi", language="zh")
+    assert event.text == "hi"
+    assert event.language == "zh"

--- a/tests/entrypoints/speech_to_text/realtime/test_realtime_protocol.py
+++ b/tests/entrypoints/speech_to_text/realtime/test_realtime_protocol.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.entrypoints.speech_to_text.realtime.protocol import (
+    RealtimeSessionConfig,
+    SessionUpdate,
+)
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def test_session_update_accepts_optional_language_and_prompt() -> None:
+    event = SessionUpdate(
+        type="session.update",
+        model="Qwen/Qwen3-ASR-1.7B",
+        language="en",
+        prompt="Santander Rewards",
+    )
+
+    assert event.model == "Qwen/Qwen3-ASR-1.7B"
+    assert event.language == "en"
+    assert event.prompt == "Santander Rewards"
+
+
+def test_session_update_model_only_payload_still_valid() -> None:
+    event = SessionUpdate(type="session.update", model="model-name")
+
+    assert event.model == "model-name"
+    assert event.language is None
+    assert event.prompt is None
+
+
+def test_realtime_session_config_defaults_are_noop() -> None:
+    config = RealtimeSessionConfig()
+
+    assert config.language is None
+    assert config.prompt is None

--- a/vllm/entrypoints/speech_to_text/realtime/connection.py
+++ b/vllm/entrypoints/speech_to_text/realtime/connection.py
@@ -234,6 +234,8 @@ class RealtimeConnection:
         """
         request_id = f"rt-{self.connection_id}-{uuid4()}"
         full_text = ""
+        sent_clean = ""
+        last_lang: str | None = None
 
         prompt_token_ids_len: int = 0
         completion_tokens_len: int = 0
@@ -264,12 +266,24 @@ class RealtimeConnection:
                     if not prompt_token_ids_len and output.prompt_token_ids:
                         prompt_token_ids_len = len(output.prompt_token_ids)
 
-                    delta = output.outputs[0].text
-                    full_text += delta
+                    full_text += output.outputs[0].text
 
                     # append output to input
                     input_stream.put_nowait(list(output.outputs[0].token_ids))
-                    await self.send(TranscriptionDelta(delta=delta))
+
+                    # Strip the model's internal language preamble from the
+                    # streamed text and surface the language separately.
+                    clean_text, detected = self.serving.model_cls.clean_realtime_text(
+                        full_text
+                    )
+                    lang = detected or self.session_config.language
+                    clean_delta = clean_text[len(sent_clean) :]
+                    sent_clean = clean_text
+                    if clean_delta or lang != last_lang:
+                        await self.send(
+                            TranscriptionDelta(delta=clean_delta, language=lang)
+                        )
+                        last_lang = lang
 
                     completion_tokens_len += len(output.outputs[0].token_ids)
 
@@ -284,7 +298,9 @@ class RealtimeConnection:
             )
 
             # Send final completion event
-            await self.send(TranscriptionDone(text=full_text, usage=usage))
+            await self.send(
+                TranscriptionDone(text=sent_clean, usage=usage, language=last_lang)
+            )
 
             # Clear queue for next utterance
             while not self.audio_queue.empty():

--- a/vllm/entrypoints/speech_to_text/realtime/connection.py
+++ b/vllm/entrypoints/speech_to_text/realtime/connection.py
@@ -22,7 +22,9 @@ from .protocol import (
     ErrorEvent,
     InputAudioBufferAppend,
     InputAudioBufferCommit,
+    RealtimeSessionConfig,
     SessionCreated,
+    SessionUpdate,
     TranscriptionDelta,
     TranscriptionDone,
 )
@@ -48,6 +50,7 @@ class RealtimeConnection:
         self.serving = serving
         self.audio_queue: asyncio.Queue[np.ndarray | None] = asyncio.Queue()
         self.generation_task: asyncio.Task | None = None
+        self.session_config = RealtimeSessionConfig()
 
         self._is_connected = False
         self._is_model_validated = False
@@ -93,6 +96,20 @@ class RealtimeConnection:
             param="model",
         )
 
+    def _validate_language(self, language: str | None) -> str | None:
+        """Validate optional language with the model's STT validator."""
+        if language is None:
+            return None
+
+        language = language.strip()
+        if not language:
+            return None
+
+        validate_language = getattr(self.serving.model_cls, "validate_language", None)
+        if validate_language is None:
+            return language
+        return validate_language(language)
+
     async def handle_event(self, event: dict):
         """Route events to handlers.
 
@@ -104,7 +121,8 @@ class RealtimeConnection:
         event_type = event.get("type")
         if event_type == "session.update":
             logger.debug("Session updated: %s", event)
-            model = event.get("model")
+            session_update = SessionUpdate(**event)
+            model = session_update.model
             if model is None:
                 await self.send_error("Missing required field: model", "invalid_event")
                 return
@@ -112,6 +130,17 @@ class RealtimeConnection:
             if err is not None:
                 await self.send_error(err.error.message, "model_not_found")
                 return
+
+            try:
+                language = self._validate_language(session_update.language)
+            except ValueError as e:
+                await self.send_error(sanitize_message(str(e)), "invalid_event")
+                return
+
+            self.session_config = RealtimeSessionConfig(
+                language=language,
+                prompt=session_update.prompt or None,
+            )
             self._is_model_validated = True
         elif event_type == "input_audio_buffer.append":
             append_event = InputAudioBufferAppend(**event)
@@ -180,7 +209,7 @@ class RealtimeConnection:
 
         # Transform to StreamingInput generator
         streaming_input_gen = self.serving.transcribe_realtime(
-            audio_stream, input_stream
+            audio_stream, input_stream, self.session_config
         )
 
         # Start generation task

--- a/vllm/entrypoints/speech_to_text/realtime/protocol.py
+++ b/vllm/entrypoints/speech_to_text/realtime/protocol.py
@@ -62,6 +62,7 @@ class TranscriptionDelta(OpenAIBaseModel):
 
     type: Literal["transcription.delta"] = "transcription.delta"
     delta: str  # Incremental text
+    language: str | None = None  # detected (auto) or forced language, ISO-639-1
 
 
 class TranscriptionDone(OpenAIBaseModel):
@@ -70,6 +71,7 @@ class TranscriptionDone(OpenAIBaseModel):
     type: Literal["transcription.done"] = "transcription.done"
     text: str  # Complete transcription
     usage: UsageInfo | None = None
+    language: str | None = None  # last detected/forced language, ISO-639-1
 
 
 class ErrorEvent(OpenAIBaseModel):

--- a/vllm/entrypoints/speech_to_text/realtime/protocol.py
+++ b/vllm/entrypoints/speech_to_text/realtime/protocol.py
@@ -29,12 +29,24 @@ class InputAudioBufferCommit(OpenAIBaseModel):
     final: bool = False
 
 
+class RealtimeSessionConfig(OpenAIBaseModel):
+    """Optional realtime transcription session parameters."""
+
+    language: str | None = None
+    """ISO-639-1 language code used to guide transcription."""
+
+    prompt: str | None = None
+    """Optional text prompt to guide transcription."""
+
+
 # Server -> Client Events
 class SessionUpdate(OpenAIBaseModel):
     """Configure session parameters"""
 
     type: Literal["session.update"] = "session.update"
     model: str | None = None
+    language: str | None = None
+    prompt: str | None = None
 
 
 class SessionCreated(OpenAIBaseModel):

--- a/vllm/entrypoints/speech_to_text/realtime/serving.py
+++ b/vllm/entrypoints/speech_to_text/realtime/serving.py
@@ -17,6 +17,8 @@ from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import SupportsRealtime
 from vllm.renderers.inputs.preprocess import parse_model_prompt
 
+from .protocol import RealtimeSessionConfig
+
 logger = init_logger(__name__)
 
 
@@ -56,6 +58,7 @@ class OpenAIServingRealtime(GenerateBaseServing):
         self,
         audio_stream: AsyncGenerator[np.ndarray, None],
         input_stream: asyncio.Queue[list[int]],
+        session_config: RealtimeSessionConfig | None = None,
     ) -> AsyncGenerator[StreamingInput, None]:
         """Transform audio stream into StreamingInput for engine.generate().
 
@@ -77,7 +80,7 @@ class OpenAIServingRealtime(GenerateBaseServing):
         stream_input_iter = cast(
             AsyncGenerator[PromptType, None],
             self.model_cls.buffer_realtime_audio(
-                audio_stream, input_stream, model_config
+                audio_stream, input_stream, model_config, session_config
             ),
         )
 

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -42,6 +42,9 @@ if TYPE_CHECKING:
         VllmConfig,
     )
     from vllm.inputs import PromptType, TokensPrompt
+    from vllm.entrypoints.speech_to_text.realtime.protocol import (
+        RealtimeSessionConfig,
+    )
     from vllm.lora.model_manager import LoRAModelManager
     from vllm.model_executor.layers.fused_moe import MoERunner
     from vllm.model_executor.layers.mamba.mamba_utils import MambaStateCopyFunc
@@ -1087,6 +1090,7 @@ class SupportsRealtime(Protocol):
         audio_stream: AsyncGenerator[np.ndarray, None],
         input_stream: asyncio.Queue[list[int]],
         model_config: "ModelConfig",
+        session_config: "RealtimeSessionConfig | None" = None,
     ) -> AsyncGenerator["PromptType", None]: ...
 
 

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -1093,6 +1093,19 @@ class SupportsRealtime(Protocol):
         session_config: "RealtimeSessionConfig | None" = None,
     ) -> AsyncGenerator["PromptType", None]: ...
 
+    @classmethod
+    def clean_realtime_text(cls, raw_text: str) -> tuple[str, str | None]:
+        """Clean accumulated realtime output and detect language.
+
+        Args:
+            raw_text: Full accumulated raw model text so far.
+
+        Returns:
+            Tuple of ``(clean_text, language_code)``. The default passthrough
+            returns the input unchanged with no detected language.
+        """
+        return raw_text, None
+
 
 @overload
 def supports_realtime(

--- a/vllm/model_executor/models/qwen3_asr_realtime.py
+++ b/vllm/model_executor/models/qwen3_asr_realtime.py
@@ -17,8 +17,9 @@
 """Inference-only Qwen3-ASR realtime model."""
 
 import asyncio
+import re
 from collections.abc import AsyncGenerator, Mapping
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
 import torch
@@ -58,6 +59,9 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 _PRE_ALLOCATE_BUFFER_SIZE_IN_S = 60
+
+_REALTIME_PREAMBLE = re.compile(r"language ([^<\n]*?)<asr_text>")
+_LANG_LEAD = "language "
 
 
 class Qwen3ASRRealtimeBuffer:
@@ -187,6 +191,9 @@ class Qwen3ASRRealtimeMultiModalProcessor(Qwen3ASRMultiModalProcessor):
 class Qwen3ASRRealtimeGeneration(Qwen3ASRForConditionalGeneration, SupportsRealtime):
     realtime_max_tokens = 64
 
+    _name_to_iso_cache: ClassVar[dict[str, str] | None] = None
+    _known_names_cache: ClassVar[frozenset[str] | None] = None
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__(vllm_config=vllm_config, prefix=prefix)
 
@@ -212,6 +219,68 @@ class Qwen3ASRRealtimeGeneration(Qwen3ASRForConditionalGeneration, SupportsRealt
             prompt += f"language {full_lang_name}{_ASR_TEXT_TAG}"
 
         return prompt
+
+    @classmethod
+    def _name_to_iso(cls) -> dict[str, str]:
+        if cls._name_to_iso_cache is None:
+            cls._name_to_iso_cache = {
+                name: code for code, name in cls.supported_languages.items()
+            }
+        return cls._name_to_iso_cache
+
+    @classmethod
+    def _known_names(cls) -> frozenset[str]:
+        if cls._known_names_cache is None:
+            cls._known_names_cache = frozenset(cls.supported_languages.values())
+        return cls._known_names_cache
+
+    @classmethod
+    def _is_pending_preamble(cls, cand: str) -> bool:
+        """Whether ``cand`` is a viable, not-yet-complete language preamble."""
+        if cand and _LANG_LEAD.startswith(cand):
+            return True
+        if cand.startswith(_LANG_LEAD):
+            rest = cand[len(_LANG_LEAD) :]
+            if "<" in rest:
+                name, _, tail = rest.partition("<")
+                return name in cls._known_names() and _ASR_TEXT_TAG.startswith(
+                    "<" + tail
+                )
+            return any(n.startswith(rest) for n in cls._known_names())
+        return False
+
+    @classmethod
+    def _strip_pending_preamble(cls, text: str) -> str:
+        """Withhold a trailing partial preamble at a segment boundary."""
+        boundary = text.rfind("\n") + 1
+        if cls._is_pending_preamble(text[boundary:]):
+            return text[:boundary]
+        return text
+
+    @classmethod
+    def clean_realtime_text(cls, raw_text: str) -> tuple[str, str | None]:
+        """Strip ``language <name><asr_text>`` preambles and detect language.
+
+        Anchored on the ``<asr_text>`` delimiter so the literal word "language"
+        in speech is not mistaken for a preamble. A trailing in-progress
+        preamble at a segment boundary is withheld until it completes (or is
+        disqualified as ordinary speech).
+
+        Args:
+            raw_text: Full accumulated raw model text so far.
+
+        Returns:
+            Tuple of ``(clean_text, language_code)``; ``language_code`` is the
+            most recently detected segment language as an ISO-639-1 code, or
+            ``None`` if no complete preamble has been seen.
+        """
+        lang: str | None = None
+        matches = list(_REALTIME_PREAMBLE.finditer(raw_text))
+        if matches:
+            lang = cls._name_to_iso().get(matches[-1].group(1).strip())
+        clean = _REALTIME_PREAMBLE.sub("", raw_text)
+        clean = cls._strip_pending_preamble(clean)
+        return clean, lang
 
     @classmethod
     async def buffer_realtime_audio(

--- a/vllm/model_executor/models/qwen3_asr_realtime.py
+++ b/vllm/model_executor/models/qwen3_asr_realtime.py
@@ -18,6 +18,7 @@
 
 import asyncio
 from collections.abc import AsyncGenerator, Mapping
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
@@ -29,11 +30,13 @@ from vllm.model_executor.models.interfaces import (
     SupportsRealtime,
 )
 from vllm.model_executor.models.qwen3_asr import (
+    _ASR_TEXT_TAG,
     Qwen3ASRDummyInputsBuilder,
     Qwen3ASRForConditionalGeneration,
     Qwen3ASRMultiModalProcessor,
     Qwen3ASRProcessingInfo,
     _get_feat_extract_output_lengths,
+    _sanitize_transcription_user_text,
 )
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.cache import _I, BaseMultiModalProcessorCache
@@ -46,6 +49,11 @@ from vllm.multimodal.processing.processor import (
 )
 from vllm.tokenizers import cached_tokenizer_from_config
 from vllm.transformers_utils.processor import cached_processor_from_config
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.speech_to_text.realtime.protocol import (
+        RealtimeSessionConfig,
+    )
 
 logger = init_logger(__name__)
 
@@ -183,11 +191,35 @@ class Qwen3ASRRealtimeGeneration(Qwen3ASRForConditionalGeneration, SupportsRealt
         super().__init__(vllm_config=vllm_config, prefix=prefix)
 
     @classmethod
+    def _get_realtime_prompt_template(
+        cls,
+        audio_placeholder: str | None,
+        session_config: "RealtimeSessionConfig | None" = None,
+    ) -> str:
+        request_prompt = session_config.prompt if session_config is not None else None
+        context = _sanitize_transcription_user_text(request_prompt or "")
+        system_turn = f"<|im_start|>system\n{context}<|im_end|>\n" if context else ""
+
+        prompt = (
+            f"{system_turn}"
+            f"<|im_start|>user\n{audio_placeholder}<|im_end|>\n"
+            f"<|im_start|>assistant\n"
+        )
+
+        language = session_config.language if session_config is not None else None
+        if language:
+            full_lang_name = cls.supported_languages.get(language, language)
+            prompt += f"language {full_lang_name}{_ASR_TEXT_TAG}"
+
+        return prompt
+
+    @classmethod
     async def buffer_realtime_audio(
         cls,
         audio_stream: AsyncGenerator[np.ndarray, None],
         input_stream: asyncio.Queue[list[int]],
         model_config: ModelConfig,
+        session_config: "RealtimeSessionConfig | None" = None,
     ) -> AsyncGenerator[PromptType, None]:
         processor = cached_processor_from_config(model_config)
         feature_extractor = processor.feature_extractor
@@ -202,8 +234,9 @@ class Qwen3ASRRealtimeGeneration(Qwen3ASRForConditionalGeneration, SupportsRealt
         )
 
         audio_placeholder = cls.get_placeholder_str("audio", 0)
-        prompt_template = (
-            f"<|im_start|>user\n{audio_placeholder}<|im_end|>\n<|im_start|>assistant\n"
+        prompt_template = cls._get_realtime_prompt_template(
+            audio_placeholder,
+            session_config,
         )
 
         prompt_token_ids = tokenizer.encode(prompt_template)

--- a/vllm/model_executor/models/voxtral_realtime.py
+++ b/vllm/model_executor/models/voxtral_realtime.py
@@ -4,6 +4,7 @@
 import asyncio
 import math
 from collections.abc import AsyncGenerator, Iterable, Iterator, Mapping
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
@@ -42,6 +43,11 @@ from vllm.utils.torch_utils import is_torch_equal_or_newer
 from .utils import (
     _flatten_embeddings,
 )
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.speech_to_text.realtime.protocol import (
+        RealtimeSessionConfig,
+    )
 
 logger = init_logger(__name__)
 
@@ -236,6 +242,7 @@ class VoxtralRealtimeGeneration(VoxtralForConditionalGeneration, SupportsRealtim
         audio_stream: AsyncGenerator[np.ndarray, None],
         input_stream: asyncio.Queue[list[int]],
         model_config: ModelConfig,
+        session_config: "RealtimeSessionConfig | None" = None,
     ) -> AsyncGenerator[PromptType, None]:
         tokenizer = cached_tokenizer_from_config(model_config)
         audio_encoder = tokenizer.instruct.audio_encoder


### PR DESCRIPTION
## Purpose

Add per-session language and prompt support for Qwen3-ASR realtime WebSocket transcription, and clean the streamed ASR output contract.

This PR allows realtime STT clients to request a specific language via `session.update.language` using ISO-639-1 codes such as `en`, `zh`, `ja`, `ko`, `de`, `fr`, and `es`. Omitting `language`, sending `null`, or sending `""` keeps auto-detection behavior.

It also surfaces language metadata in `transcription.delta.language` and `transcription.done.language`, while stripping Qwen3-ASR's internal realtime preamble such as `language English<asr_text>` from user-visible transcript text.

This is not duplicating existing work: the related ASR language/prompt work did not cover the realtime WebSocket output contract and Qwen3-ASR realtime preamble cleanup path.

Documentation and the realtime example client were updated. This PR was developed with AI assistance and manually reviewed/tested.

## Test Plan

Run focused realtime unit tests:

```bash
.venv/bin/python -m pytest -p no:cacheprovider \
  tests/entrypoints/speech_to_text/realtime/test_realtime_protocol.py \
  tests/entrypoints/speech_to_text/realtime/test_qwen3_asr_realtime_prompt.py \
  tests/entrypoints/speech_to_text/realtime/test_qwen3_asr_realtime_output.py \
  -q
```

Compile-check realtime modules not fully covered by the focused unit tests:

```bash
.venv/bin/python -m py_compile \
  vllm/entrypoints/speech_to_text/realtime/connection.py \
  vllm/entrypoints/speech_to_text/realtime/serving.py \
  vllm/model_executor/models/voxtral_realtime.py
```

Run live Qwen3-ASR realtime integration tests on an A100 host against:

```bash
VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 vllm serve Qwen/Qwen3-ASR-1.7B \
  --host 0.0.0.0 \
  --port 8000 \
  --hf-overrides '{"architectures":["Qwen3ASRRealtimeGeneration"]}' \
  --max-model-len 4096 \
  --max-num-seqs 64 \
  --max-num-batched-tokens 8192 \
  --gpu-memory-utilization 0.8 \
  --enforce-eager
```

Integration coverage includes:

- English audio with auto language detection.
- Chinese audio with forced `zh`.
- Chinese audio forced to `en`, proving language forcing overrides detection.
- Chinese audio forced to `ja`, `ko`, `de`, `fr`, and `es`.
- Prompt/hint behavior.
- Empty language and empty prompt edge cases.
- Invalid model/language/error handling.
- Commit-before-session-update validation.
- Concurrent realtime connections with different languages.
- Reconfiguration before commit, where the last valid `session.update` wins.
- Assertion that `<asr_text>` and Qwen internal language preambles never leak into deltas.

## Test Result

Focused unit tests:

```text
17 passed, 15 warnings in 0.29s
```

Compile check:

```text
PY_COMPILE_OK
```

Live integration suite on `CerebrasA100` / A100 40GB:

```text
SUMMARY: 20 passed, 0 failed, 20 total
```

Key live integration confirmations:

- `transcription.delta` and `transcription.done` include the expected `language` value.
- Auto-detected English returns `language="en"`.
- Auto-detected Chinese via empty language returns `language="zh"`.
- Forced languages return the requested language code.
- Prompt hints are applied.
- Concurrent sessions keep independent language configuration.
- No `<asr_text>` marker or `language <Name><asr_text>` preamble leaked into streamed output.