### PR TITLE
[Bugfix][MLA] Use guarded dtype for kv_c_normed cast in _compute_prefill_context

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -2154,7 +2154,7 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
             if (
                 use_fp8_prefill or _kv_b_proj_w_dtype != current_platform.fp8_dtype()
             ) and _kv_b_proj_w_dtype != torch.uint8:
-                kv_c_normed = kv_c_normed.to(self.kv_b_proj.weight.dtype)
+                kv_c_normed = kv_c_normed.to(_kv_b_proj_w_dtype)
 
             k_pe = workspace[:toks][..., self.kv_lora_rank :].unsqueeze(1)
             kv_nope = self.kv_b_proj(kv_c_normed)[0].view(


### PR DESCRIPTION
## Purpose

Finishes #34695. That PR added the guarded dtype lookup

```python
_kv_b_proj_w_dtype = (
    self.kv_b_proj.weight.dtype
    if hasattr(self.kv_b_proj, "weight")
    else self.kv_b_proj.params_dtype
)
```

for quantized MLA layers that lack a `.weight` attribute, but one line below the guard `_compute_prefill_context` still casts through the raw attribute:

```python
kv_c_normed = kv_c_normed.to(self.kv_b_proj.weight.dtype)
```

So pack-quantized MLA models (AWQ/GPTQ) still crash with

```
AttributeError: 'ColumnParallelLinear' object has no attribute 'weight'
```

whenever the context path is taken — prefix-cache hit or chunked prefill — which in practice means the first request succeeds and the second request with a shared prefix kills EngineCore.

This PR replaces the raw access with the already-computed `_kv_b_proj_w_dtype`, matching the fix pattern of #34695 at the remaining call site. One line, no behavior change for models that do have `.weight` (the guard resolves to the identical dtype).

## Test Plan

Reproduced on current `main` with GLM-4.7-Flash AWQ (MLA + prefix caching enabled, single GPU):

1. Send request A — completes fine (no context path on cold cache).
2. Send request B sharing a prefix with A — `_compute_prefill_context` runs, EngineCore dies with the `AttributeError` above.

## Test Result

With this patch (rebuilt image, same workload): step 2 completes normally; sustained mixed traffic with prefix-cache hits runs clean. FP8 and unquantized MLA models are unaffected (`hasattr(self.kv_b_proj, "weight")` is true, so the guarded dtype equals the raw one).
