### PR TITLE
[ROCm] Disable persistent sparse-MLA kernel for chunked-prefill continuations

### DIFF
--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -536,7 +536,17 @@ class ROCMAiterMLASparseMetadataBuilder(
             self._num_attention_heads,
             clamped_seq_lens.tobytes(),
         )
-        if metadata_key != self._prev_metadata_key:
+        # The persistent MLA kernel is numerically wrong for multi-token prefill
+        # batches; errors compound across chunked prefill and break long-context
+        # decode (vllm#47042). Use it only for decode and single-chunk prefills,
+        # not chunked-prefill continuations (>1 query token, seq_len > query_len).
+        step_query_lens = seg_lengths
+        total_seq_lens = common_attn_metadata.seq_lens_cpu[:num_reqs].numpy()
+        is_chunked_continuation = (step_query_lens > 1) & (
+            total_seq_lens > step_query_lens
+        )
+        use_persistent = not is_chunked_continuation.any()
+        if use_persistent and metadata_key != self._prev_metadata_key:
             from aiter import get_mla_metadata_v1
 
             get_mla_metadata_v1(
@@ -576,7 +586,7 @@ class ROCMAiterMLASparseMetadataBuilder(
             paged_kv_last_page_len=paged_kv_last_page_len,
             paged_kv_indices=paged_kv_indices,
             paged_kv_indptr=paged_kv_indptr,
-            work_meta_data=self._mla_work_meta_data,
+            work_meta_data=self._mla_work_meta_data if use_persistent else None,
             work_indptr=self._mla_work_indptr,
             work_info_set=self._mla_work_info_set,
             reduce_indptr=self._mla_reduce_indptr,


### PR DESCRIPTION
# [ROCm] Disable persistent sparse-MLA kernel for chunked-prefill continuations

## Summary
Fixes #47042. GLM-4.6/4.5 / DeepSeek-V3.2-style sparse-MLA (DSA) models on ROCm
produce correct output up to ~20K tokens and then collapse into repetition /
garbage at longer contexts.

Root cause: the AITER **persistent MLA work-stealing kernel**
(`get_mla_metadata_v1` + the `work_meta_data` persistent path in
`aiter.mla.mla_decode_fwd`, enabled unconditionally for the sparse-MLA backend
in #41990) is **numerically wrong for multi-token (prefill) batches**. The
per-token error is small in isolation, but chunked prefill runs a request
through several forward passes and the error **compounds** through the KV cache
across passes/layers until long-context decode collapses.

This is why the failure is gated on **chunk count**, not context length:

| max-num-batched-tokens | 20K prompt | chunks | result |
| --- | --- | --- | --- |
| 8192 | 22K tok | 3 | garbage (0/10 needles) |
| 12288 | 22K tok | 2 | correct |
| 21504 | 22K tok | 2 | correct |
| 12288 | 33K tok | 3 | garbage |

The persistent kernel is correct for **pure decode** (`qseqlen==1`) and for
**fresh single-chunk prefills**. This patch gates it on batch shape: it falls
back to the (correct) non-persistent split-KV path whenever any request in the
batch is a chunked-prefill *continuation* — i.e. it has more than one query
token this step *and* part of its context was already computed in an earlier
chunk (`seq_len > query_len`). Decode and single-chunk prefills keep the
persistent performance path, so there is no decode throughput regression.

## Why this is not a duplicate
- #47404 ("Synchronize sparse MLA metadata before graph replay") touches the
  same file but fixes a *different* bug: a stale-metadata race during CUDA-graph
  replay. The bug here is a **numerical correctness** bug in the kernel itself —
  it reproduces with `--enforce-eager` / `-cc.cudagraph_mode=NONE` (no graph
  replay), so metadata-ordering is not involved.
- #41973 / #41990 is the feature that *enabled* the persistent path (the source
  of this regression), not a fix.
- No open PR references #47042.

## Isolated (kernel-only) reproduction
A standalone script (no vLLM/model) builds a sparse-MLA batch, regenerates the
persistent metadata via `get_mla_metadata_v1`, and compares the persistent
kernel and the non-persistent kernel against a torch fp32 reference:

```
N=  1 (decode):        persistent max_relerr=0.000   non-persistent=0.000  -> OK
N=512 (prefill batch): persistent max_relerr=7.15    non-persistent=0.108  -> PERSISTENT WRONG
```

The non-persistent kernel matches the fp32 reference tightly everywhere; the
persistent kernel is correct for decode-shaped batches but produces large
errors for prefill-shaped batches. (The underlying kernel bug is also worth an
AITER-side fix; this PR is the vLLM-side mitigation.)

## Testing (MI355X / gfx950, TP8, GLM-FP8, vLLM nightly + aiter 0.1.16.post2)
Needle-in-a-haystack via raw `/v1/completions`, greedy, `max-num-batched-tokens
8192` (default small chunk), cudagraph/torch.compile **enabled**:

| context | before | after |
| --- | --- | --- |
| 2K  | 10/10 | 10/10 |
| 20K | **0/10 (garbage)** | 10/10 |
| 40K | garbage | 10/10 |

No accuracy regression on short context:
`lm_eval gsm8k --num_fewshot 20` (concurrency 256): **0.944 flexible / 0.945
strict** exact_match, unchanged vs baseline (decode path is untouched).

## Notes
- Python-only change; behavior differs only on ROCm sparse-MLA (`glm_moe_dsa` /
  DeepSeek-V3.2 indexer) backends.
- AI assistance (Claude) was used to investigate and draft this change; a human
  author owns and has validated it.
- `pre-commit run --files vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py`
  should be run before submission.
