### PR TITLE
[Bugfix] Require quack-kernels>=0.4.1 for cutlass-dsl 4.5+ compatibility

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -26,7 +26,8 @@ fastsafetensors >= 0.3.2
 
 # QuACK and Cutlass DSL for FA4 (cute-DSL implementation)
 nvidia-cutlass-dsl[cu13]==4.6.0
-quack-kernels>=0.4.0  # Required for tml-fa4
+# 0.4.1 floor: required for tml-fa4, and <=0.4.0 import cutlass.base_dsl.Arch, removed in cutlass-dsl 4.5+ (https://github.com/vllm-project/vllm/issues/47570)
+quack-kernels>=0.4.1
 
 # Tokenspeed_MLA for faster mla with spec decode
 tokenspeed-mla==0.1.8; platform_system == "Linux"


### PR DESCRIPTION
## Purpose

FIX #47570 (also the root cause of #43141)

**Rebased over #47442** (cutlass-dsl 4.5.2 -> 4.6.0, quack floor 0.3.3 -> 0.4.0): still needed — 4.6.0 also has no top-level `cutlass.base_dsl.Arch` (verified by AST inspection of the v4.6.0 tag), so the current `>=0.4.0` floor still admits the last broken quack release. This PR bumps it to 0.4.1, the first release with the corrected import. Fresh installs now resolve quack 0.6.1 (pins cutlass-dsl==4.6.0) and are unaffected.

Users hit this at runtime when vLLM imports `quack`:

```
ImportError: cannot import name 'Arch' from 'cutlass.base_dsl' (.../cutlass/base_dsl/__init__.py)
```

Root cause:

- `quack-kernels` 0.3.10, 0.3.11 and 0.4.0 wheels contain `from cutlass.base_dsl import Arch` in `rmsnorm.py`, `softmax.py` and `cross_entropy.py` — all reached from `import quack` (`rmsnorm.py:24` matches the traceback in #43141). Earlier releases don't reference `Arch` on the `import quack` path (0.3.8/0.3.9 use the correct form in `trace.py` only; <= 0.3.7 not at all).
- That import only ever worked because nvidia-cutlass-dsl <= 4.4.2 had a top-level `from .arch import Arch` in `base_dsl/dsl.py`, re-exported via `from .dsl import *` in `base_dsl/__init__.py`. In 4.5.x that import was moved out of module top level (now under `TYPE_CHECKING`/function scope), so `cutlass.base_dsl.Arch` no longer exists. Verified by AST inspection of the shipped wheels: `Arch` is bound at top level of `base_dsl/dsl.py` in 4.4.2 but not in 4.5.2.
- quack fixed its import in 0.4.1 (`from cutlass.base_dsl.arch import Arch`; `base_dsl/arch.py` defining `Arch` is present in the 4.5.2 wheel).

vLLM pins `nvidia-cutlass-dsl[cu13]==4.5.2` but only required `quack-kernels>=0.3.3`, and quack <= 0.4.0 declares `nvidia-cutlass-dsl>=4.4.2` with no upper bound, so resolvers happily co-install the broken combination. Fresh installs usually escape it (they resolve quack 0.5.0, since 0.5.1+ pin `nvidia-cutlass-dsl==4.6.0.dev0` and are excluded), which is why the failure is intermittent across environments — stale envs, lockfiles, or lowest-version resolution still land on a broken quack. The issue reporter confirmed their failing env resolved an old quack via uv (https://github.com/vllm-project/vllm/issues/47570#issuecomment-4878969784).

This PR raises the floor to the first release compatible with the pinned cutlass-dsl: `quack-kernels>=0.4.1`.

## Test Plan

1. Confirm the broken combination is currently resolvable (metadata does not protect against it):
   ```
   uv pip compile <(printf 'nvidia-cutlass-dsl[cu13]==4.5.2\nquack-kernels==0.4.0\n') --python-platform linux --python-version 3.12
   ```
2. Confirm the new floor keeps resolving to the same version as today for fresh installs:
   ```
   uv pip compile <(printf 'nvidia-cutlass-dsl[cu13]==4.5.2\nquack-kernels>=0.4.1\n') --python-platform linux --python-version 3.12
   ```
3. Static verification against the shipped wheels: grep `from cutlass.base_dsl import Arch` across all quack wheels 0.3.3–0.5.3 (present only in 0.3.10/0.3.11/0.4.0; 0.4.1+ use the correct `cutlass.base_dsl.arch` path); AST check that `Arch` is not a top-level name of `cutlass.base_dsl` in the nvidia-cutlass-dsl-libs-base 4.5.2 wheel (it is in 4.4.2).
4. `vllm.model_executor.layers.mamba.ops.gdn_chunk_cutedsl` and the deepseek_v4 cute-DSL ops only use `quack.compile_utils.make_fake_tensor`, which exists unchanged in 0.4.1 and 0.5.0.

## Test Result

1. Resolves to `quack-kernels==0.4.0` + `nvidia-cutlass-dsl==4.5.2` — the combination that crashes at import time.
2. Resolves to `quack-kernels==0.5.0` + `nvidia-cutlass-dsl==4.5.2` — identical to what a fresh `pip install vllm` picks today, so no behavior change for healthy environments; only the broken quack range is excluded.
3. Confirmed as described.
4. Confirmed via wheel inspection.

