### PR TITLE
fix: Load OneAPI enviroment before running vllm on xpu Docker image

### DIFF
--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -242,4 +242,14 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install -e tests/vllm_test_utils
 
-ENTRYPOINT ["vllm", "serve"]
+# Load the oneAPI enviroment before vllm serve
+RUN cat > /usr/local/bin/vllm-xpu-entrypoint.sh <<'EOF'
+#!/usr/bin/env bash
+set -e
+source /opt/intel/oneapi/setvars.sh --force
+exec vllm serve "$@"
+EOF
+
+RUN chmod +x /usr/local/bin/vllm-xpu-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/vllm-xpu-entrypoint.sh"]


### PR DESCRIPTION

Fix the Dockerfile.xpu to ensure OneAPI environment is loaded. Without this, no xpu devices are found by torch, and the container abends.

## Purpose
Ensure the XPU Docker image initializes the Intel oneAPI runtime environment when the container starts, so vllm serve can detect XPU devices without users overriding the container entrypoint.

## Test Plan
Build the updated XPU Docker image, run it with the default entrypoint and normal vllm serve command arguments, passing /dev/dri into the container. Confirm that vLLM detects the XPU platform without any Compose or Docker entrypoint override.

## Test Result
With the updated image, the container initializes the oneAPI environment during startup, vLLM detects XPUPlatform, and the server proceeds to load Qwen/Qwen3.5-9B without requiring a custom entrypoint wrapper.

# Before modification:
```
/opt/venv/lib/python3.12/site-packages/torch/xpu/__init__.py:74: UserWarning: XPU device count is zero! (Triggered internally at /pytorch/c10/xpu/XPUFunctions.cpp:113.)
   return torch._C._xpu_getDeviceCount()
INFO 07-03 20:28:25 [importing.py:53] Triton is installed but 0 active driver(s) found (expected 1). Disabling Triton to prevent runtime errors.
INFO 07-03 20:28:25 [importing.py:88] Triton not installed or not compatible; certain GPU-related functions will not be available.
Traceback (most recent call last):
  File "/opt/venv/bin/vllm", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/entrypoints/cli/main.py", line 88, in main
    cmd.subparser_init(subparsers).set_defaults(dispatch_function=cmd.cmd)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/entrypoints/cli/serve.py", line 164, in subparser_init
    serve_parser = make_arg_parser(serve_parser)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/entrypoints/openai/cli_args.py", line 382, in make_arg_parser
    parser = AsyncEngineArgs.add_cli_args(parser)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/engine/arg_utils.py", line 2690, in add_cli_args
    parser = EngineArgs.add_cli_args(parser)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/engine/arg_utils.py", line 1498, in add_cli_args
    vllm_kwargs = get_kwargs(VllmConfig)
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/engine/arg_utils.py", line 410, in get_kwargs
    return copy.deepcopy(_compute_kwargs(cls))
                         ^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/engine/arg_utils.py", line 311, in _compute_kwargs
    default = default.default_factory()  # type: ignore[call-arg]
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pydantic/_internal/_dataclasses.py", line 121, in __init__
    s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
  File "/opt/venv/lib/python3.12/site-packages/vllm/config/device.py", line 56, in __post_init__
    raise RuntimeError(
RuntimeError: Failed to infer device type, please set the environment variable `VLLM_LOGGING_LEVEL=DEBUG` to turn on verbose logging to help debug the issue.
exited with code 1 (restarting)
/opt/venv/lib/python3.12/site-packages/torch/xpu/__init__.py:74: UserWarning: XPU device count is zero! (Triggered internally at /pytorch/c10/xpu/XPUFunctions.cpp:113.)
  return torch._C._xpu_getDeviceCount()
INFO 07-03 20:28:59 [importing.py:53] Triton is installed but 0 active driver(s) found (expected 1). Disabling Triton to prevent runtime errors.
INFO 07-03 20:28:59 [importing.py:88] Triton not installed or not compatible; certain GPU-related functions will not be available.
WARNI [langchain_community.utils.user_agent] USER_AGENT environment variable not set, consider setting it to identify your requests.
Traceback (most recent call last):
  File "/opt/venv/bin/vllm", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/entrypoints/cli/main.py", line 88, in main
    cmd.subparser_init(subparsers).set_defaults(dispatch_function=cmd.cmd)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/entrypoints/cli/serve.py", line 164, in subparser_init
    serve_parser = make_arg_parser(serve_parser)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/entrypoints/openai/cli_args.py", line 382, in make_arg_parser
    parser = AsyncEngineArgs.add_cli_args(parser)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/engine/arg_utils.py", line 2690, in add_cli_args
    parser = EngineArgs.add_cli_args(parser)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/engine/arg_utils.py", line 1498, in add_cli_args
    vllm_kwargs = get_kwargs(VllmConfig)
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/engine/arg_utils.py", line 410, in get_kwargs
    return copy.deepcopy(_compute_kwargs(cls))
                         ^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/engine/arg_utils.py", line 311, in _compute_kwargs
    default = default.default_factory()  # type: ignore[call-arg]
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pydantic/_internal/_dataclasses.py", line 121, in __init__
    s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
  File "/opt/venv/lib/python3.12/site-packages/vllm/config/device.py", line 56, in __post_init__
    raise RuntimeError(
RuntimeError: Failed to infer device type, please set the environment variable `VLLM_LOGGING_LEVEL=DEBUG` to turn on verbose logging to help debug the issue.
exited with code 1 (restarting)
/opt/venv/lib/python3.12/site-packages/torch/xpu/__init__.py:74: UserWarning: XPU device count is zero! (Triggered internally at /pytorch/c10/xpu/XPUFunctions.cpp:113.)
  return torch._C._xpu_getDeviceCount()
```

# After modification:
```

 :: initializing oneAPI environment ...
    vllm-xpu-entrypoint.sh: BASH_VERSION = 5.2.21(1)-release
    args: Using "$@" for setvars.sh arguments: --force
 :: ccl -- latest
 :: compiler -- latest
 :: debugger -- latest
 :: dev-utilities -- latest
 :: dnnl -- latest
 :: dpl -- latest
 :: mkl -- latest
 :: mpi -- latest
 :: tbb -- latest
 :: umf -- latest
 :: oneAPI environment initialized ::

 DEBUG 07-03 22:48:56 [plugins/__init__.py:36] No plugins for group vllm.platform_plugins found.
 DEBUG 07-03 22:48:56 [platforms/__init__.py:36] Checking if TPU platform is available.
 DEBUG 07-03 22:48:56 [platforms/__init__.py:55] TPU platform is not available because: No module named 'libtpu'
 DEBUG 07-03 22:48:56 [platforms/__init__.py:61] Checking if CUDA platform is available.
 DEBUG 07-03 22:48:56 [platforms/__init__.py:88] Exception happens when checking CUDA platform: NVML Shared Library Not Found
 DEBUG 07-03 22:48:56 [platforms/__init__.py:105] CUDA platform is not available because: NVML Shared Library Not Found
 DEBUG 07-03 22:48:56 [platforms/__init__.py:112] Checking if ROCm platform is available.
 DEBUG 07-03 22:48:56 [platforms/__init__.py:126] ROCm platform is not available because: No module named 'amdsmi'
 DEBUG 07-03 22:48:56 [platforms/__init__.py:133] Checking if XPU platform is available.
 DEBUG 07-03 22:48:57 [platforms/__init__.py:142] Confirmed xccl backend is available.
 DEBUG 07-03 22:49:00 [platforms/__init__.py:146] Confirmed XPU platform is available.
 DEBUG 07-03 22:49:00 [platforms/__init__.py:164] Checking if CPU platform is available.
 DEBUG 07-03 22:49:00 [platforms/__init__.py:133] Checking if XPU platform is available.
 DEBUG 07-03 22:49:00 [platforms/__init__.py:142] Confirmed xccl backend is available.
 DEBUG 07-03 22:49:00 [platforms/__init__.py:146] Confirmed XPU platform is available.
 DEBUG 07-03 22:49:00 [platforms/__init__.py:245] Automatically detected platform xpu.
 DEBUG 07-03 22:50:13 [plugins/__init__.py:44] Available plugins for group vllm.general_plugins:
 DEBUG 07-03 22:50:13 [plugins/__init__.py:46] - lora_filesystem_resolver -> vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
 DEBUG 07-03 22:50:13 [plugins/__init__.py:46] - lora_hf_hub_resolver -> vllm.plugins.lora_resolvers.hf_hub_resolver:register_hf_hub_resolver
 DEBUG 07-03 22:50:13 [plugins/__init__.py:46] - arctic_inference -> arctic_inference.vllm.plugin:arctic_inference_plugin
 DEBUG 07-03 22:50:13 [plugins/__init__.py:49] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
 (APIServer pid=1) INFO 07-03 22:50:13 [entrypoints/.../utils/api_utils.py:339]
 (APIServer pid=1) INFO 07-03 22:50:13 [entrypoints/.../utils/api_utils.py:339]        █     █     █▄   ▄█
 (APIServer pid=1) INFO 07-03 22:50:13 [entrypoints/.../utils/api_utils.py:339]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.23.1rc1.dev766+gcd44f0cb3
 (APIServer pid=1) INFO 07-03 22:50:13 [entrypoints/.../utils/api_utils.py:339]   █▄█▀ █     █     █     █  model   Qwen/Qwen3-14B
 (APIServer pid=1) INFO 07-03 22:50:13 [entrypoints/.../utils/api_utils.py:339]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀
 (APIServer pid=1) INFO 07-03 22:50:13 [entrypoints/.../utils/api_utils.py:339]
```

Image from updated Dockerfile available at `telnetdoogie/vllm-xpu:latest`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

