### PR TITLE
[Bugfix] Fall back to V1 model runner when UVA is unavailable (WSL2)

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1667,3 +1667,23 @@ def test_load_config_rejects_invalid_safetensors_load_strategy():
 def test_load_config_rejects_non_string_load_format(bad_load_format):
     with pytest.raises(pydantic.ValidationError):
         LoadConfig(load_format=bad_load_format)
+
+
+def test_v2_model_runner_requires_uva(monkeypatch):
+    model_config = ModelConfig("facebook/opt-125m")
+
+    monkeypatch.setattr(vllm_config_module, "HAS_TRITON", True)
+    monkeypatch.setattr(vllm_config_module, "is_uva_available", lambda: True)
+    config = VllmConfig(model_config=model_config)
+    assert config.use_v2_model_runner
+
+    # Fall back to the V1 model runner when UVA is unavailable
+    # (e.g. WSL2 without VLLM_WSL2_ENABLE_PIN_MEMORY=1).
+    monkeypatch.setattr(vllm_config_module, "is_uva_available", lambda: False)
+    config = VllmConfig(model_config=model_config)
+    assert not config.use_v2_model_runner
+
+    # Explicitly forcing V2 without UVA raises an actionable error.
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "1")
+    with pytest.raises(ValueError, match="UVA"):
+        VllmConfig(model_config=model_config)

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -26,6 +26,7 @@ from vllm.transformers_utils.runai_utils import is_runai_obj_uri
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils import random_uuid
 from vllm.utils.hashing import safe_hash
+from vllm.utils.platform_utils import is_uva_available
 
 from .attention import AttentionConfig
 from .cache import CacheConfig
@@ -576,6 +577,14 @@ class VllmConfig:
         if not HAS_TRITON:
             logger.warning_once(
                 "Model Runner V2 requires Triton; using the V1 model runner instead."
+            )
+            return False
+
+        if not is_uva_available():
+            logger.warning_once(
+                "Model Runner V2 requires UVA (pinned memory); using the V1 "
+                "model runner instead. On WSL2, set "
+                "VLLM_WSL2_ENABLE_PIN_MEMORY=1 to enable UVA."
             )
             return False
 
@@ -2223,6 +2232,14 @@ class VllmConfig:
         """Check for features not yet supported by the V2 model runner."""
         if not HAS_TRITON:
             raise ValueError("Model Runner V2 requires Triton.")
+
+        if not is_uva_available():
+            raise ValueError(
+                "Model Runner V2 requires UVA (pinned memory), which is not "
+                "available on this platform. On WSL2, set "
+                "VLLM_WSL2_ENABLE_PIN_MEMORY=1 to enable it, or set "
+                "VLLM_USE_V2_MODEL_RUNNER=0 to use the V1 model runner."
+            )
 
         unsupported = self._get_v2_model_runner_unsupported_features()
         if unsupported:


### PR DESCRIPTION
## Purpose

FIX #47387
FIX #47292

On WSL2, `CudaPlatformBase.is_pin_memory_available()` returns `VLLM_WSL2_ENABLE_PIN_MEMORY`, which defaults to `0` — pinned memory was made opt-in for WSL2 in #41496 because it has a fixed per-tensor overhead there. That makes `is_uva_available()` `False`, and the V2 model runner (now the default for most generate models) unconditionally allocates UVA buffers during init:

```
File "vllm/v1/worker/gpu/model_runner.py", line 212, in __init__
    self.req_states = RequestState(...)
File "vllm/v1/worker/gpu/states.py", line 33, in __init__
    self.all_token_ids = StagedWriteTensor(...)
File "vllm/v1/worker/gpu/buffer_utils.py", line 141, in __init__
    self._uva_buf = UvaBuffer(size, dtype)
File "vllm/v1/worker/gpu/buffer_utils.py", line 47, in __init__
    raise RuntimeError("UVA is not available")
```

So every default WSL2 run crashes at engine startup with a bare `RuntimeError: UVA is not available` (two independent reports: #47387, #47292).

During review of #41496 the plan was to enable pinned memory on WSL2 whenever the V2 runner needs it, but the merged env-var simplification dropped that gating. This PR restores a safe default without touching the pin-memory policy:

- `VllmConfig.use_v2_model_runner` falls back to the V1 runner when UVA is unavailable, mirroring the existing `HAS_TRITON` fallback, with a warning that points at `VLLM_WSL2_ENABLE_PIN_MEMORY=1`.
- `_validate_v2_model_runner` raises an actionable error (instead of the late worker-init `RuntimeError`) when V2 is explicitly forced (`VLLM_USE_V2_MODEL_RUNNER=1`, dspark, diffusion).

## Test Plan

- New unit test: `pytest tests/test_config.py::test_v2_model_runner_requires_uva`
- E2E on an RTX 4060 Laptop GPU (Fedora 43, native Linux): simulate the WSL2 condition by forcing `is_uva_available()` to return `False` in-process (`VLLM_ENABLE_V1_MULTIPROCESSING=0`), then run `LLM("facebook/opt-125m")` and generate:
  1. unpatched nightly (576bf75d0): expect the crash from the issues
  2. patched: expect fallback warning + successful generation on the V1 runner
  3. patched + `VLLM_USE_V2_MODEL_RUNNER=1`: expect the new actionable `ValueError`
- `uvx pre-commit run --files vllm/config/vllm.py tests/test_config.py`

## Test Result

- Unit test passes.
- E2E 1 (unpatched): reproduced `RuntimeError: UVA is not available` with the exact traceback reported in #47387.
- E2E 2 (patched): logs `Model Runner V2 requires UVA (pinned memory); using the V1 model runner instead. On WSL2, set VLLM_WSL2_ENABLE_PIN_MEMORY=1 to enable UVA.` and generation completes.
- E2E 3 (patched, forced V2): raises `ValueError: Model Runner V2 requires UVA (pinned memory), which is not available on this platform. ...` at config time.
- pre-commit: all hooks pass (including mypy).
