### PR TITLE
[Perf] Keep H2D transfers dense in fused-MoE weight loading

### DIFF
--- a/tests/model_executor/test_routed_experts_h2d_copy.py
+++ b/tests/model_executor/test_routed_experts_h2d_copy.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for _copy_h2d_dst_strided in routed_experts.py.
+
+The helper must be a drop-in replacement for ``dst.copy_(src)`` for every
+source layout produced by fused-MoE checkpoint loading (see issue #31624):
+contiguous slabs, transpose views of memory-mapped tensors, and TP-narrowed
+transpose views with unit inner stride.
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.fused_moe.routed_experts import (
+    _copy_h2d_dst_strided,
+)
+
+CUDA_DTYPES = [torch.float32, torch.bfloat16, torch.float8_e4m3fn]
+CPU_DTYPES = [torch.float32, torch.bfloat16]
+
+
+def _same_bytes(a: torch.Tensor, b: torch.Tensor) -> bool:
+    """Byte-level equality: a copy must reproduce the source exactly,
+    and this stays true for dtypes whose NaNs defeat torch.equal."""
+    return torch.equal(
+        a.cpu().contiguous().view(torch.uint8),
+        b.cpu().contiguous().view(torch.uint8),
+    )
+
+
+def _make_src(layout: str, dtype: torch.dtype) -> torch.Tensor:
+    """Build a source tensor mimicking checkpoint loading layouts."""
+    # Disk layout of one fused expert slab: [hidden_in, hidden_out].
+    # Keep values within fp8_e4m3 range (max 448): out-of-range casts
+    # saturate to NaN, and NaN != NaN breaks torch.equal even for
+    # byte-identical copies.
+    base = (
+        (torch.arange(48 * 32, dtype=torch.float32) % 448.0).reshape(48, 32).to(dtype)
+    )
+    if layout == "contiguous":
+        return base
+    if layout == "transposed":
+        # Runtime orientation view, as created by llama4.py.
+        return base.transpose(-1, -2)
+    if layout == "tp_narrowed":
+        # Transpose view narrowed along the sharded dim (TP>1): unit inner
+        # stride with a padded row pitch.
+        return base.transpose(-1, -2).narrow(0, 8, 16)
+    raise ValueError(layout)
+
+
+@pytest.mark.parametrize("layout", ["contiguous", "transposed", "tp_narrowed"])
+@pytest.mark.parametrize("dtype", CPU_DTYPES)
+def test_same_device_matches_plain_copy(layout: str, dtype: torch.dtype):
+    src = _make_src(layout, dtype)
+    expected = torch.empty_like(src)
+    expected.copy_(src)
+    actual = torch.empty_like(src)
+    _copy_h2d_dst_strided(actual, src)
+    assert _same_bytes(actual, expected)
+
+
+@pytest.mark.parametrize("layout", ["contiguous", "transposed", "tp_narrowed"])
+@pytest.mark.parametrize("dtype", CUDA_DTYPES)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_h2d_matches_plain_copy(layout: str, dtype: torch.dtype):
+    src = _make_src(layout, dtype)
+    expected = torch.empty(src.shape, dtype=dtype, device="cuda")
+    expected.copy_(src)
+    actual = torch.empty(src.shape, dtype=dtype, device="cuda")
+    _copy_h2d_dst_strided(actual, src)
+    assert _same_bytes(actual, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_h2d_strided_dst_view():
+    """The destination may itself be a narrow of the parameter tensor."""
+    src = _make_src("transposed", torch.float32)
+    param = torch.zeros(64, 48, device="cuda")
+    dst = param.narrow(0, 8, 32).narrow(1, 0, 48)
+    expected = param.clone().narrow(0, 8, 32).narrow(1, 0, 48)
+    expected.copy_(src)
+    _copy_h2d_dst_strided(dst, src)
+    assert _same_bytes(dst, expected)
+
+
+def test_scalar_and_1d_fallback():
+    scalar_src = torch.tensor(3.5)
+    scalar_dst = torch.empty(())
+    _copy_h2d_dst_strided(scalar_dst, scalar_src)
+    assert scalar_dst.item() == pytest.approx(3.5)
+
+    vec_src = torch.arange(8, dtype=torch.float32)[::2]
+    vec_dst = torch.empty(4)
+    _copy_h2d_dst_strided(vec_dst, vec_src)
+    assert torch.equal(vec_dst, vec_src.contiguous())
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_h2d_dtype_conversion():
+    """copy_ semantics include implicit dtype casts; the flip must too."""
+    src = _make_src("transposed", torch.float32)
+    expected = torch.empty(src.shape, dtype=torch.bfloat16, device="cuda")
+    expected.copy_(src)
+    actual = torch.empty(src.shape, dtype=torch.bfloat16, device="cuda")
+    _copy_h2d_dst_strided(actual, src)
+    assert _same_bytes(actual, expected)

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -33,6 +33,41 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+def _copy_h2d_dst_strided(dst: torch.Tensor, src: torch.Tensor) -> None:
+    """Copy src into dst, keeping the host->device memcpy contiguous.
+
+    Fused-MoE checkpoints (e.g. ModelOpt Llama-4) store expert weights
+    transposed relative to the runtime layout, so ``src`` arrives here as
+    a non-contiguous CPU view of the memory-mapped checkpoint tensor.
+    ``dst.copy_(src)`` then materializes ``src.contiguous()`` on the CPU,
+    an elementwise strided gather that costs seconds per expert tensor
+    (see https://github.com/vllm-project/vllm/issues/31624).
+
+    Flipping the strided side to the destination keeps the H2D transfer
+    dense: ``src.transpose(-1, -2)`` recovers the contiguous on-disk slab
+    at zero cost, and the transpose is performed as a strided device-side
+    write into the existing parameter storage. No extra device memory is
+    retained; the staging buffer lives inside ATen's copy op.
+    """
+    if (
+        dst.device != src.device
+        and src.device.type == "cpu"
+        and src.ndim >= 2
+        and not src.is_contiguous()
+    ):
+        src_t = src.transpose(-1, -2)
+        if src_t.is_contiguous():
+            dst.transpose(-1, -2).copy_(src_t)
+            return
+        if src_t.stride(-1) == 1:
+            # TP-narrowed slab: unit inner stride but padded row pitch.
+            # Contiguation here degrades to row-run memcpys instead of an
+            # elementwise gather, after which the H2D transfer is dense.
+            dst.transpose(-1, -2).copy_(src_t.contiguous())
+            return
+    dst.copy_(src)
+
+
 class FusedMoeWeightScaleSupported(Enum):
     TENSOR = "tensor"
     CHANNEL = "channel"
@@ -378,7 +413,7 @@ class RoutedExperts(PluggableLayer):
                 hidden_dim=hidden_dim,
                 shard_dim=shard_dim,
             )
-            expert_data.copy_(loaded_weight)
+            _copy_h2d_dst_strided(expert_data, loaded_weight)
         elif shard_id in ("w1", "w3"):
             self._load_w13(
                 shard_id=shard_id,
@@ -494,7 +529,7 @@ class RoutedExperts(PluggableLayer):
             hidden_dim=hidden_dim,
             shard_dim=shard_dim,
         )
-        expert_data.copy_(loaded_weight)
+        _copy_h2d_dst_strided(expert_data, loaded_weight)
 
     def _load_w2(
         self,
@@ -529,7 +564,7 @@ class RoutedExperts(PluggableLayer):
             hidden_dim=hidden_dim,
             shard_dim=shard_dim,
         )
-        expert_data.copy_(loaded_weight)
+        _copy_h2d_dst_strided(expert_data, loaded_weight)
 
     def _load_single_value(
         self, param: torch.nn.Parameter, loaded_weight: torch.Tensor, expert_id: int


### PR DESCRIPTION
## Purpose

Fix the root cause of #31624: ModelOpt Llama-4 (Scout/Maverick FP8) checkpoints take 68s-495s to load depending on hardware, dominated by H2D copies from non-contiguous CPU tensors.

These checkpoints store expert weights fused as `[num_experts, hidden_in, hidden_out]`. `Llama4Model.load_moe_expert_weights` transposes to the runtime orientation with a stride-only view, so `RoutedExperts._load_w13`/`_load_w2` end up calling `expert_data.copy_(loaded_weight)` with a non-contiguous CPU source. ATen materializes `src.contiguous()` on the CPU first, and for fp8 that gather has no vectorized path, so it costs 3-4s per expert tensor. That is where the load time goes.

Per https://github.com/vllm-project/vllm/issues/31624#issuecomment-3706297841, the fix should keep the CPU weights contiguous rather than move checkpoint tensors to the GPU. This PR does that by flipping the strided side of the copy to the destination:

```python
expert_data.transpose(-1, -2).copy_(loaded_weight.transpose(-1, -2))
```

`loaded_weight.transpose(-1, -2)` undoes the earlier view and recovers the contiguous on-disk slab at zero cost, so the H2D transfer is dense. The layout transform runs as a strided device-side write into the existing parameter storage. No copy of `loaded_weight` is retained in GPU memory at any point; ATen's transient staging buffer is allocator-managed inside the copy op. TP-narrowed slabs (unit inner stride, padded row pitch) degrade to host row-run memcpys instead of an elementwise gather and then take the same dense path. That is the case that defeated the shard-first experiment in the issue thread.

Implemented as one helper (`_copy_h2d_dst_strided`) applied at the three expert-weight copy sites in `routed_experts.py`. Contiguous sources are unaffected (byte-identical behavior). Since the fix lives in the fused-MoE loader rather than `llama4.py`, it applies to any model whose checkpoints arrive transposed.

Prior attempts on the issue, for context:

| Approach | Load time | Status |
|---|---:|---|
| Baseline | 68-78s | |
| Full-tensor CPU `.contiguous()` | 88s | worse than baseline |
| Final-slice CPU `.contiguous()` (#32081) | ~60s | independently benchmarked; #46766 takes the same approach |
| GPU-first transpose | 23-37s | rejected over GPU memory lifecycle |

This PR targets the 23-37s class without moving checkpoint tensors to the GPU.

## Test Plan

- `pytest -s -v tests/model_executor/test_routed_experts_h2d_copy.py` (new): layout equivalence against plain `copy_` for contiguous, transposed, and TP-narrowed sources, strided destination views, dtype casts, and scalar fallbacks. fp8 and bf16 on CUDA, with a CPU-only subset.
- Microbenchmark of the three copy patterns before/after.
- End-to-end load time of `nvidia/Llama-4-Scout-17B-16E-Instruct-FP8` (`--quantization modelopt --kv-cache-dtype fp8`) before/after.

## Test Result

Unit tests: 18 passed (A100 80GB, CUDA fp8/bf16/fp32 + CPU subset):

```
$ pytest tests/model_executor/test_routed_experts_h2d_copy.py -q
18 passed in 6.33s
```

Per-copy microbenchmark, A100 80GB PCIe (driver 560.35.05, torch 2.11.0+cu128), Scout-class expert slab shapes, best of 5:

| shape | dtype | baseline | #32081-style | this PR | speedup |
|---|---|---:|---:|---:|---:|
| (5120, 8192) | fp8_e4m3 | 62.8 ms | 62.7 ms | 4.0 ms | 15.8x |
| (5120, 16384) | fp8_e4m3 | 130.7 ms | 131.1 ms | 8.0 ms | 16.3x |
| (8192, 5120) | fp8_e4m3 | 63.5 ms | 64.3 ms | 4.1 ms | 15.5x |
| (5120, 8192) | bf16 | 93.4 ms | 93.6 ms | 7.5 ms | 12.4x |
| (5120, 16384) | bf16 | 194.5 ms | 196.2 ms | 15.9 ms | 12.2x |
| (8192, 5120) | bf16 | 95.4 ms | 96.1 ms | 7.5 ms | 12.7x |

TP-narrowed variants (row-run memcpy path): 1.0-1.5x. Peak CUDA memory during the benchmark: 320 MiB (transient, allocator-managed). Note the #32081-style per-copy numbers match baseline. Its e2e gain came from slicing before the gather, not from removing it.

E2E: the full Scout FP8 checkpoint (~110GB) doesn't fit one A100-80G, so this is a 24-layer truncation of `nvidia/Llama-4-Scout-17B-16E-Instruct-FP8` (57.35 GiB loaded, identical per-layer load path), warm page cache, 3 runs each. The modelopt capability gate (min 8.9) was bypassed for load-path measurement only; loading completes before any fp8 kernel selection.

| `Loading weights took` | run 1 | run 2 | run 3 | mean |
|---|---:|---:|---:|---:|
| main @ 576bf75d0 | 18.45s | 19.22s | 18.81s | 18.8s |
| this PR | 12.40s | 11.71s | 13.48s | 12.5s |

33% faster weight loading on this setup. The host here is a 2x EPYC 7763 (fast CPU gather); on the H200/Blackwell setups in #31624 where the gather costs 3-4s per tensor, the expected end-to-end gain is larger. **Update (2026-09-04):** @eric1932 ran the full untruncated 48-layer `nvidia/Llama-4-Scout-17B-16E-Instruct-FP8` on 1x H200, source-hash-verified builds, paired baseline/PR runs in separate processes, page cache confirmed 100% resident both sides:

| Version | 3 runs (s) | Median (s) |
|---|---|---:|
| Baseline @ 576bf75 | 104.46, 102.58, 101.87 | 102.58 |
| This PR @ 561b5bf | 23.63, 23.35, 24.33 | 23.63 |

4.34x, full model, on the H200 class this needed. Output tokens matched across all six runs. Thanks, full details below.

Note: built with an AI-assisted engineering workflow (Claude) under my direction, disclosed per the contributing guide: I specified the approach, reviewed each iteration, and validated the benchmarks. Co-authored-by trailer on the commit.

FIX #31624


