### PR TITLE
[Perf][Frontend] Add opt-in incremental prompt-encoding cache for multi-turn chat

### DIFF
--- a/benchmarks/benchmark_incremental_encoding.py
+++ b/benchmarks/benchmark_incremental_encoding.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Benchmark the exact incremental prompt-encoding cache
+(``vllm/tokenizers/incremental_encode.py``) against full re-encoding.
+
+Simulates multi-turn conversations: for each configured history size, a
+synthetic conversation is grown turn by turn and the per-turn encode
+latency is measured for both the cold path (full re-encode, what vLLM does
+today) and the incremental path. Only ``transformers`` is required.
+
+Example usage:
+    python benchmark_incremental_encoding.py \
+        --tokenizer Qwen/Qwen2.5-0.5B \
+        --history-tokens 5000 32000 128000 512000 \
+        --num-turns 8
+"""
+
+import argparse
+import random
+import statistics
+import time
+
+from transformers import AutoTokenizer
+
+try:
+    from vllm.tokenizers.incremental_encode import IncrementalEncodeCache
+except ImportError:  # allow running without a full vLLM installation
+    import importlib.util
+    from pathlib import Path
+
+    _MODULE_PATH = (
+        Path(__file__).resolve().parents[1]
+        / "vllm"
+        / "tokenizers"
+        / "incremental_encode.py"
+    )
+    _spec = importlib.util.spec_from_file_location("incremental_encode", _MODULE_PATH)
+    _module = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_module)
+    IncrementalEncodeCache = _module.IncrementalEncodeCache
+
+FILLER = (
+    "The quick brown fox jumps over the lazy dog. "
+    "def process(batch):\n    return [x * 2 for x in batch]\n"
+    "多轮对话的前缀在每一轮都保持不变。 "
+    "Latency is dominated by re-tokenizing the unchanged prefix. "
+)
+
+
+def build_history(tokenizer, target_tokens: int, rng: random.Random) -> str:
+    """Grow a synthetic conversation history to ~target_tokens tokens."""
+    chunk = (
+        f"<|im_start|>user\nRequest {{i}}: {FILLER}{{salt}}<|im_end|>\n"
+        f"<|im_start|>assistant\nResponse {{i}}: {FILLER}<|im_end|>\n"
+    )
+    chunk_tokens = len(tokenizer(chunk, add_special_tokens=False)["input_ids"])
+    parts = [
+        chunk.format(i=i, salt=f"{rng.getrandbits(64):x}")
+        for i in range(max(1, target_tokens // chunk_tokens))
+    ]
+    return "".join(parts)
+
+
+def new_turn(i: int, rng: random.Random) -> str:
+    return (
+        f"<|im_start|>user\nTurn {i}: {FILLER} {rng.getrandbits(64):x}"
+        f"<|im_end|>\n<|im_start|>assistant\n"
+    )
+
+
+def percentile(values: list[float], p: float) -> float:
+    return statistics.quantiles(values, n=100, method="inclusive")[
+        min(98, max(0, round(p) - 1))
+    ]
+
+
+def bench_history_size(tokenizer, target_tokens: int, num_turns: int, seed: int):
+    rng = random.Random(seed)
+    history = build_history(tokenizer, target_tokens, rng)
+
+    cache = IncrementalEncodeCache()
+    cold_times: list[float] = []
+    incr_times: list[float] = []
+
+    # Seed the cache with the initial history (a miss, like the first
+    # request of a conversation after server start).
+    cache.encode(tokenizer, history)
+
+    text = history
+    for i in range(num_turns):
+        text += new_turn(i, rng)
+
+        start = time.perf_counter()
+        expected = tokenizer(text)["input_ids"]
+        cold_times.append(time.perf_counter() - start)
+
+        start = time.perf_counter()
+        actual = cache.encode(tokenizer, text)
+        incr_times.append(time.perf_counter() - start)
+
+        assert actual == expected, "incremental encode is not token-exact!"
+
+    return {
+        "prompt_tokens": len(expected),
+        "cold_p50_ms": statistics.median(cold_times) * 1e3,
+        "cold_p99_ms": percentile(cold_times, 99) * 1e3,
+        "incr_p50_ms": statistics.median(incr_times) * 1e3,
+        "incr_p99_ms": percentile(incr_times, 99) * 1e3,
+        "hits": cache.stats.hits,
+        "misses": cache.stats.misses,
+        "fallbacks": cache.stats.fallbacks,
+    }
+
+
+def main(args: argparse.Namespace):
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer)
+    print(f"tokenizer: {args.tokenizer}, turns per size: {args.num_turns}")
+    header = (
+        f"{'history':>9} {'prompt_tok':>10} {'cold p50':>10} {'cold p99':>10} "
+        f"{'incr p50':>10} {'incr p99':>10} {'speedup':>8} {'hit/miss/fb':>12}"
+    )
+    print(header)
+    print("-" * len(header))
+    for target in args.history_tokens:
+        result = bench_history_size(tokenizer, target, args.num_turns, args.seed)
+        speedup = result["cold_p50_ms"] / max(result["incr_p50_ms"], 1e-9)
+        print(
+            f"{target:>9} {result['prompt_tokens']:>10} "
+            f"{result['cold_p50_ms']:>8.2f}ms {result['cold_p99_ms']:>8.2f}ms "
+            f"{result['incr_p50_ms']:>8.2f}ms {result['incr_p99_ms']:>8.2f}ms "
+            f"{speedup:>7.1f}x "
+            f"{result['hits']:>4}/{result['misses']}/{result['fallbacks']}"
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Benchmark incremental prompt encoding vs full re-encode."
+    )
+    parser.add_argument("--tokenizer", type=str, default="Qwen/Qwen2.5-0.5B")
+    parser.add_argument(
+        "--history-tokens",
+        type=int,
+        nargs="+",
+        default=[5000, 32000, 128000, 512000],
+        help="Conversation history sizes (in tokens) to benchmark.",
+    )
+    parser.add_argument(
+        "--num-turns",
+        type=int,
+        default=8,
+        help="Number of appended turns measured per history size.",
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    main(parser.parse_args())

--- a/tests/tokenizers_/test_incremental_encode.py
+++ b/tests/tokenizers_/test_incremental_encode.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the exact incremental prompt-encoding cache.
+
+These tests only require ``transformers``; the module under test is
+dependency-free by design, so it is loaded directly from its file when a
+full vLLM installation is not available.
+"""
+
+import random
+
+import pytest
+from transformers import AutoTokenizer
+
+try:
+    from vllm.tokenizers.incremental_encode import IncrementalEncodeCache
+except ImportError:  # pragma: no cover - minimal environments without vLLM
+    import importlib.util
+    from pathlib import Path
+
+    _MODULE_PATH = (
+        Path(__file__).resolve().parents[2]
+        / "vllm"
+        / "tokenizers"
+        / "incremental_encode.py"
+    )
+    _spec = importlib.util.spec_from_file_location("incremental_encode", _MODULE_PATH)
+    _module = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_module)
+    IncrementalEncodeCache = _module.IncrementalEncodeCache
+
+TOKENIZER_IDS = [
+    "openai-community/gpt2",
+    "Qwen/Qwen2.5-0.5B",
+    "deepseek-ai/DeepSeek-V3",
+]
+
+# Deliberately adversarial turn material: code, unicode (CJK, emoji with
+# ZWJ, RTL, combining marks), whitespace runs, and literal special-token
+# strings that must not be spliced through.
+TURN_SNIPPETS = [
+    "Here is a Python helper:\n\n```python\ndef merge(a: dict, b: dict) -> dict:"
+    '\n    """Merge b into a."""\n    out = {**a}\n    for k, v in b.items():'
+    "\n        out[k] = merge(out.get(k, {}), v) if isinstance(v, dict) else v"
+    "\n    return out\n```\nIt handles nested dicts recursively.",
+    "多轮对话的关键在于前缀缓存。日本語のテキストも含めてテストします。"
+    "한국어 문장도 섞어 봅니다. 這是繁體中文。",
+    "Emoji stress: 👩‍👩‍👧‍👦 🇯🇵 🧑🏽‍💻 étude résumé שלום مرحبا done.",
+    "Whitespace run follows:" + " " * 137 + "\n\n\t\t\n" + " " * 41 + "end.",
+    "Literal special tokens: <|endoftext|> <|im_start|>user<|im_end|> "
+    "<|User|> <|Assistant|> <|begin▁of▁sentence|> and a bare <| marker.",
+    "Log excerpt:\nERROR 2026-07-03T12:00:01Z worker[3] step=41952 "
+    "loss=0.001234 grad_norm=17.3\n" * 3,
+]
+
+CACHE_KWARGS = dict(min_chars=2048, backup_chars=512, margin_chars=64)
+
+
+@pytest.fixture(scope="module", params=TOKENIZER_IDS)
+def tokenizer(request):
+    return AutoTokenizer.from_pretrained(request.param)
+
+
+def _build_turns(num_turns: int, seed: int = 0) -> list[str]:
+    rng = random.Random(seed)
+    system = (
+        "<|im_start|>system\nYou are a meticulous assistant. " * 20
+        + "Rules:\n"
+        + "\n".join(f"{i}. Always be exact." for i in range(40))
+        + "<|im_end|>\n"
+    )
+    turns = [system]
+    for i in range(num_turns):
+        snippet = TURN_SNIPPETS[i % len(TURN_SNIPPETS)]
+        turns.append(
+            f"<|im_start|>user\nTurn {i}: {snippet} "
+            f"{rng.getrandbits(64):x}<|im_end|>\n"
+            f"<|im_start|>assistant\nReply {i}: {snippet[::-1][:200]}<|im_end|>\n"
+        )
+    return turns
+
+
+@pytest.mark.parametrize("add_special_tokens", [True, False])
+def test_multi_turn_token_exact(tokenizer, add_special_tokens: bool):
+    """Growing conversation: every turn must be token-exact vs full encode."""
+    cache = IncrementalEncodeCache(**CACHE_KWARGS)
+    text = ""
+    for turn in _build_turns(num_turns=8):
+        text += turn
+        actual = cache.encode(tokenizer, text, add_special_tokens=add_special_tokens)
+        expected = tokenizer(text, add_special_tokens=add_special_tokens)["input_ids"]
+        if len(text) < cache.min_chars:
+            assert actual is None
+        else:
+            assert actual == expected, f"mismatch at len(text)={len(text)}"
+    # The growth pattern must actually exercise the splice path.
+    assert cache.stats.hits >= 4
+    assert cache.stats.misses == 1
+
+
+def test_identical_prompt_is_served_from_cache(tokenizer):
+    cache = IncrementalEncodeCache(**CACHE_KWARGS)
+    text = "".join(_build_turns(num_turns=3))
+    first = cache.encode(tokenizer, text)
+    second = cache.encode(tokenizer, text)
+    assert first == second == tokenizer(text)["input_ids"]
+    assert cache.stats.hits == 1
+
+
+def test_interleaved_conversations(tokenizer):
+    """Multiple conversations growing concurrently share the LRU."""
+    cache = IncrementalEncodeCache(**CACHE_KWARGS)
+    all_turns = [_build_turns(num_turns=6, seed=c + 1) for c in range(3)]
+    texts = ["", "", ""]
+    for i in range(6):
+        for c in range(3):
+            texts[c] += all_turns[c][i]
+            actual = cache.encode(tokenizer, texts[c])
+            if actual is not None:
+                assert actual == tokenizer(texts[c])["input_ids"]
+    assert cache.stats.hits > 0
+
+
+def test_truncation_within_limit_matches_full_encode(tokenizer):
+    cache = IncrementalEncodeCache(**CACHE_KWARGS)
+    text = "".join(_build_turns(num_turns=4))
+    limit = len(tokenizer(text)["input_ids"]) + 10
+    actual = cache.encode(tokenizer, text, truncation=True, max_length=limit)
+    expected = tokenizer(text, truncation=True, max_length=limit)["input_ids"]
+    assert actual == expected
+
+
+def test_truncation_overflow_falls_back(tokenizer):
+    cache = IncrementalEncodeCache(**CACHE_KWARGS)
+    text = "".join(_build_turns(num_turns=4))
+    assert cache.encode(tokenizer, text, truncation=True, max_length=16) is None
+    # The cache was still warmed by the attempt.
+    assert cache.encode(tokenizer, text) == tokenizer(text)["input_ids"]
+    assert cache.stats.hits == 1
+
+
+def test_unsupported_kwargs_are_rejected(tokenizer):
+    cache = IncrementalEncodeCache(**CACHE_KWARGS)
+    text = "".join(_build_turns(num_turns=4))
+    assert cache.encode(tokenizer, text, return_tensors="pt") is None
+    assert cache.encode(tokenizer, text, truncation=True) is None
+
+
+def test_short_prompts_are_skipped(tokenizer):
+    cache = IncrementalEncodeCache(**CACHE_KWARGS)
+    assert cache.encode(tokenizer, "short prompt") is None
+    assert cache.stats.misses == 0
+
+
+def test_cache_salt_partitions_entries(tokenizer):
+    cache = IncrementalEncodeCache(**CACHE_KWARGS)
+    turns = _build_turns(num_turns=4)
+    text = "".join(turns[:-1])
+    cache.encode(tokenizer, text, cache_salt="salt-a")
+    grown = text + turns[-1]
+    # Different salt: the salt-a entry must not be visible.
+    assert (
+        cache.encode(tokenizer, grown, cache_salt="salt-b")
+        == tokenizer(grown)["input_ids"]
+    )
+    assert cache.stats.hits == 0
+    assert cache.stats.misses == 2
+    # Same salt: the prefix entry is visible again.
+    grown_more = grown + turns[1]
+    assert (
+        cache.encode(tokenizer, grown_more, cache_salt="salt-b")
+        == tokenizer(grown_more)["input_ids"]
+    )
+    assert cache.stats.misses == 2
+
+
+def test_lru_is_bounded(tokenizer):
+    cache = IncrementalEncodeCache(max_entries=2, **CACHE_KWARGS)
+    for seed in range(5):
+        text = "".join(_build_turns(num_turns=3, seed=seed))
+        cache.encode(tokenizer, text)
+    assert len(cache._entries) == 2
+
+
+def test_non_fast_tokenizer_is_unsupported():
+    class _SlowTokenizer:
+        is_fast = False
+
+    cache = IncrementalEncodeCache(**CACHE_KWARGS)
+    text = "".join(_build_turns(num_turns=4))
+    assert cache.encode(_SlowTokenizer(), text) is None
+    assert cache.stats.misses == 0
+
+
+def test_append_directly_after_special_token(tokenizer):
+    """The seam guard must not break exactness when new content starts with
+    or directly follows special-token markers."""
+    cache = IncrementalEncodeCache(**CACHE_KWARGS)
+    text = "".join(_build_turns(num_turns=3)) + "<|im_start|>assistant\n"
+    assert cache.encode(tokenizer, text) == tokenizer(text)["input_ids"]
+    text += "<|endoftext|>" * 40
+    assert cache.encode(tokenizer, text) == tokenizer(text)["input_ids"]
+
+
+def test_whitespace_run_across_seam(tokenizer):
+    """A giant whitespace run spanning the backup window must either splice
+    exactly or fall back — never corrupt the output."""
+    cache = IncrementalEncodeCache(**CACHE_KWARGS)
+    base = "".join(_build_turns(num_turns=3)) + " " * 2000
+    assert cache.encode(tokenizer, base) == tokenizer(base)["input_ids"]
+    grown = base + " " * 500 + "after the run"
+    assert cache.encode(tokenizer, grown) == tokenizer(grown)["input_ids"]

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -348,6 +348,14 @@ class ModelConfig:
     The offline `LLM` entrypoint uses the synchronous renderer path and
     processes prompts (including multimodal preprocessing) serially, so
     this setting has no effect there."""
+    enable_incremental_encoding: bool = False
+    """Enable exact incremental prompt encoding for long multi-turn
+    conversations. The renderer keeps a small LRU of recently encoded
+    (text, token_ids) pairs; when a new prompt extends a cached one, only
+    the tail is re-tokenized and spliced at a verified pre-token boundary,
+    which is token-exact with respect to a full re-encode. Only takes
+    effect for HF fast tokenizers; requests that cannot be served exactly
+    fall back to a full encode."""
 
     # Pooler config
     pooler_config: PoolerConfig | None = None

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -584,6 +584,7 @@ class EngineArgs:
     )
     io_processor_plugin: str | None = None
     renderer_num_workers: int = 1
+    enable_incremental_encoding: bool = ModelConfig.enable_incremental_encoding
     skip_mm_profiling: bool = MultiModalConfig.skip_mm_profiling
     video_pruning_rate: float | None = MultiModalConfig.video_pruning_rate
     mm_tensor_ipc: MMTensorIPC = MultiModalConfig.mm_tensor_ipc
@@ -905,6 +906,10 @@ class EngineArgs:
         model_group.add_argument(
             "--renderer-num-workers",
             **model_kwargs["renderer_num_workers"],
+        )
+        model_group.add_argument(
+            "--enable-incremental-encoding",
+            **model_kwargs["enable_incremental_encoding"],
         )
 
         # Model loading arguments
@@ -1719,6 +1724,7 @@ class EngineArgs:
             mm_ipc_gpu_memory_gb=self.mm_ipc_gpu_memory_gb,
             io_processor_plugin=self.io_processor_plugin,
             renderer_num_workers=self.renderer_num_workers,
+            enable_incremental_encoding=self.enable_incremental_encoding,
         )
 
     def validate_tensorizer_args(self):

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -155,6 +155,7 @@ if TYPE_CHECKING:
     VLLM_USE_RUST_FRONTEND: bool = False
     VLLM_RUST_FRONTEND_PATH: str | None = "auto"
     VLLM_SERVER_DEV_MODE: bool = False
+    VLLM_INCREMENTAL_ENCODING: bool = False
     VLLM_V1_OUTPUT_PROC_CHUNK_SIZE: int = 128
     VLLM_MLA_DISABLE: bool = False
     VLLM_RAY_PER_WORKER_GPUS: float = 1.0
@@ -1348,6 +1349,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # some additional endpoints for developing and debugging,
     # e.g. `/reset_prefix_cache`
     "VLLM_SERVER_DEV_MODE": lambda: bool(int(os.getenv("VLLM_SERVER_DEV_MODE", "0"))),
+    # If set, enables exact incremental prompt encoding for multi-turn
+    # conversations in the renderer. Fallback for the
+    # `--enable-incremental-encoding` engine argument.
+    "VLLM_INCREMENTAL_ENCODING": lambda: bool(
+        int(os.getenv("VLLM_INCREMENTAL_ENCODING", "0"))
+    ),
     # Controls the maximum number of requests to handle in a
     # single asyncio task when processing per-token outputs in the
     # V1 AsyncLLM interface. It is applicable when handling a high

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Generic, overload
 
 from typing_extensions import TypeVar
 
+import vllm.envs as envs
 from vllm.inputs import (
     EmbedsInput,
     EmbedsPrompt,
@@ -39,6 +40,7 @@ from vllm.multimodal.processing import BaseMultiModalProcessor
 from vllm.multimodal.processing import ProcessorInputs as MMProcessorInputs
 from vllm.multimodal.registry import MultiModalTimingRegistry
 from vllm.tokenizers import TokenizerLike
+from vllm.tokenizers.incremental_encode import IncrementalEncodeCache
 from vllm.utils.async_utils import make_async
 from vllm.utils.counter import AtomicCounter
 from vllm.utils.torch_utils import set_default_torch_num_threads
@@ -78,6 +80,18 @@ class BaseRenderer(ABC, Generic[_T]):
         self.api_process_rank = config.parallel_config._api_process_rank
 
         self.tokenizer = tokenizer
+
+        # Opt-in exact prefix reuse for long multi-turn prompts. Shared
+        # across requests (renderer-level, above the tokenizer pool);
+        # requests it cannot serve exactly fall through to the regular
+        # encode path, so it is silently inert for tokenizers without an
+        # HF fast backend.
+        self._incremental_encoder: IncrementalEncodeCache | None = None
+        if tokenizer is not None and (
+            config.model_config.enable_incremental_encoding
+            or envs.VLLM_INCREMENTAL_ENCODING
+        ):
+            self._incremental_encoder = IncrementalEncodeCache()
 
         # Thread pool executor for blocking tokenizer operations.  The
         # multimodal processor receives a deep-copied tokenizer (see #36557)
@@ -475,6 +489,15 @@ class BaseRenderer(ABC, Generic[_T]):
         tokenizer = self.get_tokenizer()
         want_offsets = self._wants_offsets(prompt, params)
         kwargs = params.get_encode_kwargs()
+        if self._incremental_encoder is not None and not want_offsets:
+            token_ids = self._incremental_encoder.encode(
+                tokenizer,  # type: ignore[arg-type]
+                prompt["prompt"],
+                cache_salt=prompt.get("cache_salt"),
+                **kwargs,
+            )
+            if token_ids is not None:
+                return self._build_tokens_prompt(token_ids, prompt)
         if want_offsets:
             kwargs = {**kwargs, "return_offsets_mapping": True}
         encoding = tokenizer(prompt["prompt"], **kwargs)

--- a/vllm/tokenizers/incremental_encode.py
+++ b/vllm/tokenizers/incremental_encode.py
@@ -1,0 +1,446 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Exact incremental prompt encoding for multi-turn conversations.
+
+In multi-turn chat, each request re-sends the whole conversation, so the
+rendered prompt of turn ``N`` is almost always a strict string prefix of the
+prompt of turn ``N + 1``. Re-tokenizing the full prompt costs time linear in
+the conversation length even though only the tail is new.
+[`IncrementalEncodeCache`][vllm.tokenizers.incremental_encode.IncrementalEncodeCache]
+reuses the token ids of a previously encoded prefix and re-encodes only the
+tail, while remaining token-exact with respect to a full re-encode.
+
+Correctness rests on two mechanisms:
+
+1. *Pre-token boundary invariant*: BPE merges never cross pre-token
+   boundaries, so the token ids strictly before a pre-token boundary do not
+   depend on the text at or after it. The splice point is chosen by backing
+   up ``backup_chars`` characters from the end of the cached prefix and
+   asking the backend pre-tokenizer (``pre_tokenizer.pre_tokenize_str``) for
+   boundary candidates at least ``margin_chars`` away from both window
+   edges, keeping the seam far from the newly appended text. The seam is
+   the first candidate whose neighborhood is free of special-token markers
+   and which coincides with a token boundary in the *cached* encoding
+   (checked via its character offsets), which rules out seams inside
+   added/special tokens.
+
+2. *Overlap verification with full-encode fallback*: the tail re-encode
+   overlaps the cached encoding by roughly ``backup_chars`` characters. The
+   overlapping token ids and offsets must match the cached ones exactly
+   (excluding tokens within ``margin_chars`` of the cached text's end, which
+   may legitimately merge with the appended text). Any mismatch — or any
+   condition this module cannot prove safe: no pre-token boundary in the
+   window, special-token markers near the seam, a normalizer that rewrites
+   the window, incompatible encode kwargs, or a result that would exceed a
+   truncation limit — falls back to a full re-encode, which is also what
+   (re)fills the cache.
+
+The cache is renderer-level state shared across requests: the OpenAI
+frontend is stateless, so entries are matched purely by longest string
+prefix within a bounded LRU of recent conversations, optionally partitioned
+by ``cache_salt``. It is thread-safe: only the cheap lookup/insert steps
+take the lock, and all tokenizer calls run outside of it against whatever
+thread-safe tokenizer the caller passes in (in vLLM, the renderer's
+pool-backed HF fast tokenizer).
+
+This module deliberately has no vLLM dependencies so that the cache can be
+unit-tested against plain ``transformers`` tokenizers.
+"""
+
+import contextlib
+import logging
+import threading
+from array import array
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizerFast
+
+logger = logging.getLogger(__name__)
+
+_Offsets = list[tuple[int, int]]
+
+_SPECIAL_MARKER = "<|"
+"""Common special-token sigil; seams near it are treated as unsafe."""
+
+_AFFIX_PROBE_TEXTS = ("Hello, world!", "def f(x):\n    return x  # 你好")
+"""Texts used to validate the ``prefix + body + suffix`` special-token
+model of a tokenizer (e.g. a leading BOS token)."""
+
+
+@dataclass
+class IncrementalEncodeStats:
+    hits: int = 0
+    """Requests served by splicing (or exactly matching) a cached prefix."""
+
+    misses: int = 0
+    """Requests with no cached prefix; fully encoded and cached."""
+
+    fallbacks: int = 0
+    """Requests with a cached prefix that could not be proven safe to
+    splice; fully encoded and cached."""
+
+
+@dataclass
+class _CacheEntry:
+    salt: str | None
+    text: str
+    token_ids: array
+    """Token ids of ``text`` encoded without special tokens (``"i"`` typecode
+    to bound memory for very long conversations)."""
+
+    offsets: _Offsets
+    """Character offsets of the trailing tokens of ``token_ids`` (only the
+    tail is needed to locate and verify future splice points)."""
+
+    offsets_start: int
+    """Index into ``token_ids`` of the token described by ``offsets[0]``."""
+
+
+class IncrementalEncodeCache:
+    """Bounded LRU of ``(text, token_ids)`` pairs with prefix splicing.
+
+    A cache instance must only ever be used with a single logical tokenizer;
+    tokenizer capabilities and special-token affixes are probed once and
+    memoized. Requests that this cache cannot serve exactly (unsupported
+    tokenizer, incompatible kwargs, short prompts, truncation overflow)
+    return ``None`` and must be handled by the caller's regular encode path.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_entries: int = 16,
+        min_chars: int = 16384,
+        backup_chars: int = 1024,
+        margin_chars: int = 96,
+    ) -> None:
+        if min_chars < backup_chars + 2 * margin_chars:
+            raise ValueError(
+                "min_chars must be at least backup_chars + 2 * margin_chars "
+                f"({backup_chars + 2 * margin_chars}), got {min_chars}"
+            )
+        self.max_entries = max_entries
+        self.min_chars = min_chars
+        self.backup_chars = backup_chars
+        self.margin_chars = margin_chars
+        self.stats = IncrementalEncodeStats()
+
+        self._entries: list[_CacheEntry] = []
+        self._lock = threading.Lock()
+        self._supported: bool | None = None
+        self._pre_tokenizer: Any = None
+        self._normalizer: Any = None
+        self._affixes: dict[bool, tuple[list[int], list[int]] | None] = {}
+
+    def encode(
+        self,
+        tokenizer: "PreTrainedTokenizerFast",
+        text: str,
+        *,
+        add_special_tokens: bool = True,
+        truncation: bool = False,
+        max_length: int | None = None,
+        cache_salt: str | None = None,
+        **kwargs: Any,
+    ) -> list[int] | None:
+        """Encode ``text``, reusing a cached prefix when provably exact.
+
+        Returns the token ids (identical to
+        ``tokenizer(text, add_special_tokens=..., truncation=...,
+        max_length=...)["input_ids"]``), or ``None`` if this request cannot
+        be served by the cache and the caller should encode normally.
+        """
+        if kwargs or not isinstance(text, str) or len(text) < self.min_chars:
+            return None
+        if truncation and max_length is None:
+            return None
+        if not self._check_tokenizer(tokenizer):
+            return None
+
+        affixes = self._get_affixes(tokenizer, add_special_tokens)
+        if affixes is None:
+            return None
+        prefix_ids, suffix_ids = affixes
+
+        entry = self._find_prefix(text, cache_salt)
+        if entry is None:
+            self.stats.misses += 1
+            body = self._encode_and_store(tokenizer, text, cache_salt)
+        elif entry.text == text:
+            self.stats.hits += 1
+            self._touch(entry)
+            body = entry.token_ids
+        else:
+            body = self._splice(tokenizer, entry, text, cache_salt)
+            if body is None:
+                self.stats.fallbacks += 1
+                body = self._encode_and_store(tokenizer, text, cache_salt)
+            else:
+                self.stats.hits += 1
+
+        token_ids = prefix_ids + body.tolist() + suffix_ids
+        if truncation and max_length is not None and len(token_ids) > max_length:
+            # The cache is warm, but truncation semantics (side, pairing
+            # with special tokens) belong to the regular encode path.
+            return None
+        return token_ids
+
+    # Tokenizer capability probing
+
+    def _check_tokenizer(self, tokenizer: "PreTrainedTokenizerFast") -> bool:
+        if self._supported is None:
+            backend = (
+                getattr(tokenizer, "backend_tokenizer", None)
+                if getattr(tokenizer, "is_fast", False)
+                else None
+            )
+            pre_tokenizer = getattr(backend, "pre_tokenizer", None)
+            if pre_tokenizer is None:
+                logger.debug(
+                    "Incremental encoding disabled: tokenizer %s has no "
+                    "fast-backend pre-tokenizer",
+                    type(tokenizer).__name__,
+                )
+                self._supported = False
+            else:
+                self._pre_tokenizer = pre_tokenizer
+                self._normalizer = backend.normalizer
+                self._supported = True
+        return self._supported
+
+    def _get_affixes(
+        self,
+        tokenizer: "PreTrainedTokenizerFast",
+        add_special_tokens: bool,
+    ) -> tuple[list[int], list[int]] | None:
+        """Special tokens the tokenizer adds around the body, or ``None``.
+
+        Only tokenizers whose special tokens form a content-independent
+        ``prefix + body + suffix`` template (validated against probe texts)
+        are supported for ``add_special_tokens=True``.
+        """
+        key = bool(add_special_tokens)
+        if key not in self._affixes:
+            self._affixes[key] = self._compute_affixes(tokenizer, key)
+        return self._affixes[key]
+
+    @staticmethod
+    def _compute_affixes(
+        tokenizer: "PreTrainedTokenizerFast",
+        add_special_tokens: bool,
+    ) -> tuple[list[int], list[int]] | None:
+        if not add_special_tokens:
+            return [], []
+        try:
+            empty = list(tokenizer("", add_special_tokens=True)["input_ids"])
+            probes = [
+                (
+                    list(tokenizer(t, add_special_tokens=True)["input_ids"]),
+                    list(tokenizer(t, add_special_tokens=False)["input_ids"]),
+                )
+                for t in _AFFIX_PROBE_TEXTS
+            ]
+        except Exception:
+            logger.debug(
+                "Incremental encoding: special-token probe failed", exc_info=True
+            )
+            return None
+        for split in range(len(empty), -1, -1):
+            prefix, suffix = empty[:split], empty[split:]
+            if all(with_st == prefix + body + suffix for with_st, body in probes):
+                return prefix, suffix
+        logger.debug(
+            "Incremental encoding disabled for add_special_tokens=True: "
+            "special tokens of %s do not follow a prefix/suffix template",
+            type(tokenizer).__name__,
+        )
+        return None
+
+    # Cache bookkeeping (all lock-protected sections are O(max_entries))
+
+    def _find_prefix(self, text: str, salt: str | None) -> _CacheEntry | None:
+        with self._lock:
+            candidates = [e for e in self._entries if e.salt == salt]
+        best = None
+        for entry in candidates:
+            if (
+                len(entry.text) <= len(text)
+                and text.startswith(entry.text)
+                and (best is None or len(entry.text) > len(best.text))
+            ):
+                best = entry
+        return best
+
+    def _touch(self, entry: _CacheEntry) -> None:
+        with self._lock:
+            with contextlib.suppress(ValueError):  # concurrently evicted
+                self._entries.remove(entry)
+            self._entries.append(entry)
+
+    def _store(
+        self,
+        salt: str | None,
+        text: str,
+        token_ids: array,
+        offsets: _Offsets,
+        offsets_start: int,
+    ) -> None:
+        # Future splice points fall within the last `backup_chars` of `text`,
+        # so only the offsets of the trailing tokens need to be retained;
+        # keep 2x for slack against short subsequent turns.
+        keep_from = len(text) - 2 * self.backup_chars
+        cut = 0
+        while cut < len(offsets) and offsets[cut][1] < keep_from:
+            cut += 1
+        entry = _CacheEntry(
+            salt=salt,
+            text=text,
+            token_ids=token_ids,
+            offsets=offsets[cut:],
+            offsets_start=offsets_start + cut,
+        )
+        with self._lock:
+            self._entries = [
+                e for e in self._entries if not (e.salt == salt and e.text == text)
+            ]
+            self._entries.append(entry)
+            if len(self._entries) > self.max_entries:
+                del self._entries[0]
+
+    # Encoding
+
+    def _encode_with_offsets(
+        self,
+        tokenizer: "PreTrainedTokenizerFast",
+        text: str,
+    ) -> tuple[array, _Offsets]:
+        encoding = tokenizer(
+            text,
+            add_special_tokens=False,
+            truncation=False,
+            return_offsets_mapping=True,
+        )
+        return array("i", encoding["input_ids"]), encoding["offset_mapping"]
+
+    def _encode_and_store(
+        self,
+        tokenizer: "PreTrainedTokenizerFast",
+        text: str,
+        salt: str | None,
+    ) -> array:
+        token_ids, offsets = self._encode_with_offsets(tokenizer, text)
+        self._store(salt, text, token_ids, offsets, 0)
+        return token_ids
+
+    def _splice(
+        self,
+        tokenizer: "PreTrainedTokenizerFast",
+        entry: _CacheEntry,
+        text: str,
+        salt: str | None,
+    ) -> array | None:
+        """Reuse ``entry``'s token ids up to a safe boundary, re-encode the
+        rest of ``text``, and cache the result. ``None`` if unsafe."""
+        cached_len = len(entry.text)
+        base = cached_len - self.backup_chars
+        window = text[base:cached_len]
+
+        if self._normalizer is not None:
+            try:
+                if self._normalizer.normalize_str(window) != window:
+                    return None
+            except Exception:
+                return None
+
+        boundary = split = None
+        for candidate in self._pre_token_boundaries(window, base):
+            seam = text[candidate - self.margin_chars : candidate + self.margin_chars]
+            if _SPECIAL_MARKER in seam:
+                continue
+            split = self._boundary_token_index(entry, candidate)
+            if split is not None:
+                boundary = candidate
+                break
+        if boundary is None or split is None:
+            return None
+
+        tail_ids, tail_offsets = self._encode_with_offsets(tokenizer, text[boundary:])
+        if not self._verify_overlap(entry, split, boundary, tail_ids, tail_offsets):
+            logger.debug(
+                "Incremental encoding: overlap verification failed at "
+                "boundary %d; falling back to full encode",
+                boundary,
+            )
+            return None
+
+        token_ids = entry.token_ids[:split]
+        token_ids.extend(tail_ids)
+        offsets_head = entry.offsets[: split - entry.offsets_start]
+        offsets = offsets_head + [
+            (start + boundary, end + boundary) for start, end in tail_offsets
+        ]
+        self._store(salt, text, token_ids, offsets, entry.offsets_start)
+        return token_ids
+
+    def _pre_token_boundaries(self, window: str, base: int) -> list[int]:
+        """Absolute char indices of pre-token boundaries at least
+        ``margin_chars`` away from both ends of ``window``, earliest first
+        (i.e. candidates furthest from the appended text come first)."""
+        try:
+            segments = self._pre_tokenizer.pre_tokenize_str(window)
+        except Exception:
+            logger.debug("Incremental encoding: pre_tokenize_str failed", exc_info=True)
+            return []
+        limit = len(window) - self.margin_chars
+        return [
+            base + start
+            for _piece, (start, _end) in segments
+            if self.margin_chars <= start <= limit
+        ]
+
+    @staticmethod
+    def _boundary_token_index(entry: _CacheEntry, boundary: int) -> int | None:
+        """Index of the first cached token starting at ``boundary``, given
+        that the previous token ends exactly there; ``None`` otherwise."""
+        offsets = entry.offsets
+        for k in range(len(offsets) - 1, -1, -1):
+            end = offsets[k][1]
+            if end < boundary:
+                return None
+            if end == boundary:
+                if k + 1 >= len(offsets) or offsets[k + 1][0] != boundary:
+                    return None
+                return entry.offsets_start + k + 1
+        return None
+
+    def _verify_overlap(
+        self,
+        entry: _CacheEntry,
+        split: int,
+        boundary: int,
+        tail_ids: array,
+        tail_offsets: _Offsets,
+    ) -> bool:
+        """Check that the tail re-encode reproduces the cached tokens over
+        the overlap region (tokens within ``margin_chars`` of the cached
+        text's end are excluded, as they may merge with appended text)."""
+        verify_end = len(entry.text) - self.margin_chars
+        k = split - entry.offsets_start
+        num_verified = 0
+        while k < len(entry.offsets) and entry.offsets[k][1] <= verify_end:
+            k += 1
+            num_verified += 1
+        if num_verified == 0:
+            return False
+        if entry.token_ids[split : split + num_verified] != tail_ids[:num_verified]:
+            return False
+        expected = entry.offsets[
+            split - entry.offsets_start : split - entry.offsets_start + num_verified
+        ]
+        actual = [
+            (start + boundary, end + boundary)
+            for start, end in tail_offsets[:num_verified]
+        ]
+        return expected == actual


### PR DESCRIPTION
RFC: #47582


## Purpose

In multi-turn chat, every request re-sends the whole conversation, so the rendered prompt of turn `N` is almost always a strict string prefix of turn `N+1` — yet `BaseRenderer._tokenize_prompt` re-tokenizes the full prompt every turn. That cost is linear in history length (~0.5 s per turn at ~200K tokens) and lands on the API-server CPU, where it competes with detokenization and chat-template rendering (#39590). With automatic prefix caching, tokenization is frequently the dominant TTFT term for long conversations.

This PR adds an **opt-in**, token-exact incremental encoding cache:

- `--enable-incremental-encoding` engine/CLI flag (default **off**), env fallback `VLLM_INCREMENTAL_ENCODING=1`.
- Related but different from segment-parallel/segment-cache tokenization (#45514), which accelerates cold large prompts; this reuses the *previous request's* encoding across the multi-turn sequence. The two compose. SGLang's SMG L1 prefix tokenization cache is ecosystem precedent.

Production validation: DeepSeek-V4-Flash on 2×DGX-Spark (agentic coding, long conversations) — median multi-turn TTFT **0.92 s → 0.47 s**, encode ~35× faster at the median, token-exact on all sampled turns.

## How it works

`vllm/tokenizers/incremental_encode.py` (dependency-free, ~450 lines incl. docs):

1. Bounded LRU (16 entries) of recent `(text, token_ids)` pairs, longest-prefix match, optional `cache_salt` partitioning (the OpenAI frontend is stateless).
2. On a prefix hit, back up a 1024-char window from the cached text's end and take pre-token boundary candidates ≥96 chars from either window edge via the fast backend's `pre_tokenizer.pre_tokenize_str`. **BPE merges never cross pre-token boundaries**, so tokens strictly before such a boundary don't depend on appended text.
3. The seam must have no `<|` marker within ±96 chars and must coincide with a token boundary in the cached encoding's char offsets (rules out seams inside added/special tokens).
4. Re-encode only from the seam; **verify** the overlap token ids + offsets against the cached encoding (excluding the last 96 chars, which may merge with new text); splice `cached_prefix_ids + tail_ids`.
5. Everything unprovable falls back to a full encode (and refreshes the cache): no usable boundary, normalizer rewrites the window, verification mismatch, non-template special-token semantics (probed per `add_special_tokens` value), results exceeding `truncation`/`max_length` (returned to the regular path so truncation-side semantics stay untouched), prompts < 16K chars.

Wiring is minimal: `BaseRenderer._tokenize_prompt` consults the cache first and falls through to the existing `tokenizer(...)` call whenever the cache returns `None`. The cache sits **above** the deep-copied tokenizer pool (`maybe_make_thread_pool`) and is thread-safe; the lock covers only lookup/insert. Scope is HF fast tokenizers only — mistral/deepseek_v32/harmony renderers are untouched and the flag is silently inert for them. Default behavior is completely unchanged (`enable_incremental_encoding=False`).

Non-test footprint: 490 added lines (446 module incl. docstrings + 44 wiring/config/env).

## Benchmarks

`benchmarks/benchmark_incremental_encoding.py` (transformers-only; measures per-turn encode latency for growing synthetic conversations, asserting token-exactness every turn).

This machine (Python 3.14, tokenizers 0.22.2, `Qwen/Qwen2.5-0.5B` tokenizer, 8 turns/size):

| history (tokens) | cold p50 | cold p99 | incr p50 | incr p99 | speedup (p50) | hit/miss/fallback |
|---:|---:|---:|---:|---:|---:|---:|
| 5,000 | 3.97 ms | 4.19 ms | 0.69 ms | 0.70 ms | 5.8× | 8/1/0 |
| 32,000 | 25.67 ms | 26.03 ms | 1.17 ms | 1.25 ms | 22.0× | 8/1/0 |
| 128,000 | 151.82 ms | 155.23 ms | 2.77 ms | 2.89 ms | 54.9× | 8/1/0 |
| 512,000 | 782.94 ms | 786.05 ms | 10.95 ms | 12.06 ms | 71.5× | 8/1/0 |

`deepseek-ai/DeepSeek-V3` tokenizer: 32K → 35.66 ms vs 1.45 ms (24.6×); 128K → 160.40 ms vs 3.12 ms (51.4×).

Production (DeepSeek-V4-Flash, 2×DGX-Spark): median multi-turn TTFT 0.92 s → 0.47 s.

## Test Plan

`tests/tokenizers_/test_incremental_encode.py` — pure unit tests against real HF tokenizers, no GPU/engine required (the module is dependency-free, so they also run in a bare transformers venv):

- Growing 8-turn conversations with adversarial content (code, CJK/Korean/Japanese, emoji ZWJ sequences, RTL, combining marks, whitespace runs, literal `<|im_start|>`/`<|endoftext|>`/`<|begin▁of▁sentence|>` strings) asserted **token-exact vs full re-encode at every turn**, for `add_special_tokens` True and False, across `openai-community/gpt2`, `Qwen/Qwen2.5-0.5B`, `deepseek-ai/DeepSeek-V3` — with assertions that the splice path (not just fallback) is exercised.
- Interleaved concurrent conversations sharing the LRU; identical-prompt memoization; appends starting at/after special tokens; whitespace runs spanning the seam.
- Guard rails: kwargs compatibility rejection, truncation-overflow fallback, `cache_salt` partitioning, LRU bound, non-fast tokenizer rejection, short-prompt gate.

## Test Result

- 37/37 passed (12 test cases × 3 tokenizers + 1 tokenizer-independent): gpt2 12/12, Qwen2.5-0.5B 12/12, DeepSeek-V3 12/12, non-fast gate 1/1.
- Additional concurrency check: 8 threads × 6-turn conversations against a pool-wrapped (deep-copy pool, as in `maybe_make_thread_pool`) tokenizer — 40 hits / 8 misses / 0 fallbacks, all token-exact.
- `ruff check` / `ruff format` clean on all touched files.

## Notes

- DCO: all commits are signed off (`git commit -s`).
- An accompanying RFC issue covers motivation, alternatives (including doing this in the Rust frontend — the algorithm is self-contained and ports; the Python path remains the default today), and the relationship to #45514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## AI-assistance disclosure (AGENTS.md)

Developed with AI assistance (Claude Code); submitted and defended by the human author, who is accountable for every changed line. Duplicate-work check: searched open/closed PRs and issues for incremental/cached tokenization — the closest work is #45514 (segment-parallel encoding + segment cache), which is a different mechanism and composes with this one (detailed in the RFC #47582 and above); no open PR implements prefix-incremental encoding. Test commands: `pytest tests/tokenizers_/test_incremental_encode.py -v` (transformers-only, no GPU) and `python benchmarks/benchmark_incremental_encoding.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)