### PR TITLE
[ModelRunner V2] Support custom logits processors

### DIFF
--- a/tests/v1/worker/test_gpu_custom_logitsprocs.py
+++ b/tests/v1/worker/test_gpu_custom_logitsprocs.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the V2 model runner custom logits processor bridge.
+
+These tests exercise the CPU-side batch-diff and output-token-tracking
+logic in CustomLogitsprocs and do not require a GPU.
+"""
+
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.logits_processor import (
+    BatchUpdate,
+    LogitsProcessor,
+    LogitsProcessors,
+)
+from vllm.v1.worker.gpu.sample.logitsprocs import CustomLogitsprocs
+
+MAX_NUM_REQS = 8
+VOCAB_SIZE = 32
+
+
+class RecordingLogitsProcessor(LogitsProcessor):
+    """Records update_state calls and masks all but a target token."""
+
+    def __init__(self, argmax_invariant: bool = False):
+        self.argmax_invariant = argmax_invariant
+        self.batch_updates: list[BatchUpdate | None] = []
+        # Row index -> (params, prompt_tok_ids, output_tok_ids)
+        self.rows: dict[int, tuple[SamplingParams, list[int] | None, list[int]]] = {}
+
+    def is_argmax_invariant(self) -> bool:
+        return self.argmax_invariant
+
+    def update_state(self, batch_update: BatchUpdate | None):
+        self.batch_updates.append(batch_update)
+        if not batch_update:
+            return
+        for index, params, prompt_tok_ids, output_tok_ids in batch_update.added:
+            self.rows[index] = (params, prompt_tok_ids, output_tok_ids)
+        for index in batch_update.removed:
+            self.rows.pop(index, None)
+        assert not batch_update.moved
+
+    def apply(self, logits: torch.Tensor) -> torch.Tensor:
+        for row in self.rows:
+            logits[row] += 1.0
+        return logits
+
+
+class FakeEvent:
+    def synchronize(self) -> None:
+        pass
+
+
+def make_input_batch(slots: list[int]) -> SimpleNamespace:
+    return SimpleNamespace(
+        idx_mapping_np=np.array(slots, dtype=np.int32),
+        num_draft_tokens=0,
+    )
+
+
+def make_bridge() -> tuple[CustomLogitsprocs, RecordingLogitsProcessor]:
+    logitproc = RecordingLogitsProcessor()
+    bridge = CustomLogitsprocs(MAX_NUM_REQS, LogitsProcessors([logitproc]))
+    return bridge, logitproc
+
+
+def add_request(
+    bridge: CustomLogitsprocs,
+    req_idx: int,
+    req_id: str,
+    prompt_token_ids: list[int] | None = None,
+    output_token_ids: list[int] | None = None,
+) -> None:
+    prompt_token_ids = prompt_token_ids or [1, 2, 3]
+    prefill_token_ids = prompt_token_ids + (output_token_ids or [])
+    bridge.add_request(
+        req_idx,
+        req_id,
+        len(prompt_token_ids),
+        SamplingParams(),
+        prompt_token_ids,
+        prefill_token_ids,
+    )
+
+
+def register_sampled(
+    bridge: CustomLogitsprocs,
+    input_batch: SimpleNamespace,
+    sampled: list[int],
+    num_sampled: list[int] | None = None,
+) -> None:
+    num_rows = len(sampled)
+    bridge.register_step_output(
+        input_batch,
+        np.array(sampled, dtype=np.int64).reshape(num_rows, 1),
+        np.array(num_sampled or [1] * num_rows, dtype=np.int32),
+        FakeEvent(),
+    )
+
+
+def test_added_and_stable_batch():
+    bridge, logitproc = make_bridge()
+    add_request(bridge, req_idx=3, req_id="a", prompt_token_ids=[7, 8])
+    add_request(bridge, req_idx=5, req_id="b", prompt_token_ids=[9])
+
+    input_batch = make_input_batch([5, 3])
+    bridge.update_state(input_batch)
+
+    (batch_update,) = logitproc.batch_updates
+    assert batch_update is not None
+    assert batch_update.batch_size == 2
+    assert not batch_update.removed
+    # Row 0 -> slot 5 ("b"), row 1 -> slot 3 ("a").
+    assert [(added[0], added[2]) for added in batch_update.added] == [
+        (0, [9]),
+        (1, [7, 8]),
+    ]
+
+    # Unchanged batch: logitsprocs must still be notified with None.
+    bridge.update_state(input_batch)
+    assert logitproc.batch_updates[-1] is None
+
+
+def test_row_reorder_and_removal():
+    bridge, logitproc = make_bridge()
+    add_request(bridge, req_idx=0, req_id="a")
+    add_request(bridge, req_idx=1, req_id="b")
+    add_request(bridge, req_idx=2, req_id="c")
+    bridge.update_state(make_input_batch([0, 1, 2]))
+    assert set(logitproc.rows) == {0, 1, 2}
+
+    # Request at slot 1 finishes; remaining rows reorder.
+    bridge.remove_request(1)
+    bridge.update_state(make_input_batch([2, 0]))
+
+    batch_update = logitproc.batch_updates[-1]
+    assert batch_update is not None
+    assert batch_update.batch_size == 2
+    # Trailing row vacated; reordered rows are re-added in place.
+    assert batch_update.removed == [2]
+    assert [added[0] for added in batch_update.added] == [0, 1]
+    assert set(logitproc.rows) == {0, 1}
+
+    # The re-added rows carry the same live output token lists.
+    assert logitproc.rows[0][2] is bridge.records[2].output_token_ids
+    assert logitproc.rows[1][2] is bridge.records[0].output_token_ids
+
+
+def test_sampled_tokens_extend_output_lists():
+    bridge, logitproc = make_bridge()
+    add_request(bridge, req_idx=0, req_id="a")
+    add_request(bridge, req_idx=1, req_id="b", output_token_ids=[42])
+
+    input_batch = make_input_batch([0, 1])
+    bridge.update_state(input_batch)
+    # Resumed request "b" starts with its prior output tokens.
+    assert logitproc.rows[1][2] == [42]
+
+    # Request 0 samples token 11; request 1 is a partial prefill (0 tokens).
+    register_sampled(bridge, input_batch, sampled=[11, 99], num_sampled=[1, 0])
+    bridge.update_state(input_batch)
+
+    assert logitproc.rows[0][2] == [11]
+    assert logitproc.rows[1][2] == [42]
+
+    register_sampled(bridge, input_batch, sampled=[12, 13])
+    bridge.update_state(input_batch)
+    assert logitproc.rows[0][2] == [11, 12]
+    assert logitproc.rows[1][2] == [42, 13]
+
+
+def test_pending_tokens_skipped_after_slot_reuse():
+    bridge, logitproc = make_bridge()
+    add_request(bridge, req_idx=0, req_id="a")
+    input_batch = make_input_batch([0])
+    bridge.update_state(input_batch)
+    register_sampled(bridge, input_batch, sampled=[11])
+
+    # Request "a" finishes and slot 0 is reused before the drain.
+    bridge.remove_request(0)
+    add_request(bridge, req_idx=0, req_id="b")
+    bridge.update_state(make_input_batch([0]))
+
+    # The pending token belongs to "a" and must not leak into "b".
+    assert logitproc.rows[0][2] == []
+
+
+def test_apply_skipped_without_active_requests():
+    bridge, logitproc = make_bridge()
+    # Dummy sampler runs use slots with no tracked requests.
+    bridge.update_state(make_input_batch([0, 1]))
+    assert logitproc.batch_updates == [None]
+
+    logits = torch.zeros(2, VOCAB_SIZE)
+    assert bridge.apply_non_argmax_invariant(logits) is logits
+    assert torch.all(logits == 0)
+
+
+def test_apply_routes_by_argmax_invariance():
+    invariant = RecordingLogitsProcessor(argmax_invariant=True)
+    non_invariant = RecordingLogitsProcessor(argmax_invariant=False)
+    bridge = CustomLogitsprocs(
+        MAX_NUM_REQS, LogitsProcessors([invariant, non_invariant])
+    )
+    add_request(bridge, req_idx=0, req_id="a")
+    bridge.update_state(make_input_batch([0]))
+
+    logits = torch.zeros(1, VOCAB_SIZE)
+    bridge.apply_non_argmax_invariant(logits)
+    assert torch.all(logits == 1.0)
+    bridge.apply_argmax_invariant(logits)
+    assert torch.all(logits == 2.0)

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2228,17 +2228,6 @@ class VllmConfig:
             # Will be added by https://github.com/vllm-project/vllm/pull/38163
             unsupported.append("routed experts capture")
 
-        has_logitsproc_plugins = False
-        if model_config is not None:
-            from importlib.metadata import entry_points
-
-            has_logitsproc_plugins = bool(entry_points(group="vllm.logits_processors"))
-
-        if model_config is not None and (
-            model_config.logits_processors or has_logitsproc_plugins
-        ):
-            unsupported.append("custom logits processors")
-
         if model_config is not None and model_config.enable_prompt_embeds:
             unsupported.append("prompt embeds")
 

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -218,6 +218,36 @@ def build_logitsprocs(
     )
 
 
+def build_custom_logitsprocs(
+    vllm_config: "VllmConfig",
+    device: torch.device,
+    is_pin_memory: bool,
+    is_pooling_model: bool,
+    custom_logitsprocs: Sequence[str | type[LogitsProcessor]] = (),
+) -> LogitsProcessors:
+    """Build only custom (non-builtin) logits processors.
+
+    For model runners that implement the builtin sampling parameters
+    natively and only need the custom/plugin logits processors.
+    """
+    if is_pooling_model:
+        if custom_logitsprocs:
+            raise ValueError(STR_POOLING_REJECTS_LOGITSPROCS)
+        return LogitsProcessors()
+
+    if vllm_config.speculative_config:
+        if custom_logitsprocs:
+            raise ValueError(STR_SPEC_DEC_REJECTS_LOGITSPROCS)
+        # Match build_logitsprocs: installed plugins are not loaded when
+        # speculative decoding is enabled.
+        return LogitsProcessors()
+
+    return LogitsProcessors(
+        ctor(vllm_config, device, is_pin_memory)
+        for ctor in _load_custom_logitsprocs(custom_logitsprocs)
+    )
+
+
 cached_load_custom_logitsprocs = lru_cache(_load_custom_logitsprocs)
 
 
@@ -356,6 +386,7 @@ __all__ = [
     "BatchUpdateBuilder",
     "MoveDirectionality",
     "LogitsProcessors",
+    "build_custom_logitsprocs",
     "build_logitsprocs",
     "STR_POOLING_REJECTS_LOGITSPROCS",
     "LOGITSPROCS_GROUP",

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -52,10 +52,14 @@ from vllm.sequence import IntermediateTensors
 from vllm.tasks import SupportedTask
 from vllm.utils.math_utils import cdiv
 from vllm.utils.mem_utils import DeviceMemoryProfiler, format_gib
-from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
+from vllm.utils.torch_utils import PIN_MEMORY, STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
+from vllm.v1.sample.logits_processor import (
+    STR_POOLING_REJECTS_LOGITSPROCS,
+    build_custom_logitsprocs,
+)
 from vllm.v1.worker.block_table import get_block_table_width
 from vllm.v1.worker.cp_utils import check_attention_cp_compatibility
 from vllm.v1.worker.gpu import pcp_manager as pcp
@@ -105,6 +109,7 @@ from vllm.v1.worker.gpu.mm.lora import set_active_mm_loras
 from vllm.v1.worker.gpu.model_states import init_model_state
 from vllm.v1.worker.gpu.pool.pooling_runner import PoolingRunner
 from vllm.v1.worker.gpu.pp_utils import PPHandler
+from vllm.v1.worker.gpu.sample.logitsprocs import CustomLogitsprocs
 from vllm.v1.worker.gpu.sample.output import SamplerOutput
 from vllm.v1.worker.gpu.sample.prompt_logprob import PromptLogprobsWorker
 from vllm.v1.worker.gpu.sample.sampler import Sampler
@@ -258,6 +263,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # Samplers and decode_query_len created in load_model() after
         # model_state exists (num_new_sampled_tokens_per_step from ModelState).
         self.sampler: Sampler | None = None
+        self.custom_logitsprocs: CustomLogitsprocs | None = None
         self.rejection_sampler: RejectionSampler | None = None
         self.prompt_logprobs_worker: PromptLogprobsWorker | None = None
         self.structured_outputs_worker: StructuredOutputsWorker | None = None
@@ -347,8 +353,22 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             + self.model_state.num_new_sampled_tokens_per_step
         )
 
+        if self.is_pooling_model and self.model_config.logits_processors:
+            raise ValueError(STR_POOLING_REJECTS_LOGITSPROCS)
+
         # Initialize samplers. Model states may override via custom_sampler().
         if self.is_last_pp_rank and not self.is_pooling_model:
+            logitsprocs = build_custom_logitsprocs(
+                self.vllm_config,
+                self.device,
+                PIN_MEMORY,
+                self.is_pooling_model,
+                tuple(self.model_config.logits_processors or ()),
+            )
+            if logitsprocs.argmax_invariant or logitsprocs.non_argmax_invariant:
+                self.custom_logitsprocs = CustomLogitsprocs(
+                    self.max_num_reqs, logitsprocs
+                )
             self.sampler = Sampler(
                 max_num_reqs=self.max_num_reqs,
                 vocab_size=self.vocab_size,
@@ -357,10 +377,16 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 logprobs_mode=self.model_config.logprobs_mode,
                 num_speculative_tokens=self.decode_query_len,
                 use_fp64_gumbel=self.model_config.use_fp64_gumbel,
+                custom_logitsprocs=self.custom_logitsprocs,
             )
             custom = self.model_state.custom_sampler(self.sampler)
 
             if custom:
+                if self.custom_logitsprocs is not None:
+                    raise ValueError(
+                        "Custom logits processors are not supported for "
+                        "models with a custom sampler."
+                    )
                 self.sampler, self.rejection_sampler = custom
             elif self.speculative_config is not None:
                 self.rejection_sampler = RejectionSampler(
@@ -804,6 +830,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             return False
         if self.pooling_runner is not None:
             self.pooling_runner.remove_request(req_idx)
+        if self.custom_logitsprocs is not None:
+            self.custom_logitsprocs.remove_request(req_idx)
         if self.pp_handler is not None:
             self.pp_handler.on_req_idx_freed(req_idx)
         if self.encoder_cache is not None:
@@ -882,6 +910,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 self.sampler.add_request(
                     req_index, prompt_len, new_req_data.sampling_params
                 )
+                if self.custom_logitsprocs is not None:
+                    self.custom_logitsprocs.add_request(
+                        req_index,
+                        req_id,
+                        prompt_len,
+                        new_req_data.sampling_params,
+                        new_req_data.prompt_token_ids,
+                        new_req_data.prefill_token_ids,
+                    )
                 assert self.prompt_logprobs_worker is not None
                 self.prompt_logprobs_worker.add_request(
                     req_id, req_index, new_req_data.sampling_params
@@ -1533,6 +1570,16 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             copy_stream=self.output_copy_stream,
             check_ep_fault=self.check_ep_fault,
         )
+
+        if self.custom_logitsprocs is not None:
+            # Reuse the AsyncOutput D2H copy to extend the custom logits
+            # processors' CPU output token lists in the next step.
+            self.custom_logitsprocs.register_step_output(
+                input_batch,
+                async_output.sampled_token_ids,
+                async_output.num_sampled_tokens_np,
+                async_output.copy_event,
+            )
 
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None
         if self.speculator is not None and self.speculator.supports_mm_inputs:

--- a/vllm/v1/worker/gpu/sample/logitsprocs.py
+++ b/vllm/v1/worker/gpu/sample/logitsprocs.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+import torch
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.logits_processor import BatchUpdate, LogitsProcessors
+
+if TYPE_CHECKING:
+    from vllm.v1.worker.gpu.input_batch import InputBatch
+
+
+@dataclass(eq=False)
+class RequestRecord:
+    req_id: str
+    params: SamplingParams
+    prompt_token_ids: list[int] | None
+    # Live list of generated tokens, shared with the logits processors
+    # through BatchUpdate.added. Extended in place as sampled tokens
+    # arrive on the CPU.
+    output_token_ids: list[int]
+
+
+@dataclass
+class PendingSampledTokens:
+    # Row -> request slot and record at the time of sampling.
+    slots: np.ndarray
+    records: list["RequestRecord | None"]
+    # Backed by the AsyncOutput D2H copies; valid once copy_event completes.
+    sampled_token_ids: np.ndarray  # [num_rows, 1]
+    num_sampled: np.ndarray  # [num_rows]
+    copy_event: torch.Event
+
+
+class CustomLogitsprocs:
+    """Adapts custom logits processors to the V2 sampler.
+
+    The LogitsProcessor interface assumes a contiguous persistent batch
+    updated through BatchUpdate add/remove/move events, with a live CPU
+    list of each request's output tokens. The V2 model runner instead
+    keys request state by stable slot indices and keeps output tokens on
+    the GPU. This class bridges the two:
+
+    * Each step, the logits-row -> request assignment (idx_mapping) is
+      diffed against the previous step's and translated into BatchUpdate
+      added/removed events. A request whose row changed is re-added at
+      its new row, which the interface permits ("added requests may
+      replace existing requests with the same index"). Unlike the V1
+      runner, no moved events are emitted: per-request state is rebuilt
+      from the request's params, prompt and (live) output token ids,
+      which is lossless for logits processors that derive their state
+      from those inputs (the documented pattern).
+    * Sampled tokens are appended to the per-request CPU token lists
+      from the async D2H copy of the previous step's sampler output,
+      right before the logits processors read them (mirroring the V1
+      runner's update_async_output_token_ids).
+    """
+
+    def __init__(self, max_num_reqs: int, logitsprocs: LogitsProcessors):
+        self.logitsprocs = logitsprocs
+        self.records: list[RequestRecord | None] = [None] * max_num_reqs
+        # Row -> record assignment from the last update_state call.
+        self.prev_rows: list[RequestRecord | None] = []
+        self.pending: PendingSampledTokens | None = None
+        self.num_active = 0
+
+    def add_request(
+        self,
+        req_idx: int,
+        req_id: str,
+        prompt_len: int,
+        sampling_params: SamplingParams,
+        prompt_token_ids: list[int] | None,
+        prefill_token_ids: list[int],
+    ) -> None:
+        # prefill_token_ids holds the prompt plus any output tokens already
+        # generated (e.g. when resuming after preemption).
+        self.records[req_idx] = RequestRecord(
+            req_id=req_id,
+            params=sampling_params,
+            prompt_token_ids=prompt_token_ids,
+            output_token_ids=list(prefill_token_ids[prompt_len:]),
+        )
+
+    def remove_request(self, req_idx: int) -> None:
+        self.records[req_idx] = None
+
+    def register_step_output(
+        self,
+        input_batch: "InputBatch",
+        sampled_token_ids: np.ndarray,
+        num_sampled: np.ndarray,
+        copy_event: torch.Event,
+    ) -> None:
+        """Record this step's sampled-token D2H copy for the next step.
+
+        Called after sampling, so prev_rows holds the row -> record
+        assignment the tokens were sampled with.
+        """
+        self.pending = PendingSampledTokens(
+            # Copy: idx_mapping_np may be rebuilt before the drain.
+            slots=input_batch.idx_mapping_np.copy(),
+            records=self.prev_rows,
+            sampled_token_ids=sampled_token_ids,
+            num_sampled=num_sampled,
+            copy_event=copy_event,
+        )
+
+    def _drain_pending(self) -> None:
+        pending = self.pending
+        if pending is None:
+            return
+        self.pending = None
+        pending.copy_event.synchronize()
+        num_sampled = pending.num_sampled.tolist()
+        sampled_token_ids = pending.sampled_token_ids.tolist()
+        for row, record in enumerate(pending.records):
+            if record is None:
+                continue
+            num_tokens = num_sampled[row]
+            if num_tokens <= 0:
+                # No token sampled (e.g. partial prefill).
+                continue
+            if self.records[pending.slots[row]] is not record:
+                # The slot was reassigned since the tokens were sampled
+                # (request finished/preempted, or streaming input update).
+                continue
+            record.output_token_ids.extend(sampled_token_ids[row][:num_tokens])
+
+    def _make_batch_update(
+        self, cur_rows: list["RequestRecord | None"]
+    ) -> BatchUpdate | None:
+        prev_rows = self.prev_rows
+        added = [
+            (row, record.params, record.prompt_token_ids, record.output_token_ids)
+            for row, record in enumerate(cur_rows)
+            if record is not None
+            and (row >= len(prev_rows) or prev_rows[row] is not record)
+        ]
+        removed = [
+            row
+            for row, record in enumerate(prev_rows)
+            if record is not None and (row >= len(cur_rows) or cur_rows[row] is None)
+        ]
+        if not added and not removed:
+            return None
+        # Descending order, as guaranteed by BatchUpdateBuilder.
+        removed.sort(reverse=True)
+        return BatchUpdate(
+            batch_size=len(cur_rows),
+            removed=removed,
+            added=added,
+            moved=(),
+        )
+
+    def update_state(self, input_batch: "InputBatch") -> None:
+        assert input_batch.num_draft_tokens == 0, (
+            "Custom logits processors do not support speculative decoding."
+        )
+        self._drain_pending()
+        cur_rows: list[RequestRecord | None] = [
+            self.records[slot] for slot in input_batch.idx_mapping_np
+        ]
+        batch_update = self._make_batch_update(cur_rows)
+        self.prev_rows = cur_rows
+        self.num_active = sum(record is not None for record in cur_rows)
+        for logitproc in self.logitsprocs.all:
+            logitproc.update_state(batch_update)
+
+    def apply_non_argmax_invariant(self, logits: torch.Tensor) -> torch.Tensor:
+        if self.num_active == 0:
+            # No tracked requests (e.g. dummy sampler run).
+            return logits
+        for logitproc in self.logitsprocs.non_argmax_invariant:
+            logits = logitproc.apply(logits)
+        return logits
+
+    def apply_argmax_invariant(self, logits: torch.Tensor) -> torch.Tensor:
+        if self.num_active == 0:
+            return logits
+        for logitproc in self.logitsprocs.argmax_invariant:
+            logits = logitproc.apply(logits)
+        return logits

--- a/vllm/v1/worker/gpu/sample/sampler.py
+++ b/vllm/v1/worker/gpu/sample/sampler.py
@@ -17,6 +17,7 @@ from vllm.v1.worker.gpu.metrics.logits import get_num_nans
 from vllm.v1.worker.gpu.sample.bad_words import BadWordsState
 from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
 from vllm.v1.worker.gpu.sample.logit_bias import LogitBiasState
+from vllm.v1.worker.gpu.sample.logitsprocs import CustomLogitsprocs
 from vllm.v1.worker.gpu.sample.logprob import (
     LogprobTokenIdsState,
     compute_topk_scores,
@@ -37,6 +38,7 @@ class Sampler:
         logprobs_mode: LogprobsMode = "raw_logprobs",
         num_speculative_tokens: int = 1,
         use_fp64_gumbel: bool = False,
+        custom_logitsprocs: CustomLogitsprocs | None = None,
     ):
         self.logprobs_mode = logprobs_mode
         self.compute_nans = envs.VLLM_COMPUTE_NANS_IN_LOGITS  # False by default.
@@ -48,6 +50,7 @@ class Sampler:
         self.logit_bias_state = LogitBiasState(max_num_reqs, device)
         self.bad_words_state = BadWordsState(req_states)
         self.logprob_token_ids_state = LogprobTokenIdsState(max_num_reqs, device)
+        self.custom_logitsprocs = custom_logitsprocs
         self.num_speculative_tokens = num_speculative_tokens
         self.use_flashinfer = flashinfer_sampler_supported()
 
@@ -78,6 +81,11 @@ class Sampler:
         expanded_local_pos = input_batch.expanded_local_pos
         pos = input_batch.positions[input_batch.logits_indices]
         input_ids = input_batch.input_ids[input_batch.logits_indices]
+
+        if self.custom_logitsprocs is not None:
+            # Sync output token ids and batch makeup with the custom logits
+            # processors, once per step before the logits are processed.
+            self.custom_logitsprocs.update_state(input_batch)
 
         # NOTE(woosuk): We intentionally compute num_nans before sampling to make clear
         # that num_nans is computed before applying penalties and temperature.
@@ -181,10 +189,20 @@ class Sampler:
             expanded_local_pos,
         )
 
+        if self.custom_logitsprocs is not None:
+            # Custom logits processors that can affect greedy sampling.
+            logits = self.custom_logitsprocs.apply_non_argmax_invariant(logits)
+
         # Apply temperature in place.
         self.sampling_states.apply_temperature(
             logits, expanded_idx_mapping, idx_mapping_np
         )
+
+        if self.custom_logitsprocs is not None and not self.sampling_states.all_greedy(
+            idx_mapping_np
+        ):
+            # Custom logits processors that only affect random sampling.
+            logits = self.custom_logitsprocs.apply_argmax_invariant(logits)
 
         # Apply min_p in place.
         self.sampling_states.apply_min_p(logits, expanded_idx_mapping, idx_mapping_np)
@@ -198,6 +216,8 @@ class Sampler:
         )
 
     def _requires_logits_processing(self, idx_mapping_np: np.ndarray) -> bool:
+        if self.custom_logitsprocs is not None and self.custom_logitsprocs.num_active:
+            return True
         if np.any(self.logit_bias_state.use_logit_bias[idx_mapping_np]):
             return True
         if np.any(self.penalties_state.use_penalty[idx_mapping_np]):

--- a/vllm/v1/worker/gpu/sample/states.py
+++ b/vllm/v1/worker/gpu/sample/states.py
@@ -114,6 +114,9 @@ class SamplingStates:
     def any_greedy(self, idx_mapping_np: np.ndarray) -> bool:
         return bool(np.any(self.temperature.np[idx_mapping_np] == 0.0))
 
+    def all_greedy(self, idx_mapping_np: np.ndarray) -> bool:
+        return bool(np.all(self.temperature.np[idx_mapping_np] == 0.0))
+
     def any_explicit_seed(self, idx_mapping_np: np.ndarray) -> bool:
         return bool(np.any(self.seeds_set[idx_mapping_np]))
 


### PR DESCRIPTION
## Purpose

Custom logits processors (`--logits-processors` / entry-point plugins in the `vllm.logits_processors` group) are one of the remaining features that force a silent fallback from the V2 model runner to V1 (`_get_v2_model_runner_unsupported_features`). This PR implements them in the V2 GPU model runner and removes that gate, so dense models keep the V2 runner when custom logits processors are configured or installed.

## Design

The `LogitsProcessor` interface assumes a contiguous persistent batch updated via `BatchUpdate` added/removed/moved events, with a live CPU list of each request's output tokens. The V2 runner instead keys request state by stable slot indices (`idx_mapping`) and appends output tokens on the GPU. A new bridge, `CustomLogitsprocs` (`vllm/v1/worker/gpu/sample/logitsprocs.py`), adapts between the two:

- **Batch events**: each step, the logits-row -> request assignment is diffed against the previous step's and translated into `BatchUpdate` added/removed events. A request whose row changed is re-added at its new row (the interface permits added requests to replace existing indices). No moved events are emitted; per-request state is rebuilt from params, prompt and output token ids, which is lossless for processors following the documented pattern (`process_dict_updates` / `AdapterLogitsProcessor` / builtins).
- **Output tokens**: per-request CPU token lists are extended from the `AsyncOutput` D2H copy of the *previous* step's sampled tokens, synchronized right before the logits processors read them — the same approach the V1 runner uses for async scheduling (`update_async_output_token_ids`). Slot reuse between steps is guarded by record identity so tokens cannot leak into a new request after preemption/finish.
- **Apply order** matches the V1 sampler: non-argmax-invariant processors run before temperature; argmax-invariant ones run after temperature and are skipped for all-greedy batches.

V1 parity restrictions are preserved via a shared `build_custom_logitsprocs()` helper: custom logits processors are rejected with speculative decoding and pooling models, and installed plugins are not loaded under speculative decoding. Models with a custom sampler (diffusion) now raise a clear error instead of silently ignoring the processors.

## Duplicate-work check

Searched open PRs on 2026-07-02 for "logits processor", "logitsprocs", "logits processors model runner v2" — no open PR implements custom logits processor support in the V2 model runner (related but different scope: #43672 spec-decode LP opt-in for V1, #45034 example LP, #38199 V1 plugin fix). No tracking issue is claimed for this feature.

## Test Plan

- New CPU-only unit tests for the bridge: `tests/v1/worker/test_gpu_custom_logitsprocs.py` (batch diffing, row reordering, output-token draining, slot-reuse safety, dummy-run no-op, argmax-invariance routing).
- Existing e2e suites `tests/v1/logits_processors/` on both runners (`facebook/opt-125m` is dense, so they exercise the V2 runner by default after this change; V1 forced via `VLLM_USE_V2_MODEL_RUNNER=0`).
- Regression: `tests/v1/sample/test_sampler.py`, `tests/v1/worker/test_gpu_model_runner.py`.

## Test Result

Run on an NVIDIA L4 (CUDA 13.0 driver, torch 2.11.0+cu130, precompiled wheel install):

- `tests/v1/worker/test_gpu_custom_logitsprocs.py`: **6 passed**
- `tests/v1/logits_processors/` (V2 runner, default): **47 passed** (711s); logs contain no "Model Runner V2 does not yet support" fallback message
- `VLLM_USE_V2_MODEL_RUNNER=0 pytest tests/v1/logits_processors/`: **47 passed** (600s)
- `tests/v1/sample/test_sampler.py`: all passed. `tests/v1/worker/test_gpu_model_runner.py`: 5 failed + 12 errors, **identical set on unmodified `main`** in the same environment (pre-existing V1-runner fixture issues, unrelated to this change)
- `pre-commit run` (ruff, mypy, etc.): passed on all changed files

## AI assistance disclosure

This PR was developed with AI assistance (Claude Code). The submitting human has reviewed the changes and run the tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)