### PR TITLE
[Bugfix][Kernel] Zero TRT-LLM 8x4 FP4 scale padding

### DIFF
--- a/tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py
+++ b/tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py
@@ -39,6 +39,88 @@ SEEDS = [42]
 CUDA_DEVICES = ["cuda:0"]
 
 
+def _round_up(x: int, multiple: int) -> int:
+    return (x + multiple - 1) // multiple * multiple
+
+
+def _linearize_8x4_scale(scale: torch.Tensor, m: int, n: int) -> torch.Tensor:
+    block_size = 16
+    scale_n = n // block_size
+    rounded_m = _round_up(m, 8)
+    rounded_n = _round_up(scale_n, 4)
+    return (
+        scale.view(torch.uint8)
+        .reshape(rounded_m // 8, rounded_n // 4, 8, 4)
+        .permute(0, 2, 1, 3)
+        .reshape(rounded_m, rounded_n)
+    )
+
+
+@pytest.mark.parametrize(
+    "shape", [(1, 64), (7, 80), (8, 64), (9, 80), (31, 96), (32, 80)]
+)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@torch.inference_mode()
+def test_trtllm_8x4_scale_padding_zeroed(
+    monkeypatch: pytest.MonkeyPatch,
+    shape: tuple[int, int],
+    device: str,
+) -> None:
+    m, n = shape
+    scale_n = n // 16
+    rounded_m = _round_up(m, 8)
+    rounded_n = _round_up(scale_n, 4)
+    poisoned_scale = torch.full(
+        (rounded_m * rounded_n,), 0x7F, dtype=torch.uint8, device=device
+    )
+
+    def fake_quant(
+        input: torch.Tensor, input_global_scale: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        output = torch.empty(
+            (input.shape[0], input.shape[1] // 2),
+            dtype=torch.uint8,
+            device=input.device,
+        )
+        return output, poisoned_scale.clone()
+
+    monkeypatch.setattr(ops, "flashinfer_quant_nvfp4_8x4_sf_layout", fake_quant)
+
+    x = torch.ones((m, n), dtype=torch.bfloat16, device=device)
+    global_scale = torch.tensor([1.0], dtype=torch.float32, device=device)
+    _, output_scale = ops.scaled_fp4_quant(x, global_scale, backend="trtllm")
+    linear_scale = _linearize_8x4_scale(output_scale, m, n)
+
+    torch.testing.assert_close(
+        linear_scale[:m, :scale_n],
+        torch.full((m, scale_n), 0x7F, dtype=torch.uint8, device=device),
+    )
+    assert torch.count_nonzero(linear_scale[m:, :]) == 0
+    assert torch.count_nonzero(linear_scale[:, scale_n:]) == 0
+
+
+@pytest.mark.parametrize("shape", [(1, 64), (7, 80), (9, 80), (31, 96), (32, 80)])
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@torch.inference_mode()
+def test_trtllm_scaled_fp4_quant_8x4_padding_zeroed(
+    shape: tuple[int, int],
+    device: str,
+) -> None:
+    set_random_seed(42)
+    m, n = shape
+    scale_n = n // 16
+    x = torch.randn((m, n), dtype=torch.bfloat16, device=device)
+    global_scale = (
+        (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX) / torch.amax(x.flatten(), dim=-1)
+    ).to(torch.float32)
+
+    _, output_scale = ops.scaled_fp4_quant(x, global_scale, backend="trtllm")
+    linear_scale = _linearize_8x4_scale(output_scale, m, n)
+
+    assert torch.count_nonzero(linear_scale[m:, :]) == 0
+    assert torch.count_nonzero(linear_scale[:, scale_n:]) == 0
+
+
 def get_ref_results(
     a_fp4,
     b_fp4,

--- a/tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py
+++ b/tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py
@@ -47,6 +47,88 @@ SEEDS = [42]
 CUDA_DEVICES = ["cuda:0"]
 
 
+def _round_up(x: int, multiple: int) -> int:
+    return (x + multiple - 1) // multiple * multiple
+
+
+def _linearize_8x4_scale(scale: torch.Tensor, m: int, n: int) -> torch.Tensor:
+    block_size = 16
+    scale_n = n // block_size
+    rounded_m = _round_up(m, 8)
+    rounded_n = _round_up(scale_n, 4)
+    return (
+        scale.view(torch.uint8)
+        .reshape(rounded_m // 8, rounded_n // 4, 8, 4)
+        .permute(0, 2, 1, 3)
+        .reshape(rounded_m, rounded_n)
+    )
+
+
+@pytest.mark.parametrize(
+    "shape", [(1, 64), (7, 80), (8, 64), (9, 80), (31, 96), (32, 80)]
+)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@torch.inference_mode()
+def test_trtllm_8x4_scale_padding_zeroed(
+    monkeypatch: pytest.MonkeyPatch,
+    shape: tuple[int, int],
+    device: str,
+) -> None:
+    m, n = shape
+    scale_n = n // 16
+    rounded_m = _round_up(m, 8)
+    rounded_n = _round_up(scale_n, 4)
+    poisoned_scale = torch.full(
+        (rounded_m * rounded_n,), 0x7F, dtype=torch.uint8, device=device
+    )
+
+    def fake_quant(
+        input: torch.Tensor, input_global_scale: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        output = torch.empty(
+            (input.shape[0], input.shape[1] // 2),
+            dtype=torch.uint8,
+            device=input.device,
+        )
+        return output, poisoned_scale.clone()
+
+    monkeypatch.setattr(ops, "flashinfer_quant_nvfp4_8x4_sf_layout", fake_quant)
+
+    x = torch.ones((m, n), dtype=torch.bfloat16, device=device)
+    global_scale = torch.tensor([1.0], dtype=torch.float32, device=device)
+    _, output_scale = ops.scaled_fp4_quant(x, global_scale, backend="trtllm")
+    linear_scale = _linearize_8x4_scale(output_scale, m, n)
+
+    torch.testing.assert_close(
+        linear_scale[:m, :scale_n],
+        torch.full((m, scale_n), 0x7F, dtype=torch.uint8, device=device),
+    )
+    assert torch.count_nonzero(linear_scale[m:, :]) == 0
+    assert torch.count_nonzero(linear_scale[:, scale_n:]) == 0
+
+
+@pytest.mark.parametrize("shape", [(1, 64), (7, 80), (9, 80), (31, 96), (32, 80)])
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@torch.inference_mode()
+def test_trtllm_scaled_fp4_quant_8x4_padding_zeroed(
+    shape: tuple[int, int],
+    device: str,
+) -> None:
+    set_random_seed(42)
+    m, n = shape
+    scale_n = n // 16
+    x = torch.randn((m, n), dtype=torch.bfloat16, device=device)
+    global_scale = (
+        (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX) / torch.amax(x.flatten(), dim=-1)
+    ).to(torch.float32)
+
+    _, output_scale = ops.scaled_fp4_quant(x, global_scale, backend="trtllm")
+    linear_scale = _linearize_8x4_scale(output_scale, m, n)
+
+    assert torch.count_nonzero(linear_scale[m:, :]) == 0
+    assert torch.count_nonzero(linear_scale[:, scale_n:]) == 0
+
+
 def get_ref_results(
     a_fp4,
     b_fp4,

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -70,6 +70,40 @@ def create_fp4_scale_tensor(
         return torch.empty((m, n // block_size), device=device, dtype=torch.uint8)
 
 
+def _zero_fp4_8x4_scale_padding_(
+    output_scale: torch.Tensor,
+    m: int,
+    n: int,
+) -> None:
+    """Zero logical padding in FlashInfer's 8x4 NVFP4 scale layout."""
+    from vllm.utils.math_utils import round_up
+
+    block_size = 16
+    scale_n = n // block_size
+    rounded_m = round_up(m, 8)
+    rounded_n = round_up(scale_n, 4)
+    if rounded_m == m and rounded_n == scale_n:
+        return
+
+    scale_tiles = output_scale.view(torch.uint8).reshape(
+        rounded_m // 8, rounded_n // 4, 8, 4
+    )
+
+    full_m_tiles, m_tail = divmod(m, 8)
+    if m_tail:
+        scale_tiles[full_m_tiles, :, m_tail:, :].zero_()
+        scale_tiles[full_m_tiles + 1 :, :, :, :].zero_()
+    else:
+        scale_tiles[full_m_tiles:, :, :, :].zero_()
+
+    full_n_tiles, n_tail = divmod(scale_n, 4)
+    if n_tail:
+        scale_tiles[:, full_n_tiles, :, n_tail:].zero_()
+        scale_tiles[:, full_n_tiles + 1 :, :, :].zero_()
+    else:
+        scale_tiles[:, full_n_tiles:, :, :].zero_()
+
+
 def create_fp4_output_tensors(
     m: int,
     n: int,
@@ -1542,6 +1576,7 @@ def scaled_fp4_quant(
         output, output_scale = flashinfer_quant_nvfp4_8x4_sf_layout(
             input, input_global_scale
         )
+        _zero_fp4_8x4_scale_padding_(output_scale, m, n)
     else:
         # Pre-allocate and call .out variant (same behavior as old in-place API)
         output, output_scale = create_fp4_output_tensors(

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -66,6 +66,40 @@ def create_fp4_scale_tensor(
         return torch.empty((m, n // block_size), device=device, dtype=torch.uint8)
 
 
+def _zero_fp4_8x4_scale_padding_(
+    output_scale: torch.Tensor,
+    m: int,
+    n: int,
+) -> None:
+    """Zero logical padding in FlashInfer's 8x4 NVFP4 scale layout."""
+    from vllm.utils.math_utils import round_up
+
+    block_size = 16
+    scale_n = n // block_size
+    rounded_m = round_up(m, 8)
+    rounded_n = round_up(scale_n, 4)
+    if rounded_m == m and rounded_n == scale_n:
+        return
+
+    scale_tiles = output_scale.view(torch.uint8).reshape(
+        rounded_m // 8, rounded_n // 4, 8, 4
+    )
+
+    full_m_tiles, m_tail = divmod(m, 8)
+    if m_tail:
+        scale_tiles[full_m_tiles, :, m_tail:, :].zero_()
+        scale_tiles[full_m_tiles + 1 :, :, :, :].zero_()
+    else:
+        scale_tiles[full_m_tiles:, :, :, :].zero_()
+
+    full_n_tiles, n_tail = divmod(scale_n, 4)
+    if n_tail:
+        scale_tiles[:, full_n_tiles, :, n_tail:].zero_()
+        scale_tiles[:, full_n_tiles + 1 :, :, :].zero_()
+    else:
+        scale_tiles[:, full_n_tiles:, :, :].zero_()
+
+
 def create_fp4_output_tensors(
     m: int,
     n: int,
@@ -1641,6 +1675,7 @@ def scaled_fp4_quant(
         output, output_scale = flashinfer_quant_nvfp4_8x4_sf_layout(
             input, input_global_scale
         )
+        _zero_fp4_8x4_scale_padding_(output_scale, m, n)
     else:
         # Pre-allocate and call .out variant (same behavior as old in-place API)
         output, output_scale = create_fp4_output_tensors(


### PR DESCRIPTION
## Purpose

Fixes #37563.

When `scaled_fp4_quant(..., backend="trtllm")` uses FlashInfer's 8x4 NVFP4 scale layout (`m <= 32`), vLLM bypasses `create_fp4_scale_tensor()` and receives the scale buffer directly from `flashinfer_quant_nvfp4_8x4_sf_layout(...)`. That buffer is physically padded to 8-row / 4-scale-column tiles, and logical padding scale bytes can remain nonzero.

This PR defensively zeros the logical padding in the returned 8x4 activation scale buffer before vLLM returns it to downstream TRT-LLM FP4 GEMM callers. The zeroing uses the physical tile view `(rounded_m // 8, rounded_n // 4, 8, 4)`, preserving real scale bytes while clearing only logical row and column padding.

The change is intentionally scoped to the TRT-LLM 8x4 small-M path. The existing 128x4 swizzled allocation path is unchanged.

## Relationship to other work

#37564 addressed the same report through broader zero-initialization changes at several allocation sites. It received maintainer approval but was later closed while conflicted.

#53568 subsequently zero-initialized vLLM-owned buffers in the 128x4 quantization path. It does not cover this direct FlashInfer 8x4 return path, which still has no padding cleanup on current `main`.

A fresh duplicate search found no other open PR for this 8x4 padding path. Issue #37563 was closed automatically for inactivity, without a code fix for this path.

AI assistance was used in preparing this change. I reviewed the changed lines and ran the validation below.

## Current-base validation

Rebased onto `main` at `6865e67f0b`. `git range-diff` confirms the functional patch is identical to the B200-tested version.

```bash
git diff --check
.venv/bin/python -m py_compile \
  vllm/_custom_ops.py \
  tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py
uvx --from ruff==0.14.0 ruff check \
  vllm/_custom_ops.py \
  tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py
uvx --from ruff==0.14.0 ruff format --check \
  vllm/_custom_ops.py \
  tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py
```

All checks passed.

## B200 / SM100 validation

The functional patch was validated on an NVIDIA B200 at base `f8d03e774`:

- GPU: NVIDIA B200, compute capability 10.0 (SM100), 183359 MiB
- Driver: 580.126.09
- CUDA: 13.0
- Python: 3.12.13
- PyTorch: 2.13.0
- FlashInfer: 0.6.15.post1
- vLLM installed from the checkout with `VLLM_USE_PRECOMPILED=1`

Baseline regression demonstration with the production fix removed:

```bash
python -m pytest -v -s \
  tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py::test_trtllm_8x4_scale_padding_zeroed
```

Result: `5 failed, 1 passed`. The aligned `(8, 64)` case passed because it has no logical padding; every shape with row or column padding retained poisoned nonzero bytes and failed as expected.

Patched focused validation:

```bash
python -m pytest -v -s \
  tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py::test_trtllm_8x4_scale_padding_zeroed \
  tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py::test_trtllm_scaled_fp4_quant_8x4_padding_zeroed
```

Result: `11 passed` in 5.09 seconds, covering six poisoned-padding cases and five cases through the real FlashInfer 8x4 quantization path.

Full test file:

```bash
python -m pytest -v -s tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py
```

Result: `137 passed, 54 skipped` in 184.27 seconds, with no failures. Skips were existing backend capability and availability conditions.

No model evaluation was run: this is a wrapper-level kernel-contract fix with no model, configuration, or serving API changes; the affected numerical behavior is exercised directly by the B200 kernel suite above.

No documentation or dependency changes.
