### PR TITLE
[Bugfix] [EPLB]  Avoid Silent Accuracy Corruption in Quark MXFP4 EPLB

### DIFF
--- a/tests/quantization/test_quark_moe_eplb.py
+++ b/tests/quantization/test_quark_moe_eplb.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import Mxfp4MoeBackend
+from vllm.model_executor.layers.quantization.quark import quark_moe
+from vllm.model_executor.layers.quantization.quark.quark_moe import (
+    QuarkOCP_MX_MoEMethod,
+)
+
+
+class _MockLayer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_parameter(
+            "w13_weight",
+            torch.nn.Parameter(
+                torch.zeros(2, 4, 2, dtype=torch.uint8), requires_grad=False
+            ),
+        )
+        self.register_parameter(
+            "w2_weight",
+            torch.nn.Parameter(
+                torch.zeros(2, 3, 2, dtype=torch.uint8), requires_grad=False
+            ),
+        )
+        self.register_parameter(
+            "w13_weight_scale",
+            torch.nn.Parameter(
+                torch.ones(2, 4, 1, dtype=torch.uint8), requires_grad=False
+            ),
+        )
+        self.register_parameter(
+            "w2_weight_scale",
+            torch.nn.Parameter(
+                torch.ones(2, 3, 1, dtype=torch.uint8), requires_grad=False
+            ),
+        )
+        self.w13_input_scale = torch.ones(2)
+        self.w2_input_scale = torch.ones(2)
+        self.w13_bias = None
+        self.w2_bias = None
+
+
+class _MockStorage:
+    def __init__(self, data: torch.Tensor):
+        self.data = data
+
+
+class _MockWrappedTensor:
+    def __init__(self, data: torch.Tensor):
+        self.storage = _MockStorage(data)
+        self.shape = data.shape
+
+
+class _MockPrecisionConfig:
+    def __init__(self, weight_scale: _MockWrappedTensor):
+        self.weight_scale = weight_scale
+
+
+def test_quark_ocp_mx_aiter_fp8_registers_kernel_storage_for_eplb(
+    monkeypatch,
+):
+    layer = _MockLayer()
+    method = QuarkOCP_MX_MoEMethod.__new__(QuarkOCP_MX_MoEMethod)
+    method.mxfp4_backend = Mxfp4MoeBackend.AITER_MXFP4_FP8
+    method.experts_cls = None
+    method.moe_kernel = None
+    method.moe = SimpleNamespace(moe_parallel_config=SimpleNamespace(enable_eplb=True))
+    method.get_fused_moe_quant_config = lambda _layer: None
+
+    w13_storage = torch.full_like(layer.w13_weight, 1)
+    w2_storage = torch.full_like(layer.w2_weight, 2)
+    w13_scale_storage = torch.full_like(layer.w13_weight_scale, 3)
+    w2_scale_storage = torch.full_like(layer.w2_weight_scale, 4)
+
+    def fake_convert(**kwargs):
+        del layer.w13_weight
+        del layer.w2_weight
+        return (
+            _MockWrappedTensor(w13_storage),
+            _MockWrappedTensor(w2_storage),
+            _MockPrecisionConfig(_MockWrappedTensor(w13_scale_storage)),
+            _MockPrecisionConfig(_MockWrappedTensor(w2_scale_storage)),
+            None,
+            None,
+        )
+
+    monkeypatch.setattr(
+        quark_moe,
+        "convert_gpt_oss_weight_to_mxfp4_moe_kernel_format",
+        fake_convert,
+    )
+    monkeypatch.setattr(quark_moe.torch.accelerator, "empty_cache", lambda: None)
+
+    method._setup_kernel(layer)
+
+    params = dict(layer.named_parameters())
+    assert torch.equal(params["w13_weight_eplb"], w13_storage)
+    assert torch.equal(params["w2_weight_eplb"], w2_storage)
+    assert torch.equal(params["w13_weight_scale"], w13_scale_storage)
+    assert torch.equal(params["w2_weight_scale"], w2_scale_storage)
+    assert (
+        layer.w13_weight.storage.data.data_ptr() == params["w13_weight_eplb"].data_ptr()
+    )
+    assert (
+        layer.w2_weight.storage.data.data_ptr() == params["w2_weight_eplb"].data_ptr()
+    )
+    assert (
+        method.w13_precision_config.weight_scale.storage.data.data_ptr()
+        == params["w13_weight_scale"].data_ptr()
+    )
+    assert (
+        method.w2_precision_config.weight_scale.storage.data.data_ptr()
+        == params["w2_weight_scale"].data_ptr()
+    )

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -81,6 +81,21 @@ __all__ = [
 ]
 
 
+def _get_mxfp4_eplb_storage_data(tensor: Any) -> torch.Tensor:
+    if isinstance(tensor, torch.Tensor):
+        return tensor
+
+    storage = getattr(tensor, "storage", None)
+    data = getattr(storage, "data", None)
+    if isinstance(data, torch.Tensor):
+        return data
+
+    raise TypeError(
+        "Expected a torch.Tensor or a tensor wrapper with torch.Tensor "
+        f"storage.data, got {type(tensor).__name__}."
+    )
+
+
 class QuarkMoEMethod(FusedMoEMethodBase):
     def __init__(self, moe: FusedMoEConfig):
         super().__init__(moe)
@@ -1226,6 +1241,27 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
             layer.w2_weight = w2
             self.w13_precision_config = w13_scale
             self.w2_precision_config = w2_scale
+            if self.moe.moe_parallel_config.enable_eplb:
+                replace_parameter(
+                    layer,
+                    "w13_weight_eplb",
+                    _get_mxfp4_eplb_storage_data(w13),
+                )
+                replace_parameter(
+                    layer,
+                    "w2_weight_eplb",
+                    _get_mxfp4_eplb_storage_data(w2),
+                )
+                replace_parameter(
+                    layer,
+                    "w13_weight_scale",
+                    _get_mxfp4_eplb_storage_data(w13_scale.weight_scale),
+                )
+                replace_parameter(
+                    layer,
+                    "w2_weight_scale",
+                    _get_mxfp4_eplb_storage_data(w2_scale.weight_scale),
+                )
         else:
             # Standard backends: replace parameters
             replace_parameter(layer, "w13_weight", w13)


### PR DESCRIPTION
 
## Purpose

The PR https://github.com/vllm-project/vllm/pull/47220 enabled EPLB for QuarkOCP_MX_MoEMethod, but the AITER_MXFP4_FP8 setup path did not keep the converted expert weights in the parameter list used by EPLB.

During weight conversion, convert_gpt_oss_weight_to_mxfp4_moe_kernel_format deletes layer.w13_weight and layer.w2_weight from the module parameters. _setup_kernel then restores them through plain attribute assignment because the AITER FP8 path uses triton-style wrapped tensors. Those restored weights remain usable by the inference kernel, but they no longer appear in named_parameters().

This becomes a problem when users run a Quark OCP MXFP4 MoE model, such as Kimi-K2.6-MXFP4, with --enable-eplb and backend selection lands on AITER_MXFP4_FP8. EPLB collects expert tensors through get_expert_weights(), which relies on named_parameters(). Because the converted weights are no longer registered parameters, EPLB can miss the actual expert weights while still seeing scale tensors.
When EPLB later rearranges experts, it can move scale data without moving matching weight data. Inference then combines weights and scales from different expert positions, causing silent output degradation rather than a crash.

Expected behavior is that every tensor used by the kernel as expert-local state must stay visible to EPLB when EPLB is enabled. For the AITER MXFP4 FP8 path, kernel wrappers should remain attached for inference, but their underlying storage.data tensors and corresponding precision-config scale storage should also be registered as
parameters so EPLB rebalances the same physical tensors the kernel reads.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

