### PR TITLE
[Bugfix][Distributed] Delegate MNNVL allreduce one-shot selection

### DIFF
--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -13,6 +13,7 @@ from vllm._custom_ops import cutlass_scaled_fp4_mm, scaled_fp4_quant
 from vllm.compilation.passes.fusion.allreduce_rms_fusion import (
     AllReduceFusionPass,
     RocmAiterAllReduceFusionPass,
+    _select_flashinfer_allreduce_use_oneshot,
 )
 from vllm.compilation.passes.fx_utils import find_op_nodes
 from vllm.compilation.passes.utility.fix_functionalization import (
@@ -43,6 +44,35 @@ from vllm.utils.system_utils import update_environment_variables
 from vllm.utils.torch_utils import set_random_seed
 
 DEVICE_TYPE = current_platform.device_type
+
+
+@pytest.mark.parametrize(
+    ("workspace_backend", "device_capability", "world_size", "tensor_size", "expected"),
+    [
+        ("mnnvl", 103, 8, 2 * 1024 * 1024, None),
+        ("trtllm", 103, 8, 2 * 1024 * 1024, True),
+        ("trtllm", 103, 8, 2 * 1024 * 1024 + 1, False),
+        ("trtllm", 100, 4, 4 * 1024 * 1024, True),
+        ("trtllm", 100, 4, 4 * 1024 * 1024 + 1, False),
+        ("trtllm", None, 8, 128 * 1024 * 1024, True),
+    ],
+)
+def test_select_flashinfer_allreduce_use_oneshot(
+    workspace_backend: str,
+    device_capability: int | None,
+    world_size: int,
+    tensor_size: int,
+    expected: bool | None,
+):
+    assert (
+        _select_flashinfer_allreduce_use_oneshot(
+            workspace_backend,
+            device_capability,
+            world_size,
+            tensor_size,
+        )
+        is expected
+    )
 
 
 class TestAllReduceRMSNormModel(torch.nn.Module):

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -129,6 +129,29 @@ _FI_ALLREDUCE_ONE_SHOT_MAX_SIZES_MB: dict[int, dict[int, float]] = {
     },
 }
 
+MiB = 1024 * 1024
+
+
+def _select_flashinfer_allreduce_use_oneshot(
+    workspace_backend: str,
+    device_capability: int | None,
+    world_size: int,
+    current_tensor_size: int,
+) -> bool | None:
+    if workspace_backend == "mnnvl":
+        # FlashInfer sizes MNNVL workspaces around its own AUTO strategy.
+        # Forcing vLLM's per-rank threshold can request one-shot for tensors
+        # larger than the MNNVL one-shot workspace.
+        return None
+
+    if device_capability is None:
+        max_one_shot_size = None
+    else:
+        max_one_shot_size = _FI_ALLREDUCE_ONE_SHOT_MAX_SIZES_MB.get(
+            device_capability, {}
+        ).get(world_size)
+    return max_one_shot_size is None or current_tensor_size <= max_one_shot_size * MiB
+
 
 if flashinfer_comm is not None:
     from vllm.distributed.device_communicators.flashinfer_all_reduce import (
@@ -138,8 +161,6 @@ if flashinfer_comm is not None:
     )
 
     ar_fusion_patterns = flashinfer_comm.AllReduceFusionPattern
-
-    MiB = 1024 * 1024
 
     def call_trtllm_fused_allreduce_norm(
         allreduce_in: torch.Tensor,
@@ -175,16 +196,6 @@ if flashinfer_comm is not None:
         )
         curr_device = current_platform.get_device_capability()
         device_capability = curr_device.to_int() if curr_device is not None else None
-        # Get one shot input size limit for the current world size
-        # for the current device capability
-        max_one_shot_size = _FI_ALLREDUCE_ONE_SHOT_MAX_SIZES_MB.get(
-            device_capability,  # type: ignore[arg-type, unused-ignore]
-            {},
-        ).get(world_size, None)
-        # Use one shot if no max size is specified
-        use_oneshot = (
-            max_one_shot_size is None or current_tensor_size <= max_one_shot_size * MiB
-        )
 
         # Select workspace based on pattern: quant patterns use the
         # trtllm quant workspace, non-quant patterns use the primary workspace.
@@ -205,6 +216,12 @@ if flashinfer_comm is not None:
         )
         assert workspace is not None, (
             "Flashinfer allreduce workspace must be initialized when using flashinfer"
+        )
+        use_oneshot = _select_flashinfer_allreduce_use_oneshot(
+            workspace.backend,
+            device_capability,
+            world_size,
+            current_tensor_size,
         )
         assert flashinfer_comm is not None
         if norm_out is None:
@@ -249,7 +266,7 @@ if flashinfer_comm is not None:
             # the end for the one-shot path; the two-shot path is synchronized
             # and keeps the early completion. Related one-shot instability in
             # the same kernel: flashinfer-ai/flashinfer#1223.
-            trigger_completion_at_end=use_oneshot
+            trigger_completion_at_end=(use_oneshot is True)
             or num_tokens > PDL_ADVANCE_LAUNCH_TOKENS,
         )
 


### PR DESCRIPTION
## Purpose

Fixes #47284.

After #47219, vLLM can default FlashInfer fused allreduce/RMSNorm to the `mnnvl` workspace backend on single-node setups. The fusion call still forced `use_oneshot` from vLLM's legacy per-rank threshold table, which can disagree with FlashInfer MNNVL's AUTO workspace sizing. When vLLM forces `use_oneshot=True` for a shape that FlashInfer sized for AUTO/two-shot, FlashInfer reports an insufficient workspace.

This PR keeps the existing explicit one-shot threshold behavior for the `trtllm` workspace backend, but passes `use_oneshot=None` for `mnnvl` so FlashInfer AUTO selects the MNNVL strategy matching the allocated workspace.

Duplicate-work check before opening:

```bash
gh issue view 47284 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search '47284 in:body'
gh pr list --repo vllm-project/vllm --state open --search 'MNNVL allreduce buffer insufficient workspace oneshot'
```

Result: no open PR found for #47284 or this MNNVL `use_oneshot` mismatch at time of check.

AI assistance was used in preparing this PR. I reviewed the issue, source, test changes, validation evidence, and every changed line before submitting.

## Test Plan

Local static checks:

```bash
git diff --check
uvx ruff check vllm/compilation/passes/fusion/allreduce_rms_fusion.py tests/compile/passes/distributed/test_fusion_all_reduce.py
uvx ruff format --check vllm/compilation/passes/fusion/allreduce_rms_fusion.py tests/compile/passes/distributed/test_fusion_all_reduce.py
```

Local targeted pytest attempted:

```bash
.venv/bin/python -m pytest tests/compile/passes/distributed/test_fusion_all_reduce.py -k test_select_flashinfer_allreduce_use_oneshot -v
```

This local checkout's `.venv` did not have `pytest` installed, and direct helper import was also blocked locally because the venv did not have `torch`.

GPU validation used a synthetic direct FlashInfer MNNVL allreduce-fusion harness instead of downloading the full GLM-5.2-FP8 model. It directly exercises the workspace/strategy mismatch:

```bash
cd /root/issue_47284
uv venv --system-site-packages --python 3.12 .venv
NCCL_DEBUG=WARN TORCH_NCCL_ASYNC_ERROR_HANDLING=1 \
  .venv/bin/python -m torch.distributed.run --nproc_per_node=8 \
  /root/issue_47284/issue_47284_mnnvl_oneshot_validation.py
```

GPU environment:

- 8x NVIDIA H200, compute capability 9.0
- Image: `vllm/vllm-openai:nightly`
- vLLM: `0.23.1rc1.dev748+g2dfaae752`
- Torch: `2.11.0+cu130`
- NCCL: `2.28.9+cuda13.0`

Also ran a patched-helper smoke in the same CUDA image by copying the patched `allreduce_rms_fusion.py` into the disposable image package and asserting MNNVL returns `None` while TRT-LLM preserves the threshold behavior.

## Test Result

Local static checks passed:

```text
All checks passed!
2 files already formatted
```

H200 synthetic MNNVL validation passed. Forcing one-shot reproduced the insufficient-buffer failure; leaving strategy as AUTO succeeded:

```json
{
  "forced_oneshot": {
    "status": "error",
    "error_type": "ValueError",
    "error": "The buffer size in the given workspace is insufficient for the given problem size. Buffer: 2097152 bytes, Required: 4194304 bytes.",
    "use_oneshot": true
  },
  "auto_strategy": {
    "status": "success",
    "finite": true,
    "use_oneshot": null
  },
  "validation": {
    "forced_oneshot_failed_as_expected": true,
    "auto_strategy_succeeded": true,
    "passed": true
  },
  "workspace_backend": "mnnvl",
  "world_size": 8,
  "num_tokens": 32,
  "hidden_dim": 8192,
  "dtype": "bf16",
  "per_rank_bytes": 524288,
  "total_comm_bytes": 4194304
}
```

Patched-helper smoke result in the same CUDA image:

```text
patched helper smoke passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. Not applicable.
</details>

