### PR TITLE
 [ModelScope] Support latest get_model_files AP

### DIFF
--- a/tests/transformers_utils/test_utils.py
+++ b/tests/transformers_utils/test_utils.py
@@ -1,11 +1,32 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import sys
+from types import ModuleType
+
+import pytest
+
 from vllm.transformers_utils.utils import (
     is_azure,
     is_cloud_storage,
     is_gcs,
     is_s3,
+    modelscope_list_repo_files,
 )
+
+
+class _FakeModelScopeApiModule(ModuleType):
+    HubApi: type[object]
+
+
+def _install_fake_modelscope_hub_api(
+    monkeypatch: pytest.MonkeyPatch,
+    hub_api: type[object],
+) -> None:
+    api_module = _FakeModelScopeApiModule("modelscope.hub.api")
+    api_module.HubApi = hub_api
+    monkeypatch.setitem(sys.modules, "modelscope", ModuleType("modelscope"))
+    monkeypatch.setitem(sys.modules, "modelscope.hub", ModuleType("modelscope.hub"))
+    monkeypatch.setitem(sys.modules, "modelscope.hub.api", api_module)
 
 
 def test_is_gcs():
@@ -35,3 +56,91 @@ def test_is_cloud_storage():
     assert is_cloud_storage("az://model-container/path")
     assert not is_cloud_storage("/unix/local/path")
     assert not is_cloud_storage("nfs://nfs-fqdn.local")
+
+
+def test_modelscope_list_repo_files_old_api(monkeypatch: pytest.MonkeyPatch):
+    calls: list[tuple[object, ...]] = []
+
+    class HubApi:
+        def login(self, token: str | bool | None) -> None:
+            calls.append(("login", token))
+
+        def get_model_files(
+            self,
+            model_id: str,
+            revision: str | None = None,
+            recursive: bool = False,
+        ) -> list[dict[str, object]]:
+            calls.append(("get_model_files", model_id, revision, recursive))
+            return [
+                {"Path": "config.json", "Type": "blob"},
+                {"Path": "nested", "Type": "tree"},
+                {"Path": "model.safetensors", "Type": "blob"},
+            ]
+
+    _install_fake_modelscope_hub_api(monkeypatch, HubApi)
+
+    files = modelscope_list_repo_files(
+        "qwen/Qwen1.5-0.5B-Chat",
+        revision="master",
+        token="fake-token",
+    )
+
+    assert files == ["config.json", "model.safetensors"]
+    assert calls == [
+        ("login", "fake-token"),
+        ("get_model_files", "qwen/Qwen1.5-0.5B-Chat", "master", True),
+    ]
+
+
+def test_modelscope_list_repo_files_new_api(monkeypatch: pytest.MonkeyPatch):
+    calls: list[tuple[object, ...]] = []
+
+    class HubApi:
+        def login(self, token: str | bool | None) -> None:
+            calls.append(("login", token))
+
+        def get_model_files(
+            self,
+            model_id: str,
+            recursive: bool = True,
+        ) -> list[dict[str, object]]:
+            calls.append(("get_model_files", model_id, recursive))
+            return [
+                {"Path": ".gitattributes", "Size": 1519},
+                {"Path": "config.json", "Size": 661},
+                {"Path": "nested", "Type": "tree"},
+            ]
+
+    _install_fake_modelscope_hub_api(monkeypatch, HubApi)
+
+    files = modelscope_list_repo_files("qwen/Qwen1.5-0.5B-Chat")
+
+    assert files == [".gitattributes", "config.json"]
+    assert calls == [
+        ("login", None),
+        ("get_model_files", "qwen/Qwen1.5-0.5B-Chat", True),
+    ]
+
+
+def test_modelscope_list_repo_files_new_api_rejects_revision(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class HubApi:
+        def login(self, token: str | bool | None) -> None:
+            pass
+
+        def get_model_files(
+            self,
+            model_id: str,
+            recursive: bool = True,
+        ) -> list[dict[str, object]]:
+            return []
+
+    _install_fake_modelscope_hub_api(monkeypatch, HubApi)
+
+    with pytest.raises(ValueError, match="does not support listing files"):
+        modelscope_list_repo_files(
+            "qwen/Qwen1.5-0.5B-Chat",
+            revision="master",
+        )

--- a/vllm/transformers_utils/utils.py
+++ b/vllm/transformers_utils/utils.py
@@ -5,6 +5,7 @@ import json
 import os
 import struct
 from functools import cache
+from inspect import signature
 from os import PathLike
 from pathlib import Path
 from typing import Any
@@ -48,13 +49,25 @@ def modelscope_list_repo_files(
 
     api = HubApi()
     api.login(token)
+    get_model_files_params = signature(api.get_model_files).parameters
+    get_model_files_kwargs: dict[str, Any] = {
+        "model_id": repo_id,
+        "recursive": True,
+    }
+    if "revision" in get_model_files_params:
+        get_model_files_kwargs["revision"] = revision
+    elif revision is not None:
+        raise ValueError(
+            "The installed modelscope package does not support listing files "
+            "for a specific revision. Please use revision=None or install a "
+            "modelscope version whose HubApi.get_model_files supports revision."
+        )
+
     # same as huggingface_hub.list_repo_files
     files = [
         file["Path"]
-        for file in api.get_model_files(
-            model_id=repo_id, revision=revision, recursive=True
-        )
-        if file["Type"] == "blob"
+        for file in api.get_model_files(**get_model_files_kwargs)
+        if file.get("Type", "blob") == "blob"
     ]
     return files
 


### PR DESCRIPTION



 ## Summary

  Fix ModelScope repo file listing with newer `modelscope` releases.

  `modelscope==1.38.0` changed `HubApi.get_model_files()` so it no longer accepts the `revision` keyword argument, and its returned
  file entries may not include the older `Type` field. vLLM currently calls `get_model_files(model_id=..., revision=...,
  recursive=True)`, which causes `test_model_from_modelscope` to fail after `pip install modelscope` installs the latest release.

  This patch makes `modelscope_list_repo_files()` compatible with both API shapes:

  - older ModelScope versions that support `revision`
  - newer ModelScope versions whose `get_model_files()` only accepts `model_id` and `recursive`
  - newer returned entries without a `Type` field

  For newer ModelScope versions, non-`None` `revision` is rejected with a clear error instead of being silently ignored.

  ## Testing

  ```bash
  pre-commit run --hook-stage manual --files \
    vllm/transformers_utils/utils.py \
    tests/transformers_utils/test_utils.py

  python -m pytest -p no:cacheprovider \
    tests/transformers_utils/test_utils.py -q
```
  Manual compatibility checks:
```
  modelscope==1.38.0: modelscope_list_repo_files("qwen/Qwen1.5-0.5B-Chat") returns config.json
  modelscope==1.35.3: modelscope_list_repo_files("qwen/Qwen1.5-0.5B-Chat", revision="master") returns config.json
```
  ## Notes

  This addresses the regression failure:
```
  TypeError: LegacyHubApi.get_model_files() got an unexpected keyword argument 'revision
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

