### PR TITLE
[Kernel][Perf] Scale fused MoE default-config M-tile threshold by tokens per expert (up to 1.49x on H20 at batch 96-768)

### DIFF
--- a/tests/kernels/moe/test_moe_default_config.py
+++ b/tests/kernels/moe/test_moe_default_config.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import patch
+
+import pytest
+
+from vllm.model_executor.layers.fused_moe.fused_moe import (
+    get_default_config,
+    try_get_optimal_moe_config,
+)
+
+
+@pytest.mark.parametrize(
+    ("m", "m_is_per_expert", "expected_block_m"),
+    [
+        (512, False, 16),
+        (820, False, 64),
+        (512, True, 64),
+        (64, True, 16),
+    ],
+)
+def test_fp8_block_default_config_m_tile_respects_m_semantics(
+    m: int, m_is_per_expert: bool, expected_block_m: int
+):
+    with patch(
+        "vllm.model_executor.layers.fused_moe.fused_moe.current_platform.is_rocm",
+        return_value=False,
+    ):
+        config = get_default_config(
+            M=m,
+            E=512,
+            N=256,
+            K=2048,
+            topk=10,
+            dtype="fp8_w8a8",
+            block_shape=[128, 128],
+            m_is_per_expert=m_is_per_expert,
+        )
+
+    assert config["BLOCK_SIZE_M"] == expected_block_m
+
+
+def test_fp8_block_default_config_per_expert_m_flows_through_fallback():
+    with (
+        patch(
+            "vllm.model_executor.layers.fused_moe.get_config",
+            return_value=None,
+        ),
+        patch(
+            "vllm.model_executor.layers.fused_moe.fused_moe.get_moe_configs",
+            return_value=None,
+        ),
+        patch(
+            "vllm.model_executor.layers.fused_moe.fused_moe.current_platform.is_rocm",
+            return_value=False,
+        ),
+    ):
+        config = try_get_optimal_moe_config(
+            w1_shape=(512, 512, 2048),
+            w2_shape=(512, 2048, 256),
+            top_k=10,
+            dtype="fp8_w8a8",
+            M=512,
+            block_shape=[128, 128],
+            m_is_per_expert=True,
+        )
+
+    assert config["BLOCK_SIZE_M"] == 64

--- a/tests/kernels/moe/test_moe_default_config.py
+++ b/tests/kernels/moe/test_moe_default_config.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import patch
+
+import pytest
+
+from vllm.model_executor.layers.fused_moe.fused_moe import (
+    get_default_config,
+    try_get_optimal_moe_config,
+)
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+@pytest.mark.parametrize(
+    ("m", "m_is_per_expert", "expected_block_m"),
+    [
+        (512, False, 16),
+        (820, False, 64),
+        (512, True, 64),
+        (64, True, 16),
+    ],
+)
+def test_fp8_block_default_config_m_tile_respects_m_semantics(
+    m: int, m_is_per_expert: bool, expected_block_m: int
+):
+    with patch(
+        "vllm.model_executor.layers.fused_moe.fused_moe.current_platform.is_rocm",
+        return_value=False,
+    ):
+        config = get_default_config(
+            M=m,
+            E=512,
+            N=256,
+            K=2048,
+            topk=10,
+            dtype="fp8_w8a8",
+            block_shape=[128, 128],
+            m_is_per_expert=m_is_per_expert,
+        )
+
+    assert config["BLOCK_SIZE_M"] == expected_block_m
+
+
+def test_fp8_block_default_config_per_expert_m_flows_through_fallback():
+    with (
+        patch(
+            "vllm.model_executor.layers.fused_moe.get_config",
+            return_value=None,
+        ),
+        patch(
+            "vllm.model_executor.layers.fused_moe.fused_moe.get_moe_configs",
+            return_value=None,
+        ),
+        patch(
+            "vllm.model_executor.layers.fused_moe.fused_moe.current_platform.is_rocm",
+            return_value=False,
+        ),
+    ):
+        config = try_get_optimal_moe_config(
+            w1_shape=(512, 512, 2048),
+            w2_shape=(512, 2048, 256),
+            top_k=10,
+            dtype="fp8_w8a8",
+            M=512,
+            block_shape=[128, 128],
+            m_is_per_expert=True,
+        )
+
+    assert config["BLOCK_SIZE_M"] == 64

--- a/vllm/model_executor/layers/fused_moe/experts/fused_batched_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/fused_batched_moe.py
@@ -892,6 +892,10 @@ class BatchedTritonExperts(mk.FusedMoEExpertsModular):
             config_dtype,
             max_num_tokens,
             block_shape=self.block_shape,
+            # In the batched (3-D) layout M is already the per-expert row
+            # count, so the default-config heuristic must not rescale it
+            # by topk/E.
+            m_is_per_expert=True,
         )
 
         if hidden_states.dtype == torch.bfloat16:

--- a/vllm/model_executor/layers/fused_moe/experts/fused_batched_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/fused_batched_moe.py
@@ -948,6 +948,10 @@ class BatchedTritonExperts(mk.FusedMoEExpertsModular):
             config_dtype,
             max_num_tokens,
             block_shape=self.block_shape,
+            # In the batched (3-D) layout M is already the per-expert row
+            # count, so the default-config heuristic must not rescale it
+            # by topk/E.
+            m_is_per_expert=True,
         )
 
         if hidden_states.dtype == torch.bfloat16:

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1284,19 +1284,20 @@ def get_default_config(
         # Choose the M tile from the rows an expert's GEMM actually sees,
         # not the raw token count: routing spreads M tokens with topk
         # replication over E experts, ~M*topk/E rows each. Keep 16-row
-        # tiles until the average expert fills one (M*topk/E > 16), with
-        # the legacy M <= 64 as a floor so shapes with E/topk < 4 keep
-        # their current config. For the classic E=8/topk=2 this reproduces
-        # M <= 64 exactly; for high-expert-count MoEs (E/topk >> 4) it
-        # defers the 64-row tile past the decode/medium-batch range where
-        # it is mostly padding. CUDA only (validated on NVIDIA); ROCm
-        # keeps the prior raw-M threshold.
+        # tiles while the average expert has less than one full tile of
+        # rows (M*topk < 16*E) — beyond that a 64-row tile stops being
+        # mostly padding and measures as fast or faster. The legacy
+        # M <= 64 stays as a floor, so shapes with E/topk < 4 (e.g. the
+        # classic E=8/topk=2) keep today's configs at every M, while
+        # high-expert-count MoEs defer the 64-row tile past the
+        # decode/medium-batch range that raw M <= 64 mis-tiles. CUDA
+        # only (validated on NVIDIA); ROCm keeps the prior raw-M rule.
         if current_platform.is_rocm():
-            m_tile_switch = 64
+            small_m_tile = M <= 64
         else:
-            m_tile_switch = max(64, 16 * E // topk)
+            small_m_tile = M <= 64 or M * topk < 16 * E
         config = {
-            "BLOCK_SIZE_M": 16 if M <= m_tile_switch else 64,
+            "BLOCK_SIZE_M": 16 if small_m_tile else 64,
             "BLOCK_SIZE_N": block_n,
             "BLOCK_SIZE_K": block_shape[1],
             "GROUP_SIZE_M": 1 if M <= 16 else 32,

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1243,6 +1243,7 @@ def get_default_config(
     topk: int,
     dtype: str | None,
     block_shape: list[int] | None = None,
+    m_is_per_expert: bool = False,
 ) -> dict[str, int]:
     if envs.VLLM_BATCH_INVARIANT:
         return {
@@ -1291,8 +1292,10 @@ def get_default_config(
         # classic E=8/topk=2) keep today's configs at every M, while
         # high-expert-count MoEs defer the 64-row tile past the
         # decode/medium-batch range that raw M <= 64 mis-tiles. CUDA
-        # only (validated on NVIDIA); ROCm keeps the prior raw-M rule.
-        if current_platform.is_rocm():
+        # only (validated on NVIDIA); ROCm keeps the prior raw-M rule, as
+        # do batched (3-D) callers whose M is already the per-expert row
+        # count (max_num_tokens) rather than the pre-routing token count.
+        if current_platform.is_rocm() or m_is_per_expert:
             small_m_tile = M <= 64
         else:
             small_m_tile = M <= 64 or M * topk < 16 * E
@@ -1376,6 +1379,7 @@ def try_get_optimal_moe_config(
     dtype: str | None,
     M: int,
     block_shape: list[int] | None = None,
+    m_is_per_expert: bool = False,
 ) -> dict[str, int]:
     from vllm.model_executor.layers.fused_moe import get_config
 
@@ -1397,7 +1401,9 @@ def try_get_optimal_moe_config(
             config = configs[min(configs.keys(), key=lambda x: abs(x - M))]
         else:
             # Else use the default config
-            config = get_default_config(M, E, N, w1_shape[2], top_k, dtype, block_shape)
+            config = get_default_config(
+                M, E, N, w1_shape[2], top_k, dtype, block_shape, m_is_per_expert
+            )
     return config
 
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1281,8 +1281,22 @@ def get_default_config(
         else:
             block_n = block_shape[0]
             num_stages = 3
+        # Choose the M tile from the rows an expert's GEMM actually sees,
+        # not the raw token count: routing spreads M tokens with topk
+        # replication over E experts, ~M*topk/E rows each. Keep 16-row
+        # tiles until the average expert fills one (M*topk/E > 16), with
+        # the legacy M <= 64 as a floor so shapes with E/topk < 4 keep
+        # their current config. For the classic E=8/topk=2 this reproduces
+        # M <= 64 exactly; for high-expert-count MoEs (E/topk >> 4) it
+        # defers the 64-row tile past the decode/medium-batch range where
+        # it is mostly padding. CUDA only (validated on NVIDIA); ROCm
+        # keeps the prior raw-M threshold.
+        if current_platform.is_rocm():
+            m_tile_switch = 64
+        else:
+            m_tile_switch = max(64, 16 * E // topk)
         config = {
-            "BLOCK_SIZE_M": 16 if M <= 64 else 64,
+            "BLOCK_SIZE_M": 16 if M <= m_tile_switch else 64,
             "BLOCK_SIZE_N": block_n,
             "BLOCK_SIZE_K": block_shape[1],
             "GROUP_SIZE_M": 1 if M <= 16 else 32,

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1298,6 +1298,7 @@ def get_default_config(
     topk: int,
     dtype: str | None,
     block_shape: list[int] | None = None,
+    m_is_per_expert: bool = False,
 ) -> dict[str, int]:
     if envs.VLLM_BATCH_INVARIANT:
         return {
@@ -1324,6 +1325,8 @@ def get_default_config(
         # swap-AB kernel keeps it efficient on Hopper down to the smallest
         # batches, so prefer N=64 through low batch sizes. CUDA only (validated
         # on NVIDIA); ROCm keeps its prior tile/pipeline sizes.
+        # Batched (3-D) callers pass per-expert M, so they keep the raw-M
+        # threshold rather than applying the topk/E scaling a second time.
         if current_platform.is_rocm():
             block_n = block_shape[0]
             num_stages = num_stages_rocm
@@ -1337,7 +1340,18 @@ def get_default_config(
             block_n = block_shape[0]
             num_stages = 3
         config = {
-            "BLOCK_SIZE_M": 16 if M <= 64 else 64,
+            "BLOCK_SIZE_M": (
+                16
+                if (
+                    M <= 64
+                    or (
+                        not current_platform.is_rocm()
+                        and not m_is_per_expert
+                        and M * topk < 16 * E
+                    )
+                )
+                else 64
+            ),
             "BLOCK_SIZE_N": block_n,
             "BLOCK_SIZE_K": block_shape[1],
             "GROUP_SIZE_M": 1 if M <= 16 else 32,
@@ -1420,6 +1434,7 @@ def try_get_optimal_moe_config(
     dtype: str | None,
     M: int,
     block_shape: list[int] | None = None,
+    m_is_per_expert: bool = False,
 ) -> dict[str, int]:
     from vllm.model_executor.layers.fused_moe import get_config
 
@@ -1441,7 +1456,9 @@ def try_get_optimal_moe_config(
             config = configs[min(configs.keys(), key=lambda x: abs(x - M))]
         else:
             # Else use the default config
-            config = get_default_config(M, E, N, w1_shape[2], top_k, dtype, block_shape)
+            config = get_default_config(
+                M, E, N, w1_shape[2], top_k, dtype, block_shape, m_is_per_expert
+            )
     return config
 
 


### PR DESCRIPTION
## Purpose

In the fp8 block-quant branch of `get_default_config`, `BLOCK_SIZE_M` switches
from 16 to 64 at a raw-token-count threshold (`M > 64`) that ignores how many
rows an expert's GEMM actually sees. After routing, the `M` tokens spread with
`topk` replication over `E` experts — about `M*topk/E` rows per expert. For
modern high-expert-count MoEs (E = 256–512, topk 8–10), batches in the
high-throughput decode range (M = 96–512) leave each expert with only ~2–10
rows on average, so a 64-row tile spends most of its compute on padding.

The branch's own comment already states the intent — *"Use a small M tile for
decode-like batches where tokens are spread thin across experts"* — but the
threshold never looks at `E`/`topk` (both already passed as parameters). The
cost shows up in practice: #44830 measured the default config ~25% slower than
tuned in exactly this range for E=512/topk=10 on H100 and worked around it
with a per-shape tuned config file. Tuned configs cannot cover the long tail
of (shape × GPU) combinations; this PR fixes the fallback itself.

Change (one decision; CUDA only, following the #46642 precedent of leaving
ROCm's prior behavior untouched):

```python
# keep the 16-row tile while the average expert has less than one
# full tile of rows, with the legacy raw-M rule as a floor
BLOCK_SIZE_M = 16 if (M <= 64 or M * topk < 16 * E) else 64
```

- **E=8/topk=2 keeps today's configs at every batch size**: `M*topk < 16*E`
  ⇔ `M < 64` there, so the `M <= 64` floor makes the rule bit-identical for
  the legacy shape class the constant was originally tuned on.
- The floor also means no shape ever switches *earlier* than today — every
  shape's config is either identical or holds the 16-row tile longer.
- The same reasoning already lives elsewhere in this function: the general
  branch scales `GROUP_SIZE_M` by `tokens_per_expert`, and the wna16 branch
  keys `should_moe_wna16_use_cuda` on `M * topk`.
- Only the heuristic fallback changes; tuned-config lookups are unaffected.

### The shipped tuned configs already follow this rule

Scanning all fp8-block `[128,128]` tuned configs in the repo (NVIDIA,
monotone files, topk taken from the models these shapes belong to): the batch
where the *tuned* configs abandon the 16-row tile brackets `16*E/topk`
everywhere, while the current raw-M rule switches at 96 regardless of E:

| E | topk | new-rule switch (16E/topk, floor 64) | old-rule switch | tuned keeps M-tile=16 through | tuned first uses >16 at | files |
|---|---|---|---|---|---|---|
| 8 | 2 | 64 | 64 | 16 | 24 | 1 |
| 64 | 6 | 170 | 64 | 96–128 | 128–256 | 2 |
| 128 | 8 | 256 | 64 | 128–512 | 256–1024 | 12 |
| 160 | 8 | 320 | 64 | 256 | 512 | 2 |
| 256 | 8 | 512 | 64 | 256–2048 | 512–3072 | 7 |
| 384 | 8 | 768 | 64 | 512 | 1024 | 5 |
| 512 | 10 | 819 | 64 | 512 | 1024 | 5 |

(E=384 and E=512: unanimous across B200/GB200/H200/H100 — every file keeps
the 16-row tile through batch 512 and first uses a larger one at 1024.)

## Test Plan

A/B the old vs new rule per (E, topk, N, K, M) point with
`benchmark_moe.benchmark_config`: both rules' configs are built explicitly
and timed back-to-back, so the only variable is `BLOCK_SIZE_M`. Points where
the rules agree are also timed twice, giving an empirical noise floor.

- GPUs: NVIDIA H20 (Hopper, the bandwidth-rich case where mis-tiling is
  expensive) and RTX 4090D (Ada, compute-rich — the *least* favorable
  architecture for this change).
- fp8_w8a8, block_shape=[128,128], bf16 activations, 100 iters/point
  (CUDA-graph batched ×10), upstream default batch grid {1…4096} plus
  {192, 384, 768} to resolve the switch region.
- Shapes: the fp8-block shapes from `benchmarks/kernels/benchmark_moe_defaults.py`
  (E=256/topk8 at N=512 and N=256 with K=7168; E=512/topk10 at N=256 and
  N=512 with K=2048) plus E=128/topk8/N=768/K=2048, E=64/topk6/N=1408/K=4096,
  and the control E=8/topk2/N=256/K=4096 (identical configs across the whole
  grid by construction).
- Kernel version: vLLM v0.22.1; `get_default_config`'s fp8-block branch
  differs from main only at M ≤ 8 (#46642's N-tile choice), outside the
  changed region (M ≥ 96), and both columns run the identical kernel.

## Test Result

Both GPUs, all 29 points where the rules differ: **speedup on every single
point** (H20 geomean **1.295x**, up to **1.494x**; 4090D geomean 1.015x, all
positive). The gain is architecture-dependent as expected — wasted M-tile
lanes cost compute, so bandwidth-rich Hopper parts benefit most — consistent
with the ~25% H100 gap reported independently in #44830.

The three boundary points at exactly `M*topk == 16*E` measure 0.94–1.01x with
the 16-row tile, i.e. the 64-row tile already ties or wins there — hence the
strict `<` in the rule (the second commit).

### H20

Identical-config points timed twice: n=115, 98/115 within ±1% (full range 0.906–1.014) → noise floor.

Points where the rules differ (old picks BLOCK_SIZE_M=64, new keeps 16):

| shape E/topk/N/K | changed M | old/new speedup per M | geomean | min |
|---|---|---|---|---|
| E64/top6/N1408/K4096 | 96–128 | 96: **1.262x**, 128: **1.178x** | 1.219x | 1.178x |
| E128/top8/N768/K2048 | 96–192 | 96: **1.355x**, 128: **1.312x**, 192: **1.233x** | 1.299x | 1.233x |
| E256/top8/N256/K7168 | 96–384 | 96: **1.424x**, 128: **1.401x**, 192: **1.344x**, 256: **1.330x**, 384: **1.219x** | 1.342x | 1.219x |
| E256/top8/N512/K7168 | 96–384 | 96: **1.224x**, 128: **1.220x**, 192: **1.230x**, 256: **1.215x**, 384: **1.136x** | 1.205x | 1.136x |
| E512/top10/N256/K2048 | 96–768 | 96: **1.480x**, 128: **1.494x**, 192: **1.473x**, 256: **1.469x**, 384: **1.445x**, 512: **1.427x**, 768: **1.139x** | 1.413x | 1.139x |
| E512/top10/N512/K2048 | 96–768 | 96: **1.317x**, 128: **1.300x**, 192: **1.284x**, 256: **1.275x**, 384: **1.265x**, 512: **1.237x**, 768: **1.021x** | 1.239x | 1.021x |

All changed points: n=29, geomean **1.295x**, best 1.494x, worst 1.021x — no point below the noise floor.

Boundary calibration (M*topk == 16*E, i.e. the average expert exactly fills a 16-row tile — the new rule switches to the 64-row tile here; measured with the 16-row tile for reference):

| shape E/topk/N/K | M | 64-tile (us) | 16-tile (us) | 64→16 ratio |
|---|---|---|---|---|
| E128/top8/N768/K2048 | 256 | 386.51 | 387.73 | 0.997 |
| E256/top8/N256/K7168 | 512 | 1019.19 | 1010.77 | 1.008 |
| E256/top8/N512/K7168 | 512 | 1726.45 | 1833.38 | 0.942 |

At the boundary the 64-row tile already ties or wins, motivating the strict `<`.

<details>
<summary>Full grid (all shapes × all batch sizes)</summary>


**E=8 topk=2 N=256 K=4096**

| M | old | new | old (us) | new (us) | old/new |
|---|---|---|---|---|---|
| 1 | M16 | M16 | 29.41 | 29.36 | 1.002 (same) |
| 2 | M16 | M16 | 33.02 | 34.4 | 0.960 (same) |
| 4 | M16 | M16 | 35.96 | 35.9 | 1.002 (same) |
| 8 | M16 | M16 | 36.72 | 36.9 | 0.995 (same) |
| 16 | M16 | M16 | 44.9 | 44.92 | 1.000 (same) |
| 24 | M16 | M16 | 45.32 | 45.37 | 0.999 (same) |
| 32 | M16 | M16 | 45.42 | 45.51 | 0.998 (same) |
| 48 | M16 | M16 | 46.22 | 46.22 | 1.000 (same) |
| 64 | M16 | M16 | 49.11 | 48.71 | 1.008 (same) |
| 96 | M64 | M64 | 54.35 | 54.44 | 0.998 (same) |
| 128 | M64 | M64 | 55.8 | 57.23 | 0.975 (same) |
| 192 | M64 | M64 | 59.74 | 59.86 | 0.998 (same) |
| 256 | M64 | M64 | 67.42 | 67.94 | 0.992 (same) |
| 384 | M64 | M64 | 78.72 | 78.62 | 1.001 (same) |
| 512 | M64 | M64 | 95.88 | 96.14 | 0.997 (same) |
| 768 | M64 | M64 | 110.91 | 111.06 | 0.999 (same) |
| 1024 | M64 | M64 | 126.81 | 126.8 | 1.000 (same) |
| 1536 | M64 | M64 | 197.75 | 197.45 | 1.002 (same) |
| 2048 | M64 | M64 | 233.99 | 233.8 | 1.001 (same) |
| 3072 | M64 | M64 | 341.66 | 341.32 | 1.001 (same) |
| 4096 | M64 | M64 | 447.0 | 447.12 | 1.000 (same) |

**E=64 topk=6 N=1408 K=4096**

| M | old | new | old (us) | new (us) | old/new |
|---|---|---|---|---|---|
| 1 | M16 | M16 | 76.09 | 76.03 | 1.001 (same) |
| 2 | M16 | M16 | 115.45 | 115.56 | 0.999 (same) |
| 4 | M16 | M16 | 186.92 | 186.52 | 1.002 (same) |
| 8 | M16 | M16 | 282.33 | 282.98 | 0.998 (same) |
| 16 | M16 | M16 | 382.73 | 380.62 | 1.006 (same) |
| 24 | M16 | M16 | 428.27 | 454.46 | 0.942 (same) |
| 32 | M16 | M16 | 462.72 | 476.99 | 0.970 (same) |
| 48 | M16 | M16 | 490.47 | 499.31 | 0.982 (same) |
| 64 | M16 | M16 | 498.82 | 512.97 | 0.972 (same) |
| 96 | M64 | M16 | 634.4 | 502.62 | 1.262 |
| 128 | M64 | M16 | 643.36 | 546.2 | 1.178 |
| 192 | M64 | M64 | 639.8 | 635.73 | 1.006 (same) |
| 256 | M64 | M64 | 651.22 | 650.72 | 1.001 (same) |
| 384 | M64 | M64 | 676.64 | 680.93 | 0.994 (same) |
| 512 | M64 | M64 | 708.22 | 717.02 | 0.988 (same) |
| 768 | M64 | M64 | 1139.0 | 1137.27 | 1.002 (same) |
| 1024 | M64 | M64 | 1276.97 | 1274.63 | 1.002 (same) |
| 1536 | M64 | M64 | 1810.77 | 1812.83 | 0.999 (same) |
| 2048 | M64 | M64 | 2168.57 | 2169.92 | 0.999 (same) |
| 3072 | M64 | M64 | 3088.26 | 3090.04 | 0.999 (same) |
| 4096 | M64 | M64 | 3987.48 | 3988.91 | 1.000 (same) |

**E=128 topk=8 N=768 K=2048**

| M | old | new | old (us) | new (us) | old/new |
|---|---|---|---|---|---|
| 1 | M16 | M16 | 43.63 | 43.64 | 1.000 (same) |
| 2 | M16 | M16 | 60.48 | 60.47 | 1.000 (same) |
| 4 | M16 | M16 | 92.58 | 92.82 | 0.998 (same) |
| 8 | M16 | M16 | 134.36 | 135.54 | 0.991 (same) |
| 16 | M16 | M16 | 191.1 | 191.45 | 0.998 (same) |
| 24 | M16 | M16 | 226.0 | 225.87 | 1.001 (same) |
| 32 | M16 | M16 | 244.92 | 247.79 | 0.988 (same) |
| 48 | M16 | M16 | 269.84 | 270.44 | 0.998 (same) |
| 64 | M16 | M16 | 281.54 | 282.66 | 0.996 (same) |
| 96 | M64 | M16 | 373.92 | 276.02 | 1.355 |
| 128 | M64 | M16 | 377.45 | 287.74 | 1.312 |
| 192 | M64 | M16 | 383.92 | 311.39 | 1.233 |
| 256 | M64 | M64 | 386.51 | 386.51 | 1.000 (same) |
| 384 | M64 | M64 | 395.25 | 395.38 | 1.000 (same) |
| 512 | M64 | M64 | 402.32 | 409.55 | 0.982 (same) |
| 768 | M64 | M64 | 435.2 | 440.84 | 0.987 (same) |
| 1024 | M64 | M64 | 591.56 | 593.72 | 0.996 (same) |
| 1536 | M64 | M64 | 792.86 | 795.82 | 0.996 (same) |
| 2048 | M64 | M64 | 979.66 | 980.88 | 0.999 (same) |
| 3072 | M64 | M64 | 1366.24 | 1361.96 | 1.003 (same) |
| 4096 | M64 | M64 | 1743.89 | 1742.76 | 1.001 (same) |

**E=256 topk=8 N=256 K=7168**

| M | old | new | old (us) | new (us) | old/new |
|---|---|---|---|---|---|
| 1 | M16 | M16 | 55.89 | 55.86 | 1.000 (same) |
| 2 | M16 | M16 | 77.88 | 77.63 | 1.003 (same) |
| 4 | M16 | M16 | 123.09 | 122.75 | 1.003 (same) |
| 8 | M16 | M16 | 199.8 | 199.49 | 1.002 (same) |
| 16 | M16 | M16 | 294.77 | 292.78 | 1.007 (same) |
| 24 | M16 | M16 | 373.19 | 381.28 | 0.979 (same) |
| 32 | M16 | M16 | 449.3 | 449.26 | 1.000 (same) |
| 48 | M16 | M16 | 546.79 | 548.32 | 0.997 (same) |
| 64 | M16 | M16 | 603.46 | 609.62 | 0.990 (same) |
| 96 | M64 | M16 | 930.4 | 653.3 | 1.424 |
| 128 | M64 | M16 | 951.1 | 678.85 | 1.401 |
| 192 | M64 | M16 | 968.42 | 720.41 | 1.344 |
| 256 | M64 | M16 | 981.37 | 737.92 | 1.330 |
| 384 | M64 | M16 | 1000.11 | 820.74 | 1.219 |
| 512 | M64 | M64 | 1019.19 | 1019.19 | 1.000 (same) |
| 768 | M64 | M64 | 1050.84 | 1049.36 | 1.001 (same) |
| 1024 | M64 | M64 | 1096.24 | 1094.02 | 1.002 (same) |
| 1536 | M64 | M64 | 1194.13 | 1194.17 | 1.000 (same) |
| 2048 | M64 | M64 | 1621.28 | 1625.28 | 0.998 (same) |
| 3072 | M64 | M64 | 2222.33 | 2222.03 | 1.000 (same) |
| 4096 | M64 | M64 | 2744.87 | 2745.5 | 1.000 (same) |

**E=256 topk=8 N=512 K=7168**

| M | old | new | old (us) | new (us) | old/new |
|---|---|---|---|---|---|
| 1 | M16 | M16 | 73.68 | 73.76 | 0.999 (same) |
| 2 | M16 | M16 | 114.17 | 113.89 | 1.002 (same) |
| 4 | M16 | M16 | 182.53 | 182.24 | 1.002 (same) |
| 8 | M16 | M16 | 331.29 | 331.75 | 0.999 (same) |
| 16 | M16 | M16 | 489.82 | 540.72 | 0.906 (same) |
| 24 | M16 | M16 | 641.33 | 705.22 | 0.909 (same) |
| 32 | M16 | M16 | 840.79 | 828.74 | 1.014 (same) |
| 48 | M16 | M16 | 1006.69 | 1008.9 | 0.998 (same) |
| 64 | M16 | M16 | 1117.46 | 1120.85 | 0.997 (same) |
| 96 | M64 | M16 | 1523.72 | 1244.61 | 1.224 |
| 128 | M64 | M16 | 1573.69 | 1289.39 | 1.220 |
| 192 | M64 | M16 | 1641.35 | 1334.49 | 1.230 |
| 256 | M64 | M16 | 1661.97 | 1367.55 | 1.215 |
| 384 | M64 | M16 | 1693.23 | 1490.4 | 1.136 |
| 512 | M64 | M64 | 1726.45 | 1726.45 | 1.000 (same) |
| 768 | M64 | M64 | 1799.09 | 1801.06 | 0.999 (same) |
| 1024 | M64 | M64 | 1868.77 | 1859.31 | 1.005 (same) |
| 1536 | M64 | M64 | 1997.3 | 1992.7 | 1.002 (same) |
| 2048 | M64 | M64 | 2683.64 | 2685.36 | 0.999 (same) |
| 3072 | M64 | M64 | 3620.85 | 3624.13 | 0.999 (same) |
| 4096 | M64 | M64 | 4473.28 | 4471.13 | 1.000 (same) |

**E=512 topk=10 N=256 K=2048**

| M | old | new | old (us) | new (us) | old/new |
|---|---|---|---|---|---|
| 1 | M16 | M16 | 35.71 | 35.71 | 1.000 (same) |
| 2 | M16 | M16 | 44.96 | 45.05 | 0.998 (same) |
| 4 | M16 | M16 | 62.78 | 62.52 | 1.004 (same) |
| 8 | M16 | M16 | 92.06 | 92.4 | 0.996 (same) |
| 16 | M16 | M16 | 135.8 | 136.74 | 0.993 (same) |
| 24 | M16 | M16 | 173.39 | 172.97 | 1.002 (same) |
| 32 | M16 | M16 | 204.33 | 203.02 | 1.006 (same) |
| 48 | M16 | M16 | 253.81 | 253.87 | 1.000 (same) |
| 64 | M16 | M16 | 288.84 | 295.43 | 0.978 (same) |
| 96 | M64 | M16 | 497.6 | 336.12 | 1.480 |
| 128 | M64 | M16 | 537.39 | 359.82 | 1.494 |
| 192 | M64 | M16 | 567.8 | 385.46 | 1.473 |
| 256 | M64 | M16 | 583.71 | 397.31 | 1.469 |
| 384 | M64 | M16 | 601.91 | 416.5 | 1.445 |
| 512 | M64 | M16 | 609.91 | 427.49 | 1.427 |
| 768 | M64 | M16 | 627.97 | 551.38 | 1.139 |
| 1024 | M64 | M64 | 645.56 | 642.01 | 1.006 (same) |
| 1536 | M64 | M64 | 675.24 | 675.33 | 1.000 (same) |
| 2048 | M64 | M64 | 707.98 | 709.18 | 0.998 (same) |
| 3072 | M64 | M64 | 906.24 | 906.66 | 1.000 (same) |
| 4096 | M64 | M64 | 1317.74 | 1316.8 | 1.001 (same) |

**E=512 topk=10 N=512 K=2048**

| M | old | new | old (us) | new (us) | old/new |
|---|---|---|---|---|---|
| 1 | M16 | M16 | 43.71 | 43.63 | 1.002 (same) |
| 2 | M16 | M16 | 60.73 | 60.75 | 1.000 (same) |
| 4 | M16 | M16 | 87.92 | 87.79 | 1.002 (same) |
| 8 | M16 | M16 | 137.82 | 137.44 | 1.003 (same) |
| 16 | M16 | M16 | 213.58 | 212.6 | 1.005 (same) |
| 24 | M16 | M16 | 285.25 | 294.74 | 0.968 (same) |
| 32 | M16 | M16 | 353.06 | 352.72 | 1.001 (same) |
| 48 | M16 | M16 | 459.21 | 462.4 | 0.993 (same) |
| 64 | M16 | M16 | 541.66 | 539.68 | 1.004 (same) |
| 96 | M64 | M16 | 835.11 | 634.04 | 1.317 |
| 128 | M64 | M16 | 899.82 | 692.18 | 1.300 |
| 192 | M64 | M16 | 958.36 | 746.32 | 1.284 |
| 256 | M64 | M16 | 977.17 | 766.44 | 1.275 |
| 384 | M64 | M16 | 996.57 | 787.55 | 1.265 |
| 512 | M64 | M16 | 1006.92 | 814.13 | 1.237 |
| 768 | M64 | M16 | 1034.65 | 1013.72 | 1.021 |
| 1024 | M64 | M64 | 1063.23 | 1066.74 | 0.997 (same) |
| 1536 | M64 | M64 | 1122.45 | 1124.27 | 0.998 (same) |
| 2048 | M64 | M64 | 1183.76 | 1181.97 | 1.002 (same) |
| 3072 | M64 | M64 | 1501.84 | 1505.81 | 0.997 (same) |
| 4096 | M64 | M64 | 2139.36 | 2139.86 | 1.000 (same) |

</details>

### RTX 4090 D

Identical-config points timed twice: n=115, 109/115 within ±1% (full range 0.974–1.074) → noise floor.

Points where the rules differ (old picks BLOCK_SIZE_M=64, new keeps 16):

| shape E/topk/N/K | changed M | old/new speedup per M | geomean | min |
|---|---|---|---|---|
| E64/top6/N1408/K4096 | 96–128 | 96: **1.022x**, 128: **1.021x** | 1.021x | 1.021x |
| E128/top8/N768/K2048 | 96–192 | 96: **1.012x**, 128: **1.012x**, 192: **1.011x** | 1.012x | 1.011x |
| E256/top8/N256/K7168 | 96–384 | 96: **1.025x**, 128: **1.026x**, 192: **1.024x**, 256: **1.024x**, 384: **1.020x** | 1.024x | 1.020x |
| E256/top8/N512/K7168 | 96–384 | 96: **1.024x**, 128: **1.022x**, 192: **1.021x**, 256: **1.021x**, 384: **1.017x** | 1.021x | 1.017x |
| E512/top10/N256/K2048 | 96–768 | 96: **1.015x**, 128: **1.014x**, 192: **1.012x**, 256: **1.013x**, 384: **1.011x**, 512: **1.010x**, 768: **1.008x** | 1.012x | 1.008x |
| E512/top10/N512/K2048 | 96–768 | 96: **1.009x**, 128: **1.011x**, 192: **1.010x**, 256: **1.010x**, 384: **1.009x**, 512: **1.008x**, 768: **1.008x** | 1.009x | 1.008x |

All changed points: n=29, geomean **1.015x**, best 1.026x, worst 1.008x — no point below the noise floor.

Boundary calibration (M*topk == 16*E, i.e. the average expert exactly fills a 16-row tile — the new rule switches to the 64-row tile here; measured with the 16-row tile for reference):

| shape E/topk/N/K | M | 64-tile (us) | 16-tile (us) | 64→16 ratio |
|---|---|---|---|---|
| E128/top8/N768/K2048 | 256 | 703.15 | 695.71 | 1.011 |
| E256/top8/N256/K7168 | 512 | 1712.92 | 1682.5 | 1.018 |
| E256/top8/N512/K7168 | 512 | 3252.79 | 3219.2 | 1.010 |

At the boundary the 64-row tile already ties or wins, motivating the strict `<`.

<details>
<summary>Full grid (all shapes × all batch sizes)</summary>


**E=8 topk=2 N=256 K=4096**

| M | old | new | old (us) | new (us) | old/new |
|---|---|---|---|---|---|
| 1 | M16 | M16 | 21.13 | 21.08 | 1.003 (same) |
| 2 | M16 | M16 | 23.48 | 23.53 | 0.998 (same) |
| 4 | M16 | M16 | 25.34 | 25.37 | 0.999 (same) |
| 8 | M16 | M16 | 25.82 | 25.82 | 1.000 (same) |
| 16 | M16 | M16 | 32.89 | 32.65 | 1.007 (same) |
| 24 | M16 | M16 | 33.15 | 33.2 | 0.999 (same) |
| 32 | M16 | M16 | 33.4 | 33.37 | 1.001 (same) |
| 48 | M16 | M16 | 33.96 | 31.64 | 1.074 (same) |
| 64 | M16 | M16 | 32.85 | 32.91 | 0.998 (same) |
| 96 | M64 | M64 | 51.76 | 51.75 | 1.000 (same) |
| 128 | M64 | M64 | 53.3 | 53.28 | 1.000 (same) |
| 192 | M64 | M64 | 54.98 | 55.0 | 1.000 (same) |
| 256 | M64 | M64 | 59.72 | 59.72 | 1.000 (same) |
| 384 | M64 | M64 | 65.41 | 65.59 | 0.997 (same) |
| 512 | M64 | M64 | 67.47 | 67.5 | 1.000 (same) |
| 768 | M64 | M64 | 103.17 | 103.11 | 1.001 (same) |
| 1024 | M64 | M64 | 113.34 | 113.2 | 1.001 (same) |
| 1536 | M64 | M64 | 144.62 | 144.42 | 1.001 (same) |
| 2048 | M64 | M64 | 195.25 | 195.19 | 1.000 (same) |
| 3072 | M64 | M64 | 279.98 | 280.14 | 1.000 (same) |
| 4096 | M64 | M64 | 390.73 | 390.67 | 1.000 (same) |

**E=64 topk=6 N=1408 K=4096**

| M | old | new | old (us) | new (us) | old/new |
|---|---|---|---|---|---|
| 1 | M16 | M16 | 123.41 | 123.38 | 1.000 (same) |
| 2 | M16 | M16 | 222.09 | 221.64 | 1.002 (same) |
| 4 | M16 | M16 | 394.54 | 393.65 | 1.002 (same) |
| 8 | M16 | M16 | 643.73 | 646.94 | 0.995 (same) |
| 16 | M16 | M16 | 941.09 | 945.25 | 0.996 (same) |
| 24 | M16 | M16 | 1075.27 | 1078.11 | 0.997 (same) |
| 32 | M16 | M16 | 1140.17 | 1142.04 | 0.998 (same) |
| 48 | M16 | M16 | 1187.73 | 1185.67 | 1.002 (same) |
| 64 | M16 | M16 | 1201.41 | 1202.89 | 0.999 (same) |
| 96 | M64 | M16 | 1241.71 | 1215.34 | 1.022 |
| 128 | M64 | M16 | 1252.08 | 1226.55 | 1.021 |
| 192 | M64 | M64 | 1267.98 | 1267.67 | 1.000 (same) |
| 256 | M64 | M64 | 1287.91 | 1287.12 | 1.001 (same) |
| 384 | M64 | M64 | 1322.18 | 1322.17 | 1.000 (same) |
| 512 | M64 | M64 | 1352.44 | 1353.01 | 1.000 (same) |
| 768 | M64 | M64 | 1449.23 | 1449.43 | 1.000 (same) |
| 1024 | M64 | M64 | 1499.54 | 1498.37 | 1.001 (same) |
| 1536 | M64 | M64 | 1869.33 | 1872.02 | 0.999 (same) |
| 2048 | M64 | M64 | 2259.77 | 2263.31 | 0.998 (same) |
| 3072 | M64 | M64 | 3244.47 | 3250.75 | 0.998 (same) |
| 4096 | M64 | M64 | 4220.57 | 4228.76 | 0.998 (same) |

**E=128 topk=8 N=768 K=2048**

| M | old | new | old (us) | new (us) | old/new |
|---|---|---|---|---|---|
| 1 | M16 | M16 | 27.46 | 27.4 | 1.002 (same) |
| 2 | M16 | M16 | 54.96 | 52.84 | 1.040 (same) |
| 4 | M16 | M16 | 158.29 | 158.0 | 1.002 (same) |
| 8 | M16 | M16 | 273.68 | 274.84 | 0.996 (same) |
| 16 | M16 | M16 | 427.27 | 420.82 | 1.015 (same) |
| 24 | M16 | M16 | 516.18 | 515.47 | 1.001 (same) |
| 32 | M16 | M16 | 573.78 | 573.38 | 1.001 (same) |
| 48 | M16 | M16 | 626.44 | 627.38 | 0.999 (same) |
| 64 | M16 | M16 | 648.48 | 648.95 | 0.999 (same) |
| 96 | M64 | M16 | 671.61 | 663.48 | 1.012 |
| 128 | M64 | M16 | 678.49 | 670.44 | 1.012 |
| 192 | M64 | M16 | 691.2 | 683.78 | 1.011 |
| 256 | M64 | M64 | 703.15 | 703.15 | 1.000 (same) |
| 384 | M64 | M64 | 725.88 | 726.07 | 1.000 (same) |
| 512 | M64 | M64 | 745.88 | 746.22 | 1.000 (same) |
| 768 | M64 | M64 | 789.05 | 789.34 | 1.000 (same) |
| 1024 | M64 | M64 | 832.5 | 832.4 | 1.000 (same) |
| 1536 | M64 | M64 | 917.57 | 916.64 | 1.001 (same) |
| 2048 | M64 | M64 | 1023.79 | 1025.18 | 0.999 (same) |
| 3072 | M64 | M64 | 1400.47 | 1403.9 | 0.998 (same) |
| 4096 | M64 | M64 | 1819.51 | 1823.33 | 0.998 (same) |

**E=256 topk=8 N=256 K=7168**

| M | old | new | old (us) | new (us) | old/new |
|---|---|---|---|---|---|
| 1 | M16 | M16 | 37.06 | 36.57 | 1.014 (same) |
| 2 | M16 | M16 | 91.42 | 93.88 | 0.974 (same) |
| 4 | M16 | M16 | 193.66 | 193.44 | 1.001 (same) |
| 8 | M16 | M16 | 357.11 | 354.54 | 1.007 (same) |
| 16 | M16 | M16 | 610.28 | 608.2 | 1.003 (same) |
| 24 | M16 | M16 | 811.95 | 809.58 | 1.003 (same) |
| 32 | M16 | M16 | 975.23 | 973.64 | 1.002 (same) |
| 48 | M16 | M16 | 1190.0 | 1185.84 | 1.004 (same) |
| 64 | M16 | M16 | 1321.07 | 1319.91 | 1.001 (same) |
| 96 | M64 | M16 | 1492.02 | 1455.34 | 1.025 |
| 128 | M64 | M16 | 1550.95 | 1510.89 | 1.026 |
| 192 | M64 | M16 | 1599.39 | 1561.07 | 1.024 |
| 256 | M64 | M16 | 1625.26 | 1587.73 | 1.024 |
| 384 | M64 | M16 | 1668.71 | 1635.88 | 1.020 |
| 512 | M64 | M64 | 1712.92 | 1712.92 | 1.000 (same) |
| 768 | M64 | M64 | 1804.47 | 1805.25 | 1.000 (same) |
| 1024 | M64 | M64 | 1897.62 | 1898.24 | 1.000 (same) |
| 1536 | M64 | M64 | 2075.29 | 2074.39 | 1.000 (same) |
| 2048 | M64 | M64 | 2273.57 | 2273.88 | 1.000 (same) |
| 3072 | M64 | M64 | 2675.02 | 2674.8 | 1.000 (same) |
| 4096 | M64 | M64 | 3076.38 | 3075.15 | 1.000 (same) |

**E=256 topk=8 N=512 K=7168**

| M | old | new | old (us) | new (us) | old/new |
|---|---|---|---|---|---|
| 1 | M16 | M16 | 100.0 | 100.54 | 0.995 (same) |
| 2 | M16 | M16 | 198.19 | 199.37 | 0.994 (same) |
| 4 | M16 | M16 | 373.73 | 373.03 | 1.002 (same) |
| 8 | M16 | M16 | 714.91 | 713.02 | 1.003 (same) |
| 16 | M16 | M16 | 1185.06 | 1188.4 | 0.997 (same) |
| 24 | M16 | M16 | 1584.86 | 1582.28 | 1.002 (same) |
| 32 | M16 | M16 | 1901.1 | 1895.02 | 1.003 (same) |
| 48 | M16 | M16 | 2332.61 | 2326.23 | 1.003 (same) |
| 64 | M16 | M16 | 2591.54 | 2585.54 | 1.002 (same) |
| 96 | M64 | M16 | 2911.87 | 2844.06 | 1.024 |
| 128 | M64 | M16 | 3020.97 | 2957.41 | 1.022 |
| 192 | M64 | M16 | 3094.79 | 3031.9 | 1.021 |
| 256 | M64 | M16 | 3134.11 | 3069.01 | 1.021 |
| 384 | M64 | M16 | 3199.72 | 3145.12 | 1.017 |
| 512 | M64 | M64 | 3252.79 | 3252.79 | 1.000 (same) |
| 768 | M64 | M64 | 3355.01 | 3355.1 | 1.000 (same) |
| 1024 | M64 | M64 | 3465.18 | 3464.53 | 1.000 (same) |
| 1536 | M64 | M64 | 3677.06 | 3676.22 | 1.000 (same) |
| 2048 | M64 | M64 | 3895.33 | 3898.41 | 0.999 (same) |
| 3072 | M64 | M64 | 4304.31 | 4304.03 | 1.000 (same) |
| 4096 | M64 | M64 | 4869.02 | 4875.34 | 0.999 (same) |

**E=512 topk=10 N=256 K=2048**

| M | old | new | old (us) | new (us) | old/new |
|---|---|---|---|---|---|
| 1 | M16 | M16 | 22.21 | 22.24 | 0.999 (same) |
| 2 | M16 | M16 | 28.13 | 28.15 | 0.999 (same) |
| 4 | M16 | M16 | 41.94 | 41.54 | 1.010 (same) |
| 8 | M16 | M16 | 138.83 | 138.87 | 1.000 (same) |
| 16 | M16 | M16 | 250.65 | 251.64 | 0.996 (same) |
| 24 | M16 | M16 | 340.36 | 341.44 | 0.997 (same) |
| 32 | M16 | M16 | 417.13 | 417.76 | 0.999 (same) |
| 48 | M16 | M16 | 539.83 | 538.54 | 1.002 (same) |
| 64 | M16 | M16 | 630.1 | 629.98 | 1.000 (same) |
| 96 | M64 | M16 | 756.29 | 745.34 | 1.015 |
| 128 | M64 | M16 | 823.31 | 811.6 | 1.014 |
| 192 | M64 | M16 | 881.18 | 870.98 | 1.012 |
| 256 | M64 | M16 | 906.62 | 895.13 | 1.013 |
| 384 | M64 | M16 | 930.25 | 920.27 | 1.011 |
| 512 | M64 | M16 | 949.12 | 940.04 | 1.010 |
| 768 | M64 | M16 | 982.75 | 974.76 | 1.008 |
| 1024 | M64 | M64 | 1019.59 | 1019.32 | 1.000 (same) |
| 1536 | M64 | M64 | 1094.76 | 1095.17 | 1.000 (same) |
| 2048 | M64 | M64 | 1168.52 | 1168.1 | 1.000 (same) |
| 3072 | M64 | M64 | 1319.18 | 1319.25 | 1.000 (same) |
| 4096 | M64 | M64 | 1474.67 | 1475.24 | 1.000 (same) |

**E=512 topk=10 N=512 K=2048**

| M | old | new | old (us) | new (us) | old/new |
|---|---|---|---|---|---|
| 1 | M16 | M16 | 27.44 | 27.24 | 1.007 (same) |
| 2 | M16 | M16 | 40.34 | 39.66 | 1.017 (same) |
| 4 | M16 | M16 | 144.77 | 143.62 | 1.008 (same) |
| 8 | M16 | M16 | 265.25 | 264.64 | 1.002 (same) |
| 16 | M16 | M16 | 475.32 | 474.28 | 1.002 (same) |
| 24 | M16 | M16 | 656.03 | 652.08 | 1.006 (same) |
| 32 | M16 | M16 | 803.2 | 807.42 | 0.995 (same) |
| 48 | M16 | M16 | 1047.0 | 1050.27 | 0.997 (same) |
| 64 | M16 | M16 | 1232.89 | 1226.9 | 1.005 (same) |
| 96 | M64 | M16 | 1469.04 | 1456.56 | 1.009 |
| 128 | M64 | M16 | 1599.75 | 1582.3 | 1.011 |
| 192 | M64 | M16 | 1712.62 | 1696.28 | 1.010 |
| 256 | M64 | M16 | 1756.76 | 1739.55 | 1.010 |
| 384 | M64 | M16 | 1794.99 | 1779.24 | 1.009 |
| 512 | M64 | M16 | 1823.04 | 1807.61 | 1.008 |
| 768 | M64 | M16 | 1870.23 | 1855.67 | 1.008 |
| 1024 | M64 | M64 | 1914.53 | 1914.18 | 1.000 (same) |
| 1536 | M64 | M64 | 2012.6 | 2013.06 | 1.000 (same) |
| 2048 | M64 | M64 | 2113.16 | 2112.95 | 1.000 (same) |
| 3072 | M64 | M64 | 2297.88 | 2296.48 | 1.001 (same) |
| 4096 | M64 | M64 | 2488.83 | 2490.89 | 0.999 (same) |

</details>

AI assistance (Claude) was used for the analysis, benchmarking, and edits;
all changes were reviewed by the submitter.
