### PR TITLE
[V1][Sampling] Add opt-in fused generated-token top-logprobs path

### DIFF
--- a/tests/v1/sample/test_fused_top_logprobs.py
+++ b/tests/v1/sample/test_fused_top_logprobs.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.v1.sample.ops.fused_top_logprobs import (
+    fused_top_logprobs,
+    fused_top_logprobs_enabled,
+)
+
+
+def test_fused_top_logprobs_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("VLLM_ENABLE_FUSED_TOP_LOGPROBS", raising=False)
+
+    assert not fused_top_logprobs_enabled()
+
+
+def test_fused_top_logprobs_env_gate(monkeypatch):
+    monkeypatch.setenv("VLLM_ENABLE_FUSED_TOP_LOGPROBS", "1")
+    assert fused_top_logprobs_enabled()
+
+    monkeypatch.setenv("VLLM_ENABLE_FUSED_TOP_LOGPROBS", "true")
+    assert fused_top_logprobs_enabled()
+
+    monkeypatch.setenv("VLLM_ENABLE_FUSED_TOP_LOGPROBS", "0")
+    assert not fused_top_logprobs_enabled()
+
+
+def test_fused_top_logprobs_returns_none_on_cpu():
+    logits = torch.randn(2, 16)
+    token_ids = torch.tensor([1, 2], dtype=torch.int64)
+
+    assert fused_top_logprobs(logits, token_ids, 4) is None

--- a/vllm/v1/sample/ops/fused_top_logprobs.py
+++ b/vllm/v1/sample/ops/fused_top_logprobs.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Fused generated-token top-logprobs helper.
+
+This optional CUDA path computes the generated-token logprob, rank, and top-N
+logprobs directly from logits. It avoids materializing a full
+``log_softmax(logits)`` tensor for the common sampled-token logprobs path.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+from vllm.v1.outputs import LogprobsTensors
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:  # pragma: no cover - depends on optional GPU runtime.
+    triton = None
+    tl = None
+
+_ENV_VAR = "VLLM_ENABLE_FUSED_TOP_LOGPROBS"
+
+
+def fused_top_logprobs_enabled() -> bool:
+    return os.environ.get(_ENV_VAR, "0").strip().lower() in ("1", "true")
+
+
+def _next_power_of_2(value: int) -> int:
+    if value <= 1:
+        return 1
+    return 1 << (value - 1).bit_length()
+
+
+def _launch_config(
+    vocab_size: int,
+    top_n: int,
+    batch_size: int,
+) -> tuple[int, int, int, int]:
+    if top_n <= 0 or top_n > 64:
+        raise ValueError("top_n must be in [1, 64]")
+    if vocab_size <= 0 or vocab_size > 262_144:
+        raise ValueError("vocab_size must be in [1, 262144]")
+    if batch_size <= 0 or batch_size > 64:
+        raise ValueError("batch_size must be in [1, 64]")
+
+    block_vocab = 2048 if batch_size <= 4 else 1024
+    blocks_per_row = (vocab_size + block_vocab - 1) // block_vocab
+    num_warps = 8 if block_vocab == 2048 else 4
+    return block_vocab, blocks_per_row, num_warps, 1
+
+
+def fused_top_logprobs(
+    logits: torch.Tensor,
+    token_ids: torch.Tensor,
+    num_logprobs: int,
+) -> LogprobsTensors | None:
+    """Return vLLM-compatible top-logprobs, or ``None`` on unsupported input."""
+
+    if triton is None:
+        return None
+    if logits.ndim != 2 or token_ids.ndim != 1:
+        return None
+    if not logits.is_cuda or not token_ids.is_cuda:
+        return None
+    if token_ids.dtype != torch.int64:
+        return None
+
+    batch_size, vocab_size = logits.shape
+    if token_ids.shape != (batch_size,):
+        return None
+    try:
+        block_vocab, blocks_per_row, num_warps, num_stages = _launch_config(
+            int(vocab_size),
+            int(num_logprobs),
+            int(batch_size),
+        )
+    except ValueError:
+        return None
+
+    output_token_ids = torch.empty(
+        (batch_size, num_logprobs + 1),
+        device=logits.device,
+        dtype=torch.int32,
+    )
+    output_logprobs = torch.empty(
+        (batch_size, num_logprobs + 1),
+        device=logits.device,
+        dtype=torch.float32,
+    )
+    output_ranks = torch.empty(
+        (batch_size,),
+        device=logits.device,
+        dtype=torch.int32,
+    )
+    partial_values = torch.empty(
+        (batch_size, blocks_per_row, num_logprobs),
+        device=logits.device,
+        dtype=torch.float32,
+    )
+    partial_tokens = torch.empty(
+        (batch_size, blocks_per_row, num_logprobs),
+        device=logits.device,
+        dtype=torch.int64,
+    )
+    partial_max = torch.empty(
+        (batch_size, blocks_per_row),
+        device=logits.device,
+        dtype=torch.float32,
+    )
+    partial_sum_exp = torch.empty_like(partial_max)
+    partial_ranks = torch.empty(
+        (batch_size, blocks_per_row),
+        device=logits.device,
+        dtype=torch.int32,
+    )
+
+    _top_logprobs_partial_kernel[(batch_size, blocks_per_row)](
+        logits,
+        token_ids,
+        partial_values,
+        partial_tokens,
+        partial_max,
+        partial_sum_exp,
+        partial_ranks,
+        VOCAB=int(vocab_size),
+        TOP_N=int(num_logprobs),
+        BLOCK_VOCAB=block_vocab,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+    _top_logprobs_reduce_kernel[(batch_size,)](
+        logits,
+        token_ids,
+        partial_values,
+        partial_tokens,
+        partial_max,
+        partial_sum_exp,
+        partial_ranks,
+        output_token_ids,
+        output_logprobs,
+        output_ranks,
+        VOCAB=int(vocab_size),
+        TOP_N=int(num_logprobs),
+        BLOCKS_PER_ROW=blocks_per_row,
+        REDUCE_BLOCK=_next_power_of_2(blocks_per_row),
+        CANDIDATE_BLOCK=_next_power_of_2(blocks_per_row * int(num_logprobs)),
+        num_warps=8,
+        num_stages=1,
+    )
+    return LogprobsTensors(output_token_ids, output_logprobs, output_ranks)
+
+
+if triton is not None:  # pragma: no cover - requires CUDA.
+
+    @triton.jit
+    def _top_logprobs_partial_kernel(
+        logits,
+        token_ids,
+        partial_values,
+        partial_tokens,
+        partial_max,
+        partial_sum_exp,
+        partial_ranks,
+        VOCAB: tl.constexpr,
+        TOP_N: tl.constexpr,
+        BLOCK_VOCAB: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        block = tl.program_id(1)
+        offsets = block * BLOCK_VOCAB + tl.arange(0, BLOCK_VOCAB)
+        mask = offsets < VOCAB
+        values = tl.load(
+            logits + row * VOCAB + offsets,
+            mask=mask,
+            other=-float("inf"),
+        ).to(tl.float32)
+
+        block_max = tl.max(values, axis=0)
+        exp_values = tl.exp(values - block_max)
+        block_sum = tl.sum(tl.where(mask, exp_values, 0.0), axis=0)
+        sampled_token = tl.load(token_ids + row).to(tl.int64)
+        sampled_value = tl.load(logits + row * VOCAB + sampled_token).to(tl.float32)
+        # Match batched_count_greater_than, which uses >= for rank.
+        rank_count = tl.sum(tl.where((values >= sampled_value) & mask, 1, 0), axis=0)
+
+        block_offset = row * tl.cdiv(VOCAB, BLOCK_VOCAB) + block
+        tl.store(partial_max + block_offset, block_max)
+        tl.store(partial_sum_exp + block_offset, block_sum)
+        tl.store(partial_ranks + block_offset, rank_count)
+
+        base = block_offset * TOP_N
+        for rank in tl.static_range(0, TOP_N):
+            max_value = tl.max(values, axis=0)
+            is_max = (values == max_value) & mask
+            token_values = tl.where(is_max, offsets, VOCAB)
+            token = tl.min(token_values, axis=0)
+            tl.store(partial_values + base + rank, max_value)
+            tl.store(partial_tokens + base + rank, token)
+            values = tl.where(offsets == token, -float("inf"), values)
+
+    @triton.jit
+    def _top_logprobs_reduce_kernel(
+        logits,
+        token_ids,
+        partial_values,
+        partial_tokens,
+        partial_max,
+        partial_sum_exp,
+        partial_ranks,
+        output_token_ids,
+        output_logprobs,
+        output_ranks,
+        VOCAB: tl.constexpr,
+        TOP_N: tl.constexpr,
+        BLOCKS_PER_ROW: tl.constexpr,
+        REDUCE_BLOCK: tl.constexpr,
+        CANDIDATE_BLOCK: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        block_offsets = tl.arange(0, REDUCE_BLOCK)
+        block_mask = block_offsets < BLOCKS_PER_ROW
+        block_max = tl.load(
+            partial_max + row * BLOCKS_PER_ROW + block_offsets,
+            mask=block_mask,
+            other=-float("inf"),
+        ).to(tl.float32)
+        block_sum = tl.load(
+            partial_sum_exp + row * BLOCKS_PER_ROW + block_offsets,
+            mask=block_mask,
+            other=0.0,
+        ).to(tl.float32)
+        global_max = tl.max(block_max, axis=0)
+        total_exp = tl.sum(
+            tl.where(block_mask, block_sum * tl.exp(block_max - global_max), 0.0),
+            axis=0,
+        )
+        log_denom = tl.log(total_exp) + global_max
+
+        rank_counts = tl.load(
+            partial_ranks + row * BLOCKS_PER_ROW + block_offsets,
+            mask=block_mask,
+            other=0,
+        )
+        sampled_rank = tl.sum(rank_counts, axis=0)
+        sampled_token = tl.load(token_ids + row).to(tl.int64)
+        sampled_value = tl.load(logits + row * VOCAB + sampled_token).to(tl.float32)
+
+        out_base = row * (TOP_N + 1)
+        tl.store(output_token_ids + out_base, sampled_token)
+        tl.store(output_logprobs + out_base, sampled_value - log_denom)
+        tl.store(output_ranks + row, sampled_rank)
+
+        candidate_offsets = tl.arange(0, CANDIDATE_BLOCK)
+        candidate_count = BLOCKS_PER_ROW * TOP_N
+        candidate_mask = candidate_offsets < candidate_count
+        values = tl.load(
+            partial_values + row * candidate_count + candidate_offsets,
+            mask=candidate_mask,
+            other=-float("inf"),
+        ).to(tl.float32)
+        tokens = tl.load(
+            partial_tokens + row * candidate_count + candidate_offsets,
+            mask=candidate_mask,
+            other=VOCAB,
+        )
+        for rank in tl.static_range(0, TOP_N):
+            max_value = tl.max(values, axis=0)
+            is_max = (values == max_value) & candidate_mask & (tokens < VOCAB)
+            token_values = tl.where(is_max, tokens, VOCAB)
+            token = tl.min(token_values, axis=0)
+            tl.store(output_token_ids + out_base + rank + 1, token)
+            tl.store(output_logprobs + out_base + rank + 1, max_value - log_denom)
+            values = tl.where(tokens == token, -float("inf"), values)

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -10,6 +10,10 @@ from vllm.utils.torch_utils import PIN_MEMORY
 from vllm.v1.outputs import LogprobsTensors, SamplerOutput
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.bad_words import apply_bad_words
+from vllm.v1.sample.ops.fused_top_logprobs import (
+    fused_top_logprobs,
+    fused_top_logprobs_enabled,
+)
 from vllm.v1.sample.ops.logprobs import batched_count_greater_than
 from vllm.v1.sample.ops.penalties import apply_all_penalties
 from vllm.v1.sample.ops.topk_topp_sampler import TopKTopPSampler
@@ -83,9 +87,15 @@ class Sampler(nn.Module):
         # is used for sampling (after penalties and temperature scaling).
         num_logprobs = sampling_metadata.max_num_logprobs
         raw_logprobs: torch.Tensor | None = None
+        raw_logits_for_fused_top_logprobs: torch.Tensor | None = None
         if num_logprobs is not None or sampling_metadata.logprob_token_ids:
             if logprobs_mode == "raw_logprobs":
-                raw_logprobs = self.compute_logprobs(logits)
+                if self._can_use_fused_top_logprobs(num_logprobs, sampling_metadata):
+                    raw_logits_for_fused_top_logprobs = (
+                        logits.clone() if logits.dtype == torch.float32 else logits
+                    )
+                else:
+                    raw_logprobs = self.compute_logprobs(logits)
             elif logprobs_mode == "raw_logits":
                 if logits.dtype == torch.float32:
                     raw_logprobs = logits.clone()
@@ -102,6 +112,7 @@ class Sampler(nn.Module):
         sampled, processed_logprobs = self.sample(logits, sampling_metadata)
         if processed_logprobs is not None:
             raw_logprobs = processed_logprobs
+            raw_logits_for_fused_top_logprobs = None
         # Convert sampled token ids to int64 (long) type to ensure compatibility
         # with subsequent operations that may use these values as indices.
         # This conversion is necessary because FlashInfer sampling operations
@@ -126,9 +137,22 @@ class Sampler(nn.Module):
             )
         else:
             # Gather the logprobs and ranks of the topk and sampled token.
-            logprobs_tensors = self.gather_logprobs(
-                raw_logprobs, num_logprobs, token_ids=sampled
-            )
+            logprobs_tensors = None
+            if raw_logits_for_fused_top_logprobs is not None:
+                logprobs_tensors = fused_top_logprobs(
+                    raw_logits_for_fused_top_logprobs,
+                    sampled,
+                    num_logprobs,
+                )
+            if logprobs_tensors is None:
+                if raw_logprobs is None:
+                    assert raw_logits_for_fused_top_logprobs is not None
+                    raw_logprobs = self.compute_logprobs(
+                        raw_logits_for_fused_top_logprobs
+                    )
+                logprobs_tensors = self.gather_logprobs(
+                    raw_logprobs, num_logprobs, token_ids=sampled
+                )
 
         # If we have both num_logprobs and logprob_token_ids, prefer
         # logprob_token_ids as it's more specific
@@ -147,6 +171,18 @@ class Sampler(nn.Module):
             logprobs_tensors=logprobs_tensors,
         )
         return sampler_output
+
+    @staticmethod
+    def _can_use_fused_top_logprobs(
+        num_logprobs: int | None,
+        sampling_metadata: SamplingMetadata,
+    ) -> bool:
+        return (
+            fused_top_logprobs_enabled()
+            and num_logprobs is not None
+            and num_logprobs != -1
+            and not sampling_metadata.logprob_token_ids
+        )
 
     def gather_specific_token_logprobs(
         self,


### PR DESCRIPTION
## What

Adds an opt-in V1 sampler path for generated-token top logprobs:

- `VLLM_ENABLE_FUSED_TOP_LOGPROBS=1` enables the new path.
- The path only applies to `raw_logprobs`, sampled-token logprobs, bounded `num_logprobs`, and no explicit `logprob_token_ids`.
- Unsupported inputs fall back to the existing `log_softmax + topk + gather` implementation.
- Default behavior is unchanged.

The fused CUDA/Triton helper computes the sampled-token logprob, selected-token rank, and top-N logprobs directly from logits without materializing a full `log_softmax(logits)` tensor.

## Why

For generated-token `logprobs`, the current V1 sampler materializes full-vocab logprobs before gathering top-N. On large vocabularies this adds a measurable decode tax even though most of the full matrix is discarded.

This PR is intentionally narrow: it does not change prompt logprobs, full-vocab logprobs, processed-logprobs modes, or explicit token-id logprobs.

## Evidence

External artifact repo: https://github.com/Kevin-Li-2025/single-gpu-inference-lab

A100 vLLM serving A/B, Qwen vocab 152064, `logprobs=20`, median-of-3 paired runs:

- c1: median ITL +0.96%, output tok/s +0.86%, p99 ITL -0.37%, median TTFT -11.43%
- c4: median ITL +1.15%, output tok/s +1.15%, p99 ITL +0.09%, median TTFT +1.04%
- c16: median ITL +1.17%, output tok/s +1.29%, p99 ITL +3.44%, median TTFT -0.90%

Conformance smoke against the native vLLM path:

- text match: true
- token sequence match: true
- token logprobs match: true
- top-logprobs key/value match: true
- max token-logprob diff: 1.1920928955078125e-06
- max top-logprob diff: 1.1920928955078125e-06

Kernel microbenchmark against the PyTorch compatibility path, A100 BF16, vocab 152064, `top_n=20`:

- batch 1: 2.16x
- batch 4: 2.56x
- batch 16: 2.31x

## Tests

- `ruff check vllm/v1/sample/ops/fused_top_logprobs.py vllm/v1/sample/sampler.py tests/v1/sample/test_fused_top_logprobs.py`
- `ruff format --check vllm/v1/sample/ops/fused_top_logprobs.py vllm/v1/sample/sampler.py tests/v1/sample/test_fused_top_logprobs.py`
- `python3 -m py_compile vllm/v1/sample/ops/fused_top_logprobs.py vllm/v1/sample/sampler.py tests/v1/sample/test_fused_top_logprobs.py`
- `git diff --check`

I could not run local pytest in this checkout because the local environment is missing the upstream test dependency `tblib` while importing `tests/conftest.py`.
