### PR TITLE
fix: aggressively zero speculator buffers to prevent CUDA illegal memory access on H100

### DIFF
--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -93,8 +93,10 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         self.last_token_indices.zero_()
         self.current_draft_step.zero_()
         self.hidden_states.zero_()
-        if getattr(self, "supports_mm_inputs", False) and hasattr(self, "inputs_embeds"):
-            getattr(self, "inputs_embeds").zero_()
+        if getattr(self, "supports_mm_inputs", False) and hasattr(
+            self, "inputs_embeds"
+        ):
+            self.inputs_embeds.zero_()
         self.idx_mapping.zero_()
         self.temperature.zero_()
         self.seeds.zero_()

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -91,6 +91,16 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         # Reset indices to zeros to prevent stale values from prior
         # dummy runs to cause out-of-bounds indexing during capture.
         self.last_token_indices.zero_()
+        self.current_draft_step.zero_()
+        self.hidden_states.zero_()
+        if getattr(self, "supports_mm_inputs", False) and hasattr(self, "inputs_embeds"):
+            getattr(self, "inputs_embeds").zero_()
+        self.idx_mapping.zero_()
+        self.temperature.zero_()
+        self.seeds.zero_()
+        self.draft_tokens.zero_()
+        if self.draft_logits is not None:
+            self.draft_logits.zero_()
 
         # Capture the prefill routine (model forward + compute_logits +
         # sample).

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -149,7 +149,19 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         # Reset indices to zeros to prevent stale values from prior
         # dummy runs to cause out-of-bounds indexing during capture.
         self.last_token_indices.zero_()
+        self.current_draft_step.zero_()
+        self.hidden_states.zero_()
+        if (
+            getattr(self, "supports_mm_inputs", False)
+            and self.inputs_embeds is not None
+        ):
+            self.inputs_embeds.zero_()
         self.idx_mapping.zero_()
+        self.temperature.zero_()
+        self.seeds.zero_()
+        self.draft_tokens.zero_()
+        if self.draft_logits is not None:
+            self.draft_logits.zero_()
 
         # Capture the prefill routine (model forward + compute_logits +
         # sample).


### PR DESCRIPTION
Fixes #47561.
Root Cause: When running vLLM speculative decoding on H100s with quantized models (e.g. w8a8_fp8), the system was crashing with a CUDA illegal memory access exclusively during the speculator's prefill CUDA graph capture.

During vLLM's warmup phase prior to graph capture, a "dummy run" eagerly executes the speculator (propose()). This leaves the AutoRegressiveSpeculator's internal state buffers (hidden_states, draft_tokens, draft_logits, idx_mapping, current_draft_step, etc.) populated with values specific to the dummy run's final execution steps. Because the prefill/decode captures operated on this stale state, the dynamic shape calculations inside _prefill were thrown out of bounds. Furthermore, the TMA descriptors (used in Hopper FP8 kernels) are extremely sensitive to uninitialized/stale data (like NaN scale factors or unaligned shape inferences), causing hard segfaults when fed this stale state.

Solution: This PR introduces a robust fix that deterministically zeroes out all of the AutoRegressiveSpeculator buffers inside capture() immediately before the CUDA graphs are recorded.

By aggressively running .zero_() on last_token_indices, current_draft_step, hidden_states, inputs_embeds, idx_mapping, temperature, seeds, draft_tokens, and draft_logits, we guarantee that each CUDA graph capture step executes against a pristine, zero-initialized state. This definitively prevents the Hopper architecture from crashing due to stale bounds, NaNs, or out-of-bounds embedding lookups.