### PR TITLE
[Bugfix][Frontend] Preserve default sampling params in batch chat

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -1000,8 +1000,8 @@ class BatchChatCompletionRequest(OpenAIBaseModel):
     response_format: Any | None = None
     seed: int | None = Field(None, ge=_INT64_MIN, le=_INT64_MAX)
     stop: str | list[str] | None = Field(default_factory=list)
-    temperature: float | None = 0.7
-    top_p: float | None = 1.0
+    temperature: float | None = None
+    top_p: float | None = None
     user: str | None = None
     tool_choice: Literal["none"] | None = "none"
     include_reasoning: bool = True
@@ -1010,8 +1010,8 @@ class BatchChatCompletionRequest(OpenAIBaseModel):
     best_of: int | None = None
     use_beam_search: bool = False
     top_k: int | None = None
-    min_p: float | None = 0.0
-    repetition_penalty: float | None = 1.0
+    min_p: float | None = None
+    repetition_penalty: float | None = None
     length_penalty: float | None = 1.0
     early_stopping: bool = False
     structured_outputs: StructuredOutputsParams | None = None
@@ -1059,8 +1059,6 @@ class BatchChatCompletionRequest(OpenAIBaseModel):
         self, messages: list[ChatCompletionMessageParam]
     ) -> ChatCompletionRequest:
         """Build a single-conversation ChatCompletionRequest from one conversation."""
-        data = self.model_dump(
-            exclude={"messages"}, exclude_none=True, exclude_unset=True
-        )
+        data = self.model_dump(exclude={"messages"}, exclude_none=True)
         data["messages"] = messages
         return ChatCompletionRequest.model_validate(data)

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -1059,6 +1059,8 @@ class BatchChatCompletionRequest(OpenAIBaseModel):
         self, messages: list[ChatCompletionMessageParam]
     ) -> ChatCompletionRequest:
         """Build a single-conversation ChatCompletionRequest from one conversation."""
-        data = self.model_dump(exclude={"messages"}, exclude_none=True)
+        data = self.model_dump(
+            exclude={"messages"}, exclude_none=True, exclude_unset=True
+        )
         data["messages"] = messages
         return ChatCompletionRequest.model_validate(data)


### PR DESCRIPTION

## Purpose

`/v1/chat/completions/batch` converts each conversation into a `ChatCompletionRequest`, but the conversion currently dumps Pydantic defaults too. A batch request that omits sampling params still forwards `temperature=0.7`, `top_p=1.0`, `min_p=0.0`, and `repetition_penalty=1.0`, so it silently overrides model or server default sampling params that a normal `/v1/chat/completions` request would use.

This keeps only fields explicitly set on the batch request when building the per-conversation request. Explicit sampling params still override defaults.

I checked existing batch-chat work. #38011 introduced the endpoint, #47384 fixes batch logprob token rendering, and #42105 covers Gemma4 reasoning parser adjustment. None covers omitted sampling params overriding `default_sampling_params`.

## Test Plan

I ran a real `vllm serve` E2E twice with `Qwen3-0.6B` and server default sampling params set via `--override-generation-config`. The script first checks out the parent version of `protocol.py`, sends normal chat and batch chat HTTP requests that omit sampling params, then restores this PR and sends the same requests again. It reads the server's `--enable-log-requests` output to compare the actual `SamplingParams` passed into the engine.

## Test Result

On main, normal chat uses the server defaults, while batch chat falls back to the request model defaults. With this PR, both endpoints use the same server defaults.

<details>
<summary>repro and checks</summary>

Environment:

```text
commit before: 26eb87204d58d9d8a25c378fbaec9da23db3fb85
commit after: 81ce3901b0e0db6b5fbd8ae212fa8e658f1f82c8
model: /root/autodl-tmp/models/Qwen3-0.6B
GPU: RTX 4090
```

Run command:

```bash
ROOT=/root/autodl-tmp/code/vllm-30-codex \
PYTHON=/root/autodl-tmp/conda_envs/vllm/bin/python \
MODEL=/root/autodl-tmp/models/Qwen3-0.6B \
bash repro/run_batch_sampling_defaults_e2e.sh
```

`repro/run_batch_sampling_defaults_e2e.sh`:

```bash
#!/usr/bin/env bash
set -euo pipefail

ROOT=${ROOT:-/root/autodl-tmp/code/vllm-30-codex}
PYTHON=${PYTHON:-/root/autodl-tmp/conda_envs/vllm/bin/python}
MODEL=${MODEL:-/root/autodl-tmp/models/Qwen3-0.6B}
PORT=${PORT:-8030}
LOG_DIR=${LOG_DIR:-/root/autodl-tmp/logs/vllm-pr30}
SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)

mkdir -p "$LOG_DIR"
cd "$ROOT"

SERVER_PID=""

stop_server() {
  if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
    kill "$SERVER_PID" 2>/dev/null || true
    wait "$SERVER_PID" 2>/dev/null || true
  fi
  SERVER_PID=""
}

wait_for_server() {
  local base_url=$1
  for _ in $(seq 1 180); do
    if curl -fsS "$base_url/health" >/dev/null 2>&1; then
      return 0
    fi
    sleep 1
  done
  return 1
}

run_case() {
  local label=$1
  local expect=$2
  local log_file="$LOG_DIR/${label}.log"
  local base_url="http://127.0.0.1:${PORT}"

  rm -f "$log_file"
  VLLM_USE_FLASHINFER_SAMPLER=0 \
    VLLM_ATTENTION_BACKEND=FLASH_ATTN \
    VLLM_LOGGING_LEVEL=INFO \
    PYTHONPATH="$ROOT" \
    "$PYTHON" -m vllm.entrypoints.openai.api_server \
      --host 127.0.0.1 \
      --port "$PORT" \
      --model "$MODEL" \
      --served-model-name qwen \
      --max-model-len 1024 \
      --gpu-memory-utilization 0.35 \
      --enforce-eager \
      --generation-config vllm \
      --override-generation-config \
        '{"temperature":0.2,"top_p":0.5,"min_p":0.2,"repetition_penalty":1.3}' \
      --enable-log-requests \
      --disable-log-stats \
      >"$log_file" 2>&1 &
  SERVER_PID=$!

  if ! wait_for_server "$base_url"; then
    tail -200 "$log_file" >&2 || true
    return 1
  fi

  "$PYTHON" "$SCRIPT_DIR/check_batch_sampling_defaults.py" \
    --base-url "$base_url" \
    --log "$log_file" \
    --label "$label" \
    --expect "$expect"

  stop_server
}

trap 'stop_server; git checkout HEAD -- vllm/entrypoints/openai/chat_completion/protocol.py' EXIT

git checkout HEAD^ -- vllm/entrypoints/openai/chat_completion/protocol.py
run_case before buggy

git checkout HEAD -- vllm/entrypoints/openai/chat_completion/protocol.py
run_case after fixed
```

`repro/check_batch_sampling_defaults.py`:

```python
from __future__ import annotations

import argparse
import re
import time
from pathlib import Path

import requests


EXPECTED_DEFAULTS = {
    "temperature": 0.2,
    "top_p": 0.5,
    "min_p": 0.2,
    "repetition_penalty": 1.3,
}
BUGGY_BATCH_DEFAULTS = {
    "temperature": 0.7,
    "top_p": 1.0,
    "min_p": 0.0,
    "repetition_penalty": 1.0,
}
FIELDS = tuple(EXPECTED_DEFAULTS)


def post_json(base_url: str, path: str, request_id: str, payload: dict) -> None:
    response = requests.post(
        f"{base_url}{path}",
        headers={"X-Request-Id": request_id},
        json=payload,
        timeout=60,
    )
    response.raise_for_status()


def extract_logged_params(log_path: Path, request_id: str) -> dict[str, float]:
    pattern = re.compile(rf"Received request {re.escape(request_id)}: params: (.*)")
    deadline = time.time() + 30
    while time.time() < deadline:
        text = log_path.read_text(errors="replace") if log_path.exists() else ""
        match = pattern.search(text)
        if match:
            params = match.group(1)
            return {
                field: float(
                    re.search(  # type: ignore[union-attr]
                        rf"{field}=([^,\)]+)", params
                    ).group(1)
                )
                for field in FIELDS
            }
        time.sleep(0.5)
    raise AssertionError(f"missing request log for {request_id}")


def main() -> None:
    parser = argparse.ArgumentParser()
    parser.add_argument("--base-url", required=True)
    parser.add_argument("--log", type=Path, required=True)
    parser.add_argument("--label", required=True)
    parser.add_argument("--expect", choices=("buggy", "fixed"), required=True)
    args = parser.parse_args()

    direct_id = f"pr30-{args.label}-direct"
    batch_id = f"pr30-{args.label}-batch"
    messages = [{"role": "user", "content": "Reply with one short word."}]

    post_json(
        args.base_url,
        "/v1/chat/completions",
        direct_id,
        {"model": "qwen", "messages": messages, "max_tokens": 1},
    )
    post_json(
        args.base_url,
        "/v1/chat/completions/batch",
        batch_id,
        {"model": "qwen", "messages": [messages], "max_tokens": 1},
    )

    direct = extract_logged_params(args.log, f"chatcmpl-{direct_id}")
    batch = extract_logged_params(args.log, f"chatcmpl-{batch_id}_0")
    print(f"{args.label} direct {direct}")
    print(f"{args.label} batch  {batch}")

    assert direct == EXPECTED_DEFAULTS
    expected_batch = (
        BUGGY_BATCH_DEFAULTS if args.expect == "buggy" else EXPECTED_DEFAULTS
    )
    assert batch == expected_batch


if __name__ == "__main__":
    main()
```

Output:

```text
before direct {'temperature': 0.2, 'top_p': 0.5, 'min_p': 0.2, 'repetition_penalty': 1.3}
before batch  {'temperature': 0.7, 'top_p': 1.0, 'min_p': 0.0, 'repetition_penalty': 1.0}
after direct {'temperature': 0.2, 'top_p': 0.5, 'min_p': 0.2, 'repetition_penalty': 1.3}
after batch  {'temperature': 0.2, 'top_p': 0.5, 'min_p': 0.2, 'repetition_penalty': 1.3}
```

Lint and format:

```text
ruff check vllm/entrypoints/openai/chat_completion/protocol.py
All checks passed!

ruff format --check vllm/entrypoints/openai/chat_completion/protocol.py
1 file already formatted
```

</details>

AI assistance was used to prepare this PR.

cc @DarkLight1337
