### PR TITLE
[Bugfix][Frontend] Report named Anthropic tool calls as tool_use

### DIFF
--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -632,7 +632,9 @@ class AnthropicServingMessages(OpenAIServingChat):
             kv_transfer_params=generator.kv_transfer_params,
         )
         choice = generator.choices[0]
-        if choice.finish_reason == "stop":
+        if choice.finish_reason == "stop" and choice.message.tool_calls:
+            result.stop_reason = "tool_use"
+        elif choice.finish_reason == "stop":
             result.stop_reason = "end_turn"
         elif choice.finish_reason == "length":
             result.stop_reason = "max_tokens"
@@ -717,6 +719,7 @@ class AnthropicServingMessages(OpenAIServingChat):
 
             first_item = True
             finish_reason = None
+            tool_use_started = False
             state = _ActiveBlockState()
             # Map from tool call index to tool_use_id
             tool_index_to_id: dict[int, str] = {}
@@ -832,8 +835,10 @@ class AnthropicServingMessages(OpenAIServingChat):
                         if len(origin_chunk.choices) == 0:
                             for event in stop_and_flush():
                                 yield event
-                            stop_reason = self.stop_reason_map.get(
-                                finish_reason or "stop"
+                            stop_reason = (
+                                "tool_use"
+                                if finish_reason == "stop" and tool_use_started
+                                else self.stop_reason_map.get(finish_reason or "stop")
                             )
                             chunk = AnthropicStreamEvent(
                                 type="message_delta",
@@ -935,6 +940,7 @@ class AnthropicServingMessages(OpenAIServingChat):
                                     ):
                                         for event in stop_and_flush():
                                             yield event
+                                        tool_use_started = True
                                         start_event = start_block(
                                             AnthropicContentBlock(
                                                 type="tool_use",


### PR DESCRIPTION

## Purpose

Anthropic `/v1/messages` named tool choice can return a `tool_use` content block while the top-level response says `stop_reason="end_turn"`. Clients that follow the Anthropic contract can treat the response as a normal assistant turn and skip executing the tool.

The OpenAI chat backend keeps `finish_reason="stop"` for named function calling. The Anthropic adapter used only that field, so it lost the fact that the converted message already contains tool calls. This maps named-tool responses with tool calls to `tool_use` in non-streaming responses and records whether streaming has emitted a tool block before writing the final message delta.

No existing PR appears to cover this Anthropic named-tool `stop_reason` mismatch. #25054 covers OpenAI Chat `finish_reason`, #45807 covers Anthropic `stop_sequence`, and #46344 covers Kimi tool-call IDs.

## Test Plan

I ran a real `/v1/messages` server repro with local `Qwen3-0.6B`, `tool_choice={"type":"tool","name":"get_weather"}`, and `--tool-call-parser qwen3_coder`, then reran the same request after the fix. I checked both non-streaming and `stream=true`, and kept the diff to the Anthropic adapter.

## Test Result

The same HTTP request changed from `content[0].type="tool_use"` with `stop_reason="end_turn"` on main to `stop_reason="tool_use"` after the fix. The `stream=true` response had the same flip in its final `message_delta`.

<details>
<summary>End-to-end reproduction</summary>

Environment:

```text
vLLM commit: 26eb87204d58
GPU: NVIDIA GeForce RTX 4090, 24564 MiB
Python: 3.12.13
Torch: 2.11.0+cu130
CUDA: 13.0
Model: /root/autodl-tmp/models/Qwen3-0.6B
Served model name: qwen
```

Server:

```bash
PYTHONPATH=$PWD \
VLLM_USE_FLASHINFER_SAMPLER=0 \
VLLM_ATTENTION_BACKEND=FLASH_ATTN \
python -m vllm.entrypoints.openai.api_server \
  --host 127.0.0.1 \
  --port 18031 \
  --model /root/autodl-tmp/models/Qwen3-0.6B \
  --served-model-name qwen \
  --enable-auto-tool-choice \
  --tool-call-parser qwen3_coder \
  --enforce-eager \
  --max-model-len 1024 \
  --gpu-memory-utilization 0.25
```

Request:

```bash
curl -sS http://127.0.0.1:18031/v1/messages \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "qwen",
    "max_tokens": 64,
    "temperature": 0,
    "messages": [
      {
        "role": "user",
        "content": "What is the weather in Paris? Use the tool."
      }
    ],
    "tools": [
      {
        "name": "get_weather",
        "description": "Get the weather in a city",
        "input_schema": {
          "type": "object",
          "properties": {
            "city": {
              "type": "string"
            }
          },
          "required": ["city"]
        },
        "strict": true
      }
    ],
    "tool_choice": {
      "type": "tool",
      "name": "get_weather"
    }
  }'
```

Before:

```json
{
  "content": [
    {
      "type": "tool_use",
      "id": "chatcmpl-tool-a327d7a7aad83589",
      "name": "get_weather",
      "input": {
        "city": "Paris"
      }
    }
  ],
  "stop_reason": "end_turn",
  "usage": {
    "input_tokens": 162,
    "output_tokens": 23
  }
}
```

After:

```json
{
  "content": [
    {
      "type": "tool_use",
      "id": "chatcmpl-tool-8b840b2e112503b9",
      "name": "get_weather",
      "input": {
        "city": "Paris"
      }
    }
  ],
  "stop_reason": "tool_use",
  "usage": {
    "input_tokens": 162,
    "output_tokens": 23
  }
}
```

Streaming final delta:

```text
before: event=message_delta, stop_reason=end_turn
after:  event=message_delta, stop_reason=tool_use
```

</details>

<details>
<summary>Local checks</summary>

```text
pytest -q tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
53 passed

ruff check vllm/entrypoints/anthropic/serving.py
All checks passed!

ruff format --check vllm/entrypoints/anthropic/serving.py
1 file already formatted

git diff --check
```

</details>

AI assistance was used to prepare this PR.

cc @DarkLight1337
