### PR TITLE
Revert "[Frontend] Limit `SO_REUSEPORT` to multi-worker serving" (#47529)

### DIFF
--- a/vllm/entrypoints/cli/launch.py
+++ b/vllm/entrypoints/cli/launch.py
@@ -120,7 +120,7 @@ async def run_launch_fastapi(args: argparse.Namespace) -> None:
     signal.signal(signal.SIGTERM, _interrupt_init)
 
     # 1. Socket binding
-    listen_address, sock = setup_server(args, reuse_port=False)
+    listen_address, sock = setup_server(args)
 
     # 2. Build and serve the API server
     engine_args = AsyncEngineArgs.from_cli_args(args)

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -281,7 +281,7 @@ def run_multi_api_server(args: argparse.Namespace):
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
 
-    listen_address, sock = setup_server(args, reuse_port=num_api_servers > 1)
+    listen_address, sock = setup_server(args)
 
     engine_args = vllm.AsyncEngineArgs.from_cli_args(args)
     engine_args._api_process_count = num_api_servers

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -508,19 +508,14 @@ async def init_render_app_state(
     state.server_load_metrics = 0
 
 
-def create_server_socket(
-    addr: tuple[str, int],
-    *,
-    reuse_port: bool,
-) -> socket.socket:
+def create_server_socket(addr: tuple[str, int]) -> socket.socket:
     family = socket.AF_INET
     if is_valid_ipv6_address(addr[0]):
         family = socket.AF_INET6
 
     sock = socket.socket(family=family, type=socket.SOCK_STREAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    if reuse_port:
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
     sock.bind(addr)
 
     return sock
@@ -551,7 +546,7 @@ def validate_api_server_args(args):
 
 
 @instrument(span_name="API server setup")
-def setup_server(args, *, reuse_port: bool):
+def setup_server(args):
     """Validate API server args and create the server socket."""
 
     log_version_and_model(logger, VLLM_VERSION, args.model)
@@ -572,7 +567,7 @@ def setup_server(args, *, reuse_port: bool):
         sock = create_server_unix_socket(args.uds)
     else:
         sock_addr = (args.host or "", args.port)
-        sock = create_server_socket(sock_addr, reuse_port=reuse_port)
+        sock = create_server_socket(sock_addr)
 
     # workaround to avoid footguns where uvicorn drops requests with too
     # many concurrent requests active
@@ -693,7 +688,7 @@ async def run_server(args, **uvicorn_kwargs) -> None:
 
     signal.signal(signal.SIGTERM, _interrupt_init)
 
-    listen_address, sock = setup_server(args, reuse_port=False)
+    listen_address, sock = setup_server(args)
     await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)
 
 


### PR DESCRIPTION
## Revert of https://github.com/vllm-project/vllm/pull/47529

This reverts commit ab3b6d97aa02af45b96607042d75eedefd1e122e.

**Reason:** This PR is linked to 1 new CI failure in build [#76308](https://buildkite.com/vllm/ci/builds/76308):
- `Entrypoints Integration (API Server OpenAI - Part 2)` — shutdown test `test_wait_timeout_with_short_duration` failed with process not exiting within 18s after SIGTERM

The PR changed `serve.py`, `launch.py`, and `api_server.py`, which are directly related to server shutdown behavior.

---
*Auto-generated by CI failure analyzer*