### PR TITLE
[bugfix] fix MOSS-Audio deepstack_input_embeds initialization in PP

### DIFF
--- a/vllm/model_executor/models/moss_audio.py
+++ b/vllm/model_executor/models/moss_audio.py
@@ -862,6 +862,10 @@ class MossQwen3ForCausalLM(Qwen3ForCausalLM):
             batch_size, dtype, device
         )
         for layer_idx in self.deepstack_inject_layer_indices:
+            # Non-first PP ranks only receive DeepStack payloads for layers
+            # at or after their local start layer.
+            if layer_idx < self.model.start_layer:
+                continue
             intermediate_tensors[f"deepstack_input_embeds_{layer_idx}"] = torch.zeros(
                 (batch_size, self.config.hidden_size),
                 dtype=dtype,


### PR DESCRIPTION



## Purpose
After PR #44443, all dense models use ModelRunnerV2 as default and so does MOSS-Audio. And will run into below errors:
```
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000] WorkerProc hit an exception.
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000] Traceback (most recent call last):
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 992, in worker_busy_loop
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]     output = func(*args, **kwargs)
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]              ^^^^^^^^^^^^^^^^^^^^^
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]   File "/usr/local/lib/python3.12/dist-packages/vllm/tracing/otel.py", line 178, in sync_wrapper
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]     return func(*args, **kwargs)
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_worker.py", line 737, in compile_or_warm_up_model
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]     warmup_kernels(self.model_runner, self.execute_model, self.sample_tokens)
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]     return func(*args, **kwargs)
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu/warmup.py", line 231, in warmup_kernels
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]     worker_execute_model(prefill_output)
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]     return func(*args, **kwargs)
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_worker.py", line 898, in execute_model
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]     output = self.model_runner.execute_model(
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]     return func(*args, **kwargs)
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu/model_runner.py", line 1249, in execute_model
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]     else v[:n].copy_(intermediate_tensors.tensors[k][:n])
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000]                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
(Worker_PP1 pid=2198) ERROR 07-04 15:42:17 [multiproc_executor.py:1000] KeyError: 'deepstack_input_embeds_0'

```
## Test Plan
verified on L20.
`pytest -s -v tests/models/multimodal/generation/test_moss_audio.py::test_moss_audio_parallel_smoke[pp2]` 

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

