### PR TITLE
[Bugfix][TurboQuant] Preserve KV cache dtype in backend shape

### DIFF
--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -25,6 +25,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
     KVQuantMode,
     MambaSpec,
+    TQFullAttentionSpec,
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.worker.gpu.model_states.interface import ModelSpecificAttnMetadata
@@ -307,6 +308,7 @@ def _reshape_kv_cache(
                 layer_cache_dtype = (
                     "auto"
                     if kv_cache_spec.kv_quant_mode == KVQuantMode.NONE
+                    and not isinstance(kv_cache_spec, TQFullAttentionSpec)
                     else cache_dtype
                 )
                 kv_cache_shape = group.backend.get_kv_cache_shape(
@@ -391,7 +393,10 @@ def _update_hybrid_attention_layout(
         # (quantization only changes the last dim), so this is a no-op today,
         # but it keeps both call sites consistent for skip layers.
         layer_cache_dtype = (
-            "auto" if kv_cache_spec.kv_quant_mode == KVQuantMode.NONE else cache_dtype
+            "auto"
+            if kv_cache_spec.kv_quant_mode == KVQuantMode.NONE
+            and not isinstance(kv_cache_spec, TQFullAttentionSpec)
+            else cache_dtype
         )
         block_dim = group.backend.get_kv_cache_block_dim(
             kernel_block_sizes[group.kv_cache_group_id],


### PR DESCRIPTION
## Summary

Fix TurboQuant KV cache shape setup so `TQFullAttentionSpec` carries its real cache dtype (for example `turboquant_k8v4`) into backend shape/layout computation instead of being treated as `auto`.

This prevents TurboQuant backends from seeing `auto` and failing with an unknown TurboQuant cache dtype during startup.

## CI Failure

This fixes the Buildkite **LM Eval TurboQuant KV Cache** failure from build [#76302](https://buildkite.com/vllm/ci/builds/76302#019f2b69-d26d-40c6-bb56-20ebdb745006).

The failing command was:

```bash
pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=evals/gsm8k/configs/models-turboquant.txt
```

The first failing case was:

```text
evals/gsm8k/test_gsm8k_correctness.py::test_gsm8k_correctness[Qwen3-4B-TQ-k8v4]
```

The server was launched with `--kv-cache-dtype turboquant_k8v4` and failed during engine startup with:

```text
ValueError: Unknown TurboQuant cache dtype: 'auto'. Valid presets: turboquant_k8v4, turboquant_4bit_nc, turboquant_k3v4_nc, turboquant_3bit_nc
```

## Regression Source

This was introduced by #42890 (`67ff0ae30fe6b1ab1a912e10977d99ddb169c4b2`). That PR changed the v1 KV cache reshape path to pass `cache_dtype_str="auto"` whenever `kv_cache_spec.kv_quant_mode == KVQuantMode.NONE`, so skipped layers keep an unquantized shape.

TurboQuant cache dtypes currently map to `KVQuantMode.NONE`, while their `TQFullAttentionSpec` still needs the `turboquant_*` dtype string for backend shape selection. As a result, #42890 made TurboQuant specs enter the unquantized/`auto` path.

## Tests

```bash
pre-commit run  # via git commit --amend hooks
```

Passed on the amended production-only commit.

```bash
CUDA_VISIBLE_DEVICES=4 .venv/bin/python -m pytest -q tests/evals/gsm8k/test_gsm8k_correctness.py --config-list-file=/tmp/vllm-tq-main-fix.A6mzsf/config.txt
```

## AI Assistance

This draft PR was prepared with AI assistance. The human submitter has reviewed.