### PR TITLE
[Bugfix][DeepSeek V4] Avoid SM100 FlashMLA cache shape mismatch

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -761,8 +761,9 @@ def _select_dsv4_attn_cls(vllm_config: VllmConfig) -> type[DeepseekV4Attention]:
 
     The generic CUDA backend selector does not instantiate DSv4 layers directly,
     so map generic sparse-MLA choices to the DSv4-specialized attention class.
-    Without an explicit backend, SM12 defaults to FlashInfer while the other
-    CUDA arches keep the FlashMLA path.
+    Without an explicit backend, SM12 defaults to FlashInfer. SM10x also uses
+    FlashInfer for plain FP8 KV cache because the FlashMLA sparse kernel only
+    accepts the older 656-byte row layout, not DeepSeek V4's 584-byte row.
     """
     backend = vllm_config.attention_config.backend
     device_capability = current_platform.get_device_capability()
@@ -785,6 +786,13 @@ def _select_dsv4_attn_cls(vllm_config: VllmConfig) -> type[DeepseekV4Attention]:
     ):
         return DeepseekV4FlashMLAAttention
 
+    cache_dtype = vllm_config.cache_config.cache_dtype
+    if (
+        device_capability is not None
+        and device_capability.major == 10
+        and cache_dtype in ("fp8", "fp8_e4m3", "fp8_e5m2")
+    ):
+        return DeepseekV4FlashInferMLAAttention
     if device_capability is not None and device_capability.major == 12:
         return DeepseekV4FlashInferSM120Attention
     return DeepseekV4FlashMLAAttention


### PR DESCRIPTION
## Summary

Fix the DeepSeek V4 SM100 plain-FP8 startup path by defaulting it to the DeepSeek V4 FlashInfer MLA backend instead of the native FlashMLA sparse backend.

The native FlashMLA sparse op still expects the older row layout (`num_blocks, page_block_size, h_kv, bytes_per_token`). DeepSeek V4 plain FP8 now uses the `fp8_ds_mla` row shape, so the default SM10 path can trip the native op shape check. This keeps explicit `FLASHMLA_SPARSE_DSV4` behavior unchanged and only changes the default SM10 plain-FP8 selection.

## CI Failure

Seen in Buildkite PR #44455 build #76302, `MoE Refactor Integration Test (B200 - TEMPORARY)`:

https://buildkite.com/vllm/ci/builds/76302#019f2b69-d26d-485c-b925-5c374d55e0d3

Failing command:

```bash
pytest -s -v evals/gsm8k/test_gsm8k_correctness.py \
  --config-list-file=evals/gsm8k/configs/moe-refactor/config-b200.txt
```

Failing case:

```text
test_gsm8k_correctness[DeepSeek-V4-Flash-deepgemm-mega-moe]
```

The server launched `deepseek-ai/DeepSeek-V4-Flash` with `--kv-cache-dtype fp8`, TP=2, `deep_gemm_mega_moe`, and MTP. It selected DeepSeek's `fp8_ds_mla` KV cache format, then failed in FlashMLA sparse decode with:

```text
RuntimeError: kv must have shape (num_blocks, page_block_size, h_kv, bytes_per_token)
```

## Regression Source

This failure was exposed by #44455's KV-cache layout refactor for DeepSeek V4: the default SM10 path still selected the native FlashMLA sparse backend, while the cache row shape moved to the DeepSeek V4 `fp8_ds_mla` format.

## Tests

No new tests are added in this PR.

Commit hooks passed while amending the surgical one-file diff:

```text
ruff check, ruff format, typos, mypy-3.10, SPDX, root lazy imports,
forbidden imports, torch.cuda API check, config defaults, attention backend docs
```

Selector sanity check passed:

```bash
.venv/bin/python - <<'PY'
from types import SimpleNamespace
import vllm.models.deepseek_v4.nvidia.model as m
from vllm.platforms.interface import DeviceCapability
from vllm.v1.attention.backends.registry import AttentionBackendEnum

orig = m.current_platform.get_device_capability
try:
    m.current_platform.get_device_capability = lambda: DeviceCapability(10, 0)
    cfg = SimpleNamespace(
        attention_config=SimpleNamespace(backend=None),
        cache_config=SimpleNamespace(cache_dtype="fp8"),
    )
    assert m._select_dsv4_attn_cls(cfg).__name__ == "DeepseekV4FlashInferMLAAttention"
    cfg.attention_config.backend = AttentionBackendEnum.FLASHMLA_SPARSE_DSV4
    assert m._select_dsv4_attn_cls(cfg).__name__ == "DeepseekV4FlashMLAAttention"
finally:
    m.current_platform.get_device_capability = orig
PY
```

An earlier version of this branch with the same selector change also passed a one-question DeepSeek V4 GSM8K startup/e2e smoke locally; before the selector change, that smoke reached FlashMLA sparse decode and failed with the same `kv must have shape` error.

## AI Assistance

This draft PR was prepared with AI assistance. Reviewed by the submitter.
