### PR TITLE
[Bugfix][MoE] Handle older FlashInfer FP8 MoE signatures

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import functools
+import inspect
+
 import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
@@ -31,6 +34,40 @@ from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer_trtllm_fused_moe
 
 logger = init_logger(__name__)
+
+
+@functools.cache
+def _flashinfer_moe_supports_swiglu_params(fn_name: str) -> bool:
+    try:
+        import flashinfer
+
+        fn = getattr(flashinfer.fused_moe, fn_name)
+        return "gemm1_alpha" in inspect.signature(fn).parameters
+    except (TypeError, ValueError):
+        # If FlashInfer stops exposing an inspectable Python signature, keep
+        # passing the parameters so an incompatible install fails explicitly.
+        return True
+
+
+def _add_swiglu_params_if_supported(
+    kwargs: dict[str, object],
+    fn_name: str,
+    gemm1_alpha: torch.Tensor | None,
+    gemm1_beta: torch.Tensor | None,
+    gemm1_clamp_limit: torch.Tensor | None,
+) -> None:
+    swiglu_params = {
+        "gemm1_alpha": gemm1_alpha,
+        "gemm1_beta": gemm1_beta,
+        "gemm1_clamp_limit": gemm1_clamp_limit,
+    }
+    if _flashinfer_moe_supports_swiglu_params(fn_name):
+        kwargs.update(swiglu_params)
+    elif any(param is not None for param in swiglu_params.values()):
+        raise RuntimeError(
+            "The installed FlashInfer TRTLLM FP8 MoE kernel does not support "
+            "per-expert SwiGLU parameters. Please upgrade FlashInfer."
+        )
 
 
 class TrtLlmFp8ExpertsBase:
@@ -224,16 +261,13 @@ class TrtLlmFp8ExpertsModular(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsModular):
             weight_layout = WeightLayout.BlockMajorK
             hidden_states_scale = a1q_scale.t().contiguous()
 
-        flashinfer.fused_moe.trtllm_fp8_block_scale_routed_moe(
+        kwargs = dict(
             topk_ids=packed_topk_ids,
             routing_bias=None,
             hidden_states=hidden_states,
             hidden_states_scale=hidden_states_scale,
             gemm1_weights=w1,
             gemm1_weights_scale=self.quant_config.w1_scale,
-            gemm1_alpha=self.gemm1_alpha,
-            gemm1_beta=self.gemm1_beta,
-            gemm1_clamp_limit=self.gemm1_clamp_limit,
             gemm2_weights=w2,
             gemm2_weights_scale=self.quant_config.w2_scale,
             num_experts=global_num_experts,
@@ -250,6 +284,14 @@ class TrtLlmFp8ExpertsModular(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsModular):
             fp8_quantization_type=fp8_quant_type,
             output=output,
         )
+        _add_swiglu_params_if_supported(
+            kwargs,
+            "trtllm_fp8_block_scale_routed_moe",
+            self.gemm1_alpha,
+            self.gemm1_beta,
+            self.gemm1_clamp_limit,
+        )
+        flashinfer.fused_moe.trtllm_fp8_block_scale_routed_moe(**kwargs)
 
 
 class TrtLlmFp8ExpertsMonolithic(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsMonolithic):
@@ -402,9 +444,6 @@ class TrtLlmFp8ExpertsMonolithic(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsMonolit
             hidden_states_scale=hidden_states_scale,
             gemm1_weights=w1,
             gemm1_weights_scale=self.quant_config.w1_scale,
-            gemm1_alpha=self.gemm1_alpha,
-            gemm1_beta=self.gemm1_beta,
-            gemm1_clamp_limit=self.gemm1_clamp_limit,
             gemm2_weights=w2,
             gemm2_weights_scale=self.quant_config.w2_scale,
             num_experts=global_num_experts,
@@ -422,6 +461,13 @@ class TrtLlmFp8ExpertsMonolithic(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsMonolit
         )
         if is_mxfp8 or activation == MoEActivation.RELU2_NO_MUL:
             kwargs["activation_type"] = activation_type
+        _add_swiglu_params_if_supported(
+            kwargs,
+            "trtllm_fp8_block_scale_moe",
+            self.gemm1_alpha,
+            self.gemm1_beta,
+            self.gemm1_clamp_limit,
+        )
         return flashinfer.fused_moe.trtllm_fp8_block_scale_moe(**kwargs)
 
     def _apply_per_tensor(


### PR DESCRIPTION
## Summary

Handle installed FlashInfer builds whose TRTLLM FP8 MoE Python signatures do not accept the optional `gemm1_alpha`, `gemm1_beta`, and `gemm1_clamp_limit` kwargs.

The wrapper now checks the FlashInfer function signature and:

- passes the SwiGLU params when the installed FlashInfer supports them;
- omits them for older FlashInfer when all params are `None`;
- raises a clear error if non-default SwiGLU params are required but the installed FlashInfer cannot accept them.

This keeps newer FlashInfer behavior intact while avoiding startup failures on older wheels. No new tests are added in this PR.

## CI Failure

This is the narrower alternative to the draft auto-revert in #47431, which links #45723 to two new nightly CI failures in Buildkite build #75919:

https://buildkite.com/vllm/ci/builds/75919

Reported failures:

- `LM Eval Humming (H100 - TEMPORARY)`: `gpt-oss-20b-humming-act-fp8` scored 0.0 accuracy, expected >= 0.22.
- `MoE Refactor Integration Test (B200 DP - TEMPORARY)`: four Qwen3-30B FP8/FP4 MoE configs failed with server startup timeout.

Local reproduction on the current installed FlashInfer showed the direct compatibility symptom:

```text
TypeError: trtllm_fp8_block_scale_moe() got an unexpected keyword argument 'gemm1_alpha'
```

## Regression Source

This was introduced by #45723, merged as `fa248139a0206b3e39780296e3f056a978957f63`, which began passing `gemm1_alpha`, `gemm1_beta`, and `gemm1_clamp_limit` unconditionally to FlashInfer TRTLLM FP8 MoE APIs.

## Duplicate-work Check

I checked for overlapping open PRs before opening this draft:

```bash
gh pr list --repo vllm-project/vllm --state open --search "FlashInfer TRTLLM FP8 MoE gemm1_alpha signature" --json number,title,state,url,createdAt,headRefName --limit 20
gh pr list --repo vllm-project/vllm --state open --search "gemm1_alpha beta clamp_limit TRT-LLM FP8 MoE" --json number,title,state,url,createdAt,headRefName --limit 20
gh pr view 47431 --repo vllm-project/vllm --json number,title,state,isDraft,url,createdAt,headRefName
```

There is a related draft auto-revert, #47431, which reverts #45723 wholesale. This draft is intentionally narrower: it keeps the new SwiGLU parameter support for compatible FlashInfer installs and only drops the kwargs when the local FlashInfer signature cannot accept them.

## Tests

```bash
.venv/bin/pre-commit run ruff-check --files \
  vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
.venv/bin/pre-commit run ruff-format --files \
  vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
```

Passed.

Inline compatibility sanity check passed:

```bash
.venv/bin/python - <<'PY'
import torch
from vllm.model_executor.layers.fused_moe.experts import trtllm_fp8_moe as moe

orig = moe._flashinfer_moe_supports_swiglu_params
try:
    moe._flashinfer_moe_supports_swiglu_params = lambda fn_name: False
    kwargs = {}
    moe._add_swiglu_params_if_supported(
        kwargs, "trtllm_fp8_block_scale_moe", None, None, None
    )
    assert kwargs == {}
    try:
        moe._add_swiglu_params_if_supported(
            {}, "trtllm_fp8_block_scale_moe", torch.tensor([1.0]), None, None
        )
    except RuntimeError:
        pass
    else:
        raise AssertionError("expected RuntimeError for non-default params")

    moe._flashinfer_moe_supports_swiglu_params = lambda fn_name: True
    kwargs = {}
    moe._add_swiglu_params_if_supported(
        kwargs, "trtllm_fp8_block_scale_moe", None, None, None
    )
    assert set(kwargs) == {"gemm1_alpha", "gemm1_beta", "gemm1_clamp_limit"}
finally:
    moe._flashinfer_moe_supports_swiglu_params = orig
PY
```

Earlier local e2e reproduction for the affected Qwen3 FP8 FlashInfer path also passed with this compatibility logic:

```bash
CUDA_VISIBLE_DEVICES=0,1 HF_HUB_CACHE=/home/LucasWilkinson/.cache/huggingface/hub VLLM_WORKER_MULTIPROC_METHOD=spawn \
  .venv/bin/python -m pytest -q -s 'tests/compile/fusions_e2e/test_tp2_ar_rms.py::test_tp2_ar_rms_fp8_fusions[inductor_partition-+quant_fp8,-rms_norm-4-FLASHINFER-Qwen/Qwen3-30B-A3B-FP8-<lambda>-model_kwargs2-<lambda>]'
```

## AI Assistance

This draft PR was prepared with AI assistance. The human submitter should review every changed line and rerun/validate the relevant tests before marking it ready.
