### PR TITLE
[Bugfix][Tool Parser] llama4_pythonic: accept JSON tool calls in streaming and non-streaming

### DIFF
--- a/tests/tool_parsers/test_llama4_pythonic_tool_parser.py
+++ b/tests/tool_parsers/test_llama4_pythonic_tool_parser.py
@@ -62,6 +62,34 @@ PYTHON_TAG_FUNCTION_OUTPUT = (
     "<|python_start|>[get_weather(city='LA', metric='C')]<|python_end|>"
 )
 
+# Some Llama-4 checkpoints (e.g. served with the Llama-3.1 JSON chat template
+# rather than the pythonic one) emit tool calls as JSON instead of the
+# pythonic form this parser otherwise expects. See issue #46863.
+JSON_FUNCTION_OUTPUT = (
+    '{"type": "function", "name": "Bash", '
+    '"parameters": {"command": "echo hello", "timeout": 120000, '
+    '"run_in_background": false}}'
+)
+JSON_FUNCTION_CALL = FunctionCall(
+    name="Bash",
+    arguments='{"command": "echo hello", "timeout": 120000, '
+    '"run_in_background": false}',
+)
+JSON_ARGUMENTS_KEY_OUTPUT = (
+    '{"name": "get_weather", "arguments": {"city": "LA", "metric": "C"}}'
+)
+JSON_PARALLEL_FUNCTION_OUTPUT = (
+    '{"name": "get_weather", "parameters": {"city": "LA", "metric": "C"}}, '
+    '{"name": "register_user", "parameters": {"name": "Doe", "age": 9}}'
+)
+JSON_ARRAY_FUNCTION_OUTPUT = (
+    '[{"name": "get_weather", "parameters": {"city": "LA", "metric": "C"}}, '
+    '{"name": "register_user", "parameters": {"name": "Doe", "age": 9}}]'
+)
+REGISTER_USER_FUNCTION_CALL = FunctionCall(
+    name="register_user", arguments='{"name": "Doe", "age": 9}'
+)
+
 
 @pytest.mark.parametrize("streaming", [True, False])
 def test_no_tool_call(streaming: bool, default_tokenizer: TokenizerLike):
@@ -200,6 +228,46 @@ TEST_CASES = [
         ],
         id="parallel_calls_nonstreaming",
     ),
+    pytest.param(True, JSON_FUNCTION_OUTPUT, [JSON_FUNCTION_CALL], id="json_streaming"),
+    pytest.param(
+        False, JSON_FUNCTION_OUTPUT, [JSON_FUNCTION_CALL], id="json_nonstreaming"
+    ),
+    pytest.param(
+        True,
+        JSON_ARGUMENTS_KEY_OUTPUT,
+        [SIMPLE_FUNCTION_CALL],
+        id="json_arguments_key_streaming",
+    ),
+    pytest.param(
+        False,
+        JSON_ARGUMENTS_KEY_OUTPUT,
+        [SIMPLE_FUNCTION_CALL],
+        id="json_arguments_key_nonstreaming",
+    ),
+    pytest.param(
+        True,
+        JSON_PARALLEL_FUNCTION_OUTPUT,
+        [SIMPLE_FUNCTION_CALL, REGISTER_USER_FUNCTION_CALL],
+        id="json_parallel_streaming",
+    ),
+    pytest.param(
+        False,
+        JSON_PARALLEL_FUNCTION_OUTPUT,
+        [SIMPLE_FUNCTION_CALL, REGISTER_USER_FUNCTION_CALL],
+        id="json_parallel_nonstreaming",
+    ),
+    pytest.param(
+        True,
+        JSON_ARRAY_FUNCTION_OUTPUT,
+        [SIMPLE_FUNCTION_CALL, REGISTER_USER_FUNCTION_CALL],
+        id="json_array_streaming",
+    ),
+    pytest.param(
+        False,
+        JSON_ARRAY_FUNCTION_OUTPUT,
+        [SIMPLE_FUNCTION_CALL, REGISTER_USER_FUNCTION_CALL],
+        id="json_array_nonstreaming",
+    ),
 ]
 
 
@@ -243,6 +311,63 @@ def test_streaming_tool_call_with_large_steps(default_tokenizer: TokenizerLike):
     assert reconstructor.tool_calls[0].function == SIMPLE_FUNCTION_CALL
     assert reconstructor.tool_calls[1].function == PARAMETERLESS_FUNCTION_CALL
     assert reconstructor.tool_calls[2].function == EMPTY_LIST_FUNCTION_CALL
+
+
+@pytest.mark.parametrize(
+    "model_output",
+    [
+        # Plain JSON that happens to have a "name" field must not be
+        # mistaken for a tool call.
+        '{"answer": 42, "note": "not a tool call"}',
+        '{"name": "Alice", "age": 30}',
+        # Malformed / truncated JSON must fall through as content rather
+        # than dropping the tail.
+        '{"name": "a", "parameters": {}}, {"name":',
+        '[{"name": "a", "parameters": {}}',
+        # A valid tool call followed by trailing prose is not a clean
+        # payload, so the whole thing stays as content.
+        '{"name": "get_weather", "parameters": {"city": "LA"}} then text',
+        # Dangling / trailing commas are invalid JSON.
+        '{"name": "a", "parameters": {}},',
+        '[{"name": "a", "parameters": {}},]',
+    ],
+)
+def test_json_non_tool_content(model_output: str, default_tokenizer: TokenizerLike):
+    """JSON that isn't a clean tool-call payload must pass through as
+    content instead of being misread as (or losing part of it to) a tool
+    call."""
+    tool_parser: ToolParser = ToolParserManager.get_tool_parser("llama4_pythonic")(
+        default_tokenizer
+    )
+
+    content, tool_calls = run_tool_extraction(
+        tool_parser, model_output, streaming=False
+    )
+
+    assert content == model_output
+    assert len(tool_calls) == 0
+
+
+@pytest.mark.parametrize(
+    "model_output",
+    [
+        '{"answer": 42, "note": "not a tool call"}',
+        '{"name": "Alice", "age": 30}',
+    ],
+)
+def test_json_streaming_never_fabricates_tool_call(
+    model_output: str, default_tokenizer: TokenizerLike
+):
+    """Streamed JSON that isn't a tool call must never be reported as one,
+    even though (unlike the non-streaming path) the parser can't always
+    recover it as content once it has committed to parsing it as JSON."""
+    tool_parser: ToolParser = ToolParserManager.get_tool_parser("llama4_pythonic")(
+        default_tokenizer
+    )
+
+    _, tool_calls = run_tool_extraction(tool_parser, model_output, streaming=True)
+
+    assert len(tool_calls) == 0
 
 
 @pytest.mark.parametrize("streaming", [False])

--- a/vllm/tool_parsers/llama4_pythonic_tool_parser.py
+++ b/vllm/tool_parsers/llama4_pythonic_tool_parser.py
@@ -2,18 +2,26 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import ast
+import json
 from collections.abc import Sequence
 
+import partial_json_parser
 import regex as re
+from partial_json_parser.core.options import Allow
 from transformers import PreTrainedTokenizerBase
 
 import vllm.envs as envs
+from vllm.entrypoints.chat_utils import make_tool_call_id
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
 )
 from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
     DeltaMessage,
+    DeltaToolCall,
     ExtractedToolCallInformation,
+    FunctionCall,
+    ToolCall,
 )
 from vllm.logger import init_logger
 from vllm.tool_parsers.abstract_tool_parser import (
@@ -23,8 +31,11 @@ from vllm.tool_parsers.abstract_tool_parser import (
 from vllm.tool_parsers.utils import (
     UnexpectedAstError,
     compute_tool_delta,
+    find_common_prefix,
     handle_single_tool,
+    is_complete_json,
     make_valid_python,
+    partial_json_loads,
 )
 
 logger = init_logger(__name__)
@@ -92,6 +103,16 @@ class Llama4PythonicToolParser(ToolParser):
             )
 
         if not is_tool_call_pattern:
+            # Some Llama-4 checkpoints (e.g. served with the Llama-3.1 JSON
+            # chat template rather than the pythonic one) emit tool calls as
+            # JSON instead of the pythonic form this parser otherwise expects
+            # (see issue #46863). Fall back to a conservative JSON parse
+            # before giving up on the response.
+            json_tool_calls = self._extract_json_tool_calls(model_output)
+            if json_tool_calls is not None:
+                return ExtractedToolCallInformation(
+                    tools_called=True, tool_calls=json_tool_calls, content=None
+                )
             return ExtractedToolCallInformation(
                 tools_called=False, tool_calls=[], content=model_output
             )
@@ -119,6 +140,60 @@ class Llama4PythonicToolParser(ToolParser):
                 tools_called=False, tool_calls=[], content=model_output
             )
 
+    @staticmethod
+    def _json_obj_to_tool_call(obj: object) -> ToolCall | None:
+        """Build a ToolCall from a single JSON object, or None if it doesn't
+        look like one. A tool call needs a non-empty string ``name`` plus a
+        dict of ``arguments`` or ``parameters``; requiring the args key keeps
+        ordinary JSON content that merely has a ``name`` field (e.g.
+        ``{"name": "Alice", "age": 30}``) from being mistaken for a call."""
+        if not isinstance(obj, dict):
+            return None
+        name = obj.get("name")
+        if not isinstance(name, str) or not name:
+            return None
+        if "arguments" in obj:
+            arguments = obj["arguments"]
+        elif "parameters" in obj:
+            arguments = obj["parameters"]
+        else:
+            return None
+        if not isinstance(arguments, dict):
+            return None
+        return ToolCall(
+            type="function",
+            function=FunctionCall(
+                name=name, arguments=json.dumps(arguments, ensure_ascii=False)
+            ),
+        )
+
+    @classmethod
+    def _extract_json_tool_calls(cls, model_output: str) -> list[ToolCall] | None:
+        """Best-effort JSON fallback for a complete response: accepts a
+        single JSON object, several comma-separated objects, or a JSON array
+        of objects. The whole response must parse as one clean tool-call
+        payload; anything else (malformed JSON, trailing prose, an ordinary
+        JSON object with no ``name``/args) is left for the caller to treat as
+        plain content, mirroring how the pythonic branch above requires
+        ``ast.parse`` to consume the entire response."""
+        if "{" not in model_output:
+            return None
+        stripped = model_output.strip()
+        candidate = stripped if stripped.startswith("[") else f"[{stripped}]"
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(parsed, list) or not parsed:
+            return None
+        tool_calls: list[ToolCall] = []
+        for obj in parsed:
+            tool_call = cls._json_obj_to_tool_call(obj)
+            if tool_call is None:
+                return None
+            tool_calls.append(tool_call)
+        return tool_calls
+
     def extract_tool_calls_streaming(
         self,
         previous_text: str,
@@ -129,10 +204,27 @@ class Llama4PythonicToolParser(ToolParser):
         delta_token_ids: Sequence[int],
         request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
-        if not current_text.startswith("[") and not current_text.startswith(
-            "<|python_start|>"
+        has_python_tag = current_text.startswith("<|python_start|>")
+        if (
+            not has_python_tag
+            and not current_text.startswith("[")
+            and not current_text.startswith("{")
         ):
             return DeltaMessage(content=delta_text)
+
+        # Some Llama-4 checkpoints emit JSON tool calls instead of the
+        # pythonic form (see issue #46863). A bare JSON object is
+        # unambiguous; a leading "[" is ambiguous between a pythonic call
+        # list and a JSON array of tool calls, so peek at what follows the
+        # bracket once enough text has arrived to tell the two apart.
+        text_after_tag = (
+            current_text[len("<|python_start|>") :] if has_python_tag else current_text
+        )
+        is_json = text_after_tag.startswith("{")
+        if not is_json and text_after_tag.startswith("["):
+            is_json = text_after_tag[1:].lstrip().startswith("{")
+        if is_json:
+            return self._extract_json_tool_calls_streaming(text_after_tag)
 
         try:
             # remove <|python_start|> and <|python_end|>
@@ -208,6 +300,148 @@ class Llama4PythonicToolParser(ToolParser):
                 return None
         except Exception:
             logger.exception("Error trying to handle streaming tool call.")
+            logger.debug(
+                "Skipping chunk as a result of tool streaming extraction error"
+            )
+            return None
+
+    def _extract_json_tool_calls_streaming(self, text: str) -> DeltaMessage | None:
+        """Streaming counterpart to ``_extract_json_tool_calls``.
+
+        Incrementally parses one or more JSON tool-call objects (bare,
+        comma-separated, or wrapped in an array) out of the growing ``text``
+        and emits deltas the same way Llama3JsonToolParser streams the JSON
+        tool calls it recognizes: the function name first, then argument
+        characters as they become available.
+        """
+        try:
+            if text.endswith("<|python_end|>"):
+                text = text[: text.rfind("<|python_end|>")]
+            text = text.strip()
+            if text.startswith("["):
+                text = text[1:]
+                if text.endswith("]"):
+                    text = text[:-1]
+
+            # Only hand out a partially streamed string once the function
+            # name has already been sent; the API only ever streams a
+            # complete name.
+            flags = Allow.ALL if self.current_tool_name_sent else Allow.ALL & ~Allow.STR
+
+            tool_call_arr: list[dict] = []
+            is_complete: list[bool] = []
+            idx = 0
+            try:
+                while idx < len(text):
+                    while idx < len(text) and text[idx] in " \t\r\n,":
+                        idx += 1
+                    if idx >= len(text):
+                        break
+                    obj, end = partial_json_loads(text[idx:], flags)
+                    if not isinstance(obj, dict):
+                        return None
+                    is_complete.append(is_complete_json(text[idx : idx + end]))
+                    idx += end
+                    if "parameters" in obj and "arguments" not in obj:
+                        obj["arguments"] = obj["parameters"]
+                    tool_call_arr.append(obj)
+            except partial_json_parser.core.exceptions.MalformedJSON:
+                logger.debug("not enough tokens to parse JSON tool call yet")
+                return None
+
+            if not tool_call_arr:
+                return None
+
+            current_tool_call = tool_call_arr[self.current_tool_id]
+
+            # Starting a new tool in the array: flush whatever arguments were
+            # auto-completed for the previous one but never streamed, then
+            # move the cursor on.
+            if len(tool_call_arr) > self.current_tool_id + 1:
+                delta = None
+                if self.current_tool_id >= 0:
+                    cur_arguments = current_tool_call.get("arguments")
+                    if cur_arguments:
+                        cur_args_json = json.dumps(cur_arguments, ensure_ascii=False)
+                        sent = len(self.streamed_args_for_tool[self.current_tool_id])
+                        flush_diff = cur_args_json[sent:]
+                        delta = DeltaMessage(
+                            tool_calls=[
+                                DeltaToolCall(
+                                    index=self.current_tool_id,
+                                    function=DeltaFunctionCall(arguments=flush_diff),
+                                )
+                            ]
+                        )
+                        self.streamed_args_for_tool[self.current_tool_id] += flush_diff
+                self.current_tool_id = len(tool_call_arr) - 1
+                self.current_tool_name_sent = False
+                # Usually a single new tool call surfaces per delta, but pad
+                # up to the cursor in case a single large delta completed
+                # more than one at once.
+                while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                    self.streamed_args_for_tool.append("")
+                return delta
+
+            if not self.current_tool_name_sent:
+                function_name = current_tool_call.get("name")
+                has_args_key = (
+                    "arguments" in current_tool_call
+                    or "parameters" in current_tool_call
+                )
+                # Wait for both the name and an arguments/parameters key
+                # before committing to a tool call, so an ordinary JSON
+                # object that merely has a "name" field (e.g. {"name":
+                # "Alice", "age": 30}) is never reported as one.
+                if not function_name or not has_args_key:
+                    return None
+                self.current_tool_name_sent = True
+                self.prev_tool_call_arr = tool_call_arr
+                return DeltaMessage(
+                    tool_calls=[
+                        DeltaToolCall(
+                            index=self.current_tool_id,
+                            type="function",
+                            id=make_tool_call_id(),
+                            function=DeltaFunctionCall(name=function_name),
+                        )
+                    ]
+                )
+
+            delta = None
+            cur_arguments = current_tool_call.get("arguments")
+            if cur_arguments:
+                sent = len(self.streamed_args_for_tool[self.current_tool_id])
+                cur_args_json = json.dumps(cur_arguments, ensure_ascii=False)
+                prev_arguments = self.prev_tool_call_arr[self.current_tool_id].get(
+                    "arguments"
+                )
+
+                argument_diff: str | None = None
+                if is_complete[self.current_tool_id]:
+                    argument_diff = cur_args_json[sent:]
+                elif prev_arguments:
+                    prev_args_json = json.dumps(prev_arguments, ensure_ascii=False)
+                    if cur_args_json != prev_args_json:
+                        argument_diff = find_common_prefix(
+                            prev_args_json, cur_args_json
+                        )[sent:]
+
+                if argument_diff:
+                    delta = DeltaMessage(
+                        tool_calls=[
+                            DeltaToolCall(
+                                index=self.current_tool_id,
+                                function=DeltaFunctionCall(arguments=argument_diff),
+                            )
+                        ]
+                    )
+                    self.streamed_args_for_tool[self.current_tool_id] += argument_diff
+
+            self.prev_tool_call_arr = tool_call_arr
+            return delta
+        except Exception:
+            logger.exception("Error trying to handle streaming JSON tool call.")
             logger.debug(
                 "Skipping chunk as a result of tool streaming extraction error"
             )


### PR DESCRIPTION
## Purpose

Fixes #46863.

Some Llama-4 checkpoints (e.g. served with the Llama-3.1 JSON chat template) emit tool calls as JSON, like `{"type": "function", "name": "Bash", "parameters": {...}}`, instead of the pythonic form `llama4_pythonic` expects. Those responses were left verbatim in `content` in both the non-streaming and streaming paths.

This adds a conservative JSON fallback to both `extract_tool_calls()` and `extract_tool_calls_streaming()`. It accepts a single JSON object, comma-separated objects, or a JSON array, reading arguments from either `arguments` or `parameters`. Malformed JSON, trailing prose, or an ordinary JSON object that merely has a `name` field still pass through unchanged as content.

#46890 already covers the non-streaming path with a different, more involved hand-rolled scanner; its own description says streaming is left for a follow-up. This PR covers both paths. The non-streaming half here is written independently (wraps the response in `[...]` and uses `json.loads`, so the stdlib enforces JSON grammar instead of a custom character-scanning state machine). The streaming half reuses vLLM's own existing JSON-tool-call streaming pattern already shipped for `Llama3JsonToolParser` in llama_tool_parser.py, adapted for comma/bracket-joined objects instead of semicolon-joined ones, plus a guard that requires both a name and an arguments/parameters key before committing to a tool call in streaming (found during testing that porting the pattern naively would fabricate a bogus call from something like `{"name": "Alice", "age": 30}`).

AI assistance was used for parts of this change.

## Test Plan

- Added streaming and non-streaming Llama 4 JSON tool-call cases (bare object, `arguments` key, comma-separated parallel calls, array-wrapped calls) to the existing parametrized test_tool_call cases.
- Added non-streaming pass-through tests for non-tool JSON, malformed JSON, trailing prose, and dangling commas.
- Added streaming tests asserting non-tool JSON is never reported as a fabricated tool call.

## Test Result

- `PYTHONPATH=$PWD python -m pytest tests/tool_parsers/test_llama4_pythonic_tool_parser.py -v --confcutdir tests/tool_parsers` - 39 passed
- `pre-commit run --files vllm/tool_parsers/llama4_pythonic_tool_parser.py tests/tool_parsers/test_llama4_pythonic_tool_parser.py` - all hooks passed
