### PR TITLE
[Bugfix][Spec Decode] Trim token_ids/logprobs left past a stop string under speculative decoding

### DIFF
--- a/tests/detokenizer/test_stop_string_while_stop_model_terminates.py
+++ b/tests/detokenizer/test_stop_string_while_stop_model_terminates.py
@@ -84,7 +84,7 @@ def test_stop_string_while_stop_token_terminates(include_stop_str_in_output: boo
     # Simulate that the last token ('Z') is a stop token (stop_terminated=True).
     result = detok.update(new_token_ids=token_ids, stop_terminated=True)
 
-    # The update should not report a stop string
+    # The update should report the matched stop string.
     assert result == stop_string
 
     # Output text should reflect stop-string handling:
@@ -99,3 +99,22 @@ def test_stop_string_while_stop_token_terminates(include_stop_str_in_output: boo
     # get_next_output_text should return the full text when finished=True.
     # (Buffering only applies during streaming when finished=False.)
     assert detok.get_next_output_text(finished=True, delta=False) == expected_text
+
+
+def test_stop_string_trims_speculative_overflow(include_stop_str_in_output: bool):
+    token_ids = [ord(c) for c in "abcdef"]
+    stop_string = "cd"
+    expected_token_ids = [ord(c) for c in "abcd"]
+
+    req = _make_request(
+        stop=[stop_string], include_stop_str_in_output=include_stop_str_in_output
+    )
+    detok = _DummyDetokenizer(req)
+
+    result = detok.update(new_token_ids=token_ids, stop_terminated=False)
+
+    assert result == stop_string
+    expected_text = "abcd" if include_stop_str_in_output else "ab"
+    assert detok.output_text == expected_text
+    assert detok.output_token_ids == expected_token_ids
+    assert detok.num_stop_overflow_tokens == 2

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -30,6 +30,7 @@ INVALID_PREFIX_ERR_MSG = "Invalid prefix encountered"
 class IncrementalDetokenizer:
     def __init__(self):
         self.token_ids: list[int] = []
+        self.num_stop_overflow_tokens = 0
 
     @property
     def output_token_ids(self) -> list[int]:
@@ -114,7 +115,10 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
 
         # 1) Detokenize the new token ids incrementally.
         stop_check_offset = len(self.output_text)
+        first_new_token_index = len(self.token_ids)
+        token_start_offsets: list[int] = []
         for new_token_id in new_token_ids:
+            token_start_offsets.append(len(self.output_text))
             self.token_ids.append(new_token_id)
             self.output_text += self.decode_next(new_token_id)
             # Support min_tokens, see https://github.com/vllm-project/vllm/pull/22014
@@ -127,6 +131,7 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
 
         # 2) Evaluate stop strings.
         stop_string = None
+        self.num_stop_overflow_tokens = 0
         if self.stop and self.num_output_tokens() > self.min_tokens:
             stop = check_stop_strings(
                 output_text=self.output_text,
@@ -138,6 +143,20 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
                 stop_string, truncate_to = stop
                 if truncate_to != -1:
                     self.output_text = self.output_text[:truncate_to]
+                if not stop_terminated:
+                    # Stop strings can land in the middle of a speculative
+                    # batch; stop-token termination keeps existing semantics.
+                    stop_end = len(self.output_text)
+                    if not self.include_stop_str_in_output:
+                        stop_end += len(stop_string)
+                    keep = first_new_token_index
+                    for start in token_start_offsets:
+                        if start >= stop_end:
+                            break
+                        keep += 1
+                    self.num_stop_overflow_tokens = len(self.token_ids) - keep
+                    if self.num_stop_overflow_tokens:
+                        del self.token_ids[keep:]
 
         return stop_string
 

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -642,6 +642,15 @@ class OutputProcessor:
                 if stop_string:
                     finish_reason = FinishReason.STOP
                     stop_reason = stop_string
+                    # Mirror detokenizer trimming on delta outputs and logprobs.
+                    num_overflow_tokens = req_state.detokenizer.num_stop_overflow_tokens
+                    if num_overflow_tokens:
+                        keep = len(new_token_ids) - num_overflow_tokens
+                        del new_token_ids[keep:]
+                        if engine_core_output.new_logprobs is not None:
+                            engine_core_output.new_logprobs = (
+                                engine_core_output.new_logprobs.slice_request(0, keep)
+                            )
 
                 # 3) Compute sample and prompt logprobs for request,
                 # if required.


### PR DESCRIPTION

## Purpose

With `ngram` speculative decoding, a single decode step can accept several tokens at once. When a stop string completes in the middle of that accepted batch, V1 truncates `output_text` to the stop boundary but leaves the tokens generated after the stop in `RequestOutput.outputs[0].token_ids`. When logprobs are requested, those past-stop token logprobs are returned as well.

The root cause is that incremental detokenization appends the whole accepted token batch before stop-string evaluation. The stop-string helper returns a character truncation point, so text gets trimmed but the token ids and per-step logprobs are not mapped back to the stop boundary.

This records the text start offset for each newly accepted token, drops tokens whose text starts after the matched stop string, and propagates the dropped-token count so the per-step `new_token_ids` and `new_logprobs` are trimmed consistently for streaming, non-streaming, and logprobs outputs. It only applies when EngineCore has not already ended the step on a stop token, preserving the existing stop-token termination behavior.

## Test Plan

I ran a real `LLM(...)` reproduction with `Qwen/Qwen3-0.6B`, `ngram` speculative decoding, `temperature=0`, `stop=[" ha ha ha"]`, and `logprobs=2`. The upstream main check reproduces the leak because the speculative path returns six generated token ids and six logprobs while the non-spec baseline returns three; this branch passes with both paths returning three.

I also ran the focused detokenizer regression file, the existing min-tokens detokenizer file, and scoped pre-commit hooks for the three changed Python files.

## Test Result

The real-engine reproduction shows the baseline/spec mismatch on main and `PASS fixed behavior` on this branch. In the failing main run, both `include_stop_str_in_output` modes return correct text and `finish_reason="stop"`, but the speculative output leaks `[6386, 6386, 6386]` past the stop boundary.

<details>
<summary>End-to-end reproduction</summary>

Hardware: one NVIDIA RTX 4090. Model: `Qwen/Qwen3-0.6B` cached locally at `/root/autodl-tmp/models/Qwen3-0.6B`. Settings: `VLLM_USE_FLASHINFER_SAMPLER=0`, `enforce_eager=True`, `temperature=0`, `stop=[" ha ha ha"]`, `include_stop_str_in_output` tested both ways, `logprobs=2`, `ngram` speculative config `{"method": "ngram", "num_speculative_tokens": 6, "prompt_lookup_min": 1, "prompt_lookup_max": 4}`.

`sd_stop_boundary_probe.py`:

```python
import argparse
import gc
import json
import os

import torch

os.environ.setdefault("VLLM_LOGGING_LEVEL", "ERROR")
os.environ.setdefault("VLLM_NO_USAGE_STATS", "1")

from vllm import LLM, SamplingParams


PROMPT = "ha ha ha ha ha ha ha ha"
STOP = " ha ha ha"


def build_llm(model: str, speculative: bool) -> LLM:
    spec = None
    if speculative:
        spec = {
            "method": "ngram",
            "num_speculative_tokens": 6,
            "prompt_lookup_min": 1,
            "prompt_lookup_max": 4,
        }
    return LLM(
        model=model,
        max_model_len=2048,
        max_num_seqs=4,
        max_num_batched_tokens=256,
        gpu_memory_utilization=0.25,
        enforce_eager=True,
        speculative_config=spec,
    )


def cleanup_llm(llm: LLM) -> None:
    del llm
    gc.collect()
    torch.accelerator.empty_cache()


def run_case(llm: LLM, include_stop: bool, logprobs: int | None) -> dict:
    params = SamplingParams(
        temperature=0,
        max_tokens=16,
        stop=[STOP],
        include_stop_str_in_output=include_stop,
        skip_special_tokens=False,
        logprobs=logprobs,
    )
    output = llm.generate([PROMPT], params, use_tqdm=False)[0].outputs[0]
    result = {
        "text": output.text,
        "token_ids": list(output.token_ids),
        "finish_reason": output.finish_reason,
        "stop_reason": output.stop_reason,
    }
    if logprobs is not None:
        result["logprobs_len"] = len(output.logprobs or [])
    return result


def main() -> int:
    parser = argparse.ArgumentParser()
    parser.add_argument("--model", required=True)
    parser.add_argument("--expect", choices=["match", "leak"], required=True)
    parser.add_argument("--logprobs", type=int, default=None)
    args = parser.parse_args()

    baseline = build_llm(args.model, speculative=False)
    baseline_rows = {
        mode: run_case(baseline, mode == "include", args.logprobs)
        for mode in ("exclude", "include")
    }
    cleanup_llm(baseline)

    speculative = build_llm(args.model, speculative=True)
    spec_rows = {
        mode: run_case(speculative, mode == "include", args.logprobs)
        for mode in ("exclude", "include")
    }
    cleanup_llm(speculative)

    payload = {"baseline": baseline_rows, "spec": spec_rows}
    print(json.dumps(payload, indent=2))

    matches = all(
        spec_rows[mode]["token_ids"] == baseline_rows[mode]["token_ids"]
        for mode in ("exclude", "include")
    )
    logprobs_match = True
    if args.logprobs is not None:
        logprobs_match = all(
            spec_rows[mode]["logprobs_len"]
            == baseline_rows[mode]["logprobs_len"]
            == len(spec_rows[mode]["token_ids"])
            for mode in ("exclude", "include")
        )

    if args.expect == "match" and matches and logprobs_match:
        print("PASS fixed behavior")
        return 0
    if args.expect == "leak" and not matches:
        print("PASS leak reproduced")
        return 0

    print(
        "FAIL",
        json.dumps(
            {
                "expect": args.expect,
                "token_ids_match": matches,
                "logprobs_match": logprobs_match,
            },
            indent=2,
        ),
    )
    return 1


if __name__ == "__main__":
    raise SystemExit(main())
```

Command:

```bash
export PYTHONPATH=$PWD
export VLLM_USE_FLASHINFER_SAMPLER=0
python sd_stop_boundary_probe.py \
  --model /root/autodl-tmp/models/Qwen3-0.6B \
  --expect match \
  --logprobs 2 \
  2>probe.stderr
```

Output on this branch:

```text
{
  "baseline": {
    "exclude": {
      "text": "",
      "token_ids": [
        6386,
        6386,
        6386
      ],
      "finish_reason": "stop",
      "stop_reason": " ha ha ha",
      "logprobs_len": 3
    },
    "include": {
      "text": " ha ha ha",
      "token_ids": [
        6386,
        6386,
        6386
      ],
      "finish_reason": "stop",
      "stop_reason": " ha ha ha",
      "logprobs_len": 3
    }
  },
  "spec": {
    "exclude": {
      "text": "",
      "token_ids": [
        6386,
        6386,
        6386
      ],
      "finish_reason": "stop",
      "stop_reason": " ha ha ha",
      "logprobs_len": 3
    },
    "include": {
      "text": " ha ha ha",
      "token_ids": [
        6386,
        6386,
        6386
      ],
      "finish_reason": "stop",
      "stop_reason": " ha ha ha",
      "logprobs_len": 3
    }
  }
}
PASS fixed behavior
```

Output on upstream main with `--expect leak`:

```text
{
  "baseline": {
    "exclude": {
      "text": "",
      "token_ids": [
        6386,
        6386,
        6386
      ],
      "finish_reason": "stop",
      "stop_reason": " ha ha ha",
      "logprobs_len": 3
    },
    "include": {
      "text": " ha ha ha",
      "token_ids": [
        6386,
        6386,
        6386
      ],
      "finish_reason": "stop",
      "stop_reason": " ha ha ha",
      "logprobs_len": 3
    }
  },
  "spec": {
    "exclude": {
      "text": "",
      "token_ids": [
        6386,
        6386,
        6386,
        6386,
        6386,
        6386
      ],
      "finish_reason": "stop",
      "stop_reason": " ha ha ha",
      "logprobs_len": 6
    },
    "include": {
      "text": " ha ha ha",
      "token_ids": [
        6386,
        6386,
        6386,
        6386,
        6386,
        6386
      ],
      "finish_reason": "stop",
      "stop_reason": " ha ha ha",
      "logprobs_len": 6
    }
  }
}
PASS leak reproduced
```

Focused tests:

```text
$ CUDA_VISIBLE_DEVICES="" PYTHONPATH=$PWD python -m pytest -q tests/detokenizer/test_stop_string_while_stop_model_terminates.py
4 passed, 2 warnings in 0.89s

$ CUDA_VISIBLE_DEVICES="" PYTHONPATH=$PWD HF_HOME=/root/autodl-tmp/cache/hf HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 python -m pytest -q tests/detokenizer/test_min_tokens.py
3 passed, 5 warnings in 0.85s
```

Scoped pre-commit hooks for the three changed files:

```text
ruff-check: Passed
ruff-format: Passed
typos: Passed
check-spdx-header: Passed
check-forbidden-imports: Passed
check-torch-cuda-call: Passed
check-boolean-context-manager: Passed
check-root-lazy-imports: Passed
```

</details>

AI assistance was used to prepare this PR.

