### PR TITLE
Fix: detect reasoning end with accepted MTP tokens

### DIFF
--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -215,6 +215,45 @@ class TestReasoningStructuredOutput:
         )
         assert result is False
 
+    def test_should_advance_uses_accepted_tokens_with_mtp_preincrement(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """MTP can pre-increment num_computed_tokens past accepted tokens."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+
+        end_think_token_id = 42
+        accepted_token_ids = [9, end_think_token_id]
+        prompt_token_ids = mock_request_with_structured_output.prompt_token_ids
+        all_token_ids = prompt_token_ids + accepted_token_ids
+        mock_request_with_structured_output.all_token_ids = all_token_ids
+        mock_request_with_structured_output.num_computed_tokens = len(all_token_ids)
+        mock_request_with_structured_output.num_output_placeholders = 0
+
+        old_delta_from = (
+            mock_request_with_structured_output.num_computed_tokens
+            - mock_request_with_structured_output.num_output_placeholders
+        )
+        assert all_token_ids[old_delta_from:] == []
+
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_streaming.side_effect = (
+            lambda _all_ids, delta_ids: end_think_token_id in list(delta_ids)
+        )
+        structured_req.reasoner = reasoner
+
+        result = manager_with_reasoner.should_advance(
+            mock_request_with_structured_output, accepted_token_ids
+        )
+
+        assert structured_req.reasoning_ended is True
+        assert result is False
+        reasoner.is_reasoning_end_streaming.assert_called_once_with(
+            all_token_ids, accepted_token_ids
+        )
+
     def test_should_advance_reasoning_just_ended_with_spec_decode_structural_tag(
         self,
         manager_with_reasoner,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1633,7 +1633,9 @@ class Scheduler(SchedulerInterface):
                 request.status = RequestStatus.FINISHED_STOPPED
                 stopped = True
 
-            if new_token_ids and self.structured_output_manager.should_advance(request):
+            if new_token_ids and self.structured_output_manager.should_advance(
+                request, new_token_ids
+            ):
                 struct_output_request = request.structured_output_request
                 assert struct_output_request is not None
                 grammar = struct_output_request.grammar

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -368,7 +368,9 @@ class StructuredOutputManager:
             return request.structured_output_request.reasoning_ended
         return True
 
-    def should_advance(self, request: "Request") -> bool:
+    def should_advance(
+        self, request: "Request", new_token_ids: Sequence[int] | None = None
+    ) -> bool:
         if not request.use_structured_output:
             return False
 
@@ -391,15 +393,21 @@ class StructuredOutputManager:
         if structured_req.reasoning_ended:
             return True
 
-        # Check if reasoning ends in *this* step
-        delta_from = request.num_computed_tokens - request.num_output_placeholders
         all_token_ids = request.all_token_ids
-        start = (
-            delta_from if delta_from >= 0 else max(len(all_token_ids) + delta_from, 0)
-        )
-        if reasoner.is_reasoning_end_streaming(
-            all_token_ids, itertools.islice(all_token_ids, start, None)
-        ):
+        if new_token_ids is None:
+            delta_from = request.num_computed_tokens - request.num_output_placeholders
+            start = (
+                delta_from
+                if delta_from >= 0
+                else max(len(all_token_ids) + delta_from, 0)
+            )
+            delta_ids = itertools.islice(all_token_ids, start, None)
+        else:
+            start = max(len(all_token_ids) - len(new_token_ids), 0)
+            delta_ids = new_token_ids
+
+        # Check if reasoning ends in *this* step.
+        if reasoner.is_reasoning_end_streaming(all_token_ids, delta_ids):
             structured_req.reasoning_ended = True
 
             # Reasoning just ended this step. Defer FSM advance until the next


### PR DESCRIPTION
## Summary

Fixes reasoning-end detection when structured output is used together with reasoning mode and MTP/speculative decoding.

In the speculative decoding path, `num_computed_tokens` can be advanced before the newly accepted output tokens are appended to `request.all_token_ids`. Because `StructuredOutputManager.should_advance()` derived the token delta from `num_computed_tokens`, the derived slice could be empty even when the current accepted tokens contained the reasoning end marker. As a result, `reasoning_ended` was not set at the correct time and structured output constraints were not applied after the thinking phase.

This change passes the actual accepted output token IDs from the scheduler into `should_advance()` and uses those tokens for reasoning-end streaming detection. The previous derived-slice behavior is preserved as a fallback for existing callers.

Fixes #34650.

## Changes

* Updated `StructuredOutputManager.should_advance()` to accept optional newly accepted token IDs.
* Updated the V1 scheduler to pass the current accepted output tokens into `should_advance()`.
* Added a regression test covering the MTP-style pre-increment case where the old derived slice is empty but the accepted tokens include the reasoning end marker.

## Verification

Passed locally:

```bash
python -m compileall vllm/v1/structured_output vllm/v1/core/sched tests/v1/structured_output/test_reasoning_structured_output.py
git diff --check
```

Could not run locally:

```bash
python -m pytest tests/v1/structured_output/test_reasoning_structured_output.py
python -m ruff check ...
```

The local environment is missing pytest/ruff, and importing the test stack is blocked by missing torch. I expect CI to provide the full dependency environment.

## Related PR

There is an overlapping PR, #44927. I checked the upstream context before opening this PR. This PR focuses on passing the accepted MTP/speculative decoding tokens directly into `should_advance()` and includes a focused regression test for the pre-incremented `num_computed_tokens` case.
