### PR TITLE
[Bugfix] Unify per-layer KV cache dtype selection across v1/v2 model runners

### DIFF
--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -310,7 +310,7 @@ def _reshape_kv_cache(
                     "auto"
                     if kv_cache_spec.kv_quant_mode == KVQuantMode.NONE
                     and not isinstance(kv_cache_spec, TQFullAttentionSpec)
-                    else cache_dtype
+                    else getattr(kv_cache_spec, "cache_dtype_str", None) or cache_dtype
                 )
                 kv_cache_shape = group.backend.get_kv_cache_shape(
                     kernel_num_blocks,
@@ -397,7 +397,7 @@ def _update_hybrid_attention_layout(
             "auto"
             if kv_cache_spec.kv_quant_mode == KVQuantMode.NONE
             and not isinstance(kv_cache_spec, TQFullAttentionSpec)
-            else cache_dtype
+            else getattr(kv_cache_spec, "cache_dtype_str", None) or cache_dtype
         )
         block_dim = group.backend.get_kv_cache_block_dim(
             kernel_block_sizes[group.kv_cache_group_id],

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -156,6 +156,7 @@ from vllm.v1.kv_cache_interface import (
     KVQuantMode,
     MambaSpec,
     SlidingWindowSpec,
+    TQFullAttentionSpec,
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
@@ -7191,6 +7192,7 @@ class GPUModelRunner(
                     layer_cache_dtype_str = (
                         "auto"
                         if kv_cache_spec.kv_quant_mode == KVQuantMode.NONE
+                        and not isinstance(kv_cache_spec, TQFullAttentionSpec)
                         else getattr(
                             kv_cache_spec,
                             "cache_dtype_str",


### PR DESCRIPTION
Edit:
The main issues has been resolved in #47609 and #47716 . This PR now just make the two fix in sync for both v1 and v2 runner.

## Purpose

  1. DeepSeek V4 Flash on SM121: `Expected packed SM120 DSV4 swa_kv_cache head dim 584, got 512` (reported in #42890 comments)

  **Root cause:** #42890 passes `"auto"` to `get_kv_cache_shape()` when `spec.kv_quant_mode == NONE` (so skipped layers get the unquantized shape). But specs whose layout is encoded in the dtype **string** (`fp8_ds_mla`, `turboquant_*`) also have `kv_quant_mode == NONE`, so they wrongly received `"auto"`.

  **Fix:** trust `spec.cache_dtype_str` when present (already on the MLA specs from #40860), falling back to the skip-layer heuristic otherwise. Adds the field to
  `TQFullAttentionSpec` and sets it at construction. No behavior change for other configs.

  Not duplicating an existing PR: #47604 is a revert, not a fix; no other forward-fix is open.

  ## Test Plan

  - Repro script driving the real `_reshape_kv_cache()` with real DSV4-SWA / TurboQuant specs, run before and after the fix.
  - E2E of the #42890 feature: gpt-oss-20b, `kv_cache_dtype=nvfp4` + `kv_cache_dtype_skip_layers=["sliding_window"]`, FlashInfer, both v1/v2 model runners.
  - `ruff check` on touched files.

  ## Test Result

  - Before: Case A last dim **512** (FlashInfer expects 584); Case B raises `Unknown TurboQuant cache dtype: 'auto'`.
  - After: Case A → `(4, 64, 584)` ✅; Case B → `(4, 16, 8, 134)` (TQ slot layout) ✅. Verified fail→pass both directions via stash/pop.
  - E2E: both runners exit 0, coherent 2048-token greedy output, byte-identical v1 vs v2. Ruff clean.
  - Caveat: DSV4/SM121 verified at reshape-unit level (no SM121 hardware); would appreciate confirmation from the original reporter.
