### PR TITLE
[Perf] Batch KV scale host conversion

### DIFF
--- a/tests/model_executor/test_kv_scale_calc.py
+++ b/tests/model_executor/test_kv_scale_calc.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.attention.attention import Attention
+from vllm.model_executor.layers.attention.mla_attention import MLAAttention
+
+
+@pytest.mark.skip_global_cleanup
+def test_attention_calc_kv_scales_updates_tensor_and_float_scales():
+    layer = SimpleNamespace(
+        _q_scale=torch.tensor(0.0),
+        _k_scale=torch.tensor(0.0),
+        _v_scale=torch.tensor(0.0),
+        q_range=torch.tensor(2.0),
+        k_range=torch.tensor(4.0),
+        v_range=torch.tensor(8.0),
+        calculate_kv_scales=True,
+    )
+    query = torch.tensor([-2.0, 4.0, -6.0])
+    key = torch.tensor([-3.0, 1.0, 5.0])
+    value = torch.tensor([16.0, -8.0, 4.0])
+
+    Attention.calc_kv_scales(layer, query, key, value)
+
+    assert layer._q_scale_float == pytest.approx(3.0)
+    assert layer._k_scale_float == pytest.approx(1.25)
+    assert layer._v_scale_float == pytest.approx(2.0)
+    assert layer.calculate_kv_scales is False
+    torch.testing.assert_close(layer._q_scale, torch.tensor(3.0))
+    torch.testing.assert_close(layer._k_scale, torch.tensor(1.25))
+    torch.testing.assert_close(layer._v_scale, torch.tensor(2.0))
+
+
+@pytest.mark.skip_global_cleanup
+def test_mla_calc_kv_scales_uses_shared_kv_abs_max():
+    layer = SimpleNamespace(
+        _q_scale=torch.tensor(0.0),
+        _k_scale=torch.tensor(0.0),
+        _v_scale=torch.tensor(0.0),
+        q_range=torch.tensor(2.0),
+        k_range=torch.tensor(5.0),
+        v_range=torch.tensor(10.0),
+        calculate_kv_scales=True,
+    )
+    q = torch.tensor([-1.0, 3.0, -5.0])
+    kv_c_normed = torch.tensor([-2.0, 4.0, -8.0])
+    k_pe = torch.tensor([0.5, -0.5, 1.0])
+
+    MLAAttention.calc_kv_scales(layer, q, kv_c_normed, k_pe)
+
+    assert layer._q_scale_float == pytest.approx(2.5)
+    assert layer._k_scale_float == pytest.approx(1.6)
+    assert layer._v_scale_float == pytest.approx(0.8)
+    assert layer.calculate_kv_scales is False
+    torch.testing.assert_close(layer._q_scale, torch.tensor(2.5))
+    torch.testing.assert_close(layer._k_scale, torch.tensor(1.6))
+    torch.testing.assert_close(layer._v_scale, torch.tensor(0.8))

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -582,9 +582,14 @@ class Attention(nn.Module, AttentionLayerBase):
         self._q_scale.copy_(torch.abs(query).max() / self.q_range)
         self._k_scale.copy_(torch.abs(key).max() / self.k_range)
         self._v_scale.copy_(torch.abs(value).max() / self.v_range)
-        self._q_scale_float = self._q_scale.item()
-        self._k_scale_float = self._k_scale.item()
-        self._v_scale_float = self._v_scale.item()
+        scales_cpu = torch.stack(
+            (self._q_scale, self._k_scale, self._v_scale)
+        ).to("cpu")
+        (
+            self._q_scale_float,
+            self._k_scale_float,
+            self._v_scale_float,
+        ) = scales_cpu.tolist()
         # We only calculate the scales once
         self.calculate_kv_scales = False
 

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -989,9 +989,14 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         kv_abs_max = torch.abs(kv_c_normed).max()
         self._k_scale.copy_(kv_abs_max / k_range)
         self._v_scale.copy_(kv_abs_max / v_range)
-        self._q_scale_float = self._q_scale.item()
-        self._k_scale_float = self._k_scale.item()
-        self._v_scale_float = self._v_scale.item()
+        scales_cpu = torch.stack(
+            (self._q_scale, self._k_scale, self._v_scale)
+        ).to("cpu")
+        (
+            self._q_scale_float,
+            self._k_scale_float,
+            self._v_scale_float,
+        ) = scales_cpu.tolist()
         self.calculate_kv_scales = False
 
     def get_attn_backend(self) -> type[AttentionBackend]:


### PR DESCRIPTION
## Summary

This PR reduces synchronization overhead when `--calculate-kv-scales` computes attention KV scales.

Instead of calling `.item()` separately for q/k/v scales, it batches the three scalar tensors into one host transfer via `torch.stack(...).to("cpu").tolist()`.

The same pattern is applied to:

- `Attention.calc_kv_scales`
- `MLAAttention.calc_kv_scales`

A focused unit test covers both regular attention and MLA scale updates, including the stored tensor scales and float mirror values.

## Why

Each `.item()` can force a separate device-to-host synchronization. These scale calculations happen in attention setup paths, so batching the host conversion avoids redundant sync points while preserving the existing public behavior.

## Validation

- `git diff --check`
- `python -m py_compile tests/model_executor/test_kv_scale_calc.py`

Attempted but could not run locally in this container:

- `python -m pytest tests/model_executor/test_kv_scale_calc.py`

The default Python environment is missing `torch`, and the available repo virtual environments are missing the needed test dependencies.
