### PR TITLE
[Perf] Avoid redundant logprobs list materialization

### DIFF
--- a/tests/v1/engine/test_logprobs_processor.py
+++ b/tests/v1/engine/test_logprobs_processor.py
@@ -1,20 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Unit tests for LogprobsProcessor.
-
-These tests exercise the truncation invariant that the MRV2 sampler relies
-on: when the sampler returns a row wider than a request's own
-`num_logprobs + 1` (because another request in the batch needed a wider
-row), the trailing positions are populated with sentinel values
-(`token_id=0`, `logprob=-inf`). LogprobsProcessor must read only the first
-`num_logprobs + 1` entries so those sentinels never reach the user.
-"""
+"""Unit tests for LogprobsProcessor."""
 
 import numpy as np
+import pytest
 
-from vllm.logprobs import create_sample_logprobs
+from vllm.logprobs import Logprob, create_prompt_logprobs, create_sample_logprobs
 from vllm.v1.engine.logprobs import LogprobsProcessor
-from vllm.v1.outputs import LogprobsLists
+from vllm.v1.outputs import LogprobsLists, LogprobsTensors
 
 
 def _make_processor(num_logprobs: int) -> LogprobsProcessor:
@@ -37,7 +30,8 @@ def test_drops_trailing_sentinel_columns():
     # Layout: [sampled, custom_1, custom_2, custom_3, SENTINEL, SENTINEL]
     # Use float32-exact values so cumulative_logprob compares cleanly.
     token_ids = np.array([[sampled, 100, 200, 300, 0, 0]], dtype=np.int32)
-    logprobs = np.array([[-0.5, -1.0, -2.0, -3.0, -np.inf, -np.inf]], dtype=np.float32)
+    logprobs = np.array([[-0.5, -1.0, -2.0, -3.0, -np.inf, -np.inf]],
+                        dtype=np.float32)
     ranks = np.array([1], dtype=np.int32)
 
     processor._update_sample_logprobs(LogprobsLists(token_ids, logprobs, ranks))
@@ -64,3 +58,137 @@ def test_accepts_exactly_sized_row():
 
     pos = processor.logprobs[0]
     assert set(pos.keys()) == {7, 11, 13}
+
+
+class NoToListArray(np.ndarray):
+    def tolist(self):
+        raise AssertionError("LogprobsProcessor should not materialize rows early")
+
+
+class NoToListMatrix:
+    def __init__(self, values):
+        self.values = values
+
+    @property
+    def shape(self):
+        return (len(self.values), len(self.values[0]))
+
+    def __getitem__(self, index):
+        return self.values[index]
+
+    def tolist(self):
+        raise AssertionError("LogprobsProcessor should not materialize tensors early")
+
+
+class NoToListVector:
+    def __init__(self, values):
+        self.values = values
+
+    def __getitem__(self, index):
+        return self.values[index]
+
+    def tolist(self):
+        raise AssertionError("LogprobsProcessor should not materialize tensors early")
+
+
+def _no_tolist_array(values):
+    return np.asarray(values).view(NoToListArray)
+
+
+class FakeTokenizer:
+    def decode(self, token_ids):
+        return f"tok{token_ids[0]}"
+
+
+@pytest.mark.parametrize("flat_logprobs", [False, True])
+def test_update_sample_logprobs_iterates_numpy_rows_without_tolist(flat_logprobs):
+    processor = LogprobsProcessor(
+        tokenizer=None,
+        logprobs=create_sample_logprobs(flat_logprobs=flat_logprobs),
+        prompt_logprobs=None,
+        cumulative_logprob=0.0,
+        num_logprobs=2,
+        num_prompt_logprobs=None,
+    )
+
+    processor._update_sample_logprobs(
+        LogprobsLists(
+            logprob_token_ids=_no_tolist_array([[42, 7, 9], [43, 10, 11]]),
+            logprobs=_no_tolist_array([[-0.1, -1.0, -2.0], [-0.3, -1.3, -2.3]]),
+            sampled_token_ranks=_no_tolist_array([4, 5]),
+        ))
+
+    assert processor.cumulative_logprob == pytest.approx(-0.4)
+    assert list(processor.logprobs) == [
+        {
+            42: Logprob(logprob=-0.1, rank=4, decoded_token=None),
+            7: Logprob(logprob=-1.0, rank=1, decoded_token=None),
+            9: Logprob(logprob=-2.0, rank=2, decoded_token=None),
+        },
+        {
+            43: Logprob(logprob=-0.3, rank=5, decoded_token=None),
+            10: Logprob(logprob=-1.3, rank=1, decoded_token=None),
+            11: Logprob(logprob=-2.3, rank=2, decoded_token=None),
+        },
+    ]
+
+
+@pytest.mark.parametrize("tokenizer", [None, FakeTokenizer()])
+def test_update_prompt_logprobs_iterates_tensor_rows_without_tolist(tokenizer):
+    processor = LogprobsProcessor(
+        tokenizer=tokenizer,
+        logprobs=None,
+        prompt_logprobs=create_prompt_logprobs(flat_logprobs=False),
+        cumulative_logprob=None,
+        num_logprobs=None,
+        num_prompt_logprobs=2,
+    )
+
+    processor._update_prompt_logprobs(
+        LogprobsTensors(
+            logprob_token_ids=NoToListMatrix([[101, 102, 103], [201, 202, 203]]),
+            logprobs=NoToListMatrix([[-0.1, -1.0, -2.0],
+                                     [-0.2, -1.2, -2.2]]),
+            selected_token_ranks=NoToListVector([3, 4]),
+        ))
+
+    expected_decoded_tokens = (
+        {token_id: f"tok{token_id}" for token_id in [101, 102, 103, 201, 202, 203]}
+        if tokenizer is not None else {})
+    assert processor.prompt_logprobs == [
+        None,
+        {
+            101: Logprob(
+                logprob=-0.1,
+                rank=3,
+                decoded_token=expected_decoded_tokens.get(101),
+            ),
+            102: Logprob(
+                logprob=-1.0,
+                rank=1,
+                decoded_token=expected_decoded_tokens.get(102),
+            ),
+            103: Logprob(
+                logprob=-2.0,
+                rank=2,
+                decoded_token=expected_decoded_tokens.get(103),
+            ),
+        },
+        {
+            201: Logprob(
+                logprob=-0.2,
+                rank=4,
+                decoded_token=expected_decoded_tokens.get(201),
+            ),
+            202: Logprob(
+                logprob=-1.2,
+                rank=1,
+                decoded_token=expected_decoded_tokens.get(202),
+            ),
+            203: Logprob(
+                logprob=-2.2,
+                rank=2,
+                decoded_token=expected_decoded_tokens.get(203),
+            ),
+        },
+    ]

--- a/vllm/logprobs.py
+++ b/vllm/logprobs.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
-from collections.abc import Iterable, Iterator, MutableSequence
+from collections.abc import Iterable, Iterator, MutableSequence, Sized
 from dataclasses import dataclass, field
 from typing import overload
 
@@ -73,8 +73,8 @@ class FlatLogprobs(MutableSequence[LogprobsOnePosition | None]):
 
     def append_fast(
         self,
-        token_ids: list[int],
-        logprobs: list[float],
+        token_ids: Iterable[int],
+        logprobs: Iterable[float],
         ranks: itertools.chain[int],
         decoded_tokens: Iterable[str | None],
     ) -> None:
@@ -86,9 +86,9 @@ class FlatLogprobs(MutableSequence[LogprobsOnePosition | None]):
         for token_id, logprob, rank, decoded_token in zip(
             token_ids, logprobs, ranks, decoded_tokens
         ):
-            self.token_ids.append(token_id)
-            self.logprobs.append(logprob)
-            self.ranks.append(rank)
+            self.token_ids.append(int(token_id))
+            self.logprobs.append(float(logprob))
+            self.ranks.append(None if rank is None else int(rank))
             self.decoded_tokens.append(decoded_token)
         self.end_indices.append(len(self.logprobs))
 
@@ -174,14 +174,15 @@ def create_sample_logprobs(flat_logprobs: bool) -> SampleLogprobs:
 
 def append_logprobs_for_next_position(
     request_logprobs: PromptLogprobs | SampleLogprobs,
-    token_ids: list[int],
-    logprobs: list[float],
+    token_ids: Iterable[int],
+    logprobs: Iterable[float],
     decoded_tokens: Iterable[str | None],
     rank: int,
     num_logprobs: int,
 ) -> None:
     """Appends logprobs for the next position"""
     if num_logprobs == -1:
+        assert isinstance(logprobs, Sized)
         num_logprobs = len(logprobs)
     # We do not need a special case for the sampled token
     # being in the topk, since inserting duplicated data
@@ -194,9 +195,9 @@ def append_logprobs_for_next_position(
     else:
         request_logprobs.append(
             {
-                token_id: Logprob(
-                    logprob=logprob,
-                    rank=rank,
+                int(token_id): Logprob(
+                    logprob=float(logprob),
+                    rank=None if rank is None else int(rank),
                     decoded_token=token,
                 )
                 for token_id, logprob, rank, token in zip(

--- a/vllm/v1/engine/logprobs.py
+++ b/vllm/v1/engine/logprobs.py
@@ -83,29 +83,25 @@ class LogprobsProcessor:
 
         token_ids_lst, logprobs_lst, ranks_lst, _ = logprobs_lists
 
-        for rank_np, logprobs_np, token_ids_np in zip(
-            ranks_lst, logprobs_lst, token_ids_lst
-        ):
-            rank = rank_np.tolist()
-            logprobs = logprobs_np.tolist()
-            token_ids = token_ids_np.tolist()
+        for rank, logprobs, token_ids in zip(ranks_lst, logprobs_lst, token_ids_lst):
             # Detokenize (non-incrementally).
             decoded_tokens: list[str] | Iterable[None]
             if self.tokenizer is None:
                 decoded_tokens = NONES
             else:
+                token_ids_for_decode = token_ids.tolist()
                 decoded_tokens_list = convert_ids_list_to_tokens(
-                    self.tokenizer, token_ids
+                    self.tokenizer, token_ids_for_decode
                 )
                 context_token_ids = self._get_sampled_context_ids(self.logprobs)
                 decoded_tokens = self._verify_tokens(
                     decoded_tokens_list=decoded_tokens_list,
-                    tokens=token_ids,
+                    tokens=token_ids_for_decode,
                     context_token_ids=context_token_ids,
                 )
 
             # Sampler puts the sampled logprob in first.
-            sampled_token_logprob = logprobs[0]
+            sampled_token_logprob = float(logprobs[0])
             self.cumulative_logprob += sampled_token_logprob
 
             # Update with the Logprob container for this pos.
@@ -114,7 +110,7 @@ class LogprobsProcessor:
                 token_ids,
                 logprobs,
                 decoded_tokens,
-                rank,
+                int(rank),
                 self.num_logprobs,
             )
 
@@ -137,52 +133,41 @@ class LogprobsProcessor:
         token_ids, logprobs, ranks, _ = prompt_logprobs_tensors
 
         # Recover shapes.
-        num_prompt_tokens, num_logprobs = logprobs.shape
-
-        # Detokenize non-incrementally.
-        # Output is flat: [num_tok, num_lps] -> [num_tok * num_lps]
-        all_decoded_tokens: list[str] | None = (
-            None
-            if self.tokenizer is None
-            else convert_ids_list_to_tokens(
-                self.tokenizer, token_ids.flatten().tolist()
-            )
-        )
-
-        # Pythonize the torch tensors.
-        prompt_token_ranks = ranks.tolist()
-        prompt_logprobs = logprobs.tolist()
-        token_ids_list = token_ids.tolist()
+        num_prompt_tokens = logprobs.shape[0]
 
         # Make Logprob for each position.
         for pos in range(num_prompt_tokens):
-            # Handle flattening and UTF-8 correction per position
-            offset = pos * num_logprobs
-            offset_end = offset + num_logprobs
+            token_ids_for_pos = token_ids[pos]
 
             decoded_tokens_for_pos: list[str] | Iterable[None]
-            if all_decoded_tokens is None:
+            if self.tokenizer is None:
                 decoded_tokens_for_pos = NONES
             else:
-                # Extract decoded tokens for this position
-                decoded_tokens_slice = all_decoded_tokens[offset:offset_end]
+                token_ids_for_decode = (
+                    token_ids_for_pos.tolist()
+                    if hasattr(token_ids_for_pos, "tolist")
+                    else list(token_ids_for_pos)
+                )
+                decoded_tokens_list = convert_ids_list_to_tokens(
+                    self.tokenizer, token_ids_for_decode
+                )
                 # Context: preceding prompt tokens accumulated in
                 # self.prompt_logprobs from previous loop iterations.
                 context_token_ids = self._get_sampled_context_ids(self.prompt_logprobs)
                 # Apply UTF-8 correction within this position's token boundaries
                 decoded_tokens_for_pos = self._verify_tokens(
-                    decoded_tokens_list=decoded_tokens_slice,
-                    tokens=token_ids_list[pos],
+                    decoded_tokens_list=decoded_tokens_list,
+                    tokens=token_ids_for_decode,
                     context_token_ids=context_token_ids,
                 )
 
             # Update with the Logprob container for this pos.
             append_logprobs_for_next_position(
                 self.prompt_logprobs,
-                token_ids_list[pos],
-                prompt_logprobs[pos],
+                token_ids_for_pos,
+                logprobs[pos],
                 decoded_tokens_for_pos,
-                prompt_token_ranks[pos],
+                int(ranks[pos]),
                 self.num_prompt_logprobs,
             )
 


### PR DESCRIPTION
## Summary

This PR avoids redundant Python list materialization in V1 logprob processing.

The update keeps the per-position logprob handling iterable-based instead of eagerly converting whole rows/tensors with `.tolist()` before appending to the user-facing logprob containers.

Changes include:

- allow `append_logprobs_for_next_position` and `FlatLogprobs.append_fast` to consume iterables
- cast scalar token ids / logprobs / ranks at the append boundary
- decode only the token ids needed for each position
- add regression tests using array/tensor-like objects whose `.tolist()` raises if called too early

## Why

The previous code materialized numpy/tensor rows into Python lists before appending logprobs. That adds avoidable Python allocation overhead in a hot path, especially when logprobs are enabled for batched serving.

## Validation

- `git diff --check`
- `python -m py_compile tests/v1/engine/test_logprobs_processor.py vllm/logprobs.py vllm/v1/engine/logprobs.py`

Attempted but could not run locally in this container:

- `python -m pytest tests/v1/engine/test_logprobs_processor.py`

The default Python environment is missing `torch`, which is imported by the repository test configuration.
