### PR TITLE
[Doc] Fix stale default CUDA version in GPU install guide

### DIFF
--- a/docs/getting_started/installation/gpu.cuda.inc.md
+++ b/docs/getting_started/installation/gpu.cuda.inc.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD041 MD051 -->
 --8<-- [start:installation]
 
-vLLM contains pre-compiled C++ and CUDA (12.9) binaries.
+vLLM contains pre-compiled C++ and CUDA (13.0) binaries.
 
 --8<-- [end:installation]
 --8<-- [start:requirements]
@@ -27,21 +27,24 @@ uv pip install vllm --torch-backend=auto
 
 ??? console "pip"
     ```bash
-    # Install vLLM with CUDA 12.9.
-    pip install vllm --extra-index-url https://download.pytorch.org/whl/cu129
+    # Install vLLM with CUDA 13.0.
+    pip install vllm --extra-index-url https://download.pytorch.org/whl/cu130
     ```
 
 We recommend leveraging `uv` to [automatically select the appropriate PyTorch index at runtime](https://docs.astral.sh/uv/guides/integration/pytorch/#automatic-backend-selection) by inspecting the installed CUDA driver version via `--torch-backend=auto` (or `UV_TORCH_BACKEND=auto`). To select a specific backend (e.g., `cu130`), set `--torch-backend=cu130` (or `UV_TORCH_BACKEND=cu130`). If this doesn't work, try running `uv self update` to update `uv` first.
 
 !!! note
+    `--torch-backend` only selects the PyTorch build; it does not change the CUDA version the vLLM wheel itself is compiled with. `pip install vllm` (or `uv pip install vllm`) always installs the default CUDA 13.0 vLLM wheel. To use a vLLM wheel built for a different CUDA version, install a specific CUDA build as shown below.
+
+!!! note
     NVIDIA Blackwell GPUs (B200, GB200) require a minimum of CUDA 12.8, so make sure you are installing PyTorch wheels with at least that version. PyTorch itself offers a [dedicated interface](https://pytorch.org/get-started/locally/) to determine the appropriate pip command to run for a given target configuration.
 
-As of now, vLLM's binaries are compiled with CUDA 12.9 and public PyTorch release versions by default. We also provide vLLM binaries compiled with CUDA 12.8, 13.0, and public PyTorch release versions:
+As of now, vLLM's binaries are compiled with CUDA 13.0 and public PyTorch release versions by default. We also provide vLLM binaries compiled with other CUDA versions (e.g., 12.9) and public PyTorch release versions:
 
 ```bash
-# Install vLLM with a specific CUDA version (e.g., 13.0).
+# Install vLLM with a specific CUDA version (e.g., 12.9).
 export VLLM_VERSION=$(curl -s https://api.github.com/repos/vllm-project/vllm/releases/latest | jq -r .tag_name | sed 's/^v//')
-export CUDA_VERSION=130 # or other
+export CUDA_VERSION=129 # or other
 export CPU_ARCH=$(uname -m) # x86_64 or aarch64
 uv pip install https://github.com/vllm-project/vllm/releases/download/v${VLLM_VERSION}/vllm-${VLLM_VERSION}+cu${CUDA_VERSION}-cp38-abi3-manylinux_2_28_${CPU_ARCH}.whl --extra-index-url https://download.pytorch.org/whl/cu${CUDA_VERSION}
 ```
@@ -50,8 +53,8 @@ uv pip install https://github.com/vllm-project/vllm/releases/download/v${VLLM_VE
 
 LLM inference is a fast-evolving field, and the latest code may contain bug fixes, performance improvements, and new features that are not released yet. To allow users to try the latest code without waiting for the next release, vLLM provides wheels for every commit since `v0.5.3` on <https://wheels.vllm.ai/nightly>. There are multiple indices that could be used:
 
-- `https://wheels.vllm.ai/nightly`: the default variant (CUDA with version specified in `VLLM_MAIN_CUDA_VERSION`) built with the last commit on the `main` branch. Currently it is CUDA 12.9.
-- `https://wheels.vllm.ai/nightly/<variant>`: all other variants. Now this includes `cu130`, and `cpu`. The default variant (`cu129`) also has a subdirectory to keep consistency.
+- `https://wheels.vllm.ai/nightly`: the default variant (CUDA with version specified in `VLLM_MAIN_CUDA_VERSION`) built with the last commit on the `main` branch. Currently it is CUDA 13.0.
+- `https://wheels.vllm.ai/nightly/<variant>`: all other variants. Now this includes `cu129`, and `cpu`. The default variant (`cu130`) also has a subdirectory to keep consistency.
 
 To install from nightly index, run:
 


### PR DESCRIPTION
## Purpose

FIX #44335 (also the same confusion in #43435).

The default vLLM wheel is built for CUDA 13.0, but the GPU install guide still
said CUDA 12.9 in several places. This is what leads users to install a
cu12.9 PyTorch build next to a CUDA-13 vLLM wheel and hit
`libcudart.so.13 ... cannot open shared object file`.

Verified facts behind the change:

- `VLLM_MAIN_CUDA_VERSION` defaults to `13.0` (`vllm/envs.py`), and the nightly
  index build script sets `DEFAULT_VARIANT_ALIAS="cu130"`
  (`.buildkite/scripts/generate-and-upload-nightly-index.sh`).
- The released `vllm==0.24.0` wheels are: unsuffixed default (depends on
  `nvidia-cutlass-dsl[cu13]`), `+cu129`, and `+cpu` — there is no `+cu130`
  because cu130 is the default (unsuffixed) build. The nightly index exposes
  `cu129` and `cu130` subdirectories with `cu130` as the default.

So the docs were stale/inverted:

- default stated as 12.9 (now 13.0);
- nightly section listed `cu130` as an "other" variant and `cu129` as the
  default (they are the other way around);
- the specific-CUDA release example used `CUDA_VERSION=130`, which 404s since
  no `+cu130` wheel is published.

I also added a short note clarifying that `--torch-backend` selects only the
PyTorch build, not the vLLM wheel's CUDA variant — the point of confusion in
both issues.

AI assistance was used to draft this change; the diff and every claim above
were reviewed and verified by me.

## Test Plan

Docs-only change. Verified the factual claims against the source of truth
(`vllm/envs.py`, the nightly index script, the published `v0.24.0` wheel names
and the PyPI `requires_dist`), and ran the docs lint hooks.

```bash
uvx pre-commit run --files docs/getting_started/installation/gpu.cuda.inc.md
```

## Test Result

`markdownlint-cli2` and `typos` pass; no other hooks apply to this file.

```
typos...........................................Passed
markdownlint-cli2...............................Passed
```
