### PR TITLE
[Bugfix][OpenAI] Respect allowed_token_ids in beam search

### DIFF
--- a/vllm/entrypoints/generate/beam_search/offline.py
+++ b/vllm/entrypoints/generate/beam_search/offline.py
@@ -13,6 +13,7 @@ from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import (
+    MAX_LOGPROB_TOKEN_IDS,
     BeamSearchParams,
     SamplingParams,
     StructuredOutputsParams,
@@ -82,6 +83,7 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
         temperature = params.temperature
         ignore_eos = params.ignore_eos
         length_penalty = params.length_penalty
+        request_allowed_token_ids = params.allowed_token_ids
 
         tokenizer = self.renderer.get_tokenizer()
         eos_token_id = tokenizer.eos_token_id
@@ -115,10 +117,23 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
         # generate 2 * beam_width candidates at each step
         # following the huggingface transformers implementation
         # at https://github.com/huggingface/transformers/blob/e15687fffe5c9d20598a19aeab721ae0a7580f8a/src/transformers/generation/beam_search.py#L534 # noqa
+        request_logprob_token_ids = (
+            request_allowed_token_ids
+            if request_allowed_token_ids is not None
+            and len(request_allowed_token_ids) <= MAX_LOGPROB_TOKEN_IDS
+            else None
+        )
         base_sampling_params = SamplingParams(
-            logprobs=2 * beam_width,
+            logprobs=None if request_logprob_token_ids is not None else 2 * beam_width,
+            logprob_token_ids=request_logprob_token_ids,
             max_tokens=1,
             temperature=temperature,
+            allowed_token_ids=(
+                request_allowed_token_ids
+                if request_allowed_token_ids is not None
+                and len(request_allowed_token_ids) <= _MAX_NUM_ALLOWED_TOKEN_IDS
+                else None
+            ),
             skip_clone=True,  # Internal beam search, safe to skip clone
         )
         instances: list[BeamSearchInstance] = []
@@ -168,6 +183,7 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
                         structured_output_backend=structured_output_backend,
                         structured_output_key=structured_output_key,
                         structured_output_bitmask=structured_output_bitmask,
+                        request_allowed_token_ids=request_allowed_token_ids,
                     )
                     if should_stop:
                         break
@@ -201,6 +217,7 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
         structured_output_backend: StructuredOutputBackend | None,
         structured_output_key: tuple | None,
         structured_output_bitmask: torch.Tensor | None,
+        request_allowed_token_ids: list[int] | None,
     ) -> bool:
         """Run one token step of beam search across a batch of instances.
 
@@ -228,6 +245,7 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
                 structured_output_backend,
                 structured_output_key,
                 structured_output_bitmask,
+                request_allowed_token_ids,
             )
             active_indices = [
                 i for i, entry in enumerate(beam_entries) if entry is not None
@@ -280,7 +298,12 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
         # tokens outside the grammar's allowed set. This filtering is also
         # the only grammar enforcement for beams whose allowed set exceeds
         # the engine-side allowed_token_ids cap.
-        allowed_sets: list[set[int] | None] = [None] * len(all_beams)
+        request_allowed_set = (
+            set(request_allowed_token_ids)
+            if request_allowed_token_ids is not None
+            else None
+        )
+        allowed_sets: list[set[int] | None] = [request_allowed_set] * len(all_beams)
         if structured_output_backend is not None:
             for i, entry in enumerate(beam_entries):
                 if entry is not None:
@@ -401,6 +424,7 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
         backend: StructuredOutputBackend,
         structured_output_key: tuple,
         bitmask: torch.Tensor,
+        request_allowed_token_ids: list[int] | None,
     ) -> list[tuple[SamplingParams, list[int]] | None]:
         """Build per-beam SamplingParams and allowed token IDs from grammar.
 
@@ -408,6 +432,11 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
         """
         vocab_size = self.model_config.get_vocab_size()
         request_type, grammar_spec = structured_output_key
+        request_allowed_set = (
+            set(request_allowed_token_ids)
+            if request_allowed_token_ids is not None
+            else None
+        )
         result: list[tuple[SamplingParams, list[int]] | None] = []
 
         for beam in beams:
@@ -428,6 +457,12 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
 
             grammar.fill_bitmask(bitmask, 0)
             allowed_ids = _bitmask_to_token_ids(bitmask[0], vocab_size)
+            if request_allowed_set is not None:
+                allowed_ids = [
+                    token_id
+                    for token_id in allowed_ids
+                    if token_id in request_allowed_set
+                ]
 
             if not allowed_ids:
                 result.append(None)
@@ -437,8 +472,14 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
             # grammar still allows more tokens than the cap (e.g. inside
             # free-form strings), skip the engine-side constraint and rely
             # on the logprobs filtering in _beam_search_step instead.
+            logprob_token_ids = (
+                allowed_ids if len(allowed_ids) <= MAX_LOGPROB_TOKEN_IDS else None
+            )
             beam_params = SamplingParams(
-                logprobs=base_params.logprobs,
+                logprobs=None
+                if logprob_token_ids is not None
+                else base_params.logprobs,
+                logprob_token_ids=logprob_token_ids,
                 max_tokens=1,
                 temperature=base_params.temperature,
                 allowed_token_ids=(

--- a/vllm/entrypoints/generate/beam_search/online.py
+++ b/vllm/entrypoints/generate/beam_search/online.py
@@ -12,7 +12,11 @@ from vllm.engine.protocol import EngineClient
 from vllm.inputs import EngineInput
 from vllm.lora.request import LoRARequest
 from vllm.renderers import BaseRenderer
-from vllm.sampling_params import BeamSearchParams, SamplingParams
+from vllm.sampling_params import (
+    MAX_LOGPROB_TOKEN_IDS,
+    BeamSearchParams,
+    SamplingParams,
+)
 from vllm.utils import random_uuid
 from vllm.utils.async_utils import collect_from_async_generator
 
@@ -56,13 +60,30 @@ class BeamSearchOnlineMixin(ABC):
 
         tokenized_length = len(prompt_token_ids)
 
-        logprobs_num = 2 * beam_width
-        sampling_params = SamplingParams(
-            logprobs=logprobs_num,
-            max_tokens=1,
-            temperature=temperature,
-            detokenize=False,
+        allowed_token_ids = params.allowed_token_ids
+        allowed_token_ids_set = (
+            set(allowed_token_ids) if allowed_token_ids is not None else None
         )
+        logprobs_num = 2 * beam_width
+        if (
+            allowed_token_ids is not None
+            and len(allowed_token_ids) <= MAX_LOGPROB_TOKEN_IDS
+        ):
+            sampling_params = SamplingParams(
+                max_tokens=1,
+                temperature=temperature,
+                detokenize=False,
+                allowed_token_ids=allowed_token_ids,
+                logprob_token_ids=allowed_token_ids,
+            )
+        else:
+            sampling_params = SamplingParams(
+                logprobs=logprobs_num,
+                max_tokens=1,
+                temperature=temperature,
+                detokenize=False,
+                allowed_token_ids=allowed_token_ids,
+            )
         all_beams = [
             BeamSearchSequence(
                 orig_prompt=prompt,
@@ -127,6 +148,11 @@ class BeamSearchOnlineMixin(ABC):
                 if result.outputs[0].logprobs is not None:
                     logprobs = result.outputs[0].logprobs[0]
                     for token_id, logprob_obj in logprobs.items():
+                        if (
+                            allowed_token_ids_set is not None
+                            and token_id not in allowed_token_ids_set
+                        ):
+                            continue
                         candidate_logprob = (
                             current_beam.cum_logprob + logprob_obj.logprob
                         )

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -580,6 +580,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             temperature=temperature,
             length_penalty=self.length_penalty,
             include_stop_str_in_output=self.include_stop_str_in_output,
+            allowed_token_ids=self.allowed_token_ids,
         )
 
     def to_sampling_params(

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -255,6 +255,7 @@ class CompletionRequest(OpenAIBaseModel):
             temperature=temperature,
             length_penalty=self.length_penalty,
             include_stop_str_in_output=self.include_stop_str_in_output,
+            allowed_token_ids=self.allowed_token_ids,
         )
 
     def to_sampling_params(

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -1100,4 +1100,5 @@ class BeamSearchParams(
     temperature: float = 0.0
     length_penalty: float = 1.0
     include_stop_str_in_output: bool = False
+    allowed_token_ids: list[int] | None = None
     structured_outputs: StructuredOutputsParams | None = None


### PR DESCRIPTION

## Purpose

OpenAI-compatible completion requests already accept `allowed_token_ids`, and the normal sampling path respects it. The beam-search path dropped that field while building `BeamSearchParams`, then ranked candidates from per-step logprobs that can include tokens outside the sampling mask, so a valid request could return HTTP 200 with forbidden `token_ids`.

This keeps `allowed_token_ids` on `BeamSearchParams`, forwards it from both completion and chat completion requests, and filters beam candidates before ranking. Small allowlists use `logprob_token_ids` so beam search can score the exact allowed set; the shared offline beam path also intersects request allowlists with structured-output grammar allowlists.

## Test Plan

I ran a real OpenAI-compatible `/v1/completions` reproduction on Qwen3-0.6B with `allowed_token_ids=[43096]`, where token 43096 decodes to `" banana"`. I ran the same server/client on current main, on this branch, and after reverting this branch diff, then ran ruff on the changed runtime files.

## Test Result

On main, the beam request returned forbidden token 12095 (`" Paris"`) while the normal sampling control returned allowed token 43096 (`" banana"`). On this branch, beam and sampling both returned token 43096; after reverting this branch diff, beam returned token 12095 again.

<details>
<summary>repro (serve command, client, main, branch, revert)</summary>

Environment:

```text
GPU: NVIDIA GeForce RTX 4090
Base commit: 26eb87204d58d9d8a25c378fbaec9da23db3fb85
Model: /root/autodl-tmp/models/Qwen3-0.6B
Server: vllm.entrypoints.openai.api_server
Key flags: --dtype bfloat16 --max-model-len 1024 --enforce-eager --gpu-memory-utilization 0.40
Env: VLLM_ATTENTION_BACKEND=FLASH_ATTN, VLLM_USE_FLASHINFER_SAMPLER=0, VLLM_WORKER_MULTIPROC_METHOD=spawn
```

Serve command:

```bash
PYTHONPATH=$PWD VLLM_ATTENTION_BACKEND=FLASH_ATTN VLLM_USE_FLASHINFER_SAMPLER=0 VLLM_WORKER_MULTIPROC_METHOD=spawn \
python -m vllm.entrypoints.openai.api_server \
  --model /root/autodl-tmp/models/Qwen3-0.6B \
  --served-model-name qwen \
  --dtype bfloat16 \
  --max-model-len 1024 \
  --enforce-eager \
  --gpu-memory-utilization 0.40 \
  --port 18280 \
  --no-enable-log-requests
```

Client:

```python
import json
import urllib.request

port = 18280
allowed = [43096]
base = {
    "model": "qwen",
    "prompt": "The capital of France is",
    "max_tokens": 1,
    "temperature": 0,
    "allowed_token_ids": allowed,
    "return_token_ids": True,
}

for name, extra in [
    ("beam", {"use_beam_search": True, "n": 1}),
    ("sampling", {"use_beam_search": False}),
]:
    payload = dict(base)
    payload.update(extra)
    req = urllib.request.Request(
        f"http://127.0.0.1:{port}/v1/completions",
        data=json.dumps(payload).encode(),
        headers={"Content-Type": "application/json"},
    )
    with urllib.request.urlopen(req, timeout=120) as resp:
        body = json.loads(resp.read())
    choice = body["choices"][0]
    ids = choice.get("token_ids") or []
    print(name, json.dumps({
        "text": choice.get("text"),
        "token_ids": ids,
        "finish_reason": choice.get("finish_reason"),
    }, ensure_ascii=False))
    print(name, "allowed_ok", bool(ids) and all(token_id in allowed for token_id in ids))
```

Main:

```text
beam {"text": " Paris", "token_ids": [12095], "finish_reason": "length"}
beam allowed_ok False
sampling {"text": " banana", "token_ids": [43096], "finish_reason": "length"}
sampling allowed_ok True
```

This branch:

```text
beam {"text": " banana", "token_ids": [43096], "finish_reason": "length"}
beam allowed_ok True
sampling {"text": " banana", "token_ids": [43096], "finish_reason": "length"}
sampling allowed_ok True
```

After reverting this branch diff:

```text
beam {"text": " Paris", "token_ids": [12095], "finish_reason": "length"}
beam allowed_ok False
sampling {"text": " banana", "token_ids": [43096], "finish_reason": "length"}
sampling allowed_ok True
```

Lint:

```text
PYTHONPATH=$PWD python -m ruff check vllm/entrypoints/generate/beam_search/online.py vllm/entrypoints/generate/beam_search/offline.py vllm/entrypoints/openai/chat_completion/protocol.py vllm/entrypoints/openai/completion/protocol.py vllm/sampling_params.py
All checks passed!

PYTHONPATH=$PWD python -m ruff format --check vllm/entrypoints/generate/beam_search/online.py vllm/entrypoints/generate/beam_search/offline.py vllm/entrypoints/openai/chat_completion/protocol.py vllm/entrypoints/openai/completion/protocol.py vllm/sampling_params.py
5 files already formatted
```

</details>

AI assistance was used to prepare this PR.

cc @DarkLight1337 @njhill
