### PR TITLE
[Perf] Minimax M3 - Support cross-layer allreduce-norm fusion

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -127,7 +127,7 @@ def FusedMoE(
     num_redundant_experts: int = 0,
     has_bias: bool = False,
     is_sequence_parallel: bool = False,
-    skip_final_all_reduce: bool = False,
+    reduce_results: bool = True,
     ckpt_names: tuple[str, str, str] = ("gate_proj", "down_proj", "up_proj"),
     n_shared_experts: int | None = None,
     router_logits_dtype: torch.dtype | None = None,
@@ -185,8 +185,9 @@ def FusedMoE(
         num_redundant_experts: Number of redundant experts for EPLB
         has_bias: Whether expert layers have bias terms
         is_sequence_parallel: Whether sequence parallelism is enabled
-        skip_final_all_reduce: Whether to skip the final all-reduce, only
-        honored on the late-AR path.
+        reduce_results: Whether to all-reduce the final output. Setting this
+        to False (to fuse the all-reduce downstream) is only honored on the
+        late-AR path.
         expert_mapping: Expert parameter mapping for weight loading
         n_shared_experts: Number of shared experts to fuse into the routed
             grouped GEMM (ROCm; requires aiter FSE or the router-append path)
@@ -223,9 +224,9 @@ def FusedMoE(
         parallel_config=vllm_config.parallel_config,
     )
 
-    # Resolve the skip_final_all_reduce request against the parallel config.
+    # Resolve the deferred all-reduce request against the parallel config.
     skip_final_all_reduce = (
-        skip_final_all_reduce
+        not reduce_results
         and not moe_parallel_config.use_all2all_kernels
         and not moe_parallel_config.is_sequence_parallel
         and zero_expert_type is None

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -127,6 +127,7 @@ def FusedMoE(
     num_redundant_experts: int = 0,
     has_bias: bool = False,
     is_sequence_parallel: bool = False,
+    skip_final_all_reduce: bool = False,
     ckpt_names: tuple[str, str, str] = ("gate_proj", "down_proj", "up_proj"),
     n_shared_experts: int | None = None,
     router_logits_dtype: torch.dtype | None = None,
@@ -184,6 +185,8 @@ def FusedMoE(
         num_redundant_experts: Number of redundant experts for EPLB
         has_bias: Whether expert layers have bias terms
         is_sequence_parallel: Whether sequence parallelism is enabled
+        skip_final_all_reduce: Whether to skip the final all-reduce, only
+        honored on the late-AR path.
         expert_mapping: Expert parameter mapping for weight loading
         n_shared_experts: Number of shared experts to fuse into the routed
             grouped GEMM (ROCm; requires aiter FSE or the router-append path)
@@ -218,6 +221,14 @@ def FusedMoE(
         pcp_size=pcp_size,
         is_sequence_parallel=is_sequence_parallel,
         parallel_config=vllm_config.parallel_config,
+    )
+
+    # Resolve the skip_final_all_reduce request against the parallel config.
+    skip_final_all_reduce = (
+        skip_final_all_reduce
+        and not moe_parallel_config.use_all2all_kernels
+        and not moe_parallel_config.is_sequence_parallel
+        and zero_expert_type is None
     )
 
     global_num_experts, logical_num_experts, num_fused_shared_experts = (
@@ -340,6 +351,7 @@ def FusedMoE(
         swiglu_alpha=swiglu_alpha,
         swiglu_beta=swiglu_beta,
         max_capture_size=vllm_config.compilation_config.max_cudagraph_capture_size,
+        skip_final_all_reduce=skip_final_all_reduce,
     )
 
     logger.debug("FusedMoEConfig = %s", moe_config)

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -413,6 +413,24 @@ class MoERunner(MoERunnerInterface):
             and self._quant_method.moe_kernel.output_is_reduced()
         )
 
+    @property
+    def _can_defer_final_all_reduce(self) -> bool:
+        """Return True if the final all-reduce can be deferred for fusion."""
+        cfg = self.moe_config
+        return (
+            cfg.tp_size > 1
+            and not cfg.use_ep
+            and not cfg.is_sequence_parallel
+            and not self._fused_output_is_reduced
+        )
+
+    def try_defer_final_all_reduce(self) -> bool:
+        """Try deferring the final all-reduce for fusion."""
+        if self._can_defer_final_all_reduce:
+            self.moe_config.skip_final_all_reduce = True
+            return True
+        return False
+
     def _maybe_reduce_shared_expert_output(
         self,
         shared_output: torch.Tensor | None,

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -413,24 +413,6 @@ class MoERunner(MoERunnerInterface):
             and self._quant_method.moe_kernel.output_is_reduced()
         )
 
-    @property
-    def _can_defer_final_all_reduce(self) -> bool:
-        """Return True if the final all-reduce can be deferred for fusion."""
-        cfg = self.moe_config
-        return (
-            cfg.tp_size > 1
-            and not cfg.use_ep
-            and not cfg.is_sequence_parallel
-            and not self._fused_output_is_reduced
-        )
-
-    def try_defer_final_all_reduce(self) -> bool:
-        """Try deferring the final all-reduce for fusion."""
-        if self._can_defer_final_all_reduce:
-            self.moe_config.skip_final_all_reduce = True
-            return True
-        return False
-
     def _maybe_reduce_shared_expert_output(
         self,
         shared_output: torch.Tensor | None,
@@ -446,7 +428,6 @@ class MoERunner(MoERunnerInterface):
         if (
             shared_output is not None
             and not self.moe_config.is_sequence_parallel
-            and not self.moe_config.skip_final_all_reduce
             and self._fused_output_is_reduced
         ):
             shared_output = tensor_model_parallel_all_reduce(shared_output)
@@ -464,6 +445,13 @@ class MoERunner(MoERunnerInterface):
         here. Skipped when sequence-parallel is active (SP handles its
         own reduction) or when the early path already reduced both outputs.
         """
+        # skip_final_all_reduce must not coexist with a pre-reduced fused
+        # output. This should be enforced by MoE config initialization.
+        if self.moe_config.skip_final_all_reduce:
+            assert not self._fused_output_is_reduced, (
+                "skip_final_all_reduce requires an un-reduced fused output"
+            )
+
         # We don't need to reduce the final output if:
         # - We are not running with TP or DP
         # - The MK already reduced the fused output itself.

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -279,7 +279,7 @@ class DeepseekV2MoE(nn.Module):
         config: DeepseekV2Config | DeepseekV3Config,
         parallel_config: ParallelConfig,
         quant_config: QuantizationConfig | None = None,
-        skip_final_all_reduce: bool = False,
+        reduce_results: bool = True,
         prefix: str = "",
         apply_routed_scale_to_output: bool = False,
     ):
@@ -380,7 +380,7 @@ class DeepseekV2MoE(nn.Module):
             enable_eplb=self.enable_eplb,
             num_redundant_experts=self.n_redundant_experts,
             is_sequence_parallel=self.is_sequence_parallel,
-            skip_final_all_reduce=skip_final_all_reduce,
+            reduce_results=reduce_results,
             n_shared_experts=config.n_shared_experts
             if self.is_fusion_moe_shared_experts_enabled
             else None,

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -279,6 +279,7 @@ class DeepseekV2MoE(nn.Module):
         config: DeepseekV2Config | DeepseekV3Config,
         parallel_config: ParallelConfig,
         quant_config: QuantizationConfig | None = None,
+        skip_final_all_reduce: bool = False,
         prefix: str = "",
         apply_routed_scale_to_output: bool = False,
     ):
@@ -379,6 +380,7 @@ class DeepseekV2MoE(nn.Module):
             enable_eplb=self.enable_eplb,
             num_redundant_experts=self.n_redundant_experts,
             is_sequence_parallel=self.is_sequence_parallel,
+            skip_final_all_reduce=skip_final_all_reduce,
             n_shared_experts=config.n_shared_experts
             if self.is_fusion_moe_shared_experts_enabled
             else None,

--- a/vllm/models/deepseek_v32/nvidia/model.py
+++ b/vllm/models/deepseek_v32/nvidia/model.py
@@ -72,17 +72,17 @@ class DeepseekV32DecoderLayer(torch.nn.Module):
             and layer_idx >= config.first_k_dense_replace
             and layer_idx % moe_layer_freq == 0
         ):
+            # Defer the MoE cross-rank all-reduce; it is fused into the next
+            # layer's input_layernorm (or the final norm) via
+            # fused_allreduce_rms_norm.
             self.mlp = DeepseekV2MoE(
                 config=config,
                 parallel_config=parallel_config,
                 quant_config=quant_config,
+                skip_final_all_reduce=True,
                 prefix=f"{prefix}.mlp",
                 apply_routed_scale_to_output=False,
             )
-            # Defer the MoE cross-rank all-reduce; it is fused into the next
-            # layer's input_layernorm (or the final norm) via
-            # fused_allreduce_rms_norm. self.mlp.experts is the MoERunner.
-            self.mlp.experts.moe_config.skip_final_all_reduce = True
         else:
             self.mlp = DeepseekV2MLP(
                 hidden_size=config.hidden_size,

--- a/vllm/models/deepseek_v32/nvidia/model.py
+++ b/vllm/models/deepseek_v32/nvidia/model.py
@@ -79,7 +79,7 @@ class DeepseekV32DecoderLayer(torch.nn.Module):
                 config=config,
                 parallel_config=parallel_config,
                 quant_config=quant_config,
-                skip_final_all_reduce=True,
+                reduce_results=False,
                 prefix=f"{prefix}.mlp",
                 apply_routed_scale_to_output=False,
             )

--- a/vllm/models/deepseek_v32/nvidia/mtp.py
+++ b/vllm/models/deepseek_v32/nvidia/mtp.py
@@ -89,7 +89,7 @@ class DeepseekV32MultiTokenPredictorLayer(nn.Module):
         hidden_states, residual = self.mtp_block(
             positions=positions, hidden_states=hidden_states, residual=None
         )
-        # mtp_block's MoE output is left un-reduced (skip_final_all_reduce); the
+        # mtp_block's MoE output is left un-reduced (reduce_results=False); the
         # main model fuses that all-reduce into the next norm, but here the
         # recycle hidden is consumed directly, so reduce it now.
         hidden_states = tensor_model_parallel_all_reduce(hidden_states)

--- a/vllm/models/minimax_m3/nvidia/model.py
+++ b/vllm/models/minimax_m3/nvidia/model.py
@@ -744,6 +744,14 @@ class MiniMaxM3DecoderLayer(nn.Module):
         hidden_states = ffn(hidden_states)
         return hidden_states, residual
 
+    def defer_ffn_all_reduce(self) -> bool:
+        """Defer this layer's FFN output all-reduce to fuse with next layer's
+        input_layernorm. Returns True if the deferral is active, False otherwise.
+        """
+        if self.is_moe_layer:
+            return self.block_sparse_moe.experts.try_defer_final_all_reduce()
+        return not self.mlp.down_proj.reduce_results
+
 
 class MiniMaxM3Model(nn.Module, EagleModelMixin):
     fall_back_to_pt_during_load = False
@@ -805,6 +813,7 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states", "residual"], config.hidden_size
         )
+        self.fuse_final_norm_allreduce = False
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
@@ -840,7 +849,12 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
                 {"hidden_states": hidden_states, "residual": residual}
             )
 
-        hidden_states, _ = self.norm(hidden_states, residual)
+        if self.fuse_final_norm_allreduce:
+            hidden_states, _ = fused_allreduce_gemma_rms_norm(
+                hidden_states, residual, self.norm
+            )
+        else:
+            hidden_states, _ = self.norm(hidden_states, residual)
 
         if len(aux_hidden_states) > 0:
             return hidden_states, aux_hidden_states
@@ -980,8 +994,26 @@ class MiniMaxM3SparseForCausalLM(nn.Module, SupportsPP, SupportsEagle3):
             self.model.make_empty_intermediate_tensors
         )
 
+        # Lazy configure cross-layer allreduce/RMSNorm fusion on first forward
+        self._ar_fusion_configured = False
+
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
+
+    def _configure_allreduce_fusion(self) -> None:
+        """Configure cross-layer all-reduce/RMSNorm fusion after weights load."""
+        if self._ar_fusion_configured:
+            return
+        self._ar_fusion_configured = True
+        if get_pp_group().world_size > 1:
+            return
+        model = self.model
+        prev_defers = False
+        layers = model.layers[model.start_layer : model.end_layer]
+        for idx, layer in enumerate(layers):
+            layer.fuse_input_allreduce = idx > 0 and prev_defers
+            prev_defers = layer.defer_ffn_all_reduce()
+        model.fuse_final_norm_allreduce = prev_defers
 
     def forward(
         self,
@@ -991,6 +1023,7 @@ class MiniMaxM3SparseForCausalLM(nn.Module, SupportsPP, SupportsEagle3):
         inputs_embeds: torch.Tensor | None = None,
         **kwargs,
     ) -> torch.Tensor | IntermediateTensors:
+        self._configure_allreduce_fusion()
         return self.model(input_ids, positions, intermediate_tensors, inputs_embeds)
 
     def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:

--- a/vllm/models/minimax_m3/nvidia/model.py
+++ b/vllm/models/minimax_m3/nvidia/model.py
@@ -196,7 +196,7 @@ class MiniMaxM3MoE(nn.Module):
         config: PretrainedConfig,
         layer_id: int,
         quant_config: QuantizationConfig | None = None,
-        skip_final_all_reduce: bool = False,
+        reduce_results: bool = True,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -262,7 +262,7 @@ class MiniMaxM3MoE(nn.Module):
             router_logits_dtype=self.gate.out_dtype,
             shared_experts=self.shared_experts,
             quant_config=quant_config,
-            skip_final_all_reduce=skip_final_all_reduce,
+            reduce_results=reduce_results,
             prefix=f"{prefix}.experts",
         )
 
@@ -692,8 +692,8 @@ class MiniMaxM3DecoderLayer(nn.Module):
         # Leave the FFN output un-reduced so its all-reduce fuses into the
         # next RMSNorm. MTP blocks add the residual directly and PP sends
         # hidden states across stages, so both must reduce.
-        skip_ffn_all_reduce = (
-            not is_mtp_block and vllm_config.parallel_config.pipeline_parallel_size == 1
+        reduce_results = (
+            is_mtp_block or vllm_config.parallel_config.pipeline_parallel_size > 1
         )
         self.is_moe_layer = force_moe or _is_moe_layer(config, layer_id)
         if self.is_moe_layer:
@@ -701,7 +701,7 @@ class MiniMaxM3DecoderLayer(nn.Module):
                 config=config,
                 layer_id=layer_id,
                 quant_config=quant_config,
-                skip_final_all_reduce=skip_ffn_all_reduce,
+                reduce_results=reduce_results,
                 prefix=f"{prefix}.block_sparse_moe",
             )
         else:
@@ -710,7 +710,7 @@ class MiniMaxM3DecoderLayer(nn.Module):
                 intermediate_size=config.dense_intermediate_size,
                 quant_config=quant_config,
                 prefix=f"{prefix}.mlp",
-                reduce_results=not skip_ffn_all_reduce,
+                reduce_results=reduce_results,
             )
 
         # config.use_gemma_norm is True for M3 -> Gemma-style RMSNorm.

--- a/vllm/models/minimax_m3/nvidia/model.py
+++ b/vllm/models/minimax_m3/nvidia/model.py
@@ -196,6 +196,7 @@ class MiniMaxM3MoE(nn.Module):
         config: PretrainedConfig,
         layer_id: int,
         quant_config: QuantizationConfig | None = None,
+        skip_final_all_reduce: bool = False,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -261,6 +262,7 @@ class MiniMaxM3MoE(nn.Module):
             router_logits_dtype=self.gate.out_dtype,
             shared_experts=self.shared_experts,
             quant_config=quant_config,
+            skip_final_all_reduce=skip_final_all_reduce,
             prefix=f"{prefix}.experts",
         )
 
@@ -658,14 +660,10 @@ class MiniMaxM3DecoderLayer(nn.Module):
         layer_id = int(prefix.split(sep=".")[-1])
         self.layer_id = layer_id
 
-        # Complete the preceding dense MLP's deferred all-reduce
-        # (reduce_results=False), fused into this layer's input_layernorm.
-        # Disable this fusion when PP is set
-        self.fuse_input_allreduce = (
-            layer_id > 0
-            and not _is_moe_layer(config, layer_id - 1)
-            and vllm_config.parallel_config.pipeline_parallel_size == 1
-        )
+        # When set, complete the preceding layer's deferred FFN all-reduce
+        # fused into this layer's input_layernorm.
+        # Configured by MiniMaxM3Model.__init__
+        self.fuse_input_allreduce = False
 
         is_sparse_attention_layer = (
             force_sparse_attn or layer_id in _sparse_attention_layer_ids(config)
@@ -691,12 +689,19 @@ class MiniMaxM3DecoderLayer(nn.Module):
 
         # Dense layers store the FFN under `mlp`; MoE layers under
         # `block_sparse_moe` -- matching the checkpoint's naming.
+        # Leave the FFN output un-reduced so its all-reduce fuses into the
+        # next RMSNorm. MTP blocks add the residual directly and PP sends
+        # hidden states across stages, so both must reduce.
+        skip_ffn_all_reduce = (
+            not is_mtp_block and vllm_config.parallel_config.pipeline_parallel_size == 1
+        )
         self.is_moe_layer = force_moe or _is_moe_layer(config, layer_id)
         if self.is_moe_layer:
             self.block_sparse_moe = MiniMaxM3MoE(
                 config=config,
                 layer_id=layer_id,
                 quant_config=quant_config,
+                skip_final_all_reduce=skip_ffn_all_reduce,
                 prefix=f"{prefix}.block_sparse_moe",
             )
         else:
@@ -705,7 +710,7 @@ class MiniMaxM3DecoderLayer(nn.Module):
                 intermediate_size=config.dense_intermediate_size,
                 quant_config=quant_config,
                 prefix=f"{prefix}.mlp",
-                reduce_results=vllm_config.parallel_config.pipeline_parallel_size > 1,
+                reduce_results=not skip_ffn_all_reduce,
             )
 
         # config.use_gemma_norm is True for M3 -> Gemma-style RMSNorm.
@@ -744,12 +749,12 @@ class MiniMaxM3DecoderLayer(nn.Module):
         hidden_states = ffn(hidden_states)
         return hidden_states, residual
 
-    def defer_ffn_all_reduce(self) -> bool:
-        """Defer this layer's FFN output all-reduce to fuse with next layer's
-        input_layernorm. Returns True if the deferral is active, False otherwise.
-        """
+    @property
+    def ffn_all_reduce_deferred(self) -> bool:
+        """This layer's FFN output is left un-reduced; the caller fuses the
+        all-reduce into the next RMSNorm."""
         if self.is_moe_layer:
-            return self.block_sparse_moe.experts.try_defer_final_all_reduce()
+            return self.block_sparse_moe.experts.moe_config.skip_final_all_reduce
         return not self.mlp.down_proj.reduce_results
 
 
@@ -813,7 +818,15 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states", "residual"], config.hidden_size
         )
-        self.fuse_final_norm_allreduce = False
+
+        # Configure cross-layer all-reduce/RMSNorm fusion: a layer whose FFN output
+        # is left un-reduced has that all-reduce fused into the next layer's
+        # input_layernorm (or the final norm).
+        prev_defers = False
+        for idx, layer in enumerate(self.layers[self.start_layer : self.end_layer]):
+            layer.fuse_input_allreduce = idx > 0 and prev_defers
+            prev_defers = layer.ffn_all_reduce_deferred
+        self.fuse_final_norm_allreduce = prev_defers
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
@@ -994,26 +1007,8 @@ class MiniMaxM3SparseForCausalLM(nn.Module, SupportsPP, SupportsEagle3):
             self.model.make_empty_intermediate_tensors
         )
 
-        # Lazy configure cross-layer allreduce/RMSNorm fusion on first forward
-        self._ar_fusion_configured = False
-
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
-
-    def _configure_allreduce_fusion(self) -> None:
-        """Configure cross-layer all-reduce/RMSNorm fusion after weights load."""
-        if self._ar_fusion_configured:
-            return
-        self._ar_fusion_configured = True
-        if get_pp_group().world_size > 1:
-            return
-        model = self.model
-        prev_defers = False
-        layers = model.layers[model.start_layer : model.end_layer]
-        for idx, layer in enumerate(layers):
-            layer.fuse_input_allreduce = idx > 0 and prev_defers
-            prev_defers = layer.defer_ffn_all_reduce()
-        model.fuse_final_norm_allreduce = prev_defers
 
     def forward(
         self,
@@ -1023,7 +1018,6 @@ class MiniMaxM3SparseForCausalLM(nn.Module, SupportsPP, SupportsEagle3):
         inputs_embeds: torch.Tensor | None = None,
         **kwargs,
     ) -> torch.Tensor | IntermediateTensors:
-        self._configure_allreduce_fusion()
         return self.model(input_ids, positions, intermediate_tensors, inputs_embeds)
 
     def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:

--- a/vllm/v1/attention/backends/mla/prefill/selector.py
+++ b/vllm/v1/attention/backends/mla/prefill/selector.py
@@ -134,7 +134,7 @@ def get_mla_prefill_backend(
                 f"Reason: {invalid_reasons}"
             )
         assert backend_cls is not None
-        logger.info("Using %s MLA prefill backend.", selected_backend.name)
+        logger.info_once("Using %s MLA prefill backend.", selected_backend.name)
         return backend_cls
 
     return _auto_select_mla_prefill_backend(


### PR DESCRIPTION
## Purpose
This PR supports fusing Minimax M3's MoE layers' allreduce with next's layer's input norm.

## Performance
TP2 with InfX benchmarking: **13406 tok/s -> 13709 tok/s (2.2% speedup)**
```
vllm serve nvidia/MiniMax-M3-NVFP4 \
  --tensor-parallel-size 2 \
  --kv-cache-dtype fp8 \
  --max-model-len 9472 \
  --block-size 128 \
  --language-model-only \
  --max-cudagraph-capture-size 2048 \
  --max-num-batched-tokens 16384 \
  --stream-interval 20 \
  --no-enable-prefix-caching \
  --trust-remote-code

python3 InferenceX/utils/bench_serving/benchmark_serving.py --model nvidia/MiniMax-M3-NVFP4 --backend vllm --base-url http://0.0.0.0:8000 --dataset-name random --random-input-len 8192 --random-output-len 1024 --random-range-ratio 0.8 --num-prompts 320 --max-concurrency 32 --request-rate inf --ignore-eos --save-result --num-warmups 64 --percentile-metrics ttft,tpot,itl,e2el --trust-remote-code
```

main:
```
============ Serving Benchmark Result ============
Successful requests:                     320       
Benchmark duration (s):                  197.53    
Total input tokens:                      2352062   
Total generated tokens:                  296143    
Request throughput (req/s):              1.62      
Output token throughput (tok/s):         1499.27   
Total Token throughput (tok/s):          13406.93  
---------------Time to First Token----------------
Mean TTFT (ms):                          534.59    
Median TTFT (ms):                        240.97    
P90 TTFT (ms):                           649.88    
P99 TTFT (ms):                           4766.60   
P99.9 TTFT (ms):                         5065.79   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          20.31     
Median TPOT (ms):                        20.70     
P90 TPOT (ms):                           21.51     
P99 TPOT (ms):                           22.91     
P99.9 TPOT (ms):                         23.56     
---------------Inter-token Latency----------------
Mean ITL (ms):                           402.28    
Median ITL (ms):                         312.28    
P90 ITL (ms):                            633.81    
P99 ITL (ms):                            1050.50   
P99.9 ITL (ms):                          2566.57   
----------------End-to-end Latency----------------
Mean E2EL (ms):                          19328.52  
Median E2EL (ms):                        19418.41  
P90 E2EL (ms):                           21912.25  
P99 E2EL (ms):                           24980.55  
P99.9 E2EL (ms):                         25503.53 
```

PR:
```
============ Serving Benchmark Result ============
Successful requests:                     320       
Benchmark duration (s):                  193.16    
Total input tokens:                      2352062   
Total generated tokens:                  296143    
Request throughput (req/s):              1.66      
Output token throughput (tok/s):         1533.11   
Total Token throughput (tok/s):          13709.57  
---------------Time to First Token----------------
Mean TTFT (ms):                          523.39    
Median TTFT (ms):                        235.98    
P90 TTFT (ms):                           583.71    
P99 TTFT (ms):                           4744.90   
P99.9 TTFT (ms):                         5052.42   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          19.87     
Median TPOT (ms):                        20.28     
P90 TPOT (ms):                           21.18     
P99 TPOT (ms):                           21.91     
P99.9 TPOT (ms):                         22.78     
---------------Inter-token Latency----------------
Mean ITL (ms):                           393.59    
Median ITL (ms):                         301.95    
P90 ITL (ms):                            626.65    
P99 ITL (ms):                            1066.34   
P99.9 ITL (ms):                          2572.70   
----------------End-to-end Latency----------------
Mean E2EL (ms):                          18911.54  
Median E2EL (ms):                        18939.34  
P90 E2EL (ms):                           21504.25  
P99 E2EL (ms):                           24071.92  
P99.9 E2EL (ms):                         24385.68  
==================================================
```

## Test Plan
- GSM8k Eval (TP, TEP, DEP)

## Test Result
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9098|±  |0.0079|
|     |       |strict-match    |     5|exact_match|↑  |0.9090|±  |0.0079|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

