### PR TITLE
[Bugfix] Pass num_spec to mamba2_state_shape in FalconH1/GraniteMoeHybrid/Zamba2 (spec decode crashes at init)

### DIFF
--- a/vllm/model_executor/models/falcon_h1.py
+++ b/vllm/model_executor/models/falcon_h1.py
@@ -568,6 +568,7 @@ class FalconH1ForCausalLM(
             head_dim=hf_config.mamba_d_head,
             state_size=hf_config.mamba_d_state,
             conv_kernel=hf_config.mamba_d_conv,
+            num_spec=vllm_config.num_speculative_tokens,
         )
 
     @classmethod

--- a/vllm/model_executor/models/granitemoehybrid.py
+++ b/vllm/model_executor/models/granitemoehybrid.py
@@ -631,6 +631,7 @@ class GraniteMoeHybridForCausalLM(
             head_dim=hf_config.mamba_d_head,
             state_size=hf_config.mamba_d_state,
             conv_kernel=hf_config.mamba_d_conv,
+            num_spec=vllm_config.num_speculative_tokens,
         )
 
     @classmethod

--- a/vllm/model_executor/models/zamba2.py
+++ b/vllm/model_executor/models/zamba2.py
@@ -867,6 +867,7 @@ class Zamba2ForCausalLM(nn.Module, HasInnerState, IsHybrid, SupportsMambaPrefixC
             head_dim=hf_config.mamba_headdim,
             state_size=hf_config.mamba_d_state,
             conv_kernel=hf_config.mamba_d_conv,
+            num_spec=vllm_config.num_speculative_tokens,
         )
 
     @classmethod

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -681,7 +681,14 @@ class MambaSpec(KVCacheSpec):
             for (shape, dtype) in zip(self.shapes, self.dtypes)
         )
         if self.page_size_padded is not None:
-            assert self.page_size_padded >= page_size
+            assert self.page_size_padded >= page_size, (
+                f"page_size_padded ({self.page_size_padded}) is smaller than "
+                f"the actual page size ({page_size}). This can happen when "
+                "the mamba page-size estimate used for padding was computed "
+                "with different parameters (e.g. a model's "
+                "get_mamba_state_shape_from_config not accounting for "
+                "num_speculative_tokens) than the layer's state shape."
+            )
             return self.page_size_padded
         return page_size
 


### PR DESCRIPTION
## Purpose

FalconH1, GraniteMoeHybrid and Zamba2 cannot use speculative decoding at all — including the drafter-free ngram/suffix methods. Enabling it fails engine init with a bare `AssertionError`:

```
File ".../vllm/v1/kv_cache_interface.py", in page_size_bytes
  assert self.page_size_padded >= page_size
AssertionError
  (during EngineCore._initialize_kv_caches -> get_kv_cache_configs
   -> unify_kv_cache_spec_page_size)
```

Root cause: vLLM computes mamba state shapes in two places that must agree —

1. the model classmethod `get_mamba_state_shape_from_config`, which feeds the platform's mamba page-size estimate (`cache_config.mamba_page_size_padded`);
2. the layer's `get_state_shape` (`MambaMixer2`, num_spec-aware), which builds the actual `MambaSpec`.

`falcon_h1.py`, `granitemoehybrid.py` and `zamba2.py` omit `num_spec=vllm_config.num_speculative_tokens` in (1). The parameter was added in #33726 (Nemotron-H MTP / Mamba speculative decoding); `nemotron_h.py` and `mamba2.py` pass it, and these three models predate the sweep. With speculative decoding enabled, (1) and (2) disagree by exactly the omitted conv-state headroom and init dies.

Whether it *crashes* is config-dependent: if the attention page already covers the (correct, layer-side) mamba page the assert passes and the model runs — `Zamba2-1.2B` at k=3 boots by luck; `Falcon-H1-0.5B` and `granite-4.0-h-micro` crash.

This PR:
- passes `num_spec=vllm_config.num_speculative_tokens` in the three model classmethods (matching `nemotron_h.py` / `mamba2.py`);
- gives the assert an informative message, since a bare `AssertionError` four frames into KV-cache init is hard to act on.

PLaMo2 has the same omission but is intentionally **not** changed here: its custom `Plamo2MambaMixer` decode path is single-token only (it never passes `num_accepted_tokens`), so a sizing change alone would let the engine start without a working multi-token verify path. That model needs either mixer-side spec support or an explicit unsupported-feature gate — maintainers' call, happy to follow up either way.

## Test Plan

Standalone repro + measurement scripts (crash repro, runtime fix verification from this branch, allocation-depth instrumentation): https://github.com/jethac/vllm-repro-mamba2-spec-sizing

```bash
python repro.py --model tiiuae/Falcon-H1-0.5B-Instruct --mode base   # OK
python repro.py --model tiiuae/Falcon-H1-0.5B-Instruct --mode buggy  # AssertionError
python repro.py --model tiiuae/Falcon-H1-0.5B-Instruct --mode fix    # OK
```

Note: testing `granite-4.0-h-micro` additionally requires #47634 (GraniteMoeHybrid currently cannot load at all under transformers >= 5, independent of this bug).

## Test Result

RTX PRO 6000, vLLM 0.24.0 nightly, ngram k=3, greedy, 4 prompts x 500 tokens:

| model | spec enabled, shipped code | no-spec baseline | with this fix + spec | speedup |
|---|---|---|---|---|
| Falcon-H1-0.5B-Instruct | AssertionError at init | 73.9 tok/s | 91.1 tok/s | 1.23x |
| Zamba2-1.2B-instruct | boots by luck (this config) | 43.6 tok/s | 163.1 tok/s | **3.74x** |
| granite-4.0-h-micro | AssertionError at init | 83.5 tok/s | 168.3 tok/s | 2.02x |

Output integrity: Zamba2 outputs bit-identical to non-speculative greedy on all four prompts; Falcon/Granite match on strongly-determined prompts, and their free-form prompts vary under *any* forward-shape change (control: base-batch4 vs base-batch1 differ with no spec involved — bf16 near-tie drift), consistent with speculative decoding's distribution-level losslessness guarantee. Output token counts identical base vs fixed (falcon 1703/1703, zamba2 627/627). Instrumented runs show conv-line allocation `width-1+k` and zero token-axis overflow.

## Duplicate-work check

Searched open PRs for `mamba2_state_shape`, mamba speculative-decoding state shape, and `num_speculative_tokens`:

- **#50272** (approved) and **#44296** fix the same class of defect — speculative-decoding state sizing — but for `short_conv` / LFM2, in `short_conv.py` and `mamba_utils.py`. No file overlap with this PR, which changes `falcon_h1.py`, `granitemoehybrid.py`, `zamba2.py` and `kv_cache_interface.py`. The two are complementary: #50272 landing does not fix these three models.
- **#43518** (draft, FP8 SSM cache checkpointing) is unrelated.

No open PR passes `num_spec` in the FalconH1 / GraniteMoeHybrid / Zamba2 classmethods.

## AI assistance

This change was developed with AI assistance (Claude, via Claude Code). A human author (Jetha Chan) reviewed every changed line, ran the tests and hardware validation reported above, and can defend the change end-to-end. Commits carry the `Co-authored-by` trailer.
