### PR TITLE
[KV Connector] Normalize list/tuple KV cache input in register_kv_caches

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py
@@ -212,6 +212,76 @@ def test_register_kv_caches_deduplicates_shared_backing_memory(monkeypatch):
         connector.connector_worker = None
 
 
+def test_register_kv_caches_accepts_multi_view_list_input(monkeypatch):
+    """Layers whose backend exposes multiple views (e.g. Ascend's compressed
+    MLA with separate K and scale tensors of different dtypes) pass a list
+    as the kv_caches value. Each view must be registered, and views sharing
+    the same backing storage are deduplicated for the underlying engine.
+    """
+    monkeypatch.setenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", "5")
+    vllm_config = create_vllm_config(
+        kv_connector="MooncakeConnector",
+        kv_role="kv_consumer",
+    )
+    kv_cache_config = make_hybrid_gdn_kv_cache_config(
+        vllm_config.cache_config.block_size
+    )
+
+    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
+        connector = MooncakeConnector(
+            vllm_config,
+            KVConnectorRole.WORKER,
+            kv_cache_config,
+        )
+        worker = connector.connector_worker
+
+        # Two views of the same backing storage with DIFFERENT dtypes, like
+        # Ascend's compressed MLA [k_cache (int8), scale_cache (fp16)].
+        backing = torch.empty((4, 64), dtype=torch.float16)
+        k_cache = torch.empty((2, 2, 11), dtype=torch.int8)
+        scale_cache = torch.empty((2, 2, 11), dtype=torch.float16)
+
+        with patch.object(
+            worker.engine, "batch_register_memory", return_value=0
+        ) as batch_register_memory:
+            worker.register_kv_caches(
+                {
+                    "model.layers.0.self_attn": [k_cache, scale_cache],
+                    "model.layers.1.linear_attn": backing,
+                }
+            )
+
+        # Both views of the list-valued layer are registered.
+        assert worker.kv_caches_base_addr == [
+            k_cache.data_ptr(),
+            scale_cache.data_ptr(),
+            backing.data_ptr(),
+        ]
+        assert worker.registered_layer_names == [
+            "model.layers.0.self_attn",
+            "model.layers.0.self_attn",
+            "model.layers.1.linear_attn",
+        ]
+        batch_register_memory.assert_called_once()
+        registered_ptrs, registered_lens = batch_register_memory.call_args[0]
+        # Each unique tensor is registered once (k and scale have distinct
+        # storage here).
+        assert set(registered_ptrs) == {
+            k_cache.data_ptr(),
+            scale_cache.data_ptr(),
+            backing.data_ptr(),
+        }
+        assert registered_lens == [
+            k_cache.untyped_storage().nbytes(),
+            scale_cache.untyped_storage().nbytes(),
+            backing.untyped_storage().nbytes(),
+        ]
+
+        worker.shutdown()
+        worker.shutdown = noop_shutdown
+        connector.connector_worker = None
+
+
 def test_hybrid_gdn_transfer_params_preserve_group_identity(monkeypatch):
     monkeypatch.setenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", "5")
     vllm_config = create_vllm_config(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -1677,6 +1677,10 @@ class MooncakeConnectorWorker:
             if isinstance(layer_spec, MambaSpec):
                 conv, _ = cache_or_caches
                 cache_list = [conv]
+            elif isinstance(cache_or_caches, (list, tuple)):
+                # Some backends expose multiple views per layer when the
+                # views have different dtypes and cannot share one tensor.
+                cache_list = list(cache_or_caches)
             else:
                 # K and V are packed into one blocks-first tensor per layer,
                 # so each layer registers as a single region.


### PR DESCRIPTION
## Purpose

Some backends expose a layer's KV cache as a **list of tensors** rather than a single tensor. The motivating case is Ascend's compressed MLA (`AscendMLAAttentionSpec` with `scale_dim > 0`): the per-block quantization **scale** (fp16) and the int8 **key** have different dtypes and therefore cannot share a single `torch.Tensor`. vllm-ascend's `_adjust_kv_layout` returns `[k_cache, scale_cache]` for such layers, and the NPU indexer kernel consumes them as two independent inputs. The same per-layer-list shape will appear for any backend that needs heterogeneous-dtype views over one storage.

The Mooncake and NIXL connectors derive the per-layer tensor list with `TransferTopology.get_transfer_cache_regions()`, which so far returned `cache if split_k_and_v else [cache]`. For MLA `split_k_and_v` is `False`, so a list input was wrapped as `[[k, scale]]` and iterated into the list itself, crashing:

```
AttributeError: 'list' object has no attribute 'data_ptr'
  File ".../mooncake_connector.py", line ..., in register_kv_caches
    base_addr = cache.data_ptr()
```

The NIXL receive-side post-processing had the equivalent `cache_or_caches if split_k_and_v else [cache_or_caches]` pattern.

The topology flag is the **wrong discriminator** here: it describes whether K and V are stored separately, not whether the backend handed over multiple views of one layer. This change discriminates by the actual data shape (`isinstance(cache, (list, tuple))`) instead.

## Changes

- `TransferTopology.get_transfer_cache_regions()` now returns `list[torch.Tensor]` unconditionally. When the input is already a list/tuple (multi-view backend), each view is returned as-is so every view is registered; storage-aware deduplication downstream (Mooncake's `seen_storage_ptrs`, NIXL's `seen_base_addresses`) collapses views that share the same backing memory into one region. The non-MLA split path returns `list(cache)` instead of the bare tensor so callers can iterate uniformly.
- `NixlPullConnectorWorker`'s receive-side post-processing loop now branches on `isinstance(cache_or_caches, (list, tuple))` before falling back to the `split_k_and_v` flag, so every view of a multi-view layer is post-processed.
- Mooncake's `register_kv_caches` needs no change: it already consumes `get_transfer_cache_regions()`'s result and deduplicates by storage.

This is a **platform-agnostic** robustness fix. On CUDA DSV4 compress-MLA the `kv_caches` value is a single `uint8` tensor (scale packed into the head dimension via the `fp8_ds_mla` block format), so the list branch is not taken. On Ascend, where k (int8) and scale (fp16) must be separate views, `register_kv_caches` now succeeds instead of crashing.

## Not a duplicate

I checked open PRs and did not find one addressing the multi-view (list) `kv_caches` input. Related but orthogonal:
- #46807 added Mooncake GDN + DSV4 MLA support (CUDA, single-tensor MLA) and introduced the `seen_storage_ptrs` dedup consumed by this fix.
- #46004 adds PP/TP shared-KV metadata alignment; it also does not handle the list-input case (verified by inspecting its `register_kv_caches`).

## Out of scope

MoRIIO's `iter_layer_registration_regions` routes the layer tensor through `get_layer_transfer_geometry()`, which inspects `kv_cache.shape`/`stride()` and therefore still assumes a single tensor for the multi-view case. That path needs its own per-view geometry handling and is left for a follow-up.

## Test Plan

### Unit test

New test `test_register_kv_caches_accepts_multi_view_list_input` in `tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py`: registers a list-valued kv_caches entry with two tensors of different dtypes (int8 key + fp16 scale) and asserts both views are registered and each unique backing storage is registered once with the underlying engine.

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py -v
```

### E2E (Ascend, deepseek-v4-flash)

PD-disaggregated serving with `MooncakeConnector` (`mooncake_protocol=ascend`), prefill TP4/DP4 + decode TP1/DP16. Without this change every worker crashes in `register_kv_caches` with `'list' object has no attribute 'data_ptr'`. With this change both engines start and a disagg request returns the expected completion.

## Test Result

- Local pre-commit (`ruff-check`, `ruff-format`, `mypy-3.12`, SPDX, forbidden-imports): all passed.
- Ascend E2E: prefill + decode both reach `Application startup complete`; `bash scripts/send_request.sh 9000` returns `Hello! I'm DeepSeek, an AI` (prefill 0.996s + decode 0.476s, 10 tokens).

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR.
- [x] The test plan.
- [x] The test results.
- [ ] (Optional) Documentation update. Not applicable: this changes connector-internal input handling, not a public API or model doc.
</details>