### PR TITLE
[Tests] Add parallel sampling coverage for LLMEngine.add_request()/step() (#21948)

### DIFF
--- a/tests/v1/engine/test_parallel_sampling.py
+++ b/tests/v1/engine/test_parallel_sampling.py
@@ -1,11 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import pytest
+
 from vllm import SamplingParams
+from vllm.engine.arg_utils import EngineArgs
 from vllm.outputs import CompletionOutput
 from vllm.sampling_params import RequestOutputKind
 from vllm.v1.engine import EngineCoreRequest
+from vllm.v1.engine.llm_engine import LLMEngine
 from vllm.v1.engine.parallel_sampling import ParentRequest
+from vllm.v1.executor.abstract import Executor
+
+from ...utils import create_new_process_for_each_test
 
 
 def test_parent_request_to_output_stream() -> None:
@@ -66,6 +73,80 @@ def test_parent_request_to_output_final_only() -> None:
     assert ([output_0, output_1], True) == parent_request.get_outputs(
         "child_id_1", output_1
     )
+
+
+@pytest.mark.parametrize(
+    "output_kind",
+    [
+        RequestOutputKind.CUMULATIVE,
+        RequestOutputKind.DELTA,
+        RequestOutputKind.FINAL_ONLY,
+    ],
+)
+@create_new_process_for_each_test()
+def test_llm_engine_add_request_step_parallel_sampling(
+    output_kind: RequestOutputKind,
+) -> None:
+    """Regression test for
+    https://github.com/vllm-project/vllm/issues/21948: exercise parallel
+    sampling (n>1) directly through `LLMEngine.add_request()`/`step()` for
+    every `output_kind`. Previously only `LLM.generate()` (which always
+    enforces `FINAL_ONLY`, see `test_llm_engine.py::test_parallel_sampling`)
+    had coverage at this layer, so the `CUMULATIVE`/`DELTA` combinations here
+    -- and specifically the "`LLMEngine` + `CUMULATIVE`" combination the
+    issue calls out as suspect -- were unverified.
+    """
+    n = 2
+    engine_args = EngineArgs(
+        model="hmellor/tiny-random-LlamaForCausalLM",
+        enforce_eager=True,
+        gpu_memory_utilization=0.3,
+        max_model_len=64,
+    )
+    vllm_config = engine_args.create_engine_config()
+    executor_class = Executor.get_class(vllm_config)
+    engine = LLMEngine(
+        vllm_config=vllm_config, executor_class=executor_class, log_stats=False
+    )
+
+    sampling_params = SamplingParams(
+        n=n, output_kind=output_kind, max_tokens=8, temperature=0.9, seed=0
+    )
+    engine.add_request("req-0", "Hello, my name is", sampling_params)
+
+    texts: dict[int, str] = {i: "" for i in range(n)}
+    finished: set[int] = set()
+    steps = 0
+    while len(finished) < n and steps < 200:
+        for out in engine.step():
+            for comp in out.outputs:
+                if output_kind == RequestOutputKind.DELTA:
+                    # DELTA: each update carries only the newly generated
+                    # fragment -- reconstruct the full text by concatenating.
+                    texts[comp.index] += comp.text
+                elif output_kind == RequestOutputKind.CUMULATIVE:
+                    # CUMULATIVE: each update must extend (never diverge
+                    # from) the text already seen for this index -- this is
+                    # exactly the property #21948 suspected was broken for
+                    # LLMEngine + CUMULATIVE specifically.
+                    assert comp.text.startswith(texts[comp.index]), (
+                        f"CUMULATIVE text for index {comp.index} did not "
+                        f"extend monotonically: {texts[comp.index]!r} -> "
+                        f"{comp.text!r}"
+                    )
+                    texts[comp.index] = comp.text
+                else:
+                    # FINAL_ONLY: one update per index, carrying its full
+                    # final text.
+                    texts[comp.index] = comp.text
+                if comp.finish_reason is not None:
+                    finished.add(comp.index)
+        steps += 1
+
+    assert steps < 200, "engine never finished all child requests"
+    assert finished == set(range(n))
+    assert set(texts) == set(range(n))
+    assert all(texts[i] for i in range(n)), texts
 
 
 def make_request(sampling_params: SamplingParams) -> EngineCoreRequest:


### PR DESCRIPTION
# Candidate vllm-project/vllm#21948: [Bug]: Add tests for all parallel sampling parameter combinations

Evidence: https://github.com/vllm-project/vllm/issues/21948
Risk badge: risk=medium effort=medium impact=medium

## Repro
```

```


## Patch (branch `forager/vllm-project-vllm-21948`)
```diff
NOTE: only LLMEngine coverage (AsyncLLM scoped out -- pre-existing is_cuda()-only skip guard on that test file, unrelated to this issue, unverifiable on ROCm). Suspected bug checked directly, does not reproduce; no production fix needed.

diff --git a/tests/v1/engine/test_parallel_sampling.py b/tests/v1/engine/test_parallel_sampling.py
index 395867c06..08a93cf12 100644
--- a/tests/v1/engine/test_parallel_sampling.py
+++ b/tests/v1/engine/test_parallel_sampling.py
@@ -1,11 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import pytest
+
 from vllm import SamplingParams
+from vllm.engine.arg_utils import EngineArgs
 from vllm.outputs import CompletionOutput
 from vllm.sampling_params import RequestOutputKind
 from vllm.v1.engine import EngineCoreRequest
+from vllm.v1.engine.llm_engine import LLMEngine
 from vllm.v1.engine.parallel_sampling import ParentRequest
+from vllm.v1.executor.abstract import Executor
+
+from ...utils import create_new_process_for_each_test
 
 
 def test_parent_request_to_output_stream() -> None:
@@ -68,6 +75,80 @@ def test_parent_request_to_output_final_only() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "output_kind",
+    [
+        RequestOutputKind.CUMULATIVE,
+        RequestOutputKind.DELTA,
+        RequestOutputKind.FINAL_ONLY,
+    ],
+)
+@create_new_process_for_each_test()
+def test_llm_engine_add_request_step_parallel_sampling(
+    output_kind: RequestOutputKind,
+) -> None:
+    """Regression test for
+    https://github.com/vllm-project/vllm/issues/21948: exercise parallel
+    sampling (n>1) directly through `LLMEngine.add_request()`/`step()` for
+    every `output_kind`. Previously only `LLM.generate()` (which always
+    enforces `FINAL_ONLY`, see `test_llm_engine.py::test_parallel_sampling`)
+    had coverage at this layer, so the `CUMULATIVE`/`DELTA` combinations here
+    -- and specifically the "`LLMEngine` + `CUMULATIVE`" combination the
+    issue calls out as suspect -- were unverified.
+    """
+    n = 2
+    engine_args = EngineArgs(
+        model="hmellor/tiny-random-LlamaForCausalLM",
+        enforce_eager=True,
+        gpu_memory_utilization=0.3,
+        max_model_len=64,
+    )
+    vllm_config = engine_args.create_engine_config()
+    executor_class = Executor.get_class(vllm_config)
+    engine = LLMEngine(
+        vllm_config=vllm_config, executor_class=executor_class, log_stats=False
+    )
+
+    sampling_params = SamplingParams(
+        n=n, output_kind=output_kind, max_tokens=8, temperature=0.9, seed=0
+    )
+    engine.add_request("req-0", "Hello, my name is", sampling_params)
+
+    texts: dict[int, str] = {i: "" for i in range(n)}
+    finished: set[int] = set()
+    steps = 0
+    while len(finished) < n and steps < 200:
+        for out in engine.step():
+            for comp in out.outputs:
+                if output_kind == RequestOutputKind.DELTA:
+                    # DELTA: each update carries only the newly generated
+                    # fragment -- reconstruct the full text by concatenating.
+                    texts[comp.index] += comp.text
+                elif output_kind == RequestOutputKind.CUMULATIVE:
+                    # CUMULATIVE: each update must extend (never diverge
+                    # from) the text already seen for this index -- this is
+                    # exactly the property #21948 suspected was broken for
+                    # LLMEngine + CUMULATIVE specifically.
+                    assert comp.text.startswith(texts[comp.index]), (
+                        f"CUMULATIVE text for index {comp.index} did not "
+                        f"extend monotonically: {texts[comp.index]!r} -> "
+                        f"{comp.text!r}"
+                    )
+                    texts[comp.index] = comp.text
+                else:
+                    # FINAL_ONLY: one update per index, carrying its full
+                    # final text.
+                    texts[comp.index] = comp.text
+                if comp.finish_reason is not None:
+                    finished.add(comp.index)
+        steps += 1
+
+    assert steps < 200, "engine never finished all child requests"
+    assert finished == set(range(n))
+    assert set(texts) == set(range(n))
+    assert all(texts[i] for i in range(n)), texts
+
+
 def make_request(sampling_params: SamplingParams) -> EngineCoreRequest:
     return EngineCoreRequest(
         request_id="parent_id",

```

## Verify (MI250 log)
```
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /workspace/vllm
configfile: pyproject.toml
plugins: asyncio-1.4.0, anyio-4.14.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 5 items

tests/v1/engine/test_parallel_sampling.py::test_parent_request_to_output_stream PASSED [ 20%]
tests/v1/engine/test_parallel_sampling.py::test_parent_request_to_output_final_only PASSED [ 40%]
tests/v1/engine/test_parallel_sampling.py::test_llm_engine_add_request_step_parallel_sampling[RequestOutputKind.CUMULATIVE] PASSED [ 60%]
tests/v1/engine/test_parallel_sampling.py::test_llm_engine_add_request_step_parallel_sampling[RequestOutputKind.DELTA] PASSED [ 80%]
tests/v1/engine/test_parallel_sampling.py::test_llm_engine_add_request_step_parallel_sampling[RequestOutputKind.FINAL_ONLY] PASSED [100%]

=============================== warnings summary ===============================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../../usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: 14 warnings
  /usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 5 passed, 16 warnings in 56.64s ========================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute

```

## Self-review (4/5 approve)
  - ✅ The issue is primarily a test-coverage request with a specific suspicion ('LLMEngine + CUMULATIVE may be broken'). The patch adds a parametrized LLMEngine test covering all three output_kind values via add_request()/step(), and for CUMULATIVE it asserts `comp.text.startswith(texts[comp.index])` — a genuine monotonic-extension check that would fail if the suspected aggregation bug were real, so this isn't a tautological/reward-hacked assertion. Since the test exercises the exact reported scenario and passes, the claim that the bug doesn't reproduce is credible, and correctly means no production diff is needed — writing a fix for a non-existent bug would itself be wrong. Scoping out AsyncLLM is disclosed and justified (pre-existing is_cuda()-only skip guard unrelated to this issue, unverifiable on ROCm), so the narrowed scope is transparent rather than hidden. Minor residual uncertainty: the diff snippet shown is truncated near the end of the FINAL_ONLY branch, so the full post-loop assertions weren't visible in the review context, but the reported test run (5 passed, no errors) is consistent with a syntactically complete and functioning test file.
  - ✅ The issue is primarily a test-coverage request with a suspected (unconfirmed) bug in LLMEngine+CUMULATIVE. The patch adds a targeted regression test that directly exercises that exact combination via add_request()/step(), asserting the key correctness property (cumulative text must grow monotonically per sample index) — this is not a vacuous or over-fit assertion, it would actually catch the reported symptom if present. The test passed, supporting the author's claim that the bug doesn't reproduce, so withholding a production code change is appropriate rather than reward-hacking. Scoping out AsyncLLM coverage is disclosed and justified (pre-existing CUDA-only skip guard makes it unverifiable on this ROCm environment) rather than silently dropped. The one caveat is that AsyncLLM tests from the issue remain unwritten, so the issue's broader test-matrix ask is only partially fulfilled, but the specific reported-bug verification is sound and non-hacky.
  - ✅ The patch is a test-only addition matching the issue's request (test coverage for LLMEngine + all output_kind values). The CUMULATIVE test asserts text extends monotonically per index, which is exactly the property the reported bug (LLMEngine+CUMULATIVE) would violate if broken — this is a real invariant check, not a tautological assertion engineered to pass. AsyncLLM coverage is explicitly and transparently scoped out due to a pre-existing, unrelated is_cuda()-only skip guard that makes it unverifiable on this ROCm environment, not hidden. The submitter investigated the suspected bug directly and reports it doesn't reproduce, concluding no production fix is needed — a legitimate outcome for an issue that was fundamentally about closing a test-coverage gap and checking a suspected defect, not a confirmed code bug requiring a source fix. No evidence of narrow/gamed test construction or unrelated side effects.
  - ❌ This is a test-only patch that entirely skips the AsyncLLM half of the requested coverage (dismissed as 'unrelated skip guard'), and for the actually-reported bug (LLMEngine + CUMULATIVE reported broken by a real user) it concludes 'does not reproduce, no production fix needed' based on a single trivial run: a tiny random model, n=2, max_tokens=8, one seed, enforce_eager, no preemption/recomputation/chunked-prefill scenarios exercised. That's a weak basis for closing out a user-reported correctness bug — the monotonic-`startswith` check only catches gross divergence, not subtler issues (e.g., stale detokenizer state, index mixups under scheduling pressure, races across multiple steps) that a minimal single-step-ish repro wouldn't trigger. The patch satisfies the letter of 'add tests' but not the issue's explicit ask to 'expose and fix if so' the specific reported failure, and drops one of the two required test surfaces outright.
  - ✅ The reported issue was a test-coverage gap plus a suspected (unconfirmed) bug in LLMEngine+CUMULATIVE parallel sampling. The patch adds a real regression test that drives the actual production path (EngineArgs -> LLMEngine.add_request()/step(), no mocking) and asserts the specific semantic the issue worried about: that CUMULATIVE output text must extend monotonically per output index (comp.text.startswith(texts[comp.index])), which would fail if the suspected bug (e.g. index cross-talk or non-monotonic text) were present. It also covers DELTA and FINAL_ONLY via parametrization, matching the issue's ask. Scoping out AsyncLLM is disclosed transparently and justified by a pre-existing, unrelated CUDA-only skip guard making it unverifiable on the ROCm/MI250 target hardware — a legitimate scope narrowing rather than a hidden gap. The author's claim that the suspected bug 'does not reproduce' is consistent with the test passing without any production code changes, so this isn't reward-hacking (no weakening of assertions or mocking around the failure); it's a genuine, appropriately narrow test-only change with an honest note about what wasn't covered and why.
