### PR TITLE
[Bugfix][V1] SimpleCPUOffload: defer sliding-window mid-flight block free (load-WAR alternative to #47291)

### DIFF
--- a/tests/v1/core/test_block_pool_defer.py
+++ b/tests/v1/core/test_block_pool_defer.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Deferral fence for mid-flight skipped-block frees (BlockPool)."""
+
+from vllm.v1.core.block_pool import BlockPool
+
+
+def _make_pool() -> BlockPool:
+    return BlockPool(num_gpu_blocks=100, enable_caching=True, hash_block_size=4)
+
+
+def test_immediate_free_when_deferral_disabled():
+    pool = _make_pool()
+    assert pool.defer_skipped_free is False
+    free0 = pool.get_num_free_blocks()
+
+    blocks = pool.get_new_blocks(3)
+    assert pool.get_num_free_blocks() == free0 - 3
+
+    pool.free_blocks_maybe_deferred(blocks)
+    assert pool.get_num_free_blocks() == free0
+    assert len(pool.deferred_skipped_frees) == 0
+
+
+def test_deferred_free_holds_until_fence_processed():
+    pool = _make_pool()
+    pool.defer_skipped_free = True
+    free0 = pool.get_num_free_blocks()
+
+    blocks = pool.get_new_blocks(2)
+    assert pool.get_num_free_blocks() == free0 - 2
+
+    # Freed mid-flight while the reader forward (step 5) is still in-flight.
+    pool.skipped_free_fence = 5
+    pool.free_blocks_maybe_deferred(blocks)
+
+    # Held out of the pool with ref_cnt intact until the reader step is processed.
+    assert pool.get_num_free_blocks() == free0 - 2
+    assert len(pool.deferred_skipped_frees) == 1
+    assert all(b.ref_cnt == 1 for b in blocks)
+
+    pool.drain_skipped_frees(processed_step_seq=4)
+    assert pool.get_num_free_blocks() == free0 - 2
+
+    pool.drain_skipped_frees(processed_step_seq=5)
+    assert pool.get_num_free_blocks() == free0
+    assert len(pool.deferred_skipped_frees) == 0
+    assert all(b.ref_cnt == 0 for b in blocks)
+
+
+def test_drain_respects_monotonic_fences():
+    pool = _make_pool()
+    pool.defer_skipped_free = True
+    free0 = pool.get_num_free_blocks()
+
+    pool.skipped_free_fence = 3
+    pool.free_blocks_maybe_deferred(pool.get_new_blocks(1))
+    pool.skipped_free_fence = 7
+    pool.free_blocks_maybe_deferred(pool.get_new_blocks(1))
+    assert pool.get_num_free_blocks() == free0 - 2
+
+    # Draining at 5 releases only the fence<=5 entry; the fence=7 one stays.
+    pool.drain_skipped_frees(processed_step_seq=5)
+    assert pool.get_num_free_blocks() == free0 - 1
+    assert len(pool.deferred_skipped_frees) == 1
+
+    pool.drain_skipped_frees(processed_step_seq=7)
+    assert pool.get_num_free_blocks() == free0
+    assert len(pool.deferred_skipped_frees) == 0

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections import deque
 from collections.abc import Iterable, Sequence
 from typing import Any
 
@@ -195,6 +196,14 @@ class BlockPool:
         self.kv_event_queue: list[KVCacheEvent] = []
 
         self.metrics_collector = metrics_collector
+
+        # Deferral of blocks a running request frees mid-flight (attention
+        # windows sliding forward). Enabled by the scheduler; fenced by the
+        # scheduling step seq so a block reused as a load destination cannot
+        # clobber it while an in-flight forward still reads it (load-WAR).
+        self.defer_skipped_free = False
+        self.skipped_free_fence = 0
+        self.deferred_skipped_frees: deque[tuple[int, list[KVCacheBlock]]] = deque()
 
     def get_cached_block(
         self, block_hash: BlockHash, kv_cache_group_ids: list[int]
@@ -633,6 +642,28 @@ class BlockPool:
         # Blocks without hash always get evicted first - prepend them last to the tail
         self.free_block_queue.prepend_n(blocks_without_hash)
         self.free_block_queue.append_n(blocks_with_hash)
+
+    def free_blocks_maybe_deferred(self, ordered_blocks: list[KVCacheBlock]) -> None:
+        """Free skipped blocks, deferring the pool return when fencing is active.
+
+        See ``defer_skipped_free`` for why the deferral is needed.
+        """
+        if not self.defer_skipped_free:
+            self.free_blocks(ordered_blocks)
+            return
+        if ordered_blocks:
+            self.deferred_skipped_frees.append(
+                (self.skipped_free_fence, ordered_blocks)
+            )
+
+    def drain_skipped_frees(self, processed_step_seq: int) -> None:
+        """Return deferred skipped blocks whose fence step has been processed."""
+        while self.deferred_skipped_frees:
+            fence, _ = self.deferred_skipped_frees[0]
+            if fence > processed_step_seq:
+                break
+            _, blocks = self.deferred_skipped_frees.popleft()
+            self.free_blocks(blocks)
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -271,6 +271,10 @@ class Scheduler(SchedulerInterface):
         if self.connector is not None:
             self.connector.bind_gpu_block_pool(self.kv_cache_manager.block_pool)
 
+        # Extend request-level deferral to blocks freed mid-flight when an
+        # attention window slides forward (sliding-window / chunked-local / R-SWA).
+        self.kv_cache_manager.block_pool.defer_skipped_free = self.defer_block_free
+
         self.use_pp = self.parallel_config.pipeline_parallel_size > 1
         self.use_v2_model_runner = vllm_config.use_v2_model_runner
         # Scheduler iteration counter. Drives the V2+PP+async decode-throttle
@@ -387,6 +391,11 @@ class Scheduler(SchedulerInterface):
 
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         self.current_step += 1
+        # Fence mid-flight skipped-block frees to the reader step: sched_step_seq
+        # still holds the prior step's value here (it advances after allocation),
+        # which is exactly the in-flight forward that may still read these blocks.
+        if self.defer_block_free:
+            self.kv_cache_manager.block_pool.skipped_free_fence = self.sched_step_seq
         # NOTE(woosuk) on the scheduling algorithm:
         # There's no "decoding phase" nor "prefill phase" in the scheduler.
         # Each request just has the num_computed_tokens and
@@ -1504,6 +1513,9 @@ class Scheduler(SchedulerInterface):
         if self.defer_block_free and scheduler_output.total_num_scheduled_tokens > 0:
             self.processed_step_seq += 1
             self._drain_deferred_frees()
+            self.kv_cache_manager.block_pool.drain_skipped_frees(
+                self.processed_step_seq
+            )
 
         perf_stats: PerfStats | None = None
         if self.perf_metrics and self.perf_metrics.is_enabled():

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -502,7 +502,7 @@ class SingleTypeKVCacheManager(ABC):
             freed.append(blocks[i])
             blocks[i] = self._null_block
         if freed:
-            self.block_pool.free_blocks(freed)
+            self.block_pool.free_blocks_maybe_deferred(freed)
 
     def remove_skipped_blocks(
         self,


### PR DESCRIPTION
## Purpose

Alternative, host-side fix for the SimpleCPUOffload load-path write-after-read
(WAR) race in #47282 — the residual gap left after the store-path fix #46278
(#45704). The worker-side CUDA-event fix is already up in #47291; this PR
implements the block-lifetime *deferral* approach @hclsys suggested, so the two
can be compared.

## Root cause

Under async scheduling the scheduler runs ahead of the device. A *running*
sliding-window request (chunked-local / R-SWA behave the same) frees KV blocks
mid-flight when its attention window advances:

```
remove_skipped_blocks -> _remove_blocks_in_range -> block_pool.free_blocks
```

The scheduler treats the block as free, but the in-flight forward dispatched in
the previous step (processed+1) is still reading it on the compute stream. With
SimpleCPUOffload the freed block is immediately reused as a load destination and
the CPU->GPU copy (separate stream) overwrites it mid-read -> garbled output.

This is the *mid-flight* free path. #45357's deferral only covers
*request-completion* frees, so it does not cover this case.

## Fix

Extend #45357's fence machinery to the mid-flight skipped-block free:

- `block_pool.free_blocks_maybe_deferred()` holds skipped blocks under the
  current schedule-step fence instead of returning them to the pool;
  `drain_skipped_frees()` releases them once `processed_step_seq` reaches that
  fence (the in-flight reader step has completed).
- `single_type_kv_cache_manager._remove_blocks_in_range()` frees through
  `free_blocks_maybe_deferred()`.
- `scheduler` enables it only when `defer_block_free` is active (async + kv
  consumer), sets the fence at the top of `schedule()`, drains after
  `processed_step_seq` advances.

Disabled -> byte-for-byte the old immediate free.

## Scope

Only mid-flight-freeing attention types are affected: sliding-window,
chunked-local, R-SWA. Full / sink / cross attention free only at request
completion (already covered by #45357).

Mamba / linear-attention layers are **not** affected — confirmed empirically
(Falcon-H1-0.5B, both `align` and `all` mamba cache modes, same repro; 0 garble
over 1128 valid completions while mid-flight frees fired 1.5k-2.5k times and
external-hit loads ran ~25%). A freed Mamba state snapshot has no in-flight
reader: the recurrent forward reads only the current state block.

## Correctness + performance (measured)

Gemma-4-31B-NVFP4 + fp8 KV, `VLLM_USE_SIMPLE_KV_OFFLOAD=1`,
`--kv-offloading-size 100 --max-num-seqs 64 --gpu-memory-utilization 0.95`
(GPU KV ~30.8k tokens = 1.88x concurrency, i.e. heavy offload). 300 prompts x
3 rounds x concurrency 64 = **900 completions/variant**, `max_tokens 256`,
temperature 0.7. #45357 active in all variants. All three variants overlaid on
the same `vllm/vllm-openai:nightly` (files verified byte-identical to the fork
baseline), so only the changed files differ.

| variant | load guard | hard garble | garble rate | wall clock (900 req) |
|---|---|---|---|---|
| NOFIX | none | 44 / 900 | **4.89%** | 728 s |
| EVENT (#47291) | compute-done event | 0 / 900 | **0.00%** | 718 s |
| DEFER (this PR) | host-side defer | 0 / 900 | **0.00%** | 704 s |

Steady-state engine metrics (mean over 72x 10s samples):

| variant | gen tok/s | KV util | waiting | external hit | preemptions |
|---|---|---|---|---|---|
| NOFIX | 292.7 | 83.0% | 49.5 | 26.4% | 0 |
| EVENT | 294.5 | 80.5% | 48.8 | 27.5% | 0 |
| DEFER | 299.7 | 84.6% | 49.1 | 27.8% | 0 |

Throughput / KV util / queue depth / external-hit / preemptions all line up;
wall clock within 3% noise (defer marginally fastest). DEFER instrumentation:
863,525 blocks deferred over the run, but each is held **~1 step only** (max
deferred-queue depth 30, drained every processed step), so the in-flight held
set is tiny and swamped by offload cost itself. Free-pool idle blocks dipped to
106 at the tightest point without triggering preemption — a tighter
memory / higher-concurrency setup *could* make defer bite, but this run did not
measure it.

## Relationship to #47291 (event fix)

Same race, two places to cut it:

- **Event (#47291):** load copy waits on a compute-done CUDA event on the
  worker — one spot, covers both load-WAR and store-RAW.
- **Defer (this PR):** hold the freed block host-side until the reader step is
  done — covers load-WAR; **store-RAW still relies on the existing store
  event** (the DEFER variant above keeps it; dropping it would re-break the
  store path, which is a pure cross-stream RAW that host-side lifetime
  management cannot reach).

Defer is a correct, equally-fast load-side alternative, but it is a *partial*
fix (still needs the event for store) and more intrusive (per-manager, SWA-only
today; chunked-local / R-SWA / any future mid-flight-freeing manager must be
wired individually), whereas the event is one path-agnostic spot in
`worker.get_finished`.

## Test Plan

- Unit: `tests/v1/core/test_block_pool_defer.py` (fence/drain semantics, 3 passed).
- E2E: the 3-variant garble + perf comparison above; ruff + pre-commit clean.

Draft — opening to compare defer vs the event fix (#47291) before either lands.
