### PR TITLE
[Bugfix] Keep sub-1 req/s rates positive in bench sweep serve_workload

### DIFF
--- a/tests/benchmarks/sweep/test_serve_workload.py
+++ b/tests/benchmarks/sweep/test_serve_workload.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import importlib
+import sys
+import types
+
+import numpy as np
+import pytest
+
+# `serve_workload` imports `DEFAULT_NUM_PROMPTS` from `vllm.benchmarks.datasets`
+# at module load, which pulls in the heavy tokenizer/transformers stack. The
+# rate-anchor logic under test does not need it, so stub the module before
+# import to keep this a pure-Python unit test (no GPU / model deps).
+_datasets_stub = types.ModuleType("vllm.benchmarks.datasets")
+_datasets_stub.DEFAULT_NUM_PROMPTS = 1000
+sys.modules.setdefault("vllm.benchmarks.datasets", _datasets_stub)
+
+serve_workload = importlib.import_module("vllm.benchmarks.sweep.serve_workload")
+
+_round_workload_value = serve_workload._round_workload_value
+
+
+def _sweep_levels(serial_avg, batch_avg, workload_var, workload_iters):
+    """Mirror the anchor + intermediate computation in `explore_comb_workloads`."""
+    serial_value = _round_workload_value(serial_avg, workload_var)
+    batch_value = _round_workload_value(batch_avg, workload_var)
+
+    inter = np.linspace(serial_value, batch_value, workload_iters)[1:-1]
+    inter = sorted({_round_workload_value(v, workload_var) for v in inter})
+
+    return sorted({serial_value, batch_value, *inter})
+
+
+class TestRoundWorkloadValue:
+    def test_request_rate_keeps_sub_one_values(self):
+        # Regression for the "non-positive request rate" crash: a sub-1
+        # throughput must not collapse to 0 (which asserts in serve.py).
+        assert _round_workload_value(0.425, "request_rate") == 0.425
+        assert _round_workload_value(0.21, "request_rate") == 0.21
+
+    def test_request_rate_never_non_positive(self):
+        for value in (0.0, 0.0001, -0.5):
+            assert _round_workload_value(value, "request_rate") > 0.0
+
+    def test_max_concurrency_is_integer_and_at_least_one(self):
+        value = _round_workload_value(0.425, "max_concurrency")
+        assert isinstance(value, int)
+        assert value == 1
+
+        value = _round_workload_value(0.0, "max_concurrency")
+        assert value == 1
+
+    def test_max_concurrency_rounds_normally_above_one(self):
+        assert _round_workload_value(7.4, "max_concurrency") == 7
+        assert _round_workload_value(7.6, "max_concurrency") == 8
+
+
+class TestSweepLevels:
+    def test_sub_one_request_rate_does_not_emit_zero(self):
+        # serial ~0.21 req/s, batch ~0.425 req/s (measured on an RTX 4090 with
+        # 8K-token inputs, from issue #47651). Before the fix this produced
+        # request_rate levels [0, 1], crashing on the 0 level.
+        levels = _sweep_levels(0.21, 0.425, "request_rate", workload_iters=10)
+
+        assert all(level > 0.0 for level in levels)
+        # Sub-1 resolution is preserved instead of collapsing to {0, 1}.
+        assert any(0.0 < level < 1.0 for level in levels)
+        assert len(levels) > 2
+
+    def test_request_rate_above_one_still_works(self):
+        levels = _sweep_levels(2.0, 12.0, "request_rate", workload_iters=5)
+        assert all(level > 0.0 for level in levels)
+        assert min(levels) == pytest.approx(2.0)
+        assert max(levels) == pytest.approx(12.0)
+
+    def test_max_concurrency_never_emits_zero(self):
+        # With `--workload-var max_concurrency`, a floored batch anchor could
+        # emit max_concurrency=0, which is not a valid workload level either.
+        levels = _sweep_levels(0.4, 0.9, "max_concurrency", workload_iters=10)
+        assert all(isinstance(level, int) and level >= 1 for level in levels)

--- a/vllm/benchmarks/sweep/serve_workload.py
+++ b/vllm/benchmarks/sweep/serve_workload.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import argparse
-import math
 from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import ClassVar, Literal, get_args
@@ -29,6 +28,27 @@ except ImportError:
 
 
 WorkloadVariable = Literal["request_rate", "max_concurrency"]
+
+# Number of decimals to keep for continuous (`request_rate`) sweep levels.
+_REQUEST_RATE_DECIMALS = 3
+# Smallest positive `request_rate` we are willing to emit, so a sub-1 batch
+# throughput never collapses to a non-positive rate (see serve.py rate check).
+_MIN_REQUEST_RATE = 10**-_REQUEST_RATE_DECIMALS
+
+
+def _is_continuous_workload(workload_var: WorkloadVariable) -> bool:
+    # `request_rate` is a continuous quantity; `max_concurrency` must be an
+    # integer >= 1.
+    return workload_var == "request_rate"
+
+
+def _round_workload_value(
+    value: float,
+    workload_var: WorkloadVariable,
+) -> float | int:
+    if _is_continuous_workload(workload_var):
+        return max(_MIN_REQUEST_RATE, round(value, _REQUEST_RATE_DECIMALS))
+    return max(1, round(value))
 
 
 def _estimate_workload_value(
@@ -64,7 +84,7 @@ def run_comb_workload(
     num_runs: int,
     dry_run: bool,
     workload_var: WorkloadVariable,
-    workload_value: int,
+    workload_value: int | float,
 ) -> list[dict[str, object]] | None:
     bench_comb_workload = bench_comb | {workload_var: workload_value}
 
@@ -152,13 +172,15 @@ def explore_comb_workloads(
 
         return
 
-    serial_workload_value = math.ceil(
-        _estimate_workload_avg(serial_workload_data, workload_var)
+    serial_workload_value = _round_workload_value(
+        _estimate_workload_avg(serial_workload_data, workload_var),
+        workload_var,
     )
     print(f"Serial inference: {workload_var}={serial_workload_value}")
 
-    batch_workload_value = math.floor(
-        _estimate_workload_avg(batch_workload_data, workload_var)
+    batch_workload_value = _round_workload_value(
+        _estimate_workload_avg(batch_workload_data, workload_var),
+        workload_var,
     )
     print(f"Batch inference: {workload_var}={batch_workload_value}")
 
@@ -167,7 +189,9 @@ def explore_comb_workloads(
     inter_workload_values = np.linspace(
         serial_workload_value, batch_workload_value, workload_iters
     )[1:-1]
-    inter_workload_values = sorted(set(map(round, inter_workload_values)))
+    inter_workload_values = sorted(
+        {_round_workload_value(v, workload_var) for v in inter_workload_values}
+    )
 
     inter_workloads_data: list[dict[str, object]] = []
     for inter_workload_value in inter_workload_values:


### PR DESCRIPTION
Fixes #47651.

`vllm bench sweep serve_workload` crashes with "non-positive request rate" when a deployment's max throughput is below 1 req/s. In `explore_comb_workloads`, the serial and batch rate anchors were computed with `math.ceil` / `math.floor` and the intermediate levels with integer `round`. For a sub-1 req/s workload the batch anchor floors to 0, `np.linspace(serial, 0, iters)` rounds to `[0, 1]`, and the `request_rate=0` level trips the assertion in serve.py. This also destroyed all sub-1 resolution even when it did not crash.

The fix adds a small helper that rounds by workload variable type: `request_rate` is continuous, so it rounds to three decimals and clamps to a small positive floor (never 0); `max_concurrency` stays a discrete integer clamped to >= 1. Both anchors and the intermediate levels go through it. `apply_to_cmd` already renders values with `str()` and `--request-rate` is `type=float`, so fractional rates are fully compatible downstream.

Tests: added tests/benchmarks/sweep/test_serve_workload.py covering sub-1 request_rate levels staying positive with preserved resolution, max_concurrency staying integer >= 1, and the above-1 range unchanged. The new file plus the existing sweep tests pass (30 total), and ruff is clean.