### PR TITLE
[Model] Add EuroBERT embedding model

### DIFF
--- a/docs/models/pooling_models/embed.md
+++ b/docs/models/pooling_models/embed.md
@@ -40,6 +40,7 @@ You can compute pairwise similarity scores to build a similarity matrix using th
 | `BertModel` | BERT-based | `BAAI/bge-base-en-v1.5`, `Snowflake/snowflake-arctic-embed-xs`, etc. | | |
 | `BertSpladeSparseEmbeddingModel` | SPLADE | `naver/splade-v3` | | |
 | `BgeM3EmbeddingModel` | BGE-M3 | `BAAI/bge-m3` | | |
+| `EuroBertForMaskedLM`<sup>C</sup>, `EuroBertModel`<sup>C</sup> | EuroBERT | `EuroBERT/EuroBERT-210m`, `EuroBERT/EuroBERT-610m`, etc. | ✅︎ | ✅︎ |
 | `Gemma2Model`<sup>C</sup> | Gemma 2-based | `BAAI/bge-multilingual-gemma2`, etc. | ✅︎ | ✅︎ |
 | `Gemma3TextModel`<sup>C</sup> | Gemma 3-based | `google/embeddinggemma-300m`, etc. | ✅︎ | ✅︎ |
 | `GritLM` | GritLM | `parasail-ai/GritLM-7B-vllm`. | ✅︎ | ✅︎ |

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -579,6 +579,11 @@ _EMBEDDING_EXAMPLE_MODELS = {
         hf_overrides={"architectures": ["BertSpladeSparseEmbeddingModel"]},
     ),
     "BgeM3EmbeddingModel": _HfExamplesInfo("BAAI/bge-m3"),
+    "EuroBertForMaskedLM": _HfExamplesInfo("EuroBERT/EuroBERT-210m"),
+    "EuroBertModel": _HfExamplesInfo(
+        "EuroBERT/EuroBERT-210m",
+        hf_overrides={"architectures": ["EuroBertModel"]},
+    ),
     "Gemma2Model": _HfExamplesInfo("BAAI/bge-multilingual-gemma2"),
     "Gemma3TextModel": _HfExamplesInfo("google/embeddinggemma-300m"),
     "GritLM": _HfExamplesInfo("parasail-ai/GritLM-7B-vllm"),

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -570,6 +570,14 @@ class LlamaBidirectionalConfig(VerifyAndUpdateConfig):
         model_config.pooler_config.seq_pooling_type = pooling_type
 
 
+class EuroBertModelConfig(VerifyAndUpdateConfig):
+    @staticmethod
+    def verify_and_update_model_config(model_config: "ModelConfig") -> None:
+        # EuroBERT is a bidirectional (encoder-only) Llama. The HF config does
+        # not set `is_causal`, so enable bidirectional attention explicitly.
+        model_config.hf_config.is_causal = False
+
+
 class LlamaNemotronVLConfig(VerifyAndUpdateConfig):
     """Config handler for LlamaNemotronVL embedding models."""
 
@@ -935,6 +943,8 @@ MODELS_CONFIG_MAP: dict[str, type[VerifyAndUpdateConfig]] = {
     "DeepseekV32ForCausalLM": DeepseekV32ForCausalLM,
     "DiffusionGemmaForBlockDiffusion": DiffusionGemmaModelForBlockDiffusionConfig,  # noqa: E501
     "Ernie4_5_VLMoeForConditionalGeneration": Ernie4_5_VLMoeForConditionalGenerationConfig,  # noqa: E501
+    "EuroBertForMaskedLM": EuroBertModelConfig,
+    "EuroBertModel": EuroBertModelConfig,
     "FalconMambaForCausalLM": MambaModelConfig,
     "Gemma3TextModel": Gemma3TextModelConfig,
     "Gemma4ForCausalLM": Gemma4Config,

--- a/vllm/model_executor/models/eurobert.py
+++ b/vllm/model_executor/models/eurobert.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""EuroBERT model (https://huggingface.co/EuroBERT).
+
+EuroBERT is a multilingual encoder that is architecturally a bidirectional
+Llama (RMSNorm, GQA, SwiGLU MLP and RoPE), so it reuses the Llama building
+blocks. Bidirectional (encoder-only) attention is enabled by setting
+``is_causal=False`` on the config in ``EuroBertModelConfig``
+(``vllm/model_executor/models/config.py``).
+"""
+
+from collections.abc import Iterable
+
+import torch
+
+from vllm.model_executor.models.adapters import as_embedding_model
+from vllm.model_executor.models.interfaces_base import default_pooling_type
+from vllm.model_executor.models.llama import LlamaForCausalLM
+from vllm.model_executor.models.utils import AutoWeightsLoader
+
+
+@default_pooling_type(seq_pooling_type="MEAN")
+class EuroBertModel(as_embedding_model(LlamaForCausalLM)):
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # EuroBERT checkpoints ship a masked-LM head (`lm_head`) that the
+        # embedding model does not use.
+        loader = AutoWeightsLoader(self, skip_prefixes=["lm_head."])
+        return loader.load_weights(weights)

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -223,6 +223,8 @@ _EMBEDDING_MODELS = {
     "BertSpladeSparseEmbeddingModel": ("bert", "BertSpladeSparseEmbeddingModel"),
     "BgeM3EmbeddingModel": ("roberta", "BgeM3EmbeddingModel"),
     "DeciLMForCausalLM": ("nemotron_nas", "DeciLMForCausalLM"),
+    "EuroBertForMaskedLM": ("eurobert", "EuroBertModel"),
+    "EuroBertModel": ("eurobert", "EuroBertModel"),
     "Gemma2Model": ("gemma2", "Gemma2ForCausalLM"),
     "Gemma3TextModel": ("gemma3", "Gemma3Model"),
     "GlmForCausalLM": ("glm", "GlmForCausalLM"),


### PR DESCRIPTION
## Purpose

Adds native support for [EuroBERT](https://huggingface.co/EuroBERT) as an embedding (pooling) model. Closes #47658.

EuroBERT is a multilingual encoder that is architecturally a bidirectional Llama (RMSNorm, GQA, SwiGLU MLP, RoPE), so it reuses the existing Llama building blocks via `as_embedding_model(LlamaForCausalLM)` — no new attention layer or config-class rewrite is needed.

- `vllm/model_executor/models/eurobert.py`: `EuroBertModel = as_embedding_model(LlamaForCausalLM)`; `load_weights` skips the checkpoint's masked-LM `lm_head.` weights.
- `EuroBertModelConfig` (`config.py`): the HF config has no `is_causal` field, so it is set to `False` to enable bidirectional (encoder-only) attention. `llama.py` already maps `is_causal=False` to `AttentionType.ENCODER_ONLY`.
- Registered `EuroBertForMaskedLM` / `EuroBertModel` in the model registry, added the test-registry entries, and a row in the embedding-model docs.

**Pooling** defaults to `MEAN`. EuroBERT has no CLS token or CLS training objective, and its own `classifier_pooling` options are `bos`/`mean`/`late` (there is no `cls` option); `MEAN` is the standard encoder-embedding default and matches one of the model's supported strategies. It remains overridable via `--pooler-config`.

**Scope:** This PR adds embedding (pooling) support (`EuroBertModel`). Sequence-classification / rerank (`EuroBertForSequenceClassification`), also mentioned in #47658, is a planned follow-up — kept separate to keep this PR focused and reviewable.

## Not a duplicate

There is no existing EuroBERT PR in any state — `gh pr list --repo vllm-project/vllm --state all --search "EuroBERT"` returns nothing, and `eurobert` was absent from the model registry. This is the first implementation and addresses the open "[New Model]: EuroBERT" request (#47658).

This is also distinct from #50352, which added a clear-error rejection for EuroBERT-backbone jina-embeddings-v5 checkpoints (#50337). That change does not add EuroBERT support — this PR provides the native `EuroBertModel` implementation those encoder backbones lack.

## Test Plan

On an H100 (fp32, `EuroBERT/EuroBERT-210m`):

1. **Numerical correctness vs HF reference.** Compare vLLM masked-mean-pooled embeddings against `transformers.AutoModel` masked-mean over `last_hidden_state`, cosine similarity, for EN/FR/EN inputs.
2. **Registry tests.** `pytest tests/models/test_registry.py::test_hf_registry_coverage` and `test_registry_imports[EuroBertForMaskedLM]` / `[EuroBertModel]`.
3. **Lint.** `pre-commit run --files <changed files>`.

## Test Result

1. Correctness (cosine vs HF, fp32; 768-dim). vLLM resolves the architecture to the native `EuroBertModel` implementation added here (confirmed via the `Resolved architecture: EuroBertForMaskedLM` log), not the generic Transformers fallback:

   | Input | cosine |
   | --- | --- |
   | `Hello world` | 0.99997 |
   | `Bonjour le monde` | 0.99999 |
   | `The capital of France is Paris.` | 1.00000 |

2. Registry tests: **3 passed**.
3. `pre-commit`: all hooks pass (ruff check/format, mypy, markdownlint, typos, SPDX).

## Note

This PR was implemented with AI assistance (Claude Code). I reviewed every changed line and ran the tests above.
