### PR TITLE
[Frontend][Responses] Accept input_audio content parts in user messages (#47659)

### DIFF
--- a/tests/entrypoints/openai/responses/test_protocol.py
+++ b/tests/entrypoints/openai/responses/test_protocol.py
@@ -1,13 +1,46 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
 from openai_harmony import (
     Message,
 )
 
 from vllm.entrypoints.openai.responses.protocol import (
+    ResponsesRequest,
     serialize_message,
     serialize_messages,
 )
+
+
+@pytest.mark.parametrize("audio_format", ["mp3", "wav"])
+def test_input_audio_in_message_content(audio_format: str) -> None:
+    # Regression test for #47659: input_audio content parts inside a user
+    # message must be accepted on /v1/responses just as they are on
+    # /v1/chat/completions.
+    req = ResponsesRequest.model_validate(
+        {
+            "model": "test",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_audio",
+                            "input_audio": {
+                                "data": "AAAA",
+                                "format": audio_format,
+                            },
+                        },
+                        {"type": "input_text", "text": "what did I say?"},
+                    ],
+                }
+            ],
+        }
+    )
+    audio_part = req.input[0]["content"][0]
+    assert audio_part["type"] == "input_audio"
+    assert audio_part["input_audio"]["data"] == "AAAA"
+    assert audio_part["input_audio"]["format"] == audio_format
 
 
 def test_serialize_message() -> None:

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -15,6 +15,7 @@ from openai.types.responses import (
     ResponseContentPartAddedEvent,
     ResponseContentPartDoneEvent,
     ResponseFunctionToolCall,
+    ResponseInputAudioParam,
     ResponseInputItemParam,
     ResponseMcpCallArgumentsDeltaEvent,
     ResponseMcpCallArgumentsDoneEvent,
@@ -42,6 +43,11 @@ from openai.types.responses import (
     ResponseInProgressEvent as OpenAIResponseInProgressEvent,
 )
 from openai.types.responses.response import IncompleteDetails, ToolChoice
+from openai.types.responses.response_input_message_content_list_param import (
+    ResponseInputFileParam,
+    ResponseInputImageParam,
+    ResponseInputTextParam,
+)
 from openai.types.responses.response_reasoning_item import (
     Content as ResponseReasoningTextContent,
 )
@@ -54,6 +60,8 @@ from pydantic import (
     field_serializer,
     model_validator,
 )
+from typing_extensions import Required as _Required
+from typing_extensions import TypedDict as _TypedDict
 
 from vllm.config import ModelConfig
 from vllm.entrypoints.chat_utils import (
@@ -130,7 +138,37 @@ class ResponseRawMessageAndToken(OpenAIBaseModel):
 ResponseInputOutputMessage: TypeAlias = (
     list[ChatCompletionMessageParam] | list[ResponseRawMessageAndToken]
 )
-ResponseInputOutputItem: TypeAlias = ResponseInputItemParam | ResponseOutputItem
+
+
+class _EasyInputMessageWithAudioParam(_TypedDict, total=False):
+    """Extension of EasyInputMessageParam that additionally accepts
+    ``input_audio`` content parts.
+
+    The openai SDK's ``ResponseInputMessageContentListParam`` only permits
+    text, image, and file content parts; ``ResponseInputAudioParam`` is
+    intentionally absent.  As a result, audio messages that are accepted by
+    ``/v1/chat/completions`` fail Pydantic validation on ``/v1/responses``
+    with an opaque 422 error.  This TypedDict mirrors EasyInputMessageParam
+    while extending the content union to include ``ResponseInputAudioParam``,
+    so both endpoints accept the same audio-bearing user messages (#47659).
+    """
+
+    content: _Required[
+        str
+        | list[
+            ResponseInputTextParam
+            | ResponseInputImageParam
+            | ResponseInputFileParam
+            | ResponseInputAudioParam
+        ]
+    ]
+    role: _Required[Literal["user", "assistant", "system", "developer"]]
+    type: Literal["message"]
+
+
+ResponseInputOutputItem: TypeAlias = (
+    _EasyInputMessageWithAudioParam | ResponseInputItemParam | ResponseOutputItem
+)
 
 
 class ResponsesRequest(OpenAIBaseModel):


### PR DESCRIPTION
## Summary

Audio inputs that work on `/v1/chat/completions` fail on `/v1/responses` with an opaque 422 `ValidationError` (#47659), even though the payload is identical.

**Root cause**: The openai SDK's `ResponseInputMessageContentListParam` — the type used for `EasyInputMessageParam.content` — only permits text, image, and file content parts:

```python
ResponseInputMessageContentListParam = list[Union[
    ResponseInputTextParam,
    ResponseInputImageParam,
    ResponseInputFileParam,
]]
```

`ResponseInputAudioParam` is intentionally absent from this union. Pydantic therefore rejects any user message whose content list contains an `input_audio` part.

## Fix

Add `_EasyInputMessageWithAudioParam`, a `TypedDict` that mirrors `EasyInputMessageParam` while extending its `content` union to include `ResponseInputAudioParam`. Prepend it to `ResponseInputOutputItem` so Pydantic validates audio-bearing user messages before falling through to the narrower SDK types. No changes to the serving path are needed — audio dict passthrough already works end-to-end.

## Test Plan

CPU-only, no model/GPU needed (the failure is at request validation):

```
pytest tests/entrypoints/openai/responses/test_protocol.py
```

The new `test_input_audio_in_message_content` test reproduces the bug — it fails on `main` and passes with this fix. Both `mp3` and `wav` formats are covered; invalid formats remain rejected.