### PR TITLE
[compile] stock aot_compile driver: alternate to eval-frame stock torch.compile (#46423 sibling)

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -174,6 +174,123 @@ def test_stock_torch_compile(vllm_runner, monkeypatch):
 
 # forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
 @pytest.mark.forked
+def test_stock_aot_torch_compile(vllm_runner, monkeypatch):
+    # VLLM_USE_AOT_COMPILE drives the stock path through the aot_compile API
+    # instead of the lazy eval-frame nn.Module.compile(). The compile fires on the
+    # first forward (profile_run), so by the time the runner is up num_aot_compiles
+    # and stock_torch_compile_count are both 1 -- the model runs off a standalone
+    # AOTCompiledFunction, not the Dynamo eval frame.
+    from vllm.compilation.stock_aot import stock_aot_available
+
+    if not stock_aot_available():
+        pytest.skip("torch build lacks the aot_compile API")
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    monkeypatch.setenv("VLLM_USE_AOT_COMPILE", "1")
+    # Isolate a fresh compile (no serialized artifact reuse) so num_aot_compiles
+    # is a reliable signal rather than a possible num_aot_artifacts_loaded hit.
+    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
+    with (
+        compilation_counter.expect(
+            num_aot_compiles=1,
+            stock_torch_compile_count=1,
+        ),
+        vllm_runner(
+            "facebook/opt-125m",
+            compilation_config={
+                "mode": CompilationMode.STOCK_TORCH_COMPILE,
+                # Pin FULL_DECODE_ONLY + partition off: a piecewise cudagraph_mode
+                # without graph partition falls the config back to VllmBackend, which
+                # would (incorrectly) satisfy num_aot_compiles via the VllmBackend aot
+                # path instead of the stock aot path under test.
+                "use_inductor_graph_partition": False,
+                "cudagraph_mode": CUDAGraphMode.FULL_DECODE_ONLY,
+                "cudagraph_capture_sizes": [100],
+            },
+            gpu_memory_utilization=0.4,
+        ) as _,
+    ):
+        pass
+
+
+# forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
+@pytest.mark.forked
+def test_stock_aot_installs_forward_not_eval_frame(vllm_runner, monkeypatch):
+    # The aot path must replace the model's forward with the _StockAOTForward
+    # driver and must NOT arm nn.Module.compile(): _compiled_call_impl stays None
+    # (no eval-frame dispatch) while forward is an _StockAOTForward carrying a live
+    # AOTCompiledFunction after the first forward.
+    from vllm.compilation.stock_aot import _StockAOTForward, stock_aot_available
+
+    if not stock_aot_available():
+        pytest.skip("torch build lacks the aot_compile API")
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    monkeypatch.setenv("VLLM_USE_AOT_COMPILE", "1")
+    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
+    with vllm_runner(
+        "facebook/opt-125m",
+        compilation_config={
+            "mode": CompilationMode.STOCK_TORCH_COMPILE,
+            "use_inductor_graph_partition": False,
+            "cudagraph_mode": CUDAGraphMode.FULL_DECODE_ONLY,
+            "cudagraph_capture_sizes": [100],
+        },
+        gpu_memory_utilization=0.4,
+    ) as m:
+        runner = m.llm.llm_engine.model_executor.driver_worker.worker.model_runner
+        model = runner.get_model()
+        assert isinstance(model.forward, _StockAOTForward)
+        assert model.forward._aot_fn is not None
+        assert model._compiled_call_impl is None
+
+
+# forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
+@pytest.mark.forked
+@pytest.mark.parametrize("use_partition", [False, True])
+def test_stock_aot_matches_eval_frame_stock(vllm_runner, monkeypatch, use_partition):
+    # The aot driver must be numerically identical to the eval-frame stock driver:
+    # same stock Inductor backend, same external cudagraph + graph-partition wiring,
+    # only the compile trigger differs. Compare greedy decode of the two drivers for
+    # each partition setting. A divergence isolates an aot-specific bug (wrong self
+    # arg, stale guard, bad artifact) rather than compile-vs-eager drift.
+    from vllm.compilation.stock_aot import stock_aot_available
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    if not stock_aot_available():
+        pytest.skip("torch build lacks the aot_compile API")
+    if use_partition and not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("use_inductor_graph_partition requires torch>=2.9.0.dev")
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    prompts = [
+        "The capital of France is",
+        "The quick brown fox jumps over the",
+    ]
+
+    def _greedy(use_aot):
+        cc = {
+            "mode": CompilationMode.STOCK_TORCH_COMPILE,
+            "use_inductor_graph_partition": use_partition,
+            "cudagraph_capture_sizes": [8],
+        }
+        if not use_partition:
+            cc["cudagraph_mode"] = CUDAGraphMode.FULL_DECODE_ONLY
+        with monkeypatch.context() as mp:
+            mp.setenv("VLLM_USE_AOT_COMPILE", "1" if use_aot else "0")
+            mp.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
+            with vllm_runner(
+                "facebook/opt-125m",
+                compilation_config=cc,
+                gpu_memory_utilization=0.4,
+            ) as m:
+                return m.generate_greedy(prompts, max_tokens=32)
+
+    eval_frame = _greedy(use_aot=False)
+    aot = _greedy(use_aot=True)
+    for (base_ids, _), (aot_ids, _) in zip(eval_frame, aot):
+        assert base_ids == aot_ids
+
+
+# forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
+@pytest.mark.forked
 def test_stock_torch_compile_piecewise_graph_partition(vllm_runner, monkeypatch):
     # Stock + use_inductor_graph_partition recovers piecewise cudagraphs (step 2 of
     # the VllmBackend migration): Inductor partitions at the attention ops and the

--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -174,6 +174,114 @@ def test_stock_torch_compile(vllm_runner, monkeypatch):
 
 # forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
 @pytest.mark.forked
+def test_stock_torch_compile_piecewise_graph_partition(vllm_runner, monkeypatch):
+    # Stock + use_inductor_graph_partition recovers piecewise cudagraphs (step 2 of
+    # the VllmBackend migration): Inductor partitions at the attention ops and the
+    # external wrapper captures each partition (FULL_AND_PIECEWISE). opt-125m at one
+    # capture size -> 13 piecewise + 1 full decode = 14 captured graphs (the same
+    # count as the VllmBackend FaP path), proving the stock piecewise path actually
+    # captures rather than running attention inside the cudagraph.
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    if not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("use_inductor_graph_partition requires torch>=2.9.0.dev")
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    with (
+        compilation_counter.expect(
+            stock_torch_compile_count=1,
+            num_gpu_runner_capture_triggers=1,
+            num_cudagraph_captured=14,
+        ),
+        vllm_runner(
+            "facebook/opt-125m",
+            compilation_config={
+                "mode": CompilationMode.STOCK_TORCH_COMPILE,
+                "use_inductor_graph_partition": True,
+                "cudagraph_capture_sizes": [100],
+            },
+            gpu_memory_utilization=0.4,
+        ) as _,
+    ):
+        pass
+
+
+# forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
+@pytest.mark.forked
+def test_stock_uses_decoupled_cudagraph_wrapper(vllm_runner, monkeypatch):
+    # The stock path must capture via its own StockTorchCompileCUDAGraphWrapper, never the shared
+    # CUDAGraphWrapper (which is coupled to vLLM's non-torch.compile full-cudagraph
+    # path). Forked so the wrapper-class instance registries start empty.
+    from vllm.compilation.cuda_graph import CUDAGraphWrapper
+    from vllm.compilation.stock_cudagraph import StockTorchCompileCUDAGraphWrapper
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    if not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("use_inductor_graph_partition requires torch>=2.9.0.dev")
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    with vllm_runner(
+        "facebook/opt-125m",
+        compilation_config={
+            "mode": CompilationMode.STOCK_TORCH_COMPILE,
+            "use_inductor_graph_partition": True,
+            "cudagraph_capture_sizes": [100],
+        },
+        gpu_memory_utilization=0.4,
+    ) as _:
+        assert len(StockTorchCompileCUDAGraphWrapper._all_instances) > 0
+        assert len(CUDAGraphWrapper._all_instances) == 0
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="stock cudagraph guard queries the CUDA stream capture state",
+)
+def test_stock_cudagraph_wrapper_rejects_cross_engine_capture():
+    # The stock partition wrapper is a process-global that is never unset, so a
+    # forward driven by a DIFFERENT engine's config can reach the capture branch
+    # carrying a stale compilation config. The identity guard must raise there
+    # rather than capture a graph against the wrong config (and must not run the
+    # underlying runnable).
+    from vllm.compilation.stock_cudagraph import StockTorchCompileCUDAGraphWrapper
+    from vllm.forward_context import BatchDescriptor, set_forward_context
+
+    vllm_config = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    ran = {"n": 0}
+
+    def runnable(x):
+        ran["n"] += 1
+        return x
+
+    wrapper = StockTorchCompileCUDAGraphWrapper(
+        runnable, vllm_config, runtime_mode=CUDAGraphMode.FULL
+    )
+
+    # A second engine: its static_forward_context is a distinct dict object, so the
+    # forward context it drives will not alias the wrapper's compilation config.
+    foreign_config = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    assert (
+        foreign_config.compilation_config.static_forward_context
+        is not vllm_config.compilation_config.static_forward_context
+    )
+
+    with (
+        set_forward_context(
+            attn_metadata=None,
+            vllm_config=foreign_config,
+            cudagraph_runtime_mode=CUDAGraphMode.FULL,
+            batch_descriptor=BatchDescriptor(num_tokens=8),
+        ),
+        pytest.raises(RuntimeError, match="different vLLM engine"),
+    ):
+        wrapper(torch.empty(1))
+    assert ran["n"] == 0
+
+
+# forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
+@pytest.mark.forked
 def test_no_compilation(vllm_runner, monkeypatch):
     # Disable multiprocessing so that the counter is in the same process
     monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
@@ -788,3 +896,1002 @@ def test_inductor_asserts_user_override(monkeypatch):
     assert config.inductor_compile_config.get("size_asserts") is True
     if not _is_torch_equal_or_newer(torch.__version__, "2.12.0.dev"):
         assert config.inductor_compile_config.get("alignment_asserts") is False
+
+
+# --- STOCK_TORCH_COMPILE migration (SupportsStockCompile) config resolution ---
+# These build VllmConfig directly (no model load / GPU memory) and assert the
+# resolved compile mode / cudagraph mode. The cudagraph-mode assertions need a
+# platform that supports static graph mode (FDO is otherwise forced to NONE).
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+@pytest.mark.parametrize(
+    "user_cudagraph_mode,expected_mode,expected_cudagraph",
+    [
+        # Unset, partition explicitly off -> the opt-level default is a piecewise
+        # mode the stock path can't honor without partition, so fall back to the
+        # legacy VllmBackend (keeping the piecewise default) rather than silently
+        # degrading to a different cudagraph strategy. The partition-on default is
+        # covered by test_stock_defaults_to_graph_partition_piecewise.
+        (None, CompilationMode.VLLM_COMPILE, CUDAGraphMode.FULL_AND_PIECEWISE),
+        # Explicit NONE is the user's deliberate choice and must be preserved.
+        (CUDAGraphMode.NONE, CompilationMode.STOCK_TORCH_COMPILE, CUDAGraphMode.NONE),
+        # An explicit piecewise mode needs graph partition (off here); the stock path
+        # can't provide it, so fall back to the legacy VllmBackend (which has its own
+        # FX splitting) rather than silently dropping cudagraphs.
+        (
+            CUDAGraphMode.PIECEWISE,
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.PIECEWISE,
+        ),
+        (
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+        ),
+        # Explicit full modes need no piecewise capture, so they stay on stock as-is.
+        (CUDAGraphMode.FULL, CompilationMode.STOCK_TORCH_COMPILE, CUDAGraphMode.FULL),
+        (
+            CUDAGraphMode.FULL_DECODE_ONLY,
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+        ),
+    ],
+)
+def test_stock_cudagraph_mode_resolution(
+    user_cudagraph_mode, expected_mode, expected_cudagraph
+):
+    # Pin partition off so this isolates the no-partition resolution regardless of
+    # the torch version (the default auto-enables partition on torch>=2.9).
+    cc_kwargs = {
+        "mode": CompilationMode.STOCK_TORCH_COMPILE,
+        "use_inductor_graph_partition": False,
+    }
+    if user_cudagraph_mode is not None:
+        cc_kwargs["cudagraph_mode"] = user_cudagraph_mode
+    config = VllmConfig(compilation_config=CompilationConfig(**cc_kwargs))
+    assert config.compilation_config.mode == expected_mode
+    assert config.compilation_config.cudagraph_mode == expected_cudagraph
+    # A fallen-back stock config must be indistinguishable from a native
+    # VLLM_COMPILE one: ir_enable_torch_wrap follows the FINAL mode, not the
+    # transient STOCK mode it started in.
+    assert config.compilation_config.ir_enable_torch_wrap is (
+        expected_mode == CompilationMode.VLLM_COMPILE
+    )
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+def test_stock_late_fallback_resolves_torch_wrap():
+    # A piecewise cudagraph_mode re-introduced LATE (here via the dynamic-SD
+    # override, but also reachable via pooler / KV-connector / platform
+    # check_and_update_config) forces a stock->VLLM_COMPILE fallback AFTER the
+    # point mode is normally settled. ir_enable_torch_wrap must still resolve to
+    # True so custom IR torch-wrap/lowering stays enabled, matching a config that
+    # started as VLLM_COMPILE. Regression guard for resolving it too early.
+    def _force_piecewise(self):
+        self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+
+    with patch.object(
+        VllmConfig, "_maybe_override_dynamic_sd_cudagraph_mode", _force_piecewise
+    ):
+        config = VllmConfig(
+            compilation_config=CompilationConfig(
+                mode=CompilationMode.STOCK_TORCH_COMPILE,
+                use_inductor_graph_partition=False,
+            )
+        )
+    assert config.compilation_config.mode == CompilationMode.VLLM_COMPILE
+    assert config.compilation_config.ir_enable_torch_wrap is True
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+def test_stock_defaults_to_graph_partition_piecewise():
+    # A stock-compile model with nothing set defaults to graph-partition piecewise
+    # (FULL_AND_PIECEWISE) on torch>=2.9, auto-enabling use_inductor_graph_partition;
+    # on older torch the piecewise default can't be honored, so it falls back to the
+    # legacy VllmBackend (preserving the cudagraph mode). The flag is folded into the
+    # SupportsStockCompile default rather than being opt-in.
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    config = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    cc = config.compilation_config
+    if is_torch_equal_or_newer("2.9.0.dev"):
+        assert cc.mode == CompilationMode.STOCK_TORCH_COMPILE
+        assert cc.use_inductor_graph_partition is True
+        assert cc.cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE
+    else:
+        assert cc.mode == CompilationMode.VLLM_COMPILE
+        assert cc.cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+@pytest.mark.parametrize(
+    "supported,user_mode,expected_mode,expected_cudagraph",
+    [
+        (
+            True,
+            None,
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+        ),
+        (
+            False,
+            None,
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+        ),
+        # An explicit mode always wins over the allowlist auto-selection.
+        (
+            True,
+            CompilationMode.VLLM_COMPILE,
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+        ),
+    ],
+)
+def test_stock_mode_auto_selection(
+    supported, user_mode, expected_mode, expected_cudagraph
+):
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    cc_kwargs = {} if user_mode is None else {"mode": user_mode}
+    with patch.object(VllmConfig, "_stock_compile_supported", lambda self: supported):
+        config = VllmConfig(compilation_config=CompilationConfig(**cc_kwargs))
+    # The stock default is graph-partition piecewise only on torch>=2.9; on older
+    # torch the piecewise default can't be honored, so it falls back to VllmBackend
+    # (the cudagraph mode is preserved across the fallback).
+    if (
+        expected_mode == CompilationMode.STOCK_TORCH_COMPILE
+        and not is_torch_equal_or_newer("2.9.0.dev")
+    ):
+        expected_mode = CompilationMode.VLLM_COMPILE
+    assert config.compilation_config.mode == expected_mode
+    assert config.compilation_config.cudagraph_mode == expected_cudagraph
+
+
+@pytest.mark.parametrize(
+    "mode,cudagraph_mode,partition,expected_mode,expected_cudagraph",
+    [
+        # STOCK + a piecewise mode without graph partition can't be honored, so the
+        # engine falls back to the legacy VllmBackend (which has its own FX splitting),
+        # leaving cudagraph_mode intact for that backend to consume.
+        (
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.PIECEWISE,
+            False,
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.PIECEWISE,
+        ),
+        (
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+            False,
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+        ),
+        # STOCK + piecewise WITH graph partition is supported, so it stays on stock.
+        (
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.PIECEWISE,
+            True,
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.PIECEWISE,
+        ),
+        # A non-piecewise mode never needs fixing.
+        (
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+            False,
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+        ),
+        # VLLM_COMPILE honors piecewise itself, so it is left untouched.
+        (
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.PIECEWISE,
+            False,
+            CompilationMode.VLLM_COMPILE,
+            CUDAGraphMode.PIECEWISE,
+        ),
+        # NONE / DYNAMO_TRACE_ONCE have no compiled graph to capture piecewise, so the
+        # piecewise cudagraph_mode drops to NONE (no fallback -- there is nothing to
+        # fall back to for these explicit modes).
+        (
+            CompilationMode.NONE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+            False,
+            CompilationMode.NONE,
+            CUDAGraphMode.NONE,
+        ),
+        (
+            CompilationMode.DYNAMO_TRACE_ONCE,
+            CUDAGraphMode.PIECEWISE,
+            False,
+            CompilationMode.DYNAMO_TRACE_ONCE,
+            CUDAGraphMode.NONE,
+        ),
+    ],
+)
+def test_fix_unsupported_piecewise_cudagraph_mode(
+    mode, cudagraph_mode, partition, expected_mode, expected_cudagraph
+):
+    # Construct with a benign non-piecewise cudagraph_mode so the config settles in
+    # the requested `mode`: an unset (piecewise) default would itself trip the
+    # stock->VLLM_COMPILE fallback during __post_init__. Then set the mode under test
+    # and invoke the helper in isolation.
+    config = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=mode,
+            use_inductor_graph_partition=partition,
+            cudagraph_mode=CUDAGraphMode.NONE,
+        )
+    )
+    config.compilation_config.cudagraph_mode = cudagraph_mode
+    config._fix_unsupported_piecewise_cudagraph_mode()
+    assert config.compilation_config.mode == expected_mode
+    assert config.compilation_config.cudagraph_mode == expected_cudagraph
+
+
+# --- step 2: piecewise cudagraphs on the stock path via Inductor graph partition ---
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+@pytest.mark.parametrize(
+    "user_cudagraph_mode,expected",
+    [
+        # Unset + graph partition -> prefill can be piecewise-captured, so default to
+        # FULL_AND_PIECEWISE rather than FULL_DECODE_ONLY.
+        (None, CUDAGraphMode.FULL_AND_PIECEWISE),
+        # Explicit piecewise modes are now honored on the stock path (Inductor graph
+        # partition provides them) instead of being clamped to NONE.
+        (CUDAGraphMode.PIECEWISE, CUDAGraphMode.PIECEWISE),
+        (CUDAGraphMode.FULL_AND_PIECEWISE, CUDAGraphMode.FULL_AND_PIECEWISE),
+        # Explicit NONE is still the user's deliberate choice.
+        (CUDAGraphMode.NONE, CUDAGraphMode.NONE),
+    ],
+)
+def test_stock_graph_partition_cudagraph_mode(user_cudagraph_mode, expected):
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    if not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("use_inductor_graph_partition requires torch>=2.9.0.dev")
+    cc_kwargs = {
+        "mode": CompilationMode.STOCK_TORCH_COMPILE,
+        "use_inductor_graph_partition": True,
+    }
+    if user_cudagraph_mode is not None:
+        cc_kwargs["cudagraph_mode"] = user_cudagraph_mode
+    config = VllmConfig(compilation_config=CompilationConfig(**cc_kwargs))
+    assert config.compilation_config.cudagraph_mode == expected
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+def test_stock_graph_partition_populates_splitting_ops():
+    # With graph partition, splitting_ops must name the attention ops so Inductor
+    # partitions there; without it the stock path cannot provide piecewise cudagraphs
+    # and falls back to the legacy VllmBackend.
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    if not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("use_inductor_graph_partition requires torch>=2.9.0.dev")
+
+    partition = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE,
+            use_inductor_graph_partition=True,
+        )
+    )
+    assert partition.compilation_config.splitting_ops == list(
+        CompilationConfig._attention_ops
+    )
+
+    # An explicit empty list with partition on must still be populated (else
+    # FULL_AND_PIECEWISE would have zero piecewise partitions, silently capturing
+    # attention inside the cudagraph).
+    explicit_empty = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE,
+            use_inductor_graph_partition=True,
+            splitting_ops=[],
+        )
+    )
+    assert explicit_empty.compilation_config.splitting_ops == list(
+        CompilationConfig._attention_ops
+    )
+
+    # Partition explicitly off on the stock path can't provide piecewise cudagraphs,
+    # so it falls back to the legacy VllmBackend rather than silently degrading to a
+    # whole-graph stock path.
+    no_partition = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE,
+            use_inductor_graph_partition=False,
+        )
+    )
+    assert no_partition.compilation_config.mode == CompilationMode.VLLM_COMPILE
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="stock inductor-options pass wiring is exercised on CUDA",
+)
+def test_stock_inductor_options_fusion_gate():
+    # The fusion gate is derived from the configured PostGradPassManager rather than a
+    # hand-maintained flag list, so it cannot drift. Dense bf16 with no active fusion
+    # pass reports has_fusion False (only NoOpElimination, which buys nothing) but the
+    # base inductor_compile_config is still carried (only the pass manager is skipped);
+    # turning on a real fusion pass (enable_qk_norm_rope_fusion) reports fusion and
+    # wires the pre/post-grad passes.
+    from types import SimpleNamespace
+
+    import vllm.compilation.passes.inductor_pass as inductor_pass_mod
+    from vllm.compilation.passes.ir.inplace_functionalization import (
+        VllmIRInplaceFunctionalizationPass,
+    )
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+    def options_for(**pass_flags):
+        # Pin the whole-graph stock path (partition off, decode-only cudagraphs) so
+        # the gate reflects only the requested passes: the default now auto-enables
+        # Inductor graph partition, which itself turns on partition-gated fusions
+        # (e.g. rope_kvcache_cat_mla) that would mask the baseline.
+        vc = VllmConfig(
+            compilation_config=CompilationConfig(
+                mode=CompilationMode.STOCK_TORCH_COMPILE,
+                use_inductor_graph_partition=False,
+                cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+                pass_config=PassConfig(**pass_flags),
+            )
+        )
+        vc.model_config = MagicMock(dtype=torch.bfloat16)
+        # A user-supplied inductor_compile_config entry: it must survive into the
+        # returned options even when there is no fusion.
+        vc.compilation_config.inductor_compile_config["max_autotune"] = True
+        stub = SimpleNamespace(compilation_config=vc.compilation_config, vllm_config=vc)
+        return GPUModelRunner._stock_inductor_options(stub)
+
+    # The fusion path installs a process-global pass context (set_pass_context has no
+    # teardown by design); restore it so this unit test leaves no global state.
+    prev_pass_context = inductor_pass_mod._pass_context
+    try:
+        # Dense bf16 with no active fusion pass: has_fusion False, but the base
+        # inductor_compile_config must still be carried -- dropping it silently ignored
+        # combo-kernel / auto-functionalization gating and any user
+        # --compilation-config inductor_compile_config on the stock path.
+        base_opts, has_fusion = options_for(eliminate_noops=True)
+        assert not has_fusion
+        assert "enable_auto_functionalized_v2" in base_opts
+        assert base_opts["max_autotune"] is True
+        # The pass manager and pre-grad pass are gated on fusion -> absent here.
+        assert "pre_grad_custom_pass" not in base_opts
+        assert current_platform.pass_key not in base_opts
+
+        # A real fusion pass -> has_fusion True, and the dict must actually wire the
+        # pre/post-grad passes through Inductor's custom-pass hooks (not merely report
+        # has_fusion), while still carrying the base config.
+        opts, has_fusion = options_for(
+            eliminate_noops=True,
+            enable_qk_norm_rope_fusion=True,
+        )
+        assert has_fusion
+        assert "enable_auto_functionalized_v2" in opts
+        assert isinstance(
+            opts["pre_grad_custom_pass"], VllmIRInplaceFunctionalizationPass
+        )
+        assert current_platform.pass_key in opts
+        assert "pre_grad_custom_pass" in opts["_cache_config_ignore_prefix"]
+    finally:
+        inductor_pass_mod._pass_context = prev_pass_context
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="stock inductor-options pass wiring is exercised on CUDA",
+)
+def test_stock_inductor_options_merges_user_post_grad_pass():
+    # A user-supplied post_grad_custom_post_pass must be merged into the stock path's
+    # PostGradPassManager (mirroring VllmBackend.configure_post_pass), not clobbered by
+    # the manager registration. Regression guard: the stock path used to overwrite the
+    # pass_key unconditionally, silently dropping the user's post-grad pass.
+    from types import SimpleNamespace
+
+    import vllm.compilation.passes.inductor_pass as inductor_pass_mod
+    from vllm.compilation.passes.inductor_pass import InductorPass
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+    class _MarkerPass(InductorPass):
+        def __call__(self, graph):
+            pass
+
+    marker = _MarkerPass()
+    # Pin the whole-graph stock path (partition off, decode-only cudagraphs) with a real
+    # fusion pass active (enable_qk_norm_rope_fusion) so _stock_inductor_options
+    # registers the pass manager and reaches the merge branch instead of returning the
+    # base options early.
+    vc = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE,
+            use_inductor_graph_partition=False,
+            cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+            pass_config=PassConfig(
+                eliminate_noops=True, enable_qk_norm_rope_fusion=True
+            ),
+            inductor_compile_config={current_platform.pass_key: marker},
+        )
+    )
+    vc.model_config = MagicMock(dtype=torch.bfloat16)
+    stub = SimpleNamespace(compilation_config=vc.compilation_config, vllm_config=vc)
+
+    # set_pass_context installs process-global state with no teardown by design;
+    # restore it so this unit test leaves no global leak for other tests.
+    prev_pass_context = inductor_pass_mod._pass_context
+    try:
+        opts, has_fusion = GPUModelRunner._stock_inductor_options(stub)
+    finally:
+        inductor_pass_mod._pass_context = prev_pass_context
+
+    assert has_fusion
+    manager = opts[current_platform.pass_key]
+    # The manager replaces the raw pass under pass_key, and the user's pass is merged
+    # into the manager's pass list rather than dropped.
+    assert manager is not marker
+    assert marker in manager.passes
+
+
+def test_stock_inert_flag_warning():
+    # VllmBackend-only flags on a stock model emit one warning that names the
+    # working escape hatch and never the broken -O.mode=3 form.
+    config = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE, compile_sizes=[1, 2]
+        )
+    )
+    config.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        config._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 1
+    fmt, *fmt_args = mock_warn.call_args.args
+    assert "--compilation-config" in fmt
+    assert "-O.mode=3" not in fmt
+    assert "compile_sizes" in " ".join(str(a) for a in fmt_args)
+
+    # cudagraph_copy_inputs and splitting_ops (without graph partition) are also
+    # VllmBackend-only on the stock path and must each surface in the warning args.
+    copy_cfg = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE, cudagraph_copy_inputs=True
+        )
+    )
+    copy_cfg.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        copy_cfg._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 1
+    assert "cudagraph_copy_inputs" in " ".join(str(a) for a in mock_warn.call_args.args)
+
+    # VLLM_COMPILE honors these flags, so no warning.
+    other = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE, compile_sizes=[1, 2]
+        )
+    )
+    other.model_config = MagicMock(architectures=["LlamaForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        other._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 0
+
+
+def test_stock_graph_partition_no_piecewise_override_warning():
+    # With use_inductor_graph_partition the stock path provides piecewise cudagraphs,
+    # so resolving to FULL_AND_PIECEWISE must NOT warn about an unsupported/overridden
+    # cudagraph_mode (regression: the inert-flag warning used to fire here).
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    if not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("use_inductor_graph_partition requires torch>=2.9.0.dev")
+    config = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE,
+            use_inductor_graph_partition=True,
+        )
+    )
+    config.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        config._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 0
+
+
+def test_stock_compile_cache_flags_warn(monkeypatch):
+    # vLLM's own compile cache is inert on the stock path (torch.compile uses its
+    # own cache); setting any of its knobs must warn, not be silently ignored.
+    monkeypatch.setenv("VLLM_COMPILE_CACHE_SAVE_FORMAT", "binary")
+
+    def warn_parts(**cc):
+        config = VllmConfig(
+            compilation_config=CompilationConfig(
+                mode=CompilationMode.STOCK_TORCH_COMPILE, **cc
+            )
+        )
+        config.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+        with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+            config._warn_ignored_vllm_backend_only_flags()
+        assert mock_warn.call_count == 1
+        return " ".join(str(a) for a in mock_warn.call_args.args)
+
+    assert "cache_dir" in warn_parts(cache_dir="/tmp/vllm-cache")
+    assert "compile_cache_save_format" in warn_parts(
+        compile_cache_save_format="unpacked"
+    )
+
+    # VLLM_DISABLE_COMPILE_CACHE is an env var, not a field.
+    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
+    config = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    config.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        config._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 1
+    assert "VLLM_DISABLE_COMPILE_CACHE" in " ".join(
+        str(a) for a in mock_warn.call_args.args
+    )
+
+
+def test_stock_warn_no_false_positive_on_autopopulated_fields():
+    # compile_ranges_endpoints is auto-populated later in __post_init__ (and
+    # __post_init__ may re-run on a reused compilation_config), so a resolved
+    # non-empty value must NOT trigger a warning when the user set no inert flags.
+    config = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    # simulate the resolved/auto-populated state seen on a real run / re-run
+    config.compilation_config.compile_ranges_endpoints = [16384]
+    config.model_config = MagicMock(architectures=["GptOssForCausalLM"])
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        config._warn_ignored_vllm_backend_only_flags()
+    assert mock_warn.call_count == 0
+
+
+def test_stock_warning_handles_missing_model_config():
+    # mode==STOCK with no model_config must not raise (the warn helper dereferences
+    # model_config.architectures only after a None guard).
+    config = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE, compile_sizes=[1, 2]
+        )
+    )
+    config.model_config = None
+    config._warn_ignored_vllm_backend_only_flags()
+
+
+def test_stock_compile_supported_safe_defaults():
+    # The real _stock_compile_supported (not patched out) must return False for
+    # both the no-model case and any registry resolution error, so a broken/unknown
+    # model never gets auto-selected onto the stock path.
+    no_model = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    no_model.model_config = None
+    assert no_model._stock_compile_supported() is False
+
+    raising = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    registry = MagicMock()
+    registry.is_stock_compile_supported_model.side_effect = RuntimeError("boom")
+    raising.model_config = MagicMock(
+        architectures=["GptOssForCausalLM"], registry=registry
+    )
+    # A swallowed resolution error must still return the safe default AND be
+    # surfaced at a visible level so a stock-eligible arch silently falling
+    # back to VllmBackend is diagnosable.
+    with patch("vllm.config.vllm.logger.warning_once") as mock_warn:
+        assert raising._stock_compile_supported() is False
+    assert mock_warn.call_count == 1
+    warn_text = " ".join(str(a) for a in mock_warn.call_args.args)
+    assert "GptOssForCausalLM" in warn_text
+    assert "boom" in warn_text
+
+
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+def test_stock_dynamic_sd_overrides_to_piecewise():
+    # Dynamic spec decode varies the verification length, so the full-decode capture
+    # in FULL_AND_PIECEWISE is unsafe. The dynamic-SD override drops it to PIECEWISE;
+    # on the stock path graph partition (auto-enabled on torch>=2.9) provides those
+    # piecewise cudagraphs, so it stays on stock rather than falling back or dropping
+    # cudagraphs. An algorithmic (ngram_gpu) drafter keeps the stock path, isolating
+    # the dynamic-SD override on STOCK.
+    from types import SimpleNamespace
+
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    spec = SimpleNamespace(
+        method="ngram_gpu",
+        disable_padded_drafter_batch=False,
+        num_speculative_tokens=3,
+        max_num_new_slots_for_drafting=3,
+        parallel_drafting=False,
+        uses_dynamic_speculative_decoding=lambda: True,
+        use_eagle=lambda: False,
+        compute_hash=lambda: "spec",
+    )
+    config = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    # Assign the stub after construction (pydantic's dataclass validator rejects a
+    # SimpleNamespace at construction time) and re-run resolution to exercise the
+    # dynamic-SD override in __post_init__.
+    config.speculative_config = spec
+    config.compilation_config.cudagraph_mode = None
+    # Reset the auto-resolved partition flag too so this mirrors a fresh single
+    # construction with a dynamic drafter.
+    config.compilation_config.use_inductor_graph_partition = None
+    config.__post_init__()
+    if is_torch_equal_or_newer("2.9.0.dev"):
+        assert config.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE
+        assert config.compilation_config.cudagraph_mode == CUDAGraphMode.PIECEWISE
+        assert config.compilation_config.use_inductor_graph_partition is True
+    else:
+        # Without Inductor graph partition the stock path can't do piecewise, so the
+        # dynamic-SD PIECEWISE override falls back to the legacy backend.
+        assert config.compilation_config.mode == CompilationMode.VLLM_COMPILE
+
+
+@pytest.mark.parametrize("mode", list(CompilationMode))
+def test_deepep_high_throughput_disables_cudagraphs_all_modes(mode):
+    # DeepEP high-throughput all2all kernels are CUDA-graph-incompatible; the disable
+    # must fire regardless of compile mode (it runs before the mode-specific early
+    # return in set_splitting_ops_for_v1), including on the stock path.
+    cc = CompilationConfig(
+        mode=mode,
+        cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        use_inductor_graph_partition=True,
+    )
+    cc.set_splitting_ops_for_v1(
+        all2all_backend="deepep_high_throughput", data_parallel_size=2
+    )
+    assert cc.cudagraph_mode == CUDAGraphMode.NONE
+
+    # A non-DeepEP-HT backend leaves the cudagraph mode alone.
+    cc2 = CompilationConfig(
+        mode=mode,
+        cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        use_inductor_graph_partition=True,
+    )
+    cc2.set_splitting_ops_for_v1(
+        all2all_backend="allgather_reducescatter", data_parallel_size=2
+    )
+    assert cc2.cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE
+
+
+@pytest.mark.parametrize("decorate_outer", [True, False])
+def test_stock_support_torch_compile_routes_to_runner_compile(decorate_outer):
+    # Spec-decode drafters run under the engine-global STOCK mode with their
+    # @support_torch_compile decorator not using vLLM's custom backend
+    # (do_not_use_custom_torch_compile_backend), and the runner
+    # compiles the drafter model via nn.Module.compile().
+    # - decorate_outer=True (MTP shape): the compiled module IS the decorated class.
+    #   Because the decorator overrides nn.Module.__call__, .compile() only takes
+    #   effect if that __call__ routes to _compiled_call_impl -- with the pre-fix
+    #   decorator the backend is never invoked (calls == 0). This case guards the fix.
+    # - decorate_outer=False (eagle-head shape): an undecorated outer wraps the
+    #   decorated inner; the outer's .compile() works regardless of the fix. This is a
+    #   regression guard that the eagle shape still compiles under stock.
+    import torch
+    import torch.nn as nn
+
+    from vllm.compilation.decorators import support_torch_compile
+    from vllm.config import set_current_vllm_config
+
+    @support_torch_compile
+    class Decorated(nn.Module):
+        def __init__(self, *, vllm_config=None, prefix=""):
+            super().__init__()
+            self.lin = nn.Linear(8, 8)
+
+        def forward(self, x: torch.Tensor):
+            return self.lin(x)
+
+    cfg = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.STOCK_TORCH_COMPILE,
+            use_inductor_graph_partition=False,
+            cudagraph_mode=CUDAGraphMode.NONE,
+        )
+    )
+    with set_current_vllm_config(cfg):
+        decorated = Decorated(vllm_config=cfg)
+
+    # decorate_outer=True compiles the decorated module directly (the MTP-drafter
+    # shape); False wraps it in an undecorated outer (the eagle-head shape).
+    module = decorated if decorate_outer else nn.Sequential(decorated)
+
+    calls = {"n": 0}
+
+    def counting_backend(gm, example_inputs):
+        calls["n"] += 1
+        return gm.forward
+
+    module.compile(fullgraph=True, backend=counting_backend)
+    module(torch.randn(4, 8))
+    assert calls["n"] >= 1, (
+        "nn.Module.compile() did not take effect under STOCK_TORCH_COMPILE; the "
+        "drafter would run eager"
+    )
+
+
+def test_support_torch_compile_none_mode_runs_eager():
+    # The __call__ routing that sends do_not_use_custom_torch_compile_backend modules
+    # to _compiled_call_impl is STOCK-only: under CompilationMode.NONE the module has
+    # do_not_use_custom_torch_compile_backend set and nothing calls nn.Module.compile()
+    # on it, so _compiled_call_impl stays None and it runs eager (guards the shared
+    # decorator path against a regression).
+    import torch
+    import torch.nn as nn
+
+    from vllm.compilation.decorators import support_torch_compile
+    from vllm.config import set_current_vllm_config
+
+    @support_torch_compile
+    class Decorated(nn.Module):
+        def __init__(self, *, vllm_config=None, prefix=""):
+            super().__init__()
+            self.ran_eager = False
+
+        def forward(self, x: torch.Tensor):
+            self.ran_eager = True
+            return x
+
+    cfg = VllmConfig(compilation_config=CompilationConfig(mode=CompilationMode.NONE))
+    with set_current_vllm_config(cfg):
+        m = Decorated(vllm_config=cfg)
+    assert getattr(m, "_compiled_call_impl", None) is None
+    m(torch.randn(2, 2))
+    assert m.ran_eager
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="glue-kernel resolution comparison is CUDA-specific",
+)
+def test_stock_uses_default_glue_kernels_like_vllm_backend():
+    # Stock must NOT force the vLLM custom RMSNorm/RoPE glue kernels. A TP1-TP8 sweep
+    # found the custom glue (+rotary_embedding, ir_op_priority.rms_norm=vllm_c) is ~10%
+    # slower at batch-1 decode than the Inductor glue VllmBackend actually uses
+    # (custom_ops=none), with no throughput or prefill benefit (PR #46423). Stock must
+    # resolve to the same glue as VllmBackend so they run identical kernels.
+    stock = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    vllm = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.VLLM_COMPILE)
+    )
+    # No forced custom RoPE kernel, and RMSNorm priority is not forced to vllm_c.
+    assert "+rotary_embedding" not in stock.compilation_config.custom_ops
+    assert stock.kernel_config.ir_op_priority.rms_norm[0] != "vllm_c"
+    assert stock.kernel_config.ir_op_priority.fused_add_rms_norm[0] != "vllm_c"
+    # Stock resolves to the same glue kernels as VllmBackend.
+    assert (
+        stock.kernel_config.ir_op_priority.rms_norm
+        == vllm.kernel_config.ir_op_priority.rms_norm
+    )
+    assert (
+        stock.kernel_config.ir_op_priority.fused_add_rms_norm
+        == vllm.kernel_config.ir_op_priority.fused_add_rms_norm
+    )
+
+
+@pytest.mark.parametrize(
+    "method,expected_mode",
+    [
+        # Validated drafter methods keep the stock path (runner compiles the drafter).
+        ("eagle", CompilationMode.STOCK_TORCH_COMPILE),
+        ("eagle3", CompilationMode.STOCK_TORCH_COMPILE),
+        # Algorithmic (model-less) drafters have nothing to compile, so stay stock.
+        ("ngram", CompilationMode.STOCK_TORCH_COMPILE),
+        ("ngram_gpu", CompilationMode.STOCK_TORCH_COMPILE),
+        ("suffix", CompilationMode.STOCK_TORCH_COMPILE),
+        # Unvalidated model-backed drafters fall back so they compile as before
+        # (fullgraph-compiling them on stock is unchecked / would graph-break). mtp is
+        # not yet e2e-validated on stock, so it falls back too.
+        ("mtp", CompilationMode.VLLM_COMPILE),
+        ("draft_model", CompilationMode.VLLM_COMPILE),
+        ("medusa", CompilationMode.VLLM_COMPILE),
+        ("dflash", CompilationMode.VLLM_COMPILE),
+        ("extract_hidden_states", CompilationMode.VLLM_COMPILE),
+    ],
+)
+def test_stock_drafter_method_fallback(method, expected_mode):
+    from types import SimpleNamespace
+
+    config = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    config.speculative_config = SimpleNamespace(method=method)
+    config._maybe_fallback_stock_for_unsupported_drafter()
+    assert config.compilation_config.mode == expected_mode
+
+
+def test_stock_drafter_fallback_noop_cases():
+    from types import SimpleNamespace
+
+    # No speculative config -> stock preserved.
+    cfg = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.STOCK_TORCH_COMPILE)
+    )
+    cfg.speculative_config = None
+    cfg._maybe_fallback_stock_for_unsupported_drafter()
+    assert cfg.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE
+
+    # Non-stock mode is left untouched even with an unvalidated model-backed drafter.
+    cfg = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.VLLM_COMPILE)
+    )
+    cfg.speculative_config = SimpleNamespace(method="medusa")
+    cfg._maybe_fallback_stock_for_unsupported_drafter()
+    assert cfg.compilation_config.mode == CompilationMode.VLLM_COMPILE
+
+
+def test_algorithmic_drafter_methods_stay_stock():
+    from types import SimpleNamespace
+
+    # Iterate the shared constant (not a hardcoded list) so the single source of
+    # truth used by _maybe_fallback_stock_for_unsupported_drafter is what gets
+    # exercised: any model-less method added to _ALGORITHMIC_DRAFTER_METHODS is
+    # covered automatically, and the disjointness check guards against a method
+    # being listed as both algorithmic and validated-model-backed.
+    assert VllmConfig._ALGORITHMIC_DRAFTER_METHODS
+    assert not (
+        set(VllmConfig._ALGORITHMIC_DRAFTER_METHODS)
+        & set(VllmConfig._STOCK_SUPPORTED_DRAFTER_METHODS)
+    )
+    for method in VllmConfig._ALGORITHMIC_DRAFTER_METHODS:
+        config = VllmConfig(
+            compilation_config=CompilationConfig(
+                mode=CompilationMode.STOCK_TORCH_COMPILE
+            )
+        )
+        config.speculative_config = SimpleNamespace(method=method)
+        config._maybe_fallback_stock_for_unsupported_drafter()
+        assert config.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE, (
+            method
+        )
+
+
+# forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
+@pytest.mark.forked
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+def test_stock_torch_compile_compiles_spec_decode_drafter(vllm_runner, monkeypatch):
+    # A model-backed spec-decode drafter must be compiled on the stock path (no
+    # fallback to VLLM_COMPILE): the runner compiles both the target and the eagle
+    # drafter model via stock torch.compile, so stock_torch_compile_count == 2. The
+    # drafter's own @support_torch_compile decorator is disabled under STOCK, and its
+    # piecewise cudagraphs come from the same Inductor graph partition as the target.
+    # Llama-3.2-1B is not SupportsStockCompile, so mode=STOCK is forced here.
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    with (
+        compilation_counter.expect(stock_torch_compile_count=2),
+        vllm_runner(
+            "meta-llama/Llama-3.2-1B-Instruct",
+            speculative_config={
+                "method": "eagle3",
+                "model": "nm-testing/Llama3_2_1B_speculator.eagle3",
+                "num_speculative_tokens": 3,
+            },
+            compilation_config={"mode": CompilationMode.STOCK_TORCH_COMPILE},
+            max_model_len=2048,
+            gpu_memory_utilization=0.55,
+        ) as _,
+    ):
+        pass
+
+
+# forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
+@pytest.mark.forked
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+def test_stock_torch_compile_captures_full_cudagraph(vllm_runner, monkeypatch):
+    # The headline parity path: a stock-compiled model must still attach vLLM's
+    # external FULL cudagraph wrapper and actually capture a FULL_DECODE_ONLY graph.
+    # opt-125m is not SupportsStockCompile, so mode=STOCK is forced explicitly here;
+    # the auto-FDO promotion is allowlist-independent, so this isolates the cudagraph
+    # fall-through (not the SupportsStockCompile selection).
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    with (
+        compilation_counter.expect(
+            stock_torch_compile_count=1,
+            num_gpu_runner_capture_triggers=1,
+            num_cudagraph_captured=1,
+        ),
+        vllm_runner(
+            "facebook/opt-125m",
+            compilation_config={
+                "mode": CompilationMode.STOCK_TORCH_COMPILE,
+                # Pin partition off: this test isolates the FULL_DECODE_ONLY fall-
+                # through, while the default now auto-enables graph-partition
+                # piecewise (covered by test_stock_torch_compile_piecewise_*).
+                "use_inductor_graph_partition": False,
+                "cudagraph_capture_sizes": [100],
+            },
+            gpu_memory_utilization=0.4,
+        ) as _,
+    ):
+        pass
+
+
+# forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
+@pytest.mark.forked
+@pytest.mark.skipif(
+    not current_platform.support_static_graph_mode(),
+    reason="Skip if cudagraph mode not supported",
+)
+@pytest.mark.parametrize("use_partition", [False, True])
+def test_stock_cudagraph_replay_matches_no_cudagraph(
+    vllm_runner, monkeypatch, use_partition
+):
+    # StockTorchCompileCUDAGraphWrapper capture/replay must be numerically correct, not merely
+    # capture the right graph count. For each partition setting, compare the SAME
+    # stock-compiled model with cudagraphs off vs on: the compiled kernels are
+    # identical, so a divergence in greedy decode isolates a replay bug (wrong batch-
+    # descriptor key, stale entry.output, bad weak-ref output) rather than compile-vs-
+    # eager numeric drift. partition=False exercises the single whole-graph
+    # FULL_DECODE_ONLY wrapper; partition=True exercises the per-partition wrappers of
+    # the default FULL_AND_PIECEWISE path. The count-only capture tests stay green
+    # through such a bug.
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    if use_partition and not is_torch_equal_or_newer("2.9.0.dev"):
+        pytest.skip("use_inductor_graph_partition requires torch>=2.9.0.dev")
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    prompts = [
+        "The capital of France is",
+        "The quick brown fox jumps over the",
+    ]
+
+    def _greedy(cudagraph_on):
+        cc = {
+            "mode": CompilationMode.STOCK_TORCH_COMPILE,
+            "use_inductor_graph_partition": use_partition,
+        }
+        if cudagraph_on:
+            cc["cudagraph_capture_sizes"] = [8]
+        else:
+            cc["cudagraph_mode"] = CUDAGraphMode.NONE
+        with vllm_runner(
+            "facebook/opt-125m",
+            compilation_config=cc,
+            gpu_memory_utilization=0.4,
+        ) as m:
+            return m.generate_greedy(prompts, max_tokens=32)
+
+    base = _greedy(cudagraph_on=False)
+    replayed = _greedy(cudagraph_on=True)
+    for (base_ids, _), (replay_ids, _) in zip(base, replayed):
+        assert base_ids == replay_ids

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -136,3 +136,27 @@ def test_hf_registry_coverage():
         "Please add the following architectures to "
         f"`tests/models/registry.py`: {untested_archs}"
     )
+
+
+def test_supports_stock_compile_marker():
+    # The SupportsStockCompile marker is the single bit that opts an architecture
+    # into the stock torch.compile path; guard it so the GPT-OSS opt-in cannot be
+    # dropped and no other architecture is migrated by accident.
+    from vllm.model_executor.models.interfaces import supports_stock_compile
+
+    gptoss = ModelRegistry._try_load_model_cls("GptOssForCausalLM")
+    llama = ModelRegistry._try_load_model_cls("LlamaForCausalLM")
+    assert supports_stock_compile(gptoss)
+    assert not supports_stock_compile(llama)
+
+    # Also exercise the production resolution path (the _ModelInfo field hop that
+    # config resolution actually consults), not just the marker free function.
+    from unittest.mock import MagicMock
+
+    model_config = MagicMock(model_impl="vllm")
+    assert ModelRegistry.is_stock_compile_supported_model(
+        "GptOssForCausalLM", model_config
+    )
+    assert not ModelRegistry.is_stock_compile_supported_model(
+        "LlamaForCausalLM", model_config
+    )

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -385,15 +385,18 @@ def _support_torch_compile(
         self.vllm_config = vllm_config
         self.compilation_config = self.vllm_config.compilation_config
         enable_compile = enable_if is None or enable_if(vllm_config)
-        # for CompilationMode.STOCK_TORCH_COMPILE , the upper level model runner
-        # will handle the compilation, so we don't need to do anything here.
-        self.do_not_compile = (
+        # This flag means "do not use vLLM's custom torch.compile backend
+        # (VllmBackend)". It does NOT mean the module never gets compiled: under
+        # CompilationMode.STOCK_TORCH_COMPILE the upper level model runner compiles
+        # it via nn.Module.compile() with stock Inductor. For CompilationMode.NONE,
+        # ignored classes, and disabled enable_if, nothing compiles it at all.
+        self.do_not_use_custom_torch_compile_backend = (
             self.compilation_config.mode
             in [CompilationMode.NONE, CompilationMode.STOCK_TORCH_COMPILE]
             or _should_ignore_torch_compile(self.__class__)
             or not enable_compile
         )
-        if self.do_not_compile:
+        if self.do_not_use_custom_torch_compile_backend:
             return
 
         self._dynamic_arg_dims = dynamic_arg_dims
@@ -503,7 +506,30 @@ def _support_torch_compile(
         # torch.compiler.is_compiling() means we are inside the compilation
         # e.g. TPU has the compilation logic in model runner, so we don't
         # need to compile the model inside.
-        if self.do_not_compile or torch.compiler.is_compiling():
+        if torch.compiler.is_compiling():
+            return self.forward(*args, **kwargs)
+
+        if self.do_not_use_custom_torch_compile_backend:
+            # Under CompilationMode.STOCK_TORCH_COMPILE the model runner compiles
+            # this module via nn.Module.compile(), which stores the compiled
+            # callable on _compiled_call_impl. This decorator's __call__ overrides
+            # nn.Module._wrapped_call_impl, so route to that compiled callable here;
+            # otherwise a module whose top-level class carries this decorator and is
+            # compiled directly by the runner would silently run eager. No currently-
+            # allowlisted arch hits the compiled branch (GPT-OSS and the eagle drafters
+            # are undecorated at top level; their decorated inner modules are folded
+            # submodules with _compiled_call_impl=None) -- it guards a future
+            # top-level-decorated model.
+            # skip_compiled (enc-dec: shapes/types vary, no single graph) still forces
+            # eager, matching the compiled path below. When nothing compiled the module
+            # (_compiled_call_impl is None, the case for CompilationMode.NONE and for
+            # decorated submodules folded into a parent's stock compile), run eagerly.
+            compiled_call_impl = getattr(self, "_compiled_call_impl", None)
+            skip_compiled = (
+                is_forward_context_available() and get_forward_context().skip_compiled
+            )
+            if compiled_call_impl is not None and not skip_compiled:
+                return compiled_call_impl(*args, **kwargs)
             return self.forward(*args, **kwargs)
 
         # If skip_compiled is set, bypass compiled model call. This is used e.g. for
@@ -721,6 +747,116 @@ def _support_torch_compile(
     return cls
 
 
+def _make_partition_wrapper(
+    vllm_config: VllmConfig,
+    wrapper_cls: Callable[..., Any],
+    options_cls: Callable[..., Any],
+) -> Callable[..., Any]:
+    """Build an Inductor graph-partition wrapper.
+
+    Inductor splits the FX graph into partitions (subgraphs separated by
+    cudagraph-unsafe ops); this hook wraps each partition so it is captured and
+    replayed as its own PIECEWISE cudagraph. The per-partition options key off
+    ``partition_index``: only the first partition (id 0) logs (avoids per-graph
+    spam) and runs gc (per-partition gc is very slow), and only the last
+    partition weak-refs its output (safe because no later captured graph consumes
+    it). ``wrapper_cls``/``options_cls`` select the static-cudagraph
+    implementation: the VLLM_COMPILE path uses the platform's shared wrapper, the
+    STOCK_TORCH_COMPILE path uses its decoupled StockTorchCompileCUDAGraphWrapper.
+    """
+    from torch._inductor.utils import CUDAGraphWrapperMetadata
+
+    from vllm.config import CUDAGraphMode
+
+    def customized_cudagraph_wrapper(
+        f: Callable[..., Any], metadata: CUDAGraphWrapperMetadata
+    ) -> Any:
+        partition_id = metadata.partition_index
+        num_partitions = metadata.num_partitions
+        return wrapper_cls(
+            runnable=f,
+            vllm_config=vllm_config,
+            runtime_mode=CUDAGraphMode.PIECEWISE,
+            cudagraph_options=options_cls(
+                debug_log_enable=partition_id == 0,
+                gc_disable=partition_id != 0,
+                weak_ref_output=partition_id == num_partitions - 1,
+            ),
+        )
+
+    return customized_cudagraph_wrapper
+
+
+def _make_cudagraph_partition_wrapper(vllm_config: VllmConfig) -> Callable[..., Any]:
+    """VLLM_COMPILE graph-partition wrapper using the platform's shared static
+    cudagraph wrapper."""
+    from vllm.compilation.cuda_graph import CUDAGraphOptions
+    from vllm.platforms import current_platform
+
+    static_graph_wrapper_class = resolve_obj_by_qualname(
+        current_platform.get_static_graph_wrapper_cls()
+    )
+    return _make_partition_wrapper(
+        vllm_config, static_graph_wrapper_class, CUDAGraphOptions
+    )
+
+
+def _make_stock_cudagraph_partition_wrapper(
+    vllm_config: VllmConfig,
+) -> Callable[..., Any]:
+    """STOCK_TORCH_COMPILE graph-partition wrapper. Uses the decoupled
+    StockTorchCompileCUDAGraphWrapper rather than the shared CUDAGraphWrapper, which is coupled
+    to vLLM's non-torch.compile full-cudagraph path."""
+    from vllm.compilation.stock_cudagraph import (
+        StockCUDAGraphOptions,
+        StockTorchCompileCUDAGraphWrapper,
+    )
+
+    return _make_partition_wrapper(
+        vllm_config, StockTorchCompileCUDAGraphWrapper, StockCUDAGraphOptions
+    )
+
+
+def install_cudagraph_partition_wrapper(
+    vllm_config: VllmConfig,
+) -> Callable[..., Any] | None:
+    """Persistently install the STOCK graph-partition cudagraph wrapper and return
+    the previously installed wrapper (usually None) so a caller could restore it.
+
+    Stock torch.compile is lazy: the real Inductor compile and its post_compile
+    partition wrapping fire on the first forward, not during model.compile(). That
+    first forward runs in GPUModelRunner.profile_run() (driven by the worker's
+    determine_available_memory RPC), while the piecewise cudagraphs are captured
+    later in capture_model() (compile_or_warm_up_model RPC); the install itself runs
+    in _compile_model_stock() under the load_model RPC. The compile that reads this
+    global therefore spans three separate engine-core RPCs with no single Python
+    scope, so the install must outlive this call and cannot be bracketed by a
+    context manager the way VLLM_COMPILE does.
+
+    It is intentionally never unset. Any later graph_partition compile in the
+    process would also pick up this wrapper, and the wrapper is not inherently inert:
+    it captures any partition that executes under a PIECEWISE forward context
+    (StockTorchCompileCUDAGraphWrapper.__call__). Safety rests on the invariant that no unrelated
+    graph_partition compile ever runs under a PIECEWISE forward context, which vLLM
+    upholds by disabling graph_partition on its own nested compiles via
+    maybe_disable_graph_partition. As a backstop against that invariant being
+    violated (an unrelated in-forward compile, or a cross-engine binding in a
+    multi-engine process), StockTorchCompileCUDAGraphWrapper.__call__ fails loudly at capture
+    time if the stream is already capturing or the forward is driven by a different
+    engine's config. The previous wrapper is returned only so a future scoped-unset
+    can restore it.
+
+    TODO(stock-compile): scope the install to the region spanning the lazy compile
+    and every piecewise capture and restore the returned wrapper in a finally, once
+    the worker lifecycle exposes a hook that reliably brackets both.
+    """
+    prev_wrapper = torch._inductor.utils._unstable_customized_partition_wrapper.wrapper
+    torch._inductor.utils.set_customized_partition_wrappers(
+        _make_stock_cudagraph_partition_wrapper(vllm_config)
+    )
+    return prev_wrapper
+
+
 @contextlib.contextmanager
 def maybe_use_cudagraph_partition_wrapper(
     vllm_config: VllmConfig,
@@ -735,40 +871,13 @@ def maybe_use_cudagraph_partition_wrapper(
     graph wrapper class to maintain more control over static graph
     capture and replay.
     """
-    from vllm.config import CUDAGraphMode
-
     compilation_config = vllm_config.compilation_config
     if (
         compilation_config.cudagraph_mode.has_piecewise_cudagraphs()
         and compilation_config.use_inductor_graph_partition
     ):
-        from torch._inductor.utils import CUDAGraphWrapperMetadata
-
-        from vllm.compilation.cuda_graph import CUDAGraphOptions
-        from vllm.platforms import current_platform
-
-        static_graph_wrapper_class = resolve_obj_by_qualname(
-            current_platform.get_static_graph_wrapper_cls()
-        )
-
-        def customized_cudagraph_wrapper(
-            f: Callable[..., Any], metadata: CUDAGraphWrapperMetadata
-        ) -> Any:
-            partition_id = metadata.partition_index
-            num_partitions = metadata.num_partitions
-            return static_graph_wrapper_class(
-                runnable=f,
-                vllm_config=vllm_config,
-                runtime_mode=CUDAGraphMode.PIECEWISE,
-                cudagraph_options=CUDAGraphOptions(
-                    debug_log_enable=partition_id == 0,
-                    gc_disable=partition_id != 0,
-                    weak_ref_output=partition_id == num_partitions - 1,
-                ),
-            )
-
         torch._inductor.utils.set_customized_partition_wrappers(
-            customized_cudagraph_wrapper
+            _make_cudagraph_partition_wrapper(vllm_config)
         )
 
     yield

--- a/vllm/compilation/passes/inductor_pass.py
+++ b/vllm/compilation/passes/inductor_pass.py
@@ -54,6 +54,27 @@ def pass_context(compile_range: Range) -> Generator[None, None, None]:
         _pass_context = prev_context
 
 
+def set_pass_context(compile_range: Range) -> PassContext | None:
+    """Install a process-global PassContext that outlives this call and return the
+    previous one (usually None) so a caller could restore it.
+
+    Unlike the ``pass_context`` context manager (used by VllmBackend around each
+    synchronous per-range compile), STOCK_TORCH_COMPILE is engine-global and its
+    Inductor compiles run lazily during a later forward (profile_run / warmup), so
+    there is no single span to scope. The pre/post-grad vLLM passes and
+    PostGradPassManager.uuid() must all observe one live PassContext, so this must
+    persist until that lazy compile fires. It is safe only while no co-resident
+    VllmBackend compile also reads the global: today no stock engine runs a
+    VllmBackend, but that invariant is fragile if a second SupportsStockCompile arch
+    or a multimodal encoder co-resides with a VllmBackend compile. The previous
+    context is returned so such a future caller can restore it.
+    """
+    global _pass_context
+    prev_context = _pass_context
+    _pass_context = PassContext(compile_range)
+    return prev_context
+
+
 @functools.cache
 def _hash_source_cached(*srcs: str | type | types.FunctionType) -> str:
     hasher = hashlib.sha256()

--- a/vllm/compilation/stock_aot.py
+++ b/vllm/compilation/stock_aot.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""AOT-compile driver for the STOCK_TORCH_COMPILE path.
+
+This is an alternative to the lazy eval-frame ``nn.Module.compile()`` driver used
+by the default stock path. Instead of arming Dynamo's frame-evaluation hook and
+compiling on the first forward, it drives compilation through torch's
+``aot_compile`` API (``torch.compile(fn, backend="inductor").aot_compile(...)``),
+producing a standalone ``AOTCompiledFunction`` that runs the model WITHOUT the
+Dynamo eval frame or per-call guard checks. Selected in STOCK_TORCH_COMPILE mode
+when ``VLLM_USE_AOT_COMPILE`` is set.
+
+It mirrors the AOT plumbing in ``decorators.py`` (which the VllmBackend path uses
+under the same env var) but targets the stock Inductor backend and is driven by
+the model runner rather than the ``@support_torch_compile`` decorator, so the
+external cudagraph wrapper and Inductor graph-partition wiring are identical to
+the eval-frame stock path -- only the compile driver differs.
+"""
+
+import contextlib
+import hashlib
+import os
+from collections.abc import Callable
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+import vllm.envs as envs
+from vllm.compilation.counter import compilation_counter
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.sequence import IntermediateTensors
+
+logger = init_logger(__name__)
+
+
+def stock_aot_available() -> bool:
+    """Whether the current torch exposes the aot_compile API this path needs."""
+    return hasattr(torch._dynamo.config, "enable_aot_compile") and hasattr(
+        torch.compiler, "load_compiled_function"
+    )
+
+
+@contextlib.contextmanager
+def _enable_aot_compile():
+    if hasattr(torch._dynamo.config, "enable_aot_compile"):
+        with torch._dynamo.config.patch(enable_aot_compile=True):
+            yield
+    else:
+        yield
+
+
+def _mark_dynamic_batch_dim(*args: Any, **kwargs: Any) -> None:
+    """Mark dim 0 (the token/batch dim) dynamic on every tensor input.
+
+    The stock eval-frame path gets this from ``nn.Module.compile``'s automatic
+    dynamic handling; aot_compile bakes in a single graph, so the dynamic dims
+    must be marked explicitly on the example inputs or the graph specializes to
+    the profile-run shape and cannot serve other batch sizes.
+    """
+    for value in (*args, *kwargs.values()):
+        if isinstance(value, torch.Tensor):
+            torch._dynamo.mark_dynamic(value, 0)
+        elif isinstance(value, IntermediateTensors):
+            for tensor in value.tensors.values():
+                torch._dynamo.mark_dynamic(tensor, 0)
+
+
+class _StockAOTForward:
+    """Lazy aot-compile wrapper installed onto a module's ``forward``.
+
+    On the first forward (during ``profile_run``) it aot-compiles the original
+    bound forward against the real inputs, then stores and calls the resulting
+    ``AOTCompiledFunction`` directly. When a serialized artifact is present it is
+    loaded eagerly at install time so warm starts skip the first-forward compile
+    entirely.
+    """
+
+    def __init__(
+        self,
+        module: nn.Module,
+        vllm_config: VllmConfig,
+        options: dict[str, Any] | None,
+        aot_path: str | None,
+    ) -> None:
+        self.module = module
+        self.vllm_config = vllm_config
+        self.options = options
+        self.aot_path = aot_path
+        self._original_forward = module.forward
+        self._aot_fn: Callable[..., Any] | None = None
+        self._loaded_from_disk = False
+        self._evaluate_guards = (
+            vllm_config.compilation_config.dynamic_shapes_config.evaluate_guards
+        )
+
+        # Drop all guards, exactly as TorchCompileWithNoGuardsWrapper does for the
+        # VllmBackend path. vLLM guarantees a single full graph with the dynamic dims
+        # marked, so the guards are unnecessary; dropping them also avoids serializing
+        # guards that reference unpicklable C++ objects (e.g. mxfp4 kernels), which
+        # otherwise breaks aot_compile's guard serialization.
+        compile_options = dict(options or {})
+        if hasattr(torch.compiler, "skip_all_guards_unsafe"):
+            compile_options["guard_filter_fn"] = torch.compiler.skip_all_guards_unsafe
+        else:
+            compile_options["guard_filter_fn"] = lambda guards: [False for _ in guards]
+
+        # enable_aot_compile must be active at construction time for torch.compile
+        # to attach the .aot_compile method to the returned callable (matching
+        # TorchCompileWithNoGuardsWrapper.__init__).
+        with _enable_aot_compile():
+            self._compiled_callable = torch.compile(
+                self._original_forward,
+                fullgraph=True,
+                dynamic=False,
+                backend="inductor",
+                options=compile_options,
+            )
+
+    def install(self) -> None:
+        if self.aot_path is not None and not envs.VLLM_DISABLE_COMPILE_CACHE:
+            self._aot_fn = self._try_load()
+            if self._aot_fn is not None:
+                self._loaded_from_disk = True
+        self.module.forward = self  # type: ignore[method-assign, assignment]
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        if self._aot_fn is None:
+            self._compile(args, kwargs)
+        # AOTCompiledFunction is compiled from the *unbound* forward code, so the
+        # module (self.module) must be supplied as the first ("self") argument,
+        # matching decorators.py's `self.aot_compiled_fn(self, *args, **kwargs)`.
+        return self._aot_fn(self.module, *args, **kwargs)
+
+    def _compile(self, args: tuple[Any, ...], kwargs: dict[str, Any]) -> None:
+        _mark_dynamic_batch_dim(*args, **kwargs)
+        with _enable_aot_compile():
+            aot_fn = self._compiled_callable.aot_compile((args, kwargs))
+        if not self._evaluate_guards:
+            # vLLM guarantees a single full graph and pads to captured shapes, so
+            # the per-call guard check is pure overhead -- drop it to realize the
+            # eval-frame-free benefit of the aot path.
+            aot_fn.disable_guard_check()
+        self._aot_fn = aot_fn
+        compilation_counter.num_aot_compiles += 1
+        compilation_counter.stock_torch_compile_count += 1
+        self._maybe_save(aot_fn)
+
+    def _try_load(self) -> Callable[..., Any] | None:
+        from vllm.compilation.decorators import _verify_source_unchanged
+
+        assert self.aot_path is not None
+        if not os.path.exists(self.aot_path):
+            return None
+        try:
+            with open(self.aot_path, "rb") as f:
+                loaded_fn = torch.compiler.load_compiled_function(
+                    f, f_globals=self._original_forward.__func__.__globals__
+                )
+            _verify_source_unchanged(loaded_fn.source_info(), self.vllm_config)
+            # Some backends expose finalize_loading to eagerly materialize the
+            # compiled artifact; the stock inductor compiled_fn does not, and its
+            # partitions bind to the persistently-installed partition wrapper lazily
+            # on the first call, so only call it when present.
+            compiled_fn = loaded_fn._artifacts.compiled_fn
+            if hasattr(compiled_fn, "finalize_loading"):
+                compiled_fn.finalize_loading(self.vllm_config)
+            if not self._evaluate_guards:
+                loaded_fn.disable_guard_check()
+            compilation_counter.num_aot_artifacts_loaded += 1
+            logger.info("Loaded stock AOT compilation from %s", self.aot_path)
+            return loaded_fn
+        except Exception as e:
+            logger.warning(
+                "Recompiling: failed to load stock AOT artifact from %s (%s)",
+                self.aot_path,
+                repr(e),
+            )
+            if envs.VLLM_FORCE_AOT_LOAD:
+                raise
+            return None
+
+    def _maybe_save(self, aot_fn: Callable[..., Any]) -> None:
+        if self.aot_path is None or envs.VLLM_DISABLE_COMPILE_CACHE:
+            return
+        if self._loaded_from_disk:
+            return
+        try:
+            os.makedirs(os.path.dirname(self.aot_path), exist_ok=True)
+            tmp = f"{self.aot_path}.{os.getpid()}.tmp"
+            aot_fn.save_compiled_function(tmp)
+            os.replace(tmp, self.aot_path)
+            compilation_counter.num_aot_artifacts_saved += 1
+            logger.info_once("Saved stock AOT compilation to %s", self.aot_path)
+        except Exception as e:
+            logger.warning(
+                "Unable to save stock AOT artifact to %s: %s", self.aot_path, e
+            )
+
+
+def _aot_cache_path(module: nn.Module, vllm_config: VllmConfig) -> str | None:
+    """Per-(config, model, rank) path for the serialized aot artifact, and set the
+    process Inductor cache dir underneath it so the warm path reuses codegen."""
+    from vllm.compilation.caching import aot_compile_hash_factors
+
+    try:
+        factors = aot_compile_hash_factors(vllm_config)
+        factors.append(module.__class__.__qualname__)
+        factors.append(module.forward.__func__.__qualname__)
+    except Exception:
+        return None
+    hash_key = hashlib.sha256(str(factors).encode()).hexdigest()
+    base = os.path.join(
+        envs.VLLM_CACHE_ROOT, "torch_compile_cache", "stock_aot_compile", hash_key
+    )
+    inductor_cache = os.path.join(base, "inductor_cache")
+    os.makedirs(inductor_cache, exist_ok=True)
+    os.environ["TORCHINDUCTOR_CACHE_DIR"] = inductor_cache
+    rank = vllm_config.parallel_config.rank
+    dp_rank = vllm_config.parallel_config.data_parallel_index
+    return os.path.join(base, f"rank_{rank}_{dp_rank}", "model")
+
+
+def install_stock_aot_forward(
+    module: nn.Module,
+    vllm_config: VllmConfig,
+    options: dict[str, Any] | None,
+) -> None:
+    """Install the lazy aot-compile forward on ``module`` for the stock path."""
+    aot_path = _aot_cache_path(module, vllm_config)
+    _StockAOTForward(module, vllm_config, options, aot_path).install()

--- a/vllm/compilation/stock_cudagraph.py
+++ b/vllm/compilation/stock_cudagraph.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Stock-torch.compile cudagraph wrapper.
+
+Decoupled copy of the capture/replay logic in ``vllm/compilation/cuda_graph.py``
+for the STOCK_TORCH_COMPILE path. It is intentionally NOT the shared
+``CUDAGraphWrapper``: that class is also used by vLLM's non-torch.compile full
+cudagraph path, and keeping the stock path on its own wrapper lets vLLM evolve
+full cudagraphs without affecting torch.compile (and vice versa). The capture
+semantics mirror ``CUDAGraphWrapper`` (batch-descriptor keyed capture/replay,
+shared graph pool, weak-ref outputs); vLLM still owns padding, persistent input
+buffers, and the forward-context mode/descriptor dispatch.
+"""
+
+import dataclasses
+import weakref
+from collections.abc import Callable
+from contextlib import ExitStack
+from typing import Any, ClassVar
+from unittest.mock import patch
+
+import torch
+
+import vllm.envs as envs
+from vllm.compilation.counter import compilation_counter
+from vllm.compilation.monitor import validate_cudagraph_capturing_enabled
+from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.distributed.device_communicators.pynccl_allocator import set_graph_pool_id
+from vllm.forward_context import (
+    BatchDescriptor,
+    get_forward_context,
+    is_forward_context_available,
+)
+from vllm.logger import init_logger
+from vllm.model_executor.offloader.base import get_offloader
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import current_stream, weak_ref_tensors
+
+logger = init_logger(__name__)
+
+
+@dataclasses.dataclass
+class StockCUDAGraphEntry:
+    batch_descriptor: BatchDescriptor
+    cudagraph: torch.cuda.CUDAGraph | None = None
+    output: Any | None = None
+    # For debugging: input addresses at capture, checked to be stable on replay.
+    input_addresses: list[int] | None = None
+
+
+@dataclasses.dataclass
+class StockCUDAGraphOptions:
+    debug_log_enable: bool = True
+    gc_disable: bool = False
+    weak_ref_output: bool = True
+
+
+class StockTorchCompileCUDAGraphWrapper:
+    """Capture/replay a runnable as a cudagraph, keyed on the forward-context
+    batch descriptor. See the module docstring for why this is a separate class
+    from the shared ``CUDAGraphWrapper``."""
+
+    _all_instances: ClassVar[weakref.WeakSet["StockTorchCompileCUDAGraphWrapper"]] = (
+        weakref.WeakSet()
+    )
+
+    @classmethod
+    def clear_all_graphs(cls) -> None:
+        for instance in list(cls._all_instances):
+            instance.clear_graphs()
+
+    def __init__(
+        self,
+        runnable: Callable[..., Any],
+        vllm_config: VllmConfig,
+        runtime_mode: CUDAGraphMode,
+        cudagraph_options: StockCUDAGraphOptions | None = None,
+    ) -> None:
+        self.runnable = runnable
+        self.vllm_config = vllm_config
+        self.runtime_mode = runtime_mode
+        self.compilation_config = vllm_config.compilation_config
+
+        self.is_debugging_mode = envs.VLLM_LOGGING_LEVEL == "DEBUG"
+        self._runnable_str = str(runnable) if self.is_debugging_mode else None
+
+        assert self.runtime_mode != CUDAGraphMode.NONE
+        self.graph_pool = current_platform.get_global_graph_pool()
+
+        if cudagraph_options is None:
+            cudagraph_options = StockCUDAGraphOptions()
+        self.cudagraph_options = cudagraph_options
+        self.concrete_cudagraph_entries: dict[BatchDescriptor, StockCUDAGraphEntry] = {}
+
+        StockTorchCompileCUDAGraphWrapper._all_instances.add(self)
+
+    def __getattr__(self, key: str) -> Any:
+        if hasattr(self.runnable, key):
+            return getattr(self.runnable, key)
+        if self.is_debugging_mode:
+            raise AttributeError(
+                f"Attribute {key} not exists in the runnable of "
+                f"stock cudagraph wrapper: {self._runnable_str}"
+            )
+        raise AttributeError
+
+    def unwrap(self) -> Callable[..., Any]:
+        return self.runnable
+
+    @property
+    def cudagraph_wrapper(self) -> "StockTorchCompileCUDAGraphWrapper":
+        return self
+
+    def clear_graphs(self) -> None:
+        self.concrete_cudagraph_entries.clear()
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any | None:
+        if not is_forward_context_available():
+            # Outside the normal inference path (e.g. a vision encoder forward).
+            return self.runnable(*args, **kwargs)
+
+        forward_context = get_forward_context()
+        batch_descriptor = forward_context.batch_descriptor
+        cudagraph_runtime_mode = forward_context.cudagraph_runtime_mode
+
+        if (
+            cudagraph_runtime_mode == CUDAGraphMode.NONE
+            or cudagraph_runtime_mode != self.runtime_mode
+        ):
+            # Profile/warmup run, no cudagraph, or a mode meant for a different
+            # (nested) wrapper: run directly.
+            return self.runnable(*args, **kwargs)
+
+        assert batch_descriptor is not None
+        if batch_descriptor not in self.concrete_cudagraph_entries:
+            self.concrete_cudagraph_entries[batch_descriptor] = StockCUDAGraphEntry(
+                batch_descriptor=batch_descriptor
+            )
+
+        entry = self.concrete_cudagraph_entries[batch_descriptor]
+
+        if entry.cudagraph is None:
+            # The stock partition wrapper is installed as a process-global that is
+            # never unset, so any inductor partition running under a PIECEWISE
+            # forward context reaches this capture branch -- including one from an
+            # unrelated compile or a different engine. Guard so a leaked or misowned
+            # capture fails loudly here instead of silently corrupting memory.
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    "StockTorchCompileCUDAGraphWrapper attempted a nested cudagraph capture: "
+                    "the current stream is already capturing. A torch.compile "
+                    "region likely ran under a PIECEWISE forward context and was "
+                    "wrapped by the process-global stock partition wrapper; it must "
+                    "go through maybe_disable_graph_partition."
+                )
+            if (
+                forward_context.no_compile_layers
+                is not self.compilation_config.static_forward_context
+            ):
+                raise RuntimeError(
+                    "StockTorchCompileCUDAGraphWrapper is capturing a forward driven by a "
+                    "different vLLM engine than the one it was built for. The "
+                    "process-global stock partition wrapper carries a stale "
+                    "compilation config (wrong capture options / gc / weak-ref "
+                    "behavior)."
+                )
+            if self.cudagraph_options.debug_log_enable:
+                logger.debug(
+                    "Capturing a cudagraph on (%s,%s)",
+                    self.runtime_mode.name,
+                    entry.batch_descriptor,
+                )
+            validate_cudagraph_capturing_enabled()
+
+            entry.input_addresses = [
+                x.data_ptr() for x in args if isinstance(x, torch.Tensor)
+            ]
+            cudagraph = torch.cuda.CUDAGraph()
+
+            with ExitStack() as stack:
+                if self.cudagraph_options.gc_disable:
+                    # Piecewise mode captures one graph per partition; running gc
+                    # per partition is very slow, so gc only for the first.
+                    stack.enter_context(
+                        patch("gc.collect", lambda *args, **kwargs: None)
+                    )
+                    stack.enter_context(
+                        patch(
+                            "torch.accelerator.empty_cache",
+                            lambda *args, **kwargs: None,
+                        )
+                    )
+
+                if self.graph_pool is not None:
+                    set_graph_pool_id(self.graph_pool)
+                else:
+                    set_graph_pool_id(current_platform.graph_pool_handle())
+
+                get_offloader().sync_prev_onload()
+
+                with torch.cuda.graph(
+                    cudagraph,
+                    pool=self.graph_pool,
+                    stream=current_stream(),
+                ):
+                    output = self.runnable(*args, **kwargs)
+                    get_offloader().join_after_forward()
+                    if self.cudagraph_options.weak_ref_output:
+                        # Safe only for the last graph in piecewise mode: its
+                        # output is not consumed by another captured graph.
+                        output = weak_ref_tensors(output)
+
+            entry.output = weak_ref_tensors(output)
+            entry.cudagraph = cudagraph
+
+            compilation_counter.num_cudagraph_captured += 1
+
+            # Return the real output (not the weak ref) so pytorch manages the
+            # cudagraph-pool memory correctly during capture.
+            return output
+
+        if self.is_debugging_mode:
+            new_input_addresses = [
+                x.data_ptr() for x in args if isinstance(x, torch.Tensor)
+            ]
+            assert new_input_addresses == entry.input_addresses, (
+                f"Input addresses for cudagraphs are different during replay. "
+                f"Expected {entry.input_addresses}, got {new_input_addresses}"
+            )
+
+        get_offloader().sync_prev_onload()
+        entry.cudagraph.replay()
+        return entry.output

--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -300,8 +300,12 @@ def reset_compile_wrapper(model: torch.nn.Module) -> None:
         model = model.model
     if not isinstance(model, TorchCompileWithNoGuardsWrapper):
         return
-    # model.do_not_compile is set by the @support_torch_compile decorator
-    if hasattr(model, "do_not_compile") and model.do_not_compile:
+    # model.do_not_use_custom_torch_compile_backend is set by the
+    # @support_torch_compile decorator
+    if (
+        hasattr(model, "do_not_use_custom_torch_compile_backend")
+        and model.do_not_use_custom_torch_compile_backend
+    ):
         return
     from vllm.compilation.counter import compilation_counter
 

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -430,7 +430,8 @@ class CompilationConfig:
     model.
 
     - None: If None, we will select the default compilation mode.
-      For V1 engine this is 3.
+      For V1 engine this is 3 (VLLM_COMPILE) for most architectures; architectures
+      declaring SupportsStockCompile default to 1 (STOCK_TORCH_COMPILE).
     - 0: NONE: No torch.compile compilation is applied, model runs in fully
          eager pytorch mode. The model runs as-is.
     - 1: STOCK_TORCH_COMPILE: The standard `torch.compile` compilation pipeline.
@@ -1097,10 +1098,52 @@ class CompilationConfig:
     def set_splitting_ops_for_v1(
         self, all2all_backend: str, data_parallel_size: int = 1
     ):
+        # Disable CUDA graphs for DeepEP high-throughput since it is not CG compatible.
+        # This is independent of the compile mode (the all2all kernels are the issue),
+        # so it must run before the mode-specific early return below. It used to sit at
+        # the end of this function, which the `mode != VLLM_COMPILE` return skips -- fine
+        # when VLLM_COMPILE was the only mode reaching here with cudagraphs, but now the
+        # STOCK_TORCH_COMPILE path takes that early return and would otherwise capture the
+        # incompatible all2all kernels into a cudagraph.
+        if (
+            all2all_backend == "deepep_high_throughput"
+            and data_parallel_size > 1
+            and self.cudagraph_mode != CUDAGraphMode.NONE
+        ):
+            # TODO: Piecewise Cuda graph might be enabled
+            # if torch compile cache key issue fixed
+            # See https://github.com/vllm-project/vllm/pull/25093
+            logger.info(
+                "DeepEP: Disabling CUDA Graphs since DeepEP high-throughput kernels "
+                "are optimized for prefill and are incompatible with CUDA Graphs. "
+                "In order to use CUDA Graphs for decode-optimized workloads, "
+                "use --all2all-backend with another option, such as "
+                "deepep_low_latency, nixl_ep, or allgather_reducescatter."
+            )
+            self.cudagraph_mode = CUDAGraphMode.NONE
+
         # To compatible with OOT hardware plugin platform (for example vllm-ascend)
         # which currently only supports sequence parallelism in eager mode.
         if self.mode != CompilationMode.VLLM_COMPILE:
-            if self.splitting_ops is None:
+            # STOCK_TORCH_COMPILE recovers piecewise cudagraphs through Inductor graph
+            # partition (step 2 of the VllmBackend migration): Inductor partitions at
+            # the attention ops and routes each partition's capture through the
+            # external wrapper, so splitting_ops must name the attention ops exactly as
+            # the VLLM_COMPILE partition path does. Without graph partition the stock
+            # path is whole-graph (FULL_DECODE_ONLY / no piecewise), so splitting_ops
+            # stays empty.
+            if (
+                self.mode == CompilationMode.STOCK_TORCH_COMPILE
+                and self.use_inductor_graph_partition
+            ):
+                # Partition on -> always partition at the attention ops, populating
+                # even when the user passed an explicit empty list: an empty
+                # splitting_ops would otherwise leave FULL_AND_PIECEWISE with zero
+                # piecewise partitions (no piecewise capture, attention wrongly inside
+                # the cudagraph) and emit no warning.
+                if not self.splitting_ops:
+                    self.splitting_ops = list(self._attention_ops)
+            elif self.splitting_ops is None:
                 self.splitting_ops = []
             return
 
@@ -1182,24 +1225,6 @@ class CompilationConfig:
                     "Setting cudagraph_mode to FULL."
                 )
                 self.cudagraph_mode = CUDAGraphMode.FULL
-
-        # Disable CUDA graphs for DeepEP high-throughput since its not CG compatible
-        if (
-            all2all_backend == "deepep_high_throughput"
-            and data_parallel_size > 1
-            and self.cudagraph_mode != CUDAGraphMode.NONE
-        ):
-            # TODO: Piecewise Cuda graph might be enabled
-            # if torch compile cache key issue fixed
-            # See https://github.com/vllm-project/vllm/pull/25093
-            logger.info(
-                "DeepEP: Disabling CUDA Graphs since DeepEP high-throughput kernels "
-                "are optimized for prefill and are incompatible with CUDA Graphs. "
-                "In order to use CUDA Graphs for decode-optimized workloads, "
-                "use --all2all-backend with another option, such as "
-                "deepep_low_latency, nixl_ep, or allgather_reducescatter."
-            )
-            self.cudagraph_mode = CUDAGraphMode.NONE
 
     def set_splitting_ops_for_attn_fusion(self):
         assert self.pass_config.fuse_attn_quant

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -772,6 +772,160 @@ class VllmConfig:
         )
         self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
+    def _stock_compile_piecewise_cudagraph_mode(self) -> CUDAGraphMode | None:
+        """Resolve the effective cudagraph_mode (filling in the opt-level default
+        when the user left it unset) and return it only if it requires piecewise
+        capture; otherwise None. Helper for the STOCK_TORCH_COMPILE resolution
+        (hence the name), which needs to know whether the mode it is about to run
+        will demand piecewise cudagraphs."""
+        from vllm.platforms import current_platform
+
+        if not current_platform.support_static_graph_mode():
+            return None
+
+        cudagraph_mode = self.compilation_config.cudagraph_mode
+        if cudagraph_mode is None:
+            cudagraph_mode = OPTIMIZATION_LEVEL_TO_CONFIG[self.optimization_level][
+                "compilation_config"
+            ]["cudagraph_mode"]
+
+        if (
+            cudagraph_mode is not None
+            and cudagraph_mode.requires_piecewise_compilation()
+            and not envs.VLLM_USE_BREAKABLE_CUDAGRAPH
+        ):
+            return cudagraph_mode
+        return None
+
+    def _fallback_stock_to_vllm_compile(self, reason: str, *args: object) -> None:
+        if self.compilation_config.mode != CompilationMode.STOCK_TORCH_COMPILE:
+            return
+
+        logger.warning_once(
+            reason + " Falling back to CompilationMode.VLLM_COMPILE (the legacy custom "
+            "vLLM torch.compile backend). This compatibility fallback will be "
+            "removed in a future release; upgrade to torch>=2.9 and keep "
+            "use_inductor_graph_partition enabled to use "
+            "CompilationMode.STOCK_TORCH_COMPILE.",
+            *args,
+        )
+        self.compilation_config.mode = CompilationMode.VLLM_COMPILE
+        self.compilation_config.use_inductor_graph_partition = False
+
+    def _resolve_stock_default_cudagraph_mode(
+        self, user_set_graph_partition: bool
+    ) -> None:
+        """Enable Inductor graph partition on the stock path when the resolved
+        cudagraph_mode needs piecewise capture. Graph partition (torch>=2.9) is the
+        only way stock torch.compile provides piecewise cudagraphs, so turn it on
+        unless the user turned it off. When partition is unavailable (torch<2.9 or
+        explicitly off) the piecewise mode is left in place and
+        _fix_unsupported_piecewise_cudagraph_mode falls the config back to the legacy
+        VllmBackend -- the stock path never silently degrades to a different
+        cudagraph strategy. Runs once, before the opt-level defaults, so fusion
+        defaults and the inert-flag warning see the resolved partition state."""
+        cc = self.compilation_config
+        if cc.mode != CompilationMode.STOCK_TORCH_COMPILE:
+            return
+        if self._stock_compile_piecewise_cudagraph_mode() is None:
+            return
+
+        from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+        if is_torch_equal_or_newer("2.9.0.dev") and not user_set_graph_partition:
+            cc.use_inductor_graph_partition = True
+
+    def _fix_unsupported_piecewise_cudagraph_mode(self) -> None:
+        """Resolve a piecewise-requiring cudagraph_mode that the current compilation
+        mode cannot honor. Piecewise cudagraphs need VLLM_COMPILE (its FX splitting)
+        or STOCK_TORCH_COMPILE with Inductor graph partition. When neither holds:
+
+        - STOCK without graph partition falls back to the legacy VLLM_COMPILE backend
+          (with a deprecation warning) so the requested piecewise cudagraphs still
+          work; graph partition is the only stock piecewise path and must be enabled
+          before splitting_ops are populated, so here we can only fall back;
+        - any other mode (NONE / DYNAMO_TRACE_ONCE) has no compiled graph to capture
+          piecewise, so its cudagraph_mode drops to NONE (matching the pre-migration
+          clamp).
+
+        Covers an explicit piecewise request and a piecewise mode re-introduced later
+        by the dynamic-SD override or a pooler / enc-dec / KV-connector / platform
+        override."""
+        cc = self.compilation_config
+        if (
+            cc.cudagraph_mode is None
+            or not cc.cudagraph_mode.requires_piecewise_compilation()
+            or envs.VLLM_USE_BREAKABLE_CUDAGRAPH
+        ):
+            return
+        if cc.mode == CompilationMode.VLLM_COMPILE:
+            return
+        if cc.mode == CompilationMode.STOCK_TORCH_COMPILE:
+            if cc.use_inductor_graph_partition:
+                return
+            self._fallback_stock_to_vllm_compile(
+                "cudagraph_mode=%s needs Inductor graph partition (torch>=2.9 with "
+                "use_inductor_graph_partition enabled) on "
+                "CompilationMode.STOCK_TORCH_COMPILE.",
+                cc.cudagraph_mode.name,
+            )
+            return
+        logger.info(
+            "cudagraph_mode=%s needs piecewise compilation, which "
+            "CompilationMode.%s does not provide; overriding cudagraph_mode to NONE.",
+            cc.cudagraph_mode.name,
+            cc.mode.name,
+        )
+        cc.cudagraph_mode = CUDAGraphMode.NONE
+
+    # Spec-decode drafter methods validated to compile on the stock path. Both wrap a
+    # decorated inner decoder in an undecorated ...ForCausalLM, so nn.Module.compile()
+    # on the outer works directly; eagle3 has an e2e stock-compile test and eagle shares
+    # its exact compile topology. Other model-backed methods (mtp, dflash, medusa,
+    # draft_model, ...) are migrated one at a time via
+    # _maybe_fallback_stock_for_unsupported_drafter; they fall back to VLLM_COMPILE
+    # until validated.
+    _STOCK_SUPPORTED_DRAFTER_METHODS = ("eagle", "eagle3")
+
+    # Algorithmic (model-less) spec-decode drafters: their proposers hold no
+    # nn.Module (no `.model` attribute for _compile_model_stock to find), so there
+    # is nothing for stock torch.compile to touch and they stay on the stock path
+    # unconditionally. Keep in sync with the model-less proposers built in
+    # GPUModelRunner (NgramProposer / NgramProposerGPU / SuffixDecodingProposer):
+    # a new algorithmic method must be added here or it silently falls back to
+    # VLLM_COMPILE.
+    _ALGORITHMIC_DRAFTER_METHODS = ("ngram", "ngram_gpu", "suffix")
+
+    def _maybe_fallback_stock_for_unsupported_drafter(self) -> None:
+        """Fall back STOCK_TORCH_COMPILE to VLLM_COMPILE for a model-backed spec-decode
+        drafter whose method is not yet validated on the stock path. Validated methods
+        (eagle / eagle3) have their drafter model compiled in
+        GPUModelRunner._compile_model_stock. Other model-backed drafters (mtp,
+        draft_model, medusa, dflash, ...) would be force-compiled fullgraph there with
+        no per-drafter check -- medusa has no @support_torch_compile at all and
+        draft_model is an arbitrary user architecture -- so restore the pre-migration
+        path where VllmBackend compiles (or eagerly runs) them. Algorithmic drafters
+        (ngram / ngram_gpu / suffix) have no model and keep the stock path. This
+        intentionally overrides an explicit mode=STOCK for an unmigrated drafter."""
+        if self.compilation_config.mode != CompilationMode.STOCK_TORCH_COMPILE:
+            return
+        if self.speculative_config is None:
+            return
+        method = self.speculative_config.method
+        if method in self._ALGORITHMIC_DRAFTER_METHODS:
+            return
+        if method in self._STOCK_SUPPORTED_DRAFTER_METHODS:
+            return
+        logger.warning_once(
+            "Speculative decoding method=%s is not yet validated on "
+            "CompilationMode.STOCK_TORCH_COMPILE; falling back to "
+            "CompilationMode.VLLM_COMPILE so the drafter compiles as before. Drafter "
+            "methods are migrated to the stock path one at a time (currently: %s).",
+            method,
+            ", ".join(self._STOCK_SUPPORTED_DRAFTER_METHODS),
+        )
+        self.compilation_config.mode = CompilationMode.VLLM_COMPILE
+
     def _post_init_kv_transfer_config(self) -> None:
         """Update KVTransferConfig based on top-level configs in VllmConfig.
 
@@ -849,6 +1003,94 @@ class VllmConfig:
             "(sleep mode does this automatically and also "
             "routes KV allocations through CuMemAllocator's pool, where "
             "expandable_segments is automatically disabled)."
+        )
+
+    def _stock_compile_supported(self) -> bool:
+        """Whether the primary model architecture is allowlisted for the stock
+        torch.compile migration path (declares SupportsStockCompile). Migrated
+        architectures default to STOCK_TORCH_COMPILE; everything else (incl. the
+        Transformers backend, which lacks the flag) stays on VllmBackend. Any
+        resolution error returns False (the safe default)."""
+        if self.model_config is None:
+            return False
+        try:
+            return self.model_config.registry.is_stock_compile_supported_model(
+                self.model_config.architectures, self.model_config
+            )
+        except Exception as e:
+            # Model inspection is validated and @lru_cache'd during
+            # ModelConfig.__post_init__, so an error here is unexpected and not
+            # the normal unsupported-model result; surface it (a stock-eligible
+            # arch would otherwise silently fall back to VllmBackend) while
+            # still returning the safe default.
+            logger.warning_once(
+                "Could not resolve stock torch.compile support for "
+                "architecture(s) %s; falling back to the legacy VllmBackend "
+                "(CompilationMode.VLLM_COMPILE). Resolution error: %s",
+                ", ".join(self.model_config.architectures),
+                repr(e),
+            )
+            return False
+
+    def _warn_ignored_vllm_backend_only_flags(self) -> None:
+        """Warn when a model is running on STOCK_TORCH_COMPILE but the user set
+        compilation options that only VllmBackend honors. On the stock path these
+        are inert (shape specialization, FX splitting, the vLLM compile cache), so
+        without this they read as active but do nothing. Runs before the opt-level
+        defaults and auto-population so the
+        fields still reflect user input rather than resolved values (cudagraph_mode
+        and splitting_ops/ranges are all None until later)."""
+        cc = self.compilation_config
+        if cc.mode != CompilationMode.STOCK_TORCH_COMPILE:
+            return
+        if self.model_config is None:
+            return
+
+        ignored = []
+        if cc.compile_sizes:
+            ignored.append("compile_sizes (per-size shape specialization)")
+        # NOTE: compile_ranges_endpoints is intentionally NOT checked here. It is
+        # auto-populated (sorted, with any user values merged in) by _set_compile_ranges
+        # later in __post_init__, and __post_init__ may re-run on a reused
+        # compilation_config, so by the time this runs the field can already be a
+        # non-empty resolved value even when the user set nothing -> false positive.
+        # We do not claim every VllmBackend-only flag is covered here; the
+        # user-facing shape-specialization flag (compile_sizes, above) is covered.
+        # use_inductor_graph_partition is NOT inert on the stock path: it enables
+        # piecewise cudagraphs via Inductor graph partition (step 2). When it is on,
+        # splitting_ops is auto-populated with the attention ops (it is the partition
+        # boundary, not VllmBackend FX splitting), so neither is warned. splitting_ops
+        # is only inert when set WITHOUT graph partition (whole-graph stock).
+        if cc.splitting_ops and not cc.use_inductor_graph_partition:
+            ignored.append("splitting_ops (FX graph splitting)")
+        if cc.cudagraph_copy_inputs:
+            ignored.append("cudagraph_copy_inputs")
+        # vLLM's own compile cache is unused on the stock path (torch.compile uses
+        # its own cache). compile_cache_save_format defaults from an env var, so
+        # compare against that default to detect an explicit field override.
+        if cc.cache_dir:
+            ignored.append("cache_dir (vLLM compile cache; stock uses torch's cache)")
+        if cc.compile_cache_save_format != envs.VLLM_COMPILE_CACHE_SAVE_FORMAT:
+            ignored.append("compile_cache_save_format (vLLM compile cache)")
+        if envs.VLLM_DISABLE_COMPILE_CACHE:
+            ignored.append(
+                "VLLM_DISABLE_COMPILE_CACHE (vLLM compile cache; stock uses "
+                "torch's cache)"
+            )
+
+        if not ignored:
+            return
+
+        logger.warning_once(
+            "Model architecture %s is running on CompilationMode.STOCK_TORCH_COMPILE "
+            "(stock torch.compile). The following options are only honored by "
+            "CompilationMode.VLLM_COMPILE (the legacy custom backend) and have no "
+            "effect here -- %s. To restore the previous behavior, force the legacy "
+            "backend explicitly with `--compilation-config '{\"mode\": 3}'`. The "
+            "legacy backend (mode 3) is deprecated and will be removed once "
+            "VllmBackend is retired.",
+            ", ".join(self.model_config.architectures),
+            "ignored: " + ", ".join(ignored),
         )
 
     def __post_init__(self):
@@ -1058,6 +1300,16 @@ class VllmConfig:
                 "precision for chunked prefill triton kernels."
             )
 
+        # Capture whether the user set use_inductor_graph_partition before the
+        # opt-level defaults write it to False, so the stock path can default it on
+        # (graph-partition piecewise) without overriding an explicit user choice.
+        # The @config pydantic dataclass exposes no fields-set tracking, so None
+        # (the field default) is the only reliable "unset" signal and it must be
+        # read here, before the first writer mutates it.
+        user_set_graph_partition = (
+            self.compilation_config.use_inductor_graph_partition is not None
+        )
+
         if self.model_config is not None and self.model_config.enforce_eager:
             logger.warning(
                 "Enforce eager set, disabling torch.compile and CUDAGraphs. "
@@ -1134,16 +1386,41 @@ class VllmConfig:
 
         if self.compilation_config.mode is None:
             if self.optimization_level > OptimizationLevel.O0:
-                self.compilation_config.mode = CompilationMode.VLLM_COMPILE
+                # Model-by-model migration off VllmBackend: architectures
+                # allowlisted via SupportsStockCompile run the stock torch.compile
+                # path (codegen + external cudagraph + Inductor-hook fusion); all
+                # others stay on VllmBackend (the default). Users can force via -cc.
+                self.compilation_config.mode = (
+                    CompilationMode.STOCK_TORCH_COMPILE
+                    if self._stock_compile_supported()
+                    else CompilationMode.VLLM_COMPILE
+                )
             else:
                 self.compilation_config.mode = CompilationMode.NONE
 
-        # By default, enable torch wrapping only when using custom Inductor lowering
-        if self.compilation_config.ir_enable_torch_wrap is None:
-            self.compilation_config.ir_enable_torch_wrap = (
-                self.compilation_config.mode == CompilationMode.VLLM_COMPILE
-                and self.compilation_config.backend == "inductor"
-            )
+        # NOTE: do not force the vLLM custom RMSNorm / RoPE glue kernels on the stock
+        # path. A TP1-TP8 sweep found the custom glue (+rotary_embedding,
+        # ir_op_priority.rms_norm=vllm_c) is ~10% SLOWER at batch-1 decode than the
+        # Inductor-generated glue that VllmBackend actually uses (custom_ops=none), with
+        # no throughput or prefill benefit; letting stock use the Inductor glue matches
+        # VllmBackend at parity. See https://github.com/vllm-project/vllm/pull/46423.
+
+        # A model-backed spec-decode drafter whose method is not yet validated on the
+        # stock path falls the engine back to VLLM_COMPILE (validated eagle / eagle3
+        # drafters stay on stock and are compiled by the runner).
+        self._maybe_fallback_stock_for_unsupported_drafter()
+
+        # Stock piecewise cudagraphs require Inductor graph partition. Enable that
+        # path by default, then fall back to the legacy backend for any piecewise
+        # request (explicit or the opt-level default) that the stock path cannot
+        # honor because partition is unavailable.
+        self._resolve_stock_default_cudagraph_mode(user_set_graph_partition)
+        self._fix_unsupported_piecewise_cudagraph_mode()
+
+        # Warn about VllmBackend-only options that are inert on the stock path.
+        # Runs here (before opt-level defaults / cudagraph + splitting_ops
+        # auto-population) so the fields still reflect what the user actually set.
+        self._warn_ignored_vllm_backend_only_flags()
 
         if all(s not in self.compilation_config.custom_ops for s in ("all", "none")):
             if (
@@ -1169,18 +1446,10 @@ class VllmConfig:
 
         self._maybe_override_dynamic_sd_cudagraph_mode()
 
-        if (
-            self.compilation_config.cudagraph_mode.requires_piecewise_compilation()
-            and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
-            and not envs.VLLM_USE_BREAKABLE_CUDAGRAPH
-        ):
-            logger.info(
-                "Cudagraph mode %s is not compatible with compilation mode %s."
-                "Overriding to NONE.",
-                self.compilation_config.cudagraph_mode,
-                self.compilation_config.mode,
-            )
-            self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+        # Dynamic speculative decoding can turn FULL_AND_PIECEWISE into PIECEWISE
+        # after the first stock graph-partition check. Re-run the fallback so a
+        # piecewise mode never survives on a stock path without graph partition.
+        self._fix_unsupported_piecewise_cudagraph_mode()
 
         # async tp is built on top of sequence parallelism and requires it.
         pass_config = self.compilation_config.pass_config
@@ -1283,6 +1552,12 @@ class VllmConfig:
                     )
                     self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
+            # The pooler / KV-connector overrides above can re-introduce a piecewise
+            # cudagraph_mode; on the stock path without graph partition that is
+            # unsupported, so fall back to the legacy VllmBackend instead of tripping
+            # the piecewise-mode assert below.
+            self._fix_unsupported_piecewise_cudagraph_mode()
+
             # disable cudagraph when enforce eager execution
             if self.model_config is not None and self.model_config.enforce_eager:
                 logger.info("Cudagraph is disabled under eager mode")
@@ -1349,6 +1624,25 @@ class VllmConfig:
             )
         current_platform.check_and_update_config(self)
 
+        # check_and_update_config can itself re-introduce a piecewise cudagraph_mode
+        # (e.g. ROCm with decode/prefill context parallel). On the stock path without
+        # graph partition that is unsupported, so fall back to the legacy VllmBackend
+        # here -- BEFORE set_splitting_ops_for_v1 below, so the fallen-back VLLM_COMPILE
+        # gets its splitting_ops populated (running it after would leave VLLM_COMPILE
+        # with empty splitting_ops under a piecewise mode). On stock + graph partition
+        # this is a no-op (that path legitimately supports piecewise cudagraphs).
+        self._fix_unsupported_piecewise_cudagraph_mode()
+
+        # Resolve torch wrapping AFTER every mode fallback above: a stock model that
+        # late-falls-back to VLLM_COMPILE (dynamic SD, pooler/KV connector, or a
+        # platform check_and_update_config re-introducing a piecewise mode) must get
+        # the same ir_enable_torch_wrap as a config that started as VLLM_COMPILE.
+        if self.compilation_config.ir_enable_torch_wrap is None:
+            self.compilation_config.ir_enable_torch_wrap = (
+                self.compilation_config.mode == CompilationMode.VLLM_COMPILE
+                and self.compilation_config.backend == "inductor"
+            )
+
         if self.use_v2_model_runner:
             self._validate_v2_model_runner()
 
@@ -1406,11 +1700,20 @@ class VllmConfig:
                 )
 
             if self.compilation_config.cudagraph_mode.requires_piecewise_compilation():
+                # STOCK_TORCH_COMPILE also provides piecewise cudagraphs when Inductor
+                # graph partition is on (it partitions at the attention ops and routes
+                # capture through the external wrapper), so it is a valid mode here.
+                stock_inductor_piecewise = (
+                    self.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE
+                    and self.compilation_config.use_inductor_graph_partition
+                )
                 assert (
                     self.compilation_config.mode == CompilationMode.VLLM_COMPILE
+                    or stock_inductor_piecewise
                     or envs.VLLM_USE_BREAKABLE_CUDAGRAPH
                 ), (
                     "Compilation mode should be CompilationMode.VLLM_COMPILE "
+                    "(or STOCK_TORCH_COMPILE with use_inductor_graph_partition) "
                     "when cudagraph_mode piecewise cudagraphs is used, "
                     f"cudagraph_mode={self.compilation_config.cudagraph_mode}"
                 )

--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -12,8 +12,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributed import P2POp
 
-from vllm.compilation.counter import compilation_counter
 from vllm.compilation.cuda_graph import CUDAGraphWrapper
+from vllm.compilation.stock_cudagraph import StockTorchCompileCUDAGraphWrapper
 from vllm.compilation.wrapper import reset_compile_wrapper
 from vllm.config import (
     CompilationMode,
@@ -339,6 +339,11 @@ class ElasticEPScalingExecutor:
         elif isinstance(self.worker.model_runner.model, UBatchWrapper):
             raise RuntimeError("DBO is not yet supported in elastic EP")
 
+        # The stock torch.compile path wraps the model (and each Inductor partition) in
+        # StockTorchCompileCUDAGraphWrapper instances rather than CUDAGraphWrapper; clear all of
+        # them so no stale cudagraph is replayed after the rescale re-compile below.
+        StockTorchCompileCUDAGraphWrapper.clear_all_graphs()
+
         torch.compiler.reset()
         with set_current_vllm_config(self.worker.vllm_config):
             reset_compile_wrapper(self.worker.model_runner.get_model())
@@ -487,16 +492,13 @@ class ElasticEPScalingExecutor:
             self.worker.vllm_config.compilation_config.mode
             == CompilationMode.STOCK_TORCH_COMPILE
         ):
-            # NOTE(yongji): when using stock torch.compile,
-            # torch.compile is triggered during GPUModelRunner's load_model()
-            # TODO(yongji):check do we need to re-trigger torch.compile here?
-            # any changes to the tensor shapes in execution should already
-            # be handled internally by torch.compile.
-            backend = self.worker.vllm_config.compilation_config.init_backend(
-                self.worker.vllm_config
-            )
-            compilation_counter.stock_torch_compile_count += 1
-            self.worker.model_runner.model.compile(fullgraph=True, backend=backend)
+            # NOTE(yongji): when using stock torch.compile, the model was first
+            # compiled during GPUModelRunner.load_model(). After an EP scale event
+            # the expert layout changes, so re-trigger the stock compile through the
+            # shared helper to keep the fusion pass manager + pre-grad pass + pass
+            # context identical to the initial compile (a bare model.compile() here
+            # would silently drop them for fusion-needing models).
+            self.worker.model_runner._compile_model_stock()
 
         multi_block_table = self.worker.model_runner.input_batch.block_table
         saved_block_tables: list[tuple[torch.Tensor, torch.Tensor]] = []

--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -57,6 +57,7 @@ from .interfaces import (
     SupportsEagle3,
     SupportsLoRA,
     SupportsPP,
+    SupportsStockCompile,
 )
 from .utils import (
     AutoWeightsLoader,
@@ -1134,7 +1135,12 @@ class GptOssModel(nn.Module, EagleModelMixin):
 
 
 class GptOssForCausalLM(
-    nn.Module, SupportsPP, SupportsEagle, SupportsEagle3, SupportsLoRA
+    nn.Module,
+    SupportsPP,
+    SupportsEagle,
+    SupportsEagle3,
+    SupportsLoRA,
+    SupportsStockCompile,
 ):
     is_3d_moe_weight: bool = True
     packed_modules_mapping = {"qkv_proj": ["q_proj", "k_proj", "v_proj"]}

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -788,6 +788,39 @@ def is_attention_free(
 
 
 @runtime_checkable
+class SupportsStockCompile(Protocol):
+    """The interface for models validated to run on the stock torch.compile path
+    (backend="inductor" + vLLM's external cudagraph wrapper + Inductor-hook fusion
+    passes) instead of the custom VllmBackend. Opt in per architecture as it passes
+    the migration gate; models without this flag stay on VllmBackend."""
+
+    supports_stock_compile: ClassVar[Literal[True]] = True
+    """
+    A flag that indicates this model is validated for the stock torch.compile path.
+
+    Note:
+        There is no need to redefine this flag if this class is in the
+        MRO of your model class.
+    """
+
+
+@overload
+def supports_stock_compile(model: object) -> TypeIs[SupportsStockCompile]: ...
+
+
+@overload
+def supports_stock_compile(
+    model: type[object],
+) -> TypeIs[type[SupportsStockCompile]]: ...
+
+
+def supports_stock_compile(
+    model: type[object] | object,
+) -> TypeIs[type[SupportsStockCompile]] | TypeIs[SupportsStockCompile]:
+    return getattr(model, "supports_stock_compile", False)
+
+
+@runtime_checkable
 class IsHybrid(Protocol):
     """The interface required for all models like Jamba that have both
     attention and mamba blocks, indicates that

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -55,6 +55,7 @@ from .interfaces import (
     supports_multimodal_encoder_tp_data,
     supports_multimodal_raw_input_only,
     supports_pp,
+    supports_stock_compile,
     supports_transcription,
 )
 from .interfaces_base import (
@@ -756,6 +757,7 @@ class _ModelInfo:
     requires_raw_input_tokens: bool
     supports_multimodal_encoder_tp_data: bool
     supports_pp: bool
+    supports_stock_compile: bool
     has_inner_state: bool
     is_attention_free: bool
     is_hybrid: bool
@@ -783,6 +785,7 @@ class _ModelInfo:
                 model
             ),
             supports_pp=supports_pp(model),
+            supports_stock_compile=supports_stock_compile(model),
             has_inner_state=has_inner_state(model),
             is_attention_free=is_attention_free(model),
             is_hybrid=is_hybrid(model),
@@ -1347,6 +1350,14 @@ class _ModelRegistry:
     ) -> bool:
         model_cls, _ = self.inspect_model_cls(architectures, model_config)
         return model_cls.has_noops
+
+    def is_stock_compile_supported_model(
+        self,
+        architectures: str | list[str],
+        model_config: ModelConfig,
+    ) -> bool:
+        model_cls, _ = self.inspect_model_cls(architectures, model_config)
+        return model_cls.supports_stock_compile
 
     def is_transcription_model(
         self,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5371,8 +5371,15 @@ class GPUModelRunner(
             options = None
         options = self._maybe_enable_stock_graph_partition(options, backend)
 
-        compilation_counter.stock_torch_compile_count += 1
-        self.model.compile(fullgraph=True, backend=backend, options=options)
+        # VLLM_USE_AOT_COMPILE selects the aot_compile driver (a standalone
+        # AOTCompiledFunction, no eval frame / per-call guards) over the default
+        # lazy eval-frame nn.Module.compile(). Everything else (external cudagraph
+        # wrapper, Inductor graph partition, fusion passes) is identical.
+        use_aot = self._use_stock_aot(backend)
+
+        if not use_aot:
+            compilation_counter.stock_torch_compile_count += 1
+            self.model.compile(fullgraph=True, backend=backend, options=options)
 
         # A model-backed spec-decode drafter runs under the same engine-global STOCK
         # mode; its @support_torch_compile decorator does not use vLLM's custom
@@ -5385,9 +5392,35 @@ class GPUModelRunner(
         # model and are skipped.
         drafter = getattr(self, "drafter", None)
         drafter_model = getattr(drafter, "model", None)
-        if isinstance(drafter_model, torch.nn.Module):
+        if isinstance(drafter_model, torch.nn.Module) and not use_aot:
             compilation_counter.stock_torch_compile_count += 1
             drafter_model.compile(fullgraph=True, backend=backend, options=options)
+
+        if use_aot:
+            from vllm.compilation.stock_aot import install_stock_aot_forward
+
+            install_stock_aot_forward(self.model, self.vllm_config, options)
+            if isinstance(drafter_model, torch.nn.Module):
+                install_stock_aot_forward(drafter_model, self.vllm_config, options)
+
+    def _use_stock_aot(self, backend: str | Callable[..., Any]) -> bool:
+        """Whether to drive the stock compile through the aot_compile API.
+
+        Gated on VLLM_USE_AOT_COMPILE, an inductor backend (aot serialization is
+        only wired for the inductor/AOTAutograd path), and torch exposing the API;
+        otherwise fall back to the eval-frame nn.Module.compile() driver.
+        """
+        if not envs.VLLM_USE_AOT_COMPILE or backend != "inductor":
+            return False
+        from vllm.compilation.stock_aot import stock_aot_available
+
+        if not stock_aot_available():
+            logger.warning_once(
+                "VLLM_USE_AOT_COMPILE is set but this torch build lacks the "
+                "aot_compile API; falling back to the eval-frame stock compile."
+            )
+            return False
+        return True
 
     def _maybe_enable_stock_graph_partition(
         self, options: dict[str, Any] | None, backend: str | Callable[..., Any]

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -28,6 +28,7 @@ from vllm.compilation.breakable_cudagraph import (
 from vllm.compilation.counter import compilation_counter
 from vllm.compilation.cuda_graph import CUDAGraphStat, CUDAGraphWrapper
 from vllm.compilation.monitor import set_cudagraph_capturing_enabled
+from vllm.compilation.stock_cudagraph import StockTorchCompileCUDAGraphWrapper
 from vllm.config import (
     CompilationMode,
     CUDAGraphMode,
@@ -3212,7 +3213,13 @@ class GPUModelRunner(
         if not hasattr(self, "model"):
             raise ValueError("Cannot get model before model has been initialized")
         if isinstance(
-            self.model, (CUDAGraphWrapper, UBatchWrapper, BreakableCUDAGraphWrapper)
+            self.model,
+            (
+                CUDAGraphWrapper,
+                UBatchWrapper,
+                BreakableCUDAGraphWrapper,
+                StockTorchCompileCUDAGraphWrapper,
+            ),
         ):
             # get raw model out of the cudagraph wrapper.
             return self.model.unwrap()
@@ -5286,13 +5293,14 @@ class GPUModelRunner(
             self.vllm_config.compilation_config.mode
             == CompilationMode.STOCK_TORCH_COMPILE
         ):
-            from vllm.env_override import _apply_constrain_to_fx_strides_patch
-
-            _apply_constrain_to_fx_strides_patch()
-            backend = self.vllm_config.compilation_config.init_backend(self.vllm_config)
-            compilation_counter.stock_torch_compile_count += 1
-            self.model.compile(fullgraph=True, backend=backend)
-            return
+            self._compile_model_stock()
+            # Do NOT early-return here: the cudagraph-wrapping block below already
+            # attaches vLLM's external FULL cudagraph wrapper only when
+            # cudagraph_mode.has_full_cudagraphs() (a stock model resolved to
+            # FULL_DECODE_ONLY / FULL_AND_PIECEWISE), and leaves a stock PIECEWISE/NONE
+            # model unwrapped (piecewise capture is via the Inductor partition
+            # wrappers). Falling through ensures the shared tail (ubatch wrapper,
+            # get_offloader().post_init()) runs for every stock cudagraph mode.
         # for other compilation modes, cudagraph behavior is controlled by
         # CudagraphWrapper and CudagraphDispatcher of vllm.
 
@@ -5314,9 +5322,16 @@ class GPUModelRunner(
             cudagraph_mode.has_full_cudagraphs()
             and not self.parallel_config.use_ubatching
         ):
-            self.model = CUDAGraphWrapper(
-                self.model, self.vllm_config, runtime_mode=CUDAGraphMode.FULL
-            )
+            if self.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE:
+                # Stock path uses its own decoupled wrapper, not the shared
+                # CUDAGraphWrapper (which is coupled to vLLM full cudagraphs).
+                self.model = StockTorchCompileCUDAGraphWrapper(
+                    self.model, self.vllm_config, runtime_mode=CUDAGraphMode.FULL
+                )
+            else:
+                self.model = CUDAGraphWrapper(
+                    self.model, self.vllm_config, runtime_mode=CUDAGraphMode.FULL
+                )
         elif self.parallel_config.use_ubatching:
             if cudagraph_mode.has_full_cudagraphs():
                 self.model = UBatchWrapper(
@@ -5328,6 +5343,172 @@ class GPUModelRunner(
                 )
 
         get_offloader().post_init()
+
+    def _compile_model_stock(self) -> None:
+        """Compile self.model (and any spec-decode drafter model) with stock
+        torch.compile (Inductor codegen) for STOCK_TORCH_COMPILE mode. Shared by
+        load_model and the elastic-EP rescale path so the two compile sites cannot
+        diverge on options / pass registration.
+        """
+        from vllm.env_override import _apply_constrain_to_fx_strides_patch
+
+        _apply_constrain_to_fx_strides_patch()
+        backend = self.vllm_config.compilation_config.init_backend(self.vllm_config)
+        options: dict[str, Any] | None
+        options, has_fusion = self._stock_inductor_options()
+        if has_fusion and backend != "inductor":
+            raise ValueError(
+                "STOCK_TORCH_COMPILE with active fusion passes requires "
+                f"backend='inductor', but got backend={backend!r}. vLLM fusion "
+                "passes are registered through Inductor's custom-pass hooks and "
+                "have no effect on other backends; disable fusion or use inductor."
+            )
+        if backend != "inductor":
+            # inductor_compile_config only affects the Inductor backend; an exotic
+            # non-inductor stock backend (e.g. eager) would just warn and ignore an
+            # options dict, so drop it to keep that path behaving exactly as it did
+            # before options started always carrying the base config.
+            options = None
+        options = self._maybe_enable_stock_graph_partition(options, backend)
+
+        compilation_counter.stock_torch_compile_count += 1
+        self.model.compile(fullgraph=True, backend=backend, options=options)
+
+        # A model-backed spec-decode drafter runs under the same engine-global STOCK
+        # mode; its @support_torch_compile decorator does not use vLLM's custom
+        # backend (do_not_use_custom_torch_compile_backend), so
+        # the runner compiles the drafter model here too, reusing `options` so the two
+        # compile sites stay in lockstep on fusion passes and graph partition. With
+        # graph partition on this also gives the drafter the same piecewise cudagraphs
+        # it gets under VLLM_COMPILE (its dispatcher and dummy_run capture it exactly
+        # like the target's partitions). Algorithmic drafters (ngram / suffix) have no
+        # model and are skipped.
+        drafter = getattr(self, "drafter", None)
+        drafter_model = getattr(drafter, "model", None)
+        if isinstance(drafter_model, torch.nn.Module):
+            compilation_counter.stock_torch_compile_count += 1
+            drafter_model.compile(fullgraph=True, backend=backend, options=options)
+
+    def _maybe_enable_stock_graph_partition(
+        self, options: dict[str, Any] | None, backend: str | Callable[..., Any]
+    ) -> dict[str, Any] | None:
+        """Step 2 of the VllmBackend migration: recover piecewise cudagraphs on the
+        stock path. Inductor graph partition does the *partitioning* -- it splits the
+        FX graph at the attention ops (via the scoped compile options) -- but it does
+        not itself capture cudagraphs; it exposes a hook
+        (set_customized_partition_wrappers) that lets us choose how each partition is
+        captured. For STOCK_TORCH_COMPILE + use_inductor_graph_partition we plug in
+        StockTorchCompileCUDAGraphWrapper (running in CUDAGraphMode.PIECEWISE runtime
+        mode), which is torch.compile / Inductor driven -- NOT the eager PIECEWISE
+        cudagraph framework (the shared CUDAGraphWrapper driven by vLLM's dispatcher).
+        This mirrors how VLLM_COMPILE plugs its shared CUDAGraphWrapper into the same
+        hook: graph partition chooses *where* to split, the wrapper is *how* each
+        resulting partition is captured and replayed. Under FULL_AND_PIECEWISE the
+        whole decode forward is additionally captured by the same
+        StockTorchCompileCUDAGraphWrapper class acting as the FULL wrapper. The
+        partition wrapper is installed persistently because stock torch.compile is
+        lazy (the real compile runs on the first forward).
+        """
+        cc = self.compilation_config
+        if not (
+            cc.cudagraph_mode.has_piecewise_cudagraphs()
+            and cc.use_inductor_graph_partition
+        ):
+            return options
+        if backend != "inductor":
+            raise ValueError(
+                "STOCK_TORCH_COMPILE piecewise cudagraphs require backend='inductor' "
+                f"(Inductor graph partition), but got backend={backend!r}."
+            )
+        from vllm.compilation.decorators import install_cudagraph_partition_wrapper
+
+        options = dict(options or {})
+        options["graph_partition"] = True
+        options["custom_should_partition_ops"] = list(cc.splitting_ops or [])
+        install_cudagraph_partition_wrapper(self.vllm_config)
+        return options
+
+    def _stock_inductor_options(self) -> tuple[dict[str, Any], bool]:
+        """torch.compile options for STOCK_TORCH_COMPILE mode.
+
+        Always carries the base inductor_compile_config (enable_auto_functionalized_v2,
+        combo-kernel gating on torch>=2.9, assert gating on torch<2.12, and any user
+        --compilation-config inductor_compile_config) so those apply on the stock path
+        whether or not fusion is active. When the model has active fusion
+        passes (quantized / TP-collective models), additionally register vLLM's
+        PostGradPassManager (rms+quant / act+quant / allreduce+rmsnorm /
+        sequence-parallel fusions) and the pre-grad vLLM-IR functionalization pass via
+        Inductor's standard custom-pass hooks, so they keep their fusions without the
+        custom VllmBackend. For dense bf16 (no active fusion) we skip only the pass
+        manager registration: it would add default IR/cleanup passes that buy nothing
+        and measurably regress perf.
+
+        Returns (options, has_fusion). The caller gates the "fusion requires
+        backend=inductor" error on has_fusion, and drops options entirely for a
+        non-inductor backend since inductor_compile_config only affects Inductor.
+        """
+        import torch._inductor.config as inductor_config
+
+        from vllm.compilation.passes.inductor_pass import (
+            InductorPass,
+            set_pass_context,
+        )
+        from vllm.compilation.passes.ir.inplace_functionalization import (
+            VllmIRInplaceFunctionalizationPass,
+        )
+        from vllm.compilation.passes.pass_manager import PostGradPassManager
+        from vllm.compilation.passes.utility.noop_elimination import NoOpEliminationPass
+        from vllm.config.utils import Range
+        from vllm.utils.import_utils import resolve_obj_by_qualname
+
+        pass_manager = resolve_obj_by_qualname(
+            current_platform.get_pass_manager_cls()
+        )()
+        pass_manager.configure(self.vllm_config)
+
+        # Gate registration on whether configure() produced a real fusion/IR pass,
+        # not a hand-maintained flag list that drifts from PostGradPassManager (the
+        # old list had already dropped enable_qk_norm_rope_fusion). NoOp elimination
+        # is always registered (eliminate_noops defaults True) but on its own buys
+        # nothing for dense bf16 and registering the manager there measurably
+        # regresses perf, so it does not count as active fusion.
+        has_fusion = any(
+            not isinstance(p, NoOpEliminationPass) for p in pass_manager.passes
+        )
+
+        options = dict(self.compilation_config.inductor_compile_config)
+        if not has_fusion:
+            return options, False
+
+        # The vLLM passes (pre/post-grad) and PostGradPassManager.uuid() read
+        # get_pass_context(); torch.compile here is lazy (the real Inductor compile +
+        # passes run during a later forward) and STOCK mode is engine-global, so we
+        # install a persistent full-range pass context instead of scoping a context
+        # manager. The range is intentionally FULL: stock is a single lazy compile
+        # covering every shape (no per-range piecewise recompile), so a finite range
+        # could only drop range-gated passes, never grant specialization.
+        set_pass_context(Range(start=0, end=2**31 - 1))
+
+        pre_grad_key = "pre_grad_custom_pass"
+        options[pre_grad_key] = VllmIRInplaceFunctionalizationPass(self.vllm_config)
+        options["_cache_config_ignore_prefix"] = (
+            inductor_config._cache_config_ignore_prefix + [pre_grad_key]
+        )
+        # Merge any user-supplied post_grad_custom_post_pass into the manager rather
+        # than clobbering it, mirroring VllmBackend.configure_post_pass: the config has
+        # already wrapped it as an InductorPass, so hand it straight to the manager's
+        # add() before installing the manager under pass_key.
+        pass_key = current_platform.pass_key
+        user_post_pass = options.get(pass_key)
+        if user_post_pass is not None:
+            if isinstance(user_post_pass, PostGradPassManager):
+                raise ValueError(
+                    "PostGradPassManager can not be kept in CompilationConfig."
+                )
+            assert isinstance(user_post_pass, InductorPass)
+            pass_manager.add(user_post_pass)
+        options[pass_key] = pass_manager
+        return options, True
 
     def _setup_eagle3_aux_hidden_state_outputs(self) -> None:
         if not self.use_aux_hidden_state_outputs:
@@ -6362,6 +6543,7 @@ class GPUModelRunner(
             # graph destruction can surface HSA faults in the next engine startup.
             CUDAGraphWrapper.clear_all_graphs()
             BreakableCUDAGraphWrapper.clear_all_graphs()
+            StockTorchCompileCUDAGraphWrapper.clear_all_graphs()
             self.encoder_cudagraph_manager = None
         self.compilation_config.static_forward_context.clear()
         self.model = None  # type: ignore[assignment]
@@ -6486,8 +6668,10 @@ class GPUModelRunner(
         profiling_pool = current_platform.graph_pool_handle()
         encoder_profiling_pool = current_platform.graph_pool_handle()
         original_pools: dict[int, Any] = {}
-        all_wrappers = list(CUDAGraphWrapper._all_instances) + list(
-            BreakableCUDAGraphWrapper._all_instances
+        all_wrappers = (
+            list(CUDAGraphWrapper._all_instances)
+            + list(BreakableCUDAGraphWrapper._all_instances)
+            + list(StockTorchCompileCUDAGraphWrapper._all_instances)
         )
         for instance in all_wrappers:
             original_pools[id(instance)] = instance.graph_pool
@@ -6561,10 +6745,13 @@ class GPUModelRunner(
             set_cudagraph_capturing_enabled(False)
             CUDAGraphWrapper.clear_all_graphs()
             BreakableCUDAGraphWrapper.clear_all_graphs()
+            StockTorchCompileCUDAGraphWrapper.clear_all_graphs()
             if encoder_cudagraph_manager is not None:
                 encoder_cudagraph_manager.clear()
-            all_wrappers = list(CUDAGraphWrapper._all_instances) + list(
-                BreakableCUDAGraphWrapper._all_instances
+            all_wrappers = (
+                list(CUDAGraphWrapper._all_instances)
+                + list(BreakableCUDAGraphWrapper._all_instances)
+                + list(StockTorchCompileCUDAGraphWrapper._all_instances)
             )
             for instance in all_wrappers:
                 if id(instance) in original_pools:


### PR DESCRIPTION
## What this does

This is an **alternate implementation** of #46423, for side-by-side comparison. #46423
migrates GPT-OSS off `VllmBackend` onto **stock `torch.compile`** driven by the lazy
eval-frame `nn.Module.compile()` (Dynamo installs a frame-evaluation hook and compiles on
the first forward). This PR keeps everything about the stock path identical — stock Inductor
backend, the external `StockTorchCompileCUDAGraphWrapper`, Inductor graph partition, the fusion
passes — and swaps **only the compile driver** to torch's **`aot_compile` API**:

```python
compiled = torch.compile(model.forward, fullgraph=True, backend="inductor", options=...)
aot_fn = compiled.aot_compile((args, kwargs))   # standalone AOTCompiledFunction
```

The resulting `AOTCompiledFunction` runs the model with **no Dynamo eval frame and no
per-call guard checks**, and is **serializable** — so a warm start loads the artifact and skips
the first-forward compile entirely. This is the same `aot_compile` API vLLM's `VllmBackend`
path already uses under `VLLM_USE_AOT_COMPILE` (`wrapper.py` / `decorators.py`), but pointed at
the stock Inductor backend and driven by the model runner instead of the
`@support_torch_compile` decorator.

**Built on top of #46423** (branch `bobren/vanilla-torch-compile`) so the diff over that PR is
just the aot driver; the two are meant to be compared.

## How to select it

Both drivers use `CompilationMode.STOCK_TORCH_COMPILE`. The env var flips the driver:

- `VLLM_USE_AOT_COMPILE=0` (default) → eval-frame `nn.Module.compile()` — **PR #46423**
- `VLLM_USE_AOT_COMPILE=1` → `aot_compile` API — **this PR**

New module `vllm/compilation/stock_aot.py` installs a lazy aot forward on the model; the runner
(`_compile_model_stock`) calls it instead of `nn.Module.compile()` when the env var is set, on an
inductor backend, and torch exposes the API (otherwise it falls back to the eval-frame driver).
Guards are dropped (as the VllmBackend path does), which also avoids serializing guards that
reference unpicklable mxfp4-kernel C++ objects.

## Correctness

- `tests/compile/test_config.py`: `test_stock_aot_torch_compile` (aot compile fires,
  `num_aot_compiles=1`, no `_compiled_call_impl`), `test_stock_aot_installs_forward_not_eval_frame`,
  and `test_stock_aot_matches_eval_frame_stock[False,True]` (greedy decode **byte-identical** to
  the eval-frame stock driver, whole-graph and graph-partition piecewise).
- GPT-OSS-120B mxfp4, H100 TP1: greedy outputs identical to the eval-frame driver.

## Perf: aot_compile vs eval-frame stock (this PR vs #46423)

GPT-OSS-120B mxfp4, H100. Both `STOCK_TORCH_COMPILE`; the only difference is the compile driver.

### Compile / startup time (cold vs warm)

Wall time from `vllm serve` launch to `/health` ready, fresh vs reused cache dirs.

GPT-OSS-120B mxfp4, H100 TP1, single sample each on an idle box (zero foreign contention).

| backend | cold | warm |
|---|---:|---:|
| eval-frame (#46423) | 186 s | 72 s |
| aot_compile (this PR) | 144 s | 58 s |

- **Cold ~23% faster** (144 vs 186 s): dropping all guards skips guard build + serialization.
- **Warm ~19% faster** (58 vs 72 s): the warm start *loads* the serialized `AOTCompiledFunction`
  and skips the first-forward Dynamo trace (confirmed by `num_aot_artifacts_loaded=1` in the log:
  `Loaded stock AOT compilation from ...`). The eval-frame path can only reuse the Inductor cache,
  not skip tracing.

### TP sweep: saturated throughput + batch-1 ITL (interleaved A/B)

Launch-level interleaved A/B (ABBA rounds, 4 launches/backend, warmup rep discarded, then 3
throughput + 2 batch-1 reps per launch) so launch-to-launch compile/autotune/thermal variance is
captured and balanced -- the unit of replication is the launch. `vllm bench serve`, random
1024-in/128-out, request-rate inf; batch-1 reps at max-concurrency 1. GPT-OSS-120B mxfp4, H100,
**run to completion on an idle box** (zero foreign contention). Mean +/- std over the 4 launches;
Welch t-test on the launch means (|t|>2 ~ significant).

| metric | TP | eval-frame (#46423) | aot_compile (this PR) | aot/eval | Welch t | verdict |
|---|---|---:|---:|---:|---:|---|
| saturated tok/s | TP1 | 2476 +/- 26 | 2393 +/- 237 | 0.967 | -0.7 | parity (n.s.) |
| saturated tok/s | TP2 | 6977 +/- 126 | 6941 +/- 132 | 0.995 | -0.4 | parity (n.s.) |
| saturated tok/s | TP4 | 9125 +/- 343 | 9312 +/- 312 | 1.021 | +0.8 | parity (n.s.) |
| saturated tok/s | TP8 | 10892 +/- 550 | 11179 +/- 403 | 1.026 | +0.8 | parity (n.s.) |
| batch-1 ITL (ms) | TP1 | 5.11 +/- 0.00 | 5.12 +/- 0.00 | 1.000 | +0.8 | parity (n.s.) |
| batch-1 ITL (ms) | TP2 | 4.33 +/- 0.00 | 4.34 +/- 0.01 | 1.001 | +1.2 | parity (n.s.) |
| batch-1 ITL (ms) | TP4 | 3.84 +/- 0.02 | 3.85 +/- 0.02 | 1.003 | +0.9 | parity (n.s.) |
| batch-1 ITL (ms) | TP8 | 3.94 +/- 0.06 | 3.91 +/- 0.05 | 0.992 | -0.8 | parity (n.s.) |

**aot_compile is at parity with the eval-frame stock driver across TP1/2/4/8**, for both
saturated throughput and batch-1 decode latency -- every row is non-significant (|t| < 2). This is
the expected result: the two drivers run identical kernels, fusions, and cudagraphs and differ only
in how the compiled function is invoked. The per-call eval-frame dispatch/guard overhead that aot
removes is only measurable at batch 1, where the two are already at parity, so no throughput gap
appears at saturation either. The one low aot value (a single TP1 launch, which inflates aot's TP1
std to +/-237) was a cold first-launch Inductor autotune artifact; the launch-level design absorbs
it into the variance rather than the mean, and the difference stays non-significant. So aot buys the
cold/warm startup wins above at no steady-state throughput or latency cost.

## Test commands

```
# unit tests
.venv/bin/python -m pytest tests/compile/test_config.py -k stock_aot -q
```

TP sweep: for each TP in {1,2,4,8}, 4 launches/backend interleaved ABBA (A =
`VLLM_USE_AOT_COMPILE=0`, B = `VLLM_USE_AOT_COMPILE=1`, both `STOCK_TORCH_COMPILE`), each launch
serving `openai/gpt-oss-120b` and driving `vllm bench serve --dataset-name random
--random-input-len 1024 --random-output-len 128 --request-rate inf --ignore-eos` (256 prompts for
throughput; `--max-concurrency 1`, 16 prompts for batch-1), discarding one throughput warmup rep
then recording 3 throughput + 2 batch-1 reps per launch.

AI assistance was used for this change.

