### PR TITLE
[ROCm] Make aiter fused-qk-rmsnorm capability probe crash-safe

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -469,14 +469,14 @@ def check_aiter_fused_qk_rmsnorm() -> bool:
             )
 
             _AITER_HAS_FUSED_QK_RMSNORM = True
-        except (ImportError, ModuleNotFoundError, AttributeError):
+        except (ImportError, ModuleNotFoundError, AttributeError, KeyError, RuntimeError):
             try:
                 from aiter.ops.fused_qk_norm_rope_cache_quant import (  # noqa: F401
                     fused_qk_rmsnorm,
                 )
 
                 _AITER_HAS_FUSED_QK_RMSNORM = True
-            except (ImportError, ModuleNotFoundError, AttributeError):
+            except (ImportError, ModuleNotFoundError, AttributeError, KeyError, RuntimeError):
                 _AITER_HAS_FUSED_QK_RMSNORM = False
     return _AITER_HAS_FUSED_QK_RMSNORM
 


### PR DESCRIPTION
## Purpose
`check_aiter_fused_qk_rmsnorm()` is a capability probe that tries to import `aiter.ops.fused_qk_norm_rope_cache_quant`. During disaggregated-serving bringup the probe can re-enter the `aiter` package while it is still mid-import; importlib then raises `KeyError('aiter')` from `_get_parent_path`. That `KeyError` is **not** in the probe's `except (ImportError, ModuleNotFoundError, AttributeError)` tuple, so it propagates and kills engine initialization.

## Fix
Broaden both `except` clauses in `check_aiter_fused_qk_rmsnorm()` to also catch `KeyError` and `RuntimeError`, so any probe failure degrades to "fusion unavailable" instead of crashing. The fused qk-rmsnorm is a performance optimization; falling back to the unfused path is numerically equivalent (accuracy-neutral).

## Test Plan
Surfaced on GLM-5.1-FP8 (MI300X, gfx942) disaggregated WideEP serving, where engine init died with `KeyError: 'aiter'` from this probe. With the broadened except, engine init proceeds and serving is unaffected. Standalone (non-disagg) never hit it because the import ordering differed.

## Notes
Single file, `vllm/_aiter_ops.py`. No behavioral change on the success path.