### PR TITLE
fix(sample): validate logits processor FQCN to prevent unpacking crashes

### DIFF
--- a/tests/v1/logits_processors/test_fqcn_validation.py
+++ b/tests/v1/logits_processors/test_fqcn_validation.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+from vllm.v1.sample.logits_processor import _load_logitsprocs_by_fqcns
+
+@pytest.fixture
+def should_do_global_cleanup_after_test():
+    # Override conftest fixture to avoid PyTorch MPS allocator issues on macOS during teardown
+    return False
+
+def test_load_logitsprocs_by_fqcns_invalid_format():
+    # Test FQCN missing colon
+    with pytest.raises(ValueError) as exc_info:
+        _load_logitsprocs_by_fqcns(["math.gcd"])
+    assert "Invalid logits processor FQCN" in str(exc_info.value)
+    assert "Expected format: <module>:<type>" in str(exc_info.value)
+
+    # Test FQCN with multiple colons
+    with pytest.raises(ValueError) as exc_info:
+        _load_logitsprocs_by_fqcns(["math:gcd:extra"])
+    assert "Invalid logits processor FQCN" in str(exc_info.value)
+    assert "Expected format: <module>:<type>" in str(exc_info.value)
+
+def test_load_logitsprocs_by_fqcns_invalid_subclass():
+    # Test valid FQCN format but loads a function instead of a LogitsProcessor type.
+    # It should pass FQCN parsing, import the module, and then raise ValueError on type check.
+    with pytest.raises(ValueError) as exc_info:
+        _load_logitsprocs_by_fqcns(["math:gcd"])
+    assert "Loaded logit processor must be a type" in str(exc_info.value)

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -125,7 +125,13 @@ def _load_logitsprocs_by_fqcns(
             continue
 
         logger.debug("- Loading logits processor %s", logitproc)
-        module_path, qualname = logitproc.split(":")
+        parts = logitproc.split(":")
+        if len(parts) != 2:
+            raise ValueError(
+                f"Invalid logits processor FQCN: '{logitproc}'. "
+                "Expected format: <module>:<type>, e.g., 'mypackage.mymodule:MyLogitsProcessor'"
+            )
+        module_path, qualname = parts
 
         try:
             # Load module


### PR DESCRIPTION
### Description
Fixes #44156.

In `_load_logitsprocs_by_fqcns()`, the FQCN string is split by `:` and unpacked directly:
```python
module_path, qualname = logitproc.split(":")
```
If the FQCN does not contain a `:` or contains multiple colons, Python raises a `ValueError` during unpacking (e.g. `not enough values to unpack (expected 2, got 1)`). This crash is unhandled and engine initialization fails with an unhelpful traceback.

This PR adds explicit validation before unpacking, raising a descriptive `ValueError` explaining the expected format.

### Verification
- Added `tests/v1/logits_processors/test_fqcn_validation.py` to verify that valid and invalid formats, as well as invalid classes, are handled correctly and raise appropriate errors.
- Verified that the new unit tests pass successfully.