### PR TITLE
[Bugfix] Fix int32 overflow in triton_decode_attention page offsets

### DIFF
--- a/vllm/v1/attention/ops/triton_decode_attention.py
+++ b/vllm/v1/attention/ops/triton_decode_attention.py
@@ -133,7 +133,7 @@ def _fwd_kernel_stage1(
                 + offs_n // PAGE_SIZE,
                 mask=offs_n < split_kv_end,
                 other=0,
-            )
+            ).to(tl.int64)  # page_number * page stride overflows int32
             kv_in_page = offs_n % PAGE_SIZE
             offs_buf_k = (
                 (kv_page_number * stride_buf_kpbs + kv_in_page * stride_buf_kbs)[
@@ -375,7 +375,7 @@ def _fwd_grouped_kernel_stage1(
                 mask=offs_n < split_kv_end,
                 other=0,
                 cache_modifier=".ca",
-            )
+            ).to(tl.int64)  # page_number * page stride overflows int32
             kv_off_k = (
                 kv_page_number * stride_buf_kpbs + (offs_n % PAGE_SIZE) * stride_buf_kbs
             )


### PR DESCRIPTION
## Purpose

`_fwd_kernel_stage1` / `_fwd_grouped_kernel_stage1` load `kv_page_number` as int32 and multiply it by the KV buffer page stride in int32. With MLA c_kv (576 dims) and PAGE_SIZE 480 the page stride is ~276k, so page numbers above ~7.7k overflow to negative offsets → CUDA illegal memory access. Hybrid models hit this quickly: all layer groups share one block pool, so a 90GB KV buffer already holds ~163k pages. The error is async, so the reported stack typically blames an unrelated later kernel.

Fix: cast the page number to int64 after the load — the same pattern the other block-indexed triton kernels (fla `fused_recurrent`, `kda`, `causal_conv1d`) already use. C++ cache kernels use `int64_t` and CUTLASS_MLA is unaffected.

## Test Plan / Result

Reproduced with Kimi-Linear-48B-A3B (TRITON_MLA) on GB200: a fixed-seed request loop crashed deterministically once allocated block ids crossed ~7767 (crash-site block ids spanned 7709–7778, straddling 2³¹/(480·576)); CUTLASS_MLA on the same trigger passed, isolating the kernel. With this cast the same loop passes all rounds, and gsm8k 5-shot greedy returns to baseline (strict-match 0.8704 vs 0.8711 baseline, 0 request errors; 285/1319 failed requests before the fix). `pre-commit` (ruff, mypy) passes.

Note: the GPU validation ran on our development branch, where the identical cast was applied to the pre-refactor form of these lines; happy to rerun anything reviewers want on this exact branch.

## Duplicate check

No open PR/issue covers this: searched `triton_decode_attention`, `int32 overflow decode`, `kv_loc int64`. Closest is #45384 (int32 overflow in `concat_mla_q` warp index) — a different kernel and offset.

*AI assistance (Claude Code) was used for diagnosis and drafting; the change and tests were reviewed and run by the submitter.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)