### PR TITLE
[Quantization] Marlin FP4: report missing CUDA custom ops in is_supported

### DIFF
--- a/tests/quantization/test_marlin_fp4_registration_guard.py
+++ b/tests/quantization/test_marlin_fp4_registration_guard.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Marlin FP4 availability must reflect CUDA custom-op registration.
+
+`is_fp4_marlin_supported()` previously checked only platform + compute
+capability, so source builds without the Marlin CUDA extensions would
+select Marlin and then fail late (during weight processing) with an opaque
+missing-op error. These tests pin the registration-aware behavior.
+
+Run `pytest tests/quantization/test_marlin_fp4_registration_guard.py`.
+"""
+
+from vllm.model_executor.kernels.linear.nvfp4.marlin import MarlinNvFp4LinearKernel
+from vllm.model_executor.layers.quantization.utils import marlin_utils_fp4
+
+
+def _patch_platform_ok(monkeypatch):
+    monkeypatch.setattr(marlin_utils_fp4.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(
+        marlin_utils_fp4.current_platform,
+        "has_device_capability",
+        lambda capability: True,
+    )
+
+
+def test_marlin_fp4_unavailable_when_cuda_ops_missing(monkeypatch):
+    _patch_platform_ok(monkeypatch)
+    monkeypatch.setattr(
+        marlin_utils_fp4,
+        "_has_cuda_kernel",
+        lambda qualname: qualname != "_C::gptq_marlin_repack",
+    )
+
+    assert not marlin_utils_fp4.is_fp4_marlin_supported()
+    reason = marlin_utils_fp4.get_fp4_marlin_unavailable_reason()
+    assert reason is not None
+    assert "_C::gptq_marlin_repack" in reason
+
+    supported, kernel_reason = MarlinNvFp4LinearKernel.is_supported()
+    assert not supported
+    assert "_C::gptq_marlin_repack" in kernel_reason
+
+
+def test_marlin_fp4_available_when_cuda_ops_registered(monkeypatch):
+    _patch_platform_ok(monkeypatch)
+    monkeypatch.setattr(marlin_utils_fp4, "_has_cuda_kernel", lambda qualname: True)
+
+    assert marlin_utils_fp4.get_fp4_marlin_unavailable_reason() is None
+    assert marlin_utils_fp4.is_fp4_marlin_supported()
+
+    supported, reason = MarlinNvFp4LinearKernel.is_supported()
+    assert supported
+    assert reason is None
+
+
+def test_marlin_fp4_reason_reports_all_missing_ops(monkeypatch):
+    _patch_platform_ok(monkeypatch)
+    monkeypatch.setattr(marlin_utils_fp4, "_has_cuda_kernel", lambda qualname: False)
+
+    reason = marlin_utils_fp4.get_fp4_marlin_unavailable_reason()
+    assert reason is not None
+    for qualname in marlin_utils_fp4._FP4_MARLIN_REQUIRED_CUDA_OPS:
+        assert qualname in reason

--- a/vllm/model_executor/kernels/linear/nvfp4/marlin.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/marlin.py
@@ -6,6 +6,7 @@ import torch
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
     apply_fp4_marlin_linear,
+    get_fp4_marlin_unavailable_reason,
     is_fp4_marlin_supported,
     prepare_fp4_layer_for_marlin,
 )
@@ -24,7 +25,7 @@ class MarlinNvFp4LinearKernel(NvFp4LinearKernel):
     ) -> tuple[bool, str | None]:
         if is_fp4_marlin_supported():
             return True, None
-        return False, "Marlin FP4 not available"
+        return False, get_fp4_marlin_unavailable_reason() or "Marlin FP4 not available"
 
     @classmethod
     def can_implement(cls, config: NvFp4LinearLayerConfig) -> tuple[bool, str | None]:

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -30,9 +30,47 @@ FP4_MARLIN_SUPPORTED_GROUP_SIZES = [16]
 
 logger = init_logger(__name__)
 
+_FP4_MARLIN_REQUIRED_CUDA_OPS = (
+    "_C::gptq_marlin_repack",
+    "_C::marlin_gemm",
+)
+
+
+def _has_cuda_kernel(qualname: str) -> bool:
+    try:
+        return torch._C._dispatch_has_kernel_for_dispatch_key(qualname, "CUDA")
+    except RuntimeError:
+        return False
+
+
+def get_fp4_marlin_unavailable_reason() -> str | None:
+    """Return why Marlin FP4 cannot run in this build/platform, or None.
+
+    Capability alone is not sufficient: source builds can lack the Marlin
+    CUDA extensions (e.g. when they are skipped for a target arch), in which
+    case selecting Marlin fails much later with an opaque missing-op error
+    during weight processing.
+    """
+    if not current_platform.is_cuda():
+        return "Marlin FP4 requires CUDA"
+    if not current_platform.has_device_capability(75):
+        return "Marlin FP4 requires compute capability >= 75"
+
+    missing_cuda_ops = [
+        qualname
+        for qualname in _FP4_MARLIN_REQUIRED_CUDA_OPS
+        if not _has_cuda_kernel(qualname)
+    ]
+    if missing_cuda_ops:
+        return (
+            "Marlin FP4 CUDA kernels are not registered in this vLLM build: "
+            + ", ".join(missing_cuda_ops)
+        )
+    return None
+
 
 def is_fp4_marlin_supported():
-    return current_platform.is_cuda() and current_platform.has_device_capability(75)
+    return get_fp4_marlin_unavailable_reason() is None
 
 
 def _nvfp4_compute_scale_factor(


### PR DESCRIPTION
## Purpose

`is_fp4_marlin_supported()` checks only the platform and compute capability. A vLLM build whose
compiled extensions lack the Marlin kernels (e.g. a source build where the Marlin CUDA objects
were not built for the target arch) still passes that check, so NVFP4 kernel selection picks
`MarlinNvFp4LinearKernel` — including the forced path in `init_nvfp4_linear_kernel(use_a16=True)`
for W4A16 checkpoints — and then fails much later, during weight processing, with an opaque
missing-custom-op error from `gptq_marlin_repack`.

This PR makes availability reflect what the build can actually run:

- `get_fp4_marlin_unavailable_reason()` returns a precise reason (platform, capability, or the
  list of unregistered ops), checking dispatcher registration for `_C::gptq_marlin_repack` and
  `_C::marlin_gemm`.
- `is_fp4_marlin_supported()` delegates to it, so every existing caller inherits the check.
- `MarlinNvFp4LinearKernel.is_supported()` surfaces the reason string, so auto-selection falls
  through cleanly and forced selection fails fast at startup with the actual cause, e.g.:

  `Marlin FP4 CUDA kernels are not registered in this vLLM build: _C::gptq_marlin_repack, _C::marlin_gemm`

Observed in practice bringing up a W4A16 NVFP4 checkpoint on an SM121 (DGX Spark) source build:
before this change the load crashed inside `gptq_marlin_repack`; after it, selection reports the
missing ops at startup.

No behavior change on builds where the Marlin ops are registered.

## Test Plan

- New unit tests: `tests/quantization/test_marlin_fp4_registration_guard.py` (monkeypatched
  dispatcher/platform; covers missing-op reason, registered-op pass-through, and multi-op
  reporting).
- Manual: on a build without Marlin CUDA objects, load a W4A16 NVFP4 checkpoint and observe the
  early actionable error instead of a weight-processing crash; on a normal wheel build, confirm
  Marlin still selects.

## Test Result

- Unit tests pass locally (no GPU required).
- SM121 source build without Marlin objects: startup error names the two missing ops; wheel
  build with Marlin objects: `MarlinNvFp4LinearKernel` selected as before, tiny repack call
  succeeds.

## Duplicate-work check

Searched open PRs for Marlin FP4 support checks and NVFP4 kernel registration. No open PR guards `is_fp4_marlin_supported()` on dispatcher registration, and none touches `marlin_utils_fp4.py` for this purpose. #47674 is the stacked follow-up in this pair, not a competing implementation.

## AI assistance

This change was developed with AI assistance (Claude, via Claude Code). A human author (Jetha Chan) reviewed every changed line, ran the tests and hardware validation reported above, and can defend the change end-to-end. Commits carry the `Co-authored-by` trailer.
