### PR TITLE
[Quantization] NVFP4 W4A16: fall back to weight-only emulation when Marlin is unavailable

### DIFF
--- a/tests/quantization/test_marlin_fp4_registration_guard.py
+++ b/tests/quantization/test_marlin_fp4_registration_guard.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Marlin FP4 availability must reflect CUDA custom-op registration.
+
+`is_fp4_marlin_supported()` previously checked only platform + compute
+capability, so source builds without the Marlin CUDA extensions would
+select Marlin and then fail late (during weight processing) with an opaque
+missing-op error. These tests pin the registration-aware behavior.
+
+Run `pytest tests/quantization/test_marlin_fp4_registration_guard.py`.
+"""
+
+from vllm.model_executor.kernels.linear.nvfp4.marlin import MarlinNvFp4LinearKernel
+from vllm.model_executor.layers.quantization.utils import marlin_utils_fp4
+
+
+def _patch_platform_ok(monkeypatch):
+    monkeypatch.setattr(marlin_utils_fp4.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(
+        marlin_utils_fp4.current_platform,
+        "has_device_capability",
+        lambda capability: True,
+    )
+
+
+def test_marlin_fp4_unavailable_when_cuda_ops_missing(monkeypatch):
+    _patch_platform_ok(monkeypatch)
+    monkeypatch.setattr(
+        marlin_utils_fp4,
+        "_has_cuda_kernel",
+        lambda qualname: qualname != "_C::gptq_marlin_repack",
+    )
+
+    assert not marlin_utils_fp4.is_fp4_marlin_supported()
+    reason = marlin_utils_fp4.get_fp4_marlin_unavailable_reason()
+    assert reason is not None
+    assert "_C::gptq_marlin_repack" in reason
+
+    supported, kernel_reason = MarlinNvFp4LinearKernel.is_supported()
+    assert not supported
+    assert "_C::gptq_marlin_repack" in kernel_reason
+
+
+def test_marlin_fp4_available_when_cuda_ops_registered(monkeypatch):
+    _patch_platform_ok(monkeypatch)
+    monkeypatch.setattr(marlin_utils_fp4, "_has_cuda_kernel", lambda qualname: True)
+
+    assert marlin_utils_fp4.get_fp4_marlin_unavailable_reason() is None
+    assert marlin_utils_fp4.is_fp4_marlin_supported()
+
+    supported, reason = MarlinNvFp4LinearKernel.is_supported()
+    assert supported
+    assert reason is None
+
+
+def test_marlin_fp4_reason_reports_all_missing_ops(monkeypatch):
+    _patch_platform_ok(monkeypatch)
+    monkeypatch.setattr(marlin_utils_fp4, "_has_cuda_kernel", lambda qualname: False)
+
+    reason = marlin_utils_fp4.get_fp4_marlin_unavailable_reason()
+    assert reason is not None
+    for qualname in marlin_utils_fp4._FP4_MARLIN_REQUIRED_CUDA_OPS:
+        assert qualname in reason

--- a/tests/quantization/test_nvfp4_w4a16_emulation_fallback.py
+++ b/tests/quantization/test_nvfp4_w4a16_emulation_fallback.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""W4A16 NVFP4 must stay loadable when Marlin FP4 kernels are unavailable.
+
+With --linear-backend=auto and use_a16=True, kernel selection forces Marlin.
+On builds without the Marlin CUDA extensions that previously raised (or,
+before the registration guard, crashed during weight processing). Selection
+should instead fall back to the weight-only emulation kernel with a warning.
+
+Run `pytest tests/quantization/test_nvfp4_w4a16_emulation_fallback.py`.
+"""
+
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.model_executor.kernels.linear import (
+    EmulationA16NvFp4LinearKernel,
+    MarlinNvFp4LinearKernel,
+    init_nvfp4_linear_kernel,
+)
+from vllm.model_executor.layers.quantization.utils import marlin_utils_fp4
+
+
+def _patch_platform_ok(monkeypatch):
+    monkeypatch.setattr(marlin_utils_fp4.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(
+        marlin_utils_fp4.current_platform,
+        "has_device_capability",
+        lambda capability: True,
+    )
+
+
+def test_use_a16_falls_back_to_emulation_when_marlin_ops_missing(monkeypatch):
+    _patch_platform_ok(monkeypatch)
+    monkeypatch.setattr(marlin_utils_fp4, "_has_cuda_kernel", lambda qualname: False)
+
+    with set_current_vllm_config(VllmConfig()):
+        kernel = init_nvfp4_linear_kernel(use_a16=True)
+
+    assert isinstance(kernel, EmulationA16NvFp4LinearKernel)
+
+
+def test_use_a16_prefers_marlin_when_available(monkeypatch):
+    _patch_platform_ok(monkeypatch)
+    monkeypatch.setattr(marlin_utils_fp4, "_has_cuda_kernel", lambda qualname: True)
+
+    with set_current_vllm_config(VllmConfig()):
+        kernel = init_nvfp4_linear_kernel(use_a16=True)
+
+    assert isinstance(kernel, MarlinNvFp4LinearKernel)

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -108,6 +108,7 @@ from vllm.model_executor.kernels.linear.nvfp4.cutlass import (
     CutlassNvFp4LinearKernel,
 )
 from vllm.model_executor.kernels.linear.nvfp4.emulation import (
+    EmulationA16NvFp4LinearKernel,
     EmulationNvFp4LinearKernel,
 )
 from vllm.model_executor.kernels.linear.nvfp4.fbgemm import (
@@ -888,8 +889,22 @@ def init_nvfp4_linear_kernel(use_a16: bool = False) -> NvFp4LinearKernel:
             )
             force_kernel = EmulationNvFp4LinearKernel
     elif linear_backend == "auto" and use_a16:
-        # Force a16 (Marlin) when running weight-only quantization.
-        force_kernel = MarlinNvFp4LinearKernel
+        # Force a16 (Marlin) when running weight-only quantization. If the
+        # Marlin FP4 kernels are unavailable in this build/platform, fall
+        # back to the weight-only emulation kernel instead of failing at
+        # weight-processing time: W4A16 checkpoints stay loadable (slowly)
+        # for correctness work on builds without the Marlin extensions.
+        marlin_supported, marlin_reason = MarlinNvFp4LinearKernel.is_supported()
+        if marlin_supported:
+            force_kernel = MarlinNvFp4LinearKernel
+        else:
+            logger.warning_once(
+                "MarlinNvFp4LinearKernel is not supported (%s); falling back "
+                "to EmulationA16NvFp4LinearKernel for W4A16 NVFP4 linear "
+                "layers. This is a correctness fallback and will be slow.",
+                marlin_reason,
+            )
+            force_kernel = EmulationA16NvFp4LinearKernel
 
     if force_kernel is not None:
         is_supported, reason = force_kernel.is_supported()
@@ -1054,6 +1069,7 @@ __all__ = [
     "XPUMxFp8LinearKernel",
     "EmulationMxfp8LinearKernel",
     "CutlassNvFp4LinearKernel",
+    "EmulationA16NvFp4LinearKernel",
     "EmulationNvFp4LinearKernel",
     "FbgemmNvFp4LinearKernel",
     "FlashInferCuteDslNvFp4LinearKernel",

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -140,6 +140,7 @@ from vllm.model_executor.kernels.linear.nvfp4.cutlass import (
     CutlassNvFp4LinearKernel,
 )
 from vllm.model_executor.kernels.linear.nvfp4.emulation import (
+    EmulationA16NvFp4LinearKernel,
     EmulationNvFp4LinearKernel,
 )
 from vllm.model_executor.kernels.linear.nvfp4.fbgemm import (
@@ -1021,6 +1022,7 @@ def init_nvfp4_linear_kernel(use_a16: bool = False) -> NvFp4LinearKernel:
         FlashInferCuteDslNvFp4W4A16LinearKernel,
         MarlinNvFp4LinearKernel,
         HummingNvFp4LinearKernel,
+        EmulationA16NvFp4LinearKernel,
     )
 
     # VLLM_BATCH_INVARIANT forces deterministic execution. Prefer the
@@ -1061,14 +1063,29 @@ def init_nvfp4_linear_kernel(use_a16: bool = False) -> NvFp4LinearKernel:
         _cc = current_platform.get_device_capability()
         compute_capability = _cc.to_int() if _cc is not None else None
         # Weight-only: prefer FlashInfer CuTe-DSL W4A16 on SM100/103,
-        # otherwise Marlin.
+        # otherwise Marlin. If the Marlin FP4 kernels are unavailable in
+        # this build/platform, fall back to the weight-only emulation
+        # kernel instead of failing at weight-processing time: W4A16
+        # checkpoints stay loadable (slowly) for correctness work on
+        # builds without the Marlin extensions.
         cutedsl_ok, _ = FlashInferCuteDslNvFp4W4A16LinearKernel.is_supported(
             compute_capability
         )
         if compute_capability in (100, 103) and cutedsl_ok:
             force_kernel = FlashInferCuteDslNvFp4W4A16LinearKernel
         else:
-            force_kernel = MarlinNvFp4LinearKernel
+            marlin_supported, marlin_reason = MarlinNvFp4LinearKernel.is_supported()
+            if marlin_supported:
+                force_kernel = MarlinNvFp4LinearKernel
+            else:
+                logger.warning_once(
+                    "MarlinNvFp4LinearKernel is not supported (%s); falling "
+                    "back to EmulationA16NvFp4LinearKernel for W4A16 NVFP4 "
+                    "linear layers. This is a correctness fallback and will "
+                    "be slow.",
+                    marlin_reason,
+                )
+                force_kernel = EmulationA16NvFp4LinearKernel
 
     if force_kernel is not None:
         if use_a16 and force_kernel not in a16_kernels:
@@ -1245,6 +1262,7 @@ __all__ = [
     "XPUMxFp8LinearKernel",
     "EmulationMxfp8LinearKernel",
     "CutlassNvFp4LinearKernel",
+    "EmulationA16NvFp4LinearKernel",
     "EmulationNvFp4LinearKernel",
     "FbgemmNvFp4LinearKernel",
     "FlashInferCuteDslNvFp4LinearKernel",

--- a/vllm/model_executor/kernels/linear/nvfp4/emulation.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/emulation.py
@@ -4,6 +4,7 @@
 import torch
 
 from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import (
+    dequantize_to_dtype,
     kE2M1ToFloat_handle,
     run_nvfp4_emulations,
 )
@@ -47,3 +48,50 @@ class EmulationNvFp4LinearKernel(NvFp4LinearKernel):
         if bias is not None:
             out = out + bias
         return out
+
+
+class EmulationA16NvFp4LinearKernel(NvFp4LinearKernel):
+    """Software emulation fallback for W4A16 NVFP4 linear layers.
+
+    Unlike W4A4 NVFP4, W4A16 keeps activations in BF16/FP16, so this path
+    dequantizes only the packed NVFP4 weights and runs a plain matmul. It is
+    a correctness fallback for builds/platforms where the Marlin FP4 kernels
+    are unavailable; it makes no performance claims.
+    """
+
+    @classmethod
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
+        # Always available as a last-resort fallback.
+        return True, None
+
+    @classmethod
+    def can_implement(cls, config: NvFp4LinearLayerConfig) -> tuple[bool, str | None]:
+        return True, None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        # Move the E2M1 lookup table to the device now, because
+        # `.to(device)` is not allowed during CUDA graph capture.
+        kE2M1ToFloat_handle.val = kE2M1ToFloat_handle.val.to(layer.weight.device)
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        output_shape = [*x.shape[:-1], layer.output_size_per_partition]
+        x_2d = x.reshape(-1, x.shape[-1])
+        weight = dequantize_to_dtype(
+            layer.weight,
+            layer.weight_scale,
+            layer.weight_global_scale,
+            x.dtype,
+            block_size=16,
+            swizzle=False,
+        )
+        out = torch.matmul(x_2d, weight.t())
+        if bias is not None:
+            out = out + bias
+        return out.view(*output_shape)

--- a/vllm/model_executor/kernels/linear/nvfp4/marlin.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/marlin.py
@@ -6,6 +6,7 @@ import torch
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
     apply_fp4_marlin_linear,
+    get_fp4_marlin_unavailable_reason,
     is_fp4_marlin_supported,
     prepare_fp4_layer_for_marlin,
 )
@@ -24,7 +25,7 @@ class MarlinNvFp4LinearKernel(NvFp4LinearKernel):
     ) -> tuple[bool, str | None]:
         if is_fp4_marlin_supported():
             return True, None
-        return False, "Marlin FP4 not available"
+        return False, get_fp4_marlin_unavailable_reason() or "Marlin FP4 not available"
 
     @classmethod
     def can_implement(cls, config: NvFp4LinearLayerConfig) -> tuple[bool, str | None]:

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -30,9 +30,47 @@ FP4_MARLIN_SUPPORTED_GROUP_SIZES = [16]
 
 logger = init_logger(__name__)
 
+_FP4_MARLIN_REQUIRED_CUDA_OPS = (
+    "_C::gptq_marlin_repack",
+    "_C::marlin_gemm",
+)
+
+
+def _has_cuda_kernel(qualname: str) -> bool:
+    try:
+        return torch._C._dispatch_has_kernel_for_dispatch_key(qualname, "CUDA")
+    except RuntimeError:
+        return False
+
+
+def get_fp4_marlin_unavailable_reason() -> str | None:
+    """Return why Marlin FP4 cannot run in this build/platform, or None.
+
+    Capability alone is not sufficient: source builds can lack the Marlin
+    CUDA extensions (e.g. when they are skipped for a target arch), in which
+    case selecting Marlin fails much later with an opaque missing-op error
+    during weight processing.
+    """
+    if not current_platform.is_cuda():
+        return "Marlin FP4 requires CUDA"
+    if not current_platform.has_device_capability(75):
+        return "Marlin FP4 requires compute capability >= 75"
+
+    missing_cuda_ops = [
+        qualname
+        for qualname in _FP4_MARLIN_REQUIRED_CUDA_OPS
+        if not _has_cuda_kernel(qualname)
+    ]
+    if missing_cuda_ops:
+        return (
+            "Marlin FP4 CUDA kernels are not registered in this vLLM build: "
+            + ", ".join(missing_cuda_ops)
+        )
+    return None
+
 
 def is_fp4_marlin_supported():
-    return current_platform.is_cuda() and current_platform.has_device_capability(75)
+    return get_fp4_marlin_unavailable_reason() is None
 
 
 def _nvfp4_compute_scale_factor(


### PR DESCRIPTION
Depends on #47673 (stacked: the first commit here is that PR; review the second commit).

## Purpose

`init_nvfp4_linear_kernel(use_a16=True)` force-selects Marlin and raises `ValueError` when it is
unsupported. That makes W4A16 NVFP4 checkpoints (e.g. ModelOpt exports that mark weight-only
modules `W4A16_NVFP4`) completely unloadable on builds or platforms without the Marlin FP4 CUDA
kernels — there is no correctness path at all, where W4A4 NVFP4 already has
`EmulationNvFp4LinearKernel` as a last resort.

This PR adds the missing counterpart:

- `EmulationA16NvFp4LinearKernel`: dequantizes the packed NVFP4 weights and runs a plain matmul,
  keeping activations in BF16/FP16 (the defining property of W4A16 — the existing emulation
  kernel also emulates activation quantization, which is wrong for weight-only checkpoints).
- Under `--linear-backend=auto` with `use_a16=True`, if Marlin is unsupported, selection falls
  back to the new kernel with a `warning_once` naming the reason and stating it is a slow
  correctness fallback. Explicit backend requests keep their hard-error behavior.

Together with the registration guard this turns "opaque crash during weight processing" into
"loads and runs, with a clear warning" for W4A16 NVFP4 bring-up on new platforms.

## Test Plan

- New unit tests: `tests/quantization/test_nvfp4_w4a16_emulation_fallback.py` — with Marlin ops
  monkeypatched away, `init_nvfp4_linear_kernel(use_a16=True)` returns the A16 emulation kernel;
  with ops present, Marlin is still preferred.
- Manual: on a build without Marlin CUDA objects, load a W4A16 NVFP4 checkpoint end-to-end and
  verify coherent generation; compare a layer's output against a dequantized-weights torch
  reference.

## Test Result

- Unit tests pass locally (no GPU required).
- Manual bring-up on an SM121 source build without Marlin objects: model loads, generates
  coherently, per-layer outputs match a dequantize+matmul torch reference (weight-only
  dequantization is exact up to matmul dtype effects); normal wheel build unaffected (Marlin
  still selected).

## Duplicate-work check

Searched open PRs for NVFP4 W4A16 and emulation fallbacks. No open PR provides a weight-only NVFP4 emulation path; the existing `EmulationNvFp4LinearKernel` covers W4A4 only. This PR is stacked on #47673 (same author) rather than duplicating it — the first commit here is that PR.

## AI assistance

This change was developed with AI assistance (Claude, via Claude Code). A human author (Jetha Chan) reviewed every changed line, ran the tests and hardware validation reported above, and can defend the change end-to-end. Commits carry the `Co-authored-by` trailer.
