### PR TITLE
[XPU] Route mm_prefix models to Triton attention backend

### DIFF
--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -148,6 +148,15 @@ class XPUPlatform(Platform):
         if selected_backend == AttentionBackendEnum.TRITON_ATTN:
             logger.info_once("Using Triton backend.")
             return AttentionBackendEnum.TRITON_ATTN.get_path()
+        elif attn_selector_config.use_mm_prefix:
+            # Flash Attention on XPU has no FA4 kernel, so it cannot apply the
+            # multimodal prefix-LM bidirectional mask. Fall back to Triton
+            # Attention, which supports mm_prefix.
+            logger.warning_once(
+                "Flash Attention on XPU does not support multimodal prefix-LM "
+                "attention. Falling back to Triton Attention backend."
+            )
+            return AttentionBackendEnum.TRITON_ATTN.get_path()
         elif dtype == torch.float32:
             logger.warning_once(
                 "Flash Attention on XPU does not support float32 dtype. "


### PR DESCRIPTION



## Purpose
mm_prefix (prefix-LM bidirectional mask) is only supported by FA4, which is unavailable on XPU, so fall back to Triton attention.

## Test Plan
`pytest -s -v tests/models/multimodal/generation/test_mm_prefix_lm.py::test_mm_prefix_lm_e2e`

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

