### PR TITLE
[Bugfix][Multimodal] Normalize soundfile audio layout before resampling

### DIFF
--- a/tests/multimodal/test_audio.py
+++ b/tests/multimodal/test_audio.py
@@ -583,6 +583,62 @@ class TestAudioPipelineE2E:
         # After resampling from 48kHz to 16kHz, length should be ~16000
         assert audio_output.shape[0] == 16000
 
+    @pytest.mark.parametrize("audio_resample_method", ["pyav", "scipy", "soxr"])
+    @pytest.mark.parametrize("target_channels", [1, 2, None])
+    def test_soundfile_format_resampling_e2e(
+        self,
+        audio_resample_method,
+        target_channels,
+    ):
+        """Full pipeline: soundfile stereo format + resample."""
+        from vllm.multimodal.parse import MultiModalDataParser
+
+        if audio_resample_method == "soxr":
+            pytest.importorskip("soxr")
+
+        # Simulate soundfile output: (time, channels) at a common recording rate.
+        n_samples = 48000
+        left = np.linspace(-1.0, 1.0, n_samples, dtype=np.float32)
+        right = np.linspace(1.0, -1.0, n_samples, dtype=np.float32)
+        stereo_soundfile = np.stack([left, right], axis=1)
+
+        parser = MultiModalDataParser(
+            target_sr=16000,
+            target_channels=target_channels,
+            audio_resample_method=audio_resample_method,
+        )
+
+        result = parser.parse_mm_data({"audio": (stereo_soundfile, 48000)})["audio"]
+        audio_output = result.get(0)
+
+        expected_shapes = {
+            1: (16000,),
+            2: (2, 16000),
+            None: (16000, 2),
+        }
+        assert audio_output.shape == expected_shapes[target_channels]
+        assert np.isfinite(audio_output).all()
+
+        if target_channels == 1:
+            np.testing.assert_array_almost_equal(
+                audio_output, np.zeros(16000), decimal=5
+            )
+        elif target_channels == 2:
+            assert audio_output[0, :4000].mean() < -0.25
+            assert audio_output[0, -4000:].mean() > 0.25
+            assert audio_output[1, :4000].mean() > 0.25
+            assert audio_output[1, -4000:].mean() < -0.25
+        else:
+            left_channel = audio_output[:, 0]
+            right_channel = audio_output[:, 1]
+            assert left_channel[:4000].mean() < -0.25
+            assert left_channel[-4000:].mean() > 0.25
+            assert right_channel[:4000].mean() > 0.25
+            assert right_channel[-4000:].mean() < -0.25
+            np.testing.assert_allclose(
+                left_channel, -right_channel, atol=1e-4, rtol=1e-4
+            )
+
     def test_very_short_audio_e2e(self):
         """Full pipeline: very short audio (< 1 frame) handled correctly."""
         from vllm.multimodal.parse import MultiModalDataParser

--- a/vllm/multimodal/parse.py
+++ b/vllm/multimodal/parse.py
@@ -589,15 +589,31 @@ class MultiModalDataParser:
         new_audios = list[np.ndarray]()
         for data_item in data_items:
             audio, orig_sr = self._get_audio_with_sr(data_item)
+            restore_time_first = False
+            if self.target_channels is not None:
+                spec = AudioSpec(target_channels=self.target_channels)
+                audio = normalize_audio(audio, spec)
+                if (
+                    orig_sr is not None
+                    and isinstance(audio, np.ndarray)
+                    and audio.ndim == 2
+                ):
+                    audio = np.ascontiguousarray(audio)
+            elif (
+                orig_sr is not None
+                and audio.ndim == 2
+                and audio.shape[0] > audio.shape[1]
+            ):
+                # Resamplers expect 2D input as (channels, samples).
+                audio = np.ascontiguousarray(audio.T)
+                restore_time_first = True
+
             if orig_sr is None:
                 new_audio = audio
             else:
                 new_audio = self.audio_resampler.resample(audio, orig_sr=orig_sr)
-
-            # Apply channel normalization if target_channels is set
-            if self.target_channels is not None:
-                spec = AudioSpec(target_channels=self.target_channels)
-                new_audio = normalize_audio(new_audio, spec)
+                if restore_time_first:
+                    new_audio = new_audio.T
 
             new_audios.append(new_audio)
 


### PR DESCRIPTION

## Purpose

Direct audio inputs can be passed as `(audio_array, sample_rate)`. A common path is `soundfile.read(..., dtype="float32")`, which returns stereo audio as `(samples, channels)`.

When vLLM needs to resample that input, `MultiModalDataParser` currently sends the time-first array to resamplers before applying the existing channel normalization. The resamplers treat 2D audio as already channel-first, so a legal `(480, 2)` stereo array at 48 kHz is handled as 480 very short channels. In a real Whisper `LLM.generate` request, the mono 16 kHz control generates successfully, while the legal soundfile-style tuple crashes in `WhisperProcessor` with the wrong audio rank/shape.

This normalizes direct audio tuple layout before resampling. Mono targets are reduced before resampling, 2D normalized numpy targets are made contiguous before PyAV sees them, and stereo passthrough targets are temporarily transposed to contiguous channel-first layout and restored to the original time-first layout after resampling.

This does not duplicate existing audio work: #31595 added channel normalization but applies it after resampling, #42233 fixes scipy ratio and channel-first resampling, #46377 fixes long PyAV frame overflow, and #43322 fixes PyAV PCM normalization.

## Test Plan

I tested the real offline audio model path with `openai/whisper-tiny` on an NVIDIA GeForce RTX 4090. The repro compares an explicit mono 16 kHz control with the same self-contained 48 kHz stereo numpy input passed as a soundfile-style `(audio, sample_rate)` tuple.

I also tested the shared parser path across `pyav`, `scipy`, and `soxr`, covering `target_channels=1`, `target_channels=2`, and `target_channels=None` while changing sample rate. Reverting only the `parse.py` source fix makes both the Whisper repro and the focused parser tests fail again.

## Test Result

On upstream main `69715823df89b11ee684b84066390cbb9092d5c1`, the Whisper control request returns token ids `[542, 37592, 62, 29937, 60, 50257]`, while the soundfile-style stereo tuple crashes in `WhisperProcessor`. On this PR, the same stereo tuple returns the same token ids as the control. Reverting only `vllm/multimodal/parse.py` makes the same Whisper repro fail again.

Parser-level behavior changes as follows:

| case | upstream main | this PR |
|---|---|---|
| `target_channels=1`, 48 kHz to 16 kHz | `(1, 4800)` | `(1600,)` |
| `target_channels=2`, 48 kHz to 16 kHz | PyAV `ndarray is not C-contiguous`; scipy/soxr cannot expand one channel to two | `(2, 1600)` |
| `target_channels=None`, 48 kHz to 16 kHz | `(4800, 1)` | `(1600, 2)` |

The focused regression is one parameterized test function covering all three cases across `pyav`, `scipy`, and `soxr`: `9 passed, 16 warnings in 1.89s`. The full `tests/multimodal/test_audio.py` file passes: `55 passed, 16 warnings in 11.04s`. `ruff check`, `ruff format --check`, and `git diff --check` also pass.

<details>
<summary>Whisper E2E reproduction</summary>

Environment:

```text
GPU: NVIDIA GeForce RTX 4090
vLLM upstream main: 69715823df89b11ee684b84066390cbb9092d5c1
Model: openai/whisper-tiny
Python: 3.12
GPU commands were run through /root/gpu_lock.sh run.
```

`repro_whisper_e2e.py`:

```python
import json
import os

import numpy as np
from scipy import signal
from vllm import LLM, SamplingParams


def make_stereo48() -> np.ndarray:
    samples = 480
    t = np.arange(samples, dtype=np.float32) / 48000.0
    left = 0.5 * np.sin(2.0 * np.pi * 440.0 * t)
    right = 0.5 * np.sin(2.0 * np.pi * 660.0 * t)
    return np.stack([left, right], axis=1).astype(np.float32)


def main() -> int:
    expect_same = os.environ.get("EXPECT_SAME") == "1"
    stereo48 = make_stereo48()
    mono48 = stereo48.mean(axis=1).astype(np.float32)
    audio16 = signal.resample_poly(mono48, 16000, 48000).astype(np.float32)

    model = "openai/whisper-tiny"
    prompt = "<|startoftranscript|><|en|><|transcribe|><|notimestamps|>"
    llm = LLM(
        model=model,
        dtype="half",
        max_model_len=448,
        limit_mm_per_prompt={"audio": 1},
        enforce_eager=True,
        gpu_memory_utilization=0.45,
        disable_custom_all_reduce=True,
    )
    params = SamplingParams(max_tokens=24, temperature=0.0)
    correct = llm.generate(
        [{"prompt": prompt, "multi_modal_data": {"audio": (audio16, 16000)}}],
        params,
    )[0].outputs[0]
    soundfile_case = llm.generate(
        [{"prompt": prompt, "multi_modal_data": {"audio": (stereo48, 48000)}}],
        params,
    )[0].outputs[0]
    result = {
        "stereo48_shape": list(stereo48.shape),
        "audio16_shape": list(audio16.shape),
        "correct_text": correct.text,
        "soundfile_text": soundfile_case.text,
        "correct_ids": correct.token_ids,
        "soundfile_ids": soundfile_case.token_ids,
        "same": correct.token_ids == soundfile_case.token_ids,
        "expect_same": expect_same,
    }
    print(json.dumps(result, ensure_ascii=False, indent=2))
    return 0 if result["same"] == expect_same else 4


if __name__ == "__main__":
    raise SystemExit(main())
```

Run on upstream main:

```bash
EXPECT_SAME=1 python repro_whisper_e2e.py
```

```text
ValueError: operands could not be broadcast together with remapped shapes [original->remapped]: (2,2) and requested shape (3,2)
ValueError: Failed to apply WhisperProcessor on data=... with kwargs={'sampling_rate': 16000, 'return_tensors': 'pt'}
WHISPER_SINGLE_REVERSE_RC=1
```

Run on this PR:

```bash
EXPECT_SAME=1 python repro_whisper_e2e.py
```

```json
{
  "stereo48_shape": [
    480,
    2
  ],
  "audio16_shape": [
    160
  ],
  "correct_text": " [BLANK_AUDIO]",
  "soundfile_text": " [BLANK_AUDIO]",
  "correct_ids": [
    542,
    37592,
    62,
    29937,
    60,
    50257
  ],
  "soundfile_ids": [
    542,
    37592,
    62,
    29937,
    60,
    50257
  ],
  "same": true,
  "expect_same": true
}
WHISPER_SINGLE_FIXED_RC=0
```

Reverse causality on the PR checkout:

```bash
git diff -- vllm/multimodal/parse.py > /tmp/vllm21_parse.patch
git apply -R /tmp/vllm21_parse.patch
EXPECT_SAME=1 python repro_whisper_e2e.py
echo WHISPER_SINGLE_REVERSE_RC=$?
git apply /tmp/vllm21_parse.patch
```

```text
ValueError: Failed to apply WhisperProcessor on data=... with kwargs={'sampling_rate': 16000, 'return_tensors': 'pt'}
WHISPER_SINGLE_REVERSE_RC=1
```

After restoring the same patch and running the same script again:

```text
WHISPER_SINGLE_RESTORE_RC=0
```

</details>

<details>
<summary>Parser reproduction and tests</summary>

`check_soundfile_resample.py`:

```python
import json
import math
import os
import sys

import numpy as np


VLLM_SRC = os.environ.get("VLLM_SRC", os.getcwd())
sys.path.insert(0, VLLM_SRC)

from vllm.multimodal.parse import MultiModalDataParser  # noqa: E402


def make_stereo_soundfile(n_samples: int) -> np.ndarray:
    left = np.linspace(-1.0, 1.0, n_samples, dtype=np.float32)
    right = np.linspace(1.0, -1.0, n_samples, dtype=np.float32)
    return np.stack([left, right], axis=1)


def run_case(
    method: str,
    orig_sr: int,
    target_sr: int,
    target_channels: int | None,
) -> dict[str, object]:
    n_samples = 4800
    audio_time_channels = make_stereo_soundfile(n_samples)

    parser = MultiModalDataParser(
        target_sr=target_sr,
        target_channels=target_channels,
        audio_resample_method=method,
    )
    error = None
    parsed = None
    try:
        result = parser.parse_mm_data({"audio": (audio_time_channels, orig_sr)})[
            "audio"
        ]
        parsed = result.get(0)
    except Exception as exc:
        error = f"{type(exc).__name__}: {exc}"

    expected_len = math.ceil(n_samples * target_sr / orig_sr)
    if target_channels == 1:
        expected_shape = (expected_len,)
    elif target_channels is None:
        expected_shape = (expected_len, 2)
    else:
        expected_shape = (target_channels, expected_len)
    actual_shape = None if parsed is None else list(parsed.shape)
    ok = parsed is not None and parsed.shape == expected_shape
    return {
        "method": method,
        "target_channels": target_channels,
        "orig_sr": orig_sr,
        "target_sr": target_sr,
        "input_shape": list(audio_time_channels.shape),
        "expected_shape": list(expected_shape),
        "actual_shape": actual_shape,
        "actual_ndim": None if parsed is None else int(parsed.ndim),
        "error": error,
        "ok": ok,
    }


def main() -> int:
    methods = [
        method.strip()
        for method in os.environ.get("AUDIO_METHODS", "pyav,scipy,soxr").split(",")
        if method.strip()
    ]
    records = []
    for method in methods:
        records.append(run_case(method, 48000, 16000, 1))
        records.append(run_case(method, 48000, 16000, 2))
        records.append(run_case(method, 48000, 16000, None))
        records.append(run_case(method, 48000, 48000, 1))
        records.append(run_case(method, 48000, 48000, 2))
        records.append(run_case(method, 48000, 48000, None))

    print("AUDIO_AXIS_REPRO", json.dumps(records, sort_keys=True))
    failures = [
        r for r in records if r["orig_sr"] != r["target_sr"] and not r["ok"]
    ]
    return 2 if failures else 0


if __name__ == "__main__":
    raise SystemExit(main())
```

Before:

```text
pyav 48k->16k target_channels=1: actual_shape=[1, 4800], expected_shape=[1600], ok=false
pyav 48k->16k target_channels=2: error="ValueError: ndarray is not C-contiguous", expected_shape=[2, 1600], ok=false
pyav 48k->16k target_channels=None: actual_shape=[4800, 1], expected_shape=[1600, 2], ok=false
scipy 48k->16k target_channels=1: actual_shape=[1, 4800], expected_shape=[1600], ok=false
scipy 48k->16k target_channels=2: error="ValueError: Cannot expand 1 channels to 2", expected_shape=[2, 1600], ok=false
scipy 48k->16k target_channels=None: actual_shape=[4800, 1], expected_shape=[1600, 2], ok=false
soxr 48k->16k target_channels=1: actual_shape=[1, 4800], expected_shape=[1600], ok=false
soxr 48k->16k target_channels=2: error="ValueError: Cannot expand 1 channels to 2", expected_shape=[2, 1600], ok=false
soxr 48k->16k target_channels=None: actual_shape=[4800, 1], expected_shape=[1600, 2], ok=false
same-sample-rate controls for all three methods: ok=true
BEFORE_RC=2
```

After:

```text
pyav/scipy/soxr 48k->16k target_channels=1: actual_shape=[1600], expected_shape=[1600], ok=true
pyav/scipy/soxr 48k->16k target_channels=2: actual_shape=[2, 1600], expected_shape=[2, 1600], ok=true
pyav/scipy/soxr 48k->16k target_channels=None: actual_shape=[1600, 2], expected_shape=[1600, 2], ok=true
same-sample-rate controls for all three methods: ok=true
AFTER_REPRO_RC=0
```

Commands:

```bash
python -m pytest \
  tests/multimodal/test_audio.py::TestAudioPipelineE2E::test_soundfile_format_resampling_e2e \
  -q
python -m pytest tests/multimodal/test_audio.py -q
ruff check vllm/multimodal/parse.py tests/multimodal/test_audio.py
ruff format --check vllm/multimodal/parse.py tests/multimodal/test_audio.py
git diff --check -- vllm/multimodal/parse.py tests/multimodal/test_audio.py
```

```text
9 passed, 16 warnings in 1.89s
55 passed, 16 warnings in 11.04s
All checks passed!
2 files already formatted
git diff --check passed
```

Source-only reverse of `vllm/multimodal/parse.py`:

```text
9 failed, 16 warnings in 145.31s
REVERSE_SINGLE_TEST_RC=1
9 passed, 16 warnings in 1.83s
RESTORE_SINGLE_TEST_RC=0
```

</details>

AI assistance was used to prepare this PR.

cc @DarkLight1337 @ywang96
