### PR TITLE
[Bugfix][Pooling] Preserve cache_salt for chunked embeddings

### DIFF
--- a/vllm/entrypoints/pooling/embed/io_processor.py
+++ b/vllm/entrypoints/pooling/embed/io_processor.py
@@ -131,12 +131,13 @@ class EmbedIOProcessor(PoolingIOProcessor):
                 )
 
             prompt_token_ids = cast(list[int], token_ids)
+            cache_salt = engine_input.get("cache_salt", None)
 
             for chunk_idx, chunk_tokens in enumerate(
                 chunk_list(prompt_token_ids, max_model_len)
             ):
                 chunked_engine_inputs.append(
-                    tokens_input(prompt_token_ids=chunk_tokens)
+                    tokens_input(prompt_token_ids=chunk_tokens, cache_salt=cache_salt)
                 )
                 prompt_request_ids.append(
                     f"{request_id}-prompt-{prompt_idx}-chunk-{chunk_idx}"


### PR DESCRIPTION

## Purpose

Chunked embedding preprocessing dropped request-level `cache_salt` when it rebuilt long inputs into per-chunk token prompts. With prefix caching enabled, a second `/v1/embeddings` request using a different salt could still reuse the first request's cached chunks.

This preserves the original salt when creating chunked embedding engine inputs. Unsalted requests keep the existing behavior.

## Test Plan

Run a real `/v1/embeddings` server with prefix caching and long-text chunked processing, then send the same 8102-token embedding input with `cache_salt=tenant-a`, `cache_salt=tenant-b`, and `cache_salt=tenant-b` again. The second request must not report prefix-cache hits; the third request should report hits as the same-salt positive control.

Run scoped diff and ruff checks for the changed file.

## Test Result

On upstream main, the second request used a different salt but still reported 7856 prefix-cache hits. With this patch, that second request reports 0 hits and the same-salt repeat still reports 7856 hits. Reverting the patch brings the 7856-hit failure back.

<details><summary>server repro command and client script</summary>

The output below was captured on upstream main `394edc81082c04cb38e3455fc0c03d62ba403b72` with one RTX 4090 24 GB GPU. I used a local snapshot of `Qwen/Qwen3-Embedding-0.6B`; the command below uses the public model id.

Server command used from a clean checkout:

```bash
VLLM_USE_FLASHINFER_SAMPLER=0 \
VLLM_WORKER_MULTIPROC_METHOD=spawn \
python -m vllm.entrypoints.openai.api_server \
  --host 127.0.0.1 \
  --port 8025 \
  --model Qwen/Qwen3-Embedding-0.6B \
  --served-model-name qwen3-embed \
  --runner pooling \
  --dtype bfloat16 \
  --enforce-eager \
  --enable-prefix-caching \
  --max-model-len 512 \
  --gpu-memory-utilization 0.45 \
  --pooler-config '{"pooling_type":"LAST","use_activation":true,"enable_chunked_processing":true,"max_embed_len":10000}'
```

Client script:

```python
import json
import re
import sys
import time
import urllib.error
import urllib.request

BASE_URL = sys.argv[1] if len(sys.argv) > 1 else "http://127.0.0.1:8025"
MODEL = sys.argv[2] if len(sys.argv) > 2 else "qwen3-embed"


def request_json(method: str, path: str, payload: dict | None = None):
    data = None
    headers = {}
    if payload is not None:
        data = json.dumps(payload).encode("utf-8")
        headers["Content-Type"] = "application/json"
    req = urllib.request.Request(
        f"{BASE_URL}{path}", data=data, headers=headers, method=method
    )
    with urllib.request.urlopen(req, timeout=90) as resp:
        body = resp.read()
        if not body:
            return None
        return json.loads(body.decode("utf-8"))


def request_text(path: str) -> str:
    with urllib.request.urlopen(f"{BASE_URL}{path}", timeout=30) as resp:
        return resp.read().decode("utf-8")


def wait_ready() -> None:
    deadline = time.time() + 420
    last_error = None
    while time.time() < deadline:
        try:
            request_json("GET", "/v1/models")
            return
        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
            last_error = exc
            time.sleep(2)
    raise SystemExit(f"server did not become ready: {last_error}")


def metric_value(metrics: str, metric: str) -> float:
    pattern = re.compile(
        rf"^{re.escape(metric)}(?:_total)?(?:\{{[^}}]*\}})?\s+([0-9.]+)$"
    )
    total = 0.0
    for line in metrics.splitlines():
        match = pattern.match(line)
        if match:
            total += float(match.group(1))
    return total


def read_counters() -> dict[str, float]:
    metrics = request_text("/metrics")
    return {
        "queries": metric_value(metrics, "vllm:prefix_cache_queries"),
        "hits": metric_value(metrics, "vllm:prefix_cache_hits"),
        "cached_tokens": metric_value(metrics, "vllm:prompt_tokens_cached"),
    }


def send_embedding(cache_salt: str) -> None:
    token_ids = list(range(1000, 9102))
    response = request_json(
        "POST",
        "/v1/embeddings",
        {
            "model": MODEL,
            "input": token_ids,
            "encoding_format": "float",
            "cache_salt": cache_salt,
        },
    )
    print(
        "response",
        cache_salt,
        "status=ok",
        "items",
        len(response.get("data", [])),
        "usage",
        response.get("usage", {}),
        flush=True,
    )


def main() -> None:
    wait_ready()
    labels = ["baseline"]
    counters = [read_counters()]

    for salt in ("tenant-a", "tenant-b", "tenant-b"):
        send_embedding(salt)
        time.sleep(2)
        labels.append(salt)
        counters.append(read_counters())

    for label, counter in zip(labels, counters):
        print("metrics", label, json.dumps(counter, sort_keys=True), flush=True)

    deltas = []
    for before, after in zip(counters, counters[1:]):
        deltas.append(
            {
                key: after[key] - before[key]
                for key in ("queries", "hits", "cached_tokens")
            }
        )
    for label, delta in zip(("tenant-a", "tenant-b", "tenant-b-repeat"), deltas):
        print("delta", label, json.dumps(delta, sort_keys=True), flush=True)

    second_delta = deltas[1]
    if second_delta["hits"] > 0 or second_delta["cached_tokens"] > 0:
        raise SystemExit(
            "BUG: second request used a different cache_salt but reported "
            f"prefix-cache reuse: {json.dumps(second_delta, sort_keys=True)}"
        )

    repeat_delta = deltas[2]
    if repeat_delta["hits"] <= 0 and repeat_delta["cached_tokens"] <= 0:
        raise SystemExit(
            "inconclusive: repeated same-salt request did not show prefix-cache "
            f"reuse either: {json.dumps(repeat_delta, sort_keys=True)}"
        )

    print("OK: different cache_salt avoided prefix-cache reuse", flush=True)


if __name__ == "__main__":
    main()
```

</details>

<details><summary>before, after, and revert output</summary>

Upstream main:

```text
response tenant-a status=ok items 1 usage {'prompt_tokens': 8102, 'total_tokens': 8102, 'completion_tokens': 0, 'prompt_tokens_details': None}
response tenant-b status=ok items 1 usage {'prompt_tokens': 8102, 'total_tokens': 8102, 'completion_tokens': 0, 'prompt_tokens_details': None}
response tenant-b status=ok items 1 usage {'prompt_tokens': 8102, 'total_tokens': 8102, 'completion_tokens': 0, 'prompt_tokens_details': None}
metrics baseline {"cached_tokens": 0.0, "hits": 0.0, "queries": 0.0}
metrics tenant-a {"cached_tokens": 0.0, "hits": 0.0, "queries": 8102.0}
metrics tenant-b {"cached_tokens": 7856.0, "hits": 7856.0, "queries": 16204.0}
metrics tenant-b {"cached_tokens": 15712.0, "hits": 15712.0, "queries": 24306.0}
delta tenant-a {"cached_tokens": 0.0, "hits": 0.0, "queries": 8102.0}
delta tenant-b {"cached_tokens": 7856.0, "hits": 7856.0, "queries": 8102.0}
delta tenant-b-repeat {"cached_tokens": 7856.0, "hits": 7856.0, "queries": 8102.0}
BUG: second request used a different cache_salt but reported prefix-cache reuse: {"cached_tokens": 7856.0, "hits": 7856.0, "queries": 8102.0}
```

With this patch:

```text
response tenant-a status=ok items 1 usage {'prompt_tokens': 8102, 'total_tokens': 8102, 'completion_tokens': 0, 'prompt_tokens_details': None}
response tenant-b status=ok items 1 usage {'prompt_tokens': 8102, 'total_tokens': 8102, 'completion_tokens': 0, 'prompt_tokens_details': None}
response tenant-b status=ok items 1 usage {'prompt_tokens': 8102, 'total_tokens': 8102, 'completion_tokens': 0, 'prompt_tokens_details': None}
metrics baseline {"cached_tokens": 0.0, "hits": 0.0, "queries": 0.0}
metrics tenant-a {"cached_tokens": 0.0, "hits": 0.0, "queries": 8102.0}
metrics tenant-b {"cached_tokens": 0.0, "hits": 0.0, "queries": 16204.0}
metrics tenant-b {"cached_tokens": 7856.0, "hits": 7856.0, "queries": 24306.0}
delta tenant-a {"cached_tokens": 0.0, "hits": 0.0, "queries": 8102.0}
delta tenant-b {"cached_tokens": 0.0, "hits": 0.0, "queries": 8102.0}
delta tenant-b-repeat {"cached_tokens": 7856.0, "hits": 7856.0, "queries": 8102.0}
OK: different cache_salt avoided prefix-cache reuse
```

After reverting this patch:

```text
response tenant-a status=ok items 1 usage {'prompt_tokens': 8102, 'total_tokens': 8102, 'completion_tokens': 0, 'prompt_tokens_details': None}
response tenant-b status=ok items 1 usage {'prompt_tokens': 8102, 'total_tokens': 8102, 'completion_tokens': 0, 'prompt_tokens_details': None}
response tenant-b status=ok items 1 usage {'prompt_tokens': 8102, 'total_tokens': 8102, 'completion_tokens': 0, 'prompt_tokens_details': None}
BUG: second request used a different cache_salt but reported prefix-cache reuse: {"cached_tokens": 7856.0, "hits": 7856.0, "queries": 8102.0}
metrics baseline {"cached_tokens": 0.0, "hits": 0.0, "queries": 0.0}
metrics tenant-a {"cached_tokens": 0.0, "hits": 0.0, "queries": 8102.0}
metrics tenant-b {"cached_tokens": 7856.0, "hits": 7856.0, "queries": 16204.0}
metrics tenant-b {"cached_tokens": 15712.0, "hits": 15712.0, "queries": 24306.0}
delta tenant-a {"cached_tokens": 0.0, "hits": 0.0, "queries": 8102.0}
delta tenant-b {"cached_tokens": 7856.0, "hits": 7856.0, "queries": 8102.0}
delta tenant-b-repeat {"cached_tokens": 7856.0, "hits": 7856.0, "queries": 8102.0}
```

</details>

Scoped checks:

```text
git diff --check

python -m ruff check vllm/entrypoints/pooling/embed/io_processor.py
All checks passed!

python -m ruff format --check vllm/entrypoints/pooling/embed/io_processor.py
1 file already formatted
```

AI assistance was used to prepare this PR.

cc @noooop
