### PR TITLE
[fix][run_batch]: respect proxy env vars when downloading media URLs

### DIFF
--- a/vllm/entrypoints/openai/run_batch.py
+++ b/vllm/entrypoints/openai/run_batch.py
@@ -494,7 +494,7 @@ async def download_bytes_from_url(
             url = url_spec.url
 
         async with (
-            aiohttp.ClientSession() as session,
+            aiohttp.ClientSession(trust_env=True) as session,
             session.get(
                 url,
                 allow_redirects=envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,

--- a/vllm/entrypoints/openai/run_batch.py
+++ b/vllm/entrypoints/openai/run_batch.py
@@ -28,6 +28,7 @@ from urllib3.util import parse_url
 
 import vllm.envs as envs
 from vllm.config import config
+from vllm.connections import global_http_connection
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.openai.api_server import init_app_state
@@ -493,18 +494,9 @@ async def download_bytes_from_url(
             # between urllib3 and aiohttp (e.g. backslash-@ attacks).
             url = url_spec.url
 
-        async with (
-            aiohttp.ClientSession(trust_env=True) as session,
-            session.get(
-                url,
-                allow_redirects=envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
-            ) as resp,
-        ):
-            if resp.status != 200:
-                raise Exception(
-                    f"Failed to download data from URL: {url}. Status: {resp.status}"
-                )
-            return await resp.read()
+        return await global_http_connection.async_get_bytes(
+            url, allow_redirects=envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS
+        )
 
     else:
         raise ValueError(


### PR DESCRIPTION
aiohttp.ClientSession does not read HTTP_PROXY/HTTPS_PROXY environment variables by default. This causes download_bytes_from_url to fail with a connection timeout in network environments that require a proxy (e.g., corporate networks), even though tools like curl/wget work fine.

Add trust_env=True to aiohttp.ClientSession() in download_bytes_from_url so that aiohttp respects the system proxy settings.

This does not affect the SSRF domain allowlist protection, as that check happens before the HTTP connection is made.