### PR TITLE
[Doc] docs: fix note formatting for pooling models

### DIFF
--- a/docs/models/pooling_models/README.md
+++ b/docs/models/pooling_models/README.md
@@ -2,8 +2,7 @@
 
 !!! note
     We currently support pooling models primarily for convenience. This is not guaranteed to provide any performance
-improvements over using Hugging Face Transformers or Sentence Transformers directly.
-
+    improvements over using Hugging Face Transformers or Sentence Transformers directly.
     We plan to optimize pooling models in vLLM. Please comment on <https://github.com/vllm-project/vllm/issues/21796> if you have any suggestions!
 
 ## What are pooling models?
@@ -63,7 +62,7 @@ please refer to [IO Processor Plugins](../../design/io_processor_plugins.md).
 
 !!! note
     Within classification tasks, there is a specialized subcategory: Cross-encoder (aka reranker) models. These models
-are a subset of classification models that accept two prompts as input and output num_labels equal to 1.
+    are a subset of classification models that accept two prompts as input and output num_labels equal to 1.
 
 ### Pooling Types
 


### PR DESCRIPTION
The purpose of this PR is fixing note part of [pooling models docs](https://docs.vllm.ai/en/latest/models/pooling_models/#pooling-models).

<img width="798" height="320" alt="image" src="https://github.com/user-attachments/assets/02b81818-ed5f-4fe3-9df9-d3db380f1359" />
<img width="798" height="216" alt="image" src="https://github.com/user-attachments/assets/a7596d0d-93d9-452c-bfcd-50205fe1d7fd" />





## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

