### PR TITLE
 [Bugfix] DeepSeek V3.2/V4: drop whitespace content deltas around too…

### DIFF
--- a/tests/tool_parsers/test_deepseekv32_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv32_tool_parser.py
@@ -1206,3 +1206,92 @@ class TestDelimiterPreservation:
         assert reconstructor.tool_calls[0].function.name == "search"
         streamed_args = json.loads(reconstructor.tool_calls[0].function.arguments)
         assert streamed_args == ns_args
+
+
+
+class TestStreamingWhitespaceAroundToolCalls:
+    """DeepSeek V3.2 must never emit whitespace-only delta.content around a
+    tool_calls delta — downstream routers (e.g. claude-code-router) reject
+    such chunks once a tool_use block is active.
+    """
+
+    def _feed(self, parser, chunks, request=None):
+        if request is None:
+            request = make_request()
+        deltas = []
+        prev = ""
+        for chunk in chunks:
+            curr = prev + chunk
+            d = parser.extract_tool_calls_streaming(
+                previous_text=prev,
+                current_text=curr,
+                delta_text=chunk,
+                previous_token_ids=[],
+                current_token_ids=[],
+                delta_token_ids=[1],
+                request=request,
+            )
+            prev = curr
+            if d is not None:
+                deltas.append(d)
+        finish = parser.finish_streaming()
+        if finish is not None:
+            deltas.append(finish)
+        return deltas
+
+    @staticmethod
+    def _leaked_ws(deltas):
+        return [
+            d.content
+            for d in deltas
+            if getattr(d, "content", None) is not None
+            and d.content != ""
+            and d.content.strip() == ""
+        ]
+
+    def test_no_whitespace_content_before_tool_call(self):
+        parser = make_parser()
+        body = build_tool_call("get_weather", {"location": "Beijing"})
+        deltas = self._feed(parser, ["\n\n", body])
+        assert self._leaked_ws(deltas) == []
+
+    def test_no_whitespace_content_after_tool_call(self):
+        parser = make_parser()
+        body = build_tool_call("get_weather", {"location": "Beijing"})
+        deltas = self._feed(parser, [body, "\n"])
+        assert self._leaked_ws(deltas) == []
+
+    def test_no_whitespace_content_around_tool_call_chunked(self):
+        """Whitespace + tool + whitespace where prior real content has set
+        `_content_has_nonws`."""
+        parser = make_parser()
+        body = build_tool_call("get_weather", {"location": "Beijing"})
+        deltas = self._feed(
+            parser,
+            ["Sure, checking.", "\n\n", body, "\n"],
+        )
+        assert self._leaked_ws(deltas) == []
+        # And legitimate text before the whitespace is still emitted.
+        content = "".join(d.content for d in deltas if d.content)
+        assert content == "Sure, checking."
+
+    def test_tool_calls_chunk_has_no_content(self):
+        """The OpenAI streaming contract: any delta that carries
+        `tool_calls` must have `content=None` (or non-whitespace)."""
+        parser = make_parser()
+        body = build_tool_call("get_weather", {"location": "Beijing"})
+        deltas = self._feed(parser, ["\n\n" + body + "\n"])
+        for d in deltas:
+            if d.tool_calls:
+                assert (
+                    d.content is None or d.content.strip() != ""
+                ), f"Whitespace-only content leaked alongside tool_calls: {d.content!r}"
+
+    def test_real_text_before_tool_call_still_streamed(self):
+        """Non-whitespace content before a tool call is preserved."""
+        parser = make_parser()
+        body = build_tool_call("get_weather", {"location": "SF"})
+        deltas = self._feed(parser, ["Thinking about it. ", body])
+        content = "".join(d.content for d in deltas if d.content)
+        assert "Thinking about it." in content
+

--- a/tests/tool_parsers/test_deepseekv4_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv4_tool_parser.py
@@ -413,3 +413,117 @@ def test_composed_schema_converts_object_and_array_params():
         "wait": {"type": "for", "minutes": 2880},
         "patches": [{"op": "replace", "path": "/schedule", "value": "quiet"}],
     }
+
+
+def _stream_chunks(parser, chunks):
+    """Feed pre-split chunks and collect non-None deltas + a final flush."""
+    deltas = []
+    previous_text = ""
+    for chunk in chunks:
+        current_text = previous_text + chunk
+        delta = parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=chunk,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[1],
+            request=make_request(),
+        )
+        previous_text = current_text
+        if delta is not None:
+            deltas.append(delta)
+    finish = parser.finish_streaming()
+    if finish is not None:
+        deltas.append(finish)
+    return deltas
+
+
+def _leaked_ws_content(deltas):
+    """Return delta.content values that are whitespace-only (should never leak
+    in a stream that also emits tool_calls)."""
+    return [
+        d.content
+        for d in deltas
+        if getattr(d, "content", None) is not None
+        and d.content != ""
+        and d.content.strip() == ""
+    ]
+
+
+def test_streaming_no_whitespace_content_around_tool_call():
+    """No whitespace-only delta.content should be emitted before/after
+    tool_calls, even when a preceding non-whitespace content delta has
+    already flipped the parser's `content-seen` flag on."""
+    parser = make_parser()
+    body = build_tool_call("get_weather", {"location": "Beijing"})
+    chunks = [
+        "Sure, let me check.",  # legitimate content sets _content_has_nonws=True
+        "\n\n",                # trailing whitespace right before tool_calls
+        body,
+        "\n",                  # trailing whitespace right after tool_calls
+    ]
+
+    deltas = _stream_chunks(parser, chunks)
+    assert _leaked_ws_content(deltas) == []
+    # Legitimate content preserved
+    content_parts = [d.content for d in deltas if d.content]
+    assert "".join(content_parts) == "Sure, let me check."
+    # Tool call intact
+    tc_deltas = [tc for d in deltas if d.tool_calls for tc in d.tool_calls]
+    names = [tc.function.name for tc in tc_deltas if tc.function and tc.function.name]
+    assert names == ["get_weather"]
+    args = "".join(
+        tc.function.arguments
+        for tc in tc_deltas
+        if tc.function and tc.function.arguments
+    )
+    assert json.loads(args) == {"location": "Beijing"}
+
+
+def test_streaming_no_ws_content_when_tool_starts_no_prior_content():
+    """No whitespace-only delta.content when the model emits leading and
+    trailing whitespace around the tool block without any preceding chat
+    text."""
+    parser = make_parser()
+    body = build_tool_call("get_weather", {"location": "Beijing"})
+    chunks = ["\n\n", body, "\n"]
+
+    deltas = _stream_chunks(parser, chunks)
+    assert _leaked_ws_content(deltas) == []
+
+
+def test_streaming_ws_content_dropped_when_all_in_one_chunk():
+    """Chunk that contains leading whitespace, the full tool block, and
+    trailing whitespace must not emit any whitespace content — the tool_calls
+    chunk must have `content=None`."""
+    parser = make_parser()
+    body = build_tool_call("get_weather", {"location": "Beijing"})
+
+    deltas = _stream_chunks(parser, ["\n\n" + body + "\n"])
+    assert _leaked_ws_content(deltas) == []
+    # And the delta with tool_calls has content=None
+    for d in deltas:
+        if d.tool_calls:
+            assert d.content is None
+
+
+def test_streaming_real_text_around_tool_call_preserved():
+    """Non-whitespace content around a tool call is still preserved."""
+    parser = make_parser()
+    body = build_tool_call("search", {"query": "x"})
+    chunks = ["Result: ", body, " Great!"]
+
+    deltas = _stream_chunks(parser, chunks)
+    content = "".join(d.content for d in deltas if d.content)
+    assert content == "Result:  Great!"
+
+
+def test_streaming_trailing_whitespace_preserved_in_plain_chat():
+    """When no tool call is emitted, trailing whitespace at the end of a
+    plain chat response is still preserved (flushed on finish)."""
+    parser = make_parser()
+    deltas = _stream_chunks(parser, ["Hello", "\n"])
+    content = "".join(d.content for d in deltas if d.content)
+    assert content == "Hello\n"
+

--- a/vllm/parser/deepseek_v32.py
+++ b/vllm/parser/deepseek_v32.py
@@ -103,6 +103,7 @@ def deepseek_v32_config() -> ParserEngineConfig:
         arg_converter=_dsml_arg_converter,
         arg_structural_chars=frozenset(">"),
         strip_content_whitespace_with_tools=False,
+        drop_whitespace_only_content_after_nonws=True,
         tool_args_json=False,
     )
 

--- a/vllm/parser/deepseek_v4.py
+++ b/vllm/parser/deepseek_v4.py
@@ -205,6 +205,7 @@ def deepseek_v4_config(thinking: bool = False) -> ParserEngineConfig:
         arg_converter=_dsml_arg_converter,
         arg_structural_chars=frozenset(">"),
         strip_content_whitespace_with_tools=False,
+        drop_whitespace_only_content_after_nonws=True,
         tool_args_json=False,
     )
 

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -131,6 +131,9 @@ class ParserEngine(Parser):
         self._drop_ws_only_content_before_tools = (
             parser_engine_config.drop_whitespace_only_content_before_tools
         )
+        self._drop_ws_only_content_after_nonws = (
+            parser_engine_config.drop_whitespace_only_content_after_nonws
+        )
         self._strip_content_ws_with_tools = (
             parser_engine_config.strip_content_whitespace_with_tools
         )
@@ -747,7 +750,17 @@ class ParserEngine(Parser):
         content_str = "".join(content_parts)
 
         if self._content_has_nonws:
-            pass
+            if (
+                self._drop_ws_only_content_after_nonws
+                and content_str
+                and not content_str.strip()
+            ):
+                if self._tool_slots:
+                    if self._drop_ws_only_content_before_tools:
+                        content_str = ""
+                elif not finished:
+                    self._deferred_content = content_str
+                    content_str = ""
         elif content_str:
             stripped = content_str.strip()
             if stripped:

--- a/vllm/parser/engine/parser_engine_config.py
+++ b/vllm/parser/engine/parser_engine_config.py
@@ -89,6 +89,15 @@ class ParserEngineConfig:
     # Drop content that is entirely whitespace when tool calls follow.
     drop_whitespace_only_content_before_tools: bool = True
 
+    # Also defer/drop whitespace-only content deltas that arrive *after* some
+    # non-whitespace content has already been streamed. Without this, trailing
+    # whitespace between a legitimate content chunk and a tool_call chunk (and
+    # leading whitespace after the tool_call closes) leaks as ``delta.content``
+    # in a chunk that a downstream router may reject once a tool_use block is
+    # active. Off by default; enable per-parser where the model reliably emits
+    # whitespace around its tool-call markers (currently DeepSeek V3.2/V4).
+    drop_whitespace_only_content_after_nonws: bool = False
+
     # .strip() content text when tool calls are present.
     strip_content_whitespace_with_tools: bool = True
 


### PR DESCRIPTION
  [Bugfix] DeepSeek V3.2/V4: drop whitespace delta.content around tool_calls in streaming

  ▎ Suggested branch: bugfix/deepseek-tool-parser-whitespace-content
  ▎ Target branch: main
  ▎ PR title (≤ 70 chars): [Bugfix] DeepSeek V3.2/V4: drop whitespace content around tool_calls

  Summary

  When streaming tool calls with the DeepSeek V3.2 / V4 tool parser
  (DeepSeekV32EngineToolParser / DeepSeekV4EngineToolParser), the parser
  engine can emit whitespace-only delta.content chunks immediately before
  and after the tool_calls delta:

  delta.content       = "\n\n"
  delta.tool_calls    = [...]
  delta.content       = "\n"
  delta.finish_reason = "tool_calls"

  The OpenAI streaming contract expects content to be null in any chunk
  associated with tool_calls. Downstream routers that translate OpenAI
  streams into Anthropic Messages streams (e.g. claude-code-router) reject
  these chunks with:

  API Error: Content block is not a text block

  because the active content block has already switched to tool_use, and
  a text-content delta cannot be appended to it.

  Reproduction

  - vLLM serving deepseek-v4 with --tool-call-parser deepseek_v4 and
  streaming enabled.
  - Client: claude-code + claude-code-router proxying to vLLM.
  - Prompt: any tool-using turn (e.g. "看下今天的天气" with a get_weather tool).
  - Observed: plain-chat turns succeed; the first tool-using turn fails with
  Content block is not a text block because the vLLM stream contains
  delta.content = "\n\n" ahead of delta.tool_calls = [...] and
  another delta.content = "\n" immediately after.

  Minimal Python reproducer using the mock-tokenizer test fixture:

  chunks = [
      "Sure, let me check.",                    # legitimate text
      "\n\n",                                   # whitespace right before tool
      "<｜DSML｜tool_calls>...</｜DSML｜tool_calls>",
      "\n",                                     # whitespace right after tool
  ]
  # On main, deltas[1].content == "\n\n" and deltas[3].content == "\n"

  Root cause

  In vllm/parser/engine/parser_engine.py::_events_to_delta the streaming
  path uses _content_has_nonws as a fast-path guard: once any
  non-whitespace content has been emitted, the whitespace-drop / deferral
  logic is skipped for the rest of the stream:

  if self._content_has_nonws:
      pass                              # <-- whitespace slips through here
  elif content_str:
      stripped = content_str.strip()
      if stripped:
          self._content_has_nonws = True
      elif self._tool_slots:
          if self._drop_ws_only_content_before_tools:
              content_str = ""
      elif not finished:
          self._deferred_content = content_str
          content_str = ""

  DeepSeek V3.2/V4 reliably emit \n\n before <｜DSML｜tool_calls> and
  \n after </｜DSML｜tool_calls>. As soon as the model has produced any
  real content (or a chat template surfaces some), _content_has_nonws
  becomes True and those trailing/leading whitespace fragments are
  forwarded as delta.content — some of them landing in the same delta as
  tool_calls, and some landing after the tool_use block has already been
  opened downstream.

  Fix

  Add an opt-in config knob and use it only for DeepSeek V3.2 / V4:

  1. ParserEngineConfig — new field, default False, no effect on
  any existing parser:
  drop_whitespace_only_content_after_nonws: bool = False
  2. ParserEngine._events_to_delta — when the flag is True, keep
  applying the whitespace drop/defer step even after
  _content_has_nonws has flipped:
    - if _tool_slots are already populated → drop the whitespace
  (reuses drop_whitespace_only_content_before_tools);
    - else if not yet finished → defer via _deferred_content so that
  legitimate text arriving in a later chunk still preserves its
  leading whitespace, while tool_calls arriving instead will cause
  the deferred whitespace to be dropped.
  3. vllm/parser/deepseek_v32.py / vllm/parser/deepseek_v4.py —
  set the new flag to True in deepseek_v32_config() and
  deepseek_v4_config().

  Non-streaming (extract_tool_calls) was already correct and is
  untouched.

  Scope

  Intentionally minimal and DeepSeek-only:

  - The new config flag defaults to False, so every other parser
  (Kimi K2, Qwen3, Gemma4, MinimaxM2, Mistral, Hermes, Llama, GLM,
  Granite, …) sees zero behavior change.
  - DeepSeek V3 and V3.1 use their own non–ParserEngine implementations
  and are not touched.
  - Only V3.2 and V4 configs opt in.

  Verified via config introspection:

  kimi_k2                              drop_whitespace_only_content_after_nonws=False
  qwen3                                drop_whitespace_only_content_after_nonws=False
  gemma4                               drop_whitespace_only_content_after_nonws=False
  minimax_m2                           drop_whitespace_only_content_after_nonws=False
  deepseek_v32                         drop_whitespace_only_content_after_nonws=True   <-- fix active
  deepseek_v4 (thinking=False)         drop_whitespace_only_content_after_nonws=True   <-- fix active
  deepseek_v4 (thinking=True)          drop_whitespace_only_content_after_nonws=True   <-- fix active

  A structurally similar issue may exist in ~27 other Python tool parsers;
  they are out of scope for this PR to keep the diff reviewable. A
  follow-up issue can enumerate them so the cleanup can be split into
  per-parser PRs.

  Duplicate-work checks

  gh pr list --repo vllm-project/vllm --state open \
    --search "deepseek tool parser whitespace"
  gh pr list --repo vllm-project/vllm --state open \
    --search "Content block is not a text block"
  gh issue list --repo vllm-project/vllm \
    --search "tool_calls content whitespace"

  Tests

  Added regression tests that fail on main and pass on this branch:

  - tests/tool_parsers/test_deepseekv32_tool_parser.py — new class
  TestStreamingWhitespaceAroundToolCalls:
    - test_no_whitespace_content_before_tool_call
    - test_no_whitespace_content_after_tool_call
    - test_no_whitespace_content_around_tool_call_chunked
    - test_tool_calls_chunk_has_no_content — asserts the OpenAI
  contract: chunks carrying tool_calls have content=None or
  non-whitespace content.
    - test_real_text_before_tool_call_still_streamed — regression
  guard: legitimate leading text is preserved.
  - tests/tool_parsers/test_deepseekv4_tool_parser.py:
    - test_streaming_no_whitespace_content_around_tool_call
    - test_streaming_no_ws_content_when_tool_starts_no_prior_content
    - test_streaming_ws_content_dropped_when_all_in_one_chunk
    - test_streaming_real_text_around_tool_call_preserved
    - test_streaming_trailing_whitespace_preserved_in_plain_chat —
  regression guard: trailing whitespace in a plain chat (no tool
  call) is still flushed on finish.

  Commands run:

  .venv/bin/python -m pytest tests/tool_parsers/test_deepseekv32_tool_parser.py -v
  .venv/bin/python -m pytest tests/tool_parsers/test_deepseekv4_tool_parser.py -v
  pre-commit run --files \
    vllm/parser/engine/parser_engine_config.py \
    vllm/parser/engine/parser_engine.py \
    vllm/parser/deepseek_v32.py \
    vllm/parser/deepseek_v4.py \
    tests/tool_parsers/test_deepseekv32_tool_parser.py \
    tests/tool_parsers/test_deepseekv4_tool_parser.py

  Results (locally, with mock tokenizer):

  tests/tool_parsers/test_deepseekv32_tool_parser.py   48 → 53 passed
  tests/tool_parsers/test_deepseekv4_tool_parser.py    11 → 16 passed