### PR TITLE
[XPU] refine docker file to ensure oneAPI envs properly sourced

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-intel-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-intel-test.sh
@@ -369,7 +369,7 @@ export HF_TOKEN ZE_AFFINITY_MASK
     -e CMDS \
     --name "${container_name}" \
     "${IMAGE}" \
-    bash -c 'set -e; source /opt/intel/oneapi/setvars.sh --force; source /opt/intel/oneapi/ccl/2021.15/env/vars.sh --force; echo "ZE_AFFINITY_MASK is ${ZE_AFFINITY_MASK:-}"; eval "$CMDS"' \
+    bash -c 'set -e; echo "ZE_AFFINITY_MASK is ${ZE_AFFINITY_MASK:-}"; eval "$CMDS"' \
     >/dev/null
 } 9>/tmp/docker-pull.lock
 

--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -105,8 +105,6 @@ ARG ONECCL_INSTALLER="intel-oneccl-2021.15.9.14_offline.sh"
 RUN wget "https://github.com/uxlfoundation/oneCCL/releases/download/2021.15.9/${ONECCL_INSTALLER}" && \
     bash "${ONECCL_INSTALLER}" -a --silent --eula accept && \
     rm "${ONECCL_INSTALLER}" && \
-    echo "source /opt/intel/oneapi/setvars.sh --force" >> /root/.bashrc && \
-    echo "source /opt/intel/oneapi/ccl/2021.15/env/vars.sh --force" >> /root/.bashrc && \
     rm -f /opt/intel/oneapi/ccl/latest && \
     ln -s /opt/intel/oneapi/ccl/2021.15 /opt/intel/oneapi/ccl/latest && \
     printf '%s\n' \
@@ -116,8 +114,32 @@ RUN wget "https://github.com/uxlfoundation/oneCCL/releases/download/2021.15.9/${
     > /etc/ld.so.conf.d/oneapi-ccl.conf && \
     ldconfig
 
+# Cover different docker launch scenarios to ensure oneAPI envs sourced
+#   - /etc/bash.bashrc + /root/.bashrc : interactive non-login (`docker exec -it c bash`)
+#   - /etc/profile.d/zz-oneapi.sh      : login shells (`bash -l`)
+#   - /root/.bash_profile              : login shells that read ~/.bash_profile
+#   - $BASH_ENV                        : non-interactive bash (`bash -c ...`, scripts)
+#   - ENTRYPOINT wrapper               : `docker run <img> <cmd>`
+RUN printf '%s\n' \
+    'source /opt/intel/oneapi/setvars.sh --force >/dev/null 2>&1 || true' \
+    'source /opt/intel/oneapi/ccl/2021.15/env/vars.sh --force >/dev/null 2>&1 || true' \
+    > /etc/oneapi-env.sh && \
+    echo 'source /etc/oneapi-env.sh' >> /etc/bash.bashrc && \
+    echo 'source /etc/oneapi-env.sh' >> /root/.bashrc && \
+    printf '%s\n' 'source /etc/oneapi-env.sh' > /etc/profile.d/zz-oneapi.sh && \
+    printf '%s\n' '[ -f ~/.bashrc ] && source ~/.bashrc' > /root/.bash_profile && \
+    printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'source /etc/oneapi-env.sh' \
+    'exec "$@"' \
+    > /usr/local/bin/oneapi-entrypoint.sh && \
+    chmod +x /usr/local/bin/oneapi-entrypoint.sh
+
+ENV BASH_ENV=/etc/oneapi-env.sh
+
 SHELL ["bash", "-c"]
-CMD ["bash", "-c", "source /root/.bashrc && exec bash"]
+ENTRYPOINT ["/usr/local/bin/oneapi-entrypoint.sh"]
+CMD ["/bin/bash"]
 
 WORKDIR /workspace/vllm
 
@@ -242,4 +264,4 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install -e tests/vllm_test_utils
 
-ENTRYPOINT ["vllm", "serve"]
+ENTRYPOINT ["/usr/local/bin/oneapi-entrypoint.sh", "vllm", "serve"]


### PR DESCRIPTION



co-work with Copilot.

## Purpose
Currently we found oneAPI envs are not properly sourced in some docker run scenarios thus XPU device can't be successfully detected. In this PR, we add an env wrapper to assure it's sourced in interactive/non-interactive cases.

## Test Plan
```
docker run --rm  -v /dev/dri/by-path:/dev/dri/by-path --device /dev/dri:/dev/dri --entrypoint /usr/local/bin/oneapi-entrypoint.sh test_yan:latest   bash -c 'echo "SETVARS_COMPLETED=$SETVARS_COMPLETED; CCL_ROOT=$CCL_ROOT"'
docker run -d --name yan_test --entrypoint sleep test_yan:latest infinity && docker exec -it yan_test bash -c 'echo "CCL_ROOT=$CCL_ROOT; CMPLR_ROOT=$CMPLR_ROOT"'
docker run --rm --entrypoint bash test_yan:latest   -lc 'echo "login: SETVARS_COMPLETED=$SETVARS_COMPLETED; CCL_ROOT=$CCL_ROOT"'
docker run --rm --entrypoint bash test_yan:latest   -c 'echo "non-interactive: CCL_ROOT=$CCL_ROOT; MKLROOT=$MKLROOT"'
docker run --rm --entrypoint bash   --device=/dev/dri/card0 --device=/dev/dri/renderD128   --device=/dev/dri/card1 --device=/dev/dri/renderD129   -e ZE_ENABLE_VALIDATION_LAYER=1 -e ZE_DEBUG=4   test_yan:latest -c   "vllm --version"
```


## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

