### PR TITLE
[Perf][Kernel] Decode-M GEMM dispatch for DSA bf16 A/B projections: skinny GEMV + min-latency fused_a (Blackwell)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -718,6 +718,23 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
                    "(requires SM90+ and CUDA >= 12.0).")
   endif()
 
+  # BF16 skinny GEMM (M<=32; weight-bandwidth-bound decode shapes).
+  # Requires SM90+.
+  cuda_archs_sm90plus(BF16_SKINNY_GEMM_ARCHS "${CUDA_ARCHS}")
+  if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.0 AND BF16_SKINNY_GEMM_ARCHS)
+    set(BF16_SKINNY_GEMM_SRCS
+      "csrc/libtorch_stable/bf16_skinny_gemm_entry.cu"
+      "csrc/libtorch_stable/bf16_skinny_gemm.cu")
+    set_gencode_flags_for_srcs(
+      SRCS "${BF16_SKINNY_GEMM_SRCS}"
+      CUDA_ARCHS "${BF16_SKINNY_GEMM_ARCHS}")
+    list(APPEND VLLM_STABLE_EXT_SRC "${BF16_SKINNY_GEMM_SRCS}")
+    message(STATUS "Building bf16_skinny_gemm for archs: ${BF16_SKINNY_GEMM_ARCHS}")
+  else()
+    message(STATUS "Not building bf16_skinny_gemm as no compatible archs found "
+                   "(requires SM90+ and CUDA >= 12.0).")
+  endif()
+
   # Only build AllSpark kernels if we are building for at least some compatible archs.
   cuda_archs_loose_intersection(ALLSPARK_ARCHS "8.0;8.6;8.7;8.9" "${CUDA_ARCHS}")
   if (ALLSPARK_ARCHS)

--- a/csrc/libtorch_stable/bf16_skinny_gemm.cu
+++ b/csrc/libtorch_stable/bf16_skinny_gemm.cu
@@ -85,9 +85,6 @@ __global__ __launch_bounds__(kBlockSize, 1) void bf16_skinny_gemm_kernel(
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   cudaGridDependencySynchronize();
-  // Trigger right after our own wait (see fp32_router_gemm.cu): gridsync-ing
-  // consumers are unaffected; independent consumers may overlap our body.
-  cudaTriggerProgrammaticLaunchCompletion();
 #endif
 
 #pragma unroll
@@ -150,6 +147,15 @@ __global__ __launch_bounds__(kBlockSize, 1) void bf16_skinny_gemm_kernel(
     for (int w = 0; w < kNumWarps; w++) final_sum += sm_reduction[m][n][w];
     out[(size_t)m * out_stride + n_base + n] = __float2bfloat16(final_sum);
   }
+
+  // Trigger only after our stores: every current consumer (norm_rope, the
+  // MTP block) is a plain launch, so an early trigger buys nothing here,
+  // and a late one keeps a future PDL consumer that forgets its
+  // cudaGridDependencySynchronize from racing our output. Matches
+  // fp32_router_gemm.cu.
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  cudaTriggerProgrammaticLaunchCompletion();
+#endif
 }
 
 }  // namespace skinny

--- a/csrc/libtorch_stable/bf16_skinny_gemm.cu
+++ b/csrc/libtorch_stable/bf16_skinny_gemm.cu
@@ -246,6 +246,11 @@ INSTANTIATE_ALL_M(4, 512, 6144)
 // and every alternative loses — cublasLt top-8 3.6TB/s wall, DeepGEMM
 // 0.71x, wmma+cp.async custom 0.30x pending a TMA rewrite).
 INSTANTIATE_ALL_M(4, 2624, 6144)
+// DSv3.2 (TP8) siblings of the GLM shapes above, same dual-chip matrix:
+//   fused_qkv_a (2112, 7168), 30MB: wins M<=2 (M=1 1.30-1.34x)
+//   MTP eh_proj (7168, 14336), 205MB: wins M<=2 (M=1 1.12-1.16x)
+INSTANTIATE_ALL_M(4, 2112, 7168)
+INSTANTIATE_ALL_M(2, 7168, 14336)
 
 #undef INSTANTIATE_ALL_M
 #undef INSTANTIATE

--- a/csrc/libtorch_stable/bf16_skinny_gemm.cu
+++ b/csrc/libtorch_stable/bf16_skinny_gemm.cu
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+//
+// Skinny GEMM: activation(bf16) x weight(bf16)^T -> bf16, for decode-time
+// M <= 32 with a large reduction dim. Replaces cuBLAS splitK (GEMM +
+// splitKreduce) with a single block-per-output-column kernel; these shapes
+// are weight-bandwidth-bound, so one coalesced pass over the weight at
+// fp32 accumulation is optimal. Adapted from fp32_router_gemm.cu.
+//
+// First user: the DeepSeek-V32/GLM-5.2 MTP eh_proj (K=2*hidden=12288,
+// N=hidden/TP), whose cuBLAS splitK pick costs ~34.6us vs the ~19us
+// bandwidth floor per replicated read (and ~4us once column-parallel).
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+// ---------------------------------------------------------------------------
+// Load helpers (8 x bf16 = one uint4 load, converted to fp32)
+// ---------------------------------------------------------------------------
+
+namespace skinny {
+
+constexpr int VPT = 8;  // bf16 values per thread per load
+
+__device__ __forceinline__ void load_bf16x8(__nv_bfloat16 const* ptr,
+                                            float* dst) {
+  uint4 v = *reinterpret_cast<uint4 const*>(ptr);
+  __nv_bfloat16 const* p = reinterpret_cast<__nv_bfloat16 const*>(&v);
+#pragma unroll
+  for (int i = 0; i < VPT; i++) dst[i] = __bfloat162float(p[i]);
+}
+
+// Streaming variant for the weight: each row is read exactly once across the
+// whole grid, so bypass L2 residency (evict-first). Measured -1.4us at M=1.
+__device__ __forceinline__ void load_bf16x8_cs(__nv_bfloat16 const* ptr,
+                                               float* dst) {
+  uint4 v = __ldcs(reinterpret_cast<uint4 const*>(ptr));
+  __nv_bfloat16 const* p = reinterpret_cast<__nv_bfloat16 const*>(&v);
+#pragma unroll
+  for (int i = 0; i < VPT; i++) dst[i] = __bfloat162float(p[i]);
+}
+
+// ---------------------------------------------------------------------------
+// Kernel: each block computes kNPB output columns for all kNumTokens rows.
+// grid = kN / kNPB, block = kBlockSize threads. K is reduced VPT elements
+// per thread per iteration; fp32 accumulation, warp butterfly + smem
+// finalize, bf16 store.
+// ---------------------------------------------------------------------------
+
+template <int kBlockSize, int kNumTokens, int kNPB, int kPF, int kN, int kK>
+__global__ __launch_bounds__(kBlockSize, 1) void bf16_skinny_gemm_kernel(
+    __nv_bfloat16* out, __nv_bfloat16 const* mat_a,
+    __nv_bfloat16 const* mat_b, int64_t out_stride) {
+  constexpr int k_elems_per_iter = VPT * kBlockSize;
+  constexpr int k_iterations = kK / k_elems_per_iter;
+  static_assert(kK % k_elems_per_iter == 0);
+  constexpr int kWarpSize = 32;
+  constexpr int kNumWarps = kBlockSize / kWarpSize;
+
+  int const n_base = blockIdx.x * kNPB;
+  int const tid = threadIdx.x;
+  int const warpId = tid / kWarpSize;
+  int const laneId = tid % kWarpSize;
+
+  float acc[kNumTokens][kNPB] = {};
+  __shared__ float sm_reduction[kNumTokens][kNPB][kNumWarps];
+
+  // Register prefetch (kPF > 0): W does not depend on the predecessor, so
+  // the first kPF iterations' weight chunks are loaded raw BEFORE the
+  // dependency sync; with a PDL-releasing producer (fused_eh_norm fires
+  // gdc_launch_dependents early) these DRAM round trips overlap the norm.
+  // Pair-measured on B300 (norm+gemm in one graph, full 6144x12288):
+  // M=1 pf2 28.43us vs pf0 29.00us; deeper prefetch or M >= 2 regresses
+  // (register pressure), hence the per-M selection in the launcher.
+  uint4 w_pre[kPF > 0 ? kPF : 1][kNPB];
+#pragma unroll
+  for (int pf = 0; pf < kPF; pf++) {
+#pragma unroll
+    for (int n = 0; n < kNPB; n++) {
+      w_pre[pf][n] = *reinterpret_cast<uint4 const*>(
+          mat_b + (size_t)(n_base + n) * kK + pf * k_elems_per_iter +
+          tid * VPT);
+    }
+  }
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  cudaGridDependencySynchronize();
+  // Trigger right after our own wait (see fp32_router_gemm.cu): gridsync-ing
+  // consumers are unaffected; independent consumers may overlap our body.
+  cudaTriggerProgrammaticLaunchCompletion();
+#endif
+
+#pragma unroll
+  for (int ki = 0; ki < k_iterations; ki++) {
+    int const k_base = ki * k_elems_per_iter + tid * VPT;
+
+    float b_float[kNPB][VPT];
+    if (ki < kPF) {
+#pragma unroll
+      for (int n = 0; n < kNPB; n++) {
+        __nv_bfloat16 const* p =
+            reinterpret_cast<__nv_bfloat16 const*>(&w_pre[ki][n]);
+#pragma unroll
+        for (int v = 0; v < VPT; v++) b_float[n][v] = __bfloat162float(p[v]);
+      }
+    } else {
+#pragma unroll
+      for (int n = 0; n < kNPB; n++) {
+        load_bf16x8_cs(mat_b + (size_t)(n_base + n) * kK + k_base, b_float[n]);
+      }
+    }
+
+#pragma unroll
+    for (int m = 0; m < kNumTokens; m++) {
+      float a_float[VPT];
+      load_bf16x8(mat_a + (size_t)m * kK + k_base, a_float);
+#pragma unroll
+      for (int n = 0; n < kNPB; n++) {
+#pragma unroll
+        for (int k = 0; k < VPT; k++) {
+          acc[m][n] += a_float[k] * b_float[n][k];
+        }
+      }
+    }
+  }
+
+  // Warp-level butterfly reduction
+#pragma unroll
+  for (int m = 0; m < kNumTokens; m++) {
+#pragma unroll
+    for (int n = 0; n < kNPB; n++) {
+      float sum = acc[m][n];
+      sum += __shfl_xor_sync(0xffffffff, sum, 16);
+      sum += __shfl_xor_sync(0xffffffff, sum, 8);
+      sum += __shfl_xor_sync(0xffffffff, sum, 4);
+      sum += __shfl_xor_sync(0xffffffff, sum, 2);
+      sum += __shfl_xor_sync(0xffffffff, sum, 1);
+      if (laneId == 0) sm_reduction[m][n][warpId] = sum;
+    }
+  }
+
+  __syncthreads();
+
+  // Parallel finalize: one thread per (m, n) output.
+  for (int idx = tid; idx < kNumTokens * kNPB; idx += kBlockSize) {
+    int const m = idx / kNPB;
+    int const n = idx % kNPB;
+    float final_sum = 0.0f;
+#pragma unroll
+    for (int w = 0; w < kNumWarps; w++) final_sum += sm_reduction[m][n][w];
+    out[(size_t)m * out_stride + n_base + n] = __float2bfloat16(final_sum);
+  }
+}
+
+}  // namespace skinny
+
+// ---------------------------------------------------------------------------
+// Launcher
+// ---------------------------------------------------------------------------
+
+template <int kBlockSize, int kNPB, int kNumTokens, int kN, int kK>
+void invokeBf16SkinnyGemm(__nv_bfloat16* output, __nv_bfloat16 const* mat_a,
+                          __nv_bfloat16 const* mat_b, int64_t out_stride,
+                          cudaStream_t stream) {
+  static_assert(kN % kNPB == 0);
+  // Weight prefetch depth: only M=1 measured a win (see kernel comment).
+  constexpr int kPF = (kNumTokens == 1) ? 2 : 0;
+  cudaLaunchConfig_t config;
+  config.gridDim = kN / kNPB;
+  config.blockDim = kBlockSize;
+  config.dynamicSmemBytes = 0;
+  config.stream = stream;
+  cudaLaunchAttribute attrs[1];
+  attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attrs[0].val.programmaticStreamSerializationAllowed = 1;
+  config.numAttrs = 1;
+  config.attrs = attrs;
+  cudaLaunchKernelEx(
+      &config,
+      skinny::bf16_skinny_gemm_kernel<kBlockSize, kNumTokens, kNPB, kPF,
+                                      kN, kK>,
+      output, mat_a, mat_b, out_stride);
+}
+
+// ---------------------------------------------------------------------------
+// Explicit instantiations. M = 1..32; (N, K) pairs:
+//   (768, 12288)  eh_proj shard, TP8
+//   (1536, 12288) eh_proj shard, TP4
+//   (6144, 12288) eh_proj unsharded
+// kNPB (B300 sweep, M=1): 6144 -> 2 (3072 blocks, 23.2us vs 25.3 at kNPB=8;
+// narrow blocks minimize wave quantization); shards 768/1536 keep 4.
+// ---------------------------------------------------------------------------
+
+#define INSTANTIATE(M, NPB, N, K)                                      \
+  template void invokeBf16SkinnyGemm<128, NPB, M, N, K>(               \
+      __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*,      \
+      int64_t, cudaStream_t);
+
+#define INSTANTIATE_ALL_M(NPB, N, K)                                   \
+  INSTANTIATE(1, NPB, N, K)                                            \
+  INSTANTIATE(2, NPB, N, K)                                            \
+  INSTANTIATE(3, NPB, N, K)                                            \
+  INSTANTIATE(4, NPB, N, K)                                            \
+  INSTANTIATE(5, NPB, N, K)                                            \
+  INSTANTIATE(6, NPB, N, K)                                            \
+  INSTANTIATE(7, NPB, N, K)                                            \
+  INSTANTIATE(8, NPB, N, K)                                            \
+  INSTANTIATE(9, NPB, N, K)                                            \
+  INSTANTIATE(10, NPB, N, K)                                           \
+  INSTANTIATE(11, NPB, N, K)                                           \
+  INSTANTIATE(12, NPB, N, K)                                           \
+  INSTANTIATE(13, NPB, N, K)                                           \
+  INSTANTIATE(14, NPB, N, K)                                           \
+  INSTANTIATE(15, NPB, N, K)                                           \
+  INSTANTIATE(16, NPB, N, K)                                           \
+  INSTANTIATE(17, NPB, N, K)                                           \
+  INSTANTIATE(18, NPB, N, K)                                           \
+  INSTANTIATE(19, NPB, N, K)                                           \
+  INSTANTIATE(20, NPB, N, K)                                           \
+  INSTANTIATE(21, NPB, N, K)                                           \
+  INSTANTIATE(22, NPB, N, K)                                           \
+  INSTANTIATE(23, NPB, N, K)                                           \
+  INSTANTIATE(24, NPB, N, K)                                           \
+  INSTANTIATE(25, NPB, N, K)                                           \
+  INSTANTIATE(26, NPB, N, K)                                           \
+  INSTANTIATE(27, NPB, N, K)                                           \
+  INSTANTIATE(28, NPB, N, K)                                           \
+  INSTANTIATE(29, NPB, N, K)                                           \
+  INSTANTIATE(30, NPB, N, K)                                           \
+  INSTANTIATE(31, NPB, N, K)                                           \
+  INSTANTIATE(32, NPB, N, K)
+
+INSTANTIATE_ALL_M(4, 768, 12288)
+INSTANTIATE_ALL_M(4, 1536, 12288)
+INSTANTIATE_ALL_M(2, 6144, 12288)
+// LL-mode (M<=8 wiring guard) backbone shapes, B300 sweep vs cuBLAS:
+//   q_b_proj  (2048, 2048): 1.67x/1.29x/1.15x at M=4/6/8 (NPB=4 within
+//     0.1us of per-M best)
+//   shared-expert gate_up (512, 6144): 1.95x/1.58x/1.40x at M=4/6/8
+// cuBLAS keeps qkv_a (2624,6144) and o_proj (6144,2048) — already at
+// 3.4-3.8 TB/s there; the GEMV loses on activation re-reads.
+INSTANTIATE_ALL_M(4, 2048, 2048)
+INSTANTIATE_ALL_M(4, 512, 6144)
+// fused_qkv_a (2624, 6144), 32MB: skinny wins ONLY at M<=2 (B300: M=1
+// 6.99us vs cuBLAS 9.21 = 1.32x, M=2 1.24x; M>=4 cuBLAS holds at 3.5TB/s
+// and every alternative loses — cublasLt top-8 3.6TB/s wall, DeepGEMM
+// 0.71x, wmma+cp.async custom 0.30x pending a TMA rewrite).
+INSTANTIATE_ALL_M(4, 2624, 6144)
+
+#undef INSTANTIATE_ALL_M
+#undef INSTANTIATE

--- a/csrc/libtorch_stable/bf16_skinny_gemm_entry.cu
+++ b/csrc/libtorch_stable/bf16_skinny_gemm_entry.cu
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/ScalarType.h>
+
+#include "core/registration.h"
+#include "libtorch_stable/torch_utils.h"
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+#include <stdexcept>
+
+static constexpr int SKINNY_MAX_TOKENS = 32;
+
+// Supported (N, K) pairs (must match the instantiations in
+// bf16_skinny_gemm.cu): eh_proj shard TP8 / TP4 / unsharded.
+static inline bool bf16_skinny_gemm_supported(int n, int k) {
+  if (k == 12288 && (n == 768 || n == 1536 || n == 6144)) return true;
+  // LL-mode backbone shapes (wire callers with an M <= 8 guard; the GEMV
+  // family loses to cuBLAS at larger M).
+  if (k == 2048 && n == 2048) return true;  // q_b_proj (TP8)
+  if (k == 6144 && n == 2624) return true;  // fused_qkv_a (wire M <= 2 only)
+  if (k == 6144 && n == 512) return true;   // shared-expert gate_up (TP8)
+  return false;
+}
+
+// Forward declarations - template params must match bf16_skinny_gemm.cu
+template <int kBlockSize, int kNPB, int kNumTokens, int kN, int kK>
+void invokeBf16SkinnyGemm(__nv_bfloat16* output, __nv_bfloat16 const* mat_a,
+                          __nv_bfloat16 const* mat_b, int64_t out_stride,
+                          cudaStream_t stream);
+
+template <int kNPB, int kN, int kK, int kBegin, int kEnd>
+struct SkinnyLoopUnroller {
+  static void unroll(int num_tokens, __nv_bfloat16* output,
+                     __nv_bfloat16 const* mat_a, __nv_bfloat16 const* mat_b,
+                     int64_t out_stride, cudaStream_t stream) {
+    if (num_tokens == kBegin) {
+      invokeBf16SkinnyGemm<128, kNPB, kBegin, kN, kK>(output, mat_a, mat_b,
+                                                      out_stride, stream);
+    } else {
+      SkinnyLoopUnroller<kNPB, kN, kK, kBegin + 1, kEnd>::unroll(
+          num_tokens, output, mat_a, mat_b, out_stride, stream);
+    }
+  }
+};
+
+template <int kNPB, int kN, int kK, int kEnd>
+struct SkinnyLoopUnroller<kNPB, kN, kK, kEnd, kEnd> {
+  static void unroll(int num_tokens, __nv_bfloat16* output,
+                     __nv_bfloat16 const* mat_a, __nv_bfloat16 const* mat_b,
+                     int64_t out_stride, cudaStream_t stream) {
+    if (num_tokens == kEnd) {
+      invokeBf16SkinnyGemm<128, kNPB, kEnd, kN, kK>(output, mat_a, mat_b,
+                                                    out_stride, stream);
+    } else {
+      throw std::invalid_argument(
+          "bf16_skinny_gemm: num_tokens must be in [1, 32]");
+    }
+  }
+};
+
+static void dispatchBf16SkinnyGemm(int n, int k, int num_tokens,
+                                   __nv_bfloat16* output,
+                                   __nv_bfloat16 const* mat_a,
+                                   __nv_bfloat16 const* mat_b,
+                                   int64_t out_stride, cudaStream_t stream) {
+  if (n == 768 && k == 12288) {
+    SkinnyLoopUnroller<4, 768, 12288, 1, SKINNY_MAX_TOKENS>::unroll(
+        num_tokens, output, mat_a, mat_b, out_stride, stream);
+  } else if (n == 1536 && k == 12288) {
+    SkinnyLoopUnroller<4, 1536, 12288, 1, SKINNY_MAX_TOKENS>::unroll(
+        num_tokens, output, mat_a, mat_b, out_stride, stream);
+  } else if (n == 6144 && k == 12288) {
+    SkinnyLoopUnroller<2, 6144, 12288, 1, SKINNY_MAX_TOKENS>::unroll(
+        num_tokens, output, mat_a, mat_b, out_stride, stream);
+  } else if (n == 2048 && k == 2048) {
+    SkinnyLoopUnroller<4, 2048, 2048, 1, SKINNY_MAX_TOKENS>::unroll(
+        num_tokens, output, mat_a, mat_b, out_stride, stream);
+  } else if (n == 2624 && k == 6144) {
+    SkinnyLoopUnroller<4, 2624, 6144, 1, SKINNY_MAX_TOKENS>::unroll(
+        num_tokens, output, mat_a, mat_b, out_stride, stream);
+  } else if (n == 512 && k == 6144) {
+    SkinnyLoopUnroller<4, 512, 6144, 1, SKINNY_MAX_TOKENS>::unroll(
+        num_tokens, output, mat_a, mat_b, out_stride, stream);
+  } else {
+    throw std::invalid_argument(
+        "bf16_skinny_gemm: unsupported (N, K) pair");
+  }
+}
+
+void bf16_skinny_gemm(
+    torch::stable::Tensor& output,       // [num_tokens, N] bf16
+    torch::stable::Tensor const& mat_a,  // [num_tokens, K] bf16
+    torch::stable::Tensor const& mat_b   // [N, K] bf16
+) {
+  STD_TORCH_CHECK(output.dim() == 2 && mat_a.dim() == 2 && mat_b.dim() == 2);
+  STD_TORCH_CHECK(output.is_cuda() && mat_a.is_cuda() && mat_b.is_cuda(),
+                  "bf16_skinny_gemm: all tensors must be CUDA tensors");
+  STD_TORCH_CHECK(mat_a.is_contiguous() && mat_b.is_contiguous(),
+                  "bf16_skinny_gemm: inputs must be contiguous");
+  // Output may be a column-slice view of a wider padded buffer: unit column
+  // stride, row stride >= N (rows must not overlap).
+  STD_TORCH_CHECK(output.stride(1) == 1,
+                  "bf16_skinny_gemm: output columns must be contiguous");
+
+  const int num_tokens = mat_a.size(0);
+  const int n = mat_b.size(0);
+  const int k = mat_a.size(1);
+
+  STD_TORCH_CHECK(output.size(0) == num_tokens && output.size(1) == n,
+                  "bf16_skinny_gemm: output must be [num_tokens, N]");
+  STD_TORCH_CHECK(mat_b.size(1) == k,
+                  "bf16_skinny_gemm: mat_a and mat_b must share K");
+  STD_TORCH_CHECK(bf16_skinny_gemm_supported(n, k),
+                  "bf16_skinny_gemm: unsupported (N, K) pair");
+  const int64_t out_stride = output.stride(0);
+  STD_TORCH_CHECK(num_tokens == 1 || out_stride >= n,
+                  "bf16_skinny_gemm: output rows overlap");
+  STD_TORCH_CHECK(num_tokens >= 1 && num_tokens <= SKINNY_MAX_TOKENS,
+                  "bf16_skinny_gemm: num_tokens must be in [1, 32]");
+  STD_TORCH_CHECK(
+      mat_a.scalar_type() == torch::headeronly::ScalarType::BFloat16 &&
+          mat_b.scalar_type() == torch::headeronly::ScalarType::BFloat16 &&
+          output.scalar_type() == torch::headeronly::ScalarType::BFloat16,
+      "bf16_skinny_gemm: all tensors must be bfloat16");
+
+  auto stream = get_current_cuda_stream(mat_a.get_device_index());
+  dispatchBf16SkinnyGemm(
+      n, k, num_tokens,
+      reinterpret_cast<__nv_bfloat16*>(output.mutable_data_ptr()),
+      reinterpret_cast<__nv_bfloat16 const*>(mat_a.data_ptr()),
+      reinterpret_cast<__nv_bfloat16 const*>(mat_b.data_ptr()), out_stride,
+      stream);
+}
+
+STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, m) {
+  m.impl("bf16_skinny_gemm", TORCH_BOX(&bf16_skinny_gemm));
+}

--- a/csrc/libtorch_stable/bf16_skinny_gemm_entry.cu
+++ b/csrc/libtorch_stable/bf16_skinny_gemm_entry.cu
@@ -23,6 +23,8 @@ static inline bool bf16_skinny_gemm_supported(int n, int k) {
   // family loses to cuBLAS at larger M).
   if (k == 2048 && n == 2048) return true;  // q_b_proj (TP8)
   if (k == 6144 && n == 2624) return true;  // fused_qkv_a (wire M <= 2 only)
+  if (k == 7168 && n == 2112) return true;  // DSv3.2 fused_qkv_a (M <= 2)
+  if (k == 14336 && n == 7168) return true;  // DSv3.2 eh_proj (M <= 2)
   if (k == 6144 && n == 512) return true;   // shared-expert gate_up (TP8)
   return false;
 }
@@ -82,6 +84,12 @@ static void dispatchBf16SkinnyGemm(int n, int k, int num_tokens,
         num_tokens, output, mat_a, mat_b, out_stride, stream);
   } else if (n == 2624 && k == 6144) {
     SkinnyLoopUnroller<4, 2624, 6144, 1, SKINNY_MAX_TOKENS>::unroll(
+        num_tokens, output, mat_a, mat_b, out_stride, stream);
+  } else if (n == 2112 && k == 7168) {
+    SkinnyLoopUnroller<4, 2112, 7168, 1, SKINNY_MAX_TOKENS>::unroll(
+        num_tokens, output, mat_a, mat_b, out_stride, stream);
+  } else if (n == 7168 && k == 14336) {
+    SkinnyLoopUnroller<2, 7168, 14336, 1, SKINNY_MAX_TOKENS>::unroll(
         num_tokens, output, mat_a, mat_b, out_stride, stream);
   } else if (n == 512 && k == 6144) {
     SkinnyLoopUnroller<4, 512, 6144, 1, SKINNY_MAX_TOKENS>::unroll(

--- a/csrc/libtorch_stable/dsv3_fused_a_gemm.cu
+++ b/csrc/libtorch_stable/dsv3_fused_a_gemm.cu
@@ -740,6 +740,18 @@ template void invokeFusedAGemm<__nv_bfloat16, 2048, 2048, 16>(
     __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens,
     cudaStream_t);
 
+// DSv3.2 q_b_proj TP8 (K=1536 -> N=3072). tile_m=32 keeps 96 CTAs (single
+// wave; tile_m=16's 192 straddle two). Beats cuBLAS 1.6-1.8x at M=1..8 and
+// 1.05-1.18x at M=9..16 on B300/B200; the whole 1..16 range dispatches here
+// (no skinny tier: K=1536 does not fit the GEMV's 128x8 K-step).
+template void invokeFusedAGemm<__nv_bfloat16, 1536, 3072, 8, 32>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens,
+    cudaStream_t);
+
+template void invokeFusedAGemm<__nv_bfloat16, 1536, 3072, 16, 32>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens,
+    cudaStream_t);
+
 void dsv3_fused_a_gemm(torch::stable::Tensor& output,
                        torch::stable::Tensor const& mat_a,
                        torch::stable::Tensor const& mat_b) {
@@ -751,11 +763,12 @@ void dsv3_fused_a_gemm(torch::stable::Tensor& output,
   bool const is_dsv3 = hd_in == 7168 && hd_out == 2112;
   bool const is_glm = hd_in == 6144 && hd_out == 2624;
   bool const is_glm_qb = hd_in == 2048 && hd_out == 2048;
+  bool const is_ds_qb = hd_in == 1536 && hd_out == 3072;
   STD_TORCH_CHECK(num_tokens >= 1 && num_tokens <= 16,
                   "required 1 <= mat_a.shape[0] <= 16");
-  STD_TORCH_CHECK(
-      is_dsv3 || is_glm || is_glm_qb,
-      "supported (hd_in, hd_out): (7168, 2112), (6144, 2624), (2048, 2048)");
+  STD_TORCH_CHECK(is_dsv3 || is_glm || is_glm_qb || is_ds_qb,
+                  "supported (hd_in, hd_out): (7168, 2112), (6144, 2624), "
+                  "(2048, 2048), (1536, 3072)");
   STD_TORCH_CHECK(output.size(0) == num_tokens,
                   "required output.shape[0] == mat_a.shape[0]");
   STD_TORCH_CHECK(output.size(1) == hd_out,
@@ -797,13 +810,21 @@ void dsv3_fused_a_gemm(torch::stable::Tensor& output,
       invokeFusedAGemm<__nv_bfloat16, 6144, 2624, 16, 32>(out, a, b,
                                                           num_tokens, stream);
     }
-  } else {
+  } else if (is_glm_qb) {
     if (num_tokens <= 8) {
       invokeFusedAGemm<__nv_bfloat16, 2048, 2048, 8>(out, a, b, num_tokens,
                                                      stream);
     } else {
       invokeFusedAGemm<__nv_bfloat16, 2048, 2048, 16>(out, a, b, num_tokens,
                                                       stream);
+    }
+  } else {
+    if (num_tokens <= 8) {
+      invokeFusedAGemm<__nv_bfloat16, 1536, 3072, 8, 32>(out, a, b, num_tokens,
+                                                         stream);
+    } else {
+      invokeFusedAGemm<__nv_bfloat16, 1536, 3072, 16, 32>(out, a, b,
+                                                          num_tokens, stream);
     }
   }
 }

--- a/csrc/libtorch_stable/dsv3_fused_a_gemm.cu
+++ b/csrc/libtorch_stable/dsv3_fused_a_gemm.cu
@@ -391,7 +391,7 @@ struct MmaComputer {
   static constexpr int n_iter_cnt =
       (tile_n + 7) /
       8;  // Possible to have non-1 n_iter_cnt for ab_swap m16 case.
-  static_assert(m_iter_cnt == 1);
+  static_assert(m_iter_cnt == 1 || m_iter_cnt == 2);
   static_assert(n_iter_cnt == 1 || n_iter_cnt == 2);
 
   __device__ MmaComputer(bf16_t* gmem_c_local_, bf16_t* smem_a_,
@@ -416,13 +416,18 @@ struct MmaComputer {
  public:
   __device__ void prepare() {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  // Fragment addressing is per 16-row ldmatrix tile; m_iter selects the
+  // 16-row half within tile_m.
   #pragma unroll
-    for (int i = 0; i < k_phase_cnt; i++) {
-      int linear_idx = (lane_idx % 16) + (lane_idx / 16) * 128 + i * 256;
-      int m_idx = linear_idx % tile_m;
-      int k_idx = linear_idx / tile_m + warp_k_offset_in_tile_k;
-      k_idx = apply_swizzle_343_on_elem_row_col<bf16_t>(m_idx, k_idx);
-      a_smem_offsets[0][i] = m_idx * tile_k + k_idx;
+    for (int m = 0; m < m_iter_cnt; m++) {
+  #pragma unroll
+      for (int i = 0; i < k_phase_cnt; i++) {
+        int linear_idx = (lane_idx % 16) + (lane_idx / 16) * 128 + i * 256;
+        int m_idx = linear_idx % 16 + m * 16;
+        int k_idx = linear_idx / 16 + warp_k_offset_in_tile_k;
+        k_idx = apply_swizzle_343_on_elem_row_col<bf16_t>(m_idx, k_idx);
+        a_smem_offsets[m][i] = m_idx * tile_k + k_idx;
+      }
     }
   #pragma unroll
     for (int n_iter_idx = 0; n_iter_idx < n_iter_cnt; n_iter_idx++) {
@@ -446,11 +451,14 @@ struct MmaComputer {
       wait_barrier(smem_barrier + 0 + stage_idx * 2, phase_bit);
 
   #pragma unroll
-      for (int i = 0; i < k_phase_cnt; i++) {
-        int smem_offset = a_smem_offsets[0][i];
-        bf16_t* smem_ptr_this_iter =
-            smem_a + stage_idx * tile_m * tile_k + smem_offset;
-        ldsm_x4(smem_ptr_this_iter, reinterpret_cast<uint32_t*>(a_reg[0][i]));
+      for (int m = 0; m < m_iter_cnt; m++) {
+  #pragma unroll
+        for (int i = 0; i < k_phase_cnt; i++) {
+          int smem_offset = a_smem_offsets[m][i];
+          bf16_t* smem_ptr_this_iter =
+              smem_a + stage_idx * tile_m * tile_k + smem_offset;
+          ldsm_x4(smem_ptr_this_iter, reinterpret_cast<uint32_t*>(a_reg[m][i]));
+        }
       }
 
   #pragma unroll
@@ -469,9 +477,12 @@ struct MmaComputer {
       for (int k_iter_idx = 0; k_iter_idx < k_phase_cnt; k_iter_idx++) {
   #pragma unroll
         for (int n_iter_idx = 0; n_iter_idx < n_iter_cnt; n_iter_idx++) {
-          hmma_16_8_16_f32acc_bf16ab(
-              acc_reg[0][n_iter_idx], a_reg[0][k_iter_idx],
-              b_reg[n_iter_idx][k_iter_idx], acc_reg[0][n_iter_idx]);
+  #pragma unroll
+          for (int m = 0; m < m_iter_cnt; m++) {
+            hmma_16_8_16_f32acc_bf16ab(
+                acc_reg[m][n_iter_idx], a_reg[m][k_iter_idx],
+                b_reg[n_iter_idx][k_iter_idx], acc_reg[m][n_iter_idx]);
+          }
         }
       }
       ::arrive_barrier(smem_barrier + 1 + stage_idx * 2);
@@ -486,14 +497,14 @@ struct MmaComputer {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
     asm volatile("bar.sync %0, %1;" : : "r"(1), "r"(thread_cnt));
     // reorganize the acc_reg
-    constexpr int thread_m = 2;
+    constexpr int thread_m = 2 * m_iter_cnt;
     constexpr int thread_n = 2 * n_iter_cnt;
     constexpr int cta_mma_n = n_iter_cnt * 8;
     float acc_reg_reorg[thread_m][thread_n];
 
     for (int i = 0; i < thread_m; i++) {
       for (int j = 0; j < thread_n; j++) {
-        acc_reg_reorg[i][j] = acc_reg[0][j / 2][(j % 2) + (i * 2)];
+        acc_reg_reorg[i][j] = acc_reg[i / 2][j / 2][(j % 2) + (i % 2) * 2];
       }
     }
 
@@ -514,7 +525,8 @@ struct MmaComputer {
     for (int m_idx_thread = 0; m_idx_thread < thread_m; m_idx_thread++) {
   #pragma unroll
       for (int n_idx_thread = 0; n_idx_thread < thread_n; n_idx_thread++) {
-        int m_idx = (lane_idx / 4) + m_idx_thread * 8;
+        int m_idx =
+            (lane_idx / 4) + (m_idx_thread % 2) * 8 + (m_idx_thread / 2) * 16;
         int n_idx =
             ((lane_idx % 4) * 2) + (n_idx_thread % 2) + (n_idx_thread / 2) * 8;
         smem_c[cosize_smem_c * warp_idx + smem_c_index_func(m_idx, n_idx)] =
@@ -587,7 +599,7 @@ __global__ __launch_bounds__(256, 1) void fused_a_gemm_kernel(
   static_assert(
       tile_k == 128 || tile_k == 256 || tile_k == 512 ||
       tile_k == 1024);  // tile_k must be larger than 64 since 4 warp splitK.
-  static_assert(tile_m == 16);
+  static_assert(tile_m == 16 || tile_m == 32);
   constexpr int g2s_vec_bytes = 16;
   constexpr int a_elem_bytes = 2;
   constexpr int b_elem_bytes = 2;
@@ -647,7 +659,7 @@ __global__ __launch_bounds__(256, 1) void fused_a_gemm_kernel(
 #endif
 }
 
-template <typename T, int kHdIn, int kHdOut, int kTileN>
+template <typename T, int kHdIn, int kHdOut, int kTileN, int kTileM = 16>
 void invokeFusedAGemm(T* output, T const* mat_a, T const* mat_b, int num_tokens,
                       cudaStream_t const stream) {
   constexpr int gemm_m = kHdOut;  // 2112
@@ -655,7 +667,7 @@ void invokeFusedAGemm(T* output, T const* mat_a, T const* mat_b, int num_tokens,
   constexpr int gemm_k = kHdIn;   // 7168
   constexpr int batch_size = 1;
   std::swap(mat_a, mat_b);
-  constexpr int tile_m = 16;
+  constexpr int tile_m = kTileM;
   constexpr int tile_n = kTileN;                        // 8 or 16
   constexpr int tile_k = std::max(256, 1024 / tile_n);  // 256
   constexpr int max_stage_cnt =
@@ -702,6 +714,20 @@ template void invokeFusedAGemm<__nv_bfloat16, 7168, 2112, 16>(
     __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens,
     cudaStream_t);
 
+// GLM-5.2 fused_qkv_a (K=6144 -> N=2624). tile_m=32 so the grid is
+// 2624/32 = 82 CTAs, a single wave on B300 (148 SMs); tile_m=16's 164 CTAs
+// straddle two waves and drop to 2.9 TB/s vs 3.9-4.0 here. Beats cuBLAS
+// at every decode M: 1.11-1.15x for M<=8 (tile_n=8), 1.12x at M=16
+// (tile_n=16). The M<=2 dispatch still belongs to bf16_skinny_gemm
+// (4.5 TB/s).
+template void invokeFusedAGemm<__nv_bfloat16, 6144, 2624, 8, 32>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens,
+    cudaStream_t);
+
+template void invokeFusedAGemm<__nv_bfloat16, 6144, 2624, 16, 32>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens,
+    cudaStream_t);
+
 void dsv3_fused_a_gemm(torch::stable::Tensor& output,
                        torch::stable::Tensor const& mat_a,
                        torch::stable::Tensor const& mat_b) {
@@ -710,12 +736,12 @@ void dsv3_fused_a_gemm(torch::stable::Tensor& output,
   int const hd_in = mat_a.size(1);
   int const hd_out = mat_b.size(1);
 
-  constexpr int kHdIn = 7168;
-  constexpr int kHdOut = 2112;
+  bool const is_dsv3 = hd_in == 7168 && hd_out == 2112;
+  bool const is_glm = hd_in == 6144 && hd_out == 2624;
   STD_TORCH_CHECK(num_tokens >= 1 && num_tokens <= 16,
                   "required 1 <= mat_a.shape[0] <= 16");
-  STD_TORCH_CHECK(hd_in == kHdIn, "required mat_a.shape[1] == 7168");
-  STD_TORCH_CHECK(hd_out == kHdOut, "required mat_b.shape[1] == 2112");
+  STD_TORCH_CHECK(is_dsv3 || is_glm,
+                  "supported (hd_in, hd_out): (7168, 2112), (6144, 2624)");
   STD_TORCH_CHECK(output.size(0) == num_tokens,
                   "required output.shape[0] == mat_a.shape[0]");
   STD_TORCH_CHECK(output.size(1) == hd_out,
@@ -738,18 +764,25 @@ void dsv3_fused_a_gemm(torch::stable::Tensor& output,
   STD_TORCH_CHECK(getSMVersion() >= 90, "required CUDA ARCH >= SM_90");
 
   auto stream = get_current_cuda_stream(mat_a.get_device_index());
-  if (num_tokens <= 8) {
-    invokeFusedAGemm<__nv_bfloat16, kHdIn, kHdOut, 8>(
-        reinterpret_cast<__nv_bfloat16*>(output.mutable_data_ptr()),
-        reinterpret_cast<__nv_bfloat16 const*>(mat_a.data_ptr()),
-        reinterpret_cast<__nv_bfloat16 const*>(mat_b.data_ptr()), num_tokens,
-        stream);
+  auto* out = reinterpret_cast<__nv_bfloat16*>(output.mutable_data_ptr());
+  auto* a = reinterpret_cast<__nv_bfloat16 const*>(mat_a.data_ptr());
+  auto* b = reinterpret_cast<__nv_bfloat16 const*>(mat_b.data_ptr());
+  if (is_dsv3) {
+    if (num_tokens <= 8) {
+      invokeFusedAGemm<__nv_bfloat16, 7168, 2112, 8>(out, a, b, num_tokens,
+                                                     stream);
+    } else {
+      invokeFusedAGemm<__nv_bfloat16, 7168, 2112, 16>(out, a, b, num_tokens,
+                                                      stream);
+    }
   } else {
-    invokeFusedAGemm<__nv_bfloat16, kHdIn, kHdOut, 16>(
-        reinterpret_cast<__nv_bfloat16*>(output.mutable_data_ptr()),
-        reinterpret_cast<__nv_bfloat16 const*>(mat_a.data_ptr()),
-        reinterpret_cast<__nv_bfloat16 const*>(mat_b.data_ptr()), num_tokens,
-        stream);
+    if (num_tokens <= 8) {
+      invokeFusedAGemm<__nv_bfloat16, 6144, 2624, 8, 32>(out, a, b, num_tokens,
+                                                         stream);
+    } else {
+      invokeFusedAGemm<__nv_bfloat16, 6144, 2624, 16, 32>(out, a, b,
+                                                          num_tokens, stream);
+    }
   }
 }
 

--- a/csrc/libtorch_stable/dsv3_fused_a_gemm.cu
+++ b/csrc/libtorch_stable/dsv3_fused_a_gemm.cu
@@ -728,6 +728,18 @@ template void invokeFusedAGemm<__nv_bfloat16, 6144, 2624, 16, 32>(
     __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens,
     cudaStream_t);
 
+// GLM-5.2 q_b_proj TP8 (K=2048 -> N=2048). tile_m=16 keeps 128 CTAs (already
+// a single wave) and measures ahead of tile_m=32 here. Beats cuBLAS
+// 1.79-1.87x at M=3..8 (tile_n=8) and 1.19-1.30x at M=9..16 (tile_n=16);
+// M<=2 belongs to bf16_skinny_gemm, M>=20 to cuBLAS.
+template void invokeFusedAGemm<__nv_bfloat16, 2048, 2048, 8>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens,
+    cudaStream_t);
+
+template void invokeFusedAGemm<__nv_bfloat16, 2048, 2048, 16>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens,
+    cudaStream_t);
+
 void dsv3_fused_a_gemm(torch::stable::Tensor& output,
                        torch::stable::Tensor const& mat_a,
                        torch::stable::Tensor const& mat_b) {
@@ -738,10 +750,12 @@ void dsv3_fused_a_gemm(torch::stable::Tensor& output,
 
   bool const is_dsv3 = hd_in == 7168 && hd_out == 2112;
   bool const is_glm = hd_in == 6144 && hd_out == 2624;
+  bool const is_glm_qb = hd_in == 2048 && hd_out == 2048;
   STD_TORCH_CHECK(num_tokens >= 1 && num_tokens <= 16,
                   "required 1 <= mat_a.shape[0] <= 16");
-  STD_TORCH_CHECK(is_dsv3 || is_glm,
-                  "supported (hd_in, hd_out): (7168, 2112), (6144, 2624)");
+  STD_TORCH_CHECK(
+      is_dsv3 || is_glm || is_glm_qb,
+      "supported (hd_in, hd_out): (7168, 2112), (6144, 2624), (2048, 2048)");
   STD_TORCH_CHECK(output.size(0) == num_tokens,
                   "required output.shape[0] == mat_a.shape[0]");
   STD_TORCH_CHECK(output.size(1) == hd_out,
@@ -775,13 +789,21 @@ void dsv3_fused_a_gemm(torch::stable::Tensor& output,
       invokeFusedAGemm<__nv_bfloat16, 7168, 2112, 16>(out, a, b, num_tokens,
                                                       stream);
     }
-  } else {
+  } else if (is_glm) {
     if (num_tokens <= 8) {
       invokeFusedAGemm<__nv_bfloat16, 6144, 2624, 8, 32>(out, a, b, num_tokens,
                                                          stream);
     } else {
       invokeFusedAGemm<__nv_bfloat16, 6144, 2624, 16, 32>(out, a, b,
                                                           num_tokens, stream);
+    }
+  } else {
+    if (num_tokens <= 8) {
+      invokeFusedAGemm<__nv_bfloat16, 2048, 2048, 8>(out, a, b, num_tokens,
+                                                     stream);
+    } else {
+      invokeFusedAGemm<__nv_bfloat16, 2048, 2048, 16>(out, a, b, num_tokens,
+                                                      stream);
     }
   }
 }

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -330,6 +330,10 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
   // conditionally compiled so impl registration is in source file
   ops.def("fp32_router_gemm(Tensor! output, Tensor mat_a, Tensor mat_b) -> ()");
 
+  // BF16 skinny GEMM (M<=32, weight-BW-bound shapes, e.g. MTP eh_proj).
+  // conditionally compiled so impl registration is in source file
+  ops.def("bf16_skinny_gemm(Tensor! output, Tensor mat_a, Tensor mat_b) -> ()");
+
   // reorder weight for AllSpark Ampere W8A16 Fused Gemm kernel
   ops.def(
       "rearrange_kn_weight_as_n32k16_order(Tensor b_qweight, Tensor b_scales, "

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2208,6 +2208,20 @@ def fp32_router_gemm(
     return output
 
 
+def bf16_skinny_gemm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    """Skinny bf16 GEMM (M<=32): x [M, K] @ weight [N, K]^T -> [M, N].
+
+    Single block-per-column kernel with fp32 accumulation; replaces cuBLAS
+    splitK for weight-bandwidth-bound decode shapes (e.g. MTP eh_proj).
+    """
+    output = torch.empty((x.shape[0], weight.shape[0]), dtype=x.dtype, device=x.device)
+    torch.ops._C.bf16_skinny_gemm(output, x, weight)
+    return output
+
+
 if hasattr(torch.ops, "_C") and hasattr(torch.ops._C, "fp32_router_gemm"):
 
     @register_fake("_C::fp32_router_gemm")

--- a/vllm/models/deepseek_v32/nvidia/attention.py
+++ b/vllm/models/deepseek_v32/nvidia/attention.py
@@ -338,14 +338,21 @@ class DeepseekV32Attention(MLAAttention):
         # bf16_skinny_gemm wins at M <= 2, dsv3_fused_a_gemm at 3 <= M <= 16,
         # cuBLAS above. Blackwell-only: the boundaries and the fused_a
         # tile_m=32 choice are tied to the 148/152-SM single-wave geometry.
+        # Quantized linear methods may not register .weight until
+        # process_weights_after_loading (e.g. compressed-tensors NVFP4
+        # registers weight_packed at init) — probe with getattr.
+        qkv_a_weight = getattr(self.fused_qkv_a_proj, "weight", None)
+        q_b_weight = getattr(self.q_b_proj, "weight", None)
         self._skinny_gemm_ok = (
             current_platform.is_device_capability_family(100)
             and hasattr(torch.ops._C, "bf16_skinny_gemm")
             and hasattr(torch.ops._C, "dsv3_fused_a_gemm")
-            and self.fused_qkv_a_proj.weight.dtype == torch.bfloat16
-            and tuple(self.fused_qkv_a_proj.weight.shape) == (2624, 6144)
-            and self.q_b_proj.weight.dtype == torch.bfloat16
-            and tuple(self.q_b_proj.weight.shape) == (2048, 2048)
+            and qkv_a_weight is not None
+            and qkv_a_weight.dtype == torch.bfloat16
+            and tuple(qkv_a_weight.shape) == (2624, 6144)
+            and q_b_weight is not None
+            and q_b_weight.dtype == torch.bfloat16
+            and tuple(q_b_weight.shape) == (2048, 2048)
         )
 
         # Lightning indexer uses its own RoPE; interleave maps to non-NeoX.

--- a/vllm/models/deepseek_v32/nvidia/attention.py
+++ b/vllm/models/deepseek_v32/nvidia/attention.py
@@ -4,12 +4,14 @@ import torch
 import torch.nn as nn
 from transformers import DeepseekV2Config, DeepseekV3Config
 
+import vllm._custom_ops as ops
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.model_executor.layers.layernorm import LayerNorm, RMSNorm
+from vllm.platforms import current_platform
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
     MergedColumnParallelLinear,
@@ -331,6 +333,21 @@ class DeepseekV32Attention(MLAAttention):
             rope_parameters=config.rope_parameters,
             is_neox_style=False,
         )
+        # Decode-M GEMM dispatch for the bf16 A/B projections, measured on
+        # B300 and B200 (graph replay + rotating weights vs fp64):
+        # bf16_skinny_gemm wins at M <= 2, dsv3_fused_a_gemm at 3 <= M <= 16,
+        # cuBLAS above. Blackwell-only: the boundaries and the fused_a
+        # tile_m=32 choice are tied to the 148/152-SM single-wave geometry.
+        self._skinny_gemm_ok = (
+            current_platform.is_device_capability_family(100)
+            and hasattr(torch.ops._C, "bf16_skinny_gemm")
+            and hasattr(torch.ops._C, "dsv3_fused_a_gemm")
+            and self.fused_qkv_a_proj.weight.dtype == torch.bfloat16
+            and tuple(self.fused_qkv_a_proj.weight.shape) == (2624, 6144)
+            and self.q_b_proj.weight.dtype == torch.bfloat16
+            and tuple(self.q_b_proj.weight.shape) == (2048, 2048)
+        )
+
         # Lightning indexer uses its own RoPE; interleave maps to non-NeoX.
         self.indexer_rope_emb = get_rope(
             qk_rope_head_dim,
@@ -339,13 +356,24 @@ class DeepseekV32Attention(MLAAttention):
             is_neox_style=not getattr(config, "indexer_rope_interleave", False),
         )
 
+    def _decode_m_gemm(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+        """x @ weight.T for decode M <= 16 (see _skinny_gemm_ok)."""
+        if x.shape[0] <= 2:
+            return ops.bf16_skinny_gemm(x, weight)
+        out = torch.empty((x.shape[0], weight.shape[0]), dtype=x.dtype, device=x.device)
+        ops.dsv3_fused_a_gemm(out, x, weight.t())
+        return out
+
     def forward(  # type: ignore[override]
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         # Captured: A-projections (+ indexer A-GEMM on indexer layers).
-        qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
+        if self._skinny_gemm_ok and hidden_states.shape[0] <= 16:
+            qkv_lora = self._decode_m_gemm(hidden_states, self.fused_qkv_a_proj.weight)
+        else:
+            qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
         q_c, kv_c, k_pe = qkv_lora.split(
             [self.q_lora_rank, self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
         )
@@ -451,7 +479,11 @@ class DeepseekV32Attention(MLAAttention):
             index_rope_interleave=self._index_rope_interleave,
         )
 
-        q = self.q_b_proj(q_c)[0].view(-1, self.num_local_heads, self.qk_head_dim)
+        if self._skinny_gemm_ok and q_c.shape[0] <= 16:
+            q = self._decode_m_gemm(q_c, self.q_b_proj.weight)
+        else:
+            q = self.q_b_proj(q_c)[0]
+        q = q.view(-1, self.num_local_heads, self.qk_head_dim)
         q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
         q_nope = q_nope.transpose(0, 1)
         ql_nope = torch.bmm(q_nope, self.W_UK_T).transpose(0, 1)

--- a/vllm/models/deepseek_v32/nvidia/attention.py
+++ b/vllm/models/deepseek_v32/nvidia/attention.py
@@ -335,24 +335,33 @@ class DeepseekV32Attention(MLAAttention):
         )
         # Decode-M GEMM dispatch for the bf16 A/B projections, measured on
         # B300 and B200 (graph replay + rotating weights vs fp64):
-        # bf16_skinny_gemm wins at M <= 2, dsv3_fused_a_gemm at 3 <= M <= 16,
-        # cuBLAS above. Blackwell-only: the boundaries and the fused_a
-        # tile_m=32 choice are tied to the 148/152-SM single-wave geometry.
+        # bf16_skinny_gemm for M <= skinny_max, dsv3_fused_a_gemm up to
+        # M = 16, cuBLAS above. Blackwell-only: the boundaries and the
+        # fused_a tile choices are tied to the 148/152-SM single-wave
+        # geometry. DSv3.2 q_b has no skinny tier (K=1536 does not fit the
+        # GEMV's 128x8 K-step; fused_a still wins 1.6-1.8x there).
         # Quantized linear methods may not register .weight until
         # process_weights_after_loading (e.g. compressed-tensors NVFP4
         # registers weight_packed at init) — probe with getattr.
-        qkv_a_weight = getattr(self.fused_qkv_a_proj, "weight", None)
-        q_b_weight = getattr(self.q_b_proj, "weight", None)
-        self._skinny_gemm_ok = (
+        # (N, K) -> skinny_max
+        qkv_a_dispatch = {(2624, 6144): 2, (2112, 7168): 2}
+        q_b_dispatch = {(2048, 2048): 2, (3072, 1536): 0}
+        ok = (
             current_platform.is_device_capability_family(100)
             and hasattr(torch.ops._C, "bf16_skinny_gemm")
             and hasattr(torch.ops._C, "dsv3_fused_a_gemm")
-            and qkv_a_weight is not None
-            and qkv_a_weight.dtype == torch.bfloat16
-            and tuple(qkv_a_weight.shape) == (2624, 6144)
-            and q_b_weight is not None
-            and q_b_weight.dtype == torch.bfloat16
-            and tuple(q_b_weight.shape) == (2048, 2048)
+        )
+        qkv_a_weight = getattr(self.fused_qkv_a_proj, "weight", None)
+        q_b_weight = getattr(self.q_b_proj, "weight", None)
+        self._qkv_a_skinny_max = (
+            qkv_a_dispatch.get(tuple(qkv_a_weight.shape))
+            if ok and qkv_a_weight is not None and qkv_a_weight.dtype == torch.bfloat16
+            else None
+        )
+        self._q_b_skinny_max = (
+            q_b_dispatch.get(tuple(q_b_weight.shape))
+            if ok and q_b_weight is not None and q_b_weight.dtype == torch.bfloat16
+            else None
         )
 
         # Lightning indexer uses its own RoPE; interleave maps to non-NeoX.
@@ -363,9 +372,11 @@ class DeepseekV32Attention(MLAAttention):
             is_neox_style=not getattr(config, "indexer_rope_interleave", False),
         )
 
-    def _decode_m_gemm(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
-        """x @ weight.T for decode M <= 16 (see _skinny_gemm_ok)."""
-        if x.shape[0] <= 2:
+    def _decode_m_gemm(
+        self, x: torch.Tensor, weight: torch.Tensor, skinny_max: int
+    ) -> torch.Tensor:
+        """x @ weight.T for decode M <= 16."""
+        if x.shape[0] <= skinny_max:
             return ops.bf16_skinny_gemm(x, weight)
         out = torch.empty((x.shape[0], weight.shape[0]), dtype=x.dtype, device=x.device)
         ops.dsv3_fused_a_gemm(out, x, weight.t())
@@ -377,8 +388,12 @@ class DeepseekV32Attention(MLAAttention):
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         # Captured: A-projections (+ indexer A-GEMM on indexer layers).
-        if self._skinny_gemm_ok and hidden_states.shape[0] <= 16:
-            qkv_lora = self._decode_m_gemm(hidden_states, self.fused_qkv_a_proj.weight)
+        if self._qkv_a_skinny_max is not None and hidden_states.shape[0] <= 16:
+            qkv_lora = self._decode_m_gemm(
+                hidden_states,
+                self.fused_qkv_a_proj.weight,
+                self._qkv_a_skinny_max,
+            )
         else:
             qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
         q_c, kv_c, k_pe = qkv_lora.split(
@@ -486,8 +501,8 @@ class DeepseekV32Attention(MLAAttention):
             index_rope_interleave=self._index_rope_interleave,
         )
 
-        if self._skinny_gemm_ok and q_c.shape[0] <= 16:
-            q = self._decode_m_gemm(q_c, self.q_b_proj.weight)
+        if self._q_b_skinny_max is not None and q_c.shape[0] <= 16:
+            q = self._decode_m_gemm(q_c, self.q_b_proj.weight, self._q_b_skinny_max)
         else:
             q = self.q_b_proj(q_c)[0]
         q = q.view(-1, self.num_local_heads, self.qk_head_dim)

--- a/vllm/models/deepseek_v32/nvidia/mtp.py
+++ b/vllm/models/deepseek_v32/nvidia/mtp.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Iterable
 import torch
 import torch.nn as nn
 
+import vllm._custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import VllmConfig
 from vllm.distributed import tensor_model_parallel_all_reduce
@@ -50,6 +51,12 @@ class DeepseekV32MultiTokenPredictorLayer(nn.Module):
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        # bf16 skinny GEMM for the (6144, 12288) eh_proj: wins only at M <= 3
+        # on B300 (23.3/26.1/27.4us vs cuBLAS ~27.6); cuBLAS splitK holds
+        # from M=4 up (151MB weight streams at 5.6TB/s there).
+        self._eh_skinny_ok = current_platform.is_device_capability_family(
+            100
+        ) and hasattr(torch.ops._C, "bf16_skinny_gemm")
 
         topk_indices_buffer = torch.empty(
             vllm_config.scheduler_config.max_num_batched_tokens,
@@ -85,7 +92,14 @@ class DeepseekV32MultiTokenPredictorLayer(nn.Module):
             self.hnorm.weight,
             self.enorm.variance_epsilon,
         )
-        hidden_states = self.eh_proj(eh_input)
+        if (
+            self._eh_skinny_ok
+            and eh_input.shape[0] <= 3
+            and self.eh_proj.weight.dtype == torch.bfloat16
+        ):
+            hidden_states = ops.bf16_skinny_gemm(eh_input, self.eh_proj.weight)
+        else:
+            hidden_states = self.eh_proj(eh_input)
         hidden_states, residual = self.mtp_block(
             positions=positions, hidden_states=hidden_states, residual=None
         )

--- a/vllm/models/deepseek_v32/nvidia/mtp.py
+++ b/vllm/models/deepseek_v32/nvidia/mtp.py
@@ -51,17 +51,18 @@ class DeepseekV32MultiTokenPredictorLayer(nn.Module):
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
-        # bf16 skinny GEMM for the (6144, 12288) eh_proj: wins only at M <= 3
-        # on B300 (23.3/26.1/27.4us vs cuBLAS ~27.6); cuBLAS splitK holds
-        # from M=4 up (151MB weight streams at 5.6TB/s there).
-        # Shape-gated: the kernel only instantiates the GLM-5.2 geometry;
-        # DeepSeek-V3-family (hidden 7168 -> weight (7168, 14336)) must stay
-        # on cuBLAS.
-        self._eh_skinny_ok = (
-            current_platform.is_device_capability_family(100)
+        # bf16 skinny GEMM for the eh_proj, B300+B200 measured: GLM-5.2
+        # (6144, 12288) wins at M <= 3, DSv3.2 (7168, 14336) at M <= 2;
+        # cuBLAS holds above (the 151/205MB weights stream at ~5.7TB/s).
+        eh_dispatch = {(6144, 12288): 3, (7168, 14336): 2}
+        eh_weight = getattr(self.eh_proj, "weight", None)
+        self._eh_skinny_max = (
+            eh_dispatch.get(tuple(eh_weight.shape), 0)
+            if current_platform.is_device_capability_family(100)
             and hasattr(torch.ops._C, "bf16_skinny_gemm")
-            and self.eh_proj.weight.dtype == torch.bfloat16
-            and tuple(self.eh_proj.weight.shape) == (6144, 12288)
+            and eh_weight is not None
+            and eh_weight.dtype == torch.bfloat16
+            else 0
         )
 
         topk_indices_buffer = torch.empty(
@@ -99,8 +100,7 @@ class DeepseekV32MultiTokenPredictorLayer(nn.Module):
             self.enorm.variance_epsilon,
         )
         if (
-            self._eh_skinny_ok
-            and eh_input.shape[0] <= 3
+            eh_input.shape[0] <= self._eh_skinny_max
             and eh_input.dtype == torch.bfloat16
         ):
             hidden_states = ops.bf16_skinny_gemm(eh_input, self.eh_proj.weight)

--- a/vllm/models/deepseek_v32/nvidia/mtp.py
+++ b/vllm/models/deepseek_v32/nvidia/mtp.py
@@ -54,9 +54,15 @@ class DeepseekV32MultiTokenPredictorLayer(nn.Module):
         # bf16 skinny GEMM for the (6144, 12288) eh_proj: wins only at M <= 3
         # on B300 (23.3/26.1/27.4us vs cuBLAS ~27.6); cuBLAS splitK holds
         # from M=4 up (151MB weight streams at 5.6TB/s there).
-        self._eh_skinny_ok = current_platform.is_device_capability_family(
-            100
-        ) and hasattr(torch.ops._C, "bf16_skinny_gemm")
+        # Shape-gated: the kernel only instantiates the GLM-5.2 geometry;
+        # DeepSeek-V3-family (hidden 7168 -> weight (7168, 14336)) must stay
+        # on cuBLAS.
+        self._eh_skinny_ok = (
+            current_platform.is_device_capability_family(100)
+            and hasattr(torch.ops._C, "bf16_skinny_gemm")
+            and self.eh_proj.weight.dtype == torch.bfloat16
+            and tuple(self.eh_proj.weight.shape) == (6144, 12288)
+        )
 
         topk_indices_buffer = torch.empty(
             vllm_config.scheduler_config.max_num_batched_tokens,
@@ -95,7 +101,7 @@ class DeepseekV32MultiTokenPredictorLayer(nn.Module):
         if (
             self._eh_skinny_ok
             and eh_input.shape[0] <= 3
-            and self.eh_proj.weight.dtype == torch.bfloat16
+            and eh_input.dtype == torch.bfloat16
         ):
             hidden_states = ops.bf16_skinny_gemm(eh_input, self.eh_proj.weight)
         else:


### PR DESCRIPTION
## Purpose

At decode batch sizes (M ≤ 16, MTP draft steps run at M = 1 + k per request) the bf16 dense GEMMs in the DeepseekV32/GLM-5.2 attention path and the MTP `eh_proj` are latency-bound, and cuBLAS's picks are not optimal there. This PR adds a measured decode-M dispatch on Blackwell (`is_device_capability_family(100)`):

- **`bf16_skinny_gemm`** (new kernel, `csrc/libtorch_stable/`): a one-wave GEMV-family kernel for very small M, with PDL support (trigger fired after the stores).
- **`dsv3_fused_a_gemm`**: extended with `tile_m=32` and the GLM-5.2 qkv_a `(2624, 6144)` / q_b `(2048, 2048)` shapes for the mid range.

Dispatch (measured on B300 and B200 via graph replay with rotating weights, verified vs fp64 reference):

| projection | shape (N, K) | skinny GEMV | fused_a | cuBLAS |
|---|---|---|---|---|
| fused_qkv_a (TP8) | (2624, 6144) | M ≤ 2 | 3 ≤ M ≤ 16 | above |
| q_b (TP8) | (2048, 2048) | M ≤ 2 | 3 ≤ M ≤ 16 | above |
| MTP eh_proj GLM-5.2 | (6144, 12288) | M ≤ 3 (23.3/26.1/27.4 µs vs cuBLAS ~27.6) | — | M ≥ 4 |
| MTP eh_proj DSv3.2 | (7168, 14336) | M ≤ 2 | — | above |

Unsupported shapes/dtypes/platforms fall back to the existing paths; quantized layers (e.g. compressed-tensors NVFP4, which registers `weight_packed` at init) are detected via `getattr` and keep the fast path disabled.

## Test Plan / Results

- Kernel-level: DRAM-cold (rotating weights) benches on B300 (sm_103) and B200, correctness vs fp64 reference at all wired (N, K, M).
- E2E: GLM-5.2-NVFP4 TP8 + MTP k=5 on 8×B300, serving benchmarks at concurrency 1 and 16 — numerically identical outputs, per-step decode latency improvement in the µs-per-GEMM range above.
- Not yet run on this exact upstream tree (ported from an internal branch tracking main) — hence **draft** until upstream-tree GPU CI / local A/B is done.

## Why this is not duplicating an existing PR

Searched open PRs for `skinny gemm` (only ROCm/GFX12 work: #45559, #40977), `dsv3_fused_a` (none), and DeepSeek decode GEMM dispatch (none touching the bf16 A/B projections). No overlap.

## AI assistance disclosure

This PR was developed with AI assistance (Claude): kernel tuning sweeps, dispatch wiring, and shape/robustness guards. Every changed line has been human-reviewed, and the E2E validation on B300 was run and checked by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)