### PR TITLE
[XPU][UT] Fix vision_tower.vision_model weight mapping for multimodal Transformers backend

### DIFF
--- a/vllm/model_executor/models/transformers/base.py
+++ b/vllm/model_executor/models/transformers/base.py
@@ -337,6 +337,20 @@ class Base(
         nested_lm_head_pattern = re.compile(r"^model\.(.+\.)*(lm_head.+)")
         orig_to_new_regex[nested_lm_head_pattern] = r"\2"
 
+        # Some multimodal checkpoints nest vision tower weights under
+        # vision_tower.vision_model.*, while runtime modules expose
+        # vision_tower.* directly. Normalize these names when a vision tower is
+        # present to avoid missing-parameter load failures.
+        if getattr(self.config, "vision_config", None) is not None and any(
+            name == "vision_tower" for name, _ in self.model.named_children()
+        ):
+            orig_to_new_regex[
+                re.compile(r"^model\.vision_tower\.vision_model\.(.+)$")
+            ] = r"model.vision_tower.\1"
+            orig_to_new_regex[re.compile(r"^vision_tower\.vision_model\.(.+)$")] = (
+                r"vision_tower.\1"
+            )
+
         # Apply mapping to quantization config if needed
         self._maybe_apply_model_mapping()
 


### PR DESCRIPTION
## Summary

This PR fixes a multimodal Transformers backend weight-loading failure by remapping `vision_tower.vision_model.*` checkpoint weights to the runtime `vision_tower.*` module names.

## What changed

- Add `vision_tower.vision_model.*` weight-name remapping in the Transformers backend
- Apply the remapping only for multimodal models that expose a `vision_tower`
- Allow affected multimodal models to load vision tower weights correctly

## Root cause

Some multimodal checkpoints store vision tower weights under `vision_tower.vision_model.*`, but `TransformersMultiModalForCausalLM` exposes those parameters directly under `vision_tower.*`.

Without this PR, weight loading can fail because vLLM tries to resolve a non-existent `model.vision_tower.vision_model` module, typically surfacing as:

```text
ValueError: There is no module or parameter named 'model.vision_tower.vision_model' in TransformersMultiModalForCausalLM.
```

## Example to reproduce

```bash
ZE_AFFINITY_MASK=0 VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -sv tests/models/multimodal/generation/test_common.py::test_single_image_models[gemma3-transformers-test_case75]
