### PR TITLE
[Bugfix] Fix KV cache metrics event handling

### DIFF
--- a/tests/v1/core/test_kv_cache_metrics.py
+++ b/tests/v1/core/test_kv_cache_metrics.py
@@ -5,11 +5,23 @@ from unittest.mock import patch
 
 import pytest
 
+from vllm.sampling_params import SamplingParams
+from vllm.utils.hashing import sha256
+from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_metrics import (
     BlockMetricsState,
     KVCacheMetricsCollector,
 )
-from vllm.v1.core.kv_cache_utils import KVCacheBlock
+from vllm.v1.core.kv_cache_utils import (
+    KVCacheBlock,
+    get_request_block_hasher,
+    init_none_hash,
+)
+from vllm.v1.request import Request
+
+from .utils import create_scheduler
+
+BLOCK_SIZE = 16
 
 
 class TestBlockMetricsState:
@@ -191,6 +203,114 @@ class TestKVCacheMetricsCollector:
         events = c.drain_events()
         assert len(events) == 1
         assert events[0].lifetime_seconds > 0
+
+
+def _make_request(request_id: str, num_tokens: int) -> Request:
+    sampling_params = SamplingParams(max_tokens=17)
+    sampling_params.update_from_generation_config({}, eos_token_id=100)
+    return Request(
+        request_id=request_id,
+        prompt_token_ids=list(range(num_tokens)),
+        mm_features=None,
+        sampling_params=sampling_params,
+        pooling_params=None,
+        block_hasher=get_request_block_hasher(BLOCK_SIZE, sha256),
+    )
+
+
+class TestBlockPoolIntegration:
+    """Tests for KVCacheMetricsCollector wired into BlockPool."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        init_none_hash(sha256)
+
+    def _make_pool(
+        self, num_gpu_blocks: int = 5
+    ) -> tuple[BlockPool, KVCacheMetricsCollector]:
+        collector = KVCacheMetricsCollector(sample_rate=1.0)
+        pool = BlockPool(
+            num_gpu_blocks=num_gpu_blocks,
+            enable_caching=True,
+            hash_block_size=BLOCK_SIZE,
+            metrics_collector=collector,
+        )
+        return pool, collector
+
+    def _cache_block(self, pool: BlockPool, block: KVCacheBlock) -> None:
+        pool.cache_full_blocks(
+            request=_make_request("0", BLOCK_SIZE),
+            blocks=[block],
+            num_cached_blocks=0,
+            num_full_blocks=1,
+            block_size=BLOCK_SIZE,
+            kv_cache_group_id=0,
+        )
+
+    def test_event_only_on_prefix_cache_eviction(self):
+        # 4 usable blocks (block 0 is the null block); cache only the first.
+        pool, collector = self._make_pool()
+        blocks = pool.get_new_blocks(4)
+        self._cache_block(pool, blocks[0])
+        pool.free_blocks(blocks)
+        assert collector.drain_events() == []
+
+        # Reallocation evicts the cached block from the prefix cache; the
+        # other three were never cached, so they must not produce events.
+        pool.get_new_blocks(4)
+        assert len(collector.drain_events()) == 1
+
+    def test_evict_blocks_only_records_cached_blocks(self):
+        pool, collector = self._make_pool()
+        blocks = pool.get_new_blocks(2)
+        self._cache_block(pool, blocks[0])
+
+        # Connector-driven eviction of a cached in-use block records an event.
+        pool.evict_blocks({blocks[0].block_id})
+        assert len(collector.drain_events()) == 1
+
+        # The uncached block is not evicted: no event, state is kept.
+        pool.evict_blocks({blocks[1].block_id})
+        assert collector.drain_events() == []
+        assert blocks[1].block_id in collector.block_metrics
+
+    def test_no_stale_state_across_block_lives(self):
+        pool, collector = self._make_pool()
+        blocks = pool.get_new_blocks(1)
+        block_id = blocks[0].block_id
+        assert block_id in collector.block_metrics
+        pool.free_blocks(blocks)
+
+        # The block's next life is not sampled; state from the previous life
+        # must not survive the reallocation.
+        collector.should_sample_block = lambda: False  # type: ignore[method-assign]
+        pool.get_new_blocks(1)
+        assert block_id not in collector.block_metrics
+        assert collector.drain_events() == []
+
+
+class TestSchedulerIntegration:
+    """Tests for KVCacheMetricsCollector lifecycle in the scheduler."""
+
+    def test_collector_requires_log_stats(self):
+        # With stats logging disabled, make_stats() never drains eviction
+        # events, so the collector must not be created at all.
+        scheduler = create_scheduler(kv_cache_metrics=True, log_stats=False)
+        assert scheduler.kv_metrics_collector is None
+        assert scheduler.make_stats() is None
+
+    def test_collector_events_drain_through_make_stats(self):
+        scheduler = create_scheduler(kv_cache_metrics=True)
+        collector = scheduler.kv_metrics_collector
+        assert collector is not None
+        assert scheduler.kv_cache_manager.block_pool.metrics_collector is collector
+
+        collector.block_metrics[0] = BlockMetricsState()
+        collector.on_block_evicted(KVCacheBlock(block_id=0))
+        stats = scheduler.make_stats()
+        assert stats is not None
+        assert len(stats.kv_cache_eviction_events) == 1
+        assert collector.drain_events() == []
 
 
 def test_kv_cache_metrics_collector_smoke() -> None:

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -10,6 +10,7 @@ from vllm.config import (
     ECTransferConfig,
     KVTransferConfig,
     ModelConfig,
+    ObservabilityConfig,
     ParallelConfig,
     SchedulerConfig,
     SpeculativeConfig,
@@ -65,6 +66,8 @@ def create_scheduler(
     ec_role: str | None = None,
     use_v2_model_runner: bool | None = None,
     kv_cache_spec: KVCacheSpec | None = None,
+    log_stats: bool = True,
+    kv_cache_metrics: bool = False,
 ) -> Scheduler | AsyncScheduler:
     """Create scheduler under test.
 
@@ -165,6 +168,7 @@ def create_scheduler(
         kv_transfer_config=kv_transfer_config,
         speculative_config=speculative_config,
         ec_transfer_config=ec_transfer_config,
+        observability_config=ObservabilityConfig(kv_cache_metrics=kv_cache_metrics),
     )
     if kv_cache_spec is None:
         kv_cache_spec = FullAttentionSpec(
@@ -185,7 +189,7 @@ def create_scheduler(
         vllm_config=vllm_config,
         kv_cache_config=kv_cache_config,
         block_size=block_size,
-        log_stats=True,
+        log_stats=log_stats,
         structured_output_manager=StructuredOutputManager(vllm_config),
     )
     if use_v2_model_runner is None:

--- a/vllm/config/observability.py
+++ b/vllm/config/observability.py
@@ -48,7 +48,8 @@ class ObservabilityConfig:
     kv_cache_metrics: bool = False
     """Enable KV cache residency metrics (lifetime, idle time, reuse gaps).
     Uses sampling to minimize overhead.
-    Requires log stats to be enabled (i.e., --disable-log-stats not set)."""
+    Requires log stats to be enabled (i.e., --disable-log-stats not set);
+    ignored otherwise."""
 
     kv_cache_metrics_sample: float = Field(default=0.01, gt=0, le=1)
     """Sampling rate for KV cache metrics (0.0, 1.0]. Default 0.01 = 1% of blocks."""

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -582,15 +582,13 @@ class BlockPool:
         Returns:
             True if the block is evicted, False otherwise.
         """
-        # Clean up metrics tracking first to prevent leaks
-        if self.metrics_collector:
-            self.metrics_collector.on_block_evicted(block)
-
         evicted_hashes = self._remove_cached_block_hashes(block)
         if not evicted_hashes:
             # The block doesn't have hash, eviction is not needed
             return False
 
+        if self.metrics_collector:
+            self.metrics_collector.on_block_evicted(block)
         self._emit_block_removed_events(evicted_hashes)
         return True
 

--- a/vllm/v1/core/kv_cache_metrics.py
+++ b/vllm/v1/core/kv_cache_metrics.py
@@ -62,6 +62,10 @@ class KVCacheMetricsCollector:
     def on_block_allocated(self, block: "KVCacheBlock") -> None:
         if self.should_sample_block():
             self.block_metrics[block.block_id] = BlockMetricsState()
+        else:
+            # The block may carry state from its previous life if it was
+            # reallocated without being evicted from the prefix cache.
+            self.block_metrics.pop(block.block_id, None)
 
     def on_block_accessed(self, block: "KVCacheBlock") -> None:
         metrics = self.block_metrics.get(block.block_id)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -88,9 +88,19 @@ class Scheduler(SchedulerInterface):
         self.observability_config = vllm_config.observability_config
         self.kv_metrics_collector: KVCacheMetricsCollector | None = None
         if self.observability_config.kv_cache_metrics:
-            self.kv_metrics_collector = KVCacheMetricsCollector(
-                self.observability_config.kv_cache_metrics_sample,
-            )
+            if self.log_stats:
+                self.kv_metrics_collector = KVCacheMetricsCollector(
+                    self.observability_config.kv_cache_metrics_sample,
+                )
+            else:
+                # Eviction events are only drained via make_stats(), which is
+                # a no-op when stats logging is disabled; collecting them
+                # would grow the event buffer without bound.
+                logger.warning(
+                    "kv_cache_metrics is ignored because stats logging is "
+                    "disabled. Remove --disable-log-stats to collect KV "
+                    "cache metrics."
+                )
         self.structured_output_manager = structured_output_manager
         self.is_encoder_decoder = vllm_config.model_config.is_encoder_decoder
 


### PR DESCRIPTION

## Purpose

Fix two defects in the KV cache residency metrics introduced in #27793:

1. **Unbounded event buffer with `--disable-log-stats`.** `KVCacheMetricsCollector` is created whenever `--kv-cache-metrics` is set, but its eviction event buffer is only drained inside `Scheduler.make_stats()`, which returns early when stats logging is disabled. Running with `--kv-cache-metrics --disable-log-stats` can therefore grow `_eviction_events` without bound in a long-running engine. The config docstring already says KV cache metrics require log stats to be enabled, so the scheduler now skips collector creation in that case and logs a warning.

2. **Spurious eviction events for never-cached blocks.** `_maybe_evict_cached_block()` called `on_block_evicted()` before checking whether the block actually had a cached hash, so reallocating never-cached blocks polluted the `vllm:kv_block_lifetime_seconds` / `vllm:kv_block_idle_before_evict_seconds` histograms, including through the connector `evict_blocks()` path. Events are now recorded only for real prefix-cache evictions; stale per-block state from a previous lifetime is also dropped on reallocation.

Not a duplicate: searched open PRs/issues for "kv cache metrics", "kv_cache_metrics", "eviction event", `KVCacheMetricsCollector`, and `drain_events`. Did not find an open PR or issue covering either defect.

AI assistance (Claude) was used. I reviewed the complete diff and test results before submission.

## Test Plan

New regression coverage is in `tests/v1/core/test_kv_cache_metrics.py`.

```bash
.venv/bin/python -m pytest tests/v1/core/test_kv_cache_metrics.py -q
git diff --check main...HEAD
```

I also checked the regression tests against unpatched main by applying only the test changes in a temporary worktree.

These tests are CPU-only because the change is limited to scheduler/block-pool metadata and the Python KV cache metrics collector; it does not touch GPU kernels or model execution paths.

## Test Result

Tested locally on a CPU editable install.

- `tests/v1/core/test_kv_cache_metrics.py`: 21 passed, 17 warnings
- Unpatched main with only the test changes applied in `/tmp/vllm-main-verify`: 4 failed, 1 passed, matching the expected regressions
- `git diff --check main...HEAD`: passed