### PR TITLE
[Warmup] Tune the LM head GEMM during FlashInfer autotune

### DIFF
--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -144,7 +144,13 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     to every rank so all ranks dispatch the same kernel tactic.
     """
     import vllm.utils.flashinfer as fi_utils
-    from vllm.distributed.parallel_state import get_world_group
+    from vllm.distributed.parallel_state import get_pp_group, get_world_group
+
+    def _dummy_run_with_logits(**kwargs) -> None:
+        _, last_hidden_states = runner._dummy_run(**kwargs)
+        # include LM head into autotune to avoid fallback to heuristic tactic at runtime
+        if get_pp_group().is_last_rank and not runner.is_pooling_model:
+            runner._dummy_sampler_run(last_hidden_states)
 
     use_persistent_cache = True
 
@@ -161,7 +167,7 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
 
     if not use_persistent_cache:
         with torch.inference_mode(), fi_utils.autotune():
-            runner._dummy_run(
+            _dummy_run_with_logits(
                 num_tokens=runner.scheduler_config.max_num_batched_tokens,
                 skip_eplb=True,
                 is_profile=True,
@@ -189,9 +195,9 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     with torch.inference_mode():
         if is_leader:
             with fi_utils.autotune(tune_mode=True, cache=str(cache_path)):
-                runner._dummy_run(**dummy_run_kwargs)
+                _dummy_run_with_logits(**dummy_run_kwargs)
         else:
-            runner._dummy_run(**dummy_run_kwargs)
+            _dummy_run_with_logits(**dummy_run_kwargs)
 
     # Broadcast autotune cache from rank 0 to all other ranks so every
     # rank loads the same set of chosen tactics.


### PR DESCRIPTION
## Summary

FlashInfer autotune warmup only runs `_dummy_run`, which executes the transformer body but never calls `compute_logits`. As a result the LM head (hidden→vocab) GEMM is never observed by the autotuner, and at runtime the first decode batch triggers:
```
[AutoTuner]: No tuned config covers bf16_gemm input_shapes=(... [H, vocab] ...)
```
falling back to an untuned heuristic tactic for a GEMM that runs every decode step.

## Change
`flashinfer_autotune` now routes all three `_dummy_run` call sites (the non-persistent-cache branch and both leader/non-leader persistent-cache paths) through a helper that also runs `_dummy_sampler_run` on the returned hidden states, guarded by `is_last_rank` and `not is_pooling_model`. This mirrors how `profile_run` exercises the LM head, so the projection GEMM is tuned inside the `autotune()` context. Calling it on both leader/non-leader preserves collective (TP all-gather) symmetry.

## Test plan
- [ ] Serve a BF16 model with `--enable-flashinfer-autotune` and confirm the
      `No tuned config covers bf16_gemm` warning for the `[*, hidden] x
      [hidden, vocab]` shape no longer appears at runtime.
- [ ] Verify autotune warmup completes without regressions on a TP>1 run.

## Duplicate-work check
- None open

## AI assistance
AI assistance was used (Claude) to write this PR