### PR TITLE
[Quantization] Support Quark AWQ exports in vLLM

### DIFF
--- a/tests/quantization/test_auto_awq.py
+++ b/tests/quantization/test_auto_awq.py
@@ -20,6 +20,48 @@ import torch
 
 from tests.quantization.utils import is_quant_method_supported
 
+_REVERSE_AWQ_PACK_ORDER = [0, 4, 1, 5, 2, 6, 3, 7]
+
+
+def _sign_extend_int4_nibbles(t: torch.Tensor) -> torch.Tensor:
+    mask = (t & 0x8).bool()
+    t = t.clone()
+    t[mask] = t[mask] | 0xF0
+    return t
+
+
+def _dequantize_quark_signed_awq_torch(
+    qweight: torch.Tensor,
+    scales: torch.Tensor,
+    qzeros: torch.Tensor,
+    group_size: int,
+    *,
+    pack_reorder: bool = True,
+) -> torch.Tensor:
+    bits = 4
+    shifts = torch.arange(0, 32, bits, device=qweight.device)
+    iweights = (qweight[:, :, None] >> shifts[None, None, :]).to(torch.int8)
+    iweights = iweights.view(qweight.shape[0], -1)
+    zeros = (qzeros[:, :, None] >> shifts[None, None, :]).to(torch.int8)
+    zeros = zeros.view(qzeros.shape[0], -1)
+
+    if pack_reorder:
+        order = torch.tensor(_REVERSE_AWQ_PACK_ORDER, device=qweight.device)
+    else:
+        order = torch.arange(8, device=qweight.device)
+    iweights = iweights.view(qweight.shape[0], -1, 8)[:, :, order].reshape(
+        qweight.shape[0], -1
+    )
+    zeros = zeros.view(qzeros.shape[0], -1, 8)[:, :, order].reshape(
+        qzeros.shape[0], -1
+    )
+    iweights = _sign_extend_int4_nibbles(iweights & 0xF)
+    zeros = _sign_extend_int4_nibbles(zeros & 0xF)
+
+    scales = scales.repeat_interleave(group_size, dim=0)
+    zeros = zeros.repeat_interleave(group_size, dim=0)
+    return (iweights - zeros) * scales
+
 
 def _get_auto_awq_config_source() -> str:
     """Read the AutoAWQConfig class source code for isolated testing."""
@@ -229,3 +271,294 @@ def test_auto_awq_config_get_name():
     from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
 
     assert AutoAWQConfig.get_name() == "auto_awq"
+
+
+# =============================================================================
+# Quark AWQ format support tests
+# =============================================================================
+
+
+class TestQuarkAWQFormat:
+    """Tests for Quark AWQ export format compatibility.
+
+    Quark exports AWQ checkpoints with pack_method="reorder" and uses
+    "qscales"/"qqzeros" tensor name suffixes instead of the standard
+    AutoAWQ "scales"/"qzeros".  AutoAWQConfig must detect and remap these.
+    """
+
+    def test_standard_awq_is_not_detected_as_quark(self):
+        """Standard AutoAWQ config without pack_method should not set is_quark_format."""
+        from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
+
+        config = {
+            "w_bit": 4,
+            "q_group_size": 128,
+            "zero_point": True,
+            "version": "gemm",
+        }
+        awq_config = AutoAWQConfig.from_config(config)
+        assert not awq_config.is_quark_format
+
+    def test_quark_awq_format_detected_by_pack_method(self):
+        """pack_method='reorder' in config should trigger Quark format detection."""
+        from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
+
+        config = {
+            "bits": 4,
+            "group_size": 128,
+            "zero_point": True,
+            "quant_method": "awq",
+            "version": "gemm",
+            "pack_method": "reorder",
+        }
+        awq_config = AutoAWQConfig.from_config(config)
+        assert awq_config.is_quark_format
+
+    def test_quark_order_pack_method_sets_pack_reorder_false(self):
+        """pack_method='order' (Quark f2f export) must not apply AWQ nibble reorder."""
+        from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
+
+        config = {
+            "quant_method": "quark",
+            "export": {"pack_method": "order"},
+            "global_quant_config": {
+                "weight": {
+                    "dtype": "int4",
+                    "group_size": 128,
+                    "symmetric": True,
+                }
+            },
+            "exclude": ["model.visual"],
+        }
+        awq_config = AutoAWQConfig.from_config(config)
+        assert awq_config.is_quark_format
+        assert not awq_config.quark_pack_reorder
+        assert awq_config.lm_head_quantized
+
+    def test_quark_excluded_lm_head_is_not_remapped_to_qweight(self):
+        """Quark exports may keep lm_head as an unquantized FP16 weight."""
+        import torch
+        from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
+
+        config = {
+            "quant_method": "quark",
+            "export": {"pack_method": "reorder"},
+            "global_quant_config": {
+                "weight": {
+                    "dtype": "int4",
+                    "group_size": 128,
+                    "symmetric": True,
+                }
+            },
+            "exclude": ["lm_head"],
+        }
+        awq_config = AutoAWQConfig.from_config(config)
+        mapper = awq_config.get_cache_scale_mapper()
+
+        output_names = {
+            name for name, _ in mapper.apply([("lm_head.weight", torch.zeros(1))])
+        }
+
+        assert not awq_config.lm_head_quantized
+        assert "lm_head.weight" in output_names
+        assert "lm_head.qweight" not in output_names
+
+    def test_quark_excluded_linear_is_not_remapped_to_qweight(self):
+        """Quark real_quantized exports may exclude specific linear modules."""
+        import torch
+        from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
+
+        config = {
+            "quant_method": "quark",
+            "export": {"pack_method": "reorder"},
+            "global_quant_config": {
+                "weight": {
+                    "dtype": "int4",
+                    "group_size": 128,
+                    "symmetric": True,
+                }
+            },
+            "exclude": ["model.language_model.layers.0.mlp.gate.linear"],
+        }
+        awq_config = AutoAWQConfig.from_config(config)
+        mapper = awq_config.get_cache_scale_mapper()
+
+        output_names = {
+            name
+            for name, _ in mapper.apply(
+                [
+                    (
+                        "model.language_model.layers.0.mlp.gate.linear.weight",
+                        torch.zeros(1),
+                    ),
+                    (
+                        "model.language_model.layers.1.mlp.gate.linear.weight",
+                        torch.zeros(1),
+                    ),
+                    ("layers.0.mlp.gate.weight", torch.zeros(1)),
+                    ("layers.0.mlp.gate.qweight", torch.zeros(1)),
+                    ("layers.1.mlp.gate.weight", torch.zeros(1)),
+                ]
+            )
+        }
+
+        assert (
+            "model.language_model.layers.0.mlp.gate.linear.weight" in output_names
+        )
+        assert (
+            "model.language_model.layers.0.mlp.gate.linear.qweight"
+            not in output_names
+        )
+        assert (
+            "model.language_model.layers.1.mlp.gate.linear.qweight"
+            in output_names
+        )
+        assert "layers.0.mlp.gate.weight" in output_names
+        assert "layers.0.mlp.gate.qweight" not in output_names
+        assert "layers.1.mlp.gate.qweight" in output_names
+
+    def test_quark_excluded_projection_qweight_is_mapped_back_to_weight(self):
+        """Excluded projections stay unquantized even if a suffix remap fired."""
+        import torch
+        from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
+
+        config = {
+            "quant_method": "quark",
+            "export": {"pack_method": "reorder"},
+            "global_quant_config": {
+                "weight": {
+                    "dtype": "int4",
+                    "group_size": 128,
+                    "symmetric": True,
+                }
+            },
+            "exclude": ["layers.0.mlp.shared_expert.down_proj"],
+        }
+        awq_config = AutoAWQConfig.from_config(config)
+        mapper = awq_config.get_cache_scale_mapper()
+
+        output_names = {
+            name
+            for name, _ in mapper.apply(
+                [
+                    (
+                        "layers.0.mlp.shared_expert.down_proj.weight",
+                        torch.zeros(1),
+                    ),
+                    (
+                        "layers.1.mlp.shared_expert.down_proj.weight",
+                        torch.zeros(1),
+                    ),
+                ]
+            )
+        }
+
+        assert "layers.0.mlp.shared_expert.down_proj.weight" in output_names
+        assert (
+            "layers.0.mlp.shared_expert.down_proj.qweight" not in output_names
+        )
+        assert "layers.1.mlp.shared_expert.down_proj.qweight" in output_names
+
+    def test_quark_mapper_adds_suffix_remappings(self):
+        """get_cache_scale_mapper should add qscales/qqzeros suffix remappings
+        for Quark format."""
+        from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
+
+        config = {
+            "bits": 4,
+            "group_size": 128,
+            "zero_point": True,
+            "quant_method": "awq",
+            "pack_method": "reorder",
+        }
+        awq_config = AutoAWQConfig.from_config(config)
+        mapper = awq_config.get_cache_scale_mapper()
+
+        assert ".qscales" in mapper.orig_to_new_suffix
+        assert mapper.orig_to_new_suffix[".qscales"] == ".scales"
+        assert ".qqzeros" in mapper.orig_to_new_suffix
+        assert mapper.orig_to_new_suffix[".qqzeros"] == ".qzeros"
+
+    def test_standard_mapper_has_no_quark_suffix_remappings(self):
+        """Standard AWQ get_cache_scale_mapper should not add Quark suffix remappings."""
+        from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
+
+        config = {
+            "bits": 4,
+            "group_size": 128,
+            "zero_point": True,
+            "quant_method": "awq",
+        }
+        awq_config = AutoAWQConfig.from_config(config)
+        mapper = awq_config.get_cache_scale_mapper()
+
+        assert ".qscales" not in mapper.orig_to_new_suffix
+        assert ".qqzeros" not in mapper.orig_to_new_suffix
+
+    def test_quark_mapper_renames_tensor_names(self):
+        """The mapper returned for Quark format should rename qscales/qqzeros
+        in a simulated weight stream."""
+        import torch
+        from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
+
+        config = {
+            "bits": 4,
+            "group_size": 128,
+            "zero_point": True,
+            "quant_method": "awq",
+            "pack_method": "reorder",
+        }
+        awq_config = AutoAWQConfig.from_config(config)
+        mapper = awq_config.get_cache_scale_mapper()
+
+        input_weights = [
+            ("model.layers.0.mlp.down_proj.qweight", torch.zeros(1)),
+            ("model.layers.0.mlp.down_proj.qscales", torch.zeros(1)),
+            ("model.layers.0.mlp.down_proj.qqzeros", torch.zeros(1)),
+        ]
+        output_names = {name for name, _ in mapper.apply(input_weights)}
+
+        assert "model.layers.0.mlp.down_proj.qweight" in output_names
+        assert "model.layers.0.mlp.down_proj.scales" in output_names
+        assert "model.layers.0.mlp.down_proj.qzeros" in output_names
+        assert "model.layers.0.mlp.down_proj.qscales" not in output_names
+        assert "model.layers.0.mlp.down_proj.qqzeros" not in output_names
+
+
+@pytest.mark.skipif(
+    not __import__("vllm.platforms", fromlist=["current_platform"]).current_platform.is_cuda_alike(),
+    reason="Quark signed INT4 Triton test requires CUDA/ROCm.",
+)
+def test_quark_signed_int4_triton_matches_torch():
+    """Signed INT4 path must only affect Quark exports, not standard AWQ."""
+    import os
+
+    import torch
+    from safetensors.torch import load_file
+
+    from vllm.model_executor.layers.quantization.awq_triton import (
+        awq_dequantize_triton,
+    )
+
+    model_dir = os.environ.get("QUARK_AWQ_INT4_TEST_MODEL")
+    if model_dir is None:
+        pytest.skip("Set QUARK_AWQ_INT4_TEST_MODEL to run this checkpoint test")
+    weights_path = f"{model_dir}/model.safetensors"
+    if not os.path.isfile(weights_path):
+        pytest.skip(f"Quark AWQ INT4 checkpoint not found: {weights_path}")
+    weights = load_file(weights_path)
+    prefix = "model.layers.0.mlp.up_proj"
+    qweight = weights[f"{prefix}.weight"].cuda()
+    scales = weights[f"{prefix}.weight_scale"].cuda()
+    qzeros = weights[f"{prefix}.weight_zero_point"].cuda()
+
+    group_size = 128
+    expected = _dequantize_quark_signed_awq_torch(qweight, scales, qzeros, group_size)
+    unsigned = awq_dequantize_triton(qweight, scales, qzeros, signed_int4=False)
+    signed = awq_dequantize_triton(qweight, scales, qzeros, signed_int4=True)
+
+    cosine_unsigned = torch.nn.functional.cosine_similarity(
+        expected.flatten().float(), unsigned.flatten().float(), dim=0
+    )
+    assert cosine_unsigned < 0.5
+    torch.testing.assert_close(signed, expected, rtol=1e-2, atol=1e-2)

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -464,13 +464,21 @@ def awq_dequantize(
     split_k_iters: int,
     thx: int,
     thy: int,
+    signed_int4: bool = False,
+    pack_reorder: bool = True,
 ) -> torch.Tensor:
     if envs.VLLM_USE_TRITON_AWQ:
         from vllm.model_executor.layers.quantization.awq_triton import (
             awq_dequantize_triton,
         )
 
-        return awq_dequantize_triton(qweight, scales, zeros)
+        return awq_dequantize_triton(
+            qweight,
+            scales,
+            zeros,
+            signed_int4=signed_int4,
+            pack_reorder=pack_reorder,
+        )
     return torch.ops._C.awq_dequantize(qweight, scales, zeros, split_k_iters, thx, thy)
 
 
@@ -497,11 +505,21 @@ def awq_gemm(
     scales: torch.Tensor,
     qzeros: torch.Tensor,
     split_k_iters: int,
+    signed_int4: bool = False,
+    pack_reorder: bool = True,
 ) -> torch.Tensor:
     if envs.VLLM_USE_TRITON_AWQ:
         from vllm.model_executor.layers.quantization.awq_triton import awq_gemm_triton
 
-        return awq_gemm_triton(input, qweight, scales, qzeros, split_k_iters)
+        return awq_gemm_triton(
+            input,
+            qweight,
+            scales,
+            qzeros,
+            split_k_iters,
+            signed_int4=signed_int4,
+            pack_reorder=pack_reorder,
+        )
     return torch.ops._C.awq_gemm(input, qweight, scales, qzeros, split_k_iters)
 
 

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -261,6 +261,11 @@ class FusedMoEQuantConfig:
 
     mx_alignment: int = 0
 
+    # Some INT4 exporters (for example Quark symmetric weight-only INT4) store
+    # signed two's-complement nibbles instead of AWQ's unsigned values centered
+    # around an implicit zero point of 8.
+    signed_int4: bool = False
+
     def __post_init__(self):
         assert not self.per_act_token_quant or self.block_shape is None, (
             "illegal quantization"
@@ -887,6 +892,7 @@ def int4_w4a16_moe_quant_config(
     block_shape: list[int] | None = None,
     a1_gscale: torch.Tensor | None = None,
     a2_gscale: torch.Tensor | None = None,
+    signed_int4: bool = False,
 ) -> FusedMoEQuantConfig:
     """
     Construct a quant config for 16-bit float activations and int4 weights.
@@ -897,6 +903,7 @@ def int4_w4a16_moe_quant_config(
         _a2=FusedMoEQuantDesc(shape=group_shape, alpha_or_gscale=a2_gscale),
         _w1=FusedMoEQuantDesc("int4", group_shape, w1_scale, None, w1_zp, w1_bias),
         _w2=FusedMoEQuantDesc("int4", group_shape, w2_scale, None, w2_zp, w2_bias),
+        signed_int4=signed_int4,
     )
 
 

--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -675,6 +675,7 @@ class TritonWNA16Experts(TritonExperts):
             use_int8_w8a16=self.quant_config.use_int8_w8a16,
             use_int4_w4a16=self.quant_config.use_int4_w4a16,
             block_shape=self.block_shape,
+            signed_int4=self.quant_config.signed_int4,
         )
 
         self.activation(
@@ -708,6 +709,7 @@ class TritonWNA16Experts(TritonExperts):
             use_int8_w8a16=self.quant_config.use_int8_w8a16,
             use_int4_w4a16=self.quant_config.use_int4_w4a16,
             block_shape=self.block_shape,
+            signed_int4=self.quant_config.signed_int4,
         )
 
         # separate function is required for MoE + LoRA

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -104,6 +104,7 @@ def fused_moe_kernel_gptq_awq(
     has_zp: tl.constexpr,
     use_int4_w4a16: tl.constexpr,
     use_int8_w8a16: tl.constexpr,
+    signed_int4: tl.constexpr,
 ):
     """
     Implements the fused computation for a Mixture of Experts (MOE) using
@@ -231,6 +232,9 @@ def fused_moe_kernel_gptq_awq(
         b = tl.load(b_ptrs)
         if use_int4_w4a16:
             b = (b >> b_shifter) & 0xF
+            if signed_int4:
+                b = b.to(tl.int32)
+                b = tl.where(b >= 8, b - 16, b)
 
         b_scale_ptrs = (
             b_scale_ptr
@@ -266,6 +270,8 @@ def fused_moe_kernel_gptq_awq(
         # We accumulate along the K dimension.
         if has_zp:
             b = ((b.to(tl.float32) - b_zp) * b_scale).to(compute_type)
+        elif signed_int4 and use_int4_w4a16:
+            b = (b.to(tl.float32) * b_scale).to(compute_type)
         else:
             b = ((b.to(tl.float32) - b_zp_num) * b_scale).to(compute_type)
         accumulator = tl.dot(a, b, acc=accumulator)
@@ -659,6 +665,7 @@ def invoke_fused_moe_wna16_triton_kernel(
     use_int8_w8a16: bool,
     use_int4_w4a16: bool,
     block_shape: list[int] | None,
+    signed_int4: bool = False,
 ):
     assert B_scale is not None and B_scale.ndim == 3
     assert B_zp is None or B_zp.ndim == 3
@@ -728,6 +735,7 @@ def invoke_fused_moe_wna16_triton_kernel(
         has_zp=B_zp is not None,
         use_int4_w4a16=use_int4_w4a16,
         use_int8_w8a16=use_int8_w8a16,
+        signed_int4=signed_int4,
         **config,
     )
 
@@ -871,6 +879,7 @@ def dispatch_fused_moe_kernel(
     per_channel_quant: bool,
     block_shape: list[int] | None = None,
     B_bias: torch.Tensor | None = None,
+    signed_int4: bool = False,
 ) -> None:
     assert topk_weights is not None or not mul_routed_weight
     assert topk_weights is None or topk_weights.stride(1) == 1
@@ -891,7 +900,7 @@ def dispatch_fused_moe_kernel(
             bit=4 if use_int4_w4a16 else 8,
         )
 
-        if use_moe_wna16_cuda:
+        if use_moe_wna16_cuda and not signed_int4:
             invoke_fused_moe_wna16_cuda_kernel(
                 A,
                 B,
@@ -925,6 +934,7 @@ def dispatch_fused_moe_kernel(
             use_int8_w8a16,
             use_int4_w4a16,
             block_shape,
+            signed_int4,
         )
 
     else:
@@ -1411,6 +1421,7 @@ def fused_experts_op(
     block_shape: list[int] | None = None,
     w1_bias: torch.Tensor | None = None,
     w2_bias: torch.Tensor | None = None,
+    signed_int4: bool = False,
 ) -> torch.Tensor:
     return fused_experts_impl(
         hidden_states,
@@ -1437,6 +1448,7 @@ def fused_experts_op(
         block_shape,
         w1_bias,
         w2_bias,
+        signed_int4,
     )
 
 
@@ -1465,6 +1477,7 @@ def fused_experts_op_fake(
     block_shape: list[int] | None = None,
     w1_bias: torch.Tensor | None = None,
     w2_bias: torch.Tensor | None = None,
+    signed_int4: bool = False,
 ) -> torch.Tensor:
     return torch.empty_like(hidden_states)
 
@@ -1566,6 +1579,7 @@ def fused_experts(
         block_shape=quant_config.block_shape,
         w1_bias=quant_config.w1_bias,
         w2_bias=quant_config.w2_bias,
+        signed_int4=quant_config.signed_int4,
     )
 
 
@@ -1613,6 +1627,7 @@ def fused_experts_impl(
     block_shape: list[int] | None = None,
     w1_bias: torch.Tensor | None = None,
     w2_bias: torch.Tensor | None = None,
+    signed_int4: bool = False,
 ) -> torch.Tensor:
     if ocp_mx_scheme is not None:
         raise NotImplementedError(
@@ -1745,6 +1760,7 @@ def fused_experts_impl(
         per_channel_quant=per_channel_quant,
         block_shape=block_shape,
         B_bias=w1_bias,
+        signed_int4=signed_int4,
     )
 
     apply_moe_activation(
@@ -1784,6 +1800,7 @@ def fused_experts_impl(
         per_channel_quant=per_channel_quant,
         block_shape=block_shape,
         B_bias=w2_bias,
+        signed_int4=signed_int4,
     )
 
     ops.moe_sum(

--- a/vllm/model_executor/layers/quantization/auto_awq.py
+++ b/vllm/model_executor/layers/quantization/auto_awq.py
@@ -3,6 +3,7 @@
 
 from typing import TYPE_CHECKING, Any, Union
 
+import regex as re
 import torch
 from safetensors.torch import _TYPES as _SAFETENSORS_TO_TORCH_DTYPE
 from torch.nn import Parameter
@@ -75,6 +76,15 @@ logger = init_logger(__name__)
 # [0,4,1,5,2,6,3,7]. This permutation reverses that ordering.
 _REVERSE_AWQ_PACK_ORDER = [0, 4, 1, 5, 2, 6, 3, 7]
 
+# Quark real_quantized AWQ exports use ".weight" for packed int4 weights on
+# linear projections. Remap only known projection suffixes so unquantized
+# tensors such as embed_tokens.weight are left unchanged.
+_QUARK_AWQ_LINEAR_WEIGHT_REGEX = re.compile(
+    r"\.(q_proj|k_proj|v_proj|o_proj|gate_proj|up_proj|down_proj|out_proj|"
+    r"in_proj_qkv|in_proj_z|in_proj_b|in_proj_a)\.weight$"
+)
+_QUARK_AWQ_TOP_LEVEL_LM_HEAD_WEIGHT_REGEX = re.compile(r"^lm_head\.weight$")
+
 
 def _replace_or_register_parameter(
     layer: torch.nn.Module,
@@ -94,6 +104,8 @@ def _convert_awq_to_standard_format(
     w_q_name: str,
     w_zp_name: str,
     size_bits: int,
+    *,
+    apply_awq_pack_reorder: bool = True,
 ) -> None:
     """Convert AWQ weight and zero-point tensors to standard GPTQ-like format.
 
@@ -104,10 +116,13 @@ def _convert_awq_to_standard_format(
     pack_factor = 32 // size_bits
     mask = (1 << size_bits) - 1
     device = getattr(layer, w_q_name).device
-    reverse_order = torch.tensor(
-        _REVERSE_AWQ_PACK_ORDER, dtype=torch.long, device=device
-    )
     shifts = torch.arange(0, 32, size_bits, dtype=torch.int32, device=device)
+    if apply_awq_pack_reorder:
+        pack_order = torch.tensor(
+            _REVERSE_AWQ_PACK_ORDER, dtype=torch.long, device=device
+        )
+    else:
+        pack_order = torch.arange(pack_factor, dtype=torch.long, device=device)
 
     # --- Convert qweight: (K, N // pack) packed_dim=1 → (K // pack, N) packed_dim=0
     qw = getattr(layer, w_q_name).data
@@ -116,7 +131,7 @@ def _convert_awq_to_standard_format(
 
     # Unpack int32 → individual values, fix AWQ ordering
     unpacked = (qw.unsqueeze(-1) >> shifts) & mask  # (K, N_packed, pack_factor)
-    unpacked = unpacked[:, :, reverse_order]
+    unpacked = unpacked[:, :, pack_order]
     unpacked = unpacked.reshape(K, N)  # (K, N)
 
     # Repack along input dim (dim 0)
@@ -146,7 +161,7 @@ def _convert_awq_to_standard_format(
     G, _ = qz.shape
 
     unpacked_zp = (qz.unsqueeze(-1) >> shifts) & mask  # (G, N_packed, pack_factor)
-    unpacked_zp = unpacked_zp[:, :, reverse_order]
+    unpacked_zp = unpacked_zp[:, :, pack_order]
     unpacked_zp = unpacked_zp.reshape(G, N)  # (G, N) individual values
 
     # Transpose and repack along dim 0 (output dim)
@@ -187,6 +202,8 @@ class AutoAWQConfig(QuantizationConfig):
         lm_head_quantized: bool,
         modules_to_not_convert: list[str] | None = None,
         full_config: dict[str, Any] | None = None,
+        is_quark_format: bool = False,
+        quark_pack_reorder: bool = True,
     ) -> None:
         super().__init__()
         self.pack_factor = 32 // weight_bits  # packed into int32
@@ -196,6 +213,11 @@ class AutoAWQConfig(QuantizationConfig):
         self.weight_bits = weight_bits
         self.modules_to_not_convert = modules_to_not_convert or []
         self.full_config = full_config or {}
+        # Quark exports AWQ models with pack_method "order" or "reorder" and uses
+        # "qscales"/"qqzeros" or "weight"/"weight_scale" tensor names.
+        self.is_quark_format = is_quark_format
+        # True for pack_method="reorder" (AWQ nibble order); False for "order".
+        self.quark_pack_reorder = quark_pack_reorder
 
         if self.weight_bits not in self.TYPE_MAP:
             supported = ", ".join(str(k) for k in self.TYPE_MAP)
@@ -233,19 +255,118 @@ class AutoAWQConfig(QuantizationConfig):
     def get_config_filenames(cls) -> list[str]:
         return ["quantize_config.json", "quant_config.json"]
 
+    @staticmethod
+    def _quark_pack_method(config: dict[str, Any]) -> str | None:
+        export_config = config.get("export", {})
+        pack_method = export_config.get("pack_method")
+        if pack_method is not None:
+            return pack_method
+        return config.get("pack_method")
+
+    @staticmethod
+    def _is_quark_awq_export(config: dict[str, Any]) -> bool:
+        if config.get("quant_method", "").lower() != "quark":
+            return False
+        pack_method = AutoAWQConfig._quark_pack_method(config)
+        if pack_method not in ("order", "reorder"):
+            return False
+        algo_configs = config.get("algo_config") or []
+        return any(
+            isinstance(algo, dict) and algo.get("name") == "awq"
+            for algo in algo_configs
+        )
+
+    @staticmethod
+    def _is_quark_packed_int4_export(config: dict[str, Any]) -> bool:
+        if config.get("quant_method", "").lower() != "quark":
+            return False
+        pack_method = AutoAWQConfig._quark_pack_method(config)
+        if pack_method not in ("order", "reorder"):
+            return False
+        global_weight = config.get("global_quant_config", {}).get("weight", {})
+        return global_weight.get("dtype") in {"int4", "int8"}
+
+    @staticmethod
+    def _normalize_quark_excludes(exclude: list[str] | None) -> list[str] | None:
+        if not exclude:
+            return exclude
+
+        normalized: list[str] = []
+        seen: set[str] = set()
+
+        def add(module_name: str) -> None:
+            if module_name and module_name not in seen:
+                seen.add(module_name)
+                normalized.append(module_name)
+
+        for module_name in exclude:
+            candidates = {
+                module_name,
+                module_name.removeprefix("model.language_model."),
+                module_name.replace("model.language_model.", "model.", 1),
+            }
+            for candidate in tuple(candidates):
+                if candidate.endswith(".gate.linear"):
+                    candidates.add(candidate.removesuffix(".linear"))
+                elif candidate.endswith(".gate"):
+                    candidates.add(f"{candidate}.linear")
+            for candidate in candidates:
+                add(candidate)
+
+        return normalized
+
+    @classmethod
+    def _normalize_quark_awq_config(cls, config: dict[str, Any]) -> dict[str, Any]:
+        global_weight = config.get("global_quant_config", {}).get("weight", {})
+        dtype_to_bits = {"int4": 4, "int8": 8}
+        weight_dtype = global_weight.get("dtype")
+        if weight_dtype not in dtype_to_bits:
+            raise ValueError(
+                f"Unsupported Quark AWQ weight dtype: {weight_dtype!r}"
+            )
+        export_config = config.get("export", {})
+        return {
+            **config,
+            "bits": dtype_to_bits[weight_dtype],
+            "group_size": global_weight.get("group_size", 128),
+            "zero_point": not global_weight.get("symmetric", True),
+            "pack_method": export_config.get("pack_method"),
+            "modules_to_not_convert": cls._normalize_quark_excludes(
+                config.get("exclude")
+            ),
+        }
+
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> "AutoAWQConfig":
+        if cls._is_quark_awq_export(config) or cls._is_quark_packed_int4_export(
+            config
+        ):
+            config = cls._normalize_quark_awq_config(config)
+
         weight_bits = cls.get_from_keys(config, ["w_bit", "bits"])
         group_size = cls.get_from_keys(config, ["q_group_size", "group_size"])
-        zero_point = cls.get_from_keys(config, ["zero_point"])
+        zero_point = cls.get_from_keys_or(config, ["zero_point"], default=False)
         lm_head_quantized = cls.get_from_keys_or(config, ["lm_head"], default=False)
         modules_to_not_convert = cls.get_from_keys_or(
-            config, ["modules_to_not_convert"], None
+            config, ["modules_to_not_convert", "exclude"], None
         )
         # Ensure full_config uses "awq" as quant_method for MoE fallback compatibility.
         # MoeWNA16Config only accepts "gptq" or "awq", so we normalize here.
         full_config = config.copy()
         full_config["quant_method"] = "awq"
+        pack_method = config.get("pack_method")
+        is_quark_format = pack_method in ("order", "reorder")
+        quark_pack_reorder = pack_method == "reorder"
+        if is_quark_format and not lm_head_quantized:
+            exclude = modules_to_not_convert or []
+            lm_head_excluded = any(
+                item == "lm_head"
+                or item.endswith(".lm_head")
+                or item.startswith("lm_head.")
+                for item in exclude
+            )
+            if not lm_head_excluded:
+                lm_head_quantized = True
         return cls(
             weight_bits,
             group_size,
@@ -253,6 +374,8 @@ class AutoAWQConfig(QuantizationConfig):
             lm_head_quantized,
             modules_to_not_convert,
             full_config,
+            is_quark_format,
+            quark_pack_reorder,
         )
 
     @classmethod
@@ -266,7 +389,10 @@ class AutoAWQConfig(QuantizationConfig):
 
         quant_method = hf_quant_cfg.get("quant_method", "").lower()
 
-        if quant_method != "awq":
+        if quant_method != "awq" and not (
+            cls._is_quark_awq_export(hf_quant_cfg)
+            or cls._is_quark_packed_int4_export(hf_quant_cfg)
+        ):
             return None
 
         is_valid_user_quant = user_quant is None or user_quant in (
@@ -382,6 +508,101 @@ class AutoAWQConfig(QuantizationConfig):
         return check_marlin_supported(
             quant_type=cls.TYPE_MAP[num_bits], group_size=group_size, has_zp=zero_point
         )
+
+    def get_cache_scale_mapper(self) -> "WeightsMapper":
+        """Extend the base mapper with Quark AWQ tensor name remappings.
+
+        Quark exports AWQ checkpoints with pack_method="reorder". Depending on
+        the exporter version, tensors may use either the legacy AutoAWQ names
+        ("qweight"/"qscales"/"qqzeros") or the real_quantized names
+        ("weight"/"weight_scale"/"weight_zero_point"). Add remappings for both
+        conventions so the loader finds the right params.
+        """
+        from vllm.model_executor.models.utils import WeightsMapper
+
+        base_mapper = super().get_cache_scale_mapper()
+        if not self.is_quark_format:
+            return base_mapper
+
+        excluded_modules = set(self.modules_to_not_convert)
+        for module_name in tuple(excluded_modules):
+            if module_name.endswith(".gate"):
+                excluded_modules.add(f"{module_name}.linear")
+            elif module_name.endswith(".gate.linear"):
+                excluded_modules.add(module_name.removesuffix(".linear"))
+
+        excluded_linear_modules = [
+            re.escape(module_name)
+            for module_name in excluded_modules
+            if module_name.endswith(".linear")
+        ]
+        excluded_gate_modules = [
+            re.escape(module_name)
+            for module_name in excluded_modules
+            if module_name.endswith(".gate")
+        ]
+        excluded_module_pattern = "|".join(
+            re.escape(module_name) for module_name in excluded_modules
+        )
+
+        quark_suffix_map: dict[str, str | None] = {
+            ".qscales": ".scales",
+            ".weight_scale": ".scales",
+        }
+        if self.zero_point:
+            quark_suffix_map[".qqzeros"] = ".qzeros"
+            quark_suffix_map[".weight_zero_point"] = ".qzeros"
+        else:
+            # Quark symmetric AWQ may still export all-zero zero points.
+            quark_suffix_map[".qqzeros"] = None
+            quark_suffix_map[".weight_zero_point"] = None
+
+        quark_regex_map: dict[re.Pattern[str], str | None] = {
+            _QUARK_AWQ_LINEAR_WEIGHT_REGEX: r".\1.qweight",
+            re.compile(r"\.shared_expert_gate\.weight_scale$"): None,
+            re.compile(r"\.shared_expert_gate\.weight_zero_point$"): None,
+        }
+        linear_exclude = "|".join(excluded_linear_modules)
+        linear_weight_pattern = (
+            rf"^(?!(?:{linear_exclude})\.weight$)(?P<prefix>.*)\.linear\.weight$"
+            if linear_exclude
+            else r"^(?P<prefix>.*)\.linear\.weight$"
+        )
+        quark_regex_map[re.compile(linear_weight_pattern)] = (
+            r"\g<prefix>.linear.qweight"
+        )
+        if linear_exclude:
+            quark_regex_map[
+                re.compile(rf"^(?P<prefix>{linear_exclude})\.qweight$")
+            ] = r"\g<prefix>.weight"
+
+        gate_exclude = "|".join(excluded_gate_modules)
+        gate_weight_pattern = (
+            rf"^(?!(?:{gate_exclude})\.weight$)(?P<prefix>.*)\.gate\.weight$"
+            if gate_exclude
+            else r"^(?P<prefix>.*)\.gate\.weight$"
+        )
+        quark_regex_map[re.compile(gate_weight_pattern)] = r"\g<prefix>.gate.qweight"
+        if gate_exclude:
+            quark_regex_map[
+                re.compile(rf"^(?P<prefix>{gate_exclude})\.qweight$")
+            ] = r"\g<prefix>.weight"
+
+        if excluded_module_pattern:
+            quark_regex_map[
+                re.compile(rf"^(?P<prefix>{excluded_module_pattern})\.qweight$")
+            ] = r"\g<prefix>.weight"
+
+        if self.lm_head_quantized:
+            quark_regex_map[_QUARK_AWQ_TOP_LEVEL_LM_HEAD_WEIGHT_REGEX] = (
+                "lm_head.qweight"
+            )
+
+        quark_suffix_mapper = WeightsMapper(
+            orig_to_new_suffix=quark_suffix_map,
+            orig_to_new_regex=quark_regex_map,
+        )
+        return base_mapper | quark_suffix_mapper
 
     def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper"):
         if self.modules_to_not_convert:
@@ -530,7 +751,14 @@ class AutoAWQMarlinLinearMethod(LinearMethodBase):
         # (GPTQ-like: standard bit order, qweight packed along input dim)
         # before handing off to the kernel.
         _convert_awq_to_standard_format(
-            layer, "qweight", "qzeros", self.quant_config.quant_type.size_bits
+            layer,
+            "qweight",
+            "qzeros",
+            self.quant_config.quant_type.size_bits,
+            apply_awq_pack_reorder=(
+                not self.quant_config.is_quark_format
+                or self.quant_config.quark_pack_reorder
+            ),
         )
         self.kernel.process_weights_after_loading(layer)
 
@@ -913,6 +1141,8 @@ class AutoAWQLinearMethod(BaseAWQLinearMethod):
         layer.qweight = torch.nn.Parameter(layer.qweight.data, requires_grad=False)
         layer.qzeros = torch.nn.Parameter(layer.qzeros.data, requires_grad=False)
         layer.scales = torch.nn.Parameter(layer.scales.data, requires_grad=False)
+        if not self.quant_config.zero_point:
+            layer.qzeros.data.zero_()
 
     def apply(
         self,
@@ -924,18 +1154,33 @@ class AutoAWQLinearMethod(BaseAWQLinearMethod):
         scales = layer.scales
         qzeros = layer.qzeros
         pack_factor = self.quant_config.pack_factor
+        signed_int4 = self.quant_config.is_quark_format
+        pack_reorder = self.quant_config.quark_pack_reorder
         out_shape = x.shape[:-1] + (qweight.shape[-1] * pack_factor,)
         reshaped_x = x.reshape(-1, x.shape[-1])
 
-        # num_tokens >= threshold
-        FP16_MATMUL_HEURISTIC_CONDITION = x.shape[:-1].numel() >= 256
-        # Batch invariant mode requires torch.matmul path
-        # for Triton override
-        if FP16_MATMUL_HEURISTIC_CONDITION or envs.VLLM_BATCH_INVARIANT:
-            out = ops.awq_dequantize(qweight, scales, qzeros, 0, 0, 0)
+        if x.shape[:-1].numel() >= 256 or envs.VLLM_BATCH_INVARIANT:
+            out = ops.awq_dequantize(
+                qweight,
+                scales,
+                qzeros,
+                0,
+                0,
+                0,
+                signed_int4=signed_int4,
+                pack_reorder=pack_reorder,
+            )
             out = torch.matmul(reshaped_x, out)
         else:
-            out = ops.awq_gemm(reshaped_x, qweight, scales, qzeros, pack_factor)
+            out = ops.awq_gemm(
+                reshaped_x,
+                qweight,
+                scales,
+                qzeros,
+                pack_factor,
+                signed_int4=signed_int4,
+                pack_reorder=pack_reorder,
+            )
         if bias is not None:
             out.add_(bias)
         return out.reshape(out_shape)

--- a/vllm/model_executor/layers/quantization/awq_triton.py
+++ b/vllm/model_executor/layers/quantization/awq_triton.py
@@ -7,6 +7,15 @@ from vllm.triton_utils import tl, triton
 
 AWQ_TRITON_SUPPORTED_GROUP_SIZES = [-1, 32, 64, 128]
 
+# AWQ uses a non-standard packing order within int32 values.
+_REVERSE_AWQ_PACK_ORDER = [0, 4, 1, 5, 2, 6, 3, 7]
+
+
+@triton.jit
+def _sign_extend_int4_triton(values):
+    values = values.to(tl.int32)
+    return tl.where(values >= 8, values - 16, values)
+
 
 @triton.jit
 def awq_dequantize_kernel(
@@ -19,6 +28,8 @@ def awq_dequantize_kernel(
     num_rows,  # input num rows in qweight
     BLOCK_SIZE_X: tl.constexpr,
     BLOCK_SIZE_Y: tl.constexpr,
+    SIGNED_INT4: tl.constexpr,
+    PACK_REORDER: tl.constexpr,
 ):
     # Set up the pids.
     pid_x = tl.program_id(axis=0)
@@ -51,20 +62,23 @@ def awq_dequantize_kernel(
     iweights = tl.interleave(iweights, iweights)
     iweights = tl.interleave(iweights, iweights)
 
-    # Create reverse AWQ order as tensor: [0, 4, 1, 5, 2, 6, 3, 7]
-    # that will map given indices to the correct order.
-    reverse_awq_order_tensor = (
-        (tl.arange(0, 2) * 4)[None, :] + tl.arange(0, 4)[:, None]
-    ).reshape(8)
+    # Create nibble unpack shifts. AWQ reorder uses [0,4,1,5,2,6,3,7];
+    # Quark file-to-file "order" packing uses sequential [0..7].
+    if PACK_REORDER:
+        pack_order_tensor = (
+            (tl.arange(0, 2) * 4)[None, :] + tl.arange(0, 4)[:, None]
+        ).reshape(8)
+    else:
+        pack_order_tensor = tl.arange(0, 8)
 
-    # Use this to compute a set of shifts that can be used to unpack and
-    # reorder the values in iweights and zeros.
-    shifts = reverse_awq_order_tensor * 4
+    shifts = pack_order_tensor * 4
     shifts = tl.broadcast_to(shifts[None, :], (BLOCK_SIZE_Y * BLOCK_SIZE_X, 8))
     shifts = tl.reshape(shifts, (BLOCK_SIZE_Y, BLOCK_SIZE_X * 8))
 
     # Unpack and reorder: shift out the correct 4-bit value and mask.
     iweights = (iweights >> shifts) & 0xF
+    if SIGNED_INT4:
+        iweights = _sign_extend_int4_triton(iweights)
 
     # Compute zero offsets and masks.
     zero_offsets_y = pid_y * BLOCK_SIZE_Y // group_size + tl.arange(0, 1)
@@ -84,6 +98,8 @@ def awq_dequantize_kernel(
 
     # Unpack and reorder: shift out the correct 4-bit value and mask.
     zeros = (zeros >> shifts) & 0xF
+    if SIGNED_INT4:
+        zeros = _sign_extend_int4_triton(zeros)
 
     # Compute scale offsets and masks.
     scale_offsets_y = pid_y * BLOCK_SIZE_Y // group_size + tl.arange(0, 1)
@@ -120,6 +136,8 @@ def awq_gemm_kernel(
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
     SPLIT_K: tl.constexpr,
+    SIGNED_INT4: tl.constexpr,
+    PACK_REORDER: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
     pid_z = tl.program_id(1)
@@ -131,24 +149,16 @@ def awq_gemm_kernel(
     pid_m = pid // num_pid_n
     pid_n = pid % num_pid_n
 
-    accumulator_dtype = c_ptr.type.element_ty
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
 
-    # NOTE: This doesn't work in TRITON_INTERPRET=1 mode.  Use below instead.
-    # accumulator = tl.arange(0, BLOCK_SIZE_N)
-    # accumulator = tl.broadcast_to(accumulator[None, :],
-    # (BLOCK_SIZE_M, BLOCK_SIZE_N))
-    # accumulator = accumulator & 0x0
-    # accumulator = accumulator.to(accumulator_dtype)
-    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=accumulator_dtype)
+    if PACK_REORDER:
+        pack_order_tensor = (
+            (tl.arange(0, 2) * 4)[None, :] + tl.arange(0, 4)[:, None]
+        ).reshape(8)
+    else:
+        pack_order_tensor = tl.arange(0, 8)
 
-    # Create reverse AWQ order as tensor: [0, 4, 1, 5, 2, 6, 3, 7]
-    # that will map given indices to the correct order.
-    reverse_awq_order_tensor = (
-        (tl.arange(0, 2) * 4)[None, :] + tl.arange(0, 4)[:, None]
-    ).reshape(8)
-
-    # Create the necessary shifts to use to unpack.
-    shifts = reverse_awq_order_tensor * 4
+    shifts = pack_order_tensor * 4
     shifts = tl.broadcast_to(shifts[None, :], (BLOCK_SIZE_K * (BLOCK_SIZE_N // 8), 8))
     shifts = tl.reshape(shifts, (BLOCK_SIZE_K, BLOCK_SIZE_N))
 
@@ -179,6 +189,7 @@ def awq_gemm_kernel(
         masks_k = offsets_k < K
         masks_a = masks_am[:, None] & masks_k[None, :]
         a = tl.load(a_ptrs, mask=masks_a, other=0.0)
+        a = a.to(tl.float32)
 
         masks_b = masks_k[:, None] & masks_bn[None, :]
         b = tl.load(b_ptrs, mask=masks_b, other=0.0)
@@ -209,11 +220,14 @@ def awq_gemm_kernel(
 
         b = (b >> shifts) & 0xF
         zeros = (zeros >> shifts) & 0xF
+        if SIGNED_INT4:
+            b = _sign_extend_int4_triton(b)
+            zeros = _sign_extend_int4_triton(zeros)
         b = (b - zeros) * scales
-        b = b.to(c_ptr.type.element_ty)
+        b = b.to(tl.float32)
 
         # Accumulate results.
-        accumulator = tl.dot(a, b, accumulator, out_dtype=accumulator_dtype)
+        accumulator = tl.dot(a, b, accumulator, out_dtype=tl.float32)
 
         offsets_k += BLOCK_SIZE_K * SPLIT_K
         a_ptrs += BLOCK_SIZE_K * SPLIT_K
@@ -236,6 +250,8 @@ def awq_dequantize_triton(
     zeros: torch.Tensor,
     block_size_x: int = 32,
     block_size_y: int = 32,
+    signed_int4: bool = False,
+    pack_reorder: bool = True,
 ) -> torch.Tensor:
     K = qweight.shape[0]
     M = scales.shape[1]
@@ -274,6 +290,8 @@ def awq_dequantize_triton(
         Y,
         BLOCK_SIZE_X=block_size_x,
         BLOCK_SIZE_Y=block_size_y,
+        SIGNED_INT4=signed_int4,
+        PACK_REORDER=pack_reorder,
     )
 
     return result
@@ -293,6 +311,8 @@ def awq_gemm_triton(
     block_size_m: int = 32,
     block_size_n: int = 32,
     block_size_k: int = 32,
+    signed_int4: bool = False,
+    pack_reorder: bool = True,
 ) -> torch.Tensor:
     M, K = input.shape
     N = qweight.shape[1] * 8
@@ -330,6 +350,8 @@ def awq_gemm_triton(
         BLOCK_SIZE_N=block_size_n,
         BLOCK_SIZE_K=block_size_k,
         SPLIT_K=split_k_iters,
+        SIGNED_INT4=signed_int4,
+        PACK_REORDER=pack_reorder,
     )
 
     result = result.sum(0)

--- a/vllm/model_executor/layers/quantization/moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/moe_wna16.py
@@ -43,6 +43,9 @@ class MoeWNA16Config(QuantizationConfig):
         lm_head_quantized: bool,
         modules_to_not_convert: list[str] | None,
         full_config: dict[str, Any],
+        is_quark_format: bool = False,
+        quark_pack_reorder: bool = True,
+        signed_int4: bool = False,
     ) -> None:
         super().__init__()
         self.weight_bits = weight_bits
@@ -52,6 +55,9 @@ class MoeWNA16Config(QuantizationConfig):
         self.lm_head_quantized = lm_head_quantized
         self.linear_quant_method = linear_quant_method
         self.full_config = full_config
+        self.is_quark_format = is_quark_format
+        self.quark_pack_reorder = quark_pack_reorder
+        self.signed_int4 = signed_int4
         # Avoid circular import
         from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
 
@@ -111,6 +117,11 @@ class MoeWNA16Config(QuantizationConfig):
         else:
             raise ValueError("moe_wna16 only support gptq and awq.")
 
+        pack_method = config.get("pack_method")
+        is_quark_format = pack_method in ("order", "reorder")
+        quark_pack_reorder = (not is_quark_format) or pack_method == "reorder"
+        signed_int4 = is_quark_format and weight_bits == 4 and not has_zp
+
         return cls(
             linear_quant_method,
             weight_bits,
@@ -119,6 +130,9 @@ class MoeWNA16Config(QuantizationConfig):
             lm_head_quantized,
             modules_to_not_convert,
             config,
+            is_quark_format,
+            quark_pack_reorder,
+            signed_int4,
         )
 
     @classmethod
@@ -331,13 +345,16 @@ class MoeWNA16Method(FusedMoEMethodBase):
             else int8_w8a16_moe_quant_config
         )
 
-        return config_builder(
-            w1_scale=layer.w13_scales,
-            w2_scale=layer.w2_scales,
-            w1_zp=layer.w13_qzeros if has_zp else None,
-            w2_zp=layer.w2_qzeros if has_zp else None,
-            block_shape=[0, layer.group_size],
-        )
+        config_kwargs = {
+            "w1_scale": layer.w13_scales,
+            "w2_scale": layer.w2_scales,
+            "w1_zp": layer.w13_qzeros if has_zp else None,
+            "w2_zp": layer.w2_qzeros if has_zp else None,
+            "block_shape": [0, layer.group_size],
+        }
+        if weight_bits == 4:
+            config_kwargs["signed_int4"] = self.quant_config.signed_int4
+        return config_builder(**config_kwargs)
 
     def apply(
         self,
@@ -386,8 +403,11 @@ class MoeWNA16Method(FusedMoEMethodBase):
             # 3. change order, see
             # https://github.com/casper-hansen/AutoAWQ/blob/v0.2.8/awq/utils/quant_utils.py
             # shape -> (a, 4 * b * pack_factor_bit8)
-            reverse_awq_pack_order = [0, 4, 1, 5, 2, 6, 3, 7]
-            tensor = tensor.view(-1, 8)[:, reverse_awq_pack_order]
+            if layer.quant_config.quark_pack_reorder:
+                reverse_awq_pack_order = [0, 4, 1, 5, 2, 6, 3, 7]
+                tensor = tensor.view(-1, 8)[:, reverse_awq_pack_order]
+            else:
+                tensor = tensor.view(-1, 8)
             tensor = tensor.view(size0, -1)
 
             # 4. transpose, shape -> (4 * b * pack_factor_bit8, a)

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -206,7 +206,11 @@ class Qwen3_5Model(Qwen3NextModel):
             ".in_proj_z": (".in_proj_qkvz", 3),
             ".in_proj_b": (".in_proj_ba", 0),
             ".in_proj_a": (".in_proj_ba", 1),
-        }
+        },
+        # Quark AWQ exports nest the router under gate.linear.*
+        orig_to_new_substr={
+            ".gate.linear.": ".gate.",
+        },
     )
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
@@ -250,6 +254,76 @@ class Qwen3_5Model(Qwen3NextModel):
             self.norm = PPMissingLayer()
 
         self.aux_hidden_state_layers: tuple[int, ...] = ()
+
+    @staticmethod
+    def _dequantize_shared_expert_gate_weights(
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> Iterable[tuple[str, torch.Tensor]]:
+        """Dequantize Quark AWQ shared-expert gate weights to fp16."""
+        weight_map: dict[str, torch.Tensor] = {}
+        scale_map: dict[str, torch.Tensor] = {}
+        passthrough: list[tuple[str, torch.Tensor]] = []
+
+        for name, weight in weights:
+            if name.endswith(".shared_expert_gate.weight_scale") or name.endswith(
+                ".shared_expert_gate.scales"
+            ):
+                prefix = name.rsplit(".", 1)[0]
+                scale_map[prefix] = weight
+            elif name.endswith(".shared_expert_gate.weight") or name.endswith(
+                ".shared_expert_gate.qweight"
+            ):
+                prefix = name.rsplit(".", 1)[0]
+                weight_map[prefix] = weight
+            else:
+                passthrough.append((name, weight))
+
+        group_size = 128
+        dequantized_prefixes: set[str] = set()
+        dequantized: list[tuple[str, torch.Tensor]] = []
+        for prefix, weight in weight_map.items():
+            scale = scale_map.get(prefix)
+            if scale is None:
+                passthrough.append((f"{prefix}.weight", weight))
+                continue
+            values = weight.to(torch.int32) & 0xF
+            values = torch.where(values >= 8, values - 16, values)
+            scale_expanded = scale.to(torch.float32).repeat_interleave(
+                group_size, dim=0
+            )
+            dequantized.append(
+                (
+                    f"{prefix}.weight",
+                    (values.to(torch.float32) * scale_expanded)
+                    .t()
+                    .contiguous(),
+                )
+            )
+            dequantized_prefixes.add(prefix)
+
+        for prefix, scale in scale_map.items():
+            if prefix not in dequantized_prefixes:
+                passthrough.append((f"{prefix}.weight_scale", scale))
+
+        for name, weight in passthrough:
+            if ".shared_expert_gate." in name and (
+                name.endswith(".weight_zero_point")
+                or name.endswith(".scales")
+                or name.endswith(".qzeros")
+                or name.endswith(".qweight")
+            ):
+                continue
+            if name.endswith(".shared_expert_gate.weight_scale"):
+                prefix = name.removesuffix(".weight_scale")
+                if prefix in dequantized_prefixes:
+                    continue
+            if name.endswith(".shared_expert_gate.weight"):
+                prefix = name.rsplit(".", 1)[0]
+                if prefix in dequantized_prefixes:
+                    continue
+            yield name, weight
+
+        yield from dequantized
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         mapper = self.hf_to_vllm_mapper
@@ -357,11 +431,16 @@ class Qwen3_5ForCausalLMBase(
         return self.logits_processor(self.lm_head, hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        skip_prefixes = ["mtp."]
+        if self.config.tie_word_embeddings:
+            skip_prefixes = ["lm_head.", *skip_prefixes]
         loader = AutoWeightsLoader(
             self,
-            skip_prefixes=["mtp."],
+            skip_prefixes=skip_prefixes,
         )
-        return loader.load_weights(weights)
+        return loader.load_weights(
+            Qwen3_5Model._dequantize_shared_expert_gate_weights(weights)
+        )
 
 
 class Qwen3_5ForCausalLM(Qwen3_5ForCausalLMBase):
@@ -503,11 +582,17 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
         return hidden_states
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        skip_prefixes = ["mtp."]
+        if self.language_model.config.tie_word_embeddings:
+            skip_prefixes = ["language_model.lm_head.", *skip_prefixes]
         loader = AutoWeightsLoader(
             self,
-            skip_prefixes=["mtp."],
+            skip_prefixes=skip_prefixes,
         )
-        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        return loader.load_weights(
+            Qwen3_5Model._dequantize_shared_expert_gate_weights(weights),
+            mapper=self.hf_to_vllm_mapper,
+        )
 
     @classmethod
     def get_mamba_state_dtype_from_config(

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -78,6 +78,58 @@ logger = init_logger(__name__)
 KVCache = tuple[torch.Tensor, torch.Tensor]
 
 
+def _dequantize_quark_shared_expert_gate(
+    qweight: torch.Tensor, scales: torch.Tensor
+) -> torch.Tensor:
+    values = qweight.to(torch.int32) & 0xF
+    values = torch.where(values >= 8, values - 16, values)
+    scales = scales.to(torch.float32).repeat_interleave(128, dim=0)
+    return (values.to(torch.float32) * scales).T.contiguous()
+
+
+def _dequantize_quark_shared_expert_gate_weights(
+    weights: Iterable[tuple[str, torch.Tensor]],
+) -> Iterable[tuple[str, torch.Tensor]]:
+    pending_weights: dict[str, torch.Tensor] = {}
+    pending_scales: dict[str, torch.Tensor] = {}
+
+    def maybe_emit(prefix: str):
+        qweight = pending_weights.pop(prefix, None)
+        scales = pending_scales.pop(prefix, None)
+        if qweight is None or scales is None:
+            if qweight is not None:
+                pending_weights[prefix] = qweight
+            if scales is not None:
+                pending_scales[prefix] = scales
+            return None
+        return prefix + ".weight", _dequantize_quark_shared_expert_gate(
+            qweight, scales
+        )
+
+    for name, weight in weights:
+        if name.endswith(".shared_expert_gate.weight_scale"):
+            prefix = name[: -len(".weight_scale")]
+            pending_scales[prefix] = weight
+            emitted = maybe_emit(prefix)
+            if emitted is not None:
+                yield emitted
+            continue
+        if name.endswith(".shared_expert_gate.weight") and weight.dtype in (
+            torch.int32,
+            torch.int64,
+        ):
+            prefix = name[: -len(".weight")]
+            pending_weights[prefix] = weight
+            emitted = maybe_emit(prefix)
+            if emitted is not None:
+                yield emitted
+            continue
+        yield name, weight
+
+    for prefix, weight in pending_weights.items():
+        yield prefix + ".weight", weight
+
+
 def _is_shared_expert_fse_compatible(quant_config) -> bool:
     """Check if shared expert can be fused with routed experts.
 
@@ -139,7 +191,7 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             config.hidden_size,
             config.num_experts,
             bias=False,
-            quant_config=None,
+            quant_config=quant_config,
             prefix=f"{prefix}.gate",
         )
 
@@ -638,6 +690,7 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
                 orig_to_new_substr={"mlp.shared_expert.": f"mlp.experts.{num_routed}."}
             )
         loader = AutoWeightsLoader(self)
+        weights = _dequantize_quark_shared_expert_gate_weights(weights)
         return loader.load_weights(weights, mapper=mapper)
 
 


### PR DESCRIPTION
## Summary

- Detect Quark `pack_method="order"` / `"reorder"` in `AutoAWQConfig` and remap Quark tensor names so exported AWQ checkpoints load through `AutoWeightsLoader`.
- Handle Quark signed INT4 semantics in AWQ Triton and MoE WNA16 paths, including shared expert gate dequantization for Qwen3.5 MoE checkpoints.
- Respect excluded FP16 modules in mixed Quark AWQ exports and extend Qwen3.5 / Qwen3-Next model loading for Quark AWQ weights.

**Why not a duplicate PR:** No existing PR addresses Quark AWQ format compatibility and signed INT4 inference support together.

**Tests run:**
```
.venv/bin/python -m pytest tests/quantization/test_auto_awq.py -k "not test_auto_awq_quantization_method" -v
```

**Validation:**
- Qwen3.5 Quark AWQ int4 checkpoints load in vLLM with `quantization=auto_awq`
- Dialogue smoke test passed for mixed FP16 + INT4 exports
- GSM8K 5-shot: 86.13% (vs bf16 baseline 87.87%, delta ~1.7% as expected for int4)

**AI assistance:** This change was developed with Cursor assistance. All changed lines were reviewed by the human submitter.
