### PR TITLE
[ROCm][CI] Minimize comment in RocmAttention q_scale check

### DIFF
--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -421,13 +421,8 @@ class RocmAttentionImpl(AttentionImpl):
         if is_quantized_kv_cache(self.kv_cache_dtype):
             key_cache = key_cache.view(self.fp8_dtype)
             value_cache = value_cache.view(self.fp8_dtype)
-            # chunked_prefill_paged_decode runs attention with a full-precision
-            # query (it does not quantize Q to fp8 and does not consume
-            # q_scale), so q_scale only matters when the query itself is fp8.
-            # For a non-fp8 query, q_scale is not applicable and is ignored
-            # (mirrors TritonAttentionImpl). This avoids spuriously failing on
-            # checkpoints that carry a non-1.0 q_scale while keeping the query
-            # in full precision.
+            # q_scale only applies to an fp8 query; this path keeps the query
+            # in full precision, so a non-1.0 q_scale is not applicable here.
             if query.dtype == self.fp8_dtype and layer._q_scale_float != 1.0:
                 raise NotImplementedError(
                     "A non 1.0 q_scale with an fp8 query is not currently "


### PR DESCRIPTION
## Purpose

Follow-up to #46148 addressing review feedback from @Rohan138: the explanatory
comment above the fp8-query `q_scale` guard in `RocmAttentionImpl.forward()` was
too long. This PR shortens it to a concise two lines.

**No functional change** — only the comment is edited; the guard logic is
untouched.

## Test Plan

Comment-only change; no new tests required. Behavior is unchanged and remains
covered by the existing test that motivated #46148:

```bash
pytest tests/model_executor/model_loader/test_reload.py::test_kv_scale_reload
```

## Test Result

No functional change. The originally fixed test continues to pass on ROCm
(MI300, gfx942): `test_kv_scale_reload` -> 1 passed.

---

## Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR is clearly stated.
- [x] This is a follow-up to #46148 (review feedback), comment-only.
- [x] No functional change; existing coverage still applies.
- [ ] (CI) Validate on the ROCm CI lane.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

