### PR TITLE
[ROCm][CI][Bugfix] Update mrope triton kernel to support disabling neox style

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/mrope.py
+++ b/vllm/model_executor/layers/rotary_embedding/mrope.py
@@ -29,6 +29,7 @@ def _triton_mrope_forward(
     mrope_section_h: tl.constexpr,
     mrope_section_w: tl.constexpr,
     is_interleaved: tl.constexpr,
+    is_neox: tl.constexpr,
 ):
     # Adapted from
     # https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/qwen2vl_mrope.py
@@ -82,13 +83,21 @@ def _triton_mrope_forward(
     # Load the left and right half of q and k for the current
     # program instance (i.e. for the current token) separately
     # ####################################################################
-    # left half of the head
-    first_half_q_offsets = (
-        tl.arange(0, pad_n_qh)[:, None] * hd + tl.arange(0, pad_hd // 2)[None, :]
-    )
-    first_half_k_offsets = (
-        tl.arange(0, pad_n_kh)[:, None] * hd + tl.arange(0, pad_hd // 2)[None, :]
-    )
+    col = tl.arange(0, pad_hd // 2)
+    if is_neox:
+        first_cols = col  # 0, 1, 2, ...          (first half)
+        second_cols = col + (rd // 2)  # rd/2, rd/2+1, ...      (second half)
+    else:
+        first_cols = col * 2  # 0, 2, 4, ...           (even)
+        second_cols = col * 2 + 1  # 1, 3, 5, ...           (odd)
+
+    # left/Even half of the head
+    first_half_q_offsets = tl.arange(0, pad_n_qh)[:, None] * hd + first_cols[None, :]
+    first_half_k_offsets = tl.arange(0, pad_n_kh)[:, None] * hd + first_cols[None, :]
+    # Right/Odd half of the head
+    second_half_q_offsets = tl.arange(0, pad_n_qh)[:, None] * hd + second_cols[None, :]
+    second_half_k_offsets = tl.arange(0, pad_n_kh)[:, None] * hd + second_cols[None, :]
+
     first_q_mask = (tl.arange(0, pad_n_qh)[:, None] < n_qh) & (
         tl.arange(0, pad_hd // 2)[None, :] < rd // 2
     )
@@ -103,9 +112,6 @@ def _triton_mrope_forward(
         sin_row.dtype
     )
 
-    # right half of the head
-    second_half_q_offsets = first_half_q_offsets + (rd // 2)
-    second_half_k_offsets = first_half_k_offsets + (rd // 2)
     second_q_mask = first_q_mask
     second_k_mask = first_k_mask
 
@@ -139,6 +145,7 @@ def triton_mrope(
     head_size: int,
     rotary_dim: int,
     mrope_interleaved: bool,
+    is_neox: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Qwen2VL mrope kernel.
 
@@ -183,6 +190,7 @@ def triton_mrope(
         mrope_section[1],
         mrope_section[2],
         mrope_interleaved,
+        is_neox,
     )
     return q, k
 
@@ -349,6 +357,7 @@ class MRotaryEmbedding(RotaryEmbeddingBase):
                 self.head_size,
                 self.rotary_dim,
                 self.mrope_interleaved,
+                self.is_neox_style,
             )
 
             return q.reshape(query_shape), k.reshape(key_shape)


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix a bug with `glm4_1v-vision` model that was failing the `models/multimodal/generation/test_common.py::test_custom_inputs_models` test. The source of the issue is that the mrope embedding is expected to have GPT-J style, but the triton kernel used by default only supports running with neox style. This PR adds the neox-style flag to the triton kernel that when disabled uses GPT-J style instead. This way the mrope embeddings are properly calculated for `glm4_1v-vision` and potentially other models that are reliant on  GPT-J style mrope embeddings.

## Test Plan
Run the failing test and confirm that the output is reasonable.

## Test Result
The test is now passing and the output is reasonable.

After fix:

> vllm: "<think>Got it, let's analyze the video. First, the scene shows a child sitting on a bed, interacting with a book. The child is wearing a light blue shirt and glasses. The setting seems to be a bedroom with a bed covered in blankets or sheets, and there's a person standing in the background, maybe an adult. The child is focused on the book, turning pages, which suggests they're reading or looking at the book. The environment has a cozy, homey feel, with the bed and the person in the back. The child's actions are gentle, like flipping pages, so it's a calm moment." 

Before fix

> vllm:       "<think>Got it, let's analyze the video. First, I need to describe the video step by step. First, look at the sequence of events. The video starts with a scene where a child is sitting on the floor, maybe a little girl, wearing a light blue dress, maybe a light blue dress, sitting on the floor, maybe a light blue dress, with a book or something,then she's reading or doing something with a book, then she's sitting on the floor, then she's interacting with a book, then she's holding a book, thenshe's sitting on the floor, then she's interacting with a"

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

