### PR TITLE
[Bugfix] Add per-type field validation to AnthropicContentBlock

### DIFF
--- a/tests/entrypoints/anthropic/test_content_block_validation.py
+++ b/tests/entrypoints/anthropic/test_content_block_validation.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for AnthropicContentBlock per-type field validation.
+
+Guards that tool_use blocks missing required fields raise a 422-able
+ValidationError, and that all other block types are unaffected.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.entrypoints.anthropic.protocol import AnthropicContentBlock
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+# ======================================================================
+# tool_use — required fields enforced
+# ======================================================================
+
+
+def test_tool_use_missing_id_raises():
+    with pytest.raises(ValidationError, match="non-empty 'id'"):
+        AnthropicContentBlock(
+            type="tool_use",
+            name="get_weather",
+            input={"city": "NYC"},
+        )
+
+
+def test_tool_use_empty_id_raises():
+    with pytest.raises(ValidationError, match="non-empty 'id'"):
+        AnthropicContentBlock(
+            type="tool_use",
+            id="",
+            name="get_weather",
+            input={"city": "NYC"},
+        )
+
+
+def test_tool_use_missing_name_raises():
+    with pytest.raises(ValidationError, match="non-empty 'name'"):
+        AnthropicContentBlock(
+            type="tool_use",
+            id="toolu_01",
+            input={"city": "NYC"},
+        )
+
+
+def test_tool_use_empty_name_raises():
+    with pytest.raises(ValidationError, match="non-empty 'name'"):
+        AnthropicContentBlock(
+            type="tool_use",
+            id="toolu_01",
+            name="",
+            input={"city": "NYC"},
+        )
+
+
+def test_tool_use_missing_input_raises():
+    with pytest.raises(ValidationError, match="'input'"):
+        AnthropicContentBlock(
+            type="tool_use",
+            id="toolu_01",
+            name="get_weather",
+        )
+
+
+def test_tool_use_valid_passes():
+    block = AnthropicContentBlock(
+        type="tool_use",
+        id="toolu_01",
+        name="get_weather",
+        input={"city": "NYC"},
+    )
+    assert block.name == "get_weather"
+    assert block.id == "toolu_01"
+    assert block.input == {"city": "NYC"}
+
+
+def test_tool_use_empty_input_dict_passes():
+    block = AnthropicContentBlock(
+        type="tool_use",
+        id="toolu_01",
+        name="ping",
+        input={},
+    )
+    assert block.input == {}
+
+
+# ======================================================================
+# text — text must not be None
+# ======================================================================
+
+
+def test_text_block_none_text_raises():
+    with pytest.raises(ValidationError, match="text block requires 'text'"):
+        AnthropicContentBlock(type="text")
+
+
+def test_text_block_empty_string_passes():
+    block = AnthropicContentBlock(type="text", text="")
+    assert block.text == ""
+
+
+def test_text_block_with_content_passes():
+    block = AnthropicContentBlock(type="text", text="hello")
+    assert block.text == "hello"
+
+
+# ======================================================================
+# image — source must not be None
+# ======================================================================
+
+
+def test_image_block_missing_source_raises():
+    with pytest.raises(ValidationError, match="image block requires 'source'"):
+        AnthropicContentBlock(type="image")
+
+
+def test_image_block_with_source_passes():
+    block = AnthropicContentBlock(
+        type="image",
+        source={"type": "url", "url": "https://example.com/img.png"},
+    )
+    assert block.source is not None
+
+
+# ======================================================================
+# Unvalidated types — no new constraints introduced
+# ======================================================================
+
+
+def test_tool_result_without_tool_use_id_passes():
+    block = AnthropicContentBlock(type="tool_result")
+    assert block.type == "tool_result"
+
+
+def test_thinking_block_passes_with_no_extra_fields():
+    block = AnthropicContentBlock(type="thinking")
+    assert block.thinking is None
+
+
+def test_redacted_thinking_block_passes():
+    block = AnthropicContentBlock(type="redacted_thinking", data="opaque")
+    assert block.data == "opaque"
+
+
+def test_tool_reference_block_passes():
+    block = AnthropicContentBlock(type="tool_reference", tool_name="search")
+    assert block.tool_name == "search"

--- a/vllm/entrypoints/anthropic/protocol.py
+++ b/vllm/entrypoints/anthropic/protocol.py
@@ -61,6 +61,23 @@ class AnthropicContentBlock(BaseModel):
     # For redacted thinking content (safety-filtered by the API)
     data: str | None = None
 
+    @model_validator(mode="after")
+    def validate_required_fields(self) -> "AnthropicContentBlock":
+        if self.type == "tool_use":
+            if not self.id:
+                raise ValueError("tool_use block requires a non-empty 'id'")
+            if not self.name:
+                raise ValueError("tool_use block requires a non-empty 'name'")
+            if self.input is None:
+                raise ValueError("tool_use block requires 'input' (use {} for empty)")
+        elif self.type == "text":
+            if self.text is None:
+                raise ValueError("text block requires 'text'")
+        elif self.type == "image":
+            if self.source is None:
+                raise ValueError("image block requires 'source'")
+        return self
+
 
 class AnthropicMessage(BaseModel):
     """Message structure"""

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -384,8 +384,8 @@ class AnthropicServingMessages(OpenAIServingChat):
             "id": block.id or f"call_{int(time.time())}",
             "type": "function",
             "function": {
-                "name": block.name or "",
-                "arguments": json.dumps(block.input or {}),
+                "name": block.name,
+                "arguments": json.dumps(block.input),
             },
         }
         tool_calls.append(tool_call)


### PR DESCRIPTION
## Purpose
Fixes #47746.

`AnthropicContentBlock` in `vllm/entrypoints/anthropic/protocol.py` accepted
`tool_use` blocks with missing required fields (`name`, `id`, `input`), silently
coercing them to empty strings in `_convert_tool_use_block`:

```python
"name": block.name or "",           # empty string function name
"arguments": json.dumps(block.input or {}),  # empty args
```

This PR adds a `model_validator` enforcing required fields per type, following
the existing pattern in `AnthropicToolChoice` in the same file.

## Fix
- `protocol.py`: Added `model_validator` to `AnthropicContentBlock` enforcing:
  - `tool_use` blocks: `id`, `name`, `input` all required
  - `text` blocks: `text` must not be `None`
  - `image` blocks: `source` must not be `None`
- `serving.py`: Removed `or ""` / `or {}` fallbacks in `_convert_tool_use_block`
  (now unreachable after parse-time validation)

## Test Plan
```bash
python3 -m pytest tests/entrypoints/anthropic/test_content_block_validation.py -v
```

## Test Result
```
16 passed in 0.20s

ruff check          Passed
ruff format         Passed
typos               Passed
Run mypy (3.10)     Passed
Check SPDX headers  Passed
```

## Related
- Follows pattern of `AnthropicToolChoice` model_validator in same file
- Related to #34745 (`tool_result` fix, merged)
- Related to #45287 (streaming args fix, merged)

## AI Assistance
This change was prepared with AI assistance (Claude Code).