### PR TITLE
[CI] Skip test for checkpoint that was deleted

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -938,6 +938,7 @@ _MULTIMODAL_EXAMPLE_MODELS = {
     "HunYuanVLForConditionalGeneration": _HfExamplesInfo(
         "tencent/HunyuanOCR",
         hf_overrides={"num_experts": 0},
+        is_available_online=False,
     ),
     "Idefics3ForConditionalGeneration": _HfExamplesInfo(
         "HuggingFaceM4/Idefics3-8B-Llama3",


### PR DESCRIPTION
Tencent just deleted `tencent/HunyuanOCR` and most of vLLM's CI runners have broken HF caches.

This PR marks the checkpoint as not available online so that it deosn't block the rest of CI.