### PR TITLE
[Bugfix] Disable custom all-reduce on consumer Blackwell (sm_12x)

### DIFF
--- a/tests/distributed/test_custom_all_reduce.py
+++ b/tests/distributed/test_custom_all_reduce.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import random
+from unittest.mock import patch
 
 import pytest
 import ray
@@ -130,3 +131,27 @@ def test_custom_allreduce(
     if world_size > torch.accelerator.device_count():
         pytest.skip("Not enough GPUs to run the test.")
     multi_process_parallel(monkeypatch, tp_size, pipeline_parallel_size, test_target)
+
+
+@pytest.mark.parametrize(
+    "is_cuda,is_sm12x,expected",
+    [
+        (True, True, True),  # consumer Blackwell (sm_120 / sm_121): unsupported
+        (True, False, False),  # other CUDA arch (sm_90 / sm_100 / ...): supported
+        (False, True, False),  # non-CUDA platform (e.g. ROCm): not gated
+    ],
+)
+def test_is_unsupported_arch(is_cuda, is_sm12x, expected):
+    from vllm.distributed.device_communicators import custom_all_reduce
+
+    with (
+        patch.object(
+            custom_all_reduce.current_platform, "is_cuda", return_value=is_cuda
+        ),
+        patch.object(
+            custom_all_reduce.current_platform,
+            "is_device_capability_family",
+            return_value=is_sm12x,
+        ),
+    ):
+        assert custom_all_reduce.CustomAllreduce._is_unsupported_arch() is expected

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -66,6 +66,19 @@ class CustomAllreduce:
     _DEFAULT_REDUCE_SCATTER_MAX_SIZE = 16 * 1024 * 1024
     _DEFAULT_MNNVL_REDUCE_SCATTER_MAX_SIZE = 16 * 1024 * 1024
 
+    @staticmethod
+    def _is_unsupported_arch() -> bool:
+        # The custom all-reduce kernels are only built and tuned for sm_90 and
+        # sm_100 (see CUSTOM_ALL_REDUCE_MAX_SIZES). On consumer Blackwell
+        # (sm_12x, e.g. RTX PRO 6000 / RTX 50-series) the kernel's IPC /
+        # peer-mapping path aborts with `custom_all_reduce.cuh 'invalid
+        # argument'` during cudagraph capture, so the entire 12.x family is
+        # unsupported and callers must fall back to NCCL all-reduce.
+        return (
+            current_platform.is_cuda()
+            and current_platform.is_device_capability_family(120)
+        )
+
     # max_size: max supported allreduce size
     def __init__(
         self,
@@ -147,6 +160,14 @@ class CustomAllreduce:
         assert isinstance(device, torch.device)
         self.device = device
         device_capability = current_platform.get_device_capability()
+        if self._is_unsupported_arch():
+            logger.warning(
+                "Custom allreduce is disabled because it is not supported on "
+                "consumer Blackwell (sm_12x, e.g. RTX PRO 6000 / RTX 50-series);"
+                " falling back to NCCL all-reduce. To silence this warning, "
+                "specify disable_custom_all_reduce=True explicitly."
+            )
+            return
         if (
             current_platform.is_cuda()
             and symm_mem_enabled


### PR DESCRIPTION
## Purpose

Auto-disable vLLM's custom all-reduce on **consumer Blackwell (sm_12x)** and fall back to NCCL all-reduce.

The custom all-reduce CUDA kernels are only built and tuned for sm_90 / sm_100 (see `CUSTOM_ALL_REDUCE_MAX_SIZES`, which lists 9.0/10.0/10.3 but no 12.x). On consumer Blackwell (sm_120 / sm_121 — RTX PRO 6000, RTX 50-series, GB10/DGX Spark) the kernel's IPC / peer-mapping path aborts with `custom_all_reduce.cuh:455 'invalid argument'` during cudagraph capture, killing the TP worker.

The existing topology guards don't catch this: they only disable custom all-reduce for **more than two** PCIe-only GPUs, so a 2-GPU tensor-parallel setup passes the checks, enables the kernel, and then crashes at capture. Today users must pass `--disable-custom-all-reduce` manually.

This gates on the whole 12.x family via the existing `current_platform.is_device_capability_family(120)` helper (extracted into `CustomAllreduce._is_unsupported_arch()` for testability). sm_100 (datacenter Blackwell), Hopper, Ada, and Ampere are unaffected.

Fixes the "Issue 9a — Custom all-reduce kernel crash" blocker reported in #47266. (That report also lists 9b/9c as further, independent cudagraph-capture blockers on sm_120; this PR addresses 9a only.)

## Test Plan

- Unit test (no GPU required): `pytest tests/distributed/test_custom_all_reduce.py -k is_unsupported_arch` — asserts the sm_12x family is disabled, other CUDA archs stay enabled, and non-CUDA platforms are not gated.
- End-to-end on 2× RTX PRO 6000 (sm_120), TP=2, **without** `--disable-custom-all-reduce`:
  `vllm serve <model> --tensor-parallel-size 2` and confirm the warning fires, FULL cudagraph capture completes without the `custom_all_reduce.cuh:455` crash, and the server serves.

## Test Result

- `ruff check` / `ruff format` clean (v0.14.0, repo config); `mypy` (3.10 and 3.12) pass.
- Unit test: 3/3 pass.
- End-to-end (2× RTX PRO 6000, sm_120, TP=2, no manual flag; `disable_custom_all_reduce=False` in engine config):
  - Warning fired on both TP workers: `Custom allreduce is disabled because it is not supported on consumer Blackwell (sm_12x ...); falling back to NCCL all-reduce.`
  - `Capturing CUDA graphs (mixed prefill-decode, PIECEWISE)` and `(decode, FULL)` both completed; `Graph capturing finished` — **no `custom_all_reduce.cuh:455` crash** (the failure this PR fixes).
  - `Application startup complete`; `/health` → 200; a `/v1/completions` request returned a correct response over the NCCL fallback path.

## Notes

- **AI assistance:** this change was developed with AI assistance (Claude Code). I reviewed every changed line and ran the tests above.
- **Not a duplicate:** no open PR modifies `custom_all_reduce.py` for sm_12x (the SM12x enablement PR #41834 does not touch it); this is orthogonal to the DeepSeek-V4 `fp8_ds_mla` work in #47716.
