### PR TITLE
[ROCm] Add tuned selective_state_update config for AMD Instinct MI350/MI355

### DIFF
--- a/vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=AMD_Instinct_MI355_OAM,cache_dtype=float16.json
+++ b/vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=AMD_Instinct_MI355_OAM,cache_dtype=float16.json
@@ -1,0 +1,35 @@
+{
+    "triton_version": "3.6.0",
+    "10": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 4
+    },
+    "80": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 4
+    },
+    "160": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 4
+    },
+    "320": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 4
+    },
+    "640": {
+        "BLOCK_SIZE_M": 32,
+        "num_warps": 4
+    },
+    "1280": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 1
+    },
+    "2560": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 1
+    },
+    "5120": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 1
+    }
+}


### PR DESCRIPTION
## Summary

Adds a tuned `(BLOCK_SIZE_M, num_warps)` config for the Mamba `selective_state_update` kernel on **AMD Instinct MI350/MI355 (gfx950)**, matching the existing per-device configs vLLM already ships for NVIDIA (B200 / GB200 / H100 / H200 / RTX PRO 6000).

Without it, MI350/MI355 fall back to the generic heuristic in `get_ssm_configs()` and log:
> Using default Mamba SSU config. Performance might be sub-optimal!

## What changed

- **New file (data only, no code changes):**
  `vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=AMD_Instinct_MI355_OAM,cache_dtype=float16.json`
- Auto-loaded at runtime by `get_ssm_configs()` via device name + kernel shape. The fp16 file also covers bf16 activations (the loader canonicalizes bf16 → fp16, since the kernel only sees the state bit-width).

## How it was generated

Using the in-repo tuner on an MI355 box:

```
python benchmarks/kernels/benchmark_selective_state_update.py \
  --headdim 64 --dstate 128 --dtype float16 --mamba-ssm-cache-dtype float16 \
  --save-configs --compare --validate
```

Environment: ROCm 7.2.3, Triton 3.6.0.

## Impact (AntonV/mamba2-2.7b-hf, TP=8, MI355, fp16, conc=128, 256 prompts)

Tuned config vs the generic fallback — measured end-to-end (`vllm bench serve`, random dataset):

| decode out (in=512) | stock (fallback) | tuned | 
|---|---|---|
| 256  | 16.6K | 21.6K (+30%) |
| 512  | 19.3K | 25.1K (+30%) |
| 1024 | 21.4K | 27.4K (+28%) |
| 2048 | 22.5K | 28.6K (+27%) |
| 4096 | 23.0K | 29.2K (+27%) |

(output tok/s; ~2x on the `selective_state_update` kernel itself). Same lift observed under bf16.

## Notes

- The file targets GPUs reporting `AMD_Instinct_MI355_OAM` (from `torch.cuda.get_device_name()`). Happy to add an MI350-named copy if the reported string differs on that part.
- Follows the existing convention of one config per (headdim, dstate, device, cache_dtype). Can add the `cache_dtype=float32` variant too if desired.

Made with [Cursor](https://cursor.com)