### PR TITLE
[CPU][Bugfix] Fallback to eager sampling when Inductor C++ compile fails

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -83,6 +83,11 @@ class TopKTopPSampler(nn.Module):
         super().__init__()
         self.logprobs_mode = logprobs_mode
         self.use_fp64_gumbel = use_fp64_gumbel
+        # torch.compile's Inductor C++ backend can fail at runtime on some
+        # platforms/toolchains (e.g. macOS with a non-Apple clang++ first in
+        # PATH cannot find system headers). Disabled permanently after the
+        # first failure; the eager path below is used instead.
+        self._use_compiled_random_sample = True
         if current_platform.is_cuda():
             # FlashInfer doesn't expose post-top-k/top-p logits/logprobs,
             # so it can't be used when the configured mode requires them.
@@ -192,8 +197,20 @@ class TopKTopPSampler(nn.Module):
         elif self.logprobs_mode == "processed_logprobs":
             logits_to_return = logits.log_softmax(dim=-1, dtype=torch.float32)
 
-        if len(generators) != logits.shape[0] and not self.use_fp64_gumbel:
-            return compiled_random_sample(logits), logits_to_return
+        if (
+            self._use_compiled_random_sample
+            and len(generators) != logits.shape[0]
+            and not self.use_fp64_gumbel
+        ):
+            try:
+                return compiled_random_sample(logits), logits_to_return
+            except Exception as e:
+                logger.warning_once(
+                    "compiled_random_sample failed (%s); falling back to "
+                    "the eager sampling path.",
+                    str(e).splitlines()[0] if str(e) else type(e).__name__,
+                )
+                self._use_compiled_random_sample = False
 
         probs = logits.softmax(dim=-1, dtype=torch.float32)
         q = empty_exponential_noise_like(probs, self.use_fp64_gumbel)

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -90,6 +90,11 @@ class TopKTopPSampler(nn.Module):
         super().__init__()
         self.logprobs_mode = logprobs_mode
         self.use_fp64_gumbel = use_fp64_gumbel
+        # torch.compile's Inductor C++ backend can fail at runtime on some
+        # platforms/toolchains (e.g. macOS with a non-Apple clang++ first in
+        # PATH cannot find system headers). Disabled permanently after the
+        # first failure; the eager path below is used instead.
+        self._use_compiled_random_sample = True
         if current_platform.is_cuda():
             # FlashInfer doesn't expose post-top-k/top-p logits/logprobs,
             # so it can't be used when the configured mode requires them.
@@ -200,8 +205,20 @@ class TopKTopPSampler(nn.Module):
         elif self.logprobs_mode == "processed_logprobs":
             logits_to_return = logits.log_softmax(dim=-1, dtype=torch.float32)
 
-        if not generators and not self.use_fp64_gumbel:
-            return compiled_random_sample(logits), logits_to_return
+        if (
+            self._use_compiled_random_sample
+            and not generators
+            and not self.use_fp64_gumbel
+        ):
+            try:
+                return compiled_random_sample(logits), logits_to_return
+            except Exception as e:
+                logger.warning_once(
+                    "compiled_random_sample failed (%s); falling back to "
+                    "the eager sampling path.",
+                    str(e).splitlines()[0] if str(e) else type(e).__name__,
+                )
+                self._use_compiled_random_sample = False
 
         probs = logits.softmax(dim=-1, dtype=torch.float32)
         q = empty_exponential_noise_like(probs, self.use_fp64_gumbel)


### PR DESCRIPTION
## Purpose
On the macOS CPU backend with a non-Apple clang++ first in PATH (e.g. homebrew llvm), Inductor's C++ codegen fails: the bare clang++ has no default SDK sysroot. Model compilation can be sidestepped with enforce_eager, but compiled_random_sample is @torch.compile'd regardless, so startup dies in warmup with CppCompileError.

This warns once on the first failure and falls back to the eager sampling path for good.

Couldnt find an existing report for this.
Claude assisted with the investigation and the fix.

cc @bigPYJ1151 

## Test Plan
M3MAX, macos, torch 2.11.0:
```
VLLM_TARGET_DEVICE=cpu uv pip install -e .
```
```
from vllm import LLM, SamplingParams

if __name__ == "__main__":
    llm = LLM(model="facebook/opt-125m", enforce_eager=True,
              max_model_len=256, gpu_memory_utilization=0.2)
    outs = llm.generate(
        ["Once upon a time,"] * 2,
        [
            SamplingParams(max_tokens=8, temperature=0.0),
            SamplingParams(max_tokens=8, temperature=0.8),
        ],
    )
    for o in outs:
        print(o.outputs[0].text)
```

Three runs:
1. main, homebrew llvm first in PATH
2. this patch, same PATH
3. this patch, `PATH=/usr/bin:$PATH` (Apple's clang)

## Test Result
Run 1 dies at startup with CppCompileError(`pthread.h` file not found).
Run 2 warns once, then both prompts generate:
```
WARNING ... [topk_topp_sampler.py:280] compiled_random_sample failed
(CppCompileError: C++ compile error); falling back to the eager sampling
path.
```
Run 3 emits no warning, the compiled path compiles and runs as on main.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

