### PR TITLE
[ROCm][MLA][Perf] Fuse decode QK-RoPE + Q-concat + KV-concat + KV-cache write for sparse MLA

### DIFF
--- a/tests/kernels/core/test_fused_qk_rope_concat_and_cache_mla.py
+++ b/tests/kernels/core/test_fused_qk_rope_concat_and_cache_mla.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness test for the fused sparse-MLA decode Q-prep kernel.
+
+``rocm_aiter_ops.fused_qk_rope_concat_and_cache_mla`` collapses the decode
+RoPE + Q-concat + KV-concat + KV-cache-write into a single aiter kernel. This
+test checks it against the split kernels it replaces:
+
+  * q_out  == concat(ql_nope, RoPE(q_pe))            (nope-first)
+  * kv_cache == concat_and_cache_mla(kv_c, RoPE(k_pe))
+
+It is ROCm-only and skipped on other platforms.
+"""
+
+import random
+
+import pytest
+import torch
+
+from vllm import _custom_ops as ops
+from vllm._aiter_ops import rocm_aiter_ops
+from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_rocm(),
+    reason="fused_qk_rope_concat_and_cache_mla requires ROCm",
+)
+
+
+@pytest.fixture
+def default_vllm_config(monkeypatch):
+
+    from vllm.config import VllmConfig, set_current_vllm_config
+
+    config = VllmConfig()
+    with monkeypatch.context() as m, set_current_vllm_config(config):
+        m.setenv("VLLM_ROCM_USE_AITER", "1")
+        rocm_aiter_ops.refresh_env_variables()
+        try:
+            yield config
+        finally:
+            rocm_aiter_ops.refresh_env_variables()
+
+
+@pytest.mark.parametrize("is_neox_style", [False, True])
+@pytest.mark.parametrize("seq_len", [11, 42])
+@pytest.mark.parametrize("num_q_heads", [16, 128])
+@pytest.mark.parametrize("qk_rope_head_dim", [64])
+@pytest.mark.parametrize("kv_lora_rank", [512])
+@pytest.mark.parametrize("num_blocks", [64])
+@pytest.mark.parametrize("block_size", [1, 64])
+@pytest.mark.parametrize("contiguous_qnope", [True, False])
+@pytest.mark.parametrize("seed", [0])
+@torch.inference_mode()
+def test_fused_qk_rope_concat_and_cache_mla(
+    default_vllm_config,
+    is_neox_style: bool,
+    seq_len: int,
+    num_q_heads: int,
+    qk_rope_head_dim: int,
+    kv_lora_rank: int,
+    num_blocks: int,
+    block_size: int,
+    contiguous_qnope: bool,
+    seed: int,
+    max_position: int = 8192,
+    base: float = 10000,
+    dtype: torch.dtype = torch.bfloat16,
+) -> None:
+    rocm_aiter_ops.register_ops_once()
+    set_random_seed(seed)
+    device = "cuda"
+    torch.set_default_device(device)
+
+    rope = RotaryEmbedding(
+        qk_rope_head_dim,
+        qk_rope_head_dim,
+        max_position,
+        base,
+        is_neox_style,
+        torch.float32,
+    ).to(dtype=dtype, device=device)
+    cos_cache, sin_cache = rope.cos_sin_cache.chunk(2, dim=-1)
+    cos_cache = cos_cache.contiguous()
+    sin_cache = sin_cache.contiguous()
+
+    positions = torch.randint(0, max_position, (seq_len,), device=device)
+
+    # Post-W_UK latent (no RoPE) and the pre-RoPE positional part of q.
+    if contiguous_qnope:
+        ql_nope = torch.randn(seq_len, num_q_heads, kv_lora_rank, dtype=dtype)
+    else:
+        # Match the production layout: a transposed (non-contiguous) view of the
+        # W_UK bmm output.
+        ql_nope = torch.randn(
+            num_q_heads, seq_len, kv_lora_rank, dtype=dtype
+        ).transpose(0, 1)
+        assert not ql_nope.is_contiguous()
+    q_pe = torch.randn(seq_len, num_q_heads, qk_rope_head_dim, dtype=dtype)
+    kv_c = torch.randn(seq_len, kv_lora_rank, dtype=dtype)
+    k_pe = torch.randn(seq_len, 1, qk_rope_head_dim, dtype=dtype)
+
+    q_scale = torch.tensor([1.0], dtype=torch.float32, device=device)
+    k_scale = torch.tensor([0.1], dtype=torch.float32, device=device)
+
+    entry_size = kv_lora_rank + qk_rope_head_dim
+    slot_mapping_lst = random.sample(range(num_blocks * block_size), seq_len)
+    slot_mapping = torch.tensor(slot_mapping_lst, dtype=torch.long, device=device)
+
+    # ---- reference (split kernels) --------------------------------------
+    # RoPE q_pe / k_pe with the same routine the wrapper would use.
+    ref_q_pe, ref_k_pe = rope.forward_hip(
+        positions,
+        q_pe.clone().reshape(seq_len, num_q_heads * qk_rope_head_dim),
+        k_pe.clone().reshape(seq_len, qk_rope_head_dim),
+    )
+    ref_q_pe = ref_q_pe.reshape(seq_len, num_q_heads, qk_rope_head_dim)
+    ref_k_pe = ref_k_pe.reshape(seq_len, qk_rope_head_dim)
+
+    ref_q_out = torch.cat([ql_nope, ref_q_pe], dim=-1)
+
+    ref_kv_cache = torch.zeros(
+        num_blocks, block_size, entry_size, dtype=torch.uint8, device=device
+    )
+    ops.concat_and_cache_mla(
+        kv_c,
+        ref_k_pe,
+        ref_kv_cache,
+        slot_mapping,
+        kv_cache_dtype="fp8",
+        scale=k_scale,
+    )
+
+    # ---- fused kernel ---------------------------------------------------
+    q_out = torch.empty(seq_len, num_q_heads, entry_size, dtype=dtype, device=device)
+    kv_cache = torch.zeros(
+        num_blocks, block_size, entry_size, dtype=torch.uint8, device=device
+    )
+    rocm_aiter_ops.fused_qk_rope_concat_and_cache_mla(
+        ql_nope,
+        q_pe,
+        kv_c,
+        k_pe.squeeze(1),
+        kv_cache.view(current_platform.fp8_dtype()),
+        q_out,
+        slot_mapping,
+        k_scale,
+        q_scale,
+        positions,
+        cos_cache,
+        sin_cache,
+        is_neox=is_neox_style,
+        is_nope_first=True,
+    )
+
+    # q_out is bf16 (nope-first concat of latent + RoPE'd pe).
+    torch.testing.assert_close(q_out, ref_q_out, atol=2e-2, rtol=2e-2)
+
+    # Compare KV cache after dequant (one e4m3 ULP ~ 12.5%).
+    result = torch.empty_like(kv_cache, dtype=torch.float16)
+    expected = torch.empty_like(ref_kv_cache, dtype=torch.float16)
+    ops.convert_fp8(result, kv_cache, k_scale.item(), kv_dtype="fp8")
+    ops.convert_fp8(expected, ref_kv_cache, k_scale.item(), kv_dtype="fp8")
+    torch.testing.assert_close(result, expected, atol=1e-3, rtol=0.15)

--- a/tests/kernels/core/test_fused_qk_rope_concat_and_cache_mla.py
+++ b/tests/kernels/core/test_fused_qk_rope_concat_and_cache_mla.py
@@ -162,9 +162,7 @@ def _assert_q_out_close(q_out, c, fp8_q_out, seq_len):
         deq_ref = ref_q_fp8.to(torch.float32) * c.q_scale
         torch.testing.assert_close(deq_fused, deq_ref, atol=1e-3, rtol=0.15)
     else:
-        torch.testing.assert_close(
-            q_out, c.ref_q_out, atol=2e-2, rtol=2e-2
-        )
+        torch.testing.assert_close(q_out, c.ref_q_out, atol=2e-2, rtol=2e-2)
 
 
 def _assert_kv_close(kv_cache, c):

--- a/tests/kernels/core/test_fused_qk_rope_concat_and_cache_mla.py
+++ b/tests/kernels/core/test_fused_qk_rope_concat_and_cache_mla.py
@@ -1,18 +1,29 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Correctness test for the fused sparse-MLA decode Q-prep kernel.
+"""Correctness tests for the fused sparse-MLA decode Q-prep kernel.
 
 ``rocm_aiter_ops.fused_qk_rope_concat_and_cache_mla`` collapses the decode
-RoPE + Q-concat + KV-concat + KV-cache-write into a single aiter kernel. This
-test checks it against the split kernels it replaces:
+RoPE + Q-concat + KV-concat + KV-cache-write into a single aiter kernel. Two
+tests cover it:
 
-  * q_out  == concat(ql_nope, RoPE(q_pe))            (nope-first)
-  * kv_cache == concat_and_cache_mla(kv_c, RoPE(k_pe))
+1. ``test_fused_qk_rope_concat_and_cache_mla`` checks the raw kernel against the
+   split kernels it replaces, for both a bf16 and an fp8 ``q_out``:
+     * q_out  == concat(ql_nope, RoPE(q_pe))            (nope-first, bf16)
+     * q_out  == scaled_fp8_quant(concat(...), q_scale) (fp8; verifies the
+                 kernel's q-side quant matches vLLM's ``scaled_fp8_quant``)
+     * kv_cache == concat_and_cache_mla(kv_c, RoPE(k_pe))
 
-It is ROCm-only and skipped on other platforms.
+2. ``test_impl_handles_noncontiguous_qnope`` drives the production impl helper
+   (``ROCMAiterMLASparseImpl.fused_qk_rope_concat_and_cache``) with a
+   non-contiguous ``ql_nope`` (the transposed bmm layout production passes). The
+   raw kernel silently produces wrong q_out for a strided ``ql_nope``; the helper
+   must make it contiguous. This guards that fix.
+
+ROCm-only; skipped on other platforms.
 """
 
 import random
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -31,7 +42,6 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture
 def default_vllm_config(monkeypatch):
-
     from vllm.config import VllmConfig, set_current_vllm_config
 
     config = VllmConfig()
@@ -44,32 +54,21 @@ def default_vllm_config(monkeypatch):
             rocm_aiter_ops.refresh_env_variables()
 
 
-@pytest.mark.parametrize("is_neox_style", [False, True])
-@pytest.mark.parametrize("seq_len", [11, 42])
-@pytest.mark.parametrize("num_q_heads", [16, 128])
-@pytest.mark.parametrize("qk_rope_head_dim", [64])
-@pytest.mark.parametrize("kv_lora_rank", [512])
-@pytest.mark.parametrize("num_blocks", [64])
-@pytest.mark.parametrize("block_size", [1, 64])
-@pytest.mark.parametrize("contiguous_qnope", [True, False])
-@pytest.mark.parametrize("seed", [0])
-@torch.inference_mode()
-def test_fused_qk_rope_concat_and_cache_mla(
-    default_vllm_config,
-    is_neox_style: bool,
-    seq_len: int,
-    num_q_heads: int,
-    qk_rope_head_dim: int,
-    kv_lora_rank: int,
-    num_blocks: int,
-    block_size: int,
-    contiguous_qnope: bool,
-    seed: int,
-    max_position: int = 8192,
-    base: float = 10000,
-    dtype: torch.dtype = torch.bfloat16,
-) -> None:
-    rocm_aiter_ops.register_ops_once()
+def _build_case(
+    is_neox_style,
+    seq_len,
+    num_q_heads,
+    qk_rope_head_dim,
+    kv_lora_rank,
+    num_blocks,
+    block_size,
+    contiguous_qnope,
+    seed,
+    max_position=8192,
+    base=10000,
+    dtype=torch.bfloat16,
+):
+    """Build inputs and the split-kernel reference for one config."""
     set_random_seed(seed)
     device = "cuda"
     torch.set_default_device(device)
@@ -102,7 +101,9 @@ def test_fused_qk_rope_concat_and_cache_mla(
     kv_c = torch.randn(seq_len, kv_lora_rank, dtype=dtype)
     k_pe = torch.randn(seq_len, 1, qk_rope_head_dim, dtype=dtype)
 
-    q_scale = torch.tensor([1.0], dtype=torch.float32, device=device)
+    # A non-unit q_scale so the fp8 path actually exercises the kernel's scale
+    # convention (with 1.0, divide-vs-multiply would be indistinguishable).
+    q_scale = torch.tensor([0.3], dtype=torch.float32, device=device)
     k_scale = torch.tensor([0.1], dtype=torch.float32, device=device)
 
     entry_size = kv_lora_rank + qk_rope_head_dim
@@ -110,7 +111,6 @@ def test_fused_qk_rope_concat_and_cache_mla(
     slot_mapping = torch.tensor(slot_mapping_lst, dtype=torch.long, device=device)
 
     # ---- reference (split kernels) --------------------------------------
-    # RoPE q_pe / k_pe with the same routine the wrapper would use.
     ref_q_pe, ref_k_pe = rope.forward_hip(
         positions,
         q_pe.clone().reshape(seq_len, num_q_heads * qk_rope_head_dim),
@@ -118,7 +118,6 @@ def test_fused_qk_rope_concat_and_cache_mla(
     )
     ref_q_pe = ref_q_pe.reshape(seq_len, num_q_heads, qk_rope_head_dim)
     ref_k_pe = ref_k_pe.reshape(seq_len, qk_rope_head_dim)
-
     ref_q_out = torch.cat([ql_nope, ref_q_pe], dim=-1)
 
     ref_kv_cache = torch.zeros(
@@ -133,34 +132,177 @@ def test_fused_qk_rope_concat_and_cache_mla(
         scale=k_scale,
     )
 
-    # ---- fused kernel ---------------------------------------------------
-    q_out = torch.empty(seq_len, num_q_heads, entry_size, dtype=dtype, device=device)
+    return SimpleNamespace(
+        device=device,
+        cos_cache=cos_cache,
+        sin_cache=sin_cache,
+        positions=positions,
+        ql_nope=ql_nope,
+        q_pe=q_pe,
+        kv_c=kv_c,
+        k_pe=k_pe,
+        q_scale=q_scale,
+        k_scale=k_scale,
+        entry_size=entry_size,
+        slot_mapping=slot_mapping,
+        ref_q_out=ref_q_out,
+        ref_kv_cache=ref_kv_cache,
+    )
+
+
+def _assert_q_out_close(q_out, c, fp8_q_out, seq_len):
+    if fp8_q_out:
+        # The kernel quantizes q_out to fp8 with q_scale. Verify it matches
+        # vLLM's scaled_fp8_quant (the same convention the split path uses when
+        # it quantizes q downstream)
+        ref_q_fp8, _ = ops.scaled_fp8_quant(
+            c.ref_q_out.reshape(seq_len, -1).contiguous(), c.q_scale
+        )
+        deq_fused = q_out.to(torch.float32).reshape(seq_len, -1) * c.q_scale
+        deq_ref = ref_q_fp8.to(torch.float32) * c.q_scale
+        torch.testing.assert_close(deq_fused, deq_ref, atol=1e-3, rtol=0.15)
+    else:
+        torch.testing.assert_close(
+            q_out, c.ref_q_out, atol=2e-2, rtol=2e-2
+        )
+
+
+def _assert_kv_close(kv_cache, c):
+    # Compare KV cache after dequant (one e4m3 ULP ~ 12.5%).
+    result = torch.empty_like(kv_cache, dtype=torch.float16)
+    expected = torch.empty_like(c.ref_kv_cache, dtype=torch.float16)
+    ops.convert_fp8(result, kv_cache, c.k_scale.item(), kv_dtype="fp8")
+    ops.convert_fp8(expected, c.ref_kv_cache, c.k_scale.item(), kv_dtype="fp8")
+    torch.testing.assert_close(result, expected, atol=1e-3, rtol=0.15)
+
+
+@pytest.mark.parametrize("is_neox_style", [False, True])
+@pytest.mark.parametrize("seq_len", [11, 42])
+@pytest.mark.parametrize("num_q_heads", [16, 128])
+@pytest.mark.parametrize("qk_rope_head_dim", [64])
+@pytest.mark.parametrize("kv_lora_rank", [512])
+@pytest.mark.parametrize("num_blocks", [64])
+@pytest.mark.parametrize("block_size", [1, 64])
+@pytest.mark.parametrize("fp8_q_out", [False, True])
+@pytest.mark.parametrize("seed", [0])
+@torch.inference_mode()
+def test_fused_qk_rope_concat_and_cache_mla(
+    default_vllm_config,
+    is_neox_style: bool,
+    seq_len: int,
+    num_q_heads: int,
+    qk_rope_head_dim: int,
+    kv_lora_rank: int,
+    num_blocks: int,
+    block_size: int,
+    fp8_q_out: bool,
+    seed: int,
+) -> None:
+    """Raw-kernel parity (contiguous ql_nope), bf16 and fp8 q_out."""
+    rocm_aiter_ops.register_ops_once()
+    c = _build_case(
+        is_neox_style,
+        seq_len,
+        num_q_heads,
+        qk_rope_head_dim,
+        kv_lora_rank,
+        num_blocks,
+        block_size,
+        contiguous_qnope=True,
+        seed=seed,
+    )
+
+    q_out_dtype = current_platform.fp8_dtype() if fp8_q_out else torch.bfloat16
+    q_out = torch.empty(
+        seq_len, num_q_heads, c.entry_size, dtype=q_out_dtype, device=c.device
+    )
     kv_cache = torch.zeros(
-        num_blocks, block_size, entry_size, dtype=torch.uint8, device=device
+        num_blocks, block_size, c.entry_size, dtype=torch.uint8, device=c.device
     )
     rocm_aiter_ops.fused_qk_rope_concat_and_cache_mla(
-        ql_nope,
-        q_pe,
-        kv_c,
-        k_pe.squeeze(1),
+        c.ql_nope,
+        c.q_pe,
+        c.kv_c,
+        c.k_pe.squeeze(1),
         kv_cache.view(current_platform.fp8_dtype()),
         q_out,
-        slot_mapping,
-        k_scale,
-        q_scale,
-        positions,
-        cos_cache,
-        sin_cache,
+        c.slot_mapping,
+        c.k_scale,
+        c.q_scale,
+        c.positions,
+        c.cos_cache,
+        c.sin_cache,
         is_neox=is_neox_style,
         is_nope_first=True,
     )
 
-    # q_out is bf16 (nope-first concat of latent + RoPE'd pe).
-    torch.testing.assert_close(q_out, ref_q_out, atol=2e-2, rtol=2e-2)
+    _assert_q_out_close(q_out, c, fp8_q_out, seq_len)
+    _assert_kv_close(kv_cache, c)
 
-    # Compare KV cache after dequant (one e4m3 ULP ~ 12.5%).
-    result = torch.empty_like(kv_cache, dtype=torch.float16)
-    expected = torch.empty_like(ref_kv_cache, dtype=torch.float16)
-    ops.convert_fp8(result, kv_cache, k_scale.item(), kv_dtype="fp8")
-    ops.convert_fp8(expected, ref_kv_cache, k_scale.item(), kv_dtype="fp8")
-    torch.testing.assert_close(result, expected, atol=1e-3, rtol=0.15)
+
+@pytest.mark.parametrize("is_neox_style", [False, True])
+@pytest.mark.parametrize("num_q_heads", [16, 128])
+@pytest.mark.parametrize("block_size", [1, 64])
+@pytest.mark.parametrize("seed", [0])
+@torch.inference_mode()
+def test_impl_handles_noncontiguous_qnope(
+    default_vllm_config,
+    is_neox_style: bool,
+    num_q_heads: int,
+    block_size: int,
+    seed: int,
+    seq_len: int = 42,
+    qk_rope_head_dim: int = 64,
+    kv_lora_rank: int = 512,
+    num_blocks: int = 64,
+) -> None:
+    """The impl helper must make a transposed (non-contiguous) ql_nope
+    contiguous before the kernel; otherwise q_out is silently wrong. Drives the
+    real production helper and checks parity (fp8 q_out + KV cache)."""
+    from vllm.v1.attention.backends.mla.rocm_aiter_mla_sparse import (
+        ROCMAiterMLASparseImpl,
+    )
+
+    rocm_aiter_ops.register_ops_once()
+    c = _build_case(
+        is_neox_style,
+        seq_len,
+        num_q_heads,
+        qk_rope_head_dim,
+        kv_lora_rank,
+        num_blocks,
+        block_size,
+        contiguous_qnope=False,
+        seed=seed,
+    )
+
+    kv_cache = torch.zeros(
+        num_blocks, block_size, c.entry_size, dtype=torch.uint8, device=c.device
+    ).view(current_platform.fp8_dtype())
+
+    # Duck-typed impl / layer: the helper only reads these attributes.
+    impl = SimpleNamespace(
+        head_size=c.entry_size,
+        kv_lora_rank=kv_lora_rank,
+        kv_cache_dtype="fp8",
+    )
+    layer = SimpleNamespace(_k_scale=c.k_scale, _q_scale=c.q_scale)
+
+    q_out = ROCMAiterMLASparseImpl.fused_qk_rope_concat_and_cache(
+        impl,
+        layer,
+        c.ql_nope,  # non-contiguous
+        c.q_pe,
+        c.kv_c,
+        c.k_pe,
+        kv_cache,
+        c.slot_mapping,
+        c.positions,
+        c.cos_cache,
+        c.sin_cache,
+        is_neox_style,
+    )
+
+    assert q_out.dtype == current_platform.fp8_dtype()
+    _assert_q_out_close(q_out, c, fp8_q_out=True, seq_len=seq_len)
+    _assert_kv_close(kv_cache, c)

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -561,6 +561,61 @@ def _rocm_aiter_mla_decode_fwd_fake(
     pass
 
 
+def _rocm_aiter_fused_qk_rope_concat_and_cache_mla_impl(
+    q_nope: torch.Tensor,
+    q_pe: torch.Tensor,
+    kv_c: torch.Tensor,
+    k_pe: torch.Tensor,
+    kv_cache: torch.Tensor,
+    q_out: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    k_scale: torch.Tensor,
+    q_scale: torch.Tensor,
+    positions: torch.Tensor,
+    cos_cache: torch.Tensor,
+    sin_cache: torch.Tensor,
+    is_neox: bool,
+    is_nope_first: bool,
+) -> None:
+    from aiter.ops.cache import fused_qk_rope_concat_and_cache_mla
+
+    fused_qk_rope_concat_and_cache_mla(
+        q_nope,
+        q_pe,
+        kv_c,
+        k_pe,
+        kv_cache,
+        q_out,
+        slot_mapping,
+        k_scale,
+        q_scale,
+        positions,
+        cos_cache,
+        sin_cache,
+        is_neox=is_neox,
+        is_nope_first=is_nope_first,
+    )
+
+
+def _rocm_aiter_fused_qk_rope_concat_and_cache_mla_fake(
+    q_nope: torch.Tensor,
+    q_pe: torch.Tensor,
+    kv_c: torch.Tensor,
+    k_pe: torch.Tensor,
+    kv_cache: torch.Tensor,
+    q_out: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    k_scale: torch.Tensor,
+    q_scale: torch.Tensor,
+    positions: torch.Tensor,
+    cos_cache: torch.Tensor,
+    sin_cache: torch.Tensor,
+    is_neox: bool,
+    is_nope_first: bool,
+) -> None:
+    pass
+
+
 def _rocm_aiter_w8a8_gemm_impl(
     A: torch.Tensor,
     B: torch.Tensor,
@@ -1754,6 +1809,11 @@ class rocm_aiter_ops:
 
     @classmethod
     @if_aiter_supported
+    def is_fused_mla_qkprep_enabled(cls) -> bool:
+        return cls._AITER_ENABLED and cls._MLA_ENABLED
+
+    @classmethod
+    @if_aiter_supported
     def is_fp4bmm_enabled(cls) -> bool:
         from vllm.platforms.rocm import on_gfx950
 
@@ -1910,6 +1970,13 @@ class rocm_aiter_ops:
                 op_func=_rocm_aiter_mla_decode_fwd_impl,
                 mutates_args=["o"],
                 fake_impl=_rocm_aiter_mla_decode_fwd_fake,
+            )
+
+            direct_register_custom_op(
+                op_name="rocm_aiter_fused_qk_rope_concat_and_cache_mla",
+                op_func=_rocm_aiter_fused_qk_rope_concat_and_cache_mla_impl,
+                mutates_args=["kv_cache", "q_out"],
+                fake_impl=_rocm_aiter_fused_qk_rope_concat_and_cache_mla_fake,
             )
 
             direct_register_custom_op(
@@ -2399,6 +2466,41 @@ class rocm_aiter_ops:
             reduce_indptr=reduce_indptr,
             reduce_final_map=reduce_final_map,
             reduce_partial_map=reduce_partial_map,
+        )
+
+    @staticmethod
+    def fused_qk_rope_concat_and_cache_mla(
+        q_nope: torch.Tensor,
+        q_pe: torch.Tensor,
+        kv_c: torch.Tensor,
+        k_pe: torch.Tensor,
+        kv_cache: torch.Tensor,
+        q_out: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        k_scale: torch.Tensor,
+        q_scale: torch.Tensor,
+        positions: torch.Tensor,
+        cos_cache: torch.Tensor,
+        sin_cache: torch.Tensor,
+        is_neox: bool,
+        is_nope_first: bool = True,
+    ) -> None:
+        """Fused sparse-MLA decode Q-prep"""
+        torch.ops.vllm.rocm_aiter_fused_qk_rope_concat_and_cache_mla(
+            q_nope,
+            q_pe,
+            kv_c,
+            k_pe,
+            kv_cache,
+            q_out,
+            slot_mapping,
+            k_scale,
+            q_scale,
+            positions,
+            cos_cache,
+            sin_cache,
+            is_neox,
+            is_nope_first,
         )
 
     @staticmethod

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -513,7 +513,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         self.rotary_emb = rotary_emb
         self._fused_rope_cos_sin: tuple[torch.Tensor, torch.Tensor] | None = None
         if getattr(self.impl, "use_fused_qk_rope_cache", False) and rotary_emb is None:
-            self.impl.use_fused_qk_rope_cache = False
+            self.impl.use_fused_qk_rope_cache = False  # type: ignore[attr-defined]
 
         vllm_config = get_current_vllm_config()
         parallel_config = vllm_config.parallel_config
@@ -900,8 +900,13 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                         "forward positions when impl.use_fused_qk_rope_cache is set."
                     )
                 forward_context = get_forward_context()
-                slot_mapping = forward_context.slot_mapping[self.layer_name].flatten()
+                fc_slot_mapping = forward_context.slot_mapping
+                assert isinstance(fc_slot_mapping, dict), (
+                    f"Expected slot_mapping to be a dict, got {type(fc_slot_mapping)}."
+                )
+                slot_mapping = fc_slot_mapping[self.layer_name].flatten()
                 cos_cache, sin_cache = self._get_fused_rope_cos_sin()
+                assert self.rotary_emb is not None
                 mqa_q = self.impl.fused_qk_rope_concat_and_cache(  # type: ignore[attr-defined]
                     self,
                     mqa_ql_nope,

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -506,10 +506,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         self.q_pad_num_heads = getattr(self.impl, "q_pad_num_heads", None)
         self.use_direct_call = not current_platform.opaque_attention_op()
 
-        # the fused sparse-MLA Q-prep kernel folds the main RoPE into
-        # the decode kernel, so it needs the rotary embedding's cos/sin cache.
-        # Without a rotary embedding there is no RoPE to fold, so disable the
-        # fused path to keep the wrapper / KV-write / decode branches consistent.
+        # Disable fused Q-prep path when no rotary_emb is available.
         self.rotary_emb = rotary_emb
         self._fused_rope_cos_sin: tuple[torch.Tensor, torch.Tensor] | None = None
         if getattr(self.impl, "use_fused_qk_rope_cache", False) and rotary_emb is None:
@@ -885,14 +882,11 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 mqa_ql_nope = mqa_ql_nope.transpose(0, 1)
 
             use_fused_qk_rope_cache = (
-                is_sparse_impl
+                self.impl.is_sparse
                 and getattr(self.impl, "use_fused_qk_rope_cache", False)
                 and self.rotary_emb is not None
             )
             if use_fused_qk_rope_cache:
-                # fold RoPE + Q-concat + KV-concat + KV-cache-write
-                # into one kernel. positions is threaded in as a real argument
-                # (survives torch.compile / CUDA graph replay).
                 if positions is None:
                     raise RuntimeError(
                         "Fused MLA Q-prep is enabled but `positions` was not "

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -890,7 +890,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 and self.rotary_emb is not None
             )
             if use_fused_qk_rope_cache:
-                # fold RoPE + Q-concat + KV-concat + KV-cache-write 
+                # fold RoPE + Q-concat + KV-concat + KV-cache-write
                 # into one kernel. positions is threaded in as a real argument
                 # (survives torch.compile / CUDA graph replay).
                 if positions is None:

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -374,6 +374,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         use_sparse: bool = False,
         indexer: object | None = None,
         topk_indices_buffer: torch.Tensor | None = None,
+        rotary_emb: nn.Module | None = None,
         **extra_impl_args,
     ):
         super().__init__()
@@ -505,6 +506,15 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         self.q_pad_num_heads = getattr(self.impl, "q_pad_num_heads", None)
         self.use_direct_call = not current_platform.opaque_attention_op()
 
+        # the fused sparse-MLA Q-prep kernel folds the main RoPE into
+        # the decode kernel, so it needs the rotary embedding's cos/sin cache.
+        # Without a rotary embedding there is no RoPE to fold, so disable the
+        # fused path to keep the wrapper / KV-write / decode branches consistent.
+        self.rotary_emb = rotary_emb
+        self._fused_rope_cos_sin: tuple[torch.Tensor, torch.Tensor] | None = None
+        if getattr(self.impl, "use_fused_qk_rope_cache", False) and rotary_emb is None:
+            self.impl.use_fused_qk_rope_cache = False
+
         vllm_config = get_current_vllm_config()
         parallel_config = vllm_config.parallel_config
         self.use_pcp = parallel_config.prefill_context_parallel_size > 1
@@ -587,6 +597,14 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             )
         return self._chunked_prefill_workspace_size
 
+    def _get_fused_rope_cos_sin(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """Split rotary_emb.cos_sin_cache into contiguous cos/sin halves."""
+        if self._fused_rope_cos_sin is None:
+            assert self.rotary_emb is not None
+            cos, sin = self.rotary_emb.cos_sin_cache.chunk(2, dim=-1)
+            self._fused_rope_cos_sin = (cos.contiguous(), sin.contiguous())
+        return self._fused_rope_cos_sin
+
     def forward(
         self,
         q: torch.Tensor,
@@ -594,6 +612,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         k_pe: torch.Tensor,
         output_shape: torch.Size | None = None,
         q_dcp_replicated: torch.Tensor | None = None,
+        positions: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if self.calculate_kv_scales:
             torch.ops.vllm.maybe_calc_kv_scales(
@@ -650,6 +669,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 attn_metadata,
                 output=output,
                 q_dcp_replicated=q_dcp_replicated,
+                positions=positions,
             )
             return output
         else:
@@ -670,6 +690,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 encoded,
                 kv_cache_dummy_dep=kv_cache_dummy_dep,
                 q_dcp_replicated=q_dcp_replicated,
+                positions=positions,
             )
             return output
 
@@ -688,6 +709,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         quant_col_major: bool | None = None,
         quant_tma_aligned: bool | None = None,
         q_dcp_replicated: torch.Tensor | None = None,
+        positions: torch.Tensor | None = None,
     ) -> torch.Tensor:
         assert output is not None, "Output tensor must be provided."
 
@@ -862,7 +884,38 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 # Convert from (N, B, L) to (B, N, L)
                 mqa_ql_nope = mqa_ql_nope.transpose(0, 1)
 
-            if fp8_attention and self.impl.supports_quant_query_input:
+            use_fused_qk_rope_cache = (
+                is_sparse_impl
+                and getattr(self.impl, "use_fused_qk_rope_cache", False)
+                and self.rotary_emb is not None
+            )
+            if use_fused_qk_rope_cache:
+                # fold RoPE + Q-concat + KV-concat + KV-cache-write 
+                # into one kernel. positions is threaded in as a real argument
+                # (survives torch.compile / CUDA graph replay).
+                if positions is None:
+                    raise RuntimeError(
+                        "Fused MLA Q-prep is enabled but `positions` was not "
+                        "passed to MLAAttention.forward. The MLA wrapper must "
+                        "forward positions when impl.use_fused_qk_rope_cache is set."
+                    )
+                forward_context = get_forward_context()
+                slot_mapping = forward_context.slot_mapping[self.layer_name].flatten()
+                cos_cache, sin_cache = self._get_fused_rope_cos_sin()
+                mqa_q = self.impl.fused_qk_rope_concat_and_cache(  # type: ignore[attr-defined]
+                    self,
+                    mqa_ql_nope,
+                    mqa_q_pe,
+                    k_c_normed[:num_mqa_tokens],
+                    k_pe[:num_mqa_tokens],
+                    kv_cache,
+                    slot_mapping[:num_mqa_tokens],
+                    positions[:num_mqa_tokens],
+                    cos_cache,
+                    sin_cache,
+                    self.rotary_emb.is_neox_style,
+                )
+            elif fp8_attention and self.impl.supports_quant_query_input:
                 assert mqa_ql_nope.shape[0] == mqa_q_pe.shape[0]
                 assert mqa_ql_nope.shape[1] == mqa_q_pe.shape[1]
                 mqa_q = self._decode_concat_quant_fp8_op(
@@ -1215,6 +1268,7 @@ def unified_mla_attention_with_output(
     quant_col_major: bool | None = None,
     quant_tma_aligned: bool | None = None,
     q_dcp_replicated: torch.Tensor | None = None,
+    positions: torch.Tensor | None = None,
 ) -> None:
     # kv_cache_dummy_dep is not used but accepting it creates a data dependency
     # that ensures torch.compile preserves ordering between KV cache update and
@@ -1236,6 +1290,7 @@ def unified_mla_attention_with_output(
         quant_col_major=quant_col_major,
         quant_tma_aligned=quant_tma_aligned,
         q_dcp_replicated=q_dcp_replicated,
+        positions=positions,
     )
 
 
@@ -1253,6 +1308,7 @@ def unified_mla_attention_with_output_fake(
     quant_col_major: bool | None = None,
     quant_tma_aligned: bool | None = None,
     q_dcp_replicated: torch.Tensor | None = None,
+    positions: torch.Tensor | None = None,
 ) -> None:
     return
 

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -118,6 +118,14 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
             use_sparse=self.is_sparse,
             indexer=self.indexer,
             topk_indices_buffer=mla_modules.topk_indices_buffer,
+            rotary_emb=self.rotary_emb,
+        )
+
+        # when the decode impl fuses RoPE into its Q-prep kernel
+        # (fused_qk_rope_concat_and_cache_mla), defer the main RoPE here and
+        # pass positions down to the impl as a forward() argument.
+        self._defer_rope_to_fused_kernel = self.rotary_emb is not None and getattr(
+            self.mla_attn.impl, "use_fused_qk_rope_cache", False
         )
 
         self.prefix = prefix
@@ -172,7 +180,10 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
             heads *= q_proj_layer.group_size
         q = q.view(-1, heads, self.qk_head_dim)
 
-        if self.rotary_emb is not None:
+        fused_positions: torch.Tensor | None = None
+        if self._defer_rope_to_fused_kernel:
+            fused_positions = positions
+        elif self.rotary_emb is not None:
             q[..., self.qk_nope_head_dim :], k_pe = self.rotary_emb(
                 positions, q[..., self.qk_nope_head_dim :], k_pe
             )
@@ -193,6 +204,7 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
             k_pe,
             output_shape=(hidden_states.shape[0], self.num_heads * self.v_head_dim),
             q_dcp_replicated=q_dcp_replicated,
+            positions=fused_positions,
         )
 
         return self.o_proj(attn_out)[0]

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -121,9 +121,6 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
             rotary_emb=self.rotary_emb,
         )
 
-        # when the decode impl fuses RoPE into its Q-prep kernel
-        # (fused_qk_rope_concat_and_cache_mla), defer the main RoPE here and
-        # pass positions down to the impl as a forward() argument.
         self._defer_rope_to_fused_kernel = self.rotary_emb is not None and getattr(
             self.mla_attn.impl, "use_fused_qk_rope_cache", False
         )

--- a/vllm/models/deepseek_v32/nvidia/attention.py
+++ b/vllm/models/deepseek_v32/nvidia/attention.py
@@ -426,6 +426,7 @@ class DeepseekV32Attention(MLAAttention):
             mla_kv_cache = self.kv_cache
             mla_k_scale = self._k_scale
 
+        assert self.rotary_emb is not None
         q_c = fused_norm_rope(
             positions,
             q_c,

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -690,6 +690,79 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
             (q_concat_shape, vllm_config.model_config.dtype),
         )
 
+        # fold decode RoPE + Q-concat + KV-concat + KV-cache-write into
+        # a single aiter kernel (fused_qk_rope_concat_and_cache_mla). 
+        self.use_fused_qk_rope_cache = (
+            rocm_aiter_ops.is_fused_mla_qkprep_enabled()
+            and self.kv_cache_dtype.startswith("fp8")
+            and self.kv_cache_dtype != "fp8_ds_mla"
+        )
+
+    def do_kv_cache_update(
+        self,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        kv_cache_dtype: str,
+        k_scale: torch.Tensor,
+    ) -> None:
+        if self.use_fused_qk_rope_cache:
+            # The KV-cache write (concat + RoPE + fp8 quant) is folded into
+            # fused_qk_rope_concat_and_cache_mla
+            return
+        super().do_kv_cache_update(
+            kv_c_normed, k_pe, kv_cache, slot_mapping, kv_cache_dtype, k_scale
+        )
+
+    def fused_qk_rope_concat_and_cache(
+        self,
+        layer: AttentionLayer,
+        ql_nope: torch.Tensor,
+        q_pe: torch.Tensor,
+        k_c_normed: torch.Tensor,  # [T, kv_lora_rank]
+        k_pe: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        positions: torch.Tensor,
+        cos_cache: torch.Tensor,
+        sin_cache: torch.Tensor,
+        is_neox: bool,
+    ) -> torch.Tensor:
+        """Fused decode Q-prep.
+
+        Applies RoPE to ``q_pe``/``k_pe``, concatenates ``ql_nope`` with the
+        RoPE'd ``q_pe`` into ``q_out`` (bf16), and writes the concatenated,
+        fp8-quantized latent+rope KV row into ``kv_cache``. The returned bf16
+        ``q_out`` is quantized to fp8 downstream in ``forward_mqa`` (matching the
+        split-kernel path), so the sparse decode kernel sees an identical query.
+        """
+        num_tokens, num_q_heads = ql_nope.shape[:2]
+        q_out = torch.empty(
+            (num_tokens, num_q_heads, self.head_size),
+            dtype=ql_nope.dtype,
+            device=ql_nope.device,
+        )
+        kv_cache_3d = kv_cache.view(kv_cache.shape[0], -1, self.head_size)
+        
+        rocm_aiter_ops.fused_qk_rope_concat_and_cache_mla(
+            ql_nope,
+            q_pe,
+            k_c_normed,
+            k_pe.squeeze(1),
+            kv_cache_3d,
+            q_out,
+            slot_mapping,
+            layer._k_scale,
+            layer._q_scale,
+            positions,
+            cos_cache,
+            sin_cache,
+            is_neox=is_neox,
+            is_nope_first=True,
+        )
+        return q_out
+
     def _forward_mla(
         self,
         layer: AttentionLayer,

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -732,19 +732,29 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
         """Fused decode Q-prep.
 
         Applies RoPE to ``q_pe``/``k_pe``, concatenates ``ql_nope`` with the
-        RoPE'd ``q_pe`` into ``q_out`` (bf16), and writes the concatenated,
-        fp8-quantized latent+rope KV row into ``kv_cache``. The returned bf16
-        ``q_out`` is quantized to fp8 downstream in ``forward_mqa`` (matching the
-        split-kernel path), so the sparse decode kernel sees an identical query.
+        RoPE'd ``q_pe`` into ``q_out``, and writes the concatenated,
+        fp8-quantized latent+rope KV row into ``kv_cache``. The fused path only
+        runs with an fp8 KV cache, so ``q_out`` is produced directly in fp8
+        (quantized by the kernel with ``q_scale``).
         """
         num_tokens, num_q_heads = ql_nope.shape[:2]
+        # The aiter kernel builds the nope half of q_out (and the KV latent) by
+        # copying ql_nope and REQUIRES it to be contiguous: a strided ql_nope
+        # silently yields wrong q_out values. Force contiguity here.
+        ql_nope = ql_nope.contiguous()
+        # Emit q_out directly in fp8 when the KV cache is fp8
+        q_out_dtype = (
+            current_platform.fp8_dtype()
+            if self.kv_cache_dtype.startswith("fp8")
+            else ql_nope.dtype
+        )
         q_out = torch.empty(
             (num_tokens, num_q_heads, self.head_size),
-            dtype=ql_nope.dtype,
+            dtype=q_out_dtype,
             device=ql_nope.device,
         )
         kv_cache_3d = kv_cache.view(kv_cache.shape[0], -1, self.head_size)
-        
+
         rocm_aiter_ops.fused_qk_rope_concat_and_cache_mla(
             ql_nope,
             q_pe,

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -690,8 +690,6 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
             (q_concat_shape, vllm_config.model_config.dtype),
         )
 
-        # fold decode RoPE + Q-concat + KV-concat + KV-cache-write into
-        # a single aiter kernel (fused_qk_rope_concat_and_cache_mla).
         self.use_fused_qk_rope_cache = (
             rocm_aiter_ops.is_fused_mla_qkprep_enabled()
             and self.kv_cache_dtype.startswith("fp8")
@@ -708,8 +706,6 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
         k_scale: torch.Tensor,
     ) -> None:
         if self.use_fused_qk_rope_cache:
-            # The KV-cache write (concat + RoPE + fp8 quant) is folded into
-            # fused_qk_rope_concat_and_cache_mla
             return
         super().do_kv_cache_update(
             kv_c_normed, k_pe, kv_cache, slot_mapping, kv_cache_dtype, k_scale
@@ -729,20 +725,10 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
         sin_cache: torch.Tensor,
         is_neox: bool,
     ) -> torch.Tensor:
-        """Fused decode Q-prep.
-
-        Applies RoPE to ``q_pe``/``k_pe``, concatenates ``ql_nope`` with the
-        RoPE'd ``q_pe`` into ``q_out``, and writes the concatenated,
-        fp8-quantized latent+rope KV row into ``kv_cache``. The fused path only
-        runs with an fp8 KV cache, so ``q_out`` is produced directly in fp8
-        (quantized by the kernel with ``q_scale``).
-        """
+        """Fused RoPE + Q-concat + KV-concat + fp8 KV-cache write."""
         num_tokens, num_q_heads = ql_nope.shape[:2]
-        # The aiter kernel builds the nope half of q_out (and the KV latent) by
-        # copying ql_nope and REQUIRES it to be contiguous: a strided ql_nope
-        # silently yields wrong q_out values. Force contiguity here.
+        # aiter kernel requires contiguous ql_nope
         ql_nope = ql_nope.contiguous()
-        # Emit q_out directly in fp8 when the KV cache is fp8
         q_out_dtype = (
             current_platform.fp8_dtype()
             if self.kv_cache_dtype.startswith("fp8")

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -691,7 +691,7 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
         )
 
         # fold decode RoPE + Q-concat + KV-concat + KV-cache-write into
-        # a single aiter kernel (fused_qk_rope_concat_and_cache_mla). 
+        # a single aiter kernel (fused_qk_rope_concat_and_cache_mla).
         self.use_fused_qk_rope_cache = (
             rocm_aiter_ops.is_fused_mla_qkprep_enabled()
             and self.kv_cache_dtype.startswith("fp8")


### PR DESCRIPTION
## Summary

On ROCm, the sparse-MLA decode path currently runs the per-layer Q/KV preparation
as several back-to-back ops: main RoPE on `q_pe`/`k_pe`, the query
concat (`ql_nope` + RoPE'd `q_pe`), the KV concat, and the fp8 KV-cache write.
This PR collapses all of them into the single AITER kernel
`fused_qk_rope_concat_and_cache_mla`.

The fusion is implemented at the **model level** (eager op dispatch from the MLA
layer), **not** as an FX graph-rewrite pass since vLLM is moving away from the
graph-pass fusion mechanism, and several models already adopt the model-level
eager approach. Implementing it this way keeps this change aligned with the
current direction, and makes it easily portable to that new model-level mechanism.

The fusion is gated and falls back cleanly to the existing split-kernel path when
it is not applicable (non-ROCm, non-gfx9, no AITER, non-fp8 KV cache, the
`fp8_ds_mla` layout).


Before:

<img width="1913" height="314" alt="unfused_qk_rope_concat" src="https://github.com/user-attachments/assets/4eb75e12-b365-441a-9159-ced36bb49882" />


After:

<img width="1878" height="276" alt="fused_qk_rope_concat" src="https://github.com/user-attachments/assets/f89b4408-db01-48b5-9054-20d07582a5b4" />




Three coordinated decision sites, all keyed off one impl flag
(`ROCMAiterMLASparseImpl.use_fused_qk_rope_cache`):

1. **Wrapper (`mla.py`)** — when fusing, skip the in-place main RoPE and pass raw
   (pre-RoPE) `q_pe`/`k_pe` down, threading `positions` as a real argument.
2. **KV write (`ROCMAiterMLASparseImpl.do_kv_cache_update`)** — no-op when fusing
   (the write is folded into the fused kernel; the sparse path routes *all* tokens
   through `forward_mqa`, so `num_mqa_tokens == q.size(0)` and the fused call
   writes the full batch's KV, prefill included).
3. **Decode (`MLAAttention.forward_impl`)** — after the `W_UK` bmm, call the fused
   kernel to produce the pre-fused `q` and write the cache.

### Why `positions` is a real argument (not a forward-context stash)

`positions` is threaded through `MLAAttention.forward` → the opaque custom op
(`unified_mla_attention_with_output`) / direct `forward_impl` → the fused kernel,
as an optional trailing tensor argument. An earlier stash into
`forward_context.additional_kwargs` inside the wrapper's `forward` proved **not**
to be torch.compile / CUDA-graph safe.


## Compatibility / no-effect cases

- **deepseek-v4** is unaffected: it uses its own standalone stack
  (`DeepseekV4ROCMAiterMLAAttention` / `DeepseekV4ROCMAiterMLASparseBackend`,
  registry tag `ROCM_FLASHMLA_SPARSE_DSV4`) with its own `forward_mqa` and cache
  write — it never touches `MLAAttention`, `ROCMAiterMLASparseImpl`,
  `do_kv_cache_update`, or the fused flag.
- **deepseek-v3.2 / GLM sparse** on ROCm run through the shared, modified path and
  are the intended beneficiaries.
- **DeepseekV32Attention (nvidia)** fully overrides `forward`; base MLA path
  untouched.
- **Dense MLA / CUDA / non-fp8 / `fp8_ds_mla`** all miss the gate → byte-for-byte
  unchanged.
- **Spec-decode / MTP drafters** reuse the same `MLAAttention` layers, so the
  `positions` argument covers them too.
- **`positions`** added as an optional trailing param (`Tensor?`) on
  `MLAAttention.forward`, `forward_impl`, and `unified_mla_attention_with_output`
  — backward compatible for every existing caller.
- **Off-ROCm**: `_aiter_ops.py` registration is `@if_aiter_supported` (no-op); the
  new op body lazy-imports AITER only when dispatched.


## Test plan

### Unit test (ROCm, gfx942)

pytest tests/kernels/core/test_fused_qk_rope_concat_and_cache_mla.py -v

Two tests cover the fused kernel:

1. **Raw-kernel parity** vs the split kernels (RoPE + `concat_and_cache_mla`) on a
   *contiguous* `ql_nope`, across `is_neox` (True/False), seq lengths, head counts
   (16/128), and block sizes (1/64):
   - bf16 `q_out` == `concat(ql_nope, RoPE(q_pe))`
   - fp8 `q_out` == `scaled_fp8_quant(concat(...), q_scale)` — verifies the kernel's
     *folded* q-side quant matches vLLM's downstream convention (tested with a
     non-unit `q_scale` so a divide-vs-multiply mistake can't alias).
   - `kv_cache` == `concat_and_cache_mla(kv_c, RoPE(k_pe))` (fp8).
2. **Production-helper test** on a *non-contiguous* (transposed, production-layout)
   `ql_nope`: drives `ROCMAiterMLASparseImpl.fused_qk_rope_concat_and_cache` and
   checks fp8 `q_out` + KV parity. This guards the `.contiguous()` fix — the raw
   kernel silently produces wrong `q_out` for a strided `ql_nope`.

All configs pass.


### Accuracy GLM-5.2-FP8 (gfx942, and TP=8)

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    30|exact_match|↑  |0.9401|±  |0.0065|
|     |       |strict-match    |    30|exact_match|↑  |0.9409|±  |0.0065|


### Performance uplift GLM-5.2-FP8 (gfx942, TP=8, 3 repeats per experiment)

| ISL | OSL | conc | TPOT_p50 baseline | TPOT_p50 fused | TPOT speedup | ITL_p50 baseline | ITL_p50 fused | ITL speedup | out_tok/s baseline | out_tok/s fused | tput ratio |
|---|---|---|---|---|---|---|---|---|---|---|---|
| 1024 | 1024 | 1 | 15.03 | 14.49 | 1.037x | 15.01 | 14.48 | 1.036x | 65.93 | 68.38 | 1.037x |
| 1024 | 1024 | 8 | 18.34 | 17.79 | 1.031x | 18.34 | 17.72 | 1.035x | 423.00 | 436.86 | 1.033x |
| 1024 | 1024 | 32 | 24.84 | 24.17 | 1.028x | 24.20 | 23.60 | 1.026x | 1222.98 | 1253.28 | 1.025x |
| 1024 | 1024 | 64 | 32.78 | 32.00 | 1.024x | 31.39 | 30.66 | 1.024x | 1824.20 | 1866.93 | 1.023x |
| 8192 | 1024 | 1 | 15.85 | 15.32 | 1.035x | 15.85 | 15.32 | 1.035x | 60.72 | 62.77 | 1.034x |
| 8192 | 1024 | 8 | 21.68 | 21.16 | 1.025x | 19.34 | 18.77 | 1.031x | 330.41 | 338.36 | 1.024x |
| 8192 | 1024 | 32 | 39.66 | 37.94 | 1.045x | 23.97 | 23.43 | 1.023x | 714.48 | 743.42 | 1.040x |
| 8192 | 1024 | 64 | 63.12 | 61.98 | 1.018x | 29.19 | 28.49 | 1.024x | 931.70 | 940.19 | 1.009x |

Serving recipe:

```bash
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4

vllm serve zai-org/GLM-5.2-FP8 \
  --enable_auto_tool_choice \
  --gpu_memory_utilization 0.83 \
  --kv_cache_dtype fp8 \
  --max-model-len 16384 \
  --max_num_batched_tokens 16384 \
  --no_enable_prefix_caching \
  --port 8004 \
  --reasoning_parser glm45 \
  --tensor_parallel_size 8 \
  --tool_call_parser glm47 \
  --trust_remote_code
```

### Accuracy Deepseek-V3.2 (gfx942, TP=8)

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    30|exact_match|↑  |0.9530|±  |0.0058|
|     |       |strict-match    |    30|exact_match|↑  |0.9538|±  |0.0058|

### Performance uplift DeepSeek-V3.2 (gfx942, TP=8)

| ISL | OSL | conc | TPOT_p50 baseline | TPOT_p50 fused | TPOT speedup | ITL_p50 baseline | ITL_p50 fused | ITL speedup | out_tok/s baseline | out_tok/s fused | tput ratio |
|---|---|---|---|---|---|---|---|---|---|---|---|
| 1024 | 1024 | 1 | 11.60 | 11.29 | 1.027x | 11.59 | 11.21 | 1.034x | 85.12 | 87.74 | 1.031x |
| 1024 | 1024 | 8 | 15.82 | 15.38 | 1.029x | 15.71 | 15.21 | 1.033x | 488.21 | 507.87 | 1.040x |
| 1024 | 1024 | 32 | 23.13 | 23.20 | 0.997x | 22.86 | 22.26 | 1.027x | 1328.22 | 1299.51 | 0.978x |
| 1024 | 1024 | 64 | 29.76 | 30.67 | 0.970x | 28.81 | 28.34 | 1.017x | 2036.75 | 1970.10 | 0.967x |

the small perf drop on mc32 and mc64 is most likely run variance noise and not a real perf. regression, since TPOT and ITL disagree. I can re-run the experiments a few times and provide averages if needed. 

Serving recipe:

```bash
export VLLM_ROCM_MLA_SPARSE_MAX_SPLIT=1
export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
export VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16=1

vllm serve deepseek-ai/DeepSeek-V3.2 \
  --tensor-parallel-size 8 \
  --gpu-memory-utilization 0.85 \
  --kv-cache-dtype fp8_e4m3 \
  --no_enable_prefix_caching \
  --max_num_batched_tokens 16384 \
  --max-num-seqs 156 \
  --block-size 64 \
  --enable-expert-parallel \
  --max_model_len 132096 \
  --hf_overrides '{"use_index_cache": true, "index_topk_freq": 4}'
  ```

## Related work

- Complementary to the dense-path fusion efforts (#44437 F3, #45798).

This PR was created with the help of AI. 
