### PR TITLE
[Model] Support uneven TP3 Qwen3.5/Qwen3Next layouts

### DIFF
--- a/tests/distributed/test_tp3_ce_dispatch.py
+++ b/tests/distributed/test_tp3_ce_dispatch.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from vllm.distributed.parallel_state import _should_use_tp3_ce
+
+
+def test_tp3_ce_requires_known_large_logical_batch():
+    args = (3, 2, 5120, 3)
+    assert not _should_use_tp3_ce(None, *args)
+    assert not _should_use_tp3_ce(1365, *args)
+    assert _should_use_tp3_ce(1366, *args)
+
+
+def test_tp3_ce_rejects_unsupported_layouts():
+    assert not _should_use_tp3_ce(4096, 1, 1, 5120, 3)
+    assert not _should_use_tp3_ce(4096, 1, 2, 4096, 3)
+    assert not _should_use_tp3_ce(4096, 1, 2, 5120, 2)

--- a/tests/model_executor/layers/test_attention_head_partition.py
+++ b/tests/model_executor/layers/test_attention_head_partition.py
@@ -132,3 +132,38 @@ def test_qwopus_tp3_slot_expansion_matches_full_gqa_attention():
 
     tp_out = torch.cat(local_outputs, dim=1)
     torch.testing.assert_close(tp_out, full_out)
+
+
+def test_qwen35_tp3_dcp_full_kv_layout_matches_full_gqa_attention():
+    torch.manual_seed(0)
+    num_tokens = 5
+    num_heads = 24
+    num_kv_heads = 4
+    head_dim = 16
+    scale = head_dim**-0.5
+
+    q = torch.randn(num_tokens, num_heads, head_dim)
+    k = torch.randn(num_tokens, num_kv_heads, head_dim)
+    v = torch.randn(num_tokens, num_kv_heads, head_dim)
+
+    q_per_kv = num_heads // num_kv_heads
+    full_k = k.repeat_interleave(q_per_kv, dim=1)
+    full_v = v.repeat_interleave(q_per_kv, dim=1)
+    full_scores = torch.einsum("qhd,khd->hqk", q, full_k) * scale
+    full_probs = torch.softmax(full_scores, dim=-1)
+    full_out = torch.einsum("hqk,khd->qhd", full_probs, full_v)
+
+    local_outputs = []
+    for rank in range(3):
+        q_start = rank * (num_heads // 3)
+        q_end = q_start + (num_heads // 3)
+        local_q = q[:, q_start:q_end, :]
+        local_k = full_k[:, q_start:q_end, :]
+        local_v = full_v[:, q_start:q_end, :]
+        local_scores = torch.einsum("qhd,khd->hqk", local_q, local_k) * scale
+        local_probs = torch.softmax(local_scores, dim=-1)
+        local_outputs.append(
+            torch.einsum("hqk,khd->qhd", local_probs, local_v)
+        )
+
+    torch.testing.assert_close(torch.cat(local_outputs, dim=1), full_out)

--- a/tests/model_executor/layers/test_attention_head_partition.py
+++ b/tests/model_executor/layers/test_attention_head_partition.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.attention.head_partition import (
+    make_attention_head_partition,
+)
+
+
+def _parts(total_q: int, total_kv: int, tp: int):
+    return [
+        make_attention_head_partition(
+            total_num_heads=total_q,
+            total_num_kv_heads=total_kv,
+            tp_size=tp,
+            tp_rank=rank,
+        )
+        for rank in range(tp)
+    ]
+
+
+def test_divisible_gqa_partition_matches_existing_layout():
+    parts = _parts(total_q=24, total_kv=4, tp=2)
+
+    assert [p.q_head_indices for p in parts] == [
+        tuple(range(0, 12)),
+        tuple(range(12, 24)),
+    ]
+    assert [p.unique_kv_head_indices for p in parts] == [(0, 1), (2, 3)]
+    assert [p.kv_head_indices for p in parts] == [(0, 1), (2, 3)]
+    assert [p.num_heads for p in parts] == [12, 12]
+    assert [p.num_kv_heads for p in parts] == [2, 2]
+
+
+def test_kv_replication_when_tp_exceeds_kv_heads():
+    parts = _parts(total_q=24, total_kv=4, tp=8)
+
+    assert [p.kv_head_indices for p in parts] == [
+        (0,),
+        (0,),
+        (1,),
+        (1,),
+        (2,),
+        (2,),
+        (3,),
+        (3,),
+    ]
+    assert all(p.num_heads == 3 for p in parts)
+    assert all(p.num_kv_heads == 1 for p in parts)
+
+
+def test_overlapping_gqa_partition_for_qwopus_tp3():
+    parts = _parts(total_q=24, total_kv=4, tp=3)
+
+    assert [p.q_head_indices for p in parts] == [
+        tuple(range(0, 8)),
+        tuple(range(8, 16)),
+        tuple(range(16, 24)),
+    ]
+    assert [p.unique_kv_head_indices for p in parts] == [(0, 1), (1, 2), (2, 3)]
+    assert [p.kv_head_indices for p in parts] == [
+        (0, 0, 0, 1),
+        (1, 1, 2, 2),
+        (2, 3, 3, 3),
+    ]
+    assert [p.q_to_local_kv_indices for p in parts] == [
+        (0, 0, 1, 1, 2, 2, 3, 3),
+        (0, 0, 1, 1, 2, 2, 3, 3),
+        (0, 0, 1, 1, 2, 2, 3, 3),
+    ]
+    assert all(p.num_heads == 8 for p in parts)
+    assert all(p.num_kv_heads == 4 for p in parts)
+    assert all(p.local_q_per_kv_slot == 2 for p in parts)
+    assert all(p.has_overlapping_kv_partition for p in parts)
+
+
+def test_slot_expansion_handles_uneven_local_gqa_boundaries():
+    parts = _parts(total_q=36, total_kv=6, tp=4)
+
+    assert [p.kv_head_indices for p in parts] == [
+        (0, 0, 1),
+        (1, 2, 2),
+        (3, 3, 4),
+        (4, 5, 5),
+    ]
+    assert all(p.num_heads == 9 for p in parts)
+    assert all(p.num_kv_heads == 3 for p in parts)
+    assert all(p.local_q_per_kv_slot == 3 for p in parts)
+
+
+def test_rejects_non_gqa_head_layout():
+    with pytest.raises(ValueError, match="total_num_heads .* total_num_kv_heads"):
+        make_attention_head_partition(
+            total_num_heads=30,
+            total_num_kv_heads=8,
+            tp_size=3,
+            tp_rank=0,
+        )
+
+
+def test_qwopus_tp3_slot_expansion_matches_full_gqa_attention():
+    torch.manual_seed(0)
+    num_tokens = 5
+    num_heads = 24
+    num_kv_heads = 4
+    head_dim = 16
+    scale = head_dim**-0.5
+
+    q = torch.randn(num_tokens, num_heads, head_dim)
+    k = torch.randn(num_tokens, num_kv_heads, head_dim)
+    v = torch.randn(num_tokens, num_kv_heads, head_dim)
+
+    q_per_kv = num_heads // num_kv_heads
+    full_k = k.repeat_interleave(q_per_kv, dim=1)
+    full_v = v.repeat_interleave(q_per_kv, dim=1)
+    full_scores = torch.einsum("qhd,khd->hqk", q, full_k) * scale
+    full_probs = torch.softmax(full_scores, dim=-1)
+    full_out = torch.einsum("hqk,khd->qhd", full_probs, full_v)
+
+    local_outputs = []
+    for part in _parts(total_q=num_heads, total_kv=num_kv_heads, tp=3):
+        local_q = q[:, part.q_head_indices, :]
+        local_k = k[:, part.kv_head_indices, :]
+        local_v = v[:, part.kv_head_indices, :]
+        expanded_k = local_k.repeat_interleave(part.local_q_per_kv_slot, dim=1)
+        expanded_v = local_v.repeat_interleave(part.local_q_per_kv_slot, dim=1)
+        local_scores = torch.einsum("qhd,khd->hqk", local_q, expanded_k) * scale
+        local_probs = torch.softmax(local_scores, dim=-1)
+        local_outputs.append(torch.einsum("hqk,khd->qhd", local_probs, expanded_v))
+
+    tp_out = torch.cat(local_outputs, dim=1)
+    torch.testing.assert_close(tp_out, full_out)

--- a/tests/model_executor/layers/test_gdn_explicit_partition.py
+++ b/tests/model_executor/layers/test_gdn_explicit_partition.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.model_executor.layers.linear import ExplicitPaddedMergedColumnParallelLinear
+from vllm.model_executor.layers.mamba.gdn.head_partition import (
+    explicit_gdn_conv_weight_loader,
+    explicit_vector_weight_loader,
+    make_gdn_head_partition,
+)
+
+
+def test_gdn_partition_preserves_value_groups_for_qwopus_tp3():
+    parts = [
+        make_gdn_head_partition(
+            num_k_heads=16,
+            num_v_heads=48,
+            head_k_dim=128,
+            head_v_dim=128,
+            tp_size=3,
+            tp_rank=rank,
+        )
+        for rank in range(3)
+    ]
+
+    assert [(p.k_start, p.k_count) for p in parts] == [(0, 6), (6, 5), (11, 5)]
+    assert [(p.v_start, p.v_count) for p in parts] == [(0, 18), (18, 15), (33, 15)]
+    assert [p.local_conv_dim for p in parts] == [3840, 3200, 3200]
+    assert [p.padded_conv_dim for p in parts] == [3840, 3840, 3840]
+
+
+def test_explicit_gdn_conv_loader_pads_rank1_without_stealing_next_group():
+    partition = make_gdn_head_partition(
+        num_k_heads=16,
+        num_v_heads=48,
+        head_k_dim=2,
+        head_v_dim=2,
+        tp_size=3,
+        tp_rank=1,
+    )
+    param = torch.nn.Parameter(torch.full((partition.padded_conv_dim, 1, 2), -1.0))
+    loaded_rows = partition.num_k_heads * partition.head_k_dim * 2
+    loaded_rows += partition.num_v_heads * partition.head_v_dim
+    loaded = torch.arange(loaded_rows * 2, dtype=torch.float32).view(-1, 1, 2)
+
+    explicit_gdn_conv_weight_loader(partition)(param, loaded)
+
+    q0 = 0
+    k0 = partition.padded_key_dim
+    v0 = partition.padded_key_dim * 2
+    key_dim = partition.num_k_heads * partition.head_k_dim
+    value_offset = key_dim * 2
+
+    torch.testing.assert_close(
+        param[q0 : q0 + partition.local_key_dim],
+        loaded[partition.k_start * partition.head_k_dim :][: partition.local_key_dim],
+    )
+    torch.testing.assert_close(
+        param[k0 : k0 + partition.local_key_dim],
+        loaded[key_dim + partition.k_start * partition.head_k_dim :][
+            : partition.local_key_dim
+        ],
+    )
+    torch.testing.assert_close(
+        param[v0 : v0 + partition.local_value_dim],
+        loaded[value_offset + partition.v_start * partition.head_v_dim :][
+            : partition.local_value_dim
+        ],
+    )
+    assert torch.count_nonzero(param[q0 + partition.local_key_dim : k0]) == 0
+    assert torch.count_nonzero(param[k0 + partition.local_key_dim : v0]) == 0
+    assert torch.count_nonzero(param[v0 + partition.local_value_dim :]) == 0
+
+
+def test_explicit_vector_loader_pads_tail():
+    param = torch.nn.Parameter(torch.full((18,), -1.0))
+    loaded = torch.arange(48, dtype=torch.float32)
+
+    explicit_vector_weight_loader(start=18, size=15)(param, loaded)
+
+    torch.testing.assert_close(param[:15], loaded[18:33])
+    assert torch.count_nonzero(param[15:]) == 0
+
+
+def test_explicit_merged_loader_uses_logical_offsets_for_fused_checkpoint(monkeypatch):
+    import vllm.model_executor.layers.linear as linear
+    import vllm.model_executor.parameter as parameter
+
+    monkeypatch.setattr(linear, "get_tensor_model_parallel_world_size", lambda: 3)
+    monkeypatch.setattr(linear, "get_tensor_model_parallel_rank", lambda: 2)
+    monkeypatch.setattr(parameter, "get_tensor_model_parallel_rank", lambda: 2)
+    monkeypatch.setattr(parameter, "get_tensor_model_parallel_world_size", lambda: 3)
+
+    layer = ExplicitPaddedMergedColumnParallelLinear(
+        input_size=2,
+        output_sizes=[2048, 2048, 6144, 6144],
+        padded_output_sizes=[2304, 2304, 6912, 6912],
+        local_starts=[1408, 1408, 4224, 4224],
+        local_sizes=[640, 640, 1920, 1920],
+        bias=False,
+        quant_config=None,
+        prefix="test.gdn_qkvz",
+    )
+    loaded = torch.arange((2048 + 2048 + 6144 + 6144) * 2,
+                          dtype=torch.float32).view(-1, 2)
+
+    layer.weight_loader(layer.weight, loaded, None)
+
+    offsets = [0, 768, 1536, 3840]
+    sizes = [640, 640, 1920, 1920]
+    source_offsets = [1408, 2048 + 1408, 4096 + 4224, 10240 + 4224]
+    for dest, size, source in zip(offsets, sizes, source_offsets):
+        torch.testing.assert_close(layer.weight[dest : dest + size],
+                                   loaded[source : source + size])

--- a/tests/model_executor/layers/test_gdn_explicit_partition.py
+++ b/tests/model_executor/layers/test_gdn_explicit_partition.py
@@ -3,7 +3,11 @@
 
 import torch
 
-from vllm.model_executor.layers.linear import ExplicitPaddedMergedColumnParallelLinear
+from vllm.model_executor.layers.linear import (
+    ExplicitPaddedMergedColumnParallelLinear,
+    PaddedMergedColumnParallelLinear,
+    PaddedRowParallelLinear,
+)
 from vllm.model_executor.layers.mamba.gdn.head_partition import (
     explicit_gdn_conv_weight_loader,
     explicit_vector_weight_loader,
@@ -28,6 +32,29 @@ def test_gdn_partition_preserves_value_groups_for_qwopus_tp3():
     assert [(p.v_start, p.v_count) for p in parts] == [(0, 18), (18, 15), (33, 15)]
     assert [p.local_conv_dim for p in parts] == [3840, 3200, 3200]
     assert [p.padded_conv_dim for p in parts] == [3840, 3840, 3840]
+
+
+def test_gdn_partition_matches_regular_qwen35_tp2_split():
+    parts = [
+        make_gdn_head_partition(
+            num_k_heads=16,
+            num_v_heads=48,
+            head_k_dim=128,
+            head_v_dim=128,
+            tp_size=2,
+            tp_rank=rank,
+        )
+        for rank in range(2)
+    ]
+
+    assert [(p.k_start, p.k_count) for p in parts] == [(0, 8), (8, 8)]
+    assert [(p.v_start, p.v_count) for p in parts] == [(0, 24), (24, 24)]
+    assert [p.local_key_dim for p in parts] == [1024, 1024]
+    assert [p.local_value_dim for p in parts] == [3072, 3072]
+    assert [p.padded_qkvz_output_sizes for p in parts] == [
+        [2048, 2048, 6144, 6144],
+        [2048, 2048, 6144, 6144],
+    ]
 
 
 def test_explicit_gdn_conv_loader_pads_rank1_without_stealing_next_group():
@@ -113,3 +140,396 @@ def test_explicit_merged_loader_uses_logical_offsets_for_fused_checkpoint(monkey
     for dest, size, source in zip(offsets, sizes, source_offsets):
         torch.testing.assert_close(layer.weight[dest : dest + size],
                                    loaded[source : source + size])
+
+
+def test_explicit_merged_loader_adjusts_packed_output_fused_checkpoint(monkeypatch):
+    import vllm.model_executor.layers.linear as linear
+    import vllm.model_executor.parameter as parameter
+    from vllm.model_executor.parameter import PackedColumnParameter
+
+    monkeypatch.setattr(linear, "get_tensor_model_parallel_world_size", lambda: 3)
+    monkeypatch.setattr(linear, "get_tensor_model_parallel_rank", lambda: 2)
+    monkeypatch.setattr(parameter, "get_tensor_model_parallel_rank", lambda: 2)
+    monkeypatch.setattr(parameter, "get_tensor_model_parallel_world_size", lambda: 3)
+
+    layer = ExplicitPaddedMergedColumnParallelLinear(
+        input_size=2,
+        output_sizes=[2048, 2048, 6144, 6144],
+        padded_output_sizes=[2304, 2304, 6912, 6912],
+        local_starts=[1408, 1408, 4224, 4224],
+        local_sizes=[640, 640, 1920, 1920],
+        bias=False,
+        quant_config=None,
+        prefix="test.gdn_qkvz",
+    )
+    packed_factor = 8
+    local_padded_rows = sum(layer.output_sizes) // layer.tp_size
+    param = PackedColumnParameter(
+        data=torch.full((local_padded_rows // packed_factor, 2), -1.0),
+        weight_loader=lambda *args, **kwargs: None,
+        output_dim=0,
+        packed_dim=0,
+        packed_factor=packed_factor,
+    )
+    loaded_rows = sum(layer.logical_output_sizes) // packed_factor
+    loaded = torch.arange(loaded_rows * 2, dtype=torch.float32).view(-1, 2)
+
+    layer.weight_loader_v2(param, loaded, None)
+
+    offsets = [0, 768, 1536, 3840]
+    sizes = [640, 640, 1920, 1920]
+    source_offsets = [1408, 2048 + 1408, 4096 + 4224, 10240 + 4224]
+    for dest, size, source in zip(offsets, sizes, source_offsets):
+        dest //= packed_factor
+        size //= packed_factor
+        source //= packed_factor
+        torch.testing.assert_close(param[dest : dest + size],
+                                   loaded[source : source + size])
+
+    assert torch.count_nonzero(param[80:96]) == 0
+    assert torch.count_nonzero(param[176:192]) == 0
+    assert torch.count_nonzero(param[432:480]) == 0
+    assert torch.count_nonzero(param[720:]) == 0
+
+
+def test_explicit_merged_loader_reconstructs_wna16_quant_params_tp3(monkeypatch):
+    import vllm.model_executor.layers.linear as linear
+    import vllm.model_executor.parameter as parameter
+    from vllm.model_executor.parameter import (
+        GroupQuantScaleParameter,
+        PackedvLLMParameter,
+    )
+
+    packed_factor = 8
+    groups = 160
+    logical_sizes = [2048, 2048, 6144, 6144]
+    padded_sizes = [2304, 2304, 6912, 6912]
+    local_starts_by_rank = [
+        [0, 0, 0, 0],
+        [768, 768, 2304, 2304],
+        [1408, 1408, 4224, 4224],
+    ]
+    local_sizes_by_rank = [
+        [768, 768, 2304, 2304],
+        [640, 640, 1920, 1920],
+        [640, 640, 1920, 1920],
+    ]
+    logical_total = sum(logical_sizes)
+    padded_local_total = sum(padded_sizes) // 3
+
+    loaded_zp = torch.arange(logical_total // packed_factor * groups,
+                             dtype=torch.int32).view(-1, groups)
+    loaded_scales = torch.arange(logical_total * groups,
+                                 dtype=torch.float32).view(-1, groups)
+
+    for rank in range(3):
+        monkeypatch.setattr(linear, "get_tensor_model_parallel_world_size", lambda: 3)
+        monkeypatch.setattr(linear, "get_tensor_model_parallel_rank", lambda r=rank: r)
+        monkeypatch.setattr(parameter, "get_tensor_model_parallel_rank",
+                            lambda r=rank: r)
+        monkeypatch.setattr(parameter, "get_tensor_model_parallel_world_size",
+                            lambda: 3)
+
+        layer = ExplicitPaddedMergedColumnParallelLinear(
+            input_size=5120,
+            output_sizes=logical_sizes,
+            padded_output_sizes=padded_sizes,
+            local_starts=local_starts_by_rank[rank],
+            local_sizes=local_sizes_by_rank[rank],
+            bias=False,
+            quant_config=None,
+            prefix="test.gdn_qkvz",
+        )
+        qzeros = PackedvLLMParameter(
+            data=torch.full((padded_local_total // packed_factor, groups),
+                            -1,
+                            dtype=torch.int32),
+            weight_loader=lambda *args, **kwargs: None,
+            input_dim=1,
+            output_dim=0,
+            packed_dim=0,
+            packed_factor=packed_factor,
+        )
+        scales = GroupQuantScaleParameter(
+            data=torch.full((padded_local_total, groups), -1.0),
+            weight_loader=lambda *args, **kwargs: None,
+            input_dim=1,
+            output_dim=0,
+        )
+
+        layer.weight_loader_v2(qzeros, loaded_zp, None)
+        layer.weight_loader_v2(scales, loaded_scales, None)
+
+        dst = 0
+        src_base = 0
+        for shard, logical_size in enumerate(logical_sizes):
+            padded = padded_sizes[shard] // 3
+            local_start = local_starts_by_rank[rank][shard]
+            local_size = local_sizes_by_rank[rank][shard]
+            if local_size:
+                zp_dst = dst // packed_factor
+                zp_src = (src_base + local_start) // packed_factor
+                zp_size = local_size // packed_factor
+                torch.testing.assert_close(qzeros[zp_dst : zp_dst + zp_size],
+                                           loaded_zp[zp_src : zp_src + zp_size])
+                torch.testing.assert_close(scales[dst : dst + local_size],
+                                           loaded_scales[
+                                               src_base
+                                               + local_start : src_base
+                                               + local_start
+                                               + local_size])
+            assert torch.count_nonzero(qzeros[
+                (dst + local_size) // packed_factor : (dst + padded)
+                // packed_factor]) == 0
+            assert torch.count_nonzero(scales[dst + local_size : dst + padded]) == 0
+            dst += padded
+            src_base += logical_size
+
+
+def test_explicit_merged_loader_handles_qwen35_awq_qkv_tuple_then_z(monkeypatch):
+    import vllm.model_executor.layers.linear as linear
+    import vllm.model_executor.parameter as parameter
+    from vllm.model_executor.parameter import (
+        GroupQuantScaleParameter,
+        PackedvLLMParameter,
+    )
+
+    monkeypatch.setattr(linear, "get_tensor_model_parallel_world_size", lambda: 3)
+    monkeypatch.setattr(linear, "get_tensor_model_parallel_rank", lambda: 2)
+    monkeypatch.setattr(parameter, "get_tensor_model_parallel_rank", lambda: 2)
+    monkeypatch.setattr(parameter, "get_tensor_model_parallel_world_size", lambda: 3)
+
+    logical_sizes = [2048, 2048, 6144, 6144]
+    padded_sizes = [2304, 2304, 6912, 6912]
+    local_starts = [1408, 1408, 4224, 4224]
+    local_sizes = [640, 640, 1920, 1920]
+    packed_factor = 8
+    groups = 160
+    layer = ExplicitPaddedMergedColumnParallelLinear(
+        input_size=5120,
+        output_sizes=logical_sizes,
+        padded_output_sizes=padded_sizes,
+        local_starts=local_starts,
+        local_sizes=local_sizes,
+        bias=False,
+        quant_config=None,
+        prefix="test.gdn_qkvz",
+    )
+    local_total = sum(layer.output_sizes) // layer.tp_size
+    qzeros = PackedvLLMParameter(
+        data=torch.full((local_total // packed_factor, groups),
+                        -1,
+                        dtype=torch.int32),
+        weight_loader=lambda *args, **kwargs: None,
+        input_dim=1,
+        output_dim=0,
+        packed_dim=0,
+        packed_factor=packed_factor,
+    )
+    scales = GroupQuantScaleParameter(
+        data=torch.full((local_total, groups), -1.0),
+        weight_loader=lambda *args, **kwargs: None,
+        input_dim=1,
+        output_dim=0,
+    )
+
+    qkv_logical = sum(logical_sizes[:3])
+    z_logical = logical_sizes[3]
+    qkv_zp = torch.arange((qkv_logical // packed_factor) * groups,
+                          dtype=torch.int32).view(-1, groups)
+    qkv_scales = torch.arange(qkv_logical * groups,
+                              dtype=torch.float32).view(-1, groups)
+    z_zp = torch.arange((z_logical // packed_factor) * groups,
+                        dtype=torch.int32).view(-1, groups) + 10_000_000
+    z_scales = torch.arange(z_logical * groups,
+                            dtype=torch.float32).view(-1, groups) + 10_000_000
+
+    layer.weight_loader_v2(qzeros, qkv_zp, (0, 1, 2))
+    layer.weight_loader_v2(scales, qkv_scales, (0, 1, 2))
+    layer.weight_loader_v2(qzeros, z_zp, 3)
+    layer.weight_loader_v2(scales, z_scales, 3)
+
+    dst_offsets = [0, 768, 1536, 3840]
+    qkv_src_bases = [0, 2048, 4096]
+    for shard, src_base in enumerate(qkv_src_bases):
+        dst = dst_offsets[shard]
+        local_start = local_starts[shard]
+        local_size = local_sizes[shard]
+        torch.testing.assert_close(
+            qzeros[dst // packed_factor : (dst + local_size) // packed_factor],
+            qkv_zp[(src_base + local_start) // packed_factor : (
+                src_base + local_start + local_size
+            ) // packed_factor],
+        )
+        torch.testing.assert_close(
+            scales[dst : dst + local_size],
+            qkv_scales[src_base + local_start : src_base + local_start + local_size],
+        )
+
+    z_dst = dst_offsets[3]
+    z_local_start = local_starts[3]
+    z_local_size = local_sizes[3]
+    torch.testing.assert_close(
+        qzeros[z_dst // packed_factor : (z_dst + z_local_size) // packed_factor],
+        z_zp[z_local_start // packed_factor : (
+            z_local_start + z_local_size
+        ) // packed_factor],
+    )
+    torch.testing.assert_close(
+        scales[z_dst : z_dst + z_local_size],
+        z_scales[z_local_start : z_local_start + z_local_size],
+    )
+
+
+def test_padded_mlp_loader_reconstructs_wna16_gate_up_tp3_rank2(monkeypatch):
+    import vllm.model_executor.layers.linear as linear
+    import vllm.model_executor.parameter as parameter
+    from vllm.model_executor.parameter import (
+        GroupQuantScaleParameter,
+        PackedvLLMParameter,
+    )
+
+    monkeypatch.setattr(linear, "get_tensor_model_parallel_world_size", lambda: 3)
+    monkeypatch.setattr(linear, "get_tensor_model_parallel_rank", lambda: 2)
+    monkeypatch.setattr(parameter, "get_tensor_model_parallel_rank", lambda: 2)
+    monkeypatch.setattr(parameter, "get_tensor_model_parallel_world_size", lambda: 3)
+
+    logical = 17408
+    padded = 17472
+    packed_factor = 8
+    groups = 160
+    layer = PaddedMergedColumnParallelLinear(
+        input_size=5120,
+        output_sizes=[logical, logical],
+        padded_output_sizes=[padded, padded],
+        bias=False,
+        quant_config=None,
+        prefix="test.mlp.gate_up_proj",
+    )
+    local_total = sum(layer.output_sizes) // layer.tp_size
+    qzeros = PackedvLLMParameter(
+        data=torch.full((local_total // packed_factor, groups),
+                        -1,
+                        dtype=torch.int32),
+        weight_loader=lambda *args, **kwargs: None,
+        input_dim=1,
+        output_dim=0,
+        packed_dim=0,
+        packed_factor=packed_factor,
+    )
+    scales = GroupQuantScaleParameter(
+        data=torch.full((local_total, groups), -1.0),
+        weight_loader=lambda *args, **kwargs: None,
+        input_dim=1,
+        output_dim=0,
+    )
+    loaded_zp = torch.arange((logical * 2 // packed_factor) * groups,
+                             dtype=torch.int32).view(-1, groups)
+    loaded_scales = torch.arange(logical * 2 * groups,
+                                 dtype=torch.float32).view(-1, groups)
+
+    layer.weight_loader_v2(qzeros, loaded_zp, None)
+    layer.weight_loader_v2(scales, loaded_scales, None)
+
+    shard = padded // 3
+    copy = logical - 2 * shard
+    assert copy == 5760
+    for idx, src_base in enumerate([0, logical]):
+        dst = idx * shard
+        torch.testing.assert_close(
+            qzeros[dst // packed_factor : (dst + copy) // packed_factor],
+            loaded_zp[(src_base + 2 * shard) // packed_factor : (
+                src_base + 2 * shard + copy
+            ) // packed_factor],
+        )
+        torch.testing.assert_close(
+            scales[dst : dst + copy],
+            loaded_scales[src_base + 2 * shard : src_base + 2 * shard + copy],
+        )
+        assert torch.count_nonzero(qzeros[(dst + copy) // packed_factor : (
+            dst + shard
+        ) // packed_factor]) == 0
+        assert torch.count_nonzero(scales[dst + copy : dst + shard]) == 0
+
+
+def test_padded_row_loader_reconstructs_wna16_down_proj_tp3_rank2(monkeypatch):
+    import vllm.model_executor.layers.linear as linear
+    import vllm.model_executor.parameter as parameter
+    from vllm.model_executor.parameter import (
+        GroupQuantScaleParameter,
+        PackedvLLMParameter,
+    )
+
+    monkeypatch.setattr(linear, "get_tensor_model_parallel_world_size", lambda: 3)
+    monkeypatch.setattr(linear, "get_tensor_model_parallel_rank", lambda: 2)
+    monkeypatch.setattr(parameter, "get_tensor_model_parallel_rank", lambda: 2)
+    monkeypatch.setattr(parameter, "get_tensor_model_parallel_world_size", lambda: 3)
+
+    logical = 17408
+    padded = 17472
+    output = 5120
+    packed_factor = 8
+    layer = PaddedRowParallelLinear(
+        input_size=logical,
+        padded_input_size=padded,
+        output_size=output,
+        bias=False,
+        quant_config=None,
+        prefix="test.mlp.down_proj",
+    )
+    qweight = PackedvLLMParameter(
+        data=torch.full((output, layer.input_size_per_partition // packed_factor),
+                        -1,
+                        dtype=torch.int32),
+        weight_loader=lambda *args, **kwargs: None,
+        input_dim=1,
+        output_dim=0,
+        packed_dim=1,
+        packed_factor=packed_factor,
+    )
+    scales = GroupQuantScaleParameter(
+        data=torch.full((output, layer.input_size_per_partition // 32), -1.0),
+        weight_loader=lambda *args, **kwargs: None,
+        input_dim=1,
+        output_dim=0,
+    )
+    qzeros = PackedvLLMParameter(
+        data=torch.full((output // packed_factor,
+                         layer.input_size_per_partition // 32),
+                        -1,
+                        dtype=torch.int32),
+        weight_loader=lambda *args, **kwargs: None,
+        input_dim=1,
+        output_dim=0,
+        packed_dim=0,
+        packed_factor=packed_factor,
+    )
+    loaded_qweight = torch.arange(output * (logical // packed_factor),
+                                  dtype=torch.int32).view(output, -1)
+    loaded_scales = torch.arange(output * (logical // 32),
+                                 dtype=torch.float32).view(output, -1)
+    loaded_qzeros = torch.arange((output // packed_factor) * (logical // 32),
+                                 dtype=torch.int32).view(output // packed_factor, -1)
+
+    layer.weight_loader_v2(qweight, loaded_qweight)
+    layer.weight_loader_v2(scales, loaded_scales)
+    layer.weight_loader_v2(qzeros, loaded_qzeros)
+
+    start = 2 * layer.input_size_per_partition
+    copy = logical - start
+    assert copy == 5760
+    torch.testing.assert_close(qweight[:, : copy // packed_factor],
+                               loaded_qweight[:, start // packed_factor : (
+                                   start + copy
+                               ) // packed_factor])
+    torch.testing.assert_close(scales[:, : copy // 32],
+                               loaded_scales[:, start // 32 : (
+                                   start + copy
+                               ) // 32])
+    torch.testing.assert_close(qzeros[:, : copy // 32],
+                               loaded_qzeros[:, start // 32 : (
+                                   start + copy
+                               ) // 32])
+    assert torch.count_nonzero(qweight[:, copy // packed_factor :]) == 0
+    assert torch.count_nonzero(scales[:, copy // 32 :]) == 0
+    assert torch.count_nonzero(qzeros[:, copy // 32 :]) == 0

--- a/tests/model_executor/layers/test_overlapping_gqa_linear.py
+++ b/tests/model_executor/layers/test_overlapping_gqa_linear.py
@@ -3,7 +3,39 @@
 
 import torch
 
+from vllm.model_executor.layers.attention.head_partition import (
+    make_attention_head_partition,
+)
 from vllm.model_executor.layers.linear import QKVParallelLinearOverlappingGQA
+from vllm.model_executor.parameter import PerTensorScaleParameter
+
+
+def test_overlapping_gqa_partition_matches_qwen35_27b_tp3_gate_layout():
+    parts = [
+        make_attention_head_partition(
+            total_num_heads=48,
+            total_num_kv_heads=4,
+            tp_size=3,
+            tp_rank=rank,
+        )
+        for rank in range(3)
+    ]
+
+    assert [p.q_head_indices for p in parts] == [
+        tuple(range(0, 16)),
+        tuple(range(16, 32)),
+        tuple(range(32, 48)),
+    ]
+    assert [p.kv_head_indices for p in parts] == [
+        (0, 0, 0, 1),
+        (1, 1, 2, 2),
+        (2, 3, 3, 3),
+    ]
+    assert [p.q_to_local_kv_indices for p in parts] == [
+        (0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3),
+        (0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3),
+        (0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3),
+    ]
 
 
 def test_overlapping_gqa_qkv_loader_duplicates_kv_slots(monkeypatch):
@@ -65,3 +97,99 @@ def test_overlapping_gqa_qkv_loader_duplicates_kv_slots(monkeypatch):
             dim=0,
         ),
     )
+
+
+def test_overlapping_gqa_qkv_loader_adjusts_packed_kv_slots(monkeypatch):
+    import vllm.model_executor.layers.linear as linear
+    import vllm.model_executor.parameter as parameter
+    from vllm.model_executor.parameter import PackedColumnParameter
+
+    monkeypatch.setattr(linear, "get_tensor_model_parallel_world_size", lambda: 3)
+    monkeypatch.setattr(linear, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(parameter, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(parameter, "get_tensor_model_parallel_world_size", lambda: 3)
+
+    layer = QKVParallelLinearOverlappingGQA(
+        hidden_size=3,
+        head_size=2,
+        total_num_heads=48,
+        total_num_kv_heads=4,
+        kv_head_indices=(0, 0, 0, 1),
+        bias=False,
+        quant_config=None,
+        prefix="test.qkv_proj",
+    )
+    packed_factor = 2
+    param = PackedColumnParameter(
+        data=torch.full((layer.output_size_per_partition // packed_factor, 3), -1.0),
+        weight_loader=lambda *args, **kwargs: None,
+        output_dim=0,
+        packed_dim=0,
+        packed_factor=packed_factor,
+    )
+    k_weight = torch.arange(4 * 3, dtype=torch.float32).view(4, 3) + 1000
+    v_weight = torch.arange(4 * 3, dtype=torch.float32).view(4, 3) + 2000
+
+    layer.weight_loader_v2(param, k_weight, "k")
+    layer.weight_loader_v2(param, v_weight, "v")
+
+    q_rows = 16 * 2 // packed_factor
+    kv_rows = 4 * 2 // packed_factor
+    actual_k = param[q_rows : q_rows + kv_rows]
+    actual_v = param[q_rows + kv_rows : q_rows + kv_rows * 2]
+
+    torch.testing.assert_close(
+        actual_k,
+        torch.cat(
+            [
+                k_weight[0:1],
+                k_weight[0:1],
+                k_weight[0:1],
+                k_weight[1:2],
+            ],
+            dim=0,
+        ),
+    )
+    torch.testing.assert_close(
+        actual_v,
+        torch.cat(
+            [
+                v_weight[0:1],
+                v_weight[0:1],
+                v_weight[0:1],
+                v_weight[1:2],
+            ],
+            dim=0,
+        ),
+    )
+
+
+def test_overlapping_gqa_qkv_loader_preserves_scalar_scale_slots(monkeypatch):
+    import vllm.model_executor.layers.linear as linear
+    import vllm.model_executor.parameter as parameter
+
+    monkeypatch.setattr(linear, "get_tensor_model_parallel_world_size", lambda: 3)
+    monkeypatch.setattr(linear, "get_tensor_model_parallel_rank", lambda: 1)
+    monkeypatch.setattr(parameter, "get_tensor_model_parallel_rank", lambda: 1)
+    monkeypatch.setattr(parameter, "get_tensor_model_parallel_world_size", lambda: 3)
+
+    layer = QKVParallelLinearOverlappingGQA(
+        hidden_size=3,
+        head_size=2,
+        total_num_heads=48,
+        total_num_kv_heads=4,
+        kv_head_indices=(1, 1, 2, 2),
+        bias=False,
+        quant_config=None,
+        prefix="test.qkv_proj",
+    )
+    param = PerTensorScaleParameter(
+        data=torch.full((3,), -1.0),
+        weight_loader=layer.weight_loader_v2,
+    )
+
+    layer.weight_loader_v2(param, torch.tensor(1.25), "q")
+    layer.weight_loader_v2(param, torch.tensor(2.5), "k")
+    layer.weight_loader_v2(param, torch.tensor(5.0), "v")
+
+    torch.testing.assert_close(param, torch.tensor([1.25, 2.5, 5.0]))

--- a/tests/model_executor/layers/test_overlapping_gqa_linear.py
+++ b/tests/model_executor/layers/test_overlapping_gqa_linear.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.model_executor.layers.linear import QKVParallelLinearOverlappingGQA
+
+
+def test_overlapping_gqa_qkv_loader_duplicates_kv_slots(monkeypatch):
+    import vllm.model_executor.layers.linear as linear
+    import vllm.model_executor.parameter as parameter
+
+    monkeypatch.setattr(linear, "get_tensor_model_parallel_world_size", lambda: 3)
+    monkeypatch.setattr(linear, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(parameter, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(parameter, "get_tensor_model_parallel_world_size", lambda: 3)
+
+    layer = QKVParallelLinearOverlappingGQA(
+        hidden_size=3,
+        head_size=2,
+        total_num_heads=48,
+        total_num_kv_heads=4,
+        kv_head_indices=(0, 0, 0, 1),
+        bias=False,
+        quant_config=None,
+        prefix="test.qkv_proj",
+    )
+
+    q_weight = torch.arange(48 * 2 * 3, dtype=torch.float32).view(48 * 2, 3)
+    k_weight = torch.arange(4 * 2 * 3, dtype=torch.float32).view(4 * 2, 3) + 1000
+    v_weight = torch.arange(4 * 2 * 3, dtype=torch.float32).view(4 * 2, 3) + 2000
+
+    layer.weight_loader(layer.weight, q_weight, "q")
+    layer.weight_loader(layer.weight, k_weight, "k")
+    layer.weight_loader(layer.weight, v_weight, "v")
+
+    q_rows = 16 * 2
+    kv_rows = 4 * 2
+    actual_q = layer.weight[:q_rows]
+    actual_k = layer.weight[q_rows : q_rows + kv_rows]
+    actual_v = layer.weight[q_rows + kv_rows :]
+
+    torch.testing.assert_close(actual_q, q_weight[:q_rows])
+    torch.testing.assert_close(
+        actual_k,
+        torch.cat(
+            [
+                k_weight[0:2],
+                k_weight[0:2],
+                k_weight[0:2],
+                k_weight[2:4],
+            ],
+            dim=0,
+        ),
+    )
+    torch.testing.assert_close(
+        actual_v,
+        torch.cat(
+            [
+                v_weight[0:2],
+                v_weight[0:2],
+                v_weight[0:2],
+                v_weight[2:4],
+            ],
+            dim=0,
+        ),
+    )

--- a/tests/model_executor/layers/test_vocab_tp3_padding.py
+++ b/tests/model_executor/layers/test_vocab_tp3_padding.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from math import lcm
+
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    DEFAULT_VOCAB_PADDING_SIZE,
+    VocabParallelEmbedding,
+    pad_vocab_size,
+)
+
+
+def test_vocab_padding_is_tp_aligned_for_qwopus_tp3():
+    vocab_size = 248320
+    tp_size = 3
+    padded = pad_vocab_size(vocab_size, lcm(DEFAULT_VOCAB_PADDING_SIZE, tp_size))
+
+    assert padded == 248448
+    assert padded % tp_size == 0
+
+    shard_sizes = []
+    for rank in range(tp_size):
+        shard = VocabParallelEmbedding._get_indices(
+            vocab_size_padded=padded,
+            org_vocab_size_padded=padded,
+            vocab_size=vocab_size,
+            org_vocab_size=vocab_size,
+            tp_rank=rank,
+            tp_size=tp_size,
+        )
+        shard_sizes.append(shard.num_elements_padded)
+
+    assert shard_sizes == [82816, 82816, 82816]

--- a/tests/model_executor/models/test_qwen2_moe_tp_padding.py
+++ b/tests/model_executor/models/test_qwen2_moe_tp_padding.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.model_executor.models.qwen2_moe import (
+    _ceil_to_multiple,
+    _dense_mlp_padded_intermediate_multiple,
+)
+
+
+def test_dense_mlp_tp3_padding_aligns_awq_group_size():
+    intermediate_size = 17408
+    tp_size = 3
+
+    padded = _ceil_to_multiple(
+        intermediate_size,
+        _dense_mlp_padded_intermediate_multiple(tp_size),
+    )
+
+    assert padded == 17472
+    assert padded % tp_size == 0
+    assert (padded // tp_size) % 32 == 0

--- a/tests/model_executor/models/test_qwen3_vision_tp3_padding.py
+++ b/tests/model_executor/models/test_qwen3_vision_tp3_padding.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.model_executor.models.qwen2_5_vl import _pad_to_tp
+
+
+def test_qwen3_vision_tp3_padding_covers_heads_and_mlp():
+    assert _pad_to_tp(16, 3) == 18
+    assert _pad_to_tp(4304, 3) == 4305
+    assert _pad_to_tp(4608, 3) == 4608

--- a/tests/parser/engine/test_qwen3.py
+++ b/tests/parser/engine/test_qwen3.py
@@ -70,6 +70,87 @@ class TestNonStreaming:
         args = json.loads(result.tool_calls[0].function.arguments)
         assert args == {"city": "Tokyo"}
 
+    @pytest.mark.parametrize(
+        ("function_opener", "function_closer"),
+        [
+            ('<|im_start|>="', '"'),
+            ("<|im_start|>function=", ">"),
+            ("=", "\n"),
+        ],
+    )
+    def test_malformed_auto_function_openers(
+        self,
+        parser,
+        mock_request,
+        function_opener,
+        function_closer,
+    ):
+        text = (
+            "<tool_call>\n"
+            f"{function_opener}read{function_closer}\n"
+            "<parameter=filePath>solution.cpp</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+
+        result = parser.extract_tool_calls(text, mock_request)
+
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "read"
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert args == {"filePath": "solution.cpp"}
+
+    def test_quoted_xml_parameter_name_and_value(self, parser, mock_request):
+        text = (
+            "<tool_call>\n"
+            "<function=read>\n"
+            '<parameter="filePath">"solution.cpp"</parameter>\n'
+            "</function>\n"
+            "</tool_call>"
+        )
+
+        result = parser.extract_tool_calls(text, mock_request)
+
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert args == {"filePath": "solution.cpp"}
+
+    def test_default_api_call_fallback(self, parser, mock_request):
+        text = (
+            "I'll read it.\n"
+            "```text\n"
+            "\"call: default_api:read{'filePath': 'solution.cpp'}\"\n"
+            "```"
+        )
+
+        result = parser.extract_tool_calls(text, mock_request)
+
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "read"
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert args == {"filePath": "solution.cpp"}
+        assert "call: default_api" not in (result.content or "")
+
+    def test_json_tool_descriptor_fallback(self, parser, mock_request):
+        text = (
+            "Here is the read request.\n"
+            "```json\n"
+            '{\n  "tool": "read",\n'
+            '  "arguments": {"filePath": "solution.cpp"}\n'
+            "}\n"
+            "```"
+        )
+
+        result = parser.extract_tool_calls(text, mock_request)
+
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "read"
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert args == {"filePath": "solution.cpp"}
+
     def test_parallel_tool_calls(self, parser, mock_request):
         text = (
             "<tool_call>\n"
@@ -541,6 +622,51 @@ class TestStreaming:
         assert args_text
         parsed = json.loads(args_text)
         assert parsed["x"] == "1"
+
+    def test_streaming_malformed_auto_imstart_function_opener(
+        self,
+        parser,
+        mock_request,
+    ):
+        chunks = [
+            "<tool_call>\n",
+            '<|im_start|>="read"\n',
+            "<parameter=filePath>solution.cpp</parameter>\n",
+            "</function>\n",
+            "</tool_call>",
+        ]
+
+        results = simulate_tool_streaming(parser, mock_request, chunks)
+
+        name = collect_function_name(results)
+        assert name == "read"
+
+        args_text = collect_tool_arguments(results)
+        assert args_text
+        parsed = json.loads(args_text)
+        assert parsed["filePath"] == "solution.cpp"
+
+    def test_streaming_quoted_xml_parameter_value(
+        self,
+        parser,
+        mock_request,
+    ):
+        chunks = [
+            "<tool_call>\n",
+            "<function=read>\n",
+            '<parameter=filePath>"s',
+            "olution.cpp",
+            '"</parameter>\n',
+            "</function>\n",
+            "</tool_call>",
+        ]
+
+        results = simulate_tool_streaming(parser, mock_request, chunks)
+
+        args_text = collect_tool_arguments(results)
+        assert args_text
+        parsed = json.loads(args_text)
+        assert parsed["filePath"] == "solution.cpp"
 
     def test_char_by_char_streaming(self, mock_request):
         """Feed text character-by-character to test lexer robustness.

--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -67,6 +67,37 @@ def _convert_dtype_to_torch(dtype):
         raise ValueError(f"Unknown dtype: {dtype}")
 
 
+def test_flashinfer_dcp_paged_metadata_uses_local_context_lengths():
+    from vllm.v1.attention.backends.flashinfer import (
+        _flashinfer_seq_lens_and_blocks_for_paged_kv,
+    )
+
+    # Long chunked prefill shape from the TP3/DCP experiment:
+    # 96K cached context plus a 16K scheduled chunk. FlashInfer's paged
+    # context run must see only the DCP-local portion of the cached context;
+    # the scheduled query chunk is handled by the ragged new-token run.
+    seq_lens_cpu = torch.tensor([96_672 + 16_112], dtype=torch.int32)
+    qo_indptr_cpu = torch.tensor([0, 16_112], dtype=torch.int32)
+
+    local_seq_lens, seq_lens_np, num_blocks_np = (
+        _flashinfer_seq_lens_and_blocks_for_paged_kv(
+            seq_lens_cpu,
+            qo_indptr_cpu,
+            num_decodes=0,
+            num_prefills=1,
+            page_size=16,
+            use_dcp=True,
+            dcp_world_size=3,
+            dcp_rank=2,
+            dcp_kv_cache_interleave_size=1,
+        )
+    )
+
+    assert local_seq_lens.tolist() == [32_224]
+    assert seq_lens_np.tolist() == [32_224]
+    assert num_blocks_np.tolist() == [2_014]
+
+
 # Define common batch configurations
 BATCH_SPECS = {
     "small_decode": BatchSpec(seq_lens=[32, 40], query_lens=[1, 1]),

--- a/tests/v1/attention/test_indexer_dcp_localize.py
+++ b/tests/v1/attention/test_indexer_dcp_localize.py
@@ -810,7 +810,7 @@ def test_dcp_global_topk_physical_attention_matches_non_dcp(interleave: int):
 def test_correct_attn_out_zeroes_empty_nan_partial(is_lse_base_on_e: bool):
     out = torch.full((1, 1, 4), float("nan"), device="cuda")
     lses = torch.tensor(
-        [[[0.0]], [[float("-inf")]]],
+        [[[0.0]], [[float("-inf")]], [[float("-inf")]]],
         dtype=torch.float32,
         device="cuda",
     )

--- a/tests/v1/core/test_dcp_mamba_chunk_alignment.py
+++ b/tests/v1/core/test_dcp_mamba_chunk_alignment.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+)
+
+
+def test_mamba_align_chunk_split_uses_dcp_effective_block_size():
+    pytest.importorskip("torch")
+    from vllm.v1.core.sched.scheduler import Scheduler
+
+    request = SimpleNamespace(
+        num_computed_tokens=0,
+        num_prompt_tokens=1000,
+        num_tokens=1000,
+    )
+    scheduler = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=16),
+        block_size=16,
+        dcp_world_size=3,
+        use_eagle=False,
+    )
+
+    adjusted = Scheduler._mamba_block_aligned_split(
+        self=scheduler,
+        request=request,
+        num_new_tokens=128,
+    )
+
+    assert adjusted == 96
+    effective_block_size = scheduler.cache_config.block_size * scheduler.dcp_world_size
+    assert adjusted % effective_block_size == 0
+
+
+def test_mamba_align_split_keeps_small_chunks_when_dcp_alignment_exceeds_budget():
+    pytest.importorskip("torch")
+    from vllm.v1.core.sched.scheduler import Scheduler
+
+    request = SimpleNamespace(
+        num_computed_tokens=0,
+        num_prompt_tokens=835,
+        num_tokens=835,
+    )
+    scheduler = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=16),
+        block_size=208,
+        dcp_world_size=3,
+        use_eagle=False,
+    )
+
+    adjusted = Scheduler._mamba_block_aligned_split(
+        self=scheduler,
+        request=request,
+        num_new_tokens=256,
+    )
+
+    assert adjusted == 256
+
+
+def test_hybrid_dcp_resolves_global_scheduler_block_and_fine_hash_block():
+    torch = pytest.importorskip("torch")
+    block_size = 16
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(
+            block_size=block_size,
+            enable_prefix_caching=True,
+            hash_block_size=None,
+        ),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=3,
+            prefill_context_parallel_size=1,
+        ),
+        kv_transfer_config=None,
+    )
+
+    scheduler_block_size, hash_block_size = resolve_kv_cache_block_sizes(
+        kv_cache_config, vllm_config
+    )
+
+    assert scheduler_block_size == block_size * 3
+    assert hash_block_size == block_size

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1029,6 +1029,63 @@ def test_prefill_hybrid_model_mamba_align():
     manager.free(req0)
 
 
+def test_prefill_hybrid_model_mamba_align_dcp_replay():
+    """DCP hybrid cache insertion and lookup must use the same block geometry."""
+    block_size = 16
+    dcp_world_size = 3
+    effective_block_size = block_size * dcp_world_size
+    kv_cache_config = _make_hybrid_kv_cache_config(
+        block_size, 40, ["full", "mamba_align"]
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        scheduler_block_size=effective_block_size,
+        dcp_world_size=dcp_world_size,
+    )
+
+    common_token_ids = list(range(3 * effective_block_size))
+    req0 = make_request("dcp-fill", common_token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    blocks = manager.allocate_slots(
+        req0, req0.num_tokens, num_computed_tokens, computed_blocks
+    )
+    assert blocks is not None
+    manager.new_step_starts()
+
+    coarse_hashes = kv_cache_utils.BlockHashListWithBlockSize(
+        req0.block_hashes, block_size, effective_block_size
+    )
+    cached_by_group = [
+        [
+            manager.block_pool.get_cached_block(block_hash, [group_id]) is not None
+            for block_hash in coarse_hashes
+        ]
+        for group_id in range(2)
+    ]
+    assert cached_by_group == [[True] * 3, [False, False, True]]
+
+    req1 = make_request("dcp-replay", common_token_ids + [101] * 5, block_size, sha256)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
+
+    assert num_computed_tokens == 3 * effective_block_size
+    assert all(len(group) == 3 for group in computed_blocks.blocks)
+
+    per_group_blocks, per_group_hit_lengths = (
+        manager.coordinator.find_longest_cache_hit_per_group(
+            req1.block_hashes, req1.num_tokens - 1
+        )
+    )
+    assert per_group_hit_lengths == (3 * effective_block_size,) * 2
+    assert all(len(group) == 3 for group in per_group_blocks)
+
+    manager.free(req0)
+    manager.free(req1)
+
+
 def test_hybrid_cache_mamba_align_shared_prefix_detection():
     """Test shared prefix detection heuristic for mamba align cache mode
 

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -42,6 +42,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheTensor,
+    MambaSpec,
 )
 from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -239,6 +240,80 @@ def _make_mock_backend_for_kernel_block_size(
 
 def _make_kv_cache_spec() -> FullAttentionSpec:
     return FullAttentionSpec(block_size=1, num_kv_heads=1, head_size=1, dtype="float16")
+
+
+def test_minimal_cudagraph_profiling_blocks_scales_tokens_to_blocks():
+    attn_spec = FullAttentionSpec(
+        block_size=592,
+        num_kv_heads=4,
+        head_size=128,
+        dtype=torch.float16,
+    )
+    groups = [KVCacheGroupSpec(["attn"], attn_spec)]
+
+    min_blocks, has_mamba_cache = (
+        GPUModelRunner._get_minimal_kv_cache_blocks_for_cudagraph_profiling(
+            groups,
+            max_capture_tokens=8192,
+            max_num_reqs=8,
+            cp_size=3,
+        )
+    )
+
+    assert min_blocks == 5  # ceil(8192 / (592 * 3))
+    assert not has_mamba_cache
+
+
+def test_minimal_cudagraph_profiling_blocks_cover_mamba_cache_lines():
+    attn_spec = FullAttentionSpec(
+        block_size=592,
+        num_kv_heads=4,
+        head_size=128,
+        dtype=torch.float16,
+    )
+    mamba_spec = MambaSpec(
+        shapes=((256, 4),),
+        dtypes=(torch.float16,),
+        block_size=592,
+    )
+    groups = [
+        KVCacheGroupSpec(["attn"], attn_spec),
+        KVCacheGroupSpec(["mamba"], mamba_spec),
+    ]
+
+    min_blocks, has_mamba_cache = (
+        GPUModelRunner._get_minimal_kv_cache_blocks_for_cudagraph_profiling(
+            groups,
+            max_capture_tokens=4096,
+            max_num_reqs=8,
+            cp_size=3,
+        )
+    )
+
+    assert min_blocks == 8  # max(ceil(4096 / (592 * 3)), max_num_reqs)
+    assert has_mamba_cache
+
+
+def test_minimal_cudagraph_profiling_blocks_without_capture_size():
+    attn_spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=4,
+        head_size=128,
+        dtype=torch.float16,
+    )
+    groups = [KVCacheGroupSpec(["attn"], attn_spec)]
+
+    min_blocks, has_mamba_cache = (
+        GPUModelRunner._get_minimal_kv_cache_blocks_for_cudagraph_profiling(
+            groups,
+            max_capture_tokens=None,
+            max_num_reqs=8,
+            cp_size=1,
+        )
+    )
+
+    assert min_blocks == 1
+    assert not has_mamba_cache
 
 
 def test_select_common_block_size_prefers_manager_block_size():

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1232,6 +1232,7 @@ class ModelConfig:
         if decode_context_parallel_size > 1 and not self.use_mla:
             total_num_kv_heads = self.get_total_num_kv_heads()
             supports_sequence_sharded_gqa_dcp = self.model_arch_config.model_type in {
+                "qwen3_5",
                 "qwen3_5_text",
                 "qwen3_next",
             }
@@ -1251,12 +1252,13 @@ class ModelConfig:
                 )
 
             num_q_per_kv = total_num_attention_heads // total_num_kv_heads
-            assert num_q_per_kv % decode_context_parallel_size == 0, (
-                f"Total number of q per kv attn heads ({num_q_per_kv})"
-                " must be divisible by dcp world size when enable "
-                "decode context parallel for GQA "
-                f"({parallel_config.decode_context_parallel_size})."
-            )
+            if not supports_sequence_sharded_gqa_dcp:
+                assert num_q_per_kv % decode_context_parallel_size == 0, (
+                    f"Total number of q per kv attn heads ({num_q_per_kv})"
+                    " must be divisible by dcp world size when enable "
+                    "decode context parallel for GQA "
+                    f"({parallel_config.decode_context_parallel_size})."
+                )
             if (
                 supports_sequence_sharded_gqa_dcp
                 and tensor_parallel_size <= total_num_kv_heads

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1231,19 +1231,24 @@ class ModelConfig:
         decode_context_parallel_size = parallel_config.decode_context_parallel_size
         if decode_context_parallel_size > 1 and not self.use_mla:
             total_num_kv_heads = self.get_total_num_kv_heads()
-            assert tensor_parallel_size > total_num_kv_heads, (
-                f"tensor parallel size {tensor_parallel_size} must be greater "
-                f"than total num kv heads {total_num_kv_heads} when enable "
-                f"decode context parallel for GQA/MQA"
-            )
+            supports_sequence_sharded_gqa_dcp = self.model_arch_config.model_type in {
+                "qwen3_5_text",
+                "qwen3_next",
+            }
+            if not supports_sequence_sharded_gqa_dcp:
+                assert tensor_parallel_size > total_num_kv_heads, (
+                    f"tensor parallel size {tensor_parallel_size} must be greater "
+                    f"than total num kv heads {total_num_kv_heads} when enable "
+                    "decode context parallel for GQA/MQA"
+                )
 
-            max_dcp_size = tensor_parallel_size // total_num_kv_heads
-            assert decode_context_parallel_size <= max_dcp_size, (
-                f"decode context parallel size must less than or equal to "
-                f"(tensor parallel size {tensor_parallel_size} // total "
-                f"num kv heads {total_num_kv_heads}) = {max_dcp_size}, "
-                f"but got {decode_context_parallel_size}"
-            )
+                max_dcp_size = tensor_parallel_size // total_num_kv_heads
+                assert decode_context_parallel_size <= max_dcp_size, (
+                    "decode context parallel size must less than or equal to "
+                    f"(tensor parallel size {tensor_parallel_size} // total "
+                    f"num kv heads {total_num_kv_heads}) = {max_dcp_size}, "
+                    f"but got {decode_context_parallel_size}"
+                )
 
             num_q_per_kv = total_num_attention_heads // total_num_kv_heads
             assert num_q_per_kv % decode_context_parallel_size == 0, (
@@ -1252,6 +1257,19 @@ class ModelConfig:
                 "decode context parallel for GQA "
                 f"({parallel_config.decode_context_parallel_size})."
             )
+            if (
+                supports_sequence_sharded_gqa_dcp
+                and tensor_parallel_size <= total_num_kv_heads
+            ):
+                logger.warning(
+                    "Enabling experimental GQA DCP with tensor_parallel_size=%s, "
+                    "total_num_kv_heads=%s, decode_context_parallel_size=%s. "
+                    "This relies on sequence-dimension KV sharding instead of "
+                    "KV-head replication removal.",
+                    tensor_parallel_size,
+                    total_num_kv_heads,
+                    decode_context_parallel_size,
+                )
 
         # torch_shm uses a single IPC queue to rank 0; DP>1 is
         # incompatible because API servers can't know which
@@ -1318,6 +1336,21 @@ class ModelConfig:
         # the tensor parallel size. We will replicate the KV heads in the
         # case where the number of KV heads is smaller than the tensor
         # parallel size so each GPU has at least one KV head.
+        if (
+            self.model_arch_config.model_type in {"qwen3_5_text", "qwen3_next"}
+            and total_num_kv_heads % parallel_config.tensor_parallel_size != 0
+            and parallel_config.tensor_parallel_size % total_num_kv_heads != 0
+        ):
+            from vllm.model_executor.layers.attention.head_partition import (
+                make_attention_head_partition,
+            )
+
+            return make_attention_head_partition(
+                total_num_heads=self.model_arch_config.total_num_attention_heads,
+                total_num_kv_heads=total_num_kv_heads,
+                tp_size=parallel_config.tensor_parallel_size,
+                tp_rank=0,
+            ).num_kv_heads
         return max(1, total_num_kv_heads // parallel_config.tensor_parallel_size)
 
     def get_num_attention_heads(self, parallel_config: ParallelConfig) -> int:

--- a/vllm/distributed/device_communicators/tp3_ce_all_reduce.py
+++ b/vllm/distributed/device_communicators/tp3_ce_all_reduce.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Experimental TP3 int8 reduction through pinned shared host memory."""
+
+from __future__ import annotations
+
+import mmap
+import os
+import struct
+import time
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+from vllm.triton_utils import tl, triton
+
+
+_WORKSPACE: dict[str, object] | None = None
+
+
+@triton.jit
+def _quantize_i8_block(
+    x_ptr, q_ptr, s_ptr, n_cols: tl.constexpr, block: tl.constexpr
+):
+    row = tl.program_id(0)
+    block_id = tl.program_id(1)
+    offs = tl.arange(0, block)
+    cols = block_id * block + offs
+    mask = cols < n_cols
+    values = tl.load(x_ptr + row * n_cols + cols, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    scale = tl.maximum(tl.max(tl.abs(values), axis=0) / 127.0, 1.0e-8)
+    quantized = tl.floor(values / scale + 0.5)
+    quantized = tl.minimum(tl.maximum(quantized, -127.0), 127.0) + 128.0
+    tl.store(q_ptr + row * n_cols + cols, quantized.to(tl.uint8), mask=mask)
+    n_blocks = tl.cdiv(n_cols, block)
+    tl.store(s_ptr + row * n_blocks + block_id, scale)
+
+
+@triton.jit
+def _dequant_sum_i8_block(
+    q0_ptr, q1_ptr, q2_ptr, s0_ptr, s1_ptr, s2_ptr, out_ptr,
+    n_cols: tl.constexpr, block: tl.constexpr,
+):
+    row = tl.program_id(0)
+    block_id = tl.program_id(1)
+    offs = tl.arange(0, block)
+    cols = block_id * block + offs
+    mask = cols < n_cols
+    q0 = tl.load(q0_ptr + row * n_cols + cols, mask=mask, other=128).to(tl.float32)
+    q1 = tl.load(q1_ptr + row * n_cols + cols, mask=mask, other=128).to(tl.float32)
+    q2 = tl.load(q2_ptr + row * n_cols + cols, mask=mask, other=128).to(tl.float32)
+    n_blocks = tl.cdiv(n_cols, block)
+    scale_idx = row * n_blocks + block_id
+    values = ((q0 - 128.0) * tl.load(s0_ptr + scale_idx)
+              + (q1 - 128.0) * tl.load(s1_ptr + scale_idx)
+              + (q2 - 128.0) * tl.load(s2_ptr + scale_idx))
+    tl.store(out_ptr + row * n_cols + cols, values, mask=mask)
+
+
+def _wait_flags(mapping: mmap.mmap, offset: int, world_size: int, generation: int) -> None:
+    deadline = time.monotonic() + float(os.environ.get("VLLM_TP3_CE_TIMEOUT_S", "120"))
+    while True:
+        if all(struct.unpack_from("i", mapping, offset + rank * 4)[0] == generation
+               for rank in range(world_size)):
+            return
+        if time.monotonic() >= deadline:
+            raise TimeoutError(f"TP3 CE barrier timed out at generation {generation}")
+        time.sleep(0)
+
+
+def _workspace(group: ProcessGroup, device: torch.device, cols: int) -> dict[str, object]:
+    global _WORKSPACE
+    if _WORKSPACE is not None:
+        return _WORKSPACE
+    world_size = dist.get_world_size(group)
+    rank = dist.get_rank(group)
+    max_rows = int(os.environ.get("VLLM_TP3_CE_MAX_ROWS", "12288"))
+    quant_block = int(os.environ.get("VLLM_TP3_CE_QUANT_BLOCK", "8192"))
+    num_blocks = (cols + quant_block - 1) // quant_block
+    max_payload = max_rows * (cols + num_blocks * 4)
+    header_bytes = 4096
+    total_bytes = header_bytes + world_size * max_payload
+    path = Path(os.environ.get("VLLM_TP3_CE_SHM_PATH", "/dev/shm/vllm-tp3-ce"))
+    if rank == 0:
+        with path.open("w+b") as handle:
+            handle.truncate(total_bytes)
+    dist.barrier(group=group)
+    handle = path.open("r+b", buffering=0)
+    mapping = mmap.mmap(handle.fileno(), total_bytes)
+    host_storage = torch.frombuffer(mapping, dtype=torch.uint8)
+    status = torch.cuda.cudart().cudaHostRegister(host_storage.data_ptr(), host_storage.numel(), 1)
+    if status.value != 0:
+        raise RuntimeError(f"cudaHostRegister failed: {status}")
+    _WORKSPACE = {
+        "handle": handle,
+        "mapping": mapping,
+        "host_storage": host_storage,
+        "host": host_storage[header_bytes:].view(world_size, max_payload),
+        "max_rows": max_rows,
+        "quant_block": quant_block,
+        "num_blocks": num_blocks,
+        "generation": 0,
+        "send": torch.empty(max_payload, device=device, dtype=torch.uint8),
+        "remote": torch.empty((world_size - 1, max_payload), device=device, dtype=torch.uint8),
+        "stream": torch.cuda.Stream(device=device),
+    }
+    return _WORKSPACE
+
+
+def tp3_ce_all_reduce(input_: torch.Tensor, group: ProcessGroup) -> torch.Tensor:
+    world_size = dist.get_world_size(group)
+    rank = dist.get_rank(group)
+    if world_size != 3 or input_.dim() != 2 or input_.shape[1] != 5120:
+        raise ValueError(f"unsupported TP3 CE shape={tuple(input_.shape)}")
+    rows, cols = input_.shape
+    workspace = _workspace(group, input_.device, cols)
+    if rows > int(workspace["max_rows"]):
+        raise ValueError(f"rows={rows} exceed CE workspace")
+    quant_block = int(workspace["quant_block"])
+    num_blocks = int(workspace["num_blocks"])
+    q_bytes = rows * cols
+    scale_bytes = rows * num_blocks * 4
+    total = q_bytes + scale_bytes
+    send = workspace["send"]
+    remote = workspace["remote"]
+    host = workspace["host"]
+    mapping = workspace["mapping"]
+    stream = workspace["stream"]
+    assert isinstance(send, torch.Tensor)
+    assert isinstance(remote, torch.Tensor)
+    assert isinstance(host, torch.Tensor)
+    assert isinstance(mapping, mmap.mmap)
+    assert isinstance(stream, torch.cuda.Stream)
+
+    q_local = send[:q_bytes].view(rows, cols)
+    scale_local = send[q_bytes:total].view(torch.float32).view(rows, num_blocks)
+    _quantize_i8_block[(rows, num_blocks)](
+        input_, q_local, scale_local, cols, quant_block
+    )
+    workspace["generation"] = int(workspace["generation"]) + 1
+    generation = int(workspace["generation"])
+    current = torch.cuda.current_stream(input_.device)
+    stream.wait_stream(current)
+    with torch.cuda.stream(stream):
+        host[rank, :total].copy_(send[:total], non_blocking=True)
+    stream.synchronize()
+    struct.pack_into("i", mapping, rank * 4, generation)
+    _wait_flags(mapping, 0, world_size, generation)
+    peers = [peer for peer in range(world_size) if peer != rank]
+    with torch.cuda.stream(stream):
+        for slot, peer in enumerate(peers):
+            remote[slot, :total].copy_(host[peer, :total], non_blocking=True)
+    stream.synchronize()
+    struct.pack_into("i", mapping, 64 + rank * 4, generation)
+    _wait_flags(mapping, 64, world_size, generation)
+    current.wait_stream(stream)
+    buffers = [send[:total] if peer == rank else remote[peers.index(peer), :total]
+               for peer in range(world_size)]
+    output = torch.empty_like(input_)
+    _dequant_sum_i8_block[(rows, num_blocks)](
+        buffers[0][:q_bytes], buffers[1][:q_bytes], buffers[2][:q_bytes],
+        buffers[0][q_bytes:].view(torch.float32),
+        buffers[1][q_bytes:].view(torch.float32),
+        buffers[2][q_bytes:].view(torch.float32), output, cols, quant_block,
+    )
+    return output

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -25,6 +25,7 @@ If you only need to use the distributed environment without model/pipeline
 
 import contextlib
 import gc
+import os
 import pickle
 import weakref
 from collections import namedtuple
@@ -132,7 +133,45 @@ def all_reduce(tensor: torch.Tensor, group_name: str) -> torch.Tensor:
     group = _groups[group_name]()
     if group is None:
         raise ValueError(f"Group {group_name} is destroyed.")
+    if os.environ.get("VLLM_TP3_CE_REDUCE", "0") == "1":
+        from vllm.forward_context import (
+            get_forward_context,
+            is_forward_context_available,
+        )
+
+        logical_tokens = None
+        if is_forward_context_available():
+            logical_tokens = get_forward_context().num_tokens_unpadded
+        if _should_use_tp3_ce(
+            logical_tokens,
+            get_dcp_group().world_size,
+            tensor.dim(),
+            tensor.shape[-1],
+            group.world_size,
+        ):
+            from .device_communicators.tp3_ce_all_reduce import (
+                tp3_ce_all_reduce as run,
+            )
+
+            return run(tensor, group.device_group)
     return group._all_reduce_out_place(tensor)
+
+
+def _should_use_tp3_ce(
+    logical_tokens: int | None,
+    dcp_world_size: int,
+    tensor_dim: int,
+    hidden_size: int,
+    tp_world_size: int,
+) -> bool:
+    """Return true only for known large TP3 prefill reductions."""
+    return (
+        logical_tokens is not None
+        and logical_tokens * dcp_world_size >= 4096
+        and tensor_dim == 2
+        and hidden_size == 5120
+        and tp_world_size == 3
+    )
 
 
 def all_reduce_fake(tensor: torch.Tensor, group_name: str) -> torch.Tensor:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -2380,14 +2380,6 @@ class EngineArgs:
 
     def _check_feature_supported(self):
         """Raise an error if the feature is not supported."""
-        # No Concurrent Partial Prefills so far.
-        if (
-            self.max_num_partial_prefills != SchedulerConfig.max_num_partial_prefills
-            or self.max_long_partial_prefills
-            != SchedulerConfig.max_long_partial_prefills
-        ):
-            _raise_unsupported_error(feature_name="Concurrent Partial Prefill")
-
         if self.pipeline_parallel_size > 1:
             supports_pp = getattr(
                 self.distributed_executor_backend, "supports_pp", False

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -148,6 +148,10 @@ class ForwardContext:
     cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE
     batch_descriptor: BatchDescriptor | None = None
 
+    # Logical token count before compile/CUDA-graph padding. Runtime custom ops
+    # must use this instead of tensor shapes for quality-sensitive dispatch.
+    num_tokens_unpadded: int | None = None
+
     ubatch_slices: UBatchSlices | None = None
 
     # Boolean mask over the token axis: True for padding rows that are not real
@@ -220,6 +224,7 @@ def create_forward_context(
     additional_kwargs: dict[str, Any] | None = None,
     skip_compiled: bool = False,
     is_padding: torch.Tensor | None = None,
+    num_tokens_unpadded: int | None = None,
 ):
     if vllm_config.compilation_config.fast_moe_cold_start:
         all_moe_layers = vllm_config.compilation_config.static_all_moe_layers
@@ -238,6 +243,7 @@ def create_forward_context(
         skip_compiled=skip_compiled,
         additional_kwargs=additional_kwargs or {},
         is_padding=is_padding,
+        num_tokens_unpadded=num_tokens_unpadded,
     )
 
 
@@ -268,6 +274,7 @@ def set_forward_context(
     slot_mapping: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]] | None = None,
     skip_compiled: bool = False,
     is_padding: torch.Tensor | None = None,
+    num_tokens_unpadded: int | None = None,
 ):
     """A context manager that stores the current forward context,
     can be attention metadata, etc.
@@ -337,6 +344,7 @@ def set_forward_context(
         additional_kwargs,
         skip_compiled,
         is_padding=is_padding,
+        num_tokens_unpadded=num_tokens_unpadded,
     )
 
     try:

--- a/vllm/model_executor/layers/attention/head_partition.py
+++ b/vllm/model_executor/layers/attention/head_partition.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import dataclass
+from math import gcd
+
+
+@dataclass(frozen=True)
+class AttentionHeadPartition:
+    """Per-rank attention/GQA head mapping.
+
+    The local Q heads are tensor-parallel sharded evenly. The local KV heads
+    are the global KV heads touched by those local Q heads. This preserves GQA
+    semantics when a Q shard crosses a KV-group boundary.
+    """
+
+    total_num_heads: int
+    total_num_kv_heads: int
+    tp_size: int
+    tp_rank: int
+
+    def __post_init__(self) -> None:
+        if self.total_num_heads <= 0:
+            raise ValueError("total_num_heads must be positive")
+        if self.total_num_kv_heads <= 0:
+            raise ValueError("total_num_kv_heads must be positive")
+        if self.tp_size <= 0:
+            raise ValueError("tp_size must be positive")
+        if not 0 <= self.tp_rank < self.tp_size:
+            raise ValueError(
+                f"tp_rank must be in [0, {self.tp_size}), got {self.tp_rank}"
+            )
+        if self.total_num_heads % self.tp_size != 0:
+            raise ValueError(
+                f"total_num_heads ({self.total_num_heads}) must be divisible "
+                f"by tp_size ({self.tp_size})"
+            )
+        if self.total_num_heads % self.total_num_kv_heads != 0:
+            raise ValueError(
+                f"total_num_heads ({self.total_num_heads}) must be divisible "
+                f"by total_num_kv_heads ({self.total_num_kv_heads})"
+            )
+        if self.num_heads % self.num_kv_heads != 0:
+            raise ValueError(
+                f"local num_heads ({self.num_heads}) must be divisible by "
+                f"local num_kv_heads ({self.num_kv_heads})"
+            )
+
+    @property
+    def q_per_kv(self) -> int:
+        return self.total_num_heads // self.total_num_kv_heads
+
+    @property
+    def num_heads(self) -> int:
+        return self.total_num_heads // self.tp_size
+
+    @property
+    def q_start(self) -> int:
+        return self.tp_rank * self.num_heads
+
+    @property
+    def q_end(self) -> int:
+        return self.q_start + self.num_heads
+
+    @property
+    def q_head_indices(self) -> tuple[int, ...]:
+        return tuple(range(self.q_start, self.q_end))
+
+    @property
+    def kv_start(self) -> int:
+        return self.q_start // self.q_per_kv
+
+    @property
+    def kv_end(self) -> int:
+        return (self.q_end + self.q_per_kv - 1) // self.q_per_kv
+
+    @property
+    def unique_kv_head_indices(self) -> tuple[int, ...]:
+        return tuple(range(self.kv_start, self.kv_end))
+
+    @property
+    def q_to_unique_kv_head_indices(self) -> tuple[int, ...]:
+        return tuple(q // self.q_per_kv for q in self.q_head_indices)
+
+    @property
+    def local_q_per_kv_slot(self) -> int:
+        """Number of local Q heads represented by each local KV slot.
+
+        Current attention backends map local Q heads to local KV heads by
+        fixed-size contiguous groups. When a TP Q range cuts across global GQA
+        groups, we represent a single global KV head by multiple local KV slots.
+        """
+
+        slot_size = 0
+        for rank in range(self.tp_size):
+            q_start = rank * self.num_heads
+            q_end = q_start + self.num_heads
+            kv_start = q_start // self.q_per_kv
+            kv_end = (q_end + self.q_per_kv - 1) // self.q_per_kv
+            for kv_idx in range(kv_start, kv_end):
+                overlap_start = max(q_start, kv_idx * self.q_per_kv)
+                overlap_end = min(q_end, (kv_idx + 1) * self.q_per_kv)
+                count = overlap_end - overlap_start
+                if count > 0:
+                    slot_size = count if slot_size == 0 else gcd(slot_size, count)
+        return slot_size
+
+    @property
+    def kv_head_indices(self) -> tuple[int, ...]:
+        indices: list[int] = []
+        for kv_idx in self.unique_kv_head_indices:
+            overlap_start = max(self.q_start, kv_idx * self.q_per_kv)
+            overlap_end = min(self.q_end, (kv_idx + 1) * self.q_per_kv)
+            slot_count = (overlap_end - overlap_start) // self.local_q_per_kv_slot
+            indices.extend([kv_idx] * slot_count)
+        return tuple(indices)
+
+    @property
+    def num_kv_heads(self) -> int:
+        return len(self.kv_head_indices)
+
+    @property
+    def q_to_local_kv_indices(self) -> tuple[int, ...]:
+        return tuple(i // self.local_q_per_kv_slot for i in range(self.num_heads))
+
+    @property
+    def has_overlapping_kv_partition(self) -> bool:
+        ideal = self.total_num_kv_heads / self.tp_size
+        return self.num_kv_heads != ideal
+
+
+def make_attention_head_partition(
+    *,
+    total_num_heads: int,
+    total_num_kv_heads: int,
+    tp_size: int,
+    tp_rank: int,
+) -> AttentionHeadPartition:
+    return AttentionHeadPartition(
+        total_num_heads=total_num_heads,
+        total_num_kv_heads=total_num_kv_heads,
+        tp_size=tp_size,
+        tp_rank=tp_rank,
+    )

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -939,6 +939,260 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
             yield name
 
 
+class PaddedMergedColumnParallelLinear(MergedColumnParallelLinear):
+    """Merged column-parallel linear with padded output shards.
+
+    This is intended for dense MLP projections whose logical output size is not
+    divisible by tensor parallel size. Each logical matrix is padded
+    independently, preserving the gate/up split expected by SwiGLU.
+    """
+
+    def __init__(
+        self,
+        input_size: int,
+        output_sizes: list[int],
+        padded_output_sizes: list[int],
+        bias: bool = True,
+        gather_output: bool = False,
+        skip_bias_add: bool = False,
+        params_dtype: torch.dtype | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        *,
+        return_bias: bool = True,
+        disable_tp: bool = False,
+    ):
+        if len(output_sizes) != len(padded_output_sizes):
+            raise ValueError("Logical and padded output size lists must match.")
+        if any(padded < logical for logical, padded in zip(output_sizes,
+                                                           padded_output_sizes)):
+            raise ValueError("Padded output sizes must be >= logical output sizes.")
+        self.logical_output_sizes = output_sizes
+        super().__init__(
+            input_size=input_size,
+            output_sizes=padded_output_sizes,
+            bias=bias,
+            gather_output=gather_output,
+            skip_bias_add=skip_bias_add,
+            params_dtype=params_dtype,
+            quant_config=quant_config,
+            prefix=prefix,
+            return_bias=return_bias,
+            disable_tp=disable_tp,
+        )
+        for param in self.parameters(recurse=False):
+            param.data.zero_()
+
+    def _copy_padded_output_shard(
+        self,
+        param: Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: int,
+    ) -> bool:
+        output_dim = getattr(param, "output_dim", None)
+        if output_dim is None:
+            return False
+
+        logical_size = self.logical_output_sizes[loaded_shard_id]
+        padded_size = self.output_sizes[loaded_shard_id]
+        padded_shard_size = padded_size // self.tp_size
+        global_start = self.tp_rank * padded_shard_size
+        copy_size = max(0, min(padded_shard_size, logical_size - global_start))
+
+        local_offset = sum(self.output_sizes[:loaded_shard_id]) // self.tp_size
+        param_data = param.data.narrow(
+            output_dim, local_offset, padded_shard_size
+        )
+        param_data.zero_()
+        if copy_size == 0:
+            return True
+
+        param_data = param_data.narrow(output_dim, 0, copy_size)
+        loaded_weight = loaded_weight.narrow(output_dim, global_start, copy_size)
+        assert param_data.shape == loaded_weight.shape, (
+            f"Tried to load padded shard {loaded_weight.shape} into "
+            f"{param_data.shape}"
+        )
+        param_data.copy_(loaded_weight)
+        return True
+
+    def weight_loader(
+        self,
+        param: Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: tuple[int, ...] | int | None = None,
+    ):
+        if isinstance(loaded_shard_id, int) and self._copy_padded_output_shard(
+            param, loaded_weight, loaded_shard_id
+        ):
+            return
+        super().weight_loader(param, loaded_weight, loaded_shard_id)
+
+    def weight_loader_v2(
+        self,
+        param: BasevLLMParameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: tuple[int, ...] | int | None = None,
+    ):
+        if len(loaded_weight.shape) == 0:
+            assert loaded_weight.numel() == 1
+            loaded_weight = loaded_weight.reshape(1)
+
+        if isinstance(loaded_shard_id, int):
+            if isinstance(param, PerTensorScaleParameter):
+                param.load_merged_column_weight(loaded_weight=loaded_weight,
+                                                shard_id=loaded_shard_id)
+                return
+            if self._copy_padded_output_shard(param, loaded_weight,
+                                             loaded_shard_id):
+                return
+        super().weight_loader_v2(param, loaded_weight, loaded_shard_id)
+
+
+class ExplicitPaddedMergedColumnParallelLinear(PaddedMergedColumnParallelLinear):
+    """Merged column-parallel linear with explicit per-rank load spans.
+
+    Unlike ``PaddedMergedColumnParallelLinear``, padding does not have to be a
+    single tail on the final TP rank. Each logical shard can load an arbitrary
+    contiguous source span into the beginning of this rank's padded partition.
+    """
+
+    def __init__(
+        self,
+        input_size: int,
+        output_sizes: list[int],
+        padded_output_sizes: list[int],
+        local_starts: list[int],
+        local_sizes: list[int],
+        bias: bool = True,
+        gather_output: bool = False,
+        skip_bias_add: bool = False,
+        params_dtype: torch.dtype | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        *,
+        return_bias: bool = True,
+        disable_tp: bool = False,
+    ):
+        if len(output_sizes) != len(local_starts) or len(output_sizes) != len(
+            local_sizes
+        ):
+            raise ValueError("Explicit shard metadata must match output sizes.")
+        self.local_starts = local_starts
+        self.local_sizes = local_sizes
+        super().__init__(
+            input_size=input_size,
+            output_sizes=output_sizes,
+            padded_output_sizes=padded_output_sizes,
+            bias=bias,
+            gather_output=gather_output,
+            skip_bias_add=skip_bias_add,
+            params_dtype=params_dtype,
+            quant_config=quant_config,
+            prefix=prefix,
+            return_bias=return_bias,
+            disable_tp=disable_tp,
+        )
+
+    def _copy_padded_output_shard(
+        self,
+        param: Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: int,
+    ) -> bool:
+        output_dim = getattr(param, "output_dim", None)
+        if output_dim is None:
+            return False
+
+        padded_size = self.output_sizes[loaded_shard_id]
+        padded_shard_size = padded_size // self.tp_size
+        copy_size = self.local_sizes[loaded_shard_id]
+        global_start = self.local_starts[loaded_shard_id]
+
+        local_offset = sum(self.output_sizes[:loaded_shard_id]) // self.tp_size
+        param_data = param.data.narrow(output_dim, local_offset,
+                                       padded_shard_size)
+        param_data.zero_()
+        if copy_size == 0:
+            return True
+
+        param_data = param_data.narrow(output_dim, 0, copy_size)
+        loaded_weight = loaded_weight.narrow(output_dim, global_start,
+                                             copy_size)
+        assert param_data.shape == loaded_weight.shape, (
+            f"Tried to load explicit padded shard {loaded_weight.shape} into "
+            f"{param_data.shape}"
+        )
+        param_data.copy_(loaded_weight)
+        return True
+
+    def _copy_fused_checkpoint_weight(
+        self,
+        param: Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: tuple[int, ...] | None,
+    ) -> bool:
+        output_dim = getattr(param, "output_dim", None)
+        if output_dim is None:
+            return False
+
+        shard_ids = (
+            list(loaded_shard_id)
+            if loaded_shard_id is not None
+            else list(range(len(self.logical_output_sizes)))
+        )
+        source_offset = 0
+        if loaded_shard_id is not None:
+            source_offset = sum(self.logical_output_sizes[: loaded_shard_id[0]])
+
+        for shard_id in shard_ids:
+            logical_size = self.logical_output_sizes[shard_id]
+            loaded_weight_shard = loaded_weight.narrow(
+                output_dim, source_offset, logical_size
+            )
+            if not self._copy_padded_output_shard(
+                param, loaded_weight_shard, shard_id
+            ):
+                return False
+            source_offset += logical_size
+        return True
+
+    def weight_loader(
+        self,
+        param: Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: tuple[int, ...] | int | None = None,
+    ):
+        if (
+            loaded_shard_id is None or isinstance(loaded_shard_id, tuple)
+        ) and self._copy_fused_checkpoint_weight(
+            param, loaded_weight, loaded_shard_id
+        ):
+            return
+        super().weight_loader(param, loaded_weight, loaded_shard_id)
+
+    def weight_loader_v2(
+        self,
+        param: BasevLLMParameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: tuple[int, ...] | int | None = None,
+    ):
+        if len(loaded_weight.shape) == 0:
+            assert loaded_weight.numel() == 1
+            loaded_weight = loaded_weight.reshape(1)
+
+        if loaded_shard_id is None or isinstance(loaded_shard_id, tuple):
+            if isinstance(param, PerTensorScaleParameter):
+                return super().weight_loader_v2(
+                    param, loaded_weight, loaded_shard_id
+                )
+            if self._copy_fused_checkpoint_weight(
+                param, loaded_weight, loaded_shard_id
+            ):
+                return
+        super().weight_loader_v2(param, loaded_weight, loaded_shard_id)
+
+
 class QKVParallelLinear(ColumnParallelLinear):
     """Linear layers for the attention's QKV transformation.
 
@@ -1348,6 +1602,138 @@ class QKVParallelLinear(ColumnParallelLinear):
             yield name
 
 
+class QKVParallelLinearOverlappingGQA(QKVParallelLinear):
+    """QKV linear for TP shards that cut across GQA group boundaries.
+
+    Query heads are sharded normally. KV heads are loaded from explicit global
+    KV head indices and may be duplicated locally so existing attention kernels
+    can keep their fixed local Q-per-KV mapping.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        head_size: int,
+        total_num_heads: int,
+        total_num_kv_heads: int,
+        kv_head_indices: tuple[int, ...],
+        bias: bool = True,
+        skip_bias_add: bool = False,
+        params_dtype: torch.dtype | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        *,
+        return_bias: bool = True,
+        disable_tp: bool = False,
+        v_head_size: int | None = None,
+    ):
+        self.hidden_size = hidden_size
+        self.head_size = head_size
+        self.v_head_size = v_head_size if v_head_size is not None else head_size
+        self.total_num_heads = total_num_heads
+        self.total_num_kv_heads = total_num_kv_heads
+        self.kv_head_indices = tuple(kv_head_indices)
+        if not self.kv_head_indices:
+            raise ValueError("kv_head_indices must not be empty")
+        if any(
+            kv_idx < 0 or kv_idx >= self.total_num_kv_heads
+            for kv_idx in self.kv_head_indices
+        ):
+            raise ValueError(
+                f"kv_head_indices must be in [0, {self.total_num_kv_heads}), "
+                f"got {self.kv_head_indices}"
+            )
+
+        tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
+        self.num_heads = divide(self.total_num_heads, tp_size)
+        self.num_kv_heads = len(self.kv_head_indices)
+        self.num_kv_head_replicas = 1
+
+        input_size = self.hidden_size
+        output_size = (
+            self.num_heads * self.head_size
+            + self.num_kv_heads * self.head_size
+            + self.num_kv_heads * self.v_head_size
+        ) * tp_size
+        self.output_sizes = [
+            self.num_heads * self.head_size * tp_size,
+            self.num_kv_heads * self.head_size * tp_size,
+            self.num_kv_heads * self.v_head_size * tp_size,
+        ]
+
+        ColumnParallelLinear.__init__(
+            self,
+            input_size=input_size,
+            output_size=output_size,
+            bias=bias,
+            gather_output=False,
+            skip_bias_add=skip_bias_add,
+            params_dtype=params_dtype,
+            quant_config=quant_config,
+            prefix=prefix,
+            return_bias=return_bias,
+            disable_tp=disable_tp,
+        )
+
+    def _load_overlapping_kv_weight(
+        self,
+        param: Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: str,
+    ) -> bool:
+        if loaded_shard_id not in {"k", "v"}:
+            return False
+
+        output_dim = getattr(param, "output_dim", None)
+        if output_dim is None:
+            return False
+
+        param_data = param.data
+        local_head_size = (
+            self.head_size if loaded_shard_id == "k" else self.v_head_size
+        )
+        shard_offset = self._get_shard_offset_mapping(loaded_shard_id)
+        assert shard_offset is not None
+        param_data = param_data.narrow(
+            output_dim, shard_offset, self.num_kv_heads * local_head_size
+        )
+
+        for slot_idx, global_kv_idx in enumerate(self.kv_head_indices):
+            dst = param_data.narrow(
+                output_dim, slot_idx * local_head_size, local_head_size
+            )
+            src = loaded_weight.narrow(
+                output_dim, global_kv_idx * local_head_size, local_head_size
+            )
+            assert dst.shape == src.shape
+            dst.copy_(src)
+        return True
+
+    def weight_loader_v2(
+        self,
+        param: BasevLLMParameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: str | None = None,
+    ):
+        if loaded_shard_id in {"k", "v"} and self._load_overlapping_kv_weight(
+            param, loaded_weight, loaded_shard_id
+        ):
+            return
+        return super().weight_loader_v2(param, loaded_weight, loaded_shard_id)
+
+    def weight_loader(
+        self,
+        param: Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: str | None = None,
+    ):
+        if loaded_shard_id in {"k", "v"} and self._load_overlapping_kv_weight(
+            param, loaded_weight, loaded_shard_id
+        ):
+            return
+        return super().weight_loader(param, loaded_weight, loaded_shard_id)
+
+
 class MinimaxM3QKVParallelLinearWithIndexer(QKVParallelLinear):
     """QKV projection fused with a lightning-indexer's index_q/index_k.
 
@@ -1704,3 +2090,149 @@ class RowParallelLinear(LinearBase):
         s += f", tp_size={self.tp_size}"
         s += f", reduce_results={self.reduce_results}"
         return s
+
+
+class PaddedRowParallelLinear(RowParallelLinear):
+    """Row-parallel linear whose input dimension is padded for TP sharding."""
+
+    def __init__(
+        self,
+        input_size: int,
+        padded_input_size: int,
+        output_size: int,
+        bias: bool = True,
+        input_is_parallel: bool = True,
+        skip_bias_add: bool = False,
+        params_dtype: torch.dtype | None = None,
+        reduce_results: bool = True,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        *,
+        return_bias: bool = True,
+        disable_tp: bool = False,
+    ):
+        if padded_input_size < input_size:
+            raise ValueError("Padded input size must be >= logical input size.")
+        self.logical_input_size = input_size
+        super().__init__(
+            input_size=padded_input_size,
+            output_size=output_size,
+            bias=bias,
+            input_is_parallel=input_is_parallel,
+            skip_bias_add=skip_bias_add,
+            params_dtype=params_dtype,
+            reduce_results=reduce_results,
+            quant_config=quant_config,
+            prefix=prefix,
+            return_bias=return_bias,
+            disable_tp=disable_tp,
+        )
+        for param in self.parameters(recurse=False):
+            param.data.zero_()
+
+    def _copy_padded_input_shard(
+        self,
+        param: Parameter,
+        loaded_weight: torch.Tensor,
+    ) -> bool:
+        input_dim = getattr(param, "input_dim", None)
+        if input_dim is None:
+            return False
+
+        padded_shard_size = self.input_size_per_partition
+        global_start = self.tp_rank * padded_shard_size
+        copy_size = max(0, min(padded_shard_size,
+                               self.logical_input_size - global_start))
+
+        param_data = param.data
+        param_data.zero_()
+        if copy_size == 0:
+            return True
+
+        param_data = param_data.narrow(input_dim, 0, copy_size)
+        loaded_weight = loaded_weight.narrow(input_dim, global_start,
+                                             copy_size)
+        assert param_data.shape == loaded_weight.shape, (
+            f"Tried to load padded row shard {loaded_weight.shape} into "
+            f"{param_data.shape}"
+        )
+        param_data.copy_(loaded_weight)
+        return True
+
+    def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
+        if self._copy_padded_input_shard(param, loaded_weight):
+            return
+        super().weight_loader(param, loaded_weight)
+
+    def weight_loader_v2(self, param: BasevLLMParameter,
+                         loaded_weight: torch.Tensor):
+        if len(loaded_weight.shape) == 0:
+            assert loaded_weight.numel() == 1
+            loaded_weight = loaded_weight.reshape(1)
+
+        if self._copy_padded_input_shard(param, loaded_weight):
+            return
+        param.load_row_parallel_weight(loaded_weight=loaded_weight)
+
+
+class ExplicitPaddedRowParallelLinear(PaddedRowParallelLinear):
+    """Row-parallel linear with explicit per-rank input load spans."""
+
+    def __init__(
+        self,
+        input_size: int,
+        padded_input_size: int,
+        local_start: int,
+        local_size: int,
+        output_size: int,
+        bias: bool = True,
+        input_is_parallel: bool = True,
+        skip_bias_add: bool = False,
+        params_dtype: torch.dtype | None = None,
+        reduce_results: bool = True,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        *,
+        return_bias: bool = True,
+        disable_tp: bool = False,
+    ):
+        self.local_start = local_start
+        self.local_size = local_size
+        super().__init__(
+            input_size=input_size,
+            padded_input_size=padded_input_size,
+            output_size=output_size,
+            bias=bias,
+            input_is_parallel=input_is_parallel,
+            skip_bias_add=skip_bias_add,
+            params_dtype=params_dtype,
+            reduce_results=reduce_results,
+            quant_config=quant_config,
+            prefix=prefix,
+            return_bias=return_bias,
+            disable_tp=disable_tp,
+        )
+
+    def _copy_padded_input_shard(
+        self,
+        param: Parameter,
+        loaded_weight: torch.Tensor,
+    ) -> bool:
+        input_dim = getattr(param, "input_dim", None)
+        if input_dim is None:
+            return False
+
+        param_data = param.data
+        param_data.zero_()
+        if self.local_size == 0:
+            return True
+
+        param_data = param_data.narrow(input_dim, 0, self.local_size)
+        loaded_weight = loaded_weight.narrow(input_dim, self.local_start,
+                                             self.local_size)
+        assert param_data.shape == loaded_weight.shape, (
+            f"Tried to load explicit padded row shard {loaded_weight.shape} "
+            f"into {param_data.shape}"
+        )
+        param_data.copy_(loaded_weight)
+        return True

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -983,6 +983,25 @@ class PaddedMergedColumnParallelLinear(MergedColumnParallelLinear):
         for param in self.parameters(recurse=False):
             param.data.zero_()
 
+    @staticmethod
+    def _maybe_adjust_output_span_for_packing(
+        param: Parameter,
+        shard_size: int,
+        shard_offset: int,
+    ) -> tuple[int, int]:
+        output_dim = getattr(param, "output_dim", None)
+        packed_dim = getattr(param, "packed_dim", None)
+        if (
+            output_dim is not None
+            and packed_dim == output_dim
+            and isinstance(param, (PackedColumnParameter, PackedvLLMParameter))
+        ):
+            return param.adjust_shard_indexes_for_packing(
+                shard_size=shard_size,
+                shard_offset=shard_offset,
+            )
+        return shard_size, shard_offset
+
     def _copy_padded_output_shard(
         self,
         param: Parameter,
@@ -1000,6 +1019,9 @@ class PaddedMergedColumnParallelLinear(MergedColumnParallelLinear):
         copy_size = max(0, min(padded_shard_size, logical_size - global_start))
 
         local_offset = sum(self.output_sizes[:loaded_shard_id]) // self.tp_size
+        padded_shard_size, local_offset = self._maybe_adjust_output_span_for_packing(
+            param, padded_shard_size, local_offset
+        )
         param_data = param.data.narrow(
             output_dim, local_offset, padded_shard_size
         )
@@ -1007,6 +1029,9 @@ class PaddedMergedColumnParallelLinear(MergedColumnParallelLinear):
         if copy_size == 0:
             return True
 
+        copy_size, global_start = self._maybe_adjust_output_span_for_packing(
+            param, copy_size, global_start
+        )
         param_data = param_data.narrow(output_dim, 0, copy_size)
         loaded_weight = loaded_weight.narrow(output_dim, global_start, copy_size)
         assert param_data.shape == loaded_weight.shape, (
@@ -1016,16 +1041,68 @@ class PaddedMergedColumnParallelLinear(MergedColumnParallelLinear):
         param_data.copy_(loaded_weight)
         return True
 
+    def _copy_fused_checkpoint_weight(
+        self,
+        param: Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: tuple[int, ...] | None,
+    ) -> bool:
+        output_dim = getattr(param, "output_dim", None)
+        if output_dim is None:
+            return False
+
+        shard_ids = (
+            list(loaded_shard_id)
+            if loaded_shard_id is not None
+            else list(range(len(self.logical_output_sizes)))
+        )
+        source_offset = 0
+        if loaded_shard_id is not None:
+            source_offset = sum(self.logical_output_sizes[: loaded_shard_id[0]])
+
+        for shard_id in shard_ids:
+            logical_size = self.logical_output_sizes[shard_id]
+            source_size, packed_source_offset = (
+                self._maybe_adjust_output_span_for_packing(
+                    param, logical_size, source_offset
+                )
+            )
+            loaded_weight_shard = loaded_weight.narrow(
+                output_dim, packed_source_offset, source_size
+            )
+            if not self._copy_padded_output_shard(
+                param, loaded_weight_shard, shard_id
+            ):
+                return False
+            source_offset += logical_size
+        return True
+
     def weight_loader(
         self,
         param: Parameter,
         loaded_weight: torch.Tensor,
         loaded_shard_id: tuple[int, ...] | int | None = None,
     ):
-        if isinstance(loaded_shard_id, int) and self._copy_padded_output_shard(
-            param, loaded_weight, loaded_shard_id
-        ):
-            return
+        if isinstance(loaded_shard_id, int):
+            if isinstance(param, PerTensorScaleParameter):
+                param.load_merged_column_weight(
+                    loaded_weight=loaded_weight,
+                    shard_id=loaded_shard_id,
+                )
+                return
+            if self._copy_padded_output_shard(
+                param, loaded_weight, loaded_shard_id
+            ):
+                return
+        if loaded_shard_id is None or isinstance(loaded_shard_id, tuple):
+            if isinstance(param, PerTensorScaleParameter):
+                return super().weight_loader(
+                    param, loaded_weight, loaded_shard_id
+                )
+            if self._copy_fused_checkpoint_weight(
+                param, loaded_weight, loaded_shard_id
+            ):
+                return
         super().weight_loader(param, loaded_weight, loaded_shard_id)
 
     def weight_loader_v2(
@@ -1040,11 +1117,23 @@ class PaddedMergedColumnParallelLinear(MergedColumnParallelLinear):
 
         if isinstance(loaded_shard_id, int):
             if isinstance(param, PerTensorScaleParameter):
-                param.load_merged_column_weight(loaded_weight=loaded_weight,
-                                                shard_id=loaded_shard_id)
+                param.load_merged_column_weight(
+                    loaded_weight=loaded_weight,
+                    shard_id=loaded_shard_id,
+                )
                 return
-            if self._copy_padded_output_shard(param, loaded_weight,
-                                             loaded_shard_id):
+            if self._copy_padded_output_shard(
+                param, loaded_weight, loaded_shard_id
+            ):
+                return
+        if loaded_shard_id is None or isinstance(loaded_shard_id, tuple):
+            if isinstance(param, PerTensorScaleParameter):
+                return super().weight_loader_v2(
+                    param, loaded_weight, loaded_shard_id
+                )
+            if self._copy_fused_checkpoint_weight(
+                param, loaded_weight, loaded_shard_id
+            ):
                 return
         super().weight_loader_v2(param, loaded_weight, loaded_shard_id)
 
@@ -1110,12 +1199,18 @@ class ExplicitPaddedMergedColumnParallelLinear(PaddedMergedColumnParallelLinear)
         global_start = self.local_starts[loaded_shard_id]
 
         local_offset = sum(self.output_sizes[:loaded_shard_id]) // self.tp_size
+        padded_shard_size, local_offset = self._maybe_adjust_output_span_for_packing(
+            param, padded_shard_size, local_offset
+        )
         param_data = param.data.narrow(output_dim, local_offset,
                                        padded_shard_size)
         param_data.zero_()
         if copy_size == 0:
             return True
 
+        copy_size, global_start = self._maybe_adjust_output_span_for_packing(
+            param, copy_size, global_start
+        )
         param_data = param_data.narrow(output_dim, 0, copy_size)
         loaded_weight = loaded_weight.narrow(output_dim, global_start,
                                              copy_size)
@@ -1147,8 +1242,13 @@ class ExplicitPaddedMergedColumnParallelLinear(PaddedMergedColumnParallelLinear)
 
         for shard_id in shard_ids:
             logical_size = self.logical_output_sizes[shard_id]
+            source_size, packed_source_offset = (
+                self._maybe_adjust_output_span_for_packing(
+                    param, logical_size, source_offset
+                )
+            )
             loaded_weight_shard = loaded_weight.narrow(
-                output_dim, source_offset, logical_size
+                output_dim, packed_source_offset, source_size
             )
             if not self._copy_padded_output_shard(
                 param, loaded_weight_shard, shard_id
@@ -1675,6 +1775,25 @@ class QKVParallelLinearOverlappingGQA(QKVParallelLinear):
             disable_tp=disable_tp,
         )
 
+    @staticmethod
+    def _maybe_adjust_output_span_for_packing(
+        param: Parameter,
+        shard_size: int,
+        shard_offset: int,
+    ) -> tuple[int, int]:
+        output_dim = getattr(param, "output_dim", None)
+        packed_dim = getattr(param, "packed_dim", None)
+        if (
+            output_dim is not None
+            and packed_dim == output_dim
+            and isinstance(param, (PackedColumnParameter, PackedvLLMParameter))
+        ):
+            return param.adjust_shard_indexes_for_packing(
+                shard_size=shard_size,
+                shard_offset=shard_offset,
+            )
+        return shard_size, shard_offset
+
     def _load_overlapping_kv_weight(
         self,
         param: Parameter,
@@ -1694,16 +1813,26 @@ class QKVParallelLinearOverlappingGQA(QKVParallelLinear):
         )
         shard_offset = self._get_shard_offset_mapping(loaded_shard_id)
         assert shard_offset is not None
+        shard_size = self.num_kv_heads * local_head_size
+        shard_size, shard_offset = self._maybe_adjust_output_span_for_packing(
+            param, shard_size, shard_offset
+        )
         param_data = param_data.narrow(
-            output_dim, shard_offset, self.num_kv_heads * local_head_size
+            output_dim, shard_offset, shard_size
         )
 
         for slot_idx, global_kv_idx in enumerate(self.kv_head_indices):
+            local_span_size, dst_offset = self._maybe_adjust_output_span_for_packing(
+                param, local_head_size, slot_idx * local_head_size
+            )
+            _, src_offset = self._maybe_adjust_output_span_for_packing(
+                param, local_head_size, global_kv_idx * local_head_size
+            )
             dst = param_data.narrow(
-                output_dim, slot_idx * local_head_size, local_head_size
+                output_dim, dst_offset, local_span_size
             )
             src = loaded_weight.narrow(
-                output_dim, global_kv_idx * local_head_size, local_head_size
+                output_dim, src_offset, local_span_size
             )
             assert dst.shape == src.shape
             dst.copy_(src)
@@ -2149,6 +2278,38 @@ class PaddedRowParallelLinear(RowParallelLinear):
         if copy_size == 0:
             return True
 
+        packed_dim = getattr(param, "packed_dim", None)
+        pack_factor = getattr(
+            param, "packed_factor", getattr(param, "pack_factor", 1)
+        )
+        if packed_dim != input_dim and copy_size > param_data.shape[input_dim]:
+            if padded_shard_size % param_data.shape[input_dim] != 0:
+                raise ValueError(
+                    "Cannot infer packing for padded row shard: "
+                    f"padded_shard_size={padded_shard_size}, "
+                    f"param_shape={tuple(param_data.shape)}, "
+                    f"input_dim={input_dim}"
+                )
+            inferred_pack_factor = (
+                padded_shard_size // param_data.shape[input_dim]
+            )
+            if (
+                loaded_weight.shape[input_dim] * inferred_pack_factor
+                == self.logical_input_size
+            ):
+                pack_factor = inferred_pack_factor
+                packed_dim = input_dim
+
+        if packed_dim == input_dim and pack_factor > 1:
+            if global_start % pack_factor != 0 or copy_size % pack_factor != 0:
+                raise ValueError(
+                    "Cannot load padded packed row shard with unaligned "
+                    f"span: global_start={global_start}, copy_size={copy_size}, "
+                    f"pack_factor={pack_factor}"
+                )
+            global_start //= pack_factor
+            copy_size //= pack_factor
+
         param_data = param_data.narrow(input_dim, 0, copy_size)
         loaded_weight = loaded_weight.narrow(input_dim, global_start,
                                              copy_size)
@@ -2227,9 +2388,39 @@ class ExplicitPaddedRowParallelLinear(PaddedRowParallelLinear):
         if self.local_size == 0:
             return True
 
-        param_data = param_data.narrow(input_dim, 0, self.local_size)
-        loaded_weight = loaded_weight.narrow(input_dim, self.local_start,
-                                             self.local_size)
+        local_start = self.local_start
+        local_size = self.local_size
+        packed_dim = getattr(param, "packed_dim", None)
+        pack_factor = getattr(
+            param, "packed_factor", getattr(param, "pack_factor", 1)
+        )
+        if packed_dim != input_dim and local_size > param_data.shape[input_dim]:
+            if self.logical_input_size % loaded_weight.shape[input_dim] != 0:
+                raise ValueError(
+                    "Cannot infer packing for explicit padded row shard: "
+                    f"logical_input_size={self.logical_input_size}, "
+                    f"loaded_shape={tuple(loaded_weight.shape)}, "
+                    f"input_dim={input_dim}"
+                )
+            inferred_pack_factor = (
+                self.logical_input_size // loaded_weight.shape[input_dim]
+            )
+            if inferred_pack_factor > 1:
+                pack_factor = inferred_pack_factor
+                packed_dim = input_dim
+
+        if packed_dim == input_dim and pack_factor > 1:
+            if local_start % pack_factor != 0 or local_size % pack_factor != 0:
+                raise ValueError(
+                    "Cannot load explicit padded packed row shard with "
+                    f"unaligned span: local_start={local_start}, "
+                    f"local_size={local_size}, pack_factor={pack_factor}"
+                )
+            local_start //= pack_factor
+            local_size //= pack_factor
+
+        param_data = param_data.narrow(input_dim, 0, local_size)
+        loaded_weight = loaded_weight.narrow(input_dim, local_start, local_size)
         assert param_data.shape == loaded_weight.shape, (
             f"Tried to load explicit padded row shard {loaded_weight.shape} "
             f"into {param_data.shape}"

--- a/vllm/model_executor/layers/mamba/gdn/head_partition.py
+++ b/vllm/model_executor/layers/mamba/gdn/head_partition.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True)
+class GDNHeadPartition:
+    tp_size: int
+    tp_rank: int
+    num_k_heads: int
+    num_v_heads: int
+    head_k_dim: int
+    head_v_dim: int
+    k_start: int
+    k_count: int
+    v_start: int
+    v_count: int
+    max_k_count: int
+    max_v_count: int
+
+    @property
+    def v_per_k(self) -> int:
+        return self.num_v_heads // self.num_k_heads
+
+    @property
+    def local_key_dim(self) -> int:
+        return self.k_count * self.head_k_dim
+
+    @property
+    def local_value_dim(self) -> int:
+        return self.v_count * self.head_v_dim
+
+    @property
+    def padded_key_dim(self) -> int:
+        return self.max_k_count * self.head_k_dim
+
+    @property
+    def padded_value_dim(self) -> int:
+        return self.max_v_count * self.head_v_dim
+
+    @property
+    def local_conv_dim(self) -> int:
+        return self.local_key_dim * 2 + self.local_value_dim
+
+    @property
+    def padded_conv_dim(self) -> int:
+        return self.padded_key_dim * 2 + self.padded_value_dim
+
+    @property
+    def padded_qkvz_output_sizes(self) -> list[int]:
+        padded_key_global = self.padded_key_dim * self.tp_size
+        padded_value_global = self.padded_value_dim * self.tp_size
+        return [
+            padded_key_global,
+            padded_key_global,
+            padded_value_global,
+            padded_value_global,
+        ]
+
+    @property
+    def padded_ba_output_sizes(self) -> list[int]:
+        padded_value_heads_global = self.max_v_count * self.tp_size
+        return [padded_value_heads_global, padded_value_heads_global]
+
+
+def _balanced_range(total: int, parts: int, rank: int) -> tuple[int, int]:
+    base = total // parts
+    extra = total % parts
+    count = base + (1 if rank < extra else 0)
+    start = rank * base + min(rank, extra)
+    return start, count
+
+
+def make_gdn_head_partition(
+    *,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_k_dim: int,
+    head_v_dim: int,
+    tp_size: int,
+    tp_rank: int,
+) -> GDNHeadPartition:
+    if num_v_heads % num_k_heads != 0:
+        raise ValueError(
+            "GDN non-uniform TP requires an integral value/key head ratio. "
+            f"Got {num_v_heads=} and {num_k_heads=}."
+        )
+    if not (0 <= tp_rank < tp_size):
+        raise ValueError(f"Invalid TP rank {tp_rank} for TP size {tp_size}.")
+
+    v_per_k = num_v_heads // num_k_heads
+    k_start, k_count = _balanced_range(num_k_heads, tp_size, tp_rank)
+    max_k_count = (num_k_heads + tp_size - 1) // tp_size
+    v_start = k_start * v_per_k
+    v_count = k_count * v_per_k
+    max_v_count = max_k_count * v_per_k
+
+    return GDNHeadPartition(
+        tp_size=tp_size,
+        tp_rank=tp_rank,
+        num_k_heads=num_k_heads,
+        num_v_heads=num_v_heads,
+        head_k_dim=head_k_dim,
+        head_v_dim=head_v_dim,
+        k_start=k_start,
+        k_count=k_count,
+        v_start=v_start,
+        v_count=v_count,
+        max_k_count=max_k_count,
+        max_v_count=max_v_count,
+    )
+
+
+def explicit_gdn_conv_weight_loader(
+    partition: GDNHeadPartition,
+) -> Callable[[torch.Tensor, torch.Tensor], None]:
+    """Load packed [q, k, v] conv rows using GDN head-group spans."""
+
+    def loader(param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
+        param.data.zero_()
+        key_dim = partition.num_k_heads * partition.head_k_dim
+        value_offset = key_dim * 2
+        specs = [
+            (
+                partition.k_start * partition.head_k_dim,
+                partition.local_key_dim,
+                0,
+            ),
+            (
+                key_dim + partition.k_start * partition.head_k_dim,
+                partition.local_key_dim,
+                partition.padded_key_dim,
+            ),
+            (
+                value_offset + partition.v_start * partition.head_v_dim,
+                partition.local_value_dim,
+                partition.padded_key_dim * 2,
+            ),
+        ]
+        for source_start, copy_size, dest_start in specs:
+            if copy_size == 0:
+                continue
+            param.data[dest_start : dest_start + copy_size, ...].copy_(
+                loaded_weight[source_start : source_start + copy_size, ...]
+            )
+
+    return loader
+
+
+def explicit_vector_weight_loader(
+    start: int,
+    size: int,
+) -> Callable[[torch.Tensor, torch.Tensor], None]:
+    def loader(param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
+        param.data.zero_()
+        if size == 0:
+            return
+        param.data[:size].copy_(loaded_weight[start : start + size])
+
+    return loader

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -15,9 +15,6 @@ from vllm.config import (
     VllmConfig,
     get_current_vllm_config,
 )
-from vllm.distributed import (
-    divide,
-)
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp, PluggableLayer
@@ -34,10 +31,17 @@ from vllm.model_executor.layers.fla.ops.utils import FLA_CHUNK_SIZE
 from vllm.model_executor.layers.layernorm import RMSNormGated
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
+    ExplicitPaddedMergedColumnParallelLinear,
+    ExplicitPaddedRowParallelLinear,
     MergedColumnParallelLinear,
     RowParallelLinear,
 )
 from vllm.model_executor.layers.mamba.gdn.base import GatedDeltaNetAttention
+from vllm.model_executor.layers.mamba.gdn.head_partition import (
+    explicit_gdn_conv_weight_loader,
+    explicit_vector_weight_loader,
+    make_gdn_head_partition,
+)
 from vllm.model_executor.layers.mamba.mamba_mixer2 import mamba_v2_sharded_weight_loader
 from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateShapeCalculator,
@@ -81,7 +85,6 @@ if GDN_AITER_TRITON_AVAILABLE:
     )
 
 logger = init_logger(__name__)
-
 
 # TODO(arpera): remove ``_is_libs_cu13_install_intact`` and its caller in
 # ``_resolve_gdn_prefill_backend`` once the upstream packaging bug is
@@ -421,6 +424,22 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
     def get_state_shape(
         self,
     ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        if getattr(self, "gdn_explicit_partition", False):
+            conv_state_shape = MambaStateShapeCalculator._orient_conv_shape(
+                self.padded_local_conv_dim,
+                self.conv_kernel_size - 1 + self.num_spec,
+            )
+            temporal_state_shape = (
+                self.padded_local_num_v_heads,
+                self.head_v_dim,
+                self.head_k_dim,
+            )
+            return (
+                conv_state_shape,
+                temporal_state_shape,
+                conv_state_shape,
+                temporal_state_shape,
+            )
         return MambaStateShapeCalculator.gated_delta_net_state_shape(
             self.tp_size,
             self.num_k_heads,
@@ -448,6 +467,37 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         self.key_dim = self.head_k_dim * self.num_k_heads
         self.value_dim = self.head_v_dim * self.num_v_heads
         self.gqa_interleaved_layout = gqa_interleaved_layout
+        incompatible_gdn_tp = (
+            self.num_k_heads % self.tp_size != 0
+            or self.num_v_heads % self.tp_size != 0
+        )
+        self.gdn_explicit_partition = incompatible_gdn_tp and (
+            not self.gqa_interleaved_layout
+        )
+        self.disable_tp_for_gdn = incompatible_gdn_tp and (
+            not self.gdn_explicit_partition
+        )
+        if self.disable_tp_for_gdn:
+            self.tp_size = 1
+            self.tp_rank = 0
+        self.gdn_partition = make_gdn_head_partition(
+            num_k_heads=self.num_k_heads,
+            num_v_heads=self.num_v_heads,
+            head_k_dim=self.head_k_dim,
+            head_v_dim=self.head_v_dim,
+            tp_size=self.tp_size,
+            tp_rank=self.tp_rank,
+        )
+        self.local_num_k_heads = self.gdn_partition.k_count
+        self.local_num_v_heads = self.gdn_partition.v_count
+        self.padded_local_num_k_heads = self.gdn_partition.max_k_count
+        self.padded_local_num_v_heads = self.gdn_partition.max_v_count
+        self.local_key_dim = self.gdn_partition.local_key_dim
+        self.local_value_dim = self.gdn_partition.local_value_dim
+        self.padded_local_key_dim = self.gdn_partition.padded_key_dim
+        self.padded_local_value_dim = self.gdn_partition.padded_value_dim
+        self.local_conv_dim = self.gdn_partition.local_conv_dim
+        self.padded_local_conv_dim = self.gdn_partition.padded_conv_dim
         if current_platform.is_xpu():
             self._forward_method = self.forward_xpu
         elif current_platform.is_cpu():
@@ -464,11 +514,17 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         # QKV
         self.conv_dim = self.key_dim * 2 + self.value_dim
+        conv_output_size = (
+            self.padded_local_conv_dim * self.tp_size
+            if self.gdn_explicit_partition
+            else self.conv_dim
+        )
         self.conv1d = ColumnParallelLinear(
             input_size=self.conv_kernel_size,
-            output_size=self.conv_dim,
+            output_size=conv_output_size,
             bias=False,
             prefix=f"{prefix}.conv1d",
+            disable_tp=self.disable_tp_for_gdn,
         )
         self.conv1d.weight.data = self.conv1d.weight.data.unsqueeze(1)
 
@@ -483,6 +539,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             value_dim=self.value_dim,
             quant_config=self.quant_config,
             prefix=f"{prefix}.in_proj_qkvz",
+            disable_tp=self.disable_tp_for_gdn,
         )
 
         # ba_proj doesn't support blockwise fp8 quantization.
@@ -493,38 +550,62 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             num_v_heads=self.num_v_heads,
             quant_config=self.quant_config,
             prefix=f"{prefix}.in_proj_ba",
+            disable_tp=self.disable_tp_for_gdn,
         )
         self.disable_tp_for_ba_proj = self.maybe_disable_tp(self.quant_config)
 
         query_key_settings = (self.key_dim, 0, False)
         value_settings = (self.value_dim, 0, False)
 
-        self.conv1d.weight.weight_loader = mamba_v2_sharded_weight_loader(
-            [
-                query_key_settings,
-                query_key_settings,
-                value_settings,
-            ],
-            self.tp_size,
-            self.tp_rank,
-        )
+        if self.gdn_explicit_partition:
+            self.conv1d.weight.weight_loader = explicit_gdn_conv_weight_loader(
+                self.gdn_partition
+            )
+        else:
+            self.conv1d.weight.weight_loader = mamba_v2_sharded_weight_loader(
+                [
+                    query_key_settings,
+                    query_key_settings,
+                    value_settings,
+                ],
+                self.tp_size,
+                self.tp_rank,
+            )
 
         # selective projection used to make dt, B and C input dependent
 
         # time step projection (discretization)
         # instantiate once and copy inv_dt in init_weights of PretrainedModel
         self.dt_bias = nn.Parameter(
-            torch.ones(self.num_v_heads // self.tp_size),
+            torch.ones(self.padded_local_num_v_heads),
         )
         self.A_log = nn.Parameter(
             torch.empty(
-                divide(self.num_v_heads, self.tp_size),
+                self.padded_local_num_v_heads,
                 dtype=torch.float32,
             )
         )
 
-        set_weight_attrs(self.A_log, {"weight_loader": sharded_weight_loader(0)})
-        set_weight_attrs(self.dt_bias, {"weight_loader": sharded_weight_loader(0)})
+        if self.gdn_explicit_partition:
+            set_weight_attrs(
+                self.A_log,
+                {
+                    "weight_loader": explicit_vector_weight_loader(
+                        self.gdn_partition.v_start, self.local_num_v_heads
+                    )
+                },
+            )
+            set_weight_attrs(
+                self.dt_bias,
+                {
+                    "weight_loader": explicit_vector_weight_loader(
+                        self.gdn_partition.v_start, self.local_num_v_heads
+                    )
+                },
+            )
+        elif not self.disable_tp_for_gdn:
+            set_weight_attrs(self.A_log, {"weight_loader": sharded_weight_loader(0)})
+            set_weight_attrs(self.dt_bias, {"weight_loader": sharded_weight_loader(0)})
 
         output_gate_type = getattr(config, "output_gate_type", "silu")
         if output_gate_type == "swish":
@@ -542,20 +623,35 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             device=current_platform.current_device(),
         )
 
-        self.out_proj = RowParallelLinear(
-            self.value_dim,
-            self.hidden_size,
-            bias=False,
-            input_is_parallel=True,
-            quant_config=self.quant_config,
-            prefix=f"{prefix}.out_proj",
-        )
+        if self.gdn_explicit_partition:
+            self.out_proj = ExplicitPaddedRowParallelLinear(
+                input_size=self.value_dim,
+                padded_input_size=self.padded_local_value_dim * self.tp_size,
+                local_start=self.gdn_partition.v_start * self.head_v_dim,
+                local_size=self.local_value_dim,
+                output_size=self.hidden_size,
+                bias=False,
+                input_is_parallel=True,
+                quant_config=self.quant_config,
+                prefix=f"{prefix}.out_proj",
+            )
+        else:
+            self.out_proj = RowParallelLinear(
+                self.value_dim,
+                self.hidden_size,
+                bias=False,
+                input_is_parallel=True,
+                quant_config=self.quant_config,
+                prefix=f"{prefix}.out_proj",
+                disable_tp=self.disable_tp_for_gdn,
+            )
 
         self.chunk_gated_delta_rule = ChunkGatedDeltaRule()
         self.gdn_prefill_backend = self.chunk_gated_delta_rule.gdn_prefill_backend
         self._prefill_kernels_warmed_up = False
         self.enable_packed_recurrent_decode = (
             envs.VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE
+            and not self.gdn_explicit_partition
         )
 
         compilation_config = get_current_vllm_config().compilation_config
@@ -570,6 +666,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         value_dim: int,
         quant_config: QuantizationConfig | None,
         prefix: str,
+        disable_tp: bool = False,
     ) -> MergedColumnParallelLinear:
         # When gqa_interleaved_layout=True (Qwen3-Next), qkvz weights are
         # stored as a single fused tensor with interleaved GQA layout, so we
@@ -581,12 +678,35 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             if self.gqa_interleaved_layout
             else [key_dim, key_dim, value_dim, value_dim]
         )
+        if self.gdn_explicit_partition and not self.gqa_interleaved_layout:
+            partition = self.gdn_partition
+            return ExplicitPaddedMergedColumnParallelLinear(
+                input_size=hidden_size,
+                output_sizes=output_sizes,
+                padded_output_sizes=partition.padded_qkvz_output_sizes,
+                local_starts=[
+                    partition.k_start * self.head_k_dim,
+                    partition.k_start * self.head_k_dim,
+                    partition.v_start * self.head_v_dim,
+                    partition.v_start * self.head_v_dim,
+                ],
+                local_sizes=[
+                    partition.local_key_dim,
+                    partition.local_key_dim,
+                    partition.local_value_dim,
+                    partition.local_value_dim,
+                ],
+                bias=False,
+                quant_config=quant_config,
+                prefix=prefix,
+            )
         return MergedColumnParallelLinear(
             input_size=hidden_size,
             output_sizes=output_sizes,
             bias=False,
             quant_config=quant_config,
             prefix=prefix,
+            disable_tp=disable_tp,
         )
 
     def create_ba_proj(
@@ -595,6 +715,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         num_v_heads: int,
         quant_config: QuantizationConfig | None,
         prefix: str,
+        disable_tp: bool = False,
     ) -> MergedColumnParallelLinear:
         # When gqa_interleaved_layout=True (Qwen3-Next), in_proj_ba is stored
         # as a single fused weight [b_g0, a_g0, b_g1, a_g1, ...] interleaved
@@ -604,13 +725,26 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         output_sizes = (
             [num_v_heads * 2] if self.gqa_interleaved_layout else [num_v_heads] * 2
         )
+        if self.gdn_explicit_partition and not self.gqa_interleaved_layout:
+            partition = self.gdn_partition
+            return ExplicitPaddedMergedColumnParallelLinear(
+                input_size=hidden_size,
+                output_sizes=output_sizes,
+                padded_output_sizes=partition.padded_ba_output_sizes,
+                local_starts=[partition.v_start, partition.v_start],
+                local_sizes=[partition.v_count, partition.v_count],
+                bias=False,
+                quant_config=quant_config,
+                prefix=prefix,
+                disable_tp=self.maybe_disable_tp(quant_config),
+            )
         return MergedColumnParallelLinear(
             input_size=hidden_size,
             output_sizes=output_sizes,
             bias=False,
             quant_config=quant_config,
             prefix=prefix,
-            disable_tp=self.maybe_disable_tp(quant_config),
+            disable_tp=disable_tp or self.maybe_disable_tp(quant_config),
         )
 
     def maybe_disable_tp(self, quant_config: QuantizationConfig | None) -> bool:
@@ -633,6 +767,10 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
 
     def split_ba(self, ba: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         b, a = ba.chunk(2, dim=-1)
+        if self.gdn_explicit_partition:
+            b = b[:, : self.local_num_v_heads]
+            a = a[:, : self.local_num_v_heads]
+            return b, a
         if self.disable_tp_for_ba_proj and self.tp_size > 1:
             # ba_proj is replicated for Marlin; slice b/a to local TP rank.
             ba_chunk = self.num_v_heads // self.tp_size
@@ -640,6 +778,53 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             b = b[:, ba_start : ba_start + ba_chunk]
             a = a[:, ba_start : ba_start + ba_chunk]
         return b, a
+
+    def _split_non_interleaved_qkvz(
+        self, mixed_qkvz: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if not self.gdn_explicit_partition:
+            qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
+            z_size = self.value_dim // self.tp_size
+            mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)
+            return mixed_qkv, z.reshape(z.size(0), -1, self.head_v_dim)
+
+        qkv_size = self.padded_local_key_dim * 2 + self.padded_local_value_dim
+        z_size = self.padded_local_value_dim
+        mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)
+        z = z[:, : self.local_value_dim].reshape(
+            z.size(0), self.local_num_v_heads, self.head_v_dim
+        )
+        return mixed_qkv, z
+
+    def _strip_padded_mixed_qkv(self, mixed_qkv: torch.Tensor | None):
+        if mixed_qkv is None or not self.gdn_explicit_partition:
+            return mixed_qkv
+        q, k, v = mixed_qkv.split(
+            [
+                self.padded_local_key_dim,
+                self.padded_local_key_dim,
+                self.padded_local_value_dim,
+            ],
+            dim=-1,
+        )
+        return torch.cat(
+            [
+                q[:, : self.local_key_dim],
+                k[:, : self.local_key_dim],
+                v[:, : self.local_value_dim],
+            ],
+            dim=-1,
+        )
+
+    def _pad_local_value_flat(self, value: torch.Tensor) -> torch.Tensor:
+        if not self.gdn_explicit_partition:
+            return value
+        if self.local_value_dim == self.padded_local_value_dim:
+            return value
+        return torch.nn.functional.pad(
+            value,
+            (0, self.padded_local_value_dim - self.local_value_dim),
+        )
 
     def fix_query_key_value_ordering(
         self,
@@ -709,12 +894,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         if not self.gqa_interleaved_layout:
             # Qwen3.5: weights are in [q, k, v, z] order
             assert num_tokens == mixed_qkvz.shape[0]
-            qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
-            z_size = self.value_dim // self.tp_size
-            mixed_qkv, z_flat = mixed_qkvz.split([qkv_size, z_size], dim=-1)
-            n = mixed_qkvz.shape[0]
-            z_out = z_flat.reshape(n, -1, self.head_v_dim)
-            b, a = mixed_ba.chunk(2, dim=-1)
+            mixed_qkv, z_out = self._split_non_interleaved_qkvz(mixed_qkvz)
+            b, a = self.split_ba(mixed_ba)
             return mixed_qkv, z_out, b, a
 
         # Qwen3-Next: interleaved GQA layout
@@ -818,9 +999,9 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             return None, None, None
 
         seq_len = mixed_qkv.shape[0]
-        q_dim = self.key_dim // self.tp_size
-        k_dim = self.key_dim // self.tp_size
-        v_dim = self.value_dim // self.tp_size
+        q_dim = self.local_key_dim
+        k_dim = self.local_key_dim
+        v_dim = self.local_value_dim
 
         query, key, value = torch.split(mixed_qkv, [q_dim, k_dim, v_dim], dim=-1)
 
@@ -863,6 +1044,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         core_attn_out = self.norm(core_attn_out, z)
         core_attn_out = core_attn_out.reshape(z_shape_og)
         core_attn_out = core_attn_out.flatten(-2)  # ... h d -> ... (h d)
+        core_attn_out = self._pad_local_value_flat(core_attn_out)
         output, _ = self.out_proj(core_attn_out)
         return output
 
@@ -879,12 +1061,12 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             projected_states_qkvz = projected_states_qkvz.view(num_tokens, -1)
             projected_states_ba = projected_states_ba.view(num_tokens, -1)
             core_attn_out = torch.empty(
-                (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+                (num_tokens, self.local_num_v_heads, self.head_v_dim),
                 dtype=hidden_states.dtype,
                 device=hidden_states.device,
             )
             z = torch.empty(
-                (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+                (num_tokens, self.local_num_v_heads, self.head_v_dim),
                 dtype=projected_states_qkvz.dtype,
                 device=projected_states_qkvz.device,
             )
@@ -930,10 +1112,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             mixed_qkv = torch.cat((query, key, value), dim=-1)
         else:
             # Qwen3.5: weights are already in [q, k, v, z] and [b, a] order
-            qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
-            z_size = self.value_dim // self.tp_size
-            mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)
-            z = z.reshape(z.size(0), -1, self.head_v_dim)
+            mixed_qkv, z = self._split_non_interleaved_qkvz(mixed_qkvz)
             b, a = self.split_ba(ba)
             b = b.contiguous()
             a = a.contiguous()
@@ -944,7 +1123,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # Note: we should not use torch.empty here like other attention backends,
         # see discussions in https://github.com/vllm-project/vllm/pull/28182
         core_attn_out = torch.zeros(
-            (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+            (num_tokens, self.local_num_v_heads, self.head_v_dim),
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
@@ -984,7 +1163,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # Part 2: Core Attention
         # ============================================================
         core_attn_out = torch.zeros(
-            (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+            (num_tokens, self.local_num_v_heads, self.head_v_dim),
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
@@ -1031,15 +1210,12 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             mixed_qkv = torch.cat((query, key, value), dim=-1)
         else:
             # Qwen3.5: weights are already in [q, k, v, z] and [b, a] order
-            qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
-            z_size = self.value_dim // self.tp_size
-            mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)
-            z = z.reshape(z.size(0), -1, self.head_v_dim)
-            b, a = ba.chunk(2, dim=-1)
+            mixed_qkv, z = self._split_non_interleaved_qkvz(mixed_qkvz)
+            b, a = self.split_ba(ba)
 
         num_tokens = hidden_states.size(0)
         core_attn_out = torch.zeros(
-            (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+            (num_tokens, self.local_num_v_heads, self.head_v_dim),
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
@@ -1058,6 +1234,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         core_attn_out = self.norm(core_attn_out, z)
         core_attn_out = core_attn_out.reshape(z_shape_og)
         core_attn_out = core_attn_out.flatten(-2)  # ... h d -> ... (h d)
+        core_attn_out = self._pad_local_value_flat(core_attn_out)
         out, _ = self.out_proj(core_attn_out)
         return out
 
@@ -1092,8 +1269,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         device = qkv_or_qkvz.device
         dtype = qkv_or_qkvz.dtype
-        num_k_heads = self.num_k_heads // self.tp_size
-        num_v_heads = self.num_v_heads // self.tp_size
+        num_k_heads = self.local_num_k_heads
+        num_v_heads = self.local_num_v_heads
         _, state_dtype = self.get_state_dtype()
 
         # All kernels use BT = chunk_size, so a single pass with T = chunk_size
@@ -1102,7 +1279,12 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # then run chunk_gated_delta_rule with in-kernel L2 norm disabled.
         T = FLA_CHUNK_SIZE
         dummy_mixed_qkv = torch.randn(
-            T, qkv_or_qkvz.shape[-1] - v_dim, device=device, dtype=dtype
+            T,
+            self.local_conv_dim
+            if self.gdn_explicit_partition
+            else qkv_or_qkvz.shape[-1] - v_dim,
+            device=device,
+            dtype=dtype,
         )
         dummy_a = torch.randn(T, num_v_heads, device=device, dtype=dtype)
         dummy_b = torch.randn(T, num_v_heads, device=device, dtype=dtype)
@@ -1110,8 +1292,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             conv_output=dummy_mixed_qkv,
             a=dummy_a,
             b=dummy_b,
-            A_log=self.A_log,
-            dt_bias=self.dt_bias,
+            A_log=self.A_log[:num_v_heads],
+            dt_bias=self.dt_bias[:num_v_heads],
             num_k_heads=num_k_heads,
             head_k_dim=self.head_k_dim,
             head_v_dim=self.head_v_dim,
@@ -1310,6 +1492,13 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             else self_kv_cache[0].transpose(-1, -2)
         )
         ssm_state = self_kv_cache[1]
+        ssm_state = (
+            ssm_state[:, : self.local_num_v_heads, :, :]
+            if self.gdn_explicit_partition
+            else ssm_state
+        )
+        A_log = self.A_log[: self.local_num_v_heads]
+        dt_bias = self.dt_bias[: self.local_num_v_heads]
         num_actual_tokens = attn_metadata.num_actual_tokens
         num_accepted_tokens = attn_metadata.num_accepted_tokens
 
@@ -1385,6 +1574,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         else:
             mixed_qkv_non_spec = None
 
+        mixed_qkv_spec = self._strip_padded_mixed_qkv(mixed_qkv_spec)
+        mixed_qkv_non_spec = self._strip_padded_mixed_qkv(mixed_qkv_non_spec)
         query_spec, key_spec, value_spec = self.rearrange_mixed_qkv(mixed_qkv_spec)
 
         # Split mixed non-spec-decode+prefill to process independently
@@ -1425,9 +1616,9 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 conv_output=conv_output_prefill,
                 a=a_prefill,
                 b=b_prefill,
-                A_log=self.A_log,
-                dt_bias=self.dt_bias,
-                num_k_heads=self.num_k_heads // self.tp_size,
+                A_log=A_log,
+                dt_bias=dt_bias,
+                num_k_heads=self.local_num_k_heads,
                 head_k_dim=self.head_k_dim,
                 head_v_dim=self.head_v_dim,
                 apply_l2norm=True,
@@ -1451,10 +1642,10 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         if spec_sequence_masks is not None:
             core_attn_out_spec, last_recurrent_state = (
                 fused_sigmoid_gating_delta_rule_update(
-                    A_log=self.A_log,
+                    A_log=A_log,
                     a=a,
                     b=b,
-                    dt_bias=self.dt_bias,
+                    dt_bias=dt_bias,
                     q=query_spec,
                     k=key_spec,
                     v=value_spec,
@@ -1478,10 +1669,10 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 mixed_qkv_non_spec[:num_decode_tokens]  # type: ignore[index]
             )
             core_attn_out_decode, _ = fused_sigmoid_gating_delta_rule_update(
-                A_log=self.A_log,
+                A_log=A_log,
                 a=a[:num_decode_tokens],
                 b=b[:num_decode_tokens],
-                dt_bias=self.dt_bias,
+                dt_bias=dt_bias,
                 q=query_decode,
                 k=key_decode,
                 v=value_decode,
@@ -1536,10 +1727,10 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         elif attn_metadata.num_decodes > 0:
             core_attn_out_non_spec, last_recurrent_state = (
                 fused_sigmoid_gating_delta_rule_update(
-                    A_log=self.A_log,
+                    A_log=A_log,
                     a=a,
                     b=b,
-                    dt_bias=self.dt_bias,
+                    dt_bias=dt_bias,
                     q=query_non_spec,
                     k=key_non_spec,
                     v=value_non_spec,

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -3,6 +3,7 @@
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from math import lcm
 
 import torch
 import torch.nn.functional as F
@@ -255,11 +256,13 @@ class VocabParallelEmbedding(PluggableLayer):
         self.padding_size = padding_size
         self.org_vocab_size = org_num_embeddings or num_embeddings
         num_added_embeddings = num_embeddings - self.org_vocab_size
+        tp_aligned_padding_size = lcm(self.padding_size, self.tp_size)
         self.org_vocab_size_padded = pad_vocab_size(
-            self.org_vocab_size, self.padding_size
+            self.org_vocab_size, tp_aligned_padding_size
         )
         self.num_embeddings_padded = pad_vocab_size(
-            self.org_vocab_size_padded + num_added_embeddings, self.padding_size
+            self.org_vocab_size_padded + num_added_embeddings,
+            tp_aligned_padding_size,
         )
         assert self.org_vocab_size_padded <= self.num_embeddings_padded
 

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -57,6 +57,8 @@ from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
     MergedColumnParallelLinear,
+    PaddedMergedColumnParallelLinear,
+    PaddedRowParallelLinear,
     QKVParallelLinear,
     RowParallelLinear,
 )
@@ -304,6 +306,10 @@ Qwen2_5_VLVideoInputs: TypeAlias = (
 # === Vision Encoder === #
 
 
+def _pad_to_tp(value: int, tp_size: int) -> int:
+    return ((value + tp_size - 1) // tp_size) * tp_size
+
+
 class Qwen2_5_VisionMLP(nn.Module):
     def __init__(
         self,
@@ -363,28 +369,46 @@ class Qwen2_5_VisionAttention(nn.Module):
         self.hidden_size_per_attention_head = dist_utils.divide(
             projection_size, num_heads
         )
-        self.num_attention_heads_per_partition = dist_utils.divide(
-            num_heads, self.tp_size
+        padded_num_heads = _pad_to_tp(num_heads, self.tp_size)
+        self.num_attention_heads_per_partition = padded_num_heads // self.tp_size
+        padded_projection_size = (
+            padded_num_heads * self.hidden_size_per_attention_head
         )
 
-        self.qkv = QKVParallelLinear(
-            hidden_size=embed_dim,
-            head_size=self.hidden_size_per_attention_head,
-            total_num_heads=num_heads,
-            total_num_kv_heads=num_heads,
-            bias=True,
-            quant_config=quant_config,
-            prefix=f"{prefix}.qkv",
-            disable_tp=use_data_parallel,
-        )
-
-        self.proj = RowParallelLinear(
-            input_size=projection_size,
-            output_size=embed_dim,
-            quant_config=quant_config,
-            prefix=f"{prefix}.proj",
-            disable_tp=use_data_parallel,
-        )
+        if padded_num_heads == num_heads:
+            self.qkv = QKVParallelLinear(
+                hidden_size=embed_dim,
+                head_size=self.hidden_size_per_attention_head,
+                total_num_heads=num_heads,
+                total_num_kv_heads=num_heads,
+                bias=True,
+                quant_config=quant_config,
+                prefix=f"{prefix}.qkv",
+                disable_tp=use_data_parallel,
+            )
+            self.proj = RowParallelLinear(
+                input_size=projection_size,
+                output_size=embed_dim,
+                quant_config=quant_config,
+                prefix=f"{prefix}.proj",
+                disable_tp=use_data_parallel,
+            )
+        else:
+            self.qkv = PaddedMergedColumnParallelLinear(
+                input_size=embed_dim,
+                output_sizes=[projection_size] * 3,
+                padded_output_sizes=[padded_projection_size] * 3,
+                bias=True,
+                quant_config=quant_config,
+                prefix=f"{prefix}.qkv",
+            )
+            self.proj = PaddedRowParallelLinear(
+                input_size=projection_size,
+                padded_input_size=padded_projection_size,
+                output_size=embed_dim,
+                quant_config=quant_config,
+                prefix=f"{prefix}.proj",
+            )
 
         self.attn = MMEncoderAttention(
             num_heads=self.num_attention_heads_per_partition,

--- a/vllm/model_executor/models/qwen2_moe.py
+++ b/vllm/model_executor/models/qwen2_moe.py
@@ -25,6 +25,7 @@
 # limitations under the License.
 """Inference-only Qwen2MoE model compatible with HuggingFace weights."""
 
+import math
 from collections.abc import Iterable
 from itertools import islice
 from typing import Any
@@ -46,6 +47,8 @@ from vllm.model_executor.layers.fused_moe import (
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     MergedColumnParallelLinear,
+    PaddedMergedColumnParallelLinear,
+    PaddedRowParallelLinear,
     QKVParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
@@ -72,6 +75,15 @@ from .utils import (
 logger = init_logger(__name__)
 
 
+def _ceil_to_multiple(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def _dense_mlp_padded_intermediate_multiple(tp_size: int) -> int:
+    # Keep the rank-local K dimension aligned for grouped W4A16/AWQ kernels.
+    return math.lcm(tp_size * 32, 16)
+
+
 class Qwen2MoeMLP(nn.Module):
     def __init__(
         self,
@@ -85,23 +97,48 @@ class Qwen2MoeMLP(nn.Module):
         prefix: str = "",
     ) -> None:
         super().__init__()
-        self.gate_up_proj = MergedColumnParallelLinear(
-            hidden_size,
-            [intermediate_size] * 2,
-            bias=False,
-            quant_config=quant_config,
-            disable_tp=is_sequence_parallel,
-            prefix=f"{prefix}.gate_up_proj",
-        )
-        self.down_proj = RowParallelLinear(
-            intermediate_size,
-            hidden_size,
-            bias=False,
-            quant_config=quant_config,
-            reduce_results=reduce_results,
-            disable_tp=is_sequence_parallel,
-            prefix=f"{prefix}.down_proj",
-        )
+        tp_size = get_tensor_model_parallel_world_size()
+        needs_padding = not is_sequence_parallel and intermediate_size % tp_size != 0
+        if needs_padding:
+            padded_intermediate_size = _ceil_to_multiple(
+                intermediate_size,
+                _dense_mlp_padded_intermediate_multiple(tp_size),
+            )
+            self.gate_up_proj = PaddedMergedColumnParallelLinear(
+                hidden_size,
+                [intermediate_size] * 2,
+                [padded_intermediate_size] * 2,
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.gate_up_proj",
+            )
+            self.down_proj = PaddedRowParallelLinear(
+                intermediate_size,
+                padded_intermediate_size,
+                hidden_size,
+                bias=False,
+                quant_config=quant_config,
+                reduce_results=reduce_results,
+                prefix=f"{prefix}.down_proj",
+            )
+        else:
+            self.gate_up_proj = MergedColumnParallelLinear(
+                hidden_size,
+                [intermediate_size] * 2,
+                bias=False,
+                quant_config=quant_config,
+                disable_tp=is_sequence_parallel,
+                prefix=f"{prefix}.gate_up_proj",
+            )
+            self.down_proj = RowParallelLinear(
+                intermediate_size,
+                hidden_size,
+                bias=False,
+                quant_config=quant_config,
+                reduce_results=reduce_results,
+                disable_tp=is_sequence_parallel,
+                prefix=f"{prefix}.down_proj",
+            )
         if hidden_act != "silu":
             raise ValueError(
                 f"Unsupported activation: {hidden_act}. Only silu is supported for now."

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -38,6 +38,9 @@ from vllm.distributed import (
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm as Qwen3_5RMSNorm
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.mamba.gdn.head_partition import (
+    make_gdn_head_partition,
+)
 from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
     QwenGatedDeltaNetAttention,
 )
@@ -532,6 +535,33 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
             if vllm_config.speculative_config
             else 0
         )
+        if (
+            hf_config.linear_num_key_heads % tp_size != 0
+            or hf_config.linear_num_value_heads % tp_size != 0
+        ):
+            partition = make_gdn_head_partition(
+                num_k_heads=hf_config.linear_num_key_heads,
+                num_v_heads=hf_config.linear_num_value_heads,
+                head_k_dim=hf_config.linear_key_head_dim,
+                head_v_dim=hf_config.linear_value_head_dim,
+                tp_size=tp_size,
+                tp_rank=0,
+            )
+            conv_state_shape = MambaStateShapeCalculator._orient_conv_shape(
+                partition.padded_conv_dim,
+                hf_config.linear_conv_kernel_dim - 1 + num_spec,
+            )
+            temporal_state_shape = (
+                partition.max_v_count,
+                hf_config.linear_value_head_dim,
+                hf_config.linear_key_head_dim,
+            )
+            return (
+                conv_state_shape,
+                temporal_state_shape,
+                conv_state_shape,
+                temporal_state_shape,
+            )
         return MambaStateShapeCalculator.gated_delta_net_state_shape(
             tp_size,
             hf_config.linear_num_key_heads,

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -412,13 +412,16 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
         # Qwen3.5 does not support multimodal pruning (EVS).
         self.is_multimodal_pruning_enabled = False
 
-        with self._mark_tower_model(vllm_config, {"image", "video"}):
-            self.visual = Qwen3_VisionTransformer(
-                config.vision_config,
-                norm_eps=getattr(config, "rms_norm_eps", 1e-6),
-                quant_config=quant_config,
-                prefix=maybe_prefix(prefix, "visual"),
-            )
+        if multimodal_config.language_model_only:
+            self.visual = None
+        else:
+            with self._mark_tower_model(vllm_config, {"image", "video"}):
+                self.visual = Qwen3_VisionTransformer(
+                    config.vision_config,
+                    norm_eps=getattr(config, "rms_norm_eps", 1e-6),
+                    quant_config=quant_config,
+                    prefix=maybe_prefix(prefix, "visual"),
+                )
 
         with self._mark_language_model(vllm_config):
             self.language_model = Qwen3_5ForCausalLM(
@@ -506,9 +509,12 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
         return hidden_states
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        skip_prefixes = ["mtp."]
+        if self.multimodal_config.language_model_only:
+            skip_prefixes.append("visual.")
         loader = AutoWeightsLoader(
             self,
-            skip_prefixes=["mtp."],
+            skip_prefixes=skip_prefixes,
         )
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -10,7 +10,12 @@ from torch import nn
 
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.compilation.decorators import support_torch_compile
-from vllm.config import CacheConfig, ModelConfig, VllmConfig
+from vllm.config import (
+    CacheConfig,
+    ModelConfig,
+    VllmConfig,
+    get_current_vllm_config_or_none,
+)
 from vllm.distributed import (
     get_ep_group,
     get_pp_group,
@@ -250,7 +255,22 @@ class Qwen3NextAttention(nn.Module):
             self.total_num_kv_heads % tp_size != 0
             and tp_size % self.total_num_kv_heads != 0
         )
-        if use_overlapping_gqa:
+        vllm_config = get_current_vllm_config_or_none()
+        dcp_size = (
+            vllm_config.parallel_config.decode_context_parallel_size
+            if vllm_config is not None
+            else 1
+        )
+        self.dcp_full_kv_attention_heads = use_overlapping_gqa and dcp_size > 1
+        if self.dcp_full_kv_attention_heads:
+            self.attn_head_partition = make_attention_head_partition(
+                total_num_heads=self.total_num_heads,
+                total_num_kv_heads=self.total_num_kv_heads,
+                tp_size=tp_size,
+                tp_rank=tp_rank,
+            )
+            self.num_kv_heads = self.total_num_kv_heads
+        elif use_overlapping_gqa:
             self.attn_head_partition = make_attention_head_partition(
                 total_num_heads=self.total_num_heads,
                 total_num_kv_heads=self.total_num_kv_heads,
@@ -268,6 +288,17 @@ class Qwen3NextAttention(nn.Module):
             # the KV heads across multiple tensor parallel GPUs.
             assert tp_size % self.total_num_kv_heads == 0
             self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        logger.info_once(
+            "Qwen full-attention layout: tp=%d dcp=%d q_heads=%d "
+            "kv_heads=%d overlapping_gqa=%s full_kv=%s local_kv_heads=%d",
+            tp_size,
+            dcp_size,
+            self.total_num_heads,
+            self.total_num_kv_heads,
+            use_overlapping_gqa,
+            self.dcp_full_kv_attention_heads,
+            self.num_kv_heads,
+        )
         self.head_dim = config.head_dim or (self.hidden_size // self.num_heads)
         self.q_size = self.num_heads * self.head_dim
         self.kv_size = self.num_kv_heads * self.head_dim
@@ -279,11 +310,13 @@ class Qwen3NextAttention(nn.Module):
 
         qkv_proj_cls = (
             QKVParallelLinearOverlappingGQA
-            if use_overlapping_gqa
+            if use_overlapping_gqa or self.dcp_full_kv_attention_heads
             else QKVParallelLinear
         )
         qkv_kwargs = {}
-        if self.attn_head_partition is not None:
+        if self.dcp_full_kv_attention_heads:
+            qkv_kwargs["kv_head_indices"] = tuple(range(self.total_num_kv_heads))
+        elif self.attn_head_partition is not None:
             qkv_kwargs["kv_head_indices"] = self.attn_head_partition.kv_head_indices
         self.qkv_proj = qkv_proj_cls(
             config.hidden_size,
@@ -336,6 +369,12 @@ class Qwen3NextAttention(nn.Module):
             if self.dual_chunk_attention_config
             else {},
         )
+        self.attn.dcp_full_kv_attention_heads = self.dcp_full_kv_attention_heads
+        if self.dcp_full_kv_attention_heads:
+            assert self.attn_head_partition is not None
+            self.attn.dcp_local_kv_head_indices = (
+                self.attn_head_partition.kv_head_indices
+            )
 
         self.q_norm = Qwen3NextRMSNorm(self.head_dim, eps=config.rms_norm_eps)
         self.k_norm = Qwen3NextRMSNorm(self.head_dim, eps=config.rms_norm_eps)

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -14,11 +14,15 @@ from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.distributed import (
     get_ep_group,
     get_pp_group,
+    get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_gather,
 )
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.attention.head_partition import (
+    make_attention_head_partition,
+)
 from vllm.model_executor.layers.fused_moe import (
     FusedMoE,
 )
@@ -28,6 +32,7 @@ from vllm.model_executor.layers.layernorm import (
 )
 from vllm.model_executor.layers.linear import (
     QKVParallelLinear,
+    QKVParallelLinearOverlappingGQA,
     ReplicatedLinear,
     RowParallelLinear,
 )
@@ -235,19 +240,34 @@ class Qwen3NextAttention(nn.Module):
         self.config = config
         self.hidden_size = config.hidden_size
         tp_size = get_tensor_model_parallel_world_size()
+        tp_rank = get_tensor_model_parallel_rank()
         self.total_num_heads = config.num_attention_heads
         assert self.total_num_heads % tp_size == 0
         self.num_heads = self.total_num_heads // tp_size
         self.total_num_kv_heads = config.num_key_value_heads
-        if self.total_num_kv_heads >= tp_size:
+        self.attn_head_partition = None
+        use_overlapping_gqa = (
+            self.total_num_kv_heads % tp_size != 0
+            and tp_size % self.total_num_kv_heads != 0
+        )
+        if use_overlapping_gqa:
+            self.attn_head_partition = make_attention_head_partition(
+                total_num_heads=self.total_num_heads,
+                total_num_kv_heads=self.total_num_kv_heads,
+                tp_size=tp_size,
+                tp_rank=tp_rank,
+            )
+            self.num_kv_heads = self.attn_head_partition.num_kv_heads
+        elif self.total_num_kv_heads >= tp_size:
             # Number of KV heads is greater than TP size, so we partition
             # the KV heads across multiple tensor parallel GPUs.
             assert self.total_num_kv_heads % tp_size == 0
+            self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
         else:
             # Number of KV heads is less than TP size, so we replicate
             # the KV heads across multiple tensor parallel GPUs.
             assert tp_size % self.total_num_kv_heads == 0
-        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+            self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
         self.head_dim = config.head_dim or (self.hidden_size // self.num_heads)
         self.q_size = self.num_heads * self.head_dim
         self.kv_size = self.num_kv_heads * self.head_dim
@@ -257,7 +277,15 @@ class Qwen3NextAttention(nn.Module):
         )
         self.attn_output_gate = getattr(config, "attn_output_gate", True)
 
-        self.qkv_proj = QKVParallelLinear(
+        qkv_proj_cls = (
+            QKVParallelLinearOverlappingGQA
+            if use_overlapping_gqa
+            else QKVParallelLinear
+        )
+        qkv_kwargs = {}
+        if self.attn_head_partition is not None:
+            qkv_kwargs["kv_head_indices"] = self.attn_head_partition.kv_head_indices
+        self.qkv_proj = qkv_proj_cls(
             config.hidden_size,
             self.head_dim,
             self.total_num_heads * (1 + self.attn_output_gate),
@@ -265,6 +293,7 @@ class Qwen3NextAttention(nn.Module):
             bias=getattr(config, "qkv_bias", False),
             quant_config=quant_config,
             prefix=f"{prefix}.qkv_proj",
+            **qkv_kwargs,
         )
 
         self.o_proj = RowParallelLinear(
@@ -766,6 +795,11 @@ class Qwen3NextForCausalLM(
         parallel_config = vllm_config.parallel_config
         hf_config = vllm_config.model_config.hf_text_config
         tp_size = parallel_config.tensor_parallel_size
+        if (
+            hf_config.linear_num_key_heads % tp_size != 0
+            or hf_config.linear_num_value_heads % tp_size != 0
+        ):
+            tp_size = 1
         num_spec = (
             vllm_config.speculative_config.num_speculative_tokens
             if vllm_config.speculative_config

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -61,6 +61,8 @@ from vllm.model_executor.layers.attention.mm_encoder_attention import (
 from vllm.model_executor.layers.conv import Conv3dLayer
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
+    PaddedMergedColumnParallelLinear,
+    PaddedRowParallelLinear,
     RowParallelLinear,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -121,6 +123,7 @@ from .qwen2_5_vl import (
     Qwen2_5_VLVideoEmbeddingInputs,
     Qwen2_5_VLVideoInputs,
     Qwen2_5_VLVideoPixelInputs,
+    _pad_to_tp,
 )
 from .qwen2_vl import (
     Qwen2VLMultiModalDataParser,
@@ -385,24 +388,50 @@ class Qwen3_VisionMLP(nn.Module):
     ):
         super().__init__()
         use_data_parallel = is_vit_use_data_parallel()
-        self.linear_fc1 = ColumnParallelLinear(
-            in_features,
-            hidden_features,
-            bias=bias,
-            quant_config=quant_config,
-            return_bias=False,
-            prefix=f"{prefix}.linear_fc1",
-            disable_tp=use_data_parallel,
+        tp_size = (
+            1
+            if use_data_parallel
+            else parallel_state.get_tensor_model_parallel_world_size()
         )
-        self.linear_fc2 = RowParallelLinear(
-            hidden_features,
-            in_features,
-            bias=bias,
-            quant_config=quant_config,
-            return_bias=False,
-            prefix=f"{prefix}.linear_fc2",
-            disable_tp=use_data_parallel,
-        )
+        padded_hidden_features = _pad_to_tp(hidden_features, tp_size)
+        if padded_hidden_features == hidden_features:
+            self.linear_fc1 = ColumnParallelLinear(
+                in_features,
+                hidden_features,
+                bias=bias,
+                quant_config=quant_config,
+                return_bias=False,
+                prefix=f"{prefix}.linear_fc1",
+                disable_tp=use_data_parallel,
+            )
+            self.linear_fc2 = RowParallelLinear(
+                hidden_features,
+                in_features,
+                bias=bias,
+                quant_config=quant_config,
+                return_bias=False,
+                prefix=f"{prefix}.linear_fc2",
+                disable_tp=use_data_parallel,
+            )
+        else:
+            self.linear_fc1 = PaddedMergedColumnParallelLinear(
+                input_size=in_features,
+                output_sizes=[hidden_features],
+                padded_output_sizes=[padded_hidden_features],
+                bias=bias,
+                quant_config=quant_config,
+                return_bias=False,
+                prefix=f"{prefix}.linear_fc1",
+            )
+            self.linear_fc2 = PaddedRowParallelLinear(
+                input_size=hidden_features,
+                padded_input_size=padded_hidden_features,
+                output_size=in_features,
+                bias=bias,
+                quant_config=quant_config,
+                return_bias=False,
+                prefix=f"{prefix}.linear_fc2",
+            )
         self.act_fn = act_fn
 
     def forward(self, x: torch.Tensor):

--- a/vllm/model_executor/warmup/qwen_triton_warmup.py
+++ b/vllm/model_executor/warmup/qwen_triton_warmup.py
@@ -123,8 +123,12 @@ def _qwen_gdn_warmup_config(
             conv_cache if is_conv_state_dim_first() else conv_cache.transpose(-1, -2)
         )
         tp_size = int(layer.tp_size)
-        h = int(layer.num_k_heads) // tp_size
-        hv = int(layer.num_v_heads) // tp_size
+        h = int(
+            getattr(layer, "padded_local_num_k_heads", layer.num_k_heads // tp_size)
+        )
+        hv = int(
+            getattr(layer, "padded_local_num_v_heads", layer.num_v_heads // tp_size)
+        )
 
         return _QwenGDNWarmupConfig(
             h=h,

--- a/vllm/parser/qwen3.py
+++ b/vllm/parser/qwen3.py
@@ -16,12 +16,18 @@ The ``_qwen3_arg_converter`` parses these into a JSON object.
 
 from __future__ import annotations
 
+import ast
 import functools
 import json
 from typing import TYPE_CHECKING
 
 import regex as re
 
+from vllm.entrypoints.openai.engine.protocol import (
+    ExtractedToolCallInformation,
+    FunctionCall,
+    ToolCall,
+)
 from vllm.parser.engine.events import EventType
 from vllm.parser.engine.parser_engine import ParserEngine
 from vllm.parser.engine.parser_engine_config import (
@@ -43,7 +49,12 @@ THINK_END = "</think>"
 TOOL_CALL_START = "<tool_call>"
 TOOL_CALL_END = "</tool_call>"
 FUNC_PREFIX = "<function="
+FUNC_PREFIX_IMSTART_QUOTED = '<|im_start|>="'
+FUNC_PREFIX_IMSTART_FUNCTION = "<|im_start|>function="
+FUNC_PREFIX_BARE_EQ = "="
 FUNC_END = "</function>"
+FUNC_NAME_QUOTE_END = '"'
+FUNC_NAME_NEWLINE_END = "\n"
 PARAM_START = "<parameter="
 PARAM_END = "</parameter>"
 
@@ -54,24 +65,56 @@ _PARAM_RE = re.compile(
     re.DOTALL,
 )
 _PARTIAL_PARAM_RE = re.compile(r"<\s*parameter\s*=\s*([^>]+)>(.*)$", re.DOTALL)
+_DEFAULT_API_CALL_RE = re.compile(
+    r"call:\s*default_api:([A-Za-z_][A-Za-z0-9_]*)\s*(\{.*?\})",
+    re.DOTALL,
+)
+_JSON_OBJECT_START_RE = re.compile(r"\{")
+
+
+def _strip_wrapping_quotes(value: str, *, partial: bool = False) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    if partial and value:
+        if value[0] in ("'", '"'):
+            value = value[1:]
+        if value and value[-1] in ("'", '"'):
+            value = value[:-1]
+    return value
 
 
 def _qwen3_arg_converter(raw_args: str, partial: bool) -> str:
+    stripped = raw_args.strip()
+    if stripped.startswith("{") and (not partial or stripped.endswith("}")):
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            try:
+                parsed = ast.literal_eval(stripped)
+            except (SyntaxError, ValueError):
+                parsed = None
+        if isinstance(parsed, dict):
+            return json.dumps(
+                {str(k): v for k, v in parsed.items()},
+                ensure_ascii=False,
+            )
+
     params: dict[str, object] = {}
 
     for match in _PARAM_RE.finditer(raw_args):
-        name = match.group(1)
-        value = match.group(2)
-        params[name] = value.strip()
+        name = _strip_wrapping_quotes(match.group(1))
+        value = _strip_wrapping_quotes(match.group(2), partial=partial)
+        params[name] = value
 
     if partial:
         remaining = _PARAM_RE.sub("", raw_args)
         m = _PARTIAL_PARAM_RE.search(remaining)
         if m:
-            name = m.group(1)
-            value = m.group(2)
+            name = _strip_wrapping_quotes(m.group(1))
+            value = _strip_wrapping_quotes(m.group(2), partial=partial)
             if name:
-                params[name] = value.strip()
+                params[name] = value
 
     return json.dumps(params, ensure_ascii=False)
 
@@ -97,7 +140,12 @@ def qwen3_config(
             "TOOL_START": tool_start,
             "TOOL_END": tool_end,
             "FUNC_PREFIX": FUNC_PREFIX,
+            "FUNC_PREFIX_IMSTART_QUOTED": FUNC_PREFIX_IMSTART_QUOTED,
+            "FUNC_PREFIX_IMSTART_FUNCTION": FUNC_PREFIX_IMSTART_FUNCTION,
+            "FUNC_PREFIX_BARE_EQ": FUNC_PREFIX_BARE_EQ,
             "FUNC_END": FUNC_END,
+            "FUNC_NAME_QUOTE_END": FUNC_NAME_QUOTE_END,
+            "FUNC_NAME_NEWLINE_END": FUNC_NAME_NEWLINE_END,
             "PARAM_START": PARAM_START,
             "PARAM_END": PARAM_END,
             "CLOSE_ANGLE": ">",
@@ -108,6 +156,7 @@ def qwen3_config(
             "TOOL_START": tool_start,
             "TOOL_END": tool_end,
         },
+        preserve_tokens=frozenset({"<|im_start|>"}),
         transitions={
             # -- Reasoning transitions --
             (ParserState.REASONING, "THINK_START"): Transition(
@@ -147,9 +196,36 @@ def qwen3_config(
                 ParserState.TOOL_NAME,
                 (),
             ),
+            # Some Qwen3.6 checkpoints occasionally emit malformed auto
+            # tool-call function openers while still producing valid parameter
+            # XML. Accept the observed variants only after <tool_call>.
+            (ParserState.TOOL_PREAMBLE, "FUNC_PREFIX_IMSTART_QUOTED"): Transition(
+                ParserState.TOOL_NAME,
+                (),
+            ),
+            (ParserState.TOOL_PREAMBLE, "FUNC_PREFIX_IMSTART_FUNCTION"): Transition(
+                ParserState.TOOL_NAME,
+                (),
+            ),
+            (ParserState.TOOL_PREAMBLE, "FUNC_PREFIX_BARE_EQ"): Transition(
+                ParserState.TOOL_NAME,
+                (),
+            ),
             (ParserState.TOOL_NAME, "CLOSE_ANGLE"): Transition(
                 ParserState.TOOL_ARGS,
                 (),
+            ),
+            (ParserState.TOOL_NAME, "FUNC_NAME_QUOTE_END"): Transition(
+                ParserState.TOOL_ARGS,
+                (),
+            ),
+            (ParserState.TOOL_NAME, "FUNC_NAME_NEWLINE_END"): Transition(
+                ParserState.TOOL_ARGS,
+                (),
+            ),
+            (ParserState.TOOL_NAME, "PARAM_START"): Transition(
+                ParserState.TOOL_ARGS,
+                (EventType.ARG_VALUE_CHUNK,),
             ),
             # Malformed: </function> while still in TOOL_NAME (no closing >)
             (ParserState.TOOL_NAME, "FUNC_END"): Transition(
@@ -243,6 +319,104 @@ class Qwen3Parser(ParserEngine):
         if not self.thinking_enabled:
             return None, model_output
         return super().extract_reasoning(model_output, request)
+
+    def extract_tool_calls_from_content(
+        self,
+        content: str,
+        request: ChatCompletionRequest,
+    ) -> ExtractedToolCallInformation:
+        result = super().extract_tool_calls_from_content(content, request)
+        if result.tools_called:
+            return result
+
+        tool_calls: list[ToolCall] = []
+        content_parts: list[str] = []
+        pos = 0
+        for match in _DEFAULT_API_CALL_RE.finditer(content):
+            name = match.group(1)
+            args = match.group(2)
+            try:
+                args_json = _qwen3_arg_converter(args, partial=False)
+            except (json.JSONDecodeError, ValueError, TypeError):
+                continue
+            content_parts.append(content[pos : match.start()])
+            pos = match.end()
+            tool_calls.append(
+                ToolCall(
+                    type="function",
+                    function=FunctionCall(name=name, arguments=args_json),
+                )
+            )
+
+        if not tool_calls:
+            json_fallback = self._extract_json_tool_call_objects(content)
+            if json_fallback is not None:
+                return json_fallback
+            return result
+
+        content_parts.append(content[pos:])
+        fallback_content = "".join(content_parts).strip() or None
+        return ExtractedToolCallInformation(
+            tools_called=True,
+            tool_calls=tool_calls,
+            content=fallback_content,
+        )
+
+    def _extract_json_tool_call_objects(
+        self,
+        content: str,
+    ) -> ExtractedToolCallInformation | None:
+        decoder = json.JSONDecoder()
+        tool_calls: list[ToolCall] = []
+        spans: list[tuple[int, int]] = []
+        search_pos = 0
+
+        while True:
+            match = _JSON_OBJECT_START_RE.search(content, search_pos)
+            if match is None:
+                break
+            start = match.start()
+            try:
+                obj, end_offset = decoder.raw_decode(content[start:])
+            except json.JSONDecodeError:
+                search_pos = start + 1
+                continue
+            end = start + end_offset
+            search_pos = end
+
+            if not isinstance(obj, dict):
+                continue
+            name = obj.get("tool") or obj.get("name")
+            args = obj.get("arguments") or obj.get("parameters")
+            if not isinstance(name, str) or not isinstance(args, dict):
+                continue
+
+            tool_calls.append(
+                ToolCall(
+                    type="function",
+                    function=FunctionCall(
+                        name=name,
+                        arguments=json.dumps(args, ensure_ascii=False),
+                    ),
+                )
+            )
+            spans.append((start, end))
+
+        if not tool_calls:
+            return None
+
+        content_parts: list[str] = []
+        pos = 0
+        for start, end in spans:
+            content_parts.append(content[pos:start])
+            pos = end
+        content_parts.append(content[pos:])
+        fallback_content = "".join(content_parts).strip() or None
+        return ExtractedToolCallInformation(
+            tools_called=True,
+            tool_calls=tool_calls,
+            content=fallback_content,
+        )
 
     def is_reasoning_end(self, input_ids: list[int]) -> bool:
         if super().is_reasoning_end(input_ids):

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -91,6 +91,50 @@ logger = init_logger(__name__)
 trtllm_workspace_buffer = None
 
 
+def _flashinfer_seq_lens_and_blocks_for_paged_kv(
+    seq_lens_cpu: torch.Tensor,
+    qo_indptr_cpu: torch.Tensor,
+    num_decodes: int,
+    num_prefills: int,
+    page_size: int,
+    *,
+    use_dcp: bool,
+    dcp_world_size: int,
+    dcp_rank: int,
+    dcp_kv_cache_interleave_size: int,
+) -> tuple[torch.Tensor, np.ndarray, np.ndarray]:
+    """Return FlashInfer paged-KV lengths after context/DCP localization.
+
+    ``CommonAttentionMetadata.seq_lens`` includes the scheduled query tokens.
+    Native FlashInfer DCP prefill has two phases: attend over the previously
+    cached context with paged KV, then attend over the new ragged KV tokens.
+    Therefore the paged-KV metadata must be computed from context lengths, and
+    when DCP is enabled those context lengths must be localized before deriving
+    page counts and last-page lengths.
+    """
+    localized_seq_lens_cpu = seq_lens_cpu.clone()
+    if use_dcp:
+        if num_prefills > 0:
+            qo_indptr_prefill_cpu = (
+                qo_indptr_cpu[num_decodes:] - qo_indptr_cpu[num_decodes]
+            )
+            query_lens_prefill_cpu = (
+                qo_indptr_prefill_cpu[1:] - qo_indptr_prefill_cpu[:-1]
+            )
+            localized_seq_lens_cpu[num_decodes:] -= query_lens_prefill_cpu
+
+        localized_seq_lens_cpu = get_dcp_local_seq_lens(
+            localized_seq_lens_cpu,
+            dcp_world_size,
+            dcp_rank,
+            dcp_kv_cache_interleave_size,
+        )
+
+    seq_lens_np = localized_seq_lens_cpu.numpy()
+    num_blocks_np = (seq_lens_np + (page_size - 1)) // page_size
+    return localized_seq_lens_cpu, seq_lens_np, num_blocks_np
+
+
 def _get_trtllm_workspace_buffer():
     global trtllm_workspace_buffer
     if trtllm_workspace_buffer is None:
@@ -1014,6 +1058,15 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
         Returns paged_kv_indices, a GPU tensor with shape [num_actual_pages].
         """
+        max_num_blocks = int(num_blocks_np.max(initial=0))
+        if max_num_blocks > block_table_tensor.shape[1]:
+            raise ValueError(
+                "FlashInfer paged-KV metadata requires more pages than the "
+                "block table provides: "
+                f"max_num_blocks={max_num_blocks}, "
+                f"block_table_width={block_table_tensor.shape[1]}, "
+                f"page_size={page_size}, num_reqs={num_reqs}."
+            )
         # write self.paged_kv_indptr_cpu inplace (0-index is always 0)
         np.cumsum(
             num_blocks_np,
@@ -1174,33 +1227,25 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # (block_tables, seq_lens) directly.
         needs_seq_lens_cpu = self.use_dcp or use_cascade or not all_uses_trtllm
         seq_lens_cpu = common_attn_metadata.seq_lens_cpu if needs_seq_lens_cpu else None
-        seq_lens_np = seq_lens_cpu.numpy() if seq_lens_cpu is not None else None
-        num_blocks_np = (
-            (seq_lens_np + (page_size - 1)) // page_size
-            if seq_lens_np is not None
-            else None
-        )
-
-        # Adjust seq_lens_cpu for DCP
-        if self.use_dcp:
-            assert seq_lens_cpu is not None
-            if num_prefills > 0:
-                qo_indptr_prefill_cpu = (
-                    qo_indptr_cpu[num_decodes:] - qo_indptr_cpu[num_decodes]
-                )
-                query_lens_prefill_cpu = (
-                    qo_indptr_prefill_cpu[1:] - qo_indptr_prefill_cpu[:-1]
-                )
-                seq_lens_cpu[num_decodes:] = (
-                    seq_lens_cpu[num_decodes:] - query_lens_prefill_cpu
-                )
-
-            seq_lens_cpu = get_dcp_local_seq_lens(
+        if seq_lens_cpu is not None:
+            (
                 seq_lens_cpu,
-                self.dcp_world_size,
-                self.dcp_rank,
-                self.dcp_kv_cache_interleave_size,
+                seq_lens_np,
+                num_blocks_np,
+            ) = _flashinfer_seq_lens_and_blocks_for_paged_kv(
+                seq_lens_cpu,
+                qo_indptr_cpu,
+                num_decodes,
+                num_prefills,
+                page_size,
+                use_dcp=self.use_dcp,
+                dcp_world_size=self.dcp_world_size,
+                dcp_rank=self.dcp_rank,
+                dcp_kv_cache_interleave_size=self.dcp_kv_cache_interleave_size,
             )
+        else:
+            seq_lens_np = None
+            num_blocks_np = None
 
         # Adjust num_block_np for cascade attention
         if use_cascade:

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -353,6 +353,26 @@ class BatchDCPPrefillWrapper:
         )
         lse_context = lse_context.transpose(0, 1).contiguous()
 
+        if getattr(layer, "dcp_full_kv_attention_heads", False):
+            local_kv_head_indices = getattr(
+                layer, "dcp_local_kv_head_indices", None
+            )
+            if local_kv_head_indices is None:
+                raise ValueError(
+                    "DCP full-KV attention requires local KV head indices."
+                )
+            local_kv_head_indices_tensor = torch.tensor(
+                local_kv_head_indices,
+                device=key.device,
+                dtype=torch.long,
+            )
+            key = torch.index_select(
+                key, dim=1, index=local_kv_head_indices_tensor
+            )
+            value = torch.index_select(
+                value, dim=1, index=local_kv_head_indices_tensor
+            )
+
         output_query, lse_query = self._new_tokens.run(
             prefill_query,
             key,

--- a/vllm/v1/attention/ops/common.py
+++ b/vllm/v1/attention/ops/common.py
@@ -4,6 +4,7 @@ import torch
 
 from vllm.distributed.parallel_state import GroupCoordinator
 from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import next_power_of_2
 
 
 @triton.jit
@@ -20,6 +21,7 @@ def _correct_attn_cp_out_kernel(
     lses_stride_H,
     lse_idx,
     HEAD_DIM: tl.constexpr,
+    N: tl.constexpr,
     N_ROUNDED: tl.constexpr,
     IS_BASE_E: tl.constexpr,
 ):
@@ -51,7 +53,7 @@ def _correct_attn_cp_out_kernel(
     )
 
     # calc final lse
-    lse = tl.load(lses_ptr + lse_offsets)
+    lse = tl.load(lses_ptr + lse_offsets, mask=num_n_offsets < N, other=-float("inf"))
     lse = tl.where((lse != lse) | (lse == float("inf")), -float("inf"), lse)
     lse_max = tl.max(lse, axis=0)
     lse_max = tl.where(lse_max == -float("inf"), 0, lse_max)
@@ -174,7 +176,12 @@ def correct_attn_out(
         l_sH,
         cp_rank,
     )
-    const_args = {"HEAD_DIM": D, "N_ROUNDED": N, "IS_BASE_E": is_lse_base_on_e}
+    const_args = {
+        "HEAD_DIM": D,
+        "N": N,
+        "N_ROUNDED": next_power_of_2(N),
+        "IS_BASE_E": is_lse_base_on_e,
+    }
     ctx.call_kernel(_correct_attn_cp_out_kernel, grid, *regular_args, **const_args)
     return out, lse
 

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -551,6 +551,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         # can be a multiple of hash_block_size.
         self.hash_block_size = hash_block_size
         self.dcp_world_size = dcp_world_size
+        self.pcp_world_size = pcp_world_size
         group_block_sizes = [
             manager.block_size for manager in self.single_type_managers
         ]
@@ -667,11 +668,15 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 - The number of tokens of the longest cache hit.
         """
 
-        def _get_block_hashes(block_size: int) -> BlockHashList:
-            if block_size == self.hash_block_size:
+        def _effective_block_size(kv_cache_spec: KVCacheSpec) -> int:
+            return kv_cache_spec.block_size * self.dcp_world_size * self.pcp_world_size
+
+        def _get_block_hashes(kv_cache_spec: KVCacheSpec) -> BlockHashList:
+            effective_block_size = _effective_block_size(kv_cache_spec)
+            if effective_block_size == self.hash_block_size:
                 return block_hashes
             return BlockHashListWithBlockSize(
-                block_hashes, self.hash_block_size, block_size
+                block_hashes, self.hash_block_size, effective_block_size
             )
 
         num_groups = len(self.kv_cache_config.kv_cache_groups)
@@ -696,7 +701,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             for idx, (spec, group_ids, manager_cls, use_eagle) in enumerate(
                 self.attention_groups
             ):
-                group_block_size = self.single_type_managers[group_ids[0]].block_size
+                group_block_size = _effective_block_size(spec)
                 cached_blocks = hit_blocks_by_group[group_ids[0]]
                 if isinstance(spec, FullAttentionSpec) and cached_blocks is not None:
                     # Full attention is downward-closed: we only need to look
@@ -716,18 +721,15 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                         curr_hit_length + group_block_size, max_cache_hit_length
                     )
                 hit_blocks = manager_cls.find_longest_cache_hit(
-                    block_hashes=_get_block_hashes(group_block_size),
+                    block_hashes=_get_block_hashes(spec),
                     max_length=_max_length,
                     kv_cache_group_ids=group_ids,
                     block_pool=self.block_pool,
                     kv_cache_spec=spec,
                     drop_eagle_block=drop_eagle_block,
                     alignment_tokens=self.scheduler_block_size,
-                    dcp_world_size=(
-                        self.dcp_world_size
-                        if isinstance(spec, FullAttentionSpec)
-                        else 1
-                    ),
+                    dcp_world_size=self.dcp_world_size,
+                    pcp_world_size=self.pcp_world_size,
                 )
                 _new_hit_length = len(hit_blocks[0]) * group_block_size
                 if drop_eagle_block:
@@ -750,9 +752,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         # Truncate full attention blocks to final hit_length (if present)
         first_group = self.attention_groups[0]
         if isinstance(first_group.spec, FullAttentionSpec):
-            group_block_size = self.single_type_managers[
-                first_group.group_ids[0]
-            ].block_size
+            group_block_size = _effective_block_size(first_group.spec)
             num_blocks = hit_length // group_block_size
             for group_id in first_group.group_ids:
                 if (blks := hit_blocks_by_group[group_id]) is not None:
@@ -776,11 +776,15 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             (blocks_per_group, hit_lengths_per_group)
         """
 
+        def _effective_block_size(kv_cache_spec: KVCacheSpec) -> int:
+            return kv_cache_spec.block_size * self.dcp_world_size * self.pcp_world_size
+
         def _get_block_hashes(kv_cache_spec: KVCacheSpec) -> BlockHashList:
-            if kv_cache_spec.block_size == self.hash_block_size:
+            effective_block_size = _effective_block_size(kv_cache_spec)
+            if effective_block_size == self.hash_block_size:
                 return block_hashes
             return BlockHashListWithBlockSize(
-                block_hashes, self.hash_block_size, kv_cache_spec.block_size
+                block_hashes, self.hash_block_size, effective_block_size
             )
 
         num_groups = len(self.kv_cache_config.kv_cache_groups)
@@ -796,8 +800,10 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 kv_cache_spec=spec,
                 drop_eagle_block=use_eagle,
                 alignment_tokens=self.scheduler_block_size,
+                dcp_world_size=self.dcp_world_size,
+                pcp_world_size=self.pcp_world_size,
             )
-            group_hit = len(blocks[0]) * spec.block_size
+            group_hit = len(blocks[0]) * _effective_block_size(spec)
             for gid, blks in zip(group_ids, blocks):
                 hit_blocks[gid] = blks
                 hit_lengths[gid] = group_hit

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -627,8 +627,7 @@ def resolve_kv_cache_block_sizes(
     - ``scheduler_block_size`` is the token-alignment invariant used by the
       scheduler (e.g. for ``num_computed_tokens`` rounding). Single group:
       ``cache_config.block_size * dcp * pcp``. Multiple groups: LCM of every
-      group's effective block size. Attention groups are scaled by DCP/PCP;
-      Mamba groups keep their full per-rank state and are not scaled.
+      group's block size, scaled by the context-parallel world size.
     - ``hash_block_size`` is the granularity at which ``Request.block_hashes``
       is computed. Single group: equals scheduler block size. Multiple groups:
       ``cache_config.hash_block_size`` override if set, else the GCD of group
@@ -646,13 +645,8 @@ def resolve_kv_cache_block_sizes(
         bs = cache_config.block_size * dcp * pcp
         return bs, bs
 
-    group_block_sizes = [
-        g.kv_cache_spec.block_size * dcp * pcp
-        if isinstance(g.kv_cache_spec, AttentionSpec)
-        else g.kv_cache_spec.block_size
-        for g in groups
-    ]
-    scheduler_block_size = math.lcm(*group_block_sizes)
+    group_block_sizes = [g.kv_cache_spec.block_size for g in groups]
+    scheduler_block_size = math.lcm(*group_block_sizes) * dcp * pcp
 
     # Block hashes are only consumed by prefix caching and KV connectors
     # (P/D, offloading); when neither is active, keep hash_block_size equal

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
+import math
 import time
 from collections import defaultdict, deque
 from collections.abc import Iterable
@@ -362,7 +363,15 @@ class Scheduler(SchedulerInterface):
             # Additionally, when Eagle mode is enabled, FullAttn prunes the last
             # matching block. To prevent this from causing a Mamba cache miss, the
             # last chunk must be not smaller than `block_size`.
-            block_size = self.cache_config.block_size
+            block_size = getattr(self, "block_size", self.cache_config.block_size)
+            dcp_world_size = getattr(self, "dcp_world_size", 1)
+            if dcp_world_size > 1:
+                block_size = math.lcm(
+                    block_size,
+                    self.cache_config.block_size * dcp_world_size,
+                )
+            if num_new_tokens < block_size:
+                return num_new_tokens
             last_cache_position = request.num_tokens - request.num_tokens % block_size
             # eagle prune
             if self.use_eagle:

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1061,13 +1061,11 @@ class MambaManager(SingleTypeKVCacheManager):
         assert isinstance(kv_cache_spec, MambaSpec), (
             "MambaManager can only be used for mamba groups"
         )
-        assert dcp_world_size == 1, "DCP not support mamba now."
-        assert pcp_world_size == 1, "PCP not support mamba now."
         computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
             [] for _ in range(len(kv_cache_group_ids))
         )
 
-        block_size = kv_cache_spec.block_size
+        block_size = kv_cache_spec.block_size * dcp_world_size * pcp_world_size
         max_num_blocks = max_length // block_size
         # Search from right to left and early stop when a match is found.
         for i in range(max_num_blocks - 1, -1, -1):

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6399,6 +6399,31 @@ class GPUModelRunner(
         self.encoder_cache.clear()
         gc.collect()
 
+    @staticmethod
+    def _get_minimal_kv_cache_blocks_for_cudagraph_profiling(
+        kv_cache_groups: list[KVCacheGroupSpec],
+        max_capture_tokens: int | None,
+        max_num_reqs: int,
+        cp_size: int,
+    ) -> tuple[int, bool]:
+        if max_capture_tokens is None:
+            return 1, False
+
+        block_requirements: list[int] = []
+        has_mamba_cache = False
+        for group in kv_cache_groups:
+            kv_cache_spec = group.kv_cache_spec
+            if isinstance(kv_cache_spec, EncoderOnlyAttentionSpec):
+                continue
+            if isinstance(kv_cache_spec, MambaSpec):
+                has_mamba_cache = True
+                block_requirements.append(max_num_reqs)
+            else:
+                block_requirements.append(
+                    cdiv(max_capture_tokens, kv_cache_spec.block_size * cp_size)
+                )
+        return max(1, *block_requirements), has_mamba_cache
+
     def _init_minimal_kv_cache_for_profiling(self) -> None:
         from vllm.v1.core.kv_cache_utils import (
             get_kv_cache_config_from_groups,
@@ -6408,7 +6433,25 @@ class GPUModelRunner(
         kv_cache_spec = self.get_kv_cache_spec()
         KVCacheSpecRegistry.check_kv_cache_spec_registry(kv_cache_spec)
         kv_cache_groups = get_kv_cache_groups(self.vllm_config, kv_cache_spec)
-        min_blocks = self.compilation_config.max_cudagraph_capture_size or 1
+        max_capture_tokens = self.compilation_config.max_cudagraph_capture_size
+        cp_size = get_total_cp_world_size()
+        min_blocks, has_mamba_cache = (
+            self._get_minimal_kv_cache_blocks_for_cudagraph_profiling(
+                kv_cache_groups,
+                max_capture_tokens,
+                self.max_num_reqs,
+                cp_size,
+            )
+        )
+        if max_capture_tokens is not None:
+            logger.info(
+                "Using %d KV blocks for CUDA graph profiling "
+                "(max_capture_tokens=%d, cp_size=%d, has_mamba_cache=%s)",
+                min_blocks,
+                max_capture_tokens,
+                cp_size,
+                has_mamba_cache,
+            )
 
         # Temporarily change num_gpu_blocks_override to allocate a minimal KV cache
         saved_override = self.cache_config.num_gpu_blocks_override

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4353,6 +4353,7 @@ class GPUModelRunner(
                 ubatch_slices=ubatch_slices_padded,
                 slot_mapping=slot_mappings,
                 skip_compiled=has_encoder_input,
+                num_tokens_unpadded=num_tokens_unpadded,
             ),
             record_function_or_nullcontext("gpu_model_runner: forward"),
             self.maybe_get_kv_connector_output(
@@ -5596,29 +5597,38 @@ class GPUModelRunner(
             # then there is prompt logprob generated for each index.
             req_idx = self.input_batch.req_id_to_index[req_id]
             offset = self.query_start_loc.np[req_idx].item()
-            prompt_hidden_states = hidden_states[offset : offset + num_logits]
-            logits = self.model.compute_logits(prompt_hidden_states)
+            # Logits and FP32 log-softmax are [tokens, vocab]. Bound their peak
+            # memory independently of the scheduler's prefill chunk size.
+            max_logits_per_chunk = 64
+            for local_start in range(0, num_logits, max_logits_per_chunk):
+                local_end = min(local_start + max_logits_per_chunk, num_logits)
+                prompt_hidden_states = hidden_states[
+                    offset + local_start : offset + local_end
+                ]
+                logits = self.model.compute_logits(prompt_hidden_states)
 
-            # Get the "target" tokens for each index. For prompt at index i,
-            # the token at prompt index i+1 is the "sampled" token we want
-            # to gather the logprob for.
-            tgt_token_ids = prompt_token_ids[start_tok : start_tok + num_logits]
+                # For prompt index i, i+1 is the target token whose logprob and
+                # rank are returned.
+                tgt_token_ids = prompt_token_ids[
+                    start_tok + local_start : start_tok + local_end
+                ]
+                logprobs = self.sampler.compute_logprobs(logits)
+                token_ids, logprobs, ranks, _ = self.sampler.gather_logprobs(
+                    logprobs, num_prompt_logprobs, tgt_token_ids
+                )
 
-            # Compute prompt logprobs.
-            logprobs = self.sampler.compute_logprobs(logits)
-            token_ids, logprobs, ranks, _ = self.sampler.gather_logprobs(
-                logprobs, num_prompt_logprobs, tgt_token_ids
-            )
-
-            # Transfer GPU->CPU async.
-            chunk_slice = slice(start_idx, start_idx + num_logits)
-            logprobs_tensors.logprob_token_ids[chunk_slice].copy_(
-                token_ids, non_blocking=True
-            )
-            logprobs_tensors.logprobs[chunk_slice].copy_(logprobs, non_blocking=True)
-            logprobs_tensors.selected_token_ranks[chunk_slice].copy_(
-                ranks, non_blocking=True
-            )
+                chunk_slice = slice(
+                    start_idx + local_start, start_idx + local_end
+                )
+                logprobs_tensors.logprob_token_ids[chunk_slice].copy_(
+                    token_ids, non_blocking=True
+                )
+                logprobs_tensors.logprobs[chunk_slice].copy_(
+                    logprobs, non_blocking=True
+                )
+                logprobs_tensors.selected_token_ranks[chunk_slice].copy_(
+                    ranks, non_blocking=True
+                )
 
         # Remove requests that have completed prefill from the batch
         # num_prompt_logprobs_dict.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -207,6 +207,7 @@ from vllm.v1.worker.block_table import SlotMappingMode
 from vllm.v1.worker.cp_utils import (
     check_attention_cp_compatibility,
     get_dcp_dummy_context_len,
+    get_total_cp_world_size,
     prepare_dcp_dummy_context_metadata,
 )
 from vllm.v1.worker.dp_utils import coordinate_batch_across_dp


### PR DESCRIPTION
## Purpose

Enable Qwen3.5/Qwen3Next models whose attention, GDN, and dense-MLP dimensions are not evenly divisible by tensor parallel size. The tested target is dense Qwen3.5 27B NVFP4 with TP=3 and DCP=3 on three PCIe Blackwell GPUs.

This replaces the previous broad experimental branch with a clean rebase onto current `main`. MTP, DFlash, MoE/EP experiments, low-bit collectives, diagnostics, profiling hooks, and rejected POCs are intentionally excluded.

## Approach

- Add explicit uneven GQA and Gated DeltaNet head partitions with padded local projections and logical checkpoint spans.
- Add padded merged-column and row-parallel weight loaders, including NVFP4/WNA16 packed dimensions and scalar scales.
- Pad the dense Qwen MLP intermediate dimension while preserving grouped W4A16 alignment (`17408 -> 17472` for TP=3).
- Size Mamba states and CUDA-graph profiling caches from the actual uneven/DCP geometry.
- Align Mamba prefill chunks to effective DCP block geometry.
- Skip construction and loading of the Qwen3.5 visual tower under `--language-model-only`.
- Pad and mask the CP LSE correction reduction for non-power-of-two world sizes (`N=3`, launch width 4).

The generalized DCP validation change is restricted to `qwen3_5_text` and `qwen3_next`; other GQA/MQA models retain the previous fail-fast behavior.

## Dependencies and duplicate-work check

Searches were run for TP3 Qwen3.5, uneven tensor parallelism, FlashInfer DCP metadata, non-power-of-two DCP, and concurrent partial prefill.

- No open PR was found for the uneven Qwen3.5/Qwen3Next TP3 layout work or the non-power-of-two CP correction.
- #48003 independently fixes FlashInfer rank-local paged-KV metadata more completely. The duplicate implementation was removed from this PR. This branch requires #48003 (or equivalent) for correct FlashInfer+DCP paged metadata.
- #41399 and #31330 implement V1 concurrent partial prefill. The duplicate guard removal was removed from this PR; partial4 was validated only with a local runtime override.

## Tests

```text
28 focused pytest tests passed
Ruff passed for every changed Python file
git diff --check passed
direct CUDA DCP3 LSE probe passed for natural-log and base-2 LSE
```

The focused suite covers uneven attention/GDN partitions, packed NVFP4/WNA16 loaders, padded vocab/MLP shards, Mamba DCP chunk alignment, and CUDA-graph KV sizing.

## Model and serving validation

Candidate: `nvidia/Qwen3.6-27B-NVFP4`, TP=3, DCP=3, FlashInfer 0.6.14, FP8 KV, prefix caching, eager disabled, FULL+PIECEWISE CUDA graphs, no MTP.

- Server initialized successfully and captured all configured graphs.
- GPU KV cache: `412,903` logical tokens.
- Maximum concurrency at 153,600 tokens/request: `2.69x` with memory utilization `0.82`.
- Graph memory: approximately `0.51 GiB` per GPU.
- Tool-call sanity returned `finish_reason=tool_calls`, the requested function, and valid JSON arguments in repeated probes.
- Partial4 local POC: 4/4 unique long prompts succeeded, 0 errors, `1122.65 prompt tok/s`, wall/p50 about `22.7s`.
- Single-stream decode observed on the ABI-overlay candidate: `12.8 tok/s`. This is a correctness sanity result, not a final performance claim, because the older binary selected Marlin weight-only FP4.

MTP is excluded because the controlled agent workload regressed from 8/8 in `228.3s` without MTP to 7/8 in `294.6s` with MTP, despite synthetic decode gains.

## AI assistance

AI assistance was used for research, implementation, testing, and preparation of this PR. The submitter reviewed the resulting scope and is responsible for the change end to end.
