### PR TITLE
Fix KV offloading GSM8K eval: prefix caching, CPU reload verification, device fit

### DIFF
--- a/.buildkite/test_areas/lm_eval.yaml
+++ b/.buildkite/test_areas/lm_eval.yaml
@@ -241,17 +241,37 @@ steps:
   device: h200_35gb
   source_file_dependencies:
   - vllm/distributed/kv_transfer/kv_connector/v1/offloading/
+  - vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+  - vllm/v1/kv_offload/
+  - vllm/v1/simple_kv_offload/
   - tests/evals/gsm8k/test_gsm8k_offloading.py
   commands:
-  - pytest -s -v evals/gsm8k/test_gsm8k_offloading.py -k "nemotron-h-8b or gemma-4-e4b-it or qwen3.5-35b"
+  - pytest -s -v evals/gsm8k/test_gsm8k_offloading.py -k "nemotron-h-8b or gemma-4-e4b-it"
 
 - label: LM Eval KV-Offload (2xH100)
-  key: kv-offload-large
+  key: kv-offload-medium
   timeout_in_minutes: 60
   device: h100
   num_devices: 2
   source_file_dependencies:
   - vllm/distributed/kv_transfer/kv_connector/v1/offloading/
+  - vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+  - vllm/v1/kv_offload/
+  - vllm/v1/simple_kv_offload/
+  - tests/evals/gsm8k/test_gsm8k_offloading.py
+  commands:
+  - pytest -s -v evals/gsm8k/test_gsm8k_offloading.py -k "qwen3.5-35b"
+
+- label: LM Eval KV-Offload (4xH100)
+  key: kv-offload-large
+  timeout_in_minutes: 60
+  device: h100
+  num_devices: 4
+  source_file_dependencies:
+  - vllm/distributed/kv_transfer/kv_connector/v1/offloading/
+  - vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+  - vllm/v1/kv_offload/
+  - vllm/v1/simple_kv_offload/
   - tests/evals/gsm8k/test_gsm8k_offloading.py
   commands:
   - pytest -s -v evals/gsm8k/test_gsm8k_offloading.py -k "deepseek-v4-flash"

--- a/tests/evals/gsm8k/test_gsm8k_offloading.py
+++ b/tests/evals/gsm8k/test_gsm8k_offloading.py
@@ -5,9 +5,12 @@ GSM8K correctness test for CPU KV offloading connectors.
 
 Regression guard for stride computation bugs in the offloading worker
 (e.g. https://github.com/vllm-project/vllm/pull/46888) and silent KV
-cache data corruption during CPU offloading.  Runs GSM8K twice with
-prefix caching disabled to ensure offloaded KV data is correctly
-reloaded on the second pass.
+cache data corruption during CPU offloading.  Runs GSM8K twice, dropping
+the GPU prefix cache (but not the CPU cache) between passes so the second
+pass must reload offloaded KV data from CPU, and asserts on
+``vllm:external_prefix_cache_hits`` to verify loading occurred.  For
+OffloadingConnector, KV events are used to wait for the asynchronous
+offload to complete between passes.
 
 Covers both KV offloading connectors (OffloadingConnector and
 SimpleCPUOffloadConnector) across four architecture families:
@@ -21,11 +24,17 @@ Usage:
 """
 
 import json
+import socket
+import time
 from dataclasses import dataclass, field
 
+import msgspec
 import pytest
+import requests
+import zmq
 
 from tests.utils import RemoteOpenAIServer
+from vllm.distributed.kv_events import BlockStored, KVEventBatch
 from vllm.platforms import current_platform
 
 from .gsm8k_eval import evaluate_gsm8k
@@ -35,6 +44,14 @@ if not current_platform.is_cuda_alike():
 
 NUM_QUESTIONS = 200
 NUM_FEWSHOT = 5
+
+_KV_EVENTS_TOPIC = "kv-events"
+_EVENT_POLL_MS = 1000
+_OFFLOAD_SYNC_TIMEOUT = 180
+_EXTERNAL_CACHE_COUNTERS = (
+    "vllm:external_prefix_cache_queries",
+    "vllm:external_prefix_cache_hits",
+)
 
 
 def _kv_transfer_config(connector: str, cpu_gib: int = 4) -> str:
@@ -62,6 +79,65 @@ def _kv_transfer_config(connector: str, cpu_gib: int = 4) -> str:
         )
     else:
         raise ValueError(f"Unknown connector: {connector}")
+
+
+class _CPUStoreSubscriber:
+    """Collects BlockStored(medium="CPU") events, which OffloadingConnector
+    emits once a block is committed to the CPU cache."""
+
+    def __init__(self, endpoint: str, topic: str):
+        self.sub = zmq.Context.instance().socket(zmq.SUB)
+        self.sub.setsockopt(zmq.SUBSCRIBE, topic.encode())
+        self.sub.connect(endpoint)
+        self.decoder = msgspec.msgpack.Decoder(type=KVEventBatch)
+
+    def get_new_cpu_stored_blocks(self) -> int:
+        num_blocks = 0
+        poller = zmq.Poller()
+        poller.register(self.sub, zmq.POLLIN)
+        while dict(poller.poll(_EVENT_POLL_MS)).get(self.sub) == zmq.POLLIN:
+            _, _, payload = self.sub.recv_multipart()
+            for event in self.decoder.decode(payload).events:
+                if isinstance(event, BlockStored) and event.medium == "CPU":
+                    num_blocks += len(event.block_hashes)
+        return num_blocks
+
+    def close(self):
+        self.sub.close()
+
+
+def _force_engine_step(base_url: str) -> None:
+    """Force an engine step so completed offload transfers get processed."""
+    requests.post(
+        f"{base_url}/v1/completions",
+        json={"prompt": "0", "max_tokens": 1, "temperature": 0},
+        timeout=60,
+    ).raise_for_status()
+
+
+def _wait_for_cpu_stores(subscriber: _CPUStoreSubscriber, base_url: str) -> None:
+    """Wait until the asynchronous offload commits blocks to the CPU cache."""
+    total_blocks = 0
+    deadline = time.monotonic() + _OFFLOAD_SYNC_TIMEOUT
+    while time.monotonic() < deadline:
+        new_blocks = subscriber.get_new_cpu_stored_blocks()
+        total_blocks += new_blocks
+        if new_blocks == 0:
+            if total_blocks > 0:
+                return
+            _force_engine_step(base_url)
+    assert total_blocks > 0, f"no CPU store events within {_OFFLOAD_SYNC_TIMEOUT}s"
+
+
+def _scrape_counter(base_url: str, name: str) -> float:
+    text = requests.get(f"{base_url}/metrics", timeout=30).text
+    values = [
+        float(line.rpartition(" ")[2])
+        for line in text.splitlines()
+        if line.split("{", 1)[0].split(" ", 1)[0] in (name, f"{name}_total")
+    ]
+    assert values, f"{name} not found in /metrics"
+    return sum(values)
 
 
 @dataclass
@@ -98,8 +174,11 @@ MODELS = [
         connector="OffloadingConnector",
         accuracy_threshold=0.75,
         extra_server_args=[
+            "--tensor-parallel-size",
+            "2",
             "--enable-expert-parallel",
         ],
+        startup_timeout=1200,
     ),
     OffloadingModelConfig(
         id="offloading-deepseek-v4-flash",
@@ -109,7 +188,7 @@ MODELS = [
         accuracy_threshold=0.90,
         extra_server_args=[
             "--tensor-parallel-size",
-            "2",
+            "4",
             "--enable-expert-parallel",
             "--kv-cache-dtype",
             "fp8",
@@ -138,8 +217,11 @@ MODELS = [
         connector="SimpleCPUOffloadConnector",
         accuracy_threshold=0.75,
         extra_server_args=[
+            "--tensor-parallel-size",
+            "2",
             "--enable-expert-parallel",
         ],
+        startup_timeout=1200,
     ),
     OffloadingModelConfig(
         id="simple-deepseek-v4-flash",
@@ -148,7 +230,7 @@ MODELS = [
         accuracy_threshold=0.90,
         extra_server_args=[
             "--tensor-parallel-size",
-            "2",
+            "4",
             "--enable-expert-parallel",
             "--kv-cache-dtype",
             "fp8",
@@ -163,11 +245,12 @@ MODELS = [
 
 @pytest.mark.parametrize("cfg", MODELS, ids=lambda c: c.id)
 def test_gsm8k_offloading_correctness(cfg: OffloadingModelConfig):
+    # Prefix caching must be explicitly enabled: SimpleCPUOffloadConnector requires it.
     server_args = [
         "--enforce-eager",
         "--max-model-len",
         "4096",
-        "--no-enable-prefix-caching",
+        "--enable-prefix-caching",
         "--no-disable-hybrid-kv-cache-manager",
         "--kv-transfer-config",
         _kv_transfer_config(cfg.connector, cfg.cpu_offload_gib),
@@ -176,32 +259,91 @@ def test_gsm8k_offloading_correctness(cfg: OffloadingModelConfig):
         *cfg.extra_server_args,
     ]
 
+    # Only OffloadingConnector emits CPU BlockStored events.
+    use_kv_events = cfg.connector == "OffloadingConnector"
+    if use_kv_events:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            events_port = s.getsockname()[1]
+        server_args += [
+            "--kv-events-config",
+            json.dumps(
+                {
+                    "enable_kv_cache_events": True,
+                    "publisher": "zmq",
+                    "endpoint": f"tcp://*:{events_port}",
+                    "topic": _KV_EVENTS_TOPIC,
+                }
+            ),
+        ]
+
     with RemoteOpenAIServer(
         cfg.model,
         server_args,
+        # /reset_prefix_cache requires dev mode.
+        env_dict={"VLLM_SERVER_DEV_MODE": "1"},
         max_wait_seconds=cfg.startup_timeout,
     ) as server:
-        url = server.url_for("v1")
-        host_port = url.split("://")[1].split("/")[0]
-        host, port = host_port.rsplit(":", 1)
+        base_url = f"http://{server.host}:{server.port}"
+        subscriber = (
+            _CPUStoreSubscriber(f"tcp://127.0.0.1:{events_port}", _KV_EVENTS_TOPIC)
+            if use_kv_events
+            else None
+        )
+        try:
+            for run_idx in range(1, 3):
+                results = evaluate_gsm8k(
+                    num_questions=NUM_QUESTIONS,
+                    num_shots=NUM_FEWSHOT,
+                    host=f"http://{server.host}",
+                    port=server.port,
+                )
 
-        for run_idx in range(1, 3):
-            results = evaluate_gsm8k(
-                num_questions=NUM_QUESTIONS,
-                num_shots=NUM_FEWSHOT,
-                host=f"http://{host}",
-                port=int(port),
+                print(
+                    f"GSM8K run {run_idx}/2 + {cfg.connector} ({cfg.id}): "
+                    f"accuracy={results['accuracy']:.4f}, "
+                    f"invalid_rate={results['invalid_rate']:.3f}, "
+                    f"latency={results['latency']:.1f}s"
+                )
+
+                assert results["accuracy"] >= (
+                    cfg.accuracy_threshold - cfg.tolerance
+                ), (
+                    f"GSM8K run {run_idx}/2 accuracy "
+                    f"{results['accuracy']:.4f} below "
+                    f"{cfg.accuracy_threshold - cfg.tolerance:.4f}"
+                )
+
+                if run_idx == 1:
+                    # Wait for async offloading to finish before dropping the
+                    # GPU prefix cache: in-flight transfers hold GPU blocks
+                    # (failing the reset), and the second pass must not miss
+                    # on the CPU cache.
+                    if subscriber is not None:
+                        _wait_for_cpu_stores(subscriber, base_url)
+                    else:
+                        for _ in range(3):
+                            _force_engine_step(base_url)
+
+                    before = [
+                        _scrape_counter(base_url, name)
+                        for name in _EXTERNAL_CACHE_COUNTERS
+                    ]
+                    requests.post(
+                        f"{base_url}/reset_prefix_cache",
+                        params={"reset_external": "false"},
+                        timeout=30,
+                    ).raise_for_status()
+
+            queries, hits = (
+                _scrape_counter(base_url, name) - b
+                for name, b in zip(_EXTERNAL_CACHE_COUNTERS, before)
             )
-
             print(
-                f"GSM8K run {run_idx}/2 + {cfg.connector} ({cfg.id}): "
-                f"accuracy={results['accuracy']:.4f}, "
-                f"invalid_rate={results['invalid_rate']:.3f}, "
-                f"latency={results['latency']:.1f}s"
+                f"{cfg.id}: run 2/2 loaded {hits:.0f}/{queries:.0f} "
+                "externally queried tokens from the CPU cache"
             )
-
-            assert results["accuracy"] >= (cfg.accuracy_threshold - cfg.tolerance), (
-                f"GSM8K run {run_idx}/2 accuracy "
-                f"{results['accuracy']:.4f} below "
-                f"{cfg.accuracy_threshold - cfg.tolerance:.4f}"
-            )
+            assert queries > 0 and hits > 0, "no KV data was loaded from CPU"
+        finally:
+            if subscriber is not None:
+                subscriber.close()


### PR DESCRIPTION
Fixes for #46893 — addresses @orozery's review and the failing `lm-eval-kv-offload-*` steps.

- Enable prefix caching and reset the GPU prefix cache between passes (`POST /reset_prefix_cache?reset_external=false`) so pass 2 must reload KV from CPU. Without it, hybrid models crash at startup and `SimpleCPUOffloadConnector` silently disables itself.
- Wait for `BlockStored(medium="CPU")` KV events before the reset so pass 2 never races the async offload (`OffloadingConnector`).
- Assert `vllm:external_prefix_cache_{queries,hits}` deltas to verify loading actually occurred (both connectors).
- Fix device fit: Qwen3.5-35B → 2xH100 (TP=2), DeepSeek-V4-Flash → 4xH100 (TP=4); both OOMed on the current devices.
- Widen `source_file_dependencies` to cover `vllm/v1/kv_offload/` and the simple connector.

Qwen's 0.75 threshold needs a baseline from the first green run.
