### PR TITLE
[ROCm][KVConnector][MoRI-IO] Fix WRITE-mode remote-TP rank collapse (#46332 follow-up)

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -477,7 +477,15 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
             remote_port=int(remote_handshake_port),
             remote_handshake_port=int(remote_handshake_port),
             remote_notify_port=int(remote_notify_port),
-            tp_size=kv_transfer_params.get("tp_size", 1),
+            # Remote peer TP degree (used as remote_tp_size downstream). The
+            # proxy advertises it under "remote_tp_size"; #46332 read "tp_size"
+            # which is absent on WRITE producer requests -> defaulted to 1 ->
+            # rank collapse. Read the right key; 0 == unknown (== homogeneous).
+            tp_size=int(
+                kv_transfer_params.get("remote_tp_size")
+                or kv_transfer_params.get("tp_size")
+                or 0
+            ),
             remote_dp_size=kv_transfer_params.get("remote_dp_size", 1),
             remote_dp_rank=kv_transfer_params.get("remote_dp_rank", 0),
         )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -2148,7 +2148,8 @@ class MoRIIOConnectorWorker:
         validate_moriio_heterogeneous_tp_kv_heads(
             local_tp_size=self.world_size,
             remote_tp_size=(
-                remote_tp_size if remote_tp_size and remote_tp_size > 0
+                remote_tp_size
+                if remote_tp_size and remote_tp_size > 0
                 else self.world_size
             ),
             total_num_kv_heads=self.model_config.get_total_num_kv_heads(),

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -1352,7 +1352,7 @@ class MoRIIOConnectorWorker:
 
     def _remote_tp_rank(self, remote_tp_size: int) -> int:
         # 0/unknown remote TP == homogeneous (avoids collapsing all ranks to 0).
-        if remote_tp_size <= 0:
+        if remote_tp_size == 0:
             remote_tp_size = self.world_size
         return get_moriio_remote_tp_rank(self.tp_rank, self.world_size, remote_tp_size)
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -1351,6 +1351,9 @@ class MoRIIOConnectorWorker:
         return {remote_agent_name}
 
     def _remote_tp_rank(self, remote_tp_size: int) -> int:
+        # 0/unknown remote TP == homogeneous (avoids collapsing all ranks to 0).
+        if remote_tp_size <= 0:
+            remote_tp_size = self.world_size
         return get_moriio_remote_tp_rank(self.tp_rank, self.world_size, remote_tp_size)
 
     def _background_moriio_handshake(
@@ -2145,7 +2148,8 @@ class MoRIIOConnectorWorker:
         validate_moriio_heterogeneous_tp_kv_heads(
             local_tp_size=self.world_size,
             remote_tp_size=(
-                remote_tp_size if remote_tp_size is not None else self.world_size
+                remote_tp_size if remote_tp_size and remote_tp_size > 0
+                else self.world_size
             ),
             total_num_kv_heads=self.model_config.get_total_num_kv_heads(),
             is_mla=self._is_mla_cache_layer(layer_name),


### PR DESCRIPTION
  ## Purpose

 In WRITE mode, each prefill TP rank must target the correct decode TP rank for KV transfer. #46332 introduced heterogeneous TP support, requiring the prefill to query the decode's TP size (remote_tp_size) from the proxy to compute the correct target rank. The rank mapping reads peer TP size from kv_transfer_params, but the proxy sets remote_tp_size not tp_size. The old code read tp_size which was never set, defaulting to 1. This caused all 8 prefill TP ranks to fan into decode rank 0, leaving 7/8 of the decode KV cache unwritten and accuracy collapsing to near zero in WRITE mode. READ mode was unaffected.

**Changes**

- moriio_common.py - read remote_tp_size (falling back to tp_size, then 0) when building transfer params.
- moriio_connector.py - treat remote_tp_size <= 0 as homogeneous TP (use local world_size) instead of collapsing to rank 0.

## Test Plan

MoRIIO connector over RoCE RDMA fabric, 1P1D WRITE mode (`read_mode: false`), nightly `vllm/vllm-openai-rocm:nightly`.

### Homogeneous TP8 — MI350X

Serve DeepSeek-V3 1P1D, prefill TP8 / decode TP8.

  ```bash
  # PREFILL — TP8
  vllm serve /models/DeepSeek-V3 \
      --host $PREFILL_IP --port 8100 --tensor-parallel-size 8 \
      --gpu-memory-utilization 0.8 --kv-cache-dtype fp8 \
      --trust-remote-code --enforce-eager \
      --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer",
        "kv_connector_extra_config":{"proxy_ip":"$PREFILL_IP","proxy_ping_port":"36367",
        "http_port":"8100","handshake_port":"6301","notify_port":"61005","read_mode":false}}'                                          
  # DECODE — TP8
  vllm serve /models/DeepSeek-V3 \
      --host $DECODE_IP --port 8200 --tensor-parallel-size 8 \
      --gpu-memory-utilization 0.7 --kv-cache-dtype fp8 --trust-remote-code \
      --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_consumer",
        "kv_connector_extra_config":{"proxy_ip":"$PREFILL_IP","proxy_ping_port":"36367",                                                       "http_port":"8200","handshake_port":"6301","notify_port":"61005","read_mode":false}}'
```

### Heterogeneous TP (prefill TP4 / decode TP8) — MI300X

Serve DeepSeek-V3 1P1D, prefill TP4 / decode TP8.

  ```bash
  # PREFILL — TP4
  vllm serve /models/DeepSeek-V3 \
      --host $PREFILL_IP --port 8100 --tensor-parallel-size 4 \
      --gpu-memory-utilization 0.8 --kv-cache-dtype fp8 \
      --trust-remote-code --enforce-eager \
      --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer",
        "kv_connector_extra_config":{"proxy_ip":"$PREFILL_IP","proxy_ping_port":"36367",
        "http_port":"8100","handshake_port":"6301","notify_port":"61005","read_mode":false}}'

  # DECODE — TP8
  vllm serve /models/DeepSeek-V3 \
      --host $DECODE_IP --port 8200 --tensor-parallel-size 8 \
      --gpu-memory-utilization 0.7 --kv-cache-dtype fp8 --trust-remote-code \
      --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_consumer",
        "kv_connector_extra_config":{"proxy_ip":"$PREFILL_IP","proxy_ping_port":"36367",
        "http_port":"8200","handshake_port":"6301","notify_port":"61005","read_mode":false}}' 
``` 

Also verified Homogeous TP on MI300.

### GSM8K Evaluation

  ```bash
  lm_eval --model local-completions \
      --tasks gsm8k \
      --model_args
  model=/models/DeepSeek-V3,base_url=http://$PREFILL_IP:10001/v1/completions,num_concurrent=32,max_retries=3,tokenized_requests=False \      --limit 250
```

## Test Result

### Accuracy Results (GSM8K, flexible-extract)

  ```
  Config                                    Platform   Without fix   With fix
  ----------------------------------------  --------   -----------   --------
  1P1D homogeneous TP8                       MI350X         ~0.00      0.944
  1P1D heterogeneous (prefill TP4/dec TP8)   MI300X         ~0.00      0.95
  ``` 

Also validated on: DeepSeek-R1-MXFP4, Kimi-K2.5-MXFP4 (1P1D and 2P2D TP8).