### PR TITLE
[Bugfix] Prevent encoder cache deadlock with multiple images in Mamba align mode

### DIFF
--- a/tests/v1/core/test_scheduler_encoder_cache.py
+++ b/tests/v1/core/test_scheduler_encoder_cache.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.multimodal.inputs import PlaceholderRange
+from vllm.v1.core.sched.scheduler import Scheduler
+
+from .utils import create_requests, create_scheduler
+
+pytestmark = pytest.mark.cpu_test
+
+BLOCK_SIZE = 768
+IMAGE_EMBEDS = 500
+TEXT_GAP = 10
+IMAGE2_OFFSET = IMAGE_EMBEDS + TEXT_GAP
+TOTAL_TOKENS = IMAGE2_OFFSET + IMAGE_EMBEDS
+ENCODER_CACHE_SIZE = 600
+
+
+def _make_mamba_split_scheduler(
+    *,
+    block_size: int = BLOCK_SIZE,
+    encoder_cache_size: int = ENCODER_CACHE_SIZE,
+):
+    scheduler = create_scheduler(
+        model="llava-hf/llava-1.5-7b-hf",
+        max_num_batched_tokens=8192,
+        block_size=block_size,
+        enable_chunked_prefill=True,
+    )
+    scheduler.need_mamba_block_aligned_split = True
+    scheduler.cache_config.mamba_cache_mode = "align"
+    manager = scheduler.encoder_cache_manager
+    manager.cache_size = encoder_cache_size
+    manager.num_free_slots = encoder_cache_size
+    manager.num_freeable_slots = encoder_cache_size
+    return scheduler
+
+
+def _make_two_image_request() -> list:
+    mm_positions = [
+        [
+            PlaceholderRange(offset=0, length=IMAGE_EMBEDS),
+            PlaceholderRange(offset=IMAGE2_OFFSET, length=IMAGE_EMBEDS),
+        ]
+    ]
+    return create_requests(
+        num_requests=1,
+        num_tokens=TOTAL_TOKENS,
+        mm_positions=mm_positions,
+        block_size=BLOCK_SIZE,
+    )
+
+
+def test_mamba_block_aligned_split_preserves_sub_block_tokens():
+    """Sub-block chunks must not collapse to zero."""
+    request = _make_two_image_request()[0]
+    request.num_computed_tokens = 0
+
+    mock = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=BLOCK_SIZE),
+        use_eagle=False,
+    )
+    num_new_tokens = Scheduler._mamba_block_aligned_split(
+        self=mock,
+        request=request,
+        num_new_tokens=IMAGE2_OFFSET,
+    )
+    assert num_new_tokens == IMAGE2_OFFSET
+
+    long_request = create_requests(
+        num_requests=1,
+        num_tokens=BLOCK_SIZE * 3,
+        block_size=BLOCK_SIZE,
+    )[0]
+    long_request.num_computed_tokens = 0
+    num_new_tokens = Scheduler._mamba_block_aligned_split(
+        self=mock,
+        request=long_request,
+        num_new_tokens=BLOCK_SIZE * 2,
+    )
+    assert num_new_tokens == BLOCK_SIZE * 2
+
+
+def test_two_images_make_progress_with_encoder_cache_contention():
+    """Regression for issue #47738: two large images must not deadlock."""
+    scheduler = _make_mamba_split_scheduler()
+    (request,) = _make_two_image_request()
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+    assert request.request_id in output.num_scheduled_tokens
+    scheduled_tokens = output.num_scheduled_tokens[request.request_id]
+    assert 0 < scheduled_tokens < BLOCK_SIZE
+    assert scheduled_tokens == IMAGE2_OFFSET
+    assert output.scheduled_encoder_inputs[request.request_id] == [0]
+    assert request.num_computed_tokens == IMAGE2_OFFSET
+
+    scheduler._free_encoder_inputs(request)
+
+    output = scheduler.schedule()
+    assert request.request_id in output.num_scheduled_tokens
+    assert output.scheduled_encoder_inputs[request.request_id] == [1]

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -389,10 +389,13 @@ class Scheduler(SchedulerInterface):
             elif num_computed_tokens_after_sched < last_cache_position:
                 # Align the chunk END (not its length) to block_size;
                 # identical to flooring the length when the start is
-                # block-aligned. May yield 0 (insufficient budget to reach
-                # the next boundary); the caller then skips the request.
+                # block-aligned. If alignment would collapse to 0, keep the
+                # original sub-block chunk so encoder-cache contention between
+                # adjacent MM inputs cannot permanently stall the request.
                 aligned_end = num_computed_tokens_after_sched // block_size * block_size
-                num_new_tokens = max(aligned_end - num_computed_tokens, 0)
+                aligned = max(aligned_end - num_computed_tokens, 0)
+                if aligned > 0:
+                    num_new_tokens = aligned
             elif (
                 num_computed_tokens
                 < last_cache_position
@@ -426,7 +429,9 @@ class Scheduler(SchedulerInterface):
             ):
                 num_new_tokens = num_uncached_common_prefix_tokens
                 # keep alignment to block_size
-                num_new_tokens = num_new_tokens // block_size * block_size
+                aligned = num_new_tokens // block_size * block_size
+                if aligned > 0:
+                    num_new_tokens = aligned
         return num_new_tokens
 
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:


### PR DESCRIPTION
## Summary

- Fix a scheduling deadlock when a single request contains two large multimodal inputs whose combined encoder embeddings exceed the encoder cache budget, but each image fits individually.
- In `_mamba_block_aligned_split`, block alignment was collapsing sub-`block_size` chunks to zero (`num_new_tokens // block_size * block_size`), preventing forward progress while the first image still held encoder cache space.
- Preserve the original sub-block token count when alignment would produce zero, matching the existing documented exception that sub-block chunks simply skip Mamba state caching.

Fixes #47738

## Duplicate-work check

- #40757 and #40709 address the same `_mamba_block_aligned_split` zero-collapse root cause for hybrid Mamba + multimodal workloads.
- This PR targets #47738 specifically and includes a focused regression test for the two-image encoder cache contention scenario described in that issue.
- If one of the existing PRs lands first, this test coverage can be cherry-picked; the scheduler change is intentionally minimal and aligned with the documented intended behavior.

## AI disclosure

AI assistance (Claude) was used to investigate the deadlock, implement the fix, and add tests. The human submitter reviewed the changed lines and test results.

## Test plan

- [x] `.venv/bin/python -m pytest tests/v1/core/test_scheduler_encoder_cache.py -v` — 2 passed
- [x] `.venv/bin/python -m pytest tests/v1/core/test_prefix_caching.py::test_hybrid_cache_mamba_align_shared_prefix_detection -v` — 1 passed
