### PR TITLE
[ROCm] Use AITER topk_softplus for non-hash sqrtsoftplus MoE routing

### DIFF
--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
@@ -128,6 +128,32 @@ def vllm_topk_softplus_sqrt(
             routed_scaling_factor,
         )
 
+    # aiter's topk_softplus is a faster drop-in for the non-hash sqrtsoftplus
+    # routing (bias + sqrt(softplus) + top-k + optional renorm + scaling).
+    # It does NOT support hash routing (input_tokens / hash_indices_table), so
+    # the 3 hash layers still use the vLLM kernel. Numerically identical to
+    # topk_hash_softplus_sqrt for the non-hash case (verified: idx match 100%,
+    # max weight diff ~1.8e-7).
+    if (
+        hash_indices_table is None
+        and input_tokens is None
+        and e_score_correction_bias is not None
+        and topk_indices.dtype == torch.int32
+        and rocm_aiter_ops.is_enabled()
+    ):
+        from aiter import topk_softplus
+
+        topk_softplus(
+            topk_weights,
+            topk_indices,
+            gating_output,
+            e_score_correction_bias,
+            renormalize,
+            routed_scaling_factor,
+            "sqrtsoftplus",
+        )
+        return topk_weights, topk_indices
+
     ops.topk_hash_softplus_sqrt(
         topk_weights,
         topk_indices,


### PR DESCRIPTION
## Purpose

aiter's `topk_softplus` is a faster drop-in for the non-hash sqrtsoftplus
routing path (bias + sqrt(softplus) + top-k + optional renorm + scaling)
currently handled by `ops.topk_hash_softplus_sqrt` in
`vllm_topk_softplus_sqrt`.

It does **not** support hash routing (`input_tokens` / `hash_indices_table`),
so those layers fall through to the existing vLLM kernel unchanged. The fast
path is guarded on `rocm_aiter_ops.is_enabled()`, int32 indices, and the
absence of hash-routing inputs.

## Test Plan

- DeepSeek-V4-Pro FP4, TP8, MI355X decode.
- Numerical equivalence check vs. `ops.topk_hash_softplus_sqrt` for the
  non-hash case.

## Test Result

Numerically identical to the existing kernel for the non-hash case:
index match 100%, max top-k weight diff ~1.8e-7. gsm8k accuracy unchanged.

---
Draft — opened for early review. Part of a DeepSeek-V4 FP4 ROCm optimization set.