### PR TITLE
[CPU] Add MoE DP/EP support

### DIFF
--- a/.buildkite/hardware_tests/cpu.yaml
+++ b/.buildkite/hardware_tests/cpu.yaml
@@ -10,6 +10,7 @@ steps:
   - cmake/cpu_extension.cmake
   - CMakeLists.txt
   - vllm/_custom_ops.py
+  - vllm/model_executor/layers/fused_moe/experts/cpu_moe.py
   - tests/kernels/attention/test_cpu_attn.py
   - tests/kernels/moe/test_cpu_fused_moe.py
   - tests/kernels/moe/test_cpu_quant_fused_moe.py
@@ -33,6 +34,33 @@ steps:
       pytest -x -v -s tests/kernels/mamba/cpu/test_cpu_gdn_ops.py
       pytest -x -v -s tests/kernels/mamba/test_causal_conv1d.py
       pytest -x -v -s tests/kernels/mamba/test_mamba_ssm.py"
+
+- label: CPU-DP/EP Unit Tests
+  depends_on: []
+  device: intel_cpu
+  no_plugin: true
+  source_file_dependencies:
+  - csrc/cpu/shm.cpp
+  - vllm/v1/worker/cpu_worker.py
+  - vllm/platforms/cpu.py
+  - vllm/distributed/device_communicators/cpu_communicator.py
+  - vllm/model_executor/layers/fused_moe/experts/cpu_moe.py
+  - tests/v1/worker/test_cpu_worker.py
+  - tests/distributed/test_cpu_communicator.py
+  - tests/distributed/test_cpu_moe_ep.py
+  commands:
+    - |
+      bash .buildkite/scripts/hardware_ci/run-cpu-test.sh 5m "
+      OMP_NUM_THREADS=1 pytest -x -v -s \
+        tests/v1/worker/test_cpu_worker.py::test_get_cpushm_dist_ident_uses_dp_rendezvous \
+        tests/v1/worker/test_cpu_worker.py::test_cpu_platform_rejects_multi_node_dp_or_ep \
+        tests/v1/worker/test_cpu_worker.py::test_cpu_platform_allows_hybrid_tp_dp_ep \
+        tests/v1/worker/test_cpu_worker.py::test_cpu_platform_allows_dp_only_ep \
+        tests/distributed/test_cpu_communicator.py::test_cpu_ep_dispatch_combine_ragged \
+        tests/distributed/test_cpu_communicator.py::test_cpu_ep_compile_ragged_fastpath \
+        tests/distributed/test_cpu_communicator.py::test_cpu_dp_group_ranks_share_shm_group_name \
+        tests/distributed/test_cpu_communicator.py::test_cpu_dp_shm_all_reduce_matches_gloo \
+        tests/distributed/test_cpu_moe_ep.py::test_cpu_moe_ep_dp6_tp1"
 
 # Note: SDE can't be downloaded from CI host because of AWS WAF
 # - label: CPU-Compatibility Tests

--- a/csrc/cpu/sgl-kernels/moe.cpp
+++ b/csrc/cpu/sgl-kernels/moe.cpp
@@ -35,7 +35,7 @@ template <int BLOCK_M>
 int moe_align_block_size(
     int32_t* __restrict__ sorted_ids,
     int32_t* __restrict__ expert_ids,
-    int32_t* __restrict__ topk_ids,
+    const int32_t* __restrict__ topk_ids,
     int32_t* __restrict__ total_cnts,
     int32_t* __restrict__ cumsums,
     int32_t* __restrict__ offsets,
@@ -50,7 +50,13 @@ int moe_align_block_size(
     int32_t* __restrict__ local_cnts = T_INDEX(tid + 1);
 
     for (int i = begin; i < end; ++i) {
-      local_cnts[topk_ids[i]]++;
+      int32_t e = topk_ids[i];
+      if (e == -1) {
+        continue;
+      }
+      TORCH_CHECK(
+          0 <= e && e < num_experts, "Invalid expert id ", e, " for ", num_experts, " experts.");
+      local_cnts[e]++;
     }
   });
 
@@ -63,10 +69,12 @@ int moe_align_block_size(
   // the last row holds sums of each experts
   int32_t* total_cnts_t_1 = T_INDEX(num_threads);
 
+  int num_valid = 0;
   cumsums[0] = 0;
   for (int e = 0; e < num_experts; ++e) {
     // accumulate `num_tokens_post_pad`, also as the expert offset
     cumsums[e + 1] = cumsums[e] + div_up(total_cnts_t_1[e], BLOCK_M) * BLOCK_M;
+    num_valid += total_cnts_t_1[e];
 
     for (int k = cumsums[e]; k < cumsums[e + 1]; k += BLOCK_M) {
       expert_ids[k / BLOCK_M] = e;
@@ -81,6 +89,9 @@ int moe_align_block_size(
 
     for (int i = begin; i < end; ++i) {
       int32_t expert_id = topk_ids[i];
+      if (expert_id == -1) {
+        continue;
+      }
       int32_t b_offset = cumsums[expert_id];
       int32_t t_offset = offsets[expert_id];
       sorted_ids[b_offset + t_offset] = i;
@@ -117,8 +128,8 @@ int moe_align_block_size(
   for (int mb = 0; mb < num_token_blocks; ++mb) {
     offsets[mb + 1] += offsets[mb];
   }
-  // debug: the last value of offsets should be `numel`
-  TORCH_CHECK(offsets[num_token_blocks] == numel);
+  // debug: the last value of offsets should be `num_valid`
+  TORCH_CHECK(offsets[num_token_blocks] == num_valid);
 
   return num_tokens_post_pad;
 }
@@ -942,6 +953,9 @@ at::Tensor fused_experts_cpu(
   }
   // check scales
   check_moe_scales(moe_comp_method, w1_scale, w2_scale, block_size);
+  if (moe_comp_method == CPUQuantMethod::FP8_W8A16) {
+    CHECK_MOE_SCALES_FP8(1, 2);
+  }
 
   at::Tensor out_hidden_states = inplace ? hidden_states : at::empty_like(hidden_states);
 
@@ -983,6 +997,13 @@ at::Tensor fused_experts_cpu(
   int64_t num_tokens_post_pad = moe_align_block_size<BLOCK_M>(
       sorted_ids, expert_ids, topk_ids_.data_ptr<int32_t>(), total_cnts, cumsums, offsets, E, numel, num_threads);
 
+  bool has_skip = offsets[num_tokens_post_pad / BLOCK_M] != numel;
+
+  if (num_tokens_post_pad == 0) {
+    out_hidden_states.zero_();
+    return out_hidden_states;
+  }
+
   // unlike triton kernel, we fuse silu with gemm1 so only need 2 intermediate_caches:
   //   1. intermediate_cache1 : [M * topk, N]
   //   2. intermediate_cache2 : [M * topk, K]
@@ -1018,6 +1039,12 @@ at::Tensor fused_experts_cpu(
   AT_DISPATCH_REDUCED_FLOATING_TYPES(st, "fused_experts_kernel_impl", [&] {
     scalar_t* __restrict__ intermediate_cache1 = (scalar_t*)((void*)(buffer2.data_ptr<int8_t>()));
     scalar_t* __restrict__ intermediate_cache2 = intermediate_cache1 + M * topk * N;
+
+    if (has_skip) {
+      at::parallel_for(0, M * topk, 0, [&](int64_t begin, int64_t end) {
+        fill_stub(intermediate_cache2 + begin * K, (scalar_t)0, (end - begin) * K);
+      });
+    }
 
     if (moe_comp_method == CPUQuantMethod::INT8_W8A8) {
       uint8_t* __restrict__ A_tmp = (uint8_t*)((void*)(intermediate_cache2 + M * topk * K));

--- a/csrc/cpu/sgl-kernels/moe.cpp
+++ b/csrc/cpu/sgl-kernels/moe.cpp
@@ -8,6 +8,9 @@
 #include "common.h"
 #include "gemm.h"
 
+#include <cstring>
+#include <vector>
+
 namespace {
 
 // [NOTE]: Fused MoE kernel with AMX
@@ -874,6 +877,100 @@ static inline void check_moe_scales(
   TORCH_CHECK(w1s.size(DIM1) == div_up(K, block_size_K));     \
   TORCH_CHECK(w2s.size(DIM0) == div_up(K, block_size_N));     \
   TORCH_CHECK(w2s.size(DIM1) == div_up(N, block_size_K))
+template <typename topk_t, typename map_t>
+inline int64_t count_local_expert_selections(
+    const topk_t* __restrict__ topk_ids,
+    const map_t* __restrict__ expert_map,
+    int64_t* __restrict__ token_starts,
+    int64_t M,
+    int64_t topk,
+    int64_t global_num_experts,
+    int64_t local_num_experts) {
+  int64_t selected_count = 0;
+  for (int64_t m = 0; m < M; ++m) {
+    int64_t token_count = 0;
+    for (int64_t k = 0; k < topk; ++k) {
+      int64_t global_expert_id = static_cast<int64_t>(topk_ids[m * topk + k]);
+      if (global_expert_id == -1) {
+        continue;
+      }
+      TORCH_CHECK(
+          0 <= global_expert_id && global_expert_id < global_num_experts,
+          "Invalid expert id ",
+          global_expert_id,
+          " for ",
+          global_num_experts,
+          " experts.");
+      int64_t local_expert_id = static_cast<int64_t>(expert_map[global_expert_id]);
+      if (local_expert_id == -1) {
+        continue;
+      }
+      TORCH_CHECK(
+          0 <= local_expert_id && local_expert_id < local_num_experts,
+          "Invalid local expert id ",
+          local_expert_id,
+          " for ",
+          local_num_experts,
+          " local experts.");
+      token_count++;
+    }
+    selected_count += token_count;
+    token_starts[m + 1] = selected_count;
+  }
+  return selected_count;
+}
+
+template <typename scalar_t, typename topk_t, typename map_t, typename weight_t>
+inline void compact_local_expert_selections(
+    scalar_t* __restrict__ selected_hidden,
+    weight_t* __restrict__ selected_weights,
+    int32_t* __restrict__ selected_ids,
+    const scalar_t* __restrict__ hidden_states,
+    const weight_t* __restrict__ topk_weights,
+    const topk_t* __restrict__ topk_ids,
+    const map_t* __restrict__ expert_map,
+    const int64_t* __restrict__ token_starts,
+    int64_t M,
+    int64_t K,
+    int64_t topk) {
+  for (int64_t m = 0; m < M; ++m) {
+    int64_t out_idx = token_starts[m];
+    for (int64_t k = 0; k < topk; ++k) {
+      int64_t global_expert_id = static_cast<int64_t>(topk_ids[m * topk + k]);
+      if (global_expert_id == -1) {
+        continue;
+      }
+      int64_t local_expert_id = static_cast<int64_t>(expert_map[global_expert_id]);
+      if (local_expert_id == -1) {
+        continue;
+      }
+      copy_stub(selected_hidden + out_idx * K, hidden_states + m * K, K);
+      selected_weights[out_idx] = topk_weights[m * topk + k];
+      selected_ids[out_idx] = static_cast<int32_t>(local_expert_id);
+      out_idx++;
+    }
+  }
+}
+
+template <typename scalar_t>
+inline void scatter_add_local_expert_outputs(
+    scalar_t* __restrict__ output,
+    const scalar_t* __restrict__ selected_output,
+    const int64_t* __restrict__ token_starts,
+    int64_t M,
+    int64_t K) {
+  at::parallel_for(0, M, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t m = begin; m < end; ++m) {
+      scalar_t* __restrict__ out_row = output + m * K;
+      for (int64_t s = token_starts[m]; s < token_starts[m + 1]; ++s) {
+        const scalar_t* __restrict__ selected_row = selected_output + s * K;
+        for (int64_t h = 0; h < K; ++h) {
+          out_row[h] += selected_row[h];
+        }
+      }
+    }
+  });
+}
 
 // hidden_states: [M, K]
 // w1: [E, 2N, K] or [E, 2N, K / 2] for uint8
@@ -1021,7 +1118,7 @@ at::Tensor fused_experts_cpu(
   int64_t buffer_size_nbytes =
       M * topk * N * 2 + M * topk * K * 2 +
       num_threads * BLOCK_M * K *
-          (moe_comp_method == CPUQuantMethod::INT8_W8A8 | moe_comp_method == CPUQuantMethod::INT4_W4A8 ? 1 : 2) +
+          (moe_comp_method == CPUQuantMethod::INT8_W8A8 || moe_comp_method == CPUQuantMethod::INT4_W4A8 ? 1 : 2) +
       num_threads * 2 * BLOCK_M * BLOCK_N * sizeof(float);
 
   if (moe_comp_method == CPUQuantMethod::INT8_W8A8) {
@@ -1198,7 +1295,7 @@ at::Tensor fused_experts_cpu(
           w1_scale.value().data_ptr<float>(),
           w2_scale.value().data_ptr<float>(),
           group_size,
-          topk_weights.data_ptr<float>(),
+          topk_weights_.data_ptr<float>(),
           sorted_ids,
           expert_ids,
           offsets,
@@ -1242,6 +1339,200 @@ at::Tensor fused_experts_cpu(
     }
   });
   return out_hidden_states;
+}
+
+at::Tensor fused_experts_cpu_local_skip(
+    at::Tensor& hidden_states,
+    at::Tensor& w1,
+    at::Tensor& w2,
+    at::Tensor& topk_weights,
+    at::Tensor& topk_ids,
+    at::Tensor& expert_map,
+    int64_t moe_comp_method,
+    const std::optional<at::Tensor>& w1_scale,
+    const std::optional<at::Tensor>& w2_scale,
+    const std::optional<at::Tensor>& w1_zero,
+    const std::optional<at::Tensor>& w2_zero,
+    const std::optional<std::vector<int64_t>> block_size,
+    const std::optional<at::Tensor>& w1_bias,
+    const std::optional<at::Tensor>& w2_bias,
+    const std::optional<double>& alpha,
+    const std::optional<double>& limit,
+    bool is_vnni) {
+  CHECK_INPUT(hidden_states);
+  CHECK_INPUT(topk_weights);
+  CHECK_INPUT(topk_ids);
+  CHECK_INPUT(expert_map);
+  CHECK_DIM(2, hidden_states);
+  CHECK_DIM(2, topk_weights);
+  CHECK_DIM(2, topk_ids);
+  CHECK_DIM(1, expert_map);
+  CHECK_EQ(topk_weights.sizes(), topk_ids.sizes());
+  TORCH_CHECK(
+      topk_ids.scalar_type() == at::kInt || topk_ids.scalar_type() == at::kLong,
+      "topk_ids must be int32 or int64.");
+  TORCH_CHECK(
+      expert_map.scalar_type() == at::kInt || expert_map.scalar_type() == at::kLong,
+      "expert_map must be int32 or int64.");
+
+  const int64_t M = hidden_states.size(0);
+  const int64_t K = hidden_states.size(1);
+  const int64_t topk = topk_ids.size(1);
+  const int64_t global_num_experts = expert_map.size(0);
+  const int64_t local_num_experts = w1.size(0);
+
+  std::vector<int64_t> token_starts(M + 1, 0);
+  int64_t selected_count = 0;
+  if (topk_ids.scalar_type() == at::kInt) {
+    const int32_t* __restrict__ topk_ptr = topk_ids.data_ptr<int32_t>();
+    if (expert_map.scalar_type() == at::kInt) {
+      selected_count = count_local_expert_selections(
+          topk_ptr,
+          expert_map.data_ptr<int32_t>(),
+          token_starts.data(),
+          M,
+          topk,
+          global_num_experts,
+          local_num_experts);
+    } else {
+      selected_count = count_local_expert_selections(
+          topk_ptr,
+          expert_map.data_ptr<int64_t>(),
+          token_starts.data(),
+          M,
+          topk,
+          global_num_experts,
+          local_num_experts);
+    }
+  } else {
+    const int64_t* __restrict__ topk_ptr = topk_ids.data_ptr<int64_t>();
+    if (expert_map.scalar_type() == at::kInt) {
+      selected_count = count_local_expert_selections(
+          topk_ptr,
+          expert_map.data_ptr<int32_t>(),
+          token_starts.data(),
+          M,
+          topk,
+          global_num_experts,
+          local_num_experts);
+    } else {
+      selected_count = count_local_expert_selections(
+          topk_ptr,
+          expert_map.data_ptr<int64_t>(),
+          token_starts.data(),
+          M,
+          topk,
+          global_num_experts,
+          local_num_experts);
+    }
+  }
+
+  at::Tensor output = at::zeros_like(hidden_states);
+  if (selected_count == 0) {
+    return output;
+  }
+
+  auto topk_weights_float = topk_weights.to(at::kFloat);
+  auto selected_hidden = at::empty({selected_count, K}, hidden_states.options());
+  auto selected_weights = at::empty({selected_count, 1}, topk_weights_float.options());
+  auto selected_ids = at::empty({selected_count, 1}, topk_ids.options().dtype(at::kInt));
+
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(hidden_states.scalar_type(), "compact_local_expert_selections", [&] {
+    scalar_t* __restrict__ selected_hidden_ptr = selected_hidden.data_ptr<scalar_t>();
+    const scalar_t* __restrict__ hidden_states_ptr = hidden_states.data_ptr<scalar_t>();
+    float* __restrict__ selected_weights_ptr = selected_weights.data_ptr<float>();
+    const float* __restrict__ topk_weights_ptr = topk_weights_float.data_ptr<float>();
+    int32_t* __restrict__ selected_ids_ptr = selected_ids.data_ptr<int32_t>();
+    if (topk_ids.scalar_type() == at::kInt) {
+      const int32_t* __restrict__ topk_ptr = topk_ids.data_ptr<int32_t>();
+      if (expert_map.scalar_type() == at::kInt) {
+        compact_local_expert_selections(
+            selected_hidden_ptr,
+            selected_weights_ptr,
+            selected_ids_ptr,
+            hidden_states_ptr,
+            topk_weights_ptr,
+            topk_ptr,
+            expert_map.data_ptr<int32_t>(),
+            token_starts.data(),
+            M,
+            K,
+            topk);
+      } else {
+        compact_local_expert_selections(
+            selected_hidden_ptr,
+            selected_weights_ptr,
+            selected_ids_ptr,
+            hidden_states_ptr,
+            topk_weights_ptr,
+            topk_ptr,
+            expert_map.data_ptr<int64_t>(),
+            token_starts.data(),
+            M,
+            K,
+            topk);
+      }
+    } else {
+      const int64_t* __restrict__ topk_ptr = topk_ids.data_ptr<int64_t>();
+      if (expert_map.scalar_type() == at::kInt) {
+        compact_local_expert_selections(
+            selected_hidden_ptr,
+            selected_weights_ptr,
+            selected_ids_ptr,
+            hidden_states_ptr,
+            topk_weights_ptr,
+            topk_ptr,
+            expert_map.data_ptr<int32_t>(),
+            token_starts.data(),
+            M,
+            K,
+            topk);
+      } else {
+        compact_local_expert_selections(
+            selected_hidden_ptr,
+            selected_weights_ptr,
+            selected_ids_ptr,
+            hidden_states_ptr,
+            topk_weights_ptr,
+            topk_ptr,
+            expert_map.data_ptr<int64_t>(),
+            token_starts.data(),
+            M,
+            K,
+            topk);
+      }
+    }
+  });
+
+  auto selected_output = fused_experts_cpu(
+      selected_hidden,
+      w1,
+      w2,
+      selected_weights,
+      selected_ids,
+      false,
+      moe_comp_method,
+      w1_scale,
+      w2_scale,
+      w1_zero,
+      w2_zero,
+      block_size,
+      w1_bias,
+      w2_bias,
+      alpha,
+      limit,
+      is_vnni);
+
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(hidden_states.scalar_type(), "scatter_add_local_expert_outputs", [&] {
+    scatter_add_local_expert_outputs(
+        output.data_ptr<scalar_t>(),
+        selected_output.data_ptr<scalar_t>(),
+        token_starts.data(),
+        M,
+        K);
+  });
+
+  return output;
 }
 
 // shared expert kernel

--- a/csrc/cpu/shm.cpp
+++ b/csrc/cpu/shm.cpp
@@ -560,6 +560,9 @@ void shm_allreduce_sum(ThreadSHMContext* ctx, scalar_t* data, size_t elem_num) {
     case 4:
       shm_cc_ops::all_reduce_sum_impl<scalar_t, 4>(ctx, data, elem_num);
       break;
+    case 6:
+      shm_cc_ops::all_reduce_sum_impl<scalar_t, 6>(ctx, data, elem_num);
+      break;
     case 8:
       shm_cc_ops::all_reduce_sum_impl<scalar_t, 8>(ctx, data, elem_num);
       break;
@@ -780,26 +783,28 @@ void shm_gather(int64_t handle, torch::Tensor& data,
                 const std::optional<std::vector<torch::Tensor>>& outputs,
                 int64_t dst) {
   TORCH_CHECK(data.is_contiguous())
-  VLLM_DISPATCH_FLOATING_TYPES(data.scalar_type(), "shm_gather_impl", [&] {
-    CPU_KERNEL_GUARD_IN(shm_gather_impl)
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, data.scalar_type(),
+      "shm_gather_impl", [&] {
+        CPU_KERNEL_GUARD_IN(shm_gather_impl)
 
-    if (outputs.has_value()) {
-      TORCH_CHECK_LE(outputs->size(), MAX_SHM_RANK_NUM);
-      scalar_t* output_ptrs[MAX_SHM_RANK_NUM] = {nullptr};
-      for (int i = 0; i < outputs->size(); ++i) {
-        output_ptrs[i] = outputs->at(i).data_ptr<scalar_t>();
-      }
-      shm_gather_impl(SHMManager::get_singleton_instance(handle)->get_shm_ctx(),
-                      data.data_ptr<scalar_t>(), data.numel(), output_ptrs,
-                      dst);
-    } else {
-      shm_gather_impl(SHMManager::get_singleton_instance(handle)->get_shm_ctx(),
-                      data.data_ptr<scalar_t>(), data.numel(), (scalar_t**)(0),
-                      dst);
-    }
+        if (outputs.has_value()) {
+          TORCH_CHECK_LE(outputs->size(), MAX_SHM_RANK_NUM);
+          scalar_t* output_ptrs[MAX_SHM_RANK_NUM] = {nullptr};
+          for (int i = 0; i < outputs->size(); ++i) {
+            output_ptrs[i] = outputs->at(i).data_ptr<scalar_t>();
+          }
+          shm_gather_impl(
+              SHMManager::get_singleton_instance(handle)->get_shm_ctx(),
+              data.data_ptr<scalar_t>(), data.numel(), output_ptrs, dst);
+        } else {
+          shm_gather_impl(
+              SHMManager::get_singleton_instance(handle)->get_shm_ctx(),
+              data.data_ptr<scalar_t>(), data.numel(), (scalar_t**)(0), dst);
+        }
 
-    CPU_KERNEL_GUARD_OUT(shm_gather_impl)
-  });
+        CPU_KERNEL_GUARD_OUT(shm_gather_impl)
+      });
 }
 
 void shm_all_gather(int64_t handle, const torch::Tensor& data,
@@ -812,19 +817,21 @@ void shm_all_gather(int64_t handle, const torch::Tensor& data,
   TORCH_CHECK_EQ(output_elem_num % input_elem_num, 0);
   const int world_size = output_elem_num / input_elem_num;
 
-  VLLM_DISPATCH_FLOATING_TYPES(data.scalar_type(), "shm_all_gather_impl", [&] {
-    CPU_KERNEL_GUARD_IN(shm_all_gather_impl)
-    auto ctx = SHMManager::get_singleton_instance(handle)->get_shm_ctx();
-    TORCH_CHECK_EQ(ctx->group_size, world_size);
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, data.scalar_type(),
+      "shm_all_gather_impl", [&] {
+        CPU_KERNEL_GUARD_IN(shm_all_gather_impl)
+        auto ctx = SHMManager::get_singleton_instance(handle)->get_shm_ctx();
+        TORCH_CHECK_EQ(ctx->group_size, world_size);
 
-    scalar_t* output_ptrs[MAX_SHM_RANK_NUM] = {nullptr};
-    for (int i = 0; i < world_size; ++i) {
-      output_ptrs[i] = output.data_ptr<scalar_t>() + i * input_elem_num;
-    }
-    shm_gather_impl(ctx, data.data_ptr<scalar_t>(), data.numel(), output_ptrs,
-                    ctx->rank);
-    CPU_KERNEL_GUARD_OUT(shm_all_gather_impl)
-  });
+        scalar_t* output_ptrs[MAX_SHM_RANK_NUM] = {nullptr};
+        for (int i = 0; i < world_size; ++i) {
+          output_ptrs[i] = output.data_ptr<scalar_t>() + i * input_elem_num;
+        }
+        shm_gather_impl(ctx, data.data_ptr<scalar_t>(), data.numel(),
+                        output_ptrs, ctx->rank);
+        CPU_KERNEL_GUARD_OUT(shm_all_gather_impl)
+      });
 }
 
 void shm_allreduce(int64_t handle, torch::Tensor& data) {

--- a/csrc/cpu/torch_bindings.cpp
+++ b/csrc/cpu/torch_bindings.cpp
@@ -79,6 +79,19 @@ at::Tensor fused_experts_cpu(
     const std::optional<double>& alpha, const std::optional<double>& limit,
     bool is_vnni);
 
+at::Tensor fused_experts_cpu_local_skip(
+    at::Tensor& hidden_states, at::Tensor& w1, at::Tensor& w2,
+    at::Tensor& topk_weights, at::Tensor& topk_ids, at::Tensor& expert_map,
+    int64_t moe_comp_method, const std::optional<at::Tensor>& w1_scale,
+    const std::optional<at::Tensor>& w2_scale,
+    const std::optional<at::Tensor>& w1_zero,
+    const std::optional<at::Tensor>& w2_zero,
+    const std::optional<std::vector<int64_t>> block_size,
+    const std::optional<at::Tensor>& w1_bias,
+    const std::optional<at::Tensor>& w2_bias,
+    const std::optional<double>& alpha, const std::optional<double>& limit,
+    bool is_vnni);
+
 at::Tensor int8_scaled_mm_with_quant(at::Tensor& mat1, at::Tensor& mat2,
                                      at::Tensor& scales2,
                                      const std::optional<at::Tensor>& bias,
@@ -490,6 +503,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "bool is_vnni) -> "
       "Tensor");
   ops.impl("fused_experts_cpu", torch::kCPU, &fused_experts_cpu);
+  ops.def(
+      "fused_experts_cpu_local_skip(Tensor hidden_states, Tensor w1, Tensor "
+      "w2, Tensor topk_weights, Tensor topk_ids, Tensor expert_map, int "
+      "moe_comp_method, Tensor? w1_scale, Tensor? w2_scale, Tensor? w1_zero, "
+      "Tensor? w2_zero, int[]? block_size, Tensor? w1_bias, Tensor? w2_bias, "
+      "float? alpha, float? limit, bool is_vnni) -> Tensor");
+  ops.impl("fused_experts_cpu_local_skip", torch::kCPU,
+           &fused_experts_cpu_local_skip);
   ops.def(
       "int8_scaled_mm_with_quant(Tensor mat1, Tensor mat2, Tensor scales2, "
       "Tensor? bias, ScalarType out_dtype, bool is_vnni) -> Tensor");

--- a/tests/distributed/test_cpu_communicator.py
+++ b/tests/distributed/test_cpu_communicator.py
@@ -1,0 +1,996 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU communicator tests for DP SHM and EP dispatch paths."""
+
+import os
+import traceback
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from vllm.platforms import current_platform
+from vllm.platforms.interface import CpuArchEnum
+from vllm.utils.network_utils import get_open_port
+
+if not current_platform.is_cpu():
+    pytest.skip("CPU-only test", allow_module_level=True)
+
+import vllm._custom_ops  # noqa: E402,F401  # populates torch.ops._C for HAS_CPU_SHM
+
+HIDDEN_SIZE = 8
+NUM_EXPERTS = 6
+TOPK = 2
+HAS_CPU_SHM = hasattr(torch.ops._C, "init_shm_manager") and (
+    current_platform.get_cpu_architecture()
+    in (CpuArchEnum.X86, CpuArchEnum.ARM, CpuArchEnum.POWERPC)
+)
+
+
+def test_cpu_shm_group_name_eligibility():
+    from vllm.distributed.device_communicators.cpu_communicator import CpuCommunicator
+
+    assert CpuCommunicator._is_cpushm_group_name("tp:0")
+    assert CpuCommunicator._is_cpushm_group_name("pp:0")
+    assert CpuCommunicator._is_cpushm_group_name("dp:0")
+    assert CpuCommunicator._is_cpushm_group_name("ep:0")
+    assert not CpuCommunicator._is_cpushm_group_name("eplb:0")
+    assert not CpuCommunicator._is_cpushm_group_name("anonymous:0")
+
+
+def _ensure_spawn_start_method():
+    if mp.get_start_method(allow_none=True) is None:
+        mp.set_start_method("spawn")
+
+
+def _report_worker_failure(rank: int, err_q: mp.Queue, err: Exception) -> None:
+    err_q.put(f"[Rank {rank}]\n{traceback.format_exc()}")
+    raise SystemExit(1) from err
+
+
+def _collect_worker_failures(procs, err_q: mp.Queue) -> list[str]:
+    exit_errors = []
+    for rank, proc in enumerate(procs):
+        proc.join()
+        if proc.exitcode != 0:
+            exit_errors.append(f"[Rank {rank}] worker exited with code {proc.exitcode}")
+
+    errors = []
+    while not err_q.empty():
+        errors.append(err_q.get_nowait())
+    err_q.close()
+    err_q.join_thread()
+    return errors + exit_errors
+
+
+def _run_worker(
+    rank,
+    world_size,
+    tp_size,
+    dp_size,
+    port,
+    dp_port,
+    worker_fn,
+    params,
+    err_q,
+):
+    try:
+        worker_fn(rank, world_size, tp_size, dp_size, port, dp_port, params, err_q)
+    except Exception as err:
+        err_q.put(f"[Rank {rank}]\n{traceback.format_exc()}")
+        raise SystemExit(1) from err
+
+
+def _spawn_workers(
+    worker_fn,
+    world_size,
+    tp_size,
+    dp_size,
+    params,
+    *,
+    distributed_init_ports=None,
+    dp_port=None,
+):
+    _ensure_spawn_start_method()
+
+    if distributed_init_ports is None:
+        shared_init_port = get_open_port()
+        distributed_init_ports = [shared_init_port] * world_size
+    elif len(distributed_init_ports) != world_size:
+        raise ValueError("distributed_init_ports must provide one port per worker rank")
+
+    if dp_port is None:
+        dp_port = get_open_port()
+
+    err_q: mp.Queue = mp.Queue()
+    procs = []
+    for rank in range(world_size):
+        proc = mp.Process(
+            target=_run_worker,
+            args=(
+                rank,
+                world_size,
+                tp_size,
+                dp_size,
+                distributed_init_ports[rank],
+                dp_port,
+                worker_fn,
+                params,
+                err_q,
+            ),
+        )
+        proc.start()
+        procs.append(proc)
+
+    failures = _collect_worker_failures(procs, err_q)
+    if failures:
+        pytest.fail("Worker(s) failed:\n" + "\n---\n".join(failures))
+
+
+def _init_tp_dp_environment(rank, tp_size, dp_size, port, dp_port):
+    """Init vLLM distributed env for TP=tp_size, DP=dp_size."""
+    from vllm.config import VllmConfig, set_current_vllm_config
+    from vllm.config.parallel import ParallelConfig
+    from vllm.distributed.parallel_state import (
+        ensure_model_parallel_initialized,
+        init_distributed_environment,
+    )
+
+    dp_rank = rank // tp_size
+    tp_rank = rank % tp_size
+
+    vllm_config = VllmConfig()
+    vllm_config.parallel_config = ParallelConfig(
+        tensor_parallel_size=tp_size,
+        data_parallel_size=dp_size,
+        data_parallel_rank=dp_rank,
+        _data_parallel_master_port_list=[int(dp_port)],
+    )
+    with set_current_vllm_config(vllm_config):
+        init_distributed_environment(
+            world_size=tp_size,
+            rank=tp_rank,
+            distributed_init_method=f"tcp://localhost:{port}",
+            local_rank=rank,
+            backend="gloo",
+        )
+        ensure_model_parallel_initialized(tp_size, 1, backend="gloo")
+
+
+def _make_forward_context(dp_rank, dp_size, num_tokens, num_tokens_across_dp):
+    """Create a forward context with explicit DP token counts."""
+    from vllm.config.parallel import ParallelConfig
+    from vllm.config.vllm import VllmConfig
+    from vllm.forward_context import set_forward_context
+
+    class _AttnMeta:
+        dp_metadata = None
+
+    vllm_config = VllmConfig()
+    vllm_config.parallel_config = ParallelConfig(
+        data_parallel_size=dp_size,
+        is_moe_model=True,
+        data_parallel_rank=dp_rank,
+    )
+    return set_forward_context(
+        _AttnMeta(),
+        vllm_config,
+        num_tokens=num_tokens,
+        num_tokens_across_dp=torch.tensor(num_tokens_across_dp, dtype=torch.int),
+    )
+
+
+def _filled(rows: int, cols: int, value: float, dtype=torch.float32) -> torch.Tensor:
+    return torch.full((rows, cols), value, dtype=dtype)
+
+
+def _concat_rank_values(sizes, cols, value_scale, dtype=torch.float32):
+    chunks = [
+        _filled(size, cols, value_scale * (rank + 1), dtype)
+        for rank, size in enumerate(sizes)
+    ]
+    return torch.cat(chunks, dim=0)
+
+
+def _concat_rank_ids(sizes):
+    chunks = [
+        torch.full((size, TOPK), rank, dtype=torch.long)
+        for rank, size in enumerate(sizes)
+    ]
+    return torch.cat(chunks, dim=0)
+
+
+def _expected_combined(rank, sizes, cols):
+    total_rows = sum(sizes)
+    start = sum(sizes[:rank])
+    end = start + sizes[rank]
+    rows = (
+        torch.arange(total_rows, dtype=torch.float32)
+        .unsqueeze(1)
+        .expand(
+            total_rows,
+            cols,
+        )
+    )
+    tag_sum = sum(float((r + 1) * 1000) for r in range(len(sizes)))
+    return rows[start:end] * len(sizes) + tag_sum
+
+
+def _sp_local_sizes(dp_token_counts, tp_size):
+    sizes = []
+    for dp_tokens in dp_token_counts:
+        local_rows = (dp_tokens + tp_size - 1) // tp_size
+        sizes.extend([local_rows] * tp_size)
+    return sizes
+
+
+def _ragged_dispatch_worker(
+    rank,
+    world_size,
+    tp_size,
+    dp_size,
+    port,
+    dp_port,
+    sizes,
+    err_q,
+):
+    try:
+        os.environ.setdefault("VLLM_DIST_IDENT", f"test_cpu_ep_comm_{port}")
+        _init_tp_dp_environment(rank, tp_size, dp_size, port, dp_port)
+
+        from vllm.distributed.parallel_state import get_ep_group
+        from vllm.forward_context import get_forward_context
+
+        local_rows = sizes[rank]
+        hidden = _filled(local_rows, HIDDEN_SIZE, float(rank + 1))
+        router = _filled(local_rows, NUM_EXPERTS, float((rank + 1) * 10))
+        weights = _filled(local_rows, TOPK, float((rank + 1) * 100))
+        ids = torch.full((local_rows, TOPK), rank, dtype=torch.long)
+        extra = _filled(local_rows, 1, float((rank + 1) * 1000))
+
+        expected_hidden = _concat_rank_values(sizes, HIDDEN_SIZE, 1.0)
+        expected_router = _concat_rank_values(sizes, NUM_EXPERTS, 10.0)
+        expected_weights = _concat_rank_values(sizes, TOPK, 100.0)
+        expected_ids = _concat_rank_ids(sizes)
+        expected_extra = _concat_rank_values(sizes, 1, 1000.0)
+
+        with _make_forward_context(rank, dp_size, local_rows, sizes):
+            dp_metadata = get_forward_context().dp_metadata
+            assert dp_metadata is not None
+
+            with dp_metadata.sp_local_sizes(sequence_parallel_size=1):
+                gathered_hidden, gathered_router, gathered_extras = (
+                    get_ep_group().dispatch_router_logits(
+                        hidden.clone(),
+                        router.clone(),
+                        extra_tensors=[extra.clone()],
+                    )
+                )
+                torch.testing.assert_close(gathered_hidden, expected_hidden)
+                torch.testing.assert_close(gathered_router, expected_router)
+                assert len(gathered_extras) == 1
+                torch.testing.assert_close(gathered_extras[0], expected_extra)
+
+                gathered_hidden2, gathered_weights, gathered_ids = (
+                    get_ep_group().dispatch(
+                        hidden.clone(),
+                        weights.clone(),
+                        ids.clone(),
+                    )
+                )
+                torch.testing.assert_close(gathered_hidden2, expected_hidden)
+                torch.testing.assert_close(gathered_weights, expected_weights)
+                torch.testing.assert_close(gathered_ids, expected_ids)
+
+                total_rows = sum(sizes)
+                expert_out = torch.arange(total_rows, dtype=torch.float32).unsqueeze(
+                    1
+                ).expand(total_rows, HIDDEN_SIZE).contiguous() + float(
+                    (rank + 1) * 1000
+                )
+                combined = get_ep_group().combine(expert_out)
+                torch.testing.assert_close(
+                    combined,
+                    _expected_combined(rank, sizes, HIDDEN_SIZE),
+                )
+
+        dist.barrier()
+    except Exception as err:
+        _report_worker_failure(rank, err_q, err)
+
+
+def _sequence_parallel_worker(
+    rank,
+    world_size,
+    tp_size,
+    dp_size,
+    port,
+    dp_port,
+    dp_token_counts,
+    err_q,
+):
+    try:
+        os.environ.setdefault("VLLM_DIST_IDENT", f"test_cpu_ep_sp_{port}")
+        _init_tp_dp_environment(rank, tp_size, dp_size, port, dp_port)
+
+        from vllm.distributed.device_communicators.cpu_communicator import (
+            CpuCommunicator,
+            _CPUSHMDistributed,
+        )
+        from vllm.distributed.parallel_state import get_ep_group, get_tp_group
+        from vllm.forward_context import get_forward_context
+
+        expected_local_sizes = _sp_local_sizes(dp_token_counts, tp_size)
+        dp_rank = rank // tp_size
+        expected_tp_ranks = list(range(dp_rank * tp_size, (dp_rank + 1) * tp_size))
+
+        assert get_tp_group().ranks == expected_tp_ranks
+        ep_group = get_ep_group()
+        assert ep_group.ranks == list(range(world_size))
+
+        ep_communicator = ep_group.device_communicator
+        assert isinstance(ep_communicator, CpuCommunicator)
+        if HAS_CPU_SHM:
+            assert isinstance(ep_communicator.dist_module, _CPUSHMDistributed)
+
+        local_rows = expected_local_sizes[rank]
+
+        hidden = _filled(local_rows, HIDDEN_SIZE, float(rank + 1))
+        router = _filled(local_rows, NUM_EXPERTS, float((rank + 1) * 10))
+        weights = _filled(local_rows, TOPK, float((rank + 1) * 100))
+        ids = torch.full((local_rows, TOPK), rank, dtype=torch.long)
+        extra = _filled(local_rows, 1, float((rank + 1) * 1000))
+
+        expected_hidden = _concat_rank_values(expected_local_sizes, HIDDEN_SIZE, 1.0)
+        expected_router = _concat_rank_values(expected_local_sizes, NUM_EXPERTS, 10.0)
+        expected_weights = _concat_rank_values(expected_local_sizes, TOPK, 100.0)
+        expected_ids = _concat_rank_ids(expected_local_sizes)
+        expected_extra = _concat_rank_values(expected_local_sizes, 1, 1000.0)
+
+        with _make_forward_context(
+            dp_rank,
+            dp_size,
+            dp_token_counts[dp_rank],
+            dp_token_counts,
+        ):
+            dp_metadata = get_forward_context().dp_metadata
+            assert dp_metadata is not None
+
+            with dp_metadata.sp_local_sizes(sequence_parallel_size=tp_size) as sizes:
+                assert sizes == expected_local_sizes
+                gathered_hidden, gathered_router, gathered_extras = (
+                    ep_group.dispatch_router_logits(
+                        hidden.clone(),
+                        router.clone(),
+                        is_sequence_parallel=True,
+                        extra_tensors=[extra.clone()],
+                    )
+                )
+                torch.testing.assert_close(gathered_hidden, expected_hidden)
+                torch.testing.assert_close(gathered_router, expected_router)
+                assert len(gathered_extras) == 1
+                torch.testing.assert_close(gathered_extras[0], expected_extra)
+                assert dp_metadata.local_sizes is sizes
+
+                gathered_hidden2, gathered_weights, gathered_ids = ep_group.dispatch(
+                    hidden.clone(),
+                    weights.clone(),
+                    ids.clone(),
+                    is_sequence_parallel=True,
+                )
+                torch.testing.assert_close(gathered_hidden2, expected_hidden)
+                torch.testing.assert_close(gathered_weights, expected_weights)
+                torch.testing.assert_close(gathered_ids, expected_ids)
+                assert dp_metadata.local_sizes is sizes
+
+                total_rows = sum(expected_local_sizes)
+                expert_out = torch.arange(total_rows, dtype=torch.float32).unsqueeze(
+                    1
+                ).expand(total_rows, HIDDEN_SIZE).contiguous() + float(
+                    (rank + 1) * 1000
+                )
+                combined = ep_group.combine(
+                    expert_out,
+                    is_sequence_parallel=True,
+                )
+                torch.testing.assert_close(
+                    combined,
+                    _expected_combined(rank, expected_local_sizes, HIDDEN_SIZE),
+                )
+                assert dp_metadata.local_sizes is sizes
+
+            assert dp_metadata.local_sizes is None
+
+        dist.barrier()
+    except Exception as err:
+        _report_worker_failure(rank, err_q, err)
+
+
+@torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True)
+def _run_compiled_fastpath(rank, sizes):
+    from vllm.distributed.parallel_state import get_ep_group
+
+    device_communicator = get_ep_group().device_communicator
+    assert device_communicator is not None
+    dispatch_op = device_communicator._ep_dispatch_rl_op
+    combine_op = device_communicator._ep_combine_op
+
+    def fastpath_step(hidden_states, router_logits):
+        gathered_hidden, _ = dispatch_op(hidden_states, router_logits)
+        return combine_op(gathered_hidden) + hidden_states
+
+    compiled = torch.compile(fastpath_step, fullgraph=True, backend="eager")
+    local_rows = sizes[rank]
+    hidden = _filled(local_rows, HIDDEN_SIZE, float(rank + 1))
+    router = _filled(local_rows, NUM_EXPERTS, float((rank + 1) * 10))
+    output = compiled(hidden, router)
+    torch.testing.assert_close(output, hidden * (len(sizes) + 1))
+
+
+def _compile_fastpath_worker(
+    rank,
+    world_size,
+    tp_size,
+    dp_size,
+    port,
+    dp_port,
+    size_patterns,
+    err_q,
+):
+    try:
+        os.environ.setdefault("VLLM_DIST_IDENT", f"test_cpu_ep_compile_{port}")
+        _init_tp_dp_environment(rank, tp_size, dp_size, port, dp_port)
+        torch._dynamo.reset()
+
+        for sizes in size_patterns:
+            with _make_forward_context(rank, dp_size, sizes[rank], sizes):
+                _run_compiled_fastpath(rank, sizes)
+
+        dist.barrier()
+    except Exception as err:
+        _report_worker_failure(rank, err_q, err)
+
+
+def _get_dp_shm_communicator():
+    from vllm.distributed.device_communicators.cpu_communicator import (
+        CpuCommunicator,
+        _CPUSHMDistributed,
+    )
+    from vllm.distributed.parallel_state import get_dp_group
+
+    dp_group = get_dp_group()
+    communicator = dp_group.device_communicator
+    assert isinstance(communicator, CpuCommunicator)
+    assert isinstance(communicator.dist_module, _CPUSHMDistributed)
+    return dp_group, communicator
+
+
+def _get_tp_shm_communicator():
+    from vllm.distributed.device_communicators.cpu_communicator import (
+        CpuCommunicator,
+        _CPUSHMDistributed,
+    )
+    from vllm.distributed.parallel_state import get_tp_group
+
+    tp_group = get_tp_group()
+    communicator = tp_group.device_communicator
+    assert isinstance(communicator, CpuCommunicator)
+    assert communicator.unique_name.startswith("tp:")
+    assert isinstance(communicator.dist_module, _CPUSHMDistributed)
+    return tp_group, communicator
+
+
+def _get_ragged_buffer_capacity(communicator, tensor, buffers, *, per_rank=False):
+    buffer = buffers.get(communicator._ragged_buffer_key(tensor))
+    if buffer is None:
+        return 0
+    if per_rank:
+        return buffer.shape[0] // communicator.world_size
+    return buffer.shape[0]
+
+
+def _get_ragged_capacities(communicator, tensor):
+    return (
+        _get_ragged_buffer_capacity(
+            communicator,
+            tensor,
+            communicator._ragged_pad_buffers,
+        ),
+        _get_ragged_buffer_capacity(
+            communicator,
+            tensor,
+            communicator._ragged_shm_gather_buffers,
+            per_rank=True,
+        ),
+    )
+
+
+def _ragged_shm_buffers_worker(
+    rank,
+    world_size,
+    tp_size,
+    dp_size,
+    port,
+    dp_port,
+    size_patterns,
+    err_q,
+):
+    try:
+        os.environ.setdefault("VLLM_DIST_IDENT", f"test_cpu_dp_ragged_buffers_{port}")
+        _init_tp_dp_environment(rank, tp_size, dp_size, port, dp_port)
+
+        small_sizes, large_sizes = size_patterns
+        dp_group, communicator = _get_dp_shm_communicator()
+
+        small_hidden = _filled(small_sizes[rank], HIDDEN_SIZE, float(rank + 1))
+        small_result = dp_group.all_gatherv(small_hidden.clone(), sizes=small_sizes)
+        torch.testing.assert_close(
+            small_result,
+            _concat_rank_values(small_sizes, HIDDEN_SIZE, 1.0),
+        )
+        small_caps = _get_ragged_capacities(communicator, small_hidden)
+        small_result_repeat = dp_group.all_gatherv(
+            small_hidden.clone(),
+            sizes=small_sizes,
+        )
+        torch.testing.assert_close(
+            small_result_repeat,
+            _concat_rank_values(small_sizes, HIDDEN_SIZE, 1.0),
+        )
+        small_repeat_caps = _get_ragged_capacities(communicator, small_hidden)
+
+        large_hidden = _filled(large_sizes[rank], HIDDEN_SIZE, float(rank + 1))
+        large_result = dp_group.all_gatherv(large_hidden.clone(), sizes=large_sizes)
+        torch.testing.assert_close(
+            large_result,
+            _concat_rank_values(large_sizes, HIDDEN_SIZE, 1.0),
+        )
+        large_caps = _get_ragged_capacities(communicator, large_hidden)
+
+        large_result_repeat = dp_group.all_gatherv(
+            large_hidden.clone(),
+            sizes=large_sizes,
+        )
+        torch.testing.assert_close(
+            large_result_repeat,
+            _concat_rank_values(large_sizes, HIDDEN_SIZE, 1.0),
+        )
+        repeat_caps = _get_ragged_capacities(communicator, large_hidden)
+
+        assert small_caps == (max(small_sizes), max(small_sizes))
+        assert small_repeat_caps == small_caps
+        assert large_caps == (max(large_sizes), max(large_sizes))
+        assert large_caps[0] > small_caps[0]
+        assert large_caps[1] > small_caps[1]
+        assert repeat_caps == large_caps
+
+        dist.barrier()
+    except Exception as err:
+        _report_worker_failure(rank, err_q, err)
+
+
+def _uniform_sizes_shm_worker(
+    rank,
+    world_size,
+    tp_size,
+    dp_size,
+    port,
+    dp_port,
+    sizes,
+    err_q,
+):
+    try:
+        os.environ.setdefault("VLLM_DIST_IDENT", f"test_cpu_dp_uniform_sizes_{port}")
+        _init_tp_dp_environment(rank, tp_size, dp_size, port, dp_port)
+
+        dp_group, communicator = _get_dp_shm_communicator()
+        hidden = _filled(sizes[rank], HIDDEN_SIZE, float(rank + 1))
+        expected_hidden = _concat_rank_values(sizes, HIDDEN_SIZE, 1.0)
+
+        explicit_sizes = dp_group.all_gatherv(hidden.clone(), sizes=sizes)
+        implicit_sizes = dp_group.all_gatherv(hidden.clone(), sizes=None)
+
+        torch.testing.assert_close(explicit_sizes, expected_hidden)
+        torch.testing.assert_close(implicit_sizes, expected_hidden)
+        torch.testing.assert_close(explicit_sizes, implicit_sizes)
+        assert _get_ragged_capacities(communicator, hidden) == (0, 0)
+
+        dist.barrier()
+    except Exception as err:
+        _report_worker_failure(rank, err_q, err)
+
+
+def _all_zero_gatherv_worker(
+    rank,
+    world_size,
+    tp_size,
+    dp_size,
+    port,
+    dp_port,
+    params,
+    err_q,
+):
+    try:
+        os.environ.setdefault("VLLM_DIST_IDENT", f"test_cpu_dp_zero_gather_{port}")
+        _init_tp_dp_environment(rank, tp_size, dp_size, port, dp_port)
+
+        from vllm.distributed.parallel_state import get_dp_group
+
+        sizes = [0] * dp_size
+        hidden = torch.empty((0, HIDDEN_SIZE), dtype=torch.float32)
+        gathered = get_dp_group().all_gatherv(hidden.clone(), sizes=sizes)
+
+        assert gathered.shape == (0, HIDDEN_SIZE)
+        assert gathered.numel() == 0
+
+        dist.barrier()
+    except Exception as err:
+        _report_worker_failure(rank, err_q, err)
+
+
+def _implicit_uneven_reduce_scatterv_worker(
+    rank,
+    world_size,
+    tp_size,
+    dp_size,
+    port,
+    dp_port,
+    params,
+    err_q,
+):
+    try:
+        os.environ.setdefault(
+            "VLLM_DIST_IDENT", f"test_cpu_dp_uneven_reduce_scatterv_{port}"
+        )
+        _init_tp_dp_environment(rank, tp_size, dp_size, port, dp_port)
+
+        from vllm.distributed.parallel_state import get_dp_group
+
+        hidden = _filled(3, HIDDEN_SIZE, float(rank + 1))
+        with pytest.raises(
+            AssertionError,
+            match="Implicit reduce_scatterv requires the scatter dimension",
+        ):
+            get_dp_group().reduce_scatterv(hidden, dim=0, sizes=None)
+
+        dist.barrier()
+    except Exception as err:
+        _report_worker_failure(rank, err_q, err)
+
+
+def _dp_shm_group_name_worker(
+    rank,
+    world_size,
+    tp_size,
+    dp_size,
+    port,
+    dp_port,
+    params,
+    err_q,
+):
+    try:
+        from vllm.config import VllmConfig, set_current_vllm_config
+        from vllm.config.parallel import ParallelConfig
+        from vllm.distributed.parallel_state import (
+            ensure_model_parallel_initialized,
+            get_dp_group,
+            init_distributed_environment,
+        )
+        from vllm.v1.worker.cpu_worker import _get_cpushm_dist_ident
+
+        dp_rank = rank // tp_size
+        tp_rank = rank % tp_size
+        distributed_init_method = f"tcp://127.0.0.1:{port}"
+
+        vllm_config = VllmConfig()
+        vllm_config.parallel_config = ParallelConfig(
+            tensor_parallel_size=tp_size,
+            data_parallel_size=dp_size,
+            data_parallel_rank=dp_rank,
+            data_parallel_master_ip="127.0.0.1",
+            _data_parallel_master_port_list=[int(dp_port)],
+        )
+        os.environ["VLLM_DIST_IDENT"] = _get_cpushm_dist_ident(
+            vllm_config.parallel_config,
+            distributed_init_method,
+        )
+
+        with set_current_vllm_config(vllm_config):
+            init_distributed_environment(
+                world_size=tp_size,
+                rank=tp_rank,
+                distributed_init_method=distributed_init_method,
+                local_rank=rank,
+                backend="gloo",
+            )
+            ensure_model_parallel_initialized(tp_size, 1, backend="gloo")
+
+            dp_group = get_dp_group()
+            communicator = dp_group.device_communicator
+            assert communicator is not None
+            assert communicator._all_group_ranks_share_shm_group_name()
+
+            dist.barrier()
+    except Exception as err:
+        _report_worker_failure(rank, err_q, err)
+
+
+def _moe_parallel_config_worker(
+    rank,
+    world_size,
+    tp_size,
+    dp_size,
+    port,
+    dp_port,
+    params,
+    err_q,
+):
+    try:
+        os.environ.setdefault("VLLM_DIST_IDENT", f"test_cpu_moe_config_{port}")
+        _init_tp_dp_environment(rank, tp_size, dp_size, port, dp_port)
+
+        from vllm.config.parallel import ParallelConfig
+        from vllm.distributed.parallel_state import (
+            get_dp_group,
+            get_ep_group,
+            get_tp_group,
+        )
+        from vllm.model_executor.layers.fused_moe.config import (
+            FusedMoEParallelConfig,
+        )
+
+        dp_rank = rank // tp_size
+        tp_rank = rank % tp_size
+        expected_tp_ranks = list(range(dp_rank * tp_size, (dp_rank + 1) * tp_size))
+        expected_dp_ranks = list(range(tp_rank, world_size, tp_size))
+
+        assert get_tp_group().ranks == expected_tp_ranks
+        assert get_dp_group().ranks == expected_dp_ranks
+        assert get_dp_group().rank_in_group == dp_rank
+        assert get_ep_group().ranks == list(range(world_size))
+
+        no_ep_parallel_config = ParallelConfig(
+            tensor_parallel_size=tp_size,
+            data_parallel_size=dp_size,
+            data_parallel_rank=dp_rank,
+            enable_expert_parallel=False,
+        )
+        no_ep_moe_config = FusedMoEParallelConfig.make(
+            tp_size_=tp_size,
+            pcp_size_=1,
+            dp_size_=dp_size,
+            sp_size_=1,
+            vllm_parallel_config=no_ep_parallel_config,
+        )
+        assert no_ep_moe_config.tp_size == world_size
+        assert no_ep_moe_config.tp_rank == rank
+        assert no_ep_moe_config.dp_size == dp_size
+        assert no_ep_moe_config.dp_rank == dp_rank
+        assert no_ep_moe_config.ep_size == 1
+        assert no_ep_moe_config.ep_rank == 0
+        assert not no_ep_moe_config.use_ep
+
+        ep_parallel_config = ParallelConfig(
+            tensor_parallel_size=tp_size,
+            data_parallel_size=dp_size,
+            data_parallel_rank=dp_rank,
+            enable_expert_parallel=True,
+        )
+        ep_moe_config = FusedMoEParallelConfig.make(
+            tp_size_=tp_size,
+            pcp_size_=1,
+            dp_size_=dp_size,
+            sp_size_=1,
+            vllm_parallel_config=ep_parallel_config,
+        )
+        assert ep_moe_config.tp_size == 1
+        assert ep_moe_config.tp_rank == 0
+        assert ep_moe_config.dp_size == dp_size
+        assert ep_moe_config.dp_rank == dp_rank
+        assert ep_moe_config.ep_size == world_size
+        assert ep_moe_config.ep_rank == rank
+        assert ep_moe_config.use_ep
+
+        dist.barrier()
+    except Exception as err:
+        _report_worker_failure(rank, err_q, err)
+
+
+def _tp_shm_all_reduce_worker(
+    rank,
+    world_size,
+    tp_size,
+    dp_size,
+    port,
+    dp_port,
+    params,
+    err_q,
+):
+    """Confirm the TP all-reduce path uses SHM and matches gloo."""
+    try:
+        os.environ.setdefault("VLLM_DIST_IDENT", f"test_cpu_tp_shm_all_reduce_{port}")
+        _init_tp_dp_environment(rank, tp_size, dp_size, port, dp_port)
+
+        tp_group, _ = _get_tp_shm_communicator()
+        tensor = torch.arange(12, dtype=torch.float32).reshape(3, 4) + float(rank)
+
+        ref = tensor.clone()
+        dist.all_reduce(ref, group=tp_group.cpu_group)
+
+        orig_all_reduce = dist.all_reduce
+
+        def forbidden_all_reduce(*args, **kwargs):
+            raise AssertionError("TP SHM all_reduce fell back to torch.distributed")
+
+        dist.all_reduce = forbidden_all_reduce
+        try:
+            shm_result = tp_group.all_reduce(tensor.clone())
+        finally:
+            dist.all_reduce = orig_all_reduce
+
+        torch.testing.assert_close(shm_result, ref)
+
+        dist.barrier()
+    except Exception as err:
+        _report_worker_failure(rank, err_q, err)
+
+
+def _dp_shm_all_reduce_worker(
+    rank,
+    world_size,
+    tp_size,
+    dp_size,
+    port,
+    dp_port,
+    params,
+    err_q,
+):
+    """Confirm the DP SHM all-reduce matches the gloo reference exactly."""
+    try:
+        os.environ.setdefault("VLLM_DIST_IDENT", f"test_cpu_dp_shm_all_reduce_{port}")
+        _init_tp_dp_environment(rank, tp_size, dp_size, port, dp_port)
+
+        dp_group, _ = _get_dp_shm_communicator()
+        tensor = torch.arange(12, dtype=torch.float32).reshape(3, 4) + float(rank)
+
+        # Gloo reference (SUM over the DP group's cpu_group).
+        ref = tensor.clone()
+        dist.all_reduce(ref, group=dp_group.cpu_group)
+
+        shm_result = dp_group.all_reduce(tensor.clone())
+
+        torch.testing.assert_close(shm_result, ref)
+
+        dist.barrier()
+    except Exception as err:
+        _report_worker_failure(rank, err_q, err)
+
+
+@pytest.mark.distributed
+@pytest.mark.parametrize("sizes", [[2, 1], [0, 3]], ids=["ragged", "zero-rank"])
+def test_cpu_ep_dispatch_combine_ragged(sizes):
+    _spawn_workers(
+        _ragged_dispatch_worker,
+        world_size=2,
+        tp_size=1,
+        dp_size=2,
+        params=sizes,
+    )
+
+
+@pytest.mark.distributed
+def test_cpu_ep_sequence_parallel_uses_ep_group():
+    _spawn_workers(
+        _sequence_parallel_worker,
+        world_size=6,
+        tp_size=2,
+        dp_size=3,
+        params=[3, 1, 5],
+    )
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not hasattr(torch, "compile"), reason="torch.compile required")
+def test_cpu_ep_compile_ragged_fastpath():
+    _spawn_workers(
+        _compile_fastpath_worker,
+        world_size=2,
+        tp_size=1,
+        dp_size=2,
+        params=[[2, 1], [0, 3]],
+    )
+
+
+@pytest.mark.distributed
+def test_cpu_dp_group_ranks_share_shm_group_name():
+    _spawn_workers(
+        _dp_shm_group_name_worker,
+        world_size=2,
+        tp_size=1,
+        dp_size=2,
+        params=None,
+        distributed_init_ports=[get_open_port(), get_open_port()],
+        dp_port=get_open_port(),
+    )
+
+
+@pytest.mark.distributed
+def test_cpu_moe_tp2_dp3_parallel_config():
+    _spawn_workers(
+        _moe_parallel_config_worker,
+        world_size=6,
+        tp_size=2,
+        dp_size=3,
+        params=None,
+    )
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not HAS_CPU_SHM, reason="CPU SHM communicator required")
+def test_cpu_dp_all_gatherv_ragged_shm_buffers_reuse_and_grow():
+    _spawn_workers(
+        _ragged_shm_buffers_worker,
+        world_size=2,
+        tp_size=1,
+        dp_size=2,
+        params=[[1, 0], [3, 1]],
+    )
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not HAS_CPU_SHM, reason="CPU SHM communicator required")
+def test_cpu_dp_all_gatherv_uniform_sizes_matches_direct_shm_gather():
+    _spawn_workers(
+        _uniform_sizes_shm_worker,
+        world_size=2,
+        tp_size=1,
+        dp_size=2,
+        params=[2, 2],
+    )
+
+
+@pytest.mark.distributed
+def test_cpu_dp_all_gatherv_all_zero_rows():
+    _spawn_workers(
+        _all_zero_gatherv_worker,
+        world_size=2,
+        tp_size=1,
+        dp_size=2,
+        params=None,
+    )
+
+
+@pytest.mark.distributed
+def test_cpu_dp_reduce_scatterv_implicit_sizes_require_even_split():
+    _spawn_workers(
+        _implicit_uneven_reduce_scatterv_worker,
+        world_size=2,
+        tp_size=1,
+        dp_size=2,
+        params=None,
+    )
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not HAS_CPU_SHM, reason="CPU SHM communicator required")
+def test_cpu_dp_shm_all_reduce_matches_gloo():
+    _spawn_workers(
+        _dp_shm_all_reduce_worker,
+        world_size=6,
+        tp_size=1,
+        dp_size=6,
+        params=None,
+    )
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not HAS_CPU_SHM, reason="CPU SHM communicator required")
+def test_cpu_tp_shm_all_reduce_matches_gloo_without_fallback():
+    _spawn_workers(
+        _tp_shm_all_reduce_worker,
+        world_size=6,
+        tp_size=2,
+        dp_size=3,
+        params=None,
+    )

--- a/tests/distributed/test_cpu_moe_ep.py
+++ b/tests/distributed/test_cpu_moe_ep.py
@@ -1,0 +1,718 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU FP8 MoE expert-parallel integration coverage."""
+
+import math
+import os
+import traceback
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from vllm.platforms import current_platform
+from vllm.platforms.interface import CpuArchEnum
+from vllm.utils.network_utils import get_open_port
+
+if not current_platform.is_cpu():
+    pytest.skip("CPU-only test", allow_module_level=True)
+
+import vllm._custom_ops as ops  # noqa: E402
+from vllm.model_executor.models.utils import sequence_parallel_chunk  # noqa: E402
+
+if not hasattr(torch.ops._C, "fused_experts_cpu"):
+    pytest.skip("fused_experts_cpu op not available", allow_module_level=True)
+
+HAS_CPU_SHM = hasattr(torch.ops._C, "init_shm_manager") and (
+    current_platform.get_cpu_architecture()
+    in (CpuArchEnum.X86, CpuArchEnum.ARM, CpuArchEnum.POWERPC)
+)
+
+
+def _ensure_spawn_start_method():
+    if mp.get_start_method(allow_none=True) is None:
+        mp.set_start_method("spawn")
+
+
+def _report_worker_failure(rank: int, err_q: mp.Queue, err: Exception) -> None:
+    err_q.put(f"[Rank {rank}]\n{traceback.format_exc()}")
+    raise SystemExit(1) from err
+
+
+def _collect_worker_failures(procs, err_q: mp.Queue) -> list[str]:
+    exit_errors = []
+    for rank, proc in enumerate(procs):
+        proc.join()
+        if proc.exitcode != 0:
+            exit_errors.append(f"[Rank {rank}] worker exited with code {proc.exitcode}")
+
+    errors = []
+    while not err_q.empty():
+        errors.append(err_q.get_nowait())
+    err_q.close()
+    err_q.join_thread()
+    return errors + exit_errors
+
+
+def _spawn_workers(
+    worker_fn,
+    world_size,
+    tp_size,
+    dp_size,
+    params,
+    *,
+    distributed_init_ports=None,
+    dp_port=None,
+):
+    _ensure_spawn_start_method()
+
+    if distributed_init_ports is None:
+        shared_init_port = get_open_port()
+        distributed_init_ports = [shared_init_port] * world_size
+    elif len(distributed_init_ports) != world_size:
+        raise ValueError("distributed_init_ports must provide one port per worker rank")
+
+    if dp_port is None:
+        dp_port = get_open_port()
+
+    err_q: mp.Queue = mp.Queue()
+    procs = []
+    for rank in range(world_size):
+        proc = mp.Process(
+            target=worker_fn,
+            args=(
+                rank,
+                world_size,
+                tp_size,
+                dp_size,
+                distributed_init_ports[rank],
+                dp_port,
+                params,
+                err_q,
+            ),
+        )
+        proc.start()
+        procs.append(proc)
+
+    failures = _collect_worker_failures(procs, err_q)
+    if failures:
+        pytest.fail("Worker(s) failed:\n" + "\n---\n".join(failures))
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (mirrors tests/kernels/moe/test_cpu_quant_fused_moe.py)
+# ---------------------------------------------------------------------------
+
+BLOCK_SIZE = [128, 128]
+_FP8_INFO = torch.finfo(torch.float8_e4m3fn)
+FP8_SCALE = _FP8_INFO.max
+FACTOR_FOR_SCALE = 1e-3
+
+
+def _prepack_experts(w: torch.Tensor) -> torch.Tensor:
+    return torch.ops._C.convert_weight_packed(w)
+
+
+def _make_fp8_moe_weights(E, N, K, block_size):
+    block_n, block_k = block_size
+    w1 = (
+        (torch.randn(E, 2 * N, K) * FP8_SCALE)
+        .clamp(-FP8_SCALE, FP8_SCALE)
+        .to(torch.float8_e4m3fn)
+    )
+    w2 = (
+        (torch.randn(E, K, N) * FP8_SCALE)
+        .clamp(-FP8_SCALE, FP8_SCALE)
+        .to(torch.float8_e4m3fn)
+    )
+    w1_s = (
+        torch.randn(E, math.ceil(2 * N / block_n), math.ceil(K / block_k))
+        * FACTOR_FOR_SCALE
+    )
+    w2_s = (
+        torch.randn(E, math.ceil(K / block_n), math.ceil(N / block_k))
+        * FACTOR_FOR_SCALE
+    )
+    return w1, w2, w1_s, w2_s
+
+
+def _get_local_expert_slice(
+    expert_map: torch.Tensor,
+    local_num_experts: int,
+) -> slice:
+    owned = (expert_map != -1).nonzero(as_tuple=False)
+    expert_lo = int(owned[0].item())
+    return slice(expert_lo, expert_lo + local_num_experts)
+
+
+def _run_single_rank_reference(a, w1, w2, w1_s, w2_s, topk_weight, topk_ids, E):
+    """Single-process FP8 MoE forward over all E experts (no EP masking)."""
+    pw1, pw2 = _prepack_experts(w1), _prepack_experts(w2)
+    return ops.fused_experts_cpu(
+        a.clone(),
+        pw1,
+        pw2,
+        topk_weight,
+        topk_ids,
+        False,
+        ops.CPUQuantMethod.FP8_W8A16,
+        w1_s,
+        w2_s,
+        None,
+        None,
+        BLOCK_SIZE,
+        is_vnni=True,
+    )
+
+
+def _sequence_parallel_all_gather(
+    tensor: torch.Tensor,
+    tp_group,
+    num_tokens: int,
+) -> torch.Tensor:
+    return tp_group.all_gather(tensor, dim=0)[:num_tokens]
+
+
+# ---------------------------------------------------------------------------
+# Distributed environment setup
+# ---------------------------------------------------------------------------
+
+
+def _init_tp_dp_environment(rank, tp_size, dp_size, port, dp_port):
+    """Init vLLM distributed env for TP=tp_size, DP=dp_size.
+
+    global_rank = dp_rank * tp_size + tp_rank
+    Each DP replica contributes tp_size workers; init_distributed_environment
+    offsets rank by dp_rank*tp_size internally.
+    """
+    from vllm.config import VllmConfig, set_current_vllm_config
+    from vllm.config.parallel import ParallelConfig
+    from vllm.distributed.parallel_state import (
+        ensure_model_parallel_initialized,
+        init_distributed_environment,
+    )
+
+    dp_rank = rank // tp_size
+    tp_rank = rank % tp_size
+
+    vllm_config = VllmConfig()
+    vllm_config.parallel_config = ParallelConfig(
+        tensor_parallel_size=tp_size,
+        data_parallel_size=dp_size,
+        data_parallel_rank=dp_rank,
+        enable_expert_parallel=True,
+        _data_parallel_master_port_list=[int(dp_port)],
+    )
+    with set_current_vllm_config(vllm_config):
+        init_distributed_environment(
+            world_size=tp_size,
+            rank=tp_rank,
+            distributed_init_method=f"tcp://localhost:{port}",
+            local_rank=rank,
+            backend="gloo",
+        )
+        ensure_model_parallel_initialized(tp_size, 1, backend="gloo")
+
+
+def _make_forward_context(
+    dp_rank,
+    dp_size,
+    num_tokens_per_dp_rank,
+    num_tokens_across_dp=None,
+):
+    """Forward context with DP metadata for EP group dispatch."""
+    from vllm.config.parallel import ParallelConfig
+    from vllm.config.vllm import VllmConfig
+    from vllm.forward_context import set_forward_context
+
+    class _AttnMeta:
+        dp_metadata = None
+
+    vllm_config = VllmConfig()
+    vllm_config.parallel_config = ParallelConfig(
+        data_parallel_size=dp_size,
+        is_moe_model=True,
+        data_parallel_rank=dp_rank,
+    )
+    return set_forward_context(
+        _AttnMeta(),
+        vllm_config,
+        num_tokens=num_tokens_per_dp_rank,
+        num_tokens_across_dp=torch.tensor(
+            num_tokens_across_dp
+            if num_tokens_across_dp is not None
+            else [num_tokens_per_dp_rank] * dp_size,
+            dtype=torch.int,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Worker function
+# ---------------------------------------------------------------------------
+
+
+def _moe_ep_worker(rank, world_size, tp_size, dp_size, port, dp_port, params, err_q):
+    try:
+        # Required by CpuCommunicator's SHM-group-name check on TP groups.
+        os.environ.setdefault("VLLM_DIST_IDENT", f"test_cpu_moe_ep_{port}")
+        _init_tp_dp_environment(rank, tp_size, dp_size, port, dp_port)
+
+        from vllm.distributed.device_communicators.cpu_communicator import (
+            CpuCommunicator,
+            _CPUSHMDistributed,
+        )
+        from vllm.distributed.parallel_state import (
+            get_ep_group,
+            get_tp_group,
+        )
+        from vllm.forward_context import get_forward_context
+        from vllm.model_executor.layers.fused_moe.expert_map_manager import (
+            determine_expert_map,
+        )
+
+        M_per_dp, N, K, E, topk, seed, is_sequence_parallel = params
+        torch.manual_seed(seed)
+
+        dp_rank = rank // tp_size
+        tp_rank = rank % tp_size
+        ep_rank = dp_rank * tp_size + tp_rank  # flattened ep rank
+
+        # Build shared inputs (same across all ranks via fixed seed)
+        # M_per_dp tokens per DP replica; total M = dp_size * M_per_dp
+        total_M = dp_size * M_per_dp
+        a_all = torch.randn(total_M, K, dtype=torch.bfloat16) / math.sqrt(K)
+        w1, w2, w1_s, w2_s = _make_fp8_moe_weights(E, N, K, BLOCK_SIZE)
+        score = torch.softmax(
+            torch.randn(total_M, E, dtype=torch.bfloat16), dim=-1, dtype=torch.float32
+        )
+        topk_weight_all, topk_ids_all = torch.topk(score, topk)
+        topk_ids_all = topk_ids_all.to(torch.int32)
+
+        # Single-rank reference (no EP, all experts)
+        ref = _run_single_rank_reference(
+            a_all, w1, w2, w1_s, w2_s, topk_weight_all, topk_ids_all, E
+        )
+
+        # This rank's DP slice
+        lo, hi = dp_rank * M_per_dp, (dp_rank + 1) * M_per_dp
+        a_local = a_all[lo:hi].clone()
+        topk_weight_local = topk_weight_all[lo:hi]
+        topk_ids_local_global = topk_ids_all[lo:hi]
+
+        if is_sequence_parallel:
+            a_local = sequence_parallel_chunk(a_local)
+            topk_weight_local = sequence_parallel_chunk(topk_weight_local)
+            topk_ids_local_global = sequence_parallel_chunk(topk_ids_local_global)
+
+        # Expert placement for this EP rank
+        ep_size = dp_size * tp_size
+        local_num_experts, expert_map, _ = determine_expert_map(
+            ep_size=ep_size,
+            ep_rank=ep_rank,
+            global_num_experts=E,
+        )
+        assert expert_map is not None
+
+        local_experts = _get_local_expert_slice(expert_map, local_num_experts)
+        w1_local = w1[local_experts].contiguous()
+        w2_local = w2[local_experts].contiguous()
+        w1_s_local = w1_s[local_experts].contiguous()
+        w2_s_local = w2_s[local_experts].contiguous()
+
+        with _make_forward_context(dp_rank, dp_size, M_per_dp):
+            ep_group = get_ep_group()
+            ep_communicator = ep_group.device_communicator
+            assert isinstance(ep_communicator, CpuCommunicator)
+            if HAS_CPU_SHM:
+                assert isinstance(ep_communicator.dist_module, _CPUSHMDistributed)
+            dp_metadata = get_forward_context().dp_metadata
+            assert dp_metadata is not None
+
+            sp_size = tp_size if is_sequence_parallel else 1
+            with dp_metadata.sp_local_sizes(sequence_parallel_size=sp_size):
+                # Non-SP dispatch gathers each TP lane's DP group. SP dispatch
+                # gathers the full EP group after sequence_parallel_chunk().
+                a_gathered, tw_gathered, tid_gathered = ep_group.dispatch(
+                    a_local.clone(),
+                    topk_weight_local.clone(),
+                    topk_ids_local_global.clone().long(),
+                    is_sequence_parallel=is_sequence_parallel,
+                )
+
+            # Expert compute: skip non-local selections (the shipped path).
+            pw1, pw2 = _prepack_experts(w1_local), _prepack_experts(w2_local)
+            expert_out = ops.fused_experts_cpu_local_skip(
+                a_gathered.clone(),
+                pw1,
+                pw2,
+                tw_gathered,
+                tid_gathered,
+                expert_map,
+                ops.CPUQuantMethod.FP8_W8A16,
+                w1_s_local,
+                w2_s_local,
+                None,  # w1_zero
+                None,  # w2_zero
+                BLOCK_SIZE,
+                None,  # w1_bias
+                None,  # w2_bias
+                None,  # alpha
+                None,  # limit
+                True,  # is_vnni
+            )
+
+            with dp_metadata.sp_local_sizes(sequence_parallel_size=sp_size):
+                # Non-SP combines to the DP-local slice per TP lane. SP combines
+                # to the TP-local token chunk, then the TP all-gather below
+                # restores the DP-local slice.
+                combined = ep_group.combine(
+                    expert_out,
+                    is_sequence_parallel=is_sequence_parallel,
+                )
+
+        tp_group = get_tp_group()
+        if is_sequence_parallel:
+            combined = _sequence_parallel_all_gather(
+                combined,
+                tp_group,
+                M_per_dp,
+            )
+        else:
+            # TP all-reduce merges complementary expert shards for each DP replica.
+            combined = tp_group.all_reduce(combined)
+
+        # Gather results from all ranks at rank 0 for verification.
+        # Each rank holds its DP-slice result [M_per_dp, K].
+        # We need to reconstruct the full [total_M, K] and compare to ref.
+        # Use TP group rank 0 per DP replica to avoid double-counting:
+        # TP partners now hold identical combined tensors post-all-reduce.
+        # new_group is a collective — all ranks must call it.
+        tp0_ranks = [r for r in range(world_size) if r % tp_size == 0]
+        tp0_group = dist.new_group(ranks=tp0_ranks, backend="gloo")
+
+        result_full = None
+        if tp_rank == 0:
+            # Only TP-rank-0 workers participate in gathering
+            all_slices = [torch.zeros_like(combined) for _ in range(dp_size)]
+            dist.all_gather(all_slices, combined, group=tp0_group)
+            result_full = torch.cat(all_slices, dim=0)
+
+        if rank == 0:
+            assert result_full is not None
+            torch.testing.assert_close(
+                ref.bfloat16(), result_full, atol=1e-2, rtol=1e-2
+            )
+
+        dist.barrier()
+
+    except Exception as err:
+        _report_worker_failure(rank, err_q, err)
+
+
+def _make_monolithic_ep_step(
+    backend,
+    packed_w1,
+    packed_w2,
+    w1_scale,
+    w2_scale,
+    expert_map,
+    topk,
+    total_sp_tokens,
+    local_sp_tokens,
+    num_real_tokens,
+):
+    from vllm.distributed.parallel_state import get_ep_group, get_tp_group
+    from vllm.model_executor.layers.fused_moe.experts.cpu_moe import select_experts
+
+    def step(hidden_states, router_logits):
+        hidden_states, router_logits = get_ep_group().dispatch_router_logits(
+            hidden_states,
+            router_logits,
+            is_sequence_parallel=True,
+        )
+        torch._check(hidden_states.shape[0] == total_sp_tokens)
+        topk_weights, topk_ids = select_experts(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+            use_grouped_topk=False,
+            top_k=topk,
+            renormalize=False,
+        )
+        expert_out = ops.fused_experts_cpu_local_skip(
+            hidden_states,
+            packed_w1,
+            packed_w2,
+            topk_weights,
+            topk_ids,
+            expert_map,
+            ops.CPUQuantMethod.FP8_W8A16,
+            w1_scale,
+            w2_scale,
+            None,
+            None,
+            BLOCK_SIZE,
+            None,
+            None,
+            None,
+            None,
+            True,
+        )
+        combined = get_ep_group().combine(
+            expert_out,
+            is_sequence_parallel=True,
+        )
+        torch._check(combined.shape[0] == local_sp_tokens)
+        return get_tp_group().all_gather(combined, dim=0)[:num_real_tokens]
+
+    if backend == "none":
+        return step
+    return torch.compile(step, fullgraph=True, backend=backend)
+
+
+def _run_all_experts_reference(
+    hidden_states,
+    router_logits,
+    packed_w1,
+    packed_w2,
+    w1_scale,
+    w2_scale,
+    topk,
+):
+    from vllm.model_executor.layers.fused_moe.experts.cpu_moe import select_experts
+
+    topk_weights, topk_ids = select_experts(
+        hidden_states=hidden_states,
+        router_logits=router_logits,
+        use_grouped_topk=False,
+        top_k=topk,
+        renormalize=False,
+    )
+    return ops.fused_experts_cpu(
+        hidden_states,
+        packed_w1,
+        packed_w2,
+        topk_weights,
+        topk_ids,
+        False,
+        ops.CPUQuantMethod.FP8_W8A16,
+        w1_scale,
+        w2_scale,
+        None,
+        None,
+        BLOCK_SIZE,
+        is_vnni=True,
+    )
+
+
+@torch._dynamo.config.patch(
+    capture_dynamic_output_shape_ops=True,
+    error_on_recompile=True,
+)
+def _run_monolithic_ep_step(
+    backend,
+    hidden_inputs,
+    router_inputs,
+    packed_w1,
+    packed_w2,
+    w1_scale,
+    w2_scale,
+    expert_map,
+    topk,
+    total_sp_tokens,
+    local_sp_tokens,
+    num_real_tokens,
+):
+    step = _make_monolithic_ep_step(
+        backend,
+        packed_w1,
+        packed_w2,
+        w1_scale,
+        w2_scale,
+        expert_map,
+        topk,
+        total_sp_tokens,
+        local_sp_tokens,
+        num_real_tokens,
+    )
+    return [
+        step(hidden_states, router_logits)
+        for hidden_states, router_logits in zip(hidden_inputs, router_inputs)
+    ]
+
+
+def _moe_ep_monolithic_compile_worker(
+    rank,
+    world_size,
+    tp_size,
+    dp_size,
+    port,
+    dp_port,
+    backend,
+    err_q,
+):
+    try:
+        os.environ.setdefault("VLLM_DIST_IDENT", f"test_cpu_moe_ep_compile_{port}")
+        _init_tp_dp_environment(rank, tp_size, dp_size, port, dp_port)
+        torch._dynamo.reset()
+
+        from vllm.model_executor.layers.fused_moe.expert_map_manager import (
+            determine_expert_map,
+        )
+
+        token_counts = [5, 4, 3]
+        hidden_size = 256
+        intermediate_size = 128
+        num_experts = 12
+        topk = 2
+        dp_rank = rank // tp_size
+        num_real_tokens = token_counts[dp_rank]
+        local_sp_tokens = math.ceil(num_real_tokens / tp_size)
+        total_sp_tokens = sum(
+            math.ceil(num_tokens / tp_size) * tp_size for num_tokens in token_counts
+        )
+
+        torch.manual_seed(0)
+        hidden_variants = [
+            torch.randn(
+                sum(token_counts),
+                hidden_size,
+                dtype=torch.bfloat16,
+            )
+            / math.sqrt(hidden_size)
+            for _ in range(2)
+        ]
+        router_variants = [
+            torch.randn(
+                sum(token_counts),
+                num_experts,
+                dtype=torch.bfloat16,
+            )
+            for _ in range(2)
+        ]
+        w1, w2, w1_s, w2_s = _make_fp8_moe_weights(
+            num_experts,
+            intermediate_size,
+            hidden_size,
+            BLOCK_SIZE,
+        )
+        packed_w1 = _prepack_experts(w1)
+        packed_w2 = _prepack_experts(w2)
+
+        start = sum(token_counts[:dp_rank])
+        end = start + num_real_tokens
+        hidden_dp = [hidden[start:end].clone() for hidden in hidden_variants]
+        router_dp = [router[start:end].clone() for router in router_variants]
+        references = [
+            _run_all_experts_reference(
+                hidden,
+                router,
+                packed_w1,
+                packed_w2,
+                w1_s,
+                w2_s,
+                topk,
+            )
+            for hidden, router in zip(hidden_dp, router_dp)
+        ]
+        hidden_local = [sequence_parallel_chunk(hidden) for hidden in hidden_dp]
+        router_local = [sequence_parallel_chunk(router) for router in router_dp]
+        assert all(tensor.shape[0] == local_sp_tokens for tensor in hidden_local)
+
+        local_num_experts, expert_map, _ = determine_expert_map(
+            ep_size=world_size,
+            ep_rank=rank,
+            global_num_experts=num_experts,
+        )
+        assert expert_map is not None
+        local_experts = _get_local_expert_slice(expert_map, local_num_experts)
+
+        with _make_forward_context(
+            dp_rank,
+            dp_size,
+            num_real_tokens,
+            token_counts,
+        ):
+            outputs = _run_monolithic_ep_step(
+                backend,
+                hidden_local,
+                router_local,
+                _prepack_experts(w1[local_experts].contiguous()),
+                _prepack_experts(w2[local_experts].contiguous()),
+                w1_s[local_experts].contiguous(),
+                w2_s[local_experts].contiguous(),
+                expert_map,
+                topk,
+                total_sp_tokens,
+                local_sp_tokens,
+                num_real_tokens,
+            )
+
+        for output, reference in zip(outputs, references):
+            assert output.shape[0] == token_counts[dp_rank]
+            torch.testing.assert_close(
+                output,
+                reference.bfloat16(),
+                atol=1e-2,
+                rtol=1e-2,
+            )
+
+        output_lengths = [None] * world_size
+        dist.all_gather_object(output_lengths, outputs[-1].shape[0])
+        assert output_lengths == [5, 5, 4, 4, 3, 3]
+        dist.barrier()
+    except Exception as err:
+        _report_worker_failure(rank, err_q, err)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+# (M_per_dp, N, K, E, topk, seed)
+_PARAMS = [
+    (8, 256, 512, 10, 2, 0, False),
+]
+
+_SP_PARAMS = [
+    (7, 256, 512, 10, 2, 0, True),
+]
+
+
+@pytest.mark.distributed
+@pytest.mark.parametrize("params", _PARAMS, ids=["E10-nondiv"])
+def test_cpu_moe_ep_dp6_tp1(params):
+    """TP=1, DP=6: pure expert parallelism baseline (EP=6)."""
+    _spawn_workers(_moe_ep_worker, world_size=6, tp_size=1, dp_size=6, params=params)
+
+
+@pytest.mark.distributed
+@pytest.mark.parametrize("params", _PARAMS, ids=["E10-nondiv"])
+def test_cpu_moe_ep_tp2_dp3(params):
+    """TP=2, DP=3: DP-lane AgRs plus final TP all-reduce (EP=6)."""
+    _spawn_workers(_moe_ep_worker, world_size=6, tp_size=2, dp_size=3, params=params)
+
+
+@pytest.mark.distributed
+@pytest.mark.parametrize("params", _SP_PARAMS, ids=["E10-nondiv-sp"])
+def test_cpu_moe_ep_tp2_dp3_sequence_parallel(params):
+    """TP=2, DP=3: full EP-group AgRs plus TP all-gather restore."""
+    _spawn_workers(_moe_ep_worker, world_size=6, tp_size=2, dp_size=3, params=params)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(
+    os.environ.get("VLLM_CPU_EP_MONOLITHIC_COMPILE_TEST") != "1",
+    reason="six-rank CPU EP compile regression is opt-in",
+)
+@pytest.mark.parametrize("backend", ["none", "eager", "inductor"])
+def test_cpu_moe_ep_monolithic_compile_tp2_dp3(backend):
+    """Synthetic SP alignment rows are discarded after CPU EP combine."""
+    _spawn_workers(
+        _moe_ep_monolithic_compile_worker,
+        world_size=6,
+        tp_size=2,
+        dp_size=3,
+        params=backend,
+    )

--- a/tests/kernels/moe/test_cpu_quant_fused_moe.py
+++ b/tests/kernels/moe/test_cpu_quant_fused_moe.py
@@ -31,6 +31,86 @@ def _prepack_experts(w: torch.Tensor) -> torch.Tensor:
     return torch.ops._C.convert_weight_packed(w)
 
 
+def _ref_unquant_moe(
+    a: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weight: torch.Tensor,
+    topk_ids: torch.Tensor,
+) -> torch.Tensor:
+    """Reference unquantized fused MoE in pure torch."""
+    B = a.shape[0]
+    topk = topk_ids.size(1)
+    out = torch.zeros(B, topk, w2.shape[1], dtype=torch.float32)
+
+    for b in range(B):
+        for t in range(topk):
+            eid = topk_ids[b, t].item()
+            if eid == -1:
+                continue
+            x = a[b : b + 1].float()
+            ic = torch.matmul(x, w1[eid].float().transpose(0, 1))
+            ic = _silu_and_mul(ic)
+            out[b, t] = torch.matmul(ic, w2[eid].float().transpose(0, 1))
+
+    return (out * topk_weight.view(B, topk, 1)).sum(dim=1).to(a.dtype)
+
+
+def _run_unquant_cpu_fused_moe(
+    a: torch.Tensor,
+    pw1: torch.Tensor,
+    pw2: torch.Tensor,
+    topk_weight: torch.Tensor,
+    topk_ids: torch.Tensor,
+) -> torch.Tensor:
+    return ops.fused_experts_cpu(
+        a.clone(),
+        pw1,
+        pw2,
+        topk_weight,
+        topk_ids,
+        False,
+        ops.CPUQuantMethod.UNQUANT,
+        None,
+        None,
+        None,
+        None,
+        None,
+        is_vnni=True,
+    )
+
+
+@pytest.mark.parametrize("seed", [0])
+def test_unquant_cpu_fused_moe_skip_padding(seed):
+    """topk_ids == -1 contributes zero for unquantized fused_experts_cpu."""
+    set_random_seed(seed)
+    M, N, K, E, topk = 4, 128, 256, 8, 2
+
+    a = torch.randn(M, K, dtype=torch.bfloat16) / math.sqrt(K)
+    w1 = torch.randn(E, 2 * N, K, dtype=torch.bfloat16) / math.sqrt(K)
+    w2 = torch.randn(E, K, N, dtype=torch.bfloat16) / math.sqrt(N)
+    pw1, pw2 = _prepack_experts(w1), _prepack_experts(w2)
+
+    score = torch.randn(M, E, dtype=torch.bfloat16)
+    score = torch.softmax(score, dim=-1, dtype=torch.float32)
+    topk_weight, topk_ids = torch.topk(score, topk)
+    topk_ids = topk_ids.to(torch.int32)
+
+    topk_ids_partial = topk_ids.clone()
+    topk_ids_partial[1, 0] = -1
+    topk_ids_partial[2, :] = -1
+
+    ref_out = _ref_unquant_moe(a, w1, w2, topk_weight, topk_ids_partial)
+    out = _run_unquant_cpu_fused_moe(a, pw1, pw2, topk_weight, topk_ids_partial)
+    torch.testing.assert_close(ref_out, out, atol=1e-2, rtol=1e-2)
+
+    topk_ids_all = torch.full_like(topk_ids, -1)
+    out_all_skipped = _run_unquant_cpu_fused_moe(a, pw1, pw2, topk_weight, topk_ids_all)
+    torch.testing.assert_close(
+        out_all_skipped, torch.zeros(M, K, dtype=out_all_skipped.dtype)
+    )
+
+
 # ===========================================================================
 # FP8 W8A16 MoE
 # ===========================================================================
@@ -147,6 +227,32 @@ def _make_fp8_moe_weights(
     return w1, w2, w1_s, w2_s
 
 
+def _run_fp8_cpu_fused_moe(
+    a: torch.Tensor,
+    pw1: torch.Tensor,
+    pw2: torch.Tensor,
+    topk_weight: torch.Tensor,
+    topk_ids: torch.Tensor,
+    w1_s: torch.Tensor,
+    w2_s: torch.Tensor,
+) -> torch.Tensor:
+    return ops.fused_experts_cpu(
+        a.clone(),
+        pw1,
+        pw2,
+        topk_weight,
+        topk_ids,
+        False,
+        ops.CPUQuantMethod.FP8_W8A16,
+        w1_s,
+        w2_s,
+        None,
+        None,
+        BLOCK_SIZE,
+        is_vnni=True,
+    )
+
+
 FP8_NUM_TOKENS = [1, 2, 64, 121]
 FP8_MOE_CONFIGS = [
     (256, 512, 8, 2),
@@ -217,6 +323,108 @@ def test_w8a16_block_fp8_cpu_fused_moe(M, N, K, E, topk, seed):
         is_vnni=True,
     )
     torch.testing.assert_close(out_inplace, out, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("invalid_expert_id", [-2, 8])
+@pytest.mark.parametrize("seed", [0])
+def test_w8a16_block_fp8_cpu_fused_moe_invalid_expert_id_raises(
+    invalid_expert_id, seed
+):
+    set_random_seed(seed)
+    M, N, K, E = 1, 384, 512, 8
+
+    a = torch.randn(M, K, dtype=torch.bfloat16) / math.sqrt(K)
+    w1, w2, w1_s, w2_s = _make_fp8_moe_weights(E, N, K, BLOCK_SIZE)
+    pw1, pw2 = _prepack_experts(w1), _prepack_experts(w2)
+    topk_weight = torch.tensor([[0.25, 0.75]], dtype=torch.float32)
+    topk_ids = torch.tensor([[invalid_expert_id, 3]], dtype=torch.int32)
+
+    with pytest.raises(RuntimeError, match="Invalid expert id"):
+        _run_fp8_cpu_fused_moe(a, pw1, pw2, topk_weight, topk_ids, w1_s, w2_s)
+
+
+@pytest.mark.parametrize("M,N,K,E,topk", [(8, 256, 512, 8, 2)])
+@pytest.mark.parametrize("seed", [0])
+def test_w8a16_block_fp8_cpu_fused_moe_skip_padding(M, N, K, E, topk, seed):
+    """topk_ids == -1 contributes zero for FP8."""
+    set_random_seed(seed)
+
+    a = torch.randn(M, K, dtype=torch.bfloat16) / math.sqrt(K)
+    w1, w2, w1_s, w2_s = _make_fp8_moe_weights(E, N, K, BLOCK_SIZE)
+    pw1, pw2 = _prepack_experts(w1), _prepack_experts(w2)
+
+    score = torch.randn(M, E, dtype=torch.bfloat16)
+    score = torch.softmax(score, dim=-1, dtype=torch.float32)
+    topk_weight, topk_ids = torch.topk(score, topk)
+    topk_ids = topk_ids.to(torch.int32)
+
+    topk_ids_partial = topk_ids.clone()
+    topk_ids_partial[1, 0] = -1
+    topk_ids_partial[2, :] = -1
+
+    ref_out = ref_w8a16_block_fp8_moe(
+        a, w1, w2, w1_s, w2_s, topk_weight, topk_ids_partial, BLOCK_SIZE
+    )
+    out = ops.fused_experts_cpu(
+        a.clone(),
+        pw1,
+        pw2,
+        topk_weight,
+        topk_ids_partial,
+        False,
+        ops.CPUQuantMethod.FP8_W8A16,
+        w1_s,
+        w2_s,
+        None,
+        None,
+        BLOCK_SIZE,
+        is_vnni=True,
+    )
+    torch.testing.assert_close(ref_out.bfloat16(), out, atol=1e-2, rtol=1e-2)
+
+    topk_ids_all = torch.full_like(topk_ids, -1)
+    out_all_skipped = ops.fused_experts_cpu(
+        a.clone(),
+        pw1,
+        pw2,
+        topk_weight,
+        topk_ids_all,
+        False,
+        ops.CPUQuantMethod.FP8_W8A16,
+        w1_s,
+        w2_s,
+        None,
+        None,
+        BLOCK_SIZE,
+        is_vnni=True,
+    )
+    torch.testing.assert_close(
+        out_all_skipped, torch.zeros(M, K, dtype=out_all_skipped.dtype)
+    )
+
+
+@pytest.mark.parametrize("seed", [0])
+def test_w8a16_block_fp8_cpu_fused_moe_skip_padding_validates_scale_shape(seed):
+    """All-skipped batches still validate required FP8 scale inputs."""
+    set_random_seed(seed)
+    M, N, K, E, topk = 2, 256, 512, 8, 2
+
+    a = torch.randn(M, K, dtype=torch.bfloat16) / math.sqrt(K)
+    w1, w2, w1_s, w2_s = _make_fp8_moe_weights(E, N, K, BLOCK_SIZE)
+    pw1, pw2 = _prepack_experts(w1), _prepack_experts(w2)
+    topk_weight = torch.full((M, topk), 0.5, dtype=torch.float32)
+    topk_ids = torch.full((M, topk), -1, dtype=torch.int32)
+
+    with pytest.raises(RuntimeError):
+        _run_fp8_cpu_fused_moe(
+            a,
+            pw1,
+            pw2,
+            topk_weight,
+            topk_ids,
+            w1_s[:, :-1, :],
+            w2_s,
+        )
 
 
 # ===========================================================================
@@ -376,6 +584,31 @@ def _prepack_mxfp4_experts(
     return packed_w, packed_s
 
 
+def _run_mxfp4_cpu_fused_moe(
+    a: torch.Tensor,
+    pw1: torch.Tensor,
+    pw2: torch.Tensor,
+    topk_weight: torch.Tensor,
+    topk_ids: torch.Tensor,
+    pw1s: torch.Tensor,
+    pw2s: torch.Tensor,
+) -> torch.Tensor:
+    return ops.fused_experts_cpu(
+        a.clone(),
+        pw1,
+        pw2,
+        topk_weight,
+        topk_ids,
+        False,  # inplace
+        ops.CPUQuantMethod.MXFP4,
+        pw1s,  # w1_scale
+        pw2s,  # w2_scale
+        None,  # w1_zero
+        None,  # w2_zero
+        None,  # block_size
+    )
+
+
 MXFP4_NUM_TOKENS = [1, 2, 32, 121]
 MXFP4_MOE_CONFIGS = [
     (128, 128, 4, 2),
@@ -420,22 +653,75 @@ def test_mxfp4_cpu_fused_moe(M, N, K, E, topk, seed):
     pw2, pw2s = _prepack_mxfp4_experts(w2q, w2s)
 
     # Kernel
-    out = ops.fused_experts_cpu(
-        a.clone(),
+    out = _run_mxfp4_cpu_fused_moe(
+        a,
         pw1,
         pw2,
         topk_weight,
         topk_ids,
-        False,  # inplace
-        ops.CPUQuantMethod.MXFP4,
-        pw1s,  # w1_scale
-        pw2s,  # w2_scale
-        None,  # w1_zero
-        None,  # w2_zero
-        None,  # block_size
+        pw1s,
+        pw2s,
     )
 
     torch.testing.assert_close(ref_out.bfloat16(), out, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("M,N,K,E,topk", [(2, 128, 128, 4, 2)])
+@pytest.mark.parametrize("seed", [0])
+def test_mxfp4_cpu_fused_moe_skip_padding(M, N, K, E, topk, seed):
+    """topk_ids == -1 contributes zero for MXFP4."""
+    set_random_seed(seed)
+    dtype = torch.bfloat16
+
+    a = torch.randn(M, K, dtype=dtype) / 10
+
+    w1_bf16 = torch.randn(E, 2 * N, K, dtype=dtype) / 10
+    w1q, w1s = MXFP4QuantizeUtil.quantize(w1_bf16)
+    w1s = w1s.reshape(E, 2 * N, K // 32)
+    w1dq = MXFP4QuantizeUtil.dequantize(w1q, dtype, w1s)
+
+    w2_bf16 = torch.randn(E, K, N, dtype=dtype) / 10
+    w2q, w2s = MXFP4QuantizeUtil.quantize(w2_bf16)
+    w2s = w2s.reshape(E, K, N // 32)
+    w2dq = MXFP4QuantizeUtil.dequantize(w2q, dtype, w2s)
+
+    score = torch.randn(M, E, dtype=dtype)
+    score = torch.softmax(score, dim=-1, dtype=torch.float32)
+    topk_weight, topk_ids = torch.topk(score, topk)
+    topk_ids = topk_ids.to(torch.int32)
+
+    pw1, pw1s = _prepack_mxfp4_experts(w1q, w1s)
+    pw2, pw2s = _prepack_mxfp4_experts(w2q, w2s)
+
+    topk_ids_partial = topk_ids.clone()
+    topk_ids_partial[0, 0] = -1
+    topk_ids_partial[1, :] = -1
+
+    ref_out = ref_mxfp4_fused_moe(a, w1dq, w2dq, topk_weight, topk_ids_partial, topk)
+    out = _run_mxfp4_cpu_fused_moe(
+        a,
+        pw1,
+        pw2,
+        topk_weight,
+        topk_ids_partial,
+        pw1s,
+        pw2s,
+    )
+    torch.testing.assert_close(ref_out.bfloat16(), out, atol=1e-2, rtol=1e-2)
+
+    topk_ids_all = torch.full_like(topk_ids, -1)
+    out_all_skipped = _run_mxfp4_cpu_fused_moe(
+        a,
+        pw1,
+        pw2,
+        topk_weight,
+        topk_ids_all,
+        pw1s,
+        pw2s,
+    )
+    torch.testing.assert_close(
+        out_all_skipped, torch.zeros(M, K, dtype=out_all_skipped.dtype)
+    )
 
 
 @pytest.mark.parametrize("M", [1, 32])
@@ -552,6 +838,8 @@ def _ref_int4_moe(
     for b in range(B):
         for t in range(topk):
             eid = topk_ids[b, t].item()
+            if eid == -1:
+                continue
             x = a[b : b + 1].float()
 
             # Dequantize w1: [K, 2*N], groups along K (input dim)
@@ -669,6 +957,62 @@ def _make_int4_moe_weights(E, N, K, group_size, quant_algo):
     )
 
 
+def _prepare_int4_moe_layer(
+    w1_packed: torch.Tensor,
+    w2_packed: torch.Tensor,
+    w1_s: torch.Tensor,
+    w2_s: torch.Tensor,
+    quant_algo,
+    w1_zeros_packed: torch.Tensor,
+    w2_zeros_packed: torch.Tensor,
+):
+    from vllm.model_executor.layers.fused_moe.experts.cpu_moe import (
+        prepare_int4_moe_layer_for_cpu,
+    )
+
+    return prepare_int4_moe_layer_for_cpu(
+        w1_packed,
+        w2_packed,
+        w1_s,
+        w2_s,
+        quant_algo=quant_algo,
+        w13_zeros=w1_zeros_packed,
+        w2_zeros=w2_zeros_packed,
+    )
+
+
+def _run_int4_cpu_fused_moe(
+    a: torch.Tensor,
+    blocked_w1: torch.Tensor,
+    blocked_w2: torch.Tensor,
+    topk_weight: torch.Tensor,
+    topk_ids: torch.Tensor,
+    blocked_s1: torch.Tensor,
+    blocked_s2: torch.Tensor,
+    blocked_z1: torch.Tensor,
+    blocked_z2: torch.Tensor,
+) -> torch.Tensor:
+    return ops.fused_experts_cpu(
+        a.clone(),
+        blocked_w1,
+        blocked_w2,
+        topk_weight,
+        topk_ids,
+        False,  # inplace
+        ops.CPUQuantMethod.INT4_W4A8,
+        blocked_s1,
+        blocked_s2,
+        blocked_z1,
+        blocked_z2,
+        None,  # block_size
+        None,  # w1_bias
+        None,  # w2_bias
+        None,  # alpha
+        None,  # limit
+        True,  # is_vnni
+    )
+
+
 INT4_MOE_CONFIGS = [
     # (N, K, E, topk, group_size)
     (256, 512, 8, 2, 128),
@@ -718,42 +1062,116 @@ def test_int4_w4a16_cpu_fused_moe(M, N, K, E, topk, group_size, quant_algo, seed
         group_size,
     )
 
-    from vllm.model_executor.layers.fused_moe.experts.cpu_moe import (
-        prepare_int4_moe_layer_for_cpu,
-    )
-
     (blocked_w1, blocked_w2, blocked_s1, blocked_s2, blocked_z1, blocked_z2) = (
-        prepare_int4_moe_layer_for_cpu(
+        _prepare_int4_moe_layer(
             w1_packed,
             w2_packed,
             w1_s,
             w2_s,
-            quant_algo=quant_algo,
-            w13_zeros=w1_zeros_packed,
-            w2_zeros=w2_zeros_packed,
+            quant_algo,
+            w1_zeros_packed,
+            w2_zeros_packed,
         )
     )
 
-    out = ops.fused_experts_cpu(
-        a.clone(),
+    out = _run_int4_cpu_fused_moe(
+        a,
         blocked_w1,
         blocked_w2,
         topk_weight,
         topk_ids,
-        False,  # inplace
-        ops.CPUQuantMethod.INT4_W4A8,
         blocked_s1,
         blocked_s2,
         blocked_z1,
         blocked_z2,
-        None,  # block_size
-        None,  # w1_bias
-        None,  # w2_bias
-        None,  # alpha
-        None,  # limit
-        True,  # is_vnni
     )
     torch.testing.assert_close(ref_out.bfloat16(), out, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("M,N,K,E,topk,group_size", [(2, 256, 512, 8, 2, 128)])
+@pytest.mark.parametrize("quant_algo", [ops.CPUQuantAlgo.GPTQ])
+@pytest.mark.parametrize("seed", [0])
+def test_int4_w4a16_cpu_fused_moe_skip_padding(
+    M, N, K, E, topk, group_size, quant_algo, seed
+):
+    """topk_ids == -1 contributes zero for INT4."""
+    set_random_seed(seed)
+
+    a = torch.randn(M, K, dtype=torch.bfloat16) / (0.5 * K**0.5)
+    (
+        w1_int4,
+        w2_int4,
+        w1_packed,
+        w2_packed,
+        w1_zeros,
+        w2_zeros,
+        w1_zeros_packed,
+        w2_zeros_packed,
+        w1_s,
+        w2_s,
+    ) = _make_int4_moe_weights(E, N, K, group_size, quant_algo)
+
+    score = torch.randn(M, E, dtype=torch.bfloat16)
+    score = torch.softmax(score, dim=-1, dtype=torch.float32)
+    topk_weight, topk_ids = torch.topk(score, topk)
+    topk_ids = topk_ids.to(torch.int32)
+
+    (blocked_w1, blocked_w2, blocked_s1, blocked_s2, blocked_z1, blocked_z2) = (
+        _prepare_int4_moe_layer(
+            w1_packed,
+            w2_packed,
+            w1_s,
+            w2_s,
+            quant_algo,
+            w1_zeros_packed,
+            w2_zeros_packed,
+        )
+    )
+
+    topk_ids_partial = topk_ids.clone()
+    topk_ids_partial[0, 0] = -1
+    topk_ids_partial[1, :] = -1
+
+    ref_out = _ref_int4_moe(
+        a,
+        w1_int4,
+        w2_int4,
+        w1_zeros,
+        w2_zeros,
+        w1_s,
+        w2_s,
+        topk_weight,
+        topk_ids_partial,
+        group_size,
+    )
+    out = _run_int4_cpu_fused_moe(
+        a,
+        blocked_w1,
+        blocked_w2,
+        topk_weight,
+        topk_ids_partial,
+        blocked_s1,
+        blocked_s2,
+        blocked_z1,
+        blocked_z2,
+    )
+    torch.testing.assert_close(ref_out.bfloat16(), out, atol=1e-2, rtol=1e-2)
+
+    topk_ids_all = torch.full_like(topk_ids, -1)
+    out_all_skipped = _run_int4_cpu_fused_moe(
+        a,
+        blocked_w1,
+        blocked_w2,
+        topk_weight,
+        topk_ids_all,
+        blocked_s1,
+        blocked_s2,
+        blocked_z1,
+        blocked_z2,
+    )
+    torch.testing.assert_close(
+        out_all_skipped, torch.zeros(M, K, dtype=out_all_skipped.dtype)
+    )
 
 
 # ===========================================================================
@@ -786,6 +1204,8 @@ def _ref_int8_moe(a, w1, w2, w1_s, w2_s, topk_weight, topk_ids):
     for b in range(B):
         for t in range(topk):
             eid = topk_ids[b, t].item()
+            if eid == -1:
+                continue
 
             x = a[b : b + 1].float()
             x_q, x_s = _quantize_per_token(x)
@@ -825,6 +1245,38 @@ def _make_int8_moe_weights(E, N, K):
     )
 
 
+def _run_int8_cpu_fused_moe(
+    a: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weight: torch.Tensor,
+    topk_ids: torch.Tensor,
+    w1_s: torch.Tensor,
+    w2_s: torch.Tensor,
+    is_vnni: bool,
+    inplace: bool = False,
+) -> torch.Tensor:
+    return ops.fused_experts_cpu(
+        a.clone(),
+        w1,
+        w2,
+        topk_weight,
+        topk_ids,
+        inplace,
+        ops.CPUQuantMethod.INT8_W8A8,
+        w1_s,
+        w2_s,
+        None,  # w1_zero
+        None,  # w2_zero
+        None,  # block_size
+        None,  # w1_bias
+        None,  # w2_bias
+        None,  # alpha
+        None,  # limit
+        is_vnni,
+    )
+
+
 INT8_NUM_TOKENS = [1, 2, 64, 121]
 INT8_MOE_CONFIGS = [
     # (N, K, E, topk)
@@ -857,30 +1309,70 @@ def test_int8_w8a8_cpu_fused_moe(M, N, K, E, topk, seed, is_vnni, inplace):
     w1 = _prepack_experts(w1_q) if is_vnni else w1_q
     w2 = _prepack_experts(w2_q) if is_vnni else w2_q
 
-    out = ops.fused_experts_cpu(
-        a.clone(),
+    out = _run_int8_cpu_fused_moe(
+        a,
         w1,
         w2,
         topk_weight,
         topk_ids,
-        inplace,
-        ops.CPUQuantMethod.INT8_W8A8,
         w1_s,
         w2_s,
-        None,  # w1_zero
-        None,  # w2_zero
-        None,  # block_size
-        None,  # w1_bias
-        None,  # w2_bias
-        None,  # alpha
-        None,  # limit
         is_vnni,
+        inplace,
     )
     torch.testing.assert_close(
         ref_out.bfloat16(),
         out,
         atol=2e-1,
         rtol=2e-1,
+    )
+
+
+@pytest.mark.parametrize("M,N,K,E,topk", [(8, 256, 512, 8, 2)])
+@pytest.mark.parametrize("seed", [0])
+def test_int8_w8a8_cpu_fused_moe_skip_padding(M, N, K, E, topk, seed):
+    """topk_ids == -1 contributes zero for INT8."""
+    set_random_seed(seed)
+
+    a = torch.randn(M, K, dtype=torch.bfloat16) / (0.5 * K**0.5)
+    w1_q, w2_q, w1_s, w2_s = _make_int8_moe_weights(E, N, K)
+    w1, w2 = _prepack_experts(w1_q), _prepack_experts(w2_q)
+
+    score = torch.randn(M, E, dtype=torch.bfloat16)
+    score = torch.softmax(score, dim=-1, dtype=torch.float32)
+    topk_weight, topk_ids = torch.topk(score, topk)
+    topk_ids = topk_ids.to(torch.int32)
+
+    topk_ids_partial = topk_ids.clone()
+    topk_ids_partial[1, 0] = -1
+    topk_ids_partial[2, :] = -1
+
+    ref_out = _ref_int8_moe(a, w1_q, w2_q, w1_s, w2_s, topk_weight, topk_ids_partial)
+    out = _run_int8_cpu_fused_moe(
+        a,
+        w1,
+        w2,
+        topk_weight,
+        topk_ids_partial,
+        w1_s,
+        w2_s,
+        True,
+    )
+    torch.testing.assert_close(ref_out.bfloat16(), out, atol=2e-1, rtol=2e-1)
+
+    topk_ids_all = torch.full_like(topk_ids, -1)
+    out_all_skipped = _run_int8_cpu_fused_moe(
+        a,
+        w1,
+        w2,
+        topk_weight,
+        topk_ids_all,
+        w1_s,
+        w2_s,
+        True,
+    )
+    torch.testing.assert_close(
+        out_all_skipped, torch.zeros(M, K, dtype=out_all_skipped.dtype)
     )
 
 

--- a/tests/kernels/moe/test_cpu_quant_fused_moe.py
+++ b/tests/kernels/moe/test_cpu_quant_fused_moe.py
@@ -4,11 +4,28 @@
 
 import math
 import sys
+from dataclasses import replace
 
 import pytest
 import torch
 import torch.nn.functional as F
 
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEConfig,
+    FusedMoEParallelConfig,
+    FusedMoEQuantConfig,
+    RoutingMethodType,
+)
+from vllm.model_executor.layers.fused_moe.expert_map_manager import (
+    determine_expert_map,
+)
+from vllm.model_executor.layers.fused_moe.experts.cpu_moe import (
+    CPUExpertsFp8,
+    CPUExpertsInt4,
+    CPUExpertsInt8,
+    CPUExpertsMxfp4,
+)
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
@@ -29,6 +46,37 @@ def _silu_and_mul(x: torch.Tensor) -> torch.Tensor:
 def _prepack_experts(w: torch.Tensor) -> torch.Tensor:
     """VNNI-prepack expert weights via ``convert_weight_packed``."""
     return torch.ops._C.convert_weight_packed(w)
+
+
+def _make_topk(
+    num_tokens: int,
+    num_experts: int,
+    topk: int,
+    dtype: torch.dtype = torch.bfloat16,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    score = torch.randn(num_tokens, num_experts, dtype=dtype)
+    score = torch.softmax(score, dim=-1, dtype=torch.float32)
+    topk_weight, topk_ids = torch.topk(score, topk)
+    return topk_weight, topk_ids.to(torch.int32)
+
+
+def _make_padding_variants(
+    topk_ids: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    topk_ids_partial = topk_ids.clone()
+    topk_ids_partial[0, 0] = -1
+    if topk_ids_partial.shape[0] > 1:
+        topk_ids_partial[-1, :] = -1
+    return topk_ids_partial, torch.full_like(topk_ids, -1)
+
+
+def _get_local_expert_slice(
+    expert_map: torch.Tensor,
+    local_num_experts: int,
+) -> slice:
+    owned = (expert_map != -1).nonzero(as_tuple=False)
+    expert_lo = int(owned[0].item())
+    return slice(expert_lo, expert_lo + local_num_experts)
 
 
 def _ref_unquant_moe(
@@ -91,24 +139,38 @@ def test_unquant_cpu_fused_moe_skip_padding(seed):
     w2 = torch.randn(E, K, N, dtype=torch.bfloat16) / math.sqrt(N)
     pw1, pw2 = _prepack_experts(w1), _prepack_experts(w2)
 
-    score = torch.randn(M, E, dtype=torch.bfloat16)
-    score = torch.softmax(score, dim=-1, dtype=torch.float32)
-    topk_weight, topk_ids = torch.topk(score, topk)
-    topk_ids = topk_ids.to(torch.int32)
-
-    topk_ids_partial = topk_ids.clone()
-    topk_ids_partial[1, 0] = -1
-    topk_ids_partial[2, :] = -1
+    topk_weight, topk_ids = _make_topk(M, E, topk)
+    topk_ids_partial, topk_ids_all = _make_padding_variants(topk_ids)
 
     ref_out = _ref_unquant_moe(a, w1, w2, topk_weight, topk_ids_partial)
     out = _run_unquant_cpu_fused_moe(a, pw1, pw2, topk_weight, topk_ids_partial)
     torch.testing.assert_close(ref_out, out, atol=1e-2, rtol=1e-2)
 
-    topk_ids_all = torch.full_like(topk_ids, -1)
     out_all_skipped = _run_unquant_cpu_fused_moe(a, pw1, pw2, topk_weight, topk_ids_all)
     torch.testing.assert_close(
         out_all_skipped, torch.zeros(M, K, dtype=out_all_skipped.dtype)
     )
+
+
+@pytest.mark.parametrize(
+    ("expert_cls", "supports_ep"),
+    [
+        (CPUExpertsFp8, True),
+        (CPUExpertsMxfp4, False),
+        (CPUExpertsInt4, False),
+        (CPUExpertsInt8, False),
+    ],
+    ids=["fp8", "mxfp4", "int4-w4a16", "int8-w8a8"],
+)
+def test_cpu_quant_expert_parallel_support_is_fail_closed(
+    expert_cls,
+    supports_ep,
+):
+    no_ep = FusedMoEParallelConfig.make_no_parallel()
+    with_ep = replace(no_ep, dp_size=2, ep_size=2, use_ep=True)
+
+    assert expert_cls._supports_parallel_config(no_ep)
+    assert expert_cls._supports_parallel_config(with_ep) is supports_ep
 
 
 # ===========================================================================
@@ -277,10 +339,7 @@ def test_w8a16_block_fp8_cpu_fused_moe(M, N, K, E, topk, seed):
     a = torch.randn(M, K, dtype=torch.bfloat16) / math.sqrt(K)
     w1, w2, w1_s, w2_s = _make_fp8_moe_weights(E, N, K, BLOCK_SIZE)
 
-    score = torch.randn(M, E, dtype=torch.bfloat16)
-    score = torch.softmax(score, dim=-1, dtype=torch.float32)
-    topk_weight, topk_ids = torch.topk(score, topk)
-    topk_ids = topk_ids.to(torch.int32)
+    topk_weight, topk_ids = _make_topk(M, E, topk)
 
     ref_out = ref_w8a16_block_fp8_moe(
         a, w1, w2, w1_s, w2_s, topk_weight, topk_ids, BLOCK_SIZE
@@ -343,6 +402,256 @@ def test_w8a16_block_fp8_cpu_fused_moe_invalid_expert_id_raises(
         _run_fp8_cpu_fused_moe(a, pw1, pw2, topk_weight, topk_ids, w1_s, w2_s)
 
 
+@pytest.mark.parametrize(
+    "M,N,K,E,topk,num_ranks",
+    [
+        (1, 256, 512, 8, 2, 3),
+        (64, 256, 512, 10, 2, 4),
+        (121, 512, 512, 12, 4, 6),
+    ],
+    ids=["single-token", "nondiv-e10", "large-topk4"],
+)
+@pytest.mark.parametrize("seed", [0])
+def test_w8a16_block_fp8_cpu_fused_moe_expert_parallel(
+    M, N, K, E, topk, num_ranks, seed
+):
+    """Expert parallelism: summed per-rank outputs match the single-rank ref.
+
+    Uses ``determine_expert_map`` (the production placement function) so the
+    test mirrors real EP placement, including the remainder-to-first-ranks
+    distribution for non-divisible expert counts.
+
+    The router produces global expert ids; each rank remaps them to local ids
+    and zeroes non-local weights (the masking path in ``CPUExpertsFp8.apply``).
+    Because the kernel applies topk_weights internally and combine is SUM, the
+    sum of per-rank outputs must equal the full single-rank mixture.
+    """
+    if num_ranks > E:
+        pytest.skip(f"E={E} < num_ranks={num_ranks}, skipping degenerate case")
+
+    set_random_seed(seed)
+
+    a = torch.randn(M, K, dtype=torch.bfloat16) / math.sqrt(K)
+    w1, w2, w1_s, w2_s = _make_fp8_moe_weights(E, N, K, BLOCK_SIZE)
+
+    topk_weight, topk_ids = _make_topk(M, E, topk)
+
+    ref_out = ref_w8a16_block_fp8_moe(
+        a, w1, w2, w1_s, w2_s, topk_weight, topk_ids, BLOCK_SIZE
+    )
+
+    summed = torch.zeros(M, K, dtype=torch.bfloat16)
+    for rank in range(num_ranks):
+        local_num_experts, expert_map, _ = determine_expert_map(
+            ep_size=num_ranks,
+            ep_rank=rank,
+            global_num_experts=E,
+        )
+        assert expert_map is not None
+
+        local_experts = _get_local_expert_slice(expert_map, local_num_experts)
+
+        w1_local = w1[local_experts].contiguous()
+        w2_local = w2[local_experts].contiguous()
+        w1_s_local = w1_s[local_experts].contiguous()
+        w2_s_local = w2_s[local_experts].contiguous()
+
+        # Remap + mask (mirrors CPUExpertsFp8.apply).
+        local_ids = expert_map[topk_ids.long()]
+        topk_weight_masked = topk_weight * (local_ids != -1)
+        topk_ids_local = local_ids.clamp_min(0).to(torch.int32)
+
+        pw1, pw2 = _prepack_experts(w1_local), _prepack_experts(w2_local)
+        out = ops.fused_experts_cpu(
+            a.clone(),
+            pw1,
+            pw2,
+            topk_weight_masked,
+            topk_ids_local,
+            False,
+            ops.CPUQuantMethod.FP8_W8A16,
+            w1_s_local,
+            w2_s_local,
+            None,
+            None,
+            BLOCK_SIZE,
+            is_vnni=True,
+        )
+        summed += out
+
+    torch.testing.assert_close(ref_out.bfloat16(), summed, atol=1e-2, rtol=1e-2)
+
+
+def _run_fp8_ep_apply_over_ranks(
+    a: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    w1_s: torch.Tensor,
+    w2_s: torch.Tensor,
+    router_logits: torch.Tensor,
+    N: int,
+    E: int,
+    topk: int,
+    num_ranks: int,
+) -> torch.Tensor:
+    """Run CPUExpertsFp8.apply() once per EP rank and sum the outputs."""
+    moe_parallel_config = FusedMoEParallelConfig.make_no_parallel()
+    M, K = a.shape[0], a.shape[1]
+    summed = torch.zeros(M, K, dtype=torch.bfloat16)
+    for rank in range(num_ranks):
+        local_num_experts, expert_map, _ = determine_expert_map(
+            ep_size=num_ranks,
+            ep_rank=rank,
+            global_num_experts=E,
+        )
+        assert expert_map is not None
+
+        local_experts = _get_local_expert_slice(expert_map, local_num_experts)
+        moe_config = FusedMoEConfig(
+            num_experts=E,
+            experts_per_token=topk,
+            hidden_dim=K,
+            intermediate_size=N,
+            num_local_experts=local_num_experts,
+            num_logical_experts=E,
+            moe_parallel_config=moe_parallel_config,
+            activation=MoEActivation.SILU,
+            in_dtype=torch.bfloat16,
+            device="cpu",
+            routing_method=RoutingMethodType.Default,
+        )
+        quant_config = FusedMoEQuantConfig.make(
+            torch.float8_e4m3fn,
+            block_shape=BLOCK_SIZE,
+            w1_scale=w1_s[local_experts].contiguous(),
+            w2_scale=w2_s[local_experts].contiguous(),
+        )
+        experts = CPUExpertsFp8(moe_config, quant_config)
+        out = experts.apply(
+            hidden_states=a.clone(),
+            w1=_prepack_experts(w1[local_experts].contiguous()),
+            w2=_prepack_experts(w2[local_experts].contiguous()),
+            router_logits=router_logits,
+            activation=MoEActivation.SILU,
+            global_num_experts=E,
+            expert_map=expert_map,
+            a1q_scale=None,
+            apply_router_weight_on_input=False,
+        )
+        summed += out
+    return summed
+
+
+@pytest.mark.parametrize(
+    "M,N,K,E,topk,num_ranks",
+    [
+        (1, 256, 512, 10, 2, 3),
+        (64, 256, 512, 12, 2, 6),
+    ],
+    ids=["single-token-nondiv", "dp6"],
+)
+@pytest.mark.parametrize("seed", [0])
+def test_w8a16_block_fp8_cpu_fused_moe_expert_parallel_apply(
+    M, N, K, E, topk, num_ranks, seed
+):
+    """Same as test_w8a16_block_fp8_cpu_fused_moe_expert_parallel, but drives
+    the masking/remapping through ``CPUExpertsFp8.apply()`` (the production
+    entry point) instead of hand-rolling the mask/remap logic, so the
+    ``expert_map is not None`` branch is actually exercised.
+    """
+    if num_ranks > E:
+        pytest.skip(f"E={E} < num_ranks={num_ranks}, skipping degenerate case")
+
+    set_random_seed(seed)
+
+    a = torch.randn(M, K, dtype=torch.bfloat16) / math.sqrt(K)
+    w1, w2, w1_s, w2_s = _make_fp8_moe_weights(E, N, K, BLOCK_SIZE)
+
+    # Default routing (softmax over all logits, then topk, no renormalize)
+    # so router_logits reproduce the same topk_weight/topk_ids as `score`.
+    router_logits = torch.randn(M, E, dtype=torch.float32)
+    score = torch.softmax(router_logits, dim=-1)
+    topk_weight, topk_ids = torch.topk(score, topk)
+    topk_ids = topk_ids.to(torch.int32)
+
+    ref_out = ref_w8a16_block_fp8_moe(
+        a, w1, w2, w1_s, w2_s, topk_weight, topk_ids, BLOCK_SIZE
+    )
+
+    summed = _run_fp8_ep_apply_over_ranks(
+        a, w1, w2, w1_s, w2_s, router_logits, N, E, topk, num_ranks
+    )
+
+    torch.testing.assert_close(ref_out.bfloat16(), summed, atol=1e-2, rtol=1e-2)
+
+
+# ===========================================================================
+# FP8 W8A16 MoE: VLLM_MOE_SKIP_PADDING (dummy/padding-row skip)
+# ===========================================================================
+
+
+@pytest.mark.parametrize("M,N,K,E,topk,num_ranks", [(8, 256, 512, 8, 2, 3)])
+@pytest.mark.parametrize("seed", [0])
+def test_fp8_cpu_fused_moe_skip_padding_expert_parallel(
+    M, N, K, E, topk, num_ranks, seed
+):
+    """EP branch (fused_experts_cpu_local_skip): a topk_ids row containing
+    -1 must not index expert_map[-1] and must produce zero output for that
+    row, while other rows are unaffected."""
+    from vllm.model_executor.layers.fused_moe.experts.cpu_moe import (
+        fused_experts_cpu_local_skip,
+    )
+
+    set_random_seed(seed)
+
+    a = torch.randn(M, K, dtype=torch.bfloat16) / math.sqrt(K)
+    w1, w2, w1_s, w2_s = _make_fp8_moe_weights(E, N, K, BLOCK_SIZE)
+    topk_weight, topk_ids = _make_topk(M, E, topk)
+
+    padded_row = 1
+    topk_ids_padded = topk_ids.clone()
+    topk_ids_padded[padded_row] = -1
+
+    local_num_experts, expert_map, _ = determine_expert_map(
+        ep_size=num_ranks, ep_rank=0, global_num_experts=E
+    )
+    assert expert_map is not None
+    local_experts = _get_local_expert_slice(expert_map, local_num_experts)
+    w1_p = _prepack_experts(w1[local_experts].contiguous())
+    w2_p = _prepack_experts(w2[local_experts].contiguous())
+    w1_s_local = w1_s[local_experts].contiguous()
+    w2_s_local = w2_s[local_experts].contiguous()
+
+    common_args = (
+        w1_p,
+        w2_p,
+        expert_map,
+        ops.CPUQuantMethod.FP8_W8A16,
+        w1_s_local,
+        w2_s_local,
+        None,
+        None,
+        BLOCK_SIZE,
+        None,
+        None,
+        None,
+        None,
+        True,
+    )
+    out_padded = fused_experts_cpu_local_skip(
+        a.clone(), *common_args[:2], topk_weight, topk_ids_padded, *common_args[2:]
+    )
+    out_unpadded = fused_experts_cpu_local_skip(
+        a.clone(), *common_args[:2], topk_weight, topk_ids, *common_args[2:]
+    )
+
+    torch.testing.assert_close(
+        out_padded[padded_row], torch.zeros(K, dtype=out_padded.dtype)
+    )
+    other = torch.arange(M) != padded_row
+    torch.testing.assert_close(out_padded[other], out_unpadded[other])
+
+
 @pytest.mark.parametrize("M,N,K,E,topk", [(8, 256, 512, 8, 2)])
 @pytest.mark.parametrize("seed", [0])
 def test_w8a16_block_fp8_cpu_fused_moe_skip_padding(M, N, K, E, topk, seed):
@@ -353,50 +662,17 @@ def test_w8a16_block_fp8_cpu_fused_moe_skip_padding(M, N, K, E, topk, seed):
     w1, w2, w1_s, w2_s = _make_fp8_moe_weights(E, N, K, BLOCK_SIZE)
     pw1, pw2 = _prepack_experts(w1), _prepack_experts(w2)
 
-    score = torch.randn(M, E, dtype=torch.bfloat16)
-    score = torch.softmax(score, dim=-1, dtype=torch.float32)
-    topk_weight, topk_ids = torch.topk(score, topk)
-    topk_ids = topk_ids.to(torch.int32)
-
-    topk_ids_partial = topk_ids.clone()
-    topk_ids_partial[1, 0] = -1
-    topk_ids_partial[2, :] = -1
+    topk_weight, topk_ids = _make_topk(M, E, topk)
+    topk_ids_partial, topk_ids_all = _make_padding_variants(topk_ids)
 
     ref_out = ref_w8a16_block_fp8_moe(
         a, w1, w2, w1_s, w2_s, topk_weight, topk_ids_partial, BLOCK_SIZE
     )
-    out = ops.fused_experts_cpu(
-        a.clone(),
-        pw1,
-        pw2,
-        topk_weight,
-        topk_ids_partial,
-        False,
-        ops.CPUQuantMethod.FP8_W8A16,
-        w1_s,
-        w2_s,
-        None,
-        None,
-        BLOCK_SIZE,
-        is_vnni=True,
-    )
+    out = _run_fp8_cpu_fused_moe(a, pw1, pw2, topk_weight, topk_ids_partial, w1_s, w2_s)
     torch.testing.assert_close(ref_out.bfloat16(), out, atol=1e-2, rtol=1e-2)
 
-    topk_ids_all = torch.full_like(topk_ids, -1)
-    out_all_skipped = ops.fused_experts_cpu(
-        a.clone(),
-        pw1,
-        pw2,
-        topk_weight,
-        topk_ids_all,
-        False,
-        ops.CPUQuantMethod.FP8_W8A16,
-        w1_s,
-        w2_s,
-        None,
-        None,
-        BLOCK_SIZE,
-        is_vnni=True,
+    out_all_skipped = _run_fp8_cpu_fused_moe(
+        a, pw1, pw2, topk_weight, topk_ids_all, w1_s, w2_s
     )
     torch.testing.assert_close(
         out_all_skipped, torch.zeros(M, K, dtype=out_all_skipped.dtype)
@@ -640,10 +916,7 @@ def test_mxfp4_cpu_fused_moe(M, N, K, E, topk, seed):
     w2dq = MXFP4QuantizeUtil.dequantize(w2q, dtype, w2s)
 
     # Routing
-    score = torch.randn(M, E, dtype=dtype)
-    score = torch.softmax(score, dim=-1, dtype=torch.float32)
-    topk_weight, topk_ids = torch.topk(score, topk)
-    topk_ids = topk_ids.to(torch.int32)
+    topk_weight, topk_ids = _make_topk(M, E, topk, dtype)
 
     # Reference
     ref_out = ref_mxfp4_fused_moe(a, w1dq, w2dq, topk_weight, topk_ids, topk)
@@ -693,9 +966,7 @@ def test_mxfp4_cpu_fused_moe_skip_padding(M, N, K, E, topk, seed):
     pw1, pw1s = _prepack_mxfp4_experts(w1q, w1s)
     pw2, pw2s = _prepack_mxfp4_experts(w2q, w2s)
 
-    topk_ids_partial = topk_ids.clone()
-    topk_ids_partial[0, 0] = -1
-    topk_ids_partial[1, :] = -1
+    topk_ids_partial, topk_ids_all = _make_padding_variants(topk_ids)
 
     ref_out = ref_mxfp4_fused_moe(a, w1dq, w2dq, topk_weight, topk_ids_partial, topk)
     out = _run_mxfp4_cpu_fused_moe(
@@ -709,7 +980,6 @@ def test_mxfp4_cpu_fused_moe_skip_padding(M, N, K, E, topk, seed):
     )
     torch.testing.assert_close(ref_out.bfloat16(), out, atol=1e-2, rtol=1e-2)
 
-    topk_ids_all = torch.full_like(topk_ids, -1)
     out_all_skipped = _run_mxfp4_cpu_fused_moe(
         a,
         pw1,
@@ -1128,9 +1398,7 @@ def test_int4_w4a16_cpu_fused_moe_skip_padding(
         )
     )
 
-    topk_ids_partial = topk_ids.clone()
-    topk_ids_partial[0, 0] = -1
-    topk_ids_partial[1, :] = -1
+    topk_ids_partial, topk_ids_all = _make_padding_variants(topk_ids)
 
     ref_out = _ref_int4_moe(
         a,
@@ -1157,7 +1425,6 @@ def test_int4_w4a16_cpu_fused_moe_skip_padding(
     )
     torch.testing.assert_close(ref_out.bfloat16(), out, atol=1e-2, rtol=1e-2)
 
-    topk_ids_all = torch.full_like(topk_ids, -1)
     out_all_skipped = _run_int4_cpu_fused_moe(
         a,
         blocked_w1,
@@ -1338,14 +1605,9 @@ def test_int8_w8a8_cpu_fused_moe_skip_padding(M, N, K, E, topk, seed):
     w1_q, w2_q, w1_s, w2_s = _make_int8_moe_weights(E, N, K)
     w1, w2 = _prepack_experts(w1_q), _prepack_experts(w2_q)
 
-    score = torch.randn(M, E, dtype=torch.bfloat16)
-    score = torch.softmax(score, dim=-1, dtype=torch.float32)
-    topk_weight, topk_ids = torch.topk(score, topk)
-    topk_ids = topk_ids.to(torch.int32)
+    topk_weight, topk_ids = _make_topk(M, E, topk)
 
-    topk_ids_partial = topk_ids.clone()
-    topk_ids_partial[1, 0] = -1
-    topk_ids_partial[2, :] = -1
+    topk_ids_partial, topk_ids_all = _make_padding_variants(topk_ids)
 
     ref_out = _ref_int8_moe(a, w1_q, w2_q, w1_s, w2_s, topk_weight, topk_ids_partial)
     out = _run_int8_cpu_fused_moe(
@@ -1360,7 +1622,6 @@ def test_int8_w8a8_cpu_fused_moe_skip_padding(M, N, K, E, topk, seed):
     )
     torch.testing.assert_close(ref_out.bfloat16(), out, atol=2e-1, rtol=2e-1)
 
-    topk_ids_all = torch.full_like(topk_ids, -1)
     out_all_skipped = _run_int8_cpu_fused_moe(
         a,
         w1,

--- a/tests/v1/worker/test_cpu_worker.py
+++ b/tests/v1/worker/test_cpu_worker.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from vllm.config.parallel import ParallelConfig
+from vllm.platforms import current_platform
+from vllm.platforms.cpu import CpuPlatform
+from vllm.v1.worker.cpu_worker import _get_cpushm_dist_ident
+
+if not current_platform.is_cpu():
+    pytest.skip("CPU-only test", allow_module_level=True)
+
+
+def _make_parallel_config(dp_port: int) -> ParallelConfig:
+    return ParallelConfig(
+        tensor_parallel_size=1,
+        data_parallel_size=2,
+        data_parallel_master_ip="127.0.0.1",
+        _data_parallel_master_port_list=[dp_port],
+    )
+
+
+def _make_platform_config(
+    *,
+    tensor_parallel_size: int,
+    data_parallel_size: int,
+    enable_expert_parallel: bool,
+    nnodes: int = 1,
+):
+    return SimpleNamespace(
+        model_config=None,
+        cache_config=SimpleNamespace(
+            user_specified_block_size=True,
+            block_size=128,
+            kv_cache_memory_bytes=0,
+            mamba_ssm_cache_dtype="auto",
+        ),
+        scheduler_config=SimpleNamespace(async_scheduling=True),
+        parallel_config=ParallelConfig(
+            tensor_parallel_size=tensor_parallel_size,
+            data_parallel_size=data_parallel_size,
+            enable_expert_parallel=enable_expert_parallel,
+            data_parallel_master_ip="127.0.0.1",
+            _data_parallel_master_port_list=[26001],
+            distributed_executor_backend="mp",
+            nnodes=nnodes,
+        ),
+        compilation_config=SimpleNamespace(
+            cudagraph_capture_sizes=[1],
+            mode=None,
+            backend=None,
+            inductor_compile_config={},
+            ir_enable_torch_wrap=True,
+            custom_ops=[],
+        ),
+        lora_config=None,
+        profiler_config=SimpleNamespace(torch_profiler_dump_cuda_time_total=True),
+        device_config=SimpleNamespace(device_type="cpu"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("dp_ports", "expected"),
+    [
+        ([26001, 26001], True),
+        ([26001, 26002], False),
+    ],
+    ids=["same-dp-rendezvous", "different-dp-rendezvous"],
+)
+def test_get_cpushm_dist_ident_uses_dp_rendezvous(dp_ports, expected):
+    idents = [
+        _get_cpushm_dist_ident(
+            _make_parallel_config(dp_port),
+            f"tcp://127.0.0.1:{11001 + rank}",
+        )
+        for rank, dp_port in enumerate(dp_ports)
+    ]
+
+    assert (idents[0] == idents[1]) is expected
+
+
+def test_cpu_platform_allows_hybrid_tp_dp_ep():
+    vllm_config = _make_platform_config(
+        tensor_parallel_size=2,
+        data_parallel_size=3,
+        enable_expert_parallel=True,
+    )
+
+    with patch.dict(os.environ, {"VLLM_CPU_KVCACHE_SPACE": ""}):
+        CpuPlatform.check_and_update_config(vllm_config)
+
+
+def test_cpu_platform_allows_tp_only_ep():
+    vllm_config = _make_platform_config(
+        tensor_parallel_size=2,
+        data_parallel_size=1,
+        enable_expert_parallel=True,
+    )
+
+    with patch.dict(os.environ, {"VLLM_CPU_KVCACHE_SPACE": ""}):
+        CpuPlatform.check_and_update_config(vllm_config)
+
+
+def test_cpu_platform_allows_hybrid_tp_dp_without_ep():
+    vllm_config = _make_platform_config(
+        tensor_parallel_size=2,
+        data_parallel_size=3,
+        enable_expert_parallel=False,
+    )
+
+    with patch.dict(os.environ, {"VLLM_CPU_KVCACHE_SPACE": ""}):
+        CpuPlatform.check_and_update_config(vllm_config)
+
+
+def test_cpu_platform_allows_dp_only_ep():
+    vllm_config = _make_platform_config(
+        tensor_parallel_size=1,
+        data_parallel_size=2,
+        enable_expert_parallel=True,
+    )
+
+    with patch.dict(os.environ, {"VLLM_CPU_KVCACHE_SPACE": ""}):
+        CpuPlatform.check_and_update_config(vllm_config)
+
+
+@pytest.mark.parametrize(
+    ("data_parallel_size", "enable_expert_parallel"),
+    [(2, False), (1, True)],
+    ids=["dp-only", "ep-enabled"],
+)
+def test_cpu_platform_rejects_multi_node_dp_or_ep(
+    data_parallel_size, enable_expert_parallel
+):
+    vllm_config = _make_platform_config(
+        tensor_parallel_size=1,
+        data_parallel_size=data_parallel_size,
+        enable_expert_parallel=enable_expert_parallel,
+        nnodes=2,
+    )
+
+    with (
+        patch.dict(os.environ, {"VLLM_CPU_KVCACHE_SPACE": ""}),
+        pytest.raises(NotImplementedError, match="CPU DP/EP is single-node only"),
+    ):
+        CpuPlatform.check_and_update_config(vllm_config)

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -3327,6 +3327,31 @@ if hasattr(torch.ops._C, "dynamic_4bit_int_moe"):
         return x.new_empty((x.size(0), hidden_size))
 
 
+if hasattr(torch.ops._C, "fused_experts_cpu_local_skip"):
+
+    @register_fake("_C::fused_experts_cpu_local_skip")
+    def fused_experts_cpu_local_skip_fake(
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        expert_map: torch.Tensor,
+        moe_comp_method: CPUQuantMethod,
+        w1_scale: torch.Tensor | None,
+        w2_scale: torch.Tensor | None,
+        w1_zero: torch.Tensor | None,
+        w2_zero: torch.Tensor | None,
+        block_size: list[int] | None,
+        w1_bias: torch.Tensor | None,
+        w2_bias: torch.Tensor | None,
+        alpha: float | None,
+        limit: float | None,
+        is_vnni: bool,
+    ) -> torch.Tensor:
+        return torch.empty_like(hidden_states)
+
+
 def fused_experts_cpu(
     hidden_states: torch.Tensor,
     w1: torch.Tensor,
@@ -3353,6 +3378,46 @@ def fused_experts_cpu(
         topk_weights,
         topk_ids,
         inplace,
+        moe_comp_method,
+        w1_scale,
+        w2_scale,
+        w1_zero,
+        w2_zero,
+        block_size,
+        w1_bias,
+        w2_bias,
+        alpha,
+        limit,
+        is_vnni,
+    )
+
+
+def fused_experts_cpu_local_skip(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    expert_map: torch.Tensor,
+    moe_comp_method: CPUQuantMethod,
+    w1_scale: torch.Tensor | None,
+    w2_scale: torch.Tensor | None,
+    w1_zero: torch.Tensor | None,
+    w2_zero: torch.Tensor | None,
+    block_size: list[int] | None,
+    w1_bias: torch.Tensor | None = None,
+    w2_bias: torch.Tensor | None = None,
+    alpha: float | None = None,
+    limit: float | None = None,
+    is_vnni: bool = True,
+) -> torch.Tensor:
+    return torch.ops._C.fused_experts_cpu_local_skip(
+        hidden_states,
+        w1,
+        w2,
+        topk_weights,
+        topk_ids,
+        expert_map,
         moe_comp_method,
         w1_scale,
         w2_scale,

--- a/vllm/distributed/device_communicators/cpu_communicator.py
+++ b/vllm/distributed/device_communicators/cpu_communicator.py
@@ -8,6 +8,7 @@ import torch
 from torch.distributed import ProcessGroup
 
 from vllm.distributed.utils import pickle
+from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.platforms.interface import CpuArchEnum
@@ -18,6 +19,8 @@ logger = init_logger(__name__)
 
 
 class CpuCommunicator(DeviceCommunicatorBase):
+    _CPUSHM_GROUP_KINDS = {"tp", "pp", "dp", "ep"}
+
     def __init__(
         self,
         cpu_group: ProcessGroup,
@@ -30,6 +33,7 @@ class CpuCommunicator(DeviceCommunicatorBase):
             cpu_group, device, device_group, unique_name, use_all2all=use_all2all
         )
         self.dist_module = torch.distributed
+        use_cpushm_group = self._is_cpushm_group_name(unique_name)
 
         if (
             (
@@ -39,11 +43,11 @@ class CpuCommunicator(DeviceCommunicatorBase):
                 or current_platform.get_cpu_architecture() == CpuArchEnum.S390X
             )
             and hasattr(torch.ops._C, "init_shm_manager")
-            and (unique_name.startswith("tp") or unique_name.startswith("pp"))
+            and use_cpushm_group
             and self._all_group_ranks_share_shm_group_name()
         ):
             self.dist_module = _CPUSHMDistributed(self)
-        elif unique_name.startswith("tp") or unique_name.startswith("pp"):
+        elif use_cpushm_group:
             logger.info(
                 "CPU SHM communicator disabled for group %s: ranks do not share "
                 "the same SHM group name, falling back to torch.distributed.",
@@ -52,6 +56,15 @@ class CpuCommunicator(DeviceCommunicatorBase):
 
         # send/recv tensor_dict is only supported through the SHM communicator backend
         self.supports_tensor_dict = isinstance(self.dist_module, _CPUSHMDistributed)
+        # Ragged SHM all_gatherv needs temporary padded input and a uniform
+        # receive buffer; cache them by tensor signature to avoid steady-state
+        # reallocations.
+        self._ragged_pad_buffers: dict[
+            tuple[torch.dtype, torch.device, tuple[int, ...]], torch.Tensor
+        ] = {}
+        self._ragged_shm_gather_buffers: dict[
+            tuple[torch.dtype, torch.device, tuple[int, ...]], torch.Tensor
+        ] = {}
 
         if self.use_all2all:
             if self.all2all_backend not in (
@@ -67,6 +80,12 @@ class CpuCommunicator(DeviceCommunicatorBase):
 
             self.all2all_manager = AgRsAll2AllManager(self.cpu_group)
             logger.info("Using allgather_reducescatter all2all manager.")
+            self._register_ep_custom_ops()
+
+    @classmethod
+    def _is_cpushm_group_name(cls, unique_name: str) -> bool:
+        group_kind = unique_name.split(":", maxsplit=1)[0]
+        return group_kind in cls._CPUSHM_GROUP_KINDS
 
     def _all_group_ranks_share_shm_group_name(self) -> bool:
         """
@@ -80,7 +99,14 @@ class CpuCommunicator(DeviceCommunicatorBase):
             local_name,
             group=self.device_group,
         )
-        return len(set(names)) == 1
+        shared_name = len(set(names)) == 1
+        if not shared_name:
+            logger.debug(
+                "CPU SHM group-name mismatch for group %s: %s",
+                self.unique_name,
+                names,
+            )
+        return shared_name
 
     def all_reduce(self, input_):
         self.dist_module.all_reduce(input_, group=self.device_group)
@@ -147,6 +173,218 @@ class CpuCommunicator(DeviceCommunicatorBase):
         )
         return output_tensor
 
+    @staticmethod
+    def _ragged_buffer_key(
+        tensor: torch.Tensor,
+    ) -> tuple[torch.dtype, torch.device, tuple[int, ...]]:
+        return (tensor.dtype, tensor.device, tuple(tensor.shape[1:]))
+
+    @staticmethod
+    def _sizes_are_uniform(sizes: list[int]) -> bool:
+        return all(size == sizes[0] for size in sizes[1:])
+
+    def _get_ragged_pad_buffer(
+        self,
+        tensor: torch.Tensor,
+        padded_rows: int,
+    ) -> torch.Tensor:
+        key = self._ragged_buffer_key(tensor)
+        buffer = self._ragged_pad_buffers.get(key)
+        if buffer is None or buffer.shape[0] < padded_rows:
+            buffer = torch.empty(
+                (padded_rows,) + tensor.shape[1:],
+                dtype=tensor.dtype,
+                device=tensor.device,
+            )
+            self._ragged_pad_buffers[key] = buffer
+        return buffer[:padded_rows]
+
+    def _get_ragged_shm_gather_buffer(
+        self,
+        tensor: torch.Tensor,
+        padded_rows: int,
+    ) -> torch.Tensor:
+        key = self._ragged_buffer_key(tensor)
+        needed_rows = self.world_size * padded_rows
+        buffer = self._ragged_shm_gather_buffers.get(key)
+        if buffer is None or buffer.shape[0] < needed_rows:
+            buffer = torch.empty(
+                (needed_rows,) + tensor.shape[1:],
+                dtype=tensor.dtype,
+                device=tensor.device,
+            )
+            self._ragged_shm_gather_buffers[key] = buffer
+        return buffer[:needed_rows]
+
+    def _all_gatherv_shm_uniform(
+        self,
+        tensor: torch.Tensor,
+        rows_per_rank: int,
+    ) -> torch.Tensor:
+        output = torch.empty(
+            (self.world_size * rows_per_rank,) + tensor.shape[1:],
+            dtype=tensor.dtype,
+            device=tensor.device,
+        )
+        self.dist_module.all_gather_into_tensor(
+            output,
+            tensor.contiguous(),
+            group=self.device_group,
+        )
+        return output
+
+    def _trim_ragged_rows(
+        self,
+        gathered: torch.Tensor,
+        sizes: list[int],
+        padded_rows: int,
+    ) -> torch.Tensor:
+        """Un-pad a (world_size * padded_rows, ...) buffer into
+        (sum(sizes), ...) via bulk narrow+copy_, avoiding a Python-list
+        select/cat."""
+        total_rows = sum(sizes)
+        output = torch.empty(
+            (total_rows,) + gathered.shape[1:],
+            dtype=gathered.dtype,
+            device=gathered.device,
+        )
+        offset = 0
+        for rank, n in enumerate(sizes):
+            if n:
+                output.narrow(0, offset, n).copy_(
+                    gathered.narrow(0, rank * padded_rows, n)
+                )
+            offset += n
+        return output
+
+    def _all_gatherv_shm_ragged(
+        self,
+        tensor: torch.Tensor,
+        sizes: list[int],
+    ) -> torch.Tensor:
+        padded_rows = max(sizes)
+        padded_input = self._get_ragged_pad_buffer(tensor, padded_rows)
+        padded_input[: tensor.shape[0]].copy_(tensor.contiguous())
+
+        gathered = self._get_ragged_shm_gather_buffer(tensor, padded_rows)
+        self.dist_module.all_gather_into_tensor(
+            gathered,
+            padded_input,
+            group=self.device_group,
+        )
+
+        return self._trim_ragged_rows(gathered, sizes, padded_rows)
+
+    def _pad_rows_for_gatherv(
+        self,
+        tensor: torch.Tensor,
+        padded_rows: int,
+    ) -> torch.Tensor:
+        pad_rows = padded_rows - tensor.shape[0]
+        assert pad_rows >= 0, f"{pad_rows} < 0"
+        if pad_rows == 0:
+            return tensor.contiguous()
+        padding = torch.zeros(
+            (pad_rows,) + tensor.shape[1:],
+            dtype=tensor.dtype,
+            device=tensor.device,
+        )
+        return torch.cat([tensor.contiguous(), padding], dim=0)
+
+    def _gather_single_gatherv(
+        self,
+        t: torch.Tensor,
+        sizes: list[int] | None,
+    ) -> torch.Tensor:
+        if sizes is not None:
+            assert t.shape[0] == sizes[self.rank_in_group], (
+                f"{t.shape[0]} != {sizes[self.rank_in_group]}"
+            )
+            if not any(sizes):
+                return t.new_empty((0,) + t.shape[1:])
+
+        if isinstance(self.dist_module, _CPUSHMDistributed):
+            if sizes is None:
+                return self._all_gatherv_shm_uniform(t, t.shape[0])
+            if self._sizes_are_uniform(sizes):
+                return self._all_gatherv_shm_uniform(t, sizes[0])
+            return self._all_gatherv_shm_ragged(t, sizes)
+        else:
+            # gloo path (multi-node or non-SHM groups).
+            if sizes is not None:
+                max_size = max(sizes)
+                t_padded = self._pad_rows_for_gatherv(t, max_size)
+                recv_list = [
+                    torch.empty(
+                        (max_size,) + t.shape[1:], dtype=t.dtype, device=t.device
+                    )
+                    for _ in range(self.world_size)
+                ]
+                torch.distributed.all_gather(
+                    recv_list, t_padded, group=self.device_group
+                )
+                gathered = torch.cat(recv_list, dim=0)
+                return self._trim_ragged_rows(gathered, sizes, max_size)
+            else:
+                recv_list = [torch.empty_like(t) for _ in range(self.world_size)]
+                torch.distributed.all_gather(
+                    recv_list, t.contiguous(), group=self.device_group
+                )
+                return torch.cat(recv_list, dim=0)
+
+    def all_gatherv(
+        self,
+        input_: torch.Tensor | list[torch.Tensor],
+        dim: int = 0,
+        sizes: list[int] | None = None,
+    ) -> torch.Tensor | list[torch.Tensor]:
+        """Variable-length all-gather over dim 0."""
+        if dim != 0:
+            raise NotImplementedError("CpuCommunicator.all_gatherv only supports dim=0")
+
+        if sizes is not None:
+            assert len(sizes) == self.world_size, f"{len(sizes)} != {self.world_size}"
+
+        if isinstance(input_, torch.Tensor):
+            return self._gather_single_gatherv(input_, sizes)
+        return [self._gather_single_gatherv(t, sizes) for t in input_]
+
+    def reduce_scatterv(
+        self,
+        input_: torch.Tensor,
+        dim: int = 0,
+        sizes: list[int] | None = None,
+    ) -> torch.Tensor:
+        """Reduce-scatter with variable output sizes via all_reduce + local slice."""
+        if dim < 0:
+            dim += input_.dim()
+
+        if sizes is not None:
+            assert len(sizes) == self.world_size, f"{len(sizes)} != {self.world_size}"
+            assert input_.shape[dim] == sum(sizes), (
+                f"{input_.shape[dim]} != {sum(sizes)}"
+            )
+        else:
+            assert input_.shape[dim] % self.world_size == 0, (
+                "Implicit reduce_scatterv requires the scatter dimension "
+                f"{input_.shape[dim]} to be divisible by world_size "
+                f"{self.world_size}."
+            )
+
+        out = input_.contiguous().clone()
+
+        self.dist_module.all_reduce(out, group=self.device_group)
+
+        if sizes is not None:
+            start = sum(sizes[: self.rank_in_group])
+            end = start + sizes[self.rank_in_group]
+        else:
+            chunk = out.shape[dim] // self.world_size
+            start = self.rank_in_group * chunk
+            end = start + chunk
+
+        return out.narrow(dim, start, end - start).contiguous()
+
     def send_tensor_dict(
         self,
         tensor_dict: dict[str, torch.Tensor | Any],
@@ -170,6 +408,182 @@ class CpuCommunicator(DeviceCommunicatorBase):
             )
         return self.dist_module.recv_tensor_dict(src)
 
+    def _register_ep_custom_ops(self) -> None:
+        """Register dispatch/combine as custom ops opaque to torch.compile."""
+        assert self.all2all_manager is not None
+        mgr = self.all2all_manager
+        safe_name = (
+            self.unique_name.replace("-", "_").replace("/", "_").replace(":", "_")
+        )
+
+        def _with_non_sp_dp_sizes(fn):
+            dp_metadata = get_forward_context().dp_metadata
+            assert dp_metadata is not None
+            if dp_metadata.local_sizes is not None:
+                return fn()
+            with dp_metadata.sp_local_sizes(sequence_parallel_size=1):
+                return fn()
+
+        def _with_sp_sizes(fn):
+            dp_metadata = get_forward_context().dp_metadata
+            assert dp_metadata is not None
+            if dp_metadata.local_sizes is not None:
+                return fn()
+            dp_size = len(dp_metadata.num_tokens_across_dp_cpu)
+            assert self.world_size % dp_size == 0
+            sp_size = self.world_size // dp_size
+            with dp_metadata.sp_local_sizes(sp_size):
+                return fn()
+
+        @torch.library.custom_op(
+            f"vllm::cpu_ep_dispatch_rl_{safe_name}", mutates_args=()
+        )
+        def _dispatch_rl(
+            hidden_states: torch.Tensor,
+            router_logits: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            return _with_non_sp_dp_sizes(
+                lambda: mgr.dispatch_router_logits(
+                    hidden_states,
+                    router_logits,
+                )
+            )
+
+        @_dispatch_rl.register_fake
+        def _(
+            hidden_states: torch.Tensor, router_logits: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            # Ragged dispatch: the real op all-gathers each rank's actual row
+            # count and returns sum(per_rank_sizes) rows. That total is
+            # data-dependent and unknown at trace time, so emit an unbacked
+            # symint instead of the uniform shape[0] * world_size (GPU parity).
+            ctx = torch.library.get_ctx()
+            n = ctx.new_dynamic_size()
+            return (
+                hidden_states.new_empty((n,) + hidden_states.shape[1:]),
+                router_logits.new_empty((n,) + router_logits.shape[1:]),
+            )
+
+        @torch.library.custom_op(
+            f"vllm::cpu_ep_dispatch_rl_sp_{safe_name}", mutates_args=()
+        )
+        def _dispatch_rl_sp(
+            hidden_states: torch.Tensor,
+            router_logits: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            return _with_sp_sizes(
+                lambda: mgr.dispatch_router_logits(
+                    hidden_states,
+                    router_logits,
+                    is_sequence_parallel=True,
+                )
+            )
+
+        @_dispatch_rl_sp.register_fake
+        def _(
+            hidden_states: torch.Tensor,
+            router_logits: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            ctx = torch.library.get_ctx()
+            n = ctx.new_dynamic_size()
+            return (
+                hidden_states.new_empty((n,) + hidden_states.shape[1:]),
+                router_logits.new_empty((n,) + router_logits.shape[1:]),
+            )
+
+        @torch.library.custom_op(f"vllm::cpu_ep_dispatch_{safe_name}", mutates_args=())
+        def _dispatch(
+            hidden_states: torch.Tensor,
+            topk_weights: torch.Tensor,
+            topk_ids: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            result = _with_non_sp_dp_sizes(
+                lambda: mgr.dispatch(hidden_states, topk_weights, topk_ids)
+            )
+            return result[0], result[1], result[2]
+
+        @_dispatch.register_fake
+        def _(
+            hidden_states: torch.Tensor,
+            topk_weights: torch.Tensor,
+            topk_ids: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            # Ragged dispatch: the real op all-gathers each rank's actual row
+            # count and returns sum(per_rank_sizes) rows. That total is
+            # data-dependent and unknown at trace time, so emit an unbacked
+            # symint instead of the uniform shape[0] * world_size (GPU parity).
+            # All three outputs share the same n so downstream sees one row dim.
+            ctx = torch.library.get_ctx()
+            n = ctx.new_dynamic_size()
+            return (
+                hidden_states.new_empty((n,) + hidden_states.shape[1:]),
+                topk_weights.new_empty((n,) + topk_weights.shape[1:]),
+                topk_ids.new_empty((n,) + topk_ids.shape[1:]),
+            )
+
+        @torch.library.custom_op(
+            f"vllm::cpu_ep_dispatch_sp_{safe_name}", mutates_args=()
+        )
+        def _dispatch_sp(
+            hidden_states: torch.Tensor,
+            topk_weights: torch.Tensor,
+            topk_ids: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            result = _with_sp_sizes(
+                lambda: mgr.dispatch(
+                    hidden_states,
+                    topk_weights,
+                    topk_ids,
+                    is_sequence_parallel=True,
+                )
+            )
+            return result[0], result[1], result[2]
+
+        @_dispatch_sp.register_fake
+        def _(
+            hidden_states: torch.Tensor,
+            topk_weights: torch.Tensor,
+            topk_ids: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            ctx = torch.library.get_ctx()
+            n = ctx.new_dynamic_size()
+            return (
+                hidden_states.new_empty((n,) + hidden_states.shape[1:]),
+                topk_weights.new_empty((n,) + topk_weights.shape[1:]),
+                topk_ids.new_empty((n,) + topk_ids.shape[1:]),
+            )
+
+        @torch.library.custom_op(f"vllm::cpu_ep_combine_{safe_name}", mutates_args=())
+        def _combine(hidden_states: torch.Tensor) -> torch.Tensor:
+            return _with_non_sp_dp_sizes(lambda: mgr.combine(hidden_states))
+
+        @_combine.register_fake
+        def _(hidden_states: torch.Tensor) -> torch.Tensor:
+            ctx = torch.library.get_ctx()
+            local_n = ctx.new_dynamic_size()
+            return hidden_states.new_empty((local_n,) + hidden_states.shape[1:])
+
+        @torch.library.custom_op(
+            f"vllm::cpu_ep_combine_sp_{safe_name}", mutates_args=()
+        )
+        def _combine_sp(hidden_states: torch.Tensor) -> torch.Tensor:
+            return _with_sp_sizes(
+                lambda: mgr.combine(hidden_states, is_sequence_parallel=True)
+            )
+
+        @_combine_sp.register_fake
+        def _(hidden_states: torch.Tensor) -> torch.Tensor:
+            ctx = torch.library.get_ctx()
+            local_n = ctx.new_dynamic_size()
+            return hidden_states.new_empty((local_n,) + hidden_states.shape[1:])
+
+        self._ep_dispatch_rl_op = _dispatch_rl
+        self._ep_dispatch_rl_sp_op = _dispatch_rl_sp
+        self._ep_dispatch_op = _dispatch
+        self._ep_dispatch_sp_op = _dispatch_sp
+        self._ep_combine_op = _combine
+        self._ep_combine_sp_op = _combine_sp
+
     def dispatch_router_logits(
         self,
         hidden_states: torch.Tensor,
@@ -180,17 +594,21 @@ class CpuCommunicator(DeviceCommunicatorBase):
         tuple[torch.Tensor, torch.Tensor]
         | tuple[torch.Tensor, torch.Tensor, list[torch.Tensor]]
     ):
-        """
-        Dispatch the hidden states and router logits to the appropriate device.
-        This is a no-op in the base class.
-        """
-
         assert self.all2all_manager is not None
+        if (
+            extra_tensors is None
+            and is_sequence_parallel
+            and hasattr(self, "_ep_dispatch_rl_sp_op")
+        ):
+            return self._ep_dispatch_rl_sp_op(hidden_states, router_logits)
+        if (
+            extra_tensors is None
+            and not is_sequence_parallel
+            and hasattr(self, "_ep_dispatch_rl_op")
+        ):
+            return self._ep_dispatch_rl_op(hidden_states, router_logits)
         return self.all2all_manager.dispatch_router_logits(
-            hidden_states,
-            router_logits,
-            is_sequence_parallel,
-            extra_tensors,
+            hidden_states, router_logits, is_sequence_parallel, extra_tensors
         )
 
     def dispatch(
@@ -204,11 +622,19 @@ class CpuCommunicator(DeviceCommunicatorBase):
         tuple[torch.Tensor, torch.Tensor, torch.Tensor]
         | tuple[torch.Tensor, torch.Tensor, torch.Tensor, list[torch.Tensor]]
     ):
-        """
-        Dispatch the hidden states and topk weights/ids to the appropriate device.
-        This is a no-op in the base class.
-        """
         assert self.all2all_manager is not None
+        if (
+            extra_tensors is None
+            and is_sequence_parallel
+            and hasattr(self, "_ep_dispatch_sp_op")
+        ):
+            return self._ep_dispatch_sp_op(hidden_states, topk_weights, topk_ids)
+        if (
+            extra_tensors is None
+            and not is_sequence_parallel
+            and hasattr(self, "_ep_dispatch_op")
+        ):
+            return self._ep_dispatch_op(hidden_states, topk_weights, topk_ids)
         return self.all2all_manager.dispatch(
             hidden_states,
             topk_weights,
@@ -220,15 +646,12 @@ class CpuCommunicator(DeviceCommunicatorBase):
     def combine(
         self, hidden_states: torch.Tensor, is_sequence_parallel: bool = False
     ) -> torch.Tensor:
-        """
-        Combine the hidden states and router logits from the appropriate device.
-        This is a no-op in the base class.
-        """
         assert self.all2all_manager is not None
-        return self.all2all_manager.combine(
-            hidden_states,
-            is_sequence_parallel,
-        )
+        if is_sequence_parallel and hasattr(self, "_ep_combine_sp_op"):
+            return self._ep_combine_sp_op(hidden_states)
+        if not is_sequence_parallel and hasattr(self, "_ep_combine_op"):
+            return self._ep_combine_op(hidden_states)
+        return self.all2all_manager.combine(hidden_states, is_sequence_parallel)
 
 
 class _CPUSHMDistributed:

--- a/vllm/model_executor/layers/fused_moe/experts/cpu_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cpu_moe.py
@@ -19,6 +19,7 @@ from vllm._custom_ops import (
     cpu_prepack_moe_weight,
     cpu_prepack_moe_weight_int8,
     fused_experts_cpu,
+    fused_experts_cpu_local_skip,
 )
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.config import (
@@ -603,6 +604,32 @@ class CPUExpertsFp8(mk.FusedMoEExpertsMonolithic):
             )
         )
 
+        if expert_map is not None:
+            # Expert parallelism: select_experts returns global expert ids, but
+            # w1/w2 only hold this rank's local experts. Skip the non-local
+            # selections entirely (instead of masking them to weight 0 and
+            # still running their GEMMs), saving ~world_size x of expert
+            # compute per rank.
+            return fused_experts_cpu_local_skip(
+                hidden_states,
+                w1,
+                w2,
+                topk_weights,
+                topk_ids,
+                expert_map,
+                CPUQuantMethod.FP8_W8A16,  # moe_comp_method
+                self.w1_scale,  # w1_scale
+                self.w2_scale,  # w2_scale
+                None,  # w1_zero
+                None,  # w2_zero
+                block_shape,  # block_size
+                None,  # w1_bias
+                None,  # w2_bias
+                None,  # alpha
+                None,  # limit
+                True,  # is_vnni
+            )
+
         return fused_experts_cpu(
             hidden_states,
             w1,
@@ -684,7 +711,7 @@ class CPUExpertsMxfp4(mk.FusedMoEExpertsMonolithic):
     def _supports_parallel_config(
         moe_parallel_config: FusedMoEParallelConfig,
     ) -> bool:
-        return True
+        return not moe_parallel_config.use_ep
 
     @staticmethod
     def _supports_quant_scheme(
@@ -891,7 +918,7 @@ class CPUExpertsInt4(mk.FusedMoEExpertsMonolithic):
     def _supports_parallel_config(
         moe_parallel_config: FusedMoEParallelConfig,
     ) -> bool:
-        return True
+        return not moe_parallel_config.use_ep
 
     @staticmethod
     def _supports_quant_scheme(
@@ -1063,7 +1090,7 @@ class CPUExpertsInt8(mk.FusedMoEExpertsMonolithic):
     def _supports_parallel_config(
         moe_parallel_config: FusedMoEParallelConfig,
     ) -> bool:
-        return True
+        return not moe_parallel_config.use_ep
 
     @staticmethod
     def _supports_quant_scheme(

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -166,6 +166,11 @@ class CpuPlatform(Platform):
         scheduler_config.async_scheduling = False
 
         parallel_config = vllm_config.parallel_config
+        if parallel_config.nnodes > 1 and (
+            parallel_config.data_parallel_size > 1
+            or parallel_config.enable_expert_parallel
+        ):
+            raise NotImplementedError("CPU DP/EP is single-node only.")
         if (
             os.environ.get("VLLM_ENABLE_V1_MULTIPROCESSING", "1") == "1"
             and parallel_config.distributed_executor_backend == "uni"

--- a/vllm/v1/worker/cpu_worker.py
+++ b/vllm/v1/worker/cpu_worker.py
@@ -13,6 +13,7 @@ import psutil
 import torch
 
 from vllm.config import VllmConfig
+from vllm.config.parallel import ParallelConfig
 from vllm.logger import init_logger
 from vllm.platforms import CpuArchEnum, current_platform
 from vllm.profiler.wrapper import TorchProfilerWrapper
@@ -28,6 +29,32 @@ from vllm.v1.worker.gpu_worker import Worker, init_worker_distributed_environmen
 from vllm.v1.worker.worker_base import CompilationTimes
 
 logger = init_logger(__name__)
+
+
+def _peek_next_dp_init_port(parallel_config: ParallelConfig) -> int:
+    if parallel_config._data_parallel_master_port_list:
+        return parallel_config._data_parallel_master_port_list[-1]
+    return parallel_config.data_parallel_master_port
+
+
+def _get_cpushm_dist_ident(
+    parallel_config: ParallelConfig,
+    distributed_init_method: str,
+) -> str:
+    # Keep multi-node DP on the torch.distributed fallback path. The CPU SHM
+    # fastpath is only expected to work for single-node groups.
+    if (
+        parallel_config.data_parallel_size > 1
+        and parallel_config.nnodes == 1
+        and not parallel_config.enable_elastic_ep
+        and parallel_config.distributed_executor_backend != "external_launcher"
+    ):
+        return (
+            f"{parallel_config.data_parallel_master_ip}:"
+            f"{_peek_next_dp_init_port(parallel_config)}"
+        )
+
+    return distributed_init_method.rsplit(":", maxsplit=1)[-1]
 
 
 class CPUWorker(Worker):
@@ -157,8 +184,11 @@ class CPUWorker(Worker):
 
         torch.set_num_threads = skip_set_num_threads
 
-        # Note: unique identifier for creating allreduce shared memory
-        os.environ["VLLM_DIST_IDENT"] = self.distributed_init_method.split(":")[-1]
+        # Note: unique identifier for creating allreduce shared memory.
+        os.environ["VLLM_DIST_IDENT"] = _get_cpushm_dist_ident(
+            self.parallel_config,
+            self.distributed_init_method,
+        )
         # Initialize the distributed environment.
         init_worker_distributed_environment(
             self.vllm_config,


### PR DESCRIPTION
## Purpose

This PR adds CPU MoE support for DP/EP serving while keeping the landing stack scoped to CPU-owned code paths.

- Adds CPU SHM `all_gatherv` / `reduce_scatterv` collectives used by CPU DP/EP MoE dispatch and combine.
- Adds CPU EP MoE dispatch/combine plumbing and expert-map-aware local expert execution.
- Supports skipped (`-1`) top-k entries in `fused_experts_cpu` for padded or masked expert rows.
- Adds CPU communicator guards and CPU worker checks for unsupported hybrid TP>1 + DP>1 EP configurations.
- Adds focused distributed and kernel coverage for CPU EP communicator behavior, CPU MoE EP correctness, quantized fused MoE skip behavior, and CPU worker DP configuration validation.

Performance optimizations (especially for dp=6 and low concurrency) are generally deferred in the PR.

## Test Plan
2s 6972P
Server:
```
export VLLM_CPU_OMP_THREADS_BIND="192-223|224-255|256-287|288-319|320-351|352-383"
MODEL_NAME=Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8
vllm serve $MODEL_NAME \
	--dtype bfloat16 \
	--port 30000 --host 0.0.0.0 \
	--data-parallel-size={3,6} \
	--{no-enable-expert-parallel, enable-expert-parallel} \
```

Client:
```
MODEL_NAME=Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8
vllm bench serve --model $MODEL_NAME \
 --num-prompt 512 \
 --max-concurrency 128 \
 --port=30000 \
 --dataset-name sonnet \
 --dataset-path ./benchmarks/sonnet.txt \
 --sonnet-input-len 256 \
 --sonnet-output-len 1024
```

## Test Result

| topology | dp3noep | dp3ep | dp3router | dp6noep | dp6ep | dp6router |
|---|---:|---:|---:|---:|---:|---:|
| output toks/s | 913.95 | 810.48 | 654.44 | 973.74 | 898.94 | 943.20 |

dp3/6router Spawns 3/6 dp=1 instances and with a vllm-router instance on top.

## AI assistance disclosure
Developed with Claude and Codex.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
