### PR TITLE
[Bugfix][SM120][MLA] Enable DCP for FlashInfer sparse MLA decode

### DIFF
--- a/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
+++ b/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
@@ -9,8 +9,12 @@ import torch
 from vllm.config import set_current_vllm_config
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils import flashinfer as fi_utils
+from vllm.v1.attention.backends.mla import flashinfer_mla_sparse_sm120 as sm120_module
 from vllm.v1.attention.backends.mla.flashinfer_mla_sparse import (
     FlashInferMLASparseSM120Backend,
+)
+from vllm.v1.attention.backends.mla.flashinfer_mla_sparse_sm120 import (
+    FlashInferMLASparseSM120Impl,
 )
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
@@ -52,3 +56,99 @@ def test_v32_glm_sm120_backend_accepts_glm_block_size(
         )
 
     assert invalid_reasons == []
+
+
+def test_sm120_sparse_mla_dcp_plumbs_lse_and_valid_counts(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(fi_utils, "has_flashinfer_sparse_mla_sm120", lambda: True)
+    monkeypatch.setattr(
+        sm120_module,
+        "_get_workspace_buffer",
+        lambda device: torch.empty(1, dtype=torch.uint8, device=device),
+    )
+
+    num_tokens = 3
+    topk_tokens = 4
+    num_query_heads = 32
+    kv_lora_rank = 512
+    topk_indices = torch.arange(num_tokens * topk_tokens, dtype=torch.int32).reshape(
+        num_tokens, topk_tokens
+    )
+    topk_indices_physical = torch.tensor(
+        [[0, 1, -1, -1], [-1, -1, -1, -1], [4, 5, 6, 7]],
+        dtype=torch.int32,
+    )
+    seq_lens = torch.tensor([2, 0, 4], dtype=torch.int32)
+    captured: dict[str, dict[str, object]] = {}
+
+    def fake_filter_and_convert_dcp_index(*args: object, **kwargs: object):
+        captured["dcp_kwargs"] = kwargs
+        return topk_indices_physical, seq_lens
+
+    def fake_flashinfer_decode(**kwargs: object):
+        out = kwargs["out"]
+        assert isinstance(out, torch.Tensor)
+        assert out.shape == (num_tokens, 1, num_query_heads, kv_lora_rank)
+        assert kwargs["seq_lens"] is seq_lens
+        assert kwargs["return_lse"] is True
+        assert isinstance(kwargs["block_tables"], torch.Tensor)
+        assert kwargs["block_tables"].shape == (num_tokens, 1, topk_tokens)
+        out.fill_(1.0)
+        lse = torch.ones(num_tokens, 1, num_query_heads, dtype=torch.float32)
+        return out, lse
+
+    monkeypatch.setattr(
+        sm120_module,
+        "triton_filter_and_convert_dcp_index",
+        fake_filter_and_convert_dcp_index,
+    )
+    monkeypatch.setattr(
+        fi_utils,
+        "flashinfer_trtllm_batch_decode_with_kv_cache_mla",
+        fake_flashinfer_decode,
+    )
+
+    with set_current_vllm_config(_fake_vllm_config("glm4_moe")):
+        impl = FlashInferMLASparseSM120Impl(
+            num_heads=8,
+            head_size=576,
+            scale=1.0,
+            num_kv_heads=1,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="fp8_ds_mla",
+            logits_soft_cap=None,
+            attn_type="decoder",
+            kv_sharing_target_layer_name=None,
+            indexer=SimpleNamespace(topk_indices_buffer=topk_indices),
+            kv_lora_rank=kv_lora_rank,
+            qk_nope_head_dim=512,
+            qk_rope_head_dim=64,
+        )
+
+    impl.dcp_world_size = 4
+    impl.dcp_rank = 2
+    impl.need_to_return_lse_for_decode = True
+
+    q = torch.zeros(num_tokens, num_query_heads, 576, dtype=torch.bfloat16)
+    kv_cache = torch.zeros(1, 64, 656, dtype=torch.uint8)
+    metadata = SimpleNamespace(
+        req_id_per_token=torch.tensor([0, 0, 1], dtype=torch.int32),
+        block_table=torch.arange(8, dtype=torch.int32).reshape(2, 4),
+        block_size=64,
+        cp_kv_cache_interleave_size=1,
+        topk_tokens=topk_tokens,
+    )
+
+    out, lse = impl.forward_mqa(q, kv_cache, metadata, SimpleNamespace())
+
+    assert out.shape == (num_tokens, num_query_heads, kv_lora_rank)
+    assert lse is not None
+    assert lse.shape == (num_tokens, num_query_heads)
+    assert torch.all(out[0] == 1)
+    assert torch.all(out[1] == 0)
+    assert torch.isneginf(lse[1]).all()
+    assert captured["dcp_kwargs"]["dcp_size"] == 4
+    assert captured["dcp_kwargs"]["dcp_rank"] == 2
+    assert captured["dcp_kwargs"]["return_valid_counts"] is True

--- a/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
+++ b/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
@@ -12,8 +12,12 @@ from vllm.models.deepseek_v4.nvidia.flashinfer_sparse import (
 )
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils import flashinfer as fi_utils
+from vllm.v1.attention.backends.mla import flashinfer_mla_sparse_sm120 as sm120_module
 from vllm.v1.attention.backends.mla.flashinfer_mla_sparse import (
     FlashInferMLASparseSM120Backend,
+)
+from vllm.v1.attention.backends.mla.flashinfer_mla_sparse_sm120 import (
+    FlashInferMLASparseSM120Impl,
 )
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
@@ -85,3 +89,99 @@ def test_sm120_dsv4_required_topk_tracks_dspark_width() -> None:
 
     assert _required_sm120_sparse_topk(causal, 128) == 128
     assert _required_sm120_sparse_topk(dspark, 128) == 192
+
+
+def test_sm120_sparse_mla_dcp_plumbs_lse_and_valid_counts(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(fi_utils, "has_flashinfer_sparse_mla_sm120", lambda: True)
+    monkeypatch.setattr(
+        sm120_module,
+        "_get_workspace_buffer",
+        lambda device: torch.empty(1, dtype=torch.uint8, device=device),
+    )
+
+    num_tokens = 3
+    topk_tokens = 4
+    num_query_heads = 32
+    kv_lora_rank = 512
+    topk_indices = torch.arange(num_tokens * topk_tokens, dtype=torch.int32).reshape(
+        num_tokens, topk_tokens
+    )
+    topk_indices_physical = torch.tensor(
+        [[0, 1, -1, -1], [-1, -1, -1, -1], [4, 5, 6, 7]],
+        dtype=torch.int32,
+    )
+    seq_lens = torch.tensor([2, 0, 4], dtype=torch.int32)
+    captured: dict[str, dict[str, object]] = {}
+
+    def fake_filter_and_convert_dcp_index(*args: object, **kwargs: object):
+        captured["dcp_kwargs"] = kwargs
+        return topk_indices_physical, seq_lens
+
+    def fake_flashinfer_decode(**kwargs: object):
+        out = kwargs["out"]
+        assert isinstance(out, torch.Tensor)
+        assert out.shape == (num_tokens, 1, num_query_heads, kv_lora_rank)
+        assert kwargs["seq_lens"] is seq_lens
+        assert kwargs["return_lse"] is True
+        assert isinstance(kwargs["block_tables"], torch.Tensor)
+        assert kwargs["block_tables"].shape == (num_tokens, 1, topk_tokens)
+        out.fill_(1.0)
+        lse = torch.ones(num_tokens, 1, num_query_heads, dtype=torch.float32)
+        return out, lse
+
+    monkeypatch.setattr(
+        sm120_module,
+        "triton_filter_and_convert_dcp_index",
+        fake_filter_and_convert_dcp_index,
+    )
+    monkeypatch.setattr(
+        fi_utils,
+        "flashinfer_trtllm_batch_decode_with_kv_cache_mla",
+        fake_flashinfer_decode,
+    )
+
+    with set_current_vllm_config(_fake_vllm_config("glm4_moe")):
+        impl = FlashInferMLASparseSM120Impl(
+            num_heads=8,
+            head_size=576,
+            scale=1.0,
+            num_kv_heads=1,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="fp8_ds_mla",
+            logits_soft_cap=None,
+            attn_type="decoder",
+            kv_sharing_target_layer_name=None,
+            indexer=SimpleNamespace(topk_indices_buffer=topk_indices),
+            kv_lora_rank=kv_lora_rank,
+            qk_nope_head_dim=512,
+            qk_rope_head_dim=64,
+        )
+
+    impl.dcp_world_size = 4
+    impl.dcp_rank = 2
+    impl.need_to_return_lse_for_decode = True
+
+    q = torch.zeros(num_tokens, num_query_heads, 576, dtype=torch.bfloat16)
+    kv_cache = torch.zeros(1, 64, 656, dtype=torch.uint8)
+    metadata = SimpleNamespace(
+        req_id_per_token=torch.tensor([0, 0, 1], dtype=torch.int32),
+        block_table=torch.arange(8, dtype=torch.int32).reshape(2, 4),
+        block_size=64,
+        cp_kv_cache_interleave_size=1,
+        topk_tokens=topk_tokens,
+    )
+
+    out, lse = impl.forward_mqa(q, kv_cache, metadata, SimpleNamespace())
+
+    assert out.shape == (num_tokens, num_query_heads, kv_lora_rank)
+    assert lse is not None
+    assert lse.shape == (num_tokens, num_query_heads)
+    assert torch.all(out[0] == 1)
+    assert torch.all(out[1] == 0)
+    assert torch.isneginf(lse[1]).all()
+    assert captured["dcp_kwargs"]["dcp_size"] == 4
+    assert captured["dcp_kwargs"]["dcp_rank"] == 2
+    assert captured["dcp_kwargs"]["return_valid_counts"] is True

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """SM120 implementation variant for ``FLASHINFER_MLA_SPARSE_SM120``."""
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import torch
 
@@ -17,6 +17,7 @@ from vllm.v1.attention.backends.mla.flashinfer_mla_sparse import (
 )
 from vllm.v1.attention.backends.mla.sparse_utils import (
     triton_convert_req_index_to_global_index,
+    triton_filter_and_convert_dcp_index,
 )
 
 if TYPE_CHECKING:
@@ -33,6 +34,8 @@ class FlashInferMLASparseSM120Impl(MLAAttentionImpl[FlashInferMLASparseMetadata]
     """SM120 FlashInfer sparse-MLA implementation."""
 
     is_sparse = True
+    can_return_lse_for_decode: bool = True
+    lse_base_on_e: bool = False
 
     def __init__(
         self,
@@ -117,19 +120,31 @@ class FlashInferMLASparseSM120Impl(MLAAttentionImpl[FlashInferMLASparseMetadata]
         assert self.topk_indices_buffer is not None
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
 
-        topk_indices_physical = cast(
-            torch.Tensor,
-            triton_convert_req_index_to_global_index(
+        if self.dcp_world_size > 1:
+            topk_indices_physical, seq_lens = triton_filter_and_convert_dcp_index(
+                attn_metadata.req_id_per_token[:num_actual_toks],
+                attn_metadata.block_table,
+                topk_indices,
+                dcp_size=self.dcp_world_size,
+                dcp_rank=self.dcp_rank,
+                cp_kv_cache_interleave_size=(attn_metadata.cp_kv_cache_interleave_size),
+                BLOCK_SIZE=attn_metadata.block_size,
+                NUM_TOPK_TOKENS=topk_indices.shape[1],
+                return_valid_counts=True,
+            )
+        else:
+            topk_indices_physical, seq_lens = triton_convert_req_index_to_global_index(
                 attn_metadata.req_id_per_token[:num_actual_toks],
                 attn_metadata.block_table,
                 topk_indices,
                 BLOCK_SIZE=attn_metadata.block_size,
                 NUM_TOPK_TOKENS=topk_indices.shape[1],
-            ),
-        )
+                return_valid_counts=True,
+            )
 
+        num_query_heads = q.shape[1]
         output = q.new_empty(
-            (num_actual_toks, self.num_heads, self.kv_lora_rank),
+            (num_actual_toks, num_query_heads, self.kv_lora_rank),
             dtype=q.dtype,
         )
 
@@ -140,7 +155,7 @@ class FlashInferMLASparseSM120Impl(MLAAttentionImpl[FlashInferMLASparseMetadata]
             flashinfer_trtllm_batch_decode_with_kv_cache_mla,
         )
 
-        out = flashinfer_trtllm_batch_decode_with_kv_cache_mla(
+        kernel_out = flashinfer_trtllm_batch_decode_with_kv_cache_mla(
             query=q.unsqueeze(1),
             kv_cache=kv_c_and_k_pe_cache.view(torch.uint8).unsqueeze(1),
             workspace_buffer=self._workspace_buffer,
@@ -148,12 +163,51 @@ class FlashInferMLASparseSM120Impl(MLAAttentionImpl[FlashInferMLASparseMetadata]
             kv_lora_rank=self.kv_lora_rank,
             qk_rope_head_dim=self.qk_rope_head_dim,
             block_tables=topk_indices_physical.unsqueeze(1),
-            seq_lens=None,
+            seq_lens=seq_lens,
             max_seq_len=attn_metadata.topk_tokens,
             out=output.unsqueeze(1),
             bmm1_scale=self.scale,
             bmm2_scale=1.0,
             sparse_mla_top_k=attn_metadata.topk_tokens,
+            return_lse=self.need_to_return_lse_for_decode,
             kv_scale_format=self.kv_scale_format,
         )
-        return out.squeeze(1), None
+        if self.need_to_return_lse_for_decode:
+            assert isinstance(kernel_out, tuple)
+            out, lse = kernel_out
+        else:
+            assert isinstance(kernel_out, torch.Tensor)
+            out = kernel_out
+            lse = None
+
+        out = out.squeeze(1)
+        if lse is not None:
+            lse = self._normalize_lse(lse, out.shape[0], out.shape[1])
+            empty_rows = (topk_indices_physical == -1).all(dim=-1)
+            out.masked_fill_(empty_rows.view(-1, 1, 1), 0.0)
+            lse.masked_fill_(empty_rows.view(-1, 1), float("-inf"))
+        return out, lse
+
+    @staticmethod
+    def _normalize_lse(
+        lse: torch.Tensor,
+        num_tokens: int,
+        num_heads: int,
+    ) -> torch.Tensor:
+        # FlashInfer returns the decode LSE either as 2D (num_tokens, num_heads)
+        # or 3D ((num_tokens, num_heads, 1) / (num_tokens, 1, num_heads)).
+        # Collapse all of these to the (num_tokens, num_heads) the shared DCP
+        # reducer expects.
+        if lse.dim() == 3:
+            if lse.shape[-1] == 1:
+                lse = lse.squeeze(-1)
+            elif lse.shape[1] == 1:
+                lse = lse.squeeze(1)
+            elif lse.shape[0] * lse.shape[1] == num_tokens:
+                lse = lse.reshape(num_tokens, lse.shape[-1])
+        if lse.shape != (num_tokens, num_heads):
+            raise RuntimeError(
+                "Unexpected FlashInfer SM120 sparse MLA LSE shape: "
+                f"{tuple(lse.shape)}, expected ({num_tokens}, {num_heads})."
+            )
+        return lse


### PR DESCRIPTION
## Purpose

Enable decode context parallelism for the SM120 FlashInfer sparse MLA decode backend (`FLASHINFER_MLA_SPARSE_SM120`).

The generic FlashInfer sparse MLA backend already participates in DCP by filtering sparse top-k indices to the local DCP rank, passing valid per-row counts as `seq_lens`, requesting decode LSE, normalizing the LSE shape, and masking empty DCP rows before returning `(out, lse)` to the shared DCP reducer.

The SM120 packed sparse MLA wrapper still followed the simpler non-DCP path: it converted sparse indices without DCP filtering, passed `seq_lens=None`, did not request/return LSE, and allocated the output buffer from `self.num_heads`. On RTX PRO 6000 / SM120 GLM-5.2-NVFP4 serving with DCP this prevented startup and/or DCP reduction correctness. One concrete failure from hardware validation was:

```text
ValueError: Invalid shape of out: expected (32, 1, 32, 512), got torch.Size([32, 1, 8, 512])
```

This PR ports the existing sparse FlashInfer DCP wrapper behavior to the SM120 variant while preserving the SM120-specific packed `fp8_ds_mla` KV cache path, BF16 query input, `bmm2_scale=1.0`, and `kv_scale_format` plumbing.

Specifically, it:

- marks `FlashInferMLASparseSM120Impl` as able to return decode LSE;
- uses `triton_filter_and_convert_dcp_index` when DCP is enabled;
- passes compacted valid counts to FlashInfer as `seq_lens`;
- requests `return_lse` when the shared DCP reducer needs it;
- normalizes FlashInfer LSE to `(num_tokens, num_heads)`;
- masks empty DCP rows with `out=0` and `lse=-inf`;
- sizes the FlashInfer `out` buffer from the query head count actually passed to FlashInfer.

Dependency note: this patch applies cleanly to current `main` and does not require rebasing on another vLLM PR. Runtime validation below used FlashInfer 0.6.14. If `main` still pins 0.6.13 when this is reviewed, full SM120 GLM validation may be easier after #47669 lands.

AI assistance disclosure: OpenAI Codex was used to port the locally validated production patch into upstream form, add the focused unit test, run local checks, and draft this PR description. I reviewed the changed lines and own the submission.

## Test Plan

Local static/unit checks available in this environment:

- `python3 -m py_compile vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py`
- `python3 -m ruff check vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py`
- `python3 -m ruff format --check vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py`
- `git diff --check`

Targeted pytest attempted:

- `python3 -m pytest -q tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py`

Production hardware validation performed separately on an 8x RTX PRO 6000 / SM120 system using `nvidia/GLM-5.2-NVFP4`, vLLM V1, FlashInfer 0.6.14, packed sparse MLA, TP=8, EP enabled, `max_model_len=131072`, FP8 KV cache, DCP=4, and MTP=2.

## Test Result

Local:

- `py_compile`: passed
- `ruff check`: passed
- `ruff format --check`: passed after formatting the touched files
- `git diff --check`: passed
- targeted pytest: not runnable in this local checkout because the Python environment does not have `torch` installed (`ModuleNotFoundError: No module named 'torch'` while importing `tests/conftest.py`)

Production SM120 validation summary:

- DCP=4 startup succeeded after this wrapper fix.
- vLLM reported `GPU KV cache size: 2,096,896 tokens` and `Maximum concurrency for 131,072 tokens per request: 16.00x` for DCP-only.
- With DCP=4 + MTP=2, vLLM reported `GPU KV cache size: 1,757,952 tokens` and `Maximum concurrency for 131,072 tokens per request: 13.41x`.
- 10 parallel chatbot-style requests completed successfully.
- Sustained 3 waves x 10 requests completed 30/30 HTTP 200 with about 239 output tok/s aggregate throughput.
- A near-128K request completed HTTP 200 with about 125K prompt tokens.

Follow-up validation that would be useful from maintainers with matching hardware:

- Run the new unit test in the normal CUDA CI/dev environment.
- Re-run GLM-5.2-NVFP4 on SM120 with DCP=2 and DCP=4.
- Compare DCP output against non-DCP output on deterministic prompts.
- Confirm FlashInfer SM120 sparse MLA LSE base remains `log2`, matching the generic FlashInfer sparse MLA backend.
