### PR TITLE
fix: tolerate source checkout without vllm metadata

### DIFF
--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -3,7 +3,7 @@
 
 import os
 import types
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 from importlib.util import find_spec
 
 from vllm.logger import init_logger
@@ -57,8 +57,14 @@ if HAS_TRITON:
             )
             HAS_TRITON = False
 
-        # Check Triton CPU
-        if "cpu" in version("vllm"):
+        # Check Triton CPU. Source-tree execution may not have installed
+        # package metadata yet, in which case the build is not a CPU wheel.
+        try:
+            vllm_version = version("vllm")
+        except PackageNotFoundError:
+            vllm_version = ""
+
+        if "cpu" in vllm_version:
             if "cpu" in backends:
                 HAS_TRITON = True
             else:


### PR DESCRIPTION
### Summary

Handle source-tree execution where `importlib.metadata.version("vllm")` raises `PackageNotFoundError` because vLLM has not been installed as a package yet.

Without this guard, Triton probing can fail before runtime initialization reaches the backend checks. In a source checkout, the absence of package metadata should simply mean "not a CPU wheel" for this check.

### Changes

- Import `PackageNotFoundError` from `importlib.metadata`.
- Treat missing `vllm` package metadata as an empty version string when checking for CPU wheel builds.

### Validation

- `python3 -m py_compile vllm/triton_utils/importing.py`
- `git diff --check`
- Verified the guard is present in the source checkout path.
