### PR TITLE
[Bugfix] Support quantized eh_proj in HYV3 MTP draft model

### DIFF
--- a/vllm/model_executor/models/hy_v3_mtp.py
+++ b/vllm/model_executor/models/hy_v3_mtp.py
@@ -36,6 +36,7 @@ from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import (
@@ -99,7 +100,13 @@ class HYV3MultiTokenPredictorLayer(nn.Module):
 
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        self.eh_proj = ReplicatedLinear(
+            config.hidden_size * 2,
+            config.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.eh_proj",
+        )
         self.shared_head = HYV3SharedHead(config=config, quant_config=quant_config)
         self.mtp_block = HYV3DecoderLayer(
             config=config,
@@ -125,7 +132,7 @@ class HYV3MultiTokenPredictorLayer(nn.Module):
         inputs_embeds = self.enorm(inputs_embeds)
         previous_hidden_states = self.hnorm(previous_hidden_states)
 
-        hidden_states = self.eh_proj(
+        hidden_states, _ = self.eh_proj(
             torch.cat([inputs_embeds, previous_hidden_states], dim=-1)
         )
 


### PR DESCRIPTION
## Purpose

Fix loading of the HYV3 MTP (`hy_v3_mtp`) draft model when the checkpoint's quantization covers the MTP layer.

`HYV3MultiTokenPredictorLayer` constructs `eh_proj` as a bare `nn.Linear`. Quantized checkpoints that include the MTP layer — e.g. compressed-tensors NVFP4 (`nvfp4-pack-quantized`), which emits `weight_packed` / `weight_scale` / `weight_global_scale` for it — fail during `load_weights`:

```
KeyError: 'model.layers.80.eh_proj.weight_global_scale'
```

This PR constructs `eh_proj` as `ReplicatedLinear` with the model's `quant_config` and a proper prefix, so packed draft weights load through the standard quantized-linear path. Unquantized checkpoints are unaffected: with `quant_config=None` (or the layer in the ignore list) `ReplicatedLinear` falls back to `UnquantizedLinearMethod`, keeping the previous behavior.

## Test Plan

Serve a compressed-tensors NVFP4 quant of `tencent/Hy3-preview` with MTP speculative decoding enabled:

```
vllm serve <model> -tp 2 --speculative-config '{"method": "hy_v3_mtp", "num_speculative_tokens": 1}' ...
```

## Test Result

Verified on 2× NVIDIA DGX Spark (GB10, TP=2 over Ray): before this change the server fails at draft-weight load with the KeyError above; with it, weights load and speculative decoding runs (SpecDecoding metrics report mean acceptance length ≈ 1.7 on this checkpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)