### PR TITLE
Handle missing vLLM metadata in Triton import

### DIFF
--- a/tests/test_triton_utils.py
+++ b/tests/test_triton_utils.py
@@ -3,6 +3,7 @@
 
 import sys
 import types
+from importlib.metadata import PackageNotFoundError
 from unittest import mock
 
 from vllm.triton_utils.importing import TritonLanguagePlaceholder, TritonPlaceholder
@@ -92,3 +93,16 @@ def test_no_triton_fallback():
         assert triton.__class__.__name__ == "TritonPlaceholder"
         assert triton.language.__class__.__name__ == "TritonLanguagePlaceholder"
         assert tl.__class__.__name__ == "TritonLanguagePlaceholder"
+
+
+def test_triton_import_tolerates_missing_vllm_metadata():
+    sys.modules.pop("vllm.triton_utils", None)
+    sys.modules.pop("vllm.triton_utils.importing", None)
+
+    with mock.patch(
+        "importlib.metadata.version",
+        side_effect=PackageNotFoundError("vllm"),
+    ):
+        import vllm.triton_utils.importing as importing
+
+        assert isinstance(importing.HAS_TRITON, bool)

--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -3,7 +3,7 @@
 
 import os
 import types
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 from importlib.util import find_spec
 
 from vllm.logger import init_logger
@@ -58,7 +58,12 @@ if HAS_TRITON:
             HAS_TRITON = False
 
         # Check Triton CPU
-        if "cpu" in version("vllm"):
+        try:
+            vllm_version = version("vllm")
+        except PackageNotFoundError:
+            vllm_version = ""
+
+        if "cpu" in vllm_version:
             if "cpu" in backends:
                 HAS_TRITON = True
             else:


### PR DESCRIPTION
## Summary
- tolerate `importlib.metadata.PackageNotFoundError` when checking the installed vLLM distribution in `vllm.triton_utils.importing`
- add a regression test for importing Triton utilities from a source tree without installed package metadata

## Why
When vLLM is imported directly from a source checkout or editable development layout before distribution metadata is available, `version("vllm")` can raise `PackageNotFoundError`. That currently falls into the broad Triton compatibility exception path and disables Triton even though the failure is only a metadata lookup for the CPU wheel check.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 - <<PY ... ast.parse(...) ... PY` on the changed files
- `git diff --check`

`python3 -m pytest tests/test_triton_utils.py -q` could not run in my local checkout because this environment is missing `torch`, which is imported by the repository test conftest before this test module is collected.\n\n### Current-head validation (2026-07-26)\n\n- Rebased onto upstream `main` `0ba2aa35a81dcc3246b26291368b53fa2389c7d7`.\n- Exact PR head: `bf59c7b51d9d9d92532621563c6866225ae4e5ad`.\n- Focused Triton utility suite passed in the CANN 9.0.0 container: 8 passed.\n- Ruff check, Ruff format check, and `git diff --check` passed.\n\n\n## Contribution disclosure

- Duplicate-work check: an open-PR search for Triton missing vLLM metadata found no competing implementation; the other broad-search matches address unrelated model and attention paths.
- AI assistance was used for implementation support, test execution, rebase maintenance, and drafting this description. The human submitter remains responsible for reviewing and defending the change.
