### PR TITLE
[do not land] [wip] Add Helion call-site routing + route per_token_group_fp8_quant

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -279,7 +279,7 @@ steps:
   - tests/kernels/helion/
   - vllm/platforms/rocm.py
   commands:
-  - pip install helion==1.1.0
+  - pip install helion==1.2.0
   - pytest -v -s kernels/helion/
 
 - label: Kernels Mamba Test # TBD

--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -270,7 +270,7 @@ steps:
   - vllm/utils/import_utils.py
   - tests/kernels/helion/
   commands:
-    - pip install helion==1.1.0
+    - pip install helion==1.2.0
     - pytest -v -s kernels/helion/
 
  

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -27,3 +27,9 @@ tokenspeed-mla==0.1.2
 
 # Humming kernels for quantization gemm
 humming-kernels[cu13]==0.1.6
+
+# Helion kernels (enabled by default via VLLM_USE_HELION_KERNELS)
+# NOTE: When updating helion version, also update CI files:
+#   - .buildkite/test_areas/kernels.yaml
+#   - .buildkite/test-amd.yaml
+helion==1.2.0

--- a/setup.py
+++ b/setup.py
@@ -1256,11 +1256,10 @@ setup(
         ],  # Required for audio processing
         "video": [],  # Kept for backwards compatibility
         "flashinfer": [],  # Kept for backwards compatibility
-        # Optional deps for Helion kernel development
-        # NOTE: When updating helion version, also update CI files:
-        #   - .buildkite/test_areas/kernels.yaml
-        #   - .buildkite/test-amd.yaml
-        "helion": ["helion==1.1.0"],
+        # Helion is a base CUDA dependency (see requirements/cuda.txt); this
+        # extra is kept for backwards compatibility so `pip install vllm[helion]`
+        # still works. Keep the pin in sync with requirements/cuda.txt.
+        "helion": ["helion==1.2.0"],
         # Optional deps for gRPC server (vllm serve --grpc)
         "grpc": ["smg-grpc-servicer[vllm] >= 0.5.2"],
         # Optional deps for OpenTelemetry tracing

--- a/tests/kernels/helion/test_autotune.py
+++ b/tests/kernels/helion/test_autotune.py
@@ -9,7 +9,7 @@ from vllm.utils.import_utils import has_helion
 
 if not has_helion():
     pytest.skip(
-        "Helion is not installed. Install with: pip install vllm[helion]",
+        "Helion is not installed. Install with: pip install helion",
         allow_module_level=True,
     )
 

--- a/tests/kernels/helion/test_case_key.py
+++ b/tests/kernels/helion/test_case_key.py
@@ -7,7 +7,7 @@ from vllm.utils.import_utils import has_helion
 
 if not has_helion():
     pytest.skip(
-        "Helion is not installed. Install with: pip install vllm[helion]",
+        "Helion is not installed. Install with: pip install helion",
         allow_module_level=True,
     )
 

--- a/tests/kernels/helion/test_config_manager.py
+++ b/tests/kernels/helion/test_config_manager.py
@@ -17,7 +17,7 @@ from vllm.utils.import_utils import has_helion
 # Skip entire module if helion is not available
 if not has_helion():
     pytest.skip(
-        "Helion is not installed. Install with: pip install vllm[helion]",
+        "Helion is not installed. Install with: pip install helion",
         allow_module_level=True,
     )
 

--- a/tests/kernels/helion/test_dynamic_per_token_scaled_fp8_quant.py
+++ b/tests/kernels/helion/test_dynamic_per_token_scaled_fp8_quant.py
@@ -27,7 +27,7 @@ from vllm.utils.torch_utils import set_random_seed
 
 if not has_helion():
     pytest.skip(
-        "Helion is not installed. Install with: pip install vllm[helion]",
+        "Helion is not installed. Install with: pip install helion",
         allow_module_level=True,
     )
 

--- a/tests/kernels/helion/test_helion_available.py
+++ b/tests/kernels/helion/test_helion_available.py
@@ -14,7 +14,7 @@ from vllm.utils.import_utils import has_helion
 # Skip entire module if helion is not available
 if not has_helion():
     pytest.skip(
-        "Helion is not installed. Install with: pip install vllm[helion]",
+        "Helion is not installed. Install with: pip install helion",
         allow_module_level=True,
     )
 

--- a/tests/kernels/helion/test_pattern_matching.py
+++ b/tests/kernels/helion/test_pattern_matching.py
@@ -12,7 +12,7 @@ from vllm.utils.import_utils import has_helion
 
 if not has_helion():
     pytest.skip(
-        "Helion is not installed. Install with: pip install vllm[helion]",
+        "Helion is not installed. Install with: pip install helion",
         allow_module_level=True,
     )
 

--- a/tests/kernels/helion/test_per_token_group_fp8_quant.py
+++ b/tests/kernels/helion/test_per_token_group_fp8_quant.py
@@ -28,7 +28,7 @@ from vllm.utils.import_utils import has_helion
 
 if not has_helion():
     pytest.skip(
-        "Helion is not installed. Install with: pip install vllm[helion]",
+        "Helion is not installed. Install with: pip install helion",
         allow_module_level=True,
     )
 

--- a/tests/kernels/helion/test_register.py
+++ b/tests/kernels/helion/test_register.py
@@ -16,7 +16,7 @@ from vllm.utils.import_utils import has_helion
 
 if not has_helion():
     pytest.skip(
-        "Helion is not installed. Install with: pip install vllm[helion]",
+        "Helion is not installed. Install with: pip install helion",
         allow_module_level=True,
     )
 

--- a/tests/kernels/helion/test_rms_norm_dynamic_per_token_quant.py
+++ b/tests/kernels/helion/test_rms_norm_dynamic_per_token_quant.py
@@ -26,7 +26,7 @@ from vllm.utils.torch_utils import set_random_seed
 
 if not has_helion():
     pytest.skip(
-        "Helion is not installed. Install with: pip install vllm[helion]",
+        "Helion is not installed. Install with: pip install helion",
         allow_module_level=True,
     )
 

--- a/tests/kernels/helion/test_rms_norm_per_block_quant.py
+++ b/tests/kernels/helion/test_rms_norm_per_block_quant.py
@@ -27,7 +27,7 @@ from vllm.utils.torch_utils import set_random_seed
 
 if not has_helion():
     pytest.skip(
-        "Helion is not installed. Install with: pip install vllm[helion]",
+        "Helion is not installed. Install with: pip install helion",
         allow_module_level=True,
     )
 

--- a/tests/kernels/helion/test_silu_mul_fp8.py
+++ b/tests/kernels/helion/test_silu_mul_fp8.py
@@ -9,7 +9,7 @@ from vllm.utils.import_utils import has_helion
 
 if not has_helion():
     pytest.skip(
-        "Helion is not installed. Install with: pip install vllm[helion]",
+        "Helion is not installed. Install with: pip install helion",
         allow_module_level=True,
     )
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -175,6 +175,7 @@ if TYPE_CHECKING:
     VLLM_TPU_BUCKET_PADDING_GAP: int = 0
     VLLM_TPU_MOST_MODEL_LEN: int | None = None
     VLLM_TPU_USING_PATHWAYS: bool = False
+    VLLM_USE_HELION_KERNELS: bool = True
     VLLM_USE_DEEP_GEMM: bool = True
     VLLM_MOE_USE_DEEP_GEMM: bool = True
     VLLM_USE_DEEP_GEMM_E8M0: bool = True
@@ -1430,6 +1431,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Whether using Pathways
     "VLLM_TPU_USING_PATHWAYS": lambda: bool(
         "proxy" in os.getenv("JAX_PLATFORMS", "").lower()
+    ),
+    # Use Helion kernels when the `helion` package is installed.
+    "VLLM_USE_HELION_KERNELS": lambda: bool(
+        int(os.getenv("VLLM_USE_HELION_KERNELS", "1"))
     ),
     # Allow use of DeepGemm kernels for fused moe ops.
     "VLLM_USE_DEEP_GEMM": lambda: bool(int(os.getenv("VLLM_USE_DEEP_GEMM", "1"))),

--- a/vllm/kernels/helion/routing.py
+++ b/vllm/kernels/helion/routing.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Call-site routing for eager Helion quant ops.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+
+import torch
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_ROUTABLE_EAGER_OPS = frozenset(
+    {
+        "per_token_group_fp8_quant",
+    }
+)
+@functools.cache
+def _helion_available(op_name: str) -> bool:
+    # `import vllm.kernels.helion` transitively imports the third-party `helion`
+    # package (see register.py). Since VLLM_USE_HELION_KERNELS defaults on, this
+    # runs on every install; if `helion` is missing or broken, fall back to native
+    # instead of crashing the forward.
+    try:
+        import vllm.kernels.helion  # noqa: F401  register ops
+        from vllm.kernels.helion.register import _HOP_AVAILABLE
+
+        ready = (not _HOP_AVAILABLE) and hasattr(torch.ops.vllm_helion, op_name)
+    except Exception:
+        ready = False
+    if not ready:
+        logger.warning_once(
+            "VLLM_USE_HELION_KERNELS is set but Helion kernels are not available "
+            "for '%s'; falling back to the native kernel. Install the `helion` "
+            "package (pip install helion) to enable them.",
+            op_name,
+        )
+    return ready
+
+
+def route_quant(op_name: str, fn: Callable, *args):
+    """Dispatch a quant op to Helion iff currently capturing a CUDA graph.
+
+    ``fn`` is the fallback, invoked as ``fn(*args)`` whenever Helion is not used:
+    plain eager, torch.compile tracing (``is_compiling()``), or Helion
+    unavailable/unsupported for ``op_name``. Passing the fallback in (rather than
+    assuming ``torch.ops._C.<op_name>``) lets call sites route to any native
+    implementation with the same signature as the Helion op.
+    """
+    import vllm.envs as envs
+
+    if (
+        op_name in _ROUTABLE_EAGER_OPS
+        and envs.VLLM_USE_HELION_KERNELS
+        and not torch.compiler.is_compiling()
+        and torch.cuda.is_current_stream_capturing()
+        and _helion_available(op_name)
+    ):
+        return getattr(torch.ops.vllm_helion, op_name).default(*args)
+    return fn(*args)

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -634,7 +634,12 @@ def per_token_group_quant_fp8(
     if (
         current_platform.is_cuda_alike() or current_platform.is_xpu()
     ) and x.is_contiguous():
-        torch.ops._C.per_token_group_fp8_quant(
+        from vllm.kernels.helion.routing import route_quant
+
+        # Helion under CUDA-graph capture, native _C in eager (see routing.py).
+        route_quant(
+            "per_token_group_fp8_quant",
+            torch.ops._C.per_token_group_fp8_quant,
             x,
             x_q,
             x_s,


### PR DESCRIPTION
Non-compiled path only: route_quant() dispatches _C quant ops to their Helion equivalents at eager call sites, but only when the stream is being captured into a CUDA graph (is_current_stream_capturing). Native _C is used in plain eager (Helion's per-call dispatch overhead is a loss there) and during torch.compile tracing (is_compiling guard; the compiled path is handled by a later commit).

Introduces the VLLM_USE_HELION_KERNELS flag and wires the first op, per_token_group_fp8_quant, at its fp8_utils call site. Includes a non-compiled (eager + full CUDA-graph) benchmark: ~2.7% P50 faster than native on Qwen3-1.7B-FP8, no JIT spike.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

