### PR TITLE
[CI][LoRA] Preserve QKV fuser split sizes through LoRA wrappers

### DIFF
--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -797,12 +797,18 @@ def test_column_parallel_packed(
                 params_dtype=torch.float16,
                 prefix=f"layer_{idx}",
             )
+            linear.split_sizes = [
+                linear.num_heads * linear.head_size,
+                linear.num_kv_heads * linear.head_size,
+                linear.num_kv_heads * linear.v_head_size,
+            ]
             linear.weight.data = torch.rand_like(linear.weight.data)
             lora_linear = (
                 MergedQKVParallelLinearWithLoRA(linear)
                 if not fully_shard
                 else MergedQKVParallelLinearWithShardedLoRA(linear)
             )
+            assert lora_linear.split_sizes == linear.split_sizes
         else:
             linear = QKVParallelLinear(
                 4096,

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -467,6 +467,17 @@ class MergedQKVParallelLinearWithLoRA(MergedColumnParallelLinearWithLoRA):
             self.kv_shard_id,
             self.kv_shard_id,
         )
+        self.split_sizes = list(
+            getattr(
+                self.base_layer,
+                "split_sizes",
+                [
+                    self.q_proj_shard_size,
+                    self.kv_proj_shard_size,
+                    self.base_layer.num_kv_heads * self.base_layer.v_head_size,
+                ],
+            )
+        )
 
     def create_lora_weights(
         self,


### PR DESCRIPTION
This PR fixes the LoRA regression in CI:
- https://buildkite.com/vllm/ci/builds/76671/list?jid=019f3973-c928-4da0-997d-33258ddbe1c5&tab=output

The regression was probably introduced by:
- #47187 

After transformers QKV fuser it rewrites separate `q_proj`, `k_proj`, and `v_proj` calls into one fused `qkv_proj` call, then splits the fused output with `qkv_proj.split_sizes`. It sets `split_sizes` on the generated `QKVParallelLinear`, but the LoRA wrapper did not preserve that dynamic attribute. When `test_ilama_lora` initialized the Transformers backend with LoRA enabled, the rewritten forward referenced `MergedQKVParallelLinearWithLoRA.split_sizes` and failed during engine startup.