### PR TITLE
[NPU][0-DAY] Hy3 0-day adaptation on Ascend NPU

### DIFF
--- a/vllm/model_executor/models/hy_v3.py
+++ b/vllm/model_executor/models/hy_v3.py
@@ -166,7 +166,7 @@ class HYV3MoEFused(nn.Module):
                 intermediate_size=config.expert_hidden_dim * config.num_shared_experts,
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
-                prefix=f"{prefix}",
+                prefix=f"{prefix}.shared_mlp",
                 reduce_results=False,
             )
         else:

--- a/vllm/model_executor/models/hy_v3_mtp.py
+++ b/vllm/model_executor/models/hy_v3_mtp.py
@@ -441,6 +441,12 @@ class HYV3MTP(nn.Module):
                     if "mlp.router.gate." in name:
                         name = name.replace("router.gate.", "gate.")
 
+                    # Quantized model weight_scale/weight_offset are not
+                    # standalone parameters — they are consumed by the
+                    # quantized layer's quant_method during __init__.
+                    if name.endswith("_scale") or name.endswith("_offset"):
+                        continue
+
                     param = params_dict[name]
                     weight_loader = getattr(
                         param, "weight_loader", default_weight_loader

--- a/vllm/model_executor/models/hy_v3_mtp.py
+++ b/vllm/model_executor/models/hy_v3_mtp.py
@@ -119,7 +119,7 @@ class HYV3MultiTokenPredictorLayer(nn.Module):
     ) -> torch.Tensor:
         assert inputs_embeds is not None
         # masking inputs at position 0, as not needed by MTP
-        inputs_embeds[positions == 0] = 0
+        inputs_embeds = torch.where(positions.unsqueeze(-1) == 0, 0, inputs_embeds)
         inputs_embeds = self.enorm(inputs_embeds)
         previous_hidden_states = self.hnorm(previous_hidden_states)
 


### PR DESCRIPTION
## Purpose
  Fix three Hunyuan3 (Hy3) compatibility issues on Ascend NPU when MTP and/or quantization are enabled:

  1. **Replace boolean mask indexing with `torch.where`**: `inputs_embeds[positions == 0] = 0` triggers unsupported
  `aclnnNonzeroV2` on Ascend. Use `torch.where` instead, consistent with `deepseek_mtp.py`.
  2. **Fix `shared_mlp` weight prefix**: The prefix passed to `HYV3FeedForward` was missing `.shared_mlp` layer, causing quant 
  config key lookup failure (looking for `model.layers.X.mlp.gate_proj.weight` instead of
  `model.layers.X.mlp.shared_mlp.gate_proj.weight`).
  3. **Skip quant metadata in MTP `load_weights`**: `weight_scale`/`weight_offset` entries are consumed by quantized layers    
  during `__init__` and not present in `params_dict`, causing KeyError during weight loading.

