### PR TITLE
[Bugfix][OpenAI] Fix streamed completion logprob offsets with echo

### DIFF
--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -392,7 +392,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
                     else:
                         logprobs = None
 
-                    previous_text_lens[i] += len(output.text)
+                    previous_text_lens[i] += len(delta_text)
                     previous_num_tokens[i] += len(output.token_ids)
                     finish_reason = output.finish_reason
                     stop_reason = output.stop_reason

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -395,7 +395,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
                     else:
                         logprobs = None
 
-                    previous_text_lens[i] += len(output.text)
+                    previous_text_lens[i] += len(delta_text)
                     previous_num_tokens[i] += len(output.token_ids)
                     finish_reason = output.finish_reason
                     stop_reason = output.stop_reason


### PR DESCRIPTION

## Purpose

`/v1/completions` can silently return wrong `logprobs.text_offset` values when `stream=True`, `echo=True`, and `logprobs` are used together.

The first streamed completion chunk may include both the echoed prompt and generated text, but the stream state only advanced by the generated `output.text` length. Later chunks then started their `text_offset` from the generated-only length, so every later offset was shifted left by the prompt length.

This PR advances the offset state by `delta_text`, which is the text actually emitted in the chunk. Non-echo streaming is unchanged because `delta_text == output.text` there.

Why this is not duplicating an existing PR: #44106 covers V2 prompt logprobs, #44938 covers Rust prompt-only completions, #19379/#19380 cover `return_tokens_as_token_ids`, and #19368 is the linked issue for that path. None covers this Python streaming echo offset state.

## Test Plan

```text
python -m ruff check vllm/entrypoints/openai/completion/serving.py
python -m ruff format --check vllm/entrypoints/openai/completion/serving.py
git diff --check
```

Real server E2E was run on `facebook/opt-125m` with the same request after the fix, after reversing only the runtime fix, and after restoring the fix.

<details>
<summary>Server E2E reproduction</summary>

Environment:

```text
base commit: cbe9c40f998f13975b967773ac7e7920e115387f
PR commit: d7645c907c675ecb496d870535cc405d297857a2
reverse run: PR commit with only vllm/entrypoints/openai/completion/serving.py reverted
GPU: RTX 4090
model: facebook/opt-125m revision 27dcfa74d334bc871f3234de431e71c6eeba5dd6
env: HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 VLLM_USE_FLASHINFER_SAMPLER=0
```

Server:

```bash
MODEL=facebook/opt-125m
REVISION=27dcfa74d334bc871f3234de431e71c6eeba5dd6
python -m vllm.entrypoints.openai.api_server \
  --model "$MODEL" \
  --revision "$REVISION" \
  --served-model-name facebook/opt-125m \
  --host 127.0.0.1 \
  --port 8014 \
  --dtype float16 \
  --max-model-len 512 \
  --max-num-seqs 4 \
  --gpu-memory-utilization 0.25 \
  --enforce-eager
```

Client file `/tmp/check_streaming_echo_offsets.py`:

```python
import json
import sys

import requests

port = int(sys.argv[1])
model = sys.argv[2]
resp = requests.post(
    f"http://127.0.0.1:{port}/v1/completions",
    json={
        "model": model,
        "prompt": "Hello",
        "max_tokens": 20,
        "temperature": 0,
        "echo": True,
        "logprobs": 1,
        "stream": True,
    },
    stream=True,
    timeout=60,
)
resp.raise_for_status()

chunks = []
for line in resp.iter_lines(decode_unicode=True):
    if not line or not line.startswith("data: "):
        continue
    data = line[len("data: "):]
    if data == "[DONE]":
        break
    payload = json.loads(data)
    if not payload.get("choices"):
        continue
    choice = payload["choices"][0]
    chunks.append(
        {
            "text": choice["text"],
            "offsets": choice["logprobs"]["text_offset"],
            "tokens": choice["logprobs"]["tokens"],
            "finish_reason": choice["finish_reason"],
        }
    )

cumulative = 0
bad = []
for idx, chunk in enumerate(chunks):
    first = chunk["offsets"][0] if chunk["offsets"] else None
    if idx > 0 and first != cumulative:
        bad.append({"idx": idx, "first_offset": first, "expected": cumulative})
    cumulative += len(chunk["text"])

print("CHUNKS", json.dumps(chunks, ensure_ascii=False))
print("OFFSET_CHECK", "PASS" if not bad else json.dumps(bad, ensure_ascii=False))
if bad:
    print("BUG_REPRODUCED_IN_STREAMING_ECHO_LOGPROB_OFFSETS")
else:
    print("NO_BUG_REPRODUCED")
```

Run:

```bash
python /tmp/check_streaming_echo_offsets.py 8014 facebook/opt-125m
```

After fix:

```text
CHUNKS [{"text": "Hello, I'm a new", "offsets": [0, 4, 9, 10, 12, 14, 16], "tokens": ["</s>", "Hello", ",", " I", "'m", " a", " new"], "finish_reason": null}, {"text": "bie", "offsets": [16], "tokens": ["bie"], "finish_reason": null}, {"text": " to", "offsets": [19], "tokens": [" to"], "finish_reason": null}, {"text": " the", "offsets": [22], "tokens": [" the"], "finish_reason": null}, {"text": " game", "offsets": [26], "tokens": [" game"], "finish_reason": null}, {"text": " and", "offsets": [31], "tokens": [" and"], "finish_reason": null}, {"text": " I", "offsets": [35], "tokens": [" I"], "finish_reason": null}, {"text": "'m", "offsets": [37], "tokens": ["'m"], "finish_reason": null}, {"text": " looking", "offsets": [39], "tokens": [" looking"], "finish_reason": null}, {"text": " for", "offsets": [47], "tokens": [" for"], "finish_reason": null}, {"text": " a", "offsets": [51], "tokens": [" a"], "finish_reason": null}, {"text": " good", "offsets": [53], "tokens": [" good"], "finish_reason": null}, {"text": " way", "offsets": [58], "tokens": [" way"], "finish_reason": null}, {"text": " to", "offsets": [62], "tokens": [" to"], "finish_reason": null}, {"text": " get my", "offsets": [65, 69], "tokens": [" get", " my"], "finish_reason": "length"}]
OFFSET_CHECK PASS
NO_BUG_REPRODUCED
```

After reversing the runtime fix:

```text
CHUNKS [{"text": "Hello, I'm a", "offsets": [0, 4, 9, 10, 12, 14], "tokens": ["</s>", "Hello", ",", " I", "'m", " a"], "finish_reason": null}, {"text": " new", "offsets": [7], "tokens": [" new"], "finish_reason": null}, {"text": "bie", "offsets": [11], "tokens": ["bie"], "finish_reason": null}, {"text": " to", "offsets": [14], "tokens": [" to"], "finish_reason": null}, {"text": " the", "offsets": [17], "tokens": [" the"], "finish_reason": null}, {"text": " game", "offsets": [21], "tokens": [" game"], "finish_reason": null}, {"text": " and", "offsets": [26], "tokens": [" and"], "finish_reason": null}, {"text": " I", "offsets": [30], "tokens": [" I"], "finish_reason": null}, {"text": "'m", "offsets": [32], "tokens": ["'m"], "finish_reason": null}, {"text": " looking", "offsets": [34], "tokens": [" looking"], "finish_reason": null}, {"text": " for", "offsets": [42], "tokens": [" for"], "finish_reason": null}, {"text": " a", "offsets": [46], "tokens": [" a"], "finish_reason": null}, {"text": " good", "offsets": [48], "tokens": [" good"], "finish_reason": null}, {"text": " way", "offsets": [53], "tokens": [" way"], "finish_reason": null}, {"text": " to", "offsets": [57], "tokens": [" to"], "finish_reason": null}, {"text": " get my", "offsets": [60, 64], "tokens": [" get", " my"], "finish_reason": "length"}]
OFFSET_CHECK [{"idx": 1, "first_offset": 7, "expected": 12}, {"idx": 2, "first_offset": 11, "expected": 16}, {"idx": 3, "first_offset": 14, "expected": 19}, {"idx": 4, "first_offset": 17, "expected": 22}, {"idx": 5, "first_offset": 21, "expected": 26}, {"idx": 6, "first_offset": 26, "expected": 31}, {"idx": 7, "first_offset": 30, "expected": 35}, {"idx": 8, "first_offset": 32, "expected": 37}, {"idx": 9, "first_offset": 34, "expected": 39}, {"idx": 10, "first_offset": 42, "expected": 47}, {"idx": 11, "first_offset": 46, "expected": 51}, {"idx": 12, "first_offset": 48, "expected": 53}, {"idx": 13, "first_offset": 53, "expected": 58}, {"idx": 14, "first_offset": 57, "expected": 62}, {"idx": 15, "first_offset": 60, "expected": 65}]
BUG_REPRODUCED_IN_STREAMING_ECHO_LOGPROB_OFFSETS
```

After restoring the fix:

```text
CHUNKS [{"text": "Hello, I'm a new", "offsets": [0, 4, 9, 10, 12, 14, 16], "tokens": ["</s>", "Hello", ",", " I", "'m", " a", " new"], "finish_reason": null}, {"text": "bie", "offsets": [16], "tokens": ["bie"], "finish_reason": null}, {"text": " to", "offsets": [19], "tokens": [" to"], "finish_reason": null}, {"text": " the", "offsets": [22], "tokens": [" the"], "finish_reason": null}, {"text": " game", "offsets": [26], "tokens": [" game"], "finish_reason": null}, {"text": " and", "offsets": [31], "tokens": [" and"], "finish_reason": null}, {"text": " I", "offsets": [35], "tokens": [" I"], "finish_reason": null}, {"text": "'m", "offsets": [37], "tokens": ["'m"], "finish_reason": null}, {"text": " looking", "offsets": [39], "tokens": [" looking"], "finish_reason": null}, {"text": " for", "offsets": [47], "tokens": [" for"], "finish_reason": null}, {"text": " a", "offsets": [51], "tokens": [" a"], "finish_reason": null}, {"text": " good", "offsets": [53], "tokens": [" good"], "finish_reason": null}, {"text": " way", "offsets": [58], "tokens": [" way"], "finish_reason": null}, {"text": " to", "offsets": [62], "tokens": [" to"], "finish_reason": null}, {"text": " get my", "offsets": [65, 69], "tokens": [" get", " my"], "finish_reason": "length"}]
OFFSET_CHECK PASS
NO_BUG_REPRODUCED
```

</details>

## Test Result

```text
server E2E:
after fix: OFFSET_CHECK PASS / NO_BUG_REPRODUCED
reverse runtime fix only: BUG_REPRODUCED_IN_STREAMING_ECHO_LOGPROB_OFFSETS (idx 1 first_offset 7 expected 12)
restored fix: OFFSET_CHECK PASS / NO_BUG_REPRODUCED

ruff check:
All checks passed!

ruff format --check:
1 file already formatted

git diff --check:
PASS
```

AI assistance was used to prepare this PR.

cc @DarkLight1337 @chaunceyjiang
