### PR TITLE
[CPU] Fix NIXL transfer layout detection for CPU attention

### DIFF
--- a/docs/features/nixl_connector_usage.md
+++ b/docs/features/nixl_connector_usage.md
@@ -112,6 +112,16 @@ python tests/v1/kv_connector/nixl_integration/toy_proxy_server.py \
   --decoder-ports 8200
 ```
 
+## CPU backend
+
+For CPU backend P/D, use a NIXL build with CPU/UCX support, set
+`VLLM_CPU_KVCACHE_SPACE`, and include `kv_buffer_device="cpu"` in the
+producer and consumer `--kv-transfer-config` values. Do not set
+`CUDA_VISIBLE_DEVICES` or GPU-only flags such as `--gpu-memory-utilization`.
+
+CPU P/D with `NixlConnector` still uses NIXL transport and
+`kv_transfer_params`; `shared_storage_path` is not a `NixlConnector` option.
+
 ## Environment Variables
 
 - `VLLM_NIXL_SIDE_CHANNEL_PORT`: Port for NIXL handshake communication

--- a/tests/v1/kv_connector/unit/test_transfer_topology_sharded.py
+++ b/tests/v1/kv_connector/unit/test_transfer_topology_sharded.py
@@ -22,6 +22,17 @@ class _FakeAttentionBackend:
         return (2, num_blocks, num_kv_heads, block_size, head_size)
 
 
+class _FakeCPUAttentionBackend:
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+    ) -> tuple[int, int, int, int]:
+        return (num_blocks, num_kv_heads, block_size, 2 * head_size)
+
+
 def _make_topology(
     *,
     tp_rank: int = 1,
@@ -38,6 +49,23 @@ def _make_topology(
         total_num_kv_heads=total_num_kv_heads,
         attn_backends=[_FakeAttentionBackend],
     )
+
+
+def test_cpu_four_dimensional_cache_is_virtually_split_by_block() -> None:
+    topology = TransferTopology(
+        tp_rank=0,
+        tp_size=1,
+        block_size=16,
+        engine_id="local-engine",
+        is_mla=False,
+        is_mamba=False,
+        total_num_kv_heads=8,
+        attn_backends=[_FakeCPUAttentionBackend],
+    )
+
+    assert topology.is_kv_layout_blocks_first
+    assert topology.virtually_split_kv_in_blocks
+    assert not topology.split_k_and_v
 
 
 def test_legacy_register_remote_engine_uses_pp_rank_zero() -> None:

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -426,11 +426,12 @@ class TransferTopology:
                 head_size=1,
             )
             logger.debug("Test kv_cache_shape: %s", kv_cache_shape)
-        # Non-MLA backends caches have 5 dims [num_blocks, 2, H,N,D],
-        # we just mock num_blocks to 1 for the dimension check below.
+        # Non-MLA backends commonly use 5-D [num_blocks, 2, H, N, D].
+        # CPU attention uses 4-D [num_blocks, H, N, 2 * D].
         # Hybrid SSM models assume a single blocks_first layout
         self._is_kv_layout_blocks_first = self.is_mamba or (
-            len(kv_cache_shape) == 5 and kv_cache_shape[0] == 1
+            (len(kv_cache_shape) == 5 and kv_cache_shape[0] == 1)
+            or kv_cache_shape == (1, 1, _MOCK_BLOCK_SIZE, 2)
         )
 
         self._cross_layers_blocks = False


### PR DESCRIPTION


## Purpose

Fix CPU NixlConnector P/D layout detection by treating the CPU attention KV cache shape `[num_blocks, num_kv_heads, block_size, 2 * head_size]` as block-first, without broadening that behavior to every 4-D packed KV layout.

Also adds targeted topology tests and a short CPU backend note in the NIXL usage docs.

## Test Plan

```
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_transfer_topology_sharded.py -q
```
## Test Result
passed

## AI Assistance
AI assistance was used to review, implement, test, and draft this change.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

