### PR TITLE
[bot][XPU] Fix free memory reporting on Max 1550 for Gemma-4-12B QAT inference

### DIFF
--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -91,8 +91,10 @@ def get_mem_info_wrapper(
             f"device must be int, str, torch.device, or None, got {type(device)}"
         )
 
-    # Call the underlying C++ implementation
-    free, total = torch.ops._C_cache_ops.getMemoryInfo(device)
+    # Use torch.xpu.mem_get_info directly (the C++ getMemoryInfo op
+    # incorrectly reports free=0 on Max 1550 due to ext_intel_free_memory
+    # not being properly supported in the driver context).
+    free, total = torch.xpu.mem_get_info(device)
 
     return free, total
 


### PR DESCRIPTION
## Motivation

When running `google/gemma-4-12B-it-qat-w4a16-ct` on Intel Max 1550 GPUs, model loading fails because the memory info query reports `free=0`. This prevents the scheduler from allocating KV cache blocks.

The root cause is that the C++ `getMemoryInfo` op uses the `ext_intel_free_memory` OpenCL extension, which is not properly supported in the Max 1550 driver context and returns 0 for free memory.

## Technical Details

- **Changed file:** `vllm/platforms/xpu.py`
- **Fix:** Replace `torch.ops._C_cache_ops.getMemoryInfo(device)` with `torch.xpu.mem_get_info(device)`
- `torch.xpu.mem_get_info` uses a different code path (Level Zero SysMan API) that correctly reports free and total memory on Max 1550

This does **not** conflict with #41370 (integrated GPU fallback) since that PR adds a try/except around `mem_get_info` for iGPUs where the API itself is unsupported, whereas this fix addresses dGPUs (Max 1550) where the C++ binding returns wrong values but the PyTorch API works correctly.

## Performance Impact

- **Model:** google/gemma-4-12B-it-qat-w4a16-ct (W4A16 quantized)
- **Hardware:** Intel Max 1550 (2× tiles, 128 GB HBM2e)
- **Impact:** Unblocks model loading and inference; no runtime perf change (this is init-time only)

## Testing

Verified on Max 1550:
```python
import torch
# Before fix: torch.ops._C_cache_ops.getMemoryInfo(0) → (0, 137438953472)
# After fix:  torch.xpu.mem_get_info(0) → (131523543040, 137438953472)
```

---

*This PR was generated with AI assistance.*