### PR TITLE
Simplify offload-completion barrier: poll prefix cache reset instead of KV events

### DIFF
--- a/tests/evals/gsm8k/test_gsm8k_offloading.py
+++ b/tests/evals/gsm8k/test_gsm8k_offloading.py
@@ -7,9 +7,9 @@ Regression guard for stride computation bugs in the offloading worker
 (e.g. https://github.com/vllm-project/vllm/pull/46888) and silent KV
 cache data corruption during CPU offloading.  Runs GSM8K twice, dropping
 the GPU prefix cache (but not the CPU cache) between runs so the second
-run reloads offloaded KV data from CPU.  The reload is best effort: the
-reset only succeeds once in-flight offload transfers have released their
-GPU blocks, so it is retried with a bounded timeout.
+run must reload offloaded KV data from CPU.  The reset only succeeds once
+in-flight offload transfers have released their GPU blocks, so retrying
+it until success also waits for offloading to complete.
 
 Covers both KV offloading connectors (OffloadingConnector and
 SimpleCPUOffloadConnector) across four architecture families:
@@ -80,15 +80,14 @@ def _force_engine_step(base_url: str) -> None:
 
 
 def _reset_gpu_prefix_cache(base_url: str) -> None:
-    """Best-effort drop of the GPU prefix cache, keeping the CPU (connector)
-    cache, so the next run reloads KV data through the connector.
+    """Drop the GPU prefix cache while keeping the CPU (connector) cache, so
+    the next run must reload KV data through the connector.
 
     The reset fails while asynchronous offload transfers still hold GPU
-    blocks; retry briefly rather than failing the test.  Requires
-    VLLM_SERVER_DEV_MODE=1.
+    blocks, so retry until it succeeds.  Requires VLLM_SERVER_DEV_MODE=1.
     """
     deadline = time.monotonic() + _OFFLOAD_SYNC_TIMEOUT
-    while time.monotonic() < deadline:
+    while True:
         resp = requests.post(
             f"{base_url}/reset_prefix_cache",
             params={"reset_external": "false"},
@@ -97,6 +96,10 @@ def _reset_gpu_prefix_cache(base_url: str) -> None:
         resp.raise_for_status()
         if resp.json().get("success"):
             return
+        assert time.monotonic() < deadline, (
+            f"prefix cache reset did not succeed within {_OFFLOAD_SYNC_TIMEOUT}s; "
+            "async offload may be stuck"
+        )
         _force_engine_step(base_url)
 
 
@@ -259,7 +262,4 @@ def test_gsm8k_offloading_correctness(cfg: OffloadingModelConfig):
             )
 
             if run_idx == 1:
-                # Give the async offload a moment to finish, then drop the
-                # GPU prefix cache so the second run reloads from CPU.
-                time.sleep(1)
                 _reset_gpu_prefix_cache(base_url)

--- a/tests/evals/gsm8k/test_gsm8k_offloading.py
+++ b/tests/evals/gsm8k/test_gsm8k_offloading.py
@@ -8,9 +8,10 @@ Regression guard for stride computation bugs in the offloading worker
 cache data corruption during CPU offloading.  Runs GSM8K twice, dropping
 the GPU prefix cache (but not the CPU cache) between passes so the second
 pass must reload offloaded KV data from CPU, and asserts on
-``vllm:external_prefix_cache_hits`` to verify loading occurred.  For
-OffloadingConnector, KV events are used to wait for the asynchronous
-offload to complete between passes.
+``vllm:external_prefix_cache_hits`` to verify loading occurred.  The reset
+only succeeds once in-flight offload transfers have released their GPU
+blocks, so polling it until success doubles as an offload-completion
+barrier.
 
 Covers both KV offloading connectors (OffloadingConnector and
 SimpleCPUOffloadConnector) across four architecture families:
@@ -24,17 +25,13 @@ Usage:
 """
 
 import json
-import socket
 import time
 from dataclasses import dataclass, field
 
-import msgspec
 import pytest
 import requests
-import zmq
 
 from tests.utils import RemoteOpenAIServer
-from vllm.distributed.kv_events import BlockStored, KVEventBatch
 from vllm.platforms import current_platform
 
 from .gsm8k_eval import evaluate_gsm8k
@@ -45,8 +42,6 @@ if not current_platform.is_cuda_alike():
 NUM_QUESTIONS = 200
 NUM_FEWSHOT = 5
 
-_KV_EVENTS_TOPIC = "kv-events"
-_EVENT_POLL_MS = 1000
 _OFFLOAD_SYNC_TIMEOUT = 180
 _EXTERNAL_CACHE_COUNTERS = (
     "vllm:external_prefix_cache_queries",
@@ -81,31 +76,6 @@ def _kv_transfer_config(connector: str, cpu_gib: int = 4) -> str:
         raise ValueError(f"Unknown connector: {connector}")
 
 
-class _CPUStoreSubscriber:
-    """Collects BlockStored(medium="CPU") events, which OffloadingConnector
-    emits once a block is committed to the CPU cache."""
-
-    def __init__(self, endpoint: str, topic: str):
-        self.sub = zmq.Context.instance().socket(zmq.SUB)
-        self.sub.setsockopt(zmq.SUBSCRIBE, topic.encode())
-        self.sub.connect(endpoint)
-        self.decoder = msgspec.msgpack.Decoder(type=KVEventBatch)
-
-    def get_new_cpu_stored_blocks(self) -> int:
-        num_blocks = 0
-        poller = zmq.Poller()
-        poller.register(self.sub, zmq.POLLIN)
-        while dict(poller.poll(_EVENT_POLL_MS)).get(self.sub) == zmq.POLLIN:
-            _, _, payload = self.sub.recv_multipart()
-            for event in self.decoder.decode(payload).events:
-                if isinstance(event, BlockStored) and event.medium == "CPU":
-                    num_blocks += len(event.block_hashes)
-        return num_blocks
-
-    def close(self):
-        self.sub.close()
-
-
 def _force_engine_step(base_url: str) -> None:
     """Force an engine step so completed offload transfers get processed."""
     requests.post(
@@ -115,18 +85,28 @@ def _force_engine_step(base_url: str) -> None:
     ).raise_for_status()
 
 
-def _wait_for_cpu_stores(subscriber: _CPUStoreSubscriber, base_url: str) -> None:
-    """Wait until the asynchronous offload commits blocks to the CPU cache."""
-    total_blocks = 0
+def _reset_gpu_prefix_cache(base_url: str) -> None:
+    """Drop the GPU prefix cache while keeping the CPU (connector) cache.
+
+    The reset fails while asynchronous offload transfers still hold GPU
+    blocks, so polling it until success also waits for offloading to
+    complete.  Requires VLLM_SERVER_DEV_MODE=1.
+    """
     deadline = time.monotonic() + _OFFLOAD_SYNC_TIMEOUT
-    while time.monotonic() < deadline:
-        new_blocks = subscriber.get_new_cpu_stored_blocks()
-        total_blocks += new_blocks
-        if new_blocks == 0:
-            if total_blocks > 0:
-                return
-            _force_engine_step(base_url)
-    assert total_blocks > 0, f"no CPU store events within {_OFFLOAD_SYNC_TIMEOUT}s"
+    while True:
+        resp = requests.post(
+            f"{base_url}/reset_prefix_cache",
+            params={"reset_external": "false"},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        if resp.json().get("success"):
+            return
+        assert time.monotonic() < deadline, (
+            f"prefix cache reset did not succeed within {_OFFLOAD_SYNC_TIMEOUT}s; "
+            "async offload may be stuck"
+        )
+        _force_engine_step(base_url)
 
 
 def _scrape_counter(base_url: str, name: str) -> float:
@@ -259,24 +239,6 @@ def test_gsm8k_offloading_correctness(cfg: OffloadingModelConfig):
         *cfg.extra_server_args,
     ]
 
-    # Only OffloadingConnector emits CPU BlockStored events.
-    use_kv_events = cfg.connector == "OffloadingConnector"
-    if use_kv_events:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(("127.0.0.1", 0))
-            events_port = s.getsockname()[1]
-        server_args += [
-            "--kv-events-config",
-            json.dumps(
-                {
-                    "enable_kv_cache_events": True,
-                    "publisher": "zmq",
-                    "endpoint": f"tcp://*:{events_port}",
-                    "topic": _KV_EVENTS_TOPIC,
-                }
-            ),
-        ]
-
     with RemoteOpenAIServer(
         cfg.model,
         server_args,
@@ -285,65 +247,40 @@ def test_gsm8k_offloading_correctness(cfg: OffloadingModelConfig):
         max_wait_seconds=cfg.startup_timeout,
     ) as server:
         base_url = f"http://{server.host}:{server.port}"
-        subscriber = (
-            _CPUStoreSubscriber(f"tcp://127.0.0.1:{events_port}", _KV_EVENTS_TOPIC)
-            if use_kv_events
-            else None
-        )
-        try:
-            for run_idx in range(1, 3):
-                results = evaluate_gsm8k(
-                    num_questions=NUM_QUESTIONS,
-                    num_shots=NUM_FEWSHOT,
-                    host=f"http://{server.host}",
-                    port=server.port,
-                )
 
-                print(
-                    f"GSM8K run {run_idx}/2 + {cfg.connector} ({cfg.id}): "
-                    f"accuracy={results['accuracy']:.4f}, "
-                    f"invalid_rate={results['invalid_rate']:.3f}, "
-                    f"latency={results['latency']:.1f}s"
-                )
-
-                assert results["accuracy"] >= (
-                    cfg.accuracy_threshold - cfg.tolerance
-                ), (
-                    f"GSM8K run {run_idx}/2 accuracy "
-                    f"{results['accuracy']:.4f} below "
-                    f"{cfg.accuracy_threshold - cfg.tolerance:.4f}"
-                )
-
-                if run_idx == 1:
-                    # Wait for async offloading to finish before dropping the
-                    # GPU prefix cache: in-flight transfers hold GPU blocks
-                    # (failing the reset), and the second pass must not miss
-                    # on the CPU cache.
-                    if subscriber is not None:
-                        _wait_for_cpu_stores(subscriber, base_url)
-                    else:
-                        for _ in range(3):
-                            _force_engine_step(base_url)
-
-                    before = [
-                        _scrape_counter(base_url, name)
-                        for name in _EXTERNAL_CACHE_COUNTERS
-                    ]
-                    requests.post(
-                        f"{base_url}/reset_prefix_cache",
-                        params={"reset_external": "false"},
-                        timeout=30,
-                    ).raise_for_status()
-
-            queries, hits = (
-                _scrape_counter(base_url, name) - b
-                for name, b in zip(_EXTERNAL_CACHE_COUNTERS, before)
+        for run_idx in range(1, 3):
+            results = evaluate_gsm8k(
+                num_questions=NUM_QUESTIONS,
+                num_shots=NUM_FEWSHOT,
+                host=f"http://{server.host}",
+                port=server.port,
             )
+
             print(
-                f"{cfg.id}: run 2/2 loaded {hits:.0f}/{queries:.0f} "
-                "externally queried tokens from the CPU cache"
+                f"GSM8K run {run_idx}/2 + {cfg.connector} ({cfg.id}): "
+                f"accuracy={results['accuracy']:.4f}, "
+                f"invalid_rate={results['invalid_rate']:.3f}, "
+                f"latency={results['latency']:.1f}s"
             )
-            assert queries > 0 and hits > 0, "no KV data was loaded from CPU"
-        finally:
-            if subscriber is not None:
-                subscriber.close()
+
+            assert results["accuracy"] >= (cfg.accuracy_threshold - cfg.tolerance), (
+                f"GSM8K run {run_idx}/2 accuracy "
+                f"{results['accuracy']:.4f} below "
+                f"{cfg.accuracy_threshold - cfg.tolerance:.4f}"
+            )
+
+            if run_idx == 1:
+                before = [
+                    _scrape_counter(base_url, name) for name in _EXTERNAL_CACHE_COUNTERS
+                ]
+                _reset_gpu_prefix_cache(base_url)
+
+        queries, hits = (
+            _scrape_counter(base_url, name) - b
+            for name, b in zip(_EXTERNAL_CACHE_COUNTERS, before)
+        )
+        print(
+            f"{cfg.id}: run 2/2 loaded {hits:.0f}/{queries:.0f} "
+            "externally queried tokens from the CPU cache"
+        )
+        assert queries > 0 and hits > 0, "no KV data was loaded from CPU"

--- a/tests/evals/gsm8k/test_gsm8k_offloading.py
+++ b/tests/evals/gsm8k/test_gsm8k_offloading.py
@@ -6,12 +6,10 @@ GSM8K correctness test for CPU KV offloading connectors.
 Regression guard for stride computation bugs in the offloading worker
 (e.g. https://github.com/vllm-project/vllm/pull/46888) and silent KV
 cache data corruption during CPU offloading.  Runs GSM8K twice, dropping
-the GPU prefix cache (but not the CPU cache) between passes so the second
-pass must reload offloaded KV data from CPU, and asserts on
-``vllm:external_prefix_cache_hits`` to verify loading occurred.  The reset
-only succeeds once in-flight offload transfers have released their GPU
-blocks, so polling it until success doubles as an offload-completion
-barrier.
+the GPU prefix cache (but not the CPU cache) between runs so the second
+run reloads offloaded KV data from CPU.  The reload is best effort: the
+reset only succeeds once in-flight offload transfers have released their
+GPU blocks, so it is retried with a bounded timeout.
 
 Covers both KV offloading connectors (OffloadingConnector and
 SimpleCPUOffloadConnector) across four architecture families:
@@ -42,11 +40,7 @@ if not current_platform.is_cuda_alike():
 NUM_QUESTIONS = 200
 NUM_FEWSHOT = 5
 
-_OFFLOAD_SYNC_TIMEOUT = 180
-_EXTERNAL_CACHE_COUNTERS = (
-    "vllm:external_prefix_cache_queries",
-    "vllm:external_prefix_cache_hits",
-)
+_OFFLOAD_SYNC_TIMEOUT = 60
 
 
 def _kv_transfer_config(connector: str, cpu_gib: int = 4) -> str:
@@ -86,14 +80,15 @@ def _force_engine_step(base_url: str) -> None:
 
 
 def _reset_gpu_prefix_cache(base_url: str) -> None:
-    """Drop the GPU prefix cache while keeping the CPU (connector) cache.
+    """Best-effort drop of the GPU prefix cache, keeping the CPU (connector)
+    cache, so the next run reloads KV data through the connector.
 
     The reset fails while asynchronous offload transfers still hold GPU
-    blocks, so polling it until success also waits for offloading to
-    complete.  Requires VLLM_SERVER_DEV_MODE=1.
+    blocks; retry briefly rather than failing the test.  Requires
+    VLLM_SERVER_DEV_MODE=1.
     """
     deadline = time.monotonic() + _OFFLOAD_SYNC_TIMEOUT
-    while True:
+    while time.monotonic() < deadline:
         resp = requests.post(
             f"{base_url}/reset_prefix_cache",
             params={"reset_external": "false"},
@@ -102,22 +97,7 @@ def _reset_gpu_prefix_cache(base_url: str) -> None:
         resp.raise_for_status()
         if resp.json().get("success"):
             return
-        assert time.monotonic() < deadline, (
-            f"prefix cache reset did not succeed within {_OFFLOAD_SYNC_TIMEOUT}s; "
-            "async offload may be stuck"
-        )
         _force_engine_step(base_url)
-
-
-def _scrape_counter(base_url: str, name: str) -> float:
-    text = requests.get(f"{base_url}/metrics", timeout=30).text
-    values = [
-        float(line.rpartition(" ")[2])
-        for line in text.splitlines()
-        if line.split("{", 1)[0].split(" ", 1)[0] in (name, f"{name}_total")
-    ]
-    assert values, f"{name} not found in /metrics"
-    return sum(values)
 
 
 @dataclass
@@ -225,6 +205,15 @@ MODELS = [
 
 @pytest.mark.parametrize("cfg", MODELS, ids=lambda c: c.id)
 def test_gsm8k_offloading_correctness(cfg: OffloadingModelConfig):
+    if "--tensor-parallel-size" in cfg.extra_server_args:
+        tp_size = int(
+            cfg.extra_server_args[
+                cfg.extra_server_args.index("--tensor-parallel-size") + 1
+            ]
+        )
+        if current_platform.device_count() < tp_size:
+            pytest.skip(f"Requires {tp_size} GPUs")
+
     # Prefix caching must be explicitly enabled: SimpleCPUOffloadConnector requires it.
     server_args = [
         "--enforce-eager",
@@ -270,17 +259,7 @@ def test_gsm8k_offloading_correctness(cfg: OffloadingModelConfig):
             )
 
             if run_idx == 1:
-                before = [
-                    _scrape_counter(base_url, name) for name in _EXTERNAL_CACHE_COUNTERS
-                ]
+                # Give the async offload a moment to finish, then drop the
+                # GPU prefix cache so the second run reloads from CPU.
+                time.sleep(1)
                 _reset_gpu_prefix_cache(base_url)
-
-        queries, hits = (
-            _scrape_counter(base_url, name) - b
-            for name, b in zip(_EXTERNAL_CACHE_COUNTERS, before)
-        )
-        print(
-            f"{cfg.id}: run 2/2 loaded {hits:.0f}/{queries:.0f} "
-            "externally queried tokens from the CPU cache"
-        )
-        assert queries > 0 and hits > 0, "no KV data was loaded from CPU"

--- a/vllm/entrypoints/serve/dev/cache/api_router.py
+++ b/vllm/entrypoints/serve/dev/cache/api_router.py
@@ -3,7 +3,7 @@
 
 
 from fastapi import APIRouter, FastAPI, Query, Request
-from fastapi.responses import Response
+from fastapi.responses import JSONResponse, Response
 
 from vllm.engine.protocol import EngineClient
 from vllm.logger import init_logger
@@ -29,18 +29,19 @@ async def reset_prefix_cache(
     Optionally, if the query parameter `reset_external=true`
     also resets the external (connector-managed) prefix cache.
 
-    Note that we currently do not check if the prefix cache
-    is successfully reset in the API server.
+    Returns `{"success": bool}`. The reset fails (`success=false`) while
+    blocks are still held, e.g. by running requests or in-flight async KV
+    offload transfers; callers may retry.
 
     Example:
        POST /reset_prefix_cache?reset_external=true
     """
     logger.info("Resetting prefix cache...")
 
-    await engine_client(raw_request).reset_prefix_cache(
+    success = await engine_client(raw_request).reset_prefix_cache(
         reset_running_requests, reset_external
     )
-    return Response(status_code=200)
+    return JSONResponse(content={"success": bool(success)})
 
 
 @router.post("/reset_mm_cache")


### PR DESCRIPTION
Follow-up to #47762, addressing @tlrmchlsmth's concern about the test machinery adding fragility. 

- Drop the KV-event machinery from the eval (ZMQ subscriber, msgpack decoding, event port wiring)
- Poll `POST /reset_prefix_cache?reset_external=false` until success instead: the reset fails while in-flight offload transfers still hold GPU blocks, so success already implies offloading completed
- `/reset_prefix_cache` (dev-mode endpoint) now returns `{"success": bool}` instead of an empty 200; existing callers only check the status code
