### PR TITLE
[Bugfix] preserve split_sizes attribute in LoRA wrapper for QKVParallelLinear

### DIFF
--- a/tests/lora/test_transformers_model.py
+++ b/tests/lora/test_transformers_model.py
@@ -55,6 +55,7 @@ def test_ilama_lora(ilama_lora_files):
         max_lora_rank=16,
         trust_remote_code=True,
         enable_chunked_prefill=True,
+        enforce_eager=True,
     )
 
     output1 = do_sample(llm, ilama_lora_files, lora_id=1)

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -449,6 +449,12 @@ class MergedQKVParallelLinearWithLoRA(MergedColumnParallelLinearWithLoRA):
         super().__init__(base_layer)
         # There are three LoRA layer.
         self.n_slices = len(self.base_layer.output_sizes)
+        # The transformers-model QKV fuser sets `split_sizes` on the base
+        # QKVParallelLinear and its rewritten forward reads it from the
+        # submodule attribute. Preserve it on the wrapper so
+        # `self.qkv_proj.split_sizes` continues to resolve after LoRA wrapping.
+        if hasattr(base_layer, "split_sizes"):
+            self.split_sizes = base_layer.split_sizes
 
         self.q_proj_shard_size = self.base_layer.num_heads * self.base_layer.head_size
         self.kv_proj_shard_size = (


### PR DESCRIPTION
## Purpose

## Test Plan

pytest -sv tests/lora/test_transformers_model.py 
## Test Result
Main: 

```
(EngineCore pid=901784)     return super().__call__(*args, **kwargs)
(EngineCore pid=901784)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=901784)   File "/root/miniforge3/envs/chaojun-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1779, in _wrapped_call_impl
(EngineCore pid=901784)     return self._call_impl(*args, **kwargs)
(EngineCore pid=901784)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=901784)   File "/root/miniforge3/envs/chaojun-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1790, in _call_impl
(EngineCore pid=901784)     return forward_call(*args, **kwargs)
(EngineCore pid=901784)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=901784)   File "/root/miniforge3/envs/chaojun-vllm/lib/python3.12/site-packages/transformers/models/llama/modeling_llama.py", line 316, in forward
(EngineCore pid=901784)     hidden_states, _ = self.self_attn(
(EngineCore pid=901784)                        ^^^^^^^^^^^^^^^
(EngineCore pid=901784)   File "/root/miniforge3/envs/chaojun-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1779, in _wrapped_call_impl
(EngineCore pid=901784)     return self._call_impl(*args, **kwargs)
(EngineCore pid=901784)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=901784)   File "/root/miniforge3/envs/chaojun-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1790, in _call_impl
(EngineCore pid=901784)     return forward_call(*args, **kwargs)
(EngineCore pid=901784)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=901784)   File "/root/miniforge3/envs/chaojun-vllm/lib/python3.12/site-packages/transformers/models/llama/modeling_llama.py", line 251, in forward
(EngineCore pid=901784)     def forward(
(EngineCore pid=901784)                  
(EngineCore pid=901784)   File "/root/miniforge3/envs/chaojun-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1968, in __getattr__
(EngineCore pid=901784)     raise AttributeError(
(EngineCore pid=901784) AttributeError: 'MergedQKVParallelLinearWithLoRA' object has no attribute 'split_sizes' 
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
