### PR TITLE
[Bugfix][Responses] Respect json_object text format

### DIFF
--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -375,7 +375,7 @@ class ResponsesRequest(OpenAIBaseModel):
         # Structured output
         structured_outputs = self.structured_outputs
 
-        # Also check text.format for OpenAI-style json_schema
+        # Also check text.format for OpenAI-style structured outputs
         if self.text is not None and self.text.format is not None:
             if structured_outputs is not None:
                 raise VLLMValidationError(
@@ -392,6 +392,8 @@ class ResponsesRequest(OpenAIBaseModel):
                     # --follow-imports skip hides the class definition but also hides
                     # multiple third party conflicts, so best of both evils
                 )
+            elif response_format.type == "json_object":
+                structured_outputs = StructuredOutputsParams(json_object=True)
 
         stop = self.stop if self.stop else []
         if isinstance(stop, str):


### PR DESCRIPTION

## Purpose

`/v1/responses` accepts `text.format={"type":"json_object"}` and echoes the format back in the response, but the request is not converted into `SamplingParams.structured_outputs`. The sampler can therefore return ordinary text under an explicit JSON object constraint.

This maps `text.format.type == "json_object"` to `StructuredOutputsParams(json_object=True)`, matching the existing native `structured_outputs={"json_object": true}` path.

## Test Plan

- Run a true `/v1/responses` server repro with `Qwen/Qwen3-0.6B`, `logit_bias={"13": 100}`, and `max_output_tokens=1`; compare plain, `text.format=json_object`, and native `structured_outputs.json_object`.
- Run ruff check and ruff format check on the changed file.

## Test Result

The server repro uses an RTX 4090 and `Qwen/Qwen3-0.6B`. The biased token id `13` is `"."`.

Before this patch, the plain request and `text.format=json_object` both returned `"."`; native `structured_outputs.json_object` returned `"{\""`.

After this patch, the plain request still returned `"."`; `text.format=json_object` and native `structured_outputs.json_object` both returned `"{\""`. Reverting the patch made `text.format=json_object` return `"."` again.

<details><summary>repro (server command, client script, and outputs)</summary>

Server:

```bash
vllm serve Qwen/Qwen3-0.6B \
  --served-model-name qwen \
  --host 127.0.0.1 \
  --port 8000 \
  --max-model-len 2048 \
  --gpu-memory-utilization 0.35 \
  --enforce-eager \
  --no-enable-log-requests
```

Client:

```python
import httpx

base = "http://127.0.0.1:8000/v1"


def output_text(data):
    text = []
    for item in data.get("output") or []:
        for part in item.get("content") or []:
            if part.get("type") in {"output_text", "text"}:
                text.append(part.get("text") or "")
    return "".join(text)


cases = [
    ("plain", {}),
    ("text_format_json_object", {"text": {"format": {"type": "json_object"}}}),
    ("native_structured_json_object", {"structured_outputs": {"json_object": True}}),
]

for name, extra in cases:
    body = {
        "model": "qwen",
        "input": "Return exactly a single period.",
        "max_output_tokens": 1,
        "temperature": 0,
        "logit_bias": {"13": 100},
        **extra,
    }
    response = httpx.post(base + "/responses", json=body, timeout=60)
    data = response.json()
    print(f"{name}: status={response.status_code} text={output_text(data)!r}")
```

Before:

```text
plain: status=200 text='.'
text_format_json_object: status=200 text='.'
native_structured_json_object: status=200 text='{"'
```

After:

```text
plain: status=200 text='.'
text_format_json_object: status=200 text='{"'
native_structured_json_object: status=200 text='{"'
```

Reverse patch:

```text
plain: status=200 text='.'
text_format_json_object: status=200 text='.'
native_structured_json_object: status=200 text='{"'
```

Restore patch:

```text
plain: status=200 text='.'
text_format_json_object: status=200 text='{"'
native_structured_json_object: status=200 text='{"'
```

</details>

```text
ruff check vllm/entrypoints/openai/responses/protocol.py
All checks passed!
```

```text
ruff format --check vllm/entrypoints/openai/responses/protocol.py
1 file already formatted
```

AI assistance was used to prepare this PR.

cc @chaunceyjiang
