### PR TITLE
[Bugfix][Spec Decode] Always share target embeddings for MTP drafts (#47794)

### DIFF
--- a/tests/v1/spec_decode/test_maybe_share_embeddings.py
+++ b/tests/v1/spec_decode/test_maybe_share_embeddings.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for ``SpecDecodeBaseProposer._maybe_share_embeddings``.
+
+These exercise the embedding-sharing decision in isolation (no real model
+load) by driving the method with light-weight fake modules.
+
+Regression coverage for the interaction between two behaviors:
+
+* PR #43957 added an embedding-*width* guard so that EAGLE draft models that
+  ship their own differently-sized ``embed_tokens`` keep it instead of
+  (incorrectly) sharing the target's.
+* Issue #47794: that guard must NOT apply to MTP draft models, whose
+  projection is built for the *target* embedding width and therefore must
+  always share the target embedding regardless of the draft checkpoint's own
+  ``embed_tokens`` width (e.g. Gemma4 MTP: draft 1024 vs target 2816).
+"""
+
+import types
+
+import torch
+import torch.nn as nn
+
+from vllm.v1.spec_decode import llm_base_proposer
+from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
+
+VOCAB = 8
+
+
+class _Embed(nn.Module):
+    def __init__(self, width: int):
+        super().__init__()
+        # weight shape is (vocab, hidden); the method compares shape[-1].
+        self.weight = nn.Parameter(torch.zeros(VOCAB, width))
+
+
+class _Inner(nn.Module):
+    def __init__(self, width: int):
+        super().__init__()
+        self.embed_tokens = _Embed(width)
+
+
+class _Model(nn.Module):
+    """A stand-in language model exposing ``.model.embed_tokens``."""
+
+    def __init__(self, width: int, has_own_embed_tokens: bool | None = None):
+        super().__init__()
+        self.model = _Inner(width)
+        # Only EAGLE drafts define this attribute; MTP drafts must not.
+        if has_own_embed_tokens is not None:
+            self.has_own_embed_tokens = has_own_embed_tokens
+
+
+def _call(monkeypatch, draft: _Model, target: _Model) -> None:
+    monkeypatch.setattr(
+        llm_base_proposer,
+        "get_pp_group",
+        lambda: types.SimpleNamespace(world_size=1),
+    )
+    fake_self = types.SimpleNamespace(model=draft)
+    SpecDecodeBaseProposer._maybe_share_embeddings(fake_self, target)
+
+
+def test_mtp_shares_even_with_different_embed_width(monkeypatch):
+    # Regression test for #47794: an MTP draft (no ``has_own_embed_tokens``)
+    # with a narrower embedding than the target must still share the target's
+    # embedding, otherwise the concat width is wrong and init crashes.
+    target = _Model(width=2816)
+    draft = _Model(width=1024)  # MTP: no has_own_embed_tokens attribute
+
+    _call(monkeypatch, draft, target)
+
+    assert draft.model.embed_tokens is target.model.embed_tokens
+
+
+def test_eagle_keeps_separate_embed_when_width_differs(monkeypatch):
+    # Preserves PR #43957: an EAGLE draft without its own checkpoint embedding
+    # but a different embedding width must NOT share the target's embedding.
+    target = _Model(width=2816)
+    draft = _Model(width=1024, has_own_embed_tokens=False)
+    own_embed = draft.model.embed_tokens
+
+    _call(monkeypatch, draft, target)
+
+    assert draft.model.embed_tokens is own_embed
+    assert draft.model.embed_tokens is not target.model.embed_tokens
+
+
+def test_eagle_shares_when_width_matches(monkeypatch):
+    # Sanity: EAGLE draft with matching width shares the target embedding.
+    target = _Model(width=2816)
+    draft = _Model(width=2816, has_own_embed_tokens=False)
+
+    _call(monkeypatch, draft, target)
+
+    assert draft.model.embed_tokens is target.model.embed_tokens

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1430,7 +1430,8 @@ class SpecDecodeBaseProposer:
                 )
 
             share_embeddings = False
-            if hasattr(self.model, "has_own_embed_tokens"):
+            is_eagle_model = hasattr(self.model, "has_own_embed_tokens")
+            if is_eagle_model:
                 # EAGLE model
                 if not self.model.has_own_embed_tokens:
                     share_embeddings = True
@@ -1468,9 +1469,15 @@ class SpecDecodeBaseProposer:
                     "Sharing target model embedding weights with the draft model."
                 )
 
-            if share_embeddings:
+            if share_embeddings and is_eagle_model:
+                # EAGLE draft models may ship their own embedding of a
+                # different width than the target (e.g. Eagle3MiniMaxM2), in
+                # which case the two must stay separate (see PR #43957).
+                # MTP draft models are excluded: their projection is built for
+                # the *target* embedding width, so they must always share the
+                # target embedding regardless of the draft checkpoint's own
+                # embed_tokens width (see issue #47794 — Gemma4 MTP).
                 draft_embed = self.model.model.embed_tokens
-                # Only share when both models use the same embedding width.
                 # Guard with isinstance so non-Tensor weights (e.g. in tests)
                 # are not affected — mirrors the weight-equality check above.
                 if isinstance(target_embed_tokens.weight, torch.Tensor) and isinstance(


### PR DESCRIPTION
## Purpose
Fixes #47794. Gemma4 MTP fails during engine initialization with a linear
dimension mismatch (concat width 3840 vs expected 5632).

## Root cause
PR #43957 added an embedding-width guard in `_maybe_share_embeddings` so that
EAGLE drafts (e.g. `Eagle3MiniMaxM2`) which ship their own differently-sized
`embed_tokens` keep them instead of sharing the target's. That guard sits in the
shared code path, so it also applied to MTP drafts.

MTP draft projections are built for the *target* embedding width and must always
share the target embedding regardless of the draft checkpoint's own
`embed_tokens` width. For Gemma4 MTP (draft embed 1024, target 2816) the guard
kept the 1024-wide draft embedding, producing a concat width of
`1024 + 2816 = 3840` instead of `2816 + 2816 = 5632`, and crashing during init.

## Change
Restrict the embedding-width guard to EAGLE models (identified by the
`has_own_embed_tokens` attribute). MTP drafts always share the target embedding;
the EAGLE behavior introduced in #43957 is preserved.

## Test
Adds `tests/v1/spec_decode/test_maybe_share_embeddings.py`:
- MTP + differing embedding width → shares target embedding (regression for #47794)
- EAGLE + differing embedding width → stays separate (preserves #43957)
- EAGLE + matching embedding width → shares

Note: the fix and tests were validated by code analysis and a standalone logic
simulation; I did not have access to a Gemma4 MTP GPU checkpoint to run the
end-to-end reproduction locally.
