### PR TITLE
[Rust Frontend] Make HTTP request body limit configurable via VLLM_HTTP_MAX_JSON_BODY_SIZE

### DIFF
--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -42,12 +42,22 @@ fn runtime_lora_updating_enabled() -> bool {
         .is_some_and(|value| matches!(value.trim().to_lowercase().as_str(), "1" | "true"))
 }
 
+/// Maximum HTTP request body size (bytes) accepted by the API server,
+/// overridable via `VLLM_HTTP_MAX_JSON_BODY_SIZE`.
+fn json_body_limit_bytes() -> usize {
+    std::env::var("VLLM_HTTP_MAX_JSON_BODY_SIZE")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_JSON_BODY_LIMIT_BYTES)
+}
+
 /// Build the minimal OpenAI-compatible router for one configured model.
 pub fn build_router(state: Arc<AppState>) -> Router {
     build_router_with_options(
         state,
         server_dev_mode_enabled(),
         runtime_lora_updating_enabled(),
+        json_body_limit_bytes(),
     )
 }
 
@@ -62,13 +72,24 @@ fn build_router_with_dev_mode_and_lora(
     dev_mode_enabled: bool,
     runtime_lora_updating_enabled: bool,
 ) -> Router {
-    build_router_with_options(state, dev_mode_enabled, runtime_lora_updating_enabled)
+    build_router_with_options(
+        state,
+        dev_mode_enabled,
+        runtime_lora_updating_enabled,
+        DEFAULT_JSON_BODY_LIMIT_BYTES,
+    )
+}
+
+#[cfg(test)]
+fn build_router_with_json_body_limit(state: Arc<AppState>, json_body_limit_bytes: usize) -> Router {
+    build_router_with_options(state, false, false, json_body_limit_bytes)
 }
 
 fn build_router_with_options(
     state: Arc<AppState>,
     dev_mode_enabled: bool,
     runtime_lora_updating_enabled: bool,
+    json_body_limit_bytes: usize,
 ) -> Router {
     let mut router = Router::new()
         // Health & monitoring
@@ -124,7 +145,7 @@ fn build_router_with_options(
     let enable_api_key_auth = state.has_api_keys();
     let mut router = router
         .with_state(state.clone())
-        .layer(DefaultBodyLimit::max(DEFAULT_JSON_BODY_LIMIT_BYTES))
+        .layer(DefaultBodyLimit::max(json_body_limit_bytes))
         .layer(middleware::request_runtime_layer(state.clone()))
         .layer(from_fn_with_state(
             state.clone(),

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -48,7 +48,10 @@ use vllm_tokenizer::test_utils::TestTokenizer;
 use zeromq::prelude::{SocketRecv, SocketSend};
 use zeromq::{DealerSocket, PushSocket, ZmqMessage};
 
-use super::{build_router, build_router_with_dev_mode, build_router_with_dev_mode_and_lora};
+use super::{
+    build_router, build_router_with_dev_mode, build_router_with_dev_mode_and_lora,
+    build_router_with_json_body_limit,
+};
 use crate::config::{ApiServerOptions, CorsConfig};
 use crate::state::AppState;
 
@@ -3409,6 +3412,49 @@ async fn chat_completions_accepts_request_body_larger_than_axum_default() {
     let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
     assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
     engine_task.await.expect("mock engine task");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn chat_completions_reject_request_body_above_configured_limit() {
+    let (chat, _engine_task) = test_chat_with_engine_outputs(
+        b"engine-openai-chat-body-limit",
+        default_stream_output_specs(),
+    )
+    .await;
+    let mut app = build_router_with_json_body_limit(
+        Arc::new(AppState::new(
+            vec!["Qwen/Qwen1.5-0.5B-Chat".to_string()],
+            chat,
+        )),
+        1024,
+    );
+
+    let large_template_arg = "a".repeat(2 * 1024);
+    let response = app
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "model": "Qwen/Qwen1.5-0.5B-Chat",
+                        "stream": false,
+                        "messages": [{"role": "user", "content": "hello"}],
+                        "chat_template_kwargs": {"large": large_template_arg}
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    let body = String::from_utf8_lossy(&body);
+    assert!(body.contains("length limit exceeded"), "{body}");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -100,6 +100,7 @@ if TYPE_CHECKING:
     VERBOSE: bool = False
     VLLM_ALLOW_LONG_MAX_MODEL_LEN: bool = False
     VLLM_HTTP_TIMEOUT_KEEP_ALIVE: int = 5  # seconds
+    VLLM_HTTP_MAX_JSON_BODY_SIZE: int = 32 * 1024 * 1024  # bytes
     VLLM_MAX_N_SEQUENCES: int = 16384
     VLLM_PLUGINS: list[str] | None = None
     VLLM_LORA_RESOLVER_CACHE_DIR: str | None = None
@@ -1051,6 +1052,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Timeout in seconds for keeping HTTP connections alive in API server
     "VLLM_HTTP_TIMEOUT_KEEP_ALIVE": lambda: int(
         os.environ.get("VLLM_HTTP_TIMEOUT_KEEP_ALIVE", "5")
+    ),
+    # Maximum HTTP request body size in bytes accepted by the API server.
+    # Only enforced by the Rust frontend; the Python frontend has no limit.
+    "VLLM_HTTP_MAX_JSON_BODY_SIZE": lambda: int(
+        os.environ.get("VLLM_HTTP_MAX_JSON_BODY_SIZE", str(32 * 1024 * 1024))
     ),
     # Maximum allowed value for the `n` sampling parameter (number of output
     # sequences per request). Limits resource consumption to prevent
@@ -2082,6 +2088,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR",
         "VLLM_ENGINE_ITERATION_TIMEOUT_S",
         "VLLM_HTTP_TIMEOUT_KEEP_ALIVE",
+        "VLLM_HTTP_MAX_JSON_BODY_SIZE",
         "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS",
         "VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS",
         "VLLM_KEEP_ALIVE_ON_ENGINE_DEATH",


### PR DESCRIPTION
## Purpose

The Rust frontend caps HTTP request bodies at a fixed 32 MiB, introduced in #46582. The Python frontend (uvicorn) has no body-size limit, so long-context or batched requests that work fine against the Python server fail with a terminal client error on the Rust one (the length-limit rejection surfaces as a non-retryable 400). Anyone running long-prompt workloads or benchmark harnesses against the Rust frontend hits this divergence.

This PR keeps the 32 MiB default chosen in #46582 (which presumably has DoS resistance in mind) but makes the limit overridable via a `VLLM_HTTP_MAX_JSON_BODY_SIZE` environment variable (bytes). An env var was chosen over a CLI flag because it needs no plumbing through `SharedRuntimeArgs`/`--args-json` or the Python supervisor: the Rust process inherits the environment in both the Python-bootstrapped (`vllm serve`) and managed (`vllm-rs serve`) paths, mirroring how `VLLM_SERVER_DEV_MODE` is already handled in `routes.rs`. The env var is registered in `envs.py` for documentation and added to `compile_factors()`'s ignored factors, like `VLLM_HTTP_TIMEOUT_KEEP_ALIVE`.

## Duplicate-work check

No open PR or issue proposes making this limit configurable or raising it. Searched `gh pr list`/`gh issue list` on vllm-project/vllm for "json body limit", "body size rust", and related keywords; the only prior work is #46582 itself, which introduced the cap this PR parameterizes.

## Test Plan

- New test `chat_completions_reject_request_body_above_configured_limit`: a router built with a 1 KiB limit rejects a larger request with 400 and a length-limit error message.
- Existing test `chat_completions_accepts_request_body_larger_than_axum_default` (from #46582) still passes, confirming the default is unchanged.

```
cargo test -p vllm-server --lib
cargo clippy -p vllm-server --all-targets
cargo fmt -p vllm-server --check
```

## Test Result

All 304 `vllm-server` unit tests pass; clippy and rustfmt clean; pre-commit hooks (ruff, mypy, etc.) pass on the `envs.py` change.

## AI assistance disclosure

This PR was developed with AI assistance (Claude Code). I have reviewed every changed line and run the tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVqpq3ZQAvKLX7sJVvy6r1