### PR TITLE
[Bugfix] Reject whitespace-only bad_words in SamplingParams

### DIFF
--- a/tests/test_sampling_params.py
+++ b/tests/test_sampling_params.py
@@ -48,3 +48,19 @@ def test_diffusion_accepts_top_k_top_p():
 def test_non_diffusion_models_unaffected():
     params = SamplingParams(temperature=0.7, top_k=10, seed=42)
     params.verify(MockModelConfig(), None, None, None)
+
+
+def test_bad_words_accepts_valid_words():
+    SamplingParams(bad_words=["foo", " bar", "baz "])
+
+
+@pytest.mark.parametrize("bad_word", ["", " ", "  ", "\t", "\n", " \n\t "])
+def test_bad_words_rejects_empty_or_whitespace_only(bad_word: str):
+    # A whitespace-only bad word is reduced to "" by lstrip() in
+    # update_from_tokenizer, which then tokenizes to [] and raises an
+    # IndexError during request setup. Reject it up front instead.
+    with pytest.raises(ValueError, match="bad_words cannot contain"):
+        SamplingParams(bad_words=[bad_word])
+
+    with pytest.raises(ValueError, match="bad_words cannot contain"):
+        SamplingParams(bad_words=["valid", bad_word])

--- a/tests/test_sampling_params.py
+++ b/tests/test_sampling_params.py
@@ -49,3 +49,19 @@ def test_diffusion_accepts_top_k_top_p():
 def test_non_diffusion_models_unaffected():
     params = SamplingParams(temperature=0.7, top_k=10, seed=42)
     params.verify(MockModelConfig(), None, None, None)
+
+
+def test_bad_words_accepts_valid_words():
+    SamplingParams(bad_words=["foo", " bar", "baz "])
+
+
+@pytest.mark.parametrize("bad_word", ["", " ", "  ", "\t", "\n", " \n\t "])
+def test_bad_words_rejects_empty_or_whitespace_only(bad_word: str):
+    # A whitespace-only bad word is reduced to "" by lstrip() in
+    # update_from_tokenizer, which then tokenizes to [] and raises an
+    # IndexError during request setup. Reject it up front instead.
+    with pytest.raises(ValueError, match="bad_words cannot contain"):
+        SamplingParams(bad_words=[bad_word])
+
+    with pytest.raises(ValueError, match="bad_words cannot contain"):
+        SamplingParams(bad_words=["valid", bad_word])

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -614,9 +614,9 @@ class SamplingParams(
                 "Set detokenize=True to use stop."
             )
         assert isinstance(self.bad_words, list)
-        if any(not bad_word for bad_word in self.bad_words):
+        if any(not bad_word.strip() for bad_word in self.bad_words):
             raise ValueError(
-                f"bad_words cannot contain an empty string. "
+                f"bad_words cannot contain an empty or whitespace-only string. "
                 f"Got bad_words={self.bad_words}"
             )
 

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -639,9 +639,9 @@ class SamplingParams(
                 "Set detokenize=True to use stop."
             )
         assert isinstance(self.bad_words, list)
-        if any(not bad_word for bad_word in self.bad_words):
+        if any(not bad_word.strip() for bad_word in self.bad_words):
             raise VLLMValidationError(
-                f"bad_words cannot contain an empty string. "
+                f"bad_words cannot contain an empty or whitespace-only string. "
                 f"Got bad_words={self.bad_words}"
             )
 


### PR DESCRIPTION

## Purpose

A whitespace-only `bad_words` entry (for example `bad_words=[" "]`, `"\t"`, or
`"\n"`) passes `SamplingParams` validation and then crashes request setup with an
uncaught `IndexError`, which the server surfaces to the client as HTTP 500 rather
than a 400.

Root cause: `SamplingParams._verify_args` only rejects *empty* strings
(`if any(not bad_word ...)`), so a truthy whitespace-only word passes. Later,
`SamplingParams.update_from_tokenizer` builds each bad word with
`prompt = prefix + bad_word.lstrip()`. For a whitespace-only word the no-prefix
iteration yields `prompt == ""`, which tokenizes to `[]` for essentially every HF
tokenizer and gets appended to `self._bad_words_token_ids`. The following
`add_prefix_space` iteration then indexes that empty list at
`self._bad_words_token_ids[-1][0]`, raising `IndexError: list index out of range`.
The central error handler (`vllm/entrypoints/serve/utils/error_response.py`) maps
`ValueError`/`TypeError`/`OverflowError`/`VLLMValidationError` to 400 but not
`IndexError`, so the request falls through to a 500.

This tightens the existing check to reject a bad word that is empty *after*
stripping, mirroring the empty-string rejection. The malformed input becomes a
clean client-side `ValueError` (400) at construction time instead of a later
uncaught `IndexError` (500). Valid words with leading/trailing spaces (for example
`" bar"`, `"baz "`) are unaffected, because only fully-whitespace words strip to
`""`.

No linked issue: this is a correctness bug I did not find an existing issue for. I
searched open issues (`bad_words whitespace`, `bad_words IndexError`) and found
none.

## Test Plan

New GPU-free regression test `tests/test_sampling_params.py`:

- `test_bad_words_accepts_valid_words` asserts valid words including
  leading/trailing-space words still construct.
- `test_bad_words_rejects_empty_or_whitespace_only` is parametrized over
  `["", " ", "  ", "\t", "\n", " \n\t "]` and asserts each raises `ValueError` at
  `SamplingParams` construction, both on its own and mixed with a valid word.

```bash
uv venv --python 3.12 && source .venv/bin/activate
uv pip install vllm                    # released wheel, for Python-layer deps only
uv pip install pytest transformers
.venv/bin/python -m pytest tests/test_sampling_params.py -v
```

The test is red before the one-line source change and green after (I reverted the
source line locally to confirm the 5 whitespace cases fail with "DID NOT RAISE",
while the empty-string and valid-word cases still pass, then restored it). I also
reproduced the original `IndexError` directly with a real gpt2 tokenizer:
`encode("", add_special_tokens=False) == []`, and running the exact
`update_from_tokenizer` loop on `bad_word=" "` raises
`IndexError: list index out of range`.

## Test Result

```
tests/test_sampling_params.py::test_bad_words_accepts_valid_words PASSED
tests/test_sampling_params.py::test_bad_words_rejects_empty_or_whitespace_only[] PASSED
tests/test_sampling_params.py::test_bad_words_rejects_empty_or_whitespace_only[ ] PASSED
tests/test_sampling_params.py::test_bad_words_rejects_empty_or_whitespace_only[  ] PASSED
tests/test_sampling_params.py::test_bad_words_rejects_empty_or_whitespace_only[\t] PASSED
tests/test_sampling_params.py::test_bad_words_rejects_empty_or_whitespace_only[\n] PASSED
tests/test_sampling_params.py::test_bad_words_rejects_empty_or_whitespace_only[ \n\t ] PASSED
======================== 7 passed ========================
```

Lint (pinned `ruff` 0.14.0, matching the repo's pre-commit pin):

```
ruff check vllm/sampling_params.py tests/test_sampling_params.py   -> All checks passed!
ruff format --check <same files>                                   -> 2 files already formatted
```

## AI assistance disclosure (per AGENTS.md)

- AI assistance was used to help write this change; I reviewed every changed line
  and ran the tests and linters above myself.
- Not a duplicate: I checked the open `bad_words` PRs (#37676, #32601 fix
  space-prefixed token conversion in `update_from_tokenizer`; #45522 caches
  `bad_words` tokenization for concurrency; #46793 adds `bad_words` to
  `/v1/completions`) and the open `_verify_args` PRs (#44799 replaces `assert`
  with exceptions; #35664 migrates raises to `VLLMValidationError`; #45541 fixes
  `repr`/docstrings/`top_k` ordering). None reject whitespace-only `bad_words` or
  fix this empty-token-list `IndexError`; the fix here is a distinct two-line
  change in `_verify_args`.
