### PR TITLE
fix(security): harden P2P KV-offload against client-supplied peer add…

### DIFF
--- a/tests/entrypoints/openai/test_kv_params_sanitization.py
+++ b/tests/entrypoints/openai/test_kv_params_sanitization.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for CWE-918: client-supplied peer-topology fields
+must be stripped from kv_transfer_params before they reach the engine."""
+
+from vllm.entrypoints.openai.kv_transfer_params_sanitizer import (
+    sanitize_kv_transfer_params,
+)
+
+
+class TestSanitizeKvTransferParams:
+    def test_none_passthrough(self):
+        assert sanitize_kv_transfer_params(None) is None
+
+    def test_empty_dict_passthrough(self):
+        assert not sanitize_kv_transfer_params({})
+
+    def test_strips_remote_host_from_prefill(self):
+        params = {
+            "prefill": {
+                "kv_request_id": "req-1",
+                "remote_host": "attacker.example",
+                "remote_port": 4444,
+            }
+        }
+        result = sanitize_kv_transfer_params(params)
+        assert result is not None
+        assert result["prefill"] == {"kv_request_id": "req-1"}
+
+    def test_strips_remote_host_from_decode(self):
+        params = {
+            "decode": {
+                "kv_request_id": "req-1",
+                "remote_host": "attacker.example",
+                "remote_port": 4444,
+            }
+        }
+        result = sanitize_kv_transfer_params(params)
+        assert result is not None
+        assert result["decode"] == {"kv_request_id": "req-1"}
+
+    def test_preserves_kv_request_id(self):
+        params = {
+            "prefill": {
+                "kv_request_id": "req-42",
+                "remote_host": "10.0.0.1",
+                "remote_port": 7777,
+            }
+        }
+        result = sanitize_kv_transfer_params(params)
+        assert result is not None
+        assert result["prefill"]["kv_request_id"] == "req-42"
+
+    def test_preserves_non_topology_keys(self):
+        params = {
+            "prefill": {
+                "kv_request_id": "req-1",
+                "custom_key": "value",
+                "remote_host": "x",
+                "remote_port": 1,
+            }
+        }
+        result = sanitize_kv_transfer_params(params)
+        assert result is not None
+        assert result["prefill"]["custom_key"] == "value"
+        assert "remote_host" not in result["prefill"]
+        assert "remote_port" not in result["prefill"]
+
+    def test_does_not_mutate_original(self):
+        original_prefill = {
+            "kv_request_id": "req-1",
+            "remote_host": "10.0.0.1",
+            "remote_port": 7777,
+        }
+        params = {"prefill": original_prefill}
+        sanitize_kv_transfer_params(params)
+        assert "remote_host" in original_prefill
+
+    def test_no_prefill_or_decode_passthrough(self):
+        params = {"do_remote_prefill": True, "other_key": "val"}
+        result = sanitize_kv_transfer_params(params)
+        assert result == params
+
+    def test_prefill_without_topology_keys_unchanged(self):
+        params = {"prefill": {"kv_request_id": "req-1"}}
+        result = sanitize_kv_transfer_params(params)
+        assert result is not None
+        assert result["prefill"] == {"kv_request_id": "req-1"}
+
+    def test_strips_from_both_prefill_and_decode(self):
+        params = {
+            "prefill": {
+                "kv_request_id": "req-1",
+                "remote_host": "host-a",
+                "remote_port": 1111,
+            },
+            "decode": {
+                "kv_request_id": "req-2",
+                "remote_host": "host-b",
+                "remote_port": 2222,
+            },
+        }
+        result = sanitize_kv_transfer_params(params)
+        assert result is not None
+        assert "remote_host" not in result["prefill"]
+        assert "remote_port" not in result["prefill"]
+        assert "remote_host" not in result["decode"]
+        assert "remote_port" not in result["decode"]
+        assert result["prefill"]["kv_request_id"] == "req-1"
+        assert result["decode"]["kv_request_id"] == "req-2"
+
+    def test_non_dict_prefill_left_alone(self):
+        params = {"prefill": "not-a-dict"}
+        result = sanitize_kv_transfer_params(params)
+        assert result == {"prefill": "not-a-dict"}
+
+    def test_top_level_remote_host_stripped(self):
+        """Top-level remote_host/remote_port (used by NIXL) must also be
+        stripped -- the NIXL connector reads them to initiate outbound
+        connections (same CWE-918 vector)."""
+        params = {
+            "do_remote_prefill": True,
+            "remote_host": "10.0.0.1",
+            "remote_port": 5555,
+        }
+        result = sanitize_kv_transfer_params(params)
+        assert result is not None
+        assert "remote_host" not in result
+        assert "remote_port" not in result
+        assert result["do_remote_prefill"] is True

--- a/tests/v1/kv_offload/tiering/p2p/test_manager.py
+++ b/tests/v1/kv_offload/tiering/p2p/test_manager.py
@@ -76,8 +76,17 @@ def _job_metadata(
     )
 
 
-def _make_manager() -> P2PSecondaryTierManager:
-    """Create a manager with stubbed __init__."""
+def _make_manager(
+    allowed_peers: frozenset[str] | None = None,
+) -> P2PSecondaryTierManager:
+    """Create a manager with stubbed __init__.
+
+    Args:
+        allowed_peers: Peer allowlist.  Defaults to ``{"10.0.0.1:8000"}``
+            so that the standard ``_prefill_kv_params()`` helper is
+            accepted by default.  Pass ``frozenset()`` for an empty list
+            or a custom set as needed.
+    """
     mgr = P2PSecondaryTierManager.__new__(P2PSecondaryTierManager)
     mgr._local_id = "127.0.0.1:7777"
     mgr._finished_jobs = []
@@ -85,6 +94,9 @@ def _make_manager() -> P2PSecondaryTierManager:
     mgr._sessions = {}
     mgr._kv_to_session = {}
     mgr._unbound_stores = {}
+    mgr._allowed_peers = (
+        allowed_peers if allowed_peers is not None else frozenset({"10.0.0.1:8000"})
+    )
     return mgr
 
 
@@ -852,8 +864,8 @@ def _build_paired_managers() -> tuple[P2PSecondaryTierManager, P2PSecondaryTierM
     on the next poll. The test drives polling by calling get_finished_jobs(),
     which invokes _poll_once synchronously on the calling thread.
     """
-    mgr_a = _make_manager()
-    mgr_b = _make_manager()
+    mgr_a = _make_manager(allowed_peers=frozenset({"B:2"}))
+    mgr_b = _make_manager(allowed_peers=frozenset({"A:1"}))
     mgr_a._local_id = "A:1"
     mgr_b._local_id = "B:2"
 
@@ -1373,3 +1385,126 @@ class TestConnectionDeathMidTransfer:
         assert (900, False) not in finishes
         assert (900, True) not in finishes
         assert "req-store" in mgr_a._unbound_stores
+
+
+# ---------------------------------------------------------------------------
+# Tests for peer allowlist (CWE-918 regression)
+# ---------------------------------------------------------------------------
+
+
+class TestPeerAllowlist:
+    """Verify that outbound connections are gated by _allowed_peers."""
+
+    def test_is_peer_allowed_accepts_listed_peer(self):
+        mgr = _make_manager(allowed_peers=frozenset({"10.0.0.1:8000"}))
+        assert mgr._is_peer_allowed("10.0.0.1:8000") is True
+
+    def test_is_peer_allowed_rejects_unlisted_peer(self):
+        mgr = _make_manager(allowed_peers=frozenset({"10.0.0.1:8000"}))
+        assert mgr._is_peer_allowed("attacker.example:4444") is False
+
+    def test_is_peer_allowed_rejects_all_when_empty(self):
+        mgr = _make_manager(allowed_peers=frozenset())
+        assert mgr._is_peer_allowed("10.0.0.1:8000") is False
+
+    def test_lookup_rejects_unlisted_peer(self):
+        mgr = _make_manager(allowed_peers=frozenset({"10.0.0.99:9999"}))
+        ctx = _req_context(
+            kv_params=_prefill_kv_params(
+                remote_host="attacker.example",
+                remote_port=4444,
+            )
+        )
+        assert mgr.lookup(b"key", ctx) is LookupResult.MISS
+
+    def test_lookup_accepts_listed_peer(self):
+        mgr = _make_manager(allowed_peers=frozenset({"10.0.0.1:8000"}))
+        ctx = _req_context(kv_params=_prefill_kv_params())
+        assert mgr.lookup(b"key", ctx) is LookupResult.HIT
+
+    def test_on_new_request_rejects_unlisted_peer(self):
+        """Unlisted peer must not cause a session to be created."""
+        mgr = _make_manager(allowed_peers=frozenset({"10.0.0.99:9999"}))
+        ctx = _req_context(
+            kv_params=_prefill_kv_params(
+                remote_host="attacker.example",
+                remote_port=4444,
+            )
+        )
+        mgr.on_new_request(ctx)
+        assert "attacker.example:4444" not in mgr._sessions
+
+    def test_on_new_request_accepts_listed_peer(self):
+        """Listed peer triggers _get_or_create_session.
+
+        Without a real ControlTransport the connect() call will fail,
+        so we mock _control.connect to verify the call is attempted.
+        """
+        mgr = _make_manager(allowed_peers=frozenset({"10.0.0.1:8000"}))
+
+        class FakeControl:
+            connected_to: str | None = None
+
+            def connect(self, peer_id: str):
+                self.connected_to = peer_id
+                conn = type(
+                    "Conn",
+                    (),
+                    {
+                        "peer_id": peer_id,
+                        "alive": True,
+                        "send": lambda self, m: None,
+                        "recv": lambda self: (),
+                        "mark_dead": lambda self: None,
+                        "close": lambda self: None,
+                    },
+                )()
+                return conn
+
+        fake_ctl = FakeControl()
+        mgr._control = fake_ctl  # type: ignore[assignment]
+        mgr._data = _FakeData(mgr._local_id)  # type: ignore[assignment]
+        ctx = _req_context(kv_params=_prefill_kv_params())
+        mgr.on_new_request(ctx)
+        assert fake_ctl.connected_to == "10.0.0.1:8000"
+
+    def test_submit_load_rejects_unlisted_peer(self):
+        """submit_load for an unlisted peer fails the job immediately."""
+        mgr = _make_manager(allowed_peers=frozenset({"10.0.0.99:9999"}))
+        job = _job_metadata(
+            job_id=42,
+            keys=[b"k1"],
+            block_ids=[0],
+            kv_params=_prefill_kv_params(
+                remote_host="attacker.example",
+                remote_port=4444,
+            ),
+        )
+        mgr.submit_load(job)
+        assert mgr._finished_jobs == [JobResult(job_id=42, success=False)]
+        assert "req-1" in mgr._failed_req_ids
+
+    def test_inbound_peer_accepted_without_allowlist(self):
+        """Inbound connections bypass the allowlist entirely.
+
+        _accept_new_peers creates sessions from connections initiated by
+        the remote side -- these are not gated by _allowed_peers.
+        """
+        mgr = _make_manager(allowed_peers=frozenset())
+        mgr._data = _FakeData(mgr._local_id)  # type: ignore[assignment]
+
+        conn = type(
+            "FakeConn",
+            (),
+            {
+                "peer_id": "inbound.peer:5555",
+                "alive": True,
+                "send": lambda self, m: None,
+                "recv": lambda self: (),
+                "mark_dead": lambda self: None,
+                "close": lambda self: None,
+            },
+        )()
+
+        mgr._accept_new_peers([conn])
+        assert "inbound.peer:5555" in mgr._sessions

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -33,6 +33,9 @@ from vllm.entrypoints.openai.engine.protocol import (
     validate_structural_tag_response_format,
     validate_structured_outputs_structural_tag,
 )
+from vllm.entrypoints.openai.kv_transfer_params_sanitizer import (
+    sanitize_kv_transfer_params,
+)
 from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.logprobs import Logprob
@@ -659,9 +662,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 )
 
         extra_args: dict[str, Any] = self.vllm_xargs if self.vllm_xargs else {}
-        if self.kv_transfer_params:
-            # Pass in kv_transfer_params via extra_args
-            extra_args["kv_transfer_params"] = self.kv_transfer_params
+        sanitized_kv = sanitize_kv_transfer_params(self.kv_transfer_params)
+        if sanitized_kv:
+            extra_args["kv_transfer_params"] = sanitized_kv
         return SamplingParams.from_optional(
             n=self.n,
             presence_penalty=self.presence_penalty,

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -21,6 +21,9 @@ from vllm.entrypoints.openai.engine.protocol import (
     validate_structural_tag_response_format,
     validate_structured_outputs_structural_tag,
 )
+from vllm.entrypoints.openai.kv_transfer_params_sanitizer import (
+    sanitize_kv_transfer_params,
+)
 from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.logprobs import Logprob
@@ -339,9 +342,9 @@ class CompletionRequest(OpenAIBaseModel):
                 )
 
         extra_args: dict[str, Any] = self.vllm_xargs if self.vllm_xargs else {}
-        if self.kv_transfer_params:
-            # Pass in kv_transfer_params via extra_args
-            extra_args["kv_transfer_params"] = self.kv_transfer_params
+        sanitized_kv = sanitize_kv_transfer_params(self.kv_transfer_params)
+        if sanitized_kv:
+            extra_args["kv_transfer_params"] = sanitized_kv
         return SamplingParams.from_optional(
             n=self.n,
             presence_penalty=self.presence_penalty,

--- a/vllm/entrypoints/openai/kv_transfer_params_sanitizer.py
+++ b/vllm/entrypoints/openai/kv_transfer_params_sanitizer.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Sanitize client-supplied ``kv_transfer_params`` before they enter the
+engine.
+
+Topology fields (``remote_host``, ``remote_port``) must only come from a
+trusted router/proxy, never from a public API client.  Stripping them at
+the API boundary prevents SSRF-class issues (CWE-918) regardless of which
+KV connector is active downstream.
+"""
+
+from typing import Any
+
+_TOPOLOGY_KEYS = frozenset({"remote_host", "remote_port"})
+
+
+def sanitize_kv_transfer_params(
+    params: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return a copy of *params* with peer-topology fields removed.
+
+    Strips ``remote_host`` and ``remote_port`` from the top level
+    (used by the NIXL connector) and from the ``prefill`` / ``decode``
+    sub-dicts (used by P2P offloading) so that clients cannot steer
+    internal control-plane connections.  All other keys (e.g.
+    ``kv_request_id``, ``do_remote_prefill``) are preserved.
+
+    Returns ``None`` when *params* is ``None`` or becomes empty after
+    stripping.
+    """
+    if not params:
+        return params
+
+    out = {k: v for k, v in params.items() if k not in _TOPOLOGY_KEYS}
+
+    for role_key in ("prefill", "decode"):
+        role = out.get(role_key)
+        if not isinstance(role, dict):
+            continue
+        if role.keys() & _TOPOLOGY_KEYS:
+            out[role_key] = {k: v for k, v in role.items() if k not in _TOPOLOGY_KEYS}
+
+    return out or None

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -61,6 +61,9 @@ from vllm.entrypoints.chat_utils import (
     ChatTemplateContentFormatOption,
 )
 from vllm.entrypoints.openai.engine.protocol import OpenAIBaseModel
+from vllm.entrypoints.openai.kv_transfer_params_sanitizer import (
+    sanitize_kv_transfer_params,
+)
 from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.renderers import ChatParams, TokenizeParams, merge_kwargs
@@ -398,8 +401,9 @@ class ResponsesRequest(OpenAIBaseModel):
             stop = [stop]
 
         extra_args: dict[str, Any] = self.vllm_xargs if self.vllm_xargs else {}
-        if self.kv_transfer_params:
-            extra_args["kv_transfer_params"] = self.kv_transfer_params
+        sanitized_kv = sanitize_kv_transfer_params(self.kv_transfer_params)
+        if sanitized_kv:
+            extra_args["kv_transfer_params"] = sanitized_kv
 
         return SamplingParams.from_optional(
             temperature=temperature,

--- a/vllm/v1/kv_offload/tiering/p2p/manager.py
+++ b/vllm/v1/kv_offload/tiering/p2p/manager.py
@@ -115,6 +115,7 @@ class P2PSecondaryTierManager(SecondaryTierManager):
         port: int = 7777,
         backends: list[str] | None = None,
         num_threads: int = 4,
+        peers: list[str] | None = None,
         **kwargs,
     ) -> None:
         """Initialize the P2P secondary tier manager.
@@ -142,11 +143,20 @@ class P2PSecondaryTierManager(SecondaryTierManager):
             num_threads: NIXL agent worker threads for the UCX-only
                 branch. Ignored when ``backends`` contains a non-UCX
                 entry.
+            peers: Allowlist of ``"host:port"`` peer addresses that
+                this manager is permitted to open outbound sessions to.
+                When non-empty, outbound connections to addresses not
+                in this set are rejected.  When ``None`` or empty, all
+                outbound connections are rejected (only inbound peers
+                accepted).  Peer addresses should match the
+                ``host:port`` format used in ``kv_transfer_params``.
             **kwargs: Reserved for future tier-specific options.
         """
         super().__init__(offloading_spec, primary_kv_view, tier_type)
         port = int(port)
         self._local_id = f"{host}:{port}"
+
+        self._allowed_peers: frozenset[str] = frozenset(peers) if peers else frozenset()
 
         config_fields = FileMapper.from_offloading_spec(
             root_dir="",
@@ -194,6 +204,10 @@ class P2PSecondaryTierManager(SecondaryTierManager):
             or not prefill.get("remote_port")
             or not prefill.get("kv_request_id")
         ):
+            return LookupResult.MISS
+
+        peer_id = self._remote_id_from_params(prefill)
+        if peer_id and not self._is_peer_allowed(peer_id):
             return LookupResult.MISS
 
         kv_request_id = prefill["kv_request_id"]
@@ -347,6 +361,11 @@ class P2PSecondaryTierManager(SecondaryTierManager):
         peer_id = self._remote_id_from_params(prefill)
         assert peer_id is not None  # guaranteed by prefill checks above
 
+        if not self._is_peer_allowed(peer_id):
+            self._finished_jobs.append(JobResult(job_id=job_id, success=False))
+            self._failed_req_ids.add(kv_request_id)
+            return
+
         if not keys:
             logger.debug(
                 "P2P %s: submit_load job_id=%d short-circuit success (no keys)",
@@ -443,7 +462,25 @@ class P2PSecondaryTierManager(SecondaryTierManager):
             return f"{host}:{port}"
         return None
 
-    def _get_or_create_session(self, peer_id: str) -> P2PSession:
+    def _is_peer_allowed(self, peer_id: str) -> bool:
+        """Check *peer_id* against the configured allowlist.
+
+        Returns ``True`` when the peer is explicitly listed in
+        ``self._allowed_peers``.  An empty allowlist rejects all
+        outbound peers (only inbound connections are accepted).
+        """
+        if peer_id in self._allowed_peers:
+            return True
+        logger.warning(
+            "P2P %s: rejecting outbound connection to unlisted peer %s "
+            "(allowed_peers=%s)",
+            self._local_id,
+            peer_id,
+            self._allowed_peers or "<empty>",
+        )
+        return False
+
+    def _get_or_create_session(self, peer_id: str) -> P2PSession | None:
         """Return the existing session for peer_id, or open one outbound.
 
         Decoder-side helper for on_new_request: when ``prefill`` is set,
@@ -451,10 +488,15 @@ class P2PSecondaryTierManager(SecondaryTierManager):
         have a session toward that peer (from a prior load or a
         peer-initiated inbound), reuse it; otherwise open an outbound
         ControlConnection and build a connected session.
+
+        Returns ``None`` when the peer is not in the configured
+        allowlist.
         """
         session = self._sessions.get(peer_id)
         if session is not None:
             return session
+        if not self._is_peer_allowed(peer_id):
+            return None
         conn = self._control.connect(peer_id)
         session = P2PSession(
             peer_id=peer_id,


### PR DESCRIPTION
The P2P secondary tier for KV offloading trusted remote_host and remote_port from client-supplied kv_transfer_params, allowing an authenticated API client to steer outbound ZMQ control connections to arbitrary endpoints (SSRF).
Defense in depth with two layers:
1. Strip remote_host/remote_port from kv_transfer_params.prefill and kv_transfer_params.decode at the OpenAI API boundary before they reach the engine. Topology fields must come from a trusted router/proxy, not from public request JSON.
2. Add a peers allowlist to P2PSecondaryTierManager. Outbound connections are only opened to addresses explicitly listed in the secondary_tiers[].peers configuration. Unlisted peers are rejected at lookup, on_new_request, and submit_load time. Inbound connections remain ungated.

