### PR TITLE
[CPU][Bugfix] Fix flaky ShortConv prefill test on ARM (uninitialized weights)

### DIFF
--- a/tests/kernels/mamba/test_cpu_short_conv.py
+++ b/tests/kernels/mamba/test_cpu_short_conv.py
@@ -60,6 +60,12 @@ def test_short_conv_forward_native_prefill(vllm_config):
         layer = ShortConv(config=config, dim=dim, layer_idx=0, prefix=prefix)
 
     layer.to("cpu")
+    # vLLM Linear layers allocate weights with torch.empty (uninitialized).
+    # On ARM these come back as zero-filled pages, so in_proj output is zero and
+    # the prefill state stays zero. Seed + init to make the test platform-safe.
+    torch.manual_seed(0)
+    for p in layer.parameters():
+        torch.nn.init.normal_(p)
     dispatch_cpu_unquantized_gemm(layer.in_proj, remove_weight=False)
     dispatch_cpu_unquantized_gemm(layer.out_proj, remove_weight=False)
 
@@ -117,6 +123,9 @@ def test_short_conv_forward_native_decode(vllm_config):
         layer = ShortConv(config=config, dim=dim, layer_idx=0, prefix=prefix)
 
     layer.to("cpu")
+    torch.manual_seed(0)
+    for p in layer.parameters():
+        torch.nn.init.normal_(p)
     dispatch_cpu_unquantized_gemm(layer.in_proj, remove_weight=False)
     dispatch_cpu_unquantized_gemm(layer.out_proj, remove_weight=False)
 


### PR DESCRIPTION
## Summary

`tests/kernels/mamba/test_cpu_short_conv.py::test_short_conv_forward_native_prefill`
failed on ARM CI while passing on x86.

## Root cause

The test never initializes the `ShortConv` layer weights — it only calls
`dispatch_cpu_unquantized_gemm`, which packs the *existing* weights. vLLM Linear
layers allocate weights with `torch.empty` (uninitialized).

- On x86, the heap returns dirty (nonzero) pages, so `in_proj` produces nonzero
  output and the prefill path writes a nonzero `conv_state` → assertion passes.
- On ARM/Linux, fresh allocations come from zero-filled mmap pages, so `in_proj`
  weights+bias are zero → `B`/`x` are zero → prefill writes zeros into
  `conv_state` (initial state is also zero with `has_initial_states=False`) →
  `assert not torch.allclose(conv_state, zeros)` fails.

The decode test passes on ARM because `causal_conv1d_update_torch` shifts the
pre-seeded `randn` state regardless of weight values.

Production code is correct; the defect is a test relying on uninitialized memory.

## Fix

Seed and initialize the layer parameters (`torch.nn.init.normal_`) before the
GEMM dispatch in both tests, making output deterministically nonzero on all
platforms.

Fixes: #35059 
