### PR TITLE
[ROCm][Spec Decode] Fix EAGLE3 layer0 acceptance collapse

### DIFF
--- a/tests/model_executor/test_eagle3_aux_rmsnorm.py
+++ b/tests/model_executor/test_eagle3_aux_rmsnorm.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+pytest.importorskip("triton")
+
+from vllm.model_executor.models.eagle3_aux_rmsnorm import fused_dual_rmsnorm_cat
+from vllm.platforms import current_platform
+
+
+@pytest.mark.skipif(
+    not current_platform.is_rocm() or not torch.cuda.is_available(),
+    reason="requires ROCm",
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("leading_shape", [(7,), (2, 7)])
+def test_fused_dual_rmsnorm_cat_matches_reference(
+    dtype: torch.dtype, leading_shape: tuple[int, ...]
+):
+    torch.manual_seed(0)
+    hidden_size = 96
+    a = torch.randn(*leading_shape, hidden_size, device="cuda", dtype=dtype)
+    b = torch.randn(*leading_shape, hidden_size, device="cuda", dtype=dtype)
+    w_a = torch.randn(hidden_size, device="cuda", dtype=dtype)
+    w_b = torch.randn(hidden_size, device="cuda", dtype=dtype)
+    eps = 1e-6
+
+    actual = fused_dual_rmsnorm_cat(a, b, w_a, w_b, eps)
+
+    def rmsnorm(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+        variance = x.to(torch.float32).pow(2).mean(dim=-1, keepdim=True)
+        out = x.to(torch.float32) * torch.rsqrt(variance + eps) * weight
+        return out.to(dtype)
+
+    expected = torch.cat([rmsnorm(a, w_a), rmsnorm(b, w_b)], dim=-1)
+    torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)

--- a/vllm/model_executor/models/eagle3_aux_rmsnorm.py
+++ b/vllm/model_executor/models/eagle3_aux_rmsnorm.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Small fused RMSNorm helpers for EAGLE3 draft models."""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _fused_dual_rmsnorm_cat_kernel(
+    a_ptr,
+    b_ptr,
+    w_a_ptr,
+    w_b_ptr,
+    out_ptr,
+    hidden_size: tl.constexpr,
+    eps: tl.constexpr,
+    block_h: tl.constexpr,
+):
+    row = tl.program_id(0)
+    group = tl.program_id(1)
+    offsets = tl.arange(0, block_h)
+    mask = offsets < hidden_size
+
+    if group == 0:
+        x = tl.load(a_ptr + row * hidden_size + offsets, mask=mask, other=0.0).to(
+            tl.float32
+        )
+        w = tl.load(w_a_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    else:
+        x = tl.load(b_ptr + row * hidden_size + offsets, mask=mask, other=0.0).to(
+            tl.float32
+        )
+        w = tl.load(w_b_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+
+    variance = tl.sum(x * x, axis=0) / hidden_size
+    y = x * tl.rsqrt(variance + eps) * w
+    out_offset = row * (2 * hidden_size) + group * hidden_size + offsets
+    tl.store(out_ptr + out_offset, y.to(out_ptr.dtype.element_ty), mask=mask)
+
+
+def fused_dual_rmsnorm_cat(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    w_a: torch.Tensor,
+    w_b: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """RMS-normalize two tensors and concatenate the normalized results.
+
+    Returns ``cat([rmsnorm(a, w_a), rmsnorm(b, w_b)], dim=-1)`` using a
+    single Triton launch. Inputs must be contiguous, same-shaped CUDA tensors.
+    """
+    if a.shape != b.shape:
+        raise ValueError(f"input shapes must match, got {a.shape} and {b.shape}")
+    if not a.is_cuda or not b.is_cuda:
+        raise ValueError("fused_dual_rmsnorm_cat requires CUDA tensors")
+    if a.device != b.device or a.dtype != b.dtype:
+        raise ValueError("inputs must have the same device and dtype")
+    if not a.is_contiguous() or not b.is_contiguous():
+        raise ValueError("inputs must be contiguous")
+    hidden_size = a.shape[-1]
+    if w_a.device != a.device or w_b.device != a.device:
+        raise ValueError("RMSNorm weights must be on the input device")
+    if not w_a.is_contiguous() or not w_b.is_contiguous():
+        raise ValueError("RMSNorm weights must be contiguous")
+    if w_a.shape != (hidden_size,) or w_b.shape != (hidden_size,):
+        raise ValueError(
+            "RMSNorm weights must match the input hidden dimension: "
+            f"hidden={hidden_size}, w_a={w_a.shape}, w_b={w_b.shape}"
+        )
+
+    out = torch.empty((*a.shape[:-1], hidden_size * 2), dtype=a.dtype, device=a.device)
+    if a.numel() == 0:
+        return out
+
+    rows = a.numel() // hidden_size
+    block_h = triton.next_power_of_2(hidden_size)
+    num_warps = 8 if block_h >= 4096 else (4 if block_h >= 1024 else 2)
+    _fused_dual_rmsnorm_cat_kernel[(rows, 2)](
+        a,
+        b,
+        w_a,
+        w_b,
+        out,
+        hidden_size,
+        float(eps),
+        block_h,
+        num_warps=num_warps,
+    )
+    return out

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -18,8 +18,10 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
+from vllm.model_executor.models.eagle3_aux_rmsnorm import fused_dual_rmsnorm_cat
 from vllm.model_executor.models.llama import LlamaDecoderLayer, LlamaForCausalLM
 from vllm.multimodal.inputs import NestedTensors
+from vllm.platforms import current_platform
 
 from .utils import (
     AutoWeightsLoader,
@@ -66,7 +68,13 @@ class LlamaDecoderLayer(LlamaDecoderLayer):
         self.hidden_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.layer_idx = layer_idx
 
-        if getattr(config, "norm_before_residual", False):
+        self.norm_before_residual = bool(
+            getattr(config, "norm_before_residual", False)
+        )
+        self.use_fused_layer0_rmsnorm_cat = (
+            current_platform.is_rocm() and not self.norm_before_residual
+        )
+        if self.norm_before_residual:
             self._residual_norm = self._norm_before_residual
         else:
             self._residual_norm = self._norm_after_residual
@@ -89,6 +97,36 @@ class LlamaDecoderLayer(LlamaDecoderLayer):
         hidden_states = self.hidden_norm(hidden_states)
         return hidden_states, residual
 
+    def _can_use_fused_layer0_rmsnorm_cat(
+        self, embeds: torch.Tensor, hidden_states: torch.Tensor
+    ) -> bool:
+        return (
+            self.use_fused_layer0_rmsnorm_cat
+            and embeds.is_cuda
+            and embeds.is_contiguous()
+            and hidden_states.is_contiguous()
+            and embeds.shape == hidden_states.shape
+            and embeds.device == hidden_states.device
+            and embeds.dtype == hidden_states.dtype
+            and self.input_layernorm.weight.is_contiguous()
+            and self.hidden_norm.weight.is_contiguous()
+            and self.input_layernorm.variance_epsilon
+            == self.hidden_norm.variance_epsilon
+        )
+
+    def _fused_layer0_rmsnorm_cat(
+        self, embeds: torch.Tensor, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        residual = hidden_states
+        hidden_states = fused_dual_rmsnorm_cat(
+            embeds,
+            hidden_states,
+            self.input_layernorm.weight,
+            self.hidden_norm.weight,
+            self.input_layernorm.variance_epsilon,
+        )
+        return hidden_states, residual
+
     def forward(
         self,
         positions: torch.Tensor,
@@ -98,9 +136,16 @@ class LlamaDecoderLayer(LlamaDecoderLayer):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if self.layer_idx == 0:
             # First layer: concatenate embeds with hidden_states
-            embeds = self.input_layernorm(embeds)
-            hidden_states, residual = self._residual_norm(hidden_states=hidden_states)
-            hidden_states = torch.cat([embeds, hidden_states], dim=-1)
+            if self._can_use_fused_layer0_rmsnorm_cat(embeds, hidden_states):
+                hidden_states, residual = self._fused_layer0_rmsnorm_cat(
+                    embeds, hidden_states
+                )
+            else:
+                embeds = self.input_layernorm(embeds)
+                hidden_states, residual = self._residual_norm(
+                    hidden_states=hidden_states
+                )
+                hidden_states = torch.cat([embeds, hidden_states], dim=-1)
         else:
             # Subsequent layers: process hidden_states and residuals only
             hidden_states, residual = self.input_layernorm(hidden_states, residual)


### PR DESCRIPTION
## Summary

This PR fixes a ROCm-specific EAGLE3 speculative decoding correctness/robustness issue in the first draft decoder layer input-prep path.

The issue is backend-sensitive. ROCm EAGLE3 does not always collapse: forcing the draft model to use `ROCM_AITER_UNIFIED_ATTN` is a strong workaround. 
This PR fixes the ROCm layer0 input-prep path so the default path is usable, and it also improves acceptance when `ROCM_AITER_UNIFIED_ATTN` is explicitly used.

The change is gated to ROCm with `current_platform.is_rocm()`. Non-ROCm platforms keep the existing path.

## Problem

EAGLE3 depends on the draft model staying aligned with the target model. On ROCm, the first EAGLE3 draft layer currently builds its input with separate RMSNorm and concat operations:

```python
embeds = self.input_layernorm(embeds)
hidden_states, residual = self._residual_norm(hidden_states=hidden_states)
hidden_states = torch.cat([embeds, hidden_states], dim=-1)
```
In the default ROCm backend route, the drafter can select <code>ROCM_ATTN</code>. With that path, acceptance can collapse enough that speculative decoding stops helping.</p><p><code>ROCM_AITER_UNIFIED_ATTN</code> avoids much of the collapse and is a good operational workaround, but it is not a substitute for fixing the ROCm layer0 path. In same-batch testing, this PR still improves acceptance and throughput even with <code>ROCM_AITER_UNIFIED_ATTN</code>.</p>

## Fix

For ROCm only, this PR uses a fused layer0 RMSNorm + concat path for EAGLE3:

```python
residual = hidden_states
hidden_states = fused_dual_rmsnorm_cat(
    embeds,
    hidden_states,
    self.input_layernorm.weight,
    self.hidden_norm.weight,
    self.input_layernorm.variance_epsilon,
)
```
</pre><p>Non-ROCm platforms keep the existing fallback path unchanged.</p><h2>Validation</h2><p>MI355X, <code>vllm/vllm-openai-rocm:nightly</code>, <code>amd/MiniMax-M3-MXFP4</code>, EAGLE3 draft model <code>Inferact/MiniMax-M3-EAGLE3</code>.</p><p>Benchmark: random 8192 input / 1024 output, 640 prompts, max concurrency 64, <code>--num-warmups 2</code>.</p>

| Run | Drafter backend path | Acceptance | Accepted length | Output tok/s |
| -- | -- | --: | --: | --: |
| baseline [`d63c8e9`](https://github.com/vllm-project/vllm/commit/d63c8e944481e057d00dfee20bc49544d291e521), spec3, default backend | default -> `ROCM_ATTN` | 2.83% | 1.08 | 861.12 |
| baseline [`d63c8e9`](https://github.com/vllm-project/vllm/commit/d63c8e944481e057d00dfee20bc49544d291e521), spec3, `ROCM_AITER_UNIFIED_ATTN` | explicit unified | 36.69% | 2.10 | 2192.86 |
| this PR, spec3, `ROCM_AITER_UNIFIED_ATTN` | explicit unified | 56.19% | 2.69 | 2472.26 |
| baseline [`d63c8e9`](https://github.com/vllm-project/vllm/commit/d63c8e944481e057d00dfee20bc49544d291e521), spec3, `TRITON_ATTN` | explicit `TRITON_ATTN` | 58.27% | 2.75 | 2504.88 |
| this PR, spec3, `TRITON_ATTN` | explicit `TRITON_ATTN` | 58.63% | 2.76 | 2457.61 |

### NVIDIA Regression Check

NVIDIA validation was also run against PR.
Output throughput changed by -0.66%, which is within normal run noise for this benchmark.