### PR TITLE
[Bugfix][Docker] Add fastokens as optional pip extra and Docker build arg

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -921,6 +921,13 @@ RUN --mount=type=cache,target=/opt/uv/cache \
         fi; \
     fi
 
+# Optionally install fastokens for faster BPE tokenization (VLLM_USE_FASTOKENS=1)
+ARG INCLUDE_FASTOKENS=0
+RUN --mount=type=cache,target=/opt/uv/cache \
+    if [ "${INCLUDE_FASTOKENS}" = "1" ]; then \
+        uv pip install --system "fastokens>=0.2.0"; \
+    fi
+
 # CUDA image changed from /usr/local/nvidia to /usr/local/cuda in 12.8 but will
 # return to /usr/local/nvidia in 13.0 to allow container providers to mount drivers
 # consistently from the host (see https://github.com/vllm-project/vllm/issues/18859).

--- a/setup.py
+++ b/setup.py
@@ -1274,6 +1274,8 @@ setup(
         ],
         # extra quantization plugin
         "extra-quant": ["vllm-gguf-plugin>=0.0.2"],
+        # Optional faster Rust BPE tokenizer backend (requires VLLM_USE_FASTOKENS=1)
+        "fastokens": ["fastokens>=0.2.0"],
     },
     cmdclass=cmdclass,
     package_data=package_data,


### PR DESCRIPTION
The `fastokens` Python package (>= 0.2.0) is required when `VLLM_USE_FASTOKENS=1` 
but was absent from all requirements files, `setup.py` extras, and Dockerfiles. 
This made the feature completely unusable in the official Docker image and provided 
no clean pip install path for any user.

- Add `fastokens` to `extras_require` in `setup.py` so users can `pip install vllm[fastokens]`
- Add `ARG INCLUDE_FASTOKENS=0` to `docker/Dockerfile` so Docker users can opt in 
  via `--build-arg INCLUDE_FASTOKENS=1` without bloating the default image

## Purpose

Fixes #47855.

`VLLM_USE_FASTOKENS=1` calls `apply_fastokens_patch()` in 
`vllm/tokenizers/registry.py`, which does a bare `import fastokens` and raises 
`ImportError` immediately if the package is not installed. Since `fastokens` 
appeared in zero packaging files (`requirements/`, `docker/`, `setup.py`, 
`pyproject.toml`), Docker users had no way to enable this feature.

## Test Plan

**Reproduce the bug (before fix):**
```bash
python -c "
from vllm.tokenizers.fastokens import apply_fastokens_patch
apply_fastokens_patch()
"
# ImportError: The 'fastokens' package (>= 0.2.0) is required when VLLM_USE_FASTOKENS=1.
```

**Verify pip extra resolves correctly:**
```bash
pip install "fastokens>=0.2.0"
python -c "import fastokens; print('fastokens imported OK')"
```

**Verify Docker build arg (tested with minimal Dockerfile using same ARG/RUN pattern):**
```bash
# Default — fastokens not installed
docker build --build-arg INCLUDE_FASTOKENS=0 -f docker/Dockerfile .

# Opt-in — fastokens installed
docker build --build-arg INCLUDE_FASTOKENS=1 -f docker/Dockerfile .
```

## Test Results

| Test | Result |
|---|---|
| `apply_fastokens_patch()` without fastokens installed | `ImportError: The 'fastokens' package (>= 0.2.0) is required` ✅ |
| `pip install "fastokens>=0.2.0"` from PyPI | `fastokens 0.2.0` installed successfully ✅ |
| `apply_fastokens_patch()` with fastokens installed | `patch_transformers: successfully patched transformers v5.12.1` ✅ |
| `extras_require["fastokens"]` resolves to correct spec | `['fastokens>=0.2.0']` ✅ |
| Docker `INCLUDE_FASTOKENS=0` (default) | fastokens absent from image as expected ✅ |
| Docker `INCLUDE_FASTOKENS=1` | `fastokens imported OK` ✅ |

## Related

- #43168 — added `VLLM_USE_FASTOKENS` (merged May 21, 2026)
- #43446 — original issue, closed via #45813 which only fixed docs wording
- SGLang prior art: already exposes `pip install sglang[fastokens]` using the same pattern

> AI assistance (Claude Code) was used to investigate the gap, reproduce the 
> error, and draft this fix. All changed lines were reviewed by the submitter. 
> No existing open PR addresses this - confirmed via 
> `gh pr list --repo vllm-project/vllm --state open --search "fastokens"` 
> before submission.