### PR TITLE
[XPU] Fix Event init failure w/ blocking

### DIFF
--- a/vllm/v1/worker/xpu_model_runner.py
+++ b/vllm/v1/worker/xpu_model_runner.py
@@ -49,7 +49,13 @@ def _torch_cuda_wrapper():
     torch.cuda.current_stream = partial(torch.xpu.current_stream)
     torch.cuda.stream = partial(torch.xpu.stream)
     torch.cuda.set_stream = partial(torch.xpu.set_stream)
-    torch.cuda.Event = partial(torch.xpu.Event)
+
+    # torch.xpu.Event does not accept the ``blocking`` kwarg that
+    # torch.cuda.Event supports, so drop it here.
+    def _xpu_event(*args, blocking=None, **kwargs):
+        return torch.xpu.Event(*args, **kwargs)
+
+    torch.cuda.Event = _xpu_event
     if supports_xpu_graph():
         torch.cuda.graph = partial(torch.xpu.graph)
         torch.cuda.CUDAGraph = torch.xpu.XPUGraph


### PR DESCRIPTION



## Purpose
Error msg:
```bash
re pid=3039)   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/worker/gpu/spec_decode/utils.py", line 16, in __init__
(EngineCore pid=3039)     self.copy_event = torch.cuda.Event(blocking=True)
(EngineCore pid=3039)                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=3039) TypeError: Event.__new__() got an unexpected keyword argument 'blocking'
```
https://github.com/vllm-project/vllm/pull/47081 adds `blocking=True` to `torch.cuda.Event`. which argument is not supported by `xpu.Event`,  so this pr currently drops it.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

