### PR TITLE
[Bugfix] Fix NaNs in LoRA expand with mixed dtypes

### DIFF
--- a/tests/lora/test_punica_ops.py
+++ b/tests/lora/test_punica_ops.py
@@ -515,6 +515,117 @@ def test_kernels_hidden_size(
 
 
 @pytest.mark.parametrize("device", DEVICES)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_add_lora_linear_buffer_uses_input_dtype(device, dtype, monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm.lora.punica_wrapper.punica_gpu import PunicaWrapperGPU
+
+    torch.set_default_device(device)
+    torch.accelerator.set_device_index(device)
+
+    num_tokens = 16
+    hidden_size = 32
+    output_size = 64
+    rank = 16
+
+    wrapper = PunicaWrapperGPU(
+        max_num_batched_tokens=num_tokens,
+        max_batches=num_tokens,
+        device=device,
+        lora_config=SimpleNamespace(
+            max_loras=1,
+            specialize_active_lora=False,
+        ),
+    )
+
+    captured_dtypes = []
+
+    def add_shrink(buffer, x, lora_a_stacked, scale, **kwargs):
+        captured_dtypes.append(buffer.dtype)
+        buffer.zero_()
+
+    def add_expand(y, x, lora_b_stacked, output_slices, **kwargs):
+        captured_dtypes.append(x.dtype)
+
+    monkeypatch.setattr(wrapper, "add_shrink", add_shrink)
+    monkeypatch.setattr(wrapper, "add_expand", add_expand)
+
+    y = torch.zeros(num_tokens, output_size, dtype=dtype, device=device)
+    x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
+    lora_a_stacked = (torch.randn(1, 1, rank, hidden_size, dtype=dtype, device=device),)
+    lora_b_stacked = (torch.randn(1, 1, output_size, rank, dtype=dtype, device=device),)
+
+    wrapper.add_lora_linear(
+        y,
+        x,
+        lora_a_stacked,
+        lora_b_stacked,
+        scale=1.0,
+        output_slices=(output_size,),
+    )
+
+    assert captured_dtypes == [dtype, dtype]
+
+
+@pytest.mark.parametrize("device", DEVICES)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_add_lora_logits_buffer_uses_input_dtype(device, dtype, monkeypatch):
+    from types import SimpleNamespace
+
+    import vllm.lora.punica_wrapper.punica_gpu as punica_gpu
+    from vllm.lora.punica_wrapper.punica_gpu import PunicaWrapperGPU
+
+    torch.set_default_device(device)
+    torch.accelerator.set_device_index(device)
+
+    num_tokens = 16
+    hidden_size = 32
+    vocab_size = 64
+    rank = 16
+
+    wrapper = PunicaWrapperGPU(
+        max_num_batched_tokens=num_tokens,
+        max_batches=num_tokens,
+        device=device,
+        lora_config=SimpleNamespace(
+            max_loras=1,
+            specialize_active_lora=False,
+        ),
+    )
+    wrapper.prompt_mapping_meta.prepare_tensors(
+        torch.zeros(num_tokens, dtype=torch.long, device=device)
+    )
+
+    captured_dtypes = []
+
+    def lora_shrink(inputs, lora_a_stacked, output_tensor, *args, **kwargs):
+        captured_dtypes.append(output_tensor.dtype)
+        output_tensor.zero_()
+
+    def lora_expand(inputs, lora_b_stacked, output_tensor, *args, **kwargs):
+        captured_dtypes.append(inputs.dtype)
+
+    monkeypatch.setattr(punica_gpu, "lora_shrink", lora_shrink)
+    monkeypatch.setattr(punica_gpu, "lora_expand", lora_expand)
+
+    y = torch.zeros(num_tokens, vocab_size, dtype=dtype, device=device)
+    x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
+    lora_a_stacked = torch.randn(1, 1, rank, hidden_size, dtype=dtype, device=device)
+    lora_b_stacked = torch.randn(1, 1, vocab_size, rank, dtype=dtype, device=device)
+
+    wrapper.add_lora_logits(
+        y,
+        x,
+        lora_a_stacked,
+        lora_b_stacked,
+        scale=1.0,
+    )
+
+    assert captured_dtypes == [dtype, dtype]
+
+
+@pytest.mark.parametrize("device", DEVICES)
 def test_add_lora_fused_moe_early_exit(device):
     """
     Ensures add_lora_fused_moe does not invoke the LoRA kernel or

--- a/vllm/lora/punica_wrapper/punica_gpu.py
+++ b/vllm/lora/punica_wrapper/punica_gpu.py
@@ -240,11 +240,12 @@ class PunicaWrapperGPU(PunicaWrapperBase):
             ".add_lora_linear() instead of being passed in."
         )
         r = lora_b_stacked[0].size(-1)
-        # We set the buffer to be float32 by default, refer to:
-        # https://github.com/triton-lang/triton/issues/1387
-        # Note: buffer is zeroed inside the shrink op
+        # Keep consistent with XPU and use the input dtype for the shrink buffer.
+        # Note: buffer is zeroed inside the shrink op.
         buffer = torch.empty(
-            (len(output_slices), x.size(0), r), dtype=torch.float32, device=x.device
+            (len(output_slices), x.size(0), r),
+            dtype=x.dtype,
+            device=x.device,
         )
         add_inputs = kwargs.pop("add_inputs", True)
         self.add_shrink(
@@ -298,10 +299,13 @@ class PunicaWrapperGPU(PunicaWrapperBase):
             "To minimize overhead, the buffer should be created by "
             ".add_lora_linear() instead of being passed in."
         )
-        # We set the buffer to be float32 by default, refer to:
-        # https://github.com/triton-lang/triton/issues/1387
-        # Note: buffer is zeroed inside the shrink op
-        buffer = torch.empty((x.size(0), r), dtype=torch.float32, device=x.device)
+        # Keep consistent with XPU and use the input dtype for the shrink buffer.
+        # Note: buffer is zeroed inside the shrink op.
+        buffer = torch.empty(
+            (x.size(0), r),
+            dtype=x.dtype,
+            device=x.device,
+        )
 
         lora_shrink(
             x,


### PR DESCRIPTION


## Purpose

Fix a NaN issue in the GPU Punica LoRA path.

In local LoRA testing( H20 ), the native vLLM server could fail with:

```text
ValueError: Out of range float values are not JSON compliant: nan
```

After adding layered debug logs, we found that the NaNs were first produced by the GPU Punica LoRA expand path. The request/response JSON serialization error was only the downstream symptom.

The previous code kept the intermediate shrink buffer in `float32`:

```python
# We set the buffer to be float32 by default, refer to:
# https://github.com/triton-lang/triton/issues/1387
# Note: buffer is zeroed inside the shrink op
buffer = torch.empty(..., dtype=torch.float32, device=x.device)
```

That historical choice avoided the old bf16 `tl.atomic_add` limitation in Triton. However, when LoRA-B weights are `bf16`/`fp16`, the `float32` buffer can make `lora_expand` enter its mixed-dtype path:

```text
fp32 shrink buffer -> cast to bf16/fp16 inside Triton -> tl.dot
```

On our repro, this path can produce NaNs. This PR changes the buffer to:

```python
# Keep consistent with XPU and use the input dtype for the shrink buffer.
# Note: buffer is zeroed inside the shrink op.
buffer = torch.empty(..., dtype=x.dtype, device=x.device)
```

This matches the existing XPU Punica behavior and avoids the mixed-dtype `lora_expand` path for the common GPU Punica LoRA flow.

The old comment references triton-lang/triton#1387. That historical bf16 `atomic_add` limitation has since been addressed upstream by triton-lang/triton#6519 / triton-lang/triton@236f6b54.

Local debug context:

- Branch base: `main` at `6db31c8e76f5458177be0d716cca758e51fa2f65`
- Local vLLM version: `0.23.1rc1.dev862+g6db31c8e7`
- Model: Qwen3-4B-Instruct-2507
- Hardware: NVIDIA H20
- Torch/Triton: `torch 2.11.0+cu130`, `triton 3.6.0`

## Test Plan

Added regression tests for the two affected GPU Punica paths:

- `add_lora_linear`
- `add_lora_logits`

Local repro used a bf16 Qwen3-4B LoRA server with multiple LoRA adapters and prompt logprobs enabled. The repro workload used 8 LoRAs, 128 requests, concurrency 16, and long prompts.

Pre-commit was also run during commit.

## Test Result

Before the fix, local LoRA testing could produce NaNs in LoRA output/logits and fail with:

```text
ValueError: Out of range float values are not JSON compliant: nan
```

Layered debug logs showed that the first NaNs were produced in the GPU Punica LoRA module, after LoRA expand. Inputs, base outputs, and LoRA weights were finite.

Minimal Triton repro scale:

- Shape: `A=(8192, 64)`, `B=(64, 2560)`, `C=(8192, 2560)`
- Output elements: `20,971,520`
- Block size: `BLOCK_M=64`, `BLOCK_N=128`, `BLOCK_K=32`
- Seed: `torch.manual_seed(123)`

| Path | Kernel path | NaN count | Max finite value |
|---|---|---:|---:|
| `fp32_to_bf16_cast` | load fp32 A, cast A to bf16 inside Triton, then `tl.dot(A, B)` with bf16 B | `14,848` | `1.272e36` |
| `bf16_bf16_direct` | load bf16 A directly, then `tl.dot(A, B)` with bf16 B | `0` | `0.0009346` |
| `fp32_to_fp16_cast` | load fp32 A, cast A to fp16 inside Triton, then `tl.dot(A, B)` with fp16 B | `101,888` | `352.0` |
| `fp16_fp16_direct` | load fp16 A directly, then `tl.dot(A, B)` with fp16 B | `0` | `0.0009346` |

After the fix:

- `pre-commit` passed
- `git diff --check` passed
- `py_compile` passed
- Local GPU sanity checks passed for both `float16` and `bfloat16`
- The updated tests verify that the GPU Punica shrink buffers use the input dtype for `add_lora_linear` and `add_lora_logits`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

