### PR TITLE
Fix video temporal padding token estimates

### DIFF
--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -7,10 +7,29 @@ import torch
 from vllm.model_executor.models.utils import (
     AutoWeightsLoader,
     _merge_multimodal_embeddings,
+    get_padded_num_video_frames,
 )
 from vllm.platforms import current_platform
 
 DEVICE_TYPE = current_platform.device_type
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    ("num_frames", "temporal_patch_size", "expected"),
+    [
+        (1, 2, 2),
+        (16, 4, 16),
+        (17, 4, 20),
+        (18, 4, 20),
+        (19, 4, 20),
+        (20, 4, 20),
+    ],
+)
+def test_get_padded_num_video_frames(
+    num_frames: int, temporal_patch_size: int, expected: int
+):
+    assert get_padded_num_video_frames(num_frames, temporal_patch_size) == expected
 
 
 class ModuleWithBatchNorm(torch.nn.Module):

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -24,12 +24,15 @@ DEVICE_TYPE = current_platform.device_type
         (18, 4, 20),
         (19, 4, 20),
         (20, 4, 20),
+        (16.5, 4, 20),
     ],
 )
 def test_get_padded_num_video_frames(
-    num_frames: int, temporal_patch_size: int, expected: int
+    num_frames: int | float, temporal_patch_size: int, expected: int
 ):
-    assert get_padded_num_video_frames(num_frames, temporal_patch_size) == expected
+    padded_frames = get_padded_num_video_frames(num_frames, temporal_patch_size)
+    assert padded_frames == expected
+    assert isinstance(padded_frames, int)
 
 
 class ModuleWithBatchNorm(torch.nn.Module):

--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -111,6 +111,7 @@ from .qwen2_vl import _create_qwen2vl_field_factory
 from .utils import (
     AutoWeightsLoader,
     WeightsMapper,
+    get_padded_num_video_frames,
     init_vllm_registered_model,
     maybe_prefix,
 )
@@ -1082,9 +1083,9 @@ class Glm4vProcessingInfo(BaseProcessingInfo):
         else:
             preprocessed_size = ImageSize(width=image_width, height=image_height)
 
-        # NOTE: Frames are padded to be divisible by `temporal_patch_size`
-        # https://github.com/huggingface/transformers/blob/v4.48.3/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py#L294
-        padded_num_frames = num_frames + num_frames % temporal_patch_size
+        # NOTE: Frames are padded to be divisible by `temporal_patch_size`.
+        # https://github.com/huggingface/transformers/blob/v5.13.0/src/transformers/models/qwen2_vl/video_processing_qwen2_vl.py#L249-L252
+        padded_num_frames = get_padded_num_video_frames(num_frames, temporal_patch_size)
 
         grid_t = max(padded_num_frames // temporal_patch_size, 1)
         grid_h = preprocessed_size.height // patch_size

--- a/vllm/model_executor/models/kanana_v.py
+++ b/vllm/model_executor/models/kanana_v.py
@@ -40,7 +40,12 @@ from vllm.utils.tensor_schema import TensorSchema, TensorShape
 
 from .interfaces import MultiModalEmbeddings, SupportsMultiModal, SupportsPP
 from .qwen2_vl import Qwen2VisionTransformer
-from .utils import AutoWeightsLoader, init_vllm_registered_model, maybe_prefix
+from .utils import (
+    AutoWeightsLoader,
+    get_padded_num_video_frames,
+    init_vllm_registered_model,
+    maybe_prefix,
+)
 
 logger = init_logger(__name__)
 
@@ -408,9 +413,9 @@ class KananaVProcessingInfo(BaseProcessingInfo):
         else:
             preprocessed_size = ImageSize(width=image_width, height=image_height)
 
-        # NOTE: Frames are padded to be divisible by `temporal_patch_size`
-        # https://github.com/huggingface/transformers/blob/v4.48.3/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py#L294
-        padded_num_frames = num_frames + num_frames % temporal_patch_size
+        # NOTE: Frames are padded to be divisible by `temporal_patch_size`.
+        # https://github.com/huggingface/transformers/blob/v5.13.0/src/transformers/models/qwen2_vl/video_processing_qwen2_vl.py#L249-L252
+        padded_num_frames = get_padded_num_video_frames(num_frames, temporal_patch_size)
 
         grid_t = max(padded_num_frames // temporal_patch_size, 1)
         grid_h = preprocessed_size.height // patch_size

--- a/vllm/model_executor/models/keye.py
+++ b/vllm/model_executor/models/keye.py
@@ -71,6 +71,7 @@ from .siglip import SiglipMLP
 from .utils import (
     AutoWeightsLoader,
     WeightsMapper,
+    get_padded_num_video_frames,
     init_vllm_registered_model,
     maybe_prefix,
 )
@@ -983,7 +984,7 @@ class KeyeProcessingInfo(BaseProcessingInfo):
         else:
             preprocessed_size = ImageSize(width=image_width, height=image_height)
 
-        padded_num_frames = num_frames + num_frames % temporal_patch_size
+        padded_num_frames = get_padded_num_video_frames(num_frames, temporal_patch_size)
 
         grid_t = max(padded_num_frames // temporal_patch_size, 1)
         grid_h = preprocessed_size.height // patch_size

--- a/vllm/model_executor/models/llava_onevision2.py
+++ b/vllm/model_executor/models/llava_onevision2.py
@@ -72,6 +72,7 @@ from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.model_executor.models.utils import (
     AutoWeightsLoader,
     WeightsMapper,
+    get_padded_num_video_frames,
     init_vllm_registered_model,
     maybe_prefix,
 )
@@ -1354,7 +1355,7 @@ class LlavaOnevision2ProcessingInfo(BaseProcessingInfo):
             preprocessed = ImageSize(width=rw, height=rh)
         else:
             preprocessed = ImageSize(width=image_width, height=image_height)
-        padded_frames = num_frames + num_frames % temporal_patch_size
+        padded_frames = get_padded_num_video_frames(num_frames, temporal_patch_size)
         grid_t = max(padded_frames // temporal_patch_size, 1)
         grid_h = preprocessed.height // patch_size
         grid_w = preprocessed.width // patch_size

--- a/vllm/model_executor/models/mimo_v2_omni.py
+++ b/vllm/model_executor/models/mimo_v2_omni.py
@@ -67,7 +67,13 @@ from .qwen2_5_vl import (
     Qwen2_5_VLVideoPixelInputs,
 )
 from .qwen2_vl import _create_qwen2vl_field_factory
-from .utils import AutoWeightsLoader, IntermediateTensors, WeightsMapper, maybe_prefix
+from .utils import (
+    AutoWeightsLoader,
+    IntermediateTensors,
+    WeightsMapper,
+    get_padded_num_video_frames,
+    maybe_prefix,
+)
 
 
 class MiMoVisionMLP(Qwen2_5_VisionMLP):
@@ -715,7 +721,9 @@ class MiMoV2OmniProcessingInfo(BaseProcessingInfo):
             effective_frames = num_frames * tokens_per_second
         else:
             effective_frames = num_frames
-        padded_num_frames = effective_frames + effective_frames % temporal_patch_size
+        padded_num_frames = get_padded_num_video_frames(
+            effective_frames, temporal_patch_size
+        )
         grid_t = max(padded_num_frames // temporal_patch_size, 1)
         grid_h = preprocessed_size.height // patch_size
         grid_w = preprocessed_size.width // patch_size

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -99,6 +99,7 @@ from .interfaces import (
 from .utils import (
     AutoWeightsLoader,
     WeightsMapper,
+    get_padded_num_video_frames,
     init_vllm_registered_model,
     maybe_prefix,
 )
@@ -897,9 +898,9 @@ class Qwen2VLProcessingInfo(BaseProcessingInfo):
         else:
             preprocessed_size = ImageSize(width=image_width, height=image_height)
 
-        # NOTE: Frames are padded to be divisible by `temporal_patch_size`
-        # https://github.com/huggingface/transformers/blob/v4.48.3/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py#L294
-        padded_num_frames = num_frames + num_frames % temporal_patch_size
+        # NOTE: Frames are padded to be divisible by `temporal_patch_size`.
+        # https://github.com/huggingface/transformers/blob/v5.13.0/src/transformers/models/qwen2_vl/video_processing_qwen2_vl.py#L249-L252
+        padded_num_frames = get_padded_num_video_frames(num_frames, temporal_patch_size)
 
         grid_t = max(padded_num_frames // temporal_patch_size, 1)
         grid_h = preprocessed_size.height // patch_size

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -26,7 +26,7 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.interfaces import supports_any_eagle
 from vllm.multimodal import NestedTensors
 from vllm.sequence import IntermediateTensors
-from vllm.utils.math_utils import cdiv
+from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.torch_utils import (
     async_tensor_h2d,
     direct_register_custom_op,
@@ -38,6 +38,11 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 ShardId: TypeAlias = str | int | tuple[int, ...]
+
+
+def get_padded_num_video_frames(num_frames: int, temporal_patch_size: int) -> int:
+    """Pad video frames to a multiple of the temporal patch size."""
+    return round_up(num_frames, temporal_patch_size)
 
 
 @dataclass

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -40,9 +40,11 @@ logger = init_logger(__name__)
 ShardId: TypeAlias = str | int | tuple[int, ...]
 
 
-def get_padded_num_video_frames(num_frames: int, temporal_patch_size: int) -> int:
+def get_padded_num_video_frames(
+    num_frames: int | float, temporal_patch_size: int
+) -> int:
     """Pad video frames to a multiple of the temporal patch size."""
-    return round_up(num_frames, temporal_patch_size)
+    return int(round_up(num_frames, temporal_patch_size))
 
 
 @dataclass

--- a/vllm/utils/math_utils.py
+++ b/vllm/utils/math_utils.py
@@ -2,12 +2,22 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Math utility functions for vLLM."""
 
+from typing import overload
+
 # Approximate value of 1/ln(2), used for log/exp base conversion
 # Best FP32 approximation: 1.4426950216 (hex 0x3FB8AA3B)
 RCP_LN2 = 1.4426950216
 
 
-def cdiv(a: int, b: int) -> int:
+@overload
+def cdiv(a: int, b: int) -> int: ...
+
+
+@overload
+def cdiv(a: float, b: int) -> float: ...
+
+
+def cdiv(a: int | float, b: int) -> int | float:
     """Ceiling division."""
     return -(a // -b)
 
@@ -17,9 +27,17 @@ def next_power_of_2(n: int) -> int:
     return 1 if n < 1 else 1 << (n - 1).bit_length()
 
 
-def round_up(x: int, y: int) -> int:
+@overload
+def round_up(x: int, y: int) -> int: ...
+
+
+@overload
+def round_up(x: float, y: int) -> float: ...
+
+
+def round_up(x: int | float, y: int) -> int | float:
     """Round up x to the nearest multiple of y."""
-    return ((x + y - 1) // y) * y
+    return cdiv(x, y) * y
 
 
 def round_down(x: int, y: int) -> int:


### PR DESCRIPTION
Fixes #47866.

### Summary
- Add a shared helper for padding video frame counts to a multiple of `temporal_patch_size`.
- Replace the legacy `num_frames + num_frames % temporal_patch_size` formula in Qwen2-VL, GLM4.1V, Kanana-V, Keye, LLaVA-OneVision2, and MiMo V2 Omni token-estimation paths.
- Add a CPU unit test covering `temporal_patch_size > 2`, including the `17 -> 20` case from the issue.

### Root cause
Several `_get_vision_info` implementations copied the old Qwen2-VL image-processor formula. That formula only happens to work for common `temporal_patch_size == 2` cases, but it does not round up to the next valid multiple when `temporal_patch_size > 2`. For example, `17 + 17 % 4 == 18`, which is not divisible by 4.

### Duplicate-work check
I checked for overlapping open PRs before opening/updating this PR:
- `gh issue view 47866 --repo vllm-project/vllm --comments`
- `gh pr list --repo vllm-project/vllm --state open --search "47866 in:body"`
- `gh pr list --repo vllm-project/vllm --state open --search "temporal_patch_size video padding"`

The only matching PR for #47866 is this one. The other broad keyword hit, #40116, is about Qwen3-VL torch compile and does not address this padding bug.

### Validation
- `ruff format --check tests/models/test_utils.py vllm/model_executor/models/utils.py vllm/model_executor/models/qwen2_vl.py vllm/model_executor/models/glm4_1v.py vllm/model_executor/models/kanana_v.py vllm/model_executor/models/keye.py vllm/model_executor/models/llava_onevision2.py vllm/model_executor/models/mimo_v2_omni.py`
- `ruff check tests/models/test_utils.py vllm/model_executor/models/utils.py vllm/model_executor/models/qwen2_vl.py vllm/model_executor/models/glm4_1v.py vllm/model_executor/models/kanana_v.py vllm/model_executor/models/keye.py vllm/model_executor/models/llava_onevision2.py vllm/model_executor/models/mimo_v2_omni.py`
- `git diff --check`
- `grep -RIn "num_frames + num_frames % temporal_patch_size\|effective_frames + effective_frames % temporal_patch_size\|padded_frames = num_frames +" vllm/model_executor/models vllm/models vllm/transformers_utils | head -80`

I could not run the full pytest target locally. The local default `python3` is broken due to a Python 3.14 framework code-signature error, `/usr/bin/python3 -m pytest tests/models/test_utils.py -q` lacks `tblib`, and an isolated `uv` run cannot resolve this repo's current macOS torch split (`torch==2.11.0+cpu`). I also initially used `/usr/bin/python3 -m py_compile` before reading the local AGENTS.md; after reading it, I am not counting that as project-compliant validation.

### AI assistance
AI assistance was used to identify the repeated formula, make the mechanical edits, and draft this PR description. I reviewed the changed lines and the issue context before submitting.
