### PR TITLE
[Docs] Note that Qwen2.5-Coder models do not follow the Hermes tool-call format

### DIFF
--- a/docs/features/tool_calling.md
+++ b/docs/features/tool_calling.md
@@ -321,6 +321,10 @@ For Qwen2.5, the chat template in tokenizer_config.json has already included sup
 
 Flags: `--tool-call-parser hermes`
 
+Known issues:
+
+1. Qwen2.5-**Coder** models (`Qwen/Qwen2.5-Coder-*`) do not follow the Hermes `<tool_call>` format, so the `hermes` parser fails silently for them (tool calls are returned as plain `content` and the `tool_calls` array stays empty). See [#32926](https://github.com/vllm-project/vllm/issues/32926).
+
 ### DeepSeek-V3 Models (`deepseek_v3`)
 
 Supported models:


### PR DESCRIPTION
## Purpose

The Qwen section in `docs/features/tool_calling.md` recommends `--tool-call-parser hermes` for all `Qwen/Qwen2.5-*` models. However, Qwen2.5-**Coder** variants do not emit the Hermes `<tool_call>` format — tool calling fails silently: the model's tool calls arrive as plain `content` and the `tool_calls` array stays empty (#32926, #10952, #29192).

This adds a "Known issues" entry to the Qwen section (same style as the Mistral section above it) so users hitting this don't debug a silent failure.

## Test Plan

Docs-only change. `pre-commit run markdownlint-cli2` passes on the edited file.

## Test Result

N/A

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

