### PR TITLE
[Spec Decode][ROCm][Perf] Default EAGLE3 Llama drafter to AITER unified attention

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,6 +28,7 @@ from vllm.config import (
 from vllm.config.compilation import CompilationMode, CUDAGraphMode
 from vllm.config.kernel import IrOpPriorityConfig
 from vllm.config.load import LoadConfig
+from vllm.config.speculative import _should_default_rocm_eagle3_attention_backend
 from vllm.config.utils import get_field
 from vllm.config.vllm import (
     OPTIMIZATION_LEVEL_TO_CONFIG,
@@ -35,6 +36,7 @@ from vllm.config.vllm import (
 )
 from vllm.platforms import current_platform
 from vllm.v1.attention.backend import AttentionCGSupport
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 DEVICE_TYPE = current_platform.device_type
 
@@ -269,6 +271,87 @@ def test_is_default_v2_model_runner_model(model_config, expected):
     config = SimpleNamespace(model_config=model_config)
 
     assert VllmConfig._is_default_v2_model_runner_model(config) is expected
+
+
+@pytest.mark.parametrize(
+    (
+        "method",
+        "attention_backend",
+        "draft_model_config",
+        "is_rocm",
+        "expected",
+    ),
+    [
+        (
+            "eagle3",
+            None,
+            SimpleNamespace(architectures=["LlamaForCausalLMEagle3"]),
+            True,
+            True,
+        ),
+        (
+            "eagle3",
+            AttentionBackendEnum.ROCM_ATTN,
+            SimpleNamespace(architectures=["LlamaForCausalLMEagle3"]),
+            True,
+            False,
+        ),
+        (
+            "eagle3",
+            None,
+            SimpleNamespace(architectures=["LlamaForCausalLMEagle3"]),
+            False,
+            False,
+        ),
+        (
+            "eagle3",
+            None,
+            SimpleNamespace(architectures=["Eagle3Qwen3ForCausalLM"]),
+            True,
+            False,
+        ),
+        (
+            "eagle3",
+            None,
+            SimpleNamespace(
+                architectures=[],
+                hf_config=SimpleNamespace(architectures=["Eagle3LlamaForCausalLM"]),
+            ),
+            True,
+            True,
+        ),
+    ],
+)
+def test_should_default_rocm_eagle3_attention_backend(
+    method, attention_backend, draft_model_config, is_rocm, expected
+):
+    assert (
+        _should_default_rocm_eagle3_attention_backend(
+            method,
+            attention_backend,
+            draft_model_config,
+            is_rocm=is_rocm,
+        )
+        is expected
+    )
+
+
+def test_rocm_eagle3_lite_llama_defaults_to_aiter_unified_attention(
+    monkeypatch,
+):
+    monkeypatch.setattr(current_platform, "is_rocm", lambda: True)
+    speculative_config = SimpleNamespace(
+        method="eagle3",
+        attention_backend=None,
+        draft_model_config=SimpleNamespace(architectures=["LlamaForCausalLMEagle3"]),
+    )
+
+    SpeculativeConfig._maybe_default_rocm_eagle3_attention_backend(speculative_config)
+
+    assert (
+        speculative_config.attention_backend
+        is AttentionBackendEnum.ROCM_AITER_UNIFIED_ATTN
+    )
 
 
 @pytest.mark.skip_global_cleanup

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -74,6 +74,41 @@ RejectionSampleMethod = Literal["standard", "synthetic", "block"]
 DraftSampleMethod = Literal["greedy", "probabilistic"]
 
 
+_LLAMA_EAGLE3_DRAFT_ARCHITECTURES = frozenset(
+    ("Eagle3LlamaForCausalLM", "LlamaForCausalLMEagle3")
+)
+
+
+def _has_llama_eagle3_draft_architecture(
+    draft_model_config: ModelConfig | None,
+) -> bool:
+    if draft_model_config is None:
+        return False
+
+    architectures = getattr(draft_model_config, "architectures", None) or ()
+    if _LLAMA_EAGLE3_DRAFT_ARCHITECTURES.intersection(architectures):
+        return True
+
+    hf_config = getattr(draft_model_config, "hf_config", None)
+    hf_architectures = getattr(hf_config, "architectures", None) or ()
+    return bool(_LLAMA_EAGLE3_DRAFT_ARCHITECTURES.intersection(hf_architectures))
+
+
+def _should_default_rocm_eagle3_attention_backend(
+    method: SpeculativeMethod | None,
+    attention_backend: AttentionBackendEnum | None,
+    draft_model_config: ModelConfig | None,
+    *,
+    is_rocm: bool,
+) -> bool:
+    return (
+        is_rocm
+        and attention_backend is None
+        and method == "eagle3"
+        and _has_llama_eagle3_draft_architecture(draft_model_config)
+    )
+
+
 @config
 class SpeculativeConfig:
     """Configuration for speculative decoding."""
@@ -869,6 +904,8 @@ class SpeculativeConfig:
                 if self.method in ("dflash", "dspark"):
                     self.parallel_drafting = True
 
+                self._maybe_default_rocm_eagle3_attention_backend()
+
                 if self.num_speculative_tokens is not None and hasattr(
                     self.draft_model_config.hf_config, "num_lookahead_tokens"
                 ):
@@ -921,6 +958,23 @@ class SpeculativeConfig:
                     )
                 )
         return self
+
+    def _maybe_default_rocm_eagle3_attention_backend(self) -> None:
+        from vllm.platforms import current_platform
+
+        if not _should_default_rocm_eagle3_attention_backend(
+            self.method,
+            self.attention_backend,
+            self.draft_model_config,
+            is_rocm=current_platform.is_rocm(),
+        ):
+            return
+
+        self.attention_backend = AttentionBackendEnum.ROCM_AITER_UNIFIED_ATTN
+        logger.info_once(
+            "Using ROCM_AITER_UNIFIED_ATTN for ROCm EAGLE3 Llama draft model "
+            "attention. Set speculative_config.attention_backend to override."
+        )
 
     def _validate_suffix_decoding(self):
         if not has_arctic_inference():


### PR DESCRIPTION
This PR changes the default attention backend for ROCm EAGLE3 Llama draft models from the platform auto-selected `ROCM_ATTN` path to `ROCM_AITER_UNIFIED_ATTN`.

## Why

On ROCm, EAGLE3 Llama drafter attention currently resolves to `ROCM_ATTN` by default. For MiniMax-M3 EAGLE3 serving, that path is much slower than the available AITER unified-attention backend. The default should select the faster backend for this drafter family while still preserving explicit user overrides in `speculative_config.attention_backend`.

`ROCM_AITER_UNIFIED_ATTN` is also the most robust fast option here: `ROCM_AITER_FA` does not currently work for this stack because MiniMax-M3 requires block size `128`, while the backend only advertises `[16, 32]`. Forcing `128` experimentally allowed startup but failed at runtime in AITER `paged_attention_v1`, so it is not a valid replacement.

## Benchmark

Benchmark stack: upstream `main` + #47391 + this PR.

The code change in this PR does not depend on #47391, but the benchmark includes #47391 so MiniMax-M3 EAGLE3 acceptance and throughput are measured on the representative stack.

Note: These benchmark numbers were collected before recipes#621 clarified the nested `text_config` override. The command below is updated to the working form; the benchmark comparison remains comparable because all rows used the same config, but absolute tok/s should be rerun with nested index-topk reuse.

Server setup:
- Model: `amd/MiniMax-M3-MXFP4`
- Draft model: `Inferact/MiniMax-M3-EAGLE3`
- TP: 4
- Block size: 128
- Target attention backend: `TRITON_ATTN`
- Speculative tokens: 2
- KV cache dtype: `fp8`
- Dataset: random 8k input / 1k output
- Concurrency: 256
- Prompts: 2560

| Drafter backend | Status | Output tok/s/GPU | Total tok/s/GPU | Mean TPOT ms | P99 TPOT ms | Acceptance | Improvement vs `ROCM_ATTN` |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `ROCM_ATTN` | pass | 247.045 | 2328.647 | 253.811 | 392.013 | 68.84% | baseline |
| `TRITON_ATTN` | pass | 843.506 | 7950.873 | 71.576 | 108.118 | 67.91% | +241.44% |
| `ROCM_AITER_FA` | do not support Block size: 128 | n/a | n/a | n/a | n/a | n/a | n/a |
| `ROCM_AITER_UNIFIED_ATTN` | pass | 858.428 | 8091.533 | 70.158 | 107.299 | 67.89% | +247.48% |

`ROCM_AITER_UNIFIED_ATTN` is 3.47x the current `ROCM_ATTN` default and slightly faster than `TRITON_ATTN` on this workload.

## Test command

```bash
vllm serve amd/MiniMax-M3-MXFP4 \
  --tensor-parallel-size 4 \
  --trust-remote-code \
  --block-size 128 \
  --no-enable-prefix-caching \
  --language-model-only \
  --max-model-len 32768 \
  --attention-backend TRITON_ATTN \
  --moe-backend aiter \
  --tool-call-parser minimax_m3 \
  --enable-auto-tool-choice \
  --reasoning-parser minimax_m3 \
  --kv-cache-dtype fp8 \
  --hf-overrides '{"text_config": {"use_index_cache": true, "index_topk_freq": 4}}' \
  --speculative-config '{"method":"eagle3","model":"Inferact/MiniMax-M3-EAGLE3","num_speculative_tokens":2}' \
  --no-async-scheduling