### PR TITLE
[Bug] Fix Batched DeepGEMM

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/batched_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/batched_deep_gemm_moe.py
@@ -210,9 +210,6 @@ def persistent_masked_m_silu_mul_quant(
         DeepGemmQuantScaleFMT.UE8M0,
     ]
 
-    # Query the worker's own device (logical id 0). Passing y.device.index (a
-    # visible CUDA ordinal) would be misread as a logical id and index past a
-    # sharded assigned_physical_gpu_ids (e.g. external-LB DP).
     device_capability = current_platform.get_device_capability()
     assert device_capability is not None
     cuda_arch = device_capability.to_int()

--- a/vllm/model_executor/layers/fused_moe/experts/batched_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/batched_deep_gemm_moe.py
@@ -210,7 +210,10 @@ def persistent_masked_m_silu_mul_quant(
         DeepGemmQuantScaleFMT.UE8M0,
     ]
 
-    device_capability = current_platform.get_device_capability(device_id=y.device.index)
+    # Query the worker's own device (logical id 0). Passing y.device.index (a
+    # visible CUDA ordinal) would be misread as a logical id and index past a
+    # sharded assigned_physical_gpu_ids (e.g. external-LB DP).
+    device_capability = current_platform.get_device_capability()
     assert device_capability is not None
     cuda_arch = device_capability.to_int()
 


### PR DESCRIPTION
## Purpose
* recent PR that removed CUDA_VISIBLE_DEVICES internally seems to have intersected poorly

## Test Plan
```
launch_ll:
  vllm serve Qwen/Qwen3-30B-A3B-FP8 \
      --port 8200 \
      --disable-access-log-for-endpoints=/health,/metrics \
      --data-parallel-multi-port-external-lb \
      --data-parallel-supervisor-port=8208 \
      --enable-expert-parallel \
      --tensor-parallel-size 1 \
      --max-num-batched-tokens 256 \
      --max-num-seqs 256 \
      --data-parallel-size 2 \
      --data-parallel-size-local 2 \
      --data-parallel-rpc-port 5555 \
      --data-parallel-start-rank 0 \
      --moe-backend deep_gemm \
      --all2all-backend deepep_low_latency \
      --enforce-eager
```

## Test Result
no longer get a failure like:
```
(EngineCore_DP2 pid=1804) ERROR 07-02 15:37:42 [core.py:1231] RuntimeError: Worker failed with error 'device_id 2 is out of range for assigned_physical_gpu_ids [2] (1 devices assigned)', please check the stack trace above for the root cause
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

