### PR TITLE
[Bugfix] Avoid blocking model launching when no system ffmpeg available for TorchCodec

### DIFF
--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -14,10 +14,10 @@ import numpy.typing as npt
 import torch
 
 from vllm import envs
+from vllm.logger import init_logger
 from vllm.utils.import_utils import PlaceholderModule, check_torchcodec_available
 from vllm.utils.mem_constants import MiB_bytes
 from vllm.utils.registry import ExtensionManager
-
 
 try:
     import cv2
@@ -33,10 +33,13 @@ except ImportError:
 
 try:
     from torchcodec.decoders import VideoDecoder
-except (ImportError, RuntimeError) as e:
+except (ImportError, RuntimeError):
     VideoDecoder = PlaceholderModule("torchcodec").placeholder_attr(  # type: ignore[assignment]
         "decoders.VideoDecoder"
     )
+
+
+logger = init_logger(__name__)
 
 
 class VideoLoaderRegistry(ExtensionManager):

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -14,10 +14,10 @@ import numpy.typing as npt
 import torch
 
 from vllm import envs
-from vllm.logger import init_logger
-from vllm.utils.import_utils import PlaceholderModule
+from vllm.utils.import_utils import PlaceholderModule, check_torchcodec_available
 from vllm.utils.mem_constants import MiB_bytes
 from vllm.utils.registry import ExtensionManager
+
 
 try:
     import cv2
@@ -33,13 +33,10 @@ except ImportError:
 
 try:
     from torchcodec.decoders import VideoDecoder
-except ImportError:
+except (ImportError, RuntimeError) as e:
     VideoDecoder = PlaceholderModule("torchcodec").placeholder_attr(  # type: ignore[assignment]
         "decoders.VideoDecoder"
     )
-
-
-logger = init_logger(__name__)
 
 
 class VideoLoaderRegistry(ExtensionManager):
@@ -956,6 +953,7 @@ class VideoBackend(
             assert not frame_recovery, (
                 "frame_recovery is only available for `opencv` backend"
             )
+            check_torchcodec_available()
             decoder = cls.make_torchcodec_decoder(
                 data,
                 num_ffmpeg_threads=num_ffmpeg_threads,

--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -559,10 +559,10 @@ def check_torchcodec_available():
     try:
         import torchcodec  # noqa: F401
     except RuntimeError as e:
-        # Some modules (e.g. torchcodec) raise RuntimeError instead of
-        # ImportError when a native dependency fails to load, with a
-        # message that embeds a per-backend-version traceback dump.
-        # Trim it down to just the human-readable summary.
+        # torchcodec will raise RuntimeError during import instead
+        # of ImportError when system ffmpeg unavailable, with a
+        # message that can leak sensitive system information.
+        # Trim it down to avoid it.
         marker = (
             "The following exceptions were raised as we tried to load libtorchcodec:"
         )

--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -552,3 +552,19 @@ def has_cutedsl() -> bool:
 def has_humming() -> bool:
     """Whether the optional `humming` package is available."""
     return _has_module("humming")
+
+
+def check_torchcodec_available():
+    """Whether the optional `torchcodec` package is available."""
+    try:
+        import torchcodec  # noqa: F401
+    except RuntimeError as e:
+        # Some modules (e.g. torchcodec) raise RuntimeError instead of
+        # ImportError when a native dependency fails to load, with a
+        # message that embeds a per-backend-version traceback dump.
+        # Trim it down to just the human-readable summary.
+        marker = "The following exceptions were raised as we tried to load libtorchcodec:"
+        message = str(e)
+        if marker in message:
+            raise RuntimeError(message.split(marker, 1)[0].rstrip()) from None
+        raise e

--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -563,7 +563,9 @@ def check_torchcodec_available():
         # ImportError when a native dependency fails to load, with a
         # message that embeds a per-backend-version traceback dump.
         # Trim it down to just the human-readable summary.
-        marker = "The following exceptions were raised as we tried to load libtorchcodec:"
+        marker = (
+            "The following exceptions were raised as we tried to load libtorchcodec:"
+        )
         message = str(e)
         if marker in message:
             raise RuntimeError(message.split(marker, 1)[0].rstrip()) from None


### PR DESCRIPTION



## Purpose
- `import torchcodec` will raise RuntimeError when FFMPEG unavailable, which will block model launching even if `TorchCodec` is not specified.
- This PR catches it to only raise error at runtime to avoid blocking model launching.
```
$ vllm serve Qwen/Qwen3-VL-2B-Instruct
Traceback (most recent call last):
  File "/home/mozf/vllm/.venv/bin/vllm", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/mozf/vllm/vllm/entrypoints/cli/main.py", line 18, in main
    import vllm.entrypoints.cli.benchmark.main
  File "/home/mozf/vllm/vllm/entrypoints/cli/benchmark/main.py", line 10, in <module>
    from vllm.entrypoints.serve.utils.api_utils import VLLM_SUBCMD_PARSER_EPILOG
  File "/home/mozf/vllm/vllm/entrypoints/serve/utils/api_utils.py", line 20, in <module>
    from vllm.engine.arg_utils import EngineArgs
  File "/home/mozf/vllm/vllm/engine/arg_utils.py", line 119, in <module>
    from vllm.v1.sample.logits_processor import LogitsProcessor
  File "/home/mozf/vllm/vllm/v1/sample/logits_processor/__init__.py", line 15, in <module>
    from vllm.sampling_params import SamplingParams
  File "/home/mozf/vllm/vllm/sampling_params.py", line 23, in <module>
    from vllm.v1.serial_utils import PydanticMsgspecMixin
  File "/home/mozf/vllm/vllm/v1/serial_utils.py", line 25, in <module>
    from vllm.multimodal.inputs import (
  File "/home/mozf/vllm/vllm/multimodal/__init__.py", line 3, in <module>
    from .hasher import MultiModalHasher
  File "/home/mozf/vllm/vllm/multimodal/hasher.py", line 17, in <module>
    from .media import MediaWithBytes
  File "/home/mozf/vllm/vllm/multimodal/media/__init__.py", line 5, in <module>
    from .connector import MEDIA_CONNECTOR_REGISTRY, MediaConnector
  File "/home/mozf/vllm/vllm/multimodal/media/connector.py", line 28, in <module>
    from vllm.multimodal.video import get_video_loader_backend_for_processor
  File "/home/mozf/vllm/vllm/multimodal/video.py", line 35, in <module>
    from torchcodec.decoders import VideoDecoder
  File "/home/mozf/vllm/.venv/lib/python3.12/site-packages/torchcodec/__init__.py", line 12, in <module>
    from . import decoders, encoders, samplers, transforms  # noqa
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mozf/vllm/.venv/lib/python3.12/site-packages/torchcodec/decoders/__init__.py", line 7, in <module>
    from .._core import AudioStreamMetadata, VideoStreamMetadata
  File "/home/mozf/vllm/.venv/lib/python3.12/site-packages/torchcodec/_core/__init__.py", line 8, in <module>
    from ._metadata import (
  File "/home/mozf/vllm/.venv/lib/python3.12/site-packages/torchcodec/_core/_metadata.py", line 15, in <module>
    from torchcodec._core.ops import (
  File "/home/mozf/vllm/.venv/lib/python3.12/site-packages/torchcodec/_core/ops.py", line 38, in <module>
    load_torchcodec_shared_libraries()
  File "/home/mozf/vllm/.venv/lib/python3.12/site-packages/torchcodec/_internally_replaced_utils.py", line 111, in load_torchcodec_shared_libraries
    raise RuntimeError(
RuntimeError: Could not load libtorchcodec. Likely causes:
          1. FFmpeg is not properly installed in your environment. We support
             versions 4, 5, 6, 7, and 8, and we attempt to load libtorchcodec
             for each of those versions. Errors for versions not installed on
             your system are expected; only the error for your installed FFmpeg
             version is relevant. On Windows, ensure you've installed the
             "full-shared" version which ships DLLs.
          2. The PyTorch version (2.11.0+cu130) is not compatible with
             this version of TorchCodec. Refer to the version compatibility
             table:
             https://github.com/pytorch/torchcodec?tab=readme-ov-file#installing-torchcodec.
          3. Another runtime dependency; see exceptions below.

        The following exceptions were raised as we tried to load libtorchcodec:
        
[start of libtorchcodec loading traceback]
FFmpeg version 8:
Traceback (most recent call last):
  File "/home/mozf/vllm/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1503, in load_library
    ctypes.CDLL(path)
  File "/usr/lib/python3.12/ctypes/__init__.py", line 379, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: libavutil.so.60: cannot open shared object file: No such file or directory
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

