### PR TITLE
[Bugfix] Exclude DSpark draft KV-cache group from OffloadingConnector lookup poisoning

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -4062,3 +4062,151 @@ def test_mamba_reachable_block_mask_sparsifies_retention():
     assert retained(64) == {3, 7, 11, 14, 15}
     # interval 0 -> only the latest replay boundary (block 14).
     assert retained(0) == {14}
+
+
+def test_eagle_group_veto_exempt_does_not_poison_other_groups():
+    """A veto-exempt eagle group (KVCacheGroupSpec.eagle_group_is_veto_exempt,
+    e.g. DSpark's draft-context group per
+    SpeculativeConfig.has_ephemeral_draft_context()) whose lookup finds zero
+    matching blocks must not zero out another group's independently
+    confirmed hit. Regular eagle groups (EAGLE/EAGLE3/MTP/DFlash without the
+    veto-exempt flag) already zero the whole request on a miss, unchanged,
+    and are covered by test_prefill_hybrid_model_eagle and friends."""
+    block_size = 16
+    kv_cache_config = KVCacheConfig(
+        num_blocks=31,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer1"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["layer2"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=2 * block_size,
+                ),
+                is_eagle_group=True,
+                eagle_group_is_veto_exempt=True,
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+    )
+    hash_fn = sha256
+
+    # 4 full blocks (64 tokens), divisible by block_size for simplicity.
+    token_ids = [i for i in range(4) for _ in range(block_size)]
+    req0 = make_request("0", token_ids, block_size, hash_fn)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    manager.allocate_slots(req0, len(token_ids), num_computed_tokens, computed_blocks)
+    block_hashes = req0.block_hashes
+    manager.free(req0)
+
+    # New request with the same tokens: normally both groups would hit.
+    # Simulate the veto-exempt group's data being unavailable (e.g. DSpark's
+    # sparse, request-specific draft KV) by evicting all of ITS cached block
+    # hashes only, leaving the full-attention group's cache untouched.
+    req1 = make_request("1", token_ids, block_size, hash_fn)
+    group1_hashes = [make_block_hash_with_group_id(h, 1) for h in block_hashes]
+    cache = manager.block_pool.cached_block_hash_to_block._cache
+    backup = {h: cache.pop(h) for h in group1_hashes if h in cache}
+    try:
+        computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
+    finally:
+        for h, v in backup.items():
+            cache[h] = v
+
+    # Without the fix, the veto-exempt group's total miss would zero the
+    # whole request (num_computed_tokens == 0) despite the full-attention
+    # group having real, independently-confirmed data available. The
+    # presence of a sliding-window group reserves 1 token for logprobs
+    # (max_cache_hit_length = 63), so the full-attention group's hit aligns
+    # down to 3 blocks (48 tokens), not the full 4: that reservation is
+    # orthogonal to veto-exemption and applies regardless of this fix.
+    assert num_computed_tokens == 3 * block_size
+    assert len(computed_blocks.blocks[0]) == 3
+    # The veto-exempt group itself has nothing confirmed at this boundary.
+    assert len(computed_blocks.blocks[1]) == 0
+    manager.free(req1)
+
+
+def test_non_veto_exempt_eagle_group_miss_still_zeros_whole_request():
+    """Regression test: an eagle group WITHOUT eagle_group_is_veto_exempt
+    (the default, matching EAGLE/EAGLE3/MTP/DFlash) must still zero the
+    whole request on a total miss, exactly as before this change. Identical
+    setup to test_eagle_group_veto_exempt_does_not_poison_other_groups
+    except for the flag under test."""
+    block_size = 16
+    kv_cache_config = KVCacheConfig(
+        num_blocks=31,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer1"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["layer2"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=2 * block_size,
+                ),
+                is_eagle_group=True,
+                eagle_group_is_veto_exempt=False,
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+    )
+    hash_fn = sha256
+
+    token_ids = [i for i in range(4) for _ in range(block_size)]
+    req0 = make_request("0", token_ids, block_size, hash_fn)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    manager.allocate_slots(req0, len(token_ids), num_computed_tokens, computed_blocks)
+    block_hashes = req0.block_hashes
+    manager.free(req0)
+
+    req1 = make_request("1", token_ids, block_size, hash_fn)
+    group1_hashes = [make_block_hash_with_group_id(h, 1) for h in block_hashes]
+    cache = manager.block_pool.cached_block_hash_to_block._cache
+    backup = {h: cache.pop(h) for h in group1_hashes if h in cache}
+    try:
+        computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
+    finally:
+        for h, v in backup.items():
+            cache[h] = v
+
+    assert num_computed_tokens == 0
+    assert len(computed_blocks.blocks[0]) == 0
+    assert len(computed_blocks.blocks[1]) == 0
+    manager.free(req1)

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -31,6 +31,7 @@ from vllm.v1.kv_offload.base import (
     ReqContext,
     RequestOffloadingContext,
     get_offload_block_hash,
+    get_offload_group_idx,
     make_offload_key,
 )
 from vllm.v1.request import RequestStatus
@@ -2510,6 +2511,272 @@ class TestEagle:
                 (1, 0),
                 (1, 1),
             ),
+        )
+
+    def test_veto_exempt_eagle_group_does_not_poison_other_groups_lookup(
+        self, request_runner
+    ):
+        """A non-eagle group with a full real hit must not be zeroed out by
+        a co-existing veto-exempt eagle group (GroupOffloadConfig.
+        eagle_group_is_veto_exempt, e.g. DSpark's draft-context group)
+        whose own stored blocks are sparse/discontinuous, not just a single
+        volatile trailing block.
+
+        Setup: 2 full-attention groups, block_size=4, 3 blocks (12 tokens)
+        each.
+        - Group 0 (non-eagle): all 3 keys hit -> real, reusable content.
+        - Group 1 (eagle, veto-exempt): key at prefix position 0 is already
+          a MISS, so _maximal_prefix_lookup breaks on the very first key
+          regardless of whatever hits might exist later -> num_hit_blocks
+          == 0 for this group.
+
+        Without eagle_group_is_veto_exempt reaching this group, group 1
+        reporting 0 hits would hit the `if num_hit_blocks == 0: return 0`
+        short-circuit in _lookup(), discarding group 0's real 12-token hit,
+        so the result would be 0.
+
+        With eagle_group_is_veto_exempt=True, group 1 is dropped from the
+        rest of THIS lookup call the moment it reports 0 hits
+        (excluded_groups), but group 0, processed first, already
+        contributed its real hit before that happens. Result: 12 (group 0's
+        full hit, unaffected by group 1).
+        """
+        block_size = 4
+        groups = [
+            KVCacheGroupSpec(
+                ["layer0"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+                is_eagle_group=False,
+            ),
+            KVCacheGroupSpec(
+                ["layer1"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=2,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+                is_eagle_group=True,
+                eagle_group_is_veto_exempt=True,
+            ),
+        ]
+        runner = request_runner(
+            block_size=block_size,
+            num_gpu_blocks=100,
+            async_scheduling=False,
+            kv_cache_groups=groups,
+        )
+        sched = runner.connector_scheduler
+
+        # Group 0 keys {10,11,12}: all hit (real, reusable).
+        # Group 1 (eagle, veto-exempt) keys {1,2,3}: NONE hit, i.e.
+        # sparse/discontinuous storage, not merely "last block missing".
+        # Disjoint int ranges let a single side_effect distinguish which
+        # group a key belongs to, matching the convention already used by
+        # the sibling TestEagle tests above.
+        runner.manager.lookup.side_effect = lambda key, req_context: (
+            LookupResult.HIT
+            if int(get_offload_block_hash(key).decode()) in {10, 11, 12}
+            else LookupResult.MISS
+        )
+        req_status = self._make_req_status(
+            sched,
+            num_tokens=12,
+            offload_keys_per_group=[[10, 11, 12], [1, 2, 3]],
+        )
+
+        result = sched._lookup(req_status)
+
+        # Core regression assertion: group 0's real hit must survive group
+        # 1's (veto-exempt eagle) sparse/zero hit.
+        assert result == 12, (
+            "a veto-exempt eagle group's sparse/discontinuous storage must "
+            "not zero out a co-existing non-eagle group's real cache hit"
+        )
+
+        # Group 1 was actually queried (the exclusion drops a group only
+        # AFTER it reports 0 hits; it is not skipped up front). This is
+        # what makes the fix a no-op for eagle groups that DO hit: they are
+        # never excluded in the first place.
+        looked_up_hashes = {
+            int(get_offload_block_hash(call.args[0]).decode())
+            for call in runner.manager.lookup.call_args_list
+        }
+        assert looked_up_hashes & {1, 2, 3}, (
+            "expected group 1's keys to have been queried at least once "
+            "before being excluded"
+        )
+
+        # And it was recorded as excluded, for update_state_after_alloc to
+        # see.
+        assert req_status.lookup_excluded_groups == frozenset({1})
+
+    def test_non_veto_exempt_eagle_group_miss_still_zeros_whole_request(
+        self, request_runner
+    ):
+        """The exclusion branch must be unreachable for eagle-family groups
+        that are NOT veto-exempt (the default: EAGLE, EAGLE3, MTP, DFlash's
+        own incrementally-computed draft KV). Identical scenario to
+        test_veto_exempt_eagle_group_does_not_poison_other_groups_lookup
+        except eagle_group_is_veto_exempt is left at its default (False),
+        so a 0-hit eagle group must still zero out the entire request,
+        exactly as before this change.
+        """
+        block_size = 4
+        groups = [
+            KVCacheGroupSpec(
+                ["layer0"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+                is_eagle_group=False,
+            ),
+            KVCacheGroupSpec(
+                ["layer1"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=2,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+                is_eagle_group=True,
+                # eagle_group_is_veto_exempt left at its default: False.
+            ),
+        ]
+        runner = request_runner(
+            block_size=block_size,
+            num_gpu_blocks=100,
+            async_scheduling=False,
+            kv_cache_groups=groups,
+        )
+        sched = runner.connector_scheduler
+        assert sched.config.kv_group_configs[1].eagle_group_is_veto_exempt is False
+
+        runner.manager.lookup.side_effect = lambda key, req_context: (
+            LookupResult.HIT
+            if int(get_offload_block_hash(key).decode()) in {10, 11, 12}
+            else LookupResult.MISS
+        )
+        req_status = self._make_req_status(
+            sched,
+            num_tokens=12,
+            offload_keys_per_group=[[10, 11, 12], [1, 2, 3]],
+        )
+
+        result = sched._lookup(req_status)
+
+        assert result == 0, (
+            "eagle-family groups without eagle_group_is_veto_exempt must "
+            "keep the original all-or-nothing behavior unchanged: the "
+            "exclusion branch must never trigger for them"
+        )
+        # Nothing was ever excluded: the branch was never taken.
+        assert req_status.lookup_excluded_groups == frozenset()
+
+    @pytest.mark.parametrize("async_scheduling", [True, False])
+    def test_veto_exempt_eagle_group_load_excludes_only_the_failing_group(
+        self, request_runner, async_scheduling: bool
+    ):
+        """End-to-end: store phase is untouched (native "pop one trailing
+        block" behavior, exactly like test_full_attn_store_then_load), but
+        on reload the veto-exempt eagle group's blocks happen to all miss
+        (simulating DSpark's real sparse/non-reusable storage, as opposed to
+        a merely-volatile tail block). The non-eagle group must still load
+        its full, real hit, and the veto-exempt group must load NOTHING,
+        not the artificially-shrunk "N-1 blocks" the previous code would
+        have forced onto BOTH groups via the shared max_hit_size_tokens
+        intersection.
+
+        Compare directly against test_full_attn_store_then_load, which uses
+        a blanket `LookupResult.HIT` and gets `expected_loaded=((0,0),(0,1),
+        (1,0),(1,1))`: group 0's real 3-block hit gets dragged down to 2
+        blocks by group 1's (eagle) pop-adjusted hit. Here group 1 never
+        hits at all, so it is excluded outright and group 0 loads its full,
+        unconstrained 3-block hit instead.
+        """
+        block_size = 4
+        offloaded_block_size = block_size
+        num_gpu_blocks = 100
+
+        kv_cache_groups = [
+            KVCacheGroupSpec(
+                ["layer0"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["layer1"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=2,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+                is_eagle_group=True,
+                eagle_group_is_veto_exempt=True,
+            ),
+        ]
+
+        runner = request_runner(
+            block_size=block_size,
+            num_gpu_blocks=num_gpu_blocks,
+            async_scheduling=async_scheduling,
+            kv_cache_groups=kv_cache_groups,
+        )
+
+        # Store phase: identical to test_full_attn_store_then_load. This is
+        # a pure-prefill request (all prompt tokens, immediate EOS), so the
+        # pre-existing, untouched storable_blocks()/_build_store_jobs logic
+        # stores all 3 blocks for BOTH groups: the eagle group's trailing-
+        # block exclusion only kicks in once actually decoding. This change
+        # does not affect storage at all, for any eagle-family method.
+        runner.new_request(token_ids=[0] * offloaded_block_size * 3)
+        runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+            generate_store_output(keys)
+        )
+        runner.run(
+            decoded_tokens=[EOS_TOKEN_ID],
+            expected_stored=(
+                (0, 0),
+                (0, 1),
+                (0, 2),
+                (1, 0),
+                (1, 1),
+                (1, 2),
+            ),
+        )
+
+        runner.scheduler.reset_prefix_cache()
+
+        # Load phase: group 0 always hits; group 1 (eagle, veto-exempt)
+        # always misses, regardless of which of its (previously stored)
+        # blocks is queried: simulating storage that, in production,
+        # doesn't reliably round-trip.
+        runner.new_request(token_ids=[0] * offloaded_block_size * 3 + [1])
+        runner.manager.lookup.side_effect = lambda key, req_context: (
+            LookupResult.HIT if get_offload_group_idx(key) == 0 else LookupResult.MISS
+        )
+        runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+            generate_store_output([])
+        )
+        runner.run(
+            decoded_tokens=[EOS_TOKEN_ID],
+            # Group 0's real, unconstrained 3-block hit, NOT shrunk to 2 by
+            # group 1's failure. Group 1 loads nothing (excluded outright),
+            # so no (1, ...) entries appear at all.
+            expected_loaded=((0, 0), (0, 1), (0, 2)),
         )
 
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1249,6 +1249,27 @@ class SpeculativeConfig:
     def use_dspark(self) -> bool:
         return self.method == "dspark"
 
+    def has_ephemeral_draft_context(self) -> bool:
+        """Whether this method's draft-model KV-cache group is built from
+        the target model's auxiliary hidden states at generation time,
+        rather than incrementally through the draft's own attention over
+        previously-drafted tokens (EAGLE/EAGLE3/MTP).
+
+        Such a group's stored content has no request-independent, stable
+        meaning: it depends on which tokens were freshly computed by the
+        target vs. restored from cache during this specific serving
+        trajectory. A cache-hit-lookup miss on this group therefore does not
+        mean the group's data is genuinely unavailable for reuse the way it
+        does for other eagle-family groups, so it must not be treated as
+        authoritative when converging a multi-group cache-hit boundary (see
+        KVCacheGroupSpec.eagle_group_is_veto_exempt).
+
+        DFlash shares this same underlying property, but is intentionally
+        left out here: it has not been validated end to end in this PR, so
+        it is scoped to a follow-up rather than claimed for free.
+        """
+        return self.method in ("dspark",)
+
     def uses_dynamic_speculative_decoding(self) -> bool:
         return self.num_speculative_tokens_per_batch_size is not None
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -92,6 +92,12 @@ class GroupOffloadConfig(NamedTuple):
     # of these groups is volatile and lacks a stable hash, so it must
     # be excluded from store and load scheduling.
     is_eagle_group: bool = False
+    # Mirrors KVCacheGroupSpec.eagle_group_is_veto_exempt (see
+    # SpeculativeConfig.has_ephemeral_draft_context()). Only meaningful when
+    # is_eagle_group is True: whether a lookup miss on this group must not
+    # veto the whole request's lookup, because the group's stored content
+    # has no request-independent reuse value (DSpark today).
+    eagle_group_is_veto_exempt: bool = False
 
 
 def get_sliding_window_size_in_blocks(
@@ -175,6 +181,17 @@ class SchedulerOffloadConfig(NamedTuple):
             for idx, g in enumerate(spec.kv_cache_config.kv_cache_groups)
             if g.is_eagle_group
         }
+        # Subset of eagle_groups whose miss must not veto the rest of the
+        # lookup (see GroupOffloadConfig.eagle_group_is_veto_exempt). Left
+        # empty in the "flag all groups" fallback below, matching
+        # HybridKVCacheCoordinator's identical fallback for the same reason:
+        # per-group veto-exemption is unknown when no group was explicitly
+        # annotated, so we conservatively keep the original behavior.
+        veto_exempt_groups = {
+            idx
+            for idx, g in enumerate(spec.kv_cache_config.kv_cache_groups)
+            if g.is_eagle_group and g.eagle_group_is_veto_exempt
+        }
 
         use_eagle = (
             spec.vllm_config.speculative_config is not None
@@ -215,6 +232,7 @@ class SchedulerOffloadConfig(NamedTuple):
                         spec.kv_cache_config.kv_cache_groups[idx]
                     ),
                     is_eagle_group=idx in eagle_groups,
+                    eagle_group_is_veto_exempt=idx in veto_exempt_groups,
                 )
                 for idx, gpu_block_size in enumerate(spec.gpu_block_size)
             ),
@@ -251,6 +269,11 @@ class RequestOffloadState:
     # time.monotonic() of this request's first deferred offload lookup;
     # None once consumed (observed) or while no lookup is pending.
     deferred_lookup_start_time: float | None = None
+    # Group indices dropped from the most recent successful _lookup() call
+    # because they are veto-exempt eagle groups that reported 0 hit blocks
+    # (see GroupOffloadConfig.eagle_group_is_veto_exempt). Consumed by
+    # update_state_after_alloc to skip prepare_load for their keys.
+    lookup_excluded_groups: frozenset[int] = field(default_factory=frozenset)
 
     def __post_init__(self) -> None:
         self.group_states = tuple(
@@ -513,6 +536,16 @@ class OffloadingConnectorScheduler:
         groups (suffix lookup). Each group may tighten max_hit_size_tokens, which
         can invalidate an earlier group's result, so the loop re-runs when that
         happens until num_hit_tokens converges.
+
+        A veto-exempt eagle group (GroupOffloadConfig.eagle_group_is_veto_exempt,
+        mirroring HybridKVCacheCoordinator.find_longest_cache_hit's identical
+        mechanism) that reports zero hit blocks is dropped from the rest of
+        this lookup call instead of zeroing the whole request: such a group's
+        stored content has no request-independent reuse value, so its miss
+        does not mean the other groups' independently-confirmed hits are
+        unavailable. The excluded set is recorded on
+        req_status.lookup_excluded_groups so update_state_after_alloc knows
+        not to ask prepare_load for keys that were never confirmed present.
         """
         num_computed_tokens = req_status.num_locally_computed_tokens
         max_hit_size_tokens: int = req_status.req.num_tokens
@@ -535,6 +568,10 @@ class OffloadingConnectorScheduler:
         # in the current convergence iteration. Reset when a non-eagle group
         # tightens the hit boundary, requiring a fresh pop.
         eagle_verified: set[int] = set()
+        # Veto-exempt eagle groups dropped from this lookup call because they
+        # reported 0 hit blocks.
+        excluded_groups: set[int] = set()
+        req_status.lookup_excluded_groups = frozenset()
         while lookup_groups:
             looked_up_sliding_window: bool = False
             groups_iter = iter(lookup_groups)
@@ -600,6 +637,11 @@ class OffloadingConnectorScheduler:
                         req_status.req_context,
                     )
                 if num_hit_blocks == 0:
+                    if group_config.is_eagle_group and (
+                        group_config.eagle_group_is_veto_exempt
+                    ):
+                        excluded_groups.add(group_idx)
+                        continue
                     return 0
 
                 if num_hit_blocks is None:
@@ -626,14 +668,27 @@ class OffloadingConnectorScheduler:
                         # make another iteration on all groups to check
                         # if we still need to defer lookup
                         defer_lookup = False
-                        lookup_groups = self._lookup_groups
+                        # exclude groups already dropped this call: they'll
+                        # deterministically report 0 hits again (their data
+                        # hasn't changed).
+                        lookup_groups = tuple(
+                            g for g in self._lookup_groups if g not in excluded_groups
+                        )
                     elif looked_up_sliding_window and not lookup_groups:
                         # we need another iteration to confirm previously looked up
                         # sliding window works with the new_num_hit_tokens
-                        lookup_groups = self._sliding_window_groups
+                        lookup_groups = tuple(
+                            g
+                            for g in self._sliding_window_groups
+                            if g not in excluded_groups
+                        )
 
                 looked_up_sliding_window |= sliding_window_size_in_blocks is not None
                 num_hit_tokens = new_num_hit_tokens
+
+        # persist which groups this call dropped, so update_state_after_alloc
+        # knows not to load them.
+        req_status.lookup_excluded_groups = frozenset(excluded_groups)
 
         if defer_lookup:
             logger.debug(
@@ -647,6 +702,10 @@ class OffloadingConnectorScheduler:
             for group_config, group_state in zip(
                 self.config.kv_group_configs, req_status.group_states
             ):
+                # this group's keys were never confirmed present for the
+                # boundary num_hit_tokens settled on, nothing to check here.
+                if group_config.group_idx in excluded_groups:
+                    continue
                 offloaded_block_size = group_config.offloaded_block_size
                 sliding_window_size_in_blocks = (
                     group_config.sliding_window_size_in_blocks
@@ -770,6 +829,18 @@ class OffloadingConnectorScheduler:
             self._current_batch_allocated_block_ids.update(
                 block.block_id for block in group_blocks if block.block_id != 0
             )
+
+            # This group was dropped from the lookup that produced
+            # num_external_tokens (see _lookup()), so its keys for this hit
+            # boundary were never confirmed present. Report 0 pending blocks
+            # to keep group_sizes/block_indices index-aligned with
+            # blocks.blocks, without asking prepare_load for keys that were
+            # never verified: avoids `assert block is not None` in
+            # CPUOffloadingManager.prepare_load.
+            if group_config.group_idx in req_status.lookup_excluded_groups:
+                group_sizes.append(0)
+                block_indices.append(0)
+                continue
 
             gpu_block_size = group_config.gpu_block_size
             offloaded_block_size = group_config.offloaded_block_size

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -100,6 +100,17 @@ class KVCacheCoordinator(ABC):
         self.eagle_group_ids: set[int] = {
             i for i, g in enumerate(kv_cache_config.kv_cache_groups) if g.is_eagle_group
         }
+        # Subset of eagle_group_ids whose miss must not veto the cache-hit
+        # convergence of other groups (see KVCacheGroupSpec.
+        # eagle_group_is_veto_exempt). Left empty in the "flag all groups"
+        # fallback below: per-group veto-exemption is unknown in that case,
+        # so we conservatively preserve the original all-groups-authoritative
+        # behavior.
+        self.veto_exempt_eagle_group_ids: set[int] = {
+            i
+            for i, g in enumerate(kv_cache_config.kv_cache_groups)
+            if g.is_eagle_group and g.eagle_group_is_veto_exempt
+        }
         # Conservatively fall back to flag all groups when no group is flagged.
         if use_eagle and not self.eagle_group_ids:
             self.eagle_group_ids = set(range(len(kv_cache_config.kv_cache_groups)))
@@ -504,12 +515,20 @@ class SpecGroup(NamedTuple):
     ``use_eagle`` is True iff any member group is an EAGLE/MTP group. Members
     sharing a spec are cached and looked up jointly, so the EAGLE last-block drop
     is necessarily decided for the whole spec group.
+
+    ``veto_exempt`` is True only if EVERY member group is individually
+    veto-exempt (see KVCacheGroupSpec.eagle_group_is_veto_exempt), a
+    conservative AND, since exempting a merged group's miss also exempts it
+    for any non-exempt member sharing the same spec (in practice, members
+    that merge share an identical spec and thus an identical method-level
+    veto-exemption, so this is not expected to matter).
     """
 
     spec: KVCacheSpec
     group_ids: list[int]
     manager_cls: type[SingleTypeKVCacheManager]
     use_eagle: bool
+    veto_exempt: bool = False
 
 
 class HybridKVCacheCoordinator(KVCacheCoordinator):
@@ -584,6 +603,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             manager_cls = self.single_type_managers[i].__class__
             spec = g.kv_cache_spec
             use_eagle = i in self.eagle_group_ids
+            veto_exempt = i in self.veto_exempt_eagle_group_ids
 
             # Try to find an existing group with the same spec
             for idx, group in enumerate(self.attention_groups):
@@ -592,12 +612,21 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                         "Expected same manager class for identical KV cache specs."
                     )
                     group.group_ids.append(i)
-                    if use_eagle and not group.use_eagle:
-                        self.attention_groups[idx] = group._replace(use_eagle=True)
+                    new_use_eagle = group.use_eagle or use_eagle
+                    # AND-merge: a merged group is only veto-exempt if every
+                    # member is (conservative, see SpecGroup docstring).
+                    new_veto_exempt = group.veto_exempt and veto_exempt
+                    if (
+                        new_use_eagle != group.use_eagle
+                        or new_veto_exempt != group.veto_exempt
+                    ):
+                        self.attention_groups[idx] = group._replace(
+                            use_eagle=new_use_eagle, veto_exempt=new_veto_exempt
+                        )
                     break
             else:
                 self.attention_groups.append(
-                    SpecGroup(spec, [i], manager_cls, use_eagle)
+                    SpecGroup(spec, [i], manager_cls, use_eagle, veto_exempt)
                 )
 
         assert len(self.attention_groups) > 1, (
@@ -657,6 +686,14 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         types. This converges because length monotonically decreases and is
         bounded below by 0.
 
+        A veto-exempt eagle group (SpecGroup.veto_exempt, see
+        KVCacheGroupSpec.eagle_group_is_veto_exempt) whose lookup finds
+        exactly zero matching blocks for the current candidate length is
+        left unconfirmed for this round instead of shrinking
+        ``curr_hit_length`` to 0: such a group's stored content has no
+        request-independent reuse value, so a miss from it does not mean
+        the other, independently-confirmed groups' data is unavailable.
+
         Args:
             block_hashes: The block hashes of the request.
             max_cache_hit_length: The maximum length of the cache hit.
@@ -693,8 +730,8 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         while True:
             curr_hit_length = hit_length
 
-            for idx, (spec, group_ids, manager_cls, use_eagle) in enumerate(
-                self.attention_groups
+            for idx, (spec, group_ids, manager_cls, use_eagle, veto_exempt) in (
+                enumerate(self.attention_groups)
             ):
                 group_block_size = self.single_type_managers[group_ids[0]].block_size
                 cached_blocks = hit_blocks_by_group[group_ids[0]]
@@ -730,6 +767,10 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     ),
                 )
                 _new_hit_length = len(hit_blocks[0]) * group_block_size
+                if veto_exempt and _new_hit_length == 0:
+                    # Not authoritative: leave unconfirmed for this round
+                    # rather than vetoing every other group's confirmed hit.
+                    continue
                 if drop_eagle_block:
                     eagle_verified.add(idx)
                 elif _new_hit_length < curr_hit_length:
@@ -787,7 +828,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         hit_blocks: list[list[KVCacheBlock]] = [[] for _ in range(num_groups)]
         hit_lengths: list[int] = [0] * num_groups
 
-        for spec, group_ids, manager_cls, use_eagle in self.attention_groups:
+        for spec, group_ids, manager_cls, use_eagle, _veto_exempt in self.attention_groups:
             blocks = manager_cls.find_longest_cache_hit(
                 block_hashes=_get_block_hashes(spec),
                 max_length=max_cache_hit_length,

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1713,6 +1713,9 @@ def _annotate_eagle_groups_deepseek_v4(
     for group in kv_cache_groups:
         if last_layer in group.layer_names:
             group.is_eagle_group = True
+            group.eagle_group_is_veto_exempt = (
+                spec_config.has_ephemeral_draft_context()
+            )
             break
 
 
@@ -2019,6 +2022,8 @@ def _project_kv_cache_groups_to_worker(
                 worker_layer_names,
                 group_spec,
                 is_eagle_group=group.is_eagle_group and bool(worker_layer_names),
+                eagle_group_is_veto_exempt=group.eagle_group_is_veto_exempt
+                and bool(worker_layer_names),
             )
         )
     return projected_groups

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -951,6 +951,14 @@ class KVCacheGroupSpec:
     kv_cache_spec: KVCacheSpec
     # Whether this group contains EAGLE/MTP draft attention layers.
     is_eagle_group: bool = False
+    # Only meaningful when is_eagle_group is True. Whether a cache-hit-lookup
+    # miss on this eagle group is NOT authoritative and must not veto the
+    # cache-hit boundary that other (non-exempt) groups independently
+    # confirmed. See SpeculativeConfig.has_ephemeral_draft_context(): set for
+    # eagle-family methods whose draft KV has no request-independent reuse
+    # value (DSpark today), as opposed to methods like EAGLE/EAGLE3/MTP
+    # whose draft KV is genuinely, incrementally reusable.
+    eagle_group_is_veto_exempt: bool = False
 
 
 @dataclass


### PR DESCRIPTION
Fixes #47890

### Purpose

When serving **DeepSeek-V4-Flash-DSpark** with the native `OffloadingConnector`
(RAM-tier KV cache offload), the external (RAM-tier) prefix cache never records a
hit: `vllm:external_prefix_cache_hits_total` stays at exactly `0` for the
lifetime of the server, while `vllm:external_prefix_cache_queries_total` grows
into the millions and `vllm:kv_offload_store_bytes_total` grows into the hundreds
of GB (i.e. the RAM tier is writing data, just never successfully reading it back).

**Root cause**: DSpark's draft-model KV-cache group is flagged an eagle group,
same as EAGLE/EAGLE3/MTP/DFlash. The multi-group cache-hit lookup (both the core
`HybridKVCacheCoordinator.find_longest_cache_hit()` and the offloading
connector's `_lookup()`, which independently reimplements the same
AND-convergence algorithm) requires *every* KV-cache group to report a nonzero
hit; any single group reporting zero short-circuits the **entire request's**
lookup to zero. DSpark's draft-layer KV is recomputed from the target model's
real hidden state every decode step
(`DSparkDeepseekV4Model.precompute_and_store_context_kv`), so it has no
cross-request reuse value: its stored blocks are sparse and discontinuous
throughout (confirmed via per-key debug tracing: real `HIT`s exist but scattered
among mostly `MISS`, e.g. `[MISS, MISS, HIT, MISS, MISS]`), never satisfying the
consecutive-hit window the lookup requires. This permanently poisons the
AND-combination for the whole request, even though the model's real KV-cache
groups (SWA, compressed C4A/C128A, indexer) independently measure a working
hit rate around 89% once isolated from this effect, matching the 82.9%
end to end hit rate reproduced under this PR's fix (see Testing below).

### What this PR changes

An earlier version of this PR fixed only `OffloadingConnectorScheduler._lookup()`
with a bespoke `is_dspark` flag. Per maintainer feedback, that was the wrong
layer: the connector reimplements the same AND-convergence algorithm the core
`HybridKVCacheCoordinator` owns, so a fix living only in the connector is not a
general mechanism and does not mirror the core's own behavior. This version
redesigns the fix to live in the core first, with the connector mirroring it
exactly, and with no method name special-cased inside either lookup algorithm.

- `SpeculativeConfig.has_ephemeral_draft_context()` (new, `vllm/config/speculative.py`):
  a predicate on the speculative-decoding method itself, following the same
  pattern as the existing `use_dflash()` / `use_dspark()` methods. Returns
  `True` when a method's draft-model KV-cache group is rebuilt from the target
  model's auxiliary hidden states at generation time, rather than accumulated
  incrementally through the draft's own attention (EAGLE/EAGLE3/MTP). Scoped to
  `"dspark"` only in this PR (see "Scope" below).
- `KVCacheGroupSpec.eagle_group_is_veto_exempt` (new, `vllm/v1/kv_cache_interface.py`):
  a plain boolean field, computed once from the predicate above wherever
  `is_eagle_group` is already set (`vllm/v1/core/kv_cache_utils.py`).
- `HybridKVCacheCoordinator.find_longest_cache_hit()` (`vllm/v1/core/kv_cache_coordinator.py`,
  **the primary fix**): when a veto-exempt eagle group reports zero hit blocks
  in a round, that group is dropped from the round instead of zeroing the
  whole request's confirmed hit length. It still participates normally in every
  other round, including any round where it reports a nonzero hit.
- `vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py`
  (mirror): `GroupOffloadConfig` carries the same `eagle_group_is_veto_exempt`
  field read directly from the core `KVCacheGroupSpec` (no separate `is_dspark`
  flag). `_lookup()`'s `num_hit_blocks == 0` branch excludes the group instead
  of returning `0` for the whole request; `update_state_after_alloc()` skips
  `prepare_load` for excluded groups so it never asks for keys that were never
  confirmed present for the hit boundary the other groups settled on (this is
  what avoids `assert block is not None` in `CPUOffloadingManager.prepare_load`).

Neither `find_longest_cache_hit()` nor `_lookup()` contains a single
method-name string comparison; both derive the exemption from the same
core-owned `KVCacheGroupSpec.eagle_group_is_veto_exempt` field, computed once.

### `eagle_group_is_veto_exempt` does not mean "excluded from the lookup"

Worth stating explicitly, since it is easy to misread as a bigger behavior
change than it is: a veto-exempt group's hit length is still computed every
round exactly like any other group's. The exemption only changes what happens
when that computed hit length is zero: normally a zero from any group vetoes
(truncates to zero) every other group's independently confirmed hit; for a
group whose KV has no request-independent, stable meaning, a zero is not
informative about whether the target model's own groups have a real, reusable
hit, so it is left unconfirmed for that round instead of zeroing everyone
else. A nonzero hit from the same group participates in the AND-convergence
exactly like before, with no special casing.

### Why this has no downside for DSpark, unlike EAGLE/EAGLE3/MTP

Worth walking through explicitly, since exempting a group from the lookup's
veto power could sound like it costs something. It does not, for DSpark
specifically, and the reason is a real architectural difference from the
other eagle-family methods rather than an assumption.

EAGLE/EAGLE3/MTP's draft model runs its own causal self-attention over
tokens it has itself drafted, the same way the target model attends over its
own history. Once a draft token's KV is computed, it stays valid for the
rest of the request, and is genuinely reusable across requests that share a
prefix. That KV has real, durable, request-independent value, which is
exactly why the lookup is right to require a nonzero hit from those groups
before confirming a reuse boundary.

DSpark's draft context KV works differently. `DSparkDeepseekV4Model.precompute_and_store_context_kv`
(`vllm/models/deepseek_v4/nvidia/dspark.py`) derives each draft layer's
context KV directly from the target model's own auxiliary hidden states at
that exact decode step, and writes it into that layer's context slots. This
runs once per drafting round: the target produces real hidden states, DSpark
projects and writes fresh context KV from them, the draft model attends over
that freshly written context to produce this round's speculative tokens,
and then the next round overwrites those same slots again from the target's
next hidden states. It is a write-then-immediately-consume-within-round
buffer, not an incrementally accumulated cache. Because its content is tied
to the target's hidden state at one specific instant, it stops being valid
the moment the target produces new real tokens, whether that is later in
the same request or in an entirely different request. There is no window in
which reusing it would be meaningful, so it is not that this PR forfeits
some reuse opportunity DSpark had. It never had one to begin with; this
group's zero hit rate on cross-request lookups is the expected, permanent
steady state for this method, and the fix simply stops that from being
misread as "nothing in this request is reusable."

### Scope

Two independent scope boundaries worth being explicit about.

**Speculative method: DSpark only, DFlash is a follow-up.** DFlash's drafter
builds its context KV from the target model's auxiliary hidden states the
same way DSpark's does, so `has_ephemeral_draft_context()` could mechanically
be extended to cover `"dflash"` with a one-line change. This PR deliberately
does not do that: DFlash has not been validated end to end against this
mechanism in a live server (blocked on an unrelated attention-backend /
KV-cache-dtype compatibility gap for the DeepSeek-V4 target, plus a
checkpoint-architecture mismatch for the specific community DFlash checkpoint
available, both hit before ever reaching this code path), so claiming the fix
for DFlash here would be a claim without evidence. Extending the predicate to
`"dflash"` is left for a small follow-up once that validation exists.

**Model architecture: the whole DeepSeek-V4 family (Flash, Pro, and any
other size variant), not size-specific.** `eagle_group_is_veto_exempt` is
only ever set inside `_annotate_eagle_groups_deepseek_v4` (pre-existing code,
`vllm/v1/core/kv_cache_utils.py`), which is itself hard-scoped to
`model_version == "deepseek_v4"`. That value is set in exactly one place,
`vllm/models/deepseek_v4/attention.py`, shared by the whole
`DeepseekV4ForCausalLM` architecture regardless of which size variant is
loaded, so this is not limited to Flash specifically. Every other model
architecture outside this family falls back to a different, pre-existing
path that flags all groups as `is_eagle_group` uniformly and never touches
this new field, so this PR has no effect there, inherited from that existing
scoping rather than something this PR chose to narrow further.

### Testing

Local verification (not a substitute for CI, reported here to speed up
review while CI runs): rebased onto current main and run inside an isolated
throwaway container (source `.py` tree synced over an installed `vllm` build
to avoid needing a full rebuild).

| Suite | Result |
|---|---|
| `tests/v1/core/test_prefix_caching.py` | 83 passed |
| `tests/v1/core/` (full directory, 2 GPUs) | 400 passed, 0 failed |
| `tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py` | 91 passed |
| `tests/v1/kv_connector/unit/offloading_connector/` + `tests/v1/simple_kv_offload/` (excluding `slow_test`) | 165 passed, 8 deselected |

Also validated live: served DeepSeek-V4-Flash-DSpark with this patch behind
`OffloadingConnector` for a 600s / 64-concurrency cold run. All requests
completed successfully (0 failures out of 7712), and the external (RAM-tier)
cache hit rate measured 82.9%, no longer stuck at 0 as described above.
