### PR TITLE
[Bugfix] Size numpy arrays by nbytes in multimodal cache accounting

### DIFF
--- a/vllm/multimodal/cache.py
+++ b/vllm/multimodal/cache.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping, Sequence
 from multiprocessing.synchronize import Lock as LockType
 from typing import TYPE_CHECKING, Generic, TypeAlias, TypeVar, cast
 
+import numpy as np
 import torch
 from typing_extensions import override
 
@@ -110,8 +111,10 @@ class MultiModalCache:
         ):
             return cls.get_item_size(leaf.data)  # type: ignore
 
-        # sys.getsizeof doesn't work for tensors
+        # sys.getsizeof doesn't work for tensors or numpy arrays
         if isinstance(leaf, torch.Tensor):
+            return leaf.nbytes
+        if isinstance(leaf, np.ndarray):
             return leaf.nbytes
 
         return sys.getsizeof(leaf)


### PR DESCRIPTION
`MultiModalCache.get_leaf_size` sizes `torch.Tensor` via `.nbytes` but falls through to `sys.getsizeof` for `np.ndarray`, which returns only the object header (~112 bytes), not the buffer. Numpy leaves stored in the byte-budgeted LRU (`MultiModalProcessor/ReceiverCache`) are under-counted by orders of magnitude, so the cache does not evict them and host memory grows unbounded.

Size `np.ndarray` by `.nbytes`, mirroring the existing `torch.Tensor` branch.