### PR TITLE
[DSv4] Work around FlashInfer packed KV stride

### DIFF
--- a/vllm/models/deepseek_v4/common/ops/cache_utils.py
+++ b/vllm/models/deepseek_v4/common/ops/cache_utils.py
@@ -649,6 +649,7 @@ def build_flashinfer_mixed_sparse_indices(
     swa_block_size: int,
     compressed_block_table: torch.Tensor | None,
     compressed_block_size: int,
+    page_stride_token_stride_ratio: int,
     window_size: int,
     compress_ratio: int,
     topk: int,
@@ -751,6 +752,7 @@ def build_flashinfer_mixed_sparse_indices(
         compressed_block_table,
         compressed_block_table.stride(0),
         compressed_block_size,
+        page_stride_token_stride_ratio,
         NUM_DECODE_TOKENS=num_decode_tokens,
         WINDOW_SIZE=window_size,
         COMPRESS_RATIO=compress_ratio,
@@ -767,6 +769,18 @@ def build_flashinfer_mixed_sparse_indices(
     return sparse_indices, sparse_topk_lens
 
 
+@triton.jit
+def _remap_flashinfer_index(values, block_size, page_stride_token_stride_ratio):
+    # FlashInfer's DSv4 kernel interprets sparse indices in physical token-stride
+    # units, so packed KV cache pages need page_stride / token_stride remapping.
+    # TODO: remove this workaround once flashinfer-ai/flashinfer#3856 is fixed.
+    is_valid = values >= 0
+    safe_values = tl.where(is_valid, values, 0)
+    values = (safe_values // block_size) * page_stride_token_stride_ratio
+    values += safe_values % block_size
+    return tl.where(is_valid, values, -1)
+
+
 @triton.jit(
     do_not_specialize=[
         "sparse_indices_stride",
@@ -777,6 +791,7 @@ def build_flashinfer_mixed_sparse_indices(
         "swa_block_size",
         "compressed_block_table_stride",
         "compressed_block_size",
+        "page_stride_token_stride_ratio",
         "NUM_DECODE_TOKENS",
         "PREFILL_TOPK_STRIDE",
     ]
@@ -802,6 +817,7 @@ def _build_flashinfer_mixed_sparse_indices_kernel(
     compressed_block_table_ptr,
     compressed_block_table_stride,
     compressed_block_size,
+    page_stride_token_stride_ratio,
     NUM_DECODE_TOKENS,
     WINDOW_SIZE: tl.constexpr,
     COMPRESS_RATIO: tl.constexpr,
@@ -815,6 +831,8 @@ def _build_flashinfer_mixed_sparse_indices_kernel(
     TOPK_BLOCK_SIZE: tl.constexpr,
 ):
     token_idx = tl.program_id(0)
+    ps_ratio = page_stride_token_stride_ratio
+    c_block_size = compressed_block_size
 
     if token_idx < NUM_DECODE_TOKENS:
         for i in range(0, WINDOW_SIZE, WINDOW_BLOCK_SIZE):
@@ -825,6 +843,7 @@ def _build_flashinfer_mixed_sparse_indices_kernel(
                 mask=mask,
                 other=-1,
             )
+            values = _remap_flashinfer_index(values, swa_block_size, ps_ratio)
             tl.store(
                 sparse_indices_ptr + token_idx * sparse_indices_stride + offset,
                 values,
@@ -858,6 +877,7 @@ def _build_flashinfer_mixed_sparse_indices_kernel(
                 values = block_numbers * compressed_block_size + block_offsets
                 values = tl.where(is_valid, values, -1)
                 compressed_len += tl.sum((is_valid & token_valid).to(tl.int32), axis=0)
+            values = _remap_flashinfer_index(values, c_block_size, ps_ratio)
             tl.store(
                 sparse_indices_ptr
                 + token_idx * sparse_indices_stride
@@ -904,6 +924,7 @@ def _build_flashinfer_mixed_sparse_indices_kernel(
         block_offsets = pos_offset % swa_block_size
         slot_ids = block_numbers * swa_block_size + block_offsets
         slot_ids = tl.where(offset < swa_len, slot_ids, -1)
+        slot_ids = _remap_flashinfer_index(slot_ids, swa_block_size, ps_ratio)
         tl.store(
             sparse_indices_ptr + token_idx * sparse_indices_stride + offset,
             slot_ids,
@@ -930,6 +951,7 @@ def _build_flashinfer_mixed_sparse_indices_kernel(
         block_offsets = local_idx % compressed_block_size
         slot_ids = block_numbers * compressed_block_size + block_offsets
         slot_ids = tl.where((offset < topk_len) & is_valid, slot_ids, -1)
+        slot_ids = _remap_flashinfer_index(slot_ids, c_block_size, ps_ratio)
         tl.store(
             sparse_indices_ptr
             + token_idx * sparse_indices_stride

--- a/vllm/models/deepseek_v4/nvidia/flashinfer_sparse.py
+++ b/vllm/models/deepseek_v4/nvidia/flashinfer_sparse.py
@@ -368,6 +368,9 @@ class DeepseekV4FlashInferMLAAttention(DeepseekV4Attention):
         )
         cached_sparse = swa_metadata.flashinfer_sparse_index_cache.get(cache_key, None)
         if cached_sparse is None:
+            page_stride_token_stride_ratio = swa_k_cache.stride(
+                0
+            ) // swa_k_cache.stride(1)
             sparse_indices, sparse_topk_lens = build_flashinfer_mixed_sparse_indices(
                 decode_swa_indices,
                 decode_compressed_indices,
@@ -380,6 +383,7 @@ class DeepseekV4FlashInferMLAAttention(DeepseekV4Attention):
                 swa_metadata.block_size,
                 compressed_block_table,
                 compressed_block_size,
+                page_stride_token_stride_ratio,
                 self.window_size,
                 self.compress_ratio,
                 top_k,

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1274,6 +1274,25 @@ def _use_packed_kv_cache_config(
     return is_dsv4 or (enable_cross_layers and len(kv_cache_groups) > 1)
 
 
+# TODO: remove this workaround once flashinfer-ai/flashinfer#3856 is fixed.
+# DSv4 FlashInfer SM100 token stride: 512B fp8 or 1024B bf16.
+def _align_packed_block_stride_for_flashinfer_dsv4(
+    vllm_config: VllmConfig,
+    block_stride: int,
+) -> int:
+    from vllm.platforms import current_platform
+    from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+    capability = current_platform.get_device_capability()
+    if getattr(
+        getattr(vllm_config, "attention_config", None), "backend", None
+    ) == AttentionBackendEnum.FLASHINFER_MLA_SPARSE_DSV4 and (
+        capability is None or capability.major != 12
+    ):
+        return round_up(block_stride, 1024)
+    return block_stride
+
+
 def _get_kv_cache_config_packed(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
@@ -1289,6 +1308,9 @@ def _get_kv_cache_config_packed(
     # buckets = {page_size: [[layer_names], [layer_names], ...]}
     buckets = _bucket_layers_by_page_size(kv_cache_groups)
     total_num_bytes_per_block = sum(ps * len(slots) for ps, slots in buckets.items())
+    total_num_bytes_per_block = _align_packed_block_stride_for_flashinfer_dsv4(
+        vllm_config, total_num_bytes_per_block
+    )
 
     num_blocks = available_memory // total_num_bytes_per_block
     num_blocks = may_override_num_blocks(vllm_config, num_blocks)


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/47783

## Summary

- pad the packed DSv4 KV block stride for `FLASHINFER_MLA_SPARSE_DSV4` on SM100 so the page stride can be represented as `page_stride / token_stride`
- remap FlashInfer sparse indices inside `build_flashinfer_mixed_sparse_indices` using `page_stride_token_stride_ratio` before dispatch
- mark both pieces as temporary workarounds until flashinfer-ai/flashinfer#3856 is fixed

## Existing related PRs:

- #47493 is a draft bugfix for DSv4 garbage output.
- #47805 disables packed KV for the FlashInfer backend.

This draft is materially different from #47805: it keeps the packed KV layout enabled and works around FlashInfer's current lack of page/block stride support by padding the packed block stride and remapping sparse indices before dispatch. I also left that distinction on #47783: https://github.com/vllm-project/vllm/issues/47783#issuecomment-4906135961

## AI assistance

AI assistance was used to investigate and prepare this draft. 