### PR TITLE
[CI/Build] Accept ready-run-all-tests label in pre-commit gate

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,7 +28,8 @@ jobs:
             pull_number: context.payload.pull_request.number,
           });
 
-          const hasReadyLabel = pr.labels.some(l => l.name === 'ready');
+          const readyLabels = ['ready', 'ready-run-all-tests'];
+          const hasReadyLabel = pr.labels.some(l => readyLabels.includes(l.name));
           const hasVerifiedLabel = pr.labels.some(l => l.name === 'verified');
 
           const { data: mergedPRs } = await github.rest.search.issuesAndPullRequests({
@@ -40,7 +41,7 @@ jobs:
           if (hasReadyLabel || hasVerifiedLabel || mergedCount >= 4) {
             core.info(`Check passed: verified label=${hasVerifiedLabel}, ready label=${hasReadyLabel}, 4+ merged PRs=${mergedCount >= 4}`);
           } else {
-            core.setFailed(`PR must have the 'verified' or 'ready' (which also triggers tests) label or the author must have at least 4 merged PRs (found ${mergedCount}).`);
+            core.setFailed(`PR must have the 'verified', 'ready', or 'ready-run-all-tests' label (the ready labels also trigger tests) or the author must have at least 4 merged PRs (found ${mergedCount}).`);
           }
 
   pre-commit:


### PR DESCRIPTION
## Purpose

The `pre-commit` workflow's `pre-run-check` gate only recognizes the `ready` and `verified` labels. The newer `ready-run-all-tests` label is strictly stronger than `ready` (it triggers the full Buildkite suite), but the gate doesn't know it exists — so when a maintainer *replaces* `ready` with `ready-run-all-tests`, the pre-commit check goes red with the label-gate error for any author with fewer than 4 merged PRs, even though no hooks ran.

Observed on #47669: `ready` was swapped for `ready-run-all-tests` and pre-commit failed with `PR must have the 'verified' or 'ready' (which also triggers tests) label or the author must have at least 4 merged PRs (found 2).` while the Buildkite-side pre-commit job on the same head passed.

This change treats `ready-run-all-tests` as satisfying the gate, same as `ready`, and updates the failure message.

## Test Plan

Two-line change to the gate script inside the workflow. YAML validated; embedded script syntax-checked with `node --check`. The workflow already re-runs on `labeled` events, so behavior is exercised on the next label add.

## Test Result

N/A (workflow-only change; takes effect once merged to main).


## AI Assistance Disclosure

Developed with AI assistance (Claude); all changes reviewed and validated by the author. The commit carries a `Co-authored-by: Claude` trailer per the [AI-assisted contributions policy](https://docs.vllm.ai/en/latest/contributing/#ai-assisted-contributions).
