### PR TITLE
[CI Bug Fix] Temp fix for v3.2 accuracy

### DIFF
--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -652,6 +652,7 @@ class ParallelConfig:
             )
             and self.enable_expert_parallel
             and self.tensor_parallel_size > 1
+            and self.data_parallel_size > 1
         )
 
     @property


### PR DESCRIPTION
## Purpose

```bash
FAILED evals/gsm8k/test_gsm8k_correctness.py::test_gsm8k_correctness[DeepSeek-R1-TP] - AssertionError: GSM8K metric too low: 0.0000 < 0.9500 - 0.0800 = 0.8700
assert np.float64(0.0) >= (0.95 - 0.08)
FAILED evals/gsm8k/test_gsm8k_correctness.py::test_gsm8k_correctness[DeepSeek-V3.2-TP] - AssertionError: GSM8K metric too low: 0.0000 < 0.9500 - 0.0800 = 0.8700
assert np.float64(0.0) >= (0.95 - 0.08)
```

https://buildkite.com/vllm/ci/builds/76393/list?sid=019f3415-e06a-4286-8b5b-eae99cb5095e&tab=output

Temple fix for v3.2 accuracy

I will look further about this and fix throughly

## Test

`vllm serve deepseek-ai/DeepSeek-V3.2   --trust-remote-code   --kernel-config.enable_flashinfer_autotune=False   --enable-expert-parallel   --tensor-parallel-size 8   --tokenizer-mode deepseek_v32   --tool-call-parser deepseek_v32   --enable-auto-tool-choice   --reasoning-parser deepseek_v3 --port 9256   --speculative-config '{"method":"mtp","num_speculative_tokens":3}'`

`lm_eval --model local-completions --model_args "base_url=http://127.0.0.1:9256/v1/completions,model=$MODEL,num_concurrent=1024" --tasks gsm8k`

Now

```bash
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9545|±  |0.0057|
|     |       |strict-match    |     5|exact_match|↑  |0.9530|±  |0.0058|
```


