### PR TITLE
[Bugfix] Allow non-contiguous query in FlashInfer FP8 query quantization

### DIFF
--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1584,11 +1584,11 @@ class FlashInferImpl(AttentionImpl):
         if query.dtype != q_data_type:
             assert query.dtype in [torch.float16, torch.bfloat16]
             assert q_data_type in [torch.float8_e4m3fn, torch.float8_e5m2]
-            assert query.is_contiguous()
             assert query.dim() == 3
             num_tokens = query.shape[0]
             num_heads = query.shape[1]
             head_size = query.shape[2]
+            assert query.stride(2) == 1 and query.stride(1) == head_size
             query_quantized, _ = custom_ops.scaled_fp8_quant(
                 query.view(num_tokens, num_heads * head_size), scale=scale
             )


### PR DESCRIPTION
Fix #47905 

## Purpose

Fix an `AssertionError` in the FlashInfer attention backend when running models that slice their query from a fused QKV projection (e.g. Nemotron) with FP8 KV cache.

#43232 moved the query→FP8 quantization inline into `FlashInferImpl.maybe_quant_query`, guarded by `assert query.is_contiguous()`. Models such as Nemotron produce their query via `q, k, v = qkv.split(...)`, which returns a **view** into the fused QKV tensor. That view has a token-dim stride equal to the full QKV width, so the query is non-contiguous and trips the assert on the native FlashInfer FP8 prefill/decode path:

```
File ".../flashinfer.py", line 1587, in maybe_quant_query
    assert query.is_contiguous()
AssertionError
```

The assert is over-strict. Both `query.view(num_tokens, num_heads * head_size)` and the `scaled_fp8_quant` kernel only require that the per-token `(num_heads, head_size)` block is contiguous — the token-dim stride is free (the kernel reads it from `stride(-2)` and only requires `stride(-1) == 1`). This PR replaces the contiguity assert with that precise precondition (`query.stride(2) == 1 and query.stride(1) == head_size`), keeping the existing zero-copy `view` path.

This is not a duplicate: no open PR addresses the FlashInfer FP8 query-quantization contiguity assertion. It is a follow-up bugfix to #43232.

## Test Plan

Repro: serve a Nemotron model with `--attention-backend FLASHINFER --kv-cache-dtype fp8` (previously raised `AssertionError` in `maybe_quant_query`; also reported on Nemotron + FlashInfer FP8 outside PD-disagg).

- [x] Nemotron + FlashInfer + FP8 KV cache serves without the assertion.
- [x] Existing FlashInfer FP8 paths (contiguous query) unchanged.

## Test Result

Confirmed working

---

AI assistance (Claude Code) was used to diagnose and draft this change.