### PR TITLE
[Bugfix] Fix Gemma4 engine parser returning bare values as strings

### DIFF
--- a/tests/parser/engine/test_gemma4_streaming_reasoning.py
+++ b/tests/parser/engine/test_gemma4_streaming_reasoning.py
@@ -768,7 +768,7 @@ class TestNonStreamingToolCalls:
 
         assert result.tools_called is True
         args = json.loads(result.tool_calls[0].function.arguments)
-        assert args == {"is_active": "true", "count": "42", "score": "3.14"}
+        assert args == {"is_active": True, "count": 42, "score": 3.14}
 
     def test_no_arguments(self, tool_call_parser, mock_request):
         text = "<|tool_call>call:get_status{}<tool_call|>"
@@ -881,8 +881,8 @@ class TestStreamingToolCallEdgeCases:
         args_text = collect_tool_arguments(results)
         if args_text:
             parsed = json.loads(args_text)
-            assert parsed["count"] == "42"
-            assert parsed["active"] == "true"
+            assert parsed["count"] == 42
+            assert parsed["active"] is True
 
     def test_streaming_empty_args(self, tool_call_parser, mock_request):
         chunks = [
@@ -924,7 +924,7 @@ class TestStreamingToolCallEdgeCases:
         args_text = collect_tool_arguments(results)
         assert args_text
         parsed = json.loads(args_text)
-        assert parsed["input"]["all"] == "true"
+        assert parsed["input"]["all"] is True
 
     def test_streaming_number_split(self, tool_call_parser, mock_request):
         chunks = [
@@ -938,7 +938,7 @@ class TestStreamingToolCallEdgeCases:
         args_text = collect_tool_arguments(results)
         assert args_text
         parsed = json.loads(args_text)
-        assert parsed["count"] == "42"
+        assert parsed["count"] == 42
 
     def test_streaming_trailing_bare_bool(self, tool_call_parser, mock_request):
         chunks = [
@@ -961,7 +961,7 @@ class TestStreamingToolCallEdgeCases:
             "file_path": "src/env.py",
             "old_string": "old_val",
             "new_string": "new_val",
-            "replace_all": "false",
+            "replace_all": False,
         }
 
         assert args_text.count("replace_all") == 1

--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -123,8 +123,7 @@ def mock_request():
 
 
 class TestParseGemma4Args:
-    """Values are returned as strings; type coercion to proper JSON types
-    happens at the engine layer."""
+    """Bare values are converted to their JSON types (int, float, bool, None)."""
 
     def test_empty_string(self):
         assert _parse_gemma4_args("") == {}
@@ -148,23 +147,23 @@ class TestParseGemma4Args:
 
     def test_integer_value(self):
         result = _parse_gemma4_args("count:42")
-        assert result == {"count": "42"}
+        assert result == {"count": 42}
 
     def test_float_value(self):
         result = _parse_gemma4_args("score:3.14")
-        assert result == {"score": "3.14"}
+        assert result == {"score": 3.14}
 
     def test_boolean_true(self):
         result = _parse_gemma4_args("flag:true")
-        assert result == {"flag": "true"}
+        assert result == {"flag": True}
 
     def test_boolean_false(self):
         result = _parse_gemma4_args("flag:false")
-        assert result == {"flag": "false"}
+        assert result == {"flag": False}
 
     def test_null_value(self):
         result = _parse_gemma4_args("param:null")
-        assert result == {"param": "null"}
+        assert result == {"param": None}
 
     def test_mixed_types(self):
         result = _parse_gemma4_args(
@@ -172,9 +171,9 @@ class TestParseGemma4Args:
         )
         assert result == {
             "name": "test",
-            "count": "42",
-            "active": "true",
-            "score": "3.14",
+            "count": 42,
+            "active": True,
+            "score": 3.14,
         }
 
     def test_nested_object(self):
@@ -194,7 +193,7 @@ class TestParseGemma4Args:
         assert result == {"outer": {"inner": "val"}}
 
         result = _parse_gemma4_args('<|"|>name<|"|>:<|"|>Alice<|"|>,count:42')
-        assert result == {"name": "Alice", "count": "42"}
+        assert result == {"name": "Alice", "count": 42}
 
     def test_unterminated_string(self):
         """Unterminated strings should take everything after the delimiter."""
@@ -237,7 +236,7 @@ class TestParseGemma4Args:
 
         # Non-partial mode parses trailing dot normally
         result = _parse_gemma4_args("left:108.,right:22.8", partial=False)
-        assert result == {"left": "108.", "right": "22.8"}
+        assert result == {"left": 108.0, "right": 22.8}
 
     @pytest.mark.timeout(5)
     def test_malformed_partial_array(self):
@@ -256,7 +255,7 @@ class TestParseGemma4Array:
 
     def test_bare_values(self):
         result = _parse_gemma4_array("42,true,3.14")
-        assert result == ["42", "true", "3.14"]
+        assert result == [42, True, 3.14]
 
     @pytest.mark.timeout(5)
     def test_string_element_with_closing_bracket(self):
@@ -266,7 +265,7 @@ class TestParseGemma4Array:
     @pytest.mark.timeout(5)
     def test_stray_closing_bracket(self):
         result = _parse_gemma4_array("42,]trailing")
-        assert result == ["42"]
+        assert result == [42]
 
     def test_trailing_dot_float_partial_withheld(self):
         """Array elements with trailing dot withheld in partial mode."""
@@ -275,7 +274,7 @@ class TestParseGemma4Array:
 
         # Stable elements before trailing-dot element are kept
         result = _parse_gemma4_array("42,108.,3", partial=True)
-        assert result == ["42"]
+        assert result == [42]
 
 
 # ---------------------------------------------------------------------------

--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -65,6 +65,26 @@ def _strip_partial_delim(value: str) -> str:
     return value
 
 
+def _parse_gemma4_value(value_str: str) -> object:
+    """Parse a single Gemma4 bare value into a Python object."""
+    value_str = value_str.strip()
+    if not value_str:
+        return value_str
+    if value_str == "true":
+        return True
+    if value_str == "false":
+        return False
+    if value_str.lower() in ("null", "none", "nil"):
+        return None
+    try:
+        if "." in value_str:
+            return float(value_str)
+        return int(value_str)
+    except ValueError:
+        pass
+    return value_str
+
+
 def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
     """Parse Gemma4's custom key:value format into a Python dict.
 
@@ -196,7 +216,7 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
                 # Digits may still arrive (e.g. "108." -> "108.2");
                 # withhold to avoid corrupting the streaming diff.
                 break
-            result[key] = raw_val
+            result[key] = _parse_gemma4_value(raw_val)
 
     return result
 
@@ -277,7 +297,7 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
             raw_val = arr_str[val_start:i].strip()
             if partial and raw_val.endswith("."):
                 break
-            items.append(raw_val)
+            items.append(_parse_gemma4_value(raw_val))
 
     return items
 


### PR DESCRIPTION
## Purpose

Fixes #47906.

Since the Gemma4 parsers were replaced with the engine-based implementation (#45588, v0.24.0), `_parse_gemma4_args` in `vllm/parser/gemma4.py` stored bare values (integers, floats, booleans, null) as raw strings instead of converting them to their proper Python types. This caused tool call arguments to be serialized as `{"count": "42", "flag": "true"}` instead of `{"count": 42, "flag": true}`, a regression from v0.23.0 behavior.

The fix adds `_parse_gemma4_value()` — matching the existing implementation in the legacy `gemma4_tool_parser.py` — to convert bare values to `int`/`float`/`bool`/`None` at parse time. The streaming path is unaffected because its withholding logic already ensures only complete bare values are committed.

### AGENTS.md value re-evaluation (per the auto-comment requirement)

Per AGENTS.md, here is my objective self-evaluation. I (the AI agent that authored this PR) commit to closing this PR if any of these answers turns out to be "no":

- Real reproducible bug: YES — bare tool call argument values (int, float, bool, null) are silently coerced to strings, breaking downstream consumers that expect proper JSON types
- Fix scope ≤ 100 lines: YES (42 insertions, 23 deletions across 3 files)
- Unit-testable without GPU/distributed: YES — `tests/tool_parsers/test_gemma4_tool_parser.py`, `tests/parser/engine/test_gemma4_streaming_reasoning.py`
- No duplicate open or recently-merged PR: YES — confirmed via `gh pr list --search "47906 in:body" --state all` returning no results
- Issue not claimed by reporter/maintainer: YES — 0 comments on issue
- Defensible line-by-line: YES — `_parse_gemma4_value` is identical to the existing function in `vllm/tool_parsers/gemma4_tool_parser.py:59-84`
- Not security-sensitive: YES — pure argument parsing code path
- Not stylistic: YES — closes a concrete type-correctness regression in tool call output

## Test Plan

```bash
.venv/bin/python -m pytest tests/tool_parsers/test_gemma4_tool_parser.py -x -v
.venv/bin/python -m pytest tests/parser/engine/test_gemma4_streaming_reasoning.py -x -v
.venv/bin/python -m pytest tests/parser/ tests/tool_parsers/ -x -v
.venv/bin/pre-commit run --files vllm/parser/gemma4.py tests/tool_parsers/test_gemma4_tool_parser.py tests/parser/engine/test_gemma4_streaming_reasoning.py
```

## Test Result

- 54/54 tests pass in `test_gemma4_tool_parser.py`
- 4151/4151 tests pass across `tests/parser/` and `tests/tool_parsers/` (1 unrelated error due to gated model access)
- All pre-commit hooks pass

## AI assistance disclosure

This PR was produced by an automated nightly triage agent (Claude) running with the user's explicit authorization. The user reviews every opened PR and will close any that does not meet vLLM's value bar.