### PR TITLE
[Bugfix] Patch Hopper MXFP4 OOB scales reads leading to NaN

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -87,6 +87,12 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps=8):
                 "split_k": 1,
             }
             opt_flags.update_opt_flags_constraints(constraints)
+            # Patches #47303: pad K (num scale groups) to 0 mod 4
+            # TODO: Remove once we upgrade to Triton 3.8.0+ kernels
+            if scale.numel() > 0:
+                K = scale.shape[-1]
+                pad_k = -K % 4
+                scale = torch.nn.functional.pad(scale, (0, pad_k))
         elif current_platform.is_device_capability_family(100):
             constraints = {
                 "is_persistent": True,


### PR DESCRIPTION

## Purpose

Patch https://github.com/vllm-project/vllm/issues/47303 by padding the swizzled scales so that OOB reads won't happen. Mirrors upstream fix in https://github.com/triton-lang/triton/pull/10800. Can be cleaned up when we upgrade our triton kernels to v.3.8.0+.

TLDR:
(E, M, K) = (..., 5760, 90) gets swizzled into (E, M / 32, K * 32) -> (..., 184, 2880), which is read in tiles of (8, 128), leading to 2880:2944 being OOB. Triton's `convert_layout` for Hopper already pads with zeros to ensure that K = 90 is divisible by 2. We further ensure K is a multiple of 4 so that K * 32 is divisible by 128.

## Test Plan

```
.venv/bin/python -m pytest \
  tests/kernels/moe/test_gpt_oss_triton_kernels.py \
  tests/kernels/moe/test_modular_oai_triton_moe.py \
  tests/kernels/moe/test_ocp_mx_moe.py
```

E2E repro in #47303

GSM8K Eval on GPT-OSS 20B

## Test Result

```
33 passed, 117 skipped, 16 warnings
```

```
Before (with mem poisoning):
round 1/5: accuracy=0.0% (0/100), avg_output_len=256.0
round 2/5: accuracy=0.0% (0/100), avg_output_len=256.0
round 3/5: accuracy=0.0% (0/100), avg_output_len=256.0
round 4/5: accuracy=0.0% (0/100), avg_output_len=256.0
round 5/5: accuracy=0.0% (0/100), avg_output_len=256.0

After:
round 1/5: accuracy=100.0% (100/100), avg_output_len=29.0
round 2/5: accuracy=100.0% (100/100), avg_output_len=29.0
round 3/5: accuracy=100.0% (100/100), avg_output_len=29.0
round 4/5: accuracy=100.0% (100/100), avg_output_len=29.0
round 5/5: accuracy=100.0% (100/100), avg_output_len=29.0
```

```
Before (with mem poisoning):
round 1/5: accuracy=0.016, invalid=0.165, latency=25.550s, qps=51.624, tok/s=13215.824
round 2/5: accuracy=0.020, invalid=0.174, latency=24.102s, qps=54.725, tok/s=13999.513
round 3/5: accuracy=0.020, invalid=0.171, latency=24.043s, qps=54.859, tok/s=14033.994
round 4/5: accuracy=0.021, invalid=0.167, latency=24.260s, qps=54.369, tok/s=13898.683
round 5/5: accuracy=0.020, invalid=0.171, latency=24.128s, qps=54.666, tok/s=13994.504

After:
round 1/5: accuracy=0.333, invalid=0.152, latency=42.487s, qps=31.045, tok/s=7234.282
round 2/5: accuracy=0.328, invalid=0.159, latency=29.333s, qps=44.967, tok/s=10471.471
round 3/5: accuracy=0.327, invalid=0.158, latency=27.727s, qps=47.572, tok/s=11077.351
round 4/5: accuracy=0.324, invalid=0.159, latency=27.190s, qps=48.511, tok/s=11284.412
round 5/5: accuracy=0.323, invalid=0.158, latency=26.779s, qps=49.255, tok/s=11462.031
```

AI Assisted

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

