### PR TITLE
fix: hash speculative draft model config

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1471,6 +1471,25 @@ def test_scheduler_config_init():
         print(SchedulerConfig.default_factory().max_model_len)
 
 
+def test_speculative_config_hash_includes_draft_model_config():
+    def make_spec_config(draft_hash: str):
+        draft_model_config = SimpleNamespace(
+            compute_hash=lambda: draft_hash,
+            hf_config=SimpleNamespace(eagle_aux_hidden_state_layer_ids=(1, 2)),
+        )
+        return SimpleNamespace(
+            method="dflash",
+            draft_model_config=draft_model_config,
+        )
+
+    k26_like = make_spec_config("draft-model-k26")
+    k27_like = make_spec_config("draft-model-k27")
+
+    assert SpeculativeConfig.compute_hash(k26_like) != SpeculativeConfig.compute_hash(
+        k27_like
+    )
+
+
 @pytest.mark.parametrize(
     (
         "model_id",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1471,24 +1471,6 @@ def test_scheduler_config_init():
         print(SchedulerConfig.default_factory().max_model_len)
 
 
-def test_speculative_config_hash_includes_draft_model_config():
-    def make_spec_config(draft_hash: str):
-        draft_model_config = SimpleNamespace(
-            compute_hash=lambda: draft_hash,
-            hf_config=SimpleNamespace(eagle_aux_hidden_state_layer_ids=(1, 2)),
-        )
-        return SimpleNamespace(
-            method="dflash",
-            draft_model_config=draft_model_config,
-        )
-
-    k26_like = make_spec_config("draft-model-k26")
-    k27_like = make_spec_config("draft-model-k27")
-
-    assert SpeculativeConfig.compute_hash(k26_like) != SpeculativeConfig.compute_hash(
-        k27_like
-    )
-
 
 @pytest.mark.parametrize(
     (

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1471,7 +1471,6 @@ def test_scheduler_config_init():
         print(SchedulerConfig.default_factory().max_model_len)
 
 
-
 @pytest.mark.parametrize(
     (
         "model_id",

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -306,8 +306,10 @@ class SpeculativeConfig:
         )
         factors.append(uses_aux_hidden_states)
 
-        # The specific layers used also affect the computation graph
         if uses_aux_hidden_states and self.draft_model_config is not None:
+            factors.append(self.draft_model_config.compute_hash())
+
+            # The specific layers used also affect the computation graph.
             layer_ids = getattr(
                 self.draft_model_config.hf_config,
                 "eagle_aux_hidden_state_layer_ids",


### PR DESCRIPTION



## Purpose

AOT compilation cache keys include VllmConfig.compute_hash(), which delegates to SpeculativeConfig.compute_hash(). For DFlash and related aux-hidden-state methods, the speculative hash only distinguished whether aux states were used and which aux layer IDs were returned.

That is insufficient when two deployments share an AOT cache root but use different draft model configs with the same aux layer IDs. The second deployment can load an AOT artifact compiled for the first draft model, even though the compiled graph shape contract belongs to a different draft backbone.

Include draft_model_config.compute_hash() whenever aux-hidden-state speculative decoding uses a draft model. Keep the existing layer-id factor so configs that share the same draft model but request different aux states still hash separately.

## Test Plan

~Add a focused regression test covering two DFlash-like configs with identical aux layer IDs but different draft model hashes.~ removed per feedback

## Test Result

Avoids collision between two incompatible models on the cache key. This solves a real-world serving issue where the drafters have slightly different architectures but attempt to reuse the cache leading to assertion errors on code paths like this qwen3_dflash.py -> flash_attn.py -> vllm_flash_attn/cute/interface.py
```
assert k.shape == (num_pages, page_size, num_head_kv, head_dim)
```

Running either model independently with a clean cache works, making the fingerprint fully unique solves the collision.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

