### PR TITLE
[Bugfix][Responses API] Keep streamed function call IDs in completed responses

### DIFF
--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -7,7 +7,10 @@ from unittest.mock import MagicMock
 import pytest
 import pytest_asyncio
 from openai.types.responses import (
+    ResponseFunctionToolCall,
     ResponseOutputItemDoneEvent,
+    ResponseOutputMessage,
+    ResponseOutputText,
     ResponseReasoningItem,
     ResponseReasoningTextDeltaEvent,
     ResponseReasoningTextDoneEvent,
@@ -705,6 +708,20 @@ def _make_simple_context_with_output(text, token_ids, response_parser=None):
     return ctx
 
 
+def _get_weather_tool():
+    return {
+        "type": "function",
+        "name": "get_weather",
+        "description": "Get weather.",
+        "parameters": {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+            "additionalProperties": False,
+        },
+    }
+
+
 def _make_serving_instance_with_reasoning():
     """Create an OpenAIServingResponses with a mocked reasoning parser."""
     engine_client = MagicMock()
@@ -994,19 +1011,7 @@ class TestAutoToolStreaming:
 
         request = ResponsesRequest(
             input="hi",
-            tools=[
-                {
-                    "type": "function",
-                    "name": "get_weather",
-                    "description": "Get weather.",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {"location": {"type": "string"}},
-                        "required": ["location"],
-                        "additionalProperties": False,
-                    },
-                }
-            ],
+            tools=[_get_weather_tool()],
             tool_choice="auto",
             stream=True,
         )
@@ -1232,3 +1237,120 @@ class TestAutoToolStreaming:
         assert len(function_done) == 1
         assert function_done[0].item.name == "get_weather"
         assert function_done[0].item.arguments == tool_args
+
+    @pytest.mark.skip_global_cleanup
+    @pytest.mark.asyncio
+    async def test_completed_reuses_streamed_tool_call_and_preserves_text(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(envs, "VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT", False)
+        serving = _make_serving_instance_with_reasoning()
+        tool_args = '{"location":"Berlin"}'
+
+        response_parser = _mock_parser_with_reasoning(
+            serving,
+            [
+                DeltaMessage(
+                    tool_calls=[
+                        DeltaToolCall(
+                            id="chatcmpl-tool-stream-id",
+                            type="function",
+                            index=0,
+                            function=DeltaFunctionCall(
+                                name="get_weather",
+                                arguments=tool_args,
+                            ),
+                        )
+                    ]
+                )
+            ],
+        )
+
+        async def result_generator():
+            yield _make_simple_context_with_output("chunk", [10], response_parser)
+
+        request = ResponsesRequest(
+            input="hi",
+            tools=[_get_weather_tool()],
+            tool_choice="auto",
+            stream=True,
+        )
+        sampling_params = SamplingParams(max_tokens=64)
+
+        async def fake_full_generator(*args, **kwargs):
+            return ResponsesResponse.from_request(
+                request,
+                sampling_params,
+                model_name="test-model",
+                created_time=0,
+                output=[
+                    ResponseOutputMessage(
+                        id="msg_full_parse",
+                        content=[
+                            ResponseOutputText(
+                                annotations=[],
+                                text="The weather is mild.",
+                                type="output_text",
+                                logprobs=[
+                                    {
+                                        "token": "The",
+                                        "bytes": [84, 104, 101],
+                                        "logprob": -0.1,
+                                        "top_logprobs": [],
+                                    }
+                                ],
+                            )
+                        ],
+                        role="assistant",
+                        status="completed",
+                        type="message",
+                    ),
+                    ResponseFunctionToolCall(
+                        type="function_call",
+                        id="fc_full_parse",
+                        call_id="chatcmpl-tool-full-parse-id",
+                        name="get_weather",
+                        arguments=tool_args,
+                        status="completed",
+                    ),
+                ],
+                status="completed",
+                usage=None,
+            )
+
+        serving.responses_full_generator = fake_full_generator
+
+        events = [
+            event
+            async for event in serving.responses_stream_generator(
+                request=request,
+                sampling_params=sampling_params,
+                result_generator=result_generator(),
+                context=SimpleContext(response_parser=response_parser),
+                model_name="test-model",
+                tokenizer=MagicMock(),
+                request_metadata=RequestResponseMetadata(request_id="req"),
+                created_time=0,
+            )
+        ]
+
+        stream_done = next(
+            event
+            for event in events
+            if event.type == "response.output_item.done"
+            and getattr(event.item, "type", None) == "function_call"
+        )
+        completed = next(
+            event for event in events if event.type == "response.completed"
+        )
+
+        assert stream_done.item.call_id == "chatcmpl-tool-stream-id"
+        message_item = completed.response.output[0]
+        tool_item = completed.response.output[1]
+        assert isinstance(message_item, ResponseOutputMessage)
+        assert isinstance(tool_item, ResponseFunctionToolCall)
+        assert message_item.content[0].logprobs
+        assert tool_item.id == stream_done.item.id
+        assert tool_item.call_id == "chatcmpl-tool-stream-id"
+        assert tool_item.name == "get_weather"
+        assert tool_item.arguments == tool_args

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -1499,6 +1499,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 )
             )
 
+            streamed_function_calls: list[ResponseFunctionToolCall] = []
             try:
                 async for event_data in processor(
                     request,
@@ -1511,6 +1512,12 @@ class OpenAIServingResponses(GenerateBaseServing):
                     created_time,
                     _increment_sequence_number_and_return,
                 ):
+                    if (
+                        not self.use_harmony
+                        and event_data.type == "response.output_item.done"
+                        and isinstance(event_data.item, ResponseFunctionToolCall)
+                    ):
+                        streamed_function_calls.append(event_data.item)
                     yield event_data
             except GenerationError as e:
                 error_json = self._convert_generation_error_to_streaming_response(e)
@@ -1535,6 +1542,18 @@ class OpenAIServingResponses(GenerateBaseServing):
                 request_metadata,
                 created_time=created_time,
             )
+            if (
+                not self.use_harmony
+                and streamed_function_calls
+                and isinstance(final_response, ResponsesResponse)
+            ):
+                streamed_calls = iter(streamed_function_calls)
+                final_response.output = [
+                    next(streamed_calls, item)
+                    if isinstance(item, ResponseFunctionToolCall)
+                    else item
+                    for item in final_response.output
+                ]
             yield _increment_sequence_number_and_return(
                 ResponseCompletedEvent(
                     type="response.completed",

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -1023,10 +1023,11 @@ def emit_simple_tool_call_open(
     name: str,
     index: int | None,
     namespace: str | None = None,
+    call_id: str | None = None,
 ) -> list[StreamingResponsesResponse]:
     state.current_state = _StateType.TOOL_CALL
     state.current_item_id = random_uuid()
-    state.tool_call_id = f"call_{random_uuid()}"
+    state.tool_call_id = call_id or f"call_{random_uuid()}"
     state.tool_call_name = name
     state.tool_call_namespace = namespace
     state.tool_call_index = index
@@ -1249,6 +1250,7 @@ class SimpleStreamingEventProcessor:
                 call_name.name,
                 tool_call.index,
                 call_name.namespace,
+                tool_call.id,
             )
         return handlers.open_fn(self.state)
 


### PR DESCRIPTION

## Purpose

Fix a `/v1/responses` streaming function-call inconsistency where the same tool call can be emitted with one `call_id` in `response.output_item.done` and a different `call_id` in the final `response.completed.response.output`.

`call_id` is the protocol join key for pairing a `function_call` with a later `function_call_output`. Current main already emits proper function-call stream events for this non-Harmony path, but the stream item and final completed output are built through separate identity-generation paths. This patch makes the simple streaming item use the parser-provided tool-call id when available, then makes the final completed response reuse the streamed function-call item while leaving the full generator's text, logprobs, usage, and status intact.

This is adjacent to the older non-Harmony XML-leak and multi-tool aggregation issues, but the current-main failure here is different: a single valid streamed function call is emitted, then the final completed response gives it a different identity.

## Test Plan

I ran a real `vllm serve` reproduction with `Qwen/Qwen2.5-0.5B-Instruct`, Hermes tool parsing, `/v1/responses`, `stream=True`, and `tool_choice=required`. The same request mismatches without this patch, matches with this patch, and mismatches again after reverse-applying this patch.

I also ran the existing simple streaming event processor tests, focused serving coverage for this regression, the full Responses serving unit file, scoped ruff checks, and a logprobs regression probe.

## Test Result

Without this patch, the same function call gets different IDs:

```text
stream_done.call_id = call_b6c0330384af6c96
completed.call_id   = chatcmpl-tool-8977412e1334bf6b
CALL_ID_MISMATCH stream=['call_b6c0330384af6c96'] completed=['chatcmpl-tool-8977412e1334bf6b']
```

With this patch, the stream and completed response reuse the same function-call item:

```text
stream_done.call_id = chatcmpl-tool-8f4bcc817e070658
completed.call_id   = chatcmpl-tool-8f4bcc817e070658
CALL_ID_MATCH ['chatcmpl-tool-8f4bcc817e070658']
```

After reverse-applying this patch, the mismatch comes back:

```text
stream_done.call_id = call_97f7ec159410b50f
completed.call_id   = chatcmpl-tool-b6302e4778fd3873
CALL_ID_MISMATCH stream=['call_97f7ec159410b50f'] completed=['chatcmpl-tool-b6302e4778fd3873']
```

<details>
<summary>End-to-end reproduction</summary>

Environment used for the measured run:

```text
GPU: NVIDIA GeForce RTX 4090, driver 580.105.08, 24564 MiB
Python: 3.12.13
torch: 2.11.0+cu130
Base commit: cbe9c40f998f13975b967773ac7e7920e115387f
Model: local cache of Qwen/Qwen2.5-0.5B-Instruct at /root/autodl-tmp/cache/hf/hub/models--Qwen--Qwen2.5-0.5B-Instruct/snapshots/7ae557604adf67be50417f59c2c2f167def9a775
Server flags: --enable-auto-tool-choice --tool-call-parser hermes --structured-outputs-config.backend xgrammar --enforce-eager
```

Server command:

```bash
export PYTHONPATH=$PWD
export HF_HOME=/root/autodl-tmp/cache/hf
export HF_HUB_OFFLINE=1
export TRANSFORMERS_OFFLINE=1
export VLLM_NO_USAGE_STATS=1
export VLLM_SERVER_DEV_MODE=1
export VLLM_ENABLE_RESPONSES_API_STORE=1
export VLLM_USE_FLASHINFER_SAMPLER=0
export VLLM_ATTENTION_BACKEND=FLASH_ATTN

python -m vllm.entrypoints.openai.api_server \
  --model /root/autodl-tmp/cache/hf/hub/models--Qwen--Qwen2.5-0.5B-Instruct/snapshots/7ae557604adf67be50417f59c2c2f167def9a775 \
  --served-model-name Qwen2.5-0.5B-Instruct \
  --host 127.0.0.1 \
  --port 8017 \
  --max-model-len 4096 \
  --max-num-seqs 4 \
  --gpu-memory-utilization 0.55 \
  --enforce-eager \
  --enable-auto-tool-choice \
  --tool-call-parser hermes \
  --structured-outputs-config.backend xgrammar \
  --no-enable-log-requests
```

Client script:

```python
import argparse
import json

from openai import OpenAI


def main() -> None:
    parser = argparse.ArgumentParser()
    parser.add_argument("--base-url", default="http://127.0.0.1:8017/v1")
    parser.add_argument("--model", default="Qwen2.5-0.5B-Instruct")
    parser.add_argument("--tool-choice", default="required")
    args = parser.parse_args()

    client = OpenAI(base_url=args.base_url, api_key="dummy")
    tools = [
        {
            "type": "function",
            "name": "get_weather",
            "description": "Get the current weather for a city.",
            "parameters": {
                "type": "object",
                "properties": {"location": {"type": "string"}},
                "required": ["location"],
                "additionalProperties": False,
            },
            "strict": True,
        }
    ]

    stream = client.responses.create(
        model=args.model,
        input="Call get_weather for Berlin. Do not answer directly.",
        tools=tools,
        tool_choice=args.tool_choice,
        stream=True,
        temperature=0,
        max_output_tokens=64,
    )

    added = []
    done = []
    completed = []
    event_types = []
    for event in stream:
        event_types.append(event.type)
        if event.type == "response.output_item.added":
            item = event.item
            if getattr(item, "type", None) == "function_call":
                added.append(
                    {
                        "output_index": event.output_index,
                        "id": getattr(item, "id", None),
                        "call_id": getattr(item, "call_id", None),
                        "name": getattr(item, "name", None),
                    }
                )
        elif event.type == "response.output_item.done":
            item = event.item
            if getattr(item, "type", None) == "function_call":
                done.append(
                    {
                        "output_index": event.output_index,
                        "id": getattr(item, "id", None),
                        "call_id": getattr(item, "call_id", None),
                        "name": getattr(item, "name", None),
                        "arguments": getattr(item, "arguments", None),
                    }
                )
        elif event.type == "response.completed":
            for idx, item in enumerate(event.response.output):
                if getattr(item, "type", None) == "function_call":
                    completed.append(
                        {
                            "output_index": idx,
                            "id": getattr(item, "id", None),
                            "call_id": getattr(item, "call_id", None),
                            "name": getattr(item, "name", None),
                            "arguments": getattr(item, "arguments", None),
                        }
                    )

    summary = {
        "event_types": event_types,
        "stream_added": added,
        "stream_done": done,
        "completed": completed,
    }
    print(json.dumps(summary, indent=2, ensure_ascii=False))

    stream_ids = [item["call_id"] for item in done]
    completed_ids = [item["call_id"] for item in completed]
    if not stream_ids or not completed_ids:
        raise SystemExit("NO_FUNCTION_CALL")
    if stream_ids != completed_ids:
        raise SystemExit(
            f"CALL_ID_MISMATCH stream={stream_ids} completed={completed_ids}"
        )
    print(f"CALL_ID_MATCH {stream_ids}")


if __name__ == "__main__":
    main()
```

Client command:

```bash
python stream_call_id_probe.py \
  --base-url http://127.0.0.1:8017/v1 \
  --model Qwen2.5-0.5B-Instruct \
  --tool-choice required
```

Unpatched output:

```text
{
  "event_types": [
    "response.created",
    "response.in_progress",
    "response.output_item.added",
    "response.function_call_arguments.delta",
    "response.function_call_arguments.delta",
    "response.function_call_arguments.delta",
    "response.function_call_arguments.delta",
    "response.function_call_arguments.delta",
    "response.function_call_arguments.delta",
    "response.function_call_arguments.done",
    "response.output_item.done",
    "response.completed"
  ],
  "stream_added": [
    {
      "output_index": 0,
      "id": "ba034bf973eefd4d",
      "call_id": "call_b6c0330384af6c96",
      "name": "get_weather"
    }
  ],
  "stream_done": [
    {
      "output_index": 0,
      "id": "ba034bf973eefd4d",
      "call_id": "call_b6c0330384af6c96",
      "name": "get_weather",
      "arguments": "{\"location\": \"Berlin\"}"
    }
  ],
  "completed": [
    {
      "output_index": 0,
      "id": "fc_91b73398225ee260",
      "call_id": "chatcmpl-tool-8977412e1334bf6b",
      "name": "get_weather",
      "arguments": "{\"location\": \"Berlin\"}"
    }
  ]
}
CALL_ID_MISMATCH stream=['call_b6c0330384af6c96'] completed=['chatcmpl-tool-8977412e1334bf6b']
```

Patched output:

```text
{
  "event_types": [
    "response.created",
    "response.in_progress",
    "response.output_item.added",
    "response.function_call_arguments.delta",
    "response.function_call_arguments.delta",
    "response.function_call_arguments.delta",
    "response.function_call_arguments.delta",
    "response.function_call_arguments.delta",
    "response.function_call_arguments.delta",
    "response.function_call_arguments.done",
    "response.output_item.done",
    "response.completed"
  ],
  "stream_added": [
    {
      "output_index": 0,
      "id": "926a5ceef68dbab4",
      "call_id": "chatcmpl-tool-8f4bcc817e070658",
      "name": "get_weather"
    }
  ],
  "stream_done": [
    {
      "output_index": 0,
      "id": "926a5ceef68dbab4",
      "call_id": "chatcmpl-tool-8f4bcc817e070658",
      "name": "get_weather",
      "arguments": "{\"location\": \"Berlin\"}"
    }
  ],
  "completed": [
    {
      "output_index": 0,
      "id": "926a5ceef68dbab4",
      "call_id": "chatcmpl-tool-8f4bcc817e070658",
      "name": "get_weather",
      "arguments": "{\"location\": \"Berlin\"}"
    }
  ]
}
CALL_ID_MATCH ['chatcmpl-tool-8f4bcc817e070658']
```

After reverse-applying this patch:

```text
{
  "event_types": [
    "response.created",
    "response.in_progress",
    "response.output_item.added",
    "response.function_call_arguments.delta",
    "response.function_call_arguments.delta",
    "response.function_call_arguments.delta",
    "response.function_call_arguments.delta",
    "response.function_call_arguments.delta",
    "response.function_call_arguments.delta",
    "response.function_call_arguments.done",
    "response.output_item.done",
    "response.completed"
  ],
  "stream_added": [
    {
      "output_index": 0,
      "id": "becc97e301471016",
      "call_id": "call_97f7ec159410b50f",
      "name": "get_weather"
    }
  ],
  "stream_done": [
    {
      "output_index": 0,
      "id": "becc97e301471016",
      "call_id": "call_97f7ec159410b50f",
      "name": "get_weather",
      "arguments": "{\"location\": \"Berlin\"}"
    }
  ],
  "completed": [
    {
      "output_index": 0,
      "id": "fc_8ce9c97b23dc6548",
      "call_id": "chatcmpl-tool-b6302e4778fd3873",
      "name": "get_weather",
      "arguments": "{\"location\": \"Berlin\"}"
    }
  ]
}
CALL_ID_MISMATCH stream=['call_97f7ec159410b50f'] completed=['chatcmpl-tool-b6302e4778fd3873']
```

</details>

Additional checks:

```text
CUDA_VISIBLE_DEVICES="" PYTHONPATH=$PWD python -m pytest tests/entrypoints/openai/responses/test_streaming_events.py -q
6 passed, 16 warnings in 1.48s

CUDA_VISIBLE_DEVICES="" PYTHONPATH=$PWD python -m pytest tests/entrypoints/openai/responses/test_serving_responses.py::TestAutoToolStreaming::test_completed_reuses_streamed_tool_call_and_preserves_text -q
1 passed, 16 warnings in 0.16s

CUDA_VISIBLE_DEVICES="" PYTHONPATH=$PWD python -m pytest tests/entrypoints/openai/responses/test_serving_responses.py -q
22 passed, 1 xfailed, 16 warnings in 4.10s

PYTHONPATH=$PWD python -m ruff check vllm/entrypoints/openai/responses/serving.py vllm/entrypoints/openai/responses/streaming_events.py tests/entrypoints/openai/responses/test_serving_responses.py
All checks passed!

PYTHONPATH=$PWD python -m ruff format --check vllm/entrypoints/openai/responses/serving.py vllm/entrypoints/openai/responses/streaming_events.py tests/entrypoints/openai/responses/test_serving_responses.py
3 files already formatted

git diff --check
passed
```

Real server output-logprobs regression check with `include=["message.output_text.logprobs"]` and `top_logprobs=3`:

```text
delta_logprobs_count=8
final_logprobs_count=8
FINAL_LOGPROBS_PRESENT
```

AI assistance was used to prepare this PR.
