### PR TITLE
[Core] Pre-size cudagraph output staging buffers to the max capture descriptor

### DIFF
--- a/tests/v1/spec_decode/test_dynamic_sd_cug.py
+++ b/tests/v1/spec_decode/test_dynamic_sd_cug.py
@@ -326,3 +326,39 @@ def test_dynamic_sd_only_captures_scheduled_query_lengths(monkeypatch):
                 assert desc.num_tokens == num_tokens
                 assert desc.num_reqs is None
             assert desc.num_active_loras == 0
+
+
+def test_staging_buffer_capacity_is_capture_order_independent(monkeypatch):
+    """Output staging buffers must be sized to the largest capture descriptor,
+    not to whichever descriptor happens to run first. Otherwise the descending
+    capture order is silently load-bearing: any smaller-first order
+    under-allocates and the later, larger warmup crashes at the staging copy.
+
+    The under-allocation only manifests inside a CUDA graph capture, so this
+    CPU test pins the sizing contract on a real manager built through the
+    public constructor: capacity is one fixed value for every in-range
+    descriptor, and only a larger-than-all request exceeds it.
+    """
+
+    monkeypatch.setattr(
+        gpu_cudagraph_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    vllm_config = _create_vllm_config_for_dsd(max_num_seqs=64, max_spec_tokens=7)
+    manager = gpu_cudagraph_utils.CudaGraphManager(
+        vllm_config=vllm_config,
+        device=torch.device("cpu"),
+        cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        decode_query_len=8,
+    )
+
+    capacity = manager._staging_buffer_tokens(1)
+    # Real descriptors were registered by the constructor; capacity must cover
+    # the largest of them (the config's max capture size), not the current one.
+    assert capacity == 64 * 8
+    # Every in-range descriptor sees the same capacity: order cannot matter.
+    assert manager._staging_buffer_tokens(8) == capacity
+    assert manager._staging_buffer_tokens(capacity) == capacity
+    # A descriptor larger than every registered one still fits (fallback).
+    assert manager._staging_buffer_tokens(capacity + 100) == capacity + 100

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -292,6 +292,16 @@ class CudaGraphManager:
     def needs_capture(self) -> bool:
         return len(self._capture_descs) > 0
 
+    def _staging_buffer_tokens(self, num_tokens: int) -> int:
+        """Max num_tokens across all capture descriptors, so staging-buffer
+        capacity does not depend on capture order. Falls back to the current
+        descriptor's size if it exceeds every registered descriptor."""
+        max_desc_tokens = max(
+            (d.num_tokens for descs in self._capture_descs.values() for d in descs),
+            default=0,
+        )
+        return max(max_desc_tokens, num_tokens)
+
     @torch.inference_mode()
     def capture(
         self,
@@ -541,12 +551,16 @@ class ModelCudaGraphManager(CudaGraphManager):
                     else:
                         hidden_states = model_output
                         aux_hidden_states = []
+                    capacity = self._staging_buffer_tokens(num_tokens)
                     if self.hidden_states is None:
-                        self.hidden_states = torch.empty_like(hidden_states)
+                        self.hidden_states = hidden_states.new_empty(
+                            (capacity, *hidden_states.shape[1:])
+                        )
                     self.hidden_states[:num_tokens] = hidden_states
                     if self.use_aux_hidden_state_outputs and not self.aux_hidden_states:
                         self.aux_hidden_states = [
-                            torch.empty_like(x) for x in aux_hidden_states
+                            x.new_empty((capacity, *x.shape[1:]))
+                            for x in aux_hidden_states
                         ]
                     for i, aux in enumerate(aux_hidden_states):
                         self.aux_hidden_states[i][:num_tokens] = aux
@@ -555,8 +569,12 @@ class ModelCudaGraphManager(CudaGraphManager):
                     assert isinstance(model_output, IntermediateTensors)
                     intermediate_tensors = model_output
                     if self.intermediate_tensors is None:
-                        self.intermediate_tensors = IntermediateTensors.empty_like(
-                            intermediate_tensors
+                        capacity = self._staging_buffer_tokens(num_tokens)
+                        self.intermediate_tensors = IntermediateTensors(
+                            {
+                                k: v.new_empty((capacity, *v.shape[1:]))
+                                for k, v in intermediate_tensors.tensors.items()
+                            }
                         )
                     for k, v in intermediate_tensors.tensors.items():
                         self.intermediate_tensors[k][:num_tokens] = v


### PR DESCRIPTION
## Purpose

Capture order came up in the #feat-startup-ux discussions about parallelizing and reordering CUDA-graph capture. @galv raised that capture order affects pool fragmentation. The in-tree comment in `CudaGraphManager.capture()` already orders PIECEWISE before FULL for pool-reuse reasons. So ordering is a real memory-tuning knob.

Today it is also a silent **correctness** invariant. You cannot measure fragmentation under a different order, because any non-descending order crashes the boot.

The mechanism: `ModelCudaGraphManager` allocates its output staging buffers (`hidden_states`, `aux_hidden_states`, `intermediate_tensors`) lazily inside the first warmup forward, through `torch.empty_like`. Their capacity becomes whatever `num_tokens` the **first** descriptor happens to have. The descending sort in `_init_candidates` masks this, because the first descriptor is the max and everything fits. Under any smaller-first order, a later and larger warmup crashes at the staging copy `self.hidden_states[:num_tokens] = hidden_states` with a shape mismatch.

Measured on a vLLM 0.24.0 wheel, H100 NVL, Qwen3-8B. The lazy-allocation pattern is unchanged on current main.

- Stock: ascending order and three random shuffled orders crash the boot, 8 of 8 attempts, with a deterministic shape mismatch at the staging copy. This reproduces on the `vllm serve` path and cross-model on Qwen3-0.6B.
- Falsification check on the mechanism: a max-first then ascending order boots fine. So the invariant is that the first descriptor must be the largest. That points at this buffer, not at the memory pool.
- With max-descriptor pre-sizing, all 12 formerly-crashing boots succeed (4 orders, N=3). That enabled the first capture-order fragmentation measurement: a 2.91 GiB pool gap on the default descending order, 3.1 to 3.4 GiB on shuffles, and 7.52 GiB on strict ascending, which is 2.6 times the default. Capture time is order-independent at about 3.9 s in every order. Raw receipts (per-boot JSON, logs, hardware fingerprint) are available if useful.

So a bad order costs memory, not seconds. With this fix it costs memory measurably instead of crashing.

## Changes

- `CudaGraphManager._staging_buffer_tokens()` returns the max `num_tokens` across all registered capture descriptors. All of them are known at `__init__` time.
- The three lazy staging allocations size their leading dimension from it. The dtype, device, and trailing dimensions still come from the live tensor through `new_empty`.

**Allocations are byte-identical under the current descending order.** The sizing rule just stops depending on iteration order. This holds in every reachable config, not only by luck of the sort. PIECEWISE descriptors get the raw `cudagraph_capture_sizes`. Decode FULL descriptors are filtered by `rounded_num_tokens > max_cg_capture_size`. `compilation.py` asserts `cudagraph_capture_sizes[-1] == max_cudagraph_capture_size`. So the first descriptor to reach the staging allocation is already the global max today, and there is zero capture-time memory delta.

What this removes is the hidden coupling. Future capture-order changes, such as fragmentation tuning or parallel-capture experiments, then fail by measurement rather than by boot crash.

V1 and V2 note: this is the Model Runner V2 manager in `vllm/v1/worker/gpu/`. The V1 path stages outputs per-graph inside `CUDAGraphWrapper` and does not share the first-descriptor sizing pattern.

## Test Plan

Folded into `tests/v1/spec_decode/test_dynamic_sd_cug.py`, which exercises the MRv2 `CudaGraphManager` directly. Correction to an earlier version of this description: that is not the only test file importing `vllm.v1.worker.gpu.cudagraph_utils`. `tests/v1/cudagraph/test_breakable_cudagraph.py` also does, and `tests/v1/cudagraph/test_cudagraph_manager.py` arrived on 2026-07-21 with #48843. `tests/v1/cudagraph/test_cudagraph_manager.py` is arguably the better home now, and I am happy to move these cases there if reviewers prefer it.

The added cases cover three things: capacity equals the global max regardless of which descriptor allocates first, a descriptor larger than every registered one still fits, and the empty-descriptor fallback.

## Test Result

I verified the logic locally against the extracted helper, because this machine has no GPU dependencies available. The folded test is CPU-only and runs in CI.
