### PR TITLE
[Bugfix][Spec Decode] Mask prefix-cache-restored tokens out of the DFlash/DSpark draft context

### DIFF
--- a/tests/v1/spec_decode/test_dflash_prefix_cache_masking.py
+++ b/tests/v1/spec_decode/test_dflash_prefix_cache_masking.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DFlash/DSpark draft context masking under prefix caching.
+
+Cache-restored tokens never flow through the target forward, so the draft's
+context KV is never written for them. shift_draft_block_tables hides those
+slots from the draft's attention by left-shifting each request's block-table
+row by the restored whole blocks (seq_lens is shortened to match by
+_prepare_dflash_inputs_kernel).
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.worker.gpu.spec_decode.dflash.speculator import (
+    shift_draft_block_tables,
+)
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Requires CUDA"
+)
+
+DEVICE = "cuda"
+BLOCK_SIZE = 16
+MAX_BLOCKS = 64
+MAX_NUM_REQS = 8
+
+
+def _make_block_table(num_reqs: int) -> torch.Tensor:
+    # Distinct block ids per (request, slot) so shifts are detectable.
+    table = torch.arange(
+        MAX_NUM_REQS * MAX_BLOCKS, dtype=torch.int32, device=DEVICE
+    ).view(MAX_NUM_REQS, MAX_BLOCKS)
+    return table[:num_reqs].contiguous()
+
+
+@pytest.mark.parametrize(
+    "num_cached,expected_shift",
+    [
+        (0, 0),  # no cache hit: no-op
+        (BLOCK_SIZE * 3, 3),  # block-aligned hit (the common APC case)
+        (BLOCK_SIZE * 3 + 5, 3),  # unaligned: floor to whole blocks
+        (BLOCK_SIZE - 1, 0),  # less than one block: no-op
+    ],
+)
+def test_shift_single_request(num_cached: int, expected_shift: int):
+    block_table = _make_block_table(1)
+    original = block_table.clone()
+    idx_mapping = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+    num_cached_tokens = torch.full(
+        (MAX_NUM_REQS,), num_cached, dtype=torch.int32, device=DEVICE
+    )
+
+    seq_lens = torch.full(
+        (idx_mapping.shape[0],),
+        MAX_BLOCKS * BLOCK_SIZE,
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    shift_draft_block_tables(
+        block_table, idx_mapping, num_cached_tokens, seq_lens, BLOCK_SIZE
+    )
+
+    kept = MAX_BLOCKS - expected_shift
+    torch.testing.assert_close(
+        block_table[0, :kept], original[0, expected_shift:]
+    )
+
+
+def test_shift_per_request_and_idx_mapping():
+    # Requests in batch order 0..3 map to request-state slots 3..0, with a
+    # different cached count per slot. Each row must shift by its own count.
+    num_reqs = 4
+    block_table = _make_block_table(num_reqs)
+    original = block_table.clone()
+    idx_mapping = torch.tensor([3, 2, 1, 0], dtype=torch.int32, device=DEVICE)
+    # Slot i has i whole cached blocks.
+    num_cached_tokens = torch.zeros(
+        MAX_NUM_REQS, dtype=torch.int32, device=DEVICE
+    )
+    num_cached_tokens[:4] = (
+        torch.arange(4, dtype=torch.int32, device=DEVICE) * BLOCK_SIZE
+    )
+
+    seq_lens = torch.full(
+        (idx_mapping.shape[0],),
+        MAX_BLOCKS * BLOCK_SIZE,
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    shift_draft_block_tables(
+        block_table, idx_mapping, num_cached_tokens, seq_lens, BLOCK_SIZE
+    )
+
+    for batch_idx in range(num_reqs):
+        shift = int(idx_mapping[batch_idx])  # slot id == cached blocks
+        kept = MAX_BLOCKS - shift
+        torch.testing.assert_close(
+            block_table[batch_idx, :kept],
+            original[batch_idx, shift:],
+            msg=f"batch row {batch_idx} (slot {shift})",
+        )
+
+
+def test_shift_large_row_in_place_overlap():
+    # Shift smaller than the copy chunk (1024) exercises the overlapping
+    # in-place load-before-store path on a long row.
+    max_blocks = 4096
+    block_table = (
+        torch.arange(max_blocks, dtype=torch.int32, device=DEVICE)
+        .unsqueeze(0)
+        .contiguous()
+    )
+    original = block_table.clone()
+    idx_mapping = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+    num_cached_tokens = torch.full(
+        (1,), 7 * BLOCK_SIZE, dtype=torch.int32, device=DEVICE
+    )
+
+    seq_lens = torch.full(
+        (idx_mapping.shape[0],),
+        max_blocks * BLOCK_SIZE,
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    shift_draft_block_tables(
+        block_table, idx_mapping, num_cached_tokens, seq_lens, BLOCK_SIZE
+    )
+
+    torch.testing.assert_close(
+        block_table[0, : max_blocks - 7], original[0, 7:]
+    )
+
+
+def test_shift_copy_bounded_by_seq_len():
+    # Only the blocks referenced by the shifted sequence move; the tail of the
+    # row must stay untouched (perf guard for long-context block tables).
+    block_table = _make_block_table(1)
+    original = block_table.clone()
+    idx_mapping = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+    num_cached_tokens = torch.full(
+        (MAX_NUM_REQS,), 4 * BLOCK_SIZE, dtype=torch.int32, device=DEVICE
+    )
+    # Shifted draft length of 3.5 blocks -> exactly 4 blocks copied.
+    seq_lens = torch.full(
+        (1,), 3 * BLOCK_SIZE + BLOCK_SIZE // 2, dtype=torch.int32, device=DEVICE
+    )
+
+    shift_draft_block_tables(
+        block_table, idx_mapping, num_cached_tokens, seq_lens, BLOCK_SIZE
+    )
+
+    torch.testing.assert_close(block_table[0, :4], original[0, 4:8])
+    torch.testing.assert_close(block_table[0, 4:], original[0, 4:])

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -475,6 +475,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.speculator.set_attn(
                 self.model_state, self.kv_cache_config, self.block_tables
             )
+            if hasattr(self.speculator, "set_num_cached_tokens"):
+                # DFlash/DSpark mask cache-restored tokens out of the draft's
+                # context (their draft context KV was never computed).
+                self.speculator.set_num_cached_tokens(
+                    self.req_states.num_cached_tokens.gpu
+                )
 
         self.kv_caches: list[torch.Tensor] = []
         kv_caches_dict = init_kv_cache(

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -62,6 +62,16 @@ class DFlashSpeculator(DraftModelSpeculator):
             self.max_num_tokens, dtype=torch.int64, device=device
         )
 
+        # Per-request-slot count of tokens whose KV was restored (e.g. from the
+        # prefix cache) at the request's last (re)admission, indexed by
+        # req_state_idx. The target never ran a forward pass over them, so
+        # their draft context KV was never computed; the prep kernel and the
+        # block-table shift in propose() hide them from the draft's attention.
+        # The runner replaces this zeros fallback via set_num_cached_tokens.
+        self.num_cached_tokens = torch.zeros(
+            self.max_num_reqs, dtype=torch.int32, device=device
+        )
+
         # Per-mask-token sampling buffers. Flattened from (num_reqs, num_spec_tokens).
         max_num_sampled_tokens = self.max_num_reqs * self.num_speculative_steps
         self.sample_indices = torch.zeros(
@@ -122,6 +132,13 @@ class DFlashSpeculator(DraftModelSpeculator):
     ) -> nn.Module:
         return load_dflash_model(target_model, self.vllm_config)
 
+    def set_num_cached_tokens(self, num_cached_tokens: torch.Tensor) -> None:
+        """Register the runner's per-request-slot cache-restored token counts.
+
+        Indexed by req_state_idx; see the buffer comment in __init__.
+        """
+        self.num_cached_tokens = num_cached_tokens
+
     def set_attn(
         self,
         model_state: ModelState,
@@ -138,6 +155,17 @@ class DFlashSpeculator(DraftModelSpeculator):
         self.draft_block_size = self.block_tables.block_sizes[
             self.draft_kv_cache_group_id
         ]
+        # The shared seq_lens buffer carries the cache-shifted draft sequence
+        # lengths (see _prepare_dflash_inputs_kernel), which only works if all
+        # draft groups shift by the same number of slots per cached block.
+        draft_block_sizes = {
+            self.block_tables.block_sizes[gid]
+            for gid in self.draft_kv_cache_group_ids
+        }
+        assert len(draft_block_sizes) == 1, (
+            "DFlash requires a uniform block size across draft KV cache "
+            f"groups, got {draft_block_sizes}."
+        )
 
         # Per-group context slot buffers for the precompute (one row per group).
         self._context_slot_mappings = torch.zeros(
@@ -338,6 +366,7 @@ class DFlashSpeculator(DraftModelSpeculator):
                 next_prefill_tokens,
                 self.block_tables.input_block_tables[gid],
                 self.block_tables.block_sizes[gid],
+                self.num_cached_tokens,
                 self.parallel_drafting_token_id,
                 self.num_query_per_req,
                 self.num_speculative_steps,
@@ -346,6 +375,27 @@ class DFlashSpeculator(DraftModelSpeculator):
                 self.max_model_len,
                 self.sample_from_anchor,
             )
+
+        # Cache-restored tokens (e.g. prefix-cache hits) never flowed through
+        # the target forward, so their draft context KV was never written and
+        # their cache slots hold garbage. Hide them from the draft's
+        # attention: shift each draft block-table row left by the restored
+        # whole blocks (the prep kernel shortened seq_lens to match). Runs
+        # after prepare_dflash_inputs because the slot mappings index the
+        # unshifted table; in-place is safe because input_block_tables are
+        # regathered from the persistent block tables every step. Up to
+        # block_size - 1 restored slots may remain visible when the restored
+        # count is not block-aligned (e.g. a full-prompt cache hit). Skipped
+        # for dummy runs, whose idx_mapping does not reference live requests.
+        if not dummy_run:
+            for gid in self.draft_kv_cache_group_ids:
+                shift_draft_block_tables(
+                    self.block_tables.input_block_tables[gid],
+                    input_batch.idx_mapping,
+                    self.num_cached_tokens,
+                    self.input_buffers.seq_lens,
+                    self.block_tables.block_sizes[gid],
+                )
 
         # Pre-insert context K/V into the cache. Runs eagerly outside the captured graph
         # because the context shape varies per step. During dummy runs the block tables
@@ -437,6 +487,8 @@ def _prepare_dflash_inputs_kernel(
     # Block table for slot mapping lookup.
     block_table_ptr,
     block_table_stride,
+    # [max_num_reqs] cache-restored token counts, indexed by req_state_idx.
+    num_cached_tokens_ptr,
     # Scalars
     parallel_drafting_token_id,
     block_size,
@@ -527,8 +579,20 @@ def _prepare_dflash_inputs_kernel(
         tl.store(out_query_start_loc_ptr + req_idx, query_base)
         # seq_lens is the absolute sequence length the draft attention
         # reads up to (context + query), not just the count of accepted
-        # tokens this step.
-        tl.store(out_seq_lens_ptr + req_idx, last_valid_pos + 1 + num_query_per_req)
+        # tokens this step — minus the cache-restored whole blocks, which
+        # hold no draft KV and are shifted out of the block table (see
+        # shift_draft_block_tables).
+        num_cached = tl.load(num_cached_tokens_ptr + req_state_idx)
+        num_shifted_slots = (num_cached // block_size) * block_size
+        # The clamp guards dummy runs, where req_state_idx may point at a
+        # stale slot whose cached count exceeds the dummy sequence length.
+        tl.store(
+            out_seq_lens_ptr + req_idx,
+            tl.maximum(
+                last_valid_pos + 1 + num_query_per_req - num_shifted_slots,
+                num_query_per_req,
+            ),
+        )
         if req_idx == num_reqs - 1:
             # Pad per-request buffers to max_num_reqs for CUDA graph safety.
             last_query_end = num_reqs * num_query_per_req
@@ -582,6 +646,8 @@ def prepare_dflash_inputs(
     # [max_num_reqs, max_num_blocks]
     block_table: torch.Tensor,
     block_size: int,
+    # [max_num_reqs]
+    num_cached_tokens: torch.Tensor,
     parallel_drafting_token_id: int,
     num_query_per_req: int,
     num_speculative_steps: int,
@@ -618,6 +684,7 @@ def prepare_dflash_inputs(
         num_rejected,
         block_table,
         block_table.stride(0),
+        num_cached_tokens,
         parallel_drafting_token_id,
         block_size,
         num_query_per_req,
@@ -628,4 +695,64 @@ def prepare_dflash_inputs(
         SAMPLE_FROM_ANCHOR=sample_from_anchor,
         PAD_SLOT_ID=PAD_SLOT_ID,
         BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+
+@triton.jit
+def _shift_draft_block_tables_kernel(
+    block_table_ptr,
+    block_table_stride,
+    idx_mapping_ptr,
+    num_cached_tokens_ptr,
+    seq_lens_ptr,
+    block_size,
+    BLOCK_SIZE: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+    req_state_idx = tl.load(idx_mapping_ptr + req_idx)
+    num_cached = tl.load(num_cached_tokens_ptr + req_state_idx)
+    shift = num_cached // block_size
+    if shift == 0:
+        return
+    row_ptr = block_table_ptr + req_idx.to(tl.int64) * block_table_stride
+    # Only the blocks the shifted sequence still references need to move;
+    # seq_lens holds the cache-shifted draft length (written by
+    # _prepare_dflash_inputs_kernel, which must run first).
+    seq_len = tl.load(seq_lens_ptr + req_idx)
+    num_needed = (seq_len + block_size - 1) // block_size
+    num_remaining = tl.minimum(block_table_stride - shift, num_needed)
+    # In-place left shift is safe: iterations run in ascending order and each
+    # loads its chunk (from offset + shift) before storing (at offset), so no
+    # store ever precedes a load of the same element.
+    for i in tl.range(0, num_remaining, BLOCK_SIZE):
+        offset = i + tl.arange(0, BLOCK_SIZE)
+        mask = offset < num_remaining
+        block_ids = tl.load(row_ptr + offset + shift, mask=mask, other=0)
+        tl.store(row_ptr + offset, block_ids, mask=mask)
+
+
+def shift_draft_block_tables(
+    # [max_num_reqs, max_num_blocks]
+    block_table: torch.Tensor,
+    # [num_reqs]
+    idx_mapping: torch.Tensor,
+    # [max_num_reqs]
+    num_cached_tokens: torch.Tensor,
+    # [num_reqs] cache-shifted draft sequence lengths
+    seq_lens: torch.Tensor,
+    block_size: int,
+) -> None:
+    """Shift each request's draft block-table row left by its cache-restored
+    whole blocks, hiding slots that hold no draft context KV from the draft's
+    attention. Must run after prepare_dflash_inputs (slot mappings index the
+    unshifted table, and seq_lens must already hold the shifted lengths)."""
+    num_reqs = idx_mapping.shape[0]
+    _shift_draft_block_tables_kernel[(num_reqs,)](
+        block_table,
+        block_table.stride(0),
+        idx_mapping,
+        num_cached_tokens,
+        seq_lens,
+        block_size,
+        BLOCK_SIZE=1024,  # type: ignore
     )

--- a/vllm/v1/worker/gpu/states.py
+++ b/vllm/v1/worker/gpu/states.py
@@ -80,6 +80,15 @@ class RequestState:
             self.max_num_reqs, dtype=torch.int32, device=device
         )
 
+        # Tokens whose KV was restored (e.g. from the prefix cache) rather than
+        # computed at the request's most recent (re)admission. The target never
+        # runs a forward pass over them, so speculators that derive per-token
+        # state from target hidden states (DFlash/DSpark context KV) have
+        # nothing for these positions.
+        self.num_cached_tokens = StagedWriteTensor(
+            self.max_num_reqs, dtype=torch.int32, device=device
+        )
+
     @property
     def num_reqs(self) -> int:
         return len(self.req_id_to_index)
@@ -109,6 +118,7 @@ class RequestState:
         self.num_computed_prefill_tokens[req_idx] = num_computed_tokens
         self.num_computed_tokens_np[req_idx] = num_computed_tokens
         self.num_computed_tokens.stage_write_elem(req_idx, num_computed_tokens)
+        self.num_cached_tokens.stage_write_elem(req_idx, num_computed_tokens)
 
         self.draft_tokens[req_idx].zero_()
 
@@ -118,6 +128,7 @@ class RequestState:
         self.total_len.apply_write()
         self.all_token_ids.apply_write()
         self.num_computed_tokens.apply_write()
+        self.num_cached_tokens.apply_write()
 
     def remove_request(self, req_id: str) -> int | None:
         """Return the freed slot index, or None if the request was not found."""


### PR DESCRIPTION
## Purpose

DFlash/DSpark drafters build their context KV from the target's auxiliary hidden states, which only exist for tokens that flow through a target forward pass (`precompute_and_store_context_kv`, written per step for the scheduled tokens in `DFlashSpeculator.propose`). Tokens whose KV is restored at request (re)admission — automatic prefix caching hits, KV-connector restores, resumption after preemption — never run through the target, so their draft context KV slots are never written. The draft's attention nevertheless spans the full sequence (`seq_lens = last_valid_pos + 1 + num_query_per_req` in `_prepare_dflash_inputs_kernel`), so it reads uninitialized/stale KV for the whole restored region.

The impact scales with the cache-hit length: workloads where requests share a long common prefix degrade toward position-0-only acceptance with `mean acceptance length ~1.0` (drafts are garbage from the first position), while MTP/EAGLE-style drafters on the same workload are unaffected because they draft from the last decode hidden state and build no context KV — which is what makes this easy to misattribute to the speculator checkpoint or quantization. Existing public DSpark benchmark recipes work around it by serving with `--no-enable-prefix-caching`, giving up prefix caching entirely.

This PR keeps prefix caching enabled and instead hides the restored tokens from the draft's attention:

- `RequestState.num_cached_tokens` (new): per request-slot count of tokens whose KV was restored at the most recent (re)admission, taken from the `num_computed_tokens` already passed to `add_request` (covers APC hits, connector restores, and resume-after-preemption uniformly).
- `GPUModelRunner` hands the buffer to the speculator via `set_num_cached_tokens` (hasattr-guarded; only DFlash/DSpark opt in).
- `_prepare_dflash_inputs_kernel` shortens the draft's `seq_lens` by the restored *whole blocks*, and a new Triton kernel (`shift_draft_block_tables`) left-shifts each request's draft block-table row in place by the same amount, so the draft attends only over slots that actually hold draft KV.

Design notes:

- The in-place shift is safe: `input_block_tables` are regathered from the persistent block tables every step, the shift runs after `prepare_dflash_inputs` (slot mappings index the unshifted table), and all consumers are ordered on the same stream. It is CUDA-graph compatible — graphs read the live buffer contents at replay.
- No position rewriting is needed: draft KV stores post-RoPE keys at absolute positions, and the shift is whole-block, so logical-to-physical block lookups agree between the (absolute) write path and the (shifted) read path.
- Requests without cache hits shift by zero and are bit-identical to current behavior; same for dense DFlash/DSpark checkpoints.
- Dummy runs skip the shift (their `idx_mapping` doesn't reference live requests) and the kernel clamps `seq_lens` to at least the query length as a guard.
- Known limitation: when the restored count is not block-aligned (e.g. a full-prompt cache hit, which recomputes only the last token), up to `block_size - 1` restored slots remain visible to the draft. Output correctness is unaffected (rejection sampling), and the common APC case is block-aligned.

The draft loses the cached prefix from its visible context — bounded in practice by the drafter's training window anyway — in exchange for prefix caching and DFlash/DSpark composing at all. A follow-up could restore the full-context case by letting the draft KV cache group's blocks be reused with validity guarantees (the block-reuse machinery already exists; the gap is that `cache_full_blocks` is content-agnostic, so ingestion paths where the drafter never ran — e.g. KV-connector restores — can cache draft-group blocks that were never written). Happy to open that as a separate issue/RFC.

## Test Plan

- New unit tests: `tests/v1/spec_decode/test_dflash_prefix_cache_masking.py` — shift kernel correctness for aligned/unaligned/zero shifts, per-request shifts through `idx_mapping`, and the overlapping in-place copy on long rows.
- End-to-end A/B with aiperf on GLM-5.2 (`eigen-ai-labs/GLM-5.2-NVFP4`, TP=4, B200) + `RedHatAI/GLM-5.2-speculator.dspark`, prefix caching **enabled** in both runs:

```
--speculative-config '{"model": "RedHatAI/GLM-5.2-speculator.dspark",
  "num_speculative_tokens": 7, "method": "dspark",
  "attention_backend": "FLASH_ATTN", "draft_sample_method": "probabilistic"}'
```

aiperf: `--public-dataset spec-bench --extra-inputs temperature:0 top_p:1 --output-tokens-mean 256 --output-tokens-stddev 128 --concurrency 8 --request-count 200`, isolated pod, metrics from `vllm:spec_decode_num_accepted_tokens` / `vllm:spec_decode_num_draft_tokens` / draft-step counters over the run window.

## Test Result

SpecBench prompts are short, so cache hits only cover the shared chat-template/system prefix — even that is enough to measurably depress acceptance before the fix:

| aiperf spec-bench (temp=0, 200/200 ok) | before (same nightly) | after (this PR) |
|---|---|---|
| Token acceptance (accepted / draft) | 20.6% | **27.6%** (19,871 / 71,890) |
| Accepted draft tokens per step | 1.44 | **1.93** (19,871 / 10,270) |

Per-position accepted counts after the fix decay smoothly (pos0→pos6): 7,506 / 4,887 / 3,084 / 1,925 / 1,236 / 765 / 468 — versus an effectively position-0-only profile on cache-hit tokens before.

The improvement grows with the shared-prefix length of the workload. On an internal benchmark with a long shared system-prompt prefix (~20k tokens, near-total prefix-cache hit rate; same serve config, aiperf, temperature/top_p at serving defaults, concurrency 8, 200/200 ok):

| internal long-shared-prefix benchmark | before (same nightly) | after (this PR) |
|---|---|---|
| Token acceptance (accepted / draft) | ~0.6% | **38.2%** (40,689 / 106,575) |
| Mean acceptance length (vLLM log) | ~1.02 | **3.41** |
| Per-position acceptance rate (log) | pos0-only ~2–5%, pos1+ ≈ 0 | **83.5 / 57.2 / 38.9 / 27.8 / 16.8 / 11.1 / 6.0 %** |

i.e. speculative decoding goes from fully broken (drafts rejected from position 0) to a healthy per-position decay in line with the speculator's model card, without disabling prefix caching.

---

<details>
<summary>Essential Elements checklist</summary>

- [x] Purpose of the PR explained
- [x] Test plan included
- [x] Test results included
- [ ] (docs update not applicable)
</details>
