### PR TITLE
Preserve DeepSeek sigmoid grouped routing metadata

### DIFF
--- a/tests/models/test_deepseek_v4_moe_routing.py
+++ b/tests/models/test_deepseek_v4_moe_routing.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.models.deepseek_v4.nvidia import model as deepseek_v4_model
+from vllm.models.deepseek_v4.nvidia.model import DeepseekV4MoE
+
+
+class _FakeFusedMoE:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _make_config(*, scoring_func: str, n_group: int | None, topk_group: int | None):
+    config = SimpleNamespace(
+        n_shared_experts=None,
+        n_routed_experts=8,
+        num_experts_per_tok=2,
+        hidden_size=16,
+        moe_intermediate_size=32,
+        norm_topk_prob=True,
+        swiglu_limit=None,
+        n_group=n_group,
+        topk_group=topk_group,
+    )
+    gate = SimpleNamespace(
+        e_score_correction_bias=torch.zeros(config.n_routed_experts),
+        tid2eid=None,
+    )
+    moe = DeepseekV4MoE.__new__(DeepseekV4MoE)
+    torch.nn.Module.__init__(moe)
+    moe.tp_size = 1
+    moe.n_routed_experts = config.n_routed_experts
+    moe.shared_experts = None
+    moe.gate = gate
+    moe.scoring_func = scoring_func
+    moe.routed_scaling_factor = 2.5
+    moe.swiglu_limit = None
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            eplb_config=SimpleNamespace(num_redundant_experts=0),
+            enable_eplb=False,
+        )
+    )
+    return moe, vllm_config, config
+
+
+@pytest.mark.parametrize(
+    ("n_group", "topk_group"),
+    [
+        (1, 1),
+        (2, 1),
+    ],
+)
+def test_deepseek_v4_sigmoid_preserves_grouped_routing(
+    monkeypatch,
+    n_group,
+    topk_group,
+):
+    monkeypatch.setattr(deepseek_v4_model, "FusedMoE", _FakeFusedMoE)
+    monkeypatch.setattr(deepseek_v4_model, "get_tensor_model_parallel_rank", lambda: 0)
+    moe, vllm_config, config = _make_config(
+        scoring_func="sigmoid",
+        n_group=n_group,
+        topk_group=topk_group,
+    )
+
+    moe._init_fused_moe_experts(
+        vllm_config,
+        config,
+        quant_config=None,
+        prefix="model.layers.0.mlp",
+    )
+
+    assert moe.experts.kwargs["use_grouped_topk"] is True
+    assert moe.experts.kwargs["num_expert_group"] == n_group
+    assert moe.experts.kwargs["topk_group"] == topk_group
+
+
+@pytest.mark.parametrize(
+    ("n_group", "topk_group"),
+    [
+        (None, 1),
+        (1, None),
+        (0, 1),
+        (1, 0),
+    ],
+)
+def test_deepseek_v4_sigmoid_clears_invalid_group_routing(
+    monkeypatch,
+    n_group,
+    topk_group,
+):
+    monkeypatch.setattr(deepseek_v4_model, "FusedMoE", _FakeFusedMoE)
+    monkeypatch.setattr(deepseek_v4_model, "get_tensor_model_parallel_rank", lambda: 0)
+    moe, vllm_config, config = _make_config(
+        scoring_func="sigmoid",
+        n_group=n_group,
+        topk_group=topk_group,
+    )
+
+    moe._init_fused_moe_experts(
+        vllm_config,
+        config,
+        quant_config=None,
+        prefix="model.layers.0.mlp",
+    )
+
+    assert moe.experts.kwargs["use_grouped_topk"] is False
+    assert moe.experts.kwargs["num_expert_group"] is None
+    assert moe.experts.kwargs["topk_group"] is None
+
+
+@pytest.mark.parametrize("scoring_func", ["softmax", "sqrtsoftplus"])
+def test_deepseek_v4_non_sigmoid_clears_single_group_routing(monkeypatch, scoring_func):
+    monkeypatch.setattr(deepseek_v4_model, "FusedMoE", _FakeFusedMoE)
+    monkeypatch.setattr(deepseek_v4_model, "get_tensor_model_parallel_rank", lambda: 0)
+    moe, vllm_config, config = _make_config(
+        scoring_func=scoring_func,
+        n_group=1,
+        topk_group=1,
+    )
+
+    moe._init_fused_moe_experts(
+        vllm_config,
+        config,
+        quant_config=None,
+        prefix="model.layers.0.mlp",
+    )
+
+    assert moe.experts.kwargs["use_grouped_topk"] is False
+    assert moe.experts.kwargs["num_expert_group"] is None
+    assert moe.experts.kwargs["topk_group"] is None

--- a/tests/models/test_deepseek_v4_moe_routing.py
+++ b/tests/models/test_deepseek_v4_moe_routing.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.models.deepseek_v4.nvidia import model as deepseek_v4_model
+from vllm.models.deepseek_v4.nvidia.model import DeepseekV4MoE
+
+
+class _FakeFusedMoEFactory:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _make_config(*, scoring_func: str, n_group: int | None, topk_group: int | None):
+    config = SimpleNamespace(
+        n_shared_experts=None,
+        n_routed_experts=8,
+        num_experts_per_tok=2,
+        hidden_size=16,
+        moe_intermediate_size=32,
+        norm_topk_prob=True,
+        swiglu_limit=None,
+        n_group=n_group,
+        topk_group=topk_group,
+    )
+    gate = SimpleNamespace(
+        e_score_correction_bias=torch.zeros(config.n_routed_experts),
+        tid2eid=None,
+    )
+    moe = DeepseekV4MoE.__new__(DeepseekV4MoE)
+    torch.nn.Module.__init__(moe)
+    moe.tp_size = 1
+    moe.use_sequence_parallel = False
+    moe.n_routed_experts = config.n_routed_experts
+    moe.shared_experts = None
+    moe.gate = gate
+    moe.scoring_func = scoring_func
+    moe.routed_scaling_factor = 2.5
+    moe.swiglu_limit = None
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            eplb_config=SimpleNamespace(num_redundant_experts=0),
+            enable_eplb=False,
+        )
+    )
+    return moe, vllm_config, config
+
+
+@pytest.mark.parametrize(
+    ("n_group", "topk_group"),
+    [
+        (1, 1),
+        (2, 1),
+    ],
+)
+def test_deepseek_v4_sigmoid_preserves_grouped_routing(
+    monkeypatch,
+    n_group,
+    topk_group,
+):
+    monkeypatch.setattr(deepseek_v4_model, "FusedMoEFactory", _FakeFusedMoEFactory)
+    monkeypatch.setattr(deepseek_v4_model, "get_tensor_model_parallel_rank", lambda: 0)
+    moe, vllm_config, config = _make_config(
+        scoring_func="sigmoid",
+        n_group=n_group,
+        topk_group=topk_group,
+    )
+
+    moe._init_fused_moe_experts(
+        vllm_config,
+        config,
+        quant_config=None,
+        prefix="model.layers.0.mlp",
+    )
+
+    assert moe.experts.kwargs["use_grouped_topk"] is True
+    assert moe.experts.kwargs["num_expert_group"] == n_group
+    assert moe.experts.kwargs["topk_group"] == topk_group
+
+
+@pytest.mark.parametrize(
+    ("n_group", "topk_group"),
+    [
+        (None, 1),
+        (1, None),
+        (0, 1),
+        (1, 0),
+    ],
+)
+def test_deepseek_v4_sigmoid_clears_invalid_group_routing(
+    monkeypatch,
+    n_group,
+    topk_group,
+):
+    monkeypatch.setattr(deepseek_v4_model, "FusedMoEFactory", _FakeFusedMoEFactory)
+    monkeypatch.setattr(deepseek_v4_model, "get_tensor_model_parallel_rank", lambda: 0)
+    moe, vllm_config, config = _make_config(
+        scoring_func="sigmoid",
+        n_group=n_group,
+        topk_group=topk_group,
+    )
+
+    moe._init_fused_moe_experts(
+        vllm_config,
+        config,
+        quant_config=None,
+        prefix="model.layers.0.mlp",
+    )
+
+    assert moe.experts.kwargs["use_grouped_topk"] is False
+    assert moe.experts.kwargs["num_expert_group"] is None
+    assert moe.experts.kwargs["topk_group"] is None
+
+
+@pytest.mark.parametrize("scoring_func", ["softmax", "sqrtsoftplus"])
+def test_deepseek_v4_non_sigmoid_clears_single_group_routing(monkeypatch, scoring_func):
+    monkeypatch.setattr(deepseek_v4_model, "FusedMoEFactory", _FakeFusedMoEFactory)
+    monkeypatch.setattr(deepseek_v4_model, "get_tensor_model_parallel_rank", lambda: 0)
+    moe, vllm_config, config = _make_config(
+        scoring_func=scoring_func,
+        n_group=1,
+        topk_group=1,
+    )
+
+    moe._init_fused_moe_experts(
+        vllm_config,
+        config,
+        quant_config=None,
+        prefix="model.layers.0.mlp",
+    )
+
+    assert moe.experts.kwargs["use_grouped_topk"] is False
+    assert moe.experts.kwargs["num_expert_group"] is None
+    assert moe.experts.kwargs["topk_group"] is None

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -669,6 +669,19 @@ class DeepseekV4MoE(nn.Module):
         self.physical_expert_start = self.experts_start_idx
         self.physical_expert_end = self.experts_end_idx
 
+        num_expert_group = getattr(config, "n_group", None)
+        topk_group = getattr(config, "topk_group", None)
+        use_grouped_topk = (
+            self.scoring_func == "sigmoid"
+            and num_expert_group is not None
+            and topk_group is not None
+            and num_expert_group > 0
+            and topk_group > 0
+        )
+        if not use_grouped_topk:
+            num_expert_group = None
+            topk_group = None
+
         self.experts = FusedMoE(
             shared_experts=self.shared_experts,
             gate=self.gate,
@@ -682,6 +695,9 @@ class DeepseekV4MoE(nn.Module):
             scoring_func=self.scoring_func,
             routed_scaling_factor=self.routed_scaling_factor,
             e_score_correction_bias=self.gate.e_score_correction_bias,
+            use_grouped_topk=use_grouped_topk,
+            num_expert_group=num_expert_group,
+            topk_group=topk_group,
             hash_indices_table=self.gate.tid2eid,
             swiglu_limit=self.swiglu_limit,
             router_logits_dtype=torch.float32,

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -913,6 +913,19 @@ class DeepseekV4MoE(nn.Module):
         self.physical_expert_start = self.experts_start_idx
         self.physical_expert_end = self.experts_end_idx
 
+        num_expert_group = getattr(config, "n_group", None)
+        topk_group = getattr(config, "topk_group", None)
+        use_grouped_topk = (
+            self.scoring_func == "sigmoid"
+            and num_expert_group is not None
+            and topk_group is not None
+            and num_expert_group > 0
+            and topk_group > 0
+        )
+        if not use_grouped_topk:
+            num_expert_group = None
+            topk_group = None
+
         self.experts = FusedMoEFactory(
             shared_experts=self.shared_experts,
             gate=self.gate,
@@ -926,6 +939,9 @@ class DeepseekV4MoE(nn.Module):
             scoring_func=self.scoring_func,
             routed_scaling_factor=self.routed_scaling_factor,
             e_score_correction_bias=self.gate.e_score_correction_bias,
+            use_grouped_topk=use_grouped_topk,
+            num_expert_group=num_expert_group,
+            topk_group=topk_group,
             hash_indices_table=self.gate.tid2eid,
             swiglu_limit=self.swiglu_limit,
             router_logits_dtype=torch.float32,


### PR DESCRIPTION



## Purpose

GLM-style DeepSeekV4/DSA models can use sigmoid routing with an expert-score correction bias, norm_topk_prob=True, n_group/topk_group metadata, and a non-unit routed scaling factor. With no group metadata passed to FusedMoE, the router is classified as RoutingMethodType.Unspecified: the bias-aware top-k router has no way to distinguish an explicit grouped DeepSeek router from not-a-grouped-router at all.

That classification matters for NVFP4 FlashInfer TRTLLM MoE. The monolithic TRTLLM expert path supports RoutingMethodType.DeepSeekV3, but intentionally does not claim Unspecified. Losing grouped routing metadata can therefore push the model onto a modular/pre-routed path instead of the monolithic from-logits path, bypassing FlashInfer fixes that are specific to DeepSeekV3 routing.

Propagate the model n_group and topk_group into FusedMoE for valid sigmoid routers only. A one-group router is semantically equivalent to selecting top-k over all experts, but it preserves the DeepSeekV3 routing contract for kernel selection and for backends that consume the routing metadata directly. Do not apply this to sqrtsoftplus DeepSeekV4 routing, which is a different routing method with different kernel support.

## Test Plan

Add CPU model tests that monkeypatch FusedMoE and verify valid sigmoid grouped routing metadata is preserved for both single-group and ordinary grouped cases. The tests also verify invalid group metadata is cleared and non-sigmoid routing still clears the same metadata.

## Test Result

new unit test cases passes, this PR combined with https://github.com/flashinfer-ai/flashinfer/pull/3875 also seems to resolve https://github.com/vllm-project/vllm/issues/42426#issuecomment-4908867521 in our real world usage

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

