### PR TITLE
Account scheduled spec slots on empty output rows

### DIFF
--- a/tests/v1/core/test_async_scheduler.py
+++ b/tests/v1/core/test_async_scheduler.py
@@ -369,3 +369,57 @@ def test_no_placeholder_underflow_on_discarded_spec_frame():
     assert req.num_computed_tokens == computed_before
     assert req.async_tokens_to_discard == num_spec - 1
     assert req.status == RequestStatus.RUNNING
+
+
+@pytest.mark.parametrize(
+    "generated_token_ids",
+    [
+        [],
+        [123],
+        [123, 124, 125],
+    ],
+)
+def test_spec_output_row_refunds_unmaterialized_scheduled_slots(
+    generated_token_ids: list[int],
+):
+    num_spec = 5
+    scheduler = create_scheduler(
+        async_scheduling=True,
+        num_speculative_tokens=num_spec,
+        speculative_method="ngram_gpu",
+    )
+    req = create_requests(num_requests=1, max_tokens=20)[0]
+    scheduler.requests[req.request_id] = req
+    scheduler.running.append(req)
+    req.status = RequestStatus.RUNNING
+
+    scheduled_slots = 1 + num_spec
+    req.num_computed_tokens = req.num_tokens + scheduled_slots
+    req.num_output_placeholders = scheduled_slots
+
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={req.request_id: scheduled_slots},
+        total_num_scheduled_tokens=scheduled_slots,
+        scheduled_encoder_inputs={},
+        scheduled_spec_decode_tokens={req.request_id: [10] * num_spec},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[req.request_id],
+        req_id_to_index={req.request_id: 0},
+        sampled_token_ids=[generated_token_ids],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert req.num_computed_tokens == req.num_tokens
+    assert req.num_output_placeholders == 0
+    assert list(req.output_token_ids) == generated_token_ids
+    assert req.status == RequestStatus.RUNNING

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1588,28 +1588,46 @@ class Scheduler(SchedulerInterface):
             scheduled_spec_token_ids = (
                 scheduler_output.scheduled_spec_decode_tokens.get(req_id)
             )
-            # Skip a stale frame still pending discard (async_tokens_to_discard
-            # > 0): its pre-reset rejection count would underflow the counters.
+            # Account any materialized or rejected output slots for this
+            # speculative step. Skip a stale frame still pending discard
+            # (async_tokens_to_discard > 0): its pre-reset rejection count
+            # would underflow the counters.
             if (
                 scheduled_spec_token_ids
-                and (generated_token_ids or self.num_sampled_tokens_per_step == 0)
                 and request.async_tokens_to_discard == 0
             ):
                 num_draft_tokens = len(scheduled_spec_token_ids)
                 num_sampled = self.num_sampled_tokens_per_step
-                num_accepted = max(len(generated_token_ids) - num_sampled, 0)
-                num_rejected = num_draft_tokens - num_accepted
+                num_materialized = len(generated_token_ids)
+                num_accepted = max(num_materialized - num_sampled, 0)
+                num_accepted = min(num_accepted, num_draft_tokens)
+                num_scheduled_output_slots = num_sampled + num_draft_tokens
+                num_scheduled_output_slots = min(
+                    num_scheduled_output_slots,
+                    num_scheduled_tokens.get(req_id, num_scheduled_output_slots),
+                )
+                num_unmaterialized = max(
+                    num_scheduled_output_slots - num_materialized, 0
+                )
                 # num_computed_tokens represents the number of tokens
                 # processed in the current step, considering scheduled
                 # tokens and rejections. If some tokens are rejected,
                 # num_computed_tokens is decreased by the number of rejected
                 # tokens.
                 if request.num_computed_tokens > 0:
-                    request.num_computed_tokens -= num_rejected
+                    request.num_computed_tokens -= min(
+                        num_unmaterialized, request.num_computed_tokens
+                    )
                 # If async scheduling, num_output_placeholders also includes
-                # the scheduled spec tokens count and so is similarly adjusted.
+                # the scheduled sampled/spec token slots and so is similarly
+                # adjusted. When generated_token_ids is empty,
+                # _update_request_with_output() does not drain the sampled
+                # slot, so it is included in num_unmaterialized.
                 if request.num_output_placeholders > 0:
-                    request.num_output_placeholders -= num_rejected
+                    request.num_output_placeholders -= min(
+                        num_unmaterialized,
+                        request.num_output_placeholders,
+                    )
                 spec_decoding_stats = self.make_spec_decoding_stats(
                     spec_decoding_stats,
                     num_draft_tokens=num_draft_tokens,


### PR DESCRIPTION




## Purpose

The async scheduler reserves output slots before a speculative decode step finishes. For MTP with five draft tokens, a decode step can reserve six output slots: one sampled token slot plus five draft slots. Normal rejection sampling later drains the unmaterialized draft slots after the worker output is applied.

The old accounting only ran when both `scheduled_spec_token_ids` and `generated_token_ids` were non-empty. If the worker row parsed to an empty token list, neither accepted-token application nor rejected-token accounting ran. Repeated empty rows then leaked `num_computed_tokens` and async `num_output_placeholders` until the request reached its model-length scheduling budget with no real output progress.

GLM-5.2 reproduced this with real high-KV MTP traffic. One observed empty-row source was a recovered sampled token equal to `vocab_size`; vLLM 0.24 already contains the upstream sampler boundary fix for that case. This patch keeps the scheduler invariant robust regardless of the empty-row source: if a request had speculative output slots scheduled, every unmaterialized scheduled slot is refunded even when the parsed output row is empty.

The subtle point is the sampled/base slot. Prior upstream discussion in vllm-project/vllm#42722 noted that rolling back only rejected draft tokens is not sufficient for an empty autoregressive row. When no token materializes, the sampled slot must also be rolled back so the request can schedule the same position again instead of remaining one token ahead of concrete output.

For normal rows this reduces to the existing behavior:

- one sampled token and no accepted drafts materialized -> drain all drafts;
- sampled token plus accepted drafts materialized -> drain only the missing scheduled slots;
- all scheduled slots materialized -> drain nothing.

The unmaterialized-slot count is capped by the request's actual scheduled token count for this step, so sync and async speculative decode paths do not over- rollback if they reserve different sampled-token shapes.

## Test Plan

Added a simple unit test to handle this case. It is very difficult to share a reliable e2e reproducer, you need to figure out a way to produce invalid outputs to trigger, this, one way is to trigger the bug fixed by https://github.com/vllm-project/vllm/pull/47927 without that fix, when using MTP, we see these invalid outputs which trigger the scheduler accounting issues.

## Test Result

basic UT passes, resolves real world hangs in scheduler under reproduction scenario

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

