### PR TITLE
[Bugfix][Frontend] Return tool_calls finish reason from derendered tool calls

### DIFF
--- a/vllm/renderers/online_derenderer.py
+++ b/vllm/renderers/online_derenderer.py
@@ -135,6 +135,16 @@ class OnlineDerenderer:
                     if tool_calls
                     else []
                 )
+                auto_tools_called = (
+                    bool(tc_items)
+                    and bool(chat_request.tools)
+                    and (
+                        chat_request.tool_choice == "auto"
+                        or chat_request.tool_choice is None
+                    )
+                    and self.enable_auto_tools
+                )
+                is_required_tool_choice = chat_request.tool_choice == "required"
 
                 message = ChatMessage(
                     role="assistant",
@@ -142,19 +152,30 @@ class OnlineDerenderer:
                     content=content,
                     tool_calls=tc_items,
                 )
+                finish_reason = (
+                    "tool_calls"
+                    if auto_tools_called
+                    or (
+                        is_required_tool_choice
+                        and bool(tc_items)
+                        and choice.finish_reason == "stop"
+                    )
+                    else choice.finish_reason
+                )
             else:
                 # No parser: plain detokenization.
                 decoded_text = tokenizer.decode(
                     choice.token_ids, skip_special_tokens=True
                 )
                 message = ChatMessage(role="assistant", content=decoded_text)
+                finish_reason = choice.finish_reason
 
             choices.append(
                 ChatCompletionResponseChoice(
                     index=choice.index,
                     message=message,
                     logprobs=resolved_logprobs,
-                    finish_reason=choice.finish_reason,
+                    finish_reason=finish_reason,
                 )
             )
 


### PR DESCRIPTION

## Purpose

`/v1/chat/completions/derender` can parse generated token ids into `message.tool_calls` when the caller passes the original `chat_request`. Today that parsed response still forwards the generate-side `finish_reason="stop"`, so a successful response can contain `message.tool_calls` while telling OpenAI-compatible clients that generation stopped normally.

The coupled chat completion path already reports `finish_reason="tool_calls"` for auto and required tool calls. This applies the same rule to derendered chat choices while preserving the named tool-choice behavior.

## Test Plan

I reproduced the bug through the real render-only HTTP server using `Qwen/Qwen3-0.6B`, Hermes tool parsing, `/v1/chat/completions/render`, and `/v1/chat/completions/derender`. I also ran scoped ruff/format/diff checks on the runtime file.

## Test Result

Before the fix, derender returned a parsed `get_weather` tool call with `finish_reason="stop"`. After the fix, the same HTTP request returned `finish_reason="tool_calls"`. Removing the fix restored the `stop` finish reason.

<details>
<summary>HTTP render/derender reproduction</summary>

Environment:

```text
c4090
vLLM upstream main 3dd910da4222f52b4def7bd67d670e2ace9ede1a
Command path: vllm launch render Qwen/Qwen3-0.6B --enable-auto-tool-choice --tool-call-parser hermes
The render server only loads tokenizer/config and was run with CUDA_VISIBLE_DEVICES="".
```

`repro_derender_tool_finish.py`:

```python
import json
import os
import socket
import subprocess
import sys
import time
import urllib.error
import urllib.request

from vllm.tokenizers import get_tokenizer


MODEL_NAME = os.environ.get("MODEL_NAME", "Qwen/Qwen3-0.6B")
EXPECT_FINISH_REASON = os.environ.get("EXPECT_FINISH_REASON")
TOOL_CALL_PARSER = os.environ.get("TOOL_CALL_PARSER", "hermes")
REASONING_PARSER = os.environ.get("REASONING_PARSER")

MESSAGES = [{"role": "user", "content": "Weather in Paris?"}]
TOOLS = [
    {
        "type": "function",
        "function": {
            "name": "get_weather",
            "description": "Get weather for a city",
            "parameters": {
                "type": "object",
                "properties": {"city": {"type": "string"}},
            },
        },
    }
]
ASSISTANT_TOOL_MESSAGE = {
    "role": "assistant",
    "tool_calls": [
        {
            "type": "function",
            "function": {
                "name": "get_weather",
                "arguments": '{"city": "Paris"}',
            },
        }
    ],
}


def free_port() -> int:
    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
        sock.bind(("127.0.0.1", 0))
        return int(sock.getsockname()[1])


def request_json(method: str, url: str, payload: dict | None = None) -> object:
    data = None
    headers = {}
    if payload is not None:
        data = json.dumps(payload).encode()
        headers["content-type"] = "application/json"
    request = urllib.request.Request(url, data=data, headers=headers, method=method)
    with urllib.request.urlopen(request, timeout=60) as response:
        return json.loads(response.read().decode() or "null")


def wait_ready(base_url: str, proc: subprocess.Popen) -> None:
    deadline = time.time() + 240
    last_error = None
    while time.time() < deadline:
        if proc.poll() is not None:
            raise RuntimeError(f"server exited early with rc={proc.returncode}")
        try:
            request_json("GET", f"{base_url}/health")
            return
        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
            last_error = exc
            time.sleep(1)
    raise RuntimeError(f"server did not become ready: {last_error!r}")


def assistant_output_ids() -> list[int]:
    tokenizer = get_tokenizer(MODEL_NAME, trust_remote_code=True)
    if "gpt-oss" in MODEL_NAME:
        prompt_text = tokenizer.apply_chat_template(
            MESSAGES, add_generation_prompt=True, tokenize=False
        )
        full_text = tokenizer.apply_chat_template(
            MESSAGES + [ASSISTANT_TOOL_MESSAGE],
            add_generation_prompt=False,
            tokenize=False,
        )
        prompt_ids = tokenizer.encode(prompt_text)
        full_ids = tokenizer.encode(full_text)
        output_ids = list(full_ids[len(prompt_ids) :])
    else:
        output_text = (
            '<tool_call>\n{"name": "get_weather", '
            '"arguments": {"city": "Paris"}}\n</tool_call>'
        )
        output_ids = tokenizer.encode(output_text, add_special_tokens=False)
        decoded = tokenizer.decode(output_ids, skip_special_tokens=False)
        if "<tool_call>" not in decoded or "</tool_call>" not in decoded:
            raise RuntimeError(f"tool-call markers did not survive: {decoded!r}")
    if not output_ids:
        raise RuntimeError("failed to extract assistant tool-call token ids")
    return output_ids


def post_render(base_url: str) -> dict:
    result = request_json(
        "POST",
        f"{base_url}/v1/chat/completions/render",
        {"model": MODEL_NAME, "messages": MESSAGES},
    )
    assert isinstance(result, dict), result
    return result


def post_derender(base_url: str, output_ids: list[int], prompt_tokens: int) -> dict:
    result = request_json(
        "POST",
        f"{base_url}/v1/chat/completions/derender",
        {
            "model": MODEL_NAME,
            "generate_response": {
                "request_id": "chatcmpl-derender-tool-test",
                "choices": [
                    {
                        "index": 0,
                        "token_ids": output_ids,
                        "finish_reason": "stop",
                    }
                ],
            },
            "prompt_tokens": prompt_tokens,
            "chat_request": {
                "model": MODEL_NAME,
                "messages": MESSAGES,
                "tools": TOOLS,
                "tool_choice": "auto",
            },
        },
    )
    assert isinstance(result, dict), result
    return result


def run_probe(base_url: str) -> int:
    output_ids = assistant_output_ids()
    rendered = post_render(base_url)
    prompt_tokens = len(rendered["token_ids"])
    derendered = post_derender(base_url, output_ids, prompt_tokens)
    choice = derendered["choices"][0]
    tool_calls = choice["message"].get("tool_calls") or []
    tool_names = [
        item["function"]["name"]
        for item in tool_calls
        if item.get("function") is not None
    ]
    output = {
        "model": MODEL_NAME,
        "prompt_tokens": prompt_tokens,
        "output_token_ids": output_ids,
        "finish_reason": choice["finish_reason"],
        "tool_names": tool_names,
        "content": choice["message"].get("content"),
        "expect_finish_reason": EXPECT_FINISH_REASON,
    }
    print(json.dumps(output, indent=2, ensure_ascii=False))

    if "get_weather" not in tool_names:
        return 3
    if EXPECT_FINISH_REASON is None:
        return 0
    return 0 if choice["finish_reason"] == EXPECT_FINISH_REASON else 2


def main() -> int:
    port = free_port()
    base_url = f"http://127.0.0.1:{port}"
    env = os.environ.copy()
    env.setdefault("VLLM_NO_USAGE_STATS", "1")
    env.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
    cmd = [
        sys.executable,
        "-m",
        "vllm.entrypoints.cli.main",
        "launch",
        "render",
        MODEL_NAME,
        "--host",
        "127.0.0.1",
        "--port",
        str(port),
        "--trust-remote-code",
        "--enable-auto-tool-choice",
        "--tool-call-parser",
        TOOL_CALL_PARSER,
    ]
    if REASONING_PARSER:
        cmd.extend(["--reasoning-parser", REASONING_PARSER])
    proc = subprocess.Popen(cmd, env=env)
    try:
        wait_ready(base_url, proc)
        return run_probe(base_url)
    finally:
        proc.terminate()
        try:
            proc.wait(timeout=20)
        except subprocess.TimeoutExpired:
            proc.kill()
            proc.wait(timeout=20)


if __name__ == "__main__":
    raise SystemExit(main())
```

Before, on upstream main:

```bash
PYTHONPATH=$PWD HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
  VLLM_NO_USAGE_STATS=1 CUDA_VISIBLE_DEVICES="" MODEL_NAME=Qwen/Qwen3-0.6B \
  TOOL_CALL_PARSER=hermes EXPECT_FINISH_REASON=stop \
  python repro_derender_tool_finish.py
echo BEFORE_RC=$?
```

```json
{
  "model": "Qwen/Qwen3-0.6B",
  "prompt_tokens": 12,
  "output_token_ids": [151657, 198, 4913, 606, 788, 330, 455, 69364, 497, 330, 16370, 788, 5212, 8926, 788, 330, 59604, 95642, 151658],
  "finish_reason": "stop",
  "tool_names": ["get_weather"],
  "content": null,
  "expect_finish_reason": "stop"
}
BEFORE_RC=0
```

After, on this PR checkout:

```bash
PYTHONPATH=$PWD HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
  VLLM_NO_USAGE_STATS=1 CUDA_VISIBLE_DEVICES="" MODEL_NAME=Qwen/Qwen3-0.6B \
  TOOL_CALL_PARSER=hermes EXPECT_FINISH_REASON=tool_calls \
  python repro_derender_tool_finish.py
echo AFTER_RC=$?
```

```json
{
  "model": "Qwen/Qwen3-0.6B",
  "prompt_tokens": 12,
  "output_token_ids": [151657, 198, 4913, 606, 788, 330, 455, 69364, 497, 330, 16370, 788, 5212, 8926, 788, 330, 59604, 95642, 151658],
  "finish_reason": "tool_calls",
  "tool_names": ["get_weather"],
  "content": null,
  "expect_finish_reason": "tool_calls"
}
AFTER_RC=0
```

Reverse:

```bash
git diff upstream/main...HEAD -- vllm/renderers/online_derenderer.py > /tmp/derender-tool-finish.patch
git apply -R /tmp/derender-tool-finish.patch
PYTHONPATH=$PWD HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
  VLLM_NO_USAGE_STATS=1 CUDA_VISIBLE_DEVICES="" MODEL_NAME=Qwen/Qwen3-0.6B \
  TOOL_CALL_PARSER=hermes EXPECT_FINISH_REASON=stop \
  python repro_derender_tool_finish.py
echo REVERT_RC=$?
git apply /tmp/derender-tool-finish.patch
```

```json
{
  "model": "Qwen/Qwen3-0.6B",
  "prompt_tokens": 12,
  "output_token_ids": [151657, 198, 4913, 606, 788, 330, 455, 69364, 497, 330, 16370, 788, 5212, 8926, 788, 330, 59604, 95642, 151658],
  "finish_reason": "stop",
  "tool_names": [
    "get_weather"
  ],
  "content": null,
  "expect_finish_reason": "stop"
}
REVERT_RC=0
```

</details>

<details>
<summary>Checks</summary>

```text
python -m ruff check vllm/renderers/online_derenderer.py
All checks passed!

python -m ruff format --check vllm/renderers/online_derenderer.py
1 file already formatted

git diff --check -- vllm/renderers/online_derenderer.py
```

</details>

AI assistance was used to prepare this PR.

cc @DarkLight1337


## Non-streaming chat completion parity

The finish-reason policy matches the ordinary non-streaming chat completion path: `required` plus an upstream `stop` returns `tool_calls` even when the parsed call list is empty; automatic calls require automatic tool choice, enabled auto tools, and a tool parser; explicit null tool choice does not enter the automatic branch. Missing finish reasons fall back to `stop`. Named tool choices retain the ordinary finish reason, and required calls ending with `length` remain `length`.

Validation of this update:

```text
.venv/bin/python -m pytest tests/entrypoints/scale_out/derender/test_derender.py -k test_derender_finish_reason_matches_chat_completion -q
13 passed

# With the virtual environment activated and PYTHONPATH set to the PR checkout:
HF_HUB_OFFLINE=1 .venv/bin/python -m pytest tests/entrypoints/scale_out/derender/test_derender.py -k test_e2e_parsed_tool_call -q
1 passed

.venv/bin/pre-commit run --files vllm/renderers/online_derenderer.py tests/entrypoints/scale_out/derender/test_derender.py
Passed
```

The HTTP test uses the real tokenizer and Hermes parser with synthetic output tokens; no model inference or accuracy evaluation was run. This update modifies the existing PR rather than opening a duplicate. AI assistance was used for the implementation and validation.
