### PR TITLE
[Bugfix][Frontend] Preserve abort finish_reason for scale-out token streams

### DIFF
--- a/vllm/entrypoints/scale_out/token_in_token_out/serving.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/serving.py
@@ -390,10 +390,10 @@ class ServingTokens(GenerateBaseServing):
                     finish_reason = output.finish_reason
                     self._raise_if_error(finish_reason, request_id)
 
-                    if not delta_token_ids:
+                    if not delta_token_ids and finish_reason is None:
                         continue
 
-                    if sampling_params.logprobs is not None:
+                    if delta_token_ids and sampling_params.logprobs is not None:
                         out_logprobs = output.logprobs
                         assert out_logprobs is not None, "Did not output logprobs"
                         logprobs = self._create_tokens_logprobs(


### PR DESCRIPTION

## Purpose

`/inference/v1/generate` streams token deltas from the engine for scale-out token-in/token-out serving. The V1 abort path produces a terminal delta with `token_ids=[]` and `finish_reason="abort"`.

Today `ServingTokens` skips every empty `token_ids` delta, so an aborted stream only sends the earlier token chunks, an optional usage-only chunk, and `[DONE]`. The client never sees `choices[].finish_reason="abort"`.

This keeps skipping non-terminal empty deltas, but emits empty terminal choices when `finish_reason` is set. Empty terminal choices keep `logprobs=None`.

This does not add new response fields; it preserves the existing `finish_reason` field for empty terminal deltas.

## Test Plan

I reproduced the bug through a real `--tokens-only` HTTP server using `Qwen/Qwen3-0.6B`, `/inference/v1/generate`, and `/abort_requests`. I did not add a dedicated regression test in this PR diff; I ran the existing full scale-out streaming test file plus scoped ruff/format checks.

## Test Result

Before the fix, the same stream had no `abort` finish reason. After the fix, the stream includes a terminal choice with `token_ids=[]` and `finish_reason="abort"`. Reverting the fix makes the abort finish reason disappear again.

<details>
<summary>HTTP abort reproduction</summary>

Environment:

```text
vLLM upstream main 3dd910da4222f52b4def7bd67d670e2ace9ede1a
Model: Qwen/Qwen3-0.6B
Endpoint: /inference/v1/generate with --tokens-only
Abort endpoint: /abort_requests
```

`repro_scale_out_abort.sh`:

```bash
#!/usr/bin/env bash
set -euo pipefail

MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
SERVED_MODEL_NAME="${SERVED_MODEL_NAME:-qwen3}"
PORT="${PORT:-8134}"
PYTHON_BIN="${PYTHON_BIN:-python}"
LOG="${LOG:-/tmp/vllm-scale-out-abort.log}"

rm -f "$LOG"
"$PYTHON_BIN" -m vllm.entrypoints.openai.api_server \
  --model "$MODEL" \
  --served-model-name "$SERVED_MODEL_NAME" \
  --host 127.0.0.1 \
  --port "$PORT" \
  --tokens-only \
  --max-model-len 1024 \
  --gpu-memory-utilization 0.35 \
  --max-num-seqs 4 \
  --enforce-eager \
  --no-enable-log-requests >"$LOG" 2>&1 &
SERVER_PID=$!

cleanup() {
  kill "$SERVER_PID" >/dev/null 2>&1 || true
  wait "$SERVER_PID" >/dev/null 2>&1 || true
}
trap cleanup EXIT

"$PYTHON_BIN" check_scale_out_abort.py
```

`check_scale_out_abort.py`:

```python
import json
import os
import sys
import time

import requests
from transformers import AutoTokenizer


def main() -> None:
    port = int(os.environ.get("PORT", "8134"))
    model = os.environ.get("MODEL", "Qwen/Qwen3-0.6B")
    served_model_name = os.environ.get("SERVED_MODEL_NAME", "qwen3")
    expect_abort = os.environ.get("EXPECT_ABORT")
    base = f"http://127.0.0.1:{port}"

    for _ in range(180):
        try:
            response = requests.get(base + "/health", timeout=1)
            if response.status_code == 200:
                break
        except Exception:
            pass
        time.sleep(1)
    else:
        print("SERVER_NOT_READY")
        log_path = os.environ.get("LOG", "/tmp/vllm-scale-out-abort.log")
        print(open(log_path).read()[-4000:])
        sys.exit(2)

    tokenizer = AutoTokenizer.from_pretrained(model, trust_remote_code=True)
    prompt = (
        "Write the numbers from one to one thousand, separated by commas. "
        "Start now: "
    )
    prompt_ids = tokenizer.encode(prompt, add_special_tokens=False)
    request_id = "scale-out-abort-repro"
    payload = {
        "request_id": request_id,
        "model": served_model_name,
        "token_ids": prompt_ids,
        "sampling_params": {
            "max_tokens": 256,
            "temperature": 0.8,
            "top_p": 1.0,
        },
        "stream": True,
        "stream_options": {"include_usage": True},
    }

    print(
        "REQUEST",
        json.dumps({"request_id": request_id, "prompt_tokens": len(prompt_ids)}),
    )

    finish_reasons = []
    choice_chunks = []
    usage_chunks = 0
    aborted = False
    lines = []

    with requests.post(
        base + "/inference/v1/generate",
        json=payload,
        stream=True,
        timeout=(10, 180),
    ) as response:
        print("STATUS", response.status_code)
        response.raise_for_status()
        for raw in response.iter_lines(decode_unicode=True):
            if not raw:
                continue
            lines.append(raw)
            if len(lines) <= 12 or raw == "data: [DONE]":
                print(raw)
            if raw == "data: [DONE]":
                break
            if not raw.startswith("data: "):
                continue
            obj = json.loads(raw[len("data: ") :])
            choices = obj.get("choices") or []
            if choices:
                choice_chunks.append(obj)
                finish_reasons.extend(
                    choice.get("finish_reason") for choice in choices
                )
                if not aborted:
                    abort_response = requests.post(
                        base + "/abort_requests",
                        json={
                            "request_ids": [
                                request_id,
                                "generate-tokens-" + request_id,
                            ]
                        },
                        timeout=10,
                    )
                    print("ABORT_STATUS", abort_response.status_code)
                    aborted = True
            elif obj.get("usage") is not None:
                usage_chunks += 1

    has_abort_finish = any(reason == "abort" for reason in finish_reasons)
    print(
        "SUMMARY",
        json.dumps(
            {
                "choice_chunks": len(choice_chunks),
                "finish_reasons": finish_reasons,
                "has_abort_finish": has_abort_finish,
                "usage_chunks": usage_chunks,
                "line_count": len(lines),
            }
        ),
    )

    if expect_abort is not None:
        expected = expect_abort.lower() in {"1", "true", "yes"}
        if has_abort_finish != expected:
            sys.exit(3)


if __name__ == "__main__":
    main()
```

Before:

```bash
EXPECT_ABORT=0 bash repro_scale_out_abort.sh
```

```text
REQUEST {"request_id": "scale-out-abort-repro", "prompt_tokens": 17}
STATUS 200
data: {"request_id":"generate-tokens-scale-out-abort-repro","choices":[{"index":0,"logprobs":null,"finish_reason":null,"token_ids":[16],"routed_experts":null}],"usage":null}
ABORT_STATUS 200
data: {"request_id":"generate-tokens-scale-out-abort-repro","choices":[],"usage":{"prompt_tokens":17,"total_tokens":18,"completion_tokens":1}}
data: [DONE]
SUMMARY {"choice_chunks": 1, "finish_reasons": [null], "has_abort_finish": false, "usage_chunks": 1, "line_count": 3}
```

After:

```bash
EXPECT_ABORT=1 bash repro_scale_out_abort.sh
```

```text
REQUEST {"request_id": "scale-out-abort-repro", "prompt_tokens": 17}
STATUS 200
data: {"request_id":"generate-tokens-scale-out-abort-repro","choices":[{"index":0,"logprobs":null,"finish_reason":null,"token_ids":[16],"routed_experts":null}],"usage":null}
ABORT_STATUS 200
data: {"request_id":"generate-tokens-scale-out-abort-repro","choices":[{"index":0,"logprobs":null,"finish_reason":"abort","token_ids":[],"routed_experts":null}],"usage":null}
data: {"request_id":"generate-tokens-scale-out-abort-repro","choices":[],"usage":{"prompt_tokens":17,"total_tokens":18,"completion_tokens":1}}
data: [DONE]
SUMMARY {"choice_chunks": 2, "finish_reasons": [null, "abort"], "has_abort_finish": true, "usage_chunks": 1, "line_count": 4}
```

Reverting this change and rerunning the same script restores the before output:

```text
SUMMARY {"choice_chunks": 1, "finish_reasons": [null], "has_abort_finish": false, "usage_chunks": 1, "line_count": 3}
```

</details>

Full test file:

```text
$ HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 CUDA_VISIBLE_DEVICES="" PYTHONPATH=$PWD python -m pytest -q tests/entrypoints/scale_out/token_in_token_out/test_generate_stream.py
10 passed, 2 warnings in 6.90s
```

Ruff:

```text
$ python -m ruff check vllm/entrypoints/scale_out/token_in_token_out/serving.py
All checks passed!

$ python -m ruff format --check vllm/entrypoints/scale_out/token_in_token_out/serving.py
1 file already formatted
```

AI assistance was used to prepare this PR.
