### PR TITLE
Add tuned selective_state_update float32 config for AMD Instinct MI355

### DIFF
--- a/vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=AMD_Instinct_MI355_OAM,cache_dtype=float32.json
+++ b/vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=AMD_Instinct_MI355_OAM,cache_dtype=float32.json
@@ -1,0 +1,35 @@
+{
+    "triton_version": "3.6.0",
+    "10": {
+        "BLOCK_SIZE_M": 8,
+        "num_warps": 4
+    },
+    "80": {
+        "BLOCK_SIZE_M": 8,
+        "num_warps": 4
+    },
+    "160": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 4
+    },
+    "320": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 4
+    },
+    "640": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 4
+    },
+    "1280": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 2
+    },
+    "2560": {
+        "BLOCK_SIZE_M": 32,
+        "num_warps": 4
+    },
+    "5120": {
+        "BLOCK_SIZE_M": 32,
+        "num_warps": 4
+    }
+}


### PR DESCRIPTION
## Summary

Adds the **float32** `selective_state_update` config for the AMD Instinct MI355 (MI355_OAM), the companion to the float16 config merged in #47767.

Each NVIDIA device in `configs/selective_state_update/` ships both `cache_dtype=float16` and `cache_dtype=float32`; MI355 currently only has float16 (from #47752 / merged #47767). This brings MI355 to parity, so deployments that keep the SSM state cache in fp32 also get a tuned launch config instead of the generic `_get_default_ssm_launch_config()` heuristic.

## How it was generated

Same in-tree script as #47767, on an MI355, with the fp32 state cache:

```
python -m benchmarks.kernels.benchmark_selective_state_update \
    --dstate 128 --dtype float16 --mamba-ssm-cache-dtype float32 \
    --save-configs --compare
```

Keyed on `effective_batch = batch * nheads` (same grid as the float16 file), so it transfers across (model, TP) combos sharing `(headdim=64, dstate=128, cache_dtype=float32)`.

## Correctness

The config only selects Triton launch geometry (`BLOCK_SIZE_M`, `num_warps`); it does not change the kernel math, so model outputs are unaffected. This was verified end-to-end for the float16 companion in #47767 (identical `lm_eval` lambada_openai acc/perplexity with vs without the config), and the mechanism is dtype-independent.

## Note for AMD reviewers

The same lookup gap still applies to other AMD GPUs (MI300X, MI325X, MI350X, etc.), which fall back to the generic heuristic. Follow-up PRs adding their configs are welcome.
