### PR TITLE
[ROCm] Add tuned selective_state_update float16 config for AMD Instinct MI300X

### DIFF
--- a/vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=AMD_Instinct_MI300X,cache_dtype=float16.json
+++ b/vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=AMD_Instinct_MI300X,cache_dtype=float16.json
@@ -1,0 +1,51 @@
+{
+    "triton_version": "3.4.0",
+    "128": {
+        "BLOCK_SIZE_M": 32,
+        "num_warps": 8
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 4
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "num_warps": 1
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 32,
+        "num_warps": 2
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 2
+    },
+    "8192": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 2
+    },
+    "16384": {
+        "BLOCK_SIZE_M": 32,
+        "num_warps": 2
+    },
+    "32768": {
+        "BLOCK_SIZE_M": 64,
+        "num_warps": 8
+    },
+    "65536": {
+        "BLOCK_SIZE_M": 64,
+        "num_warps": 8
+    },
+    "131072": {
+        "BLOCK_SIZE_M": 64,
+        "num_warps": 4
+    },
+    "196608": {
+        "BLOCK_SIZE_M": 32,
+        "num_warps": 4
+    },
+    "262144": {
+        "BLOCK_SIZE_M": 32,
+        "num_warps": 4
+    }
+}


### PR DESCRIPTION
## Summary

Adds a tuned `selective_state_update` (Mamba SSU decode kernel) launch config for the **AMD Instinct MI300X**.

vLLM bundles per-device SSU configs for NVIDIA parts (B200, GB200, H100, H200, RTX PRO 6000) and, recently, MI355 (#47767). On MI300X `get_ssm_configs()` finds no matching file and falls back to the generic `_get_default_ssm_launch_config()` heuristic, which is well off the optimal `(BLOCK_SIZE_M, num_warps)` for these shapes and leaves Mamba decode throughput on the table.

This PR adds the missing config for `headdim=64, dstate=128, cache_dtype=float16` on MI300X. bf16 shares the same tuned file (the loader canonicalizes bf16 to float16, since the kernel only sees state bit-width). A float32 state-cache companion will follow separately, mirroring how the NVIDIA devices and MI355 ship both dtypes.

## How it was generated

Produced with the in-tree tuning script on an MI300X:

```
python -m benchmarks.kernels.benchmark_selective_state_update \
    --dstate 128 --dtype float16 --mamba-ssm-cache-dtype float16 \
    --save-configs --compare --validate
```

The device name and dtype key in the filename are derived automatically by the script, so the file drops straight into `configs/selective_state_update/` and is picked up at runtime with no code changes.

## Test plan

- `--validate`: all tuned `effective_batch` points pass against the CPU reference (12/12).
- `--compare`: consistent speedup over the generic heuristic across the swept `effective_batch` grid (roughly ~1.2x at small batch up to ~2.1x across the decode range).
- File is loaded at runtime (log: "Using SSM config from ... for selective_state_update").

The config only selects Triton launch geometry (`BLOCK_SIZE_M`, `num_warps`), not the kernel math, so model outputs are unaffected.

## Note for AMD reviewers

Data-only addition for one device. The same lookup gap still applies to other AMD GPUs (MI325X, MI308X, etc.); follow-up PRs adding their configs are welcome.
