### PR TITLE
[Test] Skip DeepEP MoE layer tests without P2P access

### DIFF
--- a/tests/kernels/moe/test_moe_layer.py
+++ b/tests/kernels/moe/test_moe_layer.py
@@ -36,6 +36,9 @@ from vllm.distributed import (
     get_eplb_group,
     tensor_model_parallel_all_gather,
 )
+from vllm.distributed.device_communicators.all_reduce_utils import (
+    gpu_p2p_access_check,
+)
 from vllm.distributed.eplb.eplb_communicator import create_eplb_communicator
 from vllm.distributed.eplb.rebalance_execute import rearrange_expert_weights_inplace
 from vllm.forward_context import set_forward_context
@@ -105,6 +108,8 @@ if has_deep_ep():
 
 if has_nixl_ep():
     BACKENDS += ["nixl_ep"]
+
+DEEPEP_BACKENDS = {"deepep_high_throughput", "deepep_low_latency"}
 
 QUANT_METHODS = [
     None,
@@ -414,6 +419,22 @@ def generate_valid_test_configs(
             print(f"Skipping invalid config {config} - {reason}")
 
     return configs
+
+
+@functools.cache
+def visible_devices_have_peer_access(world_size: int) -> bool:
+    if not current_platform.is_cuda():
+        return True
+
+    try:
+        return all(
+            gpu_p2p_access_check(src, dst)
+            for src in range(world_size)
+            for dst in range(world_size)
+            if src != dst
+        )
+    except RuntimeError:
+        return False
 
 
 # TODO: break this up into sections
@@ -1801,6 +1822,9 @@ def test_moe_layer(
 
     if enable_eplb and not use_ep:
         pytest.skip("EPLB requires EP.")
+
+    if backend in DEEPEP_BACKENDS and not visible_devices_have_peer_access(world_size):
+        pytest.skip("DeepEP backends require peer access between visible GPUs.")
 
     verbosity = pytestconfig.getoption("verbose")
 


### PR DESCRIPTION
## Summary

- Skip DeepEP low-latency and high-throughput backend tests when GPU peer-to-peer access is unavailable
- Fixes `CUDA error 'peer access is not supported between these two devices'` failures in `Kernels FP8 MoE Test (2xH100)` CI (56 subtests)
- Uses the existing `gpu_p2p_access_check` utility, cached per world size

Extracted from https://github.com/vllm-project/vllm/pull/45321 which addresses the broader DeepEPv2 NCCL upgrade.

## Test plan

- [x] Verified the fix passes on B200 CI in #45321 (build 76988: 480 passed, 0 failed)
- [x] On nodes with P2P access, DeepEP tests run normally
- [x] On nodes without P2P access, tests are skipped with a clear message

AI assistance was used (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)