### PR TITLE
[ROCm] Add tuned selective_state_update float32 config for AMD Instinct MI300X

### DIFF
--- a/vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=AMD_Instinct_MI300X,cache_dtype=float32.json
+++ b/vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=AMD_Instinct_MI300X,cache_dtype=float32.json
@@ -1,0 +1,51 @@
+{
+    "triton_version": "3.4.0",
+    "128": {
+        "BLOCK_SIZE_M": 8,
+        "num_warps": 4
+    },
+    "256": {
+        "BLOCK_SIZE_M": 8,
+        "num_warps": 4
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "num_warps": 1
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 32,
+        "num_warps": 4
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 32,
+        "num_warps": 4
+    },
+    "8192": {
+        "BLOCK_SIZE_M": 8,
+        "num_warps": 1
+    },
+    "16384": {
+        "BLOCK_SIZE_M": 32,
+        "num_warps": 4
+    },
+    "32768": {
+        "BLOCK_SIZE_M": 8,
+        "num_warps": 1
+    },
+    "65536": {
+        "BLOCK_SIZE_M": 64,
+        "num_warps": 4
+    },
+    "131072": {
+        "BLOCK_SIZE_M": 64,
+        "num_warps": 4
+    },
+    "196608": {
+        "BLOCK_SIZE_M": 64,
+        "num_warps": 1
+    },
+    "262144": {
+        "BLOCK_SIZE_M": 64,
+        "num_warps": 4
+    }
+}


### PR DESCRIPTION
## Summary

Adds the **float32** `selective_state_update` config for the AMD Instinct MI300X, the companion to the float16 config in #47945.

Each NVIDIA device in `configs/selective_state_update/` ships both `cache_dtype=float16` and `cache_dtype=float32`, and MI355 recently gained both (#47767, #47943). This brings MI300X to parity so deployments that keep the SSM state cache in fp32 (the default `mamba_ssm` cache dtype) also get a tuned launch config instead of the generic `_get_default_ssm_launch_config()` heuristic.

## How it was generated

Same in-tree script as #47945, on an MI300X, with the fp32 state cache:

```
python -m benchmarks.kernels.benchmark_selective_state_update \
    --dstate 128 --dtype float16 --mamba-ssm-cache-dtype float32 \
    --save-configs --compare --validate
```

Keyed on `effective_batch = batch * nheads` (same grid as the float16 file), so it transfers across (model, TP) combos sharing `(headdim=64, dstate=128, cache_dtype=float32)`.

## Test plan

- `--validate`: all tuned `effective_batch` points pass against the CPU reference (12/12).
- `--compare`: consistent speedup over the generic heuristic across the swept grid.
- File is loaded at runtime (log: "Using SSM config from ... for selective_state_update").

The config only selects Triton launch geometry (`BLOCK_SIZE_M`, `num_warps`), not the kernel math, so model outputs are unaffected.

## Note for AMD reviewers

Data-only addition for one device. The same lookup gap still applies to other AMD GPUs (MI325X, MI308X, etc.); follow-up PRs adding their configs are welcome.
