### PR TITLE
[Bug]: REGRESSION : FP8 KV cache  FlashInfer no longer available as attention backend on SM75 (Turing) in v0.24.0

### DIFF
--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -551,3 +551,28 @@ def test_flash_attn_accepts_handled_fp8_variants(
 
     monkeypatch.setattr(fa_mod.current_platform, "is_xpu", lambda: True)
     assert FlashAttentionBackend.supports_kv_cache_dtype(kv_cache_dtype)
+
+
+@pytest.mark.parametrize(
+    "major, minor, supported",
+    [
+        (7, 0, False),  # Volta: below FlashInfer's SM75 floor
+        (7, 5, True),  # Turing (T4, RTX 20xx, Quadro RTX): must stay supported
+        (8, 0, True),  # Ampere
+        (9, 0, True),  # Hopper
+        (12, 1, True),  # Upper bound
+        (12, 2, False),  # Above the supported ceiling
+    ],
+)
+def test_flashinfer_supports_sm75_turing(major: int, minor: int, supported: bool):
+    """FlashInfer must remain available on SM75 (Turing) so FP8 KV cache is not
+    silently dropped there. Regression test for
+    https://github.com/vllm-project/vllm/issues/47549."""
+    pytest.importorskip("flashinfer")
+    from vllm.platforms.interface import DeviceCapability
+    from vllm.v1.attention.backends.flashinfer import FlashInferBackend
+
+    assert (
+        FlashInferBackend.supports_compute_capability(DeviceCapability(major, minor))
+        is supported
+    )

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -440,12 +440,13 @@ class FlashInferBackend(AttentionBackend):
 
     @classmethod
     def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
-        # FlashInfer supports SM75+, but is currently broken on SM75 (Turing):
-        # https://github.com/flashinfer-ai/flashinfer/issues/3620 (fix:
-        # https://github.com/flashinfer-ai/flashinfer/pull/3621). Temporarily
-        # raise the floor to SM80 so it is not auto-selected on SM75 until
-        # that fix lands; revert to DeviceCapability(7, 5) once it does.
-        return capability >= DeviceCapability(8, 0) and capability <= DeviceCapability(
+        # FlashInfer supports SM75 (Turing) through SM121. Some FlashInfer
+        # versions have a prefill shared-memory issue on SM75
+        # (https://github.com/flashinfer-ai/flashinfer/issues/3620), but raising
+        # the floor to SM80 regressed FP8 KV cache support that worked on Turing
+        # (https://github.com/vllm-project/vllm/issues/47549), so keep SM75 as
+        # the supported floor.
+        return capability >= DeviceCapability(7, 5) and capability <= DeviceCapability(
             12, 1
         )
 


### PR DESCRIPTION
# Fix for issue #47549 — FP8 KV cache / FlashInfer unavailable on SM75 (Turing)

## 1. Root cause

`FlashInferBackend.supports_compute_capability` in
`vllm/v1/attention/backends/flashinfer.py` gated the backend on
`capability >= DeviceCapability(8, 0)` (SM80 / Ampere). On a Turing card
(SM75 = `DeviceCapability(7, 5)`) this returns `False`.

The check is consumed by the backend-selection pipeline:

- `AttentionBackend.validate_configuration` (`vllm/v1/attention/backend.py:352`)
  turns a failing `supports_compute_capability` into the invalid reason
  `"compute capability not supported"`.
- `CudaPlatform.get_valid_backends` / `get_attn_backend_cls`
  (`vllm/platforms/cuda.py`) then drop FlashInfer from the candidate list and
  also reject an explicit `--attention-backend FLASHINFER` request.

So on SM75 the only surviving non-MLA candidate is `TRITON_ATTN`, which does not
support native FP8 KV cache below SM89, producing the reported error:

> ValueError: FP8 KV cache is not supported by the Triton attention backend on
> Quadro RTX 8000 (compute capability 7.5); native FP8 (fp8e4nv) requires SM89+.

vLLM v0.23.0 exposed FlashInfer on SM75 (floor was `(7, 5)`), so FP8 KV cache
worked. Raising the floor to `(8, 0)` in v0.24.0 is the regression. The
pre-existing in-code comment even documented the intent to "revert to
`DeviceCapability(7, 5)`".

The comment justified the SM80 floor with FlashInfer bug
[flashinfer-ai/flashinfer#3620](https://github.com/flashinfer-ai/flashinfer/issues/3620)
(a prefill shared-memory miscalculation on SM75). That bug is **real but
version-specific** (reported on FlashInfer 0.6.12); the older FlashInfer shipped
with v0.23.0 ran full 22K-context prefill on Turing successfully, per the issue.
Blocking *every* SM75 user to avoid a bug present in only some FlashInfer
versions is over-broad and is what the reporter is asking to be reverted.

## 2. The fix and why

Restore the supported floor to `DeviceCapability(7, 5)` (keeping the existing
`<= DeviceCapability(12, 1)` ceiling):

```python
return capability >= DeviceCapability(7, 5) and capability <= DeviceCapability(12, 1)
```

This makes FlashInfer selectable again on SM75, restoring the v0.23.0 behavior
and re-enabling FP8 KV cache on Turing (the reporter observed a ~2× larger KV
cache and ~10× decode throughput vs. the Triton fallback). It is the minimal,
single-line change that the in-code comment itself prescribed. The comment was
rewritten to state the true support range and to keep a pointer to the known
FlashInfer prefill limitation for future maintainers, rather than presenting the
SM80 floor as intended behavior.

FP8 KV cache itself is not separately capability-gated in this backend
(`supports_kv_cache_dtype` only gates `nvfp4` to SM100), so no other change is
needed for FP8 to work once the capability floor is lowered.

## 3. Files changed

- `vllm/v1/attention/backends/flashinfer.py` — lower the
  `supports_compute_capability` floor from `(8, 0)` back to `(7, 5)`; update the
  explanatory comment.
- `tests/kernels/attention/test_attention_selector.py` — add
  `test_flashinfer_supports_sm75_turing`, a parametrized regression test
  asserting SM70 → unsupported, SM75/80/90/121 → supported, SM122 → unsupported.
  Guarded with `pytest.importorskip("flashinfer")` to match the file's existing
  convention (the backend module imports `flashinfer` at top level).

## 4. Risk / uncertainty

- **Low blast radius:** one comparison bound on one backend's capability check.
  No change to selection order, other backends, or FP8 code paths.
- **Known caveat:** FlashInfer#3620 means some FlashInfer versions can fail the
  prefill kernel launch on SM75. Re-enabling SM75 restores the v0.23.0 contract
  but does not itself fix that upstream FlashInfer bug; users on an affected
  FlashInfer version may hit it. Gating on the FlashInfer version was considered
  and rejected as fragile/over-engineered for a one-issue fix — the surfaced
  error would be an upstream FlashInfer bug, not a silently-wrong result, and
  the pre-regression behavior is what the issue explicitly requests. If upstream
  later wants belt-and-suspenders, a follow-up could allow SM75 only for an
  *explicit* user selection; that needs new plumbing to distinguish auto-select
  from override and is out of scope here.
- The upper bound `(12, 1)` is intentionally left unchanged.

## 5. How I verified it

Environment note: this sandbox has no `torch`/`flashinfer`/venv, so the full
pytest suite (and pre-commit) could not execute here. Verification performed:

- **Predicate logic:** reproduced `DeviceCapability`'s tuple-ordering semantics
  in plain Python and confirmed the new bound yields
  `SM70=False, SM75=True, SM80=True, SM90=True, SM121=True, SM122=False` — i.e.
  it matches the added test's expectations exactly.
- **Syntax:** `python3 -m py_compile` passes on both changed files.
- **Line length:** all changed lines are ≤ 88 chars (the one 89-char line in the
  test file is pre-existing and untouched).
- **Traced the consumer chain** (`validate_configuration` →
  `get_valid_backends` → `get_attn_backend_cls`) to confirm the single check is
  the load-bearing gate and that lowering it restores FlashInfer as an
  auto-selected/overridable candidate on SM75.

To run once in a CUDA+FlashInfer environment:

```bash
.venv/bin/python -m pytest \
  tests/kernels/attention/test_attention_selector.py::test_flashinfer_supports_sm75_turing -v
```
