### PR TITLE
[Bug]: Combination of sleep mode and speculative decoding cause crash (ROCm / MI250)

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,101 @@
+# Issue #47548 — Sleep mode + speculative decoding crash (ROCm / MI250)
+
+## 1. Root cause
+
+Combining `--enable-sleep-mode` with `--speculative-config '{"method":"qwen3_next_mtp",...}'`
+crashes at startup with:
+
+```
+AttributeError: .../site-packages/tilelang/lib/libcudart_stub.so: undefined symbol: hipSetDevice
+```
+
+The crash happens in the device-allocator initialization chain:
+
+```
+gpu_worker.py  _maybe_get_memory_pool_context -> get_mem_allocator_instance()
+device_allocator/cumem.py:40  libcudart = CudaRTLibrary()
+distributed/device_communicators/cuda_wrapper.py  find_loaded_library(...)
+```
+
+Why the *combination* is required:
+
+- **Sleep mode** forces the cumem allocator on, which imports `vllm/device_allocator/cumem.py`.
+  That module constructs `CudaRTLibrary()`, which calls
+  `find_loaded_library("libamdhip64" | "libcudart")` to locate the CUDA/HIP runtime.
+- **Speculative decoding with MTP** (`qwen3_next_mtp` → `mtp`) pulls in the optional
+  `tilelang` package, which loads its own `tilelang/lib/libcudart_stub.so` into the process.
+
+The real bug is in `find_loaded_library()` (`vllm/utils/system_utils.py`). It scanned
+`/proc/self/maps` with a **loose substring match** and accepted the first line containing the
+search string:
+
+```python
+if lib_name in line: ...        # "libcudart" is a substring of "libcudart_stub.so"
+...
+assert filename.rpartition(".so")[0].startswith(lib_name)   # "libcudart_stub".startswith("libcudart") == True
+```
+
+So when `tilelang`'s `libcudart_stub.so` is present, `find_loaded_library("libcudart")`
+returns the **stub** instead of the real runtime, and the sanity `assert` does *not* catch it
+(`"libcudart_stub".startswith("libcudart")` is `True`). `CudaRTLibrary` then binds against the
+stub, which does not export the HIP symbols (`hipSetDevice`, …), and crashes. Without
+speculative decoding the stub is never loaded, so sleep mode works; without sleep mode the
+allocator is never created, so speculative decoding works. Only the combination triggers it.
+
+I reproduced the matching bug deterministically (no GPU needed): searching `libcudart`
+against a maps line for `.../libcudart_stub.so` returned the stub path and passed the old
+assertion.
+
+## 2. The fix and why
+
+Harden `find_loaded_library()` so it only matches a *real* library file. A candidate is
+accepted only when the mapped file's basename is `lib_name` followed by a version/build
+separator — `.` (`libcudart.so`, `libcudart.so.12`, `cumem_allocator.cpython-312-….so`) or
+`-` (`libcudart-<hash>.so.11.0`). Names like `libcudart_stub.so` (an `_` follows) or
+`libcudarter.so` are rejected. The scan now **skips** non-matching lines and keeps looking
+(returning the real runtime even if a lookalike is mapped first) instead of breaking on the
+first substring hit and asserting.
+
+This fixes the problem at its source: the same function is used by both `cumem.py` and
+`cuda_wrapper.py`, so the fix covers the ROCm path (`libamdhip64`) and the CUDA path
+(`libcudart`), and it is robust regardless of load order. The matching logic is extracted into
+a small pure helper `_matching_library_path()` so it can be unit-tested without a GPU.
+
+## 3. Files changed
+
+- `vllm/utils/system_utils.py` — rewrote `find_loaded_library()`; added helper
+  `_matching_library_path()`; removed the too-loose substring match + `startswith` assertion.
+- `tests/utils_/test_system_utils.py` — added a parametrized test for
+  `_matching_library_path` (real variants match; `libcudart_stub.so` and `libcudarter.so`
+  are rejected) and a `find_loaded_library` test proving the stub is skipped when it is
+  mapped before the real runtime.
+
+## 4. Risk / uncertainty
+
+- **Behavior change:** matching is now stricter and the previous `assert` was removed. Callers
+  already handle a `None` return (fallback to `VLLM_CUDART_SO_PATH`, then a clear assertion),
+  so a missed match degrades to a readable error instead of a confusing symbol crash. I checked
+  all real search terms in the repo (`libcudart`, `libamdhip64`, `cumem_allocator`) and their
+  actual on-disk filename shapes still match.
+- **Environment:** the reporter runs a bleeding-edge ROCm 7.x / `_rocm_sdk_core` stack that I
+  cannot run here, so I could not execute the exact `vllm serve` repro. On current `main` the
+  ROCm branch already searches `libamdhip64` (which the stub does not match), so this change is
+  primarily a robustness/root-cause fix that also protects the CUDA + tilelang path and any
+  ROCm fallback where `libcudart` is searched. The core matching bug is verified by the new
+  tests.
+
+## 5. How I verified
+
+- Extracted the old matching logic and confirmed `find_loaded_library("libcudart")` returned
+  `.../libcudart_stub.so` and the old assertion passed — reproducing the root cause.
+- Ran the new `_matching_library_path` logic against a table of real/stub/lookalike filenames
+  and an ordered-scan case (stub mapped before the real lib): all pass, the stub is rejected,
+  and the real runtime is returned.
+- `python -m py_compile` on both changed files; verified changed lines stay within the repo's
+  88-char limit.
+
+Note: the full pytest suite could not run in this environment (vLLM runtime deps such as
+`torch`/`tblib` are not installed), so the added tests were validated via the standalone logic
+harness above rather than through `pytest`.
+
+AI assistance (Claude) was used to investigate and implement this change.

--- a/tests/utils_/test_system_utils.py
+++ b/tests/utils_/test_system_utils.py
@@ -5,7 +5,14 @@ import os
 import tempfile
 from pathlib import Path
 
-from vllm.utils.system_utils import _maybe_force_spawn, unique_filepath
+import pytest
+
+from vllm.utils.system_utils import (
+    _matching_library_path,
+    _maybe_force_spawn,
+    find_loaded_library,
+    unique_filepath,
+)
 
 
 def test_unique_filepath():
@@ -18,6 +25,55 @@ def test_unique_filepath():
         paths.add(path)
     assert len(paths) == 10
     assert len(list(Path(temp_dir).glob("*.txt"))) == 10
+
+
+def _maps_line(path: str) -> str:
+    return f"7f0000000000-7f0000010000 r-xp 00000000 00:1f 12345 {path}\n"
+
+
+@pytest.mark.parametrize(
+    "lib_name,path,expected",
+    [
+        # Real runtime variants must match.
+        ("libcudart", "/usr/local/cuda/lib64/libcudart.so", True),
+        ("libcudart", "/usr/local/cuda/lib64/libcudart.so.12", True),
+        ("libcudart", "/opt/lib/libcudart-d0da41ae.so.11.0", True),
+        ("libamdhip64", "/opt/rocm/lib/libamdhip64.so.7", True),
+        # Python extension modules (`.` separated) must match.
+        ("cumem_allocator", "/x/cumem_allocator.cpython-312-x86_64.so", True),
+        # tilelang's stub must NOT be mistaken for the CUDA runtime (#47548).
+        ("libcudart", "/x/tilelang/lib/libcudart_stub.so", False),
+        # Unrelated library that merely contains the name as a substring.
+        ("libcudart", "/x/libcudarter.so", False),
+    ],
+)
+def test_matching_library_path(lib_name, path, expected):
+    result = _matching_library_path(lib_name, _maps_line(path))
+    assert (result == path) is expected
+    if not expected:
+        assert result is None
+
+
+def test_find_loaded_library_skips_lookalike(monkeypatch, tmp_path):
+    # tilelang's stub is loaded before the real runtime; the lookalike must be
+    # skipped and the real library returned (regression for #47548).
+    real = "/usr/local/cuda/lib64/libcudart.so.12"
+    maps = tmp_path / "maps"
+    maps.write_text(
+        _maps_line("/x/tilelang/lib/libcudart_stub.so") + _maps_line(real)
+    )
+
+    import builtins
+
+    real_open = builtins.open
+    monkeypatch.setattr(
+        builtins,
+        "open",
+        lambda f, *a, **k: real_open(maps, *a, **k)
+        if f == "/proc/self/maps"
+        else real_open(f, *a, **k),
+    )
+    assert find_loaded_library("libcudart") == real
 
 
 def test_numa_bind_forces_spawn(monkeypatch):

--- a/vllm/utils/system_utils.py
+++ b/vllm/utils/system_utils.py
@@ -306,28 +306,39 @@ def set_ulimit(target_soft_limit: int = 65535):
             )
 
 
+def _matching_library_path(lib_name: str, maps_line: str) -> str | None:
+    """Return the mapped path in `maps_line` if it is the shared object
+    `lib_name`, otherwise ``None``.
+
+    The basename must be `lib_name` followed by a version/build separator
+    (``.`` or ``-``), e.g. ``libcudart.so``, ``libcudart.so.12`` or
+    ``libcudart-<hash>.so``. Lookalikes such as tilelang's
+    ``libcudart_stub.so`` are rejected so they are not mistaken for the real
+    CUDA/HIP runtime (see issue #47548).
+    """
+    if lib_name not in maps_line or "/" not in maps_line:
+        return None
+    path = maps_line[maps_line.index("/") :].strip()
+    filename = path.split("/")[-1]
+    if not filename.startswith(lib_name):
+        return None
+    suffix = filename[len(lib_name) :]
+    if suffix and suffix[0] not in ".-":
+        return None
+    return path
+
+
 def find_loaded_library(lib_name: str) -> str | None:
     """
-    According to according to https://man7.org/linux/man-pages/man5/proc_pid_maps.5.html,
-    the file `/proc/self/maps` contains the memory maps of the process, which includes the
-    shared libraries loaded by the process. We can use this file to find the path of the
-    loaded library.
-    """  # noqa
-    found_line = None
+    According to https://man7.org/linux/man-pages/man5/proc_pid_maps.5.html,
+    the file `/proc/self/maps` contains the memory maps of the process, which
+    includes the shared libraries loaded by the process. We use this file to
+    find the path of the loaded library.
+    """
     with open("/proc/self/maps") as f:
         for line in f:
-            if lib_name in line:
-                found_line = line
-                break
-    if found_line is None:
-        # the library is not loaded in the current process
-        return None
-    # if lib_name is libcudart, we need to match a line with:
-    # address /path/to/libcudart-hash.so.11.0
-    start = found_line.index("/")
-    path = found_line[start:].strip()
-    filename = path.split("/")[-1]
-    assert filename.rpartition(".so")[0].startswith(lib_name), (
-        f"Unexpected filename: {filename} for library {lib_name}"
-    )
-    return path
+            path = _matching_library_path(lib_name, line)
+            if path is not None:
+                return path
+    # the library is not loaded in the current process
+    return None


### PR DESCRIPTION
# Issue #47548 — Sleep mode + speculative decoding crash (ROCm / MI250)

## 1. Root cause

Combining `--enable-sleep-mode` with `--speculative-config '{"method":"qwen3_next_mtp",...}'`
crashes at startup with:

```
AttributeError: .../site-packages/tilelang/lib/libcudart_stub.so: undefined symbol: hipSetDevice
```

The crash happens in the device-allocator initialization chain:

```
gpu_worker.py  _maybe_get_memory_pool_context -> get_mem_allocator_instance()
device_allocator/cumem.py:40  libcudart = CudaRTLibrary()
distributed/device_communicators/cuda_wrapper.py  find_loaded_library(...)
```

Why the *combination* is required:

- **Sleep mode** forces the cumem allocator on, which imports `vllm/device_allocator/cumem.py`.
  That module constructs `CudaRTLibrary()`, which calls
  `find_loaded_library("libamdhip64" | "libcudart")` to locate the CUDA/HIP runtime.
- **Speculative decoding with MTP** (`qwen3_next_mtp` → `mtp`) pulls in the optional
  `tilelang` package, which loads its own `tilelang/lib/libcudart_stub.so` into the process.

The real bug is in `find_loaded_library()` (`vllm/utils/system_utils.py`). It scanned
`/proc/self/maps` with a **loose substring match** and accepted the first line containing the
search string:

```python
if lib_name in line: ...        # "libcudart" is a substring of "libcudart_stub.so"
...
assert filename.rpartition(".so")[0].startswith(lib_name)   # "libcudart_stub".startswith("libcudart") == True
```

So when `tilelang`'s `libcudart_stub.so` is present, `find_loaded_library("libcudart")`
returns the **stub** instead of the real runtime, and the sanity `assert` does *not* catch it
(`"libcudart_stub".startswith("libcudart")` is `True`). `CudaRTLibrary` then binds against the
stub, which does not export the HIP symbols (`hipSetDevice`, …), and crashes. Without
speculative decoding the stub is never loaded, so sleep mode works; without sleep mode the
allocator is never created, so speculative decoding works. Only the combination triggers it.

I reproduced the matching bug deterministically (no GPU needed): searching `libcudart`
against a maps line for `.../libcudart_stub.so` returned the stub path and passed the old
assertion.

## 2. The fix and why

Harden `find_loaded_library()` so it only matches a *real* library file. A candidate is
accepted only when the mapped file's basename is `lib_name` followed by a version/build
separator — `.` (`libcudart.so`, `libcudart.so.12`, `cumem_allocator.cpython-312-….so`) or
`-` (`libcudart-<hash>.so.11.0`). Names like `libcudart_stub.so` (an `_` follows) or
`libcudarter.so` are rejected. The scan now **skips** non-matching lines and keeps looking
(returning the real runtime even if a lookalike is mapped first) instead of breaking on the
first substring hit and asserting.

This fixes the problem at its source: the same function is used by both `cumem.py` and
`cuda_wrapper.py`, so the fix covers the ROCm path (`libamdhip64`) and the CUDA path
(`libcudart`), and it is robust regardless of load order. The matching logic is extracted into
a small pure helper `_matching_library_path()` so it can be unit-tested without a GPU.

## 3. Files changed

- `vllm/utils/system_utils.py` — rewrote `find_loaded_library()`; added helper
  `_matching_library_path()`; removed the too-loose substring match + `startswith` assertion.
- `tests/utils_/test_system_utils.py` — added a parametrized test for
  `_matching_library_path` (real variants match; `libcudart_stub.so` and `libcudarter.so`
  are rejected) and a `find_loaded_library` test proving the stub is skipped when it is
  mapped before the real runtime.

## 4. Risk / uncertainty

- **Behavior change:** matching is now stricter and the previous `assert` was removed. Callers
  already handle a `None` return (fallback to `VLLM_CUDART_SO_PATH`, then a clear assertion),
  so a missed match degrades to a readable error instead of a confusing symbol crash. I checked
  all real search terms in the repo (`libcudart`, `libamdhip64`, `cumem_allocator`) and their
  actual on-disk filename shapes still match.
- **Environment:** the reporter runs a bleeding-edge ROCm 7.x / `_rocm_sdk_core` stack that I
  cannot run here, so I could not execute the exact `vllm serve` repro. On current `main` the
  ROCm branch already searches `libamdhip64` (which the stub does not match), so this change is
  primarily a robustness/root-cause fix that also protects the CUDA + tilelang path and any
  ROCm fallback where `libcudart` is searched. The core matching bug is verified by the new
  tests.

## 5. How I verified

- Extracted the old matching logic and confirmed `find_loaded_library("libcudart")` returned
  `.../libcudart_stub.so` and the old assertion passed — reproducing the root cause.
- Ran the new `_matching_library_path` logic against a table of real/stub/lookalike filenames
  and an ordered-scan case (stub mapped before the real lib): all pass, the stub is rejected,
  and the real runtime is returned.
- `python -m py_compile` on both changed files; verified changed lines stay within the repo's
  88-char limit.

Note: the full pytest suite could not run in this environment (vLLM runtime deps such as
`torch`/`tblib` are not installed), so the added tests were validated via the standalone logic
harness above rather than through `pytest`.

AI assistance (Claude) was used to investigate and implement this change.
