### PR TITLE
[LoRA] Skip empty-LoRA path in eager mode when no adapter is active

### DIFF
--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -751,6 +751,107 @@ def test_linear_parallel(
 
 
 @torch.inference_mode()
+@pytest.mark.parametrize("device", DEVICES)
+@pytest.mark.parametrize("stage", STAGES)
+def test_empty_lora_eager_skip(default_vllm_config, dist_init, device, stage) -> None:
+    """When a batch has no active LoRA, the layer skips the LoRA path in eager
+    mode and returns the base output, while staying on the normal path (and
+    still correct) under cudagraph.
+    """
+    from unittest.mock import MagicMock
+
+    import vllm.lora.layers.base as lora_base
+    from vllm.config import CUDAGraphMode
+
+    if current_platform.is_cuda_alike() or current_platform.is_xpu():
+        torch.accelerator.set_device_index(device)
+
+    max_loras = 8
+    torch.set_default_device(device)
+    lora_config = LoRAConfig(
+        max_loras=max_loras, max_lora_rank=8, lora_dtype=torch.float16
+    )
+    punica_wrapper = get_punica_wrapper(8192, 256, device, lora_config=lora_config)
+    assert check_punica_wrapper(punica_wrapper)
+
+    linear = ColumnParallelLinear(
+        4096, 4096, bias=False, params_dtype=torch.float16, prefix="layer_0"
+    )
+    linear.weight.data = torch.rand_like(linear.weight.data)
+    lora_linear = ColumnParallelLinearWithLoRA(linear)
+    lora_linear.create_lora_weights(max_loras, lora_config)
+    lora_linear.set_mapping(punica_wrapper)
+
+    id_to_index = get_random_id_to_index(2, max_loras)
+    lora_dict, _ = populate_loras(
+        id_to_index, layer=lora_linear, layer_weights=linear.weight
+    )
+    active_lora_ids = list(lora_dict.keys())
+
+    def make_ctx(mode):
+        ctx = MagicMock()
+        ctx.cudagraph_runtime_mode = mode
+        return ctx
+
+    def set_no_lora_batch(no_lora: bool):
+        # active id 0 maps to "no LoRA" (token index -1). Mixing in a real
+        # adapter id yields a batch that does require LoRA.
+        ids = [0] if no_lora else [0, active_lora_ids[0]]
+        inputs, index_mapping, prompt_mapping = create_random_inputs(
+            active_lora_ids=ids,
+            num_inputs=8,
+            input_size=(1, 4096),
+            input_range=(0, 1),
+            input_type=torch.float16,
+            device=device,
+        )
+        lora_mapping = LoRAMapping(index_mapping, prompt_mapping, is_prefill=stage)
+        punica_wrapper.update_metadata(lora_mapping, id_to_index, max_loras, 512)
+        return torch.cat(inputs)
+
+    # No active LoRA in the batch: wrapper detects it and eager path skips.
+    x = set_no_lora_batch(no_lora=True)
+    assert punica_wrapper.no_lora is True
+    expected = linear(x)[0]
+    rtol, atol = TOLERANCES[expected.dtype]
+
+    # Eager (cudagraph mode NONE) -> skip taken, output == base.
+    with (
+        patch.object(lora_base, "is_forward_context_available", return_value=True),
+        patch.object(
+            lora_base, "get_forward_context", return_value=make_ctx(CUDAGraphMode.NONE)
+        ),
+    ):
+        assert lora_linear._can_skip_empty_lora() is True
+        skipped = lora_linear(x)[0]
+    torch.testing.assert_close(skipped, expected, rtol=rtol, atol=atol)
+
+    # Cudagraph (PIECEWISE) -> skip NOT taken, output still correct (== base).
+    with (
+        patch.object(lora_base, "is_forward_context_available", return_value=True),
+        patch.object(
+            lora_base,
+            "get_forward_context",
+            return_value=make_ctx(CUDAGraphMode.PIECEWISE),
+        ),
+    ):
+        assert lora_linear._can_skip_empty_lora() is False
+        not_skipped = lora_linear(x)[0]
+    torch.testing.assert_close(not_skipped, expected, rtol=rtol, atol=atol)
+
+    # Mixed batch (some tokens need LoRA): must never skip, even in eager.
+    set_no_lora_batch(no_lora=False)
+    assert punica_wrapper.no_lora is False
+    with (
+        patch.object(lora_base, "is_forward_context_available", return_value=True),
+        patch.object(
+            lora_base, "get_forward_context", return_value=make_ctx(CUDAGraphMode.NONE)
+        ),
+    ):
+        assert lora_linear._can_skip_empty_lora() is False
+
+
+@torch.inference_mode()
 @pytest.mark.parametrize("num_loras", [1, 2, 4])
 @pytest.mark.parametrize("repeats", [1, 2, 3])
 @pytest.mark.parametrize("fully_shard", [True, False])

--- a/vllm/lora/layers/base.py
+++ b/vllm/lora/layers/base.py
@@ -7,7 +7,9 @@ import torch
 import torch.nn as nn
 from transformers import PretrainedConfig
 
+from vllm.config import CUDAGraphMode
 from vllm.config.lora import LoRAConfig
+from vllm.forward_context import get_forward_context, is_forward_context_available
 
 if TYPE_CHECKING:
     from vllm.lora.punica_wrapper import PunicaWrapperBase
@@ -65,6 +67,20 @@ class BaseLayerWithLoRA(nn.Module):
         punica_wrapper,
     ):
         self.punica_wrapper: PunicaWrapperBase = punica_wrapper
+
+    def _can_skip_empty_lora(self) -> bool:
+        """Whether the LoRA path can be skipped for this forward pass.
+
+        Only safe in eager execution. Under cudagraph capture/replay a Python
+        branch would be baked into the captured graph and could be replayed for
+        a batch that does contain LoRA requests, producing wrong results. The
+        in-kernel no_lora_flag_cpu early-exit still guards those paths.
+        """
+        if not self.punica_wrapper.no_lora:
+            return False
+        if not is_forward_context_available():
+            return False
+        return get_forward_context().cudagraph_runtime_mode == CUDAGraphMode.NONE
 
     @classmethod
     def can_replace_layer(

--- a/vllm/lora/layers/base_linear.py
+++ b/vllm/lora/layers/base_linear.py
@@ -192,6 +192,10 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
         return quant_method
 
     def apply(self, x: torch.Tensor, bias: torch.Tensor | None = None) -> torch.Tensor:
+        # No active LoRA in this batch: skip the LoRA wrapper entirely and
+        # return the base layer output (eager mode only, see above).
+        if self._can_skip_empty_lora():
+            return self._get_quant_method().apply(self.base_layer, x, bias)
         # is_forward_context_available for tower modules
         if self._enable_aux_cuda_stream and is_forward_context_available():
             output_size = sum(self.output_slices)

--- a/vllm/lora/layers/logits_processor.py
+++ b/vllm/lora/layers/logits_processor.py
@@ -178,12 +178,16 @@ class LogitsProcessorWithLoRA(BaseLayerWithLoRA):
             # token_id: [0, 1, 2, 3, 4, 5, -1, -1]
             logits = logits[:, self.sharded_to_full_mapping_gpu]
 
-        lora_output: torch.Tensor | None = self.punica_wrapper.add_lora_logits(
-            logits, hidden_states, self.lora_a_stacked, self.lora_b_stacked, 1.0
-        )
+        # No active LoRA in this batch: skip the LoRA logits contribution while
+        # keeping the vocab reindex/trim that defines the output layout expected
+        # downstream (eager mode only, see BaseLayerWithLoRA._can_skip_empty_lora).
+        if not self._can_skip_empty_lora():
+            lora_output: torch.Tensor | None = self.punica_wrapper.add_lora_logits(
+                logits, hidden_states, self.lora_a_stacked, self.lora_b_stacked, 1.0
+            )
 
-        if not current_platform.can_update_inplace():
-            logits = lora_output
+            if not current_platform.can_update_inplace():
+                logits = lora_output
 
         # Remove paddings in vocab (if any).
         logits = logits[:, : self.base_layer.vocab_size]

--- a/vllm/lora/layers/vocal_parallel_embedding.py
+++ b/vllm/lora/layers/vocal_parallel_embedding.py
@@ -94,6 +94,11 @@ class VocabParallelEmbeddingWithLoRA(BaseLayerWithLoRA):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # No active LoRA in this batch: skip the added LoRA embedding lookup and
+        # accumulation, returning the base embedding directly (eager mode only).
+        if self._can_skip_empty_lora():
+            return self.base_layer.forward(x)
+
         # NB: Don't use torch.narrow here. torch.narrow triggers some
         # Dynamic Shape specialization in torch.compile
         num_tokens = x.shape[0]

--- a/vllm/lora/punica_wrapper/punica_base.py
+++ b/vllm/lora/punica_wrapper/punica_base.py
@@ -163,6 +163,11 @@ class PunicaWrapperBase(PunicaWrapperABC):
         self.token_nums: int = 0
         self.batch_size: int = -1
         self.is_prefill = False
+        # Whether the current forward pass has no active LoRA at all, i.e. every
+        # token maps to the base model (token lora index == -1). Maintained by
+        # each backend's update_metadata and consumed by the LoRA layers to skip
+        # the LoRA path entirely in eager mode
+        # (see BaseLayerWithLoRA._can_skip_empty_lora).
         self.no_lora = False
 
     def _update_base_metadata(

--- a/vllm/lora/punica_wrapper/punica_gpu.py
+++ b/vllm/lora/punica_wrapper/punica_gpu.py
@@ -87,6 +87,11 @@ class PunicaWrapperGPU(PunicaWrapperBase):
         self.token_mapping_meta.prepare_tensors(self.token_lora_indices)
         self.prompt_mapping_meta.prepare_tensors(self.sampler_indices)
 
+        # Cache the no-LoRA state computed inside prepare_tensors as a Python
+        # bool. no_lora_flag_cpu already lives on CPU, so .item() adds no device
+        # sync. Layers read this to skip the LoRA path in eager mode.
+        self.no_lora = bool(self.token_mapping_meta.no_lora_flag_cpu.item())
+
     def add_shrink(
         self,
         y: torch.Tensor,

--- a/vllm/lora/punica_wrapper/punica_xpu.py
+++ b/vllm/lora/punica_wrapper/punica_xpu.py
@@ -88,6 +88,12 @@ class PunicaWrapperXPU(PunicaWrapperBase):
         self.token_mapping_meta.prepare_tensors(self.token_lora_indices)
         self.prompt_mapping_meta.prepare_tensors(self.sampler_indices)
 
+        # Cache the no-LoRA state computed inside prepare_tensors as a Python
+        # bool. no_lora_flag_cpu already lives on CPU, so .item() adds no device
+        # sync. Layers read this to skip the LoRA path in eager mode.
+        self.no_lora = bool(self.token_mapping_meta.no_lora_flag_cpu.item())
+
+
     def _get_token_lora_indices(self, x: torch.Tensor) -> torch.IntTensor:
         return torch.narrow(self._token_lora_indices, 0, 0, x.size(0))
 


### PR DESCRIPTION

## Purpose
When a model is served with `--enable-lora`, every wrapped layer
(`ColumnParallelLinearWithLoRA`, `RowParallelLinearWithLoRA`,
`VocabParallelEmbeddingWithLoRA`, `LogitsProcessorWithLoRA`, ...) unconditionally
runs the Punica LoRA path on every forward pass — allocating the shrink/expand
buffer, building kernel metadata, and dispatching `add_shrink` / `add_expand` —
**even when the batch contains no active adapter at all** (every request targets
the base model, i.e. `lora_request=None`).

Today the only protection against this is the in-kernel `no_lora_flag_cpu`
early-exit introduced in #15152. That early-exit lives *inside* the
`lora_shrink` / `lora_expand` torch ops, so it removes the GEMM work but **not**
the Python-level, buffer-allocation, and op-dispatch overhead that happens
*before* the op is reached. #15152 deliberately put the flag inside the op
because vLLM V1 executes forward through traced `torch.compile` graphs, and
dynamic Python control flow cannot be traced (while `torch.ops` are treated as
black boxes).

That design is correct for the compiled / CUDA-graph path, where this overhead
is fully absorbed and negligible. **But it leaves the eager path unoptimized.**


We run vLLM with custom kernels that are not CUDA-graph capturable, which forces
`enforce_eager=True`. In this eager configuration we serve a mix of LoRA and
non-LoRA (base-model) requests. Whenever a scheduled batch happens to contain
only base-model requests, the model still pays the full per-layer LoRA wrapper
overhead described above. On Qwen3-32B (TP=2, eager) this inflates the
no-adapter forward latency by **tens of percent** relative to a non-LoRA server.

## Test Plan & Results

### Environment

```text
python 3.12.13
torch  2.11.0+cu128
cuda   12.8
vllm   0.1.dev18426+gcdab28319   (branch lora_dev, base commit cdab28319)
GPU    NVIDIA A800-SXM4-80GB x8
model  Qwen3-32B
```

### 1. Unit test (shipped in this PR)

Added `tests/lora/test_layers.py::test_empty_lora_eager_skip`. It asserts, on a
`ColumnParallelLinearWithLoRA` layer, that: (a) eager + no-adapter →
`_can_skip_empty_lora()` is `True` and the output equals the base layer; (b)
`CUDAGraphMode.PIECEWISE` → skip is not taken and the output is still correct;
(c) a mixed batch keeps `no_lora is False` and never skips.

```python
@torch.inference_mode()
@pytest.mark.parametrize("device", DEVICES)
@pytest.mark.parametrize("stage", STAGES)
def test_empty_lora_eager_skip(default_vllm_config, dist_init, device, stage) -> None:
    from unittest.mock import MagicMock

    import vllm.lora.layers.base as lora_base
    from vllm.config import CUDAGraphMode

    if current_platform.is_cuda_alike() or current_platform.is_xpu():
        torch.accelerator.set_device_index(device)

    max_loras = 8
    torch.set_default_device(device)
    lora_config = LoRAConfig(
        max_loras=max_loras, max_lora_rank=8, lora_dtype=torch.float16
    )
    punica_wrapper = get_punica_wrapper(8192, 256, device, lora_config=lora_config)
    assert check_punica_wrapper(punica_wrapper)

    linear = ColumnParallelLinear(
        4096, 4096, bias=False, params_dtype=torch.float16, prefix="layer_0"
    )
    linear.weight.data = torch.rand_like(linear.weight.data)
    lora_linear = ColumnParallelLinearWithLoRA(linear)
    lora_linear.create_lora_weights(max_loras, lora_config)
    lora_linear.set_mapping(punica_wrapper)

    id_to_index = get_random_id_to_index(2, max_loras)
    lora_dict, _ = populate_loras(
        id_to_index, layer=lora_linear, layer_weights=linear.weight
    )
    active_lora_ids = list(lora_dict.keys())

    def make_ctx(mode):
        ctx = MagicMock()
        ctx.cudagraph_runtime_mode = mode
        return ctx

    def set_no_lora_batch(no_lora: bool):
        # active id 0 maps to "no LoRA" (token index -1). Mixing in a real
        # adapter id yields a batch that does require LoRA.
        ids = [0] if no_lora else [0, active_lora_ids[0]]
        inputs, index_mapping, prompt_mapping = create_random_inputs(
            active_lora_ids=ids,
            num_inputs=8,
            input_size=(1, 4096),
            input_range=(0, 1),
            input_type=torch.float16,
            device=device,
        )
        lora_mapping = LoRAMapping(index_mapping, prompt_mapping, is_prefill=stage)
        punica_wrapper.update_metadata(lora_mapping, id_to_index, max_loras, 512)
        return torch.cat(inputs)

    # No active LoRA in the batch: wrapper detects it and eager path skips.
    x = set_no_lora_batch(no_lora=True)
    assert punica_wrapper.no_lora is True
    expected = linear(x)[0]
    rtol, atol = TOLERANCES[expected.dtype]

    # Eager (cudagraph mode NONE) -> skip taken, output == base.
    with (
        patch.object(lora_base, "is_forward_context_available", return_value=True),
        patch.object(
            lora_base, "get_forward_context", return_value=make_ctx(CUDAGraphMode.NONE)
        ),
    ):
        assert lora_linear._can_skip_empty_lora() is True
        skipped = lora_linear(x)[0]
    torch.testing.assert_close(skipped, expected, rtol=rtol, atol=atol)

    # Cudagraph (PIECEWISE) -> skip NOT taken, output still correct (== base).
    with (
        patch.object(lora_base, "is_forward_context_available", return_value=True),
        patch.object(
            lora_base,
            "get_forward_context",
            return_value=make_ctx(CUDAGraphMode.PIECEWISE),
        ),
    ):
        assert lora_linear._can_skip_empty_lora() is False
        not_skipped = lora_linear(x)[0]
    torch.testing.assert_close(not_skipped, expected, rtol=rtol, atol=atol)

    # Mixed batch (some tokens need LoRA): must never skip, even in eager.
    set_no_lora_batch(no_lora=False)
    assert punica_wrapper.no_lora is False
    with (
        patch.object(lora_base, "is_forward_context_available", return_value=True),
        patch.object(
            lora_base, "get_forward_context", return_value=make_ctx(CUDAGraphMode.NONE)
        ),
    ):
        assert lora_linear._can_skip_empty_lora() is False
```

Command:

```bash
CUDA_VISIBLE_DEVICES=6,7 .venv/bin/python -m pytest \
  tests/lora/test_layers.py -k test_empty_lora_eager_skip -v
```

Output:

```text
tests/lora/test_layers.py::test_empty_lora_eager_skip[True-cuda:0] PASSED  [ 25%]
tests/lora/test_layers.py::test_empty_lora_eager_skip[True-cuda:1] PASSED  [ 50%]
tests/lora/test_layers.py::test_empty_lora_eager_skip[False-cuda:0] SKIPPED [ 75%]
tests/lora/test_layers.py::test_empty_lora_eager_skip[False-cuda:1] SKIPPED [100%]
========== 2 passed, 2 skipped, 268 deselected, 16 warnings in 3.80s ===========
```

(`stage=False` is skipped on CUDA by the pre-existing `skip_cuda_with_stage_false`
fixture, since prefill/decode use the same kernels there.)

### 2. End-to-end functional correctness (real adapter)

Three cases on Qwen3-32B (TP=2, eager), greedy decode, same prompt, using a real
adapter `iLang-Qwen3-32B-v2-lora` (targets q/k/v/o/gate/up/down, r=16):

1. `enable_lora=False` (baseline)
2. `enable_lora=True`, `lora_request=None`  (hits the eager skip)
3. `enable_lora=True` + the real adapter loaded

Expected: case 1 == case 2 (skip is equivalent to base) and case 3 != case 1
(the adapter is really applied).

```bash
.venv/bin/python test_lora_functional.py --cuda-visible-devices 6,7 \
  --tensor-parallel-size 2 --max-model-len 2048 \
  --gpu-memory-utilization 0.65 --max-tokens 32
```

Output (token IDs and assertions):

```text
=== Case 1: baseline (no LoRA) ===
  tokens: [12095, 13, 220, 3007, 476, 3557, 30, 220, 81917, 697, 4226, 13, 576,
           5114, 330, 785, 6722, 315, 9625, 374, 12095, 1, 374, 3070, 2514, 334,
           382, 334, 69769, 66963, 2303, 59604]
=== Case 2: enable_lora=True, lora_request=None (eager skip) ===
  tokens: [12095, 13, 220, 3007, 476, 3557, 30, 220, 81917, 697, 4226, 13, 576,
           5114, 330, 785, 6722, 315, 9625, 374, 12095, 1, 374, 3070, 2514, 334,
           382, 334, 69769, 66963, 2303, 59604]
=== Case 3: enable_lora=True, real adapter loaded ===
  tokens: [12095, 13, 220, 3007, 476, 3557, 30, 220, 81917, 697, 4226, 13, 576,
           5114, 330, 785, 6722, 315, 9625, 374, 12095, 1, 374, 3070, 2514, 334,
           382, 334, 69769, 25, 1019, 59604]
=== Assertions ===
  PASS: case 1 == case 2 (skip path is equivalent to baseline)
  PASS: case 3 != case 1 (LoRA adapter changes output as expected)
```

Case 3 diverges from index 29 (`...69769, 66963, 2303` → `...69769, 25, 1019`),
confirming the adapter path is active (the log also shows real
`_lora_shrink_kernel` / `_lora_expand_kernel` JIT compilation).

### 3. Latency benchmark

Offline `LLM.generate(..., lora_request=[None] * bs)`, no adapter loaded,
`enable_lora=True` vs an `enable_lora=False` baseline, prefix cache disabled,
unique prompts (Qwen3-32B, TP=2, GPUs 6,7).

```bash
# Eager (this is the path the fix targets)
.venv/bin/python test_lora_enable_overhead.py \
  --mode offline --unique-prompts --disable-prefix-caching \
  --warmup-requests 1 --measure-requests 4 --offline-batch-size 8 \
  --max-tokens 16 --case-order baseline-first --min-overhead-ratio 0.0 \
  --cuda-visible-devices 6,7 --tensor-parallel-size 2 \
  --gpu-memory-utilization 0.6 --extra-vllm-arg=--enforce-eager

# CUDA-graph control (drop --extra-vllm-arg=--enforce-eager)
.venv/bin/python test_lora_enable_overhead.py \
  --mode offline --unique-prompts --disable-prefix-caching \
  --warmup-requests 1 --measure-requests 4 --offline-batch-size 8 \
  --max-tokens 16 --case-order baseline-first --min-overhead-ratio 0.0 \
  --cuda-visible-devices 6,7 --tensor-parallel-size 2 --gpu-memory-utilization 0.65
```

Output (eager, after fix):

```text
baseline:                mean=0.8371s median=0.8185s p95=0.9565s
enable_lora_no_adapters: mean=0.8630s median=0.8557s p95=0.9194s
mean_overhead_percent:   3.09
```

Output (CUDA-graph control, after fix):

```text
baseline:                mean=0.4445s median=0.4446s p95=0.4452s
enable_lora_no_adapters: mean=0.4503s median=0.4497s p95=0.4543s
mean_overhead_percent:   1.30
```

Summary of the eager no-adapter overhead (`enable_lora=True` vs baseline):

- Before the fix: **+44% – +207%** (varies with batch shape / per-layer count;
  measured historically on the unpatched build, e.g. TP=4 eager baseline
  `0.7626s` vs `1.1975s` = +57%).
- After the fix (eager, the run above): **+3.09%** (`0.8371s` → `0.8630s`); the
  small residual is run-to-run noise on sub-second latencies (an earlier run on
  a quieter GPU measured `0.7478s` → `0.7663s` = +2.48%).
- CUDA-graph control (the run above): **+1.30%** → within noise, no regression,
  confirming the fix is scoped to eager.

> The reproducer (`test_lora_enable_overhead.py`) and the functional test
> (`test_lora_functional.py`) are investigation artifacts and are **not** part of
> this PR; the PR ships only the fix plus the unit test above.
