### PR TITLE
[Bugfix][Frontend] Anchor empty-args detection to the current tool in xlam and hunyuan_a13b streaming parsers

### DIFF
--- a/tests/tool_parsers/test_hunyuan_a13b_tool_parser.py
+++ b/tests/tool_parsers/test_hunyuan_a13b_tool_parser.py
@@ -189,3 +189,36 @@ def test_hunyuan_a13b_tool_parser_non_ascii():
     args = tool_calls[0].function.arguments
     assert "北京" in args
     assert "\\u" not in args
+
+
+@pytest.mark.parametrize(
+    "model_output,expected_tool_calls",
+    [
+        # Empty-args tool first: later tools' arguments must not be dropped.
+        (
+            '<tool_calls>[{"name": "a", "arguments": {}}, {"name": "b", "arguments": {"x": 42}}]</tool_calls>',
+            [make_tool_call("a", {}), make_tool_call("b", {"x": 42})],
+        ),
+        # Empty-args tool last: earlier tools' arguments must not be dropped.
+        (
+            '<tool_calls>[{"name": "a", "arguments": {"x": 42}}, {"name": "b", "arguments": {}}]</tool_calls>',
+            [make_tool_call("a", {"x": 42}), make_tool_call("b", {})],
+        ),
+    ],
+)
+def test_hunyuan_a13b_tool_parser_streaming_one_empty_args_tool(
+    model_output, expected_tool_calls
+):
+    """An empty-args tool must not clobber other tools' streamed arguments."""
+    mock_tokenizer = MagicMock()
+    tool_parser: ToolParser = ToolParserManager.get_tool_parser("hunyuan_a13b")(
+        mock_tokenizer
+    )
+    reconstructor = run_tool_extraction_streaming(
+        tool_parser, list(model_output), assert_one_tool_per_delta=False
+    )
+
+    for idx in range(len(reconstructor.tool_calls)):
+        reconstructor.tool_calls[idx].id = expected_tool_calls[idx].id
+
+    assert reconstructor.tool_calls == expected_tool_calls

--- a/tests/tool_parsers/test_xlam_tool_parser.py
+++ b/tests/tool_parsers/test_xlam_tool_parser.py
@@ -555,3 +555,43 @@ def test_extract_tool_calls_non_ascii(xlam_tool_parser, xlam_tokenizer, streamin
 
     assert "北京" in args
     assert "\\u" not in args
+
+
+@pytest.mark.parametrize(
+    "model_output,expected",
+    [
+        # Empty-args tool first: later tools' arguments must not be dropped.
+        (
+            '[{"name": "a", "arguments": {}}, {"name": "b", "arguments": {"x": 42}}]',
+            [("a", {}), ("b", {"x": 42})],
+        ),
+        # Empty-args tool last: earlier tools' arguments must not be dropped.
+        (
+            '[{"name": "a", "arguments": {"x": 42}}, {"name": "b", "arguments": {}}]',
+            [("a", {"x": 42}), ("b", {})],
+        ),
+    ],
+)
+def test_extract_tool_calls_streaming_one_empty_args_tool(
+    xlam_tool_parser, xlam_tokenizer, model_output, expected
+):
+    """An empty-args tool must not clobber other tools' streamed arguments."""
+    request = ChatCompletionRequest(model=MODEL, messages=[])
+
+    names: dict[int, str] = {}
+    args: dict[int, str] = {}
+    for delta_message in stream_delta_message_generator(
+        xlam_tool_parser, xlam_tokenizer, model_output, request
+    ):
+        for tool_call in delta_message.tool_calls or []:
+            if tool_call.function and tool_call.function.name:
+                names[tool_call.index] = tool_call.function.name
+            if tool_call.function and tool_call.function.arguments:
+                args[tool_call.index] = (
+                    args.get(tool_call.index, "") + tool_call.function.arguments
+                )
+
+    assert [names.get(i) for i in range(len(expected))] == [n for n, _ in expected]
+    assert [json.loads(args.get(i, "")) for i in range(len(expected))] == [
+        a for _, a in expected
+    ]

--- a/vllm/tool_parsers/hunyuan_a13b_tool_parser.py
+++ b/vllm/tool_parsers/hunyuan_a13b_tool_parser.py
@@ -313,7 +313,19 @@ class HunyuanA13BToolParser(ToolParser):
         self, current_text: str, current_idx: int, tool_count: int
     ):
         if current_idx >= 0 and current_idx < tool_count:
-            empty_args_match = self.tool_empty_arg_reg.search(current_text)
+            # The empty-args pattern starts at a tool's "name" key, so anchor
+            # the match to the current tool's name position; a match for any
+            # other tool must not mark the current one as empty-args.
+            name_matches = list(self.tool_name_reg.finditer(current_text))
+            empty_args_match = next(
+                (
+                    m
+                    for m in self.tool_empty_arg_reg.finditer(current_text)
+                    if current_idx < len(name_matches)
+                    and m.start() == name_matches[current_idx].start()
+                ),
+                None,
+            )
             if empty_args_match and empty_args_match.start() > 0:
                 for i in range(tool_count):
                     if i == current_idx:

--- a/vllm/tool_parsers/xlam_tool_parser.py
+++ b/vllm/tool_parsers/xlam_tool_parser.py
@@ -405,10 +405,20 @@ class xLAMToolParser(ToolParser):
             if current_idx >= 0 and current_idx < tool_count:
                 # Support both regular and empty argument objects
                 # First, check for the empty arguments case: "arguments": {}
+                # The pattern starts at a tool's "name" key, so anchor the
+                # match to the current tool's name position; a match for any
+                # other tool must not mark the current one as empty-args.
                 empty_args_pattern = (
                     r'"name"\s*:\s*"[^"]+"\s*,\s*"arguments"\s*:\s*\{\s*\}'
                 )
-                empty_args_match = re.search(empty_args_pattern, search_text)
+                empty_args_match = next(
+                    (
+                        m
+                        for m in re.finditer(empty_args_pattern, search_text)
+                        if m.start() == name_matches[current_idx].start()
+                    ),
+                    None,
+                )
 
                 # Check if this tool has empty arguments
                 if empty_args_match and empty_args_match.start() > 0:


### PR DESCRIPTION
## Purpose

Fixes #47901 — in the `xlam` and `hunyuan_a13b` streaming tool parsers, when an earlier tool call has empty arguments (`"arguments": {}`), every later tool call's arguments are silently streamed as `{}` and the real content is dropped.

Root cause (identical copy-pasted logic in both parsers): the empty-args check does `re.search(empty_args_pattern, text)`, which matches the *first* empty-args tool anywhere in the text, and then unconditionally treats the *current* tool as empty-args — emitting `{}` and setting `sent_arguments = "{}"`, after which the prefix-diff streaming (`args_text.startswith(sent_args)`) can never recover. The `empty_args_tool_idx` variable computed next to it is dead.

Fix: the pattern starts at a tool's `"name"` key, so anchor the match to the current tool's name position (`m.start() == name_matches[current_idx].start()`). A match belonging to a different tool no longer marks the current one as empty-args. Applied to both parsers.

## Duplicate check

Claimed in #47901 ([comment](https://github.com/vllm-project/vllm/issues/47901#issuecomment-4911075978)); no open PR references the issue and keyword searches for xlam/hunyuan parser fixes found none.

## Test Plan

```bash
pytest tests/tool_parsers/test_xlam_tool_parser.py -v
pytest tests/tool_parsers/test_hunyuan_a13b_tool_parser.py -v
```

New regression tests in both files: multi-tool streaming with an empty-args call first (the reported bug) and last (guards the anchoring logic), asserting per-index reconstructed names/arguments match the non-streaming parse.

## Test Result

- On `main`: the empty-args-first cases fail in both parsers with `streamed = [{}, {}]` instead of `[{}, {"x": 42}]` — reproducing the issue exactly (also verified with the issue's standalone repro script: `streamed={0: '{}', 1: '{}'}` before, `{0: '{}', 1: '{"x": 42}'}` after).
- With this PR: full test files pass — 30 passed, 2 pre-existing xfails (nested-JSON streaming, unrelated).
- `pre-commit` (ruff check/format, mypy hook, typos) passes on all changed files.

AI assistance (Claude) was used for the analysis, fix, and tests; submitted after human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
