### PR TITLE
[Bugfix][Tool Parser] Stream full single-delta tool calls

### DIFF
--- a/tests/tool_parsers/test_gigachat3_tool_parser.py
+++ b/tests/tool_parsers/test_gigachat3_tool_parser.py
@@ -7,6 +7,7 @@ import pytest
 from transformers import AutoTokenizer
 
 from tests.tool_parsers.utils import (
+    DummyTokenizer,
     run_tool_extraction,
     run_tool_extraction_streaming,
 )
@@ -350,3 +351,15 @@ def test_streaming_tool_call_with_large_steps(
     assert call.function.name == "manage_user_memory"
     args_dict = json.loads(call.function.arguments)
     assert args_dict == COMPLEX_ARGS_DICT
+
+
+def test_streaming_complete_tool_call_single_delta():
+    tool_parser = ToolParserManager.get_tool_parser("gigachat3")(DummyTokenizer())
+    model_output = '<|function_call|>{"name": "get_weather", "arguments": {"x": 42}}'
+
+    reconstructor = run_tool_extraction_streaming(tool_parser, [model_output])
+
+    assert len(reconstructor.tool_calls) == 1
+    call = reconstructor.tool_calls[0]
+    assert call.function.name == "get_weather"
+    assert json.loads(call.function.arguments) == {"x": 42}

--- a/tests/tool_parsers/test_granite_20b_fc_tool_parser.py
+++ b/tests/tool_parsers/test_granite_20b_fc_tool_parser.py
@@ -1,12 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
+
 import pytest
 
 from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
+from tests.tool_parsers.utils import DummyTokenizer, run_tool_extraction_streaming
+from vllm.tool_parsers.granite_20b_fc_tool_parser import Granite20bFCToolParser
 
 
 class TestGranite20bFcToolParser(ToolParserTests):
@@ -74,3 +78,22 @@ class TestGranite20bFcToolParser(ToolParserTests):
             },
             xfail_nonstreaming={},
         )
+
+
+def test_streaming_parallel_calls_single_delta():
+    parser = Granite20bFCToolParser(DummyTokenizer())
+    model_output = (
+        '<function_call> {"name": "get_weather", "arguments": {"x": 42}}'
+        '<function_call> {"name": "b", "arguments": {"y": 7}}'
+    )
+
+    reconstructor = run_tool_extraction_streaming(
+        parser, [model_output], assert_one_tool_per_delta=False
+    )
+
+    assert [tc.function.name for tc in reconstructor.tool_calls] == [
+        "get_weather",
+        "b",
+    ]
+    assert json.loads(reconstructor.tool_calls[0].function.arguments) == {"x": 42}
+    assert json.loads(reconstructor.tool_calls[1].function.arguments) == {"y": 7}

--- a/tests/tool_parsers/test_granite_tool_parser.py
+++ b/tests/tool_parsers/test_granite_tool_parser.py
@@ -11,6 +11,7 @@ from tests.tool_parsers.common_tests import (
     ToolParserTests,
 )
 from tests.tool_parsers.utils import (
+    DummyTokenizer,
     run_tool_extraction,
     run_tool_extraction_streaming,
     split_string_into_token_deltas,
@@ -159,3 +160,22 @@ def test_streaming_parallel_calls_batched_deltas(granite_tokenizer, chunk_size):
     assert json.loads(reconstructor.tool_calls[0].function.arguments) == {
         "city": "Tokyo"
     }
+
+
+def test_streaming_parallel_calls_single_delta():
+    parser = GraniteToolParser(DummyTokenizer())
+    model_output = (
+        '<|tool_call|>[{"name": "get_weather", "arguments": {"x": 42}}, '
+        '{"name": "b", "arguments": {"y": 7}}]'
+    )
+
+    reconstructor = run_tool_extraction_streaming(
+        parser, [model_output], assert_one_tool_per_delta=False
+    )
+
+    assert [tc.function.name for tc in reconstructor.tool_calls] == [
+        "get_weather",
+        "b",
+    ]
+    assert json.loads(reconstructor.tool_calls[0].function.arguments) == {"x": 42}
+    assert json.loads(reconstructor.tool_calls[1].function.arguments) == {"y": 7}

--- a/tests/tool_parsers/utils.py
+++ b/tests/tool_parsers/utils.py
@@ -14,6 +14,14 @@ from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers import ToolParser
 
 
+class DummyTokenizer:
+    def get_vocab(self) -> dict[str, int]:
+        return {}
+
+    def tokenize(self, text: str) -> list[str]:
+        return []
+
+
 class StreamingToolReconstructor:
     def __init__(self, assert_one_tool_per_delta: bool = True):
         self.tool_calls: list[ToolCall] = []

--- a/vllm/tool_parsers/gigachat3_tool_parser.py
+++ b/vllm/tool_parsers/gigachat3_tool_parser.py
@@ -142,7 +142,7 @@ class GigaChat3ToolParser(ToolParser):
                     content = delta_text
             if m_func:
                 self.tool_started = True
-            if content:
+            if content and not m_func:
                 return DeltaMessage(content=content)
         if not m_func:
             return None
@@ -166,19 +166,30 @@ class GigaChat3ToolParser(ToolParser):
             self.prev_tool_call_arr.append({})
         if not self.tool_name_sent:
             if not func_name:
+                if content:
+                    return DeltaMessage(content=content)
                 return None
             self.tool_name_sent = True
             self.tool_id = make_tool_call_id()
             self.prev_tool_call_arr[0]["name"] = func_name
+            delta_function_call = DeltaFunctionCall(name=func_name)
+            if cur_args is not None:
+                self.prev_tool_call_arr[0]["arguments_str"] = cur_args
+                try:
+                    args_dict = json.loads(cur_args, strict=False)
+                    self.prev_tool_call_arr[0]["arguments"] = args_dict
+                except json.JSONDecodeError:
+                    self.prev_tool_call_arr[0]["arguments"] = {}
+                self.streamed_args_for_tool.append(cur_args)
+                delta_function_call.arguments = cur_args
             return DeltaMessage(
+                content=content,
                 tool_calls=[
                     DeltaToolCall(
                         index=0,
                         id=self.tool_id,
                         type="function",
-                        function=DeltaFunctionCall(
-                            name=func_name,
-                        ).model_dump(exclude_none=True),
+                        function=delta_function_call.model_dump(exclude_none=True),
                     )
                 ],
             )

--- a/vllm/tool_parsers/granite_20b_fc_tool_parser.py
+++ b/vllm/tool_parsers/granite_20b_fc_tool_parser.py
@@ -54,6 +54,39 @@ class Granite20bFCToolParser(ToolParser):
         self.tool_start_token = self.bot_token
         self.tool_call_regex = re.compile(r"<function_call>\s*")
 
+    def _emit_initial_complete_tool_calls(
+        self, tool_call_arr: list[dict]
+    ) -> DeltaMessage | None:
+        delta_tool_calls: list[DeltaToolCall] = []
+        streamed_args_for_tool: list[str] = []
+
+        for index, tool_call in enumerate(tool_call_arr):
+            function_name = tool_call.get("name")
+            if not function_name or "arguments" not in tool_call:
+                return None
+            arguments = json.dumps(tool_call["arguments"], ensure_ascii=False)
+            delta_tool_calls.append(
+                DeltaToolCall(
+                    index=index,
+                    type="function",
+                    id=make_tool_call_id(),
+                    function=DeltaFunctionCall(
+                        name=function_name,
+                        arguments=arguments,
+                    ).model_dump(exclude_none=True),
+                )
+            )
+            streamed_args_for_tool.append(arguments)
+
+        if not delta_tool_calls:
+            return None
+
+        self.current_tool_id = len(tool_call_arr) - 1
+        self.current_tool_name_sent = True
+        self.prev_tool_call_arr = tool_call_arr
+        self.streamed_args_for_tool = streamed_args_for_tool
+        return DeltaMessage(tool_calls=delta_tool_calls)
+
     def extract_tool_calls(
         self, model_output: str, request: ChatCompletionRequest
     ) -> ExtractedToolCallInformation:
@@ -165,6 +198,11 @@ class Granite20bFCToolParser(ToolParser):
             #   only the array brackets, stream nothing
             if len(tool_call_arr) == 0:
                 return None
+
+            if self.current_tool_id < 0 and all(is_complete):
+                initial_delta = self._emit_initial_complete_tool_calls(tool_call_arr)
+                if initial_delta is not None:
+                    return initial_delta
 
             # case: we are starting a new tool in the array
             #   -> array has > 0 length AND length has moved past cursor

--- a/vllm/tool_parsers/granite_tool_parser.py
+++ b/vllm/tool_parsers/granite_tool_parser.py
@@ -52,6 +52,39 @@ class GraniteToolParser(ToolParser):
         # for granite 3.1, the string `<tool_call>`
         self.bot_string = "<tool_call>"
 
+    def _emit_initial_complete_tool_calls(
+        self, tool_call_arr: list[dict]
+    ) -> DeltaMessage | None:
+        delta_tool_calls: list[DeltaToolCall] = []
+        streamed_args_for_tool: list[str] = []
+
+        for index, tool_call in enumerate(tool_call_arr):
+            function_name = tool_call.get("name")
+            if not function_name or "arguments" not in tool_call:
+                return None
+            arguments = json.dumps(tool_call["arguments"], ensure_ascii=False)
+            delta_tool_calls.append(
+                DeltaToolCall(
+                    index=index,
+                    type="function",
+                    id=make_tool_call_id(),
+                    function=DeltaFunctionCall(
+                        name=function_name,
+                        arguments=arguments,
+                    ).model_dump(exclude_none=True),
+                )
+            )
+            streamed_args_for_tool.append(arguments)
+
+        if not delta_tool_calls:
+            return None
+
+        self.current_tool_id = len(tool_call_arr) - 1
+        self.current_tool_name_sent = True
+        self.prev_tool_call_arr = tool_call_arr
+        self.streamed_args_for_tool = streamed_args_for_tool
+        return DeltaMessage(tool_calls=delta_tool_calls)
+
     def extract_tool_calls(
         self, model_output: str, request: ChatCompletionRequest
     ) -> ExtractedToolCallInformation:
@@ -149,6 +182,11 @@ class GraniteToolParser(ToolParser):
             #   only the array brackets, stream nothing
             if not tool_call_arr:
                 return None
+
+            if self.current_tool_id < 0 and all(is_complete):
+                initial_delta = self._emit_initial_complete_tool_calls(tool_call_arr)
+                if initial_delta is not None:
+                    return initial_delta
 
             # select as the current tool call the one we're on the state at
             current_tool_call: dict = tool_call_arr[self.current_tool_id]


### PR DESCRIPTION
Fixes #47907

### Summary
- Stream complete first-delta tool calls for `gigachat3` instead of emitting only the function name.
- Stream complete initial batches for `granite` and `granite-20b-fc`, including multiple tool calls in one delta.
- Add focused regressions using a dummy tokenizer so the issue is covered without model downloads.

### Tests
- `.venv/bin/python -m pytest --confcutdir=tests/tool_parsers tests/tool_parsers/test_gigachat3_tool_parser.py tests/tool_parsers/test_granite_tool_parser.py tests/tool_parsers/test_granite_20b_fc_tool_parser.py -q`
- `.venv/bin/pre-commit run --files vllm/tool_parsers/gigachat3_tool_parser.py vllm/tool_parsers/granite_tool_parser.py vllm/tool_parsers/granite_20b_fc_tool_parser.py tests/tool_parsers/utils.py tests/tool_parsers/test_gigachat3_tool_parser.py tests/tool_parsers/test_granite_tool_parser.py tests/tool_parsers/test_granite_20b_fc_tool_parser.py`

### Assistance disclosure
This PR was prepared with OpenAI Codex assistance and reviewed locally before submission.