### PR TITLE
[Bugfix][Core] Preserve None values in swap_dict_values

### DIFF
--- a/tests/utils_/test_collection_utils.py
+++ b/tests/utils_/test_collection_utils.py
@@ -22,26 +22,20 @@ def test_common_prefix(inputs, expected_output):
 
 
 @pytest.mark.parametrize(
-    ("obj", "key1", "key2"),
+    ("obj", "key1", "key2", "expected"),
     [
         # Tests for both keys exist
-        ({1: "a", 2: "b"}, 1, 2),
+        ({1: "a", 2: "b"}, 1, 2, {1: "b", 2: "a"}),
         # Tests for one key does not exist
-        ({1: "a", 2: "b"}, 1, 3),
+        ({1: "a", 2: "b"}, 1, 3, {2: "b", 3: "a"}),
         # Tests for both keys do not exist
-        ({1: "a", 2: "b"}, 3, 4),
+        ({1: "a", 2: "b"}, 3, 4, {1: "a", 2: "b"}),
+        # Tests for values that are present but None
+        ({1: None, 2: "b"}, 1, 2, {1: "b", 2: None}),
+        ({1: None, 2: "b"}, 1, 3, {2: "b", 3: None}),
+        ({1: None, 2: "b"}, 1, 1, {1: None, 2: "b"}),
     ],
 )
-def test_swap_dict_values(obj, key1, key2):
-    original_obj = obj.copy()
-
+def test_swap_dict_values(obj, key1, key2, expected):
     swap_dict_values(obj, key1, key2)
-
-    if key1 in original_obj:
-        assert obj[key2] == original_obj[key1]
-    else:
-        assert key2 not in obj
-    if key2 in original_obj:
-        assert obj[key1] == original_obj[key2]
-    else:
-        assert key1 not in obj
+    assert obj == expected

--- a/vllm/utils/collection_utils.py
+++ b/vllm/utils/collection_utils.py
@@ -122,13 +122,12 @@ def full_groupby(values: Iterable[_V], *, key: Callable[[_V], _K]):
 
 def swap_dict_values(obj: dict[_K, _V], key1: _K, key2: _K) -> None:
     """Swap values between two keys."""
-    v1 = obj.get(key1)
-    v2 = obj.get(key2)
-    if v1 is not None:
-        obj[key2] = v1
-    else:
-        obj.pop(key2, None)
-    if v2 is not None:
-        obj[key1] = v2
-    else:
-        obj.pop(key1, None)
+    key1_exists = key1 in obj
+    key2_exists = key2 in obj
+
+    if key1_exists and key2_exists:
+        obj[key1], obj[key2] = obj[key2], obj[key1]
+    elif key1_exists:
+        obj[key2] = obj.pop(key1)
+    elif key2_exists:
+        obj[key1] = obj.pop(key2)


### PR DESCRIPTION
## What

Preserve dictionary entries whose value is `None` when `swap_dict_values` swaps two keys. The previous implementation used `dict.get()`, which made a present `None` value indistinguishable from a missing key and could delete the other key during the swap.

## Why This Is Not A Duplicate

I checked for existing work before opening this PR:

- `gh pr list --repo vllm-project/vllm --state open --search "swap_dict_values" --limit 20` returned no results.
- `gh pr list --repo vllm-project/vllm --state open --search "collection_utils swap" --limit 20` returned no results.
- `gh issue list --repo vllm-project/vllm --state open --search "swap_dict_values OR collection_utils" --limit 20` returned no matching issue.
- `gh pr list --repo vllm-project/vllm --state open --search "None value dict swap" --limit 20` returned unrelated results only.

## Tests

- `.venv/bin/python -m pytest --noconftest tests/utils_/test_collection_utils.py -q` -> 13 passed, 1 warning
- `.venv/bin/pre-commit run --files vllm/utils/collection_utils.py tests/utils_/test_collection_utils.py` -> passed

This PR was prepared with OpenAI Codex assistance and reviewed locally before submission.