### PR TITLE
[XPU] [Fusion passes] Disable fuse_rope_kvcache_cat_mla & qk_norm_rope_ fusion on XPU

### DIFF
--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -295,6 +295,8 @@ class XPUPlatform(Platform):
             "fuse_attn_quant": "Attention + quant fusion",
             "fuse_act_padding": "Activation + padding fusion",
             "fuse_rope_kvcache": "RoPE + KV cache fusion",
+            "fuse_rope_kvcache_cat_mla": "RoPE + KV cache + MLA fusion",
+            "enable_qk_norm_rope_fusion": "QK Norm + RoPE fusion",
         }
         if compilation_config.mode != CompilationMode.NONE:
             for flag, feature_name in fusion_passes_to_disable.items():


### PR DESCRIPTION
## Purpose
This PR temporarily disables two fusion passes on the XPU backend:
- fuse_rope_kvcache_cat_mla – RoPE + KV cache + MLA fusion
- enable_qk_norm_rope_fusion – QK Norm + RoPE fusion

## Background:
These fusions are currently enabled by default on other backends while `use_inductor_graph_partition=True`, but on XPU they may introduce start issue due to some fusion kernels not implemented on XPU. (e.g. ops.concat_and_cache_mla_rope_fused)