### PR TITLE
[Bugfix] Report finish_reason='length' for tool calls truncated by max_tokens in streaming

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -2300,3 +2300,131 @@ async def test_streaming_n_gt1_independent_tool_parsers():
             f"Choice {choice_idx}: expected finish_reason='tool_calls', "
             f"got '{reasons[0]}'"
         )
+
+
+@pytest.mark.asyncio
+async def test_streaming_truncated_tool_call_reports_length_finish_reason():
+    """A tool call cut off by max_tokens must stream finish_reason="length",
+    matching the non-streaming path, not "tool_calls" (#47903).
+    """
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+
+    models = OpenAIServingModels(
+        engine_client=mock_engine,
+        base_model_paths=BASE_MODEL_PATHS,
+    )
+    online_renderer = _build_online_renderer(mock_engine, models.registry)
+
+    serving_chat = OpenAIServingChat(
+        mock_engine,
+        models,
+        response_role="assistant",
+        online_renderer=online_renderer,
+        chat_template=CHAT_TEMPLATE,
+        chat_template_content_format="auto",
+        request_logger=None,
+        enable_auto_tools=True,
+        tool_parser="hermes",
+    )
+
+    tokenizer = get_tokenizer(MODEL_NAME)
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "test"}],
+        stream=True,
+        tools=tools,
+        tool_choice="required",
+    )
+
+    truncated_tool_call_text = (
+        '<tool_call>\n{"name": "get_weather", "arguments": {"city'
+    )
+    all_token_ids = tokenizer.encode(truncated_tool_call_text, add_special_tokens=False)
+
+    steps: list[tuple[str, int]] = []
+    prev_decoded = ""
+    for i, tid in enumerate(all_token_ids):
+        decoded_so_far = tokenizer.decode(all_token_ids[: i + 1])
+        steps.append((decoded_so_far[len(prev_decoded) :], tid))
+        prev_decoded = decoded_so_far
+
+    async def result_generator():
+        for delta_text, token_id in steps:
+            yield RequestOutput(
+                request_id="test-req",
+                prompt="test",
+                prompt_token_ids=[1, 2, 3],
+                prompt_logprobs=None,
+                outputs=[
+                    CompletionOutput(
+                        index=0,
+                        text=delta_text,
+                        token_ids=[token_id],
+                        cumulative_logprob=0.0,
+                        logprobs=None,
+                    )
+                ],
+                finished=False,
+            )
+        yield RequestOutput(
+            request_id="test-req",
+            prompt="test",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text="",
+                    token_ids=[],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                    finish_reason="length",
+                )
+            ],
+            finished=True,
+        )
+
+    finish_reasons: list[str] = []
+    async for chunk_str in serving_chat.chat_completion_stream_generator(
+        request=request,
+        result_generator=result_generator(),
+        request_id="test-req",
+        model_name=MODEL_NAME,
+        conversation=[],
+        tokenizer=tokenizer,
+        request_metadata=RequestResponseMetadata(
+            request_id="test-req",
+            model_name=MODEL_NAME,
+        ),
+    ):
+        if not chunk_str.strip() or "data: [DONE]" in chunk_str:
+            continue
+        if chunk_str.startswith("data: "):
+            data = json.loads(chunk_str[6:].strip())
+            for choice in data.get("choices", []):
+                if choice.get("finish_reason") is not None:
+                    finish_reasons.append(choice["finish_reason"])
+
+    assert finish_reasons == ["length"], (
+        f"Truncated tool call must report finish_reason='length', got {finish_reasons}"
+    )

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -2345,3 +2345,131 @@ def test_make_request_with_harmony_reuses_kv_transfer_prompt_token_ids():
     assert engine_input["prompt_token_ids"] == [10, 20, 30]
     # The reuse key is consumed and other kv_transfer_params are preserved.
     assert request.kv_transfer_params == {"do_remote_prefill": True}
+
+
+@pytest.mark.asyncio
+async def test_streaming_truncated_tool_call_reports_length_finish_reason():
+    """A tool call cut off by max_tokens must stream finish_reason="length",
+    matching the non-streaming path, not "tool_calls" (#47903).
+    """
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+
+    models = OpenAIServingModels(
+        engine_client=mock_engine,
+        base_model_paths=BASE_MODEL_PATHS,
+    )
+    online_renderer = _build_online_renderer(mock_engine, models.registry)
+
+    serving_chat = OpenAIServingChat(
+        mock_engine,
+        models,
+        response_role="assistant",
+        online_renderer=online_renderer,
+        chat_template=CHAT_TEMPLATE,
+        chat_template_content_format="auto",
+        request_logger=None,
+        enable_auto_tools=True,
+        tool_parser="hermes",
+    )
+
+    tokenizer = get_tokenizer(MODEL_NAME)
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "test"}],
+        stream=True,
+        tools=tools,
+        tool_choice="required",
+    )
+
+    truncated_tool_call_text = (
+        '<tool_call>\n{"name": "get_weather", "arguments": {"city'
+    )
+    all_token_ids = tokenizer.encode(truncated_tool_call_text, add_special_tokens=False)
+
+    steps: list[tuple[str, int]] = []
+    prev_decoded = ""
+    for i, tid in enumerate(all_token_ids):
+        decoded_so_far = tokenizer.decode(all_token_ids[: i + 1])
+        steps.append((decoded_so_far[len(prev_decoded) :], tid))
+        prev_decoded = decoded_so_far
+
+    async def result_generator():
+        for delta_text, token_id in steps:
+            yield RequestOutput(
+                request_id="test-req",
+                prompt="test",
+                prompt_token_ids=[1, 2, 3],
+                prompt_logprobs=None,
+                outputs=[
+                    CompletionOutput(
+                        index=0,
+                        text=delta_text,
+                        token_ids=[token_id],
+                        cumulative_logprob=0.0,
+                        logprobs=None,
+                    )
+                ],
+                finished=False,
+            )
+        yield RequestOutput(
+            request_id="test-req",
+            prompt="test",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text="",
+                    token_ids=[],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                    finish_reason="length",
+                )
+            ],
+            finished=True,
+        )
+
+    finish_reasons: list[str] = []
+    async for chunk_str in serving_chat.chat_completion_stream_generator(
+        request=request,
+        result_generator=result_generator(),
+        request_id="test-req",
+        model_name=MODEL_NAME,
+        conversation=[],
+        tokenizer=tokenizer,
+        request_metadata=RequestResponseMetadata(
+            request_id="test-req",
+            model_name=MODEL_NAME,
+        ),
+    ):
+        if not chunk_str.strip() or "data: [DONE]" in chunk_str:
+            continue
+        if chunk_str.startswith("data: "):
+            data = json.loads(chunk_str[6:].strip())
+            for choice in data.get("choices", []):
+                if choice.get("finish_reason") is not None:
+                    finish_reasons.append(choice["finish_reason"])
+
+    assert finish_reasons == ["length"], (
+        f"Truncated tool call must report finish_reason='length', got {finish_reasons}"
+    )

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -691,7 +691,11 @@ class OpenAIServingChat(GenerateBaseServing):
                         # finish_reason is:
                         # "tool_calls" for "auto" or "required" tool calls,
                         # and "stop" for named tool calls.
-                        if tools_streamed[i] and not tool_choice_function_name:
+                        if (
+                            tools_streamed[i]
+                            and not tool_choice_function_name
+                            and output.finish_reason == "stop"
+                        ):
                             finish_reason_ = "tool_calls"
                         else:
                             finish_reason_ = (

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -713,7 +713,11 @@ class OpenAIServingChat(GenerateBaseServing):
                         # finish_reason is:
                         # "tool_calls" for "auto" or "required" tool calls,
                         # and "stop" for named tool calls.
-                        if tools_streamed[i] and not tool_choice_function_name:
+                        if (
+                            tools_streamed[i]
+                            and not tool_choice_function_name
+                            and output.finish_reason == "stop"
+                        ):
                             finish_reason_ = "tool_calls"
                         else:
                             finish_reason_ = (


### PR DESCRIPTION
## Purpose

Fixes the `finish_reason` half of #47903: when a tool call is cut off by `max_tokens`,
the streaming path reported `finish_reason="tool_calls"` while the non-streaming path
correctly reported `"length"`. Clients rely on `finish_reason` to decide whether a tool
call is complete and executable, so streaming was misreporting truncated calls as complete.

Root cause: `chat_completion/serving.py` set `finish_reason_="tool_calls"` whenever any
tool-call delta had been streamed (`tools_streamed[i]`), ignoring the actual finish
reason. This PR gates the override on `output.finish_reason == "stop"`, mirroring the
existing non-streaming logic (`is_finish_reason_tool_calls`, same file ~L958) and
matching OpenAI API behavior (truncated generations report `length`).

Scope note: the other half of #47903 (raw `<tool_call>` markup leaking into
non-streaming `content`) overlaps with #47137 / PR #47562 and is deliberately not
touched here.

Known edge: a stream that contains a *complete* tool call followed by extra generation
that then hits `max_tokens` will now report `"length"` rather than `"tool_calls"`. The
serving layer does not track parser completeness, and `"length"` is the engine's true
stop reason in that case; happy to adjust if maintainers prefer different semantics.

## Test Plan

New regression test `test_streaming_truncated_tool_call_reports_length_finish_reason`
in `tests/entrypoints/openai/chat_completion/test_serving_chat.py` — mock-engine unit
test (no GPU) that streams a hermes tool call truncated mid-arguments with
`finish_reason="length"` and asserts the SSE stream reports `length`. Fails before the
fix, passes after.

```
$ python -m pytest tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_streaming_truncated_tool_call_reports_length_finish_reason -v
tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_streaming_truncated_tool_call_reports_length_finish_reason PASSED [100%]
======================== 1 passed, 16 warnings in 3.18s ========================
```

Full mock suite in the file:

```
$ python -m pytest tests/entrypoints/openai/chat_completion/test_serving_chat.py -q -k "not gpt_oss"
33 passed, 11 deselected, 70 warnings in 33.12s
```

`pre-commit run --files vllm/entrypoints/openai/chat_completion/serving.py tests/entrypoints/openai/chat_completion/test_serving_chat.py` (ruff, mypy, SPDX) passes on both changed files.

## Disclosure

This change was developed with AI assistance (Claude Code). I have reviewed every
changed line, run the tests locally, and can speak to the change end-to-end. Not a
duplicate: no open PR addresses the streaming `finish_reason` override (checked
`gh pr list --search "47903 in:body"`); #47562 covers only the non-streaming content leak.
