### PR TITLE
[Draft] Investigate silent EngineCore hang in multimodal cache eviction

### DIFF
--- a/tests/multimodal/test_cache.py
+++ b/tests/multimodal/test_cache.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import multiprocessing as mp
+import threading
+import time
 
 import numpy as np
 import pytest
@@ -591,3 +593,57 @@ def test_sleep_wake_preserves_mm_cache_consistency():
     llm.wake_up()
     output2 = llm.generate([prompt], sampling_params)
     assert output2[0].outputs[0].text
+
+
+def test_receiver_cache_thread_safe_under_concurrent_clear():
+    """Adds from EngineCore's input socket thread can race
+    `reset_mm_cache` on the busy loop thread; unsynchronized access
+    corrupted the LRU bookkeeping and livelocked the eviction loop
+    (vllm-project/vllm#47958).
+    """
+    model_config = ModelConfig(
+        model="llava-hf/llava-onevision-qwen2-0.5b-ov-hf",
+        mm_processor_cache_gb=32 / GiB_bytes,
+    )
+    receiver_cache = MultiModalReceiverCache(model_config)
+
+    errors: list[Exception] = []
+    stop = threading.Event()
+
+    def add_items() -> None:
+        i = 0
+        while not stop.is_set():
+            mm_hash = f"image_{i % 16}"
+            try:
+                receiver_cache.get_and_update_item(
+                    MultiModalKwargsItem.dummy(5), mm_hash
+                )
+            except Exception as e:  # noqa: BLE001
+                errors.append(e)
+                break
+            i += 1
+
+    def clear_cache() -> None:
+        while not stop.is_set():
+            try:
+                receiver_cache.clear_cache()
+            except Exception as e:  # noqa: BLE001
+                errors.append(e)
+                break
+
+    threads = [
+        threading.Thread(target=add_items, daemon=True),
+        threading.Thread(target=add_items, daemon=True),
+        threading.Thread(target=clear_cache, daemon=True),
+    ]
+    for t in threads:
+        t.start()
+    time.sleep(0.5)
+    stop.set()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert not errors, f"concurrent cache access raised: {errors[0]!r}"
+    assert all(not t.is_alive() for t in threads), (
+        "cache operation livelocked (vllm-project/vllm#47958)"
+    )

--- a/tests/utils_/test_cache.py
+++ b/tests/utils_/test_cache.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import threading
+
 from vllm.utils.cache import CacheInfo, LRUCache
 
 
@@ -123,3 +125,61 @@ def test_lru_cache():
     assert 2 in cache
     assert 4 in cache
     assert 6 in cache
+
+
+def _desync_order_from_data(cache: LRUCache, key) -> None:
+    """Remove *key* from the data/size bookkeeping but leave it in the
+    order dict — the torn state unsynchronized concurrent mutation can
+    produce (see vllm-project/vllm#47958)."""
+    del cache._Cache__data[key]  # type: ignore[attr-defined]
+    cache._Cache__currsize -= (  # type: ignore[attr-defined]
+        cache._Cache__size.pop(key)  # type: ignore[attr-defined]
+    )
+
+
+def test_popitem_skips_stale_order_entry():
+    """A stale order entry must be dropped, not silently no-op popped.
+
+    pop() returns the default when the key is missing from the data
+    dict, so a stale order entry made popitem() remove nothing; the
+    eviction loop in cachetools' Cache.__setitem__ then spun forever
+    (vllm-project/vllm#47958).
+    """
+    cache = LRUCache(10, getsizeof=len)
+    cache.put("a", "xxxx")
+    cache.put("b", "yyyy")
+    _desync_order_from_data(cache, "a")
+
+    key, value = cache.popitem()
+
+    assert (key, value) == ("b", "yyyy")
+    assert "a" not in cache.order
+    assert len(cache) == 0
+
+
+def test_eviction_terminates_with_stale_order_entry():
+    """Inserting past capacity must terminate despite a stale order
+    entry (regression test for the vllm-project/vllm#47958 livelock)."""
+    cache = LRUCache(10, getsizeof=len)
+    cache.put("a", "xxxx")
+    cache.put("b", "yyyy")
+    _desync_order_from_data(cache, "a")
+
+    # currsize is 4 ("b"); size 8 forces the eviction loop, which must
+    # heal the stale "a" entry and evict "b" instead of spinning.
+    # Run in a worker thread so a regression fails fast instead of
+    # hanging the test session.
+    done = threading.Event()
+
+    def insert() -> None:
+        cache.put("c", "z" * 8)
+        done.set()
+
+    threading.Thread(target=insert, daemon=True).start()
+    assert done.wait(timeout=10), (
+        "eviction loop livelocked on a stale order entry (vllm-project/vllm#47958)"
+    )
+
+    assert set(cache.cache) == {"c"}
+    assert set(cache.order) == {"c"}
+    assert cache.currsize == 8

--- a/vllm/multimodal/cache.py
+++ b/vllm/multimodal/cache.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import operator
 import sys
+import threading
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from multiprocessing.synchronize import Lock as LockType
@@ -647,6 +648,10 @@ class MultiModalReceiverCache(BaseMultiModalReceiverCache):
             mm_config.mm_processor_cache_gb,
             MultiModalKwargsItem,
         )
+        # EngineCore mutates this cache from the input socket thread
+        # (`preprocess_add_request`) while `reset_mm_cache` runs on the
+        # busy loop thread; LRUCache is not thread-safe (#47958).
+        self._lock = threading.Lock()
 
     @override
     def get_and_update_item(
@@ -654,13 +659,14 @@ class MultiModalReceiverCache(BaseMultiModalReceiverCache):
         mm_item: MultiModalKwargsItem | None,
         mm_hash: str,
     ) -> MultiModalKwargsItem:
-        if (cached_item := self._cache.get(mm_hash)) is not None:
-            return cached_item
+        with self._lock:
+            if (cached_item := self._cache.get(mm_hash)) is not None:
+                return cached_item
 
-        assert mm_item is not None, f"Expected a cached item for {mm_hash=}"
+            assert mm_item is not None, f"Expected a cached item for {mm_hash=}"
 
-        self._cache[mm_hash] = mm_item
-        return mm_item
+            self._cache[mm_hash] = mm_item
+            return mm_item
 
     @override
     def touch_receiver_cache_item(
@@ -668,11 +674,13 @@ class MultiModalReceiverCache(BaseMultiModalReceiverCache):
         mm_hash: str,
         mm_item: MultiModalKwargsItem | None = None,
     ) -> None:
-        self._cache.touch(mm_hash)
+        with self._lock:
+            self._cache.touch(mm_hash)
 
     @override
     def clear_cache(self) -> None:
-        self._cache.clear()
+        with self._lock:
+            self._cache.clear()
 
 
 class ShmObjectStoreReceiverCache(BaseMultiModalReceiverCache):

--- a/vllm/utils/cache.py
+++ b/vllm/utils/cache.py
@@ -7,6 +7,10 @@ from typing import NamedTuple, TypeVar, cast, overload
 
 import cachetools
 
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
 _K = TypeVar("_K", bound=Hashable)
 _V = TypeVar("_V")
 _T = TypeVar("_T")
@@ -188,18 +192,35 @@ class LRUCache(cachetools.LRUCache[_K, _V]):
 
     def popitem(self, remove_pinned: bool = False):
         """Remove and return the `(key, value)` pair least recently used."""
-        if not remove_pinned:
-            # pop the oldest item in the cache that is not pinned
-            lru_key = next(
-                (key for key in self.order if key not in self.pinned_items),
-                ALL_PINNED_SENTINEL,
-            )
-            if lru_key is ALL_PINNED_SENTINEL:
-                raise RuntimeError(
-                    "All items are pinned, cannot remove oldest from the cache."
+        while True:
+            if not remove_pinned:
+                # pop the oldest item in the cache that is not pinned
+                lru_key = next(
+                    (key for key in self.order if key not in self.pinned_items),
+                    ALL_PINNED_SENTINEL,
                 )
-        else:
-            lru_key = next(iter(self.order))
+                if lru_key is ALL_PINNED_SENTINEL:
+                    raise RuntimeError(
+                        "All items are pinned, cannot remove oldest from the cache."
+                    )
+            else:
+                lru_key = next(iter(self.order))
+            if lru_key in self:
+                break
+            # A stale order entry (in the order dict but not in the data
+            # dict) makes pop() a silent no-op, which would turn
+            # cachetools' eviction loop in Cache.__setitem__ into an
+            # infinite spin because currsize never decreases. Such
+            # entries should not exist, but unsynchronized concurrent
+            # access can produce them; drop the stale entry and pick
+            # the next candidate instead of hanging.
+            logger.warning(
+                "LRUCache order/data desync detected for key %s; "
+                "dropping the stale order entry. This indicates the "
+                "cache was mutated concurrently without a lock.",
+                lru_key,
+            )
+            del self._LRUCache__order[lru_key]  # type: ignore
         value = self.pop(cast(_K, lru_key))
         return (lru_key, value)
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Investigation status:** this PR is now a draft. A maintainer correctly
> pointed out that `MultiModalReceiverCache` is single-thread-owned during
> normal serving. The concurrent-clear reproduction proves an unsupported
> reset/add interleaving can corrupt the cache, but it does **not** establish
> the root cause of #47958. I have asked the reporter whether any reset,
> pause/sleep, or utility path ran and for the installed `cachetools` version.
> The receiver-lock change will be removed. If a supported-path reproduction
> cannot be established, this PR will be closed rather than presented as a
> production fix.

## Purpose

Fixes #47958: after days under multimodal load, EngineCore's input socket
thread hangs forever inside `LRUCache.popitem` with no exception; new requests
never reach the scheduler, GPU goes idle, `/health` stays 200.

Root cause, confirmed by deterministic CPU-only reproduction:

1. `MultiModalReceiverCache` is mutated from two threads with no
   synchronization — the input socket thread (`preprocess_add_request` →
   `get_and_update_features`) and the busy loop thread (`reset_mm_cache` →
   `clear_cache`). vLLM's `LRUCache` is not thread-safe.
2. Torn interleavings desync cachetools' bookkeeping: a key can remain in the
   LRU order dict while missing from the data dict. A 3-thread stress on a
   bare `LRUCache` produces this (and `KeyError` escapes from `get()`) within
   ~0.5s; under production load the window is tiny, matching "hangs after
   days".
3. Once desynced, any insert that triggers eviction livelocks: cachetools'
   `Cache.__setitem__` loops `while currsize + size > maxsize: popitem()`,
   `popitem()` selects the stale key, and `LRUCache.pop()` silently returns
   the default for a key missing from the data dict — nothing is removed and
   `currsize` never drops. This matches the reporter's py-spy stack exactly
   (`popitem` → cachetools `__setitem__` → `get_and_update_item` →
   `preprocess_add_request`).

## Changes

- `vllm/multimodal/cache.py`: guard `MultiModalReceiverCache.get_and_update_item`
  / `touch_receiver_cache_item` / `clear_cache` with a `threading.Lock`
  (`ShmObjectStoreReceiverCache` already takes a lock for the same reason).
- `vllm/utils/cache.py`: `LRUCache.popitem()` now drops stale order entries
  with a warning instead of silently popping nothing, so any future
  bookkeeping desync degrades loudly instead of livelocking the engine. No
  behavior change when the cache is consistent.

## Test Plan

New regression tests (all CPU-only):

- `tests/utils_/test_cache.py::test_popitem_skips_stale_order_entry` — a
  manufactured stale order entry is healed; `popitem` returns the real LRU
  entry. Fails before the fix (returns `("a", None)` silently).
- `tests/utils_/test_cache.py::test_eviction_terminates_with_stale_order_entry`
  — an insert that triggers eviction over a desynced cache completes instead
  of spinning forever (bounded by a worker thread + timeout so a regression
  fails fast rather than hanging CI).
- `tests/multimodal/test_cache.py::test_receiver_cache_thread_safe_under_concurrent_clear`
  — 2 threads adding items race 1 thread clearing for 0.5s; asserts no
  exceptions escape and no thread livelocks.

```
$ python -m pytest tests/utils_/test_cache.py tests/multimodal/test_cache.py -q \
    --deselect tests/multimodal/test_cache.py::test_cache_eviction_shm_cache
12 passed, 1 skipped, 1 deselected in 11.22s
```

(`test_cache_eviction_shm_cache` is deselected because it fails on macOS on a
clean tree — shm name exceeds the platform limit — unrelated to this change.)

`pre-commit run --files <4 changed files>` (ruff, mypy, SPDX) passes.

## Disclosure

This change was developed with AI assistance (Claude Code). I have reviewed
every changed line, run the tests locally, and can speak to the change
end-to-end. Not a duplicate: no open PR references #47958 (checked
`gh pr list --search "47958 in:body"` before starting and again before
opening this PR).

