### PR TITLE
Add KVCrush KV Cache compression for vLLM

### DIFF
--- a/test_kvcrush.py
+++ b/test_kvcrush.py
@@ -1,0 +1,53 @@
+import torch
+import sys
+
+from vllm.v1.attention.backends.kvcrush import H2OKVCrushCluster
+
+# Create test tensors with specified shapes
+bsz = 1
+num_kv_heads = 8
+num_query_heads = 24
+seq_len = 50
+head_dim = 128
+
+key_states = torch.randn(bsz, num_kv_heads, seq_len, head_dim, dtype=torch.float16, device='cuda')
+query_states = torch.randn(bsz, num_query_heads, seq_len, head_dim, dtype=torch.float16, device='cuda')
+value_states = torch.randn(bsz, num_kv_heads, seq_len, head_dim, dtype=torch.float16, device='cuda')
+
+print("Input shapes:")
+print(f"key_states.shape: {key_states.shape}")
+print(f"query_states.shape: {query_states.shape}")
+print(f"value_states.shape: {value_states.shape}")
+print()
+
+# Initialize KVCrush
+window_size = 16
+max_capacity_prompt = 32
+kvcrush_ratio = 0.25
+page_size = 16  # vLLM block size
+
+kvcrush = H2OKVCrushCluster(
+    window_size=window_size,
+    max_capacity_prompt=max_capacity_prompt,
+    kvcrush_ratio=kvcrush_ratio
+)
+
+# Call update_kv
+print("\nCalling update_kv...")
+try:
+    compressed_key, compressed_value = kvcrush.update_kv(
+        key_states=key_states,
+        query_states=query_states,
+        value_states=value_states,
+        page_size=page_size
+    )
+
+    print("\nOutput shapes:")
+    print(f"compressed_key.shape: {compressed_key.shape}")
+    print(f"compressed_value.shape: {compressed_value.shape}")
+    print("\nTest passed!")
+
+except Exception as e:
+    print(f"\nTest failed with error: {e}")
+    import traceback
+    traceback.print_exc()

--- a/test_kvcrush_multi_request.py
+++ b/test_kvcrush_multi_request.py
@@ -1,0 +1,245 @@
+"""
+test_kvcrush_multi_request.py — Targeted test for KVCrush compression with
+multiple concurrent requests through the full vLLM pipeline.
+
+Exercises the KVCrush compression loop in flash_attn.py's forward() with:
+  - Multiple requests in a single batch (tests occupied_slot_mapping partitioning)
+  - Sequences long enough to trigger compression
+  - Mix of short (skip compression) and long (trigger compression) prompts
+  - Multiple decode steps after compression (verifies post-compression decode)
+
+Usage :
+    VLLM_V1_KVC_BUDGET=128 \
+    VLLM_V1_KVCRUSH_RATIO=0 \
+    VLLM_V1_KVCRUSH_START_SIZE=4 \
+    VLLM_V1_KVCRUSH_RECENT_SIZE=8 \
+    python test_kvcrush_multi_request.py
+
+    # Quick smoke test (2 requests, short):
+    VLLM_TARGET_DEVICE=xpu \
+    VLLM_V1_KVC_BUDGET=64 \
+    VLLM_V1_KVCRUSH_START_SIZE=4 \
+    VLLM_V1_KVCRUSH_RECENT_SIZE=8 \
+    python test_kvcrush_multi_request.py --scenario smoke
+
+    # All scenarios:
+    python test_kvcrush_multi_request.py --scenario all
+"""
+import argparse
+import os
+import sys
+import time
+
+# Set KVCrush env vars BEFORE importing vllm (they're read at import time)
+os.environ.setdefault("VLLM_V1_KVC_BUDGET", "128")
+os.environ.setdefault("VLLM_V1_KVCRUSH_RATIO", "0")
+os.environ.setdefault("VLLM_V1_KVCRUSH_START_SIZE", "4")
+os.environ.setdefault("VLLM_V1_KVCRUSH_RECENT_SIZE", "8")
+os.environ.setdefault("VLLM_V1_KVCRUSH_WINDOW_SIZE", "0")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Targeted KVCrush multi-request test")
+    p.add_argument("--model", type=str,
+                   default="meta-llama/Meta-Llama-3-8B-Instruct",
+                   help="Model to use (small model recommended)")
+    p.add_argument("--gpu-memory-utilization", type=float, default=0.8)
+    p.add_argument("--scenario", type=str, default="all",
+                   choices=["smoke", "multi_basic", "mixed_lengths",
+                            "concurrent_compress", "post_compress_decode",
+                            "all"],
+                   help="Which test scenario to run")
+    p.add_argument("--output-len", type=int, default=16,
+                   help="Decode tokens per request")
+    return p.parse_args()
+
+
+def build_prompt(tokenizer, target_len: int) -> str:
+    """Build a prompt that tokenizes to approximately target_len tokens."""
+    filler = "The quick brown fox jumps over the lazy dog. "
+    filler_tokens = len(tokenizer.encode(filler, add_special_tokens=False))
+    repeats = max(1, (target_len // filler_tokens) + 1)
+    long_text = filler * repeats
+    token_ids = tokenizer.encode(long_text,
+                                 add_special_tokens=False)[:target_len]
+    return tokenizer.decode(token_ids)
+
+
+def get_kvc_threshold() -> int:
+    """Minimum seq_len for compression to trigger."""
+    budget = int(os.environ.get("VLLM_V1_KVC_BUDGET", "128"))
+    start = int(os.environ.get("VLLM_V1_KVCRUSH_START_SIZE", "32"))
+    recent = int(os.environ.get("VLLM_V1_KVCRUSH_RECENT_SIZE", "128"))
+    return budget + start + recent
+
+
+def run_scenario(name, llm, tokenizer, prompts, output_len, expect_compress):
+    """Run a scenario and report results."""
+    from vllm import SamplingParams
+
+    sampling_params = SamplingParams(
+        temperature=0,
+        max_tokens=output_len,
+        ignore_eos=True,
+    )
+
+    print(f"\n{'='*60}")
+    print(f"Scenario: {name}")
+    print(f"{'='*60}")
+    print(f"  Requests: {len(prompts)}")
+    for i, p in enumerate(prompts):
+        prompt_len = len(tokenizer.encode(p))
+        print(f"  Prompt[{i}]: {prompt_len} tokens")
+    print(f"  Output tokens: {output_len}")
+    print(f"  Compression threshold: {get_kvc_threshold()} tokens")
+    print(f"  Expect compression: {expect_compress}")
+
+    t0 = time.perf_counter()
+    try:
+        outputs = llm.generate(prompts, sampling_params)
+        t1 = time.perf_counter()
+
+        print(f"  Time: {t1 - t0:.2f}s")
+        all_ok = True
+        for i, out in enumerate(outputs):
+            n_out = len(out.outputs[0].token_ids)
+            text_preview = out.outputs[0].text[:80].replace('\n', ' ')
+            status = "OK" if n_out > 0 else "FAIL"
+            if n_out == 0:
+                all_ok = False
+            print(f"  Output[{i}]: {n_out} tokens, status={status}, "
+                  f"text='{text_preview}...'")
+
+        if all_ok:
+            print(f"  RESULT: PASS")
+        else:
+            print(f"  RESULT: FAIL (some outputs empty)")
+        return all_ok
+
+    except Exception as e:
+        print(f"  RESULT: ERROR - {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def main():
+    args = parse_args()
+
+    budget = int(os.environ.get("VLLM_V1_KVC_BUDGET", "128"))
+    print(f"KVCrush config:")
+    print(f"  VLLM_V1_KVC_BUDGET={budget}")
+    print(f"  VLLM_V1_KVCRUSH_RATIO={os.environ.get('VLLM_V1_KVCRUSH_RATIO')}")
+    print(f"  VLLM_V1_KVCRUSH_START_SIZE="
+          f"{os.environ.get('VLLM_V1_KVCRUSH_START_SIZE')}")
+    print(f"  VLLM_V1_KVCRUSH_RECENT_SIZE="
+          f"{os.environ.get('VLLM_V1_KVCRUSH_RECENT_SIZE')}")
+    print(f"  Compression threshold: {get_kvc_threshold()} tokens")
+    print()
+
+    if budget == 0:
+        print("ERROR: VLLM_V1_KVC_BUDGET=0 — compression disabled. "
+              "Set it to e.g. 128.")
+        sys.exit(1)
+
+    from vllm import LLM
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+
+    # Initialize LLM once, reuse across scenarios
+    print(f"Loading model: {args.model}")
+    llm = LLM(
+        model=args.model,
+        enforce_eager=True,
+        enable_prefix_caching=False,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        # max_num_seqs=8,
+        disable_log_stats=False,
+    )
+    print("Model loaded.\n")
+
+    threshold = get_kvc_threshold()
+    # Prompts above threshold will trigger compression on first decode step
+    long_len = threshold + 64   # comfortably above threshold
+    short_len = threshold // 2  # below threshold, no compression
+
+    long_prompt = build_prompt(tokenizer, long_len)
+    short_prompt = build_prompt(tokenizer, short_len)
+
+    scenarios_to_run = []
+
+    if args.scenario in ("smoke", "all"):
+        # Scenario 1: Smoke test — 2 identical long requests
+        scenarios_to_run.append((
+            "smoke: 2 identical long requests",
+            [long_prompt, long_prompt],
+            args.output_len,
+            True,
+        ))
+
+    if args.scenario in ("multi_basic", "all"):
+        # Scenario 2: Multiple requests (4), all long enough to compress
+        scenarios_to_run.append((
+            "multi_basic: 4 long requests",
+            [long_prompt] * 4,
+            args.output_len,
+            True,
+        ))
+
+    if args.scenario in ("mixed_lengths", "all"):
+        # Scenario 3: Mix of short (no compress) and long (compress)
+        # Tests that occupied_slot_start tracking works when some
+        # requests skip and some compress
+        scenarios_to_run.append((
+            "mixed_lengths: short + long + short + long",
+            [short_prompt, long_prompt, short_prompt, long_prompt],
+            args.output_len,
+            True,  # long ones should compress
+        ))
+
+    if args.scenario in ("concurrent_compress", "all"):
+        # Scenario 4: Many concurrent requests, all compressible
+        # Stress test for the per-request compression loop
+        scenarios_to_run.append((
+            "concurrent_compress: 8 long requests",
+            [long_prompt] * 8,
+            args.output_len,
+            True,
+        ))
+
+    if args.scenario in ("post_compress_decode", "all"):
+        # Scenario 5: Long decode after compression
+        # Tests that decode steps after compression work correctly
+        # (compressed KV cache + relocated decode token)
+        scenarios_to_run.append((
+            "post_compress_decode: 2 long requests, 64 decode tokens",
+            [long_prompt, long_prompt],
+            64,  # override output_len for this scenario
+            True,
+        ))
+
+    # Run all selected scenarios
+    results = {}
+    for name, prompts, out_len, expect in scenarios_to_run:
+        ok = run_scenario(name, llm, tokenizer, prompts, out_len, expect)
+        results[name] = ok
+
+    # Summary
+    print(f"\n{'='*60}")
+    print("SUMMARY")
+    print(f"{'='*60}")
+    all_pass = True
+    for name, ok in results.items():
+        status = "PASS" if ok else "FAIL"
+        if not ok:
+            all_pass = False
+        print(f"  [{status}] {name}")
+
+    print(f"\nOverall: {'ALL PASSED' if all_pass else 'SOME FAILED'}")
+    sys.exit(0 if all_pass else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -248,6 +248,12 @@ if TYPE_CHECKING:
     VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: bool = False
     VLLM_NIXL_EP_MAX_NUM_RANKS: int = 32
     VLLM_XPU_ENABLE_XPU_GRAPH: bool = False
+    VLLM_V1_KVC_BUDGET: int = 64
+    VLLM_V1_KVCRUSH_START_SIZE: int = 32
+    VLLM_V1_KVCRUSH_WINDOW_SIZE: int = 8
+    VLLM_V1_KVCRUSH_RECENT_SIZE: int = 128
+    VLLM_V1_KVCRUSH_ANCHOR_MODE: str = "mean"
+    VLLM_V1_KVCRUSH_RATIO: float = 0.0
 
 
 def get_default_cache_root():
@@ -1648,6 +1654,23 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_XPU_ENABLE_XPU_GRAPH": lambda: bool(
         int(os.getenv("VLLM_XPU_ENABLE_XPU_GRAPH", "0"))
     ),
+    # Sets the total KV size budget (in number of tokens) used during compression.
+    # After compression the size of KVCache is start+budget+recent.
+    # The default value is 0.
+    "VLLM_V1_KVC_BUDGET":
+    lambda: int(os.getenv("VLLM_V1_KVC_BUDGET", "0")),
+
+    # Other KVCrush compression parameters
+    "VLLM_V1_KVCRUSH_START_SIZE":
+    lambda: int(os.getenv("VLLM_V1_KVCRUSH_START_SIZE", "32")),
+    "VLLM_V1_KVCRUSH_WINDOW_SIZE":
+    lambda: int(os.getenv("VLLM_V1_KVCRUSH_WINDOW_SIZE", "8")),
+    "VLLM_V1_KVCRUSH_RECENT_SIZE":
+    lambda: int(os.getenv("VLLM_V1_KVCRUSH_RECENT_SIZE", "128")),
+    "VLLM_V1_KVCRUSH_ANCHOR_MODE":
+    lambda: os.getenv("VLLM_V1_KVCRUSH_ANCHOR_MODE", "mean"),
+    "VLLM_V1_KVCRUSH_RATIO":
+    lambda: float(os.getenv("VLLM_V1_KVCRUSH_RATIO", "0.0")),
 }
 
 

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -347,6 +347,12 @@ class CommonAttentionMetadata:
 
     block_table_tensor: torch.Tensor
     slot_mapping: torch.Tensor
+    occupied_slot_mapping: torch.Tensor | None = None
+    """KVCrush: physical cache slots still live after compression (None when inactive)"""
+    total_num_kv_cache_tokens: int = 0
+    """Total number of kv cache tokens in batch (num_computed - num_dropped)"""
+    req_ids: list[str] | None = None
+    """List of request IDs in the batch"""
 
     causal: bool = True
 
@@ -400,7 +406,7 @@ class CommonAttentionMetadata:
     @deprecated(
         """
     Prefer using device seq_lens directly to avoid implicit H<>D sync which breaks full
-    async scheduling. If a CPU copy is needed, it can be derived from 
+    async scheduling. If a CPU copy is needed, it can be derived from
     query_start_loc_cpu and seq_lens.
     Will be removed in a future release, please migrate as soon as possible.
     """

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -9,6 +9,7 @@ from typing import ClassVar
 import numpy as np
 import torch
 
+from vllm import _custom_ops as ops
 from vllm.model_executor.layers.attention import Attention
 from vllm.v1.attention.backend import (
     AttentionBackend,
@@ -42,6 +43,9 @@ from vllm.config import (
 )
 from vllm.config.cache import CacheDType
 from vllm.distributed.parallel_state import get_dcp_group
+from vllm.envs import (VLLM_V1_KVC_BUDGET, VLLM_V1_KVCRUSH_START_SIZE, VLLM_V1_KVCRUSH_WINDOW_SIZE,
+                       VLLM_V1_KVCRUSH_RECENT_SIZE, VLLM_V1_KVCRUSH_ANCHOR_MODE,
+                       VLLM_V1_KVCRUSH_RATIO)
 from vllm.logger import init_logger
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils.math_utils import cdiv, round_up
@@ -213,6 +217,9 @@ class FlashAttentionMetadata:
     seq_lens: torch.Tensor
     block_table: torch.Tensor
     slot_mapping: torch.Tensor
+    num_reqs: int
+    num_dropped_tokens_list: list[int]
+    occupied_slot_mapping: torch.Tensor | None
 
     # For cascade attention.
     use_cascade: bool
@@ -229,6 +236,7 @@ class FlashAttentionMetadata:
     scheduler_metadata: torch.Tensor | None = None
     prefix_scheduler_metadata: torch.Tensor | None = None
     max_num_splits: int = 0
+    req_ids: list[str] | None = None
 
     causal: bool = True
 
@@ -363,10 +371,12 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         max_query_len = common_attn_metadata.max_query_len
         max_seq_len = common_attn_metadata.max_seq_len
+        total_num_kv_cache_tokens = common_attn_metadata.total_num_kv_cache_tokens
         query_start_loc = common_attn_metadata.query_start_loc
         seq_lens = common_attn_metadata.seq_lens
         block_table_tensor = common_attn_metadata.block_table_tensor
         slot_mapping = common_attn_metadata.slot_mapping
+        occupied_slot_mapping = common_attn_metadata.occupied_slot_mapping
         causal = common_attn_metadata.causal
 
         # the overhead of the aot schedule is not worth it for spec-decode
@@ -512,6 +522,16 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
             self.scheduler_metadata[n:] = 0
             scheduler_metadata = self.scheduler_metadata[:n]
 
+        max_num_splits = 0
+        if (self.use_full_cuda_graph
+                and num_actual_tokens <= self.max_cudagraph_size):
+            # NOTE(woosuk): Setting num_splits > 1 may increase the memory
+            # usage, because the intermediate buffers of size [num_splits,
+            # num_heads, num_tokens, head_size] are allocated. Therefore,
+            # we only set num_splits when using cuda graphs.
+            max_num_splits = self.max_num_splits
+        num_dropped_tokens_list = [0] * num_reqs
+
         attn_metadata = FlashAttentionMetadata(
             num_actual_tokens=num_actual_tokens,
             max_query_len=max_query_len,
@@ -530,8 +550,11 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
             suffix_kv_lens=suffix_kv_lens,
             prefix_scheduler_metadata=prefix_scheduler_metadata,
             max_num_splits=max_num_splits,
-            causal=causal,
-        )
+            num_reqs=num_reqs,
+            num_dropped_tokens_list=num_dropped_tokens_list,
+            occupied_slot_mapping=occupied_slot_mapping,
+            req_ids=common_attn_metadata.req_ids,
+            causal=causal)
         return attn_metadata
 
     def update_block_table(
@@ -551,6 +574,8 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
 
 class FlashAttentionImpl(AttentionImpl):
     can_return_lse_for_decode: bool = True
+    # Class-level counter to track layer indices
+    _layer_counter: int = 0
 
     def __init__(
         self,
@@ -566,6 +591,10 @@ class FlashAttentionImpl(AttentionImpl):
         kv_sharing_target_layer_name: str | None = None,
         sinks: torch.Tensor | None = None,
     ) -> None:
+        # Assign and increment layer index
+        self.layer_idx = FlashAttentionImpl._layer_counter
+        FlashAttentionImpl._layer_counter += 1
+
         self.num_heads = num_heads
         self.head_size = head_size
         self.scale = float(scale)
@@ -605,6 +634,41 @@ class FlashAttentionImpl(AttentionImpl):
             raise NotImplementedError(
                 "FlashAttention does not support fp8 kv-cache on this device."
             )
+
+        # Initialize KVCrush compressor and prefill query storage per layer.
+        # KVCrush is only supported in eager mode (--enforce-eager)
+        vllm_cfg = get_current_vllm_config_or_none()
+        is_eager = (vllm_cfg is not None
+                    and vllm_cfg.model_config.enforce_eager)
+        if VLLM_V1_KVC_BUDGET > 0 and is_eager:
+            from vllm.v1.attention.backends.kvcrush import H2OKVCrushCluster
+            logger.info(
+                "Layer %d: Initializing H2OKVCrushCluster with "
+                "max_capacity_prompt=%d, start_size=%d, window_size=%d, "
+                "recent_size=%d, anchor_mode=%s, kvcrush_ratio=%s",
+                self.layer_idx, VLLM_V1_KVC_BUDGET,
+                VLLM_V1_KVCRUSH_START_SIZE, VLLM_V1_KVCRUSH_WINDOW_SIZE,
+                VLLM_V1_KVCRUSH_RECENT_SIZE, VLLM_V1_KVCRUSH_ANCHOR_MODE,
+                VLLM_V1_KVCRUSH_RATIO)
+            self.h2O_kvcrushcompressor = H2OKVCrushCluster(
+                max_capacity_prompt=VLLM_V1_KVC_BUDGET,
+                start_size=VLLM_V1_KVCRUSH_START_SIZE,
+                window_size=VLLM_V1_KVCRUSH_WINDOW_SIZE,
+                recent_size=VLLM_V1_KVCRUSH_RECENT_SIZE,
+                anchor_mode=VLLM_V1_KVCRUSH_ANCHOR_MODE,
+                kvcrush_ratio=VLLM_V1_KVCRUSH_RATIO
+            )
+            # Store prefill queries for compression
+            # (key: request_id, value: list of query tensor chunks)
+            self.prefill_queries: dict[str, list[torch.Tensor]] = {}
+        else:
+            if VLLM_V1_KVC_BUDGET > 0 and not is_eager:
+                logger.warning_once(
+                    "KVCrush requires --enforce-eager. Disabling KVCrush "
+                    "compression because CUDA graphs are enabled.",
+                    scope="local")
+            self.h2O_kvcrushcompressor = None
+            self.prefill_queries = {}
 
         self.sinks = sinks
         if self.sinks is not None:
@@ -696,6 +760,13 @@ class FlashAttentionImpl(AttentionImpl):
         # For decoder and cross-attention, use KV cache as before
         key_cache, value_cache = kv_cache.unbind(0)
 
+        # Save float query for KVCrush scoring BEFORE fp8 quantization.
+        # In the fp8 path, `query` is reassigned to fp8 dtype below, so
+        # any clone taken after that block would be fp8 — incompatible with
+        # update_kv()'s torch.matmul.  We keep a float reference here and
+        # use it exclusively in the KVCrush accumulation/compression block.
+        query_float = query  # float16/bf16; still valid in "auto" path too
+
         if self.kv_cache_dtype.startswith("fp8"):
             # queries are quantized in the attention layer
             dtype = FlashAttentionBackend.get_fp8_dtype_for_flashattn(
@@ -731,7 +802,6 @@ class FlashAttentionImpl(AttentionImpl):
                     k_descale=k_descale,
                     v_descale=v_descale,
                 )
-                return output
             else:
                 sliding_window_size = (
                     list(self.sliding_window)
@@ -761,7 +831,186 @@ class FlashAttentionImpl(AttentionImpl):
                     num_splits=attn_metadata.max_num_splits,
                     s_aux=self.sinks,
                 )
-                return output
+            if VLLM_V1_KVC_BUDGET > 0 and self.dcp_world_size == 1 and self.h2O_kvcrushcompressor is not None:
+                # if attn_metadata.occupied_slot_mapping is None:
+                #     return output
+
+                if not self.prefill_queries and attn_metadata.max_query_len == 1:
+                    # print("No prefill queries stored, and max_query_len is 1, skipping KVCrush compression")
+                    return output
+
+                block_size = key_cache.size(1)  # block_size dimension
+
+                # Get request IDs from metadata
+                req_ids = attn_metadata.req_ids if hasattr(attn_metadata, 'req_ids') and attn_metadata.req_ids is not None else [str(i) for i in range(attn_metadata.num_reqs)]
+
+                # Batch GPU->CPU transfers to avoid per-request .item() syncs
+                query_start_locs = attn_metadata.query_start_loc[:attn_metadata.num_reqs + 1].tolist()
+                seq_lens_list = attn_metadata.seq_lens[:attn_metadata.num_reqs].tolist()
+
+                occupied_slot_start = 0
+                for i in range(attn_metadata.num_reqs):
+                    request_id = req_ids[i]
+                    query_start = query_start_locs[i]
+                    query_end = query_start_locs[i + 1]
+                    seq_len = seq_lens_list[i]
+
+                    num_kv_tokens = seq_len - (query_end - query_start)
+                    occupied_slot_end = occupied_slot_start + num_kv_tokens
+
+                    num_query_tokens = query_end - query_start
+
+                    # --- Prefill phase: accumulate queries ---
+                    if num_query_tokens != 1:
+                        # Multi-token chunk - still in prefill, accumulate
+                        if request_id in self.prefill_queries:
+                            self.prefill_queries[request_id].append(
+                                query_float[query_start:query_end].clone()
+                            )
+                        else:
+                            self.prefill_queries[request_id] = [
+                                query_float[query_start:query_end].clone()
+                            ]
+                        occupied_slot_start = occupied_slot_end
+                        continue
+
+                    if num_kv_tokens == 0:
+                        # Single-token prefill (first token of the sequence)
+                        self.prefill_queries[request_id] = [
+                            query_float[query_start:query_end].clone()
+                        ]
+                        occupied_slot_start = occupied_slot_end
+                        continue
+
+                    # --- Decode phase: single token with existing KV cache ---
+                    if seq_len < VLLM_V1_KVC_BUDGET + self.h2O_kvcrushcompressor.start_size + self.h2O_kvcrushcompressor.recent_size:
+                        self.prefill_queries.pop(request_id, None)
+                        occupied_slot_start = occupied_slot_end
+                        continue
+
+                    if request_id not in self.prefill_queries:
+                        # Already compressed
+                        occupied_slot_start = occupied_slot_end
+                        continue
+
+                    # First decode after prefill so should compress the KV cache for this request
+                    # Concatenate accumulated prefill query chunks
+                    chunks = self.prefill_queries[request_id]
+                    if len(chunks) > 1:
+                        current_query = torch.cat(chunks, dim=0)
+                    else:
+                        current_query = chunks[0]
+
+                    # Reshape for KVCrush: [seq_len, num_heads, head_dim]
+                    #   -> [batch=1, num_heads, seq_len, head_dim]
+                    current_query = current_query.transpose(0, 1).unsqueeze(0)
+
+                    req_occupied_slots = attn_metadata.occupied_slot_mapping[occupied_slot_start:occupied_slot_end]
+
+                    if req_occupied_slots.numel() == 0:
+                        # Clean up stale prefill_queries so they don't
+                        # persist and cause a length mismatch on future steps.
+                        self.prefill_queries.pop(request_id, None)
+                        occupied_slot_start = occupied_slot_end
+                        continue
+
+                    # Extract current KV cache for this request
+                    flat_key = key_cache.view(-1, key_cache.size(-2), key_cache.size(-1))
+                    flat_val = value_cache.view(-1, value_cache.size(-2), value_cache.size(-1))
+
+                    # When the KV cache is fp8-quantized, flat_key/flat_val contain
+                    # fp8 bytes (already viewed as fp8_dtype by the main forward path
+                    # above).  update_kv() calls torch.matmul on key_states, so it
+                    # requires float inputs — read the raw fp8 slots and dequantize
+                    # to the query dtype before passing them in.
+                    # For non-quantized caches ("auto") the tensors are already float
+                    # and no conversion is needed.
+                    is_fp8_kv = self.kv_cache_dtype.startswith("fp8")
+                    if is_fp8_kv:
+                        fp8_dtype = FlashAttentionBackend.get_fp8_dtype_for_flashattn(
+                            self.kv_cache_dtype)
+                        raw_key_slots = flat_key[req_occupied_slots]   # fp8_dtype
+                        raw_val_slots = flat_val[req_occupied_slots]   # fp8_dtype
+                        key_slots_f = torch.empty(raw_key_slots.shape,
+                                                  dtype=current_query.dtype,
+                                                  device=raw_key_slots.device)
+                        val_slots_f = torch.empty(raw_val_slots.shape,
+                                                  dtype=current_query.dtype,
+                                                  device=raw_val_slots.device)
+                        # dequantize: fp8 → float
+                        ops.convert_fp8(key_slots_f, raw_key_slots,
+                                        layer._k_scale.item())
+                        ops.convert_fp8(val_slots_f, raw_val_slots,
+                                        layer._v_scale.item())
+                        current_key_cache = key_slots_f.transpose(0, 1).unsqueeze(0)
+                        current_value_cache = val_slots_f.transpose(0, 1).unsqueeze(0)
+                    else:
+                        current_key_cache = flat_key[req_occupied_slots].transpose(0, 1).unsqueeze(0)
+                        current_value_cache = flat_val[req_occupied_slots].transpose(0, 1).unsqueeze(0)
+                    current_kv_len = current_key_cache.size(2)
+
+                    # Guard: accumulated prefill queries must match the KV
+                    # cache length.  A mismatch indicates stale prefill_queries
+                    # (e.g. left over from a req_occupied_slots.numel()==0 skip
+                    # or a chunked-prefill/async-scheduling edge case).  Clean
+                    # up and skip rather than crashing inside update_kv.
+                    if current_query.shape[2] != current_kv_len:
+                        del self.prefill_queries[request_id]
+                        occupied_slot_start = occupied_slot_end
+                        continue
+
+                    compressed_key_cache, compressed_value_cache = \
+                        self.h2O_kvcrushcompressor.update_kv(
+                            current_key_cache, current_query,
+                            current_value_cache, page_size=block_size
+                        )
+
+                    compressed_kv_len = compressed_key_cache.size(2)
+
+                    # Reshape back: [1, num_kv_heads, kv_len, head_dim]
+                    #            -> [kv_len, num_kv_heads, head_dim]
+                    compressed_key_cache = compressed_key_cache.squeeze(0).transpose(0, 1)
+                    compressed_value_cache = compressed_value_cache.squeeze(0).transpose(0, 1)
+
+                    if is_fp8_kv:
+                        # Re-quantize compressed float K/V back to fp8 before
+                        # writing into the paged cache buffer.
+                        # (output fp8, input float → quantize direction)
+                        ck_fp8 = torch.empty(compressed_key_cache.shape,
+                                             dtype=fp8_dtype,
+                                             device=compressed_key_cache.device)
+                        cv_fp8 = torch.empty(compressed_value_cache.shape,
+                                             dtype=fp8_dtype,
+                                             device=compressed_value_cache.device)
+                        ops.convert_fp8(ck_fp8, compressed_key_cache,
+                                        layer._k_scale.item())
+                        ops.convert_fp8(cv_fp8, compressed_value_cache,
+                                        layer._v_scale.item())
+                        flat_key[req_occupied_slots[:compressed_kv_len]] = ck_fp8
+                        flat_val[req_occupied_slots[:compressed_kv_len]] = cv_fp8
+                    else:
+                        flat_key[req_occupied_slots[:compressed_kv_len]] = compressed_key_cache
+                        flat_val[req_occupied_slots[:compressed_kv_len]] = compressed_value_cache
+
+                    # Track dropped tokens (only layer 0 writes to shared metadata)
+                    if self.layer_idx == 0:
+                        num_dropped_tokens_i = current_kv_len - compressed_kv_len
+                        attn_metadata.num_dropped_tokens_list[i] = num_dropped_tokens_i
+
+                    # Relocate the decode token from its old position
+                    # to immediately after the compressed cache
+                    if current_kv_len > compressed_kv_len:
+                        old_token_slot = attn_metadata.slot_mapping[query_start].item()
+                        new_token_slot = req_occupied_slots[compressed_kv_len].item()
+                        flat_key[new_token_slot] = flat_key[old_token_slot]
+                        flat_val[new_token_slot] = flat_val[old_token_slot]
+
+                    # Clean up stored prefill queries
+                    del self.prefill_queries[request_id]
+
+                    #Move to next request's occupied slots
+                    occupied_slot_start = occupied_slot_end
+            return output
 
         # Cascade attention (rare case).
         cascade_attention(

--- a/vllm/v1/attention/backends/kvcrush.py
+++ b/vllm/v1/attention/backends/kvcrush.py
@@ -1,0 +1,261 @@
+"""
+KVCrush cache eviction policy
+"""
+
+import torch, math
+from vllm.logger import init_logger
+logger = init_logger(__name__)
+
+class H2OKVCrushCluster:
+    def __init__(self, window_size = 16, recent_size = 128, max_capacity_prompt = 256 + 64, kvcrush_ratio=0.25, start_size=32, anchor_mode="alternate", block_size=16):
+        self.window_size = window_size
+        self.recent_size = recent_size
+        self.start_size = start_size
+        self.max_capacity_prompt = max_capacity_prompt
+        self.anchor_mode = anchor_mode
+        self.kvcrush_ratio = kvcrush_ratio
+        logger.info("H2O max_capacity_prompt %s", self.max_capacity_prompt)
+        self._cached_causal_mask = None
+        self._cached_causal_mask_size = 0
+
+        assert self.recent_size % block_size == 0, f"recent_size must be multiple of {block_size}"
+        assert self.start_size % block_size == 0, f"start_size must be multiple of {block_size}"
+        assert self.max_capacity_prompt % block_size == 0, f"max_capacity_prompt must be multiple of {block_size}"
+
+
+    def reset(self, window_size = 16, recent_size = 128, max_capacity_prompt = 256 + 64, start_size=0):
+        self.window_size = window_size
+        self.recent_size = recent_size
+        self.start_size = start_size
+        self.max_capacity_prompt = max_capacity_prompt
+        assert self.max_capacity_prompt - self.recent_size - self.start_size > 0
+
+    def _convert_group_indices(self, group_indices, seq_len, page_size, num_kv_heads):
+        """Convert group indices to token indices, following cache_processor.py pattern"""
+        num_groups = group_indices.shape[-1]
+        # Create indices tensor for a single group
+        idx = torch.arange(page_size, device=group_indices.device)
+        idx = idx.repeat(num_kv_heads * num_groups).view(num_kv_heads, num_groups, page_size)
+        expanded_mat = group_indices.unsqueeze(3)
+        expanded_mat = expanded_mat.repeat(1, 1, 1, page_size)
+
+        # Compute indices for each element in the input matrix
+        indices = expanded_mat * page_size + idx
+        indices = indices.view(1, num_kv_heads, num_groups * page_size)
+
+        # Drop extra indices from the last group that are empty
+        last_group_occupied = seq_len % page_size
+        if last_group_occupied:
+            padded = page_size - last_group_occupied
+            indices = indices[:, :, :-padded]
+
+        return indices
+
+    def update_kv(self, key_states, query_states, value_states, page_size):
+        # print("KVCrush update_kv called")
+        # kvcrush - parameters
+        seqlen = key_states.shape[-2]
+        heads = key_states.shape[1]
+        assert(page_size <= self.recent_size)
+
+        # print("key_states.shape:", key_states.shape)
+        # print("query_states.shape:", query_states.shape)
+        # print("value_states.shape:", value_states.shape)
+
+        # check if prefix phase
+        assert key_states.shape[-2] == query_states.shape[-2]
+        # Note: During decode, key_states has all cached tokens, query_states has only new tokens
+        bsz, num_heads, q_len, head_dim = query_states.shape
+        k_len = key_states.shape[-2]
+
+        # Save original key/value states (in GQA format)
+        key_states_original = key_states
+        value_states_original = value_states
+
+        # Expand temporarily for attention computation only
+        num_kv_heads = key_states.shape[1]
+        num_query_heads = query_states.shape[1]
+        num_query_heads_per_kv = num_query_heads // num_kv_heads
+
+        if num_query_heads_per_kv > 1:
+            key_states_expanded = key_states.unsqueeze(2).expand(
+                -1, -1, num_query_heads_per_kv, -1, -1
+            ).reshape(bsz, num_query_heads, k_len, head_dim)
+            value_states_expanded = value_states.unsqueeze(2).expand(
+                -1, -1, num_query_heads_per_kv, -1, -1
+            ).reshape(bsz, num_query_heads, k_len, head_dim)
+        else:
+            key_states_expanded = key_states
+            value_states_expanded = value_states
+
+        # Skip compression if sequences are empty or too short
+        if k_len == 0 or q_len == 0 or k_len < self.max_capacity_prompt:
+            return key_states_original, value_states_original
+        else:
+            attn_weights = torch.matmul(query_states[..., -self.window_size:, :], key_states_expanded.transpose(2, 3)) / math.sqrt(head_dim)
+            # Use cached causal mask to avoid re-creating every call
+            if self._cached_causal_mask is None or self._cached_causal_mask_size != self.window_size:
+                mask = torch.full((self.window_size, self.window_size), torch.finfo(attn_weights.dtype).min, device=attn_weights.device)
+                mask_cond = torch.arange(mask.size(-1), device=attn_weights.device)
+                mask.masked_fill_(mask_cond < (mask_cond + 1).view(mask.size(-1), 1), 0)
+                self._cached_causal_mask = mask
+                self._cached_causal_mask_size = self.window_size
+            attention_mask = self._cached_causal_mask[None, None, :, :]
+
+            attn_weights[:, :, -self.window_size:, -self.window_size:] += attention_mask
+
+            attn_weights = torch.nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+            attn_weights_sum = attn_weights.sum(dim = -2)
+
+            # Aggregate attention scores across query heads that share the same KV head
+            if num_query_heads_per_kv > 1:
+                # Reshape to [bsz, num_kv_heads, num_query_heads_per_kv, seq_len]
+                attn_cache_reshaped = attn_weights_sum.reshape(bsz, num_kv_heads, num_query_heads_per_kv, -1)
+                # Average across query heads that share the same KV head
+                attn_cache = attn_cache_reshaped.mean(dim=2)  # [bsz, num_kv_heads, seq_len]
+            else:
+                attn_cache = attn_weights_sum
+                #recalculate budget
+                # factor_ = 0.000001
+                # mean_ = torch.mean(attn_weights)
+                # while True:
+                #     threshold_ = factor_ * mean_
+                #     small_values_factor = torch.sum(attn_weights < threshold_).item() / attn_weights.numel()
+                #     if (small_values_factor >= .25) or (factor_ > 0.1):
+                #         break
+                #     factor_ = factor_ * 10
+                # budget_clus = int(self.max_capacity_prompt * min(self.kvcrush_ratio, small_values_factor))
+            budget_clus = int(self.max_capacity_prompt * self.kvcrush_ratio)
+            # print("KVC tokens:", budget_clus)
+            budget_impo = self.max_capacity_prompt - budget_clus
+
+            # Compute page/group scores from attention scores
+            intermediate_scores = attn_cache[:, :, self.start_size:]  # [bsz, num_kv_heads, intermediate_len]
+
+            # Pad to make it divisible by page_size
+            pad = intermediate_scores.shape[-1] % page_size
+
+            if pad:
+                intermediate_scores = torch.nn.functional.pad(intermediate_scores, (0, page_size - pad), mode='constant', value=0)
+
+            # intermediate_scores = intermediate_scores[:, :, :-self.recent_size]
+            # Reshape to groups and compute group scores by summing token scores within each group
+            group_scores = intermediate_scores.view(bsz, num_kv_heads, -1, page_size)
+            group_scores = group_scores.sum(dim=-1)  # [bsz, num_kv_heads, num_groups]
+
+            num_recent_groups = self.recent_size // page_size
+            group_scores = group_scores[:, :, :-num_recent_groups]  # Exclude recent groups
+
+            num_intermediate_groups = group_scores.shape[-1]
+            num_h2o_groups = budget_impo // page_size
+
+            # H2O selection: topk on page scores (keep as group indices)
+            h2o_group_indices = group_scores.topk(num_h2o_groups, dim=-1).indices  # [bsz, num_kv_heads, num_h2o_groups]
+            # Keep h2o_group_indices in intermediate coordinates for now
+
+            if (self.kvcrush_ratio > 0.0):
+                # print("Applying KVCrush clustering")
+                #kvcrush - parameters
+                # print("Start size:", self.start_size)
+                # print("Recent size:", self.recent_size)
+                # print("Window size:", self.window_size)
+                # print("Max capacity prompt:", self.max_capacity_prompt)
+                # print("Sequence length:", seqlen)
+                if budget_clus < page_size: #prevent edge case
+                    budget_clus = page_size
+                #kvcrush - rep
+
+                # Get intermediate scores and pad them first
+                normalized_scores = attn_cache[:, :, self.start_size:]
+                pad = normalized_scores.shape[-1] % page_size
+                if pad:
+                    normalized_scores = torch.nn.functional.pad(normalized_scores, (0, page_size - pad), mode='constant', value=0)
+
+                normalized_scores = normalized_scores[:, :, :-self.recent_size]
+
+                # Now form binary vector from padded scores
+                padded_len = normalized_scores.shape[-1]
+                indices_imp = normalized_scores.topk(int(padded_len/2), dim=-1).indices
+                binary_vector = torch.zeros((indices_imp.shape[0], indices_imp.shape[1], padded_len), dtype=int, device=h2o_group_indices.device)
+                binary_vector[0, torch.arange(indices_imp.shape[1]).unsqueeze(1), indices_imp] = 1
+                binary_vector = binary_vector.transpose(1, 2)[0]
+
+                nrows_new = binary_vector.shape[0]
+                binary_vector = binary_vector.reshape(int(nrows_new/page_size), num_kv_heads * page_size)
+
+                #kvcrush - weak clustering
+                anchor_random = torch.randint(0, 2, (1,binary_vector.shape[1]), device=h2o_group_indices.device)
+                mean_point = binary_vector.float().mean(dim=0)
+                anchor_invmean = (mean_point < 0.5).int()
+                anchor_mean = (mean_point > 0.5).int()
+                anchor_alt = torch.zeros_like(binary_vector[0])
+                anchor_alt[1::2] = 1
+                anchors = {
+                            "inv_mean": anchor_invmean,
+                            "mean": anchor_mean,
+                            "alternate": anchor_alt,
+                            "random": anchor_random
+                            }
+                dist_list = []
+                distances = torch.sum(binary_vector != anchors[self.anchor_mode], dim=1)
+                dist_list.append(distances)
+                # Filter out groups already selected by H2O before KVCrush clustering
+                # h2o_group_indices is already in intermediate coordinates [0, num_groups)
+                # h2o_selected_groups = h2o_group_indices[0, :, :].flatten().unique()
+                h2o_selected_groups = h2o_group_indices[0, 0, :]
+
+                # Create group indices for intermediate region [0, num_intermediate_groups)
+                all_group_idx = torch.arange(0, distances.numel(), 1, device=h2o_group_indices.device)
+                mask_clus_select = ~torch.isin(all_group_idx, h2o_selected_groups)
+                keep_clus_eligible = all_group_idx[mask_clus_select]
+
+                sorted_values, indices_ = torch.sort(distances)
+
+                sorted_dist_idx_select = torch.isin(indices_, keep_clus_eligible)
+                sorted_dist_idx = indices_[sorted_dist_idx_select]
+
+                # Only proceed with KVCrush if there are groups available (not all selected by H2O)
+                if sorted_dist_idx.numel() > 0:
+                    rep_indices = torch.linspace(0, sorted_dist_idx.numel() - 1, int(budget_clus / page_size), dtype=torch.long)
+                    # Keep as group indices (in intermediate coordinates)
+                    kvcrush_group_indices = sorted_dist_idx[rep_indices].unsqueeze(0).unsqueeze(0).expand(1, num_kv_heads, -1)
+                    # Concatenate H2O and KVCrush group indices
+                    keep_topk = torch.cat((h2o_group_indices, kvcrush_group_indices), dim=2)
+                    # print("Picked KVCrush")
+                else:
+                    logger.warning(
+                        "All intermediate groups already selected "
+                        "by H2O, skipping KVCrush clustering")
+                    keep_topk = h2o_group_indices
+            else:
+                # Only H2O groups
+                keep_topk = h2o_group_indices
+
+            # Sort and shift to full coordinate system (add num_past_groups offset)
+            num_past_groups = self.start_size // page_size
+            num_recent_groups = self.recent_size // page_size
+            keep_topk = keep_topk.sort(dim=-1).values + num_past_groups
+
+            # print(f"[KVCrush] keep_topk group indices (intermediate + KVCrush) after shifting: {keep_topk[0,0,:]}")
+            # Build full group index list: [past, intermediate (H2O+KVCrush), recent]
+            num_groups = num_past_groups + num_intermediate_groups + num_recent_groups
+            keep_past = torch.arange(0, num_past_groups, device=keep_topk.device).unsqueeze(0).unsqueeze(0).expand(1, num_kv_heads, -1)
+            keep_recent = torch.arange(num_groups - num_recent_groups, num_groups, device=keep_topk.device).unsqueeze(0).unsqueeze(0).expand(1, num_kv_heads, -1)
+            keep_group_idx = torch.cat([keep_past, keep_topk, keep_recent], dim=-1)
+
+            # Convert group indices to token indices
+            indices = self._convert_group_indices(keep_group_idx, seqlen, page_size, num_kv_heads)
+
+
+            #torch.set_printoptions(threshold=torch.inf)
+            # print("Indices before sorting:", indices)
+            # Sort indices to maintain sequential ordering of tokens
+            indices, _ = torch.sort(indices, dim=-1)
+
+            indices = indices.unsqueeze(-1).expand(-1, -1, -1, head_dim)
+            # print("After KVCrush, indices.shape:", indices.shape)
+            # Now gather from full key/value states (not just :-recent_size)
+            key_states = key_states_original.gather(dim=2, index=indices)
+            value_states = value_states_original.gather(dim=2, index=indices)
+
+            return key_states, value_states

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -354,6 +354,7 @@ def make_local_attention_virtual_batches(
         max_seq_len=max_seq_len,
         block_table_tensor=block_table_local,
         slot_mapping=common_attn_metadata.slot_mapping,
+        req_ids=common_attn_metadata.req_ids,
         causal=True,
         _seq_lens_cpu=seq_lens_cpu,
         _num_computed_tokens_cpu=torch.from_numpy(num_computed_tokens_local),

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -198,6 +198,18 @@ class KVCacheCoordinator(ABC):
         for manager in self.single_type_managers:
             manager.free(request_id)
 
+    def free_tail_blocks(self, request_id: str,
+                         effective_kv_len: int) -> None:
+        """
+        Free tail blocks that are no longer needed after KV cache compression.
+
+        Args:
+            request_id: The request ID.
+            effective_kv_len: The effective KV cache length after compression.
+        """
+        for manager in self.single_type_managers:
+            manager.free_tail_blocks(request_id, effective_kv_len)
+
     def get_num_common_prefix_blocks(self, running_request_id: str) -> list[int]:
         """
         Get the number of common prefix blocks for all requests with allocated

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -358,12 +358,12 @@ class KVCacheManager:
             num_local_computed_tokens + num_external_computed_tokens,
             self.max_model_len,
         )
-        num_tokens_main_model = total_computed_tokens + num_new_tokens
+        effective_computed_tokens = total_computed_tokens - request.num_dropped_tokens
+        num_tokens_main_model = effective_computed_tokens + num_new_tokens
         num_tokens_need_slot = min(
             num_tokens_main_model + num_lookahead_tokens,
             self.max_model_len,
         )
-
         # Free the blocks that are skipped during the attention computation
         # (e.g., tokens outside the sliding window).
         # We can do this even if we cannot schedule this request due to
@@ -413,6 +413,12 @@ class KVCacheManager:
         if not self.enable_caching or delay_cache_blocks:
             return self.create_kv_cache_blocks(new_blocks)
 
+        # Don't re-cache blocks for compressed requests - their KV data
+        # no longer matches token IDs, so hashes would be incorrect and
+        # future prefix cache hits would get corrupted data.
+        if request.num_dropped_tokens > 0:
+            return self.create_kv_cache_blocks(new_blocks)
+
         # NOTE(woosuk): We want to commit (cache) up to num_local_computed_tokens
         # + num_external_computed_tokens + num_new_tokens, but must exclude
         # "non-committable" tokens (e.g., draft tokens that could be rejected).
@@ -425,6 +431,16 @@ class KVCacheManager:
         self.coordinator.cache_blocks(request, num_tokens_to_cache)
 
         return self.create_kv_cache_blocks(new_blocks)
+
+    def free_tail_blocks(self, request_id: str,
+                         effective_kv_len: int) -> None:
+        """Free tail blocks and evict all prefix-cache hashes after compression.
+
+        Args:
+            request_id: The request ID.
+            effective_kv_len: The effective number of KV tokens after compression (num_computed_tokens - num_dropped_tokens).
+        """
+        self.coordinator.free_tail_blocks(request_id, effective_kv_len)
 
     def free(self, request: Request) -> None:
         """Free the blocks allocated for the request.
@@ -531,7 +547,7 @@ class KVCacheManager:
             num_computed_tokens: The number of computed tokens, including tokens
                 that are already cached and tokens to be cached.
         """
-        if self.enable_caching:
+        if self.enable_caching and request.num_dropped_tokens == 0:
             self.coordinator.cache_blocks(request, num_computed_tokens)
 
     def create_kv_cache_blocks(

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -122,7 +122,7 @@ class CachedRequestData:
     new_block_ids: list[tuple[list[int], ...] | None]
     num_computed_tokens: list[int]
     num_output_tokens: list[int]
-
+    num_dropped_tokens_list: list[int]
     # Version of dataclass repr with token IDs obfuscated.
     def anon_repr(self) -> str:
         new_token_ids_lens = [len(toks) for toks in self.new_token_ids]
@@ -137,12 +137,14 @@ class CachedRequestData:
             f"all_token_ids_lens={all_token_ids_lens},"
             f"new_block_ids={self.new_block_ids},"
             f"num_computed_tokens={self.num_computed_tokens},"
-            f"num_output_tokens={self.num_output_tokens}"
+            f"num_output_tokens={self.num_output_tokens}",
+            f"num_dropped_tokens_list={self.num_dropped_tokens_list}"
             f")"
         )
 
     def __repr__(self) -> str:
         return self.anon_repr()
+
 
     @property
     def num_reqs(self) -> int:
@@ -172,6 +174,7 @@ class CachedRequestData:
             new_block_ids=[],
             num_computed_tokens=[],
             num_output_tokens=[],
+            num_dropped_tokens_list=[],
         )
 
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -26,6 +26,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1 import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.envs import VLLM_V1_KVC_BUDGET
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
     RoutedExpertsReader,
@@ -168,6 +169,11 @@ class Scheduler(SchedulerInterface):
         self.skipped_waiting = create_request_queue(self.policy)
         self.running: list[Request] = []
 
+        # Batch size tracking (updated every schedule() call)
+        self.max_observed_batch_size: int = 0
+        self._batch_size_sum: int = 0
+        self._batch_size_count: int = 0
+
         # The request IDs that are finished in between the previous and the
         # current steps. This is used to notify the workers about the finished
         # requests so that they can free the cached states for those requests.
@@ -222,10 +228,22 @@ class Scheduler(SchedulerInterface):
                 self.num_lookahead_tokens = self.num_spec_tokens
 
         # Create the KV cache manager.
+        # Disable prefix caching when KVCrush compression is active.
+        # Compressed blocks contain shuffled/merged KV data that no longer
+        # matches token hashes, so prefix cache hits would return corrupt
+        # data. Also, cached prefill tokens skip query computation, leaving
+        # prefill_queries incomplete for KVCrush importance scoring.
+        enable_caching = self.cache_config.enable_prefix_caching
+        if VLLM_V1_KVC_BUDGET > 0 and enable_caching:
+            logger.info("KVCrush compression is active "
+                        "(VLLM_V1_KVC_BUDGET=%d). "
+                        "Disabling prefix caching to ensure correct "
+                        "compression.", VLLM_V1_KVC_BUDGET)
+            enable_caching = False
         self.kv_cache_manager = KVCacheManager(
             kv_cache_config=kv_cache_config,
             max_model_len=self.max_model_len,
-            enable_caching=self.cache_config.enable_prefix_caching,
+            enable_caching=enable_caching,
             use_eagle=self.use_eagle,
             log_stats=self.log_stats,
             enable_kv_cache_events=self.enable_kv_cache_events,
@@ -372,6 +390,13 @@ class Scheduler(SchedulerInterface):
         scheduled_timestamp = time.monotonic()
 
         self.kv_cache_manager.new_step_starts()
+
+        # Track running batch size at the start of this step.
+        _cur_batch = len(self.running)
+        if _cur_batch > self.max_observed_batch_size:
+            self.max_observed_batch_size = _cur_batch
+        self._batch_size_sum += _cur_batch
+        self._batch_size_count += 1
 
         # First, schedule the RUNNING requests.
         req_index = 0
@@ -959,6 +984,7 @@ class Scheduler(SchedulerInterface):
         self.encoder_cache_manager.free(request)
         request.status = RequestStatus.PREEMPTED
         request.num_computed_tokens = 0
+        request.num_dropped_tokens = 0
         if request.spec_token_ids:
             request.spec_token_ids = []
         request.num_preemptions += 1
@@ -1060,6 +1086,7 @@ class Scheduler(SchedulerInterface):
         num_computed_tokens: list[int] = []
         num_output_tokens: list[int] = []
         resumed_req_ids = set()
+        num_dropped_tokens_list: list[int] = []
 
         num_running_reqs = len(running_reqs)
         for idx, req in enumerate(itertools.chain(running_reqs, resumed_reqs)):
@@ -1091,6 +1118,7 @@ class Scheduler(SchedulerInterface):
                 req_to_new_blocks[req_id].get_block_ids(allow_none=True)
             )
             num_computed_tokens.append(req.num_computed_tokens)
+            num_dropped_tokens_list.append(req.num_dropped_tokens)
             num_output_tokens.append(
                 req.num_output_tokens + req.num_output_placeholders
             )
@@ -1103,6 +1131,7 @@ class Scheduler(SchedulerInterface):
             new_block_ids=new_block_ids,
             num_computed_tokens=num_computed_tokens,
             num_output_tokens=num_output_tokens,
+            num_dropped_tokens_list=num_dropped_tokens_list,
         )
 
     def _try_schedule_encoder_inputs(
@@ -1303,6 +1332,7 @@ class Scheduler(SchedulerInterface):
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
         pooler_outputs = model_runner_output.pooler_output
         num_nans_in_logits = model_runner_output.num_nans_in_logits
+        num_dropped_tokens_list = model_runner_output.num_dropped_tokens_list
         kv_connector_output = model_runner_output.kv_connector_output
         cudagraph_stats = model_runner_output.cudagraph_stats
 
@@ -1354,7 +1384,21 @@ class Scheduler(SchedulerInterface):
             req_index = model_runner_output.req_id_to_index[req_id]
             generated_token_ids = (
                 sampled_token_ids[req_index] if sampled_token_ids else []
+
             )
+            request.num_dropped_tokens += num_dropped_tokens_list[req_index]
+
+            # Free tail blocks after KV cache compression
+            if num_dropped_tokens_list[req_index] > 0:
+                free_before = self.kv_cache_manager.block_pool.get_num_free_blocks()
+                effective_kv_len = (request.num_computed_tokens
+                                    - request.num_dropped_tokens)
+                self.kv_cache_manager.free_tail_blocks(
+                    req_id, effective_kv_len)
+                free_after = self.kv_cache_manager.block_pool.get_num_free_blocks()
+                # print("Freed {} blocks for request {} after dropping {} tokens".format(
+                #     free_after - free_before, req_id, num_dropped_tokens_list[req_index]
+                # ))
 
             scheduled_spec_token_ids = (
                 scheduler_output.scheduled_spec_decode_tokens.get(req_id)
@@ -1469,7 +1513,6 @@ class Scheduler(SchedulerInterface):
             else:
                 # Invariant: EngineCore returns no partial prefill outputs.
                 assert not prompt_logprobs_tensors
-
         # Remove the stopped requests from the running and waiting queues.
         if stopped_running_reqs:
             self.running = remove_all(self.running, stopped_running_reqs)

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -290,6 +290,54 @@ class SingleTypeKVCacheManager(ABC):
         self.block_pool.free_blocks(ordered_blocks)
         self.num_cached_block.pop(request_id, None)
 
+    def free_tail_blocks(self, request_id: str,
+                         effective_kv_len: int) -> None:
+        """
+        Free tail blocks that are no longer needed after KV cache compression.
+
+        After compression, the effective KV cache length is shorter, so
+        blocks beyond the needed range can be returned to the free pool.
+        Also invalidates prefix cache hashes on remaining blocks since
+        compression changes their content.
+
+        Args:
+            request_id: The request ID.
+            effective_kv_len: The effective KV cache length after compression.
+        """
+        req_blocks = self.req_to_blocks.get(request_id)
+        if req_blocks is None:
+            return
+
+        needed_blocks = cdiv(effective_kv_len, self.block_size)
+        if needed_blocks >= len(req_blocks):
+            # No blocks to free
+            return
+
+        # Invalidate prefix cache hashes on ALL remaining blocks since
+        # compression reorders/changes their content. Without this,
+        # a future request could match stale hashes and get wrong data.
+        for blk in req_blocks[:needed_blocks]:
+            if blk.block_hash is not None:
+                self.block_pool._maybe_evict_cached_block(blk)
+
+        # Extract tail blocks to free
+        tail_blocks = req_blocks[needed_blocks:]
+        # Also evict hashes from tail blocks before freeing, otherwise
+        # they remain in cached_block_hash_to_block and a future request
+        # could hit them in the free queue with stale KV data.
+        for blk in tail_blocks:
+            if blk.block_hash is not None:
+                self.block_pool._maybe_evict_cached_block(blk)
+        # Free in reverse order (tail first)
+        self.block_pool.free_blocks(reversed(tail_blocks))
+        # Truncate the block list
+        del req_blocks[needed_blocks:]
+
+        # Reset cached block count to 0 since compression changed content.
+        # Setting to 0 (not popping) so cache_blocks doesn't KeyError.
+        if request_id in self.num_cached_block:
+            self.num_cached_block[request_id] = 0
+
     @abstractmethod
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         """

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -221,6 +221,9 @@ class ModelRunnerOutput:
     # req_id -> index
     req_id_to_index: dict[str, int]
 
+    # the number of tokens dropped due to kv cache compression for every request
+    num_dropped_tokens_list: list[int]
+    
     # num_reqs x num_generated_tokens
     # num_generated_tokens is the number of tokens
     # generated in the current step. It can be different for
@@ -252,6 +255,8 @@ class ModelRunnerOutput:
 
     # information related to cudagraph execution
     cudagraph_stats: CUDAGraphStat | None = None
+
+
 
 
 # ModelRunnerOutput wrapper for async scheduling.
@@ -302,7 +307,8 @@ def make_empty_encoder_model_runner_output(
         req_id_to_index=req_id_to_index,
         sampled_token_ids=sampled_token_ids,
         pooler_output=pooler_output,
+        num_dropped_tokens_list=[0] * len(req_ids),
     )
 
 
-EMPTY_MODEL_RUNNER_OUTPUT = ModelRunnerOutput(req_ids=[], req_id_to_index={})
+EMPTY_MODEL_RUNNER_OUTPUT = ModelRunnerOutput(req_ids=[], req_id_to_index={}, num_dropped_tokens_list=[])

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -134,6 +134,7 @@ class Request:
         self.spec_token_ids: list[int] = []
         self.num_computed_tokens = 0
         self.cache_salt: str | None = cache_salt
+        self.num_dropped_tokens = 0
 
         # Multi-modal related
         self.mm_features = mm_features or []

--- a/vllm/v1/worker/block_table.py
+++ b/vllm/v1/worker/block_table.py
@@ -99,6 +99,18 @@ class BlockTable:
             self.dcp_rank = 0
         self.cp_kv_cache_interleave_size = cp_kv_cache_interleave_size
 
+        # occupied_slot_mapping needs to accommodate all KV cache tokens,
+        # which can exceed max_num_batched_tokens (e.g., with compression like KVCrush)
+        max_kv_cache_tokens = max_num_reqs * max_num_blocks_per_req * block_size
+        self.occupied_slot_mapping_cpu = torch.zeros(max_kv_cache_tokens,
+                                                    dtype=torch.int64,
+                                                    device="cpu",
+                                                    pin_memory=self.pin_memory)
+        self.occupied_slot_mapping_np = self.occupied_slot_mapping_cpu.numpy()
+        self.occupied_slot_mapping = torch.zeros(max_kv_cache_tokens,
+                                                 dtype=torch.int64,
+                                                 device=self.device)
+
     def append_row(
         self,
         block_ids: list[int],
@@ -163,8 +175,64 @@ class BlockTable:
             BLOCK_SIZE=1024,
         )
 
+    def _compute_slot_mapping_numpy(
+        self, req_indices: np.ndarray, positions: np.ndarray,
+        is_occupied: bool) -> None:
+        # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
+        # -> [0, 0, K, K, K + 1, K + 1, K + 2, 2 * K, 2 * K, 2 * K + 1]
+        # where K is the max_num_blocks_per_req and the block size is 2.
+        # NOTE(woosuk): We can't simply use `token_indices // block_size`
+        # here because M (max_model_len) is not necessarily divisible by
+        # block_size.
+        total_cp_world_size = self.pcp_world_size * self.dcp_world_size
+        total_cp_rank = self.pcp_rank * self.dcp_world_size + self.dcp_rank
+        if total_cp_world_size > 1:
+            virtual_block_size = self.block_size * total_cp_world_size
+            block_table_indices = (
+                req_indices * self.max_num_blocks_per_req
+                + positions // virtual_block_size
+            )
+            block_numbers = self.block_table.np.ravel()[block_table_indices]
+            virtual_block_offsets = positions % virtual_block_size
+            mask = (
+                virtual_block_offsets
+                // self.cp_kv_cache_interleave_size
+                % total_cp_world_size
+                == total_cp_rank
+            )
+            block_offsets = (
+                virtual_block_offsets
+                // (total_cp_world_size * self.cp_kv_cache_interleave_size)
+                * self.cp_kv_cache_interleave_size
+                + virtual_block_offsets % self.cp_kv_cache_interleave_size
+            )
+            slot_mapping = block_numbers * self.block_size + block_offsets
+            self.slot_mapping.np[: req_indices.shape[0]] = np.where(
+                mask, slot_mapping, -1
+            )
+        else:
+            block_table_indices = (
+                req_indices * self.max_num_blocks_per_req + positions // self.block_size
+            )
+            block_numbers = self.block_table.np.ravel()[block_table_indices]
+            block_offsets = positions % self.block_size
+            out = self.slot_mapping.np
+            if is_occupied:
+                out = self.occupied_slot_mapping_np
+            np.add(
+                block_numbers * self.block_size,
+                block_offsets,
+                out=out[: positions.shape[0]],
+            )
+
     def commit_block_table(self, num_reqs: int) -> None:
         self.block_table.copy_to_gpu(num_reqs)
+
+    def commit_slot_mapping(self, total_num_scheduled_tokens: int, total_num_kv_cache_tokens: int) -> None:
+        self.slot_mapping.copy_to_gpu(total_num_scheduled_tokens)
+        if total_num_kv_cache_tokens > 0:
+            self.occupied_slot_mapping[:total_num_kv_cache_tokens].copy_(
+                self.occupied_slot_mapping_cpu[:total_num_kv_cache_tokens], non_blocking=True)
 
     def clear(self) -> None:
         self.block_table.gpu.fill_(0)
@@ -302,9 +370,19 @@ class MultiGroupBlockTable:
         for block_table in self.block_tables:
             block_table.compute_slot_mapping(num_reqs, query_start_loc, positions)
 
+    def _compute_slot_mapping_numpy(
+        self, req_indices: np.ndarray, positions: np.ndarray,
+        is_occupied: bool) -> None:
+        for block_table in self.block_tables:
+            block_table._compute_slot_mapping_numpy(req_indices, positions, is_occupied)
+
     def commit_block_table(self, num_reqs: int) -> None:
         for block_table in self.block_tables:
             block_table.commit_block_table(num_reqs)
+
+    def commit_slot_mapping(self, total_num_scheduled_tokens: int, total_num_kv_cache_tokens: int) -> None:
+        for block_table in self.block_tables:
+            block_table.commit_slot_mapping(total_num_scheduled_tokens, total_num_kv_cache_tokens)
 
     def clear(self) -> None:
         for block_table in self.block_tables:

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -148,6 +148,14 @@ class InputBatch:
             pin_memory=pin_memory,
         )
         self.num_computed_tokens_cpu = self.num_computed_tokens_cpu_tensor.numpy()
+        self.num_dropped_tokens_list_cpu_tensor = torch.zeros(
+             (max_num_reqs, ),
+             device="cpu",
+             dtype=torch.int32,
+             pin_memory=pin_memory,
+         )
+        self.num_dropped_tokens_list_cpu = \
+            self.num_dropped_tokens_list_cpu_tensor.numpy()
 
         # Block table.
         self.block_table = MultiGroupBlockTable(
@@ -351,6 +359,7 @@ class InputBatch:
         self.num_tokens_no_spec[req_index] = request.num_tokens
 
         self.num_computed_tokens_cpu[req_index] = request.num_computed_tokens
+        self.num_dropped_tokens_list_cpu[req_index] = 0
         self.block_table.add_row(request.block_ids, req_index)
 
         if sampling_params := request.sampling_params:
@@ -531,6 +540,8 @@ class InputBatch:
             # False means we don't fill with -inf.
             self.allowed_token_ids_mask_cpu_tensor[req_index].fill_(False)
         self.bad_words_token_ids.pop(req_index, None)
+        # Reset num_dropped_tokens to avoid stale data
+        self.num_dropped_tokens_list_cpu[req_index] = 0
         return req_index
 
     def swap_states(self, i1: int, i2: int) -> None:
@@ -568,6 +579,8 @@ class InputBatch:
             self.num_computed_tokens_cpu[i2],
             self.num_computed_tokens_cpu[i1],
         )
+        self.num_dropped_tokens_list_cpu[i1], self.num_dropped_tokens_list_cpu[i2] =\
+            self.num_dropped_tokens_list_cpu[i2], self.num_dropped_tokens_list_cpu[i1]
 
         # NOTE: the following is unsafe
         # self.token_ids_cpu[i1, ...], self.token_ids_cpu[i2, ...], =\
@@ -724,6 +737,8 @@ class InputBatch:
             self.num_computed_tokens_cpu[empty_index] = self.num_computed_tokens_cpu[
                 last_req_index
             ]
+            self.num_dropped_tokens_list_cpu[
+                empty_index] = self.num_dropped_tokens_list_cpu[last_req_index]
             self.block_table.move_row(last_req_index, empty_index)
 
             self.request_lora_mapping[empty_index] = self.request_lora_mapping[

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3,6 +3,7 @@
 
 import functools
 import gc
+import os
 import itertools
 import threading
 import time
@@ -759,6 +760,39 @@ class GPUModelRunner(
         self.query_pos = self._make_buffer(arange_size, dtype=torch.int64)
         self._arange_scratch = np.empty(arange_size, dtype=np.int64)
 
+        self.logical_positions_cpu = torch.zeros(self.max_num_tokens,
+                                         dtype=torch.int64,
+                                         device="cpu",
+                                         pin_memory=self.pin_memory)
+        self.logical_positions_np = self.logical_positions_cpu.numpy()
+        self.physical_positions_cpu = torch.zeros(self.max_num_tokens,
+                                         dtype=torch.int64,
+                                         device="cpu",
+                                         pin_memory=self.pin_memory)
+        self.physical_positions_np = self.physical_positions_cpu.numpy()
+        # NOTE(woosuk): These tensors are "stateless", i.e., they are literally
+        # a faster version of creating a new tensor every time. Thus, we should
+        # not make any assumptions about the values in these tensors.
+        self.input_ids_cpu = torch.zeros(self.max_num_tokens,
+                                         dtype=torch.int32,
+                                         device="cpu",
+                                         pin_memory=self.pin_memory)
+        self.positions_cpu = torch.zeros(self.max_num_tokens,
+                                         dtype=torch.int64,
+                                         device="cpu",
+                                         pin_memory=self.pin_memory)
+        self.positions_np = self.positions_cpu.numpy()
+        self.query_start_loc_cpu = torch.zeros(self.max_num_reqs + 1,
+                                               dtype=torch.int32,
+                                               device="cpu",
+                                               pin_memory=self.pin_memory)
+        self.query_start_loc_np = self.query_start_loc_cpu.numpy()
+        self.seq_lens_cpu = torch.zeros(self.max_num_reqs,
+                                        dtype=torch.int32,
+                                        device="cpu",
+                                        pin_memory=self.pin_memory)
+        self.seq_lens_np = self.seq_lens_cpu.numpy()
+
         # Layer pairings for cross-layer KV sharing.
         # If an Attention layer `layer_name` is in the keys of this dict, it
         # means this layer will perform attention using the keys and values
@@ -1065,6 +1099,15 @@ class GPUModelRunner(
         for req_id in scheduler_output.finished_req_ids:
             self.requests.pop(req_id, None)
             self.num_prompt_logprobs.pop(req_id, None)
+            # Clear any pending KVCrush drops for this request
+            if hasattr(self, '_pending_kvc_drops'):
+                self._pending_kvc_drops.pop(req_id, None)
+            # Clean up KVCrush prefill queries across all layers
+            if hasattr(self, 'model'):
+                attn_layers = get_layers_from_vllm_config(self.vllm_config, Attention)
+                for layer in attn_layers.values():
+                    if hasattr(layer.impl, 'prefill_queries'):
+                        layer.impl.prefill_queries.pop(req_id, None)
         self.late_interaction_runner.on_requests_finished(
             scheduler_output.finished_req_ids
         )
@@ -1107,6 +1150,16 @@ class GPUModelRunner(
         # sets of requests), this optimization becomes very inefficient.
         for req_id in unscheduled_req_ids:
             self.input_batch.remove_request(req_id)
+            # Clear any pending KVCrush drops for preempted/unscheduled requests
+            if hasattr(self, '_pending_kvc_drops'):
+                self._pending_kvc_drops.pop(req_id, None)
+            # Clean up KVCrush prefill queries for preempted/unscheduled requests
+            # to prevent stale queries from being concatenated with new ones on resume
+            if hasattr(self, 'model'):
+                attn_layers = get_layers_from_vllm_config(self.vllm_config, Attention)
+                for layer in attn_layers.values():
+                    if hasattr(layer.impl, 'prefill_queries'):
+                        layer.impl.prefill_queries.pop(req_id, None)
 
         is_ngram_gpu = (
             self.speculative_config is not None
@@ -1256,6 +1309,7 @@ class GPUModelRunner(
                         self.input_batch.num_tokens_no_spec[req_index] += (
                             optimistic_num_accepted
                         )
+            num_dropped_tokens = req_data.num_dropped_tokens_list[i]
 
             # Update the cached states.
             req_state.num_computed_tokens = num_computed_tokens
@@ -1293,6 +1347,19 @@ class GPUModelRunner(
                     )
                     self.input_batch.num_tokens_no_spec[req_index] = end_idx
 
+            # If compression freed tail blocks, truncate req_state.block_ids
+            # BEFORE appending new blocks, so the new blocks land at the
+            # correct (post-compression) offset.
+            if num_dropped_tokens > 0:
+                effective_kv_len = num_computed_tokens - num_dropped_tokens
+                for group_block_ids, bt in zip(
+                        req_state.block_ids,
+                        self.input_batch.block_table.block_tables):
+                    bs = bt.block_size
+                    needed = (effective_kv_len + bs - 1) // bs
+                    if len(group_block_ids) > needed:
+                        del group_block_ids[needed:]
+
             # Update the block IDs.
             if not resumed_from_preemption:
                 if new_block_ids is not None:
@@ -1324,7 +1391,22 @@ class GPUModelRunner(
                 continue
 
             # Update the persistent batch.
-            self.input_batch.num_computed_tokens_cpu[req_index] = num_computed_tokens
+            self.input_batch.num_computed_tokens_cpu[req_index] = (
+                num_computed_tokens)
+            self.input_batch.num_dropped_tokens_list_cpu[req_index] = (
+                num_dropped_tokens)
+            # If compression happened, truncate the block_table row before
+            # appending new blocks, so append_row starts at the right offset.
+            if num_dropped_tokens > 0:
+                effective_kv_len = num_computed_tokens - num_dropped_tokens
+                for bt in self.input_batch.block_table.block_tables:
+                    bs = bt.block_size
+                    needed = (effective_kv_len + bs - 1) // bs
+                    current = bt.num_blocks_per_row[req_index]
+                    if needed < current:
+                        bt.num_blocks_per_row[req_index] = needed
+                        bt.block_table.np[
+                            req_index, needed:current] = 0
             if new_block_ids is not None:
                 self.input_batch.block_table.append_row(new_block_ids, req_index)
 
@@ -1803,21 +1885,64 @@ class GPUModelRunner(
         # This way, we can overlap the copy with the following CPU operations.
         self.input_batch.block_table.commit_block_table(num_reqs)
 
+        use_kv_compression = int(os.environ.get("VLLM_V1_KVC_BUDGET", "0")) > 0
+
+        # Apply any KVCrush drops that fired in the previous forward step but
+        # haven't been reflected yet by _update_states (async scheduling lag).
+        # _update_states uses the scheduler's accumulated total, which is 1
+        # step behind when async scheduling is active.  The pending dict is
+        # keyed by req_id so index changes between steps are handled correctly.
+        if use_kv_compression and hasattr(self, '_pending_kvc_drops') and self._pending_kvc_drops:
+            for i in range(num_reqs):
+                req_id = self.input_batch.req_ids[i]
+                if req_id in self._pending_kvc_drops:
+                    self.input_batch.num_dropped_tokens_list_cpu[i] += (
+                        self._pending_kvc_drops.pop(req_id)
+                    )
+
+        num_kv_cache_tokens = (
+            self.input_batch.num_computed_tokens_cpu
+            - self.input_batch.num_dropped_tokens_list_cpu
+        )[:num_reqs]
+        # Safety check: ensure no negative values (can happen with stale data)
+        np.maximum(num_kv_cache_tokens, 0, out=num_kv_cache_tokens)
+        if use_kv_compression:
+            total_num_kv_cache_tokens = num_kv_cache_tokens.sum()
+        else:
+            total_num_kv_cache_tokens = 0
+
+        # Persist for use by _get_slot_mappings in execute_model
+        self._total_num_kv_cache_tokens = int(total_num_kv_cache_tokens)
+
         # Get request indices.
         # E.g., [2, 5, 3] -> [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]
         req_indices = np.repeat(self.arange_np[:num_reqs], num_scheduled_tokens)
+        if use_kv_compression:
+            occupied_indices = np.repeat(self.arange_np[:num_reqs],
+                                    num_kv_cache_tokens)
 
         # cu_num_tokens: [2, 5, 3] -> [2, 7, 10]
         # self.query_pos.np[:10]: [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
         cu_num_tokens = self._get_cumsum_and_arange(
             num_scheduled_tokens, self.query_pos.np
         )
+        arange = self.query_pos.np[:total_num_scheduled_tokens]
+        if use_kv_compression:
+            # For occupied positions, we need to handle potentially large KV cache sizes
+            # that may exceed the pre-allocated arange_np buffer
+            cu_num_kv_tokens = np.cumsum(num_kv_cache_tokens, dtype=np.int32)
+            cumsums_offsets = np.repeat(cu_num_kv_tokens - num_kv_cache_tokens, num_kv_cache_tokens)
+            occupied_positions_np = np.arange(int(total_num_kv_cache_tokens), dtype=np.int64) - cumsums_offsets
 
         # Get positions.
-        positions_np = (
-            self.input_batch.num_computed_tokens_cpu[req_indices]
-            + self.query_pos.np[: cu_num_tokens[-1]]
-        )
+        logical_positions_np = self.logical_positions_np[:total_num_scheduled_tokens]
+        np.add(self.input_batch.num_computed_tokens_cpu[req_indices],
+               arange,
+               out=logical_positions_np)
+        physical_positions_np = self.physical_positions_np[:total_num_scheduled_tokens]
+        np.add(num_kv_cache_tokens[req_indices],
+               arange,
+               out=physical_positions_np)
 
         # Calculate M-RoPE positions.
         # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
@@ -1834,7 +1959,7 @@ class GPUModelRunner(
         # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
         # where M is the max_model_len.
         token_indices = (
-            positions_np + req_indices * self.input_batch.token_ids_cpu.shape[1]
+            logical_positions_np + req_indices * self.input_batch.token_ids_cpu.shape[1]
         )
         token_indices_tensor = torch.from_numpy(token_indices)
 
@@ -1847,6 +1972,7 @@ class GPUModelRunner(
             token_indices_tensor,
             out=self.input_ids.cpu[:total_num_scheduled_tokens],
         )
+
         if self.enable_prompt_embeds:
             is_token_ids = self.input_batch.is_token_ids_tensor.flatten()
             torch.index_select(
@@ -1855,6 +1981,7 @@ class GPUModelRunner(
                 token_indices_tensor,
                 out=self.is_token_ids.cpu[:total_num_scheduled_tokens],
             )
+
 
         # Because we did not pre-allocate a massive prompt_embeds CPU tensor on
         # the InputBatch, we need to fill in the prompt embeds into the expected
@@ -1894,6 +2021,14 @@ class GPUModelRunner(
 
                 output_idx += num_sched
 
+        if use_kv_compression:
+            self.input_batch.block_table._compute_slot_mapping_numpy(
+                req_indices, physical_positions_np, False)
+            self.input_batch.block_table._compute_slot_mapping_numpy(
+                occupied_indices, occupied_positions_np, True)
+            self.input_batch.block_table.commit_slot_mapping(
+                total_num_scheduled_tokens, total_num_kv_cache_tokens)
+
         # Prepare the attention metadata.
         self.query_start_loc.np[0] = 0
         self.query_start_loc.np[1 : num_reqs + 1] = cu_num_tokens
@@ -1912,6 +2047,9 @@ class GPUModelRunner(
             torch.from_numpy(num_scheduled_tokens),
             out=self.optimistic_seq_lens_cpu[:num_reqs],
         )
+        self.seq_lens_np[:num_reqs] = (
+            num_kv_cache_tokens + num_scheduled_tokens
+        )
         self.optimistic_seq_lens_cpu[num_reqs:].fill_(0)
 
         # Build prev_positions mapping: current pos -> prev pos (-1 if new).
@@ -1923,9 +2061,15 @@ class GPUModelRunner(
         num_tokens_np = np.array(num_tokens, dtype=np.int32)
 
         # Record which requests should not be sampled,
-        # so that we could clear the sampled tokens before returning
+        # so that we could clear the sampled tokens before returning.
+        # NOTE: We intentionally use num_computed_tokens_cpu + num_scheduled_tokens
+        # (the logical token count) rather than seq_lens (which is
+        # num_kv_cache_tokens + num_scheduled and subtracts KVCrush drops).
+        # Using seq_lens would cause discard_request_mask to fire incorrectly
+        # for any request that has had KV cache tokens compressed/dropped,
+        # treating a normal decode step as an in-progress chunked prefill.
         self.discard_request_mask.np[:num_reqs] = (
-            self.optimistic_seq_lens_cpu[:num_reqs].numpy() < num_tokens_np
+            self.input_batch.num_computed_tokens_cpu[:num_reqs] + num_scheduled_tokens < num_tokens_np
         )
         self.discard_request_mask.copy_to_gpu(num_reqs)
 
@@ -1982,16 +2126,22 @@ class GPUModelRunner(
             self.num_computed_tokens[req_indices_gpu].to(torch.int64)
             + self.query_pos.gpu[:total_num_scheduled_tokens]
         )
-        self.seq_lens[:num_reqs] = (
-            self.num_computed_tokens[:num_reqs] + num_scheduled_tokens_gpu
-        )
+        if use_kv_compression:
+            self.seq_lens[:num_reqs].copy_(
+                self.seq_lens_cpu[:num_reqs], non_blocking=True
+            )
+        else:
+            self.seq_lens[:num_reqs] = (
+                self.num_computed_tokens[:num_reqs] + num_scheduled_tokens_gpu
+            )
         self.seq_lens[num_reqs:].fill_(0)
 
-        self.input_batch.block_table.compute_slot_mapping(
-            num_reqs,
-            self.query_start_loc.gpu[: num_reqs + 1],
-            self.positions[:total_num_scheduled_tokens],
-        )
+        if not use_kv_compression:
+            self.input_batch.block_table.compute_slot_mapping(
+                num_reqs,
+                self.query_start_loc.gpu[: num_reqs + 1],
+                self.positions[:total_num_scheduled_tokens],
+            )
 
         # Copy the tensors to the GPU.
         self._prepare_input_ids(
@@ -2021,6 +2171,11 @@ class GPUModelRunner(
             )
             target = self.mrope_positions if self.uses_mrope else self.xdrope_positions
             target.gpu[:, :total_num_scheduled_tokens] += drift
+        else:
+            # Common case (1D positions)
+            self.positions[:total_num_scheduled_tokens].copy_(
+                self.logical_positions_cpu[:total_num_scheduled_tokens],
+                non_blocking=True)
 
         use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
         if not use_spec_decode:
@@ -2091,6 +2246,9 @@ class GPUModelRunner(
         num_scheduled_tokens: dict[str, int] | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
         slot_mappings: dict[int, torch.Tensor] | None = None,
+        occupied_slot_mappings: dict[int, torch.Tensor] | None = None,
+        total_num_kv_cache_tokens: int = 0,
+        req_ids: list[str] | None = None,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
         """
         :return: tuple[attn_metadata, spec_decode_common_attn_metadata]
@@ -2138,6 +2296,11 @@ class GPUModelRunner(
         assert slot_mappings is not None
         block_table_gid_0 = _get_block_table(0)
         slot_mapping_gid_0 = slot_mappings[0]
+        occupied_slot_mapping_gid_0 = (
+            occupied_slot_mappings[0]
+            if occupied_slot_mappings is not None
+            else None
+        )
 
         if self.routed_experts_initialized:
             attn_gid = self.routed_experts_attn_gid
@@ -2173,6 +2336,9 @@ class GPUModelRunner(
             max_seq_len=max_seq_len,
             block_table_tensor=block_table_gid_0,
             slot_mapping=slot_mapping_gid_0,
+            occupied_slot_mapping=occupied_slot_mapping_gid_0,
+            total_num_kv_cache_tokens=total_num_kv_cache_tokens,
+            req_ids=req_ids,
             causal=True,
             is_prefilling=is_prefilling,
         )
@@ -2287,6 +2453,8 @@ class GPUModelRunner(
             if kv_cache_gid > 0:
                 cm.block_table_tensor = _get_block_table(kv_cache_gid)
                 cm.slot_mapping = slot_mappings[kv_cache_gid]
+                if occupied_slot_mappings is not None:
+                    cm.occupied_slot_mapping = occupied_slot_mappings[kv_cache_gid]
 
             if self.speculative_config and spec_decode_common_attn_metadata is None:
                 if isinstance(self.drafter, EagleProposer):
@@ -3142,6 +3310,7 @@ class GPUModelRunner(
             req_ids=self.input_batch.req_ids.copy(),
             req_id_to_index=self.input_batch.req_id_to_index.copy(),
             kv_connector_output=kv_connector_output,
+            num_dropped_tokens_list=[0] * num_reqs,
         )
 
         if raw_pooler_output is None or not any(finished_mask):
@@ -3682,10 +3851,12 @@ class GPUModelRunner(
         num_tokens_padded: int,
         num_reqs_padded: int,
         num_tokens_unpadded: int,
+        total_num_kv_cache_tokens: int = 0,
         ubatch_slices: "UBatchSlices | None" = None,
     ) -> tuple[
         dict[int, torch.Tensor] | None,
         dict[str, torch.Tensor] | list[dict[str, torch.Tensor]] | None,
+        dict[int, torch.Tensor] | None,
     ]:
         """
         Build slot mappings in both formats needed by the system.
@@ -3694,21 +3865,31 @@ class GPUModelRunner(
             num_tokens_padded: Total number of tokens (padded)
             num_reqs_padded: Total number of requests (padded)
             num_tokens_unpadded: Actual number of tokens (unpadded)
+            total_num_kv_cache_tokens: Total number of KV-cache tokens after
+                KVCrush compression (i.e. num_computed_tokens - num_dropped_tokens).
+                Used to slice ``occupied_slot_mapping`` per group.  Pass 0 when
+                KVCrush is not active.
             ubatch_slices: Optional ubatch slicing info for DBO
 
         Returns:
-            A tuple of:
-            - slot_mappings_by_gid: dict[int, torch.Tensor] for attention metadata
-            - slot_mappings_by_layer: dict[str, torch.Tensor] or list for ForwardContext
+            A 3-tuple of:
+            - slot_mappings_by_gid: dict[int, Tensor] — regular slot mappings
+              keyed by kv_cache_group id, for attention metadata.
+            - slot_mappings_by_layer: dict[str, Tensor] or list[dict] — regular
+              slot mappings keyed by layer name, for ForwardContext.
+            - occupied_slot_mappings_by_gid: dict[int, Tensor] — KVCrush
+              occupied-slot mappings keyed by kv_cache_group id, covering only
+              the ``total_num_kv_cache_tokens`` live entries (tail filled -1).
+              None when kv_cache_config is absent.
         """
         if not (
             hasattr(self, "kv_cache_config")
             and self.kv_cache_config is not None
             and len(self.kv_cache_config.kv_cache_groups) > 0
         ):
-            return None, None
+            return None, None, None
 
-        def _get_slot_mapping(kv_cache_gid: int):
+        def _get_slot_mapping(kv_cache_gid: int) -> torch.Tensor:
             assert num_reqs_padded is not None and num_tokens_padded is not None
             kv_cache_spec = self.kv_cache_config.kv_cache_groups[
                 kv_cache_gid
@@ -3729,10 +3910,31 @@ class GPUModelRunner(
 
             return slot_mapping
 
-        slot_mappings_by_gid = {
+        def _get_occupied_slot_mapping(kv_cache_gid: int) -> torch.Tensor:
+            """Return the occupied-slot mapping for KVCrush.
+
+            The first ``total_num_kv_cache_tokens`` entries are the physical
+            cache slots that are still live after compression; the remainder
+            are filled with -1 to avoid stale values.
+            """
+            blk_table = self.input_batch.block_table[kv_cache_gid]
+            occupied = blk_table.occupied_slot_mapping
+            occupied[total_num_kv_cache_tokens:].fill_(-1)
+            return occupied[:total_num_kv_cache_tokens]
+
+        slot_mappings_by_gid: dict[int, torch.Tensor] = {
             gid: _get_slot_mapping(gid)
             for gid, _ in enumerate(self.kv_cache_config.kv_cache_groups)
         }
+
+        occupied_slot_mappings_by_gid: dict[int, torch.Tensor] | None = (
+            {
+                gid: _get_occupied_slot_mapping(gid)
+                for gid, _ in enumerate(self.kv_cache_config.kv_cache_groups)
+            }
+            if total_num_kv_cache_tokens > 0
+            else None
+        )
 
         slot_mappings_by_layer: dict[str, torch.Tensor] = {}
         for gid, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups):
@@ -3747,9 +3949,9 @@ class GPUModelRunner(
                 for layer_name, slot_mapping in slot_mappings_by_layer.items():
                     sliced_mappings[layer_name] = slot_mapping[ubatch.token_slice]
                 result.append(sliced_mappings)
-            return slot_mappings_by_gid, result
+            return slot_mappings_by_gid, result, occupied_slot_mappings_by_gid
 
-        return slot_mappings_by_gid, slot_mappings_by_layer
+        return slot_mappings_by_gid, slot_mappings_by_layer, occupied_slot_mappings_by_gid
 
     @torch.inference_mode()
     def execute_model(
@@ -3940,15 +4142,22 @@ class GPUModelRunner(
             use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
             ubatch_slices_attn = ubatch_slices_padded if pad_attn else ubatch_slices
 
-            slot_mappings_by_group, slot_mappings = self._get_slot_mappings(
-                num_tokens_padded=num_tokens_padded
-                if pad_attn or has_separate_kv_update
-                else num_tokens_unpadded,
-                num_reqs_padded=(
-                    num_reqs_padded if pad_attn or has_separate_kv_update else num_reqs
-                ),
-                num_tokens_unpadded=num_tokens_unpadded,
-                ubatch_slices=ubatch_slices_padded,
+            slot_mappings_by_group, slot_mappings, occupied_slot_mappings_by_group = (
+                self._get_slot_mappings(
+                    num_tokens_padded=num_tokens_padded
+                    if pad_attn or has_separate_kv_update
+                    else num_tokens_unpadded,
+                    num_reqs_padded=(
+                        num_reqs_padded
+                        if pad_attn or has_separate_kv_update
+                        else num_reqs
+                    ),
+                    num_tokens_unpadded=num_tokens_unpadded,
+                    total_num_kv_cache_tokens=getattr(
+                        self, "_total_num_kv_cache_tokens", 0
+                    ),
+                    ubatch_slices=ubatch_slices_padded,
+                )
             )
 
             attn_metadata, spec_decode_common_attn_metadata = (
@@ -3964,6 +4173,11 @@ class GPUModelRunner(
                     num_scheduled_tokens=scheduler_output.num_scheduled_tokens,
                     cascade_attn_prefix_lens=cascade_attn_prefix_lens,
                     slot_mappings=slot_mappings_by_group,
+                    occupied_slot_mappings=occupied_slot_mappings_by_group,
+                    total_num_kv_cache_tokens=getattr(
+                        self, "_total_num_kv_cache_tokens", 0
+                    ),
+                    req_ids=self.input_batch.req_ids[:num_reqs]
                 )
             )
 
@@ -4023,6 +4237,36 @@ class GPUModelRunner(
                 inputs_embeds=inputs_embeds,
                 **model_kwargs,
             )
+
+        # Copy KVCrush drop counts from attn_metadata (written in forward())
+        # into a per-step delta list. We must NOT accumulate into
+        # input_batch.num_dropped_tokens_list_cpu here because that holds the
+        # *accumulated* total (set by _update_states from the scheduler).
+        # ModelRunnerOutput must send the *delta* so the scheduler can do +=.
+        self._kvcrush_step_drops = [0] * self.input_batch.num_reqs
+        if int(os.environ.get("VLLM_V1_KVC_BUDGET", "0")) > 0:
+            if isinstance(attn_metadata, dict) and attn_metadata:
+                first_meta = next(iter(attn_metadata.values()))
+                if hasattr(first_meta, 'num_dropped_tokens_list'):
+                    for i, d in enumerate(
+                            first_meta.num_dropped_tokens_list):
+                        if d > 0:
+                            self._kvcrush_step_drops[i] = d
+
+        # With async scheduling (batch_queue_size=2), the scheduler processes
+        # step N's output while step N+1 is already being prepared.  That means
+        # _update_states for step N+1 carries a stale num_dropped value (before
+        # step N's drops are reflected).  To fix the 1-step lag we store the
+        # per-request drop deltas here (indexed by req_id so they survive index
+        # reshuffling) and apply them in _prepare_inputs of the next step.
+        if not hasattr(self, '_pending_kvc_drops'):
+            self._pending_kvc_drops: dict[str, int] = {}
+        for i, d in enumerate(self._kvcrush_step_drops):
+            if d > 0:
+                req_id = self.input_batch.req_ids[i]
+                self._pending_kvc_drops[req_id] = (
+                    self._pending_kvc_drops.get(req_id, 0) + d
+                )
 
         with record_function_or_nullcontext("gpu_model_runner: postprocess"):
             if self.use_aux_hidden_state_outputs:
@@ -4307,6 +4551,7 @@ class GPUModelRunner(
                 logprobs=logprobs_lists,
                 prompt_logprobs_dict=prompt_logprobs_dict,
                 kv_connector_output=kv_connector_output,
+                num_dropped_tokens_list=getattr(self, '_kvcrush_step_drops', [0] * self.input_batch.num_reqs),
                 ec_connector_output=ec_connector_output
                 if self.supports_mm_inputs
                 else None,
@@ -5339,11 +5584,13 @@ class GPUModelRunner(
 
         attn_metadata: PerLayerAttnMetadata | None = None
 
-        slot_mappings_by_group, slot_mappings = self._get_slot_mappings(
-            num_tokens_padded=num_tokens,
-            num_reqs_padded=num_reqs_padded,
-            num_tokens_unpadded=num_tokens_unpadded,
-            ubatch_slices=ubatch_slices_padded,
+        slot_mappings_by_group, slot_mappings, occupied_slot_mappings_by_group = (
+            self._get_slot_mappings(
+                num_tokens_padded=num_tokens,
+                num_reqs_padded=num_reqs_padded,
+                num_tokens_unpadded=num_tokens_unpadded,
+                ubatch_slices=ubatch_slices_padded,
+            )
         )
 
         # _dummy_run shares pinned CPU buffers (seq_lens, query_start_loc,
@@ -5391,6 +5638,11 @@ class GPUModelRunner(
                     ubatch_slices=(ubatch_slices_padded if pad_attn else ubatch_slices),
                     for_cudagraph_capture=is_graph_capturing,
                     slot_mappings=slot_mappings_by_group,
+                    occupied_slot_mappings=occupied_slot_mappings_by_group,
+                    total_num_kv_cache_tokens=getattr(
+                        self, "_total_num_kv_cache_tokens", 0
+                    ),
+                    req_ids=[],
                     use_spec_decode=self.speculative_config is not None,
                 )
 

--- a/vllm/v1/worker/ubatch_utils.py
+++ b/vllm/v1/worker/ubatch_utils.py
@@ -210,6 +210,7 @@ def _make_metadata_with_slice(
 
     block_table_tensor = attn_metadata.block_table_tensor[request_slice]
     slot_mapping = attn_metadata.slot_mapping[token_slice]
+    req_ids = attn_metadata.req_ids[request_slice] if attn_metadata.req_ids is not None else None
 
     return CommonAttentionMetadata(
         query_start_loc=query_start_loc,
@@ -223,6 +224,7 @@ def _make_metadata_with_slice(
         slot_mapping=slot_mapping,
         _seq_lens_cpu=seq_lens_cpu,
         _num_computed_tokens_cpu=num_computed_tokens_cpu,
+        req_ids=req_ids,
     )
 
 


### PR DESCRIPTION
## Purpose
Support for **KVCrush** [paper link](https://arxiv.org/abs/2503.00022) based KVCache compression, a KV cache eviction/compression policy that complements on top of existing token-eviction methods like H2O, SnapKV, PyramidKV, into the vLLM v1 engine.

Long-context inference results in large KV caches that consume significant GPU memory and limit throughput. KVCrush reduces the active KV cache size by evicting less-important tokens just after prefill using attention-score-based scoring (H2O) and retaining the best tokens back using low overhead clustering, while preserving a configurable set of "start", "recent", and "budget" tokens.

After compression, the effective KV size per sequence is: `start_size + budget + recent_size` (instead of full sequence length).

**Key env-var knobs:**
| Variable | Default | Description |
|---|---|---|
| `VLLM_V1_KVC_BUDGET` | `0` (disabled) | Token budget for compressed middle tokens |
| `VLLM_V1_KVCRUSH_START_SIZE` | `32` | Attention-sink tokens to always keep |
| `VLLM_V1_KVCRUSH_RECENT_SIZE` | `128` | Recent tokens to always keep |
| `VLLM_V1_KVCRUSH_WINDOW_SIZE` | `8` | Sliding window for attention scoring |
| `VLLM_V1_KVCRUSH_ANCHOR_MODE` | `mean` | Anchor point (`mean`/`alternate`/`random`) |
| `VLLM_V1_KVCRUSH_RATIO` | `0.0` | Fraction of the budget contributed by KVCrush |

KVCrush is **off by default** (`VLLM_V1_KVC_BUDGET=0`) and only activates when the budget is set.

**Few considerations for KVCrush compression to operate:**
- Requires eager mode execution
- Prefix caching needs to be disabled as the cache compression rearranges the blocks


## Test Plan

```bash
# Basic correctness of KVCrush compression
VLLM_V1_KVC_BUDGET=256 python test_kvcrush_multi_request.py

# To test the KVCrush algorithm
python test_kvcrush.py

# Throughput benchmark
Using the vllm bench throughput

# LongBench quality evaluation

Accuracy evaluation on longbench dataset available at THUDM/LongBench on various anchor modes on a fixed KVCache budget.
```

## Test Result

**Accuracy evaluation on NVIDIA A6000:**

Configuration settings:

**Model: Llama-3-8B-Instruct
Cache budget = 2048 (H2O+KVCrush) + start (32) + recent(128)
Page size for KVCrush = 16 
Temperature = 0**

  | qmsum | qasper | samsum | repobench-p | hotpotqa | trec
-- | -- | -- | -- | -- | -- | --
FullKV | 21.98 | 41.31 | 42.06 | 45.51 | 42.77 | 71.5
H2O | 21.54 | 40.32 | 41.61 | 46.51 | 43.21 | 71.5
KVCrush + H2O | 22.20 | 41.15 | 41.99 | 47.16 | 43.37 | 71.5
H2O   + KVC, Anchor point mode | 512+1536,   random | 1024+1024,   mean | 1536+512,   alternate | 1536+512,   mean | 1024+1024,   mean | 1536+512,   random

**Accuracy evaluation on Intel Arc B60:**
**Model: Llama-3-8B-Instruct
Cache budget = 2048 (H2O+KVCrush) + start (32) + recent(128) = 2208
Page size for KVCrush = 16 
Temperature = 0**

  | qmsum | qasper | samsum | repobench-p | hotpotqa | trec
-- | -- | -- | -- | -- | -- | --
FullKV | 21.98 | 41.31 | 42.06 | 45.51 | 42.77 | 71.5
H2O | 21.59 | 40.38 | 41.92 | 46.42 | 43.66 | 72.0
KVCrush + H2O | 22.28 | 41.02 | 42.21 | 46.8 | 43.87 | 71.5
H2O   + KVC, ratio, Anchor point mode | 1536+512,   0.25, random | 1536+512,   0.25, random | 512+1536,   0.75, alternate | 512+ 1536,   0.75, random | 1024+1024,   0.5, random | 512+1536,   0.75, alternate

KVCrush page size != vLLM page size as KVCrush operates on the extract occupied slots of KVCache i.e, on a token level view and groups it by page - size chunks internally for scoring, picks which groups to keep, gathers those individual token indices, and writes the compressed tensors back to the physical KVCache. So the physical block layout of the paged KV cache is completely abstracted away before KVCrush is invoked. On vLLM page size of 64 as in XPU backend, the accuracy degrades as the KVCrush clustering cannot retain the best KV tokens in the cache set.

**Note:** We evaluated on the subset of tasks out of the 21 tasks of LongBench dataset


**Throughput results:**

We test the KVCrush impact on the throughput at low gpu memory utilization with budgets set as 1024 and 2048 tokens at large input length of 4096.

On NVIDIA A6000, `gpu-memory-utilization=0.5`

<img width="1725" height="616" alt="image" src="https://github.com/user-attachments/assets/bff02313-f139-4b67-b86e-e0c2cf6106d3" />

Throughput improves compared to FullKV baseline(budget=0). For example, on a 4x compression(budget=1024), the throughput improves by ~1.8x since the KVCache blocks are freed after prefill and helps the decode phase.

On Intel Arc B60 24GB, `gpu-memory-utilization=0.8`,

<img width="1685" height="602" alt="image" src="https://github.com/user-attachments/assets/e9eaa48a-a377-47f2-b920-6d824be9e590" />

Throughput improves compared to FullKV baseline(budget=0). For example, on a 4x compression(budget=1024), the throughput improves by ~1.6x since the KVCache blocks are freed after prefill and helps the decode phase.

**Maximum batch size the scheduler can allocate:**

**On NVIDIA A6000:**

<img width="2000" height="647" alt="image" src="https://github.com/user-attachments/assets/310ae23e-ae12-4a4d-9105-b28911453270" />

Since the KVCache block pool is freed more requests can be allocated in a batch, for example, on large input length request of 6144, on KVCache budget of 512, the scheduler could allocate 80 requests in a batch step.

**On Intel Arc B60:**
<img width="1816" height="588" alt="image" src="https://github.com/user-attachments/assets/6326ad70-ece7-4e1a-a386-4dd31a1481ac" />

On the B60 which has lower memory of 24GB, benefits more from compression in relative throughput terms — budget=512 at input=6144 gives 3.83x throughput gain on XPU vs 2.15x on CUDA. Similar gains on the maximum batch size the scheduler could allocate.

To evaluate this we set `max_num_seqs=256`

**Highlights of this integration:**
- KVCrush can be used irrespective of the device platform.
- Compression occurs only once after prefill so there is minimal latency overhead on the request processing. 

**Further optimizations:**
- Avoiding the QKT recomputation.
- The vLLM memory profiler has to account for the KVCrush memory allocations (like `query_start_loc` and other) during initial allocation of KVCache so that it works on any GPU memory utilization.



These changes collectively enable, configure, and validate KVCrush-based KV cache compression in vLLM, providing both low-level and end-to-end test coverage.


cc: @deepvars 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

