### PR TITLE
Remove router weight upcast for DSv2-related models

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -307,9 +307,7 @@ class DeepseekV2MoE(nn.Module):
         self.gate = GateLinear(
             config.hidden_size,
             config.n_routed_experts,
-            params_dtype=self.router_dtype,
             out_dtype=self.router_dtype,
-            force_fp32_compute=self.router_dtype == torch.float32,
             prefix=f"{prefix}.gate",
         )
         if getattr(config, "topk_method", None) == "noaux_tc":


### PR DESCRIPTION
## Purpose

#47410 upcasts router weights to FP32, disallows BF16xBF16->FP32 GEMM codepath. This PR removes weight upcast, but retain FP32 logits output, so we can use the fast BF16xBF16->FP32 GEMM.

**Further discussion** BF16xBF16->FP32 GEMM is still less accurate than FP32 SIMT GEMM. I believe this is due to accumulation across large K=6144. SIMT GEMM probably uses more accumulation buffers across threads before the final (warp) reduction), so it avoid adding a small number to a large accumulator. BF16xBF16->FP32 GEMM has 6144/16=384 MMA iterations, which means later iterations will face the issue "small number added to a large accumulator".

Using real BF16 router weights from GLM-5.2 checkpoint. Comparing with FP64 reference

tokens | FP32 vs FP64 MAE | BF16 vs FP64 MAE | BF16 vs FP32 MAE
-- | -- | -- | --
1 | 2.84e-7 | 5.10e-6 | 5.10e-6
32 | 6.49e-7 | 5.42e-6 | 5.47e-6
128 | 7.98e-7 | 7.45e-6 | 7.49e-6
1024 | 2.33e-6 | 2.34e-5 | 2.35e-5
8192 | 2.33e-6 | 2.35e-5 | 2.35e-5

BF16 error is 1 order of magnitude larger than FP32 error, though ~1e-5 is quite small. This can possibly be fixed by using more accumulation buffer in BF16 MMA mainloop.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

