### PR TITLE
BF16x3 router GEMM

### DIFF
--- a/tests/kernels/test_bf16x3_router_gemm_cutedsl.py
+++ b/tests/kernels/test_bf16x3_router_gemm_cutedsl.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the experimental SM100 BF16x3 router GEMM."""
+
+import pytest
+import torch
+
+from vllm.utils.import_utils import has_cutedsl
+
+
+def _requires_sm100_cutedsl():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    major, _ = torch.cuda.get_device_capability()
+    if major != 10:
+        pytest.skip("bf16x3 router GEMM requires SM100-class GPU")
+    if not has_cutedsl():
+        pytest.skip("cutedsl (cutlass) not installed")
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "hidden_dim", "num_experts"),
+    [(48, 6144, 128), (96, 3072, 256)],
+)
+def test_bf16x3_router_gemm_matches_reference(
+    num_tokens: int, hidden_dim: int, num_experts: int
+):
+    _requires_sm100_cutedsl()
+    from vllm.model_executor.layers.fused_moe.router.bf16x3_router_gemm_cutedsl import (  # noqa: E501
+        bf16x3_router_gemm,
+    )
+
+    torch.manual_seed(42)
+    x = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device="cuda")
+    w = torch.randn(num_experts, hidden_dim, dtype=torch.float32, device="cuda")
+    # Match the observed router weight scale
+    w *= 0.053
+    out = bf16x3_router_gemm(x, w)
+    ref = torch.nn.functional.linear(x.float(), w)
+
+    assert out.shape == (num_tokens, num_experts)
+    assert out.dtype == torch.float32
+    assert torch.mean(torch.abs(out - ref)).item() < 5e-6

--- a/tests/kernels/test_bf16x3_router_gemm_cutedsl.py
+++ b/tests/kernels/test_bf16x3_router_gemm_cutedsl.py
@@ -20,7 +20,7 @@ def _requires_sm100_cutedsl():
 
 @pytest.mark.parametrize(
     ("num_tokens", "hidden_dim", "num_experts"),
-    [(48, 6144, 128), (96, 3072, 256)],
+    [(48, 6144, 128), (96, 3072, 256), (129, 3072, 17)],
 )
 def test_bf16x3_router_gemm_matches_reference(
     num_tokens: int, hidden_dim: int, num_experts: int

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -178,6 +178,9 @@ class KernelConfig:
     enable_cutedsl_warmup: bool = True
     """If True, run CuTeDSL compile warmup during kernel warmup."""
 
+    enable_bf16x3_router_gemm: bool = False
+    """If True, use the experimental SM100 BF16x3 CuteDSL router GEMM."""
+
     moe_backend: MoEBackend = "auto"
     """Backend for MoE expert computation kernels. Available options:
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1511,13 +1511,7 @@ class EngineArgs:
         )
         kernel_group.add_argument(
             "--enable-bf16x3-router-gemm",
-            action=argparse.BooleanOptionalAction,
-            default=None,
-            help=(
-                "Enable the experimental SM100 BF16x3 CuteDSL router GEMM "
-                "for medium/large router batches not handled by the native "
-                "FP32 router GEMM kernel."
-            ),
+            **kernel_kwargs["enable_bf16x3_router_gemm"],
         )
         moe_backend_kwargs = kernel_kwargs["moe_backend"]
         moe_backend_kwargs["type"] = lambda s: s.lower().replace("-", "_")

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -665,6 +665,7 @@ class EngineArgs:
     enable_flashinfer_autotune: bool = get_field(
         KernelConfig, "enable_flashinfer_autotune"
     )
+    enable_bf16x3_router_gemm: bool | None = None
     worker_cls: str = ParallelConfig.worker_cls
     worker_extension_cls: str = ParallelConfig.worker_extension_cls
 
@@ -1508,6 +1509,16 @@ class EngineArgs:
             "--enable-flashinfer-autotune",
             **kernel_kwargs["enable_flashinfer_autotune"],
         )
+        kernel_group.add_argument(
+            "--enable-bf16x3-router-gemm",
+            action=argparse.BooleanOptionalAction,
+            default=None,
+            help=(
+                "Enable the experimental SM100 BF16x3 CuteDSL router GEMM "
+                "for medium/large router batches not handled by the native "
+                "FP32 router GEMM kernel."
+            ),
+        )
         moe_backend_kwargs = kernel_kwargs["moe_backend"]
         moe_backend_kwargs["type"] = lambda s: s.lower().replace("-", "_")
         kernel_group.add_argument("--moe-backend", **moe_backend_kwargs)
@@ -2282,6 +2293,8 @@ class EngineArgs:
                     "are mutually exclusive"
                 )
             kernel_config.enable_flashinfer_autotune = self.enable_flashinfer_autotune
+        if self.enable_bf16x3_router_gemm is not None:
+            kernel_config.enable_bf16x3_router_gemm = self.enable_bf16x3_router_gemm
         if self.moe_backend != "auto":
             kernel_config.moe_backend = self.moe_backend
         if self.linear_backend != "auto":

--- a/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
+++ b/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
@@ -34,6 +34,14 @@ def _decompose_fp32x2_to_3xbf16x2(
     loc=None,
     ip=None,
 ) -> tuple[Uint32, Uint32, Uint32]:
+    # this PTX snippets does the following
+    #   out0 = BF16(in);   res =  in - FP32(out0)
+    #   out1 = BF16(res);  res = res - FP32(out1)
+    #   out2 = BF16(res)
+    #
+    # for normal FP32, this decomposition is exact
+    # i.e. in = FP32(out0) + FP32(out1) + FP32(out2)
+    #
     out = llvm.inline_asm(
         llvm.StructType.get_literal([T.i32(), T.i32(), T.i32()]),
         [w0.ir_value(loc=loc, ip=ip), w1.ir_value(loc=loc, ip=ip)],
@@ -116,8 +124,8 @@ class Sm100BF16x3RouterGemm:
         bid_m, bid_n, bid_k = cute.arch.block_idx()
         _, _, split_k = cute.arch.grid_dim()
 
-        warp_id = cute.arch.make_warp_uniform(tid // 32)
-        lane_id = tid % 32
+        warp_id = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        lane_id = cute.arch.lane_idx()
 
         BN, BM, BK = self.cta_tile
         num_stages = self.num_stages
@@ -333,7 +341,7 @@ class Sm100BF16x3RouterGemm:
         SPLIT_K = cute.sym_int()
         X = make_fake_tensor(BFloat16, (N, K), divisibility=8)
         W = make_fake_tensor(Float32, (M, K), divisibility=4)
-        out = make_fake_tensor(Float32, (SPLIT_K, N, M), divisibility=16)
+        out = make_fake_tensor(Float32, (SPLIT_K, N, M), divisibility=1)
         stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
         kernel = Sm100BF16x3RouterGemm(BN)
         return cute.compile(

--- a/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
+++ b/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
@@ -1,0 +1,441 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CuteDSL BF16x3 router GEMM.
+
+Computes ``X @ W.T`` for BF16 ``X`` with shape ``[N, K]`` and FP32 router
+weights ``W`` with shape ``[M, K]`` by decomposing each FP32 weight value into
+three BF16 residual terms inside the kernel, then accumulating the three BF16
+MMA results into FP32 TMEM output.
+"""
+
+from functools import cache
+
+import cutlass
+import torch
+from cuda.bindings.driver import CUstream
+from cutlass import BFloat16, Float32, Int32, Int64, Uint32, cute
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cutlass_dsl import T, dsl_user_op
+from quack.compile_utils import make_fake_tensor
+
+from vllm.cute_utils import _tcgen05, simple_tma_copy
+from vllm.triton_utils import tl, triton
+from vllm.utils import math_utils
+
+__all__ = ["bf16x3_router_gemm"]
+
+
+@dsl_user_op
+def _decompose_fp32x2_to_3xbf16x2(
+    w0: Float32,
+    w1: Float32,
+    *,
+    loc=None,
+    ip=None,
+) -> tuple[Uint32, Uint32, Uint32]:
+    out = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32(), T.i32()]),
+        [w0.ir_value(loc=loc, ip=ip), w1.ir_value(loc=loc, ip=ip)],
+        "{\n\t"
+        ".reg .b32 r1_lo, r1_hi, r2_lo, r2_hi;\n\t"
+        ".reg .b32 w0_lo, w0_hi, w1_lo, w1_hi;\n\t"
+        ".reg .b64 a_pair, w0_pair, w1_pair, r1_pair, r2_pair;\n\t"
+        "cvt.rn.bf16x2.f32 $0, $4, $3;\n\t"
+        "shl.b32 w0_lo, $0, 16;\n\t"
+        "and.b32 w0_hi, $0, 0xffff0000;\n\t"
+        "mov.b64 a_pair, {$3, $4};\n\t"
+        "mov.b64 w0_pair, {w0_lo, w0_hi};\n\t"
+        "sub.rn.f32x2 r1_pair, a_pair, w0_pair;\n\t"
+        "mov.b64 {r1_lo, r1_hi}, r1_pair;\n\t"
+        "cvt.rn.bf16x2.f32 $1, r1_hi, r1_lo;\n\t"
+        "shl.b32 w1_lo, $1, 16;\n\t"
+        "and.b32 w1_hi, $1, 0xffff0000;\n\t"
+        "mov.b64 w1_pair, {w1_lo, w1_hi};\n\t"
+        "sub.rn.f32x2 r2_pair, r1_pair, w1_pair;\n\t"
+        "mov.b64 {r2_lo, r2_hi}, r2_pair;\n\t"
+        "cvt.rn.bf16x2.f32 $2, r2_hi, r2_lo;\n\t"
+        "}\n",
+        "=r,=r,=r,f,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Uint32(llvm.extractvalue(T.i32(), out, [0], loc=loc, ip=ip)),
+        Uint32(llvm.extractvalue(T.i32(), out, [1], loc=loc, ip=ip)),
+        Uint32(llvm.extractvalue(T.i32(), out, [2], loc=loc, ip=ip)),
+    )
+
+
+class Sm100BF16x3RouterGemm:
+    def __init__(self, BN: int = 128) -> None:
+        self.cta_tile = (BN, 128, 64)
+        self.num_stages = 2
+        self.num_warps = 10
+
+    @cute.jit
+    def _make_tma(self, tensor: cute.Tensor, BM: int, BK: int):
+        op = cpasync.CopyBulkTensorTileG2SOp()
+        swizzle_128B = cute.make_swizzle(3, 4, 3)
+        elems = 128 * 8 // tensor.element_type.width  # 128B
+        slayout = cute.make_layout(
+            (BM, (elems, BK // elems), self.num_stages),
+            stride=(elems, (1, BM * elems), BM * BK),
+        )
+        slayout = cute.make_composed_layout(swizzle_128B, 0, slayout)
+        return cpasync.make_tiled_tma_atom(op, tensor, slayout, (BM, BK))
+
+    @cute.jit
+    def __call__(
+        self,
+        X: cute.Tensor,
+        W: cute.Tensor,
+        out: cute.Tensor,
+        split_k: Int32,
+        stream: CUstream,
+    ):
+        BN, BM, BK = self.cta_tile
+        W_tma = self._make_tma(W, BM, BK)
+        X_tma = self._make_tma(X, BN, BK)
+
+        grid_m = cute.ceil_div(W.shape[0], BM)
+        grid_n = cute.ceil_div(X.shape[0], BN)
+
+        self.kernel(X_tma, W_tma, out).launch(
+            grid=(grid_m, grid_n, split_k),
+            block=(self.num_warps * 32, 1, 1),
+            stream=stream,
+            use_pdl=True,
+        )
+
+    @cute.kernel
+    def kernel(self, X_tma: cpasync.TmaInfo, W_tma: cpasync.TmaInfo, out: cute.Tensor):
+        tid, _, _ = cute.arch.thread_idx()
+        bid_m, bid_n, bid_k = cute.arch.block_idx()
+        _, _, split_k = cute.arch.grid_dim()
+
+        warp_id = cute.arch.make_warp_uniform(tid // 32)
+        lane_id = tid % 32
+
+        BN, BM, BK = self.cta_tile
+        num_stages = self.num_stages
+
+        N, K = X_tma.tma_tensor.shape
+        M, _ = W_tma.tma_tensor.shape
+        k_tiles = cute.ceil_div(K, BK)
+
+        smem = cutlass.utils.SmemAllocator()
+        sX = smem.allocate_tensor(
+            BFloat16,
+            X_tma.smem_layout.outer,
+            byte_alignment=128,
+            swizzle=X_tma.smem_layout.inner,
+        )
+        sW = smem.allocate_tensor(
+            Float32,
+            W_tma.smem_layout.outer,
+            byte_alignment=128,
+            swizzle=W_tma.smem_layout.inner,
+        )
+
+        tma_full_mbar = smem.allocate_array(Int64, num_stages)
+        tma_empty_mbar = smem.allocate_array(Int64, num_stages)
+        w_full_mbar = smem.allocate_array(Int64, num_stages)
+        mma_mbar = smem.allocate_array(Int64, 1)
+        taddr = smem.allocate(Int32, 4)
+
+        BAR_TMEM_ALLOC = 1
+        BAR_PREP = 2
+        BAR_EPI = 3
+
+        # tmem "allocation"
+        # acc_main is for the 1st BF16 term. acc_res is for the 2nd and 3rd
+        # BF16 terms, which are much smaller than the first term.
+        acc_main = 0
+        acc_res = BN
+        w_tmem_base = BN * 2
+
+        if warp_id == 0:
+            with cute.arch.elect_one():
+                for i in cutlass.range_constexpr(num_stages):
+                    cute.arch.mbarrier_init(tma_full_mbar + i, 1)
+                    cute.arch.mbarrier_init(tma_empty_mbar + i, 1)
+                    cute.arch.mbarrier_init(w_full_mbar + i, 128)
+                cute.arch.mbarrier_init(mma_mbar, 1)
+                cute.arch.mbarrier_init_fence()
+        elif warp_id == 1:
+            cpasync.prefetch_descriptor(X_tma.atom)
+            cpasync.prefetch_descriptor(W_tma.atom)
+        cute.arch.sync_threads()
+        cute.arch.griddepcontrol_wait()
+
+        if warp_id == 9:
+            # TMA warp
+            stage_id = 0
+            parity = 1
+
+            # (BM, BK, K/BK)
+            gW_tiles = cute.local_tile(W_tma.tma_tensor, (BM, BK), (bid_m, None))
+            gX_tiles = cute.local_tile(X_tma.tma_tensor, (BN, BK), (bid_n, None))
+
+            for tile_k in cutlass.range(bid_k, k_tiles, split_k, unroll=1):
+                cute.arch.mbarrier_wait(tma_empty_mbar + stage_id, parity)
+                mbar = tma_full_mbar + stage_id
+                with cute.arch.elect_one():
+                    stage_bytes = BN * BK * 2 + BM * BK * 4
+                    cute.arch.mbarrier_arrive_and_expect_tx(mbar, stage_bytes)
+                simple_tma_copy(
+                    W_tma.atom,
+                    gW_tiles[None, None, tile_k],
+                    sW[None, None, stage_id],
+                    mbar,
+                )
+                simple_tma_copy(
+                    X_tma.atom,
+                    gX_tiles[None, None, tile_k],
+                    sX[None, None, stage_id],
+                    mbar,
+                )
+
+                stage_id = (stage_id + 1) % num_stages
+                if stage_id == 0:
+                    parity ^= 1
+
+        elif warp_id == 8:
+            # MMA warp
+            stage_id = 0
+            parity = 0
+
+            idesc = _tcgen05.make_bf16_idesc(BM, BN)
+            sdesc = _tcgen05.make_sdesc_128B_swizzle(0)
+
+            for tile_k in cutlass.range(bid_k, k_tiles, split_k, unroll=1):
+                cute.arch.mbarrier_wait(tma_full_mbar + stage_id, parity)
+                cute.arch.mbarrier_wait(w_full_mbar + stage_id, parity)
+                _tcgen05.fence_after_thread_sync()
+
+                w_tmem = w_tmem_base + stage_id * (BK // 2 * 3)
+                x_desc = sdesc | (sX[None, None, stage_id].iterator.toint() >> 4)
+
+                for k in cutlass.range_constexpr(BK // 16):
+                    enable_d = (tile_k > bid_k) or (k > 0)
+                    _tcgen05.mma_ts_f16(
+                        acc_main, w_tmem + k * 8, x_desc, idesc, enable_d
+                    )
+                    _tcgen05.mma_ts_f16(
+                        acc_res, w_tmem + 32 + k * 8, x_desc, idesc, enable_d
+                    )
+                    _tcgen05.mma_ts_f16(
+                        acc_res, w_tmem + 64 + k * 8, x_desc, idesc, True
+                    )
+                    x_desc += 32 >> 4
+
+                _tcgen05.commit(tma_empty_mbar + stage_id)
+
+                stage_id = (stage_id + 1) % self.num_stages
+                if stage_id == 0:
+                    parity ^= 1
+
+            _tcgen05.commit(mma_mbar)
+
+        elif warp_id >= 4:
+            # prep warps: decompose FP32 W into 3xBF16
+            warp_id_ = warp_id % 4
+
+            stage_id = 0
+            parity = 0
+
+            # ld.shared.v4.f32
+            op = cute.nvgpu.CopyUniversalOp()
+            cp_atom = cute.make_copy_atom(op, Float32, num_bits_per_copy=128)
+
+            # sW_view: ((4, 1), (BK/4, num_stages))
+            row = warp_id_ * 32 + lane_id
+            sW_view = cute.zipped_divide(sW[row, None, None], (4, 1))
+
+            for _ in cutlass.range(bid_k, k_tiles, split_k, unroll=1):
+                if warp_id_ == 0:
+                    cute.arch.mbarrier_wait(tma_full_mbar + stage_id, parity)
+                cute.arch.barrier(barrier_id=BAR_PREP, number_of_threads=128)
+
+                row = warp_id_ * 32 + lane_id
+                w_tmem = w_tmem_base + stage_id * (BK // 2 * 3)
+                for kblock in cutlass.range_constexpr(BK // 4):
+                    w0 = cute.make_rmem_tensor(2, Uint32)
+                    w1 = cute.make_rmem_tensor(2, Uint32)
+                    w2 = cute.make_rmem_tensor(2, Uint32)
+
+                    w_tmp = cute.make_rmem_tensor(4, Float32)
+                    cute.copy(cp_atom, sW_view[None, (kblock, stage_id)], w_tmp)
+                    w0[0], w1[0], w2[0] = _decompose_fp32x2_to_3xbf16x2(
+                        w_tmp[0], w_tmp[1]
+                    )
+                    w0[1], w1[1], w2[1] = _decompose_fp32x2_to_3xbf16x2(
+                        w_tmp[2], w_tmp[3]
+                    )
+
+                    tcol = kblock * 2
+                    _tcgen05.st(warp_id_ * 32, w_tmem + 0 + tcol, "32x32b", 2, w0)
+                    _tcgen05.st(warp_id_ * 32, w_tmem + 32 + tcol, "32x32b", 2, w1)
+                    _tcgen05.st(warp_id_ * 32, w_tmem + 64 + tcol, "32x32b", 2, w2)
+
+                _tcgen05.wait_st()
+                _tcgen05.fence_before_thread_sync()
+                cute.arch.mbarrier_arrive(w_full_mbar + stage_id)
+
+                stage_id = (stage_id + 1) % self.num_stages
+                if stage_id == 0:
+                    parity ^= 1
+
+        else:
+            # epilogue warps
+            if warp_id == 0:
+                _tcgen05.alloc(taddr)
+            cute.arch.barrier(barrier_id=BAR_TMEM_ALLOC, number_of_threads=128)
+
+            if warp_id == 0:
+                cute.arch.mbarrier_wait(mma_mbar, 0)
+            cute.arch.barrier(barrier_id=BAR_EPI, number_of_threads=128)
+            _tcgen05.fence_after_thread_sync()
+
+            cute.arch.griddepcontrol_launch_dependents()
+
+            WIDTH = 8
+            for i in cutlass.range_constexpr(BN // WIDTH):
+                tcol = i * WIDTH
+                main_regs = cute.make_rmem_tensor(WIDTH, Float32)
+                res_regs = cute.make_rmem_tensor(WIDTH, Float32)
+                main_regs.store(_tcgen05.ld(warp_id * 32, tcol, "32x32b", WIDTH))
+                res_regs.store(_tcgen05.ld(warp_id * 32, BN + tcol, "32x32b", WIDTH))
+                _tcgen05.wait_ld()
+
+                # CuteDSL will codegen add.f32x2
+                for j in cutlass.range(WIDTH, vectorize=True):
+                    main_regs[j] += res_regs[j]
+
+                w_row_idx = bid_m * BM + tid
+                for j in cutlass.range_constexpr(WIDTH):
+                    x_row_idx = bid_n * BN + i * WIDTH + j
+                    if x_row_idx < N and w_row_idx < M:
+                        out[bid_k, x_row_idx, w_row_idx] = main_regs[j]
+
+            cute.arch.barrier(barrier_id=BAR_EPI, number_of_threads=128)
+            if warp_id == 0:
+                _tcgen05.dealloc()
+
+    @cache
+    @staticmethod
+    def compile(BN: int = 128, K: int = 6144):
+        N = cute.sym_int()
+        M = cute.sym_int()
+        SPLIT_K = cute.sym_int()
+        X = make_fake_tensor(BFloat16, (N, K), divisibility=8)
+        W = make_fake_tensor(Float32, (M, K), divisibility=4)
+        out = make_fake_tensor(Float32, (SPLIT_K, N, M), divisibility=16)
+        stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+        kernel = Sm100BF16x3RouterGemm(BN)
+        return cute.compile(
+            kernel, X, W, out, Int32(1), stream, options="--enable-tvm-ffi"
+        )
+
+
+@triton.jit
+def _splitk_reduce_kernel(
+    partials,
+    out,
+    N,
+    M: tl.constexpr,
+    split_stride,
+    k_splits,
+    BN: tl.constexpr,
+    BM: tl.constexpr,
+    BS: tl.constexpr,
+    USE_PDL: tl.constexpr,
+):
+    pid_n = tl.program_id(0)
+    pid_m = tl.program_id(1)
+    offs_n = pid_n * BN + tl.arange(0, BN)
+    offs_m = pid_m * BM + tl.arange(0, BM)
+    offs_s = tl.arange(0, BS)
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
+
+    vals = tl.load(
+        partials
+        + offs_s[:, None, None] * split_stride
+        + offs_n[None, :, None] * M
+        + offs_m[None, None, :],
+        mask=(
+            (offs_s[:, None, None] < k_splits)
+            & (offs_n[None, :, None] < N)
+            & (offs_m[None, None, :] < M)
+        ),
+        other=0.0,
+    )
+    acc = tl.sum(vals, axis=0)
+    tl.store(
+        out + offs_n[:, None] * M + offs_m[None, :],
+        acc,
+        mask=(offs_n[:, None] < N) & (offs_m[None, :] < M),
+    )
+
+
+def splitk_reduce_triton(partials: torch.Tensor, out: torch.Tensor):
+    split_k, N, M = partials.shape
+    block_s = 1 << (split_k - 1).bit_length()
+    split_stride = partials.stride(0)
+    if block_s >= 64:
+        BN, BM = 1, 32
+    elif block_s >= 8:
+        BN, BM = 1, 256
+    else:
+        BN, BM = min(16, 32 // block_s), 32
+    grid = (triton.cdiv(N, BN), triton.cdiv(M, BM))
+    _splitk_reduce_kernel[grid](
+        partials,
+        out,
+        N,
+        M,
+        split_stride,
+        split_k,
+        BN=BN,
+        BM=BM,
+        BS=block_s,
+        USE_PDL=True,
+        num_warps=4,
+        launch_pdl=True,
+    )
+
+
+def bf16x3_router_gemm(X: torch.Tensor, W: torch.Tensor) -> torch.Tensor:
+    """Return ``X @ W.T`` using the SM100 BF16x3 router GEMM kernel."""
+    N, K = X.shape
+    M, _ = W.shape
+    num_sms = torch.cuda.get_device_properties(X.device).multi_processor_count
+
+    # next power of 2 within 8 and 128
+    BN = triton.next_power_of_2(N)
+    BN = min(max(BN, 8), 128)
+
+    BM = 128
+    BK = 64
+    k_tiles = math_utils.cdiv(K, BK)
+    grid_m = math_utils.cdiv(M, BM)
+    grid_n = math_utils.cdiv(N, BN)
+
+    base_ctas = grid_m * grid_n
+    split_k = min(k_tiles, max(1, num_sms // base_ctas))
+
+    partials = X.new_empty(split_k, N, M, dtype=torch.float32)
+    Sm100BF16x3RouterGemm.compile(BN, K)(X, W, partials, split_k)
+
+    if split_k == 1:
+        return partials.squeeze(0)
+
+    out = X.new_empty(N, M, dtype=torch.float32)
+    splitk_reduce_triton(partials, out)
+    return out

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -4,10 +4,14 @@ import torch
 from torch.nn.parameter import Parameter
 
 import vllm._custom_ops as ops
+from vllm.config import get_current_vllm_config_or_none
+from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
+
+logger = init_logger(__name__)
 
 
 @PluggableLayer.register("gate_linear")
@@ -19,8 +23,9 @@ class GateLinear(ReplicatedLinear):
     2. DSV3 specialized kernel (SM90+, M<=16, H=7168 E=256/384, H=6144 E=256)
     3. fp32 specialized kernel  (SM90+, bf16/fp32 in, fp32 out, M<=32,
        (H, E) in {(3072, 256), (6144, 128), (6144, 256)})
-    4. cuBLAS bf16×bf16→fp32 (SM90+ + bf16 weight + fp32 out_dtype)
-    5. F.linear via ReplicatedLinear (ultimate fallback)
+    4. experimental bf16x3 CuteDSL kernel (opt-in, SM100, bf16 in, fp32 weight)
+    5. cuBLAS bf16×bf16→fp32 (SM90+ + bf16 weight + fp32 out_dtype)
+    6. F.linear via ReplicatedLinear (ultimate fallback)
 
     The ``out_dtype`` attribute is mutable and can be set after init
     (e.g. when the required dtype depends on the expert quantization
@@ -86,6 +91,11 @@ class GateLinear(ReplicatedLinear):
         self._dsv3_max_batch = 16 if is_hopper else 8
 
         # fp32 specialized kernel eligibility (SM90+, exact dims, fp32 weight)
+        vllm_config = get_current_vllm_config_or_none()
+        enable_bf16x3_router_gemm = (
+            vllm_config is not None
+            and vllm_config.kernel_config.enable_bf16x3_router_gemm
+        )
         self.allow_fp32_router_gemm = (
             not bias
             and self.weight.dtype == torch.float32
@@ -93,6 +103,16 @@ class GateLinear(ReplicatedLinear):
             and (is_hopper or is_blackwell)
             and (input_size, output_size) in self.FP32_SUPPORTED_SHAPES
         )
+        self.allow_bf16x3_router_gemm = (
+            not bias
+            and self.weight.dtype == torch.float32
+            and current_platform.is_cuda()
+            and is_blackwell
+            and input_size % 8 == 0
+            and enable_bf16x3_router_gemm
+        )
+        if self.allow_bf16x3_router_gemm:
+            logger.info_once("Enabled experimental SM100 BF16x3 router GEMM.")
 
         # cuBLAS bf16→fp32 eligibility
         self.allow_cublas_router_gemm = (
@@ -173,15 +193,26 @@ class GateLinear(ReplicatedLinear):
             torch.float32,
             torch.bfloat16,
         ):
-            output = torch.ops.vllm.fp32_router_gemm_dispatch(x, self.weight)
+            output = torch.ops.vllm.fp32_router_gemm_dispatch(
+                x, self.weight, self.allow_bf16x3_router_gemm
+            )
             return output, None
 
-        # Tier 4: cuBLAS bf16→fp32
+        # Tier 4: experimental bf16x3 CuteDSL kernel for fp32 router weights
+        if self.allow_bf16x3_router_gemm and x.dtype == torch.bfloat16:
+            from vllm.model_executor.layers.fused_moe.router.bf16x3_router_gemm_cutedsl import (  # noqa: E501
+                bf16x3_router_gemm,
+            )
+
+            output = bf16x3_router_gemm(x, self.weight)
+            return output, None
+
+        # Tier 5: cuBLAS bf16→fp32
         if self.allow_cublas_router_gemm and x.dtype == torch.bfloat16:
             output = torch.mm(x, self.weight.T, out_dtype=torch.float32)
             return output, None
 
-        # Tier 5: F.linear (ReplicatedLinear)
+        # Tier 6: F.linear (ReplicatedLinear)
         if self.out_dtype is not None and x.dtype != self.weight.dtype:
             x = x.to(self.weight.dtype)
         output, output_bias = super().forward(x)
@@ -194,22 +225,34 @@ _FP32_ROUTER_GEMM_MAX_TOKENS = GateLinear.FP32_MAX_TOKENS
 
 
 def fp32_router_gemm_dispatch_impl(
-    x: torch.Tensor, weight: torch.Tensor
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    allow_bf16x3_router_gemm: bool,
 ) -> torch.Tensor:
     """
     Dynamically run fp32 specialized gemm if num_tokens <= FP32_MAX_TOKENS,
-    otherwise fall back to F.linear.
+    otherwise optionally run the experimental BF16x3 kernel for medium/large
+    SM100 router batches, then fall back to F.linear.
     This must be wrapped in a custom op because our torch.compile integration
     does not support runtime dispatching on num_tokens.
     """
     if x.shape[0] <= _FP32_ROUTER_GEMM_MAX_TOKENS:
         return ops.fp32_router_gemm(x, weight)
-    else:
-        return torch.nn.functional.linear(x.float(), weight)
+
+    if allow_bf16x3_router_gemm and x.dtype == torch.bfloat16:
+        from vllm.model_executor.layers.fused_moe.router.bf16x3_router_gemm_cutedsl import (  # noqa: E501
+            bf16x3_router_gemm,
+        )
+
+        return bf16x3_router_gemm(x, weight)
+
+    return torch.nn.functional.linear(x.float(), weight)
 
 
 def fp32_router_gemm_dispatch_fake(
-    x: torch.Tensor, weight: torch.Tensor
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    allow_bf16x3_router_gemm: bool,
 ) -> torch.Tensor:
     return x.new_empty((x.shape[0], weight.shape[0]), dtype=torch.float32)
 


### PR DESCRIPTION
This PR is inspired by CuBLAS BF16x9: https://developer.nvidia.com/blog/unlocking-tensor-core-performance-with-floating-point-emulation-in-cublas/

## Background

All FP32 numbers, including subnormals, can be represented exactly by a (weighted) sum of 3 BF16 numbers. This is because FP32 has 24 mantissa bits (including the implicit `1.xxx` for normal numbers) and BF16 has 8 mantissa bits.

A simple procedure to get this decompsition

```
x: FP32 value

x0_f32 = x;                 x0 = BF16(x0_f32)
x1_f32 = x0_f32 - FP32(x0); x1 = BF16(x1_f32)
x2_f32 = x1_f32 - FP32(x1); x2 = BF16(x2_f32)

=> x = x0 + x1 + x2
```

This is fine for normal numbers, but if we want to handle subnormals correctly as well, we need to scale the subnormal range of FP32 back to representable subnormal range of BF16

```
x: FP32 value

x0_f32 = x;                         x0 = BF16(x0_f32)
x1_f32 = (x0_f32 - FP32(x0)) * 2^8; x1 = BF16(x1_f32)
x2_f32 = (x1_f32 - FP32(x1)) * 2^8; x2 = BF16(x2_f32)

=> x = x0 + x1 * 2^-8 + x2 * 2^-16
```

## Proposed change

For router gemm with FP32 weight, input is already in BF16, while weight remains in FP32. Hence, we only need to decompose weight into 3xBF16 and performs 3 BF16 MMA for each weight tile. This significantly reduces amount of MMA work compared to CuBLAS BF16x9 scheme.

For this PR, I go with the simpler route of not doing extra scaling to handle subnormals. 3xBF16 decomposition is done in-kernel. Split-K design is also adopted for SM-limited shapes, with a separate split-K reduction kernel (instead of atomic add to global buffer) to ensure deterministic result.

I also use 2 MMA accumulation buffers inside the kernel, one for the first BF16 value, and the other for the two residual BF16 values. This is because the residual is much smaller than the first BF16, hence sharing the same accumulator can lead to "small number add to a large number". From my local development experiments, using 2 MMA buffers improves MAE with respect to FP64 reference by 3 times (half order of magnitude).

Enabling BF16x3 router GEMM requires an explicit opt-in via `--enable-bf16x3-router-gemm` flag.

## Microbenchmark

<details>
<summary>Benchmark Script</summary>

```python
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
"""CUDA graph + rotating-buffer router GEMM benchmark.

This measures the useful captured span for a sequence of independent buffer
sets. Rotating buffers reduce data-cache reuse without inserting a flush kernel
inside the measured region.
"""

from __future__ import annotations

import argparse
import statistics
from collections.abc import Callable
from typing import Any

import torch

from vllm.model_executor.layers.fused_moe.router.bf16x3_router_gemm_cutedsl import (
    bf16x3_router_gemm,
)
from vllm import _custom_ops as ops

WARMUP = 10
REPEATS = 50
AUTO_ROTATION_L2_MULTIPLIER = 2


def cdiv(a: int, b: int) -> int:
    return (a + b - 1) // b


def csv_note(text: str) -> str:
    return text.replace(",", ";")


def table_note(text: str, max_len: int = 48) -> str:
    text = text.replace("\n", " ")
    if len(text) <= max_len:
        return text
    return text[: max_len - 1] + "…"


def print_summary_table(rows: list[dict[str, Any]]) -> None:
    if not rows:
        return

    import pandas as pd

    provider_labels = {
        "vllm_fp32_router_gemm": "vLLM FP32",
        "torch_fp32_linear_no_tf32": "torch FP32",
        "torch_fp32_linear_tf32": "torch TF32",
        "cutedsl": "CuteDSL",
    }
    provider_order = [
        "vllm_fp32_router_gemm",
        "torch_fp32_linear_no_tf32",
        "torch_fp32_linear_tf32",
        "cutedsl",
    ]

    rows_by_m: dict[int, dict[str, str | int]] = {}
    for row in rows:
        row_data = rows_by_m.setdefault(row["M"], {"M": row["M"]})
        row_data["rotations"] = row["rotations"]
        provider = provider_labels[row["provider"]]
        row_data[f"{provider} us"] = (
            "" if row["graph_us"] is None else f"{row['graph_us']:.3f}"
        )
        row_data[f"{provider} MAE"] = "" if row["mae"] is None else f"{row['mae']:.6g}"

    columns = ["M", "rotations"]
    for provider in provider_order:
        label = provider_labels[provider]
        columns.extend([f"{label} us", f"{label} MAE"])

    formatted_rows = []
    for m in sorted(rows_by_m):
        formatted_rows.append(
            {column: rows_by_m[m].get(column, "") for column in columns}
        )

    print("\nsummary:", flush=True)
    print(
        pd.DataFrame(formatted_rows, columns=columns).to_markdown(index=False),
        flush=True,
    )


def estimate_useful_footprint_bytes(m: int, n: int, k: int) -> int:
    x_bytes = m * k * 2
    w_bytes = n * k * 4
    out_bytes = m * n * 4
    return x_bytes + w_bytes + out_bytes


def choose_rotations(m: int, n: int, k: int, requested: int | None) -> int:
    if requested is not None:
        return requested

    properties = torch.cuda.get_device_properties()
    footprint = estimate_useful_footprint_bytes(m, n, k)
    target = properties.L2_cache_size * AUTO_ROTATION_L2_MULTIPLIER
    return max(2, cdiv(target, footprint))


def graph_span_us(fn: Callable[[int], object], rotations: int) -> float:
    for _ in range(WARMUP):
        for i in range(rotations):
            fn(i)
    torch.accelerator.synchronize()

    start = torch.cuda.Event(enable_timing=True, external=True)
    end = torch.cuda.Event(enable_timing=True, external=True)
    graph = torch.cuda.CUDAGraph()
    with torch.cuda.graph(graph):
        start.record()
        for i in range(rotations):
            fn(i)
        end.record()

    times = []
    for _ in range(REPEATS):
        graph.replay()
        end.synchronize()
        times.append(start.elapsed_time(end) * 1000 / rotations)
    return statistics.median(times)


def make_inputs(
    rotations: int,
    m: int,
    n: int,
    k: int,
    activation_std: float,
    weight_std: float,
) -> tuple[torch.Tensor, torch.Tensor]:
    a = torch.randn((rotations, m, k), dtype=torch.float32)
    a = (a * activation_std).to(torch.bfloat16)
    weight = torch.randn((rotations, n, k), dtype=torch.float32) * weight_std
    return a, weight


def benchmark_case(
    candidate: str,
    rotations: int,
    m: int,
    n: int,
    k: int,
    activation_std: float,
    weight_std: float,
) -> tuple[float | None, float | None, str]:
    a, weight = make_inputs(
        rotations,
        m,
        n,
        k,
        activation_std,
        weight_std,
    )

    def mae(actual: torch.Tensor) -> float:
        ref = torch.nn.functional.linear(a[0].double(), weight[0].double())
        return (actual.double() - ref).abs().mean().item()

    if candidate in {
        "torch_fp32_linear_no_tf32",
        "torch_fp32_linear_tf32",
    }:
        allow_tf32 = candidate == "torch_fp32_linear_tf32"
        old_tf32 = torch.backends.cuda.matmul.allow_tf32
        torch.backends.cuda.matmul.allow_tf32 = allow_tf32

        def fn(i: int) -> torch.Tensor:
            return torch.mm(a[i].float(), weight[i].T)

        try:
            actual = fn(0)
            torch.accelerator.synchronize()
            err = mae(actual)
            graph_us = graph_span_us(fn, rotations)
            return graph_us, err, "includes_bf16_to_fp32_cast"
        finally:
            torch.backends.cuda.matmul.allow_tf32 = old_tf32

    if candidate == "vllm_fp32_router_gemm":

        def fn(i: int) -> torch.Tensor:
            return ops.fp32_router_gemm(a[i], weight[i])

        try:
            actual = fn(0)
            torch.accelerator.synchronize()
            err = mae(actual)
            return graph_span_us(fn, rotations), err, ""
        except Exception as exc:  # noqa: BLE001
            torch.accelerator.synchronize()
            return None, None, f"skipped: {str(exc).splitlines()[0]}"

    if candidate == "cutedsl":

        def fn(i: int) -> torch.Tensor:
            return bf16x3_router_gemm(
                a[i],
                weight[i],
            )

        actual = fn(0)
        torch.accelerator.synchronize()
        err = mae(actual)
        return graph_span_us(fn, rotations), err, ""

    raise ValueError(f"unknown candidate: {candidate}")


def main() -> None:
    parser = argparse.ArgumentParser()
    parser.add_argument(
        "--m",
        type=int,
        nargs="*",
        default=[
            1,
            2,
            4,
            8,
            16,
            32,
            48,
            64,
            96,
            128,
            256,
            512,
            1024,
            2048,
            4096,
            8192,
        ],
    )
    parser.add_argument("--n", type=int, default=128)
    parser.add_argument("--k", type=int, default=6144)
    parser.add_argument("--activation-std", type=float, default=1.0)
    parser.add_argument(
        "--weight-std",
        type=float,
        default=0.053,
        help="router weight std; 0.053 matches early MiniMax router layers",
    )
    parser.add_argument(
        "--rotations",
        type=int,
        default=None,
        help="fixed rotating-buffer count; omitted uses an L2-footprint heuristic",
    )
    parser.add_argument(
        "--candidate",
        choices=(
            "all",
            "torch_fp32_linear_no_tf32",
            "torch_fp32_linear_tf32",
            "vllm_fp32_router_gemm",
            "cutedsl",
        ),
        default="all",
    )
    parser.add_argument("--seed", type=int, default=0)
    args = parser.parse_args()

    if not torch.cuda.is_available():
        raise RuntimeError("CUDA is required")
    torch.set_default_device("cuda")
    torch.manual_seed(args.seed)

    candidates = [
        "vllm_fp32_router_gemm",
        "torch_fp32_linear_no_tf32",
        "torch_fp32_linear_tf32",
        "cutedsl",
    ]
    if args.candidate != "all":
        candidates = [args.candidate]

    print(
        f"device={torch.cuda.get_device_name()} capability="
        f"{torch.cuda.get_device_capability()} rotations="
        f"{args.rotations if args.rotations is not None else 'auto'} "
        f"shape=N{args.n}xK{args.k} activation_std={args.activation_std} "
        f"weight_std={args.weight_std}",
        flush=True,
    )
    print(
        "M,rotations,provider,graph_us,tflops_graph,mae,notes",
        flush=True,
    )

    rows: list[dict[str, Any]] = []
    for m in args.m:
        rotations = choose_rotations(m, args.n, args.k, args.rotations)
        for candidate in candidates:
            graph_us, mae, notes = benchmark_case(
                candidate,
                rotations,
                m,
                args.n,
                args.k,
                args.activation_std,
                args.weight_std,
            )
            if graph_us is None:
                print(
                    f"{m},{rotations},{candidate},,,,{csv_note(notes)}",
                    flush=True,
                )
                rows.append(
                    {
                        "M": m,
                        "rotations": rotations,
                        "provider": candidate,
                        "graph_us": None,
                        "tflops_graph": None,
                        "mae": None,
                        "notes": notes,
                    }
                )
                continue
            tflops = 2 * m * args.n * args.k / (graph_us * 1e6)
            print(
                f"{m},{rotations},{candidate},{graph_us:.3f},{tflops:.3f},"
                f"{mae:.6g},{csv_note(notes)}",
                flush=True,
            )
            rows.append(
                {
                    "M": m,
                    "rotations": rotations,
                    "provider": candidate,
                    "graph_us": graph_us,
                    "tflops_graph": tflops,
                    "mae": mae,
                    "notes": notes,
                }
            )

    print_summary_table(rows)


if __name__ == "__main__":
    main()
```

</details>

K=6144, N=256 (GLM-5.2 shape). MAE is computed against FP64 reference

On GB200

M | vLLM FP32 us/MAE | torch FP32 us/MAE | torch TF32 us/MAE | CuteDSL us/MAE
-- | -- | -- | -- | --
1 | 1.96 / 3.76e-7 | 7.52 / 3.29e-7 | 10.9 / 4.44e-7 | 4.30 / 3.24e-7
2 | 2.03 / 3.66e-7 | 71.8 / 4.56e-7 | 19.6 / 7.08e-4 | 4.32 / 3.44e-7
4 | 2.21 / 3.79e-7 | 20.2 / 8.74e-7 | 12.0 / 6.85e-4 | 4.47 / 3.24e-7
8 | 2.61 / 3.85e-7 | 16.7 / 7.75e-7 | 12.0 / 7.01e-4 | 4.52 / 3.21e-7
16 | 3.88 / 4.26e-7 | 22.3 / 9.93e-7 | 12.2 / 6.92e-4 | 5.04 / 3.26e-7
32 | 5.57 / 4.36e-7 | 63.2 / 1.43e-6 | 19.9 / 6.97e-4 | 5.84 / 3.30e-7
48 |   | 63.4 / 1.42e-6 | 20.0 / 6.91e-4 | 7.11 / 3.29e-7
64 |   | 63.3 / 1.45e-6 | 20.1 / 6.89e-4 | 7.52 / 3.24e-7
96 |   | 64.1 / 1.47e-6 | 20.2 / 6.89e-4 | 10.2 / 3.25e-7
128 |   | 69.3 / 1.46e-6 | 20.2 / 6.88e-4 | 11.0 / 3.29e-7
256 |   | 77.8 / 1.54e-6 | 22.6 / 6.87e-4 | 12.0 / 3.80e-7
512 |   | 96.8 / 1.54e-6 | 25.8 / 6.94e-4 | 14.6 / 5.45e-7
1024 |   | 111 / 1.54e-6 | 32.8 / 6.86e-4 | 17.3 / 9.84e-7
2048 |   | 167 / 4.09e-6 | 47.8 / 6.88e-4 | 23.9 / 2.13e-6
4096 |   | 236 / 4.09e-6 | 88.3 / 6.88e-4 | 34.2 / 5.05e-6
8192 |   | 363 / 4.10e-6 | 175 / 6.87e-4 | 59.0 / 1.06e-5

On B300

M | vLLM FP32 us/MAE | torch FP32 us/MAE | torch TF32 us/MAE | CuteDSL us/MAE
-- | -- | -- | -- | --
1 | 2.01 / 3.71e-7 | 7.67 / 3.87e-7 | 11.2 / 4.17e-7 | 4.52 / 3.49e-7
2 | 2.07 / 3.87e-7 | 72.5 / 4.65e-7 | 20.1 / 6.53e-4 | 4.56 / 3.28e-7
4 | 2.27 / 3.86e-7 | 20.4 / 9.04e-7 | 12.1 / 6.63e-4 | 4.55 / 3.27e-7
8 | 2.64 / 3.86e-7 | 16.9 / 7.91e-7 | 12.4 / 7.04e-4 | 4.71 / 3.16e-7
16 | 3.89 / 4.20e-7 | 22.6 / 9.84e-7 | 12.5 / 6.89e-4 | 5.20 / 3.20e-7
32 | 5.56 / 4.26e-7 | 63.3 / 1.43e-6 | 20.4 / 6.96e-4 | 6.00 / 3.24e-7
48 |   | 63.5 / 1.46e-6 | 20.5 / 6.88e-4 | 7.27 / 3.27e-7
64 |   | 64.1 / 1.48e-6 | 20.6 / 6.87e-4 | 7.71 / 3.31e-7
96 |   | 65.6 / 1.45e-6 | 20.6 / 6.84e-4 | 10.2 / 3.26e-7
128 |   | 68.7 / 1.46e-6 | 20.7 / 6.89e-4 | 11.1 / 3.26e-7
256 |   | 83.1 / 1.55e-6 | 23.1 / 6.95e-4 | 12.1 / 3.88e-7
512 |   | 92.6 / 1.53e-6 | 25.5 / 6.85e-4 | 14.6 / 5.53e-7
1024 |   | 115 / 1.53e-6 | 33.0 / 6.88e-4 | 17.3 / 1.05e-6
2048 |   | 171 / 4.09e-6 | 49.7 / 6.88e-4 | 23.9 / 2.12e-6
4096 |   | 240 / 4.08e-6 | 91.7 / 6.87e-4 | 34.6 / 5.06e-6
8192 |   | 370 / 4.09e-6 | 181 / 6.88e-4 | 58.9 / 1.06e-5

Observations
- BF16x3 is both faster and more accurate than TF32
- BF16x3 MAE is worsened with larger M. This is because we use smaller split-K as M grows (at M=8192, there is no split-K anymore). Apparently, since K=6144 is too large, a long chain of BF16 MMA leads to inaccurate accumulation (6144/16=384), so having split-K improves MAE as we break it into smaller chains and do final accumulation of numbers of similar magnitude.
  - If this is important, we can explore other ways to improve accuracy at large M later e.g. extra accumulation buffers

## E2E benchmark

### Prefill

4xGB200, `MiniMaxAI/MiniMax-M3-MXFP8`, DEP4, FP8 indexer and FP8 attention. Rust frontend

```
vllm serve MiniMaxAI/MiniMax-M3-MXFP8 --port 8000
-dp 4 -ep
--enable-ep-weight-filter
--block-size 128
--language-model-only
--max-model-len 256000
--kv-cache-dtype fp8
--attention-config '{"backend":"FLASHINFER","use_trtllm_attention":true,"indexer_kv_dtype":"fp8"}'
--no-enable-flashinfer-autotune
--no-enable-prefix-caching
```

1000 prompts, 8k-1, concurrency 16

```
vllm-bench
--backend vllm
--base-url http://0.0.0.0:8000
--model MiniMaxAI/MiniMax-M3-MXFP8
--dataset-name random
--random-prefix-len 0
--random-input-len 8192
--random-output-len 1
--num-warmups 10
--max-concurrency 16
--num-prompts 1000
--prompt-token-ids
--percentile-metrics "ttft,tpot,itl,e2el"
--result-dir "{log_dir}/speed-bench"
--save-result
```

Branch | Prefill TPGS | P50 TTFT
---|---|---
main (FP32) | 18,784 tok/s | 1.74 s
main (TF32, `VLLM_FLOAT32_MATMUL_PRECISION=high`) | 19,514 tok/s (+3.9%) | 1.68 s (-3.4%)
this PR (BF16x3) | 19,812 tok/s (+5.5%) | 1.65 s (-5.2%)

### High throughput decode

4xGB200, `MiniMaxAI/MiniMax-M3-MXFP8`, TEP4, FP8 indexer and FP8 attention. Rust frontend

```
vllm serve MiniMaxAI/MiniMax-M3-MXFP8--port 8000
-tp 4 -ep
--enable-ep-weight-filter
--block-size 128
--language-model-only
--max-model-len 256000
--kv-cache-dtype fp8
--attention-config '{"backend":"FLASHINFER","use_trtllm_attention":true,"indexer_kv_dtype":"fp8"}'
--max-num-seqs 64
--no-enable-flashinfer-autotune
```

1000 prompts, 8k-1k, concurrency 200. Why?
- Share the same 8k prefix among all requests so that we only measure decode time. From my experience, this is more reliable than using `DecodeBenchConnector`
- Instead of benchmarking with concurrency=64, I do `--max-num-seqs 64` and concurrency=200 instead. High concurrency at the client side to drive backpressure for the server, while vLLM ensures `--max-num-seqs 64`. This avoids the situation where there might be fewer than 64 running requests when concurrency=64 is used instead, due to scheduling etc...

```
vllm-bench
--backend vllm
--base-url http://0.0.0.0:8000
--model MiniMaxAI/MiniMax-M3-MXFP8--port 8000
--dataset-name random
--random-prefix-len 8192
--random-input-len 0
--random-output-len 1024
--num-warmups 10
--max-concurrency 200
--num-prompts 1000
--prompt-token-ids
--percentile-metrics "ttft,tpot,itl,e2el"
--metric-percentiles 50,90,99
--result-dir "{log_dir}/speed-bench"
--save-result
```

Branch | Decode TPGS | P50 TPOT
---|---|---
main (FP32) | 737 tok/s | 21.08 ms
main (TF32, `VLLM_FLOAT32_MATMUL_PRECISION=high`) | 840 tok/s (+14.0%) | 18.25 ms (-13.4%)
this PR (BF16x3) | 867 tok/s (+17.6%) | 17.84 ms (-15.4%)

## Correctness

AIME25: pass@4 0.9333

## Ideas for future work

- Exploit B300 features e.g. `tcgen05.ld.red`
- Large M probably requires a separate kernel design, such as separate BF16x3 decomposition kernel so that it can be reused among `grid_m` CTAs
- Small ideas like storing decomposed BF16 Weight in smem (instead of tmem like in current design) so that we can use a deeper pipeline. Use smem staging for TMA epilogue store (right now it's direct rmem->gmem stores)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>