### PR TITLE
[Misc] Add unit test for fused_recurrent_gated_delta_rule kernel

### DIFF
--- a/tests/kernels/test_fused_recurrent_gated_delta_rule.py
+++ b/tests/kernels/test_fused_recurrent_gated_delta_rule.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Precision tests for vllm's fused_recurrent_gated_delta_rule Triton operator.
+
+Exercises fused_recurrent_gated_delta_rule_fwd_kernel via its Python wrapper.
+The kernel runs the gated delta rule recurrence over a sequence, maintaining a
+per-head hidden state h of shape (V, K). Per timestep it decays the state by a
+scalar gate, applies the delta-rule correction to v, updates the state with the
+outer product v^T @ k, and reads out o = h @ (q * scale). Compared against a
+naive float32 PyTorch reference.
+
+Source: vllm/model_executor/layers/fla/ops/fused_recurrent.py
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.fla.ops.fused_recurrent import (
+    fused_recurrent_gated_delta_rule_fwd,
+)
+from vllm.platforms import current_platform
+
+# fused_recurrent_gated_delta_rule_fwd dispatches a Triton kernel
+# that requires a GPU-class backend.
+if not (current_platform.is_cuda_alike() or current_platform.is_xpu()):
+    pytest.skip(
+        "fused_recurrent_gated_delta_rule Triton kernel requires a "
+        "CUDA-alike or XPU device",
+        allow_module_level=True,
+    )
+
+DEVICE = current_platform.device_type
+
+
+def fused_recurrent_gated_delta_rule_ref(
+    q, k, v, g, beta, scale, initial_state, indices,
+    use_qk_l2norm=False,
+):
+    """Naive float32 reference for the gated delta rule recurrence.
+
+    Args:
+        q, k: (B, T, H, K) — queries / keys.
+        v: (B, T, HV, V) — values (HV >= H for grouped value attention).
+        g: (B, T, HV) — per-(head, timestep) scalar log-decay.
+        beta: (B, T, HV) — per-(head, timestep) scalar update weight.
+        scale: float applied to q before the read-out.
+        initial_state: (Nstate, HV, V, K) — hidden state pool.
+        indices: (B,) which row of initial_state each sequence uses (> 0).
+
+    Returns:
+        o: (B, T, HV, V) — outputs.
+        final_state: (Nstate, HV, V, K) — state pool after the last timestep.
+    """
+    B, T, H, K = q.shape
+    HV, V = v.shape[2], v.shape[3]
+    rep = HV // H  # value heads per qk head (1 when HV == H)
+
+    o = torch.zeros(B, T, HV, V, dtype=torch.float32, device=q.device)
+    final_state = initial_state.float().clone()
+
+    for b in range(B):
+        for hv in range(HV):
+            h = hv // rep
+            sidx = int(indices[b])
+            s = initial_state[sidx, hv].float().clone()  # (V, K)
+
+            for t in range(T):
+                q_t = q[b, t, h].float()  # (K,)
+                k_t = k[b, t, h].float()  # (K,)
+                v_t = v[b, t, hv].float()  # (V,)
+
+                if use_qk_l2norm:
+                    q_t = q_t / torch.sqrt((q_t * q_t).sum() + 1e-6)
+                    k_t = k_t / torch.sqrt((k_t * k_t).sum() + 1e-6)
+                q_t = q_t * scale
+
+                s = s * torch.exp(g[b, t, hv].float())  # decay
+                v_new = v_t - s @ k_t  # delta-rule correction (V,)
+                v_new = v_new * beta[b, t, hv].float()
+                s = s + torch.outer(v_new, k_t)  # state update (V, K)
+                o[b, t, hv] = s @ q_t
+
+            final_state[sidx, hv] = s
+
+    return o, final_state
+
+
+def _make_inputs(B, T, H, HV, K, V, dtype=torch.float32, use_initial_state=True):
+    # Scales chosen so the recurrent output stays O(1) across all sequence
+    # lengths used here. The delta-rule recurrence amplifies the state with T:
+    # q,k ~ 0.5 already blows up to ~1e3 by T=16, which makes the comparison
+    # dominated by rtol on huge values; q,k ~ 0.25 keeps |o| in [0.5, 1.5] for
+    # T up to 32 so the test exercises a numerically healthy regime.
+    q = torch.randn(B, T, H, K, device=DEVICE, dtype=dtype) * 0.25
+    k = torch.randn(B, T, H, K, device=DEVICE, dtype=dtype) * 0.25
+    v = torch.randn(B, T, HV, V, device=DEVICE, dtype=dtype)
+    g = torch.randn(B, T, HV, device=DEVICE, dtype=torch.float32) * 0.05
+    beta = torch.rand(B, T, HV, device=DEVICE, dtype=torch.float32).sigmoid()
+
+    # Continuous-batching state pool: index 0 is NULL_BLOCK_ID (skipped by the
+    # kernel), so sequences map to rows 1..B. ssm_state_indices is (B, T) with a
+    # constant row per sequence.
+    n_state = B + 1
+    if use_initial_state:
+        initial_state = torch.randn(
+            n_state, HV, V, K, device=DEVICE, dtype=torch.float32
+        ) * 0.01
+    else:
+        initial_state = torch.zeros(
+            n_state, HV, V, K, device=DEVICE, dtype=torch.float32
+        )
+    indices = torch.arange(1, B + 1, device=DEVICE, dtype=torch.int32)
+    ssm_state_indices = indices.unsqueeze(1).expand(B, T).contiguous()
+    return q, k, v, g, beta, initial_state, indices, ssm_state_indices
+
+
+# (B, T, H, HV, K, V, use_init) — HV > H exercises grouped value attention.
+CONFIGS = [
+    (1, 8, 4, 4, 64, 64, True),
+    (2, 8, 4, 4, 64, 64, True),
+    (1, 16, 4, 4, 64, 64, True),
+    (1, 8, 4, 4, 64, 64, False),  # zero initial state
+    (1, 8, 2, 4, 64, 64, True),  # GVA: HV = 2 * H
+    (1, 8, 4, 4, 128, 128, True),  # K = V = 128
+    (2, 32, 4, 8, 64, 64, True),  # GVA + long sequence (deep recurrence)
+]
+
+
+@pytest.mark.parametrize(
+    "B,T,H,HV,K,V,use_init",
+    CONFIGS,
+    ids=[
+        f"B{b}_T{t}_H{h}_HV{hv}_K{kk}_V{v}_init{int(ui)}"
+        for b, t, h, hv, kk, v, ui in CONFIGS
+    ],
+)
+@torch.inference_mode()
+def test_fused_recurrent_gated_delta_rule(B, T, H, HV, K, V, use_init):
+    """fused_recurrent_gated_delta_rule_fwd must match the naive reference (fp32)."""
+    torch.manual_seed(0)
+    scale = K ** -0.5
+    q, k, v, g, beta, initial_state, indices, ssm_idx = _make_inputs(
+        B, T, H, HV, K, V, use_initial_state=use_init
+    )
+    state_ref = initial_state.clone()
+
+    o, final_state = fused_recurrent_gated_delta_rule_fwd(
+        q, k, v, g, beta, scale=scale, initial_state=initial_state,
+        inplace_final_state=True, ssm_state_indices=ssm_idx,
+    )
+    o_ref, state_ref = fused_recurrent_gated_delta_rule_ref(
+        q, k, v, g, beta, scale, state_ref, indices,
+    )
+
+    torch.testing.assert_close(o.float(), o_ref, atol=1e-3, rtol=1e-3)
+    # inplace_final_state writes the last-timestep state back into the pool.
+    for b in range(B):
+        idx = int(indices[b])
+        torch.testing.assert_close(
+            final_state[idx].float(), state_ref[idx], atol=1e-3, rtol=1e-3
+        )
+
+
+@torch.inference_mode()
+def test_fused_recurrent_gated_delta_rule_l2norm():
+    """use_qk_l2norm_in_kernel must match the reference with q/k normalized."""
+    torch.manual_seed(0)
+    B, T, H, HV, K, V = 1, 8, 4, 4, 64, 64
+    scale = K ** -0.5
+    q, k, v, g, beta, initial_state, indices, ssm_idx = _make_inputs(
+        B, T, H, HV, K, V
+    )
+    state_ref = initial_state.clone()
+
+    o, _ = fused_recurrent_gated_delta_rule_fwd(
+        q, k, v, g, beta, scale=scale, initial_state=initial_state,
+        inplace_final_state=True, ssm_state_indices=ssm_idx,
+        use_qk_l2norm_in_kernel=True,
+    )
+    o_ref, _ = fused_recurrent_gated_delta_rule_ref(
+        q, k, v, g, beta, scale, state_ref, indices, use_qk_l2norm=True,
+    )
+
+    torch.testing.assert_close(o.float(), o_ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@torch.inference_mode()
+def test_fused_recurrent_gated_delta_rule_low_precision(dtype):
+    """bf16/fp16 inputs (cast to fp32 inside the kernel) match the fp32 reference."""
+    torch.manual_seed(0)
+    B, T, H, HV, K, V = 1, 8, 4, 4, 64, 64
+    scale = K ** -0.5
+    q, k, v, g, beta, initial_state, indices, ssm_idx = _make_inputs(
+        B, T, H, HV, K, V, dtype=dtype
+    )
+    state_ref = initial_state.clone()
+
+    o, _ = fused_recurrent_gated_delta_rule_fwd(
+        q, k, v, g, beta, scale=scale, initial_state=initial_state,
+        inplace_final_state=True, ssm_state_indices=ssm_idx,
+    )
+    o_ref, _ = fused_recurrent_gated_delta_rule_ref(
+        q, k, v, g, beta, scale, state_ref, indices,
+    )
+
+    torch.testing.assert_close(o.float(), o_ref, atol=5e-3, rtol=5e-3)

--- a/tests/kernels/test_fused_recurrent_gated_delta_rule.py
+++ b/tests/kernels/test_fused_recurrent_gated_delta_rule.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Accuracy tests for the fused_recurrent_gated_delta_rule GDN/FLA Triton kernel."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.platforms import current_platform
+from vllm.third_party.flash_linear_attention.ops import fused_recurrent_gated_delta_rule
+from vllm.utils.torch_utils import set_random_seed
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID, PAD_SLOT_ID
+
+DEVICE = current_platform.device_type
+
+pytestmark = pytest.mark.skipif(
+    not (current_platform.is_cuda_alike() or current_platform.is_xpu()),
+    reason="Gated delta rule Triton kernels require a CUDA-alike or XPU device.",
+)
+
+# HV > H is grouped value attention; V > 32 splits the grid over V.
+SHAPES = [(4, 4, 128, 128), (2, 8, 128, 128), (2, 8, 64, 32)]
+SERVING = (torch.bfloat16, True, False)
+SERVING_FP32 = (torch.float32, True, False)
+NO_L2NORM = (torch.float32, False, False)
+HEADWISE_BETA = (torch.float32, True, True)
+MODES = [SERVING, SERVING_FP32, NO_L2NORM, HEADWISE_BETA]
+TOL = {torch.bfloat16: 1e-2, torch.float32: 1e-4}
+
+
+@pytest.fixture(autouse=True)
+def setup_device():
+    with torch.device(DEVICE):
+        set_random_seed(0)
+        yield
+
+
+def ref_fused_recurrent_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    num_accepted_tokens: torch.Tensor | None = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    inplace_final_state: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """float32 recurrence over the shared state pool, sequential only over time."""
+    q, k, v, g, beta = (x.float()[0] for x in (q, k, v, g, beta))
+    if beta.ndim == 2:  # scalar beta must broadcast over V
+        beta = beta[..., None]
+    if use_qk_l2norm_in_kernel:
+        q, k = (x * torch.rsqrt(x.pow(2).sum(-1, keepdim=True) + 1e-6) for x in (q, k))
+    rep = v.shape[1] // q.shape[1]
+    q = (q * k.shape[-1] ** -0.5).repeat_interleave(rep, dim=1)
+    k = k.repeat_interleave(rep, dim=1)
+
+    o = torch.zeros_like(v)
+    pool = initial_state.float().clone()
+    final_state = (
+        pool.clone()
+        if inplace_final_state
+        else torch.zeros(v.shape[0], *pool.shape[1:])
+    )
+    indices = ssm_state_indices.view(cu_seqlens.numel() - 1, -1).long()
+
+    for n in range(cu_seqlens.numel() - 1):
+        bos, eos = int(cu_seqlens[n]), int(cu_seqlens[n + 1])
+        first = 0 if num_accepted_tokens is None else int(num_accepted_tokens[n]) - 1
+        if indices[n, first] <= 0:
+            continue
+        h = pool[indices[n, first]]
+        for t in range(bos, eos):
+            k_t = k[t][:, None]
+            h = h * g[t][:, None, None].exp()
+            h = h + ((v[t] - (h * k_t).sum(-1)) * beta[t])[..., None] * k_t
+            o[t] = (h * q[t][:, None]).sum(-1)
+            final_state[indices[n, t - bos] if inplace_final_state else t] = h
+
+    return o.unsqueeze(0), final_state
+
+
+def make_gdn_inputs(
+    num_tokens: int,
+    H: int,
+    HV: int,
+    K: int,
+    V: int,
+    dtype: torch.dtype,
+    beta_headwise: bool = False,
+) -> tuple[torch.Tensor, ...]:
+    # Op docstring recipe: unit-norm k, g < 0 keep the recurrence stable.
+    q = torch.randn(1, num_tokens, H, K, dtype=dtype)
+    k = F.normalize(torch.randn(1, num_tokens, H, K, dtype=dtype), dim=-1)
+    v = torch.randn(1, num_tokens, HV, V, dtype=dtype)
+    g = F.logsigmoid(torch.rand(1, num_tokens, HV))
+    beta_shape = (1, num_tokens, HV, V) if beta_headwise else (1, num_tokens, HV)
+    beta = torch.rand(beta_shape, dtype=dtype).sigmoid()
+    return q, k, v, g, beta
+
+
+def make_batch(
+    num_seqs: int, seq_len: int, num_pad: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Uniform requests plus GDN's trailing zero-token NULL_BLOCK_ID padding."""
+    num_tokens = num_seqs * seq_len
+    cu_seqlens = torch.arange(0, num_tokens + 1, seq_len, dtype=torch.int32)
+    indices = (torch.randperm(num_tokens, dtype=torch.int32) + 1).view(
+        num_seqs, seq_len
+    )
+    pad = torch.full((num_pad, seq_len), NULL_BLOCK_ID, dtype=torch.int32)
+    return torch.cat([cu_seqlens, cu_seqlens[-1].repeat(num_pad)]), torch.cat(
+        [indices, pad]
+    )
+
+
+def run_pair(
+    inputs: tuple[torch.Tensor, ...],
+    state: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    indices: torch.Tensor,
+    **kwargs,
+) -> tuple[tuple[torch.Tensor, torch.Tensor], tuple[torch.Tensor, torch.Tensor]]:
+    """Reference first: it mirrors the op's kwargs, and the op overwrites `state`."""
+    ref = ref_fused_recurrent_gated_delta_rule(
+        *inputs, state, cu_seqlens, indices, **kwargs
+    )
+    out = fused_recurrent_gated_delta_rule(
+        *inputs,
+        initial_state=state,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=indices,
+        **kwargs,
+    )
+    return out, ref
+
+
+@pytest.mark.parametrize("num_decodes,num_pad", [(1, 0), (3, 2)])
+@pytest.mark.parametrize("H,HV,K,V", SHAPES)
+@pytest.mark.parametrize("dtype,use_qk_l2norm,beta_headwise", MODES)
+def test_fused_recurrent_gated_delta_rule_decode(
+    num_decodes: int,
+    num_pad: int,
+    H: int,
+    HV: int,
+    K: int,
+    V: int,
+    dtype: torch.dtype,
+    use_qk_l2norm: bool,
+    beta_headwise: bool,
+) -> None:
+    inputs = make_gdn_inputs(num_decodes, H, HV, K, V, dtype, beta_headwise)
+    state = torch.randn(num_decodes + 1, HV, V, K)
+    cu_seqlens, indices = make_batch(num_decodes, 1, num_pad)
+
+    (o, _), (o_ref, state_ref) = run_pair(
+        inputs,
+        state,
+        cu_seqlens,
+        indices[:, 0],
+        inplace_final_state=True,
+        use_qk_l2norm_in_kernel=use_qk_l2norm,
+    )
+
+    tol = TOL[dtype]
+    torch.testing.assert_close(o.float(), o_ref, atol=tol, rtol=tol)
+    torch.testing.assert_close(state, state_ref, atol=tol, rtol=tol)
+
+
+@pytest.mark.parametrize(
+    "num_spec_decodes,num_pad,num_spec_tokens", [(1, 0, 1), (2, 2, 3)]
+)
+@pytest.mark.parametrize("H,HV,K,V", SHAPES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_fused_recurrent_gated_delta_rule_spec_decode(
+    num_spec_decodes: int,
+    num_pad: int,
+    num_spec_tokens: int,
+    H: int,
+    HV: int,
+    K: int,
+    V: int,
+    dtype: torch.dtype,
+) -> None:
+    seq_len = num_spec_tokens + 1
+    num_tokens = num_spec_decodes * seq_len
+    inputs = make_gdn_inputs(num_tokens, H, HV, K, V, dtype)
+    state = torch.randn(num_tokens + 1, HV, V, K)
+    cu_seqlens, indices = make_batch(num_spec_decodes, seq_len, num_pad)
+    num_accepted_tokens = torch.randint(
+        1, seq_len + 1, (num_spec_decodes + num_pad,), dtype=torch.int32
+    )
+
+    (o, _), (o_ref, state_ref) = run_pair(
+        inputs,
+        state,
+        cu_seqlens,
+        indices,
+        inplace_final_state=True,
+        num_accepted_tokens=num_accepted_tokens,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    tol = TOL[dtype]
+    torch.testing.assert_close(o.float(), o_ref, atol=tol, rtol=tol)
+    torch.testing.assert_close(state, state_ref, atol=tol, rtol=tol)
+
+
+@pytest.mark.parametrize("H,HV,K,V", SHAPES)
+def test_fused_recurrent_gated_delta_rule_non_inplace_final_state(
+    H: int, HV: int, K: int, V: int
+) -> None:
+    num_seqs, seq_len = 2, 4
+    num_tokens = num_seqs * seq_len
+    inputs = make_gdn_inputs(num_tokens, H, HV, K, V, torch.float32)
+    state = torch.randn(num_tokens + 1, HV, V, K)
+    state_before = state.clone()
+    cu_seqlens, indices = make_batch(num_seqs, seq_len, 0)
+
+    (o, per_token), (o_ref, per_token_ref) = run_pair(
+        inputs,
+        state,
+        cu_seqlens,
+        indices,
+        inplace_final_state=False,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    tol = TOL[torch.float32]
+    torch.testing.assert_close(o.float(), o_ref, atol=tol, rtol=tol)
+    torch.testing.assert_close(per_token.float(), per_token_ref, atol=tol, rtol=tol)
+    torch.testing.assert_close(state, state_before, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("invalid_id", [NULL_BLOCK_ID, PAD_SLOT_ID])
+def test_fused_recurrent_gated_delta_rule_skips_invalid_state_index(
+    invalid_id: int,
+) -> None:
+    num_decodes, H, HV, K, V = 4, 4, 8, 128, 128
+    inputs = make_gdn_inputs(num_decodes, H, HV, K, V, torch.bfloat16)
+    state = torch.randn(num_decodes + 1, HV, V, K)
+    cu_seqlens, indices = make_batch(num_decodes, 1, 0)
+    indices = indices[:, 0]
+    indices[1] = invalid_id
+
+    (o, _), (o_ref, state_ref) = run_pair(
+        inputs, state, cu_seqlens, indices, inplace_final_state=True
+    )
+
+    # skipped requests never write o
+    valid = indices > 0
+    tol = TOL[torch.bfloat16]
+    torch.testing.assert_close(o[:, valid].float(), o_ref[:, valid], atol=tol, rtol=tol)
+    torch.testing.assert_close(state, state_ref, atol=tol, rtol=tol)


### PR DESCRIPTION
## Purpose

Adds accuracy tests for `fused_recurrent_gated_delta_rule`, which had none.
Checked against a float32 reference, covering the paths vLLM takes: decode and
speculative decode with CUDA-graph padding, GVA (`HV > H`), `NULL_BLOCK_ID` /
`PAD_SLOT_ID` skipping, `use_qk_l2norm_in_kernel`, scalar and headwise `beta`,
both `inplace_final_state` modes, bfloat16 and float32.

Two pre-existing kernel bugs found, left for a separate PR: `ssm_state_indices=None`
with the default `inplace_final_state=True` dereferences null, and the default
`beta=None` has shape `[B, T, H]` while the kernel indexes `bos * HV + i_hv`,
reading past the buffer under GVA.

## Test Plan

```bash
pytest tests/kernels/test_fused_recurrent_gated_delta_rule.py
```

## Test Result

41 passed on Intel Arc Pro B70 (XPU) and L40S