### PR TITLE
[Perf] SM120 PCIe serving stack: SP/async-TP enablement, FlashInfer spec-decode FULL cudagraphs, and PCIe-safe multi-GPU comms

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -434,8 +434,11 @@ def test_should_split():
         (None, 2048, 1, False, 257, CUDAGraphMode.FULL_AND_PIECEWISE, 257),
         # max from list
         ([1, 2, 4, 15], None, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 15),
-        # SP forces full-graph compilation, sizes are filtered by TP
-        ([1, 2, 4, 15], None, 2, True, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 4),
+        # SP only constrains sizes at or above sp_min_token_num (512 here);
+        # smaller captured sizes keep their exact shapes
+        ([1, 2, 4, 15], None, 2, True, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 15),
+        # sizes at or above sp_min_token_num are still filtered by TP
+        ([2, 511, 513], None, 2, True, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 511),
         # limited by the max_tokens
         ([1, 2, 4, 15], None, 1, False, 8, CUDAGraphMode.FULL_AND_PIECEWISE, 4),
         # the list should contain at least 1 element when use cudagraph
@@ -492,6 +495,29 @@ def test_cudagraph_sizes_post_init(
         )
 
 
+def test_spec_decode_capture_rounding_scoped_by_sp_threshold():
+    """SP only binds captured sizes at or above sp_min_token_num."""
+
+    def make_config(sp_min_token_num: int) -> CompilationConfig:
+        return CompilationConfig(
+            pass_config=PassConfig(enable_sp=True, sp_min_token_num=sp_min_token_num),
+            cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+            cudagraph_capture_sizes=[1, 2, 8, 512],
+            max_cudagraph_capture_size=512,
+        )
+
+    # uniform_decode_query_len=3 (2 speculative tokens) with tp=4: max(3, 4)
+    # is divisible by neither, but no captured size reaches the threshold,
+    # so only spec-decode divisibility applies.
+    config = make_config(sp_min_token_num=1024)
+    config.adjust_cudagraph_sizes_for_spec_decode(3, 4)
+    assert config.cudagraph_capture_sizes == [3, 9]
+
+    # With captured sizes at or above the threshold the conflict is real.
+    with pytest.raises(ValueError, match="Can't determine cudagraph shapes"):
+        make_config(sp_min_token_num=256).adjust_cudagraph_sizes_for_spec_decode(3, 4)
+
+
 @pytest.mark.skipif(
     not current_platform.support_static_graph_mode(),
     reason="Skip if not cudagraph mode supported",
@@ -507,15 +533,23 @@ def test_cudagraph_sizes_post_init(
         "expected_max_size",
     ),
     [
-        (CUDAGraphMode.PIECEWISE, False, True, CUDAGraphMode.FULL, False, [2, 4], 4),
+        (
+            CUDAGraphMode.PIECEWISE,
+            False,
+            True,
+            CUDAGraphMode.FULL,
+            False,
+            [1, 2, 4, 15],
+            15,
+        ),
         (
             CUDAGraphMode.FULL_DECODE_ONLY,
             False,
             True,
             CUDAGraphMode.FULL_DECODE_ONLY,
             False,
-            [2, 4],
-            4,
+            [1, 2, 4, 15],
+            15,
         ),
         (
             CUDAGraphMode.FULL_AND_PIECEWISE,
@@ -523,8 +557,8 @@ def test_cudagraph_sizes_post_init(
             True,
             CUDAGraphMode.FULL,
             False,
-            [2, 4],
-            4,
+            [1, 2, 4, 15],
+            15,
         ),
         (
             CUDAGraphMode.FULL_AND_PIECEWISE,
@@ -532,8 +566,8 @@ def test_cudagraph_sizes_post_init(
             True,
             CUDAGraphMode.FULL_AND_PIECEWISE,
             True,
-            [2, 4],
-            4,
+            [1, 2, 4, 15],
+            15,
         ),
     ],
 )

--- a/tests/compile/test_sequence_parallelism_threshold.py
+++ b/tests/compile/test_sequence_parallelism_threshold.py
@@ -110,6 +110,29 @@ class TestGetSequenceParallelismThreshold:
             assert result is not None
 
 
+class TestGetSequenceParallelismThresholdSM120:
+    """Tests for get_sequence_parallelism_threshold on SM120 (PCIe-only)."""
+
+    def test_sm120_hidden_4096_returns_threshold(self, mock_cuda_platform):
+        """SM120 supports SP from hidden_size 4096."""
+        with mock_cuda_platform(capability=(12, 0)):
+            result = get_sequence_parallelism_threshold(
+                hidden_size=4096, tp_size=4, element_size=2
+            )
+            # (2 * 4 * 1024 * 1024) // (4096 * 2) = 1024
+            assert result == 1024
+
+    def test_sm120_small_hidden_returns_none(self, mock_cuda_platform):
+        """SM120 with hidden_size below threshold should return None."""
+        with mock_cuda_platform(capability=(12, 0)):
+            result = get_sequence_parallelism_threshold(
+                hidden_size=SP_MIN_HIDDEN_SIZE[120] - 1,
+                tp_size=4,
+                element_size=2,
+            )
+            assert result is None
+
+
 # XPU-specific constants (must match sequence_parallelism.py values)
 _XPU_MIN_HIDDEN_SIZE = 4096
 _XPU_MIN_PER_GPU_SIZE_MB = 8.0

--- a/tests/distributed/test_pcie_comm_gates.py
+++ b/tests/distributed/test_pcie_comm_gates.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only tests for the PCIe comm-stack gates: the native-P2P-atomics
+platform query and the stream-memops symm-mem barrier replacement."""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+import vllm.distributed.device_communicators.symm_mem_pcie_barrier as spb
+from vllm.platforms.cuda import NvmlCudaPlatform
+
+
+def _fake_pynvml(statuses):
+    """pynvml stand-in whose nvmlDeviceGetP2PStatus pops from `statuses`."""
+    fake = mock.MagicMock()
+    fake.NVML_P2P_CAPS_INDEX_ATOMICS = 3
+    fake.NVML_P2P_STATUS_OK = 0
+    fake.NVMLError = RuntimeError
+    fake.nvmlDeviceGetHandleByIndex.side_effect = lambda i: f"h{i}"
+
+    def get_status(h1, h2, caps):
+        assert caps == 3
+        res = statuses.pop(0)
+        if isinstance(res, Exception):
+            raise res
+        return res
+
+    fake.nvmlDeviceGetP2PStatus.side_effect = get_status
+    return fake
+
+
+@pytest.mark.parametrize(
+    "statuses,expected",
+    [
+        ([0, 0, 0, 0, 0, 0], True),  # all six pairs of 4 GPUs OK
+        ([0, 5], False),  # second pair reports NOT_SUPPORTED
+        ([RuntimeError("nvml")], False),  # query failure -> assume absent
+    ],
+)
+def test_has_native_p2p_atomics(statuses, expected):
+    fake = _fake_pynvml(statuses)
+    with mock.patch("vllm.platforms.cuda.pynvml", fake):
+        assert NvmlCudaPlatform.has_native_p2p_atomics([0, 1, 2, 3]) is expected
+
+
+class _FakeDriver:
+    """Records memops; mimics the cuda.bindings.driver surface we use."""
+
+    def __init__(self):
+        self.calls = []
+        self.CUstreamWaitValue_flags = SimpleNamespace(CU_STREAM_WAIT_VALUE_EQ=2)
+
+    def CUstream(self, s):
+        return s
+
+    def CUdeviceptr(self, p):
+        return p
+
+    def cuStreamWriteValue32(self, stream, addr, value, flags):
+        self.calls.append(("write", addr, value))
+        return (0,)
+
+    def cuStreamWaitValue32(self, stream, addr, value, flags):
+        assert flags == 2  # EQ
+        self.calls.append(("wait", addr, value))
+        return (0,)
+
+
+def _fake_handle(world=4, rank=1):
+    return SimpleNamespace(
+        world_size=world,
+        rank=rank,
+        signal_pad_ptrs=[10_000 * (r + 1) for r in range(world)],
+        signal_pad_size=4096,
+    )
+
+
+@pytest.fixture
+def barrier_env(monkeypatch):
+    drv = _FakeDriver()
+    monkeypatch.setattr(spb, "_drv", drv)
+    spb.reset_pcie_barrier_state()
+    monkeypatch.setattr("torch.cuda.is_current_stream_capturing", lambda: False)
+    monkeypatch.setattr(
+        "torch.cuda.current_stream", lambda: SimpleNamespace(cuda_stream=0)
+    )
+    return drv
+
+
+def test_pcie_barrier_ring_slots_and_sequence(barrier_env):
+    drv = barrier_env
+    h = _fake_handle(world=4, rank=1)
+    channel = 1
+    W, R = 4, spb._RING
+
+    def base(seq):
+        return 4 * W * (channel * R + seq % R)
+
+    spb._pcie_safe_barrier(h, channel=channel)
+    writes = [c for c in drv.calls if c[0] == "write"]
+    waits = [c for c in drv.calls if c[0] == "wait"]
+    assert len(writes) == 4 and len(waits) == 4
+    # every write lands in the peer's pad, in this rank's sender lane
+    assert {a for _, a, _ in writes} == {
+        h.signal_pad_ptrs[p] + base(1) + 4 * h.rank for p in range(4)
+    }
+    # every wait polls this rank's own pad, one slot per sender
+    assert {a for _, a, _ in waits} == {
+        h.signal_pad_ptrs[h.rank] + base(1) + 4 * p for p in range(4)
+    }
+    # all writes are issued before the first wait
+    kinds = [k for k, _, _ in drv.calls]
+    assert kinds.index("wait") == 4
+    assert all(v == 1 for _, _, v in drv.calls)
+
+    # consecutive same-channel instances use different ring slots
+    drv.calls.clear()
+    spb._pcie_safe_barrier(h, channel=channel)
+    assert all(v == 2 for _, _, v in drv.calls)
+    assert {a for k, a, _ in drv.calls if k == "write"} == {
+        h.signal_pad_ptrs[p] + base(2) + 4 * h.rank for p in range(4)
+    }
+    assert base(2) != base(1)
+
+    # the ring wraps after _RING instances, values keep growing
+    for seq in range(3, R + 2):
+        drv.calls.clear()
+        spb._pcie_safe_barrier(h, channel=channel)
+        assert all(v == seq for _, _, v in drv.calls)
+    assert base(R + 1) == base(1)  # wrapped slot, distinguished by value
+
+    spb.reset_pcie_barrier_state()
+    drv.calls.clear()
+    spb._pcie_safe_barrier(h, channel=channel)
+    assert all(v == 1 for _, _, v in drv.calls)
+
+
+def test_pcie_barrier_rejects_graph_capture(barrier_env, monkeypatch):
+    monkeypatch.setattr("torch.cuda.is_current_stream_capturing", lambda: True)
+    with pytest.raises(RuntimeError, match="captured"):
+        spb._pcie_safe_barrier(_fake_handle(), channel=0)
+
+
+def test_pcie_barrier_rejects_bad_channel(barrier_env):
+    with pytest.raises(ValueError):
+        spb._pcie_safe_barrier(_fake_handle(), channel=spb._MAX_CHANNELS)

--- a/vllm/compilation/passes/fusion/sequence_parallelism.py
+++ b/vllm/compilation/passes/fusion/sequence_parallelism.py
@@ -40,6 +40,11 @@ if hasattr(torch.ops._C, "scaled_fp4_quant"):
 SP_MIN_HIDDEN_SIZE: dict[int, int] = {
     90: 8192,  # H100: only for models with hidden_size >= 8192
     100: 8192,  # Blackwell family: only for models with hidden_size >= 8192
+    # SM120 is PCIe-only, where allreduce is far more expensive relative to
+    # compute, so SP pays off at much smaller shapes (measured on 4x RTX
+    # PRO 6000: fused gemm+RS/AG crosses over between 512 and 1024 tokens
+    # at hidden_size 4096).
+    120: 4096,
 }
 
 # Min size per GPU per device capability for sequence parallelism
@@ -49,6 +54,7 @@ SP_MIN_PER_GPU_SIZE_MB: dict[int, float] = {
     90: 8,  # 8MB per GPU for H100
     # Use a more conservative threshold on Blackwell so TP8 starts later.
     100: 32,
+    120: 2,  # PCIe-only; 2MB ~ 1024 tokens at hidden 4096 / tp4 / bf16
 }
 
 

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -1225,7 +1225,11 @@ class CompilationConfig:
                 logger.warning_once(
                     "Sequence parallelism is incompatible with piecewise "
                     "cudagraph when use_inductor_graph_partition is off. "
-                    "Setting cudagraph_mode to FULL."
+                    "Setting cudagraph_mode to FULL. If the attention "
+                    "backend cannot capture FULL graphs (e.g. with "
+                    "spec-decode), cudagraphs are disabled entirely; set "
+                    "use_inductor_graph_partition=True to keep piecewise "
+                    "cudagraphs with SP."
                 )
                 self.cudagraph_mode = CUDAGraphMode.FULL
 
@@ -1519,11 +1523,24 @@ class CompilationConfig:
         self, uniform_decode_query_len: int, tensor_parallel_size: int
     ):
         multiple_of = uniform_decode_query_len
-        if tensor_parallel_size > 1 and self.pass_config.enable_sp:
-            multiple_of = max(uniform_decode_query_len, tensor_parallel_size)
+        sp_multiple_of = None
+        sp_min_token_num = self.pass_config.sp_min_token_num
+        # SP only binds captured sizes at or above sp_min_token_num; when no
+        # captured size can reach the threshold, spec-decode divisibility is
+        # the only constraint.
+        sp_binds_captured_sizes = sp_min_token_num is None or (
+            self.max_cudagraph_capture_size is not None
+            and self.max_cudagraph_capture_size >= sp_min_token_num
+        )
+        if (
+            tensor_parallel_size > 1
+            and self.pass_config.enable_sp
+            and sp_binds_captured_sizes
+        ):
+            sp_multiple_of = max(uniform_decode_query_len, tensor_parallel_size)
             if (
-                multiple_of % uniform_decode_query_len != 0
-                or multiple_of % tensor_parallel_size != 0
+                sp_multiple_of % uniform_decode_query_len != 0
+                or sp_multiple_of % tensor_parallel_size != 0
             ):
                 raise ValueError(
                     f"Can't determine cudagraph shapes that are both a "
@@ -1534,21 +1551,35 @@ class CompilationConfig:
                     f"num_speculative_tokens or disable sequence parallelism"
                 )
 
-        if not self.cudagraph_capture_sizes or multiple_of <= 1:
+        if not self.cudagraph_capture_sizes or (
+            multiple_of <= 1 and sp_multiple_of is None
+        ):
             return
+
+        def _round_for(size: int) -> int:
+            # Sizes below sp_min_token_num run non-SP graphs and only need
+            # spec-decode divisibility (sp_multiple_of % multiple_of == 0).
+            rounded = round_up(size, multiple_of)
+            if sp_multiple_of is not None and (
+                sp_min_token_num is None or rounded >= sp_min_token_num
+            ):
+                rounded = round_up(rounded, sp_multiple_of)
+            return rounded
 
         assert self.max_cudagraph_capture_size is not None
         rounded_sizes = sorted(
             set(
-                round_up(size, multiple_of)
+                _round_for(size)
                 for size in self.cudagraph_capture_sizes
-                if round_up(size, multiple_of) <= self.max_cudagraph_capture_size
+                if _round_for(size) <= self.max_cudagraph_capture_size
             )
         )
 
-        if len(rounded_sizes) == 0 and multiple_of <= self.max_cudagraph_capture_size:
+        if len(rounded_sizes) == 0:
             # if one valid but would be round_down use that
-            rounded_sizes = [multiple_of]
+            smallest = _round_for(1)
+            if smallest <= self.max_cudagraph_capture_size:
+                rounded_sizes = [smallest]
 
         if len(rounded_sizes) == 0:
             raise ValueError(

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1345,8 +1345,8 @@ class VllmConfig:
 
                 if pass_config.sp_min_token_num is None:
                     logger.warning_once(
-                        "Model hidden_size too small for the SP "
-                        "threshold heuristic, disabling. To force SP, "
+                        "No SP threshold heuristic for this device "
+                        "capability / hidden_size, disabling. To force SP, "
                         "set pass_config.sp_min_token_num manually."
                     )
                     pass_config.enable_sp = False
@@ -1705,10 +1705,18 @@ class VllmConfig:
     def update_sizes_for_sequence_parallelism(self, possible_sizes: list) -> list:
         # remove the sizes that not multiple of tp_size when
         # enable sequence parallelism
+        tp_size = self.parallel_config.tensor_parallel_size
+        sp_min_token_num = self.compilation_config.pass_config.sp_min_token_num
+
+        def needs_sp_shape(size: int) -> bool:
+            # SP only applies to compile ranges at or above sp_min_token_num;
+            # smaller captured sizes run non-SP graphs and keep their shapes.
+            return sp_min_token_num is None or size >= sp_min_token_num
+
         removed_sizes = [
             size
             for size in possible_sizes
-            if size % self.parallel_config.tensor_parallel_size != 0
+            if needs_sp_shape(size) and size % tp_size != 0
         ]
         if removed_sizes:
             logger.warning(
@@ -1716,13 +1724,13 @@ class VllmConfig:
                 "multiple of tp_size %d when "
                 "sequence parallelism is enabled",
                 removed_sizes,
-                self.parallel_config.tensor_parallel_size,
+                tp_size,
             )
 
         return [
             size
             for size in possible_sizes
-            if size % self.parallel_config.tensor_parallel_size == 0
+            if not needs_sp_shape(size) or size % tp_size == 0
         ]
 
     def _set_max_num_scheduled_tokens(self):

--- a/vllm/distributed/device_communicators/all_reduce_utils.py
+++ b/vllm/distributed/device_communicators/all_reduce_utils.py
@@ -80,6 +80,22 @@ SYMM_MEM_ALL_REDUCE_MAX_SIZES = {
         6: 32 * MiB,  # 32 MB
         8: 64 * MiB,  # 64 MB
     },
+    # PCIe-only parts (no multicast): two-shot P2P all-reduce only.
+    # Measured on 4x RTX PRO 6000 (pairs behind PCIe switches): two-shot
+    # beats the NCCL ring 1.2-2x from its ~160 KB crossover through 64 MB;
+    # below that the ~28 us barrier floor loses to NCCL LL (~16-25 us).
+    "12.0": {
+        2: 64 * MiB,  # 64 MB
+        4: 64 * MiB,  # 64 MB
+        8: 64 * MiB,  # 64 MB
+    },
+}
+
+# Below these sizes the symm-mem barrier floor loses to NCCL LL; hand the
+# input back to the next backend in the dispatch order. Capabilities not
+# listed have no floor (previous behavior).
+SYMM_MEM_ALL_REDUCE_MIN_SIZES = {
+    "12.0": 128 * 1024,  # 128 KB
 }
 
 # NCCL symmetric memory allreduce configuration based on H100 and GB200 benchmarks.

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -68,6 +68,13 @@ class CudaCommunicator(DeviceCommunicatorBase):
         self.use_flashinfer_allreduce = use_flashinfer_allreduce
         self.use_aiter_allreduce = use_aiter_allreduce
 
+        if envs.VLLM_SYMM_MEM_PCIE_SAFE_BARRIER:
+            from vllm.distributed.device_communicators.symm_mem_pcie_barrier import (
+                install_pcie_safe_barrier,
+            )
+
+            install_pcie_safe_barrier()
+
         # lazy import to avoid documentation build error
         from vllm.distributed.device_communicators.custom_all_reduce import (
             CustomAllreduce,

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from contextlib import contextmanager
 from typing import cast
 
@@ -12,6 +13,7 @@ import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm.distributed.device_communicators.all_reduce_utils import (
     CUSTOM_ALL_REDUCE_MAX_SIZES,
+    MiB,
     gpu_p2p_access_check,
 )
 from vllm.distributed.parallel_state import in_the_same_node_as
@@ -146,6 +148,16 @@ class CustomAllreduce:
         # now `device` is a `torch.device` object
         assert isinstance(device, torch.device)
         self.device = device
+        # Read once: envs attribute access hits os.environ, and
+        # should_custom_ar is on the per-all-reduce dispatch path.
+        self.allow_pcie = same_node and envs.VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE
+        # On PCIe-only opt-in topologies the 2-stage kernel keeps beating
+        # NCCL well past the default 8 MB ceiling (measured 1.2-1.3x at
+        # 8-64 MB and 1.15x at 128-256 MB on 4x RTX PRO 6000), so raise the
+        # ceiling to cover chunked-prefill all-reduces (16k tokens x 4k
+        # hidden x bf16 = 128 MiB).
+        if self.allow_pcie:
+            max_size = max(max_size, 256 * MiB)
         device_capability = current_platform.get_device_capability()
         if (
             current_platform.is_cuda()
@@ -177,12 +189,30 @@ class CustomAllreduce:
             assert current_platform.is_cuda_alike()
             fully_connected = current_platform.is_fully_connected(physical_device_ids)
         if same_node and world_size > 2 and not fully_connected:
-            logger.warning(
-                "Custom allreduce is disabled because it's not supported on"
-                " more than two PCIe-only GPUs. To silence this warning, "
-                "specify disable_custom_all_reduce=True explicitly."
-            )
-            return
+            # The sync protocol is atomics-free (peer plain writes + local
+            # polling), so PCIe-only P2P is functionally fine; the gate is a
+            # performance heuristic. Allow opting in where measurements
+            # support it.
+            if self.allow_pcie:
+                # The C++ dispatch launches no kernel for non-fully-connected
+                # world sizes > 2 unless VLLM_CUSTOM_ALLREDUCE_ALGO forces an
+                # algorithm; default to the 2-stage kernel, which beat NCCL
+                # across 8 KB - 64 MB in PCIe P2P measurements.
+                os.environ.setdefault("VLLM_CUSTOM_ALLREDUCE_ALGO", "2stage")
+                logger.info_once(
+                    "Custom allreduce enabled on %d PCIe-only GPUs by "
+                    "VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE (algo=%s).",
+                    world_size,
+                    os.environ["VLLM_CUSTOM_ALLREDUCE_ALGO"],
+                )
+            else:
+                logger.warning(
+                    "Custom allreduce is disabled because it's not supported"
+                    " on more than two PCIe-only GPUs. To silence this "
+                    "warning, specify disable_custom_all_reduce=True "
+                    "explicitly."
+                )
+                return
         # test P2P capability, this checks software/cudaruntime support
         # this is expensive to compute at the first time
         # then we cache the result
@@ -356,7 +386,7 @@ class CustomAllreduce:
             return False
         # for 4 or more non NVLink-capable GPUs, custom allreduce provides
         # little performance improvement over NCCL.
-        if self.world_size == 2 or self.fully_connected:
+        if self.world_size == 2 or self.fully_connected or self.allow_pcie:
             return inp_size < self.max_size
         return False
 

--- a/vllm/distributed/device_communicators/symm_mem.py
+++ b/vllm/distributed/device_communicators/symm_mem.py
@@ -80,6 +80,30 @@ class SymmMemCommunicator:
                 self.world_size,
             )
             return
+        # The one/two-shot kernels synchronize the group through signal
+        # pads with system-scope CAS on peer-mapped memory (put_signal /
+        # wait_signal). P2P read/write access does not imply atomic
+        # support: without native P2P atomics the CAS is not atomic,
+        # barrier tokens are lost or duplicated under load, and the whole
+        # group wedges permanently (observed on PCIe-only topologies).
+        # device.index is a visible ordinal, not a logical local ID.
+        physical_device_id = current_platform.visible_device_id_to_physical_device_id(
+            self.device.index
+        )
+        tensor = torch.tensor([physical_device_id], dtype=torch.int, device="cpu")
+        gather_list = [
+            torch.tensor([0], dtype=torch.int, device="cpu")
+            for _ in range(self.world_size)
+        ]
+        dist.all_gather(gather_list, tensor, group=self.group)
+        physical_device_ids = [t.item() for t in gather_list]
+        if not current_platform.has_native_p2p_atomics(physical_device_ids):
+            logger.warning(
+                "SymmMemCommunicator: native P2P atomics are not supported "
+                "between devices %s, communicator is not available.",
+                physical_device_ids,
+            )
+            return
         # Use override max_size if provided, otherwise use default
         if max_size_override is not None:
             self.max_size = max_size_override

--- a/vllm/distributed/device_communicators/symm_mem.py
+++ b/vllm/distributed/device_communicators/symm_mem.py
@@ -121,6 +121,13 @@ class SymmMemCommunicator:
             )
             return
         self.force_multimem = force_multimem
+        # The one/two-shot kernels synchronize the group with per-slot
+        # signal-pad exchanges, so their device execution order must match
+        # the group issue order. Callers issue all-reduces from different
+        # streams (profile / compile warmup / capture), which CUDA does not
+        # order; serialize every op of this communicator on a dedicated
+        # stream, fenced with events against the caller's stream.
+        self._comm_stream = torch.cuda.Stream(device=self.device)
         self.disabled = False
         if envs.VLLM_BATCH_INVARIANT:
             self.disabled = True
@@ -142,7 +149,6 @@ class SymmMemCommunicator:
             return None
         if out is None:
             out = torch.empty_like(inp)
-        self.buffer[: inp.numel()].copy_(inp.view(-1))
 
         # Determine which algorithm to use
         use_multimem = False
@@ -155,13 +161,18 @@ class SymmMemCommunicator:
                 self.device_capability, []
             )
 
-        if use_multimem:
-            torch.ops.symm_mem.multimem_all_reduce_(
-                self.buffer[: inp.numel()], "sum", self.group.group_name
-            )
-        else:
-            torch.ops.symm_mem.two_shot_all_reduce_(
-                self.buffer[: inp.numel()], "sum", self.group.group_name
-            )
-        out.copy_(self.buffer[: inp.numel()].view(out.shape))
+        current = torch.cuda.current_stream()
+        self._comm_stream.wait_stream(current)
+        with torch.cuda.stream(self._comm_stream):
+            self.buffer[: inp.numel()].copy_(inp.view(-1))
+            if use_multimem:
+                torch.ops.symm_mem.multimem_all_reduce_(
+                    self.buffer[: inp.numel()], "sum", self.group.group_name
+                )
+            else:
+                torch.ops.symm_mem.two_shot_all_reduce_(
+                    self.buffer[: inp.numel()], "sum", self.group.group_name
+                )
+            out.copy_(self.buffer[: inp.numel()].view(out.shape))
+        current.wait_stream(self._comm_stream)
         return out

--- a/vllm/distributed/device_communicators/symm_mem.py
+++ b/vllm/distributed/device_communicators/symm_mem.py
@@ -8,6 +8,7 @@ from torch.distributed import ProcessGroup
 import vllm.envs as envs
 from vllm.distributed.device_communicators.all_reduce_utils import (
     SYMM_MEM_ALL_REDUCE_MAX_SIZES,
+    SYMM_MEM_ALL_REDUCE_MIN_SIZES,
 )
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
@@ -28,6 +29,8 @@ class SymmMemCommunicator:
         "10.0": [6, 8],
         "10.3": [6, 8],
         "10.7": [6, 8],  # sm_107 (Rubin): reuse 10.3 thresholds
+        # 12.0: no multicast hardware; always two-shot P2P.
+        "12.0": [],
     }
 
     def __init__(
@@ -88,6 +91,7 @@ class SymmMemCommunicator:
             self.max_size = SYMM_MEM_ALL_REDUCE_MAX_SIZES[self.device_capability][
                 self.world_size
             ]
+        self.min_size = SYMM_MEM_ALL_REDUCE_MIN_SIZES.get(self.device_capability, 0)
         try:
             self.buffer = torch_symm_mem.empty(
                 self.max_size // self.dtype.itemsize,
@@ -103,7 +107,14 @@ class SymmMemCommunicator:
                 str(e),
             )
             return
-        if handle.multicast_ptr == 0:
+        # Multicast is only needed by the multimem kernels; the two-shot
+        # all-reduce runs on plain P2P mappings (e.g. PCIe-only devices).
+        may_use_multimem = force_multimem or (
+            force_multimem is None
+            and self.world_size
+            in self._WORLD_SIZES_MULTIMEM.get(self.device_capability, [])
+        )
+        if may_use_multimem and handle.multicast_ptr == 0:
             logger.warning(
                 "SymmMemCommunicator: symmetric memory "
                 "multicast operations are not supported."
@@ -122,7 +133,7 @@ class SymmMemCommunicator:
         inp_size = inp.numel() * inp.element_size()
         if inp_size % 4 != 0:
             return False
-        return inp_size <= self.max_size
+        return self.min_size <= inp_size <= self.max_size
 
     def all_reduce(
         self, inp: torch.Tensor, *, out: torch.Tensor | None = None
@@ -140,8 +151,8 @@ class SymmMemCommunicator:
             use_multimem = self.force_multimem
         else:
             # Normal logic: use multimem for supported world sizes
-            use_multimem = (
-                self.world_size in self._WORLD_SIZES_MULTIMEM[self.device_capability]
+            use_multimem = self.world_size in self._WORLD_SIZES_MULTIMEM.get(
+                self.device_capability, []
             )
 
         if use_multimem:

--- a/vllm/distributed/device_communicators/symm_mem_pcie_barrier.py
+++ b/vllm/distributed/device_communicators/symm_mem_pcie_barrier.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""PCIe-safe replacement for torch symmetric memory's group barrier.
+
+torch's ``_SymmetricMemory.barrier(channel)`` synchronizes the group with
+CAS exchanges on peer-mapped signal pads. On platforms without native P2P
+atomics (``cudaDevP2PAttrNativeAtomicSupported == 0``, e.g. PCIe-only
+multi-GPU boxes) those CAS ops are not atomic: barrier tokens get lost or
+duplicated under PCIe load and the group wedges permanently.
+
+This module swaps the barrier for a protocol that only needs primitives
+such platforms do support:
+
+  * sender:   ``cuStreamWriteValue32`` of the instance's sequence number
+              into a **per-instance ring slot** of the receiver's signal
+              pad — a plain posted P2P write (with the default preceding
+              memory barrier, giving release semantics for prior P2P
+              traffic);
+  * receiver: ``cuStreamWaitValue32(EQ)`` polling the matching slot of
+              its *own* pad — local memory only.
+
+No remote read-modify-write anywhere. Slot index is
+``(channel, seq % RING, sender)``, so concurrent same-channel instances
+issued from different streams (the pipelined fused ops interleave a
+compute and a backend stream) touch different slots and cannot corrupt
+each other regardless of device-side execution order; EQ matching makes
+a slot's stale previous-lap value simply not match. This also removes the
+multi-stream instance-interleaving hazard of the CAS design
+(pytorch/pytorch#189228). Ring-slot reuse is safe for ``RING >= 2``: a
+rank can only issue instance ``K+RING`` after completing ``K+RING-1``,
+which requires every peer to have written ``K+RING-1`` and therefore to
+have passed its wait for instance ``K``.
+
+The patch is process-global and a drop-in barrier for every handle; the
+pipelined fused ops (``fused_matmul_reduce_scatter``,
+``fused_all_gather_matmul`` and their scaled variants) synchronize
+exclusively through ``barrier(channel)`` plus stream-ordered plain
+writes, so patching the barrier makes the whole family PCIe-safe.
+
+Known constraints:
+
+  * **No CUDA graph capture.** The sequence number is baked into the
+    recorded write, so a replayed barrier would trivially satisfy its own
+    wait and synchronize nothing (the stock CAS barrier replays
+    correctly). Calling the patched barrier during capture raises. The
+    fused ops only run at sequence-parallel sizes, which sit above vLLM's
+    cudagraph capture ceiling, so this path is structurally unreachable
+    today.
+  * **Sequence state is keyed by the handle's signal-pad address.** If an
+    allocation is freed and a new symm-mem handle reuses the same VA with
+    a zeroed pad, call :func:`reset_pcie_barrier_state`. vLLM's fused ops
+    use per-group workspace handles that live for the process, so this
+    does not occur in practice.
+"""
+
+import threading
+
+import torch
+from torch._C._distributed_c10d import _SymmetricMemory
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_MAX_CHANNELS = 8
+_RING = 4
+_lock = threading.Lock()
+# own-pad VA -> {channel: last sequence number}
+_seq_state: dict[int, dict[int, int]] = {}
+_installed = False
+_orig_barrier = None
+_drv = None
+
+
+def _pcie_safe_barrier(self, channel: int = 0, timeout_ms: int = 0) -> None:
+    if torch.cuda.is_current_stream_capturing():
+        raise RuntimeError(
+            "The PCIe-safe symm-mem barrier cannot be captured in a CUDA "
+            "graph: its baked sequence number would satisfy its own wait "
+            "on replay without synchronizing the group."
+        )
+    world = self.world_size
+    rank = self.rank
+    pad_ptrs = self.signal_pad_ptrs
+    if channel >= _MAX_CHANNELS:
+        raise ValueError(f"channel {channel} >= {_MAX_CHANNELS}")
+    if self.signal_pad_size < _MAX_CHANNELS * _RING * world * 4:
+        raise RuntimeError(
+            f"signal pad too small: {self.signal_pad_size} < "
+            f"{_MAX_CHANNELS * _RING * world * 4}"
+        )
+
+    own_key = pad_ptrs[rank]
+    with _lock:
+        chans = _seq_state.setdefault(own_key, {})
+        seq = chans.get(channel, 0) + 1
+        chans[channel] = seq
+
+    stream = _drv.CUstream(torch.cuda.current_stream().cuda_stream)
+    base = 4 * world * (channel * _RING + seq % _RING)
+    eq = int(_drv.CUstreamWaitValue_flags.CU_STREAM_WAIT_VALUE_EQ)
+    for peer in range(world):
+        (err,) = _drv.cuStreamWriteValue32(
+            stream,
+            _drv.CUdeviceptr(pad_ptrs[peer] + base + 4 * rank),
+            seq,
+            0,
+        )
+        if int(err) != 0:
+            raise RuntimeError(f"cuStreamWriteValue32 failed: {err}")
+    for peer in range(world):
+        (err,) = _drv.cuStreamWaitValue32(
+            stream,
+            _drv.CUdeviceptr(pad_ptrs[rank] + base + 4 * peer),
+            seq,
+            eq,
+        )
+        if int(err) != 0:
+            raise RuntimeError(f"cuStreamWaitValue32 failed: {err}")
+
+
+def reset_pcie_barrier_state() -> None:
+    """Forget all per-handle sequence numbers (see module docstring)."""
+    with _lock:
+        _seq_state.clear()
+
+
+def install_pcie_safe_barrier() -> None:
+    """Replace ``_SymmetricMemory.barrier`` process-wide. Idempotent."""
+    global _installed, _orig_barrier, _drv
+    if _installed:
+        return
+    from cuda.bindings import driver as drv
+
+    _drv = drv
+    _orig_barrier = _SymmetricMemory.barrier
+    _SymmetricMemory.barrier = _pcie_safe_barrier
+    _installed = True
+    logger.info_once(
+        "torch symm-mem group barrier replaced with the PCIe-safe "
+        "stream-memops protocol (no native P2P atomics on this platform)."
+    )

--- a/vllm/distributed/device_communicators/symm_mem_pcie_barrier.py
+++ b/vllm/distributed/device_communicators/symm_mem_pcie_barrier.py
@@ -48,11 +48,14 @@ Known constraints:
     today.
   * **Sequence state is keyed by the handle's signal-pad address.** If an
     allocation is freed and a new symm-mem handle reuses the same VA with
-    a zeroed pad, call :func:`reset_pcie_barrier_state`. vLLM's fused ops
-    use per-group workspace handles that live for the process, so this
-    does not occur in practice.
+    a zeroed pad, call :func:`reset_pcie_barrier_state`. torch's fused
+    ops DO re-allocate their workspace when an op requests more space —
+    unsafely (see the workspace-guard notes below); the installed guard
+    floors the first allocation and keeps retired workspaces alive, so
+    VA reuse does not occur.
 """
 
+import os
 import threading
 
 import torch
@@ -61,6 +64,23 @@ from torch._C._distributed_c10d import _SymmetricMemory
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+# torch's get_symm_mem_workspace() re-allocates and re-rendezvous's the
+# fused-op workspace whenever an op requests more than the current size,
+# dropping the old workspace tensor with NO synchronization. Device-side
+# work still targeting the old workspace (parked barrier waits on its
+# signal pads, in-flight P2P chunk copies from peers) then polls freed /
+# recyclable memory and can park its stream forever. Two defenses:
+#   * floor the first allocation high enough that growth never happens
+#     in practice;
+#   * if growth does happen, drain the device and keep the old tensor
+#     alive forever (bounded leak, rare) so parked ops keep polling
+#     stable memory.
+_WORKSPACE_FLOOR = int(
+    os.getenv("VLLM_SYMM_MEM_WORKSPACE_FLOOR_MB", "256")
+) * 1024 * 1024
+_workspace_graveyard: list = []
+_orig_get_workspace = None
 
 _MAX_CHANNELS = 8
 _RING = 4
@@ -125,6 +145,34 @@ def reset_pcie_barrier_state() -> None:
         _seq_state.clear()
 
 
+def _guarded_get_workspace(group_name, min_size):
+    import torch.distributed._symmetric_memory as tsm
+
+    tensor = tsm._group_name_to_workspace_tensor.get(group_name)
+    size = tensor.numel() * tensor.element_size() if tensor is not None else 0
+    need = max(min_size, _WORKSPACE_FLOOR)
+    if tensor is not None and size < need:
+        logger.warning(
+            "symm-mem workspace grows %d -> %d bytes; draining the device "
+            "and retiring the old workspace without freeing it",
+            size,
+            need,
+        )
+        torch.cuda.synchronize()
+        _workspace_graveyard.append(tensor)
+    return _orig_get_workspace(group_name, need)
+
+
+def _install_workspace_guard() -> None:
+    global _orig_get_workspace
+    import torch.distributed._symmetric_memory as tsm
+
+    if _orig_get_workspace is not None:
+        return
+    _orig_get_workspace = tsm.get_symm_mem_workspace
+    tsm.get_symm_mem_workspace = _guarded_get_workspace
+
+
 def install_pcie_safe_barrier() -> None:
     """Replace ``_SymmetricMemory.barrier`` process-wide. Idempotent."""
     global _installed, _orig_barrier, _drv
@@ -135,8 +183,11 @@ def install_pcie_safe_barrier() -> None:
     _drv = drv
     _orig_barrier = _SymmetricMemory.barrier
     _SymmetricMemory.barrier = _pcie_safe_barrier
+    _install_workspace_guard()
     _installed = True
     logger.info_once(
         "torch symm-mem group barrier replaced with the PCIe-safe "
-        "stream-memops protocol (no native P2P atomics on this platform)."
+        "stream-memops protocol (no native P2P atomics on this platform); "
+        "fused-op workspace floored at %d MiB with growth guard."
+        % (_WORKSPACE_FLOOR // (1024 * 1024))
     )

--- a/vllm/distributed/device_communicators/symm_mem_pcie_barrier.py
+++ b/vllm/distributed/device_communicators/symm_mem_pcie_barrier.py
@@ -57,6 +57,8 @@ Known constraints:
 
 import os
 import threading
+from collections.abc import Callable
+from typing import Any
 
 import torch
 from torch._C._distributed_c10d import _SymmetricMemory
@@ -80,7 +82,7 @@ _WORKSPACE_FLOOR = (
     int(os.getenv("VLLM_SYMM_MEM_WORKSPACE_FLOOR_MB", "256")) * 1024 * 1024
 )
 _workspace_graveyard: list = []
-_orig_get_workspace = None
+_orig_get_workspace: Callable[[str, int], torch.Tensor] | None = None
 
 _MAX_CHANNELS = 8
 _RING = 4
@@ -89,7 +91,7 @@ _lock = threading.Lock()
 _seq_state: dict[int, dict[int, int]] = {}
 _installed = False
 _orig_barrier = None
-_drv = None
+_drv: Any = None
 
 
 def _pcie_safe_barrier(self, channel: int = 0, timeout_ms: int = 0) -> None:
@@ -158,9 +160,11 @@ def _guarded_get_workspace(group_name, min_size):
             size,
             need,
         )
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         _workspace_graveyard.append(tensor)
-    return _orig_get_workspace(group_name, need)
+    get_workspace = _orig_get_workspace
+    assert get_workspace is not None
+    return get_workspace(group_name, need)
 
 
 def _install_workspace_guard() -> None:
@@ -289,7 +293,7 @@ def _comm_stream_multi_all_gather_and_consume(
             offset_bytes += buf.numel() * buf.element_size()
         return bufs
 
-    shards = [[] for _ in range(group_size)]
+    shards: list[list[torch.Tensor]] = [[] for _ in range(group_size)]
     for x in ag_out:
         for i, y in enumerate(x.chunk(group_size)):
             shards[i].append(y)

--- a/vllm/distributed/device_communicators/symm_mem_pcie_barrier.py
+++ b/vllm/distributed/device_communicators/symm_mem_pcie_barrier.py
@@ -76,9 +76,9 @@ logger = init_logger(__name__)
 #   * if growth does happen, drain the device and keep the old tensor
 #     alive forever (bounded leak, rare) so parked ops keep polling
 #     stable memory.
-_WORKSPACE_FLOOR = int(
-    os.getenv("VLLM_SYMM_MEM_WORKSPACE_FLOOR_MB", "256")
-) * 1024 * 1024
+_WORKSPACE_FLOOR = (
+    int(os.getenv("VLLM_SYMM_MEM_WORKSPACE_FLOOR_MB", "256")) * 1024 * 1024
+)
 _workspace_graveyard: list = []
 _orig_get_workspace = None
 
@@ -173,6 +173,172 @@ def _install_workspace_guard() -> None:
     tsm.get_symm_mem_workspace = _guarded_get_workspace
 
 
+# Fused-op pipelines, re-issued for PCIe: torch's stock micro-pipelines
+# enqueue peer-memory operations (signal-pad memops, P2P copies)
+# concurrently from two streams per process and secure the required
+# kernel scheduling order with a sleep-kernel nudge the source itself
+# only calls "almost guarantee[d]". On PCIe platforms we replace both
+# pipelines with comm-stream variants: every peer-memory operation is
+# issued on ONE stream per process, while producers/consumers (pure
+# local kernels) ride a second stream ordered by explicit CUDA events
+# in both directions (producer-done -> comm may start; peers-done ->
+# buffer may be overwritten). Compute/comm overlap is retained; the
+# only overlap given up is between P2P copies of different streams,
+# which torch's own comments note cannot overlap anyway. Measured on
+# 4x SM120 PCIe (8192x4096 @ 4096x4096 bf16 vs unfused NCCL):
+# matmul-reduce-scatter 1.78x (stock dual-stream: 1.56x — the explicit
+# ordering also removes the stock path's scheduling-miss degradation),
+# all-gather-matmul 1.69x (stock: 1.78x). The rarely-used *_last_dim
+# all-gather variant is left stock.
+_orig_produce_a2a = None
+_orig_multi_ag = None
+
+
+def _comm_stream_produce_and_all2all(
+    chunk_producer, output, group_name, out_chunk_dim=0
+):
+    import torch.distributed._symmetric_memory as tsm
+    import torch.distributed.distributed_c10d as c10d
+
+    out_chunks = output.chunk(
+        c10d._get_group_size_by_name(group_name), dim=out_chunk_dim
+    )
+    p2p_workspace_size_req = out_chunks[0].numel() * out_chunks[0].element_size() * 2
+    symm_mem = tsm.get_symm_mem_workspace(group_name, min_size=p2p_workspace_size_req)
+    group_size = symm_mem.world_size
+    rank = symm_mem.rank
+
+    comm = torch.cuda.current_stream()
+    prod = tsm._get_backend_stream()
+
+    symm_mem.barrier(channel=0)  # entry fence, on comm stream
+    prod.wait_stream(comm)
+
+    def get_p2p_buf(r: int, idx: int) -> torch.Tensor:
+        offset = 0 if idx == 0 else out_chunks[0].numel()
+        return symm_mem.get_buffer(r, out_chunks[0].shape, out_chunks[0].dtype, offset)
+
+    # reuse-fence events: producer of step k+2 must wait until peers
+    # finished reading the same buffer at step k (second barrier done)
+    reuse_evt: list = [None, None]
+
+    for step in range(1, group_size):
+        remote_rank = (rank - step) % group_size
+        buf_id = 1 if step % 2 == 0 else 0
+
+        if reuse_evt[buf_id] is not None:
+            prod.wait_event(reuse_evt[buf_id])
+        with torch.cuda.stream(prod):
+            chunk_producer((rank + step) % group_size, get_p2p_buf(rank, buf_id))
+        done = torch.cuda.Event()
+        done.record(prod)
+
+        comm.wait_event(done)
+        # all peer-memory ops stay on the comm stream:
+        symm_mem.barrier(channel=step % 2)
+        out_chunks[remote_rank].copy_(get_p2p_buf(remote_rank, buf_id))
+        symm_mem.barrier(channel=step % 2)
+        ev = torch.cuda.Event()
+        ev.record(comm)
+        reuse_evt[buf_id] = ev
+
+    with torch.cuda.stream(prod):
+        chunk_producer(rank, out_chunks[rank])
+    comm.wait_stream(prod)
+    symm_mem.barrier(channel=0)
+
+
+def _comm_stream_multi_all_gather_and_consume(
+    shard, shard_consumer, ag_out, group_name, ag_out_needed=True
+):
+    import torch.distributed._symmetric_memory as tsm
+
+    p2p_workspace_size_req = 0
+    for x in shard:
+        p2p_workspace_size_req += x.numel() * x.element_size()
+    symm_mem = tsm.get_symm_mem_workspace(group_name, min_size=p2p_workspace_size_req)
+    group_size = symm_mem.world_size
+    rank = symm_mem.rank
+
+    for x, y in zip(shard, ag_out):
+        assert x.is_contiguous()
+        assert y.is_contiguous()
+        assert x.shape[0] * group_size == y.shape[0]
+        assert x.shape[1:] == y.shape[1:]
+
+    comm = torch.cuda.current_stream()
+    cons = tsm._get_backend_stream()
+
+    symm_mem.barrier(channel=0)
+
+    def copy_shard(dst, src):
+        for d, s in zip(dst, src):
+            d.copy_(s)
+
+    def get_p2p_bufs(remote_rank):
+        offset_bytes = 0
+        bufs = []
+        for x in shard:
+            buf = symm_mem.get_buffer(
+                remote_rank,
+                x.shape,
+                x.dtype,
+                storage_offset=offset_bytes // x.element_size(),
+            )
+            bufs.append(buf)
+            offset_bytes += buf.numel() * buf.element_size()
+        return bufs
+
+    shards = [[] for _ in range(group_size)]
+    for x in ag_out:
+        for i, y in enumerate(x.chunk(group_size)):
+            shards[i].append(y)
+
+    copy_shard(get_p2p_bufs(rank), shard)  # local write, comm stream
+    symm_mem.barrier(channel=1)
+
+    # own shard consumes the input directly; overlap it with peer copies
+    cons.wait_stream(comm)
+    with torch.cuda.stream(cons):
+        shard_consumer(shard, rank)
+
+    for step in range(1, group_size):
+        remote_rank = (step + rank) % group_size
+        # peer read on the comm stream
+        copy_shard(shards[remote_rank], get_p2p_bufs(remote_rank))
+        ev = torch.cuda.Event()
+        ev.record(comm)
+        cons.wait_event(ev)
+        with torch.cuda.stream(cons):
+            shard_consumer(shards[remote_rank], remote_rank)
+
+    if ag_out_needed:
+        copy_shard(shards[rank], shard)  # local copy, comm stream
+
+    comm.wait_stream(cons)
+    symm_mem.barrier(channel=0)
+
+
+def _install_comm_stream_pipelines() -> None:
+    """Replace both fused micro-pipelines process-wide. Idempotent."""
+    global _orig_produce_a2a, _orig_multi_ag
+    import torch.distributed._symmetric_memory as tsm
+
+    if _orig_produce_a2a is not None:
+        return
+    _orig_produce_a2a = tsm._pipelined_produce_and_all2all
+    _orig_multi_ag = tsm._pipelined_multi_all_gather_and_consume
+    tsm._pipelined_produce_and_all2all = _comm_stream_produce_and_all2all
+    tsm._pipelined_multi_all_gather_and_consume = (
+        _comm_stream_multi_all_gather_and_consume
+    )
+    logger.info_once(
+        "torch fused-op micro-pipelines replaced with comm-stream "
+        "variants: peer-memory ops on one stream, producers "
+        "event-ordered on a second."
+    )
+
+
 def install_pcie_safe_barrier() -> None:
     """Replace ``_SymmetricMemory.barrier`` process-wide. Idempotent."""
     global _installed, _orig_barrier, _drv
@@ -184,10 +350,11 @@ def install_pcie_safe_barrier() -> None:
     _orig_barrier = _SymmetricMemory.barrier
     _SymmetricMemory.barrier = _pcie_safe_barrier
     _install_workspace_guard()
+    _install_comm_stream_pipelines()
     _installed = True
+    workspace_floor_mib = _WORKSPACE_FLOOR // (1024 * 1024)
     logger.info_once(
         "torch symm-mem group barrier replaced with the PCIe-safe "
         "stream-memops protocol (no native P2P atomics on this platform); "
-        "fused-op workspace floored at %d MiB with growth guard."
-        % (_WORKSPACE_FLOOR // (1024 * 1024))
+        f"fused-op workspace floored at {workspace_floor_mib} MiB with growth guard."
     )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -245,6 +245,7 @@ if TYPE_CHECKING:
     VLLM_ALLREDUCE_USE_SYMM_MEM: bool = True
     VLLM_ALLREDUCE_USE_FLASHINFER: bool = False
     VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE: bool = False
+    VLLM_SYMM_MEM_PCIE_SAFE_BARRIER: bool = False
     VLLM_TUNED_CONFIG_FOLDER: str | None = None
     VLLM_ENABLE_STARTUP_PLAN: bool = False
     VLLM_GPT_OSS_SYSTEM_TOOL_MCP_LABELS: set[str] = set()
@@ -1777,6 +1778,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # correctness risk; measure against NCCL on your topology first.
     "VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE": lambda: bool(
         int(os.getenv("VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE", "0"))
+    ),
+    # Replace the torch symm-mem group barrier with a stream-memops
+    # sequence protocol (peer plain writes + local waits). Needed for the
+    # pipelined fused GEMM+comm ops on platforms without native P2P
+    # atomics, where the stock CAS-based barrier wedges under load.
+    "VLLM_SYMM_MEM_PCIE_SAFE_BARRIER": lambda: bool(
+        int(os.getenv("VLLM_SYMM_MEM_PCIE_SAFE_BARRIER", "0"))
     ),
     # Experimental: use this to enable MCP tool calling for non harmony models
     "VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT": lambda: bool(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -244,6 +244,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_FP8_MFMA_PAGE_ATTN: bool = False
     VLLM_ALLREDUCE_USE_SYMM_MEM: bool = True
     VLLM_ALLREDUCE_USE_FLASHINFER: bool = False
+    VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE: bool = False
     VLLM_TUNED_CONFIG_FOLDER: str | None = None
     VLLM_ENABLE_STARTUP_PLAN: bool = False
     VLLM_GPT_OSS_SYSTEM_TOOL_MCP_LABELS: set[str] = set()
@@ -1769,6 +1770,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Whether to use FlashInfer allreduce
     "VLLM_ALLREDUCE_USE_FLASHINFER": lambda: bool(
         int(os.getenv("VLLM_ALLREDUCE_USE_FLASHINFER", "0"))
+    ),
+    # Allow the custom allreduce on >2 GPUs without full NVLink connectivity
+    # (PCIe-only P2P). The custom AR sync protocol is atomics-free (peer
+    # plain writes + local polling), so this is a performance opt-in, not a
+    # correctness risk; measure against NCCL on your topology first.
+    "VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE": lambda: bool(
+        int(os.getenv("VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE", "0"))
     ),
     # Experimental: use this to enable MCP tool calling for non harmony models
     "VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT": lambda: bool(

--- a/vllm/model_executor/models/hy_v3.py
+++ b/vllm/model_executor/models/hy_v3.py
@@ -553,10 +553,7 @@ class HYV3Model(nn.Module, MixtureOfExperts):
                 {"hidden_states": hidden_states, "residual": residual}
             )
 
-        hidden_states = hidden_states + residual
-        residual = hidden_states
-
-        hidden_states = self.norm(hidden_states)
+        hidden_states, _ = self.norm(hidden_states, residual)
 
         return hidden_states
 

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -279,6 +279,10 @@ class CudaPlatformBase(Platform):
         raise NotImplementedError
 
     @classmethod
+    def has_native_p2p_atomics(cls, device_ids: list[int]) -> bool:
+        raise NotImplementedError
+
+    @classmethod
     def log_warnings(cls):
         pass
 
@@ -799,6 +803,33 @@ class NvmlCudaPlatform(CudaPlatformBase):
         return True
 
     @classmethod
+    @with_nvml_context
+    def has_native_p2p_atomics(cls, physical_device_ids: list[int]) -> bool:
+        """
+        query if every gpu pair supports native P2P atomic operations
+        (system-scope atomics issued directly on peer-mapped memory)
+        """
+        handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in physical_device_ids]
+        for i, handle in enumerate(handles):
+            for j, peer_handle in enumerate(handles):
+                if i < j:
+                    try:
+                        p2p_status = pynvml.nvmlDeviceGetP2PStatus(
+                            handle,
+                            peer_handle,
+                            pynvml.NVML_P2P_CAPS_INDEX_ATOMICS,
+                        )
+                        if p2p_status != pynvml.NVML_P2P_STATUS_OK:
+                            return False
+                    except pynvml.NVMLError:
+                        logger.exception(
+                            "P2P atomics detection failed. Assuming native"
+                            " P2P atomics are not available."
+                        )
+                        return False
+        return True
+
+    @classmethod
     def _get_physical_device_name(cls, device_id: int = 0) -> str:
         handle = pynvml.nvmlDeviceGetHandleByIndex(device_id)
         return pynvml.nvmlDeviceGetName(handle)
@@ -985,6 +1016,14 @@ class NonNvmlCudaPlatform(CudaPlatformBase):
         logger.exception(
             "NVLink detection not possible, as context support was"
             " not found. Assuming no NVLink available."
+        )
+        return False
+
+    @classmethod
+    def has_native_p2p_atomics(cls, physical_device_ids: list[int]) -> bool:
+        logger.exception(
+            "P2P atomics detection not possible, as context support was"
+            " not found. Assuming native P2P atomics are not available."
         )
         return False
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -2,10 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Attention layer with FlashInfer."""
 
+import inspect
 from dataclasses import dataclass
 from enum import Enum
-from functools import partial
-from typing import ClassVar
+from functools import cache, partial
+from typing import Any, ClassVar
 
 import numpy as np
 import torch
@@ -772,6 +773,11 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         supports_spec_as_decode = (
             self.flashinfer_trtllm_api_decode_kernel
             == FlashInferDecodeKernel.TRTLLM_GEN
+        ) or (
+            # The FI native decode wrapper can plan uniform multi-token
+            # queries (verify batches) when FlashInfer is new enough.
+            not self.use_trtllm_decode_attention
+            and flashinfer_supports_uniform_multi_token_decode()
         )
         self._init_reorder_batch_threshold(
             1,
@@ -899,9 +905,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
     ) -> AttentionCGSupport:
         """Get the cudagraph support level for FlashInfer attention.
 
-        The SM90 XQA integration only enables single-token decode today. Keep
-        specdec CUDA graphs limited to trtllm-gen until vLLM wires the XQA
-        specdec mask.
+        The SM90 XQA integration only enables single-token decode today
+        (specdec mask not wired). Elsewhere, uniform spec-decode batches
+        capture FULL graphs via trtllm-gen or, with a new enough FlashInfer,
+        via the FI native tensor-core decode path.
         """
         if current_platform.is_device_capability(90):
             return AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
@@ -929,8 +936,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 has_trtllm_support = False
                 break
 
-        # trtllm-gen only supports causal attention.
-        if has_trtllm_support and not vllm_config.attention_config.use_non_causal:
+        # The decode paths only support causal attention.
+        if (
+            has_trtllm_support or flashinfer_supports_uniform_multi_token_decode()
+        ) and not vllm_config.attention_config.use_non_causal:
             return AttentionCGSupport.UNIFORM_BATCH
         else:
             return AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
@@ -1478,11 +1487,13 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     and pure_decode
                     and num_decode_tokens <= self._decode_cudagraph_max_bs
                 )
-                num_input_tokens = num_decode_tokens
+                # Spec-as-decode verify batches carry a uniform
+                # num_decode_tokens // num_decodes tokens per request; the
+                # wrapper's batch size and kv metadata are per request.
+                assert num_decode_tokens % num_decodes == 0
+                decode_q_len = num_decode_tokens // num_decodes
 
-                decode_wrapper = self._get_decode_wrapper(
-                    num_input_tokens, use_cudagraph
-                )
+                decode_wrapper = self._get_decode_wrapper(num_decodes, use_cudagraph)
                 # Use the persistent buffer with padding length,
                 # instead of the same address but chunked version
                 # in atten_metadata when using cudagraph.
@@ -1494,11 +1505,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 )
                 fast_plan_decode(
                     decode_wrapper,
-                    indptr_cpu=self.paged_kv_indptr.cpu[: num_input_tokens + 1],
+                    indptr_cpu=self.paged_kv_indptr.cpu[: num_decodes + 1],
                     indices=paged_kv_indices,
-                    last_page_len_cpu=self.paged_kv_last_page_len.cpu[
-                        :num_input_tokens
-                    ],
+                    last_page_len_cpu=self.paged_kv_last_page_len.cpu[:num_decodes],
                     num_qo_heads=self.num_qo_heads * self.dcp_world_size,
                     num_kv_heads=self.num_kv_heads,
                     head_dim=self.head_dim,
@@ -1513,6 +1522,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     o_data_type=o_dtype,
                     fixed_split_size=self.decode_fixed_split_size,
                     disable_split_kv=self.disable_split_kv,
+                    q_len_per_req=decode_q_len,
                 )
                 attn_metadata.decode = FIDecode(wrapper=decode_wrapper)
         return attn_metadata
@@ -2290,6 +2300,14 @@ class FlashInferImpl(AttentionImpl):
             )
 
 
+@cache
+def flashinfer_supports_uniform_multi_token_decode() -> bool:
+    """Whether the installed FlashInfer can plan the tensor-core decode path
+    for a uniform q_len_per_req > 1 (spec-decode verify) and keep the plan
+    cudagraph-safe."""
+    return "q_len_per_req" in inspect.signature(fast_decode_plan).parameters
+
+
 def fast_plan_decode(
     self,  # decode wrapper
     indptr_cpu: torch.Tensor,
@@ -2312,6 +2330,7 @@ def fast_plan_decode(
     non_blocking: bool = True,
     fixed_split_size: int = -1,
     disable_split_kv: bool = False,
+    q_len_per_req: int = 1,
 ) -> None:
     """
     A faster version of BatchDecodeWithPagedKVCacheWrapper::plan used for
@@ -2326,6 +2345,15 @@ def fast_plan_decode(
     Part of the code get inspiration from the original plan from FlashInfer repo
     and the implementation of fast_decode_plan for FlashInfer in SGlang repo.
     """
+    supports_uniform_multi_token = flashinfer_supports_uniform_multi_token_decode()
+    if q_len_per_req > 1 and not supports_uniform_multi_token:
+        raise RuntimeError(
+            "The installed FlashInfer does not support uniform multi-token decode."
+        )
+    uniform_decode_kwargs: dict[str, Any] = {}
+    if supports_uniform_multi_token:
+        uniform_decode_kwargs["q_len_per_req"] = q_len_per_req
+
     # Warm up with the original plan if it is first call, and always run the
     # original plan if we run for dynamic shape. For fixed shape (cudagraph),
     # this warm up is to generate the _cached_module for the decode wrapper.
@@ -2353,6 +2381,7 @@ def fast_plan_decode(
             seq_lens=None,
             fixed_split_size=fixed_split_size,
             disable_split_kv=disable_split_kv,
+            **uniform_decode_kwargs,
         )
         self.vllm_first_call = False
         return
@@ -2380,6 +2409,7 @@ def fast_plan_decode(
         non_blocking=non_blocking,
         fixed_split_size=fixed_split_size,
         disable_split_kv=disable_split_kv,
+        **uniform_decode_kwargs,
     )
 
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3528,7 +3528,11 @@ class GPUModelRunner(
         # enabled collective fusion for SP
         tp_size = self.vllm_config.parallel_config.tensor_parallel_size
         if self.compilation_config.pass_config.enable_sp and tp_size > 1:
-            return round_up(num_scheduled_tokens, tp_size)
+            sp_min_token_num = self.compilation_config.pass_config.sp_min_token_num
+            # Below sp_min_token_num the compile range is not SP-rewritten
+            # and needs no tp divisibility.
+            if sp_min_token_num is None or num_scheduled_tokens >= sp_min_token_num:
+                return round_up(num_scheduled_tokens, tp_size)
         return num_scheduled_tokens
 
     def _prepare_mm_inputs(
@@ -3988,7 +3992,11 @@ class GPUModelRunner(
             num_tokens_padded, disable_full=use_cascade_attn or has_encoder_output
         )
         num_tokens_padded = batch_descriptor.num_tokens
-        if self.compilation_config.pass_config.enable_sp:
+        pass_config = self.compilation_config.pass_config
+        if pass_config.enable_sp and (
+            pass_config.sp_min_token_num is None
+            or batch_descriptor.num_tokens >= pass_config.sp_min_token_num
+        ):
             assert (
                 batch_descriptor.num_tokens
                 % self.vllm_config.parallel_config.tensor_parallel_size

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -586,8 +586,14 @@ def is_residual_scattered_for_sp(
         or not vllm_config.compilation_config.splitting_ops
     ), "Sequence parallelism requires full-graph compilation"
 
-    # When sequence parallelism is enabled, we always pad num_input_tokens
-    # to be a multiple of tensor_parallel_size (tp) earlier.
+    sp_min_token_num = vllm_config.compilation_config.pass_config.sp_min_token_num
+    # Below sp_min_token_num the compile range is not SP-rewritten and the
+    # residual stays full-shape.
+    if sp_min_token_num is not None and num_input_tokens < sp_min_token_num:
+        return False
+
+    # When sequence parallelism applies, num_input_tokens was padded to a
+    # multiple of tensor_parallel_size (tp) earlier.
     assert num_input_tokens % tp == 0
 
     return True


### PR DESCRIPTION
**Depends on** flashinfer-ai/flashinfer#3871 for the spec-decode FULL cudagraph benefit. The capability is feature-detected from the `fast_decode_plan` signature at runtime; with an older FlashInfer the backend behaves exactly as before, so this PR merges independently — the benefit activates once FlashInfer ships the counterpart.

### Purpose

SM120 workstation/server parts (RTX PRO 6000 family) are PCIe-only: every GPU pair reports P2P `AccessSupported=1` but `NativeAtomicSupported=0`. This PR is the full serving enablement for that platform in two parts — Part I enables sequence parallelism / async-TP and FULL spec-decode cudagraphs; Part II makes the multi-GPU comm layer both safe (torch symm-mem's CAS signal protocol is not atomic here and wedges under load) and fast (custom allreduce + a PCIe-safe barrier for the fused GEMM+comm ops).

**Part I — SP/async-TP and spec-decode**, four issues:

1. **SM120 (PCIe-only Blackwell workstation/server GPUs, e.g. RTX PRO 6000) has no SP threshold table entry**, so both passes are silently disabled — with a warning that misleadingly blames `hidden_size`. On PCIe the comm/compute cost ratio is inverted relative to NVLink platforms, so SP pays off at much smaller shapes: measured on 4x RTX PRO 6000 (tp4, hidden 4096), fused matmul+RS / AG+matmul beats plain mm+allreduce from ~640 tokens (bf16) / ~896 tokens (fp8 scaled), reaching 1.35–1.66x at 1024–8192 tokens. **Platform caveat (root-caused 2026-07-07)**: torch symmetric memory's *data* path works on SM120 over PCIe P2P (plain reads/writes), but its signal-pad synchronization issues system-scope CAS on peer memory, and SM120 PCIe boxes report `NativeAtomicSupported=0` for every GPU pair — under load the sync loses tokens and wedges (this is the first-run hang family, see Known issues). Microbenchmarks and most runs pass because failures are load-dependent.
2. **`HYV3Model`'s final norm uses an explicit add + plain rms_norm** instead of the two-arg fused-add residual idiom. The SP pass's patterns then leave the last MoE all-reduce unrewritten while the residual chain is already sharded, and compilation fails with `The size of tensor a (s72) must match the size of tensor b ((s72//4))`. Any model deviating from the idiom fails the same way with SP enabled.
3. **The tp-divisibility shape constraints for SP apply unconditionally**, while the SP pass itself only rewrites compile ranges at or above `sp_min_token_num`. Sub-threshold decode batches get padded up to tp multiples: on a 192-expert MoE at bs1 this costs +46% ITL (memory-bound expert gather runs 4x tokens; per-op grouped-GEMM time observed 22.0 → 38.8 us in traces).
4. **Spec-decode verify batches cannot capture FULL cudagraphs on the FlashInfer native (non-trtllm) path** — the backend is capped at `UNIFORM_SINGLE_TOKEN_DECODE`, so MTP/EAGLE decode runs piecewise, and combined with SP (which forbids piecewise unless `use_inductor_graph_partition` is on) cudagraphs are disabled entirely. flashinfer-ai/flashinfer#3871 makes the FA2 tensor-core decode path plan uniform multi-token queries cudagraph-safely; this PR detects and uses that capability (see the dependency note above).

**Part II — PCIe-safe multi-GPU comms**, seven changes:

5. **Serialize symm-mem all-reduce on a dedicated stream**: the one/two-shot kernels have no notion of op instances, so all-reduces issued from different streams (profile / compile warmup / capture) can interleave two barrier instances and wedge (pytorch/pytorch#189228). Fence every op of the communicator on an internal stream.
6. **Gate symm-mem all-reduce on native P2P atomics** (`CudaPlatform.has_native_p2p_atomics`, pairwise NVML query mirroring `is_fully_connected`): platforms that cannot run the CAS signal protocol fall back to the next backend instead of wedging at runtime. SM120 table entries (64 MiB cap, 128 KiB floor, multicast check scoped to the multimem kernels) only take effect where this gate passes.
7. **`VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE`**: the custom allreduce sync protocol is atomics-free (peer plain writes + local polling), so the >2-GPU full-NVLink requirement is a performance heuristic, not a correctness gate. Opt in on PCIe topologies; algo defaults to 2-stage and the size ceiling rises to 256 MiB to cover chunked-prefill all-reduces (16k tokens x 4k hidden x bf16 = 128 MiB).
8. **`VLLM_SYMM_MEM_PCIE_SAFE_BARRIER`**: replace `_SymmetricMemory.barrier(channel)` with a stream-memops **ring-slot sequence protocol**: the sender `cuStreamWriteValue32`s the instance's sequence number into a per-instance ring slot `(channel, seq % RING, sender)` of the receiver's pad; the receiver `cuStreamWaitValue32(EQ)`-polls the matching slot of its *own* pad — no remote read-modify-write anywhere. Concurrent same-channel instances issued from different streams touch disjoint slots, so the protocol is structurally immune to the multi-stream interleaving hazard (pytorch/pytorch#189228), and EQ matching makes a slot's stale previous-lap value simply not match. The pipelined fused GEMM+comm ops synchronize exclusively through this barrier, so async-TP becomes usable on PCIe-only platforms — previously it hung on ~1/3 of cold starts here. The patched barrier refuses CUDA graph capture (a baked sequence number would no-op on replay); fused ops run above the capture ceiling, so the path is structurally unreachable today.
9. CPU-only unit tests for the atomics query and the barrier protocol (ring-slot addressing, sequence progression and wrap, write-before-wait ordering, capture guard).
10. **Guard torch symm-mem workspace growth**: `get_symm_mem_workspace()` re-allocates and re-rendezvous's the fused-op workspace whenever a caller requests more than the current size, dropping the old workspace tensor with **no synchronization** — device-side work still targeting it (parked barrier waits on its signal pads, in-flight P2P chunk copies from peers) then polls freed memory and can park its stream forever; the growth decision is also per-rank local, so one rank can free while a peer still has device work against its old remote mapping. With the safe barrier installed, the workspace getter is wrapped: the first allocation is floored (`VLLM_SYMM_MEM_WORKSPACE_FLOOR_MB`, default 256) so steady-state growth never happens, and any residual growth logs, drains the device, and retires the old tensor to a keep-alive list (bounded leak, rare). This converted a 100%-reproducible sustained-load wedge on our box (8/8 runs) into 8/8 clean; an upstream torch report is being filed separately.
11. **Comm-stream fused pipelines**: torch's `_pipelined_produce_and_all2all` / `_pipelined_multi_all_gather_and_consume` enqueue peer-memory operations concurrently from two streams per process and secure the kernel scheduling order their cross-rank obligations depend on with a sleep-kernel nudge the source itself only calls "almost guarantee[d]". With the safe barrier installed, both pipelines are replaced by comm-stream variants: every peer-memory operation (signal-pad memops, P2P copies) issues on ONE stream per process, while producers/consumers (pure local kernels) ride a second stream ordered by explicit CUDA events in both directions. Compute/comm overlap is retained — the only overlap given up is between P2P copies of different streams, which torch's own comments note cannot overlap anyway — and the explicit ordering is measurably *faster* than the sleep-trick on the RS side while removing an entire class of concurrent-peer-enqueue exposure (Known issue C).

### Changes

- `hy_v3.py`: use the two-arg residual form for the final norm (also picks up the fused add+rmsnorm kernel).
- `sequence_parallelism.py`: add capability-120 threshold table entries (`hidden >= 4096`, `2 MB/GPU` ≈ 1024 tokens at hidden 4096 / tp4 / bf16).
- Scope every tp-divisibility constraint to sizes at or above `sp_min_token_num` (5 sites): cudagraph capture-size filtering (`update_sizes_for_sequence_parallelism`), spec-decode capture rounding (`adjust_cudagraph_sizes_for_spec_decode`), runner token padding (`_pad_for_sequence_parallelism`), the post-dispatch divisibility assert, and `is_residual_scattered_for_sp`. Below the threshold the graphs are not SP-rewritten and need no tp alignment.
- Reword the disable warning to name the real cause (no heuristic entry for this device capability / hidden_size).
- When SP forbids piecewise cudagraphs (inductor graph partition off), the warning now points at the escape hatch: with spec-decode the mode otherwise silently collapses to NONE (attention backends capped at `UNIFORM_SINGLE_TOKEN_DECODE` reject FULL, piecewise is forbidden), running fully eager; `use_inductor_graph_partition=True` keeps piecewise cudagraphs with SP (verified: SP/async-TP patterns still fire under partition).
- `flashinfer.py`: add a cached signature probe for the FlashInfer capability; when the FI-native decode path is active and the capability is present, classify verify batches as decode (`reorder_batch_threshold = 1 + num_speculative_tokens`, matching trtllm-gen), declare `AttentionCGSupport.UNIFORM_BATCH`, key the decode wrapper and its kv metadata by request count, and pass `q_len_per_req` through `fast_plan_decode`. At `q_len_per_req == 1` the plans are bit-identical (capability arg passed as 0) and request count equals token count. The SM90 XQA case is explicitly excluded; DCP is unaffected (base class resets the threshold).

### Test Plan

- Unit: new SM120 cases in `test_sequence_parallelism_threshold.py`; `test_config.py` capture-size matrix updated to the scoped semantics (sub-threshold sizes keep exact shapes; at/above threshold still filtered).
- E2E on 4x RTX PRO 6000 (SM120, PCIe), Hy3-FP8 (295B MoE / 21B active, fp8, tp4), serving bench 8000-in/1000-out via aiperf, gsm8k full set via lm-eval.

### Test Result

gsm8k (1319 samples): **0.9484** with SP+asyncTP (three runs 0.9393–0.9484; baseline parity).

Serving bench, SP+asyncTP vs baseline (same box/case/client):

| concurrency | output tok/s | mean TTFT | mean ITL |
|---|---|---|---|
| 1 | 86.1 (+2.3%) | 0.92 s (-12.7%) | 10.69 ms (-1.1%) |
| 4 | 193.2 (+1.7%) | 1.87 s (-16.4%) | 18.84 ms (±0) |
| 8 | 263.8 (+2.6%) | 2.50 s (-23.3%) | 27.84 ms (-0.2%) |
| 32 | 431.6 (+5.0%) | 5.10 s (-15.1%) | 68.99 ms (-3.9%) |

Without the constraint scoping (change 3), bs1 ITL regresses +46% (10.81 → 15.73 ms) and bs1 throughput -28%; with it, decode is neutral at every level.

Microbench (torch symm-mem fused ops on the shipped comm-stream pipelines, 8192x4096 @ 4096x4096, vs unfused mm + NCCL collective on the same harness): `fused_matmul_reduce_scatter` **1.78x** (bf16), `fused_all_gather_matmul` **1.76x** (bf16), `fused_scaled_matmul_reduce_scatter` **1.59x** (fp8, tensor-wise scales); numerics within reduction-order noise of the unfused goldens (rel err 3e-3–8e-3). The stock dual-stream pipelines measure 1.56x / 1.78x (bf16) on the same harness — the event-ordered variant is net faster on the RS side because it removes the stock path's scheduling-miss degradation.

Spec-decode FULL graphs (change 4), same model with SP + MTP k=1, FlashInfer native decode (`AttentionCGSupport.UNIFORM_BATCH` declared, mode resolves `FULL_DECODE_ONLY`, FULL decode graphs captured; acceptance length 1.99–2.00 unchanged). bs1 streaming per-token latency:

| probe | this PR (SP + MTP k=1, decode FULL) | MTP k=1 piecewise (no SP) | no MTP (SP, FULL) |
|---|---|---|---|
| fox 450 tok ctx | 7.13 ms | — | — |
| fox 2k ctx | 7.10 ms | — | — |
| fox 8k ctx | 7.44 ms | 7.3 ms | 10.7 ms |
| essay ~1.6k ctx | 7.22 ms | ~9.0 ms | — |

Flat across context length; the piecewise graph tax on shorter contexts (~20% at 1.6k) is recovered, and spec decode now composes with SP (the piecewise config cannot). gsm8k full set (1319, concurrency 32, cold server): 580 s wall / 0.9416 strict-match (piecewise MTP config: 589 s; no-MTP SP baseline: 451 s — verify-traffic doubling dominates throughput, as expected).

**End-to-end story (Hy3-FP8 295B MoE, tp4, gsm8k full set + 8k-in/1k-out serving bench, cold server per config)** — the two parts compose: custom allreduce carries the decode-size band (ITL), the safe-barrier fused ops carry prefill (TTFT), and the hangs that previously gated async-TP on this platform are gone:

| config | gsm8k | c1: tok/s / TTFT / ITL | c32: tok/s / TTFT / ITL |
|---|---|---|---|
| NCCL baseline (derived) | — | ~84 / ~1.05 s / ~10.8 ms | ~411 / ~6.0 s / ~71.8 ms |
| SP+async-TP, stock barrier (**~1/3 first-run hang**) | 0.939–0.948 | 86.1 / 0.92 s / 10.69 | 431.6 / 5.10 s / 68.99 |
| + custom AR only (TP-only) | 0.9424 | 93.6 / 1.16 / 9.53 | 446.7 / 5.42 / 66.17 |
| + custom AR, MTP k=1 | 0.9363 | 94.3 / 1.18 / 9.43 | 443.4 / 5.01 / 64.98 |
| full stack: SP+fused + custom AR (earlier revision†) | 0.9378 | 92.9 / 0.94 / 9.83 | 457.1 / 5.06 / 64.90 |
| **full stack + MTP k=1 (shipped pipelines)** | **0.9424** | 99.2 / 1.14 / 8.95 | **459.8 / 4.35 / 62.86** |

† measured before changes 10/11 (dual-stream pipelines, GEQ barrier); serving deltas between the pipeline variants measured within run noise at c1 and c32, so the row remains representative.

Net vs NCCL baseline: **+8–12% output throughput, best-in-matrix TTFT and ITL at c32, and spec decode now composes with SP under sustained load** (the async-TP TTFT level is restored without its ~1/3 first-run hang exposure; the MTP row was blocked by Known issue C wedges before changes 10/11).

**Known issue A (root-caused, fixed in this PR)**: the nondeterministic *first-run* hang family (~1/3 cold starts with async-TP active) was torch symm-mem synchronization failing on this platform: (I) the ops lack multi-stream instance pairing (pytorch/pytorch#189228, pure-torch repro), and (II) the signal-pad CAS protocol requires native P2P atomics, which no SM120 PCIe GPU pair supports (`nvidia-smi topo -p2p a` = NS while `-p2p r`/`-p2p w` = OK) — CAS on peer memory silently loses barrier tokens under PCIe load. Changes 5, 6 and 8 of this PR are the fix set: fence, capability gate, and the memops barrier replacement.

**Known issue B (upstream, not introduced by this PR)**: a nondeterministic hang under concurrent load (~1/25 runs in our sample; all ranks spin at 100%, launch queue saturated, `sample_tokens` RPC timeout) signature-matches vllm-project/vllm#41530 — reported there across DeepSeek-V4-Pro TP=8 + MTP, GH200 multi-node **without spec decode**, and other configs; the community-established common factor is FULL cudagraph + TP multiproc, with a lazy NCCL communicator creation observed mid-inference immediately before the hang. FlashInfer standalone is exonerated (fp8-KV / 8k-kv / real-shape capture-replay matrix bitwise-clean); enabling FULL decode graphs on this path puts SM120 spec-decode in the affected population, as any UNIFORM_BATCH backend already is. `NCCL_RUNTIME_CONNECT=0` (eager connection setup) is under evaluation as a mitigation. Update: our Known issue C forensics found the same *class* of failure (host threads parked inside libcuda enqueue calls, device queues near-empty) — if you are chasing #41530-family hangs, native host stacks of all ranks (`py-spy dump --native`) distinguish enqueue-blocks from synchronize-hangs, and `cudagraph_mode=FULL_DECODE_ONLY` did **not** prevent the wedge on our box.

**Known issue C (root-caused; fixed/mitigated in this PR; driver follow-up ongoing)**: sustained concurrent load on the SP+fused stack could wedge all four ranks permanently on this platform. Forensics across nine wedge specimens (live native stacks, device-side event bracketing, signal-pad dumps, three nsys traces) split it into two mechanisms. (1) torch's unsynchronized symm-mem workspace growth — **fixed by change 10**. (2) A residual wedge *below the framework*: at freeze every barrier instance is complete on device and stream queues are near-empty, while all host threads spin in `sched_yield` inside four distinct libcuda enqueue entry points (`cuStreamWriteValue32/WaitValue32`, `cuLaunchKernel(Ex)`); it reproduces on both matched and forward-compat driver pairings (frequency differs strongly) and is escalated to the NVIDIA driver team with a deterministic reproducer. An A/B changing **only the pipeline stream shape** passes the exact trigger that wedges the stock dual-stream shape — **change 11 removes that shape**, and the shipped stack has a 9-hour adversarial soak clean — 47 cycles of alternating burst/sustained-c32 load (~150k requests, identical accuracy every cycle) under the condition where the stock shape wedges within ~8 minutes — plus 600 stress-probe rounds. We treat that as strong suppression evidence, not proof; both features remain opt-in env gates defaulting off, so this PR adds no default-path exposure.

### Notes for reviewers

- The constraint scoping (change 3) affects all architectures when `enable_sp` is on: sub-threshold capture sizes keep exact shapes and sub-threshold steps are no longer padded. This matches the pass's own compile-range semantics; existing async-TP e2e tests exercise the new gating in CI. No NVLink-platform perf data was collected here.
- `is_residual_scattered_for_sp` now returns False below the threshold, which affects PP+SP intermediate-tensor handling; validated by unit consistency, no PP e2e in this run.
- Changes 8/10/11 monkeypatch torch symm-mem internals from vllm and engage only behind `VLLM_SYMM_MEM_PCIE_SAFE_BARRIER=1`; NVLink platforms and default configs are untouched. The comm-stream pipelines double as the concrete proposal in an upcoming torch issue on the sleep-trick scheduling contract; if torch adopts explicit ordering upstream, the vllm-side patch shrinks to the barrier + workspace guard.
- The spec-decode x SP startup guard is now also scoped: it only fires when a captured size can reach `sp_min_token_num` (unit-tested both ways). On attention backends capped below FULL spec-decode capture the guard was unreachable anyway (mode collapses to NONE first); the practical SP+spec path is `use_inductor_graph_partition=True` (piecewise graphs, SP rewrites verified firing).


