### PR TITLE
[CI] BugFix Eval Small Models Distributed test for DiffusionGemma

### DIFF
--- a/tests/evals/gsm8k/configs/DiffusionGemma-26B-A4B-it-FP8-dynamic.yaml
+++ b/tests/evals/gsm8k/configs/DiffusionGemma-26B-A4B-it-FP8-dynamic.yaml
@@ -4,6 +4,10 @@ num_questions: 1319
 num_fewshot: 5
 startup_max_wait_seconds: 1200
 use_chat_completions: true
+# Diffusion models use a fixed internal temperature schedule and do not
+# support per-request temperature or seed overrides.
+temperature: 1.0
+seed: null
 server_args: >-
   --enforce-eager
   --max-model-len 4096

--- a/tests/evals/gsm8k/test_gsm8k_correctness.py
+++ b/tests/evals/gsm8k/test_gsm8k_correctness.py
@@ -69,6 +69,8 @@ def run_gsm8k_eval(eval_config: dict, server_url: str) -> dict:
         use_chat_completions=eval_config.get("use_chat_completions", False),
         host=host,
         port=port,
+        temperature=eval_config.get("temperature", 0.0),
+        seed=eval_config.get("seed", 42),
         request_timeout_seconds=request_timeout_seconds,
         gen_prefix=eval_config.get("gen_prefix", ""),
     )


### PR DESCRIPTION
## Purpose

Fixes #47978

PR #45418 added `_validate_diffusion` which rejects `temperature != 1.0`
and `seed is not None` for diffusion models. The DiffusionGemma GSM8K eval
config did not override these, so the eval harness sent the incompatible
defaults (`temperature=0.0`, `seed=42`), causing all 1,319 requests to
fail with 400 Bad Request and 0% accuracy.


## Test Plan
- [ ] `LM Eval Small Models Distributed (2xB200)` with DiffusionGemma

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

