### PR TITLE
[Bugfix][CPU][RISC-V] Use explicit rounding mode for vfcvt float-to-int conversions

### DIFF
--- a/csrc/cpu/cpu_types_riscv_impl.hpp
+++ b/csrc/cpu/cpu_types_riscv_impl.hpp
@@ -517,8 +517,8 @@ struct FP32Vec8 : public Vec<FP32Vec8> {
     const float inv_ln2 = 1.44269504088896341f;
     fixed_fp32x8_t x_scaled =
         RVVI(__riscv_vfmul_vf_f32, LMUL_256)(x, inv_ln2, VEC_ELEM_NUM);
-    fixed_i32x8_t n_int =
-        RVVI(__riscv_vfcvt_x_f_v_i32, LMUL_256)(x_scaled, VEC_ELEM_NUM);
+    fixed_i32x8_t n_int = RVVI3(__riscv_vfcvt_x_f_v_i32, LMUL_256, _rm)(
+        x_scaled, __RISCV_FRM_RNE, VEC_ELEM_NUM);
     fixed_fp32x8_t n_float =
         RVVI(__riscv_vfcvt_f_x_v_f32, LMUL_256)(n_int, VEC_ELEM_NUM);
 
@@ -783,8 +783,8 @@ struct FP32Vec16 : public Vec<FP32Vec16> {
     const float inv_ln2 = 1.44269504088896341f;
     fixed_fp32x16_t x_scaled =
         RVVI(__riscv_vfmul_vf_f32, LMUL_512)(x, inv_ln2, VEC_ELEM_NUM);
-    fixed_i32x16_t n_int =
-        RVVI(__riscv_vfcvt_x_f_v_i32, LMUL_512)(x_scaled, VEC_ELEM_NUM);
+    fixed_i32x16_t n_int = RVVI3(__riscv_vfcvt_x_f_v_i32, LMUL_512, _rm)(
+        x_scaled, __RISCV_FRM_RNE, VEC_ELEM_NUM);
     fixed_fp32x16_t n_float =
         RVVI(__riscv_vfcvt_f_x_v_f32, LMUL_512)(n_int, VEC_ELEM_NUM);
     fixed_fp32x16_t r =
@@ -882,8 +882,8 @@ struct INT8Vec16 : public Vec<INT8Vec16> {
   fixed_i8x16_t reg;
 
   explicit INT8Vec16(const FP32Vec16& vec) {
-    auto i32_vec =
-        RVVI(__riscv_vfcvt_x_f_v_i32, LMUL_512)(vec.reg, VEC_ELEM_NUM);
+    auto i32_vec = RVVI3(__riscv_vfcvt_x_f_v_i32, LMUL_512, _rm)(
+        vec.reg, __RISCV_FRM_RNE, VEC_ELEM_NUM);
     auto i16_vec = RVVI(__riscv_vnclip_wx_i16, LMUL_256)(
         i32_vec, 0, __RISCV_VXRM_RNU, VEC_ELEM_NUM);
     reg = RVVI(__riscv_vnclip_wx_i8, LMUL_128)(i16_vec, 0, __RISCV_VXRM_RNU,


### PR DESCRIPTION
## Purpose

Three `vfcvt_x_f_v_i32` call sites in `csrc/cpu/cpu_types_riscv_impl.hpp` (`FP32Vec8::exp()`, `FP32Vec16::exp()`, and `INT8Vec16` constructor) use the non-_rm intrinsic form, which encodes rm=111 in the instruction — selecting the dynamic rounding mode.

Per the [RISC-V ISA manual](https://docs.riscv.org/reference/isa/v20260120/unpriv/f-st-ext.html):

> Floating-point operations use either a static rounding mode encoded in the instruction, or a dynamic rounding mode held in frm. [...] A value of 111 in the instruction's rm field selects the dynamic rounding mode held in frm.

> In typical implementations, writes to the dynamic rounding mode CSR state will serialize the pipeline. Static rounding modes are used to implement specialized arithmetic operations that often have to switch frequently between different rounding modes.

The dynamic mode reads fcsr.frm at runtime, but vLLM never sets frm explicitly. Any linked library may modify frm without restoring it — the RISC-V calling convention does not require preservation of fcsr. This makes the float-to-integer conversion results depend on call history: the same input can produce different exp() or INT8 quantization outputs depending on which library ran before it. Hardware testing(in Spacemit X100 board) confirmed that 42.2% of INT8 values differ when frm is changed from RNE to another mode.

The fix replaces all three calls with the _rm intrinsic variant, encoding `rm=000` (RNE) statically in the instruction. This eliminates the fcsr.frm dependency and matches the x86 (`cvtps_epi32`, MXCSR default RNE) and ARM (`vcvtnq_s32_f32`, hardcoded RNE) implementations of the same operations.


## Test Plan

## Test Result

Pre-commit has passed.

Additionly, I used Claude Opus 4.6 to fix the bug, manually reviewed code and tested on a Spacemit X100 board.