### PR TITLE
[Bugfix] Handle E8M0 block scales in CUTLASS and Triton FP8 linear kernels

### DIFF
--- a/tests/kernels/quantization/test_block_fp8.py
+++ b/tests/kernels/quantization/test_block_fp8.py
@@ -4,6 +4,7 @@
 # Adapted from https://github.com/sgl-project/sglang/pull/2575
 import itertools
 import types
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -14,10 +15,23 @@ from tests.kernels.quant_utils import (
 )
 from tests.kernels.utils import fp8_ulp_distance
 from vllm.config import VllmConfig
-from vllm.model_executor.kernels.linear.scaled_mm.cutlass import cutlass_scaled_mm
+from vllm.model_executor.kernels.linear.scaled_mm import (
+    cutlass as cutlass_kernel_module,
+)
+from vllm.model_executor.kernels.linear.scaled_mm.cutlass import (
+    CutlassFp8BlockScaledMMKernel,
+    cutlass_scaled_mm,
+)
+from vllm.model_executor.kernels.linear.scaled_mm.ScaledMMLinearKernel import (
+    FP8ScaledMMLinearLayerConfig,
+)
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8,
     w8a8_triton_block_scaled_mm,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    GroupShape,
+    create_fp8_quant_key,
 )
 from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import (
@@ -199,6 +213,132 @@ def test_w8a8_block_fp8_cutlass_matmul():
         torch.abs(out.to(torch.float32) - ref_out.to(torch.float32))
     ) / torch.mean(torch.abs(ref_out.to(torch.float32)))
     assert rel_diff < 0.001
+
+
+@torch.inference_mode()
+def test_w8a8_block_fp8_matmul_e8m0_scales():
+    # DeepSeek-V4-style checkpoints store block scales in exponent-only
+    # E8M0, which Triton cannot bind directly; the kernel upcasts them to
+    # fp32 before launch. Regression test for
+    # https://github.com/vllm-project/vllm/issues/47818.
+    M, N, K = 83, 512, 7168
+    block_size = [128, 128]
+    out_dtype = torch.bfloat16
+    torch.manual_seed(0)
+
+    fp8_info = torch.finfo(torch.float8_e4m3fn)
+    fp8_max, fp8_min = fp8_info.max, fp8_info.min
+
+    A_fp32 = (torch.rand(M, K, dtype=torch.float32) - 0.5) * 2 * fp8_max
+    A_fp8 = A_fp32.clamp(min=fp8_min, max=fp8_max).to(torch.float8_e4m3fn)
+    B_fp32 = (torch.rand(N, K, dtype=torch.float32) - 0.5) * 2 * fp8_max
+    B_fp8 = B_fp32.clamp(min=fp8_min, max=fp8_max).to(torch.float8_e4m3fn)
+
+    n_tiles = (N + block_size[0] - 1) // block_size[0]
+    k_tiles = (K + block_size[1] - 1) // block_size[1]
+
+    # Power-of-two scales round-trip E8M0 <-> fp32 exactly.
+    As = torch.exp2(torch.randint(-8, 0, (M, k_tiles)).to(torch.float32))
+    Bs = torch.exp2(torch.randint(-8, 0, (n_tiles, k_tiles)).to(torch.float32))
+
+    ref_out = w8a8_triton_block_scaled_mm(A_fp8, B_fp8, As, Bs, block_size, out_dtype)
+    out = w8a8_triton_block_scaled_mm(
+        A_fp8,
+        B_fp8,
+        As.to(torch.float8_e8m0fnu),
+        Bs.to(torch.float8_e8m0fnu),
+        block_size,
+        out_dtype,
+    )
+    assert torch.equal(out, ref_out)
+
+
+def _block_fp8_linear_config(n: int, k: int) -> FP8ScaledMMLinearLayerConfig:
+    return FP8ScaledMMLinearLayerConfig(
+        weight_quant_key=create_fp8_quant_key(
+            static=True, group_shape=GroupShape(128, 128)
+        ),
+        activation_quant_key=create_fp8_quant_key(
+            static=False, group_shape=GroupShape(1, 128)
+        ),
+        input_dtype=torch.bfloat16,
+        out_dtype=torch.bfloat16,
+        weight_shape=(n, k),
+    )
+
+
+def test_cutlass_block_fp8_sm12x_declines_unaligned_n():
+    # The SM12x CUTLASS blockwise kernels cannot serve layers whose weight
+    # output dim is not a multiple of 128 (e.g. kv_a_proj N=576 in DeepSeek
+    # models), so can_implement must fall through to the next kernel.
+    with patch.object(
+        cutlass_kernel_module.current_platform,
+        "is_device_capability_family",
+        new=lambda family: family == 120,
+    ):
+        ok, _ = CutlassFp8BlockScaledMMKernel.can_implement(
+            _block_fp8_linear_config(512, 7168)
+        )
+        assert ok
+        ok, reason = CutlassFp8BlockScaledMMKernel.can_implement(
+            _block_fp8_linear_config(576, 7168)
+        )
+        assert not ok
+        assert "divisible by 128" in reason
+
+    with patch.object(
+        cutlass_kernel_module.current_platform,
+        "is_device_capability_family",
+        new=lambda family: False,
+    ):
+        ok, _ = CutlassFp8BlockScaledMMKernel.can_implement(
+            _block_fp8_linear_config(576, 7168)
+        )
+        assert ok
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="CUTLASS only supported on CUDA platform."
+)
+@torch.inference_mode()
+def test_cutlass_block_fp8_e8m0_weight_scale_upcast(default_vllm_config):
+    # cutlass_scaled_mm rejects E8M0 scales at dispatch, so the kernel must
+    # upcast them to fp32 when processing weights. Regression test for
+    # https://github.com/vllm-project/vllm/issues/47818.
+    is_supported, reason = CutlassFp8BlockScaledMMKernel.is_supported()
+    if not is_supported:
+        pytest.skip(reason)
+
+    M, N, K = 32, 512, 7168
+    torch.manual_seed(0)
+    fp8_info = torch.finfo(torch.float8_e4m3fn)
+
+    weight = (
+        ((torch.rand(N, K, dtype=torch.float32) - 0.5) * 2 * fp8_info.max)
+        .clamp(min=fp8_info.min, max=fp8_info.max)
+        .to(torch.float8_e4m3fn)
+    )
+    scale = torch.exp2(torch.randint(-8, 0, (N // 128, K // 128)).to(torch.float32))
+
+    config = _block_fp8_linear_config(N, K)
+    kernel = CutlassFp8BlockScaledMMKernel(config)
+
+    def make_layer(weight_scale: torch.Tensor) -> torch.nn.Module:
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(weight.clone(), requires_grad=False)
+        layer.weight_scale_inv = torch.nn.Parameter(weight_scale, requires_grad=False)
+        kernel.process_weights_after_loading(layer)
+        return layer
+
+    e8m0_layer = make_layer(scale.to(torch.float8_e8m0fnu))
+    assert e8m0_layer.weight_scale_inv.dtype == torch.float32
+    assert torch.equal(e8m0_layer.weight_scale_inv, scale)
+
+    fp32_layer = make_layer(scale.clone())
+    x = torch.randn(M, K, dtype=torch.bfloat16)
+    assert torch.equal(
+        kernel.apply_weights(e8m0_layer, x), kernel.apply_weights(fp32_layer, x)
+    )
 
 
 @pytest.mark.skipif(

--- a/tests/kernels/quantization/test_block_fp8.py
+++ b/tests/kernels/quantization/test_block_fp8.py
@@ -4,6 +4,7 @@
 # Adapted from https://github.com/sgl-project/sglang/pull/2575
 import itertools
 import types
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -14,14 +15,28 @@ from tests.kernels.quant_utils import (
 )
 from tests.kernels.utils import fp8_ulp_distance
 from vllm.config import VllmConfig
+from vllm.model_executor.kernels.linear.scaled_mm import (
+    cutlass as cutlass_kernel_module,
+)
 from vllm.model_executor.kernels.linear.scaled_mm.b12x import (
     B12xFp8BlockScaledMMKernel,
     _run_b12x_fp8_block_scaled_mm,
 )
-from vllm.model_executor.kernels.linear.scaled_mm.cutlass import cutlass_scaled_mm
+from vllm.model_executor.kernels.linear.scaled_mm.cutlass import (
+    CutlassFp8BlockScaledMMKernel,
+    cutlass_scaled_mm,
+)
+from vllm.model_executor.kernels.linear.scaled_mm.ScaledMMLinearKernel import (
+    FP8ScaledMMLinearLayerConfig,
+)
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    _upcast_e8m0_to_fp32,
     per_token_group_quant_fp8,
     w8a8_triton_block_scaled_mm,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    GroupShape,
+    create_fp8_quant_key,
 )
 from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import (
@@ -203,6 +218,114 @@ def test_w8a8_block_fp8_cutlass_matmul():
         torch.abs(out.to(torch.float32) - ref_out.to(torch.float32))
     ) / torch.mean(torch.abs(ref_out.to(torch.float32)))
     assert rel_diff < 0.001
+
+
+def test_upcast_e8m0_to_fp32():
+    raw_scale = torch.tensor(
+        [0, 1, 127, 128, 254, 255], dtype=torch.uint8, device="cpu"
+    )
+    expected = torch.tensor(
+        [2**-127, 2**-126, 1.0, 2.0, 2**127],
+        dtype=torch.float32,
+        device="cpu",
+    )
+
+    for scale in (raw_scale, raw_scale.view(torch.float8_e8m0fnu)):
+        upcast = _upcast_e8m0_to_fp32(scale)
+        assert upcast.shape == raw_scale.shape
+        assert upcast.device == raw_scale.device
+        assert torch.equal(upcast[:-1], expected)
+        assert torch.isnan(upcast[-1])
+
+
+def _block_fp8_linear_config(n: int, k: int) -> FP8ScaledMMLinearLayerConfig:
+    return FP8ScaledMMLinearLayerConfig(
+        weight_quant_key=create_fp8_quant_key(
+            static=True, group_shape=GroupShape(128, 128)
+        ),
+        activation_quant_key=create_fp8_quant_key(
+            static=False, group_shape=GroupShape(1, 128)
+        ),
+        input_dtype=torch.bfloat16,
+        out_dtype=torch.bfloat16,
+        weight_shape=(n, k),
+    )
+
+
+def test_cutlass_block_fp8_sm12x_declines_unaligned_n():
+    with patch.object(
+        cutlass_kernel_module.current_platform,
+        "is_device_capability_family",
+        new=lambda family: family == 120,
+    ):
+        ok, _ = CutlassFp8BlockScaledMMKernel.can_implement(
+            _block_fp8_linear_config(512, 7168)
+        )
+        assert ok
+        ok, reason = CutlassFp8BlockScaledMMKernel.can_implement(
+            _block_fp8_linear_config(576, 7168)
+        )
+        assert not ok
+        assert "divisible by 128" in reason
+
+    with patch.object(
+        cutlass_kernel_module.current_platform,
+        "is_device_capability_family",
+        new=lambda family: False,
+    ):
+        ok, _ = CutlassFp8BlockScaledMMKernel.can_implement(
+            _block_fp8_linear_config(576, 7168)
+        )
+        assert ok
+
+
+@pytest.mark.parametrize("scale_attr", ["weight_scale", "weight_scale_inv"])
+@pytest.mark.skipif(
+    not (
+        current_platform.is_cuda() and current_platform.is_device_capability_family(120)
+    ),
+    reason="CUTLASS E8M0 regression only applies to SM120.",
+)
+@torch.inference_mode()
+def test_cutlass_block_fp8_e8m0_weight_scale_upcast(scale_attr, default_vllm_config):
+    is_supported, reason = CutlassFp8BlockScaledMMKernel.is_supported()
+    if not is_supported:
+        pytest.skip(reason)
+
+    M, N, K = 32, 512, 7168
+    config = _block_fp8_linear_config(N, K)
+    kernel = CutlassFp8BlockScaledMMKernel(config)
+    weight = torch.ones((N, K), dtype=torch.float8_e4m3fn, device="cuda")
+    e8m0_scale = torch.zeros(
+        (N // 128, K // 128), dtype=torch.uint8, device="cuda"
+    ).view(torch.float8_e8m0fnu)
+    native_scale = e8m0_scale.to(torch.float32)
+
+    def make_layer(weight_scale: torch.Tensor) -> torch.nn.Module:
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(weight.clone(), requires_grad=False)
+        setattr(
+            layer,
+            scale_attr,
+            torch.nn.Parameter(weight_scale.clone(), requires_grad=False),
+        )
+        kernel.process_weights_after_loading(layer)
+        return layer
+
+    e8m0_layer = make_layer(e8m0_scale)
+    native_layer = make_layer(native_scale)
+    converted_scale = getattr(e8m0_layer, scale_attr)
+    assert converted_scale.dtype == torch.float32
+    assert torch.equal(converted_scale, native_scale)
+
+    A = torch.ones((M, K), dtype=torch.float8_e4m3fn, device="cuda")
+    As = torch.full((K // 128, M), 2.0**120, dtype=torch.float32, device="cuda").t()
+    out = kernel.apply_block_scaled_mm(A, e8m0_layer.weight, As, converted_scale)
+    ref_out = kernel.apply_block_scaled_mm(
+        A, native_layer.weight, As, getattr(native_layer, scale_attr)
+    )
+    assert torch.equal(out, ref_out)
+    assert torch.all(ref_out != 0)
 
 
 @pytest.mark.skipif(

--- a/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
@@ -9,6 +9,9 @@ import torch
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
 from vllm.model_executor.layers.quantization.utils import replace_parameter
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    _upcast_e8m0_to_fp32,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
     QuantKey,
@@ -307,7 +310,42 @@ class CutlassFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
                 "Supports only dynamic per token group activation "
                 "quantization with group_shape=(1,128).",
             )
+
+        # The SM12x blockwise kernels reject problems whose weight output
+        # dim is not a multiple of 128 (CUTLASS can_implement fails for
+        # every tile config, e.g. the N=576 kv_a_proj in DeepSeek models);
+        # fall through to the next kernel for those layers.
+        if (
+            current_platform.is_device_capability_family(120)
+            and config.weight_shape[0] % 128 != 0
+        ):
+            return (
+                False,
+                "SM12x CUTLASS block FP8 requires the weight output "
+                f"dimension to be divisible by 128, got "
+                f"{config.weight_shape[0]}.",
+            )
         return True, None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        super().process_weights_after_loading(layer)
+        params = self._get_layer_params(layer)
+        weight_scale = (
+            params.weight_scale
+            if params.weight_scale_inv is None
+            else params.weight_scale_inv
+        )
+        # cutlass_scaled_mm requires fp32 scales; E8M0 (exponent-only)
+        # checkpoint scales upcast losslessly.
+        if weight_scale is not None and weight_scale.dtype == torch.float8_e8m0fnu:
+            scale_attr_name = (
+                params.WEIGHT_SCALE
+                if params.weight_scale_inv is None
+                else params.WEIGHT_SCALE_INV
+            )
+            replace_parameter(
+                layer, scale_attr_name, _upcast_e8m0_to_fp32(weight_scale)
+            )
 
     def apply_block_scaled_mm(
         self,

--- a/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
@@ -9,6 +9,9 @@ import torch
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
 from vllm.model_executor.layers.quantization.utils import replace_parameter
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    _upcast_e8m0_to_fp32,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
     QuantKey,
@@ -307,7 +310,36 @@ class CutlassFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
                 "Supports only dynamic per token group activation "
                 "quantization with group_shape=(1,128).",
             )
+
+        if (
+            current_platform.is_device_capability_family(120)
+            and config.weight_shape[0] % 128 != 0
+        ):
+            return (
+                False,
+                "SM12x CUTLASS block FP8 requires the weight output "
+                f"dimension to be divisible by 128, got "
+                f"{config.weight_shape[0]}.",
+            )
         return True, None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        super().process_weights_after_loading(layer)
+        params = self._get_layer_params(layer)
+        weight_scale = (
+            params.weight_scale
+            if params.weight_scale_inv is None
+            else params.weight_scale_inv
+        )
+        if weight_scale is not None and weight_scale.dtype == torch.float8_e8m0fnu:
+            scale_attr_name = (
+                params.WEIGHT_SCALE
+                if params.weight_scale_inv is None
+                else params.WEIGHT_SCALE_INV
+            )
+            replace_parameter(
+                layer, scale_attr_name, _upcast_e8m0_to_fp32(weight_scale)
+            )
 
     def apply_block_scaled_mm(
         self,

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -912,14 +912,13 @@ def w8a8_triton_block_scaled_mm(
     assert len(block_size) == 2
     block_n, block_k = block_size[0], block_size[1]
 
-    # Triton cannot currently bind E8M0 scale tensors directly. On ROCm,
+    # Triton cannot currently bind E8M0 scale tensors directly.
     # DeepSeek-V4 checkpoints store block scales in exponent-only E8M0 format,
     # so decode them to fp32 before launching the kernel.
-    if current_platform.is_rocm() or current_platform.is_xpu():
-        if As.dtype == torch.float8_e8m0fnu:
-            As = _upcast_e8m0_to_fp32(As).contiguous()
-        if Bs.dtype == torch.float8_e8m0fnu:
-            Bs = _upcast_e8m0_to_fp32(Bs).contiguous()
+    if As.dtype == torch.float8_e8m0fnu:
+        As = _upcast_e8m0_to_fp32(As).contiguous()
+    if Bs.dtype == torch.float8_e8m0fnu:
+        Bs = _upcast_e8m0_to_fp32(Bs).contiguous()
 
     assert A.shape[-1] == B.shape[-1]
     assert A.shape[:-1] == As.shape[:-1] and A.is_contiguous()

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -1068,15 +1068,8 @@ def requant_weight_ue8m0_inplace(
 
 
 def _upcast_e8m0_to_fp32(scale: torch.Tensor) -> torch.Tensor:
-    """Upcast E8M0 (exponent-only) scale to float32.
-
-    E8M0 stores only the 8-bit biased exponent (bias=127). To convert
-    to float32 we place those 8 bits into the exponent field of an
-    IEEE-754 float32 (bits 23-30) with sign=0 and mantissa=0.
-    """
-    exp_bits = scale.view(torch.uint8).to(torch.int32)
-    fp32_bits = exp_bits << 23
-    return fp32_bits.view(torch.float32)
+    """Upcast E8M0 (exponent-only) scale to float32."""
+    return scale.view(torch.float8_e8m0fnu).to(torch.float32)
 
 
 def deepgemm_post_process_weight_scale_block(


### PR DESCRIPTION
## Purpose

Fixes #47818.

DeepSeek-V4-style FP8 block checkpoints declare `"scale_fmt": "ue8m0"`, so `Fp8LinearMethod` loads `weight_scale_inv` as exponent-only `float8_e8m0fnu` (fp8.py `is_scale_e8m0`). The DeepGEMM kernel handles that dtype in its own weight post-processing, but on any setup where DeepGEMM is unavailable or disabled (which today includes SM120, see #47436) the layer routes to the CUTLASS or Triton block kernels, and both crash on the first block-scaled linear during `profile_run`:

- CUTLASS: `dispatch_scaled_mm` requires fp32 scales (`STD_TORCH_CHECK(b_scales.scalar_type() == Float)` in `scaled_mm_helper.hpp`) — the exact error in #47818. The issue's guess of a missing SM120 dispatch entry is not what happens; the SM120 blockwise kernel exists and works, the dispatch dies on the scale dtype check before reaching it.
- Triton: the kernel launch cannot bind an E8M0 tensor (`KeyError: 'float8_e8m0fnu'`) — the reporter's `--linear-backend triton` traceback.

E8M0 holds pure powers of two, so upcasting to fp32 is lossless. This PR:

1. `CutlassFp8BlockScaledMMKernel.process_weights_after_loading`: upcast E8M0 weight scales to fp32 once at load time, reusing the existing `_upcast_e8m0_to_fp32` helper (same treatment `deepgemm_post_process_fp8_weight_block` already applies on the DeepGEMM path).
2. `w8a8_triton_block_scaled_mm`: the E8M0→fp32 upcast already existed but was gated to ROCm/XPU; the Triton limitation is platform-independent, so drop the gate.
3. `CutlassFp8BlockScaledMMKernel.can_implement`: on SM12x, decline layers whose weight output dim is not a multiple of 128 so selection falls through to Triton. I swept the SM120 blockwise kernel on an RTX PRO 6000 across M ∈ {1..512} × N ∈ {512, 576, 1536, 2112, 7168} × K ∈ {1024, 7168} with fp32 scales: every N % 128 == 0 case passes (max rel err ~2-3e-3 vs fp32 dequant reference, bf16 rounding level), every N % 128 != 0 case fails CUTLASS `can_implement` ("Invalid status" from `cutlass_gemm_caller.cuh`) on all three tile configs. That kernel-level gap also explains why `test_w8a8_block_fp8_cutlass_matmul` (N=576, direct op call) fails on SM120 today — pre-existing, not addressed here, filed as #47990.

## Why this is not duplicating an existing PR

No open PR references #47818. #41834 (DSV4 SM12x enablement branch) bundles an equivalent E8M0 upcast among its ~116 files, but it routes SM12x away from CUTLASS entirely; my SM120 sweep shows the blockwise kernel is correct for 128-aligned N, so this PR keeps CUTLASS for those shapes and only falls through for the shapes the kernel genuinely rejects. This is a standalone fix for the crash on current `main`, independent of the model-enablement branch.

## Test Plan

Unit (RTX PRO 6000, SM120, torch 2.11.0+cu130, precompiled nightly kernels):

```
python -m pytest tests/kernels/quantization/test_block_fp8.py -k "e8m0 or sm12x"
```

- `test_w8a8_block_fp8_matmul_e8m0_scales` — Triton path with E8M0 As/Bs must bit-match the fp32-scale run.
- `test_cutlass_block_fp8_e8m0_weight_scale_upcast` — kernel-class level: after `process_weights_after_loading` the scale param is fp32 with exactly round-tripped values, and `apply_weights` output bit-matches an fp32-scale layer.
- `test_cutlass_block_fp8_sm12x_declines_unaligned_n` — `can_implement` falls through for N=576 on family-120, accepts elsewhere (platform mocked, runs on any host).

Runtime A/B on a 2-layer dummy-weight DeepSeek-V4-Flash config (real attention dims and `quantization_config`, `load_format=dummy`, `VLLM_USE_DEEP_GEMM=0`, single RTX PRO 6000):

- stock `main` (f7fc0ca): `Selected CutlassFp8BlockScaledMMKernel for Fp8LinearMethod` then `RuntimeError: dispatch_scaled_mm, .../scaled_mm_helper.hpp:17` — reproduces the issue byte-for-byte.
- this branch: all block-FP8 dense linears process and execute; the forward proceeds until DSV4's o_proj `fp8_einsum`, which calls DeepGEMM directly and is a separate SM120 gap (#47436 family / #41834 scope). This PR fixes the linear-kernel crash reported in #47818; it does not claim full DSV4-Flash serving on SM120.

## Test Result

- 3 new tests pass on the fix; on stock `main` the two GPU tests fail with exactly the two crash signatures from the issue (CUTLASS `scaled_mm_helper.hpp` check, Triton `KeyError: 'float8_e8m0fnu'`).
- `tests/kernels/quantization/test_block_fp8.py`: identical pass/fail set before and after the change on this GPU (the 101 pre-existing failures here are all `test_w8a8_block_fp8_deep_gemm_matmul` — DeepGEMM on SM120 — plus the N=576 direct-op case above; none are introduced or resolved by this PR).

Accuracy note: outputs for previously-working configs are unchanged by construction (the upcast is exact and only engages for E8M0 checkpoints, which currently cannot run at all on these kernels). A real-weight eval of an ue8m0 checkpoint isn't possible on this box (DeepSeek-V4-Flash is 149 GB vs 96 GB VRAM); the kernel-level tests assert bit-identity against fp32-scale references instead.

---

AI assistance was used for this PR (Claude Code); I reviewed every line and ran the tests and A/B above on my own SM120 hardware.
