### PR TITLE
[Bugfix] Use wall-clock epoch for the Dynamo bytecode transform tracing span

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -1150,8 +1150,11 @@ class VllmBackend:
             dynamo_time,
         )
 
-        # Record Dynamo time in tracing if available
-        start_time = int(torch_compile_start_time * 1e9)
+        # Record Dynamo time in tracing if available.
+        # torch_compile_start_time is a perf_counter() value (arbitrary epoch);
+        # instrument_manual expects nanoseconds since the Unix epoch, so
+        # project the measured duration back from wall-clock now.
+        start_time = time.time_ns() - int(dynamo_time * 1e9)
         attributes = {"dynamo.time_seconds": dynamo_time}
         instrument_manual("Dynamo bytecode transform", start_time, None, attributes)
 


### PR DESCRIPTION
## Purpose

#31162 added OTel spans across the loading path. Its one manually-timestamped span, `Dynamo bytecode transform`, mixes clock domains: `torch_compile_start_time` is a `time.perf_counter()` value (arbitrary epoch, set in `compilation/monitor.py`), but it is converted with `int(torch_compile_start_time * 1e9)` and passed to `instrument_manual()`, whose contract (`vllm/tracing/__init__.py`) is *"start time in nanoseconds since epoch"*. The span therefore ends at wall-clock now but starts near the perf_counter origin.

Observed on a real traced boot (H100, `--otlp-traces-endpoint`, vLLM 0.24.0): the span reports a duration of **1,748,893,494 s (~55 years)**, while the true value — 2.30 s — sits in the span's own `dynamo.time_seconds` attribute. Every other loading span from #31162 is `@instrument`-decorated and unaffected; this is the only manual-timestamp call site on the boot path (`grep -n "instrument_manual" vllm/`).

## Fix

Project the measured duration back from `time.time_ns()`:

```python
start_time = time.time_ns() - int(dynamo_time * 1e9)
```

The span now brackets the actual transform window; `dynamo.time_seconds` is unchanged.

## Test Plan

No new test: the fix is timestamp arithmetic on a path that requires a live Dynamo compile to exercise, and the value it feeds is already covered by the existing tracing suite's span-mechanics tests (`tests/tracing/test_loading_tracing.py`). Verified against a captured span from a real traced boot (raw span JSON available on request: start `34574061077712484` = perf_counter ns, end `1783467555107993330` = epoch ns).

## Test Result

N/A (no behavior change outside the span timestamp).
