### PR TITLE
[ROCm][CI] Fix failing ROCm quick reduce test

### DIFF
--- a/tests/distributed/test_quick_all_reduce.py
+++ b/tests/distributed/test_quick_all_reduce.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import multiprocessing
+import os
 import random
 
 import pytest
@@ -266,8 +267,17 @@ def graph_quickreduce(
             for dtype in [torch.float16, torch.bfloat16]:
                 with graph_capture(device=device) as graph_capture_context:
                     device_idx = torch.accelerator.current_device_index()
-                    inp1 = torch.randint(1, 23, (sz,), dtype=dtype, device=device_idx)
-                    inp2 = torch.randint(-23, 1, (sz,), dtype=dtype, device=device_idx)
+                    int_range = (
+                        23
+                        if os.getenv("VLLM_ROCM_QUICK_REDUCE_QUANTIZATION") != "INT3"
+                        else 11
+                    )
+                    inp1 = torch.randint(
+                        1, int_range, (sz,), dtype=dtype, device=device_idx
+                    )
+                    inp2 = torch.randint(
+                        -int_range, 1, (sz,), dtype=dtype, device=device_idx
+                    )
                     _assert_quickreduce(fa, inp1)
                     _assert_quickreduce(fa, inp2)
 
@@ -304,15 +314,25 @@ def eager_quickreduce(
         # Size over 8MB is sufficient for custom quick allreduce.
         sz = 16 * 1024 * 1024
         fa = get_tp_group().device_communicator.qr_comm
+
+        # The 23 interval for INT3 quantization is too large for the test to pass.
+        # Reduce the interval to 11 for INT3 quantization.
+        int_range = (
+            23 if os.getenv("VLLM_ROCM_QUICK_REDUCE_QUANTIZATION") != "INT3" else 11
+        )
         inp = torch.tensor(
-            [1.0 * ((i) % 23) for i in range(sz)], dtype=torch.float16, device=device
+            [1.0 * ((i) % int_range) for i in range(sz)],
+            dtype=torch.float16,
+            device=device,
         )
         _assert_quickreduce(fa, inp)
         out = fa.quick_all_reduce(inp)
         torch.testing.assert_close(out, inp * tp_size, atol=2.5, rtol=0.1)
 
         inp = torch.tensor(
-            [1.0 * ((i) % 23) for i in range(sz)], dtype=torch.bfloat16, device=device
+            [1.0 * ((i) % int_range) for i in range(sz)],
+            dtype=torch.bfloat16,
+            device=device,
         )
         _assert_quickreduce(fa, inp)
         out = fa.quick_all_reduce(inp)

--- a/tests/distributed/test_rocm_quick_reduce.py
+++ b/tests/distributed/test_rocm_quick_reduce.py
@@ -30,7 +30,7 @@ pytestmark = pytest.mark.skipif(
 
 MB = 1024 * 1024
 WORLD_SIZE = 2
-QUANT_LEVELS = ["FP", "INT8", "INT6", "INT4"]
+QUANT_LEVELS = ["FP", "INT8", "INT6", "INT4", "INT3"]
 
 
 def _log(message: str) -> None:


### PR DESCRIPTION
## Purpose
This PR fixes some failures in the `tests/distributed/test_rocm_quick_reduce.py` test caused by the recent addition of INT3 quantization for ROCm quick reduce (https://github.com/vllm-project/vllm/pull/45666). The quick reduce test asserts are modified to pass with the addition of the INT3 quick reduce option and the min_qr_size attribute is set at initialization to avoid an error caused by accessing an unset attribute.

## Test Plan
Run the failing test and make sure that the `mi355_2: Distributed Tests (2xH100-2xMI355)` tests pass

## Test Result
The failing test is now passing.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>