### PR TITLE
[Bugfix] MiniMax-M3 tool parser: stream tool-call arguments incrementally

### DIFF
--- a/rust/src/parser/src/tool/minimax_m3.rs
+++ b/rust/src/parser/src/tool/minimax_m3.rs
@@ -1,12 +1,12 @@
 use winnow::ascii::{multispace0 as ws0, multispace1 as ws1};
-use winnow::combinator::{alt, delimited, seq};
+use winnow::combinator::{alt, delimited, peek, preceded, seq};
 use winnow::error::{ContextError, ErrMode};
 use winnow::prelude::*;
 use winnow::stream::Partial;
 use winnow::token::{literal, rest, take_until};
 
 use super::parameters::{ParamElement, ParamInput, ToolSchemas};
-use super::utils::{MarkerScanState, parse_buffered_event, safe_text_len, take_until_marker};
+use super::utils::{parse_buffered_event, safe_text_len};
 use super::{Result, ToolCallDelta, ToolParser, ToolParserOutput};
 use crate::tool::Tool;
 
@@ -21,10 +21,11 @@ const MIXED_TEXT_FIELD: &str = "$text";
 
 type MinimaxM3Input<'i> = Partial<&'i str>;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MinimaxM3Mode {
     Text,
-    ToolBlock { invoke_end_scan: MarkerScanState },
+    ToolBlock,
+    InsideInvoke,
     Done,
 }
 
@@ -34,10 +35,14 @@ enum MinimaxM3Event {
         len: usize,
     },
     ToolBlockStart,
-    Invoke {
+    InvokeStart {
         name: String,
-        params: Vec<(String, ParamInput)>,
     },
+    Param {
+        name: String,
+        value: ParamInput,
+    },
+    InvokeEnd,
     ToolBlockEnd,
     IgnoredRest,
 }
@@ -84,11 +89,26 @@ enum MinimaxM3Event {
 /// ```
 ///
 /// MiniMax M3 emits the namespace marker `]<]minimax[>[` before each structural
-/// tag. Arguments are emitted only after a full `<invoke>` block is parsed.
+/// tag.
+///
+/// Arguments are streamed incrementally, one JSON fragment per top-level
+/// `<parameter>` element: the function name is emitted first (with empty
+/// arguments), then each parameter is emitted as its own `{"name":value` /
+/// `,"name":value` fragment, and finally a closing `}` fragment. Coalescing
+/// all fragments for one tool index reconstructs the exact same JSON object as
+/// a non-streaming parse. Nested object/array parameters are buffered and
+/// emitted as one fragment covering their whole subtree.
 pub struct MinimaxM3ToolParser {
     buffer: String,
     mode: MinimaxM3Mode,
     emitted_tool_count: usize,
+    /// Function name of the invoke currently being streamed, used for
+    /// per-parameter schema-aware conversion.
+    current_tool_name: Option<String>,
+    /// Whether the current invoke has already emitted its opening `{` and at
+    /// least one parameter fragment (controls comma placement and the closing
+    /// fragment).
+    param_emitted: bool,
     tool_parameters: ToolSchemas,
 }
 
@@ -99,8 +119,21 @@ impl MinimaxM3ToolParser {
             buffer: String::new(),
             mode: MinimaxM3Mode::Text,
             emitted_tool_count: 0,
+            current_tool_name: None,
+            param_emitted: false,
             tool_parameters: ToolSchemas::from_tools(tools),
         }
+    }
+
+    /// Push a fragment that best-effort closes the JSON of the currently open
+    /// invoke, so a truncated stream still yields a parseable object.
+    fn push_invoke_close(&mut self, output: &mut ToolParserOutput) {
+        let closing = if self.param_emitted { "}" } else { "{}" };
+        output.push_call(ToolCallDelta {
+            tool_index: self.emitted_tool_count,
+            name: None,
+            arguments: closing.to_string(),
+        });
     }
 
     /// Apply one parsed MiniMax M3 event to parser state and output.
@@ -109,22 +142,40 @@ impl MinimaxM3ToolParser {
             MinimaxM3Event::Text { len: consumed_len } => {
                 output.push_text(&self.buffer[..consumed_len]);
             }
-            MinimaxM3Event::ToolBlockStart => {
-                self.mode = MinimaxM3Mode::ToolBlock {
-                    invoke_end_scan: MarkerScanState::default(),
-                };
-            }
-            MinimaxM3Event::Invoke { name, params } => {
-                let arguments = self.tool_parameters.convert_params_with_schema(&name, params);
-                let arguments = serde_json::to_string(&arguments)
-                    .map_err(|error| parsing_failed!("failed to serialize arguments: {}", error))?;
-
+            MinimaxM3Event::ToolBlockStart => self.mode = MinimaxM3Mode::ToolBlock,
+            MinimaxM3Event::InvokeStart { name } => {
+                self.current_tool_name = Some(name.clone());
+                self.param_emitted = false;
                 output.push_call(ToolCallDelta {
                     tool_index: self.emitted_tool_count,
                     name: Some(name),
-                    arguments,
+                    arguments: String::new(),
                 });
+                self.mode = MinimaxM3Mode::InsideInvoke;
+            }
+            MinimaxM3Event::Param { name, value } => {
+                let tool_name = self.current_tool_name.as_deref().unwrap_or("");
+                let value = self.tool_parameters.convert_param_with_schema(tool_name, &name, value);
+                let key = serde_json::to_string(&name).map_err(|error| {
+                    parsing_failed!("failed to serialize parameter name: {}", error)
+                })?;
+                let value = serde_json::to_string(&value)
+                    .map_err(|error| parsing_failed!("failed to serialize arguments: {}", error))?;
+                let fragment =
+                    format!("{}{}:{}", if self.param_emitted { "," } else { "{" }, key, value);
+                output.push_call(ToolCallDelta {
+                    tool_index: self.emitted_tool_count,
+                    name: None,
+                    arguments: fragment,
+                });
+                self.param_emitted = true;
+            }
+            MinimaxM3Event::InvokeEnd => {
+                self.push_invoke_close(output);
                 self.emitted_tool_count += 1;
+                self.current_tool_name = None;
+                self.param_emitted = false;
+                self.mode = MinimaxM3Mode::ToolBlock;
             }
             MinimaxM3Event::ToolBlockEnd => self.mode = MinimaxM3Mode::Done,
             MinimaxM3Event::IgnoredRest => {}
@@ -145,7 +196,7 @@ impl ToolParser for MinimaxM3ToolParser {
         self.buffer.push_str(chunk);
 
         while let Some((event, consumed_len)) = parse_buffered_event(&self.buffer, |input| {
-            parse_next_minimax_m3_event(input, &mut self.mode)
+            parse_next_minimax_m3_event(input, self.mode)
         })? {
             self.apply_event(event, output)?;
             self.buffer.drain(..consumed_len);
@@ -160,10 +211,18 @@ impl ToolParser for MinimaxM3ToolParser {
             MinimaxM3Mode::Text => {
                 output.push_text(&self.buffer);
             }
-            MinimaxM3Mode::ToolBlock { .. } => {
-                if !self.buffer.trim_start().is_empty() {
-                    return Err(parsing_failed!("incomplete MiniMax M3 tool call"));
-                }
+            MinimaxM3Mode::InsideInvoke => {
+                // The invoke header was emitted but the closing marker never
+                // arrived (e.g. truncated generation). Degrade gracefully by
+                // best-effort closing the JSON instead of raising, so the
+                // caller still gets a parseable partial tool call.
+                self.push_invoke_close(&mut output);
+            }
+            MinimaxM3Mode::ToolBlock => {
+                // A tool block was opened but never closed. Any already-emitted
+                // invokes are self-closed; leftover buffer is incomplete
+                // structural markup and is dropped as best-effort rather than
+                // raising a hard error.
             }
             MinimaxM3Mode::Done => {}
         }
@@ -174,6 +233,8 @@ impl ToolParser for MinimaxM3ToolParser {
     fn reset(&mut self) -> String {
         self.mode = MinimaxM3Mode::Text;
         self.emitted_tool_count = 0;
+        self.current_tool_name = None;
+        self.param_emitted = false;
         std::mem::take(&mut self.buffer)
     }
 }
@@ -181,13 +242,12 @@ impl ToolParser for MinimaxM3ToolParser {
 /// Parse a MiniMax M3 event for the current parser mode.
 fn parse_next_minimax_m3_event(
     input: &mut MinimaxM3Input<'_>,
-    mode: &mut MinimaxM3Mode,
+    mode: MinimaxM3Mode,
 ) -> ModalResult<MinimaxM3Event> {
     match mode {
         MinimaxM3Mode::Text => parse_text_event(input),
-        MinimaxM3Mode::ToolBlock { invoke_end_scan } => {
-            parse_tool_block_event(input, invoke_end_scan)
-        }
+        MinimaxM3Mode::ToolBlock => parse_tool_block_event(input),
+        MinimaxM3Mode::InsideInvoke => parse_inside_invoke_event(input),
         MinimaxM3Mode::Done => ignored_rest_event(input),
     }
 }
@@ -207,15 +267,9 @@ fn safe_text_event(input: &mut MinimaxM3Input<'_>) -> ModalResult<MinimaxM3Event
     safe_text_len(input, TOOL_CALL_START).map(|len| MinimaxM3Event::Text { len })
 }
 
-/// Parse one event inside a MiniMax M3 tool block.
-fn parse_tool_block_event(
-    input: &mut MinimaxM3Input<'_>,
-    invoke_end_scan: &mut MarkerScanState,
-) -> ModalResult<MinimaxM3Event> {
-    alt((tool_block_end_event, |input: &mut MinimaxM3Input<'_>| {
-        invoke_event(input, invoke_end_scan)
-    }))
-    .parse_next(input)
+/// Parse one event inside a MiniMax M3 tool block (between invokes).
+fn parse_tool_block_event(input: &mut MinimaxM3Input<'_>) -> ModalResult<MinimaxM3Event> {
+    alt((tool_block_end_event, invoke_start_event)).parse_next(input)
 }
 
 /// Parse a MiniMax M3 tool-block end marker.
@@ -225,56 +279,63 @@ fn tool_block_end_event(input: &mut MinimaxM3Input<'_>) -> ModalResult<MinimaxM3
         .parse_next(input)
 }
 
-/// Parse a complete MiniMax M3 invoke block.
-fn invoke_event(
-    input: &mut MinimaxM3Input<'_>,
-    invoke_end_scan: &mut MarkerScanState,
-) -> ModalResult<MinimaxM3Event> {
-    let (name, body) = seq!(
+/// Parse only the header of a MiniMax M3 invoke block: `<invoke name="X">`.
+///
+/// The body (parameters) and the closing `</invoke>` are parsed incrementally
+/// afterwards while in `InsideInvoke` mode.
+fn invoke_start_event(input: &mut MinimaxM3Input<'_>) -> ModalResult<MinimaxM3Event> {
+    let name = seq!(
         _: ws0,
         _: literal(INVOKE_START),
         _: (ws1, literal("name=")),
         partial_attr_value,
         _: literal(">"),
-        take_until_marker(INVOKE_END, invoke_end_scan),
-        _: literal(INVOKE_END),
     )
     .parse_next(input)?;
-    let params = parse_invoke_params(body)?;
 
-    Ok(MinimaxM3Event::Invoke {
-        name: name.trim().to_string(),
-        params,
+    Ok(MinimaxM3Event::InvokeStart {
+        name: name.0.trim().to_string(),
     })
 }
 
-/// Parse all parameter elements inside a complete MiniMax M3 invoke body.
-fn parse_invoke_params(invoke_body: &str) -> ModalResult<Vec<(String, ParamInput)>> {
-    let mut input = invoke_body;
-    let mut elements = Vec::new();
-
-    loop {
-        let _ = ws0.parse_next(&mut input)?;
-        if input.is_empty() {
-            break;
-        }
-        if input.starts_with(ELEMENT_START) {
-            elements.push(parameter_element(&mut input)?);
-            continue;
-        }
-        if input.starts_with(NAMESPACE) {
-            return malformed();
-        }
-        // Be tolerant: ordinary text at an invokeparameter boundary ends this invoke.
-        // Keep parsed parameters and drop the remaining invoke body.
-        break;
-    }
-
-    Ok(elements.into_iter().map(|element| (element.name, element.value)).collect())
+/// Parse one event inside a MiniMax M3 invoke block.
+fn parse_inside_invoke_event(input: &mut MinimaxM3Input<'_>) -> ModalResult<MinimaxM3Event> {
+    alt((invoke_end_event, param_event, invoke_body_junk_event)).parse_next(input)
 }
 
-/// Parse a MiniMax M3 parameter element.
-fn parameter_element(input: &mut &str) -> ModalResult<ParamElement> {
+/// Parse a MiniMax M3 invoke end marker.
+fn invoke_end_event(input: &mut MinimaxM3Input<'_>) -> ModalResult<MinimaxM3Event> {
+    (ws0, literal(INVOKE_END))
+        .value(MinimaxM3Event::InvokeEnd)
+        .parse_next(input)
+}
+
+/// Parse one top-level parameter element inside an invoke block.
+fn param_event(input: &mut MinimaxM3Input<'_>) -> ModalResult<MinimaxM3Event> {
+    let element = preceded(ws0, parameter_element).parse_next(input)?;
+    Ok(MinimaxM3Event::Param {
+        name: element.name,
+        value: element.value,
+    })
+}
+
+/// Tolerantly drop the remainder of an invoke body up to and including the
+/// closing marker.
+///
+/// Mirrors the non-streaming behavior of keeping already-emitted parameters
+/// and discarding ordinary text (or otherwise unexpected content) that appears
+/// where a parameter or `</invoke>` was expected. This branch is only reached
+/// after `invoke_end_event` and `param_event` have both backtracked, i.e. the
+/// content is definitively neither the invoke end nor a (partial) parameter
+/// element.
+fn invoke_body_junk_event(input: &mut MinimaxM3Input<'_>) -> ModalResult<MinimaxM3Event> {
+    (take_until(0.., INVOKE_END), literal(INVOKE_END))
+        .value(MinimaxM3Event::InvokeEnd)
+        .parse_next(input)
+}
+
+/// Parse a MiniMax M3 parameter element (streaming, Partial-aware).
+fn parameter_element(input: &mut MinimaxM3Input<'_>) -> ModalResult<ParamElement> {
     let name = open_element_tag(input)?.to_string();
     let value = element_body(input, &name)?;
     close_element_tag(input, &name)?;
@@ -282,7 +343,7 @@ fn parameter_element(input: &mut &str) -> ModalResult<ParamElement> {
 }
 
 /// Parse a MiniMax M3 opening element tag.
-fn open_element_tag<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
+fn open_element_tag<'i>(input: &mut MinimaxM3Input<'i>) -> ModalResult<&'i str> {
     let name = seq!(
         _: literal(ELEMENT_START),
         take_until(1.., ">"),
@@ -299,14 +360,19 @@ fn open_element_tag<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
 }
 
 /// Parse a MiniMax M3 closing element tag.
-fn close_element_tag(input: &mut &str, name: &str) -> ModalResult<()> {
+fn close_element_tag(input: &mut MinimaxM3Input<'_>, name: &str) -> ModalResult<()> {
     literal(ELEMENT_END_START).void().parse_next(input)?;
     literal(name).void().parse_next(input)?;
     literal(">").void().parse_next(input)
 }
 
-/// Parse the body of one MiniMax M3 element.
-fn element_body(input: &mut &str, closing_name: &str) -> ModalResult<ParamInput> {
+/// Parse the body of one MiniMax M3 element (streaming, Partial-aware).
+///
+/// Returns `Incomplete` (via `take_until` / `literal` on the `Partial` stream)
+/// whenever the element — including any nested object/array subtree — has not
+/// fully arrived yet, so callers hold the buffer until the whole element is
+/// available.
+fn element_body(input: &mut MinimaxM3Input<'_>, closing_name: &str) -> ModalResult<ParamInput> {
     let close_tag = format!("{ELEMENT_END_START}{closing_name}>");
     let mut text = String::new();
     let mut elements = Vec::new();
@@ -314,18 +380,19 @@ fn element_body(input: &mut &str, closing_name: &str) -> ModalResult<ParamInput>
     loop {
         text.push_str(text_until_namespace(input)?);
 
-        if input.starts_with(&close_tag) {
-            // Close tag reached, end of element body.
-            break;
-        }
-        if input.starts_with(ELEMENT_START) {
-            // Child element start reached, parse child element recursively.
-            elements.push(parameter_element(input)?);
-            continue;
-        }
-        if input.starts_with(NAMESPACE) {
-            // Unexpected namespace marker.
-            return malformed();
+        // Input now begins with the namespace marker. Decide whether this is
+        // the close tag for this element (peek, do not consume — the caller's
+        // `close_element_tag` consumes it) or a nested child element. A partial
+        // marker yields `Incomplete` and holds the buffer.
+        let child = alt((
+            peek(literal(close_tag.as_str())).value(None::<ParamElement>),
+            parameter_element.map(Some),
+        ))
+        .parse_next(input)?;
+
+        match child {
+            None => break,
+            Some(child) => elements.push(child),
         }
     }
 
@@ -340,7 +407,7 @@ fn element_body(input: &mut &str, closing_name: &str) -> ModalResult<ParamInput>
 }
 
 /// Parse text until the next MiniMax M3 namespace marker.
-fn text_until_namespace<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
+fn text_until_namespace<'i>(input: &mut MinimaxM3Input<'i>) -> ModalResult<&'i str> {
     take_until(0.., NAMESPACE).parse_next(input)
 }
 
@@ -389,7 +456,7 @@ mod tests {
         TOOL_CALL_END, TOOL_CALL_START, ToolParser,
     };
     use crate::tool::test_utils::{collect_stream, split_by_chars, test_tools};
-    use crate::tool::{Tool, ToolParserEvent, ToolParserTestExt as _};
+    use crate::tool::{Tool, ToolCallDelta, ToolParserTestExt as _};
 
     fn element(name: &str, body: &str) -> String {
         format!("{ELEMENT_START}{name}>{body}{ELEMENT_END_START}{name}>")
@@ -406,6 +473,27 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
         format!("{TOOL_CALL_START}\n{invokes}\n{TOOL_CALL_END}")
+    }
+
+    /// Collect raw (non-coalesced) deltas by feeding chunks one at a time,
+    /// including the `finish()` flush.
+    fn collect_raw_deltas(parser: &mut MinimaxM3ToolParser, chunks: &[&str]) -> Vec<ToolCallDelta> {
+        let mut deltas = Vec::new();
+        for chunk in chunks {
+            let output = parser.parse_chunk(chunk).unwrap();
+            deltas.extend(output.calls().into_iter().cloned());
+        }
+        deltas.extend(parser.finish().unwrap().calls().into_iter().cloned());
+        deltas
+    }
+
+    /// The argument-bearing deltas (those without a name) for one tool index.
+    fn arg_fragments(deltas: &[ToolCallDelta]) -> Vec<String> {
+        deltas
+            .iter()
+            .filter(|delta| delta.name.is_none())
+            .map(|delta| delta.arguments.clone())
+            .collect()
     }
 
     fn m3_test_tools() -> Vec<Tool> {
@@ -725,34 +813,6 @@ mod tests {
     }
 
     #[test]
-    fn minimax_m3_streaming_preserves_ordered_events() {
-        let mut parser = MinimaxM3ToolParser::new(&m3_test_tools());
-        let output = collect_stream(
-            &mut parser,
-            &[
-                "Let me check. ",
-                TOOL_CALL_START,
-                &invoke("get_weather", &element("city", "Seattle")),
-                TOOL_CALL_END,
-            ],
-        );
-
-        assert_eq!(output.events.len(), 2);
-        assert_eq!(
-            output.events[0],
-            ToolParserEvent::Text("Let me check. ".to_string())
-        );
-        let ToolParserEvent::ToolCall(call) = &output.events[1] else {
-            panic!("expected tool-call event");
-        };
-        assert_eq!(call.name.as_deref(), Some("get_weather"));
-        assert_eq!(
-            serde_json::from_str::<Value>(&call.arguments).unwrap(),
-            json!({ "city": "Seattle" })
-        );
-    }
-
-    #[test]
     fn minimax_m3_streaming_without_tool_call_emits_text_incrementally() {
         let mut parser = MinimaxM3ToolParser::new(&m3_test_tools());
         let output = collect_stream(&mut parser, &["Hello, ", "world!"]);
@@ -788,7 +848,10 @@ mod tests {
     }
 
     #[test]
-    fn minimax_m3_streaming_does_not_emit_incomplete_tool_call() {
+    fn minimax_m3_streaming_emits_tool_call_header_before_arguments() {
+        // Incremental contract: the function name is emitted (with empty
+        // arguments) as soon as the invoke header parses, before any argument
+        // fragment. This mirrors Kimi K2's proven streaming behavior.
         let mut parser = MinimaxM3ToolParser::new(&m3_test_tools());
         let output = parser
             .parse_chunk(&format!(
@@ -797,7 +860,208 @@ mod tests {
             .unwrap();
 
         assert!(output.normal_text().is_empty());
-        assert!(output.calls().is_empty());
+        assert_eq!(output.calls().len(), 1);
+        assert_eq!(output.calls()[0].name.as_deref(), Some("get_weather"));
+        assert_eq!(output.calls()[0].tool_index, 0);
+        // No argument fragment yet: the name delta carries empty arguments.
+        assert_eq!(output.calls()[0].arguments, "");
+    }
+
+    #[test]
+    fn minimax_m3_streaming_emits_multiple_argument_fragments() {
+        // A multi-parameter tool call must stream as multiple argument
+        // fragments (one per parameter, plus the closing brace), never a
+        // single blob.
+        let mut parser = MinimaxM3ToolParser::new(&m3_test_tools());
+        let deltas = collect_raw_deltas(
+            &mut parser,
+            &[
+                TOOL_CALL_START,
+                &invoke(
+                    "get_weather",
+                    &format!("{}{}", element("city", "Seattle"), element("days", "5")),
+                ),
+                TOOL_CALL_END,
+            ],
+        );
+
+        let fragments = arg_fragments(&deltas);
+        // city fragment, days fragment, closing brace => at least 2 (here 3).
+        assert!(
+            fragments.len() > 1,
+            "expected multiple argument fragments, got {fragments:?}"
+        );
+        // No single fragment contains the whole arguments object.
+        let complete = r#"{"city":"Seattle","days":5}"#;
+        assert!(
+            fragments.iter().all(|fragment| fragment != complete
+                && !(fragment.contains("city") && fragment.contains("days"))),
+            "no single fragment should contain the whole arguments: {fragments:?}"
+        );
+        // Coalescing the fragments reconstructs the exact complete JSON.
+        assert_eq!(fragments.concat(), complete);
+    }
+
+    #[test]
+    fn minimax_m3_streaming_coalesces_to_exact_complete_json() {
+        // Byte-exact backward compatibility with the non-streaming path
+        // (serde_json is built with `preserve_order`, so key order is
+        // document order in both paths).
+        let text = build_tool_block(&[(
+            "get_weather",
+            format!("{}{}", element("city", "Seattle"), element("days", "5")),
+        )]);
+        let mut parser = MinimaxM3ToolParser::new(&m3_test_tools());
+        let output = collect_stream(&mut parser, &split_by_chars(&text, 1));
+
+        assert_eq!(output.calls().len(), 1);
+        assert_eq!(output.calls()[0].name.as_deref(), Some("get_weather"));
+        assert_eq!(output.calls()[0].arguments, r#"{"city":"Seattle","days":5}"#);
+    }
+
+    #[test]
+    fn minimax_m3_streaming_is_chunk_split_invariant() {
+        // Feeding the same input split at every possible boundary must yield
+        // identical coalesced output.
+        let text = build_tool_block(&[("create_order", order_arguments())]);
+        let expected = {
+            let mut parser = MinimaxM3ToolParser::new(&m3_test_tools());
+            parser.parse_complete(&text).unwrap()
+        };
+
+        for size in [1usize, 2, 3, 5, 7, 13, 29] {
+            let mut parser = MinimaxM3ToolParser::new(&m3_test_tools());
+            let output = collect_stream(&mut parser, &split_by_chars(&text, size));
+            assert_eq!(
+                output, expected,
+                "chunk size {size} produced different output"
+            );
+        }
+    }
+
+    #[test]
+    fn minimax_m3_streaming_buffers_nested_param_as_single_fragment() {
+        // A nested object parameter is emitted as ONE fragment covering its
+        // whole subtree, even when streamed one character at a time.
+        let text = build_tool_block(&[(
+            "create_order",
+            element(
+                "shipping",
+                &format!("{}{}", element("city", "Singapore"), element("zip", "018956")),
+            ),
+        )]);
+        let mut parser = MinimaxM3ToolParser::new(&m3_test_tools());
+        let deltas = collect_raw_deltas(&mut parser, &split_by_chars(&text, 1));
+
+        let fragments = arg_fragments(&deltas);
+        let shipping_fragments: Vec<&String> =
+            fragments.iter().filter(|fragment| fragment.contains("shipping")).collect();
+        assert_eq!(
+            shipping_fragments.len(),
+            1,
+            "nested object must arrive in exactly one fragment, got {fragments:?}"
+        );
+        // That single fragment carries the whole nested subtree.
+        assert_eq!(
+            shipping_fragments[0],
+            &r#"{"shipping":{"city":"Singapore","zip":18956}"#.to_string()
+        );
+        assert_eq!(
+            serde_json::from_str::<Value>(&fragments.concat()).unwrap(),
+            json!({ "shipping": { "city": "Singapore", "zip": 18956 } })
+        );
+    }
+
+    #[test]
+    fn minimax_m3_streaming_nested_array_of_objects_coalesces_to_valid_json() {
+        // Real production failing shape: an array of objects, e.g.
+        // `comments: [{category, content}, ...]`. Each array element is itself a
+        // nested object. The whole `comments` parameter must buffer into ONE
+        // argument fragment (covering the entire subtree) and, streamed at every
+        // char boundary, must coalesce to the exact same valid JSON as a
+        // non-streaming parse.
+        let tools = vec![Tool {
+            name: "submit_review".to_string(),
+            description: None,
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "title": { "type": "string" },
+                    "comments": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "category": { "type": "string" },
+                                "content": { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            }),
+            strict: None,
+        }];
+
+        let comment_a = element(
+            "comment",
+            &format!(
+                "{}{}",
+                element("category", "bug"),
+                element("content", "crashes on start")
+            ),
+        );
+        let comment_b = element(
+            "comment",
+            &format!(
+                "{}{}",
+                element("category", "ux"),
+                element("content", "confusing layout")
+            ),
+        );
+        let body = format!(
+            "{}{}",
+            element("title", "Beta feedback"),
+            element("comments", &format!("{comment_a}{comment_b}")),
+        );
+        let text = build_tool_block(&[("submit_review", body)]);
+
+        let expected = json!({
+            "title": "Beta feedback",
+            "comments": [
+                { "category": "bug", "content": "crashes on start" },
+                { "category": "ux", "content": "confusing layout" }
+            ]
+        });
+
+        // Non-streaming reference: the array-of-objects converts correctly.
+        {
+            let mut parser = MinimaxM3ToolParser::new(&tools);
+            let output = parser.parse_complete(&text).unwrap();
+            assert_eq!(output.calls().len(), 1);
+            assert_eq!(output.calls()[0].name.as_deref(), Some("submit_review"));
+            assert_eq!(
+                serde_json::from_str::<Value>(&output.calls()[0].arguments).unwrap(),
+                expected
+            );
+        }
+
+        // Streaming one character at a time: the `comments` array (with its
+        // nested objects) must arrive as exactly one fragment, and coalescing
+        // every fragment reconstructs valid JSON identical to the reference.
+        let mut parser = MinimaxM3ToolParser::new(&tools);
+        let deltas = collect_raw_deltas(&mut parser, &split_by_chars(&text, 1));
+        let fragments = arg_fragments(&deltas);
+        let comments_fragments: Vec<&String> =
+            fragments.iter().filter(|fragment| fragment.contains("comments")).collect();
+        assert_eq!(
+            comments_fragments.len(),
+            1,
+            "nested array-of-objects must arrive in one fragment, got {fragments:?}"
+        );
+        assert_eq!(
+            serde_json::from_str::<Value>(&fragments.concat()).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -815,15 +1079,46 @@ mod tests {
     }
 
     #[test]
-    fn minimax_m3_finish_fails_incomplete_tool_call() {
+    fn minimax_m3_finish_degrades_incomplete_tool_call() {
+        // Truncated mid-invoke: finish() must NOT error. It best-effort closes
+        // the JSON so the caller still gets a parseable partial tool call.
         let mut parser = MinimaxM3ToolParser::new(&m3_test_tools());
-        parser
+        let mut output = parser
             .parse_chunk(&format!(
                 "{TOOL_CALL_START}{INVOKE_START} name=\"get_weather\">"
             ))
             .unwrap();
+        output.append(parser.finish().unwrap());
+        let output = output.coalesce();
 
-        assert!(parser.finish().is_err());
+        assert_eq!(output.calls().len(), 1);
+        assert_eq!(output.calls()[0].name.as_deref(), Some("get_weather"));
+        // No parameters arrived, so the best-effort close is an empty object.
+        assert_eq!(
+            serde_json::from_str::<Value>(&output.calls()[0].arguments).unwrap(),
+            json!({})
+        );
+    }
+
+    #[test]
+    fn minimax_m3_finish_degrades_truncated_after_partial_params() {
+        // Truncated after some parameters streamed: best-effort close yields a
+        // valid object containing the parameters received so far.
+        let mut parser = MinimaxM3ToolParser::new(&m3_test_tools());
+        let mut output = parser
+            .parse_chunk(&format!(
+                "{TOOL_CALL_START}{INVOKE_START} name=\"get_weather\">{}",
+                element("city", "Seattle"),
+            ))
+            .unwrap();
+        output.append(parser.finish().unwrap());
+        let output = output.coalesce();
+
+        assert_eq!(output.calls().len(), 1);
+        assert_eq!(
+            serde_json::from_str::<Value>(&output.calls()[0].arguments).unwrap(),
+            json!({ "city": "Seattle" })
+        );
     }
 
     #[test]
@@ -855,9 +1150,11 @@ mod tests {
     }
 
     #[test]
-    fn minimax_m3_finish_fails_partial_outer_end_marker() {
+    fn minimax_m3_finish_degrades_partial_outer_end_marker() {
+        // A completed invoke followed by a partial tool-block end marker must
+        // degrade gracefully (the invoke is already emitted), not error.
         let mut parser = MinimaxM3ToolParser::new(&m3_test_tools());
-        parser
+        let mut output = parser
             .parse_chunk(&format!(
                 "{}\n{}\n{}",
                 TOOL_CALL_START,
@@ -865,8 +1162,14 @@ mod tests {
                 &TOOL_CALL_END[..3]
             ))
             .unwrap();
+        output.append(parser.finish().unwrap());
+        let output = output.coalesce();
 
-        assert!(parser.finish().is_err());
+        assert_eq!(output.calls().len(), 1);
+        assert_eq!(
+            serde_json::from_str::<Value>(&output.calls()[0].arguments).unwrap(),
+            json!({ "city": "Seattle" })
+        );
     }
 
     #[test]
@@ -878,10 +1181,7 @@ mod tests {
             ))
             .unwrap_err();
 
-        expect![[
-            r#"tool parser parsing failed: near "]<]minimax[>[<bad>]<]minimax[>[</tool_call>": "#
-        ]]
-        .assert_eq(&error.to_report_string());
+        expect![[r#"tool parser parsing failed: near "]<]minimax[>[<bad>]<]minimax[>[</tool_call>": "#]].assert_eq(&error.to_report_string());
     }
 
     #[test]


### PR DESCRIPTION
## Purpose

Fixes #47998 — the `minimax_m3` tool parser emits tool-call arguments only after the full `<invoke>` block is parsed (a single `ToolCallDelta` with the complete JSON), so streaming clients receive **no incremental `function.arguments` deltas**: the whole blob arrives in one SSE chunk at the end, which breaks progressive tool-calling UIs. `kimi_k2` (and other JSON-passthrough parsers) stream fine; M3 buffers because its XML `<parameter>` tags are schema-converted only after the whole `<invoke>`.

## Change

Per-parameter incremental emission, mirroring `kimi_k2`'s name-first pattern:

- Atomic `Invoke` event → `InvokeStart{name}` / `Param{name, value}` / `InvokeEnd`, with a new `InsideInvoke` mode.
- `invoke_start_event` parses only the `<invoke name="...">` header; each top-level `<parameter>` is emitted as one JSON fragment (`{"k":v` / `,"k":v`), closed with `}` (or `{}` if empty).
- The element-parsing helpers (`parameter_element` / `element_body` / tag helpers) are made `Partial`-aware, so a top-level element yields `Incomplete` until fully buffered: nested object/array params buffer their subtree as one fragment; scalars stream per-param.
- `finish()` degrades gracefully (best-effort JSON close) instead of returning an error on a truncated call.

**Backward compatibility:** coalescing all fragments by `tool_index` reconstructs exactly the same arguments JSON as before, so the non-streaming / `parse_complete` output is unchanged (covered by tests).

Because the incremental path parses one small element at a time, it no longer needs the `take_until_marker` / `MarkerScanState` whole-body scan for `</invoke>`.

## Before / after (streaming a tool call)

- **Before:** `delta.tool_calls[].function.arguments` = 1 chunk (the whole JSON, at the end).
- **After:** multiple fragments (name first, then one per top-level parameter), coalescing to identical JSON. The Anthropic `/v1/messages` frontend correspondingly emits multiple `input_json_delta` events instead of one.

## Test

`cargo test -p vllm-parser --lib` → **362 passed**. New tests:

- multi-fragment emission (>1 arg-bearing deltas; no single fragment holds all args)
- chunk-split invariance (`collect_stream` + `split_by_chars` at sizes 1..29 produce identical coalesced output)
- coalesced arguments == exact non-streaming JSON
- nested array-of-objects (`comments:[{category, content}]`) buffered as a single fragment
- graceful `finish()` on a truncated call

Also verified end-to-end on a live vLLM server for both the OpenAI `/v1/chat/completions` and Anthropic `/v1/messages` frontends: arguments now stream field-by-field, with no regression to tool-call correctness, multi-tool ordering, or the `<mm:think>` reasoning split.
