### PR TITLE
[Bugfix][Parser] Use DeepSeek tool slot name for wrapper unwrapping

### DIFF
--- a/tests/parser/engine/test_deepseek_v32.py
+++ b/tests/parser/engine/test_deepseek_v32.py
@@ -158,6 +158,32 @@ class TestNonStreaming:
         args = json.loads(result.tool_calls[0].function.arguments)
         assert args == {"location": "Beijing"}
 
+    def test_identical_raw_args_use_current_slot_schema(
+        self, mock_tokenizer, mock_request
+    ):
+        city_tool = _make_tool("tool_a", {"city": {"type": "string"}})
+        tz_tool = _make_tool("tool_b", {"tz": {"type": "string"}})
+        tools = [city_tool, tz_tool]
+        parser = DeepSeekV32Parser(mock_tokenizer, tools=tools)
+        mock_request.tools = tools
+
+        raw_args = '{"city": "Tokyo"}'
+        text = _func_calls(
+            _invoke("tool_a", _param("arguments", "false", raw_args)),
+            _invoke("tool_b", _param("arguments", "false", raw_args)),
+        )
+
+        result = parser.extract_tool_calls(text, mock_request)
+
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 2
+        assert result.tool_calls[0].function.name == "tool_a"
+        args0 = json.loads(result.tool_calls[0].function.arguments)
+        assert args0 == {"city": "Tokyo"}
+        assert result.tool_calls[1].function.name == "tool_b"
+        args1 = json.loads(result.tool_calls[1].function.arguments)
+        assert args1 == {"arguments": {"city": "Tokyo"}}
+
 
 # ── Initial state ────────────────────────────────────────────────────
 
@@ -253,6 +279,37 @@ class TestStreaming:
         assert json.loads(final_args) == {"location": "NYC"}
         assert '"arguments"' not in streamed_args
         assert final_args.startswith(streamed_args)
+
+    def test_streaming_identical_raw_args_use_current_slot_schema(
+        self, mock_tokenizer, mock_request
+    ):
+        city_tool = _make_tool("tool_a", {"city": {"type": "string"}})
+        tz_tool = _make_tool("tool_b", {"tz": {"type": "string"}})
+        tools = [city_tool, tz_tool]
+        parser = DeepSeekV32Parser(mock_tokenizer, tools=tools)
+        mock_request.tools = tools
+
+        raw_args = '{"city": "Tokyo"}'
+        chunks = [
+            DSML_FUNC_START,
+            _invoke("tool_a", _param("arguments", "false", raw_args)),
+            _invoke("tool_b", _param("arguments", "false", raw_args)),
+            DSML_FUNC_END,
+        ]
+
+        results = simulate_tool_streaming(parser, mock_request, chunks)
+        final_delta, _ = results[-1]
+        finish_delta = parser.finish_streaming()
+        extracted = parser._build_extracted_result(final_delta, finish_delta)
+
+        assert extracted.tools_called is True
+        assert len(extracted.tool_calls) == 2
+        assert extracted.tool_calls[0].function.name == "tool_a"
+        args0 = json.loads(extracted.tool_calls[0].function.arguments)
+        assert args0 == {"city": "Tokyo"}
+        assert extracted.tool_calls[1].function.name == "tool_b"
+        args1 = json.loads(extracted.tool_calls[1].function.arguments)
+        assert args1 == {"arguments": {"city": "Tokyo"}}
 
     def test_missing_invoke_end(self, mock_tokenizer, mock_request):
         text = (

--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -598,6 +598,32 @@ class TestParallelUnwrapping:
         args1 = json.loads(result.tool_calls[1].function.arguments)
         assert args1 == {"timezone": "EST"}
 
+    def test_identical_raw_args_use_current_slot_schema(
+        self, mock_tokenizer, mock_request
+    ):
+        city_tool = _make_tool("tool_a", {"city": {"type": "string"}})
+        tz_tool = _make_tool("tool_b", {"tz": {"type": "string"}})
+        tools = [city_tool, tz_tool]
+        parser = DeepSeekV4Parser(mock_tokenizer, tools=tools)
+        mock_request.tools = tools
+
+        raw_args = '{"city": "Tokyo"}'
+        text = _tool_calls(
+            _invoke("tool_a", ("arguments", "false", raw_args)),
+            _invoke("tool_b", ("arguments", "false", raw_args)),
+        )
+
+        result = parser.extract_tool_calls(text, mock_request)
+
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 2
+        assert result.tool_calls[0].function.name == "tool_a"
+        args0 = json.loads(result.tool_calls[0].function.arguments)
+        assert args0 == {"city": "Tokyo"}
+        assert result.tool_calls[1].function.name == "tool_b"
+        args1 = json.loads(result.tool_calls[1].function.arguments)
+        assert args1 == {"arguments": {"city": "Tokyo"}}
+
     def test_unwrap_parallel_streaming(
         self, mock_tokenizer, mock_request, weather_tool, time_tool
     ):
@@ -626,6 +652,37 @@ class TestParallelUnwrapping:
         assert args0 == {"location": "NYC"}
         args1 = json.loads(extracted.tool_calls[1].function.arguments)
         assert args1 == {"timezone": "EST"}
+
+    def test_streaming_identical_raw_args_use_current_slot_schema(
+        self, mock_tokenizer, mock_request
+    ):
+        city_tool = _make_tool("tool_a", {"city": {"type": "string"}})
+        tz_tool = _make_tool("tool_b", {"tz": {"type": "string"}})
+        tools = [city_tool, tz_tool]
+        parser = DeepSeekV4Parser(mock_tokenizer, tools=tools)
+        mock_request.tools = tools
+
+        raw_args = '{"city": "Tokyo"}'
+        chunks = [
+            DSML_TOOL_START,
+            _invoke("tool_a", ("arguments", "false", raw_args)),
+            _invoke("tool_b", ("arguments", "false", raw_args)),
+            DSML_TOOL_END,
+        ]
+
+        results = simulate_tool_streaming(parser, mock_request, chunks)
+        final_delta, _ = results[-1]
+        finish_delta = parser.finish_streaming()
+        extracted = parser._build_extracted_result(final_delta, finish_delta)
+
+        assert extracted.tools_called is True
+        assert len(extracted.tool_calls) == 2
+        assert extracted.tool_calls[0].function.name == "tool_a"
+        args0 = json.loads(extracted.tool_calls[0].function.arguments)
+        assert args0 == {"city": "Tokyo"}
+        assert extracted.tool_calls[1].function.name == "tool_b"
+        args1 = json.loads(extracted.tool_calls[1].function.arguments)
+        assert args1 == {"arguments": {"city": "Tokyo"}}
 
     def test_no_unwrap_parallel_when_no_match(
         self, mock_tokenizer, mock_request, weather_tool, time_tool

--- a/vllm/parser/deepseek_v32.py
+++ b/vllm/parser/deepseek_v32.py
@@ -38,6 +38,7 @@ from vllm.parser.engine.parser_engine_config import (
 )
 
 if TYPE_CHECKING:
+    from vllm.parser.engine.parser_engine import ToolCallSlot
     from vllm.tokenizers import TokenizerLike
     from vllm.tool_parsers.abstract_tool_parser import Tool
 
@@ -121,11 +122,9 @@ class DeepSeekV32Parser(ParserEngine):
             parser_engine_config=deepseek_v32_config(),
             **kwargs,
         )
-        self._arg_converter = self._convert_args
 
-    def _convert_args(self, raw_args: str, partial: bool) -> str:
-        result = _dsml_arg_converter(raw_args, partial)
+    def _convert_slot_args(self, slot: ToolCallSlot, partial: bool) -> str:
+        result = _dsml_arg_converter(slot.args, partial)
         if not self._tools:
             return result
-        func_name = next((s.name for s in self._tool_slots if s.args == raw_args), None)
-        return _unwrap_wrapper_args(result, self._tools, func_name)
+        return _unwrap_wrapper_args(result, self._tools, slot.name)

--- a/vllm/parser/deepseek_v4.py
+++ b/vllm/parser/deepseek_v4.py
@@ -35,6 +35,7 @@ from vllm.parser.engine.parser_engine_config import (
 from vllm.tool_parsers.utils import find_tool_properties
 
 if TYPE_CHECKING:
+    from vllm.parser.engine.parser_engine import ToolCallSlot
     from vllm.tokenizers import TokenizerLike
     from vllm.tool_parsers.abstract_tool_parser import Tool
 
@@ -227,11 +228,9 @@ class DeepSeekV4Parser(ParserEngine):
             parser_engine_config=deepseek_v4_config(thinking=thinking),
             **kwargs,
         )
-        self._arg_converter = self._convert_args
 
-    def _convert_args(self, raw_args: str, partial: bool) -> str:
-        result = _dsml_arg_converter(raw_args, partial)
+    def _convert_slot_args(self, slot: ToolCallSlot, partial: bool) -> str:
+        result = _dsml_arg_converter(slot.args, partial)
         if not self._tools:
             return result
-        func_name = next((s.name for s in self._tool_slots if s.args == raw_args), None)
-        return _unwrap_wrapper_args(result, self._tools, func_name)
+        return _unwrap_wrapper_args(result, self._tools, slot.name)

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -919,6 +919,12 @@ class ParserEngine(Parser):
 
     # ── Arg conversion helpers ─────────────────────────────────────────
 
+    def _convert_slot_args(self, slot: ToolCallSlot, partial: bool) -> str:
+        converter = self._arg_converter
+        if converter is None:
+            return slot.args
+        return converter(slot.args, partial)
+
     def _compute_arg_delta(self, idx: int, raw_delta: str) -> str | None:
         converter = self._arg_converter
         if converter is None:
@@ -933,7 +939,7 @@ class ParserEngine(Parser):
 
         slot = self._tool_slots[idx]
         try:
-            current_json = converter(slot.args, True)
+            current_json = self._convert_slot_args(slot, True)
         except (json.JSONDecodeError, ValueError, TypeError):
             logger.debug("arg converter failed (streaming): %s", slot.args[:80])
             return None
@@ -969,7 +975,7 @@ class ParserEngine(Parser):
 
         slot = self._tool_slots[idx]
         try:
-            final_json = converter(slot.args, False)
+            final_json = self._convert_slot_args(slot, False)
         except (json.JSONDecodeError, ValueError, TypeError):
             logger.debug("arg converter failed (flush): %s", slot.args[:80])
             return None
@@ -1021,7 +1027,7 @@ class ParserEngine(Parser):
                 converter = self._arg_converter
                 if converter is not None:
                     try:
-                        args_json = converter(raw_body, False)
+                        args_json = self._convert_slot_args(slot, False)
                     except (json.JSONDecodeError, ValueError, TypeError):
                         logger.debug(
                             "arg converter failed (extract): %s", raw_body[:80]


### PR DESCRIPTION
## Summary
- Add a slot-aware parser-engine arg conversion hook so parsers can convert arguments with the active tool-call slot context.
- Use the current DeepSeek V4/V3.2 slot name when unwrapping DSML wrapper arguments instead of matching by raw argument text.
- Add non-streaming and streaming regressions for parallel DeepSeek calls that share identical raw wrapper args but target different tool schemas.

Fixes #47986

## Duplicate checks
- Checked issue #47986 comments: no comments.
- Checked open PRs mentioning #47986: none.
- Checked open PRs matching the old DeepSeek raw-args conversion path: none.

## Tests
- .......................................................................  [100%]
=============================== warnings summary ===============================
vllm/__init__.py:7
  /Users/tommytran/Desktop/Projects/vllm-contribution/vllm/vllm/__init__.py:7: RuntimeWarning: Failed to read commit hash:
  No module named 'vllm._version'
    from .version import __version__, __version_tuple__  # isort:skip

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
71 passed, 1 warning in 0.24s
- ruff check..........................................................................................Passed
ruff format.........................................................................................Passed
typos...............................................................................................Passed
clang-format....................................................................(no files to check)Skipped
markdownlint-cli2...............................................................(no files to check)Skipped
Lint GitHub Actions workflow files..............................................(no files to check)Skipped
pip-compile.....................................................................(no files to check)Skipped
pip-compile-rocm................................................................(no files to check)Skipped
pip-compile-xpu.................................................................(no files to check)Skipped
pip-compile-cpu.................................................................(no files to check)Skipped
pip-compile-docs................................................................(no files to check)Skipped
reformat test/nightly-torch.txt to be in sync with test/cuda.in.................(no files to check)Skipped
Run mypy for Python 3.10............................................................................Passed
Lint shell scripts..............................................................(no files to check)Skipped
Lint PNG exports from excalidraw................................................(no files to check)Skipped
Check SPDX headers..................................................................................Passed
Check root lazy imports.............................................................................Passed
Check for spaces in all filenames...................................................................Passed
Update Dockerfile dependency graph..................................................................Passed
Test non-root entrypoint wrapper................................................(no files to check)Skipped
Check for forbidden imports.........................................................................Passed
Prevent new 'torch.cuda' APIs call..................................................................Passed
Validate configuration has default values and that each field has a docstring.......................Passed
Validate docker/versions.json matches Dockerfile................................(no files to check)Skipped
Check attention backend documentation is up to date.................................................Passed
Check for boolean ops in with-statements............................................................Passed
Rust - Normalize Cargo manifests with autoinherit...............................(no files to check)Skipped
Rust - Sort Cargo manifest sections.............................................(no files to check)Skipped
Rust - Format code..............................................................(no files to check)Skipped
Suggestion..........................................................................................Passed
- hook id: suggestion
- duration: 0s

To bypass all the pre-commit hooks, add --no-verify to git commit. To skip a specific hook, prefix the commit command with SKIP=<hook-id>.

## Disclosure
This PR was prepared with OpenAI Codex assistance.