### PR TITLE
[Bugfix][V1] Serialize msgpack serde aux buffer access

### DIFF
--- a/tests/v1/test_serial_utils.py
+++ b/tests/v1/test_serial_utils.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import threading
+import types
 from collections import UserDict
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 import msgspec
@@ -237,6 +240,155 @@ def test_numpy_array_serialization():
     assert np.allclose(array, decoded), (
         "Decoded numpy array does not match the original array."
     )
+
+
+def test_concurrent_encode_serializes_aux_buffer_access(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Regression test for sharing one encoder across concurrent requests."""
+
+    encoder = MsgpackEncoder(size_threshold=1)
+    decoder = MsgpackDecoder(np.ndarray)
+    original_encode_ndarray = encoder._encode_ndarray
+
+    first_inside = threading.Event()
+    release_first = threading.Event()
+    interleaved = threading.Event()
+    active_count = 0
+    active_count_lock = threading.Lock()
+
+    def encode_ndarray_with_pause(
+        _self: MsgpackEncoder,
+        obj: np.ndarray,
+    ) -> tuple[str, tuple[int, ...], int | memoryview]:
+        nonlocal active_count
+        with active_count_lock:
+            active_count += 1
+            if active_count > 1:
+                interleaved.set()
+        try:
+            if obj[0] == 1:
+                first_inside.set()
+                assert release_first.wait(timeout=2)
+            return original_encode_ndarray(obj)
+        finally:
+            with active_count_lock:
+                active_count -= 1
+
+    monkeypatch.setattr(
+        encoder,
+        "_encode_ndarray",
+        types.MethodType(encode_ndarray_with_pause, encoder),
+    )
+
+    first_array = np.full((1024,), 1, dtype=np.int64)
+    second_array = np.full((1024,), 2, dtype=np.int64)
+    encoded_results: list[Sequence[bytes | bytearray | memoryview]] = []
+    errors: list[BaseException] = []
+
+    def encode_array(array: np.ndarray):
+        try:
+            encoded_results.append(encoder.encode(array))
+        except BaseException as e:
+            errors.append(e)
+
+    first_thread = threading.Thread(target=encode_array, args=(first_array,))
+    first_thread.start()
+    assert first_inside.wait(timeout=2)
+
+    second_thread = threading.Thread(target=encode_array, args=(second_array,))
+    second_thread.start()
+    assert not interleaved.wait(timeout=0.1)
+    release_first.set()
+
+    first_thread.join(timeout=2)
+    second_thread.join(timeout=2)
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert not errors
+
+    decoded_results = [decoder.decode(encoded) for encoded in encoded_results]
+    assert len(decoded_results) == 2
+    assert any(np.array_equal(decoded, first_array) for decoded in decoded_results)
+    assert any(np.array_equal(decoded, second_array) for decoded in decoded_results)
+
+
+def test_concurrent_decode_serializes_aux_buffer_access(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Regression test for sharing one decoder across concurrent requests."""
+
+    encoder = MsgpackEncoder(size_threshold=1)
+    first_array = np.full((1024,), 1, dtype=np.int64)
+    second_array = np.full((1024,), 2, dtype=np.int64)
+    first_encoded = encoder.encode(first_array)
+    second_encoded = encoder.encode(second_array)
+
+    decoder = MsgpackDecoder(np.ndarray)
+    original_decode_ndarray = decoder._decode_ndarray
+
+    first_inside = threading.Event()
+    release_first = threading.Event()
+    interleaved = threading.Event()
+    active_count = 0
+    active_count_lock = threading.Lock()
+
+    def decode_ndarray_with_pause(
+        self: MsgpackDecoder,
+        obj: tuple[str, tuple[int, ...], int | memoryview],
+    ) -> np.ndarray:
+        nonlocal active_count
+        with active_count_lock:
+            active_count += 1
+            if active_count > 1:
+                interleaved.set()
+        try:
+            dtype, _, data = obj
+            if isinstance(data, int):
+                first_value = np.frombuffer(
+                    self.aux_buffers[data], dtype=dtype, count=1
+                )[0]
+                if first_value == 1:
+                    first_inside.set()
+                    assert release_first.wait(timeout=2)
+            return original_decode_ndarray(obj)
+        finally:
+            with active_count_lock:
+                active_count -= 1
+
+    monkeypatch.setattr(
+        decoder,
+        "_decode_ndarray",
+        types.MethodType(decode_ndarray_with_pause, decoder),
+    )
+
+    decoded_results: list[np.ndarray] = []
+    errors: list[BaseException] = []
+
+    def decode_array(encoded: Sequence[bytes | bytearray | memoryview]):
+        try:
+            decoded_results.append(decoder.decode(encoded))
+        except BaseException as e:
+            errors.append(e)
+
+    first_thread = threading.Thread(target=decode_array, args=(first_encoded,))
+    first_thread.start()
+    assert first_inside.wait(timeout=2)
+
+    second_thread = threading.Thread(target=decode_array, args=(second_encoded,))
+    second_thread.start()
+    assert not interleaved.wait(timeout=0.1)
+    release_first.set()
+
+    first_thread.join(timeout=2)
+    second_thread.join(timeout=2)
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert not errors
+
+    assert len(decoded_results) == 2
+    assert any(np.array_equal(decoded, first_array) for decoded in decoded_results)
+    assert any(np.array_equal(decoded, second_array) for decoded in decoded_results)
 
 
 class CustomClass:

--- a/vllm/v1/serial_utils.py
+++ b/vllm/v1/serial_utils.py
@@ -4,6 +4,7 @@
 import dataclasses
 import importlib
 import pickle
+import threading
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from functools import partial
@@ -136,8 +137,8 @@ class UtilityResult:
 class MsgpackEncoder:
     """Encoder with custom torch tensor and numpy array serialization.
 
-    Note that unlike vanilla `msgspec` Encoders, this interface is generally
-    not thread-safe when encoding tensors / numpy arrays.
+    Concurrent calls are serialized because tensor / numpy serialization uses
+    per-message auxiliary buffers that are visible to the msgspec hook.
 
     By default, arrays below 256B are serialized inline Larger will get sent
     via dedicated messages. Note that this is a per-tensor limit.
@@ -158,35 +159,38 @@ class MsgpackEncoder:
         # our custom `msgspec` hook, `enc_hook`. We don't have a way to
         # pass custom data to the hook otherwise.
         self.aux_buffers: list[bytestr] | None = None
+        self._encode_lock = threading.Lock()
         self.size_threshold = size_threshold
         self.oob_tensor_consumer = oob_tensor_consumer
         if envs.VLLM_ALLOW_INSECURE_SERIALIZATION:
             _log_insecure_serialization_warning()
 
     def encode(self, obj: Any) -> Sequence[bytestr]:
-        try:
-            if self.oob_tensor_consumer is not None:
-                self.oob_tensor_consumer.new_message()
-            self.aux_buffers = bufs = [b""]
-            bufs[0] = self.encoder.encode(obj)
-            # This `bufs` list allows us to collect direct pointers to backing
-            # buffers of tensors and np arrays, and return them along with the
-            # top-level encoded buffer instead of copying their data into the
-            # new buffer.
-            return bufs
-        finally:
-            self.aux_buffers = None
+        with self._encode_lock:
+            try:
+                if self.oob_tensor_consumer is not None:
+                    self.oob_tensor_consumer.new_message()
+                self.aux_buffers = bufs = [b""]
+                bufs[0] = self.encoder.encode(obj)
+                # This `bufs` list allows us to collect direct pointers to
+                # backing buffers of tensors and np arrays, and return them
+                # along with the top-level encoded buffer instead of copying
+                # their data into the new buffer.
+                return bufs
+            finally:
+                self.aux_buffers = None
 
     def encode_into(self, obj: Any, buf: bytearray) -> Sequence[bytestr]:
-        try:
-            if self.oob_tensor_consumer is not None:
-                self.oob_tensor_consumer.new_message()
-            self.aux_buffers = [buf]
-            bufs = self.aux_buffers
-            self.encoder.encode_into(obj, buf)
-            return bufs
-        finally:
-            self.aux_buffers = None
+        with self._encode_lock:
+            try:
+                if self.oob_tensor_consumer is not None:
+                    self.oob_tensor_consumer.new_message()
+                self.aux_buffers = [buf]
+                bufs = self.aux_buffers
+                self.encoder.encode_into(obj, buf)
+                return bufs
+            finally:
+                self.aux_buffers = None
 
     def enc_hook(self, obj: Any) -> Any:
         if isinstance(obj, torch.Tensor):
@@ -313,8 +317,8 @@ class MsgpackEncoder:
 class MsgpackDecoder:
     """Decoder with custom torch tensor and numpy array serialization.
 
-    Note that unlike vanilla `msgspec` Decoders, this interface is generally
-    not thread-safe when encoding tensors / numpy arrays.
+    Concurrent calls are serialized because tensor / numpy deserialization uses
+    per-message auxiliary buffers that are visible to msgspec hooks.
 
     ``oob_tensor_provider`` must be used when an OOBTensorConsumer is used on the
     encoder side.
@@ -333,19 +337,21 @@ class MsgpackDecoder:
             *args, ext_hook=self.ext_hook, dec_hook=self.dec_hook
         )
         self.aux_buffers: Sequence[bytestr] = ()
+        self._decode_lock = threading.Lock()
         self.oob_tensor_provider = oob_tensor_provider
         if envs.VLLM_ALLOW_INSECURE_SERIALIZATION:
             _log_insecure_serialization_warning()
 
     def decode(self, bufs: bytestr | Sequence[bytestr]) -> Any:
-        if isinstance(bufs, bytestr):  # type: ignore
-            return self.decoder.decode(bufs)
+        with self._decode_lock:
+            if isinstance(bufs, bytestr):  # type: ignore
+                return self.decoder.decode(bufs)
 
-        self.aux_buffers = bufs
-        try:
-            return self.decoder.decode(bufs[0])
-        finally:
-            self.aux_buffers = ()
+            self.aux_buffers = bufs
+            try:
+                return self.decoder.decode(bufs[0])
+            finally:
+                self.aux_buffers = ()
 
     def dec_hook(self, t: type, obj: Any) -> Any:
         # Given native types in `obj`, convert to type `t`.


### PR DESCRIPTION
Summary:
- Serialize MsgpackEncoder encode and encode_into calls so tensor and ndarray aux_buffers cannot be overwritten by concurrent callers.
- Serialize MsgpackDecoder decode calls for the same per-message aux buffer reason.
- Add regression tests that force concurrent encode and decode hook interleavings on large ndarray auxiliary buffers.

Duplicate check:
- gh issue list --search "MsgpackEncoder aux_buffers thread" returned no open issues.
- gh pr list --search "MsgpackEncoder thread safe serial_utils" returned no open PRs.
- This is a code-derived race fix rather than a duplicate of an existing tracked issue.

Tests:
- .venv/bin/python -m pytest --noconftest tests/v1/test_serial_utils.py -q (12 passed)
- .venv/bin/pre-commit run --files vllm/v1/serial_utils.py tests/v1/test_serial_utils.py (passed)
- Commit-time pre-commit hooks (passed)

Note: the root tests/conftest.py currently requires optional llguidance in this local environment, so the pure serialization unit test was run with --noconftest.

Model evals:
- Not run. This only changes msgpack serialization synchronization and does not affect model outputs.

Disclosure:
- This PR was prepared with OpenAI Codex assistance.