### PR TITLE
[Bugfix][Tokenizer] Reject invalid DeepSeek history tool arguments

### DIFF
--- a/tests/tokenizers_/test_deepseek_history_tool_arguments.py
+++ b/tests/tokenizers_/test_deepseek_history_tool_arguments.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.tokenizers.deepseek_v4_encoding import (
+    encode_arguments_to_dsml as encode_dsv4_arguments,
+)
+from vllm.tokenizers.deepseek_v32_encoding import (
+    encode_arguments_to_dsml as encode_dsv32_arguments,
+)
+
+
+@pytest.mark.parametrize(
+    "encoder",
+    [encode_dsv4_arguments, encode_dsv32_arguments],
+    ids=["deepseek_v4", "deepseek_v32"],
+)
+def test_deepseek_history_tool_arguments_must_be_object(encoder):
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        encoder({"name": "noop", "arguments": "-12"})
+
+
+@pytest.mark.parametrize(
+    "encoder",
+    [encode_dsv4_arguments, encode_dsv32_arguments],
+    ids=["deepseek_v4", "deepseek_v32"],
+)
+def test_deepseek_history_tool_arguments_must_be_valid_json(encoder):
+    with pytest.raises(ValueError, match="must be a valid JSON object"):
+        encoder({"name": "noop", "arguments": "{-12}"})
+
+
+@pytest.mark.parametrize(
+    "encoder",
+    [encode_dsv4_arguments, encode_dsv32_arguments],
+    ids=["deepseek_v4", "deepseek_v32"],
+)
+def test_deepseek_history_tool_arguments_preserve_objects(encoder):
+    rendered = encoder(
+        {
+            "name": "weather",
+            "arguments": '{"city": "New York", "temp": 72, "alerts": ["wind"]}',
+        }
+    )
+
+    assert '<｜DSML｜parameter name="city" string="true">New York' in rendered
+    assert '<｜DSML｜parameter name="temp" string="false">72' in rendered
+    assert '<｜DSML｜parameter name="alerts" string="false">["wind"]' in rendered

--- a/vllm/tokenizers/deepseek_encoding_utils.py
+++ b/vllm/tokenizers/deepseek_encoding_utils.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+
+def load_tool_call_arguments(tool_call: Mapping[str, Any]) -> dict[str, Any]:
+    raw_arguments = tool_call.get("arguments")
+    if isinstance(raw_arguments, str):
+        try:
+            arguments = json.loads(raw_arguments)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                "DeepSeek tool call function.arguments must be a valid JSON object."
+            ) from exc
+    else:
+        arguments = raw_arguments
+
+    if not isinstance(arguments, dict):
+        raise ValueError("DeepSeek tool call function.arguments must be a JSON object.")
+
+    return arguments

--- a/vllm/tokenizers/deepseek_v32_encoding.py
+++ b/vllm/tokenizers/deepseek_v32_encoding.py
@@ -7,6 +7,8 @@ import copy
 import json
 from typing import Any
 
+from vllm.tokenizers.deepseek_encoding_utils import load_tool_call_arguments
+
 # flake8: noqa: E501
 TOOLS_SYSTEM_TEMPLATE = """## Tools
 You have access to a set of tools you can use to answer the user's question.
@@ -80,10 +82,7 @@ def tool_calls_from_openai_format(tool_calls):
 def encode_arguments_to_dsml(tool_call: dict[str, str]) -> str:
     p_dsml_template = """<{dsml_token}parameter name="{key}" string="{is_str}">{value}</{dsml_token}parameter>"""
     P_dsml_strs = []
-    if isinstance(tool_call["arguments"], str):
-        arguments = json.loads(tool_call["arguments"])
-    else:
-        arguments = tool_call["arguments"]
+    arguments = load_tool_call_arguments(tool_call)
 
     for k, v in arguments.items():
         p_dsml_str = p_dsml_template.format(

--- a/vllm/tokenizers/deepseek_v4_encoding.py
+++ b/vllm/tokenizers/deepseek_v4_encoding.py
@@ -14,6 +14,8 @@ from typing import Any, Dict, List, Union, Optional
 import copy
 import json
 
+from vllm.tokenizers.deepseek_encoding_utils import load_tool_call_arguments
+
 # ============================================================
 # Special Tokens
 # ============================================================
@@ -139,10 +141,7 @@ def encode_arguments_to_dsml(tool_call: Dict[str, Any]) -> str:
     p_dsml_template = '<{dsml_token}parameter name="{key}" string="{is_str}">{value}</{dsml_token}parameter>'
     P_dsml_strs = []
 
-    if isinstance(tool_call["arguments"], str):
-        arguments = json.loads(tool_call["arguments"])
-    else:
-        arguments = tool_call["arguments"]
+    arguments = load_tool_call_arguments(tool_call)
 
     for k, v in arguments.items():
         p_dsml_str = p_dsml_template.format(


### PR DESCRIPTION
Fixes #47974.

Summary:
- Add a shared DeepSeek tokenizer helper that parses prior assistant tool-call arguments and requires them to be JSON objects.
- Use the helper from both DeepSeek V4 and DeepSeek V3.2 DSML encoders, avoiding AttributeError crashes when history contains scalar, array, or malformed JSON arguments.
- Add regression coverage for valid object arguments, malformed JSON, and scalar JSON in both tokenizer modes.

Duplicate check:
- Searched open vLLM PRs for #47974, encode_arguments_to_dsml, and DeepSeek function.arguments validation. Existing vLLM DeepSeek PRs are parser/streaming related and do not cover request-history encoder validation.

Tests:
- .venv/bin/python -m pytest --noconftest tests/tokenizers_/test_deepseek_history_tool_arguments.py -q
- .venv/bin/python -m pytest --noconftest tests/tokenizers_/test_deepseek_v4.py tests/tokenizers_/test_deepseek_history_tool_arguments.py -q
- .venv/bin/pre-commit run --files vllm/tokenizers/deepseek_encoding_utils.py vllm/tokenizers/deepseek_v4_encoding.py vllm/tokenizers/deepseek_v32_encoding.py tests/tokenizers_/test_deepseek_history_tool_arguments.py

Note:
- A normal local pytest run exercises the assertions successfully but hits a macOS/MPS allocator error in the repo-wide cleanup fixture after each test, so the pure tokenizer tests above were run with --noconftest.
- No model eval was run; this is tokenizer request validation logic.

This PR was prepared with OpenAI Codex assistance.