### PR TITLE
[Bugfix][Parser] Preserve partial args for truncated tool calls

### DIFF
--- a/tests/parser/engine/test_engine.py
+++ b/tests/parser/engine/test_engine.py
@@ -714,6 +714,7 @@ class TestToolPreambleFinish:
         end_events = [e for e in finish_events if e.type == EventType.TOOL_CALL_END]
         assert len(end_events) == 1
         assert end_events[0].tool_index == 0
+        assert end_events[0].truncated is True
 
     def test_finish_no_tool_call_end_without_tool_index(self):
         config = self._preamble_without_tool_call_start_config()

--- a/tests/parser/engine/test_qwen3.py
+++ b/tests/parser/engine/test_qwen3.py
@@ -459,6 +459,40 @@ class TestStreaming:
         args_text = collect_tool_arguments(results)
         assert json.loads(args_text) == {"query": "hello", "limit": "10"}
 
+    def test_truncated_parameter_value_matches_non_streaming(
+        self,
+        parser,
+        mock_tokenizer,
+        mock_request,
+    ):
+        chunks = [
+            "Let me check.",
+            "<tool_call>\n",
+            "<function=get_weather>\n",
+            "<parameter=city>\n",
+            "San Fr",
+        ]
+
+        results = simulate_tool_streaming(parser, mock_request, chunks)
+        results.append((parser.finish_streaming(), "".join(chunks)))
+        streamed_args = collect_tool_arguments(results)
+
+        assert json.loads(streamed_args) == {"city": "San Fr"}
+
+        non_streaming_parser = ParserEngine(
+            mock_tokenizer,
+            parser_engine_config=qwen3_config(thinking=False),
+        )
+        result = non_streaming_parser.extract_tool_calls(
+            "".join(chunks),
+            mock_request,
+        )
+
+        assert result.tools_called is True
+        assert result.content == "Let me check."
+        assert result.tool_calls[0].function.name == "get_weather"
+        assert result.tool_calls[0].function.arguments == streamed_args
+
     def test_streaming_numeric_values(self, parser, mock_request):
         chunks = [
             "<tool_call>\n",

--- a/vllm/parser/engine/events.py
+++ b/vllm/parser/engine/events.py
@@ -24,3 +24,4 @@ class SemanticEvent:
     type: EventType
     value: str = ""
     tool_index: int = -1
+    truncated: bool = False

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -54,6 +54,7 @@ class ToolCallSlot:
         "name_sent",
         "string_keys",
         "streamed_json",
+        "truncated",
     )
 
     def __init__(self) -> None:
@@ -64,6 +65,7 @@ class ToolCallSlot:
         self.name_sent: bool = False
         self.string_keys: set[str] | None = None
         self.streamed_json: str = ""
+        self.truncated: bool = False
 
     @property
     def args(self) -> str:
@@ -852,8 +854,9 @@ class ParserEngine(Parser):
         if idx >= len(self._tool_slots):
             return
 
-        remaining = self._flush_arg_converter(idx)
         slot = self._tool_slots[idx]
+        slot.truncated = slot.truncated or event.truncated
+        remaining = self._flush_arg_converter(idx, partial=slot.truncated)
 
         if not slot.name_sent:
             name = slot.name or self._try_extract_name(idx)
@@ -962,14 +965,14 @@ class ParserEngine(Parser):
             return diff
         return None
 
-    def _flush_arg_converter(self, idx: int) -> str | None:
+    def _flush_arg_converter(self, idx: int, *, partial: bool = False) -> str | None:
         converter = self._arg_converter
         if converter is None:
             return None
 
         slot = self._tool_slots[idx]
         try:
-            final_json = converter(slot.args, False)
+            final_json = converter(slot.args, partial)
         except (json.JSONDecodeError, ValueError, TypeError):
             logger.debug("arg converter failed (flush): %s", slot.args[:80])
             return None
@@ -1021,7 +1024,7 @@ class ParserEngine(Parser):
                 converter = self._arg_converter
                 if converter is not None:
                     try:
-                        args_json = converter(raw_body, False)
+                        args_json = converter(raw_body, slot.truncated)
                     except (json.JSONDecodeError, ValueError, TypeError):
                         logger.debug(
                             "arg converter failed (extract): %s", raw_body[:80]

--- a/vllm/parser/engine/streaming_parser_engine.py
+++ b/vllm/parser/engine/streaming_parser_engine.py
@@ -261,6 +261,7 @@ class StreamingParserEngine:
                     SemanticEvent(
                         EventType.TOOL_CALL_END,
                         tool_index=self.tool_index,
+                        truncated=True,
                     )
                 )
             self.state = ParserState.CONTENT


### PR DESCRIPTION
Addresses the remaining partial-argument case discussed in #47137.

Summary:
- Mark parser-engine tool-call end events synthesized by finish() as truncated.
- Finalize truncated tool-call arguments with arg_converter(partial=True), preserving an interrupted parameter value in both the final streaming delta and non-streaming extraction.
- Add Qwen3 regression coverage for a max_tokens-style cutoff inside a <parameter=city> value.

Duplicate check:
- #47562 covers incomplete opener/content parity for #47137.
- #47964 adds tests for truncated opener parity.
- #47963 covers finish_reason for max_tokens-truncated streaming tool calls.
- I did not find an open PR that preserves partial ParserEngine argument values when truncation happens after the function name and inside a parameter value.

Tests:
- .venv/bin/python -m pytest tests/parser/engine/test_qwen3.py::TestStreaming::test_truncated_parameter_value_matches_non_streaming -q
- .venv/bin/python -m pytest tests/parser/engine/test_qwen3.py -q
- .venv/bin/python -m pytest tests/parser/engine/test_engine.py -q
- .venv/bin/python -m pytest tests/parser/engine/test_parser_engine.py -q
- .venv/bin/python -m pytest tests/parser/engine -q
- .venv/bin/pre-commit run --files vllm/parser/engine/events.py vllm/parser/engine/streaming_parser_engine.py vllm/parser/engine/parser_engine.py tests/parser/engine/test_qwen3.py tests/parser/engine/test_engine.py

This PR was prepared with OpenAI Codex assistance.
