### PR TITLE
[docs] Fix the docs build

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -186,9 +186,10 @@ def FusedMoE(
         has_bias: Whether expert layers have bias terms
         is_sequence_parallel: Whether sequence parallelism is enabled
         reduce_results: Whether to all-reduce the final output. Setting this
-        to False (to fuse the all-reduce downstream) is only honored on the
-        late-AR path.
-        expert_mapping: Expert parameter mapping for weight loading
+            to False (to fuse the all-reduce downstream) is only honored on
+            the late-AR path.
+        ckpt_names: Checkpoint parameter name tuple (gate_proj, down_proj,
+            up_proj) used for weight loading
         n_shared_experts: Number of shared experts to fuse into the routed
             grouped GEMM (ROCm; requires aiter FSE or the router-append path)
         router_logits_dtype: Data type for router logits buffers

--- a/vllm/v1/kv_offload/tiering/p2p/manager.py
+++ b/vllm/v1/kv_offload/tiering/p2p/manager.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import time
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from typing_extensions import override
 
@@ -115,7 +115,7 @@ class P2PSecondaryTierManager(SecondaryTierManager):
         port: int = 7777,
         backends: list[str] | None = None,
         num_threads: int = 4,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Initialize the P2P secondary tier manager.
 


### PR DESCRIPTION
## Purpose

Seems to be an issue with docs hence the latest version of the docs in main do not seem to be published on https://docs.vllm.ai/en/latest/.  

Here are the 5 warnings `mkdocs build --strict` produces:

```shell
  WARNING -  griffe: vllm/model_executor/layers/fused_moe/layer.py:189: Failed to get 'name: description' pair from 'to False (to fuse the all-reduce downstream) is only honored on the'
  WARNING -  griffe: vllm/model_executor/layers/fused_moe/layer.py:190: Failed to get 'name: description' pair from 'late-AR path.'
  WARNING -  griffe: vllm/model_executor/layers/fused_moe/layer.py:191: No type or annotation for parameter 'expert_mapping'
  WARNING -  griffe: vllm/model_executor/layers/fused_moe/layer.py:191: Parameter 'expert_mapping' does not appear in the function signature
  WARNING -  griffe: vllm/v1/kv_offload/tiering/p2p/manager.py:145: No type or annotation for parameter '**kwargs'
```

