### PR TITLE
[ROCm][CI] Avoid HIP init at config time via lazy aiter import in Quark OCP-MX

### DIFF
--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py
@@ -4,6 +4,7 @@
 from collections.abc import Callable
 from fractions import Fraction
 from functools import partial
+from importlib.util import find_spec
 from typing import Any
 
 import torch
@@ -36,18 +37,14 @@ from .quark_scheme import QuarkScheme
 logger = init_logger(__name__)
 
 
-try:
-    from aiter.ops.shuffle import shuffle_weight
-    from aiter.ops.triton.gemm_afp4wfp4 import (
-        gemm_afp4wfp4,
-        gemm_afp4wfp4_preshuffled_weight_scales,
-    )
-    from aiter.ops.triton.quant import dynamic_mxfp4_quant
+# NOTE: Do not import aiter at module scope. Importing aiter eagerly initializes HIP
+# which can force the engine core to spawn instead of fork.
+# find_spec locates the package without executing its __init__, so it stays HIP-free.
+# Actual `aiter` imports are deferred to the functions/methods that need them.
+_AITER_FOUND = find_spec("aiter") is not None
 
+if _AITER_FOUND:
     from vllm.utils.torch_utils import direct_register_custom_op
-
-    if rocm_aiter_ops.is_asm_fp4_gemm_dynamic_quant_enabled():
-        from aiter import gemm_a4w4, per_1x32_f4_quant_hip
 
     def gemm_with_dynamic_quant(
         x: torch.Tensor,
@@ -57,6 +54,15 @@ try:
         out_dtype: torch.dtype | None = torch.bfloat16,
         x_scales: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        from aiter.ops.triton.gemm_afp4wfp4 import (
+            gemm_afp4wfp4,
+            gemm_afp4wfp4_preshuffled_weight_scales,
+        )
+        from aiter.ops.triton.quant import dynamic_mxfp4_quant
+
+        if rocm_use_aiter_fp4_asm_gemm:
+            from aiter import gemm_a4w4, per_1x32_f4_quant_hip
+
         M = x.shape[0]
         N = weight.shape[0]
         K = weight.shape[1]
@@ -137,13 +143,11 @@ try:
         fake_impl=gemm_with_dynamic_quant_fake,
         dispatch_key=current_platform.dispatch_key,
     )
-except (ImportError, AttributeError, RuntimeError):
-    if current_platform.is_rocm():
-        logger.warning(
-            "AITER is not found or QuarkOCP_MX is not supported on the current "
-            "platform. QuarkOCP_MX quantization will not be available."
-        )
-    dynamic_mxfp4_quant = gemm_afp4wfp4 = None
+elif current_platform.is_rocm():
+    logger.warning(
+        "AITER is not found or QuarkOCP_MX is not supported on the current "
+        "platform. QuarkOCP_MX quantization will not be available."
+    )
 
 
 class QuarkOCP_MX(QuarkScheme):
@@ -211,8 +215,8 @@ class QuarkOCP_MX(QuarkScheme):
             rocm_aiter_ops.is_asm_fp4_gemm_dynamic_quant_enabled()
         )
 
-        if not self.emulate and (dynamic_mxfp4_quant is None or gemm_afp4wfp4 is None):
-            # Currently need these kernels if not emulating
+        if not self.emulate and not _AITER_FOUND:
+            # Currently need AITER kernels if not emulating
             raise NotImplementedError(
                 f"{self.__class__.__name__} requires AITER to be installed "
                 "for non-emulation mode! Please refer to "
@@ -261,6 +265,8 @@ class QuarkOCP_MX(QuarkScheme):
     def process_dynamic_mxfp4_weights_after_loading(
         self, layer: torch.nn.Module
     ) -> None:
+        from aiter.ops.triton.quant import dynamic_mxfp4_quant
+
         w_q, w_s = dynamic_mxfp4_quant(layer.weight)
         layer.weight_scale = torch.nn.Parameter(w_s.T.contiguous(), requires_grad=False)
         layer.weight = torch.nn.Parameter(w_q, requires_grad=False)
@@ -279,6 +285,8 @@ class QuarkOCP_MX(QuarkScheme):
             if self.dynamic_mxfp4_quant:
                 self.process_dynamic_mxfp4_weights_after_loading(layer)
             elif self.rocm_use_aiter_fp4_asm_gemm:
+                from aiter.ops.shuffle import shuffle_weight
+
                 # shuffle weight scale
                 weight_scale_shuffle = layer.weight_scale.data
                 sm, sn = weight_scale_shuffle.shape

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py
@@ -4,13 +4,12 @@
 from collections.abc import Callable
 from fractions import Fraction
 from functools import partial
-from importlib.util import find_spec
 from typing import Any
 
 import torch
 import torch.nn.functional as F
 
-from vllm._aiter_ops import rocm_aiter_ops
+from vllm._aiter_ops import is_aiter_found_and_supported, rocm_aiter_ops
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
     dequant_mxfp4,
@@ -39,11 +38,13 @@ logger = init_logger(__name__)
 
 # NOTE: Do not import aiter at module scope. Importing aiter eagerly initializes HIP
 # which can force the engine core to spawn instead of fork.
-# find_spec locates the package without executing its __init__, so it stays HIP-free.
-# Actual `aiter` imports are deferred to the functions/methods that need them.
-_AITER_FOUND = find_spec("aiter") is not None
+# is_aiter_found_and_supported() checks platform + arch + library availability via
+# find_spec/amdsmi, so it stays HIP-free.
+# Actual aiter imports are deferred to the functions/methods that need them,
+# where HIP initialization is expected.
+_AITER_SUPPORTED = is_aiter_found_and_supported()
 
-if _AITER_FOUND:
+if _AITER_SUPPORTED:
     from vllm.utils.torch_utils import direct_register_custom_op
 
     def gemm_with_dynamic_quant(
@@ -215,7 +216,7 @@ class QuarkOCP_MX(QuarkScheme):
             rocm_aiter_ops.is_asm_fp4_gemm_dynamic_quant_enabled()
         )
 
-        if not self.emulate and not _AITER_FOUND:
+        if not self.emulate and not _AITER_SUPPORTED:
             # Currently need AITER kernels if not emulating
             raise NotImplementedError(
                 f"{self.__class__.__name__} requires AITER to be installed "

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py
@@ -144,8 +144,9 @@ if is_aiter_found_and_supported():
     )
 elif current_platform.is_rocm():
     logger.warning(
-        "AITER is not found or QuarkOCP_MX is not supported on the current "
-        "platform. QuarkOCP_MX quantization will not be available."
+        "AITER is not found or not supported on the current platform, "
+        "QuarkOCP_MX will fall back to emulation."
+        "Native MXFP4/MXFP6 acceleration will not be available."
     )
 
 

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py
@@ -42,9 +42,7 @@ logger = init_logger(__name__)
 # find_spec/amdsmi, so it stays HIP-free.
 # Actual aiter imports are deferred to the functions/methods that need them,
 # where HIP initialization is expected.
-_AITER_SUPPORTED = is_aiter_found_and_supported()
-
-if _AITER_SUPPORTED:
+if is_aiter_found_and_supported():
     from vllm.utils.torch_utils import direct_register_custom_op
 
     def gemm_with_dynamic_quant(
@@ -216,7 +214,7 @@ class QuarkOCP_MX(QuarkScheme):
             rocm_aiter_ops.is_asm_fp4_gemm_dynamic_quant_enabled()
         )
 
-        if not self.emulate and not _AITER_SUPPORTED:
+        if not self.emulate and not is_aiter_found_and_supported():
             # Currently need AITER kernels if not emulating
             raise NotImplementedError(
                 f"{self.__class__.__name__} requires AITER to be installed "


### PR DESCRIPTION
## Purpose
Fixes ROCm failures in the model-initialization tests, for Basic Models Tests(Extra Initialization) 3, 4, 5 and 6 .e.g.:
```
pytest -s -v "tests/models/test_initialization.py::test_can_initialize_large_subset[Eagle3DeepseekV2ForCausalLM]"
```

These tests stub out `V1EngineCore._initialize_kv_caches` via monkeypatch to skip the dummy forward pass that profiles memory. 
The stub only takes effect if the engine core is forked (so it inherits the patched parent process). On ROCm the parent's HIP context gets initialized during LLM() construction, which forces vLLM to spawn instead of fork. 
The spawned child re-imports vLLM from scratch, never sees the monkeypatch, and runs the real _initialize_kv_caches.

For any model whose HF config carries a quantization_config `ModelConfig._verify_quantization` iterates over candidate quant methods calling `get_quantization_config(name)` to detect the checkpoint format. That helper imports every quant config unconditionally, including QuarkConfig, via this chain:
```
LLM() -> create_engine_config -> create_model_config -> ModelConfig.__post_init__
  -> _verify_quantization
    -> me_quant.get_quantization_config(name)          (quantization/__init__.py:114)
      -> from ...quark.quark import QuarkConfig
        -> quark/schemes/__init__.py 
          -> quark_ocp_mx.py
            -> from aiter.ops.shuffle import shuffle_weight  # module-scope import
              -> aiter/__init__.py -> ... -> arch_info.py
               triton...get_current_target().arch
                 -> torch.cuda.current_device()   # initializes HIP
```

So merely detecting the quantization method imported aiter at module scope which in turn initialized HIP in the parent forcing spawn and breaking the test.

The fix is to stop importing aiter at module scope in quark_ocp_mx.py. 
Following the existing lazy pattern in vllm/_aiter_ops.py:
  - Probe availability with find_spec("aiter"), which locates the package without executing aiter/__init__.py (so no HIP init).
  - Defer the real from aiter... import ... statements into the functions/methods that actually use them

The custom-op registration still happens at import time, guarded by `if _AITER_FOUND`, but no longer pulls in aiter itself.

## Test Plan
Run inside the dev container on a local MI300 machine:
pytest \
  "models/test_initialization.py::test_can_initialize_large_subset[EagleDeepSeekMTPModel]" \\
  "models/test_initialization.py::test_can_initialize_large_subset[Eagle3DeepseekV2ForCausalLM]" \\
  "models/test_initialization.py::test_can_initialize_large_subset[DeepseekV32ForCausalLM]" \\
  "models/test_initialization.py::test_can_initialize_large_subset[DeepseekV3ForCausalLM]"

## Test Result
All the test exhibited different failures due to the actual dummy forward run happening, the exact failure reason are omited for brevity.
After the fix all 4 tests pass.
