### PR TITLE
[Bugfix] Do not re-apply q/k/v scales on FlashInfer TRTLLM BF16-Q paths

### DIFF
--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -3,6 +3,7 @@
 """Tests for v1 attention backends without GPUModelRunner dependency."""
 
 from functools import partial
+from typing import Any
 
 import pytest
 import torch
@@ -648,6 +649,190 @@ def test_flashinfer_xqa_bmm1_scale_matches_decode_q_dtype():
 
     assert impl.get_xqa_bmm1_scale(MockLayer, torch.bfloat16) == 1.5
     assert impl.get_xqa_bmm1_scale(MockLayer, torch.float8_e4m3fn) == 3.0
+
+
+class _TrtllmScaleMockLayer:
+    def __init__(self, device: torch.device):
+        self._q_scale = torch.tensor(2.0, device=device)
+        self._k_scale = torch.tensor(3.0, device=device)
+        self._v_scale = torch.tensor(5.0, device=device)
+        self._q_scale_float = 2.0
+        self._k_scale_float = 3.0
+        self._v_scale_float = 5.0
+        self._o_scale_float = None
+
+
+def _make_trtllm_scale_test_impl(monkeypatch, flashinfer_backend):
+    # Avoid platform/network probes; the kernels are mocked in these tests.
+    monkeypatch.setattr(
+        flashinfer_backend, "can_use_trtllm_attention", lambda *args, **kwargs: False
+    )
+    return flashinfer_backend.FlashInferImpl(
+        num_heads=2,
+        head_size=64,
+        scale=0.125,
+        num_kv_heads=1,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="fp8",
+    )
+
+
+def _make_hnd_fp8_kv_cache(device: torch.device) -> torch.Tensor:
+    # Physically HND [num_blocks, 2, num_kv_heads, block_size, head_size],
+    # passed to forward() in the logical NHD dim order.
+    return torch.zeros(
+        3, 2, 1, 16, 64, dtype=torch.float8_e4m3fn, device=device
+    ).permute(0, 1, 3, 2, 4)
+
+
+@pytest.mark.skipif(
+    AttentionBackendEnum.FLASHINFER not in BACKENDS_TO_TEST,
+    reason="FlashInfer is not available.",
+)
+def test_flashinfer_trtllm_prefill_fp8_kv_dequant_kernel_scales(monkeypatch):
+    """The BF16-Q + FP8-KV TRTLLM prefill fallback dequantizes the KV cache
+    with k/v scales already applied, so the kernel must receive plain
+    sm_scale / 1.0 instead of the quantized-path bmm scales (#47847)."""
+    from vllm.v1.attention.backends import flashinfer as flashinfer_backend
+
+    device = torch.device(f"{DEVICE_TYPE}:0")
+    impl = _make_trtllm_scale_test_impl(monkeypatch, flashinfer_backend)
+    layer = _TrtllmScaleMockLayer(device)
+
+    captured: dict[str, Any] = {}
+
+    def fake_dequant(kv_cache, block_tables, k_scale, v_scale, dequant_dtype):
+        captured["dequant_scales"] = (k_scale.item(), v_scale.item())
+        mock_cache = torch.zeros(
+            2, 2, 1, 16, 64, dtype=dequant_dtype, device=kv_cache.device
+        )
+        return mock_cache, torch.ones_like(block_tables)
+
+    def fake_prefill_kernel(**kwargs):
+        captured["kernel"] = kwargs
+
+    monkeypatch.setattr(
+        flashinfer_backend, "trtllm_prefill_attn_kvfp8_dequant", fake_dequant
+    )
+    monkeypatch.setattr(
+        flashinfer_backend, "trtllm_batch_context_with_kv_cache", fake_prefill_kernel
+    )
+
+    attn_metadata = flashinfer_backend.FlashInferMetadata(
+        num_actual_tokens=4,
+        slot_mapping=torch.zeros(4, dtype=torch.int64, device=device),
+        q_data_type_prefill=torch.bfloat16,
+        q_data_type_decode=torch.bfloat16,
+        num_decodes=0,
+        num_decode_tokens=0,
+        num_prefills=1,
+        num_prefill_tokens=4,
+        causal=True,
+        prefill=flashinfer_backend.TRTLLMPrefill(
+            block_tables=torch.tensor([[1]], dtype=torch.int32, device=device),
+            seq_lens=torch.tensor([4], dtype=torch.int32, device=device),
+            cum_seq_lens_q=torch.tensor([0, 4], dtype=torch.int32, device=device),
+            cum_seq_lens_kv=torch.tensor([0, 4], dtype=torch.int32, device=device),
+            max_q_len=4,
+            max_seq_len=4,
+        ),
+        decode=None,
+        use_cascade=False,
+        cascade_wrapper=None,
+    )
+
+    query = torch.zeros(4, 2, 64, dtype=torch.bfloat16, device=device)
+    key = torch.zeros(4, 1, 64, dtype=torch.bfloat16, device=device)
+    value = torch.zeros(4, 1, 64, dtype=torch.bfloat16, device=device)
+    output = torch.empty(4, 128, dtype=torch.bfloat16, device=device)
+
+    set_kv_cache_layout("HND")
+    try:
+        impl.forward(
+            layer,
+            query,
+            key,
+            value,
+            _make_hnd_fp8_kv_cache(device),
+            attn_metadata,
+            output,
+        )
+    finally:
+        set_kv_cache_layout(None)
+
+    assert captured["dequant_scales"] == (3.0, 5.0)
+    kernel = captured["kernel"]
+    assert kernel["kv_cache"].dtype == torch.bfloat16
+    assert kernel["bmm1_scale"] == pytest.approx(impl.scale)
+    assert kernel["bmm2_scale"] == pytest.approx(1.0)
+
+
+@pytest.mark.skipif(
+    AttentionBackendEnum.FLASHINFER not in BACKENDS_TO_TEST,
+    reason="FlashInfer is not available.",
+)
+def test_flashinfer_trtllm_gen_decode_bmm1_scale_bf16_q(monkeypatch):
+    """trtllm-gen decode must only include q_scale in bmm1 when the decode
+    query is actually FP8, like the XQA path already does (#47847)."""
+    from vllm.v1.attention.backends import flashinfer as flashinfer_backend
+
+    device = torch.device(f"{DEVICE_TYPE}:0")
+    impl = _make_trtllm_scale_test_impl(monkeypatch, flashinfer_backend)
+    layer = _TrtllmScaleMockLayer(device)
+
+    captured: dict[str, Any] = {}
+
+    def fake_decode_kernel(**kwargs):
+        captured["kernel"] = kwargs
+
+    monkeypatch.setattr(
+        flashinfer_backend, "trtllm_batch_decode_with_kv_cache", fake_decode_kernel
+    )
+
+    attn_metadata = flashinfer_backend.FlashInferMetadata(
+        num_actual_tokens=2,
+        slot_mapping=torch.zeros(2, dtype=torch.int64, device=device),
+        q_data_type_prefill=torch.bfloat16,
+        q_data_type_decode=torch.bfloat16,
+        num_decodes=2,
+        num_decode_tokens=2,
+        num_prefills=0,
+        num_prefill_tokens=0,
+        causal=True,
+        prefill=None,
+        decode=flashinfer_backend.FlashInferTrtllmAPIDecode(
+            kernel=flashinfer_backend.FlashInferDecodeKernel.TRTLLM_GEN,
+            block_tables=torch.tensor([[1], [2]], dtype=torch.int32, device=device),
+            seq_lens=torch.tensor([8, 8], dtype=torch.int32, device=device),
+            max_seq_len=8,
+        ),
+        use_cascade=False,
+        cascade_wrapper=None,
+    )
+
+    query = torch.zeros(2, 2, 64, dtype=torch.bfloat16, device=device)
+    key = torch.zeros(2, 1, 64, dtype=torch.bfloat16, device=device)
+    value = torch.zeros(2, 1, 64, dtype=torch.bfloat16, device=device)
+    output = torch.empty(2, 128, dtype=torch.bfloat16, device=device)
+
+    set_kv_cache_layout("HND")
+    try:
+        impl.forward(
+            layer,
+            query,
+            key,
+            value,
+            _make_hnd_fp8_kv_cache(device),
+            attn_metadata,
+            output,
+        )
+    finally:
+        set_kv_cache_layout(None)
+
+    kernel = captured["kernel"]
+    assert kernel["bmm1_scale"] == pytest.approx(impl.scale * layer._k_scale_float)
+    assert kernel["bmm2_scale"] == pytest.approx(layer._v_scale_float)
 
 
 @pytest.mark.skipif(

--- a/tests/v1/attention/test_trtllm_attention_integration.py
+++ b/tests/v1/attention/test_trtllm_attention_integration.py
@@ -599,7 +599,7 @@ def _run_trtllm_integration(
         if is_nvfp4:
             atol, rtol = 1.0, 1.0  # nvfp4 has higher quantization error
         elif is_fp8:
-            atol, rtol = 5e-2, 5e-2  # fp8 KV quantization error
+            atol, rtol = 2e-1, 2e-1  # fp8 KV quantization error
         else:
             atol, rtol = 1e-2, 1e-2
         torch.testing.assert_close(output, sdpa_output, atol=atol, rtol=rtol)

--- a/tests/v1/attention/test_trtllm_attention_integration.py
+++ b/tests/v1/attention/test_trtllm_attention_integration.py
@@ -280,7 +280,77 @@ def _create_nvfp4_hnd_kv_cache(
     return nvfp4_cache
 
 
-def _run_trtllm_integration(batch_spec, kv_cache_dtype="auto", model_name=MODEL):
+def _create_fp8_hnd_kv_cache(
+    k_contexts,
+    v_contexts,
+    block_size,
+    num_kv_heads,
+    head_size,
+    dtype,
+    device,
+    num_blocks,
+    common_attn_metadata,
+    kv_scale_val,
+):
+    """Create an FP8 KV cache by quantizing bf16 context via
+    reshape_and_cache_flash, using the same block-table layout as
+    _create_hnd_kv_cache."""
+    bf16_cache = _create_hnd_kv_cache(
+        k_contexts,
+        v_contexts,
+        block_size,
+        num_kv_heads,
+        head_size,
+        dtype,
+        device,
+        num_blocks,
+        common_attn_metadata,
+    )
+
+    hnd_order = (0, 1, 3, 2, 4)
+    fp8_cache = torch.zeros(
+        (num_blocks, 2, num_kv_heads, block_size, head_size),
+        dtype=torch.float8_e4m3fn,
+        device=device,
+    ).permute(*hnd_order)
+
+    block_table = common_attn_metadata.block_table_tensor
+    seq_lens = common_attn_metadata.seq_lens.cpu()
+    query_lens = (
+        common_attn_metadata.query_start_loc_cpu[1:]
+        - common_attn_metadata.query_start_loc_cpu[:-1]
+    )
+    kv_scale_t = torch.tensor(kv_scale_val, dtype=torch.float32, device=device)
+
+    for i in range(len(k_contexts)):
+        ctx_len = int(seq_lens[i]) - int(query_lens[i])
+        if ctx_len == 0:
+            continue
+        n_ctx_blocks = (ctx_len + block_size - 1) // block_size
+        blocks = block_table[i, :n_ctx_blocks]
+        k_ctx = bf16_cache[blocks, 0].reshape(-1, num_kv_heads, head_size)[:ctx_len]
+        v_ctx = bf16_cache[blocks, 1].reshape(-1, num_kv_heads, head_size)[:ctx_len]
+        token_offsets = torch.arange(ctx_len, device=device)
+        block_indices = token_offsets // block_size
+        intra_offsets = token_offsets % block_size
+        slots = block_table[i, block_indices] * block_size + intra_offsets
+        torch.ops._C_cache_ops.reshape_and_cache_flash(
+            k_ctx,
+            v_ctx,
+            fp8_cache[:, 0],
+            fp8_cache[:, 1],
+            slots,
+            "fp8",
+            kv_scale_t,
+            kv_scale_t,
+        )
+
+    return fp8_cache
+
+
+def _run_trtllm_integration(
+    batch_spec, kv_cache_dtype="auto", model_name=MODEL, disable_q_quant=False
+):
     """Run TRTLLM attention through the full FlashInfer pipeline
     and compare against an SDPA reference."""
     set_random_seed(42)
@@ -294,6 +364,7 @@ def _run_trtllm_integration(batch_spec, kv_cache_dtype="auto", model_name=MODEL)
     )
     vllm_config.attention_config.use_trtllm_attention = True
     vllm_config.cache_config.cache_dtype = kv_cache_dtype
+    vllm_config.attention_config.disable_flashinfer_q_quantization = disable_q_quant
 
     num_q_heads = vllm_config.model_config.get_num_attention_heads(
         vllm_config.parallel_config
@@ -361,11 +432,27 @@ def _run_trtllm_integration(batch_spec, kv_cache_dtype="auto", model_name=MODEL)
 
     # 2. Create HND KV cache
     is_nvfp4 = kv_cache_dtype == "nvfp4"
+    is_fp8 = kv_cache_dtype == "fp8"
     if is_nvfp4:
         # Compute a global scale from the context data.
         all_ctx = torch.cat(k_contexts + v_contexts, dim=0)
         kv_scale_val = (all_ctx.abs().amax() / 448.0).item()
         kv_cache = _create_nvfp4_hnd_kv_cache(
+            k_contexts,
+            v_contexts,
+            BLOCK_SIZE,
+            num_kv_heads,
+            head_size,
+            dtype,
+            device,
+            NUM_GPU_BLOCKS,
+            common_attn_metadata,
+            kv_scale_val,
+        )
+    elif is_fp8:
+        all_ctx = torch.cat(k_contexts + v_contexts, dim=0)
+        kv_scale_val = (all_ctx.abs().amax() / 448.0).item()
+        kv_cache = _create_fp8_hnd_kv_cache(
             k_contexts,
             v_contexts,
             BLOCK_SIZE,
@@ -396,9 +483,15 @@ def _run_trtllm_integration(batch_spec, kv_cache_dtype="auto", model_name=MODEL)
     get_kv_cache_layout.cache_clear()
 
     try:
-        is_nvfp4 = kv_cache_dtype == "nvfp4"
-        kv_quant_mode = KVQuantMode.NVFP4 if is_nvfp4 else KVQuantMode.NONE
-        spec_dtype = torch.uint8 if is_nvfp4 else dtype
+        if is_nvfp4:
+            kv_quant_mode = KVQuantMode.NVFP4
+            spec_dtype = torch.uint8
+        elif is_fp8:
+            kv_quant_mode = KVQuantMode.FP8_PER_TENSOR
+            spec_dtype = torch.float8_e4m3fn
+        else:
+            kv_quant_mode = KVQuantMode.NONE
+            spec_dtype = dtype
         kv_cache_spec = FullAttentionSpec(
             block_size=BLOCK_SIZE,
             num_kv_heads=num_kv_heads,
@@ -453,9 +546,11 @@ def _run_trtllm_integration(batch_spec, kv_cache_dtype="auto", model_name=MODEL)
             )
 
             mock_layer = MockAttentionLayer(device)
-            if is_nvfp4:
-                # For nvfp4, k_scale/v_scale are the global quantization
-                # scales (amax/448) used by reshape_and_cache_flash.
+            if is_nvfp4 or is_fp8:
+                # k_scale/v_scale are the global quantization scales
+                # (amax/448) used by reshape_and_cache_flash. The default
+                # non-unity _q_scale stays: with BF16 queries it must be
+                # ignored by the backend.
                 kv_scale_t = torch.tensor(
                     kv_scale_val, dtype=torch.float32, device=device
                 )
@@ -503,6 +598,8 @@ def _run_trtllm_integration(batch_spec, kv_cache_dtype="auto", model_name=MODEL)
         # 4. Compare against SDPA reference
         if is_nvfp4:
             atol, rtol = 1.0, 1.0  # nvfp4 has higher quantization error
+        elif is_fp8:
+            atol, rtol = 5e-2, 5e-2  # fp8 KV quantization error
         else:
             atol, rtol = 1e-2, 1e-2
         torch.testing.assert_close(output, sdpa_output, atol=atol, rtol=rtol)
@@ -522,6 +619,22 @@ def test_trtllm_gen_full_attention_integration(batch_spec_name: str):
     MetadataBuilder.build() -> FlashInferImpl.forward() pipeline,
     with real TRTLLM kernels on Blackwell."""
     _run_trtllm_integration(BATCH_SPECS[batch_spec_name])
+
+
+@pytest.mark.parametrize(
+    "batch_spec_name",
+    list(BATCH_SPECS.keys()),
+)
+@torch.inference_mode()
+def test_trtllm_gen_fp8_kv_bf16_q_integration(batch_spec_name: str):
+    """Test FP8 KV cache with BF16 queries (disable_flashinfer_q_quantization):
+    prefill takes the KV dequant fallback and decode runs trtllm-gen with a
+    model-dtype query, so q/k/v scales must be applied exactly once (#47847)."""
+    _run_trtllm_integration(
+        BATCH_SPECS[batch_spec_name],
+        kv_cache_dtype="fp8",
+        disable_q_quant=True,
+    )
 
 
 @pytest.mark.parametrize(

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1870,6 +1870,8 @@ class FlashInferImpl(AttentionImpl):
                 if needs_fp8_out:
                     out = self._nvfp4_fp8_out[:num_prefill_tokens]
 
+                prefill_bmm1_scale = self.bmm1_scale
+                prefill_bmm2_scale = self.bmm2_scale
                 prefill_kv_block_scales = None
                 if self.is_kvcache_nvfp4:
                     # NVFP4 trtllm-gen kernel requires FP8 query.
@@ -1908,6 +1910,11 @@ class FlashInferImpl(AttentionImpl):
                         layer._v_scale,
                         attn_metadata.q_data_type_prefill,
                     )
+                    # The mock KV cache is already dequantized and the query
+                    # stays in model dtype, so the kernel must not apply
+                    # q/k/v scales again.
+                    prefill_bmm1_scale = self.scale
+                    prefill_bmm2_scale = 1.0
                 else:
                     mock_kv_cache = kv_cache_permute
                     mock_block_table = block_tables_prefill
@@ -1920,8 +1927,8 @@ class FlashInferImpl(AttentionImpl):
                     seq_lens=seq_lens_prefill,
                     max_q_len=attn_metadata.prefill.max_q_len,
                     max_kv_len=attn_metadata.prefill.max_seq_len,
-                    bmm1_scale=self.bmm1_scale,
-                    bmm2_scale=self.bmm2_scale,
+                    bmm1_scale=prefill_bmm1_scale,
+                    bmm2_scale=prefill_bmm2_scale,
                     batch_size=attn_metadata.num_prefills,
                     cum_seq_lens_q=attn_metadata.prefill.cum_seq_lens_q,
                     cum_seq_lens_kv=attn_metadata.prefill.cum_seq_lens_kv,
@@ -2068,12 +2075,11 @@ class FlashInferImpl(AttentionImpl):
                         "FlashInfer XQA speculative decode is not wired in vLLM yet."
                     )
 
-                # XQA decode can use model-dtype Q with FP8 KV, so only include
-                # q_scale when the decode query is actually FP8.
-                bmm1_scale = (
-                    self.get_xqa_bmm1_scale(layer, attn_metadata.q_data_type_decode)
-                    if decode_with_xqa
-                    else self.bmm1_scale
+                # Both XQA (SM90) and trtllm-gen (with
+                # disable_flashinfer_q_quantization) can run model-dtype Q with
+                # FP8 KV, so only include q_scale when the query is actually FP8.
+                bmm1_scale = self.get_xqa_bmm1_scale(
+                    layer, attn_metadata.q_data_type_decode
                 )
 
                 trtllm_batch_decode_with_kv_cache(


### PR DESCRIPTION
## Purpose
The FlashInfer BF16-Q + FP8-KV TRTLLM prefill fallback dequantizes the KV cache into a BF16 mock cache with k/v scales already applied, but still passed bmm1_scale = sm_scale * q_scale * k_scale and bmm2_scale = v_scale to the kernel, applying k/v scales twice and q_scale to a never-quantized query; trtllm-gen decode likewise included q_scale in bmm1 for BF16 queries (the secondary issue reported in #47847).

This PR passes plain sm_scale / 1.0 in the dequant fallback and routes all TRTLLM API decode kernels through the existing get_xqa_bmm1_scale conditional, which only includes q_scale when the query is actually FP8. The bug is not relevant for the default q_scale = k_scale = v_scale = 1.0 case but corrupts attention output for checkpoints with calibrated attention scales. Two new unit tests fail on main and pass with this change, and an H100 A/B run (FLASHINFER, fp8 KV, XQA decode) confirms bit-identical outputs where behaviour was already correct.

The buggy branches only execute on SM100 with an FP8 KV cache and BF16 queries
(`disable_flashinfer_q_quantization=true`) when TRTLLM is forced (attention sinks,
`use_trtllm_attention=1`, or block size >= 128). gpt-oss served this way executes the
affected code, but the official checkpoints carry no calibrated attention scales, so all
mis-applied factors are 1.0 and outputs stay correct. Output corruption requires a
checkpoint with static (non-unity) q/k/v or KV-cache scales, e.g. modelopt or
compressed-tensors FP8 with `kv_cache_scheme: static`. That narrow overlap is why the bug
survived since #24197 (Sept 2025).

AI-assisted, every line reviewed and tested by the submitter.

## Test Plan
```
# SM100 (B200/GB200), real trtllm-gen kernels vs SDPA reference:
pytest tests/v1/attention/test_trtllm_attention_integration.py
# any FlashInfer GPU, mocked kernels, asserts scales the kernel receives:
pytest tests/v1/attention/test_attention_backends.py -k "trtllm_prefill_fp8_kv_dequant or trtllm_gen_decode_bmm1 or xqa_bmm1"
```

New SM100 integration test `test_trtllm_gen_fp8_kv_bf16_q_integration`: FP8 KV cache with
calibrated (non-unity) k/v scales, BF16 queries (`disable_flashinfer_q_quantization`), and a
non-unity q_scale that must be ignored. Two new unit tests pin the exact `bmm1_scale`/`bmm2_scale` values passed to
the kernels.

## Test Result
On GB200 (SM100): the new integration test fails on main for all three batch shapes with
63-72% of output elements mismatched vs the SDPA reference (abs error up to 1.58) and passes
with this patch (worst residual 1/57344 elements at 0.148, fp8 quantization noise), the
pre-existing bf16 and nvfp4 integration tests pass before and after. The unit tests fail on
main (e.g. decode `bmm1_scale` 0.75 = sm*q*k instead of 0.375 = sm*k) and pass with this
patch. An H100 e2e check (FLASHINFER, fp8 KV, XQA decode, greedy) is bit-identical between
main and this patch, confirming currently-correct paths are unchanged.

