### PR TITLE
[Bugfix] Re-sync parameter tp_rank after process_weights_after_loading (fix replicated / disable_tp weight reload)

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -281,6 +281,15 @@ class LinearBase(PluggableLayer):
         self.tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
 
     def update_param_tp_status(self):
+        # Single source of truth for a parameter's TP state. BasevLLMParameter
+        # stamps self.tp_rank with the *global* rank in __init__; this reconciles
+        # every child parameter to the *layer's* tp_rank/tp_size (which correctly
+        # accounts for disable_tp -> replicated weights with tp_rank == 0).
+        #
+        # Must be re-run whenever parameters are (re-)created after construction,
+        # e.g. after quant_method.process_weights_after_loading() swaps in fresh
+        # Parameters. Otherwise a later load_weights()/weight-refit would narrow a
+        # replicated weight at global_rank * shard_size and overflow.
         for param in self.parameters():
             if isinstance(param, BasevLLMParameter):
                 param.tp_rank = self.tp_rank
@@ -910,7 +919,6 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
             shard_id=loaded_shard_id,
             shard_offset=shard_offset,
             shard_size=shard_size,
-            tp_rank=self.tp_rank,
         )
 
     def load_weights(
@@ -1110,12 +1118,10 @@ class QKVParallelLinear(ColumnParallelLinear):
                 # to ensure that any subsequent reduction (like .max())
                 # works correctly while preserving the parameter shape.
                 for idx in range(param.data.shape[0]):
-                    param.load_qkv_weight(
-                        loaded_weight=loaded_weight, shard_id=idx, tp_rank=self.tp_rank
-                    )
+                    param.load_qkv_weight(loaded_weight=loaded_weight, shard_id=idx)
                 return
             elif type(param) in (RowvLLMParameter, BasevLLMParameter):
-                param.load_qkv_weight(loaded_weight=loaded_weight, tp_rank=self.tp_rank)
+                param.load_qkv_weight(loaded_weight=loaded_weight)
                 return
             # TODO: @dsikka - move to parameter.py
             self._load_fused_module_from_checkpoint(param, loaded_weight)
@@ -1139,7 +1145,6 @@ class QKVParallelLinear(ColumnParallelLinear):
             shard_id=loaded_shard_id,
             shard_offset=shard_offset,
             shard_size=shard_size,
-            tp_rank=self.tp_rank,
         )
 
     def weight_loader(
@@ -1493,7 +1498,6 @@ class MinimaxM3QKVParallelLinearWithIndexer(QKVParallelLinear):
             shard_id=loaded_shard_id,
             shard_offset=shard_offset,
             shard_size=shard_size,
-            tp_rank=self.tp_rank,
         )
 
     def weight_loader(

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -364,6 +364,11 @@ def _layerwise_process(layer: torch.nn.Module, info: LayerReloadingInfo):
     quant_method = getattr(layer, "quant_method", None)
     if isinstance(quant_method, QuantizeMethodBase):
         quant_method.process_weights_after_loading(layer)
+        # Re-reconcile parameter TP state: process_weights_after_loading may
+        # have re-created Parameters (stamped with the global rank), which would
+        # otherwise break replicated (disable_tp) weights on a subsequent reload.
+        if hasattr(layer, "update_param_tp_status"):
+            layer.update_param_tp_status()
 
     # Copy processed values into original tensor storage (preserves cudagraph refs)
     # this code is a no-op if not reloading (because kernel tensors is empty)

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -111,6 +111,13 @@ def process_weights_after_loading(
             # parameters onto device for processing and back off after.
             with device_loading_context(module, target_device):
                 quant_method.process_weights_after_loading(module)
+            # process_weights_after_loading may swap in freshly-created
+            # Parameters (e.g. FP8 requantization), which are stamped with the
+            # global rank in BasevLLMParameter.__init__. Re-reconcile their TP
+            # state to the layer so a later weight reload / RL weight-refit
+            # narrows replicated (disable_tp) weights at the correct offset.
+            if hasattr(module, "update_param_tp_status"):
+                module.update_param_tp_status()
             # Repacking transients above can leave large amounts of memory in
             # the caching allocator, which starves the OS on UMA devices.
             release_device_memory_under_pressure(target_device)


### PR DESCRIPTION
## Purpose

Weight reload can crash for replicated (`disable_tp=True`) parameters such as the DeepSeek-V2/V3 / GLM MLA fused `a`-projection (`q_a_proj` + `kv_a_proj_with_mqa` when `q_lora_rank > 0`).

`BasevLLMParameter.__init__` stamps `self.tp_rank` with the global rank. It is reconciled to the layer's `tp_rank` (0 for `disable_tp`) by `update_param_tp_status()`, but that only runs at construction. When a parameter is re-created after construction (e.g. an FP8 `process_weights_after_loading` that builds a fresh `ModelWeightParameter`) and then reloaded via `load_weights` (RL weight refit), the new parameter carries the global rank again. A replicated weight is then narrowed at `global_rank * shard_size` and every rank > 0 overflows:

```
IndexError: start out of range (expected to be in range of [-576, 576], but got 1152)
RuntimeError: start (576) + length (576) exceeds dimension size (576).
```

## Fix

Make `update_param_tp_status()` the single source of truth for a parameter's TP state, and re-run it whenever parameters are re-created:

- Re-run `layer.update_param_tp_status()` right after `quant_method.process_weights_after_loading(...)` in the default loader (`model_loader/utils.py`) and the layerwise reload path (`model_loader/reload/layerwise.py`).
- Drop the redundant `tp_rank=self.tp_rank` kwarg from the `MergedColumnParallelLinear` / `QKVParallelLinear` (and Minimax indexer) `weight_loader_v2` call sites. The parameter loaders narrow with `self.tp_rank`, which is now always correct.

This supersedes the earlier version of this PR, which instead taught the parameter loaders to honor the `tp_rank` kwarg. Thanks @Isotr0py for the suggestion to unify on `update_param_tp_status`.

## Backward compatibility

- Regular TP layers: `update_param_tp_status()` sets `param.tp_rank == layer.tp_rank`, so offsets are identical.
- Replicated (`disable_tp`) layers: `layer.tp_rank == 0`, so the full replicated weight loads at offset 0 on every rank, matching the initial load.
- This also fixes `load_column_parallel_weight`, which the previous kwarg-based approach left untouched.

## Test Plan

- Existing TP loading is unaffected (offsets identical for `tp_size > 1`).
- Repro: load a DeepSeek-V3 FP8 checkpoint (MLA, `q_lora_rank > 0`) with `tp > 1`, then trigger a weight reload (re-run `load_weights` after `process_weights_after_loading`, as RL weight-refit flows do). Before this change ranks > 0 raise the `narrow` overflow above; after it the replicated `a`-proj reloads correctly.
