### PR TITLE
[Bugfix][MLA] Set kv quant mode in MLA attention cache spec

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -277,6 +277,7 @@ from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     KVCacheSpec,
     MLAAttentionSpec,
+    get_kv_quant_mode,
 )
 
 logger = init_logger(__name__)
@@ -1007,6 +1008,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             head_size=self.head_size,
             dtype=kv_cache_dtype,
             cache_dtype_str=vllm_config.cache_config.cache_dtype,
+            kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
         )
 
     def _v_up_proj(self, x: torch.Tensor, out: torch.Tensor):


### PR DESCRIPTION
## Purpose

Fixes #47722.

MLA attention never set kv quant mode in its cache spec, so the reshape path always assumed unquantized layout. With fp8 kv cache (e.g. GLM-5.2-FP8 under EP+DP), the buffer is sized for quantized storage but reshape computes the wrong shape , causing a RuntimeError.

## Test Plan

Quant mode resolves to NONE for unquantized paths (no behavior change) and FP8_PER_TENSOR for fp8 variants (correct reshape). Matches the pattern in every other attention class.

## Test Result

Passes existing tests. No change for non-fp8 configs.