### PR TITLE
Allow configuring DP update interval with an env var

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -168,6 +168,7 @@ if TYPE_CHECKING:
     VLLM_DP_MASTER_IP: str = ""
     VLLM_DP_MASTER_PORT: int = 0
     VLLM_RANDOMIZE_DP_DUMMY_INPUTS: bool = False
+    VLLM_DP_COORDINATOR_UPDATE_INTERVAL_MS: int = 100
     VLLM_RAY_DP_PACK_STRATEGY: Literal["strict", "fill", "span"] = "strict"
     VLLM_RAY_DP_PLACEMENT_NODE_IPS: str = ""
     VLLM_RAY_EXTRA_ENV_VAR_PREFIXES_TO_COPY: str = ""
@@ -1373,6 +1374,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Randomize inputs during dummy runs when using Data Parallel
     "VLLM_RANDOMIZE_DP_DUMMY_INPUTS": lambda: (
         os.environ.get("VLLM_RANDOMIZE_DP_DUMMY_INPUTS", "0") == "1"
+    ),
+    # Minimum interval for the DP coordinator's periodic state updates
+    "VLLM_DP_COORDINATOR_UPDATE_INTERVAL_MS": lambda: int(
+        os.getenv("VLLM_DP_COORDINATOR_UPDATE_INTERVAL_MS", "100")
     ),
     # Strategy to pack the data parallel ranks for Ray.
     # Available options:

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -9,6 +9,7 @@ import weakref
 import msgspec.msgpack
 import zmq
 
+import vllm.envs as envs
 from vllm.config import ParallelConfig
 from vllm.logger import init_logger
 from vllm.utils.network_utils import make_zmq_socket
@@ -146,7 +147,7 @@ class DPCoordinatorProc:
     def __init__(
         self,
         engine_count: int,
-        min_stats_update_interval_ms: int = 100,
+        min_stats_update_interval_ms: int | None = None,
         enable_wave_coordination: bool = True,
     ):
         set_process_title("DPCoordinator")
@@ -154,7 +155,9 @@ class DPCoordinatorProc:
 
         self.engines = [EngineState() for _ in range(engine_count)]
 
-        self.stats_update_interval_ms = min_stats_update_interval_ms
+        self.stats_update_interval_ms = (
+            min_stats_update_interval_ms or envs.VLLM_DP_COORDINATOR_UPDATE_INTERVAL_MS
+        )
         self.enable_wave_coordination = enable_wave_coordination
 
     @staticmethod
@@ -164,7 +167,7 @@ class DPCoordinatorProc:
         back_output_address: str,
         back_publish_address: str,
         zmq_addr_pipe=None,
-        min_stats_update_interval_ms: int = 100,
+        min_stats_update_interval_ms: int | None = None,
         enable_wave_coordination: bool = True,
     ):
         coordinator = DPCoordinatorProc(


### PR DESCRIPTION


## Purpose
When benchmarking a DP deployment with a burst of requests, if it takes longer than 100ms to submit the burst a race condition occurs between the core client's internal bookkeeping and the dp coordinator's periodic updates:
* The coordinator sends and update
* At the same time, the client submits a request to an engine and updates its internal bookkeeping
* The client then recvs the update, overriding `.lb_engines` and losing the internal bookkeeping
* Now the client will submit the next request to the same engine according to the old states

This creates an imbalance between DP ranks during the burst. In our experience, when benchmarking with uniform ISL:OSL, this leads to a perf hit that is especially felt in decode-heavy workloads (we've observed up to 10% difference in throughput between balanced and imbalanced benchmarks).

Ideally, with a burst of uniform requests, we want all ranks to work on the same number of requests (round robin), but this is currently only achievable with an external load balancer.

With this PR, round robin is achievable by using `--api-server-count=1` and setting `VLLM_DP_COORDINATOR_UPDATE_INTERVAL_MS` to a large enough value that ensures the burst is submitted before a state update is published.

## Test Plan
It seems the dp coordinator is not heavily tested, and adding special tests just for this minimal change seemed extreme. The old default value is kept so all tests and use cases that don't set the new env var should continue working as normal.

## Test Result
N/A

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

