### PR TITLE
[Bugfix][Kernel] Make Marlin MoE route alignment deterministic

### DIFF
--- a/benchmarks/kernels/benchmark_moe_align_block_size.py
+++ b/benchmarks/kernels/benchmark_moe_align_block_size.py
@@ -6,7 +6,11 @@ import itertools
 import torch
 
 from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
+    RADIX_SORT_MIN_ROUTED_ENTRIES,
+    MoEAlignRadixScratch,
     moe_align_block_size,
+    moe_align_block_size_radix,
+    moe_align_block_size_stable_small,
 )
 from vllm.triton_utils import triton
 from vllm.utils.torch_utils import set_random_seed
@@ -36,8 +40,8 @@ configs = list(
         x_names=["num_tokens", "num_experts", "topk", "ep_size"],
         x_vals=configs,
         line_arg="provider",
-        line_vals=["vllm"],
-        line_names=["vLLM"],
+        line_vals=["vllm", "deterministic"],
+        line_names=["vLLM", "deterministic"],
         plot_name="moe-align-block-size-performance",
         args={},
     )
@@ -56,12 +60,39 @@ def benchmark(num_tokens, num_experts, topk, ep_size, provider):
         e_map[e_ids] = torch.arange(local_e, device="cuda", dtype=torch.int32)
 
     quantiles = [0.5, 0.2, 0.8]
+    scratch = None
+    if topk_ids.numel() >= RADIX_SORT_MIN_ROUTED_ENTRIES:
+        scratch = MoEAlignRadixScratch(
+            max_num_tokens=num_tokens,
+            topk=topk,
+            num_experts=num_experts,
+            device=torch.device("cuda"),
+        )
 
     if provider == "vllm":
         ms, min_ms, max_ms = triton.testing.do_bench(
             lambda: moe_align_block_size(
                 topk_ids, block_size, num_experts, e_map, ignore_invalid_experts=True
             ),
+            quantiles=quantiles,
+        )
+    elif provider == "deterministic":
+        if scratch is None:
+
+            def align():
+                return moe_align_block_size_stable_small(
+                    topk_ids, block_size, num_experts, e_map
+                )
+
+        else:
+
+            def align():
+                return moe_align_block_size_radix(
+                    topk_ids, block_size, num_experts, scratch, e_map
+                )
+
+        ms, min_ms, max_ms = triton.testing.do_bench(
+            align,
             quantiles=quantiles,
         )
 

--- a/csrc/libtorch_stable/moe/moe_align_sum_kernels.cu
+++ b/csrc/libtorch_stable/moe/moe_align_sum_kernels.cu
@@ -974,8 +974,11 @@ void moe_align_block_size_radix(
   VLLM_STABLE_DISPATCH_INTEGRAL_AND_UNSIGNED_TYPES(
       topk_ids.scalar_type(), "moe_align_block_size_radix", [&] {
         constexpr int32_t key_threads = 256;
+        // Conservative portable CUDA grid cap. The key-prep kernel uses a
+        // grid-stride loop, so larger inputs are still processed correctly.
+        constexpr int32_t max_key_grid_blocks = 65535;
         const int32_t key_blocks =
-            std::min<int64_t>(CEILDIV(numel, key_threads), 65535);
+            std::min<int64_t>(CEILDIV(numel, key_threads), max_key_grid_blocks);
         vllm::moe::prepare_radix_sort_keys_kernel<scalar_t>
             <<<key_blocks, key_threads, 0, stream>>>(
                 reinterpret_cast<const scalar_t*>(topk_ids.const_data_ptr()),

--- a/csrc/libtorch_stable/moe/moe_align_sum_kernels.cu
+++ b/csrc/libtorch_stable/moe/moe_align_sum_kernels.cu
@@ -1,4 +1,5 @@
 #include <array>
+#include <limits>
 #include <cub/cub.cuh>
 
 #include <cuda_runtime.h>
@@ -11,6 +12,9 @@
 #include "../../cuda_compat.h"
 #include "libtorch_stable/core/math.hpp"
 #include "libtorch_stable/dispatch_utils.h"
+#ifndef USE_ROCM
+  #include "libtorch_stable/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h"
+#endif
 #include "libtorch_stable/quantization/vectorization.cuh"
 #include "libtorch_stable/torch_utils.h"
 
@@ -350,6 +354,175 @@ __global__ void count_and_sort_expert_tokens_kernel(
       max_num_tokens_padded, nullptr, 0, topk_num, has_expert_map);
 }
 
+// Decode-sized inputs fit in one block. Shared-memory counts and offsets build
+// the padded expert ranges; comparing only earlier routes gives a stable rank.
+// The O(num_routes^2 + num_experts) work is explicitly capped by max_routes.
+template <typename scalar_t, int32_t max_routes>
+__global__ void stable_small_route_align_kernel(
+    const scalar_t* __restrict__ topk_ids,
+    int32_t* __restrict__ sorted_token_ids, int32_t* __restrict__ expert_ids,
+    int32_t* __restrict__ total_tokens_post_pad,
+    const int32_t* __restrict__ expert_map, int32_t num_experts,
+    int32_t block_size, int32_t numel, int32_t max_num_tokens_padded,
+    int32_t max_num_m_blocks, bool has_expert_map) {
+  __shared__ int32_t expert_counts[1024];
+  __shared__ int32_t expert_offsets[1024];
+  __shared__ int32_t route_experts[max_routes];
+  using BlockScan = cub::BlockScan<int32_t, 1024>;
+  __shared__ typename BlockScan::TempStorage scan_storage;
+
+  const int32_t tid = threadIdx.x;
+  for (int32_t index = tid; index < max_num_tokens_padded;
+       index += blockDim.x) {
+    sorted_token_ids[index] = numel;
+  }
+  if (tid < num_experts) {
+    expert_counts[tid] = 0;
+  }
+  __syncthreads();
+
+  if (tid < numel) {
+    const int32_t global_expert_id = static_cast<int32_t>(topk_ids[tid]);
+    int32_t output_expert_id = -1;
+    if (global_expert_id >= 0 && global_expert_id < num_experts) {
+      output_expert_id =
+          has_expert_map ? expert_map[global_expert_id] : global_expert_id;
+    }
+    route_experts[tid] = output_expert_id;
+    if (output_expert_id >= 0) {
+      atomicAdd(&expert_counts[output_expert_id], 1);
+    }
+  }
+  __syncthreads();
+
+  int32_t padded_count = 0;
+  if (tid < num_experts) {
+    padded_count = CEILDIV(expert_counts[tid], block_size) * block_size;
+  }
+  int32_t padded_offset;
+  BlockScan(scan_storage).ExclusiveSum(padded_count, padded_offset);
+  if (tid <= num_experts) {
+    expert_offsets[tid] = padded_offset;
+  }
+  if (tid == num_experts) {
+    total_tokens_post_pad[0] = padded_offset;
+  }
+  __syncthreads();
+
+  if (tid < num_experts) {
+    for (int32_t index = expert_offsets[tid]; index < expert_offsets[tid + 1];
+         index += block_size) {
+      expert_ids[index / block_size] = tid;
+    }
+  }
+  const int32_t first_inactive_block = expert_offsets[num_experts] / block_size;
+  for (int32_t index = first_inactive_block + tid; index < max_num_m_blocks;
+       index += blockDim.x) {
+    expert_ids[index] = -1;
+  }
+
+  if (tid < numel) {
+    const int32_t output_expert_id = route_experts[tid];
+    if (output_expert_id >= 0) {
+      int32_t rank = 0;
+      for (int32_t previous = 0; previous < tid; ++previous) {
+        rank += route_experts[previous] == output_expert_id;
+      }
+      sorted_token_ids[expert_offsets[output_expert_id] + rank] = tid;
+    }
+  }
+}
+
+template <typename scalar_t>
+__global__ void prepare_radix_sort_keys_kernel(
+    const scalar_t* __restrict__ topk_ids, int32_t* __restrict__ keys,
+    const int32_t* __restrict__ expert_map, size_t numel, int32_t num_experts,
+    bool has_expert_map) {
+  for (size_t index = blockIdx.x * blockDim.x + threadIdx.x; index < numel;
+       index += blockDim.x * gridDim.x) {
+    const int32_t expert_id = static_cast<int32_t>(topk_ids[index]);
+    if (expert_id < 0 || expert_id >= num_experts) {
+      keys[index] = 2 * num_experts - 1;
+    } else if (has_expert_map) {
+      const int32_t local_expert_id = expert_map[expert_id];
+      keys[index] =
+          local_expert_id < 0 ? num_experts + expert_id : local_expert_id;
+    } else {
+      keys[index] = expert_id;
+    }
+  }
+}
+
+__global__ void copy_compact_tokens_to_padded_kernel(
+    const int32_t* __restrict__ compact_sorted_token_ids,
+    int32_t* __restrict__ sorted_token_ids,
+    const int32_t* __restrict__ padded_expert_offsets,
+    const int64_t* __restrict__ unpadded_expert_offsets, int32_t num_experts) {
+  const int32_t expert_id = blockIdx.x;
+  if (expert_id >= num_experts) {
+    return;
+  }
+
+  const int64_t compact_start = unpadded_expert_offsets[expert_id];
+  const int64_t compact_end = unpadded_expert_offsets[expert_id + 1];
+  const int32_t padded_start = padded_expert_offsets[expert_id];
+  for (int64_t index = compact_start + threadIdx.x; index < compact_end;
+       index += blockDim.x) {
+    sorted_token_ids[padded_start + index - compact_start] =
+        compact_sorted_token_ids[index];
+  }
+}
+
+__global__ void build_padded_metadata_from_offsets_kernel(
+    int32_t* __restrict__ sorted_token_ids, int32_t* __restrict__ expert_ids,
+    int32_t* __restrict__ total_tokens_post_pad,
+    int32_t* __restrict__ padded_expert_offsets,
+    const int64_t* __restrict__ unpadded_expert_offsets, int32_t num_experts,
+    int32_t block_size, int32_t numel, int32_t max_num_tokens_padded,
+    int32_t max_num_m_blocks) {
+  if (blockIdx.x == 1) {
+    for (int32_t index = threadIdx.x; index < max_num_tokens_padded;
+         index += blockDim.x) {
+      sorted_token_ids[index] = numel;
+    }
+    return;
+  }
+
+  using BlockScan = cub::BlockScan<int32_t, 1024>;
+  __shared__ typename BlockScan::TempStorage scan_storage;
+
+  const int32_t expert_id = threadIdx.x;
+  int32_t padded_count = 0;
+  if (expert_id < num_experts) {
+    const int64_t count = unpadded_expert_offsets[expert_id + 1] -
+                          unpadded_expert_offsets[expert_id];
+    padded_count = CEILDIV(count, block_size) * block_size;
+  }
+
+  int32_t padded_offset;
+  BlockScan(scan_storage).ExclusiveSum(padded_count, padded_offset);
+  if (expert_id <= num_experts) {
+    padded_expert_offsets[expert_id] = padded_offset;
+  }
+  if (expert_id == num_experts) {
+    total_tokens_post_pad[0] = padded_offset;
+  }
+  __syncthreads();
+
+  if (expert_id < num_experts) {
+    for (int32_t index = padded_expert_offsets[expert_id];
+         index < padded_expert_offsets[expert_id + 1]; index += block_size) {
+      expert_ids[index / block_size] = expert_id;
+    }
+  }
+  const int32_t fill_start =
+      padded_expert_offsets[num_experts] / block_size + threadIdx.x;
+  for (int32_t index = fill_start; index < max_num_m_blocks;
+       index += blockDim.x) {
+    expert_ids[index] = -1;
+  }
+}
+
 // Reduce the topk expert outputs per token (summed in fp32). The output is
 // dense [num_tokens, d]; the input is addressed by its strides so non-
 // contiguous inputs work without a copy. A 16B-vectorized path is used when
@@ -579,11 +752,12 @@ __global__ void moe_lora_align_block_size_small_batch_expert_kernel(
 
 // taken from
 // https://github.com/sgl-project/sglang/blob/8b5f83ed3b7d2a49ad5c5cd5aa61c5d502f47dbc
-void moe_align_block_size(
+static void moe_align_block_size_impl(
     torch::stable::Tensor topk_ids, int64_t num_experts, int64_t block_size,
     torch::stable::Tensor sorted_token_ids, torch::stable::Tensor experts_ids,
     torch::stable::Tensor num_tokens_post_pad,
-    std::optional<torch::stable::Tensor> maybe_expert_map) {
+    std::optional<torch::stable::Tensor> maybe_expert_map,
+    bool stable_token_order) {
   const torch::stable::accelerator::DeviceGuard device_guard(
       topk_ids.get_device_index());
   const cudaStream_t stream =
@@ -598,6 +772,9 @@ void moe_align_block_size(
   // BlockScan uses 1024 threads and assigns one thread per expert.
   STD_TORCH_CHECK(padded_num_experts < 1024,
                   "padded_num_experts must be less than 1024");
+  STD_TORCH_CHECK(!stable_token_order || topk_ids.numel() <= 256,
+                  "stable alignment supports at most 256 routed entries; "
+                  "use moe_align_block_size_radix for larger inputs");
   bool has_expert_map = maybe_expert_map.has_value();
   torch::stable::Tensor expert_map;
   if (has_expert_map) {
@@ -609,6 +786,22 @@ void moe_align_block_size(
 
   VLLM_STABLE_DISPATCH_INTEGRAL_AND_UNSIGNED_TYPES(
       topk_ids.scalar_type(), "moe_align_block_size_kernel", [&] {
+        constexpr int32_t stable_small_route_limit = 256;
+        if (stable_token_order &&
+            topk_ids.numel() <= stable_small_route_limit) {
+          vllm::moe::stable_small_route_align_kernel<
+              scalar_t, stable_small_route_limit><<<1, 1024, 0, stream>>>(
+              reinterpret_cast<const scalar_t*>(topk_ids.const_data_ptr()),
+              reinterpret_cast<int32_t*>(sorted_token_ids.mutable_data_ptr()),
+              reinterpret_cast<int32_t*>(experts_ids.mutable_data_ptr()),
+              reinterpret_cast<int32_t*>(
+                  num_tokens_post_pad.mutable_data_ptr()),
+              reinterpret_cast<const int32_t*>(expert_map.const_data_ptr()),
+              num_experts, block_size, topk_ids.numel(),
+              sorted_token_ids.size(0), experts_ids.size(0), has_expert_map);
+          return;
+        }
+
         // calc needed amount of shared mem for `cumsum` tensors
         bool small_batch_expert_mode =
             (topk_ids.numel() < 1024) && (num_experts <= 64);
@@ -677,6 +870,158 @@ void moe_align_block_size(
               topk_ids.size(1), has_expert_map);
         }
       });
+}
+
+void moe_align_block_size(
+    torch::stable::Tensor topk_ids, int64_t num_experts, int64_t block_size,
+    torch::stable::Tensor sorted_token_ids, torch::stable::Tensor experts_ids,
+    torch::stable::Tensor num_tokens_post_pad,
+    std::optional<torch::stable::Tensor> maybe_expert_map) {
+  moe_align_block_size_impl(topk_ids, num_experts, block_size, sorted_token_ids,
+                            experts_ids, num_tokens_post_pad, maybe_expert_map,
+                            false);
+}
+
+void moe_align_block_size_stable_small(
+    torch::stable::Tensor topk_ids, int64_t num_experts, int64_t block_size,
+    torch::stable::Tensor sorted_token_ids, torch::stable::Tensor experts_ids,
+    torch::stable::Tensor num_tokens_post_pad,
+    std::optional<torch::stable::Tensor> maybe_expert_map) {
+  moe_align_block_size_impl(topk_ids, num_experts, block_size, sorted_token_ids,
+                            experts_ids, num_tokens_post_pad, maybe_expert_map,
+                            true);
+}
+
+void moe_align_block_size_radix(
+    torch::stable::Tensor topk_ids, int64_t num_experts, int64_t block_size,
+    torch::stable::Tensor sorted_token_ids, torch::stable::Tensor experts_ids,
+    torch::stable::Tensor num_tokens_post_pad,
+    torch::stable::Tensor sort_workspace,
+    torch::stable::Tensor sorted_expert_ids,
+    torch::stable::Tensor compact_sorted_token_ids,
+    torch::stable::Tensor token_indices,
+    torch::stable::Tensor topk_ids_for_sort,
+    torch::stable::Tensor padded_expert_offsets,
+    torch::stable::Tensor unpadded_expert_offsets,
+    std::optional<torch::stable::Tensor> maybe_expert_map) {
+#ifdef USE_ROCM
+  STD_TORCH_CHECK(false, "moe_align_block_size_radix is not supported on ROCm");
+#else
+  const torch::stable::accelerator::DeviceGuard device_guard(
+      topk_ids.get_device_index());
+  const cudaStream_t stream =
+      get_current_cuda_stream(topk_ids.get_device_index());
+  const int64_t numel = topk_ids.numel();
+
+  STD_TORCH_CHECK(num_experts > 0 && num_experts < 1024,
+                  "num_experts must be in [1, 1024)");
+  STD_TORCH_CHECK(block_size > 0, "block_size must be positive");
+  STD_TORCH_CHECK(numel > 0, "topk_ids must not be empty");
+  STD_TORCH_CHECK(numel <= std::numeric_limits<int32_t>::max(),
+                  "topk_ids contains too many entries for int32 token indices");
+  const int64_t max_padding = num_experts * (block_size - 1);
+  STD_TORCH_CHECK(numel <= std::numeric_limits<int32_t>::max() - max_padding,
+                  "padded token count exceeds the int32 alignment ABI");
+  STD_TORCH_CHECK(topk_ids.is_contiguous(), "topk_ids must be contiguous");
+
+  auto check_scratch = [&](const torch::stable::Tensor& tensor,
+                           torch::headeronly::ScalarType dtype,
+                           const char* name) {
+    STD_TORCH_CHECK(tensor.device() == topk_ids.device(), name,
+                    " must be on the same device as topk_ids");
+    STD_TORCH_CHECK(tensor.scalar_type() == dtype, name,
+                    " has an unexpected dtype");
+    STD_TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+  };
+  check_scratch(sort_workspace, torch::headeronly::ScalarType::Char,
+                "sort_workspace");
+  check_scratch(sorted_expert_ids, torch::headeronly::ScalarType::Int,
+                "sorted_expert_ids");
+  check_scratch(compact_sorted_token_ids, torch::headeronly::ScalarType::Int,
+                "compact_sorted_token_ids");
+  check_scratch(token_indices, torch::headeronly::ScalarType::Int,
+                "token_indices");
+  check_scratch(topk_ids_for_sort, torch::headeronly::ScalarType::Int,
+                "topk_ids_for_sort");
+  check_scratch(padded_expert_offsets, torch::headeronly::ScalarType::Int,
+                "padded_expert_offsets");
+  check_scratch(unpadded_expert_offsets, torch::headeronly::ScalarType::Long,
+                "unpadded_expert_offsets");
+  STD_TORCH_CHECK(sorted_expert_ids.numel() >= numel,
+                  "sorted_expert_ids is too small");
+  STD_TORCH_CHECK(compact_sorted_token_ids.numel() >= numel,
+                  "compact_sorted_token_ids is too small");
+  STD_TORCH_CHECK(token_indices.numel() >= numel, "token_indices is too small");
+  STD_TORCH_CHECK(topk_ids_for_sort.numel() >= numel,
+                  "topk_ids_for_sort is too small");
+  STD_TORCH_CHECK(padded_expert_offsets.numel() >= num_experts + 1,
+                  "padded_expert_offsets is too small");
+  STD_TORCH_CHECK(unpadded_expert_offsets.numel() >= num_experts + 1,
+                  "unpadded_expert_offsets is too small");
+
+  bool has_expert_map = maybe_expert_map.has_value();
+  if (has_expert_map) {
+    check_scratch(maybe_expert_map.value(), torch::headeronly::ScalarType::Int,
+                  "expert_map");
+    STD_TORCH_CHECK(maybe_expert_map.value().numel() >= num_experts,
+                    "expert_map is too small");
+  }
+  const int32_t* expert_map_ptr =
+      has_expert_map ? reinterpret_cast<const int32_t*>(
+                           maybe_expert_map.value().const_data_ptr())
+                     : nullptr;
+
+  VLLM_STABLE_DISPATCH_INTEGRAL_AND_UNSIGNED_TYPES(
+      topk_ids.scalar_type(), "moe_align_block_size_radix", [&] {
+        constexpr int32_t key_threads = 256;
+        const int32_t key_blocks =
+            std::min<int64_t>(CEILDIV(numel, key_threads), 65535);
+        vllm::moe::prepare_radix_sort_keys_kernel<scalar_t>
+            <<<key_blocks, key_threads, 0, stream>>>(
+                reinterpret_cast<const scalar_t*>(topk_ids.const_data_ptr()),
+                reinterpret_cast<int32_t*>(
+                    topk_ids_for_sort.mutable_data_ptr()),
+                expert_map_ptr, numel, num_experts, has_expert_map);
+      });
+
+  // CUB radix sort is stable. Monotonic input values therefore preserve
+  // flattened route order within equal expert keys without a composite key.
+  CubKeyValueSorter sorter(num_experts);
+  sorter.run(
+      sort_workspace.mutable_data_ptr(), sort_workspace.numel(),
+      reinterpret_cast<const int32_t*>(topk_ids_for_sort.const_data_ptr()),
+      reinterpret_cast<int32_t*>(sorted_expert_ids.mutable_data_ptr()),
+      reinterpret_cast<const int32_t*>(token_indices.const_data_ptr()),
+      reinterpret_cast<int32_t*>(compact_sorted_token_ids.mutable_data_ptr()),
+      numel, stream);
+
+  computeExpertFirstTokenOffset(
+      reinterpret_cast<const int32_t*>(sorted_expert_ids.const_data_ptr()),
+      numel, num_experts,
+      reinterpret_cast<int64_t*>(unpadded_expert_offsets.mutable_data_ptr()),
+      stream);
+
+  vllm::moe::build_padded_metadata_from_offsets_kernel<<<2, 1024, 0, stream>>>(
+      reinterpret_cast<int32_t*>(sorted_token_ids.mutable_data_ptr()),
+      reinterpret_cast<int32_t*>(experts_ids.mutable_data_ptr()),
+      reinterpret_cast<int32_t*>(num_tokens_post_pad.mutable_data_ptr()),
+      reinterpret_cast<int32_t*>(padded_expert_offsets.mutable_data_ptr()),
+      reinterpret_cast<const int64_t*>(
+          unpadded_expert_offsets.const_data_ptr()),
+      num_experts, block_size, numel, sorted_token_ids.size(0),
+      experts_ids.size(0));
+
+  vllm::moe::
+      copy_compact_tokens_to_padded_kernel<<<num_experts, 256, 0, stream>>>(
+          reinterpret_cast<const int32_t*>(
+              compact_sorted_token_ids.const_data_ptr()),
+          reinterpret_cast<int32_t*>(sorted_token_ids.mutable_data_ptr()),
+          reinterpret_cast<const int32_t*>(
+              padded_expert_offsets.const_data_ptr()),
+          reinterpret_cast<const int64_t*>(
+              unpadded_expert_offsets.const_data_ptr()),
+          num_experts);
+#endif
 }
 
 void batched_moe_align_block_size(int64_t max_tokens_per_batch,

--- a/csrc/libtorch_stable/moe/moe_ops.h
+++ b/csrc/libtorch_stable/moe/moe_ops.h
@@ -35,6 +35,25 @@ void moe_align_block_size(
     torch::stable::Tensor num_tokens_post_pad,
     std::optional<torch::stable::Tensor> maybe_expert_map);
 
+void moe_align_block_size_stable_small(
+    torch::stable::Tensor topk_ids, int64_t num_experts, int64_t block_size,
+    torch::stable::Tensor sorted_token_ids, torch::stable::Tensor experts_ids,
+    torch::stable::Tensor num_tokens_post_pad,
+    std::optional<torch::stable::Tensor> maybe_expert_map);
+
+void moe_align_block_size_radix(
+    torch::stable::Tensor topk_ids, int64_t num_experts, int64_t block_size,
+    torch::stable::Tensor sorted_token_ids, torch::stable::Tensor experts_ids,
+    torch::stable::Tensor num_tokens_post_pad,
+    torch::stable::Tensor sort_workspace,
+    torch::stable::Tensor sorted_expert_ids,
+    torch::stable::Tensor compact_sorted_token_ids,
+    torch::stable::Tensor token_indices,
+    torch::stable::Tensor topk_ids_for_sort,
+    torch::stable::Tensor padded_expert_offsets,
+    torch::stable::Tensor unpadded_expert_offsets,
+    std::optional<torch::stable::Tensor> maybe_expert_map);
+
 void batched_moe_align_block_size(
     int64_t max_tokens_per_batch, int64_t block_size,
     const torch::stable::Tensor& expert_num_tokens,

--- a/csrc/libtorch_stable/moe/torch_bindings.cpp
+++ b/csrc/libtorch_stable/moe/torch_bindings.cpp
@@ -35,6 +35,27 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_moe_C, m) {
       "                     Tensor! num_tokens_post_pad,"
       "                     Tensor? maybe_expert_map) -> ()");
 
+  m.def(
+      "moe_align_block_size_stable_small(Tensor topk_ids, int num_experts,"
+      "                     int block_size, Tensor! sorted_token_ids,"
+      "                     Tensor! experts_ids,"
+      "                     Tensor! num_tokens_post_pad,"
+      "                     Tensor? maybe_expert_map) -> ()");
+
+  m.def(
+      "moe_align_block_size_radix(Tensor topk_ids, int num_experts,"
+      "                     int block_size, Tensor! sorted_token_ids,"
+      "                     Tensor! experts_ids,"
+      "                     Tensor! num_tokens_post_pad,"
+      "                     Tensor! sort_workspace,"
+      "                     Tensor! sorted_expert_ids,"
+      "                     Tensor! compact_sorted_token_ids,"
+      "                     Tensor! token_indices,"
+      "                     Tensor! topk_ids_for_sort,"
+      "                     Tensor! padded_expert_offsets,"
+      "                     Tensor! unpadded_expert_offsets,"
+      "                     Tensor? maybe_expert_map) -> ()");
+
   // Aligning the number of tokens to be processed by each expert such
   // that it is divisible by the block size, but for the batched case.
   m.def(
@@ -134,6 +155,9 @@ STABLE_TORCH_LIBRARY_IMPL(_moe_C, CUDA, m) {
   m.impl("topk_softplus_sqrt", TORCH_BOX(&topk_softplus_sqrt));
   m.impl("moe_sum", TORCH_BOX(&moe_sum));
   m.impl("moe_align_block_size", TORCH_BOX(&moe_align_block_size));
+  m.impl("moe_align_block_size_stable_small",
+         TORCH_BOX(&moe_align_block_size_stable_small));
+  m.impl("moe_align_block_size_radix", TORCH_BOX(&moe_align_block_size_radix));
   m.impl("batched_moe_align_block_size",
          TORCH_BOX(&batched_moe_align_block_size));
   m.impl("moe_lora_align_block_size", TORCH_BOX(&moe_lora_align_block_size));

--- a/tests/kernels/moe/test_moe_align_block_size.py
+++ b/tests/kernels/moe/test_moe_align_block_size.py
@@ -10,8 +10,8 @@ import torch
 
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
-    MoEAlignRadixScratch,
     RADIX_SORT_MIN_ROUTED_ENTRIES,
+    MoEAlignRadixScratch,
     batched_moe_align_block_size,
     moe_align_block_size,
     moe_align_block_size_radix,

--- a/tests/kernels/moe/test_moe_align_block_size.py
+++ b/tests/kernels/moe/test_moe_align_block_size.py
@@ -11,6 +11,7 @@ import torch
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
     MoEAlignRadixScratch,
+    RADIX_SORT_MIN_ROUTED_ENTRIES,
     batched_moe_align_block_size,
     moe_align_block_size,
     moe_align_block_size_radix,
@@ -158,6 +159,35 @@ def _assert_stable_local_expert_order(
         len(expected),
     )
     assert actual == expected
+
+
+def _deterministic_moe_align_block_size_for_test(
+    topk_ids: torch.Tensor,
+    block_size: int,
+    num_experts: int,
+    expert_map: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if topk_ids.numel() >= RADIX_SORT_MIN_ROUTED_ENTRIES:
+        scratch = MoEAlignRadixScratch(
+            max_num_tokens=topk_ids.size(0),
+            topk=topk_ids.size(1),
+            num_experts=num_experts,
+            device=torch.device("cuda"),
+        )
+        return moe_align_block_size_radix(
+            topk_ids=topk_ids,
+            block_size=block_size,
+            num_experts=num_experts,
+            scratch=scratch,
+            expert_map=expert_map,
+        )
+
+    return moe_align_block_size_stable_small(
+        topk_ids=topk_ids,
+        block_size=block_size,
+        num_experts=num_experts,
+        expert_map=expert_map,
+    )
 
 
 def torch_moe_align_block_size(
@@ -423,12 +453,76 @@ def test_moe_align_block_size_stable_small_preserves_token_order(
     torch.testing.assert_close(actual_sorted_ids, golden_sorted_ids, atol=0, rtol=0)
 
 
+@pytest.mark.parametrize("num_routed_entries", [256, 257])
+@pytest.mark.parametrize("expert_map_enabled", [False, True])
+def test_deterministic_moe_align_block_size_threshold_preserves_token_order(
+    num_routed_entries: int, expert_map_enabled: bool
+):
+    topk, num_experts, block_size = 1, 16, 8
+    topk_ids = (
+        torch.arange(num_routed_entries, device="cuda", dtype=torch.int32)
+        .remainder(num_experts)
+        .view(-1, topk)
+    )
+    # Rotate the pattern so stable within-expert order is observable and not
+    # accidentally equivalent to expert-id order.
+    topk_ids = torch.roll(topk_ids, shifts=7, dims=0).contiguous()
+
+    expert_map = None
+    if expert_map_enabled:
+        expert_map = torch.full((num_experts,), -1, device="cuda", dtype=torch.int32)
+        for local_id, expert_id in enumerate(range(0, num_experts, 2)):
+            expert_map[expert_id] = local_id
+
+    actual_sorted_ids, actual_expert_ids, actual_num_tokens = (
+        _deterministic_moe_align_block_size_for_test(
+            topk_ids=topk_ids,
+            block_size=block_size,
+            num_experts=num_experts,
+            expert_map=expert_map,
+        )
+    )
+    golden_sorted_ids, golden_expert_ids, golden_num_tokens = (
+        torch_moe_align_block_size(
+            topk_ids=topk_ids,
+            block_size=block_size,
+            num_experts=num_experts,
+            expert_map=expert_map,
+        )
+    )
+
+    torch.testing.assert_close(actual_num_tokens, golden_num_tokens, atol=0, rtol=0)
+    torch.testing.assert_close(actual_expert_ids, golden_expert_ids, atol=0, rtol=0)
+    torch.testing.assert_close(actual_sorted_ids, golden_sorted_ids, atol=0, rtol=0)
+    _assert_stable_local_expert_order(
+        topk_ids,
+        actual_sorted_ids,
+        actual_expert_ids,
+        actual_num_tokens,
+        block_size,
+        num_experts,
+        expert_map,
+    )
+
+
 @pytest.mark.parametrize("topk_dtype", [torch.int16, torch.int32, torch.int64])
 @pytest.mark.parametrize("expert_map_enabled", [False, True])
+@pytest.mark.parametrize(
+    ("m", "topk", "num_experts", "block_size"),
+    [
+        (65, 4, 8, 16),
+        (257, 4, 64, 32),
+        (513, 8, 160, 64),
+    ],
+)
 def test_moe_align_block_size_radix_preserves_token_order(
-    topk_dtype: torch.dtype, expert_map_enabled: bool
+    topk_dtype: torch.dtype,
+    expert_map_enabled: bool,
+    m: int,
+    topk: int,
+    num_experts: int,
+    block_size: int,
 ):
-    m, topk, num_experts, block_size = 257, 4, 64, 32
     topk_ids = torch.randint(0, num_experts, (m, topk), device="cuda", dtype=topk_dtype)
     expert_map = None
     if expert_map_enabled:

--- a/tests/kernels/moe/test_moe_align_block_size.py
+++ b/tests/kernels/moe/test_moe_align_block_size.py
@@ -8,9 +8,13 @@ Run `pytest tests/kernels/moe/test_moe_align_block_size.py`.
 import pytest
 import torch
 
+from vllm import _custom_ops as ops
 from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
+    MoEAlignRadixScratch,
     batched_moe_align_block_size,
     moe_align_block_size,
+    moe_align_block_size_radix,
+    moe_align_block_size_stable_small,
 )
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.torch_utils import set_random_seed
@@ -87,6 +91,73 @@ def _verify_expert_level_sorting(
             f"golden={golden_expert_tokens[expert_id]}, "
             f"actual={actual_expert_tokens[expert_id]}"
         )
+
+
+def _expected_tokens_by_local_expert(
+    topk_ids: torch.Tensor,
+    num_experts: int,
+    expert_map: torch.Tensor | None,
+) -> list[list[int]]:
+    flattened_expert_ids = topk_ids.flatten().cpu().tolist()
+    if expert_map is None:
+        mapped_expert_ids = flattened_expert_ids
+        num_local_experts = num_experts
+    else:
+        expert_map_list = expert_map.cpu().tolist()
+        mapped_expert_ids = [
+            expert_map_list[expert_id] for expert_id in flattened_expert_ids
+        ]
+        num_local_experts = max(expert_map_list) + 1
+
+    expected: list[list[int]] = [[] for _ in range(num_local_experts)]
+    for token_id, expert_id in enumerate(mapped_expert_ids):
+        if expert_id >= 0:
+            expected[expert_id].append(token_id)
+    return expected
+
+
+def _actual_tokens_by_local_expert(
+    sorted_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    block_size: int,
+    total_tokens: int,
+    num_tokens_post_pad: int,
+    num_local_experts: int,
+) -> list[list[int]]:
+    sorted_ids_list = sorted_ids.cpu().tolist()
+    expert_ids_list = expert_ids.cpu().tolist()
+    actual: list[list[int]] = [[] for _ in range(num_local_experts)]
+
+    for block_start in range(0, num_tokens_post_pad, block_size):
+        expert_id = expert_ids_list[block_start // block_size]
+        if expert_id < 0:
+            continue
+        block_tokens = sorted_ids_list[block_start : block_start + block_size]
+        actual[expert_id].extend(
+            token_id for token_id in block_tokens if token_id < total_tokens
+        )
+    return actual
+
+
+def _assert_stable_local_expert_order(
+    topk_ids: torch.Tensor,
+    sorted_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_pad: torch.Tensor,
+    block_size: int,
+    num_experts: int,
+    expert_map: torch.Tensor | None,
+) -> None:
+    expected = _expected_tokens_by_local_expert(topk_ids, num_experts, expert_map)
+    actual = _actual_tokens_by_local_expert(
+        sorted_ids,
+        expert_ids,
+        block_size,
+        topk_ids.numel(),
+        num_tokens_post_pad.item(),
+        len(expected),
+    )
+    assert actual == expected
 
 
 def torch_moe_align_block_size(
@@ -313,6 +384,258 @@ def test_moe_align_block_size_deterministic():
         )
         assert torch.equal(results[0][2], results[i][2]), (
             "num_tokens should be deterministic"
+        )
+
+
+@pytest.mark.parametrize("topk_dtype", [torch.int16, torch.int32, torch.int64])
+@pytest.mark.parametrize("expert_map_enabled", [False, True])
+def test_moe_align_block_size_stable_small_preserves_token_order(
+    topk_dtype: torch.dtype, expert_map_enabled: bool
+):
+    m, topk, num_experts, block_size = 64, 4, 32, 16
+    topk_ids = torch.randint(0, num_experts, (m, topk), device="cuda", dtype=topk_dtype)
+    expert_map = None
+    if expert_map_enabled:
+        expert_map = torch.full((num_experts,), -1, device="cuda", dtype=torch.int32)
+        local_experts = list(range(0, num_experts, 2))
+        for local_id, expert_id in enumerate(local_experts):
+            expert_map[expert_id] = local_id
+
+    actual_sorted_ids, actual_expert_ids, actual_num_tokens = (
+        moe_align_block_size_stable_small(
+            topk_ids=topk_ids,
+            block_size=block_size,
+            num_experts=num_experts,
+            expert_map=expert_map,
+        )
+    )
+    golden_sorted_ids, golden_expert_ids, golden_num_tokens = (
+        torch_moe_align_block_size(
+            topk_ids=topk_ids,
+            block_size=block_size,
+            num_experts=num_experts,
+            expert_map=expert_map,
+        )
+    )
+
+    torch.testing.assert_close(actual_num_tokens, golden_num_tokens, atol=0, rtol=0)
+    torch.testing.assert_close(actual_expert_ids, golden_expert_ids, atol=0, rtol=0)
+    torch.testing.assert_close(actual_sorted_ids, golden_sorted_ids, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("topk_dtype", [torch.int16, torch.int32, torch.int64])
+@pytest.mark.parametrize("expert_map_enabled", [False, True])
+def test_moe_align_block_size_radix_preserves_token_order(
+    topk_dtype: torch.dtype, expert_map_enabled: bool
+):
+    m, topk, num_experts, block_size = 257, 4, 64, 32
+    topk_ids = torch.randint(0, num_experts, (m, topk), device="cuda", dtype=topk_dtype)
+    expert_map = None
+    if expert_map_enabled:
+        expert_map = torch.full((num_experts,), -1, device="cuda", dtype=torch.int32)
+        local_experts = list(range(0, num_experts, 2))
+        for local_id, expert_id in enumerate(local_experts):
+            expert_map[expert_id] = local_id
+
+    scratch = MoEAlignRadixScratch(
+        max_num_tokens=m,
+        topk=topk,
+        num_experts=num_experts,
+        device=torch.device("cuda"),
+    )
+    actual_sorted_ids, actual_expert_ids, actual_num_tokens = (
+        moe_align_block_size_radix(
+            topk_ids=topk_ids,
+            block_size=block_size,
+            num_experts=num_experts,
+            scratch=scratch,
+            expert_map=expert_map,
+        )
+    )
+    golden_sorted_ids, golden_expert_ids, golden_num_tokens = (
+        torch_moe_align_block_size(
+            topk_ids=topk_ids,
+            block_size=block_size,
+            num_experts=num_experts,
+            expert_map=expert_map,
+        )
+    )
+
+    torch.testing.assert_close(actual_num_tokens, golden_num_tokens, atol=0, rtol=0)
+    torch.testing.assert_close(actual_expert_ids, golden_expert_ids, atol=0, rtol=0)
+    torch.testing.assert_close(actual_sorted_ids, golden_sorted_ids, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize(
+    ("m", "topk", "num_experts", "block_size", "use_radix"),
+    [
+        (64, 4, 256, 64, False),
+        (65, 4, 256, 64, True),
+        (128, 8, 256, 64, True),
+    ],
+)
+def test_moe_align_block_size_stable_paths_repeat_exact(
+    m: int, topk: int, num_experts: int, block_size: int, use_radix: bool
+):
+    torch.manual_seed(9)
+    topk_ids = torch.randint(
+        0, num_experts, (m, topk), device="cuda", dtype=torch.int32
+    )
+    scratch = None
+    if use_radix:
+        scratch = MoEAlignRadixScratch(
+            max_num_tokens=m,
+            topk=topk,
+            num_experts=num_experts,
+            device=torch.device("cuda"),
+        )
+
+    results = []
+    for _ in range(10):
+        if scratch is None:
+            result = moe_align_block_size_stable_small(
+                topk_ids=topk_ids,
+                block_size=block_size,
+                num_experts=num_experts,
+            )
+        else:
+            result = moe_align_block_size_radix(
+                topk_ids=topk_ids,
+                block_size=block_size,
+                num_experts=num_experts,
+                scratch=scratch,
+            )
+        results.append(tuple(tensor.clone() for tensor in result))
+
+    for actual in results[1:]:
+        for expected_tensor, actual_tensor in zip(results[0], actual):
+            torch.testing.assert_close(actual_tensor, expected_tensor, atol=0, rtol=0)
+
+    _assert_stable_local_expert_order(
+        topk_ids=topk_ids,
+        sorted_ids=results[0][0],
+        expert_ids=results[0][1],
+        num_tokens_post_pad=results[0][2],
+        block_size=block_size,
+        num_experts=num_experts,
+        expert_map=None,
+    )
+
+
+@pytest.mark.parametrize("use_radix", [False, True])
+def test_moe_align_block_size_stable_paths_arbitrary_expert_map(use_radix: bool):
+    m, topk, num_experts, block_size = (32, 4, 64, 16)
+    if use_radix:
+        m = 65
+    torch.manual_seed(3)
+    topk_ids = torch.randint(
+        0, num_experts, (m, topk), device="cuda", dtype=torch.int32
+    )
+    local_num_experts = num_experts // 2
+    local_expert_ids = torch.randperm(num_experts, device="cuda", dtype=torch.int32)[
+        :local_num_experts
+    ]
+    expert_map = torch.full((num_experts,), -1, device="cuda", dtype=torch.int32)
+    expert_map[local_expert_ids] = torch.arange(
+        local_num_experts, device="cuda", dtype=torch.int32
+    )
+
+    if use_radix:
+        scratch = MoEAlignRadixScratch(
+            max_num_tokens=m,
+            topk=topk,
+            num_experts=num_experts,
+            device=torch.device("cuda"),
+        )
+        sorted_ids, expert_ids, num_tokens_post_pad = moe_align_block_size_radix(
+            topk_ids=topk_ids,
+            block_size=block_size,
+            num_experts=num_experts,
+            scratch=scratch,
+            expert_map=expert_map,
+        )
+    else:
+        sorted_ids, expert_ids, num_tokens_post_pad = moe_align_block_size_stable_small(
+            topk_ids=topk_ids,
+            block_size=block_size,
+            num_experts=num_experts,
+            expert_map=expert_map,
+        )
+
+    _assert_stable_local_expert_order(
+        topk_ids=topk_ids,
+        sorted_ids=sorted_ids,
+        expert_ids=expert_ids,
+        num_tokens_post_pad=num_tokens_post_pad,
+        block_size=block_size,
+        num_experts=num_experts,
+        expert_map=expert_map,
+    )
+
+
+def test_moe_align_block_size_radix_cuda_graph_replay():
+    m, topk, num_experts, block_size = 128, 8, 256, 64
+    torch.manual_seed(13)
+    topk_ids = torch.randint(
+        0, num_experts, (m, topk), device="cuda", dtype=torch.int32
+    )
+    scratch = MoEAlignRadixScratch(
+        max_num_tokens=m,
+        topk=topk,
+        num_experts=num_experts,
+        device=torch.device("cuda"),
+    )
+    expected_sorted_ids, expected_expert_ids, expected_num_tokens = (
+        moe_align_block_size_radix(
+            topk_ids=topk_ids,
+            block_size=block_size,
+            num_experts=num_experts,
+            scratch=scratch,
+        )
+    )
+
+    sorted_ids = torch.empty_like(expected_sorted_ids)
+    expert_ids = torch.empty_like(expected_expert_ids)
+    num_tokens_post_pad = torch.empty_like(expected_num_tokens)
+    numel = topk_ids.numel()
+
+    def align_op() -> None:
+        ops.moe_align_block_size_radix(
+            topk_ids,
+            num_experts,
+            block_size,
+            sorted_ids,
+            expert_ids,
+            num_tokens_post_pad,
+            scratch.sort_workspace,
+            scratch.sorted_expert_ids[:numel],
+            scratch.compact_sorted_token_ids[:numel],
+            scratch.token_indices[:numel],
+            scratch.topk_ids_for_sort[:numel],
+            scratch.padded_expert_offsets,
+            scratch.unpadded_expert_offsets,
+            None,
+        )
+
+    align_op()
+    torch.accelerator.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    stream = torch.cuda.Stream()
+    with torch.cuda.graph(graph, stream=stream):
+        align_op()
+    torch.accelerator.synchronize()
+
+    for _ in range(3):
+        sorted_ids.fill_(-1)
+        expert_ids.fill_(-2)
+        num_tokens_post_pad.fill_(0)
+        graph.replay()
+        torch.accelerator.synchronize()
+        torch.testing.assert_close(sorted_ids, expected_sorted_ids, atol=0, rtol=0)
+        torch.testing.assert_close(expert_ids, expected_expert_ids, atol=0, rtol=0)
+        torch.testing.assert_close(
+            num_tokens_post_pad, expected_num_tokens, atol=0, rtol=0
         )
 
 

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2122,6 +2122,60 @@ def moe_align_block_size(
     )
 
 
+def moe_align_block_size_stable_small(
+    topk_ids: torch.Tensor,
+    num_experts: int,
+    block_size: int,
+    sorted_token_ids: torch.Tensor,
+    experts_ids: torch.Tensor,
+    num_tokens_post_pad: torch.Tensor,
+    expert_map: torch.Tensor | None = None,
+) -> None:
+    torch.ops._moe_C.moe_align_block_size_stable_small(
+        topk_ids,
+        num_experts,
+        block_size,
+        sorted_token_ids,
+        experts_ids,
+        num_tokens_post_pad,
+        expert_map,
+    )
+
+
+def moe_align_block_size_radix(
+    topk_ids: torch.Tensor,
+    num_experts: int,
+    block_size: int,
+    sorted_token_ids: torch.Tensor,
+    experts_ids: torch.Tensor,
+    num_tokens_post_pad: torch.Tensor,
+    sort_workspace: torch.Tensor,
+    sorted_expert_ids: torch.Tensor,
+    compact_sorted_token_ids: torch.Tensor,
+    token_indices: torch.Tensor,
+    topk_ids_for_sort: torch.Tensor,
+    padded_expert_offsets: torch.Tensor,
+    unpadded_expert_offsets: torch.Tensor,
+    expert_map: torch.Tensor | None = None,
+) -> None:
+    torch.ops._moe_C.moe_align_block_size_radix(
+        topk_ids,
+        num_experts,
+        block_size,
+        sorted_token_ids,
+        experts_ids,
+        num_tokens_post_pad,
+        sort_workspace,
+        sorted_expert_ids,
+        compact_sorted_token_ids,
+        token_indices,
+        topk_ids_for_sort,
+        padded_expert_offsets,
+        unpadded_expert_offsets,
+        expert_map,
+    )
+
+
 def batched_moe_align_block_size(
     max_tokens_per_batch: int,
     block_size: int,

--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -621,8 +621,6 @@ class MarlinExpertsBase(mk.FusedMoEExpertsModular):
         self.gemm1_beta = (
             quant_config.gemm1_beta if quant_config.gemm1_beta is not None else 0.0
         )
-        self._align_radix_scratch: MoEAlignRadixScratch | None = None
-
         super().__init__(
             moe_config=moe_config,
             quant_config=quant_config,
@@ -630,18 +628,18 @@ class MarlinExpertsBase(mk.FusedMoEExpertsModular):
             num_dispatchers=num_dispatchers,
         )
 
+        self._align_radix_scratch = MoEAlignRadixScratch(
+            max_num_tokens=self.moe_config.max_num_tokens,
+            topk=self.moe_config.experts_per_token,
+            num_experts=self.moe_config.num_experts,
+            device=torch.device(self.moe_config.device),
+        )
+
     def _get_align_radix_scratch(
         self, topk_ids: torch.Tensor
     ) -> MoEAlignRadixScratch | None:
         if topk_ids.numel() < RADIX_SORT_MIN_ROUTED_ENTRIES:
             return None
-        if self._align_radix_scratch is None:
-            self._align_radix_scratch = MoEAlignRadixScratch(
-                max_num_tokens=self.moe_config.max_num_tokens,
-                topk=self.moe_config.experts_per_token,
-                num_experts=self.moe_config.num_experts,
-                device=torch.device(self.moe_config.device),
-            )
         return self._align_radix_scratch
 
     @staticmethod

--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -22,8 +22,11 @@ from vllm.model_executor.layers.fused_moe.experts.lora_experts_mixin import (
     LoRAExpertsMixin,
 )
 from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
+    RADIX_SORT_MIN_ROUTED_ENTRIES,
+    MoEAlignRadixScratch,
     batched_moe_align_block_size,
-    moe_align_block_size,
+    moe_align_block_size_radix,
+    moe_align_block_size_stable_small,
 )
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceDelegate,
@@ -92,6 +95,7 @@ def _fused_marlin_moe(
     clamp_limit: float | None = None,
     gemm1_alpha: float = 1.0,
     gemm1_beta: float = 0.0,
+    align_radix_scratch: MoEAlignRadixScratch | None = None,
 ) -> torch.Tensor:
     assert hidden_states.ndim == 2
     M, K = hidden_states.size()
@@ -256,6 +260,7 @@ def fused_marlin_moe(
     clamp_limit: float | None = None,
     gemm1_alpha: float = 1.0,
     gemm1_beta: float = 0.0,
+    align_radix_scratch: MoEAlignRadixScratch | None = None,
 ) -> torch.Tensor:
     """
     This function computes a Mixture of Experts (MoE) layer using two sets of
@@ -328,13 +333,35 @@ def fused_marlin_moe(
     if input_dtype is not None and input_dtype.itemsize == 1:
         block_size_m = max(block_size_m, 16)
 
-    sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
-        topk_ids,
-        block_size_m,
-        global_num_experts,
-        expert_map,
-        ignore_invalid_experts=True,
-    )
+    if topk_ids.numel() >= RADIX_SORT_MIN_ROUTED_ENTRIES:
+        if align_radix_scratch is None:
+            # The functional API permits call-local output and GEMM workspaces.
+            # Production modular-kernel callers pass persistent scratch so
+            # serving and graph replay do not allocate here.
+            align_radix_scratch = MoEAlignRadixScratch(
+                max_num_tokens=topk_ids.size(0),
+                topk=topk,
+                num_experts=global_num_experts,
+                device=topk_ids.device,
+            )
+        sorted_token_ids, expert_ids, num_tokens_post_padded = (
+            moe_align_block_size_radix(
+                topk_ids,
+                block_size_m,
+                global_num_experts,
+                align_radix_scratch,
+                expert_map,
+            )
+        )
+    else:
+        sorted_token_ids, expert_ids, num_tokens_post_padded = (
+            moe_align_block_size_stable_small(
+                topk_ids,
+                block_size_m,
+                global_num_experts,
+                expert_map,
+            )
+        )
 
     assert activation is not None
     moe_output = _fused_marlin_moe(
@@ -594,6 +621,7 @@ class MarlinExpertsBase(mk.FusedMoEExpertsModular):
         self.gemm1_beta = (
             quant_config.gemm1_beta if quant_config.gemm1_beta is not None else 0.0
         )
+        self._align_radix_scratch: MoEAlignRadixScratch | None = None
 
         super().__init__(
             moe_config=moe_config,
@@ -601,6 +629,20 @@ class MarlinExpertsBase(mk.FusedMoEExpertsModular):
             max_num_tokens=max_num_tokens,
             num_dispatchers=num_dispatchers,
         )
+
+    def _get_align_radix_scratch(
+        self, topk_ids: torch.Tensor
+    ) -> MoEAlignRadixScratch | None:
+        if topk_ids.numel() < RADIX_SORT_MIN_ROUTED_ENTRIES:
+            return None
+        if self._align_radix_scratch is None:
+            self._align_radix_scratch = MoEAlignRadixScratch(
+                max_num_tokens=self.moe_config.max_num_tokens,
+                topk=self.moe_config.experts_per_token,
+                num_experts=self.moe_config.num_experts,
+                device=torch.device(self.moe_config.device),
+            )
+        return self._align_radix_scratch
 
     @staticmethod
     def _supports_current_device() -> bool:
@@ -805,6 +847,7 @@ class MarlinExperts(LoRAExpertsMixin, MarlinExpertsBase):
                 clamp_limit=self.gemm1_clamp_limit,
                 gemm1_alpha=self.gemm1_alpha,
                 gemm1_beta=self.gemm1_beta,
+                align_radix_scratch=self._get_align_radix_scratch(topk_ids),
             )
             return
 
@@ -919,6 +962,7 @@ class MarlinExperts(LoRAExpertsMixin, MarlinExpertsBase):
             clamp_limit=self.gemm1_clamp_limit,
             gemm1_alpha=self.gemm1_alpha,
             gemm1_beta=self.gemm1_beta,
+            align_radix_scratch=self._get_align_radix_scratch(topk_ids),
         )
 
     def moe_sum(self, input: torch.Tensor, output: torch.Tensor) -> None:

--- a/vllm/model_executor/layers/fused_moe/moe_align_block_size.py
+++ b/vllm/model_executor/layers/fused_moe/moe_align_block_size.py
@@ -155,6 +155,12 @@ def moe_align_block_size(
     Aligns the token distribution across experts to be compatible with block
     size for matrix multiplication.
 
+    This is the legacy compatibility entry point. It preserves the existing
+    expert-level grouping and padding behavior, but does not guarantee stable
+    within-expert token order. Callers that require deterministic within-expert
+    order should explicitly select `moe_align_block_size_stable_small` for at
+    most 256 routed entries or `moe_align_block_size_radix` for larger inputs.
+
     Note: In the case of expert_parallel, moe_align_block_size initially
     considers all experts as valid and aligns all tokens appropriately.
     Before the function returns it marks the experts_ids that are not in

--- a/vllm/model_executor/layers/fused_moe/moe_align_block_size.py
+++ b/vllm/model_executor/layers/fused_moe/moe_align_block_size.py
@@ -1,11 +1,146 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from dataclasses import dataclass, field
+
 import torch
 
 from vllm import _custom_ops as ops
 from vllm.triton_utils import triton
 from vllm.utils.math_utils import round_up
+
+# The stable one-block decode path is explicitly bounded to 256 routes.
+# Every larger input uses the near-linear radix path.
+RADIX_SORT_MIN_ROUTED_ENTRIES = 257
+
+
+@dataclass
+class MoEAlignRadixScratch:
+    max_num_tokens: int
+    topk: int
+    num_experts: int
+    device: torch.device
+    max_numel: int = field(init=False)
+    sort_workspace: torch.Tensor = field(init=False)
+    sorted_expert_ids: torch.Tensor = field(init=False)
+    compact_sorted_token_ids: torch.Tensor = field(init=False)
+    token_indices: torch.Tensor = field(init=False)
+    topk_ids_for_sort: torch.Tensor = field(init=False)
+    padded_expert_offsets: torch.Tensor = field(init=False)
+    unpadded_expert_offsets: torch.Tensor = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.max_numel = self.max_num_tokens * self.topk
+        self.sorted_expert_ids = torch.empty(
+            self.max_numel, dtype=torch.int32, device=self.device
+        )
+        self.compact_sorted_token_ids = torch.empty_like(self.sorted_expert_ids)
+        self.token_indices = torch.arange(
+            self.max_numel, dtype=torch.int32, device=self.device
+        )
+        self.topk_ids_for_sort = torch.empty_like(self.sorted_expert_ids)
+        self.padded_expert_offsets = torch.empty(
+            self.num_experts + 1, dtype=torch.int32, device=self.device
+        )
+        self.unpadded_expert_offsets = torch.empty(
+            self.num_experts + 1, dtype=torch.int64, device=self.device
+        )
+        workspace_size = torch.ops._moe_C.moe_permute_sort_workspace_size(
+            self.max_numel, self.num_experts
+        )
+        self.sort_workspace = torch.empty(
+            workspace_size, dtype=torch.int8, device=self.device
+        )
+
+    def validate(self, topk_ids: torch.Tensor, num_experts: int) -> None:
+        assert topk_ids.device == self.token_indices.device
+        assert topk_ids.size(1) == self.topk
+        assert topk_ids.numel() <= self.max_numel
+        assert num_experts == self.num_experts
+
+
+def _allocate_outputs(
+    topk_ids: torch.Tensor,
+    block_size: int,
+    num_experts: int,
+    pad_sorted_ids: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    max_num_tokens_padded = topk_ids.numel() + num_experts * (block_size - 1)
+    if pad_sorted_ids:
+        max_num_tokens_padded = round_up(max_num_tokens_padded, block_size)
+    if topk_ids.numel() < num_experts:
+        max_num_tokens_padded = min(
+            topk_ids.numel() * block_size, max_num_tokens_padded
+        )
+    sorted_ids = torch.empty(
+        (max_num_tokens_padded,), dtype=torch.int32, device=topk_ids.device
+    )
+    max_num_m_blocks = triton.cdiv(max_num_tokens_padded, block_size)
+    expert_ids = torch.empty(
+        (max_num_m_blocks,), dtype=torch.int32, device=topk_ids.device
+    )
+    num_tokens_post_pad = torch.empty((1), dtype=torch.int32, device=topk_ids.device)
+    return sorted_ids, expert_ids, num_tokens_post_pad
+
+
+def moe_align_block_size_stable_small(
+    topk_ids: torch.Tensor,
+    block_size: int,
+    num_experts: int,
+    expert_map: torch.Tensor | None = None,
+    pad_sorted_ids: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Deterministically align at most 256 flattened routed entries."""
+    if topk_ids.numel() >= RADIX_SORT_MIN_ROUTED_ENTRIES:
+        raise ValueError(
+            "small stable alignment supports at most "
+            f"{RADIX_SORT_MIN_ROUTED_ENTRIES - 1} routed entries"
+        )
+    sorted_ids, expert_ids, num_tokens_post_pad = _allocate_outputs(
+        topk_ids, block_size, num_experts, pad_sorted_ids
+    )
+    ops.moe_align_block_size_stable_small(
+        topk_ids,
+        num_experts,
+        block_size,
+        sorted_ids,
+        expert_ids,
+        num_tokens_post_pad,
+        expert_map,
+    )
+    return sorted_ids, expert_ids, num_tokens_post_pad
+
+
+def moe_align_block_size_radix(
+    topk_ids: torch.Tensor,
+    block_size: int,
+    num_experts: int,
+    scratch: MoEAlignRadixScratch,
+    expert_map: torch.Tensor | None = None,
+    pad_sorted_ids: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    scratch.validate(topk_ids, num_experts)
+    sorted_ids, expert_ids, num_tokens_post_pad = _allocate_outputs(
+        topk_ids, block_size, num_experts, pad_sorted_ids
+    )
+    numel = topk_ids.numel()
+    ops.moe_align_block_size_radix(
+        topk_ids,
+        num_experts,
+        block_size,
+        sorted_ids,
+        expert_ids,
+        num_tokens_post_pad,
+        scratch.sort_workspace,
+        scratch.sorted_expert_ids[:numel],
+        scratch.compact_sorted_token_ids[:numel],
+        scratch.token_indices[:numel],
+        scratch.topk_ids_for_sort[:numel],
+        scratch.padded_expert_offsets,
+        scratch.unpadded_expert_offsets,
+        expert_map,
+    )
+    return sorted_ids, expert_ids, num_tokens_post_pad
 
 
 def moe_align_block_size(
@@ -71,21 +206,9 @@ def moe_align_block_size(
     - The padding ensures that the total number of tokens is now divisible
         by block_size for proper block matrix operations.
     """
-    max_num_tokens_padded = topk_ids.numel() + num_experts * (block_size - 1)
-    if pad_sorted_ids:
-        max_num_tokens_padded = round_up(max_num_tokens_padded, block_size)
-    if topk_ids.numel() < num_experts:
-        max_num_tokens_padded = min(
-            topk_ids.numel() * block_size, max_num_tokens_padded
-        )
-    sorted_ids = torch.empty(
-        (max_num_tokens_padded,), dtype=torch.int32, device=topk_ids.device
+    sorted_ids, expert_ids, num_tokens_post_pad = _allocate_outputs(
+        topk_ids, block_size, num_experts, pad_sorted_ids
     )
-    max_num_m_blocks = triton.cdiv(max_num_tokens_padded, block_size)
-    expert_ids = torch.empty(
-        (max_num_m_blocks,), dtype=torch.int32, device=topk_ids.device
-    )
-    num_tokens_post_pad = torch.empty((1), dtype=torch.int32, device=topk_ids.device)
 
     ops.moe_align_block_size(
         topk_ids,


### PR DESCRIPTION
## Background

I noticed that Qwen 3.6 35B (NVFP4) would hit bizarre reasoning loops (as small-ish models can), but more interestingly I was able to capture those loops as part of an LLM-driven game eval I was experimenting with. This afforded me the ability to replay those prompts until I could recreate the reasoning loop consistently and try to isolate the cause. 

This investigation led to this fix. Happy to discuss further and even share the prompts/replay script, it just didn't seem relevant to include everything here. ~I can link to another repo/PR/gist with it if desired.~ I've [created a gist ](https://gist.github.com/sdougbrown/812070119782cd2543660d08279753fc) with some of the investigation for those interested. It's not necessary to review this PR. 

## Purpose

Make Marlin MoE token alignment deterministic by preserving flattened routed
token order within each expert.

Local review commits:

- `fb4e68a48` - Make Marlin MoE alignment deterministic
- `1e97ec2d1` - Add deterministic MoE align boundary tests
- `146372983` - Preallocate Marlin MoE align scratch
- `d8df2c3d4` - Apply MoE align lint fix
- `e16cef168` - Name radix key-prep grid cap

The existing `moe_align_block_size` path can assign tokens to each expert using
atomic slot allocation. CUDA block scheduling can therefore produce different
within-expert token order for identical `topk_ids`. That order is
mathematically equivalent for exact per-row computation, but the observed Marlin
WNA16/NvFp4 MoE path is numerically sensitive to this layout. Marlin consumes
the aligned route order directly in its grouped/tiled quantized kernels, so
different within-expert order can produce small routed-expert output deltas. In
repeated MoE generation those deltas can perturb logits and generated tokens.

This PR adds:

- a bounded one-block stable path for decode-sized inputs (`<=256` routed
  entries);
- a stable radix-sort path for larger inputs;
- reusable radix scratch storage for Marlin modular-kernel callers so graph
  replay does not allocate in the captured path;
- CUDA/Python bindings and focused tests for deterministic output, expert-map
  behavior, small/radix threshold behavior, larger radix shapes, and CUDA graph
  replay.

Duplicate-work check:

- Open PR search `moe align deterministic marlin`: no direct duplicate found.
- Open PR searches for `moe_align_block_size`, `Marlin MoE`, and
  `routed expert order` found related PRs, but no direct duplicate:
  - #46639 supports batch invariance for WNA16 Marlin MoE by changing Marlin
    GEMM reduction/tiling behavior under `VLLM_BATCH_INVARIANT=1`. This PR
    fixes deterministic route alignment order before Marlin consumes
    `sorted_token_ids`, including small/radix alignment and graph-safe scratch
    plumbing.
  - #44167 optimizes small-batch many-expert alignment. It does not address
    deterministic ordering for large routed-entry counts or Marlin output
    nondeterminism.
  - #47785 handles `-1`/padding safety in align-sum. It does not address
    deterministic ordering.
  - #40055 is a quantized MoE optimization in a different backend.

## Test Plan

*Correctness and graph compatibility*:
```
  python -m pytest -q tests/kernels/moe/test_moe_align_block_size.py
```

*Representative Marlin tests*:
```
  python -m pytest -q \
    'tests/kernels/moe/test_moe.py::test_fused_marlin_moe[a_type0-b_type0-c_type0--1-1-128-256-5-2-1-False-True]' \
    'tests/kernels/moe/test_moe.py::test_fused_marlin_moe[a_type2-b_type2-c_type2--1-133-256-256-5-2-1-False-True]'
```

*Pre-commit*:

```
  pre-commit run --files \
    benchmarks/kernels/benchmark_moe_align_block_size.py \
    csrc/libtorch_stable/moe/moe_align_sum_kernels.cu \
    csrc/libtorch_stable/moe/moe_ops.h \
    csrc/libtorch_stable/moe/torch_bindings.cpp \
    tests/kernels/moe/test_moe_align_block_size.py \
    vllm/_custom_ops.py \
    vllm/model_executor/layers/fused_moe/experts/marlin_moe.py \
    vllm/model_executor/layers/fused_moe/moe_align_block_size.py
```



*Microbenchmark*:

```bash
python - <<'PY'
from benchmarks.kernels.benchmark_moe_align_block_size import benchmark

for cfg in [(1, 256, 8, 1), (4096, 256, 8, 1)]:
    print("config", cfg)
    for provider in ["vllm", "deterministic"]:
        print(provider, benchmark.fn(*cfg, provider))
PY
```
Local note: I ran this from the vLLM checkout with a CUDA-enabled editable install and rebuilt native extensions.


Model evaluation / serving validation:

- Qwen3.6-35B-A3B-NVFP4, Marlin WNA16/NvFp4 MoE, patched vs prepatch
  Scorched replay of the historical repeated-reasoning request.
- Qwen3.6-35B-A3B-NVFP4, Marlin WNA16/NvFp4 MoE, prefill-heavy serving smoke
  with 15k+ prompt tokens and `max_tokens=1`, to exercise the radix path during
  prefill separately from long decode behavior.
- Gemma-4-26B-A4B-NVFP4, Marlin MoE, Scorched replay as a second Marlin MoE
  model.

Backend scope:

- The reproduced sensitivity was on the Marlin WNA16/NvFp4 MoE path. This PR
  should not be read as claiming that all NvFp4 or all W4A16 backends are
  generally nondeterministic.
- FlashInfer-CUTLASS NvFp4 paths call their own fused MoE implementation and do
  not consume vLLM's `moe_align_block_size` / `sorted_token_ids` plumbing, so
  those serving runs are compatibility checks rather than direct validation of
  this Marlin alignment fix.
- CUTLASS FP8 uses a separate `moe_permute`/CUB-sort path, and CUTLASS FP4 uses
  CUTLASS-specific MoE data preparation. Those paths are separate from the
  Marlin route-order failure mode addressed here.
- ROCm can use the generic shared `moe_align_block_size` op through
  ROCm-capable MoE paths, but the targeted Marlin WNA16 path is CUDA-only. The
  new large-input radix helper is also CUDA-only because it reuses the existing
  CUB sorter plumbing; only the Marlin alignment path calls it in this change.
  Existing ROCm shared-align behavior should therefore be unchanged.

## Test Result

Correctness:

```text
463 passed, 16 warnings in 111.34s
```

Representative Marlin call-site tests:

```text
test_fused_marlin_moe[a_type0-...m=1...]   1 passed
test_fused_marlin_moe[a_type2-...m=133...] 1 passed
```

Syntax / whitespace:

```text
pre-commit on changed files: passed
git diff --check: passed
```

Microbenchmark smoke, align op only:

```text
config (1, 256, 8, 1)
vllm          median 10.27 us
deterministic median  6.14 us

config (4096, 256, 8, 1)
vllm          median 26.72 us
deterministic median 59.39 us
```

The large-prefill radix path has measurable align-kernel overhead in this
microbenchmark. Decode-sized alignment did not regress in the sampled shape.

Model evaluation:

```text
Qwen3.6-35B-A3B-NVFP4 Marlin WNA16/NvFp4, same "Scorched" replay,
4,048-token cap:

patched deterministic align:
  10/10 tool-call finishes
  0/10 length/no-action failures
  avg completion 858.0 tokens
  avg latency 9.34 s
  avg completion throughput 91.0 tok/s

prepatch align:
  8/10 tool-call finishes
  2/10 length/no-action failures
  avg completion 2096.3 tokens
  avg latency 21.25 s
  avg completion throughput 95.0 tok/s
```

Gemma Marlin validation:

```text
Gemma-4-26B-A4B-NVFP4 Marlin, "Scorched" replay, 4,048-token cap,
thinking enabled:

  3/3 tool-call finishes
  0/3 length/no-action failures
  avg completion 1202.3 tokens
  avg latency 44.37 s
  max repeated-line count 4

  All three responses emitted two duplicate move calls:
  move({"direction": "W", "distance": 3})

This is protocol-valid but game-invalid/undesirable agent behaviour. It did not
reproduce the Qwen-style repeated-reasoning spiral or a length/no-action
failure.
```

Qwen Marlin radix-prefill serving test:

```text
Qwen3.6-35B-A3B-NVFP4 Marlin WNA16/NvFp4, unique long prompts,
thinking disabled, max_tokens=1:

  iteration 1: prompt_tokens 15583, completion "OK", finish_reason length
  iteration 2: prompt_tokens 15943, completion "OK", finish_reason length
  iteration 3: prompt_tokens 16123, completion "OK", finish_reason length

The one-token cap makes finish_reason=length expected. Prompt sizes are well
above the 257 routed-entry threshold, so this exercises radix during prefill.
```

Also tested with North Mini Code but at fp8 in Marlin with this patch. It worked, tool calls were a bit funny but I'd chalk that up to a model problem. 

#### Known local validation limitations:

- The CUDA correctness tests used the existing `~/vllm-env`
  editable vLLM environment because it has the built native extensions needed
  for these kernels. Lint/pre-commit was run through a repository-local
  `uv`-created `.venv`.


### AI assistance disclosure:
Codex was used to help investigate, implement, and test this change. The submitting human (👋) reviewed every changed line, validated the results, and is responsible for the final PR.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

