### PR TITLE
[Bugfix][Scheduler] Let pooling chunked prefill use full context

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -22,6 +22,7 @@ from vllm.multimodal.inputs import (
     MultiModalKwargsItem,
     PlaceholderRange,
 )
+from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.utils.hashing import sha256
 from vllm.v1.core.encoder_cache_manager import EncoderCacheManager
@@ -165,6 +166,55 @@ def test_schedule(enable_prefix_caching: bool, prompt_logprobs: int | None):
     assert len(scheduler.running) == len(requests)
     for i, request in enumerate(requests):
         assert scheduler.running[i] == request
+
+
+@pytest.mark.skip_global_cleanup
+def test_pooling_chunked_prefill_can_finish_at_max_model_len():
+    scheduler = create_scheduler(
+        max_num_seqs=1,
+        max_model_len=8,
+        max_num_batched_tokens=4,
+        runner_type="pooling",
+        device="cpu",
+    )
+    request = Request(
+        request_id="pool",
+        prompt_token_ids=[1] * 8,
+        sampling_params=None,
+        pooling_params=PoolingParams(task="embed"),
+    )
+    scheduler.add_request(request)
+
+    first_chunk = scheduler.schedule()
+    assert first_chunk.num_scheduled_tokens == {"pool": 4}
+    scheduler.update_from_output(
+        first_chunk,
+        ModelRunnerOutput(
+            req_ids=["pool"],
+            req_id_to_index={"pool": 0},
+            pooler_output=[None],
+        ),
+    )
+    assert request in scheduler.running
+    assert request.is_prefill_chunk
+
+    final_chunk = scheduler.schedule()
+    assert final_chunk.num_scheduled_tokens == {"pool": 4}
+    pooling_output = torch.ones(3)
+    engine_core_outputs = scheduler.update_from_output(
+        final_chunk,
+        ModelRunnerOutput(
+            req_ids=["pool"],
+            req_id_to_index={"pool": 0},
+            pooler_output=[pooling_output],
+        ),
+    )
+
+    output = engine_core_outputs[0].outputs[0]
+    assert output.finish_reason == FinishReason.STOP
+    assert torch.equal(output.pooling_output, pooling_output)
+    assert not scheduler.running
+    assert "pool" not in scheduler.requests
 
 
 def test_scheduler_stats_route_to_existing_output_client():

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -7,6 +7,7 @@ import vllm.envs as envs
 from tests.v1.kv_connector.unit.utils import MockKVConfig
 from vllm.config import (
     CacheConfig,
+    DeviceConfig,
     ECTransferConfig,
     KVTransferConfig,
     ModelConfig,
@@ -65,6 +66,8 @@ def create_scheduler(
     ec_role: str | None = None,
     use_v2_model_runner: bool | None = None,
     kv_cache_spec: KVCacheSpec | None = None,
+    runner_type: str | None = None,
+    device: str | None = None,
 ) -> Scheduler | AsyncScheduler:
     """Create scheduler under test.
 
@@ -86,6 +89,8 @@ def create_scheduler(
         seed=42,
         skip_tokenizer_init=skip_tokenizer_init,
     )
+    if runner_type is not None:
+        model_config.runner_type = runner_type
     if max_model_len is None:
         max_model_len = max_num_batched_tokens
     scheduler_config = SchedulerConfig(
@@ -154,6 +159,10 @@ def create_scheduler(
         else None
     )
 
+    vllm_config_kwargs = {}
+    if device is not None:
+        vllm_config_kwargs["device_config"] = DeviceConfig(device=device)
+
     vllm_config = VllmConfig(
         scheduler_config=scheduler_config,
         model_config=model_config,
@@ -165,6 +174,7 @@ def create_scheduler(
         kv_transfer_config=kv_transfer_config,
         speculative_config=speculative_config,
         ec_transfer_config=ec_transfer_config,
+        **vllm_config_kwargs,
     )
     if kv_cache_spec is None:
         kv_cache_spec = FullAttentionSpec(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -118,9 +118,15 @@ class Scheduler(SchedulerInterface):
             self.kv_events_config is not None
             and self.kv_events_config.enable_kv_cache_events
         )
-        # Diffusion models may not sample any tokens for a denoising step.
+        # Pooling and diffusion models do not append a sampled token after
+        # prefill, so they should not reserve one context slot while scheduling.
         self.num_sampled_tokens_per_step = (
-            1 if not vllm_config.model_config.is_diffusion else 0
+            0
+            if (
+                vllm_config.model_config.runner_type == "pooling"
+                or vllm_config.model_config.is_diffusion
+            )
+            else 1
         )
 
         # Create KVConnector for the Scheduler. Note that each Worker


### PR DESCRIPTION
## Summary

- Fix a V1 scheduler liveness bug for pooling requests with chunked prefill.
- Pooling runners emit an output from the final prefill hidden state and do not append a sampled token, but the scheduler reserved one context slot for every non-diffusion request.
- When a pooling prompt length equaled `max_model_len`, the first chunk could run, the next running-step schedule would stop one token early, and the request could no longer make progress.
- Reserve zero sampled-token slots for pooling runners so the final prefill chunk can reach `max_model_len` and emit the pooling output.

Fixes #47971, Fixes #24704, Fixes #55427

## Duplicate-work check

- `gh pr list --repo vllm-project/vllm --state open --search 'repo:vllm-project/vllm 47971 in:body'` returned no open PRs.
- `gh pr list --repo vllm-project/vllm --state open --search 'repo:vllm-project/vllm 24704 in:body'` returned no open PRs.
- A root-cause search for pooling + chunked prefill + max_model_len did not find an overlapping open scheduler fix.

## Tests

- [x] `.venv/bin/python -m pytest tests/v1/core/test_scheduler.py::test_pooling_chunked_prefill_can_finish_at_max_model_len -q`
- [x] `.venv/bin/pre-commit run --files vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py tests/v1/core/utils.py`
- [x] `.venv/bin/python -m pytest tests/test_config.py::test_is_chunked_prefill_supported -q` was attempted locally, but this macOS environment failed unrelated teardown with `Allocator for mps is not a DeviceAllocator`, and one model-inspection case also lacked `compressed_tensors`.

## Model evals

Not run. This is a scheduler liveness fix for pooling request progress and does not change model outputs when the request already finishes.

## Assistance

OpenAI Codex assistance was used to investigate the scheduler liveness issue, implement the fix, and add the regression test. The human submitter reviewed the changed lines and test results.
