### PR TITLE
[ROCm] Don't re-quantize bf16 MLA kv_b_proj to fp4/fp8 for GLM MoE DSA

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -517,13 +517,32 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         self.k_range = torch.tensor(envs.K_SCALE_CONSTANT, dtype=torch.float32)
         self.v_range = torch.tensor(envs.V_SCALE_CONSTANT, dtype=torch.float32)
 
-        self.is_aiter_triton_fp8_bmm_enabled = rocm_aiter_ops.is_fp8bmm_enabled()
+        # Some checkpoints (e.g. GLM MoE DSA / GlmMoeDsaForCausalLM) intentionally
+        # keep the MLA kv_b_proj weights in bf16 and only quantize the MoE experts
+        # to MXFP4. For those models the "kv_b_proj.weight is bf16" signal must NOT
+        # be treated as "unquantized, safe to fp4/fp8" -- re-quantizing a weight the
+        # checkpoint deliberately left in high precision injects large error into
+        # every attention layer and drives greedy decoding into repetition loops.
+        _archs = []
+        if _vllm_config is not None:
+            _mc = getattr(_vllm_config, "model_config", None)
+            _archs = list(
+                getattr(_mc, "architectures", None)
+                or getattr(getattr(_mc, "hf_config", None), "architectures", None)
+                or []
+            )
+        _bf16_mla_arch = any("GlmMoeDsa" in a for a in _archs)
+
+        self.is_aiter_triton_fp8_bmm_enabled = (
+            rocm_aiter_ops.is_fp8bmm_enabled() and not _bf16_mla_arch
+        )
 
         # If kv_b_proj_weight is unquantized, quantize it to mxfp4 if supported
         self.is_aiter_triton_fp4_bmm_enabled = (
             rocm_aiter_ops.is_fp4bmm_enabled()
             and hasattr(self.kv_b_proj, "weight")
             and self.kv_b_proj.weight.dtype == torch.bfloat16
+            and not _bf16_mla_arch
         )
 
         # Attributes for forward_impl method


### PR DESCRIPTION
## Purpose

On ROCm, the AITER MLA path assumes a bf16 `kv_b_proj` is unquantized and
quantizes it to fp4/fp8. This is wrong for `GlmMoeDsaForCausalLM` (e.g.
`amd/GLM-5.2-MXFP4`), where the MLA weights are intentionally bf16 and only the
MoE experts are MXFP4.

Quantizing these MLA weights to fp4 adds ~11% error per attention layer. It
accumulates across layers and pushes greedy decoding into repetition loops.

This PR skips fp4/fp8 MLA quantization for GLM MoE DSA (matching SGLang). The MoE
experts stay MXFP4, so the model remains int4.

## Test Plan

Serve `amd/GLM-5.2-MXFP4` on gfx950 with the AITER sparse MLA backend, greedy
(`temperature=0`), `reasoning_effort="high"`:

```bash
curl -s localhost:8990/v1/chat/completions -H 'Content-Type: application/json' -d '{
  "model": "amd/GLM-5.2-MXFP4",
  "messages": [{"role":"user","content":"What is the capital of France?"}],
  "max_tokens": 200, "temperature": 0.0, "reasoning_effort": "high"
}'
```

## Test Result
Before — repeats indefinitely:
```
... No, the user asked "What is the capital of France?" No, the user asked ...
```
After:
```
...</think>The capital of France is Paris.   (finish_reason: stop)
```
Confirmed MLA weights stay bf16 and MoE experts remain MXFP4.