### PR TITLE
[Bugfix][Hardware] DeepSeek-V4 o_proj fp8 einsum NaNs on SM12x: use SM90-style raw f32 block scales

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -1123,6 +1123,13 @@ def deepgemm_post_process_fp8_weight_block(
         r = wq.size(0) // g
         wq = wq.view(g, r, d)
         ws = ws.view(g, r // quant_block_shape[0], d // quant_block_shape[1])
+        # SM12x consumer Blackwell: DeepGEMM's fp8_einsum consumes raw
+        # row-major f32 block scales there (its own SM120 test convention)
+        # and produces NaNs on the SM100-style packed layout — skip the
+        # packing transform (cf. compute_fp8_einsum_recipe in
+        # models/deepseek_v4/nvidia/ops/o_proj.py).
+        if current_platform.is_device_capability_family(120):
+            return wq, ws.contiguous()
         dg_ws = deepgemm_post_process_weight_scale_block(
             ws=ws,
             mn=r,

--- a/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
+++ b/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
@@ -15,13 +15,17 @@ def compute_fp8_einsum_recipe() -> tuple[tuple[int, int, int], bool]:
 
     SM90: FP32 block scales stay [g, r/128, d/128] → sfb_gran_mn=128.
     SM100: INT32 packed scales become [g, r, ...] → sfb_gran_mn=1.
+    SM12x (consumer Blackwell): like SM90 — raw row-major FP32 block scales
+    with the (1, 128, 128) recipe, matching DeepGEMM's own SM120 einsum test
+    convention; the SM100 packed/TMA-aligned layout produces NaNs there.
 
     Returns ``(einsum_recipe, tma_aligned_scales)`` for ``deep_gemm_fp8_o_proj``.
     """
     cap = current_platform.get_device_capability()
     assert cap is not None, "DeepseekV4 attention requires a CUDA device"
-    einsum_recipe = (1, 128, 128) if cap.major <= 9 else (1, 1, 128)
-    tma_aligned_scales = cap.major >= 10
+    sm12x = current_platform.is_device_capability_family(120)
+    einsum_recipe = (1, 128, 128) if cap.major <= 9 or sm12x else (1, 1, 128)
+    tma_aligned_scales = cap.major >= 10 and not sm12x
     return einsum_recipe, tma_aligned_scales
 
 


### PR DESCRIPTION
On consumer Blackwell (SM120/SM121, e.g. RTX 5090 / RTX PRO 6000) the
DeepSeek-V4 o_proj fp8_einsum path selects the SM100 recipe: (1, 1, 128)
with TMA-aligned packed int32 scales. DeepGEMM's SM120 einsum consumes
raw row-major f32 block scales (its own SM120 test convention) and
produces NaNs on the packed layout, so DeepSeek-V4 emits garbage on
SM12x as released.

Select the SM90-style (1, 128, 128) recipe with raw f32 scales on
family 120, and skip the SM100 weight-scale pre-packing for the is_bmm
(einsum) weights accordingly.

Verified live on RTX PRO 6000 Blackwell (DeepSeek-V4-Flash, 512-token
greedy decode + 8k prefill, no NaNs; matches DeepGEMM nv-dev SM120
unit tests).


