### PR TITLE
[Core] Use capture_error_mode="thread_local" on all CUDA-graph capture paths

### DIFF
--- a/vllm/compilation/breakable_cudagraph.py
+++ b/vllm/compilation/breakable_cudagraph.py
@@ -175,10 +175,12 @@ class BreakableCUDAGraphCapture:
     def _begin_segment(self) -> None:
         assert not self._capturing
         g = torch.cuda.CUDAGraph()
+        # thread_local: match compilation/cuda_graph.py — helper threads'
+        # CUDA work must not invalidate this thread's capture.
         if self.pool is not None:
-            g.capture_begin(pool=self.pool)
+            g.capture_begin(pool=self.pool, capture_error_mode="thread_local")
         else:
-            g.capture_begin()
+            g.capture_begin(capture_error_mode="thread_local")
         self._current_graph = g
         self._capturing = True
 

--- a/vllm/compilation/cuda_graph.py
+++ b/vllm/compilation/cuda_graph.py
@@ -310,10 +310,14 @@ class CUDAGraphWrapper:
                 get_offloader().sync_prev_onload()
 
                 # mind-exploding: carefully manage the reference and memory.
+                # thread_local: CUDA work issued by helper threads (KV
+                # offloading daemons, out-of-tree plugins moving weights on
+                # side streams) must not invalidate this thread's capture.
                 with torch.cuda.graph(
                     cudagraph,
                     pool=self.graph_pool,
                     stream=current_stream(),
+                    capture_error_mode="thread_local",
                 ):
                     # `output` is managed by pytorch's cudagraph pool
                     output = self.runnable(*args, **kwargs)

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -356,7 +356,12 @@ class CudaGraphManager:
                         # Sync offloader's copy stream before capture.
                         # Ensure any pre-capture prefetches from offloader are complete.
                         get_offloader().sync_prev_onload()
-                        with torch.cuda.graph(graph, self.pool):
+                        # thread_local: match compilation/cuda_graph.py —
+                        # helper threads' CUDA work must not invalidate this
+                        # thread's capture.
+                        with torch.cuda.graph(
+                            graph, self.pool, capture_error_mode="thread_local"
+                        ):
                             forward_fn(CUDAGraphMode.NONE)
                             # Join offloader's copy stream after forward to avoid
                             # unjoined stream error. The last layer's start_prefetch

--- a/vllm/v1/worker/gpu_ubatch_wrapper.py
+++ b/vllm/v1/worker/gpu_ubatch_wrapper.py
@@ -284,10 +284,15 @@ class UBatchWrapper:
             # Ensure any pre-capture prefetches from offloader are complete.
             get_offloader().sync_prev_onload()
 
+            # thread_local: match compilation/cuda_graph.py — helper threads'
+            # CUDA work must not invalidate this thread's capture. (The ubatch
+            # threads' own kernels are still captured: stream-capture status
+            # follows the stream, not the issuing thread's error mode.)
             with torch.cuda.graph(
                 cudagraph_metadata.cudagraph,
                 stream=compute_stream,
                 pool=self.graph_pool,
+                capture_error_mode="thread_local",
             ):
                 ubatch_metadata[0].context.cpu_wait_event.set()
                 for thread in ubatch_threads:


### PR DESCRIPTION
vLLM captures CUDA graphs with the default capture_error_mode="global",
under which CUDA work issued by ANY host thread during capture
invalidates the capture (CUDA_ERROR_STREAM_CAPTURE_INVALIDATED) — even
when that work is on an unrelated side stream and never touches the
captured stream. This breaks legitimate background activity during the
capture phase: KV-offloading copy daemons, out-of-tree plugins that move
weights on side streams (async prefetchers / cache managers), NVML or
telemetry threads that touch the CUDA context.

PyTorch exposes capture_error_mode="thread_local" for exactly this
pattern (only the capturing thread's unsafe actions invalidate the
capture). Apply it consistently to all four capture paths:

- compilation/cuda_graph.py (CUDAGraphWrapper)
- compilation/breakable_cudagraph.py (segment capture_begin)
- v1/worker/gpu/cudagraph_utils.py (CudaGraphManager)
- v1/worker/gpu_ubatch_wrapper.py (UBatchWrapper)

The ubatch threads' kernels are still captured correctly: stream-capture
status follows the stream, not the issuing thread's error mode.

Validated on RTX PRO 6000 Blackwell serving DeepSeek-V4-Flash with
FULL_AND_PIECEWISE cudagraphs while a background thread performs
side-stream H2D copies: with "global" every capture is invalidated;
with "thread_local" capture and replay are stable (graph-exact outputs).


