### PR TITLE
[Bugfix] Fix int32 offset overflow in rejection sampler kernels

### DIFF
--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -800,6 +800,7 @@ def rejection_random_sample_kernel(
     )
     end_idx = tl.load(cu_num_draft_tokens_ptr + req_idx)
     num_draft_tokens = end_idx - start_idx
+    start_idx_i64 = start_idx.to(tl.int64)
 
     rejected = False
     for pos in range(num_draft_tokens):
@@ -818,11 +819,13 @@ def rejection_random_sample_kernel(
                 else:
                     draft_prob = tl.load(
                         draft_probs_ptr
-                        + (start_idx + pos) * vocab_size
+                        + (start_idx_i64 + pos) * vocab_size
                         + draft_token_id
                     )
                 target_prob = tl.load(
-                    target_probs_ptr + (start_idx + pos) * vocab_size + draft_token_id
+                    target_probs_ptr
+                    + (start_idx_i64 + pos) * vocab_size
+                    + draft_token_id
                 )
                 # NOTE(woosuk): While the draft probability should never be 0,
                 # we check it to avoid NaNs. If it happens to be 0, we reject.
@@ -897,6 +900,8 @@ def sample_recovered_tokens_kernel(
         return
 
     token_idx = start_idx + pos
+    token_idx_i64 = token_idx.to(tl.int64)
+    req_idx_i64 = req_idx.to(tl.int64)
 
     if NO_DRAFT_PROBS:
         draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
@@ -912,18 +917,18 @@ def sample_recovered_tokens_kernel(
 
         if NO_DRAFT_PROBS:
             prob = tl.load(
-                target_probs_ptr + token_idx * vocab_size + vocab_offset,
+                target_probs_ptr + token_idx_i64 * vocab_size + vocab_offset,
                 mask=(vocab_mask & (vocab_offset != draft_token_id)),
                 other=0.0,
             )
         else:
             draft_prob = tl.load(
-                draft_probs_ptr + token_idx * vocab_size + vocab_offset,
+                draft_probs_ptr + token_idx_i64 * vocab_size + vocab_offset,
                 mask=vocab_mask,
                 other=0.0,
             )
             target_prob = tl.load(
-                target_probs_ptr + token_idx * vocab_size + vocab_offset,
+                target_probs_ptr + token_idx_i64 * vocab_size + vocab_offset,
                 mask=vocab_mask,
                 other=0.0,
             )
@@ -932,7 +937,7 @@ def sample_recovered_tokens_kernel(
             # `tl.argmax` will select the maximum value.
 
         inv_q = tl.load(
-            inv_q_ptr + req_idx * vocab_size + vocab_offset,
+            inv_q_ptr + req_idx_i64 * vocab_size + vocab_offset,
             mask=vocab_mask,
             other=0.0,
         )


### PR DESCRIPTION
## Purpose

`rejection_random_sample_kernel` and `sample_recovered_tokens_kernel` index the `[num_tokens, vocab_size]` draft/target probability tensors with an int32 row-index multiply:

- `rejection_random_sample_kernel`: `(start_idx + pos) * vocab_size`
- `sample_recovered_tokens_kernel`: `token_idx * vocab_size` and `req_idx * vocab_size`

`start_idx`/`pos`/`token_idx`/`req_idx` are int32 (loaded from `cu_num_draft_tokens_ptr` or `tl.program_id`), so `int32 * int32 -> int32` wraps once the product exceeds `2**31`. At `vocab_size=250880` that's around row 8,559. Reachable via `max_num_seqs * (1 + num_speculative_tokens)` in a large speculative-decoding batch.

Past the threshold the offset is negative: an out-of-bounds read that either corrupts accept/reject decisions and recovered-token sampling, or crashes with an illegal memory access.

Fix: promote `start_idx`/`token_idx`/`req_idx` to `int64` before the `vocab_size` multiply in both kernels.

## Duplicate check

#46560 and #47383 fixed the same class of bug (int32 row-index * vocab_size overflow) in other sampler/rejection kernels: top-k/top-p, logit-bias, penalties, min-p, gumbel, bad-words, logprobs (#46560), and the block-verification rejection kernels used by `rejection_sample_method="block"` (#47383). Neither PR covered `rejection_random_sample_kernel` or `sample_recovered_tokens_kernel` in `vllm/v1/sample/rejection_sampler.py`.

## Test Plan / Test Result

The error was reproduced using `bigscience/bloom-560m` (vocab 250,880) with stock ngram speculative decoding (`num_speculative_tokens=80`) and a 600-request concurrent batch (`tensor_parallel_size=4`).

- Reproduced on 4x RTX 5090 (TP=4): total draft rows reached 8,592, past this model's overflow threshold of 8,559 (`8592 * 250880 = 2,155,560,960 > 2**31`).
- Crash surfaced at `rejection_sampler.py:267` as `CUDA error: an illegal memory access was encountered`.
- Same configuration completes without error after the patch.

## AI assistance disclosure

Developed with AI assistance (Claude Code) to reproduce the error. The test runs above were reviewed and executed by the submitter.
