### PR TITLE
Pin PyNvVideoCodec to tested 2.0.4 wheel

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -9,7 +9,7 @@ torchaudio==2.11.0
 # These must be updated alongside torch
 torchvision==0.26.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 torchcodec >= 0.14
-PyNvVideoCodec==2.1.0
+PyNvVideoCodec==2.0.4
 # FlashInfer should be updated together with the Dockerfile
 flashinfer-python==0.6.13
 flashinfer-cubin==0.6.13


### PR DESCRIPTION
## Purpose

Pin `PyNvVideoCodec` to `2.0.4` in CUDA requirements.

The CUDA dependency currently points at `PyNvVideoCodec==2.1.0`, which is blocking CI builds while the needed wheel availability catches up. `2.0.4` wheels are now published and we validated the vLLM PyNvVideoCodec video decode path with that version, so this adopts the tested wheel version to unblock CI while preserving the new video decode backend behavior.

Duplicate-work check: no open PR was found for a `PyNvVideoCodec 2.0.4` dependency pin. Related open PRs are broader GPU video / video backend work, not this CI dependency unblock.

AI assistance was used to prepare this change and summarize the validation.

cc @Harry-Chen 

## Test Plan

- Run pre-commit on the changed requirement file.
- Install vLLM from the target checkout with Python 3.12 and `pynvvideocodec==2.0.4`.
- Validate direct PyNvVideoCodec decode through vLLM’s video loader.
- Validate OpenAI-compatible server requests using `media_io_kwargs` with `video_backend: pynvvideocodec`.
- Stress the server with repeated video chat-completion requests.
- Exercise a mixed video corpus across supported codecs and containers.

## Test Result

```bash
.venv/bin/pre-commit run --files requirements/cuda.txt
```

Result: passed.
Runtime validation on a Linux x86_64 CUDA host with NVIDIA RTX PRO 6000 Blackwell, Python 3.12.13, torch 2.11.0+cu130, and pynvvideocodec package metadata version 2.0.4.
Direct decode validation:
14/14 supported videos decoded successfully through vLLM’s PyNvVideoCodec backend.
Covered MP4 H.264, MP4 H.265/HEVC, MP4 AV1, WebM VP8, and WebM VP9.
Covered resolutions including 640x360, 1280x545, 1280x720, and 1920x1080.
WebM clips emitted expected seek-accuracy warnings but decoded successfully.
Two AVI samples were excluded from server testing after PyNv rejected them during negative coverage.
Server validation:
Single-video load, processor cache disabled: 512/512 requests succeeded at concurrency 128; post-load /health OK; fatal log scan clean.
Mixed-video load, processor cache disabled: 448/448 requests succeeded at concurrency 112.
Each of 14 videos received 32/32 HTTP 200 responses.
Post-load /health OK; server remained alive; fatal/error log scan clean.
Model outputs were reasonable for the video contents, including highway driving, jellyfish, park scenes, and Sintel/animation clips.
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>


The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".

The test plan, such as providing test command.

The test results, such as pasting the results comparison before and after, or e2e results

(Optional) The necessary documentation update, such as updating supported_models.md and examples for a new model. Not needed; this is a dependency pin only.
</details>
