### PR TITLE
docs: mention accelerated load formats for ModelOpt

### DIFF
--- a/docs/features/quantization/modelopt.md
+++ b/docs/features/quantization/modelopt.md
@@ -102,6 +102,23 @@ vllm serve <path_to_exported_checkpoint> \
   --host 0.0.0.0 --port 8000
 ```
 
+For large safetensors checkpoints, such as Llama 4 FP8 ModelOpt exports, startup
+time can be dominated by weight loading. If the default safetensors loader is
+the bottleneck, try an accelerated load format:
+
+```bash
+vllm serve <path_to_exported_checkpoint> \
+  --quantization modelopt \
+  --load-format instanttensor
+```
+
+`--load-format fastsafetensors` is another option for environments where
+`fastsafetensors` is already installed and configured. See
+[Loading Model Weights with InstantTensor](../../models/extensions/instanttensor.md)
+and
+[Loading model weights with fastsafetensors](../../models/extensions/fastsafetensor.md)
+for installation requirements and backend-specific details.
+
 ## Testing (local checkpoints)
 
 vLLM's ModelOpt unit tests are gated by local checkpoint paths and are skipped


### PR DESCRIPTION
Summary
- Add a note to the ModelOpt quantization docs about using accelerated load formats for large safetensors checkpoints.
- Show `--load-format instanttensor` in the ModelOpt serving example context.
- Link to the existing InstantTensor and fastsafetensors extension pages for installation and backend details.

Why this helps
- Large ModelOpt FP8 checkpoints, such as Llama 4 exports, can spend substantial startup time loading weights.
- This documents practical existing options users can try while loader-side performance improvements are being developed.

Changes made
- Updated `docs/features/quantization/modelopt.md` with load-format guidance.

Testing
- `git diff --check`
- `test -f docs/models/extensions/instanttensor.md && test -f docs/models/extensions/fastsafetensor.md`
- `npx markdownlint-cli2 docs/features/quantization/modelopt.md`

Related issue
Refs #31624