### PR TITLE
[Kernel] Marlin MoE: allow overriding block_size_m via VLLM_MARLIN_MOE_BLOCK_SIZE_M

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -174,6 +174,7 @@ if TYPE_CHECKING:
     VLLM_RAY_EXTRA_ENV_VARS_TO_COPY: str = ""
     VLLM_MARLIN_USE_ATOMIC_ADD: bool = False
     VLLM_MARLIN_INPUT_DTYPE: Literal["int8", "fp8"] | None = None
+    VLLM_MARLIN_MOE_BLOCK_SIZE_M: int | None = None
     VLLM_HUMMING_ONLINE_QUANT_CONFIG: dict[str, Any] | None = None
     VLLM_HUMMING_INPUT_QUANT_CONFIG: dict[str, Any] | None = None
     VLLM_HUMMING_USE_F16_ACCUM: bool = False
@@ -1422,6 +1423,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Whether to use atomicAdd reduce in gptq/awq marlin kernel.
     "VLLM_MARLIN_USE_ATOMIC_ADD": lambda: (
         os.environ.get("VLLM_MARLIN_USE_ATOMIC_ADD", "0") == "1"
+    ),
+    # Override the auto-selected M-tile (block_size_m) for the Marlin MoE
+    # kernel. None = use the heuristic. See fused_marlin_moe and
+    # https://github.com/vllm-project/vllm/issues/48066.
+    "VLLM_MARLIN_MOE_BLOCK_SIZE_M": lambda: (
+        int(os.environ["VLLM_MARLIN_MOE_BLOCK_SIZE_M"])
+        if "VLLM_MARLIN_MOE_BLOCK_SIZE_M" in os.environ
+        else None
     ),
     # The activation dtype for marlin kernel
     "VLLM_MARLIN_INPUT_DTYPE": env_with_choices(

--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -9,6 +9,7 @@ import torch
 
 import vllm._custom_ops as ops
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm import envs
 from vllm.model_executor.layers.fused_moe.activation import (
     MoEActivation,
     apply_moe_activation,
@@ -327,6 +328,14 @@ def fused_marlin_moe(
 
     if input_dtype is not None and input_dtype.itemsize == 1:
         block_size_m = max(block_size_m, 16)
+
+    # Opt-in override for the auto-selected M-tile. The heuristic above is a
+    # coarse function of tokens-per-expert; this lets a deployment pin a
+    # measured-optimal block_size_m per shape/GPU while a fully hardware-aware
+    # default is worked out. See
+    # https://github.com/vllm-project/vllm/issues/48066.
+    if envs.VLLM_MARLIN_MOE_BLOCK_SIZE_M is not None:
+        block_size_m = envs.VLLM_MARLIN_MOE_BLOCK_SIZE_M
 
     sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
         topk_ids,


### PR DESCRIPTION
## Purpose

The Marlin MoE M-tile heuristic in `fused_marlin_moe` picks `block_size_m` from `M * topk / E`
(`E = w1.size(0)` = **local** experts). Under expert parallelism `E` shrinks (gpt-oss-120b @ EP=8 →
`E=16`), so the heuristic saturates at `block_size_m = 64`, a low-occupancy variant (255 regs/thread,
112 KB smem on Hopper). For decode this is slower than a smaller tile — forcing 16/32/48 recovers
**9–30 % of decode TPOT** on gpt-oss-120b DP8. The selection loop is already marked
`# TODO: tune this further for specific models`.

This PR adds an **opt-in override**, `VLLM_MARLIN_MOE_BLOCK_SIZE_M`, applied after the existing
heuristic. **Default behavior is unchanged** (env unset → identical code path). It unblocks EP/decode
tuning today and lets us collect cross-shape data toward a principled, hardware-aware default.

Related to #48066 (full analysis + proposed autotuned-config follow-up there).

## Changes

- `vllm/model_executor/layers/fused_moe/experts/marlin_moe.py`: apply
  `envs.VLLM_MARLIN_MOE_BLOCK_SIZE_M` after the heuristic (only when set).
- `vllm/envs.py`: register `VLLM_MARLIN_MOE_BLOCK_SIZE_M: int | None = None` (next to the other
  `VLLM_MARLIN_*` vars).

```python
    if input_dtype is not None and input_dtype.itemsize == 1:
        block_size_m = max(block_size_m, 16)

    # Opt-in override ... (see #48066)
    if envs.VLLM_MARLIN_MOE_BLOCK_SIZE_M is not None:
        block_size_m = envs.VLLM_MARLIN_MOE_BLOCK_SIZE_M
```

## Benchmark

gpt-oss-120b (MXFP4, MARLIN), 8×H200, `vllm serve --data-parallel-size 8 --enable-expert-parallel`,
`vllm bench serve --dataset-name random --random-input-len 128 --random-output-len 128`.
Mean **TPOT (ms/token, lower is better)**; `block_size_m` forced via this env:

| max-concurrency | heuristic (block 64) | best forced block | improvement |
|---|---|---|---|
| 128 | 14.4 | 11.7 (block 16) | **−19 %** |
| 256 | 16.3 | 13.9 (block 32) | **−15 %** |
| 512 | 20.8 | 19.1 (block 48) | **−8 %** |

### Per-`block_size_m` latency (with EP-off baseline)

Gray bar (left of the dotted separator) = EP-off baseline; 
colored bars = EP-on forced to block 16/32/48/64. 
Block 64 is the one the current heuristic selects (marked "heur" in the figure). A smaller tile wins until per-expert token counts grow.

**gpt-oss-120b (E_local = 16):**
<img width="2760" height="738" alt="fig_absolute_120b" src="https://github.com/user-attachments/assets/4a912ec0-34cb-4a27-991d-600803a4f653" />

**gpt-oss-20b (E_local = 4 - heuristic pins 64 at every batch, penalty largest):**
<img width="2760" height="738" alt="fig_absolute_20b" src="https://github.com/user-attachments/assets/2676d583-f894-4b98-9821-10784aaf1dfa" />


Kernel-level (nsys): the effect is entirely the Marlin MoE GEMM tile — same call count and same useful
FLOPs/device, but the 64-tile runs at 255 regs / 112 KB smem (low occupancy) vs 145 regs / 76 KB for a
16-tile. (`block_size_m` tracks the local-expert count: E = 128/64/32/16 → block = 8/16/32/64.)

## Test plan

- `VLLM_MARLIN_MOE_BLOCK_SIZE_M` unset → byte-identical to current selection (default path).
- Set to `16/32/48/64` → forwarded to `moe_wna16_marlin_gemm` (`moe_block_size`), verified via the
  kernel template `thread_m_blocks = block_size_m / 16`. Output numerically unchanged (same kernel,
  different tile); only latency differs.
- `ruff check` / `ruff format` clean on both files.

## Risk / scope

- **No default behavior change** — override is opt-in (`None`).
- Evidence is gpt-oss-120b MXFP4 on H200, decode-focused. The *right default* is shape/GPU dependent
  (optimal tile grows with tokens-per-expert), so retuning the heuristic is deliberately a follow-up
  (see #48066 for a proposed device-keyed autotuned-config path, mirroring the Triton MoE mechanism).
- Out of scope: the communication component of the EP slowdown (all-gather/reduce-scatter dispatch),
  which is structural and unrelated to this heuristic.
