### PR TITLE
feat: first-class session_id for conversation-aware routing

### DIFF
--- a/tests/entrypoints/openai/test_session_id.py
+++ b/tests/entrypoints/openai/test_session_id.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+from starlette.requests import Request
+
+from vllm.entrypoints.generate.base.serving import GenerateBaseServing
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.completion.protocol import CompletionRequest
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+
+def _raw_request(headers: dict[str, str]) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/chat/completions",
+            "headers": [
+                (key.lower().encode("latin-1"), value.encode("latin-1"))
+                for key, value in headers.items()
+            ],
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "openai_request",
+    [
+        ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+        ),
+        CompletionRequest(model="test-model", prompt="hi"),
+        ResponsesRequest(model="test-model", input="hi"),
+    ],
+)
+def test_get_session_id_accepts_body_field(openai_request):
+    openai_request.session_id = "body-session"
+
+    session_id = GenerateBaseServing._get_session_id(
+        openai_request,
+        _raw_request({"X-Session-ID": "header-session"}),
+    )
+
+    assert session_id == "body-session"
+
+
+def test_get_session_id_accepts_session_header():
+    request = CompletionRequest(model="test-model", prompt="hi")
+
+    session_id = GenerateBaseServing._get_session_id(
+        request,
+        _raw_request({"X-Session-ID": "header-session"}),
+    )
+
+    assert session_id == "header-session"
+
+
+def test_get_session_id_ignores_correlation_header():
+    request = CompletionRequest(
+        model="test-model",
+        prompt="hi",
+        vllm_xargs={"session_id": "xargs-session"},
+    )
+
+    session_id = GenerateBaseServing._get_session_id(
+        request,
+        _raw_request({"X-Correlation-ID": "correlation-session"}),
+    )
+
+    assert session_id == "xargs-session"
+
+
+def test_get_session_id_keeps_vllm_xargs_as_compatibility_fallback():
+    request = CompletionRequest(
+        model="test-model",
+        prompt="hi",
+        vllm_xargs={"session_id": "xargs-session"},
+    )
+
+    session_id = GenerateBaseServing._get_session_id(request, None)
+
+    assert session_id == "xargs-session"
+
+
+def test_get_session_id_ignores_empty_and_non_string_values():
+    request = CompletionRequest(
+        model="test-model",
+        prompt="hi",
+        session_id="",
+        vllm_xargs={"session_id": 7},
+    )
+
+    session_id = GenerateBaseServing._get_session_id(request, None)
+
+    assert session_id is None
+
+
+def test_get_session_id_returns_none_when_nothing_set():
+    request = CompletionRequest(model="test-model", prompt="hi")
+
+    session_id = GenerateBaseServing._get_session_id(request, None)
+
+    assert session_id is None

--- a/tests/v1/engine/test_parallel_sampling_session_id.py
+++ b/tests/v1/engine/test_parallel_sampling_session_id.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from copy import copy
+
+from vllm import SamplingParams
+from vllm.v1.engine import EngineCoreRequest
+from vllm.v1.engine.parallel_sampling import ParentRequest
+
+
+def make_request(sampling_params: SamplingParams) -> EngineCoreRequest:
+    return EngineCoreRequest(
+        request_id="parent_id",
+        prompt_token_ids=[1, 2, 3],
+        mm_features=None,
+        sampling_params=sampling_params,
+        pooling_params=None,
+        arrival_time=0.0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+        external_req_id="external_id",
+    )
+
+
+def test_parallel_sampling_child_requests_preserve_session_id() -> None:
+    request = make_request(SamplingParams(n=2))
+    request.session_id = "session-1"
+    parent_request = ParentRequest(request)
+
+    for idx in range(parent_request.n):
+        request_id, child_params = parent_request.get_child_info(idx)
+        child_request = request if idx == parent_request.n - 1 else copy(request)
+        child_request.request_id = request_id
+        child_request.sampling_params = child_params
+
+        assert child_request.session_id == "session-1"
+
+
+def test_parallel_sampling_child_requests_default_session_id_none() -> None:
+    request = make_request(SamplingParams(n=2))
+    parent_request = ParentRequest(request)
+
+    for idx in range(parent_request.n):
+        request_id, child_params = parent_request.get_child_info(idx)
+        child_request = request if idx == parent_request.n - 1 else copy(request)
+        child_request.request_id = request_id
+        child_request.sampling_params = child_params
+
+        assert child_request.session_id is None

--- a/tests/v1/test_request_session_id.py
+++ b/tests/v1/test_request_session_id.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm import SamplingParams
+from vllm.v1.engine import EngineCoreRequest
+from vllm.v1.request import Request
+
+
+def test_request_copies_session_id_from_engine_core_request():
+    engine_request = EngineCoreRequest(
+        request_id="request-1",
+        prompt_token_ids=[1, 2, 3],
+        mm_features=None,
+        sampling_params=SamplingParams(max_tokens=1),
+        pooling_params=None,
+        arrival_time=0.0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+        session_id="session-1",
+    )
+
+    request = Request.from_engine_core_request(engine_request, block_hasher=None)
+
+    assert request.session_id == "session-1"
+
+
+def test_request_session_id_defaults_to_none():
+    engine_request = EngineCoreRequest(
+        request_id="request-1",
+        prompt_token_ids=[1, 2, 3],
+        mm_features=None,
+        sampling_params=SamplingParams(max_tokens=1),
+        pooling_params=None,
+        arrival_time=0.0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+    )
+
+    request = Request.from_engine_core_request(engine_request, block_hasher=None)
+
+    assert request.session_id is None

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -77,6 +77,7 @@ class EngineClient(ABC):
         trace_headers: Mapping[str, str] | None = None,
         priority: int = 0,
         data_parallel_rank: int | None = None,
+        session_id: str | None = None,
         reasoning_ended: bool | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
     ) -> AsyncGenerator[RequestOutput, None]:

--- a/vllm/entrypoints/generate/base/serving.py
+++ b/vllm/entrypoints/generate/base/serving.py
@@ -41,6 +41,7 @@ logger = init_logger(__name__)
 
 RequestT = TypeVar("RequestT", bound=AnyRequest)
 _T = TypeVar("_T")
+SESSION_ID_HEADER = "X-Session-ID"
 
 
 def build_per_request_timing_metrics(
@@ -214,6 +215,30 @@ class GenerateBaseServing(BaseServing, BeamSearchOnlineMixin):
             return int(rank_str)
         except ValueError:
             return None
+
+    @staticmethod
+    def _get_session_id(
+        request: ChatCompletionRequest | CompletionRequest | ResponsesRequest,
+        raw_request: Request | None,
+    ) -> str | None:
+        """Resolve the effective session_id.
+
+        Precedence:
+            1. Body-level ``session_id``
+            2. ``X-Session-ID`` HTTP header
+            3. ``vllm_xargs["session_id"]`` (temporary compatibility)
+        """
+        if request.session_id:
+            return request.session_id
+        if raw_request is not None and (
+            value := raw_request.headers.get(SESSION_ID_HEADER)
+        ):
+            return value
+        if request.vllm_xargs:
+            session_id = request.vllm_xargs.get("session_id")
+            if isinstance(session_id, str) and session_id:
+                return session_id
+        return None
 
     async def _with_kv_transfer_rejection_cleanup(
         self,

--- a/vllm/entrypoints/generate/beam_search/online.py
+++ b/vllm/entrypoints/generate/beam_search/online.py
@@ -32,6 +32,7 @@ class BeamSearchOnlineMixin(ABC):
         params: BeamSearchParams,
         lora_request: LoRARequest | None = None,
         trace_headers: Mapping[str, str] | None = None,
+        session_id: str | None = None,
     ) -> AsyncGenerator[RequestOutput, None]:
         beam_width = params.beam_width
         max_tokens = params.max_tokens
@@ -90,6 +91,7 @@ class BeamSearchOnlineMixin(ABC):
                             request_id_item,
                             lora_request=lora_request_item,
                             trace_headers=trace_headers,
+                            session_id=session_id,
                         )
                     )
                 )

--- a/vllm/entrypoints/openai/chat_completion/batch_serving.py
+++ b/vllm/entrypoints/openai/chat_completion/batch_serving.py
@@ -174,6 +174,7 @@ class OpenAIServingChatBatch(OpenAIServingChat):
                 if raw_request is None
                 else await self._get_trace_headers(raw_request.headers)
             )
+            session_id = self._get_session_id(single_request, raw_request)
             generators.append(
                 self.engine_client.generate(
                     engine_prompt,
@@ -183,6 +184,7 @@ class OpenAIServingChatBatch(OpenAIServingChat):
                     trace_headers=trace_headers,
                     priority=request.priority,
                     data_parallel_rank=data_parallel_rank,
+                    session_id=session_id,
                     reasoning_ended=None,
                 )
             )

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -366,6 +366,14 @@ class ChatCompletionRequest(OpenAIBaseModel):
             "through out the inference process and return in response."
         ),
     )
+    session_id: str | None = Field(
+        default=None,
+        description=(
+            "Stable session identity shared by related requests. Unlike "
+            "request_id, this value is expected to remain stable across "
+            "multiple requests in the same conversation or agent session."
+        ),
+    )
 
     return_tokens_as_token_ids: bool | None = Field(
         default=None,

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -332,6 +332,7 @@ class OpenAIServingChat(GenerateBaseServing):
                 if raw_request is None
                 else await self._get_trace_headers(raw_request.headers)
             )
+            session_id = self._get_session_id(request, raw_request)
 
             if isinstance(sampling_params, BeamSearchParams):
                 generator = self.beam_search(
@@ -340,6 +341,7 @@ class OpenAIServingChat(GenerateBaseServing):
                     params=sampling_params,
                     lora_request=lora_request,
                     trace_headers=trace_headers,
+                    session_id=session_id,
                 )
             else:
                 if not request.include_reasoning:
@@ -362,6 +364,7 @@ class OpenAIServingChat(GenerateBaseServing):
                     trace_headers=trace_headers,
                     priority=request.priority,
                     data_parallel_rank=data_parallel_rank,
+                    session_id=session_id,
                     reasoning_ended=reasoning_ended,
                     reasoning_parser_kwargs={
                         "chat_template_kwargs": chat_template_kwargs,

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -137,6 +137,14 @@ class CompletionRequest(OpenAIBaseModel):
             "through out the inference process and return in response."
         ),
     )
+    session_id: str | None = Field(
+        default=None,
+        description=(
+            "Stable session identity shared by related requests. Unlike "
+            "request_id, this value is expected to remain stable across "
+            "multiple requests in the same conversation or agent session."
+        ),
+    )
 
     return_tokens_as_token_ids: bool | None = Field(
         default=None,

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -194,6 +194,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
                 if raw_request is None
                 else await self._get_trace_headers(raw_request.headers)
             )
+            session_id = self._get_session_id(request, raw_request)
 
             if isinstance(sampling_params, BeamSearchParams):
                 generator = self.beam_search(
@@ -202,6 +203,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
                     params=sampling_params,
                     lora_request=lora_request,
                     trace_headers=trace_headers,
+                    session_id=session_id,
                 )
             else:
                 generator = self.engine_client.generate(
@@ -212,6 +214,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
                     trace_headers=trace_headers,
                     priority=request.priority,
                     data_parallel_rank=data_parallel_rank,
+                    session_id=session_id,
                 )
 
             generators.append(generator)

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -211,6 +211,14 @@ class ResponsesRequest(OpenAIBaseModel):
             "through out the inference process and return in response."
         ),
     )
+    session_id: str | None = Field(
+        default=None,
+        description=(
+            "Stable session identity shared by related requests. Unlike "
+            "request_id, this value is expected to remain stable across "
+            "multiple requests in the same conversation or agent session."
+        ),
+    )
     media_io_kwargs: dict[str, dict[str, Any]] | None = Field(
         default=None,
         description=(

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -451,6 +451,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 if raw_request is None
                 else await self._get_trace_headers(raw_request.headers)
             )
+            session_id = self._get_session_id(request, raw_request)
 
             chat_template_kwargs = self._effective_chat_template_kwargs(request)
             response_parser = self._make_response_parser(
@@ -516,6 +517,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 lora_request=lora_request,
                 priority=request.priority,
                 trace_headers=trace_headers,
+                session_id=session_id,
                 reasoning_parser_kwargs=reasoning_parser_kwargs
                 if self.parser and self.parser.reasoning_parser_cls is not None
                 else None,
@@ -663,6 +665,7 @@ class OpenAIServingResponses(GenerateBaseServing):
         lora_request: LoRARequest | None = None,
         priority: int = 0,
         trace_headers: Mapping[str, str] | None = None,
+        session_id: str | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
     ):
         max_model_len = self.model_config.max_model_len
@@ -687,6 +690,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 lora_request=lora_request,
                 trace_headers=trace_headers,
                 priority=priority,
+                session_id=session_id,
                 reasoning_parser_kwargs=reasoning_parser_kwargs,
             )
 

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -120,6 +120,7 @@ class EngineCoreRequest(
 
     trace_headers: Mapping[str, str] | None = None
     resumable: bool = False
+    session_id: str | None = None
 
     # The user-provided request ID. This field is set internally,
     # copied from the provided request_id that's originally assigned

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -291,6 +291,7 @@ class AsyncLLM(EngineClient):
         trace_headers: Mapping[str, str] | None = None,
         priority: int = 0,
         data_parallel_rank: int | None = None,
+        session_id: str | None = None,
         prompt_text: str | None = None,
         reasoning_ended: bool | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
@@ -328,6 +329,7 @@ class AsyncLLM(EngineClient):
                 trace_headers,
                 priority,
                 data_parallel_rank,
+                session_id,
             )
 
         # Convert Input --> Request.
@@ -357,6 +359,7 @@ class AsyncLLM(EngineClient):
                 trace_headers=trace_headers,
                 priority=priority,
                 data_parallel_rank=data_parallel_rank,
+                session_id=session_id,
             )
             prompt_text, _, _ = extract_prompt_components(self.model_config, prompt)
 
@@ -425,6 +428,7 @@ class AsyncLLM(EngineClient):
         trace_headers: Mapping[str, str] | None = None,
         priority: int = 0,
         data_parallel_rank: int | None = None,
+        session_id: str | None = None,
     ) -> RequestOutputCollector:
         self._validate_streaming_input_sampling_params(sampling_params)
 
@@ -436,6 +440,7 @@ class AsyncLLM(EngineClient):
             trace_headers=trace_headers,
             priority=priority,
             data_parallel_rank=data_parallel_rank,
+            session_id=session_id,
         )
 
         if not sampling_params.skip_clone:
@@ -536,6 +541,7 @@ class AsyncLLM(EngineClient):
         trace_headers: Mapping[str, str] | None = None,
         priority: int = 0,
         data_parallel_rank: int | None = None,
+        session_id: str | None = None,
         reasoning_ended: bool | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
     ) -> AsyncGenerator[RequestOutput, None]:
@@ -565,6 +571,7 @@ class AsyncLLM(EngineClient):
                 trace_headers=trace_headers,
                 priority=priority,
                 data_parallel_rank=data_parallel_rank,
+                session_id=session_id,
                 prompt_text=prompt_text,
                 reasoning_ended=reasoning_ended,
                 reasoning_parser_kwargs=reasoning_parser_kwargs,

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -252,6 +252,7 @@ class InputProcessor:
         priority: int = 0,
         data_parallel_rank: int | None = None,
         resumable: bool = False,
+        session_id: str | None = None,
     ) -> EngineCoreRequest:
         self._validate_params(params, supported_tasks)
         self._validate_lora(lora_request)
@@ -382,6 +383,7 @@ class InputProcessor:
             data_parallel_rank=data_parallel_rank,
             trace_headers=trace_headers,
             resumable=resumable,
+            session_id=session_id,
         )
 
     def _validate_prompt_len(

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -225,6 +225,7 @@ class LLMEngine:
         tokenization_kwargs: dict[str, Any] | None = None,
         trace_headers: Mapping[str, str] | None = None,
         priority: int = 0,
+        session_id: str | None = None,
         prompt_text: str | None = None,
     ) -> str:
         # Validate the request_id type.
@@ -257,6 +258,7 @@ class LLMEngine:
                 tokenization_kwargs=tokenization_kwargs,
                 trace_headers=trace_headers,
                 priority=priority,
+                session_id=session_id,
             )
             prompt_text, _, _ = extract_prompt_components(self.model_config, prompt)
 

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -74,6 +74,7 @@ class Request:
         trace_headers: Mapping[str, str] | None = None,
         block_hasher: Callable[["Request"], list["BlockHash"]] | None = None,
         resumable: bool = False,
+        session_id: str | None = None,
         reasoning_ended: bool | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
         abort_immediately: bool = False,
@@ -168,6 +169,8 @@ class Request:
         self.all_token_ids = ConstantList(self._all_token_ids)
         # trace_headers
         self.trace_headers = trace_headers
+        # session_id
+        self.session_id = session_id
 
         # True if this request is scheduled as a non-final prefill chunk.
         self.is_prefill_chunk = False
@@ -221,6 +224,7 @@ class Request:
             trace_headers=request.trace_headers,
             block_hasher=block_hasher,
             resumable=request.resumable,
+            session_id=request.session_id,
             reasoning_ended=request.reasoning_ended,
             reasoning_parser_kwargs=request.reasoning_parser_kwargs,
             abort_immediately=request.abort_immediately,


### PR DESCRIPTION
## [Feature] First-class `session_id` for conversation-aware routing

> **Closes** [#48049](https://github.com/vllm-project/vllm/issues/48049)

---

### The Problem

vLLM currently has **no typed, request-level identity** for sessions, conversations, or agent runs. The only existing workaround is to smuggle `session_id` through `SamplingParams.extra_args["session_id"]` — a fragile hack that:

- Overloads `request_id` (which has different lifecycle semantics)
- Hides identity inside sampling parameters where it doesn't belong
- Makes it impossible for engine internals, KV connectors, cache policies, or schedulers to consume session identity without reaching into `extra_args`

This blocks **Dynamo integration** and any future session-aware scheduling.

---

### The Solution

Add a **first-class, typed `session_id: str | None`** that flows through the entire vLLM request path:

```
OpenAI body.session_id / HTTP X-Session-ID header
  → Serving layer (_get_session_id with precedence)
  → EngineCoreRequest.session_id
  → Request.session_id
  → Engine internals, KV connectors, schedulers (future)
```

**Key design rule:** `request.session_id`, not `request.sampling_params.extra_args["session_id"]`.

---

### What Changed

#### 1. Core Engine Plumbing (6 files)

| File | Change |
|------|--------|
| `vllm/v1/engine/__init__.py` | Added `session_id: str \| None = None` to `EngineCoreRequest` struct |
| `vllm/v1/request.py` | Added `session_id` param, storage, and copy from `EngineCoreRequest` |
| `vllm/engine/protocol.py` | Added `session_id` to `EngineClient.generate()` abstract method |
| `vllm/v1/engine/async_llm.py` | Threaded through `generate()`, `add_request()`, `_add_streaming_input_request()` |
| `vllm/v1/engine/llm_engine.py` | Threaded through `add_request()` → `process_inputs()` |
| `vllm/v1/engine/input_processor.py` | Accepts `session_id`, passes to `EngineCoreRequest()` |

#### 2. OpenAI Ingress (3 files)

| File | Change |
|------|--------|
| `vllm/entrypoints/openai/chat_completion/protocol.py` | Added `session_id` field to `ChatCompletionRequest` |
| `vllm/entrypoints/openai/completion/protocol.py` | Added `session_id` field to `CompletionRequest` |
| `vllm/entrypoints/openai/responses/protocol.py` | Added `session_id` field to `ResponsesRequest` |

#### 3. Serving Layer Resolution (1 file, shared helper)

| File | Change |
|------|--------|
| `vllm/entrypoints/generate/base/serving.py` | Added `_get_session_id()` static method with clear precedence |

#### 4. Serving Layer Wiring (5 files)

| File | Change |
|------|--------|
| `vllm/entrypoints/openai/chat_completion/serving.py` | Wires `session_id` into beam search + engine generate |
| `vllm/entrypoints/openai/chat_completion/batch_serving.py` | Wires `session_id` into batch generation |
| `vllm/entrypoints/openai/completion/serving.py` | Wires `session_id` into completion generation |
| `vllm/entrypoints/openai/responses/serving.py` | Wires `session_id` into responses + `_generate_with_builtin_tools()` |
| `vllm/entrypoints/generate/beam_search/online.py` | Accepts + forwards `session_id` to all beam sub-requests |

#### 5. Parallel Sampling & Beam Search

- **Parallel sampling** (`n > 1`): Child requests inherit `session_id` via `copy(request)` — each child gets a unique `request_id` but shares the same `session_id`.
- **Beam search**: `session_id` is forwarded to every beam sub-request, preserving session identity across the beam tree.

---

### Precedence Rules

The `_get_session_id()` helper resolves the effective session ID with deterministic precedence:

```python
@staticmethod
def _get_session_id(request, raw_request) -> str | None:
    # 1. Body-level session_id (explicit, highest priority)
    if request.session_id:
        return request.session_id
    # 2. X-Session-ID HTTP header
    if raw_request is not None and (
        value := raw_request.headers.get("X-Session-ID")
    ):
        return value
    # 3. vllm_xargs["session_id"] (temporary compatibility only)
    if request.vllm_xargs:
        session_id = request.vllm_xargs.get("session_id")
        if isinstance(session_id, str) and session_id:
            return session_id
    return None
```

| Scenario | Result |
|----------|--------|
| Body `session_id` + header `X-Session-ID` | Body wins |
| Header only | Header wins |
| `vllm_xargs` only | `vllm_xargs` used (compat) |
| Empty body `session_id` | Treated as absent |
| Nothing set | `None` |

---

### What This Does NOT Include

This PR is deliberately scoped to **typed plumbing only**. The following are follow-up work:

- **Rust frontend HTTP/OpenAI surface** — The Rust server path needs the same `session_id` field in its OpenAI request types and `resolve_session_id()` helper.
- **gRPC body-level `session_id`** — Requires proto changes.
- **Native/offline `LLM.generate` parity** — The synchronous `LLM` class can expose `session_id` in a follow-up.
- **Consumer updates** — Mooncake/KV connector consumers should read `request.session_id` instead of `extra_args["session_id"]` once this lands.
- **Session-aware scheduling/cache policy** — This PR only makes identity available; policy is a separate discussion.

---

### Design Decisions

| Question | Answer | Rationale |
|----------|--------|-----------|
| Should vLLM accept `X-Correlation-ID`? | **No** — only `X-Session-ID` | Avoids ambiguity; Dynamo already normalizes its own headers |
| Body vs header precedence? | **Body wins** | Explicit value should override inferred value |
| Conflicting values? | **Resolved by precedence** | Simpler than rejection; callers control their own identity |
| Keep `vllm_xargs["session_id"]`? | **Yes, as compatibility only** | Existing experimental users need a migration path |
| Parallel sampling? | **Inherit via `copy()`** | Child requests share parent's session identity |
| Beam search? | **Forward to all sub-requests** | Session identity must survive the beam tree |

---

### Example Usage

**Via HTTP header:**
```bash
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "X-Session-ID: my-conversation-123" \
  -H "Content-Type: application/json" \
  -d '{"model": "llama-3", "messages": [{"role": "user", "content": "Hello"}]}'
```

**Via request body:**
```bash
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "llama-3",
    "session_id": "my-conversation-123",
    "messages": [{"role": "user", "content": "Hello"}]
  }'
```

**Programmatic (AsyncLLM):**
```python
async for output in engine.generate(
    prompt,
    sampling_params,
    request_id="req-1",
    session_id="my-conversation-123",  # NEW
):
    print(output)
```

---

### Tests

| Test File | What It Verifies |
|-----------|-----------------|
| `tests/entrypoints/openai/test_session_id.py` | `_get_session_id()` precedence: body > header > xargs, empty/absent handling |
| `tests/v1/test_request_session_id.py` | `Request.session_id` propagation from `EngineCoreRequest` |
| `tests/v1/engine/test_parallel_sampling_session_id.py` | Child requests preserve `session_id` while retaining unique `request_id` |

All tests pass. All linting (ruff check, ruff format, typos) passes.

---

### Related

- **Issue:** [#48049](https://github.com/vllm-project/vllm/issues/48049) — Feature request
- **Existing PR:** [#48048](https://github.com/vllm-project/vllm/pull/48048) — This PR supersedes #48048 with a cleaner implementation that includes the same Python engine plumbing plus the serving layer wiring and comprehensive tests
- **Upstream PR:** [#46547](https://github.com/vllm-project/vllm/pull/46547) — The Mooncake `extra_args` workaround that this typed field replaces

---

### Checklist

- [x] Core engine plumbing (`EngineCoreRequest` → `Request`)
- [x] OpenAI ingress (Chat, Completion, Responses)
- [x] Serving layer resolution with precedence
- [x] Beam search forwarding
- [x] Parallel sampling inheritance
- [x] Comprehensive unit tests
- [x] Ruff check + format pass
- [x] Typos pass
- [ ] Rust frontend (follow-up PR)
- [ ] Consumer updates (follow-up PR)
