### PR TITLE
[Bugfix][Distributed] Disable fused allreduce when NVLink multicast is unavailable

### DIFF
--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -37,6 +37,8 @@ except ImportError:
 _fi_ar_workspace = None
 # Extra workspace for quant fusion patterns (only supported by trtllm backend)
 _fi_ar_quant_workspace = None
+# NVLink multicast probe results, keyed by process group
+_fi_ar_multicast_supported: dict[str, bool] = {}
 
 
 def _create_workspace(
@@ -112,12 +114,42 @@ def _resolve_fi_ar_backend() -> tuple[str, bool]:
     # FlashInfer (>= 0.6.12, vLLM pins 0.6.13), so mnnvl is safe here. trtllm
     # does not support multi-node allreduce, so mnnvl is required there anyway.
     # mnnvl needs NVSwitch multicast; on single-node topologies without it,
-    # fall back to trtllm so fused allreduce stays enabled.
+    # get_fi_ar_workspace() disables fused allreduce (plain NCCL is faster).
     backend = "mnnvl"
     allow_trtllm_fallback = get_node_count() == 1
 
     logger.info_once(f"Auto-selected flashinfer allreduce backend: {backend}")
     return backend, allow_trtllm_fallback
+
+
+def _node_supports_nvlink_multicast(group: ProcessGroup, device: torch.device) -> bool:
+    """Return True if ``group`` has NVLink multicast across all ranks.
+
+    mnnvl fused allreduce requires this; FlashInfer workspace creation alone
+    does not reliably detect its absence on bridged NVLink topologies. Uses the
+    same ``multicast_ptr`` probe as ``SymmMemCommunicator``. The result is cached
+    per process group.
+    """
+    key = getattr(group, "group_name", None) or str(id(group))
+    cached = _fi_ar_multicast_supported.get(key)
+    if cached is not None:
+        return cached
+    supported = False
+    try:
+        import torch.distributed._symmetric_memory as torch_symm_mem
+
+        probe = torch_symm_mem.empty(8, device=device, dtype=torch.uint8)
+        handle = torch_symm_mem.rendezvous(probe, group.group_name)
+        supported = handle.multicast_ptr != 0
+    except Exception as e:
+        logger.warning_once(
+            "FlashInfer allreduce: multicast capability probe failed (%s); "
+            "assuming NVLink multicast is unavailable.",
+            e,
+        )
+        supported = False
+    _fi_ar_multicast_supported[key] = supported
+    return supported
 
 
 def get_fi_ar_workspace(
@@ -140,6 +172,21 @@ def get_fi_ar_workspace(
         return _fi_ar_workspace
 
     backend, allow_trtllm_fallback = _resolve_fi_ar_backend()
+
+    # Probe before workspace creation; init alone does not reliably detect
+    # missing multicast support on bridged single-node topologies.
+    if backend == "mnnvl" and allow_trtllm_fallback:
+        device = torch.device(
+            current_platform.device_type, torch.accelerator.current_device_index()
+        )
+        if not _node_supports_nvlink_multicast(group, device):
+            logger.warning_once(
+                "FlashInfer allreduce: NVLink multicast unavailable on this "
+                "single-node topology; disabling fused allreduce (plain NCCL "
+                "allreduce + native RMSNorm). The trtllm fused fallback is "
+                "much slower on bridged NVLink topologies."
+            )
+            return None
 
     if get_node_count() > 1 and backend == "trtllm":
         raise ValueError(


### PR DESCRIPTION
## Purpose

Fixes #48071.

FlashInfer's `mnnvl` fused allreduce requires NVSwitch multicast across all TP ranks. On bridged single-node NVLink topologies (H100-NVL / H200-NVL), `mnnvl` workspace creation still **succeeds**, so the existing single-node fallback in #47219 never fires and the fused kernel crashes during CUDA graph capture.

This PR completes the intent of #47219 with a topology-aware probe: when multicast is absent on the single-node `auto` path, `get_fi_ar_workspace()` returns `None` so `AllReduceFusionPass` disables itself and TP allreduce uses **plain PYNCCL + native RMSNorm** — the same effective path as `fuse_allreduce_rms=false`.

Explicit `VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm` is unchanged (user opt-in). Full NVSwitch nodes (e.g. H200x8) keep `mnnvl` when multicast is present.

## Why not trtllm auto-fallback?

Forced `trtllm` fused allreduce avoids the crash but **collapses decode performance** on NVL bridge topologies versus disabling fusion:

| Hardware | Config | cc32 ITL p50 | Outcome |
|---|---|---:|---|
| H100-NVL | baseline (`auto`, fusion ON) | — | crash (mnnvl IMA) |
| H100-NVL | forced `trtllm` | **259 ms** | works, ~10× slower than no-fuse |
| H100-NVL | `fuse_allreduce_rms=false` | **25 ms** | healthy |
| H200-NVL | baseline (`auto`, fusion ON) | — | crash (mnnvl IMA) |
| H200-NVL | forced `trtllm` | **733 ms** | works, ~35× slower than no-fuse |
| H200-NVL | `fuse_allreduce_rms=false` | **21 ms** | healthy |
| H200-NVL | this fix (probe → `None`) | **21 ms** | healthy; matches no-fuse |
| H200x8 | baseline (`auto`, fusion ON) | **9 ms** | healthy (regression guard) |

Model: `google/gemma-4-31b-it` (BF16, no quantization), TP=8, synthetic RAG workload. Image: `vllm/vllm-openai:nightly` digest `sha256:af0f839e6234795421bfd7500c55cf4690e65bbb6e06ec546a02e9ca4e4be07a`.

## Approach

Probe NVLink multicast with the same `multicast_ptr` check used by `SymmMemCommunicator` before committing to `mnnvl`. If unavailable, return `None` from `get_fi_ar_workspace()` (cached per process group).

## Test Plan

- H100-NVL / H200-NVL TP=8, default `auto`: no crash; logs show fused allreduce disabled; PYNCCL path; cc32 ITL ~20–25 ms.
- H200x8 TP=8, default `auto`: still selects `mnnvl`; no regression.
- Explicit `VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm`: unchanged.

## Scope limits

All benchmark evidence is **BF16 non-quant** only. Quantized allreduce+RMSNorm fusion on NVL bridge topologies is **untested**; when non-quant workspace returns `None`, `AllReduceFusionPass` currently disables entirely (including quant pattern registration).

---

*Developed with AI assistance and reviewed by a human before submission.*