### PR TITLE
[Core][Model] Add Confident Decoding (phase 1: Llama + core utilities)

### DIFF
--- a/.github/rfc_confident_decoding.md
+++ b/.github/rfc_confident_decoding.md
@@ -1,0 +1,97 @@
+# [RFC]: Confident Decoding — entropy-guided intermediate-layer logits selection
+
+## Summary
+
+We propose adding **Confident Decoding** to vLLM: a training-free decoding strategy that dynamically selects logits from near-final intermediate layers instead of always using the final layer. Layer selection is guided by prediction entropy (conservative backward search for the first entropy valley closest to the final layer).
+
+This is the inference implementation accompanying our paper:
+
+> **Deeper is Not Always Better: Mitigating the Alignment Tax via Confident Layer Decoding**  
+> Xuanming Zhang, Sining Zhoubian, Yuxuan Chen, et al.  
+> arXiv: https://arxiv.org/abs/2606.21906
+
+The paper shows consistent gains on challenging reasoning benchmarks (GPQA-Diamond, Omni-MATH, HLE) across dense and MoE LLMs, with zero memory overhead and <2% latency increase.
+
+## Motivation
+
+Standard autoregressive decoding always uses logits from the **final** transformer layer. Our work reveals a recurring **Guess-Refine-Perturb** dynamic: early layers form coarse guesses, intermediate layers refine reasoning-relevant semantics, and final layers can perturb refined predictions toward generic or alignment-preferred tokens.
+
+Confident Decoding bypasses harmful final-layer perturbations by selecting the most confident near-final layer at each token position.
+
+## Proposed API
+
+Enabled via `--additional-config` (no recompilation required):
+
+```bash
+vllm serve /path/to/model \
+  --additional-config '{
+    "enable_multi_layer_entropy_selection": true,
+    "select_method": "trough",
+    "p": 1.0,
+    "trough_max_backtrack_layers": 10
+  }'
+```
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `enable_multi_layer_entropy_selection` | bool | `false` | Global switch |
+| `select_method` | str | `"trough"` | Layer selection strategy (`trough`, `trough-m1`, `last-m8`, etc.) |
+| `p` | float | `1.0` | Probability of using selected-layer logits; `0.0` = standard final-layer decoding |
+| `trough_max_backtrack_layers` | int | `0` | Max layers to backtrack; `>0` uses this value; `<0` unlimited |
+| `trough_backtrack_ratio` | float | `0.0` | Used when `trough_max_backtrack_layers == 0` |
+| `trough_log_interval` | int | `0` | Periodic selection statistics logging; `0` disables |
+
+## Technical Design
+
+### CUDA graph compatibility
+
+vLLM's CUDA graph capture covers the outer model wrapper. Mutating Python attributes or dynamic buffers inside compiled forward causes stale state on graph replay. Our design:
+
+1. **Inner model** (compiled): collects raw candidate-layer hidden states only (similar to existing `aux_hidden_states`).
+2. **Outer CausalLM wrapper** (eager): applies final norm to collected states and stores in shape-keyed buffers.
+3. **Model runner** (eager): sets `_last_seq_len` and `_last_logits_indices` before `compute_logits`, keyed by CUDA graph batch shape.
+4. **`compute_logits`**: batched `lm_head` over `[L*B, H]`, entropy computation, backward trough scan, gather selected logits.
+
+### Selection algorithm (default `trough`)
+
+1. Compute logits for all candidate layers in one batched `lm_head` call.
+2. Compute per-token, per-layer prediction entropy.
+3. Scan backward from the final candidate layer; continue while entropy decreases.
+4. Stop at the first entropy increase (entropy valley closest to final layer).
+5. Optionally mix with final-layer logits via probability `p`.
+
+### Limitations (initial PR)
+
+- Pipeline parallelism (`pp > 1`): disabled for correctness.
+- Additional `lm_head` + entropy compute overhead per token (bounded by backtrack window).
+- Some multimodal entry points (e.g. Qwen3-VL with deepstack) require separate integration.
+
+## Proposed PR plan
+
+We plan to land this in phases to keep reviews manageable:
+
+| Phase | Scope |
+| --- | --- |
+| **PR 1** | `trough_utils.py`, v1 worker hooks, **Llama + Qwen3**, unit tests, `docs/features/confident_decoding.md` |
+| **PR 2** | Gemma, Mixtral, MoE variants |
+| **PR 3** | Multimodal entry points, DeepSeek, GPT-OSS |
+
+Estimated core PR size: ~800 LOC (excluding model-family expansions).
+
+## Validation plan
+
+- **Unit tests**: `vectorized_entropy_select` layer selection logic; `compute_trough_layer_range`; `prepare_trough_layer_states` alignment.
+- **Regression**: `p=0.0` produces identical outputs to standard final-layer decoding.
+- **Deterministic check**: `select_method=last-mk` selects fixed layer index.
+- **Integration**: small-model e2e generation smoke test.
+
+## Questions for maintainers
+
+1. Is `additional_config` the preferred configuration surface, or should this become a first-class `VllmConfig` field?
+2. Should we rename `enable_multi_layer_entropy_selection` → `enable_confident_decoding` for clarity (with backward-compatible alias)?
+3. Any concerns about the CUDA graph buffer design vs. alternative approaches?
+
+## References
+
+- Paper: https://arxiv.org/abs/2606.21906
+- Implementation prototype (vLLM 0.19.1 fork): https://github.com/zhoubiansining/vllm (branch `confident-dev`)

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,5 +1,7 @@
 # Features
 
+- [Confident Decoding](confident_decoding.md)
+
 ## Compatibility Matrix
 
 The tables below show mutually exclusive features and the support on some hardware.

--- a/docs/features/confident_decoding.md
+++ b/docs/features/confident_decoding.md
@@ -1,0 +1,40 @@
+# Confident Decoding
+
+Confident Decoding is a training-free decoding strategy that selects logits from near-final intermediate layers based on prediction entropy, instead of always using the final layer. It is described in [Deeper is Not Always Better: Mitigating the Alignment Tax via Confident Layer Decoding](https://arxiv.org/abs/2606.21906).
+
+## Usage
+
+Enable via `--additional-config`:
+
+```bash
+vllm serve /path/to/model \
+  --additional-config '{
+    "enable_multi_layer_entropy_selection": true,
+    "select_method": "trough",
+    "p": 1.0,
+    "trough_max_backtrack_layers": 10
+  }'
+```
+
+## Configuration
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `enable_multi_layer_entropy_selection` | bool | `false` | Global switch for Confident Decoding |
+| `select_method` | str | `"trough"` | Layer selection strategy (`trough`, `trough-m1`, `last-m8`, etc.) |
+| `p` | float | `1.0` | Probability of using selected-layer logits; `0.0` equals standard final-layer decoding |
+| `trough_max_backtrack_layers` | int | `0` | Max layers to backtrack; `>0` uses this value; `<0` unlimited |
+| `trough_backtrack_ratio` | float | `0.0` | Used when `trough_max_backtrack_layers == 0` |
+| `trough_log_interval` | int | `0` | Periodic selection statistics logging; `0` disables |
+
+## Supported models (initial)
+
+- Llama family (`LlamaForCausalLM`)
+
+Additional model families are planned in follow-up PRs. See [RFC #48080](https://github.com/vllm-project/vllm/issues/48080).
+
+## Limitations
+
+- Pipeline parallelism (`pp > 1`) is not supported and the feature is disabled automatically.
+- Confident Decoding adds bounded `lm_head` and entropy overhead for candidate layers.
+- `p=0.0` should match standard final-layer decoding and is the recommended regression setting.

--- a/tests/model_executor/test_trough_utils.py
+++ b/tests/model_executor/test_trough_utils.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.model_executor.models.trough_utils import (
+    compute_trough_layer_range,
+    prepare_trough_layer_states,
+    vectorized_entropy_select,
+)
+
+
+def test_compute_trough_layer_range_explicit_backtrack() -> None:
+    config = {
+        "trough_max_backtrack_layers": 10,
+        "trough_backtrack_ratio": 0.0,
+    }
+    start, count = compute_trough_layer_range(32, config)
+    assert start == 22
+    assert count == 10
+
+
+def test_compute_trough_layer_range_ratio() -> None:
+    config = {
+        "trough_max_backtrack_layers": 0,
+        "trough_backtrack_ratio": 0.25,
+    }
+    start, count = compute_trough_layer_range(20, config)
+    assert count == 5
+    assert start == 15
+
+
+def test_compute_trough_layer_range_all_layers_by_default() -> None:
+    config = {
+        "trough_max_backtrack_layers": 0,
+        "trough_backtrack_ratio": 0.0,
+    }
+    start, count = compute_trough_layer_range(12, config)
+    assert start == 0
+    assert count == 12
+
+
+def test_prepare_trough_layer_states_requires_indices_when_misaligned() -> None:
+    buffers = {8: torch.randn(3, 8, 4)}
+    states, reason = prepare_trough_layer_states(
+        trough_buffers=buffers,
+        last_seq_len=8,
+        last_logits_indices=None,
+        sample_batch_size=2,
+    )
+    assert states is None
+    assert reason == "missing_logits_indices"
+
+
+def test_prepare_trough_layer_states_selects_rows() -> None:
+    layer_states = torch.arange(24, dtype=torch.float32).reshape(3, 2, 4)
+    buffers = {4: layer_states}
+    indices = torch.tensor([1, 0], dtype=torch.int64)
+    states, reason = prepare_trough_layer_states(
+        trough_buffers=buffers,
+        last_seq_len=4,
+        last_logits_indices=indices,
+        sample_batch_size=2,
+    )
+    assert reason is None
+    assert states is not None
+    assert torch.equal(states[:, 0], layer_states[:, 1])
+    assert torch.equal(states[:, 1], layer_states[:, 0])
+
+
+class _LinearLmHead(torch.nn.Module):
+    def __init__(self, hidden_size: int, vocab_size: int) -> None:
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.eye(vocab_size, hidden_size))
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return hidden_states @ self.weight.T
+
+
+def _identity_logits_processor(lm_head, hidden_states: torch.Tensor) -> torch.Tensor:
+    return lm_head(hidden_states)
+
+
+def test_vectorized_entropy_select_p_zero_uses_final_layer() -> None:
+    # Two layers, one token. Layer 0 is sharper; layer 1 is flatter.
+    hidden = torch.tensor(
+        [
+            [[2.0, 0.0, 0.0, 0.0]],
+            [[0.0, 0.0, 0.0, 0.0]],
+        ],
+        dtype=torch.float32,
+    )
+    fallback = hidden[-1, :, :]
+    lm_head = _LinearLmHead(hidden_size=4, vocab_size=4)
+
+    selected, _, all_logits, _ = vectorized_entropy_select(
+        layer_states=hidden,
+        fallback_hidden_states=fallback,
+        logits_processor=_identity_logits_processor,
+        lm_head=lm_head,
+        select_method="trough",
+        trough_p=0.0,
+        trough_max_backtrack_layers=1,
+        trough_backtrack_ratio=0.0,
+        trough_start_layer=0,
+        total_model_layers=2,
+        trough_log_interval=0,
+        trough_call_count=1,
+    )
+
+    final_logits = _identity_logits_processor(lm_head, fallback)
+    assert torch.allclose(selected, final_logits)
+
+
+def test_vectorized_entropy_select_last_m1() -> None:
+    hidden = torch.randn(4, 2, 8)
+    fallback = hidden[-1]
+    lm_head = _LinearLmHead(hidden_size=8, vocab_size=8)
+
+    selected, _, all_logits, _ = vectorized_entropy_select(
+        layer_states=hidden,
+        fallback_hidden_states=fallback,
+        logits_processor=_identity_logits_processor,
+        lm_head=lm_head,
+        select_method="last-m1",
+        trough_p=1.0,
+        trough_max_backtrack_layers=4,
+        trough_backtrack_ratio=0.0,
+        trough_start_layer=0,
+        total_model_layers=4,
+        trough_log_interval=0,
+        trough_call_count=1,
+    )
+
+    expected = all_logits[2]
+    assert torch.allclose(selected, expected)

--- a/tests/model_executor/test_trough_utils.py
+++ b/tests/model_executor/test_trough_utils.py
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from unittest.mock import Mock
+
 import torch
 
 from vllm.model_executor.models.trough_utils import (
     compute_trough_layer_range,
     prepare_trough_layer_states,
+    read_trough_config,
     vectorized_entropy_select,
 )
 
@@ -38,6 +41,42 @@ def test_compute_trough_layer_range_all_layers_by_default() -> None:
     start, count = compute_trough_layer_range(12, config)
     assert start == 0
     assert count == 12
+
+
+def test_read_trough_config_from_additional_config() -> None:
+    vllm_config = Mock()
+    vllm_config.additional_config = {
+        "enable_multi_layer_entropy_selection": True,
+        "select_method": "trough-m1",
+        "p": 0.5,
+        "trough_max_backtrack_layers": 8,
+        "trough_backtrack_ratio": 0.25,
+        "trough_log_interval": 100,
+    }
+    vllm_config.model_config.hf_overrides = {}
+
+    config = read_trough_config(vllm_config)
+
+    assert config["enable_trough_decoding"] is True
+    assert config["trough_select_method"] == "trough-m1"
+    assert config["trough_p"] == 0.5
+    assert config["trough_max_backtrack_layers"] == 8
+    assert config["trough_backtrack_ratio"] == 0.25
+    assert config["trough_log_interval"] == 100
+
+
+def test_read_trough_config_hf_overrides_fallback() -> None:
+    vllm_config = Mock()
+    vllm_config.additional_config = {}
+    vllm_config.model_config.hf_overrides = {
+        "enable_multi_layer_entropy_selection": True,
+        "select_method": "last-m1",
+    }
+
+    config = read_trough_config(vllm_config)
+
+    assert config["enable_trough_decoding"] is True
+    assert config["trough_select_method"] == "last-m1"
 
 
 def test_prepare_trough_layer_states_requires_indices_when_misaligned() -> None:

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -34,6 +34,7 @@ from transformers import LlamaConfig
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
+from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.attention import (
     Attention,
@@ -74,6 +75,8 @@ from .utils import (
     make_layers,
     maybe_prefix,
 )
+
+logger = init_logger(__name__)
 
 
 class LlamaMLP(nn.Module):
@@ -443,6 +446,94 @@ class LlamaModel(nn.Module, EagleModelMixin):
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 
 
+class _LlamaTroughModelImpl(LlamaModel):
+    """Inner model that collects candidate-layer hidden states for Confident
+    Decoding. Norm and logits run outside the compiled graph."""
+
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+        layer_type: type[nn.Module] = LlamaDecoderLayer,
+    ):
+        super().__init__(vllm_config=vllm_config, prefix=prefix, layer_type=layer_type)
+
+        from .trough_utils import compute_trough_layer_range, read_trough_config
+
+        config = read_trough_config(vllm_config)
+        num_layers = self.end_layer - self.start_layer
+        start_layer, candidate_layers = compute_trough_layer_range(
+            num_layers, config
+        )
+        self._trough_candidate_layers = candidate_layers
+        self._trough_start_layer = self.start_layer + start_layer
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None,
+        inputs_embeds: torch.Tensor | None = None,
+        **extra_layer_kwargs,
+    ) -> (
+        torch.Tensor
+        | IntermediateTensors
+        | tuple[torch.Tensor, list[torch.Tensor]]
+        | tuple[torch.Tensor, list[torch.Tensor], list[torch.Tensor]]
+    ):
+        if get_pp_group().is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                hidden_states = self.embed_input_ids(input_ids)
+            residual = None
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors["residual"]
+
+        aux_hidden_states: list[torch.Tensor] = []
+        trough_states: list[torch.Tensor] = []
+        self._maybe_add_hidden_state(aux_hidden_states, 0, hidden_states, residual)
+        for idx, layer in enumerate(
+            islice(self.layers, self.start_layer, self.end_layer)
+        ):
+            hidden_states, residual = layer(
+                positions, hidden_states, residual, **extra_layer_kwargs
+            )
+            self._maybe_add_hidden_state(
+                aux_hidden_states, idx + 1, hidden_states, residual
+            )
+            if (self.start_layer + idx) >= self._trough_start_layer:
+                current_h = (
+                    hidden_states + residual if residual is not None else hidden_states
+                )
+                trough_states.append(current_h)
+
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors(
+                {"hidden_states": hidden_states, "residual": residual}
+            )
+
+        hidden_states, _ = self.norm(hidden_states, residual)
+        if aux_hidden_states:
+            return hidden_states, aux_hidden_states, trough_states
+        return hidden_states, trough_states
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": {0: "b"},
+        "positions": {0: "b"},
+        "intermediate_tensors": {0: "b"},
+        "inputs_embeds": {0: "b"},
+    },
+)
+class LlamaTroughModel(_LlamaTroughModelImpl, EagleModelMixin):
+    pass
+
+
 class LlamaForCausalLM(
     LocalArgmaxMixin,
     nn.Module,
@@ -475,6 +566,17 @@ class LlamaForCausalLM(
         quant_config = vllm_config.quant_config
         self.config = config
 
+        from .trough_utils import read_trough_config
+
+        trough_config = read_trough_config(vllm_config)
+        self.enable_trough_decoding = trough_config["enable_trough_decoding"]
+        if self.enable_trough_decoding and get_pp_group().world_size > 1:
+            logger.warning(
+                "Disabling Confident Decoding because pipeline parallelism is "
+                "enabled; current implementation only supports PP=1."
+            )
+            self.enable_trough_decoding = False
+
         self.model = self._init_model(
             vllm_config=vllm_config,
             prefix=maybe_prefix(prefix, "model"),
@@ -502,12 +604,50 @@ class LlamaForCausalLM(
             self.model.make_empty_intermediate_tensors
         )
 
+        if self.enable_trough_decoding:
+            self.trough_max_backtrack_layers = trough_config[
+                "trough_max_backtrack_layers"
+            ]
+            self.trough_backtrack_ratio = trough_config["trough_backtrack_ratio"]
+            self.trough_select_method = trough_config["trough_select_method"]
+            self.trough_p = trough_config["trough_p"]
+            self.trough_log_interval = trough_config["trough_log_interval"]
+            self._trough_call_count = 0
+            self._trough_buffers: dict[int, torch.Tensor] = {}
+            self._last_seq_len = 0
+            self._last_logits_indices: torch.Tensor | None = None
+
+            compilation_config = getattr(vllm_config, "compilation_config", None)
+            cg_sizes = (
+                getattr(compilation_config, "cudagraph_capture_sizes", None)
+                if compilation_config is not None
+                else None
+            )
+            self._trough_captured_shapes: frozenset[int] = (
+                frozenset(cg_sizes) if cg_sizes else frozenset()
+            )
+            logger.info(
+                "Llama Confident Decoding init: enabled=%s, select_method=%s, "
+                "p=%.2f, max_backtrack_layers=%d, backtrack_ratio=%.3f, "
+                "trough_log_interval=%d",
+                self.enable_trough_decoding,
+                self.trough_select_method,
+                self.trough_p,
+                self.trough_max_backtrack_layers,
+                self.trough_backtrack_ratio,
+                self.trough_log_interval,
+            )
+
     def _init_model(
         self,
         vllm_config: VllmConfig,
         prefix: str = "",
         layer_type: type[nn.Module] = LlamaDecoderLayer,
     ):
+        if self.enable_trough_decoding:
+            return LlamaTroughModel(
+                vllm_config=vllm_config, prefix=prefix, layer_type=layer_type
+            )
         return LlamaModel(vllm_config=vllm_config, prefix=prefix, layer_type=layer_type)
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
@@ -519,18 +659,52 @@ class LlamaForCausalLM(
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        **kwargs,
     ) -> torch.Tensor | IntermediateTensors:
-        model_output = self.model(
-            input_ids, positions, intermediate_tensors, inputs_embeds
+        output = self.model(
+            input_ids, positions, intermediate_tensors, inputs_embeds, **kwargs
         )
-        return model_output
+
+        is_trough_model = isinstance(self.model, _LlamaTroughModelImpl)
+        if not (
+            self.enable_trough_decoding
+            and is_trough_model
+            and get_pp_group().is_last_rank
+        ):
+            return output
+
+        if isinstance(output, tuple) and len(output) == 3:
+            hidden_states, aux_hidden_states, trough_states = output
+        else:
+            hidden_states, trough_states = output
+            aux_hidden_states = None
+        if not trough_states:
+            if aux_hidden_states:
+                return hidden_states, aux_hidden_states
+            return hidden_states
+
+        normed_layers = [self.model.norm(hs, None) for hs in trough_states]
+        self._trough_buffers[hidden_states.shape[0]] = torch.stack(normed_layers)
+        if aux_hidden_states:
+            return hidden_states, aux_hidden_states
+        return hidden_states
 
     def compute_logits(
         self,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor | None:
-        logits = self.logits_processor(self.lm_head, hidden_states)
-        return logits
+        if not self.enable_trough_decoding:
+            return self.logits_processor(self.lm_head, hidden_states)
+
+        from .trough_utils import compute_confident_decoding_logits
+
+        return compute_confident_decoding_logits(self, hidden_states)
+
+    def clear_trough_buffers(self) -> None:
+        captured = self._trough_captured_shapes
+        for key in list(self._trough_buffers.keys()):
+            if key not in captured:
+                self._trough_buffers.pop(key, None)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(

--- a/vllm/model_executor/models/trough_utils.py
+++ b/vllm/model_executor/models/trough_utils.py
@@ -1,0 +1,394 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Shared utilities for Confident Decoding (entropy-trough selection).
+
+Provides:
+- ``read_trough_config``: read trough parameters from vllm_config.
+- ``compute_trough_layer_range``: compute candidate layer range for a model.
+- ``TroughStateMixin``: base mixin adding trough-related state and methods.
+- ``vectorized_entropy_select``: memory-efficient entropy-trough layer selection.
+"""
+
+import math
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+logger = __import__("vllm.logger", fromlist=["logger"]).logger
+
+
+def read_trough_config(vllm_config: "VllmConfig") -> dict:
+    """Read trough decoding config from vllm_config.additional_config
+    or vllm_config.model_config.hf_overrides."""
+    additional_config = getattr(vllm_config, "additional_config", {}) or {}
+    hf_overrides = getattr(vllm_config.model_config, "hf_overrides", {}) or {}
+
+    def _cfg(key: str, default):
+        if key in additional_config:
+            return additional_config[key]
+        if isinstance(hf_overrides, dict) and key in hf_overrides:
+            return hf_overrides[key]
+        return default
+
+    return {
+        "enable_trough_decoding": bool(_cfg("enable_multi_layer_entropy_selection", False)),
+        "trough_max_backtrack_layers": int(_cfg("trough_max_backtrack_layers", 0)),
+        "trough_backtrack_ratio": float(_cfg("trough_backtrack_ratio", 0.0)),
+        "trough_select_method": str(_cfg("select_method", "trough")),
+        "trough_p": float(_cfg("p", 1.0)),
+        "trough_log_interval": int(_cfg("trough_log_interval", 0)),
+    }
+
+
+def compute_trough_layer_range(num_layers: int, config: dict) -> tuple[int, int]:
+    """Compute trough start layer and candidate layer count.
+
+    Returns (trough_start_layer, candidate_layers).
+    """
+    max_backtrack = config["trough_max_backtrack_layers"]
+    backtrack_ratio = config["trough_backtrack_ratio"]
+
+    if max_backtrack > 0:
+        candidate_layers = min(num_layers, max_backtrack)
+    elif backtrack_ratio > 0:
+        candidate_layers = max(1, int(math.ceil(num_layers * backtrack_ratio)))
+    else:
+        candidate_layers = num_layers
+
+    start_layer = num_layers - candidate_layers
+    return start_layer, candidate_layers
+
+
+class TroughStateMixin:
+    """Adds trough decoding state and logic to a CausalLM wrapper.
+
+    Subclasses must provide:
+    - ``model`` attribute (inner model, may be TroughModel variant).
+    - ``lm_head`` attribute.
+    - ``logits_processor`` attribute.
+    - ``_trough_start_layer`` on the inner model (set by TroughModel).
+    - ``compute_logits_override()`` class method that returns a reference
+      implementation of logits computation with trough selection.
+    """
+
+    def init_trough_state(self, config: dict) -> None:
+        self.trough_max_backtrack_layers = config["trough_max_backtrack_layers"]
+        self.trough_backtrack_ratio = config["trough_backtrack_ratio"]
+        self.trough_select_method = config["trough_select_method"]
+        self.trough_p = config["trough_p"]
+        self.trough_log_interval = config["trough_log_interval"]
+        self._trough_call_count = 0
+        self._trough_buffers: dict[int, torch.Tensor] = {}
+        self._last_eager_buf: torch.Tensor | None = None
+        self._last_seq_len: int = 0
+        self._last_logits_indices: torch.Tensor | None = None
+
+    def init_trough_buffer(
+        self,
+        output: torch.Tensor,
+        trough_states: list[torch.Tensor],
+    ) -> None:
+        """Apply final norm to collected trough states and store in buffer."""
+        if not trough_states:
+            return
+        normed_layers = [self.model.norm(hs, None) for hs in trough_states]
+        self._last_eager_buf = torch.stack(normed_layers)
+        self._trough_buffers[output.shape[0]] = self._last_eager_buf
+
+    def compute_trough_logits(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor | None:
+        """Compute logits using entropy-trough layer selection.
+
+        Returns ``None`` if trough is disabled or no buffer is available.
+        """
+        raise NotImplementedError
+
+
+def clear_trough_step_state(model) -> None:
+    """Reset per-step trough metadata after compute_logits."""
+    model._last_logits_indices = None
+    model._last_seq_len = 0
+
+
+def prepare_trough_layer_states(
+    *,
+    trough_buffers: dict[int, torch.Tensor],
+    last_seq_len: int,
+    last_logits_indices: torch.Tensor | None,
+    sample_batch_size: int,
+) -> tuple[torch.Tensor | None, str | None]:
+    """Resolve ``[L, B, H]`` layer states aligned with the sample batch.
+
+    Returns ``(layer_states, skip_reason)``. When ``skip_reason`` is set,
+    callers must fall back to final-layer logits instead of trough selection.
+    """
+    if last_seq_len <= 0:
+        return None, "invalid_last_seq_len"
+
+    layer_states = trough_buffers.get(last_seq_len)
+    if layer_states is None:
+        return None, "buffer_miss"
+
+    _, S_buf, _ = layer_states.shape
+    B = sample_batch_size
+
+    if last_logits_indices is not None:
+        if last_logits_indices.numel() != B:
+            return None, "indices_count_mismatch"
+        if last_logits_indices.numel() == 0:
+            return None, "empty_indices"
+        max_idx = int(last_logits_indices.max().item())
+        min_idx = int(last_logits_indices.min().item())
+        if min_idx < 0 or max_idx >= S_buf:
+            return None, "indices_out_of_range"
+        return layer_states[:, last_logits_indices], None
+
+    if B == S_buf:
+        return layer_states, None
+
+    # Do not guess with ``[:, -B:]`` — that misaligns prompt-logprobs and
+    # padded batches when sample rows are not the trailing S_buf positions.
+    return None, "missing_logits_indices"
+
+
+def finalize_trough_step_buffers(model) -> None:
+    """Drop eager trough buffers and clear step metadata."""
+    seq_len = model._last_seq_len
+    captured = model._trough_captured_shapes
+    if seq_len not in captured and seq_len in model._trough_buffers:
+        model._trough_buffers.pop(seq_len, None)
+    clear_trough_step_state(model)
+
+
+def _resolve_lm_head(model):
+    lm_head = getattr(model, "lm_head", None)
+    if lm_head is not None:
+        return lm_head
+    return model.model.embed_tokens
+
+
+def compute_confident_decoding_logits(
+    model,
+    hidden_states: torch.Tensor,
+) -> torch.Tensor | None:
+    """Shared Confident Decoding logits path for CausalLM wrappers."""
+    lm_head = _resolve_lm_head(model)
+    model._trough_call_count += 1
+    B = hidden_states.shape[0]
+
+    layer_states, fallback_reason = prepare_trough_layer_states(
+        trough_buffers=model._trough_buffers,
+        last_seq_len=model._last_seq_len,
+        last_logits_indices=getattr(model, "_last_logits_indices", None),
+        sample_batch_size=B,
+    )
+    if layer_states is None:
+        if fallback_reason not in (None, "buffer_miss"):
+            logger.debug(
+                "Confident Decoding fallback (%s): using final-layer logits",
+                fallback_reason,
+            )
+        clear_trough_step_state(model)
+        return model.logits_processor(lm_head, hidden_states)
+
+    inner = model.model
+    selected_logits, _, _, _ = vectorized_entropy_select(
+        layer_states=layer_states,
+        fallback_hidden_states=hidden_states,
+        logits_processor=model.logits_processor,
+        lm_head=lm_head,
+        select_method=model.trough_select_method,
+        trough_p=model.trough_p,
+        trough_max_backtrack_layers=model.trough_max_backtrack_layers,
+        trough_backtrack_ratio=model.trough_backtrack_ratio,
+        trough_start_layer=inner._trough_start_layer,
+        total_model_layers=len(inner.layers),
+        trough_log_interval=model.trough_log_interval,
+        trough_call_count=model._trough_call_count,
+    )
+    finalize_trough_step_buffers(model)
+    return selected_logits
+
+
+def vectorized_entropy_select(
+    layer_states: torch.Tensor,
+    fallback_hidden_states: torch.Tensor,
+    logits_processor,
+    lm_head,
+    select_method: str,
+    trough_p: float,
+    trough_max_backtrack_layers: int,
+    trough_backtrack_ratio: float,
+    trough_start_layer: int,
+    total_model_layers: int,
+    trough_log_interval: int,
+    trough_call_count: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    """Compute entropy trough layer selection.
+
+    Memory strategy (no extra ``[L, B, V]`` softmax buffer):
+
+    1. Stable softmax **in-place** on ``all_logits`` (only ``row_max`` / ``Z``
+       scalars per row are kept).
+    2. Entropy per layer via ``torch.special.entr`` on ``[B, V]`` slices so
+       peak temp is one layer, not ``L × B × V``.
+    3. Rebuild raw logits in-place with ``log(p) + log(Z) + max`` before
+       ``gather`` — never ``exp(probs)`` and never ``(p * p.log_())``.
+
+    Args:
+        layer_states: ``[L, B, H]`` normed hidden states per candidate layer.
+        fallback_hidden_states: ``[B, H]`` last-layer hidden states fallback.
+        logits_processor: LogitsProcessor instance.
+        lm_head: language model head (ParallelLMHead or equivalent).
+        select_method: selection strategy (``trough``, ``last-m1``, etc.).
+        trough_p: stochastic fallback probability to final layer.
+        trough_max_backtrack_layers: explicit max backtrack (0=use ratio).
+        trough_backtrack_ratio: ratio-based backtrack window.
+        trough_start_layer: global model layer index of first candidate.
+        total_model_layers: total number of layers in the model.
+        trough_log_interval: log period (0=disabled).
+        trough_call_count: current step count for logging.
+
+    Returns:
+        Tuple of (selected_logits ``[B, V]``, entropy ``[L, B]``,
+        layer_states ``[L, B, V]``, L).
+    """
+    L, B, H = layer_states.shape
+    device = layer_states.device
+
+    flat = layer_states.reshape(L * B, H)
+    flat_logits = logits_processor(lm_head, flat)
+    if flat_logits is None:
+        flat_logits = logits_processor(lm_head, fallback_hidden_states)
+        return flat_logits, torch.zeros(L, B, device=device), torch.zeros(
+            L, B, V, device=device
+        ) if (V := flat_logits.shape[-1]) else torch.zeros(L, B, 1, device=device), L
+    V = flat_logits.shape[-1]
+    all_logits = flat_logits.reshape(L, B, V)
+
+    method = select_method
+
+    if method.startswith("last-"):
+        try:
+            offset = int(method.split("-m")[-1])
+        except (IndexError, ValueError):
+            offset = 0
+        target_model_layer = max(0, total_model_layers - 1 - offset)
+        cand_idx = target_model_layer - trough_start_layer
+        cand_idx = max(0, min(L - 1, cand_idx))
+        selected_layer_idx = torch.full(
+            (B,), cand_idx, device=device, dtype=torch.long
+        )
+        entropy = torch.zeros(L, B, device=device)
+    else:
+        # In-place stable softmax; keep row_max and log(Z) for logits rebuild.
+        row_max = all_logits.max(dim=-1, keepdim=True).values
+        all_logits.sub_(row_max)
+        all_logits.exp_()
+        Z = all_logits.sum(dim=-1, keepdim=True)
+        all_logits.div_(Z)
+        log_Z = Z.log()
+
+        # Layer-wise entropy: peak temp is [B, V], not [L, B, V].
+        entropy = torch.empty(L, B, device=device, dtype=all_logits.dtype)
+        for l_idx in range(L):
+            entropy[l_idx] = torch.special.entr(all_logits[l_idx]).sum(dim=-1)
+
+        explicit = int(trough_max_backtrack_layers)
+        if explicit > 0:
+            max_backtrack = explicit
+        elif explicit < 0:
+            max_backtrack = L
+        else:
+            max_backtrack = int(L * trough_backtrack_ratio)
+        # Cap backtrack to L-1 so the loop never uses negative layer indices
+        # (e.g. max_backtrack=10, L=10 previously yielded min_layer=-1).
+        max_backtrack = min(max_backtrack, max(L - 1, 0))
+        min_layer = max(0, L - 1 - max_backtrack)
+
+        selected_layer_idx = torch.full(
+            (B,), L - 1, device=device, dtype=torch.long
+        )
+        frozen = torch.zeros(B, dtype=torch.bool, device=device)
+        prev_entropy = entropy[L - 1]
+
+        for l_idx in range(L - 2, min_layer - 1, -1):
+            cur_entropy = entropy[l_idx]
+            improves = cur_entropy < prev_entropy
+            update_mask = improves & (~frozen)
+            selected_layer_idx = torch.where(
+                update_mask,
+                torch.full_like(selected_layer_idx, l_idx),
+                selected_layer_idx,
+            )
+            frozen = frozen | (~improves)
+            prev_entropy = cur_entropy
+
+        # Rebuild logits: log(p) + log(Z) + max = raw logits (probs in buffer).
+        all_logits.log_()
+        all_logits.add_(log_Z)
+        all_logits.add_(row_max)
+
+        if method == "trough-m2":
+            selected_layer_idx = torch.clamp(selected_layer_idx - 2, 0, L - 1)
+        elif method == "trough-m1":
+            selected_layer_idx = torch.clamp(selected_layer_idx - 1, 0, L - 1)
+        elif method == "trough-p1":
+            selected_layer_idx = torch.clamp(selected_layer_idx + 1, 0, L - 1)
+        elif method == "trough-p2":
+            selected_layer_idx = torch.clamp(selected_layer_idx + 2, 0, L - 1)
+
+    p = float(trough_p)
+    if p < 1.0:
+        rng = torch.rand(B, device=device)
+        use_final = rng > p
+        selected_layer_idx = torch.where(
+            use_final,
+            torch.full((B,), L - 1, device=device, dtype=torch.long),
+            selected_layer_idx,
+        )
+
+    gather_idx = selected_layer_idx.unsqueeze(0).unsqueeze(-1).expand(1, B, V)
+    selected_logits = all_logits.gather(0, gather_idx).squeeze(0)
+
+    if B > 0 and trough_log_interval > 0 and trough_call_count % trough_log_interval == 0:
+        with torch.no_grad():
+            sel = selected_layer_idx
+            backtrack_depth = (L - 1) - sel
+            num_at_final = (sel == (L - 1)).sum().item()
+            preview = min(B, 4)
+            if method.startswith("trough"):
+                final_entropy = entropy[L - 1]
+                sample_pairs = [
+                    (int(sel[i].item()), float(final_entropy[i].item()))
+                    for i in range(preview)
+                ]
+            else:
+                sample_pairs = [(int(sel[i].item()), 0.0) for i in range(preview)]
+            logger.info(
+                "[trough-decoding] step=%d tokens=%d layers=%d "
+                "select_method=%s p=%.2f "
+                "avg_selected_layer=%.2f min_selected_layer=%d "
+                "avg_backtrack_depth=%.2f max_backtrack_depth=%d "
+                "tokens_kept_at_final=%d/%d sample=%s",
+                trough_call_count,
+                B,
+                L,
+                method,
+                p,
+                sel.float().mean().item(),
+                int(sel.min().item()),
+                backtrack_depth.float().mean().item(),
+                int(backtrack_depth.max().item()),
+                num_at_final,
+                B,
+                sample_pairs,
+            )
+
+    return selected_logits, entropy, all_logits, L

--- a/vllm/model_executor/models/trough_utils.py
+++ b/vllm/model_executor/models/trough_utils.py
@@ -35,7 +35,9 @@ def read_trough_config(vllm_config: "VllmConfig") -> dict:
         return default
 
     return {
-        "enable_trough_decoding": bool(_cfg("enable_multi_layer_entropy_selection", False)),
+        "enable_trough_decoding": bool(
+            _cfg("enable_multi_layer_entropy_selection", False)
+        ),
         "trough_max_backtrack_layers": int(_cfg("trough_max_backtrack_layers", 0)),
         "trough_backtrack_ratio": float(_cfg("trough_backtrack_ratio", 0.0)),
         "trough_select_method": str(_cfg("select_method", "trough")),
@@ -149,7 +151,7 @@ def prepare_trough_layer_states(
             return None, "indices_out_of_range"
         return layer_states[:, last_logits_indices], None
 
-    if B == S_buf:
+    if S_buf == B:
         return layer_states, None
 
     # Do not guess with ``[:, -B:]`` — that misaligns prompt-logprobs and
@@ -357,7 +359,12 @@ def vectorized_entropy_select(
     gather_idx = selected_layer_idx.unsqueeze(0).unsqueeze(-1).expand(1, B, V)
     selected_logits = all_logits.gather(0, gather_idx).squeeze(0)
 
-    if B > 0 and trough_log_interval > 0 and trough_call_count % trough_log_interval == 0:
+    should_log = (
+        B > 0
+        and trough_log_interval > 0
+        and trough_call_count % trough_log_interval == 0
+    )
+    if should_log:
         with torch.no_grad():
             sel = selected_layer_idx
             backtrack_depth = (L - 1) - sel

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4383,10 +4383,19 @@ class GPUModelRunner(
                     )
 
                 sample_hidden_states = hidden_states[logits_indices]
+                actual_model = self.get_model()
+                if getattr(actual_model, "enable_trough_decoding", False):
+                    actual_model._last_seq_len = hidden_states.shape[0]
+                    actual_model._last_logits_indices = logits_indices
                 logits = self.model.compute_logits(sample_hidden_states)
             else:
                 # Rare case.
                 assert not self.is_pooling_model
+
+                actual_model = self.get_model()
+                trough_enabled = getattr(actual_model, "enable_trough_decoding", False)
+                if trough_enabled and get_pp_group().is_last_rank:
+                    actual_model._last_seq_len = hidden_states.shape[0]
 
                 sample_hidden_states = hidden_states[logits_indices]
                 if not get_pp_group().is_last_rank:
@@ -4402,6 +4411,8 @@ class GPUModelRunner(
                     )
                     logits = None
                 else:
+                    if trough_enabled:
+                        actual_model._last_logits_indices = logits_indices
                     logits = self.model.compute_logits(sample_hidden_states)
 
                 model_output_broadcast_data: dict[str, Any] = {}
@@ -5584,7 +5595,16 @@ class GPUModelRunner(
             # then there is prompt logprob generated for each index.
             req_idx = self.input_batch.req_id_to_index[req_id]
             offset = self.query_start_loc.np[req_idx].item()
+            actual_model = self.get_model()
             prompt_hidden_states = hidden_states[offset : offset + num_logits]
+            if getattr(actual_model, "enable_trough_decoding", False):
+                actual_model._last_seq_len = hidden_states.shape[0]
+                actual_model._last_logits_indices = torch.arange(
+                    offset,
+                    offset + num_logits,
+                    device=hidden_states.device,
+                    dtype=torch.int64,
+                )
             logits = self.model.compute_logits(prompt_hidden_states)
 
             # Get the "target" tokens for each index. For prompt at index i,
@@ -6106,6 +6126,10 @@ class GPUModelRunner(
 
         hidden_states = torch.rand_like(hidden_states)
 
+        actual_model = self.get_model()
+        if getattr(actual_model, "enable_trough_decoding", False):
+            actual_model._last_logits_indices = None
+            actual_model._last_seq_len = hidden_states.shape[0]
         logits = self.model.compute_logits(hidden_states)
         num_reqs = logits.size(0)
 
@@ -6701,6 +6725,13 @@ class GPUModelRunner(
         end_time = time.perf_counter()
         elapsed_time = end_time - start_time
         cuda_graph_size = start_free_gpu_memory - end_free_gpu_memory
+
+        actual_model = self.get_model()
+        if getattr(actual_model, "enable_trough_decoding", False):
+            clear_fn = getattr(actual_model, "clear_trough_buffers", None)
+            if clear_fn is not None:
+                clear_fn()
+
         # This usually takes 5~20 seconds.
         logger.info_once(
             "Graph capturing finished in %.0f secs, took %.2f GiB",


### PR DESCRIPTION
## Summary

This PR introduces **Confident Decoding** (phase 1) to vLLM: a training-free decoding strategy that selects logits from near-final intermediate layers using entropy-guided conservative backward search, instead of always using the final layer.

This implements the inference side of our paper:

- **Deeper is Not Always Better: Mitigating the Alignment Tax via Confident Layer Decoding**
- arXiv: https://arxiv.org/abs/2606.21906
- Authors include Qwen team members

Related RFC: #48080

### Phase 1 scope (this PR)
- `trough_utils.py`: shared config parsing, buffer alignment, entropy-trough selection
- v1 GPU model runner hooks for CUDA-graph-safe `_last_seq_len` / `_last_logits_indices`
- `LlamaForCausalLM` integration
- Unit tests for core selection utilities
- User docs: `docs/features/confident_decoding.md`

### Follow-up PRs (planned)
- Qwen / Gemma / MoE / multimodal model families from our fork

## Why this is not duplicating an existing PR

Searched open PRs/issues for "confident decoding", "trough decoding", and "multi_layer_entropy" — no overlapping work found.

## Test plan

- [x] Standalone validation of `trough_utils` selection logic (CPU)
- [ ] `pytest tests/model_executor/test_trough_utils.py -v` (requires vLLM dev env)
- [ ] `p=0.0` e2e regression vs standard final-layer decoding on a small Llama model
- [ ] `pre-commit run --all-files`

## AI assistance disclosure

AI tools were used to help port the feature from our v0.19.1 fork onto upstream `main` and draft tests/docs. All changed lines were reviewed by the human submitter.


Made with [Cursor](https://cursor.com)