### PR TITLE
[Frontend] Support min_p in the Responses API

### DIFF
--- a/docs/serving/online_serving/openai_compatible_server.md
+++ b/docs/serving/online_serving/openai_compatible_server.md
@@ -175,6 +175,12 @@ you can use the [official OpenAI Python client](https://github.com/openai/openai
 
 Code example: [examples/tool_calling/openai_responses_client_with_tools.py](../../../examples/tool_calling/openai_responses_client_with_tools.py)
 
+#### Sampling parameters
+
+In addition to the OpenAI request fields, the Responses API forwards vLLM
+[sampling parameters](../../api/README.md#inference-parameters) such as `top_k`,
+`min_p`, `repetition_penalty`, `seed`, `stop`, and `ignore_eos` to the engine.
+
 #### Extra parameters
 
 The following extra parameters in the request object are supported:

--- a/tests/entrypoints/openai/responses/test_sampling_params.py
+++ b/tests/entrypoints/openai/responses/test_sampling_params.py
@@ -28,6 +28,7 @@ class TestResponsesRequestSamplingParams:
             temperature=0.8,
             top_p=0.95,
             top_k=50,
+            min_p=0.1,
             max_output_tokens=100,
         )
 
@@ -36,7 +37,19 @@ class TestResponsesRequestSamplingParams:
         assert sampling_params.temperature == 0.8
         assert sampling_params.top_p == 0.95
         assert sampling_params.top_k == 50
+        assert sampling_params.min_p == 0.1
         assert sampling_params.max_tokens == 100
+
+    def test_min_p_default(self):
+        """Test that min_p defaults to 0.0 when unset (parity with top_k)."""
+        request = ResponsesRequest(
+            model="test-model",
+            input="test input",
+        )
+
+        sampling_params = request.to_sampling_params(default_max_tokens=1000)
+
+        assert sampling_params.min_p == 0.0
 
     def test_extra_sampling_params(self):
         """Test extra sampling parameters are correctly mapped."""

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -171,6 +171,7 @@ class ResponsesRequest(OpenAIBaseModel):
     top_logprobs: int | None = 0
     top_p: float | None = None
     top_k: int | None = None
+    min_p: float | None = None
     truncation: Literal["auto", "disabled"] | None = "disabled"
     user: str | None = None
     skip_special_tokens: bool = True
@@ -337,6 +338,7 @@ class ResponsesRequest(OpenAIBaseModel):
         "temperature": 1.0,
         "top_p": 1.0,
         "top_k": 0,
+        "min_p": 0.0,
     }
 
     def to_sampling_params(
@@ -361,6 +363,10 @@ class ResponsesRequest(OpenAIBaseModel):
         if (top_k := self.top_k) is None:
             top_k = default_sampling_params.get(
                 "top_k", self._DEFAULT_SAMPLING_PARAMS["top_k"]
+            )
+        if (min_p := self.min_p) is None:
+            min_p = default_sampling_params.get(
+                "min_p", self._DEFAULT_SAMPLING_PARAMS["min_p"]
             )
 
         if (repetition_penalty := self.repetition_penalty) is None:
@@ -405,6 +411,7 @@ class ResponsesRequest(OpenAIBaseModel):
             temperature=temperature,
             top_p=top_p,
             top_k=top_k,
+            min_p=min_p,
             max_tokens=max_tokens,
             logprobs=self.top_logprobs if self.is_include_output_logprobs() else None,
             stop=stop,


### PR DESCRIPTION
## Purpose

The Responses API (`/v1/responses`) already exposes `top_k` as a request field
and forwards it to `SamplingParams`, but its natural companion `min_p` is
missing — even though `SamplingParams` (and `SamplingParams.from_optional`)
fully support it, and the Completions/Chat endpoints both expose it.

This adds the `min_p` field to `ResponsesRequest`, resolves its default
alongside `top_k` in `to_sampling_params`, and plumbs it through to
`SamplingParams.from_optional`, mirroring the existing `top_k` handling exactly.
Users of `/v1/responses` can now use min-p sampling like every other generation
endpoint.

**Not a duplicate:** searched open PRs/issues from several angles
(`responses min_p`, `ResponsesRequest min_p in:body`,
`responses/protocol.py min_p in:body`, `min_p in:title`, `responses API
sampling parameters`). `min_p` is entirely absent from
`responses/protocol.py` (no matches in the file), and no open PR adds sampling
parameters to the Responses API. PR #45839 adds sampling params to the separate
Translation API only; this change is orthogonal.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/entrypoints/openai/responses/test_sampling_params.py -v
pre-commit run --files \
  vllm/entrypoints/openai/responses/protocol.py \
  tests/entrypoints/openai/responses/test_sampling_params.py \
  docs/serving/online_serving/openai_compatible_server.md
```

Added a `min_p` assertion to `test_basic_sampling_params` and a new
`test_min_p_default` verifying the neutral default (`0.0`).

## Test Result

```
8 passed in 1.07s
```

`ruff check`, `ruff format`, and `mypy` all pass via pre-commit.

---

AI assistance disclosure: this PR was prepared with AI (Claude) assistance. I
have reviewed every changed line and ran the tests above myself.
