### PR TITLE
[Bugfix] Convert media fetch connection/DNS failures to HTTP 422

### DIFF
--- a/tests/multimodal/media/test_unprocessable_entity_error.py
+++ b/tests/multimodal/media/test_unprocessable_entity_error.py
@@ -12,12 +12,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
+import requests
 
 from vllm.entrypoints.serve.utils.error_response import create_error_response
 from vllm.exceptions import VLLMUnprocessableEntityError
 from vllm.multimodal.media import MediaConnector
 
 
+@pytest.mark.skip_global_cleanup
 class TestVLLMUnprocessableEntityError:
     """Tests for VLLMUnprocessableEntityError exception."""
 
@@ -40,6 +42,7 @@ class TestVLLMUnprocessableEntityError:
         assert isinstance(exc, ValueError)
 
 
+@pytest.mark.skip_global_cleanup
 class TestMediaConnectorErrorHandling:
     """Tests for MediaConnector error handling."""
 
@@ -64,7 +67,7 @@ class TestMediaConnectorErrorHandling:
 
     @pytest.mark.asyncio
     async def test_fetch_image_async_dns_error(self):
-        """DNS errors are transient and should remain as-is for retry."""
+        """DNS errors indicate an unreachable URL and should return 422."""
         connector = MediaConnector()
 
         with patch.object(
@@ -75,12 +78,12 @@ class TestMediaConnectorErrorHandling:
                 os_error=MagicMock(),
             )
 
-            with pytest.raises(aiohttp.ClientConnectorDNSError) as exc_info:
+            with pytest.raises(VLLMUnprocessableEntityError) as exc_info:
                 await connector.fetch_image_async(
                     "https://nonexistent.example/image.jpg"
                 )
 
-            assert isinstance(exc_info.value, aiohttp.ClientConnectorDNSError)
+            assert exc_info.value.parameter == "image_url"
 
     @pytest.mark.asyncio
     async def test_fetch_image_async_500_preserved(self):
@@ -121,20 +124,23 @@ class TestMediaConnectorErrorHandling:
             assert exc_info.value.parameter == "image_url"
 
     def test_fetch_image_connection_error(self):
-        """Connection errors are transient and should remain as-is for retry."""
+        """Connection errors indicate an unreachable URL and should return 422."""
         connector = MediaConnector()
 
         with patch.object(
             connector.connection, "get_bytes", new_callable=MagicMock
         ) as mock_get:
-            mock_get.side_effect = aiohttp.ClientConnectionError("Connection refused")
+            mock_get.side_effect = requests.exceptions.ConnectionError(
+                "Connection refused"
+            )
 
-            with pytest.raises(aiohttp.ClientConnectionError) as exc_info:
+            with pytest.raises(VLLMUnprocessableEntityError) as exc_info:
                 connector.fetch_image("https://example.com/image.jpg")
 
-            assert isinstance(exc_info.value, aiohttp.ClientConnectionError)
+            assert exc_info.value.parameter == "image_url"
 
 
+@pytest.mark.skip_global_cleanup
 class TestErrorResponse:
     """Tests for error response creation."""
 

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -56,19 +56,22 @@ def _wrap_media_fetch_error(
 ) -> VLLMUnprocessableEntityError | Exception:
     """Convert media fetch exceptions to VLLMUnprocessableEntityError.
 
-    This handles HTTP errors that indicate the media resource is invalid
-    (4xx responses except 408/429, malformed URLs) and converts them to a
-    422 Unprocessable Entity error instead of 500.
+    This handles errors that indicate the media URL is unreachable or the
+    resource cannot be processed (4xx responses except 408/429, client-side
+    connection failures including DNS and connection timeouts, malformed URLs)
+    and converts them to a 422 Unprocessable Entity error instead of 500.
 
-    Transient errors (5xx, 408, 429, DNS failures, connection errors,
-    timeouts) are returned as-is to allow retry logic to handle them
-    appropriately.
+    Server-side errors (5xx), server-side disconnects, read/operation timeouts,
+    and certain HTTP codes that are typically retryable (408, 429) are
+    returned as-is to allow retry logic or upstream handling to treat them as
+    server errors.
 
     Returns:
-        VLLMUnprocessableEntityError for permanent client errors (4xx except
-            408/429, invalid URL)
-        Original exception for transient errors (5xx, 408, 429, network blips)
-            or other exceptions
+        VLLMUnprocessableEntityError for client-side/unreachable URL errors
+            (4xx except 408/429, client-side connection/DNS failures, invalid
+            URL)
+        Original exception for server-side errors (5xx, 408, 429), server
+            disconnects, read/operation timeouts, or other exceptions
     """
     if isinstance(exc, aiohttp.ClientResponseError):
         if exc.status in (408, 429):
@@ -97,6 +100,24 @@ def _wrap_media_fetch_error(
     if isinstance(exc, requests.exceptions.InvalidURL):
         return VLLMUnprocessableEntityError(
             "Failed to fetch media from URL: Invalid URL format",
+            parameter="image_url",
+            value=url,
+        )
+
+    # Client-side connection failures from aiohttp (DNS, connection refused,
+    # connection timeout, SSL errors, etc.).
+    if isinstance(exc, aiohttp.ClientConnectorError):
+        return VLLMUnprocessableEntityError(
+            f"Failed to fetch media from URL: {exc}",
+            parameter="image_url",
+            value=url,
+        )
+
+    # Connection-level failures from requests (DNS, connection refused,
+    # connection timeout, etc.).
+    if isinstance(exc, requests.exceptions.ConnectionError):
+        return VLLMUnprocessableEntityError(
+            f"Failed to fetch media from URL: {exc}",
             parameter="image_url",
             value=url,
         )


### PR DESCRIPTION
## Purpose

Closes #47163.

`MediaConnector._wrap_media_fetch_error` already converted 4xx HTTP responses and
invalid URLs to HTTP 422, but it left client-side connection failures (DNS
resolution errors, connection refused, connection timeouts) as unwrapped
exceptions. Those exceptions bubble up to the API server as HTTP 500, even though
the problem is with the user-provided URL.

## Fix

Map `aiohttp.ClientConnectorError` and `requests.exceptions.ConnectionError` to
`VLLMUnprocessableEntityError`, so unreachable media URLs return HTTP 422
(`UnprocessableEntityError`) instead of HTTP 500.

Server-side errors (5xx), server-side disconnects, read/operation timeouts, and
retryable HTTP codes (408/429) are intentionally left as-is to preserve existing
retry/upstream handling.

## Why this is not duplicating an existing PR

Searched open PRs and issues for `47163`, `image_url 422`, `ClientConnectorError`,
`media fetch 500`, and `UnprocessableEntityError image_url`. No open PR addresses
this issue.

## Test plan

```bash
.venv/bin/python -m pytest tests/multimodal/media/test_unprocessable_entity_error.py -v
```

Result: 10 passed.

```bash
pre-commit run --files \
  vllm/multimodal/media/connector.py \
  tests/multimodal/media/test_unprocessable_entity_error.py
```

Result: all hooks passed.

## AI assistance disclosure

This PR was prepared with AI assistance. All changes have been reviewed by the
human submitter.
