### PR TITLE
fix(gemma4): force TRITON_ATTN when FA4 downgrades to FA2 for head_di…

### DIFF
--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -216,12 +216,30 @@ class Gemma4Config(VerifyAndUpdateConfig):
         if head_dim is None or global_head_dim is None or head_dim == global_head_dim:
             return
 
-        from vllm.v1.attention.backends.fa_utils import is_fa_version_supported
+        from vllm.v1.attention.backends.fa_utils import (
+            get_flash_attn_version,
+            is_fa_version_supported,
+        )
         from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
         max_head_dim = max(head_dim, global_head_dim)
 
-        if is_fa_version_supported(4) and max_head_dim <= 512:
+        # FA4 is only usable if it actually resolves to version 4 for this head
+        # dim. On SM100 (Blackwell) get_flash_attn_version() silently downgrades
+        # FA4 -> FA2 for head_size > 128 (TMEM limit), so a bare
+        # is_fa_version_supported(4) check is not enough: it would set
+        # flash_attn_version=4 but leave the backend unset, and generic backend
+        # selection then picks FlashInfer for the head_dim=512 global-attention
+        # layers -- which crashes (no trtllm-gen head_dim=512 decode cubin; the
+        # fa2 prefill fallback rejects 512). Gate on the *resolved* FA version so
+        # we force TRITON_ATTN whenever FA4 is not actually available for 512.
+        can_use_fa4 = (
+            is_fa_version_supported(4)
+            and max_head_dim <= 512
+            and get_flash_attn_version(head_size=max_head_dim) == 4
+        )
+
+        if can_use_fa4:
             if (
                 vllm_config.attention_config.flash_attn_version is None
                 and vllm_config.attention_config.backend
@@ -239,8 +257,9 @@ class Gemma4Config(VerifyAndUpdateConfig):
             vllm_config.attention_config.backend = AttentionBackendEnum.TRITON_ATTN
             logger.info(
                 "Gemma4 model has heterogeneous head dimensions "
-                "(head_dim=%d, global_head_dim=%d). FA4 not available, "
-                "forcing TRITON_ATTN backend.",
+                "(head_dim=%d, global_head_dim=%d). FA4 does not support "
+                "the required head dimensions on this device; forcing "
+                "TRITON_ATTN backend.",
                 head_dim,
                 global_head_dim,
             )


### PR DESCRIPTION


## Purpose

Fixes #48082.

Prevent `nvidia/Gemma-4-31B-IT-NVFP4` from crashing during engine
initialization on B200 when MTP speculative decoding is enabled.

Gemma 4 uses heterogeneous attention dimensions: 256 for sliding-attention
layers and 512 for global-attention layers. `Gemma4Config` intends to use one
backend for all layers: FA4 when it supports the model, otherwise
`TRITON_ATTN`.

The existing check considered FA4 usable when it was installed and the maximum
head dimension was at most 512:

```python
is_fa_version_supported(4) and max_head_dim <= 512
```

On SM100, this succeeds, but `get_flash_attn_version(head_size=512)` then
downgrades FA4 to FA2 because of FA4's TMEM limit. `Gemma4Config` consequently
sets `flash_attn_version=4` while leaving the backend unset. Generic backend
selection can then choose FlashInfer for the 512-wide global-attention layers.

With six speculative tokens, this model selects an unavailable TRTLLM-Gen
decode specialization:

```text
headDimQk=512
headDimV=512
tileSizeQ=64
tileSizeKv=128
numTokensPerPage=32
```

CUDA-graph capture fails before the server becomes ready:

```text
RuntimeError: loadKernel ... Trtllm-gen kernels not found:
  ... headDimQk=512, headDimV=512,
  tileSizeQ=64, tileSizeKv=128,
  numTokensPerPage=32 ...
```

This change gates the FA4 path on the version that resolves for the model's
actual maximum head dimension:

```python
can_use_fa4 = (
    is_fa_version_supported(4)
    and max_head_dim <= 512
    and get_flash_attn_version(head_size=max_head_dim) == 4
)
```

When FA4 does not resolve to version 4 and the user has not selected an
attention backend, the existing fallback now forces `TRITON_ATTN`.

The change is model-scoped and preserves existing behavior elsewhere:

- Platforms and head dimensions where FA4 resolves to version 4 still use
  FA4.
- Explicit user backend choices are not overridden.
- FlashInfer's generic `head_size=512` capability remains unchanged for
  configurations it supports.

FlashInfer supports some 512-wide configurations through
[flashinfer#2959](https://github.com/flashinfer-ai/flashinfer/pull/2959), but
not this exact MTP specialization. The checkpoint has NVFP4 weights, while the
failing attention path uses FP8 KV cache.

Duplicate-work check: no open upstream PR implements this Gemma 4
FA4-resolution fix. [#43257](https://github.com/vllm-project/vllm/pull/43257)
is a complementary Triton optimization; [#46329](https://github.com/vllm-project/vllm/pull/46329)
targets NVFP4 KV on SM120/SM121; and [#47118](https://github.com/vllm-project/vllm/pull/47118)
is a draft text/multimodal dual-backend design. Related
[#40677](https://github.com/vllm-project/vllm/issues/40677) concerns SM120
with an explicitly forced FlashInfer backend, whereas this fix addresses
SM100/B200 automatic selection after FA4 downgrades to FA2.

## Test Plan

Reproduce and validate on one B200 without an explicit attention backend:

```bash
vllm serve nvidia/Gemma-4-31B-IT-NVFP4 \
  --quantization modelopt \
  --tensor-parallel-size 1 \
  --no-enable-prefix-caching \
  --speculative-config \
    '{"model":"google/gemma-4-31B-it-assistant","num_speculative_tokens":6}' \
  --host 0.0.0.0 \
  --port 8000
```

Validate that:

1. On SM100, when FA4 resolves to FA2 for `global_head_dim=512`, Gemma 4
   selects `TRITON_ATTN`.
2. The server initializes and completes an ISL 5000 / OSL 500 request.
3. GSM8K remains unchanged from the baseline.
4. Platforms where FA4 resolves to version 4 and explicit user backend
   selections retain their existing behavior.

## Test Result

Hardware validation was performed on one B200 using vLLM
nightly `0.23.1rc1.dev925+g2afa3f7e9`.

- Before: engine initialization failed during MTP CUDA-graph capture with the
  missing TRTLLM-Gen cubin error.
- After, without `--attention-backend`: `Gemma4Config` reported that FA4 did
  not support the required head dimensions and forced `TRITON_ATTN`.
- The server initialized and completed an ISL 5000 / OSL 500 request with
  coherent output.
- GSM8K remained at 0.657 strict / 0.666 flexible.

Local results:

```text
.venv/bin/pre-commit run ruff-check --files \
  vllm/model_executor/models/config.py
# Passed

.venv/bin/pre-commit run ruff-format --files \
  vllm/model_executor/models/config.py
# Passed

git diff --check
# Passed
```

The commit-time pre-commit suite also passed, including Ruff, mypy, typos,
SPDX validation, configuration validation, and attention-backend documentation
validation. Targeted pytest was not runnable in the local checkout because the
existing `.venv` does not have `pytest` or `torch` installed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. No documentation update is needed because model support and user-facing configuration are unchanged.
</details>

