### PR TITLE
Fix GLM47 required tool call parsing

### DIFF
--- a/tests/tool_parsers/test_glm47_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm47_moe_tool_parser.py
@@ -92,6 +92,39 @@ def namespace_tool_request() -> ResponsesRequest:
 
 
 class TestGlm47ExtractToolCalls:
+    def test_required_skips_structured_outputs_chatcompletion(
+        self, glm47_tool_parser, sample_tools
+    ):
+        request = ChatCompletionRequest(
+            messages=[],
+            model="glm-test",
+            tools=sample_tools,
+            tool_choice="required",
+        )
+
+        adjusted = glm47_tool_parser.adjust_request(request)
+
+        assert adjusted.structured_outputs is None
+        assert adjusted.skip_special_tokens is False
+
+    def test_named_skips_structured_outputs_chatcompletion(
+        self, glm47_tool_parser, sample_tools
+    ):
+        request = ChatCompletionRequest(
+            messages=[],
+            model="glm-test",
+            tools=sample_tools,
+            tool_choice={
+                "type": "function",
+                "function": {"name": "get_weather"},
+            },
+        )
+
+        adjusted = glm47_tool_parser.adjust_request(request)
+
+        assert adjusted.structured_outputs is None
+        assert adjusted.skip_special_tokens is False
+
     def test_namespace_tool_call_round_trip_to_responses_output(
         self, glm47_tokenizer, namespace_tool_request
     ):

--- a/vllm/tool_parsers/glm47_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm47_moe_tool_parser.py
@@ -3,9 +3,28 @@
 
 from __future__ import annotations
 
+from openai.types.responses import ToolChoiceFunction
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedToolChoiceParam,
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.parser.engine.registered_adapters import Glm47MoeParserToolAdapter
 
 
 class Glm47MoeModelToolParser(Glm47MoeParserToolAdapter):  # type: ignore[valid-type, misc]
     supports_required_and_named = False
     structural_tag_model = "glm_4_7"
+
+    def adjust_request(
+        self, request: ChatCompletionRequest | ResponsesRequest
+    ) -> ChatCompletionRequest | ResponsesRequest:
+        if request.tools:
+            tc = request.tool_choice
+            if tc == "required" or isinstance(
+                tc, (ChatCompletionNamedToolChoiceParam, ToolChoiceFunction)
+            ):
+                request.skip_special_tokens = False
+                return request
+        return super().adjust_request(request)


### PR DESCRIPTION
## Purpose

  Fixes #48095.

  GLM-5.2 / GLM-4.7-style tool calls can leak raw `<tool_call>...` text into `message.content` with empty `message.tool_calls` when
  `tool_choice="required"` is used with the `glm47` tool parser.

  The issue is that `Glm47MoeModelToolParser` declares `supports_required_and_named = False`, so required/named tool choices should
  fall back to the model-native parser. However, the base `ToolParser.adjust_request()` still installs JSON `structured_outputs`
  for forced tool choices, which conflicts with GLM's native XML-like tool-call format.

  ## Changes

  - Override `Glm47MoeModelToolParser.adjust_request()`.
  - For `tool_choice="required"` and named tool choices, skip the base JSON structured-output constraint.
  - Preserve `skip_special_tokens=False` so GLM native tool-call markers remain visible to the parser.
  - Add regression coverage for Chat Completions `required` and named tool choices.

  ## Duplicate-work check

  Checked open PRs:
  - No open PR directly references #48095.
  - Related PRs exist: #47175 and #47146.

  This PR is materially different from those approaches: it keeps GLM forced tool choices on the native XML-like parser path by
  avoiding conflicting JSON `structured_outputs`, matching the existing pattern used by native-format parsers such as Gemma4/
  Poolside. It does not change the GLM `supports_required_and_named` flag or add a JSON-schema forced-call path.

  ## Testing

  Passed:
  - `.venv/bin/python -m py_compile vllm/tool_parsers/glm47_moe_tool_parser.py tests/tool_parsers/test_glm47_moe_tool_parser.py`
  - Minimal local parser validation with `/mnt/data1/models/zai-org/GLM-5.2-FP8`
  - `VLLM_ENFORCE_STRICT_TOOL_CALLING=0` full `ParserManager(glm47 + glm45)` validation: `structured_outputs` remains `None`
  - `git diff --check`