### PR TITLE
fix(speech_to_text): use real per-chunk offsets for segment timestamps

### DIFF
--- a/docs/contributing/model/transcription.md
+++ b/docs/contributing/model/transcription.md
@@ -195,7 +195,7 @@ Provide a fast duration→token estimate to improve streaming usage statistics:
 The API server takes care of basic audio I/O and optional chunking before building prompts:
 
 - Resampling: Input audio is resampled to `SpeechToTextConfig.sample_rate` using `AudioResampler`.
-- Chunking: If `SpeechToTextConfig.allow_audio_chunking` is True and the duration exceeds `max_audio_clip_s`, the server splits the audio into overlapping chunks and generates a prompt per chunk. Overlap is controlled by `overlap_chunk_second`.
+- Chunking: If `SpeechToTextConfig.allow_audio_chunking` is True and the duration exceeds `max_audio_clip_s`, the server splits the audio into non-overlapping chunks and generates a prompt per chunk. `overlap_chunk_second` is *not* an audio overlap; it is the search window used to locate a quiet (low-energy) split point near each chunk boundary. The real start time of each chunk is reported via the per-chunk offsets returned by `split_audio`.
 - Energy-aware splitting: When `min_energy_split_window_size` is set, the server finds low-energy regions to minimize cutting within words.
 
 Relevant server logic:

--- a/docs/features/multimodal_inputs.md
+++ b/docs/features/multimodal_inputs.md
@@ -369,13 +369,15 @@ from vllm.multimodal.media.audio import load_audio
 audio, sr = load_audio("long_audio.wav", sr=16000)
 
 # Split into chunks at low-energy (quiet) regions
-chunks = split_audio(
+chunks, offsets = split_audio(
     audio_data=audio,
     sample_rate=sr,
     max_clip_duration_s=30.0,      # Maximum chunk length in seconds
     overlap_duration_s=1.0,         # Search window for finding quiet split points
     min_energy_window_size=1600,    # Window size for energy calculation (~100ms at 16kHz)
 )
+# ``offsets`` gives the real start time (in seconds) of each chunk in the
+# original audio; chunks are split at quiet points, not at even boundaries.
 
 # Initialize Whisper model
 llm = LLM(model="openai/whisper-large-v3-turbo")

--- a/tests/entrypoints/speech_to_text/transcription/test_transcription_inter_chunk_spacing.py
+++ b/tests/entrypoints/speech_to_text/transcription/test_transcription_inter_chunk_spacing.py
@@ -342,7 +342,9 @@ async def test_create_transcription_non_streaming_joins_chunks_by_language():
     models.lora_requests = {}
     models.is_base_model.return_value = True
 
-    preprocess_mock = AsyncMock(return_value=([MagicMock(), MagicMock()], 1.0))
+    preprocess_mock = AsyncMock(
+        return_value=([MagicMock(), MagicMock()], [0.0, 5.0], 1.0)
+    )
 
     with (
         patch(

--- a/tests/multimodal/test_audio.py
+++ b/tests/multimodal/test_audio.py
@@ -621,7 +621,7 @@ class TestAudioChunking:
         # 10 seconds of audio at 16kHz
         audio = np.linspace(-1.0, 1.0, 160000, dtype=np.float32)
 
-        chunks = split_audio(
+        chunks, offsets = split_audio(
             audio_data=audio,
             sample_rate=16000,
             max_clip_duration_s=30.0,
@@ -629,6 +629,7 @@ class TestAudioChunking:
             min_energy_window_size=1600,
         )
 
+        assert offsets[0] == 0.0
         assert len(chunks) == 1
         np.testing.assert_array_equal(chunks[0], audio)
 
@@ -638,7 +639,7 @@ class TestAudioChunking:
         # Exactly 30 seconds at 16kHz
         audio = np.linspace(-1.0, 1.0, 480000, dtype=np.float32)
 
-        chunks = split_audio(
+        chunks, offsets = split_audio(
             audio_data=audio,
             sample_rate=16000,
             max_clip_duration_s=30.0,
@@ -655,7 +656,7 @@ class TestAudioChunking:
         # 65 seconds of audio at 16kHz
         audio = np.linspace(-1.0, 1.0, 1040000, dtype=np.float32)
 
-        chunks = split_audio(
+        chunks, offsets = split_audio(
             audio_data=audio,
             sample_rate=16000,
             max_clip_duration_s=30.0,
@@ -675,7 +676,7 @@ class TestAudioChunking:
         # 65 seconds of audio at 16kHz
         audio = np.linspace(-1.0, 1.0, 1040000, dtype=np.float32)
 
-        chunks = split_audio(
+        chunks, offsets = split_audio(
             audio_data=audio,
             sample_rate=16000,
             max_clip_duration_s=30.0,
@@ -749,7 +750,7 @@ class TestAudioChunking:
 
         audio = np.arange(1120000, dtype=np.float32)  # 70s at 16kHz
 
-        chunks = split_audio(
+        chunks, offsets = split_audio(
             audio_data=audio,
             sample_rate=16000,
             max_clip_duration_s=30.0,
@@ -759,6 +760,13 @@ class TestAudioChunking:
 
         assert chunks[0][0] == audio[0]
         assert chunks[-1][-1] == audio[-1]
+        # Offsets must be the actual start time (samples / sample_rate) of each
+        # chunk, not an evenly-spaced nominal ``idx * max_clip_duration_s``.
+        assert offsets[0] == 0.0
+        assert len(offsets) == len(chunks)
+        for chunk, offset in zip(chunks, offsets):
+            start_sample = int(round(offset * 16000))
+            assert chunk[0] == audio[start_sample]
 
     def test_find_split_point_nan_input(self):
         """find_split_point must not return 0 for all-NaN input."""
@@ -783,7 +791,7 @@ class TestAudioChunking:
         # 31 seconds of NaN at 16kHz — longer than max_clip_duration_s
         nan_audio = np.full(16000 * 31, float("nan"), dtype=np.float32)
 
-        chunks = split_audio(
+        chunks, offsets = split_audio(
             audio_data=nan_audio,
             sample_rate=16000,
             max_clip_duration_s=30.0,
@@ -802,7 +810,7 @@ class TestAudioChunking:
         # 40 seconds at 8kHz
         audio_8k = np.linspace(-1.0, 1.0, 320000, dtype=np.float32)
 
-        chunks = split_audio(
+        chunks, offsets = split_audio(
             audio_data=audio_8k,
             sample_rate=8000,
             max_clip_duration_s=30.0,

--- a/vllm/entrypoints/speech_to_text/base/serving.py
+++ b/vllm/entrypoints/speech_to_text/base/serving.py
@@ -163,7 +163,7 @@ class SpeechToTextBaseServing(GenerateBaseServing):
     def _decode_and_chunk_speech(
         self,
         audio_data: bytes,
-    ) -> tuple[list[np.ndarray], float]:
+    ) -> tuple[list[np.ndarray], list[float], float]:
         # Decode audio bytes.  For container formats (MP4, M4A, WebM) that
         # soundfile cannot detect from a BytesIO stream, _load_audio_bytes
         # transparently falls back to ffmpeg via an in-memory fd.
@@ -189,10 +189,11 @@ class SpeechToTextBaseServing(GenerateBaseServing):
 
         if not do_split_audio:
             chunks = [y]
+            chunk_offsets = [0.0]
         else:
             assert self.asr_config.max_audio_clip_s is not None
             assert self.asr_config.min_energy_split_window_size is not None
-            chunks = split_audio(
+            chunks, chunk_offsets = split_audio(
                 audio_data=y,
                 sample_rate=int(sr),
                 max_clip_duration_s=self.asr_config.max_audio_clip_s,
@@ -200,7 +201,7 @@ class SpeechToTextBaseServing(GenerateBaseServing):
                 min_energy_window_size=self.asr_config.min_energy_split_window_size,
             )
 
-        return chunks, duration
+        return chunks, chunk_offsets, duration
 
     async def _detect_language(
         self,
@@ -258,7 +259,7 @@ class SpeechToTextBaseServing(GenerateBaseServing):
         request: SpeechToTextRequest,
         audio_data: bytes,
         request_id: str,
-    ) -> tuple[list[EngineInput], float]:
+    ) -> tuple[list[EngineInput], list[float], float]:
         # Validate request
         request.language = self.model_cls.validate_language(request.language)
         request.to_language = (
@@ -275,7 +276,9 @@ class SpeechToTextBaseServing(GenerateBaseServing):
             )
 
         # Run cpu intensive preprocess step in a separate thread pool executor.
-        chunks, duration = await self._decode_and_chunk_speech_async(audio_data)
+        chunks, chunk_offsets, duration = await self._decode_and_chunk_speech_async(
+            audio_data
+        )
 
         if request.language is None and getattr(
             self.model_cls, "supports_explicit_language_detection", False
@@ -306,7 +309,7 @@ class SpeechToTextBaseServing(GenerateBaseServing):
 
         engine_inputs = await self.renderer.render_cmpl_async(parsed_prompts)
 
-        return engine_inputs, duration
+        return engine_inputs, chunk_offsets, duration
 
     def _preprocess_verbose_prompt(self, prompt: EncoderDecoderDictPrompt):
         dec_prompt = prompt["decoder_prompt"]
@@ -467,7 +470,7 @@ class SpeechToTextBaseServing(GenerateBaseServing):
 
         lora_request = self._maybe_get_adapters(request)
 
-        engine_inputs, duration_s = await self._preprocess_speech_to_text(
+        engine_inputs, chunk_offsets, duration_s = await self._preprocess_speech_to_text(
             request=request,
             audio_data=audio_data,
             request_id=request_id,
@@ -589,9 +592,11 @@ class SpeechToTextBaseServing(GenerateBaseServing):
                 )
             result_generator = merge_async_iterators(*list_result_generator)
             async for idx, op in result_generator:
-                start_time = (
-                    float(idx * chunk_size_in_s) if chunk_size_in_s is not None else 0.0
-                )
+                # Use the real start offset of each chunk within the original
+                # audio. Chunks are split at low-energy points (up to
+                # ``overlap_chunk_second`` earlier than the nominal boundary),
+                # so ``idx * chunk_size_in_s`` drifts from the true offset.
+                start_time = chunk_offsets[idx]
                 if request.response_format == "verbose_json":
                     assert op.outputs[0].logprobs
                     segments: list[SpeechToTextSegment] = self._get_verbose_segments(

--- a/vllm/entrypoints/speech_to_text/base/serving.py
+++ b/vllm/entrypoints/speech_to_text/base/serving.py
@@ -367,7 +367,7 @@ class SpeechToTextBaseServing(GenerateBaseServing):
         Note: No_speech_prob field is not supported
         in this implementation and will be None. See docs for details.
         """
-        BASE_OFFSET = 0.02
+        base_offset = 0.02
         init_token = self.tokenizer.encode("<|0.00|>", add_special_tokens=False)[0]
         if tokens[-1] == self.tokenizer.eos_token_id:
             tokens = tokens[:-1]
@@ -395,8 +395,8 @@ class SpeechToTextBaseServing(GenerateBaseServing):
                     segment_class(
                         id=len(segments),
                         seek=start_time,
-                        start=start_time + BASE_OFFSET * start_timestamp,
-                        end=start_time + BASE_OFFSET * end_timestamp,
+                        start=start_time + base_offset * start_timestamp,
+                        end=start_time + base_offset * end_timestamp,
                         temperature=request.temperature,
                         text=text,
                         # The compression ratio measures

--- a/vllm/entrypoints/speech_to_text/base/serving.py
+++ b/vllm/entrypoints/speech_to_text/base/serving.py
@@ -470,7 +470,11 @@ class SpeechToTextBaseServing(GenerateBaseServing):
 
         lora_request = self._maybe_get_adapters(request)
 
-        engine_inputs, chunk_offsets, duration_s = await self._preprocess_speech_to_text(
+        (
+            engine_inputs,
+            chunk_offsets,
+            duration_s,
+        ) = await self._preprocess_speech_to_text(
             request=request,
             audio_data=audio_data,
             request_id=request_id,

--- a/vllm/multimodal/audio.py
+++ b/vllm/multimodal/audio.py
@@ -328,12 +328,18 @@ def split_audio(
     max_clip_duration_s: float,
     overlap_duration_s: float,
     min_energy_window_size: int,
-) -> list[np.ndarray]:
+) -> tuple[list[np.ndarray], list[float]]:
     """Split audio into chunks with intelligent split points.
 
     Splits long audio into smaller chunks at low-energy regions to minimize
     cutting through speech. Uses overlapping windows to find quiet moments
     for splitting.
+
+    The split points are chosen dynamically (at the quietest point within a
+    search window), so a chunk's actual start in the original audio is not
+    always ``index * max_clip_duration_s``. Callers that report
+    chunk-relative timestamps (e.g. segment timestamps) must use the returned
+    per-chunk offsets rather than assuming evenly spaced chunks.
 
     Args:
         audio_data: Audio array to split. Can be 1D (mono) or multi-dimensional.
@@ -345,12 +351,14 @@ def split_audio(
         min_energy_window_size: Window size in samples for finding low-energy regions.
 
     Returns:
-        List of audio chunks. Each chunk is a numpy array with the same shape
-        as the input except for the last (time) dimension.
+        A tuple of ``(chunks, offsets)``. ``chunks`` is a list of audio chunks,
+        each a numpy array with the same shape as the input except for the last
+        (time) dimension. ``offsets`` is a list of the same length giving the
+        start time (in seconds) of each chunk within the original audio.
 
     Example:
         >>> audio = np.random.randn(1040000)  # 65 seconds at 16kHz
-        >>> chunks = split_audio(
+        >>> chunks, offsets = split_audio(
         ...     audio_data=audio,
         ...     sample_rate=16000,
         ...     max_clip_duration_s=30.0,
@@ -359,16 +367,20 @@ def split_audio(
         ... )
         >>> len(chunks)
         3
+        >>> offsets[0]
+        0.0
     """
     chunk_size = int(sample_rate * max_clip_duration_s)
     overlap_size = int(sample_rate * overlap_duration_s)
     chunks = []
+    offsets: list[float] = []
     i = 0
 
     while i < audio_data.shape[-1]:
         if i + chunk_size >= audio_data.shape[-1]:
             # Handle last chunk - take everything remaining
             chunks.append(audio_data[..., i:])
+            offsets.append(i / sample_rate)
             break
 
         # Find the best split point in the overlap region
@@ -385,9 +397,10 @@ def split_audio(
 
         # Extract chunk up to the split point
         chunks.append(audio_data[..., i:split_point])
+        offsets.append(i / sample_rate)
         i = split_point
 
-    return chunks
+    return chunks, offsets
 
 
 def find_split_point(

--- a/vllm/multimodal/audio.py
+++ b/vllm/multimodal/audio.py
@@ -211,10 +211,10 @@ def resample_audio_pyav(
     # libswresample requires a minimum number of input samples to produce
     # output frames; pad short inputs with zeros so we always get output,
     # then trim to the expected output length.
-    _MIN_SAMPLES = 1024
+    _min_samples = 1024
     audio_f32 = np.asarray(audio, dtype=np.float32)
-    if len(audio_f32) < _MIN_SAMPLES:
-        audio_f32 = np.pad(audio_f32, (0, _MIN_SAMPLES - len(audio_f32)))
+    if len(audio_f32) < _min_samples:
+        audio_f32 = np.pad(audio_f32, (0, _min_samples - len(audio_f32)))
     audio_f32 = audio_f32.reshape(1, -1)
 
     resampler = av.AudioResampler(format="fltp", layout="mono", rate=target_sr_int)


### PR DESCRIPTION
fix(speech_to_text): use real per-chunk offsets for segment timestamps

The `split_audio` function splits audio at low-energy points up to 1s before the nominal boundary, so chunk offsets drift and accumulate (e.g., a 60s clip yields real offsets `[0.0, 29.8, 58.8]` vs old assumed `[0.0, 30.0, 60.0]`).

- `vllm/multimodal/audio.py`: `split_audio` now returns `(chunks, offsets)` with real per-chunk start times.
- `vllm/entrypoints/speech_to_text/base/serving.py`: uses `chunk_offsets[idx]` instead of `idx * chunk_size_in_s`.

The offset logic is verified in isolation (correct offsets, `find_split_point` at quiet region). The repo's full test suite could not be executed in the authoring environment due to missing deps (`tblib`, `pybase64`), so CI is the real gate on the renamed-signature test updates.

DCO: Signed-off-by included.