### PR TITLE
[XPU] Make W8A8 FP8 weights contiguous after loading

### DIFF
--- a/tests/kernels/quantization/test_xpu_fp8_scaled_mm.py
+++ b/tests/kernels/quantization/test_xpu_fp8_scaled_mm.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.kernels.linear.scaled_mm.xpu import XPUW8A8FP8LinearKernel
+
+
+def _make_xpu_w8a8_kernel(out_features: int, in_features: int):
+    kernel = object.__new__(XPUW8A8FP8LinearKernel)
+    kernel.config = SimpleNamespace(weight_shape=(out_features, in_features))
+    return kernel
+
+
+def _make_layer(weight: torch.Tensor, out_features: int, in_features: int):
+    layer = torch.nn.Module()
+    layer.input_size_per_partition = in_features
+    layer.output_size_per_partition = out_features
+    layer.weight = torch.nn.Parameter(weight, requires_grad=False)
+    layer.weight_scale = torch.nn.Parameter(
+        torch.ones(out_features, dtype=torch.float32), requires_grad=False
+    )
+    return layer
+
+
+@pytest.mark.parametrize(
+    ("weight", "expected"),
+    [
+        pytest.param(
+            torch.arange(15, dtype=torch.float32).reshape(3, 5),
+            torch.arange(15, dtype=torch.float32).reshape(3, 5).t().contiguous(),
+            id="checkpoint_nk",
+        ),
+        pytest.param(
+            torch.arange(15, dtype=torch.float32).reshape(3, 5).t(),
+            torch.arange(15, dtype=torch.float32).reshape(3, 5).t().contiguous(),
+            id="already_transposed_view",
+        ),
+        pytest.param(
+            torch.arange(15, dtype=torch.float32).reshape(3, 5).t().contiguous(),
+            torch.arange(15, dtype=torch.float32).reshape(3, 5).t().contiguous(),
+            id="already_kn_contiguous",
+        ),
+    ],
+)
+def test_xpu_w8a8_process_weights_makes_kn_weight_contiguous(
+    weight: torch.Tensor, expected: torch.Tensor
+):
+    kernel = _make_xpu_w8a8_kernel(out_features=3, in_features=5)
+    layer = _make_layer(weight, out_features=3, in_features=5)
+
+    kernel.process_weights_after_loading(layer)
+
+    assert layer.weight.shape == (5, 3)
+    assert layer.weight.is_contiguous()
+    assert torch.equal(layer.weight, expected)
+
+
+@pytest.mark.parametrize(
+    ("weight", "expected"),
+    [
+        pytest.param(
+            torch.arange(16, dtype=torch.float32).reshape(4, 4),
+            torch.arange(16, dtype=torch.float32).reshape(4, 4).t().contiguous(),
+            id="square_checkpoint_contiguous",
+        ),
+        pytest.param(
+            torch.arange(16, dtype=torch.float32).reshape(4, 4).t(),
+            torch.arange(16, dtype=torch.float32).reshape(4, 4).t().contiguous(),
+            id="square_transposed_view",
+        ),
+    ],
+)
+def test_xpu_w8a8_process_weights_disambiguates_square_weight_layout(
+    weight: torch.Tensor, expected: torch.Tensor
+):
+    kernel = _make_xpu_w8a8_kernel(out_features=4, in_features=4)
+    layer = _make_layer(weight, out_features=4, in_features=4)
+
+    kernel.process_weights_after_loading(layer)
+
+    assert layer.weight.shape == (4, 4)
+    assert layer.weight.is_contiguous()
+    assert torch.equal(layer.weight, expected)

--- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
@@ -91,6 +91,8 @@ class XPUW8A8FP8LinearKernel(FP8ScaledMMLinearKernel):
 
         needs_transpose = w.shape == (N, K) if K != N else w.is_contiguous()
         layer_weight = w.t() if needs_transpose else w
+        if not layer_weight.is_contiguous():
+            layer_weight = layer_weight.contiguous()
         replace_parameter(layer, "weight", layer_weight)
         ws = layer.weight_scale
         if ws.numel() == 1:


### PR DESCRIPTION
## Purpose

Fixes #48058.

The XPU W8A8 FP8 linear kernel documents that `fp8_gemm` consumes a
C-contiguous `[K, N]` weight tensor after loading. Checkpoint weights arrive as
`[N, K]`, but the post-load path only transposed them into a non-contiguous
view. That made the tensor shape look correct while leaving the stride layout
incompatible with the kernel's own layout assumption.

This change makes the processed XPU W8A8 FP8 weight contiguous after the
transpose, while preserving already-correct `[K, N]` contiguous weights.

Duplicate-work check: I did not find an open PR that mentions #48058 or
directly fixes `XPUW8A8FP8LinearKernel.process_weights_after_loading`. Nearby
open PRs #47103 and #47205 target block-scaled GEMM and Triton scaled_mm,
respectively, not this W8A8 post-load weight layout.

## Test Plan

- Add a CPU-only unit test for the XPU W8A8 FP8 weight preprocessing contract.
- Cover checkpoint `[N, K]`, already-transposed view, already-contiguous
  `[K, N]`, and square-weight ambiguity cases.
- Run targeted lint/format checks for the touched files.
- Full XPU serving validation with Intel Arc Pro B70 / Battlemage was not run
  locally.

## Test Result

- `.venv/bin/python -m pytest tests/kernels/quantization/test_xpu_fp8_scaled_mm.py -v`
  -> 5 passed
- `.venv/bin/pre-commit run ruff-check --files vllm/model_executor/kernels/linear/scaled_mm/xpu.py tests/kernels/quantization/test_xpu_fp8_scaled_mm.py`
  -> Passed
- `.venv/bin/pre-commit run ruff-format --files vllm/model_executor/kernels/linear/scaled_mm/xpu.py tests/kernels/quantization/test_xpu_fp8_scaled_mm.py`
  -> Passed
