### PR TITLE
[bugfix] bge-m3-sparse-plugin mismatch requests

### DIFF
--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
@@ -3,9 +3,8 @@
 
 from collections.abc import Sequence
 
-from vllm.config import ModelConfig, PoolerConfig, VllmConfig
+from vllm.config import PoolerConfig, VllmConfig
 from vllm.entrypoints.openai.engine.protocol import UsageInfo
-from vllm.entrypoints.pooling.base.protocol import EmbedRequestMixin
 from vllm.inputs import PromptType
 from vllm.outputs import PoolingRequestOutput
 from vllm.plugins.io_processors.interface import IOProcessor
@@ -14,7 +13,6 @@ from vllm.renderers import BaseRenderer
 from vllm.tokenizers.detokenizer_utils import convert_ids_list_to_tokens
 
 from .types import (
-    EMBED_TASKS,
     SparseEmbeddingCompletionRequestMixin,
     SparseEmbeddingResponse,
     SparseEmbeddingResponseData,
@@ -38,7 +36,6 @@ class BgeM3SparseEmbeddingsProcessor(
                     continue
                 self.default_pooling_params[param] = getattr(pooler_config, param)
         self.embed_dimensions = vllm_config.model_config.embedding_size
-        self.embed_request_queue: list[EmbedRequestMixin] = []
 
     def __repr__(self) -> str:
         return (
@@ -56,44 +53,9 @@ class BgeM3SparseEmbeddingsProcessor(
         # refer to PoolingCompletionRequest.to_pooling_params
         # set and verify pooling params
         params.skip_reading_prefix_cache = True
-
-        raw_embed_request = self.embed_request_queue.pop(0)
-        if raw_embed_request.embed_task not in EMBED_TASKS:
-            raise ValueError(
-                f"Unsupported task {raw_embed_request}, "
-                f"Supported tasks are {EMBED_TASKS}"
-            )
         params.task = "embed&token_classify"
-        params.use_activation = raw_embed_request.use_activation
-        if params.use_activation is None:
-            params.use_activation = True
-
-        params.dimensions = raw_embed_request.dimensions
-
-        model_config: ModelConfig = self.vllm_config.model_config
-        for param in self.default_pooling_params:
-            if getattr(params, param, None) is None:
-                setattr(params, param, self.default_pooling_params[param])
-
-        if params.dimensions is not None:
-            if not model_config.is_matryoshka:
-                raise ValueError(
-                    f'Model "{model_config.served_model_name}" does not '
-                    f"support matryoshka representation, "
-                    f"changing output dimensions will lead to poor results."
-                )
-
-            mds = model_config.matryoshka_dimensions
-            if mds is not None:
-                if params.dimensions not in mds:
-                    raise ValueError(
-                        f"Model {model_config.served_model_name!r} "
-                        f"only supports {str(mds)} matryoshka dimensions, "
-                        f"use other output dimensions will "
-                        f"lead to poor results."
-                    )
-            elif params.dimensions < 1:
-                raise ValueError("Dimensions must be greater than 0")
+        params.use_activation = True
+        params.dimensions = self.embed_dimensions
         return params
 
     def parse_request(
@@ -113,10 +75,8 @@ class BgeM3SparseEmbeddingsProcessor(
         if request_id is not None:
             assert request_id not in self.online_requests, "request_id duplicated"
             self.online_requests[request_id] = prompt
-            self.embed_request_queue.extend(prompt.to_embed_requests_online())
         else:
             self.offline_requests.append(prompt)
-            self.embed_request_queue.extend(prompt.to_embed_requests_offline())
         return prompt.input
 
     def _get_sparse_embedding_request(self, request_id: str | None = None):
@@ -157,11 +117,7 @@ class BgeM3SparseEmbeddingsProcessor(
         raw_request = self._get_sparse_embedding_request(request_id)
         has_dense_embed = raw_request.embed_task in ["dense", "dense&sparse"]
         has_sparse_embed = raw_request.embed_task in ["sparse", "dense&sparse"]
-        embed_dimensions = (
-            self.embed_dimensions
-            if raw_request.dimensions is None
-            else raw_request.dimensions
-        )
+        embed_dimensions = self.embed_dimensions
         for idx in range(len(model_output)):
             mo = model_output[idx]
             sparse_embedding_dict: dict[int, float] = {}


### PR DESCRIPTION

<!-- markdownlint-disable -->
Fix bugs in `bge_m3_sparse_plugin`. 

## Purpose
When serving `bge-m3` with `bge_m3_sparse_plugin`,  the plugin update pooling_parameters by request, and request is fetched via `embed_request_queue.pop(0)`. 
1. A bad request  (e.g. request input exceeds model max context length) with embed_task set to `dense` arrived,  the render returned an error, but there's no chance to remove this request from `embed_request_queue`.  
2. A good request with embed_task set to `dense&sparse` arrives to `bge_m3_sparse_plugin`, `merge_pooling_params` will use the bad request as `raw_request`. As a result, the second request will only return dense embeddings, which is not as expected. 

## Test Plan
Test via unit test `test_bge_m3_sparse_io_processor_plugins.py`. 
## Test Result
All passed. 
```
============================================================ test session starts ============================================================
platform linux -- Python 3.10.16, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/local/workspace/augusto.yjh/vllm
configfile: pyproject.toml
plugins: anyio-4.14.1, asyncio-1.4.0
asyncio: mode=strict, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 5 items

test_bge_m3_sparse_io_processor_plugins.py .....                                                                                      [100%]

============================================================= warnings summary ==============================================================
<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../../../../../../../opt/conda/envs/vllm/lib/python3.10/site-packages/torch/jit/_script.py:365: 14 warnings
  /opt/conda/envs/vllm/lib/python3.10/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/plugins_tests/test_bge_m3_sparse_io_processor_plugins.py::test_bge_m3_sparse_plugin_offline[True]
tests/plugins_tests/test_bge_m3_sparse_io_processor_plugins.py::test_bge_m3_sparse_plugin_offline[False]
tests/plugins_tests/test_bge_m3_sparse_io_processor_plugins.py::test_bge_m3_sparse_plugin_offline_multiple_inputs
  /opt/conda/envs/vllm/lib/python3.10/site-packages/vllm/entrypoints/pooling/pooling/io_processor.py:123: DeprecationWarning: `parse_request` has been renamed to `parse_data`. Please update your IO Processor Plugin to use the new name. The old name will be removed in v0.19.
    validated_prompt = self.io_processor.parse_data(prompt_data)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 5 passed, 19 warnings in 74.99s (0:01:14) =================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
