### PR TITLE
[Bugfix][Spec Decode] Fix DFlash draft/target layer-count mismatch

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1405,7 +1405,7 @@ _SPECULATIVE_DECODING_EXAMPLE_MODELS = {
     # ),
     # [DFlash]
     "DFlashDraftModel": _HfExamplesInfo(
-        "Qwen/Qwen3.5-4B",
+        "Qwen/Qwen3-4B",
         speculative_model="z-lab/Qwen3-4B-DFlash-b16",
         use_original_num_layers=True,  # Need all layers since DFlash has >1 layer,
         max_model_len=8192,  # Reduce max len to ensure test runs in low-VRAM CI env

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -754,6 +754,14 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         needs_squeeze = hidden_states.dim() == 1
         if needs_squeeze:
             hidden_states = hidden_states.unsqueeze(0)
+        expected = self.model.fc.input_size
+        if hidden_states.shape[-1] != expected:
+            raise ValueError(
+                f"DFlash drafter expects {expected} concatenated aux hidden "
+                f"features but received {hidden_states.shape[-1]}. This usually "
+                "means the draft model's target_layer_ids reference layers that "
+                "do not exist in the target model (incompatible draft/target pair)."
+            )
         result = self.model.fc(hidden_states)
         if needs_squeeze:
             result = result.squeeze(0)


### PR DESCRIPTION
The DFlashDraftModel test paired z-lab/Qwen3-4B-DFlash-b16 with Qwen/Qwen3.5-4B, but that drafter's dflash_config.target_layer_ids ([1, 9, 17, 25, 33], resolved with +1 to aux layers (2, 10, 18, 26, 34)) require a target with at least 35 layers. Qwen3.5-4B has only 32, so the aux hidden state for layer 34 is never produced: the drafter's `fc` is sized for 5 concatenated aux features but receives 4, giving a cryptic `mat1 and mat2 shapes cannot be multiplied (Nx10240 and 12800x2560)`. Qwen3-4B (36 layers) is the drafter's actual target and works.

This is an incompatible model pairing rather than a runner bug, but it surfaces differently under Model Runner V2: V2 exercises the drafter's `propose()` during memory profiling (profile_run -> _dummy_run), so the mismatch fails fast at engine init. V1 does not profile the drafter, so the init test passed on V1 and the same error would only appear at the first decode step.

- Point the DFlashDraftModel test at its real target (Qwen/Qwen3-4B).
- Raise a clear error in combine_hidden_states when the collected aux feature count does not match the drafter fc, instead of the cryptic matmul failure (helps both V1 and V2).

Written with Claude.