### PR TITLE
[Structured Output][Tool Calling] Use xgrammar's reasoning parser instead vLLM's

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -26,7 +26,7 @@ outlines_core == 0.2.14
 # required for outlines backend disk cache
 diskcache == 5.6.3
 lark == 1.2.2
-xgrammar >= 0.2.1, < 1.0.0; platform_machine == "x86_64" or platform_machine == "aarch64" or platform_machine == "arm64" or platform_machine == "s390x" or platform_machine == "ppc64le"
+xgrammar >= 0.2.3, < 1.0.0; platform_machine == "x86_64" or platform_machine == "aarch64" or platform_machine == "arm64" or platform_machine == "s390x" or platform_machine == "ppc64le"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317
 partial-json-parser # used for parsing partial JSON outputs

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -1335,7 +1335,7 @@ word2number==1.1
     # via lm-eval
 wrapt==2.1.2
     # via smart-open
-xgrammar==0.2.1
+xgrammar==0.2.3
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -532,9 +532,14 @@ class DelegatingParser(Parser):
         if not need_tool_calling:
             return request
 
+        reasoning_enabled = self._reasoning_parser is not None
+        ctk = getattr(request, "chat_template_kwargs", None) or {}
+        if "enable_thinking" in ctk:
+            reasoning_enabled = bool(ctk["enable_thinking"])
+
         structure_tag = self._tool_parser.get_structural_tag(
             request,
-            reasoning=False,
+            reasoning=reasoning_enabled,
         )
         if structure_tag is None:
             return request

--- a/vllm/parser/qwen3.py
+++ b/vllm/parser/qwen3.py
@@ -22,6 +22,10 @@ from typing import TYPE_CHECKING
 
 import regex as re
 
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.parser.engine.events import EventType
 from vllm.parser.engine.parser_engine import ParserEngine
 from vllm.parser.engine.parser_engine_config import (
@@ -29,12 +33,12 @@ from vllm.parser.engine.parser_engine_config import (
     ParserState,
     Transition,
 )
+from vllm.sampling_params import StructuredOutputsParams
+from vllm.tool_parsers.structural_tag_registry import (
+    build_reasoning_json_structural_tag,
+)
 
 if TYPE_CHECKING:
-    from vllm.entrypoints.openai.chat_completion.protocol import (
-        ChatCompletionRequest,
-    )
-    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
     from vllm.tokenizers import TokenizerLike
     from vllm.tool_parsers.abstract_tool_parser import Tool
 
@@ -265,3 +269,52 @@ class Qwen3Parser(ParserEngine):
                         continue
                     return True
         return False
+
+    @staticmethod
+    def _extract_json_schema(request: ChatCompletionRequest) -> dict | None:
+        rf = request.response_format
+        if rf is not None:
+            if rf.type == "structural_tag":
+                return None
+            if rf.type == "json_object":
+                return {"type": "object"}
+            if rf.type == "json_schema" and rf.json_schema is not None:
+                return rf.json_schema.json_schema
+
+        so = request.structured_outputs
+        if so is None:
+            return None
+        if so.structural_tag:
+            return None
+        if so.json_object:
+            return {"type": "object"}
+        if so.json:
+            if isinstance(so.json, dict):
+                return so.json
+            return json.loads(so.json)
+
+        return None
+
+    def adjust_request(
+        self, request: ChatCompletionRequest | ResponsesRequest
+    ) -> ChatCompletionRequest | ResponsesRequest:
+        if not isinstance(request, ChatCompletionRequest):
+            return super().adjust_request(request)
+
+        if not self.thinking_enabled:
+            return super().adjust_request(request)
+
+        schema = self._extract_json_schema(request)
+        if schema is None:
+            return super().adjust_request(request)
+
+        tag = build_reasoning_json_structural_tag(
+            "qwen_3_5", schema, reasoning=self.thinking_enabled
+        )
+
+        request.structured_outputs = StructuredOutputsParams(
+            structural_tag=json.dumps(tag.model_dump()),
+        )
+        request.response_format = None
+
+        return super().adjust_request(request)

--- a/vllm/tool_parsers/structural_tag_registry.py
+++ b/vllm/tool_parsers/structural_tag_registry.py
@@ -136,6 +136,33 @@ def get_model_structural_tag(
     )
 
 
+def build_reasoning_json_structural_tag(
+    model: str,
+    schema: dict,
+    reasoning: bool = True,
+) -> StructuralTag:
+    suffix_tag = JSONSchemaFormat(json_schema=schema)
+
+    if not reasoning:
+        return StructuralTag(format=suffix_tag)
+
+    prefix_tag = SequenceFormat(
+        elements=[
+            TagFormat(begin="", content=AnyTextFormat(), end="</think>"),
+            ConstStringFormat(value="\n\n"),
+        ]
+    )
+
+    return StructuralTag(
+        format=SequenceFormat(
+            elements=[
+                prefix_tag,
+                suffix_tag,
+            ]
+        )
+    )
+
+
 def _dump_tool_for_xgrammar(
     tool: ChatCompletionToolsParam | ResponsesTool,
 ) -> dict[str, Any]:

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -348,6 +348,16 @@ class StructuredOutputManager:
         # and deserialization when sending this to the GPU workers.
         return bitmask_tensor.numpy()
 
+    def _grammar_handles_reasoning(self, request: "Request") -> bool:
+        structured_req = request.structured_output_request
+        if structured_req is None:
+            return False
+        return (
+            isinstance(self.backend, XgrammarBackend)
+            and structured_req.structured_output_key[0]
+            == StructuredOutputOptions.STRUCTURAL_TAG
+        )
+
     def should_fill_bitmask(self, request: "Request") -> bool:
         # NOTE (Hanchen) if enable_in_reasoning is True, it means that
         # the model needs to be constrained in reasoning. So we should always
@@ -355,6 +365,10 @@ class StructuredOutputManager:
         reasoner = self._get_reasoner(request)
         if reasoner is not None:
             if self.enable_in_reasoning:
+                return True
+            # The grammar is reasoning-aware and handles the thinking phase
+            # itself, so keep the bitmask active from the first token.
+            if self._grammar_handles_reasoning(request):
                 return True
             assert request.structured_output_request is not None
             if request.structured_output_request.reasoning_ended is None:
@@ -385,6 +399,12 @@ class StructuredOutputManager:
 
         # if the model needs structured in reasoning, we should advance
         if self.enable_in_reasoning:
+            return True
+
+        # xgrammar reasoning-aware structural_tag grammars handle the thinking
+        # phase inside the grammar itself, so advance the FSM from the first
+        # token instead of relying on vLLM's reasoning skip.
+        if self._grammar_handles_reasoning(request):
             return True
 
         structured_req = request.structured_output_request


### PR DESCRIPTION
## Purpose

Filter reasoning for structured output and tool calling on Xgrammar's side instead of vLLM's side to simplify logic of scheduler. Recently many bugs related to combinations of structured output/tool callings with reasoning were reported in vLLM. All these issues can be resolved on vLLM's side but requires code changes inside scheduler that makes them potentially hard to implement and test correctly. Instead Xgrammar itself can handle reasoning, so no need for complex logic on vLLM's side.

For tool calling we can simply turn off existing vLLM's reasoning filtering and use instead Xgrammar's one. Structured output (SO) is a bit more different case. SO can be one of the following formats: json object, json schema, structural tag. For structural tag Xgrammar has native reasoning support, for json it currently lacks support. I will do a PR to Xgrammar to implement native reasoning support for json. But as a current workaround we can translate json to structural tag and then reasoning support works as expected. In this PR this approach was implemented for now only for Qwen3.5 as a PoC.

## Test Result

### spec decoding + tool_choice auto/required + reasoning

This case was reported in https://github.com/vllm-project/vllm/issues/44006.

<details>
<summary>server</summary>

```bash
export VLLM_ENFORCE_STRICT_TOOL_CALLING=1
vllm serve Qwen/Qwen3.5-35B-A3B \
    --port 8000 -tp 2 \
    --language-model-only \
    --reasoning-parser qwen3 \
    --enable-auto-tool-choice \
    --tool-call-parser qwen3_coder \
    --max-model-len 8192 \
    --enable-log-requests \
    --trust-remote-code \
    --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
```
</details>

<details>
<summary>client</summary>

```bash
run() {  # $1 = tool_choice, $2 = N
  local fail=0
  for i in $(seq 1 "$2"); do
    code=$(curl -s -o /tmp/r.json -w '%{http_code}' \
      http://localhost:8000/v1/chat/completions -H 'Content-Type: application/json' -d '{
        "model":"Qwen/Qwen3.5-35B-A3B",
        "messages":[{"role":"user","content":"What is the weather in Seoul? Think about which tool to use first."}],
        "tool_choice":"'"$1"'","max_tokens":4096,"temperature":0.6,"top_p":0.95,
        "tools":[{"type":"function","function":{"name":"get_weather","description":"Get current weather information","parameters":{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}}}]
      }')
    echo "[$1][$i] HTTP $code"
    [ "$code" = "200" ] || fail=$((fail+1))
  done
  echo "---- $1: failed $fail/$2"
}

run required 30
run auto 30
```
</details>

**Result**: correct; no 500 HTTP responses on server side

Even though this bug has already been fixed by https://github.com/vllm-project/vllm/pull/44297 the fix itself is complicated, so probably it is better to process reasoning on xgrammar's side to keep vLLM's scheduler logic simple. This PR alone fixes the same issue but in a more simple way.

### spec decoding + structured output json schema + reasoning

This case was reported in https://github.com/vllm-project/vllm/issues/34650

<details>
<summary>server</summary>

```bash
vllm serve Qwen/Qwen3.5-35B-A3B \
    --port 8000 -tp 2 \
    --language-model-only \
    --reasoning-parser qwen3 \
    --enable-auto-tool-choice \
    --tool-call-parser qwen3_coder \
    --max-model-len 8192 \
    --enable-log-requests \
    --trust-remote-code \
    --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
```
</details>

<details>
<summary>client</summary>

```python
#!/usr/bin/env python3

import json
import urllib.request

from rich.console import Console

url = "http://localhost:8000/v1/chat/completions"
payload = {
    "model": "Qwen/Qwen3.5-35B-A3B",
    "messages": [
        {
            "role": "user",
            "content": "Pick a primary color and say how many letters its name has.",
        }
    ],
    "response_format": {
        "type": "json_schema",
        "json_schema": {
            "name": "color_fact",
            "schema": {
                "type": "object",
                "properties": {
                    "color": {"type": "string"},
                    "letter_count": {"type": "integer"},
                },
                "required": ["color", "letter_count"],
            },
        },
    },
    "chat_template_kwargs": {"enable_thinking": True},
    "max_tokens": 2048,
    "temperature": 0,
}

req = urllib.request.Request(
    url,
    data=json.dumps(payload).encode(),
    headers={"Content-Type": "application/json"},
    method="POST",
)
with urllib.request.urlopen(req) as resp:
    data = json.loads(resp.read())

Console().print_json(data=data)
```
</details>

**Result:**
`"content": "\n\n{\n  \"color\": \"Blue\",\n  \"letter_count\": 4\n}"` -- correct; no 500 HTTP responses on server side

### spec decoding + structred output json object + reasoning

This case was reported in https://github.com/vllm-project/vllm/issues/48228

<details>
<summary>server</summary>

```bash
vllm serve Qwen/Qwen3.5-35B-A3B \
    --port 8000 \
    --reasoning-parser qwen3 \
    --enable-auto-tool-choice \
    --tool-call-parser qwen3_coder \
    --speculative-config '{"method":"mtp","num_speculative_tokens":2}'
```
</details>

<details>
<summary>client</summary>

```python
#!/usr/bin/env python3

import json
import urllib.request

from rich.console import Console

url = "http://localhost:8000/v1/chat/completions"
payload = {
    "model": "Qwen/Qwen3.5-35B-A3B",
    "messages": [
        {
            "role": "user",
            "content": "Return a JSON object with keys name and age for Bob aged 30.",
        }
    ],
    "response_format": {"type": "json_object"},
    "max_tokens": 2048,
    "temperature": 0,
}

req = urllib.request.Request(
    url,
    data=json.dumps(payload).encode(),
    headers={"Content-Type": "application/json"},
    method="POST",
)
with urllib.request.urlopen(req) as resp:
    data = json.loads(resp.read())

Console().print_json(data=data)
```
</details>

**Result:**
`"content": "\n\n{\n  \"name\": \"Bob\",\n  \"age\": 30\n}"` -- correct; no 500 HTTP responses on server side

### spec decoding + async scheduling + structred output json object + reasoning

This case was reported in https://github.com/vllm-project/vllm/issues/43388

<details>
<summary>server</summary>

```bash
vllm serve Qwen/Qwen3.5-35B-A3B \
    --port 8000 \
    --reasoning-parser qwen3 \
    --async-scheduling \
    --speculative-config '{"method":"mtp","num_speculative_tokens":4}'
```
</details>

<details>
<summary>client</summary>

```python
#!/usr/bin/env python3

import json
import urllib.request

from rich.console import Console

url = "http://localhost:8000/v1/chat/completions"
payload = {
    "model": "Qwen/Qwen3.5-35B-A3B",
    "messages": [
        {
            "role": "user",
            "content": "Return a JSON object with keys color and letter_count for the color red.",
        }
    ],
    "response_format": {"type": "json_object"},
    "chat_template_kwargs": {"enable_thinking": True},
    "max_tokens": 2048,
    "temperature": 0,
}

req = urllib.request.Request(
    url,
    data=json.dumps(payload).encode(),
    headers={"Content-Type": "application/json"},
    method="POST",
)
with urllib.request.urlopen(req) as resp:
    data = json.loads(resp.read())

Console().print_json(data=data)
```
</details>

**Result:**
`"content": "\n\n{\n  \"color\": \"red\",\n  \"letter_count\": 3\n}"` -- correct; no 500 HTTP responses on server side

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
