### PR TITLE
Support online C128 compression for DeepSeek V4

### DIFF
--- a/tests/models/deepseek_v4/test_online_c128.py
+++ b/tests/models/deepseek_v4/test_online_c128.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import vllm.envs as envs
+from vllm.models.deepseek_v4 import online_c128
+from vllm.models.deepseek_v4.online_c128 import (
+    assert_online_c128_supported,
+    plan_online_c128_segments,
+)
+
+
+def _config(**kwargs):
+    values = dict(
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            prefill_context_parallel_size=1,
+        ),
+        speculative_config=None,
+        kv_transfer_config=SimpleNamespace(kv_connector=None),
+    )
+    values.update(kwargs)
+    return SimpleNamespace(**values)
+
+
+def test_plan_online_c128_segments_exact_boundary_emits_and_resets():
+    plan = plan_online_c128_segments(
+        query_start_loc_cpu=np.array([0, 128], dtype=np.int32),
+        seq_lens_cpu=np.array([128], dtype=np.int32),
+        req_state_indices_cpu=np.array([3], dtype=np.int32),
+        max_num_reqs=8,
+        device="cpu",
+    )
+
+    assert plan.emit_segments.cpu().tolist() == [[0, 128, -1, 127, -1]]
+    assert plan.update_segments.shape == (0, 5)
+    assert plan.reset_rows.cpu().tolist() == [3]
+
+
+def test_plan_online_c128_segments_partial_start_splits_emit_and_update():
+    plan = plan_online_c128_segments(
+        query_start_loc_cpu=np.array([0, 3], dtype=np.int32),
+        seq_lens_cpu=np.array([130], dtype=np.int32),
+        req_state_indices_cpu=np.array([3], dtype=np.int32),
+        max_num_reqs=8,
+        device="cpu",
+    )
+
+    assert plan.emit_segments.cpu().tolist() == [[0, 1, 3, 0, -1]]
+    assert plan.update_segments.cpu().tolist() == [[1, 2, -1, -1, 3]]
+    assert plan.reset_rows.cpu().tolist() == []
+
+
+def test_plan_online_c128_segments_req_mask_skips_unselected_reqs():
+    plan = plan_online_c128_segments(
+        query_start_loc_cpu=np.array([0, 128, 256], dtype=np.int32),
+        seq_lens_cpu=np.array([128, 256], dtype=np.int32),
+        req_state_indices_cpu=np.array([3, 4], dtype=np.int32),
+        max_num_reqs=8,
+        device="cpu",
+        req_mask=np.array([False, True]),
+    )
+
+    assert plan.emit_segments.cpu().tolist() == [[128, 128, -1, 255, -1]]
+    assert plan.update_segments.shape == (0, 5)
+    assert plan.reset_rows.cpu().tolist() == [4]
+
+
+def test_online_c128_rejects_speculative_decode(monkeypatch):
+    monkeypatch.setattr(envs, "VLLM_USE_ONLINE_C128_COMPRESS", True)
+    monkeypatch.setattr(online_c128, "_is_sm90", lambda: True)
+
+    with pytest.raises(ValueError, match="does not support speculative decoding"):
+        assert_online_c128_supported(
+            _config(speculative_config=SimpleNamespace(method="mtp")),
+            compress_ratio=128,
+            head_dim=512,
+        )
+
+
+def test_online_c128_rejects_wrong_shape(monkeypatch):
+    monkeypatch.setattr(envs, "VLLM_USE_ONLINE_C128_COMPRESS", True)
+    monkeypatch.setattr(online_c128, "_is_sm90", lambda: True)
+
+    with pytest.raises(ValueError, match="compress_ratio == 128"):
+        assert_online_c128_supported(_config(), compress_ratio=4, head_dim=512)
+
+    with pytest.raises(ValueError, match="head_dim == 512"):
+        assert_online_c128_supported(_config(), compress_ratio=128, head_dim=128)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -156,6 +156,7 @@ if TYPE_CHECKING:
     VLLM_SERVER_DEV_MODE: bool = False
     VLLM_V1_OUTPUT_PROC_CHUNK_SIZE: int = 128
     VLLM_MLA_DISABLE: bool = False
+    VLLM_USE_ONLINE_C128_COMPRESS: bool = False
     VLLM_RAY_PER_WORKER_GPUS: float = 1.0
     VLLM_RAY_BUNDLE_INDICES: str = ""
     VLLM_CUDART_SO_PATH: str | None = None
@@ -1881,6 +1882,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # for the default value of 1024 tokens.
     "VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD": lambda: int(
         os.getenv("VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD", "1024")
+    ),
+    # Opt-in DeepSeek V4 C128 online compression path.
+    "VLLM_USE_ONLINE_C128_COMPRESS": lambda: bool(
+        int(os.getenv("VLLM_USE_ONLINE_C128_COMPRESS", "0"))
     ),
     # Format for saving torch.compile cache artifacts
     # - "binary": saves as binary file

--- a/vllm/models/deepseek_v4/compressor.py
+++ b/vllm/models/deepseek_v4/compressor.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 from typing import Any, ClassVar, cast
 
+import numpy as np
 import torch
 from torch import nn
 
@@ -12,12 +13,19 @@ from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import MergedColumnParallelLinear
+from vllm.model_executor.models.utils import extract_layer_index
 from vllm.models.deepseek_v4.common.ops.fused_compress_quant_cache import (
     compress_norm_rope_store_triton,
 )
 from vllm.models.deepseek_v4.common.ops.fused_indexer_q import MXFP4_BLOCK_SIZE
 from vllm.models.deepseek_v4.common.ops.save_partial_states import (
     save_partial_states,
+)
+from vllm.models.deepseek_v4.online_c128 import (
+    DeepseekOnlineC128State,
+    assert_online_c128_supported,
+    online_c128_compress_enabled,
+    register_online_c128_state,
 )
 from vllm.platforms import current_platform
 from vllm.v1.attention.backend import (
@@ -81,6 +89,9 @@ class CompressorMetadata:
     block_size: int
 
     token_to_req_indices: torch.Tensor | None = None  # [num_tokens]
+    query_start_loc_cpu: torch.Tensor | None = None
+    seq_lens_cpu: np.ndarray | None = None
+    req_state_indices_cpu: np.ndarray | None = None
 
 
 class CompressorMetadataBuilder(AttentionMetadataBuilder):
@@ -97,6 +108,7 @@ class CompressorMetadataBuilder(AttentionMetadataBuilder):
             dtype=torch.int32,
             device=self.device,
         )
+        self._online_c128 = online_c128_compress_enabled()
 
     def build(
         self,
@@ -107,11 +119,33 @@ class CompressorMetadataBuilder(AttentionMetadataBuilder):
         token_to_req_indices = common_attn_metadata.token_to_req_indices(
             self.token_to_req_indices
         )
+        planner_query_start_loc_cpu = None
+        seq_lens_cpu = None
+        req_state_indices_cpu = None
+        if self._online_c128:
+            num_reqs = common_attn_metadata.num_reqs
+            req_state_indices_cpu = common_attn_metadata.req_state_indices_cpu
+            assert req_state_indices_cpu is not None, (
+                "C128 online compression requires req_state_indices_cpu."
+            )
+
+            planner_query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
+            seq_lens_upper_bound = common_attn_metadata.seq_lens_cpu_upper_bound
+            if seq_lens_upper_bound is not None:
+                seq_lens_cpu = seq_lens_upper_bound[:num_reqs].cpu().numpy()
+            else:
+                query_lens_np = (
+                    planner_query_start_loc_cpu[1:] - planner_query_start_loc_cpu[:-1]
+                ).numpy()
+                seq_lens_cpu = query_lens_np
         return CompressorMetadata(
             block_table=common_attn_metadata.block_table_tensor.clamp_(min=0),
             slot_mapping=common_attn_metadata.slot_mapping,
             block_size=self.block_size,
             token_to_req_indices=token_to_req_indices,
+            query_start_loc_cpu=planner_query_start_loc_cpu,
+            seq_lens_cpu=seq_lens_cpu,
+            req_state_indices_cpu=req_state_indices_cpu,
         )
 
 
@@ -122,6 +156,7 @@ class CompressorStateCache(torch.nn.Module, AttentionLayerBase):
         dtype: torch.dtype,
         compress_ratio: int,
         prefix: str,
+        online_c128: bool = False,
     ):
         super().__init__()
         self.state_dim = state_dim
@@ -136,7 +171,6 @@ class CompressorStateCache(torch.nn.Module, AttentionLayerBase):
         assert self.dtype == torch.float32
         assert compress_ratio in [4, 128]
         coff = 1 + (compress_ratio == 4)
-        self.sliding_window = coff * compress_ratio
         # Block size is constrained by tensor sharing between compressor states
         # and KV blocks. Since compressor states share the same physical tensor
         # as KV blocks, they must use the same page size.
@@ -150,6 +184,8 @@ class CompressorStateCache(torch.nn.Module, AttentionLayerBase):
             self.block_size = 8
         else:
             raise ValueError(f"Invalid compress ratio: {compress_ratio}")
+
+        self.sliding_window = self.block_size if online_c128 else coff * compress_ratio
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
         # fp8_ds_mla is the UE8M0 paged layout and needs 576B alignment. Plain
@@ -234,11 +270,17 @@ class DeepseekCompressor(nn.Module):
         )
         self.norm = RMSNorm(self.head_dim, self.rms_norm_eps)
 
+        self._use_online_c128 = (
+            online_c128_compress_enabled()
+            and compress_ratio == 128
+            and self.head_dim == 512
+        )
         self.state_cache = CompressorStateCache(
             state_dim=2 * self.coff * self.head_dim,  # kv_state + score_state
             dtype=state_dtype,
             compress_ratio=compress_ratio,
             prefix=f"{prefix}.state_cache",
+            online_c128=self._use_online_c128,
         )
 
         # Save reference to static_forward_context for forward-time KV cache lookup.
@@ -246,6 +288,21 @@ class DeepseekCompressor(nn.Module):
         self._static_forward_context = (
             vllm_config.compilation_config.static_forward_context
         )
+
+        self.online_c128_state: DeepseekOnlineC128State | None = None
+        if self._use_online_c128:
+            assert_online_c128_supported(
+                vllm_config,
+                compress_ratio=self.compress_ratio,
+                head_dim=self.head_dim,
+            )
+            self.online_c128_state = DeepseekOnlineC128State(
+                vllm_config=vllm_config,
+                head_dim=self.head_dim,
+                layer_index=extract_layer_index(prefix) if prefix else 0,
+                device=self.device,
+            )
+            register_online_c128_state(self.online_c128_state)
 
         if self.head_dim == 512:
             assert not use_fp4_cache, (
@@ -306,6 +363,37 @@ class DeepseekCompressor(nn.Module):
             else {"launch_pdl": False}
         )
 
+        cos_sin_cache = rotary_emb.cos_sin_cache
+        k_cache_metadata = cast(Any, attn_metadata[self.k_cache_prefix])
+        k_cache_layer = self._static_forward_context[self.k_cache_prefix]
+        kv_cache = k_cache_layer.kv_cache
+
+        # Plain-row V4 reads a contiguous bf16 / per-tensor fp8 cache row; the
+        # fp8_ds_mla path uses the UE8M0 paged uint8 layout.
+        store_full_kv = self.head_dim == 512 and kv_cache.dtype != torch.uint8
+        store_full_fp8 = kv_cache.dtype == torch.float8_e4m3fn
+        fp8_scale = (
+            getattr(k_cache_layer, "_flashinfer_fp8_kv_scale", None)
+            if store_full_fp8
+            else None
+        )
+
+        if self.online_c128_state is not None:
+            self._online_forward(
+                kv=kv,
+                score=score,
+                positions=positions,
+                state_metadata=state_metadata,
+                num_actual=num_actual,
+                cos_sin_cache=cos_sin_cache,
+                kv_cache=kv_cache,
+                k_cache_metadata=k_cache_metadata,
+                store_full_kv=store_full_kv,
+                store_full_fp8=store_full_fp8,
+                fp8_scale=fp8_scale,
+            )
+            return
+
         # Store the KV and score (with fused APE addition) in the state.
         # NOTE: PDL is disabled — both this kernel and the compress kernels
         # below depend on preceding kernel outputs (kv/score from the cublas
@@ -332,20 +420,6 @@ class DeepseekCompressor(nn.Module):
         #   second half sin (per-pair, length rope_head_dim // 2 each)
         # - applied to LAST rope_head_dim elements of head_dim
         # - position used: (positions // compress_ratio) * compress_ratio
-        cos_sin_cache = rotary_emb.cos_sin_cache
-        k_cache_metadata = cast(Any, attn_metadata[self.k_cache_prefix])
-        k_cache_layer = self._static_forward_context[self.k_cache_prefix]
-        kv_cache = k_cache_layer.kv_cache
-
-        # Plain-row V4 reads a contiguous bf16 / per-tensor fp8 cache row; the
-        # fp8_ds_mla path uses the UE8M0 paged uint8 layout.
-        store_full_kv = self.head_dim == 512 and kv_cache.dtype != torch.uint8
-        store_full_fp8 = kv_cache.dtype == torch.float8_e4m3fn
-        fp8_scale = (
-            getattr(k_cache_layer, "_flashinfer_fp8_kv_scale", None)
-            if store_full_fp8
-            else None
-        )
 
         # cutedsl (head=512) accepts the full-cache flags; triton (indexer/AMD)
         # does not, so the two callables have different signatures.
@@ -393,4 +467,133 @@ class DeepseekCompressor(nn.Module):
             token_stride=self._token_stride,
             scale_dim=self._scale_dim,
             **extra_kwargs,
+        )
+
+    def _online_forward(
+        self,
+        kv: torch.Tensor,
+        score: torch.Tensor,
+        positions: torch.Tensor,
+        state_metadata: CompressorMetadata,
+        num_actual: int,
+        cos_sin_cache: torch.Tensor,
+        kv_cache: torch.Tensor,
+        k_cache_metadata: Any,
+        store_full_kv: bool,
+        store_full_fp8: bool,
+        fp8_scale: torch.Tensor | None,
+    ) -> None:
+        online_state = self.online_c128_state
+        assert online_state is not None
+
+        self._online_forward_planned(
+            kv=kv,
+            score=score,
+            positions=positions,
+            state_metadata=state_metadata,
+            num_actual=num_actual,
+            run_state=online_state.state,
+            online_state=online_state,
+            cos_sin_cache=cos_sin_cache,
+            kv_cache=kv_cache,
+            k_cache_metadata=k_cache_metadata,
+            store_full_kv=store_full_kv,
+            store_full_fp8=store_full_fp8,
+            fp8_scale=fp8_scale,
+        )
+
+    def _online_forward_planned(
+        self,
+        kv: torch.Tensor,
+        score: torch.Tensor,
+        positions: torch.Tensor,
+        state_metadata: CompressorMetadata,
+        num_actual: int,
+        run_state: torch.Tensor,
+        online_state: DeepseekOnlineC128State,
+        cos_sin_cache: torch.Tensor,
+        kv_cache: torch.Tensor,
+        k_cache_metadata: Any,
+        store_full_kv: bool,
+        store_full_fp8: bool,
+        fp8_scale: torch.Tensor | None,
+    ) -> None:
+        from vllm.models.deepseek_v4.nvidia.ops.online_c128_cutedsl import (
+            online_c128_merge,
+        )
+        from vllm.models.deepseek_v4.nvidia.ops.sparse_attn_compress_cutedsl import (
+            store_compressed_kv_cutedsl,
+        )
+        from vllm.models.deepseek_v4.online_c128 import plan_online_c128_segments
+
+        query_start_loc_cpu = state_metadata.query_start_loc_cpu
+        seq_lens_cpu = state_metadata.seq_lens_cpu
+        req_state_indices_cpu = state_metadata.req_state_indices_cpu
+        assert (
+            query_start_loc_cpu is not None
+            and seq_lens_cpu is not None
+            and req_state_indices_cpu is not None
+        ), "C128 online forward requires host-side segment-plan metadata."
+
+        compressed_kv = torch.empty(
+            (num_actual, self.head_dim),
+            dtype=torch.float32,
+            device=kv.device,
+        )
+        plan = plan_online_c128_segments(
+            query_start_loc_cpu=query_start_loc_cpu.numpy(),
+            seq_lens_cpu=seq_lens_cpu,
+            req_state_indices_cpu=req_state_indices_cpu,
+            max_num_reqs=online_state.max_num_reqs,
+            device=kv.device,
+            compress_ratio=self.compress_ratio,
+        )
+
+        online_c128_merge(
+            kv=kv,
+            score=score,
+            ape=self.ape,
+            positions=positions,
+            run_state=run_state,
+            segments=plan.emit_segments,
+            compressed_kv=compressed_kv,
+            compress_ratio=self.compress_ratio,
+        )
+        online_c128_merge(
+            kv=kv,
+            score=score,
+            ape=self.ape,
+            positions=positions,
+            run_state=run_state,
+            segments=plan.update_segments,
+            compressed_kv=compressed_kv,
+            compress_ratio=self.compress_ratio,
+        )
+        if plan.reset_rows.numel() > 0:
+            online_state.reset_rows(plan.reset_rows)
+
+        store_compressed_kv_cutedsl(
+            compressed_kv=compressed_kv,
+            positions=positions,
+            slot_mapping=state_metadata.slot_mapping,
+            block_size=state_metadata.block_size,
+            rms_norm_weight=self.norm.weight,
+            rms_norm_eps=self.rms_norm_eps,
+            cos_sin_cache=cos_sin_cache,
+            k_cache=kv_cache,
+            kv_slot_mapping=k_cache_metadata.slot_mapping,
+            kv_cache_block_size=kv_cache.shape[1],
+            kv_block_stride=kv_cache.stride(0),
+            head_size=self.head_dim,
+            state_width=self.head_dim,
+            rope_head_dim=self.rope_head_dim,
+            fp8_max=448.0,
+            quant_block=self._quant_block,
+            token_stride=self._token_stride,
+            scale_dim=self._scale_dim,
+            compress_ratio=self.compress_ratio,
+            overlap=self.overlap,
+            store_full_kv=store_full_kv,
+            store_full_fp8=store_full_fp8,
+            fp8_scale=fp8_scale,
         )

--- a/vllm/models/deepseek_v4/nvidia/ops/online_c128_cutedsl.py
+++ b/vllm/models/deepseek_v4/nvidia/ops/online_c128_cutedsl.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CuTe DSL kernels for DeepSeek V4 online C128 state updates."""
+
+from __future__ import annotations
+
+from functools import cache
+
+import cutlass
+import cutlass.cute as cute
+import torch
+from cuda.bindings.driver import CUstream
+from cutlass import Float32, Int32, Int64
+from quack.compile_utils import make_fake_tensor
+
+RCP_LN2 = 1.4426950408889634
+
+
+class OnlineC128MergeKernel:
+    """Merge planned token segments into per-request running state."""
+
+    elems_per_lane = 2
+
+    def __init__(self, head_size: int, compress_ratio: int):
+        self.head_dim = head_size
+        self.compress_ratio = compress_ratio
+        self.tb_size = head_size // self.elems_per_lane
+
+    @cute.jit
+    def __call__(
+        self,
+        kv: cute.Tensor,
+        score: cute.Tensor,
+        ape: cute.Tensor,
+        positions: cute.Tensor,
+        run_state: cute.Tensor,
+        segments: cute.Tensor,
+        compressed_kv: cute.Tensor,
+        stream: CUstream,
+    ):
+        grid = (segments.shape[0], 1, 1)
+        self.kernel(
+            kv,
+            score,
+            ape,
+            positions,
+            run_state,
+            segments,
+            compressed_kv,
+        ).launch(grid=grid, block=(self.tb_size, 1, 1), stream=stream)
+
+    @cute.kernel
+    def kernel(
+        self,
+        kv: cute.Tensor,
+        score: cute.Tensor,
+        ape: cute.Tensor,
+        positions: cute.Tensor,
+        run_state: cute.Tensor,
+        segments: cute.Tensor,
+        compressed_kv: cute.Tensor,
+    ):
+        seg_id, _, _ = cute.arch.block_idx()
+        tid, _, _ = cute.arch.thread_idx()
+        col0 = tid * self.elems_per_lane
+
+        row_base = segments[seg_id, 0]
+        num_rows = segments[seg_id, 1]
+        read_row = segments[seg_id, 2]
+        emit_token = segments[seg_id, 3]
+        write_row = segments[seg_id, 4]
+
+        max_off = Int64(0)
+        sum_off = Int64(self.head_dim)
+        wsum_off = Int64(2 * self.head_dim)
+
+        run_state_w = run_state.stride[0]
+        kv_w = kv.stride[0]
+        score_w = score.stride[0]
+        ape_w = ape.stride[0]
+        compressed_w = compressed_kv.stride[0]
+
+        local_max = cute.make_rmem_tensor((self.elems_per_lane,), Float32)
+        local_sum = cute.make_rmem_tensor((self.elems_per_lane,), Float32)
+        local_product = cute.make_rmem_tensor((self.elems_per_lane,), Float32)
+
+        for e in cutlass.range_constexpr(self.elems_per_lane):
+            local_max[e] = -Float32.inf
+            local_sum[e] = Float32(0.0)
+            local_product[e] = Float32(0.0)
+
+        if read_row >= Int32(0):
+            base = read_row.to(Int64) * run_state_w + col0.to(Int64)
+            for e in cutlass.range_constexpr(self.elems_per_lane):
+                local_max[e] = run_state.iterator[base + max_off + Int64(e)]
+                local_sum[e] = run_state.iterator[base + sum_off + Int64(e)]
+                local_product[e] = run_state.iterator[base + wsum_off + Int64(e)]
+
+        for r in cutlass.range(num_rows, unroll=1):
+            token = row_base + r
+            tok64 = token.to(Int64)
+            position = positions[tok64]
+            ape_row = (position % Int64(self.compress_ratio)) * ape_w
+            kv_base = tok64 * kv_w + col0.to(Int64)
+            score_base = tok64 * score_w + col0.to(Int64)
+            ape_base = ape_row + col0.to(Int64)
+            for e in cutlass.range_constexpr(self.elems_per_lane):
+                kv_e = kv.iterator[kv_base + Int64(e)].to(Float32)
+                score_e = score.iterator[score_base + Int64(e)].to(Float32)
+                ape_e = ape.iterator[ape_base + Int64(e)]
+                score_e = score_e + ape_e
+                new_max = cute.arch.fmax(local_max[e], score_e)
+                old_scale = cute.math.exp2(
+                    (local_max[e] - new_max) * Float32(RCP_LN2), fastmath=True
+                )
+                new_scale = cute.math.exp2(
+                    (score_e - new_max) * Float32(RCP_LN2), fastmath=True
+                )
+                local_sum[e] = local_sum[e] * old_scale + new_scale
+                local_product[e] = local_product[e] * old_scale + kv_e * new_scale
+                local_max[e] = new_max
+
+        if emit_token >= Int32(0):
+            ebase = emit_token.to(Int64) * compressed_w + col0.to(Int64)
+            for e in cutlass.range_constexpr(self.elems_per_lane):
+                compressed_kv.iterator[ebase + Int64(e)] = (
+                    local_product[e] / local_sum[e]
+                )
+
+        if write_row >= Int32(0):
+            wbase = write_row.to(Int64) * run_state_w + col0.to(Int64)
+            for e in cutlass.range_constexpr(self.elems_per_lane):
+                run_state.iterator[wbase + max_off + Int64(e)] = local_max[e]
+                run_state.iterator[wbase + sum_off + Int64(e)] = local_sum[e]
+                run_state.iterator[wbase + wsum_off + Int64(e)] = local_product[e]
+
+    @cache
+    @staticmethod
+    def compile(head_size: int = 512, compress_ratio: int = 128):
+        if head_size % OnlineC128MergeKernel.elems_per_lane != 0:
+            raise ValueError("head_size must be even.")
+        num_tokens = cute.sym_int()
+        num_rows = cute.sym_int()
+        num_segments = cute.sym_int()
+        num_output_tokens = cute.sym_int()
+
+        kv = cute.runtime.make_fake_tensor(
+            Float32,
+            (num_tokens, head_size),
+            stride=(cute.sym_int64(divisibility=4), 1),
+            assumed_align=16,
+        )
+        score = cute.runtime.make_fake_tensor(
+            Float32,
+            (num_tokens, head_size),
+            stride=(cute.sym_int64(divisibility=4), 1),
+            assumed_align=16,
+        )
+        ape = cute.runtime.make_fake_tensor(
+            Float32,
+            (compress_ratio, head_size),
+            stride=(head_size, 1),
+            assumed_align=16,
+        )
+        positions = make_fake_tensor(Int64, (num_tokens,), divisibility=8)
+        run_state = cute.runtime.make_fake_tensor(
+            Float32,
+            (num_rows, 3 * head_size),
+            stride=(cute.sym_int64(divisibility=16), 1),
+            assumed_align=16,
+        )
+        segments = make_fake_tensor(Int32, (num_segments, 5), divisibility=1)
+        compressed_kv = cute.runtime.make_fake_tensor(
+            Float32,
+            (num_output_tokens, head_size),
+            stride=(head_size, 1),
+            assumed_align=4,
+        )
+        kernel = OnlineC128MergeKernel(head_size, compress_ratio)
+        stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+        return cute.compile(
+            kernel,
+            kv,
+            score,
+            ape,
+            positions,
+            run_state,
+            segments,
+            compressed_kv,
+            stream,
+            options="--enable-tvm-ffi",
+        )
+
+
+def online_c128_merge(
+    kv: torch.Tensor,
+    score: torch.Tensor,
+    ape: torch.Tensor,
+    positions: torch.Tensor,
+    run_state: torch.Tensor,
+    segments: torch.Tensor,
+    compressed_kv: torch.Tensor,
+    compress_ratio: int = 128,
+) -> None:
+    if segments.numel() == 0:
+        return
+    head_size = compressed_kv.shape[-1]
+    if kv.dtype != torch.float32 or score.dtype != torch.float32:
+        raise ValueError(
+            "online_c128_merge expects fp32 kv/score, got "
+            f"{kv.dtype} / {score.dtype}."
+        )
+    compiled = OnlineC128MergeKernel.compile(
+        head_size=head_size,
+        compress_ratio=compress_ratio,
+    )
+    compiled(kv, score, ape, positions, run_state, segments, compressed_kv)

--- a/vllm/models/deepseek_v4/nvidia/ops/sparse_attn_compress_cutedsl.py
+++ b/vllm/models/deepseek_v4/nvidia/ops/sparse_attn_compress_cutedsl.py
@@ -1965,6 +1965,98 @@ def split_kv_compress_norm_rope_insert_sparse_attn_cutedsl(
     )
 
 
+def store_compressed_kv_cutedsl(
+    compressed_kv: torch.Tensor,
+    positions: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    block_size: int,
+    rms_norm_weight: torch.Tensor,
+    rms_norm_eps: float,
+    cos_sin_cache: torch.Tensor,
+    k_cache: torch.Tensor,
+    kv_slot_mapping: torch.Tensor,
+    kv_cache_block_size: int,
+    kv_block_stride: int,
+    head_size: int = 512,
+    state_width: int = 512,
+    rope_head_dim: int = 64,
+    fp8_max: float = 448.0,
+    quant_block: int = 64,
+    token_stride: int = 576,
+    scale_dim: int = 8,
+    compress_ratio: int = 128,
+    overlap: bool = False,
+    store_full_kv: bool = False,
+    store_full_fp8: bool = False,
+    fp8_scale: torch.Tensor | None = None,
+) -> None:
+    """Run only the C128 norm/RoPE/store kernel for online compression."""
+    if k_cache.ndim != 3:
+        raise ValueError(
+            "CuTe DSL sparse-attn store expects the real DeepSeek V4 "
+            f"3D k_cache layout [num_blocks, block_size, 584], got ndim={k_cache.ndim}."
+        )
+    if not store_full_kv and kv_cache_block_size != k_cache.shape[1]:
+        raise ValueError(
+            "CuTe DSL store wrapper expected kv_cache_block_size to match "
+            f"k_cache.shape[1], got {kv_cache_block_size} and {k_cache.shape[1]}."
+        )
+    if positions.numel() == 0:
+        return
+    if rms_norm_weight.dtype not in _TORCH_TO_CUTE:
+        raise ValueError(
+            "CuTe DSL sparse-attn store supports rms_norm_weight dtype "
+            f"bf16/fp32, got {rms_norm_weight.dtype}."
+        )
+    if store_full_fp8 and not store_full_kv:
+        raise ValueError("store_full_fp8 requires store_full_kv.")
+
+    _, store = compile_split_sparse_attn_cutedsl(
+        head_size,
+        state_width,
+        block_size,
+        rope_head_dim,
+        fp8_max,
+        quant_block,
+        token_stride,
+        scale_dim,
+        kv_cache_block_size,
+        kv_block_stride,
+        compress_ratio,
+        overlap,
+        rms_norm_weight.dtype,
+        store_full_kv=store_full_kv,
+        store_full_fp8=store_full_fp8,
+    )
+    if store_full_kv:
+        if fp8_scale is None:
+            fp8_scale = torch.ones(1, dtype=torch.float32, device=k_cache.device)
+        store(
+            compressed_kv,
+            positions,
+            slot_mapping,
+            rms_norm_weight,
+            rms_norm_eps,
+            cos_sin_cache,
+            k_cache.view(torch.uint8),
+            kv_slot_mapping,
+            kv_cache_block_size,
+            fp8_scale,
+        )
+        return
+
+    store(
+        compressed_kv,
+        positions,
+        slot_mapping,
+        rms_norm_weight,
+        rms_norm_eps,
+        cos_sin_cache,
+        k_cache,
+        kv_slot_mapping,
+    )
+
+
 def fused_kv_compress_norm_rope_insert_sparse_attn_cutedsl(
     state_cache: torch.Tensor,
     token_to_req_indices: torch.Tensor,

--- a/vllm/models/deepseek_v4/online_c128.py
+++ b/vllm/models/deepseek_v4/online_c128.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DeepSeek V4 C128 online compression state."""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+import vllm.envs as envs
+from vllm.config import VllmConfig
+from vllm.platforms import current_platform
+
+ONLINE_C128_COMPRESS_RATIO = 128
+ONLINE_C128_HEAD_DIM = 512
+ONLINE_C128_NUM_STATE_VECTORS = 3
+ONLINE_C128_STATE_DTYPE = torch.float32
+
+# Descriptor columns (int32):
+#   0: row_base   - first token row for this segment
+#   1: num_rows   - number of token rows in this segment
+#   2: read_row   - online-state row to seed from, or -1
+#   3: emit_token - token row to write compressed_kv to, or -1
+#   4: write_row  - online-state row to write the trailing carry to, or -1
+SEGMENT_NUM_COLS = 5
+
+
+def online_c128_compress_enabled() -> bool:
+    return bool(envs.VLLM_USE_ONLINE_C128_COMPRESS)
+
+
+def _is_sm90() -> bool:
+    return current_platform.is_cuda() and current_platform.is_device_capability(90)
+
+
+def assert_online_c128_supported(
+    vllm_config: VllmConfig,
+    *,
+    compress_ratio: int,
+    head_dim: int,
+) -> None:
+    """Fail closed for the first online C128 support envelope."""
+    if not _is_sm90():
+        raise ValueError(
+            "VLLM_USE_ONLINE_C128_COMPRESS is only supported on CUDA SM90 "
+            "(Hopper)."
+        )
+    if compress_ratio != ONLINE_C128_COMPRESS_RATIO:
+        raise ValueError(
+            "VLLM_USE_ONLINE_C128_COMPRESS requires compress_ratio == "
+            f"{ONLINE_C128_COMPRESS_RATIO}, got {compress_ratio}."
+        )
+    if head_dim != ONLINE_C128_HEAD_DIM:
+        raise ValueError(
+            "VLLM_USE_ONLINE_C128_COMPRESS requires head_dim == "
+            f"{ONLINE_C128_HEAD_DIM}, got {head_dim}."
+        )
+
+    parallel_config = vllm_config.parallel_config
+    if getattr(parallel_config, "decode_context_parallel_size", 1) > 1:
+        raise ValueError(
+            "VLLM_USE_ONLINE_C128_COMPRESS does not support decode context "
+            "parallelism (DCP)."
+        )
+    if getattr(parallel_config, "prefill_context_parallel_size", 1) > 1:
+        raise ValueError(
+            "VLLM_USE_ONLINE_C128_COMPRESS does not support prefill context "
+            "parallelism (PCP)."
+        )
+
+    if getattr(vllm_config, "speculative_config", None) is not None:
+        raise ValueError(
+            "VLLM_USE_ONLINE_C128_COMPRESS does not support speculative "
+            "decoding in this path."
+        )
+
+    kv_transfer_config = getattr(vllm_config, "kv_transfer_config", None)
+    if kv_transfer_config is not None and getattr(
+        kv_transfer_config, "kv_connector", None
+    ):
+        raise ValueError(
+            "VLLM_USE_ONLINE_C128_COMPRESS does not support KV transfer / "
+            "disaggregated prefill."
+        )
+
+    from vllm.config.compilation import CUDAGraphMode
+
+    cudagraph_mode = vllm_config.compilation_config.cudagraph_mode
+    if cudagraph_mode not in (None, CUDAGraphMode.NONE):
+        raise ValueError(
+            "VLLM_USE_ONLINE_C128_COMPRESS does not support CUDA graphs yet; "
+            "set cudagraph_mode to NONE."
+        )
+
+
+class DeepseekOnlineC128State(torch.nn.Module):
+    """Dense per-request running state for one C128 compressor layer."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        head_dim: int,
+        layer_index: int,
+        device: torch.device | str,
+    ):
+        super().__init__()
+        self.head_dim = head_dim
+        self.layer_index = layer_index
+        self.num_state_vectors = ONLINE_C128_NUM_STATE_VECTORS
+        self.row_width = self.num_state_vectors * head_dim
+        self.max_num_reqs = vllm_config.scheduler_config.max_num_seqs
+
+        self.state = torch.empty(
+            (self.max_num_reqs, self.row_width),
+            dtype=ONLINE_C128_STATE_DTYPE,
+            device=device,
+        )
+        self.reset_all()
+
+    @property
+    def device(self) -> torch.device:
+        return self.state.device
+
+    def reset_all(self) -> None:
+        self.state[:, : self.head_dim] = float("-inf")
+        self.state[:, self.head_dim :] = 0.0
+
+    def reset_rows(self, req_state_indices: torch.Tensor) -> None:
+        if req_state_indices.numel() == 0:
+            return
+        rows = req_state_indices.to(self.state.device, dtype=torch.long)
+        rows = rows[rows >= 0]
+        if rows.numel() == 0:
+            return
+        self.state[rows, : self.head_dim] = float("-inf")
+        self.state[rows, self.head_dim :] = 0.0
+
+
+class OnlineC128Plan:
+    """Host-built segment plan for one forward step."""
+
+    def __init__(
+        self,
+        emit_segments: torch.Tensor,
+        update_segments: torch.Tensor,
+        reset_rows: torch.Tensor,
+    ):
+        self.emit_segments = emit_segments
+        self.update_segments = update_segments
+        self.reset_rows = reset_rows
+
+    @property
+    def is_empty(self) -> bool:
+        return (
+            self.emit_segments.shape[0] == 0
+            and self.update_segments.shape[0] == 0
+            and self.reset_rows.shape[0] == 0
+        )
+
+
+def plan_online_c128_segments(
+    query_start_loc_cpu: np.ndarray,
+    seq_lens_cpu: np.ndarray,
+    req_state_indices_cpu: np.ndarray,
+    max_num_reqs: int,
+    device: torch.device | str,
+    bank_id: int = 0,
+    compress_ratio: int = ONLINE_C128_COMPRESS_RATIO,
+    req_mask: np.ndarray | None = None,
+) -> OnlineC128Plan:
+    """Build emit/update/reset segments from CPU batch metadata."""
+    del max_num_reqs
+    if bank_id != 0:
+        raise ValueError("online C128 only supports committed bank 0.")
+
+    emit: list[list[int]] = []
+    update: list[list[int]] = []
+    reset: list[int] = []
+    num_reqs = len(req_state_indices_cpu)
+
+    for req in range(num_reqs):
+        if req_mask is not None and not bool(req_mask[req]):
+            continue
+        rsi = int(req_state_indices_cpu[req])
+        if rsi < 0:
+            continue
+        row_start = int(query_start_loc_cpu[req])
+        row_end = int(query_start_loc_cpu[req + 1])
+        query_len = row_end - row_start
+        if query_len <= 0:
+            continue
+
+        seq_end = int(seq_lens_cpu[req])
+        first_pos = seq_end - query_len
+        carry_len = first_pos % compress_ratio
+        cur_row = row_start
+        cur_pos = first_pos
+        seeded_from_bank = carry_len > 0
+        to_boundary = compress_ratio - (cur_pos % compress_ratio)
+        last_was_boundary = False
+
+        while cur_row < row_end:
+            seg_rows = min(to_boundary, row_end - cur_row)
+            closes_chunk = seg_rows == to_boundary
+            read_row = rsi if seeded_from_bank else -1
+            if closes_chunk:
+                emit_token = cur_row + seg_rows - 1
+                emit.append([cur_row, seg_rows, read_row, emit_token, -1])
+                last_was_boundary = True
+            else:
+                update.append([cur_row, seg_rows, read_row, -1, rsi])
+                last_was_boundary = False
+
+            cur_row += seg_rows
+            cur_pos += seg_rows
+            seeded_from_bank = False
+            to_boundary = compress_ratio
+
+        if last_was_boundary:
+            reset.append(rsi)
+
+    emit_t = torch.tensor(
+        emit if emit else [], dtype=torch.int32, device=device
+    ).reshape(-1, SEGMENT_NUM_COLS)
+    update_t = torch.tensor(
+        update if update else [], dtype=torch.int32, device=device
+    ).reshape(-1, SEGMENT_NUM_COLS)
+    reset_t = torch.tensor(reset, dtype=torch.int32, device=device)
+    return OnlineC128Plan(emit_t, update_t, reset_t)
+
+
+_ONLINE_C128_STATES: list[DeepseekOnlineC128State] = []
+
+
+def register_online_c128_state(state: DeepseekOnlineC128State) -> None:
+    _ONLINE_C128_STATES.append(state)
+
+
+def clear_online_c128_states() -> None:
+    _ONLINE_C128_STATES.clear()
+
+
+def reset_online_c128_state_rows(req_state_indices: torch.Tensor) -> None:
+    if not online_c128_compress_enabled():
+        return
+    for state in _ONLINE_C128_STATES:
+        state.reset_rows(req_state_indices)

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -439,6 +439,9 @@ class CommonAttentionMetadata:
     has positions available so that builders can pre-compute position-dependent
     sparse metadata for DeepSeek V4 C128A layers."""
 
+    req_state_indices_cpu: np.ndarray | None = None
+    """Mapping from batch slot to persistent request-state slot."""
+
     is_prefilling: torch.Tensor | None = None
     """(batch_size,) bool tensor: True if request is still in prefill phase
     (num_computed_tokens < num_prompt_tokens). Used by some backends to
@@ -572,6 +575,7 @@ class CommonAttentionMetadata:
             encoder_seq_lens_cpu=maybe_slice_reqs(self.encoder_seq_lens_cpu),
             dcp_local_seq_lens=maybe_slice_reqs(self.dcp_local_seq_lens),
             dcp_local_seq_lens_cpu=maybe_slice_reqs(self.dcp_local_seq_lens_cpu),
+            req_state_indices_cpu=maybe_slice_reqs(self.req_state_indices_cpu),
             is_prefilling=maybe_slice_reqs(self.is_prefilling),
             rswa_prefix_lens=maybe_slice_reqs(self.rswa_prefix_lens),
         )

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, replace
 from math import prod
 from typing import Any, cast
 
+import numpy as np
 import torch
 
 from vllm.config import (
@@ -571,6 +572,7 @@ def build_attn_metadata(
     dcp_local_seq_lens: torch.Tensor | None = None,
     positions: torch.Tensor | None = None,
     mm_req_doc_ranges: dict[int, list[tuple[int, int]]] | None = None,
+    req_state_indices_cpu: np.ndarray | None = None,
     model_specific_attn_metadata: ModelSpecificAttnMetadata | None = None,
     for_cudagraph_capture: bool = False,
     causal: bool | Mapping[int, bool] = True,
@@ -611,6 +613,7 @@ def build_attn_metadata(
             positions=positions,
             mm_req_doc_ranges=mm_req_doc_ranges,
             rswa_prefix_lens=rswa_prefix_lens,
+            req_state_indices_cpu=req_state_indices_cpu,
             **common_attn_metadata_extra_kwargs,
         )
 

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -237,6 +237,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.prompt_logprobs_worker: PromptLogprobsWorker | None = None
         self.structured_outputs_worker: StructuredOutputsWorker | None = None
         self.cudagraph_manager: ModelCudaGraphManager | None = None
+        self._online_c128_enabled = False
 
         # LoRA-related workers.
         self.lora_state = LoraState(max_num_reqs=self.max_num_reqs)
@@ -274,6 +275,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         time_before_load = time.perf_counter()
         if load_dummy_weights:
             self.load_config.load_format = "dummy"
+        from vllm.models.deepseek_v4.online_c128 import (
+            clear_online_c128_states,
+            online_c128_compress_enabled,
+        )
+
+        self._online_c128_enabled = online_c128_compress_enabled()
+        clear_online_c128_states()
         self.eplb.prepare_load()
         eplb_models_added = False
         with DeviceMemoryProfiler() as m:
@@ -734,6 +742,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         req_idx = self.req_states.remove_request(req_id)
         if req_idx is None:
             return False
+        if self._online_c128_enabled:
+            from vllm.models.deepseek_v4.online_c128 import (
+                reset_online_c128_state_rows,
+            )
+
+            reset_online_c128_state_rows(
+                torch.tensor([req_idx], device=self.device, dtype=torch.int32)
+            )
         if self.pp_handler is not None:
             self.pp_handler.on_req_idx_freed(req_idx)
         if self.encoder_cache is not None:

--- a/vllm/v1/worker/gpu/model_states/default.py
+++ b/vllm/v1/worker/gpu/model_states/default.py
@@ -182,6 +182,7 @@ class DefaultModelState(ModelState):
             dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
             positions=input_batch.positions,
             mm_req_doc_ranges=req_doc_ranges,
+            req_state_indices_cpu=input_batch.idx_mapping_np,
             for_cudagraph_capture=for_capture,
             rswa_prefix_lens=input_batch.prompt_lens,
         )

--- a/vllm/v1/worker/gpu/model_states/encoder_decoder.py
+++ b/vllm/v1/worker/gpu/model_states/encoder_decoder.py
@@ -144,6 +144,7 @@ class EncoderDecoderModelState(ModelState):
             kv_cache_config=kv_cache_config,
             seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
             dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
+            req_state_indices_cpu=input_batch.idx_mapping_np,
             model_specific_attn_metadata=enc_dec_attn_metadata,
             for_cudagraph_capture=for_capture,
             rswa_prefix_lens=input_batch.prompt_lens,

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -287,6 +287,7 @@ class MambaHybridModelState(DefaultModelState):
             kv_cache_config=kv_cache_config,
             seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
             dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
+            req_state_indices_cpu=input_batch.idx_mapping_np,
             model_specific_attn_metadata=mamba_attn_metadata,
             for_cudagraph_capture=for_capture,
             rswa_prefix_lens=input_batch.prompt_lens,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -661,6 +661,13 @@ class GPUModelRunner(
 
         # Request states.
         self.requests: dict[str, CachedRequestState] = {}
+        self._online_c128_enabled = bool(envs.VLLM_USE_ONLINE_C128_COMPRESS)
+        if self._online_c128_enabled:
+            self.req_id_to_state_index: dict[str, int] = {}
+            self.free_req_state_indices: list[int] = list(
+                reversed(range(self.max_num_reqs))
+            )
+        self.req_state_indices_cpu = np.empty(self.max_num_reqs, dtype=np.int32)
         # NOTE(rob): num_prompt_logprobs only includes reqs
         # that are currently in the prefill phase.
         self.num_prompt_logprobs: dict[str, int] = {}
@@ -1148,6 +1155,32 @@ class GPUModelRunner(
             self.async_output_copy_stream = stream
         return stream
 
+    def _allocate_c128_state_index(self, req_id: str) -> int:
+        state_index = self.req_id_to_state_index.get(req_id)
+        if state_index is not None:
+            return state_index
+        if not self.free_req_state_indices:
+            raise RuntimeError(
+                "C128 request-state slots exhausted: "
+                f"max_num_reqs={self.max_num_reqs}"
+            )
+        state_index = self.free_req_state_indices.pop()
+        self.req_id_to_state_index[req_id] = state_index
+        return state_index
+
+    def _release_c128_state_index(self, req_id: str) -> None:
+        state_index = self.req_id_to_state_index.pop(req_id, None)
+        if state_index is None:
+            return
+        from vllm.models.deepseek_v4.online_c128 import (
+            reset_online_c128_state_rows,
+        )
+
+        reset_online_c128_state_rows(
+            torch.tensor([state_index], device=self.device, dtype=torch.int32)
+        )
+        self.free_req_state_indices.append(state_index)
+
     def _update_states(self, scheduler_output: "SchedulerOutput") -> Callable | None:
         """Update the cached states and the persistent batch with the scheduler
         output.
@@ -1162,6 +1195,11 @@ class GPUModelRunner(
         for req_id in scheduler_output.finished_req_ids:
             self.requests.pop(req_id, None)
             self.num_prompt_logprobs.pop(req_id, None)
+            if self._online_c128_enabled:
+                self._release_c128_state_index(req_id)
+        if self._online_c128_enabled:
+            for req_id in scheduler_output.preempted_req_ids or ():
+                self._release_c128_state_index(req_id)
         self.late_interaction_runner.on_requests_finished(
             scheduler_output.finished_req_ids
         )
@@ -1221,6 +1259,8 @@ class GPUModelRunner(
             if req_id in self.requests:
                 # For streaming case only.
                 req_state = self._update_streaming_request(req_id, new_req_data)
+                if self._online_c128_enabled:
+                    self._allocate_c128_state_index(req_id)
                 reqs_to_add.append(req_state)
                 continue
 
@@ -1260,6 +1300,8 @@ class GPUModelRunner(
                 lora_request=new_req_data.lora_request,
             )
             self.requests[req_id] = req_state
+            if self._online_c128_enabled:
+                self._allocate_c128_state_index(req_id)
             self.late_interaction_runner.register_request(req_id, pooling_params)
 
             if sampling_params and sampling_params.prompt_logprobs is not None:
@@ -1408,6 +1450,8 @@ class GPUModelRunner(
                 # The request is not in the persistent batch.
                 # The request was either preempted and resumed later, or was not
                 # scheduled in the previous step and needs to be added again.
+                if self._online_c128_enabled:
+                    self._allocate_c128_state_index(req_id)
 
                 if self.use_async_scheduling and num_output_tokens > 0:
                     # We must recover the output token ids for resumed requests in the
@@ -2393,6 +2437,17 @@ class GPUModelRunner(
             mm_req_doc_ranges=req_doc_ranges,
             rswa_prefix_lens=rswa_prefix_lens,
         )
+
+        req_state_indices_cpu = self.req_state_indices_cpu[:num_reqs_padded]
+        req_state_indices_cpu.fill(-1)
+        if self._online_c128_enabled:
+            for req_index, req_id in enumerate(self.input_batch.req_ids[:num_reqs]):
+                state_index = self.req_id_to_state_index.get(req_id)
+                if state_index is not None:
+                    req_state_indices_cpu[req_index] = state_index
+        else:
+            req_state_indices_cpu[:num_reqs] = np.arange(num_reqs, dtype=np.int32)
+        cm_base.req_state_indices_cpu = req_state_indices_cpu
 
         if self.dcp_world_size > 1:
             self.dcp_local_seq_lens.cpu[:num_reqs] = get_dcp_local_seq_lens(
@@ -5210,6 +5265,9 @@ class GPUModelRunner(
             self.model_config.model,
             scope="global",
         )
+        from vllm.models.deepseek_v4.online_c128 import clear_online_c128_states
+
+        clear_online_c128_states()
 
         if self.parallel_config.enable_eplb:
             self.eplb_state = EplbState(self.parallel_config, self.device)

--- a/vllm/v1/worker/ubatch_utils.py
+++ b/vllm/v1/worker/ubatch_utils.py
@@ -243,6 +243,9 @@ def _make_metadata_with_slice(
         block_table_tensor=block_table_tensor,
         slot_mapping=slot_mapping,
         seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
+        req_state_indices_cpu=attn_metadata.req_state_indices_cpu[request_slice]
+        if attn_metadata.req_state_indices_cpu is not None
+        else None,
         _seq_lens_cpu=seq_lens_cpu,
         _num_computed_tokens_cpu=num_computed_tokens_cpu,
     )


### PR DESCRIPTION
## Purpose

Add an opt-in online C128 compression path for DeepSeek V4. The existing C128 path stores per-token partial states and compresses at 128-token boundaries; this PR instead maintains an online softmax state per request and emits the same compressed KV at C128 boundaries, reducing C128 compressor state-cache memory. 

This initial PR is intentionally limited to single-node DeepSeek V4 C128 on CUDA SM90. It does not support CUDA graph, DCP/PCP, KV transfer/PD, or speculative decoding yet. PD transfer, CUDA graph support, and MTP/speculative decoding will be handled in follow-up PRs.

## Test Plan
TODO

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

