### PR TITLE
[Hybrid] Stage the postprocess inputs with a single loop over the request list

### DIFF
--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -21,6 +21,7 @@ from vllm.v1.worker.mamba_utils import (
     collect_mamba_copy_meta,
     do_mamba_copy_block,
     preprocess_mamba,
+    stage_postprocess_inputs_to_gpu,
 )
 
 MambaStateCopyFunc = Callable[..., Any]
@@ -369,6 +370,123 @@ def _make_gpu_ctx(
         device=device,
         make_buffer=make_buffer,
     )
+
+
+# -----------------------------------------------------------------------------
+# stage_postprocess_inputs_to_gpu: single-pass staging into pinned views
+# -----------------------------------------------------------------------------
+
+
+def _make_staging_ctx(max_num_reqs: int, device: torch.device) -> MagicMock:
+    """Build a MambaSpecDecodeGPUContext stand-in exposing only the four
+    per-request staging buffers touched by stage_postprocess_inputs_to_gpu."""
+    ctx = MagicMock()
+    ctx.mamba_state_idx_buf = _MockCpuGpuBuffer(max_num_reqs, torch.int32, device)
+    ctx.num_scheduled_tokens_buf = _MockCpuGpuBuffer(max_num_reqs, torch.int32, device)
+    ctx.num_computed_tokens_buf = _MockCpuGpuBuffer(max_num_reqs, torch.int32, device)
+    ctx.num_draft_tokens_buf = _MockCpuGpuBuffer(max_num_reqs, torch.int32, device)
+    return ctx
+
+
+def test_stage_postprocess_inputs_to_gpu_fills_pinned_views():
+    """stage_postprocess_inputs_to_gpu writes each request's state_idx and
+    scheduled/computed/draft counts into slot `i` for `req_ids[i]`, leaves
+    slots past `num_reqs` untouched, and mirrors the values to the GPU buffers."""
+    device = torch.device("cpu")
+    max_num_reqs = 8
+    ctx = _make_staging_ctx(max_num_reqs, device)
+
+    # Any negative int32 works as a sentinel: all staged values (state_idx,
+    # scheduled/computed/draft token counts) are non-negative, so a negative
+    # entry surviving in slots [num_reqs:] proves the loop didn't overrun.
+    sentinel = np.int32(-1)
+    bufs = (
+        ctx.mamba_state_idx_buf,
+        ctx.num_scheduled_tokens_buf,
+        ctx.num_computed_tokens_buf,
+        ctx.num_draft_tokens_buf,
+    )
+    for buf in bufs:
+        buf.np[:] = sentinel
+
+    req_ids = ["req_a", "req_b", "req_c"]
+    num_reqs = len(req_ids)
+    scheduler_output = _make_postprocess_scheduler_output(
+        req_ids=req_ids,
+        num_scheduled_tokens={"req_a": 5, "req_b": 12, "req_c": 3},
+        # req_b intentionally absent -> defaults to 0 drafts.
+        scheduled_spec_decode_tokens={
+            "req_a": [1, 2],
+            "req_c": [1, 2, 3, 4],
+        },
+    )
+    requests = _make_requests(
+        req_ids=req_ids,
+        num_computed_tokens=[10, 20, 30],
+        block_ids_per_req=[[0], [0], [0]],
+    )
+    mamba_state_idx = {"req_a": 100, "req_b": 200, "req_c": 300}
+    # A trailing entry past num_reqs must not be read.
+    req_ids_padded = req_ids + ["not_scheduled"]
+
+    stage_postprocess_inputs_to_gpu(
+        ctx,
+        scheduler_output,
+        req_ids_padded,
+        num_reqs,
+        requests,
+        mamba_state_idx,
+    )
+
+    np.testing.assert_array_equal(
+        ctx.mamba_state_idx_buf.np[:num_reqs], [100, 200, 300]
+    )
+    np.testing.assert_array_equal(
+        ctx.num_scheduled_tokens_buf.np[:num_reqs], [5, 12, 3]
+    )
+    np.testing.assert_array_equal(
+        ctx.num_computed_tokens_buf.np[:num_reqs], [10, 20, 30]
+    )
+    np.testing.assert_array_equal(ctx.num_draft_tokens_buf.np[:num_reqs], [2, 0, 4])
+    for buf in bufs:
+        assert (buf.np[num_reqs:] == sentinel).all()
+
+    assert torch.equal(
+        ctx.mamba_state_idx_buf.gpu[:num_reqs],
+        torch.tensor([100, 200, 300], dtype=torch.int32),
+    )
+    assert torch.equal(
+        ctx.num_draft_tokens_buf.gpu[:num_reqs],
+        torch.tensor([2, 0, 4], dtype=torch.int32),
+    )
+
+
+def test_stage_postprocess_inputs_to_gpu_asserts_on_missing_state_idx():
+    """If preprocess_mamba didn't populate mamba_state_idx for a req in the
+    batch, staging must fail loudly rather than silently writing a stale index."""
+    device = torch.device("cpu")
+    ctx = _make_staging_ctx(max_num_reqs=4, device=device)
+    scheduler_output = _make_postprocess_scheduler_output(
+        req_ids=["req_a"],
+        num_scheduled_tokens={"req_a": 1},
+    )
+    requests = _make_requests(["req_a"], [0], [[0]])
+
+    # mamba_state_idx has an entry for a *different* request but not for
+    # req_a (the one being staged). This is the realistic failure mode:
+    # preprocess_mamba ran, populated some reqs, but missed this one.
+    # The safety assert in stage_postprocess_inputs_to_gpu must fire on
+    # req_a's missing entry rather than silently writing None.
+    mamba_state_idx: dict[str, int] = {"other_req": 42}
+    with pytest.raises(AssertionError, match="mamba_state_idx missing entry"):
+        stage_postprocess_inputs_to_gpu(
+            ctx,
+            scheduler_output,
+            ["req_a"],
+            1,
+            requests,
+            mamba_state_idx,
+        )
 
 
 def _run_gpu_postprocess(

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -1238,66 +1238,6 @@ def postprocess_mamba_align_gpu(
     )
 
 
-def stage_postprocess_metadata_to_gpu(
-    scheduler_output: SchedulerOutput,
-    req_ids: list[str],
-    num_reqs: int,
-    requests: dict[str, CachedRequestState],
-    num_scheduled_tokens_buf: CpuGpuBuffer,
-    num_computed_tokens_buf: CpuGpuBuffer,
-    num_draft_tokens_buf: CpuGpuBuffer,
-) -> None:
-    """Stage per-request postprocess metadata into GPU buffers (non-blocking).
-
-    Walks ``req_ids[:num_reqs]`` in batch order and writes each request's
-    scheduled/computed/draft token counts into the matching pinned numpy
-    views, then issues three non-blocking H→D copies. These values don't
-    change between ``_prepare_inputs`` and ``_update_states_after_model_execute``.
-    The fused postprocess kernel indexes the resulting GPU tensors
-    by ``req_idx``.
-    """
-    scheduled_spec_tokens = scheduler_output.scheduled_spec_decode_tokens
-    num_scheduled = scheduler_output.num_scheduled_tokens
-    scheduled_np = num_scheduled_tokens_buf.np
-    computed_np = num_computed_tokens_buf.np
-    draft_np = num_draft_tokens_buf.np
-    for i in range(num_reqs):
-        req_id = req_ids[i]
-        scheduled_np[i] = num_scheduled[req_id]
-        computed_np[i] = requests[req_id].num_computed_tokens
-        draft_np[i] = len(scheduled_spec_tokens.get(req_id, []))
-    num_scheduled_tokens_buf.copy_to_gpu(num_reqs)
-    num_computed_tokens_buf.copy_to_gpu(num_reqs)
-    num_draft_tokens_buf.copy_to_gpu(num_reqs)
-
-
-def stage_mamba_state_idx_to_gpu(
-    mamba_state_idx: dict[str, int],
-    req_ids: list[str],
-    num_reqs: int,
-    gpu_buf: CpuGpuBuffer,
-) -> None:
-    """Materialize ``mamba_state_idx`` into ``gpu_buf`` and copy to GPU.
-
-    Walks ``req_ids[:num_reqs]`` in batch order, writing each request's block
-    index into the buffer's pinned numpy view, then issues a non-blocking H→D
-    copy. The fused kernel indexes the resulting GPU tensor by ``req_idx``.
-
-    Invariant: ``preprocess_mamba`` must have run first for the same batch so
-    that every ``req_ids[i]`` has an entry in ``mamba_state_idx``.
-    """
-    np_view = gpu_buf.np
-    for i in range(num_reqs):
-        req_id = req_ids[i]
-        state_idx = mamba_state_idx.get(req_id)
-        assert state_idx is not None, (
-            f"mamba_state_idx missing entry for {req_id!r}; "
-            "preprocess_mamba must run before stage_mamba_state_idx_to_gpu"
-        )
-        np_view[i] = state_idx
-    gpu_buf.copy_to_gpu(num_reqs)
-
-
 def stage_postprocess_inputs_to_gpu(
     ctx: MambaSpecDecodeGPUContext,
     scheduler_output: SchedulerOutput,
@@ -1308,27 +1248,40 @@ def stage_postprocess_inputs_to_gpu(
 ) -> None:
     """Stage all per-request inputs the fused mamba postprocess kernel reads.
 
-    Bundles ``stage_mamba_state_idx_to_gpu`` and
-    ``stage_postprocess_metadata_to_gpu`` into a single call so the runner
-    has one entry point for postprocess staging. Buffers live on ``ctx``
+    Walks ``req_ids[:num_reqs]`` once, writing each request's mamba block
+    index and scheduled/computed/draft token counts into the matching pinned
+    numpy views, then issues four non-blocking H→D copies. The fused kernel
+    indexes the resulting GPU tensors by ``req_idx``. Buffers live on ``ctx``
     and only exist when the postprocess kernel is enabled.
+
+    Invariant: ``preprocess_mamba`` must have run first for the same batch so
+    that every ``req_ids[i]`` has an entry in ``mamba_state_idx``.
     """
     assert ctx.mamba_state_idx_buf is not None
     assert ctx.num_scheduled_tokens_buf is not None
     assert ctx.num_computed_tokens_buf is not None
     assert ctx.num_draft_tokens_buf is not None
-    stage_mamba_state_idx_to_gpu(
-        mamba_state_idx,
-        req_ids,
-        num_reqs,
-        ctx.mamba_state_idx_buf,
-    )
-    stage_postprocess_metadata_to_gpu(
-        scheduler_output,
-        req_ids,
-        num_reqs,
-        requests,
-        ctx.num_scheduled_tokens_buf,
-        ctx.num_computed_tokens_buf,
-        ctx.num_draft_tokens_buf,
-    )
+
+    scheduled_spec_tokens = scheduler_output.scheduled_spec_decode_tokens
+    num_scheduled = scheduler_output.num_scheduled_tokens
+    state_idx_np = ctx.mamba_state_idx_buf.np
+    scheduled_np = ctx.num_scheduled_tokens_buf.np
+    computed_np = ctx.num_computed_tokens_buf.np
+    draft_np = ctx.num_draft_tokens_buf.np
+
+    for i in range(num_reqs):
+        req_id = req_ids[i]
+        state_idx = mamba_state_idx.get(req_id)
+        assert state_idx is not None, (
+            f"mamba_state_idx missing entry for {req_id!r}; "
+            "preprocess_mamba must run before stage_postprocess_inputs_to_gpu"
+        )
+        state_idx_np[i] = state_idx
+        scheduled_np[i] = num_scheduled[req_id]
+        computed_np[i] = requests[req_id].num_computed_tokens
+        draft_np[i] = len(scheduled_spec_tokens.get(req_id, []))
+
+    ctx.mamba_state_idx_buf.copy_to_gpu(num_reqs)
+    ctx.num_scheduled_tokens_buf.copy_to_gpu(num_reqs)
+    ctx.num_computed_tokens_buf.copy_to_gpu(num_reqs)
+    ctx.num_draft_tokens_buf.copy_to_gpu(num_reqs)


### PR DESCRIPTION
## Purpose

#40172 introduced [`stage_postprocess_inputs_to_gpu`](https://github.com/vllm-project/vllm/blob/ae6170f874a7c66512bd24aa714b3a02f8a61838/vllm/v1/worker/mamba_utils.py#L1181) to feed the Triton kernel that runs the mamba state copies (prefix caching + MTP path).

The current implementation walks `req_ids[:num_reqs]` twice and factors the work into two helpers (`stage_mamba_state_idx_to_gpu`, `stage_postprocess_metadata_to_gpu`) that are only ever called from `stage_postprocess_inputs_to_gpu` itself.

This PR inlines both helpers into a single pass that fills all four pinned numpy views before issuing the H→D copies. Same GPU-visible behavior, less code (-47 lines net), one loop instead of two. It also adds targeted unit tests for `stage_postprocess_inputs_to_gpu`, which was previously covered only behaviorally by end-to-end hybrid + spec-decode runs.

## Test Plan

- `pytest tests/v1/worker/test_mamba_utils.py -v `

It includes two  new unit tests
     -`test_stage_postprocess_inputs_to_gpu_fills_pinned_views`
     -`test_stage_postprocess_inputs_to_gpu_asserts_on_missing_state_idx`


## Test Result

```
python -m pytest tests/v1/worker/test_mamba_utils.py -v
============================================================================================================================================================== test session starts ==============================================================================================================================================================

tests/v1/worker/test_mamba_utils.py::test_resumed_req_ids_cleared_from_mamba_state_idx PASSED                                                                                                                                                                                                                                             [  5%]
tests/v1/worker/test_mamba_utils.py::test_stage_postprocess_inputs_to_gpu_fills_pinned_views PASSED                                                                                                                                                                                                                                       [ 10%]
tests/v1/worker/test_mamba_utils.py::test_stage_postprocess_inputs_to_gpu_asserts_on_missing_state_idx PASSED                                                                                                                                                                                                                             [ 15%]
tests/v1/worker/test_mamba_utils.py::TestPostprocessMambaFusedKernel::test_matches_python_postprocess_mamba PASSED                                                                                                                                                                                                                        [ 20%]
tests/v1/worker/test_mamba_utils.py::TestPostprocessMambaFusedKernel::test_no_copy_when_not_needed PASSED                                                                                                                                                                                                                                 [ 25%]
tests/v1/worker/test_mamba_utils.py::TestPostprocessMambaFusedKernel::test_various_batch_sizes[1] PASSED                                                                                                                                                                                                                                  [ 30%]
tests/v1/worker/test_mamba_utils.py::TestPostprocessMambaFusedKernel::test_various_batch_sizes[2] PASSED                                                                                                                                                                                                                                  [ 35%]
tests/v1/worker/test_mamba_utils.py::TestPostprocessMambaFusedKernel::test_various_batch_sizes[8] PASSED                                                                                                                                                                                                                                  [ 40%]
tests/v1/worker/test_mamba_utils.py::TestPostprocessMambaFusedKernel::test_various_batch_sizes[16] PASSED                                                                                                                                                                                                                                 [ 45%]
tests/v1/worker/test_mamba_utils.py::TestPostprocessMambaFusedKernel::test_block_table_with_realistic_stride PASSED                                                                                                                                                                                                                       [ 50%]
tests/v1/worker/test_mamba_utils.py::TestPostprocessMambaFusedKernel::test_src_addr_equals_dst_addr_skips_copy_and_sets_accepted_to_1 PASSED                                                                                                                                                                                              [ 55%]
tests/v1/worker/test_mamba_utils.py::TestPostprocessMambaFusedKernel::test_same_block_idx_with_offset_copies_then_sets_accepted_to_1 PASSED                                                                                                                                                                                               [ 60%]
tests/v1/worker/test_mamba_utils.py::TestPostprocessMambaFusedKernel::test_different_block_idx_copies_without_setting_accepted_to_1 PASSED                                                                                                                                                                                                [ 65%]
tests/v1/worker/test_mamba_utils.py::TestPostprocessMambaFusedKernel::test_prefix_caching_shared_block_does_not_set_accepted_to_1 PASSED                                                                                                                                                                                                  [ 70%]
tests/v1/worker/test_mamba_utils.py::TestPostprocessMambaFusedKernel::test_prefix_caching_nonsequential_block_ids_boundary PASSED                                                                                                                                                                                                         [ 75%]
tests/v1/worker/test_mamba_utils.py::TestPostprocessMambaFusedKernel::test_prefix_caching_mixed_shared_and_distinct_blocks PASSED                                                                                                                                                                                                         [ 80%]
tests/v1/worker/test_mamba_utils.py::TestPostprocessMambaFusedKernel::test_pc_aliased_blocks_skip_must_use_logical_idx_not_addr PASSED                                                                                                                                                                                                    [ 85%]
tests/v1/worker/test_mamba_utils.py::TestPostprocessMambaFusedKernel::test_as_strided_temporal_copy_size PASSED                                                                                                                                                                                                                           [ 90%]
tests/v1/worker/test_mamba_utils.py::TestPostprocessMambaFusedKernel::test_temporal_copy_with_bias_ge_2 PASSED                                                                                                                                                                                                                            [ 95%]
tests/v1/worker/test_mamba_utils.py::TestPostprocessMambaFusedKernel::test_ds_conv_layout_bias_gt_0_byte_equal_to_sd PASSED                                                                                                                                                                                                               [100%]

```

## Not a duplicate

Checked open PRs via:
- `gh pr list --search "stage_postprocess"` — no matches.
- `gh pr list --search "stage_mamba_state_idx_to_gpu OR stage_postprocess_metadata_to_gpu"` — no matches.
- `gh pr list --search "mamba_utils postprocess"` — surfaces #46912 (copy-free align redesign),
  which touches `mamba_utils.py` broadly but does not modify the staging helpers this PR removes (it is for MRv2, while this PR touches MRv1).
  
## AI assistance

AI-assisted (Claude). I reviewed every changed line and ran the tests above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

