### PR TITLE
[Frontend] Expose canonical KV cache group metadata

### DIFF
--- a/tests/v1/engine/test_kv_cache_group_metadata.py
+++ b/tests/v1/engine/test_kv_cache_group_metadata.py
@@ -1,0 +1,354 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for EngineCore.get_kv_cache_group_metadata().
+
+Exercises the building of the data structure logic directly against fabricated
+KVCacheConfig/KVCacheGroupSpec objects with no engine/model construction.
+"""
+
+import torch
+
+from vllm.v1.engine.core import EngineCore
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    CrossAttentionSpec,
+    EncoderOnlyAttentionSpec,
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+    MLAAttentionSpec,
+    SinkFullAttentionSpec,
+    SlidingWindowSpec,
+    UniformTypeKVCacheSpecs,
+)
+
+
+class _FakeScheduler:
+    def __init__(self, kv_cache_config: KVCacheConfig | None):
+        self.kv_cache_config = kv_cache_config
+
+
+class _FakeEngineCore:
+    def __init__(self, kv_cache_config: KVCacheConfig | None):
+        self.scheduler = _FakeScheduler(kv_cache_config)
+
+
+def test_get_kv_cache_group_metadata_no_config():
+    engine_core = _FakeEngineCore(kv_cache_config=None)
+    assert EngineCore.get_kv_cache_group_metadata(engine_core) == []
+
+
+def test_get_kv_cache_group_metadata_full_attention():
+    spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.bfloat16,
+        sliding_window=None,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=1,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["layer.0", "layer.1"], spec),
+        ],
+    )
+    engine_core = _FakeEngineCore(kv_cache_config)
+
+    metadata = EngineCore.get_kv_cache_group_metadata(engine_core)
+
+    assert metadata == [
+        {
+            "group_id": 0,
+            "kind": "full_attention",
+            "block_size": 16,
+            "sliding_window": None,
+            "attention_chunk_size": None,
+            "layer_count": 2,
+            "layer_names": ["layer.0", "layer.1"],
+            "num_kv_heads": 8,
+            "head_size": 128,
+            "head_size_v": 128,
+            "dtype": "bfloat16",
+            "page_size_bytes": spec.page_size_bytes,
+            "cache_dtype_str": None,
+            "sink_len": None,
+            "shapes": None,
+            "dtypes": None,
+            "mamba_type": None,
+            "mamba_cache_mode": None,
+            "layer_specs": None,
+        }
+    ]
+
+
+def test_get_kv_cache_group_metadata_mla_attention():
+    spec = MLAAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.bfloat16,
+        cache_dtype_str="fp8_ds_mla",
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=1,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["layer.0"], spec)],
+    )
+    engine_core = _FakeEngineCore(kv_cache_config)
+
+    (group,) = EngineCore.get_kv_cache_group_metadata(engine_core)
+
+    assert group["kind"] == "mla_attention"
+    assert group["layer_names"] == ["layer.0"]
+    assert group["head_size_v"] == 576
+    assert group["cache_dtype_str"] == "fp8_ds_mla"
+    assert group["sink_len"] is None
+    assert group["shapes"] is None
+    assert group["mamba_type"] is None
+    assert group["layer_specs"] is None
+
+
+def test_get_kv_cache_group_metadata_chunked_local_attention():
+    spec = ChunkedLocalAttentionSpec(
+        block_size=16,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.float16,
+        attention_chunk_size=2048,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=1,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["layer.0"], spec)],
+    )
+    engine_core = _FakeEngineCore(kv_cache_config)
+
+    (group,) = EngineCore.get_kv_cache_group_metadata(engine_core)
+
+    assert group["kind"] == "chunked_local_attention"
+    assert group["layer_names"] == ["layer.0"]
+    assert group["attention_chunk_size"] == 2048
+    assert group["sliding_window"] is None
+    assert group["sink_len"] is None
+    assert group["layer_specs"] is None
+
+
+def test_get_kv_cache_group_metadata_sliding_window():
+    spec = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.bfloat16,
+        sliding_window=512,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=1,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["layer.0"], spec)],
+    )
+    engine_core = _FakeEngineCore(kv_cache_config)
+
+    (group,) = EngineCore.get_kv_cache_group_metadata(engine_core)
+
+    assert group["kind"] == "sliding_window"
+    assert group["layer_names"] == ["layer.0"]
+    assert group["sliding_window"] == 512
+    assert group["attention_chunk_size"] is None
+    assert group["head_size_v"] == 128
+    assert group["layer_specs"] is None
+
+
+def test_get_kv_cache_group_metadata_cross_attention():
+    spec = CrossAttentionSpec(
+        block_size=16,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.bfloat16,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=1,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["layer.0"], spec)],
+    )
+    engine_core = _FakeEngineCore(kv_cache_config)
+
+    (group,) = EngineCore.get_kv_cache_group_metadata(engine_core)
+
+    assert group["kind"] == "cross_attention"
+    assert group["layer_names"] == ["layer.0"]
+    assert group["num_kv_heads"] == 8
+    assert group["head_size"] == 128
+    assert group["sliding_window"] is None
+    assert group["attention_chunk_size"] is None
+    assert group["layer_specs"] is None
+
+
+def test_get_kv_cache_group_metadata_unhandled_spec_degrades_gracefully():
+    """EncoderOnlyAttentionSpec has none of the union specific attributes
+    (sliding_window, attention_chunk_size, cache_dtype_str, sink_len,
+    shapes/dtypes/mamba_type). Serialization must not raise and should fall
+    back to None for every attribute the spec doesn't define."""
+    spec = EncoderOnlyAttentionSpec(
+        block_size=16,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.bfloat16,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=1,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["layer.0"], spec)],
+    )
+    engine_core = _FakeEngineCore(kv_cache_config)
+
+    (group,) = EngineCore.get_kv_cache_group_metadata(engine_core)
+
+    assert group["kind"] == "encoder_only_attention"
+    assert group["sliding_window"] is None
+    assert group["attention_chunk_size"] is None
+    assert group["cache_dtype_str"] is None
+    assert group["sink_len"] is None
+    assert group["shapes"] is None
+    assert group["mamba_type"] is None
+    assert group["layer_specs"] is None
+
+
+def test_get_kv_cache_group_metadata_sink_full_attention():
+    spec = SinkFullAttentionSpec(
+        block_size=16,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.bfloat16,
+        sliding_window=2048,
+        sink_len=4,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=1,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["layer.0"], spec)],
+    )
+    engine_core = _FakeEngineCore(kv_cache_config)
+
+    (group,) = EngineCore.get_kv_cache_group_metadata(engine_core)
+
+    assert group["kind"] == "sink_full_attention"
+    assert group["layer_names"] == ["layer.0"]
+    assert group["sliding_window"] == 2048
+    assert group["sink_len"] == 4
+    assert group["head_size_v"] == 128
+    assert group["cache_dtype_str"] is None
+    assert group["layer_specs"] is None
+
+
+def test_get_kv_cache_group_metadata_mamba():
+    spec = MambaSpec(
+        block_size=1,
+        shapes=((16, 128), (5, 32, 32)),
+        dtypes=(torch.float32, torch.bfloat16),
+        num_speculative_blocks=0,
+        mamba_cache_mode="none",
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=1,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["layer.0"], spec)],
+    )
+    engine_core = _FakeEngineCore(kv_cache_config)
+
+    (group,) = EngineCore.get_kv_cache_group_metadata(engine_core)
+
+    assert group["layer_count"] == 1
+    assert group["layer_names"] == ["layer.0"]
+    assert group["num_kv_heads"] is None
+    assert group["head_size"] is None
+    assert group["head_size_v"] is None
+    assert group["dtype"] is None
+    assert group["page_size_bytes"] == spec.page_size_bytes
+    assert group["attention_chunk_size"] is None
+    assert group["cache_dtype_str"] is None
+    assert group["sink_len"] is None
+    assert group["shapes"] == [[16, 128], [5, 32, 32]]
+    assert group["dtypes"] == ["float32", "bfloat16"]
+    assert group["mamba_type"] == "mamba2"
+    assert group["mamba_cache_mode"] == "none"
+    assert group["layer_specs"] is None
+
+
+def test_get_kv_cache_group_metadata_uniform_type():
+    spec_a = ChunkedLocalAttentionSpec(
+        block_size=16,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.float16,
+        attention_chunk_size=2048,
+    )
+    spec_b = ChunkedLocalAttentionSpec(
+        block_size=16,
+        num_kv_heads=8,
+        head_size=64,
+        dtype=torch.float16,
+        attention_chunk_size=2048,
+    )
+    spec = UniformTypeKVCacheSpecs(
+        block_size=16,
+        kv_cache_specs={"layer.0": spec_a, "layer.1": spec_b},
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=1,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["layer.0", "layer.1"], spec)],
+    )
+    engine_core = _FakeEngineCore(kv_cache_config)
+
+    (group,) = EngineCore.get_kv_cache_group_metadata(engine_core)
+
+    # Both sub specs are chunked_local_attention, so the group level kind
+    # collapses to that single kind. Per layer head_size differs, so the
+    # group level attention fields are omitted in favor of `layer_specs`.
+    assert group["kind"] == "chunked_local_attention"
+    assert group["layer_count"] == 2
+    assert group["layer_names"] == ["layer.0", "layer.1"]
+    assert group["num_kv_heads"] is None
+    assert group["head_size"] is None
+    assert group["dtype"] is None
+
+    assert group["layer_specs"] == [
+        {
+            "layer_names": ["layer.0"],
+            "kind": "chunked_local_attention",
+            "block_size": 16,
+            "sliding_window": None,
+            "attention_chunk_size": 2048,
+            "num_kv_heads": 8,
+            "head_size": 128,
+            "head_size_v": None,
+            "dtype": "float16",
+            "page_size_bytes": spec_a.page_size_bytes,
+            "cache_dtype_str": None,
+            "sink_len": None,
+            "shapes": None,
+            "dtypes": None,
+            "mamba_type": None,
+            "mamba_cache_mode": None,
+        },
+        {
+            "layer_names": ["layer.1"],
+            "kind": "chunked_local_attention",
+            "block_size": 16,
+            "sliding_window": None,
+            "attention_chunk_size": 2048,
+            "num_kv_heads": 8,
+            "head_size": 64,
+            "head_size_v": None,
+            "dtype": "float16",
+            "page_size_bytes": spec_b.page_size_bytes,
+            "cache_dtype_str": None,
+            "sink_len": None,
+            "shapes": None,
+            "dtypes": None,
+            "mamba_type": None,
+            "mamba_cache_mode": None,
+        },
+    ]

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -238,6 +238,10 @@ class EngineClient(ABC):
         """Get supported tasks"""
         raise NotImplementedError
 
+    async def get_kv_cache_group_metadata(self) -> list[dict[str, Any]]:
+        """Get canonical KV cache group metadata."""
+        raise NotImplementedError
+
     async def init_weight_transfer_engine(
         self, init_request: WeightTransferInitRequest
     ) -> None:

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -277,6 +277,15 @@ class AsyncLLM(EngineClient):
 
         return self._supported_tasks
 
+    async def get_kv_cache_group_metadata(self) -> list[dict[str, Any]]:
+        if not hasattr(self, "_kv_cache_group_metadata"):
+            # Immutable for the server's lifetime, therefore cache the result.
+            self._kv_cache_group_metadata = (
+                await self.engine_core.get_kv_cache_group_metadata_async()
+            )
+
+        return self._kv_cache_group_metadata
+
     async def add_request(
         self,
         request_id: str,

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -78,7 +78,12 @@ from vllm.v1.engine.utils import (
     get_physical_gpu_ids_for_local_dp_rank,
 )
 from vllm.v1.executor import Executor
-from vllm.v1.kv_cache_interface import KVCacheConfig, get_kv_cache_spec_kind
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    KVCacheSpec,
+    UniformTypeKVCacheSpecs,
+    get_kv_cache_spec_kind,
+)
 from vllm.v1.metrics.stats import SchedulerIterationDetails, SchedulerStats
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
@@ -93,6 +98,37 @@ logger = init_logger(__name__)
 HANDSHAKE_TIMEOUT_MINS = 5
 
 _R = TypeVar("_R")  # Return type for collective_rpc
+
+
+def _dtype_str(dtype: Any) -> str | None:
+    return None if dtype is None else str(dtype).removeprefix("torch.")
+
+
+def _serialize_kv_cache_spec(spec: KVCacheSpec) -> dict[str, Any]:
+    """Return msgspec serializable fields describing KVCacheSpec."""
+    shapes = getattr(spec, "shapes", None)
+    dtypes = getattr(spec, "dtypes", None)
+    mamba_type = getattr(spec, "mamba_type", None)
+    return {
+        "kind": get_kv_cache_spec_kind(spec).value,
+        "block_size": spec.block_size,
+        "sliding_window": getattr(spec, "sliding_window", None),
+        "attention_chunk_size": getattr(spec, "attention_chunk_size", None),
+        "num_kv_heads": getattr(spec, "num_kv_heads", None),
+        "head_size": getattr(spec, "head_size", None),
+        "head_size_v": getattr(spec, "head_size_v", None),
+        "dtype": _dtype_str(getattr(spec, "dtype", None)),
+        "page_size_bytes": spec.page_size_bytes,
+        # MLA specific
+        "cache_dtype_str": getattr(spec, "cache_dtype_str", None),
+        # Sink attention specific
+        "sink_len": getattr(spec, "sink_len", None),
+        # Mamba specific
+        "shapes": None if shapes is None else [list(shape) for shape in shapes],
+        "dtypes": None if dtypes is None else [_dtype_str(d) for d in dtypes],
+        "mamba_type": None if mamba_type is None else mamba_type.name.lower(),
+        "mamba_cache_mode": getattr(spec, "mamba_cache_mode", None),
+    }
 
 
 class EngineCore:
@@ -409,23 +445,32 @@ class EngineCore:
             supported_pooling_tasks,
         )
 
-    def get_kv_cache_group_metadata(self) -> list[dict[str, int | str | None]]:
+    def get_kv_cache_group_metadata(self) -> list[dict[str, Any]]:
         """Return msgspec-serializable metadata for scheduler KV cache groups."""
         kv_cache_config = getattr(self.scheduler, "kv_cache_config", None)
         if kv_cache_config is None:
             return []
 
-        metadata: list[dict[str, int | str | None]] = []
-        for group_idx, group in enumerate(kv_cache_config.kv_cache_groups):
+        metadata: list[dict[str, Any]] = []
+        for group_id, group in enumerate(kv_cache_config.kv_cache_groups):
             spec = group.kv_cache_spec
-            metadata.append(
-                {
-                    "group_idx": group_idx,
-                    "kind": get_kv_cache_spec_kind(spec).value,
-                    "block_size": spec.block_size,
-                    "sliding_window": getattr(spec, "sliding_window", None),
-                }
-            )
+            entry: dict[str, Any] = {
+                "group_id": group_id,
+                "layer_count": len(group.layer_names),
+                "layer_names": list(group.layer_names),
+                **_serialize_kv_cache_spec(spec),
+            }
+            if isinstance(spec, UniformTypeKVCacheSpecs):
+                entry["layer_specs"] = [
+                    {
+                        "layer_names": [layer_name],
+                        **_serialize_kv_cache_spec(sub_spec),
+                    }
+                    for layer_name, sub_spec in spec.kv_cache_specs.items()
+                ]
+            else:
+                entry["layer_specs"] = None
+            metadata.append(entry)
         return metadata
 
     def add_request(self, request: Request, request_wave: int = 0):

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -215,6 +215,11 @@ class EngineCoreClient(ABC):
     async def get_supported_tasks_async(self) -> tuple[SupportedTask, ...]:
         raise NotImplementedError
 
+    async def get_kv_cache_group_metadata_async(
+        self,
+    ) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
     async def add_request_async(self, request: EngineCoreRequest) -> None:
         raise NotImplementedError
 
@@ -1117,6 +1122,11 @@ class AsyncMPClient(MPClient):
 
     async def get_supported_tasks_async(self) -> tuple[SupportedTask, ...]:
         return await self.call_utility_async("get_supported_tasks")
+
+    async def get_kv_cache_group_metadata_async(
+        self,
+    ) -> list[dict[str, Any]]:
+        return await self.call_utility_async("get_kv_cache_group_metadata")
 
     async def add_request_async(self, request: EngineCoreRequest) -> None:
         request.client_index = self.client_index


### PR DESCRIPTION
## Purpose

Prefix-cache aware routing needs per group KV cache spec data and this PR exposes the data.

Changes as follows:

- `EngineCore.get_kv_cache_group_metadata()` now returns the full field set per group (heads, head_size, dtype, page_size_bytes, MLA/sink/mamba fields)
- `UniformTypeKVCacheSpecs` groups expand into a `layer_specs` list instead of losing per layer detail
- Renamed `group_idx` -> `group_id` as it's an identity and  not a loop index
- Added `get_kv_cache_group_metadata_async` on the core client threaded through `EngineClient`/`AsyncLLM` and cached after first call

Ref: "Required core change" in RFC ##38147 description.

Partial #38147

## Test Plan

`pytest -s -v tests/v1/engine/test_kv_cache_group_metadata.py`

## Test Result

All tests pass.
