### PR TITLE
[KV Offloading] Per-request tier filtering with TierFilter/TierMatcher

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_events.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_events.py
@@ -33,6 +33,7 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.kv_offload.base import (
     Locality,
+    Medium,
     OffloadingEvent,
     OffloadingKVEventsConfig,
     OffloadKey,
@@ -40,7 +41,7 @@ from vllm.v1.kv_offload.base import (
 )
 from vllm.v1.kv_offload.tiering.spec import TieringOffloadingSpec
 
-_CPU_MEDIUM = MEDIUM_CPU
+_CPU_MEDIUM = Medium.CPU
 _FULL_ATTENTION_EVENT_SPEC = OffloadingEventGroupSpec(
     kv_cache_spec_kind=KVCacheSpecKind.FULL_ATTENTION.value,
     kv_cache_spec_sliding_window=None,
@@ -135,7 +136,7 @@ def _record_lookup_chunks(
 
 def _stored_event(
     keys: list[OffloadKey],
-    medium: str = _CPU_MEDIUM,
+    medium: Medium = _CPU_MEDIUM,
     locality: Locality | None = None,
 ) -> OffloadingEvent:
     return OffloadingEvent(
@@ -148,7 +149,7 @@ def _stored_event(
 
 def _removed_event(
     keys: list[OffloadKey],
-    medium: str = _CPU_MEDIUM,
+    medium: Medium = _CPU_MEDIUM,
     locality: Locality | None = None,
 ) -> OffloadingEvent:
     return OffloadingEvent(
@@ -181,7 +182,7 @@ def test_take_events_forwards_locality_to_rich_store():
 
     events = list(
         tracker.take_events(
-            [_stored_event([key], locality=Locality.LOCAL, medium=MEDIUM_FS)]
+            [_stored_event([key], locality=Locality.LOCAL, medium=Medium.FS)]
         )
     )
 
@@ -199,7 +200,7 @@ def test_take_events_forwards_locality_to_placeholder_store():
 
     events = list(
         tracker.take_events(
-            [_stored_event([key], locality=Locality.REMOTE, medium=MEDIUM_FS)]
+            [_stored_event([key], locality=Locality.REMOTE, medium=Medium.FS)]
         )
     )
 
@@ -216,7 +217,7 @@ def test_take_events_forwards_locality_to_remove():
 
     events = list(
         tracker.take_events(
-            [_removed_event([key], locality=Locality.LOCAL, medium=MEDIUM_FS)]
+            [_removed_event([key], locality=Locality.LOCAL, medium=Medium.FS)]
         )
     )
 
@@ -240,7 +241,7 @@ def test_take_events_publishes_routable_block_stored():
 
     for i, event in enumerate(batch1):
         assert isinstance(event, BlockStored)
-        assert event.medium == _CPU_MEDIUM
+        assert event.medium == _CPU_MEDIUM.value
         assert event.block_hashes == [_wire_hash(_hash(i))]
         assert event.block_size == block_size
         assert event.token_ids == list(
@@ -324,7 +325,7 @@ def test_lookup_promotion_factor_gt_1_store_and_remove():
     assert len(removed) == 1
     assert isinstance(removed[0], BlockRemoved)
     assert removed[0].block_hashes == expected_hashes
-    assert removed[0].medium == _CPU_MEDIUM
+    assert removed[0].medium == _CPU_MEDIUM.value
     assert removed[0].group_idx == 0
     assert not tracker._pending_event_metadata
 

--- a/tests/v1/kv_connector/unit/offloading_connector/test_events.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_events.py
@@ -9,8 +9,6 @@ from tests.v1.kv_connector.unit.utils import create_vllm_config
 from vllm.config import KVEventsConfig, KVTransferConfig
 from vllm.distributed.kv_events import (
     MEDIUM_CPU,
-    MEDIUM_FS,
-    MEDIUM_OBJ,
     BlockRemoved,
     BlockStored,
 )
@@ -445,8 +443,8 @@ def test_pending_cpu_removal_consumes_hit_backfill_until_next_hit():
     ]
 
 
-@pytest.mark.parametrize("medium", [MEDIUM_FS, MEDIUM_OBJ])
-def test_secondary_stored_event_does_not_mutate_cpu_metadata(medium: str):
+@pytest.mark.parametrize("medium", [Medium.FS, Medium.OBJ])
+def test_secondary_stored_event_does_not_mutate_cpu_metadata(medium: Medium):
     tracker, _, _, key = _lookup_chunk()
     expected_metadata = dict(tracker._pending_event_metadata)
 

--- a/tests/v1/kv_connector/unit/offloading_connector/test_events.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_events.py
@@ -180,7 +180,7 @@ def test_take_events_forwards_locality_to_rich_store():
 
     events = list(
         tracker.take_events(
-            [_stored_event([key], locality=Locality.LOCAL, medium=Medium.FS)]
+            [_stored_event([key], locality=Locality.LOCAL, medium=Medium.STORAGE)]
         )
     )
 
@@ -198,7 +198,7 @@ def test_take_events_forwards_locality_to_placeholder_store():
 
     events = list(
         tracker.take_events(
-            [_stored_event([key], locality=Locality.REMOTE, medium=Medium.FS)]
+            [_stored_event([key], locality=Locality.REMOTE, medium=Medium.STORAGE)]
         )
     )
 
@@ -215,7 +215,7 @@ def test_take_events_forwards_locality_to_remove():
 
     events = list(
         tracker.take_events(
-            [_removed_event([key], locality=Locality.LOCAL, medium=Medium.FS)]
+            [_removed_event([key], locality=Locality.LOCAL, medium=Medium.STORAGE)]
         )
     )
 
@@ -443,12 +443,11 @@ def test_pending_cpu_removal_consumes_hit_backfill_until_next_hit():
     ]
 
 
-@pytest.mark.parametrize("medium", [Medium.FS, Medium.OBJ])
-def test_secondary_stored_event_does_not_mutate_cpu_metadata(medium: Medium):
+def test_secondary_stored_event_does_not_mutate_cpu_metadata():
     tracker, _, _, key = _lookup_chunk()
     expected_metadata = dict(tracker._pending_event_metadata)
 
-    stored = list(tracker.take_events([_stored_event([key], medium)]))
+    stored = list(tracker.take_events([_stored_event([key], Medium.STORAGE)]))
     assert stored[0].token_ids == [1, 2, 3, 4]
     assert tracker._pending_event_metadata == expected_metadata
 

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -33,6 +33,7 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.kv_offload.base import (
     LookupResult,
+    Medium,
     OffloadingEvent,
     OffloadingManager,
     OffloadPolicy,
@@ -299,7 +300,7 @@ def test_abort_before_hit_uses_placeholder_then_later_hit_heals_removal(
 
     assert not tracker._pending_event_metadata
 
-    raw_events.append(OffloadingEvent(keys=[key], medium=MEDIUM_CPU, removed=False))
+    raw_events.append(OffloadingEvent(keys=[key], medium=Medium.CPU, removed=False))
     events = list(runner.connector_scheduler.take_events())
     assert len(events) == 1
     assert isinstance(events[0], BlockStored)
@@ -320,7 +321,7 @@ def test_abort_before_hit_uses_placeholder_then_later_hit_heals_removal(
     )
     assert key in tracker._pending_event_metadata
 
-    raw_events.append(OffloadingEvent(keys=[key], medium=MEDIUM_CPU, removed=True))
+    raw_events.append(OffloadingEvent(keys=[key], medium=Medium.CPU, removed=True))
     [event] = runner.connector_scheduler.take_events()
     assert isinstance(event, BlockRemoved)
     assert event.medium == MEDIUM_CPU
@@ -355,7 +356,7 @@ def test_promotion_hit_precedes_stored_event_translation(
     raw_events: list[OffloadingEvent] = []
 
     def lookup(key, req_context):
-        raw_events.append(OffloadingEvent(keys=[key], medium=MEDIUM_CPU, removed=False))
+        raw_events.append(OffloadingEvent(keys=[key], medium=Medium.CPU, removed=False))
         return LookupResult.HIT
 
     def take_raw_events():

--- a/tests/v1/kv_offload/cpu/test_manager.py
+++ b/tests/v1/kv_offload/cpu/test_manager.py
@@ -146,7 +146,7 @@ def test_cpu_eviction_removed_precedes_stored():
     stored_idx = [i for i, event in enumerate(events) if not event.removed]
     assert removed_idx and stored_idx, events
     assert max(removed_idx) < min(stored_idx)
-    assert all(event.medium == manager.medium for event in events)
+    assert all(event.medium == manager.event_medium for event in events)
 
 
 @pytest.mark.parametrize("eviction_policy", ["lru", "arc"])

--- a/tests/v1/kv_offload/cpu/test_manager.py
+++ b/tests/v1/kv_offload/cpu/test_manager.py
@@ -6,10 +6,10 @@ from dataclasses import dataclass
 import numpy as np
 import pytest
 
-from vllm.distributed.kv_events import MEDIUM_CPU
 from vllm.v1.kv_offload.base import (
     LoadStoreSpec,
     LookupResult,
+    Medium,
     OffloadingEvent,
     OffloadKey,
     PrepareStoreOutput,
@@ -115,7 +115,7 @@ def verify_events(
     stores: list[set[OffloadKey]] = []
     evictions: list[set[OffloadKey]] = []
     for event in events:
-        assert event.medium == MEDIUM_CPU
+        assert event.medium == Medium.CPU
         if event.removed:
             evictions.append(set(event.keys))
         else:
@@ -146,7 +146,7 @@ def test_cpu_eviction_removed_precedes_stored():
     stored_idx = [i for i, event in enumerate(events) if not event.removed]
     assert removed_idx and stored_idx, events
     assert max(removed_idx) < min(stored_idx)
-    assert all(event.medium == manager.event_medium for event in events)
+    assert all(event.medium == manager.medium for event in events)
 
 
 @pytest.mark.parametrize("eviction_policy", ["lru", "arc"])

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -18,10 +18,10 @@ import numpy as np
 import pytest
 import torch
 
-from vllm.distributed.kv_events import MEDIUM_FS
 from vllm.v1.kv_offload.base import (
     Locality,
     LookupResult,
+    Medium,
     OffloadingEvent,
     OffloadingKVEventsConfig,
     OffloadKey,
@@ -514,8 +514,7 @@ def test_successful_store_emits_stored_event(fs_tier_with_events):
     events = list(tier.take_events())
     assert len(events) == 1
     assert events[0].keys == keys
-    # Literal medium pins the wire contract, not just the constant choice.
-    assert events[0].medium == "FS"
+    assert events[0].medium == Medium.FS
     assert events[0].locality is Locality.LOCAL
     assert not events[0].removed
     # take_events drains the buffer.
@@ -685,7 +684,7 @@ def test_cascade_store_emits_fs_event_through_tiering_manager(tmp_path):
             events.extend(manager.take_events())
             time.sleep(0.01)
 
-        fs_events = [e for e in events if e.medium == MEDIUM_FS]
+        fs_events = [e for e in events if e.medium == Medium.FS]
         assert len(fs_events) == 1
         assert set(fs_events[0].keys) == set(keys)
         assert not fs_events[0].removed

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -18,10 +18,10 @@ import numpy as np
 import pytest
 import torch
 
-from vllm.distributed.kv_events import MEDIUM_FS
 from vllm.v1.kv_offload.base import (
     Locality,
     LookupResult,
+    Medium,
     OffloadingEvent,
     OffloadingKVEventsConfig,
     OffloadKey,
@@ -685,7 +685,7 @@ def test_cascade_store_emits_fs_event_through_tiering_manager(tmp_path):
             events.extend(manager.take_events())
             time.sleep(0.01)
 
-        fs_events = [e for e in events if e.medium == MEDIUM_FS]
+        fs_events = [e for e in events if e.medium == Medium.FS]
         assert len(fs_events) == 1
         assert set(fs_events[0].keys) == set(keys)
         assert not fs_events[0].removed

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -18,10 +18,10 @@ import numpy as np
 import pytest
 import torch
 
+from vllm.distributed.kv_events import MEDIUM_FS
 from vllm.v1.kv_offload.base import (
     Locality,
     LookupResult,
-    Medium,
     OffloadingEvent,
     OffloadingKVEventsConfig,
     OffloadKey,
@@ -685,7 +685,7 @@ def test_cascade_store_emits_fs_event_through_tiering_manager(tmp_path):
             events.extend(manager.take_events())
             time.sleep(0.01)
 
-        fs_events = [e for e in events if e.medium == Medium.FS]
+        fs_events = [e for e in events if e.medium == MEDIUM_FS]
         assert len(fs_events) == 1
         assert set(fs_events[0].keys) == set(keys)
         assert not fs_events[0].removed

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -514,7 +514,7 @@ def test_successful_store_emits_stored_event(fs_tier_with_events):
     events = list(tier.take_events())
     assert len(events) == 1
     assert events[0].keys == keys
-    assert events[0].medium == Medium.FS
+    assert events[0].medium == Medium.STORAGE
     assert events[0].locality is Locality.LOCAL
     assert not events[0].removed
     # take_events drains the buffer.
@@ -684,7 +684,7 @@ def test_cascade_store_emits_fs_event_through_tiering_manager(tmp_path):
             events.extend(manager.take_events())
             time.sleep(0.01)
 
-        fs_events = [e for e in events if e.medium == Medium.FS]
+        fs_events = [e for e in events if e.medium == Medium.STORAGE]
         assert len(fs_events) == 1
         assert set(fs_events[0].keys) == set(keys)
         assert not fs_events[0].removed

--- a/tests/v1/kv_offload/tiering/test_obj_tier.py
+++ b/tests/v1/kv_offload/tiering/test_obj_tier.py
@@ -474,7 +474,7 @@ class TestObjTierKVEvents:
         events = list(self.tier.take_events())
         assert len(events) == 1
         assert events[0].keys == keys
-        assert events[0].medium == Medium.OBJ
+        assert events[0].medium == Medium.STORAGE
         assert events[0].locality is Locality.REMOTE
         assert not events[0].removed
         # take_events drains the buffer.

--- a/tests/v1/kv_offload/tiering/test_obj_tier.py
+++ b/tests/v1/kv_offload/tiering/test_obj_tier.py
@@ -21,6 +21,7 @@ import torch
 from vllm.v1.kv_offload.base import (
     Locality,
     LookupResult,
+    Medium,
     OffloadingKVEventsConfig,
     OffloadKey,
     ReqContext,
@@ -473,8 +474,7 @@ class TestObjTierKVEvents:
         events = list(self.tier.take_events())
         assert len(events) == 1
         assert events[0].keys == keys
-        # Literal medium pins the wire contract, not just the constant choice.
-        assert events[0].medium == "OBJ"
+        assert events[0].medium == Medium.OBJ
         assert events[0].locality is Locality.REMOTE
         assert not events[0].removed
         # take_events drains the buffer.

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -31,6 +31,7 @@ from vllm.v1.kv_offload.base import (
     RequestOffloadingContext,
     ScheduleEndContext,
     TierFilter,
+    TierMatcher,
     make_offload_key,
 )
 from vllm.v1.kv_offload.tiering.base import (
@@ -978,7 +979,7 @@ class TestTieringOffloadingManager:
     @pytest.mark.parametrize(
         "load_tier_filter",
         [
-            TierFilter(matchers=({"medium": Medium.STORAGE.value},)),
+            TierFilter(matchers=(TierMatcher(medium=Medium.STORAGE),)),
             TierFilter(matchers=()),
         ],
         ids=["non_matching_medium", "empty_no_load"],
@@ -1007,8 +1008,8 @@ class TestTieringOffloadingManager:
         "load_tier_filter",
         [
             TierFilter.ALL,
-            TierFilter(matchers=({"medium": Medium.CPU.value},)),
-            TierFilter(matchers=({},)),
+            TierFilter(matchers=(TierMatcher(medium=Medium.CPU),)),
+            TierFilter(matchers=(TierMatcher(),)),
         ],
         ids=["all", "explicit_cpu", "unconstrained_matcher"],
     )

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -20,9 +20,6 @@ import torch
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
     OffloadingConnectorStats,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
-    KV_LOAD_TIERS_KEY,
-)
 from vllm.v1.kv_offload.base import (
     LookupResult,
     Medium,
@@ -978,7 +975,17 @@ class TestTieringOffloadingManager:
         self.secondary_tier2.drain_jobs.assert_called_once()
         assert self.manager._transfer_jobs == {}
 
-    def test_tier_filter_skips_filtered_secondary(self, manager_setup):
+    @pytest.mark.parametrize(
+        "load_tier_filter",
+        [
+            TierFilter(matchers=({"medium": Medium.FS.value},)),
+            TierFilter(matchers=()),
+        ],
+        ids=["non_matching_medium", "empty_no_load"],
+    )
+    def test_tier_filter_skips_filtered_secondary(
+        self, manager_setup, load_tier_filter
+    ):
         """Filter excluding secondary medium returns MISS from secondaries
         even when they hold the block; primary is unaffected."""
         blocks = to_keys(range(2))
@@ -988,14 +995,10 @@ class TestTieringOffloadingManager:
         self.manager.complete_store(blocks[:1], _CTX, success=True)
         self.secondary_tier1.blocks[blocks[1]] = True
 
+        # Secondaries have medium=CPU, so load_tier_filter skips them.
         self.secondary_tier1.lookup = MagicMock(wraps=self.secondary_tier1.lookup)
 
-        # Filter allows only FS; secondaries have medium=CPU
-        ctx = ReqContext(
-            req_id="r1",
-            kv_transfer_params={KV_LOAD_TIERS_KEY: [{"medium": Medium.FS.value}]},
-            load_tier_filter=TierFilter(matchers=({"medium": Medium.FS.value},)),
-        )
+        ctx = ReqContext(req_id="r1", load_tier_filter=load_tier_filter)
         assert self.manager.lookup(blocks[0], ctx) is LookupResult.HIT
         assert self.manager.lookup(blocks[1], ctx) is LookupResult.MISS
         self.secondary_tier1.lookup.assert_not_called()

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -988,6 +988,8 @@ class TestTieringOffloadingManager:
         self.manager.complete_store(blocks[:1], _CTX, success=True)
         self.secondary_tier1.blocks[blocks[1]] = True
 
+        self.secondary_tier1.lookup = MagicMock(wraps=self.secondary_tier1.lookup)
+
         # Filter allows only FS; secondaries have medium=CPU
         ctx = ReqContext(
             req_id="r1",
@@ -996,6 +998,7 @@ class TestTieringOffloadingManager:
         )
         assert self.manager.lookup(blocks[0], ctx) is LookupResult.HIT
         assert self.manager.lookup(blocks[1], ctx) is LookupResult.MISS
+        self.secondary_tier1.lookup.assert_not_called()
 
     @pytest.mark.parametrize(
         "load_tier_filter",

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -20,8 +20,10 @@ import torch
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
     OffloadingConnectorStats,
 )
-from vllm.v1.kv_offload.base import (
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
     KV_LOAD_TIERS_KEY,
+)
+from vllm.v1.kv_offload.base import (
     LookupResult,
     Medium,
     OffloadingCounterMetadata,

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -1086,6 +1086,10 @@ class TestTieringOffloadingWithoutSecondaryTiers:
                 )
             ),
         ),
+        (
+            [],
+            TierFilter(matchers=()),
+        ),
     ],
     ids=[
         "medium_storage",
@@ -1093,6 +1097,7 @@ class TestTieringOffloadingWithoutSecondaryTiers:
         "unconstrained",
         "with_locality",
         "multiple_matchers",
+        "empty_list_deny_all",
     ],
 )
 def test_parse_tier_filter_valid(raw, expected):
@@ -1103,11 +1108,10 @@ def test_parse_tier_filter_valid(raw, expected):
     "raw",
     [
         "not a list",
-        [],
         [{"medium": "unknown"}],
         [{"locality": "nowhere"}],
     ],
-    ids=["non_list", "empty_list", "invalid_medium", "invalid_locality"],
+    ids=["non_list", "invalid_medium", "invalid_locality"],
 )
 def test_parse_tier_filter_invalid_returns_all(raw):
     assert _parse_tier_filter(raw) is TierFilter.ALL

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -20,7 +20,11 @@ import torch
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
     OffloadingConnectorStats,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
+    _parse_tier_filter,
+)
 from vllm.v1.kv_offload.base import (
+    Locality,
     LookupResult,
     Medium,
     OffloadingCounterMetadata,
@@ -1050,6 +1054,78 @@ class TestTieringOffloadingWithoutSecondaryTiers:
         manager.complete_store(blocks, _CTX, success=True)
 
         assert count_hits(manager, blocks) == 3
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (
+            [{"medium": "storage"}],
+            TierFilter(matchers=(TierMatcher(medium=Medium.STORAGE),)),
+        ),
+        (
+            [{"medium": "CPU"}],
+            TierFilter(matchers=(TierMatcher(medium=Medium.CPU),)),
+        ),
+        (
+            [{}],
+            TierFilter(matchers=(TierMatcher(),)),
+        ),
+        (
+            [{"medium": "storage", "locality": "local"}],
+            TierFilter(
+                matchers=(TierMatcher(medium=Medium.STORAGE, locality=Locality.LOCAL),)
+            ),
+        ),
+        (
+            [{"medium": "cpu"}, {"medium": "storage"}],
+            TierFilter(
+                matchers=(
+                    TierMatcher(medium=Medium.CPU),
+                    TierMatcher(medium=Medium.STORAGE),
+                )
+            ),
+        ),
+    ],
+    ids=[
+        "medium_storage",
+        "medium_cpu_uppercase",
+        "unconstrained",
+        "with_locality",
+        "multiple_matchers",
+    ],
+)
+def test_parse_tier_filter_valid(raw, expected):
+    assert _parse_tier_filter(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "not a list",
+        [],
+        [{"medium": "unknown"}],
+        [{"locality": "nowhere"}],
+    ],
+    ids=["non_list", "empty_list", "invalid_medium", "invalid_locality"],
+)
+def test_parse_tier_filter_invalid_returns_all(raw):
+    assert _parse_tier_filter(raw) is TierFilter.ALL
+
+
+def test_parse_tier_filter_skips_bad_entries():
+    result = _parse_tier_filter(
+        [
+            {"medium": "storage"},
+            "not a dict",
+            {"medium": "bogus"},
+            {"medium": "cpu"},
+        ]
+    )
+    assert result.matchers == (
+        TierMatcher(medium=Medium.STORAGE),
+        TierMatcher(medium=Medium.CPU),
+    )
 
 
 if __name__ == "__main__":

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -250,9 +250,9 @@ class TestTieringOffloadingManager:
             self.manager.on_new_request(req_context)
 
     def test_take_events_aggregates_tier_owned_events(self, manager_setup):
-        primary_event = OffloadingEvent(to_keys([1]), "CPU", removed=False)
-        secondary_event1 = OffloadingEvent(to_keys([2]), "tier-1", removed=False)
-        secondary_event2 = OffloadingEvent(to_keys([3]), "tier-2", removed=True)
+        primary_event = OffloadingEvent(to_keys([1]), Medium.CPU, removed=False)
+        secondary_event1 = OffloadingEvent(to_keys([2]), Medium.FS, removed=False)
+        secondary_event2 = OffloadingEvent(to_keys([3]), Medium.OBJ, removed=True)
 
         self.primary_tier.take_events = MagicMock(return_value=[primary_event])
         self.secondary_tier1.take_events = MagicMock(return_value=[secondary_event1])
@@ -988,11 +988,11 @@ class TestTieringOffloadingManager:
         self.manager.complete_store(blocks[:1], _CTX, success=True)
         self.secondary_tier1.blocks[blocks[1]] = True
 
-        # Filter allows only STORAGE; secondaries have medium=CPU
+        # Filter allows only FS; secondaries have medium=CPU
         ctx = ReqContext(
             req_id="r1",
-            kv_transfer_params={KV_LOAD_TIERS_KEY: [{"medium": Medium.STORAGE.value}]},
-            load_tier_filter=TierFilter(matchers=({"medium": Medium.STORAGE.value},)),
+            kv_transfer_params={KV_LOAD_TIERS_KEY: [{"medium": Medium.FS.value}]},
+            load_tier_filter=TierFilter(matchers=({"medium": Medium.FS.value},)),
         )
         assert self.manager.lookup(blocks[0], ctx) is LookupResult.HIT
         assert self.manager.lookup(blocks[1], ctx) is LookupResult.MISS

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -990,7 +990,7 @@ class TestTieringOffloadingManager:
 
         ctx = ReqContext(
             req_id="r1",
-            kv_transfer_params={LOOKUP_SCOPE_KEY: LookupScope.PRIMARY.value},
+            kv_transfer_params={LOOKUP_SCOPE_KEY: LookupScope.CPU.value},
         )
         assert self.manager.lookup(blocks[0], ctx) is LookupResult.HIT
         assert self.manager.lookup(blocks[1], ctx) is LookupResult.MISS

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -21,7 +21,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
     OffloadingConnectorStats,
 )
 from vllm.v1.kv_offload.base import (
+    KV_LOAD_TIERS_KEY,
     LookupResult,
+    Medium,
     OffloadingCounterMetadata,
     OffloadingEvent,
     OffloadKey,
@@ -29,13 +31,12 @@ from vllm.v1.kv_offload.base import (
     ReqContext,
     RequestOffloadingContext,
     ScheduleEndContext,
+    TierFilter,
     make_offload_key,
 )
 from vllm.v1.kv_offload.tiering.base import (
-    LOOKUP_SCOPE_KEY,
     JobMetadata,
     JobResult,
-    LookupScope,
     SecondaryTierManager,
     TieringOffloadingMetrics,
 )
@@ -975,9 +976,9 @@ class TestTieringOffloadingManager:
         self.secondary_tier2.drain_jobs.assert_called_once()
         assert self.manager._transfer_jobs == {}
 
-    def test_lookup_scope_primary_skips_secondary(self, manager_setup):
-        """scope=primary queries only the primary tier; secondaries are
-        never called even when they hold the block."""
+    def test_tier_filter_skips_filtered_secondary(self, manager_setup):
+        """Filter excluding secondary medium returns MISS from secondaries
+        even when they hold the block; primary is unaffected."""
         blocks = to_keys(range(2))
         # Put one block in primary, one only in secondary
         self._start_request()
@@ -985,39 +986,34 @@ class TestTieringOffloadingManager:
         self.manager.complete_store(blocks[:1], _CTX, success=True)
         self.secondary_tier1.blocks[blocks[1]] = True
 
-        self.secondary_tier1.lookup = MagicMock(wraps=self.secondary_tier1.lookup)
-        self.secondary_tier2.lookup = MagicMock(wraps=self.secondary_tier2.lookup)
-
+        # Filter allows only STORAGE; secondaries have medium=CPU
         ctx = ReqContext(
             req_id="r1",
-            kv_transfer_params={LOOKUP_SCOPE_KEY: LookupScope.CPU.value},
+            kv_transfer_params={KV_LOAD_TIERS_KEY: [{"medium": Medium.STORAGE.value}]},
+            load_tier_filter=TierFilter(matchers=({"medium": Medium.STORAGE.value},)),
         )
         assert self.manager.lookup(blocks[0], ctx) is LookupResult.HIT
         assert self.manager.lookup(blocks[1], ctx) is LookupResult.MISS
-        self.secondary_tier1.lookup.assert_not_called()
-        self.secondary_tier2.lookup.assert_not_called()
 
     @pytest.mark.parametrize(
-        "kv_transfer_params",
+        "load_tier_filter",
         [
-            None,
-            {},
-            {LOOKUP_SCOPE_KEY: LookupScope.ALL.value},
-            {LOOKUP_SCOPE_KEY: "bogus"},
+            TierFilter.ALL,
+            TierFilter(matchers=({"medium": Medium.CPU.value},)),
+            TierFilter(matchers=({},)),
         ],
-        ids=["none", "empty", "explicit_all", "unknown_value"],
+        ids=["all", "explicit_cpu", "unconstrained_matcher"],
     )
-    def test_lookup_scope_defaults_query_secondary(
-        self, manager_setup, kv_transfer_params
+    def test_tier_filter_allows_matching_secondary(
+        self, manager_setup, load_tier_filter
     ):
-        """Absent, explicit 'all', or unknown scope defaults to querying
-        secondary tiers."""
+        """Filter that matches the secondary's medium allows lookup."""
         blocks = to_keys(range(1))
         self.secondary_tier1.blocks[blocks[0]] = True
 
         self.secondary_tier1.lookup = MagicMock(wraps=self.secondary_tier1.lookup)
 
-        ctx = ReqContext(req_id="r2", kv_transfer_params=kv_transfer_params)
+        ctx = ReqContext(req_id="r2", load_tier_filter=load_tier_filter)
         assert self.manager.lookup(blocks[0], ctx) is LookupResult.RETRY
         self.secondary_tier1.lookup.assert_called()
 

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -32,8 +32,10 @@ from vllm.v1.kv_offload.base import (
     make_offload_key,
 )
 from vllm.v1.kv_offload.tiering.base import (
+    LOOKUP_SCOPE_KEY,
     JobMetadata,
     JobResult,
+    LookupScope,
     SecondaryTierManager,
     TieringOffloadingMetrics,
 )
@@ -972,6 +974,52 @@ class TestTieringOffloadingManager:
         self.secondary_tier1.drain_jobs.assert_called_once()
         self.secondary_tier2.drain_jobs.assert_called_once()
         assert self.manager._transfer_jobs == {}
+
+    def test_lookup_scope_primary_skips_secondary(self, manager_setup):
+        """scope=primary queries only the primary tier; secondaries are
+        never called even when they hold the block."""
+        blocks = to_keys(range(2))
+        # Put one block in primary, one only in secondary
+        self._start_request()
+        self.manager.prepare_store(blocks[:1], _CTX)
+        self.manager.complete_store(blocks[:1], _CTX, success=True)
+        self.secondary_tier1.blocks[blocks[1]] = True
+
+        self.secondary_tier1.lookup = MagicMock(wraps=self.secondary_tier1.lookup)
+        self.secondary_tier2.lookup = MagicMock(wraps=self.secondary_tier2.lookup)
+
+        ctx = ReqContext(
+            req_id="r1",
+            kv_transfer_params={LOOKUP_SCOPE_KEY: LookupScope.PRIMARY.value},
+        )
+        assert self.manager.lookup(blocks[0], ctx) is LookupResult.HIT
+        assert self.manager.lookup(blocks[1], ctx) is LookupResult.MISS
+        self.secondary_tier1.lookup.assert_not_called()
+        self.secondary_tier2.lookup.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "kv_transfer_params",
+        [
+            None,
+            {},
+            {LOOKUP_SCOPE_KEY: LookupScope.ALL.value},
+            {LOOKUP_SCOPE_KEY: "bogus"},
+        ],
+        ids=["none", "empty", "explicit_all", "unknown_value"],
+    )
+    def test_lookup_scope_defaults_query_secondary(
+        self, manager_setup, kv_transfer_params
+    ):
+        """Absent, explicit 'all', or unknown scope defaults to querying
+        secondary tiers."""
+        blocks = to_keys(range(1))
+        self.secondary_tier1.blocks[blocks[0]] = True
+
+        self.secondary_tier1.lookup = MagicMock(wraps=self.secondary_tier1.lookup)
+
+        ctx = ReqContext(req_id="r2", kv_transfer_params=kv_transfer_params)
+        assert self.manager.lookup(blocks[0], ctx) is LookupResult.RETRY
+        self.secondary_tier1.lookup.assert_called()
 
 
 class TestTieringOffloadingWithoutSecondaryTiers:

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -248,8 +248,8 @@ class TestTieringOffloadingManager:
 
     def test_take_events_aggregates_tier_owned_events(self, manager_setup):
         primary_event = OffloadingEvent(to_keys([1]), Medium.CPU, removed=False)
-        secondary_event1 = OffloadingEvent(to_keys([2]), Medium.FS, removed=False)
-        secondary_event2 = OffloadingEvent(to_keys([3]), Medium.OBJ, removed=True)
+        secondary_event1 = OffloadingEvent(to_keys([2]), Medium.STORAGE, removed=False)
+        secondary_event2 = OffloadingEvent(to_keys([3]), Medium.STORAGE, removed=True)
 
         self.primary_tier.take_events = MagicMock(return_value=[primary_event])
         self.secondary_tier1.take_events = MagicMock(return_value=[secondary_event1])
@@ -978,7 +978,7 @@ class TestTieringOffloadingManager:
     @pytest.mark.parametrize(
         "load_tier_filter",
         [
-            TierFilter(matchers=({"medium": Medium.FS.value},)),
+            TierFilter(matchers=({"medium": Medium.STORAGE.value},)),
             TierFilter(matchers=()),
         ],
         ids=["non_matching_medium", "empty_no_load"],

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -43,9 +43,6 @@ class KVCacheEvent(
 
 
 MEDIUM_GPU = "GPU"
-MEDIUM_CPU = "CPU"
-MEDIUM_FS = "FS"
-MEDIUM_OBJ = "OBJ"
 
 
 class BlockStored(KVCacheEvent):

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -44,8 +44,7 @@ class KVCacheEvent(
 
 MEDIUM_GPU = "GPU"
 MEDIUM_CPU = "CPU"
-MEDIUM_FS = "FS"
-MEDIUM_OBJ = "OBJ"
+MEDIUM_STORAGE = "STORAGE"
 
 
 class BlockStored(KVCacheEvent):

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -43,6 +43,9 @@ class KVCacheEvent(
 
 
 MEDIUM_GPU = "GPU"
+MEDIUM_CPU = "CPU"
+MEDIUM_FS = "FS"
+MEDIUM_OBJ = "OBJ"
 
 
 class BlockStored(KVCacheEvent):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/events.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/events.py
@@ -28,6 +28,7 @@ from vllm.v1.kv_cache_interface import (
     get_kv_cache_spec_sliding_window,
 )
 from vllm.v1.kv_offload.base import (
+    Medium,
     OffloadingEvent,
     OffloadingKVEventsConfig,
     OffloadKey,
@@ -218,7 +219,7 @@ class OffloadingEventsTracker:
     def _placeholder_stored(
         self,
         key: OffloadKey,
-        medium: str,
+        medium: Medium,
         locality: str | None,
     ) -> BlockStored:
         return BlockStored(
@@ -229,7 +230,7 @@ class OffloadingEventsTracker:
             token_ids=[],
             lora_id=None,
             block_size=0,
-            medium=medium,
+            medium=medium.value,
             lora_name=None,
             group_idx=get_offload_group_idx(key),
             locality=locality,
@@ -267,7 +268,7 @@ class OffloadingEventsTracker:
                 token_ids=list(meta.token_ids),
                 block_size=meta.block_size,
                 lora_id=meta.lora_id,
-                medium=event.medium,
+                medium=event.medium.value,
                 lora_name=meta.lora_name,
                 extra_keys=(
                     list(meta.extra_keys) if meta.extra_keys is not None else None
@@ -308,7 +309,7 @@ class OffloadingEventsTracker:
         for group_idx, hashes in by_group.items():
             yield BlockRemoved(
                 block_hashes=hashes,
-                medium=event.medium,
+                medium=event.medium.value,
                 group_idx=group_idx,
                 locality=locality,
             )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/events.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/events.py
@@ -21,8 +21,6 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 
 from vllm.distributed.kv_events import (
     MEDIUM_CPU,
-    MEDIUM_FS,
-    MEDIUM_OBJ,
     BlockRemoved,
     BlockStored,
     KVCacheEvent,
@@ -53,8 +51,7 @@ logger = init_logger(__name__)
 
 _MEDIUM_TO_EVENT_STR: dict[Medium, str] = {
     Medium.CPU: MEDIUM_CPU,
-    Medium.FS: MEDIUM_FS,
-    Medium.OBJ: MEDIUM_OBJ,
+    Medium.STORAGE: "STORAGE",
 }
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/events.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/events.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 
 from vllm.distributed.kv_events import (
     MEDIUM_CPU,
+    MEDIUM_STORAGE,
     BlockRemoved,
     BlockStored,
     KVCacheEvent,
@@ -51,7 +52,7 @@ logger = init_logger(__name__)
 
 _MEDIUM_TO_EVENT_STR: dict[Medium, str] = {
     Medium.CPU: MEDIUM_CPU,
-    Medium.STORAGE: "STORAGE",
+    Medium.STORAGE: MEDIUM_STORAGE,
 }
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/events.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/events.py
@@ -19,7 +19,14 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from vllm.distributed.kv_events import BlockRemoved, BlockStored, KVCacheEvent
+from vllm.distributed.kv_events import (
+    MEDIUM_CPU,
+    MEDIUM_FS,
+    MEDIUM_OBJ,
+    BlockRemoved,
+    BlockStored,
+    KVCacheEvent,
+)
 from vllm.logger import init_logger
 from vllm.v1.core.kv_cache_utils import BlockHash, maybe_convert_block_hash
 from vllm.v1.kv_cache_interface import (
@@ -43,6 +50,12 @@ if TYPE_CHECKING:
     )
 
 logger = init_logger(__name__)
+
+_MEDIUM_TO_EVENT_STR: dict[Medium, str] = {
+    Medium.CPU: MEDIUM_CPU,
+    Medium.FS: MEDIUM_FS,
+    Medium.OBJ: MEDIUM_OBJ,
+}
 
 
 class OffloadingEventGroupSpec(NamedTuple):
@@ -230,7 +243,7 @@ class OffloadingEventsTracker:
             token_ids=[],
             lora_id=None,
             block_size=0,
-            medium=medium.value,
+            medium=_MEDIUM_TO_EVENT_STR[medium],
             lora_name=None,
             group_idx=get_offload_group_idx(key),
             locality=locality,
@@ -268,7 +281,7 @@ class OffloadingEventsTracker:
                 token_ids=list(meta.token_ids),
                 block_size=meta.block_size,
                 lora_id=meta.lora_id,
-                medium=event.medium.value,
+                medium=_MEDIUM_TO_EVENT_STR[event.medium],
                 lora_name=meta.lora_name,
                 extra_keys=(
                     list(meta.extra_keys) if meta.extra_keys is not None else None
@@ -309,7 +322,7 @@ class OffloadingEventsTracker:
         for group_idx, hashes in by_group.items():
             yield BlockRemoved(
                 block_hashes=hashes,
-                medium=event.medium.value,
+                medium=_MEDIUM_TO_EVENT_STR[event.medium],
                 group_idx=group_idx,
                 locality=locality,
             )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -38,7 +38,6 @@ from vllm.v1.kv_cache_interface import (
     SlidingWindowSpec,
 )
 from vllm.v1.kv_offload.base import (
-    KV_LOAD_TIERS_KEY,
     GPULoadStoreSpec,
     LookupResult,
     OffloadingManager,
@@ -55,6 +54,8 @@ from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request, RequestStatus
 
 logger = init_logger(__name__)
+
+KV_LOAD_TIERS_KEY = "kv_load_tiers"
 
 
 @dataclass(slots=True)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -38,6 +38,7 @@ from vllm.v1.kv_cache_interface import (
     SlidingWindowSpec,
 )
 from vllm.v1.kv_offload.base import (
+    KV_LOAD_TIERS_KEY,
     GPULoadStoreSpec,
     LookupResult,
     OffloadingManager,
@@ -47,6 +48,7 @@ from vllm.v1.kv_offload.base import (
     ReqContext,
     RequestOffloadingContext,
     ScheduleEndContext,
+    TierFilter,
     make_offload_key,
 )
 from vllm.v1.outputs import KVConnectorOutput
@@ -377,9 +379,16 @@ class RequestOffloadState:
 
 
 def _create_req_context(req: Request) -> ReqContext:
+    params = req.kv_transfer_params
+    load_filter = TierFilter.ALL
+    if params:
+        raw = params.get(KV_LOAD_TIERS_KEY)
+        if raw is not None:
+            load_filter = TierFilter(matchers=tuple(raw))
     return ReqContext(
         req_id=req.request_id,
-        kv_transfer_params=req.kv_transfer_params,
+        kv_transfer_params=params,
+        load_tier_filter=load_filter,
     )
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -387,7 +387,7 @@ class RequestOffloadState:
 def _parse_tier_filter(raw: Any) -> TierFilter:
     """Parse raw kv_transfer_params tier matchers into a TierFilter."""
     if not isinstance(raw, list):
-        logger.warning_once(
+        logger.warning(
             "_parse_tier_filter: expected list, got %s; ignoring",
             type(raw).__name__,
         )
@@ -395,7 +395,7 @@ def _parse_tier_filter(raw: Any) -> TierFilter:
     matchers: list[TierMatcher] = []
     for entry in raw:
         if not isinstance(entry, dict):
-            logger.warning_once("_parse_tier_filter: entry is not a dict; skipping")
+            logger.warning("_parse_tier_filter: entry is not a dict; skipping")
             continue
         medium: Medium | None = None
         locality: Locality | None = None
@@ -404,7 +404,7 @@ def _parse_tier_filter(raw: Any) -> TierFilter:
             try:
                 medium = Medium(raw_medium.upper())
             except (ValueError, AttributeError):
-                logger.warning_once(
+                logger.warning(
                     "_parse_tier_filter: unknown medium %r; skipping entry",
                     raw_medium,
                 )
@@ -414,7 +414,7 @@ def _parse_tier_filter(raw: Any) -> TierFilter:
             try:
                 locality = Locality(raw_locality.upper())
             except (ValueError, AttributeError):
-                logger.warning_once(
+                logger.warning(
                     "_parse_tier_filter: unknown locality %r; skipping entry",
                     raw_locality,
                 )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -39,6 +39,7 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.kv_offload.base import (
     GPULoadStoreSpec,
+    Locality,
     LookupResult,
     Medium,
     OffloadingManager,
@@ -58,6 +59,8 @@ from vllm.v1.request import Request, RequestStatus
 logger = init_logger(__name__)
 
 KV_LOAD_TIERS_KEY = "kv_load_tiers"
+MATCHER_MEDIUM_KEY = "medium"
+MATCHER_LOCALITY_KEY = "locality"
 
 
 @dataclass(slots=True)
@@ -381,19 +384,54 @@ class RequestOffloadState:
             )
 
 
+def _parse_tier_filter(raw: Any) -> TierFilter:
+    """Parse raw kv_transfer_params tier matchers into a TierFilter."""
+    if not isinstance(raw, list):
+        logger.warning_once(
+            "_parse_tier_filter: expected list, got %s; ignoring",
+            type(raw).__name__,
+        )
+        return TierFilter.ALL
+    matchers: list[TierMatcher] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            logger.warning_once("_parse_tier_filter: entry is not a dict; skipping")
+            continue
+        medium: Medium | None = None
+        locality: Locality | None = None
+        raw_medium = entry.get(MATCHER_MEDIUM_KEY)
+        if raw_medium is not None:
+            try:
+                medium = Medium(raw_medium.upper())
+            except (ValueError, AttributeError):
+                logger.warning_once(
+                    "_parse_tier_filter: unknown medium %r; skipping entry",
+                    raw_medium,
+                )
+                continue
+        raw_locality = entry.get(MATCHER_LOCALITY_KEY)
+        if raw_locality is not None:
+            try:
+                locality = Locality(raw_locality.upper())
+            except (ValueError, AttributeError):
+                logger.warning_once(
+                    "_parse_tier_filter: unknown locality %r; skipping entry",
+                    raw_locality,
+                )
+                continue
+        matchers.append(TierMatcher(medium=medium, locality=locality))
+    if not matchers:
+        return TierFilter.ALL
+    return TierFilter(matchers=tuple(matchers))
+
+
 def _create_req_context(req: Request) -> ReqContext:
     params = req.kv_transfer_params
     load_filter = TierFilter.ALL
     if params:
         raw = params.get(KV_LOAD_TIERS_KEY)
         if raw is not None:
-            matchers = tuple(
-                TierMatcher(
-                    medium=Medium(m["medium"].upper()) if "medium" in m else None,
-                )
-                for m in raw
-            )
-            load_filter = TierFilter(matchers=matchers)
+            load_filter = _parse_tier_filter(raw)
     return ReqContext(
         req_id=req.request_id,
         kv_transfer_params=params,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -421,6 +421,9 @@ def _parse_tier_filter(raw: Any) -> TierFilter:
                 continue
         matchers.append(TierMatcher(medium=medium, locality=locality))
     if not matchers:
+        if not raw:  # input was [] — user explicitly wants nothing
+            return TierFilter(matchers=())
+        # all entries were invalid — fall back to ALL
         return TierFilter.ALL
     return TierFilter(matchers=tuple(matchers))
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -40,6 +40,7 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.kv_offload.base import (
     GPULoadStoreSpec,
     LookupResult,
+    Medium,
     OffloadingManager,
     OffloadingSpec,
     OffloadKey,
@@ -48,6 +49,7 @@ from vllm.v1.kv_offload.base import (
     RequestOffloadingContext,
     ScheduleEndContext,
     TierFilter,
+    TierMatcher,
     make_offload_key,
 )
 from vllm.v1.outputs import KVConnectorOutput
@@ -385,7 +387,13 @@ def _create_req_context(req: Request) -> ReqContext:
     if params:
         raw = params.get(KV_LOAD_TIERS_KEY)
         if raw is not None:
-            load_filter = TierFilter(matchers=tuple(raw))
+            matchers = tuple(
+                TierMatcher(
+                    medium=Medium(m["medium"].upper()) if "medium" in m else None,
+                )
+                for m in raw
+            )
+            load_filter = TierFilter(matchers=matchers)
     return ReqContext(
         req_id=req.request_id,
         kv_transfer_params=params,

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -62,23 +62,26 @@ class Locality(Enum):
     REMOTE = "REMOTE"
 
 
+class TierMatcher(NamedTuple):
+    medium: Medium | None = None
+    locality: Locality | None = None
+
+
 @dataclass(frozen=True)
 class TierFilter:
     """Per-request filter controlling which tiers participate."""
 
-    matchers: tuple[dict[str, str], ...] = ()
+    matchers: tuple[TierMatcher, ...] = ()
 
     ALL: ClassVar["TierFilter"]
 
     def allows(self, medium: Medium) -> bool:
         if self is TierFilter.ALL:
             return True
-        return any(
-            "medium" not in m or m["medium"] == medium.value for m in self.matchers
-        )
+        return any(m.medium is None or m.medium == medium for m in self.matchers)
 
 
-TierFilter.ALL = TierFilter(matchers=({},))
+TierFilter.ALL = TierFilter(matchers=(TierMatcher(),))
 
 
 @dataclass

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Collection, Iterable, Sequence
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Any, NamedTuple, NewType, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, NewType, TypeVar
 
 import numpy as np
 import torch
@@ -48,10 +48,40 @@ def get_offload_group_idx(key: OffloadKey) -> int:
 _T = TypeVar("_T")
 
 
+class Medium(Enum):
+    """Storage medium of an offloading tier."""
+
+    CPU = "cpu"
+    STORAGE = "storage"
+
+
+KV_LOAD_TIERS_KEY = "kv_load_tiers"
+
+
+@dataclass(frozen=True)
+class TierFilter:
+    """Per-request filter controlling which tiers participate."""
+
+    matchers: tuple[dict[str, str], ...] = ()
+
+    ALL: ClassVar["TierFilter"]
+
+    def allows(self, medium: Medium) -> bool:
+        if self is TierFilter.ALL:
+            return True
+        return any(
+            "medium" not in m or m["medium"] == medium.value for m in self.matchers
+        )
+
+
+TierFilter.ALL = TierFilter(matchers=({},))
+
+
 @dataclass
 class ReqContext:
     req_id: str
     kv_transfer_params: dict[str, Any] | None = None
+    load_tier_filter: TierFilter = TierFilter.ALL
     # Per-request scratch space keyed by value type, so a tier can parse
     # kv_transfer_params once (in on_new_request) and read the result back
     # on later calls for the same request.

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -52,8 +52,7 @@ class Medium(Enum):
     """Storage medium of an offloading tier."""
 
     CPU = "CPU"
-    FS = "FS"
-    OBJ = "OBJ"
+    STORAGE = "STORAGE"
 
 
 class Locality(Enum):

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -66,6 +66,13 @@ class TierMatcher(NamedTuple):
     medium: Medium | None = None
     locality: Locality | None = None
 
+    def matches(self, medium: Medium | None, locality: Locality | None) -> bool:
+        medium_matches = self.medium is None or medium is None or self.medium == medium
+        locality_matches = (
+            self.locality is None or locality is None or self.locality == locality
+        )
+        return medium_matches and locality_matches
+
 
 @dataclass(frozen=True)
 class TierFilter:
@@ -75,10 +82,10 @@ class TierFilter:
 
     ALL: ClassVar["TierFilter"]
 
-    def allows(self, medium: Medium) -> bool:
+    def allows(self, medium: Medium | None, locality: Locality | None) -> bool:
         if self is TierFilter.ALL:
             return True
-        return any(m.medium is None or m.medium == medium for m in self.matchers)
+        return any(m.matches(medium, locality) for m in self.matchers)
 
 
 TierFilter.ALL = TierFilter(matchers=(TierMatcher(),))

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -55,9 +55,6 @@ class Medium(Enum):
     STORAGE = "storage"
 
 
-KV_LOAD_TIERS_KEY = "kv_load_tiers"
-
-
 @dataclass(frozen=True)
 class TierFilter:
     """Per-request filter controlling which tiers participate."""

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -51,8 +51,9 @@ _T = TypeVar("_T")
 class Medium(Enum):
     """Storage medium of an offloading tier."""
 
-    CPU = "cpu"
-    STORAGE = "storage"
+    CPU = "CPU"
+    FS = "FS"
+    OBJ = "OBJ"
 
 
 @dataclass(frozen=True)
@@ -147,7 +148,7 @@ class Locality(Enum):
 @dataclass
 class OffloadingEvent:
     keys: list[OffloadKey]
-    medium: str
+    medium: Medium
     # True if blocks are removed, False if stored
     removed: bool
     locality: Locality | None = None

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -56,6 +56,13 @@ class Medium(Enum):
     OBJ = "OBJ"
 
 
+class Locality(Enum):
+    """Locality of a tier's storage relative to the publishing instance."""
+
+    LOCAL = "LOCAL"
+    REMOTE = "REMOTE"
+
+
 @dataclass(frozen=True)
 class TierFilter:
     """Per-request filter controlling which tiers participate."""
@@ -136,13 +143,6 @@ class PrepareStoreOutput:
     keys_to_store: list[OffloadKey]
     store_spec: LoadStoreSpec
     evicted_keys: list[OffloadKey]
-
-
-class Locality(Enum):
-    """Locality of a tier's storage relative to the publishing instance."""
-
-    LOCAL = "LOCAL"
-    REMOTE = "REMOTE"
 
 
 @dataclass

--- a/vllm/v1/kv_offload/cpu/manager.py
+++ b/vllm/v1/kv_offload/cpu/manager.py
@@ -6,13 +6,13 @@ from typing import Literal
 
 from typing_extensions import override
 
-from vllm.distributed.kv_events import MEDIUM_CPU
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
     OffloadingConnectorStats,
 )
 from vllm.v1.kv_offload.base import (
     LoadStoreSpec,
     LookupResult,
+    Medium,
     OffloadingEvent,
     OffloadingManager,
     OffloadKey,
@@ -52,7 +52,7 @@ class CPUOffloadingManager(OffloadingManager):
         store_threshold: int = 1,
         max_tracker_size: int = 64_000,
     ):
-        self.event_medium: str = MEDIUM_CPU
+        self.medium: Medium = Medium.CPU
         self._num_blocks: int = num_blocks
         self._num_allocated_blocks: int = 0
         self._free_list: list[int] = []
@@ -219,7 +219,7 @@ class CPUOffloadingManager(OffloadingManager):
             self.events.append(
                 OffloadingEvent(
                     keys=to_evict,
-                    medium=self.event_medium,
+                    medium=self.medium,
                     removed=True,
                 )
             )
@@ -272,7 +272,7 @@ class CPUOffloadingManager(OffloadingManager):
             self.events.append(
                 OffloadingEvent(
                     keys=stored_keys,
-                    medium=self.event_medium,
+                    medium=self.medium,
                     removed=False,
                 )
             )

--- a/vllm/v1/kv_offload/cpu/manager.py
+++ b/vllm/v1/kv_offload/cpu/manager.py
@@ -52,7 +52,7 @@ class CPUOffloadingManager(OffloadingManager):
         store_threshold: int = 1,
         max_tracker_size: int = 64_000,
     ):
-        self.medium: str = MEDIUM_CPU
+        self.event_medium: str = MEDIUM_CPU
         self._num_blocks: int = num_blocks
         self._num_allocated_blocks: int = 0
         self._free_list: list[int] = []
@@ -219,7 +219,7 @@ class CPUOffloadingManager(OffloadingManager):
             self.events.append(
                 OffloadingEvent(
                     keys=to_evict,
-                    medium=self.medium,
+                    medium=self.event_medium,
                     removed=True,
                 )
             )
@@ -272,7 +272,7 @@ class CPUOffloadingManager(OffloadingManager):
             self.events.append(
                 OffloadingEvent(
                     keys=stored_keys,
-                    medium=self.medium,
+                    medium=self.event_medium,
                     removed=False,
                 )
             )

--- a/vllm/v1/kv_offload/tiering/base.py
+++ b/vllm/v1/kv_offload/tiering/base.py
@@ -7,6 +7,7 @@ Abstract interfaces and data types for the secondary tiering layer.
 from abc import ABC, abstractmethod
 from collections.abc import Collection, Iterable
 from dataclasses import dataclass
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -26,6 +27,17 @@ if TYPE_CHECKING:
         OffloadingConnectorStats,
     )
     from vllm.v1.kv_offload.base import OffloadingSpec
+
+LOOKUP_SCOPE_KEY = "lookup_scope"
+
+
+class LookupScope(Enum):
+    """Controls which tiers are queried during KV cache lookup."""
+
+    PRIMARY = "primary"
+    LOCAL = "local"  # TODO: not yet implemented — behaves as ALL
+    ALL = "all"
+
 
 # Type alias for job IDs used in async transfer tracking
 JobId = int

--- a/vllm/v1/kv_offload/tiering/base.py
+++ b/vllm/v1/kv_offload/tiering/base.py
@@ -7,13 +7,13 @@ Abstract interfaces and data types for the secondary tiering layer.
 from abc import ABC, abstractmethod
 from collections.abc import Collection, Iterable
 from dataclasses import dataclass
-from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
 
 from vllm.v1.kv_offload.base import (
     LookupResult,
+    Medium,
     OffloadingEvent,
     OffloadingMetricMetadata,
     OffloadKey,
@@ -27,16 +27,6 @@ if TYPE_CHECKING:
         OffloadingConnectorStats,
     )
     from vllm.v1.kv_offload.base import OffloadingSpec
-
-LOOKUP_SCOPE_KEY = "lookup_scope"
-
-
-class LookupScope(Enum):
-    """Controls which tiers are queried during KV cache lookup."""
-
-    CPU = "cpu"
-    LOCAL = "local"  # TODO: not yet implemented — behaves as ALL
-    ALL = "all"
 
 
 # Type alias for job IDs used in async transfer tracking
@@ -119,6 +109,8 @@ class SecondaryTierManager(ABC):
     lightweight and non-blocking. submit_load() and submit_store() submit
     async jobs; get_finished_jobs() polls for completion.
     """
+
+    filter_medium: ClassVar[Medium | None] = None
 
     def __init__(
         self,

--- a/vllm/v1/kv_offload/tiering/base.py
+++ b/vllm/v1/kv_offload/tiering/base.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 import numpy as np
 
 from vllm.v1.kv_offload.base import (
+    Locality,
     LookupResult,
     Medium,
     OffloadingEvent,
@@ -128,6 +129,7 @@ class SecondaryTierManager(ABC):
         self._offloading_spec = offloading_spec
         self._primary_kv_view: memoryview = primary_kv_view
         self.tier_type = tier_type
+        self.locality: Locality | None = None
 
     @abstractmethod
     def lookup(self, key: OffloadKey, req_context: ReqContext) -> LookupResult:

--- a/vllm/v1/kv_offload/tiering/base.py
+++ b/vllm/v1/kv_offload/tiering/base.py
@@ -110,7 +110,7 @@ class SecondaryTierManager(ABC):
     async jobs; get_finished_jobs() polls for completion.
     """
 
-    filter_medium: ClassVar[Medium | None] = None
+    medium: ClassVar[Medium | None] = None
 
     def __init__(
         self,

--- a/vllm/v1/kv_offload/tiering/base.py
+++ b/vllm/v1/kv_offload/tiering/base.py
@@ -34,7 +34,7 @@ LOOKUP_SCOPE_KEY = "lookup_scope"
 class LookupScope(Enum):
     """Controls which tiers are queried during KV cache lookup."""
 
-    PRIMARY = "primary"
+    CPU = "cpu"
     LOCAL = "local"  # TODO: not yet implemented — behaves as ALL
     ALL = "all"
 

--- a/vllm/v1/kv_offload/tiering/example/manager.py
+++ b/vllm/v1/kv_offload/tiering/example/manager.py
@@ -86,10 +86,6 @@ class ExampleSecondaryTierManager(SecondaryTierManager):
         Returns:
             HIT if the block is present, MISS if not found.
         """
-        if self.medium is not None and not req_context.load_tier_filter.allows(
-            self.medium
-        ):
-            return LookupResult.MISS
         return LookupResult.HIT if key in self.blocks else LookupResult.MISS
 
     @override

--- a/vllm/v1/kv_offload/tiering/example/manager.py
+++ b/vllm/v1/kv_offload/tiering/example/manager.py
@@ -43,7 +43,7 @@ class ExampleSecondaryTierManager(SecondaryTierManager):
     - Completes transfers immediately (synchronous)
     """
 
-    filter_medium: ClassVar[Medium | None] = Medium.CPU
+    medium: ClassVar[Medium] = Medium.CPU
 
     def __init__(
         self,
@@ -86,8 +86,8 @@ class ExampleSecondaryTierManager(SecondaryTierManager):
         Returns:
             HIT if the block is present, MISS if not found.
         """
-        if self.filter_medium is not None and not req_context.load_tier_filter.allows(
-            self.filter_medium
+        if self.medium is not None and not req_context.load_tier_filter.allows(
+            self.medium
         ):
             return LookupResult.MISS
         return LookupResult.HIT if key in self.blocks else LookupResult.MISS

--- a/vllm/v1/kv_offload/tiering/example/manager.py
+++ b/vllm/v1/kv_offload/tiering/example/manager.py
@@ -11,12 +11,13 @@ TieringOffloadingManager without requiring actual storage or network backends.
 
 import logging
 from collections.abc import Iterable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from typing_extensions import override
 
 from vllm.v1.kv_offload.base import (
     LookupResult,
+    Medium,
     OffloadKey,
     ReqContext,
     RequestOffloadingContext,
@@ -41,6 +42,8 @@ class ExampleSecondaryTierManager(SecondaryTierManager):
     - Stores blocks in a dictionary (key -> True)
     - Completes transfers immediately (synchronous)
     """
+
+    filter_medium: ClassVar[Medium | None] = Medium.CPU
 
     def __init__(
         self,
@@ -83,6 +86,10 @@ class ExampleSecondaryTierManager(SecondaryTierManager):
         Returns:
             HIT if the block is present, MISS if not found.
         """
+        if self.filter_medium is not None and not req_context.load_tier_filter.allows(
+            self.filter_medium
+        ):
+            return LookupResult.MISS
         return LookupResult.HIT if key in self.blocks else LookupResult.MISS
 
     @override

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -100,7 +100,7 @@ class FileSystemTierManager(SecondaryTierManager):
         content.
     """
 
-    medium: ClassVar[Medium] = Medium.FS
+    medium: ClassVar[Medium] = Medium.STORAGE
 
     def __init__(
         self,

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -194,10 +194,6 @@ class FileSystemTierManager(SecondaryTierManager):
 
     @override
     def lookup(self, key: OffloadKey, req_context: ReqContext) -> LookupResult:
-        if self.medium is not None and not req_context.load_tier_filter.allows(
-            self.medium
-        ):
-            return LookupResult.MISS
         result = self._lookup_manager.lookup(key, req_context)
         if result is None:
             return LookupResult.RETRY

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -30,7 +30,6 @@ except ImportError:
 
 from typing_extensions import override
 
-from vllm.distributed.kv_events import MEDIUM_FS
 from vllm.logger import init_logger
 from vllm.v1.kv_offload.base import (
     Locality,
@@ -101,8 +100,7 @@ class FileSystemTierManager(SecondaryTierManager):
         content.
     """
 
-    medium: ClassVar[str] = MEDIUM_FS
-    filter_medium: ClassVar[Medium | None] = Medium.STORAGE
+    medium: ClassVar[Medium] = Medium.FS
 
     def __init__(
         self,
@@ -196,8 +194,8 @@ class FileSystemTierManager(SecondaryTierManager):
 
     @override
     def lookup(self, key: OffloadKey, req_context: ReqContext) -> LookupResult:
-        if self.filter_medium is not None and not req_context.load_tier_filter.allows(
-            self.filter_medium
+        if self.medium is not None and not req_context.load_tier_filter.allows(
+            self.medium
         ):
             return LookupResult.MISS
         result = self._lookup_manager.lookup(key, req_context)

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -35,6 +35,7 @@ from vllm.logger import init_logger
 from vllm.v1.kv_offload.base import (
     Locality,
     LookupResult,
+    Medium,
     OffloadingEvent,
     OffloadKey,
     ReqContext,
@@ -101,6 +102,7 @@ class FileSystemTierManager(SecondaryTierManager):
     """
 
     medium: ClassVar[str] = MEDIUM_FS
+    filter_medium: ClassVar[Medium | None] = Medium.STORAGE
 
     def __init__(
         self,
@@ -194,6 +196,10 @@ class FileSystemTierManager(SecondaryTierManager):
 
     @override
     def lookup(self, key: OffloadKey, req_context: ReqContext) -> LookupResult:
+        if self.filter_medium is not None and not req_context.load_tier_filter.allows(
+            self.filter_medium
+        ):
+            return LookupResult.MISS
         result = self._lookup_manager.lookup(key, req_context)
         if result is None:
             return LookupResult.RETRY

--- a/vllm/v1/kv_offload/tiering/manager.py
+++ b/vllm/v1/kv_offload/tiering/manager.py
@@ -323,7 +323,7 @@ class TieringOffloadingManager(OffloadingManager):
 
         params = req_context.kv_transfer_params
         scope = params.get(LOOKUP_SCOPE_KEY) if params else None
-        if scope == LookupScope.PRIMARY.value:
+        if scope == LookupScope.CPU.value:
             return LookupResult.MISS
 
         lookup_start = time.monotonic()

--- a/vllm/v1/kv_offload/tiering/manager.py
+++ b/vllm/v1/kv_offload/tiering/manager.py
@@ -324,6 +324,10 @@ class TieringOffloadingManager(OffloadingManager):
         for tier in self.secondary_tiers:
             if tier is exclude_tier:
                 continue
+            if tier.medium is not None and not req_context.load_tier_filter.allows(
+                tier.medium
+            ):
+                continue
             result = tier.lookup(key, req_context)
             if result is LookupResult.HIT:
                 promoted = self._initiate_promotion(tier, key, req_context)

--- a/vllm/v1/kv_offload/tiering/manager.py
+++ b/vllm/v1/kv_offload/tiering/manager.py
@@ -47,8 +47,10 @@ from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
 from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
 from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
 from vllm.v1.kv_offload.tiering.base import (
+    LOOKUP_SCOPE_KEY,
     JobId,
     JobMetadata,
+    LookupScope,
     ParentManager,
     SecondaryTierManager,
     TieringOffloadingMetrics,
@@ -318,6 +320,11 @@ class TieringOffloadingManager(OffloadingManager):
             return LookupResult.HIT
         if primary_hit is LookupResult.HIT_PENDING:
             return LookupResult.HIT_PENDING
+
+        params = req_context.kv_transfer_params
+        scope = params.get(LOOKUP_SCOPE_KEY) if params else None
+        if scope == LookupScope.PRIMARY.value:
+            return LookupResult.MISS
 
         lookup_start = time.monotonic()
         any_retry = False

--- a/vllm/v1/kv_offload/tiering/manager.py
+++ b/vllm/v1/kv_offload/tiering/manager.py
@@ -47,10 +47,8 @@ from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
 from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
 from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
 from vllm.v1.kv_offload.tiering.base import (
-    LOOKUP_SCOPE_KEY,
     JobId,
     JobMetadata,
-    LookupScope,
     ParentManager,
     SecondaryTierManager,
     TieringOffloadingMetrics,
@@ -320,11 +318,6 @@ class TieringOffloadingManager(OffloadingManager):
             return LookupResult.HIT
         if primary_hit is LookupResult.HIT_PENDING:
             return LookupResult.HIT_PENDING
-
-        params = req_context.kv_transfer_params
-        scope = params.get(LOOKUP_SCOPE_KEY) if params else None
-        if scope == LookupScope.CPU.value:
-            return LookupResult.MISS
 
         lookup_start = time.monotonic()
         any_retry = False

--- a/vllm/v1/kv_offload/tiering/manager.py
+++ b/vllm/v1/kv_offload/tiering/manager.py
@@ -324,9 +324,7 @@ class TieringOffloadingManager(OffloadingManager):
         for tier in self.secondary_tiers:
             if tier is exclude_tier:
                 continue
-            if tier.medium is not None and not req_context.load_tier_filter.allows(
-                tier.medium
-            ):
+            if not req_context.load_tier_filter.allows(tier.medium, tier.locality):
                 continue
             result = tier.lookup(key, req_context)
             if result is LookupResult.HIT:

--- a/vllm/v1/kv_offload/tiering/obj/manager.py
+++ b/vllm/v1/kv_offload/tiering/obj/manager.py
@@ -98,7 +98,7 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
     primary tier. Object keys are formed as ``{prefix}/{hash_shard}/{hash}.bin``.
     """
 
-    medium: ClassVar[Medium] = Medium.OBJ
+    medium: ClassVar[Medium] = Medium.STORAGE
 
     def __init__(
         self,

--- a/vllm/v1/kv_offload/tiering/obj/manager.py
+++ b/vllm/v1/kv_offload/tiering/obj/manager.py
@@ -267,10 +267,6 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
         self._transfers[job_id] = TransferEntry(xfer_handle, files_desc, obj_handle)
 
     def lookup(self, key: OffloadKey, req_context: ReqContext) -> LookupResult:
-        if self.medium is not None and not req_context.load_tier_filter.allows(
-            self.medium
-        ):
-            return LookupResult.MISS
         result = self._lookup_manager.lookup(key, req_context)
         if result is None:
             return LookupResult.RETRY

--- a/vllm/v1/kv_offload/tiering/obj/manager.py
+++ b/vllm/v1/kv_offload/tiering/obj/manager.py
@@ -7,7 +7,6 @@ import time
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, ClassVar, NamedTuple
 
-from vllm.distributed.kv_events import MEDIUM_OBJ
 from vllm.distributed.nixl_utils import NixlWrapper as nixl_agent
 from vllm.distributed.nixl_utils import nixl_agent_config
 from vllm.logger import init_logger
@@ -99,8 +98,7 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
     primary tier. Object keys are formed as ``{prefix}/{hash_shard}/{hash}.bin``.
     """
 
-    medium: ClassVar[str] = MEDIUM_OBJ
-    filter_medium: ClassVar[Medium | None] = Medium.STORAGE
+    medium: ClassVar[Medium] = Medium.OBJ
 
     def __init__(
         self,
@@ -269,8 +267,8 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
         self._transfers[job_id] = TransferEntry(xfer_handle, files_desc, obj_handle)
 
     def lookup(self, key: OffloadKey, req_context: ReqContext) -> LookupResult:
-        if self.filter_medium is not None and not req_context.load_tier_filter.allows(
-            self.filter_medium
+        if self.medium is not None and not req_context.load_tier_filter.allows(
+            self.medium
         ):
             return LookupResult.MISS
         result = self._lookup_manager.lookup(key, req_context)

--- a/vllm/v1/kv_offload/tiering/obj/manager.py
+++ b/vllm/v1/kv_offload/tiering/obj/manager.py
@@ -14,6 +14,7 @@ from vllm.logger import init_logger
 from vllm.v1.kv_offload.base import (
     Locality,
     LookupResult,
+    Medium,
     OffloadingEvent,
     OffloadKey,
     ReqContext,
@@ -99,6 +100,7 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
     """
 
     medium: ClassVar[str] = MEDIUM_OBJ
+    filter_medium: ClassVar[Medium | None] = Medium.STORAGE
 
     def __init__(
         self,
@@ -267,6 +269,10 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
         self._transfers[job_id] = TransferEntry(xfer_handle, files_desc, obj_handle)
 
     def lookup(self, key: OffloadKey, req_context: ReqContext) -> LookupResult:
+        if self.filter_medium is not None and not req_context.load_tier_filter.allows(
+            self.filter_medium
+        ):
+            return LookupResult.MISS
         result = self._lookup_manager.lookup(key, req_context)
         if result is None:
             return LookupResult.RETRY


### PR DESCRIPTION
## Purpose

Adds per-request tier filtering to KV cache offloading.
Requests can specify which secondary tiers to load from via `kv_transfer_params["kv_load_tiers"]`, filtering by medium and locality.

See detailed design discussion: https://github.com/vllm-project/vllm/pull/48123#issuecomment-4979058299


Key changes:
- `Medium` enum: `CPU`/`STORAGE` (coarse granularity, both FS and OBJ → STORAGE)
- `TierMatcher(NamedTuple)` with optional `medium` and `locality` fields
- `TierFilter` with `allows()` — applied to secondary tiers only (primary always participates)
- `_parse_tier_filter()` validates request params with warning logging
- `MEDIUM_STORAGE` wire constant in `kv_events.py` (replaces `MEDIUM_FS`/`MEDIUM_OBJ`)
- `Locality` enum on `SecondaryTierManager` base class

Design decisions (confirmed by reviewers):
- Filter gates secondary tiers only; primary always participates (it's the promotion target)
- `None` on tier side = "unconstrained" (passes any filter) — supports P2P tiers with dynamic locality
- `None` on matcher side = "match anything"


## Test Plan
```
pytest -v tests/v1/kv_offload/tiering/ \
          tests/v1/kv_offload/cpu/test_manager.py \
          tests/v1/kv_connector/unit/offloading_connector/test_events.py \
          tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
```

## Test Result
```
437 passed, 17 warnings in 183.26s (0:03:03) 
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

