### PR TITLE
fix(ovis2.5): prevent VTE crash from empty indicator_tokens

### DIFF
--- a/vllm/model_executor/models/ovis2_5.py
+++ b/vllm/model_executor/models/ovis2_5.py
@@ -351,28 +351,40 @@ class Ovis2_5MultiModalProcessor(BaseMultiModalProcessor[Ovis2_5ProcessingInfo])
             mm_kwargs=mm_kwargs,
             tok_kwargs=tok_kwargs,
         )
-        hf_processor = self.info.get_hf_processor()
+        hf_config = self.info.get_hf_config()
+        vte_vocab_size = hf_config.visual_vocab_size
 
         if "videos" in mm_data:
-            visual_indicators = [
-                hf_processor.construct_visual_indicators((1, 1, 1), True)
-                for grid in processed_outputs["video_grids"]
-            ]
-            indicator_tokens = [
-                self.visual_indicators_to_visual_tokens(indicator)
-                for indicator in visual_indicators
-            ]
+            video_start = vte_vocab_size - len(INDICATOR_IDS)
+            visual_atom = vte_vocab_size - len(INDICATOR_IDS) + 1
+            video_end = vte_vocab_size - len(INDICATOR_IDS) + 3
+            indicator_tokens = []
+            for grid in processed_outputs["video_grids"]:
+                g = grid.flatten().tolist()
+                if len(g) >= 3:
+                    patches = g[0] * g[1] * g[2]
+                else:
+                    patches = 1
+                if patches > 1:
+                    indicator_tokens.append([video_start, video_end])
+                else:
+                    indicator_tokens.append([video_start, visual_atom, video_end])
             processed_outputs["video_indicator_tokens"] = torch.tensor(indicator_tokens)
         if "images" in mm_data:
-            visual_indicators = [
-                hf_processor.construct_visual_indicators((1, 1, 1), False)
-                for grid in processed_outputs["grids"]
-            ]
-            indicator_tokens = [
-                self.visual_indicators_to_visual_tokens(indicator)
-                for indicator in visual_indicators
-            ]
-
+            image_start = vte_vocab_size - len(INDICATOR_IDS)
+            visual_atom = vte_vocab_size - len(INDICATOR_IDS) + 1
+            image_end = vte_vocab_size - len(INDICATOR_IDS) + 2
+            indicator_tokens = []
+            for grid in processed_outputs["grids"]:
+                g = grid.flatten().tolist()
+                if len(g) >= 3:
+                    patches = g[0] * g[1] * g[2]
+                else:
+                    patches = 1
+                if patches > 1:
+                    indicator_tokens.append([image_start, image_end])
+                else:
+                    indicator_tokens.append([image_start, visual_atom, image_end])
             processed_outputs["indicator_tokens"] = torch.tensor(indicator_tokens)
         return processed_outputs
 
@@ -550,6 +562,24 @@ class Ovis2_5(nn.Module, SupportsMultiModal, SupportsPP):
         patches_per_image = visual_input["patches_per_item"]
         indicator_tokens = visual_input["indicator_tokens"]
         grid_thws = visual_input["grids"]
+
+        if indicator_tokens.numel() == 0:
+            vte_vocab_size = self.config.visual_vocab_size
+            is_video = visual_input["type"] == "video_patches"
+            start_idx = vte_vocab_size - len(INDICATOR_IDS)
+            atom_idx = vte_vocab_size - len(INDICATOR_IDS) + 1
+            end_idx = vte_vocab_size - len(INDICATOR_IDS) + (3 if is_video else 2)
+            tokens_list = []
+            for patches in patches_per_image:
+                if patches > 1:
+                    tokens_list.append([start_idx, end_idx])
+                else:
+                    tokens_list.append([start_idx, atom_idx, end_idx])
+            indicator_tokens = torch.tensor(
+                tokens_list,
+                dtype=indicator_tokens.dtype,
+                device=indicator_tokens.device,
+            )
 
         indicator_per_image = list(
             map(lambda x: 2 if x > 1 else x + 2, patches_per_image)


### PR DESCRIPTION
## Problem

Ovis2.5-9B crashes with `RuntimeError: mat1 and mat2 shapes cannot be multiplied (1x0 and 65536x4096)` when processing image requests.

## Root Cause

`_call_hf_processor` calls `hf_processor.construct_visual_indicators((1, 1, 1), False)` using a hardcoded grid `(1,1,1)` instead of the actual image grid dimensions. This produces indicator tokens that don't match the `indicator_per_image` computed in `_process_visual_input`.

Even after the processor fix was applied (returning `_INDICATOR_IDS` values by default), the hardcoded grid means:
- The token count is always 3 (start, atom, end) regardless of actual image dimensions
- But `indicator_per_image` expects 2 tokens for images with patches > 1
- This mismatch causes incorrect splits or empty tensors that crash the VTE embedding layer

## Fix

1. **Direct VTE index computation in `_call_hf_processor`**: Bypass the `construct_visual_indicators` -> `visual_indicators_to_visual_tokens` pipeline entirely. Compute VTE indices directly from `visual_vocab_size` and `INDICATOR_IDS`, using the actual grid from `processed_outputs` to correctly determine the token count (2 for patches>1, 3 otherwise).

2. **Defensive fallback in `_process_visual_input`**: Regenerate `indicator_tokens` if the tensor is empty, preventing crashes even if upstream data is malformed.

## Testing

- Single image non-streaming and streaming: correct output
- Text-only requests: no regression
- Model startup with profiling: no crash
- Verified VTE indices fall within valid range [0, visual_vocab_size)
- Verified indicator_tokens length matches indicator_per_image expectation