### PR TITLE
[Model] Enable LoRA support for tower and connector in Intern-S1

### DIFF
--- a/vllm/model_executor/models/interns1.py
+++ b/vllm/model_executor/models/interns1.py
@@ -542,9 +542,8 @@ class InternS1ForConditionalGeneration(
         image_size = config.vision_config.image_size[0]
         patch_size = config.vision_config.patch_size[0]
         self.patch_size = patch_size
-        self.num_image_token = int(
-            (image_size // patch_size) ** 2 * (config.downsample_ratio**2)
-        )
+        self.patch_tokens = (image_size // patch_size) ** 2
+        self.num_image_token = int(self.patch_tokens * (config.downsample_ratio**2))
         self.downsample_ratio = config.downsample_ratio
 
         with self._mark_tower_model(vllm_config, {"image", "video"}):
@@ -818,3 +817,17 @@ class InternS1ForConditionalGeneration(
             connector="multi_modal_projector",
             tower_model="vision_tower",
         )
+
+    def get_num_mm_encoder_tokens(self, num_image_tokens: int) -> int:
+        if num_image_tokens <= 0 or self.num_image_token <= 0:
+            return 0
+
+        num_patches = num_image_tokens // self.num_image_token
+        return num_patches * (self.patch_tokens + 1)
+
+    def get_num_mm_connector_tokens(self, num_vision_tokens: int) -> int:
+        if num_vision_tokens <= 0 or self.num_image_token <= 0:
+            return 0
+
+        num_patches = num_vision_tokens // (self.patch_tokens + 1)
+        return num_patches * self.num_image_token


### PR DESCRIPTION
## Purpose

Part of #31479 (enable LoRA for the tower and connector in more multimodal models).

Implement `get_num_mm_encoder_tokens()` and `get_num_mm_connector_tokens()` for `InternS1ForConditionalGeneration`, following the InternVL implementation from #32397 (same architecture family: fixed 448x448 tiles, InternViT with a CLS token, 0.5x pixel shuffle, MLP projector).

Without these methods the LoRA manager disables tower/connector LoRA for Intern-S1 even though the model already declares `SupportsLoRA` and a tower/connector `get_mm_mapping()`; running with `enable_tower_connector_lora=True` currently logs "does not support it. This will be ignored."

Token math per 448x448 tile:

- LLM placeholder embeds: `num_image_token = (448/14)^2 * 0.5^2 = 256`
- Vision tower: `(448/14)^2 + 1 = 1025` tokens (1024 patches + CLS)
- Connector input after pixel shuffle: 256 tokens

Duplicate check: no existing PR adds these helpers for Intern-S1 — #46740 (merged) covers language-backbone LoRA only, and Intern-S1 is not claimed in the #31479 thread.

## Test Plan

No GPU available locally; CPU verification:

1. `pre-commit run` (ruff, mypy, typos, DCO).
2. Validate the token math against the real HF processor (`internlm/Intern-S1-mini`) across five aspect ratios (1–13 tiles): assert placeholder embed count == tiles * 256, per-tile patch grid == 1024, and that both helpers roundtrip exactly.
3. Instantiate vLLM's `InternS1VisionEmbeddings` with the real Intern-S1-mini vision config and check the output sequence length per tile.

## Test Result

1. All pre-commit hooks pass.
2. All shapes pass, e.g. 800x1300 -> tiles=7, embeds=1792, encoder_tokens=7175 (= 7 * 1025), connector_tokens=1792; 2000x640 -> tiles=13, embeds=3328, encoder_tokens=13325, connector_tokens=3328.
3. Output shape `(2, 1025, 1024)` for two 448x448 tiles, confirming the `patch_tokens + 1` (CLS) term; the encoder blocks and final layernorm are length-preserving, so tower tokens = tiles * 1025.

I don't have GPU hardware to run e2e with `enable_tower_connector_lora=True`; would appreciate a check from anyone who does — happy to iterate.

---

This PR was developed with AI assistance; I have reviewed every changed line and take responsibility for the change.
