### PR TITLE
[Frontend] Bound realtime STT audio_queue and per-session audio bytes

### DIFF
--- a/tests/entrypoints/speech_to_text/realtime/test_realtime_audio_queue_cap.py
+++ b/tests/entrypoints/speech_to_text/realtime/test_realtime_audio_queue_cap.py
@@ -11,10 +11,10 @@ import json
 import pybase64 as base64
 import pytest
 
-from vllm.entrypoints.speech_to_text.realtime.connection import (
-    MAX_AUDIO_QUEUE_SIZE,
-    RealtimeConnection,
-)
+from vllm import envs
+from vllm.entrypoints.speech_to_text.realtime.connection import RealtimeConnection
+
+MAX_AUDIO_QUEUE_SIZE = envs.VLLM_MAX_REALTIME_AUDIO_QUEUE_SIZE
 
 
 class FakeWebSocket:

--- a/tests/entrypoints/speech_to_text/realtime/test_realtime_audio_queue_cap.py
+++ b/tests/entrypoints/speech_to_text/realtime/test_realtime_audio_queue_cap.py
@@ -6,6 +6,7 @@ Covers both the per-connection audio_queue cap and the cumulative
 byte tracking against VLLM_MAX_AUDIO_CLIP_FILESIZE_MB.
 """
 
+import asyncio
 import json
 
 import pybase64 as base64
@@ -36,6 +37,23 @@ class StubServing:
         return None
 
 
+class StubModelCls:
+    realtime_max_tokens = 100
+
+
+class StubEngineClient:
+    async def generate(self, prompt, sampling_params, request_id):
+        # Empty result stream: generation completes with no output.
+        for _ in ():
+            yield _
+
+
+class StubServingWithEngine(StubServing):
+    def __init__(self):
+        self.model_cls = StubModelCls()
+        self.engine_client = StubEngineClient()
+
+
 def _append_event(num_samples: int = 1600) -> dict:
     payload = b"\x00\x01" * num_samples
     return {
@@ -47,6 +65,14 @@ def _append_event(num_samples: int = 1600) -> dict:
 def _make_conn() -> tuple[RealtimeConnection, FakeWebSocket]:
     fake_ws = FakeWebSocket()
     conn = RealtimeConnection(fake_ws, StubServing())
+    conn._is_connected = True
+    conn._is_model_validated = True
+    return conn, fake_ws
+
+
+def _make_conn_with_engine() -> tuple[RealtimeConnection, FakeWebSocket]:
+    fake_ws = FakeWebSocket()
+    conn = RealtimeConnection(fake_ws, StubServingWithEngine())
     conn._is_connected = True
     conn._is_model_validated = True
     return conn, fake_ws
@@ -106,14 +132,67 @@ async def test_cumulative_bytes_rejects_past_threshold():
 
 
 @pytest.mark.asyncio
-async def test_cumulative_bytes_reset_after_drain():
-    conn, _ = _make_conn()
+async def test_cumulative_bytes_reset_by_generation():
+    conn, _ = _make_conn_with_engine()
 
     for _ in range(5):
         await conn.handle_event(_append_event())
     assert conn._accumulated_audio_bytes == 5 * 3200
 
-    conn._accumulated_audio_bytes = 0
+    # Drive the real reset path: _run_generation clears the queue and the
+    # byte counter in its finally block.
+    audio_stream = conn.audio_stream_generator()
+    input_stream = asyncio.Queue()
+    await conn._run_generation(audio_stream, input_stream)
 
-    await conn.handle_event(_append_event())
-    assert conn._accumulated_audio_bytes == 3200
+    assert conn._accumulated_audio_bytes == 0
+    assert conn.audio_queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_rejected_chunks_do_not_count_toward_byte_limit():
+    conn, _ = _make_conn()
+
+    for _ in range(MAX_AUDIO_QUEUE_SIZE):
+        await conn.handle_event(_append_event())
+    at_capacity = conn._accumulated_audio_bytes
+    assert at_capacity == MAX_AUDIO_QUEUE_SIZE * 3200
+
+    # Overflow appends are rejected; their bytes must not be counted.
+    for _ in range(3):
+        await conn.handle_event(_append_event())
+    assert conn._accumulated_audio_bytes == at_capacity
+
+
+@pytest.mark.asyncio
+async def test_cleanup_enqueues_sentinel_on_full_queue():
+    conn, _ = _make_conn()
+
+    for _ in range(MAX_AUDIO_QUEUE_SIZE):
+        await conn.handle_event(_append_event())
+    assert conn.audio_queue.full()
+
+    # cleanup must not raise QueueFull and must still enqueue the sentinel.
+    await conn.cleanup()
+
+    items = []
+    while not conn.audio_queue.empty():
+        items.append(conn.audio_queue.get_nowait())
+    assert items[-1] is None
+
+
+@pytest.mark.asyncio
+async def test_commit_final_enqueues_sentinel_on_full_queue():
+    conn, _ = _make_conn()
+
+    for _ in range(MAX_AUDIO_QUEUE_SIZE):
+        await conn.handle_event(_append_event())
+    assert conn.audio_queue.full()
+
+    # A final commit on a full queue must not raise QueueFull.
+    await conn.handle_event({"type": "input_audio_buffer.commit", "final": True})
+
+    items = []
+    while not conn.audio_queue.empty():
+        items.append(conn.audio_queue.get_nowait())
+    assert items[-1] is None

--- a/tests/entrypoints/speech_to_text/realtime/test_realtime_audio_queue_cap.py
+++ b/tests/entrypoints/speech_to_text/realtime/test_realtime_audio_queue_cap.py
@@ -142,7 +142,7 @@ async def test_cumulative_bytes_reset_by_generation():
     # Drive the real reset path: _run_generation clears the queue and the
     # byte counter in its finally block.
     audio_stream = conn.audio_stream_generator()
-    input_stream = asyncio.Queue()
+    input_stream: asyncio.Queue[list[int]] = asyncio.Queue()
     await conn._run_generation(audio_stream, input_stream)
 
     assert conn._accumulated_audio_bytes == 0

--- a/tests/entrypoints/speech_to_text/realtime/test_realtime_audio_queue_cap.py
+++ b/tests/entrypoints/speech_to_text/realtime/test_realtime_audio_queue_cap.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests that the realtime WebSocket audio path bounds memory.
+
+Covers both the per-connection audio_queue cap and the cumulative
+byte tracking against VLLM_MAX_AUDIO_CLIP_FILESIZE_MB.
+"""
+
+import json
+
+import pybase64 as base64
+import pytest
+
+from vllm.entrypoints.speech_to_text.realtime.connection import (
+    MAX_AUDIO_QUEUE_SIZE,
+    RealtimeConnection,
+)
+
+
+class FakeWebSocket:
+    def __init__(self):
+        self.sent: list[str] = []
+
+    async def accept(self):
+        pass
+
+    async def send_text(self, data: str):
+        self.sent.append(data)
+
+
+class StubServing:
+    def _is_model_supported(self, model):
+        return True
+
+    def create_error_response(self, **kw):
+        return None
+
+
+def _append_event(num_samples: int = 1600) -> dict:
+    payload = b"\x00\x01" * num_samples
+    return {
+        "type": "input_audio_buffer.append",
+        "audio": base64.b64encode(payload).decode("ascii"),
+    }
+
+
+def _make_conn() -> tuple[RealtimeConnection, FakeWebSocket]:
+    fake_ws = FakeWebSocket()
+    conn = RealtimeConnection(fake_ws, StubServing())
+    conn._is_connected = True
+    conn._is_model_validated = True
+    return conn, fake_ws
+
+
+@pytest.mark.asyncio
+async def test_audio_queue_is_capped():
+    conn, _ = _make_conn()
+
+    for _ in range(MAX_AUDIO_QUEUE_SIZE + 5):
+        await conn.handle_event(_append_event())
+
+    assert conn.audio_queue.qsize() == MAX_AUDIO_QUEUE_SIZE
+
+
+@pytest.mark.asyncio
+async def test_overflow_appends_emit_buffer_full_error():
+    conn, fake_ws = _make_conn()
+
+    overflow = 3
+    for _ in range(MAX_AUDIO_QUEUE_SIZE + overflow):
+        await conn.handle_event(_append_event())
+
+    errors = [json.loads(m) for m in fake_ws.sent if "error" in m]
+    buffer_full = [e for e in errors if e.get("code") == "buffer_full"]
+    assert len(buffer_full) == overflow
+
+
+@pytest.mark.asyncio
+async def test_draining_queue_allows_new_appends():
+    conn, _ = _make_conn()
+
+    for _ in range(MAX_AUDIO_QUEUE_SIZE):
+        await conn.handle_event(_append_event())
+    assert conn.audio_queue.qsize() == MAX_AUDIO_QUEUE_SIZE
+
+    while not conn.audio_queue.empty():
+        conn.audio_queue.get_nowait()
+
+    await conn.handle_event(_append_event())
+    assert conn.audio_queue.qsize() == 1
+
+
+@pytest.mark.asyncio
+async def test_cumulative_bytes_rejects_past_threshold():
+    conn, fake_ws = _make_conn()
+    conn._max_audio_filesize_mb = 0.01
+
+    # Each chunk is 1600 PCM16 samples = 3200 bytes = ~3.125 KB.
+    # The 0.01 MB (10.24 KB) threshold is crossed on the 4th chunk.
+    for _ in range(10):
+        await conn.handle_event(_append_event())
+
+    errors = [json.loads(m) for m in fake_ws.sent if "error" in m]
+    assert any(e.get("code") == "invalid_audio" for e in errors)
+    assert conn._accumulated_audio_bytes > 0.01 * 1024**2
+
+
+@pytest.mark.asyncio
+async def test_cumulative_bytes_reset_after_drain():
+    conn, _ = _make_conn()
+
+    for _ in range(5):
+        await conn.handle_event(_append_event())
+    assert conn._accumulated_audio_bytes == 5 * 3200
+
+    conn._accumulated_audio_bytes = 0
+
+    await conn.handle_event(_append_event())
+    assert conn._accumulated_audio_bytes == 3200

--- a/vllm/entrypoints/speech_to_text/realtime/connection.py
+++ b/vllm/entrypoints/speech_to_text/realtime/connection.py
@@ -30,8 +30,6 @@ from .serving import OpenAIServingRealtime
 
 logger = init_logger(__name__)
 
-MAX_AUDIO_QUEUE_SIZE = 256
-
 
 class RealtimeConnection:
     """Manages WebSocket lifecycle and state for realtime transcription.
@@ -49,7 +47,7 @@ class RealtimeConnection:
         self.connection_id = f"ws-{uuid4()}"
         self.serving = serving
         self.audio_queue: asyncio.Queue[np.ndarray | None] = asyncio.Queue(
-            maxsize=MAX_AUDIO_QUEUE_SIZE
+            maxsize=envs.VLLM_MAX_REALTIME_AUDIO_QUEUE_SIZE
         )
         self.generation_task: asyncio.Task | None = None
 

--- a/vllm/entrypoints/speech_to_text/realtime/connection.py
+++ b/vllm/entrypoints/speech_to_text/realtime/connection.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import asyncio
+import contextlib
 import json
 from collections.abc import AsyncGenerator
 from http import HTTPStatus
@@ -17,6 +18,7 @@ from vllm.entrypoints.openai.engine.protocol import ErrorResponse, UsageInfo
 from vllm.entrypoints.serve.utils.api_utils import sanitize_message
 from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
+from vllm.utils.mem_constants import MiB_bytes
 
 from .protocol import (
     ErrorEvent,
@@ -127,12 +129,12 @@ class RealtimeConnection:
                 )
 
                 self._accumulated_audio_bytes += len(audio_bytes)
-                accumulated_mb = self._accumulated_audio_bytes / 1024**2
-                if accumulated_mb > self._max_audio_filesize_mb:
+                max_bytes = self._max_audio_filesize_mb * MiB_bytes
+                if self._accumulated_audio_bytes > max_bytes:
                     raise VLLMValidationError(
                         "Maximum file size exceeded",
                         parameter="audio_filesize_mb",
-                        value=accumulated_mb,
+                        value=self._accumulated_audio_bytes / MiB_bytes,
                     )
                 if len(audio_array) == 0:
                     raise VLLMValidationError("Can't process empty audio.")
@@ -140,6 +142,9 @@ class RealtimeConnection:
                 try:
                     self.audio_queue.put_nowait(audio_array)
                 except asyncio.QueueFull:
+                    # The chunk was not buffered, so don't count it toward
+                    # the cumulative byte limit.
+                    self._accumulated_audio_bytes -= len(audio_bytes)
                     await self.send_error("Audio buffer full", "buffer_full")
 
             except Exception as e:
@@ -161,7 +166,7 @@ class RealtimeConnection:
             commit_event = InputAudioBufferCommit(**event)
             # final signals that the audio is finished
             if commit_event.final:
-                self.audio_queue.put_nowait(None)
+                self._enqueue_end_sentinel()
             else:
                 await self.start_generation()
         else:
@@ -264,14 +269,15 @@ class RealtimeConnection:
             # Send final completion event
             await self.send(TranscriptionDone(text=full_text, usage=usage))
 
-            # Clear queue for next utterance
-            while not self.audio_queue.empty():
-                self.audio_queue.get_nowait()
-            self._accumulated_audio_bytes = 0
-
         except Exception as e:
             logger.exception("Error in generation: %s", e)
             await self.send_error(sanitize_message(str(e)), "processing_error")
+        finally:
+            # Clear the queue and reset the byte counter for the next
+            # utterance, even if generation errored or was cancelled.
+            while not self.audio_queue.empty():
+                self.audio_queue.get_nowait()
+            self._accumulated_audio_bytes = 0
 
     async def send(
         self, event: SessionCreated | TranscriptionDelta | TranscriptionDone
@@ -285,10 +291,26 @@ class RealtimeConnection:
         error_event = ErrorEvent(error=message, code=code)
         await self.websocket.send_text(error_event.model_dump_json())
 
+    def _enqueue_end_sentinel(self):
+        """Enqueue the end-of-stream sentinel without blocking.
+
+        The queue is bounded, so put_nowait can raise QueueFull. Drop one
+        buffered chunk to make room so the generator still receives the
+        sentinel and exits instead of hanging.
+        """
+        try:
+            self.audio_queue.put_nowait(None)
+        except asyncio.QueueFull:
+            # Drop one buffered chunk to make room for the sentinel.
+            with contextlib.suppress(asyncio.QueueEmpty):
+                self.audio_queue.get_nowait()
+            with contextlib.suppress(asyncio.QueueFull):
+                self.audio_queue.put_nowait(None)
+
     async def cleanup(self):
         """Cleanup resources."""
         # Signal audio stream to stop
-        self.audio_queue.put_nowait(None)
+        self._enqueue_end_sentinel()
 
         # Cancel generation task if running
         if self.generation_task and not self.generation_task.done():

--- a/vllm/entrypoints/speech_to_text/realtime/connection.py
+++ b/vllm/entrypoints/speech_to_text/realtime/connection.py
@@ -30,6 +30,8 @@ from .serving import OpenAIServingRealtime
 
 logger = init_logger(__name__)
 
+MAX_AUDIO_QUEUE_SIZE = 256
+
 
 class RealtimeConnection:
     """Manages WebSocket lifecycle and state for realtime transcription.
@@ -46,13 +48,16 @@ class RealtimeConnection:
         self.websocket = websocket
         self.connection_id = f"ws-{uuid4()}"
         self.serving = serving
-        self.audio_queue: asyncio.Queue[np.ndarray | None] = asyncio.Queue()
+        self.audio_queue: asyncio.Queue[np.ndarray | None] = asyncio.Queue(
+            maxsize=MAX_AUDIO_QUEUE_SIZE
+        )
         self.generation_task: asyncio.Task | None = None
 
         self._is_connected = False
         self._is_model_validated = False
 
         self._max_audio_filesize_mb = envs.VLLM_MAX_AUDIO_CLIP_FILESIZE_MB
+        self._accumulated_audio_bytes = 0
 
     async def handle_connection(self):
         """Main connection loop."""
@@ -123,17 +128,21 @@ class RealtimeConnection:
                     / 32768.0
                 )
 
-                if len(audio_array) / 1024**2 > self._max_audio_filesize_mb:
+                self._accumulated_audio_bytes += len(audio_bytes)
+                accumulated_mb = self._accumulated_audio_bytes / 1024**2
+                if accumulated_mb > self._max_audio_filesize_mb:
                     raise VLLMValidationError(
                         "Maximum file size exceeded",
                         parameter="audio_filesize_mb",
-                        value=len(audio_array) / 1024**2,
+                        value=accumulated_mb,
                     )
                 if len(audio_array) == 0:
                     raise VLLMValidationError("Can't process empty audio.")
 
-                # Put audio chunk in queue
-                self.audio_queue.put_nowait(audio_array)
+                try:
+                    self.audio_queue.put_nowait(audio_array)
+                except asyncio.QueueFull:
+                    await self.send_error("Audio buffer full", "buffer_full")
 
             except Exception as e:
                 logger.error("Failed to decode audio: %s", e)
@@ -260,6 +269,7 @@ class RealtimeConnection:
             # Clear queue for next utterance
             while not self.audio_queue.empty():
                 self.audio_queue.get_nowait()
+            self._accumulated_audio_bytes = 0
 
         except Exception as e:
             logger.exception("Error in generation: %s", e)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -77,6 +77,7 @@ if TYPE_CHECKING:
     VLLM_MEDIA_URL_ALLOW_REDIRECTS: bool = True
     VLLM_MEDIA_LOADING_THREAD_COUNT: int = 8
     VLLM_MAX_AUDIO_CLIP_FILESIZE_MB: int = 25
+    VLLM_MAX_REALTIME_AUDIO_QUEUE_SIZE: int = 256
     VLLM_MAX_AUDIO_DECODE_DURATION_S: int = 600
     VLLM_MAX_AUDIO_PREPROCESS_WORKERS: int = max(1, min(os.cpu_count() or 1, 2))
     VLLM_MAX_IMAGE_PIXELS: int = 178_956_970
@@ -951,6 +952,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Default is 25 MB
     "VLLM_MAX_AUDIO_CLIP_FILESIZE_MB": lambda: int(
         os.getenv("VLLM_MAX_AUDIO_CLIP_FILESIZE_MB", "25")
+    ),
+    # Maximum number of audio chunks queued per realtime WebSocket
+    # connection before further input_audio_buffer.append events are
+    # rejected with a buffer_full error. Default is 256.
+    "VLLM_MAX_REALTIME_AUDIO_QUEUE_SIZE": lambda: int(
+        os.getenv("VLLM_MAX_REALTIME_AUDIO_QUEUE_SIZE", "256")
     ),
     # Maximum decoded audio duration in seconds.  Compressed audio files
     # (e.g. OPUS at very low bitrate) can expand into gigabytes of float32
@@ -2125,6 +2132,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_MEDIA_URL_ALLOW_REDIRECTS",
         "VLLM_MEDIA_LOADING_THREAD_COUNT",
         "VLLM_MAX_AUDIO_CLIP_FILESIZE_MB",
+        "VLLM_MAX_REALTIME_AUDIO_QUEUE_SIZE",
         "VLLM_MAX_AUDIO_DECODE_DURATION_S",
         "VLLM_MAX_AUDIO_PREPROCESS_WORKERS",
         "VLLM_MAX_IMAGE_PIXELS",

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -955,9 +955,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Maximum number of audio chunks queued per realtime WebSocket
     # connection before further input_audio_buffer.append events are
-    # rejected with a buffer_full error. Default is 256.
-    "VLLM_MAX_REALTIME_AUDIO_QUEUE_SIZE": lambda: int(
-        os.getenv("VLLM_MAX_REALTIME_AUDIO_QUEUE_SIZE", "256")
+    # rejected with a buffer_full error. Default is 256. Clamped to a
+    # minimum of 1, since asyncio.Queue treats maxsize <= 0 as unbounded.
+    "VLLM_MAX_REALTIME_AUDIO_QUEUE_SIZE": lambda: max(
+        1, int(os.getenv("VLLM_MAX_REALTIME_AUDIO_QUEUE_SIZE", "256"))
     ),
     # Maximum decoded audio duration in seconds.  Compressed audio files
     # (e.g. OPUS at very low bitrate) can expand into gigabytes of float32


### PR DESCRIPTION
## Purpose

The realtime speech-to-text WebSocket (`/v1/realtime`) constructs `audio_queue`
with no `maxsize`, and the per-chunk guard compares `len(audio_array)` (sample
count) against an MB threshold, so it never caps actual byte usage. A client that
appends audio without ever sending `input_audio_buffer.commit` grows the worker's
memory without bound, since nothing consumes the queue until commit arrives.

This adds two bounds:

- Cap `audio_queue` at `VLLM_MAX_REALTIME_AUDIO_QUEUE_SIZE` (default 256).
  Past-cap appends emit a `buffer_full` error event instead of growing.
- Track cumulative PCM16 bytes per session against `VLLM_MAX_AUDIO_CLIP_FILESIZE_MB`
  (default 25 MB), reset after each generation in `_run_generation`. Replaces the
  `len(audio_array)`-vs-MB check, which used sample count for a byte threshold
  (~4x off for float32) and couldn't catch a small-chunk bypass.

## Duplicate check

- #36401 attempted the byte-tracking half and was closed on 2026-06-07 without
  merging; this integrates that approach and adds the queue cap.
- #46926 and #46814 add an idle timeout/watchdog that closes sessions which stop
  sending. That bounds a different failure mode; neither caps queue depth or
  per-session bytes, so an active client that keeps appending without committing
  still grows memory unbounded. This change is complementary. Both touch
  `connection.py` and `envs.py`, so whichever lands first leaves the other a
  small rebase.

## Test Plan

```
pytest tests/entrypoints/speech_to_text/realtime/test_realtime_audio_queue_cap.py -v
```

The new test drives `RealtimeConnection.handle_event` with a stub WebSocket and
stub serving (no model required): queue cap, overflow appends emit `buffer_full`,
draining allows new appends, cumulative bytes reject past the threshold, and the
byte counter resets after drain.

## Test Result

5 passed. `ruff check` and `ruff format --check` clean on the changed files.

---

AI-assisted: Claude helped with the implementation, tests, and drafting this PR;
I reviewed the changed lines and validated the behavior.
