### PR TITLE
[Bugfix][Tool Parser] Backport GLM47 zero-arg streaming tool calls

### DIFF
--- a/tests/tool_parsers/test_glm47_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm47_moe_tool_parser.py
@@ -149,6 +149,51 @@ class TestGlm47Streaming:
             )
         assert len(glm47_tool_parser.prev_tool_call_arr) >= 1
 
+    def test_completed_zero_arg_call_returns_delta_tool_calls(
+        self, glm47_tool_parser, mock_request
+    ):
+        _reset(glm47_tool_parser)
+        text = "<tool_call>get_current_date</tool_call>"
+
+        delta = glm47_tool_parser.extract_tool_calls_streaming(
+            previous_text="",
+            current_text=text,
+            delta_text=text,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=mock_request,
+        )
+
+        assert delta is not None
+        assert delta.content is None
+        assert delta.tool_calls is not None
+        assert delta.tool_calls[0].index == 0
+        assert delta.tool_calls[0].function is not None
+        assert delta.tool_calls[0].function.name == "get_current_date"
+        assert delta.tool_calls[0].function.arguments == ""
+        assert delta.tool_calls[1].index == 0
+        assert delta.tool_calls[1].function is not None
+        assert delta.tool_calls[1].function.arguments == "{}"
+
+    def test_incomplete_zero_arg_call_does_not_return_tool_name(
+        self, glm47_tool_parser, mock_request
+    ):
+        _reset(glm47_tool_parser)
+        text = "<tool_call>get_current_date"
+
+        delta = glm47_tool_parser.extract_tool_calls_streaming(
+            previous_text="",
+            current_text=text,
+            delta_text=text,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=mock_request,
+        )
+
+        assert delta is None
+
     def test_with_args(self, glm47_tool_parser, mock_request):
         _reset(glm47_tool_parser)
         chunks = [

--- a/vllm/tool_parsers/glm47_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm47_moe_tool_parser.py
@@ -38,3 +38,9 @@ class Glm47MoeModelToolParser(Glm4MoeModelToolParser):
             r"<arg_key>(.*?)</arg_key>\s*<arg_value>(.*?)</arg_value>",
             re.DOTALL,
         )
+
+    def _extract_complete_zero_arg_tool_name(self, inner_text: str) -> str | None:
+        name = inner_text.strip()
+        if not name or "<" in name or ">" in name:
+            return None
+        return name

--- a/vllm/tool_parsers/glm4_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm4_moe_tool_parser.py
@@ -319,6 +319,10 @@ class Glm4MoeModelToolParser(ToolParser):
         name = inner_text[:cut].strip()
         return name if name else None
 
+    def _extract_complete_zero_arg_tool_name(self, inner_text: str) -> str | None:
+        """Extract a completed zero-argument tool name, if supported."""
+        return None
+
     def _build_args_json_so_far(
         self,
         tool_name: str,
@@ -450,6 +454,8 @@ class Glm4MoeModelToolParser(ToolParser):
 
             # Extract tool name
             tool_name = self._extract_tool_name_from_region(inner_text)
+            if not tool_name and is_complete:
+                tool_name = self._extract_complete_zero_arg_tool_name(inner_text)
             if not tool_name:
                 break
 


### PR DESCRIPTION
## Purpose

Backport the GLM47 zero-argument streaming tool-call fix to `releases/v0.23.0`.

On the v0.23.0 GLM47 parser, non-streaming parsing accepts zero-argument XML tool calls such as:

```text
<tool_call>get_current_date</tool_call>
```

However, the streaming parser inherited the GLM4 name extraction rule, which only considered a tool name complete after a newline or `<arg_key>`. As a result, the same completed zero-argument tool call could be parsed in non-streaming mode but fail to emit OpenAI-compatible `delta.tool_calls` in streaming mode.

## Changes

- Add a GLM47-only zero-argument completed-tool-name extraction hook.
- Keep incomplete zero-argument calls buffered until `</tool_call>` arrives.
- Add GLM47 streaming regression coverage for:
  - completed zero-argument tool calls producing name + `{}` argument deltas
  - incomplete zero-argument tool calls not emitting a premature function name

## Duplicate-work check

Checked open PRs and issues:

- #48103 fixes GLM47 `required` / named tool choice structured-output interaction on `main`; this PR targets a different failure mode and targets `releases/v0.23.0`.
- #47190 recovers malformed missing `<arg_key>` output on `main`; this PR only handles valid zero-argument GLM47 XML output on v0.23.0.
- `main` already has the declarative GLM47 parser and a `test_no_args` streaming assertion. This PR is intentionally a release-branch backport for v0.23.0 rather than a duplicate main fix.

## Testing

Passed locally:

```bash
python -m py_compile vllm/tool_parsers/glm4_moe_tool_parser.py vllm/tool_parsers/glm47_moe_tool_parser.py tests/tool_parsers/test_glm47_moe_tool_parser.py
uvx ruff check vllm/tool_parsers/glm4_moe_tool_parser.py vllm/tool_parsers/glm47_moe_tool_parser.py tests/tool_parsers/test_glm47_moe_tool_parser.py
git diff --check origin/releases/v0.23.0..HEAD
```

Not run:

- Targeted pytest did not run in this checkout because there is no project `.venv`, and the ambient environment is missing vLLM test/runtime dependencies such as `tblib` and `torch`.

AI assistance was used to prepare this patch; the changed lines and validation above were reviewed before submission.
