### PR TITLE
[Bugfix][MRV2] Reset num_accepted_tokens on add_request in all modes

### DIFF
--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -100,12 +100,13 @@ class MambaHybridModelState(DefaultModelState):
 
     def add_request(self, req_index: int, new_req_data: NewRequestData) -> None:
         super().add_request(req_index, new_req_data)
+        # Must reset the speculative acceptance count in this idx which could be stale.
+        self.num_accepted_tokens_gpu[req_index] = 1
         if self._align_mode:
             # Seed the running state block from the resumed/prefilled position.
             self._mamba_state_idx_gpu[req_index] = (
                 new_req_data.num_computed_tokens - 1
             ) // self.cache_config.block_size
-            self.num_accepted_tokens_gpu[req_index] = 1
 
     def _get_mamba_group_info(
         self, kv_cache_config: KVCacheConfig


### PR DESCRIPTION
Under P/D disaggregation a decode-role request's prefill runs on the remote producer, so its first local step is a decode. The GDN/Mamba attention metadata reads num_accepted_tokens_gpu[req_index] before postprocess_state updates it, so without a reset the request inherits a stale value from the previous occupant of that batch slot, advancing the SSM state by the wrong number of tokens and corrupting its output.

The reset was previously gated on align (prefix-caching) mode; move it out of that branch so it applies whenever a request is added.
