### PR TITLE
[Bugfix] Preserve tensor causal metadata for grouped attention

### DIFF
--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -573,7 +573,7 @@ def build_attn_metadata(
     mm_req_doc_ranges: dict[int, list[tuple[int, int]]] | None = None,
     model_specific_attn_metadata: ModelSpecificAttnMetadata | None = None,
     for_cudagraph_capture: bool = False,
-    causal: bool | Mapping[int, bool] = True,
+    causal: bool | torch.Tensor | Mapping[int, bool] = True,
     rswa_prefix_lens: torch.Tensor | None = None,
 ) -> dict[str, Any]:
     seq_lens = seq_lens[:num_reqs]
@@ -588,7 +588,9 @@ def build_attn_metadata(
         block_table = block_tables[i]
         slot_mapping = slot_mappings[i]
         # Per-group causal for hybrid drafters (mixed SWA/full attention).
-        group_causal = causal if isinstance(causal, bool) else causal.get(i, True)
+        group_causal = (
+            causal if isinstance(causal, (bool, torch.Tensor)) else causal.get(i, True)
+        )
 
         common_attn_metadata_extra_kwargs = (
             model_specific_attn_metadata.get_extra_common_attn_kwargs(i, num_reqs)


### PR DESCRIPTION
Fix for nightly CI failure: [Buildkite #77195, LM Eval Small Models Distributed (2xB200)](https://buildkite.com/vllm/ci/builds/77195#019f4388-f4da-4b16-9373-58229478cb23).

## Summary
- Preserve per-request `torch.Tensor` causal masks when grouped attention metadata is built.
- Keep the per-KV-cache-group `Mapping[int, bool]` causal override path used by hybrid DFlash drafters.

## Regression
- Breaking PR: [#47914 - [Spec Decode] Support hybrid (SWA + full attention) DFlash drafters](https://github.com/vllm-project/vllm/pull/47914), merged as `0d12618e98ff2d21d36081e0e9b4eb23573b6d38`.
- Failure signature: `test_gsm8k_correctness[DiffusionGemma-26B-A4B-it-FP8-dynamic]` exits during engine startup with `AttributeError: 'Tensor' object has no attribute 'get'` at `group_causal = causal if isinstance(causal, bool) else causal.get(i, True)`.

## Tests
- `git diff --check`
- `PATH="/home/LucasWilkinson/local/vllm3/.venv/bin:$PATH" pre-commit run ruff-check --files vllm/v1/worker/gpu/attn_utils.py`
- Commit hooks passed: ruff check, ruff format, typos, mypy, SPDX, root lazy imports, forbidden imports, torch.cuda API check, config defaults/docs, attention backend docs, boolean with-statements, sign-off.
- `CUDA_VISIBLE_DEVICES=0,1 HF_HUB_CACHE=/home/LucasWilkinson/.cache/huggingface/hub PATH="/home/LucasWilkinson/local/vllm3/.venv/bin:$PATH" .venv/bin/python -m pytest -s -v 'tests/evals/gsm8k/test_gsm8k_correctness.py::test_gsm8k_correctness[DiffusionGemma-26B-A4B-it-FP8-dynamic]' --config-list-file=configs/models-small-tp.txt`

## Model Evaluation Results
- Model: `RedHatAI/diffusiongemma-26B-A4B-it-FP8-dynamic`
- Questions: 1319
- Measured metric: 0.9272
- Expected metric: 0.8400
- Invalid rate: 0.000
- Latency: 135.7s
- QPS: 9.7
- Result: passed

## AI Assistance
AI assistance was used to reproduce the failure, identify the causal metadata contract issue, implement this patch, run validation, and draft this PR. This changes have been reviewed by the submitter.
