### PR TITLE
[Core] Add Min-k sampling: temperature-invariant logit-space truncation

### DIFF
--- a/tests/v1/logits_processors/test_correctness.py
+++ b/tests/v1/logits_processors/test_correctness.py
@@ -27,6 +27,7 @@ from vllm.v1.sample.logits_processor import (
     BatchUpdateBuilder,
     LogitBiasLogitsProcessor,
     LogitsProcessor,
+    MinKLogitsProcessor,
     MinPLogitsProcessor,
     MinTokensLogitsProcessor,
     MoveDirectionality,
@@ -341,6 +342,58 @@ def _min_p_validate(
                     )
 
 
+def _min_k_params(kwargs: dict) -> None:
+    """Min-k logitproc config"""
+    kwargs["min_k"] = True
+
+
+def _min_k_validate(
+    test_fakes: LogitsprocsTestFakes,
+    persistent_batch: list[LogitsProcsRequestParams],
+    logits_new: torch.Tensor,
+    batch_index: int,
+    request_params: LogitsProcsRequestParams,
+    step_idx: int,
+) -> None:
+    """Validate Min-k logitproc applied correctly.
+
+    The fixture gives every row one dominant token (index 0) and a flat tail,
+    so the steepest weighted drop is right after the dominant token. Min-k
+    should therefore keep token 0 and mask the tail, and leave every token
+    untouched when disabled.
+    """
+    for token_id in range(VOCAB_SIZE):
+        logits_for_token = logits_new[batch_index][token_id]
+        if token_id == 0:
+            # Dominant token is always kept (Min-k is argmax invariant).
+            if logits_for_token == -float("inf"):
+                _raise_error_invalid(
+                    msg_suffix="Invalid: dominant token 0 masked (-inf)",
+                    batch_index=batch_index,
+                    request_params=request_params,
+                    step_idx=step_idx,
+                )
+        else:
+            if request_params.params.min_k:
+                # Tail tokens fall past the cliff and should be masked.
+                if logits_for_token != -float("inf"):
+                    _raise_error_invalid(
+                        msg_suffix=f"Invalid: tail token {token_id} not masked",
+                        batch_index=batch_index,
+                        request_params=request_params,
+                        step_idx=step_idx,
+                    )
+            else:
+                # No masking when Min-k is disabled.
+                if logits_for_token == -float("inf"):
+                    _raise_error_invalid(
+                        msg_suffix=f"Invalid: token {token_id} masked when min_k off",
+                        batch_index=batch_index,
+                        request_params=request_params,
+                        step_idx=step_idx,
+                    )
+
+
 def _min_tokens_params(kwargs: dict) -> None:
     """Min-tokens logitproc config"""
     kwargs["min_tokens"] = MIN_TOKENS_LEN_THRESHOLD
@@ -583,6 +636,9 @@ logitsprocs_test_mapping = {
     ),
     MinPLogitsProcessor: LogitsprocTestHelpers(
         gen_request_fxn=_min_p_params, eval_fxn=_min_p_validate
+    ),
+    MinKLogitsProcessor: LogitsprocTestHelpers(
+        gen_request_fxn=_min_k_params, eval_fxn=_min_k_validate
     ),
     MinTokensLogitsProcessor: LogitsprocTestHelpers(
         gen_request_fxn=_min_tokens_params, eval_fxn=_min_tokens_validate

--- a/tests/v1/sample/test_min_k.py
+++ b/tests/v1/sample/test_min_k.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Numeric unit tests for the Min-k logits processor.
+
+These pin the semantic-cliff truncation and the temperature-invariance
+property from https://arxiv.org/abs/2604.11012, and run on CPU so no
+accelerator is needed.
+"""
+import torch
+
+from vllm.config import VllmConfig
+from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.logits_processor import MinKLogitsProcessor
+from vllm.v1.sample.logits_processor.interface import BatchUpdate
+
+VOCAB_SIZE = 256
+
+
+def _reference_k(row: torch.Tensor, tau: float, eps: float = 1e-8) -> int:
+    """Algorithm 1 from the paper, computed on a single logit row."""
+    sorted_logits, _ = torch.sort(row, descending=True)
+    logit_range = (sorted_logits[0] - sorted_logits[-1]).item()
+    best_decay = -1.0
+    best_i = 1
+    for i in range(1, sorted_logits.numel()):
+        decay = (sorted_logits[i - 1] - sorted_logits[i]).item() / (
+            i * (logit_range + eps)
+        )
+        if decay > best_decay:
+            best_decay = decay
+            best_i = i
+    k_cliff = best_i
+    k_fallback = int(max(0.0, tau) / (logit_range + eps))
+    return max(k_cliff, k_fallback)
+
+
+def _build_processor() -> MinKLogitsProcessor:
+    return MinKLogitsProcessor(
+        VllmConfig(), device=torch.device("cpu"), is_pin_memory=False
+    )
+
+
+def _update(proc: MinKLogitsProcessor, params: list[SamplingParams]) -> None:
+    proc.update_state(
+        BatchUpdate(
+            batch_size=len(params),
+            removed=[],
+            added=[(i, p, None, []) for i, p in enumerate(params)],
+            moved=[],
+        )
+    )
+
+
+def test_min_k_matches_algorithm_reference():
+    """Enabled rows truncate at the reference cliff position, and a disabled
+    row is untouched, all within one mixed batch."""
+    torch.manual_seed(0)
+    proc = _build_processor()
+    params = [
+        SamplingParams(temperature=1.0, min_k=True, min_k_tau=3.0),
+        SamplingParams(temperature=1.0, min_k=True, min_k_tau=0.0),
+        SamplingParams(temperature=1.0),  # disabled
+    ]
+    _update(proc, params)
+
+    logits = torch.randn(3, VOCAB_SIZE)
+    logits[:, :4] += 6.0  # a clear head, then a cliff into the tail
+    out = proc.apply(logits.clone())
+
+    for i, p in enumerate(params):
+        if not p.min_k:
+            torch.testing.assert_close(out[i], logits[i])
+            continue
+        k = _reference_k(logits[i], p.min_k_tau)
+        kth = torch.sort(logits[i], descending=True).values[k - 1]
+        expected_kept = logits[i] >= kth
+        got_kept = ~torch.isinf(out[i])
+        assert torch.equal(got_kept, expected_kept), f"row {i}, k={k}"
+        # The top-ranked token always survives.
+        assert out[i].argmax() == logits[i].argmax()
+
+
+def test_min_k_is_temperature_invariant():
+    """The kept set is identical across temperatures for the cliff mechanism."""
+    torch.manual_seed(1)
+    logits = torch.randn(1, VOCAB_SIZE)
+    logits[:, :5] += 8.0
+
+    kept_sets = []
+    for temperature in (1.0, 5.0, 10.0):
+        proc = _build_processor()
+        # tau=0 isolates the cliff mechanism from the fallback.
+        _update(proc, [SamplingParams(temperature=1.0, min_k=True, min_k_tau=0.0)])
+        out = proc.apply((logits / temperature).clone())
+        kept_sets.append(~torch.isinf(out[0]))
+
+    assert torch.equal(kept_sets[0], kept_sets[1])
+    assert torch.equal(kept_sets[0], kept_sets[2])
+
+
+def test_min_k_fallback_prevents_single_token_collapse():
+    """On a near-flat distribution with no cliff, the fallback keeps more than
+    one candidate."""
+    proc = _build_processor()
+    _update(proc, [SamplingParams(temperature=1.0, min_k=True, min_k_tau=3.0)])
+    # Tiny, near-uniform spread so the logit range is small and the fallback
+    # floor(tau / range) exceeds one.
+    logits = torch.linspace(0.0, 0.05, VOCAB_SIZE).unsqueeze(0)
+    out = proc.apply(logits.clone())
+    assert int((~torch.isinf(out[0])).sum()) > 1
+
+
+def test_min_k_disabled_is_noop():
+    proc = _build_processor()
+    _update(proc, [SamplingParams(temperature=1.0)])
+    logits = torch.randn(1, VOCAB_SIZE)
+    torch.testing.assert_close(proc.apply(logits.clone()), logits)
+
+
+def test_min_k_tau_must_be_non_negative():
+    try:
+        SamplingParams(temperature=1.0, min_k=True, min_k_tau=-1.0)
+    except ValueError:
+        return
+    raise AssertionError("negative min_k_tau should have been rejected")

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -249,6 +249,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
     use_beam_search: bool = False
     top_k: int | None = None
     min_p: float | None = None
+    min_k: bool = False
+    min_k_tau: float = 3.0
     repetition_penalty: float | None = None
     length_penalty: float = 1.0
     stop_token_ids: list[int] | None = []
@@ -674,6 +676,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
             top_p=top_p,
             top_k=top_k,
             min_p=min_p,
+            min_k=self.min_k,
+            min_k_tau=self.min_k_tau,
             seed=self.seed,
             stop=self.stop,
             stop_token_ids=stop_token_ids,
@@ -1014,6 +1018,8 @@ class BatchChatCompletionRequest(OpenAIBaseModel):
     use_beam_search: bool = False
     top_k: int | None = None
     min_p: float | None = None
+    min_k: bool = False
+    min_k_tau: float = 3.0
     repetition_penalty: float | None = None
     length_penalty: float | None = 1.0
     early_stopping: bool = False

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -76,6 +76,8 @@ class CompletionRequest(OpenAIBaseModel):
     use_beam_search: bool = False
     top_k: int | None = None
     min_p: float | None = None
+    min_k: bool = False
+    min_k_tau: float = 3.0
     repetition_penalty: float | None = None
     length_penalty: float = 1.0
     stop_token_ids: list[int] | None = []
@@ -355,6 +357,8 @@ class CompletionRequest(OpenAIBaseModel):
             top_p=top_p,
             top_k=top_k,
             min_p=min_p,
+            min_k=self.min_k,
+            min_k_tau=self.min_k_tau,
             seed=self.seed,
             stop=self.stop,
             stop_token_ids=stop_token_ids,

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -247,6 +247,20 @@ class SamplingParams(
     """Represents the minimum probability for a token to be considered,
     relative to the probability of the most likely token. Must be in [0, 1].
     Set to 0 to disable this."""
+    min_k: bool = False
+    """Enables Min-k sampling, a temperature-invariant truncation strategy that
+    works in logit space. It sorts the logits, measures a position-weighted
+    relative decay between adjacent sorted logits, and truncates at the
+    steepest drop (the "semantic cliff") separating high-confidence tokens from
+    the long tail. Because the decision is based on relative logit geometry
+    rather than probabilities, the kept set does not change with temperature.
+    Set to True to enable. See https://arxiv.org/abs/2604.11012 for details."""
+    min_k_tau: float = 3.0
+    """Fallback strength for Min-k sampling. Only used when min_k is True. When
+    the sorted logits are nearly flat and no clear cliff exists, Min-k falls
+    back to a candidate set of size floor(min_k_tau / logit_range) to avoid
+    collapsing to a single token. Must be greater than or equal to 0. The
+    default of 3.0 follows the paper and rarely activates in practice."""
     seed: int | None = None
     """Random seed to use for the generation."""
     stop: str | list[str] | None = None
@@ -362,6 +376,8 @@ class SamplingParams(
         top_p: float | None = 1.0,
         top_k: int = 0,
         min_p: float = 0.0,
+        min_k: bool = False,
+        min_k_tau: float = 3.0,
         seed: int | None = None,
         stop: str | list[str] | None = None,
         stop_token_ids: list[int] | None = None,
@@ -422,6 +438,8 @@ class SamplingParams(
             top_p=1.0 if top_p is None else top_p,
             top_k=top_k,
             min_p=min_p,
+            min_k=min_k,
+            min_k_tau=min_k_tau,
             seed=seed,
             stop=stop,
             stop_token_ids=stop_token_ids,
@@ -492,6 +510,7 @@ class SamplingParams(
             self.top_p = 1.0
             self.top_k = 0
             self.min_p = 0.0
+            self.min_k = False
             self._verify_greedy_sampling()
 
         # eos_token_id is added to this by the engine
@@ -568,6 +587,14 @@ class SamplingParams(
             )
         if not 0.0 <= self.min_p <= 1.0:
             raise ValueError(f"min_p must be in [0, 1], got {self.min_p}.")
+        if not isinstance(self.min_k, bool):
+            raise TypeError(
+                f"min_k must be a boolean, got {type(self.min_k).__name__}."
+            )
+        if self.min_k and self.min_k_tau < 0.0:
+            raise ValueError(
+                f"min_k_tau must be greater than or equal to 0, got {self.min_k_tau}."
+            )
         if self.max_tokens is not None and self.max_tokens < 1:
             raise VLLMValidationError(
                 f"max_tokens must be at least 1, got {self.max_tokens}.",
@@ -873,9 +900,9 @@ class SamplingParams(
             return
 
         # Some sampling parameters are not yet compatible with spec decoding.
-        if self.min_p > _SAMPLING_EPS or self.logit_bias:
+        if self.min_p > _SAMPLING_EPS or self.min_k or self.logit_bias:
             raise ValueError(
-                "The min_p and logit_bias sampling parameters "
+                "The min_p, min_k and logit_bias sampling parameters "
                 "are not yet supported with speculative decoding."
             )
 
@@ -889,6 +916,7 @@ class SamplingParams(
         if (
             self.temperature != 1.0
             or self.min_p > _SAMPLING_EPS
+            or self.min_k
             or self.seed is not None
             or self.min_tokens > 0
             or self.logit_bias
@@ -896,7 +924,7 @@ class SamplingParams(
             or self.allowed_token_ids
         ):
             raise ValueError(
-                "The temperature, min_p, seed, min_tokens, logit_bias, "
+                "The temperature, min_p, min_k, seed, min_tokens, logit_bias, "
                 "bad_words, and allowed_token_ids sampling parameters "
                 "are not yet supported with diffusion models."
             )
@@ -1072,6 +1100,8 @@ class SamplingParams(
             f"top_p={self.top_p}, "
             f"top_k={self.top_k}, "
             f"min_p={self.min_p}, "
+            f"min_k={self.min_k}, "
+            f"min_k_tau={self.min_k_tau}, "
             f"seed={self.seed}, "
             f"stop={self.stop}, "
             f"stop_token_ids={self.stop_token_ids}, "
@@ -1098,6 +1128,7 @@ class SamplingParams(
             top_p=0.9,
             top_k=50,
             min_p=0.1,
+            min_k=True,
             frequency_penalty=0.5,
             presence_penalty=0.5,
             repetition_penalty=1.2,

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -16,6 +16,7 @@ from vllm.sampling_params import SamplingParams
 from vllm.utils.torch_utils import guard_cuda_initialization
 from vllm.v1.sample.logits_processor.builtin import (
     LogitBiasLogitsProcessor,
+    MinKLogitsProcessor,
     MinPLogitsProcessor,
     MinTokensLogitsProcessor,
     process_dict_updates,
@@ -50,6 +51,7 @@ BUILTIN_LOGITS_PROCESSORS: list[type[LogitsProcessor]] = [
     MinTokensLogitsProcessor,
     LogitBiasLogitsProcessor,
     MinPLogitsProcessor,
+    MinKLogitsProcessor,
 ]
 
 
@@ -344,6 +346,7 @@ class AdapterLogitsProcessor(LogitsProcessor):
 __all__ = [
     "LogitsProcessor",
     "LogitBiasLogitsProcessor",
+    "MinKLogitsProcessor",
     "MinPLogitsProcessor",
     "MinTokensLogitsProcessor",
     "BatchUpdate",

--- a/vllm/v1/sample/logits_processor/builtin.py
+++ b/vllm/v1/sample/logits_processor/builtin.py
@@ -116,6 +116,154 @@ class MinPLogitsProcessor(LogitsProcessor):
         return logits
 
 
+class MinKLogitsProcessor(LogitsProcessor):
+    """Min-k sampling (https://arxiv.org/abs/2604.11012).
+
+    Min-k is a temperature-invariant truncation strategy that operates on the
+    shape of the sorted logits. For each request it sorts the logits in
+    descending order, normalizes the adjacent drops by the logit range, weights
+    each drop by 1 / rank to emphasize the head of the distribution, and
+    truncates at the position of the steepest weighted drop (the "semantic
+    cliff") that separates confident tokens from the long tail. A fallback
+    keeps floor(tau / logit_range) tokens when the distribution is nearly flat
+    and no cliff exists, which guards against collapsing to a single token.
+
+    vLLM applies temperature before logits processors run, so the logits seen
+    here are already divided by the temperature. Temperature scaling preserves
+    both the ordering of tokens and the normalized relative decay, so the
+    cliff position is identical to the one computed on the raw logits, and the
+    final sampling distribution over the kept set matches the paper exactly.
+    The fallback uses the range of the temperature-scaled logits, so its size
+    can shift with temperature, but it only activates on near-flat
+    distributions where it merely prevents a degenerate single-token set.
+
+    A per-request tau of -1 means Min-k is disabled for that request. Disabled
+    rows are computed alongside the rest and then masked out, keeping the batch
+    vectorized.
+    """
+
+    # Sentinel stored per request when Min-k is disabled (valid tau is >= 0).
+    _DISABLED = -1.0
+
+    def __init__(
+        self, vllm_config: "VllmConfig", device: torch.device, is_pin_memory: bool
+    ):
+        max_num_reqs = vllm_config.scheduler_config.max_num_seqs
+        # Number of requests with Min-k enabled (tau != _DISABLED).
+        self.min_k_count: int = 0
+
+        self.tau_cpu_tensor = torch.full(
+            (max_num_reqs,),
+            self._DISABLED,
+            dtype=torch.float32,
+            device="cpu",
+            pin_memory=is_pin_memory,
+        )
+        self.tau_cpu = self.tau_cpu_tensor.numpy()
+
+        self.use_double_tensor = torch.device(device).type != "cpu"
+
+        if self.use_double_tensor:
+            self.tau_device: torch.Tensor = torch.empty(
+                (max_num_reqs,), dtype=torch.float32, device=device
+            )
+        else:
+            self.tau_device = self.tau_cpu_tensor
+        # Current slice of the device tensor
+        self.tau: torch.Tensor = self.tau_device[:0]
+
+    @classmethod
+    def _req_tau(cls, params: SamplingParams) -> float:
+        """Effective tau for a request: the requested tau if Min-k is enabled,
+        otherwise the disabled sentinel."""
+        return params.min_k_tau if params.min_k else cls._DISABLED
+
+    def is_argmax_invariant(self) -> bool:
+        """Min-k always keeps the top-ranked token, so it cannot change the
+        outcome of greedy sampling."""
+        return True
+
+    def update_state(self, batch_update: BatchUpdate | None):
+        if not batch_update:
+            return
+
+        needs_update = False
+        disabled = self._DISABLED
+        # Process added requests.
+        for index, params, _, _ in batch_update.added:
+            tau = self._req_tau(params)
+            tau_before = self.tau_cpu[index]
+            if tau_before != tau:
+                needs_update = True
+                self.tau_cpu[index] = tau
+                enabled = tau != disabled
+                enabled_before = tau_before != disabled
+                if enabled and not enabled_before:
+                    self.min_k_count += 1
+                elif not enabled and enabled_before:
+                    self.min_k_count -= 1
+
+        if self.min_k_count:
+            # Process removed requests.
+            if batch_update.removed:
+                needs_update = True
+                for index in batch_update.removed:
+                    if self.tau_cpu[index] != disabled:
+                        self.tau_cpu[index] = disabled
+                        self.min_k_count -= 1
+
+            # Process moved requests, unidirectional (a->b) and swap (a<->b).
+            for adx, bdx, direct in batch_update.moved:
+                tau_a, tau_b = self.tau_cpu[adx], self.tau_cpu[bdx]
+                if tau_a != tau_b:
+                    needs_update = True
+                    self.tau_cpu[bdx] = tau_a
+                    if direct == MoveDirectionality.SWAP:
+                        self.tau_cpu[adx] = tau_b
+                if direct == MoveDirectionality.UNIDIRECTIONAL:
+                    if tau_a != disabled:
+                        self.tau_cpu[adx] = disabled
+                    if tau_b != disabled:
+                        self.min_k_count -= 1
+
+        # Update tensors if needed.
+        size = batch_update.batch_size
+        if self.min_k_count and (needs_update or self.tau.shape[0] != size):
+            self.tau = self.tau_device[:size]
+            if self.use_double_tensor:
+                self.tau.copy_(self.tau_cpu_tensor[:size], non_blocking=True)
+            self.tau.unsqueeze_(1)
+
+    def apply(self, logits: torch.Tensor) -> torch.Tensor:
+        if not self.min_k_count:
+            return logits
+
+        vocab_size = logits.shape[-1]
+        # Sort logits in descending order to inspect the head-to-tail shape.
+        sorted_logits, _ = torch.sort(logits, dim=-1, descending=True)
+        # Logit range, used to normalize drops so the decay is scale (and thus
+        # temperature) invariant. A small epsilon guards a uniform row.
+        logit_range = sorted_logits[:, :1] - sorted_logits[:, -1:] + 1e-8
+        # Position-weighted relative decay between adjacent sorted logits.
+        drops = sorted_logits[:, :-1] - sorted_logits[:, 1:]
+        positions = torch.arange(
+            1, vocab_size, device=logits.device, dtype=logits.dtype
+        )
+        weighted_decay = drops / logit_range / positions
+        # The steepest weighted drop marks the cliff; keep that many tokens.
+        k_cliff = weighted_decay.argmax(dim=-1) + 1
+        # Fallback for near-flat rows; disabled rows carry tau -1, clamped to 0.
+        tau = self.tau.squeeze(1)
+        k_fallback = torch.floor(tau.clamp(min=0.0) / logit_range.squeeze(1)).long()
+        k = torch.maximum(k_cliff, k_fallback).clamp_(1, vocab_size)
+        # Threshold is the k-th largest logit per row; truncate everything
+        # below it, but only for requests that enabled Min-k.
+        kth_value = sorted_logits.gather(1, (k - 1).unsqueeze(1))
+        invalid_token_mask = (logits < kth_value) & (self.tau != self._DISABLED)
+        logits.masked_fill_(invalid_token_mask, -float("inf"))
+        return logits
+
+
 class LogitBiasLogitsProcessor(LogitsProcessor):
     def __init__(self, _, device: torch.device, is_pin_memory: bool):
         self.device = device

--- a/vllm/v1/worker/gpu/sample/sampler.py
+++ b/vllm/v1/worker/gpu/sample/sampler.py
@@ -187,6 +187,9 @@ class Sampler:
         # Apply min_p in place.
         self.sampling_states.apply_min_p(logits, expanded_idx_mapping, idx_mapping_np)
 
+        # Apply Min-k in place.
+        self.sampling_states.apply_min_k(logits, expanded_idx_mapping, idx_mapping_np)
+
         if skip_top_k_top_p:
             return logits
 

--- a/vllm/v1/worker/gpu/sample/states.py
+++ b/vllm/v1/worker/gpu/sample/states.py
@@ -23,6 +23,8 @@ class SamplingStates:
         self.top_k = UvaBackedTensor(max_num_reqs, dtype=torch.int32)
         self.top_p = UvaBackedTensor(max_num_reqs, dtype=torch.float32)
         self.min_p = UvaBackedTensor(max_num_reqs, dtype=torch.float32)
+        # Min-k fallback strength per request; -1 means Min-k is disabled.
+        self.min_k_tau = UvaBackedTensor(max_num_reqs, dtype=torch.float32)
         self.seeds = UvaBackedTensor(max_num_reqs, dtype=torch.int64)
         # Tracks whether `seed` was set explicitly by the user, so callers
         # can fall back from RNG paths that don't honor per-request seeds.
@@ -33,6 +35,9 @@ class SamplingStates:
         self.top_k.copy_to_uva()
         self.top_p.np.fill(1.0)
         self.top_p.copy_to_uva()
+        # Initialize Min-k to disabled (-1) since 0 is a valid tau value.
+        self.min_k_tau.np.fill(-1.0)
+        self.min_k_tau.copy_to_uva()
 
         self.num_logprobs = np.empty(self.max_num_reqs, dtype=np.int32)
         # -1 means no logprobs are requested.
@@ -46,6 +51,9 @@ class SamplingStates:
             top_k = self.vocab_size
         self.top_k.np[req_idx] = top_k
         self.min_p.np[req_idx] = sampling_params.min_p
+        self.min_k_tau.np[req_idx] = (
+            sampling_params.min_k_tau if sampling_params.min_k else -1.0
+        )
 
         seed = sampling_params.seed
         self.seeds_set[req_idx] = seed is not None
@@ -65,6 +73,7 @@ class SamplingStates:
         self.top_p.copy_to_uva()
         self.top_k.copy_to_uva()
         self.min_p.copy_to_uva()
+        self.min_k_tau.copy_to_uva()
         self.seeds.copy_to_uva()
 
     def apply_temperature(
@@ -90,6 +99,35 @@ class SamplingStates:
             # No request uses min_p. Skip the kernel launch.
             return
         apply_min_p(logits, expanded_idx_mapping, self.min_p.gpu)
+
+    def apply_min_k(
+        self,
+        logits: torch.Tensor,
+        expanded_idx_mapping: torch.Tensor,
+        idx_mapping_np: np.ndarray,
+    ) -> None:
+        if np.all(self.min_k_tau.np[idx_mapping_np] == -1.0):
+            # No request uses Min-k. Skip the work.
+            return
+        # tau aligned to logits rows; -1 marks disabled rows.
+        tau = self.min_k_tau.gpu[expanded_idx_mapping].unsqueeze(1)
+        vocab_size = logits.shape[-1]
+        # Sort logits descending and locate the position-weighted semantic cliff.
+        sorted_logits, _ = torch.sort(logits, dim=-1, descending=True)
+        logit_range = sorted_logits[:, :1] - sorted_logits[:, -1:] + 1e-8
+        drops = sorted_logits[:, :-1] - sorted_logits[:, 1:]
+        positions = torch.arange(
+            1, vocab_size, device=logits.device, dtype=logits.dtype
+        )
+        weighted_decay = drops / logit_range / positions
+        k_cliff = weighted_decay.argmax(dim=-1) + 1
+        k_fallback = torch.floor(
+            tau.squeeze(1).clamp(min=0.0) / logit_range.squeeze(1)
+        ).long()
+        k = torch.maximum(k_cliff, k_fallback).clamp_(1, vocab_size)
+        kth_value = sorted_logits.gather(1, (k - 1).unsqueeze(1))
+        invalid = (logits < kth_value) & (tau != -1.0)
+        logits.masked_fill_(invalid, -float("inf"))
 
     def get_top_k_top_p(
         self, expanded_idx_mapping: torch.Tensor, idx_mapping_np: np.ndarray


### PR DESCRIPTION
## Purpose

This pull request adds Min-k sampling to vLLM as a builtin, temperature-invariant truncation strategy. Min-k was accepted to ACL 2026 as an oral presentation (Ding, Li, Garces Arias, Aßenmacher, Heumann, and Zhang, "Min-k Sampling: Decoupling Truncation from Temperature Scaling via Relative Logit Dynamics", ACL Anthology 2026.acl-long.681, https://arxiv.org/abs/2604.11012). At ACL and similar venues, accepted papers are split into posters and orals, and the oral track is the small top tier that the program committee selects for a talk to the full conference, so an oral is a strong signal that the reviewers judged the work among the most significant and well-validated contributions of the year. The companion p-less sampler in #48136 earned an oral at ICLR 2026 in the same way. Both methods target the same weakness in current truncation samplers from complementary angles, so I would like to see both merged as soon as the maintainers are comfortable, since together they give vLLM users a robust, well-reviewed answer to sampling at high temperature.

Min-k works entirely in logit space. For each request it sorts the logits, normalizes the drop between adjacent sorted logits by the logit range, weights each drop by one over its rank to emphasize the head of the distribution, and truncates at the position of the steepest weighted drop. That position is the "semantic cliff" separating the confident core tokens from the unreliable long tail. A fallback keeps floor(min_k_tau divided by the logit range) tokens on the rare near-flat distributions where no clear cliff exists, which prevents the candidate set from collapsing to a single token.

The motivation overlaps with the p-less PR and is worth stating plainly. As one of the min_p authors, I have seen first hand that min_p, while more robust than top_p, still keys its cutoff off a probability, and probabilities flatten as temperature rises, so min_p admits more and more tail tokens at high temperature until quality collapses. The Min-k paper quantifies this, showing probability-space methods including min_p falling to near-zero accuracy and near-total semantic noise once temperature passes about 2.0, while Min-k holds its accuracy and keeps the noise rate below ten percent even at temperature 10.0. Min-k reaches this by making the truncation depend only on the relative shape of the logits, which temperature scaling does not change. The paper proves this invariance formally, and I reproduced it numerically as part of the tests below.

This work sits alongside the top-n-sigma logits processor in #45034, which is the other logit-space, temperature-robust sampler in vLLM. Top-n-sigma thresholds on the global standard deviation of the logits, which the Min-k paper argues is dominated by background tail noise, whereas Min-k reads the local head geometry directly. Providing both gives users a choice between the two logit-space philosophies.

The change adds a min_k boolean and a min_k_tau float (default 3.0, the paper's value) to SamplingParams and to the OpenAI completion and chat protocols. Min-k runs as an argmax-invariant logits processor in the default sampler and has a matching implementation in the V2 GPU sampler, so the two sampling paths stay at parity with min_p. Because vLLM applies temperature before logits processors run, the logits Min-k sees are already divided by temperature. Temperature scaling preserves both the token ordering and the normalized relative decay, so the cliff position and the final sampling distribution over the kept set match the paper exactly. The optional fallback uses the range of the temperature-scaled logits, so its size can shift with temperature, though it only activates on near-flat distributions where it simply guards against a degenerate single-token set. As with min_p, Min-k is not yet wired into speculative decoding or diffusion models, and those combinations are rejected during validation.

## Test Plan

The new file tests/v1/sample/test_min_k.py pins the numeric behavior on CPU so it needs no accelerator. It builds the processor over a mixed batch and checks that enabled requests truncate at exactly the cliff position produced by Algorithm 1 of the paper, that the top-ranked token always survives, that a disabled request is left untouched, that the kept set is identical across temperatures 1.0, 5.0, and 10.0, that the fallback keeps more than one token on a near-flat distribution, and that a negative min_k_tau is rejected at validation time. The Min-k case was also added to the shared logits-processor correctness harness in tests/v1/logits_processors/test_correctness.py so it is exercised alongside min_p, logit bias, and min tokens across the batching, moving, and swapping paths.

Run the focused tests with `pytest tests/v1/sample/test_min_k.py` and the shared harness with `pytest tests/v1/logits_processors/test_correctness.py`.

## Test Result

I validated the algorithm with a standalone script that replicates the processor computation. It confirms that the vectorized cliff detection matches the paper's Algorithm 1 token for token, that the kept set is identical across temperatures 1.0, 5.0, and 10.0, that disabled rows are untouched, and that the fallback keeps more than one candidate on a flat distribution. All changed files pass `ruff format` and `ruff check`.

This is opened as a draft because I have not yet been able to run the full pytest suites or the V2 sampler path on a GPU. I would welcome a maintainer running the suites above on hardware to confirm the accelerator path before this is marked ready for review.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update. The new sampling parameters render into the OpenAI server docs through the existing protocol snippet markers and the SamplingParams field docstrings.
</details>
