### PR TITLE
update marlin M size for EP

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Fused MoE utilities for GPTQ."""
 
+import math
 from collections.abc import Callable
 
 import torch
@@ -312,6 +313,12 @@ def fused_marlin_moe(
     assert num_bits in [4, 8]
     assert topk_weights.dtype == torch.float32
 
+    if global_num_experts == -1:
+        global_num_experts = E
+    else:
+        # Set M to estimated valid tokens per rank
+        M = math.ceil(M * E / global_num_experts)
+
     # M block size selection logic
     # TODO: tune this further for specific models
     for block_size_m in [8, 16, 32, 48, 64]:
@@ -321,8 +328,6 @@ def fused_marlin_moe(
     if input_dtype is not None and input_dtype.itemsize == 1:
         block_size_m = max(block_size_m, 16)
 
-    if global_num_experts == -1:
-        global_num_experts = E
     sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
         topk_ids,
         block_size_m,


### PR DESCRIPTION
## Purpose
Updates the Marlin MoE `M` dimension size to estimate the number of valid tokens per rank. When using DP/EP, the `hidden_states.shape[0]` dimension is padded to `max_tokens_per_rank * num_ranks`. Scaling this by `num_experts / num_global_experts` recovers an estimated number of valid (i.e. non-padding) tokens per rank.

## Test Plan

### Benchmark results
Benchmarked `deepseek-ai/DeepSeek-V4-Flash` on 8xH200 with DP/EP=8

<details>
<summary> Serve Command  </summary>

```
vllm serve deepseek-ai/DeepSeek-V4-Flash \
    --data-parallel-size 8 --data-parallel-size-local 8 \
    --data-parallel-start-rank 0 --port 8000 \
    --enable-expert-parallel --moe-backend marlin \
    --kv-cache-dtype fp8 --tokenizer-mode deepseek_v4 \
    --max-model-len 32768 --gpu-memory-utilization 0.9 \
    --trust-remote-code --no-enable-flashinfer-autotune
```
</details>

<details>
<summary> Benchmark Command  </summary>

```
vllm bench serve --random-input-len 1024 \
    --random-output-len 1024 --max-concurrency 64 \
    --num-prompts 640
```
</details>

Result (1k/1k conc=64)

|                 | p50 ttft | p50 tpot | req/s | output tok/s |
| --------------- | -------- | -------- | ----- | ------------ |
| Before          | 1298.47  | 32.72    | 1.85  | 1896.52      |
| After (this PR) | 1254.46  | 30.35    | 1.98  | 2030.3       |
