### PR TITLE
Fix silent text-LoRA no-op for remaining VLM wrapper models

### DIFF
--- a/vllm/model_executor/models/gemma3_mm.py
+++ b/vllm/model_executor/models/gemma3_mm.py
@@ -489,6 +489,7 @@ class Gemma3ForConditionalGeneration(
             "model.vision_tower.": "vision_tower.",
             "model.multi_modal_projector.": "multi_modal_projector.",
             "lm_head.": "language_model.lm_head.",
+            "model.": "language_model.model.",
         }
     )
 

--- a/vllm/model_executor/models/lightonocr.py
+++ b/vllm/model_executor/models/lightonocr.py
@@ -137,6 +137,7 @@ class LightOnOCRForConditionalGeneration(Mistral3ForConditionalGeneration):
             "model.vision_projection.": "multi_modal_projector.",
             "lm_head.": "language_model.lm_head.",
             "model.language_model.": "language_model.model.",
+            "model.": "language_model.model.",
         }
     )
 

--- a/vllm/model_executor/models/llava.py
+++ b/vllm/model_executor/models/llava.py
@@ -519,6 +519,7 @@ class LlavaForConditionalGeneration(
             "model.vision_tower.": "vision_tower.",
             "model.multi_modal_projector.": "multi_modal_projector.",
             "lm_head.": "language_model.lm_head.",
+            "model.": "language_model.model.",
         }
     )
 

--- a/vllm/model_executor/models/llava_next.py
+++ b/vllm/model_executor/models/llava_next.py
@@ -233,6 +233,7 @@ class LlavaNextForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsP
             "model.multi_modal_projector.": "multi_modal_projector.",
             "model.image_newline": "image_newline",
             "lm_head.": "language_model.lm_head.",
+            "model.": "language_model.model.",
         }
     )
 

--- a/vllm/model_executor/models/llava_next_video.py
+++ b/vllm/model_executor/models/llava_next_video.py
@@ -320,6 +320,7 @@ class LlavaNextVideoForConditionalGeneration(
             "model.multi_modal_projector.": "multi_modal_projector.",
             "model.image_newline": "image_newline",
             "lm_head.": "language_model.lm_head.",
+            "model.": "language_model.model.",
         }
     )
 

--- a/vllm/model_executor/models/minicpmv4_6.py
+++ b/vllm/model_executor/models/minicpmv4_6.py
@@ -956,6 +956,7 @@ class MiniCPMV4_6ForConditionalGeneration(
             "model.merger.": "merger.",
             "model.language_model.": "language_model.model.",
             "lm_head.": "language_model.lm_head.",
+            "model.": "language_model.model.",
         }
     )
 

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -299,6 +299,7 @@ class PixtralForConditionalGeneration(
             "model.language_model.": "language_model.model.",
             "model.vision_tower.": "vision_encoder.",
             "model.multi_modal_projector.": "vision_language_adapter.",
+            "model.": "language_model.model.",
         },
         orig_to_new_substr={
             ".linear_1.": ".w_in.",

--- a/vllm/model_executor/models/rvl.py
+++ b/vllm/model_executor/models/rvl.py
@@ -98,6 +98,7 @@ class RForConditionalGeneration(LlavaOnevisionForConditionalGeneration):
             "model.multi_modal_projector.": "multi_modal_projector.",
             "model.image_newline": "image_newline",
             "lm_head.": "language_model.lm_head.",
+            "model.": "language_model.model.",
         }
     )
 


### PR DESCRIPTION
## Purpose

Follow-up to #48019 and #48022. #48022 fixes the silent text-PEFT-LoRA no-op for `Qwen3VLForConditionalGeneration` by appending a bare `"model.": "language_model.model."` rule to its `hf_to_vllm_mapper`. The discussion on #48019 noted the same gap likely affects other wrapper models that mount their text decoder under `self.language_model`; this PR applies the identical fix to the ones I could confirm.

Affected models, each verified to mount `self.language_model` and to lack any rule that catches a bare `model.` prefix before this change:

- `llava.py`
- `llava_next.py`
- `llava_next_video.py`
- `pixtral.py`
- `gemma3_mm.py`
- `minicpmv4_6.py`
- `lightonocr.py`
- `rvl.py`

`fuyu.py` was on the original candidate list discussed in #48019 but the model file no longer exists on main (it's marked deprecated in `registry.py` as of 0.25.0), so it's excluded here.

## Root cause (same as #48022)

A text-only PEFT LoRA trained against the plain HF causal LM produces adapter keys like `base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight`. After vLLM strips the standard `base_model.model.` prefix, the key becomes `model.layers.0.self_attn.q_proj...`. None of the affected models' `orig_to_new_prefix` rules match a bare `model.` prefix (each only maps more specific prefixes such as `model.language_model.`, `model.vision_tower.`, `model.merger.`, etc.), so `parse_fine_tuned_lora_name` resolves the key against a module path that does not exist under the wrapper. The adapter loads without error and inference proceeds unchanged, using the base model's weights.

## Fix

Append `"model.": "language_model.model."` as the **last** entry in each model's `orig_to_new_prefix` dict. `WeightsMapper._map_name_with_shard` iterates the dict in insertion order and does not break after the first match, so the more specific, pre-existing rules for vision tower / projector / merger / language-model checkpoint keys still consume their own keys first. Only keys left unmatched by any of those - i.e. exactly the bare `model.<x>` text-LoRA case - fall through to the new catch-all.

## Test Plan

Static verification against each model's real `orig_to_new_prefix` dict (no GPU/weights required), mirroring the approach in #48022:

1. For every pre-existing rule in each file, built a representative sample key using that rule's own prefix and confirmed the mapped output is identical before and after the change (no regression on vision/projector/language-model checkpoint key routing).
2. For five representative text-LoRA suffixes (`q_proj`, `k_proj`/`v_proj` pattern via `q_proj`, `gate_proj`, `up_proj`, `down_proj`, plus `lora_A`/`lora_B` variants), confirmed the mapped key resolves under `language_model.` after the change in every one of the eight files, versus none before.

## Test Result

Per-file summary (base-weight regression check across each file's own existing rules, and text-LoRA resolution before/after):

```
llava.py             base-weight: PASS (4 rules)   text-LoRA: 0/5 -> 5/5
llava_next.py         base-weight: PASS (5 rules)   text-LoRA: 0/5 -> 5/5
llava_next_video.py   base-weight: PASS (5 rules)   text-LoRA: 0/5 -> 5/5
pixtral.py            base-weight: PASS (3 rules)   text-LoRA: 0/5 -> 5/5
gemma3_mm.py           base-weight: PASS (4 rules)   text-LoRA: 0/5 -> 5/5
minicpmv4_6.py        base-weight: PASS (7 rules)   text-LoRA: 0/5 -> 5/5
lightonocr.py          base-weight: PASS (4 rules)   text-LoRA: 0/5 -> 5/5
rvl.py                 base-weight: PASS (5 rules)   text-LoRA: 0/5 -> 5/5
```

`minicpmv4_6.py` and `lightonocr.py` use their own vision-side naming (`vpm.`/`vit_merger.`/`merger.` for the former, `vision_encoder.`/`vision_projection.` for the latter) rather than the more common `vision_tower.`/`multi_modal_projector.` seen elsewhere; the regression check used each file's actual existing prefixes rather than a shared generic key set, to avoid false positives from prefixes that don't apply to a given model.

Each of these still needs to be exercised with a real text-LoRA checkpoint end to end as a final sanity check; I don't currently have GPU access to do that myself, so flagging it here in case a maintainer or another contributor can confirm on hardware before merging.

## Related

- #48019
- #48022