### PR TITLE
[Bugfix] Fix deepseek_v2 missing last layer hidden states extraction

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1461,7 +1461,10 @@ class DeepseekV2Model(nn.Module):
                 )
                 # fused_add_rms_norm requires a contiguous residual
                 residual = residual.contiguous()
-            if idx in self.aux_hidden_state_layers:
+            hidden_states, residual = layer(
+                positions, hidden_states, residual, llama_4_scaling
+            )
+            if idx + 1 in self.aux_hidden_state_layers:
                 aux_hidden_state = hidden_states + residual
                 if aux_hidden_state.shape[0] != positions.shape[0]:
                     aux_hidden_state = tensor_model_parallel_all_gather(
@@ -1469,9 +1472,6 @@ class DeepseekV2Model(nn.Module):
                     )
                     aux_hidden_state = aux_hidden_state[: positions.shape[0]]
                 aux_hidden_states.append(aux_hidden_state)
-            hidden_states, residual = layer(
-                positions, hidden_states, residual, llama_4_scaling
-            )
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(


### PR DESCRIPTION
## Summary

The `DeepseekV2Model` forward loop captures `aux_hidden_states` **before** calling `layer()`, so the output of the last layer is never included. This breaks dflash training, which requires the final layer's activation values to compute the loss.

## Fix

Move the capture to **after** `layer()` and use `idx + 1` (1-based layer numbering) instead of `idx`. This matches the pattern already used in `vllm/models/deepseek_v4/nvidia/model.py`.

## Testing

```bash
# Verify the module imports correctly
.venv/bin/python -c "from vllm.model_executor.models.deepseek_v2 import DeepseekV2ForCausalLM; print('OK')"
```

## Notes
- Fixes #48124
- AI assistance used in preparation of this PR