### PR TITLE
[Bugfix] Fix deepseek_v2 missing last layer aux hidden state extraction

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1461,7 +1461,10 @@ class DeepseekV2Model(nn.Module):
                 )
                 # fused_add_rms_norm requires a contiguous residual
                 residual = residual.contiguous()
-            if idx in self.aux_hidden_state_layers:
+            hidden_states, residual = layer(
+                positions, hidden_states, residual, llama_4_scaling
+            )
+            if idx + 1 in self.aux_hidden_state_layers:
                 aux_hidden_state = hidden_states + residual
                 if aux_hidden_state.shape[0] != positions.shape[0]:
                     aux_hidden_state = tensor_model_parallel_all_gather(
@@ -1469,9 +1472,6 @@ class DeepseekV2Model(nn.Module):
                     )
                     aux_hidden_state = aux_hidden_state[: positions.shape[0]]
                 aux_hidden_states.append(aux_hidden_state)
-            hidden_states, residual = layer(
-                positions, hidden_states, residual, llama_4_scaling
-            )
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
@@ -1489,7 +1489,10 @@ class DeepseekV2Model(nn.Module):
             residual = residual.contiguous()
 
         if self.end_layer in self.aux_hidden_state_layers:
-            aux_hidden_states.append(hidden_states + residual)
+            if aux_hidden_states:
+                aux_hidden_states[-1] = hidden_states + residual
+            else:
+                aux_hidden_states.append(hidden_states + residual)
 
         hidden_states, _ = self.norm(hidden_states, residual)
         if len(aux_hidden_states) > 0:


### PR DESCRIPTION
Move the aux_hidden_state capture in the forward loop from before layer()
to after it, and use idx + 1 so layer outputs are captured under 1-based
layer indices. Without this, the last layer's output is never appended to
aux_hidden_states, which breaks dflash training that needs the final layer
activation. Matches the pattern in deepseek_v4/nvidia/model.py.

Fixes #48124