### PR TITLE
[ROCm] Revert Part of `[ROCm] Fix pooling startup workspace lock` #47912

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -729,11 +729,6 @@ class Worker(WorkerBase):
     @instrument(span_name="Warmup (GPU)")
     def compile_or_warm_up_model(self) -> CompilationTimes:
         warmup_sizes: list[int] = []
-        cg_capture_sizes: list[int] = []
-
-        if self.vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
-            cg_sizes = self.vllm_config.compilation_config.cudagraph_capture_sizes
-            cg_capture_sizes = [] if cg_sizes is None else cg_sizes
 
         if self.vllm_config.compilation_config.mode == CompilationMode.VLLM_COMPILE:
             # warm up sizes that are not in cudagraph capture sizes,
@@ -741,8 +736,11 @@ class Worker(WorkerBase):
             # e.g. for the max-num-batched token size in chunked prefill.
             compile_sizes = self.vllm_config.compilation_config.compile_sizes
             warmup_sizes = compile_sizes.copy() if compile_sizes is not None else []  # type: ignore[assignment]
+            cg_capture_sizes: list[int] = []
 
             if self.vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
+                cg_sizes = self.vllm_config.compilation_config.cudagraph_capture_sizes
+                cg_capture_sizes = [] if cg_sizes is None else cg_sizes
                 warmup_sizes = [x for x in warmup_sizes if x not in cg_capture_sizes]
 
             compile_ranges = self.vllm_config.compilation_config.get_compile_ranges()
@@ -754,23 +752,6 @@ class Worker(WorkerBase):
             for compile_range in compile_ranges:
                 if not any(x in compile_range for x in all_sizes):
                     warmup_sizes.append(compile_range.end)
-
-        # TODO(LucasWilkinson, akaratza): Remove when MRV1 is deprecated
-        if (
-            current_platform.is_rocm()
-            and not self.use_v2_model_runner
-            and self.vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
-            and get_pp_group().is_last_rank
-        ):
-            max_num_reqs = min(
-                self.scheduler_config.max_num_seqs,
-                self.scheduler_config.max_num_batched_tokens,
-            )
-            if (
-                max_num_reqs not in cg_capture_sizes
-                and max_num_reqs not in warmup_sizes
-            ):
-                warmup_sizes.append(max_num_reqs)
 
         # We skip EPLB here since we don't want to record dummy metrics
         for size in sorted(warmup_sizes, reverse=True):


### PR DESCRIPTION

Revert part of `[ROCm] Fix pooling startup workspace lock` #47912 which is causing some failures in AMD CI, e.g. in `Model Executor`:

```
pytest -v -s tests/model_executor/model_loader/test_reload.py::test_reload_weights[inference-optimization/DeepSeek-V3-debug-empty-FP8_DYNAMIC-inference-optimization/DeepSeek-V3-debug-multiply-FP8_DYNAMIC-inference-optimization/DeepSeek-V3-debug-add-FP8_DYNAMIC-1]
```

(e.g. https://buildkite.com/vllm/ci/builds/77216/canvas?jid=019f4430-a977-4f4b-860d-01e2db3a0d16&tab=output)