### PR TITLE
[ROCm] Add tuned selective_state_update config for AMD MI350

### DIFF
--- a/vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=AMD_Instinct_MI350_OAM,cache_dtype=float16.json
+++ b/vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=AMD_Instinct_MI350_OAM,cache_dtype=float16.json
@@ -1,0 +1,51 @@
+{
+    "triton_version": "3.6.0",
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 4
+    },
+    "256": {
+        "BLOCK_SIZE_M": 32,
+        "num_warps": 4
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 2
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 8,
+        "num_warps": 1
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 8,
+        "num_warps": 1
+    },
+    "8192": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 2
+    },
+    "16384": {
+        "BLOCK_SIZE_M": 8,
+        "num_warps": 1
+    },
+    "32768": {
+        "BLOCK_SIZE_M": 8,
+        "num_warps": 1
+    },
+    "65536": {
+        "BLOCK_SIZE_M": 8,
+        "num_warps": 1
+    },
+    "131072": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 1
+    },
+    "196608": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 1
+    },
+    "262144": {
+        "BLOCK_SIZE_M": 8,
+        "num_warps": 1
+    }
+}

--- a/vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=AMD_Instinct_MI350_OAM,cache_dtype=float32.json
+++ b/vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=AMD_Instinct_MI350_OAM,cache_dtype=float32.json
@@ -1,0 +1,51 @@
+{
+    "triton_version": "3.6.0",
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 4
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 4
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 8,
+        "num_warps": 1
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 8,
+        "num_warps": 1
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 4,
+        "num_warps": 1
+    },
+    "8192": {
+        "BLOCK_SIZE_M": 32,
+        "num_warps": 2
+    },
+    "16384": {
+        "BLOCK_SIZE_M": 4,
+        "num_warps": 1
+    },
+    "32768": {
+        "BLOCK_SIZE_M": 4,
+        "num_warps": 1
+    },
+    "65536": {
+        "BLOCK_SIZE_M": 64,
+        "num_warps": 8
+    },
+    "131072": {
+        "BLOCK_SIZE_M": 64,
+        "num_warps": 8
+    },
+    "196608": {
+        "BLOCK_SIZE_M": 64,
+        "num_warps": 2
+    },
+    "262144": {
+        "BLOCK_SIZE_M": 64,
+        "num_warps": 8
+    }
+}


### PR DESCRIPTION


## Summary

Adds tuned `selective_state_update` (Mamba SSU decode kernel) launch configs for the **AMD Instinct MI350X** for both the `cache_dtype=float16` and `cache_dtype=float32` variants, mirroring how the MI355 (#47767), and MI300X (#47945, #47947) configurations were done.

vLLM bundles per-device SSU configs for NVIDIA parts (B200, GB200, H100, H200, RTX PRO 6000) and, recently, MI355 and MI300X. On MI350X `get_ssm_configs()` finds no matching file and falls back to the generic `_get_default_ssm_launch_config()` heuristic, which is well off the optimal `(BLOCK_SIZE_M, num_warps)` for these shapes and leaves Mamba decode throughput on the table.

This PR adds the missing configs for `headdim=64, dstate=128` on MI350X. bf16 shares the float16 file (the loader canonicalizes bf16 to float16, since the kernel only sees state bit-width).

## How it was generated

Produced with the in-tree tuning script on an MI350X, once per state-cache dtype:
```bash
python -m benchmarks.kernels.benchmark_selective_state_update
--dstate 128 --dtype float16 --mamba-ssm-cache-dtype float16
--save-configs --compare --validate

python -m benchmarks.kernels.benchmark_selective_state_update
--dstate 128 --dtype float16 --mamba-ssm-cache-dtype float32
--save-configs --compare --validate
```


The device name and dtype key in the filename are derived automatically by the script, so the files drop straight into `configs/selective_state_update/` and are picked up at runtime with no code changes. Keyed on `effective_batch = batch * nheads`, so a config transfers across (model, TP) combos sharing `(headdim=64, dstate=128, cache_dtype)`.

## Test plan

- `--validate`: all tuned `effective_batch` points pass against the CPU reference (12/12 for both dtypes).
- `--compare`: consistent speedup over the generic heuristic across the swept grid.
- Files are loaded at runtime (log: `Using SSM config from .../device_name=AMD_Instinct_MI350_OAM,cache_dtype=<dt>.json for selective_state_update`); with them removed, the run logs `Using default Mamba SSU config. Performance might be sub-optimal!`.
- End-to-end correctness verified with `lm_eval` lambada_openai (see Results).

The config only selects Triton launch geometry (`BLOCK_SIZE_M`, `num_warps`), not the kernel math, so model outputs are unaffected.

## Results

**Perf — `selective_state_update` kernel, tuned vs the current heuristic (M=4, w=4)**, relative speedup from `benchmark_selective_state_update.py --compare`:

| effective_batch | fp16 speedup | fp32 speedup |
|---|---|---|
| 128 | 1.20× | 1.12× |
| 256 | 1.33× | 1.19× |
| 1024 | 1.84× | 1.26× |
| 2048 | 1.68× | 1.21× |
| 4096 | 1.97× | 1.28× |
| 8192 | 2.06× | 1.52× |
| 16384 | 1.99× | 1.33× |
| 32768 | 1.97× | 1.34× |
| 65536 | 2.01× | 1.35× |
| 131072 | 2.23× | 1.36× |
| 196608 | 2.28× | 1.45× |
| 262144 | 2.23× | 1.39× |

fp16: ~1.2× at small batch (latency-bound), **~2.0–2.3× across the decode range**. fp32: ~1.1× at small batch, **~1.3–1.5× across the decode range**.

**Correctness — end-to-end, unchanged.** `lm_eval` lambada_openai (500 examples), config present vs removed, `AntonV/mamba2-2.7b-hf` (headdim=64, dstate=128), fp16 activations:

*float16 SSM state cache:*

| config | acc | perplexity |
|---|---|---|
| tuned (this PR) | 0.704 | 4.2669 |
| heuristic | 0.704 | 4.2668 |

*float32 SSM state cache:*

| config | acc | perplexity |
|---|---|---|
| tuned (this PR) | 0.704 | 4.2668 |
| heuristic | 0.704 | 4.2668 |

Identical acc and perplexity to 3 decimals — expected, since the config only changes the Triton launch geometry, not the math.