### PR TITLE
[CI] Increase extract hidden states TP2 timeout

### DIFF
--- a/tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py
+++ b/tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py
@@ -297,7 +297,7 @@ def test_extract_hidden_states_qwen35_hybrid_smoke(tmp_path):
         )
 
 
-@pytest.mark.timeout(240 if current_platform.is_rocm() else 60)
+@pytest.mark.timeout(240 if current_platform.is_rocm() else 120)
 @multi_gpu_test(num_gpus=2)
 @create_new_process_for_each_test()
 def test_extract_hidden_states_tp2():


### PR DESCRIPTION
## Why

`test_extract_hidden_states_tp2` is timing out on Buildkite just above its CUDA 60s pytest timeout. The PR run for #41359 did execute `Extract Hidden States Integration (2 GPUs)` and passed, but only barely: `1 passed, 2 deselected, 17 warnings in 60.58s`. Subsequent main runs fail around 62.6s with `Failed: Timeout >60.0s`.

This bumps the CUDA timeout for that test from 60s to 120s while keeping the existing ROCm timeout at 240s.

## Buildkite history

Last observed main pass: Buildkite build 76838 at commit `ed051fab54`.

First observed main failure: Buildkite build 76847 at merge commit `dd94484577` for #41359.

Commits between last pass and first failure:

```text
0ed05b6f82 [CI] Fix Transformers modeling backend LoRA test (#47832)
0a2965b1b3 [BugFix] Fix ModelOpt mixed-precision quantization for sparse quantized_layers configs. (#47318)
7ff656cc8b fix: ensure no double load of lm head in nemotron mtp (#47440)
dd94484577 Bump Transformers version to 5.10.4 (#41359)
```
## Tests

```text
.venv/bin/python -m pytest tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py::test_extract_hidden_states_tp2 --collect-only -q
.venv/bin/pre-commit run ruff-check --files tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py
git diff --check
```

The local environment does not have `pytest-timeout` installed, so collection reports `PytestUnknownMarkWarning`; Buildkite enforces this marker.

## Model evals

Not run; this is a CI timeout-only change and does not affect model behavior.

AI assistance was used for this change.