### PR TITLE
[Bugfix] Opt out of pinned host memory for shm multimodal decode

### DIFF
--- a/vllm/distributed/device_communicators/shm_object_storage.py
+++ b/vllm/distributed/device_communicators/shm_object_storage.py
@@ -346,12 +346,23 @@ class ObjectSerde(ABC):
 class MsgpackSerde(ObjectSerde):
     def __init__(self):
         # Delayed import to avoid circular dependency
+        import vllm.envs as envs
         from vllm.multimodal.inputs import MultiModalKwargsItem
         from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
 
         self.encoder = MsgpackEncoder()
-        self.tensor_decoder = MsgpackDecoder(torch.Tensor, share_mem=False)
-        self.mm_decoder = MsgpackDecoder(MultiModalKwargsItem, share_mem=False)
+        # Tensors read out of the shm ring must be copied out before the slot
+        # is reused (share_mem=False). By default that copy is pinned, but
+        # pinned host memory is never returned to the OS by the CUDA host
+        # allocator, so variable-sized multimodal tensors grow the pinned pool
+        # without bound. Opt out to pageable copies via env.
+        pin_tensors = False if envs.VLLM_SHM_OBJECT_STORAGE_DISABLE_PIN_MEMORY else None
+        self.tensor_decoder = MsgpackDecoder(
+            torch.Tensor, share_mem=False, pin_tensors=pin_tensors
+        )
+        self.mm_decoder = MsgpackDecoder(
+            MultiModalKwargsItem, share_mem=False, pin_tensors=pin_tensors
+        )
         self._mm_kwargs_item_cls = MultiModalKwargsItem
 
     def serialize(self, value: Any) -> tuple[bytes | list[bytes], int, bytes, int]:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -271,6 +271,7 @@ if TYPE_CHECKING:
     VLLM_LOG_MODEL_INSPECTION: bool = False
     VLLM_DEBUG_MFU_METRICS: bool = False
     VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY: bool = False
+    VLLM_SHM_OBJECT_STORAGE_DISABLE_PIN_MEMORY: bool = False
     VLLM_WEIGHT_OFFLOADING_DISABLE_UVA: bool = False
     VLLM_WSL2_ENABLE_PIN_MEMORY: bool = False
     VLLM_DISABLE_LOG_LOGO: bool = False
@@ -1908,6 +1909,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Disable using pytorch's pin memory for CPU offloading.
     "VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY": lambda: bool(
         int(os.getenv("VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY", "0"))
+    ),
+    # Disable pinning host memory when deserializing tensors / multimodal
+    # kwargs read out of the shared-memory object storage. Pinned (page-locked)
+    # copies are never returned to the OS by the CUDA host allocator, so on
+    # multimodal workloads with variable tensor sizes the pinned pool grows
+    # without bound. When set, use pageable copies (clone) instead, trading a
+    # small H2D-transfer cost for reclaimable host memory.
+    "VLLM_SHM_OBJECT_STORAGE_DISABLE_PIN_MEMORY": lambda: bool(
+        int(os.getenv("VLLM_SHM_OBJECT_STORAGE_DISABLE_PIN_MEMORY", "0"))
     ),
     # Disable using UVA (Unified Virtual Addressing) for CPU offloading.
     "VLLM_WEIGHT_OFFLOADING_DISABLE_UVA": lambda: bool(

--- a/vllm/v1/serial_utils.py
+++ b/vllm/v1/serial_utils.py
@@ -325,9 +325,14 @@ class MsgpackDecoder:
         t: Any | None = None,
         share_mem: bool = True,
         oob_tensor_provider: OOBTensorProvider | None = None,
+        pin_tensors: bool | None = None,
     ):
         self.share_mem = share_mem
-        self.pin_tensors = PIN_MEMORY
+        # When ``pin_tensors`` is None, fall back to pinning whenever pinned
+        # memory is available (the historical default). Callers that retain
+        # decoded tensors only transiently can pass ``False`` to use pageable
+        # copies and avoid growing the (never-freed) pinned host pool.
+        self.pin_tensors = PIN_MEMORY if pin_tensors is None else pin_tensors
         args = () if t is None else (t,)
         self.decoder = msgpack.Decoder(
             *args, ext_hook=self.ext_hook, dec_hook=self.dec_hook


### PR DESCRIPTION
Private_Dirty. A t0->t5 memray pair on Worker_TP0 isolated the growth to _decode_tensor (vllm/v1/serial_utils.py): +324 MB in 5 minutes, all from pin_memory() when MsgpackSerde (share_mem=False) deserializes the multimodal kwargs it reads out of the shared-memory object-storage ring.

pin_memory() copies are page-locked; the CUDA host caching allocator never returns them to the OS (and tcmalloc cannot reclaim them). With MiniMax-M3's variable-sized pixel_values the pinned pool grows without bound even though the tensor objects are freed on request finish -- the worker retained 1088 pinned buffers vs max-num-seqs 16, confirming the memory is cached by the allocator, not held by live requests.

Add a `pin_tensors` parameter to MsgpackDecoder (default None keeps the historical is_pin_memory_available() behavior) and let MsgpackSerde opt out via VLLM_SHM_OBJECT_STORAGE_DISABLE_PIN_MEMORY=1, switching the mandatory copy-out from pin_memory() to a pageable clone() that tcmalloc can release. Default behavior is unchanged; only the shm serde decoders honor the flag.

AI-assisted (Claude): root-caused via a memray worker-pair diff.




## Purpose

## Test Plan

Tested on B300, flipped the flag and took memray.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

