### PR TITLE
[ROCm][CI] Move remaining engine/samplers AMD steps to mi325_1

### DIFF
--- a/.buildkite/test_areas/engine.yaml
+++ b/.buildkite/test_areas/engine.yaml
@@ -60,7 +60,7 @@ steps:
     - pytest -v -s v1/e2e/general/test_async_scheduling.py
   mirror:
     amd:
-      device: mi250_1
+      device: mi325_1
       timeout_in_minutes: 60
       depends_on:
       - image-build-amd
@@ -76,7 +76,7 @@ steps:
     - pytest -v -s v1/e2e/general --ignore v1/e2e/general/test_async_scheduling.py
   mirror:
     amd:
-      device: mi250_1
+      device: mi325_1
       timeout_in_minutes: 35
       depends_on:
       - image-build-amd

--- a/.buildkite/test_areas/samplers.yaml
+++ b/.buildkite/test_areas/samplers.yaml
@@ -19,7 +19,7 @@ steps:
     - VLLM_USE_FLASHINFER_SAMPLER=1 pytest -v -s samplers
   mirror:
     amd:
-      device: mi250_1
+      device: mi325_1
       depends_on:
       - image-build-amd
       commands:


### PR DESCRIPTION
## Purpose

Three mirrored AMD CI steps in `.buildkite/test_areas/` were still pinned to the `mi250_1` agent pool (gfx90a): the async-scheduling e2e step and the general e2e step in `engine.yaml`, and the FlashInfer sampler step in `samplers.yaml`. Every other step under `test_areas/` already runs on `mi325_1`, and these three were the only remaining `mi250_1` references in that directory. This moves them onto `mi325_1` so all mirrored AMD steps target the same pool and no `test_areas` step depends on mi250 hardware.

This is a CI configuration change only ~@~T no product code is touched. AI-assisted (Claude); a human reviewed every line. Not a duplicate: no open PR migrates these steps (checked `vllm-project/vllm` open PRs for mi325/mi250 device changes and for the engine/samplers
test areas).

## Test Plan

Config-only change; there is no local runtime behavior to exercise. Validation is that the Buildkite AMD mirror now schedules these steps on `mi325_1`. Verified locally that after the change `test_areas/` contains zero `mi250_1` references:

```bash
grep -rn "mi250_1" .buildkite/test_areas/
```

## Test Result

Before: 3 matches (engine.yaml async-scheduling, engine.yaml general e2e, samplers.yaml FlashInfer sampler).

After: 0 matches ~@~T all mirrored AMD steps in `test_areas/` now use `mi325_1`.

The real validation is the CI run on this PR scheduling these steps on the `mi325_1` pool and passing.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

