### PR TITLE
[CI] Fix cargo-deny config flag ordering

### DIFF
--- a/.buildkite/scripts/run-rust-frontend-cargo-ci.sh
+++ b/.buildkite/scripts/run-rust-frontend-cargo-ci.sh
@@ -168,8 +168,8 @@ run_style_clippy() {
   log_section "Checking Rust dependency bans"
   cargo deny \
     --manifest-path rust/Cargo.toml \
-    check \
     --config rust/deny.toml \
+    check \
     bans
 
   log_section "Running clippy"


### PR DESCRIPTION
Fixes the Rust frontend style job after the `cargo-deny` 0.20 CLI change.

`cargo-deny` now treats `--config` as a top-level option. The Buildkite script installs `cargo-deny` without a version pin, so jobs that pick up `cargo-deny v0.20.2` fail before clippy runs with:

```text
error: unexpected argument '--config' found
```

This moves `--config rust/deny.toml` before the `check` subcommand.

Buildkite logs:
- Branch failure: [`ci` build 77375, Rust Frontend Cargo Style + Clippy](https://buildkite.com/vllm/ci/builds/77375#019f488c-c929-4132-bdf1-041683509eab) fails after installing `cargo-deny v0.20.2` with `unexpected argument '--config' found`.
- `main` daily failure: [`ci` build 77380, Rust Frontend Cargo Style + Clippy](https://buildkite.com/vllm/ci/builds/77380#019f48b0-ce3a-4eff-a202-7242d3d5cb0b) shows the same `cargo-deny v0.20.2` failure.
- Last passing AMD nightly before the external release: [`amd-ci` build 10649](https://buildkite.com/vllm/amd-ci/builds/10649#019f461b-388d-4a5b-8641-134e467d0aff) passed with `cargo-deny v0.19.9`.

Upstream reference: [`cargo-deny` PR #881](https://github.com/EmbarkStudios/cargo-deny/pull/881) refactored the CLI as a breaking change and moved `--config` from the `check` subcommand to the root command. The [`cargo-deny` changelog for 0.20.0](https://github.com/EmbarkStudios/cargo-deny/blob/main/CHANGELOG.md#0200---2026-07-09) points to that PR as the CLI refactor that moved duplicated options/flags into the root.

Tests:
- `~/.cargo/bin/cargo-deny --version` -> `cargo-deny 0.20.2`.
- `~/.cargo/bin/cargo-deny --manifest-path rust/Cargo.toml --config rust/deny.toml check --help >/tmp/cargo-deny-check-help.out` passed, confirming the new argument ordering is accepted by the 0.20.2 parser.
- `SKIP=shellcheck git commit ...` passed remaining pre-commit hooks. The unskipped `shellcheck` hook was attempted first and failed on existing repository-wide shellcheck findings in unrelated files; this change touches only `.buildkite/scripts/run-rust-frontend-cargo-ci.sh`.

Model evals: not run; this is CI script-only and does not affect model output, accuracy, or serving behavior.

AI assistance was used to investigate the Buildkite failure and prepare this change. The submitter has reviewed the changes.


