### PR TITLE
Add Phi-4-mini to batch invariance tested models

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -107,6 +107,7 @@ Batch invariance has been tested and verified on the following models:
 - **Llama 3**: Llama3.1 and 3.2 series, `meta-llama/Llama-3.2-3B-Instruct` for example
 - **GPT-OSS**: `openai/gpt-oss-20b`, `openai/gpt-oss-120b`
 - **Mistral**: `mistralai/Mistral-7B-v0.3`
+- **Phi series**: `microsoft/Phi-4-mini-instruct`
 
 Other models may also work, but these have been explicitly validated. If you encounter issues with a specific model, please report them on the [GitHub issue tracker](https://github.com/vllm-project/vllm/issues/new/choose).
 


### PR DESCRIPTION
## Purpose
Add `microsoft/Phi-4-mini-instruct` to the batch invariance tested models list. Update docs/features/batch_invariance.md. This follows the model coverage request in #27433.
## Test Plan
Ran the full batch invariance test file on the latest `main`:
```bash
VLLM_TEST_MODEL="microsoft/Phi-4-mini-instruct" \
VLLM_GPU_MEMORY_UTILIZATION=0.9 \
uv run --no-sync python -m pytest \
tests/v1/determinism/test_batch_invariance.py \
-s -vv --tb=short
```
## Test Result
16 passed, 34 warnings in 724.92s (0:12:04)
---
## Environment:
GPU: NVIDIA GeForce RTX 4080
torch: 2.11.0+cu130
torch cuda: 13.0
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating docs/features/batch_invariance.md.
</details>

