### PR TITLE
[Bugfix] Presize shared MoE Workspace To Worst-Case Size Before Lock

### DIFF
--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -39,7 +39,10 @@ from vllm.v1.worker.ubatching import (
     dbo_register_recv_hook,
     dbo_yield,
 )
-from vllm.v1.worker.workspace import current_workspace_manager
+from vllm.v1.worker.workspace import (
+    current_workspace_manager,
+    is_workspace_manager_initialized,
+)
 
 logger = init_logger(__name__)
 
@@ -1102,6 +1105,40 @@ class FusedMoEKernelModularImpl:
 
         return workspace13, workspace2, fused_out
 
+    def reserve_workspace(self, N: int, K: int) -> None:
+        """Pre-grow the shared MoE workspace to its worst-case size."""
+        # DP-EP experts size their own persistent buffers, so skip them here.
+        if self.is_dp_ep:
+            return
+        if not is_workspace_manager_initialized():
+            return
+        workspace_manager = current_workspace_manager()
+        if workspace_manager.is_locked():
+            return
+
+        moe_config = self.fused_experts.moe_config
+        max_num_tokens = moe_config.max_num_tokens
+        if max_num_tokens <= 0 or N <= 0 or K <= 0:
+            return
+
+        try:
+            self._allocate_buffers(
+                moe_config.in_dtype,
+                torch.device(moe_config.device),
+                max_num_tokens,
+                max_num_tokens,
+                N,
+                K,
+                moe_config.experts_per_token,
+                moe_config.num_experts,
+                moe_config.num_local_experts,
+                None,
+                moe_config.activation,
+            )
+        except Exception as e:
+            # If we cannot pre-size the workspace, fall back to lazy growth
+            logger.debug_once("Skipping MoE workspace reservation: %s", e)
+
     def _maybe_apply_shared_experts(
         self,
         shared_experts: SharedExperts | None,
@@ -1586,6 +1623,10 @@ class FusedMoEKernel:
 
     def supports_lora(self) -> bool:
         return self.fused_experts.supports_lora()
+
+    def reserve_workspace(self, N: int, K: int) -> None:
+        if isinstance(self.impl, FusedMoEKernelModularImpl):
+            self.impl.reserve_workspace(N, K)
 
     def _post_init_setup(self):
         """

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -1118,8 +1118,6 @@ class FusedMoEKernelModularImpl:
 
         moe_config = self.fused_experts.moe_config
         max_num_tokens = moe_config.max_num_tokens
-        if max_num_tokens <= 0 or N <= 0 or K <= 0:
-            return
 
         try:
             self._allocate_buffers(

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -889,6 +889,16 @@ class MoERunner(MoERunnerInterface):
                 )
             )
 
+    def maybe_reserve_moe_workspace(self) -> None:
+        """Pre-size the shared MoE workspace to its worst case before lock."""
+        kernel = self._quant_method.moe_kernel
+        if kernel is None:
+            return
+        w13_weight = getattr(self.routed_experts, "w13_weight", None)
+        if w13_weight is None or w13_weight.dim() != 3:
+            return
+        kernel.reserve_workspace(int(w13_weight.shape[1]), self.moe_config.hidden_dim)
+
     #
     # Properties
     #

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -111,7 +111,7 @@ from vllm.sampling_params import SamplingType
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import GenerationTask, PoolingTask, SupportedTask
 from vllm.tracing import instrument
-from vllm.utils import length_from_prompt_token_ids_or_embeds
+from vllm.utils import is_moe_layer, length_from_prompt_token_ids_or_embeds
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.mem_utils import DeviceMemoryProfiler, format_gib
 from vllm.utils.nvtx_pytorch_hooks import PytHooks
@@ -5199,6 +5199,12 @@ class GPUModelRunner(
             new_config = update_config(config, config_overrides)
             setattr(self, config_name, new_config)
 
+    def _reserve_moe_workspaces(self, model: nn.Module) -> None:
+        """Pre-size the shared MoE workspace to its worst case before lock."""
+        for module in model.modules():
+            if is_moe_layer(module) and hasattr(module, "maybe_reserve_moe_workspace"):
+                module.maybe_reserve_moe_workspace()
+
     @instrument(span_name="Loading (GPU)")
     def load_model(self, load_dummy_weights: bool = False) -> None:
         """
@@ -5309,10 +5315,12 @@ class GPUModelRunner(
         )
         if not load_dummy_weights:
             prepare_communication_buffer_for_model(self.model)
+            self._reserve_moe_workspaces(self.model)
             if (drafter := getattr(self, "drafter", None)) and (
                 drafter_model := getattr(drafter, "model", None)
             ):
                 prepare_communication_buffer_for_model(drafter_model)
+                self._reserve_moe_workspaces(drafter_model)
         mm_config = self.model_config.multimodal_config
         self.is_multimodal_pruning_enabled = (
             supports_multimodal_pruning(self.get_model())


### PR DESCRIPTION

This is to address a bug where the Fused MoE `_allocate_buffers` can try to extend the MoE workspace after it has already been locked in `lock_workspace()`

We are seeing this bug in AMD CI `Language Models Test (Extended Pooling)` https://buildkite.com/vllm/ci/builds/76664/list?sid=019f3900-a887-45a4-bd39-f1e71a7beaee&tab=output, however I do not believe it to be a ROCm-specific bug. It is a latent bug which manifested recently:

```
pytest -v -s models/language/pooling/test_token_classification.py::test_openai_privacy_filter[bfloat16-openai/privacy-filter]

(EngineCore pid=56393) ERROR 07-07 09:07:23 [core.py:1231]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1435, in apply
(EngineCore pid=56393) ERROR 07-07 09:07:23 [core.py:1231]     fused_out = self._fused_experts(
(EngineCore pid=56393) ERROR 07-07 09:07:23 [core.py:1231]                 ^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=56393) ERROR 07-07 09:07:23 [core.py:1231]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1252, in _fused_experts
(EngineCore pid=56393) ERROR 07-07 09:07:23 [core.py:1231]     workspace13, workspace2, fused_out = self._allocate_buffers(
(EngineCore pid=56393) ERROR 07-07 09:07:23 [core.py:1231]                                          ^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=56393) ERROR 07-07 09:07:23 [core.py:1231]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1096, in _allocate_buffers
(EngineCore pid=56393) ERROR 07-07 09:07:23 [core.py:1231]     common_workspace, workspace2 = current_workspace_manager().get_simultaneous(
(EngineCore pid=56393) ERROR 07-07 09:07:23 [core.py:1231]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=56393) ERROR 07-07 09:07:23 [core.py:1231]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/workspace.py", line 110, in get_simultaneous
(EngineCore pid=56393) ERROR 07-07 09:07:23 [core.py:1231]     current_workspace = self._ensure_workspace_size(total_bytes)
(EngineCore pid=56393) ERROR 07-07 09:07:23 [core.py:1231]                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=56393) ERROR 07-07 09:07:23 [core.py:1231]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/workspace.py", line 157, in _ensure_workspace_size
(EngineCore pid=56393) ERROR 07-07 09:07:23 [core.py:1231]     raise AssertionError(
(EngineCore pid=56393) ERROR 07-07 09:07:23 [core.py:1231] AssertionError: Workspace is locked but allocation from 'modular_kernel.py:1096:_allocate_buffers' requires 15.00 MB, current size is 0.06 MB. Workspace growth is not allowed after locking.
```

A previous PR https://github.com/vllm-project/vllm/pull/47912 attempted to resolve this by running a dummy run with `max_num_reqs` to force the workspace to grow to the max size before graph capture. This introduced some unintended side effects when the dummy run runs without `CUDAGraphMode.NONE`, as it hits some JIT ops that aren't allowed during graph capture (see https://github.com/vllm-project/vllm/pull/48154):

```
pytest -v -s tests/model_executor/model_loader/test_reload.py::test_reload_weights[inference-optimization/DeepSeek-V3-debug-empty-FP8_DYNAMIC-inference-optimization/DeepSeek-V3-debug-multiply-FP8_DYNAMIC-inference-optimization/DeepSeek-V3-debug-add-FP8_DYNAMIC-1]

(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/schemas.py", line 1394, in __call__
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]     output_code = self.compiler_fn(gm, example_inputs)
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 2719, in fw_compiler_base
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]     return compile_fx_forward(
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]            ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 2326, in compile_fx_forward
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]     gm = _recursive_joint_graph_passes(gm, input_device=next(iter(inputs_devices)))
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 559, in _recursive_joint_graph_passes
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]     out_gm = joint_graph_passes(gm, input_device)
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/fx_passes/joint_graph.py", line 630, in joint_graph_passes
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]     GraphTransformObserver(graph, "constant_fold_uniform_value").apply_gm_pass(
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]   File "/usr/local/lib/python3.12/dist-packages/torch/fx/passes/graph_transform_observer.py", line 90, in apply_gm_pass
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]     return pass_fn(self.gm)
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]            ^^^^^^^^^^^^^^^^
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/fx_passes/joint_graph.py", line 418, in constant_fold_uniform_value
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]     cf.run()
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/constant_folding.py", line 296, in run
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]     return super().run(initial_env=env)
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]   File "/usr/local/lib/python3.12/dist-packages/torch/fx/interpreter.py", line 200, in run
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]     self.env[node] = self.run_node(node)
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]                      ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/constant_folding.py", line 271, in run_node
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]     self.add_node_replacement(node, out)
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/fx_passes/joint_graph.py", line 295, in add_node_replacement
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]     self.node_replacements[node] = tensor.flatten()[0].item()
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231] torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
(EngineCore pid=16785) ERROR 07-09 00:31:09 [core.py:1231] AcceleratorError: CUDA error: operation not permitted when stream is capturing
```
(https://buildkite.com/vllm/ci/builds/77216/canvas?jid=019f4430-a977-4f4b-860d-01e2db3a0d16&tab=output for the full log)

I propose that we reserve the max workspace size ahead of time (bounded by `max_num_batched_tokens`) to ensure that the workspace is always sized appropriately. 

In my testing, the workspace size allocated before this PR is the same as with this PR in most cases. For example, `DeepSeek-V2-Lite-Chat` w/ the Triton MoE backend yields a workspace size of 456 MB in either case. In the failing test case mentioned at the top of the description (which uses the `openai/privacy-filter` model), the workspace size was locked at 15 MB, but this PR grows it to 1920 MB so that no later shape can try to force post-lock growth.

An alternative solution could be to reinstate the approach from https://github.com/vllm-project/vllm/pull/47912, but force the dummy run to run with `CUDAGraphMode.NONE`.