### PR TITLE
Add DCP + Eagle support for Tokenspeed MLA backends

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -232,7 +232,7 @@ MLA decode backends are selected using the standard
 | `ROCM_AITER_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %1 | Any | ❌ | ❌ | ❌ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_AITER_MLA_SPARSE` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 1, 64 | Any | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_AITER_TRITON_MLA` | fp16, bf16 | `auto` | Any | Any | ❌ | ❌ | ❌ | ❌ | ❌ | Decoder | N/A |
-| `TOKENSPEED_MLA` | fp16, bf16 | `fp8`, `fp8_e4m3` | 32, 64 | Any | ❌ | ❌ | ❌ | ❌ | ❌ | Decoder | 10.x |
+| `TOKENSPEED_MLA` | fp16, bf16 | `fp8`, `fp8_e4m3` | 32, 64 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | 10.x |
 | `TRITON_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | %16 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | Any |
 | `XPU_MLA_SPARSE` | fp16, bf16 | `auto`, `float16`, `bfloat16` | Any | 576 | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | Any |
 

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -26,7 +26,7 @@ nvidia-cutlass-dsl[cu13]==4.5.2
 quack-kernels>=0.3.3
 
 # Tokenspeed_MLA for faster mla with spec decode
-tokenspeed-mla==0.1.2; platform_system == "Linux"
+tokenspeed-mla==0.1.8; platform_system == "Linux"
 
 # Humming kernels for quantization gemm
 humming-kernels[cu13]==0.1.10

--- a/tests/kernels/attention/test_use_trtllm_attention.py
+++ b/tests/kernels/attention/test_use_trtllm_attention.py
@@ -154,6 +154,17 @@ def test_use_dcp_fallback(_mock):
     assert _call(dcp_world_size=2) is False
 
 
+@patch("vllm.utils.flashinfer.supports_trtllm_attention", return_value=True)
+def test_use_dcp_fallback_prefill(_mock):
+    # TRTLLM prefill has no cross-rank LSE combine for DCP-sharded KV.
+    assert _call(dcp_world_size=2, is_prefill=True) is False
+
+
+@patch("vllm.utils.flashinfer.supports_trtllm_attention", return_value=True)
+def test_use_dcp_fallback_prefill_force_on_still_false(_mock):
+    assert _call(dcp_world_size=2, is_prefill=True, force_use_trtllm=True) is False
+
+
 @patch("vllm.utils.flashinfer.supports_trtllm_attention", return_value=False)
 def test_use_platform_unsupported(_mock):
     assert _call() is False

--- a/tests/v1/attention/test_flashinfer_dcp_spec_reorder.py
+++ b/tests/v1/attention/test_flashinfer_dcp_spec_reorder.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 
 from tests.v1.attention.utils import create_vllm_config
-from vllm.config import SpeculativeConfig
+from vllm.config import SpeculativeConfig, set_current_vllm_config
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends import flashinfer as flashinfer_backend
 from vllm.v1.attention.backends.flashinfer import (
@@ -58,12 +58,13 @@ def test_flashinfer_gqa_dcp_spec_decode_clamps_reorder_threshold(monkeypatch):
         head_size=vllm_config.model_config.get_head_size(),
         dtype=vllm_config.model_config.dtype,
     )
-    builder = FlashInferMetadataBuilder(
-        kv_cache_spec,
-        ["layer.0"],
-        vllm_config,
-        torch.device("cpu"),
-    )
+    with set_current_vllm_config(vllm_config):
+        builder = FlashInferMetadataBuilder(
+            kv_cache_spec,
+            ["layer.0"],
+            vllm_config,
+            torch.device("cpu"),
+        )
 
     # Guard against passing vacuously with the kernel disabled.
     assert (

--- a/tests/v1/attention/test_flashinfer_dcp_spec_reorder.py
+++ b/tests/v1/attention/test_flashinfer_dcp_spec_reorder.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FlashInfer GQA builder: reorder threshold under DCP with spec decode."""
+
+import pytest
+import torch
+
+from tests.v1.attention.utils import create_vllm_config
+from vllm.config import SpeculativeConfig
+from vllm.platforms import current_platform
+from vllm.v1.attention.backends import flashinfer as flashinfer_backend
+from vllm.v1.attention.backends.flashinfer import (
+    FlashInferDecodeKernel,
+    FlashInferMetadataBuilder,
+)
+from vllm.v1.attention.backends.utils import PerLayerParameters
+from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+if not current_platform.is_cuda():
+    pytest.skip("FlashInfer backend requires a CUDA platform.", allow_module_level=True)
+
+
+def test_flashinfer_gqa_dcp_spec_decode_clamps_reorder_threshold(monkeypatch):
+    """trtllm-gen decode receives no cp_rank/global-seq-len information, so its
+    end-aligned causal mask is wrong for q_len > 1 over the DCP-interleaved
+    local KV shard. The builder must keep reorder_batch_threshold at 1 under
+    DCP so spec queries take the (DCP-aware) prefill path instead.
+    """
+    vllm_config = create_vllm_config(max_model_len=1024)
+    vllm_config.parallel_config.decode_context_parallel_size = 2
+    vllm_config.speculative_config = SpeculativeConfig(
+        method="ngram", num_speculative_tokens=3
+    )
+
+    monkeypatch.setattr(
+        flashinfer_backend, "can_use_trtllm_attention", lambda *args, **kwargs: True
+    )
+    monkeypatch.setattr(
+        FlashInferMetadataBuilder,
+        "_get_flashinfer_trtllm_api_decode_kernel",
+        staticmethod(lambda: FlashInferDecodeKernel.TRTLLM_GEN),
+    )
+    monkeypatch.setattr(
+        flashinfer_backend,
+        "get_per_layer_parameters",
+        lambda *args, **kwargs: {
+            "layer.0": PerLayerParameters(
+                window_left=-1, logits_soft_cap=None, sm_scale=0.1, has_sinks=False
+            )
+        },
+    )
+
+    kv_cache_spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=vllm_config.model_config.get_num_kv_heads(
+            vllm_config.parallel_config
+        ),
+        head_size=vllm_config.model_config.get_head_size(),
+        dtype=vllm_config.model_config.dtype,
+    )
+    builder = FlashInferMetadataBuilder(
+        kv_cache_spec,
+        ["layer.0"],
+        vllm_config,
+        torch.device("cpu"),
+    )
+
+    # Guard against passing vacuously with the kernel disabled.
+    assert (
+        builder.flashinfer_trtllm_api_decode_kernel == FlashInferDecodeKernel.TRTLLM_GEN
+    )
+    assert builder.reorder_batch_threshold == 1

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -8,6 +8,9 @@ Known Issues:
   test_backend_correctness[small_prefill], but passes when run alone.
 """
 
+import sys
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -32,6 +35,7 @@ from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.fa_utils import flash_attn_supports_mla
 from vllm.v1.attention.backends.mla import flashmla as flashmla_module
+from vllm.v1.attention.backends.mla import tokenspeed_mla as tokenspeed_mla_module
 from vllm.v1.attention.backends.mla.prefill import (
     MLAPrefillBackendEnum,
     get_mla_prefill_backend,
@@ -691,6 +695,84 @@ def test_mock_mla_dcp_fp8_decode_gathers_quantized_query(
         num_heads * impl.dcp_world_size,
         kv_lora_rank + qk_rope_head_dim,
     )
+
+
+def test_tokenspeed_mla_dcp_single_token_decode_contract(monkeypatch):
+    decode_call = None
+
+    def fake_decode(**kwargs):
+        nonlocal decode_call
+        decode_call = kwargs
+        q = kwargs["query"]
+        out = torch.empty(q.shape[0], q.shape[1], q.shape[2], 3, dtype=torch.bfloat16)
+        lse = torch.empty(q.shape[0], q.shape[1], q.shape[2], dtype=torch.float32)
+        return out, lse
+
+    monkeypatch.setitem(
+        sys.modules,
+        "tokenspeed_mla",
+        SimpleNamespace(tokenspeed_mla_decode=fake_decode),
+    )
+
+    impl = object.__new__(tokenspeed_mla_module.TokenspeedMLAImpl)
+    impl.dcp_world_size = 4
+    impl.dcp_rank = 1
+    impl.cp_kv_cache_interleave_size = 1
+    impl.need_to_return_lse_for_decode = True
+    impl.kv_lora_rank = 3
+    impl.qk_rope_head_dim = 2
+    impl.num_heads = 2
+    impl.scale = 1.0
+    impl.softmax_scale = 1.0
+    impl.output_scale = 1.0
+    impl._workspace_buffer = torch.empty(1, dtype=torch.int8)
+
+    metadata = SimpleNamespace(
+        num_decodes=2,
+        num_decode_tokens=8,
+        max_seq_len=128,
+        decode=SimpleNamespace(
+            block_table=torch.arange(8, dtype=torch.int32).view(2, 4),
+            seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+            dcp_tot_seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+        ),
+    )
+    q = torch.empty(8, 2, 5, dtype=torch.float8_e4m3fn)
+    kv_cache = torch.empty(4, 16, 5, dtype=torch.float8_e4m3fn)
+
+    with pytest.raises(NotImplementedError, match="single-token decode"):
+        impl.forward_mqa(
+            q,
+            kv_cache,
+            metadata,
+            SimpleNamespace(_q_scale_float=2.0, _k_scale_float=3.0),
+        )
+
+    metadata.num_decode_tokens = 2
+    metadata.decode.dcp_tot_seq_lens = torch.tensor([33, 44], dtype=torch.int32)
+    q = torch.empty(2, 2, 5, dtype=torch.float8_e4m3fn)
+
+    out, lse = impl.forward_mqa(
+        q,
+        kv_cache,
+        metadata,
+        SimpleNamespace(_q_scale_float=2.0, _k_scale_float=3.0),
+    )
+
+    assert out.shape == (2, 2, 3)
+    assert lse is not None
+    assert lse.shape == (2, 2)
+
+    assert decode_call is not None
+    assert decode_call["query"].shape == (2, 1, 2, 5)
+    torch.testing.assert_close(decode_call["seq_lens"], metadata.decode.seq_lens)
+    torch.testing.assert_close(decode_call["block_tables"], metadata.decode.block_table)
+    torch.testing.assert_close(
+        decode_call["causal_seqs"], metadata.decode.dcp_tot_seq_lens
+    )
+    assert decode_call["return_lse"] is True
+    assert decode_call["cp_world"] == 4
+    assert decode_call["cp_rank"] == 1
 
 
 @pytest.mark.parametrize("is_fp8_kvcache", [False, True], ids=["bf16", "fp8"])

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -699,12 +699,30 @@ def test_mock_mla_dcp_fp8_decode_gathers_quantized_query(
 
 def test_tokenspeed_mla_dcp_single_token_decode_contract(monkeypatch):
     decode_call = None
+    num_decodes = 2
+    tokens_per_decode = 1
+    num_decode_tokens = num_decodes * tokens_per_decode
+    dcp_world_size = 2
+    dcp_rank = 1
+    num_heads = 128
+    kv_lora_rank = 512
+    qk_rope_head_dim = 64
+    head_size = kv_lora_rank + qk_rope_head_dim
+    block_size = 64
+    num_blocks = 4
+    max_seq_len = 24
 
     def fake_decode(**kwargs):
         nonlocal decode_call
         decode_call = kwargs
         q = kwargs["query"]
-        out = torch.empty(q.shape[0], q.shape[1], q.shape[2], 3, dtype=torch.bfloat16)
+        out = torch.empty(
+            q.shape[0],
+            q.shape[1],
+            q.shape[2],
+            kv_lora_rank,
+            dtype=torch.bfloat16,
+        )
         lse = torch.empty(q.shape[0], q.shape[1], q.shape[2], dtype=torch.float32)
         return out, lse
 
@@ -715,42 +733,35 @@ def test_tokenspeed_mla_dcp_single_token_decode_contract(monkeypatch):
     )
 
     impl = object.__new__(tokenspeed_mla_module.TokenspeedMLAImpl)
-    impl.dcp_world_size = 4
-    impl.dcp_rank = 1
+    impl.dcp_world_size = dcp_world_size
+    impl.dcp_rank = dcp_rank
     impl.cp_kv_cache_interleave_size = 1
     impl.need_to_return_lse_for_decode = True
-    impl.kv_lora_rank = 3
-    impl.qk_rope_head_dim = 2
-    impl.num_heads = 2
+    impl.kv_lora_rank = kv_lora_rank
+    impl.qk_rope_head_dim = qk_rope_head_dim
+    impl.num_heads = num_heads
     impl.scale = 1.0
     impl.softmax_scale = 1.0
     impl.output_scale = 1.0
     impl._workspace_buffer = torch.empty(1, dtype=torch.int8)
 
     metadata = SimpleNamespace(
-        num_decodes=2,
-        num_decode_tokens=8,
-        max_seq_len=128,
+        num_decodes=num_decodes,
+        num_decode_tokens=num_decode_tokens,
+        max_seq_len=max_seq_len,
         decode=SimpleNamespace(
-            block_table=torch.arange(8, dtype=torch.int32).view(2, 4),
-            seq_lens=torch.tensor([10, 20], dtype=torch.int32),
-            dcp_tot_seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+            block_table=torch.empty((num_decodes, 1), dtype=torch.int32),
+            seq_lens=torch.tensor([16, max_seq_len], dtype=torch.int32),
+            dcp_tot_seq_lens=torch.tensor([16, max_seq_len], dtype=torch.int32),
         ),
     )
-    q = torch.empty(8, 2, 5, dtype=torch.float8_e4m3fn)
-    kv_cache = torch.empty(4, 16, 5, dtype=torch.float8_e4m3fn)
-
-    with pytest.raises(NotImplementedError, match="single-token decode"):
-        impl.forward_mqa(
-            q,
-            kv_cache,
-            metadata,
-            SimpleNamespace(_q_scale_float=2.0, _k_scale_float=3.0),
-        )
-
-    metadata.num_decode_tokens = 2
-    metadata.decode.dcp_tot_seq_lens = torch.tensor([33, 44], dtype=torch.int32)
-    q = torch.empty(2, 2, 5, dtype=torch.float8_e4m3fn)
+    q = torch.empty(num_decode_tokens, num_heads, head_size, dtype=torch.float8_e4m3fn)
+    kv_cache = torch.empty(
+        num_blocks,
+        block_size,
+        head_size,
+        dtype=torch.float8_e4m3fn,
+    )
 
     out, lse = impl.forward_mqa(
         q,
@@ -759,20 +770,25 @@ def test_tokenspeed_mla_dcp_single_token_decode_contract(monkeypatch):
         SimpleNamespace(_q_scale_float=2.0, _k_scale_float=3.0),
     )
 
-    assert out.shape == (2, 2, 3)
+    assert out.shape == (num_decode_tokens, num_heads, kv_lora_rank)
     assert lse is not None
-    assert lse.shape == (2, 2)
+    assert lse.shape == (num_decode_tokens, num_heads)
 
     assert decode_call is not None
-    assert decode_call["query"].shape == (2, 1, 2, 5)
+    assert decode_call["query"].shape == (
+        num_decodes,
+        tokens_per_decode,
+        num_heads,
+        head_size,
+    )
     torch.testing.assert_close(decode_call["seq_lens"], metadata.decode.seq_lens)
     torch.testing.assert_close(decode_call["block_tables"], metadata.decode.block_table)
     torch.testing.assert_close(
         decode_call["causal_seqs"], metadata.decode.dcp_tot_seq_lens
     )
     assert decode_call["return_lse"] is True
-    assert decode_call["cp_world"] == 4
-    assert decode_call["cp_rank"] == 1
+    assert decode_call["cp_world"] == dcp_world_size
+    assert decode_call["cp_rank"] == dcp_rank
 
 
 @pytest.mark.parametrize("is_fp8_kvcache", [False, True], ids=["bf16", "fp8"])

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -882,6 +882,59 @@ def test_flashmla_dcp_decode_metadata_uses_gathered_query_heads(
         assert fp8_call is None
 
 
+def test_flashinfer_mla_dcp_spec_decode_keeps_reorder_threshold():
+    builder_cls, _ = try_get_attention_backend(AttentionBackendEnum.FLASHINFER_MLA)
+
+    from vllm.config import SpeculativeConfig
+
+    class _DummyPrefillBackend:
+        def clone(self):
+            return self
+
+    vllm_config = create_vllm_config(
+        model_name="deepseek-ai/DeepSeek-R1",
+        tensor_parallel_size=1,
+        max_model_len=1024,
+        max_num_batched_tokens=512,
+        hf_config_override={
+            "num_attention_heads": 128,
+            "num_key_value_heads": 128,
+            "hidden_size": 7168,
+            "qk_nope_head_dim": 128,
+            "qk_rope_head_dim": 64,
+            "v_head_dim": 128,
+            "kv_lora_rank": 512,
+        },
+    )
+    vllm_config.parallel_config.decode_context_parallel_size = 4
+    vllm_config.speculative_config = SpeculativeConfig(
+        method="ngram", num_speculative_tokens=3
+    )
+    vllm_config.compilation_config.static_forward_context["layer.0"] = SimpleNamespace(
+        prefill_backend=_DummyPrefillBackend()
+    )
+
+    kv_cache_spec = MLAAttentionSpec(
+        block_size=32,
+        num_kv_heads=vllm_config.model_config.get_num_kv_heads(
+            vllm_config.parallel_config
+        ),
+        head_size=vllm_config.model_config.get_head_size(),
+        dtype=vllm_config.model_config.dtype,
+        sliding_window=vllm_config.model_config.get_sliding_window(),
+        cache_dtype_str="fp8",
+    )
+
+    builder = builder_cls(
+        kv_cache_spec,
+        ["layer.0"],
+        vllm_config,
+        torch.device("cpu"),
+    )
+
+    assert builder.reorder_batch_threshold == 4
+
+
 def run_attention_backend(
     backend: AttentionBackendEnum,
     kv_cache_spec: MLAAttentionSpec,

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -882,59 +882,6 @@ def test_flashmla_dcp_decode_metadata_uses_gathered_query_heads(
         assert fp8_call is None
 
 
-def test_flashinfer_mla_dcp_spec_decode_keeps_reorder_threshold():
-    builder_cls, _ = try_get_attention_backend(AttentionBackendEnum.FLASHINFER_MLA)
-
-    from vllm.config import SpeculativeConfig
-
-    class _DummyPrefillBackend:
-        def clone(self):
-            return self
-
-    vllm_config = create_vllm_config(
-        model_name="deepseek-ai/DeepSeek-R1",
-        tensor_parallel_size=1,
-        max_model_len=1024,
-        max_num_batched_tokens=512,
-        hf_config_override={
-            "num_attention_heads": 128,
-            "num_key_value_heads": 128,
-            "hidden_size": 7168,
-            "qk_nope_head_dim": 128,
-            "qk_rope_head_dim": 64,
-            "v_head_dim": 128,
-            "kv_lora_rank": 512,
-        },
-    )
-    vllm_config.parallel_config.decode_context_parallel_size = 4
-    vllm_config.speculative_config = SpeculativeConfig(
-        method="ngram", num_speculative_tokens=3
-    )
-    vllm_config.compilation_config.static_forward_context["layer.0"] = SimpleNamespace(
-        prefill_backend=_DummyPrefillBackend()
-    )
-
-    kv_cache_spec = MLAAttentionSpec(
-        block_size=32,
-        num_kv_heads=vllm_config.model_config.get_num_kv_heads(
-            vllm_config.parallel_config
-        ),
-        head_size=vllm_config.model_config.get_head_size(),
-        dtype=vllm_config.model_config.dtype,
-        sliding_window=vllm_config.model_config.get_sliding_window(),
-        cache_dtype_str="fp8",
-    )
-
-    builder = builder_cls(
-        kv_cache_spec,
-        ["layer.0"],
-        vllm_config,
-        torch.device("cpu"),
-    )
-
-    assert builder.reorder_batch_threshold == 4
-
-
 def run_attention_backend(
     backend: AttentionBackendEnum,
     kv_cache_spec: MLAAttentionSpec,

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -439,6 +439,16 @@ def use_trtllm_attention(
     if force_use_trtllm is not None and not force_use_trtllm:
         return False
 
+    # TRTLLM prefill attends only the DCP-local KV shard and has no
+    # cross-rank LSE combine, so it cannot be used with DCP; fall back to
+    # FlashInfer's DCP prefill path. TRTLLM decode under DCP is selected
+    # separately (all-gathered query heads + LSE combine in forward).
+    if dcp_world_size > 1:
+        logger.warning_once(
+            "TRTLLM prefill does not support DCP, reverting to FlashInfer"
+        )
+        return False
+
     # The platform is not supported
     if not supports_trtllm_attention(is_prefill=is_prefill):
         if force_use_trtllm:

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -439,14 +439,6 @@ def use_trtllm_attention(
     if force_use_trtllm is not None and not force_use_trtllm:
         return False
 
-    # Decode context parallel is not supported
-    if dcp_world_size > 1:
-        logger.warning_once(
-            "Trtllm does not support returning LSE and as a result "
-            "does not support DCP, reverting to FlashInfer"
-        )
-        return False
-
     # The platform is not supported
     if not supports_trtllm_attention(is_prefill=is_prefill):
         if force_use_trtllm:

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1122,23 +1122,6 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             has_sinks=self.has_sinks,
             has_spec=uses_spec_reorder,
         )
-        if (
-            causal
-            and self.use_dcp
-            and not prefill_use_trtllm
-            and self.flashinfer_trtllm_api_decode_kernel
-            == FlashInferDecodeKernel.TRTLLM_GEN
-            and can_use_trtllm_attention(
-                self.num_qo_heads,
-                self.num_kv_heads,
-                is_prefill=True,
-            )
-        ):
-            logger.info_once(
-                "Using TRTLLM prefill attention with DCP because trtllm-gen "
-                "attention is available."
-            )
-            prefill_use_trtllm = True
         decode_with_flashinfer_trtllm_api = causal and self.use_trtllm_decode_attention
 
         if not causal and self.use_dcp:
@@ -1322,6 +1305,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             assert qo_indptr_prefill_cpu.shape[0] == num_prefills + 1
 
             if prefill_use_trtllm:
+                # TRTLLM prefill has no cross-rank combine for DCP-sharded KV;
+                # use_trtllm_attention never selects it when DCP is enabled.
+                assert not self.use_dcp
                 # Create GPU versions
                 qo_indptr_prefill_gpu = (
                     qo_indptr[prefill_start:] - qo_indptr[prefill_start]
@@ -1330,13 +1316,6 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 # This is the cumulative sum of the number of KV cache
                 # blocks per prefill request.
                 prefill_seq_lens = seq_lens[prefill_start:]
-                if self.use_dcp:
-                    prefill_seq_lens = get_dcp_local_seq_lens(
-                        prefill_seq_lens,
-                        self.dcp_world_size,
-                        self.dcp_rank,
-                        self.dcp_kv_cache_interleave_size,
-                    )
                 num_blocks_per_req = (prefill_seq_lens + page_size - 1) // page_size
                 paged_kv_indptr_prefill_gpu = self.paged_kv_indptr.gpu[
                     prefill_start : num_reqs + 1

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -734,12 +734,25 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             if can_use_xqa_or_trtllm_gen_decode
             else None
         )
+        if (
+            self.use_dcp
+            and self.flashinfer_trtllm_api_decode_kernel == FlashInferDecodeKernel.XQA
+        ):
+            logger.warning_once(
+                "FlashInfer XQA decode does not support returning LSE and "
+                "therefore does not support DCP, reverting to native FlashInfer "
+                "decode."
+            )
+            self.use_trtllm_decode_attention = False
+            self.flashinfer_trtllm_api_decode_kernel = None
         supports_spec_as_decode = (
             self.flashinfer_trtllm_api_decode_kernel
             == FlashInferDecodeKernel.TRTLLM_GEN
         )
         self._init_reorder_batch_threshold(
-            1, supports_spec_as_decode=supports_spec_as_decode
+            1,
+            supports_spec_as_decode=supports_spec_as_decode,
+            supports_dcp_with_varlen=supports_spec_as_decode,
         )
 
         self._cascade_wrapper = None  # Wrapper for cascade attention
@@ -1109,8 +1122,25 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             has_sinks=self.has_sinks,
             has_spec=uses_spec_reorder,
         )
+        if (
+            causal
+            and self.use_dcp
+            and not prefill_use_trtllm
+            and self.flashinfer_trtllm_api_decode_kernel
+            == FlashInferDecodeKernel.TRTLLM_GEN
+            and can_use_trtllm_attention(
+                self.num_qo_heads,
+                self.num_kv_heads,
+                is_prefill=True,
+            )
+        ):
+            logger.info_once(
+                "Using TRTLLM prefill attention with DCP because trtllm-gen "
+                "attention is available."
+            )
+            prefill_use_trtllm = True
         decode_with_flashinfer_trtllm_api = (
-            causal and self.use_trtllm_decode_attention and self.dcp_world_size <= 1
+            causal and self.use_trtllm_decode_attention
         )
 
         if not causal and self.use_dcp:
@@ -1212,7 +1242,16 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # Compute paged_kv_indices if necessary
         # paged_kv_indices is only needed for FlashInfer native paths;
         # XQA/trtllm-gen paths use block_tables directly on GPU.
-        needs_paged_kv_indices = use_cascade or not all_uses_trtllm
+        needs_native_paged_prefill = (
+            num_prefills > 0
+            and not prefill_use_trtllm
+        )
+        needs_native_paged_decode = (
+            num_decodes > 0 and not decode_with_flashinfer_trtllm_api
+        )
+        needs_paged_kv_indices = (
+            use_cascade or needs_native_paged_prefill or needs_native_paged_decode
+        )
         if needs_paged_kv_indices:
             assert num_blocks_np is not None
             assert seq_lens_np is not None
@@ -1296,6 +1335,13 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 # This is the cumulative sum of the number of KV cache
                 # blocks per prefill request.
                 prefill_seq_lens = seq_lens[prefill_start:]
+                if self.use_dcp:
+                    prefill_seq_lens = get_dcp_local_seq_lens(
+                        prefill_seq_lens,
+                        self.dcp_world_size,
+                        self.dcp_rank,
+                        self.dcp_kv_cache_interleave_size,
+                    )
                 num_blocks_per_req = (prefill_seq_lens + page_size - 1) // page_size
                 paged_kv_indptr_prefill_gpu = self.paged_kv_indptr.gpu[
                     prefill_start : num_reqs + 1
@@ -1314,7 +1360,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 max_q_len_prefill = int(query_lens_prefill_cpu.max().item())
                 attn_metadata.prefill = TRTLLMPrefill(
                     block_tables=block_table_tensor[prefill_start:],
-                    seq_lens=seq_lens[prefill_start:],
+                    seq_lens=prefill_seq_lens,
                     cum_seq_lens_q=qo_indptr_prefill_gpu,
                     cum_seq_lens_kv=paged_kv_indptr_prefill_gpu,
                     max_q_len=max_q_len_prefill,
@@ -1391,10 +1437,16 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     f"Got {num_decode_tokens=} and {num_decodes=}."
                 )
                 assert self.flashinfer_trtllm_api_decode_kernel is not None
+                seq_lens_decode = seq_lens[:num_decodes]
+                if self.use_dcp:
+                    assert common_attn_metadata.dcp_local_seq_lens is not None
+                    seq_lens_decode = common_attn_metadata.dcp_local_seq_lens[
+                        :num_decodes
+                    ]
                 attn_metadata.decode = FlashInferTrtllmAPIDecode(
                     kernel=self.flashinfer_trtllm_api_decode_kernel,
                     block_tables=block_table_tensor[:num_decodes],
-                    seq_lens=seq_lens[:num_decodes],
+                    seq_lens=seq_lens_decode,
                     max_seq_len=max_seq_len,
                 )
             else:
@@ -2038,6 +2090,18 @@ class FlashInferImpl(AttentionImpl):
                     f"contiguous, got strides {kv_strides}"
                 )
 
+                if use_dcp:
+                    assert decode_with_trtllm_gen
+                    if output.dtype == FP4_DTYPE:
+                        raise NotImplementedError(
+                            "DCP decode with FlashInfer trtllm-gen does not support "
+                            "FP4 attention output yet."
+                        )
+                    decode_query = get_dcp_group().all_gather(
+                        decode_query.contiguous(), dim=-2
+                    )
+                    decode_query = canonicalize_singleton_dim_strides(decode_query)
+
                 if output.dtype == FP4_DTYPE:
                     assert self.o_sf_scale is not None
                     out = FP4Tensor(
@@ -2076,6 +2140,19 @@ class FlashInferImpl(AttentionImpl):
                     else self.bmm1_scale
                 )
 
+                lse = None
+                if use_dcp:
+                    out = torch.empty(
+                        decode_query.shape,
+                        dtype=output.dtype,
+                        device=decode_query.device,
+                    )
+                    lse = torch.empty(
+                        (decode_query.size(0), decode_query.size(1)),
+                        dtype=torch.float32,
+                        device=decode_query.device,
+                    )
+
                 trtllm_batch_decode_with_kv_cache(
                     query=decode_query,
                     kv_cache=(
@@ -2097,9 +2174,19 @@ class FlashInferImpl(AttentionImpl):
                     kv_cache_sf=(
                         nvfp4_kv_block_scales if self.is_kvcache_nvfp4 else None
                     ),
+                    lse=lse,
+                    return_lse=self.need_to_return_lse_for_decode,
                 )
 
-                if needs_fp8_out:
+                if use_dcp:
+                    assert isinstance(out, torch.Tensor)
+                    assert lse is not None
+                    output[:num_decode_tokens] = self.dcp_combine(
+                        out,
+                        lse,
+                        get_dcp_group(),
+                    )
+                elif needs_fp8_out:
                     output[:num_decode_tokens].copy_(out.to(output.dtype))
         return output_padded
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1139,9 +1139,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 "attention is available."
             )
             prefill_use_trtllm = True
-        decode_with_flashinfer_trtllm_api = (
-            causal and self.use_trtllm_decode_attention
-        )
+        decode_with_flashinfer_trtllm_api = causal and self.use_trtllm_decode_attention
 
         if not causal and self.use_dcp:
             raise NotImplementedError(
@@ -1242,10 +1240,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # Compute paged_kv_indices if necessary
         # paged_kv_indices is only needed for FlashInfer native paths;
         # XQA/trtllm-gen paths use block_tables directly on GPU.
-        needs_native_paged_prefill = (
-            num_prefills > 0
-            and not prefill_use_trtllm
-        )
+        needs_native_paged_prefill = num_prefills > 0 and not prefill_use_trtllm
         needs_native_paged_decode = (
             num_decodes > 0 and not decode_with_flashinfer_trtllm_api
         )

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -752,7 +752,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self._init_reorder_batch_threshold(
             1,
             supports_spec_as_decode=supports_spec_as_decode,
-            supports_dcp_with_varlen=supports_spec_as_decode,
+            # trtllm-gen decode receives no cp_rank/global-seq-len information,
+            # so its end-aligned causal mask is wrong for q_len > 1 over the
+            # DCP-interleaved local KV shard (spec token i misses up to
+            # (dcp_world_size - 1) * (q_len - 1 - i) KV entries, including its
+            # own). Keep the threshold at 1 under DCP so spec queries take the
+            # DCP-aware prefill path, until the kernel is CP-aware (compare
+            # flash_attn_varlen_func's cp_world_size/cp_rank/cp_tot_seqused_k).
+            supports_dcp_with_varlen=False,
         )
 
         self._cascade_wrapper = None  # Wrapper for cascade attention

--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import torch
 from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla
@@ -24,6 +24,10 @@ from vllm.v1.attention.backend import (
     MultipleOf,
 )
 from vllm.v1.attention.backends.utils import KVCacheLayoutType
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.v1.kv_cache_interface import AttentionSpec
 
 logger = init_logger(__name__)
 
@@ -51,6 +55,22 @@ def _get_workspace_buffer(return_lse: bool) -> torch.Tensor:
 class FlashInferMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.UNIFORM
+
+    def __init__(
+        self,
+        kv_cache_spec: "AttentionSpec",
+        layer_names: list[str],
+        vllm_config: "VllmConfig",
+        device: torch.device,
+    ) -> None:
+        super().__init__(
+            kv_cache_spec,
+            layer_names,
+            vllm_config,
+            device,
+            MLACommonMetadata,
+            supports_dcp_with_varlen=True,
+        )
 
 
 class FlashInferMLABackend(MLACommonBackend):

--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import ClassVar
 
 import torch
 from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla
@@ -24,10 +24,6 @@ from vllm.v1.attention.backend import (
     MultipleOf,
 )
 from vllm.v1.attention.backends.utils import KVCacheLayoutType
-
-if TYPE_CHECKING:
-    from vllm.config import VllmConfig
-    from vllm.v1.kv_cache_interface import AttentionSpec
 
 logger = init_logger(__name__)
 
@@ -55,22 +51,6 @@ def _get_workspace_buffer(return_lse: bool) -> torch.Tensor:
 class FlashInferMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.UNIFORM
-
-    def __init__(
-        self,
-        kv_cache_spec: "AttentionSpec",
-        layer_names: list[str],
-        vllm_config: "VllmConfig",
-        device: torch.device,
-    ) -> None:
-        super().__init__(
-            kv_cache_spec,
-            layer_names,
-            vllm_config,
-            device,
-            MLACommonMetadata,
-            supports_dcp_with_varlen=True,
-        )
 
 
 class FlashInferMLABackend(MLACommonBackend):

--- a/vllm/v1/attention/backends/mla/tokenspeed_mla.py
+++ b/vllm/v1/attention/backends/mla/tokenspeed_mla.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """TokenSpeed CuTe DSL MLA decode backend (Blackwell, FP8 KV cache only)."""
 
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import torch
 
@@ -23,7 +23,14 @@ from vllm.v1.attention.backend import (
     AttentionType,
     MultipleOf,
 )
-from vllm.v1.attention.backends.utils import KVCacheLayoutType
+from vllm.v1.attention.backends.utils import (
+    KVCacheLayoutType,
+    get_dcp_local_seq_lens,
+)
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.v1.kv_cache_interface import AttentionSpec
 
 logger = init_logger(__name__)
 
@@ -54,6 +61,22 @@ def _get_workspace(
 class TokenspeedMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.UNIFORM
+
+    def __init__(
+        self,
+        kv_cache_spec: "AttentionSpec",
+        layer_names: list[str],
+        vllm_config: "VllmConfig",
+        device: torch.device,
+    ) -> None:
+        super().__init__(
+            kv_cache_spec,
+            layer_names,
+            vllm_config,
+            device,
+            MLACommonMetadata,
+            supports_dcp_with_varlen=True,
+        )
 
 
 class TokenspeedMLABackend(MLACommonBackend):
@@ -240,7 +263,9 @@ class TokenspeedMLAImpl(MLACommonImpl[MLACommonMetadata]):
         causal_seqs = attn_metadata.decode.dcp_tot_seq_lens
 
         # tokenspeed_mla_decode expects query shape
-        # (num_decodes, q_len_per_request, num_heads, head_dim).
+        # (num_decodes, q_len_per_request, num_heads, head_dim). Under DCP,
+        # multi-token speculative decode must be split into one-token rows:
+        # local(G-k) is not local(G)-k in interleaved DCP layout.
         if num_decode_tokens % num_decodes != 0:
             logger.warning_once(
                 """TokenspeedMLAImpl got a query of uneven length.
@@ -248,13 +273,34 @@ class TokenspeedMLAImpl(MLACommonImpl[MLACommonMetadata]):
                 or incorrect setup in dummy_run."""
             )
             q = q.unsqueeze(1)
-        elif self.dcp_world_size > 1 and num_decode_tokens != num_decodes:
-            raise NotImplementedError(
-                "TokenSpeed MLA DCP doesn't support when "
-                "num_decode_tokens != num_decodes."
-            )
         else:
-            q = q.view(num_decodes, -1, q.shape[-2], q.shape[-1])
+            tokens_per_req = num_decode_tokens // num_decodes
+            if self.dcp_world_size > 1 and tokens_per_req > 1:
+                assert causal_seqs is not None
+                offsets = torch.arange(
+                    1 - tokens_per_req,
+                    1,
+                    device=causal_seqs.device,
+                    dtype=causal_seqs.dtype,
+                )
+                causal_seqs = (
+                    causal_seqs[:num_decodes].unsqueeze(1) + offsets
+                ).flatten()
+                seq_lens = get_dcp_local_seq_lens(
+                    causal_seqs,
+                    self.dcp_world_size,
+                    self.dcp_rank,
+                    self.cp_kv_cache_interleave_size,
+                )
+                block_tables = (
+                    block_tables[:num_decodes]
+                    .unsqueeze(1)
+                    .expand(-1, tokens_per_req, -1)
+                    .reshape(num_decode_tokens, -1)
+                )
+                q = q.view(num_decode_tokens, 1, q.shape[-2], q.shape[-1])
+            else:
+                q = q.view(num_decodes, -1, q.shape[-2], q.shape[-1])
 
         if self.softmax_scale is None:
             # FP8 KV cache is mandatory for this backend, so q_scale/k_scale

--- a/vllm/v1/attention/backends/mla/tokenspeed_mla.py
+++ b/vllm/v1/attention/backends/mla/tokenspeed_mla.py
@@ -2,10 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """TokenSpeed CuTe DSL MLA decode backend (Blackwell, FP8 KV cache only)."""
 
+import inspect
 from typing import ClassVar
 
 import torch
 
+from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import (
@@ -24,6 +26,7 @@ from vllm.v1.attention.backend import (
     MultipleOf,
 )
 from vllm.v1.attention.backends.utils import KVCacheLayoutType
+from vllm.v1.kv_cache_interface import AttentionSpec
 
 logger = init_logger(__name__)
 
@@ -35,6 +38,8 @@ logger = init_logger(__name__)
 _TOKENSPEED_MAX_Q_LEN = 8
 
 _g_workspace: dict[torch.device, torch.Tensor] = {}
+
+_DCP_DECODE_KWARGS = frozenset({"return_lse", "causal_seqs", "cp_world", "cp_rank"})
 
 
 def _get_workspace(
@@ -51,9 +56,38 @@ def _get_workspace(
     return _g_workspace[device]
 
 
+def _missing_dcp_decode_kwargs() -> set[str]:
+    try:
+        from tokenspeed_mla import tokenspeed_mla_decode
+    except ImportError:
+        return set(_DCP_DECODE_KWARGS)
+
+    try:
+        params = inspect.signature(tokenspeed_mla_decode).parameters
+    except (TypeError, ValueError):
+        return set(_DCP_DECODE_KWARGS)
+    return set(_DCP_DECODE_KWARGS.difference(params))
+
+
 class TokenspeedMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.UNIFORM
+
+    def __init__(
+        self,
+        kv_cache_spec: "AttentionSpec",
+        layer_names: list[str],
+        vllm_config: "VllmConfig",
+        device: torch.device,
+    ) -> None:
+        super().__init__(
+            kv_cache_spec,
+            layer_names,
+            vllm_config,
+            device,
+            MLACommonMetadata,
+            supports_dcp_with_varlen=True,
+        )
 
 
 class TokenspeedMLABackend(MLACommonBackend):
@@ -111,6 +145,15 @@ class TokenspeedMLABackend(MLACommonBackend):
         from vllm.config import get_current_vllm_config
 
         vllm_config = get_current_vllm_config()
+        if vllm_config.parallel_config.decode_context_parallel_size > 1:
+            missing = _missing_dcp_decode_kwargs()
+            if missing:
+                missing_args = ", ".join(sorted(missing))
+                return (
+                    "tokenspeed_mla_decode does not support DCP decode. "
+                    "Install tokenspeed-mla>=0.1.8; missing arguments: "
+                    f"{missing_args}"
+                )
         if vllm_config.model_config is not None:
             hf_text_config = vllm_config.model_config.hf_text_config
             qk_nope_head_dim = getattr(hf_text_config, "qk_nope_head_dim", 0)
@@ -130,6 +173,11 @@ class TokenspeedMLABackend(MLACommonBackend):
 
 
 class TokenspeedMLAImpl(MLACommonImpl[MLACommonMetadata]):
+    can_return_lse_for_decode: bool = True
+    # tokenspeed_mla_decode returns LSE in log2 units; its own DCP test merges
+    # partial outputs with exp2(lse).
+    lse_base_on_e: bool = False
+
     def __init__(
         self,
         num_heads: int,
@@ -228,17 +276,31 @@ class TokenspeedMLAImpl(MLACommonImpl[MLACommonMetadata]):
             f"q_scale={layer._q_scale_float}, k_scale={layer._k_scale_float}."
         )
 
+        num_decodes = attn_metadata.num_decodes
+        num_decode_tokens = attn_metadata.num_decode_tokens
+        uniform = num_decode_tokens % num_decodes == 0
+        tokens_per_req = num_decode_tokens // num_decodes if uniform else 1
+        block_tables = attn_metadata.decode.block_table
+        seq_lens = attn_metadata.decode.seq_lens
+        causal_seqs = attn_metadata.decode.dcp_tot_seq_lens
+
         # tokenspeed_mla_decode expects query shape
         # (num_decodes, q_len_per_request, num_heads, head_dim).
-        if attn_metadata.num_decode_tokens % attn_metadata.num_decodes != 0:
+        if not uniform:
             logger.warning_once(
                 """TokenspeedMLAImpl got a query of uneven length.
                 This usually indicates an issue in batch reordering
                 or incorrect setup in dummy_run."""
             )
             q = q.unsqueeze(1)
+        elif self.dcp_world_size > 1 and tokens_per_req > 1:
+            raise NotImplementedError(
+                "TokenSpeed MLA DCP only supports single-token decode in this PR. "
+                "Multi-token DCP decode for EAGLE/MTP requires follow-up "
+                "dcp_split_q support."
+            )
         else:
-            q = q.view(attn_metadata.num_decodes, -1, q.shape[-2], q.shape[-1])
+            q = q.view(num_decodes, -1, q.shape[-2], q.shape[-1])
 
         if self.softmax_scale is None:
             # FP8 KV cache is mandatory for this backend, so q_scale/k_scale
@@ -257,22 +319,29 @@ class TokenspeedMLAImpl(MLACommonImpl[MLACommonMetadata]):
 
         # vLLM kv_c_and_k_pe_cache is already (num_blocks, block_size, head_size).
         # tokenspeed_mla_decode wants 3D — pass as-is (no unsqueeze, unlike trtllm).
-        o = tokenspeed_mla_decode(
+        return_lse = self.need_to_return_lse_for_decode
+        kernel_out = tokenspeed_mla_decode(
             query=q,
             kv_cache=kv_c_and_k_pe_cache,
             workspace_buffer=self._workspace_buffer,
             kv_lora_rank=self.kv_lora_rank,
             qk_rope_head_dim=self.qk_rope_head_dim,
-            block_tables=attn_metadata.decode.block_table,
-            seq_lens=attn_metadata.decode.seq_lens,
+            block_tables=block_tables,
+            seq_lens=seq_lens,
             max_seq_len=attn_metadata.max_seq_len,
             softmax_scale=self.softmax_scale,
             output_scale=self.output_scale,
             enable_pdl=False,
+            return_lse=return_lse,
+            causal_seqs=causal_seqs if self.dcp_world_size > 1 else None,
+            cp_world=self.dcp_world_size,
+            cp_rank=self.dcp_rank,
         )
+        if return_lse:
+            o, lse = kernel_out
+            lse = lse.view(-1, lse.shape[-1])
+        else:
+            o, lse = kernel_out, None
 
-        # Flatten the output for consistent shape
         o = o.view(-1, o.shape[-2], o.shape[-1])
-
-        # tokenspeed_mla_decode does not return LSE.
-        return o, None
+        return o, lse

--- a/vllm/v1/attention/backends/mla/tokenspeed_mla.py
+++ b/vllm/v1/attention/backends/mla/tokenspeed_mla.py
@@ -23,10 +23,7 @@ from vllm.v1.attention.backend import (
     AttentionType,
     MultipleOf,
 )
-from vllm.v1.attention.backends.utils import (
-    KVCacheLayoutType,
-    get_dcp_local_seq_lens,
-)
+from vllm.v1.attention.backends.utils import KVCacheLayoutType
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -263,9 +260,7 @@ class TokenspeedMLAImpl(MLACommonImpl[MLACommonMetadata]):
         causal_seqs = attn_metadata.decode.dcp_tot_seq_lens
 
         # tokenspeed_mla_decode expects query shape
-        # (num_decodes, q_len_per_request, num_heads, head_dim). Under DCP,
-        # multi-token speculative decode must be split into one-token rows:
-        # local(G-k) is not local(G)-k in interleaved DCP layout.
+        # (num_decodes, q_len_per_request, num_heads, head_dim).
         if num_decode_tokens % num_decodes != 0:
             logger.warning_once(
                 """TokenspeedMLAImpl got a query of uneven length.
@@ -274,33 +269,7 @@ class TokenspeedMLAImpl(MLACommonImpl[MLACommonMetadata]):
             )
             q = q.unsqueeze(1)
         else:
-            tokens_per_req = num_decode_tokens // num_decodes
-            if self.dcp_world_size > 1 and tokens_per_req > 1:
-                assert causal_seqs is not None
-                offsets = torch.arange(
-                    1 - tokens_per_req,
-                    1,
-                    device=causal_seqs.device,
-                    dtype=causal_seqs.dtype,
-                )
-                causal_seqs = (
-                    causal_seqs[:num_decodes].unsqueeze(1) + offsets
-                ).flatten()
-                seq_lens = get_dcp_local_seq_lens(
-                    causal_seqs,
-                    self.dcp_world_size,
-                    self.dcp_rank,
-                    self.cp_kv_cache_interleave_size,
-                )
-                block_tables = (
-                    block_tables[:num_decodes]
-                    .unsqueeze(1)
-                    .expand(-1, tokens_per_req, -1)
-                    .reshape(num_decode_tokens, -1)
-                )
-                q = q.view(num_decode_tokens, 1, q.shape[-2], q.shape[-1])
-            else:
-                q = q.view(num_decodes, -1, q.shape[-2], q.shape[-1])
+            q = q.view(num_decodes, -1, q.shape[-2], q.shape[-1])
 
         if self.softmax_scale is None:
             # FP8 KV cache is mandatory for this backend, so q_scale/k_scale

--- a/vllm/v1/attention/backends/mla/tokenspeed_mla.py
+++ b/vllm/v1/attention/backends/mla/tokenspeed_mla.py
@@ -2,12 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """TokenSpeed CuTe DSL MLA decode backend (Blackwell, FP8 KV cache only)."""
 
-import inspect
 from typing import ClassVar
 
 import torch
 
-from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import (
@@ -26,7 +24,6 @@ from vllm.v1.attention.backend import (
     MultipleOf,
 )
 from vllm.v1.attention.backends.utils import KVCacheLayoutType
-from vllm.v1.kv_cache_interface import AttentionSpec
 
 logger = init_logger(__name__)
 
@@ -38,8 +35,6 @@ logger = init_logger(__name__)
 _TOKENSPEED_MAX_Q_LEN = 8
 
 _g_workspace: dict[torch.device, torch.Tensor] = {}
-
-_DCP_DECODE_KWARGS = frozenset({"return_lse", "causal_seqs", "cp_world", "cp_rank"})
 
 
 def _get_workspace(
@@ -56,38 +51,9 @@ def _get_workspace(
     return _g_workspace[device]
 
 
-def _missing_dcp_decode_kwargs() -> set[str]:
-    try:
-        from tokenspeed_mla import tokenspeed_mla_decode
-    except ImportError:
-        return set(_DCP_DECODE_KWARGS)
-
-    try:
-        params = inspect.signature(tokenspeed_mla_decode).parameters
-    except (TypeError, ValueError):
-        return set(_DCP_DECODE_KWARGS)
-    return set(_DCP_DECODE_KWARGS.difference(params))
-
-
 class TokenspeedMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.UNIFORM
-
-    def __init__(
-        self,
-        kv_cache_spec: "AttentionSpec",
-        layer_names: list[str],
-        vllm_config: "VllmConfig",
-        device: torch.device,
-    ) -> None:
-        super().__init__(
-            kv_cache_spec,
-            layer_names,
-            vllm_config,
-            device,
-            MLACommonMetadata,
-            supports_dcp_with_varlen=True,
-        )
 
 
 class TokenspeedMLABackend(MLACommonBackend):
@@ -145,15 +111,6 @@ class TokenspeedMLABackend(MLACommonBackend):
         from vllm.config import get_current_vllm_config
 
         vllm_config = get_current_vllm_config()
-        if vllm_config.parallel_config.decode_context_parallel_size > 1:
-            missing = _missing_dcp_decode_kwargs()
-            if missing:
-                missing_args = ", ".join(sorted(missing))
-                return (
-                    "tokenspeed_mla_decode does not support DCP decode. "
-                    "Install tokenspeed-mla>=0.1.8; missing arguments: "
-                    f"{missing_args}"
-                )
         if vllm_config.model_config is not None:
             hf_text_config = vllm_config.model_config.hf_text_config
             qk_nope_head_dim = getattr(hf_text_config, "qk_nope_head_dim", 0)
@@ -278,26 +235,23 @@ class TokenspeedMLAImpl(MLACommonImpl[MLACommonMetadata]):
 
         num_decodes = attn_metadata.num_decodes
         num_decode_tokens = attn_metadata.num_decode_tokens
-        uniform = num_decode_tokens % num_decodes == 0
-        tokens_per_req = num_decode_tokens // num_decodes if uniform else 1
         block_tables = attn_metadata.decode.block_table
         seq_lens = attn_metadata.decode.seq_lens
         causal_seqs = attn_metadata.decode.dcp_tot_seq_lens
 
         # tokenspeed_mla_decode expects query shape
         # (num_decodes, q_len_per_request, num_heads, head_dim).
-        if not uniform:
+        if num_decode_tokens % num_decodes != 0:
             logger.warning_once(
                 """TokenspeedMLAImpl got a query of uneven length.
                 This usually indicates an issue in batch reordering
                 or incorrect setup in dummy_run."""
             )
             q = q.unsqueeze(1)
-        elif self.dcp_world_size > 1 and tokens_per_req > 1:
+        elif self.dcp_world_size > 1 and num_decode_tokens != num_decodes:
             raise NotImplementedError(
-                "TokenSpeed MLA DCP only supports single-token decode in this PR. "
-                "Multi-token DCP decode for EAGLE/MTP requires follow-up "
-                "dcp_split_q support."
+                "TokenSpeed MLA DCP doesn't support when "
+                "num_decode_tokens != num_decodes."
             )
         else:
             q = q.view(num_decodes, -1, q.shape[-2], q.shape[-1])


### PR DESCRIPTION
## Purpose
Adds support to run DCP + Tokenspeed_MLA with Eagle.

Builds off of https://github.com/vllm-project/vllm/pull/47915/changes 
## Test Plan
Validated with unit test and Kimi models and the lightseekai-org's two eagle heads.

## Test Result
GSM8k is validated. 

Perf (Green- this PR, Blue- No DCP) -- validated with Agentic Benchmark:
<img width="1133" height="602" alt="image" src="https://github.com/user-attachments/assets/86159b81-d3b2-464e-9224-0b0925bd5974" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
