### PR TITLE
[CI] Right-size Attention test timeouts from nightly durations

### DIFF
--- a/.buildkite/test_areas/attention.yaml
+++ b/.buildkite/test_areas/attention.yaml
@@ -4,7 +4,7 @@ depends_on:
 steps:
 - label: V1 attention (H100-MI300)
   key: v1-attention-h100-mi300
-  timeout_in_minutes: 30
+  timeout_in_minutes: 85
   device: h100
   source_file_dependencies:
     - vllm/config/attention.py
@@ -16,7 +16,7 @@ steps:
   mirror:
     amd:
       device: mi325_1
-      timeout_in_minutes: 70
+      timeout_in_minutes: 75
       depends_on:
       - image-build-amd
       source_file_dependencies:
@@ -30,7 +30,7 @@ steps:
 
 - label: V1 attention (B200)
   key: v1-attention-b200
-  timeout_in_minutes: 30
+  timeout_in_minutes: 80
   device: b200-k8s
   source_file_dependencies:
     - vllm/config/attention.py


### PR DESCRIPTION
## Purpose

Right-size `timeout_in_minutes` for the **Attention** test area (`.buildkite/test_areas/attention.yaml`) based on the actual per-job runtimes observed in the nightly full CI run ([build 77252](https://buildkite.com/vllm/ci/builds/77252), `source: schedule`, "Full CI run - nightly").

The nightly full run relaxes per-step timeouts and runs every job to completion, so it exposes true runtimes. Two of these steps currently time out at **30 min** while actually running ~63–66 min, which risks spurious timeouts.

**Formula:** `new = round_up_to_5(observed_nightly_duration + 15 min)`

| Step | Observed (77252) | Current | New |
|------|-----------------:|--------:|----:|
| V1 attention (H100-MI300) | 65.9m | 30 | **85** |
| V1 attention (H100-MI300) — AMD mirror | 59.1m | 70 | **75** |
| V1 attention (B200) | 62.5m | 30 | **80** |

## Test

Config-only change to Buildkite pipeline timeouts — no code paths, model output, or accuracy affected, so no model eval is applicable. Durations were computed from the nightly build's per-job `started_at`/`finished_at` timestamps, using successful runs only.

## Notes

- Not a duplicate: no open PR modifies `.buildkite/test_areas/*` timeouts.
- AI assistance (Claude Code) was used to collect the nightly durations and prepare this change; the maintainer has reviewed the resulting values.
