### PR TITLE
[CI] Right-size Basic Correctness test timeout from nightly duration

### DIFF
--- a/.buildkite/test_areas/basic_correctness.yaml
+++ b/.buildkite/test_areas/basic_correctness.yaml
@@ -4,7 +4,7 @@ depends_on:
 steps:
 - label: Basic Correctness
   key: basic-correctness
-  timeout_in_minutes: 30
+  timeout_in_minutes: 45
   device: h200_18gb
   source_file_dependencies:
   - vllm/


### PR DESCRIPTION
## Purpose

Right-size `timeout_in_minutes` for the **Basic Correctness** test area (`.buildkite/test_areas/basic_correctness.yaml`) based on the actual per-job runtime observed in the nightly full CI run ([build 77252](https://buildkite.com/vllm/ci/builds/77252), `source: schedule`, "Full CI run - nightly").

**Formula:** `new = round_up_to_5(observed_nightly_duration + 15 min)`

| Step | Observed (77252) | Current | New |
|------|-----------------:|--------:|----:|
| Basic Correctness | 26.1m | 30 | **45** |
| Basic Correctness — AMD mirror | 31.5m | 50 | 50 (unchanged) |

The AMD mirror already fits within its 50m timeout, so it is left as-is.

## Test

Config-only change to Buildkite pipeline timeouts — no code paths, model output, or accuracy affected, so no model eval is applicable. Durations were computed from the nightly build's per-job `started_at`/`finished_at` timestamps, using successful runs only.

## Notes

- Not a duplicate: no open PR modifies `.buildkite/test_areas/*` timeouts.
- AI assistance (Claude Code) was used to collect the nightly durations and prepare this change; the maintainer has reviewed the resulting values.
