### PR TITLE
[CI] Right-size LoRA test timeouts from nightly durations

### DIFF
--- a/.buildkite/test_areas/lora.yaml
+++ b/.buildkite/test_areas/lora.yaml
@@ -5,7 +5,7 @@ steps:
 - label: LoRA %N
   device: h200_35gb
   key: lora
-  timeout_in_minutes: 30
+  timeout_in_minutes: 40
   source_file_dependencies:
   - vllm/lora
   - tests/lora
@@ -16,7 +16,7 @@ steps:
     amd:
       device: mi325_1
       working_dir: "/vllm-workspace/tests"
-      timeout_in_minutes: 60
+      timeout_in_minutes: 45
       source_file_dependencies:
       - vllm/lora
       - tests/lora
@@ -27,7 +27,7 @@ steps:
 
 - label: LoRA TP (Distributed)
   key: lora-tp-distributed
-  timeout_in_minutes: 30
+  timeout_in_minutes: 60
   num_devices: 4
   source_file_dependencies:
   - vllm/lora


### PR DESCRIPTION
## Purpose

Right-size `timeout_in_minutes` for the **LoRA** test area (`.buildkite/test_areas/lora.yaml`) based on the actual per-job runtimes observed in the nightly full CI run ([build 77252](https://buildkite.com/vllm/ci/builds/77252), `source: schedule`, "Full CI run - nightly").

**Formula:** `new = round_up_to_5(observed_nightly_duration + 15 min)`

| Step | Observed (77252) | Current | New |
|------|-----------------:|--------:|----:|
| LoRA (`parallelism: 4`, per-shard) | 20.5m | 30 | **40** |
| LoRA — AMD mirror | 27.2m | 60 | **45** |
| LoRA TP (Distributed) | 41.0m | 30 | **60** |

The `LoRA %N` step is sharded (`parallelism: 4`); the timeout applies per shard, so the observed value is the max runtime across the 4 shards.

## Test

Config-only change to Buildkite pipeline timeouts — no code paths, model output, or accuracy affected, so no model eval is applicable. Durations were computed from the nightly build's per-job `started_at`/`finished_at` timestamps, using successful runs only.

## Notes

- Not a duplicate: no open PR modifies `.buildkite/test_areas/*` timeouts.
- AI assistance (Claude Code) was used to collect the nightly durations and prepare this change; the maintainer has reviewed the resulting values.
