### PR TITLE
[CI] Right-size Samplers test timeout from nightly duration

### DIFF
--- a/.buildkite/test_areas/samplers.yaml
+++ b/.buildkite/test_areas/samplers.yaml
@@ -5,7 +5,7 @@ steps:
 - label: Samplers Test
   device: h200_35gb
   key: samplers-test
-  timeout_in_minutes: 75
+  timeout_in_minutes: 40
   source_file_dependencies:
   - vllm/model_executor/layers
   - vllm/sampling_metadata.py


### PR DESCRIPTION
## Purpose

Right-size `timeout_in_minutes` for the **Samplers** test area (`.buildkite/test_areas/samplers.yaml`) based on the actual per-job runtime observed in the nightly full CI run ([build 77252](https://buildkite.com/vllm/ci/builds/77252), `source: schedule`, "Full CI run - nightly").

**Formula:** `new = round_up_to_5(observed_nightly_duration + 15 min)`

| Step | Observed (77252) | Current | New |
|------|-----------------:|--------:|----:|
| Samplers Test | 20.4m | 75 | **40** |

This is a **reduction** — the current 75m timeout is well above the real ~20m runtime. Tightening it (while keeping ~2x headroom) lets a genuinely hung job fail faster instead of sitting idle for over an hour. The AMD mirror has no explicit timeout and is untouched.

## Test

Config-only change to Buildkite pipeline timeouts — no code paths, model output, or accuracy affected, so no model eval is applicable. Duration was computed from the nightly build's per-job `started_at`/`finished_at` timestamps (successful run).

## Notes

- Not a duplicate: no open PR modifies `.buildkite/test_areas/*` timeouts.
- AI assistance (Claude Code) was used to collect the nightly durations and prepare this change; the maintainer has reviewed the resulting values.
