### PR TITLE
[CI] Right-size Weight Loading test timeout from nightly duration

### DIFF
--- a/.buildkite/test_areas/weight_loading.yaml
+++ b/.buildkite/test_areas/weight_loading.yaml
@@ -4,7 +4,7 @@ depends_on:
 steps:
 - label: Weight Loading Multiple GPU  # 33min
   key: weight-loading-multiple-gpu
-  timeout_in_minutes: 45
+  timeout_in_minutes: 50
   working_dir: "/vllm-workspace/tests"
   num_devices: 2
   optional: true


### PR DESCRIPTION
## Purpose

Right-size `timeout_in_minutes` for the **Weight Loading** test area (`.buildkite/test_areas/weight_loading.yaml`) based on the actual per-job runtime observed in the nightly full CI run ([build 77252](https://buildkite.com/vllm/ci/builds/77252), `source: schedule`, "Full CI run - nightly").

**Formula:** `new = round_up_to_5(observed_nightly_duration + 15 min)`

| Step | Observed (77252) | Current | New |
|------|-----------------:|--------:|----:|
| Weight Loading Multiple GPU | 30.5m | 45 | **50** |

The observed 30.5m matches the existing `# 33min` inline note; the small bump keeps a ~15m safety margin. The AMD mirror has no explicit timeout and is untouched.

## Test

Config-only change to Buildkite pipeline timeouts — no code paths, model output, or accuracy affected, so no model eval is applicable. Duration was computed from the nightly build's per-job `started_at`/`finished_at` timestamps (successful run).

## Notes

- Not a duplicate: no open PR modifies `.buildkite/test_areas/*` timeouts.
- AI assistance (Claude Code) was used to collect the nightly durations and prepare this change; the maintainer has reviewed the resulting values.
