### PR TITLE
[Structured Output] Cache xgrammar JSON schema validation

### DIFF
--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -3,11 +3,13 @@
 
 import pytest
 
+from vllm.sampling_params import SamplingParams, StructuredOutputsParams
+from vllm.v1.structured_output import backend_xgrammar
 from vllm.v1.structured_output.backend_xgrammar import (
     has_xgrammar_unsupported_json_features,
 )
 
-pytestmark = pytest.mark.cpu_test
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
 
 
 @pytest.fixture
@@ -104,3 +106,41 @@ def test_supported_json_features(supported_schema):
     assert not has_xgrammar_unsupported_json_features(supported_schema), (
         "Schema should be supported"
     )
+
+
+def test_xgrammar_json_schema_validation_is_cached(monkeypatch):
+    calls = 0
+
+    class FakeGrammar:
+        @staticmethod
+        def from_json_schema(schema):
+            nonlocal calls
+            calls += 1
+
+    class FakeXgrammar:
+        Grammar = FakeGrammar
+
+    cache = backend_xgrammar._validate_xgrammar_json_schema
+    cache.cache_clear()
+    monkeypatch.setattr(backend_xgrammar, "xgr", FakeXgrammar)
+
+    try:
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+        }
+
+        backend_xgrammar.validate_xgrammar_grammar(
+            SamplingParams(
+                structured_outputs=StructuredOutputsParams(json=schema)
+            )
+        )
+        backend_xgrammar.validate_xgrammar_grammar(
+            SamplingParams(
+                structured_outputs=StructuredOutputsParams(json=schema)
+            )
+        )
+
+        assert calls == 1
+    finally:
+        cache.cache_clear()

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -3,6 +3,7 @@
 
 import json
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -269,6 +270,26 @@ def has_xgrammar_unsupported_json_features(schema: dict[str, Any]) -> bool:
     return check_object(schema)
 
 
+@lru_cache(maxsize=128)
+def _validate_xgrammar_json_schema(schema_json: str) -> None:
+    try:
+        schema = json.loads(schema_json)
+    except json.JSONDecodeError as e:
+        raise ValueError("Invalid JSON grammar specification.") from e
+
+    if has_xgrammar_unsupported_json_features(schema):
+        raise ValueError(
+            "The provided JSON schema contains features not supported by xgrammar."
+        )
+
+    try:
+        xgr.Grammar.from_json_schema(schema)
+    except Exception as err:
+        raise ValueError(
+            f"Failed to transform json schema into a grammar: {err}"
+        ) from err
+
+
 def validate_xgrammar_grammar(sampling_params: SamplingParams) -> None:
     """Validate that the request is supported by structured output.
 
@@ -304,24 +325,11 @@ def validate_xgrammar_grammar(sampling_params: SamplingParams) -> None:
 
     if so_params.json:
         if isinstance(so_params.json, str):
-            try:
-                schema = json.loads(so_params.json)
-            except json.JSONDecodeError as e:
-                raise ValueError("Invalid JSON grammar specification.") from e
+            schema_json = so_params.json
         else:
-            schema = so_params.json
+            schema_json = json.dumps(so_params.json)
 
-        if has_xgrammar_unsupported_json_features(schema):
-            raise ValueError(
-                "The provided JSON schema contains features not supported by xgrammar."
-            )
-
-        try:
-            xgr.Grammar.from_json_schema(schema)
-        except Exception as err:
-            raise ValueError(
-                f"Failed to transform json schema into a grammar: {err}"
-            ) from err
+        _validate_xgrammar_json_schema(schema_json)
         return
 
     if so_params.grammar:


### PR DESCRIPTION
## Summary

Cache successful xgrammar JSON schema validation on the frontend request path. `validate_xgrammar_grammar` still parses and validates cold schemas exactly as before, but repeated `response_format.json_schema` / structured-output JSON schemas now skip the repeated `xgr.Grammar.from_json_schema(...)` conversion after the first successful validation.

The engine path is unchanged: admitted requests still compile through `GrammarCompiler.compile_json_schema(...)` and use xgrammar's existing compiled-grammar cache.

## Why

The frontend validation call was added in #17623 to catch invalid xgrammar inputs before admission and return request errors instead of allowing engine crashes. That call constructs an `xgr.Grammar` only for validation; the object is not reused by the engine. For repeated schemas, caching the successful validation verdict preserves the pre-admission error behavior without redoing the schema-to-grammar conversion every request.

## Not a duplicate

Duplicate-work checks run:

```bash
gh pr list --repo vllm-project/vllm --state open --search "xgrammar validation cache"
gh pr list --repo vllm-project/vllm --state open --search "structured output json schema validation performance"
gh pr list --repo vllm-project/vllm --state open --search "from_json_schema xgrammar"
gh pr list --repo vllm-project/vllm --state open --search "validate_xgrammar_grammar"
```

Nearby open PRs do not cover this frontend validation cache:

- #45948 adds an optional persistent disk cache for engine-side compiled xgrammar grammars.
- #47312 handles engine grammar compilation failures per request.
- #45390 adds input bounds/timeouts.

This PR only caches successful request-time JSON schema validation verdicts.

## Tests

```bash
.venv/bin/python -m pytest tests/v1/structured_output/test_utils.py -q
# 7 passed, 3 warnings

.venv/bin/ruff check vllm/v1/structured_output/backend_xgrammar.py tests/v1/structured_output/test_utils.py
# All checks passed!
```

## AI assistance

This PR was prepared with AI assistance from OpenAI Codex. It is opened as a draft so the human submitter can review every changed line and confirm they can defend the change end-to-end before marking it ready.