### PR TITLE
[Core] Make the DeepGEMM JIT cache key portable across install layouts

### DIFF
--- a/cmake/external_projects/deepgemm.cmake
+++ b/cmake/external_projects/deepgemm.cmake
@@ -56,6 +56,23 @@ else()
     )
   endif()
   message(STATUS "DeepGEMM is available at ${deepgemm_SOURCE_DIR}")
+
+  # DG_KEY: make DeepGEMM's JIT cache key portable across install layouts so a
+  # prebuilt kernel cache relocates (tools/deepgemm_cache_key.patch). Applied to
+  # the fetched upstream tree only (not a user-provided DEEPGEMM_SRC_DIR). The
+  # reverse --check makes repeated cmake configures idempotent.
+  execute_process(
+    COMMAND git apply --reverse --check "${CMAKE_SOURCE_DIR}/tools/deepgemm_cache_key.patch"
+    WORKING_DIRECTORY "${deepgemm_SOURCE_DIR}"
+    RESULT_VARIABLE _dg_key_reverse_rc
+    OUTPUT_QUIET ERROR_QUIET)
+  if(NOT _dg_key_reverse_rc EQUAL 0)
+    execute_process(
+      COMMAND git apply "${CMAKE_SOURCE_DIR}/tools/deepgemm_cache_key.patch"
+      WORKING_DIRECTORY "${deepgemm_SOURCE_DIR}"
+      COMMAND_ERROR_IS_FATAL ANY)
+    message(STATUS "Applied deepgemm_cache_key.patch (portable JIT cache key)")
+  endif()
 endif()
 
 # DeepGEMM requires CUDA 12.3+ for SM90, 12.9+ for SM100 (official upstream),

--- a/tools/deepgemm_cache_key.patch
+++ b/tools/deepgemm_cache_key.patch
@@ -1,0 +1,40 @@
+diff --git a/csrc/jit/compiler.hpp b/csrc/jit/compiler.hpp
+index 42beaf5..39da71c 100644
+--- a/csrc/jit/compiler.hpp
++++ b/csrc/jit/compiler.hpp
+@@ -97,8 +97,34 @@ public:
+         fsync_path(path);
+     }
+
++    // DG_KEY: drop absolute -I include paths from a flag string so the JIT cache key
++    // is portable across install layouts, while keeping every behavioral compile flag.
++    static std::string strip_include_paths(const std::string& compile_flags) {
++        std::string out;
++        size_t i = 0;
++        while (i < compile_flags.size()) {
++            size_t j = compile_flags.find(' ', i);
++            if (j == std::string::npos)
++                j = compile_flags.size();
++            if (j > i and compile_flags.compare(i, 2, "-I") != 0) {
++                if (not out.empty())
++                    out += ' ';
++                out += compile_flags.substr(i, j - i);
++            }
++            i = j + 1;
++        }
++        return out;
++    }
++
+     std::shared_ptr<KernelRuntime> build(const std::string& name, const std::string& code) const {
+-        const auto kernel_signature = fmt::format("{}$${}$${}$${}", name, signature, flags, code);
++        // DG_KEY: content-only cache key so a prebuilt DeepGEMM cache relocates across
++        // install layouts. `signature` (local NVCC/NVRTC version) and the absolute
++        // `-I<...>/include` paths inside `flags` are toolchain/location identity, not
++        // kernel identity; `code` already embeds num_sms + shapes + include-content hash.
++        // The remaining compile flags (std, ptxas, arch) stay in the key.
++        const auto key_arch = device_runtime->get_arch(true);
++        const auto key_flags = strip_include_paths(flags);
++        const auto kernel_signature = fmt::format("{}$${}$${}$${}", name, key_arch, key_flags, code);
+         const auto dir_path = cache_dir_path / "cache" / fmt::format("kernel.{}.{}", name, get_hex_digest(kernel_signature));
+
+         // Hit the runtime cache

--- a/tools/install_deepgemm.sh
+++ b/tools/install_deepgemm.sh
@@ -4,6 +4,9 @@
 # Optional: build wheels to a directory for later installation (useful in multi-stage builds)
 set -e
 
+# Directory of this script, for locating the vendored patch after we pushd elsewhere.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Default values
 # Keep DEEPGEMM_GIT_REF in sync with cmake/external_projects/deepgemm.cmake
 DEEPGEMM_GIT_REPO="https://github.com/deepseek-ai/DeepGEMM.git"
@@ -91,6 +94,9 @@ pushd "$INSTALL_DIR/deepgemm"
 
 # Checkout the specific reference
 git checkout "$DEEPGEMM_GIT_REF"
+
+# DG_KEY: portable JIT cache key so a prebuilt cache relocates across install layouts.
+git apply "$SCRIPT_DIR/deepgemm_cache_key.patch"
 
 # Clean previous build artifacts
 # (Based on https://github.com/deepseek-ai/DeepGEMM/blob/main/install.sh)


### PR DESCRIPTION
## Purpose

DeepGEMM's JIT warmup compiles 41 distinct kernels, about 797 warmup cases, on a cold Qwen3-30B-A3B-FP8 boot. The results are fully cacheable, and vLLM already pins `DG_JIT_CACHE_DIR` under `VLLM_CACHE_ROOT`. The cache key defeats reuse across environments. The key in `csrc/jit/compiler.hpp` is `name$$signature$$flags$$code`. `signature` is the local NVCC or NVRTC version, and `flags` embeds the absolute `-I{site-packages}/deep_gemm/include` path. A cache built in one install layout misses in any other, even on identical hardware. That blocks the useful deployment shape: build a warm DeepGEMM cache once, as an image layer, a wheel-style package, or a model-adjacent artifact, and then boot fast everywhere.

Measured cost of the miss on 1xH100 NVL, DeepGEMM `a6b593d` which is this repo's pin, each cell n=1. A warm cache planted in an identical venv at a different path recompiles all 41 kernels and boots in 170.6s. With this patch's key, the same-content cache hits 41 of 41 and boots in 76.9s. **The stock key wastes 93.7s of a 170.6s boot on install-layout identity alone.**

flashinfer's adapted DeepGEMM port already made this exact change to a content-only `name$$code` key, at `flashinfer/deep_gemm.py:955`. That is what makes `flashinfer-jit-cache` shippable as a package. This PR is the narrow slice of #42431. Full AOT remains the long-term answer. It follows the design discussion on RFC #47456, where I posted it first per @simon-mo, and it sits next to @mgoin's closed #25614 on the same warmup cost.

**Upstream status, per @simon-mo's steer on this PR ("don't patch it here, is there an upstream PR that you can point to or we can propose?" and "plz stage upstream pr with clear rationale"):** the upstream fix is filed as [deepseek-ai/DeepGEMM#388](https://github.com/deepseek-ai/DeepGEMM/pull/388), opened 2026-07-20 with the narrower form. Only the library `-I` token leaves the key there, because the header content is already hashed in. **When #388 lands I will rework this PR to consume it and drop the vendored patch entirely.** The vendored patch below is the interim. #388 has no maintainer response yet, so the interim may need to stand for a while. I am happy to hold this PR until #388 resolves if reviewers prefer that.

## Changes

The interim vendored patch on the fetched DeepGEMM source, using the same in-tree pattern as `tools/ep_kernels/elastic_ep/eep_nvshmem.patch`. This is what DeepGEMM#388 replaces once it lands.

- `tools/deepgemm_cache_key.patch`: in `Compiler::build()` the key becomes `name$$key_arch$$key_flags$$code`.
  - `key_arch = get_arch(true)` is the canonical arch, `"90"`, `"100"`, or `"120"`. It stays stable across the NVCC 12.8 and 12.9 family-suffix split. The suffixed arch still keys through the arch flag inside `key_flags`.
  - `key_flags` is `flags` with only the `-I<path>` tokens removed. The std, ptxas, arch, and `DG_JIT_*` flags all still key.
  - `signature`, the local toolchain version, leaves the key. This is the flashinfer-precedented tradeoff. A cubin is a hardware ABI: compiled under NVCC 12.8 it runs correctly under 12.9. The cost is possibly-stale but functionally correct SASS until the cache directory is cleared. I am happy to add an opt-in `DG_JIT_KEY_INCLUDE_COMPILER_VERSION=1` if reviewers want the old behavior available. I propose default-off.
  - `code` already carries kernel identity through a recursive `<deep_gemm/*>` include-content hash plus `num_sms` and the shape, block, and pipeline params. Header changes and SKU differences still invalidate correctly.
- `tools/install_deepgemm.sh`: run `git apply` immediately after the pinned checkout.
- `cmake/external_projects/deepgemm.cmake`: a guarded `execute_process(git apply)` after `FetchContent_Populate`, with `--reverse --check` first so repeated configures stay idempotent. The `DEEPGEMM_SRC_DIR` local-override path is deliberately not patched, because a developer's own tree should not be mutated. There is an inline note.

## Test Plan

No new test files. The change is a build-time patch on a vendored dependency, exercised through the normal DeepGEMM warmup path. Verification is a controlled A/B on hardware: one pod, two venvs so the install path is the only variable, two-channel detection through the kernel-directory count and the warmup progress bar, and a patched `_C.so` built from a checkout with this exact patch applied and gated on its sha.

## Test Result

1xH100 NVL (SM132, driver 570.133.20, nvcc 12.8, torch 2.11.0+cu129), Qwen/Qwen3-30B-A3B-FP8 TP1, DeepGEMM `a6b593d`, each cell n=1:

| cell | `_C.so` | venv | planted cache | new kernel dirs | boot |
|---|---|---|---|---|---|
| S1 | stock | 1 (cache's own layout) | stock-key donor | 0 (hit) | 76.9s |
| S2 | stock | 2 (different path) | stock-key donor | 41 (miss) | 170.6s |
| P1 | patched | 2 (different path) | patched-key donor | 0 (hit) | 76.9s |

S1 validates the apparatus, because the same layout hits today. S2 is the blocker. P1 is the claim. Hit cells show the warmup bar at about 9,500 it/s against about 9.7 it/s on misses.

One-time migration for existing users: the old and new cache directory names are fully disjoint, measured at 0 of 82 overlapping. Upgrading rebuilds once, about 94s for this model, and old entries become dead weight rather than corruption.

These numbers come from the default NVCC path. The NVRTC path (`DG_JIT_USE_NVRTC=1`, non-default) gets the same `-I` strip by inspection, not by hardware measurement.
