### PR TITLE
[Quantization] Fix misleading NVFP4 Marlin linear warning on FP4-native GPUs

### DIFF
--- a/vllm/model_executor/kernels/linear/nvfp4/marlin.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/marlin.py
@@ -9,6 +9,9 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
     is_fp4_marlin_supported,
     prepare_fp4_layer_for_marlin,
 )
+from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
+    cutlass_fp4_supported,
+)
 
 from .base import NvFp4LinearKernel, NvFp4LinearLayerConfig
 
@@ -31,12 +34,24 @@ class MarlinNvFp4LinearKernel(NvFp4LinearKernel):
         return True, None
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        logger.warning_once(
-            "Your GPU does not have native support for FP4 computation but "
-            "FP4 quantization is being used. Weight-only FP4 compression "
-            "will be used leveraging the Marlin kernel. This may degrade "
-            "performance for compute-heavy workloads."
-        )
+        # Reachable on FP4-native GPUs too: weight-only (W4A16_NVFP4)
+        # checkpoints have no activation scales, so Marlin is their only
+        # valid kernel regardless of hardware.
+        if cutlass_fp4_supported():
+            logger.warning_once(
+                "FP4 weights will be dequantized to the activation dtype "
+                "inside the Marlin kernel instead of using this GPU's "
+                "native FP4 tensor cores (weight-only FP4 checkpoints such "
+                "as W4A16_NVFP4 only support this path). This may degrade "
+                "performance for compute-heavy workloads."
+            )
+        else:
+            logger.warning_once(
+                "Your GPU does not have native support for FP4 computation "
+                "but FP4 quantization is being used. Weight-only FP4 "
+                "compression will be used leveraging the Marlin kernel. "
+                "This may degrade performance for compute-heavy workloads."
+            )
         prepare_fp4_layer_for_marlin(layer)
 
     def apply_weights(


### PR DESCRIPTION
## Purpose

Fixes #47749

`MarlinNvFp4LinearKernel.process_weights_after_loading` unconditionally logs
"Your GPU does not have native support for FP4 computation". That claim is wrong on
SM100/SM12x: `ModelOptNvFp4W4A16LinearMethod` pins the Marlin kernel for weight-only
`W4A16_NVFP4` checkpoints on every GPU (`modelopt.py` — "For W4A16 there is exactly one
valid kernel, so we pin it"), because those checkpoints carry no activation scales and
native FP4 GEMM needs FP4 activations. So RTX 5090 / RTX PRO 6000 users loading ModelOpt
`W4A16_NVFP4` (or mixed) checkpoints are told their Blackwell GPU lacks FP4 support —
three reporters on #47749 read it exactly that way, and #23497 was filed off the same
message.

This PR branches the message on `cutlass_fp4_supported()` (the same predicate the NVFP4
kernel selection stack uses):

- FP4-native builds now get an accurate message: weights are dequantized to the
  activation dtype inside the Marlin kernel; weight-only FP4 checkpoints such as
  `W4A16_NVFP4` only support this path; performance may still degrade.
- All other configurations keep the existing message byte-for-byte.

The warning itself is kept in both branches — #31346 (which removed it) was closed
because maintainers want a warning here, since Marlin is still not native FP4 compute.

Not a duplicate: #45192 rewords the MoE-site copy of this message in
`prepare_nvfp4_moe_layer_for_marlin` (`marlin_utils_fp4.py`) and does not touch this
file. The `[marlin.py:34]` warning quoted in #47749's logs comes from the linear kernel
site fixed here; no open PR covers it. The two PRs are complementary.

AI assistance was used for this change (Claude). I reviewed every changed line and ran
the verification below myself; the change affects a log message only, so model outputs,
accuracy, and kernel behavior are unchanged (no eval delta possible).

## Test Plan

A/B dummy-boot on real SM120 (RTX PRO 6000 Blackwell, CUDA 13.0), current main
(a0f6d767e): tiny 2-layer Qwen3-style config with
`quantization_config = {"quant_method": "modelopt_fp4", "quant_algo": "W4A16_NVFP4",
"group_size": 16, "ignore": ["lm_head"]}`, booted with `load_format="dummy"`,
`quantization="modelopt_fp4"`, `enforce_eager=True`, then one `llm.generate()` call so
the forward actually runs through `apply_fp4_marlin_linear`.

```bash
python boot_47749.py   # stock, then with this patch applied
ruff check vllm/model_executor/kernels/linear/nvfp4/marlin.py
ruff format --check vllm/model_executor/kernels/linear/nvfp4/marlin.py
```

## Test Result

Stock main on SM120 (misleading):

```
WARNING [marlin.py:34] Your GPU does not have native support for FP4 computation but
FP4 quantization is being used. Weight-only FP4 compression will be used leveraging
the Marlin kernel. This may degrade performance for compute-heavy workloads.
```

With this PR on SM120:

```
WARNING [marlin.py:41] FP4 weights will be dequantized to the activation dtype inside
the Marlin kernel instead of using this GPU's native FP4 tensor cores (weight-only FP4
checkpoints such as W4A16_NVFP4 only support this path). This may degrade performance
for compute-heavy workloads.
```

Both runs boot and generate successfully through the Marlin kernel. Ruff check and
format pass. What I did not run: the non-FP4-native branch on real pre-Blackwell
hardware (none on hand) — that branch's string is asserted byte-identical to the
current message, so behavior there is unchanged by construction.
