### PR TITLE
[Core][Spec Decode] Reference implementation: per-request effective proposal lengths (RFC #48202)

### DIFF
--- a/tests/v1/spec_decode/test_proposal_lengths.py
+++ b/tests/v1/spec_decode/test_proposal_lengths.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for per-request effective proposal lengths (confidence truncation).
+
+Covers the pure pieces that do not need a GPU model: the confidence-threshold
+config validation, the first-below-threshold length computation used by the
+DSpark speculator, and the DraftTokensHandler prefix clipping semantics.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.config.speculative import SpeculativeConfig
+
+
+def _lengths_from_conf_logits(
+    conf_logits: torch.Tensor, logit_threshold: float
+) -> torch.Tensor:
+    # Mirrors DSparkSpeculator._sample_sequential's post-loop computation.
+    n_spec = conf_logits.shape[1]
+    below = conf_logits < logit_threshold
+    first_below = below.to(torch.int32).argmax(dim=1)
+    any_below = below.any(dim=1)
+    return torch.where(any_below, first_below, torch.full_like(first_below, n_spec))
+
+
+def test_confidence_threshold_rejects_out_of_range():
+    with pytest.raises(ValueError, match="confidence_threshold"):
+        SpeculativeConfig(method="dspark", confidence_threshold=1.0)
+    with pytest.raises(ValueError, match="confidence_threshold"):
+        SpeculativeConfig(method="dspark", confidence_threshold=-0.1)
+
+
+def test_confidence_threshold_requires_dspark():
+    with pytest.raises(ValueError, match="dspark"):
+        SpeculativeConfig(
+            method="ngram",
+            num_speculative_tokens=3,
+            prompt_lookup_max=4,
+            confidence_threshold=0.5,
+        )
+
+
+def test_first_below_threshold_lengths():
+    # threshold 0.5 -> logit threshold 0.0
+    conf = torch.tensor(
+        [
+            [1.0, 1.0, 1.0, 1.0],  # never below -> full length
+            [-1.0, 1.0, 1.0, 1.0],  # below at position 0 -> length 0
+            [1.0, 1.0, -1.0, 1.0],  # below at position 2 -> length 2
+            [1.0, -1.0, -1.0, -1.0],  # first below wins -> length 1
+        ]
+    )
+    lengths = _lengths_from_conf_logits(conf, logit_threshold=0.0)
+    assert lengths.tolist() == [4, 0, 2, 1]
+
+
+class _FakeInputBatch:
+    def __init__(self, req_ids, has_structured_output_reqs=False):
+        self.req_ids = req_ids
+        self.has_structured_output_reqs = has_structured_output_reqs
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_handler_clips_proposals_to_lengths():
+    from vllm.v1.worker.gpu.spec_decode.utils import DraftTokensHandler
+
+    device = torch.device("cuda")
+    handler = DraftTokensHandler(device)
+    batch = _FakeInputBatch(["a", "b", "c"])
+    draft_tokens = torch.arange(12, device=device).reshape(3, 4)
+    lengths = torch.tensor([4, 0, 2], dtype=torch.int32, device=device)
+
+    handler.set_draft_tokens(batch, draft_tokens, proposal_lengths=lengths)
+    out = handler.get_draft_tokens()
+    assert out.req_ids == ["a", "b", "c"]
+    assert [len(ids) for ids in out.draft_token_ids] == [4, 0, 2]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_handler_without_lengths_preserves_uniform_behavior():
+    from vllm.v1.worker.gpu.spec_decode.utils import DraftTokensHandler
+
+    device = torch.device("cuda")
+    handler = DraftTokensHandler(device)
+    batch = _FakeInputBatch(["a", "b"])
+    draft_tokens = torch.zeros(2, 4, dtype=torch.int64, device=device)
+
+    handler.set_draft_tokens(batch, draft_tokens)
+    out = handler.get_draft_tokens()
+    assert [len(ids) for ids in out.draft_token_ids] == [4, 4]
+    assert all(t == -1 for ids in out.draft_token_ids for t in ids)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_handler_lengths_with_structured_output_tokens():
+    from vllm.v1.worker.gpu.spec_decode.utils import DraftTokensHandler
+
+    device = torch.device("cuda")
+    handler = DraftTokensHandler(device)
+    batch = _FakeInputBatch(["a", "b"], has_structured_output_reqs=True)
+    draft_tokens = torch.arange(8, device=device).reshape(2, 4)
+    lengths = torch.tensor([1, 3], dtype=torch.int32, device=device)
+
+    handler.set_draft_tokens(batch, draft_tokens, proposal_lengths=lengths)
+    out = handler.get_draft_tokens()
+    np.testing.assert_array_equal(out.draft_token_ids[0], [0])
+    np.testing.assert_array_equal(out.draft_token_ids[1], [4, 5, 6])

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -177,6 +177,15 @@ class SpeculativeConfig:
     inclusive batch-size range.
     """
 
+    confidence_threshold: float = 0.0
+    """Per-request draft-confidence early-stop threshold (DSpark only for
+    now). When > 0, drafters that expose a confidence head truncate each
+    request's proposal at the first position whose predicted acceptance
+    probability falls below this value, so requests in the same batch may
+    propose different effective lengths. 0 (default) disables truncation and
+    preserves the uniform-K behavior exactly. Currently effective only with
+    async scheduling disabled; see the per-request proposal-lengths RFC."""
+
     # params generated in the post-init stage
     draft_model_config: SkipValidation[ModelConfig] = None  # type: ignore
     """The configuration of the draft model initialized internal."""
@@ -634,6 +643,12 @@ class SpeculativeConfig:
         # will be detected automatically if possible. If the speculative method
         # can not be detected, it will be considered as the "draft_model" by
         # default.
+
+        if not 0.0 <= self.confidence_threshold < 1.0:
+            raise ValueError(
+                "confidence_threshold must be in [0.0, 1.0); got "
+                f"{self.confidence_threshold}."
+            )
 
         # infer method from user args
         # Check if the model field contains a custom module path (e.g., 'pkg.Mod')
@@ -1170,6 +1185,12 @@ class SpeculativeConfig:
         if self.draft_model_config:
             self.draft_model_config.verify_with_parallel_config(
                 self.draft_parallel_config
+            )
+
+        if self.confidence_threshold > 0.0 and self.method != "dspark":
+            raise ValueError(
+                "confidence_threshold currently requires method='dspark' "
+                "(the only draft model exposing a confidence head)."
             )
 
         if self.use_heterogeneous_vocab and not self.uses_draft_model():

--- a/vllm/model_executor/models/qwen3_dspark.py
+++ b/vllm/model_executor/models/qwen3_dspark.py
@@ -67,6 +67,26 @@ class DSparkMarkovHead(nn.Module):
         return logits_processor(self.markov_w2, markov_embed)
 
 
+class DSparkConfidenceHead(nn.Module):
+    """Per-position acceptance-confidence head shipped in DSpark checkpoints.
+
+    A single linear over ``[backbone_hidden, markov_w1[prev_token]]``
+    predicting the acceptance probability (as a logit) of the draft token at
+    each position, following the DeepSpec training recipe
+    (``confidence_head_with_markov=True``). Replicated: the output dim is 1,
+    TP sharding is not worth it.
+    """
+
+    def __init__(self, hidden_size: int, markov_rank: int) -> None:
+        super().__init__()
+        self.proj = nn.Linear(hidden_size + markov_rank, 1)
+
+    def forward(self, hidden: torch.Tensor, markov_embed: torch.Tensor) -> torch.Tensor:
+        dtype = self.proj.weight.dtype
+        features = torch.cat([hidden.to(dtype), markov_embed.to(dtype)], dim=-1)
+        return self.proj(features).squeeze(-1).float()
+
+
 class Qwen3DSparkModel(DFlashQwen3Model):
     """DFlash Qwen3 backbone + DSpark Markov head."""
 
@@ -90,6 +110,12 @@ class Qwen3DSparkModel(DFlashQwen3Model):
             config.markov_rank,
             prefix=maybe_prefix(prefix, "markov_head"),
         )
+        spec_config = vllm_config.speculative_config
+        self.confidence_head: DSparkConfidenceHead | None = None
+        if spec_config is not None and spec_config.confidence_threshold > 0.0:
+            self.confidence_head = DSparkConfidenceHead(
+                config.hidden_size, config.markov_rank
+            )
 
 
 class Qwen3DSparkForCausalLM(DFlashQwen3ForCausalLM):
@@ -146,6 +172,17 @@ class Qwen3DSparkForCausalLM(DFlashQwen3ForCausalLM):
     def markov_bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
         return self.model.markov_head.bias(markov_embed, self.logits_processor)
 
+    @property
+    def has_confidence_head(self) -> bool:
+        return self.model.confidence_head is not None
+
+    def compute_confidence(
+        self, hidden: torch.Tensor, markov_embed: torch.Tensor
+    ) -> torch.Tensor:
+        """Acceptance-confidence logits for draft positions ([N] float32)."""
+        assert self.model.confidence_head is not None
+        return self.model.confidence_head(hidden, markov_embed)
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         model_weights = {}
         includes_embed_tokens = False
@@ -170,10 +207,14 @@ class Qwen3DSparkForCausalLM(DFlashQwen3ForCausalLM):
             process_eagle_weight(self, name)
 
         # mask_embedding is an unused placeholder param; DSpark masks via the vocab row.
-        # confidence_head is not wired into inference yet; skip its weights.
+        # confidence_head weights are loaded only when confidence-based
+        # proposal truncation is enabled (speculative_config.confidence_threshold
+        # > 0); otherwise they are skipped as before.
         # embed_tokens / lm_head are optional; when omitted they are shared from
         # the target by load_dspark_model, so skip the unloaded params here.
-        skip_substrs = ["mask_embedding", "confidence_head"]
+        skip_substrs = ["mask_embedding"]
+        if not self.has_confidence_head:
+            skip_substrs.append("confidence_head")
         if not includes_embed_tokens:
             skip_substrs.append("embed_tokens")
         if not includes_lm_head:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1482,9 +1482,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if self.num_speculative_steps > 0:
             # Spec-decode and diffusion LLMs both use draft tokens but the latter does
             # not have a speculator (i.e. self.speculator is None)
+            proposal_lengths = getattr(self.speculator, "proposal_lengths", None)
+            if proposal_lengths is not None:
+                num_reqs = len(input_batch.req_ids)
+                proposal_lengths = proposal_lengths[:num_reqs]
             self.draft_tokens_handler.set_draft_tokens(
                 input_batch,
                 self.req_states.draft_tokens[input_batch.idx_mapping],
+                proposal_lengths=proposal_lengths,
             )
 
         # Post-step KV connector related operations.

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -74,6 +74,30 @@ class DSparkSpeculator(DFlashSpeculator):
         self._d2t_scatter_index: torch.Tensor | None = None
         self._draft_scatter_buf: torch.Tensor | None = None
 
+        # Confidence-based per-request proposal truncation (off by default).
+        # Fixed-shape persistent buffers so the whole draft step stays
+        # CUDA-graph capturable; lengths are read back outside capture.
+        self.confidence_threshold = self.speculative_config.confidence_threshold
+        self.proposal_lengths: torch.Tensor | None = None
+        self._conf_logits: torch.Tensor | None = None
+        self._conf_logit_threshold: float = 0.0
+        if self.confidence_threshold > 0.0:
+            self._conf_logit_threshold = float(
+                torch.logit(torch.tensor(self.confidence_threshold)).item()
+            )
+            self._conf_logits = torch.zeros(
+                self.max_num_reqs,
+                self.num_speculative_steps,
+                dtype=torch.float32,
+                device=device,
+            )
+            self.proposal_lengths = torch.full(
+                (self.max_num_reqs,),
+                self.num_speculative_steps,
+                dtype=torch.int32,
+                device=device,
+            )
+
     def load_draft_model(
         self,
         target_model: torch.nn.Module,
@@ -112,6 +136,12 @@ class DSparkSpeculator(DFlashSpeculator):
         idx_map = self.sample_idx_mapping[:num_sample].view(num_reqs, n_spec)
         sample_pos = self.sample_pos[:num_sample].view(num_reqs, n_spec)
 
+        compute_confidence = (
+            self._conf_logits is not None and self.model.has_confidence_head
+        )
+        if compute_confidence:
+            hidden_3d = sample_hidden.view(num_reqs, n_spec, -1)
+
         # Anchor (bonus) token per request = the input id at query offset 0,
         # read via the precomputed persistent index (fixed buffer for capture).
         prev = self.input_buffers.input_ids[self._anchor_idx[:num_reqs]]
@@ -120,6 +150,13 @@ class DSparkSpeculator(DFlashSpeculator):
             # Sequential stage: Markov bias from the previously sampled token.
             markov_embed = self.model.markov_embed(prev)
             bias = self.model.markov_bias(markov_embed)
+            if compute_confidence:
+                # Acceptance confidence for the token drafted at position i,
+                # conditioned on the backbone hidden and the previous token's
+                # Markov embedding (already computed for the bias above).
+                self._conf_logits[:num_reqs, i] = self.model.compute_confidence(
+                    hidden_3d[:, i], markov_embed
+                )
             logits_i = base_logits[:, i] + bias
             if self.draft_logits is not None:
                 # Probabilistic: sample in target vocab (a reduced draft vocab is
@@ -148,6 +185,19 @@ class DSparkSpeculator(DFlashSpeculator):
                 )
             self.draft_tokens[:num_reqs, i] = draft_sampled_i
             prev = draft_sampled_i
+
+        if compute_confidence:
+            # Effective proposal length per request: the prefix before the
+            # first position whose confidence falls below the threshold.
+            # Fixed-shape tensor ops only, so this stays graph-capturable.
+            below = self._conf_logits[:num_reqs] < self._conf_logit_threshold
+            first_below = below.to(torch.int32).argmax(dim=1)
+            any_below = below.any(dim=1)
+            self.proposal_lengths[:num_reqs] = torch.where(
+                any_below,
+                first_below,
+                torch.full_like(first_below, n_spec),
+            )
 
     def _generate_draft(
         self,

--- a/vllm/v1/worker/gpu/spec_decode/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/utils.py
@@ -18,37 +18,63 @@ class DraftTokensHandler:
         self.req_ids: list[str] = []
         self.draft_tokens_np: np.ndarray | None = None
         self.num_draft_tokens: int = 0
+        self.proposal_lengths_np: np.ndarray | None = None
 
     def set_draft_tokens(
-        self, input_batch: InputBatch, draft_tokens: torch.Tensor
+        self,
+        input_batch: InputBatch,
+        draft_tokens: torch.Tensor,
+        proposal_lengths: torch.Tensor | None = None,
     ) -> None:
         self.req_ids = input_batch.req_ids
         self.num_draft_tokens = draft_tokens.shape[1]
-        if not input_batch.has_structured_output_reqs:
+        need_tokens = input_batch.has_structured_output_reqs
+        if not need_tokens and proposal_lengths is None:
             # No draft token validation needs to be performed by
-            # the scheduler for this batch.
+            # the scheduler for this batch, and lengths are uniform.
             self.draft_tokens_np = None
+            self.proposal_lengths_np = None
             return
 
         # For spec decoding + structured outputs, we must transfer the
         # draft tokens back to the scheduler for grammar validation.
+        # Per-request proposal lengths ride the same copy stream: they are
+        # bound to this exact in-flight batch and consumed with it.
         current_stream = torch.cuda.current_stream(self.device)
         self.copy_stream.wait_stream(current_stream)
         with torch.cuda.stream(self.copy_stream):
-            self.draft_tokens_np = async_copy_to_np(draft_tokens)
-            # draft_tokens is a temporary allocation on the main stream and read here on
-            # copy_stream; without record_stream, the caching allocator may reuse its
-            # memory before the async copy executes.
-            draft_tokens.record_stream(self.copy_stream)
+            if need_tokens:
+                self.draft_tokens_np = async_copy_to_np(draft_tokens)
+                # draft_tokens is a temporary allocation on the main stream and
+                # read here on copy_stream; without record_stream, the caching
+                # allocator may reuse its memory before the async copy executes.
+                draft_tokens.record_stream(self.copy_stream)
+            else:
+                self.draft_tokens_np = None
+            if proposal_lengths is not None:
+                self.proposal_lengths_np = async_copy_to_np(proposal_lengths)
+                proposal_lengths.record_stream(self.copy_stream)
+            else:
+                self.proposal_lengths_np = None
             self.copy_event.record()
 
     def get_draft_tokens(self) -> DraftTokenIds | None:
-        if self.draft_tokens_np is not None:
+        if self.draft_tokens_np is not None or self.proposal_lengths_np is not None:
             self.copy_event.synchronize()
+        if self.draft_tokens_np is not None:
             draft_token_ids = self.draft_tokens_np.tolist()
         else:
             # This case only happens when async scheduling is disabled.
             draft_token_ids = [[-1] * self.num_draft_tokens for _ in self.req_ids]
+        if self.proposal_lengths_np is not None:
+            # Only the confident prefix of each request's proposal is
+            # semantically present; positions beyond it must not reach
+            # verification or scheduler accounting.
+            lengths = self.proposal_lengths_np
+            draft_token_ids = [
+                ids[: int(lengths[i])] if i < len(lengths) else ids
+                for i, ids in enumerate(draft_token_ids)
+            ]
         return DraftTokenIds(self.req_ids, draft_token_ids)
 
 


### PR DESCRIPTION
## Purpose

Reference implementation for RFC #48202: per-request effective proposal
lengths for speculative decoding, with the DSpark confidence head as the
first consumer. Draft PR: the metadata ownership question in the RFC is
still open, and this branch implements the "independent field on
proposer/model-runner output" shape for concreteness.

## Changes

- `SpeculativeConfig.confidence_threshold` (default 0.0 = off; validated;
  currently dspark-only).
- `qwen3_dspark.py`: optional `DSparkConfidenceHead` (Linear(hidden +
  markov_rank -> 1)); checkpoint weights are loaded instead of skipped when
  the feature is enabled; `compute_confidence()` exposed.
- `DSparkSpeculator`: per-position confidence inside the sequential Markov
  loop (reuses the already-computed Markov embedding); first-below-threshold
  gives `proposal_lengths` (fixed-shape int32 buffer, graph-capturable ops).
- `DraftTokensHandler` + model runner: lengths ride the existing copy
  stream, bound to the in-flight batch; `get_draft_tokens()` clips each
  request's list to its effective length.
- Unit tests for config validation, length computation, and handler
  clipping semantics.

## Behavior

- `confidence_threshold == 0` (default): bit-for-bit unchanged.
- `> 0`: per-request truncation takes effect with async scheduling disabled.
  On the default async path the lengths are computed but not yet consumed;
  wiring them through async accounting is the infrastructure question of
  RFC #48202 and intentionally out of scope here.

## Measurements 

On Qwen3-4B / 1x L20X up to batch 64, truncation does not improve wall
clock (details in the RFC); this PR is mechanism, not a performance claim.
Acceptance-behavior validation: with threshold 0.9 on MT-Bench, per-request
proposal lengths collapse to 0-1 as expected; with 0.5, instrumented batches
show lengths spanning 0..7.

## AI-assisted contribution disclosure

Parts of this change were developed with AI assistance (Claude). I have
reviewed, tested, and take responsibility for every line. Commits carry
`Co-authored-by: Claude` per the contributing guide.

## Test plan

- `pytest tests/v1/spec_decode/test_proposal_lengths.py`
- Manual: Qwen3-4B + deepseek-ai/dspark_qwen3_4b_block7,
  `--speculative-config '{"method":"dspark","model":...,
  "num_speculative_tokens":7,"confidence_threshold":0.5}'`,
  async scheduling off; verified truncation lengths and unchanged output
  with threshold 0.