### PR TITLE
[Bugfix] Pin FlashInfer bmm_fp8 to cuBLAS on sm_12x to avoid cuDNN hot-path stalls

### DIFF
--- a/tests/kernels/quantization/test_scaled_mm_kernel_selection.py
+++ b/tests/kernels/quantization/test_scaled_mm_kernel_selection.py
@@ -127,3 +127,66 @@ def test_register_oot_linear_kernel(platform_mock):
     assert isinstance(kernel, OOTInt8ScaledMMLinearKernel), (
         "init_int8_linear_kernel should return an instance of the registered kernel"
     )
+
+
+@pytest.mark.parametrize(
+    "compute_capability,expected_supported",
+    [(90, False), (100, True), (103, True), (120, True), (121, True)],
+)
+def test_flashinfer_fp8_kernel_is_supported_per_arch(
+    compute_capability: int, expected_supported: bool
+):
+    """FlashInfer per-tensor FP8 kernel stays enabled on Blackwell,
+    including the sm_12x family — the cuDNN hot-path stall there is
+    handled by pinning the bmm_fp8 backend, not by gating the kernel
+    (see bmm_fp8_backend in vllm.utils.flashinfer)."""
+    from vllm.model_executor.kernels.linear import (
+        FlashInferFP8ScaledMMLinearKernel,
+    )
+
+    with (
+        patch(
+            "vllm.model_executor.kernels.linear.scaled_mm.flashinfer"
+            ".current_platform"
+        ) as platform_mock,
+        patch(
+            "vllm.model_executor.kernels.linear.scaled_mm.flashinfer"
+            ".has_flashinfer",
+            return_value=True,
+        ),
+    ):
+        platform_mock.is_cuda.return_value = True
+        supported, reason = FlashInferFP8ScaledMMLinearKernel.is_supported(
+            compute_capability
+        )
+    assert supported is expected_supported, reason
+
+
+@pytest.mark.parametrize(
+    "capability_family_120,expected_backend",
+    [(True, "cublas"), (False, "auto")],
+)
+def test_bmm_fp8_backend_pins_cublas_on_sm_12x(
+    capability_family_120: bool, expected_backend: str
+):
+    """On sm_12x, bmm_fp8 must not use backend="auto": with the cudnn
+    python module importable, FlashInfer's auto selection lazily builds
+    cuDNN GEMM graphs per novel (batch, seqlen) shape inside the serving
+    hot path (multi-second stalls) and can reject plans at execute time
+    (flashinfer-ai/flashinfer#3566)."""
+    from vllm.utils import flashinfer as fi_utils
+
+    def fake_family(capability: int) -> bool:
+        return capability_family_120 if capability == 120 else False
+
+    saved = fi_utils._BMM_FP8_BACKEND
+    fi_utils._BMM_FP8_BACKEND = None
+    try:
+        with patch.object(
+            fi_utils.current_platform,
+            "is_device_capability_family",
+            side_effect=fake_family,
+        ):
+            assert fi_utils.bmm_fp8_backend() == expected_backend
+    finally:
+        fi_utils._BMM_FP8_BACKEND = saved

--- a/vllm/compilation/passes/fusion/collective_fusion.py
+++ b/vllm/compilation/passes/fusion/collective_fusion.py
@@ -699,13 +699,18 @@ class FlashInferBMMFP8ReduceScatterPattern(
             a_scale: torch.Tensor,
             b_scale: torch.Tensor,
         ) -> torch.Tensor:
+            # The backend literal must match production traces from
+            # flashinfer_scaled_fp8_mm exactly or the pattern silently
+            # stops matching, so derive it from the same helper.
+            from vllm.utils.flashinfer import bmm_fp8_backend
+
             bmm = torch.ops.vllm.bmm_fp8.default(
                 torch.ops.aten.unsqueeze.default(a_2d, 0),
                 torch.ops.aten.unsqueeze.default(b_2d, 0),
                 a_scale,
                 b_scale,
                 self.dtype,
-                "auto",
+                bmm_fp8_backend(),
             )
             output = torch.ops.aten.reshape.default(bmm, list(bmm.shape[1:]))
             return torch.ops.vllm.reduce_scatter.default(
@@ -763,6 +768,10 @@ class FlashInferAllGatherBMMFP8Pattern(
             a_scale: torch.Tensor,
             b_scale: torch.Tensor,
         ) -> torch.Tensor:
+            # Backend literal must match production traces — see
+            # FlashInferBMMFP8ReduceScatterPattern.pattern.
+            from vllm.utils.flashinfer import bmm_fp8_backend
+
             all_gather = torch.ops.vllm.all_gather.default(
                 a_shard_2d,
                 dim=0,
@@ -775,7 +784,7 @@ class FlashInferAllGatherBMMFP8Pattern(
                 a_scale,
                 b_scale,
                 self.dtype,
-                "auto",
+                bmm_fp8_backend(),
             )
 
         return _pattern

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -857,6 +857,48 @@ def flashinfer_scaled_fp4_mm_out(
     return out
 
 
+_BMM_FP8_BACKEND: str | None = None
+
+
+# assume_constant_result: the backend is fixed per process (it depends only
+# on the GPU architecture), the device-capability query inside is not
+# Dynamo-traceable, and the backend must appear as a string literal in
+# compiled graphs for the AsyncTP fusion patterns to match on it.
+@torch.compiler.assume_constant_result
+def bmm_fp8_backend() -> str:
+    """Backend argument for FlashInfer's per-tensor FP8 ``bmm_fp8``.
+
+    ``"auto"`` lets FlashInfer pick from all importable backends, including
+    cuDNN whenever the ``cudnn`` python module is present (it is a
+    transitive dependency of ``nvidia-cudnn-frontend`` in
+    requirements/cuda.txt). On the sm_12x (consumer/workstation Blackwell)
+    family the cuDNN path is broken in two ways: cuDNN GEMM graphs are
+    built lazily per exact (batch, seqlen) shape on the host inside the
+    serving hot path (multi-second engine stalls on every novel prompt
+    length), and plans that build successfully can still be rejected at
+    execute time with "Plan index N is invalid"
+    (flashinfer-ai/flashinfer#3566). Pin cuBLAS there — FlashInfer's own
+    default backend for ``bmm_fp8`` — until FlashInfer builds cuDNN plans
+    off the hot path. Keep ``"auto"`` elsewhere (e.g. sm_10x datacenter
+    Blackwell), where the cuDNN runner is autotuned at warmup and
+    beneficial.
+
+    The result is memoized in a module-level constant (not
+    ``functools.cache``) so Dynamo can constant-fold the call when tracing
+    ``flashinfer_scaled_fp8_mm``: the device-capability query is not
+    traceable, and the backend must appear as a string literal in the
+    graph for the AsyncTP fusion patterns to match on it.
+    """
+    global _BMM_FP8_BACKEND
+    if _BMM_FP8_BACKEND is None:
+        _BMM_FP8_BACKEND = (
+            "cublas"
+            if current_platform.is_device_capability_family(120)
+            else "auto"
+        )
+    return _BMM_FP8_BACKEND
+
+
 def flashinfer_scaled_fp8_mm(
     a: torch.Tensor,
     b: torch.Tensor,
@@ -879,7 +921,7 @@ def flashinfer_scaled_fp8_mm(
         scale_a,
         scale_b,
         out_dtype,
-        "auto",
+        bmm_fp8_backend(),
     ).view(a.shape[0], b.shape[1])
 
     if bias is not None:
@@ -914,7 +956,7 @@ def flashinfer_scaled_fp8_mm_out(
         scale_b,
         out_dtype or out.dtype,
         out.unsqueeze(0),
-        "auto",
+        bmm_fp8_backend(),
     )
     return out
 


### PR DESCRIPTION
### Purpose

`FlashInferFP8ScaledMMLinearKernel` runs FP8 linears through `bmm_fp8(backend="auto")`. On sm_12x GPUs (RTX PRO 6000, RTX 50, GB10), `"auto"` picks cuDNN, which builds a GEMM graph for every new shape inside the serving loop. This stalls the engine 12-17 s per new prompt length, GPU at 0%.

`"cublas"` is FlashInfer's own default for `bmm_fp8`. The `"auto"` comes from vLLM. This PR keeps the kernel on and pins `"cublas"` on sm_12x only. Other GPUs keep `"auto"`.

(Reworked from the first version that gated the kernel off sm_12x. Per review, the backend pin keeps the kernel in use.)

### Change (3 files, +99/-4)

- `flashinfer.py`: new `bmm_fp8_backend()` helper returns `"cublas"` on sm_12x, else `"auto"`. Uses `@torch.compiler.assume_constant_result` (`functools.cache` crashes `torch.compile` here).
- `collective_fusion.py`: the two AsyncTP patterns use the same helper, so they still match `bmm_fp8`.
- new test: `is_supported` over cc {90,100,103,120,121}, plus the backend pin.

### Test Result (RTX PRO 6000, sm_120, Nemotron-3-Super-120B-NVFP4, ShareGPT, c=8)

| Metric | before (cuDNN) | this PR (cublas) |
|---|---:|---:|
| Output throughput | 47.8 tok/s | 210.3 tok/s |
| Median TTFT | 38.6 s | 5.8 s |
| Median TPOT | 46.8 ms | 18.7 ms |
| Novel-shape latency | 12-17 s | 0.5-1.3 s |
| Failed requests | 0 | 0 |

Kernel stays FlashInfer (no CUTLASS fallback). Tests 12/12 pass.

### Relation to flashinfer#3566

The crash half is already fixed in flashinfer 0.6.13. The stall is structural on flashinfer main. This pin fixes the stall on the vLLM side and can be relaxed once flashinfer builds cuDNN plans off the hot path.
