### PR TITLE
[Model][CI/Build] Cosmos3: enable registry tests and register Cosmos3-Super

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -514,7 +514,7 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `ChameleonForConditionalGeneration` | Chameleon | T + I | `facebook/chameleon-7b`, etc. | | ✅︎ |
 | `CheersForConditionalGeneration` | Cheers | T + I | `ai9stars/Cheers` | | ✅︎ |
 | `Cohere2VisionForConditionalGeneration` | Command A Vision, Command-A+ | T + I<sup>+</sup> | `CohereLabs/command-a-vision-07-2025`, `CohereLabs/command-a-plus-05-2026`, etc. | | ✅︎ |
-| `Cosmos3ForConditionalGeneration` | Cosmos3 (understanding tower) | T + I<sup>E+</sup> + V<sup>E+</sup> | `nvidia/Cosmos3-Nano` | | ✅︎ |
+| `Cosmos3ForConditionalGeneration` | Cosmos3 (understanding tower) | T + I<sup>E+</sup> + V<sup>E+</sup> | `nvidia/Cosmos3-Nano`, `nvidia/Cosmos3-Super` | | ✅︎ |
 | `DeepseekVLV2ForCausalLM` | DeepSeek-VL2 | T + I<sup>+</sup> | `deepseek-ai/deepseek-vl2-tiny`, `deepseek-ai/deepseek-vl2-small`, `deepseek-ai/deepseek-vl2`, etc. | | ✅︎ |
 | `DeepseekOCRForCausalLM` | DeepSeek-OCR | T + I<sup>+</sup> | `deepseek-ai/DeepSeek-OCR`, etc. | ✅︎ | ✅︎ |
 | `DeepseekOCR2ForCausalLM` | DeepSeek-OCR-2 | T + I<sup>+</sup> | `deepseek-ai/DeepSeek-OCR-2`, etc. | ✅︎ | ✅︎ |

--- a/tests/models/multimodal/generation/test_common.py
+++ b/tests/models/multimodal/generation/test_common.py
@@ -369,6 +369,12 @@ VLM_TEST_SETTINGS = {
         vllm_output_post_proc=model_utils.qwen2_vllm_to_hf_output,
         patch_hf_runner=model_utils.qwen3_vl_patch_hf_runner,
         image_size_factors=[(0.25,), (0.25, 0.25, 0.25), (0.25, 0.2, 0.15)],
+        marks=[
+            pytest.mark.skip(
+                reason="Transformers has no cosmos3_omni mapping, so the HF "
+                "reference runner cannot load the checkpoint."
+            )
+        ],
     ),
     "deepseek_vl_v2": VLMTestInfo(
         models=["Isotr0py/deepseek-vl2-tiny"],  # model repo using dynamic module

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -803,9 +803,9 @@ _MULTIMODAL_EXAMPLE_MODELS = {
     ),
     "Cosmos3ForConditionalGeneration": _HfExamplesInfo(
         "nvidia/Cosmos3-Nano",
+        extras={"super": "nvidia/Cosmos3-Super"},
         max_model_len=4096,
         min_transformers_version="4.57",
-        is_available_online=False,
     ),
     "DeepseekVLV2ForCausalLM": _HfExamplesInfo(
         "deepseek-ai/deepseek-vl2-tiny",


### PR DESCRIPTION
## Purpose

`is_available_online=False` was set on the Cosmos3 registry entry in #43356 because the checkpoint wasn't published yet. `nvidia/Cosmos3-Nano` went public days after the merge, but the flag stayed, so the registry-driven tests (initialization, multimodal processing, tensor schema) still skip this architecture.

This PR:

- Removes the stale flag.
- Registers `nvidia/Cosmos3-Super` as an `extras` model and lists it in `supported_models.md`. It declares the same `Cosmos3ForConditionalGeneration` / `cosmos3_omni` and has the same checkpoint layout; running both checkpoints' weight keys through `hf_to_vllm_mapper` gives identical module shapes and identical dropped (generator-tower) namespaces — Super is just deeper (64 vs 36 layers). Note `extras` only gets processor coverage in CI; the 32B reasoner is not initialized. Happy to drop the Super part if preferred.
- Explicitly skips the `cosmos3` VLM generation test: Transformers has no `cosmos3_omni` mapping, so the HF reference runner can't load the checkpoint. Previously this was silently disabled by the availability flag.

## Test Plan

```bash
pytest tests/models/test_initialization.py -k Cosmos3 -v
pytest tests/models/multimodal/processing/test_common.py -k Cosmos3 -v
pytest tests/models/multimodal/generation/test_common.py -k cosmos3 -v
```

## Test Result

On 1×RTX 5090, torch 2.11.0+cu130:

```
test_initialization.py::test_can_initialize_large_subset[Cosmos3ForConditionalGeneration] PASSED

processing/test_common.py -k Cosmos3
  before: 3 skipped (Model is not available online)
  after:  6 passed  (3 Nano + 3 Super)

generation/test_common.py -k cosmos3
  SKIPPED [9] Transformers has no cosmos3_omni mapping, so the HF reference runner cannot load the checkpoint.
```

As a sanity check beyond CI (which only uses dummy weights), I also served the real Nano checkpoint and ran image→text prompts; outputs are correct (e.g. stop sign described as "red and octagonal... says STOP in white letters").

No open PR or issue touches Cosmos3 (searched "cosmos"/"Cosmos3" in open PRs and issues). Written with AI assistance (Claude); I reviewed every changed line and ran the tests above.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
