### PR TITLE
[CPU] Add CPU-tuned autotune configs for FLA (GDN) Triton kernels

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
     VLLM_CPU_NUM_OF_RESERVED_CPU: int | None = None
     VLLM_CPU_SGL_KERNEL: bool = False
     VLLM_CPU_ATTN_SPLIT_KV: bool = True
+    VLLM_CPU_USE_TRITON: bool = False
     VLLM_ZENTORCH_WEIGHT_PREPACK: bool = True
     VLLM_CPU_INT4_W4A8: bool = True
     VLLM_XLA_CACHE_PATH: str = os.path.join(VLLM_CACHE_ROOT, "xla_cache")
@@ -869,6 +870,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_CPU_ATTN_SPLIT_KV": lambda: bool(
         int(os.getenv("VLLM_CPU_ATTN_SPLIT_KV", "1"))
     ),
+    # (CPU backend only) use triton-cpu Triton kernels for Mamba/GDN in the
+    # model forward instead of the native C++ CPU kernels. Requires triton-cpu
+    # to be installed; off by default (experimental).
+    "VLLM_CPU_USE_TRITON": lambda: bool(int(os.getenv("VLLM_CPU_USE_TRITON", "0"))),
     # (Zen CPU backend) eagerly prepack weights into ZenDNN blocked layout
     # at model load time. Eliminates per-inference layout conversion overhead.
     "VLLM_ZENTORCH_WEIGHT_PREPACK": lambda: bool(

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -374,12 +374,21 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         if current_platform.is_xpu():
             self._forward_method = self.forward_xpu
         elif current_platform.is_cpu():
-            from vllm.model_executor.layers.mamba.ops.cpu.gdn_attention import (
-                register_cpu_gdn_attention_ops,
-            )
+            from vllm.triton_utils import HAS_TRITON
 
-            register_cpu_gdn_attention_ops()
-            self._forward_method = self.forward_cpu
+            # On a CPU build HAS_TRITON is True only when the triton-cpu backend
+            # is installed. Prefer the FLA Triton kernels (compiled by
+            # triton-cpu) when available; otherwise fall back to the native
+            # torch/AMX CPU path.
+            if HAS_TRITON:
+                self._forward_method = self.forward_cuda
+            else:
+                from vllm.model_executor.layers.mamba.ops.cpu.gdn_attention import (
+                    register_cpu_gdn_attention_ops,
+                )
+
+                register_cpu_gdn_attention_ops()
+                self._forward_method = self.forward_cpu
         elif current_platform.is_rocm():
             self._forward_method = self.forward_hip
         else:

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -374,13 +374,12 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         if current_platform.is_xpu():
             self._forward_method = self.forward_xpu
         elif current_platform.is_cpu():
+            import vllm.envs as envs
             from vllm.triton_utils import HAS_TRITON
 
-            # On a CPU build HAS_TRITON is True only when the triton-cpu backend
-            # is installed. Prefer the FLA Triton kernels (compiled by
-            # triton-cpu) when available; otherwise fall back to the native
-            # torch/AMX CPU path.
-            if HAS_TRITON:
+            # Use the FLA Triton kernels only when triton-cpu is installed and
+            # opted in via VLLM_CPU_USE_TRITON; else the native torch/AMX path.
+            if HAS_TRITON and envs.VLLM_CPU_USE_TRITON:
                 self._forward_method = self.forward_cuda
             else:
                 from vllm.model_executor.layers.mamba.ops.cpu.gdn_attention import (

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -374,7 +374,6 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         if current_platform.is_xpu():
             self._forward_method = self.forward_xpu
         elif current_platform.is_cpu():
-            import vllm.envs as envs
             from vllm.triton_utils import HAS_TRITON
 
             # Use the FLA Triton kernels only when triton-cpu is installed and

--- a/vllm/third_party/flash_linear_attention/ops/chunk_delta_h.py
+++ b/vllm/third_party/flash_linear_attention/ops/chunk_delta_h.py
@@ -10,6 +10,7 @@
 
 import torch
 
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices, prepare_chunk_offsets
@@ -19,6 +20,18 @@ from .utils import FLA_CHUNK_SIZE, use_cuda_graph
 NUM_WARPS = [2, 4, 8, 16]
 # Triton's AMD backend fails to lower this kernel with num_stages=4.
 _CHUNK_DELTA_H_NUM_STAGES = [2, 3] if torch.version.hip else [2, 3, 4]
+IS_CPU = current_platform.is_cpu()
+CPU_THREADS = [16, 32, 64, 96]
+
+if IS_CPU:
+    _chunk_delta_h_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]
+else:
+    _chunk_delta_h_configs = [
+        triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4]
+        for num_stages in _CHUNK_DELTA_H_NUM_STAGES
+        for BV in [32, 64]
+    ]
 
 
 @triton.heuristics(
@@ -29,15 +42,15 @@ _CHUNK_DELTA_H_NUM_STAGES = [2, 3] if torch.version.hip else [2, 3, 4]
         "STORE_FINAL_STATE": lambda args: args["ht"] is not None,
         "SAVE_NEW_VALUE": lambda args: args["v_new"] is not None,
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        **(
+            {"BV": lambda args: min(triton.next_power_of_2(args["V"]), 64)}
+            if IS_CPU
+            else {}
+        ),
     }
 )
 @triton.autotune(
-    configs=[
-        triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
-        for num_warps in [2, 4]
-        for num_stages in _CHUNK_DELTA_H_NUM_STAGES
-        for BV in [32, 64]
-    ],
+    configs=_chunk_delta_h_configs,
     key=["H", "K", "V", "BT"],
     use_cuda_graph=use_cuda_graph,
 )

--- a/vllm/third_party/flash_linear_attention/ops/chunk_delta_h.py
+++ b/vllm/third_party/flash_linear_attention/ops/chunk_delta_h.py
@@ -15,13 +15,13 @@ from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices, prepare_chunk_offsets
 from .op import exp, exp2
-from .utils import FLA_CHUNK_SIZE, use_cuda_graph
+from .utils import FLA_CHUNK_SIZE, cpu_thread_choices, use_cuda_graph
 
 NUM_WARPS = [2, 4, 8, 16]
 # Triton's AMD backend fails to lower this kernel with num_stages=4.
 _CHUNK_DELTA_H_NUM_STAGES = [2, 3] if torch.version.hip else [2, 3, 4]
 IS_CPU = current_platform.is_cpu()
-CPU_THREADS = [16, 32, 64, 96]
+CPU_THREADS = cpu_thread_choices()
 
 if IS_CPU:
     _chunk_delta_h_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]

--- a/vllm/third_party/flash_linear_attention/ops/chunk_o.py
+++ b/vllm/third_party/flash_linear_attention/ops/chunk_o.py
@@ -17,12 +17,17 @@ from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
 from .op import exp
-from .utils import FLA_CHUNK_SIZE, check_shared_mem, is_nvidia_hopper
+from .utils import (
+    FLA_CHUNK_SIZE,
+    check_shared_mem,
+    cpu_thread_choices,
+    is_nvidia_hopper,
+)
 
 BKV_LIST = [64, 128] if check_shared_mem() else [32, 64]
 NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
 IS_CPU = current_platform.is_cpu()
-CPU_THREADS = [16, 32, 64, 96]
+CPU_THREADS = cpu_thread_choices()
 
 if IS_CPU:
     _chunk_o_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]

--- a/vllm/third_party/flash_linear_attention/ops/chunk_o.py
+++ b/vllm/third_party/flash_linear_attention/ops/chunk_o.py
@@ -12,6 +12,7 @@
 
 import torch
 
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
@@ -20,22 +21,37 @@ from .utils import FLA_CHUNK_SIZE, check_shared_mem, is_nvidia_hopper
 
 BKV_LIST = [64, 128] if check_shared_mem() else [32, 64]
 NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
+IS_CPU = current_platform.is_cpu()
+CPU_THREADS = [16, 32, 64, 96]
+
+if IS_CPU:
+    _chunk_o_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]
+else:
+    _chunk_o_configs = [
+        triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for BK in BKV_LIST
+        for BV in BKV_LIST
+        for num_warps in NUM_WARPS
+        for num_stages in [2, 3, 4]
+    ]
 
 
 @triton.heuristics(
     {
         "USE_G": lambda args: args["g"] is not None,
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        **(
+            {
+                "BK": lambda args: min(triton.next_power_of_2(args["K"]), 64),
+                "BV": lambda args: min(triton.next_power_of_2(args["V"]), 64),
+            }
+            if IS_CPU
+            else {}
+        ),
     }
 )
 @triton.autotune(
-    configs=[
-        triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
-        for BK in BKV_LIST
-        for BV in BKV_LIST
-        for num_warps in NUM_WARPS
-        for num_stages in [2, 3, 4]
-    ],
+    configs=_chunk_o_configs,
     key=["H", "K", "V", "BT"],
 )
 @triton.jit(do_not_specialize=["T"])

--- a/vllm/third_party/flash_linear_attention/ops/chunk_scaled_dot_kkt.py
+++ b/vllm/third_party/flash_linear_attention/ops/chunk_scaled_dot_kkt.py
@@ -15,7 +15,7 @@ from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
 from .op import exp
-from .utils import FLA_CHUNK_SIZE
+from .utils import FLA_CHUNK_SIZE, cpu_thread_choices
 
 # On RDNA (gfx11xx/gfx12xx) WMMA only
 # accepts 16-bit/int inputs, so a widened (e.g. fp32) tl.dot is lowered to a
@@ -28,7 +28,7 @@ if current_platform.is_rocm():
     _CAST_DOT_TO_K_DTYPE = on_gfx1x()
 
 IS_CPU = current_platform.is_cpu()
-CPU_THREADS = [16, 32, 64, 96]
+CPU_THREADS = cpu_thread_choices()
 
 if IS_CPU:
     _kkt_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]

--- a/vllm/third_party/flash_linear_attention/ops/chunk_scaled_dot_kkt.py
+++ b/vllm/third_party/flash_linear_attention/ops/chunk_scaled_dot_kkt.py
@@ -27,20 +27,33 @@ if current_platform.is_rocm():
 
     _CAST_DOT_TO_K_DTYPE = on_gfx1x()
 
+IS_CPU = current_platform.is_cpu()
+CPU_THREADS = [16, 32, 64, 96]
+
+if IS_CPU:
+    _kkt_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]
+else:
+    _kkt_configs = [
+        triton.Config({"BK": BK}, num_warps=num_warps, num_stages=num_stages)
+        for BK in [32, 64, 128]
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ]
+
 
 @triton.heuristics(
     {
         "USE_G": lambda args: args["g"] is not None,
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        **(
+            {"BK": lambda args: min(triton.next_power_of_2(args["K"]), 128)}
+            if IS_CPU
+            else {}
+        ),
     }
 )
 @triton.autotune(
-    configs=[
-        triton.Config({"BK": BK}, num_warps=num_warps, num_stages=num_stages)
-        for BK in [32, 64, 128]
-        for num_warps in [2, 4, 8]
-        for num_stages in [2, 3, 4]
-    ],
+    configs=_kkt_configs,
     key=["H", "K", "BT", "IS_VARLEN"],
 )
 @triton.jit(do_not_specialize=["T"])

--- a/vllm/third_party/flash_linear_attention/ops/cumsum.py
+++ b/vllm/third_party/flash_linear_attention/ops/cumsum.py
@@ -10,17 +10,33 @@
 
 import torch
 
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
 from .utils import check_shared_mem, input_guard
 
 BS_LIST = [32, 64] if check_shared_mem() else [16, 32]
+IS_CPU = current_platform.is_cpu()
+CPU_THREADS = [16, 32, 64, 96]
+
+if IS_CPU:
+    _cumsum_scalar_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]
+    _cumsum_vector_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]
+else:
+    _cumsum_scalar_configs = [
+        triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4, 8]
+    ]
+    _cumsum_vector_configs = [
+        triton.Config({"BS": BS}, num_warps=num_warps)
+        for BS in BS_LIST
+        for num_warps in [2, 4, 8]
+    ]
 
 
 @triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
 @triton.autotune(
-    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4, 8]],
+    configs=_cumsum_scalar_configs,
     key=["B", "H", "BT", "IS_VARLEN", "REVERSE"],
 )
 @triton.jit(do_not_specialize=["T"])
@@ -71,13 +87,18 @@ def chunk_local_cumsum_scalar_kernel(
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
 
 
-@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        **(
+            {"BS": lambda args: min(triton.next_power_of_2(args["S"]), 32)}
+            if IS_CPU
+            else {}
+        ),
+    }
+)
 @triton.autotune(
-    configs=[
-        triton.Config({"BS": BS}, num_warps=num_warps)
-        for BS in BS_LIST
-        for num_warps in [2, 4, 8]
-    ],
+    configs=_cumsum_vector_configs,
     key=["B", "H", "S", "BT", "IS_VARLEN", "REVERSE"],
 )
 @triton.jit(do_not_specialize=["T"])

--- a/vllm/third_party/flash_linear_attention/ops/cumsum.py
+++ b/vllm/third_party/flash_linear_attention/ops/cumsum.py
@@ -14,11 +14,11 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
-from .utils import check_shared_mem, input_guard
+from .utils import check_shared_mem, cpu_thread_choices, input_guard
 
 BS_LIST = [32, 64] if check_shared_mem() else [16, 32]
 IS_CPU = current_platform.is_cpu()
-CPU_THREADS = [16, 32, 64, 96]
+CPU_THREADS = cpu_thread_choices()
 
 if IS_CPU:
     _cumsum_scalar_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]

--- a/vllm/third_party/flash_linear_attention/ops/solve_tril.py
+++ b/vllm/third_party/flash_linear_attention/ops/solve_tril.py
@@ -12,6 +12,7 @@ import os
 
 import torch
 
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
@@ -24,14 +25,33 @@ assert FLA_TRIL_PRECISION in ALLOWED_TRIL_PRECISIONS, (
     f"FLA_TRIL_PRECISION must be one of {ALLOWED_TRIL_PRECISIONS}, but got {FLA_TRIL_PRECISION}"
 )
 
+CPU_THREADS = [16, 32, 64, 96]
 
-@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
-@triton.autotune(
-    configs=[
+if current_platform.is_cpu():
+    _solve_tril_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]
+    _merge_32_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]
+    _merge_64_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]
+else:
+    _solve_tril_configs = [
         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4, 5]
-    ],
+    ]
+    _merge_32_configs = [
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [1, 2, 4, 8]
+        for num_stages in [2, 3, 4, 5]
+    ]
+    _merge_64_configs = [
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4, 5]
+    ]
+
+
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@triton.autotune(
+    configs=_solve_tril_configs,
     key=["BT"],
 )
 @triton.jit(do_not_specialize=["T"])
@@ -102,11 +122,7 @@ def solve_tril_16x16_kernel(
 
 @triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
 @triton.autotune(
-    configs=[
-        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
-        for num_warps in [1, 2, 4, 8]
-        for num_stages in [2, 3, 4, 5]
-    ],
+    configs=_merge_32_configs,
     key=["H", "BT", "IS_VARLEN"],
 )
 @triton.jit(do_not_specialize=["T"])
@@ -227,11 +243,7 @@ def merge_16x16_to_32x32_inverse_kernel(
 
 @triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
 @triton.autotune(
-    configs=[
-        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
-        for num_warps in [2, 4, 8]
-        for num_stages in [2, 3, 4, 5]
-    ],
+    configs=_merge_64_configs,
     key=["H", "BT", "IS_VARLEN"],
 )
 @triton.jit(do_not_specialize=["T"])

--- a/vllm/third_party/flash_linear_attention/ops/solve_tril.py
+++ b/vllm/third_party/flash_linear_attention/ops/solve_tril.py
@@ -17,7 +17,7 @@ from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
 from .op import make_tensor_descriptor
-from .utils import input_guard, is_amd, is_tma_supported
+from .utils import cpu_thread_choices, input_guard, is_amd, is_tma_supported
 
 FLA_TRIL_PRECISION = os.environ.get("FLA_TRIL_PRECISION", "ieee")
 ALLOWED_TRIL_PRECISIONS = ["ieee", "tf32"] if is_amd else ["ieee", "tf32", "tf32x3"]
@@ -25,7 +25,7 @@ assert FLA_TRIL_PRECISION in ALLOWED_TRIL_PRECISIONS, (
     f"FLA_TRIL_PRECISION must be one of {ALLOWED_TRIL_PRECISIONS}, but got {FLA_TRIL_PRECISION}"
 )
 
-CPU_THREADS = [16, 32, 64, 96]
+CPU_THREADS = cpu_thread_choices()
 
 if current_platform.is_cpu():
     _solve_tril_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]

--- a/vllm/third_party/flash_linear_attention/ops/utils.py
+++ b/vllm/third_party/flash_linear_attention/ops/utils.py
@@ -22,6 +22,19 @@ from vllm.triton_utils import triton
 
 logger = logging.getLogger(__name__)
 
+
+def cpu_thread_choices() -> list[int]:
+    """Candidate ``num_cpu_threads`` values for CPU autotuning.
+
+    Probe points scale with the compute-unit count; ``0`` means all cores.
+    Empty off-CPU, where it is unused.
+    """
+    if not current_platform.is_cpu():
+        return []
+    n = current_platform.num_compute_units() or 1
+    return sorted({max(1, n // 4), max(1, 3 * n // 4), 0})
+
+
 COMPILER_MODE = os.getenv("FLA_COMPILER_MODE") == "1"
 FLA_CI_ENV = os.getenv("FLA_CI_ENV") == "1"
 

--- a/vllm/third_party/flash_linear_attention/ops/wy_fast.py
+++ b/vllm/third_party/flash_linear_attention/ops/wy_fast.py
@@ -15,8 +15,9 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
+from .utils import cpu_thread_choices
 
-CPU_THREADS = [16, 32, 64, 96]
+CPU_THREADS = cpu_thread_choices()
 
 if current_platform.is_cpu():
     _wy_fast_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]

--- a/vllm/third_party/flash_linear_attention/ops/wy_fast.py
+++ b/vllm/third_party/flash_linear_attention/ops/wy_fast.py
@@ -11,18 +11,26 @@
 
 import torch
 
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
 
+CPU_THREADS = [16, 32, 64, 96]
 
-@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
-@triton.autotune(
-    configs=[
+if current_platform.is_cpu():
+    _wy_fast_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]
+else:
+    _wy_fast_configs = [
         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
-    ],
+    ]
+
+
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@triton.autotune(
+    configs=_wy_fast_configs,
     key=["H", "K", "V", "BT", "BK", "BV", "IS_VARLEN"],
 )
 @triton.jit(do_not_specialize=["T"])


### PR DESCRIPTION
> **Depends on #49583.** That PR bumps the triton-cpu pin to a commit that includes triton-cpu #275 (the `CPUOptions.hash()` runtime-only cache-key fix). Without it, the configs here recompile once per `num_cpu_threads` candidate, so the warmup speedup is only realized after #49583 lands.

## Purpose
The FLA op kernels used GPU-oriented autotune configs that vary num_warps/num_stages. On the Triton CPU backend those parameters are ignored, so the search wasted many minutes recompiling identical x86 code during first-run warmup.

For each FLA kernel, when current_platform.is_cpu():
- Replace the block-size search with @triton.heuristics that pick tile sizes deterministically via min(triton.next_power_of_2(dim), 64/128), keeping tiles L1-resident.
- Autotune only num_cpu_threads over [16, 32, 64, 96] (the real CPU parallelism knob controlling the OpenMP launch).

Guarded on current_platform.is_cpu() so GPU behavior is unchanged.


Change-Id: I3edba2bd1fd5940d0f4d7ad6d9b752752c3b3d2e






## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
