### PR TITLE
[CPU] Add CPU-tuned autotune configs for Mamba2/SSD Triton kernels

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
     VLLM_CPU_NUM_OF_RESERVED_CPU: int | None = None
     VLLM_CPU_SGL_KERNEL: bool = False
     VLLM_CPU_ATTN_SPLIT_KV: bool = True
+    VLLM_CPU_USE_TRITON: bool = False
     VLLM_ZENTORCH_WEIGHT_PREPACK: bool = True
     VLLM_CPU_INT4_W4A8: bool = True
     VLLM_XLA_CACHE_PATH: str = os.path.join(VLLM_CACHE_ROOT, "xla_cache")
@@ -869,6 +870,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_CPU_ATTN_SPLIT_KV": lambda: bool(
         int(os.getenv("VLLM_CPU_ATTN_SPLIT_KV", "1"))
     ),
+    # (CPU backend only) use triton-cpu Triton kernels for Mamba/GDN in the
+    # model forward instead of the native C++ CPU kernels. Requires triton-cpu
+    # to be installed; off by default (experimental).
+    "VLLM_CPU_USE_TRITON": lambda: bool(int(os.getenv("VLLM_CPU_USE_TRITON", "0"))),
     # (Zen CPU backend) eagerly prepack weights into ZenDNN blocked layout
     # at model load time. Eliminates per-inference layout conversion overhead.
     "VLLM_ZENTORCH_WEIGHT_PREPACK": lambda: bool(

--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -1240,8 +1240,9 @@ def causal_conv1d_update(
 
 
 from vllm.platforms import current_platform  # noqa: E402
+from vllm.triton_utils import HAS_TRITON  # noqa: E402
 
-if current_platform.is_cpu():
+if current_platform.is_cpu() and not HAS_TRITON:
     from vllm.model_executor.layers.mamba.ops.cpu.causal_conv1d import (
         causal_conv1d_fn_cpu,
         causal_conv1d_update_cpu,

--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -1239,10 +1239,11 @@ def causal_conv1d_update(
     return out.to(original_x_dtype)
 
 
+import vllm.envs as envs  # noqa: E402
 from vllm.platforms import current_platform  # noqa: E402
 from vllm.triton_utils import HAS_TRITON  # noqa: E402
 
-if current_platform.is_cpu() and not HAS_TRITON:
+if current_platform.is_cpu() and not (HAS_TRITON and envs.VLLM_CPU_USE_TRITON):
     from vllm.model_executor.layers.mamba.ops.cpu.causal_conv1d import (
         causal_conv1d_fn_cpu,
         causal_conv1d_update_cpu,

--- a/vllm/model_executor/layers/mamba/ops/ssd_bmm.py
+++ b/vllm/model_executor/layers/mamba/ops/ssd_bmm.py
@@ -8,11 +8,19 @@
 
 import torch
 
+from vllm.model_executor.layers.mamba.ops.triton_helpers import cpu_thread_choices
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 
+CPU_THREADS = cpu_thread_choices()
+IS_CPU = current_platform.is_cpu()
 
-@triton.autotune(
-    configs=[
+if IS_CPU:
+    # Fix tile sizes heuristically on CPU (M/N~chunk_size, K~contraction) and
+    # autotune only the OpenMP thread count, instead of sweeping the block grid.
+    _bmm_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]
+else:
+    _bmm_configs = [
         triton.Config(
             {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 64},
             num_stages=3,
@@ -58,7 +66,28 @@ from vllm.triton_utils import tl, triton
             num_stages=4,
             num_warps=2,
         ),
-    ],
+    ]
+
+
+@triton.heuristics(
+    {
+        **(
+            {
+                "BLOCK_SIZE_M": lambda args: min(
+                    triton.next_power_of_2(args["chunk_size"]), 64
+                ),
+                "BLOCK_SIZE_N": lambda args: min(
+                    triton.next_power_of_2(args["chunk_size"]), 64
+                ),
+                "BLOCK_SIZE_K": lambda args: min(triton.next_power_of_2(args["K"]), 64),
+            }
+            if IS_CPU
+            else {}
+        )
+    }
+)
+@triton.autotune(
+    configs=_bmm_configs,
     key=["chunk_size", "K", "IS_CAUSAL"],
 )
 @triton.jit

--- a/vllm/model_executor/layers/mamba/ops/ssd_chunk_scan.py
+++ b/vllm/model_executor/layers/mamba/ops/ssd_chunk_scan.py
@@ -8,18 +8,24 @@
 
 from packaging import version
 
-from vllm.model_executor.layers.mamba.ops.triton_helpers import fast_exp
+from vllm.model_executor.layers.mamba.ops.triton_helpers import (
+    cpu_thread_choices,
+    fast_exp,
+)
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 
 TRITON_22 = version.parse(triton.__version__) >= version.parse("2.2.0")
 
+CPU_THREADS = cpu_thread_choices()
+IS_CPU = current_platform.is_cpu()
 
-@triton.autotune(
-    configs=[
-        # =================================================================
-        # Higher warp count configs for better latency hiding
-        # More warps = more instructions in flight = better memory latency hiding
-        # =================================================================
+if IS_CPU:
+    # Fix tile sizes heuristically on CPU (M/K~chunk_size, N~hdim) and autotune
+    # only the OpenMP thread count, instead of sweeping the block grid.
+    _chunk_scan_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]
+else:
+    _chunk_scan_configs = [
         triton.Config(
             {"BLOCK_SIZE_M": 32, "BLOCK_SIZE_N": 32, "BLOCK_SIZE_K": 32},
             num_stages=2,
@@ -35,7 +41,6 @@ TRITON_22 = version.parse(triton.__version__) >= version.parse("2.2.0")
             num_stages=2,
             num_warps=8,
         ),
-        # Smaller tiles with more stages for software pipelining
         triton.Config(
             {"BLOCK_SIZE_M": 32, "BLOCK_SIZE_N": 32, "BLOCK_SIZE_K": 32},
             num_stages=3,
@@ -46,9 +51,6 @@ TRITON_22 = version.parse(triton.__version__) >= version.parse("2.2.0")
             num_stages=2,
             num_warps=4,
         ),
-        # =================================================================
-        # Low register pressure configs (num_stages=1) for large dstate
-        # =================================================================
         triton.Config(
             {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 64},
             num_stages=1,
@@ -69,7 +71,6 @@ TRITON_22 = version.parse(triton.__version__) >= version.parse("2.2.0")
             num_stages=1,
             num_warps=4,
         ),
-        # num_stages=2 configs - moderate register pressure
         triton.Config(
             {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 64},
             num_stages=2,
@@ -85,7 +86,6 @@ TRITON_22 = version.parse(triton.__version__) >= version.parse("2.2.0")
             num_stages=2,
             num_warps=4,
         ),
-        # Original configs for larger dstate values
         triton.Config(
             {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 64},
             num_stages=3,
@@ -141,7 +141,30 @@ TRITON_22 = version.parse(triton.__version__) >= version.parse("2.2.0")
             num_stages=4,
             num_warps=2,
         ),
-    ],
+    ]
+
+
+@triton.heuristics(
+    {
+        **(
+            {
+                "BLOCK_SIZE_M": lambda args: min(
+                    triton.next_power_of_2(args["chunk_size"]), 64
+                ),
+                "BLOCK_SIZE_N": lambda args: min(
+                    triton.next_power_of_2(args["hdim"]), 64
+                ),
+                "BLOCK_SIZE_K": lambda args: min(
+                    triton.next_power_of_2(args["chunk_size"]), 64
+                ),
+            }
+            if IS_CPU
+            else {}
+        )
+    }
+)
+@triton.autotune(
+    configs=_chunk_scan_configs,
     key=["chunk_size", "hdim", "dstate", "IS_CAUSAL"],
 )
 @triton.jit

--- a/vllm/model_executor/layers/mamba/ops/ssd_chunk_state.py
+++ b/vllm/model_executor/layers/mamba/ops/ssd_chunk_state.py
@@ -8,21 +8,50 @@
 
 import torch
 
-from vllm.model_executor.layers.mamba.ops.triton_helpers import fast_exp
+from vllm.model_executor.layers.mamba.ops.triton_helpers import (
+    cpu_thread_choices,
+    fast_exp,
+)
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 
 from .mamba_ssm import softplus
 
+CPU_THREADS = cpu_thread_choices()
+IS_CPU = current_platform.is_cpu()
 
-@triton.autotune(
-    configs=[
+if IS_CPU:
+    # On CPU, fix the block size via a heuristic (small, so the tl.cumsum over
+    # the chunk axis stays cheap to compile) and autotune only the OpenMP thread
+    # count. Sweeping BLOCK_SIZE_H here compiles a large [BLOCK_SIZE_H, chunk]
+    # scan per value, which is extremely slow to lower on the CPU backend.
+    _cumsum_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]
+else:
+    _cumsum_configs = [
         triton.Config({"BLOCK_SIZE_H": 2}),
         triton.Config({"BLOCK_SIZE_H": 4}),
         triton.Config({"BLOCK_SIZE_H": 8}),
         triton.Config({"BLOCK_SIZE_H": 16}),
         triton.Config({"BLOCK_SIZE_H": 32}),
         triton.Config({"BLOCK_SIZE_H": 64}),
-    ],
+    ]
+
+
+@triton.heuristics(
+    {
+        **(
+            {
+                "BLOCK_SIZE_H": lambda args: min(
+                    triton.next_power_of_2(args["nheads"]), 8
+                )
+            }
+            if IS_CPU
+            else {}
+        )
+    }
+)
+@triton.autotune(
+    configs=_cumsum_configs,
     key=["chunk_size", "nheads"],
 )
 @triton.jit
@@ -114,9 +143,12 @@ def _chunk_cumsum_fwd_kernel(
     )
 
 
-@triton.autotune(
-    configs=[
-        # Small headdim/dstate configs (hdim<=64, dstate<=128) - increased parallelism
+if current_platform.is_cpu():
+    # Fix tile sizes heuristically on CPU (M~hdim, N~dstate, K~chunk_size) and
+    # autotune only the OpenMP thread count, instead of sweeping the block grid.
+    _chunk_state_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]
+else:
+    _chunk_state_configs = [
         triton.Config(
             {"BLOCK_SIZE_M": 32, "BLOCK_SIZE_N": 32, "BLOCK_SIZE_K": 32},
             num_stages=3,
@@ -132,7 +164,6 @@ def _chunk_cumsum_fwd_kernel(
             num_stages=3,
             num_warps=4,
         ),
-        # Low register pressure configs for large dstate (dstate=128)
         triton.Config(
             {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 64},
             num_stages=2,
@@ -143,7 +174,6 @@ def _chunk_cumsum_fwd_kernel(
             num_stages=2,
             num_warps=4,
         ),
-        # original configs for larger headdim/dstate values
         triton.Config(
             {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 64},
             num_stages=3,
@@ -189,7 +219,30 @@ def _chunk_cumsum_fwd_kernel(
             num_stages=4,
             num_warps=2,
         ),
-    ],
+    ]
+
+
+@triton.heuristics(
+    {
+        **(
+            {
+                "BLOCK_SIZE_M": lambda args: min(
+                    triton.next_power_of_2(args["hdim"]), 64
+                ),
+                "BLOCK_SIZE_N": lambda args: min(
+                    triton.next_power_of_2(args["dstate"]), 128
+                ),
+                "BLOCK_SIZE_K": lambda args: min(
+                    triton.next_power_of_2(args["chunk_size"]), 32
+                ),
+            }
+            if IS_CPU
+            else {}
+        )
+    }
+)
+@triton.autotune(
+    configs=_chunk_state_configs,
     key=["hdim", "dstate", "chunk_size"],
 )
 @triton.jit

--- a/vllm/model_executor/layers/mamba/ops/ssd_combined.py
+++ b/vllm/model_executor/layers/mamba/ops/ssd_combined.py
@@ -228,8 +228,11 @@ def mamba_chunk_scan_combined_varlen(
 
 
 from vllm.platforms import current_platform  # noqa: E402
+from vllm.triton_utils import HAS_TRITON  # noqa: E402
 
-if current_platform.is_cpu():
+# On CPU prefer the triton-cpu SSD kernels when the backend is installed
+# (HAS_TRITON), mirroring the GDN gating; otherwise use the native C++ path.
+if current_platform.is_cpu() and not HAS_TRITON:
     import vllm.model_executor.layers.mamba.ops.cpu.mamba_ssm as cpu_mamba_ssm
 
     _mamba_chunk_scan_combined_fwd = cpu_mamba_ssm._mamba_chunk_scan_combined_fwd_cpu  # type: ignore

--- a/vllm/model_executor/layers/mamba/ops/ssd_combined.py
+++ b/vllm/model_executor/layers/mamba/ops/ssd_combined.py
@@ -227,12 +227,11 @@ def mamba_chunk_scan_combined_varlen(
     return varlen_states
 
 
+import vllm.envs as envs  # noqa: E402
 from vllm.platforms import current_platform  # noqa: E402
 from vllm.triton_utils import HAS_TRITON  # noqa: E402
 
-# On CPU prefer the triton-cpu SSD kernels when the backend is installed
-# (HAS_TRITON), mirroring the GDN gating; otherwise use the native C++ path.
-if current_platform.is_cpu() and not HAS_TRITON:
+if current_platform.is_cpu() and not (HAS_TRITON and envs.VLLM_CPU_USE_TRITON):
     import vllm.model_executor.layers.mamba.ops.cpu.mamba_ssm as cpu_mamba_ssm
 
     _mamba_chunk_scan_combined_fwd = cpu_mamba_ssm._mamba_chunk_scan_combined_fwd_cpu  # type: ignore

--- a/vllm/model_executor/layers/mamba/ops/ssd_state_passing.py
+++ b/vllm/model_executor/layers/mamba/ops/ssd_state_passing.py
@@ -8,19 +8,42 @@
 
 import torch
 
-from vllm.model_executor.layers.mamba.ops.triton_helpers import fast_exp
+from vllm.model_executor.layers.mamba.ops.triton_helpers import (
+    cpu_thread_choices,
+    fast_exp,
+)
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 
+CPU_THREADS = cpu_thread_choices()
+IS_CPU = current_platform.is_cpu()
 
-@triton.autotune(
-    configs=[
+if IS_CPU:
+    # Fix BLOCK_SIZE heuristically on CPU (~dim) and autotune only the OpenMP
+    # thread count, instead of sweeping block sizes.
+    _state_passing_configs = [triton.Config({}, num_cpu_threads=t) for t in CPU_THREADS]
+else:
+    _state_passing_configs = [
         triton.Config({"BLOCK_SIZE": 64}),
         triton.Config({"BLOCK_SIZE": 128}),
         triton.Config({"BLOCK_SIZE": 256}),
         triton.Config({"BLOCK_SIZE": 512}),
         triton.Config({"BLOCK_SIZE": 1024}),
         triton.Config({"BLOCK_SIZE": 2048}),
-    ],
+    ]
+
+
+@triton.heuristics(
+    {
+        **(
+            {"BLOCK_SIZE": lambda args: min(triton.next_power_of_2(args["dim"]), 2048)}
+            if IS_CPU
+            else {}
+        )
+    }
+)
+@triton.autotune(
+    configs=_state_passing_configs,
     key=["dim"],
 )
 @triton.jit

--- a/vllm/model_executor/layers/mamba/ops/ssu_dispatch.py
+++ b/vllm/model_executor/layers/mamba/ops/ssu_dispatch.py
@@ -283,11 +283,14 @@ def initialize_mamba_ssu_backend(
     # backend unless the user explicitly chose something other than "triton".
     if backend == MambaBackendEnum.TRITON:
         from vllm.platforms import current_platform
+        from vllm.triton_utils import HAS_TRITON
 
-        if current_platform.is_cpu():
+        # Prefer triton-cpu SSU when the backend is installed (HAS_TRITON),
+        # mirroring the GDN gating; otherwise use the native C++ CPU kernel.
+        if current_platform.is_cpu() and not HAS_TRITON:
             logger.info(
-                "CPU platform detected: overriding Mamba SSU backend "
-                "from 'triton' to 'cpu'."
+                "CPU platform detected without triton-cpu: overriding Mamba "
+                "SSU backend from 'triton' to 'cpu'."
             )
             backend = MambaBackendEnum.CPU
 

--- a/vllm/model_executor/layers/mamba/ops/ssu_dispatch.py
+++ b/vllm/model_executor/layers/mamba/ops/ssu_dispatch.py
@@ -282,15 +282,16 @@ def initialize_mamba_ssu_backend(
     # unstable or unavailable.  Silently fall back to the CPU
     # backend unless the user explicitly chose something other than "triton".
     if backend == MambaBackendEnum.TRITON:
+        import vllm.envs as envs
         from vllm.platforms import current_platform
         from vllm.triton_utils import HAS_TRITON
 
-        # Prefer triton-cpu SSU when the backend is installed (HAS_TRITON),
-        # mirroring the GDN gating; otherwise use the native C++ CPU kernel.
-        if current_platform.is_cpu() and not HAS_TRITON:
+        if current_platform.is_cpu() and not (
+            HAS_TRITON and envs.VLLM_CPU_USE_TRITON
+        ):
             logger.info(
-                "CPU platform detected without triton-cpu: overriding Mamba "
-                "SSU backend from 'triton' to 'cpu'."
+                "CPU platform detected: overriding Mamba SSU backend from "
+                "'triton' to 'cpu'."
             )
             backend = MambaBackendEnum.CPU
 

--- a/vllm/model_executor/layers/mamba/ops/triton_helpers.py
+++ b/vllm/model_executor/layers/mamba/ops/triton_helpers.py
@@ -1,7 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
+
+
+def cpu_thread_choices() -> list[int]:
+    """Candidate ``num_cpu_threads`` values for CPU autotuning.
+
+    Probe points scale with the compute-unit count; ``0`` means all cores.
+    Empty off-CPU, where it is unused.
+    """
+    if not current_platform.is_cpu():
+        return []
+    n = current_platform.num_compute_units() or 1
+    return sorted({max(1, n // 4), max(1, 3 * n // 4), 0})
 
 
 @triton.jit


### PR DESCRIPTION
> **Depends on #49583.** That PR bumps the triton-cpu pin to a commit that includes triton-cpu #275 (the `CPUOptions.hash()` runtime-only cache-key fix). Without it, the configs here recompile once per `num_cpu_threads` candidate, so the warmup speedup is only realized after #49583 lands.

## Purpose
The SSD op kernels (chunk_scan, bmm, chunk_state, chunk_cumsum, state_passing) used GPU-oriented autotune configs varying num_warps/num_stages. On the Triton CPU backend those are ignored, so the search recompiled many identical x86 kernels, adding tens of minutes of first-run warmup for Mamba-hybrid models (e.g. Granite 4.0).

For each SSD kernel, when current_platform.is_cpu():
- Build a compact CPU config list over block sizes that matter on CPU and autotune num_cpu_threads over [32, 96, 0] (0 = all cores).
- Keep the original GPU config list unchanged in the else branch.

Guarded on current_platform.is_cpu() so GPU behavior is unchanged.


Change-Id: I03b408eb9d65418f0ec330fa3ababef2f9d00f6a





## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
