### PR TITLE
[Core][hybrid attention] group-aware recovery for KV load failures on hybrid models

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -26,17 +26,14 @@ from vllm.multimodal.inputs import (
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.utils.hashing import sha256
 from vllm.v1.core.encoder_cache_manager import EncoderCacheManager
-from vllm.v1.core.kv_cache_coordinator import HybridKVCacheCoordinator
 from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
-from vllm.v1.core.single_type_kv_cache_manager import register_all_kvcache_specs
 from vllm.v1.engine import FinishReason
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
-    MambaSpec,
 )
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
@@ -45,65 +42,6 @@ from vllm.v1.structured_output import StructuredOutputGrammar, StructuredOutputM
 from .utils import EOS_TOKEN_ID, create_requests, create_scheduler, mock_kv
 
 pytestmark = pytest.mark.cpu_test
-
-
-def test_make_scheduled_encoder_input_stats_output_embeddings():
-    scheduler = create_scheduler()
-    mm_features = [
-        MultiModalFeatureSpec(
-            data=MultiModalKwargsItem.dummy(),
-            modality="image",
-            identifier="image-0",
-            mm_position=PlaceholderRange(offset=0, length=196),
-        ),
-        MultiModalFeatureSpec(
-            data=MultiModalKwargsItem.dummy(),
-            modality="video",
-            identifier="video-0",
-            mm_position=PlaceholderRange(offset=200, length=196),
-        ),
-        MultiModalFeatureSpec(
-            data=MultiModalKwargsItem.dummy(),
-            modality="audio",
-            identifier="audio-0",
-            mm_position=PlaceholderRange(offset=400, length=49),
-        ),
-    ]
-    scheduler.requests["req"] = Mock(mm_features=mm_features)
-
-    stats = scheduler._make_scheduled_encoder_input_stats({"req": [0, 1, 2]})
-
-    assert stats is not None
-    assert stats.num_inputs == 3
-    assert stats.output_tokens == 441
-
-
-def test_scheduled_encoder_input_stats_disabled_without_iteration_logging(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    scheduler = create_scheduler()
-    make_stats = Mock(side_effect=AssertionError("stats should not be computed"))
-    monkeypatch.setattr(scheduler, "_make_scheduled_encoder_input_stats", make_stats)
-
-    scheduler_output = scheduler.schedule()
-
-    make_stats.assert_not_called()
-    assert scheduler_output.scheduled_encoder_input_stats is None
-
-
-def test_scheduled_encoder_input_stats_disabled_without_log_stats(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    scheduler = create_scheduler()
-    scheduler.log_stats = False
-    scheduler.observability_config.enable_logging_iteration_details = True
-    make_stats = Mock(side_effect=AssertionError("stats should not be computed"))
-    monkeypatch.setattr(scheduler, "_make_scheduled_encoder_input_stats", make_stats)
-
-    scheduler_output = scheduler.schedule()
-
-    make_stats.assert_not_called()
-    assert scheduler_output.scheduled_encoder_input_stats is None
 
 
 def test_add_requests():
@@ -169,29 +107,6 @@ def test_schedule(enable_prefix_caching: bool, prompt_logprobs: int | None):
     assert len(scheduler.running) == len(requests)
     for i, request in enumerate(requests):
         assert scheduler.running[i] == request
-
-
-def test_scheduler_stats_route_to_existing_output_client():
-    scheduler = create_scheduler()
-    request = create_requests(num_requests=1)[0]
-    request.client_index = 1
-    scheduler.add_request(request)
-
-    scheduler_output = scheduler.schedule()
-    model_output = ModelRunnerOutput(
-        req_ids=[request.request_id],
-        req_id_to_index={request.request_id: 0},
-        sampled_token_ids=[[1000]],
-        logprobs=None,
-        prompt_logprobs_dict={},
-        pooler_output=[],
-    )
-
-    engine_core_outputs = scheduler.update_from_output(scheduler_output, model_output)
-
-    assert 0 not in engine_core_outputs
-    assert engine_core_outputs[1].scheduler_stats is not None
-    assert len(engine_core_outputs[1].outputs) == 1
 
 
 def test_schedule_multimodal_requests():
@@ -1072,141 +987,6 @@ def test_preempt_during_execution():
     assert requests[1].output_token_ids[0] == 42
 
 
-def test_prefix_cache_query_not_inflated_by_connector_defer():
-    """The GPU prefix-cache query is recorded at admission, so a request the
-    connector defers several times is counted once, not once per retry."""
-    num_defers_before_matching = 3
-    scheduler = create_scheduler(
-        enable_prefix_caching=True,
-        use_kv_connector=mock_kv(
-            matched_tokens=0,
-            is_async=False,
-            num_defers_before_matching=num_defers_before_matching,
-        ),
-    )
-    request = create_requests(num_requests=1, num_tokens=32, block_size=16)[0]
-    scheduler.add_request(request)
-
-    # Each deferred step re-runs the lookup but records nothing.
-    for _ in range(num_defers_before_matching):
-        assert not scheduler.schedule().scheduled_new_reqs
-
-    output = scheduler.schedule()
-    assert any(r.req_id == request.request_id for r in output.scheduled_new_reqs)
-
-    stats = scheduler.kv_cache_manager.prefix_cache_stats
-    assert stats is not None
-    assert stats.requests == 1
-    assert stats.queries == request.num_tokens
-
-
-def test_preemption_re_records_prefix_cache_query():
-    """A preempted request re-enters the lookup on resume, so its recomputation
-    is counted again into the preempted stats."""
-    scheduler = create_scheduler(enable_prefix_caching=True)
-    request = create_requests(num_requests=1)[0]
-    scheduler.add_request(request)
-
-    scheduler.schedule()
-    stats = scheduler.kv_cache_manager.prefix_cache_stats
-    assert stats is not None
-    assert (stats.requests, stats.preempted_requests) == (1, 0)
-
-    scheduler.running.remove(request)
-    scheduler._preempt_request(request, 0.0)
-    assert request.status == RequestStatus.PREEMPTED
-
-    scheduler.schedule()
-    assert request.status == RequestStatus.RUNNING
-    assert stats.preempted_requests == 1
-
-
-def test_prefix_cache_stats_not_recorded_when_caching_disabled():
-    """With prefix caching off there is no local lookup, so admitting a request
-    records no phantom miss."""
-    scheduler = create_scheduler(enable_prefix_caching=False)
-    for request in create_requests(num_requests=2):
-        scheduler.add_request(request)
-
-    scheduler.schedule()
-
-    stats = scheduler.kv_cache_manager.prefix_cache_stats
-    assert stats is not None
-    assert (stats.requests, stats.queries, stats.hits) == (0, 0, 0)
-
-
-def test_prefix_cache_stats_counted_once_for_retried_then_scheduled_request():
-    """A real cache hit rejected once by allocate_slots and admitted on the next
-    step is counted exactly once, hits included."""
-    block_size = 16
-    scheduler = create_scheduler(
-        enable_prefix_caching=True,
-        enable_chunked_prefill=False,
-        block_size=block_size,
-    )
-
-    # Seed the cache so the next request with the same prompt hits it.
-    seed = create_requests(
-        num_requests=1,
-        num_tokens=block_size * 2,
-        max_tokens=2,
-        same_prompt=True,
-        block_size=block_size,
-        req_ids=["seed"],
-    )[0]
-    scheduler.add_request(seed)
-    _step_until_done(
-        scheduler,
-        scheduler.schedule(),
-        ModelRunnerOutput(
-            req_ids=["seed"],
-            req_id_to_index={"seed": 0},
-            sampled_token_ids=[[1000]],
-            logprobs=None,
-            prompt_logprobs_dict={},
-            pooler_output=[],
-        ),
-    )
-
-    # The seeding step swapped in a fresh accumulator, so re-read it; the
-    # retried request must be the only thing recorded from here on.
-    stats = scheduler.kv_cache_manager.prefix_cache_stats
-    assert stats is not None
-    assert (stats.requests, stats.queries, stats.hits) == (0, 0, 0)
-
-    retried = create_requests(
-        num_requests=1,
-        num_tokens=block_size * 3,
-        max_tokens=1,
-        same_prompt=True,
-        block_size=block_size,
-        req_ids=["retried"],
-    )[0]
-    scheduler.add_request(retried)
-
-    # Reject the first allocation attempt, then delegate to the real one.
-    orig_allocate_slots = scheduler.kv_cache_manager.allocate_slots
-    allocate_results: list = []
-
-    def spy_allocate_slots(*args, **kwargs):
-        result = None if not allocate_results else orig_allocate_slots(*args, **kwargs)
-        allocate_results.append(result)
-        return result
-
-    scheduler.kv_cache_manager.allocate_slots = spy_allocate_slots
-
-    assert not scheduler.schedule().scheduled_new_reqs
-    assert (stats.requests, stats.queries, stats.hits) == (0, 0, 0)
-
-    assert "retried" in scheduler.schedule().num_scheduled_tokens
-    assert allocate_results[0] is None and allocate_results[1] is not None
-    assert (stats.requests, stats.queries, stats.hits) == (
-        1,
-        retried.num_tokens,
-        block_size * 2,
-    )
-
-
 def test_scheduler_reset_prefix_cache():
     scheduler = create_scheduler(enable_prefix_caching=True)
     requests = create_requests(num_requests=10)
@@ -1575,41 +1355,6 @@ def test_spec_decode_padding_first_decode_step():
     # r2 is padded to the 1 + num_spec shape with placeholder (-1) drafts.
     assert out.num_scheduled_tokens[r2.request_id] == 1 + num_spec
     assert out.scheduled_spec_decode_tokens[r2.request_id] == [-1] * num_spec
-
-
-def test_spec_decode_padding_skipped_for_diffusion():
-    """Diffusion spec tokens are the fixed-size denoising canvas, not
-    rejectable drafts: a first-decode-step request must keep its 1-token span
-    instead of being padded to 1 + num_spec_tokens, which would overflow the
-    canvas.
-    """
-    num_spec = 3
-    scheduler = create_scheduler(
-        num_speculative_tokens=num_spec,
-        enable_prefix_caching=True,
-        block_size=16,
-    )
-    # Diffusion schedulers initialize this to 0 (model_config.is_diffusion).
-    scheduler.num_sampled_tokens_per_step = 0
-    r1, r2 = create_requests(
-        num_requests=2, num_tokens=33, same_prompt=True, max_tokens=16
-    )
-
-    scheduler.add_request(r1)
-    out = scheduler.schedule()
-    assert out.num_scheduled_tokens[r1.request_id] == 33
-    _model_output(scheduler, out, [[100]])
-    scheduler.update_draft_token_ids(DraftTokenIds([r1.request_id], [[1, 2, 3]]))
-
-    # r2 arrives; its whole prompt is a prefix-cache hit -> needs exactly
-    # 1 token while r1 is a running speculative decode.
-    scheduler.add_request(r2)
-    out = scheduler.schedule()
-
-    assert out.scheduled_spec_decode_tokens[r1.request_id] == [1, 2, 3]
-    # r2 keeps its true 1-token span; no placeholder drafts are attached.
-    assert out.num_scheduled_tokens[r2.request_id] == 1
-    assert r2.request_id not in out.scheduled_spec_decode_tokens
 
 
 def test_spec_decode_padding_skipped_with_prefill_in_batch():
@@ -3227,7 +2972,6 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.waiting = Mock()
     scheduler.kv_cache_manager = Mock()
     scheduler.kv_cache_manager.take_events.return_value = None
-    scheduler.kv_cache_manager.estimate_cached_tokens.return_value = 0
     scheduler.kv_event_publisher = Mock()
     scheduler.finished_req_ids = set()
     scheduler.finished_req_ids_dict = None
@@ -3243,7 +2987,7 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     def free_request(req: Request, delay_free_blocks: bool = False):
         scheduler.finished_req_ids.add(req.request_id)
         scheduler.requests.pop(req.request_id, None)
-        return None, None
+        return None
 
     scheduler._free_request = Mock(side_effect=free_request)
 
@@ -5521,197 +5265,3 @@ def test_async_load_reservation_prevents_wedge_e2e():
     assert b.status == RequestStatus.WAITING
     assert b.num_preemptions == 0
     assert b.request_id not in req_to_blocks
-
-
-def _create_hybrid_mamba_connector_scheduler(
-    matched_tokens: int,
-    block_size: int = 16,
-    num_blocks: int = 100,
-) -> Scheduler:
-    """FA + Mamba ("all" cache mode) scheduler with a MockKVConnector."""
-    model_config = ModelConfig(
-        model="facebook/opt-125m",
-        trust_remote_code=True,
-        dtype="float16",
-        seed=42,
-        skip_tokenizer_init=True,
-    )
-    vllm_config = VllmConfig(
-        scheduler_config=SchedulerConfig(
-            max_num_seqs=4,
-            max_num_batched_tokens=8192,
-            max_model_len=8192,
-            enable_chunked_prefill=True,
-            is_encoder_decoder=False,
-            watermark=0.0,
-        ),
-        model_config=model_config,
-        cache_config=CacheConfig(
-            block_size=block_size,
-            enable_prefix_caching=True,
-            mamba_cache_mode="all",
-        ),
-        kv_transfer_config=KVTransferConfig(
-            kv_connector="MockKVConnector",
-            kv_role="kv_both",
-            kv_connector_extra_config={
-                "matched_tokens": matched_tokens,
-                "is_async": False,
-            },
-        ),
-    )
-    vllm_config.cache_config.num_gpu_blocks = num_blocks
-    kv_cache_config = KVCacheConfig(
-        num_blocks=num_blocks,
-        kv_cache_tensors=[],
-        kv_cache_groups=[
-            KVCacheGroupSpec(
-                ["fa"],
-                FullAttentionSpec(
-                    block_size=block_size,
-                    num_kv_heads=1,
-                    head_size=1,
-                    dtype=torch.float32,
-                ),
-            ),
-            KVCacheGroupSpec(
-                ["mamba"],
-                MambaSpec(
-                    block_size=block_size,
-                    shapes=((1, 1),),
-                    dtypes=(torch.float32,),
-                    mamba_cache_mode="all",
-                ),
-            ),
-        ],
-    )
-    register_all_kvcache_specs(vllm_config)
-    return Scheduler(
-        vllm_config=vllm_config,
-        kv_cache_config=kv_cache_config,
-        structured_output_manager=StructuredOutputManager(vllm_config),
-        block_size=block_size,
-        hash_block_size=block_size,
-        log_stats=True,
-    )
-
-
-@pytest.mark.parametrize(
-    "matched_tokens,expected_num_computed",
-    [
-        # No external hit: resume on the deepest locally-consistent boundary
-        # (block 0's state survives for both groups).
-        (0, 16),
-        # One external block on top of the reconciled local boundary.
-        (16, 32),
-    ],
-)
-def test_hybrid_per_group_hit_divergence_with_connector(
-    matched_tokens: int, expected_num_computed: int
-):
-    """Per-group prefix hits can diverge for hybrid models with a connector
-    (#46453): under block pressure the FA prefix tail is evicted while a
-    deeper Mamba state block survives. The scheduler must not report the
-    deeper hit as locally computed (evicted FA blocks are not resident ->
-    engine crash / dirty KV); it falls back to the reconciled boundary that
-    every group is consistent at.
-    """
-    block_size = 16
-    scheduler = _create_hybrid_mamba_connector_scheduler(matched_tokens)
-    manager = scheduler.kv_cache_manager
-    assert isinstance(manager.coordinator, HybridKVCacheCoordinator)
-
-    # Seed a 4-block prefix so both groups cache all four boundaries
-    # (mamba cache mode "all" caches every block's state densely).
-    [fill] = create_requests(
-        num_requests=1,
-        num_tokens=4 * block_size,
-        max_tokens=1,
-        same_prompt=True,
-        block_size=block_size,
-        req_ids=["fill"],
-    )
-    computed_blocks, num_computed, _ = manager.get_computed_blocks(fill)
-    blocks = manager.allocate_slots(
-        fill, fill.num_tokens, num_computed, computed_blocks
-    )
-    fa_ids = [b.block_id for b in blocks.blocks[0]]
-    mamba_ids = [b.block_id for b in blocks.blocks[1]]
-    manager.free(fill)
-
-    # Evict the FA tail and the middle mamba states; block 0 (both groups)
-    # and the deep mamba state at block 3 survive.
-    manager.block_pool.evict_blocks({fa_ids[2], fa_ids[3], mamba_ids[1], mamba_ids[2]})
-
-    # A replay of the prefix plus one extra block now sees diverged
-    # per-group hits: FA stops at the evicted tail, while the mamba lookup
-    # finds the deeper surviving state.
-    [replay] = create_requests(
-        num_requests=1,
-        num_tokens=5 * block_size,
-        max_tokens=1,
-        same_prompt=True,
-        block_size=block_size,
-        req_ids=["replay"],
-    )
-    _, per_group_hits = manager.coordinator.find_longest_cache_hit_per_group(
-        replay.block_hashes, replay.num_tokens - 1
-    )
-    assert per_group_hits == (2 * block_size, 4 * block_size)  # diverged
-
-    scheduler.add_request(replay)
-    output = scheduler.schedule()
-    num_scheduled = output.num_scheduled_tokens[replay.request_id]
-    assert replay.num_tokens - num_scheduled == expected_num_computed
-
-
-def test_hybrid_per_group_hit_divergence_fa_deeper_no_external():
-    """The opposite divergence: the FA prefix survives deeper than the Mamba
-    state and the connector supplies nothing (ext == 0). Reporting the deep FA
-    hit as locally computed would resume with no valid Mamba state at that
-    boundary (silent bad output). The scheduler must fall back to the
-    convergent boundary that every group agrees on (block 0's surviving state).
-    """
-    block_size = 16
-    scheduler = _create_hybrid_mamba_connector_scheduler(matched_tokens=0)
-    manager = scheduler.kv_cache_manager
-    assert isinstance(manager.coordinator, HybridKVCacheCoordinator)
-
-    # Seed a 4-block prefix in both groups.
-    [fill] = create_requests(
-        num_requests=1,
-        num_tokens=4 * block_size,
-        max_tokens=1,
-        same_prompt=True,
-        block_size=block_size,
-        req_ids=["fill"],
-    )
-    computed_blocks, num_computed, _ = manager.get_computed_blocks(fill)
-    blocks = manager.allocate_slots(
-        fill, fill.num_tokens, num_computed, computed_blocks
-    )
-    mamba_ids = [b.block_id for b in blocks.blocks[1]]
-    manager.free(fill)
-
-    # Keep all FA blocks; evict every mamba state but block 0. FA reaches 4
-    # blocks, the mamba hit only reaches 1 -> diverged (FA > Mamba).
-    manager.block_pool.evict_blocks({mamba_ids[1], mamba_ids[2], mamba_ids[3]})
-
-    [replay] = create_requests(
-        num_requests=1,
-        num_tokens=5 * block_size,
-        max_tokens=1,
-        same_prompt=True,
-        block_size=block_size,
-        req_ids=["replay"],
-    )
-    _, per_group_hits = manager.coordinator.find_longest_cache_hit_per_group(
-        replay.block_hashes, replay.num_tokens - 1
-    )
-    assert per_group_hits == (4 * block_size, 1 * block_size)  # FA deeper
-
-    scheduler.add_request(replay)
-    output = scheduler.schedule()
-    num_scheduled = output.num_scheduled_tokens[replay.request_id]
-    # Must resume at the convergent boundary (block 0), not the deep FA hit.
-    assert replay.num_tokens - num_scheduled == block_size

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -26,14 +26,17 @@ from vllm.multimodal.inputs import (
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.utils.hashing import sha256
 from vllm.v1.core.encoder_cache_manager import EncoderCacheManager
+from vllm.v1.core.kv_cache_coordinator import HybridKVCacheCoordinator
 from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.core.single_type_kv_cache_manager import register_all_kvcache_specs
 from vllm.v1.engine import FinishReason
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    MambaSpec,
 )
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
@@ -42,6 +45,65 @@ from vllm.v1.structured_output import StructuredOutputGrammar, StructuredOutputM
 from .utils import EOS_TOKEN_ID, create_requests, create_scheduler, mock_kv
 
 pytestmark = pytest.mark.cpu_test
+
+
+def test_make_scheduled_encoder_input_stats_output_embeddings():
+    scheduler = create_scheduler()
+    mm_features = [
+        MultiModalFeatureSpec(
+            data=MultiModalKwargsItem.dummy(),
+            modality="image",
+            identifier="image-0",
+            mm_position=PlaceholderRange(offset=0, length=196),
+        ),
+        MultiModalFeatureSpec(
+            data=MultiModalKwargsItem.dummy(),
+            modality="video",
+            identifier="video-0",
+            mm_position=PlaceholderRange(offset=200, length=196),
+        ),
+        MultiModalFeatureSpec(
+            data=MultiModalKwargsItem.dummy(),
+            modality="audio",
+            identifier="audio-0",
+            mm_position=PlaceholderRange(offset=400, length=49),
+        ),
+    ]
+    scheduler.requests["req"] = Mock(mm_features=mm_features)
+
+    stats = scheduler._make_scheduled_encoder_input_stats({"req": [0, 1, 2]})
+
+    assert stats is not None
+    assert stats.num_inputs == 3
+    assert stats.output_tokens == 441
+
+
+def test_scheduled_encoder_input_stats_disabled_without_iteration_logging(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    scheduler = create_scheduler()
+    make_stats = Mock(side_effect=AssertionError("stats should not be computed"))
+    monkeypatch.setattr(scheduler, "_make_scheduled_encoder_input_stats", make_stats)
+
+    scheduler_output = scheduler.schedule()
+
+    make_stats.assert_not_called()
+    assert scheduler_output.scheduled_encoder_input_stats is None
+
+
+def test_scheduled_encoder_input_stats_disabled_without_log_stats(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    scheduler = create_scheduler()
+    scheduler.log_stats = False
+    scheduler.observability_config.enable_logging_iteration_details = True
+    make_stats = Mock(side_effect=AssertionError("stats should not be computed"))
+    monkeypatch.setattr(scheduler, "_make_scheduled_encoder_input_stats", make_stats)
+
+    scheduler_output = scheduler.schedule()
+
+    make_stats.assert_not_called()
+    assert scheduler_output.scheduled_encoder_input_stats is None
 
 
 def test_add_requests():
@@ -107,6 +169,29 @@ def test_schedule(enable_prefix_caching: bool, prompt_logprobs: int | None):
     assert len(scheduler.running) == len(requests)
     for i, request in enumerate(requests):
         assert scheduler.running[i] == request
+
+
+def test_scheduler_stats_route_to_existing_output_client():
+    scheduler = create_scheduler()
+    request = create_requests(num_requests=1)[0]
+    request.client_index = 1
+    scheduler.add_request(request)
+
+    scheduler_output = scheduler.schedule()
+    model_output = ModelRunnerOutput(
+        req_ids=[request.request_id],
+        req_id_to_index={request.request_id: 0},
+        sampled_token_ids=[[1000]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    engine_core_outputs = scheduler.update_from_output(scheduler_output, model_output)
+
+    assert 0 not in engine_core_outputs
+    assert engine_core_outputs[1].scheduler_stats is not None
+    assert len(engine_core_outputs[1].outputs) == 1
 
 
 def test_schedule_multimodal_requests():
@@ -987,6 +1072,141 @@ def test_preempt_during_execution():
     assert requests[1].output_token_ids[0] == 42
 
 
+def test_prefix_cache_query_not_inflated_by_connector_defer():
+    """The GPU prefix-cache query is recorded at admission, so a request the
+    connector defers several times is counted once, not once per retry."""
+    num_defers_before_matching = 3
+    scheduler = create_scheduler(
+        enable_prefix_caching=True,
+        use_kv_connector=mock_kv(
+            matched_tokens=0,
+            is_async=False,
+            num_defers_before_matching=num_defers_before_matching,
+        ),
+    )
+    request = create_requests(num_requests=1, num_tokens=32, block_size=16)[0]
+    scheduler.add_request(request)
+
+    # Each deferred step re-runs the lookup but records nothing.
+    for _ in range(num_defers_before_matching):
+        assert not scheduler.schedule().scheduled_new_reqs
+
+    output = scheduler.schedule()
+    assert any(r.req_id == request.request_id for r in output.scheduled_new_reqs)
+
+    stats = scheduler.kv_cache_manager.prefix_cache_stats
+    assert stats is not None
+    assert stats.requests == 1
+    assert stats.queries == request.num_tokens
+
+
+def test_preemption_re_records_prefix_cache_query():
+    """A preempted request re-enters the lookup on resume, so its recomputation
+    is counted again into the preempted stats."""
+    scheduler = create_scheduler(enable_prefix_caching=True)
+    request = create_requests(num_requests=1)[0]
+    scheduler.add_request(request)
+
+    scheduler.schedule()
+    stats = scheduler.kv_cache_manager.prefix_cache_stats
+    assert stats is not None
+    assert (stats.requests, stats.preempted_requests) == (1, 0)
+
+    scheduler.running.remove(request)
+    scheduler._preempt_request(request, 0.0)
+    assert request.status == RequestStatus.PREEMPTED
+
+    scheduler.schedule()
+    assert request.status == RequestStatus.RUNNING
+    assert stats.preempted_requests == 1
+
+
+def test_prefix_cache_stats_not_recorded_when_caching_disabled():
+    """With prefix caching off there is no local lookup, so admitting a request
+    records no phantom miss."""
+    scheduler = create_scheduler(enable_prefix_caching=False)
+    for request in create_requests(num_requests=2):
+        scheduler.add_request(request)
+
+    scheduler.schedule()
+
+    stats = scheduler.kv_cache_manager.prefix_cache_stats
+    assert stats is not None
+    assert (stats.requests, stats.queries, stats.hits) == (0, 0, 0)
+
+
+def test_prefix_cache_stats_counted_once_for_retried_then_scheduled_request():
+    """A real cache hit rejected once by allocate_slots and admitted on the next
+    step is counted exactly once, hits included."""
+    block_size = 16
+    scheduler = create_scheduler(
+        enable_prefix_caching=True,
+        enable_chunked_prefill=False,
+        block_size=block_size,
+    )
+
+    # Seed the cache so the next request with the same prompt hits it.
+    seed = create_requests(
+        num_requests=1,
+        num_tokens=block_size * 2,
+        max_tokens=2,
+        same_prompt=True,
+        block_size=block_size,
+        req_ids=["seed"],
+    )[0]
+    scheduler.add_request(seed)
+    _step_until_done(
+        scheduler,
+        scheduler.schedule(),
+        ModelRunnerOutput(
+            req_ids=["seed"],
+            req_id_to_index={"seed": 0},
+            sampled_token_ids=[[1000]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    # The seeding step swapped in a fresh accumulator, so re-read it; the
+    # retried request must be the only thing recorded from here on.
+    stats = scheduler.kv_cache_manager.prefix_cache_stats
+    assert stats is not None
+    assert (stats.requests, stats.queries, stats.hits) == (0, 0, 0)
+
+    retried = create_requests(
+        num_requests=1,
+        num_tokens=block_size * 3,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=block_size,
+        req_ids=["retried"],
+    )[0]
+    scheduler.add_request(retried)
+
+    # Reject the first allocation attempt, then delegate to the real one.
+    orig_allocate_slots = scheduler.kv_cache_manager.allocate_slots
+    allocate_results: list = []
+
+    def spy_allocate_slots(*args, **kwargs):
+        result = None if not allocate_results else orig_allocate_slots(*args, **kwargs)
+        allocate_results.append(result)
+        return result
+
+    scheduler.kv_cache_manager.allocate_slots = spy_allocate_slots
+
+    assert not scheduler.schedule().scheduled_new_reqs
+    assert (stats.requests, stats.queries, stats.hits) == (0, 0, 0)
+
+    assert "retried" in scheduler.schedule().num_scheduled_tokens
+    assert allocate_results[0] is None and allocate_results[1] is not None
+    assert (stats.requests, stats.queries, stats.hits) == (
+        1,
+        retried.num_tokens,
+        block_size * 2,
+    )
+
+
 def test_scheduler_reset_prefix_cache():
     scheduler = create_scheduler(enable_prefix_caching=True)
     requests = create_requests(num_requests=10)
@@ -1355,6 +1575,41 @@ def test_spec_decode_padding_first_decode_step():
     # r2 is padded to the 1 + num_spec shape with placeholder (-1) drafts.
     assert out.num_scheduled_tokens[r2.request_id] == 1 + num_spec
     assert out.scheduled_spec_decode_tokens[r2.request_id] == [-1] * num_spec
+
+
+def test_spec_decode_padding_skipped_for_diffusion():
+    """Diffusion spec tokens are the fixed-size denoising canvas, not
+    rejectable drafts: a first-decode-step request must keep its 1-token span
+    instead of being padded to 1 + num_spec_tokens, which would overflow the
+    canvas.
+    """
+    num_spec = 3
+    scheduler = create_scheduler(
+        num_speculative_tokens=num_spec,
+        enable_prefix_caching=True,
+        block_size=16,
+    )
+    # Diffusion schedulers initialize this to 0 (model_config.is_diffusion).
+    scheduler.num_sampled_tokens_per_step = 0
+    r1, r2 = create_requests(
+        num_requests=2, num_tokens=33, same_prompt=True, max_tokens=16
+    )
+
+    scheduler.add_request(r1)
+    out = scheduler.schedule()
+    assert out.num_scheduled_tokens[r1.request_id] == 33
+    _model_output(scheduler, out, [[100]])
+    scheduler.update_draft_token_ids(DraftTokenIds([r1.request_id], [[1, 2, 3]]))
+
+    # r2 arrives; its whole prompt is a prefix-cache hit -> needs exactly
+    # 1 token while r1 is a running speculative decode.
+    scheduler.add_request(r2)
+    out = scheduler.schedule()
+
+    assert out.scheduled_spec_decode_tokens[r1.request_id] == [1, 2, 3]
+    # r2 keeps its true 1-token span; no placeholder drafts are attached.
+    assert out.num_scheduled_tokens[r2.request_id] == 1
+    assert r2.request_id not in out.scheduled_spec_decode_tokens
 
 
 def test_spec_decode_padding_skipped_with_prefill_in_batch():
@@ -2972,6 +3227,7 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.waiting = Mock()
     scheduler.kv_cache_manager = Mock()
     scheduler.kv_cache_manager.take_events.return_value = None
+    scheduler.kv_cache_manager.estimate_cached_tokens.return_value = 0
     scheduler.kv_event_publisher = Mock()
     scheduler.finished_req_ids = set()
     scheduler.finished_req_ids_dict = None
@@ -2987,7 +3243,7 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     def free_request(req: Request, delay_free_blocks: bool = False):
         scheduler.finished_req_ids.add(req.request_id)
         scheduler.requests.pop(req.request_id, None)
-        return None
+        return None, None
 
     scheduler._free_request = Mock(side_effect=free_request)
 
@@ -5265,3 +5521,197 @@ def test_async_load_reservation_prevents_wedge_e2e():
     assert b.status == RequestStatus.WAITING
     assert b.num_preemptions == 0
     assert b.request_id not in req_to_blocks
+
+
+def _create_hybrid_mamba_connector_scheduler(
+    matched_tokens: int,
+    block_size: int = 16,
+    num_blocks: int = 100,
+) -> Scheduler:
+    """FA + Mamba ("all" cache mode) scheduler with a MockKVConnector."""
+    model_config = ModelConfig(
+        model="facebook/opt-125m",
+        trust_remote_code=True,
+        dtype="float16",
+        seed=42,
+        skip_tokenizer_init=True,
+    )
+    vllm_config = VllmConfig(
+        scheduler_config=SchedulerConfig(
+            max_num_seqs=4,
+            max_num_batched_tokens=8192,
+            max_model_len=8192,
+            enable_chunked_prefill=True,
+            is_encoder_decoder=False,
+            watermark=0.0,
+        ),
+        model_config=model_config,
+        cache_config=CacheConfig(
+            block_size=block_size,
+            enable_prefix_caching=True,
+            mamba_cache_mode="all",
+        ),
+        kv_transfer_config=KVTransferConfig(
+            kv_connector="MockKVConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={
+                "matched_tokens": matched_tokens,
+                "is_async": False,
+            },
+        ),
+    )
+    vllm_config.cache_config.num_gpu_blocks = num_blocks
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["fa"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="all",
+                ),
+            ),
+        ],
+    )
+    register_all_kvcache_specs(vllm_config)
+    return Scheduler(
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        structured_output_manager=StructuredOutputManager(vllm_config),
+        block_size=block_size,
+        hash_block_size=block_size,
+        log_stats=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "matched_tokens,expected_num_computed",
+    [
+        # No external hit: resume on the deepest locally-consistent boundary
+        # (block 0's state survives for both groups).
+        (0, 16),
+        # One external block on top of the reconciled local boundary.
+        (16, 32),
+    ],
+)
+def test_hybrid_per_group_hit_divergence_with_connector(
+    matched_tokens: int, expected_num_computed: int
+):
+    """Per-group prefix hits can diverge for hybrid models with a connector
+    (#46453): under block pressure the FA prefix tail is evicted while a
+    deeper Mamba state block survives. The scheduler must not report the
+    deeper hit as locally computed (evicted FA blocks are not resident ->
+    engine crash / dirty KV); it falls back to the reconciled boundary that
+    every group is consistent at.
+    """
+    block_size = 16
+    scheduler = _create_hybrid_mamba_connector_scheduler(matched_tokens)
+    manager = scheduler.kv_cache_manager
+    assert isinstance(manager.coordinator, HybridKVCacheCoordinator)
+
+    # Seed a 4-block prefix so both groups cache all four boundaries
+    # (mamba cache mode "all" caches every block's state densely).
+    [fill] = create_requests(
+        num_requests=1,
+        num_tokens=4 * block_size,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=block_size,
+        req_ids=["fill"],
+    )
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(fill)
+    blocks = manager.allocate_slots(
+        fill, fill.num_tokens, num_computed, computed_blocks
+    )
+    fa_ids = [b.block_id for b in blocks.blocks[0]]
+    mamba_ids = [b.block_id for b in blocks.blocks[1]]
+    manager.free(fill)
+
+    # Evict the FA tail and the middle mamba states; block 0 (both groups)
+    # and the deep mamba state at block 3 survive.
+    manager.block_pool.evict_blocks({fa_ids[2], fa_ids[3], mamba_ids[1], mamba_ids[2]})
+
+    # A replay of the prefix plus one extra block now sees diverged
+    # per-group hits: FA stops at the evicted tail, while the mamba lookup
+    # finds the deeper surviving state.
+    [replay] = create_requests(
+        num_requests=1,
+        num_tokens=5 * block_size,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=block_size,
+        req_ids=["replay"],
+    )
+    _, per_group_hits = manager.coordinator.find_longest_cache_hit_per_group(
+        replay.block_hashes, replay.num_tokens - 1
+    )
+    assert per_group_hits == (2 * block_size, 4 * block_size)  # diverged
+
+    scheduler.add_request(replay)
+    output = scheduler.schedule()
+    num_scheduled = output.num_scheduled_tokens[replay.request_id]
+    assert replay.num_tokens - num_scheduled == expected_num_computed
+
+
+def test_hybrid_per_group_hit_divergence_fa_deeper_no_external():
+    """The opposite divergence: the FA prefix survives deeper than the Mamba
+    state and the connector supplies nothing (ext == 0). Reporting the deep FA
+    hit as locally computed would resume with no valid Mamba state at that
+    boundary (silent bad output). The scheduler must fall back to the
+    convergent boundary that every group agrees on (block 0's surviving state).
+    """
+    block_size = 16
+    scheduler = _create_hybrid_mamba_connector_scheduler(matched_tokens=0)
+    manager = scheduler.kv_cache_manager
+    assert isinstance(manager.coordinator, HybridKVCacheCoordinator)
+
+    # Seed a 4-block prefix in both groups.
+    [fill] = create_requests(
+        num_requests=1,
+        num_tokens=4 * block_size,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=block_size,
+        req_ids=["fill"],
+    )
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(fill)
+    blocks = manager.allocate_slots(
+        fill, fill.num_tokens, num_computed, computed_blocks
+    )
+    mamba_ids = [b.block_id for b in blocks.blocks[1]]
+    manager.free(fill)
+
+    # Keep all FA blocks; evict every mamba state but block 0. FA reaches 4
+    # blocks, the mamba hit only reaches 1 -> diverged (FA > Mamba).
+    manager.block_pool.evict_blocks({mamba_ids[1], mamba_ids[2], mamba_ids[3]})
+
+    [replay] = create_requests(
+        num_requests=1,
+        num_tokens=5 * block_size,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=block_size,
+        req_ids=["replay"],
+    )
+    _, per_group_hits = manager.coordinator.find_longest_cache_hit_per_group(
+        replay.block_hashes, replay.num_tokens - 1
+    )
+    assert per_group_hits == (4 * block_size, 1 * block_size)  # FA deeper
+
+    scheduler.add_request(replay)
+    output = scheduler.schedule()
+    num_scheduled = output.num_scheduled_tokens[replay.request_id]
+    # Must resume at the convergent boundary (block 0), not the deep FA hit.
+    assert replay.num_tokens - num_scheduled == block_size

--- a/tests/v1/core/test_scheduler_kv_load_failure.py
+++ b/tests/v1/core/test_scheduler_kv_load_failure.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Unit tests for scheduler's _update_requests_with_invalid_blocks function.
+Tests for hybrid attention KV load failure recovery with recompute.
+
+Run with: python -m pytest tests/v1/core/test_scheduler_kv_load_failure.py -v
+"""
+
+import pytest
+from unittest.mock import MagicMock
+from vllm.v1.core.sched.scheduler import Scheduler
+
+def _make_mock_request(request_id: str, num_computed_tokens: int) -> MagicMock:
+    """Create a mock Request object.
+
+    Note: block_ids is obtained via kv_cache_manager.get_block_ids(),
+    so it's not needed here.
+    """
+    request = MagicMock()
+    request.request_id = request_id
+    request.num_computed_tokens = num_computed_tokens
+    return request
+
+
+def _make_mock_kv_cache_config(block_size: int = 16) -> MagicMock:
+    """Create a mock KVCacheConfig with single full-attention group."""
+    config = MagicMock()
+    group = MagicMock()
+    group.kv_cache_spec.block_size = block_size
+    config.kv_cache_groups = [group]
+    return config
+
+
+def _make_mock_kv_cache_manager(
+        block_ids_map: dict[str, tuple[list[int], ...]]
+) -> MagicMock:
+    """Create a mock KVCacheManager that returns block IDs for requests."""
+    manager = MagicMock()
+    manager.get_block_ids.side_effect = lambda req_id: block_ids_map.get(req_id, ([],))
+    manager.evict_blocks = MagicMock()
+    return manager
+
+
+class TestUpdateRequestsWithInvalidBlocks:
+    """Tests for Scheduler._update_requests_with_invalid_blocks."""
+
+    @pytest.fixture
+    def mock_scheduler(self):
+        """Create a minimal mock Scheduler with required attributes."""
+        scheduler = MagicMock()
+        scheduler.kv_cache_manager = _make_mock_kv_cache_manager({})
+        scheduler.kv_cache_config = _make_mock_kv_cache_config(block_size=16)
+        return scheduler
+
+    def test_single_block_invalid_rewinds_correctly(self, mock_scheduler):
+        """A single invalid block should rewind to the block boundary."""
+        # Request has 48 tokens (3 blocks of 16 tokens each), block 1 is invalid
+        mock_scheduler.kv_cache_manager = _make_mock_kv_cache_manager({
+            "req-0": ([0, 1, 2],),
+        })
+        requests = [_make_mock_request("req-0", 48)]
+        invalid_block_ids = {1}  # Block 1 (tokens 16-31) is invalid
+        num_scheduled_tokens = {"req-0": 0}
+
+        result = Scheduler._update_requests_with_invalid_blocks(
+            mock_scheduler,
+            requests,
+            invalid_block_ids,
+            num_scheduled_tokens,
+            evict_blocks=True,
+        )
+
+        affected, tokens, blocks = result
+        assert "req-0" in affected
+        assert requests[0].num_computed_tokens == 16
+        assert tokens == 32
+
+    def test_multiple_requests_share_invalid_block(self, mock_scheduler):
+        """When multiple requests share an invalid block, only first recomputes."""
+        # Two requests share block 1 but have different block tables
+        mock_scheduler.kv_cache_manager = _make_mock_kv_cache_manager({
+            "req-0": ([0, 1, 2],),  # req-0 uses blocks 0,1,2
+            "req-1": ([10, 1, 20],),  # req-1 uses blocks 10,1,20 (only block 1 overlaps)
+        })
+        requests = [
+            _make_mock_request("req-0", 48),
+            _make_mock_request("req-1", 48),
+        ]
+        invalid_block_ids = {1}  # Block 1 is invalid
+        num_scheduled_tokens = {"req-0": 0, "req-1": 0}
+        result = Scheduler._update_requests_with_invalid_blocks(
+            mock_scheduler,
+            requests,
+            invalid_block_ids,
+            num_scheduled_tokens,
+            evict_blocks=True,
+        )
+
+        affected, tokens, blocks = result
+        assert "req-0" in affected
+        assert "req-1" in affected
+        assert requests[0].num_computed_tokens == 16
+        assert requests[1].num_computed_tokens == 48
+
+    def test_multiple_groups_different_block_sizes(self, mock_scheduler):
+        """Test handling of multiple KV cache groups with different block sizes."""
+        # Create config with 2 groups: block_size=16 and block_size=8
+        config = MagicMock()
+        group0 = MagicMock()
+        group0.kv_cache_spec.block_size = 16
+        group1 = MagicMock()
+        group1.kv_cache_spec.block_size = 8
+        config.kv_cache_groups = [group0, group1]
+        mock_scheduler.kv_cache_config = config
+
+        # Request has 32 computed tokens:
+        # - group0 (block_size=16): 32/16 = 2 blocks → [0, 1]
+        # - group1 (block_size=8): 32/8 = 4 blocks → [10, 11, 12, 13]
+        # Using different block IDs for each group to avoid ambiguity
+        mock_scheduler.kv_cache_manager = _make_mock_kv_cache_manager({
+            "req-0": ([0, 1], [10, 11, 12, 13]),
+        })
+        requests = [_make_mock_request("req-0", 32)]
+        invalid_block_ids = {1,13}
+        num_scheduled_tokens = {"req-0": 0}
+        result = Scheduler._update_requests_with_invalid_blocks(
+            mock_scheduler,
+            requests,
+            invalid_block_ids,
+            num_scheduled_tokens,
+            evict_blocks=True,
+        )
+
+        affected, tokens, blocks = result
+        assert "req-0" in affected
+
+        # Block 1 and 13 are invalid
+        # Should rewind to 16 tokens
+        assert requests[0].num_computed_tokens == 16
+        assert tokens == 16

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -2415,7 +2415,7 @@ def test_store_recving_thread_load_failure_different_block_sizes():
     assert failed_blocks == {1, 11}
 
 
-def test_store_recving_thread_singel_group_load_failure():
+def test_store_recving_thread_single_group_load_failure():
     """Test when all blocks fail - all block IDs and their peers are recorded."""
     from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheGroupSpec
 

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -2342,3 +2342,125 @@ def test_blob_block_hashes_empty():
     view = BlobBlockHashes(memoryview(b""), 0)
     assert len(view) == 0
     assert list(view) == []
+
+
+# =============================================================================
+# Tests for KV load failure handling with peer block linkage
+# These tests verify the behavior when blocks fail to load and peer blocks
+# (blocks in other groups covering the same token span) should also be marked.
+# =============================================================================
+
+def test_store_recving_thread_load_failure_different_block_sizes():
+    """Test peer block collection with different block sizes per group.
+
+    When groups have different block_size, the peer calculation uses token_start
+    to find the correct peer block in each group.
+    """
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheGroupSpec
+
+    # Group 0: block_size=16 (3 blocks for 48 tokens)
+    db0 = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0, group_id=0), block_size=16
+    )
+    db0.set_kv_caches_base_addr([0x1000])
+    db0.set_block_len([256])
+
+    # Group 1: block_size=8 (6 blocks for 48 tokens)
+    db1 = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0, group_id=1), block_size=8
+    )
+    db1.set_kv_caches_base_addr([0x2000])
+    db1.set_block_len([128])
+
+    spec_full_0 = FullAttentionSpec(block_size=16, num_kv_heads=8, head_size=64, dtype=None)
+    spec_full_1 = FullAttentionSpec(block_size=8, num_kv_heads=8, head_size=64, dtype=None)
+    coord = mooncake_store_worker.MooncakeStoreCoordinator(
+        [KVCacheGroupSpec(["layer0"], spec_full_0), KVCacheGroupSpec(["layer1"], spec_full_1)],
+        scheduler_block_size=16,
+        hash_block_size=8,
+    )
+
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.return_value = [256, 256, 256, 256, -5, 256, 256, 256, 256]
+
+    thread = mooncake_store_worker.KVCacheStoreRecvingThread(
+        store=store,
+        token_databases=[db0, db1],
+        block_size=16,
+        tp_rank=0,
+        ready_event=MagicMock(),
+        coord=coord,
+        disk_offload_buffer_budget_bytes=None,
+    )
+    thread.request_queue.task_done = MagicMock()
+
+    req_meta = ReqMeta(
+        req_id="req-diff-sizes",
+        token_len_chunk=48,
+        block_ids=([1, 2, 3], [10, 11, 12, 13, 14, 15]),
+        block_hashes=[b"h0", b"h1", b"h2", b"h3", b"h4", b"h5", b"h6", b"h7", b"h8"],
+        load_spec=LoadSpec(
+            vllm_cached_tokens=0,
+            kvpool_cached_tokens=48,
+            can_load=True,
+            token_len=48,
+        ),
+    )
+
+    thread._handle_request(req_meta)
+
+    failed_blocks = thread.get_and_clear_block_ids_with_load_errors()
+    # Block 1 (group0) fails at token_start = 16
+    # Peer in group1: token_start 16 // 8 = 2 -> block_ids[1][2] = 12
+    assert failed_blocks == {1, 11}
+
+
+def test_store_recving_thread_singel_group_load_failure():
+    """Test when all blocks fail - all block IDs and their peers are recorded."""
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheGroupSpec
+
+    # Setup with 2 groups
+    db0 = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0, group_id=0), block_size=16
+    )
+    db0.set_kv_caches_base_addr([0x1000])
+    db0.set_block_len([256])
+
+    spec = FullAttentionSpec(block_size=16, num_kv_heads=8, head_size=64, dtype=None)
+    coord = mooncake_store_worker.MooncakeStoreCoordinator(
+        [KVCacheGroupSpec(["layer0"], spec), KVCacheGroupSpec(["layer1"], spec)],
+        scheduler_block_size=16,
+        hash_block_size=16,
+    )
+
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.return_value = [256, -5, 256]
+
+    thread = mooncake_store_worker.KVCacheStoreRecvingThread(
+        store=store,
+        token_databases=[db0],
+        block_size=16,
+        tp_rank=0,
+        ready_event=MagicMock(),
+        coord=coord,
+        disk_offload_buffer_budget_bytes=None,
+    )
+    thread.request_queue.task_done = MagicMock()
+
+    req_meta = ReqMeta(
+        req_id="req-all-fail",
+        token_len_chunk=48,
+        block_ids=([1, 2, 3],),
+        block_hashes=[b"h0", b"h1", b"h2", b"h3", b"h4", b"h5"],
+        load_spec=LoadSpec(
+            vllm_cached_tokens=0,
+            kvpool_cached_tokens=48,
+            can_load=True,
+            token_len=48,
+        ),
+    )
+
+    thread._handle_request(req_meta)
+
+    failed_blocks = thread.get_and_clear_block_ids_with_load_errors()
+    assert failed_blocks == {2}

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -342,6 +342,36 @@ def _log_mooncake_load_tier_summary(
         bytes_by_tier,
     )
 
+def _collect_peer_block_ids(
+    token_start: int,
+    req_meta: ReqMeta,
+    token_databases: list[ChunkedTokenDatabase],
+) -> set[int]:
+    """
+    Collect the peer block_ids in other groups that cover the same token span as the given block.
+
+    In the hybrid model, KV for the same token span is sharded across multiple groups.
+    If one group’s block fails to load, the KV in its peer blocks of other groups is also invalid
+    and must be marked as failed together.
+
+    Args:
+        token_start: starting token position covered by the current block
+        req_meta: request metadata (contains block_ids for each group)
+        token_databases: ChunkedTokenDatabase instance for each group
+    Returns:
+        set of peer block_ids
+    """
+    peer_block_ids: set[int] = set()
+    for peer_g_idx, peer_db in enumerate(token_databases):
+        peer_block_size = peer_db.block_size
+        peer_chunk_idx = token_start // peer_block_size
+        peer_block_ids_list = req_meta.block_ids[peer_g_idx]
+        if peer_chunk_idx < len(peer_block_ids_list):
+            peer_bid = peer_block_ids_list[peer_chunk_idx]
+            # A block_id ≤ 0 denotes an empty block in mamba-align mode (not actually allocated)
+            if peer_bid > 0:
+                peer_block_ids.add(peer_bid)
+    return peer_block_ids
 
 # ============================================================
 # Transfer Threads
@@ -787,9 +817,13 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         )
         self.coord = coord
 
-    def _add_load_error_block_ids(self, block_ids: list[int]) -> None:
+    def _add_load_error_block_ids(self, block_ids: list[int] | list[set[int]]) -> None:
         with self._invalid_block_ids_lock:
-            self._invalid_block_ids.update(block_ids)
+            for item in block_ids:
+                if isinstance(item, set):
+                    self._invalid_block_ids.update(item)
+                else:
+                    self._invalid_block_ids.add(item)
 
     def get_and_clear_block_ids_with_load_errors(self) -> set[int]:
         with self._invalid_block_ids_lock:
@@ -813,7 +847,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         addr_list: list[list[int]] = []
         size_list: list[list[int]] = []
         key_list: list[str] = []
-        block_id_list: list[int] = []
+        block_id_list: list[set[int]] = []
         for g_idx, db in enumerate(self.token_databases):
             mask = load_mask_per_group[g_idx]
             chunks: list[tuple[int, int]] = []
@@ -830,7 +864,11 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             )
             addr_list.extend(g_addrs)
             size_list.extend(g_sizes)
-            block_id_list.extend(g_block_ids)
+            for block_id, start in zip(g_block_ids, [c[0] for c in chunks]):
+                peer_ids = _collect_peer_block_ids(
+                    start, req_meta, self.token_databases
+                )
+                block_id_list.append({block_id} | peer_ids)
 
         # Rotate aligned lists by tp_rank for load balancing.
         rotation = self.tp_rank % len(key_list)
@@ -886,7 +924,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                     block_id_offset = next_block_id_offset
 
         current_batch_keys: list[str] = key_list_c
-        current_batch_block_ids: list[int] = block_id_list_c
+        current_batch_block_ids: list[set[int]] = block_id_list_c
         batch_bytes = 0
         try:
             for batch_keys, batch_addrs, batch_sizes, batch_block_ids in load_batches:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2677,7 +2677,6 @@ class Scheduler(SchedulerInterface):
         marked_invalid_block_ids: set[int] = set()
         for request in requests:
             is_affected = False
-            marked_invalid_block = False
             req_id = request.request_id
             req_block_ids_by_group = self.kv_cache_manager.get_block_ids(req_id)
             # We iterate only over blocks that may contain externally computed
@@ -2688,6 +2687,7 @@ class Scheduler(SchedulerInterface):
             )
 
             for g_idx, req_block_ids in enumerate(req_block_ids_by_group):
+                marked_invalid_block = False
                 group_block_size = self.kv_cache_config.kv_cache_groups[g_idx].kv_cache_spec.block_size
                 req_num_computed_blocks = (
                                                   req_num_computed_tokens + group_block_size - 1
@@ -2711,7 +2711,7 @@ class Scheduler(SchedulerInterface):
                     marked_invalid_block_ids.add(block_id)
 
                     if marked_invalid_block:
-                        # This request has already marked an invalid block for
+                        # This group has already marked an invalid block for
                         # recomputation and updated its num_computed_tokens.
                         continue
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2731,7 +2731,7 @@ class Scheduler(SchedulerInterface):
                     # Currently this only applies to sync loading; Async
                     # loading does not yet support block sharing
                     total_affected_tokens += (
-                            request.num_computed_tokens - req_num_computed_tokens
+                        request.num_computed_tokens - req_num_computed_tokens
                     )
                     request.num_computed_tokens = req_num_computed_tokens
                 else:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2677,6 +2677,7 @@ class Scheduler(SchedulerInterface):
         marked_invalid_block_ids: set[int] = set()
         for request in requests:
             is_affected = False
+            marked_invalid_block = False
             req_id = request.request_id
             req_block_ids_by_group = self.kv_cache_manager.get_block_ids(req_id)
             # We iterate only over blocks that may contain externally computed
@@ -2687,7 +2688,7 @@ class Scheduler(SchedulerInterface):
             )
 
             for g_idx, req_block_ids in enumerate(req_block_ids_by_group):
-                marked_invalid_block = False
+                group_marked_invalid_block = False
                 group_block_size = self.kv_cache_config.kv_cache_groups[g_idx].kv_cache_spec.block_size
                 req_num_computed_blocks = (
                                                   req_num_computed_tokens + group_block_size - 1
@@ -2710,11 +2711,12 @@ class Scheduler(SchedulerInterface):
 
                     marked_invalid_block_ids.add(block_id)
 
-                    if marked_invalid_block:
+                    if group_marked_invalid_block:
                         # This group has already marked an invalid block for
                         # recomputation and updated its num_computed_tokens.
                         continue
 
+                    group_marked_invalid_block = True
                     marked_invalid_block = True
                     failed_token_pos = idx * group_block_size
                     rewind_num_computed_tokens = min(rewind_num_computed_tokens, failed_token_pos)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2679,50 +2679,49 @@ class Scheduler(SchedulerInterface):
             is_affected = False
             marked_invalid_block = False
             req_id = request.request_id
-            # TODO (davidb): add support for hybrid memory allocator
-            (req_block_ids,) = self.kv_cache_manager.get_block_ids(req_id)
+            req_block_ids_by_group = self.kv_cache_manager.get_block_ids(req_id)
             # We iterate only over blocks that may contain externally computed
             # tokens
+            rewind_num_computed_tokens = request.num_computed_tokens - num_scheduled_tokens.get(req_id, 0)
             req_num_computed_tokens = (
-                request.num_computed_tokens - num_scheduled_tokens.get(req_id, 0)
+                    request.num_computed_tokens - num_scheduled_tokens.get(req_id, 0)
             )
 
-            req_num_computed_blocks = (
-                req_num_computed_tokens + self.block_size - 1
-            ) // self.block_size
-            for idx, block_id in zip(range(req_num_computed_blocks), req_block_ids):
-                if block_id not in invalid_block_ids:
-                    continue
+            for g_idx, req_block_ids in enumerate(req_block_ids_by_group):
+                group_block_size = self.kv_cache_config.kv_cache_groups[g_idx].kv_cache_spec.block_size
+                req_num_computed_blocks = (
+                                                  req_num_computed_tokens + group_block_size - 1
+                                          ) // group_block_size
 
-                is_affected = True
+                for idx, block_id in zip(range(req_num_computed_blocks), req_block_ids):
+                    if block_id not in invalid_block_ids:
+                        continue
 
-                if block_id in marked_invalid_block_ids:
-                    # This invalid block is shared with a previous request
-                    # and was already marked for recomputation.
-                    # This means this request can still consider this block
-                    # as computed when rescheduled.
-                    # Currently this only applies to sync loading; Async
-                    # loading does not yet support block sharing
-                    continue
+                    is_affected = True
 
-                marked_invalid_block_ids.add(block_id)
+                    if block_id in marked_invalid_block_ids:
+                        # This invalid block is shared with a previous request
+                        # and was already marked for recomputation.
+                        # This means this request can still consider this block
+                        # as computed when rescheduled.
+                        # Currently this only applies to sync loading; Async
+                        # loading does not yet support block sharing
+                        continue
 
-                if marked_invalid_block:
-                    # This request has already marked an invalid block for
-                    # recomputation and updated its num_computed_tokens.
-                    continue
+                    marked_invalid_block_ids.add(block_id)
 
-                marked_invalid_block = True
-                # Truncate the computed tokens at the first failed block
-                request.num_computed_tokens = idx * self.block_size
-                num_affected_tokens = (
-                    req_num_computed_tokens - request.num_computed_tokens
-                )
-                total_affected_tokens += num_affected_tokens
+                    if marked_invalid_block:
+                        # This request has already marked an invalid block for
+                        # recomputation and updated its num_computed_tokens.
+                        continue
 
-                # collect invalid block and all downstream dependent blocks
-                if evict_blocks:
-                    blocks_to_evict.update(req_block_ids[idx:])
+                    marked_invalid_block = True
+                    failed_token_pos = idx * group_block_size
+                    rewind_num_computed_tokens = min(rewind_num_computed_tokens, failed_token_pos)
+
+                    # collect invalid block and all downstream dependent blocks (per group)
+                    if evict_blocks:
+                        blocks_to_evict.update(req_block_ids[idx:])
 
             if is_affected:
                 if not marked_invalid_block:
@@ -2732,9 +2731,13 @@ class Scheduler(SchedulerInterface):
                     # Currently this only applies to sync loading; Async
                     # loading does not yet support block sharing
                     total_affected_tokens += (
-                        request.num_computed_tokens - req_num_computed_tokens
+                            request.num_computed_tokens - req_num_computed_tokens
                     )
                     request.num_computed_tokens = req_num_computed_tokens
+                else:
+                    request.num_computed_tokens = rewind_num_computed_tokens
+                    num_affected_tokens = req_num_computed_tokens - rewind_num_computed_tokens
+                    total_affected_tokens += num_affected_tokens
 
                 affected_req_ids.add(request.request_id)
 


### PR DESCRIPTION

## Purpose
Implements the RFC https://github.com/vllm-project/vllm/issues/47812. `kv_load_failure_policy="recompute"` has two gaps on hybrid-KV models today: (1) the scheduler assumes a single KV cache group and crashes on `get_block_ids()` multi-element unpack, and (2) a load failure in one group leaves the peer blocks covering the same token span unmarked in other groups.

This PR closes both gaps:
 
1. **Mooncake worker — peer-block linkage on load failure.**  The per-request `block_id_list` in `KVCacheStoreRecvingThread._handle_request` changes from `list[int]` to `list[set[int]]`, where each `set` contains the block IDs of all peer blocks (across every group) that cover the same token span. Peer IDs are collected via the new `_collect_peer_block_ids(token_start, req_meta, token_databases)` helper. `_add_load_error_block_ids` is widened to accept `list[int] | list[set[int]]` and flatten `set` elements. A backend `get` failure then fans out to peers naturally — the failed key's `set[int]` is unioned into `invalid_block_ids`. `batch_get_into_multi_buffers` only takes keys/addrs/sizes — `block_id_list` is never passed to the mooncake API, only used for internal error tracking — so changing its element type does not affect the API call. 
 
2. **Scheduler — group-aware rewind.** `_update_requests_with_invalid_blocks` now iterates per group over `get_block_ids(req_id)`, reads each group's own `block_size`, and maintains `rewind_num_computed_tokens = min(failed_token_pos across all groups)` where `failed_token_pos = idx * group_block_size`. The earliest failure across all groups is the safe rewind point, since any token after the earliest failure has at least one group's KV missing. 

### Changed files
 
- `vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py` — add `_collect_peer_block_ids` helper; widen `_add_load_error_block_ids` to `list[int] | list[set[int]]`; change `block_id_list` element type to `set[int]` and collect peer blocks on append.
- `vllm/v1/core/sched/scheduler.py` — make `_update_requests_with_invalid_blocks` hybrid-aware: per-group iteration, per-group `block_size`, earliest-failure rewind; remove the single-group unpack.
- `tests/v1/kv_connector/unit/test_mooncake_store_worker.py` — add new tests for peer-block collection with different per-group `block_size` and for single-group fallback.
- `tests/v1/core/test_scheduler_kv_load_failure.py` — new test file for `_update_requests_with_invalid_blocks` covering single-block rewind, shared-block dedup across requests, and multi-group with different `block_size`.

## Test Plan
- Test that in both single-group and multi-group scenarios, the mooncake store worker can correctly mark invalid blocks. 
- Test that in both single-group and multi-group scenarios, the scheduler can properly adjust `num_computed_tokens`.
```bash
pytest tests/v1/core/test_scheduler_kv_load_failure.py -v
 
pytest tests/v1/kv_connector/unit/test_mooncake_store_worker.py::test_store_recving_thread_load_failure_different_block_sizes \
       tests/v1/kv_connector/unit/test_mooncake_store_worker.py::test_store_recving_thread_single_group_load_failure -v
```

## Test Result
- 3 tests in `test_scheduler_kv_load_failure.py` are all passed
- 2 tests in `test_mooncake_store_worker.py` are all passed

```bash
tests/v1/core/test_scheduler_kv_load_failure.py::TestUpdateRequestsWithInvalidBlocks::test_single_block_invalid_rewinds_correctly PASSED                                                                [ 33%]
tests/v1/core/test_scheduler_kv_load_failure.py::TestUpdateRequestsWithInvalidBlocks::test_multiple_requests_share_invalid_block PASSED                                                                 [ 66%]
tests/v1/core/test_scheduler_kv_load_failure.py::TestUpdateRequestsWithInvalidBlocks::test_multiple_groups_different_block_sizes PASSED                                                                 [100%]
```
 
```bash
tests/v1/kv_connector/unit/test_mooncake_store_worker.py::test_store_recving_thread_load_failure_different_block_sizes PASSED                                                                           [ 50%]
tests/v1/kv_connector/unit/test_mooncake_store_worker.py::test_store_recving_thread_single_group_load_failure PASSED                                                                                    [100%]
```

## Co-author
@LCAIZJ @Pz1116 @zmc1997
