### PR TITLE
[Bugfix] Fix cumulative Whisper timestamp drift from variable-length audio chunks

### DIFF
--- a/vllm/entrypoints/speech_to_text/base/serving.py
+++ b/vllm/entrypoints/speech_to_text/base/serving.py
@@ -160,7 +160,7 @@ class OpenAISpeechToText(OpenAIServing):
     def _decode_and_chunk_speech(
         self,
         audio_data: bytes,
-    ) -> tuple[list[np.ndarray], float]:
+    ) -> tuple[list[np.ndarray], list[float], float]:
         # Decode audio bytes.  For container formats (MP4, M4A, WebM) that
         # soundfile cannot detect from a BytesIO stream, _load_audio_bytes
         # transparently falls back to ffmpeg via an in-memory fd.
@@ -197,7 +197,19 @@ class OpenAISpeechToText(OpenAIServing):
                 min_energy_window_size=self.asr_config.min_energy_split_window_size,
             )
 
-        return chunks, duration
+        chunk_start_times = self._compute_chunk_start_times(chunks, sr)
+        return chunks, chunk_start_times, duration
+
+    @staticmethod
+    def _compute_chunk_start_times(
+        chunks: list[np.ndarray], sample_rate: float
+    ) -> list[float]:
+        chunk_start_times: list[float] = []
+        current_time = 0.0
+        for chunk in chunks:
+            chunk_start_times.append(current_time)
+            current_time += chunk.shape[-1] / sample_rate
+        return chunk_start_times
 
     async def _detect_language(
         self,
@@ -255,7 +267,7 @@ class OpenAISpeechToText(OpenAIServing):
         request: SpeechToTextRequest,
         audio_data: bytes,
         request_id: str,
-    ) -> tuple[list[EngineInput], float]:
+    ) -> tuple[list[EngineInput], list[float], float]:
         # Validate request
         request.language = self.model_cls.validate_language(request.language)
         request.to_language = (
@@ -272,7 +284,9 @@ class OpenAISpeechToText(OpenAIServing):
             )
 
         # Run cpu intensive preprocess step in a separate thread pool executor.
-        chunks, duration = await self._decode_and_chunk_speech_async(audio_data)
+        chunks, chunk_start_times, duration = await self._decode_and_chunk_speech_async(
+            audio_data
+        )
 
         if request.language is None and getattr(
             self.model_cls, "supports_explicit_language_detection", False
@@ -303,7 +317,7 @@ class OpenAISpeechToText(OpenAIServing):
 
         engine_inputs = await self.renderer.render_cmpl_async(parsed_prompts)
 
-        return engine_inputs, duration
+        return engine_inputs, chunk_start_times, duration
 
     def _preprocess_verbose_prompt(self, prompt: EncoderDecoderDictPrompt):
         dec_prompt = prompt["decoder_prompt"]
@@ -464,10 +478,12 @@ class OpenAISpeechToText(OpenAIServing):
 
         lora_request = self._maybe_get_adapters(request)
 
-        engine_inputs, duration_s = await self._preprocess_speech_to_text(
-            request=request,
-            audio_data=audio_data,
-            request_id=request_id,
+        engine_inputs, chunk_start_times, duration_s = (
+            await self._preprocess_speech_to_text(
+                request=request,
+                audio_data=audio_data,
+                request_id=request_id,
+            )
         )
 
         # Schedule the request and get the result generator.
@@ -579,16 +595,9 @@ class OpenAISpeechToText(OpenAIServing):
                 "translate": TranslationSegment,
             }
             segment_class: type[SpeechToTextSegment] = segments_types[self.task_type]
-            chunk_size_in_s = self.asr_config.max_audio_clip_s
-            if chunk_size_in_s is None:
-                assert len(list_result_generator) == 1, (
-                    "`max_audio_clip_s` is set to None, audio cannot be chunked"
-                )
             result_generator = merge_async_iterators(*list_result_generator)
             async for idx, op in result_generator:
-                start_time = (
-                    float(idx * chunk_size_in_s) if chunk_size_in_s is not None else 0.0
-                )
+                start_time = chunk_start_times[idx]
                 if request.response_format == "verbose_json":
                     assert op.outputs[0].logprobs
                     segments: list[SpeechToTextSegment] = self._get_verbose_segments(


### PR DESCRIPTION
Fixes #32588

## Root Cause

When audio exceeds the max clip duration, `split_audio()` splits at low-energy points within a 1-second overlap window, producing chunks shorter than the nominal `max_clip_duration_s`. The previous code used `idx * max_audio_clip_s` to compute chunk start times, which accumulated ~0.5s error per chunk (e.g., 5s after 10 segments).

## Fix

1. **New method** `_compute_chunk_start_times()` — computes actual start times from real sample counts of each chunk
2. **`_decode_and_chunk_speech()`** — now returns `(chunks, chunk_start_times, duration)` instead of `(chunks, duration)`
3. **`_preprocess_speech_to_text()`** — passes through `chunk_start_times`
4. **`_create_speech_to_text()`** — uses `chunk_start_times[idx]` instead of `float(idx * max_audio_clip_s)`

This correctly handles variable-length chunks from whisper split points and eliminates the accumulating timestamp drift.