### PR TITLE
[Bugfix][Quark] Keep fully-excluded fused MoE experts unquantized

### DIFF
--- a/tests/quantization/test_quark.py
+++ b/tests/quantization/test_quark.py
@@ -10,6 +10,7 @@ See also `tests/kernels/moe/test_ocp_mx_moe.py`.
 import importlib.metadata
 from dataclasses import dataclass
 from importlib.util import find_spec
+from unittest.mock import patch
 
 import huggingface_hub
 import lm_eval
@@ -17,7 +18,9 @@ import pytest
 import torch
 from packaging import version
 
+from vllm.model_executor.layers.quantization.quark import quark as quark_mod
 from vllm.model_executor.layers.quantization.quark.quark import (  # noqa: E501
+    QuarkConfig,
     QuarkLinearMethod,
     QuarkW8A8Fp8,
     QuarkW8A8Int8,
@@ -533,3 +536,81 @@ def test_substr_match_on_fused_name():
         fused_mapping=FUSED_MAPPING,
         skip_with_substr=True,
     )
+
+
+class _FakeRoutedExperts:
+    """Minimal stand-in for a fused MoE (RoutedExperts) module."""
+
+    def __init__(self):
+        self.moe_config = object()
+
+
+def _make_quark_config(exclude):
+    qc = QuarkConfig(quant_config={"exclude": list(exclude)})
+    qc.packed_modules_mapping = {}
+    return qc
+
+
+def test_fully_excluded_fused_moe_is_unquantized():
+    # A nextn/MTP layer kept in bf16 has its experts excluded per leaf
+    # (model.layers.N.mlp.experts.<i>.<proj>). The fused module is queried by
+    # the coarse prefix model.layers.N.mlp.experts, so it must be detected as
+    # excluded and built unquantized rather than with the MXFP4 scheme.
+    exclude = [
+        f"model.layers.92.mlp.experts.{i}.{proj}"
+        for i in range(3)
+        for proj in ("gate_proj", "up_proj", "down_proj")
+    ]
+    qc = _make_quark_config(exclude)
+    layer = _FakeRoutedExperts()
+    sentinel = object()
+
+    with (
+        patch.object(quark_mod, "RoutedExperts", _FakeRoutedExperts),
+        patch.object(
+            quark_mod, "UnquantizedFusedMoEMethod", return_value=sentinel
+        ) as unq,
+        patch.object(quark_mod.QuarkMoEMethod, "get_moe_method") as get_moe,
+    ):
+        method = qc.get_quant_method(layer, prefix="model.layers.92.mlp.experts")
+
+    assert method is sentinel
+    unq.assert_called_once_with(layer.moe_config)
+    get_moe.assert_not_called()
+    # The exclude list must not be mutated in place.
+    assert qc.quant_config["exclude"] == exclude
+
+
+def test_non_excluded_fused_moe_stays_quantized():
+    qc = _make_quark_config(exclude=["model.layers.0.self_attn.q_proj"])
+    layer = _FakeRoutedExperts()
+    sentinel = object()
+
+    with (
+        patch.object(quark_mod, "RoutedExperts", _FakeRoutedExperts),
+        patch.object(
+            quark_mod.QuarkMoEMethod, "get_moe_method", return_value=sentinel
+        ) as get_moe,
+    ):
+        method = qc.get_quant_method(layer, prefix="model.layers.0.mlp.experts")
+
+    assert method is sentinel
+    get_moe.assert_called_once()
+
+
+def test_missing_exclude_key_does_not_crash():
+    qc = QuarkConfig(quant_config={})
+    qc.packed_modules_mapping = {}
+    layer = _FakeRoutedExperts()
+    sentinel = object()
+
+    with (
+        patch.object(quark_mod, "RoutedExperts", _FakeRoutedExperts),
+        patch.object(
+            quark_mod.QuarkMoEMethod, "get_moe_method", return_value=sentinel
+        ) as get_moe,
+    ):
+        method = qc.get_quant_method(layer, prefix="model.layers.0.mlp.experts")
+
+    assert method is sentinel
+    get_moe.assert_called_once()

--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -9,7 +9,10 @@ from transformers import PretrainedConfig
 
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
-from vllm.model_executor.layers.fused_moe import RoutedExperts
+from vllm.model_executor.layers.fused_moe import (
+    RoutedExperts,
+    UnquantizedFusedMoEMethod,
+)
 from vllm.model_executor.layers.linear import (
     LinearBase,
     LinearMethodBase,
@@ -144,7 +147,7 @@ class QuarkConfig(QuantizationConfig):
         self, layer: torch.nn.Module, prefix: str
     ) -> "QuantizeMethodBase | None":
         # Check if the layer is skipped for quantization.
-        exclude_layers = cast(list[str], self.quant_config.get("exclude"))
+        exclude_layers = cast(list[str], self.quant_config.get("exclude")) or []
         if should_ignore_layer(
             prefix, ignore=exclude_layers, fused_mapping=self.packed_modules_mapping
         ):
@@ -170,6 +173,20 @@ class QuarkConfig(QuantizationConfig):
             return QuarkKVCacheMethod(self)
 
         if isinstance(layer, RoutedExperts):
+            # Quark enumerates excluded (bf16) experts per leaf
+            # (e.g. "model.layers.N.mlp.experts.<i>.<proj>"), but the fused
+            # experts module is queried by the coarse prefix
+            # "model.layers.N.mlp.experts", which those leaf names never match
+            # via should_ignore_layer(). When the whole fused experts module is
+            # excluded (e.g. a GLM-5.2 / DeepSeek-family nextn layer kept in
+            # bf16), build it unquantized instead of forcing the checkpoint's
+            # target scheme (which would pack the bf16 weights to half width and
+            # crash at load). Mirrors sgl-project/sglang#30265, applied at
+            # vLLM's MoE dispatch point rather than by mutating the exclude list.
+            if any(
+                e.startswith(prefix + ".") for e in exclude_layers if "experts" in e
+            ):
+                return UnquantizedFusedMoEMethod(layer.moe_config)
             return QuarkMoEMethod.get_moe_method(self, module=layer, layer_name=prefix)
         return None
 


### PR DESCRIPTION
Excluded bf16 fused experts (e.g. GLM-5.2/DeepSeek MTP nextn layers) were wrongly built with MXFP4 and crashed at load; return UnquantizedFusedMoEMethod at the RoutedExperts dispatch point.


## Purpose
Fix a load-time crash for Quark **MXFP4** checkpoints that keep an entire fused
MoE (routed experts) module in **bf16** — e.g. GLM-5.2 / DeepSeek-family
**nextn (MTP)** layers — when speculative decoding is enabled.
Quark enumerates the excluded (bf16) experts **per leaf**
(`model.layers.N.mlp.experts.<i>.<proj>`), but the fused experts module is
queried by the **coarse prefix** `model.layers.N.mlp.experts`. Those per-leaf
names never match the coarse prefix via `should_ignore_layer()`, so the module
was built with the checkpoint's target MXFP4 scheme. That packs the bf16
weights to half width and crashes at load:
RuntimeError: The size of tensor a (256) must match the size of tensor b (512) at non-singleton dimension 1 File ".../vllm/model_executor/models/deepseek_mtp.py", line 438, in load_weights

Only `MXFP4 + MTP` is affected; `MXFP4` without MTP and `FP8 + MTP` both work.

## Fix
At the `RoutedExperts` dispatch point in `QuarkConfig.get_quant_method`, detect
whether any excluded leaf belongs to this fused module
(`any(e.startswith(prefix + ".") for e in exclude_layers if "experts" in e)`)
and, if so, return `UnquantizedFusedMoEMethod`. The exclude list is only read,
never mutated, so no shared config is polluted. Model-agnostic: any family
reusing `deepseek_mtp` with a bf16 nextn layer is fixed.

## Relation to prior art
Same failure mode as #39475 (moe_wna16) and #44087 (NVFP4): excluded MoE
experts are enumerated per leaf, so the fused module's coarse prefix never
matches the ignore list. Rather than patching each MTP model file
(#39475 lists deepseek_mtp/glm4_moe_mtp as pending follow-ups) or scanning
the checkpoint index on disk (#43319), this fixes it once at Quark's MoE
dispatch point for every family reusing deepseek_mtp, and only reads the
exclude list (no quant_config mutation, unlike the copy.copy discussion in
#37667).

## Test Plan
- Serve GLM-5.2-MXFP4 (Quark) on ROCm, TP=4, with
  `--speculative-config '{"method":"mtp","num_speculative_tokens":3}'`,
  `--kv-cache-dtype fp8`. Previously crashed at weight load.
- Send a chat request and inspect output correctness.
- Read `SpecDecoding metrics` from the server log to confirm MTP is effective.
- Confirm non-excluded MoE layers are still quantized (unchanged behavior).

## Test Result
- **Loads and serves**: startup reaches `Application startup complete`; all 282
  checkpoint shards load with no tensor-size mismatch.
- **Output correct**: coherent reasoning + correct answer, `finish_reason=stop`.
- **MTP effective**: `Mean acceptance length: 3.22`, per-position acceptance
  `0.870 / 0.739 / 0.609`, avg draft acceptance `73.9%`.
- **No regression**: main-model MXFP4 MoE layers remain quantized.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

