### PR TITLE
[KV Connector][Mooncake] Skip lookup for locally reused prefix

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
@@ -474,6 +474,7 @@ class _StubLookupClient:
     def __init__(self, hit_tokens: int) -> None:
         self._hit_tokens = hit_tokens
         self.num_tokens: list[int] = []
+        self.discarded_request_ids: list[str] = []
 
     def lookup(
         self,
@@ -484,6 +485,9 @@ class _StubLookupClient:
     ) -> int:
         self.num_tokens.append(num_tokens)
         return self._hit_tokens
+
+    def discard(self, req_id: str) -> None:
+        self.discarded_request_ids.append(req_id)
 
 
 def test_full_external_hit_keeps_kvpool_cached_tokens_block_aligned():
@@ -514,11 +518,8 @@ def test_full_external_hit_keeps_kvpool_cached_tokens_block_aligned():
     assert load_spec.kvpool_cached_tokens % 16 == 0
 
 
-def test_full_external_hit_with_full_local_hit_skips_load():
-    # When local prefix cache already covers the block-aligned external hit,
-    # there is nothing for the connector to load. The pre-fix behavior would
-    # have scheduled a 15-token load that the recv thread couldn't translate
-    # into any block-aligned key.
+def test_full_local_hit_skips_external_lookup():
+    # The maximum usable external hit for 48 tokens is 32.
     scheduler = _make_bare_scheduler()
     scheduler.load_async = True
     scheduler.client = _StubLookupClient(hit_tokens=32)
@@ -535,4 +536,6 @@ def test_full_external_hit_with_full_local_hit_skips_load():
 
     assert need_to_allocate == 0
     assert load_async is False
+    assert scheduler.client.num_tokens == []
+    assert scheduler.client.discarded_request_ids == ["req-0"]
     assert "req-0" not in scheduler.load_specs

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -83,6 +83,13 @@ class MooncakeStoreScheduler:
         if request.num_tokens < self._block_size:
             return 0, False
 
+        max_usable_external_hit_tokens = (
+            (request.num_tokens - 1) // self._block_size * self._block_size
+        )
+        if num_computed_tokens >= max_usable_external_hit_tokens:
+            self.client.discard(request.request_id)
+            return 0, False
+
         num_external_hit_tokens = self.client.lookup(
             request.request_id,
             request.num_tokens,


### PR DESCRIPTION
## Purpose
Skip Mooncake Store lookup when the local prefix cache already covers the maximum usable external prefix.

A full external hit is already clamped to the following block-aligned range:

```python
(request.num_tokens - 1) // block_size * block_size
```

When `num_computed_tokens` has reached this range, an external lookup cannot
produce any loadable KV blocks. Return early instead of issuing the lookup.


## Test 
```bash
python -m pytest  tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py -q
```

The added tests cover:
- local cache fully covers the usable external prefix: no lookup is issued;
- local cache does not fully cover the usable external prefix: lookup and load
  planning remain unchanged.
