### PR TITLE
[XPU][UT]Fix InternS1ProForConditionalGeneration AssertionError

### DIFF
--- a/tests/models/utils.py
+++ b/tests/models/utils.py
@@ -468,6 +468,9 @@ def dummy_hf_overrides(
     # Kimi uses `num_expert_group` instead of `n_group`.
     if n_group is None:
         n_group = getattr(text_config, "num_expert_group", None)
+    # InternS1Pro uses `router_n_groups` instead of `n_group`.
+    if n_group is None:
+        n_group = getattr(text_config, "router_n_groups", None)
     num_experts = n_group * 2 if n_group is not None else 2
 
     # we use three layers for Gemma-3n to check
@@ -515,6 +518,9 @@ def dummy_hf_overrides(
             "EagleLlama4ForCausalLM",
         ):
             num_experts_per_tok = 1
+        elif model_arch == "InternS1ProForConditionalGeneration":
+            assert n_group is not None
+            num_experts_per_tok = n_group
         update_dict.update(
             {
                 "num_experts": num_experts,


### PR DESCRIPTION
Fix UT tests/models/test_initialization.py::test_can_initialize_large_subset[InternS1ProForConditionalGeneration] meet AssertionError: 2 cannot be divided by 8

Root cause: InternS1Pro uses `router_n_groups` instead of `n_group`. 