### PR TITLE
Update LayerNorm and dtype handling in gemma4_unified

### DIFF
--- a/vllm/model_executor/models/gemma4_unified.py
+++ b/vllm/model_executor/models/gemma4_unified.py
@@ -47,6 +47,7 @@ from vllm.model_executor.models.gemma4_mm import (
 )
 from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.platforms import current_platform
 
 from .utils import (
     AutoWeightsLoader,
@@ -84,17 +85,28 @@ class Gemma4UnifiedVisionEmbedder(nn.Module):
         super().__init__()
         patch_dim = config.model_patch_size**2 * 3
         mm_embed_dim = config.mm_embed_dim
+        config_dtype = getattr(config, "dtype", None)
+        self._use_fp32_vision_projection = (
+            config_dtype is not None
+            and config_dtype not in current_platform.supported_dtypes
+        )
+        projection_dtype = (
+            torch.float32
+            if self._use_fp32_vision_projection
+            else torch.get_default_dtype()
+        )
 
         self.patch_ln1 = nn.LayerNorm(patch_dim)
         self.patch_dense = ColumnParallelLinear(
             patch_dim,
             mm_embed_dim,
             bias=True,
+            params_dtype=projection_dtype,
             quant_config=quant_config,
             prefix=f"{prefix}.patch_dense",
             gather_output=True,
         )
-        self.patch_ln2 = nn.LayerNorm(mm_embed_dim)
+        self.patch_ln2 = nn.LayerNorm(mm_embed_dim, dtype=projection_dtype)
 
         self.pos_embedding = nn.Parameter(
             torch.zeros(config.mm_posemb_size, 2, mm_embed_dim)
@@ -123,8 +135,12 @@ class Gemma4UnifiedVisionEmbedder(nn.Module):
         pixel_position_ids: torch.Tensor,
     ) -> torch.Tensor:
         hidden_states = self.patch_ln1(pixel_values.to(self.pos_embedding.dtype))
+        if self._use_fp32_vision_projection:
+            hidden_states = hidden_states.float()
         hidden_states, _ = self.patch_dense(hidden_states)
         hidden_states = self.patch_ln2(hidden_states)
+        if self._use_fp32_vision_projection:
+            hidden_states = hidden_states.to(self.pos_embedding.dtype)
 
         pos_embs = self._factorized_posemb(pixel_position_ids)
         hidden_states = hidden_states + pos_embs


### PR DESCRIPTION


## Purpose

Fixes #48231.

Gemma4 Unified image requests can produce no assistant content when the checkpoint dtype is unsupported by the current platform and vLLM falls back from BF16 to FP16. The encoder-free vision `patch_dense` projection can overflow before its following LayerNorm normalizes the result. LayerNorm then expands the `Inf` into all-NaN image embeddings, which propagate through the language model and logits and cause repeated token ID 0 generation.

This change checks whether the vision config dtype is included in `current_platform.supported_dtypes`. When it is unsupported, `vision_embedder.patch_dense` and `patch_ln2` are loaded and evaluated in FP32, and the normalized result is cast back to the model dtype before the remaining multimodal path.

The fallback is platform-agnostic and retains the existing `ColumnParallelLinear(gather_output=True)` tensor-parallel behavior. Platforms that support the checkpoint dtype keep the normal model-construction dtype.

## Test Plan

1. Serve a BF16 `Gemma4UnifiedForConditionalGeneration` checkpoint on an NVIDIA GeForce RTX 2080 Ti (compute capability 7.5), where vLLM automatically falls back to FP16.
2. Send a chat-completions request containing a generated 512x512 RGB PNG and the prompt `What color is in this image?` with `return_token_ids=true`.
3. Verify the vision embeddings, multimodal features, language-model hidden states, and decode logits contain no NaN or Inf values.
4. Verify the API returns normal assistant content instead of generating token ID 0 until the completion limit.

## Test Result

Before:

```text
patch_dense:       256 Inf values, one per valid patch row, output channel 1215
vision embeddings: 983,040 NaN values
LM hidden state:   all NaN
decode logits:     all NaN
API content:       null
finish reason:     length
completion tokens: [0, 0, 0, ...]
```

After:

```text
vision embedded: 1,075,200 / 1,075,200 finite
valid features:    983,040 /   983,040 finite
LM hidden:       1,067,520 / 1,067,520 finite
decode logits:     262,144 /   262,144 finite
NaN values: 0
API result: normal assistant content
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. No documentation update is required for this bug fix.
</details>

