### PR TITLE
[Bugfix] Fix Responses API crash on empty or refusal assistant content

### DIFF
--- a/tests/entrypoints/openai/responses/test_responses_utils.py
+++ b/tests/entrypoints/openai/responses/test_responses_utils.py
@@ -9,6 +9,7 @@ from openai.types.responses.response_function_tool_call_output_item import (
     ResponseFunctionToolCallOutputItem,
 )
 from openai.types.responses.response_output_message import ResponseOutputMessage
+from openai.types.responses.response_output_refusal import ResponseOutputRefusal
 from openai.types.responses.response_output_text import ResponseOutputText
 from openai.types.responses.response_reasoning_item import (
     Content,
@@ -265,6 +266,37 @@ class TestResponsesUtils:
         formatted_item = _single_chat_message(output_item)
         assert formatted_item["role"] == "assistant"
         assert formatted_item["content"] == "dongyi"
+
+    def test_output_message_empty_or_refusal_content(self):
+        # An assistant message replayed through `input` may have empty content
+        # or a refusal-only part (which has no `.text`). Neither carries output
+        # text, and both used to crash here (IndexError / AttributeError).
+        empty = ResponseOutputMessage(
+            id="msg_empty",
+            content=[],
+            role="assistant",
+            status="completed",
+            type="message",
+        )
+        formatted_item = _single_chat_message(empty)
+        assert formatted_item["role"] == "assistant"
+        assert formatted_item["content"] == ""
+
+        refusal = ResponseOutputMessage(
+            id="msg_refusal",
+            content=[
+                ResponseOutputRefusal(
+                    refusal="I can't help with that",
+                    type="refusal",
+                )
+            ],
+            role="assistant",
+            status="completed",
+            type="message",
+        )
+        formatted_item = _single_chat_message(refusal)
+        assert formatted_item["role"] == "assistant"
+        assert formatted_item["content"] == ""
 
 
 class TestReasoningItemContentPriority:

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -292,7 +292,12 @@ def _construct_message_from_response_item(
             "reasoning": reasoning,
         }
     elif isinstance(item, ResponseOutputMessage):
-        output_text = item.content[0].text
+        # content may be empty or hold a refusal part (which has no `.text`),
+        # so grab the first output_text part and fall back to an empty string.
+        output_text = next(
+            (part.text for part in item.content if part.type == "output_text"),
+            "",
+        )
         if prev_assistant_msg:
             previous_content = prev_assistant_msg.get("content")
             if previous_content is None:


### PR DESCRIPTION
No linked issue — found by reading the Responses API input-construction code.

## Purpose

`_construct_message_from_response_item` in `vllm/entrypoints/openai/responses/utils.py` indexes `item.content[0].text` directly when it hits a `ResponseOutputMessage`:

```python
elif isinstance(item, ResponseOutputMessage):
    output_text = item.content[0].text
```

This branch is reached from a user request: `serving.py` → `construct_input_messages` → `construct_chat_messages_with_tool_call` → `_construct_message_from_response_item`. So when a client replays a previous assistant turn through `input`, two schema-valid shapes crash the server with a 500:

- **empty content** (`content=[]`) → `IndexError: list index out of range`
- **refusal content** (a `ResponseOutputRefusal` part, which has `.refusal`, not `.text`) → `AttributeError: 'ResponseOutputRefusal' object has no attribute 'text'`

Both are valid `ResponseOutputMessage`s per the OpenAI schema, so this is a crash on valid input, not a malformed-request case.

Every sibling branch in the same function already guards its content access — the reasoning branch uses `elif item.content and len(item.content) >= 1:` and the dict-assistant branch uses `elif isinstance(content, list) and content:`. Only the `ResponseOutputMessage` branch indexes blindly.

## Fix

Grab the first `output_text` part and fall back to an empty string:

```python
output_text = next(
    (part.text for part in item.content if part.type == "output_text"),
    "",
)
```

This is behavior-preserving for the normal single-text case (`content=[ResponseOutputText(text=...)]` still yields that text) and simply avoids the crash for empty / refusal-only content.

## Test

Added `TestResponsesUtils::test_output_message_empty_or_refusal_content` in `tests/entrypoints/openai/responses/test_responses_utils.py`, covering both the empty-content and refusal-only cases (each previously crashed). `ruff check` and `ruff format` are clean.
