### PR TITLE
[Core] Add operator opt-out for the expandable_segments KV-connector rejection

### DIFF
--- a/tests/v1/kv_connector/unit/test_config.py
+++ b/tests/v1/kv_connector/unit/test_config.py
@@ -103,13 +103,20 @@ def _build_config(
     kv_connector: str | None,
     enable_sleep_mode: bool = False,
     enable_cumem_allocator: bool = False,
+    kv_connector_supports_expandable_segments: bool = False,
 ) -> VllmConfig:
     """Build a VllmConfig that exercises _verify_kv_transfer_compat without
     requiring a real model (avoids HF downloads in CI)."""
     from types import SimpleNamespace
 
     kv_transfer_config = (
-        KVTransferConfig(kv_connector=kv_connector, kv_role="kv_both")
+        KVTransferConfig(
+            kv_connector=kv_connector,
+            kv_role="kv_both",
+            kv_connector_supports_expandable_segments=(
+                kv_connector_supports_expandable_segments
+            ),
+        )
         if kv_connector is not None
         else None
     )
@@ -150,6 +157,32 @@ def test_kv_connector_allows_expandable_segments_with_cumem_allocator(
     """Manual CuMem allocation must also bypass expandable_segments."""
     monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
     _build_config(kv_connector="NixlConnector", enable_cumem_allocator=True)
+
+
+@pytest.mark.parametrize("kv_connector", ["LMCacheMPConnector", "LMCacheConnectorV1"])
+def test_kv_connector_allows_expandable_segments_with_operator_opt_in(
+    monkeypatch, kv_connector
+):
+    """Copy-based connectors (CUDA kernels / cudaMemcpy at transfer time, no
+    pinned/registered KV memory) dereference virtual addresses on every
+    transfer, so VMM physical remaps are transparent to them. The operator
+    can assert that via kv_connector_supports_expandable_segments to skip
+    the conservative rejection."""
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    _build_config(
+        kv_connector=kv_connector,
+        kv_connector_supports_expandable_segments=True,
+    )
+
+
+def test_kv_connector_opt_in_defaults_off(monkeypatch):
+    """Without the explicit operator opt-in the rejection must still fire."""
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    with pytest.raises(ValueError, match="expandable_segments"):
+        _build_config(
+            kv_connector="LMCacheMPConnector",
+            kv_connector_supports_expandable_segments=False,
+        )
 
 
 def test_kv_connector_allows_other_alloc_conf(monkeypatch):

--- a/vllm/config/kv_transfer.py
+++ b/vllm/config/kv_transfer.py
@@ -71,6 +71,19 @@ class KVTransferConfig:
     'recompute': reschedule the request to recompute failed blocks
     'fail': immediately fail the request with an error finish reason (default)"""
 
+    kv_connector_supports_expandable_segments: bool = False
+    """Operator assertion that the configured KV connector never pins or
+    registers KV cache device memory (no RDMA memory regions, no GDS/cuFile
+    registration, no CUDA IPC handles held across steps) and instead moves KV
+    with CUDA kernels or cudaMemcpy at transfer time. Such copy-based
+    connectors dereference virtual addresses on every transfer, so they are
+    unaffected when PyTorch's expandable_segments allocator remaps physical
+    pages, and the conservative expandable_segments incompatibility check can
+    be skipped. Leave False (default) unless you have verified this for your
+    connector: enabling it with a connector that does register KV memory (e.g.
+    NixlConnector, MooncakeConnector) leads to silent KV corruption or RDMA
+    failures after a remap."""
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -899,6 +899,17 @@ class VllmConfig:
             return
         if self.model_config is not None and (self.model_config.enable_cumem_allocator):
             return
+        # Copy-based connectors (CUDA kernels / cudaMemcpy at transfer time,
+        # no pinned/registered KV memory) dereference virtual addresses on
+        # every transfer, so VMM physical remaps are transparent to them. The
+        # operator can assert that property to skip the conservative check.
+        if self.kv_transfer_config.kv_connector_supports_expandable_segments:
+            logger.info_once(
+                "Allowing KV connector %s with expandable_segments:True "
+                "because kv_connector_supports_expandable_segments is set.",
+                self.kv_transfer_config.kv_connector,
+            )
+            return
 
         raise ValueError(
             f"KV connector {self.kv_transfer_config.kv_connector} is "
@@ -907,10 +918,13 @@ class VllmConfig:
             "allocator can remap KV cache virtual addresses to different "
             "physical pages, invalidating any pinned/registered KV memory "
             "(e.g. IB memory regions registered by NIXL or Mooncake). Either "
-            "unset expandable_segments:True or enable the cumem allocator "
+            "unset expandable_segments:True, enable the cumem allocator "
             "(sleep mode does this automatically and also "
             "routes KV allocations through CuMemAllocator's pool, where "
-            "expandable_segments is automatically disabled)."
+            "expandable_segments is automatically disabled), or — only if your "
+            "connector never pins/registers KV cache memory and is purely "
+            "copy-based — set "
+            "kv_transfer_config.kv_connector_supports_expandable_segments."
         )
 
     def __post_init__(self):


### PR DESCRIPTION
## Purpose

FIX #48242

`_verify_kv_transfer_compat` conservatively rejects every KV connector under `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`. That is correct for connectors that pin/register KV cache memory (NIXL `ibv_reg_mr`, Mooncake), but copy-based connectors (CUDA kernels / `cudaMemcpy` at transfer time, e.g. the LMCache connectors) dereference virtual addresses on every transfer and are unaffected by VMM physical remaps.

Both sanctioned escapes are harmful on unified-memory platforms (GB10/DGX Spark): dropping `expandable_segments` costs the anti-fragmentation margin (CUDA OOM at previously-working `gpu_memory_utilization`), and `enable_cumem_allocator` routes the weights load through the CuMem pool too (`gpu_worker.py` wraps both `tag="weights"` and `tag="kv_cache"`), which pins ~weights-sized RM sysmem and hard-crashed both nodes mid weight-load (`NVRM: NV_ERR_NO_MEMORY` from `nv_alloc_system_pages`). Details and evidence in the linked issue.

This PR adds `KVTransferConfig.kv_connector_supports_expandable_segments` (default `False` — behavior unchanged): an explicit operator assertion that the configured connector never pins/registers KV cache device memory, which skips the rejection. The error message now mentions the opt-out.

## Test Plan

```
pytest tests/v1/kv_connector/unit/test_config.py
```

New tests:
- `test_kv_connector_allows_expandable_segments_with_operator_opt_in` (LMCacheMPConnector / LMCacheConnectorV1 pass with the opt-in)
- `test_kv_connector_opt_in_defaults_off` (without the opt-in the ValueError still fires)

Existing rejection/exemption tests unchanged and still passing.

## Test Result

All 10 `_verify_kv_transfer_compat` tests in the file pass (3 rejection params, sleep-mode/cumem/other-alloc-conf/no-connector exemptions, 2 new opt-in params, 1 new default-off), verified by applying the same patch to a vLLM 0.23.1 install (function identical to main) and running the updated test file:

```
10 passed
```

(The unrelated `test_kv_connector[...]` offloading-translation cases in the same file require the cpu_test CI image and were failing identically before this change in the local environment.)
