### PR TITLE
[DCP] Add FlashInfer fused A2A backend for decode context parallelism

### DIFF
--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -38,6 +38,7 @@ DistributedExecutorBackend = Literal["ray", "mp", "uni", "external_launcher"]
 DataParallelBackend = Literal["ray", "mp"]
 EPLBPolicyOption = Literal["default"]
 DCPCommBackend = Literal["ag_rs", "a2a"]
+DCPA2ABackend = Literal["auto", "nccl", "flashinfer"]
 EPLBCommunicatorBackend = Literal["torch_nccl", "torch_gloo", "nixl", "pynccl"]
 All2AllBackend = Literal[
     "naive",
@@ -359,6 +360,18 @@ class ParallelConfig:
       per layer for MLA models.
     """
 
+    dcp_a2a_backend: DCPA2ABackend = "auto"
+    """Kernel for the DCP All-to-All exchange (only used when
+    `dcp_comm_backend="a2a"`).
+    - "auto": pick automatically — FlashInfer's fused LL128 A2A on Blackwell
+      (sm_100+) under full-cudagraph decode, where it beats NCCL packed; NCCL
+      packed everywhere else. Falls back to NCCL if the FlashInfer MNNVL
+      workspace cannot initialize.
+    - "nccl": always use the NCCL packed all_to_all path.
+    - "flashinfer": always use FlashInfer's fused LL128 A2A (still falls back to
+      NCCL if the MNNVL workspace cannot initialize).
+    """
+
     cp_kv_cache_interleave_size: int = 1
     """Interleave size of kv_cache storage while using DCP.
     Store interleave_size tokens on dcp_rank i, then store next
@@ -541,6 +554,12 @@ class ParallelConfig:
         if self.dcp_comm_backend == "a2a" and self.decode_context_parallel_size <= 1:
             raise ValueError(
                 "dcp_comm_backend='a2a' requires decode_context_parallel_size > 1."
+            )
+
+        if self.dcp_a2a_backend != "auto" and self.dcp_comm_backend != "a2a":
+            logger.warning(
+                "dcp_a2a_backend=%r is ignored unless dcp_comm_backend='a2a'.",
+                self.dcp_a2a_backend,
             )
 
         return self

--- a/vllm/distributed/dcp_alltoall_flashinfer.py
+++ b/vllm/distributed/dcp_alltoall_flashinfer.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Workspace manager for FlashInfer's DCP all-to-all kernel.
+
+This module wraps FlashInfer's ``decode_cp_a2a_*`` API (added in
+flashinfer-ai/flashinfer#2951) so that vLLM's DCP A2A path can use it as
+an alternative to ``dist.all_to_all_single``.
+
+Lifecycle (per CP group, done once):
+  1. Allocate the MNNVL-backed workspace.
+  2. ``decode_cp_a2a_init_workspace`` to reset the FIFO.
+  3. CPU barrier across the CP group so every rank's init has completed
+     before any rank issues the first all-to-all (otherwise a peer can
+     start writing into a not-yet-initialized FIFO).
+
+Per-call:
+  ``run(partial_o, softmax_stats)`` invokes ``decode_cp_a2a_alltoall``.
+  The kernel is a single fused LL128 exchange — no extra Python
+  overhead beyond the call.
+
+Workspaces are cached by ``(cp_rank, cp_size)`` so the allocate+init
+cost is paid exactly once per process.
+
+Note on ``enable_pdl=False``
+============================
+We pass ``enable_pdl=False`` to match TensorRT-LLM's binding
+(``cpp/tensorrt_llm/thop/alltoallOp.cpp``), which uses the 3-arg
+``launchHelixAllToAll`` overload (no PDL). FlashInfer 0.6.9's Python
+binding defaults to PDL on SM90+, but TRT-LLM has shipped without it
+for production helix CP — so we follow that conservative choice.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import torch
+import torch.distributed as dist
+
+if TYPE_CHECKING:
+    from torch.distributed import ProcessGroup
+
+logger = logging.getLogger(__name__)
+
+
+def _to_torch(t: Any) -> torch.Tensor:
+    """Convert a tvm-ffi tensor (or any DLPack object) to ``torch.Tensor``."""
+    if isinstance(t, torch.Tensor):
+        return t
+    return torch.from_dlpack(t)
+
+
+class DCPAllToAllFlashInfer:
+    """Manages FlashInfer DCP workspace and executes the all-to-all kernel.
+
+    Usage::
+
+        mgr = DCPAllToAllFlashInfer.get(
+            cp_rank=cp_group.rank_in_group,
+            cp_size=cp_group.world_size,
+            cp_cpu_group=cp_group.cpu_group,
+        )
+        recv_o, recv_stats = mgr.run(partial_o, softmax_stats)
+    """
+
+    _cache: dict[tuple[int, int], DCPAllToAllFlashInfer] = {}
+
+    def __init__(
+        self,
+        cp_rank: int,
+        cp_size: int,
+        workspace: torch.Tensor,
+        *,
+        use_mnnvl: bool,
+        cp_cpu_group: ProcessGroup | None = None,
+    ) -> None:
+        self.cp_rank = cp_rank
+        self.cp_size = cp_size
+        self.workspace = workspace
+        self._use_mnnvl = use_mnnvl
+        self._cp_cpu_group = cp_cpu_group
+
+    @staticmethod
+    def get(
+        cp_rank: int,
+        cp_size: int,
+        cp_cpu_group: ProcessGroup | None = None,
+    ) -> DCPAllToAllFlashInfer:
+        """Return a ready-to-use manager for the given ``(cp_rank, cp_size)``.
+
+        Allocates and initializes the workspace on first call; subsequent
+        calls return the cached instance.
+
+        Args:
+            cp_rank: This rank's position in the CP group.
+            cp_size: CP group size.
+            cp_cpu_group: CPU ``ProcessGroup`` for the CP ranks. Required
+                for the post-init barrier and (when present) drives the
+                MNNVL communicator. Pass the ``cpu_group`` from the DCP
+                ``GroupCoordinator``.
+        """
+        key = (cp_rank, cp_size)
+        cached = DCPAllToAllFlashInfer._cache.get(key)
+        if cached is not None:
+            return cached
+
+        workspace, used_mnnvl = DCPAllToAllFlashInfer._allocate(
+            cp_rank, cp_size, cp_cpu_group
+        )
+
+        from flashinfer.comm import decode_cp_a2a_init_workspace
+
+        decode_cp_a2a_init_workspace(workspace, cp_rank, cp_size)
+
+        # Cross-rank barrier so every rank's FIFO init is visible to peers
+        # before any of them starts writing to a peer's slot.
+        if cp_cpu_group is not None:
+            dist.barrier(group=cp_cpu_group)
+        else:
+            torch.accelerator.synchronize()
+
+        mgr = DCPAllToAllFlashInfer(
+            cp_rank,
+            cp_size,
+            workspace,
+            use_mnnvl=used_mnnvl,
+            cp_cpu_group=cp_cpu_group,
+        )
+        DCPAllToAllFlashInfer._cache[key] = mgr
+        logger.info(
+            "Rank %d: FlashInfer DCP A2A workspace ready "
+            "(cp_size=%d, mnnvl=%s, shape=%s)",
+            cp_rank,
+            cp_size,
+            used_mnnvl,
+            list(workspace.shape),
+        )
+        return mgr
+
+    @staticmethod
+    def _allocate(
+        cp_rank: int,
+        cp_size: int,
+        cp_cpu_group: ProcessGroup | None,
+    ) -> tuple[torch.Tensor, bool]:
+        """Allocate the MNNVL workspace; non-MNNVL is unsupported.
+
+        FlashInfer's ``decode_cp_a2a_alltoall`` kernel addresses peer FIFOs
+        through a single ``params.workspace + peer_rank * stride`` base
+        pointer. That only resolves correctly when the workspace is a
+        unified VA backed by MNNVL fabric memory. The plain ``torch.zeros``
+        fallback in PR #2951 hangs the kernel — see
+        ``project_dcp_a2a_h200_unsupported.md`` for a full diagnosis.
+        """
+        if cp_cpu_group is None:
+            raise RuntimeError(
+                "DCPAllToAllFlashInfer requires a Gloo CPU group for MNNVL "
+                "communicator setup; got cp_cpu_group=None."
+            )
+        workspace = DCPAllToAllFlashInfer._allocate_mnnvl(
+            cp_rank, cp_size, cp_cpu_group
+        )
+        return workspace, True
+
+    @staticmethod
+    def _allocate_mnnvl(
+        cp_rank: int,
+        cp_size: int,
+        cp_cpu_group: ProcessGroup | None,
+    ) -> torch.Tensor:
+        """Allocate an MNNVL-backed workspace visible across nodes.
+
+        We bypass FlashInfer's ``set_comm_from_config`` because its split
+        formula (``pp_rank * cp_size + cp_rank``) is meant for MoE A2A,
+        which groups TP peers together. For DCP A2A we want CP peers
+        grouped, which is exactly what ``cp_cpu_group`` already
+        represents — so we set ``MnnvlMemory.comm`` directly and skip
+        the split.
+        """
+        from flashinfer.comm import (
+            Mapping,
+            decode_cp_a2a_allocate_mnnvl_workspace,
+        )
+        from flashinfer.comm.mnnvl import MnnvlMemory, TorchDistBackend
+
+        MnnvlMemory.initialize()
+        MnnvlMemory.comm = TorchDistBackend(group=cp_cpu_group)
+
+        # Mapping is consumed by ``MnnvlMemory.__init__`` for segment
+        # layout; the comm is already correct so ``mnnvl_config`` is
+        # intentionally not passed (which suppresses the broken split).
+        mapping = Mapping(
+            world_size=cp_size,
+            rank=cp_rank,
+            cp_size=cp_size,
+            tp_size=1,
+            pp_size=1,
+        )
+        # New FlashInfer signature (post-#3210) takes mapping only;
+        # cp_size and cp_rank come from the mapping fields above.
+        return decode_cp_a2a_allocate_mnnvl_workspace(mapping)
+
+    def run(
+        self,
+        partial_o: torch.Tensor,
+        softmax_stats: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run the FlashInfer all-to-all and return ``(recv_o, recv_stats)``.
+
+        Args:
+            partial_o: ``[..., cp_size, D]``, half/bfloat16, contiguous.
+            softmax_stats: ``[..., cp_size, S]``, float32, contiguous,
+                ``S >= 2`` and even.
+
+        Returns:
+            ``(recv_o, recv_stats)`` with the same shapes/dtypes as the
+            inputs. Transpose property along the cp dimension:
+            ``recv_o[rank][..., peer, :] == send_o[peer][..., rank, :]``.
+        """
+        from flashinfer.comm import decode_cp_a2a_alltoall
+
+        if not getattr(self, "_first_call_logged", False):
+            logger.debug(
+                "FlashInfer DCP a2a first call: cp_rank=%d cp_size=%d "
+                "po_shape=%s po_dtype=%s",
+                self.cp_rank,
+                self.cp_size,
+                tuple(partial_o.shape),
+                partial_o.dtype,
+            )
+            self._first_call_logged = True
+
+        recv_o, recv_stats = decode_cp_a2a_alltoall(
+            partial_o,
+            softmax_stats,
+            self.workspace,
+            self.cp_rank,
+            self.cp_size,
+            enable_pdl=False,
+        )
+        return _to_torch(recv_o), _to_torch(recv_stats)
+
+    @staticmethod
+    def clear_cache() -> None:
+        """Drop all cached managers. For tests / shutdown only."""
+        DCPAllToAllFlashInfer._cache.clear()
+
+    def __repr__(self) -> str:
+        return (
+            f"DCPAllToAllFlashInfer(cp_rank={self.cp_rank}, "
+            f"cp_size={self.cp_size}, mnnvl={self._use_mnnvl}, "
+            f"workspace={tuple(self.workspace.shape)})"
+        )

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -96,6 +96,7 @@ from vllm.config.observability import DetailedTraceModules
 from vllm.config.parallel import (
     All2AllBackend,
     DataParallelBackend,
+    DCPA2ABackend,
     DCPCommBackend,
     DistributedExecutorBackend,
     ExpertPlacementStrategy,
@@ -479,6 +480,7 @@ class EngineArgs:
     prefill_context_parallel_size: int = ParallelConfig.prefill_context_parallel_size
     decode_context_parallel_size: int = ParallelConfig.decode_context_parallel_size
     dcp_comm_backend: DCPCommBackend = ParallelConfig.dcp_comm_backend
+    dcp_a2a_backend: DCPA2ABackend = ParallelConfig.dcp_a2a_backend
     dcp_kv_cache_interleave_size: int = ParallelConfig.dcp_kv_cache_interleave_size
     cp_kv_cache_interleave_size: int = ParallelConfig.cp_kv_cache_interleave_size
     data_parallel_size: int = ParallelConfig.data_parallel_size
@@ -1049,6 +1051,10 @@ class EngineArgs:
         parallel_group.add_argument(
             "--dcp-comm-backend",
             **parallel_kwargs["dcp_comm_backend"],
+        )
+        parallel_group.add_argument(
+            "--dcp-a2a-backend",
+            **parallel_kwargs["dcp_a2a_backend"],
         )
         parallel_group.add_argument(
             "--dcp-kv-cache-interleave-size",
@@ -2228,6 +2234,7 @@ class EngineArgs:
             worker_extension_cls=self.worker_extension_cls,
             decode_context_parallel_size=self.decode_context_parallel_size,
             dcp_comm_backend=self.dcp_comm_backend,
+            dcp_a2a_backend=self.dcp_a2a_backend,
             dcp_kv_cache_interleave_size=self.dcp_kv_cache_interleave_size,
             cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
             _api_process_count=self._api_process_count,

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -276,7 +276,10 @@ from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
 )
 from vllm.v1.attention.ops.common import cp_lse_ag_out_ar, cp_lse_ag_out_rs
-from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
+from vllm.v1.attention.ops.dcp_alltoall import (
+    dcp_a2a_lse_reduce,
+    ensure_dcp_a2a_backend,
+)
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.attention.ops.triton_merge_attn_states import mask_empty_context
 from vllm.v1.attention.selector import get_attn_backend
@@ -555,6 +558,8 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             and _vllm_config.parallel_config.decode_context_parallel_size > 1
             and _vllm_config.parallel_config.dcp_comm_backend == "a2a"
         )
+        if self.dcp_a2a:
+            ensure_dcp_a2a_backend(_vllm_config)
 
         self.is_aiter_triton_fp8_bmm_enabled = rocm_aiter_ops.is_fp8bmm_enabled()
 

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -30,7 +30,10 @@ from vllm.v1.attention.backends.fa_utils import (
 )
 from vllm.v1.attention.backends.utils import get_dcp_local_seq_lens
 from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
-from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
+from vllm.v1.attention.ops.dcp_alltoall import (
+    dcp_a2a_lse_reduce,
+    ensure_dcp_a2a_backend,
+)
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.worker.workspace import current_workspace_manager
 
@@ -825,6 +828,8 @@ class FlashAttentionImpl(AttentionImpl):
             and vllm_config.parallel_config.decode_context_parallel_size > 1
             and vllm_config.parallel_config.dcp_comm_backend == "a2a"
         )
+        if dcp_a2a:
+            ensure_dcp_a2a_backend(vllm_config)
         self.dcp_combine = dcp_a2a_lse_reduce if dcp_a2a else cp_lse_ag_out_rs
 
         self._dcp_dtype: torch.dtype | None = None

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -72,7 +72,10 @@ from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
 )
 from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
-from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
+from vllm.v1.attention.ops.dcp_alltoall import (
+    dcp_a2a_lse_reduce,
+    ensure_dcp_a2a_backend,
+)
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
@@ -695,6 +698,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self.dcp_a2a = (
             self.use_dcp and vllm_config.parallel_config.dcp_comm_backend == "a2a"
         )
+        if self.dcp_a2a:
+            ensure_dcp_a2a_backend(vllm_config)
 
         # Compatible with models with non-uniform per-layer head counts.
         self.num_qo_heads = get_num_attention_heads_from_layers(
@@ -1621,6 +1626,7 @@ class FlashInferImpl(AttentionImpl):
             and vllm_config.parallel_config.dcp_comm_backend == "a2a"
         )
         if dcp_a2a:
+            ensure_dcp_a2a_backend(vllm_config)
             self.dcp_combine = partial(dcp_a2a_lse_reduce, is_lse_base_on_e=False)
         else:
             self.dcp_combine = partial(cp_lse_ag_out_rs, is_lse_base_on_e=False)

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -20,6 +20,7 @@ Reference: https://arxiv.org/abs/2507.07120
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import torch
@@ -28,8 +29,108 @@ import torch.distributed as dist
 from vllm.triton_utils import tl, triton
 
 if TYPE_CHECKING:
+    from vllm.config import VllmConfig
     from vllm.distributed.parallel_state import GroupCoordinator
     from vllm.v1.attention.ops.common import CPTritonContext
+
+logger = logging.getLogger(__name__)
+
+
+# Module-level cache of the DCP A2A backend choice, resolved lazily by
+# ``ensure_dcp_a2a_backend`` the first time an attention backend selects the
+# A2A DCP-combine path. The dispatcher reads from cache during forward,
+# avoiding a dependency on ``get_current_vllm_config()`` that raises in V1's
+# async scheduling path.
+_DCP_A2A_BACKEND: str | None = None
+_DCP_A2A_INITIALIZED = False
+
+
+def set_dcp_a2a_backend(backend: str) -> None:
+    """Cache the DCP A2A backend on this worker process."""
+    global _DCP_A2A_BACKEND
+    _DCP_A2A_BACKEND = backend
+
+
+def _get_dcp_a2a_backend() -> str:
+    """Return the resolved DCP A2A kernel (``"nccl"`` or ``"flashinfer"``).
+
+    There is no user-facing flag: the choice is made automatically the first
+    time an attention backend selects the A2A combine path
+    (``ensure_dcp_a2a_backend``) — FlashInfer on Blackwell (sm_100+, where its
+    fused LL128 kernel is CUDA-graph captured and wins), NCCL packed everywhere
+    else — and cached here.
+    """
+    if _DCP_A2A_BACKEND is not None:
+        return _DCP_A2A_BACKEND
+    return "nccl"
+
+
+def ensure_dcp_a2a_backend(vllm_config: VllmConfig) -> None:
+    """Resolve the DCP A2A kernel and pre-allocate its workspace, once.
+
+    Called lazily from the attention backends when they select the A2A
+    DCP-combine path, so this hardware/feature-specific setup lives with the
+    feature rather than in the generic worker. Idempotent per process.
+
+    FlashInfer's fused LL128 A2A only wins when the decode a2a-reduce is
+    captured under a full CUDA graph on Blackwell (sm_100+); in eager /
+    piecewise-only cudagraph or on non-Blackwell its per-call launch overhead
+    makes it slower than NCCL packed, so those use NCCL.
+
+    The FlashInfer workspace must be allocated before CUDA-graph capture, which
+    holds because attention backends are constructed at model-runner /
+    attention-layer init, ahead of capture.
+
+    Args:
+        vllm_config: The active vLLM config, used to read the cudagraph mode
+            and the DCP group.
+    """
+    global _DCP_A2A_INITIALIZED
+    if _DCP_A2A_INITIALIZED:
+        return
+    _DCP_A2A_INITIALIZED = True
+
+    from vllm.config import CUDAGraphMode
+    from vllm.platforms import current_platform
+
+    cap = current_platform.get_device_capability()
+    cudagraph_mode = vllm_config.compilation_config.cudagraph_mode
+    decode_full_cudagraph = (
+        cudagraph_mode is not None
+        and cudagraph_mode.decode_mode() == CUDAGraphMode.FULL
+    )
+    use_fi = cap is not None and cap.major >= 10 and decode_full_cudagraph
+    if not use_fi:
+        set_dcp_a2a_backend("nccl")
+        return
+    set_dcp_a2a_backend("flashinfer")
+
+    from vllm.distributed.dcp_alltoall_flashinfer import DCPAllToAllFlashInfer
+    from vllm.distributed.parallel_state import get_dcp_group
+
+    g = get_dcp_group()
+    try:
+        DCPAllToAllFlashInfer.get(
+            cp_rank=g.rank_in_group,
+            cp_size=g.world_size,
+            cp_cpu_group=g.cpu_group,
+        )
+        logger.info("FlashInfer DCP A2A workspace pre-initialized.")
+    except Exception as e:
+        # FlashInfer A2A needs an MNNVL fabric workspace shared across the CP
+        # group. That works intra-node, and cross-node only on NVL72-class
+        # systems with IMEX/fabric handle exchange. On other setups the
+        # cross-node handle exchange (pidfd_open) or cuMemCreate(FABRIC) fails
+        # here. Rather than crash the engine, fall back to the NCCL all_to_all
+        # DCP path (the default; correct and portable).
+        logger.warning(
+            "FlashInfer DCP A2A workspace init failed (%s); falling back to "
+            "the NCCL all_to_all DCP path. FlashInfer A2A requires an MNNVL "
+            "fabric workspace across the CP group (GB200-NVL72-class for "
+            "cross-node); this configuration does not support it.",
+            repr(e),
+        )
+        set_dcp_a2a_backend("nccl")
 
 
 def _lse_weighted_combine(
@@ -432,8 +533,22 @@ def dcp_a2a_lse_reduce(
         cp_attn_lse = cp_attn_lse.to(torch.float32)
     lse_pack_dim = _dcp_a2a_lse_pack_dim(cp_attn_out.dtype)
 
+    use_fi = _get_dcp_a2a_backend() == "flashinfer"
+    if use_fi:
+        # FlashInfer's LL128 kernel requires partial_o last-dim × elem_size
+        # to be 16-byte aligned. Pad ``D + lse_pack_dim`` up to the next
+        # 16-byte multiple. Pack writes only the first ``D + lse_pack_dim``
+        # slots; the padding is unread by unpack_combine (which loads via
+        # explicit offsets HEAD_DIM and HEAD_DIM+1).
+        elem_size = cp_attn_out.element_size()
+        elems_per_16B = 16 // elem_size
+        D_prime_raw = D + lse_pack_dim
+        D_prime = ((D_prime_raw + elems_per_16B - 1) // elems_per_16B) * elems_per_16B
+    else:
+        D_prime = D + lse_pack_dim
+
     send_buffer, recv_buffer = _dcp_a2a_send_recv_buffers(
-        (world_size, B, H_per_rank, D + lse_pack_dim),
+        (world_size, B, H_per_rank, D_prime),
         device=cp_attn_out.device,
         dtype=cp_attn_out.dtype,
     )
@@ -448,13 +563,47 @@ def dcp_a2a_lse_reduce(
         lse_pack_dim,
     )
 
-    work = dist.all_to_all_single(
-        recv_buffer.view(-1),
-        send_buffer.view(-1),
-        group=cp_group.device_group,
-        async_op=True,
-    )
-    work.wait()
+    if use_fi:
+        from vllm.distributed.dcp_alltoall_flashinfer import (
+            DCPAllToAllFlashInfer,
+        )
+
+        # send_buffer is [N, B, H_per_rank, D_prime]; permute to
+        # FlashInfer's convention [B*H_per_rank, N, D_prime] (cp_size
+        # is the second-to-last dim).
+        send_for_fi = (
+            send_buffer.permute(1, 2, 0, 3)
+            .reshape(B * H_per_rank, world_size, D_prime)
+            .contiguous()
+        )
+        # FlashInfer takes a softmax_stats arg as well. LSE is already
+        # bit-packed inside send_for_fi; pass a small placeholder.
+        placeholder = torch.zeros(
+            B * H_per_rank,
+            world_size,
+            2,
+            dtype=torch.float32,
+            device=send_buffer.device,
+        )
+        mgr = DCPAllToAllFlashInfer.get(
+            cp_rank=cp_group.rank_in_group,
+            cp_size=world_size,
+            cp_cpu_group=cp_group.cpu_group,
+        )
+        recv_fi, _ = mgr.run(send_for_fi, placeholder)
+        recv_buffer.copy_(
+            recv_fi.reshape(B, H_per_rank, world_size, D_prime)
+            .permute(2, 0, 1, 3)
+            .contiguous()
+        )
+    else:
+        work = dist.all_to_all_single(
+            recv_buffer.view(-1),
+            send_buffer.view(-1),
+            group=cp_group.device_group,
+            async_op=True,
+        )
+        work.wait()
 
     return _dcp_a2a_unpack_combine(
         recv_buffer, D, lse_pack_dim, return_lse, is_lse_base_on_e

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -54,11 +54,11 @@ def set_dcp_a2a_backend(backend: str) -> None:
 def _get_dcp_a2a_backend() -> str:
     """Return the resolved DCP A2A kernel (``"nccl"`` or ``"flashinfer"``).
 
-    There is no user-facing flag: the choice is made automatically the first
-    time an attention backend selects the A2A combine path
-    (``ensure_dcp_a2a_backend``) — FlashInfer on Blackwell (sm_100+, where its
-    fused LL128 kernel is CUDA-graph captured and wins), NCCL packed everywhere
-    else — and cached here.
+    The choice is resolved the first time an attention backend selects the A2A
+    combine path (``ensure_dcp_a2a_backend``) and cached here. It follows the
+    ``--dcp-a2a-backend`` option: ``"nccl"`` / ``"flashinfer"`` force the kernel;
+    ``"auto"`` (default) picks FlashInfer on Blackwell (sm_100+) under
+    full-cudagraph decode, NCCL packed everywhere else.
     """
     if _DCP_A2A_BACKEND is not None:
         return _DCP_A2A_BACKEND
@@ -72,37 +72,50 @@ def ensure_dcp_a2a_backend(vllm_config: VllmConfig) -> None:
     DCP-combine path, so this hardware/feature-specific setup lives with the
     feature rather than in the generic worker. Idempotent per process.
 
-    FlashInfer's fused LL128 A2A only wins when the decode a2a-reduce is
-    captured under a full CUDA graph on Blackwell (sm_100+); in eager /
-    piecewise-only cudagraph or on non-Blackwell its per-call launch overhead
-    makes it slower than NCCL packed, so those use NCCL.
+    The kernel follows the ``--dcp-a2a-backend`` option:
+    - ``"nccl"``: always the NCCL packed all_to_all path.
+    - ``"flashinfer"``: always FlashInfer's fused LL128 A2A (with graceful NCCL
+      fallback if the MNNVL workspace cannot initialize).
+    - ``"auto"`` (default): FlashInfer only when the decode a2a-reduce is
+      captured under a full CUDA graph on Blackwell (sm_100+), where its fused
+      kernel beats NCCL packed; in eager / piecewise-only cudagraph or on
+      non-Blackwell its per-call launch overhead makes it slower, so those use
+      NCCL.
 
     The FlashInfer workspace must be allocated before CUDA-graph capture, which
     holds because attention backends are constructed at model-runner /
     attention-layer init, ahead of capture.
 
     Args:
-        vllm_config: The active vLLM config, used to read the cudagraph mode
-            and the DCP group.
+        vllm_config: The active vLLM config, used to read the backend option,
+            the cudagraph mode, and the DCP group.
     """
     global _DCP_A2A_INITIALIZED
     if _DCP_A2A_INITIALIZED:
         return
     _DCP_A2A_INITIALIZED = True
 
-    from vllm.config import CUDAGraphMode
-    from vllm.platforms import current_platform
-
-    cap = current_platform.get_device_capability()
-    cudagraph_mode = vllm_config.compilation_config.cudagraph_mode
-    decode_full_cudagraph = (
-        cudagraph_mode is not None
-        and cudagraph_mode.decode_mode() == CUDAGraphMode.FULL
-    )
-    use_fi = cap is not None and cap.major >= 10 and decode_full_cudagraph
-    if not use_fi:
+    choice = vllm_config.parallel_config.dcp_a2a_backend
+    if choice == "nccl":
         set_dcp_a2a_backend("nccl")
         return
+
+    if choice == "auto":
+        from vllm.config import CUDAGraphMode
+        from vllm.platforms import current_platform
+
+        cap = current_platform.get_device_capability()
+        cudagraph_mode = vllm_config.compilation_config.cudagraph_mode
+        decode_full_cudagraph = (
+            cudagraph_mode is not None
+            and cudagraph_mode.decode_mode() == CUDAGraphMode.FULL
+        )
+        use_fi = cap is not None and cap.major >= 10 and decode_full_cudagraph
+        if not use_fi:
+            set_dcp_a2a_backend("nccl")
+            return
+
+    # choice == "flashinfer" (forced), or "auto" resolved to FlashInfer.
     set_dcp_a2a_backend("flashinfer")
 
     from vllm.distributed.dcp_alltoall_flashinfer import DCPAllToAllFlashInfer


### PR DESCRIPTION
## Summary

Adds FlashInfer's fused MNNVL all-to-all (LL128) kernel as an alternative backend for the DCP **a2a-reduce** exchange, on top of the merged packed-NCCL a2a path (`--dcp-comm-backend a2a`, #41160). The kernel replaces the two `dist.all_to_all_single` exchanges of the packed path with a single fused `decode_cp_a2a_alltoall`.

The backend defaults to **automatic selection by hardware** (`--dcp-a2a-backend auto`), with an opt-in override:

- **Blackwell (sm_100+)** → FlashInfer fused LL128 A2A (captured under CUDA graph, where it beats the NCCL pack → `all_to_all` → unpack chain).
- **Everything else** → NCCL packed (unchanged behavior). In eager / non-Blackwell, FlashInfer's per-call overhead makes it ~3–5% slower, so it is not used there.
- **`--dcp-a2a-backend {auto,nccl,flashinfer}`** (default `auto`) lets users force the kernel. `nccl`/`flashinfer` override the auto choice; forced `flashinfer` still falls back to NCCL if the MNNVL workspace can't initialize (never crashes). Ignored unless `--dcp-comm-backend a2a`.

The FlashInfer MNNVL workspace is allocated lazily the first time an attention backend selects the A2A combine path (before CUDA-graph capture); if that fails (no NVL fabric / IMEX, e.g. non-NVL72 cross-node) it logs a warning and **falls back to NCCL packed** — no user action, no crash.

**Files (7 changed):**
- `vllm/distributed/dcp_alltoall_flashinfer.py` (new): MNNVL workspace manager (alloc + init + CPU barrier; `enable_pdl=False` to match TRT-LLM), cached per CP group.
- `vllm/v1/attention/ops/dcp_alltoall.py`: dispatcher routes `dcp_a2a_lse_reduce` to FlashInfer or NCCL; 16-byte-align pad; reuses the existing pack/unpack + Triton LSE-combine. Hosts `ensure_dcp_a2a_backend()` — honors `--dcp-a2a-backend`; `auto` consults compute capability + cudagraph mode; workspace pre-init + graceful NCCL fallback.
- `vllm/config/parallel.py`, `vllm/engine/arg_utils.py`: the `--dcp-a2a-backend` option (`DCPA2ABackend` literal, `ParallelConfig` field, CLI plumbing, ignore-warning when set without `a2a`).
- `vllm/v1/attention/backends/{flash_attn,flashinfer}.py` and `vllm/model_executor/layers/attention/mla_attention.py`: call `ensure_dcp_a2a_backend()` lazily when the A2A DCP-combine path is selected (the MLA layer is where MLA models — the DCP targets — select it).

## Why this is not a duplicate

Open PRs searched (`decode context parallel a2a`, `flashinfer alltoall`, `dcp comm backend`): #45964 (MLA query replication for decode) and #47915 (TokenSpeed MLA DCP decode) change *what* is computed for MLA decode, not *which comm kernel* performs the a2a-reduce; #47355 (draft) overlaps DCP indexer streams. None add a FlashInfer fused A2A kernel as a DCP a2a-reduce backend. This builds on the merged `--dcp-comm-backend a2a` and adds a faster kernel for it on Blackwell.

## Design note for reviewers — auto by default, override available

The default (`--dcp-a2a-backend auto`) picks the kernel by hardware: FlashInfer only where it is CUDA-graph-captured on Blackwell with an MNNVL fabric, NCCL packed otherwise. Because that choice is fully determined, `auto` is the recommended path. The `nccl`/`flashinfer` values are provided for users who want to pin the kernel (benchmarking, forcing NCCL on Blackwell, etc.); a forced setting that can't run (e.g. `flashinfer` where the MNNVL workspace can't init) still falls back to NCCL rather than crashing.

## When each backend is used

| Situation | Backend |
|---|---|
| Blackwell (sm_100+), **full-cudagraph decode**, MNNVL workspace OK | FlashInfer LL128 A2A |
| Non-Blackwell (Hopper, …) | NCCL packed |
| Eager, or piecewise-only cudagraph (decode not full-graph captured) | NCCL packed |
| Blackwell without MNNVL fabric (non-NVL72 cross-node) | NCCL packed (graceful fallback) |

The selection is gated on `cudagraph_mode.decode_mode() == FULL` (the a2a-reduce is a decode-time op), so eager and piecewise-only decode fall to NCCL where FlashInfer's per-call overhead would otherwise regress. This table describes `--dcp-a2a-backend auto`; `nccl` forces the NCCL column and `flashinfer` forces the FlashInfer kernel (still falling back to NCCL if the MNNVL workspace can't init).

## Tests

Served DeepSeek-R1 671B with `--dcp-comm-backend a2a`:

```bash
vllm serve deepseek-ai/DeepSeek-R1 \
  --tensor-parallel-size 8 --decode-context-parallel-size 8 \
  --dcp-comm-backend a2a --attention-config.backend FLASHINFER_MLA \
  --compilation-config '{"cudagraph_mode":"FULL"}' --trust-remote-code
```

- **Functional**: on Blackwell (B200/B300/GB200) the auto-select engages FlashInfer (MNNVL workspace `mnnvl=True` on all ranks; fused kernel confirmed active during decode) and serves; on Hopper it uses NCCL packed unchanged; the graceful NCCL fallback is exercised when the MNNVL workspace cannot initialize (e.g. non-NVL72 cross-node).
- **Accuracy** — this change only alters how the a2a-reduce is *transported* (the all-to-all moves the same data; the existing Triton LSE-combine does the same math), so the reduced values are numerically equivalent to the NCCL packed path modulo floating-point reduction order — there is no expected accuracy effect. gsm8k 5-shot exact-match was equal between FlashInfer A2A and NCCL packed within sampling noise on both DeepSeek-V2-Lite and DeepSeek-R1 (FLASHINFER_MLA + cudagraph FULL).
- **Performance** — DeepSeek-R1 671B (FP8, MLA), FLASHINFER_MLA + cudagraph FULL, DCP=8, ISL=512/OSL=256, measured with `vllm bench serve` (warmup per point). Mean-TPOT improvement (time per output token — the decode-step latency this a2a-reduce change acts on), FlashInfer A2A vs NCCL packed, across a concurrency sweep:

| Concurrency | 1 | 2 | 4 | 8 | 16 | 32 | 64 |
|---|---|---|---|---|---|---|---|
| Single-node (8×B300) | +3.0% | +1.9% | +2.4% | **+5.0%** | +3.5% | +1.0% | +0.6% |
| Cross-node (GB200-NVL72, 2 nodes) | +1.5% | +1.7% | +1.8% | **+2.7%** | +1.9% | −0.6% | +1.0% |

(Absolute TPOT ranges ~9.6 ms at c=1 to ~26 ms at c=64.) The improvement **peaks at moderate concurrency (c=8: +5.0% single-node, +2.7% cross-node) and tapers toward parity at high concurrency** — consistent with the fused LL128 kernel helping most in the latency-bound regime (small per-step a2a messages) and mattering less once the exchange becomes bandwidth-bound. TTFT is a prefill metric, unaffected by this decode-time change (parity). In eager mode (no cudagraph) FlashInfer is ~3–5% slower (per-call dispatcher overhead) — which is why auto-select restricts it to Blackwell + cudagraph; cross-node additionally requires the NVL72 IMEX fabric (falls back to NCCL otherwise).

## AI assistance

Developed with AI assistance (Claude). The submitter reviewed every changed line and ran the tests above. Commits carry `Signed-off-by` (DCO) and `Co-authored-by: Claude`.
