### PR TITLE
[CI] Add chat eval mode to GSM8K harness + gpt-oss-20b config

### DIFF
--- a/tests/evals/gsm8k/configs/gpt-oss-20b-MXFP4.yaml
+++ b/tests/evals/gsm8k/configs/gpt-oss-20b-MXFP4.yaml
@@ -1,0 +1,7 @@
+model_name: "openai/gpt-oss-20b"
+accuracy_threshold: 0.89
+num_questions: 1319
+num_fewshot: 5
+max_tokens: 2048
+eval_mode: chat
+server_args: "--enforce-eager --max-model-len 8192"

--- a/tests/evals/gsm8k/configs/models-blackwell.txt
+++ b/tests/evals/gsm8k/configs/models-blackwell.txt
@@ -3,3 +3,4 @@ Qwen2.5-VL-3B-Instruct-FP8-dynamic.yaml
 Qwen1.5-MoE-W4A16-CT.yaml
 DeepSeek-V2-Lite-Instruct-FP8.yaml
 Qwen3-30B-A3B-NVFP4.yaml
+gpt-oss-20b-MXFP4.yaml

--- a/tests/evals/gsm8k/gsm8k_eval.py
+++ b/tests/evals/gsm8k/gsm8k_eval.py
@@ -83,26 +83,46 @@ async def call_vllm_api(
     stop: list[str] | None = None,
     url: str | None = None,
     seed: int | None = None,
+    eval_mode: str = "completions",
 ) -> tuple[str, int]:
-    """Call vLLM's OpenAI-compatible completions endpoint.
+    """Call vLLM's OpenAI-compatible completions or chat endpoint.
+
+    ``eval_mode="chat"`` routes the few-shot prompt through
+    ``/v1/chat/completions`` (applying the model's chat template), which is
+    required for chat/reasoning models such as gpt-oss that do not follow the
+    plain completion format. Any other value uses ``/v1/completions``.
 
     Returns:
         Tuple of (response_text, completion_tokens)
     """
-    data = {
-        "prompt": prompt,
-        "temperature": temperature,
-        "max_tokens": max_tokens,
-        "stop": stop,
-    }
+    if eval_mode == "chat":
+        endpoint = f"{url}/v1/chat/completions"
+        data = {
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "stop": stop,
+        }
+    else:
+        endpoint = f"{url}/v1/completions"
+        data = {
+            "prompt": prompt,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "stop": stop,
+        }
     if seed is not None:
         data["seed"] = seed
 
     try:
-        async with session.post(f"{url}/v1/completions", json=data) as response:
+        async with session.post(endpoint, json=data) as response:
             response.raise_for_status()
             result = await response.json()
-            text = result["choices"][0]["text"]
+            choice = result["choices"][0]
+            if eval_mode == "chat":
+                text = choice["message"].get("content") or ""
+            else:
+                text = choice["text"]
             completion_tokens = result.get("usage", {}).get("completion_tokens", 0)
             return text, completion_tokens
     except Exception as e:
@@ -178,6 +198,7 @@ def evaluate_gsm8k(
     temperature: float = 0.0,
     seed: int | None = 42,
     request_timeout_seconds: float = 600,
+    eval_mode: str = "completions",
 ) -> dict[str, float | int]:
     """
     Evaluate GSM8K accuracy using vLLM serve endpoint.
@@ -201,6 +222,7 @@ def evaluate_gsm8k(
                 stop=["Question", "Assistant:", "<|separator|>"],
                 url=base_url,
                 seed=seed,
+                eval_mode=eval_mode,
             )
             states[i] = answer
             output_tokens[i] = tokens
@@ -281,6 +303,13 @@ def main() -> None:
         "--seed", type=int, default=42, help="Random seed for reproducibility"
     )
     parser.add_argument("--save-results", type=str, help="Save results to JSON file")
+    parser.add_argument(
+        "--eval-mode",
+        type=str,
+        default="completions",
+        choices=["completions", "chat"],
+        help="Endpoint to evaluate against: plain completions or chat template",
+    )
 
     args = parser.parse_args()
 
@@ -292,6 +321,7 @@ def main() -> None:
         port=args.port,
         temperature=args.temperature,
         seed=args.seed,
+        eval_mode=args.eval_mode,
     )
 
     # Print results to terminal

--- a/tests/evals/gsm8k/test_gsm8k_correctness.py
+++ b/tests/evals/gsm8k/test_gsm8k_correctness.py
@@ -68,6 +68,7 @@ def run_gsm8k_eval(eval_config: dict, server_url: str) -> dict:
         host=host,
         port=port,
         request_timeout_seconds=request_timeout_seconds,
+        eval_mode=eval_config.get("eval_mode", "completions"),
     )
 
     return results


### PR DESCRIPTION
## Purpose

Adds an opt-in `eval_mode: chat` to the GSM8K accuracy harness so chat and
reasoning models can be evaluated through `/v1/chat/completions` (applying the
model's chat template), and adds an `openai/gpt-oss-20b` (MXFP4) config that
uses it.

gpt-oss is a harmony/reasoning model. On the default `/v1/completions` path it
scores about 0.30 with a high unparseable rate (a prompt-format mismatch, not a
quant issue); through the chat endpoint it scores about 0.90. The default stays
`completions`, so all existing configs are unchanged.

Tracking issue: https://github.com/vllm-project/vllm/issues/36264

No existing/open PR adds a chat eval mode or a gpt-oss gsm8k config (checked
open PRs and the tracking issue).

## Test Plan

```
pytest -s -v tests/evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-blackwell.txt
# direct harness run:
python3 tests/evals/gsm8k/gsm8k_eval.py --port <p> --num-questions 1319 --max-tokens 2048 --eval-mode chat
```

## Test Result

openai/gpt-oss-20b (MXFP4), single Blackwell GPU, vLLM 0.22.1rc1.dev392,
GSM8K 1319 questions / 5-shot, `eval_mode: chat`, max_tokens 2048:

| path | accuracy | invalid |
|---|---|---|
| chat (this PR) | 0.899 | 1.3% |
| completions (default, for reference) | 0.300 | 18.8% |

Threshold set to 0.89.

## Note

AI assistance was used to author this change. All changes were reviewed by
hand, and the tests above were run and verified on the listed hardware.
