### PR TITLE
[Bugfix][Multimodal] Catch RuntimeError for torchcodec AudioDecoder import

### DIFF
--- a/vllm/transformers_utils/processors/mimo_v2_omni.py
+++ b/vllm/transformers_utils/processors/mimo_v2_omni.py
@@ -30,7 +30,7 @@ try:
     from torchcodec.decoders import AudioDecoder
 
     _HAS_TORCHCODEC = True
-except ImportError:
+except (ImportError, RuntimeError):
     AudioDecoder = None
     _HAS_TORCHCODEC = False
 


### PR DESCRIPTION
### What this PR does

Catches `RuntimeError` alongside `ImportError` when importing `torchcodec.decoders.AudioDecoder` in `mimo_v2_omni.py`.

This mirrors the existing fix in `vllm/multimodal/video.py` (from PR #47888) for `VideoDecoder`. The `AudioDecoder` import was missed in that PR.

### Why

`torchcodec` raises `RuntimeError` — not `ImportError` — when installed but FFmpeg shared libraries are not present on the system. The current `except ImportError` guard doesn't catch this, so vLLM crashes on startup in environments without FFmpeg (e.g. UBI9/RHEL minimal containers) even when no audio/video features are being used.

### Not duplicating an existing PR

- PR #47888 fixed `VideoDecoder` in `video.py` but did not address `AudioDecoder` in `mimo_v2_omni.py`
- Searched open PRs for "torchcodec", "AudioDecoder", "mimo" — no existing PR covers this

### Test

Verified on UBI9 container image where torchcodec is installed but FFmpeg is not available:
- **Before**: `import vllm` crashes with `RuntimeError` from torchcodec native lib loading
- **After**: `import vllm` succeeds, `_HAS_TORCHCODEC` is set to `False`, graceful degradation

### AI assistance disclosure

This PR was authored with AI assistance (Claude). The human submitter (dougbtv) has reviewed every changed line and understands the change end-to-end.

Signed-off-by: dougbtv <dosmith@redhat.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>