### PR TITLE
[Revert] [Build] Update vllm ...builds FA3 with torch stable API

### DIFF
--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -39,7 +39,7 @@ else()
   FetchContent_Declare(
           vllm-flash-attn
           GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
-          GIT_TAG b3964b1d8b95d8e8447435668ab169a2700bab65
+          GIT_TAG bb9a72e7dde0dc614ffc663e052cd6a19ce73a42
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn


### PR DESCRIPTION
## Summary
- Effectively a revert of https://github.com/vllm-project/vllm/pull/46644
- Bump the bundled vllm-flash-attn source pin from `b3964b1d8b95d8e8447435668ab169a2700bab65` to `bb9a72e7dde0dc614ffc663e052cd6a19ce73a42`.
- Picks up vllm-project/flash-attention#160, which reverts vllm-project/flash-attention#152 after it broke `FLASH_ATTN_MLA_SPARSE` in vllm-project/vllm#48221.

## Tests
- `git diff --check`
- `uvx pre-commit run --files cmake/external_projects/vllm_flash_attn.cmake`

## Model evals / serving validation
Not run locally. This is a dependency pin change for vllm-flash-attn; the relevant serving validation requires the Hopper FA3/DSpark/NIXL setup described in vllm-project/vllm#48221. Keep this PR draft until a human reviewer has reviewed the one-line change and accepted/runs the needed validation.

## AI assistance
AI assistance was used to prepare this draft PR.
