### PR TITLE
Pin RMSNorm block size under batch-invariant mode

### DIFF
--- a/csrc/libtorch_stable/layernorm_kernels.cu
+++ b/csrc/libtorch_stable/layernorm_kernels.cu
@@ -249,7 +249,12 @@ void rms_norm(torch::stable::Tensor& out,    // [..., hidden_size]
   int64_t input_shape_d3 = (num_dims >= 4) ? input.size(-3) : 0;
 
   // For large num_tokens, use smaller blocks to increase SM concurrency.
-  const int max_block_size = (num_tokens < 256) ? 1024 : 256;
+  // In batch-invariant mode the block size must not depend on num_tokens:
+  // it sets the per-row reduction order, so a num_tokens-dependent choice
+  // makes the same row normalize differently in prefill (prompt scoring)
+  // vs decode. Pin it to the small-batch value.
+  const int max_block_size =
+      (num_tokens < 256 || vllm::vllm_is_batch_invariant()) ? 1024 : 256;
   dim3 grid(num_tokens);
   const torch::stable::accelerator::DeviceGuard device_guard(
       input.get_device_index());
@@ -325,8 +330,13 @@ void fused_add_rms_norm(torch::stable::Tensor& input,     // [..., hidden_size]
   /* This kernel is memory-latency bound in many scenarios.
      When num_tokens is large, a smaller block size allows
      for increased block occupancy on CUs and better latency
-     hiding on global mem ops. */
-  const int max_block_size = (num_tokens < 256) ? 1024 : 256;
+     hiding on global mem ops.
+     In batch-invariant mode the block size must not depend on num_tokens:
+     it sets the per-row reduction order, so a num_tokens-dependent choice
+     makes the same row normalize differently in prefill (prompt scoring)
+     vs decode. Pin it to the small-batch value. */
+  const int max_block_size =
+      (num_tokens < 256 || vllm::vllm_is_batch_invariant()) ? 1024 : 256;
   dim3 block(std::min(hidden_size, max_block_size));
   const torch::stable::accelerator::DeviceGuard device_guard(
       input.get_device_index());

--- a/csrc/libtorch_stable/layernorm_quant_kernels.cu
+++ b/csrc/libtorch_stable/layernorm_quant_kernels.cu
@@ -215,7 +215,10 @@ void rms_norm_static_fp8_quant(
   int num_tokens = input.numel() / hidden_size;
 
   // For large num_tokens, use smaller blocks to increase SM concurrency.
-  const int max_block_size = (num_tokens < 256) ? 1024 : 256;
+  // In batch-invariant mode the block size must not depend on num_tokens
+  // (it sets the per-row reduction order); pin it to the small-batch value.
+  const int max_block_size =
+      (num_tokens < 256 || vllm::vllm_is_batch_invariant()) ? 1024 : 256;
   dim3 grid(num_tokens);
   const torch::stable::accelerator::DeviceGuard device_guard(
       input.get_device_index());
@@ -278,8 +281,12 @@ void fused_add_rms_norm_static_fp8_quant(
   /* This kernel is memory-latency bound in many scenarios.
      When num_tokens is large, a smaller block size allows
      for increased block occupancy on CUs and better latency
-     hiding on global mem ops. */
-  const int max_block_size = (num_tokens < 256) ? 1024 : 256;
+     hiding on global mem ops.
+     In batch-invariant mode the block size must not depend on num_tokens
+     (it sets the per-row reduction order); pin it to the small-batch
+     value. */
+  const int max_block_size =
+      (num_tokens < 256 || vllm::vllm_is_batch_invariant()) ? 1024 : 256;
   dim3 block(std::min(hidden_size, max_block_size));
   const torch::stable::accelerator::DeviceGuard device_guard(
       input.get_device_index());


### PR DESCRIPTION
The num_tokens-dependent block-size heuristic in the rms_norm and fused_add_rms_norm launchers changes the per-row reduction order at num_tokens=256, making prompt scoring disagree with decode and making batched decode load-dependent past 256 concurrent sequences, even with VLLM_BATCH_INVARIANT=1. Pin the block size to the small-batch value in batch-invariant mode; decode outputs are unchanged (num_tokens=1 already takes that branch).

Fixes #48271

## Purpose

Make RMSNorm numerics independent of `num_tokens` under `VLLM_BATCH_INVARIANT=1`. The launchers for `rms_norm` and `fused_add_rms_norm` (and both `layernorm_quant_kernels.cu` variants) currently pick the CUDA block size as:

```c
const int max_block_size = (num_tokens < 256) ? 1024 : 256;
```

The block size sets the per-row fp32 variance-reduction order, so the same row normalizes to occasionally one-ulp-different outputs depending on how many tokens share the launch. Two user-visible consequences (full forensics and self-contained repros in #48271):

- `prompt_logprobs` scoring of a ≥256-token sequence (block=256) disagrees with the greedy decode that produced it (num_tokens=1 → block=1024) at ~1.5–3% of positions — up to ~2 nats at fp32 — breaking echo-pass verification of greedy generations;
- batched decode crossing 256 concurrent sequences flips block size, making request logits depend on co-tenant load, which is exactly what batch-invariant mode promises to prevent.

This PR pins the block size to the small-batch value (1024) when `vllm_is_batch_invariant()`, in all four launchers. Pinning to 1024 rather than 256 means **decode outputs under BI mode are bitwise unchanged** (num_tokens=1 already takes that branch), so existing BI-mode results remain reproducible. Non-BI serving keeps the occupancy heuristic untouched.

Open question for maintainers: whether a shape-independent block size *unconditionally* is preferable, so prompt scoring matches decode outside BI mode too, at some occupancy cost for large batches. Related design context: #40628 — launch-configuration parameters that alter reduction order are in the same class as kernel selection for batch-invariant dispatching.

## Test Plan

1. **Kernel-level** (`upstream_repro_kernel.py` from #48271, seconds, no model): push the same 4096 rows through `fused_add_rms_norm` in one ≥256-token launch vs ≤255-row chunks; assert bitwise-identical normalized output.
2. **End-to-end** (`upstream_repro_e2e.py` from #48271, 1 GPU, ~5 min): greedy-generate 327 tokens (Qwen2.5-Coder-7B-Instruct, temperature 0), echo-score with `prompt_logprobs=1`; assert zero argmax flips at all scored positions.
3. **Decode preservation**: assert greedy generations under BI mode are bitwise identical before/after the patch (token-id sha256 comparison).

Environment: H100 80GB (driver 580.105.08), v0.24.0 release image; see #48271 for `collect_env` output.

## Test Result

| Check | Before | After |
|---|---|---|
| Kernel repro: normalized-output mismatches (4096 rows) | 107 elements in 79 rows | 0 |
| E2E: echo-scoring argmax flips (327 scored positions) | 2 | 0 |
| E2E: intermediate activations bitwise equal, decode vs echo (219 probes) | first divergence at layer-0 `post_attention_layernorm` | 219/219 equal |
| Decode token ids under BI mode (greedy, sha256) | `41f0ee8d186fe0ac…` | `41f0ee8d186fe0ac…` (unchanged) |

Note on methodology: the "After" column was validated against the **shipped v0.24.0 kernel binary** by emulating the pinned block size bit-exactly (launching the unmodified op on ≤255-row chunks, which takes the same 1024-thread branch this patch pins) — a standalone nvcc rebuild was not flag-identical to the shipped binary, so it was rejected as a validation vehicle. Re-running both repros against this branch's CI build to confirm end-to-end is the remaining step; happy to paste those results here once CI wheels exist.

## AI assistance disclosure

The investigation, bisect, patch, and this description were produced with AI assistance (Claude); all results were human-reviewed and validated on the hardware above. The commit carries a `Co-authored-by:` trailer per the contributing guidelines.
