### PR TITLE
[Bugfix][Test] Register Qwen/Qwen3.5-4B example model

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1308,6 +1308,7 @@ _MULTIMODAL_EXAMPLE_MODELS = {
     ),
     "Qwen3_5ForConditionalGeneration": _HfExamplesInfo(
         "Qwen/Qwen3.5-0.8B",
+        extras={"4b": "Qwen/Qwen3.5-4B"},
         max_model_len=4096,
     ),
     "Qwen3_5MoeForConditionalGeneration": _HfExamplesInfo(


### PR DESCRIPTION
#48113 retargeted DFlashDraftModel from Qwen/Qwen3.5-4B to Qwen/Qwen3-4B, which removed the only tests/models/registry.py reference to Qwen/Qwen3.5-4B.

`tests/renderers/test_hf.py::test_resolve_content_format_hf_defined[Qwen/Qwen3.5-4B-openai]` still looks that model up via `HF_EXAMPLE_MODELS.find_hf_info` and now fails with "No example model defined for Qwen/Qwen3.5-4B".

Register Qwen/Qwen3.5-4B as an extra on the existing Qwen3_5ForConditionalGeneration entry so find_hf_info resolves it again, leaving the entry's default model unchanged.