### PR TITLE
Skip layerwise reload for non-quantized models

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5492,10 +5492,16 @@ class GPUModelRunner(
         # begin loading weights
         logger.info_once("Reloading weights inplace...")
         if is_checkpoint_format:
-            # load weights from checkpoint/ original model format
-            initialize_layerwise_reload(model)
-            loaded_weights = model.load_weights(weights_iterator)
-            finalize_layerwise_reload(model, self.model_config)
+            # Layerwise reload only exists to defer quantization repacking;
+            # for non-quantized models it is unnecessary, and its per-layer
+            # reprocessing corrupts hybrid (Mamba) weights on reload. Use the
+            # plain startup load path instead.
+            if getattr(self.model_config, "quantization", None) is None:
+                loaded_weights = model.load_weights(weights_iterator)
+            else:
+                initialize_layerwise_reload(model)
+                loaded_weights = model.load_weights(weights_iterator)
+                finalize_layerwise_reload(model, self.model_config)
 
         else:
             # load weights from kernel format


### PR DESCRIPTION
Reloading weights at runtime (`reload_weights(is_checkpoint_format=True)`) corrupts hybrid Mamba models such as NemotronH. Reloading the model's own original weights already changes greedy decoding (e.g. `" 360"` becomes `" 150 150 ..."`), which breaks RLHF/RLVR weight sync for these models.

`is_checkpoint_format=True` wraps `model.load_weights()` in the layerwise-reload machinery (`initialize/finalize_layerwise_reload`), whose only job is to defer and redo quantization repacking. For a non-quantized model that is unnecessary, and the per-layer reprocessing is not idempotent for Mamba/SSM layers, so it corrupts them. The plain `load_weights()` used at startup works fine, so this skips the wrappers when there is nothing to quantize.

### Repro
```bash
MODEL=nvidia/NVIDIA-Nemotron-Nano-9B-v2
VLLM_SERVER_DEV_MODE=1 vllm serve "$MODEL" -tp 2 --max-model-len 8192 --port 8000 --trust-remote-code &
P='{"model":"'$MODEL'","prompt":"Question: What is 15 * 24?\nAnswer:","max_tokens":20,"temperature":0}'
curl -s localhost:8000/v1/completions -d "$P"   # note the output
curl -s -X POST localhost:8000/collective_rpc -d '{"method":"reload_weights","kwargs":{"weights_path":"'$MODEL'","is_checkpoint_format":true}}'
curl -s localhost:8000/v1/completions -d "$P"   # differs on main, unchanged with this fix
```

`start_weight_update`/`finish_weight_update` (the NCCL weight-transfer path) go through the same code and need the same guard. Can add it here if preferred.