### PR TITLE
feat: Internal session id for offloading 

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -211,6 +211,7 @@ impl ChatLlm {
             cache_salt: request.cache_salt,
             add_special_tokens: request.add_special_tokens,
             data_parallel_rank: request.data_parallel_rank,
+            session_id: request.session_id.clone(),
             reasoning_parser_kwargs,
             lora_request: request.lora_request,
             arrival_time: Some(arrival_time),

--- a/rust/src/chat/src/request.rs
+++ b/rust/src/chat/src/request.rs
@@ -435,6 +435,9 @@ pub struct ChatRequest {
     /// Override data parallel rank.
     #[serde(default)]
     pub data_parallel_rank: Option<u32>,
+    /// Stable session identity shared by related requests.
+    #[serde(default)]
+    pub session_id: Option<String>,
     /// LoRA adapter selected for this request.
     #[serde(default)]
     pub lora_request: Option<LoraRequest>,
@@ -458,6 +461,7 @@ impl ChatRequest {
             cache_salt: None,
             add_special_tokens: false,
             data_parallel_rank: None,
+            session_id: None,
             lora_request: None,
         }
     }

--- a/rust/src/engine-core-client/src/protocol/request.rs
+++ b/rust/src/engine-core-client/src/protocol/request.rs
@@ -107,6 +107,9 @@ pub struct EngineCoreRequest {
     pub trace_headers: Option<BTreeMap<String, String>>,
     #[serde(default)]
     pub resumable: bool,
+    /// Stable session identity shared by related requests.
+    #[serde(default)]
+    pub session_id: Option<String>,
     /// Original user-provided request ID, used for output reporting and aborts.
     #[serde(default)]
     pub external_req_id: Option<String>,
@@ -155,6 +158,7 @@ mod tests {
             }),
             arrival_time: 1234.5,
             client_index: 7,
+            session_id: Some("session-1".to_string()),
             ..EngineCoreRequest::default()
         };
 
@@ -165,11 +169,12 @@ mod tests {
             other => panic!("expected array, got {other:?}"),
         };
 
-        assert_eq!(array.len(), 20);
+        assert_eq!(array.len(), 21);
         assert_eq!(array[0], Value::from("req-1"));
         assert_eq!(array[2], Value::Nil);
         assert_eq!(array[4], Value::Nil);
         assert_eq!(array[10], Value::Nil);
         assert_eq!(array[11], Value::from(7));
+        assert_eq!(array[16], Value::from("session-1"));
     }
 }

--- a/rust/src/engine-core-client/src/tests/client.rs
+++ b/rust/src/engine-core-client/src/tests/client.rs
@@ -159,6 +159,7 @@ fn sample_request_with_id(request_id: &str) -> EngineCoreRequest {
             ..EngineCoreSamplingParams::for_test()
         }),
         arrival_time: 42.5,
+        session_id: Some("session-1".to_string()),
         ..EngineCoreRequest::default()
     }
 }

--- a/rust/src/engine-core-client/src/tests/python_compat.py
+++ b/rust/src/engine-core-client/src/tests/python_compat.py
@@ -71,6 +71,7 @@ class EngineCoreRequest(
     priority: int = 0
     trace_headers: dict[str, str] | None = None
     resumable: bool = False
+    session_id: str | None = None
     external_req_id: str | None = None
     reasoning_ended: bool | None = None
     reasoning_parser_kwargs: dict[str, object] | None = None
@@ -136,6 +137,7 @@ request = EngineCoreRequest(
     pooling_params=None,
     arrival_time=42.5,
     client_index=0,
+    session_id="session-1",
 )
 
 # All defaults -> empty map. Regression guard for the sparse-map decode.

--- a/rust/src/llm/examples/external_engine_smoke.rs
+++ b/rust/src/llm/examples/external_engine_smoke.rs
@@ -56,6 +56,7 @@ fn build_request(request_id: String, max_tokens: u32) -> GenerateRequest {
         trace_headers: None,
         priority: 0,
         data_parallel_rank: None,
+        session_id: None,
         reasoning_parser_kwargs: None,
         lora_request: None,
     }

--- a/rust/src/llm/src/request.rs
+++ b/rust/src/llm/src/request.rs
@@ -43,6 +43,8 @@ pub struct GenerateRequest {
     pub priority: i32,
     /// Optional data-parallel rank override for routing this request.
     pub data_parallel_rank: Option<u32>,
+    /// Stable session identity shared by related requests.
+    pub session_id: Option<String>,
     /// Optional reasoning-parser kwargs forwarded to engine-side structured
     /// output logic.
     pub reasoning_parser_kwargs: Option<ReasoningParserKwargs>,
@@ -73,6 +75,7 @@ impl GenerateRequest {
             trace_headers,
             priority,
             data_parallel_rank,
+            session_id,
             reasoning_parser_kwargs,
             lora_request,
         } = self;
@@ -102,6 +105,7 @@ impl GenerateRequest {
                 priority,
                 trace_headers,
                 resumable: false,
+                session_id,
                 external_req_id: Some(external_request_id),
                 // Rust parser doesn't expose this information, leave it unset and let the
                 // reasoning logic in engine-sided structured output manager handle it.
@@ -147,6 +151,7 @@ mod tests {
             )])),
             priority: 3,
             data_parallel_rank: Some(2),
+            session_id: Some("session-1".to_string()),
             reasoning_parser_kwargs: Some(ReasoningParserKwargs {
                 chat_template_kwargs: [(
                     "chat_template_kwargs".to_string(),
@@ -174,6 +179,7 @@ mod tests {
         assert_eq!(request.arrival_time, 42.5);
         assert_eq!(request.cache_salt.as_deref(), Some("salt"));
         assert_eq!(request.data_parallel_rank, Some(2));
+        assert_eq!(request.session_id.as_deref(), Some("session-1"));
         assert_eq!(
             request.trace_headers,
             Some(BTreeMap::from([(

--- a/rust/src/llm/tests/generate.rs
+++ b/rust/src/llm/tests/generate.rs
@@ -181,6 +181,7 @@ fn sample_generate_request(request_id: &str, max_tokens: u32) -> GenerateRequest
         trace_headers: None,
         priority: 0,
         data_parallel_rank: None,
+        session_id: None,
         reasoning_parser_kwargs: None,
         lora_request: None,
     }

--- a/rust/src/server/src/grpc/convert.rs
+++ b/rust/src/server/src/grpc/convert.rs
@@ -92,6 +92,7 @@ pub fn to_text_request(
         cache_salt: kv.map(|k| &k.cache_salt).filter(|s| !s.is_empty()).cloned(),
         add_special_tokens: true,
         data_parallel_rank: None,
+        session_id: None,
         reasoning_parser_kwargs: None,
         lora_request: None,
         arrival_time: None,

--- a/rust/src/server/src/routes/inference/generate/convert.rs
+++ b/rust/src/server/src/routes/inference/generate/convert.rs
@@ -68,6 +68,7 @@ pub(super) fn prepare_generate_request(
         cache_salt: request.cache_salt,
         add_special_tokens: false,
         data_parallel_rank: ctx.data_parallel_rank,
+        session_id: ctx.session_id,
         reasoning_parser_kwargs: None,
         lora_request: lora_resolution.lora_request.clone(),
         arrival_time: None,

--- a/rust/src/server/src/routes/openai/chat_completions/convert.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/convert.rs
@@ -13,7 +13,9 @@ use crate::routes::openai::utils::structured_outputs::convert_from_response_form
 use crate::routes::openai::utils::types::{
     ChatMessage, ContentPart, MessageContent, Tool, ToolChoice, ToolChoiceValue,
 };
-use crate::utils::{ResolvedRequestContext, convert_logit_bias, merge_kv_transfer_params};
+use crate::utils::{
+    ResolvedRequestContext, convert_logit_bias, merge_kv_transfer_params, resolve_session_id,
+};
 
 /// Lowered chat request plus the public response metadata carried by every SSE
 /// chunk.
@@ -104,6 +106,11 @@ pub(super) fn prepare_chat_request(
         request.response_format.as_ref(),
         &request.structured_outputs,
     )?;
+    let session_id = resolve_session_id(
+        &ctx,
+        request.session_id.as_deref(),
+        request.vllm_xargs.as_ref(),
+    );
 
     let chat_request = ChatRequest {
         request_id: request_id.clone(),
@@ -157,6 +164,7 @@ pub(super) fn prepare_chat_request(
         cache_salt: request.cache_salt,
         add_special_tokens: request.add_special_tokens,
         data_parallel_rank: ctx.data_parallel_rank,
+        session_id,
         lora_request: lora_resolution.lora_request.clone(),
     };
 
@@ -1095,6 +1103,49 @@ mod tests {
         )
         .expect("request is valid");
         assert_eq!(prepared.chat_request.data_parallel_rank, Some(7));
+    }
+
+    #[test]
+    fn prepare_chat_request_threads_header_session_id() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Session-ID", "header-session".parse().unwrap());
+        let prepared = prepare_chat_request(
+            base_request(),
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            request_context(&headers, None),
+        )
+        .expect("request is valid");
+        assert_eq!(
+            prepared.chat_request.session_id.as_deref(),
+            Some("header-session")
+        );
+    }
+
+    #[test]
+    fn prepare_chat_request_ignores_correlation_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Correlation-ID", "correlation-header".parse().unwrap());
+        let prepared = prepare_chat_request(
+            base_request(),
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            request_context(&headers, None),
+        )
+        .expect("request is valid");
+        assert_eq!(prepared.chat_request.session_id, None);
+    }
+
+    #[test]
+    fn prepare_chat_request_ignores_empty_session_header_without_fallback() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Session-ID", "".parse().unwrap());
+        headers.insert("X-Correlation-ID", "correlation-header".parse().unwrap());
+        let prepared = prepare_chat_request(
+            base_request(),
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            request_context(&headers, None),
+        )
+        .expect("request is valid");
+        assert_eq!(prepared.chat_request.session_id, None);
     }
 
     #[test]

--- a/rust/src/server/src/routes/openai/chat_completions/types.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/types.rs
@@ -219,6 +219,9 @@ pub struct ChatCompletionRequest {
     /// External request ID used for response correlation.
     pub request_id: Option<String>,
 
+    /// Stable session identity shared by related requests.
+    pub session_id: Option<String>,
+
     /// Tokens represented as strings of the form 'token_id:{token_id}' in
     /// logprobs
     pub return_tokens_as_token_ids: Option<bool>,
@@ -295,6 +298,7 @@ impl Default for ChatCompletionRequest {
             structured_outputs: None,
             priority: None,
             request_id: None,
+            session_id: None,
             return_tokens_as_token_ids: None,
             return_token_ids: None,
             cache_salt: None,

--- a/rust/src/server/src/routes/openai/completions/convert.rs
+++ b/rust/src/server/src/routes/openai/completions/convert.rs
@@ -7,7 +7,9 @@ use crate::error::ApiError;
 use crate::lora::LoraModelResolution;
 use crate::routes::openai::completions::validate;
 use crate::routes::openai::utils::structured_outputs::convert_from_response_format_value;
-use crate::utils::{ResolvedRequestContext, convert_logit_bias, merge_kv_transfer_params};
+use crate::utils::{
+    ResolvedRequestContext, convert_logit_bias, merge_kv_transfer_params, resolve_session_id,
+};
 
 /// Lowered completion request plus the public response metadata carried by
 /// every SSE chunk.
@@ -98,6 +100,11 @@ pub(super) fn prepare_completion_request(
 
     let structured_outputs =
         convert_from_response_format_value(&request.response_format, &request.structured_outputs)?;
+    let session_id = resolve_session_id(
+        &ctx,
+        request.session_id.as_deref(),
+        request.vllm_xargs.as_ref(),
+    );
 
     let text_request = TextRequest {
         request_id: request_id.clone(),
@@ -142,6 +149,7 @@ pub(super) fn prepare_completion_request(
         cache_salt: request.cache_salt,
         add_special_tokens: request.add_special_tokens,
         data_parallel_rank: ctx.data_parallel_rank,
+        session_id,
         reasoning_parser_kwargs: None,
         lora_request: lora_resolution.lora_request.clone(),
         arrival_time: None,
@@ -579,6 +587,76 @@ mod tests {
         )
         .expect("prepare");
         assert_eq!(prepared.text_request.data_parallel_rank, Some(3));
+    }
+
+    #[test]
+    fn prepare_completion_request_threads_body_session_id() {
+        let request: CompletionRequest = serde_json::from_value(json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "prompt": "hello",
+            "stream": false,
+            "session_id": "body-session",
+            "vllm_xargs": {"session_id": "xargs-session"},
+        }))
+        .expect("parse request");
+
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Session-ID", "header-session".parse().unwrap());
+        let prepared = prepare_completion_request(
+            request,
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            request_context(&headers, None),
+            &test_tokenizer(),
+        )
+        .expect("prepare");
+        assert_eq!(
+            prepared.text_request.session_id.as_deref(),
+            Some("body-session")
+        );
+    }
+
+    #[test]
+    fn prepare_completion_request_uses_vllm_xargs_session_id_fallback() {
+        let request: CompletionRequest = serde_json::from_value(json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "prompt": "hello",
+            "stream": false,
+            "vllm_xargs": {"session_id": "xargs-session"},
+        }))
+        .expect("parse request");
+
+        let prepared = prepare_completion_request(
+            request,
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            ResolvedRequestContext::default(),
+            &test_tokenizer(),
+        )
+        .expect("prepare");
+        assert_eq!(
+            prepared.text_request.session_id.as_deref(),
+            Some("xargs-session")
+        );
+    }
+
+    #[test]
+    fn prepare_completion_request_ignores_empty_and_non_string_session_id_values() {
+        let request: CompletionRequest = serde_json::from_value(json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "prompt": "hello",
+            "stream": false,
+            "session_id": "",
+            "vllm_xargs": {"session_id": 7},
+        }))
+        .expect("parse request");
+
+        let prepared = prepare_completion_request(
+            request,
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            ResolvedRequestContext::default(),
+            &test_tokenizer(),
+        )
+        .expect("prepare");
+        assert_eq!(prepared.text_request.session_id, None);
     }
 
     #[test]

--- a/rust/src/server/src/routes/openai/completions/types.rs
+++ b/rust/src/server/src/routes/openai/completions/types.rs
@@ -161,6 +161,9 @@ pub struct CompletionRequest {
     /// External request ID used for response correlation.
     pub request_id: Option<String>,
 
+    /// Stable session identity shared by related requests.
+    pub session_id: Option<String>,
+
     /// Tokens represented as strings of the form 'token_id:{token_id}' in
     /// logprobs
     pub return_tokens_as_token_ids: Option<bool>,

--- a/rust/src/server/src/routes/tokenize/types.rs
+++ b/rust/src/server/src/routes/tokenize/types.rs
@@ -91,6 +91,7 @@ impl TokenizeChatRequest {
             cache_salt: None,
             add_special_tokens: self.add_special_tokens,
             data_parallel_rank: None,
+            session_id: None,
             lora_request: None,
         })
     }

--- a/rust/src/server/src/utils.rs
+++ b/rust/src/server/src/utils.rs
@@ -12,6 +12,7 @@ use crate::error::ApiError;
 pub struct ResolvedRequestContext {
     pub request_id: String,
     pub data_parallel_rank: Option<u32>,
+    pub session_id: Option<String>,
 }
 
 /// Return the current Unix timestamp in seconds for OpenAI response objects.
@@ -45,6 +46,24 @@ pub fn merge_kv_transfer_params(
     xargs
 }
 
+pub fn resolve_session_id(
+    ctx: &ResolvedRequestContext,
+    request_session_id: Option<&str>,
+    xargs: Option<&HashMap<String, Value>>,
+) -> Option<String> {
+    request_session_id
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .or_else(|| ctx.session_id.clone())
+        .or_else(|| {
+            xargs
+                .and_then(|map| map.get("session_id"))
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+        })
+}
+
 /// Convert OpenAI-style `logit_bias` with string token-ID keys into the
 /// internal `HashMap<u32, f32>` representation, validating that every key
 /// parses as a `u32`.
@@ -70,8 +89,8 @@ pub fn convert_logit_bias(
         .transpose()
 }
 
-/// Extract common request metadata from HTTP headers: the external request ID
-/// and the optional data-parallel rank used for engine routing.
+/// Extract common request metadata from HTTP headers: the external request ID,
+/// session ID, and the optional data-parallel rank used for engine routing.
 pub fn resolve_request_context(
     headers: &HeaderMap,
     request_id: Option<&str>,
@@ -85,10 +104,16 @@ pub fn resolve_request_context(
     // Extract request id from header.
     let request_id_header = headers.get("X-Request-Id").and_then(|value| value.to_str().ok());
     let request_id = resolve_base_request_id(request_id_header, request_id);
+    let session_id = headers
+        .get("X-Session-ID")
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned);
 
     ResolvedRequestContext {
         request_id,
         data_parallel_rank,
+        session_id,
     }
 }
 

--- a/rust/src/text/src/lower.rs
+++ b/rust/src/text/src/lower.rs
@@ -54,6 +54,7 @@ pub fn lower_text_request(
         cache_salt: request.cache_salt.clone(),
         priority: request.priority,
         data_parallel_rank: request.data_parallel_rank,
+        session_id: request.session_id.clone(),
         reasoning_parser_kwargs: request.reasoning_parser_kwargs.clone(),
         lora_request: request.lora_request.clone(),
         arrival_time: request.arrival_time,

--- a/rust/src/text/src/request.rs
+++ b/rust/src/text/src/request.rs
@@ -180,6 +180,9 @@ pub struct TextRequest {
     /// Override data parallel rank.
     #[serde(default)]
     pub data_parallel_rank: Option<u32>,
+    /// Stable session identity shared by related requests.
+    #[serde(default)]
+    pub session_id: Option<String>,
     /// Optional reasoning-parser kwargs forwarded to engine-side structured
     /// output logic.
     #[serde(default)]
@@ -209,6 +212,7 @@ impl TextRequest {
             cache_salt: None,
             add_special_tokens: false,
             data_parallel_rank: None,
+            session_id: None,
             reasoning_parser_kwargs: None,
             lora_request: None,
             arrival_time: None,

--- a/tests/entrypoints/openai/test_session_id.py
+++ b/tests/entrypoints/openai/test_session_id.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+from starlette.requests import Request
+
+from vllm.entrypoints.generate.base.serving import GenerateBaseServing
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.completion.protocol import CompletionRequest
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+
+def _raw_request(headers: dict[str, str]) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/chat/completions",
+            "headers": [
+                (key.lower().encode("latin-1"), value.encode("latin-1"))
+                for key, value in headers.items()
+            ],
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "openai_request",
+    [
+        ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+        ),
+        CompletionRequest(model="test-model", prompt="hi"),
+        ResponsesRequest(model="test-model", input="hi"),
+    ],
+)
+def test_get_session_id_accepts_body_field(openai_request):
+    openai_request.session_id = "body-session"
+
+    session_id = GenerateBaseServing._get_session_id(
+        openai_request,
+        _raw_request({"X-Session-ID": "header-session"}),
+    )
+
+    assert session_id == "body-session"
+
+
+def test_get_session_id_accepts_session_header():
+    request = CompletionRequest(model="test-model", prompt="hi")
+
+    session_id = GenerateBaseServing._get_session_id(
+        request,
+        _raw_request({"X-Session-ID": "header-session"}),
+    )
+
+    assert session_id == "header-session"
+
+
+def test_get_session_id_ignores_correlation_header():
+    request = CompletionRequest(
+        model="test-model",
+        prompt="hi",
+        vllm_xargs={"session_id": "xargs-session"},
+    )
+
+    session_id = GenerateBaseServing._get_session_id(
+        request,
+        _raw_request({"X-Correlation-ID": "correlation-session"}),
+    )
+
+    assert session_id == "xargs-session"
+
+
+def test_get_session_id_keeps_vllm_xargs_as_compatibility_fallback():
+    request = CompletionRequest(
+        model="test-model",
+        prompt="hi",
+        vllm_xargs={"session_id": "xargs-session"},
+    )
+
+    session_id = GenerateBaseServing._get_session_id(request, None)
+
+    assert session_id == "xargs-session"
+
+
+def test_get_session_id_ignores_empty_and_non_string_values():
+    request = CompletionRequest(
+        model="test-model",
+        prompt="hi",
+        session_id="",
+        vllm_xargs={"session_id": 7},
+    )
+
+    session_id = GenerateBaseServing._get_session_id(request, None)
+
+    assert session_id is None

--- a/tests/v1/engine/test_parallel_sampling.py
+++ b/tests/v1/engine/test_parallel_sampling.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from copy import copy
+
 from vllm import SamplingParams
 from vllm.outputs import CompletionOutput
 from vllm.sampling_params import RequestOutputKind
@@ -66,6 +68,20 @@ def test_parent_request_to_output_final_only() -> None:
     assert ([output_0, output_1], True) == parent_request.get_outputs(
         "child_id_1", output_1
     )
+
+
+def test_parallel_sampling_child_requests_preserve_session_id() -> None:
+    request = make_request(SamplingParams(n=2))
+    request.session_id = "session-1"
+    parent_request = ParentRequest(request)
+
+    for idx in range(parent_request.n):
+        request_id, child_params = parent_request.get_child_info(idx)
+        child_request = request if idx == parent_request.n - 1 else copy(request)
+        child_request.request_id = request_id
+        child_request.sampling_params = child_params
+
+        assert child_request.session_id == "session-1"
 
 
 def make_request(sampling_params: SamplingParams) -> EngineCoreRequest:

--- a/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
@@ -10,6 +10,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.scheduler import (
     MooncakeStoreScheduler,
+    _session_id_from_request,
 )
 
 
@@ -176,11 +177,13 @@ def _make_pending_load_unfinished_request(
     num_tokens: int,
     block_hashes: list[bytes],
     block_ids: tuple[list[int], ...] = ([0, 1, 2],),
+    session_id: str | None = None,
 ) -> None:
     request = SimpleNamespace(
         num_tokens=num_tokens,
         block_hashes=block_hashes,
         num_output_placeholders=0,
+        session_id=session_id,
     )
     scheduler._unfinished_requests["req-0"] = (request, block_ids)
 
@@ -236,6 +239,27 @@ def test_pending_load_does_not_co_queue_save():
     # waiting for a finished_sending that will never come.
     tracker = scheduler._request_trackers["req-0"]
     assert tracker.num_saved_tokens == 0
+
+
+def test_pending_load_metadata_preserves_request_session_id():
+    scheduler = _make_bare_scheduler()
+    _make_pending_load_unfinished_request(
+        scheduler,
+        num_tokens=48,
+        block_hashes=[b"h0", b"h1", b"h2"],
+        session_id="session-1",
+    )
+    scheduler.load_specs["req-0"] = LoadSpec(
+        vllm_cached_tokens=0,
+        kvpool_cached_tokens=48,
+        can_load=True,
+    )
+
+    meta = scheduler.build_connector_meta(_make_pending_load_scheduler_output())
+
+    assert len(meta.requests) == 1
+    assert meta.requests[0].session_id == "session-1"
+    assert scheduler._request_trackers["req-0"].session_id == "session-1"
 
 
 def _make_resumed_unfinished_request(
@@ -468,6 +492,66 @@ def test_from_request_tracker_no_load_saves_normally():
     assert req_meta.can_save is True
     assert req_meta.load_spec is None
     assert tracker.num_saved_tokens == 48
+
+
+def _request_with_session(
+    *,
+    session_id: str | None = None,
+    extra_args: dict[str, object] | None = None,
+):
+    return SimpleNamespace(
+        session_id=session_id,
+        sampling_params=SimpleNamespace(extra_args=extra_args),
+    )
+
+
+def test_session_id_from_request_prefers_typed_field():
+    request = _request_with_session(
+        session_id="typed-session",
+        extra_args={"session_id": "legacy-session"},
+    )
+
+    assert _session_id_from_request(request) == "typed-session"
+
+
+def test_session_id_from_request_uses_legacy_extra_args_fallback():
+    request = _request_with_session(extra_args={"session_id": "legacy-session"})
+
+    assert _session_id_from_request(request) == "legacy-session"
+
+
+def test_session_id_from_request_ignores_missing_empty_and_non_string_values():
+    assert _session_id_from_request(SimpleNamespace()) is None
+    assert _session_id_from_request(_request_with_session(session_id="")) is None
+    assert (
+        _session_id_from_request(_request_with_session(extra_args={"session_id": ""}))
+        is None
+    )
+    assert (
+        _session_id_from_request(_request_with_session(extra_args={"session_id": 7}))
+        is None
+    )
+
+
+def test_from_request_tracker_propagates_session_id():
+    tracker = RequestTracker(
+        req_id="req-0",
+        token_len=48,
+        allocated_block_ids=([0, 1, 2],),
+        num_saved_tokens=0,
+        session_id="session-1",
+    )
+
+    req_meta = ReqMeta.from_request_tracker(
+        tracker,
+        block_size=16,
+        load_spec=None,
+        skip_save=False,
+        block_hashes=[b"h0", b"h1", b"h2"],
+    )
+
+    assert req_meta is not None
+    assert req_meta.session_id == "session-1"
 
 
 class _StubLookupClient:

--- a/tests/v1/test_request.py
+++ b/tests/v1/test_request.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from vllm.v1.request import RequestStatus
+
+from vllm import SamplingParams
+from vllm.v1.engine import EngineCoreRequest
+from vllm.v1.request import Request, RequestStatus
 
 
 def test_request_status_fmt_str():
@@ -18,3 +21,22 @@ def test_request_status_fmt_str():
     assert f"{RequestStatus.FINISHED_LENGTH_CAPPED}" == "FINISHED_LENGTH_CAPPED"
     assert f"{RequestStatus.FINISHED_ABORTED}" == "FINISHED_ABORTED"
     assert f"{RequestStatus.FINISHED_IGNORED}" == "FINISHED_IGNORED"
+
+
+def test_request_copies_session_id_from_engine_core_request():
+    engine_request = EngineCoreRequest(
+        request_id="request-1",
+        prompt_token_ids=[1, 2, 3],
+        mm_features=None,
+        sampling_params=SamplingParams(max_tokens=1),
+        pooling_params=None,
+        arrival_time=0.0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+        session_id="session-1",
+    )
+
+    request = Request.from_engine_core_request(engine_request, block_hasher=None)
+
+    assert request.session_id == "session-1"

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -285,6 +285,7 @@ class RequestTracker:
     # For a fresh request this is len(prompt). For a resumed-from-preemption
     # request it includes previously-generated tokens, which are re-prefilled.
     prefill_end_tokens: int = 0
+    session_id: str | None = None
 
     def reset(self) -> None:
         self.token_len = 0
@@ -292,6 +293,7 @@ class RequestTracker:
         self.num_saved_tokens = 0
         self.token_ids = None
         self.prefill_end_tokens = 0
+        self.session_id = None
 
     def update(
         self,
@@ -327,6 +329,7 @@ class ReqMeta:
 
     token_ids: list[int] | None = None
     num_prompt_tokens: int | None = None
+    session_id: str | None = None
 
     @staticmethod
     def from_request_tracker(
@@ -387,6 +390,7 @@ class ReqMeta:
             is_last_chunk=is_last_chunk,
             token_ids=token_ids,
             num_prompt_tokens=tracker.prefill_end_tokens,
+            session_id=tracker.session_id,
         )
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -30,6 +30,20 @@ from vllm.v1.request import Request
 logger = init_logger(__name__)
 
 
+def _session_id_from_request(request: Request) -> str | None:
+    """Read typed session identity, falling back to legacy extra_args."""
+    session_id = getattr(request, "session_id", None)
+    if isinstance(session_id, str) and session_id:
+        return session_id
+
+    sampling_params = getattr(request, "sampling_params", None)
+    extra_args = getattr(sampling_params, "extra_args", None)
+    if not extra_args:
+        return None
+    session_id = extra_args.get("session_id")
+    return session_id if isinstance(session_id, str) and session_id else None
+
+
 def _new_req_prefill_tokens(request: NewRequestData) -> list[int]:
     """Tokens this prefill will compute KV for.
 
@@ -213,6 +227,7 @@ class MooncakeStoreScheduler:
                 num_saved_tokens=0,
                 token_ids=prefill_tokens[:num_tokens_to_compute],
                 prefill_end_tokens=len(prefill_tokens),
+                session_id=_session_id_from_request(request_real),
             )
             self._request_trackers[request.req_id] = request_tracker
 
@@ -263,6 +278,7 @@ class MooncakeStoreScheduler:
                         num_saved_tokens=0,
                         token_ids=prefill_tokens[:num_tokens_to_compute].copy(),
                         prefill_end_tokens=len(prefill_tokens),
+                        session_id=_session_id_from_request(request_real),
                     )
                     self._request_trackers[req_id] = request_tracker
 
@@ -336,6 +352,7 @@ class MooncakeStoreScheduler:
                     token_len=num_tokens_to_compute,
                     allocated_block_ids=block_ids,
                     num_saved_tokens=0,
+                    session_id=_session_id_from_request(unfinished_req),
                 )
                 self._request_trackers[request_id] = request_tracker
                 req_meta = ReqMeta.from_request_tracker(

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -77,6 +77,7 @@ class EngineClient(ABC):
         trace_headers: Mapping[str, str] | None = None,
         priority: int = 0,
         data_parallel_rank: int | None = None,
+        session_id: str | None = None,
         reasoning_ended: bool | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
     ) -> AsyncGenerator[RequestOutput, None]:

--- a/vllm/entrypoints/generate/base/serving.py
+++ b/vllm/entrypoints/generate/base/serving.py
@@ -41,6 +41,7 @@ logger = init_logger(__name__)
 
 RequestT = TypeVar("RequestT", bound=AnyRequest)
 _T = TypeVar("_T")
+SESSION_ID_HEADER = "X-Session-ID"
 
 
 def build_per_request_timing_metrics(
@@ -214,6 +215,22 @@ class GenerateBaseServing(BaseServing, BeamSearchOnlineMixin):
             return int(rank_str)
         except ValueError:
             return None
+
+    @staticmethod
+    def _get_session_id(
+        request: ChatCompletionRequest | CompletionRequest | ResponsesRequest,
+        raw_request: Request | None,
+    ) -> str | None:
+        if request.session_id:
+            return request.session_id
+        if raw_request is not None:
+            if value := raw_request.headers.get(SESSION_ID_HEADER):
+                return value
+        if request.vllm_xargs:
+            session_id = request.vllm_xargs.get("session_id")
+            if isinstance(session_id, str) and session_id:
+                return session_id
+        return None
 
     async def _with_kv_transfer_rejection_cleanup(
         self,

--- a/vllm/entrypoints/generate/beam_search/online.py
+++ b/vllm/entrypoints/generate/beam_search/online.py
@@ -32,6 +32,7 @@ class BeamSearchOnlineMixin(ABC):
         params: BeamSearchParams,
         lora_request: LoRARequest | None = None,
         trace_headers: Mapping[str, str] | None = None,
+        session_id: str | None = None,
     ) -> AsyncGenerator[RequestOutput, None]:
         beam_width = params.beam_width
         max_tokens = params.max_tokens
@@ -90,6 +91,7 @@ class BeamSearchOnlineMixin(ABC):
                             request_id_item,
                             lora_request=lora_request_item,
                             trace_headers=trace_headers,
+                            session_id=session_id,
                         )
                     )
                 )

--- a/vllm/entrypoints/openai/chat_completion/batch_serving.py
+++ b/vllm/entrypoints/openai/chat_completion/batch_serving.py
@@ -174,6 +174,7 @@ class OpenAIServingChatBatch(OpenAIServingChat):
                 if raw_request is None
                 else await self._get_trace_headers(raw_request.headers)
             )
+            session_id = self._get_session_id(single_request, raw_request)
             generators.append(
                 self.engine_client.generate(
                     engine_prompt,
@@ -183,6 +184,7 @@ class OpenAIServingChatBatch(OpenAIServingChat):
                     trace_headers=trace_headers,
                     priority=request.priority,
                     data_parallel_rank=data_parallel_rank,
+                    session_id=session_id,
                     reasoning_ended=None,
                 )
             )

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -366,6 +366,14 @@ class ChatCompletionRequest(OpenAIBaseModel):
             "through out the inference process and return in response."
         ),
     )
+    session_id: str | None = Field(
+        default=None,
+        description=(
+            "Stable session identity shared by related requests. Unlike "
+            "request_id, this value is expected to remain stable across "
+            "multiple requests in the same conversation or agent session."
+        ),
+    )
 
     return_tokens_as_token_ids: bool | None = Field(
         default=None,

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -332,6 +332,7 @@ class OpenAIServingChat(GenerateBaseServing):
                 if raw_request is None
                 else await self._get_trace_headers(raw_request.headers)
             )
+            session_id = self._get_session_id(request, raw_request)
 
             if isinstance(sampling_params, BeamSearchParams):
                 generator = self.beam_search(
@@ -340,6 +341,7 @@ class OpenAIServingChat(GenerateBaseServing):
                     params=sampling_params,
                     lora_request=lora_request,
                     trace_headers=trace_headers,
+                    session_id=session_id,
                 )
             else:
                 if not request.include_reasoning:
@@ -362,6 +364,7 @@ class OpenAIServingChat(GenerateBaseServing):
                     trace_headers=trace_headers,
                     priority=request.priority,
                     data_parallel_rank=data_parallel_rank,
+                    session_id=session_id,
                     reasoning_ended=reasoning_ended,
                     reasoning_parser_kwargs={
                         "chat_template_kwargs": chat_template_kwargs,

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -136,6 +136,14 @@ class CompletionRequest(OpenAIBaseModel):
             "through out the inference process and return in response."
         ),
     )
+    session_id: str | None = Field(
+        default=None,
+        description=(
+            "Stable session identity shared by related requests. Unlike "
+            "request_id, this value is expected to remain stable across "
+            "multiple requests in the same conversation or agent session."
+        ),
+    )
 
     return_tokens_as_token_ids: bool | None = Field(
         default=None,

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -194,6 +194,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
                 if raw_request is None
                 else await self._get_trace_headers(raw_request.headers)
             )
+            session_id = self._get_session_id(request, raw_request)
 
             if isinstance(sampling_params, BeamSearchParams):
                 generator = self.beam_search(
@@ -202,6 +203,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
                     params=sampling_params,
                     lora_request=lora_request,
                     trace_headers=trace_headers,
+                    session_id=session_id,
                 )
             else:
                 generator = self.engine_client.generate(
@@ -212,6 +214,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
                     trace_headers=trace_headers,
                     priority=request.priority,
                     data_parallel_rank=data_parallel_rank,
+                    session_id=session_id,
                 )
 
             generators.append(generator)

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -211,6 +211,14 @@ class ResponsesRequest(OpenAIBaseModel):
             "through out the inference process and return in response."
         ),
     )
+    session_id: str | None = Field(
+        default=None,
+        description=(
+            "Stable session identity shared by related requests. Unlike "
+            "request_id, this value is expected to remain stable across "
+            "multiple requests in the same conversation or agent session."
+        ),
+    )
     media_io_kwargs: dict[str, dict[str, Any]] | None = Field(
         default=None,
         description=(

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -451,6 +451,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 if raw_request is None
                 else await self._get_trace_headers(raw_request.headers)
             )
+            session_id = self._get_session_id(request, raw_request)
 
             chat_template_kwargs = self._effective_chat_template_kwargs(request)
             response_parser = self._make_response_parser(
@@ -516,6 +517,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 lora_request=lora_request,
                 priority=request.priority,
                 trace_headers=trace_headers,
+                session_id=session_id,
                 reasoning_parser_kwargs=reasoning_parser_kwargs
                 if self.parser and self.parser.reasoning_parser_cls is not None
                 else None,
@@ -663,6 +665,7 @@ class OpenAIServingResponses(GenerateBaseServing):
         lora_request: LoRARequest | None = None,
         priority: int = 0,
         trace_headers: Mapping[str, str] | None = None,
+        session_id: str | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
     ):
         max_model_len = self.model_config.max_model_len
@@ -687,6 +690,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 lora_request=lora_request,
                 trace_headers=trace_headers,
                 priority=priority,
+                session_id=session_id,
                 reasoning_parser_kwargs=reasoning_parser_kwargs,
             )
 

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -120,6 +120,7 @@ class EngineCoreRequest(
 
     trace_headers: Mapping[str, str] | None = None
     resumable: bool = False
+    session_id: str | None = None
 
     # The user-provided request ID. This field is set internally,
     # copied from the provided request_id that's originally assigned

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -291,6 +291,7 @@ class AsyncLLM(EngineClient):
         trace_headers: Mapping[str, str] | None = None,
         priority: int = 0,
         data_parallel_rank: int | None = None,
+        session_id: str | None = None,
         prompt_text: str | None = None,
         reasoning_ended: bool | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
@@ -328,6 +329,7 @@ class AsyncLLM(EngineClient):
                 trace_headers,
                 priority,
                 data_parallel_rank,
+                session_id,
             )
 
         # Convert Input --> Request.
@@ -357,6 +359,7 @@ class AsyncLLM(EngineClient):
                 trace_headers=trace_headers,
                 priority=priority,
                 data_parallel_rank=data_parallel_rank,
+                session_id=session_id,
             )
             prompt_text, _, _ = extract_prompt_components(self.model_config, prompt)
 
@@ -425,6 +428,7 @@ class AsyncLLM(EngineClient):
         trace_headers: Mapping[str, str] | None = None,
         priority: int = 0,
         data_parallel_rank: int | None = None,
+        session_id: str | None = None,
     ) -> RequestOutputCollector:
         self._validate_streaming_input_sampling_params(sampling_params)
 
@@ -436,6 +440,7 @@ class AsyncLLM(EngineClient):
             trace_headers=trace_headers,
             priority=priority,
             data_parallel_rank=data_parallel_rank,
+            session_id=session_id,
         )
 
         if not sampling_params.skip_clone:
@@ -536,6 +541,7 @@ class AsyncLLM(EngineClient):
         trace_headers: Mapping[str, str] | None = None,
         priority: int = 0,
         data_parallel_rank: int | None = None,
+        session_id: str | None = None,
         reasoning_ended: bool | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
     ) -> AsyncGenerator[RequestOutput, None]:
@@ -565,6 +571,7 @@ class AsyncLLM(EngineClient):
                 trace_headers=trace_headers,
                 priority=priority,
                 data_parallel_rank=data_parallel_rank,
+                session_id=session_id,
                 prompt_text=prompt_text,
                 reasoning_ended=reasoning_ended,
                 reasoning_parser_kwargs=reasoning_parser_kwargs,

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -252,6 +252,7 @@ class InputProcessor:
         priority: int = 0,
         data_parallel_rank: int | None = None,
         resumable: bool = False,
+        session_id: str | None = None,
     ) -> EngineCoreRequest:
         self._validate_params(params, supported_tasks)
         self._validate_lora(lora_request)
@@ -382,6 +383,7 @@ class InputProcessor:
             data_parallel_rank=data_parallel_rank,
             trace_headers=trace_headers,
             resumable=resumable,
+            session_id=session_id,
         )
 
     def _validate_prompt_len(

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -225,6 +225,7 @@ class LLMEngine:
         tokenization_kwargs: dict[str, Any] | None = None,
         trace_headers: Mapping[str, str] | None = None,
         priority: int = 0,
+        session_id: str | None = None,
         prompt_text: str | None = None,
     ) -> str:
         # Validate the request_id type.
@@ -257,6 +258,7 @@ class LLMEngine:
                 tokenization_kwargs=tokenization_kwargs,
                 trace_headers=trace_headers,
                 priority=priority,
+                session_id=session_id,
             )
             prompt_text, _, _ = extract_prompt_components(self.model_config, prompt)
 

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -74,6 +74,7 @@ class Request:
         trace_headers: Mapping[str, str] | None = None,
         block_hasher: Callable[["Request"], list["BlockHash"]] | None = None,
         resumable: bool = False,
+        session_id: str | None = None,
         reasoning_ended: bool | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
         abort_immediately: bool = False,
@@ -163,6 +164,7 @@ class Request:
         self.all_token_ids = ConstantList(self._all_token_ids)
         # trace_headers
         self.trace_headers = trace_headers
+        self.session_id = session_id
 
         # True if this request is scheduled as a non-final prefill chunk.
         self.is_prefill_chunk = False
@@ -216,6 +218,7 @@ class Request:
             trace_headers=request.trace_headers,
             block_hasher=block_hasher,
             resumable=request.resumable,
+            session_id=request.session_id,
             reasoning_ended=request.reasoning_ended,
             reasoning_parser_kwargs=request.reasoning_parser_kwargs,
             abort_immediately=request.abort_immediately,


### PR DESCRIPTION
## Purpose

Lightweight propagation of session id to vLLM offloading (Mooncake, OffloadingConnector) constructs.
This PR is stacked on #48048 and depends on its typed request-level `session_id` plumbing.

Context:
- DEP/RFC: #48049
- Base session ID plumbing PR: #48048
- Related motivation: sglang#29173 shows the kind of future cache/offload policy this metadata can support

Changes:
- Propagate session identity into Mooncake Store metadata:
  `Request.session_id -> RequestTracker.session_id -> ReqMeta.session_id`
- Preserve compatibility with the prior experimental path by falling back to `sampling_params.extra_args["session_id"]` in the Mooncake Store scheduler when typed `Request.session_id` is absent.
- Propagate typed session identity into the generic offloading connector:
  `Request.session_id -> ReqContext.session_id`

This is metadata plumbing only. It does not change routing, scheduling, eviction, retention, offload placement, or Mooncake Store behavior.

## Test Plan
Passes added unit tests.
