### PR TITLE
[Core] Log result wait time in iteration details

### DIFF
--- a/tests/v1/engine/test_iteration_details_logging.py
+++ b/tests/v1/engine/test_iteration_details_logging.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import vllm.v1.engine.core as core_module
+from vllm.v1.engine.core import EngineCore
+from vllm.v1.utils import IterationDetails
+
+
+def test_iteration_details_logs_result_wait_time(caplog, monkeypatch):
+    engine = EngineCore.__new__(EngineCore)
+    engine.vllm_config = SimpleNamespace(
+        observability_config=SimpleNamespace(enable_logging_iteration_details=True)
+    )
+    engine._iteration_index = 0
+
+    scheduler_output = MagicMock()
+    scheduler_output.total_num_scheduled_tokens = 1
+
+    monkeypatch.setattr(
+        core_module,
+        "compute_iteration_details",
+        lambda _: IterationDetails(1, 2, 3, 4),
+    )
+
+    caplog.set_level(logging.INFO, logger=core_module.__name__)
+
+    with engine.log_iteration_details(scheduler_output) as timing:
+        assert timing is not None
+        timing["result_wait_time"] = 0.01234
+
+    assert "iteration elapsed time:" in caplog.text
+    assert "result wait time: 12.34 ms" in caplog.text

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -448,7 +448,14 @@ class EngineCore:
             iteration_details = compute_iteration_details(scheduler_output)
             is_dummy = False
         before = time.monotonic()
-        yield
+        timing: dict[str, float] = {}
+        yield timing
+        result_wait_time = timing.get("result_wait_time")
+        result_wait_detail = (
+            f", result wait time: {result_wait_time * 1000:.2f} ms"
+            if result_wait_time is not None
+            else ""
+        )
         logger.info(
             "".join(
                 [
@@ -465,6 +472,7 @@ class EngineCore:
                     " generation tokens, iteration elapsed time: ",
                     format((time.monotonic() - before) * 1000, ".2f"),
                     " ms",
+                    result_wait_detail,
                     " (dummy)" if is_dummy else "",
                 ]
             )
@@ -492,9 +500,12 @@ class EngineCore:
         grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
         with (
             self.log_error_detail(scheduler_output),
-            self.log_iteration_details(scheduler_output),
+            self.log_iteration_details(scheduler_output) as timing,
         ):
+            result_wait_start = time.monotonic() if timing is not None else 0.0
             model_output = future.result()
+            if timing is not None:
+                timing["result_wait_time"] = time.monotonic() - result_wait_start
             if model_output is None:
                 model_output = self.model_executor.sample_tokens(grammar_output)
 
@@ -590,9 +601,12 @@ class EngineCore:
         future, scheduler_output, exec_model_fut = batch_queue.pop()
         with (
             self.log_error_detail(scheduler_output),
-            self.log_iteration_details(scheduler_output),
+            self.log_iteration_details(scheduler_output) as timing,
         ):
+            result_wait_start = time.monotonic() if timing is not None else 0.0
             model_output = future.result()
+            if timing is not None:
+                timing["result_wait_time"] = time.monotonic() - result_wait_start
             if model_output is None:
                 # None from sample_tokens() implies that the original execute_model()
                 # call failed - raise that exception.


### PR DESCRIPTION


## Purpose

This PR adds `result wait time` to the existing iteration-detail logs.

The metric measures the wall-clock interval from immediately before
calling `future.result()` until the call returns. It is recorded in both
`EngineCore.step()` and `EngineCore.step_with_batch_queue()`.

The metric is intentionally named `result wait time` because the
measured interval may include executor, synchronization, or
communication overhead. It does not represent pure GPU execution time,
model execution time, or scheduler time.

Related to #38760. This is a narrower logging-only change and does not
implement the complete metrics pipeline proposed in the RFC.

A focused unit test is added for the new log field.

This PR was developed with assistance from ChatGPT and Antigravity.
I reviewed and understand all submitted changes.

## Test Plan

- Run the focused unit test for the new iteration-detail log field.
- Run the patch-format check.
- Run the repository pre-commit checks.
- Attempt the existing EngineCore integration test locally.

## Test Result

The focused unit test passed:

```bash
.venv/bin/python -m pytest \
  tests/v1/engine/test_iteration_details_logging.py -v
```

```text
1 passed, 16 warnings in 1.78s
```

The patch-format check passed:

```bash
git diff --cached --check
```

```text
Exit code: 0
```

The repository pre-commit checks passed:

```bash
.venv/bin/pre-commit run
```

```text
All hooks passed, including ruff, mypy, SPDX, and repository-specific checks.
Exit code: 0
```

The existing EngineCore integration test was also attempted:

```bash
.venv/bin/python -m pytest \
  tests/v1/engine/test_engine_core.py::test_engine_core -v
```

It could not complete locally because insufficient GPU memory was
available during EngineCore initialization. The failure occurred before
assertions related to this change were executed.

---
