### PR TITLE
[Bugfix][Tool Parser] Stream tool calls that arrive whole in a single delta in llama3_json, jamba and ernie45 parsers

### DIFF
--- a/tests/tool_parsers/test_ernie45_moe_tool_parser.py
+++ b/tests/tool_parsers/test_ernie45_moe_tool_parser.py
@@ -7,6 +7,7 @@ from collections.abc import Generator
 
 import pytest
 
+from tests.tool_parsers.utils import run_tool_extraction_streaming
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaMessage,
@@ -357,3 +358,40 @@ def test_extract_tool_calls_streaming_incremental(
     assert len(actual_tool_calls) > 0
     # check tool call format
     assert_tool_calls(actual_tool_calls, expected_tool_calls)
+
+
+def test_extract_tool_calls_streaming_multiple_tools_single_delta(
+    ernie45_tool_parser,
+):
+    """Multiple complete tool calls in one delta must all be emitted.
+
+    This happens e.g. with async scheduling or stream_interval > 1, where
+    a single streamed delta can contain the entire tool call message.
+    Previously only the first tool call was emitted and the rest were left
+    stranded in the internal buffer.
+    """
+    model_output = (
+        "I will check the weather and the time.\n"
+        "<tool_call>\n"
+        '{"name": "get_current_temperature", "arguments": {"location": "Beijing"}}\n'
+        "</tool_call>\n"
+        "<tool_call>\n"
+        '{"name": "get_current_time", "arguments": {"timezone": "Asia/Shanghai"}}\n'
+        "</tool_call>\n"
+    )
+
+    reconstructor = run_tool_extraction_streaming(
+        ernie45_tool_parser, [model_output], assert_one_tool_per_delta=False
+    )
+
+    assert [call.function.name for call in reconstructor.tool_calls] == [
+        "get_current_temperature",
+        "get_current_time",
+    ]
+    assert json.loads(reconstructor.tool_calls[0].function.arguments) == {
+        "location": "Beijing"
+    }
+    assert json.loads(reconstructor.tool_calls[1].function.arguments) == {
+        "timezone": "Asia/Shanghai"
+    }
+    assert "I will check the weather and the time." in reconstructor.other_content

--- a/tests/tool_parsers/test_jamba_tool_parser.py
+++ b/tests/tool_parsers/test_jamba_tool_parser.py
@@ -8,6 +8,7 @@ import partial_json_parser
 import pytest
 from partial_json_parser.core.options import Allow
 
+from tests.tool_parsers.utils import run_tool_extraction_streaming
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage, FunctionCall, ToolCall
 from vllm.tokenizers import TokenizerLike, get_tokenizer
 from vllm.tokenizers.detokenizer_utils import detokenize_incrementally
@@ -306,3 +307,31 @@ def test_extract_tool_calls_streaming(
         )
     ]
     assert_tool_calls(actual_tool_calls, expected_tool_calls)
+
+
+def test_extract_tool_calls_streaming_single_delta(jamba_tool_parser):
+    """Tool calls arriving whole in the first delta must not be dropped.
+
+    This happens e.g. with async scheduling or stream_interval > 1, where
+    a single streamed delta can contain the entire tool call message.
+    """
+    model_output = """<tool_calls>[\n    {"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}},\n    {"name": "get_current_weather", "arguments": {"city": "Orlando", "state": "FL", "unit": "fahrenheit"}}\n]</tool_calls>"""  # noqa: E501
+
+    reconstructor = run_tool_extraction_streaming(
+        jamba_tool_parser, [model_output], assert_one_tool_per_delta=False
+    )
+
+    assert [call.function.name for call in reconstructor.tool_calls] == [
+        "get_current_weather",
+        "get_current_weather",
+    ]
+    assert json.loads(reconstructor.tool_calls[0].function.arguments) == {
+        "city": "Dallas",
+        "state": "TX",
+        "unit": "fahrenheit",
+    }
+    assert json.loads(reconstructor.tool_calls[1].function.arguments) == {
+        "city": "Orlando",
+        "state": "FL",
+        "unit": "fahrenheit",
+    }

--- a/tests/tool_parsers/test_llama3_json_tool_parser.py
+++ b/tests/tool_parsers/test_llama3_json_tool_parser.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 from transformers import AutoTokenizer
 
+from tests.tool_parsers.utils import run_tool_extraction_streaming
 from vllm.entrypoints.openai.engine.protocol import ExtractedToolCallInformation
 from vllm.tool_parsers.llama_tool_parser import Llama3JsonToolParser
 
@@ -267,3 +269,82 @@ def test_regex_timeout_handling(parser):
         assert result.tools_called is False
         assert len(result.tool_calls) == 0
         mock_regex.finditer.assert_called_once()
+
+
+class StubTokenizer:
+    """Minimal tokenizer stub for streaming tests.
+
+    The streaming parser operates on text only, so the tokenizer just needs
+    to expose the bot token in its vocab. Using a stub avoids downloading
+    the gated Llama tokenizer.
+    """
+
+    def get_vocab(self) -> dict[str, int]:
+        return {"<|python_tag|>": 128010}
+
+    def tokenize(self, text: str) -> list[str]:
+        return []
+
+
+def test_streaming_complete_tool_call_single_delta():
+    """A tool call arriving whole in the first delta must not be dropped."""
+    parser = Llama3JsonToolParser(StubTokenizer())
+    model_output = '{"name": "get_weather", "arguments": {"city": "Tokyo"}}'
+
+    reconstructor = run_tool_extraction_streaming(parser, [model_output])
+
+    assert len(reconstructor.tool_calls) == 1
+    call = reconstructor.tool_calls[0]
+    assert call.function.name == "get_weather"
+    assert json.loads(call.function.arguments) == {"city": "Tokyo"}
+
+
+def test_streaming_complete_tool_call_single_delta_with_bot_token():
+    parser = Llama3JsonToolParser(StubTokenizer())
+    model_output = (
+        '<|python_tag|>{"name": "get_weather", "arguments": {"city": "Tokyo"}}'
+    )
+
+    reconstructor = run_tool_extraction_streaming(parser, [model_output])
+
+    assert len(reconstructor.tool_calls) == 1
+    call = reconstructor.tool_calls[0]
+    assert call.function.name == "get_weather"
+    assert json.loads(call.function.arguments) == {"city": "Tokyo"}
+
+
+def test_streaming_complete_tool_call_single_delta_parameters_key():
+    """Llama may emit "parameters" instead of "arguments"; both must work."""
+    parser = Llama3JsonToolParser(StubTokenizer())
+    model_output = '{"name": "get_weather", "parameters": {"city": "Tokyo"}}'
+
+    reconstructor = run_tool_extraction_streaming(parser, [model_output])
+
+    assert len(reconstructor.tool_calls) == 1
+    call = reconstructor.tool_calls[0]
+    assert call.function.name == "get_weather"
+    assert json.loads(call.function.arguments) == {"city": "Tokyo"}
+
+
+def test_streaming_parallel_tool_calls_single_delta():
+    """Multiple complete tool calls in one delta must all be emitted."""
+    parser = Llama3JsonToolParser(StubTokenizer())
+    model_output = (
+        '{"name": "get_weather", "arguments": {"city": "Tokyo"}}; '
+        '{"name": "get_time", "arguments": {"timezone": "Asia/Tokyo"}}'
+    )
+
+    reconstructor = run_tool_extraction_streaming(
+        parser, [model_output], assert_one_tool_per_delta=False
+    )
+
+    assert [call.function.name for call in reconstructor.tool_calls] == [
+        "get_weather",
+        "get_time",
+    ]
+    assert json.loads(reconstructor.tool_calls[0].function.arguments) == {
+        "city": "Tokyo"
+    }
+    assert json.loads(reconstructor.tool_calls[1].function.arguments) == {
+        "timezone": "Asia/Tokyo"
+    }

--- a/vllm/tool_parsers/ernie45_tool_parser.py
+++ b/vllm/tool_parsers/ernie45_tool_parser.py
@@ -163,8 +163,12 @@ class Ernie45ToolParser(ToolParser):
 
             return DeltaMessage(content=content if content else None)
         logger.debug("cur_text = %s", cur_text)
-        end_idx = cur_text.find(self.tool_call_end_token)
-        if end_idx != -1:
+        # a single delta may contain several complete tool calls (e.g. the
+        # whole message arrived in one delta), so keep extracting until no
+        # complete tool call is left in the buffer
+        delta_content: str | None = None
+        delta_tool_calls: list[DeltaToolCall] = []
+        while (end_idx := cur_text.find(self.tool_call_end_token)) != -1:
             if self.current_tool_id == -1:
                 self.current_tool_id = 0
                 self.prev_tool_call_arr = []
@@ -180,7 +184,9 @@ class Ernie45ToolParser(ToolParser):
 
             if len(extracted_tool_calls.tool_calls) == 0:
                 logger.warning("Failed to extract any tool calls.")
-                return None
+                if not delta_tool_calls:
+                    return None
+                break
             tool_call = extracted_tool_calls.tool_calls[0]
             self.prev_tool_call_arr[self.current_tool_id] = {
                 "name": tool_call.function.name,
@@ -189,23 +195,25 @@ class Ernie45ToolParser(ToolParser):
             self.streamed_args_for_tool[self.current_tool_id] = (
                 tool_call.function.arguments
             )
-            delta = DeltaMessage(
-                content=extracted_tool_calls.content,
-                tool_calls=[
-                    DeltaToolCall(
-                        index=self.current_tool_id,
-                        id=tool_call.id,
-                        type=tool_call.type,
-                        function=DeltaFunctionCall(
-                            name=tool_call.function.name,
-                            arguments=tool_call.function.arguments,
-                        ),
-                    )
-                ],
+            if extracted_tool_calls.content:
+                delta_content = (delta_content or "") + extracted_tool_calls.content
+            delta_tool_calls.append(
+                DeltaToolCall(
+                    index=self.current_tool_id,
+                    id=tool_call.id,
+                    type=tool_call.type,
+                    function=DeltaFunctionCall(
+                        name=tool_call.function.name,
+                        arguments=tool_call.function.arguments,
+                    ),
+                )
             )
             self.current_tool_id += 1
-            self._buffer = cur_text[end_idx + len(self.tool_call_end_token) :]
-            return delta
+            cur_text = cur_text[end_idx + len(self.tool_call_end_token) :]
+
+        if delta_tool_calls:
+            self._buffer = cur_text
+            return DeltaMessage(content=delta_content, tool_calls=delta_tool_calls)
 
         self._buffer = cur_text[start_idx:]
         content = cur_text[:start_idx].rstrip("\n")

--- a/vllm/tool_parsers/jamba_tool_parser.py
+++ b/vllm/tool_parsers/jamba_tool_parser.py
@@ -24,7 +24,7 @@ from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import Tool, ToolParser
-from vllm.tool_parsers.utils import extract_intermediate_diff
+from vllm.tool_parsers.utils import extract_intermediate_diff, is_complete_json
 from vllm.utils.mistral import is_mistral_tokenizer
 
 logger = init_logger(__name__)
@@ -68,6 +68,39 @@ class JambaToolParser(ToolParser):
                 "Jamba Tool parser could not locate tool calls start/end "
                 "tokens in the tokenizer!"
             )
+
+    def _emit_initial_complete_tool_calls(
+        self, tool_call_arr: list[dict]
+    ) -> DeltaMessage | None:
+        delta_tool_calls: list[DeltaToolCall] = []
+        streamed_args_for_tool: list[str] = []
+
+        for index, tool_call in enumerate(tool_call_arr):
+            function_name = tool_call.get("name")
+            if not function_name or "arguments" not in tool_call:
+                return None
+            arguments = json.dumps(tool_call["arguments"], ensure_ascii=False)
+            delta_tool_calls.append(
+                DeltaToolCall(
+                    index=index,
+                    type="function",
+                    id=make_tool_call_id(),
+                    function=DeltaFunctionCall(
+                        name=function_name,
+                        arguments=arguments,
+                    ).model_dump(exclude_none=True),
+                )
+            )
+            streamed_args_for_tool.append(arguments)
+
+        if not delta_tool_calls:
+            return None
+
+        self.current_tool_id = len(tool_call_arr) - 1
+        self.current_tool_name_sent = True
+        self.prev_tool_call_arr = tool_call_arr
+        self.streamed_args_for_tool = streamed_args_for_tool
+        return DeltaMessage(tool_calls=delta_tool_calls)
 
     def adjust_request(
         self, request: ChatCompletionRequest | ResponsesRequest
@@ -184,11 +217,17 @@ class JambaToolParser(ToolParser):
             if len(tool_call_arr) == 0:
                 return None
 
+            # case: the first delta already contains the complete tool call
+            #   array (e.g. the whole message arrived in one delta); emit all
+            #   tool calls now since no further deltas may arrive
+            if self.current_tool_id < 0 and is_complete_json(parsable_arr):
+                initial_delta = self._emit_initial_complete_tool_calls(tool_call_arr)
+                if initial_delta is not None:
+                    return initial_delta
+
             # case: we are starting a new tool in the array
             #   -> array has > 0 length AND length has moved past cursor
-            elif (
-                len(tool_call_arr) > 0 and len(tool_call_arr) > self.current_tool_id + 1
-            ):
+            if len(tool_call_arr) > 0 and len(tool_call_arr) > self.current_tool_id + 1:
                 # if we're moving on to a new call, first make sure we
                 # haven't missed anything in the previous one that was
                 # auto-generated due to JSON completions, but wasn't
@@ -218,7 +257,10 @@ class JambaToolParser(ToolParser):
                 # re-set stuff pertaining to progress in the current tool
                 self.current_tool_id = len(tool_call_arr) - 1
                 self.current_tool_name_sent = False
-                self.streamed_args_for_tool.append("")
+                # multiple tools may have appeared in a single delta, so make
+                # sure a slot exists for every tool up to the current one
+                while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                    self.streamed_args_for_tool.append("")
                 logger.debug("starting on new tool %d", self.current_tool_id)
                 return delta
 

--- a/vllm/tool_parsers/llama_tool_parser.py
+++ b/vllm/tool_parsers/llama_tool_parser.py
@@ -74,6 +74,39 @@ class Llama3JsonToolParser(ToolParser):
                 f"'{self.bot_token}' in the tokenizer."
             )
 
+    def _emit_initial_complete_tool_calls(
+        self, tool_call_arr: list[dict]
+    ) -> DeltaMessage | None:
+        delta_tool_calls: list[DeltaToolCall] = []
+        streamed_args_for_tool: list[str] = []
+
+        for index, tool_call in enumerate(tool_call_arr):
+            function_name = tool_call.get("name")
+            if not function_name or "arguments" not in tool_call:
+                return None
+            arguments = json.dumps(tool_call["arguments"], ensure_ascii=False)
+            delta_tool_calls.append(
+                DeltaToolCall(
+                    index=index,
+                    type="function",
+                    id=make_tool_call_id(),
+                    function=DeltaFunctionCall(
+                        name=function_name,
+                        arguments=arguments,
+                    ).model_dump(exclude_none=True),
+                )
+            )
+            streamed_args_for_tool.append(arguments)
+
+        if not delta_tool_calls:
+            return None
+
+        self.current_tool_id = len(tool_call_arr) - 1
+        self.current_tool_name_sent = True
+        self.prev_tool_call_arr = tool_call_arr
+        self.streamed_args_for_tool = streamed_args_for_tool
+        return DeltaMessage(tool_calls=delta_tool_calls)
+
     def extract_tool_calls(
         self, model_output: str, request: ChatCompletionRequest
     ) -> ExtractedToolCallInformation:
@@ -226,11 +259,17 @@ class Llama3JsonToolParser(ToolParser):
             if len(tool_call_arr) == 0:
                 return None
 
+            # case: the first delta already contains complete tool calls
+            #   (e.g. the whole message arrived in one delta); emit them all
+            #   now since no further deltas may arrive
+            if self.current_tool_id < 0 and all(is_complete):
+                initial_delta = self._emit_initial_complete_tool_calls(tool_call_arr)
+                if initial_delta is not None:
+                    return initial_delta
+
             # case: we are starting a new tool in the array
             #   -> array has > 0 length AND length has moved past cursor
-            elif (
-                len(tool_call_arr) > 0 and len(tool_call_arr) > self.current_tool_id + 1
-            ):
+            if len(tool_call_arr) > 0 and len(tool_call_arr) > self.current_tool_id + 1:
                 # if we're moving on to a new call, first make sure we
                 # haven't missed anything in the previous one that was
                 # auto-generated due to JSON completions, but wasn't
@@ -263,7 +302,10 @@ class Llama3JsonToolParser(ToolParser):
                 # re-set stuff pertaining to progress in the current tool
                 self.current_tool_id = len(tool_call_arr) - 1
                 self.current_tool_name_sent = False
-                self.streamed_args_for_tool.append("")
+                # multiple tools may have appeared in a single delta, so make
+                # sure a slot exists for every tool up to the current one
+                while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                    self.streamed_args_for_tool.append("")
                 logger.debug("starting on new tool %d", self.current_tool_id)
                 return delta
 


### PR DESCRIPTION
FIX #48294

## Purpose

When an entire tool-call message arrives in a single streamed delta (async scheduling, `stream_interval > 1`, or a short message emitted at once), three streaming tool parsers lose tool calls that the non-streaming path extracts correctly:

- **`llama3_json`** (also used for `llama4_json`) and **`jamba`**: the "starting a new tool" branch records state for the newly seen tool and returns `None` without emitting the name or arguments. No further deltas arrive, so the tool call is never emitted — the client gets an empty response.
- **`ernie45`**: only the first complete `<tool_call>...</tool_call>` block in a delta is emitted; the rest stay stranded in the internal buffer and are lost.

This is the same bug class as #47907, fixed for `gigachat3`/`granite`/`granite-20b-fc` in #47955. This PR extends the same approach to the three parsers above:

- `llama3_json`, `jamba`: when the first parsed delta already contains only complete tool calls, emit all of them (name + full arguments) in one `DeltaMessage` via a new `_emit_initial_complete_tool_calls` helper, mirroring #47955.
- `llama3_json`, `jamba`: when several tools appear at once, grow `streamed_args_for_tool` to match `current_tool_id` instead of appending a single slot. Previously the resulting `IndexError` was swallowed by the broad exception handler and silently dropped subsequent argument deltas.
- `ernie45`: drain every complete `<tool_call>...</tool_call>` block from the buffer per invocation instead of at most one, emitting one `DeltaToolCall` per block with correct indices.

**Duplicate check:** #47955 covers only `gigachat3`/`granite`/`granite-20b-fc`; #46934 covers `granite4` content loss. I found no open PR or issue addressing this for `llama3_json`, `jamba`, or `ernie45` (searched open PRs/issues for the parser names, "single delta tool", `check_tool_usage`, and related terms).

## Test Plan

New streaming regression tests (no GPU needed; the `llama3_json` tests use a tokenizer stub so the gated Llama tokenizer is not required):

```bash
pytest tests/tool_parsers/test_llama3_json_tool_parser.py \
       tests/tool_parsers/test_jamba_tool_parser.py \
       tests/tool_parsers/test_ernie45_moe_tool_parser.py
```

## Test Result

On the parent commit (735def4fc), the 6 new tests fail exactly as described (streaming emits nothing for `llama3_json`/`jamba`; only the first tool call for `ernie45`). With this change:

```text
tests/tool_parsers/test_llama3_json_tool_parser.py::test_streaming_complete_tool_call_single_delta PASSED
tests/tool_parsers/test_llama3_json_tool_parser.py::test_streaming_complete_tool_call_single_delta_with_bot_token PASSED
tests/tool_parsers/test_llama3_json_tool_parser.py::test_streaming_complete_tool_call_single_delta_parameters_key PASSED
tests/tool_parsers/test_llama3_json_tool_parser.py::test_streaming_parallel_tool_calls_single_delta PASSED
tests/tool_parsers/test_jamba_tool_parser.py::test_extract_tool_calls_streaming_single_delta PASSED
tests/tool_parsers/test_ernie45_moe_tool_parser.py::test_extract_tool_calls_streaming_multiple_tools_single_delta PASSED
```

All existing tests in the three files pass as well (21 passed total on Linux/CPU, Python 3.12). The remaining pre-existing `llama3_json` tests error at fixture setup in my environment only because the gated `meta-llama/Llama-3.2-1B-Instruct` tokenizer needs an HF token; they are unaffected by this change. `pre-commit` (ruff check/format, mypy, typos) passes on all changed files.

---

*Disclosure per the [contributing guidelines](https://docs.vllm.ai/en/latest/contributing/#ai-assisted-contributions): this PR was developed with AI assistance (Claude); commits carry a `Co-authored-by` trailer. I reviewed the changes and ran the tests above locally.*
