### PR TITLE
[Bugfix] GLM-4.7/4.5 parser: deserialize tool args with no schema type

### DIFF
--- a/tests/tool_parsers/test_glm47_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm47_moe_tool_parser.py
@@ -266,3 +266,95 @@ class TestGlm47Streaming:
         ]
         args = json.loads("".join(arguments))
         assert args["city"] == "Beijing"
+
+
+TYPED_ARGS_OUT = (
+    "<tool_call>get_weather"
+    "<arg_key>city</arg_key><arg_value>Beijing</arg_value>"
+    "<arg_key>days</arg_key><arg_value>5</arg_value>"
+    "<arg_key>metric</arg_key><arg_value>true</arg_value>"
+    "<arg_key>ids</arg_key><arg_value>[1, 2.5]</arg_value>"
+    "</tool_call>"
+)
+TYPED_ARGS_EXPECTED = {
+    "city": "Beijing",
+    "days": 5,
+    "metric": True,
+    "ids": [1, 2.5],
+}
+
+
+class TestGlm47UntypedArgDeserialization:
+    """Values with no schema type must deserialize like the legacy parser
+    (json, then Python literal) instead of staying JSON strings."""
+
+    @pytest.fixture
+    def no_tools_request(self) -> ChatCompletionRequest:
+        request = Mock(spec=ChatCompletionRequest)
+        request.tools = None
+        request.tool_choice = "auto"
+        return request
+
+    def test_no_schema_values_typed(self, glm47_tokenizer, no_tools_request):
+        parser = Glm47MoeModelToolParser(glm47_tokenizer, tools=None)
+        r = parser.extract_tool_calls(TYPED_ARGS_OUT, request=no_tools_request)
+        assert r.tools_called
+        assert json.loads(r.tool_calls[0].function.arguments) == TYPED_ARGS_EXPECTED
+
+    def test_undeclared_keys_typed_with_schema(self, glm47_tool_parser, mock_request):
+        # city is declared as string; days/metric/ids are not in the schema
+        r = glm47_tool_parser.extract_tool_calls(TYPED_ARGS_OUT, request=mock_request)
+        assert r.tools_called
+        assert json.loads(r.tool_calls[0].function.arguments) == TYPED_ARGS_EXPECTED
+
+    def test_schema_string_beats_heuristic(self, glm47_tokenizer):
+        tools = [
+            ChatCompletionToolsParam(
+                function=FunctionDefinition(
+                    name="get_weather",
+                    parameters={
+                        "type": "object",
+                        "properties": {"zip": {"type": "string"}},
+                    },
+                ),
+            ),
+        ]
+        request = Mock(spec=ChatCompletionRequest)
+        request.tools = tools
+        request.tool_choice = "auto"
+        parser = Glm47MoeModelToolParser(glm47_tokenizer, tools=tools)
+        out = (
+            "<tool_call>get_weather"
+            "<arg_key>zip</arg_key><arg_value>02139</arg_value>"
+            "</tool_call>"
+        )
+        r = parser.extract_tool_calls(out, request=request)
+        assert r.tools_called
+        assert json.loads(r.tool_calls[0].function.arguments) == {"zip": "02139"}
+
+    @pytest.mark.parametrize("chunk_size", [1, 7, len(TYPED_ARGS_OUT)])
+    def test_streaming_matches_nonstreaming(
+        self, glm47_tokenizer, no_tools_request, chunk_size
+    ):
+        parser = Glm47MoeModelToolParser(glm47_tokenizer, tools=None)
+        previous_text = ""
+        arguments = []
+        for i in range(0, len(TYPED_ARGS_OUT), chunk_size):
+            current_text = TYPED_ARGS_OUT[: i + chunk_size]
+            delta = parser.extract_tool_calls_streaming(
+                previous_text=previous_text,
+                current_text=current_text,
+                delta_text=current_text[len(previous_text) :],
+                previous_token_ids=[],
+                current_token_ids=[],
+                delta_token_ids=[],
+                request=no_tools_request,
+            )
+            previous_text = current_text
+            if delta:
+                arguments.extend(
+                    tool_call.function.arguments
+                    for tool_call in (delta.tool_calls or [])
+                    if tool_call.function and tool_call.function.arguments
+                )
+        assert json.loads("".join(arguments)) == TYPED_ARGS_EXPECTED

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -32,6 +32,7 @@ from vllm.tool_parsers.utils import (
     extract_types_from_schema,
     find_tool_name,
     find_tool_properties,
+    safe_literal_eval,
 )
 
 if TYPE_CHECKING:
@@ -125,6 +126,7 @@ class ParserEngine(Parser):
         self._arg_converter = parser_engine_config.arg_converter
         self._arg_structural_chars = parser_engine_config.arg_structural_chars
         self._stream_arg_deltas = parser_engine_config.stream_arg_deltas
+        self._deserialize_untyped_args = parser_engine_config.deserialize_untyped_args
         self._strip_trailing_reasoning_ws = (
             parser_engine_config.strip_trailing_reasoning_whitespace
         )
@@ -360,15 +362,42 @@ class ParserEngine(Parser):
                 streamable.add(key)
         return streamable
 
+    def _slot_string_keys(self, name: str) -> set[str] | None:
+        """Streamable string keys for a named tool.
+
+        With ``deserialize_untyped_args``, schema-less values may change type
+        once complete, so no key is prefix-stable without a schema.
+        """
+        keys = self._streamable_string_keys(find_tool_properties(self._tools, name))
+        if keys is None and self._deserialize_untyped_args:
+            return set()
+        return keys
+
+    @staticmethod
+    def _deserialize_untyped(value: str) -> object:
+        """Deserialize a schema-less value: JSON, then Python literal."""
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            pass
+        try:
+            return safe_literal_eval(value)
+        except (ValueError, SyntaxError):
+            pass
+        return value
+
     def _fix_arg_types(self, args_json: str, func_name: str) -> str:
         """Correct parameter types using the tool schema.
 
         String values are coerced via :func:`coerce_to_schema_type`.
         Nested objects and arrays are recursed into when the schema
         defines ``properties`` or ``items``.  Without a schema, values
-        stay as strings.
+        stay as strings — unless ``deserialize_untyped_args`` is set, in
+        which case values missing from the schema (or all values, when no
+        schema is available) are deserialized heuristically.
         """
-        if not self._tools or not func_name:
+        heuristic = self._deserialize_untyped_args
+        if not heuristic and (not self._tools or not func_name):
             return args_json
         try:
             args = json.loads(args_json)
@@ -377,11 +406,23 @@ class ParserEngine(Parser):
         if not isinstance(args, dict):
             return args_json
 
-        properties = find_tool_properties(self._tools, func_name)
-        if not properties:
+        properties = {}
+        if self._tools and func_name:
+            properties = find_tool_properties(self._tools, func_name)
+        if not properties and not heuristic:
             return args_json
 
-        _, changed = self._coerce_dict(args, properties)
+        changed = False
+        if properties:
+            _, changed = self._coerce_dict(args, properties)
+        if heuristic:
+            for key, value in args.items():
+                if key in properties or not isinstance(value, str):
+                    continue
+                converted = self._deserialize_untyped(value)
+                if converted is not value:
+                    args[key] = converted
+                    changed = True
 
         if changed:
             return json.dumps(args, ensure_ascii=False)
@@ -802,9 +843,7 @@ class ParserEngine(Parser):
         slot = self._tool_slots[idx]
         slot.name = name
         slot.name_sent = True
-        slot.string_keys = self._streamable_string_keys(
-            find_tool_properties(self._tools, name)
-        )
+        slot.string_keys = self._slot_string_keys(name)
         self._ensure_tool_id(slot, name)
         deltas.append(
             DeltaToolCall(
@@ -860,9 +899,7 @@ class ParserEngine(Parser):
             if name and self._is_valid_tool_name(name):
                 slot.name = name
                 slot.name_sent = True
-                slot.string_keys = self._streamable_string_keys(
-                    find_tool_properties(self._tools, name)
-                )
+                slot.string_keys = self._slot_string_keys(name)
                 self._ensure_tool_id(slot, name)
                 deltas.append(
                     DeltaToolCall(

--- a/vllm/parser/engine/parser_engine_config.py
+++ b/vllm/parser/engine/parser_engine_config.py
@@ -95,6 +95,12 @@ class ParserEngineConfig:
     # Reject tool calls whose names are absent from the request tools.
     validate_tool_names: bool = False
 
+    # Heuristically deserialize (JSON, then Python literal) argument values
+    # that have no schema type: keys absent from the tool's properties, or
+    # every value when the request carries no tool schema. For formats whose
+    # arg_converter emits all values as JSON strings (e.g. XML arg tags).
+    deserialize_untyped_args: bool = False
+
     @cached_property
     def terminal_defs(self):
         from vllm.parser.engine.incremental_lexer import terminals_from_literals

--- a/vllm/parser/glm47_moe.py
+++ b/vllm/parser/glm47_moe.py
@@ -169,6 +169,7 @@ def glm47_moe_config(thinking: bool = True) -> ParserEngineConfig:
         stream_arg_deltas=True,
         tool_args_json=False,
         validate_tool_names=True,
+        deserialize_untyped_args=True,
     )
 
 


### PR DESCRIPTION
## Purpose

The engine rewrite of the GLM parser (#45915) dropped the legacy parser's `_deserialize` step (`json.loads`, then a Python-literal fallback). Type correction is now entirely schema-gated (`_fix_arg_types`), so values with no schema type — keys absent from the tool's `properties`, tools without `properties`, or requests with no tools — come back as JSON strings: `<arg_value>5</arg_value>` → `"5"` (was `5`), `true` → `"true"`, `[1, 2.5]` → `"[1, 2.5]"`. Affects both `glm45` and `glm47` registrations. Same regression class as gemma4's #47906 (being fixed in its own converter in #47909); the GLM parser is not covered by any open PR.

This adds an opt-in `ParserEngineConfig.deserialize_untyped_args` that applies the legacy heuristic to string values without a schema entry, enabled for `glm47_moe`. Schema-declared types still win. Without a schema, streamed trailing values are withheld until complete, since heuristic conversion may change their serialized form and break the streamed-prefix invariant.

## Test Plan

```bash
pytest tests/tool_parsers/test_glm47_moe_tool_parser.py tests/tool_parsers/test_glm4_moe_tool_parser.py
pytest tests/parser/engine/
```

## Test Result

```
25 passed (glm47 + glm4_moe, incl. 6 new regression tests)
3697 passed (tests/parser/engine)
```

New tests cover: no-schema values typed, undeclared keys typed alongside schema coercion, schema `string` beating the heuristic (`"02139"` stays a string), and streaming == non-streaming at chunk sizes 1 / 7 / whole-output.

No open PR or issue covers this (searched glm47/glm tool parser/deserialize; #47909 is gemma4-only, #48131 was a release-branch backport of a different zero-arg bug). Written with AI assistance; I reviewed every changed line and ran the tests above.
