### PR TITLE
[Bugfix] DeepSeek V3/V3.1 tool parsers: emit tool calls that arrive in a single streaming delta

### DIFF
--- a/tests/tool_parsers/test_deepseekv31_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv31_tool_parser.py
@@ -3,6 +3,7 @@
 
 import pytest
 
+from tests.tool_parsers.utils import run_tool_extraction_streaming
 from vllm.tokenizers import get_tokenizer
 from vllm.tool_parsers.deepseekv31_tool_parser import (
     DeepSeekV31ToolParser,
@@ -59,3 +60,36 @@ def test_extract_tool_calls_with_multiple_tools(parser):
 
     # prefix is content
     assert result.content == "some prefix text"
+
+
+def test_streaming_single_tool_call_in_one_delta(parser):
+    """A whole tool call arriving in one delta must still be emitted."""
+    model_output = (
+        "<｜tool▁calls▁begin｜>"
+        '<｜tool▁call▁begin｜>foo<｜tool▁sep｜>{"x":1}<｜tool▁call▁end｜>'
+        "<｜tool▁calls▁end｜>"
+    )
+    reconstructor = run_tool_extraction_streaming(
+        parser, [model_output], assert_one_tool_per_delta=False
+    )
+    assert len(reconstructor.tool_calls) == 1
+    assert reconstructor.tool_calls[0].function.name == "foo"
+    assert reconstructor.tool_calls[0].function.arguments == '{"x":1}'
+
+
+def test_streaming_parallel_tool_calls_in_one_delta(parser):
+    """Parallel tool calls arriving in one delta must all be emitted."""
+    model_output = (
+        "<｜tool▁calls▁begin｜>"
+        '<｜tool▁call▁begin｜>foo<｜tool▁sep｜>{"x":1}<｜tool▁call▁end｜>'
+        '<｜tool▁call▁begin｜>bar<｜tool▁sep｜>{"y":2}<｜tool▁call▁end｜>'
+        "<｜tool▁calls▁end｜>"
+    )
+    reconstructor = run_tool_extraction_streaming(
+        parser, [model_output], assert_one_tool_per_delta=False
+    )
+    assert len(reconstructor.tool_calls) == 2
+    assert reconstructor.tool_calls[0].function.name == "foo"
+    assert reconstructor.tool_calls[0].function.arguments == '{"x":1}'
+    assert reconstructor.tool_calls[1].function.name == "bar"
+    assert reconstructor.tool_calls[1].function.arguments == '{"y":2}'

--- a/tests/tool_parsers/test_deepseekv3_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv3_tool_parser.py
@@ -2,12 +2,15 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import json
+
 import pytest
 
 from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
+from tests.tool_parsers.utils import run_tool_extraction_streaming
 from vllm.tokenizers import TokenizerLike, get_tokenizer
 
 
@@ -90,3 +93,37 @@ class TestDeepSeekV3ToolParser(ToolParserTests):
                 ),
             },
         )
+
+    def test_single_tool_call_in_one_delta(
+        self, tool_parser, test_config: ToolParserTestConfig
+    ):
+        """A whole tool call arriving in one delta must still be emitted."""
+        reconstructor = run_tool_extraction_streaming(
+            tool_parser,
+            [test_config.single_tool_call_output],
+            assert_one_tool_per_delta=False,
+        )
+        assert len(reconstructor.tool_calls) == 1
+        tool_call = reconstructor.tool_calls[0]
+        assert tool_call.function.name == "get_weather"
+        assert json.loads(tool_call.function.arguments) == {
+            "city": "Tokyo",
+            "unit": "celsius",
+        }
+
+    def test_parallel_tool_calls_in_one_delta(
+        self, tool_parser, test_config: ToolParserTestConfig
+    ):
+        """Parallel tool calls arriving in one delta must all be emitted."""
+        reconstructor = run_tool_extraction_streaming(
+            tool_parser,
+            [test_config.parallel_tool_calls_output],
+            assert_one_tool_per_delta=False,
+        )
+        names = [tc.function.name for tc in reconstructor.tool_calls]
+        assert names == ["get_weather", "search_hotels"]
+        args = [json.loads(tc.function.arguments) for tc in reconstructor.tool_calls]
+        assert args == [
+            {"city": "Tokyo", "unit": "celsius"},
+            {"location": "Tokyo", "check_in": "2025-01-15"},
+        ]

--- a/vllm/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv31_tool_parser.py
@@ -119,6 +119,37 @@ class DeepSeekV31ToolParser(ToolParser):
                     tools_called=False, tool_calls=[], content=model_output
                 )
 
+    def _parse_stream_tool_calls(self, text: str) -> list[dict]:
+        """Parse every tool call in *text*, in order.
+
+        Returns one dict per ``tool_call_start_token`` found: complete
+        blocks and the trailing in-progress block alike. ``name`` is
+        ``None`` while the model has not finished emitting it.
+        """
+        calls: list[dict] = []
+        pos = 0
+        while True:
+            start = text.find(self.tool_call_start_token, pos)
+            if start == -1:
+                break
+            body_start = start + len(self.tool_call_start_token)
+            end = text.find(self.tool_call_end_token, body_start)
+            body = text[body_start:end] if end != -1 else text[body_start:]
+            portion = body.rstrip()
+            match = self.stream_tool_call_portion_regex.match(portion)
+            if match:
+                name = match.group("function_name")
+                arguments = match.group("function_arguments")
+            else:
+                name_match = self.stream_tool_call_name_regex.match(portion)
+                name = name_match.group("function_name") if name_match else None
+                arguments = ""
+            calls.append({"name": name, "arguments": arguments})
+            if end == -1:
+                break
+            pos = end + len(self.tool_call_end_token)
+        return calls
+
     def extract_tool_calls_streaming(
         self,
         previous_text: str,
@@ -129,263 +160,92 @@ class DeepSeekV31ToolParser(ToolParser):
         delta_token_ids: Sequence[int],
         request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
-        logger.debug("delta_text: %s", delta_text)
-        logger.debug("delta_token_ids: %s", delta_token_ids)
-        # check to see if we should be streaming a tool call - is there a
         if self.tool_calls_start_token_id not in current_token_ids:
-            logger.debug("No tool call tokens found!")
             return DeltaMessage(content=delta_text)
+
         delta_text = delta_text.replace(self.tool_calls_start_token, "").replace(
             self.tool_calls_end_token, ""
         )
         try:
-            # figure out where we are in the parsing by counting tool call
-            # start & end tags
-            prev_tool_start_count = previous_token_ids.count(
-                self.tool_call_start_token_id
-            )
             prev_tool_end_count = previous_token_ids.count(self.tool_call_end_token_id)
             cur_tool_start_count = current_token_ids.count(
                 self.tool_call_start_token_id
             )
             cur_tool_end_count = current_token_ids.count(self.tool_call_end_token_id)
-            tool_call_portion = None
-            text_portion = None
 
-            # case: if we're generating text, OR rounding out a tool call
+            # plain text: outside any tool call (before the first one starts,
+            # or after the last one has closed)
             if (
                 cur_tool_start_count == cur_tool_end_count
                 and prev_tool_end_count == cur_tool_end_count
                 and self.tool_call_end_token not in delta_text
             ):
-                logger.debug("Generating text content! skipping tool parsing.")
                 return DeltaMessage(content=delta_text)
 
-            if self.tool_call_end_token in delta_text:
-                logger.debug("tool_call_end_token in delta_text")
-                full_text = current_text + delta_text
-                tool_call_portion = (
-                    full_text.split(self.tool_call_start_token)[-1]
-                    .split(self.tool_call_end_token)[0]
-                    .rstrip()
-                )
-                delta_text = delta_text.split(self.tool_call_end_token)[0].rstrip()
-                text_portion = delta_text.split(self.tool_call_end_token)[-1].lstrip()
+            # Re-parse every tool call from the accumulated text and stream
+            # whatever has not been sent yet. Iterating all calls (instead of
+            # advancing one state per invocation) keeps parsing correct when a
+            # single delta carries one or more complete calls, e.g. from
+            # speculative decoding or the reasoning-end re-delivery of
+            # accumulated text.
+            delta_tool_calls: list[DeltaToolCall] = []
+            for index, call in enumerate(self._parse_stream_tool_calls(current_text)):
+                if index < self.current_tool_id:
+                    continue
+                if index > self.current_tool_id:
+                    self.current_tool_id = index
+                    self.current_tool_name_sent = False
+                while len(self.streamed_args_for_tool) <= index:
+                    self.streamed_args_for_tool.append("")
+                while len(self.prev_tool_call_arr) <= index:
+                    self.prev_tool_call_arr.append({})
 
-            # case -- we're starting a new tool call
-            if (
-                cur_tool_start_count > cur_tool_end_count
-                and cur_tool_start_count > prev_tool_start_count
-            ):
-                if len(delta_token_ids) > 1:
-                    tool_call_portion = current_text.split(self.tool_call_start_token)[
-                        -1
-                    ]
-                else:
-                    tool_call_portion = None
-                    delta = None
+                name = call["name"]
+                if name is None:
+                    # tool name is still being generated; nothing further can
+                    # be streamed for this or later calls
+                    break
+                arguments = call["arguments"]
 
-                text_portion = None
+                streamed = self.streamed_args_for_tool[index]
+                argument_diff = None
+                if (
+                    arguments
+                    and len(arguments) > len(streamed)
+                    and arguments.startswith(streamed)
+                ):
+                    argument_diff = arguments[len(streamed) :]
+                    self.streamed_args_for_tool[index] = arguments
+                self.prev_tool_call_arr[index] = {
+                    "name": name,
+                    "arguments": arguments,
+                }
 
-                # set cursors and state appropriately
-                self.current_tool_id += 1
-                self.current_tool_name_sent = False
-                self.streamed_args_for_tool.append("")
-                logger.debug("Starting on a new tool %s", self.current_tool_id)
-
-            # case -- we're updating an existing tool call
-            elif (
-                cur_tool_start_count > cur_tool_end_count
-                and cur_tool_start_count == prev_tool_start_count
-            ):
-                # get the portion of the text that's the tool call
-                tool_call_portion = current_text.split(self.tool_call_start_token)[-1]
-                text_portion = None
-
-            # case -- the current tool call is being closed.
-            elif (
-                cur_tool_start_count == cur_tool_end_count
-                and cur_tool_end_count >= prev_tool_end_count
-            ):
-                if self.prev_tool_call_arr is None or len(self.prev_tool_call_arr) == 0:
-                    logger.debug("attempting to close tool call, but no tool call")
-                    return None
-                diff = self.prev_tool_call_arr[self.current_tool_id].get("arguments")
-                if diff:
-                    diff = (
-                        diff.encode("utf-8").decode("unicode_escape")
-                        if diff is str
-                        else diff
-                    )
-                    if '"}' not in delta_text:
-                        return None
-                    end_loc = delta_text.rindex('"}')
-                    diff = delta_text[:end_loc] + '"}'
-                    logger.debug(
-                        "Finishing tool and found diff that had not "
-                        "been streamed yet: %s",
-                        diff,
-                    )
-                    self.streamed_args_for_tool[self.current_tool_id] += diff
-                    return DeltaMessage(
-                        tool_calls=[
-                            DeltaToolCall(
-                                index=self.current_tool_id,
-                                function=DeltaFunctionCall(arguments=diff).model_dump(
-                                    exclude_none=True
-                                ),
-                            )
-                        ]
-                    )
-
-            # case -- otherwise we're just generating text
-            else:
-                text = delta_text.replace(self.tool_call_start_token, "")
-                text = text.replace(self.tool_call_end_token, "")
-                delta = DeltaMessage(tool_calls=[], content=text)
-                return delta
-
-            current_tool_call = dict()
-            if tool_call_portion:
-                current_tool_call_matches = self.stream_tool_call_portion_regex.match(
-                    tool_call_portion
-                )
-                if current_tool_call_matches:
-                    tool_name, tool_args = current_tool_call_matches.groups()
-                    current_tool_call["name"] = tool_name
-                    current_tool_call["arguments"] = tool_args
-                else:
-                    current_tool_call_name_matches = (
-                        self.stream_tool_call_name_regex.match(tool_call_portion)
-                    )
-                    if current_tool_call_name_matches:
-                        tool_name = current_tool_call_name_matches.groups()
-                        current_tool_call["name"] = tool_name
-                        current_tool_call["arguments"] = ""
-                    else:
-                        logger.debug("Not enough token")
-                        return None
-
-            # case - we haven't sent the tool name yet. If it's available, send
-            #   it. otherwise, wait until it's available.
-            if not self.current_tool_name_sent:
-                if current_tool_call is None:
-                    return None
-                function_name: str | None = current_tool_call.get("name")
-                if function_name:
+                if not self.current_tool_name_sent:
                     self.current_tool_name_sent = True
-                    return DeltaMessage(
-                        tool_calls=[
-                            DeltaToolCall(
-                                index=self.current_tool_id,
-                                type="function",
-                                id=make_tool_call_id(),
-                                function=DeltaFunctionCall(
-                                    name=function_name
-                                ).model_dump(exclude_none=True),
-                            )
-                        ]
-                    )
-                else:
-                    return None
-
-            # case -- otherwise, send the tool call delta
-
-            # if the tool call portion is None, send the delta as text
-            if tool_call_portion is None:
-                # if there's text but not tool calls, send that -
-                # otherwise None to skip chunk
-                delta = (
-                    DeltaMessage(content=delta_text)
-                    if text_portion is not None
-                    else None
-                )
-                return delta
-
-            # now, the nitty-gritty of tool calls
-            # now we have the portion to parse as tool call.
-
-            logger.debug(
-                "Trying to parse current tool call with ID %s", self.current_tool_id
-            )
-
-            # if we're starting a new tool call, push an empty object in as
-            #   a placeholder for the arguments
-            if len(self.prev_tool_call_arr) <= self.current_tool_id:
-                self.prev_tool_call_arr.append({})
-
-            # main logic for tool parsing here - compare prev. partially-parsed
-            #   JSON to the current partially-parsed JSON
-            prev_arguments = self.prev_tool_call_arr[self.current_tool_id].get(
-                "arguments"
-            )
-            cur_arguments = current_tool_call.get("arguments")
-
-            logger.debug("diffing old arguments: %s", prev_arguments)
-            logger.debug("against new ones: %s", cur_arguments)
-
-            # case -- no arguments have been created yet. skip sending a delta.
-            if not cur_arguments and not prev_arguments:
-                logger.debug("Skipping text %s - no arguments", delta_text)
-                delta = None
-
-            # case -- prev arguments are defined, but non are now.
-            #   probably impossible, but not a fatal error - just keep going
-            elif not cur_arguments and prev_arguments:
-                logger.error(
-                    "should be impossible to have arguments reset "
-                    "mid-call. skipping streaming anything."
-                )
-                delta = None
-
-            # case -- we now have the first info about arguments available from
-            #   autocompleting the JSON
-            elif cur_arguments and not prev_arguments:
-                delta = DeltaMessage(
-                    tool_calls=[
+                    delta_tool_calls.append(
                         DeltaToolCall(
-                            index=self.current_tool_id,
+                            index=index,
+                            type="function",
+                            id=make_tool_call_id(),
                             function=DeltaFunctionCall(
-                                arguments=cur_arguments
+                                name=name, arguments=argument_diff
                             ).model_dump(exclude_none=True),
                         )
-                    ]
-                )
-                self.streamed_args_for_tool[self.current_tool_id] = cur_arguments
-
-            # last case -- we have an update to existing arguments.
-            elif cur_arguments and prev_arguments:
-                if (
-                    isinstance(delta_text, str)
-                    and cur_arguments != prev_arguments
-                    and len(cur_arguments) > len(prev_arguments)
-                    and cur_arguments.startswith(prev_arguments)
-                ):
-                    delta_arguments = cur_arguments[len(prev_arguments) :]
-                    logger.debug("got diff %s", delta_text)
-
-                    delta = DeltaMessage(
-                        tool_calls=[
-                            DeltaToolCall(
-                                index=self.current_tool_id,
-                                function=DeltaFunctionCall(
-                                    arguments=delta_arguments
-                                ).model_dump(exclude_none=True),
-                            )
-                        ]
                     )
-                    self.streamed_args_for_tool[self.current_tool_id] = cur_arguments
-                else:
-                    delta = None
+                elif argument_diff is not None:
+                    delta_tool_calls.append(
+                        DeltaToolCall(
+                            index=index,
+                            function=DeltaFunctionCall(
+                                arguments=argument_diff
+                            ).model_dump(exclude_none=True),
+                        )
+                    )
 
-            # handle saving the state for the current tool into
-            # the "prev" list for use in diffing for the next iteration
-            if self.current_tool_id == len(self.prev_tool_call_arr) - 1:
-                self.prev_tool_call_arr[self.current_tool_id] = current_tool_call
-            else:
-                self.prev_tool_call_arr.append(current_tool_call)
-
-            return delta
+            if delta_tool_calls:
+                return DeltaMessage(tool_calls=delta_tool_calls)
+            return None
 
         except Exception:
             logger.exception("Error trying to handle streaming tool call.")

--- a/vllm/tool_parsers/deepseekv3_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv3_tool_parser.py
@@ -122,6 +122,37 @@ class DeepSeekV3ToolParser(ToolParser):
                     tools_called=False, tool_calls=[], content=model_output
                 )
 
+    def _parse_stream_tool_calls(self, text: str) -> list[dict]:
+        """Parse every tool call in *text*, in order.
+
+        Returns one dict per ``tool_call_start_token`` found: complete
+        blocks and the trailing in-progress block alike. ``name`` is
+        ``None`` while the model has not finished emitting it.
+        """
+        calls: list[dict] = []
+        pos = 0
+        while True:
+            start = text.find(self.tool_call_start_token, pos)
+            if start == -1:
+                break
+            body_start = start + len(self.tool_call_start_token)
+            end = text.find(self.tool_call_end_token, body_start)
+            body = text[body_start:end] if end != -1 else text[body_start:]
+            portion = body.rstrip()
+            match = self.stream_tool_call_portion_regex.match(portion)
+            if match:
+                name = match.group("function_name")
+                arguments = match.group("function_arguments")
+            else:
+                name_match = self.stream_tool_call_name_regex.match(portion)
+                name = name_match.group("function_name") if name_match else None
+                arguments = ""
+            calls.append({"name": name, "arguments": arguments})
+            if end == -1:
+                break
+            pos = end + len(self.tool_call_end_token)
+        return calls
+
     def extract_tool_calls_streaming(
         self,
         previous_text: str,
@@ -132,263 +163,92 @@ class DeepSeekV3ToolParser(ToolParser):
         delta_token_ids: Sequence[int],
         request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
-        logger.debug("delta_text: %s", delta_text)
-        logger.debug("delta_token_ids: %s", delta_token_ids)
-        # check to see if we should be streaming a tool call - is there a
         if self.tool_calls_start_token_id not in current_token_ids:
-            logger.debug("No tool call tokens found!")
             return DeltaMessage(content=delta_text)
+
         delta_text = delta_text.replace(self.tool_calls_start_token, "").replace(
             self.tool_calls_end_token, ""
         )
         try:
-            # figure out where we are in the parsing by counting tool call
-            # start & end tags
-            prev_tool_start_count = previous_token_ids.count(
-                self.tool_call_start_token_id
-            )
             prev_tool_end_count = previous_token_ids.count(self.tool_call_end_token_id)
             cur_tool_start_count = current_token_ids.count(
                 self.tool_call_start_token_id
             )
             cur_tool_end_count = current_token_ids.count(self.tool_call_end_token_id)
-            tool_call_portion = None
-            text_portion = None
 
-            # case: if we're generating text, OR rounding out a tool call
+            # plain text: outside any tool call (before the first one starts,
+            # or after the last one has closed)
             if (
                 cur_tool_start_count == cur_tool_end_count
                 and prev_tool_end_count == cur_tool_end_count
                 and self.tool_call_end_token not in delta_text
             ):
-                logger.debug("Generating text content! skipping tool parsing.")
                 return DeltaMessage(content=delta_text)
 
-            if self.tool_call_end_token in delta_text:
-                logger.debug("tool_call_end_token in delta_text")
-                full_text = current_text + delta_text
-                tool_call_portion = (
-                    full_text.split(self.tool_call_start_token)[-1]
-                    .split(self.tool_call_end_token)[0]
-                    .rstrip()
-                )
-                delta_text = delta_text.split(self.tool_call_end_token)[0].rstrip()
-                text_portion = delta_text.split(self.tool_call_end_token)[-1].lstrip()
+            # Re-parse every tool call from the accumulated text and stream
+            # whatever has not been sent yet. Iterating all calls (instead of
+            # advancing one state per invocation) keeps parsing correct when a
+            # single delta carries one or more complete calls, e.g. from
+            # speculative decoding or the reasoning-end re-delivery of
+            # accumulated text.
+            delta_tool_calls: list[DeltaToolCall] = []
+            for index, call in enumerate(self._parse_stream_tool_calls(current_text)):
+                if index < self.current_tool_id:
+                    continue
+                if index > self.current_tool_id:
+                    self.current_tool_id = index
+                    self.current_tool_name_sent = False
+                while len(self.streamed_args_for_tool) <= index:
+                    self.streamed_args_for_tool.append("")
+                while len(self.prev_tool_call_arr) <= index:
+                    self.prev_tool_call_arr.append({})
 
-            # case -- we're starting a new tool call
-            if (
-                cur_tool_start_count > cur_tool_end_count
-                and cur_tool_start_count > prev_tool_start_count
-            ):
-                if len(delta_token_ids) > 1:
-                    tool_call_portion = current_text.split(self.tool_call_start_token)[
-                        -1
-                    ]
-                else:
-                    tool_call_portion = None
-                    delta = None
+                name = call["name"]
+                if name is None:
+                    # tool name is still being generated; nothing further can
+                    # be streamed for this or later calls
+                    break
+                arguments = call["arguments"]
 
-                text_portion = None
+                streamed = self.streamed_args_for_tool[index]
+                argument_diff = None
+                if (
+                    arguments
+                    and len(arguments) > len(streamed)
+                    and arguments.startswith(streamed)
+                ):
+                    argument_diff = arguments[len(streamed) :]
+                    self.streamed_args_for_tool[index] = arguments
+                self.prev_tool_call_arr[index] = {
+                    "name": name,
+                    "arguments": arguments,
+                }
 
-                # set cursors and state appropriately
-                self.current_tool_id += 1
-                self.current_tool_name_sent = False
-                self.streamed_args_for_tool.append("")
-                logger.debug("Starting on a new tool %s", self.current_tool_id)
-
-            # case -- we're updating an existing tool call
-            elif (
-                cur_tool_start_count > cur_tool_end_count
-                and cur_tool_start_count == prev_tool_start_count
-            ):
-                # get the portion of the text that's the tool call
-                tool_call_portion = current_text.split(self.tool_call_start_token)[-1]
-                text_portion = None
-
-            # case -- the current tool call is being closed.
-            elif (
-                cur_tool_start_count == cur_tool_end_count
-                and cur_tool_end_count >= prev_tool_end_count
-            ):
-                if self.prev_tool_call_arr is None or len(self.prev_tool_call_arr) == 0:
-                    logger.debug("attempting to close tool call, but no tool call")
-                    return None
-                diff = self.prev_tool_call_arr[self.current_tool_id].get("arguments")
-                if diff:
-                    diff = (
-                        diff.encode("utf-8").decode("unicode_escape")
-                        if diff is str
-                        else diff
-                    )
-                    if '"}' not in delta_text:
-                        return None
-                    end_loc = delta_text.rindex('"}')
-                    diff = delta_text[:end_loc] + '"}'
-                    logger.debug(
-                        "Finishing tool and found diff that had not "
-                        "been streamed yet: %s",
-                        diff,
-                    )
-                    self.streamed_args_for_tool[self.current_tool_id] += diff
-                    return DeltaMessage(
-                        tool_calls=[
-                            DeltaToolCall(
-                                index=self.current_tool_id,
-                                function=DeltaFunctionCall(arguments=diff).model_dump(
-                                    exclude_none=True
-                                ),
-                            )
-                        ]
-                    )
-
-            # case -- otherwise we're just generating text
-            else:
-                text = delta_text.replace(self.tool_call_start_token, "")
-                text = text.replace(self.tool_call_end_token, "")
-                delta = DeltaMessage(tool_calls=[], content=text)
-                return delta
-
-            current_tool_call = dict()
-            if tool_call_portion:
-                current_tool_call_matches = self.stream_tool_call_portion_regex.match(
-                    tool_call_portion
-                )
-                if current_tool_call_matches:
-                    tool_type, tool_name, tool_args = current_tool_call_matches.groups()
-                    current_tool_call["name"] = tool_name
-                    current_tool_call["arguments"] = tool_args
-                else:
-                    current_tool_call_name_matches = (
-                        self.stream_tool_call_name_regex.match(tool_call_portion)
-                    )
-                    if current_tool_call_name_matches:
-                        tool_type, tool_name = current_tool_call_name_matches.groups()
-                        current_tool_call["name"] = tool_name
-                        current_tool_call["arguments"] = ""
-                    else:
-                        logger.debug("Not enough token")
-                        return None
-
-            # case - we haven't sent the tool name yet. If it's available, send
-            #   it. otherwise, wait until it's available.
-            if not self.current_tool_name_sent:
-                if current_tool_call is None:
-                    return None
-                function_name: str | None = current_tool_call.get("name")
-                if function_name:
+                if not self.current_tool_name_sent:
                     self.current_tool_name_sent = True
-                    return DeltaMessage(
-                        tool_calls=[
-                            DeltaToolCall(
-                                index=self.current_tool_id,
-                                type="function",
-                                id=make_tool_call_id(),
-                                function=DeltaFunctionCall(
-                                    name=function_name
-                                ).model_dump(exclude_none=True),
-                            )
-                        ]
-                    )
-                else:
-                    return None
-
-            # case -- otherwise, send the tool call delta
-
-            # if the tool call portion is None, send the delta as text
-            if tool_call_portion is None:
-                # if there's text but not tool calls, send that -
-                # otherwise None to skip chunk
-                delta = (
-                    DeltaMessage(content=delta_text)
-                    if text_portion is not None
-                    else None
-                )
-                return delta
-
-            # now, the nitty-gritty of tool calls
-            # now we have the portion to parse as tool call.
-
-            logger.debug(
-                "Trying to parse current tool call with ID %s", self.current_tool_id
-            )
-
-            # if we're starting a new tool call, push an empty object in as
-            #   a placeholder for the arguments
-            if len(self.prev_tool_call_arr) <= self.current_tool_id:
-                self.prev_tool_call_arr.append({})
-
-            # main logic for tool parsing here - compare prev. partially-parsed
-            #   JSON to the current partially-parsed JSON
-            prev_arguments = self.prev_tool_call_arr[self.current_tool_id].get(
-                "arguments"
-            )
-            cur_arguments = current_tool_call.get("arguments")
-
-            logger.debug("diffing old arguments: %s", prev_arguments)
-            logger.debug("against new ones: %s", cur_arguments)
-
-            # case -- no arguments have been created yet. skip sending a delta.
-            if not cur_arguments and not prev_arguments:
-                logger.debug("Skipping text %s - no arguments", delta_text)
-                delta = None
-
-            # case -- prev arguments are defined, but non are now.
-            #   probably impossible, but not a fatal error - just keep going
-            elif not cur_arguments and prev_arguments:
-                logger.error(
-                    "should be impossible to have arguments reset "
-                    "mid-call. skipping streaming anything."
-                )
-                delta = None
-
-            # case -- we now have the first info about arguments available from
-            #   autocompleting the JSON
-            elif cur_arguments and not prev_arguments:
-                delta = DeltaMessage(
-                    tool_calls=[
+                    delta_tool_calls.append(
                         DeltaToolCall(
-                            index=self.current_tool_id,
+                            index=index,
+                            type="function",
+                            id=make_tool_call_id(),
                             function=DeltaFunctionCall(
-                                arguments=cur_arguments
+                                name=name, arguments=argument_diff
                             ).model_dump(exclude_none=True),
                         )
-                    ]
-                )
-                self.streamed_args_for_tool[self.current_tool_id] = cur_arguments
-
-            # last case -- we have an update to existing arguments.
-            elif cur_arguments and prev_arguments:
-                if (
-                    isinstance(delta_text, str)
-                    and cur_arguments != prev_arguments
-                    and len(cur_arguments) > len(prev_arguments)
-                    and cur_arguments.startswith(prev_arguments)
-                ):
-                    delta_arguments = cur_arguments[len(prev_arguments) :]
-                    logger.debug("got diff %s", delta_text)
-
-                    delta = DeltaMessage(
-                        tool_calls=[
-                            DeltaToolCall(
-                                index=self.current_tool_id,
-                                function=DeltaFunctionCall(
-                                    arguments=delta_arguments
-                                ).model_dump(exclude_none=True),
-                            )
-                        ]
                     )
-                    self.streamed_args_for_tool[self.current_tool_id] = cur_arguments
-                else:
-                    delta = None
+                elif argument_diff is not None:
+                    delta_tool_calls.append(
+                        DeltaToolCall(
+                            index=index,
+                            function=DeltaFunctionCall(
+                                arguments=argument_diff
+                            ).model_dump(exclude_none=True),
+                        )
+                    )
 
-            # handle saving the state for the current tool into
-            # the "prev" list for use in diffing for the next iteration
-            if self.current_tool_id == len(self.prev_tool_call_arr) - 1:
-                self.prev_tool_call_arr[self.current_tool_id] = current_tool_call
-            else:
-                self.prev_tool_call_arr.append(current_tool_call)
-
-            return delta
+            if delta_tool_calls:
+                return DeltaMessage(tool_calls=delta_tool_calls)
+            return None
 
         except Exception:
             logger.exception("Error trying to handle streaming tool call.")


### PR DESCRIPTION
## Purpose

When an entire tool call arrives in one streaming delta, the DeepSeek V3 and V3.1 tool parsers emit nothing — the call is silently lost. Their streaming state machines advance at most one state per invocation, gated on begin/end token counts: with a complete call in one delta, `start_count == end_count`, so the "starting a new tool" branch never fires (`current_tool_id` stays `-1`) and the closing branch bails at `len(self.prev_tool_call_arr) == 0`. Single-delta delivery is real in production: speculative decoding accepts multiple tokens per step (DeepSeek's MTP is a mainstream deployment), and the reasoning→tool transition re-delivers all accumulated text as one delta (`vllm/parser/abstract_parser.py:862`).

Rather than patching the count gates, this replaces the state machine with the reparse-and-drain shape used by the parsers that don't have this bug (`pythonic`, `hermes`): every invocation re-parses all tool-call blocks from the accumulated text — complete blocks and the trailing in-progress one — and streams whatever hasn't been sent yet for every call, however many arrived in this delta. Names are emitted once (with the first argument diff, if any); argument diffs keep the existing `streamed_args_for_tool` prefix accounting, so the finalize flush (`get_remaining_unstreamed_args`) stays consistent. Token-by-token behavior is unchanged: with small deltas the drain loop visits one call at a time, matching the old emission order. Net −209 lines per parser.

Same bug class as #47907, fixed for granite/gigachat3 in #47955; the DeepSeek parsers are not covered by any open PR.

## Test Plan

```bash
pytest tests/tool_parsers/test_deepseekv3_tool_parser.py tests/tool_parsers/test_deepseekv31_tool_parser.py
```

## Test Result

```
22 passed, 1 xfailed (xfail pre-existing)
```

New regression tests: single tool call in one delta and two parallel tool calls in one delta, for both parsers. A CPU harness comparing streaming reconstruction against non-streaming ground truth: before, all four single-delta cases streamed `[]`; after, all match, and incremental multi-chunk streaming matches ground truth (one pre-existing v3.1 quirk where a chunk boundary splits a marker mid-token is unchanged — impossible in production since markers are atomic special tokens, and the old code corrupted that case worse).

No open PR or issue covers this (searched deepseek tool parser/streaming; #48001/#47704/#47503 touch other aspects). Written with AI assistance; I reviewed every changed line and ran the tests above.
