### PR TITLE
Revert "[Perf] fuse more rmsnorm and all-reduce in qwen3.5" (#46998)

### DIFF
--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -844,14 +844,17 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
     def forward(
         self,
         hidden_states: torch.Tensor,
-    ) -> torch.Tensor:
-        return self._forward_method(hidden_states)
+        output: torch.Tensor,
+    ):
+        self._forward_method(hidden_states, output)
 
     def _output_projection(
         self,
         core_attn_out: torch.Tensor,
         z: torch.Tensor,
-    ) -> torch.Tensor:
+        output: torch.Tensor,
+        num_tokens: int,
+    ):
         """Part 3: RMSNormGated + output linear projection.
 
         The RMSNormGated + quant sequence is eligible for fusion
@@ -863,13 +866,13 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         core_attn_out = self.norm(core_attn_out, z)
         core_attn_out = core_attn_out.reshape(z_shape_og)
         core_attn_out = core_attn_out.flatten(-2)  # ... h d -> ... (h d)
-        output, _ = self.out_proj(core_attn_out)
-        return output
+        output[:num_tokens], _ = self.out_proj(core_attn_out)
 
     def forward_hip(
         self,
         hidden_states: torch.Tensor,
-    ) -> torch.Tensor:
+        output: torch.Tensor,
+    ):
         """ROCm forward using AITER Triton fused projection+attention when
         available, otherwise falling back to the generic CUDA path."""
         if GDN_AITER_TRITON_AVAILABLE:
@@ -898,14 +901,15 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 use_aiter=True,
             )
 
-            return self._output_projection(core_attn_out, z)
+            self._output_projection(core_attn_out, z, output, num_tokens)
         else:
-            return self.forward_cuda(hidden_states)
+            self.forward_cuda(hidden_states, output)
 
     def forward_cuda(
         self,
         hidden_states: torch.Tensor,
-    ) -> torch.Tensor:
+        output: torch.Tensor,
+    ):
         """
         Forward pass with three parts:
         1. Input projection
@@ -960,12 +964,13 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # ============================================================
         # Part 3: Output Projection
         # ============================================================
-        return self._output_projection(core_attn_out, z)
+        self._output_projection(core_attn_out, z, output, num_tokens)
 
     def forward_xpu(
         self,
         hidden_states: torch.Tensor,
-    ) -> torch.Tensor:
+        output: torch.Tensor,
+    ):
         """
         Forward pass with three parts:
         1. Input projection
@@ -1008,13 +1013,13 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         core_attn_out = self.norm(core_attn_out, z)
         core_attn_out = core_attn_out.reshape(z_shape_og)
         core_attn_out = core_attn_out.flatten(-2)  # ... h d -> ... (h d)
-        out, _ = self.out_proj(core_attn_out)
-        return out
+        output[:num_tokens], _ = self.out_proj(core_attn_out)
 
     def forward_cpu(
         self,
         hidden_states: torch.Tensor,
-    ) -> torch.Tensor:
+        output: torch.Tensor,
+    ):
         assert not hasattr(self, "in_proj_qkv"), "lora isn't supported on CPU."
 
         mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
@@ -1058,8 +1063,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         core_attn_out = self.norm(core_attn_out, z)
         core_attn_out = core_attn_out.reshape(z_shape_og)
         core_attn_out = core_attn_out.flatten(-2)  # ... h d -> ... (h d)
-        out, _ = self.out_proj(core_attn_out)
-        return out
+        output[:num_tokens], _ = self.out_proj(core_attn_out)
 
     def _warmup_prefill_kernels(self, qkv_or_qkvz: torch.Tensor, v_dim: int) -> None:
         """Warm up GDN prefill kernels during V1 profiling.

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -381,15 +381,15 @@ class Qwen3NextAttention(nn.Module):
     def forward(
         self,
         positions: torch.Tensor,
+        output: torch.Tensor,
         hidden_states: torch.Tensor,
-    ) -> torch.Tensor:
+    ):
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v, gate = self._project_qkv_gate(qkv, positions)
         attn_output = self.attn(q, k, v)
         if gate is not None:
             attn_output = attn_output * torch.sigmoid(gate)
-        output, _ = self.o_proj(attn_output)
-        return output
+        output[:], _ = self.o_proj(attn_output)
 
 
 class Qwen3NextDecoderLayer(nn.Module):
@@ -484,15 +484,21 @@ class Qwen3NextDecoderLayer(nn.Module):
         else:
             hidden_states, residual = self.input_layernorm(hidden_states, residual)
 
+        self_attention_output = torch.empty_like(hidden_states)
         if self.layer_type == "linear_attention":
-            hidden_states = self.linear_attn(hidden_states=hidden_states)
-        elif self.layer_type == "full_attention":
-            hidden_states = self.self_attn(
+            self.linear_attn(
                 hidden_states=hidden_states,
+                output=self_attention_output,
+            )
+        elif self.layer_type == "full_attention":
+            self.self_attn(
+                hidden_states=hidden_states,
+                output=self_attention_output,
                 positions=positions,
             )
         else:
             raise ValueError("Invalid layer_type")
+        hidden_states = self_attention_output
 
         if self.layer_scale:
             if len(hidden_states.shape) == 2:


### PR DESCRIPTION
## Revert of #46998

This reverts the merge commit 300e337 from PR https://github.com/vllm-project/vllm/pull/46998.

**Reason:** This PR is linked to 1 new CI failure in [build #77569](https://buildkite.com/vllm/ci/builds/77569):
- **Fusion E2E TP2 Quick (H100)** — `test_tp2_ar_rms` assertions fail expecting fusion counts that no longer match after rmsnorm fusion changes

The `test_tp2_ar_rms_fp8_fusions` and `test_tp2_ar_rms_fusions` tests fail with:
- `AssertionError: Expecting full rms+quant fusion where ar+rms+quant not activated`
- `AssertionError: Could not find 2 ar_rms_fusion (found 0)`

---
*Auto-generated by CI failure analyzer*