### PR TITLE
Revert "[XPU] Enable v1/sample tests on XPU CI" (#44472)

### DIFF
--- a/.buildkite/intel_jobs/misc_intel.yaml
+++ b/.buildkite/intel_jobs/misc_intel.yaml
@@ -72,7 +72,9 @@ steps:
       pytest -v -s v1/test_oracle.py &&
       pytest -v -s v1/test_request.py &&
       pytest -v -s v1/test_outputs.py &&
-      pytest -v -s v1/sample'
+      pytest -v -s v1/sample/test_topk_topp_sampler.py &&
+      pytest -v -s v1/sample/test_logprobs.py &&
+      pytest -v -s v1/sample/test_logprobs_e2e.py'
 
 - label: Basic Models Tests (Initialization)
   timeout_in_minutes: 60


### PR DESCRIPTION
## Revert of #44472

This reverts the merge commit 28eaf05 from PR https://github.com/vllm-project/vllm/pull/44472.

**Reason:** This PR is linked to 1 new CI failure in [build #77569](https://buildkite.com/vllm/ci/builds/77569):
- **XPU V1 test** — Job timed out mid-execution after additional tests were enabled in XPU CI

The job was terminated with `signal: terminated` while still running tests, indicating the added test scope exceeds the job's timeout limit.

---
*Auto-generated by CI failure analyzer*