### PR TITLE
[Bugfix] Complete FlashInfer CUTLASS MXFP4 MoE wiring for DeepSeek-family models

### DIFF
--- a/tests/kernels/moe/test_ocp_mx_moe.py
+++ b/tests/kernels/moe/test_ocp_mx_moe.py
@@ -37,6 +37,17 @@ HOPPER_MXFP4_BF16_AVAILABLE = (
     and has_flashinfer()
 )
 
+# FlashInfer CUTLASS MXFP4 with MXFP8 activations runs on both Blackwell
+# device-capability families (sm100 and sm120).
+CUTLASS_MXFP4_MXFP8_AVAILABLE = (
+    current_platform.is_cuda()
+    and (
+        current_platform.is_device_capability_family(100)
+        or current_platform.is_device_capability_family(120)
+    )
+    and has_flashinfer()
+)
+
 # ROCm platform and dependencies
 ROCM_AVAILABLE = current_platform.is_rocm()
 ROCM_TRITON_KERNELS_AVAILABLE = False
@@ -71,6 +82,9 @@ if TRTLLM_GEN_MXFP8_AVAILABLE:
         Fp8QuantizationType,
         get_w2_permute_indices_with_cache,
     )
+
+if CUTLASS_MXFP4_MXFP8_AVAILABLE and not TRTLLM_GEN_MXFP4_AVAILABLE:
+    from flashinfer import mxfp8_quantize
 
 
 @dataclass
@@ -829,12 +843,8 @@ def test_flashinfer_cutlass_mxfp4_fused_moe(
 @pytest.mark.parametrize("intermediate_size,hidden_size", [(3072, 3072)])
 @pytest.mark.parametrize("alpha,beta,limit", [(1.0, 1.0, None), (1.702, 1.0, 7.0)])
 @pytest.mark.skipif(
-    not (
-        current_platform.is_cuda()
-        and current_platform.is_device_capability_family(100)
-        and has_flashinfer()
-    ),
-    reason="NVIDIA GPU sm100 and flashinfer are required for this test",
+    not CUTLASS_MXFP4_MXFP8_AVAILABLE,
+    reason="NVIDIA GPU sm100/sm120 family and flashinfer are required",
 )
 def test_flashinfer_cutlass_mxfp4_mxfp8_fused_moe(
     topk: int,
@@ -1025,6 +1035,478 @@ def test_flashinfer_cutlass_mxfp4_mxfp8_fused_moe(
 
     # Allow some mismatch due to MXFP4 quantization
     check_accuracy(ref, out, atol=0, rtol=0.3, percent=0.8)
+
+
+@pytest.mark.parametrize("topk", [1, 4])
+@pytest.mark.parametrize("num_experts", [32])
+@pytest.mark.parametrize("num_tokens", [128])
+# Small but aligned sizes: K=512 > 128 exercises the multi-tile scale layout
+# while keeping the einsum-based torch reference's memory footprint small
+# (reference_moe materializes [tokens, topk, rows, K] float32 gathers, which
+# at 3072x3072 would peak above 50 GiB).
+@pytest.mark.parametrize("intermediate_size,hidden_size", [(512, 512)])
+@pytest.mark.parametrize("alpha,beta,limit", [(None, None, None), (1.702, 1.0, 7.0)])
+@pytest.mark.parametrize("with_bias", [False, True])
+@pytest.mark.skipif(
+    not CUTLASS_MXFP4_MXFP8_AVAILABLE,
+    reason="NVIDIA GPU sm100/sm120 family and flashinfer are required",
+)
+def test_flashinfer_cutlass_mxfp4_mxfp8_fused_moe_via_ds4_converter(
+    topk: int,
+    num_experts: int,
+    num_tokens: int,
+    intermediate_size: int,
+    hidden_size: int,
+    alpha: float | None,
+    beta: float | None,
+    limit: float | None,
+    with_bias: bool,
+):
+    """End-to-end numerical check of the contiguous-[w1; w3] (DeepSeek/GLM/
+    MiMo-family) converter path: checkpoint-layout packed FP4 weights and
+    linear e8m0 scales go through convert_weight_to_mxfp4_moe_kernel_format
+    and the FlashInfer CUTLASS kernel, and the result is compared against a
+    dequantized torch reference that never touches the FlashInfer helpers.
+
+    alpha/beta/limit all-None exercises standard SwiGLU (the DS4-family
+    configuration: no quant-config activation overrides); the gpt-oss values
+    exercise the clamped variant. with_bias covers the converter's
+    None-tolerant bias handling in both directions.
+    """
+    from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
+        Mxfp4MoeBackend,
+        convert_weight_to_mxfp4_moe_kernel_format,
+    )
+    from vllm.utils.flashinfer import flashinfer_cutlass_fused_moe
+
+    torch.manual_seed(42)
+    device = "cuda:0"
+
+    hidden_states = torch.randn(
+        num_tokens, hidden_size, device=device, dtype=torch.bfloat16
+    )
+    # Checkpoint layout: packed FP4 weights + linear (non-swizzled) e8m0
+    # scales, w13 rows contiguous [w1/gate; w3/up].
+    w13_q = torch.randint(
+        0,
+        256,
+        (num_experts, 2 * intermediate_size, hidden_size // 2),
+        device=device,
+        dtype=torch.uint8,
+    )
+    w13_scale = torch.randint(
+        118,
+        123,
+        (num_experts, 2 * intermediate_size, hidden_size // 32),
+        device=device,
+        dtype=torch.uint8,
+    )
+    w2_q = torch.randint(
+        0,
+        256,
+        (num_experts, hidden_size, intermediate_size // 2),
+        device=device,
+        dtype=torch.uint8,
+    )
+    w2_scale = torch.randint(
+        118,
+        123,
+        (num_experts, hidden_size, intermediate_size // 32),
+        device=device,
+        dtype=torch.uint8,
+    )
+    if with_bias:
+        bias13 = (
+            torch.randn(
+                num_experts, 2 * intermediate_size, device=device, dtype=torch.bfloat16
+            )
+            * 10
+        )
+        bias2 = (
+            torch.randn(num_experts, hidden_size, device=device, dtype=torch.bfloat16)
+            * 10
+        )
+    else:
+        bias13 = None
+        bias2 = None
+    router_logits = torch.rand(
+        num_tokens, num_experts, dtype=torch.float32, device=device
+    )
+
+    w13_ref = mxfp4_dequantize(w13_q.clone(), w13_scale.clone()).reshape(
+        num_experts, 2 * intermediate_size, hidden_size
+    )
+    w2_ref = mxfp4_dequantize(w2_q.clone(), w2_scale.clone()).reshape(
+        num_experts, hidden_size, intermediate_size
+    )
+    bias13_ref = (
+        bias13.to(torch.float32)
+        if bias13 is not None
+        else torch.zeros(
+            num_experts, 2 * intermediate_size, device=device, dtype=torch.float32
+        )
+    )
+    bias2_ref = (
+        bias2.to(torch.float32)
+        if bias2 is not None
+        else torch.zeros(num_experts, hidden_size, device=device, dtype=torch.float32)
+    )
+    # alpha/beta/limit None means standard SwiGLU: silu(gate) * up, which is
+    # the clamped reference with alpha=1, beta=0 and no limit.
+    ref = reference_moe(
+        router_logits.to(torch.float32),
+        topk,
+        num_experts,
+        hidden_states.to(torch.float32),
+        w13_ref,
+        bias13_ref,
+        w2_ref,
+        bias2_ref,
+        alpha if alpha is not None else 1.0,
+        beta if beta is not None else 0.0,
+        limit,
+        "mxfp8",
+        activation="swiglu",
+        use_interleaved_layout=False,
+    )
+
+    # The code under test: the production converter for this backend.
+    (conv_w13, conv_w2, conv_w13_scale, conv_w2_scale, conv_w13_bias, conv_w2_bias) = (
+        convert_weight_to_mxfp4_moe_kernel_format(
+            mxfp4_backend=Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
+            layer=torch.nn.Module(),
+            w13_weight=w13_q,
+            w2_weight=w2_q,
+            w13_weight_scale=w13_scale,
+            w2_weight_scale=w2_scale,
+            w13_bias=bias13,
+            w2_bias=bias2,
+        )
+    )
+    assert (conv_w13_bias is None) == (bias13 is None)
+    assert (conv_w2_bias is None) == (bias2 is None)
+
+    routing_weights = torch.nn.functional.softmax(
+        router_logits, dim=1, dtype=torch.float32
+    )
+    token_final_scales, token_selected_experts = torch.topk(
+        routing_weights, topk, dim=-1
+    )
+    token_final_scales = token_final_scales / token_final_scales.sum(
+        dim=-1, keepdim=True
+    )
+    token_selected_experts = token_selected_experts.to(torch.int).contiguous()
+
+    hidden_states_q, hidden_states_sf = mxfp8_quantize(hidden_states, True, 32)
+
+    def per_expert(value: float | None) -> torch.Tensor | None:
+        if value is None:
+            return None
+        return torch.full((num_experts,), value, device=device)
+
+    fake_input_scale = torch.ones(num_experts, device=device)
+    quant_scales = [
+        conv_w13_scale.view(torch.int32),
+        fake_input_scale,
+        conv_w2_scale.view(torch.int32),
+        fake_input_scale,
+    ]
+
+    out = torch.empty_like(hidden_states, dtype=torch.bfloat16)
+    _ = flashinfer_cutlass_fused_moe(
+        input=hidden_states_q,
+        token_selected_experts=token_selected_experts,
+        token_final_scales=token_final_scales,
+        fc1_expert_weights=conv_w13.contiguous().view(torch.long),
+        fc2_expert_weights=conv_w2.contiguous().view(torch.long),
+        output_dtype=torch.bfloat16,
+        output=out,
+        quant_scales=quant_scales,
+        fc1_expert_biases=conv_w13_bias,
+        fc2_expert_biases=conv_w2_bias,
+        swiglu_alpha=per_expert(alpha),
+        swiglu_beta=per_expert(beta),
+        swiglu_limit=per_expert(limit),
+        tp_size=1,
+        tp_rank=0,
+        ep_size=1,
+        ep_rank=0,
+        use_mxfp8_act_scaling=True,
+        input_sf=hidden_states_sf,
+    )
+
+    # Allow some mismatch due to MXFP4 quantization
+    check_accuracy(ref, out, atol=0, rtol=0.3, percent=0.8)
+
+
+@pytest.mark.parametrize("topk", [4])
+@pytest.mark.parametrize("num_experts", [32])
+@pytest.mark.parametrize("num_tokens", [128])
+# Small but aligned sizes; see the MXFP8 twin above for the rationale.
+@pytest.mark.parametrize("intermediate_size,hidden_size", [(512, 512)])
+@pytest.mark.parametrize("alpha,beta,limit", [(None, None, None), (1.702, 1.0, 7.0)])
+@pytest.mark.parametrize("with_bias", [False, True])
+@pytest.mark.skipif(
+    not HOPPER_MXFP4_BF16_AVAILABLE,
+    reason="nvidia gpu sm90 and flashinfer are required for this test",
+)
+def test_flashinfer_cutlass_mxfp4_bf16_fused_moe_via_ds4_converter(
+    topk: int,
+    num_experts: int,
+    num_tokens: int,
+    intermediate_size: int,
+    hidden_size: int,
+    alpha: float | None,
+    beta: float | None,
+    limit: float | None,
+    with_bias: bool,
+):
+    """BF16-activation twin of the DS4-converter test above (sm90 backend)."""
+    from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
+        Mxfp4MoeBackend,
+        convert_weight_to_mxfp4_moe_kernel_format,
+    )
+    from vllm.utils.flashinfer import flashinfer_cutlass_fused_moe
+
+    torch.manual_seed(42)
+    device = "cuda:0"
+
+    hidden_states = torch.randn(
+        num_tokens, hidden_size, device=device, dtype=torch.bfloat16
+    )
+    w13_q = torch.randint(
+        0,
+        256,
+        (num_experts, 2 * intermediate_size, hidden_size // 2),
+        device=device,
+        dtype=torch.uint8,
+    )
+    w13_scale = torch.randint(
+        118,
+        123,
+        (num_experts, 2 * intermediate_size, hidden_size // 32),
+        device=device,
+        dtype=torch.uint8,
+    )
+    w2_q = torch.randint(
+        0,
+        256,
+        (num_experts, hidden_size, intermediate_size // 2),
+        device=device,
+        dtype=torch.uint8,
+    )
+    w2_scale = torch.randint(
+        118,
+        123,
+        (num_experts, hidden_size, intermediate_size // 32),
+        device=device,
+        dtype=torch.uint8,
+    )
+    if with_bias:
+        bias13 = (
+            torch.randn(
+                num_experts, 2 * intermediate_size, device=device, dtype=torch.bfloat16
+            )
+            * 10
+        )
+        bias2 = (
+            torch.randn(num_experts, hidden_size, device=device, dtype=torch.bfloat16)
+            * 10
+        )
+    else:
+        bias13 = None
+        bias2 = None
+    router_logits = torch.rand(
+        num_tokens, num_experts, dtype=torch.float32, device=device
+    )
+
+    w13_ref = mxfp4_dequantize(w13_q.clone(), w13_scale.clone()).reshape(
+        num_experts, 2 * intermediate_size, hidden_size
+    )
+    w2_ref = mxfp4_dequantize(w2_q.clone(), w2_scale.clone()).reshape(
+        num_experts, hidden_size, intermediate_size
+    )
+    bias13_ref = (
+        bias13.to(torch.float32)
+        if bias13 is not None
+        else torch.zeros(
+            num_experts, 2 * intermediate_size, device=device, dtype=torch.float32
+        )
+    )
+    bias2_ref = (
+        bias2.to(torch.float32)
+        if bias2 is not None
+        else torch.zeros(num_experts, hidden_size, device=device, dtype=torch.float32)
+    )
+    ref = reference_moe(
+        router_logits.to(torch.float32),
+        topk,
+        num_experts,
+        hidden_states.to(torch.float32),
+        w13_ref,
+        bias13_ref,
+        w2_ref,
+        bias2_ref,
+        alpha if alpha is not None else 1.0,
+        beta if beta is not None else 0.0,
+        limit,
+        "bf16",
+        activation="swiglu",
+        use_interleaved_layout=False,
+    )
+
+    (conv_w13, conv_w2, conv_w13_scale, conv_w2_scale, conv_w13_bias, conv_w2_bias) = (
+        convert_weight_to_mxfp4_moe_kernel_format(
+            mxfp4_backend=Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
+            layer=torch.nn.Module(),
+            w13_weight=w13_q,
+            w2_weight=w2_q,
+            w13_weight_scale=w13_scale,
+            w2_weight_scale=w2_scale,
+            w13_bias=bias13,
+            w2_bias=bias2,
+        )
+    )
+
+    routing_weights = torch.nn.functional.softmax(
+        router_logits, dim=1, dtype=torch.float32
+    )
+    token_final_scales, token_selected_experts = torch.topk(
+        routing_weights, topk, dim=-1
+    )
+    token_final_scales = token_final_scales / token_final_scales.sum(
+        dim=-1, keepdim=True
+    )
+    token_selected_experts = token_selected_experts.to(torch.int).contiguous()
+
+    def per_expert(value: float | None) -> torch.Tensor | None:
+        if value is None:
+            return None
+        return torch.full((num_experts,), value, device=device)
+
+    out = torch.empty_like(hidden_states, dtype=torch.bfloat16)
+    _ = flashinfer_cutlass_fused_moe(
+        input=hidden_states,
+        token_selected_experts=token_selected_experts,
+        token_final_scales=token_final_scales,
+        fc1_expert_weights=conv_w13,
+        fc2_expert_weights=conv_w2,
+        output_dtype=torch.bfloat16,
+        output=out,
+        quant_scales=[conv_w13_scale.to(torch.uint8), conv_w2_scale.to(torch.uint8)],
+        fc1_expert_biases=conv_w13_bias,
+        fc2_expert_biases=conv_w2_bias,
+        swiglu_alpha=per_expert(alpha),
+        swiglu_beta=per_expert(beta),
+        swiglu_limit=per_expert(limit),
+        tp_size=1,
+        tp_rank=0,
+        ep_size=1,
+        ep_rank=0,
+        use_w4_group_scaling=True,
+    )
+
+    # Allow some mismatch due to MXFP4 quantization
+    check_accuracy(ref, out, atol=0, rtol=0.3, percent=0.8)
+
+
+def test_gpt_oss_quant_config_supplies_clamped_swiglu_params():
+    """GptOssMxfp4MoEMethod must keep supplying gpt-oss's clamped-SwiGLU
+    parameters through its quant config: FlashInferExperts no longer
+    hardcodes them, so losing these would silently change gpt-oss
+    numerics."""
+    from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import Mxfp4MoeBackend
+    from vllm.model_executor.layers.quantization.mxfp4 import GptOssMxfp4MoEMethod
+
+    fake_method = types.SimpleNamespace(
+        mxfp4_backend=Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
+        w13_precision_config=None,
+        w2_precision_config=None,
+    )
+    fake_layer = types.SimpleNamespace(
+        w13_weight_scale=torch.zeros(2, 4, 2, dtype=torch.uint8),
+        w2_weight_scale=torch.zeros(2, 4, 2, dtype=torch.uint8),
+    )
+    quant_config = GptOssMxfp4MoEMethod.get_fused_moe_quant_config(
+        fake_method, fake_layer
+    )
+    assert quant_config is not None
+    assert quant_config.gemm1_alpha == 1.702
+    assert quant_config.gemm1_beta == 1.0
+    assert quant_config.gemm1_clamp_limit == 7.0
+
+
+@pytest.mark.skipif(
+    not (current_platform.is_cuda() and has_flashinfer()),
+    reason="CUDA and flashinfer are required for FlashInferExperts",
+)
+@pytest.mark.parametrize("supplied", [False, True])
+def test_flashinfer_experts_swiglu_params_follow_quant_config(supplied: bool):
+    """FlashInferExperts honors quant-config-supplied gemm1 SwiGLU
+    parameters and leaves all three None (standard SwiGLU) when the quant
+    config supplies none — there are no model-specific defaults."""
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+    from vllm.model_executor.layers.fused_moe.config import (
+        FusedMoEConfig,
+        FusedMoEParallelConfig,
+        RoutingMethodType,
+        mxfp4_w4a16_moe_quant_config,
+    )
+    from vllm.model_executor.layers.fused_moe.experts.flashinfer_cutlass_moe import (
+        FlashInferExperts,
+    )
+
+    num_experts, intermediate_size, hidden_size = 2, 128, 256
+    w1_scale = torch.zeros(
+        (num_experts, 2 * intermediate_size, hidden_size // 32),
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    w2_scale = torch.zeros(
+        (num_experts, hidden_size, intermediate_size // 32),
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    extra = (
+        {"gemm1_alpha": 0.5, "gemm1_beta": 0.25, "gemm1_clamp_limit": 3.0}
+        if supplied
+        else {}
+    )
+    quant_config = mxfp4_w4a16_moe_quant_config(
+        w1_scale=w1_scale, w2_scale=w2_scale, **extra
+    )
+    moe_config = FusedMoEConfig(
+        num_experts=num_experts,
+        experts_per_token=1,
+        hidden_dim=hidden_size,
+        intermediate_size=intermediate_size,
+        num_local_experts=num_experts,
+        num_logical_experts=num_experts,
+        activation=MoEActivation.SILU,
+        device="cuda",
+        routing_method=RoutingMethodType.TopK,
+        moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
+        in_dtype=torch.bfloat16,
+    )
+    experts = FlashInferExperts(moe_config=moe_config, quant_config=quant_config)
+
+    if supplied:
+        for name, value in (
+            ("gemm1_alpha", 0.5),
+            ("gemm1_beta", 0.25),
+            ("gemm1_clamp_limit", 3.0),
+        ):
+            param = getattr(experts, name)
+            assert isinstance(param, torch.Tensor), f"{name} should be a tensor"
+            assert param.dtype == torch.float32
+            assert param.shape == (num_experts,)
+            assert torch.equal(
+                param.cpu(), torch.full((num_experts,), value, dtype=torch.float32)
+            ), f"{name} != {value}"
+    else:
+        assert experts.gemm1_alpha is None
+        assert experts.gemm1_beta is None
+        assert experts.gemm1_clamp_limit is None
 
 
 @pytest.mark.parametrize("topk", [1, 4])

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -93,7 +93,24 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
         # - pass per-block weight scales to the kernel
         # - skip input activation quantization (kernel applies scaling)
         self.use_deepseek_fp8_block_scale = quant_config.is_block_quantized
+        # gpt-oss supplies its clamped-SwiGLU parameters (alpha=1.702,
+        # beta=1.0, clamp=7.0) via its quant config (GptOssMxfp4MoEMethod);
+        # None means standard SwiGLU.
+        self.gemm1_alpha: torch.Tensor | None = None
+        self.gemm1_beta: torch.Tensor | None = None
         self.gemm1_clamp_limit: torch.Tensor | None = None
+        if quant_config.gemm1_alpha is not None:
+            self.gemm1_alpha = torch.tensor(
+                [quant_config.gemm1_alpha] * self.num_experts,
+                dtype=torch.float32,
+                device=self.device,
+            )
+        if quant_config.gemm1_beta is not None:
+            self.gemm1_beta = torch.tensor(
+                [quant_config.gemm1_beta] * self.num_experts,
+                dtype=torch.float32,
+                device=self.device,
+            )
         if quant_config.gemm1_clamp_limit is not None:
             self.gemm1_clamp_limit = torch.tensor(
                 [quant_config.gemm1_clamp_limit] * self.num_experts,
@@ -101,27 +118,15 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
                 device=self.device,
             )
 
-        if quant_config.weight_quant_dtype == "mxfp4":
-            # This value is used specifically for gpt-oss,
-            # Need to revisit this for other models
-            self.gemm1_alpha = torch.tensor(
-                [1.702] * self.num_experts, dtype=torch.float32, device=self.device
+        if (
+            quant_config.weight_quant_dtype == "mxfp4"
+            and quant_config.quant_dtype == "mxfp8"
+        ):
+            self.fake_input_scale = torch.ones(
+                self.num_experts,
+                device=self.device,
+                dtype=torch.float32,
             )
-            self.gemm1_beta = torch.tensor(
-                [1.0] * self.num_experts, dtype=torch.float32, device=self.device
-            )
-            if self.gemm1_clamp_limit is None:
-                self.gemm1_clamp_limit = torch.tensor(
-                    [7.0] * self.num_experts,
-                    dtype=torch.float32,
-                    device=self.device,
-                )
-            if quant_config.quant_dtype == "mxfp8":
-                self.fake_input_scale = torch.ones(
-                    self.num_experts,
-                    device=self.device,
-                    dtype=torch.float32,
-                )
 
     @property
     def expects_unquantized_inputs(self) -> bool:
@@ -324,9 +329,6 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
         elif self.weight_quant_dtype == "mxfp4":
             assert self.w1_scale is not None and self.w2_scale is not None
             assert w1.is_contiguous() and w2.is_contiguous()
-            assert self.gemm1_alpha is not None
-            assert self.gemm1_beta is not None
-            assert self.gemm1_clamp_limit is not None
             assert topk_ids.is_contiguous()
 
             fc1_expert_biases = self.w1_bias

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -664,6 +664,77 @@ def mxfp4_round_up_hidden_size_and_intermediate_size(
     return hidden_size, intermediate_size
 
 
+def _swapped_weights_to_flashinfer_cutlass_kernel_format(
+    mxfp4_backend: Mxfp4MoeBackend,
+    w13_weight_swapped: torch.Tensor,
+    w2_weight: torch.Tensor,
+    w13_scale_swapped: torch.Tensor,
+    w2_weight_scale: torch.Tensor,
+    w13_bias_swapped: torch.Tensor | None,
+    w2_bias: torch.Tensor | None,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor | None,
+    torch.Tensor | None,
+]:
+    """Interleave [w3, w1]-ordered tensors into FlashInfer CUTLASS kernel
+    format: block-scale interleave for the MXFP8-activation backend, sm90
+    mixed-gemm interleaves for the BF16-activation backend."""
+    if mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8:
+        from flashinfer import block_scale_interleave
+
+        orig_shape = w13_scale_swapped.shape
+        w13_scale_interleaved = block_scale_interleave(
+            w13_scale_swapped.view(torch.uint8)
+        ).reshape(orig_shape)
+
+        orig_shape = w2_weight_scale.shape
+        w2_scale_interleaved = block_scale_interleave(
+            w2_weight_scale.view(torch.uint8)
+        ).reshape(orig_shape)
+
+        return (
+            w13_weight_swapped,
+            w2_weight,
+            w13_scale_interleaved,
+            w2_scale_interleaved,
+            w13_bias_swapped,
+            w2_bias,
+        )
+
+    assert mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16
+
+    from flashinfer.fused_moe import (
+        interleave_moe_scales_for_sm90_mixed_gemm,
+        interleave_moe_weights_for_sm90_mixed_gemm,
+    )
+
+    w13_weight_interleaved = interleave_moe_weights_for_sm90_mixed_gemm(
+        w13_weight_swapped.contiguous(), "fp4"
+    )
+    w2_weight_interleaved = interleave_moe_weights_for_sm90_mixed_gemm(
+        w2_weight.contiguous(), "fp4"
+    )
+    w31_scales_interleaved = interleave_moe_scales_for_sm90_mixed_gemm(
+        w13_scale_swapped.to(torch.uint8)
+    )
+    w2_scale_interleaved = interleave_moe_scales_for_sm90_mixed_gemm(
+        w2_weight_scale.to(torch.uint8)
+    )
+
+    return (
+        w13_weight_interleaved,
+        w2_weight_interleaved,
+        w31_scales_interleaved,
+        w2_scale_interleaved,
+        w13_bias_swapped,
+        w2_bias,
+    )
+
+
 def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
     mxfp4_backend: Mxfp4MoeBackend,
     layer: torch.nn.Module,
@@ -908,58 +979,15 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
         s1, s3 = torch.chunk(deinterleaved_w13_s, 2, dim=1)
         w13_scale_swapped = torch.cat([s3, s1], dim=1)
 
-        if mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8:
-            from flashinfer import block_scale_interleave
-
-            orig_shape = w13_scale_swapped.shape
-            w13_scale_interleaved = block_scale_interleave(
-                w13_scale_swapped.view(torch.uint8)
-            ).reshape(orig_shape)
-
-            w2_s = w2_weight_scale.data
-            orig_shape = w2_s.shape
-            w2_scale_interleaved = block_scale_interleave(
-                w2_s.view(torch.uint8)
-            ).reshape(orig_shape)
-
-            return (
-                w13_weight_swapped,
-                w2_weight,
-                w13_scale_interleaved,
-                w2_scale_interleaved,
-                w13_bias_swapped,
-                w2_bias,
-            )
-
-        else:
-            assert mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16
-
-            from flashinfer.fused_moe import (
-                interleave_moe_scales_for_sm90_mixed_gemm,
-                interleave_moe_weights_for_sm90_mixed_gemm,
-            )
-
-            w13_weight_interleaved = interleave_moe_weights_for_sm90_mixed_gemm(
-                w13_weight_swapped.contiguous(), "fp4"
-            )
-            w2_weight_interleaved = interleave_moe_weights_for_sm90_mixed_gemm(
-                w2_weight.contiguous(), "fp4"
-            )
-            w31_scales_interleaved = interleave_moe_scales_for_sm90_mixed_gemm(
-                w13_scale_swapped.to(torch.uint8)
-            )
-            w2_scale_interleaved = interleave_moe_scales_for_sm90_mixed_gemm(
-                w2_weight_scale.data.to(torch.uint8)
-            )
-
-            return (
-                w13_weight_interleaved,
-                w2_weight_interleaved,
-                w31_scales_interleaved,
-                w2_scale_interleaved,
-                w13_bias_swapped,
-                w2_bias,
-            )
+        return _swapped_weights_to_flashinfer_cutlass_kernel_format(
+            mxfp4_backend,
+            w13_weight_swapped,
+            w2_weight,
+            w13_scale_swapped,
+            w2_weight_scale.data,
+            w13_bias_swapped,
+            w2_bias,
+        )
 
     elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_MXFP4:
         from vllm._aiter_ops import rocm_aiter_ops
@@ -1257,7 +1285,8 @@ def convert_weight_to_mxfp4_moe_kernel_format(
 ]:
     """Convert loaded weights into backend-specific kernel format.
 
-    Supports DeepGEMM, TRTLLM MXFP8, Triton and Marlin backends.
+    Supports DeepGEMM, TRTLLM MXFP8, FlashInfer CUTLASS, Triton and Marlin
+    backends.
     """
 
     if mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MXFP4:
@@ -1485,6 +1514,47 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             shuffled_w13_scale,
             shuffled_w2_scale,
             w13_bias,
+            w2_bias,
+        )
+
+    elif mxfp4_backend in (
+        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
+        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
+    ):
+        # Native GLM/DeepSeek/MiMo MXFP4 loading produces contiguous
+        # [w1/gate, w3/up] rows. FlashInfer Cutlass consumes the opposite
+        # SwiGLU order, so swap the two halves without GPT-OSS de-interleave.
+        logger.info_once(
+            "Using contiguous w13 layout for FlashInfer Cutlass MXFP4 MoE."
+        )
+        intermediate_size = w13_weight.shape[1] // 2
+        w13_w = w13_weight.data
+        w1_w = w13_w[:, :intermediate_size, :]
+        w3_w = w13_w[:, intermediate_size:, :]
+        w13_weight_swapped = torch.cat([w3_w, w1_w], dim=1)
+
+        if w13_bias is not None:
+            w13_bias = w13_bias.data.to(torch.float32)
+            b1 = w13_bias[:, :intermediate_size]
+            b3 = w13_bias[:, intermediate_size:]
+            w13_bias_swapped = torch.cat([b3, b1], dim=-1).to(torch.bfloat16)
+        else:
+            w13_bias_swapped = None
+        if w2_bias is not None:
+            w2_bias = w2_bias.data.to(torch.float32).to(torch.bfloat16)
+
+        w13_s = w13_weight_scale.data
+        s1 = w13_s[:, :intermediate_size, :]
+        s3 = w13_s[:, intermediate_size:, :]
+        w13_scale_swapped = torch.cat([s3, s1], dim=1)
+
+        return _swapped_weights_to_flashinfer_cutlass_kernel_format(
+            mxfp4_backend,
+            w13_weight_swapped,
+            w2_weight.data,
+            w13_scale_swapped,
+            w2_weight_scale.data,
+            w13_bias_swapped,
             w2_bias,
         )
 


### PR DESCRIPTION
## Purpose

`moe_backend=flashinfer_cutlass` is accepted for DeepSeek-family MXFP4 models, but their weight converter has no FlashInfer CUTLASS branch, so initialization fails with `Unsupported mxfp4_backend`.

This change:

- converts contiguous `[w1, w3]` checkpoint rows to FlashInfer's `[w3, w1]` layout for weights, scales, and optional biases;
- shares the remaining CUTLASS formatting with the existing gpt-oss converter; and
- removes gpt-oss-specific SwiGLU constants from `FlashInferExperts` and uses values supplied by the quantization config. The gpt-oss config supplies the existing `1.702`, `1.0`, and `7.0` values.

The non-gpt-oss backend priority list does not select FlashInfer CUTLASS automatically, so this path changes only when it is requested explicitly.

## Duplicate check

Open-PR searches found no other focused fix. #41834 carries this change within a broad SM12x enablement branch; this PR isolates the converter and activation-parameter changes on main.

## Tests

`pytest tests/kernels/moe/test_ocp_mx_moe.py -k "via_ds4_converter or gpt_oss_quant_config or flashinfer_experts_swiglu or cutlass_mxfp4_mxfp8_fused_moe"`: 19 passed, 4 skipped on SM120. The skipped cases require SM90.

Full-weight TP=2 startup selected `FLASHINFER_CUTLASS_MXFP4_MXFP8` with zero restarts.

## Model evaluation

Both arms of the matched serving A/B passed eight sequential and C8 semantic-correctness prompts.

Created with AI assistance.
