### PR TITLE
[Bugfix] Honor DeepSeek V4 checkpoints' MTP-layer compress_ratio entry (unscaled draft rope)

### DIFF
--- a/tests/models/test_deepseek_v4_rope.py
+++ b/tests/models/test_deepseek_v4_rope.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for DeepSeek V4 per-layer rope selection.
+
+Covers the MTP draft layer's compress_ratios handling: checkpoints that
+include their draft layer in compress_ratios with an entry of 0 get an
+uncompressed-KV, plain-rope draft; the operational compress ratio is never
+0 (KV-cache specs treat 1 as "no compression" and divide by the ratio).
+"""
+
+import types
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.rotary_embedding import _ROPE_DICT, RotaryEmbedding
+from vllm.model_executor.layers.rotary_embedding.deepseek_scaling_rope import (
+    DeepseekScalingRotaryEmbedding,
+    DeepseekV4ScalingRotaryEmbedding,
+)
+from vllm.models.deepseek_v4.attention import resolve_layer_compress_ratio
+from vllm.models.deepseek_v4.common.rope import build_deepseek_v4_rope
+
+NUM_HIDDEN_LAYERS = 4
+
+
+@pytest.fixture(autouse=True)
+def _clear_rope_cache():
+    _ROPE_DICT.clear()
+    yield
+    _ROPE_DICT.clear()
+
+
+def _config(compress_ratios: list[int]) -> types.SimpleNamespace:
+    return types.SimpleNamespace(
+        num_hidden_layers=NUM_HIDDEN_LAYERS,
+        compress_ratios=compress_ratios,
+        rope_theta=10000.0,
+        compress_rope_theta=1000000.0,
+        max_position_embeddings=4096,
+        rope_parameters={
+            "rope_type": "yarn",
+            "factor": 8.0,
+            "original_max_position_embeddings": 512,
+            "beta_fast": 32,
+            "beta_slow": 1,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "compress_ratios,layer_id,expected_ratio,expected_unscaled",
+    [
+        # Main layers: clamped, never unscaled (unchanged upstream behavior).
+        ([1, 4, 4, 1], 0, 1, False),
+        ([1, 4, 4, 1], 1, 4, False),
+        ([0, 4, 4, 1], 0, 1, False),
+        # Draft layer present in the list with 0: operational ratio 1,
+        # unscaled rope selected.
+        ([1, 4, 4, 1, 0], NUM_HIDDEN_LAYERS, 1, True),
+        # Draft layer present with an explicit nonzero entry: honored.
+        ([1, 4, 4, 1, 4], NUM_HIDDEN_LAYERS, 4, False),
+        # Draft layer absent from the list: legacy fallback (ratio 1, yarn).
+        ([1, 4, 4, 1], NUM_HIDDEN_LAYERS, 1, False),
+        ([1, 4, 4, 1], NUM_HIDDEN_LAYERS + 1, 1, False),
+    ],
+)
+def test_resolve_layer_compress_ratio(
+    compress_ratios: list[int],
+    layer_id: int,
+    expected_ratio: int,
+    expected_unscaled: bool,
+):
+    ratio, unscaled = resolve_layer_compress_ratio(_config(compress_ratios), layer_id)
+    assert ratio == expected_ratio
+    assert unscaled == expected_unscaled
+    # The operational ratio is an invariant: never below 1.
+    assert ratio >= 1
+
+
+def test_unscaled_rope_selects_plain_rotary_embedding(default_vllm_config):
+    config = _config([1, 4, 4, 1, 0])
+    rope = build_deepseek_v4_rope(
+        config,
+        head_dim=64,
+        rope_head_dim=64,
+        max_position_embeddings=config.max_position_embeddings,
+        compress_ratio=1,
+        use_unscaled_rope=True,
+    )
+    assert type(rope) is RotaryEmbedding
+    assert not isinstance(rope, DeepseekScalingRotaryEmbedding)
+
+
+def test_scaled_rope_unchanged_without_flag(default_vllm_config):
+    config = _config([1, 4, 4, 1])
+    rope = build_deepseek_v4_rope(
+        config,
+        head_dim=64,
+        rope_head_dim=64,
+        max_position_embeddings=config.max_position_embeddings,
+        compress_ratio=1,
+    )
+    # The V4 subclass specifically: losing is_deepseek_v4 would silently
+    # downgrade to the base deepseek-yarn implementation.
+    assert isinstance(rope, DeepseekV4ScalingRotaryEmbedding)
+
+
+def test_attention_init_wires_the_resolver():
+    # Guards the production wiring: the resolver and rope builder are unit
+    # tested above, but a refactor that reverts DeepseekV4Attention.__init__
+    # to inline forced-ratio logic (leaving the helper unused) must fail.
+    from vllm.models.deepseek_v4.attention import DeepseekV4Attention
+
+    assert (
+        "resolve_layer_compress_ratio" in DeepseekV4Attention.__init__.__code__.co_names
+    )
+
+
+def test_rope_parameters_dict_not_mutated(default_vllm_config):
+    config = _config([1, 4, 4, 1, 0])
+    snapshot = dict(config.rope_parameters)
+    for compress_ratio, use_unscaled in ((1, True), (1, False), (4, False)):
+        build_deepseek_v4_rope(
+            config,
+            head_dim=64,
+            rope_head_dim=64,
+            max_position_embeddings=config.max_position_embeddings,
+            compress_ratio=compress_ratio,
+            use_unscaled_rope=use_unscaled,
+        )
+        assert config.rope_parameters == snapshot
+
+
+def test_default_rope_cos_sin_cache_is_fp32_under_bf16_default(default_vllm_config):
+    config = _config([1, 4, 4, 1, 0])
+    old_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(torch.bfloat16)
+    try:
+        rope = build_deepseek_v4_rope(
+            config,
+            head_dim=64,
+            rope_head_dim=64,
+            max_position_embeddings=config.max_position_embeddings,
+            compress_ratio=1,
+            use_unscaled_rope=True,
+        )
+    finally:
+        torch.set_default_dtype(old_dtype)
+    assert rope.cos_sin_cache.dtype == torch.float32

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -98,6 +98,25 @@ def _resolve_dsv4_kv_cache_dtype(
     return kv_cache_dtype, torch.bfloat16
 
 
+def resolve_layer_compress_ratio(config, layer_id: int) -> tuple[int, bool]:
+    """Resolve (operational_compress_ratio, use_unscaled_rope) for a layer.
+
+    NOTE(zyongye) Compress ratio can't be 0; historically every layer_id >=
+    num_hidden_layers (the MTP draft layer) was mapped to 1 because "MTP layer
+    is not included in the compress ratio list". Some checkpoints DO include
+    their MTP draft layer in compress_ratios, with an entry of 0 meaning
+    uncompressed KV and plain (unscaled) rope. The operational ratio stays
+    clamped to >= 1 (KV-cache specs treat 1 as "no compression" and divide by
+    it); a raw 0 only selects unscaled rope for that layer.
+    """
+    if layer_id < config.num_hidden_layers:
+        return max(1, config.compress_ratios[layer_id]), False
+    if layer_id < len(config.compress_ratios):
+        raw_compress_ratio = config.compress_ratios[layer_id]
+        return max(1, raw_compress_ratio), raw_compress_ratio == 0
+    return 1, False
+
+
 class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
     """DeepseekV4 MLA attention layer.
 
@@ -181,13 +200,9 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         self.n_groups = config.o_groups
         self.n_local_groups = self.n_groups // tp_size
         self.window_size = config.sliding_window
-        # NOTE(zyongye) Compress ratio can't be 0
-        # we do this for because MTP layer is not included
-        # in the compress ratio list
-        if layer_id < config.num_hidden_layers:
-            self.compress_ratio = max(1, config.compress_ratios[layer_id])
-        else:
-            self.compress_ratio = 1
+        self.compress_ratio, use_unscaled_rope = resolve_layer_compress_ratio(
+            config, layer_id
+        )
         self.eps = config.rms_norm_eps
         self.scale = self.head_dim**-0.5
 
@@ -245,6 +260,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
             rope_head_dim=self.rope_head_dim,
             max_position_embeddings=config.max_position_embeddings,
             compress_ratio=self.compress_ratio,
+            use_unscaled_rope=use_unscaled_rope,
         )
         self.indexer_rotary_emb = self.rotary_emb
         self.topk_indices_buffer = topk_indices_buffer

--- a/vllm/models/deepseek_v4/common/rope.py
+++ b/vllm/models/deepseek_v4/common/rope.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """DeepseekV4 rotary embedding initialization."""
 
+import torch
+
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.rotary_embedding.base import RotaryEmbedding
 
@@ -13,11 +15,17 @@ def build_deepseek_v4_rope(
     rope_head_dim: int,
     max_position_embeddings: int,
     compress_ratio: int,
+    use_unscaled_rope: bool = False,
 ) -> RotaryEmbedding:
-    rope_parameters = config.rope_parameters
+    # Copy so per-layer overrides cannot leak into the shared hf_config dict.
+    rope_parameters = dict(config.rope_parameters)
     rope_parameters["rope_theta"] = (
         config.compress_rope_theta if compress_ratio > 1 else config.rope_theta
     )
+    if use_unscaled_rope:
+        # The MTP draft layer of DSpark-style checkpoints (compress_ratios
+        # entry 0) is trained with plain rope, not the yarn-scaled variant.
+        rope_parameters["rope_type"] = "default"
     if rope_parameters["rope_type"] != "default":
         rope_parameters["rope_type"] = (
             "deepseek_yarn"
@@ -33,4 +41,8 @@ def build_deepseek_v4_rope(
         max_position=max_position_embeddings,
         rope_parameters=rope_parameters,
         is_neox_style=False,
+        # DeepSeek V4 kernels consume the cached cos/sin table directly and
+        # require FP32 even when the draft/MTP model is initialized under a
+        # lower default dtype.
+        dtype=torch.float32,
     )


### PR DESCRIPTION
## Purpose

The released DeepSeek-V4-Flash-DSpark config has `num_hidden_layers=43` and additional `compress_ratios` entries, including zero-valued draft entries. `DeepseekV4Attention` currently ignores every entry at `layer_id >= num_hidden_layers` and uses ratio 1 with YaRN rope.

This change honors an in-range draft entry, clamps its operational cache ratio to at least 1, and uses a zero entry to select default rope. Draft layers beyond the list retain the existing ratio-1/YaRN fallback.

It also copies `rope_parameters` before per-layer updates and requests an FP32 rope cache; DeepSeek V4 kernels read that cache directly as FP32.

## Duplicate check

#41834 carries this change within a broad SM12x enablement branch. This PR isolates the three DeepSeek V4 source files and focused tests on main.

## Tests

`pytest tests/models/test_deepseek_v4_rope.py`: 12 passed in the SM120 serving image. The tests are CPU-only.

## Model evaluation

In a matched TP=2 DSpark MTP:2 serving A/B, mean draft acceptance changed from 57% to 69%, and position-2 acceptance changed from 0.275 to 0.50. Rope selection and the FP32 cache change were tested together.

Created with AI assistance.
