### PR TITLE
[Doc] Add --dtype float16 to GGUF documentation examples

### DIFF
--- a/docs/features/quantization/gguf.md
+++ b/docs/features/quantization/gguf.md
@@ -16,7 +16,7 @@ To run a GGUF model with vLLM, you can use the `repo_id:quant_type` format to lo
 
 ```bash
 # We recommend using the tokenizer from base model to avoid long-time and buggy tokenizer conversion.
-vllm serve unsloth/Qwen3-0.6B-GGUF:Q4_K_M --tokenizer Qwen/Qwen3-0.6B
+vllm serve unsloth/Qwen3-0.6B-GGUF:Q4_K_M --tokenizer Qwen/Qwen3-0.6B --dtype float16
 ```
 
 You can also add `--tensor-parallel-size 2` to enable tensor parallelism inference with 2 GPUs:
@@ -24,6 +24,7 @@ You can also add `--tensor-parallel-size 2` to enable tensor parallelism inferen
 ```bash
 vllm serve unsloth/Qwen3-0.6B-GGUF:Q4_K_M \
    --tokenizer Qwen/Qwen3-0.6B \
+   --dtype float16 \
    --tensor-parallel-size 2
 ```
 
@@ -31,7 +32,7 @@ Alternatively, you can download and use a local GGUF file:
 
 ```bash
 wget https://huggingface.co/unsloth/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q4_K_M.gguf
-vllm serve ./Qwen3-0.6B-Q4_K_M.gguf --tokenizer Qwen/Qwen3-0.6B
+vllm serve ./Qwen3-0.6B-Q4_K_M.gguf --tokenizer Qwen/Qwen3-0.6B --dtype float16
 ```
 
 !!! warning
@@ -43,6 +44,7 @@ GGUF assumes that HuggingFace can convert the metadata to a config file. In case
 # If your model is not supported by HuggingFace you can manually provide a HuggingFace compatible config path
 vllm serve unsloth/Qwen3-0.6B-GGUF:Q4_K_M \
    --tokenizer Qwen/Qwen3-0.6B \
+   --dtype float16 \
    --hf-config-path Qwen/Qwen3-0.6B
 ```
 
@@ -80,6 +82,7 @@ You can also use the GGUF model directly through the LLM entrypoint:
       llm = LLM(
          model="unsloth/Qwen3-0.6B-GGUF:Q4_K_M",
          tokenizer="Qwen/Qwen3-0.6B",
+         dtype="float16",
       )
       # Generate texts from the prompts. The output is a list of RequestOutput objects
       # that contain the prompt, generated text, and other information.


### PR DESCRIPTION
## Description

Without `--dtype float16`, GGUF model serving fails with:
```
torch.bfloat16 is not supported for quantization method gguf
```

This PR adds `--dtype float16` to all example commands in `docs/features/quantization/gguf.md` so users can run them directly without hitting the error.

## Changes
- Added `--dtype float16` to all 4 shell examples
- Added `dtype="float16"` to the Python LLM example

## Related Issue
Closes #47461

## Testing
- Documentation change only, no code changes
- Verified the flag is needed by checking the GGUF plugin requirements

---
🤖 AI assistance used: identified issue, edited docs, committed and opened PR.
Human submitter reviewed each line.