### PR TITLE
[Bugfix] Guard json.loads in Anthropic messages_full_converter against malformed tool call arguments

### DIFF
--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -657,11 +657,20 @@ class AnthropicServingMessages(OpenAIServingChat):
             )
 
         for tool_call in choice.message.tool_calls:
+            try:
+                tool_input = json.loads(tool_call.function.arguments)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "Failed to parse tool call arguments for %s: %s",
+                    tool_call.function.name,
+                    tool_call.function.arguments,
+                )
+                tool_input = {}
             anthropic_tool_call = AnthropicContentBlock(
                 type="tool_use",
                 id=tool_call.id,
                 name=tool_call.function.name,
-                input=json.loads(tool_call.function.arguments),
+                input=tool_input,
             )
             content += [anthropic_tool_call]
 


### PR DESCRIPTION
## Description

When a model produces invalid JSON for tool call arguments, the unguarded `json.loads()` call in `messages_full_converter` raises an unhandled `JSONDecodeError`, which bubbles up through fastapi as a **500 Internal Server Error**.

This PR wraps `json.loads()` in try/except, logs a warning with the function name and raw arguments, and falls back to an empty dict `{}` so the tool call is still delivered to the client without crashing the server.

This matches the pattern used in the Responses API (`context.py`) where `VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY` enables graceful handling.

## Changes
- Single file: `vllm/entrypoints/anthropic/serving.py:659-675`
- Added `try/except json.JSONDecodeError` around `json.loads()`
- Falls back to `{}` on parse failure
- Logs warning with tool name and raw arguments for debugging

## Related Issue
Closes #48273

## Testing
- Existing tests in `tests/entrypoints/anthropic/test_anthropic_messages_conversion.py` cover `messages_full_converter`
- Valid JSON parsing path is unchanged — backward-compatible

---
🤖 AI assistance used: identified the issue, wrote the fix, committed and opened PR.
Human submitter reviewed each line.