### PR TITLE
[Bugfix][Tool Parser] Mistral v11: keep tool-call boundaries when content precedes multiple tool calls in one delta

### DIFF
--- a/tests/tool_parsers/test_mistral_tool_parser.py
+++ b/tests/tool_parsers/test_mistral_tool_parser.py
@@ -964,6 +964,25 @@ def test_extract_tool_calls_streaming_v11_no_tools(
         pytest.param(
             "mistral_tool_parser",
             "mistral_tokenizer",
+            """I will help.[TOOL_CALLS]add{"a": 3.5, "b": 4}[TOOL_CALLS]multiply{"a": 3, "b": 6}""",  # noqa: E501
+            [
+                ToolCall(
+                    function=FunctionCall(
+                        name="add", arguments=json.dumps({"a": 3.5, "b": 4})
+                    )
+                ),
+                ToolCall(
+                    function=FunctionCall(
+                        name="multiply", arguments=json.dumps({"a": 3, "b": 6})
+                    )
+                ),
+            ],
+            "I will help.",
+            id="v11-content_before_multiple_tool_calls",
+        ),
+        pytest.param(
+            "mistral_tool_parser",
+            "mistral_tokenizer",
             """hi{hi[TOOL_CALLS]bash{"command": "print(\\"hello world!\\")\\nre.compile(r\'{}\')"}""",  # noqa: E501
             [
                 ToolCall(

--- a/vllm/tool_parsers/mistral_tool_parser.py
+++ b/vllm/tool_parsers/mistral_tool_parser.py
@@ -428,10 +428,12 @@ class MistralToolParser(ToolParser):
             if self.bot_token not in delta_text:
                 return DeltaMessage(content=delta_text)
             if not delta_text.startswith(self.bot_token):
-                additional_content += delta_text.split(self.bot_token)[0]
-                delta_text = self.bot_token + "".join(
-                    delta_text.split(self.bot_token)[1:]
-                )
+                # split off the content before the first bot token only, so
+                # that any further bot tokens in the delta keep separating
+                # their tool calls
+                content, _, tool_calls_text = delta_text.partition(self.bot_token)
+                additional_content += content
+                delta_text = self.bot_token + tool_calls_text
 
         delta_tool_calls = self._generate_delta_tool_call(delta_text)
         if not additional_content and len(delta_tool_calls) == 0:


### PR DESCRIPTION
FIX #48318

## Purpose

In the v11 streaming path of `MistralToolParser`, when the first tool call arrives in a delta that also contains leading assistant content, the content-splitting logic rejoined the remainder with `"".join(delta_text.split(self.bot_token)[1:])`, dropping every `[TOOL_CALLS]` separator after the first one. All subsequent tool calls in that delta were merged into the first tool call's arguments — the client received one tool call with invalid JSON arguments instead of separate calls.

For the single delta `I will help.[TOOL_CALLS]add{"a": 3.5, "b": 4}[TOOL_CALLS]multiply{"a": 3, "b": 6}`:

- Before: content `I will help.` + **one** tool call `add` with arguments `{"a": 3.5, "b": 4}multiply{"a": 3, "b": 6}` (invalid JSON)
- After: content `I will help.` + two tool calls, matching the non-streaming parser and the streaming behavior when no content precedes the first bot token (that path was already handled correctly by `_generate_delta_tool_call`).

The fix splits off only the content before the *first* bot token with `partition()`, keeping later separators intact. Single-delta multi-tool outputs are realistic — the existing test file notes they are produced by async scheduling / `stream_interval > 1`, and `test_extract_tool_calls_streaming_one_chunk` already covers whole-message deltas, just not this combination.

**Duplicate check:** searched open PRs/issues for the Mistral parser and streaming boundary handling; #47739 (tool_call_id format) and #45310/#45168 (Hermes) are unrelated. No open PR touches this code path.

## Test Plan

```bash
pytest tests/tool_parsers/test_mistral_tool_parser.py
```

Adds the missing one-chunk case `v11-content_before_multiple_tool_calls` to the existing parametrized test.

## Test Result

On the parent commit the new case fails exactly as described (one merged tool call). With this change:

```text
76 passed in 48.02s
```

(75 pre-existing tests + the new case, Linux/CPU, Python 3.12.) `pre-commit` (ruff check/format, mypy, typos) passes on the changed files.

---

*Disclosure per the [contributing guidelines](https://docs.vllm.ai/en/latest/contributing/#ai-assisted-contributions): this PR was developed with AI assistance (Claude); commits carry a `Co-authored-by` trailer. I reviewed the changes and ran the tests above locally.*
