### PR TITLE
[Bugfix][Frontend] Responses API: resolve explicit null background/truncation to their defaults

### DIFF
--- a/tests/entrypoints/openai/responses/test_protocol.py
+++ b/tests/entrypoints/openai/responses/test_protocol.py
@@ -1,10 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
+import pytest
 from openai_harmony import (
     Message,
 )
 
 from vllm.entrypoints.openai.responses.protocol import (
+    ResponsesRequest,
+    ResponsesResponse,
     serialize_message,
     serialize_messages,
 )
@@ -37,3 +42,73 @@ def test_serialize_messages() -> None:
     }
     msg = Message.from_dict(msg_value)
     assert serialize_messages([msg, dict_value]) == [msg_value, dict_value]
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (True, True),
+        (False, False),
+        (None, False),  # explicit null must resolve to the documented default
+    ],
+)
+def test_responses_response_background_null_resolves_to_default(value, expected):
+    """An explicit ``"background": null`` in the request must not fail
+    response construction (``ResponsesResponse.background`` is a
+    non-optional bool)."""
+    request = ResponsesRequest.model_validate(
+        {"input": "Hello", "model": "test-model", "background": value}
+    )
+    sampling_params = request.to_sampling_params(default_max_tokens=16)
+    response = ResponsesResponse.from_request(
+        request=request,
+        sampling_params=sampling_params,
+        model_name="test-model",
+        created_time=0,
+        output=[],
+        status="completed",
+    )
+    assert response.background is expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("auto", "auto"),
+        ("disabled", "disabled"),
+        (None, "disabled"),  # explicit null must resolve to the default
+    ],
+)
+def test_responses_response_truncation_null_resolves_to_default(value, expected):
+    """An explicit ``"truncation": null`` in the request must not fail
+    response construction (``ResponsesResponse.truncation`` is a
+    non-optional literal)."""
+    request = ResponsesRequest.model_validate(
+        {"input": "Hello", "model": "test-model", "truncation": value}
+    )
+    sampling_params = request.to_sampling_params(default_max_tokens=16)
+    response = ResponsesResponse.from_request(
+        request=request,
+        sampling_params=sampling_params,
+        model_name="test-model",
+        created_time=0,
+        output=[],
+        status="completed",
+    )
+    assert response.truncation == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected_truncate",
+    [
+        ("auto", -1),
+        ("disabled", None),
+        (None, None),  # explicit null must behave like the default, not "auto"
+    ],
+)
+def test_responses_request_truncation_tok_params(value, expected_truncate):
+    request = ResponsesRequest.model_validate(
+        {"input": "Hello", "model": "test-model", "truncation": value}
+    )
+    tok_params = request.build_tok_params(SimpleNamespace(max_model_len=2048))
+    assert tok_params.truncate_prompt_tokens == expected_truncate

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -337,7 +337,9 @@ class ResponsesRequest(OpenAIBaseModel):
         return TokenizeParams(
             max_total_tokens=model_config.max_model_len,
             max_output_tokens=self.max_output_tokens or 0,
-            truncate_prompt_tokens=-1 if self.truncation != "disabled" else None,
+            # an explicit null truncation means the default ("disabled"),
+            # so only enable truncation when "auto" is requested
+            truncate_prompt_tokens=-1 if self.truncation == "auto" else None,
             max_total_tokens_param="max_model_len",
             max_output_tokens_param="max_output_tokens",
         )
@@ -742,7 +744,10 @@ class ResponsesResponse(OpenAIBaseModel):
             tool_choice=request.tool_choice,
             tools=request.tools,
             top_p=sampling_params.top_p,
-            background=request.background,
+            # optional request fields accept an explicit null, but the
+            # corresponding response fields are non-optional; fall back to
+            # the documented defaults so response validation does not fail
+            background=request.background or False,
             max_output_tokens=sampling_params.max_tokens,
             max_tool_calls=request.max_tool_calls,
             previous_response_id=request.previous_response_id,
@@ -754,7 +759,7 @@ class ResponsesResponse(OpenAIBaseModel):
             status=status,
             text=request.text,
             top_logprobs=sampling_params.logprobs,
-            truncation=request.truncation,
+            truncation=request.truncation or "disabled",
             user=request.user,
             usage=usage,
             kv_transfer_params=kv_transfer_params,


### PR DESCRIPTION
FIX #48319

## Purpose

`ResponsesRequest.background` and `ResponsesRequest.truncation` are optional and accept an explicit JSON `null`, but the corresponding `ResponsesResponse` fields are non-optional. `from_request()` passed them through unguarded, so a schema-valid request with `"background": null` or `"truncation": null` failed with a Pydantic `ValidationError` during response construction, after generation had already completed:

- **Non-streaming**: confusing 400 error exposing `ResponsesResponse` internals for a request that should succeed.
- **Streaming**: `from_request()` runs inside the SSE generator after the 200 headers are sent, so the stream is torn down mid-flight with no terminal event.

Additionally, `build_tok_params()` decided prompt truncation with `truncation != "disabled"`, so an explicit `"truncation": null` silently **enabled** prompt truncation as if `"auto"` had been requested.

This PR resolves explicit nulls to the documented defaults (`background: false`, `truncation: "disabled"`) in `from_request()`, and only enables `truncate_prompt_tokens` when truncation is `"auto"` — the same approach as #48098 (`parallel_tool_calls`) and #45356 (`store`).

**Duplicate check:** #48098 covers only `parallel_tool_calls`, #45356 covers only `store`, #47184 addresses null *serialization* of response output fields (a different problem). No open PR or issue covers `background`/`truncation` null handling; this PR intentionally does not touch the `parallel_tool_calls`/`store` lines to avoid conflicting with those PRs.

## Test Plan

```bash
pytest tests/entrypoints/openai/responses/test_protocol.py
pytest tests/tool_use/test_responses_request_validations.py  # related suite, regression check
```

Adds parametrized tests covering `true`/`false`/`null` for `background`, `"auto"`/`"disabled"`/`null` for `truncation` (both response construction and `build_tok_params`).

## Test Result

On the parent commit, exactly the three explicit-`null` cases fail (ValidationError for `background`/`truncation`; `truncate_prompt_tokens=-1` for null truncation). With this change:

```text
tests/entrypoints/openai/responses/test_protocol.py: 11 passed
tests/tool_use/test_responses_request_validations.py: 17 passed
```

(Linux/CPU, Python 3.12.) `pre-commit` (ruff check/format, mypy, typos) passes on the changed files.

---

*Disclosure per the [contributing guidelines](https://docs.vllm.ai/en/latest/contributing/#ai-assisted-contributions): this PR was developed with AI assistance (Claude); commits carry a `Co-authored-by` trailer. I reviewed the changes and ran the tests above locally.*
