### PR TITLE
[Doc] Clarify that max_num_batched_tokens also shrinks the KV cache pool

### DIFF
--- a/docs/configuration/optimization.md
+++ b/docs/configuration/optimization.md
@@ -58,6 +58,18 @@ You can tune the performance by adjusting `max_num_batched_tokens`:
 - For optimal throughput, we recommend setting `max_num_batched_tokens > 8192` especially for smaller models on large GPUs.
 - If `max_num_batched_tokens` is the same as `max_model_len`, that's almost the equivalent to the V0 default scheduling policy (except that it still prioritizes decodes).
 
+!!! note
+    Raising `max_num_batched_tokens` also enlarges the dummy batch used during startup memory
+    profiling. The reserved activation memory and the KV cache pool are sized from the same
+    budget (`gpu_memory_utilization`), so a larger startup batch leaves a smaller KV cache pool.
+    On GPUs where memory is the binding constraint, this can outweigh the TTFT benefit above,
+    especially for cache-sensitive (e.g. multi-turn) workloads whose working set sits near the
+    pool's capacity: in one measurement (RTX 4090 24GB, Qwen3-8B bf16,
+    `gpu_memory_utilization=0.9`), raising the startup value from 2048 to 8192 shrank the pool by
+    10% (40,464 -> 36,720 tokens) and increased p99 TTFT by 71% (23.9s -> 40.8s) on a multi-turn
+    workload, with no change in total throughput. Check the "GPU KV cache size: ... tokens" line
+    the server logs at startup before and after changing this value.
+
 !!! warning
     When chunked prefill is disabled, `max_num_batched_tokens` must be greater than `max_model_len`.  
     In that case, if `max_num_batched_tokens < max_model_len`, vLLM may crash at server start‑up.

--- a/docs/configuration/optimization.md
+++ b/docs/configuration/optimization.md
@@ -64,11 +64,10 @@ You can tune the performance by adjusting `max_num_batched_tokens`:
     budget (`gpu_memory_utilization`), so a larger startup batch leaves a smaller KV cache pool.
     On GPUs where memory is the binding constraint, this can outweigh the TTFT benefit above,
     especially for cache-sensitive (e.g. multi-turn) workloads whose working set sits near the
-    pool's capacity: in one measurement (RTX 4090 24GB, Qwen3-8B bf16,
-    `gpu_memory_utilization=0.9`), raising the startup value from 2048 to 8192 shrank the pool by
-    10% (40,464 -> 36,720 tokens) and increased p99 TTFT by 71% (23.9s -> 40.8s) on a multi-turn
-    workload, with no change in total throughput. Check the "GPU KV cache size: ... tokens" line
-    the server logs at startup before and after changing this value.
+    pool's capacity: in one measurement, a 4x larger startup value shrank the KV cache pool by
+    around 10% and increased p99 TTFT by around 70% under a multi-turn workload, with no change
+    in total throughput. Check the "GPU KV cache size: ... tokens" line the server logs at
+    startup before and after changing this value.
 
 !!! warning
     When chunked prefill is disabled, `max_num_batched_tokens` must be greater than `max_model_len`.  


### PR DESCRIPTION
## Purpose

`docs/configuration/optimization.md` recommends raising `max_num_batched_tokens` for better TTFT, but doesn't mention that a larger startup value also enlarges the dummy batch used for startup memory profiling, which reduces the memory left for the KV cache pool (`gpu_memory_utilization` bounds weights + activation peak + KV cache together).

On memory-constrained GPUs with cache-sensitive (e.g. multi-turn/agentic) workloads whose working set sits near the pool's capacity, this can erase the intended TTFT benefit: in one measurement (RTX 4090 24GB, Qwen3-8B bf16, `gpu_memory_utilization=0.9`), raising the startup `max_num_batched_tokens` from 2048 to 8192 shrank the KV cache pool by 10% (40,464 -> 36,720 tokens), which increased p99 TTFT by 71% (23.9s -> 40.8s) and dropped goodput from 54.7% to 46.2% on a multi-turn workload, with no change in total throughput (6062 vs 6055 tok/s). This adds a note pointing readers at the "GPU KV cache size: ... tokens" startup log line so they can check the actual pool impact before/after tuning this value.

This is a documentation-only change; no code paths are modified.

**Not a duplicate:**

- #27951 is an RFC about memory-profiling *accuracy* in general (imbalanced MoE / CUDA graph estimation), with no proposed fix and no docs change; it doesn't cover this `max_num_batched_tokens` <-> KV-cache-pool tradeoff.
- #46307 is an unrelated GB10 unified-memory OOM/host-hang bug during profiling, not a documentation gap.
- Searched `gh issue list`/`gh pr list --search` across several keyword combinations (`max_num_batched_tokens kv cache profiling`, `memory profiling activation kv cache`, `profile_run activation memory kv cache budget`, etc.); no open or merged PR touches this section of `docs/configuration/optimization.md` for this tradeoff.

The pool-size and latency numbers cited in the note are from independent single-variable ablation benchmarking (multi-turn workload replay, all else held constant between the 2048 and 8192 startup configurations); happy to share the raw results if useful for review.