### PR TITLE
[CI][KVConnector] Add MultiConnector (Nixl+Offloading) PD + spec deco…

### DIFF
--- a/.buildkite/test_areas/disaggregated.yaml
+++ b/.buildkite/test_areas/disaggregated.yaml
@@ -176,6 +176,23 @@ steps:
     - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
     - bash v1/kv_connector/nixl_integration/run_multi_connector_accuracy_test.sh
 
+- label: MultiConnector (Nixl+Offloading) PD + Spec Decode accuracy (2 GPUs)
+  key: multiconnector-nixl-offloading-pd-spec-decode-accuracy-2-gpus
+  timeout_in_minutes: 30
+  working_dir: "/vllm-workspace/tests"
+  num_devices: 2
+  source_file_dependencies:
+    - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
+    - vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+    - vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+    - vllm/distributed/kv_transfer/kv_connector/v1/offloading/
+    - vllm/v1/worker/kv_connector_model_runner_mixin.py
+    - vllm/v1/spec_decode/
+    - tests/v1/kv_connector/nixl_integration/
+  commands:
+    - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
+    - bash v1/kv_connector/nixl_integration/run_multi_connector_spec_decode_test.sh
+
 - label: NixlConnector PD + Spec Decode acceptance (2 GPUs)
   key: nixlconnector-pd-spec-decode-acceptance-2-gpus
   timeout_in_minutes: 45

--- a/tests/v1/kv_connector/nixl_integration/run_multi_connector_spec_decode_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/run_multi_connector_spec_decode_test.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Integration accuracy test for MultiConnector (NixlConnector + OffloadingConnector)
+# with speculative decoding enabled.
+#
+# Launches a P/D setup where both prefill and decode instances use MultiConnector
+# wrapping NixlConnector and OffloadingConnector, with ngram speculative decoding
+# turned on, then runs gsm8k accuracy via test_accuracy.py.
+#
+# Speculative decoding is output-preserving under greedy sampling, so gsm8k
+# accuracy through this pipeline must stay within RTOL of the non-spec baseline;
+# a drop signals speculative advance/rollback corrupting KV across the NIXL
+# transfer and CPU offload path.
+#
+# Usage:
+#   bash tests/v1/kv_connector/nixl_integration/run_multi_connector_spec_decode_test.sh
+#
+# Environment variables:
+#   MODEL_NAME               - target model to test (default: Qwen/Qwen3-0.6B)
+#   PREFILL_GPU              - GPU index for the prefill instance (default: 0)
+#   DECODE_GPU               - GPU index for the decode instance (default: 1)
+#   NUM_SPEC_TOKENS          - speculative tokens per decode step (default: 3)
+#   PROMPT_LOOKUP_MAX        - max ngram proposer window (default: 5)
+#   PROMPT_LOOKUP_MIN        - min ngram proposer window (default: 3)
+#   GPU_MEMORY_UTILIZATION   - GPU memory fraction (default: 0.6)
+#   CPU_OFFLOAD_BYTES        - CPU offload buffer size in bytes (default: 1000000000)
+#   MAX_MODEL_LEN            - max sequence length (default: 8192)
+set -ex
+
+# ── Model & spec decode config ──────────────────────────────────────────
+MODEL_NAME="${MODEL_NAME:-Qwen/Qwen3-0.6B}"
+NUM_SPEC_TOKENS="${NUM_SPEC_TOKENS:-3}"
+PROMPT_LOOKUP_MAX="${PROMPT_LOOKUP_MAX:-5}"
+PROMPT_LOOKUP_MIN="${PROMPT_LOOKUP_MIN:-3}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-8192}"
+
+# ngram: no "model" field, driven purely by prompt lookup. Prefill barely uses
+# spec decode (it doesn't generate), so keep its window at 1.
+PREFILL_SPEC_CONFIG="{\"method\":\"ngram\",\"num_speculative_tokens\":1,\"prompt_lookup_max\":${PROMPT_LOOKUP_MAX},\"prompt_lookup_min\":${PROMPT_LOOKUP_MIN}}"
+DECODE_SPEC_CONFIG="{\"method\":\"ngram\",\"num_speculative_tokens\":${NUM_SPEC_TOKENS},\"prompt_lookup_max\":${PROMPT_LOOKUP_MAX},\"prompt_lookup_min\":${PROMPT_LOOKUP_MIN}}"
+
+# ── Cluster layout ───────────────────────────────────────────────────────
+GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.6}"
+BLOCK_SIZE="${BLOCK_SIZE:-128}"
+CPU_OFFLOAD_BYTES="${CPU_OFFLOAD_BYTES:-1000000000}"
+PREFILL_GPU="${PREFILL_GPU:-0}"
+DECODE_GPU="${DECODE_GPU:-1}"
+PREFILL_PORT="${PREFILL_PORT:-8100}"
+DECODE_PORT="${DECODE_PORT:-8200}"
+PREFILL_SIDE_CHANNEL_PORT="${PREFILL_SIDE_CHANNEL_PORT:-5559}"
+DECODE_SIDE_CHANNEL_PORT="${DECODE_SIDE_CHANNEL_PORT:-5659}"
+SERVER_HOST="${SERVER_HOST:-127.0.0.1}"
+NIXL_SIDE_CHANNEL_HOST="${NIXL_SIDE_CHANNEL_HOST:-$SERVER_HOST}"
+PROXY_PORT=8192
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+GIT_ROOT="${GIT_ROOT:-$(cd -- "${SCRIPT_DIR}/../../../.." && pwd -P)}"
+
+# ── KV transfer config: MultiConnector[Nixl + Offloading], kv_both ───────
+# Prefill and decode both wrap NixlConnector + OffloadingConnector.
+KV_CONFIG="{
+  \"kv_connector\":\"MultiConnector\",
+  \"kv_role\":\"kv_both\",
+  \"kv_connector_extra_config\":{
+    \"connectors\":[
+      {\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"},
+      {\"kv_connector\":\"OffloadingConnector\",\"kv_role\":\"kv_both\",
+       \"kv_connector_extra_config\":{\"cpu_bytes_to_use\":${CPU_OFFLOAD_BYTES}}}
+    ]
+  }
+}"
+KV_CONFIG=$(echo "$KV_CONFIG" | tr -d '[:space:]')
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+cleanup_instances() {
+  echo ""
+  echo "Cleaning up..."
+  jobs -pr | xargs -r kill 2>/dev/null || true
+  sleep 1
+  jobs -pr | xargs -r kill -9 2>/dev/null || true
+  pkill -9 -f "vllm serve.*${MODEL_NAME}" 2>/dev/null || true
+  pkill -9 -f "toy_proxy_server.*${PROXY_PORT}" 2>/dev/null || true
+  sleep 1
+  echo "Cleanup done."
+}
+trap cleanup_instances EXIT
+trap 'echo " Interrupted."; exit 130' INT TERM
+
+wait_for_server() {
+  local port=$1 server_pid=$2 server_name=$3
+  local endpoint=${4:-/v1/completions} deadline=${5:-600} elapsed=0
+  echo "Waiting for ${server_name} on port ${port}..."
+  while [ "$elapsed" -lt "$deadline" ]; do
+    if ! ps -p "$server_pid" > /dev/null 2>&1; then
+      local status=0; wait "$server_pid" || status=$?
+      echo "FAIL: ${server_name} pid ${server_pid} exited with ${status} before port ${port} was ready"
+      exit 1
+    fi
+    if curl -s "http://${SERVER_HOST}:${port}${endpoint}" > /dev/null 2>&1; then
+      echo "${server_name} on port ${port} ready"; return 0
+    fi
+    sleep 2; elapsed=$((elapsed + 2))
+  done
+  echo "FAIL: ${server_name} on port ${port} did not start within ${deadline}s"; exit 1
+}
+
+wait_for_nixl_side_channel() {
+  local host=$1 port=$2 server_pid=$3 server_name=$4 deadline=120 elapsed=0
+  echo "Waiting for ${server_name} NIXL side channel on ${host}:${port}..."
+  while [ $elapsed -lt $deadline ]; do
+    if ! ps -p "$server_pid" > /dev/null 2>&1; then
+      local status=0; wait "$server_pid" || status=$?
+      echo "FAIL: ${server_name} pid ${server_pid} exited with ${status} before side channel ${host}:${port} was ready"
+      exit 1
+    fi
+    if python3 "${GIT_ROOT}/tests/v1/kv_connector/nixl_integration/nixl_side_channel_probe.py" \
+      --host "$host" --port "$port" --timeout-ms 1000 > /dev/null 2>&1; then
+      echo "${server_name} NIXL side channel ${host}:${port} ready"; return 0
+    fi
+    sleep 2; elapsed=$((elapsed + 2))
+  done
+  echo "FAIL: ${server_name} NIXL side channel ${host}:${port} did not start within ${deadline}s"; exit 1
+}
+
+# ── Launch ───────────────────────────────────────────────────────────────
+echo "================================================================"
+echo "MultiConnector(Nixl+Offloading) PD + ngram spec decode -- gsm8k"
+echo "Model:            ${MODEL_NAME}"
+echo "Spec tokens:      prefill=1 decode=${NUM_SPEC_TOKENS} (lookup ${PROMPT_LOOKUP_MIN}-${PROMPT_LOOKUP_MAX})"
+echo "KV config:        ${KV_CONFIG}"
+echo "Prefill GPU/port: ${PREFILL_GPU}/${PREFILL_PORT}   Decode GPU/port: ${DECODE_GPU}/${DECODE_PORT}"
+echo "================================================================"
+
+echo "Starting prefill instance..."
+env CUDA_VISIBLE_DEVICES="$PREFILL_GPU" \
+  VLLM_KV_CACHE_LAYOUT='HND' \
+  UCX_NET_DEVICES=all \
+  VLLM_NIXL_SIDE_CHANNEL_HOST="$NIXL_SIDE_CHANNEL_HOST" \
+  VLLM_NIXL_SIDE_CHANNEL_PORT="$PREFILL_SIDE_CHANNEL_PORT" \
+  vllm serve "$MODEL_NAME" \
+    --port "$PREFILL_PORT" \
+    --enforce-eager \
+    --max-model-len "$MAX_MODEL_LEN" \
+    --block-size "$BLOCK_SIZE" \
+    --gpu-memory-utilization "$GPU_MEMORY_UTILIZATION" \
+    --tensor-parallel-size 1 \
+    --kv-transfer-config "$KV_CONFIG" \
+    --speculative-config "$PREFILL_SPEC_CONFIG" &
+PREFILL_PID=$!
+wait_for_server "$PREFILL_PORT" "$PREFILL_PID" "prefill"
+wait_for_nixl_side_channel "$NIXL_SIDE_CHANNEL_HOST" "$PREFILL_SIDE_CHANNEL_PORT" "$PREFILL_PID" "prefill"
+
+echo "Starting decode instance..."
+env CUDA_VISIBLE_DEVICES="$DECODE_GPU" \
+  VLLM_KV_CACHE_LAYOUT='HND' \
+  UCX_NET_DEVICES=all \
+  VLLM_NIXL_SIDE_CHANNEL_HOST="$NIXL_SIDE_CHANNEL_HOST" \
+  VLLM_NIXL_SIDE_CHANNEL_PORT="$DECODE_SIDE_CHANNEL_PORT" \
+  vllm serve "$MODEL_NAME" \
+    --port "$DECODE_PORT" \
+    --enforce-eager \
+    --max-model-len "$MAX_MODEL_LEN" \
+    --block-size "$BLOCK_SIZE" \
+    --gpu-memory-utilization "$GPU_MEMORY_UTILIZATION" \
+    --tensor-parallel-size 1 \
+    --kv-transfer-config "$KV_CONFIG" \
+    --speculative-config "$DECODE_SPEC_CONFIG" &
+DECODE_PID=$!
+wait_for_server "$DECODE_PORT" "$DECODE_PID" "decode"
+wait_for_nixl_side_channel "$NIXL_SIDE_CHANNEL_HOST" "$DECODE_SIDE_CHANNEL_PORT" "$DECODE_PID" "decode"
+
+echo "Starting proxy on port ${PROXY_PORT}..."
+python3 "${GIT_ROOT}/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py" \
+  --port "$PROXY_PORT" \
+  --prefiller-hosts "$SERVER_HOST" \
+  --prefiller-ports "$PREFILL_PORT" \
+  --decoder-hosts "$SERVER_HOST" \
+  --decoder-ports "$DECODE_PORT" &
+PROXY_PID=$!
+wait_for_server "$PROXY_PORT" "$PROXY_PID" "proxy" "/healthcheck" 60
+
+# ── Correctness: gsm8k accuracy stays within RTOL of the baseline ────────
+echo "Running gsm8k accuracy test through the combined PD pipeline..."
+TEST_MODEL=$MODEL_NAME python3 -m pytest -s -x \
+  "${GIT_ROOT}/tests/v1/kv_connector/nixl_integration/test_accuracy.py"
+
+# ── Liveness: speculative decoding is still accepting drafts (accept len > 1.3) ─
+echo "Asserting speculative decoding stayed engaged on the decode server..."
+SERVER_HOST=$SERVER_HOST DECODE_PORT=$DECODE_PORT python3 -m pytest -s -x \
+  "${GIT_ROOT}/tests/v1/kv_connector/nixl_integration/test_spec_decode_metrics.py"
+
+echo ""
+echo "=== MultiConnector(Nixl+Offloading) + ngram spec decode test passed ==="

--- a/tests/v1/kv_connector/nixl_integration/test_spec_decode_metrics.py
+++ b/tests/v1/kv_connector/nixl_integration/test_spec_decode_metrics.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Assert speculative decoding stays engaged across the PD + offload path.
+
+Speculative decoding is output-preserving, so an accuracy test alone cannot
+tell whether it is actually running: if drafts silently stop being accepted
+across the NIXL transfer + CPU offload path, decoding falls back to one token
+per step and the output (and gsm8k accuracy) is unchanged.
+
+After traffic has flowed through the pipeline, the decode server's spec-decode
+counters must therefore show a healthy mean acceptance length, i.e. drafts were
+proposed and a meaningful fraction was accepted.
+
+Environment variables:
+    SERVER_HOST  - decode server host (default: 127.0.0.1)
+    DECODE_PORT  - decode server port to scrape /metrics from (default: 8200)
+"""
+
+import os
+from urllib.request import urlopen
+
+SERVER_HOST = os.environ.get("SERVER_HOST", "127.0.0.1")
+DECODE_PORT = os.environ.get("DECODE_PORT", "8200")
+
+MIN_ACCEPTANCE_LENGTH = 1.3
+
+
+def _fetch_counter(metric_name: str) -> float:
+    """Return a single counter value from the decode server's /metrics."""
+    url = f"http://{SERVER_HOST}:{DECODE_PORT}/metrics"
+    body = urlopen(url).read().decode()
+    for line in body.split("\n"):
+        if line.startswith(metric_name + "{") or line.startswith(metric_name + " "):
+            return float(line.rsplit(" ", 1)[-1])
+    raise ValueError(f"Metric {metric_name} not found in decode /metrics")
+
+
+def test_spec_decode_engaged():
+    """Speculative decoding must remain active through the combined pipeline."""
+    n_drafts = _fetch_counter("vllm:spec_decode_num_drafts_total")
+    n_accepted = _fetch_counter("vllm:spec_decode_num_accepted_tokens_total")
+
+    assert n_drafts > 0, "No speculative drafts were generated on the decode server"
+
+    mean_acceptance_length = 1 + (n_accepted / n_drafts)
+    print(
+        f"\nspec decode: drafts={n_drafts:.0f} accepted={n_accepted:.0f} "
+        f"mean acceptance length={mean_acceptance_length:.3f}"
+    )
+    assert mean_acceptance_length > MIN_ACCEPTANCE_LENGTH, (
+        f"Mean acceptance length {mean_acceptance_length:.3f} <= "
+        f"{MIN_ACCEPTANCE_LENGTH}: speculative decoding degraded; drafts are "
+        "not being accepted through the NIXL transfer + CPU offload path"
+    )


### PR DESCRIPTION
<!--
PR TITLE (copy into the GitHub title field):

[CI][KVConnector] Add MultiConnector (Nixl+Offloading) PD + spec decode accuracy test

Open PR at: https://github.com/shliba123/vllm/pull/new/nixl-cpu-offload-spec-decode-test
base = vllm-project/vllm : main   |   make sure you're logged in as shliba123

Everything below this comment is the PR body -- copy from "## Purpose" down.
-->

## Purpose

Add a CI integration test for MultiConnector (Nixl + Offloading) P/D disaggregation with speculative decoding enabled.

Part of #33702 — implements the roadmap item "PD+CPU Offloading+Spec Decoding verification and CI tests".

## Test Plan

```
bash tests/v1/kv_connector/nixl_integration/run_multi_connector_spec_decode_test.sh
```

## Test Result

Run locally on 2x RTX 4090 with `Qwen/Qwen3-0.6B`:

```
gsm8k exact_match      = 0.4230   (baseline 0.41, RTOL 0.05)          PASS
mean acceptance length = 1.755    (38276 drafts / 28917 accepted)     PASS
```

## AI assistance

AI assistance (Claude) was used to prepare this change. I reviewed every line, ran the test above, and checked for existing open PRs covering this combination (found none).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
