### PR TITLE
Fix platform plugin load error message swallowed (#48277)

### DIFF
--- a/tests/plugins_tests/test_platform_plugins.py
+++ b/tests/plugins_tests/test_platform_plugins.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import logging
+
 import pytest
 import torch
 
@@ -45,3 +47,25 @@ def test_oot_custom_op(default_vllm_config, monkeypatch: pytest.MonkeyPatch):
         "Expected DummyRotaryEmbedding to have an 'addition_config' attribute, "
         "which is set by the custom op."
     )
+
+
+def test_broken_platform_plugin_logs_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    from vllm.platforms import resolve_current_platform_cls_qualname
+
+    def broken_plugin() -> str | None:
+        raise ModuleNotFoundError("no module named 'totally_broken_plugin'")
+
+    monkeypatch.setattr(
+        "vllm.platforms.load_plugins_by_group",
+        lambda group: {"broken": broken_plugin},
+    )
+
+    with caplog.at_level(logging.WARNING):
+        resolve_current_platform_cls_qualname()
+
+    assert any(
+        "broken" in record.getMessage() and "failed to load" in record.getMessage()
+        for record in caplog.records
+    ), "Expected a warning naming the broken plugin, but none was logged"

--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -219,8 +219,12 @@ def resolve_current_platform_cls_qualname() -> str:
             platform_cls_qualname = func()
             if platform_cls_qualname is not None:
                 activated_plugins.append(name)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(
+                "Platform plugin %s failed to load and will be skipped",
+                name,
+                exc_info=e,
+            )
 
     activated_builtin_plugins = list(
         set(activated_plugins) & set(builtin_platform_plugins.keys())


### PR DESCRIPTION
### What does this PR do?

Fixes #48277

When an out-of-tree platform plugin fails to register (e.g., a stale `vllm-metal` installation raising `ModuleNotFoundError`), `resolve_current_platform_cls_qualname()` was silently swallowing the exception and falling back to the CPU platform. This lack of diagnostics made it extremely difficult to identify the root cause of the fallback. 

This PR updates `vllm/platforms/__init__.py` to log a clear warning (including the exception details) when a platform plugin fails to load. It also includes a test case to explicitly verify the warning is emitted.

### Why is this not duplicating an existing PR?

I have checked the issue tracker for `#48277` and searched open PRs for keywords like "platform plugin failure" or "silent CPU fallback". There are no other active PRs attempting to address this specific logging gap.

### Testing

**Commands Run:**
```bash
pytest tests/plugins_tests/test_platform_plugins.py
```
Results: Tests passed. The newly added test successfully verifies that caplog captures the expected warning message when a mock broken plugin throws an exception during initialization.

Model Evaluation Results
Not applicable. This PR only modifies the platform plugin discovery logging logic and has no impact on model outputs, correctness, or serving performance.