### PR TITLE
[CI] Point CI at Transformers release rather than release branch

### DIFF
--- a/requirements/test/cpu.txt
+++ b/requirements/test/cpu.txt
@@ -1159,7 +1159,7 @@ tqdm==4.67.3
     #   segmentation-models-pytorch
     #   sentence-transformers
     #   transformers
-transformers @ git+https://github.com/huggingface/transformers.git@bef013c4a2180aeef83355bd200a7383ce1ac7e3
+transformers==5.13.1
     # via
     #   -r requirements/test/../common.txt
     #   -r requirements/test/cuda.in

--- a/requirements/test/cuda.in
+++ b/requirements/test/cuda.in
@@ -39,7 +39,7 @@ open_clip_torch==2.32.0 # Required for nemotron_vl test, Nemotron Parse in test_
 datamodel_code_generator # required for minicpm3 test
 lm-eval[api]>=0.4.12 # required for model evaluation test
 mteb[bm25s]>=2, <3 # required for mteb test
-transformers @ git+https://github.com/huggingface/transformers.git@v5.13-release
+transformers==5.13.1
 tokenizers==0.22.2
 schemathesis>=4.0.0 # Required for openai schema test.
 # quantization

--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -1261,7 +1261,7 @@ tqdm==4.67.3
     #   segmentation-models-pytorch
     #   sentence-transformers
     #   transformers
-transformers @ git+https://github.com/huggingface/transformers.git@bef013c4a2180aeef83355bd200a7383ce1ac7e3
+transformers==5.13.1
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt

--- a/requirements/test/nightly-torch.txt
+++ b/requirements/test/nightly-torch.txt
@@ -29,7 +29,7 @@ opencv-python-headless >= 4.13.0 # required for video test
 datamodel_code_generator # required for minicpm3 test
 lm-eval[api]>=0.4.12 # required for model evaluation test
 mteb[bm25s]>=2, <3 # required for mteb test
-transformers @ git+https://github.com/huggingface/transformers.git@v5.13-release
+transformers==5.13.1
 tokenizers==0.22.2
 schemathesis>=4.0.0 # Required for openai schema test.
 # quantization

--- a/requirements/test/rocm.in
+++ b/requirements/test/rocm.in
@@ -35,7 +35,7 @@ open_clip_torch==2.32.0 # Required for nemotron_vl test, Nemotron Parse in test_
 datamodel_code_generator # required for minicpm3 test
 lm-eval[api]>=0.4.12 # required for model evaluation test
 mteb[bm25s]>=2, <3 # required for mteb test
-transformers @ git+https://github.com/huggingface/transformers.git@v5.13-release
+transformers==5.13.1
 tokenizers==0.22.2
 schemathesis>=4.0.0 # Required for openai schema test
 # quantization

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -1218,7 +1218,7 @@ tqdm==4.67.3
     #   sentence-transformers
     #   tilelang
     #   transformers
-transformers @ git+https://github.com/huggingface/transformers.git@bef013c4a2180aeef83355bd200a7383ce1ac7e3
+transformers==5.13.1
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt

--- a/requirements/test/xpu.in
+++ b/requirements/test/xpu.in
@@ -17,7 +17,7 @@ accelerate
 arctic-inference
 lm_eval[api]>=0.4.12
 modelscope<1.38
-transformers @ git+https://github.com/huggingface/transformers.git@v5.13-release
+transformers==5.13.1
 
 # --- Audio Processing ---
 librosa

--- a/requirements/test/xpu.txt
+++ b/requirements/test/xpu.txt
@@ -940,7 +940,7 @@ tqdm==4.67.3
     #   pqdm
     #   sentence-transformers
     #   transformers
-transformers @ git+https://github.com/huggingface/transformers.git@bef013c4a2180aeef83355bd200a7383ce1ac7e3
+transformers==5.13.1
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/47867 updated vLLM so use 5.13.1 via the release branch. This PR updates vLLM to use the same version but using the tag from PyPI now that it has been released.