### PR TITLE
fix(entrypoints): stop resolve_items leaking in-flight media fetch tasks on partial failure

### DIFF
--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -2781,4 +2781,3 @@ async def test_resolve_items_does_not_leak_tasks_on_partial_failure():
         f"resolve_items left {len(leaked_tasks)} task(s) running after "
         f"raising: {leaked_tasks}"
     )
-

--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import asyncio
 import warnings
 from collections.abc import Mapping
 from typing import Literal
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -13,6 +15,7 @@ from vllm.assets.image import ImageAsset
 from vllm.assets.video import VideoAsset
 from vllm.config import ModelConfig
 from vllm.entrypoints.chat_utils import (
+    AsyncMultiModalItemTracker,
     ConversationMessage,
     _postprocess_messages,
     parse_chat_messages,
@@ -2742,3 +2745,40 @@ def test_postprocess_messages_null_arguments_string():
     tool_calls = messages[0]["tool_calls"]
     assert tool_calls is not None
     assert tool_calls[0]["function"]["arguments"] == {}
+
+
+@pytest.mark.asyncio
+async def test_resolve_items_does_not_leak_tasks_on_partial_failure():
+    """Regression test: one failing media fetch must not abandon the other
+    still-in-flight fetches in the same modality batch.
+
+    Before the fix, `resolve_items` gathered per-modality fetches with plain
+    `asyncio.gather`, so the first exception propagated immediately while
+    sibling fetches (real network/thread-pool work in production) kept
+    running detached, with nothing left to await or cancel them.
+    """
+
+    async def _fetch(should_fail: bool, delay: float):
+        if should_fail:
+            await asyncio.sleep(0.01)
+            raise ValueError("simulated fetch failure")
+        await asyncio.sleep(delay)
+        return ("decoded", None)
+
+    tracker = AsyncMultiModalItemTracker(MagicMock())
+    tracker._items_by_modality["image"] = [
+        lambda: _fetch(True, 0),
+        lambda: _fetch(False, 0.2),
+        lambda: _fetch(False, 0.2),
+    ]
+
+    tasks_before = asyncio.all_tasks()
+    with pytest.raises(ValueError, match="simulated fetch failure"):
+        await tracker.resolve_items()
+
+    leaked_tasks = asyncio.all_tasks() - tasks_before
+    assert not leaked_tasks, (
+        f"resolve_items left {len(leaked_tasks)} task(s) running after "
+        f"raising: {leaked_tasks}"
+    )
+

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -821,10 +821,19 @@ class AsyncMultiModalItemTracker(BaseMultiModalItemTracker[_AsyncMultiModalItem]
         if not self._items_by_modality:
             return None, None
 
-        resolved_items_by_modality = {
-            modality: await asyncio.gather(*(item() for item in items))
-            for modality, items in self._items_by_modality.items()
-        }
+        resolved_items_by_modality: dict[str, list[Any]] = {}
+        for modality, items in self._items_by_modality.items():
+            results = await asyncio.gather(
+                *(item() for item in items), return_exceptions=True
+            )
+            for result in results:
+                if isinstance(result, BaseException):
+                    # Gathering with return_exceptions=True lets every task in
+                    # this modality finish (or itself fail) before we raise,
+                    # instead of abandoning still-in-flight fetches (real
+                    # network/thread-pool work) the moment the first one fails.
+                    raise result
+            resolved_items_by_modality[modality] = results
 
         mm_processor = (
             self.mm_processor if self._model_config.is_multimodal_model else None


### PR DESCRIPTION
## Purpose

`AsyncMultiModalItemTracker.resolve_items` fans out each modality's media fetches with plain `asyncio.gather`. When one fetch in a modality fails (bad URL, timeout, an SSRF/domain-allowlist rejection, a decode error), `gather` propagates that exception immediately, but it does not cancel or await the sibling fetches for that same modality that are still in flight. Those tasks keep running detached from the request that spawned them, holding onto real network sockets and `global_thread_pool` work with nothing left to await or cancel them.

This matters most for the very common case of a single message containing multiple images/audio clips: one bad item in the batch leaks the fetches for the others past the point where the request handler has already raised and returned an error to the caller.

Reproduced against the actual `AsyncMultiModalItemTracker` class (not just a simulation):

```python
tracker = AsyncMultiModalItemTracker(MagicMock())
tracker._items_by_modality["image"] = [
    lambda: fetch_image_async("http://bad-host/broken.png", True, 0),
    lambda: fetch_image_async("http://good-host/a.png", False, 2.0),
    lambda: fetch_image_async("http://good-host/b.png", False, 2.0),
]
try:
    await tracker.resolve_items()
except ValueError:
    pass
# 2 tasks still pending here, running with nothing awaiting them
```

## Fix

Gather each modality's fetches with `return_exceptions=True`, then raise the first exception only after every task in that modality has actually finished (or itself failed). This keeps the batch's lifetime bounded to the `resolve_items` call, at the cost of waiting for the slowest sibling fetch before surfacing an error instead of failing the instant the first one does, the correct tradeoff to avoid abandoning in-flight work.

## Test Plan

Added `test_resolve_items_does_not_leak_tasks_on_partial_failure` in `tests/entrypoints/unit_tests/test_chat_utils.py`, which constructs an `AsyncMultiModalItemTracker` with one failing and two slower-succeeding fetches in the same modality, and asserts via `asyncio.all_tasks()` diffing that nothing is left pending after `resolve_items` raises.

Verified locally against the unpatched class that the leak reproduces (2 orphaned tasks), and against the patched class that it's gone (0 orphaned tasks), with the exception still propagating correctly in both cases.

## Duplicate check

Searched for existing open PRs/issues on this before opening: `gh pr list --search "resolve_items"` and a search for the orphaned-task pattern in `chat_utils.py` turned up nothing else addressing this specific leak. No related open issue exists to link.

## AI assistance disclosure

This PR was prepared with AI assistance (Claude, operated by @ErenAta16). The bug was found and the fix verified by running it against the real `AsyncMultiModalItemTracker` class as described above (task-count diffing before/after, on both the unpatched and patched code), not from a description or simulation alone. I reviewed the diff and the reasoning behind the `return_exceptions=True` + collect-and-reraise approach before submitting, and I'm glad to answer follow-up questions on any part of it or make requested changes.
