### PR TITLE
[Bugfix] Fix level-2 sleep/wake crash with enable_lora=True

### DIFF
--- a/tests/v1/worker/test_deep_sleep_lora.py
+++ b/tests/v1/worker/test_deep_sleep_lora.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Test level-2 sleep/wake/reload with LoRA enabled.
+
+Validates that:
+1. LoRA-wrapped parameter names resolve correctly during reload_weights()
+2. LoRA stacked tensors are re-zeroed after wake (not left with stale GPU data)
+3. Multiple sleep/wake cycles do not accumulate corruption
+
+Requires: single GPU, ~500MB VRAM (tiny model).
+"""
+
+import pytest
+import torch
+
+from vllm import LLM, SamplingParams
+
+
+@pytest.fixture
+def model_name():
+    return "hmellor/tiny-random-LlamaForCausalLM"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_deep_sleep_lora_single_cycle(model_name):
+    """Level-2 sleep + wake + reload with LoRA should produce same output."""
+    llm = LLM(
+        model_name,
+        enable_sleep_mode=True,
+        enable_lora=True,
+        max_lora_rank=8,
+        enforce_eager=True,
+    )
+    params = SamplingParams(temperature=0, max_tokens=10)
+    output_before = llm.generate("How are you?", params)
+
+    llm.sleep(level=2)
+    llm.wake_up(tags=["weights"])
+    llm.collective_rpc("reload_weights")
+    llm.wake_up(tags=["kv_cache"])
+
+    output_after = llm.generate("How are you?", params)
+    assert output_before[0].outputs[0].text == output_after[0].outputs[0].text
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_deep_sleep_lora_multi_cycle(model_name):
+    """Multiple sleep/wake cycles should not accumulate corruption."""
+    llm = LLM(
+        model_name,
+        enable_sleep_mode=True,
+        enable_lora=True,
+        max_lora_rank=8,
+        enforce_eager=True,
+    )
+    params = SamplingParams(temperature=0, max_tokens=10)
+    output_ref = llm.generate("Hello world", params)
+
+    for _ in range(3):
+        llm.sleep(level=2)
+        llm.wake_up(tags=["weights"])
+        llm.collective_rpc("reload_weights")
+        llm.wake_up(tags=["kv_cache"])
+
+    output_final = llm.generate("Hello world", params)
+    assert output_ref[0].outputs[0].text == output_final[0].outputs[0].text

--- a/tests/v1/worker/test_deep_sleep_lora.py
+++ b/tests/v1/worker/test_deep_sleep_lora.py
@@ -2,16 +2,20 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Regression tests for level-2 sleep/wake with LoRA enabled (#39934).
 
-Two bugs fixed:
+Three bugs fixed:
 1. LoRA wrapping moves parameters under base_layer, breaking
    named_parameters() name resolution during reload_weights().
 2. LoRA stacked tensors (lora_a_stacked, lora_b_stacked) are plain
    attributes not restored by reload — must be explicitly re-zeroed.
+3. sharded_to_full_mapping_gpu (TP>1 logit reordering) is not a LoRA
+   tensor and must NOT be zeroed, but it also isn't restored by
+   reload_weights — must be rebuilt from its CPU-side source.
 
 These tests validate that:
 - Single and multi-cycle sleep/wake/reload produce deterministic output
 - LoRA stacked tensors are properly zeroed (not left with stale GPU data)
-- sharded_to_full_mapping_gpu (TP>1) is NOT zeroed by zero_lora_state
+- sharded_to_full_mapping_gpu (TP>1) is NOT zeroed by zero_lora_state,
+  and IS correctly restored across TP=2/4/8
 - The fix works across different models
 """
 
@@ -22,6 +26,10 @@ from tests.utils import create_new_process_for_each_test, multi_gpu_test
 from vllm import LLM, SamplingParams
 
 MODEL = "hmellor/tiny-random-LlamaForCausalLM"
+# TP tests shard across up to 8 ranks; tiny-random-Llama only has 4
+# attention/KV heads and cannot be sharded past TP=4. Use a model with
+# enough heads (16 attn / 8 KV) for the TP=8 case.
+MODEL_MULTI_GPU = "Qwen/Qwen3-0.6B"
 PROMPT = "How are you?"
 SAMPLING_PARAMS = SamplingParams(temperature=0, max_tokens=10)
 
@@ -32,6 +40,31 @@ def _sleep_wake_reload(llm: LLM) -> None:
     llm.wake_up(tags=["weights"])
     llm.collective_rpc("reload_weights")
     llm.wake_up(tags=["kv_cache"])
+
+
+def _run_tp_sleep_wake(tensor_parallel_size: int) -> None:
+    """Shared body for TP>1 sleep/wake/reload regression tests.
+
+    Validates that reload_weights succeeds under tensor parallelism and
+    that sharded_to_full_mapping_gpu is correctly restored (not left as
+    stale garbage) across single- and multi-cycle sleep/wake.
+    """
+    llm = LLM(MODEL_MULTI_GPU,
+              enable_sleep_mode=True,
+              enable_lora=True,
+              max_lora_rank=8,
+              enforce_eager=True,
+              tensor_parallel_size=tensor_parallel_size)
+
+    output_before = llm.generate(PROMPT, SAMPLING_PARAMS)
+    _sleep_wake_reload(llm)
+    output_after = llm.generate(PROMPT, SAMPLING_PARAMS)
+    assert output_before[0].outputs[0].text == output_after[0].outputs[0].text
+
+    for _ in range(2):
+        _sleep_wake_reload(llm)
+    output_final = llm.generate(PROMPT, SAMPLING_PARAMS)
+    assert output_before[0].outputs[0].text == output_final[0].outputs[0].text
 
 
 # ---- Single-GPU tests ----
@@ -151,33 +184,27 @@ def test_deep_sleep_lora_preserves_non_lora_tensors():
     assert output_before[0].outputs[0].text == output_after[0].outputs[0].text
 
 
-# ---- Multi-GPU (TP>1) test ----
+# ---- Multi-GPU (TP>1) tests ----
+#
+# sharded_to_full_mapping_gpu is only allocated when TP>1 (it reorders
+# gathered logits back to full-vocab order across ranks). These tests
+# cover a range of TP sizes since the restore path rebuilds it from a
+# CPU-side list whose sharding depends on tp_size/tp_rank.
 
 
 @multi_gpu_test(num_gpus=2)
 def test_deep_sleep_lora_tp2():
-    """Level-2 sleep/wake/reload with LoRA at TP=2.
+    """Level-2 sleep/wake/reload with LoRA at TP=2."""
+    _run_tp_sleep_wake(tensor_parallel_size=2)
 
-    Validates that:
-    - reload_weights succeeds under tensor parallelism
-    - sharded_to_full_mapping_gpu is preserved (not zeroed)
-    - Output is deterministic across sleep/wake cycles
-    """
-    llm = LLM(MODEL,
-              enable_sleep_mode=True,
-              enable_lora=True,
-              max_lora_rank=8,
-              enforce_eager=True,
-              tensor_parallel_size=2)
 
-    output_before = llm.generate(PROMPT, SAMPLING_PARAMS)
-    _sleep_wake_reload(llm)
-    output_after = llm.generate(PROMPT, SAMPLING_PARAMS)
+@multi_gpu_test(num_gpus=4)
+def test_deep_sleep_lora_tp4():
+    """Level-2 sleep/wake/reload with LoRA at TP=4."""
+    _run_tp_sleep_wake(tensor_parallel_size=4)
 
-    assert output_before[0].outputs[0].text == output_after[0].outputs[0].text
 
-    # Multi-cycle at TP=2
-    for _ in range(2):
-        _sleep_wake_reload(llm)
-    output_final = llm.generate(PROMPT, SAMPLING_PARAMS)
-    assert output_before[0].outputs[0].text == output_final[0].outputs[0].text
+@multi_gpu_test(num_gpus=8)
+def test_deep_sleep_lora_tp8():
+    """Level-2 sleep/wake/reload with LoRA at TP=8."""
+    _run_tp_sleep_wake(tensor_parallel_size=8)

--- a/tests/v1/worker/test_deep_sleep_lora.py
+++ b/tests/v1/worker/test_deep_sleep_lora.py
@@ -1,66 +1,183 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Test level-2 sleep/wake/reload with LoRA enabled.
+"""Regression tests for level-2 sleep/wake with LoRA enabled (#39934).
 
-Validates that:
-1. LoRA-wrapped parameter names resolve correctly during reload_weights()
-2. LoRA stacked tensors are re-zeroed after wake (not left with stale GPU data)
-3. Multiple sleep/wake cycles do not accumulate corruption
+Two bugs fixed:
+1. LoRA wrapping moves parameters under base_layer, breaking
+   named_parameters() name resolution during reload_weights().
+2. LoRA stacked tensors (lora_a_stacked, lora_b_stacked) are plain
+   attributes not restored by reload — must be explicitly re-zeroed.
 
-Requires: single GPU, ~500MB VRAM (tiny model).
+These tests validate that:
+- Single and multi-cycle sleep/wake/reload produce deterministic output
+- LoRA stacked tensors are properly zeroed (not left with stale GPU data)
+- sharded_to_full_mapping_gpu (TP>1) is NOT zeroed by zero_lora_state
+- The fix works across different models
 """
 
 import pytest
 import torch
 
+from tests.utils import create_new_process_for_each_test, multi_gpu_test
 from vllm import LLM, SamplingParams
 
+MODEL = "hmellor/tiny-random-LlamaForCausalLM"
+PROMPT = "How are you?"
+SAMPLING_PARAMS = SamplingParams(temperature=0, max_tokens=10)
 
-@pytest.fixture
-def model_name():
-    return "hmellor/tiny-random-LlamaForCausalLM"
 
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_deep_sleep_lora_single_cycle(model_name):
-    """Level-2 sleep + wake + reload with LoRA should produce same output."""
-    llm = LLM(
-        model_name,
-        enable_sleep_mode=True,
-        enable_lora=True,
-        max_lora_rank=8,
-        enforce_eager=True,
-    )
-    params = SamplingParams(temperature=0, max_tokens=10)
-    output_before = llm.generate("How are you?", params)
-
+def _sleep_wake_reload(llm: LLM) -> None:
+    """Execute one full sleep-level-2 / wake / reload cycle."""
     llm.sleep(level=2)
     llm.wake_up(tags=["weights"])
     llm.collective_rpc("reload_weights")
     llm.wake_up(tags=["kv_cache"])
 
-    output_after = llm.generate("How are you?", params)
+
+# ---- Single-GPU tests ----
+
+
+@create_new_process_for_each_test()
+def test_deep_sleep_lora_single_cycle():
+    """Level-2 sleep + wake + reload with LoRA produces same output."""
+    llm = LLM(MODEL,
+              enable_sleep_mode=True,
+              enable_lora=True,
+              max_lora_rank=8,
+              enforce_eager=True)
+
+    output_before = llm.generate(PROMPT, SAMPLING_PARAMS)
+    _sleep_wake_reload(llm)
+    output_after = llm.generate(PROMPT, SAMPLING_PARAMS)
+
     assert output_before[0].outputs[0].text == output_after[0].outputs[0].text
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_deep_sleep_lora_multi_cycle(model_name):
-    """Multiple sleep/wake cycles should not accumulate corruption."""
-    llm = LLM(
-        model_name,
-        enable_sleep_mode=True,
-        enable_lora=True,
-        max_lora_rank=8,
-        enforce_eager=True,
-    )
-    params = SamplingParams(temperature=0, max_tokens=10)
-    output_ref = llm.generate("Hello world", params)
+@create_new_process_for_each_test()
+def test_deep_sleep_lora_multi_cycle():
+    """Multiple sleep/wake cycles do not accumulate corruption."""
+    llm = LLM(MODEL,
+              enable_sleep_mode=True,
+              enable_lora=True,
+              max_lora_rank=8,
+              enforce_eager=True)
+
+    output_ref = llm.generate(PROMPT, SAMPLING_PARAMS)
 
     for _ in range(3):
-        llm.sleep(level=2)
-        llm.wake_up(tags=["weights"])
-        llm.collective_rpc("reload_weights")
-        llm.wake_up(tags=["kv_cache"])
+        _sleep_wake_reload(llm)
 
-    output_final = llm.generate("Hello world", params)
+    output_final = llm.generate(PROMPT, SAMPLING_PARAMS)
     assert output_ref[0].outputs[0].text == output_final[0].outputs[0].text
+
+
+@create_new_process_for_each_test()
+def test_deep_sleep_lora_level1_still_works():
+    """Level-1 sleep (CPU backup) with LoRA should still work correctly."""
+    llm = LLM(MODEL,
+              enable_sleep_mode=True,
+              enable_lora=True,
+              max_lora_rank=8,
+              enforce_eager=True)
+
+    output_before = llm.generate(PROMPT, SAMPLING_PARAMS)
+
+    llm.sleep(level=1)
+    llm.wake_up()
+
+    output_after = llm.generate(PROMPT, SAMPLING_PARAMS)
+    assert output_before[0].outputs[0].text == output_after[0].outputs[0].text
+
+
+@create_new_process_for_each_test()
+def test_deep_sleep_lora_stacked_tensors_zeroed():
+    """After level-2 sleep/wake/reload, LoRA stacked tensors must be zero."""
+    llm = LLM(MODEL,
+              enable_sleep_mode=True,
+              enable_lora=True,
+              max_lora_rank=8,
+              enforce_eager=True)
+
+    _sleep_wake_reload(llm)
+
+    # Inspect model LoRA layers — stacked tensors should be zero
+    from vllm.lora.layers.base import BaseLayerWithLoRA
+    model = llm.llm_engine.model_executor.driver_worker.worker.model_runner.model  # noqa: E501
+    for name, module in model.named_modules():
+        if isinstance(module, BaseLayerWithLoRA):
+            for attr_name in module._LORA_TENSOR_ATTRS:
+                val = getattr(module, attr_name, None)
+                if val is None:
+                    continue
+                if isinstance(val, torch.Tensor):
+                    tensors = [val]
+                elif isinstance(val, (tuple, list)):
+                    tensors = [t for t in val if isinstance(t, torch.Tensor)]
+                else:
+                    continue
+                for t in tensors:
+                    if t.device.type != "meta":
+                        assert t.abs().sum() == 0, (
+                            f"{name}.{attr_name} not zeroed after sleep/wake"
+                        )
+
+
+@create_new_process_for_each_test()
+def test_deep_sleep_lora_preserves_non_lora_tensors():
+    """zero_lora_state must NOT zero non-LoRA unregistered tensors.
+
+    LogitsProcessorWithLoRA.sharded_to_full_mapping_gpu is an unregistered
+    tensor used for TP>1 logit reordering. Zeroing it would cause logits
+    to be indexed from position 0 repeatedly. This test validates that
+    _LORA_TENSOR_ATTRS is correctly scoped.
+    """
+    from vllm.lora.layers.base import BaseLayerWithLoRA
+
+    # Verify the explicit attr list does not include non-LoRA tensors
+    assert "sharded_to_full_mapping_gpu" not in BaseLayerWithLoRA._LORA_TENSOR_ATTRS
+    assert "indices" not in BaseLayerWithLoRA._LORA_TENSOR_ATTRS
+
+    # Functional check: sleep/wake/reload should not break generation
+    llm = LLM(MODEL,
+              enable_sleep_mode=True,
+              enable_lora=True,
+              max_lora_rank=8,
+              enforce_eager=True)
+
+    output_before = llm.generate(PROMPT, SAMPLING_PARAMS)
+    _sleep_wake_reload(llm)
+    output_after = llm.generate(PROMPT, SAMPLING_PARAMS)
+
+    assert output_before[0].outputs[0].text == output_after[0].outputs[0].text
+
+
+# ---- Multi-GPU (TP>1) test ----
+
+
+@multi_gpu_test(num_gpus=2)
+def test_deep_sleep_lora_tp2():
+    """Level-2 sleep/wake/reload with LoRA at TP=2.
+
+    Validates that:
+    - reload_weights succeeds under tensor parallelism
+    - sharded_to_full_mapping_gpu is preserved (not zeroed)
+    - Output is deterministic across sleep/wake cycles
+    """
+    llm = LLM(MODEL,
+              enable_sleep_mode=True,
+              enable_lora=True,
+              max_lora_rank=8,
+              enforce_eager=True,
+              tensor_parallel_size=2)
+
+    output_before = llm.generate(PROMPT, SAMPLING_PARAMS)
+    _sleep_wake_reload(llm)
+    output_after = llm.generate(PROMPT, SAMPLING_PARAMS)
+
+    assert output_before[0].outputs[0].text == output_after[0].outputs[0].text
+
+    # Multi-cycle at TP=2
+    for _ in range(2):
+        _sleep_wake_reload(llm)
+    output_final = llm.generate(PROMPT, SAMPLING_PARAMS)
+    assert output_before[0].outputs[0].text == output_final[0].outputs[0].text

--- a/vllm/lora/layers/base.py
+++ b/vllm/lora/layers/base.py
@@ -84,6 +84,22 @@ class BaseLayerWithLoRA(nn.Module):
                     if isinstance(t, torch.Tensor) and t.device.type != "meta":
                         t.zero_()
 
+    def restore_non_parameter_tensors(self) -> None:
+        """Restore non-LoRA GPU tensors from their CPU sources after sleep.
+
+        Some LoRA layers hold GPU tensors (e.g. sharded_to_full_mapping_gpu)
+        that are neither nn.Parameters nor LoRA stacked tensors. After
+        level-2 sleep their GPU memory contains undefined data. This method
+        rebuilds them from their CPU-side sources.
+        """
+        cpu_mapping = getattr(self, "sharded_to_full_mapping", None)
+        if cpu_mapping is not None:
+            self.sharded_to_full_mapping_gpu = torch.tensor(
+                cpu_mapping,
+                device=getattr(self, "device", "cuda"),
+                dtype=torch.long,
+            )
+
     @overload
     def slice_lora_a(
         self, lora_a: list[torch.Tensor | None]

--- a/vllm/lora/layers/base.py
+++ b/vllm/lora/layers/base.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, overload
 
 import torch
@@ -14,6 +15,75 @@ if TYPE_CHECKING:
 
 
 class BaseLayerWithLoRA(nn.Module):
+    # Known LoRA stacked tensor attribute names allocated on GPU.
+    # These are plain attributes (not nn.Parameter or registered buffers)
+    # that must be explicitly re-zeroed after level-2 sleep/wake.
+    _LORA_TENSOR_ATTRS = (
+        "lora_a_stacked",
+        "lora_b_stacked",
+        "lora_embedding_a",
+        "lora_embedding_b",
+    )
+
+    def named_modules(
+        self,
+        memo: set[nn.Module] | None = None,
+        prefix: str = "",
+        remove_duplicate: bool = True,
+    ) -> Iterable[tuple[str, nn.Module]]:
+        """Make the LoRA wrapper transparent in the module tree.
+
+        LoRA wrapping moves parameters under ``base_layer``
+        (e.g. ``qkv_proj.weight`` -> ``qkv_proj.base_layer.weight``).
+        This override flattens ``base_layer`` out so that
+        ``named_parameters()`` returns the original checkpoint names.
+        """
+        if memo is None:
+            memo = set()
+        if remove_duplicate and self in memo:
+            return
+        memo.add(self)
+        yield prefix, self
+
+        base: nn.Module | None = getattr(self, "base_layer", None)
+        if base is not None:
+            if not (remove_duplicate and base in memo):
+                memo.add(base)
+                yield prefix, base
+                for name, child in base._modules.items():
+                    if child is not None:
+                        child_prefix = f"{prefix}.{name}" if prefix else name
+                        yield from child.named_modules(
+                            memo, child_prefix, remove_duplicate
+                        )
+
+        for name, child in self._modules.items():
+            if name == "base_layer" or child is None:
+                continue
+            child_prefix = f"{prefix}.{name}" if prefix else name
+            yield from child.named_modules(
+                memo, child_prefix, remove_duplicate
+            )
+
+    def zero_lora_state(self) -> None:
+        """Re-zero LoRA stacked tensors after level-2 sleep/wake.
+
+        These tensors are plain attributes (not nn.Parameter or registered
+        buffers). After level-2 sleep, their GPU memory is discarded and
+        remapped with undefined contents. reload_weights() only restores
+        parameters and buffers, so these must be explicitly re-zeroed.
+        """
+        for attr_name in self._LORA_TENSOR_ATTRS:
+            val = getattr(self, attr_name, None)
+            if val is None:
+                continue
+            if isinstance(val, torch.Tensor) and val.device.type != "meta":
+                val.zero_()
+            elif isinstance(val, (tuple, list)):
+                for t in val:
+                    if isinstance(t, torch.Tensor) and t.device.type != "meta":
+                        t.zero_()
+
     @overload
     def slice_lora_a(
         self, lora_a: list[torch.Tensor | None]

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5509,13 +5509,16 @@ class GPUModelRunner(
                 param.copy_(loaded_weight)
                 loaded_weights.add(name)
 
-        # Re-zero LoRA stacked tensors that are not restored by reload.
-        # After level-2 sleep their GPU memory contains undefined data.
+        # Re-zero LoRA stacked tensors that are not restored by reload,
+        # and restore non-parameter GPU tensors (e.g. sharded_to_full_mapping_gpu)
+        # from their CPU sources. After level-2 sleep their GPU memory
+        # contains undefined data.
         if self.lora_config:
             from vllm.lora.layers.base import BaseLayerWithLoRA
             for module in model.modules():
                 if isinstance(module, BaseLayerWithLoRA):
                     module.zero_lora_state()
+                    module.restore_non_parameter_tensors()
 
         # logging and validation
         counter_after_reloading = time.perf_counter()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5509,6 +5509,14 @@ class GPUModelRunner(
                 param.copy_(loaded_weight)
                 loaded_weights.add(name)
 
+        # Re-zero LoRA stacked tensors that are not restored by reload.
+        # After level-2 sleep their GPU memory contains undefined data.
+        if self.lora_config:
+            from vllm.lora.layers.base import BaseLayerWithLoRA
+            for module in model.modules():
+                if isinstance(module, BaseLayerWithLoRA):
+                    module.zero_lora_state()
+
         # logging and validation
         counter_after_reloading = time.perf_counter()
         diff_seconds = counter_after_reloading - counter_before_reloading


### PR DESCRIPTION
## Summary

Closes #39934. Listed as P0 in the RL sleep/wake correctness tracker #48310.

Level-2 sleep followed by `reload_weights()` crashes with `KeyError` when `enable_lora=True`. Two root causes, both fixed in this PR:

1. LoRA wrapping moves parameters under `base_layer` (`qkv_proj.weight` → `qkv_proj.base_layer.weight`), so checkpoint keys don't match `named_parameters()` during reload.
2. LoRA stacked tensors (`lora_a_stacked`, `lora_b_stacked`) are plain attributes not restored by `reload_weights()`. After level-2 sleep their GPU memory contains undefined data, silently corrupting output.

## What Changed

**`vllm/lora/layers/base.py`** (+70 lines):
- Override `named_modules()` to flatten `base_layer` out of the module tree, restoring original checkpoint parameter names.
- Add `zero_lora_state()` with an explicit `_LORA_TENSOR_ATTRS` list to re-zero stacked tensors after reload.

**`vllm/v1/worker/gpu_model_runner.py`** (+8 lines):
- Call `zero_lora_state()` on all `BaseLayerWithLoRA` modules at the end of `reload_weights()` when `lora_config` is set.

**`tests/v1/worker/test_deep_sleep_lora.py`** (new, 60 lines):
- Single-cycle and multi-cycle (3×) sleep/wake/reload regression tests.

## Reproduction

```python
from vllm import LLM, SamplingParams

llm = LLM("Qwen/Qwen3-0.6B",
           enable_lora=True, max_lora_rank=8,
           enable_sleep_mode=True, enforce_eager=True)

llm.generate("Hello", SamplingParams(temperature=0, max_tokens=10))
llm.sleep(level=2)
llm.wake_up(tags=["weights"])
llm.collective_rpc("reload_weights")  # KeyError: 'embed_tokens.weight'
```

## Validation

Tested on A100-80GB, vLLM 0.24.0, FlashInfer 0.6.12.

**Without patch** — `KeyError: 'embed_tokens.weight'` on `reload_weights()`.

**With patch** (Qwen/Qwen3-0.6B):
```
Before: " Answer! I'm a bit confused about the problem"
After:  " Answer! I'm a bit confused about the problem"
Match:  True
3-cycle: True
```

Output is identical across single and 3× consecutive sleep/wake cycles.

## Related

- #39935 — prior fix attempt (same approach, stale since April, `needs-rebase`). This PR adopts the Gemini review feedback: uses an explicit `_LORA_TENSOR_ATTRS` list instead of scanning `vars(self)`.
- #48310 — RL sleep/wake correctness tracker (this issue is listed as P0)
- #48311 — Sleep/Wake/Drain lifecycle RFC