### PR TITLE
[Bugfix][Frontend] Flatten list message content when echoing in streaming chat completions

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -2307,3 +2307,70 @@ async def test_streaming_n_gt1_independent_tool_parsers():
             f"Choice {choice_idx}: expected finish_reason='tool_calls', "
             f"got '{reasons[0]}'"
         )
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_echo_with_list_content():
+    """echo=true must not break streaming when the last conversation message
+    content is a list of text parts (the "openai" chat template content
+    format used for multimodal models).
+
+    Regression: the streaming echo path passed the list straight into
+    ``DeltaMessage.content`` (a str-only field), raising a pydantic
+    ValidationError that surfaced as an in-stream error chunk, while the
+    identical non-streaming request succeeded and echoed the flattened text.
+    """
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+
+    serving_chat = _build_serving_chat(mock_engine)
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "What is 1+1?"}],
+        echo=True,
+        stream=True,
+        add_generation_prompt=False,
+    )
+    conversation = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is"},
+                {"type": "text", "text": "1+1?"},
+            ],
+        }
+    ]
+
+    chunks: list[dict[str, Any]] = []
+    async for line in serving_chat.chat_completion_stream_generator(
+        request,
+        _single_request_output(_make_metrics_request_output(metrics=None)),
+        "chatcmpl-test-id",
+        MODEL_NAME,
+        conversation=conversation,
+        tokenizer=MagicMock(),
+        request_metadata=RequestResponseMetadata(request_id="chatcmpl-test-id"),
+    ):
+        line = line.strip()
+        if not line.startswith("data: "):
+            continue
+        payload = line[len("data: ") :]
+        if payload != "[DONE]":
+            chunks.append(json.loads(payload))
+
+    assert chunks, "Expected streamed chunks"
+    assert all("error" not in chunk for chunk in chunks), (
+        f"Streaming echo produced an error chunk: {chunks}"
+    )
+    streamed_content = "".join(
+        chunk["choices"][0]["delta"].get("content") or ""
+        for chunk in chunks
+        if chunk.get("choices")
+    )
+    # the echoed input must be flattened the same way as in the
+    # non-streaming path
+    assert "What is\n1+1?" in streamed_content

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -535,6 +535,10 @@ class OpenAIServingChat(GenerateBaseServing):
                             and conversation[-1].get("role") == role
                         ):
                             last_msg_content = conversation[-1]["content"] or ""
+                        if isinstance(last_msg_content, list):
+                            last_msg_content = "\n".join(
+                                msg["text"] for msg in last_msg_content
+                            )
 
                         if last_msg_content:
                             for i in range(num_choices):


### PR DESCRIPTION
FIX #48338

## Purpose

With `"echo": true`, the last conversation message's content can be a list of text parts when the chat template content format resolves to `"openai"` (multimodal models). The non-streaming path flattens that list before building the response; the streaming path passed the list straight into `DeltaMessage.content` (`str | None`), raising a pydantic `ValidationError` that the stream's generic exception handler turned into an in-stream error chunk and a dead stream. The identical non-streaming request succeeds and echoes the flattened text.

This PR applies the same list flattening in the streaming echo path (4 lines), making both paths behave identically. The streaming code already annotated the variable as `str | list[dict[str, str]]` — the list case was documented but unhandled.

**Duplicate check:** searched open PRs/issues for echo/streaming/list-content/DeltaMessage terms; #47815 (streamed completion logprob offsets with echo) is the closest and is unrelated (completions API, logprobs offsets). No open PR touches this path.

## Test Plan

```bash
pytest tests/entrypoints/openai/chat_completion/test_serving_chat.py -k "not TestGPTOSS"
```

Adds `test_chat_stream_echo_with_list_content`, driving `chat_completion_stream_generator` directly with list message content (same harness as the existing per-request-metrics tests — no GPU or model needed).

## Test Result

On the parent commit the new test fails: the stream contains an error chunk (`ValidationError: ... content - Input should be a valid string`) and no echoed content. With this change:

```text
34 passed, 10 deselected in 242.31s
```

(The 10 deselected tests are the `TestGPTOSS*` classes, which launch a real gpt-oss-20b server and only run in CI.) Linux/CPU, Python 3.12. `pre-commit` (ruff check/format, mypy, typos) passes on the changed files.

---

*Disclosure per the [contributing guidelines](https://docs.vllm.ai/en/latest/contributing/#ai-assisted-contributions): this PR was developed with AI assistance (Claude); commits carry a `Co-authored-by` trailer. I reviewed the changes and ran the tests above locally.*
