### PR TITLE
[Bugfix] Disable FA3 AOT scheduling for spec-decode proposer

### DIFF
--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -583,6 +583,7 @@ def build_attn_metadata(
     for_cudagraph_capture: bool = False,
     causal: bool | torch.Tensor | Mapping[int, bool] = True,
     rswa_prefix_lens: torch.Tensor | None = None,
+    fast_build: bool = False,
 ) -> dict[str, Any]:
     seq_lens = seq_lens[:num_reqs]
     if dcp_local_seq_lens is not None:
@@ -642,6 +643,7 @@ def build_attn_metadata(
                 metadata = attn_metadata_builder.build(
                     common_prefix_len=0,
                     common_attn_metadata=common_attn_metadata,
+                    fast_build=fast_build,
                     **attn_metadata_extra_kwargs,
                 )
             for layer_name in attn_group.layer_names:

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -231,6 +231,7 @@ class DraftModelSpeculator(BaseSpeculator):
             slot_mappings=slot_mappings,
             kv_cache_config=self.kv_cache_config,
             causal=causal,
+            fast_build=True,
         )
         return attn_metadata
 


### PR DESCRIPTION
## Summary

Fixes [this](https://gist.github.com/elvircrn/70adb4b040fe9f6dca38a3116986d18c.).

- Pass `fast_build=True` from the speculator through `build_attn_metadata()` so FA3 skips AOT scheduling for draft model attention
- `get_scheduler_metadata` hardcodes `is_varlen=true` while `mha_fwd` derives it from actual tensor shapes — this divergence causes `metadata_size` mismatch and a `CHECK_SHAPE` crash on Hopper GPUs with spec-decode
- `fast_build=True` makes `scheduler_metadata=None` so `mha_fwd` allocates its own internally, avoiding the mismatch

Fixes #48221

## Test plan

- [x] `pre-commit run ruff-check --all-files` passes
- [ ] Verify DSpark spec-decode with FA3 on Hopper no longer crashes with `scheduler_metadata must have shape (metadata_size)`

AI assistance was used. Not duplicating an existing PR — no open PRs address this specific crash path.