### PR TITLE
[Bugfix][Tool Parser] DeepSeek V3: don't truncate final streamed tool arguments that don't end with '"}'

### DIFF
--- a/tests/tool_parsers/test_deepseekv3_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv3_tool_parser.py
@@ -90,3 +90,97 @@ class TestDeepSeekV3ToolParser(ToolParserTests):
                 ),
             },
         )
+
+
+TOOL_CALLS_BEGIN = "<｜tool▁calls▁begin｜>"
+TOOL_CALLS_END = "<｜tool▁calls▁end｜>"
+TOOL_CALL_BEGIN = "<｜tool▁call▁begin｜>"
+TOOL_CALL_END = "<｜tool▁call▁end｜>"
+TOOL_SEP = "<｜tool▁sep｜>"
+
+
+@pytest.fixture(scope="module")
+def deepseekv3_tokenizer():
+    return get_tokenizer("deepseek-ai/DeepSeek-V3")
+
+
+def _stream_deltas(tokenizer, deltas):
+    """Drive the streaming parser with explicit multi-token text deltas,
+    as produced by async scheduling / stream_interval > 1."""
+    from vllm.entrypoints.openai.chat_completion.protocol import (
+        ChatCompletionRequest,
+    )
+    from vllm.tool_parsers.deepseekv3_tool_parser import DeepSeekV3ToolParser
+
+    parser = DeepSeekV3ToolParser(tokenizer)
+    request = ChatCompletionRequest(messages=[], model="test-model")
+
+    name = None
+    args = ""
+    previous_text = ""
+    previous_ids: list[int] = []
+    for delta_text in deltas:
+        delta_ids = tokenizer.encode(delta_text, add_special_tokens=False)
+        current_text = previous_text + delta_text
+        current_ids = previous_ids + delta_ids
+        delta_message = parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=delta_text,
+            previous_token_ids=previous_ids,
+            current_token_ids=current_ids,
+            delta_token_ids=delta_ids,
+            request=request,
+        )
+        if delta_message is not None:
+            for tool_call in delta_message.tool_calls:
+                if tool_call.function:
+                    if tool_call.function.name:
+                        name = tool_call.function.name
+                    if tool_call.function.arguments:
+                        args += tool_call.function.arguments
+        previous_text = current_text
+        previous_ids = current_ids
+    return name, args
+
+
+@pytest.mark.parametrize(
+    "final_args_deltas,expected_args",
+    [
+        # arguments ending with a number: the final characters and the
+        # tool-call end token arrive in the same delta
+        (['{"code": 1', "23}\n```" + TOOL_CALL_END], '{"code": 123}'),
+        # arguments ending with a nested object
+        (
+            ['{"a": {"b": "x', '"}}\n```' + TOOL_CALL_END],
+            '{"a": {"b": "x"}}',
+        ),
+        # arguments ending with a boolean
+        (['{"flag": ', "true}\n```" + TOOL_CALL_END], '{"flag": true}'),
+        # control: arguments ending with a quoted string (worked before)
+        (['{"city": "Tok', 'yo"}\n```' + TOOL_CALL_END], '{"city": "Tokyo"}'),
+    ],
+    ids=["number_tail", "nested_object_tail", "boolean_tail", "string_tail"],
+)
+def test_streaming_final_args_chunk_shares_delta_with_end_token(
+    deepseekv3_tokenizer, final_args_deltas, expected_args
+):
+    """The last characters of the arguments arriving in the same delta as
+    the tool-call end token must not be dropped, regardless of what
+    character the arguments end with.
+
+    Regression: the closing branch reconstructed the unstreamed tail with
+    a `"}`-based heuristic, dropping the tail entirely for arguments
+    ending in a number/boolean/null and truncating nested objects.
+    """
+    deltas = [
+        TOOL_CALLS_BEGIN + TOOL_CALL_BEGIN + "function" + TOOL_SEP + "get_code\n"
+        "```json\n",
+        *final_args_deltas,
+        TOOL_CALLS_END,
+    ]
+
+    name, args = _stream_deltas(deepseekv3_tokenizer, deltas)
+
+    assert name == "get_code"
+    assert args == expected_args

--- a/vllm/tool_parsers/deepseekv3_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv3_tool_parser.py
@@ -213,17 +213,26 @@ class DeepSeekV3ToolParser(ToolParser):
                 if self.prev_tool_call_arr is None or len(self.prev_tool_call_arr) == 0:
                     logger.debug("attempting to close tool call, but no tool call")
                     return None
-                diff = self.prev_tool_call_arr[self.current_tool_id].get("arguments")
-                if diff:
-                    diff = (
-                        diff.encode("utf-8").decode("unicode_escape")
-                        if diff is str
-                        else diff
-                    )
-                    if '"}' not in delta_text:
+                if self.prev_tool_call_arr[self.current_tool_id].get("arguments"):
+                    # the tool call is complete: extract the final arguments
+                    # from the full tool call text and emit whatever has not
+                    # been streamed yet. Reconstructing the tail from
+                    # delta_text is not reliable, since the arguments need
+                    # not end with `"}` (numbers, booleans, null, arrays,
+                    # nested objects).
+                    expected_args = None
+                    if tool_call_portion is not None:
+                        matches = self.stream_tool_call_portion_regex.match(
+                            tool_call_portion
+                        )
+                        if matches:
+                            expected_args = matches.group("function_arguments")
+                    if expected_args is None:
                         return None
-                    end_loc = delta_text.rindex('"}')
-                    diff = delta_text[:end_loc] + '"}'
+                    already_streamed = self.streamed_args_for_tool[self.current_tool_id]
+                    diff = expected_args[len(already_streamed) :]
+                    if not diff:
+                        return None
                     logger.debug(
                         "Finishing tool and found diff that had not "
                         "been streamed yet: %s",


### PR DESCRIPTION
FIX #48342

## Purpose

When the final characters of tool arguments arrive in the same streamed delta as the `<｜tool▁call▁end｜>` token (async scheduling, `stream_interval > 1`), the DeepSeek V3 parser's closing branch reconstructed the unstreamed tail from `delta_text` assuming arguments always end with `"}`:

- arguments ending with a **number/boolean/null/array** → the tail was dropped entirely, clients received invalid truncated JSON (`{"code": 1` instead of `{"code": 123}`);
- arguments ending with a **nested object** → cut at the inner `"}`, dropping outer braces (`{"a": {"b": "x"}` instead of `{"a": {"b": "x"}}`);
- arguments ending with a quoted string worked, confirming the heuristic's exact boundary.

Instead of guessing from `delta_text`, this PR extracts the completed arguments from the full tool-call text with the existing `stream_tool_call_portion_regex` and emits exactly the not-yet-streamed part (`expected_args[len(already_streamed):]`). It also removes the dead `diff is str` branch (comparison against the type object, always `False`).

**Scope / duplicate check:** the V3.1 parser shares this heuristic but is partially reworked by open PR #38866, so this PR intentionally touches only the V3 parser (`deepseekv3_tool_parser.py`), which no open PR modifies. Also checked #47704 (V3.2/V4 whitespace deltas — different files) and #48001/#48006 (different layers).

## Test Plan

```bash
pytest tests/tool_parsers/test_deepseekv3_tool_parser.py
```

New parametrized streaming test places the final argument characters and the end token in one delta, covering number/boolean/nested-object tails plus a quoted-string control. The existing common tests (one token per delta) cover the unchanged paths.

## Test Result

On the parent commit, the three non-control cases fail exactly as described; the control passes. With this change:

```text
20 passed, 1 xfailed in 24.59s
```

(The xfail is a pre-existing, documented malformed-input case.) Linux/CPU, Python 3.12, real DeepSeek-V3 tokenizer. `pre-commit` (ruff check/format, mypy, typos) passes on the changed files.

---

*Disclosure per the [contributing guidelines](https://docs.vllm.ai/en/latest/contributing/#ai-assisted-contributions): this PR was developed with AI assistance (Claude); commits carry a `Co-authored-by` trailer. I reviewed the changes and ran the tests above locally.*
