### PR TITLE
Revert "[BugFix] Fix packed HND KV cache reshape for FlashAttention" (#47314)

### DIFF
--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -218,7 +218,7 @@ def _reshape_attention_kv_cache(
         kv_cache = (
             kv_raw_tensor.view(-1, block_stride)[:, offset : offset + page_bytes]
             .view(dtype)
-            .view(permuted_kv_cache_shape)
+            .view(kv_cache_shape)
         )
     elif kv_cache_spec.page_size_padded is not None:
         # Use a strided view to skip the padding between physical pages.


### PR DESCRIPTION
## Revert of https://github.com/vllm-project/vllm/pull/47314

**Reason:** This PR is suspected of causing 1 new CI failure in [build #77599](https://buildkite.com/vllm/ci/builds/77599).

**Failed test:**
- `e2e Core (1 GPU)` — `test_cascade_attention[FLASH_ATTN]` assertion error: output text mismatch when using FlashAttention cascade attention backend

**Details:** PR #47314 modified `vllm/v1/worker/gpu/attn_utils.py` to fix packed HND KV cache reshape for FlashAttention. After this change, the cascade attention test produces slightly different LLM output ("I can help you with that" vs "I can help with that"), indicating the attention computation may have changed behavior.

---
*Auto-generated by CI failure analyzer.*