### PR TITLE
Revert "[Misc] Use meta tensor for KV cache stride calculation" (#47316)

### DIFF
--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -238,7 +238,7 @@ def _reshape_attention_kv_cache(
         page_stride = kv_cache_spec.page_size_bytes // dtype_size
 
         num_blocks_dim = inv_order[0]
-        strides = list(torch.empty(permuted_kv_cache_shape, device="meta").stride())
+        strides = list(torch.empty(permuted_kv_cache_shape).stride())
         strides[num_blocks_dim] = page_stride
 
         kv_cache = torch.as_strided(


### PR DESCRIPTION
## Revert of https://github.com/vllm-project/vllm/pull/47316

**Reason:** This PR is suspected of causing 1 new CI failure in [build #77599](https://buildkite.com/vllm/ci/builds/77599).

**Failed test:**
- `e2e Core (1 GPU)` — `test_cascade_attention[FLASH_ATTN]` assertion error: output text mismatch when using FlashAttention cascade attention backend

**Details:** PR #47316 modified `vllm/v1/worker/gpu/attn_utils.py` to use meta tensor for KV cache stride calculation. After this change, the cascade attention test produces slightly different LLM output, indicating the attention computation may have changed behavior. This PR and #47314 both modified the same file in this build range.

---
*Auto-generated by CI failure analyzer.*