### PR TITLE
[Bugfix][Tool Parser] InternLM2: stream tool calls that arrive whole in a single delta

### DIFF
--- a/tests/tool_parsers/test_internlm2_tool_parser.py
+++ b/tests/tool_parsers/test_internlm2_tool_parser.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -9,7 +10,9 @@ from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
+from tests.tool_parsers.utils import run_tool_extraction_streaming
 from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers.internlm2_tool_parser import Internlm2ToolParser
 
 
 class TestInternLM2ToolParser(ToolParserTests):
@@ -120,3 +123,38 @@ class TestInternLM2ToolParser(ToolParserTests):
                 ),
             },
         )
+
+    def test_streaming_complete_tool_call_single_delta(self, tokenizer):
+        """A tool call arriving whole in one delta (e.g. async scheduling or
+        stream_interval > 1) must emit both the name and the arguments;
+        previously only the name was emitted and the arguments were lost."""
+        parser = Internlm2ToolParser(tokenizer)
+        model_output = (
+            '<|action_start|><|plugin|>{"name": "get_weather", '
+            '"parameters": {"city": "Tokyo"}}<|action_end|>'
+        )
+
+        reconstructor = run_tool_extraction_streaming(parser, [model_output])
+
+        assert len(reconstructor.tool_calls) == 1
+        call = reconstructor.tool_calls[0]
+        assert call.function.name == "get_weather"
+        assert json.loads(call.function.arguments) == {"city": "Tokyo"}
+
+    def test_streaming_content_then_complete_tool_call_single_delta(self, tokenizer):
+        """Content preceding a complete tool call in the same delta must not
+        cause the tool call to be dropped; previously the parser emitted the
+        content and returned, losing the tool call entirely."""
+        parser = Internlm2ToolParser(tokenizer)
+        model_output = (
+            'Sure, let me check.<|action_start|><|plugin|>{"name": "get_weather", '
+            '"parameters": {"city": "Tokyo"}}<|action_end|>'
+        )
+
+        reconstructor = run_tool_extraction_streaming(parser, [model_output])
+
+        assert reconstructor.other_content == "Sure, let me check."
+        assert len(reconstructor.tool_calls) == 1
+        call = reconstructor.tool_calls[0]
+        assert call.function.name == "get_weather"
+        assert json.loads(call.function.arguments) == {"city": "Tokyo"}

--- a/vllm/tool_parsers/internlm2_tool_parser.py
+++ b/vllm/tool_parsers/internlm2_tool_parser.py
@@ -26,7 +26,7 @@ from vllm.tool_parsers.abstract_tool_parser import (
     Tool,
     ToolParser,
 )
-from vllm.tool_parsers.utils import extract_intermediate_diff
+from vllm.tool_parsers.utils import extract_intermediate_diff, is_complete_json
 
 logger = init_logger(__name__)
 
@@ -79,12 +79,19 @@ class Internlm2ToolParser(ToolParser):
         new_delta = current_text[last_pos:]
         text, action = new_delta.split("<|action_start|><|plugin|>")
 
-        if len(text) > 0:
-            self.position = self.position + len(text)
-            return DeltaMessage(content=text)
-
         action = action.strip()
         action = action.split("<|action_end|>".strip())[0]
+
+        content_prefix: str | None = None
+        if len(text) > 0:
+            self.position = self.position + len(text)
+            # if the tool call is not yet complete, emit the content now and
+            # keep parsing the tool call from later deltas; otherwise fall
+            # through, so that a tool call arriving whole in this same delta
+            # is not lost when no further deltas arrive
+            if not is_complete_json(action):
+                return DeltaMessage(content=text)
+            content_prefix = text
 
         # bit mask flags for partial JSON parsing. If the name hasn't been
         # sent yet, don't allow sending
@@ -109,20 +116,31 @@ class Internlm2ToolParser(ToolParser):
                 function_name = tool_call_arr.get("name")
                 if function_name:
                     self.current_tool_id = self.current_tool_id + 1
+                    delta_function_call = DeltaFunctionCall(name=function_name)
+                    streamed_args = ""
+                    cur_arguments = self.get_arguments(tool_call_arr)
+                    # if the whole tool call arrived in a single delta (e.g.
+                    # with async scheduling or stream_interval > 1), emit the
+                    # complete arguments together with the name, since no
+                    # further deltas may arrive
+                    if cur_arguments is not None and is_complete_json(action):
+                        streamed_args = json.dumps(cur_arguments, ensure_ascii=False)
+                        delta_function_call.arguments = streamed_args
                     delta = DeltaMessage(
+                        content=content_prefix,
                         tool_calls=[
                             DeltaToolCall(
                                 index=self.current_tool_id,
                                 type="function",
                                 id=make_tool_call_id(),
-                                function=DeltaFunctionCall(
-                                    name=function_name
-                                ).model_dump(exclude_none=True),
+                                function=delta_function_call.model_dump(
+                                    exclude_none=True
+                                ),
                             )
-                        ]
+                        ],
                     )
                     self.current_tool_name_sent = True
-                    self.streamed_args_for_tool.append("")
+                    self.streamed_args_for_tool.append(streamed_args)
                 else:
                     delta = None
             # now we know we're on the same tool call and we're streaming


### PR DESCRIPTION
FIX #48347

## Purpose

When an entire tool call arrives in one streamed delta (async scheduling, `stream_interval > 1`, or a short message emitted at once), the InternLM2 streaming parser lost data in two ways:

1. **Arguments lost**: the name-sending branch emitted only the function name and returned; with no further deltas arriving, the arguments were never streamed. Clients received a tool call with empty arguments while the non-streaming parser extracted the full call.
2. **Whole tool call lost**: when assistant content preceded the tool call in the same delta, the parser emitted the content and returned immediately, dropping the tool call entirely.

Fix, following the approach of #47955 (gigachat3/granite) and #48295 (llama3_json/jamba/ernie45): when the tool-call JSON in the delta is already complete (`is_complete_json`), emit the name and the full arguments in one `DeltaMessage`, carrying any preceding content in the same message instead of returning early. Per-token streaming behavior is unchanged (at name-send time the JSON is still incomplete, so the old path runs).

**Duplicate check:** searched open PRs/issues for the InternLM2 parser — only #40115 (new Intern-S1 parser feature) exists, unrelated. The single-delta bug class is being fixed parser-by-parser (#47955, #46934, #48295); no open PR covers internlm2.

## Test Plan

```bash
pytest tests/tool_parsers/test_internlm2_tool_parser.py
```

Adds two streaming regression tests (whole call in one delta; content + whole call in one delta) using the file's existing vocab-patched gpt2 tokenizer — no downloads needed.

## Test Result

On the parent commit both new tests fail exactly as described. With this change:

```text
11 passed, 8 xfailed in 6.71s
```

The 8 xfailed are the pre-existing "InternLM2 streaming not fully implemented" markers — unchanged (no XPASS flips, i.e. no behavior change for per-token streaming). Linux/CPU, Python 3.12. `pre-commit` (ruff check/format, mypy, typos) passes on the changed files.

---

*Disclosure per the [contributing guidelines](https://docs.vllm.ai/en/latest/contributing/#ai-assisted-contributions): this PR was developed with AI assistance (Claude); commits carry a `Co-authored-by` trailer. I reviewed the changes and ran the tests above locally.*
