### PR TITLE
[Bugfix] YaRN RoPE: honor explicit attention_factor from the rope config

### DIFF
--- a/tests/kernels/core/test_pos_encoding.py
+++ b/tests/kernels/core/test_pos_encoding.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import math
 from collections.abc import Callable
 from itertools import product
 
@@ -191,3 +192,57 @@ def test_rope_module_cache(default_vllm_config):
         )
         # check if cache take effect
         assert id(rope) == rope_setting_id_map[str(setting)]
+
+
+def _get_yarn_rope(factor: float, attention_factor: float | None):
+    rope_parameters = {
+        "rope_type": "yarn",
+        "rope_theta": 10000,
+        "factor": factor,
+        "original_max_position_embeddings": 512,
+    }
+    if attention_factor is not None:
+        rope_parameters["attention_factor"] = attention_factor
+    return get_rope(
+        head_size=64,
+        max_position=int(512 * factor),
+        is_neox_style=True,
+        rope_parameters=rope_parameters,
+        dtype=torch.float32,
+    )
+
+
+def _yarn_output_at_position_zero(rope) -> torch.Tensor:
+    # At position 0 all rotation angles are zero, so the output is `query * mscale`.
+    positions = torch.zeros(1, dtype=torch.long)
+    query = torch.ones(1, 64, dtype=torch.float32)
+    out_query, _ = rope.forward_native(positions, query)
+    return out_query
+
+
+@pytest.mark.parametrize("attention_factor", [1.0, 0.5])
+@torch.inference_mode()
+def test_yarn_explicit_attention_factor(default_vllm_config, attention_factor):
+    rope = _get_yarn_rope(factor=8.0, attention_factor=attention_factor)
+    out_query = _yarn_output_at_position_zero(rope)
+    expected = torch.full_like(out_query, attention_factor)
+    torch.testing.assert_close(
+        out_query,
+        expected,
+        atol=get_default_atol(out_query),
+        rtol=get_default_rtol(out_query),
+    )
+
+
+@torch.inference_mode()
+def test_yarn_default_mscale(default_vllm_config):
+    factor = 8.0
+    rope = _get_yarn_rope(factor=factor, attention_factor=None)
+    out_query = _yarn_output_at_position_zero(rope)
+    expected = torch.full_like(out_query, 0.1 * math.log(factor) + 1.0)
+    torch.testing.assert_close(
+        out_query,
+        expected,
+        atol=get_default_atol(out_query),
+        rtol=get_default_rtol(out_query),
+    )

--- a/vllm/model_executor/layers/rotary_embedding/__init__.py
+++ b/vllm/model_executor/layers/rotary_embedding/__init__.py
@@ -271,6 +271,10 @@ def get_rope(
                 **extra_kwargs,
             )
         else:
+            # Forward HF's `attention_factor` (the final YaRN mscale) when set.
+            attention_factor = rope_parameters.get("attention_factor")
+            if attention_factor is not None:
+                extra_kwargs["attention_factor"] = attention_factor
             rotary_emb = YaRNScalingRotaryEmbedding(
                 head_size,
                 rotary_dim,

--- a/vllm/model_executor/layers/rotary_embedding/yarn_scaling_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/yarn_scaling_rope.py
@@ -29,6 +29,7 @@ class YaRNScalingRotaryEmbedding(RotaryEmbedding):
         beta_slow: int = 1,
         apply_yarn_scaling: bool = True,
         truncate: bool = True,
+        attention_factor: float | None = None,
     ) -> None:
         self.scaling_factor = scaling_factor
         self.extrapolation_factor = extrapolation_factor
@@ -36,12 +37,16 @@ class YaRNScalingRotaryEmbedding(RotaryEmbedding):
         self.beta_fast = beta_fast
         self.beta_slow = beta_slow
         self.truncate = truncate
-        # Get n-d magnitude scaling corrected for interpolation
-        self.mscale = (
-            float(yarn_get_mscale(self.scaling_factor) * attn_factor)
-            if apply_yarn_scaling
-            else float(attn_factor)
-        )
+        # HF supplies the final YaRN mscale as `attention_factor`; use it when set.
+        if attention_factor is not None:
+            self.mscale = float(attention_factor)
+        else:
+            # Get n-d magnitude scaling corrected for interpolation
+            self.mscale = (
+                float(yarn_get_mscale(self.scaling_factor) * attn_factor)
+                if apply_yarn_scaling
+                else float(attn_factor)
+            )
         super().__init__(
             head_size, rotary_dim, max_position_embeddings, base, is_neox_style, dtype
         )


### PR DESCRIPTION
> This replaces #46280, which was closed when its source fork was deleted. The original context remains there.

## Purpose

`get_rope()` builds the YaRN branch's keyword arguments from a whitelist that includes `attn_factor` but not `attention_factor` (`vllm/model_executor/layers/rotary_embedding/__init__.py`). HF stores the final YaRN magnitude scaling under `attention_factor` and applies it to cos/sin (`transformers/modeling_rope_utils.py::_compute_yarn_parameters`), while vLLM expresses the same quantity as `mscale = yarn_get_mscale(factor) * attn_factor` (`yarn_scaling_rope.py`). A config that sets `attention_factor` has the key silently dropped, vLLM falls back to `0.1 * ln(factor) + 1`, and the two stacks apply different magnitude scaling whenever the configured value differs from that fallback.

This PR lets `YaRNScalingRotaryEmbedding` accept `attention_factor` and use it as the mscale when present, matching transformers, and `get_rope` forwards it on the YaRN path. Configs without the key are unchanged; only the values baked into the cos/sin cache change. Scope is intentionally the explicit `attention_factor` on the plain YaRN path: the `mscale`/`mscale_all_dim` fallback and MRoPE-yarn are not covered here.

## Affected configs

When #46280 was opened (2026-06-21), the then-current `poolside/Laguna-XS.2` config ([revision f5f4885](https://huggingface.co/poolside/Laguna-XS.2/blob/f5f48854b62bd9bbe208dcaae6cd4b92ce4aa5da/config.json), committed 2026-06-18) set `factor=64, attention_factor=1.0`, so transformers applied 1.0 while vLLM applied 1.4158883. On 2026-07-14 poolside corrected the configs across their repos ([commit](https://huggingface.co/poolside/Laguna-XS.2/commit/69e3f4046616e40fb55ac54e0e2e6accbe5cadfe): "fix(rope): YaRN attention_factor is (0.1\*ln(factor)+1)\*attn_factor, not the bare multiplier"). The corrected values equal vLLM's fallback exactly, so for the canonical poolside repos this change is now numerically a no-op.

The divergence is still live in third-party requantizations that snapshotted an older config (`factor=32`, from before the 256K context bump): [RedHatAI/Laguna-XS.2-FP8](https://huggingface.co/RedHatAI/Laguna-XS.2-FP8/blob/main/config.json), [RedHatAI/Laguna-XS.2-NVFP4](https://huggingface.co/RedHatAI/Laguna-XS.2-NVFP4/blob/main/config.json) and [cyankiwi/Laguna-XS.2-AWQ-INT4](https://huggingface.co/cyankiwi/Laguna-XS.2-AWQ-INT4/blob/main/config.json) still carry `attention_factor=1.0`, where transformers applies 1.0 and vLLM main applies 1.3465736. More generally, transformers reads the documented key first and vLLM silently drops it, so any config that sets it away from the fallback gets divergent numerics between the two stacks.

## Related work

#48623 and #48629 address the broader #48621 `mscale`/`mscale_all_dim` and nested Llama 4 gaps. This PR is limited to honoring an explicit `attention_factor`; #48629 is stacked on it, while #48623 is independent and does not currently cover that explicit override.

## Test Plan

The earlier standalone `tests/model_executor/test_yarn_attention_factor.py` asserted the internal `.mscale` field. It is replaced by two tests in the existing `tests/kernels/core/test_pos_encoding.py` suite, asserting the output of `forward_native` on a `get_rope`-constructed module instead of internal fields. At position 0 all rotation angles are zero, so the output is exactly `query * mscale`, which makes the applied scaling observable:

- `test_yarn_explicit_attention_factor[1.0 / 0.5]`: an explicit `attention_factor` is the applied mscale.
- `test_yarn_default_mscale`: without the key, the applied mscale stays `0.1 * ln(factor) + 1`.

```
pytest tests/kernels/core/test_pos_encoding.py -k yarn
```

## Test Result

Local run on macOS CPU (torch 2.11.0, transformers 5.14.1):

```
3 passed, 385 deselected, 16 warnings in 0.60s
```

With the two source files reverted to `main` and the tests kept, `test_yarn_explicit_attention_factor[1.0]` and `[0.5]` fail while `test_yarn_default_mscale` passes. The tests exercise `forward_native` on CPU; I have no CUDA device locally, so the kernel paths were not run. The diff does not modify kernel code, only the mscale written into the cos/sin cache.
