### PR TITLE
[V1][LoRA] Version prefix-cache keys for local runtime LoRA reloads

### DIFF
--- a/tests/entrypoints/serve/lora/test_serving_models.py
+++ b/tests/entrypoints/serve/lora/test_serving_models.py
@@ -102,6 +102,50 @@ async def test_load_lora_adapter_duplicate():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip_global_cleanup
+async def test_load_lora_adapter_inplace_reload_updates_cache_key(tmp_path):
+    serving_models = await _async_serving_models_init()
+    adapter = tmp_path / "tenant-adapter"
+    adapter.mkdir()
+    weights = adapter / "adapter_model.safetensors"
+
+    weights.write_bytes(b"ADAPTER_A")
+    await serving_models.load_lora_adapter(
+        LoadLoRAAdapterRequest(lora_name="adapter1", lora_path=str(adapter))
+    )
+    first_lora = serving_models.lora_requests["adapter1"]
+
+    # Same name, SAME path, but different on-disk adapter contents (issue
+    # #42125): in-place reload reuses the lora_int_id, so only a
+    # content-derived identity can separate the two adapter versions.
+    weights.write_bytes(b"ADAPTER_B")
+    await serving_models.load_lora_adapter(
+        LoadLoRAAdapterRequest(
+            lora_name="adapter1", lora_path=str(adapter), load_inplace=True
+        )
+    )
+    second_lora = serving_models.lora_requests["adapter1"]
+
+    assert second_lora.lora_int_id == first_lora.lora_int_id
+    assert second_lora.lora_path == first_lora.lora_path
+    # Different contents -> different identity, so stale prefix-cache blocks
+    # computed with adapter A cannot be reused for adapter B.
+    assert second_lora.lora_cache_key != first_lora.lora_cache_key
+
+    # Reloading identical contents -> identical identity. A deterministic,
+    # content-derived key (not a per-process counter) preserves legitimate
+    # cache reuse and stays reproducible across API-server replicas.
+    weights.write_bytes(b"ADAPTER_A")
+    await serving_models.load_lora_adapter(
+        LoadLoRAAdapterRequest(
+            lora_name="adapter1", lora_path=str(adapter), load_inplace=True
+        )
+    )
+    third_lora = serving_models.lora_requests["adapter1"]
+    assert third_lora.lora_cache_key == first_lora.lora_cache_key
+
+
+@pytest.mark.asyncio
 async def test_unload_lora_adapter_success():
     serving_models = await _async_serving_models_init()
     request = LoadLoRAAdapterRequest(

--- a/tests/lora/test_cache_identity.py
+++ b/tests/lora/test_cache_identity.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.lora.cache_identity import (
+    compute_lora_cache_key,
+    ensure_lora_cache_key,
+    is_content_versioned,
+)
+from vllm.lora.request import LoRARequest
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def _write_adapter(
+    d, *, config: bytes, weights: bytes, name="adapter_model.safetensors"
+):
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "adapter_config.json").write_bytes(config)
+    (d / name).write_bytes(weights)
+    return str(d)
+
+
+def test_same_content_same_key(tmp_path):
+    # Reproducibility: identical contents -> identical key (cross-process safe).
+    a = _write_adapter(tmp_path / "a", config=b'{"r":16}', weights=b"W")
+    b = _write_adapter(tmp_path / "b", config=b'{"r":16}', weights=b"W")
+    assert compute_lora_cache_key(a) == compute_lora_cache_key(b)
+
+
+def test_changed_weights_change_key(tmp_path):
+    # The #42125 property: same path, different weight bytes -> different key.
+    d = tmp_path / "adapter"
+    p = _write_adapter(d, config=b'{"r":16}', weights=b"WEIGHTS_A")
+    key_a = compute_lora_cache_key(p)
+    (d / "adapter_model.safetensors").write_bytes(b"WEIGHTS_B")
+    key_b = compute_lora_cache_key(p)
+    assert key_a != key_b
+
+
+def test_changed_config_changes_key(tmp_path):
+    a = _write_adapter(tmp_path / "a", config=b'{"r":16}', weights=b"W")
+    b = _write_adapter(tmp_path / "b", config=b'{"r":32}', weights=b"W")
+    assert compute_lora_cache_key(a) != compute_lora_cache_key(b)
+
+
+def test_is_3d_flag_changes_key(tmp_path):
+    p = _write_adapter(tmp_path / "a", config=b'{"r":16}', weights=b"W")
+    assert compute_lora_cache_key(p, is_3d_lora_weight=False) != compute_lora_cache_key(
+        p, is_3d_lora_weight=True
+    )
+
+
+def test_tensorizer_config_changes_key(tmp_path):
+    p = _write_adapter(tmp_path / "a", config=b'{"r":16}', weights=b"W")
+    # tensorizer_config_dict reroutes the weight source; differing configs must
+    # not alias even with the same lora_path.
+    k1 = compute_lora_cache_key(p, tensorizer_config_dict={"tensorizer_dir": "/x"})
+    k2 = compute_lora_cache_key(p, tensorizer_config_dict={"tensorizer_dir": "/y"})
+    assert k1 != k2
+
+
+def test_length_prefix_no_concat_collision(tmp_path):
+    # Without length-prefixed framing, (config=b"AB", weights=b"C") and
+    # (config=b"A", weights=b"BC") would hash the same byte stream.
+    a = _write_adapter(tmp_path / "a", config=b"AB", weights=b"C")
+    b = _write_adapter(tmp_path / "b", config=b"A", weights=b"BC")
+    assert compute_lora_cache_key(a) != compute_lora_cache_key(b)
+
+
+def test_missing_sources_fall_back_to_path(tmp_path):
+    # Unreadable/empty path -> deterministic path-only identity; different
+    # paths differ, identical path matches.
+    p1 = str(tmp_path / "nope-1")
+    p2 = str(tmp_path / "nope-2")
+    assert compute_lora_cache_key(p1) == compute_lora_cache_key(p1)
+    assert compute_lora_cache_key(p1) != compute_lora_cache_key(p2)
+
+
+def test_weight_source_precedence_safetensors_over_bin(tmp_path):
+    # The loader prefers adapter_model.safetensors over .bin; the identity must
+    # mirror that, so a change to the lower-precedence .bin is invisible.
+    d = tmp_path / "a"
+    d.mkdir()
+    (d / "adapter_config.json").write_bytes(b'{"r":16}')
+    (d / "adapter_model.safetensors").write_bytes(b"ST")
+    (d / "adapter_model.bin").write_bytes(b"BIN1")
+    k1 = compute_lora_cache_key(str(d))
+    (d / "adapter_model.bin").write_bytes(b"BIN2")
+    assert compute_lora_cache_key(str(d)) == k1
+
+
+def test_weight_source_bin_only_tracks_bin(tmp_path):
+    d = tmp_path / "a"
+    d.mkdir()
+    (d / "adapter_config.json").write_bytes(b'{"r":16}')
+    (d / "adapter_model.bin").write_bytes(b"BIN_A")
+    k1 = compute_lora_cache_key(str(d))
+    (d / "adapter_model.bin").write_bytes(b"BIN_B")
+    assert compute_lora_cache_key(str(d)) != k1
+
+
+def test_ensure_fills_when_missing(tmp_path):
+    p = _write_adapter(tmp_path / "a", config=b'{"r":16}', weights=b"W")
+    req = LoRARequest(lora_name="x", lora_int_id=1, lora_path=p)
+    assert req.lora_cache_key is None
+    ensure_lora_cache_key(req)
+    assert req.lora_cache_key == compute_lora_cache_key(p)
+
+
+def test_ensure_noop_when_present(tmp_path):
+    p = _write_adapter(tmp_path / "a", config=b'{"r":16}', weights=b"W")
+    req = LoRARequest(
+        lora_name="x", lora_int_id=1, lora_path=p, lora_cache_key="preset"
+    )
+    ensure_lora_cache_key(req)
+    assert req.lora_cache_key == "preset"
+
+
+def test_config_canonicalization_ignores_formatting(tmp_path):
+    # Same JSON content, different whitespace / key order -> same identity.
+    a = _write_adapter(tmp_path / "a", config=b'{"r": 16, "alpha": 32}', weights=b"W")
+    b = _write_adapter(tmp_path / "b", config=b'{"alpha":32,"r":16}', weights=b"W")
+    assert compute_lora_cache_key(a) == compute_lora_cache_key(b)
+
+
+def test_relative_path_is_path_only(tmp_path, monkeypatch):
+    # A relative path must NOT hash on-disk contents (worker may resolve it from
+    # a different CWD); it degrades to a deterministic path-only identity.
+    _write_adapter(tmp_path / "adapter", config=b'{"r":16}', weights=b"WEIGHTS_A")
+    monkeypatch.chdir(tmp_path)
+    k1 = compute_lora_cache_key("adapter")
+    (tmp_path / "adapter" / "adapter_model.safetensors").write_bytes(b"WEIGHTS_B")
+    # content changed but the relative path is path-only -> key unchanged
+    assert compute_lora_cache_key("adapter") == k1
+
+
+def test_is_content_versioned(tmp_path, monkeypatch):
+    p = _write_adapter(tmp_path / "a", config=b'{"r":16}', weights=b"W")
+    assert is_content_versioned(p) is True
+    assert (
+        is_content_versioned(str(tmp_path / "missing")) is False
+    )  # absolute, no files
+    monkeypatch.chdir(tmp_path)
+    assert is_content_versioned("a") is False  # relative -> path-only
+
+
+def test_ensure_handles_none():
+    ensure_lora_cache_key(None)  # must not raise

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -80,6 +80,7 @@ def make_request(
     mm_hashes: list[str] | None = None,
     cache_salt: str | None = None,
     prompt_embeds: torch.Tensor | None = None,
+    lora_request: LoRARequest | None = None,
 ):
     mm_features = []
     if mm_positions is not None:
@@ -102,7 +103,7 @@ def make_request(
         mm_features=mm_features if mm_features else None,
         sampling_params=sampling_params,
         pooling_params=None,
-        lora_request=None,
+        lora_request=lora_request,
         cache_salt=cache_salt,
         block_hasher=get_request_block_hasher(block_size, hash_fn),
         prompt_embeds=prompt_embeds,
@@ -638,6 +639,7 @@ def test_generate_block_hash_extra_keys_different_prompt_embeds():
     assert extra_keys1 != extra_keys2
 
 
+@pytest.mark.skip_global_cleanup
 def test_generate_block_hash_extra_keys_lora():
     request = make_request(
         request_id="0",
@@ -649,11 +651,96 @@ def test_generate_block_hash_extra_keys_lora():
     )
 
     extra_keys, _ = generate_block_hash_extra_keys(request, 0, 3, 0)
-    assert extra_keys == ("test_lora_adapter",)
+    assert extra_keys == (
+        ("lora", "test_lora_adapter"),
+        ("lora_identity", "/path/to/lora"),
+    )
+
+    request.lora_request = LoRARequest(
+        lora_name="test_lora_adapter",
+        lora_int_id=1,
+        lora_path="/path/to/lora",
+        lora_cache_key="load-1",
+    )
+
+    extra_keys, _ = generate_block_hash_extra_keys(request, 0, 3, 0)
+    assert extra_keys == (("lora", "test_lora_adapter"), ("lora_identity", "load-1"))
 
     request.lora_request = None
     extra_keys, _ = generate_block_hash_extra_keys(request, 0, 3, 0)
     assert extra_keys is None
+
+
+@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor])
+@pytest.mark.skip_global_cleanup
+def test_hash_tokens_same_lora_name_different_path(hash_fn):
+    lora_a = LoRARequest(lora_name="tenant", lora_int_id=1, lora_path="/path/to/lora-a")
+    lora_b = LoRARequest(lora_name="tenant", lora_int_id=1, lora_path="/path/to/lora-b")
+    request1 = make_request(
+        request_id="0",
+        prompt_token_ids=[_ for _ in range(6)],
+        block_size=3,
+        hash_fn=hash_fn,
+        lora_request=lora_a,
+    )
+    request2 = make_request(
+        request_id="1",
+        prompt_token_ids=[_ for _ in range(6)],
+        block_size=3,
+        hash_fn=hash_fn,
+        lora_request=lora_b,
+    )
+    request3 = make_request(
+        request_id="2",
+        prompt_token_ids=[_ for _ in range(6)],
+        block_size=3,
+        hash_fn=hash_fn,
+        lora_request=lora_a,
+    )
+
+    assert request1.block_hashes != request2.block_hashes
+    assert request1.block_hashes == request3.block_hashes
+
+
+@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor])
+@pytest.mark.skip_global_cleanup
+def test_hash_tokens_same_lora_path_different_cache_key(hash_fn):
+    lora_load_1 = LoRARequest(
+        lora_name="tenant",
+        lora_int_id=1,
+        lora_path="/path/to/lora",
+        lora_cache_key="load-1",
+    )
+    lora_load_2 = LoRARequest(
+        lora_name="tenant",
+        lora_int_id=1,
+        lora_path="/path/to/lora",
+        lora_cache_key="load-2",
+    )
+    request1 = make_request(
+        request_id="0",
+        prompt_token_ids=[_ for _ in range(6)],
+        block_size=3,
+        hash_fn=hash_fn,
+        lora_request=lora_load_1,
+    )
+    request2 = make_request(
+        request_id="1",
+        prompt_token_ids=[_ for _ in range(6)],
+        block_size=3,
+        hash_fn=hash_fn,
+        lora_request=lora_load_2,
+    )
+    request3 = make_request(
+        request_id="2",
+        prompt_token_ids=[_ for _ in range(6)],
+        block_size=3,
+        hash_fn=hash_fn,
+        lora_request=lora_load_1,
+    )
+
+    assert request1.block_hashes != request2.block_hashes
+    assert request1.block_hashes == request3.block_hashes
 
 
 @pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor])

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -349,6 +349,100 @@ def test_prefill(hash_fn):
     )
 
 
+@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor])
+@pytest.mark.skip_global_cleanup
+def test_prefix_cache_separates_same_lora_name_different_path(hash_fn):
+    block_size = 16
+    manager = make_kv_cache_manager(
+        make_kv_cache_config(block_size, 11),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    token_ids = [i for i in range(3) for _ in range(block_size)] + [3] * 5
+    lora_a = LoRARequest(
+        lora_name="tenant", lora_int_id=1, lora_path="/path/to/lora-a"
+    )
+    lora_b_same_name = LoRARequest(
+        lora_name="tenant", lora_int_id=1, lora_path="/path/to/lora-b"
+    )
+
+    req_a = make_request("a", token_ids, block_size, hash_fn, lora_request=lora_a)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req_a)
+    assert computed_blocks.get_block_ids(allow_none=True) is None
+    assert num_computed_tokens == 0
+    blocks = manager.allocate_slots(
+        req_a, len(token_ids), num_computed_tokens, computed_blocks
+    )
+    assert blocks is not None
+    manager.free(req_a)
+
+    req_a_replay = make_request(
+        "a_replay", token_ids, block_size, hash_fn, lora_request=lora_a
+    )
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req_a_replay)
+    assert computed_blocks.get_block_ids() == ([1, 2, 3],)
+    assert num_computed_tokens == 3 * block_size
+
+    req_b = make_request(
+        "b", token_ids, block_size, hash_fn, lora_request=lora_b_same_name
+    )
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req_b)
+    assert computed_blocks.get_block_ids(allow_none=True) is None
+    assert num_computed_tokens == 0
+
+
+@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor])
+@pytest.mark.skip_global_cleanup
+def test_prefix_cache_separates_same_lora_path_different_cache_key(hash_fn):
+    block_size = 16
+    manager = make_kv_cache_manager(
+        make_kv_cache_config(block_size, 11),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    token_ids = [i for i in range(3) for _ in range(block_size)] + [3] * 5
+    lora_load_1 = LoRARequest(
+        lora_name="tenant",
+        lora_int_id=1,
+        lora_path="/path/to/lora",
+        lora_cache_key="load-1",
+    )
+    lora_load_2 = LoRARequest(
+        lora_name="tenant",
+        lora_int_id=1,
+        lora_path="/path/to/lora",
+        lora_cache_key="load-2",
+    )
+
+    req_1 = make_request(
+        "load_1", token_ids, block_size, hash_fn, lora_request=lora_load_1
+    )
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req_1)
+    assert computed_blocks.get_block_ids(allow_none=True) is None
+    assert num_computed_tokens == 0
+    blocks = manager.allocate_slots(
+        req_1, len(token_ids), num_computed_tokens, computed_blocks
+    )
+    assert blocks is not None
+    manager.free(req_1)
+
+    req_1_replay = make_request(
+        "load_1_replay", token_ids, block_size, hash_fn, lora_request=lora_load_1
+    )
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req_1_replay)
+    assert computed_blocks.get_block_ids() == ([1, 2, 3],)
+    assert num_computed_tokens == 3 * block_size
+
+    req_2 = make_request(
+        "load_2", token_ids, block_size, hash_fn, lora_request=lora_load_2
+    )
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req_2)
+    assert computed_blocks.get_block_ids(allow_none=True) is None
+    assert num_computed_tokens == 0
+
+
 def test_prefill_hybrid_model():
     block_size = 16
     manager = make_kv_cache_manager(

--- a/vllm/entrypoints/openai/models/serving.py
+++ b/vllm/entrypoints/openai/models/serving.py
@@ -21,6 +21,7 @@ from vllm.entrypoints.serve.lora.protocol import (
 from vllm.entrypoints.serve.utils.error_response import create_error_response
 from vllm.exceptions import LoRAAdapterNotFoundError
 from vllm.logger import init_logger
+from vllm.lora.cache_identity import ensure_lora_cache_key, is_content_versioned
 from vllm.lora.request import LoRARequest
 from vllm.lora.resolver import LoRAResolver, LoRAResolverRegistry
 from vllm.utils.counter import AtomicCounter
@@ -190,6 +191,25 @@ class OpenAIServingModels:
             )
             if base_model_name is not None and self.is_base_model(base_model_name):
                 lora_request.base_model_name = base_model_name
+            # Content-derived prefix-cache identity (single source of truth with
+            # the process_inputs backstop) so a same-name in-place reload of a
+            # readable local adapter's changed contents does not reuse stale
+            # prefix-cache KV. HF-Hub / relative / remote paths fall back to a
+            # path-only identity (not content-versioned).
+            ensure_lora_cache_key(lora_request)
+            if request.load_inplace and not is_content_versioned(
+                lora_path,
+                tensorizer_config_dict=lora_request.tensorizer_config_dict,
+            ):
+                logger.warning(
+                    "In-place reload of LoRA adapter '%s' from a "
+                    "non-content-versioned path (%s): its prefix-cache blocks "
+                    "are keyed by path only, so a same-path content change may "
+                    "still reuse stale KV. Load under a new name/path, or "
+                    "disable prefix caching for this adapter.",
+                    lora_name,
+                    lora_path,
+                )
 
             # Validate that the adapter can be loaded into the engine
             # This will also preload it for incoming requests

--- a/vllm/lora/cache_identity.py
+++ b/vllm/lora/cache_identity.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Content-derived identity for a runtime LoRA adapter, used to version
+prefix-cache block hashes across same-name reloads (issue #42125).
+
+For a readable LOCAL adapter, the identity digests the on-disk contents (the
+selected weight file + canonicalized ``adapter_config.json``) plus
+loader-affecting request fields, so reloading different contents under the same
+``lora_name`` yields a different key -- deterministically across API-server
+replicas, unlike a per-process counter. The key is filled before block hashes
+are computed (serving load + ``InputProcessor.process_inputs`` backstop).
+
+Limitations: adapters whose files are not readable where the key is computed
+(Hugging Face Hub ids, relative/remote paths, shared-nothing multi-node) get a
+path-only identity and are NOT content-versioned. There is no guard against the
+adapter bytes changing between when the key is computed and when the worker
+loads them (the TOCTOU race is out of scope), and external KV connectors do not
+consume these keys.
+"""
+
+import contextlib
+import hashlib
+import json
+import os
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+# Bump when the manifest layout changes so old/new keys never alias.
+_VERSION = b"vllm-lora-effective-id-v1"
+
+# Weight file names in the loader's selection order
+# (see LoRAModel.from_local_checkpoint).
+_WEIGHT_NAMES = ("adapter_model.safetensors", "adapter_model.bin", "adapter_model.pt")
+_TENSORIZER_WEIGHT = "adapter_model.tensors"
+_CONFIG_NAME = "adapter_config.json"
+
+_READ_CHUNK = 1 << 20
+
+
+def _frame(hasher: "hashlib._Hash", label: bytes, length: int) -> None:
+    # Length-prefixed framing so fields concatenate unambiguously
+    # (avoids ("ab","c") vs ("a","bc") collisions -- no raw concat).
+    hasher.update(len(label).to_bytes(8, "big"))
+    hasher.update(label)
+    hasher.update(length.to_bytes(8, "big"))
+
+
+def _add_bytes(hasher: "hashlib._Hash", label: bytes, payload: bytes) -> None:
+    _frame(hasher, label, len(payload))
+    hasher.update(payload)
+
+
+def _add_file(hasher: "hashlib._Hash", label: bytes, path: str) -> None:
+    size = os.path.getsize(path)
+    _frame(hasher, label, size)
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(_READ_CHUNK), b""):
+            hasher.update(chunk)
+
+
+def _select_sources(
+    lora_path: str, tensorizer_config_dict: dict | None
+) -> tuple[str, str | None]:
+    """Approximate LoRAModel.from_local_checkpoint's source selection for LOCAL
+    files: a tensorizer dir if configured, else safetensors/.bin/.pt by the
+    loader's precedence. Remote tensorizer URIs and HF-Hub ids are not resolved
+    here -- they have no local file and degrade to a path-only identity.
+
+    Returns (config_path, weight_path); weight_path is None if no known local
+    weight file is present.
+    """
+    if tensorizer_config_dict:
+        tdir = tensorizer_config_dict.get("tensorizer_dir") or lora_path
+        return (
+            os.path.join(tdir, _CONFIG_NAME),
+            os.path.join(tdir, _TENSORIZER_WEIGHT),
+        )
+    config_path = os.path.join(lora_path, _CONFIG_NAME)
+    for name in _WEIGHT_NAMES:
+        candidate = os.path.join(lora_path, name)
+        if os.path.isfile(candidate):
+            return config_path, candidate
+    return config_path, None
+
+
+def compute_lora_cache_key(
+    lora_path: str,
+    *,
+    is_3d_lora_weight: bool = False,
+    tensorizer_config_dict: dict | None = None,
+) -> str:
+    """Deterministic content identity for a local adapter.
+
+    Hashes the selected weight file + canonicalized ``adapter_config.json`` +
+    loader-affecting fields. Degrades to a path-only identity when no local
+    source is readable (HF-Hub ids, relative/remote paths). This is not a
+    guarantee about the bytes the worker ultimately loads -- there is no TOCTOU
+    re-verification.
+    """
+    lora_path = os.path.expanduser(lora_path)
+    hasher = hashlib.sha256()
+    _add_bytes(hasher, b"version", _VERSION)
+    _add_bytes(hasher, b"is_3d_lora_weight", b"\x01" if is_3d_lora_weight else b"\x00")
+    if tensorizer_config_dict is not None:
+        canonical = json.dumps(
+            tensorizer_config_dict, sort_keys=True, separators=(",", ":")
+        )
+        _add_bytes(hasher, b"tensorizer_config", canonical.encode("utf-8"))
+
+    config_path, weight_path = _select_sources(lora_path, tensorizer_config_dict)
+    hashed_any = False
+    try:
+        # Only hash absolute local paths: a relative path can resolve to a
+        # different location on the worker (different CWD), so it is treated as
+        # path-only here to avoid "API hashes A, worker loads B".
+        if os.path.isabs(config_path) and os.path.isfile(config_path):
+            # Canonicalize JSON so reformatting alone does not change the key;
+            # a non-JSON config is hashed as raw bytes.
+            with open(config_path, "rb") as f:
+                cfg = f.read()
+            with contextlib.suppress(ValueError, TypeError):
+                cfg = json.dumps(
+                    json.loads(cfg), sort_keys=True, separators=(",", ":")
+                ).encode("utf-8")
+            _add_bytes(hasher, b"adapter_config.json", cfg)
+            hashed_any = True
+        if (
+            weight_path is not None
+            and os.path.isabs(weight_path)
+            and os.path.isfile(weight_path)
+        ):
+            _add_file(
+                hasher,
+                b"weights:" + os.path.basename(weight_path).encode(),
+                weight_path,
+            )
+            hashed_any = True
+    except OSError:
+        hashed_any = False
+    if not hashed_any:
+        # Nothing readable here (e.g. a Hugging Face Hub id or a path resolved
+        # elsewhere) -> path-only identity. A same-path content overwrite cannot
+        # be distinguished in this degraded case; surface it so operators know
+        # the adapter is not content-versioned.
+        logger.debug(
+            "LoRA prefix-cache identity for %r is path-only (no readable adapter "
+            "files at this location); same-path content swaps are not detected.",
+            lora_path,
+        )
+        _add_bytes(hasher, b"path-fallback", lora_path.encode("utf-8"))
+    return hasher.hexdigest()
+
+
+def is_content_versioned(
+    lora_path: str, *, tensorizer_config_dict: dict | None = None
+) -> bool:
+    """Whether ``compute_lora_cache_key`` hashes on-disk content for this path.
+
+    True for an absolute local path with a readable ``adapter_config.json`` or
+    weight file; False (path-only identity) for HF-Hub ids and relative/remote
+    paths. Callers use this to warn when an in-place reload would be keyed by
+    path only and thus cannot detect a same-path content swap.
+    """
+    lora_path = os.path.expanduser(lora_path)
+    config_path, weight_path = _select_sources(lora_path, tensorizer_config_dict)
+    return any(
+        p is not None and os.path.isabs(p) and os.path.isfile(p)
+        for p in (config_path, weight_path)
+    )
+
+
+def ensure_lora_cache_key(lora_request) -> None:
+    """Fill ``lora_request.lora_cache_key`` in place if unset.
+
+    Single source of truth for the prefix-cache identity so every fill site
+    (serving load, ``InputProcessor.process_inputs`` backstop) hashes the same
+    inputs. No-op when the request is None or already carries a key.
+    """
+    if lora_request is None or lora_request.lora_cache_key is not None:
+        return
+    lora_request.lora_cache_key = compute_lora_cache_key(
+        lora_request.lora_path,
+        is_3d_lora_weight=lora_request.is_3d_lora_weight,
+        tensorizer_config_dict=lora_request.tensorizer_config_dict,
+    )

--- a/vllm/lora/request.py
+++ b/vllm/lora/request.py
@@ -20,6 +20,9 @@ class LoRARequest(
         with the same lora_int_id already exists in the cache. This replaces
         the existing adapter in-place. If False (default), only loads if the
         adapter is not already loaded.
+    lora_cache_key: Optional key identifying a loaded adapter instance for
+        prefix caching. This lets runtime reloads invalidate same-name LoRA
+        prefix-cache entries without flushing unrelated cache blocks.
     """
 
     lora_name: str
@@ -35,6 +38,7 @@ class LoRARequest(
     tensors per expert). Only consulted when the engine is started with
     `enable_mixed_moe_lora_format=True`; otherwise it is ignored and the
     on-disk format is inferred from the base model."""
+    lora_cache_key: str | None = None
 
     def __post_init__(self):
         if self.lora_int_id < 1:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -433,7 +433,7 @@ def need_extra_keys(request: Request) -> bool:
     """
 
     # Multimodal requests need to include the MM hash.
-    # LoRA requests need to include the LoRA name.
+    # LoRA requests need to include the LoRA adapter identity.
     # Request with provided cache salt need to include the salt.
     return (
         bool(request.mm_features)
@@ -509,19 +509,25 @@ def _gen_mm_extra_hash_keys(
     return extra_keys, curr_mm_idx
 
 
-def _gen_lora_extra_hash_keys(request: Request) -> list[str]:
+def _gen_lora_extra_hash_keys(request: Request) -> list[tuple[str, str]]:
     """Generate extra keys related to LoRA for block hash computation.
 
     Args:
         request: The request object.
 
     Returns:
-        Return LoRA name of the request if it is a LoRA request. Return empty
-        list otherwise.
+        Return LoRA identity of the request if it is a LoRA request. Return
+        empty list otherwise.
     """
-    if not request.lora_request:
+    lora_request = request.lora_request
+    if not lora_request:
         return []
-    return [request.lora_request.lora_name]
+    identity_key = (
+        lora_request.lora_cache_key
+        if lora_request.lora_cache_key is not None
+        else lora_request.lora_path
+    )
+    return [("lora", lora_request.lora_name), ("lora_identity", identity_key)]
 
 
 def _gen_prompt_embeds_extra_hash_keys(
@@ -570,7 +576,7 @@ def generate_block_hash_extra_keys(
     mm_extra_keys, new_start_mm_idx = _gen_mm_extra_hash_keys(
         request, start_token_idx, end_token_idx, start_mm_idx
     )
-    lora_extra_keys: list[str] = _gen_lora_extra_hash_keys(request)
+    lora_extra_keys = _gen_lora_extra_hash_keys(request)
     cache_salt_keys: list[str] = (
         [request.cache_salt] if (start_token_idx == 0 and request.cache_salt) else []
     )

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -15,6 +15,7 @@ from vllm.inputs import (
 )
 from vllm.inputs.preprocess import InputPreprocessor
 from vllm.logger import init_logger
+from vllm.lora.cache_identity import ensure_lora_cache_key
 from vllm.lora.request import LoRARequest
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.multimodal.encoder_budget import MultiModalBudget
@@ -255,6 +256,12 @@ class InputProcessor:
     ) -> EngineCoreRequest:
         self._validate_params(params, supported_tasks)
         self._validate_lora(lora_request)
+
+        # Ensure a content-derived prefix-cache identity is set before block
+        # hashes are computed. Covers offline / direct / resolver-built
+        # LoRARequests that did not pass through the serving load path; requests
+        # already carrying a key (e.g. from /v1/load_lora_adapter) are left as-is.
+        ensure_lora_cache_key(lora_request)
 
         parallel_config = self.vllm_config.parallel_config
         dp_size = parallel_config.data_parallel_size


### PR DESCRIPTION
> This replaces #45981, which I accidentally closed when its source fork was detached. The change has been rebased onto current `main`; the original discussion remains in #45981.

## Purpose

Same-name runtime LoRA reloads (`/v1/load_lora_adapter`, `load_inplace=true`) could reuse stale prefix-cache KV from the previous adapter. The block-hash key identified a LoRA only by `lora_name`, while an in-place reload preserves both `lora_name` and `lora_int_id` even when the adapter bytes change.

For readable local adapters loaded from absolute paths, this change keys LoRA prefix-cache extra keys on a content-derived identity: a digest of the selected weight file, canonicalized `adapter_config.json`, and loader-affecting fields. The identity is populated in the serving load path, with a `process_inputs` backstop.

Extra keys are now `("lora", name) + ("lora_identity", id)`. `lora_int_id` is no longer part of the key.

## Scope

This partially addresses #42125, but does not close the issue.

This is path-only for sources that cannot be content-versioned, so same-name stale reuse may still occur for:

- HF Hub IDs
- relative or remote paths
- tensorizer URIs
- shared-nothing multi-node setups
- external KV connectors
- the TOCTOU window before the worker loads the adapter

An in-place reload from a path-only source now logs a warning. `process_inputs` hashes the selected weight file once on first use of an unkeyed request, which is not free for large adapters. Old EngineCore peers that predate this field drop it, so a rolling upgrade will not fix those peers until they are restarted.

Prior art: #42495 (self-closed) proposed the `lora_cache_key` field with a per-process counter; this PR uses a content digest instead and narrows the claim. #44706 is still open and does overlapping domain-tag work, so this PR may need a rebase. I did not find an exact open duplicate for #42125.

## Test Plan

```bash
python -m pytest tests/lora/test_cache_identity.py tests/v1/core/test_kv_cache_utils.py \
  tests/v1/core/test_prefix_caching.py tests/entrypoints/serve/lora/test_serving_models.py -q
ruff check <changed files>
```

Plus an end-to-end check on RTX 4090 / Qwen2.5-3B: load adapter A, warm the prefix cache, then reload a different adapter B under the same name and path with `load_inplace=true`, and compare against a cold load of B.

## Test Result

Targeted tests: 25 passed. Ruff is clean.

End-to-end: before the change, the same-name same-path reload returns stale (adapter A) output; after the change it returns adapter B, matching a cold load of B.

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR.
- [x] The test plan.
- [x] The test results.
- [ ] (Optional) Documentation update.
</details>

## Validation
- `pytest -q tests/lora/test_cache_identity.py tests/v1/core/test_prefix_caching.py::test_prefix_cache_separates_same_lora_path_different_cache_key` (17 passed)
