### PR TITLE
[Bugfix] Fix collect_env.py crash on non-Linux platforms

### DIFF
--- a/tests/test_collect_env.py
+++ b/tests/test_collect_env.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm import collect_env
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+@pytest.mark.parametrize("platform", ["darwin", "win32", "cygwin"])
+def test_get_pkg_version_skips_linux_package_managers_off_linux(
+    monkeypatch, platform
+):
+    def unexpected_run(_command):
+        raise AssertionError("Linux package manager must not run off Linux")
+
+    monkeypatch.setattr(collect_env, "get_platform", lambda: platform)
+
+    assert collect_env.get_pkg_version(unexpected_run, "igc") is None

--- a/vllm/collect_env.py
+++ b/vllm/collect_env.py
@@ -301,7 +301,11 @@ def get_xpu_runtime_version():
 
 
 def get_pkg_version(run_lambda, pkg):
-    assert get_platform() == "linux"
+    # These versions come from Linux package managers; there is nothing to query
+    # on other platforms, so return None instead of raising (keeps collect_env
+    # working on macOS/Windows).
+    if get_platform() != "linux":
+        return None
 
     if pkg == "vllm_xpu_kernels":
         rc, out, _ = run_lambda("pip show vllm-xpu-kernels")


### PR DESCRIPTION
> This replaces #45162, which I accidentally closed when its source fork was detached. The change has been rebased onto current `main`; the original discussion remains in #45162.

## Purpose

`python collect_env.py` aborts with `AssertionError` on non-Linux platforms: `get_env_info()` unconditionally calls `get_pkg_version()`, whose first line is `assert get_platform() == "linux"`, so collect_env prints nothing there. These queries read Linux package managers for Intel/XPU packages, so they now return `None` off Linux instead of asserting. Reproduced on macOS 15.6 (arm64); Windows hits the same assert since `get_platform()` returns `"win32"`, and the script otherwise has dedicated win32 handling (e.g. `get_windows_version`).

## Test Plan

`python collect_env.py` on macOS 15.6 (arm64).

## Test Result

Before: aborts at `get_pkg_version` (line 304) with `AssertionError`, printing no report.

After: exits 0 and prints the full report — System Info, PyTorch Info, Python Environment, library versions, vLLM Info, and Environment Variables. The Linux-only Intel/XPU package fields are simply not shown on macOS. On Linux the new branch is not taken, so behavior there is unchanged.

## Validation
- `pytest -q tests/test_collect_env.py` (3 passed)
