### PR TITLE
[Bugfix][Model Loader] Save noncontiguous sharded-state tensors

### DIFF
--- a/tests/model_executor/model_loader/test_sharded_state_loader.py
+++ b/tests/model_executor/model_loader/test_sharded_state_loader.py
@@ -50,6 +50,27 @@ def test_filter_subtensors():
         assert tensor is state_dict[key]
 
 
+def test_filter_subtensors_handles_transposed_tensor():
+    base = torch.arange(24).reshape(2, 3, 4)
+    state_dict = {
+        "base": base,
+        "transpose": base.transpose(0, 2),
+    }
+
+    filtered_state_dict = ShardedStateLoader._filter_subtensors(state_dict)
+
+    assert tuple(filtered_state_dict) == ("base",)
+
+
+def test_filter_subtensors_copies_uncovered_noncontiguous_tensor():
+    tensor = torch.arange(24).reshape(2, 3, 4).transpose(0, 2)
+
+    filtered_state_dict = ShardedStateLoader._filter_subtensors({"tensor": tensor})
+
+    assert filtered_state_dict["tensor"].is_contiguous()
+    torch.testing.assert_close(filtered_state_dict["tensor"], tensor)
+
+
 @pytest.fixture(scope="module")
 def llama_3p2_1b_files():
     input_dir = snapshot_download(

--- a/vllm/model_executor/model_loader/sharded_state_loader.py
+++ b/vllm/model_executor/model_loader/sharded_state_loader.py
@@ -70,7 +70,14 @@ class ShardedStateLoader(BaseModelLoader):
                 same_storage_groups[tensor.device, ptr].append((key, tensor))
 
         def get_end_ptr(tensor: torch.Tensor) -> int:
-            return tensor.view(-1)[-1].data_ptr() + tensor.element_size()
+            max_offset = tensor.storage_offset() + sum(
+                max(0, (size - 1) * stride)
+                for size, stride in zip(tensor.shape, tensor.stride())
+            )
+            return (
+                tensor.untyped_storage().data_ptr()
+                + (max_offset + 1) * tensor.element_size()
+            )
 
         result: dict[str, torch.Tensor] = {}
         for group in same_storage_groups.values():
@@ -88,7 +95,7 @@ class ShardedStateLoader(BaseModelLoader):
                         # Same tensors, keep the one with the smaller key.
                         break
                 else:
-                    result[k] = t
+                    result[k] = t if t.is_contiguous() else t.contiguous()
         return result
 
     def _prepare_weights(self, model_name_or_path: str, revision: str | None):


### PR DESCRIPTION
## Summary

Make `ShardedStateLoader._filter_subtensors()` handle noncontiguous tensors. Compute storage coverage from shape/stride instead of calling `view(-1)`, and materialize an uncovered noncontiguous tensor before serialization.

## Reproduction

Moonlight FP8 runtime snapshot failed in `save_sharded_state()` when an MLA transposed runtime parameter reached `_filter_subtensors()`:

```text
RuntimeError: view size is not compatible with input tensor's size and stride
```

## Validation

- Existing contiguous/alias test plus two transpose regressions — 3 passed in the vLLM container.
- Pre-commit passed on both changed files.

## Duplicate-work check

No matching open PR was found for noncontiguous sharded-state filtering.

AI assistance: OpenAI Codex was used to investigate, implement, and test this draft. Human review is required before marking it ready.