### PR TITLE
[Doc] Fix stale ModelOpt test instructions in modelopt.md

### DIFF
--- a/docs/features/quantization/modelopt.md
+++ b/docs/features/quantization/modelopt.md
@@ -104,11 +104,11 @@ vllm serve <path_to_exported_checkpoint> \
 
 ## Testing (local checkpoints)
 
-vLLM's ModelOpt unit tests are gated by local checkpoint paths and are skipped
-by default in CI. To run the tests locally:
+The `FP8_PER_CHANNEL_PER_TOKEN` and `FP8_PB_WO` checkpoint tests in
+`tests/quantization/test_modelopt.py` download small public checkpoints from
+the Hugging Face Hub on demand and are skipped automatically if the download
+fails; no environment variables need to be set. To run the tests locally:
 
 ```bash
-export VLLM_TEST_MODELOPT_FP8_PC_PT_MODEL_PATH=<path_to_fp8_pc_pt_checkpoint>
-export VLLM_TEST_MODELOPT_FP8_PB_WO_MODEL_PATH=<path_to_fp8_pb_wo_checkpoint>
 pytest -q tests/quantization/test_modelopt.py
 ```


### PR DESCRIPTION
## Purpose

The "Testing (local checkpoints)" section of `docs/features/quantization/modelopt.md` instructs contributors to export `VLLM_TEST_MODELOPT_FP8_PC_PT_MODEL_PATH` and `VLLM_TEST_MODELOPT_FP8_PB_WO_MODEL_PATH` before running `tests/quantization/test_modelopt.py`, but the test file never reads either variable. The FP8 PC/PT and PB/WO tests download small public checkpoints from the Hugging Face Hub via `_snapshot_download_or_skip` and skip automatically if the download fails — no environment variables are involved:

- Old doc instructions: https://github.com/vllm-project/vllm/blob/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5/docs/features/quantization/modelopt.md?plain=1#L111-L112
- `_snapshot_download_or_skip`: https://github.com/vllm-project/vllm/blob/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5/tests/quantization/test_modelopt.py#L43
- FP8 PC/PT test: https://github.com/vllm-project/vllm/blob/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5/tests/quantization/test_modelopt.py#L301-L304
- FP8 PB/WO test: https://github.com/vllm-project/vllm/blob/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5/tests/quantization/test_modelopt.py#L365-L368

A repo-wide search confirms these variable names appear nowhere outside this doc. Commit 19cc9468f (#30957) added the doc text and the test code in the same commit, so the instructions were inaccurate from the start rather than drifting later.

This PR replaces the export instructions with an accurate description of the auto-download/auto-skip behavior; the `pytest` command itself is unchanged.

## Test Plan

Docs-only change. Verified by reading the test file (permalinks above) and searching the repo for both variable names; checked the rendered page via the ReadTheDocs preview build.

## Test Result

A repo-wide search for `VLLM_TEST_MODELOPT` matches only the doc lines this PR fixes. Docs preview renders correctly.

Written with AI assistance; I reviewed every changed line and verified the test-file behavior against the source.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>