### PR TITLE
[Doc] Add NemotronHPuzzleForCausalLM to supported_models.md

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -420,7 +420,7 @@ th {
 | `MixtralForCausalLM` | Mixtral-8x7B, Mixtral-8x7B-Instruct | `mistralai/Mixtral-8x7B-v0.1`, `mistralai/Mixtral-8x7B-Instruct-v0.1`, `mistral-community/Mixtral-8x22B-v0.1`, etc. | ✅︎ | ✅︎ |
 | `MPTForCausalLM` | MPT, MPT-Instruct, MPT-Chat, MPT-StoryWriter | `mosaicml/mpt-7b`, `mosaicml/mpt-7b-storywriter`, `mosaicml/mpt-30b`, etc. | | ✅︎ |
 | `NemotronForCausalLM` | Nemotron-3, Nemotron-4, Minitron | `nvidia/Minitron-8B-Base`, `mgoin/Nemotron-4-340B-Base-hf-FP8`, etc. | ✅︎ | ✅︎ |
-| `NemotronHForCausalLM` | Nemotron-H | `nvidia/Nemotron-H-8B-Base-8K`, `nvidia/Nemotron-H-47B-Base-8K`, `nvidia/Nemotron-H-56B-Base-8K`, etc. | ✅︎ | ✅︎ |
+| `NemotronHForCausalLM`, `NemotronHPuzzleForCausalLM` | Nemotron-H, Nemotron-H-Puzzle | `nvidia/Nemotron-H-8B-Base-8K`, `nvidia/Nemotron-H-47B-Base-8K`, `nvidia/Nemotron-H-56B-Base-8K`, etc. | ✅︎ | ✅︎ |
 | `Olmo3ForCausalLM` | OLMo3 | `allenai/Olmo-3-7B-Instruct`, `allenai/Olmo-3-32B-Think`, etc. | ✅︎ | ✅︎ |
 | `OlmoHybridForCausalLM` | OLMo Hybrid | `allenai/Olmo-Hybrid-7B` | ✅︎ | ✅︎ |
 | `OlmoeForCausalLM` | OLMoE | `allenai/OLMoE-1B-7B-0924`, `allenai/OLMoE-1B-7B-0924-Instruct`, etc. | | ✅︎ |


### PR DESCRIPTION
## Purpose

`NemotronHPuzzleForCausalLM` (NVIDIA's heterogeneous NemotronH variant) has been registered as a text-generation architecture since #32549, extended in #37803, but supported_models.md was never updated to mention it:

- Registry entry: https://github.com/vllm-project/vllm/blob/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5/vllm/model_executor/models/registry.py#L174
- Test registry entry: https://github.com/vllm-project/vllm/blob/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5/tests/models/registry.py#L442

This adds the architecture to the existing NemotronH row, following the file's alias-row convention. Note: no example checkpoint ID is added, because the test registry lists no publicly available checkpoint for this architecture yet — documenting the architecture without an example ID follows the existing precedent of entries like `DeepseekV4ForCausalLM`, which is documented despite `is_available_online=False` in the test registry.

## Test Plan

Docs-only change. Verified the architecture name and its target class against the registry (permalinks above) and checked the rendered table via the ReadTheDocs preview build.

## Test Result

Docs preview renders correctly.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>