### PR TITLE
[Bugfix] Gemma4: don't crash when a KV-shared layer has no same-type target

### DIFF
--- a/tests/models/test_gemma4_kv_sharing.py
+++ b/tests/models/test_gemma4_kv_sharing.py
@@ -26,14 +26,19 @@ from vllm.model_executor.models.gemma4 import Gemma4ForCausalLM
 pytestmark = pytest.mark.cpu_test
 
 
-def _build_model(hf_overrides: dict) -> Gemma4ForCausalLM:
+def _build_model(
+    hf_overrides: dict, kv_sharing_fast_prefill: bool = False
+) -> Gemma4ForCausalLM:
     model_config = ModelConfig(
         "google/gemma-4-E4B-it-assistant",
         hf_overrides={"architectures": ["Gemma4ForCausalLM"], **hf_overrides},
         dtype="bfloat16",
     )
     vllm_config = VllmConfig(
-        model_config=model_config, cache_config=CacheConfig(block_size=16)
+        model_config=model_config,
+        cache_config=CacheConfig(
+            block_size=16, kv_sharing_fast_prefill=kv_sharing_fast_prefill
+        ),
     )
     temp_file = tempfile.mkstemp()[1]
     with set_current_vllm_config(vllm_config=vllm_config):
@@ -79,4 +84,14 @@ def test_gemma4_partial_kv_sharing_still_engages():
     assert layers[3].self_attn.attn.kv_sharing_target_layer_name is None
 
     del model
+    cleanup_dist_env_and_memory()
+
+
+def test_gemma4_fallback_rejects_kv_sharing_fast_prefill():
+    # Fast prefill skips most prompt tokens in cross-decoder layers, so a
+    # fallback layer's private KV cache would never be populated for them.
+    # Such configs must be rejected at init instead of corrupting outputs.
+    with pytest.raises(ValueError, match="kv_sharing_fast_prefill"):
+        _build_model({}, kv_sharing_fast_prefill=True)
+
     cleanup_dist_env_and_memory()

--- a/tests/models/test_gemma4_kv_sharing.py
+++ b/tests/models/test_gemma4_kv_sharing.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Gemma4 KV-sharing initialization.
+
+Draft/assistant checkpoints (e.g. ``google/gemma-4-E4B-it-assistant``)
+declare ``num_kv_shared_layers == num_hidden_layers``: every layer is
+KV-shared and the proposer wires cross-model sharing after construction.
+Loading such a config standalone used to raise
+``ValueError: 'sliding_attention' is not in list`` from ``list.index``
+in ``Gemma4Attention``.
+"""
+
+import tempfile
+
+import pytest
+import torch
+
+from vllm.config import CacheConfig, ModelConfig, VllmConfig, set_current_vllm_config
+from vllm.distributed import (
+    cleanup_dist_env_and_memory,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm.model_executor.models.gemma4 import Gemma4ForCausalLM
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _build_model(hf_overrides: dict) -> Gemma4ForCausalLM:
+    model_config = ModelConfig(
+        "google/gemma-4-E4B-it-assistant",
+        hf_overrides={"architectures": ["Gemma4ForCausalLM"], **hf_overrides},
+        dtype="bfloat16",
+    )
+    vllm_config = VllmConfig(
+        model_config=model_config, cache_config=CacheConfig(block_size=16)
+    )
+    temp_file = tempfile.mkstemp()[1]
+    with set_current_vllm_config(vllm_config=vllm_config):
+        init_distributed_environment(
+            world_size=1,
+            rank=0,
+            distributed_init_method=f"file://{temp_file}",
+            local_rank=0,
+            backend="gloo",
+        )
+        initialize_model_parallel(tensor_model_parallel_size=1)
+        with torch.device("meta"):
+            return Gemma4ForCausalLM(vllm_config=vllm_config)
+
+
+def test_gemma4_all_layers_kv_shared_initializes():
+    # num_kv_shared_layers == num_hidden_layers == 4 in the checkpoint:
+    # there is no non-shared prefix, so every layer must fall back to a
+    # regular KV cache instead of raising from list.index.
+    model = _build_model({})
+    for layer in model.model.layers:
+        attn = layer.self_attn
+        assert not attn.is_kv_shared_layer
+        assert attn.attn.kv_sharing_target_layer_name is None
+
+    del model
+    cleanup_dist_env_and_memory()
+
+
+def test_gemma4_partial_kv_sharing_still_engages():
+    # layer_types is [sliding, sliding, sliding, full]; with 2 shared
+    # layers the prefix is [sliding, sliding]: layer 2 (sliding) shares
+    # with layer 1, while layer 3 (full) has no full layer in the prefix
+    # and must fall back.
+    model = _build_model({"text_config": {"num_kv_shared_layers": 2}})
+    layers = model.model.layers
+
+    assert layers[2].self_attn.is_kv_shared_layer
+    target = layers[2].self_attn.attn.kv_sharing_target_layer_name
+    assert target is not None and target.endswith(".layers.1.self_attn.attn")
+
+    assert not layers[3].self_attn.is_kv_shared_layer
+    assert layers[3].self_attn.attn.kv_sharing_target_layer_name is None
+
+    del model
+    cleanup_dist_env_and_memory()

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -1123,6 +1123,21 @@ class Gemma4Model(nn.Module, EagleModelMixin):
         self.fast_prefill_enabled = cache_config.kv_sharing_fast_prefill
 
         if self.fast_prefill_enabled:
+            # Fast prefill runs cross-decoder layers only for logits indices,
+            # relying on every suffix layer reusing a self-decoder layer's KV
+            # cache. A suffix layer that fell back to a regular KV cache (no
+            # same-type sharing target) would never populate it for skipped
+            # prompt tokens, silently corrupting outputs — reject instead.
+            for layer in self.layers[first_kv_shared_layer_idx:]:
+                self_attn = getattr(layer, "self_attn", None)
+                if self_attn is not None and not self_attn.is_kv_shared_layer:
+                    raise ValueError(
+                        "kv_sharing_fast_prefill requires every KV-shared "
+                        "suffix layer to have a same-type sharing target, "
+                        "but at least one layer fell back to a regular KV "
+                        "cache. Disable kv-sharing fast prefill for this "
+                        "checkpoint."
+                    )
             # Allocate static buffers for CUDAGraph
             max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
             device = next(self.parameters()).device

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -462,14 +462,16 @@ class Gemma4Attention(nn.Module):
         if num_kv_shared_layers > 0:
             first_kv_shared_layer_idx = config.num_hidden_layers - num_kv_shared_layers
             if layer_idx >= first_kv_shared_layer_idx:
-                self.is_kv_shared_layer = True
                 # Find the last non-shared layer of the same attention type
                 prev_layers = config.layer_types[:first_kv_shared_layer_idx]
                 current_layer_type = config.layer_types[layer_idx]
-                kv_shared_layer_index = (
-                    len(prev_layers) - 1 - prev_layers[::-1].index(current_layer_type)
-                )
-                if kv_shared_layer_index >= 0:
+                if current_layer_type in prev_layers:
+                    self.is_kv_shared_layer = True
+                    kv_shared_layer_index = (
+                        len(prev_layers)
+                        - 1
+                        - prev_layers[::-1].index(current_layer_type)
+                    )
                     if ".layers." in prefix:
                         param_name_before_layers = prefix.split(".layers.")[0]
                     else:
@@ -480,6 +482,19 @@ class Gemma4Attention(nn.Module):
                     kv_sharing_target_layer_name = (
                         f"{param_name_before_layers}.layers."
                         f"{kv_shared_layer_index}.self_attn.attn"
+                    )
+                else:
+                    # No earlier layer of this type to share with. Draft
+                    # checkpoints mark every layer KV-shared (the proposer
+                    # wires cross-model sharing after construction); when
+                    # such a config is loaded standalone, fall back to a
+                    # regular KV cache instead of raising from list.index.
+                    logger.warning_once(
+                        "Gemma4 layer %d is marked KV-shared but no earlier "
+                        "%s layer exists to share with; using a regular KV "
+                        "cache for this layer.",
+                        layer_idx,
+                        current_layer_type,
                     )
 
         self.rotary_emb = get_rope(


### PR DESCRIPTION
## Purpose

`Gemma4Attention` resolves each KV-shared layer's sharing target with `list.index()` over the non-shared prefix of `layer_types`. When no earlier layer of the current type exists, `.index()` raises

```
ValueError: 'sliding_attention' is not in list
```

instead of returning a negative value — so the `if kv_shared_layer_index >= 0` guard beneath it is dead code. Published draft/assistant checkpoints hit exactly this shape: `google/gemma-4-E4B-it-assistant` and `google/gemma-4-12B-it-assistant` declare `num_kv_shared_layers == num_hidden_layers`, so the non-shared prefix is empty and model construction crashes at layer 0. The spec-decode path papers over it by zeroing `num_kv_shared_layers` (`vllm/config/speculative.py`), but instantiating such a config directly still fails.

Fix: implement what the dead guard intended — when the current layer type is absent from the prefix, fall back to a regular KV cache for that layer (with a warning) instead of raising. Layers with a valid same-type target keep the existing sharing behavior.

## Test Plan

```bash
pytest tests/models/test_gemma4_kv_sharing.py
```

Both tests are CPU-only (gloo + meta device) and use the real assistant checkpoint config.

## Test Result

Before the fix, the all-shared test reproduces the crash verbatim (`ValueError: 'sliding_attention' is not in list` at the `.index()` call). After:

```
2 passed in 3.71s
```

The partial-sharing test pins the happy path: with `num_kv_shared_layers=2`, layer 2 (sliding) still wires its target (`...layers.1.self_attn.attn`) while layer 3 (full, absent from the prefix) falls back cleanly.

GPU sanity check (1×RTX 5090): engine-level run of the assistant config through the fixed path (`load_format=dummy`, `enforce_eager`) initializes, allocates KV caches, and completes a 16-token decode; all 4 layers log the new fallback warning. On main the same invocation crashes at engine init with the `ValueError`.
