### PR TITLE
[Bugfix] Handle malformed DeepSeek V3 tool calls

### DIFF
--- a/tests/tool_parsers/test_deepseekv3_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv3_tool_parser.py
@@ -8,6 +8,7 @@ from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
+from tests.tool_parsers.utils import run_tool_extraction_nonstreaming
 from vllm.tokenizers import TokenizerLike, get_tokenizer
 
 
@@ -83,10 +84,16 @@ class TestDeepSeekV3ToolParser(ToolParserTests):
             parallel_tool_calls_names=["get_weather", "search_hotels"],
             # xfail markers
             xfail_streaming={},
-            xfail_nonstreaming={
-                "test_malformed_input": (
-                    "Parser sets tools_called=True even when tool_calls is "
-                    "empty (detects start token but fails to parse)"
-                ),
-            },
+            xfail_nonstreaming={},
         )
+
+    def test_malformed_input_preserves_content(
+        self, tool_parser, test_config: ToolParserTestConfig
+    ):
+        # This fixture contains the outer marker but no complete tool-call match.
+        malformed_input = test_config.malformed_input_outputs[1]
+        extracted = run_tool_extraction_nonstreaming(tool_parser, malformed_input)
+
+        assert extracted.tools_called is False
+        assert extracted.tool_calls == []
+        assert extracted.content == malformed_input

--- a/vllm/tool_parsers/deepseekv3_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv3_tool_parser.py
@@ -96,6 +96,12 @@ class DeepSeekV3ToolParser(ToolParser):
                 # findall is an array of tuples where one is a function call and
                 # the other is None
                 function_call_tuples = self.tool_call_regex.findall(model_output)
+                if not function_call_tuples:
+                    return ExtractedToolCallInformation(
+                        tools_called=False,
+                        tool_calls=[],
+                        content=model_output,
+                    )
 
                 tool_calls = []
                 for match in function_call_tuples:


### PR DESCRIPTION
## Summary

Fix the DeepSeek V3 non-streaming tool parser fallback when model output contains the outer tool-call marker but no complete tool-call match.

Previously, `tool_call_regex.findall()` could return no matches while the parser still returned `tools_called=True` with an empty `tool_calls` list. This violated the extraction invariant that `tools_called` should reflect whether any tool calls were successfully parsed.

The parser now:

- returns `tools_called=False`;
- returns an empty `tool_calls` list;
- preserves the complete original model output as content.

The stale non-streaming expected failure was removed, and a focused regression test was added for the no-match case.

## Testing

```text
python -m pytest tests/tool_parsers/test_deepseekv3_tool_parser.py -vv
18 passed
```

```text
pre-commit run --files \
  vllm/tool_parsers/deepseekv3_tool_parser.py \
  tests/tool_parsers/test_deepseekv3_tool_parser.py

All hooks passed
```

```text
git diff --check
Passed
```