### PR TITLE
[Bug] Fix KV connector throughput metric under concurrent transfers

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_stats.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_stats.py
@@ -34,8 +34,8 @@ def test_record_transfer_and_reduce():
     # avg = (1 + 2) / 2 = 1.5 ms
     assert reduced["Avg xfer time (ms)"] == 1.5
     assert reduced["Avg MB per transfer"] == 1.5
-    # 3 MB total / 3 ms total = 1000 MB/s
-    assert reduced["Throughput (MB/s)"] == 1000.0
+    # mean(1 MB / 0.001 s, 2 MB / 0.002 s) = mean(1000, 1000) = 1000 MB/s
+    assert reduced["Avg per-transfer throughput (MB/s)"] == 1000.0
     assert reduced["Avg number of descriptors"] == 5.0
     assert reduced["Num failed transfers"] == 0
     assert reduced["Num failed recvs"] == 0
@@ -279,3 +279,58 @@ def test_expired_request_bumps_counter():
     assert worker.xfer_stats.data["num_kv_expired_reqs"] == [1]
     # Expired transfer also cleaned out of reqs_need_send.
     assert "tid1" not in worker.reqs_need_send
+
+
+def test_reduce_overlapping_transfers_throughput():
+    """
+    Regression test: the old formula ``total_mb / sum(durations)`` understates
+    throughput when transfers overlap concurrently.
+
+    Concretely:
+      Transfer A: 4 MB in 1 s  → per-link rate = 4 MB/s
+      Transfer B: 2 MB in 2 s  → per-link rate = 1 MB/s
+
+    Old formula:  (4+2) MB / (1+2) s = 2.000 MB/s   ← wrong under overlap
+    New formula:  mean(4, 1)          = 2.500 MB/s   ← correct per-link avg
+
+    The two results differ, so this test would have failed on the old code.
+    """
+    import pytest
+
+    stats = MooncakeKVConnectorStats()
+    stats.record_transfer(duration_s=1.0, total_bytes=4 * 2**20, num_descs=4)
+    stats.record_transfer(duration_s=2.0, total_bytes=2 * 2**20, num_descs=4)
+
+    reduced = stats.reduce()
+    throughput = reduced["Avg per-transfer throughput (MB/s)"]
+
+    # New (correct) value: mean(4 MB/s, 1 MB/s) = 2.5 MB/s
+    assert throughput == pytest.approx(2.5, rel=1e-3)
+
+    # Verify the old formula would have given a different (wrong) answer.
+    old_formula_result = (4 + 2) / (1 + 2)  # = 2.0
+    assert throughput != pytest.approx(old_formula_result, rel=1e-3)
+
+
+def test_reduce_key_name_is_updated():
+    """The old 'Throughput (MB/s)' key must not appear; new key must."""
+    stats = MooncakeKVConnectorStats()
+    stats.record_transfer(duration_s=0.001, total_bytes=2**20, num_descs=1)
+    reduced = stats.reduce()
+    assert "Avg per-transfer throughput (MB/s)" in reduced
+    assert "Throughput (MB/s)" not in reduced
+
+
+def test_reduce_ignores_zero_duration_transfer():
+    stats = MooncakeKVConnectorStats()
+    stats.record_transfer(duration_s=0.0, total_bytes=0, num_descs=0)
+    stats.record_transfer(duration_s=1.0, total_bytes=2 * 2**20, num_descs=1)
+    reduced = stats.reduce()
+    assert reduced["Avg per-transfer throughput (MB/s)"] == 2.0
+
+
+def test_reduce_returns_zero_when_all_durations_are_zero():
+    stats = MooncakeKVConnectorStats()
+    stats.record_transfer(duration_s=0.0, total_bytes=0, num_descs=0)
+    reduced = stats.reduce()
+    assert reduced["Avg per-transfer throughput (MB/s)"] == 0

--- a/tests/v1/kv_connector/unit/test_nixl_stats.py
+++ b/tests/v1/kv_connector/unit/test_nixl_stats.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for NixlKVConnectorStats.reduce() metric math.
+
+nixlXferTelemetry is only imported under TYPE_CHECKING in nixl/stats.py, so
+these tests bypass record_transfer() and inject data directly — no nixl
+hardware or installation required.
+"""
+
+import pytest
+
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.stats import (
+    NixlKVConnectorStats,
+)
+
+MB = 2**20  # bytes per megabyte
+
+
+def _stats_with_transfers(
+    transfers: list[tuple[float, int, int]],
+) -> NixlKVConnectorStats:
+    """Build a NixlKVConnectorStats pre-populated with (duration_s, bytes, descs)
+    rows, bypassing the nixlXferTelemetry dependency."""
+    stats = NixlKVConnectorStats()
+    for duration_s, total_bytes, descs in transfers:
+        stats.data["transfer_duration"].append(duration_s)
+        stats.data["post_duration"].append(duration_s * 0.1)  # stub value
+        stats.data["bytes_transferred"].append(total_bytes)
+        stats.data["num_descriptors"].append(descs)
+    return stats
+
+
+def test_is_empty_on_fresh_stats():
+    stats = NixlKVConnectorStats()
+    assert stats.is_empty()
+    assert stats.num_successful_transfers == 0
+
+
+def test_reduce_returns_zeros_when_no_successful_transfers():
+    stats = NixlKVConnectorStats()
+    stats.record_failed_transfer()
+    reduced = stats.reduce()
+    assert reduced["Num successful transfers"] == 0
+    assert reduced["Avg per-transfer throughput (MB/s)"] == 0
+
+
+def test_reduce_single_transfer():
+    # 2 MB in 2 s → 1 MB/s per-transfer rate; mean of one = 1 MB/s
+    stats = _stats_with_transfers([(2.0, 2 * MB, 4)])
+    reduced = stats.reduce()
+    assert reduced["Num successful transfers"] == 1
+    assert reduced["Avg MB per transfer"] == pytest.approx(2.0, rel=1e-3)
+    assert reduced["Avg per-transfer throughput (MB/s)"] == pytest.approx(1.0, rel=1e-3)
+
+
+def test_reduce_sequential_uniform_transfers():
+    # Two transfers with identical per-link rate: mean must equal that rate.
+    # 1 MB in 1 s and 2 MB in 2 s → both 1 MB/s; mean = 1 MB/s.
+    stats = _stats_with_transfers(
+        [
+            (1.0, 1 * MB, 2),
+            (2.0, 2 * MB, 3),
+        ]
+    )
+    reduced = stats.reduce()
+    assert reduced["Num successful transfers"] == 2
+    assert reduced["Avg per-transfer throughput (MB/s)"] == pytest.approx(1.0, rel=1e-3)
+
+
+def test_reduce_overlapping_transfers_old_formula_would_be_wrong():
+    """
+    Regression test: the old formula ``total_mb / sum(durations)`` understates
+    throughput under concurrency.  With concurrent transfers (C=2) the
+    denominator is doubled even though wall-clock time is only half as long.
+
+    Concretely:
+      Transfer A: 4 MB in 1 s  → per-link rate = 4 MB/s
+      Transfer B: 2 MB in 2 s  → per-link rate = 1 MB/s
+
+    Old formula:  (4+2) MB / (1+2) s = 2.000 MB/s   ← wrong under overlap
+    New formula:  mean(4, 1)          = 2.500 MB/s   ← correct per-link avg
+
+    The two values differ, so this test would have failed on the old code.
+    """
+    stats = _stats_with_transfers(
+        [
+            (1.0, 4 * MB, 4),
+            (2.0, 2 * MB, 4),
+        ]
+    )
+    reduced = stats.reduce()
+    throughput = reduced["Avg per-transfer throughput (MB/s)"]
+
+    # New (correct) value.
+    assert throughput == pytest.approx(2.5, rel=1e-3)
+
+    # Verify the old formula would have produced a different (wrong) answer.
+    old_formula_result = (4 + 2) / (1 + 2)  # = 2.0
+    assert throughput != pytest.approx(old_formula_result, rel=1e-3)
+
+
+def test_reduce_many_concurrent_uniform_transfers():
+    """
+    C identical concurrent transfers each doing R MB/s must still report R.
+
+    Old formula gives R/C (off by the concurrency factor).
+    New formula gives mean(R, R, …, R) = R — correct.
+    """
+    R = 10.0  # MB/s per link
+    C = 8  # concurrency
+    duration_s = 0.1
+    bytes_per_transfer = int(R * duration_s * MB)
+    transfers = [(duration_s, bytes_per_transfer, 1)] * C
+
+    stats = _stats_with_transfers(transfers)
+    reduced = stats.reduce()
+    assert reduced["Num successful transfers"] == C
+    assert reduced["Avg per-transfer throughput (MB/s)"] == pytest.approx(R, rel=1e-3)
+
+
+def test_reduce_key_names():
+    """Confirm the metric dict uses the new key name, not the old one."""
+    stats = _stats_with_transfers([(1.0, 1 * MB, 1)])
+    reduced = stats.reduce()
+    assert "Avg per-transfer throughput (MB/s)" in reduced
+    assert "Throughput (MB/s)" not in reduced
+
+
+def test_reduce_ignores_zero_duration_transfer():
+    stats = _stats_with_transfers(
+        [
+            (0.0, 0, 0),
+            (1.0, 2 * MB, 1),
+        ]
+    )
+    reduced = stats.reduce()
+    assert reduced["Avg per-transfer throughput (MB/s)"] == pytest.approx(2.0)
+
+
+def test_reduce_returns_zero_when_all_durations_are_zero():
+    stats = _stats_with_transfers([(0.0, 0, 0)])
+    reduced = stats.reduce()
+    assert reduced["Avg per-transfer throughput (MB/s)"] == 0
+
+
+def test_record_failure_methods():
+    stats = NixlKVConnectorStats()
+    stats.record_failed_transfer()
+    stats.record_failed_notification()
+    stats.record_kv_expired_req()
+    assert not stats.is_empty()
+    reduced = stats.reduce()
+    assert reduced["Num successful transfers"] == 0
+    assert reduced["Avg per-transfer throughput (MB/s)"] == 0
+
+
+def test_aggregate_combines_data():
+    a = _stats_with_transfers([(1.0, 1 * MB, 2)])
+    b = _stats_with_transfers([(2.0, 2 * MB, 3)])
+    a.aggregate(b)
+    assert a.num_successful_transfers == 2
+
+
+def test_clone_and_reset():
+    stats = _stats_with_transfers([(0.5, 1 * MB, 1)])
+    snap = stats.clone_and_reset()
+    assert snap.num_successful_transfers == 1
+    assert stats.is_empty()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/stats.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/stats.py
@@ -109,7 +109,7 @@ class MooncakeKVConnectorStats(KVConnectorStats):
                 "Avg xfer time (ms)": 0,
                 "P90 xfer time (ms)": 0,
                 "Avg MB per transfer": 0,
-                "Throughput (MB/s)": 0,
+                "Avg per-transfer throughput (MB/s)": 0,
                 "Avg number of descriptors": 0,
                 "Num failed transfers": num_failed_transfers,
                 "Num failed recvs": num_failed_recvs,
@@ -124,9 +124,15 @@ class MooncakeKVConnectorStats(KVConnectorStats):
 
         total_mb = mb.sum()
         avg_mb = total_mb / n
-        total_time_seconds = xfer_time.sum()
-        throughput_mb_s = (
-            total_mb / total_time_seconds if total_time_seconds > 0 else 0.0
+        # Mean of positive-duration per-transfer rates is well-defined under
+        # concurrent transfers. Zero-duration telemetry has no defined rate.
+        # total_mb / xfer_time.sum() would inflate the denominator by concurrency
+        # because independent per-handle durations overlap in steady state.
+        positive_duration = xfer_time > 0
+        avg_throughput_mb_s = (
+            (mb[positive_duration] / xfer_time[positive_duration]).mean()
+            if positive_duration.any()
+            else 0.0
         )
 
         return {
@@ -134,7 +140,7 @@ class MooncakeKVConnectorStats(KVConnectorStats):
             "Avg xfer time (ms)": round(xfer_time.mean() * 1e3, 3),
             "P90 xfer time (ms)": round(np.percentile(xfer_time, 90).item() * 1e3, 3),
             "Avg MB per transfer": round(avg_mb, 3),
-            "Throughput (MB/s)": round(throughput_mb_s, 3),
+            "Avg per-transfer throughput (MB/s)": round(avg_throughput_mb_s, 3),
             "Avg number of descriptors": round(descs.mean(), 1),
             "Num failed transfers": num_failed_transfers,
             "Num failed recvs": num_failed_recvs,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
@@ -95,7 +95,7 @@ class NixlKVConnectorStats(KVConnectorStats):
                 "Avg post time (ms)": 0,
                 "P90 post time (ms)": 0,
                 "Avg MB per transfer": 0,
-                "Throughput (MB/s)": 0,
+                "Avg per-transfer throughput (MB/s)": 0,
                 "Avg number of descriptors": 0,
             }
 
@@ -110,8 +110,16 @@ class NixlKVConnectorStats(KVConnectorStats):
         total_mb = mb.sum()
         avg_mb = total_mb / n
 
-        total_time_seconds = xfer_time.sum()
-        throughput_mb_s = total_mb / total_time_seconds
+        # Mean of positive-duration per-transfer rates is well-defined under
+        # concurrent transfers. Zero-duration telemetry has no defined rate.
+        # total_mb / xfer_time.sum() would inflate the denominator by concurrency
+        # because independent per-handle durations overlap in steady state.
+        positive_duration = xfer_time > 0
+        avg_throughput_mb_s = (
+            (mb[positive_duration] / xfer_time[positive_duration]).mean()
+            if positive_duration.any()
+            else 0.0
+        )
 
         return {
             "Num successful transfers": n,
@@ -120,7 +128,7 @@ class NixlKVConnectorStats(KVConnectorStats):
             "Avg post time (ms)": round(post_time.mean() * 1e3, 3),
             "P90 post time (ms)": round(np.percentile(post_time, 90).item() * 1e3, 3),
             "Avg MB per transfer": round(avg_mb, 3),
-            "Throughput (MB/s)": round(throughput_mb_s, 3),
+            "Avg per-transfer throughput (MB/s)": round(avg_throughput_mb_s, 3),
             "Avg number of descriptors": round(descs.mean(), 1),
         }
 


### PR DESCRIPTION
## What's wrong

`NixlKVConnectorStats.reduce()` and `MooncakeKVConnectorStats.reduce()` both report:

```text
Throughput (MB/s) = total_mb / sum(per_transfer_durations)
```

Because transfers are posted without waiting for completion, independent per-handle stopwatch spans overlap in steady state. Summing them inflates the denominator by the average in-flight concurrency `C`, so the reported value is approximately the actual per-link throughput divided by `C`.

This was previously noted in #33170 (closed as stale) and partially addressed for NIXL only in #35876 (open and needs a rebase), but not for Mooncake.

## Fix

Replace `total_mb / sum(xfer_time)` with `mean(mb_i / xfer_time_i)`: the mean of individual positive-duration per-transfer rates. Zero-duration telemetry is ignored, with a zero fallback when no positive duration is available.

This metric is stable under concurrency, requires no cross-process clock reconciliation, and matches the per-transfer semantics already documented for the adjacent `Avg MB per transfer` field.

The metric key is renamed to `Avg per-transfer throughput (MB/s)` to accurately reflect what is measured.

## Files changed

- `vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py`
- `vllm/distributed/kv_transfer/kv_connector/v1/mooncake/stats.py`
- `tests/v1/kv_connector/unit/test_nixl_stats.py` (new)
- `tests/v1/kv_connector/unit/test_mooncake_stats.py` (updated)

## Validation

- `ruff check` passed for all four changed files.
- `ruff format --check` passed for all four changed files.
- `git diff --check` passed.
- Python byte-compilation passed for all four changed files.
- Focused unit-test execution was attempted, but this macOS environment cannot resolve vLLM's pinned `torch==2.11.0+cpu` dependency. Full multi-GPU disaggregated inference was not run because suitable hardware is unavailable.

The change only touches the reporting reduction path; it does not affect transfer data flow or execution.

Fixes #48224
