### PR TITLE
[CI/Build] Re-enable registry tests for 3 now-public model checkpoints

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -895,7 +895,6 @@ _MULTIMODAL_EXAMPLE_MODELS = {
     ),
     "Granite4VisionForConditionalGeneration": _HfExamplesInfo(
         "ibm-granite/granite-vision-4.1-4b",
-        is_available_online=False,
     ),
     "GraniteVision": _HfExamplesInfo("ibm-granite/granite-vision-3.3-2b"),
     "GraniteSpeechForConditionalGeneration": _HfExamplesInfo(
@@ -1442,7 +1441,6 @@ _SPECULATIVE_DECODING_EXAMPLE_MODELS = {
     "Qwen3DSparkModel": _HfExamplesInfo(
         "Qwen/Qwen3-8B",
         speculative_model="deepseek-ai/dspark_qwen3_8b_block7",
-        is_available_online=False,
         use_original_num_layers=True,  # DSpark backbone requires all layers
     ),
     # [Eagle]
@@ -1617,7 +1615,6 @@ _SPECULATIVE_DECODING_EXAMPLE_MODELS = {
     "GlmOcrMTPModel": _HfExamplesInfo(
         "zai-org/GLM-OCR",
         speculative_model="zai-org/GLM-OCR",
-        is_available_online=False,
         min_transformers_version="5.1.0",
     ),
     "HYV3MTPModel": _HfExamplesInfo(


### PR DESCRIPTION
## Purpose

`Granite4VisionForConditionalGeneration`, `GlmOcrMTPModel` and `Qwen3DSparkModel` carry `is_available_online=False` in `tests/models/registry.py`, set while their checkpoints were unpublished. All three repos have since gone public, so the flags now only disable their CI coverage (initialization, and for Granite4-Vision the multimodal processing tests). Same class as #48211.

Each entry was verified three ways before unflagging: the HF repo is public, its `config.json` declares the registered architecture, and `test_can_initialize_large_subset` passes locally.

An audit of the other flagged entries found they must **stay** flagged — not for availability, but because initialization genuinely fails today: DeepSeek-V4 asserts `fp8_ds_mla` requires an fp8 KV cache (the test uses `auto`), MiniMax-M3 OOMs a 32 GiB GPU even with dummy weights, and Gemma4-Unified/Intern-S2 hit config errors. Details in the commit message; those need their own fixes first.

## Test Plan

```bash
pytest tests/models/test_initialization.py -k "Granite4Vision or GlmOcrMTP or Qwen3DSpark"
```

## Test Result

On 1×RTX 5090:

```
3 passed, 360 deselected in 29.26s
```