### PR TITLE
[BugFix] Honor drop_eagle_block in MambaManager

### DIFF
--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -14,11 +14,15 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     ChunkedLocalAttentionManager,
+    FullAttentionManager,
+    MambaManager,
     RSWAManager,
     SlidingWindowManager,
 )
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
+    FullAttentionSpec,
+    MambaSpec,
     RSWASpec,
     SlidingWindowSpec,
 )
@@ -534,3 +538,74 @@ def test_predictor_matches_allocator_blocks_calculation_with_admission_cap():
             f"but allocator pulled {len(new_blocks)}"
         )
         total_computed = num_tokens
+
+
+def test_mamba_honors_drop_eagle_block():
+    """MambaManager must drop the EAGLE lookahead block, like FullAttentionManager.
+
+    EAGLE/MTP requires the final matched block of a cache hit be dropped and
+    recomputed: it can hold state written over draft positions that verification
+    later rejects. FullAttentionManager pops it. Before this fix MambaManager
+    accepted `drop_eagle_block` and ignored it, so its hit came back one block
+    longer, and the retained block's recurrent-state snapshot -- taken over the
+    unverified positions -- stayed hash-reachable for every later request sharing
+    the prefix (#43559).
+
+    block_size == alignment_tokens here, so the alignment loop is a no-op in both
+    managers and the eagle drop is the only behavior under test.
+    """
+    block_size = 16
+    num_blocks = 5
+    full_gid, mamba_gid = 0, 1
+
+    block_pool = BlockPool(
+        num_gpu_blocks=64, enable_caching=True, hash_block_size=block_size
+    )
+    block_hashes = [BlockHash(f"blk{i:04d}".encode()) for i in range(num_blocks)]
+
+    # Cache the same prefix chain under both groups, each on real blocks.
+    for gid in (full_gid, mamba_gid):
+        for i, (block_hash, block) in enumerate(
+            zip(block_hashes, block_pool.get_new_blocks(num_blocks))
+        ):
+            block_pool._insert_block_hash(
+                make_block_hash_with_group_id(block_hash, gid),
+                block,
+                num_tokens=(i + 1) * block_size,
+            )
+
+    full_spec = FullAttentionSpec(
+        block_size=block_size, num_kv_heads=1, head_size=1, dtype=torch.float16
+    )
+    mamba_spec = MambaSpec(
+        block_size=block_size,
+        shapes=((1,),),
+        dtypes=(torch.float16,),
+        mamba_cache_mode="align",
+    )
+
+    def hit_blocks(manager, gid, spec, drop_eagle_block):
+        return len(
+            manager.find_longest_cache_hit(
+                block_hashes=block_hashes,
+                max_length=num_blocks * block_size,
+                kv_cache_group_ids=[gid],
+                block_pool=block_pool,
+                kv_cache_spec=spec,
+                drop_eagle_block=drop_eagle_block,
+                alignment_tokens=block_size,
+            )[0]
+        )
+
+    # Control: with no eagle drop, both groups see the whole cached prefix.
+    assert hit_blocks(FullAttentionManager, full_gid, full_spec, False) == num_blocks
+    assert hit_blocks(MambaManager, mamba_gid, mamba_spec, False) == num_blocks
+
+    # With the eagle drop requested, both must give up the final block.
+    full_hit = hit_blocks(FullAttentionManager, full_gid, full_spec, True)
+    mamba_hit = hit_blocks(MambaManager, mamba_gid, mamba_spec, True)
+    assert full_hit == num_blocks - 1
+    assert mamba_hit == full_hit, (
+        f"MambaManager ignored drop_eagle_block: full-attention dropped the "
+        f"lookahead block (hit={full_hit}), mamba kept it (hit={mamba_hit})"
+    )

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -781,3 +781,74 @@ def test_predictor_matches_allocator_blocks_calculation_with_admission_cap():
             f"but allocator pulled {len(new_blocks)}"
         )
         total_computed = num_tokens
+
+
+def test_mamba_honors_drop_eagle_block():
+    """MambaManager must drop the EAGLE lookahead block, like FullAttentionManager.
+
+    EAGLE/MTP requires the final matched block of a cache hit be dropped and
+    recomputed: it can hold state written over draft positions that verification
+    later rejects. FullAttentionManager pops it. Before this fix MambaManager
+    accepted `drop_eagle_block` and ignored it, so its hit came back one block
+    longer, and the retained block's recurrent-state snapshot -- taken over the
+    unverified positions -- stayed hash-reachable for every later request sharing
+    the prefix (#43559).
+
+    block_size == alignment_tokens here, so the alignment loop is a no-op in both
+    managers and the eagle drop is the only behavior under test.
+    """
+    block_size = 16
+    num_blocks = 5
+    full_gid, mamba_gid = 0, 1
+
+    block_pool = BlockPool(
+        num_gpu_blocks=64, enable_caching=True, hash_block_size=block_size
+    )
+    block_hashes = [BlockHash(f"blk{i:04d}".encode()) for i in range(num_blocks)]
+
+    # Cache the same prefix chain under both groups, each on real blocks.
+    for gid in (full_gid, mamba_gid):
+        for i, (block_hash, block) in enumerate(
+            zip(block_hashes, block_pool.get_new_blocks(num_blocks))
+        ):
+            block_pool._insert_block_hash(
+                make_block_hash_with_group_id(block_hash, gid),
+                block,
+                num_tokens=(i + 1) * block_size,
+            )
+
+    full_spec = FullAttentionSpec(
+        block_size=block_size, num_kv_heads=1, head_size=1, dtype=torch.float16
+    )
+    mamba_spec = MambaSpec(
+        block_size=block_size,
+        shapes=((1,),),
+        dtypes=(torch.float16,),
+        mamba_cache_mode="align",
+    )
+
+    def hit_blocks(manager, gid, spec, drop_eagle_block):
+        return len(
+            manager.find_longest_cache_hit(
+                block_hashes=block_hashes,
+                max_length=num_blocks * block_size,
+                kv_cache_group_ids=[gid],
+                block_pool=block_pool,
+                kv_cache_spec=spec,
+                drop_eagle_block=drop_eagle_block,
+                alignment_tokens=block_size,
+            )[0]
+        )
+
+    # Control: with no eagle drop, both groups see the whole cached prefix.
+    assert hit_blocks(FullAttentionManager, full_gid, full_spec, False) == num_blocks
+    assert hit_blocks(MambaManager, mamba_gid, mamba_spec, False) == num_blocks
+
+    # With the eagle drop requested, both must give up the final block.
+    full_hit = hit_blocks(FullAttentionManager, full_gid, full_spec, True)
+    mamba_hit = hit_blocks(MambaManager, mamba_gid, mamba_spec, True)
+    assert full_hit == num_blocks - 1
+    assert mamba_hit == full_hit, (
+        f"MambaManager ignored drop_eagle_block: full-attention dropped the "
+        f"lookahead block (hit={full_hit}), mamba kept it (hit={mamba_hit})"
+    )

--- a/tests/v1/e2e/general/test_mamba_prefix_cache.py
+++ b/tests/v1/e2e/general/test_mamba_prefix_cache.py
@@ -898,6 +898,102 @@ def _run_mamba_prefix_cache_mrv1(
     cleanup_dist_env_and_memory()
 
 
+def _run_mamba_eagle_block_reuse(
+    monkeypatch: pytest.MonkeyPatch, async_scheduling: bool
+):
+    """Recreate the #43559 failure conditions: a request finishing right after a
+    block boundary it crossed with every draft rejected, then a second request
+    whose cache hit lands on that final (eagle) block.
+
+    Request A ends a few tokens past the 2nd aligned boundary; with
+    num_accepted_tokens=1 every boundary crossing happens with rejected drafts
+    in flight, and A finishes before any later step could repair its cached
+    snapshot. Request B shares the prefix: pre-fix MambaManager returns the
+    boundary block as part of the hit (B resumes on the possibly-poisoned
+    snapshot), post-fix the hit stops one block earlier and B recomputes it.
+
+    Assertions, all deterministic:
+      1. B's num_cached_tokens == BLOCK_SIZE (the eagle block was dropped).
+      2. A's cached snapshot at the boundary matches the no-spec reference.
+      3. B's state at its next boundary matches the reference -- corruption
+         resumed from the reused block would surface here (the user-visible
+         failure, at state level).
+    """
+    global async_scheduling_mode
+    async_scheduling_mode = async_scheduling
+    run_ref_mamba_state_in_subprocess()
+    apply_patch(monkeypatch)
+    full_prompt = datasets.load_dataset("heheda/a_long_article")["train"][0]["text"]
+
+    engine = LLM(
+        model=MODEL,
+        load_format="dummy",
+        enable_prefix_caching=True,
+        block_size=BLOCK_SIZE,
+        mamba_cache_mode="align",
+        speculative_config={
+            "method": "qwen3_next_mtp",
+            "num_speculative_tokens": num_speculative_tokens,
+        },
+        max_num_batched_tokens=3072,
+        hf_overrides={"num_hidden_layers": NUM_HIDDEN_LAYERS},
+        async_scheduling=async_scheduling,
+        seed=42,
+    )
+    global prompt_token_ids
+    prompt_token_ids = engine.get_tokenizer().encode(full_prompt)
+    global num_accepted_tokens
+    num_accepted_tokens = 1
+    global cur_step_action_idx, step_actions
+    cur_step_action_idx = 0
+    step_actions = []
+
+    boundary = BLOCK_SIZE * 2
+    # A decodes across BOTH boundaries (align mode only snapshots state at
+    # decode/chunk crossings, and B needs a fallback state block once the
+    # eagle block is dropped), rejecting 3 drafts every step, and finishes
+    # a few tokens past the second boundary -- no later step can repair the
+    # cached snapshot.
+    engine.generate(
+        [TokensPrompt(prompt_token_ids=prompt_token_ids[: BLOCK_SIZE - 2])],
+        SamplingParams(temperature=0.0, max_tokens=BLOCK_SIZE + 10),
+    )
+    a_boundary_state = mamba_kv_cache_dict.get(boundary)
+    assert a_boundary_state is not None, "A never cached the boundary block"
+    mamba_kv_cache_dict.clear()
+
+    # B: prefix through the boundary, prompt ending shy of the next one so a
+    # few decode steps cross it and its state gets captured for comparison.
+    next_boundary = BLOCK_SIZE * 3
+    (out_b,) = engine.generate(
+        [TokensPrompt(prompt_token_ids=prompt_token_ids[: next_boundary - 10])],
+        SamplingParams(temperature=0.0, max_tokens=15),
+    )
+    assert out_b.num_cached_tokens == BLOCK_SIZE, (
+        f"cache hit must drop the eagle block: expected {BLOCK_SIZE} cached "
+        f"tokens, got {out_b.num_cached_tokens}"
+    )
+
+    mamba_state_ref = torch.load("mamba_kv_cache_dict_ref.pth")
+    check_mamba_state_equal(mamba_state_ref, {boundary: a_boundary_state}, [boundary])
+    check_mamba_state_equal(mamba_state_ref, mamba_kv_cache_dict, [next_boundary])
+
+    mamba_kv_cache_dict.clear()
+    del engine
+    torch.accelerator.empty_cache()
+    cleanup_dist_env_and_memory()
+
+
+@create_new_process_for_each_test()
+def test_mamba_eagle_block_reuse_mrv1(monkeypatch: pytest.MonkeyPatch):
+    _run_mamba_eagle_block_reuse(monkeypatch, async_scheduling=False)
+
+
+@create_new_process_for_each_test()
+def test_mamba_eagle_block_reuse_mrv1_async(monkeypatch: pytest.MonkeyPatch):
+    _run_mamba_eagle_block_reuse(monkeypatch, async_scheduling=True)
+
+
 @create_new_process_for_each_test()
 def test_mamba_prefix_cache_mrv1(monkeypatch: pytest.MonkeyPatch):
     _run_mamba_prefix_cache_mrv1(monkeypatch, async_scheduling=False)

--- a/tests/v1/e2e/general/test_mamba_prefix_cache.py
+++ b/tests/v1/e2e/general/test_mamba_prefix_cache.py
@@ -938,6 +938,102 @@ def _run_mamba_prefix_cache_mrv1(
     cleanup_dist_env_and_memory()
 
 
+def _run_mamba_eagle_block_reuse(
+    monkeypatch: pytest.MonkeyPatch, async_scheduling: bool
+):
+    """Recreate the #43559 failure conditions: a request finishing right after a
+    block boundary it crossed with every draft rejected, then a second request
+    whose cache hit lands on that final (eagle) block.
+
+    Request A ends a few tokens past the 2nd aligned boundary; with
+    num_accepted_tokens=1 every boundary crossing happens with rejected drafts
+    in flight, and A finishes before any later step could repair its cached
+    snapshot. Request B shares the prefix: pre-fix MambaManager returns the
+    boundary block as part of the hit (B resumes on the possibly-poisoned
+    snapshot), post-fix the hit stops one block earlier and B recomputes it.
+
+    Assertions, all deterministic:
+      1. B's num_cached_tokens == BLOCK_SIZE (the eagle block was dropped).
+      2. A's cached snapshot at the boundary matches the no-spec reference.
+      3. B's state at its next boundary matches the reference -- corruption
+         resumed from the reused block would surface here (the user-visible
+         failure, at state level).
+    """
+    global async_scheduling_mode
+    async_scheduling_mode = async_scheduling
+    run_ref_mamba_state_in_subprocess()
+    apply_patch(monkeypatch)
+    full_prompt = datasets.load_dataset("heheda/a_long_article")["train"][0]["text"]
+
+    engine = LLM(
+        model=MODEL,
+        load_format="dummy",
+        enable_prefix_caching=True,
+        block_size=BLOCK_SIZE,
+        mamba_cache_mode="align",
+        speculative_config={
+            "method": "qwen3_next_mtp",
+            "num_speculative_tokens": num_speculative_tokens,
+        },
+        max_num_batched_tokens=3072,
+        hf_overrides={"num_hidden_layers": NUM_HIDDEN_LAYERS},
+        async_scheduling=async_scheduling,
+        seed=42,
+    )
+    global prompt_token_ids
+    prompt_token_ids = engine.get_tokenizer().encode(full_prompt)
+    global num_accepted_tokens
+    num_accepted_tokens = 1
+    global cur_step_action_idx, step_actions
+    cur_step_action_idx = 0
+    step_actions = []
+
+    boundary = BLOCK_SIZE * 2
+    # A decodes across BOTH boundaries (align mode only snapshots state at
+    # decode/chunk crossings, and B needs a fallback state block once the
+    # eagle block is dropped), rejecting 3 drafts every step, and finishes
+    # a few tokens past the second boundary -- no later step can repair the
+    # cached snapshot.
+    engine.generate(
+        [TokensPrompt(prompt_token_ids=prompt_token_ids[: BLOCK_SIZE - 2])],
+        SamplingParams(temperature=0.0, max_tokens=BLOCK_SIZE + 10),
+    )
+    a_boundary_state = mamba_kv_cache_dict.get(boundary)
+    assert a_boundary_state is not None, "A never cached the boundary block"
+    mamba_kv_cache_dict.clear()
+
+    # B: prefix through the boundary, prompt ending shy of the next one so a
+    # few decode steps cross it and its state gets captured for comparison.
+    next_boundary = BLOCK_SIZE * 3
+    (out_b,) = engine.generate(
+        [TokensPrompt(prompt_token_ids=prompt_token_ids[: next_boundary - 10])],
+        SamplingParams(temperature=0.0, max_tokens=15),
+    )
+    assert out_b.num_cached_tokens == BLOCK_SIZE, (
+        f"cache hit must drop the eagle block: expected {BLOCK_SIZE} cached "
+        f"tokens, got {out_b.num_cached_tokens}"
+    )
+
+    mamba_state_ref = torch.load("mamba_kv_cache_dict_ref.pth")
+    check_mamba_state_equal(mamba_state_ref, {boundary: a_boundary_state}, [boundary])
+    check_mamba_state_equal(mamba_state_ref, mamba_kv_cache_dict, [next_boundary])
+
+    mamba_kv_cache_dict.clear()
+    del engine
+    torch.accelerator.empty_cache()
+    cleanup_dist_env_and_memory()
+
+
+@create_new_process_for_each_test("spawn")
+def test_mamba_eagle_block_reuse_mrv1(monkeypatch: pytest.MonkeyPatch):
+    _run_mamba_eagle_block_reuse(monkeypatch, async_scheduling=False)
+
+
+@create_new_process_for_each_test("spawn")
+def test_mamba_eagle_block_reuse_mrv1_async(monkeypatch: pytest.MonkeyPatch):
+    _run_mamba_eagle_block_reuse(monkeypatch, async_scheduling=True)
+
+
 @create_new_process_for_each_test("spawn")
 def test_mamba_prefix_cache_mrv1(monkeypatch: pytest.MonkeyPatch):
     _run_mamba_prefix_cache_mrv1(monkeypatch, async_scheduling=False)

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1069,6 +1069,15 @@ class MambaManager(SingleTypeKVCacheManager):
 
         block_size = kv_cache_spec.block_size
         max_num_blocks = max_length // block_size
+        if drop_eagle_block and max_num_blocks > 0:
+            # EAGLE/MTP: drop the final matched page. Its recurrent-state snapshot
+            # may have been taken over draft tokens that verification later rejects,
+            # so the state must be restored from the previous page boundary and
+            # recomputed forward. FullAttentionManager (see find_longest_cache_hit
+            # above) pops the last block; Mamba keeps only the rightmost real block
+            # with the prefix null-padded, so a literal pop would delete the state
+            # block itself -- lower the search ceiling by one page instead.
+            max_num_blocks -= 1
         # Search from right to left and early stop when a match is found.
         for i in range(max_num_blocks - 1, -1, -1):
             if cached_block := block_pool.get_cached_block(

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1507,6 +1507,15 @@ class MambaManager(SingleTypeKVCacheManager):
             return computed_blocks, hit_length
 
         max_num_blocks = max_length // block_size
+        if drop_eagle_block and max_num_blocks > 0:
+            # EAGLE/MTP: drop the final matched page. Its recurrent-state snapshot
+            # may have been taken over draft tokens that verification later rejects,
+            # so the state must be restored from the previous page boundary and
+            # recomputed forward. FullAttentionManager (see find_longest_cache_hit
+            # above) pops the last block; Mamba keeps only the rightmost real block
+            # with the prefix null-padded, so a literal pop would delete the state
+            # block itself -- lower the search ceiling by one page instead.
+            max_num_blocks -= 1
         # Search from right to left and early stop when a match is found.
         for i in range(max_num_blocks - 1, -1, -1):
             if cached_block := block_pool.get_cached_block(


### PR DESCRIPTION
## Purpose

On a hybrid model (full-attention + Mamba/GDN layers, e.g. Qwen3.6-35B-A3B), enabling MTP/EAGLE
speculative decoding together with prefix caching corrupts the recurrent state, and the server
serves wrong answers. #43559 reports tool-eval accuracy dropping from ~90% to ~50%. Nothing raises
an exception and nothing shows up in the logs, so an operator has no signal that anything is wrong,
and prefix caching then spreads it, because the corrupted state is hash-reachable and every later
request sharing that prefix restores from it.

The root cause is the `find_longest_cache_hit` method on `MambaManager`, at
`vllm/v1/core/single_type_kv_cache_manager.py:1049` on `main`, which takes `drop_eagle_block` in its
signature and never acts on it. Its body searches right-to-left for the last cached block, builds
`[null]*i + [cached]`, and breaks, referencing neither `drop_eagle_block` nor `.pop(`.

Every other manager that can receive the flag handles it:

| Manager | Behavior on `drop_eagle_block` |
|---|---|
| `FullAttentionManager` (:603) | `if drop_eagle_block and computed_blocks[0]: computed.pop()` |
| `SlidingWindowManager` (:763) | pops |
| `ChunkedLocalAttentionManager` (:936) | asserts `drop_eagle_block is False` rather than mishandle it |
| `MambaManager` (:1049) | **accepts the flag and silently ignores it** |

EAGLE/MTP requires the final matched block of a cache hit be dropped and recomputed, because it can
hold state written over draft positions that verification later rejects. Full-attention honors that.
The Mamba group keeps its final block, whose recurrent-state snapshot was taken over those
unverified positions. The one-block length mismatch between the two groups is how the bug is
detected; the harm is that the retained snapshot is restored and reused.

It propagates rather than getting masked. The coordinator's fixed-point loop only shrinks the
candidate length when a group reports a *shorter* hit. Mamba reports a *longer* one, so nothing
converges downward, and the final `hit_length` is the un-dropped mamba length
(`kv_cache_coordinator.py:732`).

The configuration that triggers this is the only one Qwen3.6 can be in. `is_eagle_group = True` is
set in exactly one place, `kv_cache_utils.py:1715`, inside `_annotate_eagle_groups_deepseek_v4`,
which early-returns
unless a spec's `model_version == "deepseek_v4"` (:1705). For any non-deepseek_v4 model, no group is
flagged, so `HybridKVCacheCoordinator` takes its "conservatively fall back to flag all groups when no
group is flagged" path (`kv_cache_coordinator.py:103-104`) and the mamba group is included. With MTP
on, Qwen3.6 is *guaranteed* to hand the mamba group `drop_eagle_block=True` (:710) and to have it
ignored.

### The fix

A nine-line change to `MambaManager.find_longest_cache_hit`: when `drop_eagle_block` is set, lower
the search ceiling by one page (`max_num_blocks -= 1`) so the rightmost retained page is the one
before the eagle lookahead block.

It is deliberately **not** a literal `.pop()` mirroring `FullAttentionManager:603`. Mamba's hit list
is null-padded with the single real state block at the *end*: `[null, null, null, null, REAL]`. A
literal pop removes the real block and leaves an all-null hit claiming N-1 pages computed with no
state to restore from, which is worse than the bug it fixes. Lowering the ceiling instead lands on a
real earlier snapshot, `[null, null, null, REAL]`, which is what the coordinator's `_max_length`
peek-bump (`kv_cache_coordinator.py:712-720`) was set up to allow.

### Cost

This recomputes one mamba page per eagle cache hit, and a mamba page is 1000+ tokens of recurrent
state. That is expensive, and it is what EAGLE correctness requires.

The cheaper fix is on the write side: stop caching the lookahead block at all (the `_max_length` bump
plus the align-mode snapshot in `MambaManager.cache_blocks` / `reachable_block_mask`), so nothing
needs recomputing. That is the better long-term answer, and it is what the existing drafts (#43650,
#45477, #46281, and #47861 from @yanghui1-arch) are working toward. That change is larger and
subtler, and none of the drafts has merged yet.

This PR is the minimal correctness fix. Serving correct answers slower beats serving fast wrong ones,
and the write-side optimization can land on top of it without conflict. Scope is the aligned-block
case that align-mode prefix caching already guarantees.

Fixes #43559.

## Test Plan

`test_mamba_honors_drop_eagle_block` in `tests/v1/core/test_single_type_kv_cache_manager.py`,
alongside the existing manager tests. It is a `cpu_test`: no GPU, no model weights, no server, no
monkeypatching, using the real `BlockPool`, real specs, and the real classmethod. `block_size ==
alignment_tokens`, so the alignment loop is a no-op in both managers and the eagle drop is the only
behavior under test.

It carries a positive control (`drop_eagle_block=False`, both managers must see the full 5-block
prefix) so a passing result cannot come from a broken fixture, then asserts that with
`drop_eagle_block=True` the mamba hit matches full-attention's.

The bug also reproduces one level up, through `get_kv_cache_coordinator` ->
`HybridKVCacheCoordinator`: unpatched, the coordinator adopts the un-dropped mamba length and
returns `hit_length=80` where full-attention dropped to 64. I have that repro as well and am glad to
add it as a second test if you want the coverage at that layer.

## Test Result

Before, the new test fails on the parity assertion:

```
drop_eagle_block=False -> full-attn 5 blocks, mamba 5 blocks   (control passes)
drop_eagle_block=True  -> full-attn 4 blocks, mamba 5 blocks   (mamba retained the final block)
AssertionError: MambaManager ignored drop_eagle_block ...
```

After:

```
drop_eagle_block=False -> full-attn 5 blocks, mamba 5 blocks   (control unchanged)
drop_eagle_block=True  -> full-attn 4 blocks, mamba 4 blocks   (parity)
```

At the coordinator level, `hit_length` goes from 80 tokens (the un-dropped mamba length) to 64,
matching what full-attention dropped to.

One note on how this was validated. The bug was found and the fix exercised against v0.24.0, where I
could run the code with its compiled extensions: RED before, GREEN after, with the installed tree
left byte-identical and the change applied to a copy. The same change applies cleanly to `main`
(offset only), `MambaManager.find_longest_cache_hit` on `main` still takes `drop_eagle_block` and
still never reads it, and every API the test touches is unchanged there. I do not have a `main`
source build locally, so CI is the first execution of this test against `main`.
