### PR TITLE
[Doc] Correct suffix decoding default

### DIFF
--- a/docs/features/speculative_decoding/suffix.md
+++ b/docs/features/speculative_decoding/suffix.md
@@ -10,7 +10,7 @@ Suffix Decoding can achieve better performance for tasks with high repetition, s
     Suffix Decoding requires [Arctic Inference](https://github.com/snowflakedb/ArcticInference). You can install it with `pip install arctic-inference`.
 
 !!! tip "Suffix Decoding Speculative Tokens"
-    Suffix Decoding will speculate a dynamic number of tokens for each request at each decoding step, so the `num_speculative_tokens` configuration specifies the *maximum* number of speculative tokens. It is suggested to use a high number such as `16` or `32` (default).
+    Suffix Decoding will speculate a dynamic number of tokens for each request at each decoding step, so the `num_speculative_tokens` configuration specifies the *maximum* number of speculative tokens. It is suggested to use a high number such as `16` or `24` (default).
 
 ```python
 from vllm import LLM, SamplingParams


### PR DESCRIPTION
## Summary

Correct the documented default maximum speculative token count for suffix decoding from 32 to 24. This matches `suffix_decoding_max_tree_depth` and the fallback assignment in `SpeculativeConfig._validate_suffix_decoding`.

## Duplicate work

I searched open pull requests for suffix decoding documentation and default-value changes. PR #37383 documents the broader speculative configuration surface, including the correct tree-depth default, but it does not modify `suffix.md` or fix this stale sentence. No open PR found by the other keyword searches addresses this correction.

## Testing

- `git diff --check`
- Cross-checked the value against `vllm/config/speculative.py` and `docs/features/speculative_decoding/README.md`

## Model evaluation

Not applicable; this documentation-only change does not affect model output, accuracy, or serving behavior.

## AI assistance

AI assistance was used to inspect the implementation and history, make the one-word documentation correction, and prepare this pull request. I reviewed the complete changed line and verified the documented value against the implementation.