### PR TITLE
[Bugfix] Set kv_quant_mode on the generic MLA KV-cache spec

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1008,10 +1008,6 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             head_size=self.head_size,
             dtype=kv_cache_dtype,
             cache_dtype_str=vllm_config.cache_config.cache_dtype,
-            # Without this the spec defaults to KVQuantMode.NONE, which the
-            # KV-cache reshape treats as "layer skipped from quantization" and
-            # sizes the view by head_size instead of the fp8_ds_mla byte
-            # layout (mirrors the DeepseekV4 fix in #47716).
             kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
         )
 

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -277,6 +277,7 @@ from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     KVCacheSpec,
     MLAAttentionSpec,
+    get_kv_quant_mode,
 )
 
 logger = init_logger(__name__)
@@ -1007,6 +1008,11 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             head_size=self.head_size,
             dtype=kv_cache_dtype,
             cache_dtype_str=vllm_config.cache_config.cache_dtype,
+            # Without this the spec defaults to KVQuantMode.NONE, which the
+            # KV-cache reshape treats as "layer skipped from quantization" and
+            # sizes the view by head_size instead of the fp8_ds_mla byte
+            # layout (mirrors the DeepseekV4 fix in #47716).
+            kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
         )
 
     def _v_up_proj(self, x: torch.Tensor, out: torch.Tensor):


### PR DESCRIPTION
FIX #48378

`MLAAttention.get_kv_cache_spec` left `kv_quant_mode` at its `KVQuantMode.NONE` default, so the KV-cache reshape treated every MLA layer as skipped from quantization and sized the view by `head_size` (576 elements/token) while the raw tensor is allocated by the fp8_ds_mla byte layout (656 B/token):

```
RuntimeError: shape '[512, 64, 576]' is invalid for input of size 21495808
```

Any DeepSeek-V3.2 / GLM DSA model with `--kv-cache-dtype fp8_ds_mla` crashes at engine init on current main (no DCP or spec-decode needed). The DeepseekV4-specific spec constructor received the same fix in #47716; this mirrors it on the generic MLA path.

**Not a duplicate:** #47309 switches `cache_dtype_str` to the per-layer value but does not set `kv_quant_mode`; #47776 preserves `kv_quant_mode` through the SWA-MLA spec merge only. Neither touches `MLAAttention.get_kv_cache_spec`.

**Testing** (4×H200, GLM-5.2-NVFP4):
- Repro before fix on plain nightly `0.25.1.dev37+g3d99b0499`: `vllm serve nvidia/GLM-5.2-NVFP4 --tensor-parallel-size 4 --kv-cache-dtype fp8_ds_mla --max-model-len 131072` → the RuntimeError above.
- After fix: same command boots; additionally validated TP4/DCP4/EP + MTP at 786k context — cudagraph capture clean, coherent output, exact 198k-token needle retrieval, 78 tok/s N=1 / 854 tok/s aggregate N=32.
- `pytest tests/v1/attention/test_sparse_mla_backends.py tests/v1/attention/test_indexer_dcp_localize.py -v` — 140 passed / 420 skipped (SM-gated) / 0 failed on H200.

AI assistance was used for this change (Claude); the submitter reviewed every line and ran the tests above.
