### PR TITLE
[Perf][Model Loader] Reload layout-preserving weights directly

### DIFF
--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -10,6 +10,7 @@ from torch.nn.parameter import UninitializedParameter
 
 import vllm.model_executor.model_loader.reload.meta as reload_meta
 from vllm.model_executor.layers.linear import QKVParallelLinear
+from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.model_loader.reload.layerwise import (
     finalize_layerwise_reload,
     initialize_layerwise_reload,
@@ -99,6 +100,41 @@ class _NonPersistentBufferLayer(torch.nn.Module):
         self.register_buffer("scale", torch.tensor(0.25), persistent=False)
 
 
+class _DirectReloadMethod(QuantizeMethodBase):
+    def __init__(self, supported: bool):
+        self.supported = supported
+        self.process_calls = 0
+
+    def create_weights(self, layer, *weight_args, **extra_weight_attrs):
+        raise NotImplementedError
+
+    def apply(self, layer, *args, **kwargs):
+        raise NotImplementedError
+
+    def process_weights_after_loading(self, layer):
+        self.process_calls += 1
+
+    def supports_direct_weight_reload(self, layer):
+        return self.supported
+
+
+class _DirectReloadLayer(torch.nn.Module):
+    def __init__(self, supported: bool):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.arange(6.0).reshape(2, 3))
+        self.weight.weight_loader = default_weight_loader
+        self.quant_method = _DirectReloadMethod(supported)
+
+
+class _DirectReloadParameter(torch.nn.Parameter):
+    def load_merged_weight(self, loaded_weight):
+        self.data.copy_(loaded_weight)
+
+
+def _merged_weight_loader(param, loaded_weight):
+    param.load_merged_weight(loaded_weight)
+
+
 def test_move_metatensors():
     tensor = torch.empty((1, 2, 3))
     meta_tensor = to_meta_tensor(tensor)
@@ -135,6 +171,61 @@ def test_reload_lifecycle():
         assert tensor.shape == materialized_tensor.shape
         assert tensor.__class__ == materialized_tensor.__class__
         assert tensor.__dict__ == materialized_tensor.__dict__
+
+
+@pytest.mark.parametrize("supported", [True, False])
+def test_direct_weight_reload_preserves_runtime_storage(supported):
+    layer = _DirectReloadLayer(supported)
+    model = torch.nn.Sequential(layer)
+    original_data_ptr = layer.weight.data_ptr()
+    loaded_weight = torch.full_like(layer.weight, 7.0)
+
+    record_metadata_for_reloading(model)
+    initialize_layerwise_reload(model)
+
+    if supported:
+        assert not layer.weight.is_meta
+    else:
+        assert layer.weight.is_meta
+
+    layer.weight.weight_loader(layer.weight, loaded_weight)
+    finalize_layerwise_reload(model, model_config=None)
+
+    assert torch.equal(layer.weight, loaded_weight)
+    assert layer.weight.data_ptr() == original_data_ptr
+    assert layer.quant_method.process_calls == (0 if supported else 1)
+
+
+def test_direct_weight_reload_requires_matching_layout():
+    layer = _DirectReloadLayer(supported=True)
+    model = torch.nn.Sequential(layer)
+
+    record_metadata_for_reloading(model)
+    layer.weight = torch.nn.Parameter(layer.weight.t().contiguous())
+    layer.weight.weight_loader = default_weight_loader
+    initialize_layerwise_reload(model)
+
+    assert layer.weight.is_meta
+
+
+def test_direct_weight_reload_restores_parameter_loading_metadata():
+    layer = _DirectReloadLayer(supported=True)
+    layer.weight = _DirectReloadParameter(layer.weight.data)
+    layer.weight.weight_loader = _merged_weight_loader
+    model = torch.nn.Sequential(layer)
+    loaded_weight = torch.full_like(layer.weight, 7.0)
+
+    record_metadata_for_reloading(model)
+    original_data_ptr = layer.weight.data_ptr()
+    layer.weight = torch.nn.Parameter(layer.weight.data)
+    initialize_layerwise_reload(model)
+
+    assert isinstance(layer.weight, _DirectReloadParameter)
+    layer.weight.weight_loader(layer.weight, loaded_weight)
+    finalize_layerwise_reload(model, model_config=None)
+
+    assert torch.equal(layer.weight, loaded_weight)
+    assert layer.weight.data_ptr() == original_data_ptr
 
 
 def test_materialize_layer_preserves_non_meta_tensors():

--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -12,7 +12,6 @@ import vllm.model_executor.model_loader.reload.meta as reload_meta
 from vllm.model_executor.layers.linear import QKVParallelLinear
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.model_loader.reload.layerwise import (
-    _DEFERRED_ATTENTION_TYPES,
     _matching_tensor_layouts,
     finalize_layerwise_reload,
     get_layerwise_info,
@@ -262,20 +261,8 @@ def test_direct_weight_reload_requires_matching_tensor_sets():
     assert not _matching_tensor_layouts(
         {"weight": weight}, {"weight": weight, "extra": extra}
     )
-
-
-def test_deferred_attention_types_are_complete():
-    from vllm.model_executor.layers.attention import (
-        Attention,
-        MLAAttention,
-        MMEncoderAttention,
-    )
-
-    assert (
-        Attention,
-        MLAAttention,
-        MMEncoderAttention,
-    ) == _DEFERRED_ATTENTION_TYPES
+    for tensor in (UninitializedParameter(), UninitializedBuffer()):
+        assert not _matching_tensor_layouts({"weight": tensor}, {"weight": tensor})
 
 
 def test_direct_weight_reload_restores_parameter_loading_metadata():
@@ -555,11 +542,6 @@ def test_capture_layer_to_meta_skips_uninitialized_parameter_storage_ptrs():
     _, buffers = capture_layer_to_meta(layer)
 
     assert "weight_view" not in buffers
-
-
-def test_lazy_tensors_fail_closed_without_reading_storage():
-    for tensor in (UninitializedParameter(), UninitializedBuffer()):
-        assert not _matching_tensor_layouts({"weight": tensor}, {"weight": tensor})
 
 
 def test_layerwise_reload_skips_child_parameter_alias_buffers(monkeypatch):

--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -2,14 +2,19 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import gc
 import inspect
+from types import SimpleNamespace
 from weakref import WeakKeyDictionary, ref
 
 import pytest
 import torch
 from torch.nn.parameter import UninitializedBuffer, UninitializedParameter
 
+import vllm.model_executor.model_loader.reload.layerwise as reload_layerwise
 import vllm.model_executor.model_loader.reload.meta as reload_meta
-from vllm.model_executor.layers.linear import QKVParallelLinear
+from vllm.model_executor.layers.linear import (
+    QKVParallelLinear,
+    UnquantizedLinearMethod,
+)
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.model_loader.reload.layerwise import (
     _matching_tensor_layouts,
@@ -179,6 +184,17 @@ class _RuntimeViewReloadLayer(torch.nn.Module):
         param.data.copy_(loaded_weight)
 
 
+class _PostLoadAttention(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.arange(6.0).reshape(2, 3))
+        self.weight.weight_loader = default_weight_loader
+        self.processed_dtype = None
+
+    def process_weights_after_loading(self, dtype):
+        self.processed_dtype = dtype
+
+
 def test_move_metatensors():
     tensor = torch.empty((1, 2, 3))
     meta_tensor = to_meta_tensor(tensor)
@@ -252,6 +268,42 @@ def test_direct_weight_reload_requires_matching_layout():
     initialize_layerwise_reload(model)
 
     assert layer.weight.is_meta
+
+
+@pytest.mark.parametrize("runtime_shape", [(2, 3), (0,)])
+def test_unquantized_linear_reload_uses_layout_validation(runtime_shape):
+    layer = _DirectReloadLayer(supported=True)
+    layer.quant_method = UnquantizedLinearMethod()
+    model = torch.nn.Sequential(layer)
+
+    record_metadata_for_reloading(model)
+    layer.weight = torch.nn.Parameter(torch.empty(runtime_shape))
+    layer.weight.weight_loader = default_weight_loader
+    initialize_layerwise_reload(model)
+
+    matching_layout = runtime_shape == (2, 3)
+    assert layer.weight.is_meta is not matching_layout
+    assert get_layerwise_info(layer).runtime_bound is matching_layout
+
+
+def test_direct_attention_runs_deferred_post_load(monkeypatch):
+    monkeypatch.setattr(
+        reload_layerwise, "_POST_LOAD_ATTENTION_TYPES", (_PostLoadAttention,)
+    )
+    layer = _PostLoadAttention()
+    model = torch.nn.Sequential(layer)
+    loaded_weight = torch.full_like(layer.weight, 7.0)
+
+    record_metadata_for_reloading(model)
+    initialize_layerwise_reload(model)
+
+    assert get_layerwise_info(layer).runtime_bound
+    assert layer.processed_dtype is None
+    layer.weight.weight_loader(layer.weight, loaded_weight)
+    finalize_layerwise_reload(model, model_config=SimpleNamespace(dtype=torch.float16))
+
+    assert torch.equal(layer.weight, loaded_weight)
+    assert layer.processed_dtype is torch.float16
 
 
 def test_direct_weight_reload_requires_matching_tensor_sets():

--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -6,13 +6,16 @@ from weakref import WeakKeyDictionary, ref
 
 import pytest
 import torch
-from torch.nn.parameter import UninitializedParameter
+from torch.nn.parameter import UninitializedBuffer, UninitializedParameter
 
 import vllm.model_executor.model_loader.reload.meta as reload_meta
 from vllm.model_executor.layers.linear import QKVParallelLinear
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.model_loader.reload.layerwise import (
+    _DEFERRED_ATTENTION_TYPES,
+    _matching_tensor_layouts,
     finalize_layerwise_reload,
+    get_layerwise_info,
     initialize_layerwise_reload,
     record_metadata_for_reloading,
 )
@@ -24,7 +27,11 @@ from vllm.model_executor.model_loader.reload.meta import (
     restore_layer_on_meta,
     to_meta_tensor,
 )
-from vllm.model_executor.model_loader.reload.types import LayerReloadingInfo
+from vllm.model_executor.model_loader.reload.types import (
+    LayerReloadingInfo,
+    LayerReloadMode,
+    TensorReloadSignature,
+)
 from vllm.model_executor.model_loader.reload.utils import get_layer_tensors
 from vllm.model_executor.model_loader.weight_utils import (
     composed_weight_loader,
@@ -114,8 +121,10 @@ class _DirectReloadMethod(QuantizeMethodBase):
     def process_weights_after_loading(self, layer):
         self.process_calls += 1
 
-    def supports_direct_weight_reload(self, layer):
-        return self.supported
+    def get_runtime_weight_reload_mapping(
+        self, layer, checkpoint_params, runtime_params
+    ):
+        return runtime_params if self.supported else None
 
 
 class _DirectReloadLayer(torch.nn.Module):
@@ -139,25 +148,40 @@ class _RuntimeViewReloadMethod(_DirectReloadMethod):
     def __init__(self):
         super().__init__(supported=False)
 
-    def bind_runtime_weight_reload(self, layer, runtime_params):
-        checkpoint_param = layer.weight
+    def get_runtime_weight_reload_mapping(
+        self, layer, checkpoint_params, runtime_params
+    ):
+        checkpoint_param = checkpoint_params["weight"]
         bound_param = torch.nn.Parameter(runtime_params["weight"].t())
         bound_param.__class__ = checkpoint_param.__class__
         bound_param.__dict__ = checkpoint_param.__dict__.copy()
-        layer.weight = bound_param
-        return True
+        return {"weight": bound_param}
 
     def process_weights_after_loading(self, layer):
         self.process_calls += 1
         layer.weight = torch.nn.Parameter(layer.weight.t().contiguous())
 
 
+class _DetachedRuntimeViewReloadMethod(_RuntimeViewReloadMethod):
+    def get_runtime_weight_reload_mapping(
+        self, layer, checkpoint_params, runtime_params
+    ):
+        checkpoint_param = checkpoint_params["weight"]
+        bound_param = torch.nn.Parameter(runtime_params["weight"].t().clone())
+        bound_param.__class__ = checkpoint_param.__class__
+        bound_param.__dict__ = checkpoint_param.__dict__.copy()
+        return {"weight": bound_param}
+
+
 class _RuntimeViewReloadLayer(torch.nn.Module):
-    def __init__(self):
+    def __init__(self, quant_method=None):
         super().__init__()
         self.weight = torch.nn.Parameter(torch.arange(6.0).reshape(2, 3))
-        self.weight.weight_loader = default_weight_loader
-        self.quant_method = _RuntimeViewReloadMethod()
+        self.weight.weight_loader = self._weight_loader
+        self.quant_method = quant_method or _RuntimeViewReloadMethod()
+
+    def _weight_loader(self, param, loaded_weight):
+        param.data.copy_(loaded_weight)
 
 
 def test_move_metatensors():
@@ -208,6 +232,9 @@ def test_direct_weight_reload_preserves_runtime_storage(supported):
     record_metadata_for_reloading(model)
     initialize_layerwise_reload(model)
 
+    expected_mode = LayerReloadMode.DIRECT if supported else LayerReloadMode.LAYERWISE
+    assert get_layerwise_info(layer).reload_plan.mode is expected_mode
+
     if supported:
         assert not layer.weight.is_meta
     else:
@@ -231,6 +258,29 @@ def test_direct_weight_reload_requires_matching_layout():
     initialize_layerwise_reload(model)
 
     assert layer.weight.is_meta
+
+
+def test_direct_weight_reload_requires_matching_tensor_sets():
+    weight = torch.empty(2, 3)
+    extra = torch.empty(1)
+
+    assert not _matching_tensor_layouts(
+        {"weight": weight}, {"weight": weight, "extra": extra}
+    )
+
+
+def test_deferred_attention_types_are_complete():
+    from vllm.model_executor.layers.attention import (
+        Attention,
+        MLAAttention,
+        MMEncoderAttention,
+    )
+
+    assert (
+        Attention,
+        MLAAttention,
+        MMEncoderAttention,
+    ) == _DEFERRED_ATTENTION_TYPES
 
 
 def test_direct_weight_reload_restores_parameter_loading_metadata():
@@ -264,12 +314,71 @@ def test_runtime_view_reload_uses_existing_kernel_storage():
     initialize_layerwise_reload(model)
 
     assert not layer.weight.is_meta
+    assert get_layerwise_info(layer).reload_plan.mode is LayerReloadMode.RUNTIME_VIEW
     layer.weight.weight_loader(layer.weight, loaded_weight)
     finalize_layerwise_reload(model, model_config=None)
 
     assert torch.equal(layer.weight, loaded_weight.t())
     assert layer.weight.data_ptr() == original_data_ptr
     assert layer.quant_method.process_calls == 1
+
+
+def test_runtime_view_reload_rejects_detached_mapping_atomically():
+    layer = _RuntimeViewReloadLayer(_DetachedRuntimeViewReloadMethod())
+    model = torch.nn.Sequential(layer)
+
+    record_metadata_for_reloading(model)
+    layer.quant_method.process_weights_after_loading(layer)
+    initialize_layerwise_reload(model)
+
+    assert layer.weight.is_meta
+    assert get_layerwise_info(layer).reload_plan.mode is LayerReloadMode.LAYERWISE
+
+
+def test_runtime_view_reload_reuses_validated_plan():
+    layer = _RuntimeViewReloadLayer()
+    model = torch.nn.Sequential(layer)
+    loaded_weight = torch.full_like(layer.weight, 7.0)
+
+    record_metadata_for_reloading(model)
+    layer.quant_method.process_weights_after_loading(layer)
+    original_data_ptr = layer.weight.data_ptr()
+
+    for _ in range(2):
+        initialize_layerwise_reload(model)
+        assert get_layerwise_info(layer).reload_plan.mode is (
+            LayerReloadMode.RUNTIME_VIEW
+        )
+        layer.weight.weight_loader(layer.weight, loaded_weight)
+        finalize_layerwise_reload(model, model_config=None)
+        assert layer.weight.data_ptr() == original_data_ptr
+
+
+def test_direct_weight_reload_detects_runtime_storage_replacement():
+    layer = _DirectReloadLayer(supported=True)
+    model = torch.nn.Sequential(layer)
+
+    record_metadata_for_reloading(model)
+    initialize_layerwise_reload(model)
+    layer.weight = torch.nn.Parameter(layer.weight.detach().clone())
+
+    with pytest.raises(RuntimeError, match="changed runtime tensor storage"):
+        finalize_layerwise_reload(model, model_config=None)
+
+
+def test_cached_direct_plan_rechecks_quant_method_support():
+    layer = _DirectReloadLayer(supported=True)
+    model = torch.nn.Sequential(layer)
+
+    record_metadata_for_reloading(model)
+    initialize_layerwise_reload(model)
+    finalize_layerwise_reload(model, model_config=None)
+    assert get_layerwise_info(layer).reload_plan.mode is LayerReloadMode.DIRECT
+
+    layer.quant_method = _DirectReloadMethod(supported=False)
+    initialize_layerwise_reload(model)
+
+    assert get_layerwise_info(layer).reload_plan.mode is LayerReloadMode.LAYERWISE
 
 
 def test_materialize_layer_preserves_non_meta_tensors():
@@ -453,6 +562,12 @@ def test_capture_layer_to_meta_skips_uninitialized_parameter_storage_ptrs():
     _, buffers = capture_layer_to_meta(layer)
 
     assert "weight_view" not in buffers
+
+
+def test_lazy_tensors_fail_closed_without_reading_storage():
+    for tensor in (UninitializedParameter(), UninitializedBuffer()):
+        assert not _matching_tensor_layouts({"weight": tensor}, {"weight": tensor})
+        assert TensorReloadSignature.from_tensor(tensor).storage_ptr is None
 
 
 def test_layerwise_reload_skips_child_parameter_alias_buffers(monkeypatch):

--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -135,6 +135,31 @@ def _merged_weight_loader(param, loaded_weight):
     param.load_merged_weight(loaded_weight)
 
 
+class _RuntimeViewReloadMethod(_DirectReloadMethod):
+    def __init__(self):
+        super().__init__(supported=False)
+
+    def bind_runtime_weight_reload(self, layer, runtime_params):
+        checkpoint_param = layer.weight
+        bound_param = torch.nn.Parameter(runtime_params["weight"].t())
+        bound_param.__class__ = checkpoint_param.__class__
+        bound_param.__dict__ = checkpoint_param.__dict__.copy()
+        layer.weight = bound_param
+        return True
+
+    def process_weights_after_loading(self, layer):
+        self.process_calls += 1
+        layer.weight = torch.nn.Parameter(layer.weight.t().contiguous())
+
+
+class _RuntimeViewReloadLayer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.arange(6.0).reshape(2, 3))
+        self.weight.weight_loader = default_weight_loader
+        self.quant_method = _RuntimeViewReloadMethod()
+
+
 def test_move_metatensors():
     tensor = torch.empty((1, 2, 3))
     meta_tensor = to_meta_tensor(tensor)
@@ -226,6 +251,25 @@ def test_direct_weight_reload_restores_parameter_loading_metadata():
 
     assert torch.equal(layer.weight, loaded_weight)
     assert layer.weight.data_ptr() == original_data_ptr
+
+
+def test_runtime_view_reload_uses_existing_kernel_storage():
+    layer = _RuntimeViewReloadLayer()
+    model = torch.nn.Sequential(layer)
+    loaded_weight = torch.full_like(layer.weight, 7.0)
+
+    record_metadata_for_reloading(model)
+    layer.quant_method.process_weights_after_loading(layer)
+    original_data_ptr = layer.weight.data_ptr()
+    initialize_layerwise_reload(model)
+
+    assert not layer.weight.is_meta
+    layer.weight.weight_loader(layer.weight, loaded_weight)
+    finalize_layerwise_reload(model, model_config=None)
+
+    assert torch.equal(layer.weight, loaded_weight.t())
+    assert layer.weight.data_ptr() == original_data_ptr
+    assert layer.quant_method.process_calls == 1
 
 
 def test_materialize_layer_preserves_non_meta_tensors():

--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -269,6 +269,8 @@ def test_direct_weight_reload_restores_parameter_loading_metadata():
     layer = _DirectReloadLayer(supported=True)
     layer.weight = _DirectReloadParameter(layer.weight.data)
     layer.weight.weight_loader = _merged_weight_loader
+    # Runtime-only tensors must not make an otherwise direct mapping non-identity.
+    layer.e_score_correction_bias = torch.nn.Parameter(torch.ones(1))
     model = torch.nn.Sequential(layer)
     loaded_weight = torch.full_like(layer.weight, 7.0)
 

--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -27,11 +27,7 @@ from vllm.model_executor.model_loader.reload.meta import (
     restore_layer_on_meta,
     to_meta_tensor,
 )
-from vllm.model_executor.model_loader.reload.types import (
-    LayerReloadingInfo,
-    LayerReloadMode,
-    TensorReloadSignature,
-)
+from vllm.model_executor.model_loader.reload.types import LayerReloadingInfo
 from vllm.model_executor.model_loader.reload.utils import get_layer_tensors
 from vllm.model_executor.model_loader.weight_utils import (
     composed_weight_loader,
@@ -232,13 +228,12 @@ def test_direct_weight_reload_preserves_runtime_storage(supported):
     record_metadata_for_reloading(model)
     initialize_layerwise_reload(model)
 
-    expected_mode = LayerReloadMode.DIRECT if supported else LayerReloadMode.LAYERWISE
-    assert get_layerwise_info(layer).reload_plan.mode is expected_mode
-
     if supported:
         assert not layer.weight.is_meta
+        assert get_layerwise_info(layer).runtime_bound
     else:
         assert layer.weight.is_meta
+        assert not get_layerwise_info(layer).runtime_bound
 
     layer.weight.weight_loader(layer.weight, loaded_weight)
     finalize_layerwise_reload(model, model_config=None)
@@ -314,7 +309,7 @@ def test_runtime_view_reload_uses_existing_kernel_storage():
     initialize_layerwise_reload(model)
 
     assert not layer.weight.is_meta
-    assert get_layerwise_info(layer).reload_plan.mode is LayerReloadMode.RUNTIME_VIEW
+    assert get_layerwise_info(layer).runtime_bound
     layer.weight.weight_loader(layer.weight, loaded_weight)
     finalize_layerwise_reload(model, model_config=None)
 
@@ -332,10 +327,10 @@ def test_runtime_view_reload_rejects_detached_mapping_atomically():
     initialize_layerwise_reload(model)
 
     assert layer.weight.is_meta
-    assert get_layerwise_info(layer).reload_plan.mode is LayerReloadMode.LAYERWISE
+    assert not get_layerwise_info(layer).runtime_bound
 
 
-def test_runtime_view_reload_reuses_validated_plan():
+def test_runtime_view_reload_revalidates_mapping():
     layer = _RuntimeViewReloadLayer()
     model = torch.nn.Sequential(layer)
     loaded_weight = torch.full_like(layer.weight, 7.0)
@@ -346,9 +341,7 @@ def test_runtime_view_reload_reuses_validated_plan():
 
     for _ in range(2):
         initialize_layerwise_reload(model)
-        assert get_layerwise_info(layer).reload_plan.mode is (
-            LayerReloadMode.RUNTIME_VIEW
-        )
+        assert get_layerwise_info(layer).runtime_bound
         layer.weight.weight_loader(layer.weight, loaded_weight)
         finalize_layerwise_reload(model, model_config=None)
         assert layer.weight.data_ptr() == original_data_ptr
@@ -366,19 +359,19 @@ def test_direct_weight_reload_detects_runtime_storage_replacement():
         finalize_layerwise_reload(model, model_config=None)
 
 
-def test_cached_direct_plan_rechecks_quant_method_support():
+def test_direct_reload_rechecks_quant_method_support():
     layer = _DirectReloadLayer(supported=True)
     model = torch.nn.Sequential(layer)
 
     record_metadata_for_reloading(model)
     initialize_layerwise_reload(model)
     finalize_layerwise_reload(model, model_config=None)
-    assert get_layerwise_info(layer).reload_plan.mode is LayerReloadMode.DIRECT
 
     layer.quant_method = _DirectReloadMethod(supported=False)
     initialize_layerwise_reload(model)
 
-    assert get_layerwise_info(layer).reload_plan.mode is LayerReloadMode.LAYERWISE
+    assert layer.weight.is_meta
+    assert not get_layerwise_info(layer).runtime_bound
 
 
 def test_materialize_layer_preserves_non_meta_tensors():
@@ -567,7 +560,6 @@ def test_capture_layer_to_meta_skips_uninitialized_parameter_storage_ptrs():
 def test_lazy_tensors_fail_closed_without_reading_storage():
     for tensor in (UninitializedParameter(), UninitializedBuffer()):
         assert not _matching_tensor_layouts({"weight": tensor}, {"weight": tensor})
-        assert TensorReloadSignature.from_tensor(tensor).storage_ptr is None
 
 
 def test_layerwise_reload_skips_child_parameter_alias_buffers(monkeypatch):

--- a/tests/quantization/test_moe_wna16.py
+++ b/tests/quantization/test_moe_wna16.py
@@ -7,6 +7,9 @@ import pytest
 import torch
 
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_wna16 import (  # noqa: E501
+    CompressedTensorsWNA16MoEMethod,
+)
 from vllm.model_executor.layers.quantization.moe_wna16 import MoeWNA16Method
 from vllm.platforms import current_platform
 
@@ -47,3 +50,51 @@ def test_moe_wna16_apply_passes_layer_activation(monkeypatch):
 
     assert output.shape == (1, 2)
     assert captured_kwargs["activation"] is MoEActivation.GELU_TANH
+
+
+def test_compressed_tensors_wna16_binds_checkpoint_views_to_runtime_storage():
+    layer = torch.nn.Module()
+    checkpoint_shapes = {
+        "w13_weight_packed": ((2, 4, 6), torch.int32),
+        "w2_weight_packed": ((2, 3, 8), torch.int32),
+        "w13_weight_scale": ((2, 5, 6), torch.float16),
+        "w2_weight_scale": ((2, 3, 8), torch.float16),
+        "w13_weight_shape": ((2, 2), torch.float32),
+        "w2_weight_shape": ((2, 2), torch.float32),
+    }
+    for name, (shape, dtype) in checkpoint_shapes.items():
+        layer.register_parameter(
+            name,
+            torch.nn.Parameter(torch.empty(shape, dtype=dtype), requires_grad=False),
+        )
+
+    runtime_params = {
+        "w13_weight_packed": torch.nn.Parameter(
+            torch.empty((2, 6, 16), dtype=torch.uint8), requires_grad=False
+        ),
+        "w2_weight_packed": torch.nn.Parameter(
+            torch.empty((2, 8, 12), dtype=torch.uint8), requires_grad=False
+        ),
+        "w13_weight_scale": torch.nn.Parameter(
+            torch.empty((2, 6, 5), dtype=torch.float16), requires_grad=False
+        ),
+        "w2_weight_scale": torch.nn.Parameter(
+            torch.empty((2, 8, 3), dtype=torch.float16), requires_grad=False
+        ),
+        "w13_weight_shape": torch.nn.Parameter(
+            torch.empty((2, 2)), requires_grad=False
+        ),
+        "w2_weight_shape": torch.nn.Parameter(torch.empty((2, 2)), requires_grad=False),
+    }
+    runtime_ptrs = {name: param.data_ptr() for name, param in runtime_params.items()}
+    method = object.__new__(CompressedTensorsWNA16MoEMethod)
+
+    assert method.bind_runtime_weight_reload(layer, runtime_params)
+    assert layer.w13_weight_packed.shape == (2, 6, 4)
+    assert layer.w2_weight_packed.shape == (2, 8, 3)
+    assert layer.w13_weight_scale.shape == (2, 6, 5)
+    assert layer.w2_weight_scale.shape == (2, 8, 3)
+    assert not layer.w13_weight_packed.is_transposed
+    assert not layer.w13_weight_scale.is_transposed
+    bound_ptrs = {name: param.data_ptr() for name, param in layer.named_parameters()}
+    assert bound_ptrs == runtime_ptrs

--- a/tests/quantization/test_moe_wna16.py
+++ b/tests/quantization/test_moe_wna16.py
@@ -87,14 +87,24 @@ def test_compressed_tensors_wna16_binds_checkpoint_views_to_runtime_storage():
         "w2_weight_shape": torch.nn.Parameter(torch.empty((2, 2)), requires_grad=False),
     }
     runtime_ptrs = {name: param.data_ptr() for name, param in runtime_params.items()}
+    checkpoint_ptrs = {
+        name: param.data_ptr() for name, param in layer.named_parameters()
+    }
     method = object.__new__(CompressedTensorsWNA16MoEMethod)
 
-    assert method.bind_runtime_weight_reload(layer, runtime_params)
-    assert layer.w13_weight_packed.shape == (2, 6, 4)
-    assert layer.w2_weight_packed.shape == (2, 8, 3)
-    assert layer.w13_weight_scale.shape == (2, 6, 5)
-    assert layer.w2_weight_scale.shape == (2, 8, 3)
-    assert not layer.w13_weight_packed.is_transposed
-    assert not layer.w13_weight_scale.is_transposed
-    bound_ptrs = {name: param.data_ptr() for name, param in layer.named_parameters()}
+    checkpoint_params = dict(layer.named_parameters())
+    mapping = method.get_runtime_weight_reload_mapping(
+        layer, checkpoint_params, runtime_params
+    )
+    assert mapping is not None
+    assert {
+        name: param.data_ptr() for name, param in layer.named_parameters()
+    } == checkpoint_ptrs
+    assert mapping["w13_weight_packed"].shape == (2, 6, 4)
+    assert mapping["w2_weight_packed"].shape == (2, 8, 3)
+    assert mapping["w13_weight_scale"].shape == (2, 6, 5)
+    assert mapping["w2_weight_scale"].shape == (2, 8, 3)
+    assert not mapping["w13_weight_packed"].is_transposed
+    assert not mapping["w13_weight_scale"].is_transposed
+    bound_ptrs = {name: param.data_ptr() for name, param in mapping.items()}
     assert bound_ptrs == runtime_ptrs

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -223,7 +223,7 @@ class UnquantizedLinearMethod(LinearMethodBase):
         checkpoint_params: Mapping[str, Parameter],
         runtime_params: Mapping[str, Parameter],
     ) -> Mapping[str, Parameter] | None:
-        return runtime_params if not current_platform.is_cpu() else None
+        return runtime_params
 
     def apply(
         self,

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -217,6 +217,9 @@ class UnquantizedLinearMethod(LinearMethodBase):
 
             dispatch_cpu_unquantized_gemm(layer, remove_weight=True)
 
+    def supports_direct_weight_reload(self, layer: torch.nn.Module) -> bool:
+        return not current_platform.is_cpu()
+
     def apply(
         self,
         layer: torch.nn.Module,

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -3,7 +3,7 @@
 
 import itertools
 from abc import abstractmethod
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from typing import Any
 
 import torch
@@ -217,8 +217,13 @@ class UnquantizedLinearMethod(LinearMethodBase):
 
             dispatch_cpu_unquantized_gemm(layer, remove_weight=True)
 
-    def supports_direct_weight_reload(self, layer: torch.nn.Module) -> bool:
-        return not current_platform.is_cpu()
+    def get_runtime_weight_reload_mapping(
+        self,
+        layer: torch.nn.Module,
+        checkpoint_params: Mapping[str, Parameter],
+        runtime_params: Mapping[str, Parameter],
+    ) -> Mapping[str, Parameter] | None:
+        return runtime_params if not current_platform.is_cpu() else None
 
     def apply(
         self,

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -71,6 +71,10 @@ class QuantizeMethodBase(ABC):
         """
         return
 
+    def supports_direct_weight_reload(self, layer: nn.Module) -> bool:
+        """Whether checkpoint weights can reload into runtime tensors directly."""
+        return False
+
 
 def method_has_implemented_embedding(method_class: type[QuantizeMethodBase]) -> bool:
     """

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -72,17 +72,19 @@ class QuantizeMethodBase(ABC):
         """
         return
 
-    def supports_direct_weight_reload(self, layer: nn.Module) -> bool:
-        """Whether checkpoint weights can reload into runtime tensors directly."""
-        return False
-
-    def bind_runtime_weight_reload(
+    def get_runtime_weight_reload_mapping(
         self,
         layer: nn.Module,
+        checkpoint_params: Mapping[str, nn.Parameter],
         runtime_params: Mapping[str, nn.Parameter],
-    ) -> bool:
-        """Bind checkpoint-layout parameters to existing runtime storage."""
-        return False
+    ) -> Mapping[str, nn.Parameter] | None:
+        """Return loader-facing parameters backed by runtime storage.
+
+        Implementations must not mutate ``layer`` and must return every checkpoint
+        parameter as a view over its complete runtime storage, or return ``None``.
+        The reload framework validates the whole mapping before committing it.
+        """
+        return None
 
 
 def method_has_implemented_embedding(method_class: type[QuantizeMethodBase]) -> bool:

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -3,6 +3,7 @@
 
 import inspect
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 import regex as re
@@ -73,6 +74,14 @@ class QuantizeMethodBase(ABC):
 
     def supports_direct_weight_reload(self, layer: nn.Module) -> bool:
         """Whether checkpoint weights can reload into runtime tensors directly."""
+        return False
+
+    def bind_runtime_weight_reload(
+        self,
+        layer: nn.Module,
+        runtime_params: Mapping[str, nn.Parameter],
+    ) -> bool:
+        """Bind checkpoint-layout parameters to existing runtime storage."""
         return False
 
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
@@ -213,28 +213,29 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
             layer.w2_weight_scale.transpose(1, 2).contiguous(), requires_grad=False
         )
 
-    def bind_runtime_weight_reload(
+    def get_runtime_weight_reload_mapping(
         self,
         layer: torch.nn.Module,
+        checkpoint_params: Mapping[str, torch.nn.Parameter],
         runtime_params: Mapping[str, torch.nn.Parameter],
-    ) -> bool:
+    ) -> Mapping[str, torch.nn.Parameter] | None:
         packed_weights = {"w13_weight_packed", "w2_weight_packed"}
         transposed_scales = {"w13_weight_scale", "w2_weight_scale"}
         bound_params = {}
 
-        for name, checkpoint_param in layer._parameters.items():
-            if checkpoint_param is None or name not in runtime_params:
-                return False
+        if checkpoint_params.keys() - runtime_params.keys():
+            return None
 
+        for name, checkpoint_param in checkpoint_params.items():
             runtime_data = runtime_params[name].data
             if name in packed_weights:
                 if checkpoint_param.ndim != 3 or runtime_data.dtype != torch.uint8:
-                    return False
+                    return None
                 reload_data = runtime_data.view(torch.int32)
                 expected_shape = checkpoint_param.transpose(1, 2).shape
             elif name in transposed_scales:
                 if checkpoint_param.ndim != 3:
-                    return False
+                    return None
                 reload_data = runtime_data
                 expected_shape = checkpoint_param.transpose(1, 2).shape
             else:
@@ -245,18 +246,19 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
                 reload_data.shape != expected_shape
                 or reload_data.dtype != checkpoint_param.dtype
             ):
-                return False
+                return None
             bound_params[name] = (checkpoint_param, reload_data)
 
+        mapping = {}
         for name, (checkpoint_param, reload_data) in bound_params.items():
             bound_param = torch.nn.Parameter(reload_data, requires_grad=False)
             bound_param.__class__ = checkpoint_param.__class__
             bound_param.__dict__ = checkpoint_param.__dict__.copy()
             if name in packed_weights or name in transposed_scales:
                 bound_param.is_transposed = False
-            setattr(layer, name, bound_param)
+            mapping[name] = bound_param
 
-        return True
+        return mapping
 
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
@@ -221,7 +221,7 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
     ) -> Mapping[str, torch.nn.Parameter] | None:
         packed_weights = {"w13_weight_packed", "w2_weight_packed"}
         transposed_scales = {"w13_weight_scale", "w2_weight_scale"}
-        bound_params = {}
+        mapping = {}
 
         if checkpoint_params.keys() - runtime_params.keys():
             return None
@@ -247,10 +247,6 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
                 or reload_data.dtype != checkpoint_param.dtype
             ):
                 return None
-            bound_params[name] = (checkpoint_param, reload_data)
-
-        mapping = {}
-        for name, (checkpoint_param, reload_data) in bound_params.items():
             bound_param = torch.nn.Parameter(reload_data, requires_grad=False)
             bound_param.__class__ = checkpoint_param.__class__
             bound_param.__dict__ = checkpoint_param.__dict__.copy()

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections.abc import Mapping
 
 import torch
 from compressed_tensors.quantization import (
@@ -211,6 +212,51 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
         layer.w2_weight_scale = torch.nn.Parameter(
             layer.w2_weight_scale.transpose(1, 2).contiguous(), requires_grad=False
         )
+
+    def bind_runtime_weight_reload(
+        self,
+        layer: torch.nn.Module,
+        runtime_params: Mapping[str, torch.nn.Parameter],
+    ) -> bool:
+        packed_weights = {"w13_weight_packed", "w2_weight_packed"}
+        transposed_scales = {"w13_weight_scale", "w2_weight_scale"}
+        bound_params = {}
+
+        for name, checkpoint_param in layer._parameters.items():
+            if checkpoint_param is None or name not in runtime_params:
+                return False
+
+            runtime_data = runtime_params[name].data
+            if name in packed_weights:
+                if checkpoint_param.ndim != 3 or runtime_data.dtype != torch.uint8:
+                    return False
+                reload_data = runtime_data.view(torch.int32)
+                expected_shape = checkpoint_param.transpose(1, 2).shape
+            elif name in transposed_scales:
+                if checkpoint_param.ndim != 3:
+                    return False
+                reload_data = runtime_data
+                expected_shape = checkpoint_param.transpose(1, 2).shape
+            else:
+                reload_data = runtime_data
+                expected_shape = checkpoint_param.shape
+
+            if (
+                reload_data.shape != expected_shape
+                or reload_data.dtype != checkpoint_param.dtype
+            ):
+                return False
+            bound_params[name] = (checkpoint_param, reload_data)
+
+        for name, (checkpoint_param, reload_data) in bound_params.items():
+            bound_param = torch.nn.Parameter(reload_data, requires_grad=False)
+            bound_param.__class__ = checkpoint_param.__class__
+            bound_param.__dict__ = checkpoint_param.__dict__.copy()
+            if name in packed_weights or name in transposed_scales:
+                bound_param.is_transposed = False
+            setattr(layer, name, bound_param)
+
+        return True
 
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -18,6 +18,9 @@ from vllm.model_executor.kernels.linear.scaled_mm import (
     CutlassFP8ScaledMMLinearKernel,
     MarlinFP8ScaledMMLinearKernel,
 )
+from vllm.model_executor.kernels.linear.scaled_mm.cutlass import (
+    CutlassFp8BlockScaledMMKernel,
+)
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEMethodBase,
@@ -443,6 +446,13 @@ class Fp8LinearMethod(LinearMethodBase):
 
         self.fp8_linear.process_weights_after_loading(layer)
 
+    def supports_direct_weight_reload(self, layer: torch.nn.Module) -> bool:
+        return (
+            self.block_quant
+            and isinstance(self.fp8_linear, CutlassFp8BlockScaledMMKernel)
+            and not current_platform.is_fp8_fnuz()
+        )
+
     def apply(
         self,
         layer: torch.nn.Module,
@@ -760,6 +770,13 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         # Shuffle weights to runtime format and setup kernel.
         self._setup_kernel(
             layer, w13, w2, w13_scale, w2_scale, w13_input_scale, w2_input_scale
+        )
+
+    def supports_direct_weight_reload(self, layer: torch.nn.Module) -> bool:
+        return (
+            self.block_quant
+            and self.fp8_backend in (Fp8MoeBackend.TRITON, Fp8MoeBackend.BATCHED_TRITON)
+            and not current_platform.is_fp8_fnuz()
         )
 
     def maybe_make_prepare_finalize(

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -446,12 +447,18 @@ class Fp8LinearMethod(LinearMethodBase):
 
         self.fp8_linear.process_weights_after_loading(layer)
 
-    def supports_direct_weight_reload(self, layer: torch.nn.Module) -> bool:
-        return (
+    def get_runtime_weight_reload_mapping(
+        self,
+        layer: torch.nn.Module,
+        checkpoint_params: Mapping[str, torch.nn.Parameter],
+        runtime_params: Mapping[str, torch.nn.Parameter],
+    ) -> Mapping[str, torch.nn.Parameter] | None:
+        supported = (
             self.block_quant
             and isinstance(self.fp8_linear, CutlassFp8BlockScaledMMKernel)
             and not current_platform.is_fp8_fnuz()
         )
+        return runtime_params if supported else None
 
     def apply(
         self,
@@ -772,12 +779,18 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             layer, w13, w2, w13_scale, w2_scale, w13_input_scale, w2_input_scale
         )
 
-    def supports_direct_weight_reload(self, layer: torch.nn.Module) -> bool:
-        return (
+    def get_runtime_weight_reload_mapping(
+        self,
+        layer: torch.nn.Module,
+        checkpoint_params: Mapping[str, torch.nn.Parameter],
+        runtime_params: Mapping[str, torch.nn.Parameter],
+    ) -> Mapping[str, torch.nn.Parameter] | None:
+        supported = (
             self.block_quant
             and self.fp8_backend in (Fp8MoeBackend.TRITON, Fp8MoeBackend.BATCHED_TRITON)
             and not current_platform.is_fp8_fnuz()
         )
+        return runtime_params if supported else None
 
     def maybe_make_prepare_finalize(
         self,

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -115,6 +115,10 @@ def initialize_layerwise_reload(model: torch.nn.Module):
             direct_layers += 1
             continue
 
+        if _bind_runtime_weight_reload(layer, info):
+            direct_layers += 1
+            continue
+
         # Save current tensors for later copying
         info.kernel_tensors = get_layer_params_buffers(layer)
         # snapshot now: restore_layer_on_meta drops alias buffers from the live set
@@ -165,6 +169,36 @@ def _restore_loading_metadata(layer: torch.nn.Module, info: LayerReloadingInfo) 
             checkpoint_tensor = restore_layer_refs(checkpoint_tensor, layer)
             runtime_tensor.__class__ = checkpoint_tensor.__class__
             runtime_tensor.__dict__.update(checkpoint_tensor.__dict__)
+
+
+def _bind_runtime_weight_reload(
+    layer: torch.nn.Module, info: LayerReloadingInfo
+) -> bool:
+    if isinstance(layer, (Attention, MLAAttention)):
+        return False
+
+    quant_method = getattr(layer, "quant_method", None)
+    if not isinstance(quant_method, QuantizeMethodBase):
+        return False
+    if (
+        quant_method.__class__.bind_runtime_weight_reload
+        is QuantizeMethodBase.bind_runtime_weight_reload
+    ):
+        return False
+
+    _, restore_buffers = info.restore_metadata
+    if restore_buffers:
+        return False
+
+    info.kernel_tensors = get_layer_params_buffers(layer)
+    restore_layer_on_meta(layer, info)
+    if quant_method.bind_runtime_weight_reload(layer, info.kernel_tensors[0]):
+        info.runtime_bound = True
+        return True
+
+    _place_kernel_tensors(layer, info)
+    info.kernel_tensors = None
+    return False
 
 
 def _matching_tensor_layouts(
@@ -310,6 +344,10 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
 
     for layer in model.modules():
         info = get_layerwise_info(layer)
+        if info.runtime_bound:
+            _place_kernel_tensors(layer, info)
+            info.reset()
+            continue
         if not info.can_load():
             info.reset()
             continue
@@ -465,13 +503,17 @@ def _copy_and_restore_kernel_tensors(layer: torch.nn.Module, info: LayerReloadin
     non_persistent = info.kernel_non_persistent_buffers
     loaded_tensor_names = {name for name, _ in info.loaded_weights}
     for name, param in parameters.items():
-        param.data.copy_(getattr(layer, name))
+        loaded_param = getattr(layer, name)
+        if param.data_ptr() != loaded_param.data_ptr():
+            param.data.copy_(loaded_param)
     for name, buffer in buffers.items():
         if name not in layer._buffers:
             continue
         if name in non_persistent and name not in loaded_tensor_names:
             continue
-        buffer.data.copy_(getattr(layer, name))
+        loaded_buffer = getattr(layer, name)
+        if buffer.data_ptr() != loaded_buffer.data_ptr():
+            buffer.data.copy_(loaded_buffer)
 
     _place_kernel_tensors(layer, info)
 

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -206,12 +206,13 @@ def _bind_runtime_weight_reload_mapping(
 ) -> bool:
     restore_params, restore_buffers = info.restore_metadata
     runtime_params, runtime_buffers = runtime_tensors
-    is_identity = mapping.keys() == runtime_params.keys() and all(
-        mapping[name] is runtime_params[name] for name in mapping
+    reloadable_runtime_params, _ = get_reloadable_layer_tensors(layer)
+    is_identity = mapping.keys() == reloadable_runtime_params.keys() and all(
+        mapping[name] is reloadable_runtime_params[name] for name in mapping
     )
 
     if is_identity:
-        if not _matching_tensor_layouts(restore_params, runtime_params):
+        if not _matching_tensor_layouts(restore_params, reloadable_runtime_params):
             return False
     else:
         if restore_buffers:

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -20,6 +20,7 @@ from .meta import (
     materialize_layer,
     restore_layer_on_meta,
 )
+from .sanitize import restore_layer_refs
 from .types import LayerReloadingInfo
 from .utils import (
     get_info_size,
@@ -100,11 +101,18 @@ def initialize_layerwise_reload(model: torch.nn.Module):
     model._original_do_torchao_reload = getattr(model, "_do_torchao_reload", False)
     model._do_torchao_reload = False
 
+    direct_layers = 0
+    layerwise_layers = 0
     for layer in model.modules():
         info = get_layerwise_info(layer)
 
         # Skip if the layer has already been initialized
         if info.can_load():
+            continue
+
+        if _supports_direct_weight_reload(layer, info):
+            _restore_loading_metadata(layer, info)
+            direct_layers += 1
             continue
 
         # Save current tensors for later copying
@@ -117,6 +125,63 @@ def initialize_layerwise_reload(model: torch.nn.Module):
 
         # Wrap weight loaders to buffer loading
         initialize_online_processing(layer)
+        layerwise_layers += 1
+
+    logger.info_once(
+        "Weight reload uses %d direct layers and %d layerwise layers",
+        direct_layers,
+        layerwise_layers,
+    )
+
+
+def _supports_direct_weight_reload(
+    layer: torch.nn.Module, info: LayerReloadingInfo
+) -> bool:
+    if isinstance(layer, (Attention, MLAAttention)):
+        return False
+
+    restore_params, restore_buffers = info.restore_metadata
+    runtime_params, runtime_buffers = get_layer_params_buffers(layer)
+    if not _matching_tensor_layouts(restore_params, runtime_params):
+        return False
+    if not _matching_tensor_layouts(restore_buffers, runtime_buffers):
+        return False
+
+    quant_method = getattr(layer, "quant_method", None)
+    if not isinstance(quant_method, QuantizeMethodBase):
+        return True
+    return quant_method.supports_direct_weight_reload(layer)
+
+
+def _restore_loading_metadata(layer: torch.nn.Module, info: LayerReloadingInfo) -> None:
+    restore_params, restore_buffers = info.restore_metadata
+    runtime_params, runtime_buffers = get_layer_params_buffers(layer)
+    for checkpoint_tensors, runtime_tensors in (
+        (restore_params, runtime_params),
+        (restore_buffers, runtime_buffers),
+    ):
+        for name, checkpoint_tensor in checkpoint_tensors.items():
+            runtime_tensor = runtime_tensors[name]
+            checkpoint_tensor = restore_layer_refs(checkpoint_tensor, layer)
+            runtime_tensor.__class__ = checkpoint_tensor.__class__
+            runtime_tensor.__dict__.update(checkpoint_tensor.__dict__)
+
+
+def _matching_tensor_layouts(
+    checkpoint_tensors: dict[str, torch.Tensor],
+    runtime_tensors: dict[str, torch.Tensor],
+) -> bool:
+    for name, checkpoint_tensor in checkpoint_tensors.items():
+        runtime_tensor = runtime_tensors.get(name)
+        if runtime_tensor is None:
+            return False
+        if (
+            checkpoint_tensor.shape != runtime_tensor.shape
+            or checkpoint_tensor.stride() != runtime_tensor.stride()
+            or checkpoint_tensor.dtype != runtime_tensor.dtype
+        ):
+            return False
+    return True
 
 
 def initialize_online_processing(layer: torch.nn.Module):

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -180,16 +180,6 @@ def _get_runtime_weight_reload_mapping(
     return dict(mapping)
 
 
-def _is_identity_reload_mapping(
-    layer: torch.nn.Module,
-    mapping: dict[str, torch.nn.Parameter],
-) -> bool:
-    runtime_params, _ = get_reloadable_layer_tensors(layer)
-    return mapping.keys() == runtime_params.keys() and all(
-        mapping[name] is runtime_params[name] for name in mapping
-    )
-
-
 def _restore_loading_metadata(layer: torch.nn.Module, info: LayerReloadingInfo) -> None:
     restore_params, restore_buffers = info.restore_metadata
     runtime_params, runtime_buffers = get_layer_params_buffers(layer)
@@ -212,16 +202,13 @@ def _bind_runtime_weight_reload_mapping(
     layer: torch.nn.Module,
     info: LayerReloadingInfo,
     runtime_tensors: tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]],
-    mapping: dict[str, torch.nn.Parameter] | None = None,
+    mapping: dict[str, torch.nn.Parameter],
 ) -> bool:
-    if mapping is None:
-        mapping = _get_runtime_weight_reload_mapping(layer, info)
-    if mapping is None:
-        return False
-
     restore_params, restore_buffers = info.restore_metadata
     runtime_params, runtime_buffers = runtime_tensors
-    is_identity = _is_identity_reload_mapping(layer, mapping)
+    is_identity = mapping.keys() == runtime_params.keys() and all(
+        mapping[name] is runtime_params[name] for name in mapping
+    )
 
     if is_identity:
         if not _matching_tensor_layouts(restore_params, runtime_params):

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -30,9 +30,6 @@ from .meta import (
 from .sanitize import restore_layer_refs
 from .types import (
     LayerReloadingInfo,
-    LayerReloadMode,
-    LayerReloadPlan,
-    TensorReloadSignature,
 )
 from .utils import (
     get_info_size,
@@ -115,8 +112,7 @@ def initialize_layerwise_reload(model: torch.nn.Module):
     model._original_do_torchao_reload = getattr(model, "_do_torchao_reload", False)
     model._do_torchao_reload = False
 
-    direct_layers = 0
-    runtime_view_layers = 0
+    mapped_layers = 0
     layerwise_layers = 0
     for layer in model.modules():
         info = get_layerwise_info(layer)
@@ -126,46 +122,12 @@ def initialize_layerwise_reload(model: torch.nn.Module):
             continue
 
         runtime_tensors = get_layer_params_buffers(layer)
-        plan = info.reload_plan
-        if plan is not None and not _matches_runtime_plan(plan, runtime_tensors):
-            info.reload_plan = plan = None
-
-        if plan is not None and plan.mode is LayerReloadMode.DIRECT:
-            mapping = _get_runtime_weight_reload_mapping(layer, info)
-            if mapping is not None and _is_direct_reload_mapping(layer, info, mapping):
-                _restore_loading_metadata(layer, info)
-                direct_layers += 1
-                continue
-            info.reload_plan = plan = None
-
-        if plan is not None and plan.mode is LayerReloadMode.RUNTIME_VIEW:
-            if _bind_runtime_weight_reload_mapping(layer, info, runtime_tensors):
-                runtime_view_layers += 1
-                continue
-            info.reload_plan = plan = None
-
-        if plan is None:
-            mapping = _get_runtime_weight_reload_mapping(layer, info)
-            if mapping is not None and _is_direct_reload_mapping(layer, info, mapping):
-                info.reload_plan = _make_reload_plan(
-                    LayerReloadMode.DIRECT, runtime_tensors
-                )
-                _restore_loading_metadata(layer, info)
-                direct_layers += 1
-                continue
-
-            if mapping is not None and _bind_runtime_weight_reload_mapping(
-                layer, info, runtime_tensors, mapping
-            ):
-                info.reload_plan = _make_reload_plan(
-                    LayerReloadMode.RUNTIME_VIEW, runtime_tensors
-                )
-                runtime_view_layers += 1
-                continue
-
-            info.reload_plan = _make_reload_plan(
-                LayerReloadMode.LAYERWISE, runtime_tensors
-            )
+        mapping = _get_runtime_weight_reload_mapping(layer, info)
+        if mapping is not None and _bind_runtime_weight_reload_mapping(
+            layer, info, runtime_tensors, mapping
+        ):
+            mapped_layers += 1
+            continue
 
         # Save current tensors for later copying
         info.kernel_tensors = get_layer_params_buffers(layer)
@@ -180,10 +142,8 @@ def initialize_layerwise_reload(model: torch.nn.Module):
         layerwise_layers += 1
 
     logger.info_once(
-        "Weight reload uses %d direct layers, %d runtime-view layers, "
-        "and %d layerwise layers",
-        direct_layers,
-        runtime_view_layers,
+        "Weight reload uses %d mapped layers and %d layerwise layers",
+        mapped_layers,
         layerwise_layers,
     )
 
@@ -218,17 +178,6 @@ def _get_runtime_weight_reload_mapping(
     if mapping is None or mapping.keys() != restore_params.keys():
         return None
     return dict(mapping)
-
-
-def _is_direct_reload_mapping(
-    layer: torch.nn.Module,
-    info: LayerReloadingInfo,
-    mapping: dict[str, torch.nn.Parameter],
-) -> bool:
-    restore_params, _ = info.restore_metadata
-    return _is_identity_reload_mapping(layer, mapping) and (
-        _matching_tensor_layouts(restore_params, get_reloadable_layer_tensors(layer)[0])
-    )
 
 
 def _is_identity_reload_mapping(
@@ -267,29 +216,53 @@ def _bind_runtime_weight_reload_mapping(
 ) -> bool:
     if mapping is None:
         mapping = _get_runtime_weight_reload_mapping(layer, info)
-    if mapping is None or _is_identity_reload_mapping(layer, mapping):
+    if mapping is None:
         return False
 
     restore_params, restore_buffers = info.restore_metadata
-    runtime_params, _ = runtime_tensors
-    if restore_buffers:
-        return False
+    runtime_params, runtime_buffers = runtime_tensors
+    is_identity = _is_identity_reload_mapping(layer, mapping)
 
-    for name, checkpoint_param in restore_params.items():
-        mapped_param = mapping[name]
-        runtime_param = runtime_params.get(name)
-        if (
-            runtime_param is None
-            or mapped_param.__class__ is not checkpoint_param.__class__
-            or not _covers_same_storage(mapped_param, runtime_param)
-        ):
+    if is_identity:
+        if not _matching_tensor_layouts(restore_params, runtime_params):
+            return False
+    else:
+        if restore_buffers:
             return False
 
+        for name, checkpoint_param in restore_params.items():
+            mapped_param = mapping[name]
+            runtime_param = runtime_params.get(name)
+            if (
+                runtime_param is None
+                or mapped_param.__class__ is not checkpoint_param.__class__
+                or not _covers_same_storage(mapped_param, runtime_param)
+            ):
+                return False
+
     info.kernel_tensors = runtime_tensors
-    for name, mapped_param in mapping.items():
-        setattr(layer, name, mapped_param)
+    info.kernel_non_persistent_buffers = set(layer._non_persistent_buffers_set)
+    if is_identity:
+        _restore_loading_metadata(layer, info)
+    else:
+        for name, mapped_param in mapping.items():
+            setattr(layer, name, mapped_param)
     info.runtime_bound = True
     return True
+
+
+def _validate_runtime_binding(layer: torch.nn.Module, info: LayerReloadingInfo) -> None:
+    assert info.kernel_tensors is not None
+    runtime_params, runtime_buffers = info.kernel_tensors
+    for name, runtime_tensor in {**runtime_params, **runtime_buffers}.items():
+        bound_tensor = getattr(layer, name, None)
+        if bound_tensor is None or not _covers_same_storage(
+            bound_tensor, runtime_tensor
+        ):
+            raise RuntimeError(
+                f"{layer.__class__.__name__} changed runtime tensor storage "
+                "during weight reload"
+            )
 
 
 def _covers_same_storage(view: torch.Tensor, runtime_tensor: torch.Tensor) -> bool:
@@ -331,45 +304,6 @@ def _matching_tensor_layouts(
         ):
             return False
     return True
-
-
-def _make_reload_plan(
-    mode: LayerReloadMode,
-    runtime_tensors: tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]],
-) -> LayerReloadPlan:
-    params, buffers = runtime_tensors
-    return LayerReloadPlan(
-        mode=mode,
-        runtime_signatures=(
-            {
-                name: TensorReloadSignature.from_tensor(tensor)
-                for name, tensor in params.items()
-            },
-            {
-                name: TensorReloadSignature.from_tensor(tensor)
-                for name, tensor in buffers.items()
-            },
-        ),
-    )
-
-
-def _matches_runtime_plan(
-    plan: LayerReloadPlan,
-    runtime_tensors: tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]],
-) -> bool:
-    current = _make_reload_plan(plan.mode, runtime_tensors)
-    return plan.runtime_signatures == current.runtime_signatures
-
-
-def _verify_reload_plan(layer: torch.nn.Module, info: LayerReloadingInfo) -> None:
-    plan = info.reload_plan
-    if plan is None:
-        return
-    if not _matches_runtime_plan(plan, get_layer_params_buffers(layer)):
-        raise RuntimeError(
-            f"{layer.__class__.__name__} changed runtime tensor storage or "
-            "layout during weight reload"
-        )
 
 
 def initialize_online_processing(layer: torch.nn.Module):
@@ -499,12 +433,11 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
     for layer in model.modules():
         info = get_layerwise_info(layer)
         if info.runtime_bound:
+            _validate_runtime_binding(layer, info)
             _place_kernel_tensors(layer, info)
-            _verify_reload_plan(layer, info)
             info.reset()
             continue
         if not info.can_load():
-            _verify_reload_plan(layer, info)
             info.reset()
             continue
 
@@ -535,13 +468,11 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
             logger.debug("%s: Delayed processing", layer.__class__.__name__)
             _layerwise_process(layer, info)
 
-        _verify_reload_plan(layer, info)
         info.reset()
 
     # Process attention layers after all other layers are done
     for layer, info in deferred_attn:
         _finalize_attention_layer(layer, info, model_config)
-        _verify_reload_plan(layer, info)
         info.reset()
 
     LOADING_LAYERS.clear()

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -41,7 +41,7 @@ from .utils import (
 
 logger = init_logger(__name__)
 
-_DEFERRED_ATTENTION_TYPES = (Attention, MLAAttention, MMEncoderAttention)
+_POST_LOAD_ATTENTION_TYPES = (Attention, MLAAttention, MMEncoderAttention)
 
 __all__ = [
     "get_layerwise_info",
@@ -152,9 +152,6 @@ def _get_runtime_weight_reload_mapping(
     layer: torch.nn.Module,
     info: LayerReloadingInfo,
 ) -> dict[str, torch.nn.Parameter] | None:
-    if isinstance(layer, _DEFERRED_ATTENTION_TYPES):
-        return None
-
     restore_params, restore_buffers = info.restore_metadata
     runtime_params, runtime_buffers = get_reloadable_layer_tensors(layer)
     if not _matching_tensor_layouts(restore_buffers, runtime_buffers):
@@ -371,7 +368,7 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
         )
 
         # Do not online process attention layers, must wait until finalize
-        if isinstance(layer, _DEFERRED_ATTENTION_TYPES):
+        if isinstance(layer, _POST_LOAD_ATTENTION_TYPES):
             return ret
 
         # Log warnings allocating excessive buffers on device
@@ -420,6 +417,11 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
 
     for layer in model.modules():
         info = get_layerwise_info(layer)
+        if isinstance(layer, _POST_LOAD_ATTENTION_TYPES) and (
+            info.runtime_bound or info.can_load()
+        ):
+            deferred_attn.append((layer, info))
+            continue
         if info.runtime_bound:
             _validate_runtime_binding(layer, info)
             _place_kernel_tensors(layer, info)
@@ -427,11 +429,6 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
             continue
         if not info.can_load():
             info.reset()
-            continue
-
-        # Attention/MLA layers are processed after all other layers
-        if isinstance(layer, _DEFERRED_ATTENTION_TYPES):
-            deferred_attn.append((layer, info))
             continue
 
         # No weights were loaded
@@ -473,7 +470,10 @@ def finalize_layerwise_reload(*args, **kwargs):
 def _finalize_attention_layer(
     layer: torch.nn.Module, info: LayerReloadingInfo, model_config: ModelConfig
 ) -> None:
-    if info.load_numel > 0 and info.kernel_tensors is not None:
+    if info.runtime_bound:
+        _validate_runtime_binding(layer, info)
+        _place_kernel_tensors(layer, info)
+    elif info.load_numel > 0 and info.kernel_tensors is not None:
         # Reload with new scale weights from checkpoint
         _place_kernel_tensors(layer, info)
         _reload_attention_scales(layer, info)

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -6,10 +6,15 @@ from functools import wraps
 from weakref import WeakKeyDictionary, WeakSet
 
 import torch
+from torch.nn.parameter import is_lazy
 
 from vllm.config import ModelConfig
 from vllm.logger import init_logger
-from vllm.model_executor.layers.attention import Attention, MLAAttention
+from vllm.model_executor.layers.attention import (
+    Attention,
+    MLAAttention,
+    MMEncoderAttention,
+)
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
@@ -17,11 +22,18 @@ from .meta import (
     SKIP_TENSORS,
     capture_layer_to_meta,
     get_numel_loaded,
+    get_reloadable_layer_tensors,
     materialize_layer,
     restore_layer_on_meta,
+    to_meta_tensor,
 )
 from .sanitize import restore_layer_refs
-from .types import LayerReloadingInfo
+from .types import (
+    LayerReloadingInfo,
+    LayerReloadMode,
+    LayerReloadPlan,
+    TensorReloadSignature,
+)
 from .utils import (
     get_info_size,
     get_layer_params_buffers,
@@ -31,6 +43,8 @@ from .utils import (
 )
 
 logger = init_logger(__name__)
+
+_DEFERRED_ATTENTION_TYPES = (Attention, MLAAttention, MMEncoderAttention)
 
 __all__ = [
     "get_layerwise_info",
@@ -102,6 +116,7 @@ def initialize_layerwise_reload(model: torch.nn.Module):
     model._do_torchao_reload = False
 
     direct_layers = 0
+    runtime_view_layers = 0
     layerwise_layers = 0
     for layer in model.modules():
         info = get_layerwise_info(layer)
@@ -110,14 +125,47 @@ def initialize_layerwise_reload(model: torch.nn.Module):
         if info.can_load():
             continue
 
-        if _supports_direct_weight_reload(layer, info):
-            _restore_loading_metadata(layer, info)
-            direct_layers += 1
-            continue
+        runtime_tensors = get_layer_params_buffers(layer)
+        plan = info.reload_plan
+        if plan is not None and not _matches_runtime_plan(plan, runtime_tensors):
+            info.reload_plan = plan = None
 
-        if _bind_runtime_weight_reload(layer, info):
-            direct_layers += 1
-            continue
+        if plan is not None and plan.mode is LayerReloadMode.DIRECT:
+            mapping = _get_runtime_weight_reload_mapping(layer, info)
+            if mapping is not None and _is_direct_reload_mapping(layer, info, mapping):
+                _restore_loading_metadata(layer, info)
+                direct_layers += 1
+                continue
+            info.reload_plan = plan = None
+
+        if plan is not None and plan.mode is LayerReloadMode.RUNTIME_VIEW:
+            if _bind_runtime_weight_reload_mapping(layer, info, runtime_tensors):
+                runtime_view_layers += 1
+                continue
+            info.reload_plan = plan = None
+
+        if plan is None:
+            mapping = _get_runtime_weight_reload_mapping(layer, info)
+            if mapping is not None and _is_direct_reload_mapping(layer, info, mapping):
+                info.reload_plan = _make_reload_plan(
+                    LayerReloadMode.DIRECT, runtime_tensors
+                )
+                _restore_loading_metadata(layer, info)
+                direct_layers += 1
+                continue
+
+            if mapping is not None and _bind_runtime_weight_reload_mapping(
+                layer, info, runtime_tensors, mapping
+            ):
+                info.reload_plan = _make_reload_plan(
+                    LayerReloadMode.RUNTIME_VIEW, runtime_tensors
+                )
+                runtime_view_layers += 1
+                continue
+
+            info.reload_plan = _make_reload_plan(
+                LayerReloadMode.LAYERWISE, runtime_tensors
+            )
 
         # Save current tensors for later copying
         info.kernel_tensors = get_layer_params_buffers(layer)
@@ -132,29 +180,65 @@ def initialize_layerwise_reload(model: torch.nn.Module):
         layerwise_layers += 1
 
     logger.info_once(
-        "Weight reload uses %d direct layers and %d layerwise layers",
+        "Weight reload uses %d direct layers, %d runtime-view layers, "
+        "and %d layerwise layers",
         direct_layers,
+        runtime_view_layers,
         layerwise_layers,
     )
 
 
-def _supports_direct_weight_reload(
-    layer: torch.nn.Module, info: LayerReloadingInfo
-) -> bool:
-    if isinstance(layer, (Attention, MLAAttention)):
-        return False
+def _get_runtime_weight_reload_mapping(
+    layer: torch.nn.Module,
+    info: LayerReloadingInfo,
+) -> dict[str, torch.nn.Parameter] | None:
+    if isinstance(layer, _DEFERRED_ATTENTION_TYPES):
+        return None
 
     restore_params, restore_buffers = info.restore_metadata
-    runtime_params, runtime_buffers = get_layer_params_buffers(layer)
-    if not _matching_tensor_layouts(restore_params, runtime_params):
-        return False
+    runtime_params, runtime_buffers = get_reloadable_layer_tensors(layer)
     if not _matching_tensor_layouts(restore_buffers, runtime_buffers):
-        return False
+        return None
 
     quant_method = getattr(layer, "quant_method", None)
     if not isinstance(quant_method, QuantizeMethodBase):
-        return True
-    return quant_method.supports_direct_weight_reload(layer)
+        return (
+            runtime_params
+            if _matching_tensor_layouts(restore_params, runtime_params)
+            else None
+        )
+
+    checkpoint_params = {
+        name: restore_layer_refs(to_meta_tensor(param), layer)
+        for name, param in restore_params.items()
+    }
+    mapping = quant_method.get_runtime_weight_reload_mapping(
+        layer, checkpoint_params, runtime_params
+    )
+    if mapping is None or mapping.keys() != restore_params.keys():
+        return None
+    return dict(mapping)
+
+
+def _is_direct_reload_mapping(
+    layer: torch.nn.Module,
+    info: LayerReloadingInfo,
+    mapping: dict[str, torch.nn.Parameter],
+) -> bool:
+    restore_params, _ = info.restore_metadata
+    return _is_identity_reload_mapping(layer, mapping) and (
+        _matching_tensor_layouts(restore_params, get_reloadable_layer_tensors(layer)[0])
+    )
+
+
+def _is_identity_reload_mapping(
+    layer: torch.nn.Module,
+    mapping: dict[str, torch.nn.Parameter],
+) -> bool:
+    runtime_params, _ = get_reloadable_layer_tensors(layer)
+    return mapping.keys() == runtime_params.keys() and all(
+        mapping[name] is runtime_params[name] for name in mapping
+    )
 
 
 def _restore_loading_metadata(layer: torch.nn.Module, info: LayerReloadingInfo) -> None:
@@ -166,48 +250,79 @@ def _restore_loading_metadata(layer: torch.nn.Module, info: LayerReloadingInfo) 
     ):
         for name, checkpoint_tensor in checkpoint_tensors.items():
             runtime_tensor = runtime_tensors[name]
-            checkpoint_tensor = restore_layer_refs(checkpoint_tensor, layer)
+            checkpoint_tensor = restore_layer_refs(
+                to_meta_tensor(checkpoint_tensor), layer
+            )
             runtime_tensor.__class__ = checkpoint_tensor.__class__
             runtime_tensor.__dict__.update(checkpoint_tensor.__dict__)
+            if not hasattr(runtime_tensor, "weight_loader"):
+                runtime_tensor.weight_loader = default_weight_loader
 
 
-def _bind_runtime_weight_reload(
-    layer: torch.nn.Module, info: LayerReloadingInfo
+def _bind_runtime_weight_reload_mapping(
+    layer: torch.nn.Module,
+    info: LayerReloadingInfo,
+    runtime_tensors: tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]],
+    mapping: dict[str, torch.nn.Parameter] | None = None,
 ) -> bool:
-    if isinstance(layer, (Attention, MLAAttention)):
+    if mapping is None:
+        mapping = _get_runtime_weight_reload_mapping(layer, info)
+    if mapping is None or _is_identity_reload_mapping(layer, mapping):
         return False
 
-    quant_method = getattr(layer, "quant_method", None)
-    if not isinstance(quant_method, QuantizeMethodBase):
-        return False
-    if (
-        quant_method.__class__.bind_runtime_weight_reload
-        is QuantizeMethodBase.bind_runtime_weight_reload
-    ):
-        return False
-
-    _, restore_buffers = info.restore_metadata
+    restore_params, restore_buffers = info.restore_metadata
+    runtime_params, _ = runtime_tensors
     if restore_buffers:
         return False
 
-    info.kernel_tensors = get_layer_params_buffers(layer)
-    restore_layer_on_meta(layer, info)
-    if quant_method.bind_runtime_weight_reload(layer, info.kernel_tensors[0]):
-        info.runtime_bound = True
-        return True
+    for name, checkpoint_param in restore_params.items():
+        mapped_param = mapping[name]
+        runtime_param = runtime_params.get(name)
+        if (
+            runtime_param is None
+            or mapped_param.__class__ is not checkpoint_param.__class__
+            or not _covers_same_storage(mapped_param, runtime_param)
+        ):
+            return False
 
-    _place_kernel_tensors(layer, info)
-    info.kernel_tensors = None
-    return False
+    info.kernel_tensors = runtime_tensors
+    for name, mapped_param in mapping.items():
+        setattr(layer, name, mapped_param)
+    info.runtime_bound = True
+    return True
+
+
+def _covers_same_storage(view: torch.Tensor, runtime_tensor: torch.Tensor) -> bool:
+    if view.device != runtime_tensor.device or view.is_meta:
+        return False
+    try:
+        view_storage = view.untyped_storage()
+        runtime_storage = runtime_tensor.untyped_storage()
+    except (RuntimeError, ValueError):
+        return False
+
+    return (
+        view_storage.data_ptr() == runtime_storage.data_ptr()
+        and view_storage.nbytes() == runtime_storage.nbytes()
+        and view.storage_offset() * view.element_size()
+        == runtime_tensor.storage_offset() * runtime_tensor.element_size()
+        and view.numel() * view.element_size()
+        == runtime_tensor.numel() * runtime_tensor.element_size()
+        and torch._debug_has_internal_overlap(view) == 0
+    )
 
 
 def _matching_tensor_layouts(
     checkpoint_tensors: dict[str, torch.Tensor],
     runtime_tensors: dict[str, torch.Tensor],
 ) -> bool:
+    if checkpoint_tensors.keys() != runtime_tensors.keys():
+        return False
     for name, checkpoint_tensor in checkpoint_tensors.items():
         runtime_tensor = runtime_tensors.get(name)
         if runtime_tensor is None:
+            return False
+        if is_lazy(checkpoint_tensor) or is_lazy(runtime_tensor):
             return False
         if (
             checkpoint_tensor.shape != runtime_tensor.shape
@@ -216,6 +331,45 @@ def _matching_tensor_layouts(
         ):
             return False
     return True
+
+
+def _make_reload_plan(
+    mode: LayerReloadMode,
+    runtime_tensors: tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]],
+) -> LayerReloadPlan:
+    params, buffers = runtime_tensors
+    return LayerReloadPlan(
+        mode=mode,
+        runtime_signatures=(
+            {
+                name: TensorReloadSignature.from_tensor(tensor)
+                for name, tensor in params.items()
+            },
+            {
+                name: TensorReloadSignature.from_tensor(tensor)
+                for name, tensor in buffers.items()
+            },
+        ),
+    )
+
+
+def _matches_runtime_plan(
+    plan: LayerReloadPlan,
+    runtime_tensors: tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]],
+) -> bool:
+    current = _make_reload_plan(plan.mode, runtime_tensors)
+    return plan.runtime_signatures == current.runtime_signatures
+
+
+def _verify_reload_plan(layer: torch.nn.Module, info: LayerReloadingInfo) -> None:
+    plan = info.reload_plan
+    if plan is None:
+        return
+    if not _matches_runtime_plan(plan, get_layer_params_buffers(layer)):
+        raise RuntimeError(
+            f"{layer.__class__.__name__} changed runtime tensor storage or "
+            "layout during weight reload"
+        )
 
 
 def initialize_online_processing(layer: torch.nn.Module):
@@ -295,7 +449,7 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
         )
 
         # Do not online process attention layers, must wait until finalize
-        if isinstance(layer, (Attention, MLAAttention)):
+        if isinstance(layer, _DEFERRED_ATTENTION_TYPES):
             return ret
 
         # Log warnings allocating excessive buffers on device
@@ -346,14 +500,16 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
         info = get_layerwise_info(layer)
         if info.runtime_bound:
             _place_kernel_tensors(layer, info)
+            _verify_reload_plan(layer, info)
             info.reset()
             continue
         if not info.can_load():
+            _verify_reload_plan(layer, info)
             info.reset()
             continue
 
         # Attention/MLA layers are processed after all other layers
-        if isinstance(layer, (Attention, MLAAttention)):
+        if isinstance(layer, _DEFERRED_ATTENTION_TYPES):
             deferred_attn.append((layer, info))
             continue
 
@@ -379,11 +535,13 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
             logger.debug("%s: Delayed processing", layer.__class__.__name__)
             _layerwise_process(layer, info)
 
+        _verify_reload_plan(layer, info)
         info.reset()
 
     # Process attention layers after all other layers are done
     for layer, info in deferred_attn:
         _finalize_attention_layer(layer, info, model_config)
+        _verify_reload_plan(layer, info)
         info.reset()
 
     LOADING_LAYERS.clear()

--- a/vllm/model_executor/model_loader/reload/meta.py
+++ b/vllm/model_executor/model_loader/reload/meta.py
@@ -15,6 +15,7 @@ __all__ = [
     "to_meta_tensor",
     "materialize_meta_tensor",
     "capture_layer_to_meta",
+    "get_reloadable_layer_tensors",
     "restore_layer_on_meta",
     "materialize_layer",
     "get_numel_loaded",
@@ -93,16 +94,27 @@ def capture_layer_to_meta(layer: torch.nn.Module) -> LayerTensors:
     if layer.__class__.__name__ in SKIP_MODULES:
         return ({}, {})
 
-    params, buffers = get_layer_params_buffers(layer)
-    parameter_storage_ptrs = _parameter_storage_ptrs(layer)
+    params, buffers = get_reloadable_layer_tensors(layer)
     return (
         {
             name: sanitize_layer_refs(to_meta_tensor(param), layer)
             for name, param in params.items()
-            if name not in SKIP_TENSORS
         },
         {
             name: sanitize_layer_refs(to_meta_tensor(buffer), layer)
+            for name, buffer in buffers.items()
+        },
+    )
+
+
+def get_reloadable_layer_tensors(layer: torch.nn.Module) -> LayerTensors:
+    """Return tensors represented by checkpoint-format reload metadata."""
+    params, buffers = get_layer_params_buffers(layer)
+    parameter_storage_ptrs = _parameter_storage_ptrs(layer)
+    return (
+        {name: param for name, param in params.items() if name not in SKIP_TENSORS},
+        {
+            name: buffer
             for name, buffer in buffers.items()
             if name not in SKIP_TENSORS
             and not _is_non_persistent_parameter_alias_buffer(

--- a/vllm/model_executor/model_loader/reload/types.py
+++ b/vllm/model_executor/model_loader/reload/types.py
@@ -33,6 +33,9 @@ class LayerReloadingInfo:
     # persistence survives `_non_persistent_buffers_set` being mutated during reload
     kernel_non_persistent_buffers: set[str] = field(default_factory=set)
 
+    # checkpoint-layout views are bound directly to kernel storage while reloading
+    runtime_bound: bool = False
+
     def reset(self):
         self.__init__(  # type: ignore[misc]
             restore_metadata=self.restore_metadata, restore_device=self.restore_device

--- a/vllm/model_executor/model_loader/reload/types.py
+++ b/vllm/model_executor/model_loader/reload/types.py
@@ -1,14 +1,76 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from dataclasses import dataclass, field
+from enum import Enum, auto
 from inspect import BoundArguments
 
 import torch
+from torch.nn.parameter import is_lazy
 
-__all__ = ["LayerTensors", "LayerReloadingInfo"]
+__all__ = [
+    "LayerReloadMode",
+    "LayerReloadPlan",
+    "LayerReloadingInfo",
+    "LayerTensors",
+    "TensorReloadSignature",
+]
 
 # encodes both parameters and buffers separately
 LayerTensors = tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]
+
+
+class LayerReloadMode(Enum):
+    DIRECT = auto()
+    RUNTIME_VIEW = auto()
+    LAYERWISE = auto()
+
+
+@dataclass(frozen=True)
+class TensorReloadSignature:
+    shape: torch.Size | None
+    stride: tuple[int, ...]
+    dtype: torch.dtype
+    device: torch.device
+    data_ptr: int | None
+    storage_ptr: int | None
+    storage_offset: int
+    storage_nbytes: int
+
+    @classmethod
+    def from_tensor(cls, tensor: torch.Tensor) -> "TensorReloadSignature":
+        if is_lazy(tensor):
+            return cls(
+                shape=None,
+                stride=(),
+                dtype=tensor.dtype,
+                device=tensor.device,
+                data_ptr=None,
+                storage_ptr=None,
+                storage_offset=0,
+                storage_nbytes=0,
+            )
+        storage = tensor.untyped_storage()
+        return cls(
+            shape=tensor.shape,
+            stride=tensor.stride(),
+            dtype=tensor.dtype,
+            device=tensor.device,
+            data_ptr=tensor.data_ptr(),
+            storage_ptr=storage.data_ptr(),
+            storage_offset=tensor.storage_offset(),
+            storage_nbytes=storage.nbytes(),
+        )
+
+
+TensorReloadSignatures = tuple[
+    dict[str, TensorReloadSignature], dict[str, TensorReloadSignature]
+]
+
+
+@dataclass(frozen=True)
+class LayerReloadPlan:
+    mode: LayerReloadMode
+    runtime_signatures: TensorReloadSignatures
 
 
 @dataclass
@@ -36,9 +98,14 @@ class LayerReloadingInfo:
     # checkpoint-layout views are bound directly to kernel storage while reloading
     runtime_bound: bool = False
 
+    # reusable strategy and runtime-storage invariants
+    reload_plan: LayerReloadPlan | None = None
+
     def reset(self):
         self.__init__(  # type: ignore[misc]
-            restore_metadata=self.restore_metadata, restore_device=self.restore_device
+            restore_metadata=self.restore_metadata,
+            restore_device=self.restore_device,
+            reload_plan=self.reload_plan,
         )
 
     def can_load(self) -> bool:

--- a/vllm/model_executor/model_loader/reload/types.py
+++ b/vllm/model_executor/model_loader/reload/types.py
@@ -5,10 +5,7 @@ from inspect import BoundArguments
 
 import torch
 
-__all__ = [
-    "LayerReloadingInfo",
-    "LayerTensors",
-]
+__all__ = ["LayerTensors", "LayerReloadingInfo"]
 
 # encodes both parameters and buffers separately
 LayerTensors = tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]

--- a/vllm/model_executor/model_loader/reload/types.py
+++ b/vllm/model_executor/model_loader/reload/types.py
@@ -1,76 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from dataclasses import dataclass, field
-from enum import Enum, auto
 from inspect import BoundArguments
 
 import torch
-from torch.nn.parameter import is_lazy
 
 __all__ = [
-    "LayerReloadMode",
-    "LayerReloadPlan",
     "LayerReloadingInfo",
     "LayerTensors",
-    "TensorReloadSignature",
 ]
 
 # encodes both parameters and buffers separately
 LayerTensors = tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]
-
-
-class LayerReloadMode(Enum):
-    DIRECT = auto()
-    RUNTIME_VIEW = auto()
-    LAYERWISE = auto()
-
-
-@dataclass(frozen=True)
-class TensorReloadSignature:
-    shape: torch.Size | None
-    stride: tuple[int, ...]
-    dtype: torch.dtype
-    device: torch.device
-    data_ptr: int | None
-    storage_ptr: int | None
-    storage_offset: int
-    storage_nbytes: int
-
-    @classmethod
-    def from_tensor(cls, tensor: torch.Tensor) -> "TensorReloadSignature":
-        if is_lazy(tensor):
-            return cls(
-                shape=None,
-                stride=(),
-                dtype=tensor.dtype,
-                device=tensor.device,
-                data_ptr=None,
-                storage_ptr=None,
-                storage_offset=0,
-                storage_nbytes=0,
-            )
-        storage = tensor.untyped_storage()
-        return cls(
-            shape=tensor.shape,
-            stride=tensor.stride(),
-            dtype=tensor.dtype,
-            device=tensor.device,
-            data_ptr=tensor.data_ptr(),
-            storage_ptr=storage.data_ptr(),
-            storage_offset=tensor.storage_offset(),
-            storage_nbytes=storage.nbytes(),
-        )
-
-
-TensorReloadSignatures = tuple[
-    dict[str, TensorReloadSignature], dict[str, TensorReloadSignature]
-]
-
-
-@dataclass(frozen=True)
-class LayerReloadPlan:
-    mode: LayerReloadMode
-    runtime_signatures: TensorReloadSignatures
 
 
 @dataclass
@@ -98,14 +39,10 @@ class LayerReloadingInfo:
     # checkpoint-layout views are bound directly to kernel storage while reloading
     runtime_bound: bool = False
 
-    # reusable strategy and runtime-storage invariants
-    reload_plan: LayerReloadPlan | None = None
-
     def reset(self):
         self.__init__(  # type: ignore[misc]
             restore_metadata=self.restore_metadata,
             restore_device=self.restore_device,
-            reload_plan=self.reload_plan,
         )
 
     def can_load(self) -> bool:


### PR DESCRIPTION
## Summary

This PR removes redundant reconstruction work from online weight reload while
preserving the runtime tensor storage used by kernels and CUDA graphs.

It adds two fail-closed fast paths:

1. **Layout-identical direct reload:** when checkpoint and runtime tensors have
   exactly the same shape, stride, and dtype, the original weight loader writes
   directly into the existing runtime storage.
2. **Runtime-backed checkpoint views:** an explicitly opted-in quantization
   method may expose checkpoint-layout views backed by already transformed
   runtime storage. The loader writes through those views, and finalization only
   restores the original `Parameter` objects.

The initial runtime-view implementation covers compressed-tensors WNA16 Triton
MoE weights and scales. Unsupported methods, unverified layouts, and failed atomic bindings keep
using the existing layerwise materialize/process/copy fallback. Attention
wrappers may use direct/runtime-view loading when their layouts pass the same
contract, but all attention variants still share one deferred post-load
finalization stage.

The important result is that this PR does **not** skip the original weight
loader, change the inference backend, replace Triton with Marlin, or rebuild
CUDA-graph-visible kernel tensors. It removes the temporary layer lifecycle
that is unnecessary when the final storage can be safely targeted directly.

## Motivation

The existing layerwise reload path is necessary when
`process_weights_after_loading()` changes the checkpoint representation into a
different runtime representation. However, it applies the same reconstruction
lifecycle to layers whose final storage is already known and safely writable.

Before this PR, each arriving checkpoint tensor could go through:

```text
checkpoint tensor
  -> recompute layer size and wrap late-registered loaders
  -> bind and normalize loader arguments
  -> retain BoundArguments and count loaded numel
  -> update and scan the set of concurrently loading layers
  -> materialize a temporary checkpoint-layout layer
  -> replay the original loaders
  -> rerun post-load quantization / packing / transpose
  -> copy processed tensors back into the original runtime storage
  -> restore the original Parameter / Buffer objects
```

This is correct, but redundant for two common cases:

- the checkpoint tensor already has the same layout as the runtime tensor; or
- the runtime tensor can safely expose a checkpoint-layout view sharing the
  same storage.

After this PR:

```text
layout-identical tensor
  -> original loader -> existing runtime storage

WNA16 runtime-view tensor
  -> original loader -> checkpoint-layout view of existing packed storage
  -> restore original Parameter object at finalize (no data movement)

unverified / unsupported tensor
  -> unchanged layerwise fallback
```

## Design

### 1. One non-mutating format-owner hook

Quantization methods expose one opt-in contract:

```python
get_runtime_weight_reload_mapping(
    layer,
    checkpoint_params,
    runtime_params,
) -> Mapping[str, Parameter] | None
```

The default returns `None`. An implementation must not mutate `layer`; it either
returns a complete checkpoint-name-to-runtime-storage mapping or declines the
fast path. This replaces the earlier boolean `supports_direct_weight_reload()`
plus mutating `bind_runtime_weight_reload()` pair. One mapping describes both
identity and nontrivial runtime-view cases, so capability and destination cannot
disagree.

Modules without a quantization method may use the generic identity mapping when
the complete tensor layout matches. A quantized method must opt in explicitly;
generic code never guesses that a packed or transformed quantized layout is
safe.

### 2. Complete-set direct-layout validation

Identity/direct reload requires the complete checkpoint-facing parameter and
buffer key sets to match the reloadable runtime key sets. Every tensor must
match in shape, stride, and dtype. Lazy/uninitialized tensors fail closed. A
matching name, shape alone, or equal byte count is insufficient. `Attention`, `MLAAttention`, and `MMEncoderAttention` use the same deferred
post-load stage because their scales and runtime state have ordering requirements
beyond a local identity copy. Deferring finalization no longer forces their
checkpoint-compatible tensors onto the layerwise reconstruction path.

### 3. Explicit reusable reload plans

Every layer receives exactly one cached mode:

- `DIRECT`: the original loader targets the identical runtime tensor;
- `RUNTIME_VIEW`: the format owner supplies a checkpoint-layout view over the
  existing runtime storage;
- `LAYERWISE`: the existing materialize/process/copy-back fallback.

The plan records signatures for all runtime parameters and buffers: shape,
stride, dtype, device, data pointer, storage pointer, storage offset, and storage
size. Before every update, a stale plan is discarded if any signature changed.
DIRECT and RUNTIME_VIEW also re-confirm the current quant-method mapping on every
update, so replacing a quant method cannot silently reuse an old capability.
Finalization verifies the signature again and raises if reload changed runtime
storage or layout.

### 4. Atomic runtime-view binding validation

A custom mapping is accepted only after the entire mapping passes validation:

- every checkpoint parameter is present;
- the mapped Parameter class matches the checkpoint-facing class;
- the view remains on the same device as its runtime tensor;
- storage pointer and storage byte size are identical;
- byte offset and covered byte length are identical;
- the view has no internal overlap;
- checkpoint-facing buffers require exact-layout handling and are not inferred
  through the custom mapping.

Only after all entries pass does generic code bind the complete mapping to the
layer. A detached clone, partial mapping, mismatched view, or unsupported method
falls back without partially rebinding the live layer. This atomicity applies to
structural binding; it does not claim rollback of weight bytes after a transport
failure has already partially written an update.

### 5. Preserve loader metadata without retaining layer cycles

Direct/runtime-view loading still invokes the original weight loader, preserving
its slicing, TP/PP/EP sharding, stacked-parameter, and copy semantics. Loader
metadata is restored onto the live destination from a fresh meta copy.
Layer-bound references are restored only on that copy: the stored metadata
remains sanitized, avoids a layer-reference cycle, and cannot leave a loader
bound to the sanitizer sentinel. A real H200 run exposed this sentinel-bound
method case; the implementation and a bound-loader regression test cover it.

### 6. WNA16 Triton runtime views

Compressed-tensors WNA16 uses different checkpoint and runtime representations:

- packed runtime weights are transposed contiguous `uint8` storage, while the
  checkpoint-facing loader expects an `int32` view with checkpoint axis order;
- runtime scales are already transposed relative to checkpoint metadata.

The WNA16 method owns this transform. It returns `int32` views over the complete
packed `uint8` storage and checkpoint-facing views of the transposed scales,
copies loader metadata to temporary Parameters, and clears `is_transposed` for
the loader-facing view. Generic code proves that these views cover the exact
live storage before binding them. Finalization restores the original runtime
Parameter objects without transposing, repacking, or copying weight data.

### 7. Conservative fallback

The existing layerwise path remains for:

- FNUZ and unproven dtype conversions;
- Marlin WNA16;
- methods with buffers or derived state not fully represented by the mapping;
- unknown quantization methods;
- incomplete key sets, lazy tensors, detached views, internal overlap, or any
  shape/stride/dtype/storage mismatch.

## Initial opt-ins

- `UnquantizedLinearMethod` on every platform; generic key/shape/stride/dtype
  validation rejects CPU optimized layouts that removed or replaced `weight`;
- block-FP8 `Fp8LinearMethod` with `CutlassFp8BlockScaledMMKernel`;
- block-FP8 `Fp8MoEMethod` with Triton or Batched Triton;
- compressed-tensors `CompressedTensorsWNA16MoEMethod` checkpoint-layout runtime
  views.

## Unified post-load and CPU layout update

The latest head removes two remaining policy special cases.

### Attention finalizes once, independently of load mode

`Attention`, `MLAAttention`, and `MMEncoderAttention` are classified by one
`_POST_LOAD_ATTENTION_TYPES` tuple. Their checkpoint-compatible tensors may now
use the same direct/runtime-view planner as other layers. Regardless of whether
a layer selected direct, runtime-view, or legacy layerwise loading, it is queued
for the same final stage after all incoming tensors have arrived:

1. validate and restore the original runtime storage for a direct/runtime-view
   layer, or restore/reload attention scales for a layerwise layer;
2. invoke `layer.process_weights_after_loading(model_config.dtype)` exactly once;
3. reset the reload state.

This separates two independent questions: where bytes can safely be written, and
when module-wide derived state must be finalized.

### CPU Linear uses the generic contract

`UnquantizedLinearMethod.get_runtime_weight_reload_mapping()` now returns the
runtime parameters on every platform. That is only a candidate mapping. Generic
code still requires the complete checkpoint-facing and runtime key sets to match
in shape, stride, and dtype.

Therefore:

- ordinary CPU functional Linear retains a matching `weight` and can reload
  directly;
- CPU optimized implementations such as paths that remove or replace
  `weight` no longer match and automatically fall back;
- the reload path contains no CPU backend-name allowlist.

The same simplification is deliberately **not** applied to arbitrary quantized
methods. Equal shape/dtype cannot prove that packed or transformed runtime
storage is checkpoint-compatible; the format owner must explicitly opt in.

## Broad local A/B validation

A second validation layer was run on exact vLLM v0.25.1 using the same container
and the same prerequisite model-support/backend fixes on both sides:

- baseline port: `48c2ba006277e50331580c789a56ba623aa52494`;
- candidate port: `eda369098c21eaea99fe0e4329815b0f6c1f85eb`;
- PR head: `55da21d9604334f6ff418630d8aef8a153b44740`;
- image: `sha256:267dab8accfcdbbb31aa09ce8b74a31e13a9aaec3d7968164b3dad7ae865dd2c`;
- hosts: `h200-0` and `h200-1`, each with 8 H200 GPUs.

Each paired process used eager execution, prefix caching disabled, a fixed
prompt, greedy generation of eight tokens, and three same-checkpoint reloads.
The table reports the median of reloads 2 and 3. A and B ran concurrently on
separate GPUs where possible.

| Model / format | A steady | B steady | Delta | B mapped / layerwise |
|---|---:|---:|---:|---:|
| Pythia-14M BF16 | 0.050 s | 0.031 s | +60.5% | 68 / 2 |
| OPT-125M FP16 | 0.268 s | 0.259 s | +3.4% | 116 / 1 |
| Qwen2.5-0.5B BF16 | 0.316 s | 0.235 s | +34.6% | 271 / 1 |
| Qwen3-0.6B BF16 | 0.352 s | 0.332 s | +6.3% | 371 / 1 |
| Qwen3-4B BF16 | 2.073 s | 1.890 s | +9.7% | 475 / 1 |
| Qwen3-4B INT4 | 0.961 s | 0.985 s | -2.5% | 295 / 181 |
| Qwen3-4B NVFP4 | 1.031 s | 1.055 s | -2.2% | 295 / 181 |
| Qwen3.5-0.8B GDN | 0.550 s | 0.458 s | +20.2% | 484 / 1 |
| Qwen3-VL-2B, MM encoder | 1.231 s | 1.085 s | +13.5% | 665 / 1 |
| Qwen2 1.5B FP8 dynamic | 0.694 s | 0.690 s | +0.6% | 175 / 142 |
| Llama-3.1-8B FP8 | 2.312 s | 2.406 s | -3.9% | 199 / 162 |
| Gemma4-12B BF16 | 6.099 s | 5.577 s | +9.4% | 746 / 2 |
| MiMo-7B-RL BF16 | 3.325 s | 3.549 s | -6.3% | 403 / 2 |
| GLM-Z1-9B BF16 | 4.509 s | 4.381 s | +2.9% | 527 / 2 |
| PowerMoE-3B | 3.754 s | 3.748 s | +0.2% | 359 / 34 |
| GLM-4.7-Flash INT4 AWQ | 19.968 s | 20.319 s | -1.7% | 806 / 279 |
| Qwen3-30B-A3B FP8 | 14.075 s | 11.765 s | +19.6% | 487 / 146 |
| Qwen3-30B-A3B INT4 | 26.281 s | 26.491 s | -0.8% | 535 / 98 |
| Moonlight-16B-A3B FP8, MLA | 5.855 s | 5.474 s | +6.9% | 407 / 191 |
| Qwen3.6-35B-A3B INT4 | 30.704 s | 30.940 s | -0.8% | 747 / 52 |
| Qwen3-Coder-Next FP8, TP2 | 49.709 s | 39.706 s | +25.2% | 751 / 206 |

All 21 pairs passed. For every model, all three post-reload outputs matched the
pre-reload token IDs, text, and selected-token logprobs exactly. Baseline and
candidate token IDs and selected-token logprobs also matched exactly (maximum
cross-variant selected-logprob absolute difference: `0.0`).

Small negative timing deltas on mostly-layerwise formats are within the observed
NFS/page-cache variance and have no corresponding output difference. This disk
matrix is a breadth/correctness regression test; the VIME/NCCL results below
remain the end-to-end transport performance evidence.

Three attempted fixtures failed identically on A and B and are not counted:
DeepSeek-V2-Lite had an incomplete offline remote-code cache; GPT-OSS MXFP4 hit
the pre-existing `w13_weight` meta-restore collision; and the local GPT-OSS FP8
checkpoint did not match the model's `w2_bias` parameter set.

## Benchmark methodology

The benchmark was designed to isolate this PR from both sender-side
optimizations and inference-backend changes.

### Fixed environment

- Hardware: two independent nodes, `h200-0` and `h200-1`, each with 8 NVIDIA
  H200 141 GB GPUs.
- Container image digest:
  `sha256:267dab8accfcdbbb31aa09ce8b74a31e13a9aaec3d7968164b3dad7ae865dd2c`.
- Image vLLM: `0.25.1`, commit
  `752a3a504485790a2e8491cacbb35c137339ad34`.
- VIME validation head:
  `b41b854964a162ada035f1875e055b949fc82796`.
- Sender buffer: 512 MiB.
- vLLM sleep mode: Level 2.
- Eager execution for all three model integrations.
- Both A and B include the same VIME sender behavior, including
  `vllm-project/vime#340`; sender optimization is therefore held constant.

### Same-backend requirement and #49065

Both A and B explicitly use `--vllm-moe-backend triton`.

Both sides also include the behavior from #49065: WNA16 may select Marlin only
when `moe_backend in ("auto", "marlin")`; an explicit Triton selection remains
on `CompressedTensorsWNA16MoEMethod`.

This is important because an earlier Qwen3.6 comparison accidentally used
Marlin for A and Triton for B. That number was invalid as a reload-only A/B and
was removed. The results below rerun both sides on Triton. Logs from every Qwen
run contain `Using CompressedTensorsWNA16MoEMethod` and contain no Marlin
selection.

#49065 is not part of this PR. It only holds backend selection constant so that
the measured delta belongs to this reload change.

### A/B definition

- **A:** vLLM v0.25.1 plus the #49065 backend-selection behavior, without this
  PR.
- **B:** the exact same environment plus this PR's functional changes.

The profiling code, transport instrumentation, model checkpoint, VIME code,
container, topology, sender settings, and backend selection are identical
between A and B.

### Topologies

| Model | Trainer | Rollout | Transport/runtime |
|---|---|---|---|
| Qwen3.6-35B-A3B INT4 | TP1 / PP4 on GPUs 0-3 | 2 engines x TP2 on GPUs 4-7 | non-colocated, WNA16 Triton |
| Moonlight-16B-A3B FP8 | TP4 / EP2 on 8 GPUs | 4 engines x TP2 / EP2 | colocated IPC, block-FP8 Triton |
| Qwen3-Coder-Next FP8 | PP6 on GPUs 0-5 | 1 engine x TP2 / EP2 on GPUs 6-7 | non-colocated packed NCCL, FP8 Triton |

### Timing definitions

Three nested timing levels are reported and are never added across parent/child
boundaries:

1. **Outer update:** VIME's trainer-side `Timer update_weights`; this is the
   user-visible end-to-end time.
2. **Receiver critical path:** the single vLLM worker with the largest complete
   `start_weight_update()` to `finish_weight_update()` interval. All additive
   stages in a row come from that same worker.
3. **Nested receiver stages:** transport and loader blocks inside the receiver.

The receiver hierarchy is:

```text
receiver total
├── transfer.initialize
├── lifecycle uncovered / inter-chunk gap
├── transfer.receive
│   ├── IPC tensor reconstruction, or
│   └── NCCL broadcast + unpack + model.load_weights callback
└── transfer.finalize
```

`transfer.receive` contains `model.load_weights`; those values must not be
added. Similarly, `loader.trigger_process` contains the six
`_layerwise_process()` sub-blocks.

For attribution runs, transport and callback boundaries synchronize CUDA so
the callback values are CUDA-complete. The per-weight direct-loader timer is
CPU-only to avoid a synchronization per tensor.

The matrix measures the initial update and stops only after:

- the outer timer ends;
- the update endpoint returns successfully; and
- the expected profile JSON is present for every worker.

The final `KeyboardInterrupt` in these controlled logs is the orchestrator
stopping the job after the measured update, not an update failure.

## End-to-end performance

The low-instrumentation/reference outer results are the appropriate production
performance comparison:

| Model | A initial | B initial | Speedup | A post-train | B post-train | B direct / runtime-view / layerwise |
|---|---:|---:|---:|---:|---:|---:|
| Moonlight-16B-A3B FP8 | 5.4604 s | **3.4695 s** | **1.57x** | 4.5 s | **2.9 s** | 569 / 0 / 29 |
| Qwen3-Coder-Next FP8 | 49.4392 s | **31.9505 s** | **1.55x** | 50.0 s | **32.8 s** | 943 / 0 / 14 |
| Qwen3.6-35B-A3B INT4 | 6075.7 s | **20.6 s** | **294.9x** | not run | **20.9 s** | 747 / 40 / 12 |

The detailed profiler adds synchronization and Python timing overhead, so its
absolute outer values are not substituted for the table above. Its purpose is
to identify where the time went:

| Model | Profiled outer A / B | Receiver critical A / B | `model.load_weights` A / B |
|---|---:|---:|---:|
| Moonlight FP8 | 5.5 / 4.0 s | 4.468 / 3.144 s | 2.119 / 0.878 s |
| Qwen3-Coder-Next FP8 | 67.2 / 42.4 s | 67.067 / 42.303 s | 37.549 / 19.885 s |
| Qwen3.6 INT4, h200-0 same-host | 6608.2 / 23.2 s | 6608.095 / 23.091 s | 6478.328 / 8.621 s |
| Qwen3.6 INT4, h200-1 repeat | 5853.9 / 21.5 s | 5853.846 / 21.460 s | 5664.862 / 8.579 s |

## Detailed breakdown: Moonlight-16B-A3B FP8

### Receiver critical path

| Stage | A | B | B - A |
|---|---:|---:|---:|
| Receiver total | 4.468 s | 3.144 s | -1.324 s |
| `transfer.initialize` | 0.032 s | 0.019 s | -0.013 s |
| Lifecycle uncovered | 1.918 s | 1.835 s | -0.083 s |
| `transfer.receive` (60 calls) | 2.508 s | 1.279 s | -1.229 s |
| `transfer.finalize` | 0.010 s | 0.011 s | +0.001 s |
| Outer minus receiver | 1.032 s | 0.856 s | -0.176 s |

Moonlight uses colocated IPC:

| Nested receive stage | A | B | Interpretation |
|---|---:|---:|---|
| IPC handle-to-tensor reconstruction | 0.387 s | 0.398 s | unchanged; not optimized by this PR |
| `model.load_weights` | 2.119 s | 0.878 s | **-1.241 s; explains almost all receiver improvement** |

### A: old callback blocks

| Mutually exclusive top-level callback block | Calls | Time |
|---|---:|---:|
| refresh layer size and wrap late parameters | 10,472 | 0.090 s |
| `inspect.Signature.bind` and defaults | 10,472 | 0.089 s |
| retain `BoundArguments` and count numel | 10,472 | 0.823 s |
| device-buffer accounting | 10,472 | 0.052 s |
| trigger completed-layer processing | 298 | 0.459 s |

These blocks total approximately 1.513 s. The remaining approximately 0.606 s
inside `model.load_weights` is model traversal, original-loader work outside
the wrapper, and CUDA completion.

The 0.459 s trigger block contains:

| `_layerwise_process()` sub-block | Time |
|---|---:|
| materialize | 0.041 s |
| reset quantization flag | 0.0010 s |
| unwrap deferred loaders | 0.0014 s |
| replay original loaders | 0.354 s |
| quantize/process after loading | 0.016 s |
| copy back and restore runtime objects | 0.019 s |

### B: direct and fallback work

- 569 layers use direct reload; 29 remain on fallback.
- 10,496 direct loader calls use 0.446 s of CPU dispatch time.
- Fallback reaches the buffered processing path only twice; buffer time is
  0.0008 s and trigger time is approximately 0.0016 s.
- Direct-layout checking for all 598 layers is 0.0062 s.
- Restoring loader metadata for 569 direct layers is 0.0034 s.
- Only the 29 fallback layers capture runtime tensors, restore meta tensors,
  and wrap loaders: 0.0001 / 0.0005 / 0.0021 s.

An independent h200-1 repeat reproduced outer 5.0 -> 3.4 s, receiver
4.145 -> 2.683 s, and `model.load_weights` 2.088 -> 0.921 s. The A-side
`buffer_and_count` hotspot remained 0.826 s.

## Detailed breakdown: Qwen3-Coder-Next FP8

### Receiver critical path

| Stage | A | B | B - A |
|---|---:|---:|---:|
| Receiver total | 67.067 s | 42.303 s | -24.764 s |
| `transfer.initialize` | 0.057 s | 0.028 s | -0.029 s |
| Lifecycle uncovered | 27.634 s | 20.899 s | -6.735 s |
| `transfer.receive` (56 calls) | 39.370 s | 21.371 s | -17.999 s |
| `transfer.finalize` | 0.006 s | 0.006 s | approximately unchanged |
| Outer minus receiver | 0.133 s | 0.097 s | -0.036 s |

Coder uses packed NCCL. `broadcast_and_unpack` includes the callback:

| Nested receive stage | A | B | B - A |
|---|---:|---:|---:|
| NCCL broadcast + unpack + callback | 39.369 s | 21.369 s | -18.000 s |
| 104 `model.load_weights` callbacks | 37.549 s | 19.885 s | **-17.664 s** |

### A: old callback blocks

123,807 wrapped loader calls are measured; 122,880 come from
`RoutedExperts`.

| Mutually exclusive top-level callback block | Calls | Time | RoutedExperts contribution |
|---|---:|---:|---:|
| refresh and wrap | 123,807 | 0.993 s | dominant call count |
| bind arguments | 123,807 | 1.041 s | dominant call count |
| retain arguments and count numel | 123,807 | 10.986 s | 10.907 s |
| device-buffer accounting | 123,807 | 0.627 s | 0.620 s |
| trigger completed-layer processing | 603 | 4.600 s | 4.381 s |

The five blocks total approximately 18.247 s. The remaining approximately
19.302 s is model traversal and original-loader/CUDA work outside the wrapper;
it is reported as residual rather than assigned to a function that was not
directly timed.

The trigger block contains:

| `_layerwise_process()` sub-block | Time |
|---|---:|
| materialize | 1.046 s |
| reset quantization flag | 0.0017 s |
| unwrap deferred loaders | 0.0027 s |
| replay original loaders | 3.302 s |
| quantize/process after loading | 0.026 s |
| copy back and restore runtime objects | 0.042 s |

### B: direct and fallback work

- 943 layers use direct reload; 14 remain on fallback.
- 148,381 direct loader calls use 4.070 s of CPU dispatch time.
- 147,456 calls / 4.043 s are `RoutedExperts`.
- Fallback reaches the buffered processing path only twice, taking about
  0.020 s.
- Direct checking for 957 layers is 0.0106 s.
- Metadata restoration for 943 direct layers is 0.0056 s.
- Capture / restore-meta / wrap for the 14 fallback layers is
  0.00004 / 0.00047 / 0.00177 s.

The direct and old wrapper call counts are not expected to match exactly. The
old wrapper returns early after a layer has already been processed, while the
direct timer records every original-loader invocation. The authoritative
comparison is the CUDA-complete callback boundary: 37.549 -> 19.885 s.

An independent h200-1 repeat reproduced outer 50.0 -> 34.0 s, receiver
49.946 -> 33.988 s, and `model.load_weights` 34.008 -> 19.338 s. Of the
15.958 s receiver reduction, 14.670 s is again inside the callback.

## Detailed breakdown: Qwen3.6-35B-A3B INT4

Qwen is the most important same-backend result because the old path exposes a
pathological interaction between checkpoint ordering and layerwise buffer
accounting.

### h200-0 same-host receiver critical path

| Stage | A | B | B - A |
|---|---:|---:|---:|
| Receiver total | 6608.095 s | 23.091 s | -6585.004 s |
| `transfer.initialize` | 0.048 s | 0.026 s | -0.022 s |
| Lifecycle uncovered | 126.173 s | 13.993 s | -112.180 s |
| `transfer.receive` (50 calls) | 6479.109 s | 9.065 s | -6470.045 s |
| `transfer.finalize` | 2.765 s | 0.0075 s | -2.758 s |
| Outer minus receiver | 0.105 s | 0.109 s | +0.004 s |

NCCL broadcast/unpack is 6479.108 -> 9.064 s and includes 50 CUDA-complete
`model.load_weights` callbacks totaling **6478.328 -> 8.621 s**.

The four B workers are tightly grouped at 23.0900-23.0914 s, so the critical
worker is not an outlier.

### A: exact old-path hotspot

The critical worker enters 92,773 wrapped loader calls; 92,160 come from
`RoutedExperts`.

| Mutually exclusive top-level callback block | Calls | Time | RoutedExperts contribution |
|---|---:|---:|---:|
| refresh layer size and wrap late parameters | 92,773 | 1.906 s | 92,160 calls |
| bind and normalize loader arguments | 92,773 | 1.735 s | 92,160 calls |
| retain `BoundArguments` and count numel | 92,773 | 24.519 s | 24.434 s |
| device-buffer accounting and warning | 92,773 | **6431.107 s** | **6399.295 s** |
| trigger completed-layer processing | 463 | 0.203 s | not dominant |

The device-buffer accounting block alone is 97.32% of the profiled outer time;
its `RoutedExperts` contribution alone is 96.84%.

The five mutually exclusive blocks total 6459.470 s. The remaining 18.857 s
inside `model.load_weights` contains traversal, `can_load`/early-return paths,
original-loader work outside the timed wrapper blocks, and CUDA completion.

463 layers process immediately. Another 40 partially loaded WNA16
`RoutedExperts` process during finalization in 2.755 s. Across both paths,
503 `_layerwise_process()` calls contain:

| `_layerwise_process()` sub-block | Calls | Time |
|---|---:|---:|
| materialize temporary layer | 503 | 0.102 s |
| reset quantization flag | 503 | 0.0019 s |
| unwrap deferred loaders | 503 | 0.0032 s |
| replay original loaders | 503 | 2.689 s |
| quantize / repack | 503 | 0.0202 s |
| copy back and restore runtime objects | 503 | 0.0268 s |

These six sub-blocks total approximately 2.843 s. Therefore the 6000+ second
result is not caused by Triton quantization or repacking; it is caused by the
per-weight Python accounting/warning block.

### Why accounting becomes pathological

For every arriving device weight, the old wrapper:

1. inserts the parent layer into `LOADING_LAYERS`;
2. constructs and sorts the class-name list for all currently loading layers;
3. traverses all those layers and sums `get_info_size(...)`;
4. calls `logger.warning_once` with the computed memory and layer-name list.

The list, sort, and sum execute before entering the logger. In addition,
`warning_once` is backed by `@lru_cache` with `(logger, message, *args)` as the
key. Both `mem_used` and the layer-name list change as more `RoutedExperts`
accumulate, producing new cache keys and actual warning writes.

The h200-0 attribution run emits exactly 179,828 such warnings (about 111 MB of
log); B emits zero. During the slow buckets, all eight GPUs show 0% compute
utilization while the four vLLM TP workers use approximately 90-98% CPU. The
GPU is waiting for Python accounting and logging, not executing a slow Triton
kernel.

### B: WNA16 direct/runtime-view path

Initialization sees 799 layers:

- 747 are layout-identical direct layers;
- 52 attempt runtime binding;
- 40 `RoutedExperts` bind successfully;
- 12 layers conservatively remain on fallback.

Measured initialization/finalization cost:

| B code block | Calls | Time |
|---|---:|---:|
| direct-layout check | 799 | 0.00755 s |
| restore direct-loader metadata | 747 | 0.00335 s |
| runtime-bind attempts | 52 | 0.00469 s |
| restore original runtime-bound parameters | 40 | 0.00182 s |

The loader side contains:

- 92,771 direct loader calls in 2.052 s of CPU dispatch time;
- 92,160 `RoutedExperts` calls in 2.036 s;
- two fallback loads (embedding and LM head);
- 0.00084 s fallback buffer time;
- 0.00365 s fallback trigger time.

The fallback trigger contains 0.00221 s materialize, 0.00066 s replay, and
0.00055 s copy/restore; all other sub-blocks total less than 0.00006 s.

No WNA16 `RoutedExperts` layer is materialized, repacked, and copied back in B.
The original loader writes through the runtime-backed checkpoint view into the
existing kernel storage.

### Independent Qwen repeat

h200-1 independently reproduces the same result:

| Metric | A | B |
|---|---:|---:|
| Outer update | 5853.9 s | 21.5 s |
| Receiver critical | 5853.846 s | 21.460 s |
| `model.load_weights` | 5664.862 s | 8.579 s |
| Device-buffer accounting | 5623.209 s | removed from the direct path |
| `buffer_and_count` | 21.537 s | 0.00091 s fallback only |
| Direct loader CPU | not applicable | 2.115 s |
| Runtime bind | not applicable | 0.00426 s |

This is a 272.3x same-host speedup. The h200-1 A run also emits exactly 179,828
accounting warnings, and 5595.712 s of its accounting time is specifically
attributed to `RoutedExperts`.

The two absolute profiled A times differ because both long runs overlap on a
shared NFS log path and profiling changes synchronization/interleaving. Their
call counts, warning counts, hotspot, and B results agree. Production speedup is
therefore reported from the lower-instrumentation 6075.7 -> 20.6 s result, while
the synchronized profiles are used only for code-block attribution.

## What remains after the fast path

The following table locates remaining B cost. Columns are nested; they must not
be added horizontally.

| Model | B receiver | Lifecycle uncovered | Receive | `model.load_weights` | Direct-loader CPU | Callback residual |
|---|---:|---:|---:|---:|---:|---:|
| Moonlight | 3.144 s | 1.835 s | 1.279 s | 0.878 s | 0.446 s | approximately 0.430 s |
| Coder-Next | 42.303 s | 20.899 s | 21.371 s | 19.885 s | 4.070 s | approximately 15.796 s |
| Qwen3.6 INT4 | 23.091 s | 13.993 s | 9.065 s | 8.621 s | 2.052 s | approximately 6.565 s |

The callback residual is inclusive callback time minus direct-loader CPU and
the tiny fallback trigger. It includes model traversal, original-loader CUDA
work, and callback-end CUDA completion; it is not labeled as pure NCCL or pure
kernel time.

The largest remaining top-level component is generally lifecycle uncovered
time: sender/chunk arrival, HTTP/Ray scheduling, and inter-chunk gaps. This PR
does not change transport scheduling.

## Profiling caveats

- Transfer chunk and callback boundaries synchronize CUDA for attribution.
- A records multiple `perf_counter` blocks per wrapped loader call.
- B times direct loaders on CPU only; synchronizing every tensor materially
  perturbs the result and was excluded.
- Parent and child timings are never added.
- A callback residuals are reported explicitly rather than assigned to an
  unmeasured function.
- Production performance comes from low-instrumentation outer timers; detailed
  profiles are used for attribution.
- The two long Qwen A profiles overlapped on shared NFS to keep both H200 nodes
  occupied, so their absolute logging cost is intentionally treated as
  profiling-disturbed.

Despite the instrumentation overhead, the direction and attribution are
stable. For example, Coder's profiled speedup is 67.2 / 42.4 = 1.58x versus
49.4 / 32.0 = 1.54x without detailed profiling.

## Validation

### Static and unit validation

- final PR head: `ce0cf2e2a944cb366fb43de37aa7642f676a786d`;
- exact vLLM v0.25.1 validation port: `14c2444aed42705873fc8b614e702c38ed9218a6`;
- focused direct/runtime-view reload tests: **9 passed**;
- full final-fix pre-commit passed, including ruff, format, mypy, SPDX,
  forbidden-import, configuration, and sign-off checks;
- exact container source passed `py_compile`.

Tests cover exact key/layout acceptance and rejection, lazy parameters and
buffers, detached mapping rejection before mutation, bound-method metadata,
repeated runtime-view validation, quant-method replacement, storage replacement
detection, model cleanup, alias/non-persistent buffer preservation, WNA16
checkpoint views, and identity mappings in the presence of runtime-only MoE
tensors.

### Final-head three-model validation

Only the PR side was rerun; the pre-change measurements above were reused. All
three runs used the same H200 host, pinned image, explicit Triton MoE backend,
and exact final code.

| Model | Initial update | Post-train update | Train/rollout logprob abs diff | Result |
|---|---:|---:|---:|---|
| Qwen3.6-35B-A3B INT4 | **20.5 s** | **20.8 s** | 0.0159767 | `PR48382_CASE_DONE` |
| Moonlight-16B-A3B FP8 | **3.5 s** | **3.5 s** | 0.0507528 | `PR48382_CASE_DONE` |
| Qwen3-Coder-Next FP8 | **33.7 s** | **31.5 s** | 0.0144532 | `PR48382_CASE_DONE` |

The final revalidation caught and fixed an intermediate fail-closed regression:
a runtime-only MoE tensor made an otherwise identity mapping look non-identity,
which skipped restoration of FP8 scale loader metadata. Identity is now checked
against the checkpoint-reloadable runtime tensor set, and the focused test
includes that exact boundary. No final log contains a weight-update traceback,
endpoint failure, storage/layout validation error, NaN, or invalid MoE scale
quant method.

### Cross-framework design validation

The design was checked against 12 locally cloned inference or inference-adjacent
frameworks: SGLang, LMDeploy, TensorRT-LLM, xLLM, LightLLM, TGI, DeepSpeed,
Megatron-LM, llama.cpp, MLC-LLM, FlexFlow, and Dynamo. The common requirements
are: quiesce inference, plan destinations before mutation, let the format owner
define transforms, preserve runtime storage, finalize exactly once, and fail
closed when support cannot be proved.

### CUDA graph and transaction boundary

This PR preserves and verifies registered Parameter/Buffer storage used by the
fast path. It deliberately does not recursively walk arbitrary backend object
graphs. RFC #48478 owns explicit registration and a ModelRunner-level completion
gate for graph-visible backend tensors; draft #48902 is useful as an audit
prototype, not the production discovery contract. PR #48908 owns the common
prepare/finish/abort lifecycle.

This is a zero-copy refit, not a full value rollback. If transport fails after
some bytes have been written, correctness requires the worker to remain
paused/unhealthy until full reload or restart; successful binding validation
cannot reconstruct the previous model without retaining a second copy.

## Scope and non-goals

- This PR does not choose between Marlin and Triton. #49065 owns that backend
  selection correction.
- This PR does not optimize sender collectives; VIME #340 is held constant.
- This PR does not remove the layerwise fallback.
- This PR does not claim the remaining callback residual is one specific
  kernel or transport cost.
- This PR does not opt in unknown quantization methods based on tensor names.
- This PR does not recursively discover unregistered backend tensors; #48478 owns the explicit graph-storage contract.
- This PR does not promise value rollback after a partially written transfer; failed workers must remain paused.

## Related work

- #49065 fixes WNA16 backend selection so explicit Triton is respected.
- `vllm-project/vime#340` optimizes sender collectives and packed transfer; it is
  present on both benchmark sides.
- #48251 fixes graph-captured derived-tensor identity; this PR preserves kernel
  storage while removing redundant reload work.
- #48284 skips reload for an entirely non-quantized model; this PR selects safe
  layers inside quantized models.
- #42823 routes repeated raw loading through layerwise reload; this PR optimizes
  that pipeline without changing its entry points.
- #48908 unifies the prepare/finish/abort lifecycle; this PR supplies safe destination plans within that lifecycle.
- #48478 defines the production fail-closed graph-storage registry and completion gate.
- #48902 audits unmanaged backend tensors; production support still requires explicit registration.

AI assistance was used. The submitter reviewed every changed line and ran the
listed validations.
