### PR TITLE
fix(reasoning): recompute ernie45 response-end index after stripping prefix

### DIFF
--- a/tests/reasoning/test_ernie45_reasoning_parser.py
+++ b/tests/reasoning/test_ernie45_reasoning_parser.py
@@ -6,6 +6,7 @@ from transformers import AutoTokenizer
 
 from tests.reasoning.utils import run_reasoning_extraction
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
+from vllm.reasoning.ernie45_reasoning_parser import Ernie45ReasoningParser
 
 parser_name = "ernie45"
 
@@ -122,3 +123,54 @@ def test_reasoning(
 
     assert reasoning == param_dict["reasoning"]
     assert content == param_dict["content"]
+
+
+def _streaming_parser() -> Ernie45ReasoningParser:
+    # Exercise the pure streaming logic with explicit token ids, without a
+    # tokenizer: the run_reasoning_extraction harness feeds one token per
+    # delta, so it cannot build a delta that spans </think>, <response> and
+    # </response> at once (which happens under speculative decoding).
+    parser = object.__new__(Ernie45ReasoningParser)
+    parser.start_token_id = 1
+    parser.end_token_id = 2
+    parser.response_start_token_id = 3
+    parser.response_end_token_id = 4
+    parser.newline_token_id = 5
+    parser.parser_token_ids = [2, 4]
+    return parser
+
+
+def test_streaming_multi_token_delta_with_response_block():
+    # </think> + a full <response>...</response> block in a single delta: the
+    # <response> prefix and </response> suffix must both be stripped cleanly.
+    parser = _streaming_parser()
+    delta = "</think>\n<response>\nHello\n</response>\n"
+    msg = parser.extract_reasoning_streaming(
+        previous_text="",
+        current_text=delta,
+        delta_text=delta,
+        previous_token_ids=[],
+        current_token_ids=[2, 3, 4],
+        delta_token_ids=[2, 3, 4],
+    )
+    assert msg is not None
+    assert msg.reasoning == ""
+    assert msg.content == "\nHello\n"
+
+
+def test_streaming_multi_token_delta_without_response_block():
+    # </think> followed by plain content (no <response> wrapper) in one delta
+    # must keep the content intact.
+    parser = _streaming_parser()
+    delta = "</think>def"
+    msg = parser.extract_reasoning_streaming(
+        previous_text="",
+        current_text=delta,
+        delta_text=delta,
+        previous_token_ids=[],
+        current_token_ids=[2, 9],
+        delta_token_ids=[2, 9],
+    )
+    assert msg is not None
+    assert msg.reasoning == ""
+    assert msg.content == "def"

--- a/vllm/reasoning/ernie45_reasoning_parser.py
+++ b/vllm/reasoning/ernie45_reasoning_parser.py
@@ -92,9 +92,12 @@ class Ernie45ReasoningParser(BaseThinkingReasoningParser):
             content = delta_text[think_end_index + len(self.end_token) :]
             content = content.lstrip("\n")
             response_start_idx = content.find(self.response_start_token)
-            response_end_idx = content.rfind(self.response_end_token)
             if response_start_idx != -1:
                 content = content[response_start_idx + len(self.response_start_token) :]
+            # Recompute the end index *after* the prefix slice above, otherwise
+            # it is stale (offset by len("<response>")) and truncates the
+            # content — mirrors the sibling elif branch below.
+            response_end_idx = content.rfind(self.response_end_token)
             if response_end_idx != -1:
                 content = content[:response_end_idx]
             return DeltaMessage(


### PR DESCRIPTION
> **AI assistance disclosure (per AGENTS.md):** This fix was prepared with AI assistance (Claude / Claude Code): the bug was surfaced by an automated review pass, and the diff + tests were drafted with the tool. The change is small, local, and has been verified as described under Test Result. It is submitted under human account ownership; a human should review every line before merge.

## Purpose

`Ernie45ReasoningParser.extract_reasoning_streaming` corrupts the emitted content when a single streaming delta carries `</think>` together with a full `<response>...</response>` block.

The `</think> in delta` branch computes the response-end index *before* slicing off the `<response>` prefix:

```python
response_start_idx = content.find(self.response_start_token)
response_end_idx = content.rfind(self.response_end_token)   # computed on the pre-slice string
if response_start_idx != -1:
    content = content[response_start_idx + len(self.response_start_token):]  # content now shorter by len("<response>")
if response_end_idx != -1:
    content = content[:response_end_idx]                     # stale index → wrong cut
```

After the prefix slice the string is shorter by `len("<response>")` (10 chars), so the stale `response_end_idx` truncates the content. For the delta `"</think>\n<response>\nHello\n</response>\n"` the parser returns content `"\nHello\n</response"` instead of `"\nHello\n"`.

This is reachable under **speculative decoding**, where several accepted tokens arrive in one decode step, so a delta can span `</think>`, `<response>` and `</response>` at once. The sibling `elif` branch and the non-streaming `extract_reasoning` both already recompute the end index *after* the front slice — only this first branch was wrong.

The fix moves the `response_end_idx = content.rfind(...)` computation to after the `<response>` prefix slice, matching the sibling branch.

## Not a duplicate

Checked open/closed PRs touching this parser (`gh pr list --search "ernie45 reasoning"`). The most recent change, #46255, added the `if response_end_idx != -1` miss-guard but kept the stale-index ordering; this PR fixes that ordering and is complementary. The open #45385/#44310 are a separate Rust-frontend reimplementation. No open PR addresses this bug.

## Test Plan

Added two direct unit tests in `tests/reasoning/test_ernie45_reasoning_parser.py`. The existing `run_reasoning_extraction` harness feeds one token per delta and cannot build a delta spanning `</think>`, `<response>` and `</response>` at once, so the new tests construct the parser with explicit token ids and drive `extract_reasoning_streaming` directly:

## Test Result

- `test_streaming_multi_token_delta_with_response_block` — full block in one delta → content `"\nHello\n"`. **Fails on `main`** (`content == "\nHello\n</response"`), passes with this change.
- `test_streaming_multi_token_delta_without_response_block` — `</think>` + plain content, no wrapper → content `"def"` (guards the reorder against regressing the common path). Passes before and after.

Verified by executing the parser code against these inputs (fail-before / pass-after confirmed). `ruff check` / `ruff format --check` clean on both files. This is a string-slicing correctness fix on already-generated tokens (it does not change model outputs), so no model-quality eval applies.
