### PR TITLE
[V1] Add device-neutral KVConnector host-contract mixins

### DIFF
--- a/tests/v1/kv_connector/unit/test_host_contract_mixins.py
+++ b/tests/v1/kv_connector/unit/test_host_contract_mixins.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the device-neutral KVConnector host-contract mixins added to
+vLLM core. Validate the generic behavior in isolation (no device, no specific
+connector):
+- worker mixin: init is a no-op without a connector; handshake returns None.
+- runner mixin: register is a no-op without a connector; the sync/writeback
+  hooks default to no-op and are overridable.
+"""
+
+import types
+
+
+def test_worker_mixin_init_noop_without_connector(monkeypatch):
+    import vllm.v1.worker.kv_connector_worker_mixin as m
+
+    calls: dict[str, object] = {}
+    monkeypatch.setattr(
+        m,
+        "ensure_kv_transfer_initialized",
+        lambda cfg, kvc: calls.setdefault("init", (cfg, kvc)),
+    )
+    m.KVConnectorWorkerMixin.maybe_initialize_kv_transfer("CFG", "KVC")
+    assert calls["init"] == ("CFG", "KVC")
+
+
+def test_worker_mixin_handshake_none_without_connector(monkeypatch):
+    import vllm.v1.worker.kv_connector_worker_mixin as m
+
+    monkeypatch.setattr(m, "has_kv_transfer_group", lambda: False)
+    assert m.KVConnectorWorkerMixin.get_kv_connector_handshake_metadata() is None
+
+
+def test_runner_mixin_register_noop_without_connector(monkeypatch):
+    import vllm.v1.worker.kv_connector_model_runner_mixin as m
+
+    monkeypatch.setattr(m, "has_kv_transfer_group", lambda: False)
+    # Must not raise and must not call get_kv_transfer_group.
+    called = {"n": 0}
+    monkeypatch.setattr(
+        m, "get_kv_transfer_group", lambda: called.__setitem__("n", called["n"] + 1)
+    )
+    m.KVConnectorModelRunnerMixin.register_kv_caches_with_connector({"l0": object()})
+    assert called["n"] == 0
+
+
+def test_runner_mixin_register_calls_connector_when_present(monkeypatch):
+    import vllm.v1.worker.kv_connector_model_runner_mixin as m
+
+    monkeypatch.setattr(m, "has_kv_transfer_group", lambda: True)
+    seen: dict[str, object] = {}
+    conn = types.SimpleNamespace(
+        register_kv_caches=lambda kv: seen.setdefault("kv", kv)
+    )
+    monkeypatch.setattr(m, "get_kv_transfer_group", lambda: conn)
+    kv = {"l0": object()}
+    m.KVConnectorModelRunnerMixin.register_kv_caches_with_connector(kv)
+    assert seen["kv"] is kv
+
+
+def test_runner_mixin_sync_hooks_default_noop():
+    from vllm.v1.worker.kv_connector_model_runner_mixin import (
+        KVConnectorModelRunnerMixin as R,
+    )
+
+    class _Runner(R):
+        pass
+
+    r = _Runner()
+    # Default hooks are no-ops (return None, don't raise) regardless of args.
+    assert r.sync_kv_caches_before_save(object()) is None
+    assert r.writeback_kv_caches_after_load(object()) is None
+
+
+def test_runner_mixin_sync_hooks_overridable():
+    from vllm.v1.worker.kv_connector_model_runner_mixin import (
+        KVConnectorModelRunnerMixin as R,
+    )
+
+    calls = []
+
+    class _Runner(R):
+        def sync_kv_caches_before_save(self, so):
+            calls.append(("sync", so))
+
+        def writeback_kv_caches_after_load(self, so):
+            calls.append(("writeback", so))
+
+    r = _Runner()
+    r.sync_kv_caches_before_save("A")
+    r.writeback_kv_caches_after_load("B")
+    assert calls == [("sync", "A"), ("writeback", "B")]

--- a/vllm/v1/worker/kv_connector_model_runner_mixin.py
+++ b/vllm/v1/worker/kv_connector_model_runner_mixin.py
@@ -33,6 +33,48 @@ logger = init_logger(__name__)
 # Defined as a kv connector functionality mixin for ModelRunner (GPU, TPU)
 class KVConnectorModelRunnerMixin:
     @staticmethod
+    def register_kv_caches_with_connector(
+        kv_caches: dict[str, torch.Tensor],
+    ) -> None:
+        """Register the runner's paged KV caches with the configured connector.
+
+        Device-neutral host-contract helper: any model runner (GPU, TPU, or an
+        out-of-tree backend) calls this after building its per-layer KV tensors
+        in ``initialize_kv_cache``. It is a no-op when no ``kv_transfer_config``
+        is set. The runner is responsible only for supplying ``kv_caches`` as a
+        ``{layer_name: torch.Tensor}`` mapping (a backend whose cache is not
+        natively a torch tensor exposes a torch view of its buffers); this
+        helper contains no device- or connector-specific knowledge.
+        """
+        if not has_kv_transfer_group():
+            return
+        get_kv_transfer_group().register_kv_caches(kv_caches)
+
+    def sync_kv_caches_before_save(self, scheduler_output: "SchedulerOutput") -> None:
+        """Hook: make the registered KV tensors reflect the live cache pre-save.
+
+        Default no-op. A backend whose registered tensors are a *copy/view* of
+        its native buffers (rather than an alias) overrides this to refresh the
+        touched blocks before the connector reads them for a store. Called by
+        the shared execute path immediately before connector finalize. Device-
+        and connector-agnostic: the base contract is simply "the registered
+        tensors are current."
+        """
+        return
+
+    def writeback_kv_caches_after_load(
+        self, scheduler_output: "SchedulerOutput"
+    ) -> None:
+        """Hook: push loaded KV from the registered tensors into the live cache.
+
+        Default no-op. A backend whose registered tensors are a copy/view
+        overrides this to write loaded blocks back into its native buffers
+        after a retrieve. Called by the shared execute path after loads
+        complete. Device- and connector-agnostic.
+        """
+        return
+
+    @staticmethod
     def kv_connector_no_forward(
         scheduler_output: "SchedulerOutput", vllm_config: VllmConfig
     ) -> ModelRunnerOutput:

--- a/vllm/v1/worker/kv_connector_worker_mixin.py
+++ b/vllm/v1/worker/kv_connector_worker_mixin.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Define KV connector host-contract mixin for worker classes.
+
+The worker half of the device-neutral KV-connector host contract. A worker
+initializes the configured KV-transfer connector (building the worker-side
+connector agent) *before* the model runner allocates its KV cache, mirroring
+what ``GPUWorker.initialize_from_config`` does inline. Any worker (GPU, TPU, or
+an out-of-tree backend) can mix this in and call ``maybe_initialize_kv_transfer``
+so the same lifecycle runs without duplicating connector logic. It is a no-op
+when no ``kv_transfer_config`` is set and contains no device- or
+connector-specific knowledge.
+"""
+
+from typing import TYPE_CHECKING
+
+from vllm.distributed.kv_transfer import (
+    ensure_kv_transfer_initialized,
+    get_kv_transfer_group,
+    has_kv_transfer_group,
+)
+from vllm.distributed.parallel_state import get_pp_group, get_tp_group
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+        KVConnectorHandshakeMetadata,
+    )
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+
+
+class KVConnectorWorkerMixin:
+    @staticmethod
+    def maybe_initialize_kv_transfer(
+        vllm_config: "VllmConfig",
+        kv_cache_config: "KVCacheConfig",
+    ) -> None:
+        """Initialize the KV-transfer connector for this worker, if configured.
+
+        Must be called before the model runner's ``initialize_kv_cache`` so the
+        worker-side connector agent exists when the runner registers its KV
+        caches. No-op without a ``kv_transfer_config``.
+        """
+        ensure_kv_transfer_initialized(vllm_config, kv_cache_config)
+
+    @staticmethod
+    def get_kv_connector_handshake_metadata() -> (
+        "dict[tuple[int, int], KVConnectorHandshakeMetadata] | None"
+    ):
+        """Return this worker's KV-connector handshake metadata, if any.
+
+        Generic worker host-contract method (mirrors ``GPUWorker``): the engine
+        core collects handshake metadata from every worker via ``collective_rpc``
+        after KV setup. Keyed by ``(pp_rank, tp_rank)``. Returns ``None`` when no
+        connector is configured or the connector needs no handshake exchange.
+        Device- and connector-agnostic.
+        """
+        if not has_kv_transfer_group():
+            return None
+        connector = get_kv_transfer_group()
+        metadata = connector.get_handshake_metadata()
+        if metadata is None:
+            return None
+        pp_rank = get_pp_group().rank_in_group
+        tp_rank = get_tp_group().rank_in_group
+        return {(pp_rank, tp_rank): metadata}


### PR DESCRIPTION
## Purpose

The worker-side KVConnector lifecycle — initializing the connector before KV-cache allocation, and collecting handshake metadata — currently lives **inline in `GPUWorker`**, and the runner-side `register_kv_caches` call is inlined in `GPUModelRunner.initialize_kv_cache`. Out-of-tree runners/workers that don't inherit the GPU classes (TPU plugins, the Apple-Silicon `vllm-metal` plugin, etc.) can't reuse it and must re-implement the whole lifecycle.

This PR exposes the KVConnector **host contract** as device-neutral mixins so any runner/worker can opt in without duplicating connector logic.

**Purely additive** — existing GPU/TPU code paths are unchanged, and everything is a no-op without a `kv_transfer_config`.

## Changes

**New `KVConnectorWorkerMixin`** (`vllm/v1/worker/kv_connector_worker_mixin.py`):
- `maybe_initialize_kv_transfer(vllm_config, kv_cache_config)` — wraps `ensure_kv_transfer_initialized`; call before `initialize_kv_cache`.
- `get_kv_connector_handshake_metadata()` — the same logic `GPUWorker` uses today, keyed by `(pp_rank, tp_rank)`; returns `None` without a connector.

**`KVConnectorModelRunnerMixin`** (existing shared runner mixin) gains:
- `register_kv_caches_with_connector(kv_caches)` — the `has_kv_transfer_group()` guard + register currently inlined in `GPUModelRunner`.
- `sync_kv_caches_before_save` / `writeback_kv_caches_after_load` — **overridable hooks, default no-op**. A backend whose registered tensors are a *copy/view* of its native buffers (rather than a live alias) overrides these to refresh touched blocks before a store and write loaded blocks back after a load. GPU keeps the no-op defaults (its cache is a live torch alias, so nothing changes).

## Why the two hooks

Most backends register the live KV tensors directly (an alias), so the connector reads/writes them in place — the hooks are no-ops. But a backend whose paged cache is not natively a torch tensor (e.g. MLX arrays on Apple Silicon) must expose a torch *view*, and if that view is a copy, it needs a defined point to re-sync before a store and write back after a load. Rather than push that backend detail into core, core just defines the two no-op hooks; the backend overrides them.

## Test Plan

- New `tests/v1/kv_connector/unit/test_host_contract_mixins.py` (6 tests, no device required): worker init is a no-op wrapper; handshake returns `None` without a connector; runner register is a no-op without a connector and calls `register_kv_caches` when present; the sync hooks default to no-op and are overridable.
- Exercised end-to-end by an out-of-tree consumer (the Apple-Metal `vllm-metal` plugin) with a real KV connector: full lifecycle fires (`maybe_initialize_kv_transfer`, `register_kv_caches_with_connector`, `get_kv_connector_handshake_metadata`, the two hooks), and generated output is **bit-identical** to recompute with a real cross-process store/retrieve. GPU path unchanged (defaults preserve current behavior).

🤖 Authored by Navi on behalf of @lokic233.
