### PR TITLE
[Bugfix] Fix int32 address overflow in DeepGEMM ep_gather Triton kernel

### DIFF
--- a/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py
@@ -389,9 +389,12 @@ def _fwd_kernel_ep_gather(
                 expert_id = apply_expert_map(expert_id, expert_map)
 
             if expert_id >= 0:
+                # int64: source rows live in the expert-sorted (padded) buffer,
+                # whose row offset can exceed int32 range for large-batch
+                # EP/DP shapes (source_token_index * stride0 > 2**31 - 1).
                 source_token_index = tl.load(
                     input_index + cur_token * input_index_stride0 + topk_index
-                )
+                ).to(tl.int64)
                 acc_weight = tl.load(
                     recv_topk_weight + cur_token * recv_topk_weight_stride0 + topk_index
                 )
@@ -405,7 +408,7 @@ def _fwd_kernel_ep_gather(
 
         tl.store(
             output_tensor
-            + cur_token * output_tensor_stride0
+            + cur_token.to(tl.int64) * output_tensor_stride0
             + cur_block * BLOCK_D
             + off_d,
             accumulator.to(output_tensor.dtype.element_ty),

--- a/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py
@@ -389,9 +389,6 @@ def _fwd_kernel_ep_gather(
                 expert_id = apply_expert_map(expert_id, expert_map)
 
             if expert_id >= 0:
-                # int64: source rows live in the expert-sorted (padded) buffer,
-                # whose row offset can exceed int32 range for large-batch
-                # EP/DP shapes (source_token_index * stride0 > 2**31 - 1).
                 source_token_index = tl.load(
                     input_index + cur_token * input_index_stride0 + topk_index
                 ).to(tl.int64)


### PR DESCRIPTION
## Purpose

`_fwd_kernel_ep_gather` (`vllm/model_executor/layers/fused_moe/deep_gemm_utils.py`) computes the source-row address of the expert-sorted grouped-GEMM output in int32: `source_token_index` is loaded as int32 and multiplied by `input_tensor_stride0` with no widening. Once the expert-sorted buffer exceeds `2**31` elements (524,288 rows at hidden size 4096), the offset overflows and the kernel faults with `CUDA error: an illegal memory access was encountered`.

This is reachable through `DeepGemmExperts` / `deepgemm_unpermute_and_reduce` with large `max_num_batched_tokens` under DP+EP, and it reliably crashes **engine startup**: the memory-profiling dummy batch uses identical token IDs, so the router sends every token to the same top-k experts and one rank's expert segments absorb the whole DP-global batch. That is how we hit it: Qwen3.5-397B-A17B (top_k=10) on 8x H100, DP=8 + `--enable-expert-parallel`, `max_num_batched_tokens=16384` — the profiling batch is 8 x 16384 x 10 = 1.31M routed slots landing on one rank's experts, and `determine_available_memory()` dies with the illegal access. Sufficiently skewed real traffic (shared prefixes, hot experts) can hit the same overflow at runtime after a successful startup.

This is the same bug class as the two already-fixed kernels in this family:

- #39211 / #39213 — `_fwd_kernel_ep_scatter_2` output-address overflow (fixed: `dest_token_index`/`output_tensor_stride0` widened to int64)
- #42173 / #42201 — `_silu_mul_per_token_group_quant_fp8_colmajor` offset overflow (fixed: `m_offset`/`n_offset` widened to int64)

`ep_gather` is the remaining kernel of this (LightLLM-derived) group without the widening. SGLang fixed both scatter **and** gather in its copy of the same code in sgl-project/sglang#6348.

Fix: widen `source_token_index` to int64 before the stride multiply, and widen the `cur_token` output-row offset in the store for the same reason (output rows x hidden can also exceed int32 range for very large warmup shapes, cf. the M=4.6M case in #42173).

## Test Plan

Standalone reproducer (H100, `CUDA_LAUNCH_BLOCKING=1`): the kernel extracted verbatim with a `FIXED_INT64: tl.constexpr` switch, 600,000 source rows x hidden 4096 (max element offset 2,457,587,712 > 2**31 - 1), 8192 tokens x top_k 8 routed uniformly over the source rows, compared against a float32 torch reference.

<details>
<summary>repro_ep_gather_overflow.py</summary>

```python
"""Standalone repro for the int32 address overflow in _fwd_kernel_ep_gather.

The kernel loads `source_token_index` (int32) from `input_index` and multiplies
it by `input_tensor_stride0` in int32. Once the expert-sorted source buffer has
more than 2**31 / hidden rows (524,288 rows at hidden 4096), the row offset
overflows and the load hits an illegal address.

Run:  CUDA_LAUNCH_BLOCKING=1 python repro_ep_gather_overflow.py [--fixed]
  (default)  runs the current vLLM kernel -> illegal memory access
  --fixed    runs the kernel with int64 row addressing -> passes + matches ref
"""

import argparse

import torch
import triton
import triton.language as tl

NUM_SOURCE_ROWS = 600_000  # > 2**31 / HIDDEN -> overflows int32 addressing
HIDDEN = 4096
NUM_TOKENS = 8192
TOP_K = 8
SEED = 0


@triton.jit
def _apply_expert_map(expert_id, expert_map):
    if expert_id != -1:
        expert_id = tl.load(expert_map + expert_id).to(expert_id.dtype)
    return expert_id


@triton.jit
def _fwd_kernel_ep_gather(
    total_token_num,
    input_tensor,
    input_tensor_stride0,
    recv_topk_ids,
    recv_topk_ids_stride0,
    recv_topk_weight,
    recv_topk_weight_stride0,
    input_index,
    input_index_stride0,
    output_tensor,
    output_tensor_stride0,
    topk_num: tl.constexpr,
    expert_map,
    HAS_EXPERT_MAP: tl.constexpr,
    BLOCK_D: tl.constexpr,
    FIXED_INT64: tl.constexpr,
):
    cur_block = tl.program_id(0)
    start_cur_token = tl.program_id(1)
    grid_num = tl.num_programs(1)

    for cur_token in range(start_cur_token, total_token_num, grid_num):
        off_d = tl.arange(0, BLOCK_D)
        accumulator = tl.zeros([BLOCK_D], dtype=tl.float32)
        for topk_index in range(0, topk_num):
            expert_id = tl.load(
                recv_topk_ids + cur_token * recv_topk_ids_stride0 + topk_index
            )
            if HAS_EXPERT_MAP:
                expert_id = _apply_expert_map(expert_id, expert_map)

            if expert_id >= 0:
                source_token_index = tl.load(
                    input_index + cur_token * input_index_stride0 + topk_index
                )
                if FIXED_INT64:
                    source_token_index = source_token_index.to(tl.int64)
                acc_weight = tl.load(
                    recv_topk_weight + cur_token * recv_topk_weight_stride0 + topk_index
                )
                tmp = tl.load(
                    input_tensor
                    + source_token_index * input_tensor_stride0
                    + cur_block * BLOCK_D
                    + off_d
                )
                accumulator += tmp.to(tl.float32) * acc_weight

        if FIXED_INT64:
            out_row = cur_token.to(tl.int64) * output_tensor_stride0
        else:
            out_row = cur_token * output_tensor_stride0
        tl.store(
            output_tensor + out_row + cur_block * BLOCK_D + off_d,
            accumulator.to(output_tensor.dtype.element_ty),
        )


def main(fixed: bool) -> None:
    device = torch.device("cuda")
    gen = torch.Generator(device="cpu").manual_seed(SEED)

    input_tensor = torch.randn(
        NUM_SOURCE_ROWS, HIDDEN, generator=gen, dtype=torch.float32
    ).to(torch.bfloat16).to(device)
    topk_ids = torch.randint(0, 64, (NUM_TOKENS, TOP_K), generator=gen).to(
        torch.int32
    ).to(device)
    topk_weight = torch.rand(NUM_TOKENS, TOP_K, generator=gen).to(device)
    # Point routes at high source rows so row * HIDDEN exceeds 2**31 - 1.
    input_index = torch.randint(
        0, NUM_SOURCE_ROWS, (NUM_TOKENS, TOP_K), generator=gen
    ).to(torch.int32).to(device)
    output = torch.empty(NUM_TOKENS, HIDDEN, dtype=torch.bfloat16, device=device)

    max_offset = int(input_index.max()) * HIDDEN
    print(f"max source element offset = {max_offset:,} (int32 max = {2**31 - 1:,})")

    block_d = min(HIDDEN, 1024)
    grid = (triton.cdiv(HIDDEN, block_d), min(NUM_TOKENS, 1024))
    _fwd_kernel_ep_gather[grid](
        NUM_TOKENS,
        input_tensor,
        input_tensor.stride(0),
        topk_ids,
        topk_ids.stride(0),
        topk_weight,
        topk_weight.stride(0),
        input_index,
        input_index.stride(0),
        output,
        output.stride(0),
        topk_num=TOP_K,
        expert_map=None,
        HAS_EXPERT_MAP=False,
        num_warps=2,
        BLOCK_D=block_d,
        FIXED_INT64=fixed,
    )
    torch.cuda.synchronize()

    ref = torch.einsum(
        "tk,tkd->td",
        topk_weight.float(),
        input_tensor[input_index.long()].float(),
    )
    torch.testing.assert_close(output.float(), ref, rtol=2e-2, atol=2e-2)
    print(f"PASS (fixed={fixed}): kernel matches torch reference")


if __name__ == "__main__":
    parser = argparse.ArgumentParser()
    parser.add_argument("--fixed", action="store_true")
    args = parser.parse_args()
    main(args.fixed)
```

</details>

## Test Result

Before (current kernel, `FIXED_INT64=False`):

```
RuntimeError: Triton Error [CUDA]: an illegal memory access was encountered
```

After (`FIXED_INT64=True`, identical to this PR's change):

```
max source element offset = 2,457,587,712 (int32 max = 2,147,483,647)
PASS (fixed=True): kernel matches torch reference
```

With this change applied to our vLLM install, the DP8+EP deployment described above starts up and serves correctly at `max_num_batched_tokens=16384` (previously crashed in `determine_available_memory()`).

Made with [Cursor](https://cursor.com)
