### PR TITLE
[Model] Add EAGLE-3 support for SeedOssForCausalLM

### DIFF
--- a/vllm/model_executor/models/seed_oss.py
+++ b/vllm/model_executor/models/seed_oss.py
@@ -53,7 +53,7 @@ from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.config import set_default_rope_theta
 from vllm.v1.attention.backend import AttentionType
 
-from .interfaces import SupportsLoRA, SupportsPP
+from .interfaces import EagleModelMixin, SupportsEagle3, SupportsLoRA, SupportsPP
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -260,7 +260,7 @@ class SeedOssDecoderLayer(nn.Module):
         "inputs_embeds": 0,
     }
 )
-class SeedOssModel(nn.Module):
+class SeedOssModel(nn.Module, EagleModelMixin):
     def __init__(
         self,
         *,
@@ -345,21 +345,33 @@ class SeedOssModel(nn.Module):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
-        for layer in islice(self.layers, self.start_layer, self.end_layer):
+
+        aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
+        for idx, layer in enumerate(
+            islice(self.layers, self.start_layer, self.end_layer)
+        ):
             hidden_states, residual = layer(
                 positions,
                 hidden_states,
                 residual,
             )
+            self._maybe_add_hidden_state(
+                aux_hidden_states, idx + 1, hidden_states, residual
+            )
+
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )
         hidden_states, _ = self.norm(hidden_states, residual)
+
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
+
         return hidden_states
 
 
-class SeedOssForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
+class SeedOssForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle3):
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_stacked={
             # weight_name: (param_name, shard_id)


### PR DESCRIPTION
## Purpose

Enable EAGLE-3 speculative decoding for the Seed-OSS architecture (ByteDance Seed-OSS-36B and fine-tunes such as NousResearch/Hermes-4.3-36B). An EAGLE-3 draft head now exists for this family (trained with SpecForge against Hermes-4.3-36B); without this interface vLLM cannot serve it speculatively.

## Changes

Follows the canonical SupportsEagle3 enablement pattern (#36658, per @benchislett):

- `SeedOssModel` inherits `EagleModelMixin` and collects `hidden_states + residual` at the aux layer indices in `forward` (same shape as `Qwen2Model`).
- `SeedOssForCausalLM` declares `SupportsEagle3`.
- Default aux layers come from the interface defaults; no model-specific override needed.

No behavior change when no speculative config is set.

## Testing

The change is the mechanical qwen2/qwen3 pattern; ruff check and format clean. I train and serve the Hermes-4.3-36B EAGLE-3 head on other engines today and will exercise this path against the released head; happy to add it to the EAGLE-3 test matrix once the drafter checkpoint is public on HF.
