### PR TITLE
Add runtime LoRA weight updates

### DIFF
--- a/tests/distributed/test_weight_transfer.py
+++ b/tests/distributed/test_weight_transfer.py
@@ -231,6 +231,49 @@ class TestNCCLEngineParsing:
         assert update_info.shapes == [[100, 100], [50]]
 
 
+@pytest.mark.parametrize(
+    ("backend", "engine_cls"),
+    [
+        ("nccl", NCCLWeightTransferEngine),
+        ("ipc", IPCWeightTransferEngine),
+    ],
+)
+def test_dense_engine_skips_model_reload_for_lora_target(
+    backend, engine_cls, monkeypatch
+):
+    from vllm.model_executor.model_loader import reload as reload_module
+
+    initialize = MagicMock()
+    finalize = MagicMock()
+    monkeypatch.setattr(reload_module, "initialize_layerwise_reload", initialize)
+    monkeypatch.setattr(reload_module, "finalize_layerwise_reload", finalize)
+    original_model = MagicMock(spec=torch.nn.Module)
+    target = MagicMock()
+    engine = engine_cls(
+        WeightTransferConfig(backend=backend),
+        create_mock_vllm_config(),
+        torch.device("cuda"),
+        original_model,
+    )
+
+    engine.set_weight_update_target(
+        target,
+        MagicMock(),
+        requires_model_reload=False,
+    )
+    engine.start_weight_update()
+    engine.finish_weight_update()
+
+    initialize.assert_not_called()
+    finalize.assert_not_called()
+    assert engine.model is target
+    assert engine.requires_model_reload is False
+
+    engine.reset_weight_update_target()
+    assert engine.model is original_model
+    assert engine.requires_model_reload is True
+
+
 # --- Unit Tests: Engine Registry ---
 
 

--- a/tests/entrypoints/openai/test_openai_schema.py
+++ b/tests/entrypoints/openai/test_openai_schema.py
@@ -144,6 +144,7 @@ def test_openapi_stateless(case: schemathesis.Case):
     # (weight_transfer_config) and are meant to be stateful.
     if case.operation.path in (
         "/init_weight_transfer_engine",
+        "/start_lora_weight_update",
         "/start_weight_update",
         "/start_draft_weight_update",
         "/update_weights",

--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -20,6 +22,7 @@ from vllm.lora.lora_model import LoRAModel
 from vllm.lora.lora_weights import LoRALayerWeights, PackedLoRALayerWeights
 from vllm.lora.model_manager import (
     DEFAULT_LANGUAGE_WRAPPER_KEY,
+    AdapterLRUCache,
     LoRAMapping,
     LoRAModelManager,
     LRUCacheLoRAModelManager,
@@ -72,6 +75,143 @@ def test_from_lora_tensors(qwen3_lora_files, device):
             f"{lora.lora_a.shape=}, {lora.lora_b.shape=}"
         )
         assert lora.lora_a.shape[0] == 8
+
+
+def test_replace_adapter_from_tensors_uses_existing_lora_pipeline():
+    manager = object.__new__(WorkerLoRAManager)
+    manager.max_position_embeddings = 4096
+    manager.vocab_size = 32000
+    manager.lora_config = LoRAConfig(
+        max_lora_rank=16,
+        lora_dtype=torch.float32,
+    )
+
+    adapter_manager = MagicMock()
+    adapter_manager.list_adapters.return_value = {1: MagicMock()}
+    adapter_manager.supported_lora_modules = ["q_proj"]
+    adapter_manager.packed_modules_mapping = {}
+    adapter_manager.model = SimpleNamespace()
+    manager._adapter_manager = adapter_manager
+
+    lora_model_cls = MagicMock()
+    loaded_lora = SimpleNamespace(id=1, is_3d_lora_weight=False)
+    lora_model_cls.from_lora_tensors.return_value = loaded_lora
+    manager._lora_model_cls = lora_model_cls
+
+    tensors = {
+        "base_model.model.layers.0.self_attn.q_proj.lora_A.weight": torch.ones(8, 16),
+        "base_model.model.layers.0.self_attn.q_proj.lora_B.weight": torch.ones(16, 8),
+    }
+    manager.replace_adapter_from_tensors(
+        lora_int_id=1,
+        tensors=tensors,
+        peft_config={
+            "r": 8,
+            "lora_alpha": 16,
+            "target_modules": ["q_proj"],
+        },
+        is_3d_lora_weight=True,
+    )
+
+    lora_model_cls.check_unexpected_modules.assert_called_once()
+    lora_model_cls.from_lora_tensors.assert_called_once()
+    assert loaded_lora.is_3d_lora_weight is True
+    adapter_manager.replace_adapter.assert_called_once_with(loaded_lora)
+
+
+def test_replace_adapter_restores_old_adapter_on_activation_failure():
+    manager = object.__new__(LoRAModelManager)
+    old_lora = SimpleNamespace(id=1)
+    new_lora = SimpleNamespace(id=1)
+    manager._registered_adapters = AdapterLRUCache(1, manager.deactivate_adapter)
+    manager._active_adapters = AdapterLRUCache(1, manager._deactivate_adapter)
+    manager.lora_index_to_id = [1]
+    manager.modules = {}
+    manager.lora_config = SimpleNamespace(max_cpu_loras=1, max_loras=1)
+    manager._create_merged_loras_inplace = MagicMock()
+    manager._registered_adapters.put(1, old_lora)
+    manager._active_adapters.put(1, None)
+
+    activation_attempts = 0
+
+    def activate_adapter(adapter_id):
+        nonlocal activation_attempts
+        activation_attempts += 1
+        if activation_attempts == 1:
+            raise RuntimeError("activation failed")
+        return LoRAModelManager.activate_adapter(manager, adapter_id)
+
+    manager.activate_adapter = activate_adapter
+
+    with pytest.raises(RuntimeError, match="activation failed"):
+        LoRAModelManager.replace_adapter(manager, new_lora)
+
+    assert manager.get_adapter(1) is old_lora
+    assert 1 in manager._active_adapters
+    assert manager.lora_index_to_id == [1]
+
+
+def test_replace_adapter_preserves_lru_pin_state():
+    manager = object.__new__(LoRAModelManager)
+    old_lora = SimpleNamespace(id=1)
+    new_lora = SimpleNamespace(id=1)
+    manager._active_adapters = AdapterLRUCache(1, manager._deactivate_adapter)
+    manager._registered_adapters = AdapterLRUCache(1, manager.deactivate_adapter)
+    manager.lora_index_to_id = [1]
+    manager.modules = {}
+    manager.lora_config = SimpleNamespace(max_cpu_loras=1, max_loras=1)
+    manager._create_merged_loras_inplace = MagicMock()
+    manager._registered_adapters.put(1, old_lora)
+    manager._active_adapters.put(1, None)
+    manager._registered_adapters.pin(1)
+    manager._active_adapters.pin(1)
+
+    LoRAModelManager.replace_adapter(manager, new_lora)
+
+    assert manager.get_adapter(1) is new_lora
+    assert 1 in manager._registered_adapters.pinned_items
+    assert 1 in manager._active_adapters.pinned_items
+
+
+def test_replace_inactive_adapter_does_not_take_gpu_slot():
+    manager = object.__new__(LoRAModelManager)
+    old_lora = SimpleNamespace(id=1)
+    active_lora = SimpleNamespace(id=2)
+    new_lora = SimpleNamespace(id=1)
+    manager._registered_adapters = AdapterLRUCache(2, manager.deactivate_adapter)
+    manager._active_adapters = AdapterLRUCache(1, manager._deactivate_adapter)
+    manager.lora_index_to_id = [2]
+    manager.modules = {}
+    manager.lora_config = SimpleNamespace(max_cpu_loras=2, max_loras=1)
+    manager._create_merged_loras_inplace = MagicMock()
+    manager._registered_adapters.put(1, old_lora)
+    manager._registered_adapters.put(2, active_lora)
+    manager._active_adapters.put(2, None)
+
+    LoRAModelManager.replace_adapter(manager, new_lora)
+
+    assert manager.get_adapter(1) is new_lora
+    assert list(manager._active_adapters) == [2]
+    assert manager.lora_index_to_id == [2]
+
+
+def test_from_lora_tensors_rejects_incomplete_pair():
+    peft_helper = PEFTHelper(
+        r=8,
+        lora_alpha=16,
+        target_modules=["q_proj"],
+    )
+    tensors = {
+        "base_model.model.layers.0.self_attn.q_proj.lora_A.weight": torch.ones(8, 16)
+    }
+
+    with pytest.raises(ValueError, match="both A and B"):
+        LoRAModel.from_lora_tensors(
+            1,
+            tensors,
+            peft_helper=peft_helper,
+            device="cpu",
+        )
 
 
 def create_lora(

--- a/tests/v1/worker/test_gpu_worker_weight_transfer.py
+++ b/tests/v1/worker/test_gpu_worker_weight_transfer.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Tests for GPUWorker weight-transfer pass-through behavior.
+"""Tests for GPUWorker weight-transfer pass-through behavior."""
 
-The worker no longer contains transport, layerwise, or sparse logic: it only
-delegates to the configured weight transfer engine and tracks whether an update
-session is active. These tests verify that delegation and the session guard.
-"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
+import torch
 
 from vllm.v1.worker.gpu_worker import Worker
 
@@ -15,12 +14,24 @@ from vllm.v1.worker.gpu_worker import Worker
 class _RecordingEngine:
     """Minimal stand-in for a weight transfer engine."""
 
+    supports_draft_weight_update = True
+    supports_lora_weight_update = True
+
     def __init__(self, raise_on_update: bool = False):
         self.raise_on_update = raise_on_update
         self.started = False
         self.finished = False
         self.reset_count = 0
         self.update_calls: list[dict] = []
+        self.target = None
+        self.requires_model_reload = True
+
+    def set_weight_update_target(
+        self, target, model_config, *, requires_model_reload=True
+    ) -> None:
+        del model_config
+        self.target = target
+        self.requires_model_reload = requires_model_reload
 
     def start_weight_update(self) -> None:
         self.started = True
@@ -29,19 +40,35 @@ class _RecordingEngine:
         self.update_calls.append(update_info)
         if self.raise_on_update:
             raise ValueError("boom")
+        if self.target is not None and "weights" in update_info:
+            self.target.load_weights(update_info["weights"])
 
     def finish_weight_update(self) -> None:
         self.finished = True
 
     def reset_weight_update_target(self) -> None:
         self.reset_count += 1
+        self.target = None
+        self.requires_model_reload = True
 
 
 def _make_worker(engine: _RecordingEngine | None) -> Worker:
     worker = object.__new__(Worker)
     worker.weight_transfer_engine = engine
     worker._weight_update_active = False
+    worker._lora_weight_update_target = None
+    worker.model_config = MagicMock()
     return worker
+
+
+def _attach_lora_manager(worker: Worker, adapter_ids: set[int]):
+    lora_manager = MagicMock()
+    lora_manager.list_adapters.return_value = adapter_ids
+    worker.model_runner = SimpleNamespace(
+        lora_manager=lora_manager,
+        _ensure_lora_enabled=lambda: None,
+    )
+    return lora_manager
 
 
 def test_start_update_finish_delegates_to_engine():
@@ -89,7 +116,6 @@ def test_update_resets_active_on_error():
     with pytest.raises(ValueError, match="boom"):
         Worker.update_weights(worker, {"names": ["w"]})
 
-    # A failed update ends the session so the next start is clean.
     assert engine.reset_count == 1
     assert worker._weight_update_active is False
 
@@ -98,3 +124,107 @@ def test_missing_engine_raises():
     worker = _make_worker(None)
     with pytest.raises(RuntimeError, match="Weight transfer not configured"):
         Worker.start_weight_update(worker)
+
+
+def test_lora_weight_update_uses_engine_target_and_replaces_adapter(monkeypatch):
+    monkeypatch.setattr(torch.accelerator, "synchronize", lambda: None)
+    engine = _RecordingEngine()
+    worker = _make_worker(engine)
+    lora_manager = _attach_lora_manager(worker, {1})
+    tensor_name = "base_model.model.q_proj.lora_A.weight"
+
+    Worker.start_lora_weight_update(
+        worker,
+        {
+            "lora_int_id": 1,
+            "peft_config": {
+                "r": 8,
+                "lora_alpha": 16,
+                "target_modules": ["q_proj"],
+            },
+            "tensor_names": [tensor_name],
+        },
+    )
+    assert engine.target is worker._lora_weight_update_target
+    assert engine.requires_model_reload is False
+
+    source_tensor = torch.ones(2, 2)
+    Worker.update_weights(worker, {"weights": [(tensor_name, source_tensor)]})
+    source_tensor.zero_()
+    Worker.finish_weight_update(worker)
+
+    call = lora_manager.replace_adapter_from_tensors.call_args
+    assert call.kwargs["lora_int_id"] == 1
+    assert torch.equal(call.kwargs["tensors"][tensor_name], torch.ones(2, 2))
+    assert engine.target is None
+    assert worker._weight_update_active is False
+    assert worker._lora_weight_update_target is None
+
+
+def test_lora_weight_update_requires_existing_adapter():
+    worker = _make_worker(_RecordingEngine())
+    _attach_lora_manager(worker, set())
+
+    with pytest.raises(ValueError, match="must be loaded"):
+        Worker.start_lora_weight_update(
+            worker,
+            {
+                "lora_int_id": 1,
+                "peft_config": {
+                    "r": 8,
+                    "lora_alpha": 16,
+                    "target_modules": ["q_proj"],
+                },
+                "tensor_names": ["lora_A"],
+            },
+        )
+
+    assert worker._weight_update_active is False
+
+
+def test_lora_weight_update_rejects_unsupported_engine():
+    engine = _RecordingEngine()
+    engine.supports_lora_weight_update = False
+    worker = _make_worker(engine)
+    _attach_lora_manager(worker, {1})
+
+    with pytest.raises(RuntimeError, match="does not support LoRA"):
+        Worker.start_lora_weight_update(
+            worker,
+            {
+                "lora_int_id": 1,
+                "peft_config": {
+                    "r": 8,
+                    "lora_alpha": 16,
+                    "target_modules": ["q_proj"],
+                },
+                "tensor_names": ["lora_A"],
+            },
+        )
+
+
+def test_finish_lora_weight_update_rejects_incomplete_manifest():
+    engine = _RecordingEngine()
+    worker = _make_worker(engine)
+    lora_manager = _attach_lora_manager(worker, {1})
+    Worker.start_lora_weight_update(
+        worker,
+        {
+            "lora_int_id": 1,
+            "peft_config": {
+                "r": 8,
+                "lora_alpha": 16,
+                "target_modules": ["q_proj"],
+            },
+            "tensor_names": ["lora_A", "lora_B"],
+        },
+    )
+    Worker.update_weights(worker, {"weights": [("lora_A", torch.ones(2, 2))]})
+
+    with pytest.raises(ValueError, match="manifest mismatch"):
+        Worker.finish_weight_update(worker)
+
+    lora_manager.replace_adapter_from_tensors.assert_not_called()
+    assert engine.target is None
+    assert worker._weight_update_active is False
+    assert worker._lora_weight_update_target is None

--- a/vllm/distributed/weight_transfer/base.py
+++ b/vllm/distributed/weight_transfer/base.py
@@ -49,6 +49,24 @@ class WeightTransferUpdateRequest:
     update_info: dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass
+class LoRAWeightUpdateRequest:
+    """Metadata required to update an existing LoRA adapter in memory."""
+
+    lora_int_id: int
+    peft_config: dict[str, Any]
+    tensor_names: list[str]
+    is_3d_lora_weight: bool = False
+
+    def __post_init__(self) -> None:
+        if self.lora_int_id < 1:
+            raise ValueError(
+                f"lora_int_id must be greater than 0, got {self.lora_int_id}"
+            )
+        if not self.tensor_names:
+            raise ValueError("tensor_names cannot be empty")
+
+
 class WeightTransferEngine(ABC, Generic[TInitInfo, TUpdateInfo]):
     """
     Base class for weight transfer engines that handle transport of model weights
@@ -74,6 +92,7 @@ class WeightTransferEngine(ABC, Generic[TInitInfo, TUpdateInfo]):
     update_info_cls: type[TUpdateInfo]
 
     supports_draft_weight_update: bool = True
+    supports_lora_weight_update: bool = False
 
     def __init__(
         self,
@@ -99,20 +118,25 @@ class WeightTransferEngine(ABC, Generic[TInitInfo, TUpdateInfo]):
         self.model = model
         self._default_model_config = self.model_config
         self._default_model = model
+        self.requires_model_reload = True
 
     def set_weight_update_target(
         self,
-        model: torch.nn.Module,
+        model: Any,
         model_config: Any,
+        *,
+        requires_model_reload: bool = True,
     ) -> None:
         """Set the model that will receive the active weight update."""
         self.model = model
         self.model_config = model_config
+        self.requires_model_reload = requires_model_reload
 
     def reset_weight_update_target(self) -> None:
         """Restore weight updates to the engine's default target model."""
         self.model = self._default_model
         self.model_config = self._default_model_config
+        self.requires_model_reload = True
 
     def parse_init_info(self, init_dict: dict[str, Any]) -> TInitInfo:
         """

--- a/vllm/distributed/weight_transfer/ipc_engine.py
+++ b/vllm/distributed/weight_transfer/ipc_engine.py
@@ -146,6 +146,7 @@ class IPCWeightTransferEngine(
     # Define backend-specific dataclass types
     init_info_cls = IPCWeightTransferInitInfo
     update_info_cls = IPCWeightTransferUpdateInfo
+    supports_lora_weight_update = True
 
     def __init__(
         self,
@@ -208,6 +209,8 @@ class IPCWeightTransferEngine(
 
     def start_weight_update(self) -> None:
         """Initialize layerwise reloading for the incoming checkpoint weights."""
+        if not self.requires_model_reload:
+            return
         from vllm.model_executor.model_loader.reload import (
             initialize_layerwise_reload,
         )
@@ -216,6 +219,8 @@ class IPCWeightTransferEngine(
 
     def finish_weight_update(self) -> None:
         """Finalize layerwise reloading after all weights have been received."""
+        if not self.requires_model_reload:
+            return
         from vllm.model_executor.model_loader.reload import (
             finalize_layerwise_reload,
         )

--- a/vllm/distributed/weight_transfer/nccl_engine.py
+++ b/vllm/distributed/weight_transfer/nccl_engine.py
@@ -111,6 +111,7 @@ class NCCLWeightTransferEngine(
     # Define backend-specific dataclass types
     init_info_cls = NCCLWeightTransferInitInfo
     update_info_cls = NCCLWeightTransferUpdateInfo
+    supports_lora_weight_update = True
 
     def __init__(
         self,
@@ -136,6 +137,8 @@ class NCCLWeightTransferEngine(
 
     def start_weight_update(self) -> None:
         """Initialize layerwise reloading for the incoming checkpoint weights."""
+        if not self.requires_model_reload:
+            return
         from vllm.model_executor.model_loader.reload import (
             initialize_layerwise_reload,
         )
@@ -144,6 +147,8 @@ class NCCLWeightTransferEngine(
 
     def finish_weight_update(self) -> None:
         """Finalize layerwise reloading after all weights have been received."""
+        if not self.requires_model_reload:
+            return
         from vllm.model_executor.model_loader.reload import (
             finalize_layerwise_reload,
         )

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from vllm.config import ModelConfig, VllmConfig
 from vllm.distributed.weight_transfer.base import (
+    LoRAWeightUpdateRequest,
     WeightTransferInitRequest,
     WeightTransferUpdateRequest,
 )
@@ -250,6 +251,10 @@ class EngineClient(ABC):
 
     async def start_draft_weight_update(self) -> None:
         """Start a new weight update targeting the speculative draft model."""
+        raise NotImplementedError
+
+    async def start_lora_weight_update(self, request: LoRAWeightUpdateRequest) -> None:
+        """Start an update for an existing LoRA adapter."""
         raise NotImplementedError
 
     async def update_weights(self, request: WeightTransferUpdateRequest) -> None:

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Callable, Sequence
+from dataclasses import asdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -29,6 +30,7 @@ from vllm.config.model import (
 )
 from vllm.config.quantization import QuantizationConfigArgs
 from vllm.distributed.weight_transfer.base import (
+    LoRAWeightUpdateRequest,
     WeightTransferInitRequest,
     WeightTransferUpdateRequest,
 )
@@ -880,6 +882,13 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
     def start_draft_weight_update(self) -> None:
         """Start a new weight update targeting the speculative draft model."""
         self.llm_engine.collective_rpc("start_draft_weight_update")
+
+    def start_lora_weight_update(self, request: LoRAWeightUpdateRequest | dict) -> None:
+        """Start an update for an existing LoRA adapter."""
+        request_dict = request if isinstance(request, dict) else asdict(request)
+        self.llm_engine.collective_rpc(
+            "start_lora_weight_update", kwargs={"request": request_dict}
+        )
 
     def update_weights(self, request: WeightTransferUpdateRequest | dict) -> None:
         """

--- a/vllm/entrypoints/serve/dev/rlhf/api_router.py
+++ b/vllm/entrypoints/serve/dev/rlhf/api_router.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, FastAPI, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
 from vllm.distributed.weight_transfer.base import (
+    LoRAWeightUpdateRequest,
     WeightTransferInitRequest,
     WeightTransferUpdateRequest,
 )
@@ -182,6 +183,39 @@ async def start_weight_update(raw_request: Request):
 async def start_draft_weight_update(raw_request: Request):
     await engine_client(raw_request).start_draft_weight_update()
     return JSONResponse(content={"message": "Draft weight update started"})
+
+
+@router.post("/start_lora_weight_update")
+async def start_lora_weight_update(raw_request: Request):
+    try:
+        body = await raw_request.json()
+    except json.JSONDecodeError as e:
+        raise HTTPException(status_code=400, detail="Invalid JSON format") from e  # noqa: B904
+
+    request = body.get("lora_request")
+    if request is None:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST.value,
+            detail="Missing 'lora_request' in request body",
+        )
+    try:
+        lora_request = LoRAWeightUpdateRequest(**request)
+    except (TypeError, ValueError) as e:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST.value,
+            detail=str(e),
+        ) from e
+
+    engine = engine_client(raw_request)
+    if not await engine.is_paused():
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST.value,
+            detail=(
+                "LoRA weight updates require paused generation. Call /pause first."
+            ),
+        )
+    await engine.start_lora_weight_update(lora_request)
+    return JSONResponse(content={"message": "LoRA weight update started"})
 
 
 @router.post("/update_weights")

--- a/vllm/lora/lora_model.py
+++ b/vllm/lora/lora_model.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
 
 import safetensors
@@ -114,6 +115,41 @@ class LoRAModel:
         return False
 
     @classmethod
+    def check_unexpected_modules(
+        cls,
+        tensor_names: Iterable[str],
+        expected_lora_modules: set[str],
+        *,
+        weights_mapper: WeightsMapper | None = None,
+        skip_prefixes: list[str] | None = None,
+        source: str = "LoRA tensors",
+    ) -> None:
+        unexpected_modules: list[str] = []
+        for tensor_name in tensor_names:
+            if is_base_embedding_weights(tensor_name):
+                continue
+            if "base_layer" in tensor_name:
+                continue
+            if skip_prefixes and cls._should_skip_module(tensor_name, skip_prefixes):
+                continue
+
+            module_name, _ = parse_fine_tuned_lora_name(tensor_name, weights_mapper)
+            if ".experts" in module_name:
+                expert_idx = module_name.find(".experts")
+                module_suffix = module_name[expert_idx + 1 :]
+                if module_suffix not in expected_lora_modules:
+                    unexpected_modules.append(module_name)
+            elif module_name.rsplit(".", 1)[-1] not in expected_lora_modules:
+                unexpected_modules.append(module_name)
+
+        if unexpected_modules:
+            raise ValueError(
+                f"While loading {source}, expected target modules in "
+                f"{expected_lora_modules} but received {unexpected_modules}. "
+                "Please verify that the loaded LoRA module is correct"
+            )
+
+    @classmethod
     def from_lora_tensors(
         cls,
         lora_model_id: int,
@@ -161,6 +197,17 @@ class LoRAModel:
                 if pin_memory:
                     loras[module_name].lora_b = loras[module_name].lora_b.pin_memory()
 
+        incomplete_modules = [
+            module_name
+            for module_name, lora in loras.items()
+            if lora.lora_a is None or lora.lora_b is None
+        ]
+        if incomplete_modules:
+            raise ValueError(
+                "LoRA tensors must contain both A and B weights for every module; "
+                f"incomplete modules: {incomplete_modules}"
+            )
+
         return cls(lora_model_id, peft_helper.r, loras)
 
     @classmethod
@@ -207,40 +254,6 @@ class LoRAModel:
         lora_pt_file_path = os.path.join(lora_dir, "adapter_model.pt")
 
         tensors: dict[str, torch.Tensor] = {}
-        unexpected_modules: list[list[str] | str] = []
-
-        def check_unexpected_modules(modules: dict):
-            for lora_module in modules.keys():  # noqa
-                if is_base_embedding_weights(lora_module):
-                    continue
-                # Handle PEFT file format where experts.base_layer is the
-                # gate_up_proj and experts is the down_proj
-                if "base_layer" in lora_module:
-                    continue
-                # Skip modules based on model-defined prefixes
-                if skip_prefixes and cls._should_skip_module(
-                    lora_module, skip_prefixes
-                ):
-                    continue
-                module_name, _ = parse_fine_tuned_lora_name(lora_module, weights_mapper)
-                # Case for expert lora weights
-                if ".experts" in module_name:
-                    expert_idx = module_name.find(".experts")
-                    expert_suffix = module_name[expert_idx + 1 :]
-                    if expert_suffix not in expected_lora_modules:
-                        unexpected_modules.append(module_name)
-
-                elif module_name.rsplit(".", 1)[-1] not in expected_lora_modules:
-                    unexpected_modules.append(module_name)
-
-            if unexpected_modules:
-                raise ValueError(
-                    f"While loading {lora_dir}, expected"
-                    f" target modules in {expected_lora_modules}"
-                    f" but received {unexpected_modules}."
-                    f" Please verify that the loaded LoRA module is correct"
-                )
-
         if tensorizer_config_dict:
             from tensorizer import TensorDeserializer
 
@@ -256,7 +269,13 @@ class LoRAModel:
                 device=device,
                 **tensorizer_args.deserialization_kwargs,
             )
-            check_unexpected_modules(tensors)
+            cls.check_unexpected_modules(
+                tensors.keys(),
+                expected_lora_modules,
+                weights_mapper=weights_mapper,
+                skip_prefixes=skip_prefixes,
+                source=lora_dir,
+            )
 
         elif os.path.isfile(lora_tensor_path):
             # Find unexpected modules.
@@ -265,10 +284,15 @@ class LoRAModel:
             # in the model it won’t error and model will be trained with A, B
             # loraified. C won’t exist in the safetensor but it will exist in
             # the target_modules of the adapter_config.json.
-            unexpected_modules = []
             with safetensors.safe_open(lora_tensor_path, framework="pt") as f:  # type: ignore
                 # Load tensors if there are only expected modules.
-                check_unexpected_modules(f)
+                cls.check_unexpected_modules(
+                    f.keys(),
+                    expected_lora_modules,
+                    weights_mapper=weights_mapper,
+                    skip_prefixes=skip_prefixes,
+                    source=lora_dir,
+                )
                 for module in f.keys():  # noqa
                     if moe_ep_spec is not None and _is_remote_expert_key(
                         module, moe_ep_spec
@@ -282,7 +306,13 @@ class LoRAModel:
                 else lora_pt_file_path
             )
             tensors = torch.load(lora_file_path, map_location=device, weights_only=True)
-            check_unexpected_modules(tensors)
+            cls.check_unexpected_modules(
+                tensors.keys(),
+                expected_lora_modules,
+                weights_mapper=weights_mapper,
+                skip_prefixes=skip_prefixes,
+                source=lora_dir,
+            )
             if moe_ep_spec is not None:
                 # `.bin`/`.pt` adapters can't be lazy-loaded, but pruning
                 # the dict here still frees the non-local expert tensors

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -1147,6 +1147,41 @@ class LoRAModelManager:
         self._add_adapter(adapter)
         return True
 
+    def replace_adapter(self, adapter: LoRAModel) -> None:
+        adapter_id = adapter.id
+        old_adapter = self.get_adapter(adapter_id)
+        if old_adapter is None:
+            raise ValueError(f"LoRA adapter id {adapter_id} is not registered")
+
+        was_active = adapter_id in self._active_adapters
+        registered_cache = self._registered_adapters
+        active_cache = self._active_adapters
+        cpu_was_pinned = adapter_id in registered_cache.pinned_items
+        gpu_was_pinned = adapter_id in active_cache.pinned_items
+
+        self.remove_adapter(adapter_id)
+        try:
+            self._add_adapter(adapter)
+            if was_active:
+                self.activate_adapter(adapter_id)
+            if cpu_was_pinned:
+                registered_cache.pin(adapter_id)
+            if was_active and gpu_was_pinned:
+                active_cache.pin(adapter_id)
+        except Exception as update_error:
+            try:
+                self.remove_adapter(adapter_id)
+                registered_cache[adapter_id] = old_adapter
+                if cpu_was_pinned:
+                    registered_cache.pin(adapter_id)
+                if was_active:
+                    self.activate_adapter(adapter_id)
+                    if gpu_was_pinned:
+                        active_cache.pin(adapter_id)
+            except Exception as rollback_error:
+                raise rollback_error from update_error
+            raise
+
     def set_adapter_mapping(self, mapping: LoRAMapping) -> None:
         # The punica metadata derives from the slot layout as well as the
         # mapping: an out-of-band add_lora() can LRU-evict and reassign slots

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -102,19 +102,21 @@ class WorkerLoRAManager:
         self._adapter_manager = lora_manager
         return lora_manager.model
 
+    def _expected_lora_modules(self) -> set[str]:
+        expected_lora_modules: list[str] = []
+        packed_modules_mapping = self._adapter_manager.packed_modules_mapping
+        for module in self._adapter_manager.supported_lora_modules:
+            if module in packed_modules_mapping:
+                expected_lora_modules.extend(packed_modules_mapping[module])
+            else:
+                expected_lora_modules.append(module)
+            if module == "experts":
+                expected_lora_modules.append(module)
+        return set(expected_lora_modules)
+
     def _load_adapter(self, lora_request: LoRARequest) -> LoRAModel:
         try:
-            supported_lora_modules = self._adapter_manager.supported_lora_modules
-            packed_modules_mapping = self._adapter_manager.packed_modules_mapping
-            expected_lora_lst: list[str] = []
-            for module in supported_lora_modules:
-                if module in packed_modules_mapping:
-                    expected_lora_lst.extend(packed_modules_mapping[module])
-                else:
-                    expected_lora_lst.append(module)
-                if module == "experts":
-                    expected_lora_lst.append(module)
-            expected_lora_modules = set(expected_lora_lst)
+            expected_lora_modules = self._expected_lora_modules()
             lora_path = get_adapter_absolute_path(lora_request.lora_path)
 
             peft_helper = PEFTHelper.from_local_dir(
@@ -170,6 +172,47 @@ class WorkerLoRAManager:
             raise e
 
         return lora
+
+    def replace_adapter_from_tensors(
+        self,
+        lora_int_id: int,
+        tensors: dict[str, torch.Tensor],
+        peft_config: dict[str, Any],
+        *,
+        is_3d_lora_weight: bool = False,
+    ) -> None:
+        if not tensors:
+            raise ValueError("No LoRA tensors were received")
+
+        peft_config = dict(peft_config)
+        peft_config["vllm_max_position_embeddings"] = self.max_position_embeddings
+        peft_helper = PEFTHelper.from_dict(peft_config)
+        peft_helper.validate_legal(self.lora_config)
+
+        model = self._adapter_manager.model
+        weights_mapper = getattr(model, "hf_to_vllm_mapper", None)
+        skip_prefixes = getattr(model, "lora_skip_prefixes", None)
+        expected_lora_modules = self._expected_lora_modules()
+        self._lora_model_cls.check_unexpected_modules(
+            tensors.keys(),
+            expected_lora_modules,
+            weights_mapper=weights_mapper,
+            skip_prefixes=skip_prefixes,
+            source="transferred LoRA tensors",
+        )
+        lora = self._lora_model_cls.from_lora_tensors(
+            lora_model_id=lora_int_id,
+            tensors=tensors,
+            peft_helper=peft_helper,
+            device="cpu",
+            dtype=self.lora_config.lora_dtype,
+            model_vocab_size=self.vocab_size,
+            weights_mapper=weights_mapper,
+            skip_prefixes=skip_prefixes,
+        )
+        lora.is_3d_lora_weight = is_3d_lora_weight
+
+        self._adapter_manager.replace_adapter(lora)
 
     def add_dummy_lora(self, lora_request: LoRARequest, rank: int) -> bool:
         if lora_request.lora_int_id in self.list_adapters():

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -7,6 +7,7 @@ import time
 import warnings
 from collections.abc import AsyncGenerator, Iterable, Mapping
 from copy import copy
+from dataclasses import asdict
 from typing import Any
 
 import torch
@@ -15,6 +16,7 @@ import vllm.envs as envs
 from vllm import TokensPrompt
 from vllm.config import VllmConfig
 from vllm.distributed.weight_transfer.base import (
+    LoRAWeightUpdateRequest,
     WeightTransferInitRequest,
     WeightTransferUpdateRequest,
 )
@@ -1087,6 +1089,13 @@ class AsyncLLM(EngineClient):
     async def start_draft_weight_update(self) -> None:
         """Start a new weight update targeting the speculative draft model."""
         await self.collective_rpc("start_draft_weight_update")
+
+    async def start_lora_weight_update(self, request: LoRAWeightUpdateRequest) -> None:
+        """Start an update for an existing LoRA adapter."""
+        await self.collective_rpc(
+            "start_lora_weight_update",
+            kwargs={"request": asdict(request)},
+        )
 
     async def update_weights(self, request: WeightTransferUpdateRequest) -> None:
         """

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from datetime import timedelta
 from types import NoneType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import regex as re
@@ -48,6 +48,7 @@ from vllm.distributed.weight_transfer import (
     WeightTransferEngine,
     WeightTransferEngineFactory,
 )
+from vllm.distributed.weight_transfer.base import LoRAWeightUpdateRequest
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.model_executor.warmup.kernel_warmup import kernel_warmup
@@ -127,6 +128,29 @@ class AsyncIntermediateTensors(IntermediateTensors):
         return object.__getattribute__(self, name)
 
 
+class _LoRAWeightUpdateTarget:
+    def __init__(self, request: LoRAWeightUpdateRequest) -> None:
+        self.request = request
+        self.tensors: dict[str, torch.Tensor] = {}
+
+    def load_weights(self, weights: list[tuple[str, torch.Tensor]]) -> None:
+        for name, weight in weights:
+            if name in self.tensors:
+                raise ValueError(f"Received duplicate LoRA tensor {name!r}")
+            self.tensors[name] = weight.detach().clone()
+
+    def validate_manifest(self) -> None:
+        expected = set(self.request.tensor_names)
+        received = set(self.tensors)
+        if expected != received:
+            missing = sorted(expected - received)
+            unexpected = sorted(received - expected)
+            raise ValueError(
+                "Transferred LoRA tensor manifest mismatch: "
+                f"missing={missing}, unexpected={unexpected}"
+            )
+
+
 class Worker(WorkerBase):
     def __init__(
         self,
@@ -160,6 +184,7 @@ class Worker(WorkerBase):
         # is available, since the engine needs a reference to the model.
         self.weight_transfer_engine: WeightTransferEngine | None = None
         self._weight_update_active = False
+        self._lora_weight_update_target: _LoRAWeightUpdateTarget | None = None
 
         # Torch/CUDA profiler. Enabled and configured through profiler_config.
         # Profiler wrapper is created lazily in profile() when start is called,
@@ -1225,7 +1250,28 @@ class Worker(WorkerBase):
         """
         self._start_weight_update(is_draft=True)
 
-    def _start_weight_update(self, is_draft: bool = False) -> None:
+    def start_lora_weight_update(self, request: dict) -> None:
+        """Start an update for an existing LoRA adapter."""
+        lora_request = LoRAWeightUpdateRequest(**request)
+        self.model_runner._ensure_lora_enabled()
+        if (
+            lora_request.lora_int_id
+            not in self.model_runner.lora_manager.list_adapters()
+        ):
+            raise ValueError(
+                f"LoRA adapter id {lora_request.lora_int_id} must be loaded "
+                "before it can be updated"
+            )
+
+        target = _LoRAWeightUpdateTarget(lora_request)
+        self._start_weight_update(lora_target=target)
+        self._lora_weight_update_target = target
+
+    def _start_weight_update(
+        self,
+        is_draft: bool = False,
+        lora_target: _LoRAWeightUpdateTarget | None = None,
+    ) -> None:
         self._check_weight_transfer_engine()
         assert self.weight_transfer_engine is not None
 
@@ -1233,6 +1279,14 @@ class Worker(WorkerBase):
             raise RuntimeError(
                 f"{type(self.weight_transfer_engine).__name__} does not support "
                 "draft model weight updates."
+            )
+        if (
+            lora_target is not None
+            and not self.weight_transfer_engine.supports_lora_weight_update
+        ):
+            raise RuntimeError(
+                f"{type(self.weight_transfer_engine).__name__} does not support "
+                "LoRA weight updates."
             )
 
         if self._weight_update_active:
@@ -1244,11 +1298,26 @@ class Worker(WorkerBase):
         try:
             if is_draft:
                 self._set_draft_weight_update_target()
+            elif lora_target is not None:
+                self.weight_transfer_engine.set_weight_update_target(
+                    lora_target,
+                    self.model_config,
+                    requires_model_reload=False,
+                )
             self.weight_transfer_engine.start_weight_update()
         except BaseException:
-            self.weight_transfer_engine.reset_weight_update_target()
+            self._reset_weight_update_session()
             raise
         self._weight_update_active = True
+
+    def _reset_weight_update_session(self) -> None:
+        try:
+            cast(
+                WeightTransferEngine[Any, Any], self.weight_transfer_engine
+            ).reset_weight_update_target()
+        finally:
+            self._weight_update_active = False
+            self._lora_weight_update_target = None
 
     def update_weights(self, update_info: dict) -> None:
         """
@@ -1273,8 +1342,7 @@ class Worker(WorkerBase):
         try:
             self.weight_transfer_engine.update_weights(update_info)
         except BaseException:
-            self._weight_update_active = False
-            self.weight_transfer_engine.reset_weight_update_target()
+            self._reset_weight_update_session()
             raise
 
     def finish_weight_update(self) -> None:
@@ -1287,9 +1355,21 @@ class Worker(WorkerBase):
                 "finish_weight_update called without a matching start_weight_update."
             )
 
-        self.weight_transfer_engine.finish_weight_update()
-        self.weight_transfer_engine.reset_weight_update_target()
-        self._weight_update_active = False
+        try:
+            self.weight_transfer_engine.finish_weight_update()
+            target = self._lora_weight_update_target
+            if target is not None:
+                target.validate_manifest()
+                lora_request = target.request
+                self.model_runner.lora_manager.replace_adapter_from_tensors(
+                    lora_int_id=lora_request.lora_int_id,
+                    tensors=target.tensors,
+                    peft_config=lora_request.peft_config,
+                    is_3d_lora_weight=lora_request.is_3d_lora_weight,
+                )
+                torch.accelerator.synchronize()
+        finally:
+            self._reset_weight_update_session()
 
     def shutdown(self) -> None:
         gc.unfreeze()


### PR DESCRIPTION
## Summary

- add a dedicated `start_lora_weight_update` request while reusing the existing `start_weight_update` / `update_weights` / `finish_weight_update` transaction
- receive only LoRA tensors through the existing IPC and NCCL weight-transfer engines instead of transferring full-model weights
- rebuild and atomically replace an already-loaded LoRA adapter while preserving active and LRU pin state
- add the RLHF development endpoint plus synchronous and asynchronous engine APIs

## Design

Inference remains paused for the entire single-slot weight-update transaction. The worker installs an in-memory LoRA receiver as the weight-transfer target, validates the received tensor manifest, constructs the replacement through the existing LoRA loading pipeline, and commits it during `finish_weight_update`.

Sparse NCCL fails fast because its in-place sparse update semantics are not compatible with constructing a replacement LoRA adapter.

## Validation

- all repository pre-commit hooks passed, including Ruff, formatting, typos, mypy, SPDX, and import checks
- added coverage for request parsing, transfer-target selection, unsupported engines, incomplete manifests, tensor-based LoRA construction, adapter rollback, active state, and LRU pin preservation
- independent Claude Code review completed with no remaining findings
