### PR TITLE
[Bugfix] V1: fix allowed_token_ids_mask aliasing in InputBatch.swap_states

### DIFF
--- a/tests/v1/worker/test_gpu_input_batch.py
+++ b/tests/v1/worker/test_gpu_input_batch.py
@@ -377,6 +377,60 @@ def test_swap_states_in_input_batch(device: str, batch_size: int, swap_list: lis
     _compare_objs(input_batch, ref_input_batch)
 
 
+@pytest.mark.parametrize("device", DEVICES)
+def test_swap_states_preserves_allowed_token_ids_mask(device: str):
+    """swap_states() must exchange the two allowed_token_ids_mask rows.
+
+    Swapping row views via a tuple assignment
+    (t[i1], t[i2] = t[i2], t[i1]) aliases them, so both rows collapse to the
+    second row's contents and one request silently loses its token
+    restriction. This is the sibling of the condense() leak fixed for
+    https://github.com/vllm-project/vllm/issues/43894.
+    """
+    allowed_token_id = 13
+    input_batch = InputBatch(
+        max_num_reqs=2,
+        max_model_len=1024,
+        max_num_batched_tokens=1024,
+        device=torch.device(device),
+        vocab_size=VOCAB_SIZE,
+        block_sizes=[1],
+        kernel_block_sizes=[1],
+        max_num_blocks_per_req=[1024],
+    )
+
+    def _make_req(suffix: int, allowed_token_ids=None) -> CachedRequestState:
+        return CachedRequestState(
+            req_id=f"req_id_{suffix}",
+            prompt_token_ids=[1, 2, 3],
+            sampling_params=SamplingParams(allowed_token_ids=allowed_token_ids),
+            pooling_params=None,
+            mm_features=[],
+            block_ids=([],),
+            generator=None,
+            num_computed_tokens=0,
+            output_token_ids=[],
+        )
+
+    # Row 0 is constrained to a single token; row 1 is unconstrained.
+    assert input_batch.add_request(_make_req(0, [allowed_token_id])) == 0
+    assert input_batch.add_request(_make_req(1)) == 1
+
+    mask = input_batch.allowed_token_ids_mask_cpu_tensor
+    assert mask is not None
+    assert int(mask[0].sum().item()) == VOCAB_SIZE - 1
+    assert not mask[0][allowed_token_id].item()
+    assert int(mask[1].sum().item()) == 0
+
+    input_batch.swap_states(0, 1)
+
+    # The constrained request now sits at row 1 and must keep its mask; the
+    # unconstrained request now sits at row 0 and must stay open.
+    assert int(mask[1].sum().item()) == VOCAB_SIZE - 1
+    assert not mask[1][allowed_token_id].item()
+    assert int(mask[0].sum().item()) == 0
+
+
 def _construct_pooling_request(req_id_suffix: int, pooling_params=None):
     from vllm.pooling_params import PoolingParams
 

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -670,12 +670,8 @@ class InputBatch:
         swap_dict_values(self.bad_words_token_ids, i1, i2)
 
         if self.allowed_token_ids_mask_cpu_tensor is not None:
-            (
-                self.allowed_token_ids_mask_cpu_tensor[i1],
-                self.allowed_token_ids_mask_cpu_tensor[i2],
-            ) = (
-                self.allowed_token_ids_mask_cpu_tensor[i2],
-                self.allowed_token_ids_mask_cpu_tensor[i1],
+            self.allowed_token_ids_mask_cpu_tensor[[i1, i2]] = (
+                self.allowed_token_ids_mask_cpu_tensor[[i2, i1]]
             )
 
     def _get_active_token_count(self, req_index: int) -> int:


### PR DESCRIPTION
## Purpose

`InputBatch.swap_states()` swaps the two `allowed_token_ids_mask_cpu_tensor`
rows with a tuple assignment on row **views**:

```python
(
    self.allowed_token_ids_mask_cpu_tensor[i1],
    self.allowed_token_ids_mask_cpu_tensor[i2],
) = (
    self.allowed_token_ids_mask_cpu_tensor[i2],
    self.allowed_token_ids_mask_cpu_tensor[i1],
)
```

Integer indexing on a `torch.Tensor` returns a **view**, not a copy. The RHS
tuple holds two views into the live tensor, so the left-to-right assignment
first overwrites row `i1` with row `i2`, then overwrites row `i2` with the
row-`i1` view that now already contains row `i2`'s data. Both rows collapse to
the original `i2` contents, and the request that ends up at index `i2` silently
loses its `allowed_token_ids` restriction (or inherits the wrong one).

`swap_states` is invoked by `reorder_batch`
(`vllm/v1/attention/backends/utils.py`) on the MLA / Mamba / GDN / FlashInfer
decode–prefill split, so any request using `SamplingParams.allowed_token_ids`
that gets reordered samples from the wrong token set — wrong output, no error.

The fix uses fancy indexing (which copies on the RHS), matching the safe
`is_token_ids` swap two lines above. Only the CPU staging tensor needs swapping;
`_make_sampling_metadata` copies it to the GPU tensor every step.

**Not a duplicate.** Issue #43894 / PR #43931 address the sibling row-leak in
`InputBatch.condense()`. This PR fixes the separate `swap_states` aliasing that
none of them touch.

## Test Plan

Added `test_swap_states_preserves_allowed_token_ids_mask` to
`tests/v1/worker/test_gpu_input_batch.py` (constrained request at row 0,
unconstrained at row 1, swap, assert the constraint follows the request).

```bash
pytest tests/v1/worker/test_gpu_input_batch.py::test_swap_states_preserves_allowed_token_ids_mask
pytest tests/v1/worker/test_gpu_input_batch.py
```

## Test Result

Verified on 1× NVIDIA H200 (CUDA 13.0, torch 2.11.0).

```
# new test, BEFORE fix (bug reproduced):
>   assert int(mask[1].sum().item()) == VOCAB_SIZE - 1
E   assert 0 == (1024 - 1)
1 failed

# new test, AFTER fix:
1 passed

# whole file, AFTER fix:
10 passed

# lint:
ruff check      -> All checks passed!
ruff format     -> 2 files already formatted
```

The change only alters behavior for `allowed_token_ids` requests that are
reordered; it restores the intended masking, so it can only make constrained
output more correct. Covered by the deterministic unit test above.

---

*AI assistance (Claude) was used to develop this change. The submitter has
reviewed every changed line and run the tests above.*
