### PR TITLE
[Bugfix][LoRA] Skip no-LoRA tokens (index -1) in CPU torch bgmv ops

### DIFF
--- a/tests/lora/test_punica_ops.py
+++ b/tests/lora/test_punica_ops.py
@@ -5,6 +5,7 @@ from threading import Lock
 import pytest
 import torch
 
+import vllm.lora.ops.torch_ops as torch_ops
 import vllm.lora.ops.triton_ops as triton_ops
 from vllm.lora.ops.triton_ops import LoRAKernelMeta
 from vllm.lora.ops.triton_ops.utils import _LORA_A_PTR_DICT, _LORA_B_PTR_DICT
@@ -636,3 +637,43 @@ def test_add_lora_fused_moe_early_exit(device):
     assert torch.equal(y, y_snapshot), (
         "add_lora_fused_moe modified output tensor despite no_lora_flag_cpu=True"
     )
+
+
+def test_torch_ops_bgmv_skips_no_lora_tokens():
+    """The CPU torch bgmv ops must apply no delta to tokens with index -1.
+
+    ``token_lora_indices`` uses -1 to mark "no LoRA" (PunicaWrapperBase); the
+    triton kernels early-exit on ``lora_id == -1``. The torch reference indexed
+    ``lora_weights[-1]`` instead, applying the last stacked adapter to
+    base-model tokens in a mixed batch. Fixing bgmv also fixes sgmv, which
+    delegates to it.
+    """
+    torch.manual_seed(0)
+    num_loras, in_dim, rank, out_dim = 2, 8, 4, 6
+    # token 0 uses LoRA 0; token 1 is a base-model token (no LoRA).
+    lora_indices = torch.tensor([0, -1], dtype=torch.long)
+
+    # shrink: [T, in] x [L, rank, in] -> [T, rank]
+    x = torch.randn(2, in_dim)
+    a = torch.randn(num_loras, rank, in_dim)
+    y = torch.zeros(2, rank)
+    torch_ops.bgmv_shrink(x, a, y, lora_indices, scaling=1.0)
+    assert torch.count_nonzero(y[1]) == 0
+    torch.testing.assert_close(y[0], x[0] @ a[0].T)
+
+    # expand (add): [T, rank] x [L, out, rank] -> [T, out]
+    xe = torch.randn(2, rank)
+    b = torch.randn(num_loras, out_dim, rank)
+    ye = torch.zeros(2, out_dim)
+    torch_ops.bgmv_expand(xe, b, ye, lora_indices, add_inputs=True)
+    assert torch.count_nonzero(ye[1]) == 0
+    torch.testing.assert_close(ye[0], xe[0] @ b[0].T)
+
+    # expand_slice (add into a column slice): [T, rank] x [L, slice, rank]
+    offset = 3
+    ys = torch.zeros(2, out_dim + offset)
+    torch_ops.bgmv_expand_slice(
+        xe, b, ys, lora_indices, offset, out_dim, add_inputs=True
+    )
+    assert torch.count_nonzero(ys[1]) == 0
+    torch.testing.assert_close(ys[0, offset : offset + out_dim], xe[0] @ b[0].T)

--- a/vllm/lora/ops/torch_ops/lora_ops.py
+++ b/vllm/lora/ops/torch_ops/lora_ops.py
@@ -28,11 +28,15 @@ def bgmv_expand(
     lora_indices_tensor: torch.Tensor,
     add_inputs: bool = True,
 ):
-    selected_loras = lora_b_weights[lora_indices_tensor].to(dtype=output_tensor.dtype)
+    no_lora_mask = (lora_indices_tensor == -1).unsqueeze(-1)
+    selected_loras = lora_b_weights[lora_indices_tensor.clamp(min=0)].to(
+        dtype=output_tensor.dtype
+    )
     if len(selected_loras.shape) == 4:
         selected_loras = selected_loras.squeeze(dim=1)
     inputs = inputs.to(dtype=output_tensor.dtype)
     outputs = torch.einsum("bi, boi -> bo", inputs, selected_loras)
+    outputs = outputs.masked_fill(no_lora_mask, 0)
 
     limit = output_tensor.shape[0]
     if outputs.shape[0] == 1 and output_tensor.shape[0] != 1:
@@ -71,11 +75,15 @@ def bgmv_shrink(
     lora_indices_tensor: torch.Tensor,
     scaling: float = 1.0,
 ):
-    selected_loras = lora_b_weights[lora_indices_tensor].to(dtype=output_tensor.dtype)
+    no_lora_mask = (lora_indices_tensor == -1).unsqueeze(-1)
+    selected_loras = lora_b_weights[lora_indices_tensor.clamp(min=0)].to(
+        dtype=output_tensor.dtype
+    )
     if len(selected_loras.shape) == 4:
         selected_loras = selected_loras.squeeze(dim=1)
     inputs = inputs.to(dtype=output_tensor.dtype)
     outputs = torch.einsum("bi, boi -> bo", inputs, selected_loras)
+    outputs = outputs.masked_fill(no_lora_mask, 0)
 
     output_tensor[:, : outputs.shape[1]] = scaling * outputs[:]
 
@@ -116,11 +124,15 @@ def bgmv_expand_slice(
     slice_size: int,
     add_inputs: bool = True,
 ):
-    selected_loras = lora_b_weights[lora_indices_tensor].to(dtype=output_tensor.dtype)
+    no_lora_mask = (lora_indices_tensor == -1).unsqueeze(-1)
+    selected_loras = lora_b_weights[lora_indices_tensor.clamp(min=0)].to(
+        dtype=output_tensor.dtype
+    )
     inputs = inputs.to(dtype=output_tensor.dtype)
     if len(selected_loras.shape) == 4:
         selected_loras = selected_loras.squeeze(dim=1)
     outputs = torch.einsum("bi, boi -> bo", inputs, selected_loras)
+    outputs = outputs.masked_fill(no_lora_mask, 0)
 
     if add_inputs:
         output_tensor[:, slice_offset : slice_offset + slice_size] += outputs[:]


### PR DESCRIPTION
## Purpose

`token_lora_indices` marks base-model (no-LoRA) tokens with the sentinel `-1`
(see `PunicaWrapperBase`; the value is documented as "an index of -1 means no
lora should be applied"). The Triton LoRA kernels honor it by early-exiting
(`if lora_id == -1: return` in `lora_shrink_op`/`lora_expand_op`).

The pure-PyTorch fallback ops used on the **CPU platform**
(`vllm/lora/ops/torch_ops/lora_ops.py`) instead did:

```python
selected_loras = lora_b_weights[lora_indices_tensor]
```

For a `-1` token this selects `lora_b_weights[-1]` — the **last stacked
adapter** — instead of skipping. So in a mixed batch (e.g. the default
`max_loras=1` with one adapter loaded), a base-model request batched next to a
LoRA request silently gets the adapter's delta applied to its logits /
embeddings — wrong output, no error. This affects `bgmv_shrink`, `bgmv_expand`
and `bgmv_expand_slice`, and therefore the `sgmv_*` prefill ops that delegate to
them.

**Fix:** clamp the gather index to `0` and zero the LoRA delta for `-1` tokens
(`masked_fill`), mirroring the Triton early-exit. For valid indices the behavior
is bit-for-bit unchanged (`clamp` is a no-op, the mask is all-False), so the
existing kernel-parity tests are unaffected.

## Test Plan

Added `test_torch_ops_bgmv_skips_no_lora_tokens` to
`tests/lora/test_punica_ops.py`: a 2-token batch `[LoRA-0, no-LoRA(-1)]` run
through `bgmv_shrink` / `bgmv_expand` / `bgmv_expand_slice`, asserting the `-1`
token receives a zero delta and the valid token receives the correct delta.

```bash
pytest tests/lora/test_punica_ops.py::test_torch_ops_bgmv_skips_no_lora_tokens
pytest tests/lora/test_punica_ops.py       # full parity suite, no regressions
```

## Test Result

Verified on 1× NVIDIA H200 (torch 2.11.0).

```
# new test, BEFORE fix (base-model token wrongly modified):
>   assert torch.count_nonzero(y[1]) == 0
E   assert tensor(4) == 0
1 failed

# new test, AFTER fix:
1 passed

# full file (torch-vs-triton parity tests), AFTER fix:
4274 passed
```

`pre-commit run --files ...` (ruff, ruff-format, mypy, typos, SPDX) passes.

---

*AI assistance (Claude) was used to develop this change. The submitter has
reviewed every changed line and run the tests above.*
