### PR TITLE
[Bugfix][Quantization] Run block kernel post-processing for ModelOpt FP8_PB_WO

### DIFF
--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -605,3 +605,33 @@ def test_modelopt_mixed_precision_builds_w4a16_sibling_config():
     assert config.nvfp4_config.LinearMethodCls is m.ModelOptNvFp4LinearMethod
     assert config.w4a16_nvfp4_config.quant_method == "W4A16_NVFP4"
     assert config.w4a16_nvfp4_config.LinearMethodCls is m.ModelOptNvFp4W4A16LinearMethod
+
+
+def test_modelopt_fp8_pb_wo_runs_block_kernel_process_weights():
+    """FP8_PB_WO must forward process_weights_after_loading to its block kernel.
+
+    The kernel is stored as ``w8a8_block_fp8_linear``, but the post-load call
+    was gated on ``hasattr(self, "fp8_linear")`` -- an attribute this method
+    never sets -- so the mandatory scale/layout relayout (deep_gemm on
+    Hopper/Blackwell, e4m3fn->e4m3fnuz on ROCm) was silently skipped and
+    ``apply`` ran the GEMM on unprocessed weights.
+    """
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptFp8PbWoLinearMethod,
+    )
+
+    method = object.__new__(ModelOptFp8PbWoLinearMethod)
+    method.w8a8_block_fp8_linear = Mock()
+
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(
+        torch.zeros(128, 128, dtype=torch.float8_e4m3fn), requires_grad=False
+    )
+    # ModelOpt exports block scales as [out_blk, 1, in_blk, 1].
+    layer.weight_scale = torch.nn.Parameter(torch.ones(1, 1, 1, 1), requires_grad=False)
+
+    method.process_weights_after_loading(layer)
+
+    method.w8a8_block_fp8_linear.process_weights_after_loading.assert_called_once_with(
+        layer
+    )

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -738,8 +738,7 @@ class ModelOptFp8PbWoLinearMethod(LinearMethodBase):
 
         layer.weight_scale = Parameter(scale.contiguous(), requires_grad=False)
 
-        if hasattr(self, "fp8_linear"):
-            self.fp8_linear.process_weights_after_loading(layer)
+        self.w8a8_block_fp8_linear.process_weights_after_loading(layer)
 
     def apply(
         self,


### PR DESCRIPTION
## Purpose

`ModelOptFp8PbWoLinearMethod` (ModelOpt block-wise weight-only FP8, `FP8_PB_WO`)
stores its GEMM kernel as `self.w8a8_block_fp8_linear` (set in
`create_weights`). But `process_weights_after_loading` gated the kernel's own
post-load step on the wrong attribute:

```python
if hasattr(self, "fp8_linear"):
    self.fp8_linear.process_weights_after_loading(layer)
```

`self.fp8_linear` is never set on this class (only the two sibling per-tensor
methods use that name), so the condition is always `False` and the kernel's
`process_weights_after_loading` is **silently skipped**. That step performs the
mandatory scale/layout relayout the block GEMM requires — deep_gemm's
e8m0/TMA-aligned scale layout on Hopper/Blackwell, and the `e4m3fn -> e4m3fnuz`
weight conversion on ROCm. With it skipped, `apply()` runs the GEMM on
unprocessed weights, producing wrong output (or a deep_gemm assert). The two
sibling FP8 methods call `process_weights_after_loading` unconditionally.

**Fix:** call `self.w8a8_block_fp8_linear.process_weights_after_loading(layer)`
unconditionally, matching the siblings.

## Test Plan

Added `test_modelopt_fp8_pb_wo_runs_block_kernel_process_weights` to
`tests/quantization/test_modelopt.py`, asserting
`process_weights_after_loading` forwards to the block kernel's own
`process_weights_after_loading`.

```bash
pytest tests/quantization/test_modelopt.py
```

## Test Result

Verified on 1× NVIDIA H200 (torch 2.11.0).

```
# new test, BEFORE fix (kernel post-processing skipped):
E   AssertionError: Expected 'process_weights_after_loading' to be called once. Called 0 times.
1 failed

# new test, AFTER fix:
1 passed

# full file, AFTER fix:
19 passed, 1 skipped   # the skip is the checkpoint-gated e2e test
```

`pre-commit run --files ...` (ruff, ruff-format, mypy) passes.

**On end-to-end eval:** the fix restores the documented, sibling-consistent
post-load path that was being skipped, and this is a load-time wiring bug
(no numerics changed for valid inputs — the path simply wasn't running). A full
generation eval needs a `FP8_PB_WO` (block-wise weight-only) ModelOpt
checkpoint; the repo's existing `FP8_PB_WO` tests are checkpoint-gated and skip
when none is present locally, and I don't have a public one to point at. Happy
to add e2e numbers if a maintainer can share such a checkpoint.

---

*AI assistance (Claude) was used to develop this change. The submitter has
reviewed every changed line and run the tests above.*
