### PR TITLE
[Refactor] Fix mypy for `vllm/model_executor/layers/fla/ops`

### DIFF
--- a/tools/pre_commit/mypy.py
+++ b/tools/pre_commit/mypy.py
@@ -105,7 +105,6 @@ SEPARATE_GROUPS = [
 # TODO(woosuk): Include the code from Megatron and HuggingFace.
 EXCLUDE = [
     "vllm/model_executor/models",
-    "vllm/model_executor/layers/fla/ops",
 ]
 
 

--- a/vllm/model_executor/layers/fla/ops/chunk.py
+++ b/vllm/model_executor/layers/fla/ops/chunk.py
@@ -69,6 +69,7 @@ def chunk_gated_delta_rule_fwd(
         chunk_indices=chunk_indices,
         chunk_offsets=chunk_offsets,
     )
+    assert v_new is not None
     o = chunk_fwd_o(
         q=q,
         k=k,
@@ -141,7 +142,7 @@ def chunk_gated_delta_rule(
     v: torch.Tensor,
     g: torch.Tensor,
     beta: torch.Tensor,
-    scale: float = None,
+    scale: float | None = None,
     initial_state: torch.Tensor = None,
     output_final_state: bool = False,
     cu_seqlens: torch.Tensor | None = None,

--- a/vllm/model_executor/layers/fla/ops/chunk_delta_h.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_delta_h.py
@@ -132,7 +132,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     # main recurrence
     for i_t in range(NT):
         p_h1 = tl.make_block_ptr(
-            h + i_t.to(tl.int64) * stride_h,
+            h + i_t.to(tl.int64) * stride_h,  # type: ignore[attr-defined]
             (V, K),
             (K, 1),
             (i_v * BV, 0),
@@ -142,7 +142,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
         tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
         if K > 64:
             p_h2 = tl.make_block_ptr(
-                h + i_t.to(tl.int64) * stride_h,
+                h + i_t.to(tl.int64) * stride_h,  # type: ignore[attr-defined]
                 (V, K),
                 (K, 1),
                 (i_v * BV, 64),
@@ -152,7 +152,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
             tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), boundary_check=(0, 1))
         if K > 128:
             p_h3 = tl.make_block_ptr(
-                h + i_t.to(tl.int64) * stride_h,
+                h + i_t.to(tl.int64) * stride_h,  # type: ignore[attr-defined]
                 (V, K),
                 (K, 1),
                 (i_v * BV, 128),
@@ -162,7 +162,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
             tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), boundary_check=(0, 1))
         if K > 192:
             p_h4 = tl.make_block_ptr(
-                h + i_t.to(tl.int64) * stride_h,
+                h + i_t.to(tl.int64) * stride_h,  # type: ignore[attr-defined]
                 (V, K),
                 (K, 1),
                 (i_v * BV, 192),
@@ -205,9 +205,9 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
             )
             tl.store(p_v, b_v.to(p_v.dtype.element_ty), boundary_check=(0, 1))
 
-        last_idx = min((i_t.to(tl.int64) + 1) * BT, T) - 1
+        last_idx = min((i_t.to(tl.int64) + 1) * BT, T) - 1  # type: ignore[attr-defined]
         if USE_G:
-            m_t = (i_t.to(tl.int64) * BT + tl.arange(0, BT)) < T
+            m_t = (i_t.to(tl.int64) * BT + tl.arange(0, BT)) < T  # type: ignore[attr-defined]
             b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
             p_g = tl.make_block_ptr(
                 g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
@@ -331,10 +331,11 @@ def chunk_gated_delta_rule_fwd_h(
     chunk_indices: torch.Tensor | None = None,
     chunk_offsets: torch.Tensor | None = None,
     use_exp2: bool = False,
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
     # This kernel is slightly different from fla to support Q/K with different head numbers.
     # In fla, Q/K always have the same head number, so Hg is always equal to H.
-    B, T, Hg, K, V = *k.shape, u.shape[-1]
+    B, T, Hg, K = k.shape
+    V = u.shape[-1]
     H = u.shape[-2]
     BT = chunk_size
 
@@ -344,7 +345,7 @@ def chunk_gated_delta_rule_fwd_h(
     if cu_seqlens is None:
         N, NT, chunk_offsets = B, triton.cdiv(T, BT), None
     else:
-        N, NT = len(cu_seqlens) - 1, len(chunk_indices)
+        N, NT = len(cu_seqlens) - 1, len(chunk_indices)  # type: ignore[arg-type]
         if chunk_offsets is None:
             chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT)
     assert K <= 256, "current kernel does not support head dimension larger than 256."

--- a/vllm/model_executor/layers/fla/ops/chunk_o.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_o.py
@@ -150,12 +150,13 @@ def chunk_fwd_o(
     chunk_size: int = FLA_CHUNK_SIZE,
     core_attn_out: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    B, T, Hg, K, V = *q.shape, v.shape[-1]
+    B, T, Hg, K = q.shape
+    V = v.shape[-1]
     H = v.shape[-2]
     BT = chunk_size
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
-    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)  # type: ignore[arg-type]
     if scale is None:
         scale = k.shape[-1] ** -0.5
 

--- a/vllm/model_executor/layers/fla/ops/chunk_scaled_dot_kkt.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_scaled_dot_kkt.py
@@ -135,11 +135,11 @@ def chunk_scaled_dot_kkt_fwd(
     # This kernel is slightly different from fla to support Q/K with different head numbers.
     # In fla, Q/K always have the same head number, so Hg is always equal to H.
     B, T, Hg, K = k.shape
-    H = beta.shape[-1]
+    H = beta.shape[-1]  # type: ignore[union-attr]
     BT = chunk_size
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
-    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)  # type: ignore[arg-type]
 
     A = torch.empty(B, T, H, BT, device=k.device, dtype=output_dtype)
     chunk_scaled_dot_kkt_fwd_kernel[(NT, B * H)](

--- a/vllm/model_executor/layers/fla/ops/cumsum.py
+++ b/vllm/model_executor/layers/fla/ops/cumsum.py
@@ -176,7 +176,7 @@ def chunk_local_cumsum_scalar(
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
     BT = chunk_size
-    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)  # type: ignore[arg-type]
     g_org, g = g, torch.empty_like(g, dtype=output_dtype or g.dtype)
     grid = (NT, B * H)
     chunk_local_cumsum_scalar_kernel[grid](
@@ -213,7 +213,7 @@ def chunk_local_cumsum_vector(
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
     BT = chunk_size
-    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)  # type: ignore[arg-type]
 
     g_org, g = g, torch.empty_like(g, dtype=output_dtype or g.dtype)
 

--- a/vllm/model_executor/layers/fla/ops/fused_recurrent.py
+++ b/vllm/model_executor/layers/fla/ops/fused_recurrent.py
@@ -189,7 +189,8 @@ def fused_recurrent_gated_delta_rule_fwd(
     num_accepted_tokens: torch.Tensor | None = None,
     use_qk_l2norm_in_kernel: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    B, T, H, K, V = *k.shape, v.shape[-1]
+    B, T, H, K = k.shape
+    V = v.shape[-1]
     HV = v.shape[2]
     N = B if cu_seqlens is None else len(cu_seqlens) - 1
     BK, BV = triton.next_power_of_2(K), min(triton.next_power_of_2(V), 32)
@@ -519,7 +520,7 @@ def fused_recurrent_gated_delta_rule(
     v: torch.Tensor,
     g: torch.Tensor,
     beta: torch.Tensor = None,
-    scale: float = None,
+    scale: float | None = None,
     initial_state: torch.Tensor = None,
     inplace_final_state: bool = True,
     cu_seqlens: torch.Tensor | None = None,

--- a/vllm/model_executor/layers/fla/ops/fused_sigmoid_gating.py
+++ b/vllm/model_executor/layers/fla/ops/fused_sigmoid_gating.py
@@ -188,7 +188,7 @@ def fused_sigmoid_gating_delta_rule_update(
     v: torch.Tensor,
     beta: float = 1.0,
     threshold: float = 20.0,
-    scale: float = None,
+    scale: float | None = None,
     initial_state: torch.Tensor = None,
     inplace_final_state: bool = True,
     cu_seqlens: torch.Tensor | None = None,
@@ -202,7 +202,8 @@ def fused_sigmoid_gating_delta_rule_update(
     This function uses a single fused kernel that combines both sigmoid gating
     computation and the recurrent delta rule update for better performance.
     """
-    B, T, H, K, V = *k.shape, v.shape[-1]
+    B, T, H, K = k.shape
+    V = v.shape[-1]
     HV = v.shape[2]
     N = B if cu_seqlens is None else len(cu_seqlens) - 1
     BK, BV = triton.next_power_of_2(K), min(triton.next_power_of_2(V), 32)

--- a/vllm/model_executor/layers/fla/ops/kda.py
+++ b/vllm/model_executor/layers/fla/ops/kda.py
@@ -43,7 +43,8 @@ def fused_recurrent_kda_fwd(
     num_accepted_tokens: torch.Tensor | None = None,
     use_qk_l2norm_in_kernel: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    B, T, H, K, V = *k.shape, v.shape[-1]
+    B, T, H, K = k.shape
+    V = v.shape[-1]
     HV = v.shape[2]
     N = B if cu_seqlens is None else len(cu_seqlens) - 1
     BK, BV = next_power_of_2(K), min(next_power_of_2(V), 8)
@@ -112,7 +113,7 @@ def fused_recurrent_kda(
     v: torch.Tensor,
     g: torch.Tensor,
     beta: torch.Tensor = None,
-    scale: float = None,
+    scale: float | None = None,
     initial_state: torch.Tensor = None,
     inplace_final_state: bool = True,
     use_qk_l2norm_in_kernel: bool = True,
@@ -751,7 +752,7 @@ def chunk_kda_scaled_dot_kkt_fwd(
     BT = chunk_size
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
-    NT = cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NT = cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)  # type: ignore[arg-type]
 
     BC = min(16, BT)
     NC = cdiv(BT, BC)
@@ -966,15 +967,16 @@ def recompute_w_u_fwd(
     gk: torch.Tensor | None = None,
     cu_seqlens: torch.Tensor | None = None,
     chunk_indices: torch.Tensor | None = None,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    B, T, H, K, V = *k.shape, v.shape[-1]
+) -> tuple[torch.Tensor, torch.Tensor, None, torch.Tensor | None]:
+    B, T, H, K = k.shape
+    V = v.shape[-1]
     BT = A.shape[-1]
     BK = 64
     BV = 64
 
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
-    NT = cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NT = cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)  # type: ignore[arg-type]
 
     w = torch.empty_like(k)
     u = torch.empty_like(v)
@@ -1135,12 +1137,13 @@ def chunk_gla_fwd_o_gk(
     chunk_indices: torch.Tensor | None = None,
     chunk_size: int = FLA_CHUNK_SIZE,
 ):
-    B, T, H, K, V = *q.shape, v.shape[-1]
+    B, T, H, K = q.shape
+    V = v.shape[-1]
     BT = chunk_size
 
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
-    NT = cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NT = cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)  # type: ignore[arg-type]
 
     def grid(meta):
         return (cdiv(V, meta["BV"]), NT, B * H)
@@ -1272,7 +1275,7 @@ def fused_kda_gate_chunk_cumsum(
     B, T, H, D = raw_g.shape
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
-    NT = cdiv(T, chunk_size) if cu_seqlens is None else len(chunk_indices)
+    NT = cdiv(T, chunk_size) if cu_seqlens is None else len(chunk_indices)  # type: ignore[arg-type]
 
     A_log = A_log.reshape(-1)
     if g_bias is not None:
@@ -1343,6 +1346,7 @@ def _chunk_kda_fwd_with_cumulative_g(
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
     )
+    assert kg is not None
     del A
     h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
         k=kg,
@@ -1355,6 +1359,7 @@ def _chunk_kda_fwd_with_cumulative_g(
         chunk_indices=chunk_indices,
         use_exp2=True,
     )
+    assert v_new is not None
     del w, u, kg
     o = chunk_gla_fwd_o_gk(
         q=q,
@@ -1461,7 +1466,7 @@ def chunk_kda(
     v: torch.Tensor,
     g: torch.Tensor,
     beta: torch.Tensor,
-    scale: float = None,
+    scale: float | None = None,
     initial_state: torch.Tensor = None,
     output_final_state: bool = False,
     use_qk_l2norm_in_kernel: bool = False,

--- a/vllm/model_executor/layers/fla/ops/layernorm_guard.py
+++ b/vllm/model_executor/layers/fla/ops/layernorm_guard.py
@@ -182,7 +182,7 @@ def layer_norm_fwd(
     eps: float,
     z: torch.Tensor = None,
     out: torch.Tensor = None,
-    group_size: int = None,
+    group_size: int | None = None,
     norm_before_gate: bool = True,
     is_rms_norm: bool = False,
     activation: str = "swish",

--- a/vllm/model_executor/layers/fla/ops/solve_tril.py
+++ b/vllm/model_executor/layers/fla/ops/solve_tril.py
@@ -534,7 +534,7 @@ def solve_tril(
     B, T, H, BT = A.shape
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
-    NT = len(chunk_indices) if cu_seqlens is not None else triton.cdiv(T, BT)
+    NT = len(chunk_indices) if cu_seqlens is not None else triton.cdiv(T, BT)  # type: ignore[arg-type]
 
     Ai = torch.zeros_like(A, dtype=output_dtype)
     if BT == 16:

--- a/vllm/model_executor/layers/fla/ops/utils.py
+++ b/vllm/model_executor/layers/fla/ops/utils.py
@@ -13,7 +13,7 @@ import logging
 import os
 from collections.abc import Callable
 from enum import Enum
-from typing import Any, Literal
+from typing import Any
 
 import torch
 
@@ -47,7 +47,7 @@ def tensor_cache(fn: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]
             A wrapped version of the input function with single-entry caching.
     """
 
-    cache_entries: tuple[tuple | None, dict | None, Any] = []
+    cache_entries: list[tuple[tuple[Any, ...], dict[str, Any], Any]] = []
     cache_size = 8
 
     @functools.wraps(fn)
@@ -126,7 +126,7 @@ def get_available_device() -> str:
 
 
 @functools.cache
-def _check_platform() -> Literal["nvidia", "amd", "intel", "musa"]:
+def _check_platform() -> str:
     device = get_available_device()
     mapping = {
         "cuda": "nvidia",
@@ -165,6 +165,8 @@ is_tma_supported = (
 
 
 def get_all_max_shared_mem():
+    if device_torch_lib is None:
+        return [-1]
     try:
         return [
             triton.runtime.driver.active.utils.get_device_properties(i)[

--- a/vllm/model_executor/layers/fla/ops/wy_fast.py
+++ b/vllm/model_executor/layers/fla/ops/wy_fast.py
@@ -125,13 +125,14 @@ def recompute_w_u_fwd(
     cu_seqlens: torch.Tensor | None,
     chunk_indices: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    B, T, Hg, K, V = *k.shape, v.shape[-1]
+    B, T, Hg, K = k.shape
+    V = v.shape[-1]
     H = v.shape[-2]
     BT = A.shape[-1]
 
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
-    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)  # type: ignore[arg-type]
     BK = 64
     BV = 64
     u = torch.empty_like(v)


### PR DESCRIPTION
## Purpose

Part of https://github.com/vllm-project/vllm/issues/26533

## Test

`pre-commit run --hook-stage manual mypy-3.13 -a`

```bash
...
vllm/model_executor/layers/fla/ops/kda.py:1337: error: Need more than 2 values to unpack (4 expected)  [misc]
vllm/model_executor/layers/fla/ops/kda.py:1347: error: Need more than 2 values to unpack (3 expected)  [misc]
vllm/model_executor/layers/fla/ops/kda.py:1464: error: Incompatible default for parameter "scale" (default has type "None", parameter has type "float")  [assignment]
vllm/model_executor/layers/fla/ops/kda.py:1464: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
vllm/model_executor/layers/fla/ops/kda.py:1464: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
Found 134 errors in 12 files (checked 919 source files)
```

Now

```bash
Run mypy for Python 3.13.................................................Passed
```