### PR TITLE
[ROCm][Quant] Requantize serialized MXFP8 linears to FP8 PTPC

### DIFF
--- a/docs/features/quantization/online.md
+++ b/docs/features/quantization/online.md
@@ -84,6 +84,23 @@ vllm serve openai/gpt-oss-20b --quantization-config.moe.activation mxfp8
 
 Combine with `--moe-backend` to pin a specific kernel family.
 
+### Requantize ModelOpt MXFP8 linears on ROCm
+
+On ROCm, serialized ModelOpt MXFP8 linears can be converted to
+per-channel-weight/per-token-activation FP8 at load time. For example:
+
+```bash
+vllm serve MiniMaxAI/MiniMax-M3-MXFP8 \
+  --linear-backend auto \
+  --quantization-config.linear fp8_per_channel
+```
+
+The ModelOpt source method loads the serialized MXFP8 values and E8M0 block
+scales, reconstructs the weight in BF16, and passes it to the generic online
+PTPC method. Checkpoint-excluded and user-ignored linears retain their original
+scheme. MoE remains on checkpoint quantization. This path requires an AITER
+preshuffled per-token FP8 kernel.
+
 ### Separate Schemes for Dense and MoE Layers
 
 You can apply different quantization schemes to dense linear layers and MoE expert layers via the `linear` and `moe` fields. Each accepts either a full spec dict, or a bare string naming an online shorthand (e.g. `"fp8_per_block"`) or weight format (e.g. `"fp8_per_block_static"`); fields not set fall back to the shorthand defaults.

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -6,6 +6,7 @@ Run `pytest tests/quantization/test_modelopt.py`.
 """
 
 import os
+from types import SimpleNamespace
 from typing import Any, NoReturn
 from unittest.mock import MagicMock, Mock, patch
 
@@ -14,13 +15,23 @@ import torch
 
 from tests.quantization.utils import is_quant_method_supported
 from vllm.config.model import ModelConfig
-from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+from vllm.config.quantization import QuantizationConfigArgs
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptFp8Config,
     ModelOptMixedPrecisionConfig,
     ModelOptMxFp8Config,
+    ModelOptMxFp8LinearMethod,
     ModelOptNvFp4Config,
     ModelOptNvFp4LinearMethod,
+)
+from vllm.model_executor.layers.quantization.online.fp8 import (
+    Fp8PtpcOnlineLinearMethod,
+)
+from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+    MXFP8_SCALE_DTYPE,
+    MXFP8_VALUE_DTYPE,
+    dequant_mxfp8_to_bf16,
 )
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -238,6 +249,196 @@ def test_modelopt_mixed_precision_does_not_infer_missing_sibling_linear(
     method = config.get_quant_method(fake_layer, missing_prefix)
 
     assert isinstance(method, UnquantizedLinearMethod)
+
+
+@pytest.mark.parametrize(
+    ("is_rocm", "online_args", "uses_ptpc"),
+    [
+        (True, QuantizationConfigArgs(linear="fp8_per_channel"), True),
+        (
+            True,
+            QuantizationConfigArgs(
+                linear="fp8_per_channel",
+                ignore=["model.layers.0.self_attn.qkv_proj"],
+            ),
+            False,
+        ),
+        (True, None, False),
+        (False, QuantizationConfigArgs(linear="fp8_per_channel"), False),
+    ],
+)
+def test_modelopt_mxfp8_uses_generic_online_ptpc_override(
+    is_rocm, online_args, uses_ptpc
+):
+    prefix = "model.layers.0.self_attn.qkv_proj"
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            dtype=torch.bfloat16,
+            hf_config=SimpleNamespace(model_type="not_minimax"),
+            quantization_config=online_args,
+        ),
+        kernel_config=SimpleNamespace(linear_backend="auto"),
+    )
+    config = ModelOptMxFp8Config(
+        is_checkpoint_mxfp8_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[],
+    )
+    layer = MagicMock(spec=LinearBase)
+
+    with (
+        patch(
+            "vllm.model_executor.layers.quantization.modelopt.get_current_vllm_config",
+            return_value=vllm_config,
+        ),
+        patch(
+            "vllm.model_executor.layers.quantization.online.fp8."
+            "get_current_vllm_config",
+            return_value=vllm_config,
+        ),
+        patch.object(current_platform, "is_rocm", return_value=is_rocm),
+        patch(
+            "vllm.model_executor.layers.quantization.modelopt.init_mxfp8_linear_kernel"
+        ),
+    ):
+        method = config.get_quant_method(layer, prefix)
+
+    if uses_ptpc:
+        assert isinstance(method, Fp8PtpcOnlineLinearMethod)
+        assert isinstance(method.requantization_source, ModelOptMxFp8LinearMethod)
+    else:
+        assert isinstance(method, ModelOptMxFp8LinearMethod)
+
+
+def test_modelopt_mxfp8_ptpc_rejects_incompatible_rocm_backend():
+    prefix = "model.layers.0.self_attn.qkv_proj"
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            dtype=torch.bfloat16,
+            quantization_config=QuantizationConfigArgs(linear="fp8_per_channel"),
+        ),
+        kernel_config=SimpleNamespace(linear_backend="emulation"),
+    )
+    config = ModelOptMxFp8Config(
+        is_checkpoint_mxfp8_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[],
+    )
+    layer = MagicMock(spec=LinearBase)
+
+    with (
+        patch(
+            "vllm.model_executor.layers.quantization.modelopt.get_current_vllm_config",
+            return_value=vllm_config,
+        ),
+        patch(
+            "vllm.model_executor.layers.quantization.online.fp8."
+            "get_current_vllm_config",
+            return_value=vllm_config,
+        ),
+        patch.object(current_platform, "is_rocm", return_value=True),
+        pytest.raises(
+            ValueError,
+            match="ModelOpt MXFP8.*use --linear-backend=auto",
+        ),
+    ):
+        config.get_quant_method(layer, prefix)
+
+
+def test_modelopt_mxfp8_ptpc_loads_and_requantizes_source_weight(monkeypatch):
+    class FakeAiterKernel:
+        def __init__(self):
+            self.processed = False
+
+        def process_weights_after_loading(self, layer):
+            self.processed = True
+
+    fake_kernel = FakeAiterKernel()
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(dtype=torch.bfloat16),
+        kernel_config=SimpleNamespace(linear_backend="auto"),
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.online.fp8.get_current_vllm_config",
+        lambda: vllm_config,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.online.fp8.init_fp8_linear_kernel",
+        lambda **kwargs: fake_kernel,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.kernels.linear."
+        "AiterPreshuffledPerTokenFp8ScaledMMLinearKernel",
+        FakeAiterKernel,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_rank",
+        lambda: 0,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+    monkeypatch.setattr(current_platform, "is_rocm", lambda: True)
+
+    captured: list[torch.Tensor] = []
+
+    def fake_scaled_fp8_quant(weight, *, scale=None, **kwargs):
+        assert scale is None
+        assert kwargs == {"use_per_token_if_dynamic": True}
+        captured.append(weight.clone())
+        return (
+            torch.empty_like(weight, dtype=MXFP8_VALUE_DTYPE),
+            torch.ones((weight.shape[0], 1), dtype=torch.float32),
+        )
+
+    monkeypatch.setattr(
+        "vllm._custom_ops.scaled_fp8_quant",
+        fake_scaled_fp8_quant,
+    )
+
+    config = ModelOptMxFp8Config(
+        is_checkpoint_mxfp8_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[],
+    )
+    source_method = ModelOptMxFp8LinearMethod(config, init_kernel=False)
+    method = Fp8PtpcOnlineLinearMethod()
+    method.set_requantization_source(source_method)
+    layer = torch.nn.Module()
+
+    method.create_weights(
+        layer,
+        input_size_per_partition=64,
+        output_partition_sizes=[16],
+        input_size=64,
+        output_size=16,
+        params_dtype=torch.bfloat16,
+        weight_loader=MagicMock(),
+    )
+
+    assert method.uses_meta_device is False
+    assert layer.weight.shape == (16, 64)
+    assert layer.weight.dtype == MXFP8_VALUE_DTYPE
+    assert layer.weight_scale.shape == (16, 2)
+    assert layer.weight_scale.dtype == MXFP8_SCALE_DTYPE
+    assert method.fp8_linear is fake_kernel
+
+    source_weight = torch.linspace(-1.5, 1.5, 16 * 64).reshape(16, 64)
+    source_weight = source_weight.to(MXFP8_VALUE_DTYPE)
+    source_scale = torch.arange(32, dtype=torch.uint8).reshape(16, 2)
+    source_scale = (source_scale % 3 + 126).to(MXFP8_SCALE_DTYPE)
+    layer.weight.data.copy_(source_weight)
+    layer.weight_scale.data.copy_(source_scale)
+    expected_bf16 = dequant_mxfp8_to_bf16(source_weight, source_scale)
+
+    method.process_weights_after_loading(layer)
+
+    assert len(captured) == 1
+    torch.testing.assert_close(captured[0], expected_bf16, rtol=0, atol=0)
+    assert layer.weight.shape == (64, 16)
+    assert layer.weight_scale.shape == (16, 1)
+    assert fake_kernel.processed
 
 
 def test_vocab_parallel_embedding_weight_loader_accepts_scalar_scale():

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -10,6 +10,7 @@ from torch.nn.parameter import Parameter
 import vllm.envs as envs
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.config import get_current_vllm_config
+from vllm.config.quantization import QuantizationConfigArgs
 from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear import (
     MarlinNvFp4LinearKernel,
@@ -58,6 +59,12 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
+from vllm.model_executor.layers.quantization.online.base import (
+    OnlineQuantizationConfig,
+)
+from vllm.model_executor.layers.quantization.online.fp8 import (
+    Fp8PtpcOnlineLinearMethod,
+)
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     process_fp8_input_tensor_strategy_moe,
     process_fp8_weight_channel_strategy,
@@ -70,6 +77,7 @@ from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
     MXFP8_BLOCK_SIZE,
     MXFP8_SCALE_DTYPE,
     MXFP8_VALUE_DTYPE,
+    dequant_mxfp8_to_bf16,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
@@ -93,6 +101,7 @@ from vllm.model_executor.parameter import (
     PerTensorScaleParameter,
 )
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
+from vllm.platforms import current_platform
 
 if TYPE_CHECKING:
     from vllm.model_executor.models.utils import WeightsMapper
@@ -1714,6 +1723,40 @@ class ModelOptMxFp8Config(ModelOptQuantConfigBase):
     def get_supported_act_dtypes(self) -> list[torch.dtype]:
         return [torch.bfloat16]
 
+    def get_quant_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> "QuantizeMethodBase | None":
+        if current_platform.is_rocm() and isinstance(layer, LinearBase):
+            model_config = get_current_vllm_config().model_config
+            args = model_config.quantization_config
+            if isinstance(args, QuantizationConfigArgs) and not self.is_layer_excluded(
+                prefix
+            ):
+                target_method = OnlineQuantizationConfig(args).get_quant_method(
+                    layer, prefix
+                )
+                if isinstance(target_method, Fp8PtpcOnlineLinearMethod):
+                    linear_backend = (
+                        get_current_vllm_config().kernel_config.linear_backend
+                    )
+                    if linear_backend not in {"auto", "aiter"}:
+                        raise ValueError(
+                            "ModelOpt MXFP8 to FP8 PTPC requantization requires "
+                            "the AITER linear kernel; use --linear-backend=auto "
+                            "or --linear-backend=aiter, got "
+                            f"--linear-backend={linear_backend}."
+                        )
+                    source_method = ModelOptMxFp8LinearMethod(self, init_kernel=False)
+                    target_method.set_requantization_source(source_method)
+                    logger.info_once(
+                        "ModelOpt MXFP8 linear override: checkpoint MXFP8 + "
+                        "E8M0 -> BF16 -> FP8 PTPC; unspecified linears and "
+                        "MoE retain checkpoint quantization.",
+                        scope="global",
+                    )
+                    return target_method
+        return super().get_quant_method(layer, prefix)
+
     @classmethod
     def get_min_capability(cls) -> int:
         # Marlin kernel supports MXFP8 on SM80+
@@ -1779,7 +1822,9 @@ class ModelOptMxFp8Config(ModelOptQuantConfigBase):
 class ModelOptMxFp8LinearMethod(LinearMethodBase):
     """Linear method for ModelOpt MXFP8 quantization."""
 
-    def __init__(self, quant_config: ModelOptMxFp8Config) -> None:
+    def __init__(
+        self, quant_config: ModelOptMxFp8Config, *, init_kernel: bool = True
+    ) -> None:
         self.quant_config = quant_config
 
         if not self.quant_config.is_checkpoint_mxfp8_serialized:
@@ -1788,7 +1833,7 @@ class ModelOptMxFp8LinearMethod(LinearMethodBase):
                 "Dynamic quantization is not supported."
             )
 
-        self.kernel = init_mxfp8_linear_kernel()
+        self.kernel = init_mxfp8_linear_kernel() if init_kernel else None
 
     def create_weights(
         self,
@@ -1853,6 +1898,12 @@ class ModelOptMxFp8LinearMethod(LinearMethodBase):
         if layer.weight.element_size() >= 2:
             return
 
+        self._validate_serialized_weight(layer)
+        assert self.kernel is not None
+        self.kernel.process_weights_after_loading(layer)
+
+    @staticmethod
+    def _validate_serialized_weight(layer: torch.nn.Module) -> None:
         # Validate weight tensor
         if layer.weight.ndim != 2:
             raise ValueError(
@@ -1876,7 +1927,12 @@ class ModelOptMxFp8LinearMethod(LinearMethodBase):
             f" got {layer.weight_scale.dtype}"
         )
 
-        self.kernel.process_weights_after_loading(layer)
+    def dequantize_weight(self, layer: torch.nn.Module) -> torch.Tensor:
+        """Reconstruct the serialized MXFP8 weight for online requantization."""
+        self._validate_serialized_weight(layer)
+        return dequant_mxfp8_to_bf16(
+            layer.weight.contiguous(), layer.weight_scale.contiguous()
+        )
 
     def apply(
         self,
@@ -1884,6 +1940,7 @@ class ModelOptMxFp8LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        assert self.kernel is not None
         return self.kernel.apply_weights(layer, x, bias)
 
 

--- a/vllm/model_executor/layers/quantization/online/fp8.py
+++ b/vllm/model_executor/layers/quantization/online/fp8.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 import torch
 from torch.nn import Module
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm.config import get_current_vllm_config
+from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear import init_fp8_linear_kernel
 from vllm.model_executor.kernels.linear.scaled_mm import (
     CutlassFP8ScaledMMLinearKernel,
@@ -53,6 +54,26 @@ from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import per_block_cast_to_fp8
 from vllm.utils.math_utils import round_up
+
+logger = init_logger(__name__)
+
+
+class LinearRequantizationSource(Protocol):
+    """Serialized linear method that can materialize an unquantized weight."""
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None: ...
+
+    def dequantize_weight(self, layer: torch.nn.Module) -> torch.Tensor: ...
+
 
 # ---------------------------------------------------------------------------
 # Online FP8 Linear Methods
@@ -292,6 +313,18 @@ class Fp8PtpcOnlineLinearMethod(_Fp8OnlineLinearBase):
     weight_quant_key = kFp8StaticChannelSym
     activation_quant_key = kFp8DynamicTokenSym
 
+    def __init__(self) -> None:
+        super().__init__()
+        self.requantization_source: LinearRequantizationSource | None = None
+        self.input_is_partitioned = False
+
+    def set_requantization_source(
+        self, source_method: LinearRequantizationSource
+    ) -> None:
+        """Load a serialized source scheme before converting it to PTPC."""
+        self.requantization_source = source_method
+        self.uses_meta_device = False
+
     def create_weights(
         self,
         layer: torch.nn.Module,
@@ -302,15 +335,27 @@ class Fp8PtpcOnlineLinearMethod(_Fp8OnlineLinearBase):
         params_dtype: torch.dtype,
         **extra_weight_attrs,
     ):
-        super().create_weights(
-            layer,
-            input_size_per_partition,
-            output_partition_sizes,
-            input_size,
-            output_size,
-            params_dtype,
-            **extra_weight_attrs,
-        )
+        self.input_is_partitioned = input_size_per_partition != input_size
+        if self.requantization_source is None:
+            super().create_weights(
+                layer,
+                input_size_per_partition,
+                output_partition_sizes,
+                input_size,
+                output_size,
+                params_dtype,
+                **extra_weight_attrs,
+            )
+        else:
+            self.requantization_source.create_weights(
+                layer,
+                input_size_per_partition,
+                output_partition_sizes,
+                input_size,
+                output_size,
+                params_dtype,
+                **extra_weight_attrs,
+            )
 
         self.fp8_linear = init_fp8_linear_kernel(
             activation_quant_key=self.activation_quant_key,
@@ -329,15 +374,49 @@ class Fp8PtpcOnlineLinearMethod(_Fp8OnlineLinearBase):
                 "weight-only. Requires SM89+ for Cutlass FP8 or ROCm MI3xx "
                 "for rowwise scaled_mm."
             )
+        if self.requantization_source is not None and current_platform.is_rocm():
+            from vllm.model_executor.kernels.linear import (
+                AiterPreshuffledPerTokenFp8ScaledMMLinearKernel,
+            )
+
+            if not isinstance(
+                self.fp8_linear,
+                AiterPreshuffledPerTokenFp8ScaledMMLinearKernel,
+            ):
+                raise RuntimeError(
+                    "ROCm source-aware FP8 PTPC requantization requires the "
+                    "AITER preshuffled per-token FP8 kernel, selected "
+                    f"{type(self.fp8_linear).__name__}."
+                )
 
     def process_weights_after_loading(self, layer: Module) -> None:
         if getattr(layer, "_already_called_process_weights_after_loading", False):
             return
 
+        weight = (
+            layer.weight
+            if self.requantization_source is None
+            else self.requantization_source.dequantize_weight(layer)
+        )
         layer.input_scale = None
         qweight, weight_scale = ops.scaled_fp8_quant(
-            layer.weight, scale=None, use_per_token_if_dynamic=True
+            weight, scale=None, use_per_token_if_dynamic=True
         )
+        if self.requantization_source is not None and self.input_is_partitioned:
+            from vllm.distributed import get_tp_group
+
+            tp_group = get_tp_group()
+            if tp_group.world_size > 1:
+                torch.distributed.all_reduce(
+                    weight_scale,
+                    op=torch.distributed.ReduceOp.MAX,
+                    group=tp_group.device_group,
+                )
+                qweight, weight_scale = ops.scaled_fp8_quant(
+                    weight,
+                    scale=weight_scale,
+                    group_shape=(1, -1),
+                )
 
         replace_parameter(layer, "weight", qweight.t())
         replace_parameter(layer, "weight_scale", weight_scale)
@@ -345,6 +424,12 @@ class Fp8PtpcOnlineLinearMethod(_Fp8OnlineLinearBase):
         self.fp8_linear.process_weights_after_loading(layer)
 
         layer._already_called_process_weights_after_loading = True
+        if self.requantization_source is not None:
+            logger.info_once(
+                "Requantized serialized weights to FP8 PTPC via %s",
+                type(self.fp8_linear).__name__,
+                scope="global",
+            )
 
     def apply(
         self,


### PR DESCRIPTION
## Summary

This PR lets ROCm users requantize serialized MXFP8 linear weights to FP8 per-token/per-channel (PTPC) at model startup:

```text
MXFP8 values + E8M0 block scales -> BF16 -> FP8 PTPC
```

The supported activation flag is:

```bash
--quantization-config.linear fp8_per_channel
```

The implementation is source-format-aware and model-agnostic. It adds no model-specific quantization class or model-name routing.

`ModelOpt` names vLLM's existing checkpoint-format handler: `ModelOptMxFp8Config` and `ModelOptMxFp8LinearMethod`. MiniMax-M3 checkpoints tagged with `quant_method: mxfp8` use the same serialized E4M3-value plus E8M0 block-scale format, so vLLM routes them through this handler. This does not mean the checkpoint was created by NVIDIA ModelOpt.

The PTPC target is generic, but this PR currently provides source reconstruction for the ModelOpt MXFP8 loader. 

## Implementation

- `LinearRequantizationSource` is the small generic interface between a serialized source method and an online quantizer.
- `ModelOptMxFp8LinearMethod.dequantize_weight()` reconstructs BF16 from the checkpoint's MXFP8 values and E8M0 scales.
- `Fp8PtpcOnlineLinearMethod` performs PTPC quantization and AITER preshuffling from the reconstructed weight.
- Routing uses checkpoint quantization and `QuantizationConfigArgs`; there is no `model_type` check or hard-coded layer-name list.
- Excluded and unspecified linears keep checkpoint quantization. MoE remains MXFP8.
- Tensor-parallel row weights synchronize their per-channel scale before final quantization.


## Usage

```bash
vllm serve MiniMaxAI/MiniMax-M3-MXFP8 \
  --tensor-parallel-size 4 \
  --attention-backend TRITON_ATTN \
  --moe-backend aiter \
  --linear-backend auto \
  --kv-cache-dtype fp8 \
  --no-enable-prefix-caching \
  --language-model-only \
  --quantization-config.linear fp8_per_channel
```

Without the final flag, the checkpoint keeps its native MXFP8 linear path.

## Validation

### environment

| Item | Value |
|---|---|
| Current-main base | `b6754f536e9cb40a1e117705a44d74218873b437` |
| PR head | `85199f11c15b8860429c2eb8f37ff2b8dec143cf` |
| Hardware | AMD Instinct MI355X |

### Startup and backend checks

| Test | Configuration | Result |
|---|---|---|
| Current Main | Base, `auto`, no PTPC flag | `RocmDotScaledMxfp8LinearKernel` |
| PR with PTPC | Head, `auto`, `fp8_per_channel` | `AiterPreshuffledPerTokenFp8ScaledMMLinearKernel` |
| PR without Flag | Head, `auto`, no PTPC flag | Unchanged native MXFP8 |
| Invalid Backend | Head, `emulation`, `fp8_per_channel` | Expected early actionable failure |
| Forced Emulation | Base, `emulation`, no PTPC flag | `EmulationMxfp8LinearKernel` |

### Quality: does PTPC preserve native MXFP8 accuracy?

The required paired GSM8K run used `lm-eval[api]==0.4.12`, 25-shot, 200 samples, chat template, temperature 0, max 4096 tokens, concurrency 200, and the same dataset revision.

| Metric | Current Main | PR with PTPC | Difference |
|---|---:|---:|---:|
| Strict exact match | 0.965 | 0.955 | -0.010 |
| Flexible exact match | 0.965 | 0.955 | -0.010 |

Because this two-sample difference lacked per-sample records, a separate full-dataset run repeated the protocol on all 1,319 samples with sample logging:

| Metric | Current Main | PR with PTPC | Difference |
|---|---:|---:|---:|
| Strict exact match | 0.948446 | 0.951478 | +0.003033 |
| Flexible exact match | 0.947688 | 0.950720 | +0.003033 |

### C64: does PTPC improve over current native MXFP8?

| Metric | Current Main | PR with PTPC | Change |
|---|---:|---:|---:|
| Output throughput / GPU (tok/s) | 315.378 | 328.463 | +4.149% |
| Total output throughput (tok/s) | 1261.512 | 1313.853 | +4.149% |
| Total token throughput (tok/s) | 22259.993 | 23183.570 | +4.149% |
| Mean TTFT (ms) | 1229.384 | 1143.733 | -6.967% |
| p99 TTFT (ms) | 12933.988 | 11926.503 | -7.789% |
| Mean TPOT (ms) | 47.398 | 45.379 | -4.260% |
| p99 TPOT (ms) | 73.013 | 72.471 | -0.742% |
| p99 ITL (ms) | 405.151 | 378.142 | -6.666% |
| Server startup (s) | 237.961 | 257.985 | +8.415% |
| Ready TP4 VRAM (GB) | 1165.783 | 1166.422 | +0.055% |

PTPC improved throughput by 4.149%; every reported request-latency metric also
improved in this run.

### C256: does PTPC improve over current native MXFP8?

| Metric | Current Main | PR with PTPC | Change |
|---|---:|---:|---:|
| Output throughput / GPU (tok/s) | 662.991 | 694.401 | +4.738% |
| Total output throughput (tok/s) | 2651.963 | 2777.604 | +4.738% |
| Total token throughput (tok/s) | 24997.365 | 26181.652 | +4.738% |
| Mean TTFT (ms) | 3250.910 | 2971.010 | -8.610% |
| p99 TTFT (ms) | 48113.349 | 44232.797 | -8.065% |
| Mean TPOT (ms) | 92.812 | 88.881 | -4.235% |
| p99 TPOT (ms) | 155.739 | 164.762 | +5.793% |
| p99 ITL (ms) | 616.272 | 583.070 | -5.388% |
| Server startup (s) | 233.559 | 258.725 | +10.775% |
| Ready TP4 VRAM (GB) | 1165.783 | 1166.422 | +0.055% |

PTPC improved throughput by 4.738%. 

### Migration: is PTPC better than forced emulation?

This was a direct concurrent C256 comparison, not a percentage inferred from
other runs. Both arms completed 2,560/2,560 with zero failures and no
measured-phase JIT/autotuning.

| Metric | Forced Emulation | PR with PTPC | Change |
|---|---:|---:|---:|
| Output throughput / GPU (tok/s) | 676.806 | 696.070 | +2.846% |
| Total output throughput (tok/s) | 2707.224 | 2784.281 | +2.846% |
| Total token throughput (tok/s) | 25518.253 | 26244.596 | +2.846% |
| Mean TTFT (ms) | 3032.546 | 2927.926 | -3.450% |
| p99 TTFT (ms) | 48231.056 | 44180.714 | -8.398% |
| Mean TPOT (ms) | 91.190 | 88.622 | -2.816% |
| p99 TPOT (ms) | 163.426 | 156.802 | -4.053% |
| p99 ITL (ms) | 603.063 | 565.714 | -6.193% |
| Server startup (s) | 237.764 | 258.186 | +8.590% |
| Ready TP4 VRAM (GB) | 1174.890 | 1166.422 | -0.721% |

PTPC improved throughput by 2.846%