### PR TITLE
[BugFix] Restore full tokens for Qwen MTP When MoE SP

### DIFF
--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -26,6 +26,7 @@ from vllm.model_executor.models.qwen3_5 import (
 )
 from vllm.model_executor.models.qwen3_next import (
     QwenNextMixtureOfExperts,
+    _all_gather_hidden_and_residual,
     _is_shared_expert_fse_compatible,
 )
 from vllm.sequence import IntermediateTensors
@@ -150,7 +151,8 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
             residual = intermediate_tensors["residual"]
 
         current_step_idx = spec_step_idx % self.num_mtp_layers
-        hidden_states, residual = self.layers[current_step_idx](
+        mtp_layer = self.layers[current_step_idx]
+        hidden_states, residual = mtp_layer(
             positions=positions,
             hidden_states=hidden_states,
             residual=residual,
@@ -161,6 +163,13 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
                 {"hidden_states": hidden_states, "residual": residual}
             )
 
+        if mtp_layer.use_attn_reduce_scatter_for_moe:
+            hidden_states, residual = _all_gather_hidden_and_residual(
+                hidden_states,
+                residual,
+                positions.shape[-1],
+                self.config.hidden_size,
+            )
         hidden_states, _ = self.norm(hidden_states, residual)
         return hidden_states
 

--- a/vllm/model_executor/models/qwen3_next_mtp.py
+++ b/vllm/model_executor/models/qwen3_next_mtp.py
@@ -23,6 +23,7 @@ from vllm.model_executor.models.qwen3_next import (
     Qwen3NextModel,
     Qwen3NextRMSNorm,
     QwenNextMixtureOfExperts,
+    _all_gather_hidden_and_residual,
 )
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.qwen3_next import Qwen3NextConfig
@@ -130,7 +131,8 @@ class Qwen3NextMultiTokenPredictor(nn.Module):
             residual = intermediate_tensors["residual"]
 
         current_step_idx = spec_step_idx % self.num_mtp_layers
-        hidden_states, residual = self.layers[current_step_idx](
+        mtp_layer = self.layers[current_step_idx]
+        hidden_states, residual = mtp_layer(
             positions=positions,
             hidden_states=hidden_states,
             residual=residual,
@@ -141,6 +143,13 @@ class Qwen3NextMultiTokenPredictor(nn.Module):
                 {"hidden_states": hidden_states, "residual": residual}
             )
 
+        if mtp_layer.use_attn_reduce_scatter_for_moe:
+            hidden_states, residual = _all_gather_hidden_and_residual(
+                hidden_states,
+                residual,
+                positions.shape[-1],
+                self.config.hidden_size,
+            )
         hidden_states, _ = self.norm(hidden_states, residual)
         return hidden_states
 


### PR DESCRIPTION



## Purpose

After #47006, the MTP of Qwen is breaking when MoE SP is enabled. Because MTP is calling the DecodeLayer of Qwen instead of the complete model. And we have moved the gather to the front of attention, so it will be shared when you directly call decoder layer api. We should call `_all_gather_hidden_and_residual` to restore the full tokens view.

Without this PR, it will happen the error below when running Qwen MTP with MoE SP:

```
   File "/root/vllm-workspace/vllm/vllm/v1/worker/gpu_model_runner.py", line 3808, in synchronize_input_prep
(Worker_TP2_EP2 pid=1753218) ERROR 07-12 17:56:58 [multiproc_executor.py:1007]     self.prepare_inputs_event.record()
(Worker_TP2_EP2 pid=1753218) ERROR 07-12 17:56:58 [multiproc_executor.py:1007]   File "/root/vllm-workspace/vllm/.venv/lib/python3.11/site-packages/torch/cuda/streams.py", line 209, in record
(Worker_TP3_EP3 pid=1753219) ERROR 07-12 17:56:58 [multiproc_executor.py:1007] Traceback (most recent call last):
(Worker_TP2_EP2 pid=1753218) ERROR 07-12 17:56:58 [multiproc_executor.py:1007]     super().record(stream)
(Worker_TP2_EP2 pid=1753218) ERROR 07-12 17:56:58 [multiproc_executor.py:1007] torch.AcceleratorError: CUDA error: device-side assert triggered
(Worker_TP3_EP3 pid=1753219) ERROR 07-12 17:56:58 [multiproc_executor.py:1007]   File "/root/vllm-workspace/vllm/vllm/v1/worker/gpu_model_runner.py", line 3806, in synchronize_input_prep
(Worker_TP2_EP2 pid=1753218) ERROR 07-12 17:56:58 [multiproc_executor.py:1007] Search for `cudaErrorAssert' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
(Worker_TP3_EP3 pid=1753219) ERROR 07-12 17:56:58 [multiproc_executor.py:1007]     yield
(Worker_TP2_EP2 pid=1753218) ERROR 07-12 17:56:58 [multiproc_executor.py:1007] CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
```

## Test Plan

```
VLLM_DISABLE_COMPILE_CACHE=1 vllm serve /mnt/data1/huggingface/hub/models--Qwen--Qwen3.5-122B-A10B/snapshots/dc4d348443bc740c68e2d77492492c11606384d5 \
      --served-model-name qwen35-mtp \
      --host 127.0.0.1 \
      --port 9256 \
      --trust-remote-code \
      --enable-expert-parallel \
      --tensor-parallel-size 4 \
      --max-num-batched-tokens 8192 \
      --gpu-memory-utilization 0.95 \
      --speculative-config '{"method":"mtp","num_speculative_tokens":1}'
```

```
MODEL_PATH=/mnt/data1/huggingface/hub/models--Qwen--Qwen3.5-122B-A10B/snapshots/dc4d348443bc740c68e2d77492492c11606384d5

lm_eval \
      --model local-completions \
      --model_args "base_url=http://127.0.0.1:9256/v1/completions,model=qwen35-mtp,tokenizer=${MODEL_PATH},tokenizer_backend=huggingface,trust_remote_code=True,num_concurrent=1024" \
      --tasks gsm8k
```

## Test Result

This PR:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8575|±  |0.0096|
|     |       |strict-match    |     5|exact_match|↑  |0.8378|±  |0.0102|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

