### PR TITLE
[Bugfix][KV Connector] Preserve async load reservations

### DIFF
--- a/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
+++ b/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
@@ -742,6 +742,96 @@ def test_local_admission_respects_async_load_reservation():
     assert local_req.status == RequestStatus.WAITING
 
 
+def test_failed_async_load_releases_reservation():
+    """A fully-failed async load frees its blocks and must also stop reserving
+    capacity for its remaining sequence: holding nothing, it waits like any
+    other request, so a stale reservation must not starve running requests.
+
+    9 usable blocks. remote_a (4-block sequence, 2 loaded) and remote_b
+    (3-block sequence, 2 loaded) park with reservations of 2 and 1; local_req
+    holds 2 and decodes. remote_a's transfer fails entirely, so promotion
+    frees its blocks and re-admission fails (4 + 1 watermark > 9 - 4 held - 1
+    reserved). local_req's next decode block must then be gated only by
+    remote_b's reservation, not by empty-handed remote_a's."""
+    vllm_config = create_vllm_config(kv_load_failure_policy="recompute")
+    BLOCK_SIZE = vllm_config.cache_config.block_size
+    vllm_config.scheduler_config.watermark = 0.1  # 1 block
+    scheduler = create_scheduler(vllm_config, num_blocks=10)  # usable = 9
+
+    remote_a = create_request(
+        request_id=1,
+        block_size=BLOCK_SIZE,
+        num_tokens=BLOCK_SIZE * 4,
+        do_remote_prefill=True,
+        num_remote_blocks=2,
+    )
+    remote_b = create_request(
+        request_id=2,
+        block_size=BLOCK_SIZE,
+        num_tokens=BLOCK_SIZE * 3,
+        do_remote_prefill=True,
+        num_remote_blocks=2,
+    )
+    # 2 blocks of prompt; needs a 3rd block on its 3rd decoded token.
+    local_req = create_request(
+        request_id=3,
+        block_size=BLOCK_SIZE,
+        num_tokens=BLOCK_SIZE * 2 - 2,
+    )
+    for req in (remote_a, remote_b, local_req):
+        scheduler.add_request(req)
+
+    matched = {
+        remote_a.request_id: (BLOCK_SIZE * 2, True),
+        remote_b.request_id: (BLOCK_SIZE * 2, True),
+    }
+
+    with patch.object(
+        scheduler.connector,
+        "get_num_new_matched_tokens",
+        side_effect=lambda req, _: matched.pop(req.request_id, (0, False)),
+    ):
+        output = scheduler.schedule()
+        assert remote_a.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+        assert remote_b.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+        assert local_req.status == RequestStatus.RUNNING
+        scheduler.update_from_output(
+            output, create_model_runner_output(reqs=[local_req])
+        )
+
+        # remote_a's transfer fails entirely (first block invalid).
+        output = scheduler.schedule()
+        (remote_a_blocks,) = scheduler.kv_cache_manager.get_block_ids(
+            remote_a.request_id
+        )
+        scheduler.update_from_output(
+            output,
+            create_model_runner_output(
+                reqs=[local_req],
+                invalid_block_ids={remote_a_blocks[0]},
+                finished_recving={remote_a.request_id},
+            ),
+        )
+        assert remote_a.num_computed_tokens == 0
+
+        # Promotion frees remote_a's blocks; re-admission fails.
+        output = scheduler.schedule()
+        assert remote_a.status == RequestStatus.WAITING
+        assert remote_a not in scheduler._inflight_prefills
+        scheduler.update_from_output(
+            output, create_model_runner_output(reqs=[local_req])
+        )
+
+        # local_req needs a new block; a stale reservation from remote_a
+        # would fail this allocation and preempt local_req.
+        output = scheduler.schedule()
+
+    assert local_req.status == RequestStatus.RUNNING
+    assert local_req.request_id in output.num_scheduled_tokens
+    assert local_req.num_preemptions == 0
+    assert remote_a.status == RequestStatus.WAITING
+
+
 def test_async_loads_both_admitted_when_pool_fits():
     """Sanity: with a pool large enough, the reservation gate admits both async
     loads (it is not over-conservative)."""

--- a/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
+++ b/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
@@ -711,6 +711,37 @@ def test_async_load_reserves_blocks_for_inflight():
     assert req_b.request_id not in req_to_blocks
 
 
+def test_local_admission_respects_async_load_reservation():
+    vllm_config = create_vllm_config()
+    block_size = vllm_config.cache_config.block_size
+    scheduler = create_scheduler(vllm_config, num_blocks=8)  # usable = 7
+
+    remote_req = create_request(
+        request_id=1,
+        block_size=block_size,
+        num_tokens=block_size * 4,
+        do_remote_prefill=True,
+        num_remote_blocks=1,
+    )
+    local_req = create_request(
+        request_id=2,
+        block_size=block_size,
+        num_tokens=block_size * 4,
+    )
+    scheduler.add_request(remote_req)
+    scheduler.add_request(local_req)
+
+    with patch.object(
+        scheduler.connector,
+        "get_num_new_matched_tokens",
+        side_effect=[(block_size, True), (0, False)],
+    ):
+        scheduler.schedule()
+
+    assert remote_req.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+    assert local_req.status == RequestStatus.WAITING
+
+
 def test_async_loads_both_admitted_when_pool_fits():
     """Sanity: with a pool large enough, the reservation gate admits both async
     loads (it is not over-conservative)."""

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -306,9 +306,10 @@ class KVCacheManager:
                 requests when chunked prefill would otherwise only check the first chunk
             reserved_blocks: Number of free blocks that must be left available for
                 other in-flight sequences to complete. The actual allocation is only
-                made if it fits within (free blocks - reserved_blocks). Used to gate
-                async KV-connector loads so their initial allocation cannot consume
-                blocks an already in-flight (prefilling) sequence is relying on.
+                made if it fits within (free blocks - reserved_blocks). Applied to
+                every admission and running allocation so that no request can
+                consume blocks an in-flight prefill (e.g. a parked async KV load)
+                still needs to finish.
             has_scheduled_reqs: Whether any requests are already scheduled to run
                 this step, controls whether watermark is applied.
 

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -409,7 +409,9 @@ class KVCacheManager:
                 apply_admission_cap=True,
             )
             required_blocks = num_blocks_to_allocate + watermark_blocks
-            if required_blocks > self.block_pool.get_num_free_blocks():
+            if required_blocks > (
+                self.block_pool.get_num_free_blocks() - reserved_blocks
+            ):
                 return None
 
         num_tokens_main_model = total_computed_tokens + num_new_tokens

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -474,6 +474,11 @@ class Scheduler(SchedulerInterface):
             throttle_prefills and not self.prefill_capacity_bound
         ) and any(not r.is_prefill_chunk for r in self.running)
 
+        # Blocks promised to in-flight async KV loads. Loop-invariant: async
+        # loads are never RUNNING, so allocations below neither change this sum
+        # nor need to exclude themselves from it.
+        async_load_reserved = self._inflight_prefill_reserved_blocks()
+
         # First, schedule the RUNNING requests.
         req_index = 0
         while req_index < len(self.running) and token_budget > 0:
@@ -573,7 +578,7 @@ class Scheduler(SchedulerInterface):
                         request,
                         num_new_tokens,
                         num_lookahead_tokens=self.num_lookahead_tokens,
-                        reserved_blocks=self._inflight_prefill_reserved_blocks(request),
+                        reserved_blocks=async_load_reserved,
                     )
 
                     if new_blocks is not None:
@@ -932,7 +937,9 @@ class Scheduler(SchedulerInterface):
                         for i in encoder_inputs_to_schedule
                     )
 
-                reserved_blocks = self._inflight_prefill_reserved_blocks(request)
+                reserved_blocks = self._inflight_prefill_reserved_blocks(
+                    request, include_chunked_prefill=load_kv_async
+                )
 
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,
@@ -2477,19 +2484,29 @@ class Scheduler(SchedulerInterface):
             apply_admission_cap=True,
         )
 
-    def _inflight_prefill_reserved_blocks(self, exclude: Request | None = None) -> int:
-        """Num blocks in-flight prefills still need to finish (their reservation).
+    def _inflight_prefill_reserved_blocks(
+        self, exclude: Request | None = None, include_chunked_prefill: bool = False
+    ) -> int:
+        """Num free blocks to set aside for in-flight prefills to finish.
 
-        Every admission and running allocation must fit within (free - this
-        reservation) so ordinary work cannot consume capacity a parked async
-        KV load or a running chunked prefill is relying on to complete.
-        `exclude` lets a request spend its own reservation.
+        By default only counts async KV loads (parked for their transfer, or
+        landed and holding blocks until scheduled), which make no forward
+        progress and cannot be preempted; every allocation must leave them
+        room to finish. Zero when no KV connector is in use.
+
+        Args:
+            exclude: Request allowed to spend its own reservation.
+            include_chunked_prefill: Also count in-progress chunked prefills.
+                Used when admitting an async load, which once parked cannot be
+                preempted and so must not squeeze out prefills already making
+                progress.
         """
 
         return sum(
             self._request_remaining_blocks(req)
             for req in self._inflight_prefills
             if req is not exclude
+            and (include_chunked_prefill or req.status != RequestStatus.RUNNING)
         )
 
     def _update_waiting_for_remote_kv(self, request: Request) -> None:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2478,7 +2478,13 @@ class Scheduler(SchedulerInterface):
         )
 
     def _inflight_prefill_reserved_blocks(self, exclude: Request | None = None) -> int:
-        """Num blocks in-flight prefills still need to finish (their reservation)."""
+        """Num blocks in-flight prefills still need to finish (their reservation).
+
+        Every admission and running allocation must fit within (free - this
+        reservation) so ordinary work cannot consume capacity a parked async
+        KV load or a running chunked prefill is relying on to complete.
+        `exclude` lets a request spend its own reservation.
+        """
 
         return sum(
             self._request_remaining_blocks(req)
@@ -2506,6 +2512,9 @@ class Scheduler(SchedulerInterface):
                 # No valid computed tokens, release allocated blocks.
                 # There may be a local cache hit on retry.
                 self.kv_cache_manager.free(request)
+                # Holding no blocks, it waits like any other request and
+                # must not keep a completion reservation.
+                self._inflight_prefills.discard(request)
 
             self.failed_recving_kv_req_ids.remove(request.request_id)
         else:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -573,6 +573,7 @@ class Scheduler(SchedulerInterface):
                         request,
                         num_new_tokens,
                         num_lookahead_tokens=self.num_lookahead_tokens,
+                        reserved_blocks=self._inflight_prefill_reserved_blocks(request),
                     )
 
                     if new_blocks is not None:
@@ -931,13 +932,7 @@ class Scheduler(SchedulerInterface):
                         for i in encoder_inputs_to_schedule
                     )
 
-                reserved_blocks = 0
-                if load_kv_async:
-                    # An async load holds its blocks for the whole transfer with
-                    # no forward progress and isn't preemptible here. Admit it
-                    # only if it fits in (free - other in-flight reservations), to
-                    # avoid deadlock and predictable preemptions.
-                    reserved_blocks = self._inflight_prefill_reserved_blocks()
+                reserved_blocks = self._inflight_prefill_reserved_blocks(request)
 
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,
@@ -2482,11 +2477,13 @@ class Scheduler(SchedulerInterface):
             apply_admission_cap=True,
         )
 
-    def _inflight_prefill_reserved_blocks(self) -> int:
+    def _inflight_prefill_reserved_blocks(self, exclude: Request | None = None) -> int:
         """Num blocks in-flight prefills still need to finish (their reservation)."""
 
         return sum(
-            self._request_remaining_blocks(req) for req in self._inflight_prefills
+            self._request_remaining_blocks(req)
+            for req in self._inflight_prefills
+            if req is not exclude
         )
 
     def _update_waiting_for_remote_kv(self, request: Request) -> None:


### PR DESCRIPTION
## Summary

Async KV loads reserve the blocks they still need to finish, but the scheduler only honored that reservation when admitting another async load. Ordinary local admissions and subsequent running chunks could consume the reserved headroom. The full-sequence admission check also ignored `reserved_blocks`.

This change:

- applies in-flight prefill reservations to both waiting and running allocations;
- excludes the request that owns the reservation when it resumes;
- includes reserved blocks in the full-sequence fit check; and
- adds a regression test where a local request would otherwise consume an async load's remaining capacity.

The reservation is only nonzero while async loads or chunked prefills are in flight, so normal scheduling is unchanged.

## Why this is not a duplicate

I searched open PRs for async KV reservation, scheduler deadlock, and `reserved_blocks`.

- #44560 introduced reservation-based admission between async loads. This PR closes the remaining gap where non-async allocations ignore that reservation.
- #42568 changes `max_num_seqs` accounting for async loads; it does not protect block reservations.
- #45406 scans past an unschedulable queue head to promote a completed parked load; it addresses a different post-admission queue-stranding state.

## Validation

Focused lifecycle test file:

```bash
.venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py -q
```

```text
10 passed, 17 warnings in 6.82s
```

Repository hooks on the modified files:

```bash
pre-commit run --files \
  vllm/v1/core/kv_cache_manager.py \
  vllm/v1/core/sched/scheduler.py \
  tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
```

All hooks passed.

I also ran a local two-GPU DSv4-Pro-shaped stress test with DP=2, EP=2, DeepGEMM MegaMoE, dummy weights, a deliberately small KV pool, one delayed async external-KV load, and heavily imbalanced requests. All 8 requests completed without a collective stall. On the original target branch, the same-config A/B reduced peak logical KV usage from 94.2% to 87.2% and completion time from 28.91s to 20.82s. Current upstream `main` with this patch completed in 20.78s with 87.8% peak KV usage.

This test validates the reservation-pressure behavior; it does not claim that every production collective hang has the same root cause.

## AI assistance

OpenAI Codex was used to investigate the scheduler path, draft the patch and regression test, and run the validation. I reviewed every changed line and am responsible for the change.
