### PR TITLE
[KV Offload] Coalesce contiguous descriptor runs before batch submission

### DIFF
--- a/benchmarks/kernels/benchmark_swap_blocks_batch.py
+++ b/benchmarks/kernels/benchmark_swap_blocks_batch.py
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Microbenchmarks for the CPU KV-offload copy path.
+
+Modes:
+
+``--merge`` (default)
+    Descriptor run-coalescing (``merge_contiguous_descriptors``) on the C++
+    ``cuMemcpyBatchAsync`` path: sweeps page size x contiguous-run length and
+    reports, for unmerged vs merged descriptor lists, the CPU submission cost
+    (cuMemcpyBatchAsync charges ~0.5us of CPU per descriptor), the solo-call
+    latency (submission stall exposed, as for a single prefix-hit load), and
+    the pipelined back-to-back throughput. The Triton fast path is shown for
+    reference where it applies.
+
+``--crossover``
+    DMA vs Triton fast path across page size x batch size, for re-validating
+    ``THRESHOLD_BYTES`` / ``MIN_N`` / ``NUM_SMS`` when the kernel changes.
+
+All timed calls run on a dedicated CUDA stream: cuMemcpyBatchAsync rejects
+the legacy default stream and would otherwise silently take the per-copy
+fallback loop.
+
+Run on a CUDA host:
+
+    .venv/bin/python benchmarks/kernels/benchmark_swap_blocks_batch.py
+    .venv/bin/python benchmarks/kernels/benchmark_swap_blocks_batch.py --crossover
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from functools import partial
+
+import numpy as np
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.triton_utils import triton
+from vllm.v1.kv_offload.cpu.gpu_worker import merge_contiguous_descriptors
+from vllm.v1.kv_offload.cpu.swap_blocks_triton import (
+    MIN_N,
+    NUM_SMS,
+    THRESHOLD_BYTES,
+    _swap_blocks_kernel,
+)
+
+KiB = 1024
+
+
+def _make_batch(n: int, page_size: int, run_len: int = 1):
+    """Build a descriptor list of ``n`` pages in contiguous runs of ``run_len``.
+
+    Runs are contiguous on both host and device (as consecutive blocks within
+    a layer are in production), while run order is shuffled with a one-page
+    gap so no two runs are accidentally adjacent.
+    """
+    num_runs = (n + run_len - 1) // run_len
+    pool_pages = num_runs * (run_len + 1)
+    host = torch.empty(pool_pages * page_size, dtype=torch.uint8, pin_memory=True)
+    host.random_()
+    dev = torch.zeros(pool_pages * page_size, dtype=torch.uint8, device="cuda")
+
+    rng = np.random.default_rng(seed=42)
+    run_order = rng.permutation(num_runs)
+    starts = run_order * (run_len + 1)
+    offsets = (starts[:, None] + np.arange(run_len)[None, :]).ravel()[:n]
+    offsets = offsets * page_size
+
+    src = (host.data_ptr() + offsets).astype(np.int64)
+    dst = (dev.data_ptr() + offsets).astype(np.int64)
+    sizes = np.full(n, page_size, dtype=np.int64)
+    page_idx = torch.from_numpy((offsets // page_size).astype(np.int64))
+    return host, dev, src, dst, sizes, page_idx
+
+
+def _verify_copied_pages(host, dev, page_idx, page_size):
+    """Compare only the pages the descriptor list covers (runs have gaps)."""
+    hv = host.view(-1, page_size)[page_idx]
+    dv = dev.view(-1, page_size)[page_idx].cpu()
+    assert torch.equal(dv, hv), "copy produced wrong bytes"
+
+
+def _to_pinned(arr: np.ndarray) -> torch.Tensor:
+    return torch.from_numpy(arr.copy()).pin_memory()
+
+
+def _dma_call(src_addrs, dst_addrs, sizes):
+    ops.swap_blocks_batch(src_addrs, dst_addrs, sizes, is_src_access_order_any=True)
+
+
+def _triton_call(src_addrs, dst_addrs, sizes, bytes_per_chunk: int):
+    n = src_addrs.numel()
+    _swap_blocks_kernel[(min(NUM_SMS, n),)](
+        src_addrs.to("cuda", non_blocking=True),
+        dst_addrs.to("cuda", non_blocking=True),
+        sizes.to("cuda", non_blocking=True),
+        n,
+        BYTES_PER_CHUNK=bytes_per_chunk,
+    )
+
+
+def _submit_us(fn, stream, iters: int = 10) -> float:
+    """Average CPU cost of enqueuing one call (no synchronization)."""
+    fn()
+    stream.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    dt = time.perf_counter() - t0
+    stream.synchronize()
+    return dt / iters * 1e6
+
+
+def _solo_ms(fn, stream, iters: int = 10) -> float:
+    """Median submit+complete latency of an isolated call."""
+    fn()
+    stream.synchronize()
+    ts = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        fn()
+        stream.synchronize()
+        ts.append(time.perf_counter() - t0)
+    ts.sort()
+    return ts[len(ts) // 2] * 1e3
+
+
+def _b2b_ms(fn, stream, iters: int = 10, warmup: int = 3) -> float:
+    """Average per-call time of back-to-back (pipelined) calls."""
+    for _ in range(warmup):
+        fn()
+    stream.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record(stream)
+    for _ in range(iters):
+        fn()
+    end.record(stream)
+    end.synchronize()
+    return start.elapsed_time(end) / iters
+
+
+def _gbps(total_bytes: int, ms: float) -> float:
+    return total_bytes / (ms * 1e-3) / 1e9
+
+
+def run_merge(n: int, page_kib_values: list[int], run_lengths: list[int]) -> None:
+    stream = torch.cuda.Stream()
+    header = (
+        f"{'page':>6}{'run':>5}{'n_merged':>9}{'merge_us':>9}"
+        f"{'submit_us u/m':>16}{'solo_ms u/m':>16}"
+        f"{'b2b_GBps u/m':>16}{'triton_solo':>12}"
+    )
+    print(header)
+    print("-" * len(header))
+    for pk in page_kib_values:
+        page = pk * KiB
+        for run_len in run_lengths:
+            host, dev, src, dst, sizes, page_idx = _make_batch(n, page, run_len)
+            total = n * page
+
+            t0 = time.perf_counter()
+            m_src, m_dst, m_sizes = src.copy(), dst.copy(), sizes.copy()
+            n_merged = merge_contiguous_descriptors(m_src, m_dst, m_sizes)
+            merge_us = (time.perf_counter() - t0) * 1e6
+
+            sa_u, da_u, sz_u = _to_pinned(src), _to_pinned(dst), _to_pinned(sizes)
+            sa_m = _to_pinned(m_src[:n_merged])
+            da_m = _to_pinned(m_dst[:n_merged])
+            sz_m = _to_pinned(m_sizes[:n_merged])
+
+            with torch.cuda.stream(stream):
+                dev.zero_()
+                _dma_call(sa_m, da_m, sz_m)
+            stream.synchronize()
+            _verify_copied_pages(host, dev, page_idx, page)
+
+            unmerged = partial(_dma_call, sa_u, da_u, sz_u)
+            merged = partial(_dma_call, sa_m, da_m, sz_m)
+            with torch.cuda.stream(stream):
+                sub_u = _submit_us(unmerged, stream)
+                sub_m = _submit_us(merged, stream)
+                solo_u = _solo_ms(unmerged, stream)
+                solo_m = _solo_ms(merged, stream)
+                b2b_u = _gbps(total, _b2b_ms(unmerged, stream))
+                b2b_m = _gbps(total, _b2b_ms(merged, stream))
+                tri = "-"
+                if page < THRESHOLD_BYTES and n >= MIN_N:
+                    chunk = min(triton.next_power_of_2(page), 8192)
+                    tri_fn = partial(_triton_call, sa_u, da_u, sz_u, chunk)
+                    tri = f"{_solo_ms(tri_fn, stream):.2f}"
+
+            print(
+                f"{pk:>5}K{run_len:>5}{n_merged:>9}{merge_us:>9.0f}"
+                f"{sub_u:>8.0f}/{sub_m:<7.0f}{solo_u:>8.2f}/{solo_m:<7.2f}"
+                f"{b2b_u:>8.1f}/{b2b_m:<7.1f}{tri:>12}"
+            )
+            del host, dev
+    print(
+        f"\nn={n} descriptors; run = contiguous pages per run (both sides); "
+        "u/m = unmerged/merged.\nsubmit_us = CPU enqueue cost per call; "
+        "solo_ms = isolated submit+complete latency;\nb2b_GBps = pipelined "
+        "back-to-back throughput; triton_solo (ms) shown below the "
+        f"{THRESHOLD_BYTES // KiB}KiB\nfast-path threshold for reference."
+    )
+
+
+def run_crossover(n_values: list[int], max_kib: int) -> None:
+    stream = torch.cuda.Stream()
+    page_sizes = list(range(4 * KiB, max_kib * KiB + 1, 4 * KiB))
+    header = "page".rjust(8)
+    for n in n_values:
+        header += f" | DMA n={n}".rjust(13) + "Triton".rjust(10) + "win".rjust(5)
+    print(header)
+    print("-" * len(header))
+    for ps in page_sizes:
+        chunk = min(triton.next_power_of_2(ps), 8192)
+        row = f"{ps // KiB:>6}KB"
+        for n in n_values:
+            host, dev, src, dst, sizes, page_idx = _make_batch(n, ps)
+            sa, da, sz = _to_pinned(src), _to_pinned(dst), _to_pinned(sizes)
+            with torch.cuda.stream(stream):
+                dev.zero_()
+                _triton_call(sa, da, sz, chunk)
+            stream.synchronize()
+            _verify_copied_pages(host, dev, page_idx, ps)
+            with torch.cuda.stream(stream):
+                dma = _solo_ms(partial(_dma_call, sa, da, sz), stream)
+                tri = _solo_ms(partial(_triton_call, sa, da, sz, chunk), stream)
+            win = "T" if tri < dma else "D"
+            row += f" | {dma * 1e3:>9.0f}us{tri * 1e3:>8.0f}us{win:>5}"
+            del host, dev
+        print(row)
+    print(f"\n(threshold={THRESHOLD_BYTES / KiB:g}KiB, min_n={MIN_N}, sms={NUM_SMS})")
+
+
+def main() -> None:
+    if not torch.cuda.is_available():
+        raise SystemExit("This benchmark requires CUDA.")
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--merge",
+        action="store_true",
+        help="benchmark descriptor run-coalescing on the DMA path",
+    )
+    p.add_argument(
+        "--crossover",
+        action="store_true",
+        help="sweep page size vs. batch size, mark DMA/Triton winner",
+    )
+    p.add_argument("--n", type=int, default=8192, help="descriptors for --merge")
+    p.add_argument("--n-values", type=int, nargs="+", default=[16, 256, 4096])
+    p.add_argument("--max-kib", type=int, default=64)
+    p.add_argument("--run-lengths", type=int, nargs="+", default=[1, 4, 16, 128, 8192])
+    p.add_argument("--page-kib", type=int, nargs="+", default=[8, 16, 32])
+    args = p.parse_args()
+
+    if not args.crossover and not args.merge:
+        args.merge = True
+
+    if args.merge:
+        print("=== descriptor run-coalescing on cuMemcpyBatchAsync ===")
+        run_merge(args.n, args.page_kib, args.run_lengths)
+    if args.crossover:
+        print("\n=== DMA (cuMemcpyBatchAsync) vs. Triton fast path ===")
+        run_crossover(args.n_values, args.max_kib)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/v1/kv_offload/cpu/test_merge_descriptors.py
+++ b/tests/v1/kv_offload/cpu/test_merge_descriptors.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for descriptor run-coalescing in the CPU offloading worker."""
+
+import numpy as np
+import pytest
+
+from vllm.v1.kv_offload.cpu.gpu_worker import merge_contiguous_descriptors
+
+PAGE = 8192
+
+
+def _arrays(src, dst, sizes, dtype=np.int64):
+    return (
+        np.array(src, dtype=dtype),
+        np.array(dst, dtype=dtype),
+        np.array(sizes, dtype=dtype),
+    )
+
+
+def test_fully_contiguous_run_collapses_to_one():
+    n = 16
+    src, dst, sizes = _arrays(
+        [1000 + i * PAGE for i in range(n)],
+        [5000 + i * PAGE for i in range(n)],
+        [PAGE] * n,
+    )
+    assert merge_contiguous_descriptors(src, dst, sizes) == 1
+    assert src[0] == 1000 and dst[0] == 5000 and sizes[0] == n * PAGE
+
+
+def test_per_layer_runs_merge_per_layer():
+    # Two "layers" at distant bases; blocks contiguous within each layer.
+    src, dst, sizes = _arrays(
+        [10**6 + i * PAGE for i in range(4)] + [10**9 + i * PAGE for i in range(4)],
+        [2 * 10**6 + i * PAGE for i in range(4)]
+        + [2 * 10**9 + i * PAGE for i in range(4)],
+        [PAGE] * 8,
+    )
+    assert merge_contiguous_descriptors(src, dst, sizes) == 2
+    assert list(sizes[:2]) == [4 * PAGE, 4 * PAGE]
+    assert list(src[:2]) == [10**6, 10**9]
+    assert list(dst[:2]) == [2 * 10**6, 2 * 10**9]
+
+
+def test_requires_contiguity_on_both_sides():
+    # src contiguous, dst scattered -> no merge.
+    src, dst, sizes = _arrays(
+        [i * PAGE for i in range(4)],
+        [0, 10 * PAGE, 20 * PAGE, 30 * PAGE],
+        [PAGE] * 4,
+    )
+    assert merge_contiguous_descriptors(src, dst, sizes) == 4
+    assert list(dst) == [0, 10 * PAGE, 20 * PAGE, 30 * PAGE]
+
+
+def test_scattered_descriptors_unchanged():
+    src, dst, sizes = _arrays(
+        [i * 3 * PAGE for i in range(5)],
+        [i * 7 * PAGE for i in range(5)],
+        [PAGE] * 5,
+    )
+    assert merge_contiguous_descriptors(src, dst, sizes) == 5
+
+
+def test_mixed_runs_and_variable_sizes():
+    # [a: 2 pages contiguous] [gap] [b: 3 pages contiguous with mixed sizes]
+    src, dst, sizes = _arrays(
+        [0, PAGE, 100 * PAGE, 101 * PAGE, 101 * PAGE + PAGE // 2],
+        [0, PAGE, 200 * PAGE, 201 * PAGE, 201 * PAGE + PAGE // 2],
+        [PAGE, PAGE, PAGE, PAGE // 2, PAGE // 2],
+    )
+    assert merge_contiguous_descriptors(src, dst, sizes) == 2
+    assert list(sizes[:2]) == [2 * PAGE, 2 * PAGE]
+    assert src[1] == 100 * PAGE and dst[1] == 200 * PAGE
+
+
+@pytest.mark.parametrize("dtype", [np.int64, np.uint64])
+def test_single_descriptor_and_dtypes(dtype):
+    src, dst, sizes = _arrays([123], [456], [PAGE], dtype=dtype)
+    assert merge_contiguous_descriptors(src, dst, sizes) == 1
+    src, dst, sizes = _arrays(
+        [0, PAGE, 2 * PAGE], [0, PAGE, 2 * PAGE], [PAGE] * 3, dtype=dtype
+    )
+    assert merge_contiguous_descriptors(src, dst, sizes) == 1
+    assert sizes[0] == 3 * PAGE

--- a/tests/v1/kv_offload/cpu/test_swap_blocks_triton.py
+++ b/tests/v1/kv_offload/cpu/test_swap_blocks_triton.py
@@ -29,3 +29,27 @@ def test_triton_swap_copies_source_bytes():
 
     for s, t in zip(src, dst):
         assert torch.equal(t, s)  # kernel copied the source bytes verbatim
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Triton swap fast path requires CUDA"
+)
+@pytest.mark.parametrize("gpu_to_cpu", [False, True])
+def test_triton_swap_host_device(gpu_to_cpu: bool):
+    # Production shape: one side is pinned host memory dereferenced over UVA.
+    # gpu_to_cpu=True is the store direction (kernel writes to host memory).
+    sizes = [4096, 8192, 8200, 16384, 4088] * 8
+
+    def make(device_side: bool, s: int) -> torch.Tensor:
+        t = torch.randint(256, (s,), dtype=torch.uint8, device="cpu").pin_memory()
+        return t.to("cuda") if device_side else t
+
+    src = [make(gpu_to_cpu, s) for s in sizes]
+    dst = [make(not gpu_to_cpu, s).zero_() for s in sizes]
+    sizes_t = torch.tensor(sizes, dtype=torch.int64)
+
+    swap_blocks_batch(_addrs(src), _addrs(dst), sizes_t, bytes_per_chunk=8192)
+    torch.accelerator.synchronize()
+
+    for s, t in zip(src, dst):
+        assert torch.equal(t.cpu(), s.cpu())

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -120,6 +120,48 @@ def compute_sub_block_ptrs(
     output[:] = flat[skip_count : skip_count + num_sub_blocks]
 
 
+def merge_contiguous_descriptors(
+    src: np.ndarray, dst: np.ndarray, sizes: np.ndarray
+) -> int:
+    """Coalesce descriptor runs that are contiguous in both src and dst.
+
+    cuMemcpyBatchAsync costs ~0.5us of submission CPU per descriptor
+    (measured on H100, CUDA 13 / driver 580), so a store of B blocks over
+    L layers pays B*L*0.5us before any byte moves. Consecutive blocks
+    within a layer are usually adjacent on both sides, letting runs
+    collapse to one descriptor each.
+
+    Merged descriptors are written into the arrays' prefix in place.
+
+    Args:
+        src: source byte pointers, one per descriptor.
+        dst: destination byte pointers, one per descriptor.
+        sizes: descriptor sizes in bytes.
+
+    Returns:
+        The merged descriptor count.
+    """
+    n = len(src)
+    if n <= 1:
+        return n
+    contig = (src[1:] == src[:-1] + sizes[:-1]) & (dst[1:] == dst[:-1] + sizes[:-1])
+    if not contig.any():
+        return n
+    starts = np.empty(n, dtype=bool)
+    starts[0] = True
+    np.logical_not(contig, out=starts[1:])
+    run_starts = np.flatnonzero(starts)
+    bounds = np.zeros(n + 1, dtype=sizes.dtype)
+    np.cumsum(sizes, out=bounds[1:])
+    run_ends = np.append(run_starts[1:], n)
+    merged_sizes = bounds[run_ends] - bounds[run_starts]
+    num_merged = len(run_starts)
+    src[:num_merged] = src[run_starts]
+    dst[:num_merged] = dst[run_starts]
+    sizes[:num_merged] = merged_sizes
+    return num_merged
+
+
 def pin_mmap_region(region: SharedOffloadRegion) -> None:
     """Register the entire mmap as CUDA pinned memory via cudaHostRegister."""
     if not current_platform.is_cuda_alike():
@@ -218,6 +260,10 @@ class SingleDirectionOffloadingHandler:
         self._swap_blocks_batch = _select_swap_blocks_fn(
             kv_cache_groups_data_refs, gpu_to_cpu
         )
+        # Merging only pays on the DMA path, where submission cost scales
+        # with descriptor count. The Triton kernel parallelizes across
+        # descriptors, so merging could shrink its grid below NUM_SMS.
+        self._merge_descriptors = self._swap_blocks_batch is ops.swap_blocks_batch
 
         # GPU blocks may be smaller
         # cpu_page_size = gpu_page_size * block_size_factor.
@@ -362,6 +408,12 @@ class SingleDirectionOffloadingHandler:
         assert src_offset == num_src_blocks
         assert dst_offset == num_dst_blocks
         assert op_idx == num_copy_ops
+
+        if self._merge_descriptors and num_copy_ops > 1:
+            num_copy_ops = merge_contiguous_descriptors(all_src, all_dst, all_sizes)
+            src = src[:num_copy_ops]
+            dst = dst[:num_copy_ops]
+            sizes = sizes[:num_copy_ops]
 
         stream = (
             self._stream_pool.pop() if self._stream_pool else current_platform.Stream()


### PR DESCRIPTION
`cuMemcpyBatchAsync` costs **~0.5 µs of CPU per descriptor at submission** — more
than the copy itself below 32 KiB (6.33 ms enqueue vs 1.94 ms execution at
N=12,288, 8 KiB pages). The offloading connector submits one descriptor per
(GPU block × layer), so per-layer-KV models (gpt-oss, Gemma-3, Llama-4) pay
milliseconds of worker CPU per transfer job, and solo prefix-hit loads run
submission-bound at ~16 GB/s instead of 50+. The driver never merges adjacent
descriptors (scattered ≡ sequential, measured).

This PR coalesces descriptor runs contiguous in **both** src and dst before
submission (vectorized numpy, DMA path only — the Triton path parallelizes
across descriptors). No-op when nothing is contiguous (12–300 µs at n=8K–131K).

![enqueue cost vs execution](https://raw.githubusercontent.com/Etelis/vllm/pr-assets-desc-coalescing/assets/fig1_enqueue_cost.png)

## Microbenchmark

`benchmarks/kernels/benchmark_swap_blocks_batch.py --merge` (file also fixed:
stale pre-#42212 imports, and DMA was timed on the legacy stream = the
per-copy fallback). H100 PCIe Gen5, n=8192 descriptors, unmerged → merged:

| page | run len | submit µs | solo ms | b2b GB/s |
|---:|---:|---:|---:|---:|
| 8K | 1 | 5153 → 5114 | 10.3 → 10.6 | 12.5 → 15.2 |
| 8K | 16 | 5063 → 270 | 10.0 → 1.49 | 15.0 → 54.1 |
| 8K | 128 | 5006 → 37 | 13.3 → 1.25 | 13.7 → 55.1 |
| 32K | 16 | 4206 → 266 | 9.08 → 5.12 | 50.9 → 55.1 |

![solo latency vs run length](https://raw.githubusercontent.com/Etelis/vllm/pr-assets-desc-coalescing/assets/fig2_solo_latency.png)
![pipelined throughput vs run length](https://raw.githubusercontent.com/Etelis/vllm/pr-assets-desc-coalescing/assets/fig3_b2b_throughput.png)

## End-to-end

gpt-oss-20b (per-layer 32 KiB pages), 1× H100, `--no-enable-prefix-caching`;
96 unique 4K-token prompts seeded, then replayed so prefixes load from the CPU
tier. 3 separate-boot reps, median [min, max]:

| phase | metric | unmerged | merged | Δ |
|---|---|---:|---:|---:|
| replay, conc 32 | req/s | 33.4 [32.4, 34.2] | 36.1 [35.6, 36.3] | **+8.1%** |
| replay, conc 32 | mean TTFT | 526 [513, 548] ms | 435 [426, 439] ms | **−17.3%** |
| replay, conc 32 | P99 TTFT | 587 [579, 643] ms | 537 [499, 557] ms | **−8.5%** |
| replay, conc 4 | req/s | 6.47 | 6.36 | ~0 |

Load submission 1.71 → 0.09 ms/job, load bandwidth 37–42 → 53.5 GB/s; stores
unchanged (~50 GB/s — chained stores already pipeline their submission).
Qwen2.5-0.5B (8 KiB regime): descriptors/job 8,137 → 34, submit CPU
4.23 → 0.06 ms/job; throughput unchanged.

![e2e replay comparison](https://raw.githubusercontent.com/Etelis/vllm/pr-assets-desc-coalescing/assets/fig4_e2e.png)
