### PR TITLE
[KV Offload] Bypass power-of-2 rounding in KV offload CPU pinned allocation

### DIFF
--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -498,12 +498,24 @@ class CPUOffloadingWorker(OffloadingWorker):
                 cpu_tensor = mmap_region.create_next_view(cpu_page_size_bytes)
             else:
                 t0 = time.monotonic()
+                # Allocate non-pinned first, then pin via cudaHostRegister to
+                # bypass PyTorch's CUDACachingHostAllocator which rounds up to
+                # the next power of 2 (e.g. 100 GB -> 128 GB).
                 cpu_tensor = torch.zeros(
                     (num_cpu_blocks, cpu_page_size_bytes),
                     dtype=torch.int8,
                     device="cpu",
-                    pin_memory=pin_memory,
                 )
+                if pin_memory:
+                    result = torch.cuda.cudart().cudaHostRegister(
+                        cpu_tensor.data_ptr(), cpu_tensor.nbytes, 0
+                    )
+                    if result.value != 0:
+                        logger.warning(
+                            "cudaHostRegister failed (code=%d) — transfers "
+                            "will still work but may be slower (unpinned DMA)",
+                            result,
+                        )
                 logger.debug(
                     "torch.zeros pinned tensor %d×%d (%.2f GB): %.3f s",
                     num_cpu_blocks,


### PR DESCRIPTION
## Purpose

PyTorch's CUDACachingHostAllocator rounds every pin_memory=True allocation up to the next power of 2 (e.g. 33 GiB -> 64 GiB). In CPUOffloadingWorker this caused each TP worker to allocate far more host memory than requested when kv_offloading_size was not an exact power of 2 per rank.

Fix: allocate non-pinned first, then pin via cudaHostRegister to bypass the caching allocator, matching what SimpleCPUOffloadWorker already does.

## Test Plan

* Manually verified RSS profile with TP=2 and `--kv-offloading-size 64`/`--kv-offloading-size 80` before and after the fix. Before, `--kv-offloading-size 64` would cause per-worker RSS of ~35GB (32GB + 3), and `--kv-offloading-size 80` would cause per-worker RSS of ~67GB (64GB + 3)
* Automated a probing sequence deliberately designed to evict and fetch from external cache and measuring the hits

## Test Result

* After the fix, `--kv-offloading-size 80` causes per-worker RSS of ~43GB, exactly in line with the expected 40GB + 3
* External cache still works as expected after the fix

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

