### PR TITLE
fix(lora): validate LoRA rank is positive in PEFTHelper

### DIFF
--- a/tests/lora/test_peft_helper.py
+++ b/tests/lora/test_peft_helper.py
@@ -22,6 +22,8 @@ ERROR_CASES = [
         {"modules_to_save": ["lm_head"]},
         "only supports modules_to_save being None",
     ),
+    ("test_rank_zero", {"r": 0}, "must be a positive integer"),
+    ("test_rank_negative", {"r": -8}, "must be a positive integer"),
 ]
 
 
@@ -97,3 +99,18 @@ def test_peft_helper_error(
         PEFTHelper.from_local_dir(
             test_dir, max_position_embeddings=4096
         ).validate_legal(lora_config)
+
+
+@pytest.mark.parametrize("bad_rank", [0, -1, -8])
+def test_peft_helper_invalid_rank_direct(bad_rank: int):
+    """Regression test: constructing a PEFTHelper with a non-positive rank
+    must raise a clear ValueError instead of crashing with an unrelated
+    ZeroDivisionError (r=0) or silently succeeding with a sign-flipped
+    scaling factor that validate_legal() never catches (r<0, since its only
+    rank check is the upper bound against max_lora_rank).
+
+    Network-free: constructs PEFTHelper directly rather than going through
+    from_local_dir(), which needs an on-disk adapter_config.json.
+    """
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        PEFTHelper(r=bad_rank, lora_alpha=16, target_modules=["q_proj"])

--- a/vllm/lora/peft_helper.py
+++ b/vllm/lora/peft_helper.py
@@ -51,6 +51,10 @@ class PEFTHelper:
         return error_msg
 
     def __post_init__(self):
+        if self.r <= 0:
+            raise ValueError(
+                f"LoRA rank `r` must be a positive integer, got {self.r}."
+            )
         if self.use_rslora:
             logger.info_once("Loading LoRA weights trained with rsLoRA.")
             self.vllm_lora_scaling_factor = self.lora_alpha / math.sqrt(self.r)

--- a/vllm/lora/peft_helper.py
+++ b/vllm/lora/peft_helper.py
@@ -52,9 +52,7 @@ class PEFTHelper:
 
     def __post_init__(self):
         if self.r <= 0:
-            raise ValueError(
-                f"LoRA rank `r` must be a positive integer, got {self.r}."
-            )
+            raise ValueError(f"LoRA rank `r` must be a positive integer, got {self.r}.")
         if self.use_rslora:
             logger.info_once("Loading LoRA weights trained with rsLoRA.")
             self.vllm_lora_scaling_factor = self.lora_alpha / math.sqrt(self.r)


### PR DESCRIPTION
## Problem

`PEFTHelper.__post_init__` computes `vllm_lora_scaling_factor` as `lora_alpha / r` (or `lora_alpha / sqrt(r)` for rsLoRA) without checking that `r` is positive. `r` comes straight from an adapter's `adapter_config.json`, parsed before `validate_legal()` -- the class's own intended validation gate, called right after construction by `LoRAWorkerManager._load_adapter` -- ever runs.

Two failure modes:

- `r == 0` raises an unrelated `ZeroDivisionError` out of the dataclass constructor, before `validate_legal()` gets a chance to reject it cleanly -- a malformed adapter turns into an internal crash instead of a clean error.
- `r < 0` raises nothing at all: it silently computes a negative scaling factor, and `validate_legal()`'s only rank check is the upper bound (`r > max_lora_rank`), so a negative-rank adapter passes validation clean and gets loaded with a sign-flipped scaling factor.

Repro:
```python
from vllm.lora.peft_helper import PEFTHelper
from vllm.config.lora import LoRAConfig

PEFTHelper(r=0, lora_alpha=16, target_modules=['q_proj'])
# ZeroDivisionError: division by zero

p = PEFTHelper(r=-5, lora_alpha=16, target_modules=['q_proj'])
p.validate_legal(LoRAConfig(max_lora_rank=16, max_cpu_loras=3, max_loras=2))
# no exception!
print(p.vllm_lora_scaling_factor)  # -3.2, silently wrong, never rejected
```

## Fix

Reject `r <= 0` with a clear `ValueError` before it reaches the division.

## Testing

Added `test_peft_helper_invalid_rank_direct` (network-free, parametrized over `r=0/-1/-8`) directly exercising `PEFTHelper.__init__`. Verified against both unpatched vllm (`r=0` raises `ZeroDivisionError`, `r=-1`/`r=-8` raise nothing) and the patched version (all three raise the intended `ValueError`); confirmed `r=8` still computes the correct scaling factor (2.0), unaffected.

Also added two `ERROR_CASES` entries (`r=0`, `r=-8`) to the existing HF-fixture-based `test_peft_helper_error`, matching the file's pattern for other invalid-config cases -- covers the same fix through the `from_local_dir()` loading path.