### PR TITLE
Re-disable CUDA graph memory profiling on ROCm

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -492,14 +492,11 @@ class Worker(WorkerBase):
             )
 
             # Profile CUDA graph memory if graphs will be captured.
-            # ROCm is included: #44825 moved the profiler to
-            # torch.accelerator.get_memory_info (reliable on ROCm, as used by
-            # the AMD-CI mem tests), and graph_pool_handle resolves to the same
-            # torch.cuda handle the live capture path already uses on ROCm.
-            # XPU stays excluded (see #39977).
+            # Skip on ROCm/HIP/XPU as graph pool handles and get_memory_info
+            # behave differently and can produce incorrect/negative estimates.
             cudagraph_memory_estimate = 0
             if (
-                current_platform.is_cuda_alike()
+                current_platform.is_cuda()
                 and self.vllm_config.compilation_config.cudagraph_mode
                 != CUDAGraphMode.NONE
             ):
@@ -515,7 +512,8 @@ class Worker(WorkerBase):
             + profile_result.weights_memory
         )
 
-        # Respect the opt-in flag as originally designed.
+        # On ROCm, cudagraph_memory_estimate is always 0 so this is a no-op.
+        # On CUDA, respect the opt-in flag as originally designed.
         cudagraph_memory_estimate_applied = (
             cudagraph_memory_estimate
             if envs.VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS


### PR DESCRIPTION
Reverts the `vllm/v1/worker/gpu_worker.py` change from #47366, restoring the pre-#47366 `is_cuda()` gate so ROCm skips cudagraph memory profiling. On ROCm the profiling capture regresses steady-state decode throughput. #47366's test-side fix (`wait_for_rocm_memory_to_settle`) is retained.

AI assistance (Claude) was used to prepare this PR.
