### PR TITLE
[Bugfix][ROCm] Keep TP all_gather on base-class collective

### DIFF
--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -352,6 +352,14 @@ class CudaCommunicator(DeviceCommunicatorBase):
         if pynccl_comm is None or pynccl_comm.disabled:
             return super().all_gather(input_, dim)
 
+        # On ROCm, the base-class all_gather (all_gather_into_tensor) is faster
+        # than the manual pynccl + torch.empty + movedim + reshape path below,
+        # which adds a per-call output allocation and (for dim != 0) an extra
+        # copy on every step. This is on the hot path for TP forward passes, so
+        # keep ROCm on the base-class collective to avoid a decode regression.
+        if current_platform.is_rocm():
+            return super().all_gather(input_, dim)
+
         input_size = input_.size()
         output_size = (input_size[0] * self.world_size,) + input_size[1:]
         output_tensor = torch.empty(


### PR DESCRIPTION
## Summary

PR #40996 (DCP supports hybrid attention) changed `CudaCommunicator.all_gather` to bypass the base-class collective (`all_gather_into_tensor`) and instead run an inline pynccl path that allocates a fresh output tensor with `torch.empty` and then does `movedim` + `reshape` on every call:

https://github.com/vllm-project/vllm/blob/main/vllm/distributed/device_communicators/cuda_communicator.py

This is on the hot path for every tensor-parallel `all_gather` (e.g. sequence-parallel gather-before-GEMM), so it runs on every step.

On **ROCm** the inline path is slower than the base-class collective: the extra per-call output allocation and (for `dim != 0`) an extra copy add measurable per-step overhead. On DeepSeek-V4 with TP=8 this regresses decode throughput by ~22%.

This PR routes ROCm back to the base-class `all_gather` while leaving the CUDA / NVLS symmetric-memory path untouched. DCP itself is unaffected because it uses its own process group, not this method.

## Measurements

DeepSeek-V4, MI355X, TP=8, fp8 KV, 8k input / 1k output, concurrency 4 (mean TPOT):

| Build | mean TPOT |
|---|---|
| Before #40996 | 26.4 ms |
| After #40996 (current main) | 32.5 ms |
| With this fix | 26.4 ms |

Bisected to a single file: reverting only `cuda_communicator.py` to the pre-#40996 version restores the baseline, and this targeted ROCm guard reproduces that recovery on top of the full current tree.

## Test plan

- [x] CI (distributed / TP tests)
- [x] DeepSeek-V4 TP=8 decode throughput restored to pre-#40996 baseline on ROCm (MI355X)
- [x] Confirm no change on CUDA (path is unchanged for non-ROCm)

cc @vllm-project maintainers of #40996

Made with [Cursor](https://cursor.com)