### PR TITLE
Revert "[Bugfix] Guard mixed-dtype allreduce RMSNorm quant fusions" (#48330)

### DIFF
--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -222,25 +222,6 @@ class TestAllReduceRMSNormStaticQuantFP8Model(torch.nn.Module):
         ]
 
 
-class TestAllReduceGemmaRMSNormStaticQuantFP8Model(
-    TestAllReduceRMSNormStaticQuantFP8Model
-):
-    def __init__(
-        self,
-        hidden_size=16,
-        token_num=16,
-        eps=1e-6,
-        dtype: torch.dtype = torch.float16,
-    ):
-        super().__init__(hidden_size, token_num, eps, dtype)
-        self.norm = [GemmaRMSNorm(hidden_size, eps) for _ in range(4)]
-        for norm in self.norm:
-            norm.weight.requires_grad_(False)
-
-    def ops_in_model_before(self):
-        return [torch.ops.vllm.all_reduce.default]
-
-
 class TestAiterAllReduceRMSNormGroupQuantFP8Model(torch.nn.Module):
     """Exercises the new ROCm AITER AR+RMS+per-group-FP8-quant patterns.
 
@@ -428,15 +409,6 @@ class TestAllReduceFusedAddRMSNormStaticQuantFP4Model(torch.nn.Module):
         ),
         pytest.param(
             TestAllReduceRMSNormStaticQuantFP8Model,
-            True,
-            False,
-            marks=pytest.mark.skipif(
-                current_platform.is_rocm(),
-                reason="Not supported on ROCm platform",
-            ),
-        ),
-        pytest.param(
-            TestAllReduceGemmaRMSNormStaticQuantFP8Model,
             True,
             False,
             marks=pytest.mark.skipif(
@@ -634,10 +606,7 @@ def all_reduce_fusion_pass_on_test_model(
         )
         backend.check_before_ops(model.ops_in_model_before(), fully_replaced=False)
         backend.check_after_ops(model.ops_in_model_after())
-        if test_model_cls in (
-            TestAllReduceGemmaRMSNormModel,
-            TestAllReduceGemmaRMSNormStaticQuantFP8Model,
-        ):
+        if test_model_cls is TestAllReduceGemmaRMSNormModel:
             fused_op = torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm.default
             fused_nodes = list(find_op_nodes(fused_op, backend.graph_post_pass))
             assert fused_nodes

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -752,12 +752,7 @@ class AllReduceFusedAddRMSNormStaticQuantFP8Pattern(BasePattern):
             return allreduce[4], allreduce[2]
 
         pm.register_replacement(
-            pattern,
-            replacement,
-            self.get_inputs(),
-            pm.fwd_only,
-            pm_pass,
-            extra_check=_norm_input_weight_dtype_match,
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
         )
 
 
@@ -946,12 +941,7 @@ class AllReduceFusedAddRMSNormStaticQuantNVFP4Pattern(BasePattern):
             return allreduce[4], allreduce[2], allreduce[5]
 
         pm.register_replacement(
-            pattern,
-            replacement,
-            self.get_inputs(),
-            pm.fwd_only,
-            pm_pass,
-            extra_check=_norm_input_weight_dtype_match,
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
         )
 
 


### PR DESCRIPTION
## Revert of #48330

This reverts commit 5f8e73cb8b8d41f7a2a5168cddf5b772888fa991.

**Original PR:** https://github.com/vllm-project/vllm/pull/48330
**Failure count:** 1 new failure linked to this PR
**Build:** https://buildkite.com/vllm/ci/builds/77712

### Failed tests
- Distributed Compile Unit Tests (2xH100) — `all_reduce_fusion_pass.matched_count=0` (expected 4), 36 test cases failed

### Root cause
PR #48330 modified `allreduce_rms_fusion.py` and `test_fusion_all_reduce.py`. After merge, the all-reduce fusion pass no longer matches any patterns in the MNNVL and non-MNNVL test configurations, causing assertion failures.

---
*Auto-generated by CI failure analyzer*