### PR TITLE
[Bugfix][UT]Fix EagleMiniCPMForCausalLM meet TypeError

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1513,7 +1513,7 @@ _SPECULATIVE_DECODING_EXAMPLE_MODELS = {
         tokenizer="meta-llama/Llama-4-Scout-17B-16E-Instruct",
     ),
     "EagleMiniCPMForCausalLM": _HfExamplesInfo(
-        "openbmb/MiniCPM-1B-sft-bf16",
+        "openbmb/MiniCPM-2B-sft-bf16",
         trust_remote_code=True,
         speculative_model="openbmb/MiniCPM-2B-sft-bf16",
         speculative_method="eagle",

--- a/vllm/model_executor/models/minicpm_eagle.py
+++ b/vllm/model_executor/models/minicpm_eagle.py
@@ -70,6 +70,9 @@ class EagleMiniCPMDecoderLayer(nn.Module):
         self.quant_config = quant_config
         self.hidden_size = config.hidden_size
         self.max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
+        self.mup_denominator = getattr(
+            config, "mup_denominator", config.num_hidden_layers
+        )
         self.prefix = prefix
         self._init_attn_block()
         self._init_ffn_block()
@@ -125,7 +128,7 @@ class EagleMiniCPMDecoderLayer(nn.Module):
             hidden_states=hidden_states,
         )
         hidden_states = residual + hidden_states * (
-            self.config.scale_depth / math.sqrt(self.config.mup_denominator)
+            self.config.scale_depth / math.sqrt(self.mup_denominator)
         )
 
         # Fully Connected
@@ -133,7 +136,7 @@ class EagleMiniCPMDecoderLayer(nn.Module):
         hidden_states = self.post_attention_layernorm(hidden_states)
         hidden_states = self.mlp(hidden_states)
         hidden_states = residual + hidden_states * (
-            self.config.scale_depth / math.sqrt(self.config.mup_denominator)
+            self.config.scale_depth / math.sqrt(self.mup_denominator)
         )
 
         return hidden_states, None
@@ -360,7 +363,12 @@ class EagleMiniCPMForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        if inputs_embeds is not None:
+            raise NotImplementedError(
+                f"{type(self).__name__} does not support multimodal inputs yet."
+            )
         hidden_states, hidden_states2 = self.model(input_ids, positions, hidden_states)
         hidden_states = hidden_states / self.scale_width
         hidden_states2 = hidden_states2 / self.scale_width


### PR DESCRIPTION
Fix UT
VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -sv tests/models/test_initialization.py::test_can_initialize_large_subset[EagleMiniCPMForCausalLM] meet TypeError: EagleMiniCPMForCausalLM.forward() got an unexpected keyword argument 'inputs_embeds'

Root cause:
1. The fixture paired target MiniCPM-1B-sft-bf16 (hidden 1536) with draft MiniCPM-2B-sft-bf16 (hidden 2304).
2. Missing inputs_embeds argument.
3.  Missing mup denominator config attr.

Verified on CUDA and XPU platforms. 
