### PR TITLE
[Bugfix] Bound Responses API in-memory store

### DIFF
--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import asyncio
+from collections import deque
 from contextlib import AsyncExitStack
 from unittest.mock import MagicMock
 
@@ -11,6 +13,7 @@ from openai.types.responses import (
     ResponseReasoningItem,
     ResponseReasoningTextDeltaEvent,
     ResponseReasoningTextDoneEvent,
+    ResponseStatus,
     ResponseTextConfig,
     ResponseTextDeltaEvent,
 )
@@ -152,6 +155,102 @@ def test_extract_tool_types(monkeypatch: pytest.MonkeyPatch) -> None:
         "auto",
         "code_interpreter",
         "web_search_preview",
+    }
+
+
+def _make_stored_response(
+    response_id: str, status: ResponseStatus
+) -> ResponsesResponse:
+    request = ResponsesRequest(request_id=response_id, input="test")
+    sampling_params = SamplingParams(max_tokens=1)
+    return ResponsesResponse.from_request(
+        request=request,
+        sampling_params=sampling_params,
+        model_name="test-model",
+        created_time=0,
+        output=[],
+        status=status,
+    )
+
+
+@pytest.fixture
+def bounded_response_store() -> OpenAIServingResponses:
+    serving = object.__new__(OpenAIServingResponses)
+    serving.max_store_entries = 2
+    serving.response_store = {}
+    serving.response_store_lock = asyncio.Lock()
+    serving.msg_store = {}
+    serving.event_store = {}
+    return serving
+
+
+@pytest.mark.asyncio
+async def test_response_store_evicts_related_state(
+    bounded_response_store: OpenAIServingResponses,
+) -> None:
+    for response_id in ("response-1", "response-2", "response-3"):
+        bounded_response_store.msg_store[response_id] = []
+        bounded_response_store.event_store[response_id] = (
+            deque(),
+            asyncio.Event(),
+        )
+        await bounded_response_store._store_response(
+            _make_stored_response(response_id, "completed")
+        )
+
+    expected_ids = {"response-2", "response-3"}
+    assert set(bounded_response_store.response_store) == expected_ids
+    assert set(bounded_response_store.msg_store) == expected_ids
+    assert set(bounded_response_store.event_store) == expected_ids
+
+
+@pytest.mark.asyncio
+async def test_response_store_retrieval_refreshes_recency(
+    bounded_response_store: OpenAIServingResponses,
+) -> None:
+    await bounded_response_store._store_response(
+        _make_stored_response("response-1", "completed")
+    )
+    await bounded_response_store._store_response(
+        _make_stored_response("response-2", "completed")
+    )
+
+    response = await bounded_response_store.retrieve_responses(
+        "response-1", starting_after=None, stream=False
+    )
+    assert isinstance(response, ResponsesResponse)
+
+    await bounded_response_store._store_response(
+        _make_stored_response("response-3", "completed")
+    )
+    assert set(bounded_response_store.response_store) == {
+        "response-1",
+        "response-3",
+    }
+
+
+@pytest.mark.asyncio
+async def test_response_store_does_not_evict_active_responses(
+    bounded_response_store: OpenAIServingResponses,
+) -> None:
+    bounded_response_store.max_store_entries = 1
+    await bounded_response_store._store_response(
+        _make_stored_response("queued", "queued")
+    )
+    await bounded_response_store._store_response(
+        _make_stored_response("in-progress", "in_progress")
+    )
+    await bounded_response_store._store_response(
+        _make_stored_response("completed-1", "completed")
+    )
+    await bounded_response_store._store_response(
+        _make_stored_response("completed-2", "completed")
+    )
+
+    assert set(bounded_response_store.response_store) == {
+        "queued",
+        "in-progress",
+        "completed-2",
     }
 
 

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -107,6 +107,8 @@ from vllm.utils.collection_utils import as_list
 
 logger = init_logger(__name__)
 
+_ACTIVE_RESPONSE_STATUSES = frozenset(("queued", "in_progress"))
+
 
 def _extract_allowed_tools_from_mcp_requests(
     tools: list[Tool],
@@ -206,11 +208,16 @@ class OpenAIServingResponses(GenerateBaseServing):
         # behavior in OpenAI's Responses API is to store the response, but
         # vLLM's default behavior is not.
         self.enable_store = envs.VLLM_ENABLE_RESPONSES_API_STORE
+        self.max_store_entries = envs.VLLM_RESPONSES_API_STORE_MAX_ENTRIES
+        if self.enable_store and self.max_store_entries <= 0:
+            raise ValueError(
+                "VLLM_RESPONSES_API_STORE_MAX_ENTRIES must be greater than 0"
+            )
         if self.enable_store:
             logger.warning_once(
-                "`VLLM_ENABLE_RESPONSES_API_STORE` is enabled. This may "
-                "cause a memory leak since we never remove responses from "
-                "the store."
+                "`VLLM_ENABLE_RESPONSES_API_STORE` is enabled. The server "
+                "will retain up to %d completed responses in memory.",
+                self.max_store_entries,
             )
 
         self.use_harmony = self.model_config.hf_config.model_type == "gpt_oss"
@@ -220,20 +227,11 @@ class OpenAIServingResponses(GenerateBaseServing):
                 "and always enable tool use."
             )
         self.enable_auto_tools = enable_auto_tools
-        # HACK(woosuk): This is a hack. We should use a better store.
-        # FIXME: If enable_store=True, this may cause a memory leak since we
-        # never remove responses from the store.
         self.response_store: dict[str, ResponsesResponse] = {}
         self.response_store_lock = asyncio.Lock()
 
-        # HACK(woosuk): This is a hack. We should use a better store.
-        # FIXME: If enable_store=True, this may cause a memory leak since we
-        # never remove messages from the store.
         self.msg_store: dict[str, list[ChatCompletionMessageParam]] = {}
 
-        # HACK(wuhang): This is a hack. We should use a better store.
-        # FIXME: If enable_store=True, this may cause a memory leak since we
-        # never remove events from the store.
         self.event_store: dict[
             str, tuple[deque[StreamingResponsesResponse], asyncio.Event]
         ] = {}
@@ -241,6 +239,45 @@ class OpenAIServingResponses(GenerateBaseServing):
         self.background_tasks: dict[str, asyncio.Task] = {}
 
         self.tool_server = tool_server
+
+    def _remove_stored_response(self, response_id: str) -> None:
+        self.response_store.pop(response_id, None)
+        self.msg_store.pop(response_id, None)
+        self.event_store.pop(response_id, None)
+
+    def _evict_stored_responses(self) -> None:
+        completed_response_ids = [
+            response_id
+            for response_id, response in self.response_store.items()
+            if response.status not in _ACTIVE_RESPONSE_STATUSES
+        ]
+        for response_id in completed_response_ids[: -self.max_store_entries]:
+            self._remove_stored_response(response_id)
+
+    async def _store_response(
+        self,
+        response: ResponsesResponse,
+        *,
+        preserve_cancelled: bool = False,
+    ) -> None:
+        async with self.response_store_lock:
+            stored_response = self.response_store.get(response.id)
+            if (
+                preserve_cancelled
+                and stored_response is not None
+                and stored_response.status == "cancelled"
+            ):
+                return
+            self.response_store.pop(response.id, None)
+            self.response_store[response.id] = response
+            self._evict_stored_responses()
+
+    async def _get_stored_response(self, response_id: str) -> ResponsesResponse | None:
+        async with self.response_store_lock:
+            response = self.response_store.pop(response_id, None)
+            if response is not None:
+                self.response_store[response_id] = response
+            return response
 
     def _effective_chat_template_kwargs(
         self, request: ResponsesRequest
@@ -371,8 +408,7 @@ class OpenAIServingResponses(GenerateBaseServing):
         # Handle the previous response ID.
         prev_response_id = request.previous_response_id
         if prev_response_id is not None:
-            async with self.response_store_lock:
-                prev_response = self.response_store.get(prev_response_id)
+            prev_response = await self._get_stored_response(prev_response_id)
             if prev_response is None:
                 return self._make_not_found_error(prev_response_id)
         else:
@@ -540,8 +576,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 status="queued",
                 usage=None,
             )
-            async with self.response_store_lock:
-                self.response_store[response.id] = response
+            await self._store_response(response)
 
             # Run the request in the background.
             if request.stream:
@@ -936,11 +971,7 @@ class OpenAIServingResponses(GenerateBaseServing):
         )
 
         if request.store:
-            async with self.response_store_lock:
-                stored_response = self.response_store.get(response.id)
-                # If the response is already cancelled, don't update it.
-                if stored_response is None or stored_response.status != "cancelled":
-                    self.response_store[response.id] = response
+            await self._store_response(response, preserve_cancelled=True)
         return response
 
     def _topk_logprobs(
@@ -1240,6 +1271,9 @@ class OpenAIServingResponses(GenerateBaseServing):
                 assert stored_response is not None
                 if stored_response.status not in ("completed", "cancelled"):
                     stored_response.status = "failed"
+                    self.response_store.pop(response_id)
+                    self.response_store[response_id] = stored_response
+                    self._evict_stored_responses()
 
     async def responses_background_stream_generator(
         self,
@@ -1280,8 +1314,7 @@ class OpenAIServingResponses(GenerateBaseServing):
         | ResponsesResponse
         | AsyncGenerator[StreamingResponsesResponse, None]
     ):
-        async with self.response_store_lock:
-            response = self.response_store.get(response_id)
+        response = await self._get_stored_response(response_id)
 
         if response is None:
             return self._make_not_found_error(response_id)
@@ -1312,6 +1345,9 @@ class OpenAIServingResponses(GenerateBaseServing):
 
             # Update the status to "cancelled".
             response.status = "cancelled"
+            self.response_store.pop(response_id)
+            self.response_store[response_id] = response
+            self._evict_stored_responses()
 
         # Abort the request.
         if task := self.background_tasks.get(response_id):

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -236,6 +236,7 @@ if TYPE_CHECKING:
     VLLM_LOOPBACK_IP: str = ""
     VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE: bool = True
     VLLM_ENABLE_RESPONSES_API_STORE: bool = False
+    VLLM_RESPONSES_API_STORE_MAX_ENTRIES: int = 1000
     VLLM_HAS_FLASHINFER_CUBIN: bool = False
     VLLM_ROCM_FP8_MFMA_PAGE_ATTN: bool = False
     VLLM_ALLREDUCE_USE_SYMM_MEM: bool = True
@@ -1735,13 +1736,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # When set to 1, vLLM's OpenAI server will retain the input and output
     # messages for those requests in memory. By default, this is disabled (0),
     # and the "store" option is ignored.
-    # NOTE/WARNING:
-    # 1. Messages are kept in memory only (not persisted to disk) and will be
-    #    lost when the vLLM server shuts down.
-    # 2. Enabling this option will cause a memory leak, as stored messages are
-    #    never removed from memory until the server terminates.
+    # Messages are kept in memory only (not persisted to disk) and will be lost
+    # when the vLLM server shuts down.
     "VLLM_ENABLE_RESPONSES_API_STORE": lambda: bool(
         int(os.getenv("VLLM_ENABLE_RESPONSES_API_STORE", "0"))
+    ),
+    # Maximum number of completed Responses API entries to retain in memory.
+    # Active responses are not evicted and may temporarily exceed this limit.
+    "VLLM_RESPONSES_API_STORE_MAX_ENTRIES": lambda: int(
+        os.getenv("VLLM_RESPONSES_API_STORE_MAX_ENTRIES", "1000")
     ),
     # If set, use the fp8 mfma in rocm paged attention.
     "VLLM_ROCM_FP8_MFMA_PAGE_ATTN": lambda: bool(


### PR DESCRIPTION
## Purpose

  Hey! This fixes unbounded memory growth when
  `VLLM_ENABLE_RESPONSES_API_STORE=1`.

  The Responses API previously retained responses, rendered messages, and
  background streaming events for the lifetime of the server. Long-running
  servers could therefore accumulate memory until process termination.

  This change:

  - Retains at most 1,000 completed responses by default.
  - Adds `VLLM_RESPONSES_API_STORE_MAX_ENTRIES` to configure that limit.
  - Uses least-recently-used eviction, refreshing entries when retrieved or
    referenced through `previous_response_id`.
  - Protects queued and in-progress responses from eviction.
  - Removes response, message, and event state together.

  Active responses can temporarily exceed the configured limit. Once they reach
  a terminal state, normal eviction restores the bound.

  ## Duplicate-work check

  TODO before submission: GitHub issue/PR search was unavailable in the
  development environment. Please run the repository's required duplicate-work
  checks and confirm no open PR already addresses bounded Responses API storage.

  Suggested area keywords:

  - `Responses API store memory`
  - `VLLM_ENABLE_RESPONSES_API_STORE`
  - `response_store eviction`

  ## Test Plan

  ```bash
  .venv/bin/python -m pytest \
    tests/entrypoints/openai/responses/test_serving_responses.py \
    tests/test_envs.py -q

  pre-commit run --files \
    vllm/envs.py \
    vllm/entrypoints/openai/responses/serving.py \
    tests/entrypoints/openai/responses/test_serving_responses.py

  pre-commit run mypy-3.12 --hook-stage manual --files \
    vllm/envs.py \
    vllm/entrypoints/openai/responses/serving.py \
    tests/entrypoints/openai/responses/test_serving_responses.py

  The repository-wide pytest suite was also attempted.

  ## Test Result

  - Relevant tests: 76 passed, 1 pre-existing xfailed.
  - Ruff check and formatting passed.
  - Mypy for Python 3.10 and 3.12 passed.
  - All applicable pre-commit hooks passed.
  - Full-suite collection found 63,036 tests but stopped with 134 unrelated
    environment/platform collection errors and 62 skips. This macOS ARM64 host
    cannot install the complete Linux-oriented test dependency set or load the
    GPU accelerator extensions.

  No model evaluation was run because this change only affects in-memory
  Responses API lifecycle management, not inference output or accuracy.
