### PR TITLE
Re-enable DBO accuracy test on Blackwell

### DIFF
--- a/tests/v1/distributed/test_dbo.py
+++ b/tests/v1/distributed/test_dbo.py
@@ -9,22 +9,10 @@ correctly with the DeepSeek-V2-Lite model using GSM8K evaluation.
 """
 
 import pytest
-import torch
 
 from tests.evals.gsm8k.gsm8k_eval import evaluate_gsm8k
 from tests.utils import RemoteOpenAIServer
 from vllm.utils.import_utils import has_deep_ep
-
-# Detect Blackwell / B200 (compute capability 10.x)
-try:
-    if torch.cuda.is_available():
-        cap = torch.cuda.get_device_capability(0)
-        IS_BLACKWELL = cap[0] >= 10
-    else:
-        IS_BLACKWELL = False
-except Exception:
-    # Be conservative: if we can't detect, don't xfail by default
-    IS_BLACKWELL = False
 
 MODEL_NAME = "deepseek-ai/DeepSeek-V2-Lite-Chat"
 DP_SIZE = 2
@@ -47,13 +35,6 @@ DEEPEP_BACKENDS = [
 
 @pytest.mark.skipif(not has_deep_ep(), reason="These tests require deep_ep to run")
 @pytest.mark.parametrize("all2all_backend", DEEPEP_BACKENDS)
-@pytest.mark.xfail(
-    IS_BLACKWELL,
-    reason=(
-        "Temporary: DBO accuracy unstable on Blackwell "
-        "(doesn't meet expectation of MIN_ACCURACY = 0.62)"
-    ),
-)
 def test_dbo_dp_ep_gsm8k(all2all_backend: str, num_gpus_available):
     """
     Test DBO with DP+EP using GSM8K evaluation.


### PR DESCRIPTION

  ## Summary

  This removes the temporary Blackwell xfail from the DP+EP dual batch
  overlap accuracy test.

  The exemption currently covers both DeepEP backends, so the existing B200
  job treats any GSM8K accuracy regression as expected. Removing it restores
  the same minimum-accuracy assertion already enforced on other supported
  accelerators.

  The associated Blackwell detection and `torch` import are also removed
  because they are no longer needed.

  ## Why now?

  The xfail was introduced as a temporary workaround for unstable B200
  accuracy. The DBO and DeepEP synchronization paths have changed materially
  since then, while the non-strict exemption has remained in place.

  The existing 2xB200 CI job is the appropriate place to validate both:

  - `deepep_low_latency`
  - `deepep_high_throughput`

  I'd especially appreciate confirmation from that job. If either backend
  still misses the threshold, the backend-specific accuracy result will give
  us actionable evidence for a narrower follow-up.

  ## Duplicate work

  I checked the local repository history and found no later commit removing
  or narrowing this exemption.

  Upstream GitHub duplicate searches must be completed before submission
  because GitHub CLI access was unavailable in the development environment.

  ## Testing

  - `.venv/bin/python -m pytest tests/v1/distributed/test_dbo.py -v`
    - 2 skipped locally: DeepEP/B200 hardware unavailable
  - `.venv/bin/python -m pytest tests/v1/attention/test_attention_splitting.py -k 'prefill_split_across_ubatches' -v`
    - 2 passed
  - `.venv/bin/pre-commit run`
    - passed
  - `.venv/bin/pre-commit run ruff-check --all-files`
    - passed
  - `.venv/bin/pre-commit run mypy-3.12 --all-files --hook-stage manual`
    - passed
  - `.venv/bin/python -m pytest`
    - collection could not complete on macOS/Apple Silicon
    - 2,003 tests discovered with 32 unrelated collection errors from missing
      optional dependencies, compiled CUDA operators, and distributed-launch
      environment variables

  ## Model evaluation

  This is a test-only change and does not alter model output. The existing
  GSM8K evaluation could not run locally because it requires two supported
  GPUs and DeepEP. The 2xB200 CI job is required for final evaluation.
