### PR TITLE
[AMD] Fix ROCm TRITON_ATTN OOM in eagle_correctness_heavy

### DIFF
--- a/tests/v1/e2e/spec_decode/test_spec_decode.py
+++ b/tests/v1/e2e/spec_decode/test_spec_decode.py
@@ -445,7 +445,9 @@ def _run_eagle_correctness(
         # keep the default gpu_memory_utilization.
         gpu_memory_utilization_kwargs = (
             {"gpu_memory_utilization": 0.85}
-            if attn_backend == "TRITON_ATTN" and "Llama-4-Scout" in model_name
+            if current_platform.is_rocm()
+            and attn_backend == "TRITON_ATTN"
+            and "Llama-4-Scout" in model_name
             else {}
         )
 

--- a/tests/v1/e2e/spec_decode/test_spec_decode.py
+++ b/tests/v1/e2e/spec_decode/test_spec_decode.py
@@ -436,11 +436,25 @@ def _run_eagle_correctness(
         max_model_len = 2048
         max_num_batched_tokens = 128 if enable_chunked_prefill else max_model_len
 
+        # TODO(peizhang56, akaratza): Remove once
+        # https://github.com/vllm-project/vllm/issues/48453 is resolved.
+        # TRITON_ATTN graph capture has a large fixed VRAM overhead that the
+        # ROCm memory profiler does not reserve for, so the default utilization
+        # OOMs the KV cache on Llama-4-Scout. Lower it to leave room for
+        # capture. Only affects this backend/model combination; other cases
+        # keep the default gpu_memory_utilization.
+        gpu_memory_utilization_kwargs = (
+            {"gpu_memory_utilization": 0.85}
+            if attn_backend == "TRITON_ATTN" and "Llama-4-Scout" in model_name
+            else {}
+        )
+
         ref_llm = LLM(
             model=model_name,
             max_model_len=max_model_len,
             tensor_parallel_size=tp_size,
             attention_config=attention_config,
+            **gpu_memory_utilization_kwargs,
         )
         evaluate_llm_for_gsm8k(
             ref_llm, expected_accuracy_threshold=expected_accuracy_threshold
@@ -468,6 +482,7 @@ def _run_eagle_correctness(
             enable_chunked_prefill=enable_chunked_prefill,
             model_impl=model_impl,
             attention_config=attention_config,
+            **gpu_memory_utilization_kwargs,
         )
         # EAGLE/EAGLE3 supports async scheduling; assert it is active by default.
         assert spec_llm.llm_engine.vllm_config.scheduler_config.async_scheduling


### PR DESCRIPTION
## Purpose

On the AMD "V1 e2e (4 GPUs)" step, `test_eagle_correctness_heavy[TRITON_ATTN-llama4_eagle]` and `[TRITON_ATTN-llama4_eagle_mm]` abort at engine init with `HSA_STATUS_ERROR_OUT_OF_RESOURCES` ("Available Free mem : 0 MB") right after CUDA graph capture. Root cause: on ROCm the memory profiler does not reserve headroom for CUDA graph capture, so the KV cache is sized using only the `(1 - gpu_memory_utilization)` slack. TRITON_ATTN graph capture on Llama-4-Scout has a large, roughly fixed ~20 GiB overhead that exceeds the default slack on MI300, so startup OOMs. ROCM_AITER_FA has a smaller capture overhead that fits, which is why the same model passes on that backend.

This PR fixes only the OOM: it lowers `gpu_memory_utilization` to 0.85 for the `TRITON_ATTN` + `Llama-4-Scout` cases so the KV pool leaves room for capture. It is scoped to that backend/model combination; other parametrizations keep the default utilization, so there is no throughput impact.

This is a temporary workaround, not the underlying fix. The proper fix - making ROCm cudagraph memory profiling reserve capture headroom without regressing throughput - is tracked separately in #48453. Once #48453 is resolved this workaround should be reverted; the `TODO(peizhang56, akaratza)` in the test references that issue.

AI assistance (Claude) was used to diagnose and implement this change. Not a duplicate: profiler-side reservation on ROCm (#47366) fixed this OOM but regressed AMD throughput ~20% and was reverted in #48440; #48440 does not re-add any OOM fix, and no open PR addresses the resulting `eagle_correctness_heavy` OOM.

## Test Plan

```
pytest -v -s v1/e2e/spec_decode/test_spec_decode.py -k "eagle_correctness_heavy"
```

Hardware: AMD MI300 (gfx942), 4 GPUs, TP=4. Run with `VLLM_WORKER_MULTIPROC_METHOD=spawn`. This is the exact command from the "V1 e2e (4 GPUs)" step in `.buildkite/test-amd.yaml`.

## Test Result

Before (with the #48440 revert in place, i.e. no profiler-side reservation on ROCm), the two `TRITON_ATTN` heavy cases fail during engine init:

```
HSA_STATUS_ERROR_OUT_OF_RESOURCES: ... Available Free mem : 0 MB
terminate called after throwing an instance of 'c10::AcceleratorError'
FAILED v1/e2e/spec_decode/test_spec_decode.py::test_eagle_correctness_heavy[TRITON_ATTN-llama4_eagle]
FAILED v1/e2e/spec_decode/test_spec_decode.py::test_eagle_correctness_heavy[TRITON_ATTN-llama4_eagle_mm]
```

After, both cases pass back to back:

```
================= 2 passed, 16 warnings =================

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

