### PR TITLE
[Bugfix] Exclude DSpark draft-model KV-cache group from core prefix-cache lookup veto

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -3281,6 +3281,10 @@ def _spec_decode_grouping_config(method="dspark", model_type=None):
         speculative_config=SimpleNamespace(
             method=method,
             use_eagle=lambda: True,
+            # Mirrors SpeculativeConfig.has_ephemeral_draft_context(): the
+            # annotation path reads it to decide whether a flagged group is
+            # also veto-exempt.
+            has_ephemeral_draft_context=lambda: method in ("dspark",),
         ),
     )
 

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -4309,3 +4309,151 @@ def test_swa_shared_prefix_reuse_under_zero_retention(monkeypatch):
     assert last_req_hit(retention=0, pin=False) == 0
     # retention=0 with the pin keeps the junction window -> reuse restored.
     assert last_req_hit(retention=0, pin=True) == 4 * block_size
+
+
+def test_eagle_group_veto_exempt_does_not_poison_other_groups():
+    """A veto-exempt eagle group (KVCacheGroupSpec.eagle_group_is_veto_exempt,
+    e.g. DSpark's draft-context group per
+    SpeculativeConfig.has_ephemeral_draft_context()) whose lookup finds zero
+    matching blocks must not zero out another group's independently
+    confirmed hit. Regular eagle groups (EAGLE/EAGLE3/MTP/DFlash without the
+    veto-exempt flag) already zero the whole request on a miss, unchanged,
+    and are covered by test_prefill_hybrid_model_eagle and friends."""
+    block_size = 16
+    kv_cache_config = KVCacheConfig(
+        num_blocks=31,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer1"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["layer2"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=2 * block_size,
+                ),
+                is_eagle_group=True,
+                eagle_group_is_veto_exempt=True,
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+    )
+    hash_fn = sha256
+
+    # 4 full blocks (64 tokens), divisible by block_size for simplicity.
+    token_ids = [i for i in range(4) for _ in range(block_size)]
+    req0 = make_request("0", token_ids, block_size, hash_fn)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    manager.allocate_slots(req0, len(token_ids), num_computed_tokens, computed_blocks)
+    block_hashes = req0.block_hashes
+    manager.free(req0)
+
+    # New request with the same tokens: normally both groups would hit.
+    # Simulate the veto-exempt group's data being unavailable (e.g. DSpark's
+    # sparse, request-specific draft KV) by evicting all of ITS cached block
+    # hashes only, leaving the full-attention group's cache untouched.
+    req1 = make_request("1", token_ids, block_size, hash_fn)
+    group1_hashes = [make_block_hash_with_group_id(h, 1) for h in block_hashes]
+    cache = manager.block_pool.cached_block_hash_to_block._cache
+    backup = {h: cache.pop(h) for h in group1_hashes if h in cache}
+    try:
+        computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    finally:
+        for h, v in backup.items():
+            cache[h] = v
+
+    # Without the fix, the veto-exempt group's total miss would zero the
+    # whole request (num_computed_tokens == 0) despite the full-attention
+    # group having real, independently-confirmed data available. The
+    # presence of a sliding-window group reserves 1 token for logprobs
+    # (max_cache_hit_length = 63), so the full-attention group's hit aligns
+    # down to 3 blocks (48 tokens), not the full 4: that reservation is
+    # orthogonal to veto-exemption and applies regardless of this fix.
+    assert num_computed_tokens == 3 * block_size
+    assert len(computed_blocks.blocks[0]) == 3
+    # The veto-exempt group itself has nothing confirmed at this boundary.
+    assert len(computed_blocks.blocks[1]) == 0
+    manager.free(req1)
+
+
+def test_non_veto_exempt_eagle_group_miss_still_zeros_whole_request():
+    """Regression test: an eagle group WITHOUT eagle_group_is_veto_exempt
+    (the default, matching EAGLE/EAGLE3/MTP/DFlash) must still zero the
+    whole request on a total miss, exactly as before this change. Identical
+    setup to test_eagle_group_veto_exempt_does_not_poison_other_groups
+    except for the flag under test."""
+    block_size = 16
+    kv_cache_config = KVCacheConfig(
+        num_blocks=31,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer1"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["layer2"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=2 * block_size,
+                ),
+                is_eagle_group=True,
+                eagle_group_is_veto_exempt=False,
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+    )
+    hash_fn = sha256
+
+    token_ids = [i for i in range(4) for _ in range(block_size)]
+    req0 = make_request("0", token_ids, block_size, hash_fn)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
+    manager.allocate_slots(req0, len(token_ids), num_computed_tokens, computed_blocks)
+    block_hashes = req0.block_hashes
+    manager.free(req0)
+
+    req1 = make_request("1", token_ids, block_size, hash_fn)
+    group1_hashes = [make_block_hash_with_group_id(h, 1) for h in block_hashes]
+    cache = manager.block_pool.cached_block_hash_to_block._cache
+    backup = {h: cache.pop(h) for h in group1_hashes if h in cache}
+    try:
+        computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    finally:
+        for h, v in backup.items():
+            cache[h] = v
+
+    assert num_computed_tokens == 0
+    assert len(computed_blocks.blocks[0]) == 0
+    assert len(computed_blocks.blocks[1]) == 0
+    manager.free(req1)

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -4334,3 +4334,151 @@ def test_swa_shared_prefix_reuse_under_zero_retention():
     assert last_req_hit(retention=0, pin=False) == 0
     # retention=0 with the pin keeps the junction window -> reuse restored.
     assert last_req_hit(retention=0, pin=True) == 4 * block_size
+
+
+def test_eagle_group_veto_exempt_does_not_poison_other_groups():
+    """A veto-exempt eagle group (KVCacheGroupSpec.eagle_group_is_veto_exempt,
+    e.g. DSpark's draft-context group per
+    SpeculativeConfig.has_ephemeral_draft_context()) whose lookup finds zero
+    matching blocks must not zero out another group's independently
+    confirmed hit. Regular eagle groups (EAGLE/EAGLE3/MTP/DFlash without the
+    veto-exempt flag) already zero the whole request on a miss, unchanged,
+    and are covered by test_prefill_hybrid_model_eagle and friends."""
+    block_size = 16
+    kv_cache_config = KVCacheConfig(
+        num_blocks=31,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer1"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["layer2"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=2 * block_size,
+                ),
+                is_eagle_group=True,
+                eagle_group_is_veto_exempt=True,
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+    )
+    hash_fn = sha256
+
+    # 4 full blocks (64 tokens), divisible by block_size for simplicity.
+    token_ids = [i for i in range(4) for _ in range(block_size)]
+    req0 = make_request("0", token_ids, block_size, hash_fn)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    manager.allocate_slots(req0, len(token_ids), num_computed_tokens, computed_blocks)
+    block_hashes = req0.block_hashes
+    manager.free(req0)
+
+    # New request with the same tokens: normally both groups would hit.
+    # Simulate the veto-exempt group's data being unavailable (e.g. DSpark's
+    # sparse, request-specific draft KV) by evicting all of ITS cached block
+    # hashes only, leaving the full-attention group's cache untouched.
+    req1 = make_request("1", token_ids, block_size, hash_fn)
+    group1_hashes = [make_block_hash_with_group_id(h, 1) for h in block_hashes]
+    cache = manager.block_pool.cached_block_hash_to_block._cache
+    backup = {h: cache.pop(h) for h in group1_hashes if h in cache}
+    try:
+        computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    finally:
+        for h, v in backup.items():
+            cache[h] = v
+
+    # Without the fix, the veto-exempt group's total miss would zero the
+    # whole request (num_computed_tokens == 0) despite the full-attention
+    # group having real, independently-confirmed data available. The
+    # presence of a sliding-window group reserves 1 token for logprobs
+    # (max_cache_hit_length = 63), so the full-attention group's hit aligns
+    # down to 3 blocks (48 tokens), not the full 4: that reservation is
+    # orthogonal to veto-exemption and applies regardless of this fix.
+    assert num_computed_tokens == 3 * block_size
+    assert len(computed_blocks.blocks[0]) == 3
+    # The veto-exempt group itself has nothing confirmed at this boundary.
+    assert len(computed_blocks.blocks[1]) == 0
+    manager.free(req1)
+
+
+def test_non_veto_exempt_eagle_group_miss_still_zeros_whole_request():
+    """Regression test: an eagle group WITHOUT eagle_group_is_veto_exempt
+    (the default, matching EAGLE/EAGLE3/MTP/DFlash) must still zero the
+    whole request on a total miss, exactly as before this change. Identical
+    setup to test_eagle_group_veto_exempt_does_not_poison_other_groups
+    except for the flag under test."""
+    block_size = 16
+    kv_cache_config = KVCacheConfig(
+        num_blocks=31,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer1"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["layer2"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=2 * block_size,
+                ),
+                is_eagle_group=True,
+                eagle_group_is_veto_exempt=False,
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+    )
+    hash_fn = sha256
+
+    token_ids = [i for i in range(4) for _ in range(block_size)]
+    req0 = make_request("0", token_ids, block_size, hash_fn)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
+    manager.allocate_slots(req0, len(token_ids), num_computed_tokens, computed_blocks)
+    block_hashes = req0.block_hashes
+    manager.free(req0)
+
+    req1 = make_request("1", token_ids, block_size, hash_fn)
+    group1_hashes = [make_block_hash_with_group_id(h, 1) for h in block_hashes]
+    cache = manager.block_pool.cached_block_hash_to_block._cache
+    backup = {h: cache.pop(h) for h in group1_hashes if h in cache}
+    try:
+        computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    finally:
+        for h, v in backup.items():
+            cache[h] = v
+
+    assert num_computed_tokens == 0
+    assert len(computed_blocks.blocks[0]) == 0
+    assert len(computed_blocks.blocks[1]) == 0
+    manager.free(req1)

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1274,6 +1274,27 @@ class SpeculativeConfig:
     def use_dspark(self) -> bool:
         return self.method == "dspark"
 
+    def has_ephemeral_draft_context(self) -> bool:
+        """Whether this method's draft-model KV-cache group is built from
+        the target model's auxiliary hidden states at generation time,
+        rather than incrementally through the draft's own attention over
+        previously-drafted tokens (EAGLE/EAGLE3/MTP).
+
+        Such a group's stored content has no request-independent, stable
+        meaning: it depends on which tokens were freshly computed by the
+        target vs. restored from cache during this specific serving
+        trajectory. A cache-hit-lookup miss on this group therefore does not
+        mean the group's data is genuinely unavailable for reuse the way it
+        does for other eagle-family groups, so it must not be treated as
+        authoritative when converging a multi-group cache-hit boundary (see
+        KVCacheGroupSpec.eagle_group_is_veto_exempt).
+
+        DFlash shares this same underlying property, but is intentionally
+        left out here: it has not been validated end to end in this PR, so
+        it is scoped to a follow-up rather than claimed for free.
+        """
+        return self.method in ("dspark",)
+
     def uses_dynamic_speculative_decoding(self) -> bool:
         return self.num_speculative_tokens_per_batch_size is not None
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1852,6 +1852,27 @@ class SpeculativeConfig:
     def use_dspark(self) -> bool:
         return self.method == "dspark"
 
+    def has_ephemeral_draft_context(self) -> bool:
+        """Whether this method's draft-model KV-cache group is built from
+        the target model's auxiliary hidden states at generation time,
+        rather than incrementally through the draft's own attention over
+        previously-drafted tokens (EAGLE/EAGLE3/MTP).
+
+        Such a group's stored content has no request-independent, stable
+        meaning: it depends on which tokens were freshly computed by the
+        target vs. restored from cache during this specific serving
+        trajectory. A cache-hit-lookup miss on this group therefore does not
+        mean the group's data is genuinely unavailable for reuse the way it
+        does for other eagle-family groups, so it must not be treated as
+        authoritative when converging a multi-group cache-hit boundary (see
+        KVCacheGroupSpec.eagle_group_is_veto_exempt).
+
+        DFlash shares this same underlying property, but is intentionally
+        left out here: it has not been validated end to end in this PR, so
+        it is scoped to a follow-up rather than claimed for free.
+        """
+        return self.method in ("dspark",)
+
     def uses_dynamic_speculative_decoding(self) -> bool:
         return self.num_speculative_tokens_per_batch_size is not None
 

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -99,6 +99,17 @@ class KVCacheCoordinator(ABC):
         self.eagle_group_ids: set[int] = {
             i for i, g in enumerate(kv_cache_config.kv_cache_groups) if g.is_eagle_group
         }
+        # Subset of eagle_group_ids whose miss must not veto the cache-hit
+        # convergence of other groups (see KVCacheGroupSpec.
+        # eagle_group_is_veto_exempt). Left empty in the "flag all groups"
+        # fallback below: per-group veto-exemption is unknown in that case,
+        # so we conservatively preserve the original all-groups-authoritative
+        # behavior.
+        self.veto_exempt_eagle_group_ids: set[int] = {
+            i
+            for i, g in enumerate(kv_cache_config.kv_cache_groups)
+            if g.is_eagle_group and g.eagle_group_is_veto_exempt
+        }
         # Conservatively fall back to flag all groups when no group is flagged.
         if use_eagle and not self.eagle_group_ids:
             self.eagle_group_ids = set(range(len(kv_cache_config.kv_cache_groups)))
@@ -512,12 +523,20 @@ class SpecGroup(NamedTuple):
     ``use_eagle`` is True iff any member group is an EAGLE/MTP group. Members
     sharing a spec are cached and looked up jointly, so the EAGLE last-block drop
     is necessarily decided for the whole spec group.
+
+    ``veto_exempt`` is True only if EVERY member group is individually
+    veto-exempt (see KVCacheGroupSpec.eagle_group_is_veto_exempt), a
+    conservative AND, since exempting a merged group's miss also exempts it
+    for any non-exempt member sharing the same spec (in practice, members
+    that merge share an identical spec and thus an identical method-level
+    veto-exemption, so this is not expected to matter).
     """
 
     spec: KVCacheSpec
     group_ids: list[int]
     manager_cls: type[SingleTypeKVCacheManager]
     use_eagle: bool
+    veto_exempt: bool = False
 
 
 class HybridKVCacheCoordinator(KVCacheCoordinator):
@@ -610,6 +629,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             manager_cls = self.single_type_managers[i].__class__
             spec = g.kv_cache_spec
             use_eagle = i in self.eagle_group_ids
+            veto_exempt = i in self.veto_exempt_eagle_group_ids
 
             # Try to find an existing group with the same spec
             for idx, group in enumerate(self.attention_groups):
@@ -618,12 +638,21 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                         "Expected same manager class for identical KV cache specs."
                     )
                     group.group_ids.append(i)
-                    if use_eagle and not group.use_eagle:
-                        self.attention_groups[idx] = group._replace(use_eagle=True)
+                    new_use_eagle = group.use_eagle or use_eagle
+                    # AND-merge: a merged group is only veto-exempt if every
+                    # member is (conservative, see SpecGroup docstring).
+                    new_veto_exempt = group.veto_exempt and veto_exempt
+                    if (
+                        new_use_eagle != group.use_eagle
+                        or new_veto_exempt != group.veto_exempt
+                    ):
+                        self.attention_groups[idx] = group._replace(
+                            use_eagle=new_use_eagle, veto_exempt=new_veto_exempt
+                        )
                     break
             else:
                 self.attention_groups.append(
-                    SpecGroup(spec, [i], manager_cls, use_eagle)
+                    SpecGroup(spec, [i], manager_cls, use_eagle, veto_exempt)
                 )
 
         assert len(self.attention_groups) > 1, (
@@ -688,6 +717,14 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         types. This converges because length monotonically decreases and is
         bounded below by 0.
 
+        A veto-exempt eagle group (SpecGroup.veto_exempt, see
+        KVCacheGroupSpec.eagle_group_is_veto_exempt) whose lookup finds
+        exactly zero matching blocks for the current candidate length is
+        left unconfirmed for this round instead of shrinking
+        ``curr_hit_length`` to 0: such a group's stored content has no
+        request-independent reuse value, so a miss from it does not mean
+        the other, independently-confirmed groups' data is unavailable.
+
         Args:
             block_hashes: The block hashes of the request.
             max_cache_hit_length: The maximum length of the cache hit.
@@ -720,8 +757,8 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         while True:
             curr_hit_length = hit_length
 
-            for idx, (spec, group_ids, manager_cls, use_eagle) in enumerate(
-                self.attention_groups
+            for idx, (spec, group_ids, manager_cls, use_eagle, veto_exempt) in (
+                enumerate(self.attention_groups)
             ):
                 first_group_id = group_ids[0]
                 # DCP/PCP shard each block's KV across ranks, so the manager's
@@ -770,6 +807,10 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                         else 1
                     ),
                 )
+                if veto_exempt and _new_hit_length == 0:
+                    # Not authoritative: leave unconfirmed for this round
+                    # rather than vetoing every other group's confirmed hit.
+                    continue
                 if drop_eagle_block:
                     eagle_verified.add(idx)
                 elif _new_hit_length < curr_hit_length:
@@ -824,7 +865,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         hit_blocks: list[list[KVCacheBlock]] = [[] for _ in range(num_groups)]
         hit_lengths: list[int] = [0] * num_groups
 
-        for spec, group_ids, manager_cls, use_eagle in self.attention_groups:
+        for spec, group_ids, manager_cls, use_eagle, _veto_exempt in self.attention_groups:
             blocks, group_hit = manager_cls.find_longest_cache_hit(
                 block_hashes=block_hashes,
                 max_length=max_cache_hit_length,

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -107,6 +107,17 @@ class KVCacheCoordinator(ABC):
         self.eagle_group_ids: set[int] = {
             i for i, g in enumerate(kv_cache_config.kv_cache_groups) if g.is_eagle_group
         }
+        # Subset of eagle_group_ids whose miss must not veto the cache-hit
+        # convergence of other groups (see KVCacheGroupSpec.
+        # eagle_group_is_veto_exempt). Left empty in the "flag all groups"
+        # fallback below: per-group veto-exemption is unknown in that case,
+        # so we conservatively preserve the original all-groups-authoritative
+        # behavior.
+        self.veto_exempt_eagle_group_ids: set[int] = {
+            i
+            for i, g in enumerate(kv_cache_config.kv_cache_groups)
+            if g.is_eagle_group and g.eagle_group_is_veto_exempt
+        }
         # Conservatively fall back to flag all groups when no group is flagged.
         if use_eagle and not self.eagle_group_ids:
             self.eagle_group_ids = set(range(len(kv_cache_config.kv_cache_groups)))
@@ -549,12 +560,20 @@ class SpecGroup(NamedTuple):
     ``use_eagle`` is True iff any member group is an EAGLE/MTP group. Members
     sharing a spec are cached and looked up jointly, so the EAGLE last-block drop
     is necessarily decided for the whole spec group.
+
+    ``veto_exempt`` is True only if EVERY member group is individually
+    veto-exempt (see KVCacheGroupSpec.eagle_group_is_veto_exempt), a
+    conservative AND, since exempting a merged group's miss also exempts it
+    for any non-exempt member sharing the same spec (in practice, members
+    that merge share an identical spec and thus an identical method-level
+    veto-exemption, so this is not expected to matter).
     """
 
     spec: KVCacheSpec
     group_ids: list[int]
     manager_cls: type[SingleTypeKVCacheManager]
     use_eagle: bool
+    veto_exempt: bool = False
 
 
 class HybridKVCacheCoordinator(KVCacheCoordinator):
@@ -680,6 +699,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             manager_cls = self.single_type_managers[i].__class__
             spec = g.kv_cache_spec
             use_eagle = i in self.eagle_group_ids
+            veto_exempt = i in self.veto_exempt_eagle_group_ids
 
             # Try to find an existing group with the same spec
             for idx, group in enumerate(self.attention_groups):
@@ -688,12 +708,21 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                         "Expected same manager class for identical KV cache specs."
                     )
                     group.group_ids.append(i)
-                    if use_eagle and not group.use_eagle:
-                        self.attention_groups[idx] = group._replace(use_eagle=True)
+                    new_use_eagle = group.use_eagle or use_eagle
+                    # AND-merge: a merged group is only veto-exempt if every
+                    # member is (conservative, see SpecGroup docstring).
+                    new_veto_exempt = group.veto_exempt and veto_exempt
+                    if (
+                        new_use_eagle != group.use_eagle
+                        or new_veto_exempt != group.veto_exempt
+                    ):
+                        self.attention_groups[idx] = group._replace(
+                            use_eagle=new_use_eagle, veto_exempt=new_veto_exempt
+                        )
                     break
             else:
                 self.attention_groups.append(
-                    SpecGroup(spec, [i], manager_cls, use_eagle)
+                    SpecGroup(spec, [i], manager_cls, use_eagle, veto_exempt)
                 )
 
         assert self.attention_groups, (
@@ -776,6 +805,14 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         types. This converges because length monotonically decreases and is
         bounded below by 0.
 
+        A veto-exempt eagle group (SpecGroup.veto_exempt, see
+        KVCacheGroupSpec.eagle_group_is_veto_exempt) whose lookup finds
+        exactly zero matching blocks for the current candidate length is
+        left unconfirmed for this round instead of shrinking
+        ``curr_hit_length`` to 0: such a group's stored content has no
+        request-independent reuse value, so a miss from it does not mean
+        the other, independently-confirmed groups' data is unavailable.
+
         Args:
             block_hashes: The block hashes of the request.
             max_cache_hit_length: The maximum length of the cache hit.
@@ -808,9 +845,13 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         while True:
             curr_hit_length = hit_length
 
-            for idx, (spec, group_ids, manager_cls, use_eagle) in enumerate(
-                self.attention_groups
-            ):
+            for idx, (
+                spec,
+                group_ids,
+                manager_cls,
+                use_eagle,
+                veto_exempt,
+            ) in enumerate(self.attention_groups):
                 first_group_id = group_ids[0]
                 # DCP/PCP shard each block's KV across ranks, so the manager's
                 # effective block size may exceed the spec's.
@@ -858,6 +899,10 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                         else 1
                     ),
                 )
+                if veto_exempt and _new_hit_length == 0:
+                    # Not authoritative: leave unconfirmed for this round
+                    # rather than vetoing every other group's confirmed hit.
+                    continue
                 if drop_eagle_block:
                     eagle_verified.add(idx)
                 elif _new_hit_length < curr_hit_length:
@@ -912,7 +957,13 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         hit_blocks: list[list[KVCacheBlock]] = [[] for _ in range(num_groups)]
         hit_lengths: list[int] = [0] * num_groups
 
-        for spec, group_ids, manager_cls, use_eagle in self.attention_groups:
+        for (
+            spec,
+            group_ids,
+            manager_cls,
+            use_eagle,
+            _veto_exempt,
+        ) in self.attention_groups:
             blocks, group_hit = manager_cls.find_longest_cache_hit(
                 block_hashes=block_hashes,
                 max_length=max_cache_hit_length,

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1723,6 +1723,9 @@ def _annotate_eagle_groups_deepseek_v4(
     for group in kv_cache_groups:
         if last_layer in group.layer_names:
             group.is_eagle_group = True
+            group.eagle_group_is_veto_exempt = (
+                spec_config.has_ephemeral_draft_context()
+            )
             break
 
 
@@ -2029,6 +2032,8 @@ def _project_kv_cache_groups_to_worker(
                 worker_layer_names,
                 group_spec,
                 is_eagle_group=group.is_eagle_group and bool(worker_layer_names),
+                eagle_group_is_veto_exempt=group.eagle_group_is_veto_exempt
+                and bool(worker_layer_names),
             )
         )
     return projected_groups

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1828,6 +1828,7 @@ def _annotate_eagle_groups(
             for spec in iter_layer_specs(group.kv_cache_spec)
         ):
             group.is_eagle_group = True
+            group.eagle_group_is_veto_exempt = spec_config.has_ephemeral_draft_context()
 
     if not use_deepseek_v4_fallback:
         return
@@ -1835,6 +1836,7 @@ def _annotate_eagle_groups(
     for group in kv_cache_groups:
         if last_layer in group.layer_names:
             group.is_eagle_group = True
+            group.eagle_group_is_veto_exempt = spec_config.has_ephemeral_draft_context()
             break
 
 
@@ -2194,6 +2196,8 @@ def _project_kv_cache_groups_to_worker(
                 worker_layer_names,
                 group_spec,
                 is_eagle_group=group.is_eagle_group and bool(worker_layer_names),
+                eagle_group_is_veto_exempt=group.eagle_group_is_veto_exempt
+                and bool(worker_layer_names),
             )
         )
     return projected_groups

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -951,6 +951,14 @@ class KVCacheGroupSpec:
     kv_cache_spec: KVCacheSpec
     # Whether this group contains EAGLE/MTP draft attention layers.
     is_eagle_group: bool = False
+    # Only meaningful when is_eagle_group is True. Whether a cache-hit-lookup
+    # miss on this eagle group is NOT authoritative and must not veto the
+    # cache-hit boundary that other (non-exempt) groups independently
+    # confirmed. See SpeculativeConfig.has_ephemeral_draft_context(): set for
+    # eagle-family methods whose draft KV has no request-independent reuse
+    # value (DSpark today), as opposed to methods like EAGLE/EAGLE3/MTP
+    # whose draft KV is genuinely, incrementally reusable.
+    eagle_group_is_veto_exempt: bool = False
 
 
 @dataclass

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -1198,6 +1198,14 @@ class KVCacheGroupSpec:
     kv_cache_spec: KVCacheSpec
     # Whether this group contains EAGLE/MTP draft attention layers.
     is_eagle_group: bool = False
+    # Only meaningful when is_eagle_group is True. Whether a cache-hit-lookup
+    # miss on this eagle group is NOT authoritative and must not veto the
+    # cache-hit boundary that other (non-exempt) groups independently
+    # confirmed. See SpeculativeConfig.has_ephemeral_draft_context(): set for
+    # eagle-family methods whose draft KV has no request-independent reuse
+    # value (DSpark today), as opposed to methods like EAGLE/EAGLE3/MTP
+    # whose draft KV is genuinely, incrementally reusable.
+    eagle_group_is_veto_exempt: bool = False
     # Whether this group is part of the externally transferable KV state.
     enable_kv_transfer: bool = True
 


### PR DESCRIPTION
Fixes #48455

### Purpose

Split out from #47891 per review feedback there: this PR is the core-only
half of that fix, the offloading connector's PR will be rebased to align
with this once it merges.

`HybridKVCacheCoordinator.find_longest_cache_hit()`
(`vllm/v1/core/kv_cache_coordinator.py`) requires every KV-cache group of a
hybrid model to independently report a nonzero hit before confirming any
prefix reuse for a request, on the GPU tier. When serving DeepSeek-V4 with
DSpark speculative decoding, the draft-model KV-cache group can never
satisfy this, so it incorrectly vetoes reuse of the target model's own
KV-cache groups (SWA, compressed C4A/C128A, indexer) even when those groups
genuinely still hold valid, resident GPU blocks for a matching prefix. A
follow-up request sharing a prefix with GPU blocks still resident from a
previous request, or a request resumed after preemption, gets treated as
having zero reusable prefix and is fully recomputed from scratch.

### What this PR changes

- `SpeculativeConfig.has_ephemeral_draft_context()` (new,
  `vllm/config/speculative.py`): a predicate on the speculative method
  itself, following the same pattern as the existing `use_dflash()` and
  `use_dspark()`. Returns `True` for `"dspark"`. Identifies methods whose
  draft-model KV-cache group is rebuilt from the target model's auxiliary
  hidden states at generation time, rather than accumulated incrementally
  through the draft's own attention (EAGLE/EAGLE3/MTP).
- `KVCacheGroupSpec.eagle_group_is_veto_exempt` (new,
  `vllm/v1/kv_cache_interface.py`): a plain boolean field, computed once
  from the predicate above wherever `is_eagle_group` is already set
  (`vllm/v1/core/kv_cache_utils.py`).
- `HybridKVCacheCoordinator.find_longest_cache_hit()`
  (`vllm/v1/core/kv_cache_coordinator.py`, the primary fix): when a
  veto-exempt eagle group reports zero hit blocks in a round, that group is
  dropped from the round instead of zeroing the whole request's confirmed
  hit length. It still participates normally in every other round,
  including any round where it reports a nonzero hit.

Neither `find_longest_cache_hit()` nor `find_longest_cache_hit_per_group()`
contains a single method-name string comparison; the exemption is derived
once from `KVCacheGroupSpec.eagle_group_is_veto_exempt` and consumed as a
plain boolean.

### `eagle_group_is_veto_exempt` does not mean "excluded from the lookup"

A veto-exempt group's hit length is still computed every round exactly like
any other group's. The exemption only changes what happens when that
computed hit length is zero: normally a zero from any group vetoes
(truncates to zero) every other group's independently confirmed hit; for a
group whose KV has no request-independent, stable meaning, a zero is not
informative about whether the target model's own groups have a real,
reusable hit, so it is left unconfirmed for that round instead of zeroing
everyone else. A nonzero hit from the same group participates in the
AND-convergence exactly like before, with no special casing.

### Why this has no downside for DSpark, unlike EAGLE/EAGLE3/MTP

EAGLE/EAGLE3/MTP's draft model runs its own causal self-attention over
tokens it has itself drafted. Once a draft token's KV is computed, it stays
valid for the rest of the request and is genuinely reusable across requests
that share a prefix.

DSpark's draft context KV works differently.
`DSparkDeepseekV4Model.precompute_and_store_context_kv`
(`vllm/models/deepseek_v4/nvidia/dspark.py`) derives each draft layer's
context KV directly from the target model's own auxiliary hidden states at
that exact decode step, and writes it into that layer's context slots. This
runs once per drafting round: the target produces real hidden states,
DSpark writes fresh context KV from them, the draft model attends over that
freshly written context to produce this round's speculative tokens, and the
next round overwrites those same slots again from the target's next hidden
states. It is a write-then-immediately-consume-within-round buffer, not an
incrementally accumulated cache. There is no window in which reusing it
would be meaningful, so this PR does not forfeit any reuse opportunity
DSpark had. It never had one to begin with.

### Scope

Two independent scope boundaries.

**Speculative method: DSpark only, DFlash is a follow-up.** DFlash's
drafter builds its context KV from the target model's auxiliary hidden
states the same way DSpark's does, so `has_ephemeral_draft_context()` could
mechanically be extended to cover `"dflash"` with a one-line change. This
PR deliberately does not do that: DFlash has not been validated end to end
in a live server (blocked on an unrelated attention-backend /
KV-cache-dtype compatibility gap for the DeepSeek-V4 target, plus a
checkpoint-architecture mismatch for the specific community DFlash
checkpoint available), so claiming the fix for DFlash here would be a claim
without evidence.

**Model architecture: the whole DeepSeek-V4 family (Flash, Pro, and any
other size variant), not size-specific.** `eagle_group_is_veto_exempt` is
only ever set inside `_annotate_eagle_groups_deepseek_v4` (pre-existing
code, `vllm/v1/core/kv_cache_utils.py`), which is itself hard-scoped to
`model_version == "deepseek_v4"`. That value is set in exactly one place,
`vllm/models/deepseek_v4/attention.py`, shared by the whole
`DeepseekV4ForCausalLM` architecture regardless of size variant. Every
other model architecture falls back to a different, pre-existing path that
flags all groups as `is_eagle_group` uniformly and never touches this new
field, so this PR has no effect there.

Live serving validation of this mechanism, via #47891 which shares the
same core fix, was on the Flash size variant.

### Testing

| Suite | Result |
|---|---|
| `tests/v1/core/test_prefix_caching.py` | included in full run below |
| `tests/v1/core/` (full directory, 2 GPUs) | 423 passed, 0 failed |

Run inside an isolated throwaway container (source `.py` tree synced over
an installed `vllm` build to avoid needing a full rebuild), on this
branch alone, with no dependency on the offloading connector changes in
#47891.
