### PR TITLE
Support partial fused MoE LoRA adapters

### DIFF
--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -362,6 +363,107 @@ def test_get_dummy_lora_warmup_rank_for_fully_sharded_moe():
     }
 
     assert manager.get_dummy_lora_warmup_rank(8) == 32
+
+
+@pytest.mark.parametrize(
+    "target_projections",
+    [
+        pytest.param({"gate_up"}, id="gate-up-only"),
+        pytest.param({"down"}, id="down-only"),
+        pytest.param({"gate_up", "down"}, id="gate-up-and-down"),
+    ],
+)
+@pytest.mark.skip_global_cleanup
+def test_stack_partial_3d_moe_lora_weights(target_projections):
+    """Omitted fused-MoE projections remain no-ops after EP slicing."""
+    module_name = "model.layers.0.mlp.experts"
+    gate_up_name = module_name + ".base_layer"
+    global_num_experts = 4
+    local_num_experts = 2
+    ep_rank = 1
+    rank = 2
+    hidden_size = 3
+    intermediate_size = 5
+
+    gate_up_a = torch.arange(
+        global_num_experts * rank * hidden_size, dtype=torch.float32
+    ).reshape(global_num_experts * rank, hidden_size)
+    gate_up_b = torch.arange(
+        intermediate_size * 2 * global_num_experts * rank,
+        dtype=torch.float32,
+    ).reshape(intermediate_size * 2, global_num_experts * rank)
+    down_a = torch.arange(
+        global_num_experts * rank * intermediate_size, dtype=torch.float32
+    ).reshape(global_num_experts * rank, intermediate_size)
+    down_b = torch.arange(
+        hidden_size * global_num_experts * rank, dtype=torch.float32
+    ).reshape(hidden_size, global_num_experts * rank)
+
+    loras = {}
+    if "gate_up" in target_projections:
+        loras[gate_up_name] = LoRALayerWeights(
+            gate_up_name, rank, rank, gate_up_a.clone(), gate_up_b.clone()
+        )
+    if "down" in target_projections:
+        loras[module_name] = LoRALayerWeights(
+            module_name, rank, rank, down_a.clone(), down_b.clone()
+        )
+
+    lora_model = LoRAModel(1, rank, loras)
+    manager = LoRAModelManager.__new__(LoRAModelManager)
+    manager.is_pooling_model = False
+    manager._is_3d_moe_model = True
+    module = SimpleNamespace(
+        global_num_experts=global_num_experts,
+        ep_rank=ep_rank,
+        w13_input_size=hidden_size,
+        w13_output_size=intermediate_size * 2,
+        w2_input_size=intermediate_size,
+        w2_output_size=hidden_size,
+        w13_lora_a_stacked=(torch.empty(1, local_num_experts, rank, hidden_size),),
+    )
+
+    manager._stack_moe_lora_weights(lora_model, module, module_name)
+
+    module_lora = lora_model.loras[module_name]
+    assert isinstance(module_lora.lora_a, list)
+    assert isinstance(module_lora.lora_b, list)
+    assert gate_up_name not in lora_model.loras
+
+    expert_start = ep_rank * local_num_experts
+    expert_end = expert_start + local_num_experts
+    expected_gate_up_a = gate_up_a.reshape(global_num_experts, rank, hidden_size)[
+        expert_start:expert_end
+    ]
+    expected_gate_up_b = (
+        gate_up_b.reshape(intermediate_size * 2, rank, global_num_experts)[
+            ..., expert_start:expert_end
+        ]
+        .permute(2, 0, 1)
+        .contiguous()
+    )
+    expected_down_a = down_a.reshape(global_num_experts, rank, intermediate_size)[
+        expert_start:expert_end
+    ]
+    expected_down_b = (
+        down_b.reshape(hidden_size, rank, global_num_experts)[
+            ..., expert_start:expert_end
+        ]
+        .permute(2, 0, 1)
+        .contiguous()
+    )
+
+    if "gate_up" not in target_projections:
+        expected_gate_up_a = torch.zeros_like(expected_gate_up_a)
+        expected_gate_up_b = torch.zeros_like(expected_gate_up_b)
+    if "down" not in target_projections:
+        expected_down_a = torch.zeros_like(expected_down_a)
+        expected_down_b = torch.zeros_like(expected_down_b)
+
+    torch.testing.assert_close(module_lora.lora_a[0], expected_gate_up_a)
+    torch.testing.assert_close(module_lora.lora_b[0], expected_gate_up_b)
+    torch.testing.assert_close(module_lora.lora_a[1], expected_down_a)
+    torch.testing.assert_close(module_lora.lora_b[1], expected_down_b)
 
 
 @pytest.mark.parametrize("device", DEVICES)

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -828,21 +828,60 @@ class LoRAModelManager:
     def _stack_moe_lora_weights(
         self, lora_model: LoRAModel, module: FusedMoE3DWithLoRA, module_name: str
     ):
-        module_lora = self._get_lora_layer_weights(lora_model, module_name)
+        gate_up_proj_lora = self._get_lora_layer_weights(
+            lora_model, module_name + ".base_layer"
+        )
+        down_proj_lora = self._get_lora_layer_weights(lora_model, module_name)
 
         # Note (gnovack) - If MOE lora weights are not split into
         # num_experts chunks, we split them here
-        if module_lora and torch.is_tensor(module_lora.lora_a):
+        if any(
+            lora is not None and torch.is_tensor(lora.lora_a)
+            for lora in (gate_up_proj_lora, down_proj_lora)
+        ):
             # Handle PEFT file format where experts.base_layer is the
             # gate_up_proj and experts is the down_proj
-            gate_up_proj_lora = self._get_lora_layer_weights(
-                lora_model, module_name + ".base_layer"
-            )
-            down_proj_lora = module_lora
-            # FIXME Edge case where LoRA is not added to gate_up_proj
-            # or down_proj
-            assert gate_up_proj_lora is not None
-            assert down_proj_lora is not None
+            reference_lora = gate_up_proj_lora or down_proj_lora
+            assert reference_lora is not None
+            assert torch.is_tensor(reference_lora.lora_a)
+            assert torch.is_tensor(reference_lora.lora_b)
+
+            # PEFT allows either fused projection to be targeted independently.
+            # Keep the wrapper's fixed two-projection layout by making an omitted
+            # projection an explicit no-op.
+            def create_zero_lora(
+                name: str, input_size: int, output_size: int
+            ) -> LoRALayerWeights:
+                num_experts = module.global_num_experts
+                rank = reference_lora.rank
+                return LoRALayerWeights(
+                    name,
+                    rank,
+                    reference_lora.lora_alpha,
+                    reference_lora.lora_a.new_zeros(num_experts * rank, input_size),
+                    reference_lora.lora_b.new_zeros(output_size, num_experts * rank),
+                    scaling=1,
+                )
+
+            if gate_up_proj_lora is None:
+                gate_up_proj_lora = create_zero_lora(
+                    module_name + ".base_layer",
+                    module.w13_input_size,
+                    module.w13_output_size,
+                )
+            if down_proj_lora is None:
+                down_proj_lora = create_zero_lora(
+                    module_name,
+                    module.w2_input_size,
+                    module.w2_output_size,
+                )
+                lora_model.loras[module_name] = down_proj_lora
+
+            assert torch.is_tensor(gate_up_proj_lora.lora_a)
+            assert torch.is_tensor(gate_up_proj_lora.lora_b)
+            assert torch.is_tensor(down_proj_lora.lora_a)
+            assert torch.is_tensor(down_proj_lora.lora_b)
+            module_lora = down_proj_lora
             if self._is_3d_moe_model:
                 local_num_experts = module.w13_lora_a_stacked[0].shape[1]
                 # The checkpoint holds weights for all global experts, but
@@ -919,6 +958,8 @@ class LoRAModelManager:
 
                 module_lora.lora_a = lora_a
                 module_lora.lora_b = lora_b
+
+            lora_model.loras.pop(module_name + ".base_layer", None)
 
     def _convert_3d_to_2d_moe_lora(
         self,


### PR DESCRIPTION
## Summary

  Hey! This fixes loading PEFT-format fused MoE adapters that target only one
  of the two fused projections.

  Previously, a down-projection-only adapter hit an unconditional assertion
  because the loader expected matching `gate_up_proj` weights. The inverse case,
  a gate/up-only adapter, was silently ignored because no entry was created for
  the fused wrapper.

  The loader now:

  - Accepts gate/up-only and down-only adapters.
  - Represents an omitted projection with zero-valued LoRA weights.
  - Preserves the wrapper's existing fixed two-projection layout.
  - Applies the existing expert-parallel slicing to both real and no-op weights.
  - Removes the redundant `base_layer` entry after consolidating the weights.

  Adapters containing both projections continue through the same stacking path.

  ## Testing

  ```bash
  .venv/bin/python -m pytest \
    tests/lora/test_lora_manager.py \
    -k stack_partial_3d_moe_lora_weights -v

  .venv/bin/pre-commit run

  .venv/bin/pre-commit run ruff-check --all-files

  .venv/bin/pre-commit run mypy-3.12 \
    --all-files --hook-stage manual

  Results:

  - Partial fused-MoE regression tests: 3 passed
  - All applicable pre-commit hooks passed
  - Repository-wide Ruff passed
  - Python 3.10 and 3.12 mypy passed

  The full pytest suite was attempted. It collected 2,003 tests before stopping
  with 32 unrelated environment/platform collection errors involving missing
  optional packages, unavailable compiled accelerator operators, and distributed
  tests requiring launcher variables.

  ## Model evaluation

  A model-level evaluation was not available on this macOS host because the
  affected path requires a supported fused-MoE accelerator environment and a
  partial 3D MoE adapter.

  The focused tests verify the exact loaded tensors, EP ownership, and no-op
  behavior for omitted projections. I'd especially appreciate CI or maintainer
  validation with a GPT-OSS/Qwen-style 3D MoE adapter under EP before merging.

  ## Duplicate-work check

  Local history contains no later fix for the partial-projection FIXME.

  The required upstream GitHub searches could not be completed because
  gh auth status reports no authenticated GitHub host. Before submission,
  please run:

  gh pr list --repo vllm-project/vllm --state open \
    --search "partial fused MoE LoRA"

  gh pr list --repo vllm-project/vllm --state open \
    --search "gate_up_proj down_proj LoRA"
