### PR TITLE
Apply current settings to Harmony continuations

### DIFF
--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -23,6 +23,7 @@ from openai.types.responses.tool import (
     Mcp,
     Tool,
 )
+from openai_harmony import ReasoningEffort, Role
 
 import vllm.envs as envs
 from vllm.entrypoints.mcp.tool_server import ToolServer
@@ -94,6 +95,91 @@ def test_serialize_message_pydantic_model_returns_dict() -> None:
     assert isinstance(serialized, dict)
     assert serialized["type"] == "raw_message_tokens"
     assert serialized["message"] == "hello"
+
+
+@pytest.mark.parametrize(
+    ("instructions", "reasoning", "expected_effort"),
+    [
+        pytest.param(
+            "new instructions",
+            {"effort": "low"},
+            ReasoningEffort.LOW,
+            id="replace",
+        ),
+        pytest.param(None, None, ReasoningEffort.MEDIUM, id="remove"),
+    ],
+)
+def test_harmony_continuation_rebuilds_preamble(
+    instructions, reasoning, expected_effort
+) -> None:
+    serving = OpenAIServingResponses.__new__(OpenAIServingResponses)
+    serving.tool_server = None
+    serving.msg_store = {}
+
+    first_request = ResponsesRequest(
+        model="test",
+        input="first question",
+        instructions="old instructions",
+        reasoning={"effort": "high"},
+    )
+    previous_messages = serving._construct_input_messages_with_harmony(
+        first_request, None
+    )
+    previous_response = MagicMock(id="resp_1", output=[])
+    serving.msg_store[previous_response.id] = previous_messages
+
+    continuation = ResponsesRequest(
+        model="test",
+        input="follow-up question",
+        instructions=instructions,
+        reasoning=reasoning,
+        previous_response_id=previous_response.id,
+    )
+    messages = serving._construct_input_messages_with_harmony(
+        continuation, previous_response
+    )
+
+    roles = [message.author.role for message in messages]
+    expected_roles = [Role.SYSTEM]
+    if instructions is not None:
+        expected_roles.append(Role.DEVELOPER)
+    expected_roles.extend([Role.USER, Role.USER])
+    assert roles == expected_roles
+    assert messages[0].content[0].reasoning_effort == expected_effort
+    if instructions is not None:
+        assert messages[1].content[0].instructions == instructions
+
+
+def test_harmony_continuation_extracts_current_input_instructions() -> None:
+    serving = OpenAIServingResponses.__new__(OpenAIServingResponses)
+    serving.tool_server = None
+    serving.msg_store = {}
+    previous_response = MagicMock(id="resp_1", output=[])
+    serving.msg_store[previous_response.id] = (
+        serving._construct_input_messages_with_harmony(
+            ResponsesRequest(model="test", input="first question"), None
+        )
+    )
+
+    continuation = ResponsesRequest(
+        model="test",
+        input=[
+            {"role": "system", "content": "current instructions"},
+            {"role": "user", "content": "follow-up question"},
+        ],
+        previous_response_id=previous_response.id,
+    )
+    messages = serving._construct_input_messages_with_harmony(
+        continuation, previous_response
+    )
+
+    assert [message.author.role for message in messages] == [
+        Role.SYSTEM,
+        Role.DEVELOPER,
+        Role.USER,
+        Role.USER,
+    ]
+    assert messages[1].content[0].instructions == "current instructions"
 
 
 @pytest.fixture

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping, Se
 from contextlib import AsyncExitStack
 from copy import copy
 from http import HTTPStatus
-from typing import Any, Final
+from typing import Any, Final, cast
 
 from fastapi import Request
 from openai.types.responses import (
@@ -22,6 +22,7 @@ from openai.types.responses import (
 from openai.types.responses.response_output_text import Logprob, LogprobTopLogprob
 from openai.types.responses.tool import Mcp, Tool
 from openai_harmony import Message as OpenAIHarmonyMessage
+from openai_harmony import Role
 from pydantic import TypeAdapter
 
 from vllm import envs
@@ -1148,39 +1149,44 @@ class OpenAIServingResponses(GenerateBaseServing):
     ) -> list[OpenAIHarmonyMessage]:
         messages: list[OpenAIHarmonyMessage] = []
         request_input = request.input
+        instructions = request.instructions
+        if instructions is None and isinstance(request_input, list):
+            instructions, request_input = extract_instructions_from_messages(
+                request_input
+            )
+
+        tool_types = extract_tool_types(request.tools)
+        with_custom_tools = has_custom_tools(tool_types)
+        tool_descriptions = self._get_harmony_builtin_tool_descriptions(
+            request, tool_types
+        )
+        tools = request.tools if with_custom_tools else None
+        messages.extend(
+            build_harmony_preamble(
+                instructions=instructions,
+                tools=tools,
+                reasoning_effort=(
+                    request.reasoning.effort if request.reasoning else None
+                ),
+                with_custom_tools=with_custom_tools,
+                **tool_descriptions,
+            )
+        )
+
         if prev_response is None:
             # New conversation.
-            tool_types = extract_tool_types(request.tools)
-            with_custom_tools = has_custom_tools(tool_types)
-            instructions = request.instructions
-            if instructions is None and isinstance(request_input, list):
-                instructions, request_input = extract_instructions_from_messages(
-                    request_input
-                )
-            tool_descriptions = self._get_harmony_builtin_tool_descriptions(
-                request, tool_types
-            )
-            tools = request.tools if with_custom_tools else None
-            messages.extend(
-                build_harmony_preamble(
-                    instructions=instructions,
-                    tools=tools,
-                    reasoning_effort=(
-                        request.reasoning.effort if request.reasoning else None
-                    ),
-                    with_custom_tools=with_custom_tools,
-                    **tool_descriptions,
-                )
-            )
             messages += construct_harmony_previous_input_messages(request)
 
         else:
             # Continue the previous conversation.
-            # FIXME(woosuk): Currently, request params like reasoning and
-            # instructions are ignored.
-            prev_msgs = self.msg_store[prev_response.id]
-
-            messages.extend(prev_msgs)
+            prev_msgs = cast(
+                list[OpenAIHarmonyMessage], self.msg_store[prev_response.id]
+            )
+            messages.extend(
+                msg
+                for msg in prev_msgs
+                if msg.author.role not in (Role.SYSTEM, Role.DEVELOPER)
+            )
         # Append the new input.
         # Responses API supports simple text inputs without chat format.
         if isinstance(request_input, str):


### PR DESCRIPTION
## Summary

  When continuing a GPT-OSS Harmony conversation with `previous_response_id`,
  the server reused the previous system/developer preamble. This caused new
  `instructions`, `reasoning.effort`, and tool settings to be ignored.

  This change rebuilds the preamble for every request while preserving the prior
  conversation history.

  ## Tests

  - `tests/entrypoints/openai/responses/test_serving_responses.py`
  - `tests/entrypoints/openai/responses/test_harmony_utils.py`
  - `tests/entrypoints/openai/responses/test_response_input_to_harmony.py`
  - `tests/entrypoints/openai/responses/test_responses_utils.py`
  - Ruff, formatting, and mypy hooks

  Results: `170 passed, 1 xfailed`.

  Full-suite collection is blocked locally by unavailable optional dependencies,
  CUDA extensions, and platform-specific tests.

  GPT-OSS model evaluation requires an appropriate accelerator environment and
  should be run in CI or by a maintainer.

  ## Notes

  GitHub duplicate-issue/PR checks could not be completed because the local `gh`
  client is unauthenticated.

  AI assistance was used. The submitting human should review every changed line
  and validate the model behavior end-to-end.
