### PR TITLE
remove force channels_last in Idefics3MultiModalProcessor

### DIFF
--- a/vllm/model_executor/models/idefics3.py
+++ b/vllm/model_executor/models/idefics3.py
@@ -310,7 +310,6 @@ class Idefics3MultiModalProcessor(BaseMultiModalProcessor[Idefics3ProcessingInfo
             prompt_ids = self._apply_hf_processor_tokens_only(prompt_ids)
             return BatchFeature(dict(input_ids=[prompt_ids]), tensor_type="pt")
 
-        mm_kwargs = {"input_data_format": "channels_last", **mm_kwargs}
         processed_outputs = super()._call_hf_processor(
             prompt,
             mm_data,

--- a/vllm/model_executor/models/idefics3.py
+++ b/vllm/model_executor/models/idefics3.py
@@ -310,6 +310,10 @@ class Idefics3MultiModalProcessor(BaseMultiModalProcessor[Idefics3ProcessingInfo
             prompt_ids = self._apply_hf_processor_tokens_only(prompt_ids)
             return BatchFeature(dict(input_ids=[prompt_ids]), tensor_type="pt")
 
+        image_processor = self.info.get_hf_processor().image_processor
+        if getattr(image_processor, "backend", "pil") == "pil":
+            mm_kwargs = {"input_data_format": "channels_last", **mm_kwargs}
+
         processed_outputs = super()._call_hf_processor(
             prompt,
             mm_data,


### PR DESCRIPTION



## Purpose
After transformers bumped to `5.13.1`(#47867), force `channels_last` would permute already-CHW tensors and cause below error:
```

E               RuntimeError: Test subprocess 'test_model_tensor_schema' failed (exit code 1):
E               Traceback (most recent call last):
E                 File "/workspace/mayan/vllm-mm/vllm/multimodal/processing/context.py", line 270, in call_hf_processor
E                   output = hf_processor(**data, **allowed_kwargs)
E                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E                 File "/opt/venv/lib/python3.12/site-packages/transformers/models/smolvlm/processing_smolvlm.py", line 247, in __call__
E                   vision_inputs = self.image_processor(images, **output_kwargs["images_kwargs"])
E                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E                 File "/opt/venv/lib/python3.12/site-packages/transformers/image_processing_utils.py", line 217, in __call__
E                   return self.preprocess(images, *args, **kwargs)
E                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E                 File "/opt/venv/lib/python3.12/site-packages/transformers/models/smolvlm/image_processing_smolvlm.py", line 212, in preprocess
E                   return super().preprocess(images, **kwargs)
E                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E                 File "/opt/venv/lib/python3.12/site-packages/transformers/image_processing_utils.py", line 400, in preprocess
E                   return self._preprocess_image_like_inputs(images, *args, **kwargs)
E                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E                 File "/opt/venv/lib/python3.12/site-packages/transformers/image_processing_utils.py", line 312, in _preprocess_image_like_inputs
E                   return self._preprocess(images, *args, **kwargs)
E                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E                 File "/opt/venv/lib/python3.12/site-packages/transformers/models/smolvlm/image_processing_smolvlm.py", line 439, in _preprocess
E                   grouped_images, grouped_images_index = group_images_by_shape(
E                                                          ^^^^^^^^^^^^^^^^^^^^^^
E                 File "/opt/venv/lib/python3.12/site-packages/transformers/image_transforms.py", line 1039, in group_images_by_shape
E                   grouped_images = {shape: torch.stack(images_list, dim=0) for shape, images_list in grouped_images.items()}
E                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E                 File "/opt/venv/lib/python3.12/site-packages/torch/utils/_device.py", line 122, in __torch_function__
E                   return func(*args, **kwargs)
E                          ^^^^^^^^^^^^^^^^^^^^^
E               RuntimeError: stack expects each tensor to be equal size, but got [384, 384, 384] at entry 0 and [192, 384, 384] at entry 5

```
## Test Plan
`pytest -s -v tests/models/multimodal/processing/test_tensor_schema.py::test_model_tensor_schema[HuggingFaceTB/SmolVLM2-2.2B-Instruct]
`
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

