### PR TITLE
[MRV2] Profile multimodal encoder & encoder cache to prevent from over-allocating KV cache

### DIFF
--- a/tests/models/multimodal/generation/test_memory_leak.py
+++ b/tests/models/multimodal/generation/test_memory_leak.py
@@ -180,3 +180,33 @@ def test_no_memory_leak(llm, image_urls: list[str]) -> None:
             f"cpu_peak_growth={_format_mib(cpu_peak_growth)}, "
             f"cpu_peak_threshold={CPU_PEAK_GROWTH_THRESHOLD_MIB} MiB"
         )
+
+
+def get_num_gpu_blocks(skip_mm_profiling: bool) -> int:
+    llm = LLM(
+        model=MODEL_NAME,
+        max_model_len=MAX_MODEL_LEN,
+        limit_mm_per_prompt={"image": 4},
+        enforce_eager=True,
+        gpu_memory_utilization=0.9,
+        skip_mm_profiling=skip_mm_profiling,
+        disable_log_stats=True,
+        seed=0,
+    )
+    num_gpu_blocks = llm.llm_engine.vllm_config.cache_config.num_gpu_blocks
+    del llm
+    cleanup_dist_env_and_memory()
+    return num_gpu_blocks
+
+
+@pytest.mark.core_model
+def test_memory_profile_mm_encoder():
+    """Profiling the encoder reserves memory, leaving fewer KV cache blocks.
+
+    Skipping it leaves the encoder and its cache unaccounted for, so they OOM at
+    runtime instead.
+    """
+    profiled = get_num_gpu_blocks(skip_mm_profiling=False)
+    skipped = get_num_gpu_blocks(skip_mm_profiling=True)
+
+    assert profiled < skipped, f"profiled={profiled} skipped={skipped}"

--- a/vllm/v1/worker/gpu/mm/encoder_cache.py
+++ b/vllm/v1/worker/gpu/mm/encoder_cache.py
@@ -23,14 +23,6 @@ class EncoderCache:
     def remove_request(self, req_id: str) -> None:
         self.mm_features.pop(req_id, None)
 
-    def reset_mm_cache(self) -> None:
-        """
-        Clear the multi-modal cache that was used during profiling,
-        but no longer needed during inference.
-        """
-        # TODO: Implement MM budget for encoder dummy run
-        pass
-
     def reset_encoder_cache(self) -> None:
         """Clear the GPU-side encoder cache storing vision embeddings.
 

--- a/vllm/v1/worker/gpu/mm/encoder_runner.py
+++ b/vllm/v1/worker/gpu/mm/encoder_runner.py
@@ -3,7 +3,10 @@
 import numpy as np
 import torch
 
+from vllm.config import VllmConfig
 from vllm.model_executor.models.interfaces import SupportsMultiModal, supports_realtime
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.encoder_budget import MultiModalBudget
 from vllm.multimodal.inputs import MultiModalKwargsItem
 from vllm.multimodal.utils import get_mm_features_in_window, group_and_batch_mm_kwargs
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
@@ -13,6 +16,7 @@ from vllm.v1.worker.utils import sanity_check_mm_encoder_outputs
 class EncoderRunner:
     def __init__(
         self,
+        vllm_config: VllmConfig,
         model: SupportsMultiModal,
         max_num_tokens: int,
         hidden_size: int,
@@ -20,6 +24,7 @@ class EncoderRunner:
         dtype: torch.dtype,
         device: torch.device,
     ):
+        self.vllm_config = vllm_config
         self.model = model
         self.max_num_tokens = max_num_tokens
         self.hidden_size = hidden_size
@@ -27,6 +32,7 @@ class EncoderRunner:
         self.dtype = dtype
         self.device = device
         self.is_realtime = supports_realtime(model)
+        self.mm_budget = MultiModalBudget(vllm_config, MULTIMODAL_REGISTRY)
 
         self.inputs_embeds = torch.zeros(
             max_num_tokens, hidden_size, dtype=dtype, device=device
@@ -60,6 +66,36 @@ class EncoderRunner:
             sanity_check_mm_encoder_outputs(batch_outputs, expected_num_items=num_items)
             encoder_outputs.extend(batch_outputs)
         return encoder_outputs
+
+    def profile_encoder(self) -> None:
+        """Run the encoder on a dummy max-size batch and reserve the encoder
+        cache, so memory profiling accounts for both the encoder activation and
+        the encoder-cache footprint.
+        """
+        mm_budget = self.mm_budget
+        if mm_budget.get_encoder_budget() <= 0 or not mm_budget.mm_max_toks_per_item:
+            # No encoder to profile (e.g. embedding-only, all mm limits are 0).
+            return
+
+        # Profile a single modality with the maximum tokens per item;
+        # `mm_max_items_per_batch` bounds items to the budget.
+        modality = mm_budget.get_modality_with_max_tokens()
+        max_items = mm_budget.mm_max_items_per_batch[modality]
+        dummy_mm_inputs = MULTIMODAL_REGISTRY.get_dummy_mm_inputs(
+            self.vllm_config.model_config,
+            mm_counts={modality: 1},
+            cache=mm_budget.cache,
+        )
+        dummy_item = dummy_mm_inputs["mm_kwargs"][modality][0]
+        assert dummy_item is not None, "Dummy item should not already be cached"
+
+        encoder_outputs = self.execute_mm_encoder([(modality, dummy_item)] * max_items)
+        for i, output in enumerate(encoder_outputs):
+            self.encoder_cache.encoder_outputs[f"tmp_{i}"] = output
+
+    def reset_mm_cache(self) -> None:
+        """Clear the processor cache populated while profiling the encoder."""
+        self.mm_budget.reset_cache()
 
     def gather_mm_embeddings(
         self,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -653,6 +653,19 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
     @torch.inference_mode()
     def profile_run(self) -> None:
+        # Profile the multimodal encoder + encoder cache so their memory is
+        # reserved. Skipping it under-counts non-KV memory, over-allocates the
+        # KV cache, and OOMs once the encoder runs.
+        if self.supports_mm_inputs and self.is_first_pp_rank:
+            mm_config = self.model_config.multimodal_config
+            if mm_config is not None and mm_config.skip_mm_profiling:
+                logger.info(
+                    "Skipping memory profiling for multimodal encoder and "
+                    "encoder cache."
+                )
+            else:
+                self.model_state.profile_encoder()
+
         hidden_states, sample_hidden_states = self._dummy_run(
             self.max_num_tokens, skip_attn=True, is_profile=True
         )
@@ -667,14 +680,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         torch.accelerator.synchronize()
         del hidden_states, sample_hidden_states
+        if self.encoder_cache is not None:
+            self.encoder_cache.reset_encoder_cache()
         gc.collect()
 
     def post_kv_cache_wake_up(self) -> None:
         self.block_tables.init_block_table_layout_tensors()
 
     def reset_mm_cache(self) -> None:
-        if self.encoder_cache is not None:
-            self.encoder_cache.reset_mm_cache()
+        self.model_state.reset_mm_cache()
 
     def reset_encoder_cache(self) -> None:
         if self.encoder_cache is not None:

--- a/vllm/v1/worker/gpu/model_states/interface.py
+++ b/vllm/v1/worker/gpu/model_states/interface.py
@@ -60,6 +60,7 @@ class ModelState(ABC):
         if encoder_cache is not None:
             self.encoder_cache = encoder_cache
             self.encoder_runner = EncoderRunner(
+                vllm_config=vllm_config,
                 model=self.model,
                 max_num_tokens=self.max_num_tokens,
                 hidden_size=self.inputs_embeds_size,
@@ -67,6 +68,20 @@ class ModelState(ABC):
                 dtype=self.dtype,
                 device=self.device,
             )
+
+    def profile_encoder(self) -> None:
+        """Profile the multimodal encoder + encoder cache for memory profiling.
+
+        No-op for text-only models (no encoder runner). Shared by all
+        multimodal model states, which encode via ``encoder_runner``.
+        """
+        if self.supports_mm_inputs:
+            self.encoder_runner.profile_encoder()
+
+    def reset_mm_cache(self) -> None:
+        """Clear the multimodal profiling cache; no-op for text-only models."""
+        if self.supports_mm_inputs:
+            self.encoder_runner.reset_mm_cache()
 
     def get_supported_generation_tasks(self) -> tuple[GenerationTask, ...]:
         from vllm.model_executor.models.interfaces import (


### PR DESCRIPTION
## Purpose

MRV2's `profile_run` ran only a text dummy forward, so it never memory-profiled the multimodal encoder or reserved the encoder cache (unlike MRV1). It therefore under-counted non-KV memory, over-allocated the KV cache, and OOM'd at runtime once the vision encoder + encoder cache ran.

This ports V1's profiling into MRV2:

- `EncoderRunner.profile_encoder()` runs the encoder on a max-size dummy batch and reserves the encoder cache.
- `profile_run` invokes it before the LM dummy run and clears the cache after; honors `multimodal_config.skip_mm_profiling`; gated to the first PP rank.
- Implements `reset_mm_cache` at V1 parity: persist `MultiModalBudget` and clear its processor cache via `ModelState`.


<details>
<summary><strong>Note: Three multimodal memory consumers.</strong></summary>

<br>

| Component | Description |
|-----------|-------------|
| **MM budget** (`MultiModalBudget`) | Computes the worst-case multimodal sizes (maximum tokens/items per modality) that determine what `profile_encoder` profiles. |
| **MM cache** | Host-side processor cache that stores processed **pre-encoder** tensors (for example, `pixel_values`). Cleared by `reset_mm_cache`. |
| **Encoder cache** | GPU-side cache that stores **post-encoder** vision embeddings for reuse during inference. Cleared by `reset_encoder_cache`. |

</details>


## Relationship to #37370

#37370  targets the same gap but seems to be stalled. Opening this to push the fix forward. This PR is more targeted, matches the current tree, and adds a regression test.

## Test Plan

- New `test_memory_profile_mm_encoder` in `tests/models/multimodal/generation/test_memory_leak.py`: a profiled engine ends up with fewer KV blocks than one built with `skip_mm_profiling=True`.

## Test Result

| model (available KV) | MRV1 | MRV2 + this PR | `skip_mm_profiling` |
|---|---|---|---|
| Qwen3-VL-4B | 9.14 GiB | 9.14 GiB | 10.51 GiB |
| Qwen2.5-0.5B (text) | 18.55 GiB | 18.55 GiB | n/a |

### Tested with Ray

Surfaced by [Ray's integration test](https://github.com/ray-project/ray/pull/64697#issuecomment-4953267849) (failure [link](https://buildkite.com/ray-project/premerge/builds/69875/table?jid=019f53ad-8b82-4f36-bbdf-822db443d585&tab=output)). Here's a minimal Ray Data LLM with VLM repro which OOMs on vLLM 0.25.0. With the change in this PR, OOM no longer reproduces.

```python
import ray
from ray.data.llm import vLLMEngineProcessorConfig, build_processor

config = vLLMEngineProcessorConfig(
    model_source="Qwen/Qwen3-VL-4B-Instruct",
    engine_kwargs=dict(tensor_parallel_size=2, limit_mm_per_prompt={"image": 4}),
    batch_size=8,
    concurrency=1,
)
processor = build_processor(
    config,
    preprocess=lambda row: dict(
        messages=[{"role": "user", "content": [
            {"type": "text", "text": "Describe."},
            {"type": "image_url", "image_url": {"url": IMG}},
        ]}],
        sampling_params=dict(max_tokens=32),
    ),
    postprocess=lambda row: dict(text=row["generated_text"]),
)
processor(ray.data.range(64)).take_all()  # OOMs without this change
```

## AI disclosure

Developed with AI assistance (Claude). I reviewed every changed line and ran the tests above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

