### PR TITLE
fix(security): validate GPTQ kernel inputs to prevent OOB reads

### DIFF
--- a/csrc/libtorch_stable/quantization/gptq/q_gemm.cu
+++ b/csrc/libtorch_stable/quantization/gptq/q_gemm.cu
@@ -1835,8 +1835,11 @@ __global__ void check_g_idx_bounds_kernel(const int* __restrict__ g_idx,
 
 bool check_g_idx_in_bounds(const int* g_idx, int n, int upper_bound) {
   int* d_flag = nullptr;
-  cudaMalloc(&d_flag, sizeof(int));
-  cudaMemset(d_flag, 0, sizeof(int));
+  if (cudaMalloc(&d_flag, sizeof(int)) != cudaSuccess) return false;
+  if (cudaMemset(d_flag, 0, sizeof(int)) != cudaSuccess) {
+    cudaFree(d_flag);
+    return false;
+  }
 
   const int threads = 256;
   const int blocks = (n + threads - 1) / threads;
@@ -1845,9 +1848,11 @@ bool check_g_idx_in_bounds(const int* g_idx, int n, int upper_bound) {
       g_idx, n, upper_bound, d_flag);
 
   int h_flag = 0;
-  cudaMemcpyAsync(&h_flag, d_flag, sizeof(int), cudaMemcpyDeviceToHost, stream);
-  cudaStreamSynchronize(stream);
+  cudaError_t cpy_err = cudaMemcpyAsync(&h_flag, d_flag, sizeof(int),
+                                        cudaMemcpyDeviceToHost, stream);
+  cudaError_t sync_err = cudaStreamSynchronize(stream);
   cudaFree(d_flag);
+  if (cpy_err != cudaSuccess || sync_err != cudaSuccess) return false;
   return h_flag == 0;
 }
 
@@ -1870,10 +1875,16 @@ torch::stable::Tensor gptq_gemm(torch::stable::Tensor a,
   STD_TORCH_CHECK(groups > 0,
                   "gptq_gemm: groups (b_gptq_qzeros.size(0)) must be > 0");
 
+  STD_TORCH_CHECK(b_gptq_scales.size(0) >= groups,
+                  "gptq_gemm: b_gptq_scales.size(0) (", b_gptq_scales.size(0),
+                  ") must be >= groups (", groups, ")");
+
   bool has_g_idx = b_g_idx.device().type() != torch::stable::DeviceType::Meta &&
                    b_g_idx.numel() > 0;
   if (has_g_idx) {
     int64_t size_k = a.size(1);
+    STD_TORCH_CHECK(b_g_idx.numel() >= size_k, "gptq_gemm: g_idx length (",
+                    b_g_idx.numel(), ") must be >= size_k (", size_k, ")");
     int upper_bound =
         use_exllama ? static_cast<int>(size_k) : static_cast<int>(groups);
     STD_TORCH_CHECK(vllm::gptq::check_g_idx_in_bounds(

--- a/csrc/libtorch_stable/quantization/gptq/q_gemm.cu
+++ b/csrc/libtorch_stable/quantization/gptq/q_gemm.cu
@@ -1821,6 +1821,36 @@ void shuffle_exllama_weight(uint32_t* q_weight, int* q_perm, int height,
   shuffle_kernel<<<gridDim, blockDim, 0, stream>>>(q_weight, height, width);
 }
 
+__global__ void check_g_idx_bounds_kernel(const int* __restrict__ g_idx,
+                                          const int n, const int upper_bound,
+                                          int* __restrict__ out_flag) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < n) {
+    int val = g_idx[idx];
+    if (val < 0 || val >= upper_bound) {
+      atomicExch(out_flag, 1);
+    }
+  }
+}
+
+bool check_g_idx_in_bounds(const int* g_idx, int n, int upper_bound) {
+  int* d_flag = nullptr;
+  cudaMalloc(&d_flag, sizeof(int));
+  cudaMemset(d_flag, 0, sizeof(int));
+
+  const int threads = 256;
+  const int blocks = (n + threads - 1) / threads;
+  const cudaStream_t stream = get_current_cuda_stream();
+  check_g_idx_bounds_kernel<<<blocks, threads, 0, stream>>>(
+      g_idx, n, upper_bound, d_flag);
+
+  int h_flag = 0;
+  cudaMemcpyAsync(&h_flag, d_flag, sizeof(int), cudaMemcpyDeviceToHost, stream);
+  cudaStreamSynchronize(stream);
+  cudaFree(d_flag);
+  return h_flag == 0;
+}
+
 }  // namespace gptq
 }  // namespace vllm
 
@@ -1832,6 +1862,27 @@ torch::stable::Tensor gptq_gemm(torch::stable::Tensor a,
                                 bool use_v2_format, int64_t bit) {
   const torch::stable::accelerator::DeviceGuard device_guard(
       a.get_device_index());
+
+  STD_TORCH_CHECK(bit == 2 || bit == 3 || bit == 4 || bit == 8,
+                  "gptq_gemm: bit must be 2, 3, 4, or 8, got ", bit);
+
+  int64_t groups = b_gptq_qzeros.size(0);
+  STD_TORCH_CHECK(groups > 0,
+                  "gptq_gemm: groups (b_gptq_qzeros.size(0)) must be > 0");
+
+  bool has_g_idx = b_g_idx.device().type() != torch::stable::DeviceType::Meta &&
+                   b_g_idx.numel() > 0;
+  if (has_g_idx) {
+    int64_t size_k = a.size(1);
+    int upper_bound =
+        use_exllama ? static_cast<int>(size_k) : static_cast<int>(groups);
+    STD_TORCH_CHECK(vllm::gptq::check_g_idx_in_bounds(
+                        (const int*)b_g_idx.data_ptr(),
+                        static_cast<int>(b_g_idx.numel()), upper_bound),
+                    "gptq_gemm: g_idx contains values outside [0, ",
+                    upper_bound, ")");
+  }
+
   auto c = torch::stable::new_zeros(a, {a.size(0), b_q_weight.size(1)});
   auto temp_dq =
       torch::stable::empty({b_q_weight.size(0) * 32 / bit, b_q_weight.size(1)},
@@ -1842,10 +1893,8 @@ torch::stable::Tensor gptq_gemm(torch::stable::Tensor a,
       (const uint32_t*)b_q_weight.data_ptr(),
       (const uint32_t*)b_gptq_qzeros.data_ptr(),
       (const half*)b_gptq_scales.data_ptr(),
-      b_g_idx.device().type() == torch::stable::DeviceType::Meta
-          ? NULL
-          : (const int*)b_g_idx.data_ptr(),
-      (half*)c.data_ptr(), (half*)temp_dq.data_ptr(),
+      has_g_idx ? (const int*)b_g_idx.data_ptr() : NULL, (half*)c.data_ptr(),
+      (half*)temp_dq.data_ptr(),
       c.size(0),              // m
       c.size(1),              // n
       a.size(1),              // k
@@ -1856,6 +1905,9 @@ torch::stable::Tensor gptq_gemm(torch::stable::Tensor a,
 
 void gptq_shuffle(torch::stable::Tensor q_weight, torch::stable::Tensor q_perm,
                   int64_t bit) {
+  STD_TORCH_CHECK(bit == 2 || bit == 3 || bit == 4 || bit == 8,
+                  "gptq_shuffle: bit must be 2, 3, 4, or 8, got ", bit);
+
   const torch::stable::accelerator::DeviceGuard device_guard(
       q_weight.get_device_index());
   vllm::gptq::shuffle_exllama_weight(

--- a/tests/kernels/quantization/test_gptq.py
+++ b/tests/kernels/quantization/test_gptq.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import pytest
 import torch
 
 from tests.kernels.utils import opcheck
@@ -33,3 +34,106 @@ def test_gptq_gemm_opcheck():
     opcheck(
         torch.ops._C.gptq_gemm, (a, weight, zeros, scales, idx, use_exllama, False, bit)
     )
+
+
+# --- Validation tests for GHSA-4hhp-h66f-j5j7 ---
+
+
+@pytest.mark.parametrize("invalid_bit", [0, 1, 5, 6, 7, 16])
+def test_gptq_gemm_invalid_bit(invalid_bit):
+    """bit must be in {2, 3, 4, 8}; other values must raise."""
+    a = torch.rand((8, 4096), device="cuda", dtype=torch.float16)
+    weight = torch.randint(0, 2**31 - 1, (512, 6144), device="cuda", dtype=torch.int32)
+    zeros = torch.zeros((32, 768), device="cuda", dtype=torch.int32)
+    scales = torch.rand((32, 6144), device="cuda", dtype=torch.float16)
+    idx = torch.empty((0,), device="cuda", dtype=torch.int32)
+
+    with pytest.raises(RuntimeError, match="gptq_gemm"):
+        torch.ops._C.gptq_gemm(a, weight, zeros, scales, idx, True, True, invalid_bit)
+
+
+def test_gptq_gemm_zero_groups():
+    """groups == 0 (b_gptq_qzeros.size(0) == 0) must raise."""
+    a = torch.rand((8, 4096), device="cuda", dtype=torch.float16)
+    weight = torch.randint(0, 2**31 - 1, (512, 6144), device="cuda", dtype=torch.int32)
+    zeros = torch.zeros((0, 768), device="cuda", dtype=torch.int32)
+    scales = torch.rand((0, 6144), device="cuda", dtype=torch.float16)
+    idx = torch.empty((0,), device="cuda", dtype=torch.int32)
+
+    with pytest.raises(RuntimeError, match="gptq_gemm"):
+        torch.ops._C.gptq_gemm(a, weight, zeros, scales, idx, True, True, 4)
+
+
+def test_gptq_gemm_g_idx_oob_group_index():
+    """g_idx with value >= groups when use_exllama=False must raise."""
+    size_k = 4096
+    size_n = 6144
+    groups = 32
+    bit = 4
+
+    a = torch.rand((8, size_k), device="cuda", dtype=torch.float16)
+    weight = torch.randint(
+        0,
+        2**31 - 1,
+        (size_k * bit // 32, size_n),
+        device="cuda",
+        dtype=torch.int32,
+    )
+    zeros = torch.zeros((groups, size_n // 8), device="cuda", dtype=torch.int32)
+    scales = torch.rand((groups, size_n), device="cuda", dtype=torch.float16)
+
+    g_idx = torch.zeros(size_k, device="cuda", dtype=torch.int32)
+    g_idx[0] = groups  # OOB: equals groups (valid range is [0, groups))
+
+    with pytest.raises(RuntimeError, match="gptq_gemm"):
+        torch.ops._C.gptq_gemm(a, weight, zeros, scales, g_idx, False, True, bit)
+
+
+def test_gptq_gemm_g_idx_negative():
+    """g_idx with negative value must raise."""
+    size_k = 4096
+    size_n = 6144
+    groups = 32
+    bit = 4
+
+    a = torch.rand((8, size_k), device="cuda", dtype=torch.float16)
+    weight = torch.randint(
+        0,
+        2**31 - 1,
+        (size_k * bit // 32, size_n),
+        device="cuda",
+        dtype=torch.int32,
+    )
+    zeros = torch.zeros((groups, size_n // 8), device="cuda", dtype=torch.int32)
+    scales = torch.rand((groups, size_n), device="cuda", dtype=torch.float16)
+
+    g_idx = torch.zeros(size_k, device="cuda", dtype=torch.int32)
+    g_idx[100] = -1
+
+    with pytest.raises(RuntimeError, match="gptq_gemm"):
+        torch.ops._C.gptq_gemm(a, weight, zeros, scales, g_idx, False, True, bit)
+
+
+def test_gptq_gemm_g_idx_oob_permutation():
+    """g_idx with value >= size_k when use_exllama=True must raise."""
+    size_k = 4096
+    size_n = 6144
+    groups = 32
+    bit = 4
+
+    a = torch.rand((8, size_k), device="cuda", dtype=torch.float16)
+    weight = torch.randint(
+        0,
+        2**31 - 1,
+        (size_k * bit // 32, size_n),
+        device="cuda",
+        dtype=torch.int32,
+    )
+    zeros = torch.zeros((groups, size_n // 8), device="cuda", dtype=torch.int32)
+    scales = torch.rand((groups, size_n), device="cuda", dtype=torch.float16)
+
+    g_idx = torch.arange(size_k, device="cuda", dtype=torch.int32)
+    g_idx[0] = size_k  # OOB: equals size_k (valid range is [0, size_k))
+
+    with pytest.raises(RuntimeError, match="gptq_gemm"):
+        torch.ops._C.gptq_gemm(a, weight, zeros, scales, g_idx, True, True, bit)

--- a/tests/kernels/quantization/test_gptq.py
+++ b/tests/kernels/quantization/test_gptq.py
@@ -137,3 +137,50 @@ def test_gptq_gemm_g_idx_oob_permutation():
 
     with pytest.raises(RuntimeError, match="gptq_gemm"):
         torch.ops._C.gptq_gemm(a, weight, zeros, scales, g_idx, True, True, bit)
+
+
+def test_gptq_gemm_scales_fewer_rows_than_groups():
+    """b_gptq_scales with fewer rows than groups must raise."""
+    size_k = 4096
+    size_n = 6144
+    groups = 32
+    bit = 4
+
+    a = torch.rand((8, size_k), device="cuda", dtype=torch.float16)
+    weight = torch.randint(
+        0,
+        2**31 - 1,
+        (size_k * bit // 32, size_n),
+        device="cuda",
+        dtype=torch.int32,
+    )
+    zeros = torch.zeros((groups, size_n // 8), device="cuda", dtype=torch.int32)
+    scales = torch.rand((groups - 1, size_n), device="cuda", dtype=torch.float16)
+    idx = torch.empty((0,), device="cuda", dtype=torch.int32)
+
+    with pytest.raises(RuntimeError, match="gptq_gemm"):
+        torch.ops._C.gptq_gemm(a, weight, zeros, scales, idx, True, True, bit)
+
+
+def test_gptq_gemm_g_idx_too_short():
+    """g_idx shorter than size_k must raise."""
+    size_k = 4096
+    size_n = 6144
+    groups = 32
+    bit = 4
+
+    a = torch.rand((8, size_k), device="cuda", dtype=torch.float16)
+    weight = torch.randint(
+        0,
+        2**31 - 1,
+        (size_k * bit // 32, size_n),
+        device="cuda",
+        dtype=torch.int32,
+    )
+    zeros = torch.zeros((groups, size_n // 8), device="cuda", dtype=torch.int32)
+    scales = torch.rand((groups, size_n), device="cuda", dtype=torch.float16)
+
+    g_idx = torch.zeros(size_k // 2, device="cuda", dtype=torch.int32)
+
+    with pytest.raises(RuntimeError, match="gptq_gemm"):
+        torch.ops._C.gptq_gemm(a, weight, zeros, scales, g_idx, False, True, bit)


### PR DESCRIPTION
Add bounds checking to the gptq_gemm and gptq_shuffle entry points to prevent out-of-bounds GPU memory accesses from malicious model checkpoints.
The GPTQ dequant/GEMM kernels use g_idx to index into scales and zeros matrices without validation. A crafted checkpoint with out-of-range g_idx values causes illegal device memory reads (information disclosure or denial of service).
Validations added:
- bit must be in {2, 3, 4, 8} (prevents host SIGFPE)
- groups must be > 0 (prevents device divide-by-zero)
- g_idx values must be in [0, upper_bound) where upper_bound is size_k for exllama mode or groups for alt mode
