### PR TITLE
[ROCm][P/D] Fix MoRIIO READ prefix-cache block matching

### DIFF
--- a/tests/v1/kv_connector/unit/test_moriio_connector.py
+++ b/tests/v1/kv_connector/unit/test_moriio_connector.py
@@ -139,6 +139,17 @@ def _write_consumer_scheduler_for_finished_request(tp_size: int = 2):
     return scheduler
 
 
+def _read_consumer_scheduler_for_alloc():
+    scheduler = MoRIIOConnectorScheduler.__new__(MoRIIOConnectorScheduler)
+    scheduler.is_producer = False
+    scheduler.mode = MoRIIOMode.READ
+    scheduler.transfer_id_to_request_id = {}
+    scheduler.request_id_to_transfer_id = {}
+    scheduler._reqs_need_save = {}
+    scheduler._reqs_need_recv = {}
+    return scheduler
+
+
 class FakeMoRIIOWrapper:
     # A fake MoRIIOWrapper for testing purposes
     def __init__(self, *args, **kwargs):
@@ -457,6 +468,79 @@ def test_read_mode_loads_remote_block_ids():
         ],
     ):
         assert block_id == block.block_id, f"{block_id} != {block.block_id}"
+
+
+def test_read_mode_prefix_cache_slices_remote_suffix_blocks():
+    scheduler = _read_consumer_scheduler_for_alloc()
+    request = create_request(request_id=7, do_remote_prefill=True)
+    request.kv_transfer_params.update(
+        {
+            "transfer_id": "xfer-partial",
+            "remote_engine_id": "prefill-engine",
+            "remote_block_ids": [10, 11, 12, 13],
+        }
+    )
+    blocks = MagicMock()
+    blocks.get_block_ids.return_value = [[101, 102]]
+
+    scheduler.update_state_after_alloc(request, blocks, num_external_tokens=32)
+
+    recv_request, local_block_ids = scheduler._reqs_need_recv[request.request_id]
+    assert recv_request is request
+    assert local_block_ids == [101, 102]
+    assert request.kv_transfer_params["remote_block_ids"] == [12, 13]
+    assert request.kv_transfer_params["do_remote_prefill"] is False
+
+
+def test_read_mode_full_prefix_hit_queues_release_only_metadata():
+    scheduler = _read_consumer_scheduler_for_alloc()
+    request = create_request(request_id=7, do_remote_prefill=True)
+    request.kv_transfer_params.update(
+        {
+            "transfer_id": "xfer-full",
+            "remote_engine_id": "prefill-engine",
+            "remote_block_ids": [10, 11, 12, 13],
+        }
+    )
+    blocks = MagicMock()
+    blocks.get_block_ids.return_value = [[]]
+
+    scheduler.update_state_after_alloc(request, blocks, num_external_tokens=0)
+
+    recv_request, local_block_ids = scheduler._reqs_need_recv[request.request_id]
+    assert recv_request is request
+    assert local_block_ids == []
+    assert request.kv_transfer_params["remote_block_ids"] == []
+    assert request.kv_transfer_params["do_remote_prefill"] is False
+
+
+def test_read_mode_full_prefix_hit_releases_without_read():
+    worker = MoRIIOConnectorWorker.__new__(MoRIIOConnectorWorker)
+    worker.mode = MoRIIOMode.READ
+    worker.world_size = 1
+    worker.tp_rank = 0
+    worker.moriio_wrapper = MagicMock()
+    worker._get_built_session = MagicMock()
+
+    worker._read_blocks(
+        local_block_ids=[],
+        remote_block_ids=[],
+        dst_engine_id="prefill-engine",
+        request_id="req-full-hit",
+        transfer_id="xfer-full-hit",
+        remote_host="127.0.0.1",
+        remote_notify_port=7000,
+        remote_tp_size=1,
+    )
+
+    worker._get_built_session.assert_not_called()
+    worker.moriio_wrapper.send_notify.assert_called_once_with(
+        "xfer-full-hit",
+        "127.0.0.1",
+        "7000",
+        message_type="release",
+        message_fields={"consumer_tp_size": 1},
+    )
 
 
 @pytest.mark.parametrize(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -553,16 +553,25 @@ class MoRIIOConnectorScheduler:
                         if num_external_tokens > 0:
                             # Get unhashed blocks to pull from remote.
                             local_block_ids = blocks.get_block_ids()[0]
-                            assert len(local_block_ids) <= len(remote_block_ids)
-                            if len(local_block_ids) != len(remote_block_ids):
-                                local_block_ids = remote_block_ids[
+                            if len(local_block_ids) > len(remote_block_ids):
+                                raise ValueError(
+                                    "MoRIIO READ decode allocated more local "
+                                    "blocks than prefill remote blocks: "
+                                    f"{len(local_block_ids)} > "
+                                    f"{len(remote_block_ids)}"
+                                )
+                            if len(local_block_ids) < len(remote_block_ids):
+                                remote_block_ids = remote_block_ids[
                                     -len(local_block_ids) :
                                 ]
+                                params["remote_block_ids"] = remote_block_ids
                         else:
-                            # If remote_blocks and num_external_tokens = 0, we have
-                            # a full prefix cache hit on the D worker. We need to call
-                            # send_notify in _read_blocks to free the memory on the P.
+                            # Full prefix cache hit on decode. No KV data needs
+                            # to be read, but prefill still needs a release
+                            # notification for the held remote blocks.
                             local_block_ids = []
+                            remote_block_ids = []
+                            params["remote_block_ids"] = remote_block_ids
 
                         self._reqs_need_recv[request.request_id] = (
                             request,
@@ -1945,6 +1954,29 @@ class MoRIIOConnectorWorker:
         remote_tp_size: int,
     ) -> None:
         if self.mode == MoRIIOMode.WRITE:
+            return
+
+        if len(local_block_ids) != len(remote_block_ids):
+            raise ValueError(
+                "MoRIIO READ requires matched local/remote block lists after "
+                "prefix-cache slicing: "
+                f"{len(local_block_ids)} != {len(remote_block_ids)}"
+            )
+
+        if not local_block_ids:
+            self.moriio_wrapper.send_notify(
+                transfer_id,
+                remote_host,
+                str(remote_notify_port + self._remote_tp_rank(remote_tp_size)),
+                message_type="release",
+                message_fields={"consumer_tp_size": self.world_size},
+            )
+            logger.info(
+                "MoRIIO READ full prefix hit: released prefill blocks without "
+                "remote read for request %s transfer %s",
+                request_id,
+                transfer_id,
+            )
             return
 
         dp0_engine_id = self.get_engine_name_with_dp(dst_engine_id, 0)


### PR DESCRIPTION
## Purpose

This PR fixes a MoRIIO READ-mode failure when prefix caching is enabled.

In READ mode, decode may already have some or all prefix KV blocks locally. In that case, decode only allocates local destination blocks for the missing suffix. The prefill side can still report the full remote block list, which previously caused mismatched block lists such as:

```text
local_block_ids = 0
remote_block_ids = 12
```

and failed with:

```text
ValueError: local_block_ids and remote_block_ids must have the same length: 0 != 12
```

This PR makes MoRIIO READ prefix-cache aware:

- For partial prefix-cache hits, slice `remote_block_ids` to only the suffix that decode still needs.
- For full prefix-cache hits, skip the READ transfer and send a release notification to prefill.
- Keep a hard failure if local/remote block counts are still inconsistent after slicing.

This complements the READ-mode robustness work in #47495 by handling the scheduler-level prefix-cache block matching case.

## Test Plan

Unit/sanity checks:

```bash
python -m py_compile \
  vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py \
  tests/v1/kv_connector/unit/test_moriio_connector.py
```

Manual E2E test on MI350X with MiniMax-M3-MXFP8, intranode MoRIIO READ mode, RDMA backend, TP4 prefill + TP4 decode, routed through `vllm-router`.

Important: high-concurrency `lm-eval` needs the container/router file descriptor limit raised:

```bash
--ulimit nofile=1048576:1048576
```

Docker container:

```bash
docker run -it \
   --network=host \
   --group-add=video \
   --ipc=host \
   --cap-add=SYS_PTRACE \
   --cap-add=IPC_LOCK \
   --security-opt seccomp=unconfined \
   --ulimit memlock=-1:-1 \
   --ulimit stack=67108864:67108864 \
   --ulimit nofile=1048576:1048576 \
   --device /dev/kfd \
   --device /dev/dri \
   --device /dev/infiniband \
   --shm-size=128G \
   -v /home/amd/models:/app/model \
   -e HF_HUB_CACHE="/app/model" \
   --name test \
   --entrypoint bash \
   vllm/vllm-openai-rocm:nightly
```

Prefill:

```bash
HIP_VISIBLE_DEVICES=0,1,2,3 vllm serve MiniMaxAI/MiniMax-M3-MXFP8 \
  --host 0.0.0.0 \
  --port 8100 \
  --tensor-parallel-size 4 \
  --block-size 128 \
  --trust-remote-code \
  --kv-transfer-config '{
    "kv_connector": "MoRIIOConnector",
    "kv_role": "kv_producer",
    "kv_connector_extra_config": {
      "host_ip": "165.245.143.170",
      "proxy_ip": "127.0.0.1",
      "proxy_ping_port": 36367,
      "http_port": 8100,
      "handshake_port": 6301,
      "notify_port": 6105,
      "read_mode": true,
      "backend": "rdma"
    }
  }'
```

Decode:

```bash
HIP_VISIBLE_DEVICES=4,5,6,7 vllm serve MiniMaxAI/MiniMax-M3-MXFP8 \
  --block-size 128 \
  --host 0.0.0.0 \
  --port 8200 \
  --tensor-parallel-size 4 \
  --trust-remote-code \
  --kv-transfer-config '{
    "kv_connector": "MoRIIOConnector",
    "kv_role": "kv_consumer",
    "kv_connector_extra_config": {
      "host_ip": "165.245.143.170",
      "proxy_ip": "127.0.0.1",
      "proxy_ping_port": 36367,
      "http_port": 8200,
      "handshake_port": 7301,
      "notify_port": 7501,
      "read_mode": true,
      "backend": "rdma"
    }
  }'
```

Router:

```bash
docker run --rm \
  --network host \
  --ulimit memlock=-1:-1 \
  --ulimit stack=67108864:67108864 \
  --ulimit nofile=1048576:1048576 \
  vllm/vllm-router:nightly \
  vllm-router \
  --host 127.0.0.1 \
  --port 30000 \
  --vllm-pd-disaggregation \
  --kv-connector moriio \
  --vllm-discovery-address "0.0.0.0:36367"
```

Run `lm-eval` twice or more to exercise prefix-cache reuse:

```bash
lm_eval run \
  --model local-chat-completions \
  --model_args "model=MiniMaxAI/MiniMax-M3-MXFP8,base_url=http://localhost:30000/v1/chat/completions,tokenizer=MiniMaxAI/MiniMax-M3-MXFP8,num_concurrent=1024" \
  --tasks gsm8k \
  --num_fewshot 5 \
  --apply_chat_template \
  --batch_size 1 \
  --gen_kwargs '{"max_tokens":4096}'
```

## Test Result

Before this fix, repeated/high-concurrency `lm-eval` with prefix caching enabled could crash the decode worker with:

```text
ValueError: local_block_ids and remote_block_ids must have the same length: 0 != 12
```

The decode log showed prefix caching enabled and high external prefix-cache hit rate before the crash.

After this fix, MoRIIO READ mode handles the prefix-cache cases correctly:

- Partial prefix hit transfers only the missing suffix blocks.
- Full prefix hit sends release notification without issuing a READ.
- The previous `0 != 12` block-list mismatch is avoided.
