### PR TITLE
[CI] Add SPDX license header to Rust/Protobuf sources

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -210,7 +210,7 @@ repos:
     name: Check SPDX headers
     entry: python tools/pre_commit/check_spdx_header.py
     language: python
-    types: [python]
+    types_or: [python, rust, proto]
   - id: check-root-lazy-imports
     name: Check root lazy imports
     entry: python tools/pre_commit/check_init_lazy_imports.py

--- a/rust/proto/vllm_grpc.proto
+++ b/rust/proto/vllm_grpc.proto
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 syntax = "proto3";
 package vllm;
 

--- a/rust/src/chat/examples/external_engine_chat_qwen.rs
+++ b/rust/src/chat/examples/external_engine_chat_qwen.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};

--- a/rust/src/chat/src/backend/hf.rs
+++ b/rust/src/chat/src/backend/hf.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use tracing::info;

--- a/rust/src/chat/src/backend/mod.rs
+++ b/rust/src/chat/src/backend/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/rust/src/chat/src/error.rs
+++ b/rust/src/chat/src/error.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use thiserror::Error;
 use thiserror_ext::{AsReport as _, Macro};
 

--- a/rust/src/chat/src/event.rs
+++ b/rust/src/chat/src/event.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::ops::Deref;
 use std::sync::Arc;
 

--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Minimal chat facade above [`vllm_text`].
 //!
 //! This crate keeps the northbound boundary intentionally small:

--- a/rust/src/chat/src/multimodal.rs
+++ b/rust/src/chat/src/multimodal.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Chat-layer multimodal media preparation.
 //!
 //! This module owns the multimodal path for chat requests: it extracts media

--- a/rust/src/chat/src/multimodal/expand.rs
+++ b/rust/src/chat/src/multimodal/expand.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Prompt placeholder expansion shared across modalities.
 
 use std::collections::{HashMap, VecDeque};

--- a/rust/src/chat/src/multimodal/image.rs
+++ b/rust/src/chat/src/multimodal/image.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Image-modality preparation: batch preprocessing and per-item feature
 //! build.
 

--- a/rust/src/chat/src/multimodal/tensor.rs
+++ b/rust/src/chat/src/multimodal/tensor.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::HashMap;
 
 use half::{bf16, f16};

--- a/rust/src/chat/src/multimodal/video.rs
+++ b/rust/src/chat/src/multimodal/video.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Video-modality preparation: per-clip preprocessing, config resolution,
 //! and per-item feature build.
 

--- a/rust/src/chat/src/output/default/mod.rs
+++ b/rust/src/chat/src/output/default/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Default output processing pipeline.
 
 mod structural_tag;

--- a/rust/src/chat/src/output/default/structural_tag.rs
+++ b/rust/src/chat/src/output/default/structural_tag.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Applies xgrammar structural-tag constraints for strict tool calling.
 
 use thiserror_ext::AsReport;

--- a/rust/src/chat/src/output/default/unified.rs
+++ b/rust/src/chat/src/output/default/unified.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Adapts decoded text updates into parsed assistant deltas.
 //!
 //! This stage sits between low-level token decoding and final block assembly.

--- a/rust/src/chat/src/output/harmony/mod.rs
+++ b/rust/src/chat/src/output/harmony/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Native Harmony output processing for `gpt_oss`.
 //!
 //! Unlike the default text-first pipeline, this processor consumes

--- a/rust/src/chat/src/output/harmony/tests.rs
+++ b/rust/src/chat/src/output/harmony/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use futures::executor::block_on;

--- a/rust/src/chat/src/output/mod.rs
+++ b/rust/src/chat/src/output/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::pin::Pin;
 use std::sync::Arc;
 

--- a/rust/src/chat/src/output/structured.rs
+++ b/rust/src/chat/src/output/structured.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Adapts parsed assistant updates into structured chat events.
 //!
 //! This module remains the final assembly stage in `vllm-chat`. Token-to-text

--- a/rust/src/chat/src/parser/mod.rs
+++ b/rust/src/chat/src/parser/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 pub mod reasoning;
 pub mod tool;
 pub mod unified;

--- a/rust/src/chat/src/parser/reasoning/mod.rs
+++ b/rust/src/chat/src/parser/reasoning/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Reasoning parser registration and selection boundary for `vllm-chat`.
 
 use std::sync::{Arc, LazyLock};

--- a/rust/src/chat/src/parser/reasoning/tests.rs
+++ b/rust/src/chat/src/parser/reasoning/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use vllm_tokenizer::test_utils::TestTokenizer;

--- a/rust/src/chat/src/parser/tool/mod.rs
+++ b/rust/src/chat/src/parser/tool/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Tool parser registration and selection boundary for `vllm-chat`.
 
 use std::sync::{Arc, LazyLock};

--- a/rust/src/chat/src/parser/tool/tests.rs
+++ b/rust/src/chat/src/parser/tool/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use vllm_parser::tool::{Result, ToolParserOutput};
 
 use super::{ToolParser, ToolParserFactory, names};

--- a/rust/src/chat/src/parser/unified.rs
+++ b/rust/src/chat/src/parser/unified.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Unified parser registration and selection boundary for `vllm-chat`.
 
 use std::sync::LazyLock;

--- a/rust/src/chat/src/renderer/deepseek_v32/encoding.rs
+++ b/rust/src/chat/src/renderer/deepseek_v32/encoding.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! DeepSeek V3.2 prompt renderer.
 
 use std::collections::{HashMap, HashSet};

--- a/rust/src/chat/src/renderer/deepseek_v32/mod.rs
+++ b/rust/src/chat/src/renderer/deepseek_v32/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 mod encoding;
 
 use vllm_text::Prompt;

--- a/rust/src/chat/src/renderer/deepseek_v32/tests.rs
+++ b/rust/src/chat/src/renderer/deepseek_v32/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::path::PathBuf;
 
 use expect_test::{ExpectFile, expect, expect_file};

--- a/rust/src/chat/src/renderer/deepseek_v4/encoding.rs
+++ b/rust/src/chat/src/renderer/deepseek_v4/encoding.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! DeepSeek V4 prompt renderer.
 //!
 //! Original Python implementation:

--- a/rust/src/chat/src/renderer/deepseek_v4/mod.rs
+++ b/rust/src/chat/src/renderer/deepseek_v4/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 mod encoding;
 
 use vllm_text::Prompt;

--- a/rust/src/chat/src/renderer/deepseek_v4/tests.rs
+++ b/rust/src/chat/src/renderer/deepseek_v4/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::path::PathBuf;
 
 use expect_test::{ExpectFile, expect, expect_file};

--- a/rust/src/chat/src/renderer/harmony/encoding.rs
+++ b/rust/src/chat/src/renderer/harmony/encoding.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Shared Harmony encoding helper for the GPT-OSS renderer and output parser.
 
 use std::sync::LazyLock;

--- a/rust/src/chat/src/renderer/harmony/mod.rs
+++ b/rust/src/chat/src/renderer/harmony/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Native Harmony chat renderer for `gpt_oss`.
 
 pub(crate) mod encoding;

--- a/rust/src/chat/src/renderer/harmony/tests.rs
+++ b/rust/src/chat/src/renderer/harmony/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::path::PathBuf;
 
 use expect_test::{ExpectFile, expect, expect_file};

--- a/rust/src/chat/src/renderer/hf/error.rs
+++ b/rust/src/chat/src/renderer/hf/error.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use thiserror::Error as ThisError;
 
 #[derive(Debug, ThisError)]

--- a/rust/src/chat/src/renderer/hf/format.rs
+++ b/rust/src/chat/src/renderer/hf/format.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::{HashSet, VecDeque};
 use std::fmt;
 use std::str::FromStr;

--- a/rust/src/chat/src/renderer/hf/mod.rs
+++ b/rust/src/chat/src/renderer/hf/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::HashMap;
 
 use serde::Serialize;

--- a/rust/src/chat/src/renderer/hf/template.rs
+++ b/rust/src/chat/src/renderer/hf/template.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Chat template support for tokenizers using Jinja2 templates.
 //!
 //! This module is inlined from SMG's tokenizer crate with local adaptations:

--- a/rust/src/chat/src/renderer/hf/tojson.rs
+++ b/rust/src/chat/src/renderer/hf/tojson.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use minijinja::value::{Kwargs, ViaDeserialize};
 use minijinja::{Error as MinijinjaError, ErrorKind, Value};
 use serde::Deserialize;

--- a/rust/src/chat/src/renderer/hf/value.rs
+++ b/rust/src/chat/src/renderer/hf/value.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use indexmap::IndexMap;

--- a/rust/src/chat/src/renderer/mod.rs
+++ b/rust/src/chat/src/renderer/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/rust/src/chat/src/renderer/selection.rs
+++ b/rust/src/chat/src/renderer/selection.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::fmt;
 use std::str::FromStr;
 

--- a/rust/src/chat/src/renderer/test_utils.rs
+++ b/rust/src/chat/src/renderer/test_utils.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::fs;
 use std::path::Path;
 

--- a/rust/src/chat/src/request.rs
+++ b/rust/src/chat/src/request.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::HashMap;
 
 use llm_multimodal::ImageDetail;

--- a/rust/src/chat/src/stream.rs
+++ b/rust/src/chat/src/stream.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};

--- a/rust/src/chat/tests/chat.rs
+++ b/rust/src/chat/tests/chat.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::BTreeSet;
 use std::fmt;
 use std::sync::Arc;

--- a/rust/src/chat/tests/roundtrip.rs
+++ b/rust/src/chat/tests/roundtrip.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Roundtrip tests for the real chat-template and output-processor pairing.
 //!
 //! The invariant under test is that a structured assistant message rendered as history can be

--- a/rust/src/cmd/src/cli.rs
+++ b/rust/src/cmd/src/cli.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! CLI argument definitions for the `vllm-rs` binary.
 //!
 //! Python vLLM references:

--- a/rust/src/cmd/src/cli/tests.rs
+++ b/rust/src/cmd/src/cli/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use expect_test::expect;
 use vllm_engine_core_client::TransportMode;
 use vllm_server::{Config, HttpListenerMode, ParserSelection, RendererSelection};

--- a/rust/src/cmd/src/cli/unsupported.rs
+++ b/rust/src/cmd/src/cli/unsupported.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 #![allow(clippy::doc_lazy_continuation)]
 
 use std::fmt::Display;

--- a/rust/src/cmd/src/logging.rs
+++ b/rust/src/cmd/src/logging.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::{env, fmt, process};
 
 use time::UtcOffset;

--- a/rust/src/cmd/src/main.rs
+++ b/rust/src/cmd/src/main.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 mod cli;
 mod logging;
 

--- a/rust/src/engine-core-client/examples/external_engine_logprobs.rs
+++ b/rust/src/engine-core-client/examples/external_engine_logprobs.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};

--- a/rust/src/engine-core-client/examples/external_engine_utility_call.rs
+++ b/rust/src/engine-core-client/examples/external_engine_utility_call.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};

--- a/rust/src/engine-core-client/src/client.rs
+++ b/rust/src/engine-core-client/src/client.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/rust/src/engine-core-client/src/client/imp.rs
+++ b/rust/src/engine-core-client/src/client/imp.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/rust/src/engine-core-client/src/client/state.rs
+++ b/rust/src/engine-core-client/src/client/state.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::atomic::{AtomicU64, Ordering};
 

--- a/rust/src/engine-core-client/src/client/stream.rs
+++ b/rust/src/engine-core-client/src/client/stream.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::ops::Deref;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/rust/src/engine-core-client/src/coordinator/bootstrap.rs
+++ b/rust/src/engine-core-client/src/coordinator/bootstrap.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::Duration;
 
 use bytes::Bytes;

--- a/rust/src/engine-core-client/src/coordinator/external.rs
+++ b/rust/src/engine-core-client/src/coordinator/external.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};

--- a/rust/src/engine-core-client/src/coordinator/handle.rs
+++ b/rust/src/engine-core-client/src/coordinator/handle.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use parking_lot::Mutex;

--- a/rust/src/engine-core-client/src/coordinator/inproc.rs
+++ b/rust/src/engine-core-client/src/coordinator/inproc.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};

--- a/rust/src/engine-core-client/src/coordinator/mod.rs
+++ b/rust/src/engine-core-client/src/coordinator/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 mod bootstrap;
 mod external;
 mod handle;

--- a/rust/src/engine-core-client/src/error.rs
+++ b/rust/src/engine-core-client/src/error.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/rust/src/engine-core-client/src/lib.rs
+++ b/rust/src/engine-core-client/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 mod client;
 mod coordinator;
 mod error;

--- a/rust/src/engine-core-client/src/metrics.rs
+++ b/rust/src/engine-core-client/src/metrics.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/rust/src/engine-core-client/src/mock_engine.rs
+++ b/rust/src/engine-core-client/src/mock_engine.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::path::Path;
 use std::time::Duration;
 

--- a/rust/src/engine-core-client/src/protocol/dtype.rs
+++ b/rust/src/engine-core-client/src/protocol/dtype.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use serde::{Deserialize, Serialize};
 
 /// Effective model dtype reported by the engine after config resolution.

--- a/rust/src/engine-core-client/src/protocol/handshake.rs
+++ b/rust/src/engine-core-client/src/protocol/handshake.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};

--- a/rust/src/engine-core-client/src/protocol/logprobs.rs
+++ b/rust/src/engine-core-client/src/protocol/logprobs.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 mod array;
 #[cfg(test)]
 mod tests;

--- a/rust/src/engine-core-client/src/protocol/logprobs/array.rs
+++ b/rust/src/engine-core-client/src/protocol/logprobs/array.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::io::Cursor;
 
 use byteorder::{BigEndian, LittleEndian, NativeEndian, ReadBytesExt};

--- a/rust/src/engine-core-client/src/protocol/logprobs/tests.rs
+++ b/rust/src/engine-core-client/src/protocol/logprobs/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::BTreeSet;
 
 use bytes::Bytes;

--- a/rust/src/engine-core-client/src/protocol/logprobs/wire.rs
+++ b/rust/src/engine-core-client/src/protocol/logprobs/wire.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use crate::protocol::tensor::WireNdArray;

--- a/rust/src/engine-core-client/src/protocol/lora.rs
+++ b/rust/src/engine-core-client/src/protocol/lora.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use crate::protocol::OpaqueValue;

--- a/rust/src/engine-core-client/src/protocol/mod.rs
+++ b/rust/src/engine-core-client/src/protocol/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::any::type_name;
 use std::io::Cursor;
 

--- a/rust/src/engine-core-client/src/protocol/multimodal.rs
+++ b/rust/src/engine-core-client/src/protocol/multimodal.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};

--- a/rust/src/engine-core-client/src/protocol/output.rs
+++ b/rust/src/engine-core-client/src/protocol/output.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::BTreeSet;
 
 use enum_as_inner::EnumAsInner;

--- a/rust/src/engine-core-client/src/protocol/request.rs
+++ b/rust/src/engine-core-client/src/protocol/request.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::{BTreeMap, HashMap};
 
 use bytes::Bytes;

--- a/rust/src/engine-core-client/src/protocol/sampling.rs
+++ b/rust/src/engine-core-client/src/protocol/sampling.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::{BTreeSet, HashMap};
 
 use serde::{Deserialize, Serialize};

--- a/rust/src/engine-core-client/src/protocol/stats.rs
+++ b/rust/src/engine-core-client/src/protocol/stats.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};

--- a/rust/src/engine-core-client/src/protocol/structured_outputs.rs
+++ b/rust/src/engine-core-client/src/protocol/structured_outputs.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use enum_as_inner::EnumAsInner;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;

--- a/rust/src/engine-core-client/src/protocol/tensor.rs
+++ b/rust/src/engine-core-client/src/protocol/tensor.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use bytemuck::allocation::pod_collect_to_vec;
 use enum_as_inner::EnumAsInner;
 use half::{bf16, f16};

--- a/rust/src/engine-core-client/src/protocol/utility.rs
+++ b/rust/src/engine-core-client/src/protocol/utility.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::any::type_name;
 use std::fmt;
 use std::str::FromStr;

--- a/rust/src/engine-core-client/src/runtime.rs
+++ b/rust/src/engine-core-client/src/runtime.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
 use std::sync::OnceLock;

--- a/rust/src/engine-core-client/src/test_utils.rs
+++ b/rust/src/engine-core-client/src/test_utils.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::future::Future;
 use std::path::Path;
 use std::pin::Pin;

--- a/rust/src/engine-core-client/src/tests/client.rs
+++ b/rust/src/engine-core-client/src/tests/client.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
 use std::io::Cursor;

--- a/rust/src/engine-core-client/src/tests/mod.rs
+++ b/rust/src/engine-core-client/src/tests/mod.rs
@@ -1,1 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 mod client;

--- a/rust/src/engine-core-client/src/transport.rs
+++ b/rust/src/engine-core-client/src/transport.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
 use std::ops::Deref;

--- a/rust/src/llm/examples/external_engine_smoke.rs
+++ b/rust/src/llm/examples/external_engine_smoke.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};

--- a/rust/src/llm/src/error.rs
+++ b/rust/src/llm/src/error.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/rust/src/llm/src/inflight.rs
+++ b/rust/src/llm/src/inflight.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Tracking of the external→internal request-id mapping for in-flight requests.
 //!
 //! When request-id randomization is enabled (the default), [`crate::Llm`]

--- a/rust/src/llm/src/lib.rs
+++ b/rust/src/llm/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use tracing::Span;
 use vllm_engine_core_client::EngineCoreClient;
 

--- a/rust/src/llm/src/log_stats.rs
+++ b/rust/src/llm/src/log_stats.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::fmt::Write;
 use std::time::{Duration, Instant};
 

--- a/rust/src/llm/src/output.rs
+++ b/rust/src/llm/src/output.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;

--- a/rust/src/llm/src/request.rs
+++ b/rust/src/llm/src/request.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::BTreeMap;
 
 use uuid::Uuid;

--- a/rust/src/llm/src/request_metrics.rs
+++ b/rust/src/llm/src/request_metrics.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use vllm_engine_core_client::protocol::output::{

--- a/rust/src/llm/tests/generate.rs
+++ b/rust/src/llm/tests/generate.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::BTreeSet;
 use std::sync::Once;
 use std::time::Duration;

--- a/rust/src/managed-engine/src/cli.rs
+++ b/rust/src/managed-engine/src/cli.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::HashSet;
 use std::ffi::OsString;
 

--- a/rust/src/managed-engine/src/lib.rs
+++ b/rust/src/managed-engine/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 pub mod cli;
 mod process;
 

--- a/rust/src/managed-engine/src/process.rs
+++ b/rust/src/managed-engine/src/process.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::io;
 use std::net::TcpListener;
 use std::process::{Command as StdCommand, ExitStatus, Stdio};

--- a/rust/src/metrics/src/api_server.rs
+++ b/rust/src/metrics/src/api_server.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::histogram::Histogram;

--- a/rust/src/metrics/src/lib.rs
+++ b/rust/src/metrics/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::fmt;
 use std::sync::LazyLock;
 use std::sync::atomic::AtomicU64;

--- a/rust/src/metrics/src/request.rs
+++ b/rust/src/metrics/src/request.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::histogram::Histogram;

--- a/rust/src/metrics/src/scheduler.rs
+++ b/rust/src/metrics/src/scheduler.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
 

--- a/rust/src/mock-engine/src/engine.rs
+++ b/rust/src/mock-engine/src/engine.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::hash::{Hash as _, Hasher as _};
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/rust/src/mock-engine/src/io.rs
+++ b/rust/src/mock-engine/src/io.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use anyhow::{Context as _, Result, anyhow, bail};
 use futures::{Stream, StreamExt as _, stream};
 use tokio::sync::mpsc;

--- a/rust/src/mock-engine/src/lib.rs
+++ b/rust/src/mock-engine/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use anyhow::{Context, Result, bail};
 use clap::Parser;
 use tokio::sync::mpsc;

--- a/rust/src/mock-engine/src/main.rs
+++ b/rust/src/mock-engine/src/main.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use anyhow::{Context, Result};
 use clap::Parser as _;
 use tokio_util::sync::CancellationToken;

--- a/rust/src/mock-engine/src/tests.rs
+++ b/rust/src/mock-engine/src/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::net::TcpListener;
 use std::time::Duration;
 

--- a/rust/src/parser/benches/deepseek_v3.rs
+++ b/rust/src/parser/benches/deepseek_v3.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::Duration;
 
 use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, criterion_main};

--- a/rust/src/parser/benches/deepseek_v31.rs
+++ b/rust/src/parser/benches/deepseek_v31.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::Duration;
 
 use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, criterion_main};

--- a/rust/src/parser/benches/deepseek_v32.rs
+++ b/rust/src/parser/benches/deepseek_v32.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::Duration;
 
 use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, criterion_main};

--- a/rust/src/parser/benches/gemma4.rs
+++ b/rust/src/parser/benches/gemma4.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::Duration;
 
 use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, criterion_main};

--- a/rust/src/parser/benches/glm45_moe.rs
+++ b/rust/src/parser/benches/glm45_moe.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::Duration;
 
 use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, criterion_main};

--- a/rust/src/parser/benches/granite4.rs
+++ b/rust/src/parser/benches/granite4.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::Duration;
 
 use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, criterion_main};

--- a/rust/src/parser/benches/kimi_k2.rs
+++ b/rust/src/parser/benches/kimi_k2.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::Duration;
 
 use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, criterion_main};

--- a/rust/src/parser/benches/llama3_json.rs
+++ b/rust/src/parser/benches/llama3_json.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::Duration;
 
 use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, criterion_main};

--- a/rust/src/parser/benches/minimax_m2.rs
+++ b/rust/src/parser/benches/minimax_m2.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::Duration;
 
 use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, criterion_main};

--- a/rust/src/parser/benches/qwen3_coder.rs
+++ b/rust/src/parser/benches/qwen3_coder.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::Duration;
 
 use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, criterion_main};

--- a/rust/src/parser/benches/qwen3_xml.rs
+++ b/rust/src/parser/benches/qwen3_xml.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::Duration;
 
 use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, criterion_main};

--- a/rust/src/parser/benches/utils/adapter.rs
+++ b/rust/src/parser/benches/utils/adapter.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use vllm_parser::tool::{

--- a/rust/src/parser/benches/utils/mod.rs
+++ b/rust/src/parser/benches/utils/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 // This module is shared by multiple benchmark targets.
 // There could be false positives for unused code or imports, and fixing them would lead to some other benchmarks failing to compile.
 #![allow(dead_code)]

--- a/rust/src/parser/python/src/lib.rs
+++ b/rust/src/parser/python/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Thin PyO3 bindings for `vllm_parser::tool`.
 //!
 //! This crate exposes the Rust tool parser trait and data shapes to Python

--- a/rust/src/parser/src/lib.rs
+++ b/rust/src/parser/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Streaming parsers for chat completions.
 
 pub mod reasoning;

--- a/rust/src/parser/src/reasoning/cohere_cmd.rs
+++ b/rust/src/parser/src/reasoning/cohere_cmd.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use vllm_tokenizer::DynTokenizer;
 
 use super::{DelimitedReasoningParser, ReasoningDelta, ReasoningParser, Result};

--- a/rust/src/parser/src/reasoning/deepseek_r1.rs
+++ b/rust/src/parser/src/reasoning/deepseek_r1.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use vllm_tokenizer::DynTokenizer;
 
 use super::{DelimitedReasoningParser, ReasoningDelta, ReasoningParser, Result};

--- a/rust/src/parser/src/reasoning/delimited.rs
+++ b/rust/src/parser/src/reasoning/delimited.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use vllm_tokenizer::{DynTokenizer, Tokenizer};
 
 use super::{ReasoningDelta, ReasoningError, Result};

--- a/rust/src/parser/src/reasoning/kimi.rs
+++ b/rust/src/parser/src/reasoning/kimi.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use vllm_tokenizer::DynTokenizer;
 
 use super::{DelimitedReasoningParser, ReasoningDelta, ReasoningParser, Result};

--- a/rust/src/parser/src/reasoning/minimax_m3.rs
+++ b/rust/src/parser/src/reasoning/minimax_m3.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use vllm_tokenizer::DynTokenizer;
 
 use super::{DelimitedReasoningParser, ReasoningDelta, ReasoningParser, Result};

--- a/rust/src/parser/src/reasoning/mod.rs
+++ b/rust/src/parser/src/reasoning/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Streaming reasoning parsers for chat completions.
 //!
 //! The key design choice here is that parser initialization prefers the

--- a/rust/src/parser/src/reasoning/qwen3.rs
+++ b/rust/src/parser/src/reasoning/qwen3.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use vllm_tokenizer::DynTokenizer;
 
 use super::{DelimitedReasoningParser, ReasoningDelta, ReasoningParser, Result};

--- a/rust/src/parser/src/reasoning/seed_oss.rs
+++ b/rust/src/parser/src/reasoning/seed_oss.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use vllm_tokenizer::DynTokenizer;
 
 use super::{DelimitedReasoningParser, ReasoningDelta, ReasoningParser, Result};

--- a/rust/src/parser/src/reasoning/step3p5.rs
+++ b/rust/src/parser/src/reasoning/step3p5.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use vllm_tokenizer::DynTokenizer;
 
 use super::{DelimitedReasoningParser, ReasoningDelta, ReasoningParser, Result};

--- a/rust/src/parser/src/reasoning/tests.rs
+++ b/rust/src/parser/src/reasoning/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use vllm_tokenizer::test_utils::TestTokenizer;

--- a/rust/src/parser/src/tool/deepseek_dsml/deepseek_v32.rs
+++ b/rust/src/parser/src/tool/deepseek_dsml/deepseek_v32.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use super::{DeepSeekDsmlToolParser, DsmlTokens};
 use crate::tool::{Result, StructuralTagModel, Tool, ToolParser, ToolParserOutput};
 

--- a/rust/src/parser/src/tool/deepseek_dsml/deepseek_v4.rs
+++ b/rust/src/parser/src/tool/deepseek_dsml/deepseek_v4.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use super::{DeepSeekDsmlToolParser, DsmlTokens};
 use crate::tool::{Result, StructuralTagModel, Tool, ToolParser, ToolParserOutput};
 

--- a/rust/src/parser/src/tool/deepseek_dsml/mod.rs
+++ b/rust/src/parser/src/tool/deepseek_dsml/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use winnow::ascii::{multispace0 as ws0, multispace1 as ws1};
 use winnow::combinator::{alt, delimited, eof, repeat, seq, terminated};
 use winnow::prelude::*;

--- a/rust/src/parser/src/tool/deepseek_json/deepseek_v3.rs
+++ b/rust/src/parser/src/tool/deepseek_json/deepseek_v3.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use super::{DeepSeekJsonFormat, DeepSeekJsonToolParser};
 use crate::tool::{Result, StructuralTagModel, Tool, ToolParser, ToolParserOutput};
 

--- a/rust/src/parser/src/tool/deepseek_json/deepseek_v31.rs
+++ b/rust/src/parser/src/tool/deepseek_json/deepseek_v31.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use super::{DeepSeekJsonFormat, DeepSeekJsonToolParser};
 use crate::tool::{Result, StructuralTagModel, Tool, ToolParser, ToolParserOutput};
 

--- a/rust/src/parser/src/tool/deepseek_json/mod.rs
+++ b/rust/src/parser/src/tool/deepseek_json/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 mod deepseek_v3;
 mod deepseek_v31;
 

--- a/rust/src/parser/src/tool/error.rs
+++ b/rust/src/parser/src/tool/error.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use thiserror::Error;
 use thiserror_ext::Macro;
 

--- a/rust/src/parser/src/tool/glm_xml/glm45_moe.rs
+++ b/rust/src/parser/src/tool/glm_xml/glm45_moe.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use super::{GlmXmlToolParser, Separator};
 use crate::tool::{Result, Tool, ToolParser, ToolParserOutput};
 

--- a/rust/src/parser/src/tool/glm_xml/glm47_moe.rs
+++ b/rust/src/parser/src/tool/glm_xml/glm47_moe.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use super::{GlmXmlToolParser, Separator};
 use crate::tool::{Result, StructuralTagModel, Tool, ToolParser, ToolParserOutput};
 

--- a/rust/src/parser/src/tool/glm_xml/mod.rs
+++ b/rust/src/parser/src/tool/glm_xml/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use winnow::ascii::multispace0 as ws0;
 use winnow::combinator::{alt, eof, repeat, seq, terminated};
 use winnow::prelude::*;

--- a/rust/src/parser/src/tool/hy_v3.rs
+++ b/rust/src/parser/src/tool/hy_v3.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use winnow::ascii::multispace0 as ws0;
 use winnow::combinator::{alt, delimited, eof, repeat, seq, terminated};
 use winnow::prelude::*;

--- a/rust/src/parser/src/tool/json/granite4.rs
+++ b/rust/src/parser/src/tool/json/granite4.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use winnow::ascii::multispace0 as ws0;
 use winnow::combinator::{alt, peek, seq};
 use winnow::error::{ContextError, ErrMode, ModalResult, StrContext};

--- a/rust/src/parser/src/tool/json/hermes.rs
+++ b/rust/src/parser/src/tool/json/hermes.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use super::{JsonToolCallConfig, JsonToolCallParser, JsonToolCallWhitespace};
 use crate::tool::{Result, StructuralTagModel, Tool, ToolParser, ToolParserOutput};
 

--- a/rust/src/parser/src/tool/json/internlm2.rs
+++ b/rust/src/parser/src/tool/json/internlm2.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use super::{JsonToolCallConfig, JsonToolCallParser, JsonToolCallWhitespace};
 use crate::tool::{Result, Tool, ToolParser, ToolParserOutput};
 

--- a/rust/src/parser/src/tool/json/llama.rs
+++ b/rust/src/parser/src/tool/json/llama.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use winnow::ascii::multispace0 as ws0;
 use winnow::combinator::seq;
 use winnow::error::{ModalResult, StrContext};

--- a/rust/src/parser/src/tool/json/mistral.rs
+++ b/rust/src/parser/src/tool/json/mistral.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use super::{JsonToolCallConfig, JsonToolCallParser, JsonToolCallWhitespace};
 use crate::tool::{Result, Tool, ToolParser, ToolParserOutput};
 

--- a/rust/src/parser/src/tool/json/mod.rs
+++ b/rust/src/parser/src/tool/json/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Shared parser core for JSON tool calls wrapped by text markers.
 
 pub use granite4::Granite4ToolParser;

--- a/rust/src/parser/src/tool/json/phi4mini.rs
+++ b/rust/src/parser/src/tool/json/phi4mini.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use super::{JsonToolCallConfig, JsonToolCallParser, JsonToolCallWhitespace};
 use crate::tool::{Result, Tool, ToolParser, ToolParserOutput};
 

--- a/rust/src/parser/src/tool/json/qwen.rs
+++ b/rust/src/parser/src/tool/json/qwen.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use super::{JsonToolCallConfig, JsonToolCallParser, JsonToolCallWhitespace};
 use crate::tool::{Result, StructuralTagModel, Tool, ToolParser, ToolParserOutput};
 

--- a/rust/src/parser/src/tool/kimi_k2.rs
+++ b/rust/src/parser/src/tool/kimi_k2.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::BTreeMap;
 
 use winnow::ascii::{digit1, multispace0 as ws0};

--- a/rust/src/parser/src/tool/minimax_m2.rs
+++ b/rust/src/parser/src/tool/minimax_m2.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use winnow::ascii::{multispace0 as ws0, multispace1 as ws1};
 use winnow::combinator::{alt, delimited, eof, repeat, seq, terminated};
 use winnow::prelude::*;

--- a/rust/src/parser/src/tool/minimax_m3.rs
+++ b/rust/src/parser/src/tool/minimax_m3.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use winnow::ascii::{multispace0 as ws0, multispace1 as ws1};
 use winnow::combinator::{alt, delimited, seq};
 use winnow::error::{ContextError, ErrMode};

--- a/rust/src/parser/src/tool/mod.rs
+++ b/rust/src/parser/src/tool/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Streaming tool parsers for chat completions.
 
 #[macro_use]

--- a/rust/src/parser/src/tool/parameters.rs
+++ b/rust/src/parser/src/tool/parameters.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::BTreeMap;
 
 use serde_json::{Map, Number, Value};

--- a/rust/src/parser/src/tool/qwen_coder.rs
+++ b/rust/src/parser/src/tool/qwen_coder.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use winnow::ascii::multispace0 as ws0;
 use winnow::combinator::{alt, delimited, eof, repeat, seq, terminated};
 use winnow::prelude::*;

--- a/rust/src/parser/src/tool/test_utils.rs
+++ b/rust/src/parser/src/tool/test_utils.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use serde_json::json;
 
 use super::{ToolParser, ToolParserOutput};

--- a/rust/src/parser/src/tool/tests.rs
+++ b/rust/src/parser/src/tool/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use super::{Result, Tool, ToolCallDelta, ToolParser, ToolParserEvent, ToolParserOutput};
 use crate::tool::ToolParserTestExt as _;
 

--- a/rust/src/parser/src/unified/combined.rs
+++ b/rust/src/parser/src/unified/combined.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Adapter that combines reasoning and tool parsers.
 
 use vllm_tokenizer::DynTokenizer;

--- a/rust/src/parser/src/unified/gemma4.rs
+++ b/rust/src/parser/src/unified/gemma4.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use serde_json::{Map, Number, Value};
 use vllm_tokenizer::DynTokenizer;
 use winnow::ascii::multispace0 as ws0;

--- a/rust/src/parser/src/unified/mod.rs
+++ b/rust/src/parser/src/unified/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Unified parser interface for reasoning and tool-call deltas.
 
 mod combined;

--- a/rust/src/parser/src/utils.rs
+++ b/rust/src/parser/src/utils.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Shared helpers for streaming parsers.
 
 use winnow::Parser;

--- a/rust/src/server/build.rs
+++ b/rust/src/server/build.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let proto_dir = format!("{manifest_dir}/../../proto");

--- a/rust/src/server/examples/external_engine_openai_qwen.rs
+++ b/rust/src/server/examples/external_engine_openai_qwen.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};

--- a/rust/src/server/src/config.rs
+++ b/rust/src/server/src/config.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::HashMap;
 use std::fmt;
 use std::time::Duration;

--- a/rust/src/server/src/error.rs
+++ b/rust/src/server/src/error.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use axum::Json;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};

--- a/rust/src/server/src/grpc/convert.rs
+++ b/rust/src/server/src/grpc/convert.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Conversion between gRPC protobuf types and internal `vllm-text`
 //! request/response types.
 

--- a/rust/src/server/src/grpc/mod.rs
+++ b/rust/src/server/src/grpc/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! gRPC Generate service backed by the shared [`vllm_text::TextLlm`] facade.
 
 mod convert;

--- a/rust/src/server/src/grpc/tests.rs
+++ b/rust/src/server/src/grpc/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::future::Future;
 use std::io;
 use std::pin::Pin;

--- a/rust/src/server/src/lib.rs
+++ b/rust/src/server/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Minimal OpenAI-compatible HTTP server above [`vllm_chat`].
 
 mod config;

--- a/rust/src/server/src/listener.rs
+++ b/rust/src/server/src/listener.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Unified listener wrapper for the Rust frontend.
 //!
 //! This module hides the difference between TCP and Unix-domain listeners so

--- a/rust/src/server/src/lora.rs
+++ b/rust/src/server/src/lora.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use indexmap::IndexMap;

--- a/rust/src/server/src/middleware/auth.rs
+++ b/rust/src/server/src/middleware/auth.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use axum::Json;

--- a/rust/src/server/src/middleware/cors.rs
+++ b/rust/src/server/src/middleware/cors.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! CORS support mirroring Python's Starlette `CORSMiddleware`.
 //!
 //! Built on `tower_http::cors::CorsLayer`, configured to reproduce Starlette's

--- a/rust/src/server/src/middleware/load.rs
+++ b/rust/src/server/src/middleware/load.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::pin::Pin;
 use std::sync::{Arc, Weak};
 use std::task::{Context, Poll};

--- a/rust/src/server/src/middleware/metrics.rs
+++ b/rust/src/server/src/middleware/metrics.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::time::Instant;
 
 use axum::extract::{MatchedPath, Request};

--- a/rust/src/server/src/middleware/mod.rs
+++ b/rust/src/server/src/middleware/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 mod auth;
 mod cors;
 mod load;

--- a/rust/src/server/src/middleware/offload.rs
+++ b/rust/src/server/src/middleware/offload.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 use std::task::{Context, Poll};
 

--- a/rust/src/server/src/middleware/request_id.rs
+++ b/rust/src/server/src/middleware/request_id.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use axum::extract::Request;
 use axum::http::HeaderValue;
 use axum::http::header::HeaderName;

--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 mod abort_requests;
 mod cache;
 mod collective_rpc;

--- a/rust/src/server/src/routes/abort_requests.rs
+++ b/rust/src/server/src/routes/abort_requests.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use axum::Json;

--- a/rust/src/server/src/routes/cache.rs
+++ b/rust/src/server/src/routes/cache.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use axum::Json;

--- a/rust/src/server/src/routes/collective_rpc.rs
+++ b/rust/src/server/src/routes/collective_rpc.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::BTreeMap;
 use std::sync::Arc;
 

--- a/rust/src/server/src/routes/health.rs
+++ b/rust/src/server/src/routes/health.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use axum::extract::State;

--- a/rust/src/server/src/routes/http_client_tests.rs
+++ b/rust/src/server/src/routes/http_client_tests.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Integration tests that exercise the OpenAI-compatible HTTP API through a
 //! real TCP connection using the `async-openai` client library, backed by a
 //! mock engine.

--- a/rust/src/server/src/routes/inference/generate.rs
+++ b/rust/src/server/src/routes/inference/generate.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 mod convert;
 mod types;
 mod validate;

--- a/rust/src/server/src/routes/inference/generate/convert.rs
+++ b/rust/src/server/src/routes/inference/generate/convert.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use vllm_text::{Prompt, TextDecodeOptions, TextRequest};
 
 use super::types::GenerateRequest;

--- a/rust/src/server/src/routes/inference/generate/types.rs
+++ b/rust/src/server/src/routes/inference/generate/types.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};

--- a/rust/src/server/src/routes/inference/generate/validate.rs
+++ b/rust/src/server/src/routes/inference/generate/validate.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use super::types::GenerateRequest;
 use crate::error::{ApiError, bail_invalid_request};
 

--- a/rust/src/server/src/routes/inference/mod.rs
+++ b/rust/src/server/src/routes/inference/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 pub mod generate;
 
 pub use generate::generate;

--- a/rust/src/server/src/routes/load.rs
+++ b/rust/src/server/src/routes/load.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use axum::Json;

--- a/rust/src/server/src/routes/lora.rs
+++ b/rust/src/server/src/routes/lora.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 

--- a/rust/src/server/src/routes/metrics.rs
+++ b/rust/src/server/src/routes/metrics.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use axum::http::header::CONTENT_TYPE;
 use axum::http::{HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};

--- a/rust/src/server/src/routes/openai/chat_completions.rs
+++ b/rust/src/server/src/routes/openai/chat_completions.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 pub(crate) mod convert;
 mod types;
 mod validate;

--- a/rust/src/server/src/routes/openai/chat_completions/convert.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/convert.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use itertools::Itertools as _;
 use vllm_chat::{
     AssistantContentBlock, AssistantToolCall, ChatContent, ChatContentPart,

--- a/rust/src/server/src/routes/openai/chat_completions/types.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/types.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::HashMap;
 use std::fmt;
 

--- a/rust/src/server/src/routes/openai/chat_completions/validate.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/validate.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use super::types::ChatCompletionRequest;
 use crate::error::{ApiError, bail_invalid_request};
 use crate::routes::openai::utils::types::{ChatMessage, Tool};

--- a/rust/src/server/src/routes/openai/completions.rs
+++ b/rust/src/server/src/routes/openai/completions.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 mod convert;
 mod types;
 mod validate;

--- a/rust/src/server/src/routes/openai/completions/convert.rs
+++ b/rust/src/server/src/routes/openai/completions/convert.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use thiserror_ext::AsReport as _;
 use vllm_text::tokenizer::Tokenizer;
 use vllm_text::{Prompt, SamplingParams, TextDecodeOptions, TextRequest};

--- a/rust/src/server/src/routes/openai/completions/types.rs
+++ b/rust/src/server/src/routes/openai/completions/types.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};

--- a/rust/src/server/src/routes/openai/completions/validate.rs
+++ b/rust/src/server/src/routes/openai/completions/validate.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use super::types::CompletionRequest;
 use crate::error::{ApiError, bail_invalid_request};
 

--- a/rust/src/server/src/routes/openai/mod.rs
+++ b/rust/src/server/src/routes/openai/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 pub mod chat_completions;
 mod completions;
 mod models;

--- a/rust/src/server/src/routes/openai/models.rs
+++ b/rust/src/server/src/routes/openai/models.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/rust/src/server/src/routes/openai/utils/logprobs.rs
+++ b/rust/src/server/src/routes/openai/utils/logprobs.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::HashMap;
 
 use itertools::Itertools as _;

--- a/rust/src/server/src/routes/openai/utils/mod.rs
+++ b/rust/src/server/src/routes/openai/utils/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 pub mod logprobs;
 pub mod structured_outputs;
 pub mod types;

--- a/rust/src/server/src/routes/openai/utils/structured_outputs.rs
+++ b/rust/src/server/src/routes/openai/utils/structured_outputs.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use vllm_engine_core_client::protocol::structured_outputs::StructuredOutputsParams;

--- a/rust/src/server/src/routes/openai/utils/types.rs
+++ b/rust/src/server/src/routes/openai/utils/types.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::HashMap;
 use std::slice;
 

--- a/rust/src/server/src/routes/openai/utils/usage.rs
+++ b/rust/src/server/src/routes/openai/utils/usage.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use super::types::Usage;
 
 /// Tracks cumulative token counts for OpenAI streaming chunks.

--- a/rust/src/server/src/routes/openai/utils/validated_json.rs
+++ b/rust/src/server/src/routes/openai/utils/validated_json.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Validated JSON extractor for automatic request validation.
 //! Variation of https://github.com/lightseekorg/smg/blob/main/crates/protocols/src/validated.rs
 

--- a/rust/src/server/src/routes/pause.rs
+++ b/rust/src/server/src/routes/pause.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use axum::Json;

--- a/rust/src/server/src/routes/profile.rs
+++ b/rust/src/server/src/routes/profile.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use axum::extract::State;

--- a/rust/src/server/src/routes/server_info.rs
+++ b/rust/src/server/src/routes/server_info.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use axum::Json;

--- a/rust/src/server/src/routes/sleep.rs
+++ b/rust/src/server/src/routes/sleep.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use axum::Json;

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 // Route tests should use `Service::call` rather than `ServiceExt::oneshot`.
 // `oneshot` consumes the router and can drop `AppState` before a streaming
 // response body is fully drained, which closes the mock engine connection too

--- a/rust/src/server/src/routes/tokenize.rs
+++ b/rust/src/server/src/routes/tokenize.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! `POST /tokenize` and `POST /detokenize` (root paths, matching Python).
 //!
 //! Encode/decode runs entirely in-process via [`DynTokenizer`]; the inference

--- a/rust/src/server/src/routes/tokenize/types.rs
+++ b/rust/src/server/src/routes/tokenize/types.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::HashMap;
 
 use itertools::Itertools as _;

--- a/rust/src/server/src/routes/version.rs
+++ b/rust/src/server/src/routes/version.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use axum::Json;

--- a/rust/src/server/src/routes/world_size.rs
+++ b/rust/src/server/src/routes/world_size.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use axum::Json;

--- a/rust/src/server/src/runtime.rs
+++ b/rust/src/server/src/runtime.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use tokio::runtime::Builder;
 use tracing::{info, warn};
 use vllm_engine_core_client::runtime::BackgroundShutdownRuntime;

--- a/rust/src/server/src/server_info.rs
+++ b/rust/src/server/src/server_info.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::BTreeMap;
 
 use serde_json::{Value, json};

--- a/rust/src/server/src/state.rs
+++ b/rust/src/server/src/state.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 

--- a/rust/src/server/src/tls.rs
+++ b/rust/src/server/src/tls.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! OpenSSL server-config construction for TLS termination.
 //!
 //! Builds an OpenSSL [`SslContext`] from the uvicorn-style `ssl_*` arguments

--- a/rust/src/server/src/tls_tests.rs
+++ b/rust/src/server/src/tls_tests.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! TLS tests: `build_server_config` unit checks plus end-to-end OpenSSL handshakes
 //! through the production listener/connection path, with a trivial router since TLS
 //! terminates below the app.

--- a/rust/src/server/src/utils.rs
+++ b/rust/src/server/src/utils.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/rust/src/text/src/backend/hf/config.rs
+++ b/rust/src/text/src/backend/hf/config.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;

--- a/rust/src/text/src/backend/hf/mod.rs
+++ b/rust/src/text/src/backend/hf/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 mod config;
 mod model_files;
 

--- a/rust/src/text/src/backend/hf/model_files.rs
+++ b/rust/src/text/src/backend/hf/model_files.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::path::{Path, PathBuf};
 
 use hf_hub::Cache;

--- a/rust/src/text/src/backend/mod.rs
+++ b/rust/src/text/src/backend/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 pub mod hf;
 
 use std::sync::Arc;

--- a/rust/src/text/src/error.rs
+++ b/rust/src/text/src/error.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use thiserror::Error;
 use vllm_engine_core_client::Error as EngineCoreError;
 use vllm_llm::Error as LlmError;

--- a/rust/src/text/src/lib.rs
+++ b/rust/src/text/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Shared text-generation support used by chat and future raw completions.
 //!
 //! This crate intentionally stays below chat semantics:

--- a/rust/src/text/src/lower.rs
+++ b/rust/src/text/src/lower.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::BTreeSet;
 
 pub(crate) mod logprobs;

--- a/rust/src/text/src/lower/logprobs.rs
+++ b/rust/src/text/src/lower/logprobs.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Python-compatible validation for logprobs sampling params.
 //!
 //! `-1` is expanded only for bounds checks. The original request values are

--- a/rust/src/text/src/lower/token_ids.rs
+++ b/rust/src/text/src/lower/token_ids.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::result::Result;
 
 use thiserror::Error;

--- a/rust/src/text/src/output/decoded.rs
+++ b/rust/src/text/src/output/decoded.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use asynk_strim_attr::{TryYielder, try_stream};

--- a/rust/src/text/src/output/logprobs.rs
+++ b/rust/src/text/src/output/logprobs.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use itertools::Itertools as _;
 use serde::{Deserialize, Serialize};
 use vllm_llm::{Logprobs, PositionLogprobs};

--- a/rust/src/text/src/output/mod.rs
+++ b/rust/src/text/src/output/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Output processing helpers shared by text and chat layers.
 
 pub use decoded::{DecodedTextEvent, Finished, TextDecodeOptions, decoded_text_event_stream};

--- a/rust/src/text/src/request.rs
+++ b/rust/src/text/src/request.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::HashMap;
 
 use enum_as_inner::EnumAsInner;

--- a/rust/src/tokenizer/benches/hf.rs
+++ b/rust/src/tokenizer/benches/hf.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use hf_hub::api::tokio::ApiBuilder;
 use tokio::runtime::Runtime;

--- a/rust/src/tokenizer/benches/tiktoken.rs
+++ b/rust/src/tokenizer/benches/tiktoken.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use hf_hub::api::tokio::ApiBuilder;
 use tokio::runtime::Runtime;

--- a/rust/src/tokenizer/src/byte_level_decode.rs
+++ b/rust/src/tokenizer/src/byte_level_decode.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 //! Fast GPT-2 byte-level detokenization that writes into a single `Vec<u8>`,
 //! avoiding the `Vec<String>` / `String::join` assembly in fastokens' generic
 //! `Decoder::decode` pipeline.

--- a/rust/src/tokenizer/src/error.rs
+++ b/rust/src/tokenizer/src/error.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use thiserror::Error;
 use thiserror_ext::Macro;
 

--- a/rust/src/tokenizer/src/hf.rs
+++ b/rust/src/tokenizer/src/hf.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::path::Path;
 use std::sync::Arc;
 

--- a/rust/src/tokenizer/src/hf/added_tokens.rs
+++ b/rust/src/tokenizer/src/hf/added_tokens.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::fs;
 use std::path::Path;
 

--- a/rust/src/tokenizer/src/incremental.rs
+++ b/rust/src/tokenizer/src/incremental.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::mem::take;
 
 use crate::{Result, Tokenizer};

--- a/rust/src/tokenizer/src/lib.rs
+++ b/rust/src/tokenizer/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::sync::Arc;
 
 use crate::incremental::DecodeStream;

--- a/rust/src/tokenizer/src/tekken.rs
+++ b/rust/src/tokenizer/src/tekken.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::path::Path;
 
 use tekken::Tekkenizer;

--- a/rust/src/tokenizer/src/test_utils.rs
+++ b/rust/src/tokenizer/src/test_utils.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::BTreeMap;
 
 use crate::{Result, Tokenizer, TokenizerError};

--- a/rust/src/tokenizer/src/tiktoken.rs
+++ b/rust/src/tokenizer/src/tiktoken.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Mutex;

--- a/tools/pre_commit/check_spdx_header.py
+++ b/tools/pre_commit/check_spdx_header.py
@@ -2,7 +2,17 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import sys
+from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class HeaderStyle:
+    """Comment syntax and preamble handling for an SPDX header."""
+
+    comment_prefix: str
+    preserve_shebang: bool = False
 
 
 class SPDXStatus(Enum):
@@ -15,37 +25,56 @@ class SPDXStatus(Enum):
     MISSING_BOTH = "missing_both"  # Completely missing
 
 
-FULL_SPDX_HEADER = (
-    "# SPDX-License-Identifier: Apache-2.0\n"
-    "# SPDX-FileCopyrightText: Copyright contributors to the vLLM project"
-)
+LICENSE_TEXT = "SPDX-License-Identifier: Apache-2.0"
+COPYRIGHT_TEXT = "SPDX-FileCopyrightText: Copyright contributors to the vLLM project"
+FILE_STYLES = {
+    ".py": HeaderStyle("#", preserve_shebang=True),
+    ".rs": HeaderStyle("//"),
+    ".proto": HeaderStyle("//"),
+}
 
-LICENSE_LINE = "# SPDX-License-Identifier: Apache-2.0"
-COPYRIGHT_LINE = "# SPDX-FileCopyrightText: Copyright contributors to the vLLM project"  # noqa: E501
+
+def file_style(file_path):
+    """Return the declared header style for a file."""
+    suffix = Path(file_path).suffix
+    try:
+        return FILE_STYLES[suffix]
+    except KeyError:
+        raise ValueError(f"Unsupported file type: {file_path}") from None
+
+
+def spdx_header(style):
+    """Return the SPDX header for a file style."""
+    license_line = f"{style.comment_prefix} {LICENSE_TEXT}"
+    copyright_line = f"{style.comment_prefix} {COPYRIGHT_TEXT}"
+    return license_line, copyright_line
+
+
+def header_insertion_index(style, lines):
+    """Return the line index where a missing header should be inserted."""
+    if style.preserve_shebang and lines and lines[0].startswith("#!"):
+        return 1
+    return 0
 
 
 def check_spdx_header_status(file_path):
     """Check SPDX header status of the file"""
+    license_line, copyright_line = spdx_header(file_style(file_path))
     with open(file_path, encoding="UTF-8") as file:
         lines = file.readlines()
         if not lines:
             # Empty file
             return SPDXStatus.EMPTY
 
-        # Skip shebang line
-        start_idx = 0
-        if lines and lines[0].startswith("#!"):
-            start_idx = 1
-
         has_license = False
         has_copyright = False
 
         # Check all lines for SPDX headers (not just the first two)
-        for i in range(start_idx, len(lines)):
-            line = lines[i].strip()
-            if line == LICENSE_LINE:
+        for raw_line in lines:
+            line = raw_line.strip()
+            if line == license_line:
                 has_license = True
-            elif line == COPYRIGHT_LINE:
+            elif line == copyright_line:
                 has_copyright = True
 
         # Determine status based on what we found
@@ -54,8 +83,8 @@ def check_spdx_header_status(file_path):
         elif has_license and not has_copyright:
             # Only has license line
             return SPDXStatus.MISSING_COPYRIGHT
-            # Only has copyright line
         elif not has_license and has_copyright:
+            # Only has copyright line
             return SPDXStatus.MISSING_LICENSE
         else:
             # Completely missing both lines
@@ -64,6 +93,9 @@ def check_spdx_header_status(file_path):
 
 def add_header(file_path, status):
     """Add or supplement SPDX header based on status"""
+    style = file_style(file_path)
+    license_line, copyright_line = spdx_header(style)
+    full_spdx_header = f"{license_line}\n{copyright_line}"
     with open(file_path, "r+", encoding="UTF-8") as file:
         lines = file.readlines()
         file.seek(0, 0)
@@ -71,25 +103,23 @@ def add_header(file_path, status):
 
         if status == SPDXStatus.MISSING_BOTH:
             # Completely missing, add complete header
-            if lines and lines[0].startswith("#!"):
-                # Preserve shebang line
-                file.write(lines[0])
-                file.write(FULL_SPDX_HEADER + "\n")
-                file.writelines(lines[1:])
-            else:
-                # Add header directly
-                file.write(FULL_SPDX_HEADER + "\n")
-                file.writelines(lines)
+            insertion_index = header_insertion_index(style, lines)
+            file.writelines(lines[:insertion_index])
+            file.write(full_spdx_header + "\n")
+            remaining_lines = lines[insertion_index:]
+            if remaining_lines and remaining_lines[0].strip():
+                file.write("\n")
+            file.writelines(remaining_lines)
 
         elif status == SPDXStatus.MISSING_COPYRIGHT:
             # Only has license line, need to add copyright line
             # Find the license line and add copyright line after it
             for i, line in enumerate(lines):
-                if line.strip() == LICENSE_LINE:
+                if line.strip() == license_line:
                     # Insert copyright line after license line
                     lines.insert(
                         i + 1,
-                        f"{COPYRIGHT_LINE}\n",
+                        f"{copyright_line}\n",
                     )
                     break
 
@@ -99,9 +129,9 @@ def add_header(file_path, status):
             # Only has copyright line, need to add license line
             # Find the copyright line and add license line before it
             for i, line in enumerate(lines):
-                if line.strip() == COPYRIGHT_LINE:
+                if line.strip() == copyright_line:
                     # Insert license line before copyright line
-                    lines.insert(i, f"{LICENSE_LINE}\n")
+                    lines.insert(i, f"{license_line}\n")
                     break
             file.writelines(lines)
 


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com><!-- markdownlint-disable -->


## Purpose

Extend the SPDX license header pre-commit hook to cover Rust and Protobuf sources as well.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

