### PR TITLE
[Bugfix] Return 400 instead of 500 when multimodal data is sent to a text-only model

### DIFF
--- a/tests/renderers/test_process_multi_modal_uuids.py
+++ b/tests/renderers/test_process_multi_modal_uuids.py
@@ -47,26 +47,12 @@ def _build_text_only_renderer() -> HfRenderer:
     )
 
 
-def test_text_only_model_rejects_mm_data_with_value_error():
-    """Sending multimodal data to a text-only model is a client mistake, so it
-    must surface as a ValueError rather than an internal failure."""
-    renderer = _build_text_only_renderer()
-
-    with pytest.raises(ValueError, match="text-only"):
-        renderer._process_multimodal(
-            prompt="What is in this image?",
-            mm_data={"image": [cherry_pil_image]},
-            mm_uuids=None,
-            mm_processor_kwargs=None,
-            tokenization_kwargs=None,
-        )
-
-
 def test_text_only_model_mm_data_maps_to_bad_request():
-    """The text-only rejection must reach the client as HTTP 400, not 500."""
+    """Sending multimodal data to a text-only model is a client mistake, so it
+    must surface as a ValueError and reach the client as HTTP 400, not 500."""
     renderer = _build_text_only_renderer()
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match="text-only") as exc_info:
         renderer._process_multimodal(
             prompt="What is in this image?",
             mm_data={"image": [cherry_pil_image]},

--- a/tests/renderers/test_process_multi_modal_uuids.py
+++ b/tests/renderers/test_process_multi_modal_uuids.py
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from http import HTTPStatus
+
 import pytest
 
 from vllm.assets.image import ImageAsset
 from vllm.assets.video import VideoAsset
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
+from vllm.entrypoints.serve.utils.error_response import create_error_response
 from vllm.multimodal.parse import parse_mm_uuids
 from vllm.renderers.hf import HfRenderer
 from vllm.tokenizers.registry import cached_tokenizer_from_config
@@ -33,6 +36,47 @@ def _build_renderer(
         vllm_config,
         cached_tokenizer_from_config(model_config),
     )
+
+
+def _build_text_only_renderer() -> HfRenderer:
+    model_config = ModelConfig(model="openai-community/gpt2", max_model_len=128)
+
+    return HfRenderer(
+        VllmConfig(model_config=model_config),
+        cached_tokenizer_from_config(model_config),
+    )
+
+
+def test_text_only_model_rejects_mm_data_with_value_error():
+    """Sending multimodal data to a text-only model is a client mistake, so it
+    must surface as a ValueError rather than an internal failure."""
+    renderer = _build_text_only_renderer()
+
+    with pytest.raises(ValueError, match="text-only"):
+        renderer._process_multimodal(
+            prompt="What is in this image?",
+            mm_data={"image": [cherry_pil_image]},
+            mm_uuids=None,
+            mm_processor_kwargs=None,
+            tokenization_kwargs=None,
+        )
+
+
+def test_text_only_model_mm_data_maps_to_bad_request():
+    """The text-only rejection must reach the client as HTTP 400, not 500."""
+    renderer = _build_text_only_renderer()
+
+    with pytest.raises(ValueError) as exc_info:
+        renderer._process_multimodal(
+            prompt="What is in this image?",
+            mm_data={"image": [cherry_pil_image]},
+            mm_uuids=None,
+            mm_processor_kwargs=None,
+            tokenization_kwargs=None,
+        )
+
+    error_response = create_error_response(exc_info.value)
+    assert error_response.error.code == HTTPStatus.BAD_REQUEST
 
 
 def test_multi_modal_uuids_length_mismatch_raises():

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -735,12 +735,12 @@ class BaseRenderer(ABC, Generic[_T]):
         *,
         skip_mm_cache: bool = False,
     ) -> "MultiModalInput":
-        mm_req_id = f"renderer{self.api_process_rank}-mm-{self._mm_req_counter.inc(1)}"
-
         if skip_mm_cache and self._readonly_mm_processor is not None:
             mm_processor = self._readonly_mm_processor
         else:
             mm_processor = self.get_mm_processor()
+
+        mm_req_id = f"renderer{self.api_process_rank}-mm-{self._mm_req_counter.inc(1)}"
 
         mm_data_items = mm_processor.info.parse_mm_data(mm_data)
         mm_uuid_items = parse_mm_uuids(mm_uuids)


### PR DESCRIPTION
## Purpose

Sending multimodal data (e.g. an `image_url`) to a **text-only** model returns **HTTP 500 InternalServerError**. It is a client mistake and should be **HTTP 400 BadRequest**.

`BaseRenderer._process_multimodal` reads `self._mm_req_counter` before resolving the processor:

```python
mm_req_id = f"renderer{self.api_process_rank}-mm-{self._mm_req_counter.inc(1)}"

if skip_mm_cache and self._readonly_mm_processor is not None:
    mm_processor = self._readonly_mm_processor
else:
    mm_processor = self.get_mm_processor()
```

`_mm_req_counter` is only initialized inside the `if mm_registry.supports_multimodal_inputs(...)` block, so on a text-only model the attribute does not exist. The line above raises `AttributeError`, which matches no client-error branch in `create_error_response` and falls through to `INTERNAL_SERVER_ERROR`.

That also means the guard already sitting in `get_mm_processor()` — `raise ValueError("Multi-modal processor not available for text-only models")` — was **dead code**: the `AttributeError` always fired one line earlier.

The fix resolves the processor *before* using the counter, making the existing guard reachable. `ValueError` maps to 400, which is the intended behaviour. No new exception type, no signature change.

| Exception raised | HTTP status |
|---|---|
| `AttributeError` (before) | 500 InternalServerError |
| `ValueError` (after) | 400 BadRequest |

**Not a duplicate:** no open PR touches this path. Searched open PRs for `_mm_req_counter`, `get_mm_processor`, and text-only/multimodal 500-vs-400 error handling — no overlap.

## Test Plan

Two tests added to the existing `tests/renderers/test_process_multi_modal_uuids.py`, which already builds a real `HfRenderer` and exercises `_process_multimodal`:

- `test_text_only_model_rejects_mm_data_with_value_error` — mm data on a text-only model (`openai-community/gpt2`) raises `ValueError`, not an internal failure.
- `test_text_only_model_mm_data_maps_to_bad_request` — that exception maps to `HTTPStatus.BAD_REQUEST` through `create_error_response`.

```bash
# New tests + full existing file
pytest tests/renderers/test_process_multi_modal_uuids.py -v

# Regression: the 422 media-error path must stay intact
pytest tests/multimodal/media/test_unprocessable_entity_error.py \
       tests/entrypoints/openai/chat_completion/test_chat_error.py -v
```

## Test Result

Both new tests fail on `main` and pass with the fix.

**Before (bug reproduced):**

```
FAILED tests/renderers/test_process_multi_modal_uuids.py::test_text_only_model_rejects_mm_data_with_value_error
FAILED tests/renderers/test_process_multi_modal_uuids.py::test_text_only_model_mm_data_maps_to_bad_request
E   AttributeError: 'HfRenderer' object has no attribute '_mm_req_counter'
vllm/renderers/base.py:738: AttributeError
2 failed, 9 deselected
```

**After:**

```
tests/renderers/test_process_multi_modal_uuids.py .......... 11 passed, 16 warnings in 39.30s
```

**Regression (unchanged):**

```
tests/multimodal/media/test_unprocessable_entity_error.py
tests/entrypoints/openai/chat_completion/test_chat_error.py
30 passed
```

Model evaluation: not applicable. This changes only the exception type on an error path that previously crashed; no effect on generated output, accuracy, or serving of valid requests.

---

AI assistance was used to produce this change (Claude Code). Per `AGENTS.md`, I have reviewed every changed line and run the tests above myself.
