### PR TITLE
[Bugfix] Clamp spec-decode state index load for zero num_accepted_tokens in GDN kernels

### DIFF
--- a/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
+++ b/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
@@ -100,6 +100,81 @@ def test_fused_sigmoid_gating_delta_rule_update_non_spec(
     )
 
 
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_spec_decoding_zero_accepted_tokens_reads_first_slot(
+    dtype: torch.dtype,
+) -> None:
+    """A zero entry in num_accepted_tokens (stale or padded batch row) must
+    read the state at slot 0 of ssm_state_indices, exactly like an entry of
+    1, instead of indexing out of bounds (issue #41190 hardening)."""
+    torch.set_default_device(DEVICE)
+    set_random_seed(0)
+    num_reqs, num_k_heads, num_v_heads = 2, 16, 32
+    head_k_dim = head_v_dim = 128
+    num_speculative_tokens = 3
+    num_tokens = num_reqs * (num_speculative_tokens + 1)
+    total_entries = num_tokens * 2
+
+    query = torch.rand(1, num_tokens, num_k_heads, head_k_dim, dtype=dtype)
+    key = torch.rand(1, num_tokens, num_k_heads, head_k_dim, dtype=dtype)
+    value = torch.rand(1, num_tokens, num_v_heads, head_v_dim, dtype=dtype)
+    A_log = torch.rand(num_v_heads, dtype=dtype)
+    dt_bias = torch.rand(num_v_heads, dtype=dtype)
+    a = torch.rand(num_tokens, num_v_heads, dtype=dtype)
+    b = torch.rand(num_tokens, num_v_heads, dtype=dtype)
+    ssm_state = torch.rand(
+        total_entries, num_v_heads, head_k_dim, head_v_dim, dtype=dtype
+    )
+    state_indices = torch.randperm(total_entries, dtype=torch.int32)[:num_tokens].view(
+        num_reqs, num_speculative_tokens + 1
+    )
+    cu_seqlens = torch.arange(
+        0, num_tokens + 1, num_speculative_tokens + 1, dtype=torch.int32
+    )
+    beta = b.sigmoid()
+    g = -A_log.float().exp() * F.softplus(a.float() + dt_bias)
+
+    def run_gating(num_accepted_tokens: torch.Tensor):
+        return fused_sigmoid_gating_delta_rule_update(
+            A_log=A_log,
+            a=a,
+            b=b,
+            dt_bias=dt_bias,
+            q=query,
+            k=key,
+            v=value,
+            initial_state=ssm_state.clone(),
+            inplace_final_state=True,
+            ssm_state_indices=state_indices,
+            cu_seqlens=cu_seqlens,
+            num_accepted_tokens=num_accepted_tokens,
+            use_qk_l2norm_in_kernel=True,
+        )
+
+    def run_recurrent(num_accepted_tokens: torch.Tensor):
+        return fused_recurrent_gated_delta_rule(
+            q=query,
+            k=key,
+            v=value,
+            g=g.unsqueeze(0),
+            beta=beta.unsqueeze(0),
+            initial_state=ssm_state.clone(),
+            inplace_final_state=True,
+            ssm_state_indices=state_indices,
+            cu_seqlens=cu_seqlens,
+            num_accepted_tokens=num_accepted_tokens,
+            use_qk_l2norm_in_kernel=True,
+        )
+
+    zeros = torch.zeros(num_reqs, dtype=torch.int32)
+    ones = torch.ones(num_reqs, dtype=torch.int32)
+    for run in (run_gating, run_recurrent):
+        out_zero, state_zero = run(zeros)
+        out_one, state_one = run(ones)
+        torch.testing.assert_close(out_zero, out_one, atol=0, rtol=0)
+        torch.testing.assert_close(state_zero, state_one, atol=0, rtol=0)
+
+
 @pytest.mark.parametrize("tp_size", [1])
 @pytest.mark.parametrize("num_reqs", [1, 2, 4])
 @pytest.mark.parametrize("num_k_heads", [16])

--- a/vllm/model_executor/layers/fla/ops/fused_recurrent.py
+++ b/vllm/model_executor/layers/fla/ops/fused_recurrent.py
@@ -103,7 +103,11 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
     if USE_INITIAL_STATE:
         if IS_CONTINUOUS_BATCHING:
             if IS_SPEC_DECODING:
-                i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
+                # Clamp so a zero (stale or padded batch row) entry in
+                # num_accepted_tokens cannot index outside this request's
+                # row of ssm_state_indices; matches the clamp in the align
+                # kernel in vllm/v1/worker/mamba_utils.py.
+                i_t = tl.maximum(tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1, 0)
             else:
                 i_t = 0
             # Load state index and check for invalid entries

--- a/vllm/model_executor/layers/fla/ops/fused_sigmoid_gating.py
+++ b/vllm/model_executor/layers/fla/ops/fused_sigmoid_gating.py
@@ -103,7 +103,11 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     if USE_INITIAL_STATE:
         if IS_CONTINUOUS_BATCHING:
             if IS_SPEC_DECODING:
-                i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
+                # Clamp so a zero (stale or padded batch row) entry in
+                # num_accepted_tokens cannot index outside this request's
+                # row of ssm_state_indices; matches the clamp in the align
+                # kernel in vllm/v1/worker/mamba_utils.py.
+                i_t = tl.maximum(tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1, 0)
             else:
                 i_t = 0
             # Load state index and check for invalid entries


### PR DESCRIPTION
## Purpose

Harden the GDN spec-decode initial-state load against out-of-bounds indexing. Related to #41190.

In `fused_recurrent_gated_delta_rule_fwd_kernel` and `fused_sigmoid_gating_delta_rule_update_kernel`, the spec-decode path computes

```python
i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
```

with no lower bound. If a zero ever reaches `num_accepted_tokens` (stale batch row, padded row, or the D2H race acknowledged in `gpu_model_runner.py`), `i_t = -1` reads the state index from outside the request's row of `ssm_state_indices` — for row 0, outside the tensor entirely. The garbage `state_idx` then becomes an arbitrary initial-state pointer, which is consistent with the `cudaErrorIllegalAddress` reports in #41190 (see @PavelPaha's trace in that thread into `fused_sigmoid_gating_delta_rule_update_kernel` via `rejection_random_sample_kernel`'s `-1` placeholders).

This PR clamps `i_t` to 0, matching the existing clamp in the align kernel (`vllm/v1/worker/mamba_utils.py`: `src_off = tl.maximum(num_accepted - 1, 0)`). For `num_accepted_tokens >= 1` the computation is unchanged, so normal-path behavior and output are identical. I could not reproduce #41190 on 2×A10 (details in [this comment](https://github.com/vllm-project/vllm/issues/41190#issuecomment-4955274039)), so this is defense-in-depth rather than a confirmed root-cause fix — but it converts a potential silent OOB read into well-defined behavior at zero cost (one `tl.maximum` on an already-loaded scalar).

**Duplicate check**: no open PR addresses #41190 or adds this clamp (`gh pr list --search "41190 in:body"` empty; the only open PR touching these files, #46912, is a prefix-cache feature and does not change this indexing).

## Test Plan

Added `test_spec_decoding_zero_accepted_tokens_reads_first_slot` to the existing `tests/kernels/test_fused_sigmoid_gating_delta_rule.py`: with `num_accepted_tokens = 0`, both kernels must produce bitwise-identical output/state to `num_accepted_tokens = 1` (both should read slot 0), instead of indexing out of bounds.

```bash
pytest tests/kernels/test_fused_sigmoid_gating_delta_rule.py -v
pytest tests/kernels/test_fused_recurrent_packed_decode.py -v
```

## Test Result

On 2×A10 (sm_86):

- New test **fails without the kernel fix** (zero row reads a wrong state) and **passes with it**, for both float32 and bfloat16.
- Pre-existing tests: pass/fail sets are identical with and without this change (some bfloat16 comparisons in these files fail on my A10 box both before and after this PR — unrelated to this change).
- `pre-commit` (ruff check/format, mypy-3.10, SPDX, etc.) green on the three changed files.

Since the clamp is an identity for all values ≥ 1 that the normal path produces, no model-output change is expected; the bitwise-equality test above pins the only affected case.

---

AI assistance was used for this PR (Claude Code); I reviewed every changed line and ran the tests above myself.

