### PR TITLE
Update vendored LMCache connector for current IPCCacheServerKey API

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/multi_process_adapter.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/multi_process_adapter.py
@@ -11,7 +11,7 @@ import zmq
 from lmcache.utils import _lmcache_nvtx_annotate, init_logger
 from lmcache.v1.multiprocess.custom_types import (
     CudaIPCWrapper,
-    IPCCacheEngineKey,
+    IPCCacheServerKey,
     KVCache,
 )
 from lmcache.v1.multiprocess.mq import MessageQueueClient, MessagingFuture
@@ -318,9 +318,9 @@ class LMCacheMPSchedulerAdapter:
         start: int = 0,
         end: int = 0,
         request_id: str | None = None,
-    ) -> IPCCacheEngineKey:
+    ) -> IPCCacheServerKey:
         """Convert token IDs to an IPC cache engine key"""
-        return IPCCacheEngineKey(
+        return IPCCacheServerKey(
             model_name=self.model_name,
             world_size=self.world_size,
             worker_id=self.worker_id,
@@ -328,20 +328,27 @@ class LMCacheMPSchedulerAdapter:
             start=start,
             end=end,
             request_id=request_id,
-            tp_size=self.tp_size,
+            use_mla=self.parallel_strategy.use_mla,
         )
 
     def _create_hash_key(
         self, chunk_hash: bytes, request_id: str | None = None
-    ) -> IPCCacheEngineKey:
-        """Create a hash-mode IPC cache engine key"""
-        return IPCCacheEngineKey(
-            model_name=self.model_name,
-            world_size=self.world_size,
-            worker_id=None,
-            chunk_hash=chunk_hash,
-            request_id=request_id,
-            tp_size=self.tp_size,
+    ) -> IPCCacheServerKey:
+        """Create a hash-mode IPC cache engine key.
+
+        .. deprecated::
+            The current ``IPCCacheServerKey`` API is token-based (no
+            ``chunk_hash`` field).  Hash-mode keys are no longer
+            supported.  This method is retained for API compatibility
+            with callers that haven't been migrated to the token-based
+            ``_create_key`` path.  When the lmcache package is installed
+            (the normal case), the LMCache-tree adapter is used instead
+            of this vendored fallback, so this method is never reached.
+        """
+        raise NotImplementedError(
+            "Hash-mode IPCCacheServerKey is no longer supported. "
+            "Use _create_key (token-based) instead, or install the "
+            "lmcache package to use the LMCache-tree adapter."
         )
 
 
@@ -513,7 +520,7 @@ class LMCacheMPWorkerAdapter:
             event: The CUDA event that is recorded after the current
                 model inference step
         """
-        all_keys: list[IPCCacheEngineKey] = []
+        all_keys: list[IPCCacheServerKey] = []
         block_ids: list[int] = []
         for request_id, op in zip(request_ids, ops, strict=False):
             if op.block_hashes is not None:
@@ -562,7 +569,7 @@ class LMCacheMPWorkerAdapter:
             event: The CUDA event that is recorded after the current
                 model inference step
         """
-        all_keys: list[IPCCacheEngineKey] = []
+        all_keys: list[IPCCacheServerKey] = []
         block_ids: list[int] = []
         for request_id, op in zip(request_ids, ops, strict=False):
             if op.block_hashes is not None:
@@ -711,9 +718,9 @@ class LMCacheMPWorkerAdapter:
         start: int = 0,
         end: int = 0,
         request_id: str | None = None,
-    ) -> IPCCacheEngineKey:
+    ) -> IPCCacheServerKey:
         """Convert token IDs to an IPC cache engine key"""
-        return IPCCacheEngineKey(
+        return IPCCacheServerKey(
             model_name=self.model_name,
             world_size=self.world_size,
             worker_id=self.worker_id,
@@ -721,16 +728,20 @@ class LMCacheMPWorkerAdapter:
             start=start,
             end=end,
             request_id=request_id,
+            use_mla=self.parallel_strategy.use_mla,
         )
 
     def _create_hash_key(
         self, chunk_hash: bytes, request_id: str | None = None
-    ) -> IPCCacheEngineKey:
-        """Create a hash-mode IPC cache engine key"""
-        return IPCCacheEngineKey(
-            model_name=self.model_name,
-            world_size=self.world_size,
-            worker_id=self.worker_id,
-            chunk_hash=chunk_hash,
-            request_id=request_id,
+    ) -> IPCCacheServerKey:
+        """Create a hash-mode IPC cache engine key.
+
+        .. deprecated::
+            Hash-mode keys are no longer supported by the current
+            ``IPCCacheServerKey`` API (token-based only).  See the
+            scheduler adapter's ``_create_hash_key`` for details.
+        """
+        raise NotImplementedError(
+            "Hash-mode IPCCacheServerKey is no longer supported. "
+            "Use _create_key (token-based) instead."
         )


### PR DESCRIPTION
## What

The vendored fallback LMCache connector (`vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/multi_process_adapter.py`) was stale relative to the current `lmcache` package API:

1. **`IPCCacheEngineKey` → `IPCCacheServerKey`**: The key class was renamed in the LMCache codebase. The vendored connector still imported the old name, which would cause `ImportError` if the fallback path were ever reached.

2. **`tp_size` field → `use_mla` field**: `IPCCacheServerKey` no longer has a `tp_size` constructor argument. It now has `use_mla: bool` (backward-compatible msgspec field, defaults `False`). Both `_create_key` methods updated to pass `use_mla=self.parallel_strategy.use_mla`.

3. **`chunk_hash` field removed**: `IPCCacheServerKey` no longer supports hash-mode keys (the `chunk_hash` field was removed). The `_create_hash_key` methods now raise `NotImplementedError` with a clear message directing users to the token-based `_create_key` path or to install the `lmcache` package (which has the current, fully-maintained adapter).

## Why

This vendored connector is a **fallback** — it is only used when `from lmcache.integration.vllm.vllm_multi_process_adapter import ...` fails (i.e., the `lmcache` package is not installed). In the normal case (lmcache installed), the LMCache-tree adapter is used instead, which is kept in sync with the API.

However, if the fallback is ever reached (e.g., partial install, version mismatch), the stale imports would cause confusing `ImportError`/`TypeError` crashes. This PR makes the fallback at least importable and gives clear error messages for the removed hash-mode API.

## Companion PR

This pairs with [LMCache PR #4082](https://github.com/LMCache/LMCache/pull/4082), which:
- Enables pipeline parallelism (PP) for MLA models (Kimi K2, GLM-4.6) in multi-server MP mode
- Adds explicit `use_mla` flag to `IPCCacheServerKey` (replacing the fragile `tp > world_size` heuristic)
- Adds full ROCm platform support (pin memory, IPC wrapper, device spec)
- Fixes the abort-leak (LOOKUP locks freed on request cancel)

## Testing

The file compiles cleanly. The vendored connector is not directly testable without a full vLLM+lmcache environment, but the changes are straightforward API renames.