### PR TITLE
fix: LlamaTokenizerFast garbled spaces/newlines in transformers v5

### DIFF
--- a/vllm/tokenizers/hf.py
+++ b/vllm/tokenizers/hf.py
@@ -207,6 +207,31 @@ class CachedHfTokenizer(TokenizerLike):
         **kwargs,
     ) -> HfTokenizer:
         try:
+            # --- transformers v5 LlamaTokenizerFast fix ---
+            # LlamaTokenizerFast.__init__ in transformers v5 configures
+            # the Rust decoder incorrectly, producing garbled spaces/newlines
+            # (Ġ → 'G', \n → 'C'). Replace __init__ with the base
+            # PreTrainedTokenizerFast version, then restore after loading.
+            try:
+                from transformers import (
+                    LlamaTokenizerFast,
+                    PreTrainedTokenizerFast,
+                )
+                from tokenizers import decoders as _decoders
+
+                _orig_llama_init = LlamaTokenizerFast.__init__
+
+                def _fixed_init(self, *args, **kwargs):
+                    PreTrainedTokenizerFast.__init__(self, *args, **kwargs)
+                    self._tokenizer.decoder = _decoders.ByteLevel(
+                        add_prefix_space=False, trim_offsets=True
+                    )
+
+                LlamaTokenizerFast.__init__ = _fixed_init
+                _llama_init_patched = True
+            except ImportError:
+                _llama_init_patched = False
+
             tokenizer = AutoTokenizer.from_pretrained(
                 path_or_repo_id,
                 *args,
@@ -215,6 +240,10 @@ class CachedHfTokenizer(TokenizerLike):
                 cache_dir=download_dir,
                 **kwargs,
             )
+
+            if _llama_init_patched:
+                LlamaTokenizerFast.__init__ = _orig_llama_init
+            # --- end fix ---
         except ValueError as e:
             # If the error pertains to the tokenizer class not existing or not
             # currently being imported,


### PR DESCRIPTION
transformers v5 changed LlamaTokenizerFast.__init__ to configure the Rust tokenizer decoder differently from PreTrainedTokenizerFast. This causes incremental decoding to produce garbled characters: Ġ (BPE space prefix, U+0120) → 'G', newline (\n) → 'C'.

Fix: temporarily replace LlamaTokenizerFast.__init__ with PreTrainedTokenizerFast.__init__ before AutoTokenizer.from_pretrained, and set the decoder to ByteLevel standard parameters. Restore the original __init__ after loading.

This is a pure in-memory fix that does not modify any model files.

Fixes: DeepSeek-R1-Distill-Llama series (tokenizer_class=LlamaTokenizerFast)
Affected versions: transformers >= 5.0.0




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

