### PR TITLE
lower memory required for capturing cudagraphs for large cudagraph sizes

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6426,7 +6426,11 @@ class GPUModelRunner(
         kv_cache_spec = self.get_kv_cache_spec()
         KVCacheSpecRegistry.check_kv_cache_spec_registry(kv_cache_spec)
         kv_cache_groups = get_kv_cache_groups(self.vllm_config, kv_cache_spec)
-        min_blocks = self.compilation_config.max_cudagraph_capture_size or 1
+        # the minimum number of blocks required is 1 block *per sequence*
+        min_blocks = (
+            min(self.max_num_reqs, self.compilation_config.max_cudagraph_capture_size)
+            or 1
+        )
 
         # Temporarily change num_gpu_blocks_override to allocate a minimal KV cache
         saved_override = self.cache_config.num_gpu_blocks_override


### PR DESCRIPTION


## Purpose
Fix an over-allocation during memory estimates.
When attempting to capture CUDA graphs with large sizes, the dummy KV cache allocated 1 block *per-token*. However, we only ever need one block *per-sequence*. This over allocation makes it impossible to capture CUDA graphs for large sizes since it just OOMs.

With this fix, the dummy KV cache allocates the true safe minimum of blocks, preventing the over allocation and enabling large CUDA graph capturing.

## Test Plan
I don't see any existing tests for this part of the code, so I didn't want to add a whole suite just for a one line change. If there are relevant tests that I missed please point them out and I'll add relevant cases to them.

## Test Result
N/A

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

