### PR TITLE
[Bugfix][CPU][RISC-V] Trust native RVV capability probe

### DIFF
--- a/tests/kernels/attention/test_cpu_attn.py
+++ b/tests/kernels/attention/test_cpu_attn.py
@@ -9,7 +9,10 @@ import torch
 
 from vllm.platforms import CpuArchEnum, current_platform
 from vllm.utils.torch_utils import set_random_seed
-from vllm.v1.attention.backends.cpu_attn import _get_attn_isa
+from vllm.v1.attention.backends.cpu_attn import (
+    _get_attn_isa,
+    _riscv_supports_rvv,
+)
 
 if not current_platform.is_cpu():
     pytest.skip("skipping CPU-only tests", allow_module_level=True)
@@ -61,6 +64,44 @@ def get_attn_isa(
         dtype if dtype is not None else torch.bfloat16,
         block_size if block_size else 32,
     )
+
+
+@pytest.fixture
+def clear_riscv_support_cache():
+    _riscv_supports_rvv.cache_clear()
+    yield
+    _riscv_supports_rvv.cache_clear()
+
+
+@pytest.mark.parametrize("native_result", [True, False])
+def test_riscv_rvv_support_uses_native_result(
+    monkeypatch, clear_riscv_support_cache, native_result
+):
+    monkeypatch.setattr(torch.ops._C, "cpu_attn_has_isa", lambda isa: native_result)
+
+    assert _riscv_supports_rvv() is native_result
+
+
+def test_riscv_rvv_support_fails_closed(monkeypatch, clear_riscv_support_cache):
+    def unavailable(isa):
+        raise RuntimeError("native capability probe unavailable")
+
+    monkeypatch.setattr(torch.ops._C, "cpu_attn_has_isa", unavailable)
+
+    assert not _riscv_supports_rvv()
+
+
+def test_riscv_native_false_selects_scalar_attention(
+    monkeypatch, clear_riscv_support_cache
+):
+    monkeypatch.setattr(torch.cpu, "_is_amx_tile_supported", lambda: False)
+    monkeypatch.setattr(torch.cpu, "_is_avx512_supported", lambda: False)
+    monkeypatch.setattr(
+        current_platform, "get_cpu_architecture", lambda: CpuArchEnum.RISCV
+    )
+    monkeypatch.setattr(torch.ops._C, "cpu_attn_has_isa", lambda isa: False)
+
+    assert _get_attn_isa(torch.float32, 32) == "vec"
 
 
 # rand number generation takes too much time, cache rand tensors

--- a/tests/kernels/attention/test_cpu_attn.py
+++ b/tests/kernels/attention/test_cpu_attn.py
@@ -3,13 +3,17 @@
 
 import functools
 import math
+from unittest.mock import mock_open
 
 import pytest
 import torch
 
 from vllm.platforms import CpuArchEnum, current_platform
 from vllm.utils.torch_utils import set_random_seed
-from vllm.v1.attention.backends.cpu_attn import _get_attn_isa
+from vllm.v1.attention.backends.cpu_attn import (
+    _get_attn_isa,
+    _riscv_supports_rvv,
+)
 
 if not current_platform.is_cpu():
     pytest.skip("skipping CPU-only tests", allow_module_level=True)
@@ -61,6 +65,67 @@ def get_attn_isa(
         dtype if dtype is not None else torch.bfloat16,
         block_size if block_size else 32,
     )
+
+
+@pytest.fixture
+def clear_riscv_support_cache():
+    _riscv_supports_rvv.cache_clear()
+    yield
+    _riscv_supports_rvv.cache_clear()
+
+
+@pytest.fixture
+def rvv_cpuinfo(monkeypatch):
+    cpuinfo = mock_open(read_data="isa : rv64imafdcv_zvl256b\n")
+    monkeypatch.setattr("builtins.open", cpuinfo)
+    return cpuinfo
+
+
+def test_riscv_rvv_support_uses_native_true(monkeypatch, clear_riscv_support_cache):
+    monkeypatch.setattr(
+        torch.ops._C, "cpu_attn_has_isa", lambda isa: True, raising=False
+    )
+
+    assert _riscv_supports_rvv()
+
+
+def test_riscv_rvv_support_does_not_override_native_false(
+    monkeypatch, clear_riscv_support_cache, rvv_cpuinfo
+):
+    monkeypatch.setattr(
+        torch.ops._C, "cpu_attn_has_isa", lambda isa: False, raising=False
+    )
+
+    assert not _riscv_supports_rvv()
+    rvv_cpuinfo.assert_not_called()
+
+
+def test_riscv_rvv_support_fails_closed(
+    monkeypatch, clear_riscv_support_cache, rvv_cpuinfo
+):
+    def unavailable(isa):
+        raise RuntimeError("native capability probe unavailable")
+
+    monkeypatch.setattr(torch.ops._C, "cpu_attn_has_isa", unavailable, raising=False)
+
+    assert not _riscv_supports_rvv()
+    rvv_cpuinfo.assert_not_called()
+
+
+def test_riscv_native_false_selects_scalar_attention(
+    monkeypatch, clear_riscv_support_cache, rvv_cpuinfo
+):
+    monkeypatch.setattr(torch.cpu, "_is_amx_tile_supported", lambda: False)
+    monkeypatch.setattr(torch.cpu, "_is_avx512_supported", lambda: False)
+    monkeypatch.setattr(
+        current_platform, "get_cpu_architecture", lambda: CpuArchEnum.RISCV
+    )
+    monkeypatch.setattr(
+        torch.ops._C, "cpu_attn_has_isa", lambda isa: False, raising=False
+    )
+
+    assert _get_attn_isa(torch.float32, 32) == "vec"
+    rvv_cpuinfo.assert_not_called()
 
 
 # rand number generation takes too much time, cache rand tensors

--- a/vllm/v1/attention/backends/cpu_attn.py
+++ b/vllm/v1/attention/backends/cpu_attn.py
@@ -433,32 +433,11 @@ class CPUAttentionBackendImpl(AttentionImpl):
 
 @functools.lru_cache(maxsize=1)
 def _riscv_supports_rvv() -> bool:
-    """Whether the C++ RVV attention path is usable.
-
-    The kernel in csrc/cpu/cpu_attn_rvv.hpp uses VLEN-agnostic RVVI()
-    macros and supports VLEN=128 and VLEN=256.  CMake auto-detects the
-    largest zvl<N>b from /proc/cpuinfo and passes it via -mrvv-vector-bits.
-    The RVV path is compiled whenever __riscv_v_min_vlen is defined, so
-    we check that at least one supported zvl<N>b is advertised.
-    """
-    # The C++ compile-time check is the ground truth: it knows which
-    # VLEN the binary was actually compiled for.  The cpuinfo check
-    # below is only a fast-path shortcut.
+    """Whether the loaded C++ extension supports RVV attention."""
     try:
-        import torch
-
-        if torch.ops._C.cpu_attn_has_isa("rvv"):
-            return True
-    except Exception:
-        pass
-
-    # Fallback: check /proc/cpuinfo for zvl128b/zvl256b.
-    try:
-        with open("/proc/cpuinfo") as f:
-            cpuinfo = f.read()
-    except OSError:
+        return torch.ops._C.cpu_attn_has_isa("rvv")
+    except (AttributeError, RuntimeError):
         return False
-    return any(f"zvl{n}b" in cpuinfo for n in (128, 256))
 
 
 def _get_attn_isa(

--- a/vllm/v1/attention/backends/cpu_attn.py
+++ b/vllm/v1/attention/backends/cpu_attn.py
@@ -449,32 +449,11 @@ class CPUAttentionBackendImpl(AttentionImpl):
 
 @functools.lru_cache(maxsize=1)
 def _riscv_supports_rvv() -> bool:
-    """Whether the C++ RVV attention path is usable.
-
-    The kernel in csrc/cpu/cpu_attn_rvv.hpp uses VLEN-agnostic RVVI()
-    macros and supports VLEN=128 and VLEN=256.  CMake auto-detects the
-    largest zvl<N>b from /proc/cpuinfo and passes it via -mrvv-vector-bits.
-    The RVV path is compiled whenever __riscv_v_min_vlen is defined, so
-    we check that at least one supported zvl<N>b is advertised.
-    """
-    # The C++ compile-time check is the ground truth: it knows which
-    # VLEN the binary was actually compiled for.  The cpuinfo check
-    # below is only a fast-path shortcut.
+    """Whether the loaded C++ extension supports RVV attention."""
     try:
-        import torch
-
-        if torch.ops._C.cpu_attn_has_isa("rvv"):
-            return True
-    except Exception:
-        pass
-
-    # Fallback: check /proc/cpuinfo for zvl128b/zvl256b.
-    try:
-        with open("/proc/cpuinfo") as f:
-            cpuinfo = f.read()
-    except OSError:
+        return torch.ops._C.cpu_attn_has_isa("rvv")
+    except (AttributeError, RuntimeError):
         return False
-    return any(f"zvl{n}b" in cpuinfo for n in (128, 256))
 
 
 def _get_attn_isa(


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Fix a false-positive RISC-V RVV attention selection when the host supports RVV but the loaded vLLM CPU extension does not contain the RVV attention kernel.

`torch.ops._C.cpu_attn_has_isa("rvv")` reports the capability of the loaded binary, while `/proc/cpuinfo` only reports host hardware capability. The current fallback can override a native `false` result with `zvl<N>b` from cpuinfo, causing a scalar build to select an unavailable RVV implementation.

This change:

- Uses `cpu_attn_has_isa("rvv")` as the source of truth.
- Removes the `/proc/cpuinfo` fallback.
- Fails closed when the native probe is unavailable.
- Adds deterministic regression tests with controlled RVV cpuinfo.

This complements #43179 and #47532 rather than duplicating them. Those PRs introduced and refined native/VLEN detection, but the Python selector can still override a native `false` result with host cpuinfo.

This change only affects ISA selection. It does not modify attention computation or numerical results.

## Test Plan

```bash
.venv/bin/python -m pytest \
    tests/kernels/attention/test_cpu_attn.py \
    -k "riscv_rvv_support or riscv_native_false" \
    -vv

uvx pre-commit run --files \
    vllm/v1/attention/backends/cpu_attn.py \
    tests/kernels/attention/test_cpu_attn.py
```

The regression tests provide controlled cpuinfo containing `zvl256b`, so their result does not depend on the architecture or `/proc/cpuinfo` contents of the CI runner.

## Test Result

The same focused tests were run against the upstream implementation at 7ca49fbe4b and the current PR head.

| Scenario | Before | After |
| --- | --- | --- |
| Native probe returns `true` | `true` | `true` |
| Native probe returns `false`, cpuinfo has `zvl256b` | Incorrectly returns `true` | Returns `false` |
| Native probe is unavailable, cpuinfo has `zvl256b` | Incorrectly returns `true` | Fails closed with `false` |
| RISC-V attention ISA after native `false` | Incorrectly selects `rvv` | Selects `vec` |

The baseline fails the three affected regression scenarios. The patched source passes all four scenarios without reading cpuinfo.

A SpacemiT K1 scalar CPU extension provided the real native negative control:

```text
cpu_attn_has_isa("rvv"): False
NATIVE PROBE: PASS
```

Source checks:

```text
pre-commit: PASS
python -m py_compile: PASS
git diff --check: PASS
```

Focused pytest result:

- `.venv/bin/python -m pytest tests/kernels/attention/test_cpu_attn.py -k riscv -vv`
  - Patched: 4 passed
  - Upstream implementation with the same tests: 1 passed, 3 failed

The focused tests run on x86 by injecting the RISC-V-only capability operator. They remain in the existing CPU Buildkite test file and exercise the real Python dispatch logic.

Model evaluation is not applicable because this change does not alter model computation, numerical accuracy, or serving output semantics.

AI assistance was used for code-path analysis and regression-test drafting. I manually reviewed every changed line and verified the reported evidence.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

