### PR TITLE
[Mypy Fix] Split mypy work

### DIFF
--- a/tools/pre_commit/mypy.py
+++ b/tools/pre_commit/mypy.py
@@ -104,7 +104,30 @@ SEPARATE_GROUPS = [
 
 # TODO(woosuk): Include the code from Megatron and HuggingFace.
 EXCLUDE = [
-    "vllm/model_executor/models",
+    r"vllm/model_executor/models/[aA]",
+    r"vllm/model_executor/models/[bB]",
+    r"vllm/model_executor/models/[cC]",
+    r"vllm/model_executor/models/[dD]",
+    r"vllm/model_executor/models/[eE]",
+    r"vllm/model_executor/models/[fF]",
+    r"vllm/model_executor/models/[gG]",
+    r"vllm/model_executor/models/[hH]",
+    r"vllm/model_executor/models/[iI]",
+    r"vllm/model_executor/models/[jJ]",
+    r"vllm/model_executor/models/[kK]",
+    r"vllm/model_executor/models/[lL]",
+    r"vllm/model_executor/models/[mM]",
+    r"vllm/model_executor/models/[nN]",
+    r"vllm/model_executor/models/[oO]",
+    r"vllm/model_executor/models/[pP]",
+    r"vllm/model_executor/models/[qQ]",
+    r"vllm/model_executor/models/[rR]",
+    r"vllm/model_executor/models/[sS]",
+    r"vllm/model_executor/models/[tT]",
+    r"vllm/model_executor/models/[uU]",
+    r"vllm/model_executor/models/[vV]",
+    r"vllm/model_executor/models/[wW]",
+    r"vllm/model_executor/models/[zZ]",
     "vllm/model_executor/layers/fla/ops",
 ]
 


### PR DESCRIPTION
## Purpose

There are 1700+ failures for `"vllm/model_executor/models",`, this PR split the work so it should be easier to pick subtasks.
