### PR TITLE
[Bugfix] Reject incompatible user-specified --block-size before model load

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -26,14 +26,16 @@ from vllm.distributed.parallel_state import (
 from vllm.lora.layers import LoRAMappingType
 from vllm.lora.request import LoRARequest
 from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.mamba.mamba_mixer2 import MambaMixer2
 from vllm.multimodal.inputs import MultiModalFeatureSpec, PlaceholderRange
 from vllm.platforms import current_platform
+from vllm.platforms.interface import Platform
 from vllm.sampling_params import SamplingParams
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.system_utils import update_environment_variables
 from vllm.utils.torch_utils import set_random_seed
-from vllm.v1.attention.backend import MultipleOf
+from vllm.v1.attention.backend import AttentionBackend, MultipleOf
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.core.kv_cache_utils import estimate_max_model_len, get_kv_cache_configs
 from vllm.v1.core.sched.output import CachedRequestData, NewRequestData, SchedulerOutput
@@ -342,6 +344,61 @@ def test_select_common_block_size_no_valid_option():
 
     with pytest.raises(ValueError):
         select_common_block_size(48, [backend_a, backend_b])
+
+
+def _make_vllm_config_with_backend(
+    backend_cls, block_size: int | None
+) -> SimpleNamespace:
+    class _FakeLayer(AttentionLayerBase):
+        def get_attn_backend(self):
+            return backend_cls
+
+        def get_kv_cache_spec(self, vllm_config):
+            return None
+
+    return SimpleNamespace(
+        cache_config=CacheConfig(block_size=block_size),
+        model_config=SimpleNamespace(is_hybrid=False),
+        compilation_config=SimpleNamespace(
+            static_forward_context={"layers.0.attn": _FakeLayer()}
+        ),
+    )
+
+
+def test_update_block_size_for_backend_rejects_incompatible_user_block_size():
+    # FlashAttention-style backend: kernel block size must be a multiple of 16.
+    class _StrictMultipleBackend(AttentionBackend):
+        @staticmethod
+        def get_name():
+            return "STRICT_MULTIPLE"
+
+        @staticmethod
+        def get_supported_kernel_block_sizes():
+            return [MultipleOf(16)]
+
+    # --block-size 1 is listed as a CLI choice but is not a multiple of 16,
+    # so it must be rejected before any model loading occurs, not silently
+    # passed through to fail deep inside select_common_block_size() later.
+    vllm_config = _make_vllm_config_with_backend(_StrictMultipleBackend, 1)
+
+    with pytest.raises(ValueError, match="STRICT_MULTIPLE"):
+        Platform.update_block_size_for_backend(vllm_config)
+
+
+def test_update_block_size_for_backend_accepts_compatible_user_block_size():
+    class _StrictMultipleBackend(AttentionBackend):
+        @staticmethod
+        def get_name():
+            return "STRICT_MULTIPLE"
+
+        @staticmethod
+        def get_supported_kernel_block_sizes():
+            return [MultipleOf(16)]
+
+    vllm_config = _make_vllm_config_with_backend(_StrictMultipleBackend, 16)
+
+    Platform.update_block_size_for_backend(vllm_config)
+    assert vllm_config.cache_config.block_size == 16
 
 
 def test_set_active_mm_loras_builds_tower_and_connector_mappings():

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -638,6 +638,13 @@ class Platform:
                     backend_cls.get_name(),
                 )
             cache_config.block_size = preferred
+        elif not backend_cls.supports_block_size(cache_config.block_size):
+            raise ValueError(
+                f"User-specified block_size={cache_config.block_size} is not "
+                f"supported by the {backend_cls.get_name()} attention "
+                f"backend. Supported kernel block sizes: "
+                f"{backend_cls.get_supported_kernel_block_sizes()}."
+            )
 
         # Phase 2: Align block/mamba sizes for hybrid models
         # (may override user settings).


### PR DESCRIPTION
## Purpose

Fixes #42510.

`Platform.update_block_size_for_backend()` only auto-picks/validates the KV cache block size on the path where the user did **not** pass `--block-size`:

```python
if not cache_config.user_specified_block_size:
    ...
    cache_config.block_size = preferred
```

When a user explicitly passes `--block-size 1` or `--block-size 8` — both listed by the CLI as valid choices (`choose from 1, 8, 16, 32, 64, 128, 256`) — but the active attention backend doesn't actually support that size, this branch is skipped entirely and nothing validates the value. The incompatibility only surfaces later, inside `select_common_block_size()` (`vllm/v1/worker/utils.py`), with `ValueError: No common block size for 1.` — after model loading, `torch.compile`, and KV cache memory profiling have already run.

This adds an early check on the user-specified path using `AttentionBackend.supports_block_size()` — the same predicate the auto-pick path already trusts via `get_preferred_block_size()` — so an incompatible value is rejected immediately with a clear message instead of failing deep inside KV cache init.

**Not a duplicate:** checked the issue (no comments) and searched open PRs for `42510`, `block_size`/`block-size`, `common block size`, and `select_common_block_size` in title/body. PR #48313 ("Pick KV cache block size from all attention backends") is in the same file but addresses a different bug (#48286: the auto-pick path only consulting the first of several backends when the user did *not* specify `--block-size`) — it does not touch the user-specified path this PR fixes, confirmed by reading its diff. PR #48125 is about NIXL KV-transfer cache-shape validation, an unrelated code path.

## Test Plan

CPU-only, no GPU required:

```
python -m pytest tests/v1/worker/test_gpu_model_runner.py -k update_block_size_for_backend -v
```

Added two tests calling `Platform.update_block_size_for_backend()` directly against a fake backend/layer (mirroring the existing `_make_mock_backend_for_kernel_block_size` / `test_select_common_block_size_*` pattern already in this file):
- `test_update_block_size_for_backend_rejects_incompatible_user_block_size` — `block_size=1` against a backend requiring `MultipleOf(16)`. Fails on current `main` (`DID NOT RAISE ValueError`); passes with this change.
- `test_update_block_size_for_backend_accepts_compatible_user_block_size` — `block_size=16` against the same backend, asserts it's left untouched.

Also ran the full `-k block_size` slice and the whole file locally; failures/errors present are identical before and after this change (all `RuntimeError: Device string must not be empty`, pre-existing on `main` in this no-GPU-device environment, unrelated to this diff).

## Test Result

```
tests/v1/worker/test_gpu_model_runner.py::test_update_block_size_for_backend_rejects_incompatible_user_block_size PASSED
tests/v1/worker/test_gpu_model_runner.py::test_update_block_size_for_backend_accepts_compatible_user_block_size PASSED
```

`pre-commit run ruff-check`, `ruff format --check`, and `mypy` (`--ignore-missing-imports --follow-imports=silent`, matched against unmodified `main` to confirm zero new errors) all clean on the two changed files.