### PR TITLE
fix(models): pass quant_config to eh_proj in MTP layers to prevent silent precision loss

### DIFF
--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -15,6 +15,7 @@ from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import (
@@ -74,7 +75,13 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
 
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        self.eh_proj = ReplicatedLinear(
+            config.hidden_size * 2,
+            config.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.eh_proj",
+        )
 
         self.device = current_platform.device_type
 
@@ -114,7 +121,7 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
         inputs_embeds = self.enorm(inputs_embeds)
         previous_hidden_states = self.hnorm(previous_hidden_states)
 
-        hidden_states = self.eh_proj(
+        hidden_states, _ = self.eh_proj(
             torch.cat([inputs_embeds, previous_hidden_states], dim=-1)
         )
 

--- a/vllm/model_executor/models/glm4_moe_lite_mtp.py
+++ b/vllm/model_executor/models/glm4_moe_lite_mtp.py
@@ -37,6 +37,7 @@ from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import (
@@ -89,7 +90,13 @@ class Glm4MoeLiteMultiTokenPredictorLayer(nn.Module):
 
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        self.eh_proj = ReplicatedLinear(
+            config.hidden_size * 2,
+            config.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.eh_proj",
+        )
 
         self.device = current_platform.device_type
 
@@ -129,7 +136,7 @@ class Glm4MoeLiteMultiTokenPredictorLayer(nn.Module):
         inputs_embeds = self.enorm(inputs_embeds)
         previous_hidden_states = self.hnorm(previous_hidden_states)
 
-        hidden_states = self.eh_proj(
+        hidden_states, _ = self.eh_proj(
             torch.cat([inputs_embeds, previous_hidden_states], dim=-1)
         )
 

--- a/vllm/model_executor/models/glm4_moe_mtp.py
+++ b/vllm/model_executor/models/glm4_moe_mtp.py
@@ -38,6 +38,7 @@ from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import (
@@ -87,7 +88,13 @@ class Glm4MoeMultiTokenPredictorLayer(nn.Module):
         super().__init__()
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        self.eh_proj = ReplicatedLinear(
+            config.hidden_size * 2,
+            config.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.eh_proj",
+        )
         self.shared_head = SharedHead(
             config=config, prefix=prefix, quant_config=quant_config
         )
@@ -114,7 +121,7 @@ class Glm4MoeMultiTokenPredictorLayer(nn.Module):
         inputs_embeds = self.enorm(inputs_embeds)
         previous_hidden_states = self.hnorm(previous_hidden_states)
 
-        hidden_states = self.eh_proj(
+        hidden_states, _ = self.eh_proj(
             torch.cat([inputs_embeds, previous_hidden_states], dim=-1)
         )
 

--- a/vllm/model_executor/models/glm_ocr_mtp.py
+++ b/vllm/model_executor/models/glm_ocr_mtp.py
@@ -30,6 +30,7 @@ import torch.nn as nn
 
 from vllm.config import VllmConfig
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding,
@@ -64,7 +65,13 @@ class GlmOcrMultiTokenPredictorLayer(nn.Module):
 
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        self.eh_proj = ReplicatedLinear(
+            config.hidden_size * 2,
+            config.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.eh_proj",
+        )
 
         self.device = current_platform.device_type
         self.shared_head = SharedHead(
@@ -89,7 +96,7 @@ class GlmOcrMultiTokenPredictorLayer(nn.Module):
         inputs_embeds = self.enorm(inputs_embeds)
         previous_hidden_states = self.hnorm(previous_hidden_states)
 
-        hidden_states = self.eh_proj(
+        hidden_states, _ = self.eh_proj(
             torch.cat([inputs_embeds, previous_hidden_states], dim=-1)
         )
 

--- a/vllm/model_executor/models/hy_v3_mtp.py
+++ b/vllm/model_executor/models/hy_v3_mtp.py
@@ -36,6 +36,7 @@ from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import (
@@ -103,7 +104,13 @@ class HYV3MultiTokenPredictorLayer(nn.Module):
 
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        self.eh_proj = ReplicatedLinear(
+            config.hidden_size * 2,
+            config.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.eh_proj",
+        )
         self.shared_head = HYV3SharedHead(config=config, quant_config=quant_config)
         self.mtp_block = HYV3DecoderLayer(
             config=config,
@@ -129,7 +136,7 @@ class HYV3MultiTokenPredictorLayer(nn.Module):
         inputs_embeds = self.enorm(inputs_embeds)
         previous_hidden_states = self.hnorm(previous_hidden_states)
 
-        hidden_states = self.eh_proj(
+        hidden_states, _ = self.eh_proj(
             torch.cat([inputs_embeds, previous_hidden_states], dim=-1)
         )
 

--- a/vllm/model_executor/models/openpangu_mtp.py
+++ b/vllm/model_executor/models/openpangu_mtp.py
@@ -32,6 +32,7 @@ from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding,
@@ -58,7 +59,13 @@ class OpenPanguMultiTokenPredictorLayer(DeepSeekMultiTokenPredictorLayer):
 
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        self.eh_proj = ReplicatedLinear(
+            config.hidden_size * 2,
+            config.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.eh_proj",
+        )
         self.shared_head = SharedHead(
             config=config,
             quant_config=quant_config,

--- a/vllm/model_executor/models/step3p5_mtp.py
+++ b/vllm/model_executor/models/step3p5_mtp.py
@@ -9,6 +9,7 @@ from transformers import PretrainedConfig
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import (
@@ -61,7 +62,13 @@ class Step3p5AMultiTokenPredictorLayer(nn.Module):
         quant_config = vllm_config.quant_config
         self.enorm = GemmaRMSNorm(config.hidden_size, config.rms_norm_eps)
         self.hnorm = GemmaRMSNorm(config.hidden_size, config.rms_norm_eps)
-        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        self.eh_proj = ReplicatedLinear(
+            config.hidden_size * 2,
+            config.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.eh_proj",
+        )
         self.shared_head = SharedHead(
             config=config, quant_config=quant_config, prefix=f"{prefix}.shared_head"
         )
@@ -82,7 +89,7 @@ class Step3p5AMultiTokenPredictorLayer(nn.Module):
         inputs_embeds = self.enorm(inputs_embeds)
         previous_hidden_states = self.hnorm(previous_hidden_states)
 
-        hidden_states = self.eh_proj(
+        hidden_states, _ = self.eh_proj(
             torch.cat([inputs_embeds, previous_hidden_states], dim=-1)
         )
 


### PR DESCRIPTION
## Summary

Fixes #48492. Seven MTP (Multi-Token Prediction) model implementations define `eh_proj` as a plain `nn.Linear`, which doesn't accept `quant_config`. Under W8A8 (or similar) quantization, the default weight loader loads raw INT8 checkpoint values into a BF16 tensor without applying the dequantization scale, the following RMSNorm masks the resulting global magnitude amplification, so there's no crash, but per-channel proportions and BF16 precision are permanently destroyed before normalization, silently degrading generation quality. Full root-cause analysis is in #48492, including a dump-based comparison against the BF16 baseline.

`longcat_flash_mtp.py` and `mimo_v2_mtp.py` already use the correct pattern (`ReplicatedLinear` with `quant_config` and `prefix="eh_proj"`), this PR brings the same pattern to the seven files that didn't:

- `hy_v3_mtp.py`
- `deepseek_mtp.py`
- `glm4_moe_lite_mtp.py`
- `glm4_moe_mtp.py`
- `glm_ocr_mtp.py`
- `openpangu_mtp.py`
- `step3p5_mtp.py`

## One correction versus the fix proposed in #48492

`ReplicatedLinear` returns a `(output, bias)` tuple, unlike `nn.Linear` which returns just the tensor. The diff sketched in the issue only showed changing the layer definition; applying just that would leave every `hidden_states = self.eh_proj(...)` call site trying to use a tuple as a tensor. This PR updates the layer definition **and** the call site in each file (`hidden_states, _ = self.eh_proj(...)`) to match the working pattern in `longcat_flash_mtp.py`.

`openpangu_mtp.py` is a partial exception: `OpenPanguMultiTokenPredictorLayer` subclasses `DeepSeekMultiTokenPredictorLayer` and inherits its `forward()` rather than overriding it, so only the `__init__` needed the layer-definition change there, the inherited (now-fixed) forward from `deepseek_mtp.py` already unpacks correctly.

## Verification

- Confirmed `quant_config` is in scope at each `eh_proj` definition site in all seven files (either as a constructor parameter or a local pulled from `vllm_config.quant_config`) before making the change.
- Checked `deepseek_mtp.py`'s `_rewrite_spec_layer_name`, which does substring matching (`"eh_proj" in name`) against weight names for spec-layer remapping. `ReplicatedLinear`'s `prefix="eh_proj"` preserves this, so no change needed there.
- Grepped the diff for any remaining `nn.Linear` eh_proj definitions or un-updated call sites across all seven files, none left.

Not able to run an end-to-end W8A8 generation comparison in this environment (no GPU), so this is verified by static tracing against the known-correct reference implementations rather than a fresh empirical repro. Flagging that explicitly rather than claiming more than I checked.
