### PR TITLE
[Bug][Quantization] Fix humming is_layer_skipped for compressed-tensors "re:" ignore entries

### DIFF
--- a/tests/quantization/test_humming_ignore.py
+++ b/tests/quantization/test_humming_ignore.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for humming's is_layer_skipped handling of compressed-tensors
+regex ("re:") ignore entries.
+
+Regression test: compressed-tensors checkpoints (e.g. Kimi-K2.6) list ignored
+layers as regex patterns prefixed with "re:" (e.g. "re:vision_tower.*").
+humming previously substring-matched these literals, so ignored layers were
+never skipped and got (incorrectly) quantized -- which then diverged between
+the real weight-load path (falls back to unquantized) and the dummy-load path
+(stays quantized), breaking any consumer that byte-compares the two.
+"""
+
+import pytest
+
+from vllm.model_executor.layers.quantization.humming import HummingConfig
+
+# The real ignore list from Kimi-K2.6's compressed-tensors quantization_config.
+K26_IGNORE = [
+    "re:.*self_attn.*",
+    "re:.*shared_experts.*",
+    r"re:.*mlp\.(gate|up|gate_up|down)_proj.*",
+    "re:.*lm_head.*",
+    "re:vision_tower.*",
+    "re:mm_projector.*",
+]
+
+
+@pytest.mark.parametrize(
+    "prefix,expected",
+    [
+        # ignored layers (must be skipped -> stay unquantized)
+        ("vision_tower.encoder.blocks.0.mlp.fc0", True),
+        ("vision_tower.encoder.blocks.16.wo", True),
+        ("mm_projector.linear_1", True),
+        ("language_model.model.layers.0.self_attn.o_proj", True),
+        ("language_model.model.layers.0.mlp.gate_up_proj", True),
+        ("language_model.model.layers.0.mlp.down_proj", True),
+        ("language_model.model.layers.3.mlp.shared_experts.gate_proj", True),
+        ("model.lm_head", True),
+        # routed experts are NOT ignored -> must be quantized
+        ("language_model.model.layers.3.mlp.experts.383.up_proj", False),
+        ("language_model.model.layers.3.mlp.experts.0.down_proj", False),
+    ],
+)
+def test_is_layer_skipped_regex_ignore(prefix, expected):
+    cfg = HummingConfig(full_config={"ignore": K26_IGNORE})
+    assert cfg.is_layer_skipped({"ignore": K26_IGNORE}, prefix) is expected
+
+
+def test_plain_substring_entries_still_work():
+    # bitsandbytes-style modules_to_not_convert use plain substrings.
+    cfg = HummingConfig()
+    cfg_dict = {"modules_to_not_convert": ["lm_head", "vision"]}
+    assert cfg.is_layer_skipped(cfg_dict, "model.vision.encoder.fc") is True
+    assert cfg.is_layer_skipped(cfg_dict, "model.layers.0.mlp.up_proj") is False

--- a/vllm/model_executor/layers/quantization/humming.py
+++ b/vllm/model_executor/layers/quantization/humming.py
@@ -217,8 +217,17 @@ class HummingConfig(QuantizationConfig):
         if hasattr(self, "hf_to_vllm_mapper"):
             ignored_layers = self.hf_to_vllm_mapper.apply_list(ignored_layers)
 
-        if any(module_name in prefix for module_name in ignored_layers):
-            return True
+        for module_name in ignored_layers:
+            # compressed-tensors style entries may be regex patterns prefixed
+            # with "re:" (e.g. "re:vision_tower.*"). These must be regex-matched;
+            # plain substring matching never matches the literal "re:..." string,
+            # so ignored layers get silently quantized. Non-"re:" entries keep the
+            # existing substring behavior (e.g. bitsandbytes modules_to_not_convert).
+            if module_name.startswith("re:"):
+                if re.match(module_name[3:], prefix):
+                    return True
+            elif module_name in prefix:
+                return True
         if "lm_head" in prefix:
             return True
 


### PR DESCRIPTION
## Purpose

`HummingConfig.is_layer_skipped` decides which layers stay unquantized. It reads the
checkpoint's `ignore` / `ignored_layers` / `modules_to_not_convert` list and matches each
entry against the layer prefix using a plain **substring** check:

```python
if any(module_name in prefix for module_name in ignored_layers):
    return True
```

compressed-tensors checkpoints express ignored layers as **regex patterns prefixed with
`re:`** (e.g. `"re:vision_tower.*"`, `r"re:.*mlp\.(gate|up|gate_up|down)_proj.*"`). The literal
string `"re:vision_tower.*"` is never a substring of `"vision_tower.encoder.blocks.0.mlp.fc0"`,
so **none of these entries match and the layers are not skipped** — they get (incorrectly)
quantized by humming even though the checkpoint stored them unquantized.

This is silent: on a real weight load humming detects the incoming bf16 tensor and falls back
to unquantized, but on the dummy-weight path (`--load-format dummy`, and any consumer that
relies on it) there is nothing to trigger the fallback, so the same layer stays quantized. The
two load paths then produce different tensor shapes/dtypes for the same layer (observed:
476 layers differ between real and dummy load for a compressed-tensors INT4 VLM), which breaks
byte-level weight sharing / P2P weight transfer.

## Fix

Regex-match `re:`-prefixed entries (matching compressed-tensors semantics, as in
`compressed_tensors/utils.py::_is_equal_or_regex_match`) while keeping substring matching for
plain entries (e.g. bitsandbytes `modules_to_not_convert`). Minimal and backward compatible.

## Test

Added `tests/quantization/test_humming_ignore.py` parametrized on a real compressed-tensors
`ignore` list. Verified against the actual `HummingConfig.is_layer_skipped` in a
`vllm/vllm-openai:v0.23.0` container:

- before the fix: `7 failed, 4 passed` (vision_tower, mm_projector, self_attn, dense mlp
  gate_up/down_proj, shared_experts are NOT skipped)
- after the fix: `11 passed`

Also confirmed via an in-code print on an unpatched build that every ignored layer reports
`substring_skip=False, regex_skip=True`, and that a dummy-vs-real model init diverges on 476
layers without the fix and 0 with it.
