### PR TITLE
fix(models): materialize gemma4_mtp suppress_token_ids as a device buffer

### DIFF
--- a/vllm/model_executor/models/gemma4_mtp.py
+++ b/vllm/model_executor/models/gemma4_mtp.py
@@ -529,7 +529,20 @@ class Gemma4MTP(nn.Module):
 
         draft_cfg = vllm_config.speculative_config.draft_model_config
         gen_cfg = draft_cfg.try_get_generation_config()
-        self._suppress_token_ids = gen_cfg.get("suppress_tokens") if gen_cfg else None
+        suppress_token_ids = gen_cfg.get("suppress_tokens") if gen_cfg else None
+        if suppress_token_ids:
+            # Register as a buffer (not a plain list) so it moves to the
+            # right device with the rest of the module. Indexing a CUDA
+            # tensor with a Python list triggers an implicit unpinned
+            # host-to-device copy, which is illegal during CUDA graph
+            # capture (see capture_model() -> speculator.capture()).
+            self.register_buffer(
+                "_suppress_token_ids",
+                torch.tensor(suppress_token_ids, dtype=torch.long),
+                persistent=False,
+            )
+        else:
+            self._suppress_token_ids = None
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
@@ -581,7 +594,7 @@ class Gemma4MTP(nn.Module):
             )
         else:
             logits = self.logits_processor(self.lm_head, hidden_states)
-        if logits is not None and self._suppress_token_ids:
+        if logits is not None and self._suppress_token_ids is not None:
             logits[:, self._suppress_token_ids] = -float("inf")
         return logits
 


### PR DESCRIPTION
## Summary

Fixes #48503. `Gemma4MTPForCausalLM.__init__` stores the generation_config's `suppress_tokens` as a plain Python list (`self._suppress_token_ids = gen_cfg.get("suppress_tokens") ...`). `compute_logits` then does `logits[:, self._suppress_token_ids] = -float("inf")`, indexing a CUDA tensor with a Python list. That triggers an implicit unpinned host-to-device copy, which CUDA graph capture forbids, crashing `capture_model() -> speculator.capture()`. As the issue notes, this is independent of quantization/attention backend, since the crashing line never touches model weights.

## Fix

Register `_suppress_token_ids` as a buffer instead of a plain attribute, `persistent=False`, matching the existing pattern in `longcat_flash_ngram.py` for similar non-weight constant tensors (`ne_weights`, `ne_mods`, `exclusive_sizes`). A registered buffer moves to the correct device along with the rest of the module automatically, so by the time `compute_logits` runs during graph capture, indexing is tensor-into-tensor, no implicit copy.

Also changed the `compute_logits` guard from `if ... and self._suppress_token_ids:` to `is not None`. A multi-element tensor's truth value is ambiguous (`RuntimeError: Boolean value of Tensor with more than one element is ambiguous`), the old truthiness check only worked because the old value was a plain list.

## Notes on scope

`gemma4_unified.py` (the non-MTP Gemma4 model) sets the same `self._suppress_token_ids = gen_cfg.get("suppress_tokens") ...` pattern but never actually reads it anywhere in that file, so it isn't affected by this bug in practice (dead assignment) and I left it alone rather than changing behavior nobody's relying on. Only `gemma4_mtp.py` both sets and uses it.

## Verification

No GPU in this environment, so I wasn't able to reproduce the actual CUDA-graph-capture crash or confirm the fix resolves it end-to-end. What I did verify:

- Confirmed `register_buffer(name, tensor, persistent=False)` is an established pattern in this codebase for equivalent non-weight constant tensors (`longcat_flash_ngram.py`).
- Grepped all four usages of `_suppress_token_ids` in the file, both the definition site and the `compute_logits` read site are updated consistently.
- `gemma4_unified.py` was checked to confirm it doesn't share this bug in a way this PR needs to also touch.

Flagging the lack of GPU verification explicitly rather than claiming this was tested end-to-end.
