### PR TITLE
[ROCm][CI] Unblock `AMD: Language Models Test (Extended Pooling)`

### DIFF
--- a/tests/models/language/pooling/test_token_classification.py
+++ b/tests/models/language/pooling/test_token_classification.py
@@ -128,6 +128,10 @@ PRIVACY_FILTER_PROMPTS = [
 ]
 
 
+@pytest.mark.skipif(
+    current_platform.is_rocm(),
+    reason="Workspace growth allocation issue on ROCm. See https://github.com/vllm-project/vllm/issues/48510",
+)
 @pytest.mark.parametrize("model", ["openai/privacy-filter"])
 @pytest.mark.parametrize("dtype", ["bfloat16"])
 @torch.inference_mode


### PR DESCRIPTION

Add a skip for the failing test `models/language/pooling/test_token_classification.py::test_openai_privacy_filter[bfloat16-openai/privacy-filter]` (https://buildkite.com/vllm/ci/builds/77673/list?sid=019f5553-8716-4596-8f4c-62c6657cef31&tab=output) until this issue is resolved https://github.com/vllm-project/vllm/issues/48510.

One attempt to resolve is in progress here https://github.com/vllm-project/vllm/pull/48179.