### PR TITLE
[BugFix] Add SM120 fallback for DeepSeek sparse indexer logits

### DIFF
--- a/tests/kernels/test_sparse_attn_indexer_sm120.py
+++ b/tests/kernels/test_sparse_attn_indexer_sm120.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.sparse_indexer_sm120 import (
+    fp8_mqa_logits_sm120,
+    fp8_paged_mqa_logits_sm120,
+)
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+def _reference_logits(q, k, k_scale, weights):
+    scores = torch.einsum("mhd,nd->mnh", q.float(), k.float()).relu_()
+    return (scores * weights.float().unsqueeze(1)).sum(dim=-1) * k_scale.float()
+
+
+def test_fp8_mqa_logits_sm120_matches_reference():
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    fp8_dtype = torch.float8_e4m3fn
+    q = torch.randn(5, 4, 128, device=device).to(fp8_dtype)
+    k = torch.randn(11, 128, device=device).to(fp8_dtype)
+    k_scale = torch.rand(11, device=device) + 0.5
+    weights = torch.randn(5, 4, device=device)
+    starts = torch.tensor([0, 0, 1, 2, 4], dtype=torch.int32, device=device)
+    ends = torch.tensor([1, 3, 5, 8, 11], dtype=torch.int32, device=device)
+
+    actual = fp8_mqa_logits_sm120(
+        q, k, k_scale, weights, starts, ends, clean_logits=True
+    )
+    expected = _reference_logits(q, k, k_scale, weights)
+    positions = torch.arange(k.shape[0], device=device).unsqueeze(0)
+    valid = (positions >= starts.unsqueeze(1)) & (positions < ends.unsqueeze(1))
+    expected.masked_fill_(~valid, float("-inf"))
+
+    torch.testing.assert_close(actual, expected, atol=0.1, rtol=0.02)
+
+
+def test_fp8_paged_mqa_logits_sm120_matches_reference():
+    torch.manual_seed(1)
+    device = torch.device("cuda")
+    fp8_dtype = torch.float8_e4m3fn
+    batch_size, next_n, num_heads, head_dim = 2, 2, 4, 128
+    block_size, num_blocks, max_model_len = 64, 4, 128
+
+    values = torch.randn(num_blocks, block_size, head_dim, device=device).to(fp8_dtype)
+    scales = torch.rand(num_blocks, block_size, device=device) + 0.5
+    cache_flat = torch.empty(
+        num_blocks,
+        block_size * (head_dim + 4),
+        dtype=torch.uint8,
+        device=device,
+    )
+    value_bytes = block_size * head_dim
+    cache_flat[:, :value_bytes].copy_(values.view(torch.uint8).view(num_blocks, -1))
+    cache_flat[:, value_bytes:].copy_(
+        scales.contiguous().view(torch.uint8).view(num_blocks, -1)
+    )
+    cache = cache_flat.view(num_blocks, block_size, 1, head_dim + 4)
+
+    q = torch.randn(batch_size, next_n, num_heads, head_dim, device=device).to(
+        fp8_dtype
+    )
+    weights = torch.randn(batch_size * next_n, num_heads, device=device)
+    context_lens = torch.tensor([[63, 64], [97, 128]], dtype=torch.int32, device=device)
+    block_tables = torch.tensor([[2, 0], [3, 1]], dtype=torch.int32, device=device)
+
+    actual = fp8_paged_mqa_logits_sm120(
+        q,
+        cache,
+        weights,
+        context_lens,
+        block_tables,
+        max_model_len,
+        clean_logits=True,
+    )
+
+    expected_rows = []
+    weights = weights.view(batch_size, next_n, num_heads)
+    for batch in range(batch_size):
+        pages = block_tables[batch].long()
+        k = values[pages].reshape(max_model_len, head_dim)
+        k_scale = scales[pages].reshape(max_model_len)
+        expected_rows.append(_reference_logits(q[batch], k, k_scale, weights[batch]))
+    expected = torch.cat(expected_rows)
+    positions = torch.arange(max_model_len, device=device).unsqueeze(0)
+    expected.masked_fill_(~(positions < context_lens.reshape(-1, 1)), float("-inf"))
+
+    torch.testing.assert_close(actual, expected, atol=0.1, rtol=0.02)

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -462,6 +462,24 @@ def sparse_attn_indexer(
                         cu_seqlen_ks,
                         cu_seqlen_ke,
                     )
+                elif current_platform.is_device_capability_family(120):
+                    from vllm.model_executor.layers.sparse_indexer_sm120 import (
+                        fp8_mqa_logits_sm120,
+                    )
+
+                    if q_scale_slice is not None:
+                        raise RuntimeError(
+                            "The SM120 sparse indexer fallback does not support FP4 Q"
+                        )
+                    logits = fp8_mqa_logits_sm120(
+                        q_slice_cast,
+                        k_quant_cast,
+                        k_scale_cast,
+                        weights[chunk.token_start : chunk.token_end],
+                        cu_seqlen_ks,
+                        cu_seqlen_ke,
+                        clean_logits=False,
+                    )
                 else:
                     logits = fp8_fp4_mqa_logits(
                         (q_slice_cast, q_scale_slice),
@@ -557,6 +575,24 @@ def sparse_attn_indexer(
                 decode_metadata.block_table,
                 decode_metadata.schedule_metadata,
                 max_model_len,
+            )
+        elif current_platform.is_device_capability_family(120):
+            from vllm.model_executor.layers.sparse_indexer_sm120 import (
+                fp8_paged_mqa_logits_sm120,
+            )
+
+            if padded_q_scale is not None:
+                raise RuntimeError(
+                    "The SM120 sparse indexer fallback does not support FP4 Q"
+                )
+            logits = fp8_paged_mqa_logits_sm120(
+                padded_q_quant_cast,
+                kv_cache,
+                weights[:num_padded_tokens],
+                seq_lens,
+                decode_metadata.block_table,
+                max_model_len,
+                clean_logits=False,
             )
         else:
             logits = fp8_fp4_paged_mqa_logits(

--- a/vllm/model_executor/layers/sparse_indexer_sm120.py
+++ b/vllm/model_executor/layers/sparse_indexer_sm120.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compatibility sparse-indexer logits implementations for SM120."""
+
+import torch
+
+
+def fp8_mqa_logits_sm120(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    k_scale: torch.Tensor,
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+    clean_logits: bool,
+) -> torch.Tensor:
+    """Compute non-paged MQA logits without unsupported DeepGEMM kernels."""
+    if q.ndim != 3 or k.ndim != 2 or q.shape[-1] != k.shape[-1]:
+        raise ValueError(f"Unexpected q/k shapes: {q.shape=}, {k.shape=}")
+    if weights.shape != q.shape[:2]:
+        raise ValueError(f"Unexpected weights shape: {weights.shape}")
+
+    q_bf16 = q.to(torch.bfloat16)
+    k_bf16_t = k.to(torch.bfloat16).T.contiguous()
+    logits = torch.zeros((q.shape[0], k.shape[0]), dtype=torch.float32, device=q.device)
+    for head in range(q.shape[1]):
+        head_logits = torch.mm(q_bf16[:, head], k_bf16_t).float()
+        head_logits.relu_()
+        head_logits.mul_(weights[:, head].float().unsqueeze(1))
+        logits.add_(head_logits)
+    logits.mul_(k_scale.float().reshape(1, -1))
+
+    if clean_logits:
+        positions = torch.arange(k.shape[0], device=q.device).unsqueeze(0)
+        valid = (positions >= cu_seqlen_ks.reshape(-1, 1)) & (
+            positions < cu_seqlen_ke.reshape(-1, 1)
+        )
+        logits.masked_fill_(~valid, float("-inf"))
+    return logits
+
+
+def fp8_paged_mqa_logits_sm120(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    max_model_len: int,
+    clean_logits: bool,
+) -> torch.Tensor:
+    """Compute paged MQA logits for an FP8 indexer cache on SM120."""
+    if q.ndim != 4:
+        raise ValueError(f"Expected q to have shape [B, N, H, D], got {q.shape}")
+    batch_size, next_n, num_heads, head_dim = q.shape
+    block_size = kv_cache.shape[1]
+    if kv_cache.shape[2:] != (1, head_dim + 4):
+        raise ValueError(f"Unexpected indexer cache shape: {kv_cache.shape}")
+    if weights.shape != (batch_size * next_n, num_heads):
+        raise ValueError(f"Unexpected weights shape: {weights.shape}")
+
+    max_pages = min(
+        block_tables.shape[1], (max_model_len + block_size - 1) // block_size
+    )
+    padded_seq_len = min(max_pages * block_size, max_model_len)
+    cache_rows = kv_cache.reshape(kv_cache.shape[0], block_size * (head_dim + 4))
+    value_bytes = block_size * head_dim
+    q_bf16 = q.to(torch.bfloat16)
+    weights = weights.view(batch_size, next_n, num_heads).float()
+    logits = torch.zeros(
+        (batch_size, next_n, max_model_len),
+        dtype=torch.float32,
+        device=q.device,
+    )
+
+    # Process requests independently so the dequantized K workspace scales with
+    # one sequence rather than batch_size * max_model_len.
+    for batch in range(batch_size):
+        page_ids = block_tables[batch, :max_pages].clamp_min(0).long()
+        pages = cache_rows[page_ids]
+        k = pages[:, :value_bytes].contiguous().view(q.dtype)
+        k = k.view(max_pages * block_size, head_dim)[:padded_seq_len]
+        k_scale = pages[:, value_bytes:].contiguous().view(torch.float32)
+        k_scale = k_scale.view(-1)[:padded_seq_len]
+        k_bf16_t = k.to(torch.bfloat16).T.contiguous()
+
+        output = logits[batch, :, :padded_seq_len]
+        for head in range(num_heads):
+            head_logits = torch.mm(q_bf16[batch, :, head], k_bf16_t).float()
+            head_logits.relu_()
+            head_logits.mul_(weights[batch, :, head].unsqueeze(1))
+            output.add_(head_logits)
+        output.mul_(k_scale.float().unsqueeze(0))
+
+    logits = logits.view(batch_size * next_n, max_model_len)
+    if clean_logits:
+        seq_lens = context_lens.reshape(batch_size, next_n)
+        positions = torch.arange(max_model_len, device=q.device).unsqueeze(0)
+        logits.masked_fill_(~(positions < seq_lens.reshape(-1, 1)), float("-inf"))
+    return logits

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -723,8 +723,11 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             if seq_lens.dim() == 1:
                 seq_lens = seq_lens.unsqueeze(-1)
 
-            # DeepGEMM is required for the paged MQA logits on CUDA devices
-            if current_platform.is_cuda() and has_deep_gemm():
+            # The SM120 compatibility path does not consume DeepGEMM's
+            # architecture-specific scheduler metadata.
+            if current_platform.is_device_capability_family(120):
+                self.scheduler_metadata_buffer.zero_()
+            elif current_platform.is_cuda() and has_deep_gemm():
                 self.scheduler_metadata_buffer[:] = get_paged_mqa_logits_metadata(
                     seq_lens,
                     self.kv_cache_spec.storage_block_size,


### PR DESCRIPTION
## Purpose

DeepSeek sparse MLA on SM120 already selects the dedicated FlashInfer attention backend, but the sparse indexer still calls DeepGEMM for MQA logits and paged scheduler metadata. Those DeepGEMM paths reject SM120 with an unsupported-architecture error.

This PR:

- routes FP8 prefill and paged-decode indexer logits through a Torch/BF16 compatibility implementation on SM120;
- avoids generating DeepGEMM scheduler metadata that the SM120 fallback does not consume;
- fails explicitly for FP4 Q, which this compatibility path does not support.

This is a correctness fallback for the indexer stage. The optimized SM120 sparse-attention stage remains handled by FlashInfer.

Related to #47266 and #47818.

## Test Plan

```bash
uvx ruff format --check   vllm/model_executor/layers/sparse_attn_indexer.py   vllm/model_executor/layers/sparse_indexer_sm120.py   vllm/v1/attention/backends/mla/indexer.py   tests/kernels/test_sparse_attn_indexer_sm120.py

uvx ruff check   vllm/model_executor/layers/sparse_attn_indexer.py   vllm/model_executor/layers/sparse_indexer_sm120.py   vllm/v1/attention/backends/mla/indexer.py   tests/kernels/test_sparse_attn_indexer_sm120.py

pytest -q tests/kernels/test_sparse_attn_indexer_sm120.py
```

Manual DeepSeek-V4-Flash TP=8 serving smoke test on 8x NVIDIA RTX 6000D (SM120), including a short chat request and a 12K-token prompt.

## Test Result

- Ruff format and lint checks passed.
- GPU unit tests: `2 passed in 6.64s`.
- Service health check returned HTTP 200.
- Short chat: HTTP 200, 13 prompt tokens + 32 completion tokens, coherent output.
- Long-context smoke: HTTP 200, 12,006 prompt tokens + 2 completion tokens.
- No Traceback, OOM, or unsupported-architecture errors in the service log.

The end-to-end smoke used the exact PR fallback implementation mounted into the available NGC 26.06 runtime, with a thin call-signature adapter for that image's older indexer API.

No documentation update is needed because this change does not alter the public API or backend-selection behavior.

---
<details>
<summary>Essential elements checklist</summary>

- [x] Purpose and related issues
- [x] Test commands
- [x] Unit and end-to-end test results
- [x] Documentation impact considered

</details>
