### PR TITLE
fix(models): Resolve Gemma 4 CUDA graph capture crash and H2D copies in suppress_token_ids

### DIFF
--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -1131,7 +1131,12 @@ class Gemma4ForConditionalGeneration(
         self.num_redundant_experts = self.language_model.num_redundant_experts
 
         gen_cfg = vllm_config.model_config.try_get_generation_config()
-        self._suppress_token_ids = gen_cfg.get("suppress_tokens") if gen_cfg else None
+        ids = gen_cfg.get("suppress_tokens") if gen_cfg else None
+        self.register_buffer(
+            "_suppress_token_ids",
+            torch.tensor(ids, dtype=torch.long) if ids else None,
+            persistent=False,
+        )
 
     # ------------------------------------------------------------------ #
     # Input parsing
@@ -1612,8 +1617,8 @@ class Gemma4ForConditionalGeneration(
         hidden_states: torch.Tensor,
     ) -> torch.Tensor | None:
         logits = self.language_model.compute_logits(hidden_states)
-        if logits is not None and self._suppress_token_ids:
-            logits[:, self._suppress_token_ids] = -float("inf")
+        if logits is not None and self._suppress_token_ids is not None:
+            logits.index_fill_(1, self._suppress_token_ids, float("-inf"))
         return logits
 
     # ------------------------------------------------------------------ #

--- a/vllm/model_executor/models/gemma4_mtp.py
+++ b/vllm/model_executor/models/gemma4_mtp.py
@@ -529,7 +529,12 @@ class Gemma4MTP(nn.Module):
 
         draft_cfg = vllm_config.speculative_config.draft_model_config
         gen_cfg = draft_cfg.try_get_generation_config()
-        self._suppress_token_ids = gen_cfg.get("suppress_tokens") if gen_cfg else None
+        ids = gen_cfg.get("suppress_tokens") if gen_cfg else None
+        self.register_buffer(
+            "_suppress_token_ids",
+            torch.tensor(ids, dtype=torch.long) if ids else None,
+            persistent=False,
+        )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
@@ -581,8 +586,8 @@ class Gemma4MTP(nn.Module):
             )
         else:
             logits = self.logits_processor(self.lm_head, hidden_states)
-        if logits is not None and self._suppress_token_ids:
-            logits[:, self._suppress_token_ids] = -float("inf")
+        if logits is not None and self._suppress_token_ids is not None:
+            logits.index_fill_(1, self._suppress_token_ids, float("-inf"))
         return logits
 
     def get_top_tokens(

--- a/vllm/model_executor/models/gemma4_unified.py
+++ b/vllm/model_executor/models/gemma4_unified.py
@@ -347,7 +347,12 @@ class Gemma4UnifiedForConditionalGeneration(Gemma4ForConditionalGeneration):
         self.set_eplb_state = self.language_model.set_eplb_state
 
         gen_cfg = vllm_config.model_config.try_get_generation_config()
-        self._suppress_token_ids = gen_cfg.get("suppress_tokens") if gen_cfg else None
+        ids = gen_cfg.get("suppress_tokens") if gen_cfg else None
+        self.register_buffer(
+            "_suppress_token_ids",
+            torch.tensor(ids, dtype=torch.long) if ids else None,
+            persistent=False,
+        )
 
     # ------------------------------------------------------------------ #
     # Multimodal processing (encoder-free overrides)


### PR DESCRIPTION
Resolves #48503

### Description
This fixes a `RuntimeError: Cannot copy between CPU and CUDA tensors during CUDA graph capture` crash when Gemma 4 models (with MTP speculative decoding enabled) suppress tokens during `compute_logits`.

Two bugs contributed to this:
1. `_suppress_token_ids` was stored as a Python list. Indexing a CUDA tensor with it triggers an implicit unpinned H2D copy.
2. The assignment `logits[:, ids] = -float('inf')` uses a Python float scalar, which PyTorch's advanced indexing internally converts to a CPU scalar tensor, triggering another H2D copy.

**Fixes:**
* Materialize `_suppress_token_ids` as a device tensor via `register_buffer(persistent=False)`.
* Use `logits.index_fill_(1, ids, float("-inf"))` to assign the scalar value natively on-device.
* Applied the fix to `gemma4_mtp.py`, `gemma4_mm.py`, and `gemma4_unified.py` since all three share the same latent bug.

### Why not duplicate PR #48509?
PR #48509 only fixes the first bug (the list index) and only in `gemma4_mtp.py`. The advanced indexing scalar assignment in that PR will still crash during graph capture. This PR fixes both bugs across all affected models.

### Testing
- [x] Ran a standalone CUDA graph capture unit test to verify that `index_fill_` succeeds where advanced indexing fails.
- [x] Verified `pre-commit` linters pass.

