### PR TITLE
[Bugfix][Structured Output][Spec Decode] Advance grammar same-step for all structured types at the reasoning boundary

### DIFF
--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -241,6 +241,116 @@ class TestReasoningStructuredOutput:
         assert structured_req.reasoning_ended is True
         assert result is True
 
+    def test_should_advance_reasoning_just_ended_with_spec_decode_json(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """When reasoning ends this step under speculative decoding, advance
+        immediately for every structured type, not just structural tags: the
+        step may already contain accepted post-marker content, and deferring
+        leaves the grammar one token behind the sampled stream (#48228)."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+        structured_req.structured_output_key = (
+            StructuredOutputOptions.JSON,
+            '{"type": "object"}',
+        )
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_streaming.return_value = True
+        structured_req.reasoner = reasoner
+
+        manager_with_reasoner.vllm_config.speculative_config = Mock()
+
+        result = manager_with_reasoner.should_advance(
+            mock_request_with_structured_output
+        )
+
+        assert structured_req.reasoning_ended is True
+        assert result is True
+        assert isinstance(structured_req.reasoning_end_token_index, int)
+
+    def test_should_advance_detects_end_from_new_token_ids(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """new_token_ids is the authoritative step delta: with speculative
+        decoding, num_computed_tokens is pre-incremented past accepted draft
+        tokens, so the counter-derived window misses the end marker (#34650)."""
+        end_token_id, content_token_id = 42, 99
+        request = mock_request_with_structured_output
+        structured_req = request.structured_output_request
+        structured_req.reasoning_ended = False
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_streaming.side_effect = (
+            lambda input_ids, delta_ids: end_token_id in list(delta_ids)
+        )
+        structured_req.reasoner = reasoner
+
+        request.all_token_ids = request.prompt_token_ids + [
+            7,
+            end_token_id,
+            content_token_id,
+        ]
+        # Spec decode pre-incremented past the accepted tokens: the
+        # counter-derived window all_token_ids[num_computed_tokens:] is empty.
+        request.num_computed_tokens = len(request.all_token_ids)
+        request.num_output_placeholders = 0
+
+        # The counter fallback misses the marker...
+        assert manager_with_reasoner.should_advance(request) is False
+        assert structured_req.reasoning_ended is False
+
+        # ...the explicit step delta does not (no spec config here, so the
+        # advance itself is still deferred to the next step).
+        result = manager_with_reasoner.should_advance(
+            request, [end_token_id, content_token_id]
+        )
+        assert structured_req.reasoning_ended is True
+        assert result is False
+
+    def test_should_advance_straddle_step_trims_and_advances_same_step(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """A speculative step accepting [</think>, "{"] must advance the
+        grammar with exactly the post-marker content in the same step;
+        otherwise the next bitmask is computed from the un-advanced grammar
+        and re-forces the content token, doubling it in the output (#48228)."""
+        end_token_id, content_token_id = 42, 99
+        request = mock_request_with_structured_output
+        structured_req = request.structured_output_request
+        structured_req.reasoning_ended = False
+        structured_req.structured_output_key = (
+            StructuredOutputOptions.JSON,
+            '{"type": "object"}',
+        )
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_streaming.side_effect = (
+            lambda input_ids, delta_ids: end_token_id in list(delta_ids)
+        )
+        structured_req.reasoner = reasoner
+        manager_with_reasoner.vllm_config.speculative_config = Mock()
+
+        new_token_ids = [end_token_id, content_token_id]
+        request.all_token_ids = request.prompt_token_ids + [
+            7,
+            end_token_id,
+            content_token_id,
+        ]
+        request.num_computed_tokens = len(request.all_token_ids)
+        request.num_output_placeholders = 0
+
+        assert manager_with_reasoner.should_advance(request, new_token_ids) is True
+        assert structured_req.reasoning_end_token_index == (
+            len(request.all_token_ids) - 2
+        )
+        assert manager_with_reasoner.trim_reasoning_for_advance(
+            request, new_token_ids
+        ) == [content_token_id]
+
     def test_should_advance_reasoning_already_ended(
         self,
         manager_with_reasoner,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1690,7 +1690,9 @@ class Scheduler(SchedulerInterface):
                 request.status = RequestStatus.FINISHED_STOPPED
                 stopped = True
 
-            if new_token_ids and self.structured_output_manager.should_advance(request):
+            if new_token_ids and self.structured_output_manager.should_advance(
+                request, new_token_ids
+            ):
                 struct_output_request = request.structured_output_request
                 assert struct_output_request is not None
                 grammar = struct_output_request.grammar

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -15,7 +15,6 @@ from vllm.v1.structured_output.backend_guidance import GuidanceBackend
 from vllm.v1.structured_output.backend_types import (
     StructuredOutputBackend,
     StructuredOutputGrammar,
-    StructuredOutputOptions,
 )
 from vllm.v1.structured_output.backend_xgrammar import XgrammarBackend
 
@@ -368,7 +367,9 @@ class StructuredOutputManager:
             return request.structured_output_request.reasoning_ended
         return True
 
-    def should_advance(self, request: "Request") -> bool:
+    def should_advance(
+        self, request: "Request", new_token_ids: Sequence[int] | None = None
+    ) -> bool:
         if not request.use_structured_output:
             return False
 
@@ -391,33 +392,38 @@ class StructuredOutputManager:
         if structured_req.reasoning_ended:
             return True
 
-        # Check if reasoning ends in *this* step
-        delta_from = request.num_computed_tokens - request.num_output_placeholders
+        # Check if reasoning ends in *this* step. Prefer the caller's actual
+        # new_token_ids over reconstructing the step window from scheduler
+        # counters: with speculative decoding, num_computed_tokens is already
+        # advanced past the accepted draft tokens when this runs, so the
+        # counter-derived window can miss the reasoning-end marker.
         all_token_ids = request.all_token_ids
-        start = (
-            delta_from if delta_from >= 0 else max(len(all_token_ids) + delta_from, 0)
-        )
-        if reasoner.is_reasoning_end_streaming(
-            all_token_ids, itertools.islice(all_token_ids, start, None)
-        ):
+        if new_token_ids is not None:
+            start = max(len(all_token_ids) - len(new_token_ids), 0)
+            delta: Iterable[int] = new_token_ids
+        else:
+            delta_from = request.num_computed_tokens - request.num_output_placeholders
+            start = (
+                delta_from
+                if delta_from >= 0
+                else max(len(all_token_ids) + delta_from, 0)
+            )
+            delta = itertools.islice(all_token_ids, start, None)
+        if reasoner.is_reasoning_end_streaming(all_token_ids, delta):
             structured_req.reasoning_ended = True
 
-            # Reasoning just ended this step. Defer FSM advance until the next
-            # pass (see reasoning_ended check above) for JSON/regex/choice/grammar:
-            # advancing on the closing boundary token can accept tokens that still
-            # belong to the reasoning stream. Structural tags are the only safe
-            # same-step exception: they model phased output (e.g. thinking tag ->
-            # answer tag), and speculative decoding must run grammar.validate_tokens
-            # on draft tokens produced immediately after that transition.
-            if (
-                self.vllm_config.speculative_config is not None
-                and structured_req.structured_output_key[0]
-                == StructuredOutputOptions.STRUCTURAL_TAG
-            ):
-                # The scheduler will advance the grammar with this step's
-                # tokens right away, but the step still contains reasoning
-                # content up to and including the end marker. Record where
-                # it ends so trim_reasoning_for_advance() can drop it.
+            # Reasoning just ended this step. Without speculative decoding the
+            # boundary step ends at the marker, so deferring the FSM advance to
+            # the next pass (see reasoning_ended check above) is safe. With
+            # speculative decoding the same step can already contain accepted
+            # post-marker content (e.g. a drafted "{" verified right after the
+            # end marker); deferring would leave the grammar permanently one
+            # token behind the sampled stream, and the next bitmask would then
+            # force a duplicate of a token the model already emitted. Advance
+            # same-step for every structured type: trim_reasoning_for_advance()
+            # drops everything up to and including the marker, so the grammar
+            # never sees reasoning content.
+            if self.vllm_config.speculative_config is not None:
                 structured_req.reasoning_end_token_index = (
                     self._find_reasoning_end_index(reasoner, all_token_ids, start)
                 )


### PR DESCRIPTION
## Purpose

Fixes #48228 (structured output under speculative decoding starts with a doubled
opening token, e.g. `{{`). Fixes #34650 (structured output under speculative
decoding runs entirely unconstrained with delta-sensitive reasoning parsers). Both
are reasoning-boundary bugs addressed by the two changes below.

### 1. Same-step advance is gated to STRUCTURAL_TAG; other structured types fall one token behind

When reasoning ends mid-step under speculative decoding, the same step can also
accept post-marker content — a `{` drafted right after `</think>` and verified in
the same step (`grammar_bitmask()` already constrains those positions since #44297).
But `should_advance()` returns True same-step only for structural tags; for
JSON/regex/choice/grammar the advance is deferred, so the accepted `{` never reaches
`accept_tokens()`. The persisted grammar stays one token behind the sampled stream,
and the next step's bitmask — computed from the un-advanced grammar — forces a
duplicate of the token the model already emitted: `{{`. (This is the persisted-state
counterpart of the transient window handling hardened in #44297: its in-window
advances are rolled back by design, so the persisted grammar must catch up here.)

Fix: extend the same-step trimmed advance to all structured output types under
speculative decoding. `trim_reasoning_for_advance()` already drops everything up to
and including the marker, so the grammar never sees reasoning content and #44006
stays fixed.

### 2. `should_advance()` reconstructs the step window from pre-incremented counters

`should_advance()` derives "this step's tokens" as
`all_token_ids[num_computed_tokens - num_output_placeholders:]`, but with
speculative decoding `num_computed_tokens` is already advanced past the accepted
draft tokens when `update_from_output()` runs, so the window can miss the
reasoning-end marker entirely for delta-sensitive streaming detectors (#34650 — the
`BaseThinkingReasoningParser` family, e.g. `deepseek_r1`), and it mislocates the
marker index needed for trimming with full-scan detectors (the current qwen3
adapter).

Fix: pass the call site's actual `new_token_ids` into `should_advance()`, used both
as the detection delta and to locate the marker within the true step window. The
counter arithmetic remains as a fallback for call sites without token context (the
two draft-validation sites, which run after `update_from_output()` and inherit the
persisted `reasoning_ended`).

## Test Plan

- 3 new unit tests in `tests/v1/structured_output/test_reasoning_structured_output.py`:
  same-step advance for JSON under spec decode; detection via explicit
  `new_token_ids` where the counter-derived window is empty; a straddle step
  `[</think>, "{"]` advancing the grammar with exactly the post-marker suffix.
- `pytest tests/v1/structured_output/test_reasoning_structured_output.py`
- E2E (#48228 config): Qwen3.6-27B (MTP weights preserved), TP=2,
  `--reasoning-parser qwen3 --tool-call-parser qwen3_coder --speculative-config
  '{"method":"mtp","num_speculative_tokens":2}' --structured-outputs-config
  '{"backend": "xgrammar", "disable_any_whitespace": true}'`; 10 concurrent requests
  per cell over 5 JSON schemas (3 from the structured-outputs docs + 2 production
  ones) × strict on/off, plus forced / `required` / `auto` tool calls.
- E2E repro of #34650: same model and flags but `--reasoning-parser deepseek_r1`
  (delta-sensitive; its `</think>` string resolves in the Qwen3.6 vocab), stock
  v0.25.0 vs this patch, 5 runs per schema × strict cell.

## Test Result

- Unit: 12/12 in the file (9 pre-existing, including the structural-tag same-step
  test, + 3 new).
- E2E (#48228 config) before: ~50% of `response_format json_schema` responses
  invalid (doubled `{{`), including the simple schemas from the structured-outputs
  docs. After: 100/100 valid across all cells; tool calls unaffected (10/10).
- #34650 A/B with the delta-sensitive parser: stock v0.25.0 free-generates under MTP
  (e.g. MathResponse 1/5 valid, a 6-field production schema 0/5; failures are
  invented keys or markdown-fenced JSON with `finish_reason=stop`), while this patch
  yields 50/50 valid across all schema × strict cells.

**AI disclosure**: developed with AI assistance (Claude Code); the submitter
reviewed all changed lines and validated behavior end-to-end on the deployments
described above. Commits carry `Co-authored-by` attribution.