### PR TITLE
[Bugfix] Include generation config stop token IDs in sampling defaults

### DIFF
--- a/tests/entrypoints/openai/test_stop_token_ids.py
+++ b/tests/entrypoints/openai/test_stop_token_ids.py
@@ -13,12 +13,35 @@ request because to_sampling_params() never fell back to defaults.
 
 import pytest
 
+from vllm.config import ModelConfig
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
 )
 from vllm.entrypoints.openai.completion.protocol import (
     CompletionRequest,
 )
+
+
+def test_generation_config_stop_ids_reach_openai_sampling_params(monkeypatch):
+    """Model generation metadata reaches the per-request OpenAI sampler."""
+    model_config = object.__new__(ModelConfig)
+    model_config.generation_config = "auto"
+    model_config.override_generation_config = {}
+    monkeypatch.setattr(
+        ModelConfig,
+        "try_get_generation_config",
+        lambda self: {"stop_token_ids": [200012, 200002]},
+    )
+
+    defaults = model_config.get_diff_sampling_param()
+    request = CompletionRequest(model="test-model", prompt="hello")
+    sampling_params = request.to_sampling_params(
+        max_tokens=100,
+        default_sampling_params=defaults,
+    )
+
+    assert defaults["stop_token_ids"] == [200012, 200002]
+    assert sampling_params.stop_token_ids == [200012, 200002]
 
 
 class TestChatCompletionStopTokenIds:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -725,7 +725,11 @@ def test_generation_config_loading():
     assert model_config.get_diff_sampling_param() == correct_generation_config
 
     # The generation config could be overridden by the user.
-    override_generation_config = {"temperature": 0.5, "top_k": 5}
+    override_generation_config = {
+        "temperature": 0.5,
+        "top_k": 5,
+        "stop_token_ids": [200012, 200002],
+    }
 
     model_config = ModelConfig(
         model_id,

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1510,6 +1510,7 @@ class ModelConfig:
             "top_p",
             "min_p",
             "max_new_tokens",
+            "stop_token_ids",
         ]
         if any(p in config for p in available_params):
             diff_sampling_param = {


### PR DESCRIPTION
## Purpose

`ModelConfig.get_diff_sampling_param()` currently filters model-authored `stop_token_ids` out of `generation_config.json`, even though `GenerationConfig` preserves the model-specific field and vLLM's `SamplingParams` supports it.

PR #35076 already merges `default_sampling_params["stop_token_ids"]` into OpenAI chat and completion requests when that default exists. This patch fills the earlier metadata-loading gap by adding `stop_token_ids` to the sampling-default allowlist.

Related PR #45978 addresses user-provided `override_generation_config` values reaching the special-token path. This PR addresses model-authored `stop_token_ids` reaching sampling defaults. The changes are complementary; #45978 intentionally leaves the sampling allowlist unchanged.

The existing request merge and deduplication behavior is unchanged. Offline consumers of `ModelConfig.get_diff_sampling_param()` also receive the model-authored default.

### Behavioral impact

Models publishing `stop_token_ids` may stop earlier because vLLM will no longer silently discard that metadata from sampling defaults. Operators can retain neutral vLLM defaults with:

```bash
--generation-config vllm
```

This is a generation-config semantics fix. It does not claim to resolve a model-specific benchmark, early-termination report, or performance regression.

### AI assistance and contributor review

AI assistance from Hermes was used during the investigation and initial patch/test drafting. I reviewed every changed line, reproduced the red/green test behavior, and understand and can defend the generation-config and stop-token propagation semantics end to end.

### Duplicate-work check

I searched open issues and PRs concerning `stop_token_ids`, `generation_config`, and sampling defaults.

- #35076 merges stop-token defaults into OpenAI requests once those defaults exist.
- #45978 propagates user-provided `override_generation_config` values through the special-token path.
- Neither adds model-authored `stop_token_ids` to `get_diff_sampling_param()`'s allowlist.

This PR fills that remaining metadata-loading gap.

### Model evaluation

I first evaluated the current public `openai/gpt-oss-20b` metadata and request-conversion path. Its `generation_config.json` publishes `eos_token_id: [200002, 199999, 200012]`, not `stop_token_ids`, so it cannot exercise this allowlist change. Main and this PR both produced no generation-config stop IDs for that checkpoint. The `--generation-config vllm` control also remained neutral.

I then ran a full controlled behavioral evaluation with the public `HuggingFaceTB/SmolLM2-135M-Instruct` checkpoint. The model metadata fixture was deliberately synthetic:

```json
{"stop_token_ids": [3995]}
```

All three runs used the same weights, image (`sha256:c530ac073aabe6e5e2cbd4199c331145626c541be741b219ddb00068b13e8431`), prompt (`The capital of France is`), seed (`123`), temperature (`0`), and `max_tokens` (`24`).

| Run | finish_reason | stop_reason | completion tokens |
| --- | --- | --- | ---: |
| Main with synthetic metadata | `length` | `null` | 24 |
| PR with synthetic metadata | `stop` | `3995` | 6 |
| PR with `--generation-config vllm` | `length` | `null` | 24 |

On main, the synthetic field was filtered and generation continued to the length limit. On this PR, generation stopped when token `3995` was sampled and reported that token as the stop reason. The PR's stopped token sequence was the exact prefix of the main sequence through token `3995`. The `--generation-config vllm` control exactly matched main's 24-token text and token IDs.

All servers remained healthy after the request and no trailing generation failure occurred. A parser was not involved because this evaluation used the completions endpoint.

## Test Plan

```bash
.venv/bin/python -m pytest -q \
  --confcutdir=tests/entrypoints/openai \
  tests/entrypoints/openai/test_stop_token_ids.py

.venv/bin/python -m pytest -q --noconftest \
  tests/test_config.py -k generation_config_loading

pre-commit run ruff-check --files \
  vllm/config/model.py \
  tests/test_config.py \
  tests/entrypoints/openai/test_stop_token_ids.py

pre-commit run ruff-format --files \
  vllm/config/model.py \
  tests/test_config.py \
  tests/entrypoints/openai/test_stop_token_ids.py
```

The new regression coverage exercises:

1. model generation metadata containing `stop_token_ids`;
2. `ModelConfig.get_diff_sampling_param()`;
3. `CompletionRequest.to_sampling_params()`;
4. final per-request `SamplingParams.stop_token_ids`.

## Test Result

With the patch-specific tests applied to unmodified current main, the new assertions fail as expected:

```text
1 failed, 8 passed
1 failed, 157 deselected
```

With this patch:

```text
9 passed in tests/entrypoints/openai/test_stop_token_ids.py
1 passed, 157 deselected in tests/test_config.py -k generation_config_loading
pre-commit ruff-check passed
pre-commit ruff-format passed
```

The signed commit was rebased onto current main `5c342876a6bde2689fa933548f31d0a9412a428a` before submission.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR is described.
- [x] The test plan includes the exact commands.
- [x] The test results include unpatched and patched outcomes.
- [x] Documentation impact was considered. Existing generation-config documentation already describes model defaults and `--generation-config vllm`.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>**
