### PR TITLE
[ROCm][Perf] Optimize sparse attention prefill kernel for DeepSeek-V4

### DIFF
--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -1187,10 +1187,12 @@ def _sparse_attn_prefill_ragged_kernel(
     kv_len = kv_end - kv_start
 
     k_offsets = tl.arange(0, BLOCK_K)
+    slot = tl.load(
+        kv_indices_ptr + kv_start + k_offsets, mask=k_offsets < kv_len, other=-1
+    )
     for k_start in tl.range(0, kv_len, BLOCK_K):
         k_pos = k_start + k_offsets
         in_range = k_pos < kv_len
-        slot = tl.load(kv_indices_ptr + kv_start + k_pos, mask=in_range, other=-1)
         valid = in_range & (slot >= 0) & (slot < num_kv)
         safe_slot = tl.where(valid, slot, 0)
 
@@ -1201,7 +1203,11 @@ def _sparse_attn_prefill_ragged_kernel(
             mask=valid[:, None] & dim_mask[None, :],
             other=0.0,
         )
-        kv = tl.where(valid[:, None] & dim_mask[None, :], kv, 0.0)
+
+        next_k_pos = k_start + BLOCK_K + k_offsets
+        slot = tl.load(
+            kv_indices_ptr + kv_start + next_k_pos, mask=next_k_pos < kv_len, other=-1
+        )
 
         scores = tl.dot(q, tl.trans(kv)) * scale
         scores = tl.where(head_mask[:, None] & valid[None, :], scores, neg_large)
@@ -1865,6 +1871,7 @@ def _rocm_sparse_attn_prefill_ragged_triton(
     block_h = 16
     block_d = triton.next_power_of_2(head_dim)
     block_k = 16 if head_dim >= 256 else 32
+    num_warps = 4 if num_heads <= 16 else 8
     out = torch.empty_like(q, dtype=torch.bfloat16)
     _sparse_attn_prefill_ragged_kernel[(num_queries, triton.cdiv(num_heads, block_h))](
         q,
@@ -1889,7 +1896,7 @@ def _rocm_sparse_attn_prefill_ragged_triton(
         BLOCK_H=block_h,
         BLOCK_D=block_d,
         BLOCK_K=block_k,
-        num_warps=8,
+        num_warps=num_warps,
     )
     return out
 

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -1871,7 +1871,7 @@ def _rocm_sparse_attn_prefill_ragged_triton(
     block_h = 16
     block_d = triton.next_power_of_2(head_dim)
     block_k = 16 if head_dim >= 256 else 32
-    num_warps = 4 if num_heads <= 16 else 8
+    num_warps = 4
     out = torch.empty_like(q, dtype=torch.bfloat16)
     _sparse_attn_prefill_ragged_kernel[(num_queries, triton.cdiv(num_heads, block_h))](
         q,


### PR DESCRIPTION



## Purpose
This PR optimizes DeepSeek-V4's dedicated sparse attention ragged prefill kernel in ROCm. The optimization speeds up the kernel by ~2x, and in E2E benchmark reduces TTFT by ~10%.

In the current upstream ROCm path, this kernel has some slight inefficiencies that can be optimized. Specifically, this PR addresses three points of optimization.

- `num_warps` setting. In DSv4-Pro's architecture, the per-workgroup tile under TP8 is `[BLOCK_H=16, 512]` and reduces to `[16, 16]`. Setting `num_warps` splits the K dimension, however, splitting it as high as 8 gives larger cross-wave reduction and more barriers for LDS reads/writes. Therefore, this PR sets `num_warps=4` instead to lower this overhead.
- Remove redundant mask. In the upstream kernel, `kv` is loaded with valid regions masked, and immediately after masked with the same predicate. The later mask should be redundant as the `kv` elements are already `0.0` where masks are `False` at loading. This redundant masking also inserts a mask op right between the load-MFMA ordering, preventing the kernel from benefiting from software pipelining.
- Prefetch the next tile. Overlap the next-tile kv load with MFMA to bring further performance gain.

All these optimization combined, for DeepSeek-V4-Pro's running shapes, the kernel achieves ~2x speed up compared with the current upstream baseline.

Kernel latency under `num_heads=16`, `head_dim=512` (DSv4-Pro TP8)
shape | main kernel latency (ms) | PR kernel latency (ms) | speedup
-- | -- | -- | --
prefill S=2048 | 0.348 ms | 0.190 ms | 1.83×
prefill S=4096 | 1.065 ms | 0.526 ms | 2.02×
prefill S=8192 | 2.782 ms | 1.306 ms | 2.13×


## Test Plan
`lm_eval` with gsm8k and performance benchmark on MI355

Server command
```
VLLM_ROCM_USE_AITER=1 \
vllm serve deepseek-ai/DeepSeek-V4-Pro \
  --host localhost \
  --port 8000 \
  --tensor-parallel-size 8 \
  --max-num-seqs 512 \
  --distributed-executor-backend mp \
  --trust-remote-code \
  --gpu-memory-utilization 0.8 \
  --tokenizer-mode deepseek_v4 \
  --reasoning-parser deepseek_v4 \
  --tool-call-parser deepseek_v4 \
  --enable-auto-tool-choice \
  --kv-cache-dtype fp8 \
  --block-size 256 \
  --no-enable-prefix-caching \
  --compilation-config '{"mode":3,"cudagraph_mode": "FULL_AND_PIECEWISE"}'
```

Performance benchmark
```
vllm bench serve --model deepseek-ai/DeepSeek-V4-Pro --trust-remote-code --dataset-name random --random-input-len $ISL --random-output-len $OSL --max-concurrency $CONC --num-prompts $PROMPTS --temperature 0 --ignore-eos
```

lm_eval
```
lm_eval --model local-completions --model_args model=deepseek-ai/DeepSeek-V4-Pro,base_url=http://0.0.0.0:8000/v1/completions,tokenizer_backend=None,tokenized_requests=False,num_concurrent=128,max_retries=10,max_gen_toks=2048,timeout=60000 --batch_size auto --tasks gsm8k --num_fewshot 30
```

## Test Result
deepseek-ai/DeepSeek-V4-Pro gsm8k PR
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    30|exact_match|↑  |0.9515|±  |0.0059|
|     |       |strict-match    |    30|exact_match|↑  |0.9522|±  |0.0059|

deepseek-ai/DeepSeek-V4-Pro E2E performance benchmark
| ISL/OSL | Conc | Config | Total tokens/s | Delta (%) | Total reqs/s | Delta (%) | mean TTFT (ms) | delta (%) | mean TPOT (ms) | delta (%) | mean ITL (ms) | delta (%) |
|---|---|---|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|
| 8k/1k | 8 | main | 2461.06 | - | 0.2670 | - | 2096.48 | - | 27.19 | - | 27.19 | - |
| 8k/1k | 8 | PR | 2500.38 | +1.6% | 0.2713 | +1.6% | 1955.92 | -6.7% | 26.86 | -1.2% | 26.86 | -1.2% |
| 8k/1k | 16 | main | 4146.70 | - | 0.4499 | - | 3202.50 | - | 31.53 | - | 31.53 | - |
| 8k/1k | 16 | PR | 4246.08 | +2.4% | 0.4607 | +2.4% | 2875.94 | -10.2% | 31.04 | -1.6% | 31.04 | -1.6% |
| 8k/1k | 32 | main | 6218.51 | - | 0.6748 | - | 5241.16 | - | 41.03 | - | 41.03 | - |
| 8k/1k | 32 | PR | 6465.07 | +4.0% | 0.7015 | +4.0% | 4700.07 | -10.3% | 39.79 | -3.0% | 39.79 | -3.0% |
| 8k/1k | 64 | main | 8239.43 | - | 0.8940 | - | 9213.52 | - | 60.51 | - | 60.51 | - |
| 8k/1k | 64 | PR | 8755.96 | +6.3% | 0.9501 | +6.3% | 8250.82 | -10.4% | 57.33 | -5.3% | 57.33 | -5.3% |
| 8k/1k | 128 | main | 10295.29 | - | 1.1171 | - | 17251.59 | - | 94.04 | - | 94.04 | - |
| 8k/1k | 128 | PR | 11049.28 | +7.3% | 1.1989 | +7.3% | 15447.22 | -10.5% | 88.17 | -6.2% | 88.17 | -6.2% |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

