### PR TITLE
[Bugfix] Pass quant_config to DiffusionGemma's ParallelLMHead

### DIFF
--- a/vllm/model_executor/models/diffusion_gemma.py
+++ b/vllm/model_executor/models/diffusion_gemma.py
@@ -239,6 +239,8 @@ class DiffusionGemmaForConditionalGeneration(
         self.lm_head = ParallelLMHead(
             num_embeddings=text_config.vocab_size,
             embedding_dim=text_config.hidden_size,
+            quant_config=vllm_config.quant_config,
+            prefix=maybe_prefix(prefix, "lm_head"),
         )
 
         if text_config.tie_word_embeddings:


### PR DESCRIPTION
## Purpose

`DiffusionGemmaForConditionalGeneration` builds its `ParallelLMHead` without
`quant_config` or `prefix`, so the head is always constructed as an unquantized
layer. Any checkpoint that quantizes `lm_head` therefore fails to load:

```
ValueError: There is no module or parameter named 'lm_head.weight_scale' in
DiffusionGemmaForConditionalGeneration
```

**Cause:** `vllm/model_executor/models/diffusion_gemma.py` omits the two
arguments that every other quantization-aware model passes. Compare `llama.py`:

```python
self.lm_head = ParallelLMHead(
    config.vocab_size,
    config.hidden_size,
    quant_config=quant_config,      # <- missing in diffusion_gemma.py
    prefix=maybe_prefix(prefix, "lm_head"),   # <- missing
)
```

The same file already threads `quant_config` and `maybe_prefix(...)` into the
vision tower and the language backbone a few lines above, so this reads as an
oversight rather than a deliberate exclusion.

**Fix:** pass both, reading the config off `vllm_config` directly:

```python
self.lm_head = ParallelLMHead(
    num_embeddings=text_config.vocab_size,
    embedding_dim=text_config.hidden_size,
    quant_config=vllm_config.quant_config,
    prefix=maybe_prefix(prefix, "lm_head"),
)
```

Note `vllm_config.quant_config` is used rather than the local `quant_config`
name, because that local is only bound inside the `if vision_config is not None:`
branch and would raise `NameError` on a text-only config.

**No behaviour change for existing checkpoints:** `quant_config` is `None` for
unquantized models, and the published quantized checkpoints
(`nvidia/diffusiongemma-26B-A4B-it-NVFP4`,
`RedHatAI/diffusiongemma-26B-A4B-it-FP8-dynamic`) both list `lm_head` in their
`ignore`, so the head stays unquantized there either way. The change only
affects checkpoints that explicitly quantize the head — which today cannot be
loaded at all.

## Test Plan

Initialization is enough to cover the regression, since the failure is at
weight-loading time:

```bash
pytest -sv tests/models/test_initialization.py -k DiffusionGemma
```

For the end-to-end repro, serve a compressed-tensors DiffusionGemma checkpoint
whose `lm_head` is untied from the embedding table and quantized (FP8,
per-channel weights + dynamic per-token activations) on top of NVFP4 experts:

```bash
vllm serve <diffusiongemma-nvfp4-fp8-head-checkpoint>
```

Hardware used: 1× RTX PRO 6000 Blackwell (sm_120), CUDA 13.

## Test Result

- **Before:** engine core fails at startup with the `lm_head.weight_scale`
  `ValueError` above; the model cannot be served at all.
- **After:** loads and generates correctly, and the head's GEMM moves off the
  bf16 path — a torch-profiler trace over one 256-token generation shows
  `cutlass_80` bf16 kernel time drop from **25.1 ms → 16.0 ms**.
- Unquantized and existing quantized checkpoints are unaffected (head remains
  bf16 in both, as before).

One honest caveat for reviewers: quantizing this head is **not** a throughput
win in our measurements — per-channel dequant plus dynamic activation
quantization costs roughly what it saves at `M=256 × vocab=262k`, and
end-to-end tok/s was unchanged within run-to-run variance. The point of this PR
is to **unblock** quantized-head checkpoints, not to speed up the default path.
