### PR TITLE
[Bugfix] Drop Gemma4 terminal tokens from streamed content

### DIFF
--- a/tests/parser/engine/test_gemma4_streaming_reasoning.py
+++ b/tests/parser/engine/test_gemma4_streaming_reasoning.py
@@ -27,6 +27,8 @@ TOOL_CALL_START_ID = 48  # <|tool_call>
 TOOL_CALL_END_ID = 49  # <tool_call|>
 QUOTED_ID = 52  # <|"|>
 NEW_TURN_ID = 53  # <|turn>
+TURN_END_ID = 54  # <turn|>
+EOS_ID = 55  # <eos>
 SPECIAL_TOKEN_MAP = {
     CHANNEL_START_ID: "<|channel>",
     CHANNEL_END_ID: "<channel|>",
@@ -34,6 +36,8 @@ SPECIAL_TOKEN_MAP = {
     TOOL_CALL_END_ID: "<tool_call|>",
     QUOTED_ID: '<|"|>',
     NEW_TURN_ID: "<|turn>",
+    TURN_END_ID: "<turn|>",
+    EOS_ID: "<eos>",
 }
 
 SPECIAL_TEXT_TO_ID = {v: k for k, v in SPECIAL_TOKEN_MAP.items()}
@@ -182,6 +186,34 @@ def request_obj():
 
 
 # ── Tests ────────────────────────────────────────────────────────────
+
+
+class TestGemma4DroppedTerminalText:
+    """Response-ending special-token text must not leak into content."""
+
+    @pytest.fixture
+    def plain_tokenizer(self):
+        return _make_tokenizer([(6000, "The answer is 4.")])
+
+    @pytest.fixture
+    def plain_parser(self, plain_tokenizer):
+        return Gemma4Parser(plain_tokenizer)
+
+    @pytest.mark.parametrize("terminal_text", ["<turn|>", "<eos>"])
+    def test_terminal_text_without_token_id_is_dropped(
+        self, plain_parser, request_obj, terminal_text
+    ):
+        delta = plain_parser.parse_delta(
+            f"The answer is 4.{terminal_text}",
+            [6000],
+            request_obj,
+            prompt_token_ids=[],
+            finished=True,
+        )
+
+        assert delta is not None
+        assert delta.content == "The answer is 4."
+        assert terminal_text not in delta.content
 
 
 class TestGemma4StreamingReasoningThenToolCall:

--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -39,6 +39,8 @@ CHANNEL_START = "<|channel>"
 CHANNEL_END = "<channel|>"
 TOOL_CALL_START = "<|tool_call>"
 TOOL_CALL_END = "<tool_call|>"
+TURN_END = "<turn|>"
+EOS_TOKEN = "<eos>"
 STRING_DELIM = '<|"|>'
 _DELIM_LEN = len(STRING_DELIM)
 
@@ -302,6 +304,8 @@ def gemma4_config() -> ParserEngineConfig:
             "THINK_END": CHANNEL_END,
             "TOOL_START": TOOL_CALL_START,
             "TOOL_END": TOOL_CALL_END,
+            "TURN_END": TURN_END,
+            "EOS": EOS_TOKEN,
             "CALL_PREFIX": "call:",
             "OPEN_BRACE": "{",
         },
@@ -363,6 +367,16 @@ def gemma4_config() -> ParserEngineConfig:
             # Absorb a bare <channel|> that arrives after we already
             # returned to CONTENT; prevents leaking it as TEXT_CHUNK.
             (ParserState.CONTENT, "THINK_END"): Transition(
+                ParserState.CONTENT,
+                (),
+            ),
+            # Drop response-ending tokens even if text arrives before the
+            # corresponding token ID reaches the streaming parser.
+            (ParserState.CONTENT, "TURN_END"): Transition(
+                ParserState.CONTENT,
+                (),
+            ),
+            (ParserState.CONTENT, "EOS"): Transition(
                 ParserState.CONTENT,
                 (),
             ),


### PR DESCRIPTION
## Purpose

Follow-up for the separate terminal-token leak described in https://github.com/vllm-project/vllm/issues/48217#issuecomment-4949594204.

When the Gemma4 streaming parser has already seen token IDs, text-only occurrences of special tokens such as `<turn|>` and `<eos>` can be treated as content if the detokenizer flushes the token text before the corresponding token ID reaches the parser. That can leak response-ending sentinel text into streamed `content`.

This PR registers the Gemma4 turn-end and EOS sentinels as explicit parser terminals and drops them from `CONTENT`, so they are removed even when the current delta only contains the token text.

Duplicate check: I checked open PRs for issue `48217`, `gemma4 eot`, `gemma4 eos`, and terminal-token related parser changes. #48262 addresses the channel-less streaming classification bug, but its diff does not cover `<turn|>` / `<eos>` terminal text leakage.

AI assistance was used to prepare this focused patch; I reviewed the changed lines and ran the tests below.

## Test Plan

Added `TestGemma4DroppedTerminalText` covering both `<turn|>` and `<eos>` arriving in `delta_text` without their token IDs.

## Verification

```bash
.venv/bin/python -m pytest tests/parser/engine/test_gemma4_streaming_reasoning.py -q
# 57 passed, 1 warning in 0.16s

.venv/bin/python -m pytest tests/parser/engine/test_gemma4_streaming_reasoning.py tests/parser/engine/test_token_id_scanner.py -q
# 86 passed, 1 warning in 0.22s

uvx ruff check vllm/parser/gemma4.py tests/parser/engine/test_gemma4_streaming_reasoning.py
# All checks passed!
```

A broader attempted command included non-existent local paths (`tests/reasoning/test_gemma4_reasoning_parser.py`, `tests/tool_parsers/test_gemma4_tool_parser.py`) and exited before collection; I replaced it with the parser-engine suites above.
