### PR TITLE
[Bugfix] Skip minimax_m3 tool parser tests when Rust extension is absent

### DIFF
--- a/tests/tool_parsers/test_minimax_m3_tool_parser.py
+++ b/tests/tool_parsers/test_minimax_m3_tool_parser.py
@@ -14,6 +14,10 @@ from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.tool_parsers import ToolParserManager
 from vllm.tool_parsers.minimax_m3_tool_parser import MinimaxM3ToolParser
 
+# MinimaxM3ToolParser extends RustToolParser; skip when the PyO3 extension
+# is absent (mirrors the guard in test_rust_tool_parser.py).
+pytest.importorskip("vllm._rust_tool_parser")
+
 pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
 
 NS = "]<]minimax[>["


### PR DESCRIPTION
## Purpose

`test_minimax_m3_tool_parser.py` fails with `RuntimeError: Rust tool parsing requires the vllm._rust_tool_parser PyO3 extension` when the Rust extension is not built into the wheel.

`MinimaxM3ToolParser` extends `RustToolParser`, so these tests require the PyO3 extension. `test_rust_tool_parser.py` already guards against this with `pytest.importorskip("vllm._rust_tool_parser")`, but `test_minimax_m3_tool_parser.py` does not.

## Changes

Added `pytest.importorskip("vllm._rust_tool_parser")` to `test_minimax_m3_tool_parser.py`, consistent with the existing guard in `test_rust_tool_parser.py`.

## Context

This surfaces in downstream builds where the Rust frontend/extensions are not compiled (e.g. CPU-only wheels). The tests should skip gracefully rather than fail with a RuntimeError.

## Test Plan

- When Rust extension is present: tests run as before
- When Rust extension is absent: tests skip with `SKIPPED (no vllm._rust_tool_parser)`