### PR TITLE
[Core][LoRA] Support fp32 lm_head (head_dtype) on the LoRA path

### DIFF
--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -368,8 +368,9 @@ def test_embeddings(
 @pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("vocab_size", [64000, 256512, 258048])
 @pytest.mark.parametrize("stage", STAGES)
+@pytest.mark.parametrize("head_dtype", [None, torch.float32])
 def test_lm_head_logits_processor(
-    default_vllm_config, dist_init, num_loras, device, vocab_size, stage
+    default_vllm_config, dist_init, num_loras, device, vocab_size, stage, head_dtype
 ) -> None:
     if current_platform.is_cuda_alike() or current_platform.is_xpu():
         torch.accelerator.set_device_index(device)
@@ -391,6 +392,8 @@ def test_lm_head_logits_processor(
         linear.weight.data = torch.rand_like(linear.weight.data)
         linear.weight.data[:, vocab_size:] = 0
         logits_processor = LogitsProcessor(vocab_size)
+        # Exercise an fp32 lm_head (head_dtype) on the LoRA path.
+        logits_processor.head_dtype = head_dtype
         lora_logits_processor = LogitsProcessorWithLoRA(
             logits_processor, 1024, linear.weight.dtype, linear.weight.device, None
         )

--- a/tests/v1/sample/test_head_dtype.py
+++ b/tests/v1/sample/test_head_dtype.py
@@ -124,22 +124,6 @@ def test_get_top_tokens_honors_head_dtype(default_vllm_config):
     assert torch.equal(top, expected)
 
 
-def test_fp32_head_rejected_with_lora(default_vllm_config):
-    from vllm.lora.layers.logits_processor import LogitsProcessorWithLoRA
-
-    base = _build_processor(64)
-    base.head_dtype = torch.float32
-
-    with pytest.raises(ValueError, match="not yet supported with LoRA"):
-        LogitsProcessorWithLoRA(
-            base,
-            hidden_size=16,
-            dtype=torch.bfloat16,
-            device=torch.device("cpu"),
-            sharded_to_full_mapping=None,
-        )
-
-
 @pytest.mark.core_model
 def test_fp32_head_e2e_no_nan():
     """An fp32 head produces finite logprobs end-to-end.

--- a/vllm/lora/layers/logits_processor.py
+++ b/vllm/lora/layers/logits_processor.py
@@ -45,15 +45,6 @@ class LogitsProcessorWithLoRA(BaseLayerWithLoRA):
         self.hidden_size = hidden_size
         self.dtype = dtype
         self.device = device
-        # The fp32 lm_head path lives in the base LogitsProcessor._get_logits,
-        # which this wrapper bypasses. Rather than silently emit model-dtype
-        # logits, reject the combination until the LoRA path supports it.
-        head_dtype = getattr(base_layer, "head_dtype", None)
-        if head_dtype is not None and head_dtype != dtype:
-            raise ValueError(
-                "A head_dtype different from the model dtype (e.g. an fp32 "
-                "lm_head) is not yet supported with LoRA."
-            )
         self.tp_size = get_tensor_model_parallel_world_size()
         self.tp_rank = get_tensor_model_parallel_rank()
         self.sharded_to_full_mapping = sharded_to_full_mapping
@@ -158,9 +149,13 @@ class LogitsProcessorWithLoRA(BaseLayerWithLoRA):
             actual_lm_head = lm_head.base_layer
         else:
             actual_lm_head = lm_head
-        logits = actual_lm_head.quant_method.apply(actual_lm_head, hidden_states)
-        if embedding_bias is not None:
-            logits += embedding_bias
+        # Run the base projection through the LogitsProcessor so head_dtype
+        # (e.g. an fp32 lm_head) is honored on the LoRA path too. The LoRA
+        # delta is accumulated into these logits by add_lora_logits below,
+        # whose internal buffer is already fp32.
+        logits = self.base_layer._apply_head(
+            actual_lm_head, hidden_states, embedding_bias
+        )
 
         # Gather logits for TP
         logits = self.base_layer._gather_logits(logits)


### PR DESCRIPTION
## Purpose

Follow-up to #48390 (fp32 lm_head via `head_dtype`), requested by @aoshen02.
That PR **rejected** `head_dtype != model dtype` when `--enable-lora` was set,
because `LogitsProcessorWithLoRA._get_logits` computes the base projection
itself and bypassed the head_dtype-aware path in `LogitsProcessor`. This PR
makes the two work together, which RL + LoRA workflows need
([RFC #48297](https://github.com/vllm-project/vllm/issues/48297),
[RFC #48305](https://github.com/vllm-project/vllm/issues/48305) §3.6).

## Change

- `LogitsProcessorWithLoRA._get_logits` now runs the base projection through
  `LogitsProcessor._apply_head`, so an fp32 lm_head is honored on the LoRA path.
- Remove the reject guard added in #48390.

No kernel change is needed: `add_lora_logits` already builds its internal
`buffer` in fp32, and `lora_expand` already handles fp32 accumulation for
fp16/bf16 LoRA weights (`CAST_TYPE`), so the fp32 base logits `y` are accepted
and the LoRA delta is accumulated in fp32.

## Test

- `tests/lora/test_layers.py::test_lm_head_logits_processor` parametrized over
  `head_dtype ∈ {None, float32}` — the fp32-head LoRA path matches the fp32
  reference (18 passed).
- Removed the now-obsolete `test_fp32_head_rejected_with_lora`.
- Manual e2e: opt-125m + a LoRA adapter + `hf_overrides={"head_dtype":"float32"}`
  + `processed_logprobs`: finite logprobs, no NaN; bf16 and fp32 heads both clean.

## Notes

- Scope is the standard LoRA logits path. Quantized lm_head + fp32 head remains
  unsupported (unchanged).
- AI assistance (Claude Code) was used; I reviewed every line.
