### PR TITLE
[Bugfix] GLM 5.2: Fix skip_topk on the fused DSA path (MTP index share)

### DIFF
--- a/vllm/models/deepseek_v32/nvidia/attention.py
+++ b/vllm/models/deepseek_v32/nvidia/attention.py
@@ -398,7 +398,10 @@ class DeepseekV32Attention(MLAAttention):
         assert isinstance(slot_mapping, dict)
         mla_slot = slot_mapping.get(self.layer_name)
 
-        if self.indexer is not None:
+        # index_k is None when skip_topk (MTP draft steps 1+ under
+        # index_share_for_mtp_iteration): treat this forward as a shared
+        # layer so the step-0 top-k is reused instead of cleared/recomputed.
+        if self.indexer is not None and index_k is not None:
             has_indexer = True
             indexer_k_norm_w = self.indexer.k_norm.weight
             indexer_k_norm_bias = self.indexer.k_norm.bias
@@ -456,7 +459,7 @@ class DeepseekV32Attention(MLAAttention):
         q_nope = q_nope.transpose(0, 1)
         ql_nope = torch.bmm(q_nope, self.W_UK_T).transpose(0, 1)
 
-        if self.indexer is not None:
+        if self.indexer is not None and has_indexer:
             index_q = self.indexer.wq_b(q_c)[0]
             index_q = index_q.view(-1, self.indexer.n_head, self.indexer.head_dim)
         else:
@@ -478,7 +481,7 @@ class DeepseekV32Attention(MLAAttention):
             quantize_mqa=self._fp8_query,
         )
 
-        if self.indexer is not None:
+        if self.indexer is not None and has_indexer:
             sparse_attn_indexer(
                 q_c,
                 self.indexer.k_cache.prefix,


### PR DESCRIPTION
## Purpose
Bug in new optional GLM model definiton.

Fix a crash (and, latently, wrong semantics) in the fused DSA path
(`vllm/models/deepseek_v32/nvidia/attention.py`) when
`index_share_for_mtp_iteration` is active.

With index share, the proposer toggles `skip_topk=True` for MTP draft steps 1+
(#44420, #45895). `forward()` then correctly passes `index_k=None` /
`index_weights=None`, but `_fused_attention` derived `has_indexer` from
`self.indexer is not None` alone — which is always true on MTP layers — so:

- `fused_norm_rope` immediately fails its `assert index_k is not None`
  (kernels.py:412), crashing the first multi-step proposal; and
- even absent the assert, the unconditional `sparse_attn_indexer` call would
  clear and recompute the shared top-k buffer every draft step, defeating
  index share.

The fix keys `has_indexer` on `index_k is not None` (and gates the `index_q`
GEMM and `sparse_attn_indexer` call on it), routing draft steps into the
kernels' existing `HAS_INDEXER=False` "shared layer" branch: no indexer K/Q
processing, no top-k recompute, and no buffer clear — the sparse attention
reuses the compacted step-0 indices. This matches the reference path, which
skips the indexer under the same flag (`mla.py`:
`if self.indexer and self.is_sparse and not self.skip_topk`).

Reachability: the fused path is opt-in via `model_class_overrides`, and
`index_share_for_mtp_iteration` is currently set only by GLM-5.2 configs
(DeepSeek-V3.2 does not set it)

---

AI assistance was used for this change (analysis, patch, and tests); the
change has been human-reviewed line by line.
