### PR TITLE
[Bugfix] Fix offloading set_ overflow for packed non-uniform KV caches

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
@@ -92,16 +92,17 @@ class OffloadingConnectorWorker:
                         if layer_is_packed[layer_name]
                         else page
                     )
+                    raw = torch.empty(
+                        0,
+                        dtype=torch.int8,
+                        device=layer_kv_cache.device,
+                    ).set_(layer_kv_cache.untyped_storage())
                     tensors_per_block[layer_name] = (
-                        torch.tensor(
-                            [],
-                            dtype=torch.int8,
-                            device=layer_kv_cache.device,
-                        ).set_(
-                            layer_kv_cache.untyped_storage(),
-                            byte_offset,
+                        torch.as_strided(
+                            raw,
                             (num_blocks, page),
                             (block_stride_bytes, 1),
+                            byte_offset,
                         ),
                     )
                     page_size_bytes[layer_name] = layer_kv_cache_spec.page_size_bytes


### PR DESCRIPTION
## Summary
- When attention layers are packed into a shared KV cache tensor (e.g. MLA models with non-uniform page sizes), each layer's `page_size` can be smaller than the `block_stride`. `torch.Tensor.set_(storage, offset, size, stride)` validates that `offset + size_bytes <= storage_size`, but for packed layouts the last block's `offset + page` extends past the per-layer boundary into the next layer's region — valid memory but fails `set_`'s bounds check.
- Replace `set_()` with `torch.as_strided()` on a raw storage-backed tensor, which allows creating a view with non-contiguous strides without the restrictive bounds check.
- The resulting tensor has identical shape, strides, and `storage_offset` as the intended `set_()` result.

## Test plan
- [x] Verified on GLM-5.2-FP8 (MLA + packed KV cache + KV offloading) in production — the `set_()` crash is eliminated
- [ ] CI passes