### PR TITLE
[Bugfix] Stop baking NVFP4 weight_scale_2 into b12x MoE block scales

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -65,6 +65,8 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         # a synthesized uniform-1.0 tensor for W4A16 checkpoints that lack
         # one. Holding it on the instance keeps apply() alloc-free.
         self._fc2_input_scale: torch.Tensor | None = None
+        # FC1 input-quant global scale, bound in process_weights_after_loading.
+        self._fc1_input_gs: torch.Tensor | None = None
 
         # Shape params for B12xMoEWrapper construction.
         self.global_num_experts = moe_config.num_experts
@@ -91,26 +93,15 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         self.w2_sf_mma: torch.Tensor | None = None
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        # Normalise block scales to absorb the per-expert weight global scale
-        # (w_gs).  vLLM's NVFP4 convention stores:
-        #   block_scale = max_abs * w_gs / fp4_max,  g1_alphas = 1/w_gs
-        # The SM12x kernel treats w1_alpha (= g1_alphas) as a per-expert weight
-        # dequant multiplier separate from input_gs (activation scale).  We bake
-        # w_gs into the block scales so that w1_alpha = 1.0 and the kernel sees
-        # the simpler form:
-        #   block_scale = max_abs / fp4_max,  w1_alpha = 1.0
-        # The FP4-packed values and dequantised results are identical in both
-        # representations.  We set scale_2 = 1.0 to signal that the bake-in is
-        # already done.
-        layer.w13_weight_scale.data = (
-            layer.w13_weight_scale.float() * layer.w13_weight_scale_2.view(-1, 1, 1)
-        ).to(layer.w13_weight_scale.dtype)
-        layer.w13_weight_scale_2.data.fill_(1.0)
-
-        layer.w2_weight_scale.data = (
-            layer.w2_weight_scale.float() * layer.w2_weight_scale_2.view(-1, 1, 1)
-        ).to(layer.w2_weight_scale.dtype)
-        layer.w2_weight_scale_2.data.fill_(1.0)
+        # Pass scale_2 (via g1/g2_alphas) to the kernel in full precision
+        # instead of baking it into the e4m3 block scales, which distorts the
+        # dequantized weights. input_global_scale=1.0 keeps FC1 activation
+        # quantization unchanged.
+        self._fc1_input_gs = torch.ones(
+            self.num_local_experts,
+            device=layer.w13_weight.device,
+            dtype=torch.float32,
+        )
 
         # The SM12x kernel uses dynamic per-block quantization for FC2 input
         # activations (the SwiGLU output before the down projection).  The
@@ -285,6 +276,7 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             w1_weight=w1,
             w1_weight_sf=self.w1_sf_mma,
             w1_alpha=self.g1_alphas,
+            input_global_scale=self._fc1_input_gs,
             fc2_input_scale=self._fc2_input_scale,
             w2_weight=w2,
             w2_weight_sf=self.w2_sf_mma,

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -66,6 +66,8 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         # a synthesized uniform-1.0 tensor for W4A16 checkpoints that lack
         # one. Holding it on the instance keeps apply() alloc-free.
         self._fc2_input_scale: torch.Tensor | None = None
+        # FC1 input-quant global scale, bound in process_weights_after_loading.
+        self._fc1_input_gs: torch.Tensor | None = None
 
         # Shape params for B12xMoEWrapper construction.
         self.global_num_experts = moe_config.num_experts
@@ -92,26 +94,15 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         self.w2_sf_mma: torch.Tensor | None = None
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        # Normalise block scales to absorb the per-expert weight global scale
-        # (w_gs).  vLLM's NVFP4 convention stores:
-        #   block_scale = max_abs * w_gs / fp4_max,  g1_alphas = 1/w_gs
-        # The SM12x kernel treats w1_alpha (= g1_alphas) as a per-expert weight
-        # dequant multiplier separate from input_gs (activation scale).  We bake
-        # w_gs into the block scales so that w1_alpha = 1.0 and the kernel sees
-        # the simpler form:
-        #   block_scale = max_abs / fp4_max,  w1_alpha = 1.0
-        # The FP4-packed values and dequantised results are identical in both
-        # representations.  We set scale_2 = 1.0 to signal that the bake-in is
-        # already done.
-        layer.w13_weight_scale.data = (
-            layer.w13_weight_scale.float() * layer.w13_weight_scale_2.view(-1, 1, 1)
-        ).to(layer.w13_weight_scale.dtype)
-        layer.w13_weight_scale_2.data.fill_(1.0)
-
-        layer.w2_weight_scale.data = (
-            layer.w2_weight_scale.float() * layer.w2_weight_scale_2.view(-1, 1, 1)
-        ).to(layer.w2_weight_scale.dtype)
-        layer.w2_weight_scale_2.data.fill_(1.0)
+        # Pass scale_2 (via g1/g2_alphas) to the kernel in full precision
+        # instead of baking it into the e4m3 block scales, which distorts the
+        # dequantized weights. input_global_scale=1.0 keeps FC1 activation
+        # quantization unchanged.
+        self._fc1_input_gs = torch.ones(
+            self.num_local_experts,
+            device=layer.w13_weight.device,
+            dtype=torch.float32,
+        )
 
         # The SM12x kernel uses dynamic per-block quantization for FC2 input
         # activations (the SwiGLU output before the down projection).  The
@@ -290,6 +281,7 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             w1_weight=w1,
             w1_weight_sf=self.w1_sf_mma,
             w1_alpha=self.g1_alphas,
+            input_global_scale=self._fc1_input_gs,
             fc2_input_scale=self._fc2_input_scale,
             w2_weight=w2,
             w2_weight_sf=self.w2_sf_mma,


### PR DESCRIPTION
## Purpose

The SM12x b12x MoE path (RTX Pro 6000 / DGX Spark) distorts NVFP4 weights at load time:

- The FlashInfer kernel's `w1_alpha` does two jobs: FC1 activation-quant global scale and post-GEMM multiplier. The checkpoint's per-expert weight scale (`weight_scale_2`, ~2e-5) would wreck activation quantization if passed as `w1_alpha`, so the b12x experts class bakes it into the e4m3 weight block scales instead.
- The bake pushes nearly all block-scale bytes into the 3-bit e4m3 subnormal range and noticeably perturbs the dequantized weights. Marlin applies the same scale in full precision and is unaffected.

FlashInfer added a separate `input_global_scale` argument for the activation-quant job (flashinfer-ai/flashinfer#3932, shipped in v0.6.17). With it, this PR:

- Skips the bake and keeps the checkpoint's block scales as loaded. `weight_scale_2` reaches the kernel as an exact fp32 multiplier; no extra wiring is needed because `g1_alphas`/`g2_alphas` already alias the scale_2 parameters.
- Passes `input_global_scale=1.0` so FC1 activation quantization behaves exactly as before.

Depends on flashinfer-ai/flashinfer#3932, which shipped in FlashInfer v0.6.17 — the version vLLM pins on main since #52681. The kernel call passes `input_global_scale` unconditionally; a FlashInfer build without it rejects the argument loudly at call time rather than producing wrong results.

## Test Plan

- End-to-end accuracy and token-efficiency evals on GB10 (SM121) with an NVFP4 MoE checkpoint, against the Marlin backend as baseline, identical serving settings across configs.
- Weight-parity check on captured kernel inputs: the kernel receives the checkpoint's pristine block scales and exact per-expert alphas (verified via FlashInfer tensor dumps).

## Test Result

With this patch plus the FlashInfer-side kernel fixes in flashinfer-ai/flashinfer#3932, the b12x W4A4 excess token usage vs Marlin drops substantially and accuracy stays on par. The weight-parity check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
