### PR TITLE
[Quant] Add `nvfp4_per_token` online MoE quantization

### DIFF
--- a/tests/quantization/test_online.py
+++ b/tests/quantization/test_online.py
@@ -16,7 +16,11 @@ from vllm.model_executor.layers.quantization.online.fp8 import (
     Fp8PerTensorOnlineLinearMethod,
     Fp8PerTensorOnlineMoEMethod,
 )
+from vllm.model_executor.layers.quantization.online.nvfp4 import (
+    Nvfp4OnlineMoEMethod,
+)
 from vllm.platforms import current_platform
+from vllm.utils.flashinfer import has_flashinfer_trtllm_fused_moe
 
 
 @pytest.mark.skipif(
@@ -141,6 +145,38 @@ def test_online_quantization(
 
         llm.apply_model(check_model)
 
+        outputs = llm.generate_greedy(["Hello my name is"], max_tokens=4)
+        print(outputs[0][1])
+
+
+@pytest.mark.skipif(
+    not (
+        current_platform.is_cuda()
+        and current_platform.is_device_capability_family(100)
+        and has_flashinfer_trtllm_fused_moe()
+    ),
+    reason="nvfp4_per_token needs a Blackwell (SM100) GPU + FlashInfer TRTLLM MoE.",
+)
+def test_online_nvfp4_per_token_moe(vllm_runner, monkeypatch) -> None:
+    """Online NVFP4 quantizes the MoE and leaves dense layers unquantized."""
+    monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+
+    with vllm_runner(
+        "ibm-granite/granite-3.0-1b-a400m-base",
+        quantization="nvfp4_per_token",
+        enforce_eager=True,
+    ) as llm:
+
+        def check_model(model):
+            layer = model.model.layers[0]
+            assert isinstance(
+                layer.block_sparse_moe.experts._quant_method, Nvfp4OnlineMoEMethod
+            )
+            assert isinstance(
+                layer.self_attn.o_proj.quant_method, UnquantizedLinearMethod
+            )
+
+        llm.apply_model(check_model)
         outputs = llm.generate_greedy(["Hello my name is"], max_tokens=4)
         print(outputs[0][1])
 

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -18,6 +18,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kInt8StaticChannelSym,
     kMxfp4Dynamic,
     kMxfp8Dynamic,
+    kNvfp4Static,
 )
 
 # User-facing names addressable from quantization_config.
@@ -133,6 +134,11 @@ _ONLINE_SHORTHANDS: dict[str, QuantizationConfigArgs] = {
     # INT8 weight-only on MoE; linear stays unquantized (no `linear` field).
     "int8_per_channel_weight_only": QuantizationConfigArgs(
         moe=QuantSpec(weight=kInt8StaticChannelSym),
+    ),
+    # Online NVFP4 on MoE with per-token dynamic activation scales (Blackwell +
+    # FlashInfer TRTLLM only); linear stays unquantized (no `linear` field).
+    "nvfp4_per_token": QuantizationConfigArgs(
+        moe=QuantSpec(weight=kNvfp4Static),
     ),
 }
 

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -261,6 +261,10 @@ class FusedMoEQuantConfig:
 
     mx_alignment: int = 0
 
+    # NVFP4: quantize activations with a per-token (not static per-tensor)
+    # global scale at runtime, via the FlashInfer TRTLLM per_token_scale input.
+    nvfp4_per_token_activation: bool = False
+
     def __post_init__(self):
         assert not self.per_act_token_quant or self.block_shape is None, (
             "illegal quantization"
@@ -511,6 +515,7 @@ class FusedMoEQuantConfig:
         gemm1_alpha: float | None = None,
         gemm1_beta: float | None = None,
         gemm1_clamp_limit: float | None = None,
+        nvfp4_per_token_activation: bool = False,
     ) -> "FusedMoEQuantConfig":
         """
         General builder function for a FusedMoEQuantConfig.
@@ -582,6 +587,7 @@ class FusedMoEQuantConfig:
             gemm1_alpha=gemm1_alpha,
             gemm1_beta=gemm1_beta,
             gemm1_clamp_limit=gemm1_clamp_limit,
+            nvfp4_per_token_activation=nvfp4_per_token_activation,
         )
         assert quant_config.per_act_token_quant == per_act_token_quant
         assert quant_config.per_out_ch_quant == per_out_ch_quant
@@ -815,6 +821,7 @@ def nvfp4_moe_quant_config(
     w2_bias: torch.Tensor | None = None,
     is_scale_swizzled: bool = True,
     gemm1_clamp_limit: float | None = None,
+    nvfp4_per_token_activation: bool = False,
 ) -> FusedMoEQuantConfig:
     """
     Construct a quant config for mxfp4 activations and nvp4 weights.
@@ -834,6 +841,7 @@ def nvfp4_moe_quant_config(
         block_shape=None,
         is_scale_swizzled=is_scale_swizzled,
         gemm1_clamp_limit=gemm1_clamp_limit,
+        nvfp4_per_token_activation=nvfp4_per_token_activation,
     )
 
 

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -261,10 +261,6 @@ class FusedMoEQuantConfig:
 
     mx_alignment: int = 0
 
-    # NVFP4: quantize activations with a per-token (not static per-tensor)
-    # global scale at runtime, via the FlashInfer TRTLLM per_token_scale input.
-    nvfp4_per_token_activation: bool = False
-
     def __post_init__(self):
         assert not self.per_act_token_quant or self.block_shape is None, (
             "illegal quantization"
@@ -515,7 +511,6 @@ class FusedMoEQuantConfig:
         gemm1_alpha: float | None = None,
         gemm1_beta: float | None = None,
         gemm1_clamp_limit: float | None = None,
-        nvfp4_per_token_activation: bool = False,
     ) -> "FusedMoEQuantConfig":
         """
         General builder function for a FusedMoEQuantConfig.
@@ -587,7 +582,6 @@ class FusedMoEQuantConfig:
             gemm1_alpha=gemm1_alpha,
             gemm1_beta=gemm1_beta,
             gemm1_clamp_limit=gemm1_clamp_limit,
-            nvfp4_per_token_activation=nvfp4_per_token_activation,
         )
         assert quant_config.per_act_token_quant == per_act_token_quant
         assert quant_config.per_out_ch_quant == per_out_ch_quant
@@ -821,7 +815,6 @@ def nvfp4_moe_quant_config(
     w2_bias: torch.Tensor | None = None,
     is_scale_swizzled: bool = True,
     gemm1_clamp_limit: float | None = None,
-    nvfp4_per_token_activation: bool = False,
 ) -> FusedMoEQuantConfig:
     """
     Construct a quant config for mxfp4 activations and nvp4 weights.
@@ -841,7 +834,6 @@ def nvfp4_moe_quant_config(
         block_shape=None,
         is_scale_swizzled=is_scale_swizzled,
         gemm1_clamp_limit=gemm1_clamp_limit,
-        nvfp4_per_token_activation=nvfp4_per_token_activation,
     )
 
 

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
@@ -33,6 +33,10 @@ from vllm.utils.flashinfer import has_flashinfer_trtllm_fused_moe
 
 logger = init_logger(__name__)
 
+# Base multiplier for per-token NVFP4 activation quant; the kernel derives the
+# per-token global scale from the activation amax on top of it.
+_PER_TOKEN_BASE_GLOBAL_SCALE = 1.0 / (448.0 * 6.0)
+
 
 class TrtLlmNvFp4ExpertsBase:
     """
@@ -46,6 +50,9 @@ class TrtLlmNvFp4ExpertsBase:
     ):
         self.moe_config = moe_config
         self.quant_config = quant_config
+        # Per-token activation: quantize the input here (deferred from prepare)
+        # to capture a per-token global scale, instead of a static one.
+        self.per_token_activation = quant_config.nvfp4_per_token_activation
 
         self.routing_method_type = self.moe_config.routing_method
         self.topk = moe_config.experts_per_token
@@ -211,6 +218,27 @@ class TrtLlmNvFp4ExpertsBase:
     def activation_format() -> mk.FusedMoEActivationFormat:
         return mk.FusedMoEActivationFormat.Standard
 
+    @property
+    def expects_unquantized_inputs(self) -> bool:
+        return self.per_token_activation
+
+    def _quantize_per_token_input(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """NVFP4-quantize activations with a per-token global scale.
+
+        Returns ``(packed_fp4, block_scale, per_token_scale)``.
+        """
+        from flashinfer import SfLayout, nvfp4_quantize
+
+        hs_fp4, hs_block_scale, per_token_scale = nvfp4_quantize(
+            hidden_states,
+            _PER_TOKEN_BASE_GLOBAL_SCALE,
+            sfLayout=SfLayout.layout_linear,
+            per_token_activation=True,
+        )
+        return hs_fp4, hs_block_scale, per_token_scale
+
     def _get_chunk_size(self) -> int:
         MAX_GRID_Y = 65535
         MAX_TILE_TOKENS_DIM = 128
@@ -255,6 +283,15 @@ class TrtLlmNvFp4ExpertsModular(TrtLlmNvFp4ExpertsBase, mk.FusedMoEExpertsModula
         expert_tokens_meta: mk.ExpertTokensMetadata | None,
         activation: MoEActivation,
     ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        if self.per_token_activation:
+            # Deferred input quant leaves K unpacked here, breaking the
+            # workspace assumptions below. Per-token NVFP4 is only supported on
+            # the monolithic (non-EP) path for now.
+            raise NotImplementedError(
+                "NVFP4 per-token activation is only supported on the monolithic "
+                "(non-EP) FlashInfer TRTLLM MoE path."
+            )
+
         # The workspaces for this implementation are managed by flashinfer.
         workspace1 = (0,)
         workspace2 = (0,)
@@ -286,6 +323,15 @@ class TrtLlmNvFp4ExpertsModular(TrtLlmNvFp4ExpertsBase, mk.FusedMoEExpertsModula
         assert self.quant_config.w1_scale is not None
         assert self.quant_config.w2_scale is not None
 
+        # Per-token: input is unquantized, quantize it here. Otherwise it was
+        # already quantized in prepare() with the static global scale.
+        if self.per_token_activation:
+            hidden_states, block_scale, per_token_scale = (
+                self._quantize_per_token_input(hidden_states)
+            )
+        else:
+            block_scale, per_token_scale = a1q_scale, None
+
         # Pack topk ids and weights into format expected by the kernel.
         packed_tensor = trtllm_moe_pack_topk_ids_weights(topk_ids, topk_weights)
         output1_scale_gate_scalar = self.quant_config.g1_alphas
@@ -295,7 +341,7 @@ class TrtLlmNvFp4ExpertsModular(TrtLlmNvFp4ExpertsBase, mk.FusedMoEExpertsModula
             topk_ids=packed_tensor,
             routing_bias=None,
             hidden_states=hidden_states,
-            hidden_states_scale=a1q_scale.view(torch.float8_e4m3fn).reshape(
+            hidden_states_scale=block_scale.view(torch.float8_e4m3fn).reshape(
                 *hidden_states.shape[:-1], -1
             ),
             gemm1_weights=w1,
@@ -321,6 +367,7 @@ class TrtLlmNvFp4ExpertsModular(TrtLlmNvFp4ExpertsBase, mk.FusedMoEExpertsModula
             routing_method_type=1,  # not used
             do_finalize=True,
             activation_type=activation_to_flashinfer_int(activation),
+            per_token_scale=per_token_scale,
             output=output,
             tune_max_num_tokens=min(
                 fi_moe_largest_bucket(self.moe_config), self._get_chunk_size()
@@ -346,7 +393,8 @@ class TrtLlmNvFp4ExpertsModular(TrtLlmNvFp4ExpertsBase, mk.FusedMoEExpertsModula
         apply_router_weight_on_input: bool,
     ):
         assert self._supports_activation(activation)
-        assert a1q_scale is not None
+        # Per-token defers input quant to _invoke_kernel, so a1q_scale is None.
+        assert a1q_scale is not None or self.per_token_activation
 
         M = hidden_states.shape[0]
         chunk_size = self._get_chunk_size()
@@ -375,7 +423,7 @@ class TrtLlmNvFp4ExpertsModular(TrtLlmNvFp4ExpertsBase, mk.FusedMoEExpertsModula
                     topk_ids[start:end],
                     activation,
                     global_num_experts,
-                    a1q_scale[start:end],
+                    None if a1q_scale is None else a1q_scale[start:end],
                 )
 
 
@@ -439,7 +487,7 @@ class TrtLlmNvFp4ExpertsMonolithic(
         import flashinfer
 
         assert self._supports_activation(activation)
-        assert a1q_scale is not None
+        assert a1q_scale is not None or self.per_token_activation
         assert self.quant_config.w1_scale is not None
         assert self.quant_config.w2_scale is not None
         assert (
@@ -450,6 +498,14 @@ class TrtLlmNvFp4ExpertsMonolithic(
             and self.routing_method_type != RoutingMethodType.Llama4
         )
 
+        # Per-token: input is unquantized, quantize it here (see modular apply).
+        if self.per_token_activation:
+            hidden_states, block_scale, per_token_scale = (
+                self._quantize_per_token_input(hidden_states)
+            )
+        else:
+            block_scale, per_token_scale = a1q_scale, None
+
         output1_scale_gate_scalar = self.quant_config.g1_alphas
 
         # Invoke kernel.
@@ -459,7 +515,7 @@ class TrtLlmNvFp4ExpertsMonolithic(
             routing_logits=router_logits,
             routing_bias=e_score_correction_bias,
             hidden_states=hidden_states,
-            hidden_states_scale=a1q_scale.view(torch.float8_e4m3fn).reshape(
+            hidden_states_scale=block_scale.view(torch.float8_e4m3fn).reshape(
                 *hidden_states.shape[:-1], -1
             ),
             gemm1_weights=w1,
@@ -485,5 +541,6 @@ class TrtLlmNvFp4ExpertsMonolithic(
             routing_method_type=self.routing_method_type,
             do_finalize=True,
             activation_type=activation_to_flashinfer_int(activation),
+            per_token_scale=per_token_scale,
             tune_max_num_tokens=fi_moe_largest_bucket(self.moe_config),
         )[0]

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
@@ -33,8 +33,8 @@ from vllm.utils.flashinfer import has_flashinfer_trtllm_fused_moe
 
 logger = init_logger(__name__)
 
-# Base multiplier for per-token NVFP4 activation quant; the kernel derives the
-# per-token global scale from the activation amax on top of it.
+# Base scale for per-token NVFP4 activation quant; the kernel folds the
+# per-token global scale (from the activation amax) on top of it.
 _PER_TOKEN_BASE_GLOBAL_SCALE = 1.0 / (448.0 * 6.0)
 
 
@@ -47,12 +47,13 @@ class TrtLlmNvFp4ExpertsBase:
         self,
         moe_config: FusedMoEConfig,
         quant_config: FusedMoEQuantConfig,
+        per_token_activation: bool = False,
     ):
         self.moe_config = moe_config
         self.quant_config = quant_config
-        # Per-token activation: quantize the input here (deferred from prepare)
-        # to capture a per-token global scale, instead of a static one.
-        self.per_token_activation = quant_config.nvfp4_per_token_activation
+        # Quantize the input here (deferred from prepare) to capture a per-token
+        # global scale, instead of a static one.
+        self.per_token_activation = per_token_activation
 
         self.routing_method_type = self.moe_config.routing_method
         self.topk = moe_config.experts_per_token

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -469,7 +469,6 @@ def make_nvfp4_moe_quant_config(
     a2_scale: torch.Tensor,
     swiglu_limit: float | None = None,
     layer: torch.nn.Module | None = None,
-    per_token_activation: bool = False,
 ) -> FusedMoEQuantConfig:
     if backend == NvFp4MoeBackend.HUMMING:
         from vllm.model_executor.layers.fused_moe import RoutedExperts
@@ -520,7 +519,6 @@ def make_nvfp4_moe_quant_config(
             )
         ),
         gemm1_clamp_limit=swiglu_limit,
-        nvfp4_per_token_activation=per_token_activation,
     )
 
 
@@ -531,6 +529,7 @@ def make_nvfp4_moe_kernel(
     backend: NvFp4MoeBackend,
     routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
     layer: torch.nn.Module | None = None,
+    per_token_activation: bool = False,
 ) -> mk.FusedMoEKernel:
     # Create Prepare/Finalize.
     prepare_finalize = maybe_make_prepare_finalize(
@@ -548,6 +547,8 @@ def make_nvfp4_moe_kernel(
     if backend == NvFp4MoeBackend.HUMMING:
         assert layer is not None
         extra_kwargs = {"layer": layer}
+    if backend == NvFp4MoeBackend.FLASHINFER_TRTLLM and per_token_activation:
+        extra_kwargs["per_token_activation"] = True
 
     # Create Experts.
     if prepare_finalize.activation_format == mk.FusedMoEActivationFormat.BatchedExperts:

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -469,6 +469,7 @@ def make_nvfp4_moe_quant_config(
     a2_scale: torch.Tensor,
     swiglu_limit: float | None = None,
     layer: torch.nn.Module | None = None,
+    per_token_activation: bool = False,
 ) -> FusedMoEQuantConfig:
     if backend == NvFp4MoeBackend.HUMMING:
         from vllm.model_executor.layers.fused_moe import RoutedExperts
@@ -519,6 +520,7 @@ def make_nvfp4_moe_quant_config(
             )
         ),
         gemm1_clamp_limit=swiglu_limit,
+        nvfp4_per_token_activation=per_token_activation,
     )
 
 

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -42,6 +42,7 @@ QuantizationMethods = Literal[
     "fp8_per_block",
     "fp8_per_channel",
     "int8_per_channel_weight_only",
+    "nvfp4_per_token",
     "mxfp8",
 ]
 QUANTIZATION_METHODS: list[str] = list(get_args(QuantizationMethods))

--- a/vllm/model_executor/layers/quantization/online/base.py
+++ b/vllm/model_executor/layers/quantization/online/base.py
@@ -40,6 +40,9 @@ from vllm.model_executor.layers.quantization.online.mxfp8 import (
     Mxfp8OnlineLinearMethod,
     Mxfp8OnlineMoEMethod,
 )
+from vllm.model_executor.layers.quantization.online.nvfp4 import (
+    Nvfp4OnlineMoEMethod,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kFp8Static128BlockSym,
@@ -47,6 +50,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
     kInt8StaticChannelSym,
     kMxfp8Dynamic,
+    kNvfp4Static,
 )
 
 logger = init_logger(__name__)
@@ -68,6 +72,7 @@ _ONLINE_MOE_METHODS: dict[QuantKey, type] = {
     kFp8StaticChannelSym: Fp8PtpcOnlineMoEMethod,
     kMxfp8Dynamic: Mxfp8OnlineMoEMethod,
     kInt8StaticChannelSym: Int8OnlineMoEMethod,
+    kNvfp4Static: Nvfp4OnlineMoEMethod,
 }
 
 

--- a/vllm/model_executor/layers/quantization/online/nvfp4.py
+++ b/vllm/model_executor/layers/quantization/online/nvfp4.py
@@ -152,6 +152,7 @@ class Nvfp4OnlineMoEMethod(OnlineMoEMethodBase):
             backend=self.nvfp4_backend,
             routing_tables=layer._expert_routing_tables(),
             layer=layer,
+            per_token_activation=True,
         )
         self.moe_kernel.fused_experts.process_weights_after_loading(layer)
 
@@ -166,5 +167,4 @@ class Nvfp4OnlineMoEMethod(OnlineMoEMethodBase):
             a2_scale=layer.w2_input_scale,
             swiglu_limit=getattr(layer, "swiglu_limit", None),
             layer=layer,
-            per_token_activation=True,
         )

--- a/vllm/model_executor/layers/quantization/online/nvfp4.py
+++ b/vllm/model_executor/layers/quantization/online/nvfp4.py
@@ -40,24 +40,25 @@ def _quantize_moe_weight_to_nvfp4(
     global scale ``(E,)`` stored as ``amax / (fp4_max * fp8_max)``.
     """
     assert weight.dim() == 3, f"expected 3D expert weights, got {weight.shape}"
-    num_experts, _, k = weight.shape
+    num_experts, n, k = weight.shape
     assert k % 16 == 0, f"last dim must be a multiple of 16, got {k}"
 
     amax = weight.abs().amax(dim=(1, 2)).to(torch.float32).clamp_min(1e-8)
     global_scale = (FLOAT4_E2M1_MAX * FLOAT8_E4M3_MAX) / amax
     weight_scale_2 = (1.0 / global_scale).to(torch.float32)
 
-    qweights, block_scales = [], []
-    for expert in range(num_experts):
-        q, block_scale = scaled_fp4_quant(
-            weight[expert].contiguous(),
-            global_scale[expert],
-            is_sf_swizzled_layout=False,
-        )
-        qweights.append(q)
-        block_scales.append(block_scale)
-
-    return torch.stack(qweights), torch.stack(block_scales), weight_scale_2
+    # scaled_fp4_quant(w, g) == scaled_fp4_quant(w * g, 1), so fold each
+    # expert's scale in and quantize all experts in one call (fp32 to keep the
+    # large scale precise), rather than looping per expert.
+    scaled = (weight.float() * global_scale[:, None, None]).to(weight.dtype)
+    scaled = scaled.reshape(-1, k)
+    one = torch.ones((), device=weight.device, dtype=torch.float32)
+    qweight, block_scale = scaled_fp4_quant(scaled, one, is_sf_swizzled_layout=False)
+    return (
+        qweight.reshape(num_experts, n, k // 2),
+        block_scale.reshape(num_experts, n, k // 16),
+        weight_scale_2,
+    )
 
 
 class Nvfp4OnlineMoEMethod(OnlineMoEMethodBase):

--- a/vllm/model_executor/layers/quantization/online/nvfp4.py
+++ b/vllm/model_executor/layers/quantization/online/nvfp4.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+from torch.nn import Module
+
+from vllm._custom_ops import scaled_fp4_quant
+from vllm.model_executor.layers.fused_moe import RoutedExperts
+from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
+from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+    convert_to_nvfp4_moe_kernel_format,
+    make_nvfp4_moe_kernel,
+    make_nvfp4_moe_quant_config,
+    select_nvfp4_moe_backend,
+)
+from vllm.model_executor.layers.quantization.online.moe_base import (
+    OnlineMoEMethodBase,
+)
+from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import (
+    FLOAT4_E2M1_MAX,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kNvfp4Dynamic,
+    kNvfp4Static,
+)
+from vllm.model_executor.utils import replace_parameter
+from vllm.platforms import current_platform
+
+FLOAT8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
+
+
+def _quantize_moe_weight_to_nvfp4(
+    weight: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Quantize stacked MoE expert weights ``(E, N, K)`` to NVFP4.
+
+    One FP32 global scale per expert plus per-block (group-16) FP8 scales,
+    matching the ModelOpt NVFP4 checkpoint layout. Returns packed FP4 weights
+    ``(E, N, K // 2)``, block scales ``(E, N, K // 16)``, and the per-expert
+    global scale ``(E,)`` stored as ``amax / (fp4_max * fp8_max)``.
+    """
+    assert weight.dim() == 3, f"expected 3D expert weights, got {weight.shape}"
+    num_experts, _, k = weight.shape
+    assert k % 16 == 0, f"last dim must be a multiple of 16, got {k}"
+
+    amax = weight.abs().amax(dim=(1, 2)).to(torch.float32).clamp_min(1e-8)
+    global_scale = (FLOAT4_E2M1_MAX * FLOAT8_E4M3_MAX) / amax
+    weight_scale_2 = (1.0 / global_scale).to(torch.float32)
+
+    qweights, block_scales = [], []
+    for expert in range(num_experts):
+        q, block_scale = scaled_fp4_quant(
+            weight[expert].contiguous(),
+            global_scale[expert],
+            is_sf_swizzled_layout=False,
+        )
+        qweights.append(q)
+        block_scales.append(block_scale)
+
+    return torch.stack(qweights), torch.stack(block_scales), weight_scale_2
+
+
+class Nvfp4OnlineMoEMethod(OnlineMoEMethodBase):
+    """Online NVFP4 MoE quantization with per-token activation scales.
+
+    Quantizes fp16/bf16 expert weights to NVFP4 at load time; the FlashInfer
+    TRTLLM kernel computes per-token activation scales at runtime. Blackwell
+    (SM100) only.
+    """
+
+    def __init__(
+        self,
+        *,
+        layer: torch.nn.Module,
+    ):
+        if not current_platform.is_device_capability_family(100):
+            raise ValueError(
+                "nvfp4_per_token online quantization requires a Blackwell (SM100) GPU."
+            )
+        super().__init__(layer.moe_config)
+        self.nvfp4_backend, self.experts_cls = select_nvfp4_moe_backend(
+            config=self.moe,
+            weight_key=kNvfp4Static,
+            activation_key=kNvfp4Dynamic,
+        )
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        if getattr(layer, "_already_called_process_weights_after_loading", False):
+            return
+
+        self._quantize_weights(layer)
+        self._setup_kernel(layer)
+
+        layer._already_called_process_weights_after_loading = True
+
+    def _quantize_weights(self, layer: Module) -> None:
+        w13, w13_scale, w13_scale_2 = _quantize_moe_weight_to_nvfp4(layer.w13_weight)
+        w2, w2_scale, w2_scale_2 = _quantize_moe_weight_to_nvfp4(layer.w2_weight)
+
+        replace_parameter(layer, "w13_weight", w13)
+        replace_parameter(layer, "w13_weight_scale", w13_scale)
+        replace_parameter(layer, "w13_weight_scale_2", w13_scale_2)
+        replace_parameter(layer, "w2_weight", w2)
+        replace_parameter(layer, "w2_weight_scale", w2_scale)
+        replace_parameter(layer, "w2_weight_scale_2", w2_scale_2)
+
+        # Neutral (1.0) activation global scales: the kernel derives per-token
+        # scales at runtime, so the output scalars reduce to the weight scales.
+        ones = torch.ones(layer.num_experts, device=w13.device, dtype=torch.float32)
+        replace_parameter(layer, "w13_input_scale", ones)
+        replace_parameter(layer, "w2_input_scale", ones.clone())
+
+    def _setup_kernel(self, layer: RoutedExperts) -> None:
+        (
+            w13,
+            w13_scale,
+            w13_scale_2,
+            a13_scale,
+            w2,
+            w2_scale,
+            w2_scale_2,
+            a2_scale,
+        ) = convert_to_nvfp4_moe_kernel_format(
+            nvfp4_backend=self.nvfp4_backend,
+            layer=layer,
+            w13=layer.w13_weight,
+            w13_scale=layer.w13_weight_scale,
+            w13_scale_2=layer.w13_weight_scale_2,
+            a13_scale=layer.w13_input_scale,
+            w2=layer.w2_weight,
+            w2_scale=layer.w2_weight_scale,
+            w2_scale_2=layer.w2_weight_scale_2,
+            a2_scale=layer.w2_input_scale,
+            is_act_and_mul=self.moe.is_act_and_mul,
+        )
+
+        replace_parameter(layer, "w13_weight", w13)
+        replace_parameter(layer, "w13_weight_scale", w13_scale)
+        replace_parameter(layer, "w13_weight_scale_2", w13_scale_2)
+        replace_parameter(layer, "w13_input_scale", a13_scale)
+        replace_parameter(layer, "w2_weight", w2)
+        replace_parameter(layer, "w2_weight_scale", w2_scale)
+        replace_parameter(layer, "w2_weight_scale_2", w2_scale_2)
+        replace_parameter(layer, "w2_input_scale", a2_scale)
+
+        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+        assert self.experts_cls is not None
+        self.moe_kernel = make_nvfp4_moe_kernel(
+            moe_quant_config=self.moe_quant_config,
+            moe_config=self.moe,
+            experts_cls=self.experts_cls,
+            backend=self.nvfp4_backend,
+            routing_tables=layer._expert_routing_tables(),
+            layer=layer,
+        )
+        self.moe_kernel.fused_experts.process_weights_after_loading(layer)
+
+    def get_fused_moe_quant_config(self, layer: torch.nn.Module) -> FusedMoEQuantConfig:
+        return make_nvfp4_moe_quant_config(
+            backend=self.nvfp4_backend,
+            w13_scale=layer.w13_weight_scale,
+            w2_scale=layer.w2_weight_scale,
+            w13_scale_2=layer.w13_weight_scale_2,
+            w2_scale_2=layer.w2_weight_scale_2,
+            a13_scale=layer.w13_input_scale,
+            a2_scale=layer.w2_input_scale,
+            swiglu_limit=getattr(layer, "swiglu_limit", None),
+            layer=layer,
+            per_token_activation=True,
+        )


### PR DESCRIPTION
## Purpose

Adds a new online-quantization shorthand, `--quantization nvfp4_per_token`, that quantizes MoE expert weights to NVFP4 at load time from a bf16 checkpoint and runs them through the FlashInfer TRTLLM fused-MoE kernel with **dynamic per-token global activation scales**. Similar in spirit to https://github.com/sgl-project/sglang/pull/26083, but fits right in vLLM's existing online-quant framework, so it's just a new quant key + online MoE method plus wiring the kernel's `per_token_scale` input.

Blackwell (SM100f) + FlashInfer TRTLLM only; MoE-only (dense layers stay unquantized as we don't have a per-token NVFP4 kernel there yet)

### How it works
- New `nvfp4_per_token` shorthand → `Nvfp4OnlineMoEMethod` (weight key `kNvfp4Static`, activation `kNvfp4Dynamic`), reusing the existing NVFP4 MoE oracle/convert/kernel path.
- Weights: per-expert FP32 global scale + per-block FP8 scales (byte-identical to FlashInfer's reference quantizer).
- Activations: the TRTLLM experts defer input quant and call `nvfp4_quantize(..., per_token_activation=True)`, feeding the per-token scale into the kernel's `per_token_scale` arg (previously always `None` in vLLM).

### Testing (B200, GSM8K, 1319Q 5-shot)
| Model | bf16 | nvfp4_per_token |
|---|---|---|
| Qwen3-30B-A3B | 0.912 | **0.908** |

### Open Follow-ups
- Accuracy on hybrid/shared-expert models, consider easy utils for skipping shared-expert/known sensitive layers.
- EP/modular path (currently raises `NotImplementedError`; only monolithic/non-EP supported).
- Broaden beyond Blackwell/TRTLLM if/when other kernels support the scheme. It shouldn't be too hard to add this support to Humming

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

