### PR TITLE
[Frontend] Speed up offline prompt tokenization by 2.4x

### DIFF
--- a/tests/entrypoints/multimodal/llm/test_mm_processor_kwargs.py
+++ b/tests/entrypoints/multimodal/llm/test_mm_processor_kwargs.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 import pytest
 
 from vllm import LLM, SamplingParams
+from vllm.entrypoints.offline_utils import _OFFLINE_TOKENIZATION_BATCH_SIZE
 
 
 def _make_mock_llm() -> LLM:
@@ -152,7 +153,7 @@ def test_add_completion_requests_forwards_mm_processor_kwargs() -> None:
     llm._params_to_seq = Mock(return_value=[sampling_params])
     llm._lora_request_to_seq = Mock(return_value=[None])
     llm._priority_to_seq = Mock(return_value=[0])
-    llm._preprocess_cmpl_one = Mock(return_value={"prompt_token_ids": [1]})
+    llm._preprocess_cmpl = Mock(return_value=[{"prompt_token_ids": [1]}])
 
     captured_prompts = []
 
@@ -170,12 +171,51 @@ def test_add_completion_requests_forwards_mm_processor_kwargs() -> None:
     )
 
     assert request_ids == ["req-0"]
-    llm._preprocess_cmpl_one.assert_called_once_with(
-        "prompt",
+    llm._preprocess_cmpl.assert_called_once_with(
+        ["prompt"],
         None,
         mm_processor_kwargs=mm_processor_kwargs,
     )
     assert captured_prompts == [{"prompt_token_ids": [1]}]
+
+
+def test_add_completion_requests_bounds_preprocessing_batches() -> None:
+    llm = _make_mock_llm()
+    sampling_params = SamplingParams(max_tokens=1)
+    prompts = [
+        f"prompt-{index}" for index in range(_OFFLINE_TOKENIZATION_BATCH_SIZE + 1)
+    ]
+
+    llm._params_to_seq = Mock(return_value=[sampling_params] * len(prompts))
+    llm._lora_request_to_seq = Mock(return_value=[None] * len(prompts))
+    llm._priority_to_seq = Mock(return_value=[0] * len(prompts))
+    preprocess_batch_sizes = []
+    added_token_ids = []
+
+    def fake_preprocess(prompt_batch, *_args, **_kwargs):
+        preprocess_batch_sizes.append(len(prompt_batch))
+        return [
+            {"prompt_token_ids": [int(prompt.rsplit("-", 1)[1])]}
+            for prompt in prompt_batch
+        ]
+
+    def fake_render_and_add_requests(*, prompts, **_kwargs):
+        for prompt in prompts:
+            added_token_ids.extend(prompt["prompt_token_ids"])
+        return [f"req-{index}" for index in range(len(added_token_ids))]
+
+    llm._preprocess_cmpl = Mock(side_effect=fake_preprocess)
+    llm._render_and_add_requests = Mock(side_effect=fake_render_and_add_requests)
+
+    request_ids = llm._add_completion_requests(
+        prompts=prompts,
+        params=sampling_params,
+        use_tqdm=False,
+    )
+
+    assert len(request_ids) == len(prompts)
+    assert preprocess_batch_sizes == [_OFFLINE_TOKENIZATION_BATCH_SIZE, 1]
+    assert added_token_ids == list(range(len(prompts)))
 
 
 def test_preprocess_cmpl_applies_mm_processor_kwargs_to_renderer(

--- a/tests/renderers/test_completions.py
+++ b/tests/renderers/test_completions.py
@@ -3,6 +3,7 @@
 
 import io
 from collections.abc import Sequence
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
 
@@ -120,6 +121,15 @@ def _preprocess_prompt(
         )
         for prompt in prompt_to_seq(prompt_or_prompts)
     ]
+
+
+@pytest.fixture
+def fast_renderer():
+    from transformers import AutoTokenizer
+
+    renderer = object.__new__(HfRenderer)
+    renderer.tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME, use_fast=True)
+    return renderer
 
 
 class TestValidatePrompt:
@@ -446,6 +456,66 @@ class TestRenderPrompt:
         assert len(results[0]["prompt_token_ids"]) == 4
 
         assert renderer.tokenizer._captured_text_len <= 100
+
+
+class TestBatchTokenizePrompts:
+    def test_fast_tokenizer_batches_plain_text(
+        self, fast_renderer: HfRenderer, monkeypatch: pytest.MonkeyPatch
+    ):
+        prompts = [
+            {"prompt": "HELLO WORLD FROM VLLM"},
+            {"prompt": "A SHORTER PROMPT"},
+        ]
+        params = TokenizeParams(
+            max_total_tokens=None,
+            truncate_prompt_tokens=4,
+            truncation_side="left",
+            do_lower_case=True,
+            return_token_offsets=True,
+        )
+        expected = [
+            fast_renderer.tokenize_prompt(prompt, params)
+            for prompt in deepcopy(prompts)
+        ]
+
+        tokenizer_type = type(fast_renderer.tokenizer)
+        original_call = tokenizer_type.__call__
+        call_inputs = []
+
+        def track_call(tokenizer, text, *args, **kwargs):
+            call_inputs.append(text)
+            return original_call(tokenizer, text, *args, **kwargs)
+
+        monkeypatch.setattr(tokenizer_type, "__call__", track_call)
+
+        actual = fast_renderer.tokenize_prompts(deepcopy(prompts), params)
+
+        assert actual == expected
+        assert call_inputs == [[prompt["prompt"].lower() for prompt in prompts]]
+
+    def test_mixed_prompts_use_singleton_fallback(
+        self, fast_renderer: HfRenderer, monkeypatch: pytest.MonkeyPatch
+    ):
+        prompts = [
+            {"prompt": "text prompt"},
+            {"prompt_token_ids": [1, 2, 3]},
+        ]
+        params = TokenizeParams(max_total_tokens=None)
+
+        tokenizer_type = type(fast_renderer.tokenizer)
+        original_call = tokenizer_type.__call__
+        call_inputs = []
+
+        def track_call(tokenizer, text, *args, **kwargs):
+            call_inputs.append(text)
+            return original_call(tokenizer, text, *args, **kwargs)
+
+        monkeypatch.setattr(tokenizer_type, "__call__", track_call)
+
+        actual = fast_renderer.tokenize_prompts(deepcopy(prompts), params)
+
+        assert actual[1]["prompt_token_ids"] == [1, 2, 3]
+        assert call_inputs == ["text prompt"]
 
 
 class TestRenderEmbedPrompt:

--- a/vllm/entrypoints/offline_utils.py
+++ b/vllm/entrypoints/offline_utils.py
@@ -37,6 +37,20 @@ from vllm.v1.engine.llm_engine import LLMEngine
 logger = init_logger(__name__)
 
 
+_OFFLINE_TOKENIZATION_BATCH_SIZE = 32
+
+
+def _batch_prompts(prompts: Iterable[PromptType]) -> Iterable[list[PromptType]]:
+    batch = []
+    for prompt in prompts:
+        batch.append(prompt)
+        if len(batch) == _OFFLINE_TOKENIZATION_BATCH_SIZE:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
 _P = TypeVar("_P", bound=SamplingParams | PoolingParams | None)
 _O = TypeVar(
     "_O",
@@ -305,17 +319,19 @@ class OfflineInferenceMixin:
         seq_lora_requests = self._lora_request_to_seq(lora_request, len(seq_prompts))
         seq_priority = self._priority_to_seq(priority, len(seq_prompts))
 
+        prompt_iter = maybe_tqdm(
+            seq_prompts,
+            use_tqdm=use_tqdm,
+            desc="Rendering prompts",
+        )
         return self._render_and_add_requests(
             prompts=(
-                self._preprocess_cmpl_one(
-                    prompt,
+                processed_prompt
+                for prompt_batch in _batch_prompts(prompt_iter)
+                for processed_prompt in self._preprocess_cmpl(
+                    prompt_batch,
                     tokenization_kwargs,
                     mm_processor_kwargs=mm_processor_kwargs,
-                )
-                for prompt in maybe_tqdm(
-                    seq_prompts,
-                    use_tqdm=use_tqdm,
-                    desc="Rendering prompts",
                 )
             ),
             params=seq_params,

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -18,6 +18,7 @@ import jinja2.nodes
 import jinja2.parser
 import jinja2.sandbox
 import torch
+from transformers import TokenizersBackend
 from typing_extensions import override
 
 from vllm.entrypoints.chat_utils import (
@@ -62,15 +63,20 @@ if TYPE_CHECKING:
         ChatTemplateContentFormatOption,
         ConversationMessage,
     )
-    from vllm.inputs import MultiModalDataDict, MultiModalUUIDDict, TokensPrompt
+    from vllm.inputs import (
+        MultiModalDataDict,
+        MultiModalUUIDDict,
+        TextPrompt,
+        TokensPrompt,
+    )
     from vllm.inputs.engine import TokensInput
     from vllm.multimodal.processing.processor import (
         MultiModalPromptUpdates,
         ResolvedPromptUpdate,
     )
 
-    from .inputs import DictPrompt
-    from .params import ChatParams
+    from .inputs import DictPrompt, TokPrompt
+    from .params import ChatParams, TokenizeParams
 
 logger = init_logger(__name__)
 
@@ -925,6 +931,59 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
         # HF tokenizers may be slow (use_fast=False); only fast tokenizers
         # expose offset_mapping.
         return self.tokenizer is not None and self.tokenizer.is_fast
+
+    def tokenize_prompts(
+        self,
+        prompts: Sequence[DictPrompt],
+        params: TokenizeParams,
+    ) -> list[TokPrompt]:
+        tokenizer = self.get_tokenizer()
+        if (
+            not isinstance(tokenizer, TokenizersBackend)
+            or not prompts
+            or any(
+                "encoder_prompt" in prompt
+                or "prompt_token_ids" in prompt
+                or "prompt_embeds" in prompt
+                or not isinstance(prompt.get("prompt"), str)
+                or "multi_modal_data" in prompt
+                or "multi_modal_uuids" in prompt
+                for prompt in prompts
+            )
+        ):
+            return super().tokenize_prompts(prompts, params)
+
+        text_prompts = [
+            params.apply_pre_tokenization(tokenizer, cast("TextPrompt", prompt))
+            for prompt in prompts
+        ]
+        want_offsets = params.return_token_offsets and self._can_produce_offsets()
+        kwargs = params.get_encode_kwargs()
+        if want_offsets:
+            kwargs = {**kwargs, "return_offsets_mapping": True}
+
+        encoding = tokenizer(
+            [prompt["prompt"] for prompt in text_prompts],
+            **kwargs,
+        )
+        offset_mappings = encoding.get("offset_mapping")
+
+        tokenized_prompts: list[TokPrompt] = []
+        for index, (prompt, token_ids) in enumerate(
+            zip(text_prompts, encoding["input_ids"], strict=True)
+        ):
+            tokenized = self._build_tokens_prompt(
+                token_ids,
+                prompt,
+                offset_mapping=(
+                    offset_mappings[index] if offset_mappings is not None else None
+                ),
+            )
+            tokenized_prompts.append(
+                params.apply_post_tokenization(tokenizer, tokenized)
+            )
+
+        return tokenized_prompts
 
     def render_messages(
         self,


### PR DESCRIPTION
## Summary

This batches synchronous offline completion preprocessing instead of invoking
the tokenizer once per prompt:

- `OfflineInferenceMixin._add_completion_requests` preprocesses prompts in
  bounded groups of 32.
- `HfRenderer.tokenize_prompts` sends homogeneous plain-text groups to the
  Hugging Face fast-tokenizer list API.
- Slow or custom tokenizers, token IDs, embeddings, encoder-decoder prompts,
  multimodal prompts, and mixed groups retain the existing singleton path.

Prompt order, tokenization kwargs, offsets, truncation, lowercasing, padding,
LoRA/priority alignment, multimodal kwargs, and exception cleanup are
preserved.

## Motivation

`LLM.generate()` already receives a sequence of offline prompts, but the
completion path currently calls `_preprocess_cmpl_one` for every item.
`BaseRenderer.tokenize_prompts` therefore makes one Python-to-tokenizer call per
prompt.

On a warmed Qwen3-0.6B Metal workload with 128 long shared-prefix prompts and
one output token, request rendering/tokenization accounted for roughly 8% of
wall time. Hugging Face's Rust-backed tokenizer can process the text list in a
single call and amortize that Python overhead.

The group size is bounded at 32. This matches the default used by the previously
merged online microbatch tokenizer while avoiding an unbounded tokenizer batch.

## Performance

Measured on an Apple M4 (10 CPU cores, 32 GB) using the local
`Qwen/Qwen3-0.6B` tokenizer. The tokenizer benchmark used 128 distinct
384-word prompts and reports the median of 21 samples.

| Path | Median | Relative |
| --- | ---: | ---: |
| Singleton tokenizer calls | 47.397 ms | 1.00x |
| Bounded batches of 32 | 19.527 ms | **2.43x** |

All prompt token IDs matched exactly. Single-prompt measurements were neutral:
`0.3387 -> 0.3364 ms` for a 384-word prompt and `0.0110 -> 0.0107 ms` for a
short prompt.

A 30-pair model-backed run on one warmed vLLM-Metal engine measured the complete
request-add/preprocessing stage:

| Path | Median | Change |
| --- | ---: | ---: |
| Current singleton path | 57.196 ms | - |
| Batched path | 24.608 ms | **56.98% lower** |

That saves 32.588 ms per 128-request batch. Prompt token IDs matched exactly;
generated output token IDs also matched in the final run.

Full Metal wall time was too noisy to support a definitive end-to-end
percentage: pair-level deltas ranged from -13.94% to +7.76% despite the stable
CPU-stage reduction. I am therefore not claiming an end-to-end speedup from
this machine. The benchmark scripts and raw caveats are available in the
[public reproduction artifact](https://gist.github.com/trevorprater/34627b18c0ea94e51d2e4f89621b286f).

## Correctness and tests

```bash
PYTHONPATH=$PWD .venv/bin/python -m pytest \
  tests/renderers/test_completions.py \
  tests/renderers/test_token_offsets.py \
  tests/entrypoints/multimodal/llm/test_mm_processor_kwargs.py -q
# 50 passed

PYTHONPATH=$PWD .venv/bin/python -m pytest tests/renderers -q \
  -k 'not test_resolve_content_format_hf_defined and not test_resolve_content_format_fallbacks'
# 237 passed, 11 deselected

pre-commit run --files \
  vllm/entrypoints/offline_utils.py \
  vllm/renderers/hf.py \
  tests/renderers/test_completions.py \
  tests/entrypoints/multimodal/llm/test_mm_processor_kwargs.py
# all hooks passed, including Python 3.10 mypy
```

The 11 deselected cases fetch gated Hugging Face model configurations. An
unfiltered run reached 244 passes; its only four failures were HTTP 401 errors
for gated Llama, Chameleon, and PaliGemma repositories before this code was
exercised.

## Duplicate check

- #19012 and merged PR #19334 address microbatch tokenization in online
  serving, not synchronous offline `LLM.generate()` preprocessing.
- Open PR #47699 overlaps preprocessing with execution for offline pooling
  models and changes different files. This PR targets completion generation.
- Searches for open PRs containing `offline tokenization`, `batch tokenizer`,
  and `tokenize_prompts` found no implementation of this change.

## AI assistance

OpenAI Codex was used for profiling, implementation, testing, and preparing the
benchmark evidence. The human submitter reviewed every changed line and
confirmed that they understand and can defend the change end to end.
