### PR TITLE
[Test][kv_offload] Fix flaky drain() helper in test_fs_tier.py

### DIFF
--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -91,24 +91,10 @@ def make_job(
     )
 
 
-def drain(tier: FileSystemTierManager, max_rounds: int = 100) -> list:
-    """
-    Call get_finished_jobs() repeatedly until no new results arrive for 20
-    consecutive rounds or max_rounds is reached.
-    """
-    results = []
-    idle = 0
-    for _ in range(max_rounds):
-        time.sleep(0.01)
-        new = list(tier.get_finished_jobs())
-        results.extend(new)
-        if new:
-            idle = 0
-        else:
-            idle += 1
-            if idle >= 20:
-                break
-    return results
+def drain(tier: FileSystemTierManager) -> list:
+    """Block until all in-flight jobs finish, then collect results."""
+    tier.drain_jobs()
+    return list(tier.get_finished_jobs())
 
 
 def lookup_and_wait(


### PR DESCRIPTION
## Summary  
   The `drain()` test helper in `test_fs_tier.py` used a polling loop that exited early after 20 consecutive empty rounds (200 ms). Under a loaded system, store tasks could complete after the 200 ms window, causing `test_load_job_emits_no_event` and `test_partially_failed_store_emits_no_event` to fail with `assert 0 == 1`. 

## Fix  
   Replace the polling loop with `tier.drain_jobs()` (which calls `wait_idle()` and blocks until all in-flight tasks truly finish) followed by a single `get_finished_jobs()` call. This is both simpler and race-condition-free.     