### PR TITLE
[RFC][Model Runner V2] Add sealed graph-safe weight reload

### DIFF
--- a/docs/design/graph_safe_weight_reload.md
+++ b/docs/design/graph_safe_weight_reload.md
@@ -1,0 +1,247 @@
+# Graph-safe weight reload
+
+This document describes the sealed reload plan used by Model Runner V2 to
+update model weights without invalidating an existing CUDA or HIP graph.
+
+## Problem
+
+A weight update is not always a direct copy into an `nn.Parameter`. Backends
+often derive additional runtime tensors after loading a checkpoint:
+
+- transposed or split projections;
+- packed or shuffled kernel weights;
+- converted attention sinks;
+- quantization scales;
+- strides, workspaces, and backend descriptors.
+
+A graph records the addresses used during capture. Rebinding one of these
+tensors updates the Python model but leaves the graph reading its old storage.
+Keeping the address stable is also insufficient when a derived tensor or a
+runtime cache still contains values from the previous model version.
+
+Weight reload therefore has four independent correctness requirements:
+
+1. **Storage identity:** every graph-visible stable slot keeps its original
+   storage and layout.
+2. **Derived freshness:** every affected derived slot is refreshed in the
+   current reload epoch.
+3. **Loader lifecycle:** load, post-load processing, validation, and commit run
+   exactly once and in order.
+4. **Runtime state:** caches and backend state are refreshed, invalidated, or
+   explicitly proven safe to preserve.
+
+## Scope and assumptions
+
+The current implementation is intentionally limited to Model Runner V2.
+Model Runner V1 does not participate in this contract.
+
+Reload starts only after inference has been paused and in-flight requests have
+been drained. A successful update reuses the existing graph. The implementation
+does not automatically recapture a graph, keep a shadow model, or roll back a
+partially written model.
+
+An unsupported backend fails before the first model mutation. After a failure
+during loading or validation, the reload plan remains failed and the worker
+must be restarted or fully reloaded before serving resumes.
+
+## Architecture
+
+The implementation has three layers:
+
+```text
+LLM / AsyncLLM
+  prepare every worker
+  commit only after every prepare succeeds
+                |
+                v
+Worker weight-transfer lifecycle
+  begin -> receive -> finalize -> prepare -> commit
+                |
+                v
+Model Runner V2 ReloadCoordinator
+  ReloadPlan + one active ReloadTransaction
+```
+
+The transport is not the owner of reload correctness. Disk, NCCL, IPC, and
+future transports provide inputs to the same transaction. `ReloadCoordinator`
+owns the plan, active epoch, state policy, and commit gate.
+
+## Reload plan
+
+`ReloadPlan` is compiled after initial model loading and before compilation or
+graph capture. It contains the following objects.
+
+### Direct inputs
+
+Parameters and buffers whose checkpoint and runtime layouts are identical are
+direct inputs. A transaction updates them with `copy_`; rebinding the parameter
+or changing its view is rejected during validation.
+
+### Stable tensor slots
+
+Every direct or derived graph-visible tensor has a stable slot. A slot retains
+a strong reference to its initial tensor and records:
+
+- storage identity;
+- data pointer and storage size;
+- shape, stride, and storage offset;
+- dtype and device.
+
+Comparing only `data_ptr` is insufficient because an allocator can reuse an
+address. Comparing only storage identity is also insufficient because a view
+can change its offset or layout.
+
+### Derived nodes
+
+A reload participant declares an explicit dependency and output set:
+
+```python
+def build_reload_plan(self, builder, prefix):
+    builder.derived(
+        f"{prefix}.runtime_projection",
+        owner=self,
+        owner_key="runtime_projection",
+        outputs=("runtime_weight",),
+        depends_on=(f"{prefix}.weight",),
+    )
+```
+
+Post-load processing publishes a newly computed value with
+`refresh_reload_derived`. During initial loading this binds the attribute.
+During reload it copies into the original stable slot and marks the node with
+the active epoch.
+
+```python
+refresh_reload_derived(
+    self,
+    "runtime_projection",
+    {"runtime_weight": transformed_weight},
+)
+```
+
+Commit rejects a required node whose `last_executed_epoch` is stale. This
+catches a missing post-load refresh even when the old and new tensors have
+identical shapes, strides, and values in a same-weight test.
+
+### Runtime state
+
+Non-checkpoint state uses one of three policies:
+
+| Policy | Meaning |
+| --- | --- |
+| `REFRESH` | Recompute state for the new model version. |
+| `INVALIDATE` | Clear state before publishing the new epoch. |
+| `PRESERVE` | Keep state only when its validator proves it version-independent. |
+
+Model Runner V2 currently invalidates encoder and multimodal caches as part of
+the transaction.
+
+### Capabilities
+
+A plan has one of three capabilities:
+
+| Capability | Behavior |
+| --- | --- |
+| `GRAPH_SAFE_V1` | Reload is allowed with a live graph. |
+| `EAGER_ONLY` | Reload is numerically complete but graph storage is not certified. |
+| `UNSUPPORTED` | Reload is rejected in every execution mode. |
+
+Quantization backends that have not declared a complete reload plan are
+currently `UNSUPPORTED`. This is deliberate: derived-value staleness can
+silently corrupt eager execution as well as graph replay.
+
+## Transaction lifecycle
+
+A transaction has the following state machine:
+
+```text
+LOADING -> FINALIZING -> VALIDATING -> PREPARED -> COMMITTED
+    \           \             \            \
+     +-----------+-------------+-------------> FAILED
+```
+
+- `begin` verifies capability before mutation and assigns a new epoch.
+- `write` validates a direct input and copies it into its stable slot.
+- `FINALIZING` permits post-load participants to refresh derived slots.
+- `prepare` checks input completeness, derived epochs, state policies, and all
+  storage fingerprints without publishing the epoch.
+- `commit` publishes the epoch only after every worker prepared successfully.
+
+There is no transition from `FAILED` back to an active serving state.
+
+## Distributed commit
+
+`LLM.finish_weight_update` and `AsyncLLM.finish_weight_update` perform two
+collective calls:
+
+1. `prepare_weight_update` finalizes and validates every worker.
+2. `commit_weight_update` runs only if the first collective succeeded on every
+   worker.
+
+If any prepare fails, the coordinator broadcasts `abort_weight_update` and no
+worker publishes the new epoch. Commit itself only publishes already validated
+local state; model mutation and backend finalization happen during prepare.
+
+## Initial participants
+
+The first participants cover known high-risk attention paths:
+
+- MLA projections derived from `kv_b_proj`, including `W_UK_T`, `W_UV`, and
+  AITER FP4/FP8 projection tensors;
+- FlashInfer attention sinks converted to FP32 after loading.
+
+FlashInfer retains the original checkpoint source separately from the runtime
+FP32 slot. Every reload derives the runtime value from the updated source and
+copies it into the storage captured by the graph.
+
+Additional quantization, MoE, and opaque C++ backends must implement the same
+participant contract before their capability can be upgraded from
+`UNSUPPORTED`.
+
+## Failure examples
+
+### Storage replacement
+
+```python
+layer.runtime_weight = transform(layer.weight)
+```
+
+If this bypasses `refresh_reload_derived`, storage validation reports the slot
+name and its expected and actual fingerprint before inference resumes.
+
+### Missing derived refresh
+
+If the source parameter was written but its required derived node did not run,
+commit raises `StaleDerivedSlotError` with the node and epoch.
+
+### Incomplete input set
+
+For a reload with a declared input manifest, commit reports the missing logical
+inputs rather than publishing a partially updated model.
+
+### Stale runtime cache
+
+A state node without its required action fails plan compilation. A preserve
+validator that returns false fails transaction preparation.
+
+## Testing strategy
+
+CPU contract tests cover:
+
+- direct in-place writes;
+- parameter and derived-slot rebinding;
+- missing and duplicate inputs;
+- stale derived epochs;
+- transaction ordering and permanent failure;
+- state invalidation and preserve validation;
+- eager-only and unsupported capability gates;
+- prepare without premature epoch publication.
+
+V2 integration tests cover coordinator reload, cache invalidation, rejection
+before mutation, Worker lifecycle, and sync/async two-phase commit. A focused
+FlashInfer test verifies that updated BF16 source values reach the original
+FP32 runtime storage.
+
+Hardware CI should add differential output checks for every backend promoted to
+`GRAPH_SAFE_V1`: capture once, reload different weights, replay the existing
+graph, and compare logits with a fresh eager model.

--- a/tests/model_executor/model_loader/test_reload_plan.py
+++ b/tests/model_executor/model_loader/test_reload_plan.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.model_executor.model_loader.reload.plan import (
+    ReloadCapability,
+    ReloadCapabilityError,
+    ReloadInputError,
+    ReloadLifecycleError,
+    ReloadPlanBuilder,
+    ReloadPlanCompileError,
+    ReloadStatePolicy,
+    ReloadStatePolicyError,
+    ReloadStorageIdentityError,
+    StaleDerivedSlotError,
+    refresh_reload_derived,
+)
+
+
+class DerivedModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.arange(4, dtype=torch.float32))
+        self.runtime_weight = self.weight.detach().clone()
+
+    def build_reload_plan(self, builder: ReloadPlanBuilder, prefix: str) -> None:
+        builder.derived(
+            f"{prefix}.runtime_transform",
+            owner=self,
+            owner_key="runtime_transform",
+            outputs=("runtime_weight",),
+            depends_on=(f"{prefix}.weight",),
+        )
+
+    def refresh_runtime_weight(self) -> None:
+        refresh_reload_derived(
+            self,
+            "runtime_transform",
+            {"runtime_weight": self.weight.detach() * 2},
+        )
+
+
+def test_direct_input_write_preserves_storage_and_updates_value():
+    model = torch.nn.Linear(4, 3, bias=False)
+    plan = ReloadPlanBuilder.from_model(model).seal()
+    original = model.weight
+
+    with plan.begin(expected_inputs=("model.weight",)) as transaction:
+        transaction.write("model.weight", torch.full_like(model.weight, 2))
+        transaction.commit_or_raise()
+
+    assert model.weight is original
+    assert torch.equal(model.weight, torch.full_like(model.weight, 2))
+    assert plan.committed_epoch == 1
+
+
+def test_category1_rejects_logical_slot_rebind_before_commit():
+    model = torch.nn.Linear(4, 3, bias=False)
+    plan = ReloadPlanBuilder.from_model(model).seal()
+    transaction = plan.begin()
+
+    model.weight = torch.nn.Parameter(model.weight.detach().clone())
+
+    with pytest.raises(ReloadStorageIdentityError, match="model.weight"):
+        transaction.commit_or_raise()
+
+    assert plan.active_transaction is None
+
+
+def test_category2_rejects_derived_slot_not_refreshed():
+    model = DerivedModel()
+    plan = ReloadPlanBuilder.from_model(model).seal()
+    transaction = plan.begin(expected_inputs=("model.weight",))
+    transaction.write("model.weight", torch.full_like(model.weight, 3))
+
+    with pytest.raises(StaleDerivedSlotError, match="runtime_transform"):
+        transaction.commit_or_raise()
+
+
+def test_derived_refresh_copies_into_original_storage_and_marks_epoch():
+    model = DerivedModel()
+    original_runtime_weight = model.runtime_weight
+    plan = ReloadPlanBuilder.from_model(model).seal()
+
+    with plan.begin(expected_inputs=("model.weight",)) as transaction:
+        transaction.write("model.weight", torch.full_like(model.weight, 3))
+        model.refresh_runtime_weight()
+        transaction.commit_or_raise()
+
+    assert model.runtime_weight is original_runtime_weight
+    assert torch.equal(model.runtime_weight, torch.full_like(model.weight, 6))
+
+
+def test_category3_rejects_lifecycle_operations_out_of_order():
+    model = torch.nn.Linear(4, 3, bias=False)
+    plan = ReloadPlanBuilder.from_model(model).seal()
+    transaction = plan.begin()
+
+    with pytest.raises(ReloadLifecycleError, match="already active"):
+        plan.begin()
+
+    transaction.start_finalizing()
+    with pytest.raises(ReloadLifecycleError, match="expected LOADING"):
+        transaction.write("model.weight", torch.ones_like(model.weight))
+
+    transaction.abort()
+
+
+def test_missing_expected_input_fails_closed():
+    model = torch.nn.Linear(4, 3, bias=False)
+    plan = ReloadPlanBuilder.from_model(model).seal()
+    transaction = plan.begin(expected_inputs=("model.weight",))
+
+    with pytest.raises(ReloadInputError, match="Missing reload inputs"):
+        transaction.commit_or_raise()
+
+
+def test_category4_requires_state_action_at_plan_compile_time():
+    builder = ReloadPlanBuilder()
+
+    with pytest.raises(ReloadPlanCompileError, match="requires an action"):
+        builder.state("prefix_cache", policy=ReloadStatePolicy.INVALIDATE)
+
+
+def test_category4_rejects_preserved_state_that_fails_validation():
+    builder = ReloadPlanBuilder()
+    builder.state(
+        "shape_only_workspace",
+        policy=ReloadStatePolicy.PRESERVE,
+        validate=lambda: False,
+    )
+    plan = builder.seal()
+    transaction = plan.begin()
+
+    with pytest.raises(ReloadStatePolicyError, match="shape_only_workspace"):
+        transaction.commit_or_raise()
+
+
+def test_state_invalidation_runs_before_commit():
+    state: dict[str, str | None] = {"cache": "old"}
+    builder = ReloadPlanBuilder()
+    builder.state(
+        "prefix_cache",
+        policy=ReloadStatePolicy.INVALIDATE,
+        action=lambda: state.update(cache=None),
+    )
+    plan = builder.seal()
+
+    with plan.begin() as transaction:
+        transaction.commit_or_raise()
+
+    assert state["cache"] is None
+
+
+def test_prepare_validates_without_publishing_epoch():
+    model = torch.nn.Linear(4, 3, bias=False)
+    plan = ReloadPlanBuilder.from_model(model).seal()
+    transaction = plan.begin(expected_inputs=("model.weight",))
+    transaction.write("model.weight", torch.ones_like(model.weight))
+
+    transaction.prepare_or_raise()
+
+    assert plan.committed_epoch == 0
+    assert plan.active_transaction is transaction
+    transaction.commit_prepared()
+    assert plan.committed_epoch == 1
+
+
+def test_eager_only_backend_rejected_for_graph_reload_before_mutation():
+    builder = ReloadPlanBuilder()
+    builder.eager_only("backend replaces graph-visible storage")
+    plan = builder.seal()
+
+    assert plan.capability is ReloadCapability.EAGER_ONLY
+    with pytest.raises(ReloadCapabilityError, match="replaces graph-visible"):
+        plan.begin(require_graph_safe=True)
+
+    with plan.begin(require_graph_safe=False) as transaction:
+        transaction.commit_or_raise()
+
+
+def test_uncertified_backend_rejected_in_eager_mode_before_mutation():
+    builder = ReloadPlanBuilder()
+    builder.unsupported("opaque backend has no reload participant")
+    plan = builder.seal()
+
+    assert plan.capability is ReloadCapability.UNSUPPORTED
+    with pytest.raises(ReloadCapabilityError, match="opaque backend"):
+        plan.begin(require_graph_safe=False)
+
+
+def test_unknown_dependency_is_rejected_when_plan_is_sealed():
+    owner = DerivedModel()
+    builder = ReloadPlanBuilder()
+    builder.derived(
+        "runtime_transform",
+        owner=owner,
+        owner_key="runtime_transform",
+        outputs=("runtime_weight",),
+        depends_on=("missing.weight",),
+    )
+
+    with pytest.raises(ReloadPlanCompileError, match="unknown dependencies"):
+        builder.seal()
+
+
+def test_flashinfer_sinks_refresh_from_source_into_stable_storage():
+    from vllm.v1.attention.backends.flashinfer import FlashInferImpl
+
+    impl = object.__new__(FlashInferImpl)
+    source = torch.nn.Parameter(torch.tensor([1, 2], dtype=torch.bfloat16))
+    impl.sinks = source
+    FlashInferImpl.process_weights_after_loading(impl, torch.bfloat16)
+    original_runtime_sinks = impl.sinks
+
+    builder = ReloadPlanBuilder()
+    builder.direct_input("sinks", source, resolver=lambda: source)
+    builder.derived(
+        "runtime_sinks",
+        owner=impl,
+        owner_key="attention_sinks",
+        outputs=("sinks",),
+        depends_on=("sinks",),
+    )
+    plan = builder.seal()
+
+    with plan.begin(expected_inputs=("sinks",)) as transaction:
+        transaction.write("sinks", torch.tensor([3, 4], dtype=torch.bfloat16))
+        FlashInferImpl.process_weights_after_loading(impl, torch.bfloat16)
+        transaction.commit_or_raise()
+
+    assert impl.sinks is original_runtime_sinks
+    assert impl.sinks.dtype == torch.float32
+    assert torch.equal(impl.sinks, torch.tensor([3, 4], dtype=torch.float32))

--- a/tests/v1/engine/test_weight_update_commit.py
+++ b/tests/v1/engine/test_weight_update_commit.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.entrypoints.llm import LLM
+from vllm.v1.engine.async_llm import AsyncLLM
+
+
+class _SyncEngine:
+    def __init__(self, fail_prepare: bool = False) -> None:
+        self.fail_prepare = fail_prepare
+        self.calls: list[str] = []
+
+    def collective_rpc(self, method: str) -> None:
+        self.calls.append(method)
+        if method == "prepare_weight_update" and self.fail_prepare:
+            raise RuntimeError("prepare failed")
+
+
+class _AsyncClient:
+    def __init__(self, fail_prepare: bool = False) -> None:
+        self.fail_prepare = fail_prepare
+        self.calls: list[str] = []
+
+    async def collective_rpc(self, method: str) -> None:
+        self.calls.append(method)
+        if method == "prepare_weight_update" and self.fail_prepare:
+            raise RuntimeError("prepare failed")
+
+
+def test_sync_finish_prepares_all_workers_before_commit():
+    llm = object.__new__(LLM)
+    llm.llm_engine = _SyncEngine()
+
+    LLM.finish_weight_update(llm)
+
+    assert llm.llm_engine.calls == [
+        "prepare_weight_update",
+        "commit_weight_update",
+    ]
+
+
+def test_sync_finish_aborts_when_prepare_fails():
+    llm = object.__new__(LLM)
+    llm.llm_engine = _SyncEngine(fail_prepare=True)
+
+    with pytest.raises(RuntimeError, match="prepare failed"):
+        LLM.finish_weight_update(llm)
+
+    assert llm.llm_engine.calls == [
+        "prepare_weight_update",
+        "abort_weight_update",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_finish_prepares_all_workers_before_commit():
+    client = _AsyncClient()
+
+    await AsyncLLM.finish_weight_update(client)  # type: ignore[arg-type]
+
+    assert client.calls == ["prepare_weight_update", "commit_weight_update"]

--- a/tests/v1/worker/test_gpu_worker_weight_transfer.py
+++ b/tests/v1/worker/test_gpu_worker_weight_transfer.py
@@ -21,6 +21,8 @@ class _RecordingEngine:
         self.finished = False
         self.reset_count = 0
         self.update_calls: list[dict] = []
+        self.model = object()
+        self.model_config = object()
 
     def start_weight_update(self) -> None:
         self.started = True
@@ -37,9 +39,38 @@ class _RecordingEngine:
         self.reset_count += 1
 
 
+class _RecordingModelRunner:
+    def __init__(self, raise_on_commit: bool = False):
+        self.raise_on_commit = raise_on_commit
+        self.events: list[str] = []
+        self.reload_coordinator = self
+
+    def begin(self, model, model_config) -> None:
+        self.events.append("begin")
+
+    def record_inputs(self, update_info: dict) -> None:
+        self.events.append("record")
+
+    def start_finalizing(self) -> None:
+        self.events.append("finalize")
+
+    def prepare(self) -> None:
+        self.events.append("prepare")
+
+    def commit(self) -> None:
+        self.events.append("commit")
+        if self.raise_on_commit:
+            raise RuntimeError("commit failed")
+
+    def abort(self) -> None:
+        self.events.append("abort")
+
+
 def _make_worker(engine: _RecordingEngine | None) -> Worker:
     worker = object.__new__(Worker)
     worker.weight_transfer_engine = engine
+    worker.model_runner = _RecordingModelRunner()
+    worker.use_v2_model_runner = True
     worker._weight_update_active = False
     return worker
 
@@ -60,6 +91,13 @@ def test_start_update_finish_delegates_to_engine():
     assert engine.finished is True
     assert engine.reset_count == 1
     assert worker._weight_update_active is False
+    assert worker.model_runner.events == [
+        "begin",
+        "record",
+        "finalize",
+        "prepare",
+        "commit",
+    ]
 
 
 def test_double_start_raises():
@@ -67,6 +105,27 @@ def test_double_start_raises():
     Worker.start_weight_update(worker)
     with pytest.raises(RuntimeError, match="already"):
         Worker.start_weight_update(worker)
+
+
+def test_reload_commit_failure_keeps_update_active():
+    engine = _RecordingEngine()
+    worker = _make_worker(engine)
+    worker.model_runner = _RecordingModelRunner(raise_on_commit=True)
+    Worker.start_weight_update(worker)
+
+    with pytest.raises(RuntimeError, match="commit failed"):
+        Worker.finish_weight_update(worker)
+
+    assert engine.finished is True
+    assert engine.reset_count == 0
+    assert worker._weight_update_active is True
+    assert worker.model_runner.events == [
+        "begin",
+        "finalize",
+        "prepare",
+        "commit",
+        "abort",
+    ]
 
 
 def test_update_without_start_raises():
@@ -92,9 +151,21 @@ def test_update_resets_active_on_error():
     # A failed update ends the session so the next start is clean.
     assert engine.reset_count == 1
     assert worker._weight_update_active is False
+    assert worker.model_runner.events == ["begin", "record", "abort"]
 
 
 def test_missing_engine_raises():
     worker = _make_worker(None)
     with pytest.raises(RuntimeError, match="Weight transfer not configured"):
         Worker.start_weight_update(worker)
+
+
+def test_sealed_reload_rejects_v1_model_runner():
+    engine = _RecordingEngine()
+    worker = _make_worker(engine)
+    worker.use_v2_model_runner = False
+
+    with pytest.raises(NotImplementedError, match="v2 model runner"):
+        Worker.start_weight_update(worker)
+
+    assert engine.started is False

--- a/tests/v1/worker/test_reload_coordinator.py
+++ b/tests/v1/worker/test_reload_coordinator.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.config import CompilationMode, CUDAGraphMode
+from vllm.model_executor.model_loader.reload import ReloadCapabilityError
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+from vllm.v1.worker.reload_coordinator import ReloadCoordinator
+
+
+class _Owner:
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        *,
+        quantization: str | None = None,
+        cudagraph_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+    ) -> None:
+        self.model = model
+        self.model_config = SimpleNamespace(
+            model="test-model",
+            quantization=quantization,
+        )
+        self.compilation_config = SimpleNamespace(
+            mode=CompilationMode.NONE,
+            cudagraph_mode=cudagraph_mode,
+        )
+        self.load_config = SimpleNamespace(load_format="dummy")
+        self.cache_events: list[str] = []
+
+    def get_model(self) -> torch.nn.Module:
+        return self.model
+
+    def reset_encoder_cache(self) -> None:
+        self.cache_events.append("encoder")
+
+    def reset_mm_cache(self) -> None:
+        self.cache_events.append("multimodal")
+
+
+def test_v2_reload_coordinator_commits_and_invalidates_caches():
+    model = torch.nn.Linear(4, 3, bias=False)
+    owner = _Owner(model)
+    coordinator = ReloadCoordinator(owner)
+    original_weight = model.weight
+
+    coordinator.reload_weights(
+        weights_iterator=[("weight", torch.ones_like(model.weight))],
+        is_checkpoint_format=False,
+    )
+
+    assert model.weight is original_weight
+    assert torch.equal(model.weight, torch.ones_like(model.weight))
+    assert owner.cache_events == ["encoder", "multimodal"]
+    assert coordinator.plan_for().committed_epoch == 1
+
+
+def test_v2_graph_reload_rejects_uncertified_backend_before_mutation():
+    model = torch.nn.Linear(4, 3, bias=False)
+    owner = _Owner(
+        model,
+        quantization="fp8",
+        cudagraph_mode=CUDAGraphMode.PIECEWISE,
+    )
+    coordinator = ReloadCoordinator(owner)
+    original = model.weight.detach().clone()
+
+    with pytest.raises(ReloadCapabilityError, match="fp8"):
+        coordinator.reload_weights(
+            weights_iterator=[("weight", torch.zeros_like(model.weight))],
+            is_checkpoint_format=False,
+        )
+
+    assert torch.equal(model.weight, original)
+
+
+def test_v2_runner_delegates_reload_to_coordinator():
+    runner = object.__new__(GPUModelRunner)
+    runner.reload_coordinator = Mock()
+    weights = [("weight", torch.ones(2, 2))]
+
+    GPUModelRunner.reload_weights(
+        runner,
+        weights_iterator=weights,
+        is_checkpoint_format=False,
+    )
+
+    runner.reload_coordinator.reload_weights.assert_called_once_with(
+        weights_iterator=weights,
+        is_checkpoint_format=False,
+    )

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -897,8 +897,23 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
         )
 
     def finish_weight_update(self) -> None:
-        """Finish the current weight update."""
-        self.llm_engine.collective_rpc("finish_weight_update")
+        """Atomically publish a weight update after every worker validates it."""
+        try:
+            self.llm_engine.collective_rpc("prepare_weight_update")
+        except BaseException:
+            try:
+                self.llm_engine.collective_rpc("abort_weight_update")
+            except BaseException:
+                logger.exception("Failed to abort weight update on every worker")
+            raise
+        try:
+            self.llm_engine.collective_rpc("commit_weight_update")
+        except BaseException:
+            try:
+                self.llm_engine.collective_rpc("abort_weight_update")
+            except BaseException:
+                logger.exception("Failed to abort weight update on every worker")
+            raise
 
     def __repr__(self) -> str:
         """Return a transformers-style hierarchical view of the model."""

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -48,6 +48,7 @@ from vllm.v1.kv_cache_interface import (
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.attention import MLAAttention
+    from vllm.model_executor.model_loader.reload import ReloadPlanBuilder
 
 logger = init_logger(__name__)
 
@@ -596,6 +597,25 @@ class Attention(nn.Module, AttentionLayerBase):
         s += f", scale={self.impl.scale}"  # type: ignore
         s += f", backend={self.impl.__class__.__name__}"
         return s
+
+    def build_reload_plan(
+        self,
+        builder: "ReloadPlanBuilder",
+        prefix: str,
+    ) -> None:
+        """Declare backend-owned tensors rebuilt after checkpoint loading."""
+        sinks = getattr(self.impl, "sinks", None)
+        if not isinstance(sinks, torch.Tensor):
+            return
+        node_name = f"{prefix}.attention_sinks" if prefix else "attention_sinks"
+        source = getattr(self.impl, "_reload_sinks_source", sinks)
+        builder.derived(
+            node_name,
+            owner=self.impl,
+            owner_key="attention_sinks",
+            outputs=("sinks",),
+            depends_on=builder.inputs_for_tensor(source),
+        )
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         self.impl.process_weights_after_loading(act_dtype)

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -191,7 +191,7 @@ import functools
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import ClassVar, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar, cast
 
 import torch
 import torch.nn as nn
@@ -278,6 +278,9 @@ from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
     MLAAttentionSpec,
 )
+
+if TYPE_CHECKING:
+    from vllm.model_executor.model_loader.reload import ReloadPlanBuilder
 
 logger = init_logger(__name__)
 
@@ -872,6 +875,23 @@ class MLAAttention(nn.Module, AttentionLayerBase):
 
         return output_padded
 
+    def build_reload_plan(self, builder: "ReloadPlanBuilder", prefix: str) -> None:
+        """Declare the graph-visible projection derived from ``kv_b_proj``."""
+        outputs: tuple[str, ...]
+        if self.is_aiter_triton_fp4_bmm_enabled or self.is_aiter_triton_fp8_bmm_enabled:
+            outputs = ("W_K", "W_K_scale", "W_V", "W_V_scale")
+        else:
+            outputs = ("W_UV", "W_UK_T")
+        node_name = f"{prefix}.mla_projection" if prefix else "mla_projection"
+        input_prefix = f"{prefix}.kv_b_proj" if prefix else "kv_b_proj"
+        builder.derived(
+            node_name,
+            owner=self,
+            owner_key="mla_projection",
+            outputs=outputs,
+            depends_on=builder.input_names(prefix=input_prefix),
+        )
+
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         # we currently do not have quantized bmm's which are needed for
         # `W_UV` and `W_UK_T`, we just store fp16/bf16 copies and perform
@@ -906,23 +926,33 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 quark_quantize_weight_to_mxfp4,
             )
 
-            self.W_K, self.W_K_scale = quark_quantize_weight_to_mxfp4(W_UK)
+            W_K, W_K_scale = quark_quantize_weight_to_mxfp4(W_UK)
             # Convert from (L, N, P) to (N, L, P)
-            self.W_K = self.W_K.transpose(0, 1)
-            self.W_K_scale = self.W_K_scale.transpose(0, 1)
+            W_K = W_K.transpose(0, 1)
+            W_K_scale = W_K_scale.transpose(0, 1)
 
-            self.W_V, self.W_V_scale = quark_quantize_weight_to_mxfp4(
-                W_UV.permute(1, 2, 0)
-            )
+            W_V, W_V_scale = quark_quantize_weight_to_mxfp4(W_UV.permute(1, 2, 0))
+            derived_values = {
+                "W_K": W_K,
+                "W_K_scale": W_K_scale,
+                "W_V": W_V,
+                "W_V_scale": W_V_scale,
+            }
         elif self.is_aiter_triton_fp8_bmm_enabled:
             W_K = W_UK.transpose(0, 1)  # 16 512 128
             W_V = W_UV.permute(1, 2, 0)  # 16 128 512
-            self.W_K, self.W_K_scale = dynamic_per_batched_tensor_quant(
+            W_K, W_K_scale = dynamic_per_batched_tensor_quant(
                 W_K, dtype=current_platform.fp8_dtype()
             )
-            self.W_V, self.W_V_scale = dynamic_per_batched_tensor_quant(
+            W_V, W_V_scale = dynamic_per_batched_tensor_quant(
                 W_V, dtype=current_platform.fp8_dtype()
             )
+            derived_values = {
+                "W_K": W_K,
+                "W_K_scale": W_K_scale,
+                "W_V": W_V,
+                "W_V_scale": W_V_scale,
+            }
 
             # The kernel operates on non-padded inputs. Hence, pre-compiling
             # triton kernel to avoid runtime compilation for unseen batch sizes
@@ -939,27 +969,37 @@ class MLAAttention(nn.Module, AttentionLayerBase):
 
             for m in pre_compilation_list:
                 x = torch.empty(
-                    (self.W_K.shape[0], m, self.W_K.shape[2]),
+                    (W_K.shape[0], m, W_K.shape[2]),
                     dtype=torch.bfloat16,
-                    device=self.W_K.device,
+                    device=W_K.device,
                 )
                 rocm_aiter_ops.triton_fp8_bmm(
-                    x, self.W_K, self.W_K_scale, group_size=128, transpose_bm=True
+                    x, W_K, W_K_scale, group_size=128, transpose_bm=True
                 )
 
                 x = torch.empty(
-                    (self.W_V.shape[0], m, self.W_V.shape[2]),
+                    (W_V.shape[0], m, W_V.shape[2]),
                     dtype=torch.bfloat16,
-                    device=self.W_V.device,
+                    device=W_V.device,
                 )
                 rocm_aiter_ops.triton_fp8_bmm(
-                    x, self.W_V, self.W_V_scale, group_size=128, transpose_bm=True
+                    x, W_V, W_V_scale, group_size=128, transpose_bm=True
                 )
         else:
             # Convert from (L, N, V) to (N, L, V)
-            self.W_UV = W_UV.transpose(0, 1)
+            runtime_w_uv = W_UV.transpose(0, 1)
             # Convert from (L, N, P) to (N, P, L)
-            self.W_UK_T = W_UK.permute(1, 2, 0)
+            runtime_w_uk_t = W_UK.permute(1, 2, 0)
+            derived_values = {
+                "W_UV": runtime_w_uv,
+                "W_UK_T": runtime_w_uk_t,
+            }
+
+        from vllm.model_executor.model_loader.reload import (
+            refresh_reload_derived,
+        )
+
+        refresh_reload_derived(self, "mla_projection", derived_values)
 
         # If we should not load quant weights, we initialize the scales to 1.0
         # as the default value. See [Note: Register q/k/v/prob scales in state dict]

--- a/vllm/model_executor/model_loader/reload/__init__.py
+++ b/vllm/model_executor/model_loader/reload/__init__.py
@@ -24,6 +24,20 @@ __all__ = [
     "finalize_layerwise_reload",
     "set_torchao_reload_attrs",
     "support_quantized_model_reload_from_hp_weights",
+    "ReloadCapability",
+    "ReloadCapabilityError",
+    "ReloadInputError",
+    "ReloadLifecycleError",
+    "ReloadPlan",
+    "ReloadPlanBuilder",
+    "ReloadPlanCompileError",
+    "ReloadStatePolicy",
+    "ReloadStatePolicyError",
+    "ReloadStorageIdentityError",
+    "ReloadTransaction",
+    "ReloadTransactionState",
+    "StaleDerivedSlotError",
+    "refresh_reload_derived",
 ]
 
 from .layerwise import (
@@ -31,6 +45,22 @@ from .layerwise import (
     finalize_layerwise_reload,
     initialize_layerwise_reload,
     record_metadata_for_reloading,
+)
+from .plan import (
+    ReloadCapability,
+    ReloadCapabilityError,
+    ReloadInputError,
+    ReloadLifecycleError,
+    ReloadPlan,
+    ReloadPlanBuilder,
+    ReloadPlanCompileError,
+    ReloadStatePolicy,
+    ReloadStatePolicyError,
+    ReloadStorageIdentityError,
+    ReloadTransaction,
+    ReloadTransactionState,
+    StaleDerivedSlotError,
+    refresh_reload_derived,
 )
 from .torchao_decorator import (
     set_torchao_reload_attrs,

--- a/vllm/model_executor/model_loader/reload/plan.py
+++ b/vllm/model_executor/model_loader/reload/plan.py
@@ -1,0 +1,833 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fail-closed model refit contract for weight reload."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Literal
+
+import torch
+
+TensorResolver = Callable[[], torch.Tensor | None]
+StateCallback = Callable[[], None]
+StateValidator = Callable[[], bool | None]
+DerivedCallback = Callable[[], Mapping[str, torch.Tensor]]
+
+_BINDINGS_ATTR = "_vllm_reload_plan_bindings"
+
+
+class ReloadCapability(Enum):
+    """The strongest reload mode certified by a plan."""
+
+    UNSUPPORTED = auto()
+    EAGER_ONLY = auto()
+    GRAPH_SAFE_V1 = auto()
+
+
+class ReloadStatePolicy(Enum):
+    """Required action for state that crosses model versions."""
+
+    REFRESH = auto()
+    INVALIDATE = auto()
+    PRESERVE = auto()
+
+
+class ReloadTransactionState(Enum):
+    LOADING = auto()
+    FINALIZING = auto()
+    VALIDATING = auto()
+    PREPARED = auto()
+    COMMITTED = auto()
+    FAILED = auto()
+
+
+class ReloadPlanError(RuntimeError):
+    """Base error for reload contract violations."""
+
+
+class ReloadPlanCompileError(ReloadPlanError):
+    """Raised when a reload plan is incomplete or inconsistent."""
+
+
+class ReloadCapabilityError(ReloadPlanError):
+    """Raised before mutation when a model is not graph-safe reloadable."""
+
+
+class ReloadLifecycleError(ReloadPlanError):
+    """Raised when transaction operations occur out of order."""
+
+
+class ReloadInputError(ReloadPlanError):
+    """Raised when reload input metadata violates its prototype."""
+
+
+class ReloadStorageIdentityError(ReloadPlanError):
+    """Raised when a stable tensor slot changes storage or layout."""
+
+
+class StaleDerivedSlotError(ReloadPlanError):
+    """Raised when a required derived node did not refresh."""
+
+
+class ReloadStatePolicyError(ReloadPlanError):
+    """Raised when reload-sensitive state does not satisfy its policy."""
+
+
+@dataclass(frozen=True)
+class TensorFingerprint:
+    """Storage and layout identity captured when the plan is sealed."""
+
+    storage_cdata: int
+    data_ptr: int
+    storage_nbytes: int
+    shape: tuple[int, ...]
+    stride: tuple[int, ...]
+    storage_offset: int
+    dtype: torch.dtype
+    device: torch.device
+
+    @classmethod
+    def from_tensor(cls, tensor: torch.Tensor) -> TensorFingerprint:
+        storage = tensor.untyped_storage()
+        return cls(
+            storage_cdata=storage._cdata,
+            data_ptr=tensor.data_ptr(),
+            storage_nbytes=storage.nbytes(),
+            shape=tuple(tensor.shape),
+            stride=tuple(tensor.stride()),
+            storage_offset=tensor.storage_offset(),
+            dtype=tensor.dtype,
+            device=tensor.device,
+        )
+
+
+@dataclass(frozen=True)
+class InputPrototype:
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+
+    @classmethod
+    def from_tensor(cls, tensor: torch.Tensor) -> InputPrototype:
+        return cls(shape=tuple(tensor.shape), dtype=tensor.dtype)
+
+
+@dataclass
+class _StableTensorSlot:
+    name: str
+    resolver: TensorResolver
+    tensor: torch.Tensor
+    fingerprint: TensorFingerprint
+    last_written_epoch: int = 0
+
+    def current(self) -> torch.Tensor:
+        tensor = self.resolver()
+        if tensor is None:
+            raise ReloadStorageIdentityError(
+                f"Stable reload slot {self.name!r} disappeared"
+            )
+        if not isinstance(tensor, torch.Tensor):
+            raise ReloadStorageIdentityError(
+                f"Stable reload slot {self.name!r} resolved to "
+                f"{type(tensor).__name__}, expected Tensor"
+            )
+        return tensor
+
+    def validate(self) -> None:
+        current = self.current()
+        actual = TensorFingerprint.from_tensor(current)
+        if actual != self.fingerprint:
+            raise ReloadStorageIdentityError(
+                f"Stable reload slot {self.name!r} changed storage or layout: "
+                f"expected={self.fingerprint}, actual={actual}"
+            )
+
+    def copy_from(self, value: torch.Tensor, epoch: int) -> None:
+        expected = self.fingerprint
+        if tuple(value.shape) != expected.shape:
+            raise ReloadInputError(
+                f"Reload value for {self.name!r} has shape {tuple(value.shape)}, "
+                f"expected {expected.shape}"
+            )
+        if value.dtype != expected.dtype:
+            raise ReloadInputError(
+                f"Reload value for {self.name!r} has dtype {value.dtype}, "
+                f"expected {expected.dtype}"
+            )
+        self.tensor.copy_(value)
+        self.last_written_epoch = epoch
+
+
+@dataclass(frozen=True)
+class _DirectInput:
+    name: str
+    prototype: InputPrototype
+    slot: _StableTensorSlot
+
+
+@dataclass
+class _DerivedNode:
+    name: str
+    owner: object
+    owner_key: str
+    depends_on: tuple[str, ...]
+    outputs: dict[str, _StableTensorSlot]
+    refresh: DerivedCallback | None
+    always_refresh: bool
+    last_executed_epoch: int = 0
+
+
+@dataclass
+class _StateNode:
+    name: str
+    policy: ReloadStatePolicy
+    action: StateCallback | None
+    validate: StateValidator | None
+    last_executed_epoch: int = 0
+
+
+@dataclass(frozen=True)
+class _DerivedBinding:
+    plan: ReloadPlan
+    node_name: str
+
+
+class ReloadPlanBuilder:
+    """Builds an immutable reload contract before the first mutation."""
+
+    def __init__(self) -> None:
+        self._slots: dict[str, _StableTensorSlot] = {}
+        self._inputs: dict[str, _DirectInput] = {}
+        self._derived: dict[str, _DerivedNode] = {}
+        self._states: dict[str, _StateNode] = {}
+        self._unsupported_reasons: list[str] = []
+        self._eager_only_reasons: list[str] = []
+        self._sealed = False
+
+    @classmethod
+    def from_model(
+        cls,
+        model: torch.nn.Module,
+        *,
+        prefix: str = "model",
+    ) -> ReloadPlanBuilder:
+        builder = cls()
+        builder.add_module_tensors(model, prefix=prefix)
+        for module_name, module in model.named_modules():
+            participant = getattr(module, "build_reload_plan", None)
+            if participant is None:
+                continue
+            full_name = _join_name(prefix, module_name)
+            participant(builder, full_name)
+        return builder
+
+    def add_module_tensors(
+        self,
+        module: torch.nn.Module,
+        *,
+        prefix: str = "model",
+    ) -> None:
+        self._ensure_mutable()
+        for name, tensor in module.named_parameters(remove_duplicate=False):
+            full_name = _join_name(prefix, name)
+            self.direct_input(
+                full_name,
+                tensor,
+                resolver=_module_parameter_resolver(module, name),
+            )
+        for name, tensor in module.named_buffers(remove_duplicate=False):
+            full_name = _join_name(prefix, name)
+            self.direct_input(
+                full_name,
+                tensor,
+                resolver=_module_buffer_resolver(module, name),
+            )
+
+    def direct_input(
+        self,
+        name: str,
+        tensor: torch.Tensor,
+        *,
+        resolver: TensorResolver,
+    ) -> None:
+        self._ensure_mutable()
+        slot = self._add_slot(name, tensor, resolver)
+        if name in self._inputs:
+            raise ReloadPlanCompileError(f"Reload input {name!r} is duplicated")
+        self._inputs[name] = _DirectInput(
+            name=name,
+            prototype=InputPrototype.from_tensor(tensor),
+            slot=slot,
+        )
+
+    def derived(
+        self,
+        name: str,
+        *,
+        owner: object,
+        owner_key: str,
+        outputs: Iterable[str],
+        depends_on: Iterable[str] = (),
+        refresh: DerivedCallback | None = None,
+        always_refresh: bool = True,
+    ) -> None:
+        self._ensure_mutable()
+        if name in self._derived:
+            raise ReloadPlanCompileError(f"Derived reload node {name!r} is duplicated")
+
+        output_slots: dict[str, _StableTensorSlot] = {}
+        for attr_name in outputs:
+            value = getattr(owner, attr_name, None)
+            if not isinstance(value, torch.Tensor):
+                raise ReloadPlanCompileError(
+                    f"Derived output {name}.{attr_name} is not a Tensor"
+                )
+            slot_name = f"{name}.{attr_name}"
+            output_slots[attr_name] = self._add_slot(
+                slot_name,
+                value,
+                resolver=_attribute_resolver(owner, attr_name),
+            )
+
+        self._derived[name] = _DerivedNode(
+            name=name,
+            owner=owner,
+            owner_key=owner_key,
+            depends_on=tuple(depends_on),
+            outputs=output_slots,
+            refresh=refresh,
+            always_refresh=always_refresh,
+        )
+
+    def input_names(self, *, prefix: str | None = None) -> tuple[str, ...]:
+        """Return declared input names, optionally limited to a module prefix."""
+        if prefix is None:
+            return tuple(self._inputs)
+        dotted_prefix = f"{prefix}." if prefix else ""
+        return tuple(
+            name
+            for name in self._inputs
+            if name == prefix or name.startswith(dotted_prefix)
+        )
+
+    def inputs_for_tensor(self, tensor: torch.Tensor) -> tuple[str, ...]:
+        """Return logical inputs that alias a participant's source tensor."""
+        return tuple(
+            name
+            for name, direct in self._inputs.items()
+            if _same_storage_and_layout(direct.slot.tensor, tensor)
+        )
+
+    def state(
+        self,
+        name: str,
+        *,
+        policy: ReloadStatePolicy,
+        action: StateCallback | None = None,
+        validate: StateValidator | None = None,
+    ) -> None:
+        self._ensure_mutable()
+        if name in self._states:
+            raise ReloadPlanCompileError(f"Reload state {name!r} is duplicated")
+        if policy in (ReloadStatePolicy.REFRESH, ReloadStatePolicy.INVALIDATE):
+            if action is None:
+                raise ReloadPlanCompileError(
+                    f"Reload state {name!r} with policy {policy.name} "
+                    "requires an action"
+                )
+        elif validate is None:
+            raise ReloadPlanCompileError(
+                f"Reload state {name!r} with policy PRESERVE requires a validator"
+            )
+        self._states[name] = _StateNode(
+            name=name,
+            policy=policy,
+            action=action,
+            validate=validate,
+        )
+
+    def unsupported(self, reason: str) -> None:
+        self._ensure_mutable()
+        if reason and reason not in self._unsupported_reasons:
+            self._unsupported_reasons.append(reason)
+
+    def eager_only(self, reason: str) -> None:
+        self._ensure_mutable()
+        if reason and reason not in self._eager_only_reasons:
+            self._eager_only_reasons.append(reason)
+
+    def seal(self) -> ReloadPlan:
+        self._ensure_mutable()
+        self._validate_dependencies()
+        self._sealed = True
+        plan = ReloadPlan(
+            slots=self._slots,
+            inputs=self._inputs,
+            derived=self._derived,
+            states=self._states,
+            unsupported_reasons=tuple(self._unsupported_reasons),
+            eager_only_reasons=tuple(self._eager_only_reasons),
+        )
+        plan._install_bindings()
+        return plan
+
+    def _add_slot(
+        self,
+        name: str,
+        tensor: torch.Tensor,
+        resolver: TensorResolver,
+    ) -> _StableTensorSlot:
+        if not name:
+            raise ReloadPlanCompileError("Reload slot name must not be empty")
+        if name in self._slots:
+            raise ReloadPlanCompileError(f"Stable reload slot {name!r} is duplicated")
+        current = resolver()
+        if current is None or not _same_storage_and_layout(current, tensor):
+            raise ReloadPlanCompileError(
+                f"Resolver for stable reload slot {name!r} does not resolve "
+                "to the declared tensor"
+            )
+        slot = _StableTensorSlot(
+            name=name,
+            resolver=resolver,
+            tensor=tensor,
+            fingerprint=TensorFingerprint.from_tensor(tensor),
+        )
+        self._slots[name] = slot
+        return slot
+
+    def _validate_dependencies(self) -> None:
+        known = set(self._inputs) | set(self._derived)
+        for node in self._derived.values():
+            missing = set(node.depends_on) - known
+            if missing:
+                raise ReloadPlanCompileError(
+                    f"Derived reload node {node.name!r} has unknown dependencies: "
+                    f"{sorted(missing)}"
+                )
+        _topological_order(self._derived)
+
+    def _ensure_mutable(self) -> None:
+        if self._sealed:
+            raise ReloadPlanCompileError("Reload plan builder is already sealed")
+
+
+class ReloadPlan:
+    """A sealed model refit plan shared by all reload transports."""
+
+    def __init__(
+        self,
+        *,
+        slots: dict[str, _StableTensorSlot],
+        inputs: dict[str, _DirectInput],
+        derived: dict[str, _DerivedNode],
+        states: dict[str, _StateNode],
+        unsupported_reasons: tuple[str, ...],
+        eager_only_reasons: tuple[str, ...],
+    ) -> None:
+        self._slots = dict(slots)
+        self._inputs = dict(inputs)
+        self._derived = dict(derived)
+        self._states = dict(states)
+        self._topological_order = _topological_order(self._derived)
+        self.unsupported_reasons = unsupported_reasons
+        self.eager_only_reasons = eager_only_reasons
+        if unsupported_reasons:
+            self.capability = ReloadCapability.UNSUPPORTED
+        elif eager_only_reasons:
+            self.capability = ReloadCapability.EAGER_ONLY
+        else:
+            self.capability = ReloadCapability.GRAPH_SAFE_V1
+        self.committed_epoch = 0
+        self._active: ReloadTransaction | None = None
+        self._failed = False
+
+    @property
+    def active_transaction(self) -> ReloadTransaction | None:
+        return self._active
+
+    def begin(
+        self,
+        *,
+        expected_inputs: Iterable[str] | None = None,
+        require_graph_safe: bool = True,
+    ) -> ReloadTransaction:
+        if self._failed:
+            raise ReloadLifecycleError(
+                "Reload plan is failed; fully reload or restart the worker"
+            )
+        if self._active is not None:
+            raise ReloadLifecycleError("A reload transaction is already active")
+        if self.capability is ReloadCapability.UNSUPPORTED:
+            reasons = "; ".join(self.unsupported_reasons)
+            raise ReloadCapabilityError(
+                f"The model does not support warm reload: {reasons}"
+            )
+        if require_graph_safe and self.capability is ReloadCapability.EAGER_ONLY:
+            reasons = "; ".join(self.eager_only_reasons)
+            raise ReloadCapabilityError(
+                "The model is not certified for warm reload with a live graph: "
+                f"{reasons}"
+            )
+        transaction = ReloadTransaction(
+            plan=self,
+            epoch=self.committed_epoch + 1,
+            expected_inputs=(
+                frozenset(expected_inputs) if expected_inputs is not None else None
+            ),
+        )
+        self._active = transaction
+        return transaction
+
+    def _install_bindings(self) -> None:
+        pending_keys: set[tuple[int, str]] = set()
+        for node in self._derived.values():
+            existing_bindings = node.owner.__dict__.get(_BINDINGS_ATTR, {})
+            key = (id(node.owner), node.owner_key)
+            if node.owner_key in existing_bindings or key in pending_keys:
+                raise ReloadPlanCompileError(
+                    f"Reload participant key {node.owner_key!r} is duplicated on "
+                    f"{type(node.owner).__name__}"
+                )
+            pending_keys.add(key)
+
+        for node in self._derived.values():
+            bindings: dict[str, _DerivedBinding] = node.owner.__dict__.setdefault(
+                _BINDINGS_ATTR, {}
+            )
+            bindings[node.owner_key] = _DerivedBinding(self, node.name)
+
+    def _refresh_derived(
+        self,
+        node_name: str,
+        values: Mapping[str, torch.Tensor],
+    ) -> None:
+        transaction = self._active
+        if transaction is None:
+            raise ReloadLifecycleError(
+                f"Derived node {node_name!r} refreshed outside a reload transaction"
+            )
+        transaction.refresh_derived(node_name, values)
+
+    def _commit(self, transaction: ReloadTransaction) -> None:
+        if self._active is not transaction:
+            raise ReloadLifecycleError("Cannot commit an inactive reload transaction")
+        self.committed_epoch = transaction.epoch
+        self._active = None
+
+    def _abort(self, transaction: ReloadTransaction) -> None:
+        if self._active is transaction:
+            self._active = None
+        self._failed = True
+
+
+class ReloadTransaction:
+    """One fail-closed application of a sealed reload plan."""
+
+    def __init__(
+        self,
+        *,
+        plan: ReloadPlan,
+        epoch: int,
+        expected_inputs: frozenset[str] | None,
+    ) -> None:
+        self.plan = plan
+        self.epoch = epoch
+        self.expected_inputs = expected_inputs
+        self.state = ReloadTransactionState.LOADING
+        self._written_inputs: set[str] = set()
+        self._required_nodes = self._compute_required_nodes()
+
+    def __enter__(self) -> ReloadTransaction:
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> Literal[False]:
+        if exc_value is not None:
+            self.abort()
+        elif self.state is not ReloadTransactionState.COMMITTED:
+            self.abort()
+            raise ReloadLifecycleError(
+                f"Reload transaction epoch {self.epoch} exited without commit"
+            )
+        return False
+
+    def record_input(
+        self,
+        name: str,
+        tensor: torch.Tensor | None = None,
+        *,
+        allow_unknown: bool = False,
+        allow_duplicate: bool = False,
+    ) -> None:
+        self._require_state(ReloadTransactionState.LOADING)
+        if name in self._written_inputs:
+            if allow_duplicate:
+                return
+            raise ReloadInputError(f"Reload input {name!r} was written twice")
+        direct = self.plan._inputs.get(name)
+        if direct is None:
+            if allow_unknown:
+                self._written_inputs.add(name)
+                return
+            raise ReloadInputError(f"Unknown reload input {name!r}")
+        if tensor is not None:
+            actual = InputPrototype.from_tensor(tensor)
+            if actual != direct.prototype:
+                raise ReloadInputError(
+                    f"Reload input {name!r} has prototype {actual}, "
+                    f"expected {direct.prototype}"
+                )
+        self._written_inputs.add(name)
+
+    @torch.no_grad()
+    def write(self, name: str, tensor: torch.Tensor) -> None:
+        self.record_input(name, tensor)
+        direct = self.plan._inputs[name]
+        direct.slot.copy_from(tensor, self.epoch)
+
+    def start_finalizing(self) -> None:
+        self._require_state(ReloadTransactionState.LOADING)
+        self.state = ReloadTransactionState.FINALIZING
+
+    @torch.no_grad()
+    def refresh_derived(
+        self,
+        node_name: str,
+        values: Mapping[str, torch.Tensor],
+    ) -> None:
+        if self.state not in (
+            ReloadTransactionState.LOADING,
+            ReloadTransactionState.FINALIZING,
+        ):
+            raise ReloadLifecycleError(
+                f"Cannot refresh derived node {node_name!r} while transaction "
+                f"is {self.state.name}"
+            )
+        node = self.plan._derived.get(node_name)
+        if node is None:
+            raise ReloadPlanCompileError(f"Unknown derived reload node {node_name!r}")
+        if node.last_executed_epoch == self.epoch:
+            raise ReloadLifecycleError(
+                f"Derived reload node {node_name!r} executed twice in epoch "
+                f"{self.epoch}"
+            )
+        if set(values) != set(node.outputs):
+            raise ReloadInputError(
+                f"Derived reload node {node_name!r} produced outputs "
+                f"{sorted(values)}, expected {sorted(node.outputs)}"
+            )
+        for output_name, slot in node.outputs.items():
+            slot.copy_from(values[output_name], self.epoch)
+            setattr(node.owner, output_name, slot.tensor)
+        node.last_executed_epoch = self.epoch
+
+    @torch.no_grad()
+    def prepare_or_raise(self) -> None:
+        if self.state is ReloadTransactionState.LOADING:
+            self.start_finalizing()
+        self._require_state(ReloadTransactionState.FINALIZING)
+        try:
+            self._run_derived_callbacks()
+            self._validate_inputs()
+            self._validate_derived_nodes()
+            self._run_state_nodes()
+            self.state = ReloadTransactionState.VALIDATING
+            for slot in self.plan._slots.values():
+                slot.validate()
+        except BaseException:
+            self.abort()
+            raise
+        self.state = ReloadTransactionState.PREPARED
+
+    def commit_prepared(self) -> None:
+        self._require_state(ReloadTransactionState.PREPARED)
+        self.state = ReloadTransactionState.COMMITTED
+        self.plan._commit(self)
+
+    def commit_or_raise(self) -> None:
+        self.prepare_or_raise()
+        self.commit_prepared()
+
+    def abort(self) -> None:
+        if self.state in (
+            ReloadTransactionState.COMMITTED,
+            ReloadTransactionState.FAILED,
+        ):
+            return
+        self.state = ReloadTransactionState.FAILED
+        self.plan._abort(self)
+
+    def _compute_required_nodes(self) -> set[str]:
+        if self.expected_inputs is None:
+            return {
+                node.name for node in self.plan._derived.values() if node.always_refresh
+            }
+        changed: set[str] = set(self.expected_inputs)
+        required: set[str] = set()
+        for node_name in self.plan._topological_order:
+            node = self.plan._derived[node_name]
+            if node.always_refresh or changed.intersection(node.depends_on):
+                required.add(node_name)
+                changed.add(node_name)
+        return required
+
+    def _run_derived_callbacks(self) -> None:
+        for node_name in self.plan._topological_order:
+            if node_name not in self._required_nodes:
+                continue
+            node = self.plan._derived[node_name]
+            if node.last_executed_epoch == self.epoch or node.refresh is None:
+                continue
+            self.refresh_derived(node_name, node.refresh())
+
+    def _validate_inputs(self) -> None:
+        if self.expected_inputs is None:
+            return
+        unknown = self.expected_inputs - self.plan._inputs.keys()
+        if unknown:
+            raise ReloadInputError(f"Unknown expected reload inputs: {sorted(unknown)}")
+        missing = set(self.expected_inputs - self._written_inputs)
+        for node_name in self._required_nodes:
+            node = self.plan._derived[node_name]
+            missing.update(
+                dependency
+                for dependency in node.depends_on
+                if dependency in self.plan._inputs
+                and dependency not in self._written_inputs
+            )
+        if missing:
+            raise ReloadInputError(f"Missing reload inputs: {sorted(missing)}")
+
+    def _validate_derived_nodes(self) -> None:
+        stale = [
+            node_name
+            for node_name in self._required_nodes
+            if self.plan._derived[node_name].last_executed_epoch != self.epoch
+        ]
+        if stale:
+            raise StaleDerivedSlotError(
+                f"Derived reload nodes were not refreshed in epoch {self.epoch}: "
+                f"{sorted(stale)}"
+            )
+
+    def _run_state_nodes(self) -> None:
+        for node in self.plan._states.values():
+            if node.action is not None:
+                node.action()
+            if node.validate is not None and node.validate() is False:
+                raise ReloadStatePolicyError(
+                    f"Reload state {node.name!r} failed {node.policy.name} validation"
+                )
+            node.last_executed_epoch = self.epoch
+
+    def _require_state(self, expected: ReloadTransactionState) -> None:
+        if self.state is not expected:
+            raise ReloadLifecycleError(
+                f"Reload transaction epoch {self.epoch} is {self.state.name}, "
+                f"expected {expected.name}"
+            )
+
+
+def refresh_reload_derived(
+    owner: object,
+    owner_key: str,
+    values: Mapping[str, torch.Tensor],
+) -> None:
+    """Publish newly derived values into stable plan-owned output slots.
+
+    Before a plan is sealed this performs the initial attribute binding. During
+    reload it writes into the original tensors and records the current epoch.
+    """
+    bindings: dict[str, _DerivedBinding] | None = getattr(owner, _BINDINGS_ATTR, None)
+    if bindings is None or owner_key not in bindings:
+        for name, tensor in values.items():
+            setattr(owner, name, tensor)
+        return
+    binding = bindings[owner_key]
+    binding.plan._refresh_derived(binding.node_name, values)
+
+
+def _attribute_resolver(owner: object, name: str) -> TensorResolver:
+    def resolve() -> torch.Tensor | None:
+        value = getattr(owner, name, None)
+        return value if isinstance(value, torch.Tensor) else None
+
+    return resolve
+
+
+def _module_parameter_resolver(module: torch.nn.Module, name: str) -> TensorResolver:
+    def resolve() -> torch.Tensor | None:
+        try:
+            return module.get_parameter(name)
+        except AttributeError:
+            return None
+
+    return resolve
+
+
+def _module_buffer_resolver(module: torch.nn.Module, name: str) -> TensorResolver:
+    def resolve() -> torch.Tensor | None:
+        try:
+            return module.get_buffer(name)
+        except AttributeError:
+            return None
+
+    return resolve
+
+
+def _same_storage_and_layout(left: torch.Tensor, right: torch.Tensor) -> bool:
+    return TensorFingerprint.from_tensor(left) == TensorFingerprint.from_tensor(right)
+
+
+def _join_name(prefix: str, name: str) -> str:
+    if prefix and name:
+        return f"{prefix}.{name}"
+    return prefix or name
+
+
+def _topological_order(nodes: Mapping[str, _DerivedNode]) -> tuple[str, ...]:
+    incoming = {
+        name: {dependency for dependency in node.depends_on if dependency in nodes}
+        for name, node in nodes.items()
+    }
+    ready = sorted(name for name, dependencies in incoming.items() if not dependencies)
+    order: list[str] = []
+    while ready:
+        name = ready.pop(0)
+        order.append(name)
+        for candidate, dependencies in incoming.items():
+            if name not in dependencies:
+                continue
+            dependencies.remove(name)
+            if not dependencies and candidate not in order and candidate not in ready:
+                ready.append(candidate)
+                ready.sort()
+    if len(order) != len(nodes):
+        cyclic = sorted(set(nodes) - set(order))
+        raise ReloadPlanCompileError(
+            f"Reload plan contains a derived dependency cycle: {cyclic}"
+        )
+    return tuple(order)
+
+
+__all__ = [
+    "InputPrototype",
+    "ReloadCapability",
+    "ReloadCapabilityError",
+    "ReloadInputError",
+    "ReloadLifecycleError",
+    "ReloadPlan",
+    "ReloadPlanBuilder",
+    "ReloadPlanCompileError",
+    "ReloadPlanError",
+    "ReloadStatePolicy",
+    "ReloadStatePolicyError",
+    "ReloadStorageIdentityError",
+    "ReloadTransaction",
+    "ReloadTransactionState",
+    "StaleDerivedSlotError",
+    "TensorFingerprint",
+    "refresh_reload_derived",
+]

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1580,8 +1580,18 @@ class FlashInferImpl(AttentionImpl):
 
     # FlashInfer requires attention sinks to be float32
     def process_weights_after_loading(self, act_dtype: torch.dtype):
-        if self.sinks is not None and self.sinks.dtype != torch.float32:
-            self.sinks = self.sinks.to(torch.float32)
+        source = getattr(self, "_reload_sinks_source", self.sinks)
+        if source is None:
+            return
+        self._reload_sinks_source = source
+        sinks = source.to(torch.float32)
+        from vllm.model_executor.model_loader.reload import refresh_reload_derived
+
+        refresh_reload_derived(
+            self,
+            "attention_sinks",
+            {"sinks": sinks},
+        )
 
     def get_xqa_bmm1_scale(self, layer: torch.nn.Module, q_data_type: torch.dtype):
         bmm1_scale = self.scale

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -1108,5 +1108,20 @@ class AsyncLLM(EngineClient):
         )
 
     async def finish_weight_update(self) -> None:
-        """Finish the current weight update."""
-        await self.collective_rpc("finish_weight_update")
+        """Atomically publish a weight update after every worker validates it."""
+        try:
+            await self.collective_rpc("prepare_weight_update")
+        except BaseException:
+            try:
+                await self.collective_rpc("abort_weight_update")
+            except BaseException:
+                logger.exception("Failed to abort weight update on every worker")
+            raise
+        try:
+            await self.collective_rpc("commit_weight_update")
+        except BaseException:
+            try:
+                await self.collective_rpc("abort_weight_update")
+            except BaseException:
+                logger.exception("Failed to abort weight update on every worker")
+            raise

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -112,6 +112,7 @@ from vllm.v1.worker.gpu.spec_decode.utils import DraftTokensHandler
 from vllm.v1.worker.gpu.states import RequestState
 from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
+from vllm.v1.worker.reload_coordinator import ReloadCoordinator
 from vllm.v1.worker.utils import KVBlockZeroer, copy_kv_cache_blocks_inplace
 
 logger = init_logger(__name__)
@@ -237,6 +238,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.prompt_logprobs_worker: PromptLogprobsWorker | None = None
         self.structured_outputs_worker: StructuredOutputsWorker | None = None
         self.cudagraph_manager: ModelCudaGraphManager | None = None
+        self.reload_coordinator = ReloadCoordinator(self)
 
         # LoRA-related workers.
         self.lora_state = LoraState(max_num_reqs=self.max_num_reqs)
@@ -368,6 +370,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 device=self.device,
             )
 
+        # Seal the refit contract before compilation or CUDA graph capture.
+        self.reload_coordinator.plan_for(self.model, self.model_config)
+        if (draft_model := self.get_draft_model()) is not None:
+            assert self.speculative_config is not None
+            draft_config = self.speculative_config.draft_model_config
+            assert draft_config is not None
+            self.reload_coordinator.plan_for(draft_model, draft_config)
+
     def get_model(self) -> nn.Module:
         return self.model
 
@@ -378,10 +388,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         return speculator.model
 
     def reload_weights(self, *args, **kwargs) -> None:
-        # TODO(Wentao): Use full version instead of import when fully migrated to v2
-        from vllm.v1.worker.gpu_model_runner import GPUModelRunner as GPUModelRunnerV1
-
-        GPUModelRunnerV1.reload_weights(self, *args, **kwargs)  # type: ignore[arg-type]
+        self.reload_coordinator.reload_weights(*args, **kwargs)
 
     def update_config(self, *args, **kwargs) -> None:
         # TODO(Wentao): Use full version instead of import when fully migrated to v2

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1206,6 +1206,13 @@ class Worker(WorkerBase):
         typed_init_info = self.weight_transfer_engine.parse_init_info(init_info)
         self.weight_transfer_engine.init_transfer_engine(typed_init_info)
 
+    def _get_reload_coordinator(self) -> Any:
+        if not self.use_v2_model_runner:
+            raise NotImplementedError(
+                "Sealed weight reload transactions require the v2 model runner"
+            )
+        return self.model_runner.reload_coordinator  # type: ignore[attr-defined]
+
     def start_weight_update(self) -> None:
         """
         Start a new weight update session.
@@ -1239,11 +1246,17 @@ class Worker(WorkerBase):
                 "active. Call finish_weight_update first."
             )
 
+        coordinator = self._get_reload_coordinator()
         try:
             if is_draft:
                 self._set_draft_weight_update_target()
+            coordinator.begin(
+                self.weight_transfer_engine.model,
+                self.weight_transfer_engine.model_config,
+            )
             self.weight_transfer_engine.start_weight_update()
         except BaseException:
+            coordinator.abort()
             self.weight_transfer_engine.reset_weight_update_target()
             raise
         self._weight_update_active = True
@@ -1268,15 +1281,27 @@ class Worker(WorkerBase):
                 "start_weight_update must be called before update_weights."
             )
 
+        coordinator = self._get_reload_coordinator()
         try:
+            coordinator.record_inputs(update_info)
             self.weight_transfer_engine.update_weights(update_info)
         except BaseException:
+            coordinator.abort()
             self._weight_update_active = False
             self.weight_transfer_engine.reset_weight_update_target()
             raise
 
     def finish_weight_update(self) -> None:
-        """Finish the current weight update session."""
+        """Prepare and commit one local weight update session."""
+        try:
+            self.prepare_weight_update()
+            self.commit_weight_update()
+        except BaseException:
+            self._get_reload_coordinator().abort()
+            raise
+
+    def prepare_weight_update(self) -> None:
+        """Finalize backend transforms and validate without publishing an epoch."""
         self._check_weight_transfer_engine()
         assert self.weight_transfer_engine is not None
 
@@ -1285,7 +1310,34 @@ class Worker(WorkerBase):
                 "finish_weight_update called without a matching start_weight_update."
             )
 
-        self.weight_transfer_engine.finish_weight_update()
+        coordinator = self._get_reload_coordinator()
+        try:
+            coordinator.start_finalizing()
+            self.weight_transfer_engine.finish_weight_update()
+            coordinator.prepare()
+        except BaseException:
+            coordinator.abort()
+            raise
+
+    def commit_weight_update(self) -> None:
+        """Publish a weight update after every worker prepared successfully."""
+        self._check_weight_transfer_engine()
+        assert self.weight_transfer_engine is not None
+        if not self._weight_update_active:
+            raise RuntimeError(
+                "commit_weight_update called without a prepared weight update."
+            )
+        coordinator = self._get_reload_coordinator()
+        coordinator.commit()
+        self.weight_transfer_engine.reset_weight_update_target()
+        self._weight_update_active = False
+
+    def abort_weight_update(self) -> None:
+        """Fail a prepared distributed update and release its transport target."""
+        self._check_weight_transfer_engine()
+        assert self.weight_transfer_engine is not None
+        coordinator = self._get_reload_coordinator()
+        coordinator.abort()
         self.weight_transfer_engine.reset_weight_update_target()
         self._weight_update_active = False
 

--- a/vllm/v1/worker/reload_coordinator.py
+++ b/vllm/v1/worker/reload_coordinator.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""V2 model-runner owner for sealed weight-reload transactions."""
+
+import time
+from collections.abc import Iterable
+from typing import Any, Protocol, cast
+
+import torch
+
+from vllm.config import CompilationMode, CUDAGraphMode
+from vllm.logger import init_logger
+from vllm.model_executor.model_loader import get_model_loader
+from vllm.model_executor.model_loader.reload import (
+    ReloadPlan,
+    ReloadPlanBuilder,
+    ReloadStatePolicy,
+    ReloadTransaction,
+    ReloadTransactionState,
+    finalize_layerwise_reload,
+    initialize_layerwise_reload,
+)
+
+logger = init_logger(__name__)
+
+
+class ReloadCoordinatorOwner(Protocol):
+    model_config: Any
+    compilation_config: Any
+    load_config: Any
+
+    def get_model(self) -> torch.nn.Module: ...
+
+    def reset_encoder_cache(self) -> None: ...
+
+    def reset_mm_cache(self) -> None: ...
+
+
+class ReloadCoordinator:
+    """Own all refit plans and the single active reload transaction."""
+
+    def __init__(self, owner: ReloadCoordinatorOwner) -> None:
+        self.owner = owner
+        self._plans: dict[int, ReloadPlan] = {}
+        self._active: ReloadTransaction | None = None
+
+    def plan_for(
+        self,
+        model: torch.nn.Module | None = None,
+        model_config: Any | None = None,
+    ) -> ReloadPlan:
+        model = model or self.owner.get_model()
+        key = id(model)
+        if plan := self._plans.get(key):
+            return plan
+
+        builder = ReloadPlanBuilder.from_model(model, prefix="")
+        config = model_config or self.owner.model_config
+        if config.quantization is not None:
+            builder.unsupported(
+                f"quantization backend {config.quantization!r} has not declared "
+                "a complete reload plan"
+            )
+        builder.state(
+            "encoder_cache",
+            policy=ReloadStatePolicy.INVALIDATE,
+            action=self.owner.reset_encoder_cache,
+        )
+        builder.state(
+            "multimodal_cache",
+            policy=ReloadStatePolicy.INVALIDATE,
+            action=self.owner.reset_mm_cache,
+        )
+        plan = builder.seal()
+        self._plans[key] = plan
+        return plan
+
+    def begin(
+        self,
+        model: torch.nn.Module | None = None,
+        model_config: Any | None = None,
+        expected_inputs: Iterable[str] | None = None,
+    ) -> ReloadTransaction:
+        if self._active is not None:
+            raise RuntimeError("A model reload transaction is already active")
+        plan = self.plan_for(model, model_config)
+        config = self.owner.compilation_config
+        require_graph_safe = (
+            config.mode == CompilationMode.STOCK_TORCH_COMPILE
+            or config.cudagraph_mode != CUDAGraphMode.NONE
+        )
+        self._active = plan.begin(
+            expected_inputs=expected_inputs,
+            require_graph_safe=require_graph_safe,
+        )
+        return self._active
+
+    def record_inputs(self, update_info: dict[str, Any]) -> None:
+        transaction = self._require_active()
+        for name in update_info.get("names", ()):
+            transaction.record_input(
+                name,
+                allow_unknown=True,
+                allow_duplicate=True,
+            )
+
+    def start_finalizing(self) -> None:
+        self._require_active().start_finalizing()
+
+    def prepare(self) -> None:
+        self._require_active().prepare_or_raise()
+
+    def commit(self) -> None:
+        transaction = self._require_active()
+        try:
+            transaction.commit_prepared()
+        finally:
+            if transaction.state in (
+                ReloadTransactionState.COMMITTED,
+                ReloadTransactionState.FAILED,
+            ):
+                self._active = None
+
+    def abort(self) -> None:
+        if self._active is not None:
+            self._active.abort()
+            self._active = None
+
+    def _clear_active(self) -> None:
+        """Clear a transaction already committed through its direct API."""
+        self._active = None
+
+    def reload_weights(
+        self,
+        weights_iterator: Iterable[tuple[str, torch.Tensor]] | None = None,
+        weights_path: str | None = None,
+        is_checkpoint_format: bool = True,
+    ) -> None:
+        """Reload the v2 model through the same sealed transaction as WTE."""
+        if weights_iterator is None and not is_checkpoint_format:
+            logger.warning(
+                "Reloading from disk means that weights are in checkpoint format. "
+                "Set `is_checkpoint_format=True` to avoid loading errors."
+            )
+
+        model = self.owner.get_model()
+        weights_to_load = {name for name, _ in model.named_parameters()}
+        started_at = time.perf_counter()
+
+        if weights_iterator is None:
+            model_loader = get_model_loader(self.owner.load_config)
+            if not hasattr(model_loader, "get_all_weights"):
+                raise NotImplementedError(
+                    f"Model reloading with `{self.owner.load_config.load_format}` "
+                    "format is not supported"
+                )
+            if weights_path is not None:
+                self.owner.model_config.model = weights_path
+            weights_iterator = cast(
+                Iterable[tuple[str, torch.Tensor]],
+                model_loader.get_all_weights(self.owner.model_config, model),
+            )
+
+        expected_inputs = (
+            weights_to_load if self.owner.model_config.quantization is None else None
+        )
+        transaction = self.begin(
+            model,
+            self.owner.model_config,
+            expected_inputs=expected_inputs,
+        )
+        try:
+            logger.info_once("Reloading weights inplace...")
+            if is_checkpoint_format:
+                initialize_layerwise_reload(model)
+                loaded_weights = model.load_weights(weights_iterator)
+                if expected_inputs is not None:
+                    for name in loaded_weights:
+                        transaction.record_input(name)
+                transaction.start_finalizing()
+                finalize_layerwise_reload(model, self.owner.model_config)
+            else:
+                loaded_weights = set()
+                for name, loaded_weight in weights_iterator:
+                    transaction.write(name, loaded_weight)
+                    loaded_weights.add(name)
+
+            transaction.commit_or_raise()
+            self._clear_active()
+        except BaseException:
+            transaction.abort()
+            self._clear_active()
+            raise
+
+        logger.info_once(
+            "Reloading and processing weights took %.2f seconds",
+            time.perf_counter() - started_at,
+        )
+        if self.owner.model_config.quantization is None:
+            weights_not_loaded = weights_to_load - loaded_weights
+            if weights_not_loaded:
+                logger.warning(
+                    "Following weights were not loaded from checkpoint: %s",
+                    weights_not_loaded,
+                )
+
+    def _require_active(self) -> ReloadTransaction:
+        if self._active is None:
+            raise RuntimeError("No model reload transaction is active")
+        return self._active
+
+
+__all__ = ["ReloadCoordinator", "ReloadCoordinatorOwner"]


### PR DESCRIPTION
## Summary

Add a sealed, fail-closed weight-reload contract for Model Runner V2.

The implementation compiles a `ReloadPlan` before graph capture, executes every
reload through one `ReloadTransaction`, preserves graph-visible tensor storage,
tracks derived-tensor freshness by epoch, applies explicit runtime-state
policies, and publishes a new model epoch only after every worker prepares
successfully.

This PR also adds the design document in
`docs/design/graph_safe_weight_reload.md`.

Related: #48312, #48478, #48251.

## Root cause

Weight reload is currently treated primarily as a parameter-copy operation,
but attention and quantization backends create additional runtime tensors during
post-load processing. CUDA/HIP graphs retain the addresses used during capture.
Rebinding a derived tensor updates Python state while graph replay continues to
read the old storage. Address stability alone also cannot prove that derived
values and model-version-dependent caches were refreshed.

The missing abstraction is a model-level refit contract describing direct
inputs, stable runtime slots, derived dependencies, state policy, lifecycle,
and commit semantics.

## Changes

- Add `ReloadPlan`, `ReloadPlanBuilder`, and `ReloadTransaction`.
- Validate storage identity and layout with a strong storage fingerprint.
- Require affected derived nodes to refresh in the active reload epoch.
- Add `REFRESH`, `INVALIDATE`, and `PRESERVE` runtime-state policies.
- Add `GRAPH_SAFE_V1`, `EAGER_ONLY`, and `UNSUPPORTED` capability gates.
- Add a Model Runner V2 `ReloadCoordinator`; Model Runner V1 is intentionally
  outside the contract.
- Use prepare/commit collective RPCs so no worker publishes its epoch before
  all workers validate successfully.
- Migrate MLA runtime projections and FlashInfer FP32 attention sinks to stable
  derived slots.
- Reject undeclared quantization backends before the first weight mutation.
- Add CPU contract, V2 coordinator, Worker lifecycle, distributed commit, and
  FlashInfer sink tests.

## Duplicate-work check

This is not a duplicate of #48539, which repairs one Machete act-order storage
site. It is also not a duplicate of #48382, which optimizes direct
layout-preserving reload. This PR adds the model-level completeness, freshness,
state, capability, and distributed commit contract that those site-specific or
transport changes do not provide.

## Validation

Passed locally:

```text
.venv/bin/pre-commit run
.venv/bin/pre-commit run --hook-stage manual mypy-3.12 --files <changed Python files>
.venv/bin/pytest tests/model_executor/model_loader/test_reload_plan.py
.venv/bin/pytest tests/v1/worker/test_reload_coordinator.py
.venv/bin/pytest tests/v1/worker/test_gpu_worker_weight_transfer.py
.venv/bin/pytest tests/v1/engine/test_weight_update_commit.py
```

The checks include Ruff, Markdown lint, SPDX validation, mypy for Python 3.10
and 3.12, and the targeted CPU test suites.

Model/GPU evaluation has not been run in this workspace. Before this draft is
marked ready, the submitter must run capture-once/reload/replay differential
logit tests on the hardware/backend matrix described in the design document.

## Contribution disclosure

AI assistance was used to research, design, implement, and test this draft.
The human submitter must review every changed line, understand the contract and
failure semantics end-to-end, and run the required GPU model evaluations before
requesting review.

