### PR TITLE
[Bugfix] Initialize MiniMax M3 reasoning from prompt mode

### DIFF
--- a/tests/reasoning/test_minimax_m3_reasoning_parser.py
+++ b/tests/reasoning/test_minimax_m3_reasoning_parser.py
@@ -3,12 +3,17 @@
 
 import string
 from collections.abc import Sequence
+from unittest.mock import Mock
 
 import pytest
 
+from vllm.config import VllmConfig
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.parser.abstract_parser import DelegatingParser
 from vllm.reasoning import ReasoningParserManager
 from vllm.reasoning.minimax_m3_reasoning_parser import MiniMaxM3ReasoningParser
+from vllm.v1.request import Request
+from vllm.v1.structured_output import StructuredOutputManager
 
 pytestmark = pytest.mark.skip_global_cleanup
 
@@ -95,6 +100,10 @@ class RuntimeSplitMiniMaxM3Tokenizer(MiniMaxM3Tokenizer):
 
     def encode_runtime(self, text: str) -> list[int]:
         return [self._add_token(token) for token in list(text)]
+
+
+class MiniMaxM3DelegatingParser(DelegatingParser):
+    reasoning_parser_cls = MiniMaxM3ReasoningParser
 
 
 def make_parser(
@@ -231,6 +240,52 @@ def test_streaming_reasoning_tags_are_not_returned():
     assert reasoning == "plan"
     assert content == "answer"
     assert end_states == [False, False, True, True]
+
+
+@pytest.mark.parametrize(
+    ("thinking_mode", "prompt_suffix", "chunks", "expected_reasoning"),
+    [
+        (
+            "adaptive",
+            "",
+            ["<mm:think>", "plan", "</mm:think>", "answer"],
+            "plan",
+        ),
+        ("adaptive", "", ["answer"], ""),
+        ("enabled", "<mm:think>", ["plan", "</mm:think>", "answer"], "plan"),
+        ("disabled", "</mm:think>", ["answer"], ""),
+    ],
+)
+def test_streaming_prompt_instructions_respect_thinking_mode(
+    thinking_mode, prompt_suffix, chunks, expected_reasoning
+):
+    tokenizer = MiniMaxM3Tokenizer()
+    parser = MiniMaxM3DelegatingParser(
+        tokenizer, chat_template_kwargs={"thinking_mode": thinking_mode}
+    )
+    request = ChatCompletionRequest(messages=[], model="test-model")
+    prompt_token_ids = tokenizer.encode(
+        "When thinking is enabled, wrap reasoning in "
+        f"<mm:think></mm:think> tags.\nai\n{prompt_suffix}"
+    )
+    reasoning_parts: list[str] = []
+    content_parts: list[str] = []
+
+    for index, chunk in enumerate(chunks):
+        delta = parser.parse_delta(
+            chunk,
+            tokenizer.encode(chunk),
+            request,
+            prompt_token_ids=prompt_token_ids if index == 0 else None,
+            finished=index == len(chunks) - 1,
+        )
+        if delta is not None and delta.reasoning is not None:
+            reasoning_parts.append(delta.reasoning)
+        if delta is not None and delta.content is not None:
+            content_parts.append(delta.content)
+
+    assert "".join(reasoning_parts) == expected_reasoning
+    assert "".join(content_parts) == "answer"
 
 
 def test_streaming_boundary_can_emit_reasoning_and_content():
@@ -459,3 +514,136 @@ def test_token_id_helpers_enabled_mode():
     assert parser.count_reasoning_tokens(open_reasoning_ids) == len(
         tokenizer.encode("abc")
     )
+
+
+@pytest.mark.parametrize(
+    ("thinking_mode", "expected"),
+    [
+        (None, None),
+        ("adaptive", None),
+        ("enabled", False),
+        ("disabled", True),
+    ],
+)
+def test_prompt_reasoning_state_follows_thinking_mode(thinking_mode, expected):
+    chat_template_kwargs = (
+        None if thinking_mode is None else {"thinking_mode": thinking_mode}
+    )
+    parser, tokenizer = make_parser(chat_template_kwargs=chat_template_kwargs)
+    prompt_token_ids = tokenizer.encode(
+        "Instructions may contain <mm:think></mm:think> examples.\nai\n"
+    )
+
+    assert parser.is_reasoning_end_from_prompt(prompt_token_ids) is expected
+
+
+def make_structured_output_manager(
+    tokenizer: MiniMaxM3Tokenizer,
+) -> StructuredOutputManager:
+    config = Mock(spec=VllmConfig)
+    config.model_config.skip_tokenizer_init = True
+    config.scheduler_config.max_num_seqs = 1
+    config.structured_outputs_config.enable_in_reasoning = False
+    config.speculative_config = None
+    manager = StructuredOutputManager(config)
+    manager.reasoner_cls = MiniMaxM3ReasoningParser
+    manager.tokenizer = tokenizer
+    return manager
+
+
+def make_structured_output_request(
+    tokenizer: MiniMaxM3Tokenizer, thinking_mode: str = "adaptive"
+) -> Mock:
+    request = Mock(spec=Request)
+    request.request_id = "test-request"
+    request.use_structured_output = True
+    request.prompt_token_ids = tokenizer.encode(
+        "Instructions contain <mm:think></mm:think> examples.\nai\n"
+    )
+    request.num_prompt_tokens = len(request.prompt_token_ids)
+    request.all_token_ids = list(request.prompt_token_ids)
+    request.num_computed_tokens = len(request.prompt_token_ids)
+    request.num_output_placeholders = 0
+    structured_request = Mock()
+    structured_request.reasoning_ended = None
+    structured_request.reasoning_end_token_index = None
+    structured_request.deferred_grammar_start_index = None
+    structured_request.reasoning_parser_kwargs = {
+        "chat_template_kwargs": {"thinking_mode": thinking_mode}
+    }
+    structured_request.reasoner = None
+    request.structured_output_request = structured_request
+    return request
+
+
+def append_structured_output_step(request: Mock, token_ids: list[int]) -> None:
+    request.num_computed_tokens = len(request.all_token_ids)
+    request.all_token_ids.extend(token_ids)
+
+
+def test_adaptive_structured_output_advances_direct_content():
+    tokenizer = MiniMaxM3Tokenizer()
+    manager = make_structured_output_manager(tokenizer)
+    request = make_structured_output_request(tokenizer)
+
+    assert manager.should_fill_bitmask(request) is False
+    assert request.structured_output_request.reasoning_ended is None
+
+    content_ids = tokenizer.encode("{")
+    append_structured_output_step(request, content_ids)
+
+    assert manager.should_advance(request) is True
+    assert request.structured_output_request.reasoning_ended is True
+    assert manager.trim_reasoning_for_advance(request, content_ids) == content_ids
+
+
+def test_adaptive_structured_output_replays_ambiguous_direct_prefix():
+    tokenizer = RuntimeSplitMiniMaxM3Tokenizer()
+    manager = make_structured_output_manager(tokenizer)
+    request = make_structured_output_request(tokenizer)
+
+    prefix_ids = tokenizer.encode_runtime("<m")
+    append_structured_output_step(request, prefix_ids)
+
+    assert manager.should_advance(request) is False
+    assert request.structured_output_request.reasoning_ended is None
+
+    content_ids = tokenizer.encode_runtime("X")
+    append_structured_output_step(request, content_ids)
+
+    assert manager.should_advance(request) is True
+    advance_ids = manager.trim_reasoning_for_advance(request, content_ids)
+    assert tokenizer.decode(advance_ids) == "<mX"
+
+
+def test_adaptive_structured_output_tracks_split_reasoning_markers():
+    tokenizer = RuntimeSplitMiniMaxM3Tokenizer()
+    manager = make_structured_output_manager(tokenizer)
+    request = make_structured_output_request(tokenizer)
+
+    append_structured_output_step(request, tokenizer.encode_runtime("<mm:"))
+    assert manager.should_advance(request) is False
+    assert request.structured_output_request.reasoning_ended is None
+
+    append_structured_output_step(request, tokenizer.encode_runtime("think>"))
+    assert manager.should_advance(request) is False
+    assert request.structured_output_request.reasoning_ended is None
+
+    append_structured_output_step(request, tokenizer.encode_runtime("plan</mm:think>"))
+    assert manager.should_advance(request) is False
+    assert request.structured_output_request.reasoning_ended is True
+
+
+def test_adaptive_structured_output_skips_prompt_embed_placeholders():
+    tokenizer = MiniMaxM3Tokenizer()
+    manager = make_structured_output_manager(tokenizer)
+    request = make_structured_output_request(tokenizer)
+    request.prompt_token_ids = None
+    request.num_prompt_tokens = 3
+    request.all_token_ids = [0] * request.num_prompt_tokens
+
+    content_ids = tokenizer.encode("{")
+    append_structured_output_step(request, content_ids)
+
+    assert manager.should_advance(request) is True
+    assert manager.trim_reasoning_for_advance(request, content_ids) == content_ids

--- a/tests/tool_parsers/test_minimax_m3_tool_parser.py
+++ b/tests/tool_parsers/test_minimax_m3_tool_parser.py
@@ -2,15 +2,19 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import json
+from collections.abc import Sequence
 from typing import Any
 
 import pytest
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
     ChatCompletionToolsParam,
     FunctionDefinition,
 )
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+from vllm.parser.abstract_parser import DelegatingParser
+from vllm.reasoning.minimax_m3_reasoning_parser import MiniMaxM3ReasoningParser
 from vllm.tool_parsers import ToolParserManager
 from vllm.tool_parsers.minimax_m3_tool_parser import MinimaxM3ToolParser
 
@@ -33,6 +37,37 @@ class FakeTokenizer:
 
     def get_vocab(self) -> dict[str, int]:
         return self.vocab
+
+
+class CombinedTokenizer(FakeTokenizer):
+    """Tokenizer used to exercise the combined reasoning/tool parser."""
+
+    def __init__(self):
+        super().__init__()
+        self.vocab = {"<mm:think>": 1, "</mm:think>": 2}
+        self._id_to_token = {token_id: token for token, token_id in self.vocab.items()}
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        if text in self.vocab:
+            return [self.vocab[text]]
+        token_ids = []
+        for char in text:
+            if char not in self.vocab:
+                token_id = len(self.vocab) + 1
+                self.vocab[char] = token_id
+                self._id_to_token[token_id] = char
+            token_ids.append(self.vocab[char])
+        return token_ids
+
+    def decode(
+        self, token_ids: Sequence[int], skip_special_tokens: bool = False
+    ) -> str:
+        return "".join(self._id_to_token[token_id] for token_id in token_ids)
+
+
+class CombinedMiniMaxM3Parser(DelegatingParser):
+    reasoning_parser_cls = MiniMaxM3ReasoningParser
+    tool_parser_cls = MinimaxM3ToolParser
 
 
 def sample_tools() -> list[ChatCompletionToolsParam]:
@@ -263,3 +298,53 @@ def test_streaming_nested_tool_call(parser):
     )
     assert json.loads(parser.prev_tool_call_arr[0]["arguments"])["items"][1]["qty"] == 5
     assert results[-1].content is None
+
+
+def test_combined_streaming_parser_keeps_reasoning_tags_out_of_tool_calls():
+    tokenizer = CombinedTokenizer()
+    tools = sample_tools()
+    parser = CombinedMiniMaxM3Parser(
+        tokenizer,
+        tools=tools,
+        chat_template_kwargs={"thinking_mode": "adaptive"},
+    )
+    request = ChatCompletionRequest(
+        messages=[],
+        model="test-model",
+        tools=tools,
+        tool_choice="auto",
+        include_reasoning=True,
+    )
+    prompt_token_ids = tokenizer.encode(
+        "Instructions contain <mm:think></mm:think> examples.\nai\n"
+    )
+    tool_call = build_order_call()
+    chunks = [
+        "<mm:think>",
+        "plan",
+        "</mm:think>",
+        tool_call[:17],
+        tool_call[17:120],
+        tool_call[120:],
+        "",
+    ]
+    results = []
+
+    for index, chunk in enumerate(chunks):
+        token_ids = [EOS_ID] if not chunk else tokenizer.encode(chunk)
+        delta = parser.parse_delta(
+            chunk,
+            token_ids,
+            request,
+            prompt_token_ids,
+            finished=index == len(chunks) - 1,
+        )
+        if delta is not None:
+            results.append(delta)
+
+    assert "".join(result.reasoning or "" for result in results) == "plan"
+    assert _collect_content(results) == ""
+    tool_calls = _collect_tool_calls(results)
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["name"] == "create_order"
+    assert json.loads(tool_calls[0]["arguments"])["user_id"] == 42

--- a/tests/v1/spec_decode/test_mtp_structured_output.py
+++ b/tests/v1/spec_decode/test_mtp_structured_output.py
@@ -274,6 +274,10 @@ class _MarkerReasoner:
     def is_reasoning_end_streaming(self, input_ids, delta_ids):
         return self.marker in list(delta_ids)
 
+    def extract_content_ids(self, input_ids):
+        marker_index = len(input_ids) - 1 - input_ids[::-1].index(self.marker)
+        return input_ids[marker_index + 1 :]
+
 
 def _setup_boundary_request(backend: str):
     """Request with a structural-tag key and reasoning not yet ended."""

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -16,7 +16,9 @@ from vllm.v1.structured_output.backend_types import StructuredOutputOptions
 class MockReasoner:
     def __init__(self, tokenizer):
         self.is_reasoning_end = Mock(return_value=False)
+        self.is_reasoning_end_from_prompt = Mock(return_value=False)
         self.is_reasoning_end_streaming = Mock(return_value=False)
+        self.extract_content_ids = Mock(return_value=[])
 
 
 class TestReasoningStructuredOutput:
@@ -62,6 +64,7 @@ class TestReasoningStructuredOutput:
         request = Mock(spec=Request)
         request.structured_output_request = Mock()
         request.structured_output_request.reasoning_ended = None
+        request.structured_output_request.deferred_grammar_start_index = None
         request.structured_output_request.grammar = Mock()
         request.structured_output_request.reasoning_parser_kwargs = None
         request.structured_output_request.reasoner = None
@@ -70,6 +73,7 @@ class TestReasoningStructuredOutput:
         )
         request.use_structured_output = True
         request.prompt_token_ids = [1, 2, 3, 4, 5]
+        request.num_prompt_tokens = len(request.prompt_token_ids)
         request.all_token_ids = [1, 2, 3, 4, 5, 6, 7, 8]
         request.num_computed_tokens = 5
         request.num_output_placeholders = 0
@@ -138,6 +142,9 @@ class TestReasoningStructuredOutput:
 
             def is_reasoning_end(self, input_ids):
                 return not self.chat_template_kwargs.get("enable_thinking", False)
+
+            def is_reasoning_end_from_prompt(self, prompt_token_ids):
+                return self.is_reasoning_end(prompt_token_ids)
 
         manager = StructuredOutputManager(mock_vllm_config)
         manager.reasoner_cls = KwargReasoner
@@ -258,3 +265,39 @@ class TestReasoningStructuredOutput:
 
         # Should return True since reasoning has ended
         assert result is True
+
+    def test_should_advance_replays_speculative_content_after_reasoning(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = None
+        structured_req.structured_output_key = (
+            StructuredOutputOptions.JSON,
+            "{}",
+        )
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_streaming.return_value = True
+        reasoner.extract_content_ids.return_value = [8]
+        structured_req.reasoner = reasoner
+        manager_with_reasoner.vllm_config.speculative_config = Mock()
+
+        assert manager_with_reasoner.should_advance(mock_request_with_structured_output)
+        assert structured_req.reasoning_end_token_index == 6
+        assert manager_with_reasoner.trim_reasoning_for_advance(
+            mock_request_with_structured_output, [6, 7, 8]
+        ) == [8]
+
+    def test_speculative_replay_is_validated_before_accepting(
+        self, manager_with_reasoner
+    ):
+        grammar = Mock()
+        grammar.validate_tokens.return_value = [10]
+
+        accepted = manager_with_reasoner._accept_validated_tokens(
+            grammar, "test-request", [10, 11]
+        )
+
+        assert accepted == 0
+        grammar.accept_tokens.assert_not_called()

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -350,7 +350,9 @@ class OpenAIServingChat(GenerateBaseServing):
                     # non-reasoning outputs.
                     reasoning_ended = True
                 elif parser is not None and parser.reasoning_parser is not None:
-                    reasoning_ended = parser.is_reasoning_end(prompt_token_ids or [])
+                    reasoning_ended = parser.is_reasoning_end_from_prompt(
+                        prompt_token_ids or []
+                    )
                 else:
                     reasoning_ended = None
 

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -193,6 +193,10 @@ class Parser:
             True if the reasoning content ends in the input_ids.
         """
 
+    def is_reasoning_end_from_prompt(self, prompt_token_ids: list[int]) -> bool | None:
+        """Check whether reasoning has ended at the generation boundary."""
+        return self.is_reasoning_end(prompt_token_ids)
+
     def is_reasoning_end_streaming(
         self, input_ids: list[int], delta_ids: list[int]
     ) -> bool:
@@ -723,6 +727,11 @@ class DelegatingParser(Parser):
             return False
         return self._reasoning_parser.is_reasoning_end(input_ids)
 
+    def is_reasoning_end_from_prompt(self, prompt_token_ids: list[int]) -> bool | None:
+        if self._reasoning_parser is None:
+            return False
+        return self._reasoning_parser.is_reasoning_end_from_prompt(prompt_token_ids)
+
     def is_reasoning_end_streaming(
         self, input_ids: list[int], delta_ids: list[int]
     ) -> bool:
@@ -812,7 +821,7 @@ class DelegatingParser(Parser):
 
         if not state.prompt_reasoning_checked and prompt_token_ids is not None:
             state.prompt_reasoning_checked = True
-            if self._reasoning_parser is None or self.is_reasoning_end(
+            if self._reasoning_parser is None or self.is_reasoning_end_from_prompt(
                 prompt_token_ids
             ):
                 state.reasoning_ended = True

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -87,6 +87,18 @@ class ReasoningParser:
             True if the reasoning content ends in the input_ids.
         """
 
+    def is_reasoning_end_from_prompt(
+        self, prompt_token_ids: Sequence[int]
+    ) -> bool | None:
+        """Check whether reasoning has ended at the generation boundary.
+
+        Parsers whose prompts contain instructional or historical reasoning
+        markers can override this without changing generated-output parsing.
+        ``None`` means generated output must disambiguate whether the response
+        starts with reasoning or direct content.
+        """
+        return self.is_reasoning_end(prompt_token_ids)
+
     def is_reasoning_end_streaming(
         self, input_ids: Sequence[int], delta_ids: Iterable[int]
     ) -> bool:

--- a/vllm/reasoning/minimax_m3_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m3_reasoning_parser.py
@@ -40,7 +40,8 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
         self._start_token_ids = self._encode_marker(self.start_token)
         self._end_token_ids = self._encode_marker(self.end_token)
         chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
-        self._initial_in_reasoning = chat_kwargs.get("thinking_mode") == "enabled"
+        self._thinking_mode = chat_kwargs.get("thinking_mode", "adaptive")
+        self._initial_in_reasoning = self._thinking_mode == "enabled"
         self._reasoning_ended_streaming = False
         self._reasoning_active_streaming = self._initial_in_reasoning
         self._pending_marker_streaming = False
@@ -200,23 +201,25 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
         if self._reasoning_ended_streaming:
             return True
 
-        if self._reasoning_active_streaming or self._pending_marker_streaming:
-            return False
-
         delta_ids = tuple(delta_ids)
         if self._contains_token_sequence(delta_ids, self._end_token_ids):
             return True
         if self._contains_token_sequence(input_ids, self._end_token_ids):
             return True
+        text = self._decode_text(input_ids)
+        if self.end_token in text:
+            return True
+        if self._reasoning_active_streaming or self._pending_marker_streaming:
+            return False
         if self._initial_in_reasoning:
             return False
         if self._ends_with_token_sequence_prefix(input_ids, self._start_token_ids):
             return False
         if self._ends_with_token_sequence_prefix(input_ids, self._end_token_ids):
             return False
-        if not self._contains_token_sequence(input_ids, self._start_token_ids):
-            return bool(input_ids)
-        return False
+        if self.start_token.startswith(text) or self.end_token.startswith(text):
+            return False
+        return not text.startswith(self.start_token)
 
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
         if (
@@ -232,7 +235,16 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
         if end_index >= 0:
             return input_ids[end_index + len(self._end_token_ids) :]
 
-        has_start = self._contains_token_sequence(input_ids, self._start_token_ids)
+        text = self._decode_text(input_ids)
+        text_end_index = text.rfind(self.end_token)
+        if text_end_index >= 0:
+            content = text[text_end_index + len(self.end_token) :] or None
+            return self._content_suffix_token_ids(text, input_ids, content)
+
+        has_start = (
+            self._contains_token_sequence(input_ids, self._start_token_ids)
+            or self.start_token in text
+        )
         if self._initial_in_reasoning and not has_start:
             return []
 
@@ -318,3 +330,12 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
         if start_index < 0:
             return True
         return end_index > start_index
+
+    def is_reasoning_end_from_prompt(
+        self, prompt_token_ids: Sequence[int]
+    ) -> bool | None:
+        if self._thinking_mode == "disabled":
+            return True
+        if self._thinking_mode == "enabled":
+            return False
+        return None

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -196,6 +196,20 @@ class StructuredOutputManager:
                 # requests here.
                 self._grammar_bitmask[index].fill_(self._full_mask)
 
+    @staticmethod
+    def _accept_validated_tokens(
+        grammar: StructuredOutputGrammar,
+        request_id: str,
+        token_ids: list[int],
+    ) -> int:
+        if grammar.validate_tokens(token_ids) != token_ids:
+            return 0
+        return len(token_ids) if grammar.accept_tokens(request_id, token_ids) else 0
+
+    @staticmethod
+    def _output_start_index(request: "Request") -> int:
+        return min(request.num_prompt_tokens, len(request.all_token_ids))
+
     def _async_submit_fill_bitmask(
         self, batch: list[tuple[StructuredOutputGrammar, int, bool]]
     ) -> Future:
@@ -280,6 +294,9 @@ class StructuredOutputManager:
                 )
                 simulated_buf: list[int] | None = None
                 history_len = 0
+                reasoning_was_undetermined = (
+                    structured_output_request.reasoning_ended is None
+                )
 
                 state_advancements = 0
                 post_reasoning_end_in_window = False
@@ -296,7 +313,8 @@ class StructuredOutputManager:
                         and not apply_bitmask
                     ):
                         if simulated_buf is None:
-                            history = list(request.all_token_ids)
+                            output_start = self._output_start_index(request)
+                            history = list(request.all_token_ids[output_start:])
                             history_len = len(history)
                             simulated_buf = history + list(req_tokens)
                         simulated = simulated_buf[: history_len + i + 1]
@@ -311,6 +329,16 @@ class StructuredOutputManager:
                             apply_bitmask = True
                             advance_grammar = False
                             post_reasoning_end_in_window = True
+                            if reasoning_was_undetermined:
+                                content_ids = reasoner.extract_content_ids(simulated)
+                                if (
+                                    content_ids == simulated
+                                    and not grammar.is_terminated()
+                                ):
+                                    state_advancements += self._accept_validated_tokens(
+                                        grammar, req_id, content_ids
+                                    )
+                                reasoning_was_undetermined = False
                     if advance_grammar and not grammar.is_terminated():
                         accepted = grammar.accept_tokens(req_id, [token])
                         if accepted:
@@ -363,9 +391,11 @@ class StructuredOutputManager:
                 # After unifying the `openai_gptoss` and non-`openai_gptoss` styles,
                 # it can be removed.
                 request.structured_output_request.reasoning_ended = (
-                    reasoner.is_reasoning_end(request.prompt_token_ids or [])
+                    reasoner.is_reasoning_end_from_prompt(
+                        request.prompt_token_ids or []
+                    )
                 )
-            return request.structured_output_request.reasoning_ended
+            return request.structured_output_request.reasoning_ended is True
         return True
 
     def should_advance(self, request: "Request") -> bool:
@@ -391,24 +421,44 @@ class StructuredOutputManager:
         if structured_req.reasoning_ended:
             return True
 
+        reasoning_was_undetermined = structured_req.reasoning_ended is None
+
         # Check if reasoning ends in *this* step
         delta_from = request.num_computed_tokens - request.num_output_placeholders
         all_token_ids = request.all_token_ids
         start = (
             delta_from if delta_from >= 0 else max(len(all_token_ids) + delta_from, 0)
         )
+        output_start = self._output_start_index(request)
+        output_token_ids = all_token_ids[output_start:]
+        step_start = max(start, output_start)
+        output_delta_start = step_start - output_start
         if reasoner.is_reasoning_end_streaming(
-            all_token_ids, itertools.islice(all_token_ids, start, None)
+            output_token_ids,
+            itertools.islice(output_token_ids, output_delta_start, None),
         ):
             structured_req.reasoning_ended = True
+            output_token_ids = list(output_token_ids)
+            content_ids = reasoner.extract_content_ids(output_token_ids)
 
-            # Reasoning just ended this step. Defer FSM advance until the next
-            # pass (see reasoning_ended check above) for JSON/regex/choice/grammar:
-            # advancing on the closing boundary token can accept tokens that still
-            # belong to the reasoning stream. Structural tags are the only safe
-            # same-step exception: they model phased output (e.g. thinking tag ->
-            # answer tag), and speculative decoding must run grammar.validate_tokens
-            # on draft tokens produced immediately after that transition.
+            if reasoning_was_undetermined:
+                if content_ids == output_token_ids:
+                    structured_req.deferred_grammar_start_index = output_start
+                    return True
+                structured_req.deferred_grammar_start_index = None
+
+            if content_ids and output_token_ids[-len(content_ids) :] == content_ids:
+                structured_req.reasoning_end_token_index = (
+                    len(all_token_ids) - len(content_ids) - 1
+                )
+                return True
+
+            # No post-reasoning content suffix was identified, so defer FSM
+            # advance until the next pass for JSON/regex/choice/grammar. Advancing
+            # on the closing boundary token can accept reasoning-stream tokens.
+            # Structural tags remain a safe same-step exception because they model
+            # tagged output transitions, and speculative decoding must validate
+            # drafts produced immediately after the transition.
             if (
                 self.vllm_config.speculative_config is not None
                 and structured_req.structured_output_key[0]
@@ -419,15 +469,27 @@ class StructuredOutputManager:
                 # content up to and including the end marker. Record where
                 # it ends so trim_reasoning_for_advance() can drop it.
                 structured_req.reasoning_end_token_index = (
-                    self._find_reasoning_end_index(reasoner, all_token_ids, start)
+                    self._find_reasoning_end_index(
+                        reasoner, all_token_ids, output_start, step_start
+                    )
                 )
                 return True
+
+        elif (
+            reasoning_was_undetermined
+            and structured_req.deferred_grammar_start_index is None
+            and start < len(all_token_ids)
+        ):
+            structured_req.deferred_grammar_start_index = output_start
 
         return False
 
     @staticmethod
     def _find_reasoning_end_index(
-        reasoner: "ReasoningParser", all_token_ids: Sequence[int], start: int
+        reasoner: "ReasoningParser",
+        all_token_ids: Sequence[int],
+        output_start: int,
+        start: int,
     ) -> int:
         """Locates the last reasoning token within ``all_token_ids[start:]``.
 
@@ -438,7 +500,7 @@ class StructuredOutputManager:
             a multi-token marker only recognized on the full delta), which
             conservatively treats the whole step as reasoning content.
         """
-        prefix = list(itertools.islice(all_token_ids, start))
+        prefix = list(itertools.islice(all_token_ids, output_start, start))
         for idx in range(start, len(all_token_ids)):
             token = all_token_ids[idx]
             prefix.append(token)
@@ -463,6 +525,10 @@ class StructuredOutputManager:
         structured_req = request.structured_output_request
         if structured_req is None:
             return new_token_ids
+        deferred_start = structured_req.deferred_grammar_start_index
+        if deferred_start is not None:
+            structured_req.deferred_grammar_start_index = None
+            return list(request.all_token_ids[deferred_start:])
         end_idx = structured_req.reasoning_end_token_index
         if end_idx is None:
             return new_token_ids

--- a/vllm/v1/structured_output/request.py
+++ b/vllm/v1/structured_output/request.py
@@ -29,6 +29,10 @@ class StructuredOutputRequest:
     # reasoning ends in a step whose tokens the scheduler advances immediately
     # (structural tags + speculative decoding, see #42452).
     reasoning_end_token_index: int | None = None
+    # Absolute index into all_token_ids where grammar content began while an
+    # adaptive reasoning prefix was still ambiguous. Once direct content is
+    # confirmed, all tokens from this index must be replayed into the grammar.
+    deferred_grammar_start_index: int | None = None
     reasoning_parser_kwargs: dict[str, Any] | None = None
     # Cached per request; do not share reasoning parsers across requests because
     # their behavior can depend on reasoning_parser_kwargs.


### PR DESCRIPTION
## Purpose

Initialize MiniMax M3 reasoning from prompt mode without treating instructional tags in the prompt as generated reasoning. Preserve deferred reasoning content with structured output and speculative decoding.

This is broader than #46616 and covers adaptive, structured-output, speculative, and tool-parsing paths.

AI assistance was used; the changes were reviewed before submission.

## Test Plan

Testing was performed by GPT 5.5 on two NVIDIA B300 nodes.

- Ruff passed.
- Focused parser, tool-calling, and structured-output tests: **52 passed**.
- Skipped: `test_should_advance_records_reasoning_end_index` and `test_trim_reasoning_for_advance` because the source-only environment lacked a matching compiled `vllm._C`, so platform detection stopped before their assertions.
- Live MiniMax M3 validation: **6 passed, 0 failed**.
- Adaptive-direct output was not selected in five attempts, so that optional path was inconclusive.
- No NIXL failures or serving restarts were observed.

No performance benchmark or profiler was run.
