### PR TITLE
[XPU][UT]Convert awq-packed MoE qweight to the gptq-equivalent layout on xpu

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
@@ -965,13 +965,20 @@ def _process_weights_xpu(
     expects this convention; on a big-endian host the byte order reverses
     and the kernel would silently miscompute, so we hard-fail.
     """
-    del layer, quant_config  # unused — kept for parity with the marlin helper
+    del layer  # unused — kept for parity with the marlin helper
 
     if sys.byteorder != "little":
         raise NotImplementedError(
             "_process_weights_xpu requires a little-endian host: the GPTQ "
             "int32 → uint8 nibble repack relies on LE byte ordering."
         )
+    from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
+
+    if isinstance(quant_config, AutoAWQConfig):
+        from vllm_xpu_kernels.quantization._quantize_convert import AWQUtils
+
+        w13_qweight = AWQUtils.moe_repack(w13_qweight)
+        w2_qweight = AWQUtils.moe_repack(w2_qweight)
 
     w13_xpu = w13_qweight.transpose(1, 2).contiguous().view(torch.uint8)
     w2_xpu = w2_qweight.transpose(1, 2).contiguous().view(torch.uint8)


### PR DESCRIPTION
Fixed tests/models/quantization/test_awq.py::test_awq_load[gemma4-moe-standard-awq-dot-suffix] meet RuntimeError: ptr_A.size(1) must match ptr_B.size(1)

Root cause: 
The process_weights_xpu assumed GPTQ K-packed nibble layout ( [E, K//pack_factor, N], ascending nibble order) for all quant configs, but AWQ MOE weights use a different layout ([E, K, N//pack_factor], packed along N with AWQ's own nibble order).
