### PR TITLE
[Bugfix] Match WeightsMapper stacked remaps on path components

### DIFF
--- a/tests/model_executor/test_weight_utils.py
+++ b/tests/model_executor/test_weight_utils.py
@@ -281,5 +281,128 @@ class TestKvCacheScaleMapper:
         )
 
 
+class TestWeightsMapperStacked:
+    """Regression tests for #48423 / #48449: stacked QKV remaps must not turn
+    ``qkv_proj`` into ``qkqkv_proj`` or overwrite q/k shard ids with ``v``."""
+
+    @pytest.fixture
+    def minicpm_style_mapper(self):
+        # MiniCPM-V-4.6 ViT attention uses bare component names (no leading dot).
+        from vllm.model_executor.models.utils import WeightsMapper
+
+        return WeightsMapper(
+            orig_to_new_stacked={
+                "q_proj": ("qkv_proj", "q"),
+                "k_proj": ("qkv_proj", "k"),
+                "v_proj": ("qkv_proj", "v"),
+            }
+        )
+
+    @pytest.fixture
+    def dotted_style_mapper(self):
+        # Qwen2 / Siglip style: leading-dot patterns.
+        from vllm.model_executor.models.utils import WeightsMapper
+
+        return WeightsMapper(
+            orig_to_new_stacked={
+                ".q_proj": (".qkv_proj", "q"),
+                ".k_proj": (".qkv_proj", "k"),
+                ".v_proj": (".qkv_proj", "v"),
+                ".gate_proj": (".gate_up_proj", 0),
+                ".up_proj": (".gate_up_proj", 1),
+            }
+        )
+
+    @pytest.mark.parametrize(
+        "name,expected_name,expected_shard",
+        [
+            ("q_proj.weight", "qkv_proj.weight", "q"),
+            ("k_proj.weight", "qkv_proj.weight", "k"),
+            ("v_proj.weight", "qkv_proj.weight", "v"),
+            ("q_proj.bias", "qkv_proj.bias", "q"),
+            (
+                "vit_merger.self_attn.q_proj.weight",
+                "vit_merger.self_attn.qkv_proj.weight",
+                "q",
+            ),
+            (
+                "vit_merger.self_attn.k_proj.weight",
+                "vit_merger.self_attn.qkv_proj.weight",
+                "k",
+            ),
+            (
+                "vit_merger.self_attn.v_proj.weight",
+                "vit_merger.self_attn.qkv_proj.weight",
+                "v",
+            ),
+            # Already-fused / unrelated names must not be mangled.
+            ("qkv_proj.weight", "qkv_proj.weight", None),
+            ("out_proj.weight", "out_proj.weight", None),
+        ],
+    )
+    def test_bare_component_names(
+        self, minicpm_style_mapper, name, expected_name, expected_shard
+    ):
+        mapped = minicpm_style_mapper._map_name_with_shard(name)
+        assert mapped == (expected_name, expected_shard)
+
+    @pytest.mark.parametrize(
+        "name,expected_name,expected_shard",
+        [
+            (
+                "model.layers.0.self_attn.q_proj.weight",
+                "model.layers.0.self_attn.qkv_proj.weight",
+                "q",
+            ),
+            (
+                "model.layers.0.self_attn.k_proj.weight",
+                "model.layers.0.self_attn.qkv_proj.weight",
+                "k",
+            ),
+            (
+                "model.layers.0.self_attn.v_proj.weight",
+                "model.layers.0.self_attn.qkv_proj.weight",
+                "v",
+            ),
+            (
+                "model.layers.0.self_attn.qkv_proj.weight",
+                "model.layers.0.self_attn.qkv_proj.weight",
+                None,
+            ),
+            (
+                "model.layers.0.mlp.gate_proj.weight",
+                "model.layers.0.mlp.gate_up_proj.weight",
+                0,
+            ),
+            (
+                "model.layers.0.mlp.up_proj.weight",
+                "model.layers.0.mlp.gate_up_proj.weight",
+                1,
+            ),
+        ],
+    )
+    def test_dotted_component_names(
+        self, dotted_style_mapper, name, expected_name, expected_shard
+    ):
+        mapped = dotted_style_mapper._map_name_with_shard(name)
+        assert mapped == (expected_name, expected_shard)
+
+    def test_qualified_fuse_map_beats_short_alias(self):
+        """Longer stacked keys (fuser qualnames) must win over short aliases."""
+        from vllm.model_executor.models.utils import WeightsMapper
+
+        mapper = WeightsMapper(
+            orig_to_new_stacked={
+                "q_proj": ("qkv_proj", "q"),
+                "model.layers.0.self_attn.q_proj": (
+                    "model.layers.0.self_attn.qkv_proj",
+                    "q",
+                ),
+            }
+        )
+        mapped = mapper._map_name_with_shard("model.layers.0.self_attn.q_proj.weight")
+        assert mapped == ("model.layers.0.self_attn.qkv_proj.weight", "q")
+
+
 if __name__ == "__main__":
     test_download_weights_from_hf()

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -77,6 +77,24 @@ class WeightsMapper:
         result = self._map_name_with_shard(key)
         return result[0] if result is not None else None
 
+    @staticmethod
+    def _replace_stacked_component(key: str, old: str, new: str) -> str | None:
+        """Replace ``old`` with ``new`` when ``old`` is a dotted path component.
+
+        Unlike a raw substring replace, ``v_proj`` does not match inside
+        ``qkv_proj``. Leading dots on ``old``/``new`` (e.g. ``.q_proj``) are
+        ignored for matching; separators already present in ``key`` are kept.
+        """
+        old_norm = old.lstrip(".")
+        new_norm = new.lstrip(".")
+        if not old_norm:
+            return None
+        pattern = re.compile(rf"(^|\.)({re.escape(old_norm)})(\.|$)")
+        match = pattern.search(key)
+        if match is None:
+            return None
+        return key[: match.start(2)] + new_norm + key[match.end(2) :]
+
     def _map_name_with_shard(self, key: str) -> tuple[str, ShardId | None] | None:
         """Map a weight name and extract any shard_id metadata.
 
@@ -112,10 +130,21 @@ class WeightsMapper:
                 key = key.replace(substr, new_key, 1)
 
         shard_id: ShardId | None = None
-        for substr, (new_key, new_shard_id) in self.orig_to_new_stacked.items():
-            if substr in key:
-                key = key.replace(substr, new_key, 1)
+        # Match stacked patterns as dotted path components (not raw substrings)
+        # and stop after the first hit. Otherwise `v_proj` rewrites inside
+        # `qkv_proj` (→ `qkqkv_proj`) and overwrites the q/k shard id — see
+        # https://github.com/vllm-project/vllm/issues/48423.
+        stacked_items = sorted(
+            self.orig_to_new_stacked.items(),
+            key=lambda item: len(item[0].lstrip(".")),
+            reverse=True,
+        )
+        for substr, (new_key, new_shard_id) in stacked_items:
+            replaced = self._replace_stacked_component(key, substr, new_key)
+            if replaced is not None:
+                key = replaced
                 shard_id = new_shard_id
+                break
 
         for prefix, new_key in self.orig_to_new_prefix.items():
             if key.startswith(prefix):


### PR DESCRIPTION
## Purpose

Fixes #48423
Fixes #48449

`WeightsMapper._map_name_with_shard` matches `orig_to_new_stacked` keys as raw substrings and keeps scanning after a hit. With mappings like MiniCPM-V-4.6's ViT attention (`q_proj`/`k_proj`/`v_proj` -> `qkv_proj`), a name such as `...self_attn.q_proj.weight` is first rewritten to `...qkv_proj.weight`, and then the `v_proj` entry matches *inside* the freshly written `qkv_proj`, producing `...qkqkv_proj.weight` and overwriting the `q`/`k` shard id with `v`. This breaks weight loading for MiniCPM-V-4.6 on v0.25.0 (`KeyError`/garbage output depending on path).

This PR changes stacked remapping to:

- match keys as dotted path components (so `v_proj` no longer matches inside `qkv_proj`),
- stop after the first successful match,
- prefer longer (fully-qualified) keys over short aliases when both match.

No behavior change for existing dotted-style mappings (`.q_proj` etc.); already-fused names like `qkv_proj.weight` now pass through untouched.

Not duplicating existing work: no open PR addresses #48423/#48449 (checked open PRs referencing the issues and `WeightsMapper`).

## Test Plan

Added regression tests in `tests/model_executor/test_weight_utils.py::TestWeightsMapperStacked` covering:

- bare component-name mappings (MiniCPM-V style): `q/k/v_proj` -> `qkv_proj` with correct shard ids, and `qkv_proj`/`out_proj` left untouched,
- dotted-style mappings (Qwen2/Siglip style) including `gate_proj`/`up_proj` -> `gate_up_proj`,
- qualified stacked keys taking precedence over short aliases.

```bash
pytest tests/model_executor/test_weight_utils.py -v
```

## Test Result

All tests in `tests/model_executor/test_weight_utils.py` pass locally (CPU), including the new `TestWeightsMapperStacked` cases. `pre-commit` (ruff, mypy, etc.) passes on the changed files.
