### PR TITLE
[Frontend] Add cache_salt support to the Anthropic Messages API

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -1443,3 +1443,13 @@ class TestCacheSaltField:
     def test_cache_salt_non_string_rejected(self):
         with pytest.raises(ValueError, match="cache_salt"):
             _make_request([{"role": "user", "content": "hi"}], cache_salt=123)
+
+    def test_cache_salt_forwarded_to_chat_request(self):
+        request = _make_request([{"role": "user", "content": "hi"}], cache_salt="org-A")
+        result = _convert(request)
+        assert result.cache_salt == "org-A"
+
+    def test_no_cache_salt_forwarded_as_none(self):
+        request = _make_request([{"role": "user", "content": "hi"}])
+        result = _convert(request)
+        assert result.cache_salt is None

--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -1420,3 +1420,26 @@ class TestMessagesFullConverter:
         assert len(result.content) == 1
         assert result.content[0].type == "text"
         assert result.content[0].text == ""
+
+
+# ======================================================================
+# cache_salt (vLLM extension field)
+# ======================================================================
+
+
+class TestCacheSaltField:
+    def test_cache_salt_accepted(self):
+        request = _make_request([{"role": "user", "content": "hi"}], cache_salt="org-A")
+        assert request.cache_salt == "org-A"
+
+    def test_cache_salt_defaults_to_none(self):
+        request = _make_request([{"role": "user", "content": "hi"}])
+        assert request.cache_salt is None
+
+    def test_cache_salt_empty_string_rejected(self):
+        with pytest.raises(ValueError, match="cache_salt"):
+            _make_request([{"role": "user", "content": "hi"}], cache_salt="")
+
+    def test_cache_salt_non_string_rejected(self):
+        with pytest.raises(ValueError, match="cache_salt"):
+            _make_request([{"role": "user", "content": "hi"}], cache_salt=123)

--- a/vllm/entrypoints/anthropic/protocol.py
+++ b/vllm/entrypoints/anthropic/protocol.py
@@ -7,6 +7,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from vllm.exceptions import VLLMValidationError
+
 
 class AnthropicError(BaseModel):
     """Error structure for Anthropic API"""
@@ -143,6 +145,17 @@ class AnthropicMessagesRequest(BaseModel):
             "ECTransfer parameters used for encoder-cache disaggregated serving."
         ),
     )
+    cache_salt: str | None = Field(
+        default=None,
+        description=(
+            "If specified, the prefix cache will be salted with the provided "
+            "string to prevent an attacker to guess prompts in multi-user "
+            "environments. The salt should be random, protected from "
+            "access by 3rd parties, and long enough to be "
+            "unpredictable (e.g., 43 characters base64-encoded, corresponding "
+            "to 256 bit)."
+        ),
+    )
     chat_template_kwargs: dict[str, Any] | None = Field(
         default=None,
         description=(
@@ -164,6 +177,18 @@ class AnthropicMessagesRequest(BaseModel):
         if v <= 0:
             raise ValueError("max_tokens must be positive")
         return v
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_cache_salt_support(cls, data):
+        if data.get("cache_salt") is not None and (
+            not isinstance(data["cache_salt"], str) or not data["cache_salt"]
+        ):
+            raise VLLMValidationError(
+                "Parameter 'cache_salt' must be a non-empty string if provided.",
+                parameter="cache_salt",
+            )
+        return data
 
 
 class AnthropicDelta(BaseModel):

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -490,6 +490,7 @@ class AnthropicServingMessages(OpenAIServingChat):
             temperature=anthropic_request.temperature,
             top_p=anthropic_request.top_p,
             top_k=anthropic_request.top_k,
+            cache_salt=anthropic_request.cache_salt,
             kv_transfer_params=anthropic_request.kv_transfer_params,
             ec_transfer_params=anthropic_request.ec_transfer_params,
             chat_template_kwargs=anthropic_request.chat_template_kwargs,


### PR DESCRIPTION
## Purpose

`cache_salt` (per-request prefix-cache salting for multi-user isolation) is supported on `/v1/chat/completions`, `/v1/completions`, and `/v1/responses`, but not on the Anthropic Messages API (`/v1/messages`). `AnthropicMessagesRequest` has no such field and `_build_base_request` never sets it, so Anthropic-dialect requests always reach the engine with `cache_salt=None` and share prefix-cache blocks across users. A proxy cannot work around this, since the endpoint does not accept the field.

This adds `cache_salt` as a vLLM-specific extension field on `AnthropicMessagesRequest` — following the existing `kv_transfer_params` / `ec_transfer_params` pattern — with the same validator as `ChatCompletionRequest`, and forwards it in `_build_base_request`. Request-only (not echoed in responses), and not added to `count_tokens` (which never touches the KV cache). No behavior change when the field is absent.

## Test Plan

`pytest tests/entrypoints/anthropic/test_anthropic_messages_conversion.py -k CacheSaltField` — new tests cover: field accepted and forwarded to the internal `ChatCompletionRequest`, default `None` preserved, empty-string and non-string values rejected with a validation error.

## Test Result

All new tests pass; full `tests/entrypoints/anthropic/` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)