### PR TITLE
fix(logprobs): guard convert_ids_list_to_tokens against out-of-range ids

### DIFF
--- a/tests/tokenizers_/test_detokenize.py
+++ b/tests/tokenizers_/test_detokenize.py
@@ -222,6 +222,38 @@ def test_decode_streaming(
     assert out_ids == all_input_ids[starting_index:]
 
 
+class _FakeRustTokenizer:
+    """Minimal tokenizer that mimics a fast (rust-backed) tokenizer's
+    behaviour on decode: out-of-vocab-but-representable ids decode to "",
+    while ids outside the u32 range raise OverflowError (as the rust
+    tokenizer does when converting the Python int to a u32)."""
+
+    def __init__(self, vocab_size: int):
+        self._vocab_size = vocab_size
+
+    def __len__(self) -> int:
+        return self._vocab_size
+
+    def decode(self, token_ids, *args, **kwargs) -> str:
+        for token_id in token_ids:
+            if token_id < 0 or token_id > 0xFFFFFFFF:
+                raise OverflowError("out of range integral type conversion attempted")
+        return ""
+
+
+@pytest.mark.parametrize("token_id", [-1, -12345, 2**32, 2**63])
+def test_convert_ids_list_to_tokens_out_of_range(token_id):
+    """Out-of-range prompt logprob token ids (e.g. from uninitialized
+    tensor slots) must not crash detokenization with OverflowError."""
+    from vllm.tokenizers.detokenizer_utils import convert_ids_list_to_tokens
+
+    tokenizer = _FakeRustTokenizer(vocab_size=32000)
+
+    tokens = convert_ids_list_to_tokens(tokenizer, [token_id])
+
+    assert tokens == [""]
+
+
 @pytest.mark.parametrize("tokenizer_name", TOKENIZERS)
 @pytest.mark.parametrize("fast", (True, False))
 def test_oov_decode(tokenizer, fast):

--- a/vllm/tokenizers/detokenizer_utils.py
+++ b/vllm/tokenizers/detokenizer_utils.py
@@ -95,7 +95,14 @@ def convert_ids_list_to_tokens(
 
     """
     token_str_lst = []
+    vocab_size = len(tokenizer)
     for token_id in token_ids:
+        # Out-of-range ids (e.g. uninitialized prompt-logprobs slots) make a
+        # fast tokenizer's u32 conversion raise OverflowError; guard like
+        # detokenize_incrementally does.
+        if not 0 <= token_id < vocab_size:
+            token_str_lst.append("")
+            continue
         # use default skip_special_tokens.
         token_str = tokenizer.decode([token_id])
         if token_str is None:


### PR DESCRIPTION
## Summary

`convert_ids_list_to_tokens` in `vllm/tokenizers/detokenizer_utils.py` calls `tokenizer.decode([token_id])` for every id with **no bounds check**. When an out-of-range id (negative, or beyond the u32 range) reaches a fast/rust-backed tokenizer, the rust binding raises `OverflowError: out of range integral type conversion attempted` while converting the Python int to a `u32`. Such ids can surface in uninitialized slots of the chunked prompt-logprobs tensor (`LogprobsTensors.empty_cpu` uses `torch.empty`, filled slice-by-slice across prefill chunks), crashing the async output handler.

`detokenize_incrementally` in the same file already guards this exact case with `if 0 <= new_token_id < len(tokenizer)`, but `convert_ids_list_to_tokens` — used by both sample and prompt logprobs — was missing the equivalent guard.

## Fix

Mirror the existing `0 <= id < len(tokenizer)` guard: out-of-range ids decode to `""` instead of being passed to the tokenizer. Since the result is empty (no U+FFFD), it does not perturb the downstream byte-fallback UTF-8 correction path.

## Test plan

- [x] Added `test_convert_ids_list_to_tokens_out_of_range` (parametrized over `-1, -12345, 2**32, 2**63`) using a fake rust-like tokenizer that raises `OverflowError` on out-of-range ids; asserts the result is `[""]`.
