### PR TITLE
[Kernel] Extend Marlin atomic-add reduction to fused MoE

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -35,6 +35,7 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     marlin_make_workspace_new,
     marlin_moe_intermediate_size,
     marlin_quant_input,
+    should_use_atomic_add_reduce,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
@@ -132,6 +133,13 @@ def _fused_marlin_moe(
     elif input_dtype == torch.float8_e4m3fn:
         gate_up_input, a_scales1 = marlin_quant_input(hidden_states, input_dtype)
 
+    use_atomic_add1 = should_use_atomic_add_reduce(
+        m=M * num_topk,
+        n=w13_num_shards * N,
+        k=K,
+        device=hidden_states.device,
+        dtype=hidden_states.dtype,
+    )
     intermediate_cache1 = ops.moe_wna16_marlin_gemm(
         gate_up_input,
         intermediate_cache1,
@@ -156,7 +164,7 @@ def _fused_marlin_moe(
         size_n=w13_num_shards * N,
         size_k=K,
         is_k_full=is_k_full,
-        use_atomic_add=False,
+        use_atomic_add=use_atomic_add1,
         use_fp32_reduce=True,
         is_zp_float=False,
     )
@@ -191,6 +199,13 @@ def _fused_marlin_moe(
             intermediate_cache2, input_dtype
         )
 
+    use_atomic_add2 = should_use_atomic_add_reduce(
+        m=M * num_topk,
+        n=K,
+        k=N,
+        device=hidden_states.device,
+        dtype=hidden_states.dtype,
+    )
     output = ops.moe_wna16_marlin_gemm(
         intermediate_cache2,
         output,
@@ -215,7 +230,7 @@ def _fused_marlin_moe(
         size_n=K,
         size_k=N,
         is_k_full=is_k_full,
-        use_atomic_add=False,
+        use_atomic_add=use_atomic_add2,
         use_fp32_reduce=True,
         is_zp_float=False,
     )


### PR DESCRIPTION
## Summary

- Apply the existing `should_use_atomic_add_reduce` policy to both Marlin
  fused-MoE GEMMs.
- Replace the fused-MoE path's hardcoded `use_atomic_add=False` with a per-GEMM
  decision using the actual `(M, N, K)`, device, and activation dtype.
- Preserve the current default behavior: atomic reduction remains opt-in via
  `VLLM_MARLIN_USE_ATOMIC_ADD=1`.

## Motivation

Dense Marlin already uses the atomic-add policy introduced in #14138, while the
current fused-MoE integration hardcodes the option off even though
`moe_wna16_marlin_gemm` supports it. This change restores policy parity for MoE
without changing the kernel or enabling experimental behavior by default.

Atomic reduction can avoid Marlin's lock/global-reduction path for eligible
GEMMs with a narrow output dimension and large reduction dimension. The benefit
is workload-dependent, so this PR deliberately reuses the existing opt-in
policy rather than introducing a new default.

Example eligibility under the existing `n < 2048`, `k >= 2048` shape gates:

| Model shape | GEMM1 (`n=2I`, `k=H`) | GEMM2 (`n=H`, `k=I`) |
|---|---|---|
| Qwen3-30B-A3B (`H=2048`, `I=768`) | eligible | ineligible |
| 128-expert 26B MoE (`H=2816`, `I=704`) | eligible | ineligible |
| Mixtral-8x7B (`H=4096`, `I=14336`) | ineligible | ineligible |

The existing helper also preserves its CUDA, environment-variable, and BF16
architecture checks.

## Performance validation

Tested on NVIDIA GB10 (SM121) with BF16 activations and 4-bit weights.

### vLLM serving: Qwen3-30B-A3B-GPTQ-Int4

| Workload | Atomic OFF | Atomic ON | Delta |
|---|---:|---:|---:|
| B=1, GSM8K greedy, 50 requests | 82.7 tok/s | 81.4 tok/s | -1.6% |
| Concurrency 8, 32 requests | 256.6 tok/s | 259.3 tok/s | +1.1% |
| Concurrency 32, 64 requests | 516.9 tok/s | 525.5 tok/s | +1.7% |

The B=1 median was effectively unchanged (82.8 vs 83.0 tok/s); aggregate gains
appeared as the effective batch size increased.

### DiffusionGemma custom decode stack

This comparison isolates atomic reduction while holding AWQ and
`moe_block_size=32` fixed:

| Configuration | GSM8K accuracy | Throughput |
|---|---:|---:|
| Block size 32, atomic OFF | 46/50 | 303.6 tok/s |
| Block size 32, atomic ON | 45/50 | 314.5 tok/s |

Atomic reduction improved end-to-end throughput by 3.6% in this workload. The
accuracy counts are a coarse task-level sanity check, not a
numerical-equivalence claim.

### Paired Marlin MoE-layer timing

With block size held at 32, paired/interleaved timing showed the isolated atomic
contribution tapering with token count:

| Tokens | Atomic OFF | Atomic ON | Delta |
|---:|---:|---:|---:|
| 64 | 1.95 ms | 1.81 ms | +7% |
| 128 | 2.16 ms | 1.93 ms | +11% |
| 256 | 2.08 ms | 2.04 ms | +2% |
| 512 | 2.34 ms | 2.32 ms | +1% |

## Correctness and limitations

- The environment flag is off by default, so existing users see no behavior
  change.
- Atomic floating-point accumulation is order-dependent and may produce small
  ULP-level differences, matching the trade-off of the existing dense Marlin
  path.
- Validation above is from one SM121 system. The existing helper continues to
  reject unsupported or unsuitable device, dtype, and shape combinations.
- The GSM8K samples are end-to-end sanity checks; kernel numerical tests and
  project CI remain authoritative.

## Test plan

- [x] Verify that vLLM loads the patched fused-MoE path.
- [x] Run atomic OFF/ON serving comparisons at B=1 and concurrency 8/32.
- [x] Run paired/interleaved Marlin MoE-layer timing with block size fixed.
- [x] Run an isolated DiffusionGemma block-size-32 OFF/ON comparison.
- [ ] Pass vLLM CI and existing Marlin/MoE kernel tests.

## AI assistance disclosure

Claude and Cursor were used for non-trivial assistance during implementation,
validation, and PR preparation. The submitter reviewed the changed code and
validation results. The commit includes the corresponding `Co-authored-by`
trailer and DCO sign-off.
