### PR TITLE
[Bugfix][Spec Decode] Warm spec-sized logits all-gather during init

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6485,6 +6485,25 @@ class GPUModelRunner(
                 output = self._dummy_sampler_run(last_hidden_states)
         else:
             output = None
+        # Warm compute_logits' vocab-parallel all-gather at the spec-decode row
+        # count (max_num_reqs*(1+num_spec_tokens)), larger than the 1-row-per-
+        # request warmup above. On ROCm/RCCL the larger message connects extra
+        # channels lazily on first use, so if that first use is a live decode
+        # step the connect fails ("no transport for peer on channel N"). Running
+        # it here forces the connect during init.
+        if (
+            self.num_spec_tokens > 0
+            and get_pp_group().is_last_rank
+            and not self.is_pooling_model
+        ):
+            spec_logit_rows = min(
+                self.max_num_reqs * (1 + self.num_spec_tokens),
+                self.max_num_tokens,
+            )
+            if spec_logit_rows > last_hidden_states.shape[0]:
+                self.model.compute_logits(
+                    last_hidden_states[:1].expand(spec_logit_rows, -1).contiguous()
+                )
         self._sync_device()
         del hidden_states, output
         self.encoder_cache.clear()


### PR DESCRIPTION
## Purpose

Fixes DeepSeek/GLM-5.2 MTP speculative decoding hanging at startup (#48568).

Warmup runs `compute_logits`' vocab-parallel all-gather at one row per request, but spec decode verifies `max_num_reqs*(1+num_speculative_tokens)` rows. On ROCm/RCCL the larger message connects extra channels lazily on first use, so when that first use is a live decode step the connect fails (`no transport for peer on channel N`) and the engine hangs. Warm `compute_logits` at the spec-decode row count during init.

## Test Plan

Serve GLM-5.2-FP8 with MTP speculative decoding on 8x MI300X (gfx942):

```
vllm serve zai-org/GLM-5.2-FP8 --tensor-parallel-size 8 \
  --kv-cache-dtype fp8_e4m3 --linear-backend aiter --moe-backend aiter \
  --speculative-config '{"method":"mtp","num_speculative_tokens":1}'
```

## Test Result

Server starts and serves normally with MTP speculative decoding, producing coherent completions. Without this change the engine hangs in the logits all-gather on the first speculative-decode step.
