### PR TITLE
[Rust Frontend] Migrate to hf-hub 1.0

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.3.4",
  "once_cell",
  "serde",
@@ -127,6 +127,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,7 +163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.4",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
@@ -182,13 +191,13 @@ dependencies = [
  "hex",
  "hmac",
  "rand 0.9.2",
- "reqwest",
+ "reqwest 0.12.28",
  "reqwest-eventsource",
  "secrecy",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -300,6 +309,29 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "axum"
@@ -424,7 +456,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "constant_time_eq",
  "cpufeatures 0.3.0",
 ]
@@ -436,6 +468,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+dependencies = [
+ "darling 0.23.0",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -525,9 +591,32 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -611,6 +700,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,13 +721,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
- "cfg-if",
+ "cfg-if 1.0.4",
  "itoa",
  "rustversion",
  "ryu",
@@ -657,6 +774,27 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-str"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f"
+
+[[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
+dependencies = [
+ "typewit",
 ]
 
 [[package]]
@@ -692,6 +830,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "countio"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9702aee5d1d744c01d82f6915644f950f898e014903385464c773b96fefdecb"
+dependencies = [
+ "futures-io",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,7 +862,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -752,6 +899,15 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -802,6 +958,25 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctor"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb22e947478ccf9dc44d8922042c677a63fbb88f2cb468521d1145816e5087cb"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
 ]
 
 [[package]]
@@ -967,9 +1142,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1026,6 +1212,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,7 +1259,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -1200,7 +1392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12dd43e5011e8d8411a3215a0d57a2ec5c68282fb90eb5d7221fab0113442174"
 dependencies = [
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "document-features",
  "image",
  "num-traits",
@@ -1319,6 +1511,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fslock"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,6 +1631,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gearhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8cf82cf76cd16485e56295a1377c775ce708c9f1a0be6b029076d60a245d213"
+dependencies = [
+ "cfg-if 0.1.10",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,9 +1664,11 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
+ "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1468,7 +1677,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "r-efi 5.3.0",
@@ -1482,11 +1691,14 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1497,6 +1709,39 @@ checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
+]
+
+[[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1525,7 +1770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "crunchy",
  "zerocopy",
 ]
@@ -1561,6 +1806,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "heapify"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0049b265b7f201ca9ab25475b22b47fe444060126a51abe00f77d986fc5cc52e"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,23 +1831,54 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hf-hub"
-version = "0.5.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
+checksum = "e7ccb6bcc85dec15413ef5949879f9a5497ca4568ed702547eb83fac23376e5c"
 dependencies = [
- "dirs",
+ "base64 0.22.1",
+ "bon",
+ "bytes",
  "futures",
- "indicatif",
- "libc",
- "log",
- "num_cpus",
- "rand 0.9.2",
- "reqwest",
+ "getrandom 0.2.17",
+ "globset",
+ "hf-xet",
+ "hyper",
+ "pathdiff",
+ "percent-encoding",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "windows-sys 0.61.2",
+ "tokio-retry",
+ "tokio-util",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba6e94f549dbe76ced2c56ada52958e63f9056afabb21f74aae1b5777c8cd5d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "more-asserts",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tokio_with_wasm",
+ "tracing",
+ "uuid",
+ "xet-client",
+ "xet-core-structures",
+ "xet-data",
+ "xet-runtime",
 ]
 
 [[package]]
@@ -1605,7 +1887,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1658,6 +1940,21 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1963,7 +2260,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -2069,6 +2366,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if 1.0.4",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,6 +2433,23 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "konst"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f660d5f887e3562f9ab6f4a14988795b694099d66b4f5dedc02d197ba9becb1d"
+dependencies = [
+ "const_panic",
+ "konst_proc_macros",
+ "typewit",
+]
+
+[[package]]
+name = "konst_proc_macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
 
 [[package]]
 name = "lalrpop-util"
@@ -2118,7 +2481,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link",
 ]
 
@@ -2145,6 +2508,18 @@ checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "link-section"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e333fe507b738576d6da5bb3f1a7d7a1c80307ed9ef31624c057d844c19c93e9"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2174,12 +2549,11 @@ dependencies = [
  "blake3",
  "bytes",
  "fast_image_resize",
- "hf-hub",
  "image",
  "libloading",
  "ndarray 0.17.2",
  "once_cell",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_with",
@@ -2204,6 +2578,21 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "macro_rules_attribute"
@@ -2386,7 +2775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -2411,6 +2800,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "more-asserts"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "moxcms"
@@ -2487,6 +2882,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,22 +2933,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -2558,6 +2980,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oneshot"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
 name = "onig"
@@ -2613,7 +3041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.4",
  "foreign-types",
  "libc",
  "openssl-macros",
@@ -2666,6 +3094,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "oss-harmony"
 version = "0.0.11"
 source = "git+https://github.com/oss-harmony/harmony?tag=v0.0.11#76e849426cc092f84509e31a17027755f67d662a"
@@ -2678,7 +3115,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "zstd",
 ]
@@ -2705,7 +3142,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -2717,6 +3154,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pcre2"
@@ -2874,7 +3317,7 @@ version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
@@ -3158,6 +3601,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3200,6 +3700,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,6 +3746,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3281,6 +3807,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
 dependencies = [
  "rustfft",
+]
+
+[[package]]
+name = "redb"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba239c1c1693315d3cc0e601db3b3965543afbf48c41730fdca2f069f510f4a"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3360,20 +3895,16 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "mime_guess",
  "native-tls",
  "percent-encoding",
@@ -3392,7 +3923,52 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -3408,8 +3984,22 @@ dependencies = [
  "mime",
  "nom",
  "pin-project-lite",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest 0.13.4",
+ "thiserror 2.0.18",
+ "tower-service",
 ]
 
 [[package]]
@@ -3419,7 +4009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.2.17",
  "libc",
  "untrusted",
@@ -3494,6 +4084,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustfft"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3526,6 +4125,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -3534,13 +4134,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3548,6 +4188,7 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3627,6 +4268,12 @@ name = "saa"
 version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16c7f49c9d5caa3bf4b3106900484b447b9253fe99670ceb81cb6cb5027855e1"
+
+[[package]]
+name = "safe-transmute"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944826ff8fa8093089aba3acb4ef44b9446a99a16f3bf4e74af3f77d340ab7d"
 
 [[package]]
 name = "same-file"
@@ -3977,9 +4624,30 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3989,6 +4657,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "bstr",
+ "dirs",
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -4012,6 +4691,22 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -4077,6 +4772,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
+
+[[package]]
 name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4128,6 +4833,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4167,6 +4878,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]
@@ -4308,7 +5033,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -4418,6 +5143,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tls-listener"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4517,6 +5257,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-retry"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
+dependencies = [
+ "pin-project-lite",
+ "rand 0.10.2",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4562,6 +5313,30 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio_with_wasm"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34e40fbbbd95441133fe9483f522db15dbfd26dc636164ebd8f2dd28759a6aa6"
+dependencies = [
+ "js-sys",
+ "tokio",
+ "tokio_with_wasm_proc",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "tokio_with_wasm_proc"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d01145a2c788d6aae4cd653afec1e8332534d7d783d01897cefcafe4428de992"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4744,6 +5519,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4788,6 +5576,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4797,12 +5595,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -4846,10 +5647,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
+name = "twox-hash"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "typewit"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
 
 [[package]]
 name = "unic-char-property"
@@ -4995,6 +5808,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5097,7 +5916,7 @@ dependencies = [
  "ndarray 0.17.2",
  "oss-harmony",
  "paste",
- "reqwest",
+ "reqwest 0.12.28",
  "rmp-serde",
  "serde",
  "serde-json-fmt",
@@ -5303,7 +6122,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serial_test",
- "sha2",
+ "sha2 0.10.9",
  "socket2",
  "subtle",
  "tempfile",
@@ -5344,7 +6163,7 @@ dependencies = [
  "futures",
  "hf-hub",
  "itertools 0.14.0",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_with",
@@ -5368,7 +6187,7 @@ dependencies = [
  "criterion",
  "fastokens",
  "hf-hub",
- "reqwest",
+ "reqwest 0.12.28",
  "riptoken",
  "rustc-hash 1.1.0",
  "serde",
@@ -5420,6 +6239,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5438,12 +6266,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -5456,7 +6293,7 @@ version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-util",
  "js-sys",
  "once_cell",
@@ -5532,6 +6369,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5564,10 +6414,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "whoami"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
+]
 
 [[package]]
 name = "win_uds"
@@ -5612,6 +6484,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5622,6 +6515,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5651,6 +6555,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -5713,6 +6627,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -5871,6 +6794,151 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xet-client"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45fc10a88b05d4824d7fc0f97d04c13eaea98da5e8032194b8a0cbdab942090"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "crc32fast",
+ "futures",
+ "http",
+ "hyper",
+ "lazy_static",
+ "more-asserts",
+ "rand 0.10.2",
+ "redb",
+ "reqwest 0.13.4",
+ "reqwest-middleware",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "statrs",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-retry",
+ "tokio_with_wasm",
+ "tracing",
+ "url",
+ "urlencoding",
+ "web-time",
+ "xet-core-structures",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-core-structures"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb39bc5e0478e8f03e15f08b0a396f197fcfa2ef5027da666fd100c806bf0ea3"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "blake3",
+ "bytemuck",
+ "bytes",
+ "countio",
+ "futures",
+ "futures-util",
+ "getrandom 0.4.2",
+ "heapify",
+ "itertools 0.14.0",
+ "lazy_static",
+ "lz4_flex",
+ "more-asserts",
+ "rand 0.10.2",
+ "regex",
+ "safe-transmute",
+ "serde",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "web-time",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-data"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e428a3b9667c1d0d335a4c77407c04d3a3e6c4f228aee364a1b56ed94cf861ca"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "gearhash",
+ "http",
+ "itertools 0.14.0",
+ "lazy_static",
+ "more-asserts",
+ "rand 0.10.2",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tokio_with_wasm",
+ "tracing",
+ "url",
+ "uuid",
+ "web-time",
+ "xet-client",
+ "xet-core-structures",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-runtime"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e1f8cfa256029d1bba7860ca12bfd145f17aa7aede5d968e9c304047656be1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "colored",
+ "const-str",
+ "ctor",
+ "dirs",
+ "futures",
+ "git-version",
+ "humantime",
+ "konst",
+ "lazy_static",
+ "libc",
+ "more-asserts",
+ "oneshot",
+ "pin-project",
+ "rand 0.10.2",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "shellexpand",
+ "sysinfo",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tokio_with_wasm",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "web-time",
+ "whoami",
+ "winapi",
+]
 
 [[package]]
 name = "xgrammar-structural-tag"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -42,7 +42,7 @@ fastokens = { version = "0.2.1", default-features = false }
 futures = "0.3.31"
 half = { version = "2.7.1", features = ["bytemuck"] }
 hex = "0.4.3"
-hf-hub = { version = "0.5.0", default-features = false, features = ["tokio"] }
+hf-hub = { version = "1.0.0", default-features = false }
 http-body = "1.0.1"
 hyper = { version = "1.10.1", features = ["http1", "server"] }
 hyper-util = { version = "0.1.20", features = [
@@ -53,7 +53,9 @@ hyper-util = { version = "0.1.20", features = [
 indexmap = "2.13.0"
 itertools = "0.14.0"
 libc = "0.2.177"
-llm-multimodal = { git = "https://github.com/smg-project/llm-multimodal", rev = "c8a29dcc755139fdc26185f400ea48c6d6d48273" }
+llm-multimodal = { git = "https://github.com/smg-project/llm-multimodal", rev = "c8a29dcc755139fdc26185f400ea48c6d6d48273", default-features = false, features = [
+    "native-tls",
+] }
 mimalloc = "0.1.52"
 minijinja = { version = "2.0", features = ["unstable_machinery", "json", "builtins", "loader", "loop_controls", "preserve_order"] }
 minijinja-contrib = { version = "2.0", features = ["pycompat"] }

--- a/rust/src/text/src/backend/hf/model_files.rs
+++ b/rust/src/text/src/backend/hf/model_files.rs
@@ -54,30 +54,32 @@ impl<'a> HubModel<'a> {
         }
     }
 
-    async fn cached_file(&self, filename: &str) -> Result<Option<PathBuf>> {
-        let result =
-            self.repo.download_file().filename(filename).local_files_only(true).send().await;
+    async fn cached_snapshot(&self) -> Result<Option<PathBuf>> {
+        let result = self.repo.snapshot_download().local_files_only(true).send().await;
         match result {
             Ok(path) => Ok(Some(path)),
             Err(HFError::LocalEntryNotFound { .. } | HFError::EntryNotFound { .. }) => Ok(None),
-            Err(source) => Err(Error::HuggingFaceHubFile {
+            Err(source) => Err(Error::HuggingFaceHubSnapshot {
                 operation: "resolve cached",
-                filename: filename.to_owned(),
                 model_id: self.model_id.to_owned(),
                 source: Box::new(source),
             }),
         }
     }
 
-    async fn download_file(&self, filename: &str) -> Result<PathBuf> {
-        self.repo.download_file().filename(filename).send().await.map_err(|source| {
-            Error::HuggingFaceHubFile {
+    async fn download_file(&self, filename: &str, revision: &str) -> Result<PathBuf> {
+        self.repo
+            .download_file()
+            .filename(filename)
+            .revision(revision)
+            .send()
+            .await
+            .map_err(|source| Error::HuggingFaceHubFile {
                 operation: "download",
                 filename: filename.to_owned(),
                 model_id: self.model_id.to_owned(),
                 source: Box::new(source),
-            }
-        })
+            })
     }
 }
 
@@ -103,7 +105,7 @@ impl ResolvedModelFiles {
     /// finally the Hub.
     pub async fn new(model_id: &str) -> Result<Self> {
         if Path::new(model_id).is_dir() {
-            return resolve_local_model_files(Path::new(model_id));
+            return resolve_model_dir(Path::new(model_id));
         }
         let model = HubModel::from_env(model_id)?;
         if let Some(files) = resolve_cached_model_files(&model).await? {
@@ -113,12 +115,24 @@ impl ResolvedModelFiles {
     }
 }
 
-fn resolve_local_model_files(model_dir: &Path) -> Result<ResolvedModelFiles> {
+fn resolve_model_dir(model_dir: &Path) -> Result<ResolvedModelFiles> {
+    try_resolve_model_dir(model_dir)?.ok_or_else(|| {
+        Error::Tokenizer(format!(
+            "model directory '{}' does not contain a supported tokenizer file \
+             (tokenizer.json, tiktoken.model, or *.tiktoken)",
+            model_dir.display()
+        ))
+    })
+}
+
+fn try_resolve_model_dir(model_dir: &Path) -> Result<Option<ResolvedModelFiles>> {
     let tokenizer_config_path = local_file_if_exists(model_dir, "tokenizer_config.json");
     let tokenizer_config = load_tokenizer_config(tokenizer_config_path.as_deref())?;
-    let tokenizer = resolve_local_tokenizer_source(model_dir, &tokenizer_config)?;
+    let Some(tokenizer) = resolve_tokenizer_source_in_dir(model_dir, &tokenizer_config) else {
+        return Ok(None);
+    };
 
-    Ok(ResolvedModelFiles {
+    Ok(Some(ResolvedModelFiles {
         tokenizer,
         tokenizer_config_path,
         generation_config_path: local_file_if_exists(model_dir, "generation_config.json"),
@@ -130,7 +144,7 @@ fn resolve_local_model_files(model_dir: &Path) -> Result<ResolvedModelFiles> {
         processor_config_path: local_file_if_exists(model_dir, "processor_config.json"),
         chat_template_path: discover_chat_template_in_dir(model_dir),
         config_path: local_file_if_exists(model_dir, "config.json"),
-    })
+    }))
 }
 
 async fn resolve_remote_model_files(model: &HubModel<'_>) -> Result<ResolvedModelFiles> {
@@ -139,189 +153,101 @@ async fn resolve_remote_model_files(model: &HubModel<'_>) -> Result<ResolvedMode
         source: Box::new(source),
     })?;
 
-    let siblings = info
-        .siblings
-        .iter()
-        .flatten()
-        .map(|sibling| sibling.rfilename.as_str())
-        .collect::<std::collections::BTreeSet<_>>();
-
-    let tokenizer_config_path =
-        download_if_present(model, &siblings, "tokenizer_config.json").await?;
-    let tokenizer_config = load_tokenizer_config(tokenizer_config_path.as_deref())?;
-
-    let tokenizer = resolve_remote_tokenizer_source(
-        model,
-        &siblings,
-        tokenizer_config.tokenizer_class.as_deref(),
-    )
-    .await?;
-
-    let generation_config_path =
-        download_if_present(model, &siblings, "generation_config.json").await?;
-    let preprocessor_config_path =
-        download_if_present(model, &siblings, "preprocessor_config.json").await?;
-    let video_preprocessor_config_path =
-        download_if_present(model, &siblings, "video_preprocessor_config.json").await?;
-    let processor_config_path =
-        download_if_present(model, &siblings, "processor_config.json").await?;
-    let chat_template_name = siblings
-        .contains("chat_template.json")
-        .then_some("chat_template.json")
-        .or_else(|| siblings.contains("chat_template.jinja").then_some("chat_template.jinja"))
-        .or_else(|| siblings.iter().copied().find(|name| name.ends_with(".jinja")));
-    let chat_template_path = match chat_template_name {
-        Some(name) => Some(model.download_file(name).await?),
-        None => None,
-    };
-    let config_path = download_if_present(model, &siblings, "config.json").await?;
-
-    Ok(ResolvedModelFiles {
-        tokenizer,
-        tokenizer_config_path,
-        generation_config_path,
-        preprocessor_config_path,
-        video_preprocessor_config_path,
-        processor_config_path,
-        chat_template_path,
-        config_path,
-    })
-}
-
-async fn resolve_cached_model_files(model: &HubModel<'_>) -> Result<Option<ResolvedModelFiles>> {
-    let tokenizer_config_path = model.cached_file("tokenizer_config.json").await?;
-    let tokenizer_config = load_tokenizer_config(tokenizer_config_path.as_deref())?;
-    let config_path = model.cached_file("config.json").await?;
-    let tokenizer =
-        match resolve_cached_tokenizer_source(model, &tokenizer_config, config_path.as_deref())
-            .await?
-        {
-            Some(tokenizer) => tokenizer,
-            None => return Ok(None),
-        };
-
-    let model_dir = tokenizer.path().parent().ok_or_else(|| {
-        Error::Tokenizer("resolved tokenizer file has no parent directory".to_string())
+    let revision = info.sha.as_deref().ok_or_else(|| Error::HuggingFaceHubModelRevision {
+        model_id: model.model_id.to_owned(),
     })?;
-    let generation_config_path = model.cached_file("generation_config.json").await?;
-    let preprocessor_config_path = model.cached_file("preprocessor_config.json").await?;
-    let video_preprocessor_config_path =
-        model.cached_file("video_preprocessor_config.json").await?;
-    let processor_config_path = model.cached_file("processor_config.json").await?;
-    let chat_template_path = discover_chat_template_in_dir(model_dir);
-
-    Ok(Some(ResolvedModelFiles {
-        tokenizer,
-        tokenizer_config_path,
-        generation_config_path,
-        preprocessor_config_path,
-        video_preprocessor_config_path,
-        processor_config_path,
-        chat_template_path,
-        config_path,
-    }))
-}
-
-async fn resolve_remote_tokenizer_source(
-    model: &HubModel<'_>,
-    siblings: &std::collections::BTreeSet<&str>,
-    tokenizer_class: Option<&str>,
-) -> Result<TokenizerSource> {
-    if let Some(tekken_path) = download_if_present(model, siblings, "tekken.json").await? {
-        return Ok(TokenizerSource::Tekken(tekken_path));
-    }
-
-    let tokenizer_path = if siblings.contains("tokenizer.json") {
-        model.download_file("tokenizer.json").await?
-    } else if let Some(tiktoken_name) = find_tiktoken_sibling(siblings) {
-        model.download_file(tiktoken_name).await?
-    } else {
-        return Err(Error::Tokenizer(format!(
-            "model '{}' does not expose a supported tokenizer file \
-             (tokenizer.json, tiktoken.model, or *.tiktoken) on Hugging Face",
-            model.model_id
-        )));
-    };
-
-    Ok(resolve_tokenizer_source(
-        tokenizer_path,
-        tokenizer_class,
-        None,
-    ))
-}
-
-async fn resolve_cached_tokenizer_source(
-    model: &HubModel<'_>,
-    tokenizer_config: &HfTokenizerConfig,
-    config_path: Option<&Path>,
-) -> Result<Option<TokenizerSource>> {
-    if let Some(tekken_path) = model.cached_file("tekken.json").await? {
-        return Ok(Some(TokenizerSource::Tekken(tekken_path)));
-    }
-
-    let tokenizer_path = match model.cached_file("tokenizer.json").await? {
-        Some(path) => Some(path),
-        None => match model.cached_file("tiktoken.model").await? {
-            Some(path) => Some(path),
-            None => config_path.and_then(Path::parent).and_then(discover_tiktoken_in_dir),
-        },
-    };
-    let Some(tokenizer_path) = tokenizer_path else {
-        return Ok(None);
-    };
-
-    Ok(Some(resolve_tokenizer_source(
-        tokenizer_path,
-        tokenizer_config.tokenizer_class.as_deref(),
-        None,
-    )))
-}
-
-fn resolve_local_tokenizer_source(
-    model_dir: &Path,
-    tokenizer_config: &HfTokenizerConfig,
-) -> Result<TokenizerSource> {
-    let tekken_path = local_file_if_exists(model_dir, "tekken.json");
-    if let Some(tekken_path) = tekken_path {
-        return Ok(TokenizerSource::Tekken(tekken_path));
-    }
-
-    let tokenizer_path = local_file_if_exists(model_dir, "tokenizer.json")
-        .or_else(|| local_file_if_exists(model_dir, "tiktoken.model"))
-        .or_else(|| discover_tiktoken_in_dir(model_dir))
+    let mut filenames = collect_remote_model_files(
+        info.siblings.iter().flatten().map(|sibling| sibling.rfilename.as_str()),
+    );
+    let root_filename = filenames
+        .iter()
+        .copied()
+        .find(|filename| is_tokenizer_artifact(filename))
         .ok_or_else(|| {
             Error::Tokenizer(format!(
-                "local model directory '{}' does not contain a supported tokenizer file \
-                 (tokenizer.json, tiktoken.model, or *.tiktoken)",
-                model_dir.display()
+                "model '{}' does not expose a supported tokenizer file \
+             (tokenizer.json, tiktoken.model, or *.tiktoken) on Hugging Face",
+                model.model_id
             ))
         })?;
 
-    Ok(resolve_tokenizer_source(
-        tokenizer_path,
-        tokenizer_config.tokenizer_class.as_deref(),
-        None,
-    ))
+    let root_path = model.download_file(root_filename, revision).await?;
+    let model_dir = model_dir_from_download(&root_path, root_filename)?;
+    filenames.remove(root_filename);
+    for filename in filenames {
+        model.download_file(filename, revision).await?;
+    }
+
+    resolve_model_dir(&model_dir)
 }
 
-/// Choose the tokenizer.
+async fn resolve_cached_model_files(model: &HubModel<'_>) -> Result<Option<ResolvedModelFiles>> {
+    let Some(model_dir) = model.cached_snapshot().await? else {
+        return Ok(None);
+    };
+    try_resolve_model_dir(&model_dir)
+}
+
+const REMOTE_METADATA_FILES: &[&str] = &[
+    "tokenizer_config.json",
+    "generation_config.json",
+    "preprocessor_config.json",
+    "video_preprocessor_config.json",
+    "processor_config.json",
+    "chat_template.json",
+    "config.json",
+];
+
+fn collect_remote_model_files<'a>(
+    siblings: impl IntoIterator<Item = &'a str>,
+) -> std::collections::BTreeSet<&'a str> {
+    siblings
+        .into_iter()
+        .filter(|filename| {
+            REMOTE_METADATA_FILES.contains(filename)
+                || is_tokenizer_artifact(filename)
+                || filename.ends_with(".jinja")
+        })
+        .collect()
+}
+
+fn is_tokenizer_artifact(filename: &str) -> bool {
+    matches!(
+        filename,
+        "tekken.json" | "tokenizer.json" | "tiktoken.model"
+    ) || filename.ends_with(".tiktoken")
+}
+
+/// Choose the tokenizer from a materialized model directory.
 ///
 /// Selection order:
 /// 1. `tekken.json` — Mistral native tokenizer (preferred over HF `tokenizer.json` because the HF
 ///    version has a known regex bug for Mistral models).
-/// 2. File extension — `.tiktoken` / `tiktoken.model` files use tiktoken from BPE data.
-/// 3. `tokenizer_class` in `tokenizer_config.json` — classes containing "Tiktoken" (case-
-///    insensitive) trigger tiktoken loading from a sibling BPE file.
-/// 4. Default — `tokenizer.json` in HuggingFace format.
+/// 2. `tokenizer.json` — classes containing "Tiktoken" in `tokenizer_config.json` redirect to a
+///    sibling BPE file; other classes use the Hugging Face tokenizer.
+/// 3. `tiktoken.model` or `*.tiktoken` — use tiktoken directly from BPE data.
+fn resolve_tokenizer_source_in_dir(
+    model_dir: &Path,
+    tokenizer_config: &HfTokenizerConfig,
+) -> Option<TokenizerSource> {
+    if let Some(tekken_path) = local_file_if_exists(model_dir, "tekken.json") {
+        return Some(TokenizerSource::Tekken(tekken_path));
+    }
+
+    let tokenizer_path = local_file_if_exists(model_dir, "tokenizer.json")
+        .or_else(|| local_file_if_exists(model_dir, "tiktoken.model"))
+        .or_else(|| discover_tiktoken_in_dir(model_dir))?;
+
+    Some(resolve_tokenizer_source(
+        tokenizer_path,
+        tokenizer_config.tokenizer_class.as_deref(),
+    ))
+}
+
 fn resolve_tokenizer_source(
     tokenizer_path: PathBuf,
     tokenizer_class: Option<&str>,
-    tekken_path: Option<PathBuf>,
 ) -> TokenizerSource {
-    if let Some(tekken_path) = tekken_path {
-        return TokenizerSource::Tekken(tekken_path);
-    }
-
     if is_tiktoken_file(&tokenizer_path) {
         return TokenizerSource::Tiktoken(tokenizer_path);
     }
@@ -336,29 +262,21 @@ fn resolve_tokenizer_source(
     TokenizerSource::HuggingFace(tokenizer_path)
 }
 
-/// Download `filename` only if it exists in `siblings`.
-async fn download_if_present(
-    model: &HubModel<'_>,
-    siblings: &std::collections::BTreeSet<&str>,
-    filename: &str,
-) -> Result<Option<PathBuf>> {
-    match siblings.contains(filename) {
-        true => model.download_file(filename).await.map(Some),
-        false => Ok(None),
-    }
+fn model_dir_from_download(path: &Path, filename: &str) -> Result<PathBuf> {
+    path.ancestors()
+        .nth(Path::new(filename).components().count())
+        .map(Path::to_path_buf)
+        .ok_or_else(|| {
+            Error::Tokenizer(format!(
+                "downloaded model file '{}' does not contain repository path '{filename}'",
+                path.display()
+            ))
+        })
 }
 
 fn local_file_if_exists(dir: &Path, filename: &str) -> Option<PathBuf> {
     let path = dir.join(filename);
     path.is_file().then_some(path)
-}
-
-/// Find a tiktoken file name among repo siblings, preferring `tiktoken.model`.
-fn find_tiktoken_sibling<'a>(siblings: &std::collections::BTreeSet<&'a str>) -> Option<&'a str> {
-    if siblings.contains("tiktoken.model") {
-        return Some("tiktoken.model");
-    }
-    siblings.iter().copied().find(|name| name.ends_with(".tiktoken"))
 }
 
 /// Discover a tiktoken model file in a local directory.
@@ -367,17 +285,10 @@ pub(super) fn discover_tiktoken_in_dir(dir: &std::path::Path) -> Option<PathBuf>
     if tiktoken_model.exists() {
         return Some(tiktoken_model);
     }
-    std::fs::read_dir(dir).ok()?.flatten().find_map(|entry| {
-        let path = entry.path();
-        if path
-            .file_name()
+    discover_file_recursively(dir, |path| {
+        path.file_name()
             .and_then(|n| n.to_str())
             .is_some_and(|n| n.ends_with(".tiktoken"))
-        {
-            Some(path)
-        } else {
-            None
-        }
     })
 }
 
@@ -389,7 +300,7 @@ pub(super) fn is_tiktoken_file(path: &std::path::Path) -> bool {
 }
 
 /// Chat templates are sometimes stored as dedicated .jinja files rather than as
-/// a fixed-name config entry, so we scan the cached model dir.
+/// a fixed-name config entry, so we scan the model dir.
 fn discover_chat_template_in_dir(dir: &std::path::Path) -> Option<PathBuf> {
     let json_template_path = dir.join("chat_template.json");
     if json_template_path.exists() {
@@ -401,22 +312,47 @@ fn discover_chat_template_in_dir(dir: &std::path::Path) -> Option<PathBuf> {
         return Some(jinja_path);
     }
 
-    std::fs::read_dir(dir).ok()?.flatten().map(|entry| entry.path()).find(|path| {
+    discover_file_recursively(dir, |path| {
         path.file_name()
             .and_then(|name| name.to_str())
             .is_some_and(|name| name.ends_with(".jinja"))
     })
 }
 
+fn discover_file_recursively(dir: &Path, matches: impl Fn(&Path) -> bool) -> Option<PathBuf> {
+    let mut pending = vec![dir.to_path_buf()];
+    let mut selected: Option<PathBuf> = None;
+
+    while let Some(dir) = pending.pop() {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if entry.file_type().is_ok_and(|file_type| file_type.is_dir()) {
+                pending.push(path);
+            } else if matches(&path) && selected.as_ref().is_none_or(|current| path < *current) {
+                selected = Some(path);
+            }
+        }
+    }
+
+    selected
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::path::Path;
 
     use hf_hub::HFClient;
     use tempfile::tempdir;
     use vllm_tokenizer::{TiktokenTokenizer, Tokenizer};
 
-    use super::{HubModel, ResolvedModelFiles, TokenizerSource, resolve_cached_model_files};
+    use super::{
+        HubModel, ResolvedModelFiles, TokenizerSource, collect_remote_model_files,
+        model_dir_from_download, resolve_cached_model_files,
+    };
 
     #[tokio::test]
     async fn resolved_model_files_prefers_absolute_local_model_dir() {
@@ -492,6 +428,116 @@ mod tests {
         assert_eq!(
             files.chat_template_path,
             Some(snapshot_dir.join("chat_template.jinja"))
+        );
+    }
+
+    #[tokio::test]
+    async fn cached_snapshot_without_tokenizer_is_a_cache_miss() {
+        let cache = tempdir().expect("create cache dir");
+        let repo_dir = cache.path().join("models--test--partial");
+        let commit = "0123456789abcdef0123456789abcdef01234567";
+        let snapshot_dir = repo_dir.join("snapshots").join(commit);
+        fs::create_dir_all(&snapshot_dir).expect("create snapshot dir");
+        fs::create_dir_all(repo_dir.join("refs")).expect("create refs dir");
+        fs::write(repo_dir.join("refs/main"), commit).expect("write main ref");
+        fs::write(snapshot_dir.join("config.json"), "{}").expect("write config");
+
+        let client = HFClient::builder()
+            .endpoint("http://127.0.0.1:1")
+            .cache_dir(cache.path())
+            .build()
+            .expect("build hf-hub client");
+        let model = HubModel::new("test/partial", client);
+
+        assert!(
+            resolve_cached_model_files(&model)
+                .await
+                .expect("inspect cached snapshot")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn downloaded_nested_repo_file_resolves_snapshot_root() {
+        let path =
+            Path::new("/cache/models--test--nested/snapshots/commit/tokenizers/model.tiktoken");
+        assert_eq!(
+            model_dir_from_download(path, "tokenizers/model.tiktoken")
+                .expect("resolve snapshot root"),
+            Path::new("/cache/models--test--nested/snapshots/commit")
+        );
+    }
+
+    #[test]
+    fn directory_resolver_finds_nested_tiktoken_file() {
+        let dir = tempdir().expect("create temp dir");
+        let tokenizer_dir = dir.path().join("tokenizers");
+        fs::create_dir_all(&tokenizer_dir).expect("create tokenizer dir");
+        fs::write(tokenizer_dir.join("model.tiktoken"), "fixture").expect("write tokenizer");
+
+        let files = super::resolve_model_dir(dir.path()).expect("resolve model directory");
+        match files.tokenizer {
+            TokenizerSource::Tiktoken(path) => {
+                assert_eq!(path, tokenizer_dir.join("model.tiktoken"));
+            }
+            other => panic!("expected tiktoken tokenizer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn directory_resolver_owns_tokenizer_and_chat_template_priority() {
+        let dir = tempdir().expect("create temp dir");
+        for filename in [
+            "tekken.json",
+            "tokenizer.json",
+            "tiktoken.model",
+            "chat_template.json",
+            "chat_template.jinja",
+        ] {
+            fs::write(dir.path().join(filename), "fixture").expect("write model file");
+        }
+
+        let files = super::resolve_model_dir(dir.path()).expect("resolve model directory");
+        match files.tokenizer {
+            TokenizerSource::Tekken(path) => {
+                assert_eq!(path, dir.path().join("tekken.json"));
+            }
+            other => panic!("expected Tekken tokenizer, got {other:?}"),
+        }
+        assert_eq!(
+            files.chat_template_path,
+            Some(dir.path().join("chat_template.json"))
+        );
+    }
+
+    #[test]
+    fn remote_model_file_collection_includes_all_candidates() {
+        let siblings = std::collections::BTreeSet::from([
+            "README.md",
+            "config.json",
+            "tokenizer.json",
+            "tokenizer_config.json",
+            "tiktoken.model",
+            "tekken.json",
+            "tokenizers/model.tiktoken",
+            "chat_template.json",
+            "chat_template.jinja",
+            "templates/tool_use.jinja",
+            "model.safetensors",
+        ]);
+        assert_eq!(
+            collect_remote_model_files(siblings),
+            std::collections::BTreeSet::from([
+                "chat_template.jinja",
+                "chat_template.json",
+                "config.json",
+                "tekken.json",
+                "templates/tool_use.jinja",
+                "tiktoken.model",
+                "tokenizer.json",
+                "tokenizer_config.json",
+                "tokenizers/model.tiktoken",
+            ])
         );
     }
 

--- a/rust/src/text/src/backend/hf/model_files.rs
+++ b/rust/src/text/src/backend/hf/model_files.rs
@@ -3,14 +3,10 @@
 
 use std::path::{Path, PathBuf};
 
-use hf_hub::Cache;
-use hf_hub::api::tokio::{Api, ApiBuilder, ApiRepo};
-use thiserror_ext::AsReport as _;
+use hf_hub::{HFClient, HFError, HFRepository, RepoTypeModel, split_id};
 
 use super::config::{HfTokenizerConfig, load_tokenizer_config};
 use crate::error::{Error, Result};
-
-const HF_TOKEN_ENV: &str = "HF_TOKEN";
 
 /// The tokenizer source selected for a model.
 #[derive(Debug, Clone)]
@@ -33,6 +29,55 @@ impl TokenizerSource {
         match self {
             Self::HuggingFace(path) | Self::Tiktoken(path) | Self::Tekken(path) => path,
         }
+    }
+}
+
+/// A typed Hugging Face model repository with shared client configuration.
+struct HubModel<'a> {
+    model_id: &'a str,
+    repo: HFRepository<RepoTypeModel>,
+}
+
+impl<'a> HubModel<'a> {
+    fn from_env(model_id: &'a str) -> Result<Self> {
+        let client = HFClient::new().map_err(|source| Error::HuggingFaceHubClient {
+            source: Box::new(source),
+        })?;
+        Ok(Self::new(model_id, client))
+    }
+
+    fn new(model_id: &'a str, client: HFClient) -> Self {
+        let (owner, name) = split_id(model_id);
+        Self {
+            model_id,
+            repo: client.model(owner, name),
+        }
+    }
+
+    async fn cached_file(&self, filename: &str) -> Result<Option<PathBuf>> {
+        let result =
+            self.repo.download_file().filename(filename).local_files_only(true).send().await;
+        match result {
+            Ok(path) => Ok(Some(path)),
+            Err(HFError::LocalEntryNotFound { .. } | HFError::EntryNotFound { .. }) => Ok(None),
+            Err(source) => Err(Error::HuggingFaceHubFile {
+                operation: "resolve cached",
+                filename: filename.to_owned(),
+                model_id: self.model_id.to_owned(),
+                source: Box::new(source),
+            }),
+        }
+    }
+
+    async fn download_file(&self, filename: &str) -> Result<PathBuf> {
+        self.repo.download_file().filename(filename).send().await.map_err(|source| {
+            Error::HuggingFaceHubFile {
+                operation: "download",
+                filename: filename.to_owned(),
+                model_id: self.model_id.to_owned(),
+                source: Box::new(source),
+            }
+        })
     }
 }
 
@@ -60,10 +105,11 @@ impl ResolvedModelFiles {
         if Path::new(model_id).is_dir() {
             return resolve_local_model_files(Path::new(model_id));
         }
-        if let Some(files) = resolve_cached_model_files(model_id)? {
+        let model = HubModel::from_env(model_id)?;
+        if let Some(files) = resolve_cached_model_files(&model).await? {
             return Ok(files);
         }
-        resolve_remote_model_files(model_id).await
+        resolve_remote_model_files(&model).await
     }
 }
 
@@ -87,52 +133,48 @@ fn resolve_local_model_files(model_dir: &Path) -> Result<ResolvedModelFiles> {
     })
 }
 
-async fn resolve_remote_model_files(model_id: &str) -> Result<ResolvedModelFiles> {
-    let api = build_api().map_err(|error| Error::Tokenizer(error.to_report_string()))?;
-    let repo = api.model(model_id.to_string());
-    let info = repo.info().await.map_err(|error| {
-        Error::Tokenizer(format!(
-            "failed to fetch model '{model_id}': {}",
-            error.as_report()
-        ))
+async fn resolve_remote_model_files(model: &HubModel<'_>) -> Result<ResolvedModelFiles> {
+    let info = model.repo.info().send().await.map_err(|source| Error::HuggingFaceHubModel {
+        model_id: model.model_id.to_owned(),
+        source: Box::new(source),
     })?;
 
     let siblings = info
         .siblings
         .iter()
+        .flatten()
         .map(|sibling| sibling.rfilename.as_str())
         .collect::<std::collections::BTreeSet<_>>();
 
     let tokenizer_config_path =
-        download_if_present(&repo, model_id, &siblings, "tokenizer_config.json").await?;
+        download_if_present(model, &siblings, "tokenizer_config.json").await?;
     let tokenizer_config = load_tokenizer_config(tokenizer_config_path.as_deref())?;
 
     let tokenizer = resolve_remote_tokenizer_source(
-        &repo,
-        model_id,
+        model,
         &siblings,
         tokenizer_config.tokenizer_class.as_deref(),
     )
     .await?;
 
     let generation_config_path =
-        download_if_present(&repo, model_id, &siblings, "generation_config.json").await?;
+        download_if_present(model, &siblings, "generation_config.json").await?;
     let preprocessor_config_path =
-        download_if_present(&repo, model_id, &siblings, "preprocessor_config.json").await?;
+        download_if_present(model, &siblings, "preprocessor_config.json").await?;
     let video_preprocessor_config_path =
-        download_if_present(&repo, model_id, &siblings, "video_preprocessor_config.json").await?;
+        download_if_present(model, &siblings, "video_preprocessor_config.json").await?;
     let processor_config_path =
-        download_if_present(&repo, model_id, &siblings, "processor_config.json").await?;
+        download_if_present(model, &siblings, "processor_config.json").await?;
     let chat_template_name = siblings
         .contains("chat_template.json")
         .then_some("chat_template.json")
         .or_else(|| siblings.contains("chat_template.jinja").then_some("chat_template.jinja"))
         .or_else(|| siblings.iter().copied().find(|name| name.ends_with(".jinja")));
     let chat_template_path = match chat_template_name {
-        Some(name) => Some(download_known_file(&repo, model_id, name).await?),
+        Some(name) => Some(model.download_file(name).await?),
         None => None,
     };
-    let config_path = download_if_present(&repo, model_id, &siblings, "config.json").await?;
+    let config_path = download_if_present(model, &siblings, "config.json").await?;
 
     Ok(ResolvedModelFiles {
         tokenizer,
@@ -146,25 +188,27 @@ async fn resolve_remote_model_files(model_id: &str) -> Result<ResolvedModelFiles
     })
 }
 
-fn resolve_cached_model_files(model_id: &str) -> Result<Option<ResolvedModelFiles>> {
-    let cache_repo = Cache::from_env().model(model_id.to_string());
-
-    let tokenizer_config_path = cache_repo.get("tokenizer_config.json");
+async fn resolve_cached_model_files(model: &HubModel<'_>) -> Result<Option<ResolvedModelFiles>> {
+    let tokenizer_config_path = model.cached_file("tokenizer_config.json").await?;
     let tokenizer_config = load_tokenizer_config(tokenizer_config_path.as_deref())?;
-    let tokenizer = match resolve_cached_tokenizer_source(&cache_repo, &tokenizer_config)? {
-        Some(tokenizer) => tokenizer,
-        None => return Ok(None),
-    };
+    let config_path = model.cached_file("config.json").await?;
+    let tokenizer =
+        match resolve_cached_tokenizer_source(model, &tokenizer_config, config_path.as_deref())
+            .await?
+        {
+            Some(tokenizer) => tokenizer,
+            None => return Ok(None),
+        };
 
     let model_dir = tokenizer.path().parent().ok_or_else(|| {
         Error::Tokenizer("resolved tokenizer file has no parent directory".to_string())
     })?;
-    let generation_config_path = cache_repo.get("generation_config.json");
-    let preprocessor_config_path = cache_repo.get("preprocessor_config.json");
-    let video_preprocessor_config_path = cache_repo.get("video_preprocessor_config.json");
-    let processor_config_path = cache_repo.get("processor_config.json");
+    let generation_config_path = model.cached_file("generation_config.json").await?;
+    let preprocessor_config_path = model.cached_file("preprocessor_config.json").await?;
+    let video_preprocessor_config_path =
+        model.cached_file("video_preprocessor_config.json").await?;
+    let processor_config_path = model.cached_file("processor_config.json").await?;
     let chat_template_path = discover_chat_template_in_dir(model_dir);
-    let config_path = cache_repo.get("config.json");
 
     Ok(Some(ResolvedModelFiles {
         tokenizer,
@@ -179,23 +223,23 @@ fn resolve_cached_model_files(model_id: &str) -> Result<Option<ResolvedModelFile
 }
 
 async fn resolve_remote_tokenizer_source(
-    repo: &ApiRepo,
-    model_id: &str,
+    model: &HubModel<'_>,
     siblings: &std::collections::BTreeSet<&str>,
     tokenizer_class: Option<&str>,
 ) -> Result<TokenizerSource> {
-    if let Some(tekken_path) = download_if_present(repo, model_id, siblings, "tekken.json").await? {
+    if let Some(tekken_path) = download_if_present(model, siblings, "tekken.json").await? {
         return Ok(TokenizerSource::Tekken(tekken_path));
     }
 
     let tokenizer_path = if siblings.contains("tokenizer.json") {
-        download_known_file(repo, model_id, "tokenizer.json").await?
+        model.download_file("tokenizer.json").await?
     } else if let Some(tiktoken_name) = find_tiktoken_sibling(siblings) {
-        download_known_file(repo, model_id, tiktoken_name).await?
+        model.download_file(tiktoken_name).await?
     } else {
         return Err(Error::Tokenizer(format!(
-            "model '{model_id}' does not expose a supported tokenizer file \
-             (tokenizer.json, tiktoken.model, or *.tiktoken) on Hugging Face"
+            "model '{}' does not expose a supported tokenizer file \
+             (tokenizer.json, tiktoken.model, or *.tiktoken) on Hugging Face",
+            model.model_id
         )));
     };
 
@@ -206,24 +250,23 @@ async fn resolve_remote_tokenizer_source(
     ))
 }
 
-fn resolve_cached_tokenizer_source(
-    cache_repo: &hf_hub::CacheRepo,
+async fn resolve_cached_tokenizer_source(
+    model: &HubModel<'_>,
     tokenizer_config: &HfTokenizerConfig,
+    config_path: Option<&Path>,
 ) -> Result<Option<TokenizerSource>> {
-    let tekken_path = cache_repo.get("tekken.json");
-
-    if let Some(tekken_path) = tekken_path {
+    if let Some(tekken_path) = model.cached_file("tekken.json").await? {
         return Ok(Some(TokenizerSource::Tekken(tekken_path)));
     }
 
-    let Some(tokenizer_path) = cache_repo.get("tokenizer.json").or_else(|| {
-        // tiktoken.model is the most common name, try it first.
-        cache_repo.get("tiktoken.model").or_else(|| {
-            // Scan for any *.tiktoken file in the cache snapshot directory.
-            let snapshot_dir = cache_repo.get("config.json")?.parent()?.to_path_buf();
-            discover_tiktoken_in_dir(&snapshot_dir)
-        })
-    }) else {
+    let tokenizer_path = match model.cached_file("tokenizer.json").await? {
+        Some(path) => Some(path),
+        None => match model.cached_file("tiktoken.model").await? {
+            Some(path) => Some(path),
+            None => config_path.and_then(Path::parent).and_then(discover_tiktoken_in_dir),
+        },
+    };
+    let Some(tokenizer_path) = tokenizer_path else {
         return Ok(None);
     };
 
@@ -295,34 +338,14 @@ fn resolve_tokenizer_source(
 
 /// Download `filename` only if it exists in `siblings`.
 async fn download_if_present(
-    repo: &ApiRepo,
-    model_id: &str,
+    model: &HubModel<'_>,
     siblings: &std::collections::BTreeSet<&str>,
     filename: &str,
 ) -> Result<Option<PathBuf>> {
     match siblings.contains(filename) {
-        true => download_known_file(repo, model_id, filename).await.map(Some),
+        true => model.download_file(filename).await.map(Some),
         false => Ok(None),
     }
-}
-
-async fn download_known_file(repo: &ApiRepo, model_id: &str, filename: &str) -> Result<PathBuf> {
-    repo.get(filename).await.map_err(|error| {
-        Error::Tokenizer(format!(
-            "failed to download '{filename}' for model '{model_id}': {}",
-            error.as_report()
-        ))
-    })
-}
-
-fn build_api() -> anyhow::Result<Api> {
-    let mut builder = ApiBuilder::from_env().with_progress(true);
-    if let Ok(token) = std::env::var(HF_TOKEN_ENV)
-        && !token.is_empty()
-    {
-        builder = builder.with_token(Some(token));
-    }
-    Ok(builder.build()?)
 }
 
 fn local_file_if_exists(dir: &Path, filename: &str) -> Option<PathBuf> {
@@ -389,10 +412,11 @@ fn discover_chat_template_in_dir(dir: &std::path::Path) -> Option<PathBuf> {
 mod tests {
     use std::fs;
 
+    use hf_hub::HFClient;
     use tempfile::tempdir;
     use vllm_tokenizer::{TiktokenTokenizer, Tokenizer};
 
-    use super::{ResolvedModelFiles, TokenizerSource};
+    use super::{HubModel, ResolvedModelFiles, TokenizerSource, resolve_cached_model_files};
 
     #[tokio::test]
     async fn resolved_model_files_prefers_absolute_local_model_dir() {
@@ -419,6 +443,55 @@ mod tests {
         assert_eq!(
             files.tokenizer_config_path,
             Some(dir.path().join("tokenizer_config.json"))
+        );
+    }
+
+    #[tokio::test]
+    async fn resolved_model_files_uses_hf_cache_without_network() {
+        let cache = tempdir().expect("create cache dir");
+        let repo_dir = cache.path().join("models--test--cached");
+        let commit = "0123456789abcdef0123456789abcdef01234567";
+        let snapshot_dir = repo_dir.join("snapshots").join(commit);
+        fs::create_dir_all(&snapshot_dir).expect("create snapshot dir");
+        fs::create_dir_all(repo_dir.join("refs")).expect("create refs dir");
+        fs::write(repo_dir.join("refs/main"), commit).expect("write main ref");
+        fs::write(
+            snapshot_dir.join("tokenizer_config.json"),
+            r#"{"tokenizer_class":"TiktokenTokenizer"}"#,
+        )
+        .expect("write tokenizer config");
+        fs::write(snapshot_dir.join("tiktoken.model"), "fixture").expect("write tokenizer");
+        fs::write(snapshot_dir.join("config.json"), "{}").expect("write config");
+        fs::write(snapshot_dir.join("generation_config.json"), "{}")
+            .expect("write generation config");
+        fs::write(snapshot_dir.join("chat_template.jinja"), "{{ messages }}")
+            .expect("write chat template");
+
+        let client = HFClient::builder()
+            .endpoint("http://127.0.0.1:1")
+            .cache_dir(cache.path())
+            .build()
+            .expect("build hf-hub client");
+        let model = HubModel::new("test/cached", client);
+        let files = resolve_cached_model_files(&model)
+            .await
+            .expect("resolve cached model files")
+            .expect("cached tokenizer is complete");
+
+        match files.tokenizer {
+            TokenizerSource::Tiktoken(path) => {
+                assert_eq!(path, snapshot_dir.join("tiktoken.model"));
+            }
+            other => panic!("expected tiktoken tokenizer, got {other:?}"),
+        }
+        assert_eq!(files.config_path, Some(snapshot_dir.join("config.json")));
+        assert_eq!(
+            files.generation_config_path,
+            Some(snapshot_dir.join("generation_config.json"))
+        );
+        assert_eq!(
+            files.chat_template_path,
+            Some(snapshot_dir.join("chat_template.jinja"))
         );
     }
 

--- a/rust/src/text/src/error.rs
+++ b/rust/src/text/src/error.rs
@@ -23,6 +23,15 @@ pub enum Error {
         #[source]
         source: Box<hf_hub::HFError>,
     },
+    #[error("model `{model_id}` metadata from Hugging Face Hub has no commit revision")]
+    HuggingFaceHubModelRevision { model_id: String },
+    #[error("failed to {operation} snapshot for model `{model_id}` through Hugging Face Hub")]
+    HuggingFaceHubSnapshot {
+        operation: &'static str,
+        model_id: String,
+        #[source]
+        source: Box<hf_hub::HFError>,
+    },
     #[error("failed to {operation} `{filename}` for model `{model_id}` through Hugging Face Hub")]
     HuggingFaceHubFile {
         operation: &'static str,

--- a/rust/src/text/src/error.rs
+++ b/rust/src/text/src/error.rs
@@ -12,6 +12,25 @@ pub use crate::lower::token_ids::TokenIdsError;
 pub enum Error {
     #[error("tokenizer error: {0}")]
     Tokenizer(String),
+    #[error("failed to create Hugging Face Hub client")]
+    HuggingFaceHubClient {
+        #[source]
+        source: Box<hf_hub::HFError>,
+    },
+    #[error("failed to fetch model `{model_id}` from Hugging Face Hub")]
+    HuggingFaceHubModel {
+        model_id: String,
+        #[source]
+        source: Box<hf_hub::HFError>,
+    },
+    #[error("failed to {operation} `{filename}` for model `{model_id}` through Hugging Face Hub")]
+    HuggingFaceHubFile {
+        operation: &'static str,
+        filename: String,
+        model_id: String,
+        #[source]
+        source: Box<hf_hub::HFError>,
+    },
     #[error("text request `{request_id}` must contain at least one prompt token ID")]
     EmptyPromptTokenIds { request_id: String },
     #[error(

--- a/rust/src/tokenizer/benches/hf.rs
+++ b/rust/src/tokenizer/benches/hf.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
-use hf_hub::api::tokio::ApiBuilder;
+use hf_hub::{HFClient, split_id};
 use tokio::runtime::Runtime;
 use vllm_tokenizer::{HuggingFaceTokenizer, Tokenizer};
 
@@ -60,12 +60,13 @@ impl BenchFixture {
 
 fn tokenizer_json() -> std::path::PathBuf {
     Runtime::new().expect("build tokio runtime").block_on(async {
-        ApiBuilder::from_env()
-            .with_progress(false)
-            .build()
+        let (owner, name) = split_id(MODEL_ID);
+        HFClient::new()
             .expect("build hf-hub api")
-            .model(MODEL_ID.to_string())
-            .get("tokenizer.json")
+            .model(owner, name)
+            .download_file()
+            .filename("tokenizer.json")
+            .send()
             .await
             .expect("fetch tokenizer.json from hf-hub")
     })

--- a/rust/src/tokenizer/benches/tiktoken.rs
+++ b/rust/src/tokenizer/benches/tiktoken.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
-use hf_hub::api::tokio::ApiBuilder;
+use hf_hub::{HFClient, split_id};
 use tokio::runtime::Runtime;
 use vllm_tokenizer::{TiktokenTokenizer, Tokenizer};
 
@@ -57,16 +57,23 @@ impl BenchFixture {
 
 fn tiktoken_model() -> std::path::PathBuf {
     Runtime::new().expect("build tokio runtime").block_on(async {
-        let repo = ApiBuilder::from_env()
-            .with_progress(false)
-            .build()
-            .expect("build hf-hub api")
-            .model(MODEL_ID.to_string());
-        repo.get("config.json").await.expect("fetch config.json from hf-hub");
-        repo.get("tokenizer_config.json")
+        let (owner, name) = split_id(MODEL_ID);
+        let repo = HFClient::new().expect("build hf-hub api").model(owner, name);
+        repo.download_file()
+            .filename("config.json")
+            .send()
+            .await
+            .expect("fetch config.json from hf-hub");
+        repo.download_file()
+            .filename("tokenizer_config.json")
+            .send()
             .await
             .expect("fetch tokenizer_config.json from hf-hub");
-        repo.get("tiktoken.model").await.expect("fetch tiktoken.model from hf-hub")
+        repo.download_file()
+            .filename("tiktoken.model")
+            .send()
+            .await
+            .expect("fetch tiktoken.model from hf-hub")
     })
 }
 


### PR DESCRIPTION
## Purpose

This draft explores migrating the Rust frontend from `hf-hub` 0.5 to 1.0.

The implementation follows the redesigned 1.0 API:

- reuse one `HFClient` and a typed `HFRepository<RepoTypeModel>`
- resolve cached files through `download_file().local_files_only(true)`
- classify structured `HFError` variants and preserve their source chains
- use the builder-based `info()` and `download_file()` APIs
- migrate the tokenizer benchmarks
- remove the unused `llm-multimodal` `hf-hub` feature so the dependency graph contains one `hf-hub` version

### Blockers

#### 1. Rust TLS and crypto violate the workspace dependency policy

`hf-hub` 1.0.0 has two paths that activate Rust TLS:

1. Its direct `reqwest 0.13` dependency keeps reqwest's default features, which select `default-tls -> rustls`.
2. Its unconditional `hf-xet` dependency reaches `xet-client`, whose default feature is `rustls-tls`.

`reqwest 0.13`'s `rustls` feature selects the AWS-LC provider. As a result, `cargo deny check bans` fails for:

- `rustls`
- `aws-lc-rs`
- `aws-lc-sys`

The Rust workspace deliberately uses `native-tls`/OpenSSL and bans these crates in `rust/deny.toml`. `hf-hub` 1.0.0 exposes no downstream feature combination that selects `native-tls` for both paths.

#### 2. Xet-backed cold-cache downloads stall on GCP

On a GCP GB200 host, a cold-cache download for `moonshotai/Kimi-K2.5` consistently behaves as follows:

- `tokenizer_config.json` downloads successfully.
- The 2,795,286-byte Xet-backed `tiktoken.model` remains at zero downloaded bytes until the test timeout.
- Reducing Xet concurrency and setting explicit connect/read timeouts produces the same result.
- A direct HTTP range request to the same resolve URL returns `206` immediately.

Related upstream reports include [xet-core#800](https://github.com/huggingface/xet-core/issues/800) and [xet-core#869](https://github.com/huggingface/xet-core/issues/869). The proposal to make `hf-xet` optional was closed in [huggingface/hf-hub#181](https://github.com/huggingface/hf-hub/pull/181).

#### Dependency impact

The lockfile grows from 575 to 668 packages. The 93-package net increase comes from the unconditional Xet stack, `reqwest 0.13`, rustls/AWS-LC, and their platform-specific dependencies.

This PR will remain a draft while the two blockers above are active.

## Test Plan

```bash
cd rust
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo nextest run --workspace
cargo deny check bans
```

Cold-cache reproduction:

```bash
cd rust
HF_HUB_CACHE="$(mktemp -d)" \
  cargo nextest run -p vllm-text \
  tiktoken_real_kimi_k25_tokenizer_files_load_and_handle_special_tokens \
  --run-ignored ignored-only
```

## Test Result

- `cargo fmt --all -- --check`: passed
- `cargo clippy --workspace --all-targets -- -D warnings`: passed
- `cargo nextest run --workspace`: 1,205 passed, 1 skipped
- cache-only resolution test with an unreachable endpoint: passed
- `cargo deny check bans`: failed on `rustls`, `aws-lc-rs`, and `aws-lc-sys` as documented above
- cold-cache Xet reproduction: stalled at zero bytes for `tiktoken.model`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is documented.
- [x] The test plan is documented.
- [x] Test results and current blockers are documented.
- [x] Documentation impact was reviewed; this dependency migration requires no user-facing documentation update.

</details>

