### PR TITLE
[Bugfix][Frontend] Handle None/NaN/Inf logprob values when using FP8 quantization

### DIFF
--- a/tests/samplers/test_logprobs.py
+++ b/tests/samplers/test_logprobs.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import math
+
 import pytest
 
 from vllm import SamplingParams
-from vllm.logprobs import FlatLogprobs
+from vllm.logprobs import FlatLogprobs, clamp_logprob
 
 MODELS = ["distilbert/distilgpt2"]
 MAX_TOKENS = 5
@@ -89,3 +91,30 @@ def test_ranks(
             assert set(range(1, NUM_TOP_LOGPROBS + 1)).issubset(
                 {logprob.rank for logprob in logprobs.values()}
             )
+
+
+# ---------------------------------------------------------------------------
+# Tests for logprob clamping (fix for None / nan / inf logprob values)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_logprob, expected",
+    [
+        (None, -9999.0),  # not computed
+        (float("-inf"), -9999.0),  # zero-probability token
+        (float("inf"), -9999.0),  # abnormal value
+        (float("nan"), -9999.0),  # numerical instability
+        (-1.5, -1.5),  # normal value passes through
+        (-99999.0, -9999.0),  # finite but below floor
+    ],
+)
+def test_clamp_logprob(bad_logprob, expected):
+    """clamp_logprob must handle None / non-finite values without raising.
+
+    Before the fix, the call site used max(logprob, -9999.0), which raises
+    TypeError when logprob is None, and silently passes through nan/inf.
+    """
+    result = clamp_logprob(bad_logprob)
+    assert result == expected
+    assert math.isfinite(result)

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -41,7 +41,7 @@ from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 from vllm.exceptions import VLLMValidationError
 from vllm.inputs import EngineInput
 from vllm.logger import init_logger
-from vllm.logprobs import Logprob
+from vllm.logprobs import Logprob, clamp_logprob
 from vllm.outputs import RequestOutput
 from vllm.renderers.online_renderer import OnlineRenderer
 from vllm.sampling_params import BeamSearchParams, SamplingParams
@@ -700,7 +700,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
                     tokenizer,
                     return_as_token_id=should_return_as_token_id,
                 )
-                token_logprob = max(step_token.logprob, -9999.0)
+                token_logprob = clamp_logprob(step_token.logprob)
 
                 out_tokens.append(token)
                 out_token_logprobs.append(token_logprob)
@@ -718,7 +718,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
                             top_lp[0],
                             tokenizer,
                             return_as_token_id=should_return_as_token_id,
-                        ): max(top_lp[1].logprob, -9999.0)
+                        ): clamp_logprob(top_lp[1].logprob)
                         for i, top_lp in enumerate(step_top_logprobs.items())
                         if logprob_token_ids or num_output_top_logprobs >= i
                     }

--- a/vllm/logprobs.py
+++ b/vllm/logprobs.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
+import math
 from collections.abc import Iterable, Iterator, MutableSequence
 from dataclasses import dataclass, field
 from typing import overload
@@ -204,3 +205,22 @@ def append_logprobs_for_next_position(
                 )
             }
         )
+
+
+# Fallback value used by the OpenAI-compatible API for non-finite logprobs
+# (None, nan, or ±inf). Matches the sentinel used in the original vLLM impl.
+_LOGPROB_FALLBACK = -9999.0
+
+
+def clamp_logprob(logprob: float | None) -> float:
+    """Return a finite logprob, clamping non-finite / missing values.
+
+    Handles three cases that would break JSON serialization or downstream
+    consumers:
+      - None : logprob was not computed
+      - nan  : numerical instability
+      - ±inf : float("-inf") is common for zero-probability tokens
+    """
+    if logprob is None or not math.isfinite(logprob):
+        return _LOGPROB_FALLBACK
+    return max(logprob, _LOGPROB_FALLBACK)


### PR DESCRIPTION
## Purpose

When using FP8 quantization (`--quantization fp8`), token logprobs can be `None`, `NaN`, or `±inf` due to numerical underflow or instability in the quantized computation path. The existing code used `max(step_token.logprob, -9999.0)` which raises `TypeError` when `logprob` is `None`, and silently propagates `NaN`/`inf` to the JSON response, causing a serialization failure:

```
ValueError: Out of range float values are not JSON compliant
```

This issue is not universally reproducible — it was observed on a fine-tuned model under specific request conditions. However, the root cause (non-finite logprob values leaking into the serving layer) is a latent risk for any FP8-quantized model, so this fix is intentionally **defensive**.

This PR introduces a `clamp_logprob()` helper in `vllm/logprobs.py` that safely handles all three cases (`None`, `NaN`, `±inf`) by clamping them to `-9999.0` — the sentinel value already used by vLLM for zero-probability tokens — and applies it at both call sites in `_create_completion_logprobs`.

Fixes: logprob JSON serialization error when using FP8 quantization with `logprobs` enabled.

## Test Plan

Run the unit test (no GPU required):

```bash
pytest tests/samplers/test_logprobs.py::test_clamp_logprob -v
```

To reproduce the original bug end-to-end (note: this is **not universally reproducible** — it was triggered on a fine-tuned Qwen3-VL model under specific request conditions; the fix is defensive and covers any case where FP8 quantization produces non-finite logprob values):

```bash
# Start server with FP8 quantization
python -m vllm.entrypoints.openai.api_server \
    --model <your-model> \
    --quantization fp8 \
    --port 8000

# Send a request with logprobs enabled
curl http://localhost:8000/v1/completions \
    -H "Content-Type: application/json" \
    -d '{"model": "<your-fp8-model>", "prompt": "Hello", "max_tokens": 10, "logprobs": 5}'
```

## Test Result

**Before fix** — server crashes with:

```
ValueError: Out of range float values are not JSON compliant
```

Server-side traceback:
```
File "vllm/entrypoints/openai/completion/api_router.py", line 57, in create_completion
    return JSONResponse(
  ...
  File "/usr/local/lib/python3.10/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
ValueError: Out of range float values are not JSON compliant
```

Client receives: `Engine internal server error!: Internal server error, error_msg is Out of range float values are not JSON compliant, error_cause is None`

**After fix** — request succeeds, non-finite logprobs are clamped to `-9999.0`:

```json
{
  "logprobs": {
    "token_logprobs": [-9999, -9999, ...],
    "tokens": ["!", "!", ...],
    "top_logprobs": [{"!": -9999, "\"": -9999, ...}, ...]
  }
}
```

**Unit test result:**
```
platform linux -- Python 3.10.12, pytest-9.0.2, pluggy-1.6.0
collected 6 items

test_logprobs.py::test_clamp_logprob[None--9999.0] PASSED                [ 16%]
test_logprobs.py::test_clamp_logprob[-inf--9999.0] PASSED                [ 33%]
test_logprobs.py::test_clamp_logprob[inf--9999.0] PASSED                 [ 50%]
test_logprobs.py::test_clamp_logprob[nan--9999.0] PASSED                 [ 66%]
test_logprobs.py::test_clamp_logprob[-1.5--1.5] PASSED                   [ 83%]
test_logprobs.py::test_clamp_logprob[-99999.0--9999.0] PASSED            [100%]

======================== 6 passed, 2 warnings in 5.45s =========================
```
