### PR TITLE
[Bugfix] Reject CUTLASS block-scaled FP8 when N is not a multiple of 128

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
@@ -307,6 +307,31 @@ class CutlassFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
                 "Supports only dynamic per token group activation "
                 "quantization with group_shape=(1,128).",
             )
+
+        # The CUTLASS block-scaled FP8 GEMM (sm90/sm100/sm120) tiles the weight
+        # scale factors with a fixed (128, 128) granularity along (N, K) and
+        # provides no kernel for a partial N tile (the swap_ab dispatch only
+        # handles small/unaligned M). If N is not a multiple of the weight
+        # block size, CUTLASS' gemm_op.can_implement() rejects the problem at
+        # runtime and raises "Invalid status". Report this here so kernel
+        # selection can fall back to a kernel that supports it (e.g. Triton)
+        # instead of crashing. See e.g. Qwen3.5 GDN in_proj layers (N=16).
+        weight_group_shape = config.weight_quant_key.scale.group_shape
+        n, k = config.weight_shape
+        if weight_group_shape.row > 0 and n % weight_group_shape.row != 0:
+            return (
+                False,
+                f"CUTLASS block-scaled FP8 requires the output dim N ({n}) to "
+                f"be a multiple of the weight block size "
+                f"({weight_group_shape.row}).",
+            )
+        if weight_group_shape.col > 0 and k % weight_group_shape.col != 0:
+            return (
+                False,
+                f"CUTLASS block-scaled FP8 requires the input dim K ({k}) to "
+                f"be a multiple of the weight block size "
+                f"({weight_group_shape.col}).",
+            )
         return True, None
 
     def apply_block_scaled_mm(


### PR DESCRIPTION
## Purpose
`--quantization fp8_per_block` crashes at startup for models that have a linear
layer whose output dim N is not a multiple of the weight block size (128).

`CutlassFp8BlockScaledMMKernel` gets selected by kernel auto-selection, but the
CUTLASS c3x block-scaled FP8 GEMM (sm90/sm100/sm120) tiles the weight scale
factors with a fixed (128,128) granularity along (N,K) and its dispatch only
special-cases small/unaligned M (swap_ab). There is no kernel for a partial N
tile, so `gemm_op.can_implement()` rejects the problem at runtime:

```
RuntimeError: cutlass_gemm_caller, .../c3x/cutlass_gemm_caller.cuh:52, Invalid status
```

`CUTLASS_BLOCK_FP8_SUPPORTED` is True and `can_implement()` did not validate the
shape, so selection picked CUTLASS and aborted instead of falling back.

## Fix
Add an N (and K) block-alignment check to
`CutlassFp8BlockScaledMMKernel.can_implement()`. When N (or K) is not a multiple
of the weight block size, report the kernel as unable to implement, so
per-layer selection falls back to a kernel that supports the shape (e.g.
`TritonFp8BlockScaledMMKernel`). Aligned layers keep the fast CUTLASS path.

## Repro
Model: `Qwen/Qwen3.5-0.8B` (GDN `language_model.layers.*.linear_attn.in_proj_a/b`
weights are `[16, 1024]`, i.e. N=16), GPU: RTX PRO 5000 (Blackwell, sm_120),
vLLM `0.23.1rc1.dev1060+g9e57de719`.

Kernel-level (before fix):
| N | N%128 | cutlass | triton |
|---|---|---|---|
| 1024 / 512 | 0 | OK | OK |
| 320 / 64 | !=0 | FAIL (Invalid status) | OK |

End-to-end:
- Before: `vllm serve Qwen/Qwen3.5-0.8B --quantization fp8_per_block` → EngineCore fails to start (Invalid status). Workaround was `--kernel-config '{"linear_backend":"triton"}'` (forces ALL linear layers to Triton).
- After: same command starts and serves correctly with the default `auto` backend; logs show both `CutlassFp8BlockScaledMMKernel` and `TritonFp8BlockScaledMMKernel` selected (per-layer).

## Test Plan
- Existing scaled-mm kernel selection tests.
- Manual: serve Qwen3.5-0.8B with `--quantization fp8_per_block` on sm_120 and confirm startup + correct generation.