### PR TITLE
[Bugfix] Pad unaligned N in SM12x CUTLASS blockwise FP8 GEMM

### DIFF
--- a/tests/kernels/quantization/test_block_fp8.py
+++ b/tests/kernels/quantization/test_block_fp8.py
@@ -13,10 +13,23 @@ from tests.kernels.quant_utils import (
 )
 from tests.kernels.utils import fp8_ulp_distance
 from vllm.config import VllmConfig
-from vllm.model_executor.kernels.linear.scaled_mm.cutlass import cutlass_scaled_mm
+from vllm.model_executor.kernels.linear.scaled_mm.cutlass import (
+    CutlassFp8BlockScaledMMKernel,
+    cutlass_scaled_mm,
+)
+from vllm.model_executor.kernels.linear.scaled_mm.ScaledMMLinearKernel import (
+    FP8ScaledMMLinearLayerConfig,
+)
+from vllm.model_executor.kernels.linear.scaled_mm.triton import (
+    TritonFp8BlockScaledMMKernel,
+)
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8,
     w8a8_triton_block_scaled_mm,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    GroupShape,
+    create_fp8_quant_key,
 )
 from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import (
@@ -156,13 +169,20 @@ def test_w8a8_block_fp8_matmul(M, N, K, block_size, out_dtype, seed):
 @pytest.mark.skipif(
     not current_platform.is_cuda(), reason="CUTLASS only supported on CUDA platform."
 )
+@pytest.mark.parametrize("M", [1, 32, 256])
+@pytest.mark.parametrize(
+    ("N", "K"),
+    [
+        # weight.shape[0] % 128 != 0, like DSV3 kv_a_proj_with_mqa; on SM12x
+        # the kernel requires N padded to the 128 scale block (#47990).
+        (576, 7168),
+        (2112, 1536),
+        # aligned control
+        (512, 7168),
+    ],
+)
 @torch.inference_mode()
-def test_w8a8_block_fp8_cutlass_matmul():
-    # Test simple case where weight.shape % 128 != 0,
-    # like in DSV3 kv_a_proj_with_mqa
-    M = 32
-    N = 576
-    K = 7168
+def test_w8a8_block_fp8_cutlass_matmul(M, N, K):
     block_size = [128, 128]
     out_dtype = torch.bfloat16
     seed = 0
@@ -198,6 +218,92 @@ def test_w8a8_block_fp8_cutlass_matmul():
         torch.abs(out.to(torch.float32) - ref_out.to(torch.float32))
     ) / torch.mean(torch.abs(ref_out.to(torch.float32)))
     assert rel_diff < 0.001
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="CUTLASS only supported on CUDA platform."
+)
+@torch.inference_mode()
+def test_cutlass_fp8_block_kernel_unaligned_n_layer(default_vllm_config):
+    # Layer-level path for weight.shape[0] % 128 != 0 (#47990): on SM12x the
+    # kernel zero-pads N to the 128 scale block at load time and slices the
+    # padding off at apply time; on other architectures the weight is
+    # untouched. Uses a 3D input to also cover the logical output_shape.
+    N, K = 576, 7168
+    batch, seq = 2, 16
+    torch.manual_seed(0)
+
+    is_supported, reason = CutlassFp8BlockScaledMMKernel.is_supported()
+    if not is_supported:
+        pytest.skip(reason)
+
+    fp8_info = torch.finfo(torch.float8_e4m3fn)
+    weight_fp32 = (torch.rand(N, K, dtype=torch.float32) - 0.5) * 2 * fp8_info.max
+    weight = weight_fp32.clamp(fp8_info.min, fp8_info.max).to(torch.float8_e4m3fn)
+    weight_scale = (
+        torch.rand((N + 127) // 128, (K + 127) // 128, dtype=torch.float32) * 1e-2
+    )
+
+    config = FP8ScaledMMLinearLayerConfig(
+        weight_quant_key=create_fp8_quant_key(
+            static=True, group_shape=GroupShape(128, 128)
+        ),
+        activation_quant_key=create_fp8_quant_key(
+            static=False, group_shape=GroupShape(1, 128)
+        ),
+        weight_shape=(N, K),
+        input_dtype=torch.bfloat16,
+        out_dtype=torch.bfloat16,
+    )
+    kernel = CutlassFp8BlockScaledMMKernel(config)
+    triton_kernel = TritonFp8BlockScaledMMKernel(config)
+
+    def make_layer():
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(weight.clone(), requires_grad=False)
+        layer.weight_scale_inv = torch.nn.Parameter(
+            weight_scale.clone(), requires_grad=False
+        )
+        layer.input_scale = None
+        return layer
+
+    layer = make_layer()
+    kernel.process_weights_after_loading(layer)
+    expected_rows = 640 if current_platform.is_device_capability_family(120) else N
+    assert layer.weight.shape[0] == expected_rows
+
+    ref_layer = make_layer()
+    triton_kernel.process_weights_after_loading(ref_layer)
+    assert ref_layer.weight.shape[0] == N
+
+    x = torch.randn(batch, seq, K, dtype=torch.bfloat16)
+    bias = torch.randn(N, dtype=torch.bfloat16)
+    out = kernel.apply_weights(layer, x, bias)
+    assert out.shape == (batch, seq, N)
+
+    # Both kernels share the base apply_weights and QuantFP8 activation
+    # quantization, so the comparison isolates the GEMM (and the pad/slice).
+    ref_out = triton_kernel.apply_weights(ref_layer, x, bias)
+    rel_diff = torch.mean(
+        torch.abs(out.to(torch.float32) - ref_out.to(torch.float32))
+    ) / torch.mean(torch.abs(ref_out.to(torch.float32)))
+    assert rel_diff < 0.001
+
+    # Loose sanity check against the native reference (quantized with an
+    # independent implementation, hence the wide tolerance).
+    x_fp8, x_scale = per_token_group_quant_fp8(
+        x.view(-1, K).float(), 128, column_major_scales=False
+    )
+    native_ref = (
+        native_w8a8_block_matmul(
+            x_fp8, weight, x_scale, weight_scale, [128, 128], torch.bfloat16
+        )
+        + bias
+    )
+    native_rel_diff = torch.mean(
+        torch.abs(out.view(-1, N).to(torch.float32) - native_ref.to(torch.float32))
+    ) / torch.mean(torch.abs(native_ref.to(torch.float32)))
+    assert native_rel_diff < 0.05
 
 
 @pytest.mark.skipif(

--- a/tests/kernels/quantization/test_block_fp8.py
+++ b/tests/kernels/quantization/test_block_fp8.py
@@ -18,10 +18,23 @@ from vllm.model_executor.kernels.linear.scaled_mm.b12x import (
     B12xFp8BlockScaledMMKernel,
     _run_b12x_fp8_block_scaled_mm,
 )
-from vllm.model_executor.kernels.linear.scaled_mm.cutlass import cutlass_scaled_mm
+from vllm.model_executor.kernels.linear.scaled_mm.cutlass import (
+    CutlassFp8BlockScaledMMKernel,
+    cutlass_scaled_mm,
+)
+from vllm.model_executor.kernels.linear.scaled_mm.ScaledMMLinearKernel import (
+    FP8ScaledMMLinearLayerConfig,
+)
+from vllm.model_executor.kernels.linear.scaled_mm.triton import (
+    TritonFp8BlockScaledMMKernel,
+)
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8,
     w8a8_triton_block_scaled_mm,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    GroupShape,
+    create_fp8_quant_key,
 )
 from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import (
@@ -161,13 +174,20 @@ def test_w8a8_block_fp8_matmul(M, N, K, block_size, out_dtype, seed):
 @pytest.mark.skipif(
     not current_platform.is_cuda(), reason="CUTLASS only supported on CUDA platform."
 )
+@pytest.mark.parametrize("M", [1, 32, 256])
+@pytest.mark.parametrize(
+    ("N", "K"),
+    [
+        # weight.shape[0] % 128 != 0, like DSV3 kv_a_proj_with_mqa; on SM12x
+        # the kernel requires N padded to the 128 scale block (#47990).
+        (576, 7168),
+        (2112, 1536),
+        # aligned control
+        (512, 7168),
+    ],
+)
 @torch.inference_mode()
-def test_w8a8_block_fp8_cutlass_matmul():
-    # Test simple case where weight.shape % 128 != 0,
-    # like in DSV3 kv_a_proj_with_mqa
-    M = 32
-    N = 576
-    K = 7168
+def test_w8a8_block_fp8_cutlass_matmul(M, N, K):
     block_size = [128, 128]
     out_dtype = torch.bfloat16
     seed = 0
@@ -262,6 +282,92 @@ def test_w8a8_block_fp8_torch_scaled_mm_matmul():
         torch.abs(out.to(torch.float32) - ref_out.to(torch.float32))
     ) / torch.mean(torch.abs(ref_out.to(torch.float32)))
     assert rel_diff < 0.001
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="CUTLASS only supported on CUDA platform."
+)
+@torch.inference_mode()
+def test_cutlass_fp8_block_kernel_unaligned_n_layer(default_vllm_config):
+    # Layer-level path for weight.shape[0] % 128 != 0 (#47990): on SM12x the
+    # kernel zero-pads N to the 128 scale block at load time and slices the
+    # padding off at apply time; on other architectures the weight is
+    # untouched. Uses a 3D input to also cover the logical output_shape.
+    N, K = 576, 7168
+    batch, seq = 2, 16
+    torch.manual_seed(0)
+
+    is_supported, reason = CutlassFp8BlockScaledMMKernel.is_supported()
+    if not is_supported:
+        pytest.skip(reason)
+
+    fp8_info = torch.finfo(torch.float8_e4m3fn)
+    weight_fp32 = (torch.rand(N, K, dtype=torch.float32) - 0.5) * 2 * fp8_info.max
+    weight = weight_fp32.clamp(fp8_info.min, fp8_info.max).to(torch.float8_e4m3fn)
+    weight_scale = (
+        torch.rand((N + 127) // 128, (K + 127) // 128, dtype=torch.float32) * 1e-2
+    )
+
+    config = FP8ScaledMMLinearLayerConfig(
+        weight_quant_key=create_fp8_quant_key(
+            static=True, group_shape=GroupShape(128, 128)
+        ),
+        activation_quant_key=create_fp8_quant_key(
+            static=False, group_shape=GroupShape(1, 128)
+        ),
+        weight_shape=(N, K),
+        input_dtype=torch.bfloat16,
+        out_dtype=torch.bfloat16,
+    )
+    kernel = CutlassFp8BlockScaledMMKernel(config)
+    triton_kernel = TritonFp8BlockScaledMMKernel(config)
+
+    def make_layer():
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(weight.clone(), requires_grad=False)
+        layer.weight_scale_inv = torch.nn.Parameter(
+            weight_scale.clone(), requires_grad=False
+        )
+        layer.input_scale = None
+        return layer
+
+    layer = make_layer()
+    kernel.process_weights_after_loading(layer)
+    expected_rows = 640 if current_platform.is_device_capability_family(120) else N
+    assert layer.weight.shape[0] == expected_rows
+
+    ref_layer = make_layer()
+    triton_kernel.process_weights_after_loading(ref_layer)
+    assert ref_layer.weight.shape[0] == N
+
+    x = torch.randn(batch, seq, K, dtype=torch.bfloat16)
+    bias = torch.randn(N, dtype=torch.bfloat16)
+    out = kernel.apply_weights(layer, x, bias)
+    assert out.shape == (batch, seq, N)
+
+    # Both kernels share the base apply_weights and QuantFP8 activation
+    # quantization, so the comparison isolates the GEMM (and the pad/slice).
+    ref_out = triton_kernel.apply_weights(ref_layer, x, bias)
+    rel_diff = torch.mean(
+        torch.abs(out.to(torch.float32) - ref_out.to(torch.float32))
+    ) / torch.mean(torch.abs(ref_out.to(torch.float32)))
+    assert rel_diff < 0.001
+
+    # Loose sanity check against the native reference (quantized with an
+    # independent implementation, hence the wide tolerance).
+    x_fp8, x_scale = per_token_group_quant_fp8(
+        x.view(-1, K).float(), 128, column_major_scales=False
+    )
+    native_ref = (
+        native_w8a8_block_matmul(
+            x_fp8, weight, x_scale, weight_scale, [128, 128], torch.bfloat16
+        )
+        + bias
+    )
+    native_rel_diff = torch.mean(
+        torch.abs(out.view(-1, N).to(torch.float32) - native_ref.to(torch.float32))
+    ) / torch.mean(torch.abs(native_ref.to(torch.float32)))
+    assert native_rel_diff < 0.05
 
 
 @pytest.mark.skipif(

--- a/vllm/model_executor/kernels/linear/scaled_mm/BlockScaledMMLinearKernel.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/BlockScaledMMLinearKernel.py
@@ -114,7 +114,10 @@ class Fp8BlockScaledMMLinearKernel(
 
         # View input as 2D matrix for fp8 methods
         input_2d = x.view(-1, x.shape[-1])
-        output_shape = [*x.shape[:-1], weight.shape[0]]
+        # The weight tensor may carry kernel-specific padding (e.g. the SM12x
+        # CUTLASS kernel pads N to the 128 scale block), so the logical output
+        # width comes from the layer config rather than weight.shape[0].
+        output_shape = [*x.shape[:-1], self.config.weight_shape[0]]
 
         if self.apply_input_quant:
             q_input, input_scale = self.quant_fp8(

--- a/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
@@ -153,6 +153,27 @@ class CutlassInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         )
 
 
+def _pad_to_alignment(
+    x: torch.Tensor, dim: int, alignment: int, value: float = 0.0
+) -> torch.Tensor:
+    """Pad tensor ``x`` along ``dim`` to the next multiple of ``alignment``."""
+    remainder = x.shape[dim] % alignment
+    if remainder == 0:
+        return x
+    pad_size = alignment - remainder
+    pad_spec = [0] * (2 * x.dim())
+    pad_spec[-(2 * dim + 1)] = pad_size
+    return torch.nn.functional.pad(x, pad_spec, value=value)
+
+
+def padded_weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
+    if loaded_weight.shape != param.shape:
+        slices = tuple(slice(0, s) for s in loaded_weight.shape)
+        param.data[slices].copy_(loaded_weight)
+    else:
+        param.data.copy_(loaded_weight.view(param.shape))
+
+
 class CutlassFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
     def __init__(
         self, c: FP8ScaledMMLinearLayerConfig, layer_param_names: Sequence[str]
@@ -179,28 +200,6 @@ class CutlassFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
             return kFp8StaticTensorSym
         return None
 
-    @staticmethod
-    def _pad_to_alignment(
-        x: torch.Tensor, dim: int, alignment: int, value: float = 0.0
-    ) -> torch.Tensor:
-        """Pad tensor ``x`` along ``dim`` to the next multiple of
-        ``alignment``."""
-        remainder = x.shape[dim] % alignment
-        if remainder == 0:
-            return x
-        pad_size = alignment - remainder
-        pad_spec = [0] * (2 * x.dim())
-        pad_spec[-(2 * dim + 1)] = pad_size
-        return torch.nn.functional.pad(x, pad_spec, value=value)
-
-    @staticmethod
-    def padded_weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
-        if loaded_weight.shape != param.shape:
-            slices = tuple(slice(0, s) for s in loaded_weight.shape)
-            param.data[slices].copy_(loaded_weight)
-        else:
-            param.data.copy_(loaded_weight.view(param.shape))
-
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         weight_name, weight_scale_name, _, _ = self.layer_param_names
         weight = getattr(layer, weight_name)
@@ -222,21 +221,21 @@ class CutlassFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
         set_weight_attrs(
             getattr(layer, weight_name),
             {
-                "weight_loader": self.padded_weight_loader,
+                "weight_loader": padded_weight_loader,
             },
         )
 
         weight_scale = getattr(layer, weight_scale_name, None)
         if weight_scale is not None and pad_n > 0 and weight_scale.numel() > 1:
             flat_scale = weight_scale.reshape(-1)
-            padded_scale = self._pad_to_alignment(
+            padded_scale = _pad_to_alignment(
                 flat_scale, dim=0, alignment=16, value=1.0
             ).view(-1, *weight_scale.shape[1:])
             replace_parameter(layer, weight_scale_name, padded_scale.data)
             set_weight_attrs(
                 getattr(layer, weight_name),
                 {
-                    "weight_loader": self.padded_weight_loader,
+                    "weight_loader": padded_weight_loader,
                 },
             )
 
@@ -258,9 +257,9 @@ class CutlassFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
         pad_n = padded_n - output_size
 
         if pad_k > 0:
-            A = self._pad_to_alignment(A, dim=1, alignment=16)
+            A = _pad_to_alignment(A, dim=1, alignment=16)
         if pad_n > 0 and bias is not None:
-            bias = self._pad_to_alignment(bias, dim=0, alignment=16)
+            bias = _pad_to_alignment(bias, dim=0, alignment=16)
 
         output = ops.cutlass_scaled_mm(
             A, B, out_dtype=out_dtype, scale_a=As, scale_b=Bs, bias=bias
@@ -309,6 +308,33 @@ class CutlassFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             )
         return True, None
 
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        super().process_weights_after_loading(layer)
+        # The SM12x blockwise kernels reject shapes whose N is not a multiple
+        # of the 128x128 scale block, e.g. the N=576 kv_a_proj_with_mqa in
+        # DeepSeek models (https://github.com/vllm-project/vllm/issues/47990).
+        # Zero-pad N up to the block size: the padded rows fall in the last,
+        # already present, scale block and only produce zero output columns,
+        # which apply_block_scaled_mm slices away.
+        if not current_platform.is_device_capability_family(120):
+            return
+        params = self._get_layer_params(layer)
+        padded_weight = _pad_to_alignment(params.weight, dim=0, alignment=128)
+        if padded_weight is params.weight:
+            return
+        weight_scale = (
+            params.weight_scale
+            if params.weight_scale_inv is None
+            else params.weight_scale_inv
+        )
+        assert weight_scale is not None
+        assert weight_scale.shape[0] * 128 == padded_weight.shape[0]
+        replace_parameter(layer, params.WEIGHT, padded_weight.data)
+        set_weight_attrs(
+            getattr(layer, params.WEIGHT),
+            {"weight_loader": padded_weight_loader},
+        )
+
     def apply_block_scaled_mm(
         self,
         A: torch.Tensor,
@@ -317,13 +343,17 @@ class CutlassFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
         Bs: torch.Tensor,
     ) -> torch.Tensor:
         out_dtype = self.config.out_dtype
-        return ops.cutlass_scaled_mm(
+        output = ops.cutlass_scaled_mm(
             A,
             B.T,
             out_dtype=out_dtype,
             scale_a=As,
             scale_b=Bs.T,
         )
+        out_features = self.config.weight_shape[0]
+        if output.shape[-1] != out_features:
+            output = output[..., :out_features].contiguous()
+        return output
 
 
 def cutlass_scaled_mm(
@@ -334,10 +364,18 @@ def cutlass_scaled_mm(
     block_size: list[int],
     output_dtype: torch.dtype = torch.float16,
 ) -> torch.Tensor:
-    return ops.cutlass_scaled_mm(
+    out_features = B.shape[0]
+    if current_platform.is_device_capability_family(120):
+        # Per-call padding is acceptable here: this wrapper is a test/utility
+        # surface; the layer path pads once in process_weights_after_loading.
+        B = _pad_to_alignment(B, dim=0, alignment=128)
+    output = ops.cutlass_scaled_mm(
         A,
         B.T,
         out_dtype=output_dtype,
         scale_a=As,
         scale_b=Bs.T,
     )
+    if output.shape[-1] != out_features:
+        output = output[..., :out_features].contiguous()
+    return output


### PR DESCRIPTION
## Purpose

Fixes #47990.

The SM120 CUTLASS c3x blockwise FP8 GEMM rejects every problem whose weight output dim N is not a multiple of 128: all three tile configs in `scaled_mm_blockwise_sm120_fp8_dispatch.cuh` fail CUTLASS `can_implement`. N=576 is `kv_a_proj_with_mqa` (512+64) in DeepSeek-V3-family models, so any block-FP8 DeepSeek-shaped checkpoint crashes at engine startup with `cutlass_gemm_caller ... Invalid status` whenever the layer routes to the CUTLASS kernel (e.g. wherever DeepGEMM is unavailable or auto-disabled on SM12x, see #47436 / #47169).

This implements the padding remediation suggested in the issue: zero-pad the weight N to the next multiple of 128 once at load time, and slice the padded columns off after the GEMM. The padded rows land inside the last, already-present scale block (checkpoint scales have `ceil(N/128)` rows), so the scale tensor needs no change. This is the same pattern `CutlassFP8ScaledMMLinearKernel` already uses for its 16-element alignment padding, and NVFP4 uses via `pad_nvfp4_weight_for_cutlass`.

Changes:

- `scaled_mm/cutlass.py`: move the `_pad_to_alignment` / `padded_weight_loader` helpers from `CutlassFP8ScaledMMLinearKernel` to module scope so both CUTLASS kernels share them; `CutlassFp8BlockScaledMMKernel.process_weights_after_loading` pads N on SM12x (installing `padded_weight_loader` so weight reloads keep working) and `apply_block_scaled_mm` slices the output back to the logical width; the module-level `cutlass_scaled_mm` wrapper (test surface) pads per call.
- `scaled_mm/BlockScaledMMLinearKernel.py`: the base `apply_weights` derives the logical output width from `config.weight_shape[0]` instead of `weight.shape[0]`, since the weight may now carry padding.
- `tests/kernels/quantization/test_block_fp8.py`: parametrize `test_w8a8_block_fp8_cutlass_matmul` over M x (N, K) including the previously-failing N=576 / N=2112 plus an aligned control, and add a layer-level test covering load-time padding, output slicing, bias, and a 3D input, compared head-to-head against `TritonFp8BlockScaledMMKernel` (both share the base `apply_weights` and `QuantFP8`, isolating the GEMM and pad/slice).

## Why padding instead of falling back to Triton

#47988 adds a selection-level guard that declines unaligned N on SM12x so those layers fall through to Triton. That is correct for safety, but keeps DeepSeek-shaped layers off the faster kernel. Measured on an RTX PRO 5000 Blackwell (SM120, CUDA 13.0, torch 2.11.0+cu130), padded CUTLASS **including the output-slice copy** vs `w8a8_triton_block_scaled_mm` (default config; no tuned JSON exists for this device):

| M | N=576, K=7168 (kv_a_proj) | N=2112, K=1536 |
|---|---|---|
| 1 | 21.5 us vs 57.6 us (**2.68x**) | 21.0 us vs 33.2 us (**1.58x**) |
| 16 | 25.8 us vs 59.6 us (**2.31x**) | 25.0 us vs 35.9 us (**1.44x**) |
| 64 | 24.8 us vs 71.2 us (**2.87x**) | 25.0 us vs 34.5 us (**1.38x**) |
| 256 | 30.8 us vs 59.7 us (**1.93x**) | 25.0 us vs 33.2 us (**1.33x**) |
| 1024 | 55.4 us vs 61.6 us (1.11x) | 32.9 us vs 34.0 us (1.03x) |
| 4096 | 110.8 us vs 147.7 us (1.33x) | 81.1 us vs 89.8 us (1.11x) |

Correctness sweep vs the fp32-dequant native reference: rel err <= 2e-8 across M in {1, 32, 83, 256} x N in {576, 2112}, identical to Triton's error.

If this lands, the SM12x `N % 128` guard in #47988 becomes unnecessary (its E8M0 handling is orthogonal and still needed) — happy to coordinate, cc @waynehacking8.

The remaining kernel-level gap (native ragged-N support in the CUTLASS SM120 blockwise collectives) is upstream CUTLASS work; padding at the integration layer costs at most 127 zero columns on a single projection (64 x 7168 FP8 = 448 KiB for DeepSeek's kv_a_proj).

## Test Plan

All executed on RTX PRO 5000 Blackwell (SM120), CUDA 13.0, torch 2.11.0+cu130, precompiled kernels at merge-base:

- `pytest tests/kernels/quantization/test_block_fp8.py -k cutlass`: **10 passed** (the N=576 case fails on current main with `Invalid status`).
- Full `test_block_fp8.py`: no new failures (the pre-existing SM120 DeepGEMM failures are identical on clean main).
- `pytest tests/kernels/quantization/test_cutlass_scaled_mm.py -k fp8`: **261 passed** (validates the helper refactor; the file's int8 tests fail on SM120 with "Int8 not supported on SM120" both before and after this change).
- `pre-commit` (ruff check/format, typos, SPDX, etc.) and `mypy` clean on the changed files.
- E2E A/B with a tiny DeepSeek-V3-arch block-FP8 config (`kv_a_proj_with_mqa` N=576, `--load-format dummy`, `--linear-backend cutlass`, dense-only to avoid unrelated SM120 MoE issues):
  - main: `Selected CutlassFp8BlockScaledMMKernel for Fp8LinearMethod` -> `EngineCore failed to start ... RuntimeError: cutlass_gemm_caller ... Invalid status`
  - this PR: same selection -> startup completes and generation works.

## Test Result

See above; all listed tests pass on SM120 hardware.

---

AI tooling assisted with this change; I reviewed all changes and ran every test and benchmark above on my own SM120 hardware.
