### PR TITLE
[Model] Fix MiniMax M3 top-k buffer views

### DIFF
--- a/vllm/models/minimax_m3/amd/model.py
+++ b/vllm/models/minimax_m3/amd/model.py
@@ -1083,8 +1083,8 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
             tp_size = get_tensor_model_parallel_world_size()
             num_index_heads = max(1, sparse_cfg["sparse_num_index_heads"] // tp_size)
             self.topk_indices_buffer = torch.empty(
-                num_index_heads,
                 vllm_config.scheduler_config.max_num_batched_tokens,
+                num_index_heads,
                 sparse_cfg["sparse_topk_blocks"],
                 dtype=torch.int32,
             )

--- a/vllm/models/minimax_m3/common/indexer.py
+++ b/vllm/models/minimax_m3/common/indexer.py
@@ -420,9 +420,7 @@ class MiniMaxM3IndexerTritonImpl(MiniMaxM3IndexerImpl):
         )
         kv = self.index_cache.kv_cache
 
-        # Both sides write into the single shared persistent topk_indices_buffer
-        # (decode at [:, :nd], prefill at [:, nd:]) and return views into it; the
-        # kernels' out= writes out[:, :total_q]. None -> allocate fresh.
+        # Triton kernels use head-major views of the token-major shared buffer.
         buf = self.topk_indices_buffer
         decode_topk: torch.Tensor | None = None
         prefill_topk: torch.Tensor | None = None
@@ -441,7 +439,7 @@ class MiniMaxM3IndexerTritonImpl(MiniMaxM3IndexerImpl):
                 self.num_kv_heads,
                 d.decode_query_len,
                 d.max_decode_query_len,
-                out=buf,
+                out=buf[:nd].transpose(0, 1) if buf is not None else None,
             )
         if index_md.num_prefills > 0:
             p = index_md.prefill
@@ -465,7 +463,7 @@ class MiniMaxM3IndexerTritonImpl(MiniMaxM3IndexerImpl):
                 self.topk_blocks,
                 self.init_blocks,
                 self.local_blocks,
-                out=buf[:, nd:, :] if buf is not None else None,
+                out=buf[nd:].transpose(0, 1) if buf is not None else None,
             )
         return decode_topk, prefill_topk
 

--- a/vllm/models/minimax_m3/common/sparse_attention.py
+++ b/vllm/models/minimax_m3/common/sparse_attention.py
@@ -383,7 +383,6 @@ class MiniMaxM3SparseTritonImpl(MiniMaxM3SparseImpl):
 
         nd = main_md.num_decode_tokens
         num_tokens = main_md.num_actual_tokens
-        # Indexer top-k from the shared buffer: decode [:, :nd], prefill [:, nd:].
         topk = layer.topk_indices_buffer  # type: ignore[attr-defined]
         assert topk is not None
         hd = self.head_size
@@ -402,7 +401,7 @@ class MiniMaxM3SparseTritonImpl(MiniMaxM3SparseImpl):
             minimax_m3_sparse_attn_decode(
                 q[:nd],
                 kv_cache,
-                topk[:, :nd, :],
+                topk[:nd].transpose(0, 1),
                 d.block_table,
                 d.seq_lens,
                 self.num_kv_heads,
@@ -420,7 +419,7 @@ class MiniMaxM3SparseTritonImpl(MiniMaxM3SparseImpl):
             minimax_m3_sparse_attn(
                 q[nd:],
                 kv_cache,
-                topk[:, nd:num_tokens, :],
+                topk[nd:num_tokens].transpose(0, 1),
                 p.block_table,
                 p.cu_seqlens_q,
                 p.seq_lens,


### PR DESCRIPTION
## Summary

- keep the MiniMax M3 persistent top-k buffer token-major (`[T, H, K]`) on NVIDIA and AMD
- pass head-major transposed views (`[H, T, K]`) at Triton indexer write and sparse-attention read boundaries
- prevent incorrect shape/stride interpretation that causes CUDA illegal memory access on the A100 Triton path

Fixes #48603.

## Why this is not a duplicate

I searched existing vLLM issues and open PRs for MiniMax M3 top-k buffer layout, `index_topk`, and CUDA illegal-memory-access fixes. No existing issue or open PR addresses this mismatch.

## Test plan

- [x] `uv run --no-project python -m py_compile vllm/models/minimax_m3/amd/model.py vllm/models/minimax_m3/common/indexer.py vllm/models/minimax_m3/common/sparse_attention.py`
- [x] Manual model evaluation on 8x NVIDIA A100, TP=8, using MiniMax-M3-MXFP8
- [x] 100/100 long-context benchmark requests completed successfully after the fix
- [x] LMCache registered all 117 MiniMax M3 KV tensors and inference remained stable
- [ ] SM100 MSA hardware validation
- [ ] ROCm hardware validation

## Model evaluation

Before the fix, inference failed in `minimax_m3_index_topk` / `_topk_index_kernel` with `Triton Error [CUDA]: an illegal memory access was encountered`. After the fix, the same A100 deployment completed the long-context benchmark without worker crashes.