### PR TITLE
[Kernel] TRITON_MLA SWA

### DIFF
--- a/tests/kernels/attention/test_triton_decode_sliding_window_bug.py
+++ b/tests/kernels/attention/test_triton_decode_sliding_window_bug.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kernel-only reproducer for the TRITON split-KV decode sliding-window bug.
+
+The split-KV decode kernels disagree on how the KV range is tiled when a
+sliding window is active:
+
+* stage 1 (``_fwd_kernel_stage1`` / ``_fwd_grouped_kernel_stage1``) tiles only
+  the *windowed* range ``[seq_len - W, seq_len)`` -- so trailing splits can be
+  empty and are left unwritten in ``attn_logits``.
+* stage 2 (``_fwd_kernel_stage2``) recomputes split boundaries from the *full*
+  ``seq_len`` (it is never told the window) and merges every split whose
+  full-seq range is non-empty -- including the ones stage 1 left unwritten.
+
+``attn_logits`` is allocated with ``torch.empty`` (uninitialized), so stage 2
+folds garbage LSE/values into the softmax merge. In production this is
+*intermittent* (depends on what is in memory) and only appears once the dynamic
+``num_kv_splits`` grows past the window (long context). Here we make it
+deterministic by poisoning ``attn_logits`` with a large finite value before the
+call, then assert the property the kernel must satisfy: **the result must not
+depend on num_kv_splits.**
+
+Run: pytest -q tests/kernels/attention/test_triton_decode_sliding_window_bug.py
+Fails on buggy code (the >window split count diverges), passes once stage 2 is
+made window-aware.
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.attention.ops.triton_decode_attention import decode_attention_fwd
+
+DEVICE = current_platform.device_type
+
+# Small, model-independent MHA setup (kv_group_num == 1 -> normal kernel path).
+B, H, D = 1, 1, 16
+SEQ_LEN = 64
+WINDOW = 8
+POISON = 1.0e30
+
+
+def _run(num_kv_splits: int) -> torch.Tensor:
+    torch.manual_seed(0)
+    q = torch.randn(B, H, D, dtype=torch.bfloat16, device=DEVICE)
+    k = torch.randn(SEQ_LEN, H, D, dtype=torch.bfloat16, device=DEVICE)
+    v = torch.randn(SEQ_LEN, H, D, dtype=torch.bfloat16, device=DEVICE)
+    # Identity paged mapping, page_size = 1.
+    req_to_token = torch.arange(SEQ_LEN, device=DEVICE).view(1, SEQ_LEN)
+    b_seq_len = torch.full((B,), SEQ_LEN, device=DEVICE)
+
+    o = torch.zeros(B, H, D, dtype=torch.bfloat16, device=DEVICE)
+    lse = torch.zeros(B, H, dtype=torch.bfloat16, device=DEVICE)
+    # Poison the scratch buffer to model worst-case uninitialized memory.
+    attn_logits = torch.full(
+        (B, H, num_kv_splits, D + 1), POISON, dtype=torch.float32, device=DEVICE
+    )
+
+    decode_attention_fwd(
+        q,
+        k,
+        v,
+        o,
+        lse,
+        req_to_token,
+        b_seq_len,
+        attn_logits,
+        num_kv_splits,
+        1.0 / (D**0.5),
+        page_size=1,
+        sliding_window=WINDOW,
+    )
+    return o
+
+
+def _torch_windowed_ref() -> torch.Tensor:
+    torch.manual_seed(0)
+    q = torch.randn(B, H, D, dtype=torch.bfloat16, device=DEVICE).float()
+    k = torch.randn(SEQ_LEN, H, D, dtype=torch.bfloat16, device=DEVICE).float()
+    v = torch.randn(SEQ_LEN, H, D, dtype=torch.bfloat16, device=DEVICE).float()
+    sw_start = max(SEQ_LEN - WINDOW, 0)
+    kw = k[sw_start:SEQ_LEN, 0]  # [W, D]
+    vw = v[sw_start:SEQ_LEN, 0]
+    scores = (q[0, 0] @ kw.T) * (1.0 / (D**0.5))  # [W]
+    p = torch.softmax(scores, dim=-1)
+    return (p @ vw).view(B, H, D)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(), reason="Triton decode kernel needs GPU"
+)
+def test_sliding_window_decode_independent_of_num_kv_splits():
+    ref = _torch_windowed_ref()
+    out_1 = _run(num_kv_splits=1)  # 1 split: no empty split -> correct
+    out_4 = _run(num_kv_splits=4)  # 4 <= W, divides W: no empty split -> correct
+    out_16 = _run(num_kv_splits=16)  # 16 > W: trailing empty splits -> bug
+
+    # Baselines agree with the windowed reference.
+    torch.testing.assert_close(out_1.float(), ref, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(out_4.float(), ref, atol=2e-2, rtol=2e-2)
+    # The property under test: the result must not depend on the split count.
+    # On buggy code out_16 is dominated by the poisoned (unwritten) splits.
+    torch.testing.assert_close(out_16.float(), out_1.float(), atol=2e-2, rtol=2e-2)

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -45,6 +45,7 @@ from vllm.v1.attention.ops.flashmla import is_flashmla_dense_supported
 from vllm.v1.kv_cache_interface import (
     KVQuantMode,
     MLAAttentionSpec,
+    SlidingWindowMLASpec,
 )
 
 BACKENDS_TO_TEST = [
@@ -970,6 +971,7 @@ def run_attention_backend(
     k_scale: float,
     kv_cache_dtype: str = "auto",
     prefill_backend: MLAPrefillBackendEnum | None = None,
+    sliding_window: int | None = None,
 ) -> torch.Tensor:
     """Run attention computation using the specified backend's AttentionImpl."""
 
@@ -1000,7 +1002,7 @@ def run_attention_backend(
             scale=scale,
             num_kv_heads=num_kv_heads,
             alibi_slopes=None,
-            sliding_window=None,
+            sliding_window=sliding_window,
             kv_cache_dtype=kv_cache_dtype,
             logits_soft_cap=None,
             attn_type="decoder",
@@ -1599,3 +1601,494 @@ def test_backend_correctness(
         summary = f"{len(failures)} backend(s) failed: {', '.join(backend_names)}"
         detailed_msg = "\n".join(failures)
         pytest.fail(f"{summary}\n{detailed_msg}")
+
+
+def test_triton_mla_sliding_window_correctness(
+    default_vllm_config, dist_init, workspace_init
+):
+    """TritonMLAImpl decode output with sliding window matches windowed SDPA reference.
+
+    Verifies both that the window is applied (output differs from full attention)
+    and that it is applied correctly (output matches windowed SDPA reference).
+    """
+    if AttentionBackendEnum.TRITON_MLA not in BACKENDS_TO_TEST:
+        pytest.skip("TRITON_MLA not available on this platform")
+
+    sliding_window = 32
+    # seq_lens must all exceed sliding_window so masking is active.
+    batch_spec = BatchSpec(seq_lens=[64, 128, 96], query_lens=[1, 1, 1])
+    model = "deepseek-ai/DeepSeek-R1"
+    device = torch.device(f"{DEVICE_TYPE}:0")
+    block_size = BACKEND_BLOCK_SIZES[AttentionBackendEnum.TRITON_MLA]
+
+    required_blocks = sum(
+        (s + block_size - 1) // block_size for s in batch_spec.seq_lens
+    )
+    num_gpu_blocks = required_blocks + 1 + 10
+
+    vllm_config = create_vllm_config(
+        model_name=model,
+        tensor_parallel_size=1,
+        max_model_len=max(batch_spec.seq_lens),
+        num_gpu_blocks=num_gpu_blocks,
+        block_size=block_size,
+    )
+
+    num_q_heads = vllm_config.model_config.get_num_attention_heads(
+        vllm_config.parallel_config
+    )
+    head_size = vllm_config.model_config.get_head_size()
+    dtype = _convert_dtype_to_torch(vllm_config.model_config.dtype)
+    kv_lora_rank = 512
+    qk_rope_head_dim = 64
+    qk_nope_head_dim = 128
+    v_head_dim = 128
+    scale = (qk_nope_head_dim + qk_rope_head_dim) ** -0.5
+
+    weight_scale = kv_lora_rank**-0.5
+    W_UK = (
+        torch.randn(
+            kv_lora_rank, num_q_heads, qk_nope_head_dim, dtype=dtype, device=device
+        )
+        * weight_scale
+    )
+    W_UV = (
+        torch.randn(kv_lora_rank, num_q_heads, v_head_dim, dtype=dtype, device=device)
+        * weight_scale
+    )
+
+    all_q_vllm, all_kv_c_vllm, all_k_pe_vllm = [], [], []
+    all_sdpa_windowed, all_sdpa_full = [], []
+    kv_c_contexts, k_pe_contexts = [], []
+
+    for s_len in batch_spec.seq_lens:
+        # query_len=1 for all sequences
+        context_len = s_len - 1
+
+        q_c = torch.randn(
+            1,
+            num_q_heads,
+            qk_nope_head_dim + qk_rope_head_dim,
+            dtype=dtype,
+            device=device,
+        )
+        kv_c_full = torch.randn(s_len, kv_lora_rank, dtype=dtype, device=device)
+        k_pe_full = torch.randn(s_len, 1, qk_rope_head_dim, dtype=dtype, device=device)
+
+        q_nope, q_pe = q_c.split([qk_nope_head_dim, qk_rope_head_dim], dim=-1)
+        ql_nope = torch.einsum("qnh,lnh->qnl", q_nope, W_UK)
+        q_mqa = torch.cat([ql_nope, q_pe], dim=-1)
+        k_mqa = (
+            torch.cat([kv_c_full, k_pe_full.squeeze(1)], dim=-1)
+            .unsqueeze(1)
+            .expand(-1, num_q_heads, -1)
+        )
+        v_mqa = kv_c_full.unsqueeze(1).expand(-1, num_q_heads, -1)
+
+        # SDPA expects (N=1, H, L, D)
+        q_sdpa = q_mqa.unsqueeze(0).transpose(1, 2)
+        k_sdpa = k_mqa.unsqueeze(0).transpose(1, 2)
+        v_sdpa = v_mqa.unsqueeze(0).transpose(1, 2)
+
+        # Full-attention mask: decode token attends to all KV positions
+        full_mask = torch.ones(1, s_len, dtype=torch.bool, device=device)
+
+        # Sliding-window mask: only the last `sliding_window` positions are visible
+        kv_positions = torch.arange(s_len, device=device)
+        windowed_mask = (context_len - kv_positions < sliding_window).unsqueeze(0)
+
+        def _run_sdpa(q, k, v, mask):
+            out = torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask=mask, scale=scale
+            )
+            # (N=1, H, q_len=1, kv_lora_rank) -> (q_len, H, kv_lora_rank)
+            out = out.transpose(1, 2).squeeze(0)
+            return torch.einsum("qnl,lnv->qnv", out, W_UV).flatten(-2)
+
+        all_sdpa_full.append(_run_sdpa(q_sdpa, k_sdpa, v_sdpa, full_mask))
+        all_sdpa_windowed.append(_run_sdpa(q_sdpa, k_sdpa, v_sdpa, windowed_mask))
+
+        all_q_vllm.append(q_c)
+        all_kv_c_vllm.append(kv_c_full[-1:])
+        all_k_pe_vllm.append(k_pe_full[-1:])
+        kv_c_contexts.append(kv_c_full[:-1])
+        k_pe_contexts.append(k_pe_full[:-1])
+
+    query_vllm = torch.cat(all_q_vllm, dim=0)
+    kv_c_vllm = torch.cat(all_kv_c_vllm, dim=0)
+    k_pe_vllm = torch.cat(all_k_pe_vllm, dim=0)
+    sdpa_windowed_ref = torch.cat(all_sdpa_windowed, dim=0)
+    sdpa_full_ref = torch.cat(all_sdpa_full, dim=0)
+
+    from vllm.model_executor.layers.linear import ColumnParallelLinear
+
+    kv_b_proj_weight = torch.cat([W_UK, W_UV], dim=-1).view(
+        kv_lora_rank, num_q_heads * (qk_nope_head_dim + v_head_dim)
+    )
+    mock_kv_b_proj = ColumnParallelLinear(
+        input_size=kv_lora_rank,
+        output_size=num_q_heads * (qk_nope_head_dim + v_head_dim),
+        bias=False,
+    ).to(device=device, dtype=dtype)
+    mock_kv_b_proj.weight = torch.nn.Parameter(kv_b_proj_weight.T, requires_grad=False)
+
+    common_attn_metadata = create_common_attn_metadata(batch_spec, block_size, device)
+
+    required_divisor = 128 // block_size
+    current_block_num = common_attn_metadata.block_table_tensor.shape[1]
+    if current_block_num % required_divisor != 0:
+        padded = (
+            (current_block_num + required_divisor - 1) // required_divisor
+        ) * required_divisor
+        padding = torch.zeros(
+            (
+                common_attn_metadata.block_table_tensor.shape[0],
+                padded - current_block_num,
+            ),
+            dtype=torch.int32,
+            device=device,
+        )
+        common_attn_metadata.block_table_tensor = torch.cat(
+            [common_attn_metadata.block_table_tensor, padding], dim=1
+        )
+
+    kv_cache = create_and_prepopulate_kv_cache(
+        kv_c_contexts=kv_c_contexts,
+        k_pe_contexts=k_pe_contexts,
+        block_size=block_size,
+        head_size=head_size,
+        dtype=dtype,
+        device=device,
+        num_blocks=num_gpu_blocks,
+        common_attn_metadata=common_attn_metadata,
+    )
+
+    # The window is applied by the decode kernel via impl.sliding_window_size,
+    # not the KV cache spec, so the spec stays a standard full-attention MLA spec.
+    kv_cache_spec = MLAAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=vllm_config.model_config.get_num_kv_heads(
+            vllm_config.parallel_config
+        ),
+        head_size=head_size,
+        dtype=vllm_config.model_config.dtype,
+        cache_dtype_str="auto",
+    )
+
+    backend_output = run_attention_backend(
+        AttentionBackendEnum.TRITON_MLA,
+        kv_cache_spec,
+        ["placeholder"],
+        vllm_config,
+        device,
+        common_attn_metadata,
+        query_vllm,
+        kv_c_vllm,
+        k_pe_vllm,
+        kv_cache,
+        kv_lora_rank,
+        qk_nope_head_dim,
+        qk_rope_head_dim,
+        v_head_dim,
+        mock_kv_b_proj,
+        q_scale=1.0,
+        k_scale=1.0,
+        sliding_window=sliding_window,
+    )
+
+    assert torch.isfinite(backend_output).all(), "TRITON_MLA produced non-finite values"
+
+    # The window must be active: windowed and full-attention refs must differ.
+    assert not torch.allclose(sdpa_windowed_ref, sdpa_full_ref), (
+        "Windowed and full-attention SDPA references are identical — "
+        "the test is not exercising the window (seq_lens may be <= sliding_window)"
+    )
+
+    # Output must match windowed reference (window correctly applied).
+    assert torch.allclose(backend_output, sdpa_windowed_ref, rtol=1e-2, atol=5e-1), (
+        f"TRITON_MLA output differs from windowed SDPA. "
+        f"Max diff: {torch.max(torch.abs(backend_output - sdpa_windowed_ref)):.6f}"
+    )
+
+    # Output must not match full-attention reference (window was not silently dropped).
+    assert not torch.allclose(backend_output, sdpa_full_ref, atol=1e-2), (
+        "TRITON_MLA output matches full-attention SDPA — sliding window was not applied"
+    )
+
+
+def _windowed_causal_mask(
+    q_len: int,
+    s_len: int,
+    context_len: int,
+    sliding_window: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """(q_len, s_len) bool mask: query i (abs pos context_len+i) attends to kv j
+    iff j <= context_len+i (causal) and (context_len+i) - j < sliding_window."""
+    q_pos = context_len + torch.arange(q_len, device=device).unsqueeze(1)
+    kv_pos = torch.arange(s_len, device=device).unsqueeze(0)
+    causal = kv_pos <= q_pos
+    window = (q_pos - kv_pos) < sliding_window
+    return causal & window
+
+
+@pytest.mark.parametrize(
+    "batch_spec_name",
+    ["prefill_no_context", "prefill_with_context"],
+)
+def test_triton_mla_sliding_window_prefill(
+    default_vllm_config, dist_init, workspace_init, batch_spec_name: str
+):
+    """TritonMLA prefill (forward_mha) with a sliding window.
+
+    Covers both the new-token prefill path (``prefill_no_context``) and the
+    windowed chunked-context path ``_forward_prefill_swa_with_context``
+    (``prefill_with_context``). The latter requires the FlashAttn prefill
+    backend and a ``SlidingWindowMLASpec`` so the metadata builder populates
+    ``swa_groups``.
+    """
+    if AttentionBackendEnum.TRITON_MLA not in BACKENDS_TO_TEST:
+        pytest.skip("TRITON_MLA not available on this platform")
+
+    sliding_window = 32
+    with_context = batch_spec_name == "prefill_with_context"
+    if with_context:
+        # seq_len > query_len -> context present -> chunked-context SWA path.
+        batch_spec = BatchSpec(seq_lens=[96, 128], query_lens=[16, 16])
+    else:
+        # query_len == seq_len -> pure new-token prefill (no context).
+        batch_spec = BatchSpec(seq_lens=[64, 96], query_lens=[64, 96])
+
+    model = "deepseek-ai/DeepSeek-R1"
+    device = torch.device(f"{DEVICE_TYPE}:0")
+    block_size = BACKEND_BLOCK_SIZES[AttentionBackendEnum.TRITON_MLA]
+
+    required_blocks = sum(
+        (s + block_size - 1) // block_size for s in batch_spec.seq_lens
+    )
+    num_gpu_blocks = required_blocks + 1 + 100
+
+    vllm_config = create_vllm_config(
+        model_name=model,
+        tensor_parallel_size=1,
+        max_model_len=max(batch_spec.seq_lens),
+        num_gpu_blocks=num_gpu_blocks,
+        block_size=block_size,
+    )
+
+    num_q_heads = vllm_config.model_config.get_num_attention_heads(
+        vllm_config.parallel_config
+    )
+    head_size = vllm_config.model_config.get_head_size()
+    dtype = _convert_dtype_to_torch(vllm_config.model_config.dtype)
+    kv_lora_rank = 512
+    qk_rope_head_dim = 64
+    qk_nope_head_dim = 128
+    v_head_dim = 128
+    prefill_scale = (qk_nope_head_dim + qk_rope_head_dim) ** -0.5
+
+    weight_scale = kv_lora_rank**-0.5
+    W_UK = (
+        torch.randn(
+            kv_lora_rank, num_q_heads, qk_nope_head_dim, dtype=dtype, device=device
+        )
+        * weight_scale
+    )
+    W_UV = (
+        torch.randn(kv_lora_rank, num_q_heads, v_head_dim, dtype=dtype, device=device)
+        * weight_scale
+    )
+    kv_b_proj_weight = torch.cat([W_UK, W_UV], dim=-1)
+
+    all_q_vllm, all_kv_c_vllm, all_k_pe_vllm = [], [], []
+    all_sdpa_windowed, all_sdpa_full = [], []
+    kv_c_contexts, k_pe_contexts = [], []
+
+    for s_len, q_len in zip(batch_spec.seq_lens, batch_spec.query_lens):
+        context_len = s_len - q_len
+        q_c = torch.randn(
+            q_len,
+            num_q_heads,
+            qk_nope_head_dim + qk_rope_head_dim,
+            dtype=dtype,
+            device=device,
+        )
+        kv_c_full = torch.randn(s_len, kv_lora_rank, dtype=dtype, device=device)
+        k_pe_full = torch.randn(s_len, 1, qk_rope_head_dim, dtype=dtype, device=device)
+
+        q_nope, q_pe = q_c.split([qk_nope_head_dim, qk_rope_head_dim], dim=-1)
+
+        # MHA reference (matches forward_mha): decompress full latent K/V.
+        kv_nope_full = torch.einsum("sl,lnh->snh", kv_c_full, kv_b_proj_weight)
+        k_nope_full, v_full = kv_nope_full.split([qk_nope_head_dim, v_head_dim], dim=-1)
+        q_mha = torch.cat([q_nope, q_pe], dim=-1)
+        k_full = torch.cat([k_nope_full, k_pe_full.expand(-1, num_q_heads, -1)], dim=-1)
+
+        q_sdpa = q_mha.unsqueeze(0).transpose(1, 2)
+        k_sdpa = k_full.unsqueeze(0).transpose(1, 2)
+        v_sdpa = v_full.unsqueeze(0).transpose(1, 2)
+
+        windowed_mask = _windowed_causal_mask(
+            q_len, s_len, context_len, sliding_window, device
+        )
+        full_mask = torch.ones(q_len, s_len, dtype=torch.bool, device=device)
+        full_mask[:, context_len:] = torch.tril(
+            torch.ones(q_len, q_len, dtype=torch.bool, device=device)
+        )
+
+        def _sdpa(q, k, v, mask):
+            out = torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask=mask, scale=prefill_scale
+            )
+            return out.transpose(1, 2).squeeze(0).flatten(start_dim=-2)
+
+        all_sdpa_windowed.append(_sdpa(q_sdpa, k_sdpa, v_sdpa, windowed_mask))
+        all_sdpa_full.append(_sdpa(q_sdpa, k_sdpa, v_sdpa, full_mask))
+
+        all_q_vllm.append(q_c)
+        all_kv_c_vllm.append(kv_c_full[context_len:])
+        all_k_pe_vllm.append(k_pe_full[context_len:])
+        kv_c_contexts.append(kv_c_full[:context_len])
+        k_pe_contexts.append(k_pe_full[:context_len])
+
+    query_vllm = torch.cat(all_q_vllm, dim=0)
+    kv_c_vllm = torch.cat(all_kv_c_vllm, dim=0)
+    k_pe_vllm = torch.cat(all_k_pe_vllm, dim=0)
+    sdpa_windowed_ref = torch.cat(all_sdpa_windowed, dim=0)
+    sdpa_full_ref = torch.cat(all_sdpa_full, dim=0)
+
+    from vllm.model_executor.layers.linear import ColumnParallelLinear
+
+    mock_kv_b_proj = ColumnParallelLinear(
+        input_size=kv_lora_rank,
+        output_size=num_q_heads * (qk_nope_head_dim + v_head_dim),
+        bias=False,
+    ).to(device=device, dtype=dtype)
+    mock_kv_b_proj.weight = torch.nn.Parameter(
+        kv_b_proj_weight.view(
+            kv_lora_rank, num_q_heads * (qk_nope_head_dim + v_head_dim)
+        ).T,
+        requires_grad=False,
+    )
+
+    common_attn_metadata = create_common_attn_metadata(batch_spec, block_size, device)
+    required_divisor = 128 // block_size
+    current_block_num = common_attn_metadata.block_table_tensor.shape[1]
+    if current_block_num % required_divisor != 0:
+        padded = (
+            (current_block_num + required_divisor - 1) // required_divisor
+        ) * required_divisor
+        padding = torch.zeros(
+            (
+                common_attn_metadata.block_table_tensor.shape[0],
+                padded - current_block_num,
+            ),
+            dtype=torch.int32,
+            device=device,
+        )
+        common_attn_metadata.block_table_tensor = torch.cat(
+            [common_attn_metadata.block_table_tensor, padding], dim=1
+        )
+
+    kv_cache = create_and_prepopulate_kv_cache(
+        kv_c_contexts=kv_c_contexts,
+        k_pe_contexts=k_pe_contexts,
+        block_size=block_size,
+        head_size=head_size,
+        dtype=dtype,
+        device=device,
+        num_blocks=num_gpu_blocks,
+        common_attn_metadata=common_attn_metadata,
+    )
+
+    # The chunked-context SWA path reads spec.sliding_window to build swa_groups;
+    # the new-token path does not need it but a windowed spec is still valid.
+    kv_cache_spec = SlidingWindowMLASpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=head_size,
+        dtype=vllm_config.model_config.dtype,
+        sliding_window=sliding_window,
+        cache_dtype_str="auto",
+    )
+
+    backend_output = run_attention_backend(
+        AttentionBackendEnum.TRITON_MLA,
+        kv_cache_spec,
+        ["placeholder"],
+        vllm_config,
+        device,
+        common_attn_metadata,
+        query_vllm,
+        kv_c_vllm,
+        k_pe_vllm,
+        kv_cache,
+        kv_lora_rank,
+        qk_nope_head_dim,
+        qk_rope_head_dim,
+        v_head_dim,
+        mock_kv_b_proj,
+        q_scale=1.0,
+        k_scale=1.0,
+        sliding_window=sliding_window,
+        prefill_backend=MLAPrefillBackendEnum.FLASH_ATTN,
+    )
+
+    assert torch.isfinite(backend_output).all(), "TRITON_MLA produced non-finite values"
+    assert not torch.allclose(sdpa_windowed_ref, sdpa_full_ref), (
+        "Windowed and full references are identical — test not exercising the window"
+    )
+    assert torch.allclose(backend_output, sdpa_windowed_ref, rtol=1e-2, atol=5e-1), (
+        f"TRITON_MLA prefill differs from windowed SDPA. "
+        f"Max diff: {torch.max(torch.abs(backend_output - sdpa_windowed_ref)):.6f}"
+    )
+    assert not torch.allclose(backend_output, sdpa_full_ref, atol=1e-2), (
+        "TRITON_MLA prefill matches full-attention SDPA — sliding window not applied"
+    )
+
+
+@pytest.mark.parametrize("sliding_window", [None, 128])
+def test_mla_get_kv_cache_spec_sliding_window(default_vllm_config, sliding_window):
+    """MLAAttention.get_kv_cache_spec returns a SlidingWindowMLASpec when a
+    per-layer sliding window is set, and a plain MLAAttentionSpec otherwise."""
+    if AttentionBackendEnum.TRITON_MLA not in BACKENDS_TO_TEST:
+        pytest.skip("TRITON_MLA not available on this platform")
+
+    from vllm.model_executor.layers.linear import ColumnParallelLinear
+    from vllm.v1.attention.backends.mla.triton_mla import TritonMLABackend
+
+    device = torch.device(f"{DEVICE_TYPE}:0")
+    kv_lora_rank = 512
+    qk_rope_head_dim = 64
+    qk_nope_head_dim = 128
+    v_head_dim = 128
+    num_heads = 16
+    dtype = _convert_dtype_to_torch(default_vllm_config.model_config.dtype)
+
+    kv_b_proj = ColumnParallelLinear(
+        input_size=kv_lora_rank,
+        output_size=num_heads * (qk_nope_head_dim + v_head_dim),
+        bias=False,
+    ).to(device=device, dtype=dtype)
+
+    with set_current_vllm_config(default_vllm_config):
+        layer = MLAAttention(
+            num_heads=num_heads,
+            scale=(qk_nope_head_dim + qk_rope_head_dim) ** -0.5,
+            qk_nope_head_dim=qk_nope_head_dim,
+            qk_rope_head_dim=qk_rope_head_dim,
+            v_head_dim=v_head_dim,
+            q_lora_rank=None,
+            kv_lora_rank=kv_lora_rank,
+            kv_b_proj=kv_b_proj,
+            cache_config=default_vllm_config.cache_config,
+            attn_backend=TritonMLABackend,
+            per_layer_sliding_window=sliding_window,
+        )
+        spec = layer.get_kv_cache_spec(default_vllm_config)
+
+    if sliding_window is None:
+        assert type(spec) is MLAAttentionSpec
+    else:
+        assert isinstance(spec, SlidingWindowMLASpec)
+        assert spec.sliding_window == sliding_window

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -191,7 +191,7 @@ import functools
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import ClassVar, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar, cast
 
 import torch
 import torch.nn as nn
@@ -278,13 +278,20 @@ from vllm.v1.attention.ops.common import cp_lse_ag_out_ar, cp_lse_ag_out_rs
 from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.attention.ops.triton_merge_attn_states import mask_empty_context
+from vllm.v1.attention.ops.triton_swa_scatter_combined import swa_scatter_combined
 from vllm.v1.attention.selector import get_attn_backend
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     KVCacheSpec,
     MLAAttentionSpec,
+    SlidingWindowMLASpec,
     get_kv_quant_mode,
 )
+
+if TYPE_CHECKING:
+    from vllm.v1.attention.backends.mla.prefill.flash_attn import (
+        FlashAttnPrefillBackend,
+    )
 
 logger = init_logger(__name__)
 
@@ -375,6 +382,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         use_sparse: bool = False,
         indexer: object | None = None,
         topk_indices_buffer: torch.Tensor | None = None,
+        per_layer_sliding_window: int | None = None,
         **extra_impl_args,
     ):
         super().__init__()
@@ -414,6 +422,13 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 prefix,
                 kv_cache_dtype,
             )
+        self.sliding_window: int | None
+        if per_layer_sliding_window is not None:
+            self.sliding_window = per_layer_sliding_window
+        elif cache_config is not None:
+            self.sliding_window = cache_config.sliding_window
+        else:
+            self.sliding_window = None
 
         dtype = torch.get_default_dtype()
         if attn_backend is not None:
@@ -430,6 +445,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 use_mla=True,
                 use_sparse=use_sparse,
                 num_heads=self.num_heads,
+                has_sliding_window=self.sliding_window is not None,
             )
 
         normalized_kv_cache_dtype = _canonicalize_sparse_mla_kv_cache_dtype(
@@ -487,7 +503,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             scale=self.scale,
             num_kv_heads=1,
             alibi_slopes=None,
-            sliding_window=None,
+            sliding_window=self.sliding_window,
             kv_cache_dtype=self.kv_cache_dtype,
             logits_soft_cap=None,
             attn_type=AttentionType.DECODER,
@@ -1114,6 +1130,20 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         kv_cache_dtype = kv_cache_dtype_str_to_dtype(
             self.kv_cache_dtype, vllm_config.model_config
         )
+        # Per-layer sliding-window MLA layers need a sliding-window cache spec so
+        # the metadata builder populates `swa_groups` (the windowed-context
+        # gather tables) consumed by `_forward_prefill_swa_with_context`.
+        # Full-attention MLA layers use the standard spec.
+        sliding_window = getattr(self.impl, "sliding_window_size", 0) or 0
+        if sliding_window > 0:
+            return SlidingWindowMLASpec(
+                block_size=vllm_config.cache_config.block_size,
+                num_kv_heads=1,
+                head_size=self.head_size,
+                dtype=kv_cache_dtype,
+                sliding_window=sliding_window,
+                cache_dtype_str=vllm_config.cache_config.cache_dtype,
+            )
         return MLAAttentionSpec(
             block_size=vllm_config.cache_config.block_size,
             num_kv_heads=1,
@@ -1369,6 +1399,156 @@ class MLACommonBackend(AttentionBackend):
 
 
 @dataclass
+class SWAContextGroup:
+    """Index tables for one sliding-window attention (SWA) prefill group.
+
+    A group is a contiguous span of sequences whose windowed context fits
+    the chunked-prefill workspace. The tensors below map the gathered
+    windowed context and the new query tokens into a single combined
+    latent sequence `[context | new_tokens]` per sequence.
+
+    Attributes:
+        total_windowed_tokens: Total windowed context tokens in the group.
+        total_combined: `total_windowed_tokens` plus the new query tokens.
+        max_combined_len: Longest combined (context + query) sequence length.
+        windowed_starts: Per-sequence start offset of the visible window in
+            the KV cache (block-aligned).
+        cu_ctx: Cumulative windowed-context lengths (varlen prefix sum).
+        combined_cu: Cumulative combined lengths, used as `cu_seqlens_k`.
+        token_to_seq: Sequence index for each gathered context token.
+        ctx_dst: Destination rows for context tokens in the combined buffer.
+        new_dst: Destination rows for new query tokens in the combined buffer.
+        query_start_loc: Cumulative query lengths, used as `cu_seqlens_q`.
+        seq_start: First sequence index of the group (into the prefill batch).
+        seq_end: One past the last sequence index of the group.
+        q_start: First query-token index of the group.
+        q_end: One past the last query-token index of the group.
+    """
+
+    total_windowed_tokens: int
+    total_combined: int
+    max_combined_len: int
+    windowed_starts: torch.Tensor
+    cu_ctx: torch.Tensor
+    combined_cu: torch.Tensor
+    token_to_seq: torch.Tensor
+    ctx_dst: torch.Tensor
+    new_dst: torch.Tensor
+    query_start_loc: torch.Tensor
+    seq_start: int
+    seq_end: int
+    q_start: int
+    q_end: int
+
+
+def _cumulative_lengths(lens: torch.Tensor) -> torch.Tensor:
+    """Varlen-style prefix sum: `[0, lens[0], lens[0]+lens[1], ...]`."""
+    cu = torch.zeros(lens.shape[0] + 1, dtype=lens.dtype)
+    cu[1:] = torch.cumsum(lens, dim=0)
+    return cu
+
+
+def _build_swa_group(
+    context_lens_cpu: torch.Tensor,
+    query_start_loc_cpu: torch.Tensor,
+    num_new_tokens: int,
+    block_size: int,
+    sliding_window_size: int,
+    device: torch.device,
+    seq_start: int,
+    seq_end: int,
+    q_start: int,
+    q_end: int,
+) -> SWAContextGroup:
+    """Compute the index tables for a single SWA group."""
+    num_seqs = context_lens_cpu.shape[0]
+    query_lens = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+
+    visible_ctx = context_lens_cpu.clamp(max=sliding_window_size)
+    windowed_starts = (context_lens_cpu - visible_ctx) // block_size * block_size
+    windowed_lens = context_lens_cpu - windowed_starts
+    combined_lens = windowed_lens + query_lens
+
+    total_windowed_tokens = int(windowed_lens.sum())
+    total_combined = total_windowed_tokens + num_new_tokens
+    max_combined_len = int(combined_lens.max())
+
+    cu_ctx = _cumulative_lengths(windowed_lens)
+    combined_cu = _cumulative_lengths(combined_lens)
+
+    token_to_seq = torch.repeat_interleave(
+        torch.arange(num_seqs, dtype=torch.int32),
+        windowed_lens,
+        output_size=total_windowed_tokens,
+    )
+
+    ctx_offset_per_seq = combined_cu[:-1] - cu_ctx[:-1]
+    ctx_dst = torch.arange(total_windowed_tokens) + torch.repeat_interleave(
+        ctx_offset_per_seq, windowed_lens, output_size=total_windowed_tokens
+    )
+
+    new_offset_per_seq = combined_cu[:-1] + windowed_lens - query_start_loc_cpu[:-1]
+    new_dst = torch.arange(num_new_tokens) + torch.repeat_interleave(
+        new_offset_per_seq, query_lens, output_size=num_new_tokens
+    )
+
+    return SWAContextGroup(
+        total_windowed_tokens=total_windowed_tokens,
+        total_combined=total_combined,
+        max_combined_len=max_combined_len,
+        windowed_starts=windowed_starts.to(device),
+        cu_ctx=cu_ctx.to(device),
+        combined_cu=combined_cu.to(device),
+        token_to_seq=token_to_seq.to(device),
+        ctx_dst=ctx_dst.to(device),
+        new_dst=new_dst.to(device),
+        query_start_loc=query_start_loc_cpu.to(device),
+        seq_start=seq_start,
+        seq_end=seq_end,
+        q_start=q_start,
+        q_end=q_end,
+    )
+
+
+def build_swa_groups(
+    context_lens_cpu: torch.Tensor,
+    query_start_loc_cpu: torch.Tensor,
+    block_size: int,
+    sliding_window_size: int,
+    workspace_size: int,
+    device: torch.device,
+) -> list[SWAContextGroup]:
+    """Split prefill sequences into SWA groups that fit the workspace."""
+    num_seqs = context_lens_cpu.shape[0]
+    max_windowed_per_seq = sliding_window_size + block_size - 1
+    max_seqs_per_group = max(1, workspace_size // max_windowed_per_seq)
+
+    groups: list[SWAContextGroup] = []
+    for g_start in range(0, num_seqs, max_seqs_per_group):
+        g_end = min(g_start + max_seqs_per_group, num_seqs)
+        q_start = int(query_start_loc_cpu[g_start])
+        q_end = int(query_start_loc_cpu[g_end])
+        group_qsl = (
+            query_start_loc_cpu[g_start : g_end + 1] - query_start_loc_cpu[g_start]
+        )
+        groups.append(
+            _build_swa_group(
+                context_lens_cpu=context_lens_cpu[g_start:g_end],
+                query_start_loc_cpu=group_qsl,
+                num_new_tokens=q_end - q_start,
+                block_size=block_size,
+                sliding_window_size=sliding_window_size,
+                device=device,
+                seq_start=g_start,
+                seq_end=g_end,
+                q_start=q_start,
+                q_end=q_end,
+            )
+        )
+    return groups
+
+
+@dataclass
 class MLACommonPrefillMetadata:
     """Prefill Specific Metadata"""
 
@@ -1402,6 +1582,7 @@ class MLACommonPrefillMetadata:
     q_data_type: torch.dtype | None = None
     output_dtype: torch.dtype | None = None
     prefill_backend: MLAPrefillBackend | None = None
+    swa_groups: list[SWAContextGroup] | None = None
 
 
 @dataclass
@@ -1992,6 +2173,18 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                 dcp_virtual_block_size=self.dcp_virtual_block_size,
             )
 
+            swa_window_size = getattr(self.kv_cache_spec, "sliding_window", 0) or 0
+            swa_groups: list[SWAContextGroup] | None = None
+            if chunked_context_metadata is not None and swa_window_size:
+                swa_groups = build_swa_groups(
+                    context_lens_cpu=context_lens_cpu,
+                    query_start_loc_cpu=prefill_query_start_loc_cpu,
+                    block_size=self.kv_cache_spec.block_size,
+                    sliding_window_size=swa_window_size,
+                    workspace_size=self.chunked_prefill_workspace_size,
+                    device=device,
+                )
+
             prefill_metadata = MLACommonPrefillMetadata(
                 block_table=block_table_tensor[reqs_start:, ...],
                 query_start_loc=prefill_query_start_loc,
@@ -2000,6 +2193,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                 output_dtype=self.model_config.dtype,
                 q_data_type=self.q_data_type,
                 prefill_backend=self._prefill_backend,
+                swa_groups=swa_groups,
             )
 
             self._prefill_backend.prepare_metadata(prefill_metadata)
@@ -2157,6 +2351,13 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
         self.qk_head_dim = qk_head_dim
         self.v_head_dim = v_head_dim
         self.kv_b_proj = kv_b_proj
+        self.has_rope = qk_rope_head_dim > 0
+
+        # Sliding window is a dense-impl feature; the base defaults to full
+        # attention so shared prefill helpers are valid for sparse impls too.
+        # Dense MLACommonImpl overrides these from its `sliding_window` arg.
+        self.sliding_window: tuple[int, int] | None = None
+        self.sliding_window_size = 0
 
     def _concat_k_nope_k_pe(
         self, k_nope: torch.Tensor, k_pe: torch.Tensor
@@ -2188,6 +2389,146 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
             k[..., : k_nope.shape[-1]] = k_nope
             k[..., k_nope.shape[-1] :] = k_pe
         return k
+
+    def _extract_k_pe(self, workspace: torch.Tensor, toks: int) -> torch.Tensor:
+        """Extract `k_pe` from the KV cache workspace.
+
+        Returns an empty tensor for NoPE layers.
+        """
+        if self.has_rope:
+            return workspace[
+                :toks,
+                self.kv_lora_rank : self.kv_lora_rank + self.qk_rope_head_dim,
+            ].unsqueeze(1)
+        return workspace[:toks, :0].unsqueeze(1)
+
+    def _forward_prefill_swa_with_context(
+        self,
+        q: torch.Tensor,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata: "MLACommonMetadata",
+        k_scale: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        """For SWA layers with context: gather only the last
+        `sliding_window_size` tokens of context per sequence, build a combined
+        latent sequence `[context | new_tokens]`, decompress once, and run a
+        single causal+windowed flash attention.
+
+        Sequences are split into groups that fit the workspace.
+        """
+        from vllm.v1.attention.backends.mla.prefill.flash_attn import (
+            FlashAttnPrefillBackend,
+        )
+
+        assert attn_metadata.prefill is not None
+        prefill = attn_metadata.prefill
+        assert prefill.chunked_context is not None
+        assert prefill.swa_groups is not None
+        assert isinstance(prefill.prefill_backend, FlashAttnPrefillBackend), (
+            "SWA MLA prefill requires the FlashAttn prefill backend"
+        )
+        prefill_backend = prefill.prefill_backend
+        workspace = prefill.chunked_context.workspace
+
+        for swa_group in prefill.swa_groups:
+            self._forward_swa_group(
+                q=q[swa_group.q_start : swa_group.q_end],
+                kv_c_normed=kv_c_normed[swa_group.q_start : swa_group.q_end],
+                k_pe=k_pe[swa_group.q_start : swa_group.q_end],
+                kv_c_and_k_pe_cache=kv_c_and_k_pe_cache,
+                k_scale=k_scale,
+                output=output[swa_group.q_start : swa_group.q_end],
+                workspace=workspace,
+                swa_group=swa_group,
+                block_table=prefill.block_table[
+                    swa_group.seq_start : swa_group.seq_end
+                ],
+                max_query_len=prefill.max_query_len,
+                prefill_backend=prefill_backend,
+            )
+
+    def _forward_swa_group(
+        self,
+        q: torch.Tensor,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        kv_c_and_k_pe_cache: torch.Tensor,
+        k_scale: torch.Tensor,
+        output: torch.Tensor,
+        workspace: torch.Tensor,
+        swa_group: SWAContextGroup,
+        block_table: torch.Tensor,
+        max_query_len: int,
+        prefill_backend: "FlashAttnPrefillBackend",
+    ) -> None:
+        """Gather windowed context, build the combined latent sequence, and
+        run one causal+windowed flash attention for a single SWA group."""
+        ops.gather_and_maybe_dequant_cache(
+            src_cache=kv_c_and_k_pe_cache,
+            dst=workspace,
+            block_table=block_table,
+            cu_seq_lens=swa_group.cu_ctx,
+            token_to_seq=swa_group.token_to_seq,
+            num_tokens=swa_group.total_windowed_tokens,
+            kv_cache_dtype=self.kv_cache_dtype,
+            scale=k_scale,
+            seq_starts=swa_group.windowed_starts,
+        )
+
+        ctx_k_pe = self._extract_k_pe(workspace, swa_group.total_windowed_tokens)
+
+        combined_kv_c = torch.empty(
+            swa_group.total_combined,
+            self.kv_lora_rank,
+            device=q.device,
+            dtype=workspace.dtype,
+        )
+        combined_k_pe = torch.empty(
+            swa_group.total_combined,
+            *ctx_k_pe.shape[1:],
+            device=q.device,
+            dtype=workspace.dtype,
+        )
+        swa_scatter_combined(
+            workspace=workspace,
+            kv_c_normed=kv_c_normed,
+            k_pe=k_pe,
+            ctx_dst=swa_group.ctx_dst,
+            new_dst=swa_group.new_dst,
+            combined_kv_c=combined_kv_c,
+            combined_k_pe=combined_k_pe,
+            kv_lora_rank=self.kv_lora_rank,
+            qk_rope_head_dim=self.qk_rope_head_dim,
+        )
+
+        kv_nope = self.kv_b_proj(combined_kv_c)[0].view(
+            -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim
+        )
+        combined_k_nope, combined_v = kv_nope.split(
+            [self.qk_nope_head_dim, self.v_head_dim], dim=-1
+        )
+        combined_k = self._concat_k_nope_k_pe(combined_k_nope, combined_k_pe)
+
+        # Intentional cross-class call: SWA prefill is FlashAttn-only (asserted
+        # above), and the windowed flash-attn entry point lives on the backend.
+        attn_out = prefill_backend._flash_attn_varlen_diff_headdims(
+            q=q,
+            k=combined_k,
+            v=combined_v,
+            cu_seqlens_q=swa_group.query_start_loc,
+            cu_seqlens_k=swa_group.combined_cu,
+            max_seqlen_q=max_query_len,
+            max_seqlen_k=swa_group.max_combined_len,
+            softmax_scale=self.scale,
+            causal=True,
+            window_size=(self.sliding_window_size - 1, 0),
+        )
+
+        assert isinstance(attn_out, torch.Tensor)
+        output.copy_(attn_out.view(-1, self.num_heads * self.v_head_dim))
 
     def _compute_prefill_context(
         self,
@@ -2496,6 +2837,19 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
             "Fused FP8 output is only wired for the non-chunked-context path"
         )
 
+        if self.sliding_window_size > 0 and has_context:
+            assert not use_fp8_prefill, "fp8+swa not supported"
+            self._forward_prefill_swa_with_context(
+                q,
+                kv_c_normed,
+                k_pe,
+                kv_c_and_k_pe_cache,
+                attn_metadata,
+                k_scale,
+                output,
+            )
+            return
+
         kv_nope = self.kv_b_proj(kv_c_normed)[0].view(
             -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim
         )
@@ -2517,6 +2871,7 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
                 else None
             ),
             output_scale=output_scale,
+            window_size=self.sliding_window,
         )
 
         if has_context:
@@ -2611,6 +2966,9 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
             v_head_dim,
             kv_b_proj,
         )
+        if sliding_window is not None:
+            self.sliding_window = (sliding_window - 1, 0)
+        self.sliding_window_size = sliding_window or 0
         self.q_lora_rank = q_lora_rank
         self.indexer = indexer
         self.q_pad_num_heads = q_pad_num_heads

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -27,6 +27,7 @@ class MLAModules:
     is_sparse: bool
     topk_indices_buffer: torch.Tensor | None
     indexer_rotary_emb: torch.nn.Module | None = None
+    per_layer_sliding_window: int | None = None
 
 
 # --8<-- [start:multi_head_latent_attention]
@@ -118,6 +119,7 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
             use_sparse=self.is_sparse,
             indexer=self.indexer,
             topk_indices_buffer=mla_modules.topk_indices_buffer,
+            per_layer_sliding_window=mla_modules.per_layer_sliding_window,
         )
 
         self.prefix = prefix

--- a/vllm/v1/attention/backends/mla/prefill/aiter_flash_attn.py
+++ b/vllm/v1/attention/backends/mla/prefill/aiter_flash_attn.py
@@ -73,7 +73,13 @@ class AiterFlashAttnPrefillBackend(MLAPrefillBackend):
         return_softmax_lse: bool,
         out: torch.Tensor | None = None,
         output_scale: torch.Tensor | None = None,
+        window_size: tuple[int, int] | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if window_size is not None:
+            raise NotImplementedError(
+                "AiterFlashAttnPrefillBackend does not support sliding "
+                "window attention (window_size) for new-token prefill."
+            )
         assert output_scale is None, (
             "AiterFlashAttnPrefillBackend does not support fused quantized output."
         )

--- a/vllm/v1/attention/backends/mla/prefill/base.py
+++ b/vllm/v1/attention/backends/mla/prefill/base.py
@@ -158,7 +158,22 @@ class MLAPrefillBackend(ABC):
         return_softmax_lse: bool,
         out: torch.Tensor | None = None,
         output_scale: torch.Tensor | None = None,
+        window_size: tuple[int, int] | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        """Run attention over the fresh prompt tokens (no prior context).
+
+        Args:
+            q: Query tensor.
+            k: Key tensor.
+            v: Value tensor.
+            return_softmax_lse: Whether to also return the log-sum-exp.
+            window_size: Optional flash-attn `(left, right)` sliding window.
+                `None` means full causal attention. Sliding-window layers
+                pass `(sliding_window - 1, 0)`.
+
+        Returns:
+            The attention output, optionally with the log-sum-exp.
+        """
         raise NotImplementedError
 
     @abstractmethod

--- a/vllm/v1/attention/backends/mla/prefill/base.py
+++ b/vllm/v1/attention/backends/mla/prefill/base.py
@@ -160,20 +160,6 @@ class MLAPrefillBackend(ABC):
         output_scale: torch.Tensor | None = None,
         window_size: tuple[int, int] | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        """Run attention over the fresh prompt tokens (no prior context).
-
-        Args:
-            q: Query tensor.
-            k: Key tensor.
-            v: Value tensor.
-            return_softmax_lse: Whether to also return the log-sum-exp.
-            window_size: Optional flash-attn `(left, right)` sliding window.
-                `None` means full causal attention. Sliding-window layers
-                pass `(sliding_window - 1, 0)`.
-
-        Returns:
-            The attention output, optionally with the log-sum-exp.
-        """
         raise NotImplementedError
 
     @abstractmethod

--- a/vllm/v1/attention/backends/mla/prefill/flash_attn.py
+++ b/vllm/v1/attention/backends/mla/prefill/flash_attn.py
@@ -430,7 +430,11 @@ class FlashAttnPrefillBackend(MLAPrefillBackend):
         return_softmax_lse: bool,
         out: torch.Tensor | None = None,
         output_scale: torch.Tensor | None = None,
+        window_size: tuple[int, int] | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        extra_kwargs: dict[str, tuple[int, int]] = {}
+        if window_size is not None:
+            extra_kwargs["window_size"] = window_size
         return self._flash_attn_varlen_diff_headdims(
             q=q,
             k=k,
@@ -444,6 +448,7 @@ class FlashAttnPrefillBackend(MLAPrefillBackend):
             return_softmax_lse=return_softmax_lse,
             out=out,
             output_scale=output_scale,
+            **extra_kwargs,
         )
 
     def run_prefill_context_chunk(

--- a/vllm/v1/attention/backends/mla/prefill/flashinfer.py
+++ b/vllm/v1/attention/backends/mla/prefill/flashinfer.py
@@ -199,7 +199,14 @@ class FlashInferPrefillBackend(MLAPrefillBackend):
         return_softmax_lse: bool,
         out: torch.Tensor | None = None,
         output_scale: torch.Tensor | None = None,
+        window_size: tuple[int, int] | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if window_size is not None:
+            raise NotImplementedError(
+                "FlashInferPrefillBackend does not support a per-call "
+                "sliding window (window_size) for new-token prefill; the "
+                "window is fixed at plan() time via window_left."
+            )
         assert self._prefill_main is not None
 
         ret = self._prefill_main.run(

--- a/vllm/v1/attention/backends/mla/prefill/tokenspeed_mla.py
+++ b/vllm/v1/attention/backends/mla/prefill/tokenspeed_mla.py
@@ -126,7 +126,13 @@ class TokenspeedMLAPrefillBackend(MLAPrefillBackend):
         return_softmax_lse: bool,
         out: torch.Tensor | None = None,
         output_scale: torch.Tensor | None = None,
+        window_size: tuple[int, int] | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if window_size is not None:
+            raise NotImplementedError(
+                "TokenspeedMLAPrefillBackend does not support sliding "
+                "window attention (window_size) for new-token prefill."
+            )
         from tokenspeed_mla import tokenspeed_mla_prefill
 
         # `v` arrives as the second half of `kv_nope.split(...)` in

--- a/vllm/v1/attention/backends/mla/prefill/trtllm_ragged.py
+++ b/vllm/v1/attention/backends/mla/prefill/trtllm_ragged.py
@@ -99,7 +99,13 @@ class TrtllmRaggedPrefillBackend(MLAPrefillBackend):
         return_softmax_lse: bool,
         out: torch.Tensor | None = None,
         output_scale: torch.Tensor | None = None,
+        window_size: tuple[int, int] | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if window_size is not None:
+            raise NotImplementedError(
+                "TrtllmRaggedPrefillBackend does not support sliding "
+                "window attention (window_size) for new-token prefill."
+            )
         from flashinfer.prefill import trtllm_ragged_attention_deepseek
 
         out = torch.empty(

--- a/vllm/v1/attention/backends/mla/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/triton_mla.py
@@ -176,8 +176,6 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
                 "alibi_slopes, logits_soft_cap"
             )
 
-        # self.sliding_window_size is set by MLACommonImpl.__init__.
-
         if attn_type != AttentionType.DECODER:
             raise NotImplementedError(
                 "Encoder self-attention and "

--- a/vllm/v1/attention/backends/mla/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/triton_mla.py
@@ -117,6 +117,10 @@ class TritonMLABackend(MLACommonBackend):
         return "TRITON_MLA"
 
     @classmethod
+    def supports_sliding_window(cls) -> bool:
+        return True
+
+    @classmethod
     def supports_batch_invariance(cls) -> bool:
         return True
 
@@ -165,12 +169,14 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
             **mla_args,
         )
 
-        unsupported_features = [alibi_slopes, sliding_window, logits_soft_cap]
+        unsupported_features = [alibi_slopes, logits_soft_cap]
         if any(unsupported_features):
             raise NotImplementedError(
                 "TritonMLAImpl does not support one of the following: "
-                "alibi_slopes, sliding_window, logits_soft_cap"
+                "alibi_slopes, logits_soft_cap"
             )
+
+        # self.sliding_window_size is set by MLACommonImpl.__init__.
 
         if attn_type != AttentionType.DECODER:
             raise NotImplementedError(
@@ -281,6 +287,7 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
             k_scale=layer._k_scale,
             v_scale=layer._k_scale,
             is_mla=True,
+            sliding_window=self.sliding_window_size,
         )
 
         return o, lse

--- a/vllm/v1/attention/ops/triton_decode_attention.py
+++ b/vllm/v1/attention/ops/triton_decode_attention.py
@@ -97,6 +97,7 @@ def _fwd_kernel_stage1(
     logit_cap: tl.constexpr,
     Lk: tl.constexpr,
     Lv: tl.constexpr,
+    SLIDING_WINDOW: tl.constexpr = 0,
 ):
     cur_batch = tl.program_id(0)
     cur_head = tl.program_id(1)
@@ -114,8 +115,15 @@ def _fwd_kernel_stage1(
     off_q = cur_batch * stride_qbs + cur_head * stride_qh + offs_d
     q = tl.load(Q + off_q, mask=mask_d, other=0.0)
 
-    kv_len_per_split = tl.cdiv(cur_batch_seq_len, NUM_KV_SPLITS)
-    split_kv_start = kv_len_per_split * split_kv_id
+    if SLIDING_WINDOW > 0:
+        sw_start = tl.maximum(cur_batch_seq_len - SLIDING_WINDOW, 0)
+        effective_len = cur_batch_seq_len - sw_start
+    else:
+        sw_start = 0
+        effective_len = cur_batch_seq_len
+
+    kv_len_per_split = tl.cdiv(effective_len, NUM_KV_SPLITS)
+    split_kv_start = sw_start + kv_len_per_split * split_kv_id
     split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
 
     e_max = -float("inf")
@@ -220,6 +228,7 @@ def _decode_att_m_fwd(
     logit_cap,
     k_scale,
     v_scale,
+    sliding_window=0,
 ):
     BLOCK = 64 if not is_hip_ else 8
 
@@ -272,6 +281,7 @@ def _decode_att_m_fwd(
         num_stages=2,
         Lk=Lk,
         Lv=Lv,
+        SLIDING_WINDOW=sliding_window,
     )
 
 
@@ -311,6 +321,7 @@ def _fwd_grouped_kernel_stage1(
     Lk: tl.constexpr,
     Lv: tl.constexpr,
     IS_MLA: tl.constexpr = False,
+    SLIDING_WINDOW: tl.constexpr = 0,
 ):
     cur_batch = tl.program_id(0)
     cur_head_id = tl.program_id(1)
@@ -350,8 +361,15 @@ def _fwd_grouped_kernel_stage1(
             cache_modifier=".ca",
         )
 
-    kv_len_per_split = tl.cdiv(cur_batch_seq_len, NUM_KV_SPLITS)
-    split_kv_start = kv_len_per_split * split_kv_id
+    if SLIDING_WINDOW > 0:
+        sw_start = tl.maximum(cur_batch_seq_len - SLIDING_WINDOW, 0)
+        effective_len = cur_batch_seq_len - sw_start
+    else:
+        sw_start = 0
+        effective_len = cur_batch_seq_len
+
+    kv_len_per_split = tl.cdiv(effective_len, NUM_KV_SPLITS)
+    split_kv_start = sw_start + kv_len_per_split * split_kv_id
     split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
 
     e_max = tl.zeros([BLOCK_H], dtype=tl.float32) - float("inf")
@@ -481,6 +499,7 @@ def _decode_grouped_att_m_fwd(
     k_scale,
     v_scale,
     is_mla=False,
+    sliding_window=0,
 ):
     # with is_mla there is only a single c_kv in smem.
     # could increase BLOCK or num_stages.
@@ -568,6 +587,7 @@ def _decode_grouped_att_m_fwd(
         Lk=Lk,
         Lv=Lv,
         IS_MLA=is_mla,
+        SLIDING_WINDOW=sliding_window,
         **extra_kargs,
     )
 
@@ -588,6 +608,7 @@ def _fwd_kernel_stage2(
     BLOCK_DV: tl.constexpr,
     Lv: tl.constexpr,
     OUTPUT_FP16: tl.constexpr = 0,
+    SLIDING_WINDOW: tl.constexpr = 0,
 ):
     cur_batch = tl.program_id(0)
     cur_head = tl.program_id(1)
@@ -604,9 +625,20 @@ def _fwd_kernel_stage2(
     offs_v = cur_batch * stride_mid_ob + cur_head * stride_mid_oh + offs_d
     offs_logic = cur_batch * stride_mid_ob + cur_head * stride_mid_oh + Lv
 
+    # Must tile the KV range exactly as stage 1 did, otherwise the splits this
+    # kernel includes won't match the splits stage 1 actually wrote and we would
+    # merge uninitialized `Mid_O` entries. With a sliding window stage 1 only
+    # covers [seq_len - SLIDING_WINDOW, seq_len); default (0) covers the full seq.
+    if SLIDING_WINDOW > 0:
+        sw_start = tl.maximum(cur_batch_seq_len - SLIDING_WINDOW, 0)
+        effective_len = cur_batch_seq_len - sw_start
+    else:
+        sw_start = 0
+        effective_len = cur_batch_seq_len
+    kv_len_per_split = tl.cdiv(effective_len, NUM_KV_SPLITS)
+
     for split_kv_id in range(0, NUM_KV_SPLITS):
-        kv_len_per_split = tl.cdiv(cur_batch_seq_len, NUM_KV_SPLITS)
-        split_kv_start = kv_len_per_split * split_kv_id
+        split_kv_start = sw_start + kv_len_per_split * split_kv_id
         split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
 
         if split_kv_end > split_kv_start:
@@ -647,6 +679,7 @@ def _decode_softmax_reducev_fwd(
     v_buffer,
     b_seq_len,
     num_kv_splits,
+    sliding_window=0,
 ):
     batch, head_num = q.shape[0], q.shape[1]
     Lv = v_buffer.shape[-1]
@@ -675,6 +708,7 @@ def _decode_softmax_reducev_fwd(
         NUM_KV_SPLITS=NUM_KV_SPLITS,
         BLOCK_DV=BLOCK_DV,
         Lv=Lv,
+        SLIDING_WINDOW=sliding_window,
         num_warps=4,
         num_stages=2,
         **extra_kargs,
@@ -696,6 +730,7 @@ def decode_attention_fwd_normal(
     logit_cap=0.0,
     k_scale=None,
     v_scale=None,
+    sliding_window=0,
 ):
     _decode_att_m_fwd(
         q,
@@ -710,9 +745,10 @@ def decode_attention_fwd_normal(
         logit_cap,
         k_scale,
         v_scale,
+        sliding_window=sliding_window,
     )
     _decode_softmax_reducev_fwd(
-        attn_logits, q, o, lse, v_buffer, b_seq_len, num_kv_splits
+        attn_logits, q, o, lse, v_buffer, b_seq_len, num_kv_splits, sliding_window
     )
 
 
@@ -732,6 +768,7 @@ def decode_attention_fwd_grouped(
     k_scale=None,
     v_scale=None,
     is_mla=False,
+    sliding_window=0,
 ):
     _decode_grouped_att_m_fwd(
         q,
@@ -747,9 +784,10 @@ def decode_attention_fwd_grouped(
         k_scale,
         v_scale,
         is_mla=is_mla,
+        sliding_window=sliding_window,
     )
     _decode_softmax_reducev_fwd(
-        attn_logits, q, o, lse, v_buffer, b_seq_len, num_kv_splits
+        attn_logits, q, o, lse, v_buffer, b_seq_len, num_kv_splits, sliding_window
     )
 
 
@@ -769,6 +807,7 @@ def decode_attention_fwd(
     k_scale=None,
     v_scale=None,
     is_mla=False,
+    sliding_window=0,
 ):
     assert num_kv_splits == attn_logits.shape[2]
 
@@ -796,6 +835,7 @@ def decode_attention_fwd(
             logit_cap,
             k_scale,
             v_scale,
+            sliding_window=sliding_window,
         )
     else:
         # GQA/MQA/MLA
@@ -815,4 +855,5 @@ def decode_attention_fwd(
             k_scale,
             v_scale,
             is_mla=is_mla,
+            sliding_window=sliding_window,
         )

--- a/vllm/v1/attention/ops/triton_swa_scatter_combined.py
+++ b/vllm/v1/attention/ops/triton_swa_scatter_combined.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _swa_scatter_combined_kernel(
+    workspace_ptr,
+    kv_c_normed_ptr,
+    k_pe_ptr,
+    ctx_dst_ptr,
+    new_dst_ptr,
+    combined_kv_c_ptr,
+    combined_k_pe_ptr,
+    total_windowed_tokens,
+    workspace_row_stride: tl.int64,
+    kv_c_normed_row_stride: tl.int64,
+    k_pe_row_stride: tl.int64,
+    combined_kv_c_row_stride: tl.int64,
+    combined_k_pe_row_stride: tl.int64,
+    L: tl.constexpr,
+    R: tl.constexpr,
+    BLOCK_L: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    is_ctx = pid < total_windowed_tokens
+    offs_l = tl.arange(0, BLOCK_L)
+    mask_l = offs_l < L
+    offs_r = tl.arange(0, BLOCK_R)
+    mask_r = offs_r < R
+
+    if is_ctx:
+        src_row = pid
+        dst_row = tl.load(ctx_dst_ptr + pid)
+        kv_c_src_base = workspace_ptr + src_row.to(tl.int64) * workspace_row_stride
+        kv_c_vals = tl.load(kv_c_src_base + offs_l, mask=mask_l, other=0.0)
+        k_pe_vals = tl.load(kv_c_src_base + L + offs_r, mask=mask_r, other=0.0)
+    else:
+        src_row = pid - total_windowed_tokens
+        dst_row = tl.load(new_dst_ptr + src_row)
+        kv_c_vals = tl.load(
+            kv_c_normed_ptr + src_row.to(tl.int64) * kv_c_normed_row_stride + offs_l,
+            mask=mask_l,
+            other=0.0,
+        )
+        k_pe_vals = tl.load(
+            k_pe_ptr + src_row.to(tl.int64) * k_pe_row_stride + offs_r,
+            mask=mask_r,
+            other=0.0,
+        )
+
+    tl.store(
+        combined_kv_c_ptr + dst_row * combined_kv_c_row_stride + offs_l,
+        kv_c_vals,
+        mask=mask_l,
+    )
+    tl.store(
+        combined_k_pe_ptr + dst_row * combined_k_pe_row_stride + offs_r,
+        k_pe_vals,
+        mask=mask_r,
+    )
+
+
+def swa_scatter_combined(
+    workspace: torch.Tensor,
+    kv_c_normed: torch.Tensor,
+    k_pe: torch.Tensor,
+    ctx_dst: torch.Tensor,
+    new_dst: torch.Tensor,
+    combined_kv_c: torch.Tensor,
+    combined_k_pe: torch.Tensor,
+    kv_lora_rank: int,
+    qk_rope_head_dim: int,
+) -> None:
+    """Fused scatter: replaces 4 separate index_put launches with one
+    Triton kernel. Reads context from `workspace` (packed
+    `[kv_lora_rank | qk_rope_head_dim]` per row) and new tokens from
+    `kv_c_normed` / `k_pe`, writing both into the combined output
+    buffers.
+    """
+    total_windowed_tokens = ctx_dst.shape[0]
+    num_new_tokens = new_dst.shape[0]
+    grid = (total_windowed_tokens + num_new_tokens,)
+    block_l = triton.next_power_of_2(kv_lora_rank)
+    block_r = triton.next_power_of_2(qk_rope_head_dim)
+    _swa_scatter_combined_kernel[grid](
+        workspace,
+        kv_c_normed,
+        k_pe,
+        ctx_dst,
+        new_dst,
+        combined_kv_c,
+        combined_k_pe,
+        total_windowed_tokens,
+        workspace.stride(0),
+        kv_c_normed.stride(0),
+        k_pe.stride(0),
+        combined_kv_c.stride(0),
+        combined_k_pe.stride(0),
+        L=kv_lora_rank,
+        R=qk_rope_head_dim,
+        BLOCK_L=block_l,
+        BLOCK_R=block_r,
+    )


### PR DESCRIPTION
Enables TritonMLA to run sliding-window attention.

What this PR enables:
  - Windowed decode for TritonMLA
  - Windowed new-token prefill — prompts longer than the window now attend only within it, instead of full-causal.
  - Windowed chunked-prefill with context — cached context beyond the window is correctly excluded when attending over prior tokens.
  - Per-layer sliding windows for MLA layers, so interleaved full/SWA models can mix window sizes across layers.
  - Windowed KV-cache allocation via SlidingWindowMLASpec, so SWA MLA layers only retain the window's worth of KV.
  - TritonMLA now advertises SWA as a supported capability, so the backend selector can pick it for sliding-window MLA models.
  - Adds `triton_swa_scatter_combined`, a small Triton scatter kernel that fuses building the combined [windowed context | new tokens] latent sequence (replaces 4 separate index_put launches) used by the chunked-context SWA prefill path.

## How to test 
```
# Backend correctness — decode, new-token prefill, and chunked-context SWA
pytest tests/v1/attention/test_mla_backends.py -k sliding_window -v

# Cache-spec selection (SlidingWindowMLASpec when a window is set, else MLAAttentionSpec)
pytest tests/v1/attention/test_mla_backends.py -k get_kv_cache_spec_sliding_window -v
```

What's covered:
- test_triton_mla_sliding_window_correctness — windowed decode.
- test_triton_mla_sliding_window_prefill[prefill_no_context] — new-token prefill windowing.
- test_triton_mla_sliding_window_prefill[prefill_with_context] — chunked-context SWA (_forward_prefill_swa_with_context), FlashAttn prefill backend.
- test_mla_get_kv_cache_spec_sliding_window — cache-spec selection.

PS FlashAttn is the supported **prefill backend** for windowed chunked-context; other MLA prefill backends raise NotImplementedError if a window is requested.

cc @MatthewBonanni 