### PR TITLE
[CI] Always rebuild the torch-nightly image (add FORCE_REBUILD)

### DIFF
--- a/.buildkite/image_build/image_build_torch_nightly.sh
+++ b/.buildkite/image_build/image_build_torch_nightly.sh
@@ -36,14 +36,18 @@ docker buildx create --name vllm-builder --driver docker-container --use || true
 docker buildx inspect --bootstrap
 docker buildx ls
 
-# --- Skip if image already exists ---
-echo "--- :mag: Checking if image already exists"
-if docker manifest inspect "$IMAGE_TAG" >/dev/null 2>&1; then
-  echo "Image found: $IMAGE_TAG — skipping build"
+# --- Skip if image already exists (unless forcing a rebuild) ---
+# The image tag is keyed on the vLLM commit SHA only, with no PyTorch nightly
+# date/version in it. Reusing a cached image for the same commit would run the
+# tests against a stale nightly, so default to always rebuilding here. Set
+# FORCE_REBUILD=0 to opt back into cache reuse.
+FORCE_REBUILD="${FORCE_REBUILD:-1}"
+if [[ "$FORCE_REBUILD" != "1" ]] && docker manifest inspect "$IMAGE_TAG" >/dev/null 2>&1; then
+  echo "Image found: $IMAGE_TAG — skipping build (FORCE_REBUILD=0)"
   .buildkite/scripts/annotate-image-build.sh "$IMAGE_TAG"
   exit 0
 fi
-echo "Image not found, proceeding with build..."
+echo "Building image (FORCE_REBUILD=$FORCE_REBUILD): $IMAGE_TAG"
 
 # --- CUDA 13.0 for nightly builds ---
 # Nightly CI uses CUDA 13.0 while regular CI stays on CUDA 12.9


### PR DESCRIPTION
## Purpose

`.buildkite/image_build/image_build_torch_nightly.sh` skipped the build when an image already existed for the vLLM commit SHA (`docker manifest inspect $IMAGE_TAG`). The tag is keyed on the **commit SHA only** — it has no PyTorch nightly date/version in it — so re-running the nightly for the same vLLM commit reused a cached image and ran the tests against a **stale** PyTorch nightly instead of the current one.

Example: build [77968](https://buildkite.com/vllm/ci/builds/77968) `:docker: Build image` logged `Image found: …vllm-ci-postmerge-repo:<sha> — skipping build` and never rebuilt, so the nightly torch was whatever was current when that image was first built.

## Change

Default to **always rebuilding** in this nightly-only script so the image tracks the latest nightly:

```bash
FORCE_REBUILD="${FORCE_REBUILD:-1}"
if [[ "$FORCE_REBUILD" != "1" ]] && docker manifest inspect "$IMAGE_TAG" >/dev/null 2>&1; then
  # skip
fi
```

- Only affects the torch-nightly path (`image_build_torch_nightly.sh`); regular postmerge/PR image builds via `image_build.sh` keep their existing caching.
- `FORCE_REBUILD=0` opts back into cache reuse if needed.

## Test Plan

- `bash -n` passes on the script.
- On the next nightly run, the `:docker: Build image` step should log `Building image (FORCE_REBUILD=1): …` and perform a full rebuild instead of `— skipping build`.

This PR was authored with the assistance of an AI coding assistant; the change and test plan were reviewed by the submitter.