### PR TITLE
[Bugfix][Frontend] Accept `tools: null` on the Responses API

### DIFF
--- a/tests/entrypoints/openai/responses/test_protocol.py
+++ b/tests/entrypoints/openai/responses/test_protocol.py
@@ -5,9 +5,20 @@ from openai_harmony import (
 )
 
 from vllm.entrypoints.openai.responses.protocol import (
+    ResponsesRequest,
     serialize_message,
     serialize_messages,
 )
+
+
+def test_tools_none_is_accepted_on_continuation_turns() -> None:
+    """OpenAI-style tool loops null out `tools` once it has been sent, so the
+    Responses API must coerce it to an empty list instead of rejecting the turn,
+    matching Chat Completions' leniency."""
+    request = ResponsesRequest(input="What is the weather?", tools=None)
+
+    assert request.tools == []
+    assert request.tool_choice == "none"
 
 
 def test_serialize_message() -> None:

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -588,8 +588,12 @@ class ResponsesRequest(OpenAIBaseModel):
             return data
 
         tools = data.get("tools")
+        if tools is None:
+            # Tool loops routinely null out `tools` on continuation turns.
+            tools = data["tools"] = []
+
         tool_choice = data.get("tool_choice", "auto")
-        has_tools = tools is not None and len(tools) > 0
+        has_tools = len(tools) > 0
         is_named_tool_choice = (
             isinstance(tool_choice, dict) and tool_choice.get("type") == "function"
         )
@@ -607,7 +611,7 @@ class ResponsesRequest(OpenAIBaseModel):
                     "Tool choice 'function' not found in 'tools' parameter.",
                     parameter="tool_choice",
                 )
-        elif is_named_tool_choice and tools is not None:
+        elif is_named_tool_choice:
             tool_name = tool_choice.get("name")
             tool_names = set()
             for tool in tools:


### PR DESCRIPTION
## Purpose

The Responses API rejects an explicit `tools: null` with **HTTP 400**, while Chat Completions accepts it:

| Schema | `tools` declaration | Accepts `null`? |
|---|---|---|
| `ChatCompletionRequest` | `list[ChatCompletionToolsParam] \| None = None` | yes |
| `ResponsesRequest` | `list[Tool] = Field(default_factory=list)` | **no** |

```
{'type': 'list_type', 'loc': ('body', 'tools'), 'msg': 'Input should be a valid list', 'input': None}
```

OpenAI-style tool loops routinely null out `tools` on continuation turns once it has already been sent, so this breaks turns 2+ of an agentic loop against `/v1/responses` while the same client works fine against `/v1/chat/completions`.

Notably, the `check_tool_usage` validator **already anticipated null** — it guards on `tools is not None` — but that intent never took effect, because Pydantic field validation rejects the null before the guard can matter.

**Fix:** coerce `null` → `[]` inside the existing `mode="before"` validator.

I deliberately did *not* widen the annotation to `list[Tool] | None = None`. There are 16 downstream call sites that treat `request.tools` as a real list (`len(request.tools) == 0`, dict comprehensions over it, `extract_tool_types(request.tools)`, …); widening the type would push null handling into every one of them. Coercing in the validator keeps the "always a list" contract those call sites rely on, and the diff stays at 6 lines. The `tools is not None` guards, now unreachable, are dropped.

Validation is not weakened — only `tools: null` changes from rejected to accepted:

| Request | Before | After |
|---|---|---|
| `tools=None` | 400 `list_type` | accepted → `tools=[]`, `tool_choice="none"` |
| `tools=None`, `tool_choice="required"` | rejected | rejected (unchanged) |
| `tools=None`, named `tool_choice` | rejected | rejected (unchanged) |
| `tools` omitted | `[]`, `tool_choice="none"` | unchanged |
| `tools=[...]` | works | unchanged |

**Not a duplicate.** Searched open PRs for `responses tools null`, `check_tool_usage`, and `ResponsesRequest tools`. The closest is #47184 (Responses API null field *serialization*), which touches the same file but sanitizes null keys on the response **output** path; it does not make the request schema accept `tools: null`. No overlap.

## Test Plan

Added one test to the existing `tests/entrypoints/openai/responses/test_protocol.py`:

- `test_tools_none_is_accepted_on_continuation_turns` — `ResponsesRequest(input=..., tools=None)` must construct, yielding `tools == []` and `tool_choice == "none"`.

```bash
pytest tests/entrypoints/openai/responses/test_protocol.py -v

# Regression across the tool-choice / function-call / harmony paths
pytest tests/entrypoints/openai/responses/test_function_call_parsing.py \
       tests/entrypoints/openai/responses/test_responses_utils.py \
       tests/entrypoints/openai/responses/test_harmony_utils.py -v
```

## Test Result

The new test fails on `main` and passes with the fix.

**Before:**

```
E   pydantic_core._pydantic_core.ValidationError: 1 validation error for ResponsesRequest
E     Input should be a valid list [type=list_type, input_value=None, input_type=NoneType]
tests/entrypoints/openai/responses/test_protocol.py:18: ValidationError
1 failed, 2 passed
```

**After:**

```
tests/entrypoints/openai/responses/test_protocol.py ...   3 passed in 1.29s
```

**Regression:**

```
test_function_call_parsing.py + test_responses_utils.py + test_harmony_utils.py
140 passed in 37.46s
```

The four validation branches above were also exercised directly to confirm `tool_choice="required"` and named `tool_choice` are still rejected when no tools are supplied.

Model evaluation: not applicable. This only changes request-schema validation on an error path; it does not affect generated output, accuracy, or serving of valid requests.

---

AI assistance was used to produce this change (Claude Code). Per `AGENTS.md`, I have reviewed every changed line and run the tests above myself.
