### PR TITLE
[Bugfix] Don't crash the engine on KV transfer notifications for untracked requests

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -4336,6 +4336,64 @@ def test_abort_request_waiting_for_remote_kvs():
     assert not scheduler.finished_recving_kv_req_ids
 
 
+def test_late_recv_notification_for_untracked_request():
+    """A finished_recving signal for a request the scheduler no longer
+    tracks (aborted and fully freed while its async transfer was in flight,
+    or a duplicated signal) must be ignored, not crash the engine."""
+    scheduler = create_scheduler(use_kv_connector=True)
+
+    request = create_requests(num_requests=1)[0]
+    scheduler.add_request(request)
+
+    # abort while waiting for remote KVs; the designed flow keeps the
+    # request tracked until the transfer notification arrives...
+    request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+    scheduler.finish_requests((request.request_id,), RequestStatus.FINISHED_ABORTED)
+    scheduler_output = scheduler.schedule()
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[],
+        req_id_to_index={},
+        kv_connector_output=KVConnectorOutput(finished_recving={request.request_id}),
+    )
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+    assert request.request_id not in scheduler.requests
+
+    # ...but a second (late/duplicate) notification for the now-untracked
+    # request previously hit `assert req_id in self.requests` and killed
+    # the EngineCore. It must be a no-op.
+    scheduler_output = scheduler.schedule()
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[],
+        req_id_to_index={},
+        kv_connector_output=KVConnectorOutput(finished_recving={request.request_id}),
+    )
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+    assert request.request_id not in scheduler.requests
+    assert not scheduler.finished_recving_kv_req_ids
+
+
+def test_late_send_notification_for_untracked_request():
+    """Same as above for the finished_sending path."""
+    scheduler = create_scheduler(use_kv_connector=True)
+
+    request = create_requests(num_requests=1)[0]
+    scheduler.add_request(request)
+    scheduler.schedule()
+
+    request.status = RequestStatus.FINISHED_ABORTED
+    scheduler._free_request(request)
+    assert request.request_id not in scheduler.requests
+
+    scheduler_output = scheduler.schedule()
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[],
+        req_id_to_index={},
+        kv_connector_output=KVConnectorOutput(finished_sending={request.request_id}),
+    )
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+    assert request.request_id not in scheduler.requests
+
+
 def test_abort_request_finished_recving():
     scheduler = create_scheduler(use_kv_connector=True)
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2553,19 +2553,53 @@ class Scheduler(SchedulerInterface):
             self.connector.update_connector_output(kv_connector_output)
 
         # KV Connector:: update recv and send status from last step.
+        # A transfer-finished notification can arrive for a request the
+        # scheduler no longer tracks: the request may have been aborted and
+        # fully freed while the async transfer was still in flight, or the
+        # signal may be a duplicate. Blocks are only ever released via
+        # _free_blocks, which also removes the request from self.requests,
+        # so an untracked req_id has nothing left to free; ignore the
+        # notification instead of crashing the engine.
         for req_id in kv_connector_output.finished_recving or ():
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            req = self.requests[req_id]
+            req = self.requests.get(req_id)
+            if req is None:
+                # Aborted and already freed; nothing left to do.
+                logger.debug(
+                    "Finished recving KV transfer for untracked request %s",
+                    req_id,
+                )
+                continue
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
+            elif RequestStatus.is_finished(req.status):
+                self._free_blocks(req)
             else:
-                assert RequestStatus.is_finished(req.status)
-                self._free_blocks(self.requests[req_id])
+                logger.warning(
+                    "Finished recving KV transfer for request %s in "
+                    "unexpected status %s; ignoring.",
+                    req_id,
+                    req.status,
+                )
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            self._free_blocks(self.requests[req_id])
+            req = self.requests.get(req_id)
+            if req is None:
+                # Aborted and already freed; nothing left to do.
+                logger.debug(
+                    "Finished sending KV transfer for untracked request %s",
+                    req_id,
+                )
+                continue
+            if not req.is_finished():
+                logger.warning(
+                    "Finished sending KV transfer for request %s still in "
+                    "status %s; ignoring.",
+                    req_id,
+                    req.status,
+                )
+                continue
+            self._free_blocks(req)
 
     def _update_requests_with_invalid_blocks(
         self,


### PR DESCRIPTION
## Purpose

`Scheduler._update_from_kv_xfer_finished()` asserts that every request in `kv_connector_output.finished_recving` / `finished_sending` is still present in `self.requests`:

```python
for req_id in kv_connector_output.finished_recving or ():
    logger.debug("Finished recving KV transfer for request %s", req_id)
    assert req_id in self.requests
```

This assumption does not always hold. KV transfers complete asynchronously relative to the request lifecycle, so a transfer-finished notification can arrive for a request the scheduler no longer tracks: the request may have been aborted (client disconnect) and fully freed while its async transfer was still in flight, or the completion signal may be delivered more than once (e.g. a connector reports a transfer for a request whose abort-cleanup path already consumed an earlier signal and freed it via `_free_blocks`).

When this happens, the bare `assert` raises inside `EngineCore.run_busy_loop()`, where there is no exception boundary, so the entire engine process dies, killing every in-flight request on the instance and dropping its full KV cache.

We hit this in production on a P/D-disaggregated deployment (NixlConnector, latency-sensitive traffic where clients cancel requests aggressively): engines crashed 1-2x/day with this exact stack, and one instance's death escalated to a wider outage. The same assertion failure has been reported independently with a different connector (KVBM) in ai-dynamo/dynamo#5857, which suggests this is a connector-interface robustness gap rather than a single connector's behavior.

Stack observed (v0.23.0; the code is unchanged on main):

```
File ".../vllm/v1/engine/core.py", line 1229, in run_busy_loop
    self._process_engine_step()
File ".../vllm/v1/core/sched/scheduler.py", line 1597, in update_from_output
    self._update_from_kv_xfer_finished(kv_connector_output)
File ".../vllm/v1/core/sched/scheduler.py", line 2238, in _update_from_kv_xfer_finished
    assert req_id in self.requests
AssertionError
```

## Fix

Treat a transfer-finished notification for an untracked request as a benign late/duplicate signal: skip it (with a debug log, mirroring the existing per-transfer debug logging in this function and the silent-skip handling of invalid request IDs in `finish_requests`), instead of asserting.

This is safe with respect to memory: requests are only ever removed from `self.requests` in `_free_blocks()`, which frees their KV blocks first. So by construction, an untracked `req_id` has nothing left to free, and ignoring the notification cannot leak blocks.

Two adjacent hardening changes in the same function follow the same reasoning (both states are otherwise engine-fatal via bare asserts): a `finished_recving` signal for a request in an unexpected (non-waiting, non-finished) status is skipped with a warning rather than `assert`-ed, and a `finished_sending` signal for a request that is not finished is skipped with a warning rather than crashing in `_free_blocks`'s `assert request.is_finished()` (its blocks are freed by the normal completion path). These states are genuinely anomalous, hence warning-level, while the untracked-request case is an expected race and logs at debug.

The designed paths are untouched: a waiting request still moves to `finished_recving_kv_req_ids`, and the abort-while-transferring flow (request retained until the notification arrives, then freed) behaves exactly as before, both covered by the existing tests (`test_abort_request_waiting_for_remote_kvs`, `test_abort_request_finished_recving`), which still pass.

## Test Plan

Two new regression tests in `tests/v1/core/test_scheduler.py`, next to the existing abort/transfer tests and using the same harness:

- `test_late_recv_notification_for_untracked_request`: runs the designed abort-while-waiting flow to completion (request freed), then delivers a second `finished_recving` for the now-untracked request.
- `test_late_send_notification_for_untracked_request`: delivers a `finished_sending` for a request that was finished and fully freed.

## Test Result

On current `main`, without the fix, both tests fail with the exact production failure:

```
FAILED tests/v1/core/test_scheduler.py::test_late_recv_notification_for_untracked_request - AssertionError
FAILED tests/v1/core/test_scheduler.py::test_late_send_notification_for_untracked_request - AssertionError
```

With the fix, both pass, and the neighboring designed-path tests continue to pass:

```
tests/v1/core/test_scheduler.py::test_late_recv_notification_for_untracked_request PASSED
tests/v1/core/test_scheduler.py::test_late_send_notification_for_untracked_request PASSED
tests/v1/core/test_scheduler.py::test_abort_request_waiting_for_remote_kvs PASSED
tests/v1/core/test_scheduler.py::test_abort_request_finished_recving PASSED
```

We have also been running this change in production (backported to v0.23.0) under the same traffic that previously crashed engines daily: the race has since been observed firing (via the new skip-path log line) with zero engine deaths.

Related: ai-dynamo/dynamo#5857
