### PR TITLE
[Bugfix] Don't crash the engine on KV transfer notifications for untracked requests

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2555,17 +2555,42 @@ class Scheduler(SchedulerInterface):
         # KV Connector:: update recv and send status from last step.
         for req_id in kv_connector_output.finished_recving or ():
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            req = self.requests[req_id]
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.debug(
+                    "Finished recving KV transfer for untracked request %s",
+                    req_id,
+                )
+                continue
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
+            elif RequestStatus.is_finished(req.status):
+                self._free_blocks(req)
             else:
-                assert RequestStatus.is_finished(req.status)
-                self._free_blocks(self.requests[req_id])
+                logger.warning(
+                    "Finished recving KV transfer for request %s in "
+                    "unexpected status %s; ignoring.",
+                    req_id,
+                    req.status,
+                )
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            self._free_blocks(self.requests[req_id])
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.debug(
+                    "Finished sending KV transfer for untracked request %s",
+                    req_id,
+                )
+                continue
+            if not req.is_finished():
+                logger.warning(
+                    "Finished sending KV transfer for request %s still in "
+                    "status %s; ignoring.",
+                    req_id,
+                    req.status,
+                )
+                continue
+            self._free_blocks(req)
 
     def _update_requests_with_invalid_blocks(
         self,


### PR DESCRIPTION
## Purpose

`Scheduler._update_from_kv_xfer_finished()` asserts that every request in `kv_connector_output.finished_recving` / `finished_sending` is still present in `self.requests`:

```python
for req_id in kv_connector_output.finished_recving or ():
    logger.debug("Finished recving KV transfer for request %s", req_id)
    assert req_id in self.requests
```

This assumption does not always hold. KV transfers complete asynchronously relative to the request lifecycle, so a transfer-finished notification can arrive for a request the scheduler no longer tracks: the request may have been aborted (client disconnect) and fully freed while its async transfer was still in flight, or the completion signal may be delivered more than once (e.g. a connector reports a transfer for a request whose abort-cleanup path already consumed an earlier signal and freed it via `_free_blocks`).

When this happens, the bare `assert` raises inside `EngineCore.run_busy_loop()`, where there is no exception boundary, so the entire engine process dies, killing every in-flight request on the instance and dropping its full KV cache.

We hit this in production on a P/D-disaggregated deployment (NixlConnector, latency-sensitive traffic where clients cancel requests aggressively): engines crashed 1-2x/day with this exact stack, and one instance's death escalated to a wider outage. The same assertion failure has been reported independently with a different connector (KVBM) in ai-dynamo/dynamo#5857, which suggests this is a connector-interface robustness gap rather than a single connector's behavior.

Stack observed (v0.23.0; the code is unchanged on main):

```
File ".../vllm/v1/engine/core.py", line 1229, in run_busy_loop
    self._process_engine_step()
File ".../vllm/v1/core/sched/scheduler.py", line 1597, in update_from_output
    self._update_from_kv_xfer_finished(kv_connector_output)
File ".../vllm/v1/core/sched/scheduler.py", line 2238, in _update_from_kv_xfer_finished
    assert req_id in self.requests
AssertionError
```

## Fix

Treat a transfer-finished notification for an untracked request as a benign late/duplicate signal and skip it (debug log, matching the existing per-transfer debug logging in this function and the silent-skip handling of invalid request IDs in `finish_requests`), instead of asserting.

This is safe with respect to memory: requests are only ever removed from `self.requests` in `_free_blocks()`, which frees their KV blocks first. So by construction, an untracked `req_id` has nothing left to free, and ignoring the notification cannot leak blocks.

The two remaining states in the same function that were also engine-fatal via bare asserts are handled the same way, at warning level since they are genuinely anomalous: a `finished_recving` signal for a request in an unexpected (non-waiting, non-finished) status, and a `finished_sending` signal for a request that is not finished (its blocks are freed by the normal completion path).

The designed paths are untouched: a waiting request still moves to `finished_recving_kv_req_ids`, and the abort-while-transferring flow (request retained until the notification arrives, then freed) behaves exactly as before.

## Test Plan

The existing scheduler tests covering the designed transfer/abort flows (`test_abort_request_waiting_for_remote_kvs`, `test_abort_request_finished_recving`) pass unchanged.

## Test Result

Existing tests pass. We have also been running this change in production (backported to v0.23.0) under the same traffic that previously crashed engines daily: the race has since been observed firing, with zero engine deaths.

Related: ai-dynamo/dynamo#5857
