### PR TITLE
[CI] Add ModelOpt NVFP4 EPLB accuracy test (Qwen3-30B-A3B, 2xB200)

### DIFF
--- a/.buildkite/scripts/scheduled_integration_test/qwen30b_a3b_nvfp4_ep_eplb.sh
+++ b/.buildkite/scripts/scheduled_integration_test/qwen30b_a3b_nvfp4_ep_eplb.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# args: [THRESHOLD] [NUM_QUESTIONS] [START_PORT] [DATA_PARALLEL_SIZE] [TENSOR_PARALLEL_SIZE]
+THRESHOLD=${1:-0.8}
+NUM_Q=${2:-1319}
+PORT=${3:-8060}
+DATA_PARALLEL_SIZE=${4:-2}
+TENSOR_PARALLEL_SIZE=${5:-2}
+OUT_DIR=${OUT_DIR:-/tmp/vllm-scheduled}
+mkdir -p "${OUT_DIR}"
+
+# NVFP4 first-start runs the FlashInfer FP4 autotuner + cutedsl warmup, which can
+# exceed the default engine-ready timeout on a cold cache. Give it room.
+export VLLM_ENGINE_READY_TIMEOUT_S=${VLLM_ENGINE_READY_TIMEOUT_S:-1800}
+
+wait_for_server() {
+  local port=$1
+  timeout 600 bash -c '
+    until curl -sf "http://127.0.0.1:'"$port"'/health" > /dev/null; do
+      sleep 1
+    done'
+}
+
+# ModelOpt NVFP4 checkpoint (exercises EPLB + NVFP4 MoE on Blackwell).
+MODEL="nvidia/Qwen3-30B-A3B-FP4"
+BACKENDS=("deepep_high_throughput" "deepep_low_latency")
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+    kill "${SERVER_PID}" 2>/dev/null || true
+    for _ in {1..20}; do
+      kill -0 "${SERVER_PID}" 2>/dev/null || break
+      sleep 0.5
+    done
+    kill -9 "${SERVER_PID}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+for BACK in "${BACKENDS[@]}"; do
+  VLLM_DEEP_GEMM_WARMUP=skip \
+  vllm serve "$MODEL" \
+    --enforce-eager \
+    --enable-eplb \
+    --all2all-backend "$BACK" \
+    --eplb-config '{"window_size":10, "step_interval":100, "num_redundant_experts":0, "log_balancedness":true, "use_async":false}' \
+    --tensor-parallel-size "${TENSOR_PARALLEL_SIZE}" \
+    --data-parallel-size "${DATA_PARALLEL_SIZE}" \
+    --enable-expert-parallel \
+    --trust-remote-code \
+    --max-model-len 2048 \
+    --port "$PORT" &
+  SERVER_PID=$!
+  wait_for_server "$PORT"
+
+  TAG=$(echo "$MODEL" | tr '/: \\n' '_____')
+  OUT="${OUT_DIR}/${TAG}_${BACK}.json"
+  python3 tests/evals/gsm8k/gsm8k_eval.py --host http://127.0.0.1 --port "$PORT" --num-questions "${NUM_Q}" --save-results "${OUT}"
+  python3 - <<PY
+import json; acc=json.load(open('${OUT}'))['accuracy']
+print(f"${MODEL} ${BACK}: accuracy {acc:.3f}")
+assert acc >= ${THRESHOLD}, f"${MODEL} ${BACK} accuracy {acc}"
+PY
+
+  cleanup
+  SERVER_PID=
+  sleep 1
+  PORT=$((PORT+1))
+done

--- a/.buildkite/test_areas/e2e_integration.yaml
+++ b/.buildkite/test_areas/e2e_integration.yaml
@@ -32,6 +32,16 @@ steps:
   commands:
   - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_block_ep_eplb.sh 0.8 200 8020 2 1
 
+- label: Qwen3-30B-A3B-NVFP4 Sync EPLB Accuracy (2xB200)
+  key: qwen3-30b-a3b-nvfp4-sync-eplb-accuracy-2xb200
+  timeout_in_minutes: 60
+  device: b200-k8s
+  optional: true
+  num_devices: 2
+  working_dir: "/vllm-workspace"
+  commands:
+  - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_nvfp4_ep_eplb.sh 0.8 200 8060 2 1
+
 - label: Qwen3-30B-A3B-FP8 DP4 Async EPLB Accuracy
   key: qwen3-30b-a3b-fp8-dp4-async-eplb-accuracy
   timeout_in_minutes: 60


### PR DESCRIPTION
## Purpose

Adds an end-to-end EPLB accuracy test for a ModelOpt NVFP4 MoE. The existing
Sync EPLB Accuracy suite covers FP8 only (DeepSeek-V2-Lite, Qwen3-30B-A3B-FP8);
this adds the NVFP4 path, exercising `--enable-eplb` + expert parallelism over
the deepep all2all backends on `nvidia/Qwen3-30B-A3B-FP4`, checked against
gsm8k accuracy on a 2x B200 lane.

Tracking issue: https://github.com/vllm-project/vllm/issues/36264

No existing/open PR adds an NVFP4 EPLB accuracy test (checked open PRs and the
tracking issue).

## Test Plan

```
bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_nvfp4_ep_eplb.sh 0.8 200 8060 2 1
```

## Test Result

GB200 (SM100 Blackwell), vLLM 0.23.1rc1.dev1000, `nvidia/Qwen3-30B-A3B-FP4`,
EPLB (window_size=10, step_interval=100), gsm8k 200 questions, DP2 TP1:

| all2all backend | accuracy |
|---|---|
| deepep_high_throughput | 0.85 |
| deepep_low_latency | 0.88 |

EPLB was confirmed active during the run (log lines `Rearranged experts in
0.35 s` and per-step `balancedness` recorded), so the test exercises the
rebalancing path rather than passing vacuously.

The script raises `VLLM_ENGINE_READY_TIMEOUT_S` because the NVFP4 first start
runs the FlashInfer FP4 autotuner, which can exceed the default engine-ready
timeout on a cold cache.

## Note

AI assistance was used to author this test. All changes were reviewed by hand,
and the tests above were run and verified on the listed hardware.
