### PR TITLE
[Bugfix][R3] Exclude draft routers from expert capture

### DIFF
--- a/tests/model_executor/test_routed_experts_capture.py
+++ b/tests/model_executor/test_routed_experts_capture.py
@@ -138,9 +138,7 @@ def test_gpu_model_runner_binds_router_capture(monkeypatch):
     monkeypatch.setattr(fused_moe_layer, "MoERunner", DummyFusedMoE)
 
     dummy_self = types.SimpleNamespace(
-        compilation_config=types.SimpleNamespace(
-            static_forward_context={"dummy": dummy_module}
-        )
+        model=types.SimpleNamespace(modules=lambda: [dummy_module])
     )
 
     capturer = DummyCapturer()
@@ -177,9 +175,7 @@ def test_gpu_model_runner_binding_stage(monkeypatch):
     monkeypatch.setattr(fused_moe_layer, "MoERunner", DummyFusedMoE)
 
     dummy_self = types.SimpleNamespace(
-        compilation_config=types.SimpleNamespace(
-            static_forward_context={"dummy": dummy_module}
-        )
+        model=types.SimpleNamespace(modules=lambda: [dummy_module])
     )
 
     # Before binding, no capture hook.
@@ -192,6 +188,38 @@ def test_gpu_model_runner_binding_stage(monkeypatch):
     assert callable(dummy_module.router.capture_fn)
     dummy_module.router.capture_fn(torch.tensor([[9, 10]]))
     assert len(capturer.calls) == 1
+
+
+def test_gpu_model_runner_does_not_bind_draft_router_capture(monkeypatch):
+    from vllm.v1.worker import gpu_model_runner as gmr
+
+    class DummyFusedMoE:
+        def __init__(self, layer_id):
+            self.layer_id = layer_id
+            self.router = _make_router()
+
+    target_module = DummyFusedMoE(layer_id=7)
+    draft_module = DummyFusedMoE(layer_id=0)
+
+    import vllm.model_executor.layers.fused_moe.layer as fused_moe_layer
+
+    monkeypatch.setattr(fused_moe_layer, "MoERunner", DummyFusedMoE)
+
+    dummy_self = types.SimpleNamespace(
+        model=types.SimpleNamespace(modules=lambda: [target_module]),
+        compilation_config=types.SimpleNamespace(
+            static_forward_context={
+                "model.layers.7.mlp.experts": target_module,
+                "mtp.layers.0.mlp.experts": draft_module,
+            }
+        ),
+    )
+
+    capturer = types.SimpleNamespace(capture=lambda *_: None)
+    gmr.GPUModelRunner._bind_routed_experts_capturer(dummy_self, capturer)
+
+    assert target_module.router.capture_fn is not None
+    assert draft_module.router.capture_fn is None
 
 
 def test_routed_experts_capturer_single_dp_no_metadata():

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -7589,7 +7589,7 @@ class GPUModelRunner(
             BaseRouter,
         )
 
-        for module in self.compilation_config.static_forward_context.values():
+        for module in self.model.modules():
             if isinstance(module, MoERunner) and isinstance(module.router, BaseRouter):
                 layer_id = module.layer_id
 


### PR DESCRIPTION
## Purpose

Fix routed-experts (R3) capture corruption when speculative decoding uses a
MoE draft model such as MTP.

`GPUModelRunner._bind_routed_experts_capturer` currently walks
`compilation_config.static_forward_context`, which contains modules from both
the target model and the draft model. The target and draft can both have an MoE
layer with `layer_id=0`, so the later draft forward overwrites the target
layer-0 entry in the shared routed-experts buffer. The response still has the
target-sized shape, but one layer contains draft expert IDs and R3 replays the
wrong target experts during training.

This PR binds the capturer only to `self.model.modules()`. The target verifier
continues to return the authoritative target routes; the draft model only
proposes tokens and no longer writes into the target capture buffer. This is
also the behavior adopted by SGLang in
[sgl-project/sglang#26980](https://github.com/sgl-project/sglang/pull/26980).

The regression test constructs a target MoE module and a draft MoE module that
share `layer_id=0` semantics through the global forward context, and verifies
that only the target router receives a capture callback.

## Test Plan

```bash
uv run --no-project python -m pytest \
  tests/model_executor/test_routed_experts_capture.py -q

uv tool run pre-commit run --files \
  vllm/v1/worker/gpu_model_runner.py \
  tests/model_executor/test_routed_experts_capture.py
```

End-to-end validation used Qwen3.6-35B-A3B on 8x H200 with a 40-layer MoE
target, one MTP draft layer, TP4/EP4 rollout, CP2/EP4 actor, one speculative
token, and routed-experts replay enabled.

## Test Result

Targeted test:

```text
9 passed
```

Token-level rollout-vs-actor comparison over 192 action tokens:

| Case | Mean abs dlogp | Max abs dlogp | abs dlogp > 0.1 |
|---|---:|---:|---:|
| R3 without MTP | 0.007255 | 0.126561 | 4/192 |
| MTP + R3 before this fix | 0.042898 | 1.781218 | 24/192 |
| MTP + R3 after this fix | 0.002992 | 0.077535 | 0/192 |
| MTP + R3 + prefix caching after this fix | 0.006525 | 0.145504 | 3/192 |

The final colocated online-training smoke test completed successfully with:

```text
MTP draft acceptance: 58 / 67 (86.6%)
vLLM KL: 0.001138
R3 target layers captured: 40
```

The same one-line fix was validated in the vLLM 0.24.0 runtime used by the
training image; this PR ports it onto current `main` and adds the regression
coverage there.

## Contribution notes

- Open-PR searches found no duplicate fix for the MTP routed-experts capture
  collision.
- AI assistance was used. The human submitter is responsible for reviewing and
  defending the change end-to-end.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] Purpose and root cause described.
- [x] Test plan provided.
- [x] Unit and end-to-end results provided.
- [x] Duplicate-work check documented.
- [x] AI assistance disclosed.
- [x] No documentation update is required.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>**
