### PR TITLE
[Bugfix] Emit DeepSeek V3/V3.1 tool calls that arrive in a single streaming delta

### DIFF
--- a/tests/tool_parsers/test_deepseekv31_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv31_tool_parser.py
@@ -3,6 +3,7 @@
 
 import pytest
 
+from tests.tool_parsers.utils import run_tool_extraction_streaming
 from vllm.tokenizers import get_tokenizer
 from vllm.tool_parsers.deepseekv31_tool_parser import (
     DeepSeekV31ToolParser,
@@ -59,3 +60,50 @@ def test_extract_tool_calls_with_multiple_tools(parser):
 
     # prefix is content
     assert result.content == "some prefix text"
+
+
+def test_streaming_whole_tool_call_in_one_delta(parser):
+    # A complete tool call (begin tag, name, arguments, end tag) arriving in a
+    # single streaming delta must be emitted, matching the non-streaming result.
+    # Before the fix, start_count == end_count on the first pass sent the parser
+    # into the "closing" branch with nothing opened, dropping the call.
+    model_output = (
+        "<｜tool▁calls▁begin｜>"
+        '<｜tool▁call▁begin｜>foo<｜tool▁sep｜>{"x":1}<｜tool▁call▁end｜>'
+        "<｜tool▁calls▁end｜>"
+    )
+
+    nonstream = parser.extract_tool_calls(model_output, None)
+    assert len(nonstream.tool_calls) == 1
+
+    reconstructor = run_tool_extraction_streaming(parser, [model_output])
+
+    assert len(reconstructor.tool_calls) == 1
+    assert reconstructor.tool_calls[0].function.name == "foo"
+    assert reconstructor.tool_calls[0].function.name == (
+        nonstream.tool_calls[0].function.name
+    )
+    assert reconstructor.tool_calls[0].function.arguments == '{"x":1}'
+    assert reconstructor.tool_calls[0].function.arguments == (
+        nonstream.tool_calls[0].function.arguments
+    )
+
+
+def test_streaming_parallel_tool_calls_in_one_delta(parser):
+    # Multiple complete tool calls in a single delta must all be emitted.
+    model_output = (
+        "<｜tool▁calls▁begin｜>"
+        '<｜tool▁call▁begin｜>foo<｜tool▁sep｜>{"x":1}<｜tool▁call▁end｜>'
+        '<｜tool▁call▁begin｜>bar<｜tool▁sep｜>{"y":2}<｜tool▁call▁end｜>'
+        "<｜tool▁calls▁end｜>"
+    )
+
+    reconstructor = run_tool_extraction_streaming(
+        parser, [model_output], assert_one_tool_per_delta=False
+    )
+
+    assert len(reconstructor.tool_calls) == 2
+    assert reconstructor.tool_calls[0].function.name == "foo"
+    assert reconstructor.tool_calls[0].function.arguments == '{"x":1}'
+    assert reconstructor.tool_calls[1].function.name == "bar"
+    assert reconstructor.tool_calls[1].function.arguments == '{"y":2}'

--- a/tests/tool_parsers/test_deepseekv3_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv3_tool_parser.py
@@ -8,6 +8,10 @@ from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
+from tests.tool_parsers.utils import (
+    run_tool_extraction,
+    run_tool_extraction_streaming,
+)
 from vllm.tokenizers import TokenizerLike, get_tokenizer
 
 
@@ -90,3 +94,58 @@ class TestDeepSeekV3ToolParser(ToolParserTests):
                 ),
             },
         )
+
+    def test_streaming_whole_tool_call_in_one_delta(
+        self,
+        tool_parser,
+        test_config: ToolParserTestConfig,
+    ):
+        """A complete tool call delivered in a single streaming delta must be
+        emitted, matching the non-streaming result.
+
+        Chunk boundaries can batch a whole tool call (begin tag, name,
+        arguments, and end tag) into one delta -- e.g. under speculative
+        decoding or scheduler batching. Feeding the full output as a single
+        delta reproduces that case; before the fix the call was silently
+        dropped (streamed result was empty).
+        """
+        _, tools_non = run_tool_extraction(
+            tool_parser, test_config.single_tool_call_output, streaming=False
+        )
+
+        reconstructor = run_tool_extraction_streaming(
+            tool_parser, [test_config.single_tool_call_output]
+        )
+
+        assert len(reconstructor.tool_calls) == 1
+        assert reconstructor.tool_calls[0].function.name == (
+            test_config.single_tool_call_expected_name
+        )
+        assert (
+            reconstructor.tool_calls[0].function.arguments
+            == tools_non[0].function.arguments
+        )
+
+    def test_streaming_parallel_tool_calls_in_one_delta(
+        self,
+        tool_parser,
+        test_config: ToolParserTestConfig,
+    ):
+        """Multiple complete tool calls in a single delta must all be emitted."""
+        _, tools_non = run_tool_extraction(
+            tool_parser, test_config.parallel_tool_calls_output, streaming=False
+        )
+
+        reconstructor = run_tool_extraction_streaming(
+            tool_parser,
+            [test_config.parallel_tool_calls_output],
+            assert_one_tool_per_delta=False,
+        )
+
+        assert len(reconstructor.tool_calls) == test_config.parallel_tool_calls_count
+        for streamed, expected_name in zip(
+            reconstructor.tool_calls, test_config.parallel_tool_calls_names
+        ):
+            assert streamed.function.name == expected_name
+        for streamed, non_streamed in zip(reconstructor.tool_calls, tools_non):
+            assert streamed.function.arguments == non_streamed.function.arguments

--- a/vllm/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv31_tool_parser.py
@@ -172,6 +172,45 @@ class DeepSeekV31ToolParser(ToolParser):
                 delta_text = delta_text.split(self.tool_call_end_token)[0].rstrip()
                 text_portion = delta_text.split(self.tool_call_end_token)[-1].lstrip()
 
+            # case -- one or more complete tool calls (a begin tag and its
+            #   matching end tag) arrived within this single delta. The
+            #   count-based branches below assume every tool call spends at
+            #   least one delta in a "started but not yet closed" state
+            #   (start_count > end_count) before its end tag is seen. When a
+            #   whole call arrives at once, start_count == end_count on the
+            #   first pass, so it would fall into the "closing" branch with an
+            #   empty prev_tool_call_arr and be silently dropped. Re-use the
+            #   non-streaming regex to parse every complete block and emit the
+            #   ones we have not streamed yet.
+            if (
+                cur_tool_start_count == cur_tool_end_count
+                and cur_tool_start_count > prev_tool_start_count
+                and prev_tool_start_count == prev_tool_end_count
+            ):
+                complete_calls = self.tool_call_regex.findall(current_text)
+                new_calls = complete_calls[self.current_tool_id + 1 :]
+                if not new_calls:
+                    return None
+                delta_tool_calls = []
+                for function_name, function_args in new_calls:
+                    self.current_tool_id += 1
+                    self.current_tool_name_sent = True
+                    self.streamed_args_for_tool.append(function_args)
+                    self.prev_tool_call_arr.append(
+                        {"name": function_name, "arguments": function_args}
+                    )
+                    delta_tool_calls.append(
+                        DeltaToolCall(
+                            index=self.current_tool_id,
+                            type="function",
+                            id=make_tool_call_id(),
+                            function=DeltaFunctionCall(
+                                name=function_name, arguments=function_args
+                            ).model_dump(exclude_none=True),
+                        )
+                    )
+                return DeltaMessage(tool_calls=delta_tool_calls)
+
             # case -- we're starting a new tool call
             if (
                 cur_tool_start_count > cur_tool_end_count

--- a/vllm/tool_parsers/deepseekv3_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv3_tool_parser.py
@@ -175,6 +175,45 @@ class DeepSeekV3ToolParser(ToolParser):
                 delta_text = delta_text.split(self.tool_call_end_token)[0].rstrip()
                 text_portion = delta_text.split(self.tool_call_end_token)[-1].lstrip()
 
+            # case -- one or more complete tool calls (a begin tag and its
+            #   matching end tag) arrived within this single delta. The
+            #   count-based branches below assume every tool call spends at
+            #   least one delta in a "started but not yet closed" state
+            #   (start_count > end_count) before its end tag is seen. When a
+            #   whole call arrives at once, start_count == end_count on the
+            #   first pass, so it would fall into the "closing" branch with an
+            #   empty prev_tool_call_arr and be silently dropped. Re-use the
+            #   non-streaming regex to parse every complete block and emit the
+            #   ones we have not streamed yet.
+            if (
+                cur_tool_start_count == cur_tool_end_count
+                and cur_tool_start_count > prev_tool_start_count
+                and prev_tool_start_count == prev_tool_end_count
+            ):
+                complete_calls = self.tool_call_regex.findall(current_text)
+                new_calls = complete_calls[self.current_tool_id + 1 :]
+                if not new_calls:
+                    return None
+                delta_tool_calls = []
+                for tool_type, function_name, function_args in new_calls:
+                    self.current_tool_id += 1
+                    self.current_tool_name_sent = True
+                    self.streamed_args_for_tool.append(function_args)
+                    self.prev_tool_call_arr.append(
+                        {"name": function_name, "arguments": function_args}
+                    )
+                    delta_tool_calls.append(
+                        DeltaToolCall(
+                            index=self.current_tool_id,
+                            type="function",
+                            id=make_tool_call_id(),
+                            function=DeltaFunctionCall(
+                                name=function_name, arguments=function_args
+                            ).model_dump(exclude_none=True),
+                        )
+                    )
+                return DeltaMessage(tool_calls=delta_tool_calls)
+
             # case -- we're starting a new tool call
             if (
                 cur_tool_start_count > cur_tool_end_count


### PR DESCRIPTION
## Purpose

Fixes #48020.

The DeepSeek V3 and V3.1 streaming tool parsers
(`extract_tool_calls_streaming`) infer their state by comparing the number of
tool-call begin/end tokens between `previous_token_ids` and
`current_token_ids`. Every count-based branch assumes a tool call spends at
least one delta in a "started but not yet closed" state
(`start_count > end_count`) before its end tag is observed.

That assumption breaks when a whole tool call — begin tag, name, arguments, and
end tag — arrives in a single delta. On the first pass `start_count ==
end_count`, so the parser skips the "starting a new tool" branch
(`current_tool_id` stays `-1`) and falls into the "closing" branch, finds
`prev_tool_call_arr` empty, logs `attempting to close tool call, but no tool
call`, and returns `None`. The call is silently dropped, even though the
non-streaming `extract_tool_calls` parses the same text correctly. A single
delta carrying a complete call is common in practice: short names/arguments,
`--stream-interval > 1`, speculative decoding (DeepSeek MTP), or plain scheduler
batching under load.

This is the same failure mode already fixed for DeepSeek-V3.2 in #36056.

## Fix

Add one early branch to each parser, immediately before the existing count-based
`if/elif` chain, that detects the "one or more complete tool calls in this
delta" case:

```python
if (
    cur_tool_start_count == cur_tool_end_count
    and cur_tool_start_count > prev_tool_start_count
    and prev_tool_start_count == prev_tool_end_count
):
    ...
```

When it fires, it re-uses the parser's own non-streaming `tool_call_regex` to
parse every complete block from `current_text` and emits the calls that have not
been streamed yet (sliced by emission state, `current_tool_id + 1`, not by token
counts). Reusing the non-streaming regex gives streaming/non-streaming parity by
construction. It also updates `streamed_args_for_tool` and `prev_tool_call_arr`
so the base-class finalize path (`get_remaining_unstreamed_args`) stays
consistent and does not double-emit.

The extra guard `prev_tool_start_count == prev_tool_end_count` restricts the new
branch to the "no call currently open" case, so the existing incremental logic
is left entirely untouched. Token-by-token streaming behaves exactly as before
(the new branch never fires mid-call, when counts are unbalanced).

Per-parser difference: V3's regex yields `(type, name, arguments)` 3-tuples
(arguments come from inside the ` ```json ` fence); V3.1's yields
`(name, arguments)` 2-tuples with no fence. Both emit `type="function"`,
matching each parser's non-streaming path.

Scope is deliberately limited to the two DeepSeek V3/V3.1 parsers named in the
issue title. The same symptom class was raised in the issue thread for
`functiongemma` and `internlm2`; those are separate code paths and are left for
follow-up so this diff stays reviewable. The pre-existing unrelated V3.1 bug at
the `stream_tool_call_name_regex` branch (`tool_name` assigned a `.groups()`
tuple) is also intentionally left alone.

## Test Plan

```bash
pytest tests/tool_parsers/test_deepseekv3_tool_parser.py \
       tests/tool_parsers/test_deepseekv31_tool_parser.py
```

New regression tests (added to the two existing parser test files, which already
download the real DeepSeek-V3 / V3.1 tokenizers):

- `test_streaming_whole_tool_call_in_one_delta` — feeds a full tool call as a
  single streaming delta and asserts the reconstructed name/arguments equal the
  non-streaming result.
- `test_streaming_parallel_tool_calls_in_one_delta` — feeds two complete tool
  calls in one delta and asserts both survive with correct indices/arguments
  (uses `assert_one_tool_per_delta=False`, since one delta legitimately carries
  two calls).

## Test Result

Before the fix, feeding a complete tool call as a single delta streams nothing;
after the fix it matches the non-streaming result exactly. Verified with the
real parser modules and real DeepSeek tokenizers:

```
# before
V3   streamed(1 delta): None
V3   parallel streamed: None
V3.1 streamed(1 delta): None

# after
V3   non-streaming    : [('get_weather', '{"city": "Tokyo", "unit": "celsius"}')]
V3   streamed(1 delta): [('get_weather', '{"city": "Tokyo", "unit": "celsius"}')]
V3   parallel streamed: [('get_weather', '{"city": "Tokyo", "unit": "celsius"}'),
                         ('search_hotels', '{"location": "Tokyo", "check_in": "2025-01-15"}')]
V3.1 non-streaming    : [('foo', '{"x":1}')]
V3.1 streamed(1 delta): [('foo', '{"x":1}')]
```

Token-by-token streaming reconstruction is unchanged before and after the fix
(the new branch does not fire mid-call), confirming no regression on the
incremental path.

Note on the environment: this validation was run as isolated parser logic on
macOS (a full vLLM build is not possible there), exercising the real parser
modules and real DeepSeek tokenizers directly. The added pytest regression
tests are intended to run in Linux CI.

`ruff check`, `ruff format`, and the `typos`/`check-spdx-header`/
`check-forbidden-imports` pre-commit hooks pass on the four changed files.

---

**Disclosure (AI Assisted Contributions):** this change was developed with AI
assistance (Claude). I reviewed every line, reproduced the bug, validated the
fix and its tests locally as described above, and I stand by the change. The
commit carries a `Co-authored-by: Claude` trailer alongside my
`Signed-off-by`, per the contributing guidelines.
