### PR TITLE
[Tests] Cover Nemotron V3 required XML tool parsing

### DIFF
--- a/tests/parser/engine/test_nemotron_v3.py
+++ b/tests/parser/engine/test_nemotron_v3.py
@@ -22,8 +22,11 @@ from tests.parser.engine.streaming_helpers import (
 )
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
+    ChatCompletionToolsParam,
+    FunctionDefinition,
 )
 from vllm.parser.nemotron_v3 import NemotronV3Parser
+from vllm.parser.parser_manager import ParserManager
 
 _THINK_START_ID = 50
 _THINK_END_ID = 51
@@ -46,6 +49,25 @@ def _make_request(**chat_template_kwargs):
     request.include_reasoning = True
     request.chat_template_kwargs = chat_template_kwargs or None
     return request
+
+
+def _weather_tool() -> ChatCompletionToolsParam:
+    return ChatCompletionToolsParam(
+        type="function",
+        function=FunctionDefinition(
+            name="get_current_weather",
+            description="Get current weather",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                    "state": {"type": "string"},
+                    "unit": {"type": "string"},
+                },
+                "required": ["city"],
+            },
+        ),
+    )
 
 
 @pytest.fixture
@@ -128,6 +150,61 @@ class TestNonStreamingToolCalls:
         assert result.tool_calls[0].function.name == "get_weather"
         args = json.loads(result.tool_calls[0].function.arguments)
         assert args == {"city": "Tokyo"}
+
+    @pytest.mark.parametrize(
+        "tool_choice",
+        [
+            "required",
+            {
+                "type": "function",
+                "function": {"name": "get_current_weather"},
+            },
+        ],
+    )
+    def test_required_and_named_tool_choice_parse_xml_after_reasoning(
+        self, tool_choice
+    ):
+        """Regression: Nemotron V3 must not send Qwen XML to JSON parsing."""
+        tool_payload = _weather_tool().model_dump(mode="json", exclude_none=True)
+        request = ChatCompletionRequest(
+            model="model",
+            messages=[],
+            tools=[tool_payload],
+            tool_choice=tool_choice,
+        )
+        tool = request.tools[0]
+        parser_cls = ParserManager.get_parser(
+            tool_parser_name="qwen3_coder",
+            reasoning_parser_name="nemotron_v3",
+            enable_auto_tools=True,
+            model_name="model",
+        )
+        parser = parser_cls(make_mock_tokenizer(_VOCAB), [tool])
+        model_output = (
+            "The user asked for weather.</think>\n"
+            "<tool_call>\n"
+            "<function=get_current_weather>\n"
+            "<parameter=city>Dallas</parameter>\n"
+            "<parameter=state>TX</parameter>\n"
+            "<parameter=unit>fahrenheit</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+
+        reasoning, content, tool_calls = parser.parse(
+            model_output, request, enable_auto_tools=True
+        )
+
+        assert reasoning == "The user asked for weather."
+        assert content is None
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].name == "get_current_weather"
+        assert json.loads(tool_calls[0].arguments) == {
+            "city": "Dallas",
+            "state": "TX",
+            "unit": "fahrenheit",
+        }
 
     def test_parallel_tool_calls(self, parser):
         text = (


### PR DESCRIPTION
## Summary

Add regression coverage for the migrated `nemotron_v3` parser path when it is composed with the Qwen3 XML tool parser.

This verifies that `--reasoning-parser nemotron_v3 --tool-call-parser qwen3_coder` parses Qwen XML tool calls after reasoning for both:

- `tool_choice="required"`
- named function tool choice

The test exercises the same `ParserManager` composition used by serving, so it guards against routing XML tool-call output through the generic JSON required-tool parser.

## Duplicate-work check

Checked the prior closed PR and open PRs:

- `gh issue view 44447 --repo vllm-project/vllm --comments` was attempted, but GitHub returned a `projectCards` deprecation GraphQL error. I used `gh pr view 44447 --json ...` and the issue comments API as a fallback.
- `gh pr list --repo vllm-project/vllm --state open --search "44447 in:body"` returned no open PRs.
- `gh pr list --repo vllm-project/vllm --state open --search "nemotron_v3 qwen3_coder required tool_choice XML"` returned no open PRs.
- `gh pr list --repo vllm-project/vllm --state open --search "Nemotron V3 parser tool_choice required"` returned no open PRs.
- `gh pr list --repo vllm-project/vllm --state open --search "qwen3_coder required named tool_choice"` returned only unrelated #47598.

This is not a re-submission of #44447: current main already has the structural/parser-engine migration. This PR only adds Nemotron-specific regression coverage for that migrated composed path.

## Validation

- `.venv/bin/python -m pytest tests/parser/engine/test_nemotron_v3.py -q` - passed, `16 passed`
- `.venv/bin/python -m ruff check tests/parser/engine/test_nemotron_v3.py` - passed

## AI assistance

AI assistance was used to inspect the prior PR discussion, reproduce the parser path on current main, add the regression test, run targeted validation, and prepare this draft PR. The human submitter is responsible for reviewing and defending the change end-to-end.
