### PR TITLE
[ROCm][CI] fix flashinfer import check

### DIFF
--- a/tests/v1/attention/test_flashinfer_dcp_spec_reorder.py
+++ b/tests/v1/attention/test_flashinfer_dcp_spec_reorder.py
@@ -3,11 +3,16 @@
 """FlashInfer GQA builder: reorder threshold under DCP with spec decode."""
 
 import pytest
+
+from vllm.platforms import current_platform
+
+if not current_platform.is_cuda():
+    pytest.skip("FlashInfer backend requires a CUDA platform.", allow_module_level=True)
+
 import torch
 
 from tests.v1.attention.utils import create_vllm_config
 from vllm.config import SpeculativeConfig, set_current_vllm_config
-from vllm.platforms import current_platform
 from vllm.v1.attention.backends import flashinfer as flashinfer_backend
 from vllm.v1.attention.backends.flashinfer import (
     FlashInferDecodeKernel,
@@ -15,9 +20,6 @@ from vllm.v1.attention.backends.flashinfer import (
 )
 from vllm.v1.attention.backends.utils import PerLayerParameters
 from vllm.v1.kv_cache_interface import FullAttentionSpec
-
-if not current_platform.is_cuda():
-    pytest.skip("FlashInfer backend requires a CUDA platform.", allow_module_level=True)
 
 
 def test_flashinfer_gqa_dcp_spec_decode_clamps_reorder_threshold(monkeypatch):


### PR DESCRIPTION
cuda platform check needs to be done before from flashinfer backend import

Resolves ([buildkite test fail link](https://buildkite.com/vllm/ci/builds/78059/canvas?jid=019f61ac-fb57-42cd-93c9-8bcd99ee3c9f&tab=output)): 
```
from vllm.v1.attention.backends import flashinfer as flashinfer_backend
/usr/local/lib/python3.12/dist-packages/vllm/v1/attention/backends/flashinfer.py:12: in <module>
from flashinfer import (
E   ModuleNotFoundError: No module named 'flashinfer'

```