### PR TITLE
[Bugfix] Fix multimodal CUDA graph capture inputs

### DIFF
--- a/vllm/v1/worker/gpu/model_states/default.py
+++ b/vllm/v1/worker/gpu/model_states/default.py
@@ -125,6 +125,8 @@ class DefaultModelState(ModelState):
         if self.supports_mm_inputs:
             inputs_embeds = self.encoder_runner.inputs_embeds[:num_tokens]
             model_inputs["inputs_embeds"] = inputs_embeds
+            if not self.model.requires_raw_input_tokens:
+                model_inputs["input_ids"] = None
         if self.rope_state is not None:
             model_inputs["positions"] = self.rope_state.get_positions(num_tokens)
         return model_inputs


### PR DESCRIPTION
- Clear dummy-capture `input_ids` when a multimodal model uses `inputs_embeds`.
- Preserve raw token IDs for models that explicitly require them.

CUDA graph capture initializes `model_inputs` with an `input_ids` tensor and then merges the model state's dummy inputs. Multimodal dummy inputs also provide `inputs_embeds`, so models that do not accept both arguments can fail during capture with: `ValueError: You cannot specify both input_ids and inputs_embeds at the same time`. The normal execution path already clears `input_ids` under the same condition. This change makes dummy CUDA graph capture match that runtime behavior.