### PR TITLE
[Bugfix][CI] Fix test_head_dtype quant_method test on ROCm

### DIFF
--- a/tests/v1/sample/test_head_dtype.py
+++ b/tests/v1/sample/test_head_dtype.py
@@ -72,14 +72,26 @@ def test_non_fp32_head_dtype_uses_cast_path(default_vllm_config):
 
 
 def test_head_dtype_equal_to_model_dtype_uses_quant_method(default_vllm_config):
+    from unittest import mock
+
     vocab_size, hidden_size = 64, 16
     lp = _build_processor(vocab_size)
     lp.head_dtype = torch.bfloat16
 
     hidden_states = torch.randn(4, hidden_size, dtype=torch.bfloat16)
     weight = torch.randn(vocab_size, hidden_size, dtype=torch.bfloat16)
+    lm_head = _FakeLmHead(weight)
 
-    logits = lp._get_logits(hidden_states, _FakeLmHead(weight), None)
+    with mock.patch.object(
+        lm_head.quant_method,
+        "apply",
+        side_effect=lambda layer, x, bias=None: torch.nn.functional.linear(
+            x, layer.weight, bias
+        ),
+    ) as apply_mock:
+        logits = lp._get_logits(hidden_states, lm_head, None)
+
+    apply_mock.assert_called_once()
     assert logits.dtype == torch.bfloat16
 
 


### PR DESCRIPTION

This ROCm-specific test failure was introduced by #48390, which added both this test and the `_apply_head` path it exercises. Failure log: https://buildkite.com/vllm/ci/builds/77772/canvas?jid=019f5ac7-4a84-4f1a-9b09-3a047ad8cb91&tab=output

`test_head_dtype_equal_to_model_dtype_uses_quant_method` fails on AMD CI: `NotImplementedError: Could not run 'vllm::rocm_unquantized_gemm' with arguments from the 'CPU' backend`.

The test sets `head_dtype == model dtype`, which routes through `lm_head.quant_method.apply(...)` to `dispatch_unquantized_gemm()`. On ROCm that returns `rocm_unquantized_gemm`, a custom op not registered for CPU. The test uses CPU tensors, so there's no kernel to dispatch to. This wasn't issue on CUDA because this path resolves to a plain `F.linear` there. This is a test of `LogitsProcessor` routing, not of the gemm kernel, so the fix patches `quant_method.apply` with a plain `F.linear` and asserts it was called.

`pytest -v tests/v1/sample/test_head_dtype.py` passes on AMD CI with this PR.