### PR TITLE
[Core] Add an explicit sequence_parallel_moe override

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1647,3 +1647,29 @@ def test_load_config_rejects_invalid_safetensors_load_strategy():
 def test_load_config_rejects_non_string_load_format(bad_load_format):
     with pytest.raises(pydantic.ValidationError):
         LoadConfig(load_format=bad_load_format)
+
+
+def test_sequence_parallel_moe_override():
+    """`sequence_parallel_moe` overrides the auto heuristic in both directions.
+
+    The heuristic enables sequence-parallel MoE for any EP + TP deployment, but
+    it costs an all-gather/reduce-scatter per MoE layer plus activation memory,
+    which does not pay off everywhere. Deployments need a way to opt out (and in)
+    without changing `all2all_backend`.
+    """
+    from vllm.config import ParallelConfig
+
+    ep_tp = dict(tensor_parallel_size=4, enable_expert_parallel=True)
+
+    # Default: heuristic decides (EP + TP > 1 with the default all2all backend).
+    assert ParallelConfig(**ep_tp).use_sequence_parallel_moe
+
+    # Explicit values win over the heuristic.
+    assert not ParallelConfig(
+        **ep_tp, sequence_parallel_moe=False
+    ).use_sequence_parallel_moe
+    assert ParallelConfig(
+        tensor_parallel_size=4,
+        enable_expert_parallel=False,
+        sequence_parallel_moe=True,
+    ).use_sequence_parallel_moe

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -161,6 +161,13 @@ class ParallelConfig:
     """Whether the deployed model is MoE (if known)."""
     enable_expert_parallel: bool = False
     """Use expert parallelism instead of tensor parallelism for MoE layers."""
+    sequence_parallel_moe: bool | None = None
+    """Whether to make the input to the experts sequence parallel. `None`
+    selects it automatically from the all2all backend and the parallel sizes;
+    set it explicitly to override that heuristic. Sequence-parallel MoE avoids
+    duplicate expert work across the tensor-parallel group, but it adds an
+    all-gather/reduce-scatter per MoE layer and extra activation memory, which
+    can cost more than it saves on some deployments."""
     enable_ep_weight_filter: bool = False
     """Skip non-local expert weights during model loading when expert
     parallelism is active.  Each rank only reads its own expert shard from
@@ -640,6 +647,8 @@ class ParallelConfig:
     #
     @property
     def use_sequence_parallel_moe(self) -> bool:
+        if self.sequence_parallel_moe is not None:
+            return self.sequence_parallel_moe
         return (
             self.all2all_backend
             in (

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -487,6 +487,7 @@ class EngineArgs:
     data_parallel_multi_port_external_lb: bool = False
     data_parallel_backend: DataParallelBackend = ParallelConfig.data_parallel_backend
     enable_expert_parallel: bool = ParallelConfig.enable_expert_parallel
+    sequence_parallel_moe: bool | None = ParallelConfig.sequence_parallel_moe
     enable_ep_weight_filter: bool = ParallelConfig.enable_ep_weight_filter
     moe_backend: MoEBackend = KernelConfig.moe_backend
     linear_backend: LinearBackend = KernelConfig.linear_backend
@@ -1099,6 +1100,10 @@ class EngineArgs:
             "--enable-expert-parallel",
             "-ep",
             **parallel_kwargs["enable_expert_parallel"],
+        )
+        parallel_group.add_argument(
+            "--sequence-parallel-moe",
+            **parallel_kwargs["sequence_parallel_moe"],
         )
         parallel_group.add_argument(
             "--enable-ep-weight-filter",
@@ -2111,6 +2116,7 @@ class EngineArgs:
             data_parallel_hybrid_lb=self.data_parallel_hybrid_lb,
             is_moe_model=model_config.is_moe,
             enable_expert_parallel=self.enable_expert_parallel,
+            sequence_parallel_moe=self.sequence_parallel_moe,
             enable_ep_weight_filter=self.enable_ep_weight_filter,
             all2all_backend=self.all2all_backend,
             enable_elastic_ep=self.enable_elastic_ep,


### PR DESCRIPTION
## Purpose

`ParallelConfig.use_sequence_parallel_moe` is a derived property with no override: it is decided entirely by the all2all backend and the parallel sizes. This PR adds an explicit `sequence_parallel_moe` setting (`--sequence-parallel-moe` / `--no-sequence-parallel-moe`) that defaults to `None`, i.e. **no behavior change** — the current heuristic keeps deciding unless an operator sets the flag.

Motivation is #48656. Since #48036 removed the `data_parallel_size > 1` condition, sequence-parallel MoE auto-enables on every EP + TP deployment without data parallelism. On our TP=4 / EP / dp=1 GLM-5.2 setup (4×H200) that measured as:

| | GPU KV cache | N=1 | N=8 | N=32 |
|---|---|---|---|---|
| SP-MoE off | 1,032,448 tok | 75 tok/s | 407 tok/s | 931 tok/s |
| SP-MoE on (current `main`) | 784,300 tok | 61 tok/s | 353 tok/s | 875 tok/s |

The extra all-gather/reduce-scatter per MoE layer, plus the activation memory it needs, cost more than the duplicate expert work it avoids — and today the only escape is switching `all2all_backend` away from the default, which changes the expert-exchange mechanism entirely. Patching `parallel.py` downstream (what we do now) is worse.

This PR only adds the knob; whether the auto-heuristic itself should be revisited for `dp=1` is the open question in #48656.

## Test plan

```bash
pytest tests/test_config.py -k sequence_parallel_moe
```

New test asserts the default still follows the heuristic and that an explicit value overrides it in both directions.

## Test result

- `pytest tests/test_config.py -k sequence_parallel_moe`: passes.
- `ruff check` / `ruff format`: clean.
- Verified on hardware (4×H200, GLM-5.2-NVFP4, TP4/EP/dp1): CLI parses to `None` / `True` / `False`, and `--no-sequence-parallel-moe` reproduces the "SP-MoE off" row above end-to-end.

## AI assistance

AI assistance (Claude) was used for this change. The human submitter reviewed every changed line and ran the tests above.
