### PR TITLE
fix: MLA-aware head_size for transformers backend Attention instances

### DIFF
--- a/vllm/model_executor/models/transformers/base.py
+++ b/vllm/model_executor/models/transformers/base.py
@@ -530,6 +530,23 @@ class Base(
         num_kv_heads = self.model_config.get_num_kv_heads(self.parallel_config)
         logits_soft_cap = getattr(text_config, "attn_logit_softcapping", None)
 
+        # For MLA models (e.g., DeepSeek, GLM) using the transformers backend,
+        # the generic Attention layer receives the full Q/K/V from the model code
+        # which handles MLA decompression internally. The default head_size from
+        # get_head_size() returns the MLA latent size (kv_lora_rank + qk_rope_head_dim),
+        # which is incorrect for the transformers backend. Use the actual query/key/value
+        # head dimensions from the config instead.
+        head_size_v = None
+        if self.model_config.is_deepseek_mla and self.model_config.using_transformers_backend():
+            qk_nope_head_dim = getattr(text_config, "qk_nope_head_dim", 0)
+            qk_rope_head_dim = getattr(text_config, "qk_rope_head_dim", 0)
+            if qk_nope_head_dim and qk_rope_head_dim:
+                head_size = qk_nope_head_dim + qk_rope_head_dim
+                # The model code decompresses MLA K/V into full heads,
+                # so head_size_v = v_head_dim and num_kv_heads = num_kv_heads / TP
+                v_head_dim = getattr(text_config, "v_head_dim", head_size)
+                head_size_v = v_head_dim
+
         # In encoder models, the attention layers will have `is_causal=False`
         is_encoder = lambda module: not getattr(module, "is_causal", True)
         has_encoder = lambda model: any(is_encoder(m) for m in model.modules())
@@ -564,6 +581,7 @@ class Base(
             attention_instances[i] = attn_cls(
                 num_heads=num_heads,
                 head_size=head_size,
+                head_size_v=head_size_v,
                 # NOTE: We use Llama scale as default, if it's set by
                 # Transformers, it's updated in vllm_attention_forward
                 scale=head_size**-0.5,


### PR DESCRIPTION
## Problem

When running MLA models (DeepSeek-V2/V3, GLM-4.5, etc.) through the **transformers backend** (`using_transformers_backend()` returns `True`), the generic vLLM `Attention` layer is instantiated with an incorrect `head_size`.

`ModelConfig.get_head_size()` returns the **MLA latent size** (`kv_lora_rank + qk_rope_head_dim`) because it is designed for the vLLM-native MLA path, where the compressed latent is stored directly in the KV cache. However, the transformers backend takes a different approach: the model code (from the `transformers` library) **internally decompresses** MLA K/V into full per-head tensors before passing them to vLLM's `Attention` layer. The `Attention` instance therefore receives full Q/K/V heads, not latent vectors.

Using the latent size as `head_size` causes:
- **Wrong KV cache allocation** — the cache is sized for the latent dimension rather than the actual per-head V dimension.
- **Shape mismatches** between the attention layer's expectations and the decompressed tensors produced by the model code.
- **Incorrect `scale`** — `head_size ** -0.5` is computed from the wrong dimension, corrupting attention scaling.

This issue is tracked in #48652.

## Fix

In `create_attention_instances()` of the transformers backend `Base` class, add MLA-aware `head_size` / `head_size_v` computation:

When `is_deepseek_mla` is `True` **and** `using_transformers_backend()` is `True`:
- `head_size` (query/key) = `qk_nope_head_dim + qk_rope_head_dim` — the full per-head Q/K dimension after MLA decompression.
- `head_size_v` (value) = `v_head_dim` — the actual per-head value dimension.
- These values are read from the model's `text_config`.

For non-MLA models or the native vLLM backend, behavior is unchanged (`head_size_v` remains `None`, `head_size` comes from `get_head_size()` as before).

## Why This Is Not a Duplicate

PR #48653 addresses a separate FP8 quantization dispatch issue for the transformers backend. This PR specifically fixes the attention `head_size` computation for MLA models, which is an independent bug.

## Testing

- Verified the fix resolves attention shape errors when loading DeepSeek-V3 with the transformers backend.
- Confirmed non-MLA models are unaffected (the `head_size_v=None` default path is preserved).
- The guard `if qk_nope_head_dim and qk_rope_head_dim` ensures the override only activates when the config actually contains MLA dimension fields.

## AI Assistance Disclosure

This PR was prepared with AI assistance (Hermes Agent). The submitting human has reviewed every changed line and verified the fix resolves the described issue.

Closes #48652