### PR TITLE
[Bugfix][DBO] Include ubatch id in attention metadata cache key

### DIFF
--- a/tests/v1/distributed/test_dbo.py
+++ b/tests/v1/distributed/test_dbo.py
@@ -15,18 +15,12 @@ from tests.evals.gsm8k.gsm8k_eval import evaluate_gsm8k
 from tests.utils import RemoteOpenAIServer
 from vllm.utils.import_utils import has_deep_ep
 
-# Detect Blackwell / B200 (compute capability 10.x)
-try:
-    if torch.cuda.is_available():
-        cap = torch.cuda.get_device_capability(0)
-        IS_BLACKWELL = cap[0] >= 10
-    else:
-        IS_BLACKWELL = False
-except Exception:
-    # Be conservative: if we can't detect, don't xfail by default
-    IS_BLACKWELL = False
+IS_BLACKWELL = False
 
-MODEL_NAME = "deepseek-ai/DeepSeek-V2-Lite-Chat"
+MODEL_NAMES = [
+    "deepseek-ai/DeepSeek-V2-Lite-Chat",
+    "Qwen/Qwen3-30B-A3B-FP8",
+]
 DP_SIZE = 2
 
 # GSM8K eval configuration
@@ -46,6 +40,7 @@ DEEPEP_BACKENDS = [
 
 
 @pytest.mark.skipif(not has_deep_ep(), reason="These tests require deep_ep to run")
+@pytest.mark.parametrize("model_name", MODEL_NAMES)
 @pytest.mark.parametrize("all2all_backend", DEEPEP_BACKENDS)
 @pytest.mark.xfail(
     IS_BLACKWELL,
@@ -54,7 +49,7 @@ DEEPEP_BACKENDS = [
         "(doesn't meet expectation of MIN_ACCURACY = 0.62)"
     ),
 )
-def test_dbo_dp_ep_gsm8k(all2all_backend: str, num_gpus_available):
+def test_dbo_dp_ep_gsm8k(model_name: str, all2all_backend: str, num_gpus_available):
     """
     Test DBO with DP+EP using GSM8K evaluation.
     """
@@ -85,7 +80,7 @@ def test_dbo_dp_ep_gsm8k(all2all_backend: str, num_gpus_available):
     ]
 
     with RemoteOpenAIServer(
-        MODEL_NAME,
+        model_name,
         server_args,
         max_wait_seconds=600,  # Allow time for model loading with DP+EP
     ) as remote_server:

--- a/tests/v1/distributed/test_dbo.py
+++ b/tests/v1/distributed/test_dbo.py
@@ -15,7 +15,16 @@ from tests.evals.gsm8k.gsm8k_eval import evaluate_gsm8k
 from tests.utils import RemoteOpenAIServer
 from vllm.utils.import_utils import has_deep_ep
 
-IS_BLACKWELL = False
+# Detect Blackwell / B200 (compute capability 10.x)
+try:
+    if torch.cuda.is_available():
+        cap = torch.cuda.get_device_capability(0)
+        IS_BLACKWELL = cap[0] >= 10
+    else:
+        IS_BLACKWELL = False
+except Exception:
+    # Be conservative: if we can't detect, don't xfail by default
+    IS_BLACKWELL = False
 
 MODEL_NAMES = [
     "deepseek-ai/DeepSeek-V2-Lite-Chat",

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2417,7 +2417,8 @@ class GPUModelRunner(
         # can cache the attention metadata builds and just update the block table using
         # `builder.update_block_table` if the builder supports it.
         cached_attn_metadata: dict[
-            tuple[KVCacheSpec, type[AttentionMetadataBuilder]], AttentionMetadata
+            tuple[KVCacheSpec, type[AttentionMetadataBuilder], int | None],
+            AttentionMetadata,
         ] = {}
 
         def _build_attn_group_metadata(
@@ -2431,7 +2432,7 @@ class GPUModelRunner(
             kv_cache_spec = kv_cache_groups[kv_cache_gid].kv_cache_spec
             if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
                 kv_cache_spec = kv_cache_spec.kv_cache_specs[attn_group.layer_names[0]]
-            cache_key = (kv_cache_spec, type(builder))
+            cache_key = (kv_cache_spec, type(builder), ubid)
 
             cascade_attn_prefix_len = (
                 cascade_attn_prefix_lens[kv_cache_gid][attn_gid]


### PR DESCRIPTION
## Purpose
When DBO splits a batch into micro-batches, attention metadata is built per-ubatch. However, the cached_attn_metadata dict in _prepare_inputs was keyed only by (kv_cache_spec, builder_type). For backends that support update_block_table (e.g. FlashAttention), ubatch 1 would hit ubatch 0's cache entry and take the update path, swapping in ubatch 1's block table and slot mapping while keeping ubatch 0's cu_seqlens_q, seq_lens, and scheduler metadata. Because the two ubatches generally have different request counts and sequence lengths, the reused metadata no longer matches ubatch 1's block table.

Adding ubid to the cache key forces the cache to store distinct metadata instances for each ubatch, keeping the block table and sequence data consistent.

Reproduction
```
vllm serve Qwen/Qwen3-30B-A3B-FP8 \
    --max-model-len 4096 \
    --max-num-seqs 64 \
    --data-parallel-size 4 \
    --enable-expert-parallel \
    --enable-dbo \
    --dbo-decode-token-threshold 16 \
    --dbo-prefill-token-threshold 256 \
    --all2all-backend deepep_low_latency \
    --attention-backend FLASH_ATTN
```
Running lm_eval against this server fails with:
```
File "vllm/vllm_flash_attn/cute/interface.py", line 435, in _flash_attn_fwd
    assert page_table.shape == (batch_size, max_num_pages_per_seq)
AssertionError
```
The DBO integration test only runs deepseek-ai/DeepSeek-V2-Lite-Chat, which uses MLA attention. MLA backends don't set supports_update_block_table = True (it defaults to False on the base builder), so ubatch 1 always rebuilds its metadata from scratch and the stale-cache path is never hit. Only backends that opt into `supports_update_block_table = True` exercise this code path, which is why the bug went unnoticed
## Test Plan
I added `Qwen/Qwen3-30B-A3B-FP8` to test_dbo.py. This adds about 5-6 minutes the the runtime of the test.

## Test Result
This new integration test fails on main and succeeds with this PR.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

