### PR TITLE
[Bugfix] Surface DCP-compatible backends in the DCP error message

### DIFF
--- a/tests/test_attention_backend_registry.py
+++ b/tests/test_attention_backend_registry.py
@@ -7,6 +7,7 @@ from vllm.v1.attention.backend import (
 from vllm.v1.attention.backends.registry import (
     AttentionBackendEnum,
     MambaAttentionBackendEnum,
+    get_dcp_capable_backend_names,
     register_backend,
 )
 
@@ -32,6 +33,42 @@ class CustomAttentionBackend(AttentionBackend):
     @staticmethod
     def get_impl_cls():
         return CustomAttentionImpl
+
+    @staticmethod
+    def get_builder_cls():
+        """Mock builder class."""
+        return None
+
+    @staticmethod
+    def get_required_kv_cache_layout():
+        """Mock KV cache layout."""
+        return None
+
+
+class DcpCapableAttentionImpl(AttentionImpl):
+    """Mock attention impl that can return the softmax LSE for decode,
+    i.e. one that supports Decode Context Parallelism (DCP)."""
+
+    can_return_lse_for_decode = True
+
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+    def forward(self, *args, **kwargs):
+        """Mock forward pass."""
+        pass
+
+
+class DcpCapableAttentionBackend(AttentionBackend):
+    """Mock backend wrapping DcpCapableAttentionImpl for testing."""
+
+    @staticmethod
+    def get_name():
+        return "CUSTOM"
+
+    @staticmethod
+    def get_impl_cls():
+        return DcpCapableAttentionImpl
 
     @staticmethod
     def get_builder_cls():
@@ -167,3 +204,47 @@ def test_register_custom_mamba_backend_with_class_path():
     backend_cls = MambaAttentionBackendEnum.CUSTOM.get_class()
     assert backend_cls.get_name() == "CUSTOM_MAMBA"
     assert backend_cls.get_impl_cls() == CustomMambaAttentionImpl
+
+
+def test_get_dcp_capable_backend_names_includes_lse_capable_backend():
+    # Register a mock backend whose impl explicitly supports returning the
+    # softmax LSE for decode - it must show up as DCP-capable.
+    register_backend(
+        backend=AttentionBackendEnum.CUSTOM,
+        class_path="tests.test_attention_backend_registry.DcpCapableAttentionBackend",
+        is_mamba=False,
+    )
+    try:
+        assert "CUSTOM" in get_dcp_capable_backend_names()
+    finally:
+        AttentionBackendEnum.CUSTOM.clear_override()
+
+
+def test_get_dcp_capable_backend_names_excludes_non_lse_backend():
+    # Register a mock backend whose impl does NOT support returning the
+    # softmax LSE for decode (the CustomAttentionImpl default) - it must not
+    # be reported as DCP-capable.
+    register_backend(
+        backend=AttentionBackendEnum.CUSTOM,
+        class_path="tests.test_attention_backend_registry.CustomAttentionBackend",
+        is_mamba=False,
+    )
+    try:
+        assert "CUSTOM" not in get_dcp_capable_backend_names()
+    finally:
+        AttentionBackendEnum.CUSTOM.clear_override()
+
+
+def test_get_dcp_capable_backend_names_skips_unimportable_backends():
+    # Point CUSTOM at a class path that can't be imported. The helper must
+    # skip it silently rather than raising, since it only powers a
+    # best-effort error/log message.
+    register_backend(
+        backend=AttentionBackendEnum.CUSTOM,
+        class_path="tests.test_attention_backend_registry.DoesNotExist",
+        is_mamba=False,
+    )
+    try:
+        assert "CUSTOM" not in get_dcp_capable_backend_names()
+    finally:
+        AttentionBackendEnum.CUSTOM.clear_override()

--- a/vllm/v1/attention/backends/registry.py
+++ b/vllm/v1/attention/backends/registry.py
@@ -163,6 +163,34 @@ class AttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
         _ATTN_OVERRIDES.pop(self, None)
 
 
+def get_dcp_capable_backend_names() -> list[str]:
+    """Return the names of registered attention backends that support
+    Decode Context Parallelism (DCP).
+
+    A backend supports DCP when its attention impl can return the softmax
+    LSE (log-sum-exp) for decode, since DCP needs the per-shard LSE to
+    combine partial attention outputs across ranks (see
+    ``AttentionImplBase.can_return_lse_for_decode``).
+
+    This is best-effort: backends that fail to import (e.g. because an
+    optional dependency like FlashInfer isn't installed, or the current
+    platform doesn't support them) are silently skipped. The result is only
+    used to build a helpful error/log message, never to gate correctness.
+    """
+    capable_backends: list[str] = []
+    for member in AttentionBackendEnum:
+        try:
+            impl_cls = member.get_class().get_impl_cls()
+        except Exception:
+            # Backend isn't importable in this environment (missing
+            # optional dependency, unsupported platform, unregistered
+            # CUSTOM/TORCH_SDPA placeholder, etc.) - not relevant here.
+            continue
+        if getattr(impl_cls, "can_return_lse_for_decode", False):
+            capable_backends.append(member.name)
+    return capable_backends
+
+
 class MambaAttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
     """Enumeration of all supported mamba attention backends.
 

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -9,6 +9,7 @@ from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.distributed import get_dcp_group, get_pcp_group
 from vllm.logger import init_logger
 from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.attention.backends.registry import get_dcp_capable_backend_names
 from vllm.v1.attention.backends.utils import split_decodes_prefills_and_extends
 
 if TYPE_CHECKING:
@@ -35,13 +36,19 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                     "MTP with cp_kv_cache_interleave_size > 1 is not "
                     f"supported in {layer_impl.__class__.__name__}."
                 )
-            if dcp_size > 1:
-                assert layer_impl.need_to_return_lse_for_decode, (
+            if dcp_size > 1 and not layer_impl.need_to_return_lse_for_decode:
+                compatible = get_dcp_capable_backend_names()
+                suggestion = (
+                    f" Backends that support DCP: {', '.join(compatible)}."
+                    if compatible
+                    else ""
+                )
+                raise AssertionError(
                     "Decode Context Parallelism (DCP) requires attention "
-                    "implementations to return the softmax LSE during decode, "
-                    f"but {layer_impl.__class__.__name__} does not. "
-                    "Try a different backend by setting "
-                    "--attention-backend or disable DCP."
+                    "implementations to return the softmax LSE during "
+                    f"decode, but {layer_impl.__class__.__name__} does "
+                    f"not.{suggestion} Try a different backend by "
+                    "setting --attention-backend, or disable DCP."
                 )
 
             if pcp_size > 1:


### PR DESCRIPTION
## Purpose

Fixes #28407.

When `--decode-context-parallel-size` (DCP) is set with an attention backend whose impl can't return the softmax LSE for decode, `check_attention_cp_compatibility` in `vllm/v1/worker/cp_utils.py` raised an assertion telling the user to "try a different backend" without saying which ones actually work.

This adds `get_dcp_capable_backend_names()` to `vllm/v1/attention/backends/registry.py`, which checks the same `can_return_lse_for_decode` flag that `tools/pre_commit/generate_attention_backend_docs.py` already uses to populate the DCP column in `docs/design/attention_backends.md`. The assertion message in `cp_utils.py` now lists the concrete set of backends that support DCP instead of a generic hint.

## Test Plan

Added three unit tests in `tests/test_attention_backend_registry.py`:
- a mock backend whose impl sets `can_return_lse_for_decode = True` is reported as DCP-capable
- a mock backend without it is excluded
- a mock backend pointing at an unimportable class path is skipped silently rather than raising


Ran the existing suites for both touched test files to confirm no regressions, plus lint:

```bash
pytest tests/test_attention_backend_registry.py -v
pytest tests/v1/worker/test_cp_utils.py -v
pre-commit run -a
```

## Test Result
tests/test_attention_backend_registry.py: 7 passed
tests/v1/worker/test_cp_utils.py: 5 passed

All pre-existing tests in both files continue to pass alongside the three new ones.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

