### PR TITLE
[Bugfix][Spec Decode] Support heterogeneous QK fusion geometry

### DIFF
--- a/tests/compile/passes/test_qk_norm_rope_fusion.py
+++ b/tests/compile/passes/test_qk_norm_rope_fusion.py
@@ -212,3 +212,73 @@ def test_qk_norm_rope_fusion(
 
         backend.check_before_ops(model.ops_in_model_before())
         backend.check_after_ops(model.ops_in_model_after())
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Only test on CUDA and ROCm platforms",
+)
+def test_qk_norm_rope_fusion_with_heterogeneous_draft_model():
+    """The fusion pass should support target and draft attention geometries."""
+    if not hasattr(torch.ops._C, "fused_qk_norm_rope"):
+        pytest.skip("fused_qk_norm_rope custom op not available")
+
+    dtype = torch.bfloat16
+    torch.set_default_device(current_platform.device_type)
+    torch.set_default_dtype(dtype)
+    torch.manual_seed(0)
+
+    vllm_config = VllmConfig(
+        model_config=ModelConfig(dtype=dtype),
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE,
+            custom_ops=["+rms_norm", "+rotary_embedding"],
+            pass_config=PassConfig(
+                enable_qk_norm_rope_fusion=True,
+                eliminate_noops=True,
+            ),
+        ),
+    )
+
+    with (
+        set_current_vllm_config(vllm_config),
+        vllm_config.kernel_config.ir_op_priority.set_priority(),
+    ):
+        target_model = QKNormRoPETestModel(
+            num_heads=32,
+            num_kv_heads=8,
+            head_dim=128,
+            eps=1e-6,
+            is_neox=True,
+            vllm_config=vllm_config,
+            dtype=dtype,
+            prefix="model.layers.0.self_attn.attn",
+        )
+        draft_model = QKNormRoPETestModel(
+            num_heads=16,
+            num_kv_heads=8,
+            head_dim=128,
+            eps=1e-6,
+            is_neox=True,
+            vllm_config=vllm_config,
+            dtype=dtype,
+            prefix="draft_model.layers.0.self_attn.attn",
+        )
+
+        fusion_pass = QKNormRoPEFusionPass(vllm_config)
+        backend = TestBackend(
+            NoOpEliminationPass(vllm_config),
+            SplitCoalescingPass(vllm_config),
+            fusion_pass,
+            PostCleanupPass(vllm_config),
+        )
+
+        for model in (target_model, draft_model):
+            num_tokens = 5
+            qkv = torch.randn(num_tokens, model.q_size + 2 * model.kv_size)
+            positions = torch.arange(num_tokens, dtype=torch.long, device=qkv.device)
+            torch._dynamo.mark_dynamic(qkv, 0)
+            torch._dynamo.mark_dynamic(positions, 0)
+            torch.compile(model, backend=backend)(qkv, positions)
+
+            assert fusion_pass.matched_count == 1

--- a/vllm/compilation/passes/fusion/qk_norm_rope_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_fusion.py
@@ -123,7 +123,11 @@ class QkNormRopePattern:
             cos_sin_cache: torch.Tensor,
         ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
             # split qkv -> q,k,v
-            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            try:
+                q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            except ValueError as e:
+                # register_replacement treats RuntimeError as a trace mismatch.
+                raise RuntimeError from e
 
             # Q path: view -> RMS -> view back to q.shape
             q_by_head = q.view(
@@ -194,6 +198,7 @@ class QKNormRoPEFusionPass(VllmPatternMatcherPass):
         self.patterns: PatternMatcherPass = PatternMatcherPass(
             pass_name="qk_norm_rope_fusion_pass"
         )
+        self._attention_geometries: tuple[tuple[int, int, int], ...] = ()
 
         dtype = config.model_config.dtype
         if dtype not in (torch.bfloat16, torch.float16):
@@ -202,7 +207,6 @@ class QKNormRoPEFusionPass(VllmPatternMatcherPass):
             )
             return
 
-        # use one attn layer to get meta (such as head_dim) for QkNormRopePattern
         attn_layers: dict[str, Attention] = get_layers_from_vllm_config(
             config, Attention
         )
@@ -211,28 +215,31 @@ class QKNormRoPEFusionPass(VllmPatternMatcherPass):
                 "QK Norm+RoPE fusion enabled, but no Attention layers were discovered."
             )
             return
-        layer = next(iter(attn_layers.values()))
 
-        for epsilon in [1e-5, 1e-6]:
-            for neox in [True, False]:
-                if RotaryEmbedding.enabled():
-                    for rope_flashinfer in [False, True]:
+        self._attention_geometries = tuple(
+            sorted(
+                {
+                    (layer.head_size, layer.num_heads, layer.num_kv_heads)
+                    for layer in attn_layers.values()
+                }
+            )
+        )
+
+        rope_flashinfer_options = (
+            [False, True] if RotaryEmbedding.enabled() else [False]
+        )
+        for head_dim, num_heads, num_kv_heads in self._attention_geometries:
+            for epsilon in [1e-5, 1e-6]:
+                for neox in [True, False]:
+                    for rope_flashinfer in rope_flashinfer_options:
                         QkNormRopePattern(
-                            head_dim=layer.head_size,
-                            num_heads=layer.num_heads,
-                            num_kv_heads=layer.num_kv_heads,
+                            head_dim=head_dim,
+                            num_heads=num_heads,
+                            num_kv_heads=num_kv_heads,
                             eps=epsilon,
                             is_neox=neox,
                             rope_flashinfer=rope_flashinfer,
                         ).register(self.patterns)
-                else:
-                    QkNormRopePattern(
-                        head_dim=layer.head_size,
-                        num_heads=layer.num_heads,
-                        num_kv_heads=layer.num_kv_heads,
-                        eps=epsilon,
-                        is_neox=neox,
-                    ).register(self.patterns)
 
         self.dump_patterns(config, self.patterns)
 
@@ -242,4 +249,6 @@ class QKNormRoPEFusionPass(VllmPatternMatcherPass):
         logger.debug("Fused QK Norm+RoPE on %s sites", self.matched_count)
 
     def uuid(self) -> str:
-        return VllmInductorPass.hash_source(self, QkNormRopePattern)
+        return VllmInductorPass.hash_source(
+            self, QkNormRopePattern, repr(self._attention_geometries)
+        )


### PR DESCRIPTION
## Purpose

Fix QK Norm+RoPE fusion when speculative decoding uses target and draft models
with different attention geometries.

`QKNormRoPEFusionPass` discovers attention metadata from
`CompilationConfig.static_forward_context`, which contains modules from both the
target and draft models. It previously selected only the first attention layer
and registered patterns for that geometry. Compiling a draft graph with a
different number of heads could therefore fail while retracing the target-shaped
split.

For example, a Qwen3-8B target has a QKV width of 6144
(`32 * 128 + 2 * 8 * 128`), while a Qwen3-0.6B draft has a QKV width of 4096
(`16 * 128 + 2 * 8 * 128`). Before this change, compiling the draft graph failed
with:

```text
ValueError: Split sizes add up to 6144 but got tensor size 4096
```

## Changes

- Collect every unique `(head_dim, num_heads, num_kv_heads)` geometry from the
  shared attention registry.
- Register QK Norm+RoPE patterns for each geometry.
- Treat a shape-incompatible pattern trace as a normal mismatch so matching can
  continue to the applicable target or draft pattern.
- Include the geometry set in the pass UUID so Inductor does not reuse a pass
  cache entry created for a different target/draft combination.
- Add a regression test that compiles both a 32-head target and a 16-head draft
  from the same forward context and verifies that both graphs fuse.

The pass and regression test use `current_platform.is_cuda_alike()`, which is
shared by CUDA and ROCm. Local runtime validation was performed on NVIDIA H200;
AMD hardware was not tested.

## Test Plan

```bash
uv run --no-project python -m pytest \
  tests/compile/passes/test_qk_norm_rope_fusion.py -q

uv tool run pre-commit run --files \
  vllm/compilation/passes/fusion/qk_norm_rope_fusion.py \
  tests/compile/passes/test_qk_norm_rope_fusion.py
```

Results on H200:

- QK Norm+RoPE fusion test file: `33 passed`.
- Final heterogeneous target/draft regression rerun:
  `1 passed, 32 deselected`.
- Pre-commit, including Ruff and mypy: passed.

The failure was also reproduced end-to-end with a Qwen3-8B target and
Qwen3-0.6B draft. Enabling QK Norm+RoPE fusion failed during engine
initialization with the 6144-vs-4096 split error; disabling only this fusion
restored successful serving. The control request returned HTTP 200, and
speculative decoding reported 23 accepted of 30 drafted tokens (76.7%). The
post-fix validation in this PR is the compilation regression suite above; the
full serving case was not rerun after the patch.

## Contribution notes

- Open-PR searches for heterogeneous QK Norm+RoPE draft geometry and
  `qk_norm_rope` draft-model failures found no duplicate fix.
- AI assistance was used. The human submitter is responsible for reviewing and
  defending the change end-to-end.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] Purpose and root cause described.
- [x] Test commands and results provided.
- [x] Serving reproduction and validation scope provided.
- [x] Duplicate-work check documented.
- [x] AI assistance disclosed.
- [x] No documentation update is required.
</details>
