### PR TITLE
fix: reject required/named tool_choice for Harmony models without a tool parser

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -2134,6 +2134,71 @@ async def test_tool_choice_validation_without_parser():
 
 
 @pytest.mark.asyncio
+async def test_tool_choice_validation_without_parser_harmony():
+    """Harmony models must also reject named/"required" tool choice with no parser.
+
+    Harmony renders tool syntax natively, so it was exempted from the tool
+    parser check entirely. But HarmonyParser only emits tool calls when a tool
+    parser is loaded, and nothing constrains generation to the tool schema
+    without one, so these requests used to be accepted and come back with an
+    empty `tool_calls` list instead of the guaranteed tool call.
+    """
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.model_config.hf_config = MockHFConfig(model_type="gpt_oss")
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+
+    # No tool parser: enable_auto_tools=False and tool_parser=None.
+    serving_chat = _build_serving_chat(mock_engine)
+    assert serving_chat.online_renderer.use_harmony
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the weather in a given location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                    "required": ["location"],
+                },
+            },
+        }
+    ]
+    messages = [{"role": "user", "content": "What's the weather?"}]
+
+    for tool_choice in (
+        "required",
+        {"type": "function", "function": {"name": "get_weather"}},
+    ):
+        response = await serving_chat.create_chat_completion(
+            ChatCompletionRequest(
+                model=MODEL_NAME,
+                messages=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+            )
+        )
+        assert isinstance(response, ErrorResponse)
+        assert "tool_choice" in response.error.message
+        assert "--tool-call-parser" in response.error.message
+
+    # "auto" remains best-effort on Harmony and must still be accepted.
+    auto_result = await serving_chat.render_chat_request(
+        ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=messages,
+            tools=tools,
+            tool_choice="auto",
+        )
+    )
+    assert not isinstance(auto_result, ErrorResponse)
+
+
+@pytest.mark.asyncio
 async def test_streaming_n_gt1_independent_tool_parsers():
     """n>1 streaming must use independent parser instances
     and token-id histories per choice.

--- a/vllm/renderers/online_renderer.py
+++ b/vllm/renderers/online_renderer.py
@@ -115,10 +115,8 @@ class OnlineRenderer:
             _mt.validate_request_params(request)
 
         # Check if tool parsing is unavailable (common condition)
-        tool_parsing_unavailable = (
-            tool_parser is None
-            and not is_mistral_tokenizer(tokenizer)
-            and not self.use_harmony
+        tool_parsing_unavailable = tool_parser is None and not is_mistral_tokenizer(
+            tokenizer
         )
 
         # Validate tool_choice when tool parsing is required but unavailable
@@ -126,15 +124,21 @@ class OnlineRenderer:
             None,
             "none",
         ):
-            if request.tool_choice == "auto" and not self.enable_auto_tools:
+            if request.tool_choice == "auto":
                 # for hf tokenizers, "auto" tools requires
-                # --enable-auto-tool-choice and --tool-call-parser
-                return self.create_error_response(
-                    '"auto" tool choice requires '
-                    "--enable-auto-tool-choice and --tool-call-parser to be set"
-                )
-            elif request.tool_choice != "auto":
-                # "required" or named tool requires tool parser
+                # --enable-auto-tool-choice and --tool-call-parser. Harmony
+                # renders tool syntax natively, so "auto" stays best-effort
+                # and degrades to a plain completion.
+                if not self.enable_auto_tools and not self.use_harmony:
+                    return self.create_error_response(
+                        '"auto" tool choice requires '
+                        "--enable-auto-tool-choice and --tool-call-parser to be set"
+                    )
+            else:
+                # "required" or named tool requires tool parser. This holds for
+                # Harmony too: it only emits tool calls when a tool parser is
+                # loaded, and nothing constrains generation to the tool schema
+                # without one, so the guaranteed tool call cannot be honoured.
                 if isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam):
                     tool_choice_desc = f'function "{request.tool_choice.function.name}"'
                 else:


### PR DESCRIPTION
### Summary
In the OpenAI-compatible chat path, when no tool-call parser is configured, `tool_choice="required"` and named tool choices were accepted for Harmony (gpt-oss) models and then produced empty or incorrect tool-call results.

### Fix
Only exempt Harmony for `tool_choice="auto"` (best effort). Named and `required` now fail closed with a 400 when no tool parser is available. Adds a regression test.

Fixes #48207
