### PR TITLE
fix(v1): freeze offline multiprocess front-end heap (#48229)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1312,7 +1312,7 @@ class VllmRunner:
             # a hard kill leaves the whole allocation for the driver's slow async
             # VRAM reclamation, which starves the next test's startup.
             shutdown_timeout = 60.0 if current_platform.is_rocm() else None
-            self.llm.llm_engine.engine_core.shutdown(timeout=shutdown_timeout)
+            self.llm.llm_engine.shutdown(timeout=shutdown_timeout)
         except Exception:
             # Ignore shutdown errors as cleanup will still proceed
             pass

--- a/tests/v1/engine/test_llm_engine.py
+++ b/tests/v1/engine/test_llm_engine.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import gc
 import random
 from typing import TYPE_CHECKING
 
@@ -16,6 +17,33 @@ else:
 
 MODEL = "facebook/opt-125m"
 DTYPE = "half"
+
+
+def test_offline_multiprocess_frontend_heap_freeze_lifecycle(monkeypatch):
+    """Offline multiprocess freezes the front-end heap and thaws on teardown.
+
+    Regression guard for gh #48229. In multiprocess mode the EngineCore child
+    and the online server both freeze their heaps, but the offline front-end
+    process (the one running step()) was never frozen, so its oldest-generation
+    GC pauses could grow over long runs. Building a multiprocess ``LLM`` must
+    leave the driver process with a frozen heap; explicit teardown (via the
+    context manager here) must unfreeze it, so repeatedly creating and
+    destroying offline ``LLM`` instances in one process does not strand each
+    frozen heap.
+    """
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "1")
+    gc.collect()
+    before = gc.get_freeze_count()
+    with LLM(
+        MODEL,
+        dtype=DTYPE,
+        max_model_len=128,
+        enforce_eager=True,
+        gpu_memory_utilization=0.5,
+    ):
+        frozen = gc.get_freeze_count()
+        assert frozen > before
+    assert gc.get_freeze_count() < frozen
 
 
 def _vllm_model(

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -383,6 +383,24 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
         # Cache for __repr__ to avoid repeated collective_rpc calls
         self._cached_repr: str | None = None
 
+    def shutdown(self) -> None:
+        """Release the engine's resources.
+
+        Offline usage that creates and destroys many ``LLM`` instances in one
+        process should call this (or use the ``LLM`` as a context manager) so
+        the multiprocess front-end ``gc.freeze()`` is undone deterministically.
+        See gh #48229.
+        """
+        llm_engine = getattr(self, "llm_engine", None)
+        if llm_engine is not None:
+            llm_engine.shutdown()
+
+    def __enter__(self) -> "LLM":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.shutdown()
+
     @classmethod
     def from_engine_args(cls, engine_args: EngineArgs) -> "LLM":
         """Create an LLM instance from EngineArgs."""

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import gc
 import time
 import weakref
 from collections.abc import Callable, Mapping
@@ -28,6 +29,7 @@ from vllm.tasks import SupportedTask
 from vllm.tokenizers import TokenizerLike
 from vllm.tracing import init_tracer
 from vllm.usage.usage_lib import UsageContext
+from vllm.utils.gc_utils import freeze_gc_heap
 from vllm.v1.engine import EngineCoreRequest, PauseMode
 from vllm.v1.engine.core_client import EngineCoreClient
 from vllm.v1.engine.input_processor import InputProcessor
@@ -139,6 +141,25 @@ class LLMEngine:
 
         # Don't keep the dummy data in memory
         self.reset_mm_cache()
+
+        # Initialized on every path so shutdown()/the finalizer are always safe.
+        self._frozen_gc_heap = False
+        self._heap_unfreezer: weakref.finalize | None = None
+        if multiprocess_mode:
+            # In multiprocess mode the EngineCore child freezes its own heap
+            # (EngineCore.__init__), but this front-end process is never
+            # frozen -- unlike the online server, which freezes it from the
+            # serve lifespan. Freeze it here, after warmup, so oldest-
+            # generation GC pauses in the process that runs step() do not grow
+            # over long-lived runs.
+            freeze_gc_heap()
+            self._frozen_gc_heap = True
+            # Backstop unfreeze for callers that drop the engine without an
+            # explicit shutdown(). The callback holds no reference to self, so
+            # it never pins the frozen engine graph; it runs on collection in
+            # the acyclic case and otherwise at interpreter exit. shutdown() is
+            # the deterministic path.
+            self._heap_unfreezer = weakref.finalize(self, gc.unfreeze)
 
     @classmethod
     def from_vllm_config(
@@ -441,6 +462,30 @@ class LLMEngine:
         for module in model.modules():
             if isinstance(module, TorchCompileWithNoGuardsWrapper):
                 module.cleanup()
+
+    def shutdown(self, timeout: float | None = None) -> None:
+        """Tear down the engine and release its resources.
+
+        Undoes the multiprocess front-end ``gc.freeze()`` from ``__init__``
+        (gh #48229) and shuts down the ``EngineCore`` client. Safe to call
+        more than once. Offline callers that repeatedly build and drop
+        ``LLM`` instances in one process should call this (directly or via the
+        ``LLM`` context manager) so each frozen front-end heap is released
+        deterministically instead of stranded in the permanent GC generation.
+
+        Args:
+            timeout: Optional shutdown timeout forwarded to the ``EngineCore``
+                client.
+        """
+        if getattr(self, "_frozen_gc_heap", False):
+            self._frozen_gc_heap = False
+            if self._heap_unfreezer is not None:
+                self._heap_unfreezer.detach()
+                self._heap_unfreezer = None
+            gc.unfreeze()
+        engine_core = getattr(self, "engine_core", None)
+        if engine_core is not None:
+            engine_core.shutdown(timeout=timeout)
 
     def __del__(self):
         dp_group = getattr(self, "dp_group", None)


### PR DESCRIPTION
fix(v1): freeze offline multiprocess front-end heap and unfreeze on teardown (#48229)

## Summary

In multiprocess mode the offline `LLM` / `LLMEngine` front-end process (the one that runs `step()`) is never handed to `gc.freeze()`, even though every comparable long-lived heap in vLLM already is:

- the **online** API server freezes its front-end heap in the serve lifespan (`entrypoints/serve/utils/server_utils.py`),
- the **`EngineCore`** child freezes its own heap at the end of `__init__` (`v1/engine/core.py`),
- the **GPU worker** freezes after warmup (`v1/worker/gpu_worker.py`).

Only the offline multiprocess front-end was left out. This PR closes that gap: `LLMEngine.__init__` calls `freeze_gc_heap()` at the end of construction when `multiprocess_mode` is set, and — because offline callers can build and destroy many `LLM`s in one long-lived process — pairs it with a deterministic `gc.unfreeze()` on explicit teardown.

Reference: #48229.

## Motivation and honest framing

This is a **consistency + insurance** change, **not** a fix for the original sporadic 0.7–2 s step stall reported in #48229. That stall did **not** reproduce on fresh hosts, and I am deliberately not claiming it does. What is real and measurable is oldest-generation GC pressure in the front-end process:

- Reporter **@arjmandi** (thanks for the investigation and for OK'ing citing it) measured driver-side gen-2 collection time growing from **~23 ms to ~422 ms** on their H100 over a long-lived run, silenced by freezing the driver heap.
- On the H100 verification box (vLLM 0.25.0), a full front-end gen-2 collection over **~631,928** tracked objects takes **~379 ms**. After `freeze_gc_heap()` that startup heap is out of the cyclic collector's reach, so those objects no longer contribute to every subsequent oldest-gen pause.

The offline front-end is the process that runs `step()`, so this is exactly where such a pause matters. Matching the online server / `EngineCore` behavior here is a strict, low-risk consistency improvement even in the absence of the original stall.

## Not a duplicate

`git grep` and `gh pr list -R vllm-project/vllm --state open --search "freeze_gc_heap"` (and `--search "48229 in:body"`) return no open PR touching `freeze_gc_heap` or referencing #48229. On `main` today `v1/engine/llm_engine.py` has no `import gc`, no `gc_utils` import, and no freeze/unfreeze anywhere — this front-end freeze does not exist yet, so there is nothing to collide with.

## Design: why unfreeze is an *explicit* teardown, not `__del__`/finalizer

`freeze_gc_heap()` → `gc.freeze()` moves **all** currently tracked objects (including `self`, its `EngineCoreClient`, the config graph, and the outer `LLM`) into the permanent generation, which the cyclic collector never scans again. Frozen objects are still freed by reference counting, but **not** by the cyclic collector.

Consequence: if any frozen object sits in a reference cycle, `del llm` will not drive its refcount to zero, and the collector that would normally break the cycle skips it because it is frozen. So a `gc.unfreeze()` hung off `LLMEngine.__del__`, or off a `weakref.finalize` gated on collecting the frozen `LLMEngine`/`engine_core`, would **not fire** on `del llm` in that case — each new instance would re-freeze and strand the prior graph until interpreter exit. That is the precise leak @arjmandi asked us to avoid, and a finalizer-on-`self` design would appear to work while silently failing.

The only trigger that fires reliably and promptly for a frozen-and-possibly-cyclic `self` is a **direct method call**. This PR therefore mirrors the sanctioned `EngineCore.__init__` (freeze) / `EngineCore.shutdown()` (`gc.unfreeze()`) precedent:

- **`LLMEngine.shutdown()`** — new explicit teardown: unfreezes (guarded by a `_frozen_gc_heap` flag so in-process mode is a pure no-op and only the multiprocess path that actually froze thaws) and delegates to `engine_core.shutdown()` (idempotent for the `SyncMPClient`), so it both releases the frozen heap **and** terminates the child `EngineCore` process. Safe to call more than once.
- **`LLM.shutdown()` + context manager** (`__enter__`/`__exit__`) — the offline entrypoint had no explicit teardown at all; this gives callers a deterministic path: `with LLM(...) as llm:` or `llm.shutdown()`.
- **Backstop** `weakref.finalize(self, gc.unfreeze)` — the callback holds **no** reference to `self`, so it never pins the frozen graph. It fires per-instance on `del llm` in the common acyclic case, and at worst runs at interpreter exit via `weakref.finalize`'s atexit hook. `shutdown()` detaches it to avoid a redundant global unfreeze.

Deliberately **no `LLM.__del__`**: it would route `engine_core.shutdown()` onto in-process `del` (changing unrelated in-process semantics) and would not fire for a frozen-cyclic `LLM` anyway.

To route the existing test suite's offline teardown through the unfreeze, `tests/conftest.py` now calls `self.llm.llm_engine.shutdown(timeout=...)` instead of `...engine_core.shutdown(timeout=...)`. For in-process runs this calls the identical `engine_core.shutdown(timeout)` (no behavior change); for multiprocess it additionally unfreezes between sequential models.

## Testing

Regression test added to `tests/v1/engine/test_llm_engine.py` asserting both freeze on build and unfreeze on teardown (GPU CI lane — requires a real engine build):

```
def test_offline_multiprocess_frontend_heap_freeze_lifecycle(...):
    before = gc.get_freeze_count()
    with LLM(MODEL, ..., enforce_eager=True):
        frozen = gc.get_freeze_count()
        assert frozen > before
    assert gc.get_freeze_count() < frozen
```

Verified on 4× H100 NVL (driver 595.71.05), precompiled editable build of this
branch (`VLLM_USE_PRECOMPILED=1`), multiprocess (`VLLM_ENABLE_V1_MULTIPROCESSING=1`),
`facebook/opt-125m`:

- **With the patch:** **PASS**.
- **Negative control** (`freeze_gc_heap()` disabled in-place, re-run, then restored):
  **FAIL** with `assert frozen > before` → `assert 375 > 375` — the freeze count
  does not move without the patch, confirming the test genuinely exercises the
  change and is not vacuous.
- **Lint:** `pre-commit` on the changed files — all hooks passed, no reformatting.

Magnitude (earlier freeze-only round, same `opt-125m`, vLLM 0.25.0, H100):
`gc.get_freeze_count()` jumped **375 → 643,160** after build, and a full
front-end gen-2 collection over **~631,928** tracked objects took **~379 ms** —
that startup heap is out of the cyclic collector's reach after `freeze_gc_heap()`.

The final unfreeze assertion runs after `__exit__` → `shutdown()` → synchronous
`gc.unfreeze()`, so it never depends on `del`+GC timing and is not flaky. It
requires a GPU to build the engine, so it lands in the GPU CI lane. Not asserted
(stated for honesty): bare-`del llm` unfreeze on a *cyclic* graph cannot be
tested deterministically — it resolves only at interpreter exit — so it is
intentionally left uncovered.

## Caveats

- **Deterministic unfreeze requires explicit teardown** (`llm.shutdown()` or `with LLM(...)`). Plain `del llm` unfreezes per-instance only when the front-end graph is acyclic (the backstop finalizer fires on collection); if the graph is cyclic, `del llm` degrades to an unfreeze at interpreter exit. This is a fundamental CPython constraint of `gc.freeze()`, not fixable by any GC-triggered hook, and is never worse than not unfreezing at all.
- **Single-instance / one-shot processes** (the common offline case) need no unfreeze — the process exits and the OS reclaims everything, exactly like the online-server precedent that freezes and never unfreezes. The teardown machinery only matters for repeated create/destroy in one long-lived process.
- **`gc.unfreeze()` is process-global** (same coarse semantics as `EngineCore.shutdown()` / `gpu_worker.shutdown()`): tearing down one of several coexisting offline `LLM`s thaws the others' frozen startup heaps — a loss of the pause optimization, not a correctness issue. Concurrent offline `LLM`s are rare.

## Out of scope

The separate offline teardown issue **#48620** is not addressed here.

## Credits and disclosure

- Co-developed with reporter **@arjmandi**, whose driver-side gen-2 measurements (23 → 422 ms on H100) and testing motivated and validated this change.
- **AI assistance disclosure:** this change was developed with AI assistance (analysis, drafting, and review). All design decisions, the GC-semantics reasoning above, and the H100 test results were reviewed and verified by a human before submission.
