### PR TITLE
[ROCm][CI] fix test_common.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -642,10 +642,12 @@ class HfRunner:
 
         outputs: list[tuple[list[list[int]], list[str]]] = []
         for inputs in all_inputs:
+            generate_kwargs = dict(kwargs)
+            generate_kwargs.setdefault("tokenizer", self.tokenizer)
             output_ids: torch.Tensor = self.model.generate(
                 **self.wrap_device(inputs),
                 use_cache=True,
-                **kwargs,
+                **generate_kwargs,
             )
             if self.processor is None:
                 raise RuntimeError(
@@ -724,6 +726,8 @@ class HfRunner:
 
         all_logprobs: list[list[torch.Tensor]] = []
         for inputs in all_inputs:
+            generate_kwargs = dict(kwargs)
+            generate_kwargs.setdefault("tokenizer", self.tokenizer)
             output: "GenerateOutput" = self.model.generate(
                 **self.wrap_device(inputs),
                 use_cache=True,
@@ -731,7 +735,7 @@ class HfRunner:
                 max_new_tokens=max_tokens,
                 output_hidden_states=True,
                 return_dict_in_generate=True,
-                **kwargs,
+                **generate_kwargs,
             )
             seq_logprobs = self._hidden_states_to_seq_logprobs(output.hidden_states)
             all_logprobs.append(seq_logprobs)
@@ -812,6 +816,8 @@ class HfRunner:
         all_output_strs: list[str] = []
 
         for inputs in all_inputs:
+            generate_kwargs = dict(kwargs)
+            generate_kwargs.setdefault("tokenizer", self.tokenizer)
             output: "GenerateOutput" = self.model.generate(
                 **self.wrap_device(inputs),
                 use_cache=use_cache,
@@ -819,7 +825,7 @@ class HfRunner:
                 max_new_tokens=max_tokens,
                 output_hidden_states=True,
                 return_dict_in_generate=True,
-                **kwargs,
+                **generate_kwargs,
             )
 
             # Encoder-decoder models return decoder_hidden_states instead of

--- a/vllm/model_executor/models/hyperclovax.py
+++ b/vllm/model_executor/models/hyperclovax.py
@@ -459,7 +459,7 @@ class HyperCLOVAXForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         *,
-        intermediate_tensors: IntermediateTensors | None,
+        intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         model_output = self.model(


### PR DESCRIPTION
**Cause**

Newer Transformers requires a tokenizer when generate() uses stop strings. That can come from:

Explicit stop_strings= in the call, or
The model’s generation_config.json
naver-hyperclovax/HyperCLOVAX-SEED-Think-14B (used in test_common.py) has this in its generation config:

"stop_strings": ["<|endofturn|>", "<|stop|>"]
HfRunner in tests/conftest.py was calling:

self.model.generate(**inputs, ...)
without tokenizer=, so Transformers raised that ValueError.

**Fix**
HfRunner now passes the tokenizer by default in all three model.generate() paths:

```
generate_kwargs = dict(kwargs)
generate_kwargs.setdefault("tokenizer", self.tokenizer)
self.model.generate(..., **generate_kwargs)
```
Callers can still override by passing tokenizer= explicitly (as vlm_utils/core.py already does).