### PR TITLE
[Bugfix] Gemma4 parser: don't truncate string args at interior `<|"|>` tokens

### DIFF
--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -278,6 +278,73 @@ class TestParseGemma4Array:
         assert result == ["42"]
 
 
+class TestStringValuesContainingDelim:
+    """Regression tests for string values whose content contains STRING_DELIM.
+
+    ``<|"|>`` doubles as the literal-quote token inside values, so e.g. a
+    Python triple-quoted string inside an ``execute_python``-style ``code``
+    argument is three consecutive delimiter tokens. The closing-delimiter
+    scan must not stop at the first interior token, and must not absorb
+    sibling arguments. Regression tests for #44715.
+    """
+
+    def test_triple_quote_in_code_argument(self):
+        code = (
+            'result = duckdb.sql(<|"|><|"|><|"|> SELECT a, b FROM t '
+            '<|"|><|"|><|"|>).df()'
+        )
+        args = (
+            f'code:<|"|>{code}<|"|>,'
+            'data_refs:[<|"|>df_1<|"|>],return_vars:[<|"|>result<|"|>]'
+        )
+        result = _parse_gemma4_args(args)
+        assert result == {
+            "code": code,
+            "data_refs": ["df_1"],
+            "return_vars": ["result"],
+        }
+
+    def test_escaped_quote_pair_in_value(self):
+        result = _parse_gemma4_args(
+            'code:<|"|>print(<|"|>hi<|"|>)<|"|>,return_vars:[<|"|>x<|"|>]'
+        )
+        assert result == {
+            "code": 'print(<|"|>hi<|"|>)',
+            "return_vars": ["x"],
+        }
+
+    def test_dict_literal_in_code_argument(self):
+        """Quoted keys inside content must not be mistaken for arg boundaries."""
+        code = 'params = {<|"|>a<|"|>: 1, <|"|>b<|"|>: 2}'
+        result = _parse_gemma4_args(
+            f'code:<|"|>{code}<|"|>,return_vars:[<|"|>params<|"|>]'
+        )
+        assert result == {"code": code, "return_vars": ["params"]}
+
+    def test_list_literal_in_code_argument(self):
+        code = 'xs = [<|"|>a<|"|>, <|"|>b<|"|>]'
+        result = _parse_gemma4_args(f'code:<|"|>{code}<|"|>,data_refs:[<|"|>df<|"|>]')
+        assert result == {"code": code, "data_refs": ["df"]}
+
+    def test_delim_content_in_last_value(self):
+        result = _parse_gemma4_args('a:<|"|>1<|"|>,code:<|"|>f(<|"|>x<|"|>)<|"|>')
+        assert result == {"a": "1", "code": 'f(<|"|>x<|"|>)'}
+
+    def test_delim_content_in_array_item(self):
+        result = _parse_gemma4_array('<|"|>say <|"|>hi<|"|> now<|"|>')
+        assert result == ['say <|"|>hi<|"|> now']
+
+    @pytest.mark.timeout(5)
+    def test_streaming_prefixes_no_crash(self):
+        """Every prefix must parse without crashing (streaming path)."""
+        full = (
+            'code:<|"|>r = duckdb.sql(<|"|><|"|><|"|>SELECT 1<|"|><|"|><|"|>'
+            ').df()<|"|>,data_refs:[<|"|>df_1<|"|>],return_vars:[<|"|>r<|"|>]'
+        )
+        for cut in range(1, len(full) + 1):
+            _parse_gemma4_args(full[:cut], partial=True)
+
+
 # ---------------------------------------------------------------------------
 # Non-streaming extraction tests
 # ---------------------------------------------------------------------------

--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import functools
 import json
+import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -63,6 +64,44 @@ def _strip_partial_delim(value: str) -> str:
         if value.endswith(suffix):
             return value[: -len(suffix)]
     return value
+
+
+# ``STRING_DELIM`` doubles as the literal-quote token inside values, so the
+# first occurrence after an opener is not reliably the closer (e.g. a Python
+# ``\"\"\"`` in a code argument is three consecutive delimiter tokens).
+_KEY_AFTER_COMMA_RE = re.compile(r",\s*[A-Za-z_][A-Za-z0-9_.-]*\s*:")
+
+
+def _find_closing_delim(
+    s: str, start: int, *, in_array: bool = False, structural: bool = False
+) -> int:
+    """Return the index of the closing ``STRING_DELIM`` for a string value
+    opened at *start*.
+
+    A delimiter is treated as the closer when the text after it
+    (whitespace-stripped) is empty (end of args) or is a plausible value
+    boundary: ``,key:`` between keyword args, a bare ``,`` between array
+    items, and — only when *structural* is set, i.e. when skipping strings
+    while brace-counting a nested container — a ``}`` or ``]``. The first
+    such delimiter wins, so sibling arguments are never absorbed. When none
+    qualifies (malformed or mid-stream input) fall back to the last
+    delimiter, so a streamed value only ever grows as more of the argument
+    string arrives. Returns -1 when no delimiter exists at all, matching
+    ``str.find``.
+    """
+    pos = s.find(STRING_DELIM, start)
+    last = pos
+    while pos != -1:
+        tail = s[pos + _DELIM_LEN :].lstrip()
+        if not tail:
+            return pos
+        if tail[0] == "," and (in_array or _KEY_AFTER_COMMA_RE.match(tail)):
+            return pos
+        if structural and tail[0] in "}]":
+            return pos
+        last = pos
+        pos = s.find(STRING_DELIM, pos + _DELIM_LEN)
+    return last
 
 
 def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
@@ -122,7 +161,7 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
         if args_str[i : i + _DELIM_LEN] == STRING_DELIM:
             i += _DELIM_LEN
             val_start = i
-            end_pos = args_str.find(STRING_DELIM, i)
+            end_pos = _find_closing_delim(args_str, i)
             if end_pos == -1:
                 # Unterminated string — take rest, strip partial delimiter.
                 value = args_str[val_start:]
@@ -141,7 +180,7 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
                 if args_str[i : i + _DELIM_LEN] == STRING_DELIM:
                     # Skip over string contents to avoid counting { inside strings
                     i += _DELIM_LEN
-                    next_delim = args_str.find(STRING_DELIM, i)
+                    next_delim = _find_closing_delim(args_str, i, structural=True)
                     i = n if next_delim == -1 else next_delim + _DELIM_LEN
                     continue
                 if args_str[i] == "{":
@@ -163,7 +202,9 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
             while i < n and depth > 0:
                 if args_str[i : i + _DELIM_LEN] == STRING_DELIM:
                     i += _DELIM_LEN
-                    next_delim = args_str.find(STRING_DELIM, i)
+                    next_delim = _find_closing_delim(
+                        args_str, i, in_array=True, structural=True
+                    )
                     i = n if next_delim == -1 else next_delim + _DELIM_LEN
                     continue
                 if args_str[i] == "[":
@@ -214,7 +255,7 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
 
         if arr_str[i : i + _DELIM_LEN] == STRING_DELIM:
             i += _DELIM_LEN
-            end_pos = arr_str.find(STRING_DELIM, i)
+            end_pos = _find_closing_delim(arr_str, i, in_array=True)
             if end_pos == -1:
                 items.append(arr_str[i:])
                 break
@@ -228,7 +269,7 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
             while i < n and depth > 0:
                 if arr_str[i : i + _DELIM_LEN] == STRING_DELIM:
                     i += _DELIM_LEN
-                    nd = arr_str.find(STRING_DELIM, i)
+                    nd = _find_closing_delim(arr_str, i, structural=True)
                     i = nd + _DELIM_LEN if nd != -1 else n
                     continue
                 if arr_str[i] == "{":
@@ -248,7 +289,7 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
             while i < n and depth > 0:
                 if arr_str[i : i + _DELIM_LEN] == STRING_DELIM:
                     i += _DELIM_LEN
-                    nd = arr_str.find(STRING_DELIM, i)
+                    nd = _find_closing_delim(arr_str, i, in_array=True, structural=True)
                     i = nd + _DELIM_LEN if nd != -1 else n
                     continue
                 if arr_str[i] == "[":


### PR DESCRIPTION
FIX #44715

## Purpose

`_parse_gemma4_args` bounds string values with `args_str.find(STRING_DELIM, i)` — the *first* `<|"|>` after the opener. But `<|"|>` is also the token the Gemma4 format uses for a **literal `"` inside a value**, so any string argument whose content contains a quote is truncated at the first interior token, and the remainder is re-parsed as garbage keys, corrupting or dropping sibling arguments.

The highest-impact real-world case is agentic `execute_python`-style tools: a `code` argument containing a Python triple-quoted string (e.g. `duckdb.sql("""…""")`) is three consecutive `<|"|>` tokens. The model's output is valid; the parser mangles it in transit, and the client then fails `ast.parse` with `unterminated triple-quoted string literal` — deterministically on every retry. #39069 / #45553 fixed the same class of bug only in the offline `_parse_tool_arguments` variant; this boundary scan was untouched.

Reproduction against the current function:

```
IN : code:<|"|>result = duckdb.sql(<|"|><|"|><|"|> SELECT ... <|"|><|"|><|"|>).df()<|"|>,data_refs:[<|"|>df_1<|"|>],return_vars:[<|"|>result<|"|>]
OUT: {"code": "result = duckdb.sql(",
      "<|\"|><|\"|> SELECT ... ).df()<|\"|>,data_refs": ["df_1"], ...}   ← truncated + garbage key
```

## Fix

Add `_find_closing_delim()` and use it at all six `find(STRING_DELIM, …)` boundary sites (string-value branch, array-item branch, and the four string-skip scans inside the brace-counting object/array branches).

A delimiter is accepted as the **closer** only when the text after it (whitespace-stripped) looks like a real boundary:

- empty (end of args) — covers last values, including recursed object/array bodies whose brackets are already stripped;
- `,` followed by a bare-identifier key and `:` (`,\s*[A-Za-z_][A-Za-z0-9_.-]*\s*:`) between keyword arguments;
- a bare `,` between array items (`in_array=True`);
- `}` / `]` **only** in the brace-skip contexts (`structural=True`), where a string can legitimately be the last element of a raw (unstripped) container.

The **first** qualifying delimiter wins, so sibling arguments are never absorbed and all existing well-formed inputs parse identically to before. When no delimiter qualifies (malformed or mid-stream partial input) it falls back to the **last** delimiter, so under streaming a value only ever grows as more of the argument string arrives (no shrink between consecutive partial parses, which would corrupt the streamed JSON diff).

Deliberate trade-offs of a heuristic on an ambiguous format (the delimiter token and the escaped-quote token are identical, with no doubling convention):

- The `,key:` matcher requires **bare** identifier keys. This is what the format's docstring examples and observed model output use, and it keeps Python dict literals inside `code` content (`{<|"|>a<|"|>: 1, <|"|>b<|"|>: 2}`) from being mistaken for argument boundaries.
- Content that contains a `<|"|>` immediately followed by `,identifier:` can still close early — but every such input was *already* truncated (earlier) by the first-occurrence scan, so this change is monotonic: strictly fewer truncations, never new ones.

Longer-term alternatives worth discussing (out of scope here): schema-aware bounding — the parser has the request's `tools`, so a string value could be closed only at the delimiter preceding a *known* argument name; or a chat-template change that doubles interior delimiters, removing the ambiguity at the source.

## Test Plan

- New `TestStringValuesContainingDelim` unit tests in `tests/tool_parsers/test_gemma4_tool_parser.py`: triple-quoted code + sibling args, escaped quote pairs, dict/list literals inside `code` content, interior delims in a last value and in array items, and an all-prefixes streaming crash check.
- All existing `TestParseGemma4Args` / `TestParseGemma4Array` cases (26) pass unchanged, including the `a]b`-inside-nested-array and delim-quoted-key edge cases.
- Live end-to-end on a production deployment (Gemma 4 26B-A4B AWQ, TP=2, MTP K=4, v0.24.0 + this patch as an overlay): an `execute_python` tool call with a triple-quoted duckdb SQL body now returns all three arguments intact and `ast.parse`-clean; previously the `code` value truncated mid-body. Vision, nested-schema streaming (30/30), and thinking-disabled tool parsing re-certified green with the patch live.

## Test Result

All existing + new parser unit tests pass. Live deployment verification green (details above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CimDmfG1YdbELpMbRqeRaK