### PR TITLE
[Bugfix] Fix HYV3 shared_mlp prefix for compressed-tensors ignore matching

### DIFF
--- a/vllm/model_executor/models/hy_v3.py
+++ b/vllm/model_executor/models/hy_v3.py
@@ -171,7 +171,7 @@ class HYV3MoEFused(nn.Module):
                 intermediate_size=config.expert_hidden_dim * config.num_shared_experts,
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
-                prefix=f"{prefix}",
+                prefix=f"{prefix}.shared_mlp",
                 reduce_results=False,
             )
         else:


### PR DESCRIPTION
## What does this PR do?

Fixes a `KeyError: 'layers.N.mlp.shared_mlp.down_proj.weight'` raised at load time when serving a W4A16 compressed-tensors hy_v3 checkpoint whose shared expert (`shared_mlp`) is intentionally kept in BF16.

## Root cause

`HYV3MoEFused` builds its shared expert as an `HYV3FeedForward` with `prefix=f"{prefix}"`, omitting the `.shared_mlp` segment. The `Linear` layers inside it (`gate_up_proj`, `down_proj`) register their parameters under `...mlp.shared_mlp.<proj>.*` — the `shared_mlp` attribute name is appended by `nn.Module` regardless of the `prefix` argument.

`CompressedTensorsConfig` decides whether a `Linear` is quantized by matching the **prefix** against its `ignore` list. With the missing segment, the ignore check saw `...mlp.down_proj` instead of `...mlp.shared_mlp.down_proj`, so a `re:.*shared_mlp.*` ignore entry failed to match.

Consequence: the shared expert was built as a quantized `Linear` expecting `weight_packed`/`scale`/`shape`, while real W4A16 hy_v3 checkpoints (produced by llm-compressor) correctly keep `shared_mlp` in BF16 as `.weight`. This raised the `KeyError` at load.

## Fix

Pass `prefix=f"{prefix}.shared_mlp"` so the ignore check matches the real parameter registration path and the shared expert is built unquantized (`UnquantizedLinearMethod`), aligning with the BF16 checkpoint. Parameter registration names are unchanged.

## Duplicate-work check

Searched `vllm-project/vllm`:
- Open PRs matching `shared_mlp` / `hy_v3 compressed` / `shared_mlp prefix`: only #47813 (`[NPU][0-DAY] Hy3 0-day adaptation on Ascend NPU`) — a hardware-backend adaptation, unrelated to compressed-tensors prefix matching.
- Issues matching `hy_v3 shared_mlp` / `hy_v3 compressed tensors`: none.

No existing PR addresses this fix.

## Test commands and results

This is a one-line fix to the prefix passed at module construction. Validation:

- End-to-end: on a CUDA server, before the fix the W4A16 hy_v3 checkpoint failed to load with the `KeyError` above; after applying this one-line fix the checkpoint loads and the vLLM service starts successfully.

The fix changes which Linear method the shared expert is built with; it does not alter the forward computation (the unquantized shared expert computes exactly the BF16 path the checkpoint was quantized against). No model-eval accuracy regression is expected; reviewer may request evals if deemed necessary.

## AI assistance

AI assistance was used in producing this change: root-cause diagnosis was developed with AI assistance. The submitting human has reviewed every changed line and validated the fix end-to-end on a CUDA server.