### PR TITLE
[Bugfix] MiniMax M3 reasoning parser: treat non-leading <mm:think> as content

### DIFF
--- a/tests/reasoning/test_minimax_m3_reasoning_parser.py
+++ b/tests/reasoning/test_minimax_m3_reasoning_parser.py
@@ -199,6 +199,39 @@ def test_nonstreaming_non_leading_end_tag_is_content():
     assert content == "XXX</mm:think>YYY"
 
 
+def test_nonstreaming_non_leading_start_tag_is_content():
+    parser, _ = make_parser()
+    request = ChatCompletionRequest(messages=[], model="test-model")
+
+    reasoning, content = parser.extract_reasoning("XXX<mm:think>YYY", request)
+
+    assert reasoning is None
+    assert content == "XXX<mm:think>YYY"
+
+
+def test_nonstreaming_literal_start_marker_in_json_content():
+    parser, _ = make_parser()
+    request = ChatCompletionRequest(messages=[], model="test-model")
+
+    payload = '{"note": "the <mm:think> marker leaks"}'
+    reasoning, content = parser.extract_reasoning(payload, request)
+
+    assert reasoning is None
+    assert content == payload
+
+
+def test_nonstreaming_enabled_mode_literal_start_marker_in_reasoning():
+    parser, _ = make_parser(chat_template_kwargs={"thinking_mode": "enabled"})
+    request = ChatCompletionRequest(messages=[], model="test-model")
+
+    reasoning, content = parser.extract_reasoning(
+        "quoting <mm:think> here</mm:think>answer", request
+    )
+
+    assert reasoning == "quoting <mm:think> here"
+    assert content == "answer"
+
+
 def test_nonstreaming_enabled_mode_starts_in_reasoning():
     parser, _ = make_parser(chat_template_kwargs={"thinking_mode": "enabled"})
     request = ChatCompletionRequest(messages=[], model="test-model")
@@ -273,6 +306,20 @@ def test_streaming_non_leading_end_tag_is_content():
     assert reasoning is None
     assert content == "XXX</mm:think>YYY"
     assert end_states == [True]
+
+
+def test_streaming_non_leading_start_tag_stays_content():
+    parser, tokenizer = make_parser()
+
+    reasoning, content, end_states = run_streaming(
+        parser,
+        tokenizer,
+        ["the ", "<mm:think>", " marker leaks"],
+    )
+
+    assert reasoning is None
+    assert content == "the <mm:think> marker leaks"
+    assert end_states == [True, True, True]
 
 
 def test_streaming_enabled_mode_starts_in_reasoning():
@@ -459,3 +506,43 @@ def test_token_id_helpers_enabled_mode():
     assert parser.count_reasoning_tokens(open_reasoning_ids) == len(
         tokenizer.encode("abc")
     )
+
+
+def test_token_id_helpers_literal_start_marker_is_content():
+    parser, tokenizer = make_parser()
+    payload = '{"note": "the <mm:think> marker leaks"}'
+    output_ids = tokenizer.encode(payload, add_special_tokens=False)
+
+    assert parser.extract_content_ids(output_ids) == output_ids
+    assert parser.count_reasoning_tokens(output_ids) == 0
+
+
+def test_token_id_helpers_literal_start_marker_split_tokens():
+    tokenizer = SplitMiniMaxM3Tokenizer()
+    parser = MiniMaxM3ReasoningParser(tokenizer)
+    payload = '{"note": "the <mm:think> marker leaks"}'
+    output_ids = tokenizer.encode(payload, add_special_tokens=False)
+
+    assert parser.extract_content_ids(output_ids) == output_ids
+    assert parser.count_reasoning_tokens(output_ids) == 0
+
+
+def test_is_reasoning_end_prompt_state_preserved():
+    # is_reasoning_end runs on the full prompt/history to initialize reasoning
+    # state (serving.py, structured_output/__init__.py, abstract_parser.py), so
+    # it must keep rightmost-marker semantics, not the leading-only rule used
+    # for generated output.
+    parser, tokenizer = make_parser()
+    closed_prompt = tokenizer.encode(
+        "<chat>user asks</chat></mm:think>", add_special_tokens=False
+    )
+    assert parser.is_reasoning_end(closed_prompt)
+
+    enabled_parser, tokenizer = make_parser(
+        chat_template_kwargs={"thinking_mode": "enabled"}
+    )
+    open_prompt = tokenizer.encode(
+        "<mm:think>past</mm:think>answer<chat>new</chat><mm:think>",
+        add_special_tokens=False,
+    )
+    assert not enabled_parser.is_reasoning_end(open_prompt)

--- a/vllm/reasoning/minimax_m3_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m3_reasoning_parser.py
@@ -106,6 +106,26 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
         return -1
 
     @staticmethod
+    def _find_token_sequence(
+        token_ids: Sequence[int], marker_ids: Sequence[int], start: int = 0
+    ) -> int:
+        if not marker_ids or len(marker_ids) > len(token_ids):
+            return -1
+        marker_len = len(marker_ids)
+        for i in range(start, len(token_ids) - marker_len + 1):
+            if tuple(token_ids[i : i + marker_len]) == tuple(marker_ids):
+                return i
+        return -1
+
+    @staticmethod
+    def _starts_with_token_sequence(
+        token_ids: Sequence[int], marker_ids: Sequence[int]
+    ) -> bool:
+        if not marker_ids or len(marker_ids) > len(token_ids):
+            return False
+        return tuple(token_ids[: len(marker_ids)]) == tuple(marker_ids)
+
+    @staticmethod
     def _ends_with_token_sequence_prefix(
         token_ids: Sequence[int], marker_ids: Sequence[int]
     ) -> bool:
@@ -148,51 +168,57 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
                 if not text:
                     return None, None
 
-        if self._initial_in_reasoning and self.start_token not in text:
+        if self._initial_in_reasoning:
             reasoning, end, content = text.partition(self.end_token)
             if end:
                 return reasoning or None, content or None
             reasoning = self._strip_partial_marker_suffix(reasoning, self.end_token)
             return reasoning or None, None
 
-        if self.start_token not in text:
-            content = self._strip_partial_marker_suffix(text, self.start_token)
-            return None, content or None
+        # Only a leading start marker opens reasoning; hold back while the text so
+        # far is still a prefix of that marker. A start marker anywhere else is
+        # literal content, so it never gets stripped mid-stream.
+        if not text.startswith(self.start_token):
+            if self.start_token.startswith(text):
+                return None, None
+            return None, text
 
-        content_before, _, after_start = text.partition(self.start_token)
+        after_start = text[len(self.start_token) :]
         reasoning, end, content_after = after_start.partition(self.end_token)
         if end:
-            return reasoning or None, (content_before + content_after) or None
+            return reasoning or None, content_after or None
 
         reasoning = self._strip_partial_marker_suffix(reasoning, self.end_token)
-        return reasoning or None, content_before or None
+        return reasoning or None, None
 
     def extract_reasoning(
         self,
         model_output: str,
         request: "ChatCompletionRequest | ResponsesRequest",
     ) -> tuple[str | None, str | None]:
-        # MiniMax M3 can start a response with a stray closer. Drop that first
-        # token only; later unmatched closers stay visible as content.
-        if not self._initial_in_reasoning and model_output.startswith(self.end_token):
-            content = model_output[len(self.end_token) :]
-            return None, content or None
-
-        if self._initial_in_reasoning and self.start_token not in model_output:
+        # Markers are only meaningful at the boundary they delimit: a reasoning
+        # block is opened by a leading start marker (or the prefilled template in
+        # enabled mode) and closed by the first end marker. A start marker that
+        # the model emits inside content is literal text, not a block opener.
+        if self._initial_in_reasoning:
             reasoning, end, content = model_output.partition(self.end_token)
             if not end:
                 return model_output, None
             return reasoning, content or None
 
-        if self.start_token not in model_output:
+        # A leading closer is a stray token; drop it. Later closers stay content.
+        if model_output.startswith(self.end_token):
+            content = model_output[len(self.end_token) :]
+            return None, content or None
+
+        if not model_output.startswith(self.start_token):
             return None, model_output
 
-        content_before, _, after_start = model_output.partition(self.start_token)
+        after_start = model_output[len(self.start_token) :]
         reasoning, end, content_after = after_start.partition(self.end_token)
         if not end:
-            return reasoning, content_before or None
-
-        return reasoning, (content_before + content_after) or None
+            return reasoning, None
+        return reasoning, content_after or None
 
     def is_reasoning_end_streaming(
         self, input_ids: Sequence[int], delta_ids: Iterable[int]
@@ -232,13 +258,15 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
         if end_index >= 0:
             return input_ids[end_index + len(self._end_token_ids) :]
 
-        has_start = self._contains_token_sequence(input_ids, self._start_token_ids)
-        if self._initial_in_reasoning and not has_start:
+        # Reasoning is open only from a leading start marker (or the prefilled
+        # template). A start marker elsewhere is literal content, so without a
+        # closer the whole sequence is content.
+        leading_reasoning = self._initial_in_reasoning or (
+            self._starts_with_token_sequence(input_ids, self._start_token_ids)
+        )
+        if leading_reasoning:
             return []
-
-        if not has_start:
-            return input_ids
-        return []
+        return input_ids
 
     def extract_reasoning_streaming(
         self,
@@ -288,29 +316,25 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
         return DeltaMessage(reasoning=reasoning, content=content)
 
     def count_reasoning_tokens(self, token_ids: Sequence[int]) -> int:
-        count = 0
-        depth = 1 if self._initial_in_reasoning else 0
-        i = 0
-        while i < len(token_ids):
-            if tuple(token_ids[i : i + len(self._start_token_ids)]) == (
-                self._start_token_ids
-            ):
-                depth += 1
-                i += len(self._start_token_ids)
-                continue
-            if tuple(token_ids[i : i + len(self._end_token_ids)]) == (
-                self._end_token_ids
-            ):
-                if depth > 0:
-                    depth -= 1
-                i += len(self._end_token_ids)
-                continue
-            if depth > 0:
-                count += 1
-            i += 1
-        return count
+        # Reasoning spans from a leading start marker (or the prefilled template)
+        # to the first closer. A non-leading start marker is literal content.
+        token_ids = list(token_ids)
+        if self._initial_in_reasoning:
+            body_start = 0
+        elif self._starts_with_token_sequence(token_ids, self._start_token_ids):
+            body_start = len(self._start_token_ids)
+        else:
+            return 0
+        end_index = self._find_token_sequence(
+            token_ids, self._end_token_ids, body_start
+        )
+        body_end = end_index if end_index >= 0 else len(token_ids)
+        return body_end - body_start
 
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
+        # Operates on the full prompt/history token stream to initialize
+        # reasoning state, so it uses rightmost-marker (current-state) semantics
+        # rather than the leading-only rule used for generated output above.
         start_index = self._rfind_token_sequence(input_ids, self._start_token_ids)
         end_index = self._rfind_token_sequence(input_ids, self._end_token_ids)
         if end_index < 0:


### PR DESCRIPTION
## Purpose

Fixes #48663.

`MiniMaxM3ReasoningParser` recognized the `<mm:think>` start marker **anywhere** in the model output. MiniMax M3 delimits reasoning positionally — `<mm:think>reasoning</mm:think>content` — so a `<mm:think>` the model emits *inside* content is literal text, not a block opener. Treating it as an opener splits one valid response across both fields:

- Everything before the marker → `content`
- Everything after → `reasoning`
- `finish_reason` is `"stop"`, so nothing signals a problem

This reliably bites structured-output workloads whose JSON quotes the marker text (logs, transcripts, docs, issue text). In the reporter's case, 2 of 546 documents failed — exactly the two that contained `<mm:think>`. Concatenating `content + reasoning` reassembles the original, well-formed JSON: the model complied with the grammar; only the parser was wrong.

### Fix

Recognize the start marker only where it delimits a boundary: a **leading** start marker (or the prefilled template in `enabled` mode) opens reasoning; a start marker **anywhere else** is literal content. This mirrors the parser's existing end-marker handling — a non-leading `</mm:think>` already stays content (`test_nonstreaming_non_leading_end_tag_is_content`).

**Method audit** — the fix is scoped to the methods that parse **generated output**, where a leading start marker (or the prefilled template) opens reasoning:

| Method | Path (generated output) | Before → after on `{"note": "the <mm:think> marker leaks"}` |
|---|---|---|
| `extract_reasoning` | non-streaming response | split → intact `content` |
| `_visible_segments` | streaming response | split → intact `content` |
| `extract_content_ids` | `abstract_parser.py:853` → tool parser | `[]` → full token IDs |
| `count_reasoning_tokens` | `responses/serving.py:895` → `usage.reasoning_tokens` | `15` → `0` |

A shared `_starts_with_token_sequence` / `_find_token_sequence` helper pair keeps the token-ID checks consistent.

**`is_reasoning_end` is deliberately left unchanged (rightmost-marker semantics).** Unlike the methods above, it is called on the **full prompt/history** to initialize reasoning state (`chat_completion/serving.py:353`, `v1/structured_output/__init__.py:365`, `abstract_parser.py:815`). A prompt never *starts* with `<mm:think>`, so applying the leading-only rule there would invert the result — reporting a closed disabled-mode prompt as still-reasoning and an open enabled-mode prompt as ended, misinitializing structured-output grammar. A regression test (`test_is_reasoning_end_prompt_state_preserved`) locks in that contract. This also keeps the PR clear of #48550's `is_reasoning_end_from_prompt()` prompt-state work.

### Not a duplicate

- No open or recently-closed PR references #48663 (`gh pr list -R vllm-project/vllm --state all --search "48663 in:body"` → none).
- **Overlap note re #48550** (MiniMax M3 reasoning): it rewrites `is_reasoning_end_streaming` / `extract_content_ids` for a *different* defect (prompt-mode initialization / structured-output gating) and does **not** touch `extract_reasoning`, `_visible_segments`, `count_reasoning_tokens`, or `is_reasoning_end`. Its `extract_content_ids` still uses `... or self.start_token in text` (containment), so it does not fix this bug. The only file overlap is `extract_content_ids`; happy to rebase around #48550 or coordinate on ordering — flagging so a maintainer can sequence the two.

### Known assumption / open question (leading whitespace)

The leading-marker checks are strict: `model_output.startswith("<mm:think>")`, no `lstrip()`. This assumes a genuine reasoning block begins with `<mm:think>` as the first generated token in `adaptive`/`disabled` mode (`enabled` mode is unaffected — the marker is prefilled, so the parser never looks for a leading marker there). If M3's chat template or tokenizer can ever emit a leading space/newline *before* a real `<mm:think>`, these checks would treat the whole response as content — the mirror image of this bug.

I could not verify M3's exact template behavior without the model (NVFP4/TP4, no local GPU), and preferred a strict check over hand-rolling whitespace tolerance into the streaming state machine on an unverified assumption. **If a maintainer/model author knows M3 can prepend whitespace before the marker, it's a trivial `lstrip()`-tolerant follow-up** — flagging it explicitly rather than guessing.

## Test Plan

Added regression tests to `tests/reasoning/test_minimax_m3_reasoning_parser.py` covering the text and token-ID paths; each fails on unfixed `main` and passes with the fix (red/green verified by reverting the source):

- `test_nonstreaming_non_leading_start_tag_is_content` — mirror of the existing end-marker test.
- `test_nonstreaming_literal_start_marker_in_json_content` — the reporter's exact JSON payload.
- `test_nonstreaming_enabled_mode_literal_start_marker_in_reasoning` — `enabled` mode, literal marker inside prefilled reasoning.
- `test_streaming_non_leading_start_tag_stays_content` — streaming, marker split across deltas.
- `test_token_id_helpers_literal_start_marker_is_content` / `..._split_tokens` — `extract_content_ids` / `count_reasoning_tokens`, atomic and text-tokenized markers.
- `test_is_reasoning_end_prompt_state_preserved` — locks the prompt-state contract for `is_reasoning_end` (closed prompt → ended; enabled prompt with a fresh open marker → still open).

```bash
.venv/bin/python -m pytest tests/reasoning/test_minimax_m3_reasoning_parser.py -v
pre-commit run --files vllm/reasoning/minimax_m3_reasoning_parser.py \
  tests/reasoning/test_minimax_m3_reasoning_parser.py
```

CPU-only, no GPU required.

## Test Result

```
tests/reasoning/test_minimax_m3_reasoning_parser.py ............. 29 passed
```

- **Red/green:** the 6 literal-marker tests fail on unfixed `main`, pass with the fix. `test_is_reasoning_end_prompt_state_preserved` passes on `main` (its behavior is unchanged) and fails against a leading-only variant of `is_reasoning_end` — a guard proving the prompt contract was preserved.
- **Full `tests/reasoning/`:** 456 passed (the `test_cohere_command_reasoning_parser` collection error is a pre-existing missing optional dependency, `cohere_melody`, unrelated to this change).
- **Lint:** `ruff check`, `ruff format`, `mypy` (3.10), SPDX header, and the other pre-commit hooks all pass.

Model eval: not applicable — parser-only fix on the reasoning/content-extraction paths; the split is exercised directly by the added unit tests, and generated model output is unchanged.

## Real behavior proof

**Behavior addressed:** With `--reasoning-parser minimax_m3`, a `<mm:think>` string the model emits *inside* its answer (e.g. structured output whose JSON quotes the marker) was treated as a reasoning-block opener — splitting the response across `content`/`reasoning`, dropping content token IDs fed to the tool parser, and over-counting `usage.reasoning_tokens`. After the fix the marker is literal content on all paths.

**Real environment tested:** vLLM built from this branch on a local checkout; the parser is resolved through the production `ReasoningParserManager.get_reasoning_parser("minimax_m3")` dispatch — the exact lookup the OpenAI serving layer performs for `--reasoning-parser minimax_m3` — and driven through the real non-streaming (`extract_reasoning`), streaming (`extract_reasoning_streaming`), and token-ID (`extract_content_ids`, `count_reasoning_tokens`) entry points. Input is the reporter's exact payload `{"note": "the <mm:think> marker leaks"}`. (MiniMax-M3 is NVFP4/TP4 and cannot run on the test machine, so the model weights themselves are not exercised — see below.)

**Exact steps or command run after this patch:**
```
python proof_minimax_m3.py     # response paths, AFTER: this branch
python proof_tokenids.py       # token-ID paths, AFTER: this branch
git show origin/main:vllm/reasoning/minimax_m3_reasoning_parser.py \
  > vllm/reasoning/minimax_m3_reasoning_parser.py   # revert to main
python proof_minimax_m3.py     # BEFORE
python proof_tokenids.py       # BEFORE
git restore vllm/reasoning/minimax_m3_reasoning_parser.py
```

**Evidence after fix:**
```
# response paths
[non-streaming] content: '{"note": "the <mm:think> marker leaks"}'   reasoning: None
[streaming]     content: '{"note": "the <mm:think> marker leaks"}'   reasoning: None
# token-ID paths
extract_content_ids    : '{"note": "the <mm:think> marker leaks"}'  (full payload)
count_reasoning_tokens : 0  (no reasoning)
RESULT: PASS
```
Same harness on unpatched `main`:
```
[non-streaming] content: '{"note": "the '   reasoning: ' marker leaks"}'
[streaming]     content: '{"note": "the '   reasoning: ' marker leaks"}'
extract_content_ids    : ''   (*** TRUNCATED ***)
count_reasoning_tokens : 15   (*** WRONG ***)
RESULT: FAIL
```

**Observed result after fix:** On all four paths the full valid JSON is preserved as content, no reasoning is emitted, content token IDs are intact, and `reasoning_tokens` is `0`. On unpatched `main` the identical input splits the document, drops content token IDs to `[]`, and reports 15 phantom reasoning tokens. Full unit suite: `28 passed`; the 6 new tests fail on `main`, pass here.

**What was not tested:** End-to-end serving against real MiniMax-M3 weights (NVFP4, TP4) — no GPU available. The reasoning/content split is entirely in the CPU-side parser, driven here through its production dispatch with the reporter's exact payload; the untested surface is only the model generation upstream of the parser, which this change does not touch.

<sub>AI-assisted (Claude); every line reviewed and tests run locally before submission.</sub>
