### PR TITLE
[Bugfix] Make Gemma 4 suppress-token masking CUDA-graph safe

### DIFF
--- a/tests/model_executor/test_gemma4_suppress_tokens.py
+++ b/tests/model_executor/test_gemma4_suppress_tokens.py
@@ -1,0 +1,274 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+from vllm.model_executor.models.gemma4_mtp import Gemma4MTP, Gemma4MTPMaskedEmbedder
+from vllm.model_executor.models.gemma4_unified import (
+    Gemma4UnifiedForConditionalGeneration,
+)
+from vllm.model_executor.models.utils import (
+    make_suppress_token_ids,
+    register_suppress_token_ids,
+)
+
+
+class _FakeLanguageModel(nn.Module):
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return hidden_states.clone()
+
+
+class _FakeLogitsProcessor:
+    def __call__(self, lm_head: nn.Module, hidden_states: torch.Tensor) -> torch.Tensor:
+        return hidden_states.clone()
+
+
+def test_gemma4_unified_suppress_tokens_masking():
+    model = Gemma4UnifiedForConditionalGeneration.__new__(
+        Gemma4UnifiedForConditionalGeneration
+    )
+    nn.Module.__init__(model)
+    model.language_model = _FakeLanguageModel()
+    model.register_buffer(
+        "_suppress_token_ids",
+        torch.tensor([1, 3], dtype=torch.long),
+        persistent=False,
+    )
+
+    logits = model.compute_logits(torch.zeros(2, 5))
+
+    assert torch.isneginf(logits[:, [1, 3]]).all()
+    assert torch.equal(logits[:, [0, 2, 4]], torch.zeros(2, 3))
+
+
+@pytest.mark.parametrize(
+    ("suppress_tokens", "expected_suppressed"),
+    [(0, [0]), (torch.empty(0, dtype=torch.long), [])],
+)
+def test_gemma4_mtp_suppress_tokens_masking(suppress_tokens, expected_suppressed):
+    model = Gemma4MTP.__new__(Gemma4MTP)
+    nn.Module.__init__(model)
+    model.masked_embedding = None
+    model.lm_head = nn.Identity()
+    model.logits_processor = _FakeLogitsProcessor()
+    register_suppress_token_ids(model, suppress_tokens, torch.empty(0), 5)
+
+    logits = model.compute_logits(torch.zeros(2, 5))
+
+    if expected_suppressed:
+        assert torch.isneginf(logits[:, expected_suppressed]).all()
+    else:
+        assert torch.equal(logits, torch.zeros(2, 5))
+
+
+def test_gemma4_mtp_sparse_argmax_excludes_suppressed_tokens(monkeypatch):
+    masked_embedding = Gemma4MTPMaskedEmbedder(
+        hidden_size=2,
+        vocab_size=4,
+        num_centroids=2,
+        centroid_intermediate_top_k=1,
+    )
+    sparse_logits = torch.tensor([[10.0, 9.0]])
+    sparse_indices = torch.tensor([[1, 2]])
+    monkeypatch.setattr(
+        masked_embedding,
+        "_select_and_score",
+        lambda hidden_states, lm_head_weight: (sparse_logits, sparse_indices),
+    )
+
+    top_tokens = masked_embedding.get_top_tokens(
+        torch.zeros(1, 2),
+        torch.zeros(4, 2),
+        torch.tensor([1]),
+        torch.tensor(0),
+    )
+
+    assert torch.equal(top_tokens, torch.tensor([2]))
+
+
+@pytest.mark.parametrize(
+    ("suppress_token_ids", "expected"),
+    [
+        (None, 1),
+        ([1], 2),
+        ([1, 2], 0),
+    ],
+)
+def test_gemma4_mtp_sparse_argmax_matches_full_logits(
+    monkeypatch,
+    suppress_token_ids,
+    expected,
+):
+    masked_embedding = Gemma4MTPMaskedEmbedder(
+        hidden_size=2,
+        vocab_size=4,
+        num_centroids=2,
+        centroid_intermediate_top_k=1,
+    )
+    sparse_logits = torch.tensor([[10.0, 9.0]])
+    sparse_indices = torch.tensor([[1, 2]])
+    monkeypatch.setattr(
+        masked_embedding,
+        "_select_and_score",
+        lambda hidden_states, lm_head_weight: (sparse_logits, sparse_indices),
+    )
+    model = nn.Module()
+    register_suppress_token_ids(model, suppress_token_ids, torch.empty(0), 4)
+
+    sparse_top = masked_embedding.get_top_tokens(
+        torch.zeros(1, 2),
+        torch.zeros(4, 2),
+        model._suppress_token_ids,
+        model._suppress_fallback_token_id,
+    )
+    full_logits = masked_embedding(
+        torch.zeros(1, 2),
+        torch.zeros(4, 2),
+    )
+    if model._suppress_token_ids is not None:
+        full_logits.index_fill_(1, model._suppress_token_ids, -float("inf"))
+
+    assert torch.equal(sparse_top, full_logits.argmax(-1))
+    assert sparse_top.item() == expected
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+def test_gemma4_mtp_suppress_tokens_cuda_graph_capture_and_replay():
+    model = Gemma4MTP.__new__(Gemma4MTP)
+    nn.Module.__init__(model)
+    model.masked_embedding = None
+    model.lm_head = nn.Identity()
+    model.logits_processor = _FakeLogitsProcessor()
+
+    hidden_states = torch.zeros(2, 5, device="cuda")
+    register_suppress_token_ids(model, [1, 3], hidden_states, 5)
+
+    model.compute_logits(hidden_states)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        logits = model.compute_logits(hidden_states)
+
+    for value in (1.0, 2.0):
+        hidden_states.fill_(value)
+        graph.replay()
+        torch.accelerator.synchronize()
+        assert torch.isneginf(logits[:, [1, 3]]).all()
+        assert torch.equal(
+            logits[:, [0, 2, 4]],
+            torch.full((2, 3), value, device="cuda"),
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+@pytest.mark.parametrize(
+    ("suppress_token_ids", "expected"),
+    [([1], 2), ([1, 2], 0)],
+    ids=["partial", "all-selected"],
+)
+def test_gemma4_mtp_sparse_suppress_tokens_cuda_graph_capture_and_replay(
+    monkeypatch,
+    suppress_token_ids,
+    expected,
+):
+    model = Gemma4MTP.__new__(Gemma4MTP)
+    nn.Module.__init__(model)
+    model.masked_embedding = Gemma4MTPMaskedEmbedder(
+        hidden_size=2,
+        vocab_size=4,
+        num_centroids=2,
+        centroid_intermediate_top_k=1,
+    ).cuda()
+    indices = torch.tensor([[1, 2]], device="cuda")
+    monkeypatch.setattr(
+        model.masked_embedding,
+        "_select_and_score",
+        lambda hidden_states, lm_head_weight: (hidden_states, indices),
+    )
+    lm_head_weight = torch.zeros(4, 2, device="cuda")
+    monkeypatch.setattr(model, "_get_full_lm_head_weight", lambda: lm_head_weight)
+    register_suppress_token_ids(model, suppress_token_ids, lm_head_weight, 4)
+
+    sparse_logits = torch.tensor([[10.0, 9.0]], device="cuda")
+    model.get_top_tokens(sparse_logits)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        top_tokens = model.get_top_tokens(sparse_logits)
+
+    for values in ([10.0, 9.0], [1.0, 2.0]):
+        sparse_logits.copy_(torch.tensor([values], device="cuda"))
+        graph.replay()
+        torch.accelerator.synchronize()
+        assert torch.equal(top_tokens, torch.tensor([expected], device="cuda"))
+
+
+def test_register_suppress_token_ids_follows_parameter_device_and_is_nonpersistent():
+    model = nn.Module()
+    reference = nn.Parameter(torch.empty(1, device="cpu"))
+
+    register_suppress_token_ids(model, torch.tensor([1, 3]), reference, 5)
+
+    assert model._suppress_token_ids.device == reference.device
+    assert "_suppress_token_ids" not in model.state_dict()
+    assert "_suppress_fallback_token_id" not in model.state_dict()
+    model.to("meta")
+    assert model._suppress_token_ids.device.type == "meta"
+    assert model._suppress_fallback_token_id.device.type == "meta"
+
+
+def test_register_suppress_token_ids_supports_meta_reference():
+    model = nn.Module()
+    reference = torch.empty(1, device="meta")
+
+    register_suppress_token_ids(model, [1, 3], reference, 5)
+
+    assert model._suppress_token_ids.device.type == "meta"
+    assert model._suppress_fallback_token_id.device.type == "meta"
+
+
+@pytest.mark.parametrize(
+    ("suppress_tokens", "expected"),
+    [
+        (None, None),
+        ([], None),
+        ((), None),
+        (np.array([], dtype=np.int64), None),
+        (torch.empty(0, dtype=torch.long), None),
+        (0, [0]),
+        (7, [7]),
+        ([1, 3], [1, 3]),
+        ((2, 4), [2, 4]),
+        (np.array([5, 6]), [5, 6]),
+        (torch.tensor([8, 9]), [8, 9]),
+        (torch.tensor(10), [10]),
+    ],
+)
+def test_make_suppress_token_ids(suppress_tokens, expected):
+    token_ids = make_suppress_token_ids(suppress_tokens, torch.device("cpu"), 16)
+
+    if expected is None:
+        assert token_ids is None
+    else:
+        assert token_ids is not None
+        assert token_ids.ndim == 1
+        assert token_ids.dtype == torch.long
+        assert torch.equal(token_ids, torch.tensor(expected, dtype=torch.long))
+
+
+@pytest.mark.parametrize("suppress_tokens", [True, 1.5, [1, 2.0], torch.tensor(3.0)])
+def test_make_suppress_token_ids_rejects_non_integral_values(suppress_tokens):
+    with pytest.raises(ValueError, match="integer token IDs"):
+        make_suppress_token_ids(suppress_tokens, torch.device("cpu"), 4)
+
+
+@pytest.mark.parametrize("suppress_tokens", [-1, 4, [0, 4]])
+def test_make_suppress_token_ids_rejects_out_of_range_values(suppress_tokens):
+    with pytest.raises(ValueError, match=r"must be in \[0, 4\)"):
+        make_suppress_token_ids(suppress_tokens, torch.device("cpu"), 4)
+
+
+def test_make_suppress_token_ids_rejects_entire_vocabulary():
+    with pytest.raises(ValueError, match="entire vocabulary"):
+        make_suppress_token_ids([0, 1, 2, 3], torch.device("cpu"), 4)

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -82,6 +82,7 @@ from .utils import (
     WeightsMapper,
     init_vllm_registered_model,
     maybe_prefix,
+    register_suppress_token_ids,
 )
 
 if TYPE_CHECKING:
@@ -1134,7 +1135,13 @@ class Gemma4ForConditionalGeneration(
         self.num_redundant_experts = self.language_model.num_redundant_experts
 
         gen_cfg = vllm_config.model_config.try_get_generation_config()
-        self._suppress_token_ids = gen_cfg.get("suppress_tokens") if gen_cfg else None
+        suppress_token_ids = gen_cfg.get("suppress_tokens") if gen_cfg else None
+        register_suppress_token_ids(
+            self,
+            suppress_token_ids,
+            self.language_model.lm_head.weight,
+            text_config.vocab_size,
+        )
 
     # ------------------------------------------------------------------ #
     # Input parsing
@@ -1615,8 +1622,8 @@ class Gemma4ForConditionalGeneration(
         hidden_states: torch.Tensor,
     ) -> torch.Tensor | None:
         logits = self.language_model.compute_logits(hidden_states)
-        if logits is not None and self._suppress_token_ids:
-            logits[:, self._suppress_token_ids] = -float("inf")
+        if logits is not None and self._suppress_token_ids is not None:
+            logits.index_fill_(1, self._suppress_token_ids, -float("inf"))
         return logits
 
     # ------------------------------------------------------------------ #

--- a/vllm/model_executor/models/gemma4_mtp.py
+++ b/vllm/model_executor/models/gemma4_mtp.py
@@ -53,6 +53,7 @@ from .utils import (
     extract_layer_index,
     get_draft_quant_config,
     maybe_prefix,
+    register_suppress_token_ids,
 )
 
 logger = init_logger(__name__)
@@ -139,10 +140,27 @@ class Gemma4MTPMaskedEmbedder(nn.Module):
         self,
         hidden_states: torch.Tensor,
         lm_head_weight: torch.Tensor,
+        suppress_token_ids: torch.Tensor | None = None,
+        suppress_fallback_token_id: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Sparse argmax — returns vocab token IDs without full-vocab tensor."""
         logits, indices = self._select_and_score(hidden_states, lm_head_weight)
-        return indices.gather(-1, logits.argmax(-1, keepdim=True)).squeeze(-1)
+        all_candidates_suppressed = None
+        if suppress_token_ids is not None:
+            suppressed = (indices.unsqueeze(-1) == suppress_token_ids).any(-1)
+            logits.masked_fill_(suppressed, -float("inf"))
+            all_candidates_suppressed = suppressed.all(-1)
+        top_tokens = indices.gather(-1, logits.argmax(-1, keepdim=True)).squeeze(-1)
+        if (
+            all_candidates_suppressed is not None
+            and suppress_fallback_token_id is not None
+        ):
+            top_tokens = torch.where(
+                all_candidates_suppressed,
+                suppress_fallback_token_id,
+                top_tokens,
+            )
+        return top_tokens
 
 
 class Gemma4MTPAttention(nn.Module):
@@ -529,7 +547,13 @@ class Gemma4MTP(nn.Module):
 
         draft_cfg = vllm_config.speculative_config.draft_model_config
         gen_cfg = draft_cfg.try_get_generation_config()
-        self._suppress_token_ids = gen_cfg.get("suppress_tokens") if gen_cfg else None
+        suppress_token_ids = gen_cfg.get("suppress_tokens") if gen_cfg else None
+        register_suppress_token_ids(
+            self,
+            suppress_token_ids,
+            self.lm_head.weight,
+            text_config.vocab_size,
+        )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
@@ -581,8 +605,8 @@ class Gemma4MTP(nn.Module):
             )
         else:
             logits = self.logits_processor(self.lm_head, hidden_states)
-        if logits is not None and self._suppress_token_ids:
-            logits[:, self._suppress_token_ids] = -float("inf")
+        if logits is not None and self._suppress_token_ids is not None:
+            logits.index_fill_(1, self._suppress_token_ids, -float("inf"))
         return logits
 
     def get_top_tokens(
@@ -593,6 +617,8 @@ class Gemma4MTP(nn.Module):
         return self.masked_embedding.get_top_tokens(
             hidden_states,
             self._get_full_lm_head_weight(),
+            self._suppress_token_ids,
+            self._suppress_fallback_token_id,
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:

--- a/vllm/model_executor/models/gemma4_unified.py
+++ b/vllm/model_executor/models/gemma4_unified.py
@@ -53,6 +53,7 @@ from .utils import (
     WeightsMapper,
     init_vllm_registered_model,
     maybe_prefix,
+    register_suppress_token_ids,
 )
 
 # Re-export so tests/code targeting the unified variant can import from here
@@ -347,7 +348,13 @@ class Gemma4UnifiedForConditionalGeneration(Gemma4ForConditionalGeneration):
         self.set_eplb_state = self.language_model.set_eplb_state
 
         gen_cfg = vllm_config.model_config.try_get_generation_config()
-        self._suppress_token_ids = gen_cfg.get("suppress_tokens") if gen_cfg else None
+        suppress_token_ids = gen_cfg.get("suppress_tokens") if gen_cfg else None
+        register_suppress_token_ids(
+            self,
+            suppress_token_ids,
+            self.language_model.lm_head.weight,
+            text_config.vocab_size,
+        )
 
     # ------------------------------------------------------------------ #
     # Multimodal processing (encoder-free overrides)

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -43,6 +43,81 @@ logger = init_logger(__name__)
 ShardId: TypeAlias = str | int | tuple[int, ...]
 
 
+def make_suppress_token_ids(
+    suppress_tokens: Any,
+    device: torch.device,
+    vocab_size: int,
+) -> torch.Tensor | None:
+    """Convert suppress-token values to a one-dimensional long tensor.
+
+    Args:
+        suppress_tokens: Token IDs or ``None``.
+        device: Device on which to create the tensor.
+        vocab_size: Number of tokens in the vocabulary.
+
+    Returns:
+        A one-dimensional long tensor of token IDs, or ``None`` if empty.
+    """
+    if suppress_tokens is None:
+        return None
+
+    try:
+        token_ids = torch.as_tensor(suppress_tokens, device="cpu").reshape(-1)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError("suppress_tokens must contain integer token IDs") from exc
+    if token_ids.numel() == 0:
+        return None
+    if token_ids.dtype == torch.bool or token_ids.is_floating_point():
+        raise ValueError("suppress_tokens must contain integer token IDs")
+    if token_ids.is_complex():
+        raise ValueError("suppress_tokens must contain integer token IDs")
+
+    token_values = token_ids.tolist()
+    if any(token_id < 0 or token_id >= vocab_size for token_id in token_values):
+        raise ValueError(
+            f"suppress_tokens must be in [0, {vocab_size}), got {token_values}"
+        )
+    if len(set(token_values)) == vocab_size:
+        raise ValueError("suppress_tokens cannot contain the entire vocabulary")
+    return token_ids.to(dtype=torch.long, device=device)
+
+
+def register_suppress_token_ids(
+    module: nn.Module,
+    suppress_tokens: Any,
+    reference_tensor: torch.Tensor,
+    vocab_size: int,
+) -> None:
+    """Register suppress-token IDs on the model parameter's device."""
+    token_ids = make_suppress_token_ids(
+        suppress_tokens,
+        reference_tensor.device,
+        vocab_size,
+    )
+    module.register_buffer(
+        "_suppress_token_ids",
+        token_ids,
+        persistent=False,
+    )
+    fallback_token_id = None
+    if token_ids is not None:
+        suppressed = set(
+            torch.as_tensor(suppress_tokens, device="cpu").reshape(-1).tolist()
+        )
+        fallback_token_id = torch.tensor(
+            next(
+                token_id for token_id in range(vocab_size) if token_id not in suppressed
+            ),
+            dtype=torch.long,
+            device=reference_tensor.device,
+        )
+    module.register_buffer(
+        "_suppress_fallback_token_id",
+        fallback_token_id,
+        persistent=False,
+    )
+
+
 @dataclass
 class WeightsMapper:
     """Maps the name of each weight if they match the following patterns.

--- a/vllm/v1/spec_decode/gemma4.py
+++ b/vllm/v1/spec_decode/gemma4.py
@@ -115,7 +115,6 @@ class Gemma4Proposer(SpecDecodeBaseProposer):
     def _setup_centroids_cuda_graphs(self) -> None:
         """Capture CUDA graphs for centroids get_top_tokens at key sizes."""
         masked_emb = self.model.masked_embedding
-        lm_head_weight = self.model._get_full_lm_head_weight()
 
         for size in [1, 2, 4, 8, 16, 32, 64]:
             static_input = torch.zeros(
@@ -125,15 +124,12 @@ class Gemma4Proposer(SpecDecodeBaseProposer):
                 device=self.device,
             )
             for _ in range(3):
-                masked_emb.get_top_tokens(static_input, lm_head_weight)
+                self.model.get_top_tokens(static_input)
             torch.accelerator.synchronize()
 
             g = torch.cuda.CUDAGraph()
             with torch.cuda.graph(g):
-                static_output = masked_emb.get_top_tokens(
-                    static_input,
-                    lm_head_weight,
-                )
+                static_output = self.model.get_top_tokens(static_input)
             self._centroids_graphs[size] = g
             self._centroids_inputs[size] = static_input
             self._centroids_outputs[size] = static_output


### PR DESCRIPTION
## Purpose

Gemma 4 CUDA graph capture used Python suppress-token IDs and advanced indexed
assignment with a Python scalar. Both can introduce host-to-device work during
capture. Store validated IDs as nonpersistent model buffers and use
`index_fill_` for graph-safe masking in the target, unified, and MTP paths.

The centroid MTP proposer also returned sparse token IDs without applying the
same suppression policy as full logits. Sparse argmax now masks those IDs and,
if every selected candidate is suppressed, returns the same lowest eligible
fallback token that full-vocabulary argmax selects. Invalid dtype/range values
and suppression of the entire vocabulary fail at model initialization.

Addresses #48503. Use `Fixes #48503` after the exact affected-model evaluation
below passes. #48509 covered only part of the failure; #48515 closed unmerged
when its source repository disappeared. Mandatory duplicate searches found no
competing open PR.

AI assistance was used. The human submitter must review every changed line and
the recorded model result before readiness.

## Validation

Current head `79d3a4c7f` is based on upstream `1a659a0c3`.

```text
pytest -q tests/model_executor/test_gemma4_suppress_tokens.py
29 passed, 3 skipped  # local host has no CUDA

pre-commit run --files <five changed source/test files>
all applicable hooks passed, including mypy

git diff --check
passed
```

The suite covers direct dense masking, sparse/full argmax parity for none,
partial, and all-selected suppression, invalid types and bounds, scalar zero,
empty values, nonpersistent registration, actual LM-head placement, module and
meta-device movement, and separate dense and sparse CUDA-graph capture/replay
tests.

On an earlier H100 revision with the same dense masking mechanism,
`Gemma4MTP.compute_logits` captured and replayed twice successfully and the
then-current focused suite passed. The newly strengthened sparse/fallback CUDA
tests exercise both partial and all-selected suppression, but have not yet run
on H100, so that historical result is not claimed as a current-head GPU pass.

Still required before readiness:

- Run the complete current-head focused suite on H100.
- Start and generate under CUDA graphs with
  `google/gemma-4-12B-it-qat-w4a16-ct` and the affected Gemma 4 MTP assistant.
- Compare eager and graph greedy token IDs or run the repository-appropriate
  deterministic model evaluation because this changes proposal/logit output.
- Human review and reviewer-triggered full CI.

## Release note

Gemma 4 with MTP speculative decoding no longer performs suppress-token
host-to-device copies during CUDA graph capture, and sparse centroid proposals
honor the same validated suppression policy as full logits.

After affected-model evaluation and mainline merge, this crash/correctness fix
is a v0.26 backport candidate.
