### PR TITLE
[Bugfix] Avoid FlashAttention 3 with batch invariance on Hopper

### DIFF
--- a/tests/v1/attention/test_fa_batch_invariant.py
+++ b/tests/v1/attention/test_fa_batch_invariant.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import sys
+from types import ModuleType, SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
+
+
+@pytest.fixture
+def fa_utils_on_hopper(monkeypatch):
+    fake_flash_attn = ModuleType("vllm.vllm_flash_attn")
+    fake_flash_attn_any = cast(Any, fake_flash_attn)
+    fake_flash_attn_any.compile_flash_attn_varlen_func_from_specs = object()
+    fake_flash_attn_any.flash_attn_varlen_func = object()
+    fake_flash_attn_any.get_scheduler_metadata = object()
+    fake_flash_attn_interface = ModuleType("vllm.vllm_flash_attn.flash_attn_interface")
+    fake_flash_attn_interface_any = cast(Any, fake_flash_attn_interface)
+    fake_flash_attn_interface_any.flash_attn_varlen_func = object()
+    fake_flash_attn_interface_any.fa_version_unsupported_reason = lambda _: None
+    fake_flash_attn_interface_any.is_fa_version_supported = lambda version: version in (
+        2,
+        3,
+    )
+    monkeypatch.setitem(sys.modules, "vllm.vllm_flash_attn", fake_flash_attn)
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.vllm_flash_attn.flash_attn_interface",
+        fake_flash_attn_interface,
+    )
+
+    from vllm.v1.attention.backends import fa_utils
+
+    monkeypatch.setattr(
+        fa_utils,
+        "current_platform",
+        SimpleNamespace(
+            is_xpu=lambda: False,
+            is_rocm=lambda: False,
+            get_device_capability=lambda: SimpleNamespace(major=9),
+        ),
+    )
+    return fa_utils
+
+
+@pytest.mark.parametrize("configured_version", [None, 3])
+def test_fa3_falls_back_on_hopper_with_batch_invariance(
+    monkeypatch, fa_utils_on_hopper, configured_version
+):
+    vllm_config = SimpleNamespace(
+        attention_config=SimpleNamespace(flash_attn_version=configured_version),
+        model_config=None,
+    )
+    monkeypatch.setattr("vllm.envs.VLLM_BATCH_INVARIANT", True)
+    monkeypatch.setattr(
+        "vllm.config.get_current_vllm_config_or_none", lambda: vllm_config
+    )
+
+    assert fa_utils_on_hopper.get_flash_attn_version() == 2
+
+
+def test_fa3_remains_default_without_batch_invariance(monkeypatch, fa_utils_on_hopper):
+    monkeypatch.setattr("vllm.envs.VLLM_BATCH_INVARIANT", False)
+    monkeypatch.setattr("vllm.config.get_current_vllm_config_or_none", lambda: None)
+
+    assert fa_utils_on_hopper.get_flash_attn_version() == 3
+
+
+def test_flashattention_mla_rejects_batch_invariance(fa_utils_on_hopper):
+    from vllm.v1.attention.backends.mla.flashattn_mla import (
+        FlashAttnMLABackend,
+    )
+
+    assert not FlashAttnMLABackend.supports_batch_invariance()

--- a/tests/v1/determinism/utils.py
+++ b/tests/v1/determinism/utils.py
@@ -13,7 +13,6 @@ from vllm.transformers_utils.model_arch_config_convertor import (
     ModelArchConfigConvertorBase,
 )
 from vllm.triton_utils import HAS_TRITON
-from vllm.v1.attention.backends.fa_utils import flash_attn_supports_mla
 
 
 class DeviceConfig(NamedTuple):
@@ -45,8 +44,7 @@ if os.getenv("VLLM_TEST_MODEL"):
     if ModelArchConfigConvertorBase(config, config.get_text_config()).is_deepseek_mla():
         DEVICE_BACKENDS["cuda"] = DeviceConfig(
             available=DEVICE_BACKENDS["cuda"].available,
-            backends=["TRITON_MLA"]
-            + (["FLASH_ATTN_MLA"] if flash_attn_supports_mla() else []),
+            backends=["TRITON_MLA"],
         )
         DEVICE_BACKENDS["xpu"] = DeviceConfig(
             available=DEVICE_BACKENDS["xpu"].available,

--- a/vllm/v1/attention/backends/fa_utils.py
+++ b/vllm/v1/attention/backends/fa_utils.py
@@ -171,6 +171,17 @@ def get_flash_attn_version(
         ):
             fa_version = vllm_config.attention_config.flash_attn_version
 
+        if (
+            envs.VLLM_BATCH_INVARIANT
+            and device_capability.major == 9
+            and fa_version == 3
+        ):
+            logger.warning_once(
+                "Cannot use FlashAttention 3 with batch invariance on "
+                "Hopper; defaulting to FlashAttention 2."
+            )
+            fa_version = 2
+
         # 3. fallback for unsupported combinations
         if device_capability.major >= 10 and fa_version == 3:
             logger.warning_once(

--- a/vllm/v1/attention/backends/mla/flashattn_mla.py
+++ b/vllm/v1/attention/backends/mla/flashattn_mla.py
@@ -66,7 +66,7 @@ class FlashAttnMLABackend(MLACommonBackend):
 
     @classmethod
     def supports_batch_invariance(cls) -> bool:
-        return True
+        return False
 
     @staticmethod
     def get_builder_cls() -> type["FlashAttnMLAMetadataBuilder"]:


### PR DESCRIPTION
## Purpose

`VLLM_BATCH_INVARIANT=1` is a correctness contract: serving may choose a
slower backend, but output must not change with batch composition. Hopper FA3
violates that contract in #47069, while FA2 is invariant in the same replay.
Fail closed to FA2 for regular Hopper attention and advertise the FA3-only
FlashAttention MLA backend as non-invariant so automatic selection can choose
an invariant MLA backend.

Fixes #47069.

This follows the capability-aware selection merged in #40193 and the FA4-to-FA2
invariant fallback merged in #36059. flash-attention#169 is the preferred
kernel-level future repair, but it remains an unmerged draft and does not
supersede vLLM capability policy until a pinned FA3 version passes the contract.
Mandatory issue/keyword searches found no competing vLLM PR.

AI assistance was used.

## Implementation

- Implicit and explicitly configured FA3 fall back to FA2 on SM90 under batch
  invariance.
- `FlashAttnMLABackend.supports_batch_invariance()` reports the stable
  capability `False`.
- Automatic MLA selection can choose `TRITON_MLA`; explicit unsafe MLA
  selection fails clearly.
- The determinism matrix no longer advertises FA3-only MLA.
- CPU selector tests cover implicit/explicit fallback, unchanged normal mode,
  and MLA capability without unnecessary global GPU cleanup.

## Validation

Current head `049c7aa67` is based on upstream `1a659a0c3`. The production
diff is unchanged from the H100-validated revision; the rebase added only
unrelated TPU/Rust-frontend changes.

```text
pytest -q tests/v1/attention/test_fa_batch_invariant.py
4 passed

pytest -q tests/v1/determinism/test_batch_invariance.py::test_logprobs_bitwise_batch_invariance_bs1_vs_bsN -k FLASH_ATTN
2 passed, 4 deselected  # H100 SXM 80 GB

pre-commit run --from-ref origin/main --to-ref HEAD
all applicable hooks passed, including mypy

git diff --check origin/main...HEAD
passed
```

The exact public `Qwen/Qwen2.5-0.5B-Instruct` #47069 reproducer ran 60
concurrent replays. The upstream parent selected FA3 and produced two outputs
in r01 and r04; r04 flipped with a 0.125 log-prob gap. This branch warned,
selected FA2, and produced one identical output for every r01-r04 replay.
Selector probes also confirmed automatic MLA chooses `TRITON_MLA`, explicit
`FLASH_ATTN_MLA` rejects, and non-invariant mode still selects FA3.

Human maintainer review and reviewer-triggered full CI remain normal merge
gates; they are not author-side draft blockers.

## Release note

On Hopper, batch-invariant serving uses FA2 instead of the currently unsafe FA3
path, and automatic MLA selection uses an invariant backend. Once a pinned FA3
release provides and passes a batch-invariant mode, this policy can select it
again without changing the user contract.
