### PR TITLE
[Bugfix] Gate FlashInfer FP4 MoE on kernel availability

### DIFF
--- a/tests/model_executor/test_flashinfer_capability.py
+++ b/tests/model_executor/test_flashinfer_capability.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from vllm.utils import flashinfer
+
+
+def _clear_cache() -> None:
+    flashinfer.has_flashinfer_cutlass_fused_moe_fp4.cache_clear()
+
+
+def test_fp4_capability_accepts_precompiled_cubin():
+    _clear_cache()
+    with (
+        patch.object(flashinfer, "has_flashinfer_cutlass_fused_moe", return_value=True),
+        patch.object(flashinfer, "has_flashinfer_cubin", return_value=True),
+        patch.object(flashinfer.shutil, "which", return_value=None),
+    ):
+        assert flashinfer.has_flashinfer_cutlass_fused_moe_fp4()
+    _clear_cache()
+
+
+def test_fp4_capability_requires_supported_nvcc_without_cubin():
+    for version, expected in [
+        ("Cuda compilation tools, release 12.7, V12.7.99", False),
+        ("Cuda compilation tools, release 12.8, V12.8.99", True),
+    ]:
+        _clear_cache()
+        with (
+            patch.object(
+                flashinfer, "has_flashinfer_cutlass_fused_moe", return_value=True
+            ),
+            patch.object(flashinfer, "has_flashinfer_cubin", return_value=False),
+            patch.object(flashinfer.importlib.util, "find_spec", return_value=None),
+            patch.object(flashinfer.shutil, "which", return_value="/usr/bin/nvcc"),
+            patch.object(
+                flashinfer.subprocess,
+                "run",
+                return_value=SimpleNamespace(stdout=version),
+            ),
+        ):
+            assert flashinfer.has_flashinfer_cutlass_fused_moe_fp4() is expected
+    _clear_cache()

--- a/tests/model_executor/test_flashinfer_capability.py
+++ b/tests/model_executor/test_flashinfer_capability.py
@@ -43,3 +43,15 @@ def test_fp4_capability_requires_supported_nvcc_without_cubin():
         ):
             assert flashinfer.has_flashinfer_cutlass_fused_moe_fp4() is expected
     _clear_cache()
+
+
+def test_fp4_capability_rejects_missing_nvcc_without_cubin():
+    _clear_cache()
+    with (
+        patch.object(flashinfer, "has_flashinfer_cutlass_fused_moe", return_value=True),
+        patch.object(flashinfer, "has_flashinfer_cubin", return_value=False),
+        patch.object(flashinfer.importlib.util, "find_spec", return_value=None),
+        patch.object(flashinfer.shutil, "which", return_value=None),
+    ):
+        assert not flashinfer.has_flashinfer_cutlass_fused_moe_fp4()
+    _clear_cache()

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -27,6 +27,7 @@ from vllm.platforms import current_platform
 from vllm.utils.flashinfer import (
     flashinfer_cutlass_fused_moe,
     has_flashinfer_cutlass_fused_moe,
+    has_flashinfer_cutlass_fused_moe_fp4,
 )
 
 logger = init_logger(__name__)
@@ -171,6 +172,10 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
                     (kFp8Static128BlockSym, kFp8Dynamic128Sym),
                 ]
                 and p.is_device_capability(90)
+                and (
+                    scheme != (kMxfp4Static, None)
+                    or has_flashinfer_cutlass_fused_moe_fp4()
+                )
             )
             # nvfp4, wmxfp4amxfp8 on 10.0+
             or (
@@ -180,6 +185,7 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
                     (kNvfp4Static, kNvfp4Dynamic),
                 ]
                 and p.has_device_capability(100)
+                and has_flashinfer_cutlass_fused_moe_fp4()
             )
         )
 

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -11,9 +11,11 @@ import importlib
 import importlib.util
 import os
 import shutil
+import subprocess
 from collections.abc import Callable
 from typing import Any, NoReturn
 
+import regex as re
 import requests
 import torch
 
@@ -278,6 +280,33 @@ def has_flashinfer_cutlass_fused_moe() -> bool:
         if not mod or not hasattr(mod, attr_name):
             return False
     return True
+
+
+@functools.cache
+def has_flashinfer_cutlass_fused_moe_fp4() -> bool:
+    """Return whether the FlashInfer CUTLASS build contains FP4 kernels."""
+    if not has_flashinfer_cutlass_fused_moe():
+        return False
+    if importlib.util.find_spec("flashinfer_jit_cache") is not None:
+        return True
+
+    nvcc = shutil.which("nvcc")
+    if nvcc is None:
+        return False
+    try:
+        result = subprocess.run(
+            [nvcc, "--version"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    match = re.search(r"release (\d+)\.(\d+)", result.stdout)
+    if match is None:
+        return False
+    return (int(match.group(1)), int(match.group(2))) >= (12, 8)
 
 
 @functools.cache
@@ -1040,6 +1069,7 @@ __all__ = [
     "has_flashinfer_nvlink_two_sided",
     "has_flashinfer_nvlink_one_sided",
     "has_flashinfer_cutlass_fused_moe",
+    "has_flashinfer_cutlass_fused_moe_fp4",
     "has_flashinfer_cutedsl_grouped_gemm_nt_masked",
     "has_flashinfer_cutedsl_moe_nvfp4",
     "has_flashinfer_b12x_moe",

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -287,6 +287,8 @@ def has_flashinfer_cutlass_fused_moe_fp4() -> bool:
     """Return whether the FlashInfer CUTLASS build contains FP4 kernels."""
     if not has_flashinfer_cutlass_fused_moe():
         return False
+    if has_flashinfer_cubin():
+        return True
     if importlib.util.find_spec("flashinfer_jit_cache") is not None:
         return True
 


### PR DESCRIPTION
## Purpose

FlashInfer CUTLASS MoE selection accepted FP4 schemes when the installed build
had no FP4 support. On the reported H100 setup, `nvcc` was absent and no
`flashinfer_jit_cache` package was installed. The selector could then spend
minutes compiling before failing. Check FP4 capability before accepting the
FP4 schemes.

Fixes #48541

Related work: I searched open and closed PR references for #48541 and found no
overlapping PR. AI assistance was used; I reviewed the changed code and the
GPU results.

## Test Plan

```bash
uv tool run ruff check repro/gpu_validate_flashinfer_fp4.py
uv run --no-project python -m py_compile \
  repro/gpu_validate_flashinfer_fp4.py
python repro/gpu_validate_flashinfer_fp4.py
```

The GPU validation ran on an H100 SXM with CUDA 13.0 and no `nvcc`. The
validation checked the stock wheel, then overlaid:

```text
vllm/utils/flashinfer.py
vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
```

Added CPU unit tests for precompiled cubins, missing `nvcc`, and supported or
older `nvcc` versions.

## Test Result

Unpatched H100 result:

```text
NVCC: ABSENT
NVFP4_SELECTION_PREDICATE: True
```

This reproduced the bad selection for
`_supports_quant_scheme(kMxfp4Static, None)`. Patched result:

```text
FP4_CAPABILITY: False
NVFP4_SELECTION_PREDICATE: False
PASS: patched FlashInfer selection rejects unavailable NVFP4
```

The direct NVFP4 predicate stayed false in both variants because that branch
requires compute capability 100. No long JIT failure was started.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
