### PR TITLE
[Bugfix] Reject DeepSeek V4 FP4 MoE tensor parallelism

### DIFF
--- a/tests/models/test_deepseek_v4_quant_config.py
+++ b/tests/models/test_deepseek_v4_quant_config.py
@@ -2,12 +2,14 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 from torch import nn
 
 from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
 from vllm.models.deepseek_v4.quant_config import DeepseekV4FP8Config
+from vllm.platforms import current_platform
 
 
 def test_deepseek_v4_fp4_guard_uses_moe_shard_tp_size():
@@ -23,5 +25,31 @@ def test_deepseek_v4_fp4_guard_uses_moe_shard_tp_size():
         moe_parallel_config=SimpleNamespace(tp_size=2),
     )
 
-    with pytest.raises(ValueError, match="not supported with tensor parallelism"):
+    with (
+        patch.object(current_platform, "is_cuda", return_value=True),
+        pytest.raises(ValueError, match="not supported with tensor parallelism"),
+    ):
         quant_config.get_quant_method(layer, "experts")
+
+
+def test_deepseek_v4_fp4_guard_keeps_rocm_tp_available(monkeypatch):
+    quant_config = DeepseekV4FP8Config.__new__(DeepseekV4FP8Config)
+    quant_config.ignored_layers = []
+    quant_config.packed_modules_mapping = {}
+    quant_config._resolved_expert_dtype = "fp4"
+    quant_config._resolved_moe_quant_algo = "MXFP4"
+
+    layer = RoutedExperts.__new__(RoutedExperts)
+    nn.Module.__init__(layer)
+    layer.moe_config = SimpleNamespace(
+        moe_parallel_config=SimpleNamespace(tp_size=2),
+    )
+
+    expected_method = object()
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: False)
+    monkeypatch.setattr(
+        "vllm.models.deepseek_v4.quant_config.Mxfp4MoEMethod",
+        lambda moe_config: expected_method,
+    )
+
+    assert quant_config.get_quant_method(layer, "experts") is expected_method

--- a/tests/models/test_deepseek_v4_quant_config.py
+++ b/tests/models/test_deepseek_v4_quant_config.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+from torch import nn
+
+from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
+from vllm.models.deepseek_v4.quant_config import DeepseekV4FP8Config
+
+
+def test_deepseek_v4_fp4_guard_uses_moe_shard_tp_size():
+    quant_config = DeepseekV4FP8Config.__new__(DeepseekV4FP8Config)
+    quant_config.ignored_layers = []
+    quant_config.packed_modules_mapping = {}
+    quant_config._resolved_expert_dtype = "fp4"
+    quant_config._resolved_moe_quant_algo = "MXFP4"
+
+    layer = RoutedExperts.__new__(RoutedExperts)
+    nn.Module.__init__(layer)
+    layer.moe_config = SimpleNamespace(
+        moe_parallel_config=SimpleNamespace(tp_size=2),
+    )
+
+    with pytest.raises(ValueError, match="not supported with tensor parallelism"):
+        quant_config.get_quant_method(layer, "experts")

--- a/vllm/models/deepseek_v4/quant_config.py
+++ b/vllm/models/deepseek_v4/quant_config.py
@@ -17,6 +17,7 @@ from vllm.model_executor.layers.quantization.mxfp4 import Mxfp4MoEMethod
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     is_layer_skipped,
 )
+from vllm.platforms import current_platform
 
 _DEEPSEEK_V4_EXPERT_DTYPES = ("fp4", "fp8")
 
@@ -140,7 +141,10 @@ class DeepseekV4FP8Config(Fp8Config):
             ):
                 return UnquantizedFusedMoEMethod(layer.moe_config)
             if self.expert_dtype == "fp4":
-                if layer.moe_config.moe_parallel_config.tp_size > 1:
+                if (
+                    current_platform.is_cuda()
+                    and layer.moe_config.moe_parallel_config.tp_size > 1
+                ):
                     raise ValueError(
                         "DeepSeek V4 FP4 MoE is not supported with tensor "
                         "parallelism. Use data parallelism with expert "

--- a/vllm/models/deepseek_v4/quant_config.py
+++ b/vllm/models/deepseek_v4/quant_config.py
@@ -140,8 +140,7 @@ class DeepseekV4FP8Config(Fp8Config):
             ):
                 return UnquantizedFusedMoEMethod(layer.moe_config)
             if self.expert_dtype == "fp4":
-                parallel_config = get_current_vllm_config().parallel_config
-                if parallel_config.tensor_parallel_size > 1:
+                if layer.moe_config.moe_parallel_config.tp_size > 1:
                     raise ValueError(
                         "DeepSeek V4 FP4 MoE is not supported with tensor "
                         "parallelism. Use data parallelism with expert "

--- a/vllm/models/deepseek_v4/quant_config.py
+++ b/vllm/models/deepseek_v4/quant_config.py
@@ -140,6 +140,13 @@ class DeepseekV4FP8Config(Fp8Config):
             ):
                 return UnquantizedFusedMoEMethod(layer.moe_config)
             if self.expert_dtype == "fp4":
+                parallel_config = get_current_vllm_config().parallel_config
+                if parallel_config.tensor_parallel_size > 1:
+                    raise ValueError(
+                        "DeepSeek V4 FP4 MoE is not supported with tensor "
+                        "parallelism. Use data parallelism with expert "
+                        "parallelism instead."
+                    )
                 if self.moe_quant_algo == "NVFP4":
                     from vllm.model_executor.layers.quantization.modelopt import (
                         ModelOptNvFp4FusedMoE,


### PR DESCRIPTION
## Purpose

DeepSeek V4 FP4 MoE accepts tensor parallelism on NVIDIA even though this path
is not validated and can produce wrong output. Reject CUDA shard TP sizes
greater than one before constructing the FP4 MoE method or loading weights.
The guard reads the MoE layer's own shard `tp_size` rather than the global
tensor parallel size, so attention-only TP with DP+EP experts stays allowed.
The guard is scoped to CUDA because the official
[DeepSeek-V4-Flash recipe](https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4-Flash)
documents FP4 TP=4 on MI355X with ROCm/AITER and suggests TP=8. The error
points NVIDIA users to data parallelism with expert parallelism.

Fixes #47528

Related work: `gh search prs 47528 --repo vllm-project/vllm --match body`
returned no PR for this issue. The only broad numeric match was an unrelated
CI PR. AI assistance was used; I reviewed the changed code and validation
results.

## Test Plan

```bash
uv tool run ruff check repro/gpu_validate_deepseek_v4_tp_guard.py
uv run --no-project python -m py_compile \
  repro/gpu_validate_deepseek_v4_tp_guard.py
CUDA_VISIBLE_DEVICES=0,1 python repro/gpu_validate_deepseek_v4_tp_guard.py
```

The probe was run against the stock wheel and then after overlaying:

```text
vllm/models/deepseek_v4/quant_config.py
```

Added CPU unit coverage that constructs a minimal FP4 MoE layer with TP=2,
checks the CUDA guard, and verifies that the ROCm/AITER path remains available.
The test passes with two cases:

```text
2 passed
```

Validation ran on an H100 SXM and on a two-RTX-5090 pod. No checkpoint is
needed for the configuration-level guard.

## Test Result

H100 result:

```text
DEEPSEEK_V4_QUANT_CONFIG: UNPATCHED
EXPECTED: unpatched source accepts the unsupported TP path

DEEPSEEK_V4_QUANT_CONFIG: PATCHED
PASS: config guard rejected TP=2: DeepSeek V4 FP4 MoE is not supported with tensor parallelism. Use data parallelism with expert parallelism instead.
```

Two-RTX-5090 result:

```text
DEEPSEEK_V4_QUANT_CONFIG: UNPATCHED
CONFIG_CASE: expert_dtype=fp4, moe_quant_algo=NVFP4, TP=2
EXPECTED: unpatched source accepts the unsupported TP path
CUDA_DEVICES: 2
PASS: two-GPU pod is available for config-backed validation

DEEPSEEK_V4_QUANT_CONFIG: PATCHED
CONFIG_CASE: expert_dtype=fp4, moe_quant_algo=NVFP4, TP=2
PASS: config guard rejected TP=2: DeepSeek V4 FP4 MoE is not supported with tensor parallelism. Use data parallelism with expert parallelism instead.
CUDA_DEVICES: 2
PASS: two-GPU pod is available for config-backed validation
```

The full numerical corruption reproduction still needs the large
DeepSeek-V4-FP4 checkpoint and is outside this validation.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
