### PR TITLE
[BugFix] Fix FunctionGemma streaming tool-call arguments corrupted once a 2nd key arrives

### DIFF
--- a/tests/tool_parsers/test_functiongemma_tool_parser.py
+++ b/tests/tool_parsers/test_functiongemma_tool_parser.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -118,6 +119,61 @@ class TestParseArguments:
     def test_argument_with_spaces(self, parser):
         result = parser._parse_arguments("message:<escape>Hello World<escape>")
         assert result == {"message": "Hello World"}
+
+
+class TestExtractToolCallsStreaming:
+    def _stream(self, parser, chunks):
+        current_text = ""
+        collected_args = ""
+        for chunk in chunks:
+            previous_text = current_text
+            current_text += chunk
+            result = parser.extract_tool_calls_streaming(
+                previous_text=previous_text,
+                current_text=current_text,
+                delta_text=chunk,
+                previous_token_ids=[],
+                current_token_ids=[],
+                delta_token_ids=[],
+                request=None,
+            )
+            if result and result.tool_calls:
+                function = result.tool_calls[0].function
+                arguments = getattr(function, "arguments", None)
+                if arguments:
+                    collected_args += arguments
+        return collected_args
+
+    def test_streamed_arguments_form_valid_json_with_two_keys(self, parser):
+        # Regression test: each streaming delta previously diffed
+        # json.dumps(current_args) by raw string length against the last-sent
+        # string. Since json.dumps() closes the object with '}' on every call,
+        # the delta after the first key arrived re-sent a stale closing brace
+        # mid-object, corrupting the client-side reconstructed JSON.
+        chunks = [
+            "<start_function_call>call:get_weather{",
+            "ci",
+            "ty:<escape>NYC<escape>",
+            "unit:<escape>celsius<escape>",
+            "}<end_function_call>",
+        ]
+        reconstructed = self._stream(parser, chunks)
+        assert json.loads(reconstructed) == {"city": "NYC", "unit": "celsius"}
+
+    def test_streamed_arguments_form_valid_json_with_three_keys(self, parser):
+        chunks = [
+            "<start_function_call>call:search{",
+            "query:<escape>python<escape>",
+            "limit:<escape>10<escape>",
+            "sort:<escape>relevance<escape>",
+            "}<end_function_call>",
+        ]
+        reconstructed = self._stream(parser, chunks)
+        assert json.loads(reconstructed) == {
+            "query": "python",
+            "limit": 10,
+            "sort": "relevance",
+        }
 
 
 class TestAdjustRequest:

--- a/vllm/tool_parsers/functiongemma_tool_parser.py
+++ b/vllm/tool_parsers/functiongemma_tool_parser.py
@@ -22,6 +22,7 @@ from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import Tool, ToolParser
+from vllm.tool_parsers.utils import find_common_prefix
 
 logger = init_logger(__name__)
 
@@ -238,15 +239,23 @@ class FunctionGemmaToolParser(ToolParser):
                         if self.current_tool_name_sent and args_part:
                             current_args = self._parse_arguments(args_part)
                             if current_args:
+                                # Mid-stream, more keys may still arrive, so the
+                                # object isn't closed yet -- drop the trailing '}'
+                                # that json.dumps() always adds for a complete
+                                # dict. The real closing brace is only sent once,
+                                # from the "function call just ended" branch below.
                                 current_args_json = json.dumps(
                                     current_args, ensure_ascii=False
-                                )
+                                )[:-1]
                                 prev_streamed = self.streamed_args_for_tool[
                                     self.current_tool_id
                                 ]
 
-                                if len(current_args_json) > len(prev_streamed):
-                                    diff = current_args_json[len(prev_streamed) :]
+                                if current_args_json != prev_streamed:
+                                    common = find_common_prefix(
+                                        current_args_json, prev_streamed
+                                    )
+                                    diff = current_args_json[len(common) :]
                                     self.streamed_args_for_tool[
                                         self.current_tool_id
                                     ] = current_args_json
@@ -288,8 +297,9 @@ class FunctionGemmaToolParser(ToolParser):
                         prev_streamed = self.streamed_args_for_tool[
                             self.current_tool_id
                         ]
-                        if len(args_json) > len(prev_streamed):
-                            diff = args_json[len(prev_streamed) :]
+                        if args_json != prev_streamed:
+                            common = find_common_prefix(args_json, prev_streamed)
+                            diff = args_json[len(common) :]
                             self.streamed_args_for_tool[self.current_tool_id] = (
                                 args_json
                             )


### PR DESCRIPTION
## Purpose

`FunctionGemmaToolParser.extract_tool_calls_streaming()` diffs
`json.dumps(current_args)` against the last-sent string purely by length:

```python
if len(current_args_json) > len(prev_streamed):
    diff = current_args_json[len(prev_streamed):]
```

This assumes `prev_streamed` is always a strict prefix of the new
`json.dumps()` output. But `json.dumps()` of a complete dict always ends
with a closing `}` — so as soon as a **second** argument key arrives, that
stale `}` from the previous (shorter) dict sits in the middle of
`prev_streamed`, breaking the prefix assumption. The client-side
concatenation of streamed argument deltas then contains a premature closing
brace followed by more content: invalid JSON.

### Repro (also the added regression test)

Streaming these 5 deltas (a normal token-by-token pattern once more than one
argument key is involved):

```
'<start_function_call>call:get_weather{'
'ci'
'ty:<escape>NYC<escape>'
'unit:<escape>celsius<escape>'
'}<end_function_call>'
```

previously reconstructed on the client side to:

```
'{"city": "NYC"} "unit": "celsius"}'   # invalid JSON
```

This reproduces with **any** FunctionGemma tool call that has 2+ arguments
split across streaming deltas — not an edge case, this is the normal
streaming pattern.

**Fix**

Mid-stream, the argument dict isn't closed yet (more keys may still arrive),
so strip the trailing `}` that `json.dumps()` always adds before treating it
as the diffable/stored state — the real closing brace is only ever sent
once, from the "function call just ended" branch, which already computes
the true final arguments. Compute the diff via `find_common_prefix()`
(already used elsewhere in `vllm/tool_parsers/utils.py` for the same
partial-JSON-diffing purpose) instead of a raw length slice, so a
same-length or shorter update also diffs correctly. The same length-based
diff — and now the same fix — was duplicated in the "function call just
ended" branch; both call sites are updated.

**Not duplicating an existing PR**

`gh pr list --repo vllm-project/vllm --state open --search "functiongemma"` and
`gh api search/issues -f q='repo:vllm-project/vllm is:open functiongemma'` show
no open PR/issue referencing FunctionGemma or touching this file. The only
match, #47254, is an unrelated Rust-frontend FunctionGemma implementation
that only touches `rust/src/**` — confirmed via `gh pr view 47254 --json
files`, no overlap with `vllm/tool_parsers/functiongemma_tool_parser.py`.

## Test Plan

- Drive the parser's `extract_tool_calls_streaming()` directly against the real installed
  `vllm` package with hand-constructed internal state, isolating this code path from the
  rest of the streaming pipeline.
- `pytest tests/tool_parsers/` for the affected parser's test file — added a regression
  test and ran the existing ones alongside it.
- Confirm red→green by reverting only the source change and re-running.

## Test Result

- Independently reproduced the corruption against the actual installed
  `vllm` package (`VLLM_USE_PRECOMPILED=1 uv pip install -e .
  --torch-backend=auto`) via `object.__new__(FunctionGemmaToolParser)` +
  manual streaming state — not just static analysis.
- Confirmed the fix produces valid, correctly-ordered JSON for both a 2-key
  and 3-key streaming case.
- Added `TestExtractToolCallsStreaming` to
  `tests/tool_parsers/test_functiongemma_tool_parser.py` (previously **zero**
  streaming-path test coverage existed for this parser) covering the exact
  repro plus a 3-key variant. Confirmed red→green: reverting only the source
  change reproduces `json.decoder.JSONDecodeError: Extra data` for both new
  tests; reapplying passes all 17 tests in the file (15 pre-existing + 2
  new).
- `pre-commit run ruff-check`, `ruff-format`, `mypy-3.12` (all `--files`
  scoped to the 2 changed files): pass.

Model-eval N/A — this only changes streaming-argument diff bookkeeping
logic, not model output/accuracy.

---

Found via an AI-assisted code review pass (Claude Code) over
`vllm/tool_parsers/`. I independently reproduced the corruption against the
real installed package, traced the root cause (the length-diff-vs-json.dumps
closing-brace mismatch), verified the fix, and ran the tests above myself
before submitting.
