### PR TITLE
[Bugfix][Parser] Fix streaming tool-call args truncated by schema coercion

### DIFF
--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -25,6 +25,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     FunctionDefinition,
 )
 from vllm.parser.abstract_parser import DelegatingParser
+from vllm.parser.qwen3 import _qwen3_arg_converter
 from vllm.parser.engine.adapters import make_adapters
 from vllm.parser.engine.events import EventType, SemanticEvent
 from vllm.parser.engine.parser_engine import ParserEngine
@@ -1412,6 +1413,14 @@ class TestSafeArgPrefix:
 # ── Coercion instability regression tests ────────────────────────
 
 
+def _json_converter(raw_args: str, partial: bool) -> str:
+    """Identity converter: round-trips JSON, returns raw string when partial."""
+    try:
+        return json.dumps(json.loads(raw_args), ensure_ascii=False)
+    except (json.JSONDecodeError, ValueError):
+        return raw_args if partial else ""
+
+
 def _growing_kv_converter(raw_args: str, partial: bool) -> str:
     """Converter that produces growing bare values (no delimiter)."""
     params: dict[str, str] = {}
@@ -1494,6 +1503,76 @@ class TestCoercionInstabilityRegression:
         assert parsed["val"] == "4e"
         assert isinstance(parsed["val"], str)
         assert parsed["extra"] == "ok"
+
+    def test_integer_middle_field_not_truncated_by_coercion(self):
+        """Integer middle field must not cause truncation when coerced at flush.
+
+        Three chunks are required: the first triggers tool-name emission
+        (consuming the chunk without calling _compute_arg_delta), the second
+        leaves the integer value complete in streamed_json as a quoted string
+        ("42") while the JSON is still open, and the third closes the JSON.
+        Without the fix, flush-time coercion changes "42"→42, breaking the
+        startswith invariant and silently dropping the rest of the arguments.
+        """
+        tool = _make_tool(
+            "f", {"n": {"type": "integer"}, "s": {"type": "string"}}
+        )
+        engine = _make_engine(_converter_config(_json_converter), tools=[tool])
+        parsed = _run_streaming_tool(
+            engine, "f", ["{", '"n": "42", "s": "h', 'i"}']
+        )
+        assert parsed == {"n": 42, "s": "hi"}
+        assert isinstance(parsed["n"], int)
+
+    def test_boolean_middle_field_not_truncated_by_coercion(self):
+        """Boolean middle field must not cause truncation when coerced at flush."""
+        tool = _make_tool(
+            "f", {"flag": {"type": "boolean"}, "msg": {"type": "string"}}
+        )
+        engine = _make_engine(_converter_config(_json_converter), tools=[tool])
+        parsed = _run_streaming_tool(
+            engine, "f", ["{", '"flag": "true", "msg": "h', 'i"}']
+        )
+        assert parsed == {"flag": True, "msg": "hi"}
+        assert isinstance(parsed["flag"], bool)
+
+    def test_null_middle_field_not_truncated_by_coercion(self):
+        """Null-typed middle field must not cause truncation when coerced at flush."""
+        tool = _make_tool(
+            "f", {"v": {"type": "null"}, "tag": {"type": "string"}}
+        )
+        engine = _make_engine(_converter_config(_json_converter), tools=[tool])
+        parsed = _run_streaming_tool(
+            engine, "f", ["{", '"v": "null", "tag": "h', 'i"}']
+        )
+        assert parsed == {"v": None, "tag": "hi"}
+        assert parsed["v"] is None
+
+    def test_qwen3_partial_xml_close_tag_not_included_in_value(self):
+        """Qwen3 partial XML close tag must not leak into streamed string value.
+
+        When an XML close tag (</parameter>) is split across chunks, the
+        partial tag text must not appear in the streamed string value for
+        the preceding key.
+        """
+        tool = _make_tool(
+            "f", {"n": {"type": "integer"}, "s": {"type": "string"}}
+        )
+        engine = _make_engine(
+            _converter_config(_qwen3_arg_converter), tools=[tool]
+        )
+        parsed = _run_streaming_tool(
+            engine,
+            "f",
+            [
+                "<parameter=",
+                "n>42</parameter><parameter=s>ok</par",
+                "ameter>",
+            ],
+        )
+        assert parsed == {"n": 42, "s": "ok"}
+        assert isinstance(parsed["n"], int)
+        assert parsed["s"] == "ok"
 
 
 _DROP_VOCAB: dict[str, int] = {

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -281,13 +281,16 @@ class ParserEngine(Parser):
     def _safe_arg_prefix(json_str: str, string_keys: set[str] | None = None) -> str:
         """Return the prefix of *json_str* up to the last top-level value.
 
-        Middle values (followed by a comma) are stable across streaming
-        ticks and included.  The trailing value is excluded for non-string
-        values because type coercion may change its serialised form between
-        ticks, which would violate the ``startswith(prev)`` prefix invariant.
-        String values for keys in ``string_keys`` are prefix-stable, so stream
-        their unterminated content instead of buffering long arguments until
-        the closing tag arrives.
+        The trailing value is excluded for non-string keys because type
+        coercion may change its serialised form, which would violate the
+        ``startswith(prev)`` prefix invariant.  String values for keys in
+        ``string_keys`` are prefix-stable, so their unterminated content is
+        streamed incrementally.
+
+        Middle (comma-terminated) values for non-string keys are also excluded
+        for the same coercion reason: the prefix is clipped at the start of the
+        first non-string-typed value so that ``_fix_arg_types`` at flush time
+        never rewrites anything already sent to the client.
         """
         last_colon = -1
         last_key: str | None = None
@@ -296,6 +299,9 @@ class ParserEngine(Parser):
         escape = False
         string_start = -1
         depth = 0
+        # Index of the first non-string-typed value start; -1 if none seen yet.
+        non_string_clip: int = -1
+
         for i, c in enumerate(json_str):
             if escape:
                 escape = False
@@ -319,8 +325,24 @@ class ParserEngine(Parser):
                 last_colon = i
                 last_key = pending_key
                 pending_key = None
+                if string_keys is not None and last_key not in string_keys:
+                    # Record where this key's value starts; clip here so the
+                    # value is never partially sent before flush-time coercion.
+                    val_start = i + 1
+                    while val_start < len(json_str) and json_str[val_start] in (
+                        " ", "\t", "\n", "\r"
+                    ):
+                        val_start += 1
+                    if non_string_clip < 0:
+                        non_string_clip = val_start
+
         if last_colon < 0:
             return ""
+
+        # If a non-string-typed key's value has started, clip before it.
+        if non_string_clip >= 0:
+            return json_str[:non_string_clip]
+
         end = last_colon + 1
         while end < len(json_str) and json_str[end] in (" ", "\t", "\n", "\r"):
             end += 1


### PR DESCRIPTION
Fixes #48702

## Purpose

`_safe_arg_prefix` included completed middle-field values in `streamed_json` even for non-string-typed keys (integer/boolean/null/number). When `_fix_arg_types` coerced those values at flush time (e.g. `"42"` → `42`, `"true"` → `true`, `"null"` → `null`), the already-sent prefix no longer matched the final JSON, causing `_flush_arg_converter` to silently return `None` and drop the closing brace and any remaining content. Clients received truncated, invalid JSON with no error or log line indicating anything had gone wrong.

**Fix:** during the character scan in `_safe_arg_prefix`, record the position of the first non-string-typed key's value start (`non_string_clip`). After the scan, clip the safe prefix there instead of including it. This ensures the value arrives entirely as a single flush delta after coercion, preserving the `startswith` invariant so the client always accumulates valid, complete JSON.

Affects all parsers using `stream_arg_deltas=True` with an `arg_converter` that cannot parse partial JSON (Qwen3, DeepSeek V4/V32, GLM47, MiniMax, Gemma4, Kimi K2). Parsers that resolve types during streaming itself (e.g. DeepSeek DSML) are structurally unaffected. String-typed fields, already-native-typed values (e.g. unquoted integers), and schemas without a type annotation are unaffected.

This slots in cleanly on top of #46351 (merged). #46351 already protects trailing non-string fields via a dedicated branch in _safe_arg_prefix (the scan's last_key is always the trailing key, so that branch fully covers it) — non_string_clip is never consulted for trailing fields and only fires for middle (comma-terminated) non-string values, which #46351 didn't address. Verified empirically: a trailing non-string field already passes on main; middle non-string fields do not, and pass only with this patch.

**Not a duplicate of:**
- #46351 (merged) — related, complementary; covers trailing values only, not middle fields.
- #48343 — different file/mechanism (DeepSeek V3 closing-token heuristic in `deepseekv3_tool_parser.py`).
- #47643 — different bug (Python-repr `None` coercion in `coerce_to_schema_type`).
- #48678 — different file/mechanism (Gemma4 delimiter handling).

## Test Plan

````python -m pytest tests/parser/engine/````

4 new deterministic regression tests added to `TestCoercionInstabilityRegression` in `test_parser_engine.py`, each constructing the exact chunk boundary that triggers the bug:
- `test_integer_middle_field_not_truncated_by_coercion`
- `test_boolean_middle_field_not_truncated_by_coercion`
- `test_null_middle_field_not_truncated_by_coercion`
- `test_qwen3_partial_xml_close_tag_not_included_in_value`

Each test is verified to fail on `main` and pass with this fix. Also verified against:
- 202 fuzz cases (200 random schema/payload combinations + 2 targeted: array-of-non-string values, back-to-back non-string fields)
- 3 wire formats (identity JSON, Qwen3 XML, DeepSeek DSML)
- Call-site audit (AST scan): `_safe_arg_prefix` has exactly one production caller

## Test Result

```3678 passed, 0 failed```

Full `tests/parser/engine/` suite, no regressions. No latency regression — the fix causes an earlier return in `_safe_arg_prefix`, making the non-string path measurably faster than baseline.

Live end-to-end reproduction was also attempted against a running vLLM server (Qwen2.5-1.5B/0.5B-Instruct, `qwen3_xml` parser) across ~45 real generations. The malformation did not occur spontaneously, consistent with guided/structured decoding constraining generated tokens to match the declared schema in this configuration. The unit tests above isolate and prove the underlying invariant violation deterministically, independent of live reproducibility.
