### PR TITLE
[ROCm] Fix sparse MLA metadata missing num_decodes

### DIFF
--- a/tests/kernels/attention/test_rocm_aiter_mla_sparse_metadata_sync.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_sparse_metadata_sync.py
@@ -67,6 +67,7 @@ def _make_builder():
     builder._prev_req_extent = 0
     builder._prev_indices_extent = 0
     builder._prev_metadata_key = None
+    builder.reorder_batch_threshold = 1
     return builder
 
 
@@ -85,6 +86,80 @@ def _make_common_metadata():
         block_table_tensor=torch.arange(16, dtype=torch.int32, device="cpu").view(2, 8),
         slot_mapping=torch.arange(2, dtype=torch.int64, device="cpu"),
     )
+
+
+def _make_mixed_common_metadata():
+    # req0: query_len 1 (decode), req1: query_len 4 (prefill) -> decode-first
+    query_start_loc = torch.tensor([0, 1, 5], dtype=torch.int32, device="cpu")
+    seq_lens = torch.tensor([16, 10], dtype=torch.int32, device="cpu")
+    return CommonAttentionMetadata(
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc,
+        seq_lens=seq_lens,
+        _seq_lens_cpu=seq_lens,
+        num_reqs=2,
+        num_actual_tokens=5,
+        max_query_len=4,
+        max_seq_len=16,
+        block_table_tensor=torch.arange(16, dtype=torch.int32, device="cpu").view(2, 8),
+        slot_mapping=torch.arange(5, dtype=torch.int64, device="cpu"),
+    )
+
+
+def _patch_build_deps(monkeypatch, events=None):
+    """Stub the aiter kernel, triton helper and CUDA sync so ``build()`` runs
+    on CPU."""
+
+    def fake_generate_sparse_seqlen_triton(
+        query_lens, seq_lens, cu_query_lens, topk_token, num_tokens, max_query_len
+    ):
+        return torch.zeros(num_tokens, dtype=torch.int32, device="cpu")
+
+    fake_aiter = _FakeAiter("aiter")
+    fake_aiter.get_mla_metadata_v1 = Mock(side_effect=lambda *a, **k: None)
+    monkeypatch.setitem(sys.modules, "aiter", fake_aiter)
+    monkeypatch.setattr(
+        sparse_mod, "generate_sparse_seqlen_triton", fake_generate_sparse_seqlen_triton
+    )
+    monkeypatch.setattr(
+        sparse_mod.torch.cuda,
+        "current_stream",
+        lambda device=None: SimpleNamespace(
+            synchronize=lambda: events.append("sync") if events is not None else None
+        ),
+    )
+
+
+def test_build_populates_decode_only_split_fields(monkeypatch):
+    """Decode-only batch: all reqs count as decodes, prefill fields default."""
+    builder = _make_builder()
+    _patch_build_deps(monkeypatch)
+
+    md = builder.build(
+        common_prefix_len=0, common_attn_metadata=_make_common_metadata()
+    )
+
+    assert md.num_decodes == 2
+    assert md.num_prefills == 0
+    assert md.num_decode_tokens == 2
+    assert md.prefill_max_seq_len == 0
+    assert md.prefill is None
+
+
+def test_build_populates_mixed_split_fields(monkeypatch):
+    """Mixed decode+prefill batch: split is reported, ``prefill`` stays None."""
+    builder = _make_builder()
+    _patch_build_deps(monkeypatch)
+
+    md = builder.build(
+        common_prefix_len=0, common_attn_metadata=_make_mixed_common_metadata()
+    )
+
+    assert md.num_decodes == 1
+    assert md.num_prefills == 1
+    assert md.num_decode_tokens == 1
+    assert md.prefill_max_seq_len == 10
+    assert md.prefill is None
 
 
 def test_sparse_persistent_metadata_syncs_only_after_recompute(monkeypatch):

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -536,6 +536,20 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 vllm_config=vllm_config,
             )
 
+        # Drop the prefill backend for sparse impls without a dense-MHA path
+        # so the shared forward keeps every token on the MQA path.
+        if (
+            self.impl.is_sparse
+            and self.prefill_backend is not None
+            and not self.impl.supports_dense_mha_prefill
+        ):
+            logger.warning_once(
+                "The sparse MLA backend %s does not implement a dense-MHA "
+                "prefill path; using the top-k MQA path only.",
+                type(self.impl).__name__,
+            )
+            self.prefill_backend = None
+
         self.kv_cache = torch.tensor([])
 
         self.use_sparse = use_sparse

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -998,6 +998,9 @@ class MLAAttentionImpl(AttentionImplBase[T], Generic[T]):
     """MLA attention implementation with forward_mqa and forward_mha methods."""
 
     supports_pcp: bool = True
+    # Whether this impl provides a dense-MHA prefill path (``forward_mha``).
+    # Sparse impls with only the top-k MQA path set this to ``False``.
+    supports_dense_mha_prefill: bool = True
 
     @abstractmethod
     def __init__(

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -13,6 +13,7 @@ from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.config.cache import CacheDType
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import (
+    MLACommonPrefillMetadata,
     get_mla_dims,
 )
 from vllm.platforms import current_platform
@@ -30,6 +31,7 @@ from vllm.v1.attention.backend import (
 from vllm.v1.attention.backends.mla.rocm_aiter_mla import (
     AiterMLAHelper,
 )
+from vllm.v1.attention.backends.utils import split_decodes_and_prefills
 from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm.v1.worker.workspace import current_workspace_manager
 
@@ -333,6 +335,14 @@ class ROCMAiterMLASparseMetadata(AttentionMetadata):
     block_size: int = 1
     topk_tokens: int = 2048
 
+    # Decode/prefill split consumed by the shared MLA forward wrapper to keep
+    # all tokens on the MQA path; `prefill`/`prefill_max_seq_len` stay default.
+    num_decodes: int = 0
+    num_prefills: int = 0
+    num_decode_tokens: int = 0
+    prefill_max_seq_len: int = 0
+    prefill: MLACommonPrefillMetadata | None = None
+
     # Persistent MLA metadata (only populated when persistent mode is enabled,
     # i.e. when the aiter sparse decode kernel supports work-stealing splits).
     work_meta_data: torch.Tensor | None = None
@@ -488,6 +498,16 @@ class ROCMAiterMLASparseMetadataBuilder(
         fast_build: bool = False,
     ) -> ROCMAiterMLASparseMetadata:
         num_tokens = common_attn_metadata.num_actual_tokens
+        num_decodes, num_prefills, num_decode_tokens, _ = split_decodes_and_prefills(
+            common_attn_metadata,
+            decode_threshold=self.reorder_batch_threshold or 1,
+        )
+        prefill_max_seq_len = 0
+        if num_prefills > 0:
+            seq_lens_cpu = common_attn_metadata.seq_lens_cpu
+            prefill_max_seq_len = int(
+                seq_lens_cpu[num_decodes : num_decodes + num_prefills].max().item()
+            )
         starts = np.asarray(common_attn_metadata.query_start_loc_cpu, dtype=np.int32)
         seg_lengths = np.diff(starts)
         req_id_per_token = np.repeat(
@@ -604,6 +624,10 @@ class ROCMAiterMLASparseMetadataBuilder(
             block_size=self.kv_cache_spec.block_size,
             attn_out_dtype=self.model_dtype,
             topk_tokens=self.topk_tokens,
+            num_decodes=num_decodes,
+            num_prefills=num_prefills,
+            num_decode_tokens=num_decode_tokens,
+            prefill_max_seq_len=prefill_max_seq_len,
             qo_indptr=qo_indptr,
             paged_kv_last_page_len=paged_kv_last_page_len,
             paged_kv_indices=paged_kv_indices,
@@ -649,6 +673,9 @@ def reference_mla_sparse_prefill(
 
 class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
     is_sparse = True
+    # Only implements the top-k MQA path (forward_mqa), no dense-MHA prefill;
+    # the shared wrapper keeps every token on the MQA path.
+    supports_dense_mha_prefill = False
 
     def __init__(
         self,


### PR DESCRIPTION
## Purpose
After #47327 the MLA wrapper reads `num_decodes` / `num_prefills` / `num_decode_tokens`
from the attention metadata, but the ROCm AITER sparse-MLA metadata
(`ROCMAiterMLASparseMetadata`) never carried these fields. On gfx950 this raises
`AttributeError: 'ROCMAiterMLASparseMetadata' object has no attribute 'num_decodes'`
at runtime, so GLM-5.2 (FP8 / MXFP4, DeepSeek Sparse Attention) crashes on the first
forward pass on AMD MI355X.
This PR:
- Adds the missing `num_decodes` / `num_prefills` / `num_decode_tokens` (plus
  `prefill_max_seq_len` / `prefill`) fields to `ROCMAiterMLASparseMetadata` with
  safe defaults, and populates them in `build()` via `split_decodes_and_prefills`.
- Introduces a `supports_dense_mha_prefill` capability flag on `MLAAttentionImpl`
  (default `True`). The ROCm sparse impl sets it to `False`, and the MLA layer then
  disables the dense-MHA prefill backend for such impls so it only dispatches the
  implemented top-k MQA path (avoids calling the unimplemented `forward_mha`).
- Keeps MTP / speculative decoding working unchanged.
## Test Plan
- Unit: `pytest tests/kernels/attention/test_rocm_aiter_mla_sparse_metadata_sync.py`
  (new cases cover decode-only and mixed decode+prefill batches).
- E2E: GLM-5.2-FP8 + sparse MLA + MTP(num_speculative_tokens=5) on MI355X (gfx950) x4,
  TP=4, kv-cache fp8, 115k input / 1k output; plus gsm8k 5-shot accuracy.
## Test Result
- Before: server aborts during the first forward with
  `AttributeError: ... has no attribute 'num_decodes'`.
- After:
  - Unit tests pass; metadata fields match `split_decodes_and_prefills`.
  - Server starts and serves; 115k/1k benchmark runs cleanly
    (out ~71 tok/s, total ~8.1k tok/s, TTFT ~23.6s, TPOT p50 ~28.7ms @ CONC=4).
  - gsm8k 5-shot = 0.96 (192/200) — no accuracy regression.
  - MTP acceptance length ~4.5–5.0 / 6 (pos0 ~0.93) — speculative decoding healthy.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

