### PR TITLE
[Bugfix]: add spec decode headroom to mrope/xdrope position buffers

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -812,15 +812,25 @@ class GPUModelRunner(
             # identical position IDs, making M-RoPE functionally equivalent to
             # 1D-RoPE.
             # See page 5 of https://arxiv.org/abs/2409.12191
+            # Add headroom for speculative decode tokens which are scheduled
+            # on top of the base token budget.
+            mrope_buf_size = self.max_num_tokens + 1
+            if self.speculative_config:
+                mrope_buf_size += self.num_spec_tokens * self.max_num_reqs
             self.mrope_positions = self._make_buffer(
-                (3, self.max_num_tokens + 1), dtype=torch.int64
+                (3, mrope_buf_size), dtype=torch.int64
             )
 
         # Only relevant for models using XD-RoPE (e.g, HunYuan-VL)
         if self.uses_xdrope_dim > 0:
             # Similar to mrope but use assigned dimension number for RoPE, 4 as default.
+            # Add headroom for speculative decode tokens which are scheduled
+            # on top of the base token budget.
+            xdrope_buf_size = self.max_num_tokens + 1
+            if self.speculative_config:
+                xdrope_buf_size += self.num_spec_tokens * self.max_num_reqs
             self.xdrope_positions = self._make_buffer(
-                (self.uses_xdrope_dim, self.max_num_tokens + 1), dtype=torch.int64
+                (self.uses_xdrope_dim, xdrope_buf_size), dtype=torch.int64
             )
 
         # None in the first PP rank. The rest are set after load_model.


### PR DESCRIPTION
## fix(v1): add spec decode headroom to mrope/xdrope position buffers

### Summary

Fixes tensor index out-of-bounds crash when running HunyuanVL/HunyuanOCR with dflash speculative decoding.

### Problem

When speculative decoding (dflash) is enabled, the scheduler schedules `num_spec_tokens` draft tokens per decode request **on top of** the base `max_num_batched_tokens` budget. However, the M-RoPE and XD-RoPE position buffers were allocated with only `max_num_tokens + 1` capacity.

During `_calc_xdrope_positions` / `_calc_mrope_positions`, the write pointer advances by `completion_part_len` which includes draft tokens, causing writes beyond the buffer boundary.

**Repro:**
```bash
vllm serve tencent/HunyuanOCR \
  --speculative-config '{"method": "dflash", "model": "./hyocr_dflash", "num_spec_tokens": 15}'
```

**Error:** `RuntimeError: index out of bounds` in position tensor slicing.

### Fix

Pre-allocate additional headroom of `num_spec_tokens * max_num_reqs` in both `mrope_positions` and `xdrope_positions` buffers. This covers the worst case where all requests are simultaneously decoding with maximum draft tokens.

The fix:
- Is consistent with how other spec decode buffers handle this (e.g., `extract_hidden_states.py` uses `max_num_batched_tokens + max_batch_size`)
- Has negligible memory impact (~120KB extra for typical configs)
- Only activates when `speculative_config` is set

### Affected Models

- **HunyuanVL / HunyuanOCR** (XD-RoPE, `uses_xdrope_dim > 0`)
- **Qwen2-VL** (M-RoPE, `uses_mrope`) — preventive fix for same potential issue

### Testing

- [x] Verified buffer sizing logic with `num_spec_tokens=15, max_num_reqs=256`
- [ ] E2E test: HunyuanOCR + dflash no longer crashes
