### PR TITLE
[ROCm][Perf][DeepSeek V4] Enable heterogeneous MXFP4/FP8 fused shared expert

### DIFF
--- a/tests/kernels/moe/test_topk_softplus_sqrt.py
+++ b/tests/kernels/moe/test_topk_softplus_sqrt.py
@@ -7,12 +7,14 @@ import torch
 import torch.nn.functional as F
 
 import vllm._custom_ops as ops
+from vllm.model_executor.layers.fused_moe import layer as moe_layer
 from vllm.model_executor.layers.fused_moe.config import (
     RoutingMethodType,
     get_routing_method_type,
 )
 from vllm.model_executor.layers.fused_moe.router.dsv4_topk import dsv4_topk
 from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
+    FusedTopKBiasRouter,
     fused_topk_bias,
 )
 from vllm.platforms import current_platform
@@ -68,6 +70,89 @@ def test_sqrtsoftplus_bias_uses_deepseek_v4_routing_method():
             has_e_score_bias=True,
         )
         == RoutingMethodType.Unspecified
+    )
+
+
+def test_deepseek_v4_fused_shared_expert_is_appended_after_routing(monkeypatch):
+    routed_weights = torch.tensor(
+        [
+            [0.25, 0.50, 0.25, 0.50, 0.50, 0.50],
+            [0.125, 0.375, 0.25, 0.75, 0.50, 0.50],
+        ],
+        dtype=torch.float32,
+    )
+    routed_ids = torch.tensor(
+        [[1, 2, 3, 4, 5, 6], [10, 20, 30, 40, 50, 60]],
+        dtype=torch.int32,
+    )
+
+    def fake_fused_topk_bias(**kwargs):
+        return routed_weights.clone(), routed_ids.clone()
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.fused_moe.router."
+        "fused_topk_bias_router.fused_topk_bias",
+        fake_fused_topk_bias,
+    )
+    router = FusedTopKBiasRouter(
+        top_k=6,
+        global_num_experts=384,
+        e_score_correction_bias=torch.zeros(384),
+        renormalize=True,
+        routed_scaling_factor=2.5,
+        scoring_func="sqrtsoftplus",
+        num_fused_shared_experts=1,
+        shared_expert_weight=1.0,
+    )
+
+    weights, ids = router.select_experts(
+        torch.empty(2, 8),
+        torch.empty(2, 384),
+        torch.int32,
+    )
+
+    assert weights.shape == ids.shape == (2, 7)
+    torch.testing.assert_close(weights[:, :6], routed_weights, rtol=0, atol=0)
+    torch.testing.assert_close(ids[:, :6], routed_ids, rtol=0, atol=0)
+    torch.testing.assert_close(
+        weights[:, :6].sum(-1), torch.full((2,), 2.5), rtol=0, atol=0
+    )
+    torch.testing.assert_close(weights[:, 6], torch.ones(2), rtol=0, atol=0)
+    torch.testing.assert_close(
+        ids[:, 6],
+        torch.full((2,), 384, dtype=torch.int32),
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("aiter_enabled", "env_enabled", "is_act_and_mul"),
+    [
+        (aiter_enabled, env_enabled, is_act_and_mul)
+        for aiter_enabled in (False, True)
+        for env_enabled in (False, True)
+        for is_act_and_mul in (False, True)
+    ],
+)
+def test_shared_expert_count_preserves_aiter_and_backend_neutral_gates(
+    monkeypatch, aiter_enabled, env_enabled, is_act_and_mul
+):
+    monkeypatch.setattr(
+        moe_layer.rocm_aiter_ops,
+        "is_fusion_moe_shared_experts_enabled",
+        lambda: aiter_enabled,
+    )
+    monkeypatch.setattr(
+        moe_layer.envs,
+        "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS",
+        env_enabled,
+    )
+    expected_fused_experts = int((aiter_enabled or env_enabled) and is_act_and_mul)
+    assert moe_layer.determine_expert_counts(384, 0, 1, is_act_and_mul) == (
+        384,
+        384,
+        expected_fused_experts,
     )
 
 

--- a/tests/models/test_deepseek_v4_amd_moe.py
+++ b/tests/models/test_deepseek_v4_amd_moe.py
@@ -1,0 +1,549 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import inspect
+import weakref
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from vllm.platforms import current_platform
+
+if not current_platform.is_rocm():
+    pytest.skip("DeepSeek V4 AMD MoE tests require ROCm", allow_module_level=True)
+
+import vllm.models.deepseek_v4.amd.model as amd_model
+from vllm._aiter_ops import (
+    _rocm_aiter_fused_moe_fake,
+    _rocm_aiter_fused_moe_impl,
+    rocm_aiter_ops,
+)
+from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
+    rocm_aiter_fused_experts,
+)
+from vllm.models.deepseek_v4.amd.model import (
+    DeepseekV4HeterogeneousSharedRoutedExperts,
+    _make_deepseek_v4_weights_mapper,
+    _pad_and_expand_native_fp8_shared_expert,
+    _should_fuse_shared_expert,
+)
+
+
+def _make_fusion_config():
+    quant_config = SimpleNamespace(
+        get_name=lambda: "deepseek_v4_fp8",
+        moe_quant_algo="",
+        weight_block_size=[128, 128],
+        is_checkpoint_fp8_serialized=True,
+        is_scale_e8m0=True,
+        ignored_layers=[],
+    )
+    hf_config = SimpleNamespace(
+        n_routed_experts=384,
+        hidden_size=7168,
+        moe_intermediate_size=3072,
+        num_experts_per_tok=6,
+        n_shared_experts=1,
+        expert_dtype="fp4",
+        hidden_act="silu",
+    )
+    return SimpleNamespace(
+        model_config=SimpleNamespace(hf_config=hf_config, dtype=torch.bfloat16),
+        quant_config=quant_config,
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=8,
+            enable_expert_parallel=False,
+            enable_eplb=False,
+        ),
+        offload_config=SimpleNamespace(
+            uva=SimpleNamespace(cpu_offload_gb=0),
+            prefetch=SimpleNamespace(offload_group_size=0),
+        ),
+        kernel_config=SimpleNamespace(moe_backend="aiter"),
+    )
+
+
+@pytest.mark.parametrize(
+    "guard",
+    [
+        "aiter_moe",
+        "heterogeneous_kernel",
+        "gfx950",
+        "backend",
+        "tensor_parallel",
+        "routed_experts",
+        "hidden_size",
+        "intermediate_size",
+        "top_k",
+        "shared_experts",
+        "expert_dtype",
+        "activation",
+        "model_dtype",
+        "moe_quant_algo",
+        "block_size",
+        "serialized_fp8",
+        "scale_dtype",
+        "ignored_layers",
+        "expert_parallel",
+        "eplb",
+        "uva_weight_offload",
+        "prefetch_weight_offload",
+    ],
+)
+def test_deepseek_v4_shared_expert_fusion_guards(monkeypatch, guard):
+    config = _make_fusion_config()
+    monkeypatch.setattr(
+        amd_model.rocm_aiter_ops,
+        "is_fusion_moe_shared_experts_enabled",
+        lambda: guard != "aiter_moe",
+    )
+    monkeypatch.setattr(
+        amd_model.rocm_aiter_ops,
+        "fused_moe_supports_heterogeneous_shared_expert",
+        lambda: guard != "heterogeneous_kernel",
+    )
+    monkeypatch.setattr(amd_model, "on_gfx950", lambda: guard != "gfx950")
+
+    if guard == "backend":
+        config.kernel_config.moe_backend = "triton"
+    elif guard == "tensor_parallel":
+        config.parallel_config.tensor_parallel_size = 4
+    elif guard == "routed_experts":
+        config.model_config.hf_config.n_routed_experts = 256
+    elif guard == "hidden_size":
+        config.model_config.hf_config.hidden_size = 4096
+    elif guard == "intermediate_size":
+        config.model_config.hf_config.moe_intermediate_size = 1536
+    elif guard == "top_k":
+        config.model_config.hf_config.num_experts_per_tok = 8
+    elif guard == "shared_experts":
+        config.model_config.hf_config.n_shared_experts = 2
+    elif guard == "expert_dtype":
+        config.model_config.hf_config.expert_dtype = "fp8"
+    elif guard == "activation":
+        config.model_config.hf_config.hidden_act = "gelu"
+    elif guard == "model_dtype":
+        config.model_config.dtype = torch.float16
+    elif guard == "moe_quant_algo":
+        config.quant_config.moe_quant_algo = "NVFP4"
+    elif guard == "block_size":
+        config.quant_config.weight_block_size = [64, 128]
+    elif guard == "serialized_fp8":
+        config.quant_config.is_checkpoint_fp8_serialized = False
+    elif guard == "scale_dtype":
+        config.quant_config.is_scale_e8m0 = False
+    elif guard == "ignored_layers":
+        config.quant_config.ignored_layers = ["shared_experts"]
+    elif guard == "expert_parallel":
+        config.parallel_config.enable_expert_parallel = True
+    elif guard == "eplb":
+        config.parallel_config.enable_eplb = True
+    elif guard == "uva_weight_offload":
+        config.offload_config.uva.cpu_offload_gb = 1
+    elif guard == "prefetch_weight_offload":
+        config.offload_config.prefetch.offload_group_size = 1
+
+    assert not _should_fuse_shared_expert(config)
+
+
+def test_deepseek_v4_shared_expert_fusion_policy_accepts_supported_config(
+    monkeypatch,
+):
+    config = _make_fusion_config()
+    monkeypatch.setattr(
+        amd_model.rocm_aiter_ops,
+        "is_fusion_moe_shared_experts_enabled",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        amd_model.rocm_aiter_ops,
+        "fused_moe_supports_heterogeneous_shared_expert",
+        lambda: True,
+    )
+    monkeypatch.setattr(amd_model, "on_gfx950", lambda: True)
+
+    assert _should_fuse_shared_expert(config)
+
+
+@pytest.mark.parametrize(
+    ("projection", "mapped_projection"),
+    [("w1", "w1"), ("w2", "down_proj"), ("w3", "w3")],
+)
+def test_shared_expert_checkpoint_names_stay_on_native_mlp(
+    projection, mapped_projection
+):
+    name = f"layers.1.ffn.shared_experts.{projection}.scale"
+    weight = torch.empty(0)
+    mapped_name, _ = next(
+        iter(_make_deepseek_v4_weights_mapper("fp4").apply([(name, weight)]))
+    )
+
+    assert mapped_name == (
+        f"model.layers.1.ffn.shared_experts.{mapped_projection}.weight_scale_inv"
+    )
+    assert ".experts.384." not in mapped_name
+
+
+def test_fused_moe_registers_native_mlp_before_derived_routed_buffers(monkeypatch):
+    captured = {}
+
+    class FakeGate(nn.Module):
+        def __init__(self, **kwargs):
+            super().__init__()
+
+    class FakeSharedExpert(nn.Module):
+        def __init__(self, **kwargs):
+            super().__init__()
+            self.gate_up_proj = nn.Module()
+            self.down_proj = nn.Module()
+
+    def fake_fused_moe(**kwargs):
+        captured.update(kwargs)
+        runner = nn.Module()
+        runner.routed_experts = nn.Module()
+        return runner
+
+    monkeypatch.setattr(amd_model, "GateLinear", FakeGate)
+    monkeypatch.setattr(amd_model, "DeepseekV4MLP", FakeSharedExpert)
+    monkeypatch.setattr(amd_model, "FusedMoE", fake_fused_moe)
+    monkeypatch.setattr(amd_model, "get_tensor_model_parallel_world_size", lambda: 8)
+    monkeypatch.setattr(amd_model, "get_tensor_model_parallel_rank", lambda: 0)
+    config = SimpleNamespace(
+        routed_scaling_factor=2.5,
+        hidden_size=7168,
+        n_routed_experts=384,
+        num_experts_per_tok=6,
+        moe_intermediate_size=3072,
+        swiglu_limit=10.0,
+        norm_topk_prob=True,
+        scoring_func="sqrtsoftplus",
+        num_hash_layers=0,
+        vocab_size=163840,
+        topk_method=None,
+        n_shared_experts=1,
+        hidden_act="silu",
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(hf_config=config),
+        quant_config=object(),
+    )
+
+    moe = amd_model.DeepseekV4MoE(
+        vllm_config,
+        prefix="model.layers.0.ffn",
+        fuse_heterogeneous_shared_expert=True,
+    )
+
+    module_names = [name for name, _ in moe.named_modules()]
+    assert module_names.index("shared_experts.gate_up_proj") < module_names.index(
+        "experts.routed_experts"
+    )
+    assert captured["shared_experts"] is None
+    assert captured["n_shared_experts"] == 1
+    assert captured["routed_scaling_factor"] == 2.5
+    assert captured["routed_experts_cls"] is (
+        DeepseekV4HeterogeneousSharedRoutedExperts
+    )
+    assert captured["routed_experts_args"] == {
+        "shared_expert": moe.shared_experts,
+        "shared_expert_id": 384,
+    }
+
+
+def _native_shared_tensors():
+    native_intermediate = 128
+    hidden_size = 256
+    w13_values = (
+        torch.arange(2 * native_intermediate * hidden_size, dtype=torch.int32) % 15
+    ) - 7
+    w2_values = (
+        torch.arange(hidden_size * native_intermediate, dtype=torch.int32) % 13
+    ) - 6
+    w13 = w13_values.to(torch.float8_e4m3fn).view(2 * native_intermediate, hidden_size)
+    w2 = w2_values.to(torch.float8_e4m3fn).view(hidden_size, native_intermediate)
+    w13_scale = torch.tensor([[120, 121], [130, 131]], dtype=torch.uint8).view(
+        torch.float8_e8m0fnu
+    )
+    w2_scale = torch.tensor([[122], [132]], dtype=torch.uint8).view(
+        torch.float8_e8m0fnu
+    )
+    return w13, w2, w13_scale, w2_scale
+
+
+def test_native_fp8_padding_preserves_bytes_and_expands_e8m0_losslessly():
+    w13, w2, w13_scale, w2_scale = _native_shared_tensors()
+
+    padded_w13, padded_w2, expanded_w13_scale, expanded_w2_scale = (
+        _pad_and_expand_native_fp8_shared_expert(
+            w13, w2, w13_scale, w2_scale, padded_intermediate_size=256
+        )
+    )
+
+    assert padded_w13.shape == (1, 512, 256)
+    assert padded_w2.shape == (1, 256, 256)
+    assert expanded_w13_scale.shape == (512, 8)
+    assert expanded_w2_scale.shape == (256, 8)
+    assert torch.equal(
+        padded_w13[0, :128].view(torch.uint8), w13[:128].view(torch.uint8)
+    )
+    assert torch.equal(
+        padded_w13[0, 256:384].view(torch.uint8), w13[128:].view(torch.uint8)
+    )
+    assert torch.count_nonzero(padded_w13[0, 128:256].view(torch.uint8)) == 0
+    assert torch.count_nonzero(padded_w13[0, 384:].view(torch.uint8)) == 0
+    assert torch.equal(padded_w2[0, :, :128].view(torch.uint8), w2.view(torch.uint8))
+    assert torch.count_nonzero(padded_w2[0, :, 128:].view(torch.uint8)) == 0
+
+    w13_scale_bytes = expanded_w13_scale.view(torch.uint8)
+    w2_scale_bytes = expanded_w2_scale.view(torch.uint8)
+    expected_gate = w13_scale[:1].view(torch.uint8).repeat_interleave(128, 0)
+    expected_gate = expected_gate.repeat_interleave(4, 1)
+    expected_up = w13_scale[1:].view(torch.uint8).repeat_interleave(128, 0)
+    expected_up = expected_up.repeat_interleave(4, 1)
+    expected_w2 = w2_scale.view(torch.uint8).repeat_interleave(128, 0)
+    expected_w2 = expected_w2.repeat_interleave(4, 1)
+    assert torch.equal(w13_scale_bytes[:128], expected_gate)
+    assert torch.equal(w13_scale_bytes[256:384], expected_up)
+    assert torch.all(w13_scale_bytes[128:256] == 0x7F)
+    assert torch.all(w13_scale_bytes[384:] == 0x7F)
+    assert torch.equal(w2_scale_bytes[:, :4], expected_w2)
+    assert torch.all(w2_scale_bytes[:, 4:] == 0x7F)
+
+
+class _NativeSharedExpert(nn.Module):
+    def __init__(self):
+        super().__init__()
+        w13, w2, w13_scale, w2_scale = _native_shared_tensors()
+        self.gate_up_proj = nn.Module()
+        self.gate_up_proj.weight = w13
+        self.gate_up_proj.weight_scale_inv = w13_scale
+        self.down_proj = nn.Module()
+        self.down_proj.weight = w2
+        self.down_proj.weight_scale_inv = w2_scale
+
+
+def _empty_heterogeneous_experts(shared_expert):
+    experts = object.__new__(DeepseekV4HeterogeneousSharedRoutedExperts)
+    nn.Module.__init__(experts)
+    experts._shared_expert_ref = weakref.ref(shared_expert)
+    experts.moe_config = SimpleNamespace(intermediate_size_per_partition=256)
+    experts.register_buffer("shared_w1", None, persistent=False)
+    experts.register_buffer("shared_w2", None, persistent=False)
+    experts.register_buffer("shared_w1_scale", None, persistent=False)
+    experts.register_buffer("shared_w2_scale", None, persistent=False)
+    return experts
+
+
+def test_native_fp8_postload_uses_gate_up_interleaved_aiter_layout(monkeypatch):
+    shared_expert = _NativeSharedExpert()
+    experts = _empty_heterogeneous_experts(shared_expert)
+    calls: list[tuple[object, ...]] = []
+
+    def shuffle_weight(tensor, lanes, gate_up):
+        calls.append(("weight", tensor.shape, lanes, gate_up))
+        return tensor
+
+    def shuffle_scale_a16w4(tensor, num_experts, gate_up):
+        calls.append(("scale_a16w4", tensor.shape, num_experts, gate_up))
+        return tensor
+
+    def shuffle_scale(tensor):
+        calls.append(("scale", tensor.shape))
+        return tensor
+
+    monkeypatch.setattr(
+        amd_model.rocm_aiter_ops, "shuffle_weight_a16w4", shuffle_weight
+    )
+    monkeypatch.setattr(
+        amd_model.rocm_aiter_ops,
+        "shuffle_scale_a16w4",
+        shuffle_scale_a16w4,
+    )
+    monkeypatch.setattr(amd_model.rocm_aiter_ops, "shuffle_scale", shuffle_scale)
+
+    experts.prepare_heterogeneous_shared_expert()
+
+    assert calls == [
+        ("weight", torch.Size([1, 512, 256]), 16, True),
+        ("scale_a16w4", torch.Size([512, 8]), 1, True),
+        ("weight", torch.Size([1, 256, 256]), 16, False),
+        ("scale", torch.Size([256, 8])),
+    ]
+
+
+def test_heterogeneous_adapter_forwards_topk7_and_separate_fp8_tensors(monkeypatch):
+    experts = _empty_heterogeneous_experts(_NativeSharedExpert())
+    experts.shared_expert_id = 384
+    experts.w13_weight = torch.empty(385, 512, 128, dtype=torch.uint8)
+    experts.w2_weight = torch.empty(385, 256, 128, dtype=torch.uint8)
+    experts.shared_w1 = torch.empty(1, 512, 256, dtype=torch.float8_e4m3fn)
+    experts.shared_w2 = torch.empty(1, 256, 256, dtype=torch.float8_e4m3fn)
+    experts.shared_w1_scale = torch.empty(512, 8, dtype=torch.float8_e8m0fnu)
+    experts.shared_w2_scale = torch.empty(256, 8, dtype=torch.float8_e8m0fnu)
+    quant_config = object()
+    experts.quant_method = SimpleNamespace(moe_quant_config=quant_config)
+    experts.activation = object()
+    experts.rocm_aiter_fmoe_enabled = False
+    experts._expert_map = None
+    captured = {}
+
+    def fake_fused_experts(**kwargs):
+        captured.update(kwargs)
+        return torch.ones_like(kwargs["hidden_states"])
+
+    monkeypatch.setattr(amd_model, "rocm_aiter_fused_experts", fake_fused_experts)
+    monkeypatch.setattr(amd_model.rocm_aiter_ops, "get_moe_dispatch_policy", lambda: 7)
+    x = torch.empty(2, 256)
+    topk_weights = torch.tensor(
+        [
+            [0.25, 0.50, 0.25, 0.50, 0.50, 0.50, 1.0],
+            [0.125, 0.375, 0.25, 0.75, 0.50, 0.50, 1.0],
+        ]
+    )
+    topk_ids = torch.tensor(
+        [[0, 1, 2, 3, 4, 5, 384], [6, 7, 8, 9, 10, 11, 384]],
+        dtype=torch.int32,
+    )
+
+    output = experts.forward_modular(x, topk_weights, topk_ids)
+
+    assert output.shape == x.shape
+    assert captured["w1"].shape[0] == 385
+    assert captured["topk_weights"] is topk_weights
+    torch.testing.assert_close(
+        captured["topk_weights"][:, :6].sum(-1),
+        torch.full((2,), 2.5),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        captured["topk_weights"][:, -1], torch.ones(2), rtol=0, atol=0
+    )
+    assert torch.all(captured["topk_ids"][:, -1] == 384)
+    assert captured["quant_config"] is quant_config
+    assert captured["shared_w1"] is experts.shared_w1
+    assert captured["shared_w2"] is experts.shared_w2
+    assert captured["shared_w1_scale"] is experts.shared_w1_scale
+    assert captured["shared_w2_scale"] is experts.shared_w2_scale
+    assert captured["shared_expert_id"] == 384
+
+
+@pytest.mark.parametrize("swiglu_limit", [None, 10.0])
+def test_rocm_aiter_adapter_forwards_heterogeneous_contract_and_swiglu_limit(
+    monkeypatch, swiglu_limit
+):
+    captured = {}
+
+    def fake_fused_moe(*args, **kwargs):
+        captured.update(kwargs)
+        return torch.empty_like(args[0])
+
+    monkeypatch.setattr(amd_model.rocm_aiter_ops, "fused_moe", fake_fused_moe)
+    quant_config = SimpleNamespace(
+        per_act_token_quant=False,
+        use_fp8_w8a8=False,
+        use_mxfp4_w4a4=False,
+        use_mxfp4_w4a16=True,
+        block_shape=None,
+        w1_scale=torch.empty(0),
+        w2_scale=torch.empty(0),
+        a1_scale=None,
+        a2_scale=None,
+        w1_bias=None,
+        w2_bias=None,
+    )
+    moe_config = SimpleNamespace(
+        hidden_dim_unpadded=256,
+        intermediate_size_per_partition_unpadded=256,
+        intermediate_size_per_partition=256,
+        intermediate_pad=None,
+        tp_size=1,
+        swiglu_limit=swiglu_limit,
+    )
+    shared = [torch.empty(0) for _ in range(4)]
+
+    rocm_aiter_fused_experts(
+        hidden_states=torch.empty(2, 256),
+        w1=torch.empty(385, 512, 128),
+        w2=torch.empty(385, 256, 128),
+        topk_weights=torch.ones(2, 7),
+        topk_ids=torch.zeros(2, 7, dtype=torch.int32),
+        moe_config=moe_config,
+        quant_config=quant_config,
+        shared_w1=shared[0],
+        shared_w2=shared[1],
+        shared_w1_scale=shared[2],
+        shared_w2_scale=shared[3],
+        shared_expert_id=384,
+    )
+
+    assert captured["swiglu_limit"] == (
+        0.0 if swiglu_limit is None else float(swiglu_limit)
+    )
+    assert captured["shared_w1"] is shared[0]
+    assert captured["shared_w2"] is shared[1]
+    assert captured["shared_w1_scale"] is shared[2]
+    assert captured["shared_w2_scale"] is shared[3]
+    assert captured["shared_expert_id"] == 384
+
+
+def test_heterogeneous_custom_op_impl_fake_and_public_signatures_match():
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    expected = {
+        "shared_w1",
+        "shared_w2",
+        "shared_w1_scale",
+        "shared_w2_scale",
+        "shared_expert_id",
+    }
+    for function in (
+        _rocm_aiter_fused_moe_impl,
+        _rocm_aiter_fused_moe_fake,
+        rocm_aiter_ops.fused_moe,
+        rocm_aiter_fused_experts,
+    ):
+        assert expected <= inspect.signature(function).parameters.keys()
+
+    for function in (
+        _rocm_aiter_fused_moe_impl,
+        _rocm_aiter_fused_moe_fake,
+        rocm_aiter_ops.fused_moe,
+    ):
+        assert inspect.signature(function).parameters["swiglu_limit"].default == 0.0
+
+    hidden_states = torch.empty(2, 256, dtype=torch.float16)
+    output = _rocm_aiter_fused_moe_fake(
+        hidden_states,
+        torch.empty(385, 512, 128),
+        torch.empty(385, 256, 128),
+        torch.ones(2, 7),
+        torch.zeros(2, 7, dtype=torch.int32),
+        output_dtype=torch.bfloat16,
+        shared_w1=torch.empty(1, 512, 256),
+        shared_w2=torch.empty(1, 256, 256),
+        shared_w1_scale=torch.empty(512, 8),
+        shared_w2_scale=torch.empty(256, 8),
+        shared_expert_id=384,
+    )
+    assert output.shape == hidden_states.shape
+    assert output.dtype == torch.bfloat16
+
+    with FakeTensorMode():
+        custom_op_output = rocm_aiter_ops.fused_moe(
+            torch.empty(2, 256),
+            torch.empty(385, 512, 128),
+            torch.empty(385, 256, 128),
+            torch.ones(2, 7),
+            torch.zeros(2, 7, dtype=torch.int32),
+            output_dtype=torch.bfloat16,
+            shared_w1=torch.empty(1, 512, 256),
+            shared_w2=torch.empty(1, 256, 256),
+            shared_w1_scale=torch.empty(512, 8),
+            shared_w2_scale=torch.empty(256, 8),
+            shared_expert_id=384,
+        )
+    assert custom_op_output.shape == hidden_states.shape
+    assert custom_op_output.dtype == torch.bfloat16

--- a/tests/models/test_deepseek_v4_amd_moe.py
+++ b/tests/models/test_deepseek_v4_amd_moe.py
@@ -23,6 +23,9 @@ from vllm._aiter_ops import (
 from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
     rocm_aiter_fused_experts,
 )
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    _upcast_e8m0_to_fp32,
+)
 from vllm.models.deepseek_v4.amd.model import (
     DeepseekV4HeterogeneousSharedRoutedExperts,
     _make_deepseek_v4_weights_mapper,
@@ -321,6 +324,38 @@ def test_native_fp8_padding_preserves_bytes_and_expands_e8m0_losslessly():
     assert torch.all(w13_scale_bytes[384:] == 0x7F)
     assert torch.equal(w2_scale_bytes[:, :4], expected_w2)
     assert torch.all(w2_scale_bytes[:, 4:] == 0x7F)
+
+
+def test_native_fp8_padding_recovers_aiter_fp32_scale_upcasts():
+    w13, w2, w13_scale, w2_scale = _native_shared_tensors()
+    expected = _pad_and_expand_native_fp8_shared_expert(
+        w13, w2, w13_scale, w2_scale, padded_intermediate_size=256
+    )
+
+    actual = _pad_and_expand_native_fp8_shared_expert(
+        w13,
+        w2,
+        _upcast_e8m0_to_fp32(w13_scale),
+        _upcast_e8m0_to_fp32(w2_scale),
+        padded_intermediate_size=256,
+    )
+
+    for actual_tensor, expected_tensor in zip(actual, expected):
+        assert torch.equal(
+            actual_tensor.view(torch.uint8), expected_tensor.view(torch.uint8)
+        )
+
+
+@pytest.mark.parametrize("invalid_scale", [-1.0, 1.5])
+def test_native_fp8_padding_rejects_non_e8m0_fp32_scales(invalid_scale):
+    w13, w2, w13_scale, w2_scale = _native_shared_tensors()
+    w13_scale = _upcast_e8m0_to_fp32(w13_scale)
+    w13_scale[0, 0] = invalid_scale
+
+    with pytest.raises(ValueError, match="must be exact E8M0 upcasts"):
+        _pad_and_expand_native_fp8_shared_expert(
+            w13, w2, w13_scale, w2_scale, padded_intermediate_size=256
+        )
 
 
 class _NativeSharedExpert(nn.Module):

--- a/tests/models/test_deepseek_v4_amd_moe.py
+++ b/tests/models/test_deepseek_v4_amd_moe.py
@@ -68,6 +68,7 @@ def _make_fusion_config():
 @pytest.mark.parametrize(
     "guard",
     [
+        "fusion_env",
         "aiter_moe",
         "heterogeneous_kernel",
         "gfx950",
@@ -94,6 +95,11 @@ def _make_fusion_config():
 )
 def test_deepseek_v4_shared_expert_fusion_guards(monkeypatch, guard):
     config = _make_fusion_config()
+    monkeypatch.setattr(
+        amd_model.envs,
+        "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS",
+        guard != "fusion_env",
+    )
     monkeypatch.setattr(
         amd_model.rocm_aiter_ops,
         "is_fusion_moe_shared_experts_enabled",
@@ -152,6 +158,11 @@ def test_deepseek_v4_shared_expert_fusion_policy_accepts_supported_config(
     monkeypatch,
 ):
     config = _make_fusion_config()
+    monkeypatch.setattr(
+        amd_model.envs,
+        "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS",
+        True,
+    )
     monkeypatch.setattr(
         amd_model.rocm_aiter_ops,
         "is_fusion_moe_shared_experts_enabled",

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -133,6 +133,11 @@ def _rocm_aiter_fused_moe_impl(
     bias2: torch.Tensor | None = None,
     moe_sorting_dispatch_policy: int = 0,
     swiglu_limit: float = 0.0,
+    shared_w1: torch.Tensor | None = None,
+    shared_w2: torch.Tensor | None = None,
+    shared_w1_scale: torch.Tensor | None = None,
+    shared_w2_scale: torch.Tensor | None = None,
+    shared_expert_id: int = -1,
 ) -> torch.Tensor:
     from aiter import ActivationType, QuantType
     from aiter.fused_moe import fused_moe
@@ -143,6 +148,24 @@ def _rocm_aiter_fused_moe_impl(
     extra_kwargs: dict = {}
     if gate_mode and rocm_aiter_ops.fused_moe_supports_gate_mode():
         extra_kwargs["gate_mode"] = gate_mode
+
+    shared_tensors = (shared_w1, shared_w2, shared_w1_scale, shared_w2_scale)
+    if any(tensor is not None for tensor in shared_tensors):
+        if not all(tensor is not None for tensor in shared_tensors):
+            raise ValueError(
+                "Heterogeneous fused MoE requires both shared weights and scales."
+            )
+        if shared_expert_id < 0:
+            raise ValueError(
+                "Heterogeneous fused MoE requires a non-negative shared expert ID."
+            )
+        extra_kwargs.update(
+            shared_w1=shared_w1,
+            shared_w2=shared_w2,
+            shared_w1_scale=shared_w1_scale,
+            shared_w2_scale=shared_w2_scale,
+            shared_expert_id=shared_expert_id,
+        )
 
     return fused_moe(
         hidden_states,
@@ -193,6 +216,11 @@ def _rocm_aiter_fused_moe_fake(
     bias2: torch.Tensor | None = None,
     moe_sorting_dispatch_policy: int = 0,
     swiglu_limit: float = 0.0,
+    shared_w1: torch.Tensor | None = None,
+    shared_w2: torch.Tensor | None = None,
+    shared_w1_scale: torch.Tensor | None = None,
+    shared_w2_scale: torch.Tensor | None = None,
+    shared_expert_id: int = -1,
 ) -> torch.Tensor:
     if output_dtype is not None:
         return torch.empty_like(hidden_states, dtype=output_dtype)
@@ -1786,6 +1814,27 @@ class rocm_aiter_ops:
 
         return "gate_mode" in inspect.signature(fused_moe).parameters
 
+    @classmethod
+    @if_aiter_supported
+    @functools.cache
+    def fused_moe_supports_heterogeneous_shared_expert(cls) -> bool:
+        """Whether AITER accepts native-FP8 shared-expert tensors."""
+        import inspect
+
+        from aiter.fused_moe import fused_moe
+
+        params = inspect.signature(fused_moe).parameters
+        return all(
+            name in params
+            for name in (
+                "shared_w1",
+                "shared_w2",
+                "shared_w1_scale",
+                "shared_w2_scale",
+                "shared_expert_id",
+            )
+        )
+
     @staticmethod
     @if_aiter_supported
     def register_ops_once() -> None:
@@ -2155,6 +2204,11 @@ class rocm_aiter_ops:
         bias2: torch.Tensor | None = None,
         moe_sorting_dispatch_policy: int = 0,
         swiglu_limit: float = 0.0,
+        shared_w1: torch.Tensor | None = None,
+        shared_w2: torch.Tensor | None = None,
+        shared_w1_scale: torch.Tensor | None = None,
+        shared_w2_scale: torch.Tensor | None = None,
+        shared_expert_id: int = -1,
     ) -> torch.Tensor:
         return torch.ops.vllm.rocm_aiter_fused_moe(
             hidden_states,
@@ -2179,6 +2233,11 @@ class rocm_aiter_ops:
             bias2,
             moe_sorting_dispatch_policy,
             swiglu_limit,
+            shared_w1,
+            shared_w2,
+            shared_w1_scale,
+            shared_w2_scale,
+            shared_expert_id,
         )
 
     @staticmethod
@@ -2732,6 +2791,13 @@ class rocm_aiter_ops:
         from aiter.ops.shuffle import shuffle_scale_a16w4
 
         return shuffle_scale_a16w4(tensor, num_experts, gate_up)
+
+    @staticmethod
+    def shuffle_scale(tensor: torch.Tensor) -> torch.Tensor:
+        """Shuffle a non-gate/up E8M0 scale tensor for AITER."""
+        from aiter.ops.shuffle import shuffle_scale
+
+        return shuffle_scale(tensor)
 
     @staticmethod
     def shuffle_weights(

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -246,6 +246,11 @@ def rocm_aiter_fused_experts(
     num_local_tokens: torch.Tensor | None = None,
     output_dtype: torch.dtype | None = None,
     moe_sorting_dispatch_policy: int = 0,
+    shared_w1: torch.Tensor | None = None,
+    shared_w2: torch.Tensor | None = None,
+    shared_w1_scale: torch.Tensor | None = None,
+    shared_w2_scale: torch.Tensor | None = None,
+    shared_expert_id: int = -1,
 ) -> torch.Tensor:
     """ROCm AITER fused MoE expert computation."""
     if quant_config is None:
@@ -379,6 +384,9 @@ def rocm_aiter_fused_experts(
                 else GateMode.SEPARATED.value
             )
 
+        swiglu_limit = (
+            0.0 if moe_config.swiglu_limit is None else float(moe_config.swiglu_limit)
+        )
         return rocm_aiter_ops.fused_moe(
             hidden_states,
             w1,
@@ -401,6 +409,12 @@ def rocm_aiter_fused_experts(
             bias1=quant_config.w1_bias if quant_config.use_mxfp4_w4a16 else None,
             bias2=quant_config.w2_bias if quant_config.use_mxfp4_w4a16 else None,
             moe_sorting_dispatch_policy=moe_sorting_dispatch_policy,
+            swiglu_limit=swiglu_limit,
+            shared_w1=shared_w1,
+            shared_w2=shared_w2,
+            shared_w1_scale=shared_w1_scale,
+            shared_w2_scale=shared_w2_scale,
+            shared_expert_id=shared_expert_id,
         )
 
 

--- a/vllm/models/deepseek_v4/amd/model.py
+++ b/vllm/models/deepseek_v4/amd/model.py
@@ -201,7 +201,19 @@ def _pad_and_expand_native_fp8_shared_expert(
             return scale.contiguous().view(torch.uint8)
         if scale.dtype == torch.uint8:
             return scale.contiguous()
-        raise ValueError("Heterogeneous shared-expert scales must be E8M0 bytes.")
+        if scale.dtype == torch.float32:
+            scale_bits = scale.contiguous().view(torch.int32)
+            exponent_bytes = (scale_bits >> 23).to(torch.uint8)
+            if not torch.equal(scale_bits, exponent_bytes.to(torch.int32) << 23):
+                raise ValueError(
+                    "Heterogeneous shared-expert FP32 scales must be exact "
+                    "E8M0 upcasts."
+                )
+            return exponent_bytes
+        raise ValueError(
+            "Heterogeneous shared-expert scales must be E8M0 bytes or exact "
+            "FP32 E8M0 upcasts."
+        )
 
     w13_scale_bytes = scale_bytes(w13_scale)
     w2_scale_bytes = scale_bytes(w2_scale)

--- a/vllm/models/deepseek_v4/amd/model.py
+++ b/vllm/models/deepseek_v4/amd/model.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import typing
+import weakref
 from collections.abc import Callable, Iterable
 from itertools import islice
 
@@ -9,17 +10,23 @@ import torch
 import torch.nn as nn
 
 import vllm.envs as envs
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import (
     get_pp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
+from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul, SiluAndMulWithClamp
 from vllm.model_executor.layers.fused_moe import (
     FusedMoE,
     GateLinear,
+    RoutedExperts,
     fused_moe_make_expert_params_mapping,
+)
+from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
+    rocm_aiter_fused_experts,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
@@ -36,6 +43,7 @@ from vllm.model_executor.layers.mhc import (
     MHCPreOp,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.mxfp4 import Mxfp4MoEMethod
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -57,7 +65,293 @@ from vllm.model_executor.models.utils import (
 )
 from vllm.models.deepseek_v4.amd.rocm import DeepseekV4ROCMAiterMLAAttention
 from vllm.platforms import current_platform
+from vllm.platforms.rocm import on_gfx950
 from vllm.sequence import IntermediateTensors
+
+logger = init_logger(__name__)
+
+
+def _should_fuse_shared_expert(vllm_config: VllmConfig) -> bool:
+    config = vllm_config.model_config.hf_config
+    quant_config = vllm_config.quant_config
+    parallel_config = vllm_config.parallel_config
+    offload_config = getattr(vllm_config, "offload_config", None)
+    reasons = []
+
+    if not current_platform.is_rocm() or not on_gfx950():
+        reasons.append("the device is not ROCm gfx950")
+    if not rocm_aiter_ops.is_fusion_moe_shared_experts_enabled():
+        reasons.append("AITER fused MoE and/or shared expert fusion is not enabled")
+    if not rocm_aiter_ops.fused_moe_supports_heterogeneous_shared_expert():
+        reasons.append("AITER does not support heterogeneous shared experts")
+    if vllm_config.kernel_config.moe_backend != "aiter":
+        reasons.append("the MoE backend is not AITER")
+    if getattr(parallel_config, "tensor_parallel_size", None) != 8:
+        reasons.append("tensor parallelism is not the validated TP=8 layout")
+    if getattr(parallel_config, "enable_expert_parallel", False):
+        reasons.append("expert parallelism is enabled")
+    if getattr(parallel_config, "enable_eplb", False):
+        reasons.append("EPLB is enabled")
+    if offload_config is not None and (
+        getattr(getattr(offload_config, "uva", None), "cpu_offload_gb", 0) > 0
+        or getattr(getattr(offload_config, "prefetch", None), "offload_group_size", 0)
+        > 0
+    ):
+        reasons.append("weight offloading is enabled")
+    if getattr(config, "n_routed_experts", None) != 384:
+        reasons.append("the model does not have 384 routed experts")
+    if getattr(config, "hidden_size", None) != 7168:
+        reasons.append("the model hidden size is not 7168")
+    if getattr(config, "moe_intermediate_size", None) != 3072:
+        reasons.append("the model MoE intermediate size is not 3072")
+    if getattr(config, "num_experts_per_tok", None) != 6:
+        reasons.append("the model does not route to 6 experts per token")
+    if getattr(config, "n_shared_experts", None) != 1:
+        reasons.append("the model does not have exactly one shared expert")
+    if getattr(config, "expert_dtype", None) != "fp4":
+        reasons.append("routed experts are not FP4")
+    if getattr(config, "hidden_act", None) != "silu":
+        reasons.append("the model activation is not SiLU")
+    if getattr(vllm_config.model_config, "dtype", None) != torch.bfloat16:
+        reasons.append("the model dtype is not BF16")
+    if quant_config is None or quant_config.get_name() != "deepseek_v4_fp8":
+        reasons.append("the DeepSeek V4 FP8 quantization config is not active")
+    else:
+        if getattr(quant_config, "moe_quant_algo", "").upper() == "NVFP4":
+            reasons.append("routed experts use NVFP4 instead of MXFP4")
+        if getattr(quant_config, "weight_block_size", None) != [128, 128]:
+            reasons.append("shared experts are not 128x128 block FP8")
+        if not getattr(quant_config, "is_checkpoint_fp8_serialized", False):
+            reasons.append("shared experts are not serialized as FP8")
+        if not getattr(quant_config, "is_scale_e8m0", False):
+            reasons.append("shared-expert scales are not E8M0")
+        if getattr(quant_config, "ignored_layers", None):
+            reasons.append("the quantization config has ignored layers")
+
+    if reasons:
+        logger.debug_once(
+            "DeepSeek V4 shared-expert fusion is unavailable: %s. Using the "
+            "separate shared MLP.",
+            "; ".join(reasons),
+        )
+        return False
+
+    logger.info_once(
+        "Fusing the DeepSeek V4 native-FP8 shared expert into AITER MoE "
+        "(semantic top-k=6; internal E=385, top-k=7)."
+    )
+    return True
+
+
+@torch.no_grad()
+def _pad_and_expand_native_fp8_shared_expert(
+    w13: torch.Tensor,
+    w2: torch.Tensor,
+    w13_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    padded_intermediate_size: int,
+    block_size: tuple[int, int] = (128, 128),
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pad native FP8 weights and losslessly expand E8M0 scales to 1x32."""
+    block_n, block_k = block_size
+    if w13.dtype != torch.float8_e4m3fn or w2.dtype != torch.float8_e4m3fn:
+        raise ValueError("Heterogeneous shared-expert weights must be FP8 E4M3.")
+    if w13.ndim != 2 or w2.ndim != 2:
+        raise ValueError("Heterogeneous shared-expert weights must be 2D.")
+
+    native_intermediate, hidden_size = w13.shape[0] // 2, w13.shape[1]
+    if w13.shape[0] != 2 * native_intermediate or w2.shape != (
+        hidden_size,
+        native_intermediate,
+    ):
+        raise ValueError("Shared gate/up and down projection shapes do not match.")
+    if (
+        native_intermediate % block_n
+        or hidden_size % block_k
+        or padded_intermediate_size < native_intermediate
+        or padded_intermediate_size % block_n
+    ):
+        raise ValueError("Shared-expert dimensions are incompatible with 128x128 FP8.")
+
+    def scale_bytes(scale: torch.Tensor) -> torch.Tensor:
+        if scale.dtype == torch.float8_e8m0fnu:
+            return scale.contiguous().view(torch.uint8)
+        if scale.dtype == torch.uint8:
+            return scale.contiguous()
+        raise ValueError("Heterogeneous shared-expert scales must be E8M0 bytes.")
+
+    w13_scale_bytes = scale_bytes(w13_scale)
+    w2_scale_bytes = scale_bytes(w2_scale)
+    expected_w13_scale_shape = (
+        2 * native_intermediate // block_n,
+        hidden_size // block_k,
+    )
+    expected_w2_scale_shape = (
+        hidden_size // block_n,
+        native_intermediate // block_k,
+    )
+    if w13_scale_bytes.shape != expected_w13_scale_shape:
+        raise ValueError(
+            f"Expected shared W13 scale shape {expected_w13_scale_shape}, got "
+            f"{tuple(w13_scale_bytes.shape)}."
+        )
+    if w2_scale_bytes.shape != expected_w2_scale_shape:
+        raise ValueError(
+            f"Expected shared W2 scale shape {expected_w2_scale_shape}, got "
+            f"{tuple(w2_scale_bytes.shape)}."
+        )
+
+    padded_w13 = w13.new_zeros((2 * padded_intermediate_size, hidden_size))
+    padded_w13[:native_intermediate].copy_(w13[:native_intermediate])
+    padded_w13[
+        padded_intermediate_size : padded_intermediate_size + native_intermediate
+    ].copy_(w13[native_intermediate:])
+    padded_w2 = w2.new_zeros((hidden_size, padded_intermediate_size))
+    padded_w2[:, :native_intermediate].copy_(w2)
+
+    scale_k_expansion = block_k // 32
+    native_gate_scale, native_up_scale = w13_scale_bytes.chunk(2, dim=0)
+    native_gate_scale = native_gate_scale.repeat_interleave(block_n, dim=0)
+    native_gate_scale = native_gate_scale.repeat_interleave(scale_k_expansion, dim=1)
+    native_up_scale = native_up_scale.repeat_interleave(block_n, dim=0)
+    native_up_scale = native_up_scale.repeat_interleave(scale_k_expansion, dim=1)
+    native_w2_scale = w2_scale_bytes.repeat_interleave(block_n, dim=0)
+    native_w2_scale = native_w2_scale.repeat_interleave(scale_k_expansion, dim=1)
+
+    neutral_e8m0 = 0x7F
+    padded_w13_scale = torch.full(
+        (2 * padded_intermediate_size, hidden_size // 32),
+        neutral_e8m0,
+        dtype=torch.uint8,
+        device=w13.device,
+    )
+    padded_w13_scale[:native_intermediate].copy_(native_gate_scale)
+    padded_w13_scale[
+        padded_intermediate_size : padded_intermediate_size + native_intermediate
+    ].copy_(native_up_scale)
+    padded_w2_scale = torch.full(
+        (hidden_size, padded_intermediate_size // 32),
+        neutral_e8m0,
+        dtype=torch.uint8,
+        device=w2.device,
+    )
+    padded_w2_scale[:, : native_intermediate // 32].copy_(native_w2_scale)
+
+    return (
+        padded_w13.unsqueeze(0),
+        padded_w2.unsqueeze(0),
+        padded_w13_scale.view(torch.float8_e8m0fnu),
+        padded_w2_scale.view(torch.float8_e8m0fnu),
+    )
+
+
+class DeepseekV4HeterogeneousMxfp4MoEMethod(Mxfp4MoEMethod):
+    def process_weights_after_loading(self, layer: RoutedExperts) -> None:
+        super().process_weights_after_loading(layer)
+        assert isinstance(layer, DeepseekV4HeterogeneousSharedRoutedExperts)
+        layer.prepare_heterogeneous_shared_expert()
+
+
+class DeepseekV4HeterogeneousSharedRoutedExperts(RoutedExperts):
+    def __init__(
+        self,
+        *args,
+        shared_expert: "DeepseekV4MLP",
+        shared_expert_id: int,
+        **kwargs,
+    ):
+        self._shared_expert_ref = weakref.ref(shared_expert)
+        self.shared_expert_id = shared_expert_id
+        super().__init__(*args, **kwargs)
+        if self.expert_map_manager.num_fused_shared_experts != 1:
+            raise ValueError(
+                "DeepSeek V4 heterogeneous fusion requires one appended expert."
+            )
+        if self.shared_expert_id != self.global_num_experts:
+            raise ValueError(
+                "The shared expert ID must name the appended dummy routed row."
+            )
+        self.register_buffer("shared_w1", None, persistent=False)
+        self.register_buffer("shared_w2", None, persistent=False)
+        self.register_buffer("shared_w1_scale", None, persistent=False)
+        self.register_buffer("shared_w2_scale", None, persistent=False)
+
+    def _get_quant_method(self, prefix, quant_config, moe_config):
+        quant_method = super()._get_quant_method(prefix, quant_config, moe_config)
+        if not isinstance(quant_method, Mxfp4MoEMethod):
+            raise ValueError(
+                "DeepSeek V4 heterogeneous fusion requires MXFP4 routed experts."
+            )
+        return DeepseekV4HeterogeneousMxfp4MoEMethod(moe_config)
+
+    @torch.no_grad()
+    def prepare_heterogeneous_shared_expert(self) -> None:
+        shared_expert = self._shared_expert_ref()
+        if shared_expert is None:
+            raise RuntimeError("The native shared-expert module was released.")
+
+        shared_w1, shared_w2, shared_w1_scale, shared_w2_scale = (
+            _pad_and_expand_native_fp8_shared_expert(
+                shared_expert.gate_up_proj.weight,
+                shared_expert.down_proj.weight,
+                shared_expert.gate_up_proj.weight_scale_inv,
+                shared_expert.down_proj.weight_scale_inv,
+                self.moe_config.intermediate_size_per_partition,
+            )
+        )
+        self.shared_w1 = rocm_aiter_ops.shuffle_weight_a16w4(shared_w1, 16, True)
+        self.shared_w1_scale = rocm_aiter_ops.shuffle_scale_a16w4(
+            shared_w1_scale, 1, True
+        )
+        self.shared_w2 = rocm_aiter_ops.shuffle_weight_a16w4(shared_w2, 16, False)
+        self.shared_w2_scale = rocm_aiter_ops.shuffle_scale(shared_w2_scale)
+
+    def forward_modular(
+        self,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts=None,
+        shared_experts_input: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if shared_experts is not None or shared_experts_input is not None:
+            raise ValueError("The heterogeneous kernel owns the shared-expert path.")
+        if any(
+            tensor is None
+            for tensor in (
+                self.shared_w1,
+                self.shared_w2,
+                self.shared_w1_scale,
+                self.shared_w2_scale,
+            )
+        ):
+            raise RuntimeError(
+                "Heterogeneous shared-expert weights were not prepared after loading."
+            )
+
+        self._ensure_moe_quant_config_init()
+        quant_config = self.quant_method.moe_quant_config
+        if quant_config is None:
+            raise RuntimeError("The routed MXFP4 quantization config is unavailable.")
+        return rocm_aiter_fused_experts(
+            hidden_states=x,
+            w1=self.w13_weight,
+            w2=self.w2_weight,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            moe_config=self.moe_config,
+            activation=self.activation,
+            apply_router_weight_on_input=False,
+            expert_map=self.expert_map,
+            quant_config=quant_config,
+            output_dtype=x.dtype,
+            moe_sorting_dispatch_policy=rocm_aiter_ops.get_moe_dispatch_policy(),
+            shared_w1=self.shared_w1,
+            shared_w2=self.shared_w2,
+            shared_w1_scale=self.shared_w1_scale,
+            shared_w2_scale=self.shared_w2_scale,
+            shared_expert_id=self.shared_expert_id,
+        )
 
 
 class DeepseekV4MLP(nn.Module):
@@ -161,6 +455,7 @@ class DeepseekV4MoE(nn.Module):
         self,
         vllm_config: VllmConfig,
         prefix: str = "",
+        fuse_heterogeneous_shared_expert: bool = False,
     ):
         super().__init__()
 
@@ -213,6 +508,12 @@ class DeepseekV4MoE(nn.Module):
         self.n_shared_experts = config.n_shared_experts
 
         self.fuse_shared_experts = _fuse_shared_experts_enabled(config, prefix)
+        # The heterogeneous path absorbs a native-FP8 shared MLP after loading and
+        # so needs that module to stay materialized, which the same-precision MXFP4
+        # fusion below does not. The two never apply to the same checkpoint.
+        self.fuse_heterogeneous_shared_expert = (
+            fuse_heterogeneous_shared_expert and not self.fuse_shared_experts
+        )
 
         if config.n_shared_experts is None or self.fuse_shared_experts:
             self.shared_experts = None
@@ -237,9 +538,13 @@ class DeepseekV4MoE(nn.Module):
         self.experts_end_idx = self.experts_start_idx + self.n_local_experts
 
         self.experts = FusedMoE(
-            shared_experts=self.shared_experts,
+            shared_experts=(
+                None if self.fuse_heterogeneous_shared_expert else self.shared_experts
+            ),
             n_shared_experts=(
-                config.n_shared_experts if self.fuse_shared_experts else None
+                config.n_shared_experts
+                if self.fuse_shared_experts or self.fuse_heterogeneous_shared_expert
+                else None
             ),
             gate=self.gate,
             num_experts=config.n_routed_experts,
@@ -255,6 +560,19 @@ class DeepseekV4MoE(nn.Module):
             hash_indices_table=self.gate.tid2eid,
             swiglu_limit=self.swiglu_limit,
             router_logits_dtype=torch.float32,
+            routed_experts_cls=(
+                DeepseekV4HeterogeneousSharedRoutedExperts
+                if self.fuse_heterogeneous_shared_expert
+                else None
+            ),
+            routed_experts_args=(
+                {
+                    "shared_expert": self.shared_experts,
+                    "shared_expert_id": config.n_routed_experts,
+                }
+                if self.fuse_heterogeneous_shared_expert
+                else None
+            ),
         )
 
     def forward(
@@ -289,6 +607,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         prefix,
         topk_indices_buffer: torch.Tensor | None = None,
         aux_stream_list: list[torch.cuda.Stream] | None = None,
+        fuse_heterogeneous_shared_expert: bool = False,
     ):
         super().__init__()
 
@@ -306,7 +625,11 @@ class DeepseekV4DecoderLayer(nn.Module):
             topk_indices_buffer=topk_indices_buffer,
             aux_stream_list=aux_stream_list,
         )
-        self.ffn = DeepseekV4MoE(vllm_config, prefix=f"{prefix}.ffn")
+        self.ffn = DeepseekV4MoE(
+            vllm_config,
+            prefix=f"{prefix}.ffn",
+            fuse_heterogeneous_shared_expert=fuse_heterogeneous_shared_expert,
+        )
 
         self.attn_norm = RMSNorm(self.hidden_size, self.rms_norm_eps)
         self.ffn_norm = RMSNorm(self.hidden_size, self.rms_norm_eps)
@@ -506,6 +829,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         self.hc_mult = config.hc_mult
         self.hc_dim = self.hc_mult * config.hidden_size
         self.rms_norm_eps = config.rms_norm_eps
+        self.fuse_heterogeneous_shared_expert = _should_fuse_shared_expert(vllm_config)
 
         # Three aux streams: one per non-default input GEMM in
         # DeepseekV4Attention.attn_gemm_parallel_execute
@@ -544,6 +868,9 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 prefix=prefix,
                 topk_indices_buffer=self.topk_indices_buffer,
                 aux_stream_list=aux_stream_list,
+                fuse_heterogeneous_shared_expert=(
+                    self.fuse_heterogeneous_shared_expert
+                ),
             ),
             prefix=f"{prefix}.layers",
         )

--- a/vllm/models/deepseek_v4/amd/model.py
+++ b/vllm/models/deepseek_v4/amd/model.py
@@ -71,6 +71,26 @@ from vllm.sequence import IntermediateTensors
 logger = init_logger(__name__)
 
 
+def _shared_expert_fusion_possible(config, parallel_config=None) -> bool:
+    """Preconditions common to every shared-expert fusion path.
+
+    These decide *whether* the shared expert may be folded into the routed
+    grouped GEMM at all. Which kernel then takes it depends on its precision:
+    ``_should_fuse_shared_expert`` for a native-FP8 shared expert (preferred,
+    heterogeneous AITER) and ``_fuse_shared_experts_enabled`` for a
+    same-precision MXFP4 one.
+    """
+    if not (
+        current_platform.is_rocm()
+        and getattr(config, "n_shared_experts", None)
+        and envs.VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS
+    ):
+        return False
+    if parallel_config is None:
+        parallel_config = get_current_vllm_config().parallel_config
+    return not parallel_config.enable_expert_parallel
+
+
 def _should_fuse_shared_expert(vllm_config: VllmConfig) -> bool:
     config = vllm_config.model_config.hf_config
     quant_config = vllm_config.quant_config
@@ -78,6 +98,11 @@ def _should_fuse_shared_expert(vllm_config: VllmConfig) -> bool:
     offload_config = getattr(vllm_config, "offload_config", None)
     reasons = []
 
+    if not _shared_expert_fusion_possible(config, parallel_config):
+        reasons.append(
+            "shared-expert fusion is off (needs ROCm, a shared expert, "
+            "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1, and no expert parallelism)"
+        )
     if not current_platform.is_rocm() or not on_gfx950():
         reasons.append("the device is not ROCm gfx950")
     if not rocm_aiter_ops.is_fusion_moe_shared_experts_enabled():
@@ -88,8 +113,6 @@ def _should_fuse_shared_expert(vllm_config: VllmConfig) -> bool:
         reasons.append("the MoE backend is not AITER")
     if getattr(parallel_config, "tensor_parallel_size", None) != 8:
         reasons.append("tensor parallelism is not the validated TP=8 layout")
-    if getattr(parallel_config, "enable_expert_parallel", False):
-        reasons.append("expert parallelism is enabled")
     if getattr(parallel_config, "enable_eplb", False):
         reasons.append("EPLB is enabled")
     if offload_config is not None and (
@@ -438,12 +461,7 @@ def _fuse_shared_experts_enabled(config, prefix: str = "") -> bool:
     routed experts. Some layers may carry a shared expert in a different quantization
     than the routed experts; when so, it runs as its own linear and must not be fused.
     """
-    if not (
-        current_platform.is_rocm()
-        and getattr(config, "n_shared_experts", None)
-        and envs.VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS
-        and not get_current_vllm_config().parallel_config.enable_expert_parallel
-    ):
+    if not _shared_expert_fusion_possible(config):
         return False
     return _shared_experts_are_fp4(
         config, extract_layer_index(prefix) if prefix else None
@@ -507,12 +525,18 @@ class DeepseekV4MoE(nn.Module):
 
         self.n_shared_experts = config.n_shared_experts
 
+        # The checkpoint picks the kernel. An MXFP4 shared expert matches the
+        # routed experts and folds into the normal fused MoE, which redirects its
+        # weights into a routed slot at load time. A native-FP8 shared expert
+        # alongside MXFP4 routed experts instead needs the heterogeneous AITER
+        # kernel, which keeps the shared MLP and absorbs it after loading.
         self.fuse_shared_experts = _fuse_shared_experts_enabled(config, prefix)
-        # The heterogeneous path absorbs a native-FP8 shared MLP after loading and
-        # so needs that module to stay materialized, which the same-precision MXFP4
-        # fusion below does not. The two never apply to the same checkpoint.
         self.fuse_heterogeneous_shared_expert = (
             fuse_heterogeneous_shared_expert and not self.fuse_shared_experts
+        )
+        # Either path appends the shared expert as a slot in the grouped GEMM.
+        fuse_shared_into_routed = (
+            self.fuse_shared_experts or self.fuse_heterogeneous_shared_expert
         )
 
         if config.n_shared_experts is None or self.fuse_shared_experts:
@@ -538,13 +562,9 @@ class DeepseekV4MoE(nn.Module):
         self.experts_end_idx = self.experts_start_idx + self.n_local_experts
 
         self.experts = FusedMoE(
-            shared_experts=(
-                None if self.fuse_heterogeneous_shared_expert else self.shared_experts
-            ),
+            shared_experts=None if fuse_shared_into_routed else self.shared_experts,
             n_shared_experts=(
-                config.n_shared_experts
-                if self.fuse_shared_experts or self.fuse_heterogeneous_shared_expert
-                else None
+                config.n_shared_experts if fuse_shared_into_routed else None
             ),
             gate=self.gate,
             num_experts=config.n_routed_experts,


### PR DESCRIPTION
## Summary

Enable the native DeepSeek-V4 shared expert to use AITER's heterogeneous fused-shared-expert kernel on ROCm gfx950.

The checkpoint stores 384 routed experts as MXFP4 but stores the shared expert as serialized FP8 E4M3 with 128x128 E8M0 scales. This change keeps both formats intact:

- retain the native shared-expert FP8 weights instead of converting them to MXFP4;
- losslessly expand the 128x128 E8M0 scale grid to the kernel's per-32 layout and pad the intermediate dimension with neutral zero blocks;
- append semantic expert 384 to the top-k metadata while passing its FP8 weights and scales separately from the MXFP4 routed tensors;
- thread the heterogeneous contract through the existing AITER custom-op and fused-MoE adapters without changing the existing float custom-op ABI; and
- fall back to the separate shared MLP when the installed AITER does not expose the heterogeneous interface or any validated configuration guard is not met.

The current PR head is `c1005d4d4` on current upstream `main`. The series changes five paths: three implementation files and two focused test files.

## Why this replaces the previous implementation

The previous version of #48728 dequantized every native FP8 shared-expert matrix and requantized it to MXFP4 before appending it. Real-weight measurements showed about 12% relative-L2 reconstruction error, and the full 20-shot GSM8K run exposed a generation-quality/extraction regression. Matching AITER's MXFP4 quantizer did not recover the accuracy.

The heterogeneous kernel in ROCm/aiter#4269 removes that conversion. Routed experts remain MXFP4 and the shared expert remains FP8 within one fused stage-1/stage-2 schedule, preserving native precision without giving up the FSE performance path.

## Enablement and fallback

The optimization requires all of the following:

- ROCm gfx950;
- an AITER version containing ROCm/aiter#4269;
- AITER MoE plus `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1`;
- TP=8 with no EP, EPLB, or weight offload;
- DeepSeek-V4's validated 384-routed-expert, top-k=6, one-shared-expert geometry;
- MXFP4 routed experts and serialized 128x128 block-FP8/E8M0 shared weights; and
- BF16 SiLU model execution through the AITER MoE backend.

If any guard fails, vLLM logs the reason at debug level and keeps the existing separate shared-expert MLP. A signature capability probe also prevents an older AITER installation from receiving the new arguments.

This PR remains Draft until the AITER dependency is accepted and available.

## Existing work and duplicate check

Required open-PR searches were run for `DeepSeek V4 heterogeneous shared expert AITER`, `FP8 MXFP4 fused shared expert`, and `DeepSeek V4 FSE ROCm`. No separate heterogeneous-FSE enablement PR exists. The only direct duplicate was this already-open #48728, so it was updated in place rather than opening a second PR.

vllm-project/vllm#48044 overlaps in DeepSeek-V4 shared-expert model wiring but targets AMD-Quark checkpoints whose shared expert is already MXFP4. This PR targets the native checkpoint whose shared expert is FP8 and now requires format-heterogeneous execution. The two changes must be reconciled if #48044 merges first; #48728 remains a coordinated follow-up rather than an independent competing implementation. No issue number was supplied, so the issue-specific duplicate lookup was not applicable.

## Accuracy

Post-fix validation at `c1005d4d4` used DeepSeek-V4-Pro TP8 with AITER
`0.1.20.dev13+gd5821d95e.d20260730`, all **1,319 GSM8K samples**,
20-shot prompts, concurrency 64, and temperature 0:

| Metric | Result |
|---|---:|
| Strict exact match | 1273/1319 (`0.965125 ± 0.005053`) |
| Flexible extract | 1272/1319 (`0.964367 ± 0.005106`) |

The strict score passes the 94% acceptance threshold and is two correct samples
above the directly comparable prior 20-shot run. All 1,319 API requests returned
HTTP 200, with no E8M0-scale, worker, or ROCm errors.

## 8K-input / 1K-output serving performance

Post-fix validation at `c1005d4d4` used DeepSeek-V4-Pro on 8x gfx950,
TP=8, random inputs at the harness's 0.8 input-length ratio, 1K requested output,
10 measured prompts per concurrency, and 2 warmup prompts per concurrency:

| Concurrency | Completed | Output tok/s | Total tok/s | Mean TTFT (ms) | Mean TPOT (ms) | Duration (s) |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 10/10 | 62.08 | 555.69 | 416.05 | 15.68 | 149.86 |
| 4 | 40/40 | 206.01 | 1851.93 | 490.66 | 18.43 | 178.65 |
| 8 | 80/80 | 373.83 | 3325.38 | 571.50 | 20.37 | 198.14 |
| 16 | 160/160 | 591.44 | 5337.61 | 745.25 | 25.37 | 247.58 |
| 32 | 320/320 | 867.49 | 7757.40 | 1263.79 | 34.57 | 341.38 |
| 64 | 640/640 | 1095.70 | 9876.42 | 1841.94 | 55.48 | 538.40 |

At concurrency 4, output throughput was 16.9% above the strongest directly
comparable recent local result (176.23 tok/s), while mean TPOT was 14.7% below
the best comparable result (21.599 ms).

Because AITER was intentionally installed with `PREBUILD_KERNELS=0`, the first
concurrency-32 attempt triggered a one-time CKTile build during measurement and
exceeded vLLM's 300-second model-RPC timeout. That cold attempt was discarded
(145/320 completed). After the JIT artifact finished building outside the server,
concurrency 32 and 64 were rerun from a clean server and completed 320/320 and
640/640. The final server log contained 1,153 HTTP 200 responses and no scale,
worker, ROCm, timeout, or HTTP 500 errors.

## Tests

Focused tests were rerun after replaying the unchanged patch onto current upstream `main`:

```bash
.venv/bin/python -m pytest \
  tests/models/test_deepseek_v4_amd_moe.py \
  tests/kernels/moe/test_topk_softplus_sqrt.py::test_sqrtsoftplus_bias_uses_deepseek_v4_routing_method \
  tests/kernels/moe/test_topk_softplus_sqrt.py::test_deepseek_v4_fused_shared_expert_is_appended_after_routing \
  tests/kernels/moe/test_topk_softplus_sqrt.py::test_shared_expert_count_preserves_aiter_and_backend_neutral_gates \
  -v
```

Result: **47 passed**.

```bash
.venv/bin/pre-commit run --files \
  tests/kernels/moe/test_topk_softplus_sqrt.py \
  tests/models/test_deepseek_v4_amd_moe.py \
  vllm/_aiter_ops.py \
  vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py \
  vllm/models/deepseek_v4/amd/model.py
```

Result: **all changed-file hooks passed**, including Ruff, formatting, mypy, SPDX, import, configuration, and ROCm API guards. `git diff --check upstream/main...HEAD` also passed.

## Stability scope

During follow-up stress triage, a two-wave high-concurrency GPU memory fault was reproduced on the pre-FSE vLLM parent with official AITER `v0.1.16.post3`, FSE absent, and custom all-reduce disabled (PYNCCL). Wave 1 completed 64/64 requests and wave 2 faulted. That baseline issue is independent of this patch and is tracked in Fangzhou-Ai/vllm#13; it is not presented as an FSE regression or as something this PR fixes.

## AI assistance disclosure

OpenAI Codex assisted with implementation, rebase, test execution, evaluation analysis, and drafting this description. The human submitter reviewed every changed line and is responsible for understanding and defending the change end-to-end.
