### PR TITLE
[Bugfix][GLM4V] Fix video dummy profiling and memory usage

### DIFF
--- a/tests/models/multimodal/processing/test_glm4_1v.py
+++ b/tests/models/multimodal/processing/test_glm4_1v.py
@@ -1,14 +1,66 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from unittest.mock import Mock
+
 import pytest
 
 from vllm.assets.video import VideoAsset
+from vllm.model_executor.models.glm4_1v import (
+    Glm4vForConditionalGeneration,
+    Glm4vProcessingInfo,
+)
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import batched_tensors_equal
 from vllm.multimodal.video import DynamicVideoBackend, VideoBackend
 
 from ...utils import build_model_context
+
+
+@pytest.mark.parametrize(
+    (
+        "max_video_pixels",
+        "max_tokens",
+        "expected_num_frames",
+    ),
+    [
+        (47_040_000, 124_988, 11),
+        (47_040_000, 30_000, 24),
+        (100_352_000, 124_988, 21),
+        (100_352_000, 30_000, 7),
+        (100_352_000, 0, 1),
+    ],
+)
+def test_get_max_video_frames_matches_glm_resize(
+    max_video_pixels: int,
+    max_tokens: int,
+    expected_num_frames: int,
+):
+    info = Mock(spec=Glm4vProcessingInfo)
+    info.get_image_size_with_most_features.return_value = (2184, 2184)
+    info._get_video_max_pixels.return_value = max_video_pixels
+    vision_config = info.get_hf_config.return_value.vision_config
+    vision_config.patch_size = 14
+    vision_config.spatial_merge_size = 2
+    vision_config.temporal_patch_size = 2
+    info._get_vision_info.side_effect = lambda **kwargs: (
+        Glm4vProcessingInfo._get_vision_info(info, **kwargs)
+    )
+
+    num_frames = Glm4vProcessingInfo._get_max_video_frames(
+        info,
+        max_tokens=max_tokens,
+    )
+
+    assert num_frames == expected_num_frames
+    assert info._get_video_max_pixels.call_count == 1
+    assert info._get_vision_info.call_count == 600
+
+
+def test_encoder_cudagraph_uses_model_video_frame_limit():
+    model = Mock()
+
+    assert Glm4vForConditionalGeneration.get_max_frames_per_video(model) == 600
 
 
 @pytest.mark.parametrize("model_id", ["zai-org/GLM-4.1V-9B-Thinking"])

--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -40,6 +40,7 @@ import transformers
 from einops import rearrange
 from packaging.version import Version
 from transformers import BatchFeature, Glm4vProcessor
+from transformers.image_processing_base import ImageProcessingMixin
 from transformers.models.glm4v.configuration_glm4v import (
     Glm4vTextConfig,
     Glm4vVisionConfig,
@@ -49,6 +50,7 @@ from transformers.models.glm4v.image_processing_glm4v import (
     smart_resize,
 )
 from transformers.models.glm4v.video_processing_glm4v import Glm4vVideoProcessor
+from transformers.video_processing_utils import BaseVideoProcessor
 from transformers.video_utils import VideoMetadata
 
 from vllm.config import VllmConfig
@@ -94,6 +96,8 @@ from vllm.multimodal.processing import (
     PromptUpdateDetails,
 )
 from vllm.sequence import IntermediateTensors
+from vllm.transformers_utils.processor import get_processor_cls_name_from_config
+from vllm.transformers_utils.utils import convert_model_repo_to_path
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.worker.encoder_cudagraph_defs import EncoderCudaGraphReplayBuffers
@@ -982,11 +986,6 @@ class Glm4vProcessingInfo(BaseProcessingInfo):
         return self.get_hf_processor(**kwargs).video_processor
 
     def _get_processor_class_name(self) -> str | None:
-        from vllm.transformers_utils.processor import (
-            get_processor_cls_name_from_config,
-        )
-        from vllm.transformers_utils.utils import convert_model_repo_to_path
-
         return get_processor_cls_name_from_config(
             convert_model_repo_to_path(self.ctx.model_config.model),
             revision=self.ctx.model_config.revision,
@@ -1109,8 +1108,6 @@ class Glm4vProcessingInfo(BaseProcessingInfo):
 
         image_processor_config = self.ctx.get_hf_image_processor_config()
         if not image_processor_config.get("size"):
-            from transformers.image_processing_base import ImageProcessingMixin
-
             image_processor_config, _ = ImageProcessingMixin.get_image_processor_dict(
                 self.ctx.model_config.model,
                 revision=self.ctx.model_config.revision,
@@ -1122,8 +1119,6 @@ class Glm4vProcessingInfo(BaseProcessingInfo):
         return self._get_longest_edge(size, "GLM4V image processor size")
 
     def _get_video_max_pixels(self) -> int:
-        from transformers.video_processing_utils import BaseVideoProcessor
-
         mm_kwargs = self.ctx.get_merged_mm_kwargs({})
         if (override_max_pixels := mm_kwargs.get("max_pixels")) is not None:
             return int(override_max_pixels)
@@ -1175,39 +1170,29 @@ class Glm4vProcessingInfo(BaseProcessingInfo):
             image_height=target_height,
         )
 
-    def get_num_video_tokens(
-        self,
-        *,
-        image_width: int,
-        image_height: int,
-        num_frames: int,
-    ) -> int:
-        _, num_video_tokens = self._get_vision_info(
-            image_width=image_width,
-            image_height=image_height,
-            num_frames=num_frames,
-            max_image_pixels=28 * 28 * 2 * 30000,
-        )
-        return num_video_tokens
-
     def _get_max_video_frames(self, max_tokens: int) -> int:
         target_width, target_height = self.get_image_size_with_most_features()
 
-        num_frames = 0
+        max_video_pixels = self._get_video_max_pixels()
+        num_frames_with_most_features = 1
+        max_vision_tokens = 0
 
-        while True:
-            next_num_frames = num_frames + 1
-            next_max_tokens = self.get_num_video_tokens(
+        for num_frames in range(1, _MAX_FRAMES_PER_VIDEO + 1):
+            _, num_vision_tokens = self._get_vision_info(
                 image_width=target_width,
                 image_height=target_height,
-                num_frames=next_num_frames,
+                num_frames=num_frames,
+                max_image_pixels=max_video_pixels,
             )
-            if next_max_tokens > max_tokens or next_max_tokens == 0:
-                break
 
-            num_frames = next_num_frames
+            if (
+                0 < num_vision_tokens <= max_tokens
+                and num_vision_tokens > max_vision_tokens
+            ):
+                num_frames_with_most_features = num_frames
+                max_vision_tokens = num_vision_tokens
 
-        return num_frames
+        return num_frames_with_most_features
 
     def get_num_frames_with_most_features(
         self,
@@ -1215,15 +1200,9 @@ class Glm4vProcessingInfo(BaseProcessingInfo):
         mm_counts: Mapping[str, int],
     ) -> int:
         max_images = mm_counts.get("image", 0)
-        max_videos = mm_counts.get("video", 0)
 
         max_image_tokens = self.get_max_image_tokens() * max_images
-        max_total_frames = self._get_max_video_frames(seq_len - max_image_tokens)
-        max_frames_per_video = min(
-            max_total_frames // max(max_videos, 1), _MAX_FRAMES_PER_VIDEO
-        )
-
-        return max(max_frames_per_video, 1)
+        return self._get_max_video_frames(seq_len - max_image_tokens)
 
     def _get_video_second_idx_glm4v(
         self, metadata: dict[str, Any], total_frames: int
@@ -2001,15 +1980,7 @@ class Glm4vForConditionalGeneration(
         raise AssertionError("This line should be unreachable.")
 
     def get_max_frames_per_video(self) -> int:
-        mm_registry = MULTIMODAL_REGISTRY
-        info = mm_registry.get_processing_info(self.model_config)
-        max_frames_per_video = info.get_num_frames_with_most_features(
-            seq_len=self.model_config.max_model_len,
-            mm_counts={"video": self.multimodal_config.get_limit_per_prompt("video")},
-        )
-        # Small 'max_frames_per_video' will cause 'tensor mismatch' in PR#43403
-        # 16 is the default 'num_frames' of '_get_vision_info'
-        return max(max_frames_per_video, 16)
+        return _MAX_FRAMES_PER_VIDEO
 
     def get_encoder_cudagraph_budget_range(
         self,


### PR DESCRIPTION
# [Bugfix][GLM4V] Fix video dummy profiling and memory usage

## Purpose

This PR fixes GLM4V video profiling during multimodal startup. It addresses an
unbounded frame search, incorrect selection on a non-monotonic token curve,
video pixel-budget mismatch, and excessive dummy video memory usage.

This follow-up was discovered while validating
[PR #47155](https://github.com/vllm-project/vllm/pull/47155). Startup was fast
when video inputs were disabled:

```bash
--limit-mm-per-prompt '{"image": 1, "video": 0}'
```

After enabling one video per prompt, APIServer multimodal warmup became much
slower and consumed substantially more host memory:

```bash
--limit-mm-per-prompt '{"image": 1, "video": 1}'
```

Tracing this difference exposed the unbounded `_get_max_video_frames` search
and the 600-frame dummy video allocation fixed by this PR. With `video: 0`, the
video dummy path is not exercised, so this issue remains hidden.

### Problem

The non-monotonic estimation happens in the vLLM
[`_get_vision_info()`](https://github.com/vllm-project/vllm/blob/v0.25.1/vllm/model_executor/models/glm4_1v.py#L1057-L1096)
path:

```text
_get_max_video_frames()
-> _get_vision_info(num_frames=...)
-> smart_resize(num_frames, height, width, ...)
-> grid_t * grid_h * grid_w / merge_size**2
```

For every candidate frame count, `_get_vision_info()` calls `smart_resize`.
Adding frames can reduce the resized height and width, so the calculated vision
token count can increase, remain unchanged, or decrease.

The resize formula is implemented at
[`image_processing_glm46v.py#L50-L83`](https://github.com/huggingface/transformers/blob/v5.13.1/src/transformers/models/glm46v/image_processing_glm46v.py#L50-L83).

The previous `_get_max_video_frames` implementation assumed monotonic growth
and stopped at the first token-budget violation. With the instrumented
configuration from the issue analysis:

```text
max_model_len:            131,072
image tokens:               6,084
remaining video tokens:   124,988
```

The old loop accepted frame 249,976, evaluated frame 249,977, observed 124,989
tokens, and stopped. The result was then capped to 600 frames. This performed
249,977 token estimations even though the supported profiling range ends at
600 frames.

The old frame result reached the allocation through this path:
[glm4_1v.py](https://github.com/vllm-project/vllm/blob/v0.25.1/vllm/model_executor/models/glm4_1v.py#L1499)
```text
BaseRenderer._warmup_mm_processor()
-> Glm4vDummyInputsBuilder.get_dummy_mm_data()
-> get_image_size_with_most_features()
-> _get_dummy_videos()
-> np.full((num_frames, width, height, 3), dtype=np.uint8)
```

`get_dummy_mm_data()` still used the maximum image width and height for the
dummy video. Therefore, before Hugging Face could run `smart_resize`, the old
result allocated the following full-size numpy array:

```text
shape:  (600, 2184, 2184, 3)
dtype:  uint8
size:   8,188 MiB
```

The measured process PSS increased from 764.93 MiB to 8,952.93 MiB, exactly
matching the 8,188 MiB numpy allocation. At allocation time, the height and
width were still the maximum `2184 x 2184`, rather than the resized dimensions.
GLM4V subsequently copied the video, which could temporarily increase the
single-video peak further.

Finally, the old estimation path hard-coded a 47,040,000-pixel video budget.
The local GLM-4.6V-Flash model config defines 100,352,000 pixels, which is what
the real Hugging Face video processor uses. This could make the estimate and
the resulting `video_grid_thw` disagree.

### Root cause

The previous implementation assumed that vision tokens grow monotonically with
the frame count. It also reused the dummy profiling frame count for encoder
CUDA Graph buffer sizing, although these values have different purposes for
GLM4V.

### Changes

This PR updates the GLM4V-specific path to:

1. Scan the bounded range from 1 through `_MAX_FRAMES_PER_VIDEO`.
2. Evaluate the complete range without assuming token monotonicity.
3. Select the feasible candidate with the most vision tokens.
4. Read the actual video pixel limit through `_get_video_max_pixels()` instead
   of using a hard-coded value.
5. Keep encoder CUDA Graph capacity independently at the existing vLLM cap of
   600 frames.
6. Move the metadata helper imports introduced by PR #47155 to module scope,
   completing the cleanup requested during that review.

The bounded scan performs 600 token estimations. A binary search is
intentionally not used because the token curve is not monotonic. The dummy
builder remains unchanged; its memory usage drops because profiling now
selects 21 frames instead of capping an unbounded result to 600.

### Before and after

Using the local GLM-4.6V-Flash configuration:

| Metric | Before | After |
| --- | ---: | ---: |
| Token estimations | 249,977 | 600 |
| Selected profiling frames | 600 after cap | 21 |
| Selected vision tokens | 58,800 at 600 frames | 66,924 at 21 frames |
| Dummy video shape | `600x2184x2184x3` | `21x2184x2184x3` |
| Dummy numpy size | 8,188 MiB | 286.58 MiB |

The dummy numpy allocation is reduced by approximately 96.5%. Encoder CUDA
Graph capacity remains 600 and no longer depends on the profiling candidate.

With the default 47,040,000-pixel Transformers budget, the corresponding
maximum-feature candidate is 11 frames, producing 31,974 vision tokens. The
unchanged dummy builder initially allocates 11 frames at 2184x2184, requiring
approximately 150.14 MiB, before Hugging Face resizes them to 2044x2044.

### Scope and compatibility

- The change is limited to GLM4V processing information and encoder CUDA Graph
  frame sizing.
- Hugging Face `smart_resize` behavior is unchanged.
- Model weights, vision encoder computation, sampling, and generated outputs
  are unchanged.
- The estimate now follows each model's video preprocessor configuration.
- GLM currently supports at most one video per prompt, so multi-video frame
  allocation is outside the supported input contract.
- Complete prompt overhead from frame boundaries and timestamp text remains
  outside this PR. The search keeps the previous vision-token budget semantics.

### Startup validation

The following measurements enable one image and one video per prompt with
`--limit-mm-per-prompt '{"image": 1, "video": 1}'`.

Repeated server startups produced stable profiling results before and after
the change:

| Model | Before | After | Consistent across calls |
| --- | --- | --- | --- |
| GLM-OCR | 2 calls, both 600 | 2 calls, both 3 | Yes |
| GLM-4.6V-Flash | 2 calls, both 600 | 2 calls, both 21 | Yes |
| GLM-4.1V-9B-Thinking | 5 calls, all 600 | 5 calls, all 11 | Yes |

Total APIServer multimodal processor warmup time (`Multi-modal` plus
`Readonly multi-modal`) was reduced for all three models:

```text
[base.py:236] Multi-modal warmup completed in <time>s
[base.py:236] Readonly multi-modal warmup completed in <time>s
```

These are the two Renderer startup warmups. The table reports their sum; it
does not include model loading, EngineCore profiling, or model execution.

| Model | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| GLM-OCR | 49.581 s | 5.597 s | 8.9x |
| GLM-4.6V-Flash | 65.505 s | 17.119 s | 3.8x |
| GLM-4.1V-9B-Thinking | 57.313 s | 15.866 s | 3.6x |

The selected frame count follows each model's configured video pixel limit:

| Model | Video pixel limit | Frames with most features |
| --- | ---: | ---: |
| GLM-OCR | 9,633,792 | 3 |
| GLM-4.1V-9B-Thinking | 47,040,000 | 11 |
| GLM-4.6V-Flash | 100,352,000 | 21 |

### Related PR

[PR #47155](https://github.com/vllm-project/vllm/pull/47155) avoids creating a
full Hugging Face processor when GLM4V startup paths only need metadata such as
`processor_class`, `size.longest_edge`, and token IDs. It reduces repeated
processor initialization in APIServer, EngineCore, and worker processes.

This PR addresses the next stage after that metadata is read. When video is
enabled, renderer warmup constructs and processes a dummy video. PR #47155 does
not change `_get_max_video_frames`, the selected dummy frame count, or the dummy
numpy allocation. This PR bounds that search, uses the video pixel limit read
through the configuration path introduced by #47155, and selects the
maximum-feature candidate within the supported 600-frame range.

It also completes a review follow-up from PR #47155 by moving its metadata
helper imports to module scope. This is an import-only cleanup with no runtime
behavior change.

Moving these four imports to module scope does not introduce noticeable
startup overhead. At this point, the related Transformers and vLLM modules
have already been imported, and these imports do not initialize the full
Hugging Face processor. A local incremental measurement showed approximately
0.020-0.026 seconds additional time and 0.16 MiB additional PSS. Therefore,
moving them to the file header has very small time and memory cost.

The two changes are therefore complementary:

- With `video: 0`, PR #47155 removes unnecessary processor initialization and
  the video dummy path is skipped.
- With `video: 1`, this PR prevents the video warmup path from performing about
  250,000 estimations and allocating a 600-frame dummy video.

## Test Plan

Add focused unit coverage for:

1. A non-monotonic token curve with a later feasible candidate.
2. Selecting the maximum-vision-token candidate rather than the largest frame
   count.
3. Reading both 47,040,000- and 100,352,000-pixel video configurations.
4. Keeping encoder CUDA Graph capacity at 600 frames.
5. Matching the GLM resize curve for both large and constrained budgets.

Commands run:

```bash
python -m pytest \
  tests/models/multimodal/processing/test_glm4_1v.py -v

pre-commit run ruff-check --files \
  vllm/model_executor/models/glm4_1v.py \
  tests/models/multimodal/processing/test_glm4_1v.py

pre-commit run ruff-format --files \
  vllm/model_executor/models/glm4_1v.py \
  tests/models/multimodal/processing/test_glm4_1v.py
```

The local model configuration was also used to call the profiling method and
construct dummy data without running model inference. The observed result was:

```text
frames=21
size=ImageSize(width=2184, height=2184)
max_video_pixels=100352000
tokens=66924
dummy shape=(21, 2184, 2184, 3)
dummy size=286.58 MiB
```

The constrained 30,000 vision-token regression cases select 24 frames with the
47,040,000-pixel configuration and 7 frames with the 100,352,000-pixel
configuration. These cases verify the non-monotonic scan only; they do not
claim that the complete text prompt fits within 30,000 tokens.

Model evaluation is not applicable because the change affects dummy input
sizing and startup budget estimation only. It does not change inference
computation or model outputs.


Moving these four imports to module scope does not introduce noticeable
startup overhead. 
``` python
import os,time

import psutil
from transformers import BatchFeature, Glm4vProcessor
from transformers.models.glm4v.configuration_glm4v import (
    Glm4vTextConfig,
    Glm4vVisionConfig,
)
from transformers.models.glm4v.image_processing_glm4v import Glm4vImageProcessor, smart_resize
from transformers.models.glm4v.video_processing_glm4v import Glm4vVideoProcessor
from transformers.video_utils import VideoMetadata

from vllm.config import VllmConfig

def pss_mb() -> float:
    return psutil.Process(os.getpid()).memory_full_info().pss / 1024**2

def main() -> None:
    
    t0 = time.time()
    pss0 = pss_mb()
    from transformers.image_processing_base import ImageProcessingMixin
    from transformers.video_processing_utils import BaseVideoProcessor
    from vllm.transformers_utils.processor import get_processor_cls_name_from_config
    from vllm.transformers_utils.utils import convert_model_repo_to_path
    pss1 = pss_mb()
    t1 = time.time()
    print(f'time use:{t1-t0}  pass:{pss1-pss0}')
    # time use:0.0210111141204834  pass:0.15625

if __name__ == "__main__":
    main()

```


## Test Result

```text
Focused regression tests: 6 passed
Full test file: 14 passed
```

```text
ruff check       Passed
ruff format      Passed
git diff --check Passed
```

## AI assistance disclosure

AI assistance was used to analyze the issue, prepare the implementation, add
the focused tests, and draft this PR description. The human submitter must
review and understand every changed line before submitting the PR.
