### PR TITLE
[Feature] Add env-gated Kimi K2 agentic validations

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -32,6 +32,9 @@ from vllm.entrypoints.openai.chat_completion.serving import (
     _make_prompt_tokens_details,
 )
 from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
     ErrorResponse,
     FunctionCall,
     RequestResponseMetadata,
@@ -819,6 +822,26 @@ def _make_metrics_request_output(
     )
 
 
+def _make_tool_stream_request_output() -> RequestOutput:
+    return RequestOutput(
+        request_id="test-id",
+        prompt="Test prompt",
+        prompt_token_ids=[1, 2, 3],
+        prompt_logprobs=None,
+        outputs=[
+            CompletionOutput(
+                index=0,
+                text="tool",
+                token_ids=[100, 101],
+                cumulative_logprob=None,
+                logprobs=None,
+                finish_reason="stop",
+            )
+        ],
+        finished=True,
+    )
+
+
 async def _single_request_output(
     request_output: RequestOutput,
 ) -> AsyncIterator[RequestOutput]:
@@ -828,11 +851,12 @@ async def _single_request_output(
 async def _collect_metrics_stream_chunks(
     serving: OpenAIServingChat,
     request: ChatCompletionRequest,
+    request_output: RequestOutput | None = None,
 ) -> list[dict[str, Any]]:
     chunks: list[dict[str, Any]] = []
     async for line in serving.chat_completion_stream_generator(
         request,
-        _single_request_output(_make_metrics_request_output()),
+        _single_request_output(request_output or _make_metrics_request_output()),
         "chatcmpl-test-id",
         "test-model",
         conversation=[{"role": "user", "content": "Test"}],
@@ -846,6 +870,259 @@ async def _collect_metrics_stream_chunks(
         if payload != "[DONE]":
             chunks.append(json.loads(payload))
     return chunks
+
+
+@pytest.mark.asyncio
+async def test_kimi_streaming_terminal_usage_uses_separate_empty_delta(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", True, raising=False)
+    serving = _build_minimal_metrics_serving_chat(enable_per_request_metrics=False)
+    chunks = await _collect_metrics_stream_chunks(
+        serving,
+        ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Test prompt"}],
+            max_tokens=10,
+            stream=True,
+        ),
+    )
+
+    terminal = next(
+        chunk["choices"][0]
+        for chunk in chunks
+        if chunk.get("choices") and chunk["choices"][0]["finish_reason"] is not None
+    )
+    assert terminal["delta"] == {}
+    assert terminal["usage"] == {
+        "prompt_tokens": 3,
+        "completion_tokens": 2,
+        "total_tokens": 5,
+        "prompt_tokens_details": {"cached_tokens": 0},
+        "completion_tokens_details": {"reasoning_tokens": 0},
+    }
+    assert any(
+        chunk["choices"][0].get("delta", {}).get("content") == "Hello"
+        and chunk["choices"][0]["finish_reason"] is None
+        for chunk in chunks
+        if chunk.get("choices")
+    )
+
+
+@pytest.mark.asyncio
+async def test_kimi_streaming_usage_summary_includes_required_details(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", True, raising=False)
+    serving = _build_minimal_metrics_serving_chat(enable_per_request_metrics=False)
+    chunks = await _collect_metrics_stream_chunks(
+        serving,
+        ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Test prompt"}],
+            max_tokens=10,
+            stream=True,
+            stream_options={"include_usage": True},
+        ),
+    )
+
+    summary = next(chunk for chunk in chunks if chunk.get("choices") == [])
+    assert summary["usage"] == {
+        "prompt_tokens": 3,
+        "completion_tokens": 2,
+        "total_tokens": 5,
+        "prompt_tokens_details": {
+            "cached_tokens": 0,
+        },
+        "completion_tokens_details": {"reasoning_tokens": 0},
+    }
+
+
+@pytest.mark.asyncio
+async def test_kimi_streaming_usage_counts_reasoning_from_prompt_and_output_ids(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", True, raising=False)
+
+    class CountingParser:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def parse_delta(self, *, delta_text, **kwargs):
+            return DeltaMessage(content=delta_text)
+
+        def count_reasoning_tokens(self, token_ids):
+            assert token_ids == [1, 2, 3, 100, 101]
+            return 1
+
+    serving = _build_minimal_metrics_serving_chat(enable_per_request_metrics=False)
+    serving.parser_cls = CountingParser
+    serving.model_config = MagicMock()
+    serving.enable_structured_outputs_in_reasoning = False
+    chunks = await _collect_metrics_stream_chunks(
+        serving,
+        ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Test prompt"}],
+            max_tokens=10,
+            stream=True,
+            stream_options={"include_usage": True},
+        ),
+    )
+
+    summary = next(chunk for chunk in chunks if chunk.get("choices") == [])
+    assert summary["usage"]["completion_tokens_details"] == {"reasoning_tokens": 1}
+
+
+@pytest.mark.asyncio
+async def test_upstream_streaming_terminal_usage_shape_is_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", False, raising=False)
+    serving = _build_minimal_metrics_serving_chat(enable_per_request_metrics=False)
+    chunks = await _collect_metrics_stream_chunks(
+        serving,
+        ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Test prompt"}],
+            max_tokens=10,
+            stream=True,
+        ),
+    )
+
+    terminal = next(
+        chunk["choices"][0]
+        for chunk in chunks
+        if chunk.get("choices") and chunk["choices"][0]["finish_reason"] is not None
+    )
+    assert "usage" not in terminal
+    assert terminal["delta"]["content"] == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_kimi_streaming_tool_delta_starts_with_empty_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", True, raising=False)
+
+    class ToolParser:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def parse_delta(self, *, delta_text, **kwargs):
+            return DeltaMessage(
+                tool_calls=[
+                    DeltaToolCall(
+                        id="call_0",
+                        type="function",
+                        index=0,
+                        function=DeltaFunctionCall(
+                            name="get_weather", arguments='{"city":"Beijing"}'
+                        ),
+                    )
+                ]
+            )
+
+    serving = _build_minimal_metrics_serving_chat(enable_per_request_metrics=False)
+    serving.parser_cls = ToolParser
+    serving.model_config = MagicMock()
+    serving.enable_structured_outputs_in_reasoning = False
+    chunks = await _collect_metrics_stream_chunks(
+        serving,
+        ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "What is the weather?"}],
+            max_tokens=10,
+            stream=True,
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+        ),
+        request_output=_make_tool_stream_request_output(),
+    )
+
+    tool_chunks = [
+        chunk["choices"][0]
+        for chunk in chunks
+        if chunk.get("choices") and chunk["choices"][0]["delta"].get("tool_calls")
+    ]
+    assert len(tool_chunks) == 2
+    assert tool_chunks[0]["delta"]["tool_calls"][0] == {
+        "id": "call_0",
+        "type": "function",
+        "function": {"name": "get_weather", "arguments": ""},
+        "index": 0,
+    }
+    assert tool_chunks[1]["delta"]["tool_calls"][0] == {
+        "function": {"arguments": '{"city":"Beijing"}'},
+        "index": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_upstream_streaming_tool_delta_shape_is_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", False, raising=False)
+
+    class ToolParser:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def parse_delta(self, *, delta_text, **kwargs):
+            return DeltaMessage(
+                tool_calls=[
+                    DeltaToolCall(
+                        id="call_0",
+                        type="function",
+                        index=0,
+                        function=DeltaFunctionCall(
+                            name="get_weather", arguments='{"city":"Beijing"}'
+                        ),
+                    )
+                ]
+            )
+
+    serving = _build_minimal_metrics_serving_chat(enable_per_request_metrics=False)
+    serving.parser_cls = ToolParser
+    serving.model_config = MagicMock()
+    serving.enable_structured_outputs_in_reasoning = False
+    chunks = await _collect_metrics_stream_chunks(
+        serving,
+        ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "What is the weather?"}],
+            max_tokens=10,
+            stream=True,
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+        ),
+        request_output=_make_tool_stream_request_output(),
+    )
+
+    tool_chunks = [
+        chunk["choices"][0]
+        for chunk in chunks
+        if chunk.get("choices") and chunk["choices"][0]["delta"].get("tool_calls")
+    ]
+    assert len(tool_chunks) == 1
+    assert tool_chunks[0]["delta"]["tool_calls"][0]["function"] == {
+        "name": "get_weather",
+        "arguments": '{"city":"Beijing"}',
+    }
 
 
 def test_build_per_request_timing_metrics_valid_timestamps():

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -18,6 +18,7 @@ from tests.entrypoints.openai.utils import (
     verify_harmony_messages,
 )
 from tests.utils import RemoteOpenAIServer
+from vllm import envs
 from vllm._aiter_ops import is_aiter_found_and_supported
 from vllm.config import MultiModalConfig
 from vllm.entrypoints.generate.base.serving import build_per_request_timing_metrics
@@ -32,6 +33,7 @@ from vllm.entrypoints.openai.chat_completion.serving import (
 )
 from vllm.entrypoints.openai.engine.protocol import (
     ErrorResponse,
+    FunctionCall,
     RequestResponseMetadata,
 )
 from vllm.entrypoints.openai.models.serving import (
@@ -616,6 +618,163 @@ def _build_serving_chat(
     )
 
     return serving_chat
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kimi_validations", "expected_reasoning"),
+    [(True, [True]), (False, [])],
+)
+async def test_online_renderer_propagates_structured_outputs_in_reasoning(
+    monkeypatch,
+    kimi_validations,
+    expected_reasoning,
+):
+    from vllm.tool_parsers import structural_tag_registry
+
+    monkeypatch.setattr(
+        envs,
+        "NOVITA_ENABLE_KIMI_VALIDATIONS",
+        kimi_validations,
+        raising=False,
+    )
+    captured_reasoning: list[bool] = []
+    get_structural_tag = structural_tag_registry.get_xgrammar_model_structural_tag
+
+    def record_reasoning(*args, reasoning: bool, **kwargs):
+        captured_reasoning.append(reasoning)
+        return get_structural_tag(*args, reasoning=reasoning, **kwargs)
+
+    monkeypatch.setattr(
+        structural_tag_registry,
+        "get_xgrammar_model_structural_tag",
+        record_reasoning,
+    )
+
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+    online_renderer = OnlineRenderer(
+        model_config=mock_engine.model_config,
+        renderer=mock_engine.renderer,
+        request_logger=None,
+        chat_template=CHAT_TEMPLATE,
+        chat_template_content_format="auto",
+        enable_auto_tools=True,
+        tool_parser="kimi_k2",
+        reasoning_parser="kimi_k2",
+        enable_structured_outputs_in_reasoning=True,
+    )
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "Use get_weather."}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                },
+            }
+        ],
+        tool_choice="auto",
+        chat_template_kwargs={"thinking": True},
+    )
+
+    result = await online_renderer.render_chat(request)
+
+    assert not isinstance(result, ErrorResponse)
+    assert (request.structured_outputs is not None) is kimi_validations
+    assert captured_reasoning == expected_reasoning
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kimi_validations", "expected_finish_reason"),
+    [(True, "length"), (False, "tool_calls")],
+)
+async def test_nonstreaming_tool_call_length_finish_reason_is_env_gated(
+    monkeypatch,
+    kimi_validations,
+    expected_finish_reason,
+):
+    monkeypatch.setattr(
+        envs,
+        "NOVITA_ENABLE_KIMI_VALIDATIONS",
+        kimi_validations,
+        raising=False,
+    )
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+    serving = _build_serving_chat(
+        mock_engine,
+        tool_parser="hermes",
+        enable_auto_tools=True,
+    )
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "Use get_weather."}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+        tool_choice="auto",
+    )
+    parser = MagicMock()
+    parser.parse.return_value = (
+        None,
+        None,
+        [
+            FunctionCall(
+                id="call_0",
+                name="get_weather",
+                arguments='{"city": "Tokyo"}',
+            )
+        ],
+    )
+    output = RequestOutput(
+        request_id="test-id",
+        prompt="Test prompt",
+        prompt_token_ids=[1, 2, 3],
+        prompt_logprobs=None,
+        outputs=[
+            CompletionOutput(
+                index=0,
+                text="tool output",
+                token_ids=[100, 101],
+                cumulative_logprob=None,
+                logprobs=None,
+                finish_reason="length",
+            )
+        ],
+        finished=True,
+    )
+
+    response = await serving.chat_completion_full_generator(
+        request,
+        _single_request_output(output),
+        "chatcmpl-test-id",
+        MODEL_NAME,
+        conversation=[],
+        tokenizer=MagicMock(),
+        request_metadata=RequestResponseMetadata(request_id="chatcmpl-test-id"),
+        parser=parser,
+    )
+
+    assert isinstance(response, ChatCompletionResponse)
+    assert response.choices[0].message.tool_calls
+    assert response.choices[0].finish_reason == expected_finish_reason
 
 
 def _build_minimal_metrics_serving_chat(
@@ -2134,10 +2293,29 @@ async def test_tool_choice_validation_without_parser():
 
 
 @pytest.mark.asyncio
-async def test_streaming_n_gt1_independent_tool_parsers():
+@pytest.mark.parametrize(
+    ("kimi_validations", "engine_finish_reason", "expected_finish_reason"),
+    [
+        (True, "stop", "tool_calls"),
+        (True, "length", "length"),
+        (False, "length", "tool_calls"),
+    ],
+)
+async def test_streaming_n_gt1_independent_tool_parsers(
+    monkeypatch,
+    kimi_validations,
+    engine_finish_reason,
+    expected_finish_reason,
+):
     """n>1 streaming must use independent parser instances
     and token-id histories per choice.
     """
+    monkeypatch.setattr(
+        envs,
+        "NOVITA_ENABLE_KIMI_VALIDATIONS",
+        kimi_validations,
+        raising=False,
+    )
     mock_engine = MagicMock(spec=AsyncLLM)
     mock_engine.errored = False
     mock_engine.model_config = MockModelConfig()
@@ -2239,7 +2417,7 @@ async def test_streaming_n_gt1_independent_tool_parsers():
                     token_ids=[],
                     cumulative_logprob=0.0,
                     logprobs=None,
-                    finish_reason="stop",
+                    finish_reason=engine_finish_reason,
                 )
                 for choice_idx in range(num_choices)
             ],
@@ -2303,7 +2481,8 @@ async def test_streaming_n_gt1_independent_tool_parsers():
         assert len(reasons) == 1, (
             f"Choice {choice_idx}: expected exactly 1 finish_reason, got {reasons}"
         )
-        assert reasons[0] == "tool_calls", (
-            f"Choice {choice_idx}: expected finish_reason='tool_calls', "
+        assert reasons[0] == expected_finish_reason, (
+            f"Choice {choice_idx}: expected finish_reason="
+            f"'{expected_finish_reason}', "
             f"got '{reasons[0]}'"
         )

--- a/tests/tool_parsers/test_kimi_k2_tool_parser.py
+++ b/tests/tool_parsers/test_kimi_k2_tool_parser.py
@@ -11,6 +11,7 @@ from tests.tool_parsers.utils import (
     run_tool_extraction,
     run_tool_extraction_streaming,
 )
+from vllm import envs
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
 )
@@ -26,7 +27,14 @@ def kimi_k2_tokenizer():
 
 
 @pytest.fixture
-def parser(kimi_k2_tokenizer):
+def parser(kimi_k2_tokenizer, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", False, raising=False)
+    return KimiK2ToolParser(kimi_k2_tokenizer)
+
+
+@pytest.fixture
+def validated_parser(kimi_k2_tokenizer, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", True, raising=False)
     return KimiK2ToolParser(kimi_k2_tokenizer)
 
 
@@ -148,8 +156,46 @@ class TestExtractToolCalls:
             # id format: "something:digit"
             assert tc.id.split(":")[-1].isdigit()
 
-    def test_invalid_json_still_extracted(self, parser):
-        """Tool calls with invalid JSON are still returned (arguments as-is)."""
+    @pytest.mark.parametrize(
+        "invalid_args",
+        [
+            pytest.param('{"city": "Beijing"', id="truncated_json"),
+            pytest.param('{"a": 1}{"b": 2}', id="multiple_json_values"),
+            pytest.param('{"a": 1} trailing', id="trailing_data"),
+        ],
+    )
+    def test_invalid_json_tool_call_skipped(self, validated_parser, invalid_args):
+        model_output = (
+            "Help. "
+            + SECTION_BEGIN
+            + _tool("functions.bad:0", invalid_args)
+            + _tool("functions.good:1", '{"city": "Shanghai"}')
+            + SECTION_END
+        )
+        content, tool_calls = run_tool_extraction(
+            validated_parser, model_output, streaming=False
+        )
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "good"
+        assert json.loads(tool_calls[0].function.arguments) == {"city": "Shanghai"}
+
+    def test_truncated_tool_call_skipped(self, validated_parser):
+        model_output = (
+            "Help. "
+            + SECTION_BEGIN
+            + TOOL_BEGIN
+            + "functions.get_weather:0 "
+            + ARG_BEGIN
+            + '{"city": "Bei'
+        )
+
+        content, tool_calls = run_tool_extraction(
+            validated_parser, model_output, streaming=False
+        )
+
+        assert tool_calls == []
+
+    def test_invalid_json_keeps_upstream_behavior_without_validations(self, parser):
         model_output = (
             "Help. "
             + SECTION_BEGIN
@@ -157,10 +203,11 @@ class TestExtractToolCalls:
             + _tool("functions.good:1", '{"city": "Shanghai"}')
             + SECTION_END
         )
-        content, tool_calls = run_tool_extraction(parser, model_output, streaming=False)
-        assert len(tool_calls) == 2
-        assert tool_calls[0].function.name == "bad"
-        assert tool_calls[1].function.name == "good"
+
+        _, tool_calls = run_tool_extraction(parser, model_output, streaming=False)
+
+        assert [call.function.name for call in tool_calls] == ["bad", "good"]
+        assert tool_calls[0].function.arguments == '{"city": "Beijing"'
 
     def test_invalid_funcall_id_skipped(self, parser):
         """Tool calls with malformed id (no colon+digit) are skipped."""
@@ -410,8 +457,8 @@ class TestStreamingEdgeCases:
         ids = [tc.id for tc in rec.tool_calls]
         assert len(set(ids)) == 3  # unique ids
 
-    def test_truncated_tool_call_no_end_marker(self, parser):
-        """Stream ending mid-tool-call (max_tokens) doesn't crash."""
+    def test_truncated_tool_call_no_end_marker(self, validated_parser):
+        """A max_tokens cutoff must not expose a partial tool call."""
         deltas = [
             "I'll check. ",
             SECTION_BEGIN,
@@ -421,16 +468,54 @@ class TestStreamingEdgeCases:
             '{"city": "Bei',
             # Stream ends here — no TOOL_END, no SECTION_END
         ]
-        rec = run_tool_extraction_streaming(parser, deltas)
+        rec = run_tool_extraction_streaming(validated_parser, deltas)
 
-        # Should not crash; tool name and partial args extracted
-        assert len(rec.tool_calls) == 1
-        assert rec.tool_calls[0].function.name == "get_weather"
-        assert rec.tool_calls[0].id == "functions.get_weather:0"
-        assert rec.tool_calls[0].function.arguments == '{"city": "Bei'
+        finish_delta = validated_parser.finish_streaming()
+
+        assert rec.tool_calls == []
+        assert finish_delta is None or not finish_delta.tool_calls
         # No markers leaked into content
         for marker in [SECTION_BEGIN, SECTION_END, TOOL_BEGIN, TOOL_END, ARG_BEGIN]:
             assert marker not in rec.other_content
+
+    @pytest.mark.parametrize(
+        "invalid_args",
+        [
+            pytest.param('{"a": 1}{"b": 2}', id="multiple_json_values"),
+            pytest.param('{"a": 1} trailing', id="trailing_data"),
+        ],
+    )
+    def test_invalid_json_tool_call_not_streamed(self, validated_parser, invalid_args):
+        deltas = _split_tool_output_to_deltas(
+            "Help. ",
+            [
+                ("functions.bad:0", invalid_args),
+                ("functions.good:1", '{"city": "Shanghai"}'),
+            ],
+        )
+
+        rec = run_tool_extraction_streaming(validated_parser, deltas)
+
+        assert len(rec.tool_calls) == 1
+        assert rec.tool_calls[0].function.name == "good"
+        assert rec.tool_calls[0].id == "functions.good:1"
+        assert json.loads(rec.tool_calls[0].function.arguments) == {"city": "Shanghai"}
+
+    def test_truncated_stream_keeps_upstream_behavior_without_validations(self, parser):
+        deltas = [
+            "I'll check. ",
+            SECTION_BEGIN,
+            TOOL_BEGIN,
+            "functions.get_weather:0 ",
+            ARG_BEGIN,
+            '{"city": "Bei',
+        ]
+
+        rec = run_tool_extraction_streaming(parser, deltas)
+
+        assert len(rec.tool_calls) == 1
+        assert rec.tool_calls[0].function.name == "get_weather"
+        assert rec.tool_calls[0].function.arguments == '{"city": "Bei'
 
     def test_content_after_tool_section(self, parser):
         """Trailing text after section_end doesn't crash or leak markers."""

--- a/tests/tool_parsers/test_structural_tag_registry.py
+++ b/tests/tool_parsers/test_structural_tag_registry.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 from xgrammar import StructuralTag
 
+from vllm import envs
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionNamedFunction,
     ChatCompletionNamedToolChoiceParam,
@@ -288,6 +289,113 @@ def test_unified_parser_get_structural_tag_disables_reasoning(
     assert captured == [False]
 
 
+@pytest.mark.parametrize(
+    (
+        "kimi_validations",
+        "enable_in_reasoning",
+        "chat_template_kwargs",
+        "expected",
+    ),
+    [
+        (True, True, None, True),
+        (True, True, {"thinking": True}, True),
+        (True, True, {"thinking": False}, False),
+        (True, True, {"enable_thinking": False}, False),
+        (True, True, {"thinking": False, "enable_thinking": True}, True),
+        (True, False, {"thinking": True}, False),
+        (False, True, {"thinking": True}, False),
+    ],
+)
+def test_kimi_auto_structural_tag_reasoning_matches_effective_thinking(
+    monkeypatch: pytest.MonkeyPatch,
+    sample_tools: list[ChatCompletionToolsParam],
+    kimi_validations: bool,
+    enable_in_reasoning: bool,
+    chat_template_kwargs: dict | None,
+    expected: bool,
+):
+    monkeypatch.setattr(
+        envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", kimi_validations, raising=False
+    )
+    captured: list[bool] = []
+
+    def fake_get_model_structural_tag(*, reasoning: bool, **kwargs):
+        captured.append(reasoning)
+        return None
+
+    monkeypatch.setattr(
+        "vllm.tool_parsers.structural_tag_registry.get_model_structural_tag",
+        fake_get_model_structural_tag,
+    )
+
+    class TestParser(DelegatingParser):
+        tool_parser_cls = KimiK2ToolParser
+
+    request = ChatCompletionRequest(
+        messages=[],
+        model="m",
+        tools=sample_tools,
+        tool_choice="auto",
+    )
+    parser = TestParser(
+        MagicMock(),
+        tools=sample_tools,
+        chat_template_kwargs=chat_template_kwargs,
+        enable_structured_outputs_in_reasoning=enable_in_reasoning,
+    )
+
+    parser.adjust_request(request)
+
+    assert captured == [expected]
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        "required",
+        ChatCompletionNamedToolChoiceParam(
+            function=ChatCompletionNamedFunction(name="get_weather")
+        ),
+    ],
+)
+def test_kimi_non_auto_structural_tags_keep_reasoning_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    sample_tools: list[ChatCompletionToolsParam],
+    tool_choice,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", True, raising=False)
+    captured: list[bool] = []
+
+    def fake_get_model_structural_tag(*, reasoning: bool, **kwargs):
+        captured.append(reasoning)
+        return None
+
+    monkeypatch.setattr(
+        "vllm.tool_parsers.structural_tag_registry.get_model_structural_tag",
+        fake_get_model_structural_tag,
+    )
+
+    class TestParser(DelegatingParser):
+        tool_parser_cls = KimiK2ToolParser
+
+    request = ChatCompletionRequest(
+        messages=[],
+        model="m",
+        tools=sample_tools,
+    )
+    request.tool_choice = tool_choice
+    parser = TestParser(
+        MagicMock(),
+        tools=sample_tools,
+        chat_template_kwargs={"thinking": True},
+        enable_structured_outputs_in_reasoning=True,
+    )
+
+    parser.adjust_request(request)
+
+    assert captured == [False]
+
+
 def test_xgrammar_function_parameters_are_preserved(
     monkeypatch: pytest.MonkeyPatch,
     sample_tools_strict: list[ChatCompletionToolsParam],
@@ -317,7 +425,97 @@ def test_xgrammar_function_parameters_are_preserved(
     assert sample_tools_strict[0].function.parameters is not None
 
 
-@pytest.mark.parametrize("model", sorted(XGRAMMAR_BUILTIN_STRUCTURAL_TAG_MODELS))
+def test_kimi_auto_tools_ignore_strict_and_preserve_parameters(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", True, raising=False)
+    captured: list[list[dict]] = []
+
+    def fake_get_xgrammar_model_structural_tag(*, tools: list[dict], **kwargs):
+        captured.append(tools)
+        return None
+
+    monkeypatch.setattr(
+        "vllm.tool_parsers.structural_tag_registry.get_xgrammar_model_structural_tag",
+        fake_get_xgrammar_model_structural_tag,
+    )
+    parameters = {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    }
+
+    for strict in (None, True, False):
+        function = {"name": "get_weather", "parameters": parameters}
+        if strict is not None:
+            function["strict"] = strict
+        tools = [ChatCompletionToolsParam(type="function", function=function)]
+        get_model_structural_tag(
+            model="kimi",
+            tools=tools,
+            tool_choice="auto",
+            reasoning=False,
+        )
+
+    assert captured[0] == captured[1] == captured[2]
+    assert captured[0][0]["function"]["parameters"] == parameters
+    assert "strict" not in captured[0][0]["function"]
+
+
+def test_kimi_auto_tool_choice_uses_structural_tag_without_strict(
+    monkeypatch: pytest.MonkeyPatch,
+    sample_tools: list[ChatCompletionToolsParam],
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", True, raising=False)
+    tag = get_model_structural_tag(
+        model="kimi",
+        tools=sample_tools,
+        tool_choice="auto",
+        reasoning=False,
+    )
+
+    assert isinstance(tag, StructuralTag)
+
+
+@pytest.mark.parametrize("strict", [None, False])
+def test_kimi_auto_tool_choice_keeps_upstream_behavior_without_validations(
+    monkeypatch: pytest.MonkeyPatch,
+    sample_tools: list[ChatCompletionToolsParam],
+    strict: bool | None,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", False, raising=False)
+
+    tools = [tool.model_copy(deep=True) for tool in sample_tools]
+    tools[0].function.strict = strict
+    tag = get_model_structural_tag(
+        model="kimi",
+        tools=tools,
+        tool_choice="auto",
+        reasoning=False,
+    )
+
+    assert tag is None
+
+
+def test_kimi_auto_strict_tool_keeps_upstream_behavior_without_validations(
+    monkeypatch: pytest.MonkeyPatch,
+    sample_tools_strict: list[ChatCompletionToolsParam],
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", False, raising=False)
+
+    tag = get_model_structural_tag(
+        model="kimi",
+        tools=sample_tools_strict,
+        tool_choice="auto",
+        reasoning=False,
+    )
+
+    assert isinstance(tag, StructuralTag)
+
+
+@pytest.mark.parametrize(
+    "model", sorted(XGRAMMAR_BUILTIN_STRUCTURAL_TAG_MODELS - {"kimi"})
+)
 def test_auto_tool_choice_skips_structural_tag_without_strict(
     model: str,
     sample_tools: list[ChatCompletionToolsParam],

--- a/tests/tool_use/test_chat_completion_request_validations.py
+++ b/tests/tool_use/test_chat_completion_request_validations.py
@@ -122,6 +122,58 @@ def test_top_level_thinking_is_ignored_without_kimi_validations(
     assert request.thinking == {"type": "disabled"}
 
 
+def test_internal_content_rejected_with_kimi_validations(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", True, raising=False)
+
+    with pytest.raises(ValueError, match="include_internal_content.*not supported"):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "stream": True,
+                "stream_options": {"include_internal_content": True},
+            }
+        )
+
+
+def test_internal_content_false_accepted_with_kimi_validations(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", True, raising=False)
+
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "model": "facebook/opt-125m",
+            "stream": True,
+            "stream_options": {"include_internal_content": False},
+        }
+    )
+
+    assert request.stream_options is not None
+    assert request.stream_options.include_internal_content is False
+
+
+def test_internal_content_preserved_without_kimi_validations(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", False, raising=False)
+
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "model": "facebook/opt-125m",
+            "stream": True,
+            "stream_options": {"include_internal_content": True},
+        }
+    )
+
+    assert request.stream_options is not None
+    assert request.stream_options.include_internal_content is True
+
+
 @pytest.mark.parametrize("tool_choice", ["auto", "required"])
 def test_chat_completion_request_with_tool_choice_but_no_tools(tool_choice):
     with pytest.raises(

--- a/tests/tool_use/test_chat_completion_request_validations.py
+++ b/tests/tool_use/test_chat_completion_request_validations.py
@@ -3,6 +3,7 @@
 
 import pytest
 
+from vllm import envs
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 
 
@@ -35,6 +36,90 @@ def test_chat_completion_request_with_no_tools():
                 "tools": [],
             }
         )
+
+
+def test_empty_tools_accepted_with_kimi_validations(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", True, raising=False)
+
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "model": "facebook/opt-125m",
+            "tools": [],
+            "tool_choice": "auto",
+        }
+    )
+
+    assert request.tools is None
+    assert request.tool_choice == "none"
+
+
+@pytest.mark.parametrize(
+    ("thinking_type", "enabled"),
+    [("enabled", True), ("disabled", False)],
+)
+def test_top_level_thinking_normalized_with_kimi_validations(
+    monkeypatch: pytest.MonkeyPatch,
+    thinking_type: str,
+    enabled: bool,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", True, raising=False)
+
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "model": "facebook/opt-125m",
+            "thinking": {"type": thinking_type},
+        }
+    )
+
+    assert request.chat_template_kwargs == {
+        "thinking": enabled,
+        "enable_thinking": enabled,
+    }
+    assert not hasattr(request, "thinking")
+
+
+def test_explicit_chat_template_kwargs_override_top_level_thinking(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", True, raising=False)
+
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "model": "facebook/opt-125m",
+            "thinking": {"type": "disabled"},
+            "chat_template_kwargs": {
+                "thinking": True,
+                "enable_thinking": True,
+            },
+        }
+    )
+
+    assert request.chat_template_kwargs == {
+        "thinking": True,
+        "enable_thinking": True,
+    }
+
+
+def test_top_level_thinking_is_ignored_without_kimi_validations(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", False, raising=False)
+
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "model": "facebook/opt-125m",
+            "thinking": {"type": "disabled"},
+        }
+    )
+
+    assert request.chat_template_kwargs is None
+    assert request.thinking == {"type": "disabled"}
 
 
 @pytest.mark.parametrize("tool_choice", ["auto", "required"])

--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import Mock
 
@@ -8,8 +9,18 @@ import torch
 import torch.nn.functional as F
 
 from tests.v1.sample.utils import create_allowed_token_ids
+from vllm import envs
 from vllm.platforms import current_platform
-from vllm.v1.sample.logits_processor import LogitsProcessors
+from vllm.v1.sample.logits_processor import (
+    STR_SPEC_DEC_REJECTS_LOGITSPROCS,
+    LogitsProcessors,
+    build_logitsprocs,
+)
+from vllm.v1.sample.logits_processor.builtin import (
+    KimiReasoningLogitsProcessor,
+    MinPLogitsProcessor,
+    MinTokensLogitsProcessor,
+)
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import (
     PLACEHOLDER_TOKEN_ID,
@@ -82,6 +93,7 @@ def create_sampling_metadata(
     repetition_penalties: list[float] | None = None,
     bad_words_token_ids: dict[int, list[list[int]]] | None = None,
     allowed_token_ids_mask: torch.Tensor | None = None,
+    logitsprocs: LogitsProcessors | None = None,
 ) -> SamplingMetadata:
     """Create a v1 sampling metadata object with all_greedy set
     to the given value. Either all greedy or all random sampling
@@ -125,7 +137,7 @@ def create_sampling_metadata(
         spec_token_ids=[] if spec_token_ids is None else spec_token_ids,
         allowed_token_ids_mask=allowed_token_ids_mask,
         bad_words_token_ids={} if bad_words_token_ids is None else bad_words_token_ids,
-        logitsprocs=LogitsProcessors(),
+        logitsprocs=logitsprocs if logitsprocs is not None else LogitsProcessors(),
     )
 
 
@@ -1183,3 +1195,250 @@ def test_placeholder_draft_token_rejected_random(rejection_sampler):
     assert sampled[0, 1].item() == vocab_size - 1
     recovered = sampled[0, 2].item()
     assert 0 <= recovered < vocab_size
+
+
+def _spec_decode_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        speculative_config=object(),
+        structured_outputs_config=None,
+    )
+
+
+@pytest.mark.skipif(
+    current_platform.is_tpu(),
+    reason="vLLM V1 on TPU does not support custom logits processors",
+)
+def test_spec_decode_accepts_and_deduplicates_kimi_reasoning_logits_processor(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", True, raising=False)
+    fqcn = "vllm.v1.sample.logits_processor.builtin:KimiReasoningLogitsProcessor"
+    logitsprocs = build_logitsprocs(
+        vllm_config=_spec_decode_config(),
+        device=torch.device("cpu"),
+        is_pin_memory=False,
+        is_pooling_model=False,
+        custom_logitsprocs=[fqcn, fqcn],
+    )
+
+    assert (
+        sum(
+            isinstance(processor, KimiReasoningLogitsProcessor)
+            for processor in logitsprocs.all
+        )
+        == 1
+    )
+    assert (
+        sum(
+            isinstance(processor, MinTokensLogitsProcessor)
+            for processor in logitsprocs.all
+        )
+        == 1
+    )
+
+
+@pytest.mark.skipif(
+    current_platform.is_tpu(),
+    reason="vLLM V1 on TPU does not support custom logits processors",
+)
+def test_spec_decode_still_rejects_unsupported_logits_processor(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", True, raising=False)
+    with pytest.raises(ValueError) as exc_info:
+        build_logitsprocs(
+            vllm_config=_spec_decode_config(),
+            device=torch.device("cpu"),
+            is_pin_memory=False,
+            is_pooling_model=False,
+            custom_logitsprocs=[MinPLogitsProcessor],
+        )
+    assert "Rejected: MinPLogitsProcessor" in str(exc_info.value)
+
+
+def test_spec_decode_keeps_upstream_custom_processor_rejection_without_validations(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", False, raising=False)
+
+    with pytest.raises(ValueError, match=f"^{STR_SPEC_DEC_REJECTS_LOGITSPROCS}$"):
+        build_logitsprocs(
+            vllm_config=_spec_decode_config(),
+            device=torch.device("cpu"),
+            is_pin_memory=False,
+            is_pooling_model=False,
+            custom_logitsprocs=[KimiReasoningLogitsProcessor],
+        )
+
+
+def test_kimi_reasoning_logits_processor_applies_to_speculative_rows(
+    monkeypatch: pytest.MonkeyPatch,
+    rejection_sampler,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", True, raising=False)
+    spec_tokens = [[1, 2, 3], [1, 2, 3], [1, 2, 3]]
+    output_tokens = [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]]
+    logits = create_logits_tensor(output_tokens, token_idx_to_override=15)
+
+    processor = KimiReasoningLogitsProcessor.__new__(KimiReasoningLogitsProcessor)
+    processor.device = torch.device(DEVICE_TYPE)
+    processor.pin_memory = False
+    processor.req_states = {
+        0: ([], True, 0),
+        1: ([], False, 0),
+        2: ([], True, 0),
+    }
+    processor.has_reasoning = True
+    processor.think_start_token_id = 8
+    processor.reasoning_end_token_ids = {9}
+    processor.banned_token_ids_tensor = torch.tensor(
+        [2], device=DEVICE_TYPE, dtype=torch.int64
+    )
+    processor.neg_inf_tensor = torch.tensor(
+        -float("inf"), device=DEVICE_TYPE, dtype=torch.float32
+    )
+
+    metadata = create_sampling_metadata(
+        all_greedy=True,
+        output_token_ids=[[2], [3], [4]],
+        spec_token_ids=spec_tokens,
+        logitsprocs=LogitsProcessors([processor]),
+    )
+    bonus_token_tensor = torch.tensor(
+        [output[-1] for output in output_tokens], device=logits.device
+    )
+    spec_decode_metadata = create_spec_decode_metadata(spec_tokens, logits)
+    mock_sampler_output(rejection_sampler, bonus_token_tensor)
+
+    output = rejection_sampler(
+        spec_decode_metadata,
+        draft_probs=None,
+        logits=logits,
+        sampling_metadata=metadata,
+    )
+
+    expected = torch.tensor(
+        [[1, 15, -1, -1], [1, 2, 3, 4], [1, 15, -1, -1]],
+        dtype=torch.int,
+        device=logits.device,
+    )
+    assert torch.equal(output.sampled_token_ids, expected)
+
+
+def test_kimi_reasoning_logits_processor_transitions_within_speculative_rows():
+    processor = KimiReasoningLogitsProcessor.__new__(KimiReasoningLogitsProcessor)
+    processor.device = torch.device(DEVICE_TYPE)
+    processor.pin_memory = False
+    processor.req_states = {0: ([], True, 0)}
+    processor.has_reasoning = True
+    processor.think_start_token_id = 8
+    processor.reasoning_end_token_ids = {7}
+    processor.banned_token_ids_tensor = torch.tensor(
+        [2], device=DEVICE_TYPE, dtype=torch.int64
+    )
+    processor.neg_inf_tensor = torch.tensor(
+        -float("inf"), device=DEVICE_TYPE, dtype=torch.float32
+    )
+
+    logits = torch.zeros((3, 10), device=DEVICE_TYPE)
+    processor.apply_with_spec_decode(logits, [3], [[1, 7, 1]])
+
+    assert torch.isneginf(logits[0, 2])
+    assert torch.isneginf(logits[1, 2])
+    assert not torch.isneginf(logits[2, 2])
+    assert processor.req_states[0][1] is True
+
+
+def test_kimi_reasoning_logits_processor_transitions_for_speculative_bonus_rows(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", True, raising=False)
+    processor = KimiReasoningLogitsProcessor.__new__(KimiReasoningLogitsProcessor)
+    processor.device = torch.device(DEVICE_TYPE)
+    processor.pin_memory = False
+    processor.req_states = {
+        0: ([], True, 0),
+        1: ([], False, 0),
+    }
+    processor.has_reasoning = True
+    processor.think_start_token_id = 8
+    processor.reasoning_end_token_ids = {7}
+    processor.banned_token_ids_tensor = torch.tensor(
+        [2], device=DEVICE_TYPE, dtype=torch.int64
+    )
+    processor.neg_inf_tensor = torch.tensor(
+        -float("inf"), device=DEVICE_TYPE, dtype=torch.float32
+    )
+    metadata = create_sampling_metadata(
+        all_greedy=True,
+        output_token_ids=[[], []],
+        spec_token_ids=[[1, 7, 1], [1, 8, 1]],
+        logitsprocs=LogitsProcessors([processor]),
+    )
+
+    logits = Sampler().apply_logits_processors(
+        torch.zeros((2, 10), device=DEVICE_TYPE),
+        metadata,
+        predict_bonus_token=True,
+    )
+
+    assert not torch.isneginf(logits[0, 2])
+    assert torch.isneginf(logits[1, 2])
+    assert processor.req_states[0][1] is True
+    assert processor.req_states[1][1] is False
+
+
+def test_kimi_reasoning_logits_processor_reads_kimi_engine_token_ids(monkeypatch):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", True, raising=False)
+    vocab = {
+        "<think>": 1,
+        "</think>": 2,
+        "<|tool_calls_section_begin|>": 3,
+        "<|tool_calls_section_end|>": 4,
+        "<|tool_call_begin|>": 5,
+        "<|tool_call_argument_begin|>": 6,
+        "<|tool_call_end|>": 7,
+    }
+    tokenizer = SimpleNamespace(
+        get_vocab=lambda: vocab,
+        all_special_tokens=list(vocab),
+        all_special_ids=list(vocab.values()),
+        added_tokens_encoder=vocab,
+    )
+    monkeypatch.setattr(
+        "vllm.tokenizers.cached_tokenizer_from_config",
+        lambda **_: tokenizer,
+    )
+    vllm_config = SimpleNamespace(
+        structured_outputs_config=SimpleNamespace(reasoning_parser="kimi_k2"),
+        model_config=SimpleNamespace(skip_tokenizer_init=False),
+    )
+
+    processor = KimiReasoningLogitsProcessor(
+        vllm_config,
+        device=torch.device(DEVICE_TYPE),
+        is_pin_memory=False,
+    )
+
+    assert processor.think_start_token_id == 1
+    assert processor.reasoning_end_token_ids == {2, 3}
+    assert set(processor.banned_special_token_ids) == {1, 4, 5, 6, 7}
+
+
+def test_kimi_reasoning_logits_processor_is_disabled_without_validations(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(envs, "NOVITA_ENABLE_KIMI_VALIDATIONS", False, raising=False)
+    processor = KimiReasoningLogitsProcessor(
+        _spec_decode_config(),
+        device=torch.device(DEVICE_TYPE),
+        is_pin_memory=False,
+    )
+
+    logits = torch.zeros((1, 8), device=DEVICE_TYPE)
+    result = processor.apply(logits)
+
+    assert processor.think_start_token_id is None
+    assert processor.reasoning_end_token_ids == set()
+    assert processor.banned_special_token_ids == []
+    assert torch.equal(result, logits)

--- a/vllm/entrypoints/generate/api_router.py
+++ b/vllm/entrypoints/generate/api_router.py
@@ -126,6 +126,9 @@ async def init_generate_state(
         exclude_tools_when_tool_choice_none=args.exclude_tools_when_tool_choice_none,
         tool_parser=args.tool_call_parser,
         reasoning_parser=args.structured_outputs_config.reasoning_parser,
+        enable_structured_outputs_in_reasoning=(
+            args.structured_outputs_config.enable_in_reasoning
+        ),
         enable_prompt_tokens_details=args.enable_prompt_tokens_details,
         enable_force_include_usage=args.enable_force_include_usage,
         enable_log_outputs=args.enable_log_outputs,

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -420,6 +420,9 @@ async def init_app_state(
         exclude_tools_when_tool_choice_none=args.exclude_tools_when_tool_choice_none,
         tool_parser=args.tool_call_parser,
         reasoning_parser=args.structured_outputs_config.reasoning_parser,
+        enable_structured_outputs_in_reasoning=(
+            args.structured_outputs_config.enable_in_reasoning
+        ),
         default_chat_template_kwargs=args.default_chat_template_kwargs,
         log_error_stack=args.log_error_stack,
     )
@@ -523,6 +526,9 @@ async def init_render_app_state(
         exclude_tools_when_tool_choice_none=args.exclude_tools_when_tool_choice_none,
         tool_parser=args.tool_call_parser,
         reasoning_parser=args.reasoning_parser,
+        enable_structured_outputs_in_reasoning=(
+            args.structured_outputs_config.enable_in_reasoning
+        ),
         default_chat_template_kwargs=args.default_chat_template_kwargs,
         log_error_stack=args.log_error_stack,
     )

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -13,6 +13,7 @@ from openai.types.chat.chat_completion_audio import (
 from openai.types.chat.chat_completion_message import Annotation as OpenAIAnnotation
 from pydantic import Field, PrivateAttr, model_serializer, model_validator
 
+from vllm import envs
 from vllm.config import ModelConfig
 from vllm.config.utils import replace
 from vllm.entrypoints.chat_utils import (
@@ -471,6 +472,34 @@ class ChatCompletionRequest(OpenAIBaseModel):
 
     @model_validator(mode="before")
     @classmethod
+    def _normalize_kimi_thinking(cls, data: Any) -> Any:
+        if not envs.NOVITA_ENABLE_KIMI_VALIDATIONS or not isinstance(data, dict):
+            return data
+
+        thinking = data.get("thinking")
+        if not isinstance(thinking, dict) or thinking.get("type") not in (
+            "enabled",
+            "disabled",
+        ):
+            return data
+
+        chat_template_kwargs = data.get("chat_template_kwargs")
+        if chat_template_kwargs is not None and not isinstance(
+            chat_template_kwargs, dict
+        ):
+            return data
+
+        enabled = thinking["type"] == "enabled"
+        data = dict(data)
+        data["chat_template_kwargs"] = {
+            "thinking": enabled,
+            "enable_thinking": enabled,
+        } | (chat_template_kwargs or {})
+        data.pop("thinking", None)
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
     def _normalize_messages_before(cls, data: Any) -> Any:
         """Pre-process message dicts before Pydantic field validation.
 
@@ -836,10 +865,15 @@ class ChatCompletionRequest(OpenAIBaseModel):
 
         # Reject empty tools array, matching OpenAI API behavior
         if data.get("tools") == []:
-            raise ValueError(
-                "`tools` must not be an empty array. "
-                "Either provide at least one tool or omit the field entirely."
-            )
+            if envs.NOVITA_ENABLE_KIMI_VALIDATIONS:
+                data = dict(data)
+                data.pop("tools", None)
+                data.pop("tool_choice", None)
+            else:
+                raise ValueError(
+                    "`tools` must not be an empty array. "
+                    "Either provide at least one tool or omit the field entirely."
+                )
 
         # if "tool_choice" is not specified but tools are provided,
         # default to "auto" tool_choice

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -147,6 +147,7 @@ class ChatCompletionResponseStreamChoice(OpenAIBaseModel):
     logprobs: ChatCompletionLogProbs | None = None
     finish_reason: str | None = None
     stop_reason: int | str | None = None
+    usage: UsageInfo | None = None
     # not part of the OpenAI spec but for tracing the tokens
     token_ids: list[int] | None = None
 
@@ -778,6 +779,17 @@ class ChatCompletionRequest(OpenAIBaseModel):
             raise VLLMValidationError(
                 "Stream options can only be defined when `stream=True`.",
                 parameter="stream_options",
+            )
+
+        stream_options = data.get("stream_options")
+        if (
+            envs.NOVITA_ENABLE_KIMI_VALIDATIONS
+            and isinstance(stream_options, dict)
+            and stream_options.get("include_internal_content")
+        ):
+            raise VLLMValidationError(
+                "`stream_options.include_internal_content` is not supported.",
+                parameter="stream_options.include_internal_content",
             )
 
         return data

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -40,7 +40,10 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatMessage,
 )
 from vllm.entrypoints.openai.engine.protocol import (
+    CompletionTokenUsageInfo,
+    DeltaFunctionCall,
     DeltaMessage,
+    DeltaToolCall,
     ErrorResponse,
     FunctionCall,
     PerRequestTimingMetrics,
@@ -432,6 +435,7 @@ class OpenAIServingChat(GenerateBaseServing):
         # Send response for each token for each request.n (index)
         num_choices = 1 if request.n is None else request.n
         previous_num_tokens = [0] * num_choices
+        output_token_ids: list[list[int]] = [[] for _ in range(num_choices)]
         finish_reason_sent = [False] * num_choices
         num_prompt_tokens = 0
         num_cached_tokens = None
@@ -475,6 +479,89 @@ class OpenAIServingChat(GenerateBaseServing):
         include_usage, include_continuous_usage = should_include_usage(
             stream_options, self.enable_force_include_usage
         )
+
+        tool_calls_started: list[set[int]] = [set() for _ in range(num_choices)]
+
+        def make_kimi_usage(
+            completion_tokens: int, choice_index: int | None = None
+        ) -> UsageInfo:
+            usage = UsageInfo(
+                prompt_tokens=num_prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=num_prompt_tokens + completion_tokens,
+            )
+            prompt_token_ids = (
+                last_res.prompt_token_ids
+                if last_res is not None and last_res.prompt_token_ids is not None
+                else []
+            )
+            if choice_index is None:
+                parser_token_ids = zip(parsers, output_token_ids)
+            else:
+                parser_token_ids = [
+                    (parsers[choice_index], output_token_ids[choice_index])
+                ]
+            reasoning_tokens = 0
+            for parser_for_choice, token_ids in parser_token_ids:
+                count_reasoning_tokens = getattr(
+                    parser_for_choice, "count_reasoning_tokens", None
+                )
+                if count_reasoning_tokens is not None:
+                    reasoning_tokens += count_reasoning_tokens(
+                        [*prompt_token_ids, *token_ids]
+                    )
+            usage.completion_tokens_details = CompletionTokenUsageInfo(
+                reasoning_tokens=reasoning_tokens,
+            )
+            prompt_details = PromptTokenUsageInfo(cached_tokens=num_cached_tokens or 0)
+            if mm_token_counts:
+                prompt_details.multimodal_tokens = mm_token_counts
+            usage.prompt_tokens_details = prompt_details
+            return usage
+
+        def split_kimi_tool_delta(
+            delta_message: DeltaMessage, choice_index: int
+        ) -> tuple[DeltaMessage, list[DeltaToolCall]]:
+            continuation_calls: list[DeltaToolCall] = []
+            rewritten_calls: list[DeltaToolCall] = []
+            for tool_call in delta_message.tool_calls:
+                function = tool_call.function
+                has_metadata = (
+                    tool_call.id is not None
+                    or tool_call.type is not None
+                    or (function is not None and function.name is not None)
+                )
+                if (
+                    tool_call.index not in tool_calls_started[choice_index]
+                    and has_metadata
+                ):
+                    tool_calls_started[choice_index].add(tool_call.index)
+                    arguments = function.arguments if function is not None else None
+                    rewritten_calls.append(
+                        tool_call.model_copy(
+                            update={
+                                "function": DeltaFunctionCall(
+                                    name=(
+                                        function.name if function is not None else None
+                                    ),
+                                    arguments="",
+                                )
+                            }
+                        )
+                    )
+                    if arguments:
+                        continuation_calls.append(
+                            DeltaToolCall(
+                                index=tool_call.index,
+                                function=DeltaFunctionCall(arguments=arguments),
+                            )
+                        )
+                else:
+                    rewritten_calls.append(tool_call)
+            return (
+                delta_message.model_copy(update={"tool_calls": rewritten_calls}),
+                continuation_calls,
+            )
 
         last_res: RequestOutput | None = None
         try:
@@ -527,10 +614,14 @@ class OpenAIServingChat(GenerateBaseServing):
 
                         # if continuous usage stats are requested, add it
                         if include_continuous_usage:
-                            chunk.usage = UsageInfo(
-                                prompt_tokens=num_prompt_tokens,
-                                completion_tokens=0,
-                                total_tokens=num_prompt_tokens,
+                            chunk.usage = (
+                                make_kimi_usage(0, i)
+                                if envs.NOVITA_ENABLE_KIMI_VALIDATIONS
+                                else UsageInfo(
+                                    prompt_tokens=num_prompt_tokens,
+                                    completion_tokens=0,
+                                    total_tokens=num_prompt_tokens,
+                                )
                             )
 
                         data = chunk.model_dump_json(exclude_unset=True)
@@ -563,10 +654,14 @@ class OpenAIServingChat(GenerateBaseServing):
                                     model=model_name,
                                 )
                                 if include_continuous_usage:
-                                    chunk.usage = UsageInfo(
-                                        prompt_tokens=num_prompt_tokens,
-                                        completion_tokens=0,
-                                        total_tokens=num_prompt_tokens,
+                                    chunk.usage = (
+                                        make_kimi_usage(0, i)
+                                        if envs.NOVITA_ENABLE_KIMI_VALIDATIONS
+                                        else UsageInfo(
+                                            prompt_tokens=num_prompt_tokens,
+                                            completion_tokens=0,
+                                            total_tokens=num_prompt_tokens,
+                                        )
                                     )
 
                                 data = chunk.model_dump_json(exclude_unset=True)
@@ -622,6 +717,7 @@ class OpenAIServingChat(GenerateBaseServing):
 
                     # set the previous values for the next iteration
                     previous_num_tokens[i] += len(output.token_ids)
+                    output_token_ids[i].extend(as_list(output.token_ids))
 
                     # if the message delta is None (e.g. because it was a
                     # "control token" for tool calls or the parser otherwise
@@ -646,6 +742,12 @@ class OpenAIServingChat(GenerateBaseServing):
                         ):
                             continue
                         delta_message = DeltaMessage()
+
+                    tool_call_continuation: list[DeltaToolCall] = []
+                    if envs.NOVITA_ENABLE_KIMI_VALIDATIONS and delta_message.tool_calls:
+                        delta_message, tool_call_continuation = split_kimi_tool_delta(
+                            delta_message, i
+                        )
 
                     # Log streaming delta if output logging is enabled
                     if self.enable_log_outputs and self.request_logger:
@@ -715,6 +817,86 @@ class OpenAIServingChat(GenerateBaseServing):
                             finish_reason_ = (
                                 output.finish_reason if output.finish_reason else "stop"
                             )
+                        if envs.NOVITA_ENABLE_KIMI_VALIDATIONS and (
+                            delta_message.role is not None
+                            or delta_message.content is not None
+                            or delta_message.reasoning is not None
+                            or delta_message.tool_calls
+                        ):
+                            delta_choice = ChatCompletionResponseStreamChoice(
+                                index=i,
+                                delta=delta_message,
+                                logprobs=logprobs,
+                                finish_reason=None,
+                                token_ids=(
+                                    as_list(output.token_ids)
+                                    if include_token_ids
+                                    else None
+                                ),
+                            )
+                            delta_chunk = ChatCompletionStreamResponse(
+                                id=request_id,
+                                object=chunk_object_type,
+                                created=created_time,
+                                choices=[delta_choice],
+                                model=model_name,
+                            )
+                            if include_continuous_usage:
+                                delta_chunk.usage = (
+                                    make_kimi_usage(previous_num_tokens[i], i)
+                                    if envs.NOVITA_ENABLE_KIMI_VALIDATIONS
+                                    else UsageInfo(
+                                        prompt_tokens=num_prompt_tokens,
+                                        completion_tokens=previous_num_tokens[i],
+                                        total_tokens=(
+                                            num_prompt_tokens + previous_num_tokens[i]
+                                        ),
+                                    )
+                                )
+                            delta_data = delta_chunk.model_dump_json(exclude_unset=True)
+                            yield f"data: {delta_data}\n\n"
+                            if tool_call_continuation:
+                                continuation_choice = maybe_filter_parallel_tool_calls(
+                                    ChatCompletionResponseStreamChoice(
+                                        index=i,
+                                        delta=DeltaMessage(
+                                            tool_calls=tool_call_continuation
+                                        ),
+                                        logprobs=None,
+                                        finish_reason=None,
+                                    ),
+                                    request,
+                                )
+                                continuation_chunk = ChatCompletionStreamResponse(
+                                    id=request_id,
+                                    object=chunk_object_type,
+                                    created=created_time,
+                                    choices=[continuation_choice],
+                                    model=model_name,
+                                )
+                                if include_continuous_usage:
+                                    continuation_chunk.usage = make_kimi_usage(
+                                        previous_num_tokens[i], i
+                                    )
+                                continuation_data = continuation_chunk.model_dump_json(
+                                    exclude_unset=True
+                                )
+                                yield f"data: {continuation_data}\n\n"
+                                tool_call_continuation = []
+                            delta_message = DeltaMessage()
+                            logprobs = None
+                            include_token_ids = False
+
+                        completion_tokens = previous_num_tokens[i]
+                        terminal_usage = (
+                            make_kimi_usage(completion_tokens, i)
+                            if envs.NOVITA_ENABLE_KIMI_VALIDATIONS
+                            else UsageInfo(
+                                prompt_tokens=num_prompt_tokens,
+                                completion_tokens=completion_tokens,
+                                total_tokens=num_prompt_tokens + completion_tokens,
+                            )
+                        )
                         choice_data = ChatCompletionResponseStreamChoice(
                             index=i,
                             delta=delta_message,
@@ -723,6 +905,11 @@ class OpenAIServingChat(GenerateBaseServing):
                             stop_reason=output.stop_reason,
                             token_ids=(
                                 as_list(output.token_ids) if include_token_ids else None
+                            ),
+                            **(
+                                {"usage": terminal_usage}
+                                if envs.NOVITA_ENABLE_KIMI_VALIDATIONS
+                                else {}
                             ),
                         )
 
@@ -750,29 +937,61 @@ class OpenAIServingChat(GenerateBaseServing):
                     # handle usage stats if requested & if continuous
                     if include_continuous_usage:
                         completion_tokens = previous_num_tokens[i]
-                        chunk.usage = UsageInfo(
-                            prompt_tokens=num_prompt_tokens,
-                            completion_tokens=completion_tokens,
-                            total_tokens=num_prompt_tokens + completion_tokens,
+                        chunk.usage = (
+                            make_kimi_usage(completion_tokens, i)
+                            if envs.NOVITA_ENABLE_KIMI_VALIDATIONS
+                            else UsageInfo(
+                                prompt_tokens=num_prompt_tokens,
+                                completion_tokens=completion_tokens,
+                                total_tokens=num_prompt_tokens + completion_tokens,
+                            )
                         )
 
                     data = chunk.model_dump_json(exclude_unset=True)
                     yield f"data: {data}\n\n"
+                    if tool_call_continuation:
+                        continuation_choice = maybe_filter_parallel_tool_calls(
+                            ChatCompletionResponseStreamChoice(
+                                index=i,
+                                delta=DeltaMessage(tool_calls=tool_call_continuation),
+                                logprobs=None,
+                                finish_reason=None,
+                            ),
+                            request,
+                        )
+                        continuation_chunk = ChatCompletionStreamResponse(
+                            id=request_id,
+                            object=chunk_object_type,
+                            created=created_time,
+                            choices=[continuation_choice],
+                            model=model_name,
+                        )
+                        if include_continuous_usage:
+                            continuation_chunk.usage = make_kimi_usage(
+                                previous_num_tokens[i], i
+                            )
+                        continuation_data = continuation_chunk.model_dump_json(
+                            exclude_unset=True
+                        )
+                        yield f"data: {continuation_data}\n\n"
 
             # once the final token is handled, if stream_options.include_usage
             # is sent, send the usage
             if include_usage:
                 completion_tokens = sum(previous_num_tokens)
-                final_usage = UsageInfo(
-                    prompt_tokens=num_prompt_tokens,
-                    completion_tokens=completion_tokens,
-                    total_tokens=num_prompt_tokens + completion_tokens,
-                )
-                final_usage.prompt_tokens_details = _make_prompt_tokens_details(
-                    self.enable_prompt_tokens_details,
-                    num_cached_tokens,
-                    mm_token_counts,
-                )
+                if envs.NOVITA_ENABLE_KIMI_VALIDATIONS:
+                    final_usage = make_kimi_usage(completion_tokens)
+                else:
+                    final_usage = UsageInfo(
+                        prompt_tokens=num_prompt_tokens,
+                        completion_tokens=completion_tokens,
+                        total_tokens=num_prompt_tokens + completion_tokens,
+                    )
+                    final_usage.prompt_tokens_details = _make_prompt_tokens_details(
+                        self.enable_prompt_tokens_details,
+                        num_cached_tokens,
+                        mm_token_counts,
+                    )
 
                 # In streaming, metrics ride on this final usage chunk, which is
                 # only emitted when usage reporting is enabled (i.e.
@@ -806,10 +1025,14 @@ class OpenAIServingChat(GenerateBaseServing):
 
             # report to FastAPI middleware aggregate usage across all choices
             num_completion_tokens = sum(previous_num_tokens)
-            request_metadata.final_usage_info = UsageInfo(
-                prompt_tokens=num_prompt_tokens,
-                completion_tokens=num_completion_tokens,
-                total_tokens=num_prompt_tokens + num_completion_tokens,
+            request_metadata.final_usage_info = (
+                make_kimi_usage(num_completion_tokens)
+                if envs.NOVITA_ENABLE_KIMI_VALIDATIONS
+                else UsageInfo(
+                    prompt_tokens=num_prompt_tokens,
+                    completion_tokens=num_completion_tokens,
+                    total_tokens=num_prompt_tokens + num_completion_tokens,
+                )
             )
 
             # Log complete streaming response if output logging is enabled

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -13,6 +13,7 @@ import numpy as np
 import pybase64 as base64
 from fastapi import Request
 
+from vllm import envs
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import (
     ChatTemplateContentFormatOption,
@@ -117,6 +118,7 @@ class OpenAIServingChat(GenerateBaseServing):
         trust_request_chat_template: bool = False,
         return_tokens_as_token_ids: bool = False,
         reasoning_parser: str = "",
+        enable_structured_outputs_in_reasoning: bool = False,
         enable_auto_tools: bool = False,
         exclude_tools_when_tool_choice_none: bool = False,
         tool_parser: str | None = None,
@@ -144,6 +146,9 @@ class OpenAIServingChat(GenerateBaseServing):
         self.enable_log_deltas = enable_log_deltas
 
         self.enable_auto_tools: bool = enable_auto_tools
+        self.enable_structured_outputs_in_reasoning = (
+            enable_structured_outputs_in_reasoning
+        )
         self.parser_cls = ParserManager.get_parser(
             tool_parser_name=tool_parser,
             reasoning_parser_name=reasoning_parser,
@@ -262,6 +267,9 @@ class OpenAIServingChat(GenerateBaseServing):
                 request.tools,
                 chat_template_kwargs=chat_template_kwargs,
                 model_config=self.model_config,
+                enable_structured_outputs_in_reasoning=(
+                    self.enable_structured_outputs_in_reasoning
+                ),
             )
         result = await self.render_chat_request(request)
         if isinstance(result, ErrorResponse):
@@ -448,6 +456,9 @@ class OpenAIServingChat(GenerateBaseServing):
                         request.tools,
                         chat_template_kwargs=chat_template_kwargs,
                         model_config=self.model_config,
+                        enable_structured_outputs_in_reasoning=(
+                            self.enable_structured_outputs_in_reasoning
+                        ),
                     )
                     for _ in range(num_choices)
                 ]
@@ -691,7 +702,14 @@ class OpenAIServingChat(GenerateBaseServing):
                         # finish_reason is:
                         # "tool_calls" for "auto" or "required" tool calls,
                         # and "stop" for named tool calls.
-                        if tools_streamed[i] and not tool_choice_function_name:
+                        if (
+                            tools_streamed[i]
+                            and not tool_choice_function_name
+                            and (
+                                not envs.NOVITA_ENABLE_KIMI_VALIDATIONS
+                                or output.finish_reason == "stop"
+                            )
+                        ):
                             finish_reason_ = "tool_calls"
                         else:
                             finish_reason_ = (
@@ -957,7 +975,13 @@ class OpenAIServingChat(GenerateBaseServing):
             # In OpenAI's API, when a tool is called, the finish_reason is:
             # "tool_calls" for "auto" or "required" tool calls,
             # and "stop" for named tool calls.
-            is_finish_reason_tool_calls = auto_tools_called or (
+            is_finish_reason_tool_calls = (
+                auto_tools_called
+                and (
+                    not envs.NOVITA_ENABLE_KIMI_VALIDATIONS
+                    or output.finish_reason == "stop"
+                )
+            ) or (
                 request.tool_choice
                 and request.tool_choice == "required"
                 and output.finish_reason == "stop"

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -108,11 +108,16 @@ class PromptTokenUsageInfo(OpenAIBaseModel):
     request has no multimodal input."""
 
 
+class CompletionTokenUsageInfo(OpenAIBaseModel):
+    reasoning_tokens: int = 0
+
+
 class UsageInfo(OpenAIBaseModel):
     prompt_tokens: int = 0
     total_tokens: int = 0
     completion_tokens: int | None = 0
     prompt_tokens_details: PromptTokenUsageInfo | None = None
+    completion_tokens_details: CompletionTokenUsageInfo | None = None
 
 
 class PerRequestTimingMetrics(OpenAIBaseModel):
@@ -249,6 +254,7 @@ def validate_structured_outputs_structural_tag(
 class StreamOptions(OpenAIBaseModel):
     include_usage: bool | None = False
     continuous_usage_stats: bool | None = False
+    include_internal_content: bool | None = False
 
 
 class FunctionDefinition(OpenAIBaseModel):

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -218,6 +218,7 @@ if TYPE_CHECKING:
     VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: int = 163840
     VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS: int = 1
     VLLM_ENFORCE_STRICT_TOOL_CALLING: bool = True
+    NOVITA_ENABLE_KIMI_VALIDATIONS: bool = False
     VLLM_MQ_MAX_CHUNK_BYTES_MB: int = 16
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: int = 300
     VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS: int = 5
@@ -1662,6 +1663,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ENFORCE_STRICT_TOOL_CALLING": lambda: (
         os.getenv("VLLM_ENFORCE_STRICT_TOOL_CALLING", "True").lower() in ("true", "1")
     ),
+    "NOVITA_ENABLE_KIMI_VALIDATIONS": lambda: bool(
+        int(os.getenv("NOVITA_ENABLE_KIMI_VALIDATIONS", "0"))
+    ),
     # Control the max chunk bytes (in MB) for the rpc message queue.
     # Object larger than this threshold will be broadcast to worker
     # processes via zmq.
@@ -2169,6 +2173,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_ENABLE_CUDA_COMPATIBILITY",
         "VLLM_CUDA_COMPATIBILITY_PATH",
         "VLLM_SKIP_MODEL_NAME_VALIDATION",
+        "NOVITA_ENABLE_KIMI_VALIDATIONS",
         "LOCAL_RANK",
         "CUDA_VISIBLE_DEVICES",
         "NO_COLOR",

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -11,6 +11,7 @@ from functools import cached_property
 from openai.types.responses import ToolChoiceFunction
 from pydantic import TypeAdapter, ValidationError
 
+from vllm import envs
 from vllm.entrypoints.chat_utils import (
     get_tool_call_id_type,
     make_tool_call_id,
@@ -115,9 +116,14 @@ class Parser:
         tools: list[Tool] | None = None,
         *args,
         model_config=None,
+        enable_structured_outputs_in_reasoning: bool = False,
         **kwargs,
     ):
         self.model_tokenizer = tokenizer
+        self._chat_template_kwargs = kwargs.get("chat_template_kwargs") or {}
+        self._enable_structured_outputs_in_reasoning = (
+            enable_structured_outputs_in_reasoning
+        )
         self._reasoning_parser: ReasoningParser | None = None
         self._tool_parser: ToolParser | None = None
         if self.__class__.reasoning_parser_cls is not None:
@@ -540,9 +546,10 @@ class DelegatingParser(Parser):
         if not need_tool_calling:
             return request
 
+        reasoning = self._should_enable_structural_tag_reasoning(request)
         structure_tag = self._tool_parser.get_structural_tag(
             request,
-            reasoning=False,
+            reasoning=reasoning,
         )
         if structure_tag is None:
             return request
@@ -556,6 +563,24 @@ class DelegatingParser(Parser):
         else:
             request.response_format = None
         return request
+
+    def _should_enable_structural_tag_reasoning(
+        self, request: ChatCompletionRequest | ResponsesRequest
+    ) -> bool:
+        if (
+            not envs.NOVITA_ENABLE_KIMI_VALIDATIONS
+            or not self._enable_structured_outputs_in_reasoning
+            or self._tool_parser is None
+            or self._tool_parser.structural_tag_model != "kimi"
+            or request.tool_choice != "auto"
+        ):
+            return False
+
+        thinking = self._chat_template_kwargs.get("thinking")
+        enable_thinking = self._chat_template_kwargs.get("enable_thinking")
+        if thinking is None and enable_thinking is None:
+            return True
+        return bool(thinking) or bool(enable_thinking)
 
     def extract_reasoning_streaming(
         self,

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -54,6 +54,7 @@ class ToolCallSlot:
         "name_sent",
         "string_keys",
         "streamed_json",
+        "complete",
     )
 
     def __init__(self) -> None:
@@ -64,6 +65,7 @@ class ToolCallSlot:
         self.name_sent: bool = False
         self.string_keys: set[str] | None = None
         self.streamed_json: str = ""
+        self.complete: bool = False
 
     @property
     def args(self) -> str:
@@ -1017,6 +1019,8 @@ class ParserEngine(Parser):
 
         tool_calls: list[ToolCall] = []
         for idx, slot in enumerate(self._tool_slots):
+            if not self._should_include_tool_slot(slot):
+                continue
             if not slot.name and not slot.args:
                 continue
 
@@ -1058,6 +1062,9 @@ class ParserEngine(Parser):
             tool_calls=tool_calls,
             content=content,
         )
+
+    def _should_include_tool_slot(self, slot: ToolCallSlot) -> bool:
+        return True
 
     @staticmethod
     def _extract_args_value(parsed: dict) -> str | None:

--- a/vllm/parser/engine/parser_engine_config.py
+++ b/vllm/parser/engine/parser_engine_config.py
@@ -78,6 +78,10 @@ class ParserEngineConfig:
 
     tool_args_json: bool = True
 
+    # Emit TOOL_CALL_END at EOF for parsers that historically accepted
+    # unterminated tool calls.
+    close_incomplete_tool_call_on_finish: bool = True
+
     arg_structural_chars: frozenset[str] | None = None
 
     # Special tokens exempt from auto-drop but not state-machine terminals.

--- a/vllm/parser/engine/streaming_parser_engine.py
+++ b/vllm/parser/engine/streaming_parser_engine.py
@@ -256,7 +256,10 @@ class StreamingParserEngine:
             ParserState.TOOL_NAME,
             ParserState.TOOL_BETWEEN,
         ):
-            if self.tool_index >= 0:
+            if (
+                self.config.close_incomplete_tool_call_on_finish
+                and self.tool_index >= 0
+            ):
                 events.append(
                     SemanticEvent(
                         EventType.TOOL_CALL_END,

--- a/vllm/parser/kimi_k2.py
+++ b/vllm/parser/kimi_k2.py
@@ -16,11 +16,14 @@ call id. The function name is the final component before ``:N``.
 from __future__ import annotations
 
 import functools
+import json
 from collections.abc import Sequence
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 import regex as re
 
+from vllm import envs
 from vllm.entrypoints.openai.engine.protocol import DeltaFunctionCall, DeltaToolCall
 from vllm.parser.engine.events import EventType
 from vllm.parser.engine.parser_engine import ParserEngine
@@ -164,10 +167,16 @@ class KimiK2Parser(ParserEngine):
             if thinking is None and enable_thinking is None
             else bool(thinking) or bool(enable_thinking)
         )
-        kwargs.setdefault(
-            "parser_engine_config",
-            kimi_k2_config(thinking=self.thinking_enabled),
+        self._validate_complete_tool_calls = envs.NOVITA_ENABLE_KIMI_VALIDATIONS
+        parser_engine_config = kwargs.get(
+            "parser_engine_config", kimi_k2_config(thinking=self.thinking_enabled)
         )
+        if self._validate_complete_tool_calls:
+            parser_engine_config = replace(
+                parser_engine_config,
+                close_incomplete_tool_call_on_finish=False,
+            )
+        kwargs["parser_engine_config"] = parser_engine_config
         super().__init__(tokenizer, tools, **kwargs)
 
         vocab = self.vocab
@@ -205,17 +214,58 @@ class KimiK2Parser(ParserEngine):
 
     def _handle_tool_end(self, event, deltas) -> None:
         idx = event.tool_index
-        if 0 <= idx < len(self._tool_slots) and not self._tool_slots[idx].name_sent:
-            tool_id, tool_name = self._extract_tool_id_and_name(
-                self._tool_slots[idx].name
+        if not self._validate_complete_tool_calls:
+            if 0 <= idx < len(self._tool_slots) and not self._tool_slots[idx].name_sent:
+                tool_id, tool_name = self._extract_tool_id_and_name(
+                    self._tool_slots[idx].name
+                )
+                if tool_name:
+                    self._tool_slots[idx].id = tool_id or ""
+                    self._tool_slots[idx].name = tool_name
+            super()._handle_tool_end(event, deltas)
+            return
+
+        if not 0 <= idx < len(self._tool_slots):
+            return
+
+        slot = self._tool_slots[idx]
+        tool_id, tool_name = self._extract_tool_id_and_name(slot.name)
+        if not tool_name:
+            return
+
+        args_json = slot.args.strip() or "{}"
+        try:
+            parsed_args = json.loads(args_json)
+        except json.JSONDecodeError:
+            return
+        if not isinstance(parsed_args, dict):
+            return
+
+        slot.id = tool_id or ""
+        slot.name = tool_name
+        if not self._is_valid_tool_name(tool_name):
+            return
+
+        slot.complete = True
+        slot.name_sent = True
+        args_json = self._fix_arg_types(args_json, tool_name)
+        output_idx = sum(prev.complete for prev in self._tool_slots[:idx])
+        deltas.append(
+            DeltaToolCall(
+                index=output_idx,
+                id=slot.id,
+                type="function",
+                function=DeltaFunctionCall(name=tool_name, arguments=args_json),
             )
-            if tool_name:
-                self._tool_slots[idx].id = tool_id or ""
-                self._tool_slots[idx].name = tool_name
-        super()._handle_tool_end(event, deltas)
+        )
 
     def _handle_arg_chunk(self, event, deltas) -> None:
         idx = event.tool_index
+        if self._validate_complete_tool_calls:
+            if event.value and 0 <= idx < len(self._tool_slots):
+                self._tool_slots[idx].append_args(event.value)
+            return
+
         name_sent_before = (
             0 <= idx < len(self._tool_slots) and self._tool_slots[idx].name_sent
         )
@@ -232,6 +282,11 @@ class KimiK2Parser(ParserEngine):
                     function=DeltaFunctionCall(arguments=event.value),
                 )
             )
+
+    def _should_include_tool_slot(self, slot) -> bool:
+        if not self._validate_complete_tool_calls:
+            return True
+        return slot.complete
 
     def _extract_args_json(self, raw_args: str, func_name: str) -> str:
         return raw_args.strip() or "{}"

--- a/vllm/renderers/online_renderer.py
+++ b/vllm/renderers/online_renderer.py
@@ -61,6 +61,7 @@ class OnlineRenderer:
         exclude_tools_when_tool_choice_none: bool = False,
         tool_parser: str | None = None,
         reasoning_parser: str | None = None,
+        enable_structured_outputs_in_reasoning: bool = False,
         default_chat_template_kwargs: dict[str, Any] | None = None,
         log_error_stack: bool = False,
     ) -> None:
@@ -69,6 +70,9 @@ class OnlineRenderer:
         self.request_logger = request_logger
 
         self.enable_auto_tools = enable_auto_tools
+        self.enable_structured_outputs_in_reasoning = (
+            enable_structured_outputs_in_reasoning
+        )
         self.exclude_tools_when_tool_choice_none = exclude_tools_when_tool_choice_none
         self.use_harmony = model_config.hf_config.model_type == "gpt_oss"
         self.parser: type[Parser] | None = ParserManager.get_parser(
@@ -415,6 +419,9 @@ class OnlineRenderer:
                     request.tools,
                     model_config=self.model_config,
                     chat_template_kwargs=chat_params.chat_template_kwargs,
+                    enable_structured_outputs_in_reasoning=(
+                        self.enable_structured_outputs_in_reasoning
+                    ),
                 ).adjust_request(
                     request=request,
                 )

--- a/vllm/tool_parsers/structural_tag_registry.py
+++ b/vllm/tool_parsers/structural_tag_registry.py
@@ -25,6 +25,7 @@ from xgrammar.structural_tag import (
     TriggeredTagsFormat,
 )
 
+from vllm import envs
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionNamedToolChoiceParam,
     ChatCompletionToolsParam,
@@ -106,10 +107,20 @@ def get_model_structural_tag(
     if not tools or tool_choice == "none":
         return None
 
-    if tool_choice == "auto" and not _any_tool_strict(tools):
+    kimi_auto_enabled = (
+        envs.NOVITA_ENABLE_KIMI_VALIDATIONS
+        and model == "kimi"
+        and tool_choice == "auto"
+    )
+    if tool_choice == "auto" and not kimi_auto_enabled and not _any_tool_strict(tools):
         return None
 
     dumped_tools = [_dump_tool_for_xgrammar(tool) for tool in tools]
+    if kimi_auto_enabled:
+        for tool in dumped_tools:
+            function = tool.get("function")
+            if isinstance(function, dict):
+                function.pop("strict", None)
     dumped_tool_choice = _dump_tool_choice_for_xgrammar(tool_choice)
 
     if model in _VLLM_STRUCTURAL_TAG_REGISTRY:

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -10,11 +10,13 @@ from typing import TYPE_CHECKING
 
 import torch
 
+from vllm import envs
 from vllm.logger import init_logger
 from vllm.logits_process import LogitsProcessor as RequestLogitsProcessor
 from vllm.sampling_params import SamplingParams
 from vllm.utils.torch_utils import guard_cuda_initialization
 from vllm.v1.sample.logits_processor.builtin import (
+    KimiReasoningLogitsProcessor,
     LogitBiasLogitsProcessor,
     MinPLogitsProcessor,
     MinTokensLogitsProcessor,
@@ -50,6 +52,13 @@ BUILTIN_LOGITS_PROCESSORS: list[type[LogitsProcessor]] = [
     MinTokensLogitsProcessor,
     LogitBiasLogitsProcessor,
     MinPLogitsProcessor,
+]
+
+# Only processors with an explicit speculative-draft implementation belong
+# here. Other custom processors keep the target branch's rejection behavior.
+KIMI_SPEC_DECODE_LOGITS_PROCESSORS: list[type[LogitsProcessor]] = [
+    MinTokensLogitsProcessor,
+    KimiReasoningLogitsProcessor,
 ]
 
 
@@ -199,13 +208,48 @@ def build_logitsprocs(
 
     # Check if speculative decoding is enabled.
     if vllm_config.speculative_config:
+        spec_decode_custom_classes: list[type[LogitsProcessor]] = []
         if custom_logitsprocs:
-            raise ValueError(STR_SPEC_DEC_REJECTS_LOGITSPROCS)
+            if not envs.NOVITA_ENABLE_KIMI_VALIDATIONS:
+                raise ValueError(STR_SPEC_DEC_REJECTS_LOGITSPROCS)
+
+            from vllm.platforms import current_platform
+
+            if current_platform.is_tpu():
+                logger.warning(
+                    "Ignoring custom logits processors under speculative "
+                    "decoding because TPU does not support them."
+                )
+            else:
+                spec_decode_custom_classes = _load_logitsprocs_by_fqcns(
+                    custom_logitsprocs
+                )
+                unsupported = [
+                    processor
+                    for processor in spec_decode_custom_classes
+                    if processor not in KIMI_SPEC_DECODE_LOGITS_PROCESSORS
+                ]
+                if unsupported:
+                    rejected = ", ".join(cls.__name__ for cls in unsupported)
+                    supported = ", ".join(
+                        cls.__name__ for cls in KIMI_SPEC_DECODE_LOGITS_PROCESSORS
+                    )
+                    raise ValueError(
+                        "One or more custom logits processor(s) are not supported "
+                        "under speculative decoding. "
+                        f"Rejected: {rejected}. "
+                        f"Supported under spec decode: {supported}."
+                    )
         logger.warning(
             "min_p and logit_bias parameters won't work with speculative decoding."
         )
+
+        processor_classes = dict.fromkeys(
+            [MinTokensLogitsProcessor, *spec_decode_custom_classes]
+        )
         return LogitsProcessors(
-            [MinTokensLogitsProcessor(vllm_config, device, is_pin_memory)]
+            processor(vllm_config, device, is_pin_memory)
+            for processor in processor_classes
         )
 
     custom_logitsprocs_classes = _load_custom_logitsprocs(custom_logitsprocs)
@@ -346,6 +390,7 @@ __all__ = [
     "LogitBiasLogitsProcessor",
     "MinPLogitsProcessor",
     "MinTokensLogitsProcessor",
+    "KimiReasoningLogitsProcessor",
     "BatchUpdate",
     "BatchUpdateBuilder",
     "MoveDirectionality",

--- a/vllm/v1/sample/logits_processor/builtin.py
+++ b/vllm/v1/sample/logits_processor/builtin.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING, TypeVar
 import numpy as np
 import torch
 
-from vllm import SamplingParams
+from vllm import SamplingParams, envs
+from vllm.logger import init_logger
 from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.sample.logits_processor.interface import (
     BatchUpdate,
@@ -16,6 +17,8 @@ from vllm.v1.sample.logits_processor.interface import (
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+
+logger = init_logger(__name__)
 
 T = TypeVar("T")
 
@@ -236,6 +239,7 @@ class MinTokensLogitsProcessor(LogitsProcessor):
         self,
         logits: torch.Tensor,
         num_draft_tokens: list[int],
+        _spec_token_ids: list[list[int]] | None = None,
     ) -> torch.Tensor:
         """Spec-decode version of apply().
         Priority: ``min_tokens`` > ``stop_token_ids`` / EOS.
@@ -325,3 +329,260 @@ def process_dict_updates(
                     req_entries[a_index] = b_entry
 
     return updated
+
+
+class KimiReasoningLogitsProcessor(LogitsProcessor):
+    """Bans invalid Kimi special tokens while a request is reasoning."""
+
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        device: torch.device,
+        is_pin_memory: bool,
+    ):
+        self.device = device
+        self.pin_memory = is_pin_memory
+
+        self.think_start_token_id: int | None = None
+        self.reasoning_end_token_ids: set[int] = set()
+        self.banned_special_token_ids: list[int] = []
+        self.banned_token_ids_tensor = torch.tensor(
+            [], device=self.device, dtype=torch.int64
+        )
+        self._init_token_ids(vllm_config)
+
+        # index -> (output_tok_ids, is_reasoning, last_checked_pos)
+        self.req_states: dict[int, tuple[Sequence[int], bool, int]] = {}
+        self.has_reasoning = False
+        self.reasoning_indices_tensor = torch.tensor(
+            [], device=self.device, dtype=torch.int64
+        )
+        self.neg_inf_tensor = torch.tensor(
+            -float("inf"), dtype=torch.float32, device=self.device
+        )
+
+    def _init_token_ids(self, vllm_config: "VllmConfig") -> None:
+        if not envs.NOVITA_ENABLE_KIMI_VALIDATIONS:
+            return
+
+        structured_outputs_config = getattr(
+            vllm_config, "structured_outputs_config", None
+        )
+        if structured_outputs_config is None:
+            return
+        reasoning_parser_name = structured_outputs_config.reasoning_parser
+        if reasoning_parser_name != "kimi_k2":
+            return
+        model_config = getattr(vllm_config, "model_config", None)
+        if model_config is None or model_config.skip_tokenizer_init:
+            return
+
+        try:
+            from vllm.reasoning import ReasoningParserManager
+            from vllm.tokenizers import cached_tokenizer_from_config
+
+            tokenizer = cached_tokenizer_from_config(model_config=model_config)
+            reasoner_cls = ReasoningParserManager.get_reasoning_parser(
+                reasoning_parser_name
+            )
+            reasoner = reasoner_cls(tokenizer=tokenizer)
+            reasoner_impl = getattr(reasoner, "_parser_engine", reasoner)
+
+            self.think_start_token_id = getattr(
+                reasoner_impl,
+                "_start_token_id",
+                getattr(reasoner_impl, "_reasoning_start_token_id", None),
+            )
+            think_end_token_id = getattr(
+                reasoner_impl,
+                "_end_token_id",
+                getattr(reasoner_impl, "_reasoning_end_token_id", None),
+            )
+
+            all_special_ids: set[int] = set()
+            if hasattr(tokenizer, "all_special_ids"):
+                all_special_ids.update(tokenizer.all_special_ids)
+            if hasattr(tokenizer, "added_tokens_encoder"):
+                all_special_ids.update(tokenizer.added_tokens_encoder.values())
+
+            # Kimi can end reasoning implicitly by starting a tool-call section.
+            # Those tokens must remain legal and also flip reasoning state off.
+            reasoning_end_token_ids: set[int] = set()
+            if think_end_token_id is not None:
+                reasoning_end_token_ids.add(think_end_token_id)
+            for token_id in all_special_ids:
+                try:
+                    if reasoner.is_reasoning_end([token_id]):
+                        reasoning_end_token_ids.add(token_id)
+                except Exception:
+                    pass
+            self.reasoning_end_token_ids = reasoning_end_token_ids
+
+            self.banned_special_token_ids = list(
+                all_special_ids - reasoning_end_token_ids
+            )
+            self.banned_token_ids_tensor = torch.tensor(
+                self.banned_special_token_ids,
+                device="cpu",
+                dtype=torch.int64,
+                pin_memory=self.pin_memory,
+            ).to(device=self.device, non_blocking=True)
+        except Exception as exc:
+            logger.warning(
+                "KimiReasoningLogitsProcessor init token ids failed: %s", exc
+            )
+
+    def _device_tensor(self, data: list, dtype: torch.dtype) -> torch.Tensor:
+        return torch.tensor(
+            data, device="cpu", dtype=dtype, pin_memory=self.pin_memory
+        ).to(device=self.device, non_blocking=True)
+
+    def is_argmax_invariant(self) -> bool:
+        return False
+
+    def _check_prompt_reasoning(self, prompt_tok_ids: Sequence[int] | None) -> bool:
+        if not prompt_tok_ids:
+            return False
+        is_reasoning = False
+        for token_id in prompt_tok_ids:
+            if token_id == self.think_start_token_id:
+                is_reasoning = True
+            elif token_id in self.reasoning_end_token_ids:
+                is_reasoning = False
+        return is_reasoning
+
+    def _check_reasoning_state(
+        self,
+        output_tok_ids: Sequence[int],
+        is_reasoning: bool,
+        last_pos: int,
+    ) -> tuple[bool, int]:
+        current_len = len(output_tok_ids)
+        checked_pos = last_pos
+        for index in range(last_pos, current_len):
+            token_id = output_tok_ids[index]
+            if token_id == -1:
+                break
+            checked_pos = index + 1
+            if token_id == self.think_start_token_id:
+                is_reasoning = True
+            elif token_id in self.reasoning_end_token_ids:
+                is_reasoning = False
+        return is_reasoning, checked_pos
+
+    def update_state(self, batch_update: BatchUpdate | None) -> None:
+        if (
+            self.think_start_token_id is None
+            or not self.reasoning_end_token_ids
+            or not self.banned_special_token_ids
+        ):
+            return
+
+        if batch_update:
+            for index in batch_update.removed:
+                self.req_states.pop(index, None)
+
+            for index, _, prompt_tok_ids, output_tok_ids in batch_update.added:
+                initial_reasoning = self._check_prompt_reasoning(prompt_tok_ids)
+                self.req_states[index] = (output_tok_ids, initial_reasoning, 0)
+
+            for a_index, b_index, direct in batch_update.moved:
+                a_state = self.req_states.pop(a_index, None)
+                b_state = self.req_states.pop(b_index, None)
+                if a_state is not None:
+                    self.req_states[b_index] = a_state
+                if b_state is not None and direct == MoveDirectionality.SWAP:
+                    self.req_states[a_index] = b_state
+
+        reasoning_indices: list[int] = []
+        for index, (token_ids, is_reasoning, last_pos) in self.req_states.items():
+            is_reasoning, last_pos = self._check_reasoning_state(
+                token_ids, is_reasoning, last_pos
+            )
+            self.req_states[index] = (token_ids, is_reasoning, last_pos)
+            if is_reasoning:
+                reasoning_indices.append(index)
+
+        self.has_reasoning = bool(reasoning_indices)
+        if self.has_reasoning:
+            self.reasoning_indices_tensor = self._device_tensor(
+                reasoning_indices, torch.int64
+            )
+
+    def apply(self, logits: torch.Tensor) -> torch.Tensor:
+        if self.has_reasoning:
+            logits[
+                self.reasoning_indices_tensor[:, None],
+                self.banned_token_ids_tensor[None, :],
+            ] = self.neg_inf_tensor
+        return logits
+
+    def apply_with_spec_decode(
+        self,
+        logits: torch.Tensor,
+        num_draft_tokens: list[int],
+        spec_token_ids: list[list[int]] | None = None,
+    ) -> torch.Tensor:
+        if not self.req_states:
+            return logits
+
+        num_draft_arr = np.array(num_draft_tokens, dtype=np.int64)
+        cumulative_tokens = np.concatenate([[0], np.cumsum(num_draft_arr)])
+
+        rows: list[int] = []
+        for index, (_, is_reasoning, _) in self.req_states.items():
+            offset = int(cumulative_tokens[index])
+            num_tokens = int(num_draft_arr[index])
+            draft_ids = (
+                spec_token_ids[index]
+                if spec_token_ids is not None and index < len(spec_token_ids)
+                else ()
+            )
+            for draft_pos in range(num_tokens):
+                if is_reasoning:
+                    rows.append(offset + draft_pos)
+                if draft_pos >= len(draft_ids):
+                    continue
+                token_id = draft_ids[draft_pos]
+                if token_id == -1:
+                    continue
+                if token_id == self.think_start_token_id:
+                    is_reasoning = True
+                elif token_id in self.reasoning_end_token_ids:
+                    is_reasoning = False
+
+        if rows:
+            row_tensor = self._device_tensor(rows, torch.int64)
+            logits[
+                row_tensor[:, None],
+                self.banned_token_ids_tensor[None, :],
+            ] = self.neg_inf_tensor
+
+        return logits
+
+    def apply_to_spec_decode_bonus(
+        self,
+        logits: torch.Tensor,
+        spec_token_ids: list[list[int]] | None,
+    ) -> torch.Tensor:
+        if not self.req_states:
+            return logits
+
+        draft_tokens = spec_token_ids or []
+        rows: list[int] = []
+        for index, (_, is_reasoning, _) in self.req_states.items():
+            if index < len(draft_tokens):
+                is_reasoning, _ = self._check_reasoning_state(
+                    draft_tokens[index], is_reasoning, 0
+                )
+            if is_reasoning:
+                rows.append(index)
+
+        if rows:
+            row_tensor = self._device_tensor(rows, torch.int64)
+            logits[
+                row_tensor[:, None],
+                self.banned_token_ids_tensor[None, :],
+            ] = self.neg_inf_tensor
+
+        return logits

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import torch
 import torch.nn as nn
 
+from vllm import envs
 from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplerOutput
@@ -333,7 +334,18 @@ class RejectionSampler(nn.Module):
             )
 
         for processor in sampling_metadata.logitsprocs.non_argmax_invariant:
-            if isinstance(processor, MinTokensLogitsProcessor):
+            if envs.NOVITA_ENABLE_KIMI_VALIDATIONS:
+                apply_with_spec_decode = getattr(
+                    processor, "apply_with_spec_decode", None
+                )
+                if not callable(apply_with_spec_decode):
+                    continue
+                logits = apply_with_spec_decode(
+                    logits,
+                    metadata.num_draft_tokens,
+                    sampling_metadata.spec_token_ids,
+                )
+            elif isinstance(processor, MinTokensLogitsProcessor):
                 logits = processor.apply_with_spec_decode(
                     logits, metadata.num_draft_tokens
                 )

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -5,6 +5,7 @@
 import torch
 import torch.nn as nn
 
+from vllm import envs
 from vllm.config.model import LogprobsMode
 from vllm.utils.torch_utils import PIN_MEMORY
 from vllm.v1.outputs import LogprobsTensors, SamplerOutput
@@ -402,6 +403,15 @@ class Sampler(nn.Module):
 
         # Apply logits processors which can impact greedy sampling.
         for processor in sampling_metadata.logitsprocs.non_argmax_invariant:
+            if envs.NOVITA_ENABLE_KIMI_VALIDATIONS and predict_bonus_token:
+                apply_to_spec_decode_bonus = getattr(
+                    processor, "apply_to_spec_decode_bonus", None
+                )
+                if callable(apply_to_spec_decode_bonus):
+                    logits = apply_to_spec_decode_bonus(
+                        logits, sampling_metadata.spec_token_ids
+                    )
+                    continue
             logits = processor.apply(logits)
 
         # Apply penalties (e.g., freq_penalties).


### PR DESCRIPTION
## Summary
- Add `NOVITA_ENABLE_KIMI_VALIDATIONS` env gate to opt into Kimi K2 agentic serving behavior without changing upstream defaults when disabled.
- Harden Kimi tool-call parsing with structural tags, reasoning-aware structured output configuration, and suppression of incomplete/invalid native tool calls.
- Enforce Kimi reasoning state during speculative decoding via an env-gated logits processor, including draft/bonus-token state transitions.
- Complete the gated streaming vendor contract for chat completions, including reasoning token usage reporting and Kimi-specific tool-call delta handling.

## Test plan
- [x] `pytest tests/tool_parsers/test_kimi_k2_tool_parser.py`
- [x] `pytest tests/tool_parsers/test_structural_tag_registry.py`
- [x] `pytest tests/entrypoints/openai/chat_completion/test_serving_chat.py`
- [x] `pytest tests/entrypoints/openai/test_chat_completion_request_validations.py`
- [x] `pytest tests/v1/sample/test_rejection_sampler.py`


Made with [Cursor](https://cursor.com)