### PR TITLE
[Kernel] Use fixed BLOCK_SIZE in count_expert_num_tokens to avoid Triton recompiles

### DIFF
--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -94,8 +94,7 @@ def count_expert_num_tokens(
     )
 
     grid = num_local_experts
-    BLOCK_SIZE = min(topk_ids.numel(), 1024)
-    BLOCK_SIZE = triton.next_power_of_2(BLOCK_SIZE)
+    BLOCK_SIZE = 1024
 
     _count_expert_num_tokens[(grid,)](
         topk_ids,


### PR DESCRIPTION
## What this PR does
Hardcodes `BLOCK_SIZE=1024` in `count_expert_num_tokens` instead of computing it as `next_power_of_2(min(numel, 1024))`. The latter is a runtime-varying `tl.constexpr`, which forces a Triton kernel recompile every time `numel` crosses a new power-of-2 boundary — one of several instances flagged in #48650.

The kernel's existing masking logic (`tl.cdiv(topk_numel, BLOCK_SIZE)`-based loop with per-iteration masks) already handles any `BLOCK_SIZE` correctly regardless of the actual `numel`, so this is a pure performance fix with no behavior change.

## Testing
- `pytest tests/kernels/moe/test_count_expert_num_tokens.py` — 146/146 passed
- Manually verified correctness across numel values from 8 to 100,000 on a T4 GPU
- Manually verified call-to-call latency stays stable (no periodic spikes) across non-monotonic numel values, consistent with the recompile being eliminated

Related to #48650.