### PR TITLE
[Perf] Improve `--linear-backend` filtering

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1319,6 +1319,21 @@ class VllmConfig:
         self.kernel_config.set_platform_defaults(self)
 
         default_config = OPTIMIZATION_LEVEL_TO_CONFIG[self.optimization_level]
+
+        # flashinfer_b12x only beats CUTLASS with autotuning, so guarantee it
+        # when explicitly requested instead of serving the slow fallback.
+        if "flashinfer_b12x" in (
+            self.kernel_config.linear_backend,
+            self.kernel_config.moe_backend,
+        ):
+            if self.kernel_config.enable_flashinfer_autotune is None:
+                self.kernel_config.enable_flashinfer_autotune = True
+            elif self.kernel_config.enable_flashinfer_autotune is False:
+                logger.warning(
+                    "flashinfer_b12x requested with autotuning off; expect "
+                    "~3.6x slower prefill from heuristic fallback tactics."
+                )
+
         self._apply_optimization_level_defaults(default_config)
         if self.kernel_config.enable_flashinfer_autotune is None:
             raise ValueError(

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1319,21 +1319,6 @@ class VllmConfig:
         self.kernel_config.set_platform_defaults(self)
 
         default_config = OPTIMIZATION_LEVEL_TO_CONFIG[self.optimization_level]
-
-        # flashinfer_b12x only beats CUTLASS with autotuning, so guarantee it
-        # when explicitly requested instead of serving the slow fallback.
-        if "flashinfer_b12x" in (
-            self.kernel_config.linear_backend,
-            self.kernel_config.moe_backend,
-        ):
-            if self.kernel_config.enable_flashinfer_autotune is None:
-                self.kernel_config.enable_flashinfer_autotune = True
-            elif self.kernel_config.enable_flashinfer_autotune is False:
-                logger.warning(
-                    "flashinfer_b12x requested with autotuning off; expect "
-                    "~3.6x slower prefill from heuristic fallback tactics."
-                )
-
         self._apply_optimization_level_defaults(default_config)
         if self.kernel_config.enable_flashinfer_autotune is None:
             raise ValueError(

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -333,7 +333,7 @@ def _resolve_backend_kernels(
     """Apply --linear-backend filtering to one layer type's kernel list.
 
     When the requested backend has no kernel for this layer type, fall back
-    to the unfiltered list (with an INFO log) instead of failing engine
+    to the unfiltered list (with a WARNING log) instead of failing engine
     startup: an explicitly requested backend usually provides kernels for a
     single quantization scheme, while a model can contain several linear
     layer types (e.g. NVFP4 MoE projections next to FP8 attention
@@ -344,7 +344,7 @@ def _resolve_backend_kernels(
         return kernels
     filtered = _filter_kernels_by_backend(linear_backend, kernels)
     if not filtered:
-        logger.info_once(
+        logger.warning_once(
             "--linear-backend=%s was requested, but no %s kernel exists for "
             "%s layers; falling back to normal kernel selection for this "
             "layer.",
@@ -496,8 +496,6 @@ _POSSIBLE_NVFP4_KERNELS: dict[PlatformEnum, list[type[NvFp4LinearKernel]]] = {
     PlatformEnum.CUDA: [
         FlashInferCuteDslNvFp4LinearKernel,
         FlashInferCutlassNvFp4LinearKernel,
-        # After CUTLASS for auto-selection; explicit --linear-backend
-        # flashinfer_b12x force-enables the autotuning it needs to win.
         FlashInferB12xNvFp4LinearKernel,
         CutlassNvFp4LinearKernel,
         MarlinNvFp4LinearKernel,

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -326,6 +326,37 @@ def _filter_kernels_by_backend(
     return [k for k in kernels if k in backend_kernels]
 
 
+def _resolve_backend_kernels(
+    kernels: list[type],
+    layer_desc: str,
+) -> list[type]:
+    """Apply --linear-backend filtering to one layer type's kernel list.
+
+    When the requested backend has no kernel for this layer type, fall back
+    to the unfiltered list (with an INFO log) instead of failing engine
+    startup: an explicitly requested backend usually provides kernels for a
+    single quantization scheme, while a model can contain several linear
+    layer types (e.g. NVFP4 MoE projections next to FP8 attention
+    projections).
+    """
+    linear_backend = _get_linear_backend()
+    if linear_backend == "auto":
+        return kernels
+    filtered = _filter_kernels_by_backend(linear_backend, kernels)
+    if not filtered:
+        logger.info_once(
+            "--linear-backend=%s was requested, but no %s kernel exists for "
+            "%s layers; falling back to normal kernel selection for this "
+            "layer.",
+            linear_backend,
+            linear_backend,
+            layer_desc,
+            scope="global",
+        )
+        return kernels
+    return filtered
+
+
 # in priority/performance order (when available)
 _POSSIBLE_INT8_KERNELS: dict[PlatformEnum, list[type[Int8ScaledMMLinearKernel]]] = {
     PlatformEnum.CPU: [ZentorchInt8ScaledMMLinearKernel, CPUInt8ScaledMMLinearKernel],
@@ -464,10 +495,12 @@ _POSSIBLE_MXFP8_KERNELS: dict[PlatformEnum, list[type[Mxfp8LinearKernel]]] = {
 _POSSIBLE_NVFP4_KERNELS: dict[PlatformEnum, list[type[NvFp4LinearKernel]]] = {
     PlatformEnum.CUDA: [
         FlashInferCuteDslNvFp4LinearKernel,
-        # FlashInferB12xNvFp4LinearKernel excluded from auto-selection until
-        # upstream CUTLASS SM121 MMA op guard is resolved; use
-        # --linear-backend flashinfer_b12x to opt in explicitly.
         FlashInferCutlassNvFp4LinearKernel,
+        # Listed after the CUTLASS kernel so auto-selection prefers CUTLASS:
+        # the b12x GEMM needs FlashInfer autotuning (opt-in) to outperform
+        # it; heuristic fallback tactics are slower at prefill shapes.
+        # Select explicitly with --linear-backend flashinfer_b12x.
+        FlashInferB12xNvFp4LinearKernel,
         CutlassNvFp4LinearKernel,
         MarlinNvFp4LinearKernel,
         FlashInferTrtllmNvFp4LinearKernel,
@@ -585,15 +618,7 @@ def choose_scaled_mm_linear_kernel(
     platform_kernels = possible_kernels.get(current_platform._enum, [])
 
     # Apply --linear-backend filtering when set.
-    linear_backend = _get_linear_backend()
-    if linear_backend != "auto":
-        filtered = _filter_kernels_by_backend(linear_backend, platform_kernels)
-        if not filtered:
-            raise ValueError(
-                f"--linear-backend={linear_backend} was requested but no "
-                f"'{linear_backend}' kernel exists for this layer type."
-            )
-        platform_kernels = filtered
+    platform_kernels = _resolve_backend_kernels(platform_kernels, "scaled-mm")
 
     for kernel in platform_kernels:
         is_supported_and_can_implement, failure_reason = (
@@ -749,15 +774,9 @@ def choose_mp_linear_kernel(
     platform_kernels = _POSSIBLE_KERNELS.get(current_platform._enum, [])
 
     # Apply --linear-backend filtering when set.
-    linear_backend = _get_linear_backend()
-    if linear_backend != "auto":
-        filtered = _filter_kernels_by_backend(linear_backend, platform_kernels)
-        if not filtered:
-            raise ValueError(
-                f"--linear-backend={linear_backend} was requested but no "
-                f"'{linear_backend}' kernel exists for mixed-precision layers."
-            )
-        platform_kernels = filtered
+    platform_kernels = _resolve_backend_kernels(
+        platform_kernels, "mixed-precision"
+    )
 
     failure_reasons = []
     for kernel in platform_kernels:
@@ -800,15 +819,7 @@ def init_mxfp8_linear_kernel() -> Mxfp8LinearKernel:
     possible = list(_POSSIBLE_MXFP8_KERNELS.get(platform, []))
 
     # Apply --linear-backend filtering when set.
-    linear_backend = _get_linear_backend()
-    if linear_backend != "auto":
-        filtered = _filter_kernels_by_backend(linear_backend, possible)
-        if not filtered:
-            raise ValueError(
-                f"--linear-backend={linear_backend} was requested but no "
-                f"'{linear_backend}' kernel exists for MXFP8 layers."
-            )
-        possible = filtered
+    possible = _resolve_backend_kernels(possible, "MXFP8")
 
     failure_reasons = []
     for kernel_cls in possible:
@@ -852,14 +863,7 @@ def init_mxfp4_linear_kernel(
     possible = list(_POSSIBLE_MXFP4_KERNELS.get(platform, []))
 
     # Apply --linear-backend filtering when set.
-    if linear_backend != "auto":
-        filtered = _filter_kernels_by_backend(linear_backend, possible)
-        if not filtered:
-            raise ValueError(
-                f"--linear-backend={linear_backend} was requested but no "
-                f"'{linear_backend}' kernel exists for MXFP4 layers."
-            )
-        possible = filtered
+    possible = _resolve_backend_kernels(possible, "MXFP4")
 
     failure_reasons = []
     for kernel_cls in possible:
@@ -1039,14 +1043,7 @@ def init_nvfp4_linear_kernel(use_a16: bool = False) -> NvFp4LinearKernel:
         possible = [kernel for kernel in possible if kernel in a16_kernels]
 
     # Apply --linear-backend filtering when set.
-    if linear_backend != "auto":
-        filtered = _filter_kernels_by_backend(linear_backend, possible)
-        if not filtered:
-            raise ValueError(
-                f"--linear-backend={linear_backend} was requested but no "
-                f"'{linear_backend}' kernel exists for NVFP4 layers."
-            )
-        possible = filtered
+    possible = _resolve_backend_kernels(possible, "NVFP4")
 
     failure_reasons = []
     for kernel_cls in possible:

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -496,10 +496,8 @@ _POSSIBLE_NVFP4_KERNELS: dict[PlatformEnum, list[type[NvFp4LinearKernel]]] = {
     PlatformEnum.CUDA: [
         FlashInferCuteDslNvFp4LinearKernel,
         FlashInferCutlassNvFp4LinearKernel,
-        # Listed after the CUTLASS kernel so auto-selection prefers CUTLASS:
-        # the b12x GEMM needs FlashInfer autotuning (opt-in) to outperform
-        # it; heuristic fallback tactics are slower at prefill shapes.
-        # Select explicitly with --linear-backend flashinfer_b12x.
+        # After CUTLASS for auto-selection; explicit --linear-backend
+        # flashinfer_b12x force-enables the autotuning it needs to win.
         FlashInferB12xNvFp4LinearKernel,
         CutlassNvFp4LinearKernel,
         MarlinNvFp4LinearKernel,

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -774,9 +774,7 @@ def choose_mp_linear_kernel(
     platform_kernels = _POSSIBLE_KERNELS.get(current_platform._enum, [])
 
     # Apply --linear-backend filtering when set.
-    platform_kernels = _resolve_backend_kernels(
-        platform_kernels, "mixed-precision"
-    )
+    platform_kernels = _resolve_backend_kernels(platform_kernels, "mixed-precision")
 
     failure_reasons = []
     for kernel in platform_kernels:
@@ -856,8 +854,6 @@ def init_mxfp4_linear_kernel(
     config = MxFp4LinearLayerConfig(
         activation_quant_key=activation_quant_key,
     )
-
-    linear_backend = _get_linear_backend()
 
     platform = current_platform._enum
     possible = list(_POSSIBLE_MXFP4_KERNELS.get(platform, []))


### PR DESCRIPTION
## Purpose

The `--linear-backend <name>` currently raises at startup for any linear layer type the backend doesn't cover, so single-scheme backends are unusable. `flashinfer_b12x` is doubly blocked: its only kernel is absent from the NVFP4 auto-selection list, so the filter comes back empty even for NVFP4 layers and the documented opt-in never worked.

## Changes

1. **Replace the five duplicated filter blocks** with one `_resolve_backend_kernels()` helper that logs and falls back to normal selection for uncovered layer types.

2. **List FlashInfer-B12x × NvFp4-linearKernel in `POSITIVE_FILTER_HINTS`** after the fix kernel – unless both are supported, but the cuDNN filter can now find the kernel. It stays behind `CUTLASS_EPILOGUE` deliberately: the b12x GEMM needs FlashInfer autotuning (opt-in) to win; its heuristic fallback tactics are up to 3.6× slower at prefill shapes. Its previous exclusion reason (`NVIDIA-cutlass-3.4.5.1`) is fixed in nvidia/cutlass-3.4.5.1.

## Test

**GB10 (SM121)**, Nemotron-3-Super-120B-A12B-NVFP4, ISL=150k/USL=4k, 10 requests, autotuning enabled: `--linear-backend flashinfer_b12x` previously crashed at startup; now selects the b12x GEMM and improves TTFT 12% over FlashInfer-cutlass (70.1s → 69.4s), 17.2 → 17.7 GB/s, `--linear-backend auto` selection is unchanged.