### PR TITLE
[Perf] Reduce Triton recompiles for multimodal attention ranges

### DIFF
--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -2,10 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+from unittest import mock
+
 import pytest
 import torch
 
 from vllm.platforms import current_platform
+from vllm.utils import jit_monitor
 from vllm.utils.math_utils import next_power_of_2
 from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.attention.ops.triton_unified_attention import unified_attention
@@ -86,6 +89,123 @@ def ref_paged_attn(
         start_idx += query_len
 
     return torch.cat(outputs, dim=0)
+
+
+@pytest.mark.skipif(DEVICE_TYPE not in ("cuda", "rocm"), reason="Requires Triton")
+@pytest.mark.parametrize(
+    ("query_len", "seq_threshold_3D"),
+    [(4, 0), (1, 8)],
+    ids=["prefill-2d", "decode-3d"],
+)
+@pytest.mark.parametrize(
+    ("logical_range_count", "bucket_range_count"),
+    [(3, 4), (5, 8)],
+    ids=["3-to-4", "5-to-8"],
+)
+@torch.inference_mode()
+def test_mm_prefix_range_count_does_not_recompile(
+    query_len: int,
+    seq_threshold_3D: int,
+    logical_range_count: int,
+    bucket_range_count: int,
+) -> None:
+    """Changing the runtime range count must not create a Triton specialization."""
+    torch.set_default_device(DEVICE_TYPE)
+    set_random_seed(0)
+
+    num_heads = 4
+    num_kv_heads = 4
+    head_size = 128
+    block_size = 16
+    kv_len = 64
+    scale = head_size**-0.5
+    query = torch.randn(query_len, num_heads, head_size, dtype=torch.bfloat16)
+    key_cache = torch.randn(
+        4, block_size, num_kv_heads, head_size, dtype=torch.bfloat16
+    )
+    value_cache = torch.randn_like(key_cache)
+    output = torch.empty_like(query)
+    cu_query_lens = torch.tensor([0, query_len], dtype=torch.int32)
+    seq_lens = torch.tensor([kv_len], dtype=torch.int32)
+    block_tables = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
+    softmax_segm_output = torch.empty(
+        (seq_threshold_3D, num_heads, 16, head_size), dtype=torch.float32
+    )
+    softmax_segm_max = torch.empty(
+        (seq_threshold_3D, num_heads, 16), dtype=torch.float32
+    )
+    softmax_segm_expsum = torch.empty(
+        (seq_threshold_3D, num_heads, 16), dtype=torch.float32
+    )
+
+    def run(mm_prefix_range: torch.Tensor | None) -> torch.Tensor:
+        unified_attention(
+            q=query,
+            k=key_cache,
+            v=value_cache,
+            out=output,
+            cu_seqlens_q=cu_query_lens,
+            seqused_k=seq_lens,
+            max_seqlen_q=query_len,
+            max_seqlen_k=kv_len,
+            softmax_scale=scale,
+            causal=True,
+            window_size=(-1, -1),
+            block_table=block_tables,
+            softcap=0,
+            q_descale=None,
+            k_descale=None,
+            v_descale=None,
+            mm_prefix_range=mm_prefix_range,
+            seq_threshold_3D=seq_threshold_3D,
+            num_par_softmax_segments=16,
+            softmax_segm_output=softmax_segm_output,
+            softmax_segm_max=softmax_segm_max,
+            softmax_segm_expsum=softmax_segm_expsum,
+        )
+        return output.clone()
+
+    output_without_prefix = run(None)
+    candidate_ranges = [
+        [0, 1],
+        [8, 9],
+        [16, 17],
+        [24, 25],
+        [kv_len - max(query_len, 2), kv_len - 1],
+    ]
+    logical_ranges = torch.tensor(
+        [[*candidate_ranges[: logical_range_count - 1], candidate_ranges[-1]]],
+        dtype=torch.int32,
+    )
+    output_logical_ranges = run(logical_ranges)
+    if query_len > 1:
+        assert not torch.allclose(output_without_prefix, output_logical_ranges)
+
+    from triton import knobs
+
+    previous_jit_hook = knobs.runtime.jit_post_compile_hook
+    try:
+        with (
+            mock.patch.object(jit_monitor, "_active", False),
+            mock.patch.object(jit_monitor, "_mode", "warn"),
+            mock.patch.object(jit_monitor, "_verbose", False),
+            mock.patch.object(jit_monitor, "_setup_triton_autotuning_print"),
+            mock.patch.object(jit_monitor, "_setup_cutedsl_jit_hook"),
+            mock.patch.object(jit_monitor, "_setup_tilelang_jit_hook"),
+        ):
+            jit_monitor.activate()
+            with mock.patch.object(jit_monitor.logger, "warning_once") as warning:
+                output_bucket_ranges = run(
+                    torch.nn.functional.pad(
+                        logical_ranges,
+                        (0, 0, 0, bucket_range_count - logical_range_count),
+                    )
+                )
+            warning.assert_not_called()
+    finally:
+        knobs.runtime.jit_post_compile_hook = previous_jit_hook
+
+    torch.testing.assert_close(output_logical_ranges, output_bucket_ranges)
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -32,6 +32,7 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.backends.utils import (
+    compute_mm_prefix_range_tensor,
     set_kv_cache_layout,
 )
 from vllm.v1.kv_cache_interface import FullAttentionSpec
@@ -53,6 +54,56 @@ FP8_KV_CACHE_DTYPES = {
     "fp8": current_platform.fp8_dtype(),
     "fp8_e4m3": current_platform.fp8_dtype(),
 }
+
+
+def test_compute_mm_prefix_range_tensor_power_of_two_padding() -> None:
+    ranges = {0: [(0, 1), (2, 3), (4, 5)], 1: [(6, 7)]}
+    device = torch.device("cpu")
+
+    unbucketed = compute_mm_prefix_range_tensor(ranges, 2, device)
+    bucketed = compute_mm_prefix_range_tensor(
+        ranges, 2, device, pad_to_power_of_two=True
+    )
+    assert unbucketed is not None
+    assert bucketed is not None
+
+    expected_unbucketed = torch.tensor(
+        [
+            [[0, 1], [2, 3], [4, 5]],
+            [[6, 7], [0, 0], [0, 0]],
+        ],
+        dtype=torch.int32,
+        device=device,
+    )
+    expected_bucketed = torch.tensor(
+        [
+            [[0, 1], [2, 3], [4, 5], [0, 0]],
+            [[6, 7], [0, 0], [0, 0], [0, 0]],
+        ],
+        dtype=torch.int32,
+        device=device,
+    )
+    torch.testing.assert_close(unbucketed, expected_unbucketed)
+    torch.testing.assert_close(bucketed, expected_bucketed)
+    assert bucketed.device == device
+    assert bucketed.dtype == torch.int32
+
+    already_bucketed = compute_mm_prefix_range_tensor(
+        {0: [(0, 1), (2, 3), (4, 5), (6, 7)]},
+        1,
+        device,
+        pad_to_power_of_two=True,
+    )
+    assert already_bucketed is not None
+    torch.testing.assert_close(
+        already_bucketed,
+        torch.tensor(
+            [[[0, 1], [2, 3], [4, 5], [6, 7]]],
+            dtype=torch.int32,
+            device=device,
+        ),
+    )
+
 
 # Remove flashinfer from the list if it's not available
 try:

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -251,7 +251,10 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
         if mm_ranges is not None:
             attn_metadata.mm_prefix_range = mm_ranges
             attn_metadata.mm_prefix_range_tensor = compute_mm_prefix_range_tensor(
-                mm_ranges, num_reqs, seq_lens.device
+                mm_ranges,
+                num_reqs,
+                seq_lens.device,
+                pad_to_power_of_two=True,
             )
 
         rswa_prefix_lens = common_attn_metadata.rswa_prefix_lens

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -16,7 +16,7 @@ import torch
 from typing_extensions import runtime_checkable
 
 from vllm.config import VllmConfig, get_layers_from_vllm_config
-from vllm.utils.math_utils import cdiv
+from vllm.utils.math_utils import cdiv, next_power_of_2
 from vllm.utils.torch_utils import PIN_MEMORY, async_tensor_h2d, np_to_pinned_tensor
 from vllm.v1.kv_cache_interface import KVCacheSpec, MambaSpec
 
@@ -50,11 +50,14 @@ def compute_mm_prefix_range_tensor(
     mm_prefix_range: dict[int, list[tuple[int, int]]] | None,
     num_seqs: int,
     device: torch.device,
+    *,
+    pad_to_power_of_two: bool = False,
 ) -> torch.Tensor | None:
     """Convert mm_prefix_range dict to padded tensor for Triton kernel.
 
     Returns shape: (num_seqs, max_ranges, 2) with 0-padding for empty ranges.
     Empty ranges have start==end==0, which kernel skips via is_valid check.
+    Optionally bucket max_ranges to the next power of two.
     """
     if mm_prefix_range is None:
         return None
@@ -67,6 +70,8 @@ def compute_mm_prefix_range_tensor(
         return None
 
     max_ranges = max(len(r) for r in range_lists)
+    if pad_to_power_of_two:
+        max_ranges = next_power_of_2(max_ranges)
     padded = []
     for r in range_lists:
         padded_r = list(r) + [(0, 0)] * (max_ranges - len(r))

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -219,7 +219,7 @@ def kernel_unified_attention(
     USE_PER_SEQ_CAUSAL: tl.constexpr,  # bool
     per_seq_causal_ptr,  # [num_seqs] bool, or None
     USE_MM_PREFIX: tl.constexpr,  # bool
-    MAX_MM_RANGES: tl.constexpr,  # int
+    MAX_MM_RANGES: tl.constexpr,  # int, power-of-two bucket
     mm_prefix_range_ptr,
     rswa_prefix_lens_ptr,
     R_SWA_WINDOW: tl.constexpr,  # int
@@ -908,10 +908,18 @@ def unified_attention(
 
     use_mm_prefix = False
     max_mm_ranges = 0
+    max_mm_ranges_bucket = 0
     if mm_prefix_range is not None:
         if mm_prefix_range.ndim == 3:
-            use_mm_prefix = True
             max_mm_ranges = mm_prefix_range.shape[1]
+            if max_mm_ranges > 0:
+                use_mm_prefix = True
+                max_mm_ranges_bucket = 1 << (max_mm_ranges - 1).bit_length()
+                if max_mm_ranges != max_mm_ranges_bucket:
+                    mm_prefix_range = torch.nn.functional.pad(
+                        mm_prefix_range,
+                        (0, 0, 0, max_mm_ranges_bucket - max_mm_ranges),
+                    )
         else:
             raise ValueError(
                 f"Unsupported mm_prefix_range shape: {mm_prefix_range.shape}"
@@ -1130,7 +1138,7 @@ def unified_attention(
         USE_PER_SEQ_CAUSAL=use_per_seq_causal,
         per_seq_causal_ptr=per_seq_causal_ptr,
         USE_MM_PREFIX=use_mm_prefix,
-        MAX_MM_RANGES=max_mm_ranges,
+        MAX_MM_RANGES=max_mm_ranges_bucket,
         mm_prefix_range_ptr=mm_prefix_range,
         rswa_prefix_lens_ptr=rswa_prefix_lens if use_rswa else seqused_k,
         R_SWA_WINDOW=rswa_window or 0,


### PR DESCRIPTION
## Purpose

Part of #48650.

Triton unified attention receives `MAX_MM_RANGES` as a `tl.constexpr`. Passing
every exact multimodal range count creates a new specialization on first use.
Pad production metadata to the next power-of-two width with inert `[0, 0]`
rows, reducing the specialization set to 1/2/4/8/... without changing logical
ranges.

This matches vLLM's existing power-of-two specialization policy. #48734,
#48739, and #48813 own independent constexpr sites and have no file overlap.
Mandatory duplicate searches found no competing implementation.

AI assistance was used. The human submitter must review every changed line and
the recorded performance evidence before readiness.

## Implementation

- Bucket Triton production metadata before device transfer.
- Preserve the unbucketed default used by FlashAttention.
- Guard nonstandard direct unified-kernel callers, including zero-width input.
  The INT4 direct dispatcher bypasses this fallback, but its production
  metadata is already bucketed by the shared builder.
- Leave the kernel loop and invalid-range semantics unchanged.
- Test padding, dtype/device, numerical equivalence, and JIT reuse for prefill
  and decode at both 3→4 and 5→8 bucket transitions.

## Validation

Current head `d6b338142` is based on upstream `1a659a0c3`.

```text
pytest -q \
  tests/kernels/attention/test_triton_unified_attention.py::test_mm_prefix_range_count_does_not_recompile \
  --collect-only
4 tests collected

pre-commit run --files tests/kernels/attention/test_triton_unified_attention.py
all applicable hooks passed, including mypy

git diff --check
passed
```

An earlier production-equivalent revision passed the builder test and the
3→4 prefill JIT-monitor test on H100. Fresh-cache service testing on H100
compiled only widths 1/2/4/8 for logical widths 1..8, rather than eight exact
specializations. A Gemma 3 W8A8 service selected `TRITON_ATTN`, completed graph
capture, and served image counts `1,2,3,4,5,6,7,8,3,5,7` without recompiling
the repeated 3/5/7 requests.

The current test is stronger than that historical GPU run: it covers 3→4 and
5→8 on forced 2D prefill and 3D decode. It has only been collected locally;
no current-head H100 or MI300X pass is claimed.

Still required before readiness:

- Run the four-case current-head test on H100 and MI300X/gfx942.
- Measure steady-state raw-vs-padded 3/4 and 5/8 kernel cost on both platforms,
  excluding Python padding and reporting repeated distributions rather than a
  hard CI threshold.
- Compare representative model output with the parent or another backend,
  then obtain human review and full CI.

## Release note

Reduce serving-time Triton attention recompilations for multimodal batches by
grouping prefix-range specializations into power-of-two buckets.

This is a mainline performance change, not a v0.26 cherry-pick candidate.
