### PR TITLE
[Perf] Vectorize pooling prompt-token padding in InputBatch

### DIFF
--- a/tests/v1/worker/test_gpu_input_batch.py
+++ b/tests/v1/worker/test_gpu_input_batch.py
@@ -519,7 +519,7 @@ def test_pooling_metadata_token_id_buffers(
         assert metadata.prompt_token_ids_cpu is None
 
 
-def test_pooling_metadata_cpu_token_ids_pad_without_per_request_loop():
+def test_pooling_metadata_cpu_token_ids_padding():
     from vllm.pooling_params import PoolingParams
 
     input_batch = InputBatch(
@@ -551,7 +551,8 @@ def test_pooling_metadata_cpu_token_ids_pad_without_per_request_loop():
         input_batch.add_request(request)
     input_batch.refresh_metadata()
 
-    prompt_token_ids = input_batch.get_pooling_metadata().prompt_token_ids_cpu
+    with torch.device("meta"):
+        prompt_token_ids = input_batch.get_pooling_metadata().prompt_token_ids_cpu
 
     assert prompt_token_ids is not None
     assert prompt_token_ids.tolist() == [

--- a/tests/v1/worker/test_gpu_input_batch.py
+++ b/tests/v1/worker/test_gpu_input_batch.py
@@ -517,3 +517,45 @@ def test_pooling_metadata_token_id_buffers(
         assert metadata.get_prompt_token_ids_cpu()[0].tolist() == req.prompt_token_ids
     else:
         assert metadata.prompt_token_ids_cpu is None
+
+
+def test_pooling_metadata_cpu_token_ids_pad_without_per_request_loop():
+    from vllm.pooling_params import PoolingParams
+
+    input_batch = InputBatch(
+        max_num_reqs=3,
+        max_model_len=MAX_PROMPT_SIZE + NUM_OUTPUT_TOKENS,
+        max_num_batched_tokens=3 * (MAX_PROMPT_SIZE + NUM_OUTPUT_TOKENS),
+        device=torch.device("cpu"),
+        vocab_size=VOCAB_SIZE,
+        block_sizes=[16],
+        kernel_block_sizes=[16],
+        max_num_blocks_per_req=[64],
+        is_pooling_model=True,
+    )
+    requests = [
+        CachedRequestState(
+            req_id=f"pool_req_{i}",
+            prompt_token_ids=list(range(2 + i)),
+            sampling_params=None,
+            pooling_params=PoolingParams(task="classify", requires_token_ids=True),
+            mm_features=[],
+            block_ids=([],),
+            generator=None,
+            num_computed_tokens=0,
+            output_token_ids=[],
+        )
+        for i in range(3)
+    ]
+    for request in requests:
+        input_batch.add_request(request)
+    input_batch.refresh_metadata()
+
+    prompt_token_ids = input_batch.get_pooling_metadata().prompt_token_ids_cpu
+
+    assert prompt_token_ids is not None
+    assert prompt_token_ids.tolist() == [
+        [0, 1, VOCAB_SIZE, VOCAB_SIZE],
+        [0, 1, 2, VOCAB_SIZE],
+        [0, 1, 2, 3],
+    ]

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -974,7 +974,8 @@ class InputBatch:
         # token_id of this value.
         prompt_lens = self.num_prompt_tokens_cpu_tensor[:num_reqs]
         padding = (
-            torch.arange(max_prompt_len).expand(num_reqs, -1) >= (prompt_lens[:, None])
+            torch.arange(max_prompt_len, device="cpu").expand(num_reqs, -1)
+            >= (prompt_lens[:, None])
         )
         prompt_token_ids_cpu_tensor.masked_fill_(padding, self.vocab_size)
         return prompt_token_ids_cpu_tensor

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -972,8 +972,11 @@ class InputBatch:
         prompt_token_ids[:] = self.token_ids_cpu[:num_reqs, :max_prompt_len]
         # Use the value of vocab_size as a pad since we don't have a
         # token_id of this value.
-        for i in range(num_reqs):
-            prompt_token_ids[i, self.num_prompt_tokens[i] :] = self.vocab_size
+        prompt_lens = self.num_prompt_tokens_cpu_tensor[:num_reqs]
+        padding = (
+            torch.arange(max_prompt_len).expand(num_reqs, -1) >= (prompt_lens[:, None])
+        )
+        prompt_token_ids_cpu_tensor.masked_fill_(padding, self.vocab_size)
         return prompt_token_ids_cpu_tensor
 
     def make_lora_inputs(


### PR DESCRIPTION
## Purpose

Pooling methods with `requires_token_ids` build a padded CPU prompt-token tensor
in the legacy GPU model runner. Replace the per-request tail-fill loop in
`InputBatch._make_prompt_token_ids_cpu_tensor` with one broadcast mask and
`masked_fill_`. The `vocab_size` sentinel and observable tensor contents are
unchanged.

This remains relevant because pooling is not generally routed through Model
Runner V2: its pooling path currently covers only a narrow decoder-only
LAST/embed subset, while token-ID-requiring StepPool, SPLADE, and GritLM-style
paths still use this code. The change allocates a temporary
`O(batch * max_prompt_len)` boolean mask in addition to the existing int64
output buffer.

Related: #27222, #46121, #43702. No open PR changes this helper. #49153
parallelizes frontend pooling preprocessing but does not touch the model-runner
metadata construction changed here. AI assistance was used. The human
submitter must review the rebased diff and representative workload evidence
before readiness.

## Validation

The regression checks exact mixed-length padding and calls metadata construction
under a `meta` default-device context, guarding the explicit CPU allocation
that the first revision missed.

Completed on the rebased branch:

```bash
.venv/bin/pre-commit run --from-ref origin/main --to-ref HEAD
# all applicable hooks passed

.venv/bin/python -m pytest tests/v1/worker/test_gpu_input_batch.py -q
# 10 passed

git diff --check origin/main...HEAD
# passed
```

A follow-up audit found that the original benchmark used a Torch indexed
assignment for every old-path row. Production instead pads through the NumPy
view of the output tensor, making that published baseline artificially 3-5.5x
slower. A faithful rerun used the production NumPy loop, ten warmups, seven
samples, four Torch threads, `pin_memory=False`, and identical validated output:

| Batch x length | Length distribution | New / production old |
| ---: | --- | ---: |
| 16 x 128 | uniform `[L/4, L]` | 1.33x slower |
| 64 x 128 | uniform `[L/4, L]` | 0.84x |
| 64 x 2048 | uniform `[L/4, L]` | 2.12x slower |
| 256 x 128 | uniform `[L/4, L]` | 0.58x |
| 256 x 2048 | uniform `[L/4, L]` | 1.38x slower |
| 1024 x 128 | uniform `[L/4, L]` | 0.33x |
| 512 x 32768 | equal | 2.11x slower |
| 512 x 32768 | one short | 1.62x slower |
| 512 x 32768 | ramp | 1.26x slower |

The short-sequence wins are 3-160 microseconds locally, while long prompts
regress by up to several milliseconds and the largest case adds a 16 MiB
boolean mask. There is no representative end-to-end pooling result. This does
not clear the repository's no-busywork/value bar, so the PR is being closed
rather than adding a workload-specific threshold heuristic.

What would justify a future replacement:

- Benchmark a representative token-ID-requiring pooling workload such as
  StepPool, SPLADE, or GritLM at realistic batch and prompt-length
  distributions.
- Report CPU, pin-memory setting, Torch thread count, allocations/copies timed,
  peak temporary memory, and end-to-end throughput/latency.
- Have the human submitter review every changed line and record exact commands.

## Release note

Reduce host overhead when building token-ID metadata for batched pooling
requests by vectorizing CPU sentinel padding.

No release note: this implementation should not merge. A future replacement
needs representative end-to-end pooling evidence without long-context or
temporary-memory regressions.
