### PR TITLE
[BugFix] Don't apply weight in batch-invariant RMSNorm when has_weight=False

### DIFF
--- a/tests/v1/determinism/test_rms_norm_batch_invariant.py
+++ b/tests/v1/determinism/test_rms_norm_batch_invariant.py
@@ -342,54 +342,6 @@ def test_rms_norm_different_hidden_sizes(default_vllm_config, hidden_size: int):
 
 
 @skip_unsupported
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("use_residual", [False, True])
-def test_rms_norm_weightless_ignores_identity_weight(
-    default_vllm_config, monkeypatch, dtype: torch.dtype, use_residual: bool
-):
-    """
-    RMSNorm(has_weight=False) keeps its identity weight as a plain tensor that
-    load_weights never restores, so sleep(level=2) leaves it with garbage data.
-    The batch-invariant path must skip the weight multiply instead of reading it.
-    """
-    device = torch.device(DEVICE_TYPE)
-    hidden_size = 2048
-    eps = 1e-6
-
-    torch.manual_seed(42)
-    x = torch.randn(8, hidden_size, dtype=dtype, device=device)
-
-    with torch.device(device):
-        layer = RMSNorm(hidden_size, eps=eps, has_weight=False, dtype=dtype)
-    # Simulate the discarded weight pool after sleep(level=2) + weight re-sync.
-    layer.weight.zero_()
-
-    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
-    if use_residual:
-        residual = torch.randn(8, hidden_size, dtype=dtype, device=device)
-        out, _ = layer.forward_cuda(x.clone(), residual.clone())
-        merged = (x.float() + residual.float()).to(dtype)
-    else:
-        out = layer.forward_cuda(x.clone())
-        merged = x
-
-    merged_f32 = merged.float()
-    expected = (
-        merged_f32 * torch.rsqrt(merged_f32.pow(2).mean(-1, keepdim=True) + eps)
-    ).to(dtype)
-
-    rtol, atol = (1e-1, 1e-1) if dtype == torch.bfloat16 else (1e-2, 1e-2)
-    torch.testing.assert_close(
-        out,
-        expected,
-        rtol=rtol,
-        atol=atol,
-        msg="Weightless RMSNorm must not apply the stale identity weight "
-        f"(use_residual={use_residual})",
-    )
-
-
-@skip_unsupported
 def test_rms_norm_determinism(default_vllm_config):
     """
     Test that batch-invariant RMS norm produces deterministic results.

--- a/tests/v1/determinism/test_rms_norm_batch_invariant.py
+++ b/tests/v1/determinism/test_rms_norm_batch_invariant.py
@@ -342,6 +342,54 @@ def test_rms_norm_different_hidden_sizes(default_vllm_config, hidden_size: int):
 
 
 @skip_unsupported
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("use_residual", [False, True])
+def test_rms_norm_weightless_ignores_identity_weight(
+    default_vllm_config, monkeypatch, dtype: torch.dtype, use_residual: bool
+):
+    """
+    RMSNorm(has_weight=False) keeps its identity weight as a plain tensor that
+    load_weights never restores, so sleep(level=2) leaves it with garbage data.
+    The batch-invariant path must skip the weight multiply instead of reading it.
+    """
+    device = torch.device(DEVICE_TYPE)
+    hidden_size = 2048
+    eps = 1e-6
+
+    torch.manual_seed(42)
+    x = torch.randn(8, hidden_size, dtype=dtype, device=device)
+
+    with torch.device(device):
+        layer = RMSNorm(hidden_size, eps=eps, has_weight=False, dtype=dtype)
+    # Simulate the discarded weight pool after sleep(level=2) + weight re-sync.
+    layer.weight.zero_()
+
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
+    if use_residual:
+        residual = torch.randn(8, hidden_size, dtype=dtype, device=device)
+        out, _ = layer.forward_cuda(x.clone(), residual.clone())
+        merged = (x.float() + residual.float()).to(dtype)
+    else:
+        out = layer.forward_cuda(x.clone())
+        merged = x
+
+    merged_f32 = merged.float()
+    expected = (
+        merged_f32 * torch.rsqrt(merged_f32.pow(2).mean(-1, keepdim=True) + eps)
+    ).to(dtype)
+
+    rtol, atol = (1e-1, 1e-1) if dtype == torch.bfloat16 else (1e-2, 1e-2)
+    torch.testing.assert_close(
+        out,
+        expected,
+        rtol=rtol,
+        atol=atol,
+        msg="Weightless RMSNorm must not apply the stale identity weight "
+        f"(use_residual={use_residual})",
+    )
+
+
+@skip_unsupported
 def test_rms_norm_determinism(default_vllm_config):
     """
     Test that batch-invariant RMS norm produces deterministic results.

--- a/vllm/model_executor/layers/batch_invariant.py
+++ b/vllm/model_executor/layers/batch_invariant.py
@@ -781,6 +781,7 @@ def _rms_norm_kernel(
     n_cols,
     eps,
     BLOCK_SIZE: tl.constexpr,
+    HAS_WEIGHT: tl.constexpr,
 ):
     """
     Compute RMS normalization along the last dimension of a 2D tensor.
@@ -813,18 +814,19 @@ def _rms_norm_kernel(
         col_idx = col_offset + tl.arange(0, BLOCK_SIZE)
         mask = col_idx < n_cols
         vals = tl.load(row_start_ptr + col_idx, mask=mask, other=0.0)
-        weight = tl.load(weight_ptr + col_idx, mask=mask, other=1.0)
         # Compute in float32 then convert back to input dtype
         vals_f32 = vals.to(tl.float32)
-        weight_f32 = weight.to(tl.float32)
-        output_f32 = vals_f32 * inv_rms * weight_f32
+        output_f32 = vals_f32 * inv_rms
+        if HAS_WEIGHT:
+            weight = tl.load(weight_ptr + col_idx, mask=mask, other=1.0)
+            output_f32 = output_f32 * weight.to(tl.float32)
         output = output_f32.to(vals.dtype)
         tl.store(output_row_start_ptr + col_idx, output, mask=mask)
 
 
 def rms_norm_batch_invariant(
     input: torch.Tensor,
-    weight: torch.Tensor,
+    weight: torch.Tensor | None,
     eps: float = 1e-6,
     residual: torch.Tensor | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
@@ -834,7 +836,8 @@ def rms_norm_batch_invariant(
 
     Args:
         input: Input tensor of shape (..., hidden_size)
-        weight: Weight tensor of shape (hidden_size,)
+        weight: Weight tensor of shape (hidden_size,), or None to skip the
+            per-channel multiply (``RMSNorm(has_weight=False)``)
         eps: Small constant for numerical stability
         residual: Optional residual tensor fused into the normalization path
 
@@ -851,17 +854,18 @@ def rms_norm_batch_invariant(
         ops.fused_add_rms_norm(input, residual, weight, eps)
         return input, residual
 
-    assert weight.dim() == 1, "Weight must be 1-dimensional"
-    assert input.shape[-1] == weight.shape[0], (
-        f"Input last dimension ({input.shape[-1]}) must match "
-        f"weight dimension ({weight.shape[0]})"
-    )
+    if weight is not None:
+        assert weight.dim() == 1, "Weight must be 1-dimensional"
+        assert input.shape[-1] == weight.shape[0], (
+            f"Input last dimension ({input.shape[-1]}) must match "
+            f"weight dimension ({weight.shape[0]})"
+        )
+        weight = weight.contiguous()
 
     # Flatten all dimensions except the last one
     original_shape = input.shape
     input_2d = input.reshape(-1, input.shape[-1])
     input_2d = input_2d.contiguous()
-    weight = weight.contiguous()
 
     n_rows, n_cols = input_2d.shape
 
@@ -870,13 +874,14 @@ def rms_norm_batch_invariant(
     grid = (n_rows,)
     _rms_norm_kernel[grid](
         input_2d,
-        weight,
+        weight if weight is not None else input_2d,
         output,
         input_2d.stride(0),
         output.stride(0),
         n_cols,
         eps,
         BLOCK_SIZE=BLOCK_SIZE,
+        HAS_WEIGHT=weight is not None,
     )
     return output.reshape(original_shape)
 

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -102,9 +102,12 @@ class RMSNorm(CustomOp):
             assert self.variance_size_override is None, (
                 "Batch invariance is not supported for variance_size_override"
             )
+            pass_weight = (
+                self.pass_weight_add if residual is not None else self.pass_weight
+            )
             return rms_norm_batch_invariant(
                 x,
-                self.weight.data,
+                self.weight.data if pass_weight else None,
                 self.variance_epsilon,
                 residual=residual,
             )


### PR DESCRIPTION
## Purpose

Fix silent output corruption for models using `RMSNorm(has_weight=False)` (Gemma4, Gemma3n, Llama4) when `VLLM_BATCH_INVARIANT=1` is combined with sleep mode - e.g. in standard RL rollout configuration.

`RMSNorm(has_weight=False)` keeps its identity weight as a plain tensor, not an `nn.Parameter` - so `sleep(level=2)` discards it and weight re-sync brings it back zeroed. `VLLM_BATCH_INVARIANT` branch still passed `self.weight.data` unconditionally: after a sleep/wake/re-sync cycle it multiplies by zeros and the model silently generates garbage.

**Fix:** the batch-invariant branch now respects `pass_weight`, and `rms_norm_batch_invariant` accepts `weight=None`: `rms_norm_batch_invariant` gets a `HAS_WEIGHT: tl.constexpr` to skip the multiply, and the residual path passes
`None` to `ops.fused_add_rms_norm`, which already supports it.

### Reproducing evidence
`google/gemma-4-E2B-it`, 1×H100, `VLLM_BATCH_INVARIANT=1`, `attention_backend=TRITON_ATTN`. 
Layer-level: zero the identity weight to simulate the post-sleep state, run the batch-invariant forward.

<details>
<summary>Layer-level repro script</summary>

```python
import os
os.environ["VLLM_BATCH_INVARIANT"] = "1"

import torch
from vllm.config import VllmConfig, set_current_vllm_config
from vllm.model_executor.layers.layernorm import RMSNorm

device, dtype, eps = torch.device("cuda"), torch.bfloat16, 1e-6
x = torch.randn(4, 2048, dtype=dtype, device=device)

with set_current_vllm_config(VllmConfig()), torch.device(device):
    norm = RMSNorm(2048, eps=eps, has_weight=False, dtype=dtype)

x32 = x.float()
expected = (x32 * torch.rsqrt(x32.pow(2).mean(-1, keepdim=True) + eps)).to(dtype)

norm.weight.zero_()  # what sleep(level=2) + weight re-sync leaves behind
out = norm.forward_cuda(x.clone())

print("expected:", expected[0, :4].tolist())
print("actual:  ", out[0, :4].tolist())  # all zeros before this PR
```

</details>

Before this PR:
```
expected[0,:4]           [-0.9296875, -0.427734375, -2.65625, 0.146484375]
after 'sleep'[0,:4]      [-0.0, -0.0, -0.0, 0.0]
```

After this PR:
```
expected[0,:4]           [-0.9296875, -0.427734375, -2.65625, 0.146484375]
after 'sleep'[0,:4]      [-0.9296875, -0.427734375, -2.65625, 0.146484375]
```

## Test Plan

New regression test, on 1×H100:

```bash
pytest tests/v1/determinism/test_rms_norm_batch_invariant.py -k weightless -v
4 passed
```

Full file: `pytest tests/v1/determinism/test_rms_norm_batch_invariant.py -v`

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

Co-authored-by: michael-go <michael.gokhman@yahoo.com>