### PR TITLE
[Bugfix] Fix local speculators with dots in the name from classifying as custom_class

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -626,6 +626,18 @@ class SpeculativeConfig:
             SpeculativeConfig._apply_composed_hf_override, target_hf_overrides
         )
 
+    @staticmethod
+    def _is_custom_proposer_path(model: str | None) -> bool:
+        """True if ``model`` is a dotted import path (e.g. ``pkg.MyProposer``)."""
+        if model is None:
+            return False
+        if model.startswith(("http://", "https://", "file://")):
+            return False
+        if "/" in model:
+            return False
+        parts = model.split(".")
+        return len(parts) >= 2 and all(part.isidentifier() for part in parts)
+
     def __post_init__(self):
         # Note: "method" is a new parameter that helps to extend the
         # configuration of non-model-based proposers, and the "model" parameter
@@ -636,14 +648,9 @@ class SpeculativeConfig:
         # default.
 
         # infer method from user args
-        # Check if the model field contains a custom module path (e.g., 'pkg.Mod')
-        if (
-            self.model is not None
-            and "." in self.model
-            and not self.model.startswith(("http://", "https://", "file://"))
-            and "/" not in self.model  # not a HuggingFace repo (org/model)
+        if self.method is None and SpeculativeConfig._is_custom_proposer_path(
+            self.model
         ):
-            # Treat as a custom class path
             self.method = "custom_class"
         elif self.method is None:
             if self.model in ("ngram", "[ngram]"):


### PR DESCRIPTION



## Purpose

Fix speculative config so draft model names with dots (e.g. local `GLM-5.2-speculator.dspark` folder) are not misclassified as `custom_class` import paths.

## Test Plan

## Test Result

Before:

```
vllm serve zai-org/GLM-5.2-FP8 --max-model-len 20k --spec-model GLM-5.2-speculator.dspark --spec-method dspark --spec-tokens 7 -tp 4
...
ImportError: Cannot import module 'GLM-5.2-speculator' for custom proposer 'GLM-5.2-speculator.dspark': No module named 'GLM-5'
```

After: loads normally, same as using `RedHatAI/GLM-5.2-speculator.dspark` for the model

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

