### PR TITLE
[Bugfix][Tool Parser] InternLM2: don't index delta_text into re-serialized JSON

### DIFF
--- a/tests/tool_parsers/test_internlm2_tool_parser.py
+++ b/tests/tool_parsers/test_internlm2_tool_parser.py
@@ -10,6 +10,7 @@ from tests.tool_parsers.common_tests import (
     ToolParserTests,
 )
 from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers.internlm2_tool_parser import Internlm2ToolParser
 
 
 class TestInternLM2ToolParser(ToolParserTests):
@@ -120,3 +121,42 @@ class TestInternLM2ToolParser(ToolParserTests):
                 ),
             },
         )
+
+
+def test_streaming_first_arguments_delta_survives_compact_json_formatting():
+    """The first streamed arguments delta must not depend on delta_text
+    appearing verbatim inside json.dumps(cur_arguments): a model emitting
+    compact JSON (no space after ':') never matches Python's default
+    json.dumps formatting, so cur_arguments_json.index(delta_text) raises
+    ValueError, which the caller swallows into a lost delta.
+    """
+    parser = Internlm2ToolParser(tokenizer=None, tools=[])
+
+    first = parser.extract_tool_calls_streaming(
+        previous_text="",
+        current_text='<|action_start|><|plugin|>{"name":"get_weather"',
+        delta_text='<|action_start|><|plugin|>{"name":"get_weather"',
+        previous_token_ids=[],
+        current_token_ids=[],
+        delta_token_ids=[],
+        request=None,
+    )
+    assert first is not None
+    assert first.tool_calls[0].function.name == "get_weather"
+
+    second = parser.extract_tool_calls_streaming(
+        previous_text='<|action_start|><|plugin|>{"name":"get_weather"',
+        current_text=(
+            '<|action_start|><|plugin|>{"name":"get_weather",'
+            '"parameters":{"city":"SF"}}'
+        ),
+        delta_text=',"parameters":{"city":"SF"}}',
+        previous_token_ids=[],
+        current_token_ids=[],
+        delta_token_ids=[],
+        request=None,
+    )
+
+    assert second is not None
+    assert second.tool_calls[0].function.arguments is not None
+    assert parser.streamed_args_for_tool[0] != ""

--- a/vllm/tool_parsers/internlm2_tool_parser.py
+++ b/vllm/tool_parsers/internlm2_tool_parser.py
@@ -146,9 +146,11 @@ class Internlm2ToolParser(ToolParser):
                 elif cur_arguments and not prev_arguments:
                     cur_arguments_json = json.dumps(cur_arguments, ensure_ascii=False)
 
-                    arguments_delta = cur_arguments_json[
-                        : cur_arguments_json.index(delta_text) + len(delta_text)
-                    ]
+                    # delta_text may not appear verbatim in cur_arguments_json
+                    # (e.g. compact model output vs. json.dumps spacing), so
+                    # diff against an empty previous string instead of
+                    # locating delta_text as a substring.
+                    arguments_delta = extract_intermediate_diff(cur_arguments_json, "")
                     delta = DeltaMessage(
                         tool_calls=[
                             DeltaToolCall(


### PR DESCRIPTION
## Purpose

`Internlm2ToolParser.extract_tool_calls_streaming`'s "first time to get parameters" branch computes the initial arguments delta with:

```python
arguments_delta = cur_arguments_json[
    : cur_arguments_json.index(delta_text) + len(delta_text)
]
```

This assumes the model's raw `delta_text` always appears verbatim inside `json.dumps(cur_arguments)`'s re-serialized string. Once the model's own JSON formatting diverges from Python's default `json.dumps` spacing (e.g. compact JSON with no space after `:`, which InternLM2 and many models commonly emit), `.index()` raises `ValueError`, which the caller's broad `except Exception` swallows into a lost delta — the arguments for that tool call are permanently dropped (`prev_tool_call_arr` is never updated on this path either, so the parser doesn't recover on the next chunk).

## Modifications

Mirror the sibling "both prev and cur parameters" branch a few lines below, which already uses `extract_intermediate_diff(cur, prev)` instead of any substring-position assumption. For the first-time case there's no previous string to diff against, so `extract_intermediate_diff(cur_arguments_json, "")` resolves to the full re-serialized JSON string as intended, without depending on `delta_text`'s exact formatting.

## Duplicate-work check

Read the full diffs of all 3 currently open PRs touching this file:
- #44140 (multi-marker `ValueError` fix) — touches lines 77 and 202
- #48348 (whole-call-in-single-delta) — touches lines 26 and 79–128
- #47968 (unlisted tool name) — touches line 214

None of their changed line ranges overlap line 150 or the "first time to get parameters" branch this PR fixes; they address unrelated symptoms in the same file.

## Test Plan

- Drive a real `Internlm2ToolParser` with a streamed compact-JSON tool call — `'{"name":"get_weather"'` then `',"parameters":{"city":"SF"}}'` (no space after `:`), the formatting the parser's `.index()` lookup assumes away.
- Add a regression test for that exact scenario to `tests/tool_parsers/test_internlm2_tool_parser.py`.
- `pytest tests/tool_parsers/test_internlm2_tool_parser.py`; confirm red-before/green-after by reverting only the source change.
- `ruff check` / `ruff format --check`.

## Test Result

- Reproduced against a real `Internlm2ToolParser` instance before touching source: streaming `'{"name":"get_weather"'` then `',"parameters":{"city":"SF"}}'` (compact JSON, no space after `:`) raised `ValueError: substring not found` and returned `None` for the second delta.
- Added `test_streaming_first_arguments_delta_survives_compact_json_formatting` to `tests/tool_parsers/test_internlm2_tool_parser.py` covering this exact scenario — verified red before the fix, green after.
- Full `tests/tool_parsers/test_internlm2_tool_parser.py`: 10 passed, 8 xfailed. The 8 xfails are pre-existing `"InternLM2 streaming not fully implemented"` markers in the shared `ToolParserTests` harness, unchanged before/after this diff.
- `ruff check` and `ruff format --check`: clean.

## AI disclosure

Found via an AI-assisted (Claude) review pass over `vllm/tool_parsers/`, independently reproduced, fixed, and verified by me before submitting.
