### PR TITLE
[Bugfix] Count unsplit Idefics3 image patches

### DIFF
--- a/tests/models/multimodal/processing/test_smolvlm.py
+++ b/tests/models/multimodal/processing/test_smolvlm.py
@@ -23,6 +23,7 @@ from ...utils import build_model_context
     [
         ({"max_image_size": {"longest_edge": 384}}, 1377),
         ({"max_image_size": {"longest_edge": 768}}, 405),
+        ({"do_image_splitting": False}, 81),
     ],
 )
 @pytest.mark.parametrize("num_imgs", [1, 2])
@@ -69,6 +70,14 @@ def test_processor_override(
 
     # Ensure the placeholders format are correct
     hf_processor = processor.info.get_hf_processor(**hf_processor_mm_kwargs)
+    num_patches = processor.info.get_num_patches(
+        image_width=dummy_image.width,
+        image_height=dummy_image.height,
+        processor=hf_processor,
+        mm_kwargs=hf_processor_mm_kwargs,
+    )
+    assert num_patches == expected_toks_per_img // hf_processor.image_seq_len
+
     hf_processed_inputs = hf_processor(
         text=prompt,
         images=mm_data["image"],

--- a/vllm/model_executor/models/idefics3.py
+++ b/vllm/model_executor/models/idefics3.py
@@ -193,7 +193,7 @@ class Idefics3ProcessingInfo(BaseProcessingInfo):
             mm_kwargs=mm_kwargs,
         )
 
-        return num_patches
+        return max(num_patches, 1)
 
     def _get_image_token(self, processor: Idefics3Processor) -> tuple[str, str, str]:
         image_token = processor.image_token


### PR DESCRIPTION


## Purpose

Fixes #48667.

Hugging Face's Idefics3 image processor still emits one global image frame
when tiling is disabled, but its patch-count helper reports zero. vLLM used
that zero to size the flattened multimodal fields. Clamp the processed frame
count to at least one, and add regression coverage for SmolVLM with
`do_image_splitting=False`, for both init-time and call-time processor kwargs
with one and two images.

This does not duplicate an existing PR. Immediately before committing, I
checked open PRs for both `48667` and `Idefics3 num_patches` and found none.

This PR was developed with AI assistance. I reviewed every changed line and
ran the tests and repository hooks listed below locally.

## Test Plan

- Exercise the new no-split case alone before and after the production fix.
- Run the complete SmolVLM multimodal processor test module on a macOS
  Apple-silicon CPU build.
- Run all configured pre-commit hooks against both changed files.
- Model evaluation: N/A. This fixes processor frame accounting and does not
  change model weights or inference math.

## Test Result

- Before the fix, the new focused case failed with `assert 0 == 1`
  (`1 failed, 14 warnings in 25.94s`).
- After the fix, the same focused case passed
  (`1 passed, 14 warnings in 26.36s`).
- `.venv/bin/python -m pytest tests/models/multimodal/processing/test_smolvlm.py -q`
  passed (`12 passed, 14 warnings in 113.22s`).
- `.venv/bin/pre-commit run --files vllm/model_executor/models/idefics3.py tests/models/multimodal/processing/test_smolvlm.py`
  passed all applicable hooks, including Ruff, mypy, SPDX, forbidden-import,
  and configuration checks.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. N/A; this internal bug fix is covered by a regression test.
</details>

