### PR TITLE
[Bugfix][V1] Invalidate encoder cache on finish_weight_update

### DIFF
--- a/tests/entrypoints/weight_transfer/test_weight_transfer_llm.py
+++ b/tests/entrypoints/weight_transfer/test_weight_transfer_llm.py
@@ -9,7 +9,7 @@ actual NCCL communication.
 
 import os
 from dataclasses import dataclass
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -301,6 +301,67 @@ def test_full_weight_transfer_flow():
             assert result["update_called"], "receive_weights should be called"
             assert result["init_param"] == "flow_test"
             assert result["update_names"] == ["test.weight"]
+
+
+@create_new_process_for_each_test()
+def test_finish_weight_update_invalidates_encoder_cache():
+    """finish_weight_update invalidates the encoder cache by default and
+    leaves the prefix cache untouched unless explicitly requested.
+
+    Guards the #45093/#44910 regression: after a weight update the multimodal
+    encoder cache (keyed only by mm_hash) must not keep serving embeddings
+    computed with the old weights.
+    """
+    if torch.accelerator.device_count() < 1:
+        pytest.skip("Need at least 1 GPU for this test")
+
+    os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
+    os.environ["VLLM_ALLOW_INSECURE_SERIALIZATION"] = "1"
+
+    with patch(
+        "vllm.v1.worker.gpu_worker.WeightTransferEngineFactory.create_engine",
+        mock_create_engine,
+    ):
+        llm = LLM(
+            model=MODEL_NAME,
+            enforce_eager=True,
+            load_format="dummy",
+            tensor_parallel_size=1,
+            weight_transfer_config=WeightTransferConfig(backend="nccl"),
+        )
+
+        def run(**kwargs):
+            llm.init_weight_transfer_engine(
+                WeightTransferInitRequest(init_info={"test_param": "cache"})
+            )
+            llm.start_weight_update()
+            llm.update_weights(
+                WeightTransferUpdateRequest(
+                    update_info={
+                        "names": ["test.weight"],
+                        "dtype_names": ["bfloat16"],
+                        "shapes": [[8, 8]],
+                    }
+                )
+            )
+            enc = MagicMock()
+            pre = MagicMock()
+            with (
+                patch.object(llm.llm_engine, "reset_encoder_cache", enc),
+                patch.object(llm.llm_engine, "reset_prefix_cache", pre),
+            ):
+                llm.finish_weight_update(**kwargs)
+            return enc, pre
+
+        # Default: encoder cache invalidated, prefix cache left intact.
+        enc, pre = run()
+        enc.assert_called_once()
+        pre.assert_not_called()
+
+        # Opt out of encoder reset, opt in to prefix reset.
+        enc, pre = run(reset_encoder_cache=False, reset_prefix_cache=True)
+        enc.assert_not_called()
+        pre.assert_called_once()
 
 
 @create_new_process_for_each_test()

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -256,6 +256,17 @@ class EngineClient(ABC):
         """Batched weight update for RL training."""
         raise NotImplementedError
 
-    async def finish_weight_update(self) -> None:
-        """Finish the current weight update."""
+    async def finish_weight_update(
+        self,
+        reset_encoder_cache: bool = True,
+        reset_prefix_cache: bool = False,
+    ) -> None:
+        """Finish the current weight update.
+
+        Args:
+            reset_encoder_cache: Invalidate the multimodal encoder cache so
+                stale vision embeddings from the old weights are not reused.
+            reset_prefix_cache: Invalidate the prefix cache (KV blocks from
+                the old weights). Off by default.
+        """
         raise NotImplementedError

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -896,9 +896,32 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
             "update_weights", kwargs={"update_info": update_info_dict}
         )
 
-    def finish_weight_update(self) -> None:
-        """Finish the current weight update."""
+    def finish_weight_update(
+        self,
+        reset_encoder_cache: bool = True,
+        reset_prefix_cache: bool = False,
+    ) -> None:
+        """Finish the current weight update.
+
+        Caches populated with the old weights are stale once the update
+        commits. Callers are expected to invoke this at a quiesced point
+        (no in-flight requests), matching the weight-transfer contract.
+
+        Args:
+            reset_encoder_cache: Invalidate the multimodal encoder cache so
+                stale vision embeddings computed with the old weights are not
+                reused. On by default because the cache is keyed only by
+                ``mm_hash`` and is otherwise served stale after the update.
+            reset_prefix_cache: Invalidate the prefix cache (KV blocks
+                computed with the old weights). Off by default; leave this
+                decision to the caller so warm prefix cache is not discarded
+                on every update.
+        """
         self.llm_engine.collective_rpc("finish_weight_update")
+        if reset_encoder_cache:
+            self.llm_engine.reset_encoder_cache()
+        if reset_prefix_cache:
+            self.llm_engine.reset_prefix_cache()
 
     def __repr__(self) -> str:
         """Return a transformers-style hierarchical view of the model."""

--- a/vllm/entrypoints/serve/dev/rlhf/api_router.py
+++ b/vllm/entrypoints/serve/dev/rlhf/api_router.py
@@ -203,8 +203,22 @@ async def update_weights(raw_request: Request):
 
 
 @router.post("/finish_weight_update")
-async def finish_weight_update(raw_request: Request):
-    await engine_client(raw_request).finish_weight_update()
+async def finish_weight_update(
+    raw_request: Request,
+    reset_encoder_cache: Annotated[bool, Query()] = True,
+    reset_prefix_cache: Annotated[bool, Query()] = False,
+):
+    """Finish the current weight update.
+
+    By default the multimodal encoder cache is invalidated so stale vision
+    embeddings from the old weights are not reused. The prefix cache is left
+    intact unless ``reset_prefix_cache`` is set, so warm KV is not discarded
+    on every update.
+    """
+    await engine_client(raw_request).finish_weight_update(
+        reset_encoder_cache=reset_encoder_cache,
+        reset_prefix_cache=reset_prefix_cache,
+    )
     return JSONResponse(content={"message": "Weight update finished"})
 
 

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -1107,6 +1107,29 @@ class AsyncLLM(EngineClient):
             "update_weights", kwargs={"update_info": update_info_dict}
         )
 
-    async def finish_weight_update(self) -> None:
-        """Finish the current weight update."""
+    async def finish_weight_update(
+        self,
+        reset_encoder_cache: bool = True,
+        reset_prefix_cache: bool = False,
+    ) -> None:
+        """Finish the current weight update.
+
+        Caches populated with the old weights are stale once the update
+        commits. Callers are expected to invoke this at a quiesced point
+        (no in-flight requests), matching the weight-transfer contract.
+
+        Args:
+            reset_encoder_cache: Invalidate the multimodal encoder cache so
+                stale vision embeddings computed with the old weights are not
+                reused. On by default because the cache is keyed only by
+                ``mm_hash`` and is otherwise served stale after the update.
+            reset_prefix_cache: Invalidate the prefix cache (KV blocks
+                computed with the old weights). Off by default; leave this
+                decision to the caller so warm prefix cache is not discarded
+                on every update.
+        """
         await self.collective_rpc("finish_weight_update")
+        if reset_encoder_cache:
+            await self.reset_encoder_cache()
+        if reset_prefix_cache:
+            await self.reset_prefix_cache()


### PR DESCRIPTION
## Purpose

Fixes #44910. Re-lands the encoder-cache invalidation from #45093 (reverted by #46125) in a scoped, non-reverting form.

After a native weight update (`finish_weight_update`), the V1 multimodal **encoder cache** could keep serving vision embeddings computed with the **old** weights. The cache is keyed only by `mm_hash` with no weight epoch (`vllm/v1/core/encoder_cache_manager.py`), so a repeated image/`mm_hash` hits a stale entry until `reset_encoder_cache()` is called manually.

#45093 fixed this but was reverted because it **also** reset the **prefix** cache on every update — as noted in #46125, that decision should be left to the user, not done silently. This PR addresses that objection by scoping the default to the encoder cache only.

## Change

`finish_weight_update` now:

- **invalidates the encoder cache by default** (`reset_encoder_cache=True`) — it is keyed only by `mm_hash`, is otherwise served stale after the update, and is small/cheap to rebuild;
- **leaves the prefix cache untouched** unless the caller opts in (`reset_prefix_cache=False` by default) — this is the exact behavior the revert asked for;
- exposes both as parameters on the offline `LLM`, `AsyncLLM`, and the `EngineClient` interface, and as query params on the `/finish_weight_update` dev endpoint.

It reuses the existing `reset_encoder_cache()` plumbing (only the call site was removed by the revert). Callers are expected to invoke `finish_weight_update` at a quiesced point (no in-flight requests), matching the existing weight-transfer contract; this is documented on the methods.

Scope is intentionally encoder-only. Prefix-cache staleness across LoRA reloads is handled separately by #48352 (per-adapter content-hash identity) and encoder-cache staleness across LoRA reloads by #44950; this PR is the still-open native-weight-update case and does not overlap either.

## Test Plan

```bash
VLLM_USE_V2_MODEL_RUNNER=0 python -m pytest \
  tests/entrypoints/weight_transfer/test_weight_transfer_llm.py -q
```

New test `test_finish_weight_update_invalidates_encoder_cache` asserts the default invalidates the encoder cache and leaves the prefix cache intact, and that the flags reverse this.

End-to-end check on `Qwen2-VL-2B-Instruct` (single GPU, `--enforce-eager`, prefix caching disabled to isolate the encoder cache), oracle = first-token logprob for a fixed red-image prompt:

1. Warm the encoder cache (logprob `-0.5364`, encoder runs; repeat → identical, cache hit).
2. Zero a vision-tower weight (`visual.patch_embed.proj.weight`) via `apply_model`.
3. On unpatched `main`: the same request stays bit-identical (`-0.5364`) — stale encoder cache.
4. With this change, `finish_weight_update()` (default) makes the same request return `-0.9869` — the encoder recomputes with the new weights automatically.

## Test Result

- `tests/entrypoints/weight_transfer/test_weight_transfer_llm.py`: 6 passed.
- E2E: red → stale `-0.5364`; green → `-0.9869` (matches a manual `reset_encoder_cache()`).
- `ruff` and `mypy` (pre-commit) clean on all changed files.

This change does not alter model output for a fixed weight set; it only ensures a *changed* weight set is reflected, so no accuracy eval applies beyond the logprob check above.

## Open questions for reviewers

cc @DarkLight1337 @SumanthRH @aoshen02 (from the #46125 revert discussion):

1. **Default:** this PR defaults `reset_encoder_cache=True`. The alternative is default-off with an opt-in flag, but that leaves the reported bug present unless the caller remembers to opt in. Is default-on acceptable, or would you prefer default-off?
2. **Mechanism:** would you rather solve this class via a **weight-generation counter folded into cache identity** (bump on update; stale entries miss lazily, nothing is reset, in-flight requests stay coherent) instead of an explicit invalidate? That generalizes to the prefix cache too, but is a larger change and overlaps the keying work in #48352. Happy to pursue that direction if preferred.

## Note

AI assistance (Claude) was used to help write and validate this change; the author has reviewed every line and run the tests above.
