### PR TITLE
[ROCm][CI] Fix cuda graph mem profile issue

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -120,6 +120,7 @@ from vllm.utils.platform_utils import num_compute_units
 from vllm.utils.torch_utils import (
     PIN_MEMORY,
     async_tensor_h2d,
+    current_stream,
     get_dtype_size,
     is_quantized_kv_cache,
     kv_cache_dtype_str_to_dtype,
@@ -6608,17 +6609,19 @@ class GPUModelRunner(
         per_graph_estimate = {}
         encoder_memory_estimate = 0
 
-        # On ROCm, capture these throwaway profiling graphs on the current stream
-        # instead of the fresh side stream graph_capture() allocates by default.
-        # torch's allocator pools free blocks per stream, so a side-stream forward
-        # strands a persistent aiter scratch buffer in a separate pool, shifting
-        # the physical placement of the real KV cache allocated afterward and
-        # slowing bandwidth-bound decode ~20%. The graphs are discarded, so a
-        # side stream is unnecessary here.
-        # cap_ctx=None keeps the side-stream path on CUDA, where the current
-        # stream is the legacy default stream, on which capture cannot begin.
+        # On ROCm, capture these throwaway profiling graphs on vLLM's dedicated
+        # compute stream instead of the fresh side stream graph_capture()
+        # allocates by default. torch's allocator pools free blocks per stream,
+        # so a side-stream forward strands a persistent aiter scratch buffer in
+        # a separate pool, shifting the physical placement of the real KV cache
+        # allocated afterward and slowing bandwidth-bound decode ~20%. The
+        # graphs are discarded, so a side stream is unnecessary here.
+        # Use current_stream(), not torch.cuda.current_stream(): before vLLM
+        # initializes its dedicated stream, torch returns the per-thread default
+        # stream (cuda_stream=0), which cannot be used for cudagraph capture.
+        # cap_ctx=None keeps the side-stream path on CUDA.
         cap_ctx = (
-            GraphCaptureContext(torch.cuda.current_stream(self.device))
+            GraphCaptureContext(current_stream())
             if current_platform.is_rocm()
             else None
         )


### PR DESCRIPTION

### Root cause
During `determine_available_memory` → `profile_cudagraph_memory`, capture runs inside `torch.cuda.graph()`. PyTorch requires a non-default stream (cuda_stream != 0).

On ROCm, the profiling path was using:

GraphCaptureContext(torch.cuda.current_stream(self.device))
Before vLLM initializes its dedicated compute stream, torch.cuda.current_stream() is the per-thread default stream (cuda_stream=0). That object is not torch.cuda.default_stream() by identity, but PyTorch still rejects it for graph capture — which matches your error:

RuntimeError: CUDA graphs must be captured on a non-default stream.
### Fix
Use vLLM's current_stream() instead. It creates a dedicated non-default compute stream (the same one used for normal inference), which:

Satisfies PyTorch's cudagraph capture requirement
Preserves the ROCm intent of profiling on the compute stream, not a throwaway side stream from graph_capture()