### PR TITLE
[Model] Enable torch.compile/CUDA graphs for HYV3MTP draft model

### DIFF
--- a/vllm/model_executor/models/hy_v3_mtp.py
+++ b/vllm/model_executor/models/hy_v3_mtp.py
@@ -31,6 +31,7 @@ import torch
 from torch import nn
 from transformers import PretrainedConfig
 
+from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
@@ -201,6 +202,7 @@ class HYV3MultiTokenPredictor(nn.Module):
         return logits
 
 
+@support_torch_compile
 class HYV3MTP(nn.Module):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()


### PR DESCRIPTION

## Purpose

Fixes #48766.

`HYV3MTP` lacks `@support_torch_compile`, so while the target model runs
compiled with CUDA graphs, every MTP draft forward runs fully eager. The
Hy3 draft layer is a 192-expert MoE block plus a full-vocab logits GEMM;
eager, one draft cycle costs about one full graphed target step, making
speculative decoding slower than plain decode on this model family.

`DeepSeekMTP` has carried this decorator since #25109 with the same forward
shape. This PR applies the identical two-line change to `hy_v3_mtp.py`.

## Changes

- `vllm/model_executor/models/hy_v3_mtp.py`: import
  `support_torch_compile`, decorate `HYV3MTP`.

## Test plan / results

tencent/Hy3-FP8, 4x RTX PRO 6000 Blackwell (SM120), TP4, single-stream
decode, patched:

| config | tok/s |
|---|---|
| plain decode | 96.9 (unchanged by construction — the draft model never loads on this path) |
| MTP depth 1 | 105.7, **+9.1% over plain**, 57.7% pos-0 acceptance |
| MTP depth 2 | 87.2 (checkpoint-limited: single-layer head trained for depth 1) |

Stock (un-decorated) measurements demonstrating the regression are in the
linked issue: same hardware and engine, MTP runs 21-29% *below* plain
decode (94/90 tok/s at depth 1 on v0.24/v0.25 vs 119 plain, measured on a
4-bit quant of the same checkpoint — the eager draft cycle costs about one
full target step regardless of weight precision). Acceptance sits in the
same 56-58% pos-0 band in every stock and patched measurement, as expected:
compilation changes the draft cycle cost, not the draft distributions.

## Disclosure

This change was developed with AI assistance (Claude). The diagnosis,
measurements, and final text were verified and reviewed by the submitting
engineer.

Assisted-by: Claude <noreply@anthropic.com>
