### PR TITLE
[CI] Fix macOS wheel release annotation context

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -113,7 +113,7 @@ steps:
           - 'mv artifacts/reassembled/wheel "artifacts/dist/$$wheel_name"'
           - "aws sts get-caller-identity"
           - "VLLM_WHEEL_PLATFORM=macos bash .buildkite/scripts/upload-nightly-wheels.sh"
-          - 'bash .buildkite/scripts/annotate-build-artifact.sh "$$BUILDKITE_LABEL" "s3://vllm-wheels/$$BUILDKITE_COMMIT/$(cd artifacts/dist && echo *.whl)"'
+          - 'bash .buildkite/scripts/annotate-build-artifact.sh "$$BUILDKITE_LABEL" "s3://vllm-wheels/$$BUILDKITE_COMMIT/$(cd artifacts/dist && echo *.whl)" release-wheels'
         plugins:
           - aws-assume-role-with-web-identity#v1.6.0:
               role-arn: arn:aws:iam::936637512419:role/vllm-release-macos-wheel-uploader


### PR DESCRIPTION
## Summary

- add the required `release-wheels` annotation context to the macOS arm64 wheel upload step
- keep the macOS wheel artifact in the same dedicated annotation as the other wheel builds

## Root cause

The macOS wheel upload step was added while the release-artifact annotation split was in flight. It retained the helper's old two-argument invocation, but the merged helper requires a third context argument. The wheel uploaded successfully, then the job failed while annotating with `3: context is required`.

## Duplicate check

Searched open pull requests for `macOS release wheel annotation`, `annotate-build-artifact release-wheels`, and `buildkite context is required`. No PR addressing this regression was found.

## Validation

- `bk pipeline validate --file .buildkite/release-pipeline.yaml` — passed
- static audit of all `annotate-build-artifact.sh` callers — all 23 provide one of the three release contexts
- `git diff --check` — passed
- pre-commit hooks run by `git commit` — passed

Model evaluation is not applicable because this only changes Buildkite annotation routing.

AI assistance was used to diagnose the failed Buildkite job, audit callers, implement the one-line fix, and run validation. The human submitter reviewed the complete diff before publication.

## Buildkite

- [release-v2 #3916](https://buildkite.com/vllm/release-v2/builds/3916) — triggered from `khluu:codex/fix-macos-wheel-annotation` at `83143d84f3359d962ca0654dac14c6b0e0c661d3`
