### PR TITLE
[Inkling] Use <|unused_200053|>/<|unused_200054|> for image/audio placeholder token ids

### DIFF
--- a/vllm/transformers_utils/processors/inkling.py
+++ b/vllm/transformers_utils/processors/inkling.py
@@ -40,8 +40,8 @@ AUDIO_MARKER_ID = 200020  # <|content_audio_input|>
 # Per-patch / per-frame placeholder ids marking where tower embeddings are
 # scattered in. These are unused slots in the padded vocabulary and the
 # corresponding positions are always overwritten by tower embeddings.
-IMAGE_TOKEN_ID = 200007  # <|unused_200007|>
-AUDIO_TOKEN_ID = 200009  # <|unused_200009|>
+IMAGE_TOKEN_ID = 200053  # <|unused_200053|>
+AUDIO_TOKEN_ID = 200054  # <|unused_200054|>
 
 # ---------------------------------------------------------------------------
 # Image processing


### PR DESCRIPTION
## Summary

Repoint the Inkling image/audio **placeholder** token ids to the unused vocab slots `200053` and `200054`:

| Constant | Before | After |
| --- | --- | --- |
| `IMAGE_TOKEN_ID` | `200007` (`<|unused_200007|>`) | `200053` (`<|unused_200053|>`) |
| `AUDIO_TOKEN_ID` | `200009` (`<|unused_200009|>`) | `200054` (`<|unused_200054|>`) |

These are the per-patch / per-frame placeholder ids whose positions are always overwritten by tower embeddings; only the id values change. The block-start markers (`IMAGE_MARKER_ID` = `<|content_image|>`, `AUDIO_MARKER_ID` = `<|content_audio_input|>`) are untouched.

## Scope

Single file, two lines: `vllm/transformers_utils/processors/inkling.py`. No other references to `200007` / `200009` exist in the branch.

## Pending Rust follow-up (this PR is Python-only)

The Rust serving path resolves these placeholder ids from the `llm-multimodal` crate (pinned in `rust/Cargo.toml` / `rust/Cargo.lock`), not from this repo. For end-to-end consistency, a follow-up must land **after** the crate is updated on its `tml-audio` branch:

1. Bump the pinned `llm-multimodal` rev in `rust/Cargo.toml` (comment) and `rust/Cargo.lock` to the new `tml-audio` HEAD that carries `IMAGE_TOKEN_ID = 200053` / `AUDIO_TOKEN_ID = 200054`.
2. Update the Rust test constant `INKLING_AUDIO_EMBED_ID` in `rust/src/chat/src/multimodal/audio.rs` from `200_009` to `200_054` (asserted by `resolves_inkling_audio_from_model_spec` and `inkling_tracker_and_processor_use_standard_audio_key`).

Deferred here to avoid pinning an unmerged crate rev / red CI. The Rust renderer (`renderer/inkling/mod.rs`) resolves markers from the tokenizer by string and needs no change.
