### PR TITLE
Fix generation config loading

### DIFF
--- a/tests/transformers_utils/test_config.py
+++ b/tests/transformers_utils/test_config.py
@@ -6,8 +6,15 @@ only get the `eos_token_id` from the tokenizer as defined by
 `BaseRenderer.get_eos_token_id`.
 """
 
+from unittest.mock import MagicMock, call, patch
+
+from transformers import GenerationConfig, PretrainedConfig
+
 from vllm.tokenizers import get_tokenizer
-from vllm.transformers_utils.config import try_get_generation_config
+from vllm.transformers_utils.config import (
+    _generation_config_from_hf_configs,
+    try_get_generation_config,
+)
 
 
 def test_get_llama3_eos_token():
@@ -30,3 +37,47 @@ def test_get_blip2_eos_token():
     generation_config = try_get_generation_config(model_name, trust_remote_code=False)
     assert generation_config is not None
     assert generation_config.eos_token_id == 50118
+
+
+def test_try_get_generation_config_uses_loaded_hf_config():
+    hf_config = MagicMock(spec=PretrainedConfig)
+    hf_text_config = MagicMock(spec=PretrainedConfig)
+    expected = GenerationConfig(eos_token_id=42)
+
+    with patch(
+        "vllm.transformers_utils.config.GenerationConfig.from_pretrained",
+        side_effect=OSError("missing generation_config.json"),
+    ), patch(
+        "vllm.transformers_utils.config._generation_config_from_hf_configs",
+        return_value=expected,
+    ) as from_hf_configs, patch(
+        "vllm.transformers_utils.config.get_config",
+    ) as get_config:
+        result = try_get_generation_config(
+            "deepseek-ai/deepseek-vl2-tiny",
+            trust_remote_code=False,
+            hf_config=hf_config,
+            hf_text_config=hf_text_config,
+        )
+
+    assert result is expected
+    get_config.assert_not_called()
+    from_hf_configs.assert_called_once_with(hf_config, hf_text_config)
+
+
+def test_generation_config_from_hf_configs_falls_back_to_text_config():
+    hf_config = MagicMock(spec=PretrainedConfig)
+    hf_text_config = MagicMock(spec=PretrainedConfig)
+    expected = GenerationConfig(eos_token_id=7)
+
+    with patch(
+        "vllm.transformers_utils.config.GenerationConfig.from_model_config",
+        side_effect=[ValueError("invalid full config"), expected],
+    ) as from_model_config:
+        result = _generation_config_from_hf_configs(hf_config, hf_text_config)
+
+    assert result is expected
+    assert from_model_config.call_args_list == [
+        call(hf_config),
+        call(hf_text_config),
+    ]

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1479,6 +1479,8 @@ class ModelConfig:
                 revision=self.revision,
                 config_format=self.config_format,
                 hf_token=self.hf_token,
+                hf_config=self.hf_config,
+                hf_text_config=self.hf_text_config,
             )
         else:
             config = try_get_generation_config(

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -1066,12 +1066,30 @@ def get_hf_text_config(config: PretrainedConfig):
     return text_config
 
 
+def _generation_config_from_hf_configs(
+    hf_config: PretrainedConfig,
+    hf_text_config: PretrainedConfig | None = None,
+) -> GenerationConfig | None:
+    try:
+        return GenerationConfig.from_model_config(hf_config)
+    except ValueError:
+        if hf_text_config is not None and hf_text_config is not hf_config:
+            try:
+                return GenerationConfig.from_model_config(hf_text_config)
+            except ValueError:
+                return None
+        return None
+
+
 def try_get_generation_config(
     model: str,
     trust_remote_code: bool,
     revision: str | None = None,
     config_format: str | ConfigFormat = "auto",
     hf_token: bool | str | None = None,
+    *,
+    hf_config: PretrainedConfig | None = None,
+    hf_text_config: PretrainedConfig | None = None,
 ) -> GenerationConfig | None:
     try:
         return GenerationConfig.from_pretrained(
@@ -1080,6 +1098,14 @@ def try_get_generation_config(
             token=hf_token,
         )
     except OSError:  # Not found
+        if hf_config is not None:
+            text_config = hf_text_config
+            if text_config is None:
+                try:
+                    text_config = get_hf_text_config(hf_config)
+                except ValueError:
+                    text_config = None
+            return _generation_config_from_hf_configs(hf_config, text_config)
         try:
             config = get_config(
                 model,
@@ -1088,8 +1114,9 @@ def try_get_generation_config(
                 config_format=config_format,
                 token=hf_token,
             )
-            return GenerationConfig.from_model_config(config)
-        except OSError:  # Not found
+            text_config = get_hf_text_config(config)
+            return _generation_config_from_hf_configs(config, text_config)
+        except (OSError, ValueError):
             return None
 
 


### PR DESCRIPTION
 ## Purpose

Fix decode-server startup failures for models without a HuggingFace `generation_config.json` (e.g. `deepseek-ai/deepseek-vl2-tiny`) by reusing configs already loaded during `ModelConfig` initialization instead of re-fetching model config from the hub when building generation defaults.

**Problem**

The AMD CI job `crosslayer-kv-layout-distributed-nixlconnector-pd-accuracy-tests-4-gpus` failed on the last config sweep iteration:

`GPU_MEMORY_UTILIZATION=0.8 PREFILLER_TP_SIZE=2 DECODER_TP_SIZE=1 MODEL_NAMES=deepseek-ai/deepseek-vl2-tiny`

Prefill (port 8100) started successfully, but the decode server (port 8200) crashed during API initialization with:

```
ValueError: Unrecognized model in deepseek-ai/deepseek-vl2-tiny.
Should have a `model_type` key in its config.json.
```

The test then timed out after 1200s waiting for port 8200. The timeout was a symptom, not the root cause — the decode process had already exited.

**Root cause**

When `generation_config.json` is missing, `try_get_generation_config()` falls back after `GenerationConfig.from_pretrained()` raises `OSError`. The old fallback called `get_config(model, ...)` again — a **second** HuggingFace fetch — even though `ModelConfig` had already loaded `hf_config` / `hf_text_config` during init.

Under CI load (parallel prefill/decode startup, repeated deepseek sweep iterations, HF 429 rate limits), this redundant fetch could fail while the initial load succeeded, crashing the API server during `OpenAIServingCompletion` setup.

**Fix**

- Add `_generation_config_from_hf_configs()` to build `GenerationConfig` from already-loaded configs, with fallback to `hf_text_config` for multimodal models.
- Extend `try_get_generation_config()` to accept optional `hf_config` / `hf_text_config` and skip the redundant hub fetch when provided.
- Update `ModelConfig.try_get_generation_config()` to pass `self.hf_config` and `self.hf_text_config`.
                                                                                                                                     Models that ship `generation_config.json` are unchanged — the first `GenerationConfig.from_pretrained()` path still succeeds.

## Test Plan

- [x] Unit tests for the new behavior:

  ```bash
  pytest tests/transformers_utils/test_config.py::test_try_get_generation_config_uses_loaded_hf_config \
         tests/transformers_utils/test_config.py::test_generation_config_from_hf_configs_falls_back_to_text_config -v
  ```

- [x] Integration check (Docker / ROCm CI image) — verify `try_get_generation_config()` with pre-loaded `hf_config` does not call `get_config()` and returns expected `eos_token_id` for `deepseek-ai/deepseek-vl2-tiny`.

- [ ] CI: re-run `crosslayer-kv-layout-distributed-nixlconnector-pd-accuracy-tests-4-gpus` (AMD mirror):

  ```bash
  CROSS_LAYERS_BLOCKS=True ATTENTION_BACKEND=TRITON_ATTN \
    bash tests/v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
  ```
## Test Result

**Unit tests

```
tests/transformers_utils/test_config.py::test_try_get_generation_config_uses_loaded_hf_config PASSED
tests/transformers_utils/test_config.py::test_generation_config_from_hf_configs_falls_back_to_text_config PASSED
2 passed in ~1.2s