### PR TITLE
[Core] Make KV-cache dtype support platform-aware

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ import logging
 import os
 from dataclasses import MISSING, Field, asdict, dataclass, field
 from types import SimpleNamespace
+from typing import get_args
 from unittest.mock import patch
 
 import pydantic
@@ -25,6 +26,7 @@ from vllm.config import (
     VllmConfig,
     update_config,
 )
+from vllm.config.cache import CacheConfig, CacheDType
 from vllm.config.compilation import CompilationMode, CUDAGraphMode
 from vllm.config.kernel import IrOpPriorityConfig
 from vllm.config.load import LoadConfig
@@ -1647,3 +1649,38 @@ def test_load_config_rejects_invalid_safetensors_load_strategy():
 def test_load_config_rejects_non_string_load_format(bad_load_format):
     with pytest.raises(pydantic.ValidationError):
         LoadConfig(load_format=bad_load_format)
+
+
+# ---- KV-cache dtype platform support (issue #48099) ----
+
+
+def test_default_supported_kv_cache_dtypes_covers_all_known():
+    # By default a platform supports every known kv-cache dtype, so behavior is
+    # unchanged until a platform opts in to restrict or extend the set.
+    assert set(current_platform.get_supported_kv_cache_dtypes()) == set(
+        get_args(CacheDType)
+    )
+
+
+def test_cache_dtype_rejected_when_platform_unsupported(monkeypatch):
+    monkeypatch.setattr(
+        current_platform,
+        "get_supported_kv_cache_dtypes",
+        lambda: ["auto", "fp8"],
+    )
+    # A supported dtype is accepted.
+    assert CacheConfig(cache_dtype="fp8").cache_dtype == "fp8"
+    # An unsupported (but otherwise valid) dtype is rejected with a clear error.
+    with pytest.raises(pydantic.ValidationError, match="not supported"):
+        CacheConfig(cache_dtype="fp8_e5m2")
+
+
+def test_cache_dtype_auto_always_allowed(monkeypatch):
+    # "auto" defers dtype resolution and must stay valid even if a platform
+    # omits it from its supported list.
+    monkeypatch.setattr(
+        current_platform,
+        "get_supported_kv_cache_dtypes",
+        lambda: ["fp8"],
+    )
+    assert CacheConfig(cache_dtype="auto").cache_dtype == "auto"

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -274,6 +274,15 @@ class CacheConfig:
     @field_validator("cache_dtype", mode="after")
     @classmethod
     def _validate_cache_dtype(cls, cache_dtype: CacheDType) -> CacheDType:
+        from vllm.platforms import current_platform
+
+        supported = current_platform.get_supported_kv_cache_dtypes()
+        if cache_dtype != "auto" and cache_dtype not in supported:
+            raise ValueError(
+                f"kv-cache dtype '{cache_dtype}' is not supported on "
+                f"{current_platform.device_name}. Supported kv-cache dtypes: "
+                f"{supported}."
+            )
         if kv_cache_uses_per_token_head_scales(cache_dtype):
             logger.info(
                 "Using %s data type to store kv cache. It reduces the GPU "

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -186,6 +186,18 @@ class Platform:
         # when encountering unsupported dtypes in "auto" dtype.
         return [torch.bfloat16, torch.float16, torch.float32]
 
+    def get_supported_kv_cache_dtypes(self) -> list[str]:
+        """The ``--kv-cache-dtype`` values supported on this platform.
+
+        Defaults to all known kv-cache dtypes; platforms may override this to
+        restrict the set or add platform-specific dtypes.
+        """
+        from typing import get_args
+
+        from vllm.config.cache import CacheDType
+
+        return list(get_args(CacheDType))
+
     def is_cuda(self) -> bool:
         return self._enum == PlatformEnum.CUDA
 


### PR DESCRIPTION
## Purpose

Implements #48099 — make the valid `--kv-cache-dtype` set platform-aware.

Today `CacheDType` is a fixed global list and the `cache_dtype` validator in
`CacheConfig` never checks whether the current platform actually supports the
requested dtype. This PR lets each platform declare its supported set.

### Changes

- Add `Platform.get_supported_kv_cache_dtypes()` to the base platform
  interface, defaulting to **all** known kv-cache dtypes.
- Consult it in `CacheConfig._validate_cache_dtype`, raising a clear error for
  an unsupported dtype. `auto` is always allowed (it defers resolution).

Default behavior is unchanged — the base platform returns the full set, so
platforms opt in by overriding. Platform-specific overrides can follow.

## Test Plan

```
pytest tests/test_config.py -k "cache_dtype or supported_kv_cache" -v
```

New unit tests (written test-first) in `tests/test_config.py`:

- `test_default_supported_kv_cache_dtypes_covers_all_known`
- `test_cache_dtype_rejected_when_platform_unsupported`
- `test_cache_dtype_auto_always_allowed`

## Test Result

All 3 pass:

```
tests/test_config.py::test_default_supported_kv_cache_dtypes_covers_all_known PASSED
tests/test_config.py::test_cache_dtype_rejected_when_platform_unsupported PASSED
tests/test_config.py::test_cache_dtype_auto_always_allowed PASSED
3 passed
```

Ran the full `tests/test_config.py`; no regressions attributable to this change
(remaining failures are pre-existing HF-model-download / GPU-only env issues on
a CPU-only box).

---

**Not a duplicate:** Checked open PRs — none reference #48099. Related
KV-connector metric PRs (e.g. #48368) address a different issue.

**AI assistance:** This change was AI-assisted (Claude Code). I reviewed every
changed line and ran the tests myself.
