### PR TITLE
[ROCm][CI] Set "highest" matmul precision for reference hf_runner in `test_bert_for_masked_lm`

### DIFF
--- a/tests/models/language/pooling/test_token_classification.py
+++ b/tests/models/language/pooling/test_token_classification.py
@@ -272,6 +272,11 @@ def test_bert_for_masked_lm(
     if current_platform.is_rocm():
         hf_model_kwargs["attn_implementation"] = "eager"
 
+    # Run hf_runner reference with "highest" fp32 precision to match
+    # default behvior of vLLM. This is needed on ROCm since the
+    # pooling tests set matmul precision to "high" in conftest.py
+    prev_matmul_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("highest")
     with hf_runner(
         model,
         dtype=dtype,
@@ -285,6 +290,7 @@ def test_bert_for_masked_lm(
             inputs = hf_model.wrap_device(inputs)
             output = hf_model.model(**inputs)
             hf_outputs.append(softmax(output.logits[0]))
+    torch.set_float32_matmul_precision(prev_matmul_precision)
 
     # Compare the per-token vocabulary distributions position by position.
     for hf_output, vllm_output in zip(hf_outputs, vllm_outputs):


### PR DESCRIPTION

https://github.com/vllm-project/vllm/pull/48463 added `test_bert_for_masked_lm` which fails on ROCm due to subtle accuracy differences:

```
>           torch.testing.assert_close(hf_output, vllm_output, atol=3.2e-2, rtol=1e-3)
E           AssertionError: Tensor-likes are not close!
E           
E           Mismatched elements: 2 / 702006 (0.0%)
E           Greatest absolute difference: 0.049376606941223145 at index (7, 1011) (up to 0.032 allowed)
E           Greatest relative difference: 0.10987269133329391 at index (7, 1010) (up to 0.001 allowed)
models/language/pooling/test_token_classification.py:255: AssertionError
```
https://buildkite.com/vllm/ci/builds/77892/canvas?jid=019f5db5-b9e5-4728-86b6-2f2b8ef7e7c3&tab=output

This is because the vLLM runner uses matmul precisoin "highest" by default:
https://github.com/vllm-project/vllm/blob/ecf4aa5ce2ccd4069f12318ca9d3fcef7c9f6257/vllm/envs.py#L597-L602
https://github.com/vllm-project/vllm/blob/ecf4aa5ce2ccd4069f12318ca9d3fcef7c9f6257/vllm/v1/worker/gpu_worker.py#L147-L149

However, for this test group, we explicitly set `torch.set_float32_matmul_precision("high")` on ROCm to workaround a separate issue (see https://github.com/vllm-project/vllm/pull/31820). 

https://github.com/vllm-project/vllm/blob/ecf4aa5ce2ccd4069f12318ca9d3fcef7c9f6257/tests/models/language/pooling/conftest.py#L23

This gets picked up by the reference `hf_runner`, so the accuracy of the reference is less stable than on CUDA which does not set `torch.set_float32_matmul_precision("high")`.