### PR TITLE
[Bugfix] Fix activation quantization dispatch for WNA4Int/WNA8Int

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa4.py
@@ -96,7 +96,7 @@ class CompressedTensorsWNA4Int(CompressedTensorsScheme):
         return 75
 
     def _build_input_quant_config(self) -> dict | None:
-        """Build the config dict that HummingInputSchema.from_config expects."""
+        """Build the config dict that BaseInputSchema.from_config expects."""
         if self.input_quant is None:
             return None
         iq = self.input_quant
@@ -112,7 +112,7 @@ class CompressedTensorsWNA4Int(CompressedTensorsScheme):
             "dynamic": iq.dynamic,
             "group_size": iq.group_size or 0,
             "quant_method": "compressed-tensors",
-            "format": self.quant_format,
+            "format": "int-quantized",
         }
 
     def create_weights(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa8.py
@@ -96,7 +96,7 @@ class CompressedTensorsWNA8Int(CompressedTensorsScheme):
         return 75
 
     def _build_input_quant_config(self) -> dict | None:
-        """Build the config dict that HummingInputSchema.from_config expects."""
+        """Build the config dict that BaseInputSchema.from_config expects."""
         if self.input_quant is None:
             return None
         iq = self.input_quant
@@ -112,7 +112,7 @@ class CompressedTensorsWNA8Int(CompressedTensorsScheme):
             "dynamic": iq.dynamic,
             "group_size": iq.group_size or 0,
             "quant_method": "compressed-tensors",
-            "format": self.quant_format,
+            "format": "int-quantized",
         }
 
     def create_weights(

--- a/vllm/model_executor/layers/quantization/utils/humming_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/humming_utils.py
@@ -441,6 +441,7 @@ def prepare_humming_layer(
     input_quant_config: dict | None = None,
 ):
     from vllm.utils.humming import (
+        BaseInputSchema,
         BaseWeightSchema,
         HummingInputSchema,
         HummingMethod,
@@ -448,7 +449,7 @@ def prepare_humming_layer(
 
     weight_schema = BaseWeightSchema.from_config(quant_config)
     if input_quant_config is not None:
-        input_schema = HummingInputSchema.from_config(input_quant_config)
+        input_schema = BaseInputSchema.from_config(input_quant_config)
     else:
         input_schema = HummingInputSchema()
 
@@ -463,9 +464,15 @@ def prepare_humming_layer(
     shape_k_stacks = [input_size_per_partition]
     shape_n_stacks = layer.output_partition_sizes
 
-    # Step 1: convert weight to humming standard format
+    # Step 1: convert weight and input schemas to humming standard format
     weight_schema, tensors = weight_schema.convert_humming(
         tensors=dict(layer.named_parameters()),
+        shape_n_stacks=shape_n_stacks,
+        shape_k_stacks=shape_k_stacks,
+        param_dtype=layer.params_dtype,
+    )
+    input_schema, _ = input_schema.convert_humming(
+        tensors={},
         shape_n_stacks=shape_n_stacks,
         shape_k_stacks=shape_k_stacks,
         param_dtype=layer.params_dtype,


### PR DESCRIPTION
## Summary

CT humming path was pretending to do wNaM but was falling back to wNa16

### Problem 1: HummingInputSchema -> BaseInputSchema

if you call HummingInputSchema.from_config from a subclass it won't enter into the 

```
        if cls is BaseInputSchema:
            quant_method = config["quant_method"]
            ...
```

[branch](https://github.com/inclusionAI/humming/blob/main/humming/schema/base.py#L297). so it won't get to CompressedTensorsInputSchema it will instead try to create keys based on humming names. Those names aren't set up so instead they default to none. When that would get passed into the kernel the a_dtype was None which resolved to bfloat16 rather than erroring.

## Problem 2: pack-quantized -> int-quantized (fake)

after the first fix we now get an error instead of silent fallback. the reason for this is that
CompressedTensorsInputSchema doesn't accept pack-quantized for some reason.
Its already bizarre that humming takes the format at all since format is for the weight format, its only use is 

`self.input_scale_key = "input_global_scale" if "nvfp4" in self.format else "input_scale"`

so its basically just checking yes/no `nvfp4-pack-quantized`. However there's an assert that self.format is 'valid' but doesn't have pack-quantized as an option. This has been rectified in https://github.com/inclusionAI/humming/pull/42 but until a new release goes out and vllm updates its pin, we can just pass int-quantized to the CompressedTensorsInputSchema since every non `nvfp4-pack-quantized` format is treated the same aside from that assert.

## Test plan
https://github.com/vllm-project/llm-compressor/pull/2821
e2e tests now pass and make sense, see the drop for the activation quantized formats:

```
Model                                     bits_per_byte  byte_perplexity  word_perplexity
-----------------------------------------------------------------------------------------
Meta-Llama-3-8B-Instruct-W2A16-RTN               3.9238          15.1770     2071698.9589
Meta-Llama-3-8B-Instruct-W3A16-RTN               0.9087           1.8773          29.0214
Meta-Llama-3-8B-Instruct-W5A16-RTN               0.6325           1.5502          10.4260
Meta-Llama-3-8B-Instruct-W6A16-RTN               0.6302           1.5478          10.3401
Meta-Llama-3-8B-Instruct-W7A16-RTN               0.6302           1.5478          10.3381
Meta-Llama-3-8B-Instruct-W2A4-RTN                4.0975          17.1188     3943998.9400
Meta-Llama-3-8B-Instruct-W3A4-RTN                2.1307           4.3792        2690.4775
Meta-Llama-3-8B-Instruct-W2A8-RTN                3.9468          15.4212     2256332.4243
Meta-Llama-3-8B-Instruct-W3A8-RTN                0.9223           1.8951          30.5256
Meta-Llama-3-8B-Instruct-W5A8-RTN                0.6333           1.5511          10.4563
Meta-Llama-3-8B-Instruct-W6A8-RTN                0.6308           1.5484          10.3624
Meta-Llama-3-8B-Instruct-W7A8-RTN                0.6301           1.5477          10.3341
```

note: previously my evals were split with wNa16 doing groupwise quantization and wNa4/8 doing channelwise quantization (a bug), which is why this wasn't noticed before, the drop from groupwise->channelwise was masking the lack of a drop from wNa16 -> wNa4/8


🤖 Generated with [Claude Code](https://claude.com/claude-code)