### PR TITLE
[ROCm][Perf][DSV4] Improve sparse decode reduction occupancy on gfx950

### DIFF
--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -2198,7 +2198,7 @@ def _rocm_sparse_attn_decode_ragged_triton(
         num_warps=4,
     )
 
-    _sparse_attn_decode_reduce_kernel[(num_queries, heads_blocks)](
+    _sparse_attn_decode_reduce_kernel[(num_queries, num_heads)](
         part_m,
         part_l,
         part_acc,
@@ -2214,7 +2214,7 @@ def _rocm_sparse_attn_decode_ragged_triton(
         num_heads,
         HAS_ATTN_SINK=has_attn_sink,
         COMB_DIM=comb_dim,
-        BLOCK_H=block_h,
+        BLOCK_H=1,
         NUM_SPLITS=num_splits,
         SPLITS_PAD=triton.next_power_of_2(num_splits),
         num_warps=4,


### PR DESCRIPTION
## Summary

The split-K sparse decode reducer currently processes 16 heads per workgroup,
which keeps a `[16, COMB_DIM]` FP32 accumulator in each workgroup and limits
workgroup-level parallelism.

This change processes one head per reducer workgroup. It lowers per-workgroup
accumulator/register pressure and exposes up to 16 times more independent
workgroups while preserving the per-head reduction math and ordering.

On current upstream, this changes only the gfx950 split-K decode path. gfx942
remains on the fallback path and requires separate correctness, accuracy, and
performance verification. If #46275 broadens the split-K path to gfx942, this
reducer geometry must be validated there or separately gated before combining
the changes.

## Duplicate-work check

I searched the open vLLM PRs using DSV4, sparse decode, split-K reduction,
reducer, and gfx950-related keywords and did not find another PR implementing
this reducer launch-geometry change.

The closest related work is:

- #46275 broadens split sparse decode to gfx942 but does not independently
  optimize the reducer geometry.
- #46172 optimizes the sparse indexer path rather than this split-K reducer.

There is no linked issue for this focused performance change.

## Performance

The reference results come from the [official InferenceX MI355X TP8
sweep](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28593351944/attempts/1)
using `vllm-openai-rocm:nightly-09663ab`. Candidate results use upstream main
`3034c8d38` plus this change at `5d955f1fc`, with the same InferenceX workload
and serving recipe.

Both runs use 8 x MI355X/gfx950, TP8, DeepSeek-V4-Pro, FP8 KV cache, async
scheduling, disabled prefix caching, randomized 8K/1K requests with range ratio
0.8, 2 x CONC warmups, and 10 x CONC measured requests. Other scheduler and
model limits use vLLM defaults.

Because the reference and candidate use different vLLM revisions and separate
runs, these are directional end-to-end comparisons rather than an isolated
same-build A/B measurement of this patch.

| CONC | Output tok/s (reference -> change) | Delta | Mean TPOT ms (reference -> change) | Improvement | Mean TTFT ms (reference -> change) | Improvement |
|---:|---:|---:|---:|---:|---:|---:|
| 4 | 143.56 -> 149.78 | +4.34% | 26.41 -> 25.40 | 3.82% | 738.32 -> 613.71 | 16.88% |
| 16 | 431.65 -> 452.40 | +4.81% | 34.75 -> 33.17 | 4.54% | 1034.67 -> 932.43 | 9.88% |
| 64 | 888.84 -> 926.45 | +4.23% | 68.28 -> 65.50 | 4.06% | 2263.22 -> 2154.13 | 4.82% |

Positive output delta means higher throughput; positive latency improvement
means lower latency.

## Accuracy

Full GSM8K evaluation on this change (1,319 examples):

| Metric | This change |
|---|---:|
| Strict match | 1262/1319 (95.679%) |
| Flexible extract | 1261/1319 (95.603%) |

Both results exceed the required 94% threshold.

## Tests

```text
HIP_VISIBLE_DEVICES=0 .venv/bin/python -m pytest \
  tests/kernels/attention/test_rocm_triton_attn_dsv4.py -q
```

Result: `40 passed`.

```text
.venv/bin/pre-commit run --from-ref upstream/main --to-ref HEAD
```

Result: all hooks passed.

## AI assistance

AI assistance was used for implementation support, validation orchestration,
and drafting this PR. This Draft is intended for human inspection. Before
marking it ready for review, the human submitter will review every changed line,
confirm the reported results, and take responsibility for understanding and
defending the change.
