### PR TITLE
[Bugfix][Spec Decode] Fix multi-layer Qwen3.5 MTP dispatch

### DIFF
--- a/tests/model_executor/test_qwen3_5_quantization.py
+++ b/tests/model_executor/test_qwen3_5_quantization.py
@@ -76,3 +76,35 @@ def test_qwen3_5_mtp_lm_head_receives_quant_config():
         MockLMHead.assert_called_once()
         call_kwargs = MockLMHead.call_args.kwargs
         assert call_kwargs["quant_config"] is mock_quant_config
+
+
+def test_qwen3_5_mtp_forwards_spec_step_idx():
+    from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MTP
+
+    mtp = Mock()
+    mtp.model.return_value = expected_hidden_states = Mock()
+    input_ids = Mock()
+    positions = Mock()
+    hidden_states = Mock()
+    intermediate_tensors = Mock()
+    inputs_embeds = Mock()
+
+    output = Qwen3_5MTP.forward(
+        mtp,
+        input_ids,
+        positions,
+        hidden_states,
+        intermediate_tensors,
+        inputs_embeds,
+        spec_step_idx=2,
+    )
+
+    mtp.model.assert_called_once_with(
+        input_ids,
+        positions,
+        hidden_states,
+        intermediate_tensors,
+        inputs_embeds,
+        2,
+    )
+    assert output is expected_hidden_states

--- a/tests/v1/spec_decode/test_mtp.py
+++ b/tests/v1/spec_decode/test_mtp.py
@@ -115,7 +115,7 @@ def test_mtp_load_model_unified(mock_get_model, mock_get_layers, mock_get_pp_gro
     assert proposer.model.model.embed_tokens == target_model.model.embed_tokens
 
 
-@pytest.mark.parametrize("num_speculative_tokens", [1])
+@pytest.mark.parametrize("num_speculative_tokens", [1, 3])
 def test_mtp_propose(num_speculative_tokens, monkeypatch):
     """Test that MTP's forward method returns hidden states directly"""
 
@@ -126,6 +126,7 @@ def test_mtp_propose(num_speculative_tokens, monkeypatch):
     vocab_size = 100
 
     proposer = _create_mtp_proposer(num_speculative_tokens)
+    proposer.block_size = 16
     hidden_size = proposer.hidden_size
 
     # Mock the MTP model to verify it returns hidden states directly
@@ -217,5 +218,9 @@ def test_mtp_propose(num_speculative_tokens, monkeypatch):
 
     # Verify the model was called correctly
     assert model_mock.called
+    assert [
+        model_call.kwargs["spec_step_idx"]
+        for model_call in model_mock.call_args_list
+    ] == list(range(num_speculative_tokens))
     # Verify output shape
     assert result.shape == (batch_size, num_speculative_tokens)

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -860,15 +860,19 @@ class SpeculativeConfig:
                     MTPModelTypes
                 ):
                     self.method = "mtp"
+                    n_predict = getattr(
+                        self.draft_model_config.hf_config, "n_predict", None
+                    )
                     if (
-                        self.num_speculative_tokens > 1
-                        and self.draft_model_config.hf_config.model_type
-                        != "step3p5_mtp"
+                        n_predict is not None
+                        and self.num_speculative_tokens > n_predict
                     ):
                         logger.warning(
-                            "Enabling num_speculative_tokens > 1 will run "
-                            "multiple times of forward on same MTP layer"
-                            ",which may result in lower acceptance rate"
+                            "num_speculative_tokens=%d exceeds the %d trained MTP "
+                            "layers; layers will be reused cyclically, which may "
+                            "lower acceptance rate",
+                            self.num_speculative_tokens,
+                            n_predict,
                         )
                 elif self.method == "draft_model":
                     pass

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -274,10 +274,15 @@ class Qwen3_5MTP(LocalArgmaxMixin, nn.Module, SupportsMultiModal):
         hidden_states: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
-        **kwargs: object,
+        spec_step_idx: int = 0,
     ):
         hidden_states = self.model(
-            input_ids, positions, hidden_states, intermediate_tensors, inputs_embeds
+            input_ids,
+            positions,
+            hidden_states,
+            intermediate_tensors,
+            inputs_embeds,
+            spec_step_idx,
         )
         return hidden_states
 

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -565,6 +565,8 @@ class SpecDecodeBaseProposer:
         model_kwargs, slot_mapping_size = self.build_model_inputs_first_pass(
             num_tokens, num_input_tokens, mm_embed_inputs
         )
+        if self.method == "mtp":
+            model_kwargs["spec_step_idx"] = 0
         # Step 0 of index_share_for_mtp_iteration: let the MTP layer
         # compute its own indices (skip_topk=False) so subsequent steps
         # can reuse them.
@@ -729,6 +731,8 @@ class SpecDecodeBaseProposer:
             }
             if self.pass_hidden_states_to_model:
                 model_kwargs["hidden_states"] = self.hidden_states[:input_batch_size]
+            if self.method == "mtp":
+                model_kwargs["spec_step_idx"] = token_index + 1
 
             if self.eplb_state is not None:
                 self.eplb_state.prepare_forward(
@@ -1661,6 +1665,8 @@ class SpecDecodeBaseProposer:
                 )
                 if self.pass_hidden_states_to_model:
                     kwargs["hidden_states"] = self.hidden_states[:num_input_tokens]
+                if self.method == "mtp":
+                    kwargs["spec_step_idx"] = fwd_idx
                 self.model(**kwargs)
 
     def _get_eagle3_use_aux_hidden_state_from_config(self) -> bool:


### PR DESCRIPTION
## Purpose

Qwen3.5's MTP predictor already selects a trained layer using
`spec_step_idx % num_mtp_layers`. However, the generic speculative proposer did
not pass `spec_step_idx`, and `Qwen3_5MTP.forward()` did not forward it to the
inner predictor. Every draft pass therefore used the default index 0.

This change:

- passes index 0 for the first MTP pass
- passes `token_index + 1` for subsequent autoregressive draft passes
- passes `fwd_idx` during dummy runs and CUDA graph preparation
- forwards the index through `Qwen3_5MTP`
- warns about cyclic layer reuse only when the requested draft length exceeds
  the number of trained MTP layers
- adds regressions for both single-token and three-token drafting

### Duplicate-work check

PR #42146 also forwards `spec_step_idx` from MTP wrappers to their inner
predictors, but it does not modify `SpecDecodeBaseProposer`. Its description
explicitly notes that `spec_step_idx > 0` remains dead code.

This PR addresses that remaining runtime boundary: it supplies the index from
the first-pass, iterative, and dummy-run proposer paths, making nonzero indices
reachable for Qwen3.5. It is therefore materially different from #42146.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/v1/spec_decode/test_mtp.py::test_mtp_propose -v

.venv/bin/python -m pytest \
  tests/model_executor/test_qwen3_5_quantization.py::test_qwen3_5_mtp_forwards_spec_step_idx -v

.venv/bin/python -m py_compile \
  speculative.py \
  qwen3_5_mtp.py \
  llm_base_proposer.py \
  test_mtp.py \
  test_qwen3_5_quantization.py

git diff --check
