### PR TITLE
[Bugfix][Model] Fix Qwen3.5 MTP multimodal weight loading

### DIFF
--- a/tests/model_executor/test_qwen3_5_quantization.py
+++ b/tests/model_executor/test_qwen3_5_quantization.py
@@ -76,3 +76,32 @@ def test_qwen3_5_mtp_lm_head_receives_quant_config():
         MockLMHead.assert_called_once()
         call_kwargs = MockLMHead.call_args.kwargs
         assert call_kwargs["quant_config"] is mock_quant_config
+
+
+def test_qwen3_5_mtp_remaps_multimodal_weights():
+    from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MTP
+
+    weights = [
+        ("mtp.layers.0.self_attn.q_proj.weight", Mock()),
+        ("language_model.embed_tokens.weight", Mock()),
+        ("language_model.embed_tokens_extend.weight", Mock()),
+        ("language_model.lm_head.weight", Mock()),
+        ("visual.patch_embed.weight", Mock()),
+    ]
+    remapped_names = []
+
+    with patch(
+        "vllm.model_executor.models.qwen3_5_mtp.AutoWeightsLoader"
+    ) as MockLoader:
+        def capture_weights(remapped_weights):
+            remapped_names.extend(name for name, _ in remapped_weights)
+            return set(remapped_names)
+
+        MockLoader.return_value.load_weights.side_effect = capture_weights
+        Qwen3_5MTP.load_weights(Mock(), weights)
+
+    assert remapped_names == [
+        "model.layers.0.self_attn.q_proj.weight",
+        "embed_tokens.weight",
+        "lm_head.weight",
+    ]

--- a/tests/model_executor/test_qwen3_5_quantization.py
+++ b/tests/model_executor/test_qwen3_5_quantization.py
@@ -83,10 +83,10 @@ def test_qwen3_5_mtp_remaps_multimodal_weights():
 
     weights = [
         ("mtp.layers.0.self_attn.q_proj.weight", Mock()),
-        ("language_model.embed_tokens.weight", Mock()),
-        ("language_model.embed_tokens_extend.weight", Mock()),
-        ("language_model.lm_head.weight", Mock()),
-        ("visual.patch_embed.weight", Mock()),
+        ("model.language_model.embed_tokens.weight", Mock()),
+        ("model.language_model.embed_tokens_extend.weight", Mock()),
+        ("lm_head.weight", Mock()),
+        ("model.visual.patch_embed.weight", Mock()),
     ]
     remapped_names = []
 
@@ -102,6 +102,6 @@ def test_qwen3_5_mtp_remaps_multimodal_weights():
 
     assert remapped_names == [
         "model.layers.0.self_attn.q_proj.weight",
-        "embed_tokens.weight",
+        "model.embed_tokens.weight",
         "lm_head.weight",
     ]

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -295,8 +295,9 @@ class Qwen3_5MTP(LocalArgmaxMixin, nn.Module, SupportsMultiModal):
                     name = name.replace("mtp.", "model.")
                 elif "embed_tokens_extend" in name:
                     continue
-                elif "embed_tokens" in name or "lm_head" in name:
-                    name = name.replace("language_model.", "")
+                elif any(key in name for key in ["embed_tokens", "lm_head"]):
+                    if "embed_tokens" in name:
+                        name = name.replace("language_model.", "")
                 else:
                     continue
                 yield name, weight

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -293,9 +293,10 @@ class Qwen3_5MTP(LocalArgmaxMixin, nn.Module, SupportsMultiModal):
             for name, weight in weights:
                 if name.startswith("mtp."):
                     name = name.replace("mtp.", "model.")
-                elif any(key in name for key in ["embed_tokens", "lm_head"]):
-                    if "embed_tokens" in name:
-                        name = name.replace("language_model.", "")
+                elif "embed_tokens_extend" in name:
+                    continue
+                elif "embed_tokens" in name or "lm_head" in name:
+                    name = name.replace("language_model.", "")
                 else:
                     continue
                 yield name, weight


### PR DESCRIPTION
## Purpose

`Qwen3_5MTP.load_weights()` treats any weight name containing
`embed_tokens` as the shared token embedding. Multimodal checkpoints may also
contain `embed_tokens_extend` weights, which belong to multimodal components and
must not be loaded into the MTP drafter's embedding table.

This change filters `embed_tokens_extend` before the existing substring match.

The existing behavior for supported checkpoint keys is preserved:

- `model.language_model.embed_tokens.*` is remapped to `model.embed_tokens.*`
- top-level `lm_head.*` is passed through unchanged
- `mtp.*` continues to be remapped to `model.*`
- unrelated multimodal weights continue to be ignored

A regression test uses the actual Qwen3.5 checkpoint naming patterns and verifies
the complete set of names passed to `AutoWeightsLoader`.

### Duplicate-work check

I searched open PRs for `embed_tokens_extend`, `Qwen3_5MTP.load_weights`, and
Qwen3.5 multimodal MTP weight loading. No open PR addresses this remapping bug.

Related PRs such as #44644, #41994, #44943, and #48606 address duplicate
backbone allocation, quantization ignore lists, fused expert names, or Quark AWQ
loading. None filters `embed_tokens_extend` in this loader path.

## Test Plan

```bash
.venv/bin/python -m pytest \
  test_qwen3_5_quantization.py -v

git diff --check