### PR TITLE
[Bugfix][Tool Parser] Phi4Mini: don't drop tool calls with nested-array arguments

### DIFF
--- a/tests/tool_parsers/test_phi4mini_tool_parser.py
+++ b/tests/tool_parsers/test_phi4mini_tool_parser.py
@@ -98,10 +98,6 @@ Would you like to know more?""",
                 "test_streaming_reconstruction": "Phi4 Mini streaming not implemented",
             },
             xfail_nonstreaming={
-                "test_various_data_types": (
-                    "Phi4MiniJsonToolParser regex has nesting limitations "
-                    "with nested objects"
-                ),
                 "test_malformed_input": (
                     "Phi4MiniJsonToolParser incorrectly sets "
                     "tools_called=True on empty array"

--- a/vllm/tool_parsers/phi4mini_tool_parser.py
+++ b/vllm/tool_parsers/phi4mini_tool_parser.py
@@ -5,7 +5,6 @@ import json
 from collections.abc import Sequence
 from typing import Any
 
-import regex as re
 from transformers import PreTrainedTokenizerBase
 
 from vllm.entrypoints.chat_utils import make_tool_call_id
@@ -60,10 +59,9 @@ class Phi4MiniJsonToolParser(ToolParser):
         """
         logger.debug("Model output: %s", model_output)
 
-        pattern = r"functools\[(.*?)\]"
-        matches = re.search(pattern, model_output, re.DOTALL)
+        bot_idx = model_output.find(self.bot_token)
 
-        if not matches:
+        if bot_idx == -1:
             logger.debug("No function calls found")
             return ExtractedToolCallInformation(
                 tools_called=False, tool_calls=[], content=model_output
@@ -72,9 +70,14 @@ class Phi4MiniJsonToolParser(ToolParser):
         try:
             function_call_arr: list[dict[str, Any]] = []
             try:
-                json_content = "[" + matches.group(1) + "]"
-
-                function_call_arr = json.loads(json_content)
+                # Decode the JSON array directly after the `functools` marker.
+                # A `functools\[(.*?)\]` regex stops at the first `]`, which
+                # truncates any tool call whose arguments contain a nested
+                # list (e.g. `{"tags": ["a", "b"]}`); raw_decode handles
+                # arbitrary nesting and ignores any trailing text.
+                function_call_arr, _ = json.JSONDecoder().raw_decode(
+                    model_output, bot_idx + len(self.bot_token)
+                )
                 logger.debug(
                     "Successfully extracted %d function calls", len(function_call_arr)
                 )


### PR DESCRIPTION
## Purpose

`Phi4MiniJsonToolParser.extract_tool_calls` matched the tool-call block with `functools\[(.*?)\]` under `re.DOTALL`. The non-greedy `.*?` stops at the **first** `]`, so any tool call whose arguments contain a JSON array — e.g. `{"tags": ["a", "b"]}` — is truncated at the array's inner `]`:

```python
>>> import regex as re
>>> m = re.search(r"functools\[(.*?)\]", 'functools[{"name": "search", "arguments": {"tags": ["a", "b"]}}]', re.DOTALL)
>>> "[" + m.group(1) + "]"
'[{"name": "search", "arguments": {"tags": ["a"]'   # truncated -> invalid JSON
```

`json.loads` on that truncated string raises `JSONDecodeError` (swallowed by the logger), `function_call_arr` stays empty, and the parser returns `tools_called=True, tool_calls=[], content=None` — **the tool call and any content are both silently lost**. Any function call with an array-valued argument (a very common shape) is affected.

## Modification

Replace the regex with `json.JSONDecoder().raw_decode()` starting at the `functools` marker. `raw_decode` decodes the `[...]` array with correct handling of arbitrary nesting and ignores any trailing text after the array, so array-valued and deeply-nested arguments parse correctly. The now-unused `regex` import is removed.

## Test Plan

- Drive a real `Phi4MiniJsonToolParser` with `functools[{"name": "search", "arguments": {"tags": ["a", "b"]}}]` — a nested-array argument, the shape the parser's regex can't handle.
- Remove the `xfail_nonstreaming` marker the repo already had on `test_various_data_types` (its note says *"Phi4MiniJsonToolParser regex has nesting limitations with nested objects"* — i.e. this exact bug) and run it.
- `pytest tests/tool_parsers/test_phi4mini_tool_parser.py`; confirm red-before/green-after by stashing the source change.
- `ruff check` / `ruff format --check`.

## Test Result

- Reproduced against a real `Phi4MiniJsonToolParser` before touching source: `functools[{"name": "search", "arguments": {"tags": ["a", "b"]}}]` returned `tools_called=True, tool_calls=[], content=None`.
- The repo's own test suite **already had** `test_various_data_types` — whose input includes `"array_field": ["a", "b", "c"]` and a nested `object_field` — marked `xfail_nonstreaming` with the note *"Phi4MiniJsonToolParser regex has nesting limitations with nested objects"*, i.e. exactly this bug. This PR removes that xfail marker; the test now passes.
- Verified red-before/green-after: stashing the source change makes `test_various_data_types[False]` **fail** on pre-fix code (`Expecting ',' delimiter`), and it **passes** with the fix.
- Full `tests/tool_parsers/test_phi4mini_tool_parser.py`: **8 passed, 9 xfailed**, 0 unexpected. The remaining xfails are the unrelated streaming-not-implemented markers and the separate `tools_called=True`-on-empty-array issue, both untouched.
- `ruff check` and `ruff format --check`: clean.

## Duplicate-work check

`gh pr list --search "phi4mini"` / `"phi4_mini"` / `gh search prs "phi4mini_tool_parser"` — no open PR references this file or parser.

## AI disclosure

Found via an AI-assisted (Claude) review pass over `vllm/tool_parsers/`, independently reproduced, fixed, and verified by me before submitting.
