### PR TITLE
[Bugfix] Respect user-set TRITON_CACHE_DIR in InductorAdaptor

### DIFF
--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -477,7 +477,7 @@ class InductorAdaptor(CompilerInterface):
         os.environ["TORCHINDUCTOR_CACHE_DIR"] = inductor_cache
         triton_cache = os.path.join(self.base_cache_dir, "triton_cache")
         os.makedirs(triton_cache, exist_ok=True)
-        os.environ["TRITON_CACHE_DIR"] = triton_cache
+        os.environ.setdefault("TRITON_CACHE_DIR", triton_cache)
 
     def compile(
         self,


### PR DESCRIPTION
## Summary

`InductorAdaptor.initialize_cache()` unconditionally overwrites `TRITON_CACHE_DIR` with `os.environ["TRITON_CACHE_DIR"] = triton_cache`. This silently discards any user-provided Triton cache location.

## Why this matters

When a pre-warmed Triton cache (e.g. baked into a Docker image with all kernel specializations pre-compiled) is mounted at a custom location via `TRITON_CACHE_DIR=/path/to/cache`, vLLM overwrites it on startup and redirects to `vllm_cache/triton_cache`. All pre-compiled specializations are lost, and every kernel must be JIT-compiled again on the first request.

Using `setdefault` respects the user's choice: if `TRITON_CACHE_DIR` is already set, keep it; otherwise default to `vllm_cache/triton_cache`.

## Why only TRITON_CACHE_DIR

`TORCHINDUCTOR_CACHE_DIR` is left as an unconditional assignment because vLLM fully owns the Inductor compilation pipeline — it compiles the graphs, so it manages where the inductor cache lives. Triton kernels, however, may be compiled by other tools (e.g. a separate warmup script) and the cache may be shared.

## Test commands

```bash
.venv/bin/ruff check vllm/compilation/compiler_interface.py
.venv/bin/ruff format --check vllm/compilation/compiler_interface.py
```

## Pre-commit

`ruff check`, `ruff format`, `mypy`, `check-torch-cuda-call`, `check-spdx-headers`, and `check-forbidden-imports` all pass. Three other hooks fail due to local Python version incompatibility in the hook scripts themselves, not related to this PR.

## AI assistance

This PR was prepared with AI assistance (opencode). Every changed line was reviewed by a human.