### PR TITLE
Fix device undefied， w_zp -1 bugs

### DIFF
--- a/vllm/model_executor/kernels/linear/mixed_precision/exllama.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/exllama.py
@@ -16,7 +16,7 @@ from .MPLinearKernel import MPLinearKernel, MPLinearLayerConfig
 
 
 class ExllamaLinearKernel(MPLinearKernel):
-    SUPPORTED_QUANT_TYPES = [scalar_types.uint4b8, scalar_types.uint8b128]
+    SUPPORTED_QUANT_TYPES = [scalar_types.uint4, scalar_types.uint4b8, scalar_types.uint8b128]
     # In theory supports `scalar_types.uint2b2, scalar_types.uint3b4` too but
     # currently untested so not added to the list
 
@@ -110,7 +110,21 @@ class ExllamaLinearKernel(MPLinearKernel):
             setattr(
                 layer, self.w_zp_name, torch.nn.Parameter(zeros, requires_grad=False)
             )
-
+        else:
+            def transform_w_zp(x):
+                assert isinstance(x, BasevLLMParameter)
+                if c.weight_type.size_bits == 4:
+                    x.data = x.data - 0x11111111
+                elif c.weight_type.size_bits == 8:
+                    x.data = x.data - 0x01010101
+                else:
+                    raise NotImplementedError("Cannot fix GPTQ bug by simply substracting 1.")        
+                permute_param_layout_(x, input_dim=0, output_dim=1)
+                x.data = x.data.contiguous()
+                return x.to(dtype=torch.int32)
+            self._transform_param(layer, self.w_zp_name, transform_w_zp)
+            
+                
         if c.has_g_idx:
 
             def transform_w_g_idx(x):
@@ -121,6 +135,7 @@ class ExllamaLinearKernel(MPLinearKernel):
             self._transform_param(layer, self.w_gidx_name, transform_w_g_idx)  # type: ignore
         else:
             self.w_gidx_name = "g_idx"
+            device = getattr(layer, self.w_q_name).device
             empty_g_idx = torch.nn.Parameter(
                 torch.empty((0,), dtype=torch.int, device=device), requires_grad=False
             )

--- a/vllm/model_executor/kernels/linear/mixed_precision/exllama.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/exllama.py
@@ -95,7 +95,7 @@ class ExllamaLinearKernel(MPLinearKernel):
                 #  https://garden.danieldk.eu/GPTQ-Checkpoint-Format
                 zeros = torch.full(
                     (groups, out_features),
-                    c.weight_type.bias - 1,
+                    c.weight_type.bias,
                     dtype=torch.int32,
                     device=device,
                 )
@@ -112,16 +112,10 @@ class ExllamaLinearKernel(MPLinearKernel):
             )
         else:
             def transform_w_zp(x):
-                assert isinstance(x, BasevLLMParameter)
-                if c.weight_type.size_bits == 4:
-                    x.data = x.data - 0x11111111
-                elif c.weight_type.size_bits == 8:
-                    x.data = x.data - 0x01010101
-                else:
-                    raise NotImplementedError("Cannot fix GPTQ bug by simply substracting 1.")        
+                assert isinstance(x, BasevLLMParameter)      
                 permute_param_layout_(x, input_dim=0, output_dim=1)
                 x.data = x.data.contiguous()
-                return x.to(dtype=torch.int32)
+                return x
             self._transform_param(layer, self.w_zp_name, transform_w_zp)
             
                 
@@ -177,7 +171,7 @@ class ExllamaLinearKernel(MPLinearKernel):
         # gptq_gemm supports GPTQv2 format by passing use_v2_format=True.
         # However, the MPLinearLayerConfig doesn't contain format info.
         # So hardcode GPTQv1 format here, to keep its behavior unchanged.
-        use_v2_format = False
+        use_v2_format = True
 
         assert w_zp is not None, "Zero points are required by Exllama"
         assert w_g_idx is not None, "Group index is required by Exllama"


### PR DESCRIPTION
device is undefiend in the g_idx processing brach, add it.

Substracting zp by 1, because the gptq_gemm kernel adds 1.




## Purpose

The exllama weight processing function has two bugs.
I fixed them.

1) The device is undefied in the g_idx missing brach. I added it. Following is the vllm log when loading a model without g_idx:

(EngineCore pid=587)     torch.empty((0,), dtype=torch.int, device=device), requires_grad=False
(EngineCore pid=587)                                               ^^^^^^
(EngineCore pid=587) UnboundLocalError: cannot access local variable 'device' where it is not associated with a value


2) For assymertical quantized weight, each zero point value should minus 1, because the gemm_gptq kernel adds 1 to fix a previous GPTQ formatting bug.

## Test Plan
Tested with GPTQ and AWQ models. 

## Test Result
All passed.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

