### PR TITLE
[Bugfix] Reject per-request disable_any_whitespace in structured outputs

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -802,6 +802,22 @@ class SamplingParams(
         else:
             self.structured_outputs._backend = backend
 
+        if (
+            self.structured_outputs.disable_any_whitespace
+            != structured_outputs_config.disable_any_whitespace
+        ):
+            raise ValueError(
+                "Request-level `disable_any_whitespace` is not supported. "
+                f"The request set `disable_any_whitespace="
+                f"{self.structured_outputs.disable_any_whitespace}` but "
+                "the server was started with `--structured-outputs-config "
+                f'{{"disable_any_whitespace": '
+                f"{structured_outputs_config.disable_any_whitespace}}}"`. "
+                "Remove `disable_any_whitespace` from the request-level "
+                "`structured_outputs` and use the server-level "
+                "`--structured-outputs-config` instead."
+            )
+
         # Request content validation
         if (
             isinstance(self.structured_outputs.choice, list)


### PR DESCRIPTION
## Summary

Per-request `disable_any_whitespace` in `StructuredOutputsParams` is
silently ignored. Only the server-level `--structured-outputs-config`
value is ever used. This adds an explicit validation error when the
request value differs from the engine config.

## Root cause

`XgrammarBackend` reads the flag from the engine config once at
construction and never consults per-request params. Grammar compilation
is also cached per backend, so per-request values would need to be in
the cache key to be honoured. Rather than changing the caching strategy,
this PR follows the simpler approach already used for per-request
backend selection: reject with a clear error message.

## How

Added a validation check in `SamplingParams._validate_structured_outputs`
that compares the request-level `disable_any_whitespace` against the
server config. If they differ, raises `ValueError` with guidance to use
`--structured-outputs-config` instead.

## Testing

```bash
# Start server
vllm serve Qwen/Qwen3.6-27B-FP8 --port 8007 --reasoning-parser qwen3

# Request with per-request disable_any_whitespace should now 400:
curl -s http://localhost:8007/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"Qwen/Qwen3.6-27B-FP8","messages":[{"role":"user","content":"hello"}],
       "structured_outputs":{"json":{"type":"object"},"disable_any_whitespace":true}}'

# Expected: 400 with clear error message about the mismatch
```

Fixes #48765