### PR TITLE
[Kernel] Remove unused N/B constexpr params from pack/unpack seq kernels

### DIFF
--- a/vllm/v1/attention/ops/common.py
+++ b/vllm/v1/attention/ops/common.py
@@ -262,7 +262,6 @@ def _pack_seq_kernel(
     x_ptr,  # [N, D]
     out_ptr,  # [B, Lmax, D]
     lengths_ptr,  # *i32, [B]
-    N: tl.constexpr,
     D: tl.constexpr,
     Lmax: tl.constexpr,
     PAD_VALUE: tl.constexpr,
@@ -366,7 +365,6 @@ def pack_seq_triton(
         x_reshaped,
         out,
         lengths.int(),
-        N,
         D,
         Lmax,
         PAD_VALUE=pad_constexpr,
@@ -388,7 +386,6 @@ def _unpack_seq_triton_kernel(
     packed_ptr,  # [B, Lmax, D]
     out_ptr,  # [N, D]
     lengths_ptr,  # *i32, [B]
-    B: tl.constexpr,
     Lmax: tl.constexpr,
     D: tl.constexpr,
     BLOCK_T: tl.constexpr,  # timesteps per program
@@ -466,7 +463,6 @@ def unpack_seq_triton(
         packed_reshaped,
         out,
         lengths.int(),
-        B,
         Lmax,
         D,
         BLOCK_T=block_t,


### PR DESCRIPTION
Related to #48650. _pack_seq_kernel's N and _unpack_seq_triton_kernel's B were declared as tl.constexpr but never referenced in either kernel body. Since constexpr values are baked into Triton's JIT cache key, these unused params caused pure cache-key pollution , unnecessary recompiles triggered by token/request count changes that don't actually affect the compiled kernel.


## Purpose
`_pack_seq_kernel`'s `N` and `_unpack_seq_triton_kernel`'s `B` are declared as `tl.constexpr` but never referenced in either kernel body. Since constexpr values are baked into Triton's JIT cache key, these unused params cause pure cache-key pollution — unnecessary recompiles triggered by token/request count changes that don't actually affect the compiled kernel. One of several instances flagged in #48650.

Removed both unused params from the kernel signatures and their call sites. No logic change.

Related to #48650.

## Test Plan
- Manual pack/unpack round-trip test on a T4 GPU across varying batch sizes and sequence-length distributions (including single-sequence edge cases).
- `tests/kernels/attention/test_pack_unpack_triton.py` — attempted, but requires fp8e4m3 support (compute capability 8.9+). Confirmed via `git stash` that it fails identically on unmodified `main` on a T4 (compute capability 7.5), so this is an environment limitation, not something introduced by this change.

## Test Result
Manual round-trip tests (fp32, lengths `[4,4,4]`, `[1,7,3]`, `[10,1,1,1,1]`, `[50,60,70]`, `[1]`, `[100,100,100,100]`) — all passed, exact match against input.

`test_pack_unpack_triton.py` could not be run to completion locally due to the fp8 hardware requirement above. Happy for a reviewer with fp8-capable hardware to confirm the full suite passes — the change itself only removes unused constexpr params and doesn't touch any fp8-specific logic.