### PR TITLE
Fix MTP Mamba align prefix cache retention

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import dataclasses
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -5246,3 +5247,29 @@ def test_async_load_reservation_prevents_wedge_e2e():
     assert b.status == RequestStatus.WAITING
     assert b.num_preemptions == 0
     assert b.request_id not in req_to_blocks
+
+
+def _split_with_mtp_cache_retention(enabled: bool, num_tokens: int = 14) -> int:
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.use_eagle = True
+    scheduler.retain_mamba_align_mtp_cache_block = enabled
+    scheduler.cache_config = SimpleNamespace(block_size=4)
+    scheduler.hash_block_size = 4
+    scheduler.mamba_partial_cache_hit = False
+    request = SimpleNamespace(
+        num_computed_tokens=0,
+        num_prompt_tokens=num_tokens,
+        num_tokens=num_tokens,
+        shared_prefix_boundary=0,
+    )
+    return scheduler._mamba_block_aligned_split(request, num_new_tokens=14)
+
+
+def test_mamba_align_mtp_can_retain_final_cache_boundary() -> None:
+    """MTP should not discard a complete Mamba block before the prompt tail."""
+    # The legacy EAGLE rule drops the final complete block (12 -> 8).
+    assert _split_with_mtp_cache_retention(enabled=False) == 8
+    # MTP still computes the two-token tail, so the 12-token state is valid.
+    assert _split_with_mtp_cache_retention(enabled=True) == 12
+    # Without a tail, preserve EAGLE's safety block.
+    assert _split_with_mtp_cache_retention(enabled=True, num_tokens=12) == 8

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
+import os
 import time
 from collections import defaultdict, deque
 from collections.abc import Iterable
@@ -299,6 +300,15 @@ class Scheduler(SchedulerInterface):
         self.need_mamba_block_aligned_split = (
             self.has_mamba_layers and self.cache_config.mamba_cache_mode == "align"
         )
+        self.retain_mamba_align_mtp_cache_block = (
+            speculative_config is not None
+            and speculative_config.method == "mtp"
+            and self.need_mamba_block_aligned_split
+            and os.getenv(
+                "VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK", "0"
+            ).strip().lower()
+            in {"1", "true", "yes", "on"}
+        )
         # A finer prefix_match_unit is configured: a mamba partial tail entry
         # can only be registered by a step ending exactly at the prompt's last
         # hash boundary, so the split adds that stop.
@@ -373,7 +383,15 @@ class Scheduler(SchedulerInterface):
         # Eagle, FullAttn prunes the last matching block, so back off one
         # block to avoid a Mamba cache miss.
         last_cache_position = request.num_tokens - request.num_tokens % block_size
-        if self.use_eagle:
+        # MTP follows the EAGLE scheduler path, but an uncached prompt tail
+        # still runs and produces the hidden states needed by the proposer.
+        # In that case the final aligned Mamba state is valid and retaining it
+        # avoids throwing away a full (often ~2K-token) prefix block.
+        retain_final_mtp_block = (
+            self.retain_mamba_align_mtp_cache_block
+            and last_cache_position < request.num_tokens
+        )
+        if self.use_eagle and not retain_final_mtp_block:
             last_cache_position = max(last_cache_position - block_size, 0)
 
         end = start + num_new_tokens


### PR DESCRIPTION
## Purpose

Retain the final block-aligned Mamba prefix-cache state for MTP when an uncached prompt tail is still evaluated. Qwen3.5 MTP uses the EAGLE scheduler path, whose generic backoff discards one complete Mamba block even though the tail still produces proposer hidden states.

The behavior is opt-in with `VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK=1`. Prompts ending exactly at a block boundary keep the existing EAGLE safety backoff.

Related issue: https://github.com/vllm-project/vllm/issues/38182

## Test Plan

- `python -m py_compile vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py`
- focused scheduler regression: legacy split 8, retained split 12 with a tail, exact-boundary split 8
- live Qwen3.5 MTP A/B validation on the 8008 deployment

## Test Result

On the tested deployment, hot-cache performance improved from 6,336 / 8,339 cached prompt tokens at about 1.18 s TTFT to 8,448 / 8,525 cached tokens at about 235 ms TTFT. Decode throughput remained about 102 tok/s.