### PR TITLE
[Bugfix]Fix hybrid model sliding window RuntimeError

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1463,10 +1463,9 @@ def unify_hybrid_kv_cache_specs(kv_cache_spec: dict[str, KVCacheSpec]):
     )
 
     uniform_block_size: int | None = None
-    if has_swa_mla:
-        # For DeepseekV4, block sizes can be different for different KV cache groups.
-        # E.g., Full MLA: 256; SWA MLA: 64; C4 partial states: 4, C128 states: 8.
-        assert has_full_attention
+    if has_full_attention and (has_swa_mla or has_sliding_window):
+        # For DeepseekV4, block sizes can be different for different KV cache
+        # groups (e.g. Full MLA: 256; SWA MLA: 64; C4: 4, C128: 8).
         any_full_spec = next(
             iter(
                 spec
@@ -1478,11 +1477,14 @@ def unify_hybrid_kv_cache_specs(kv_cache_spec: dict[str, KVCacheSpec]):
 
     if has_full_attention and (has_sliding_window or has_chunked_local_attention):
         for layer_name, spec in kv_cache_spec.items():
+            block_size = (
+                uniform_block_size
+                if uniform_block_size is not None
+                else spec.block_size
+            )
             if isinstance(spec, SlidingWindowMLASpec):
                 kv_cache_spec[layer_name] = MLAAttentionSpec(
-                    block_size=uniform_block_size
-                    if uniform_block_size is not None
-                    else spec.block_size,
+                    block_size=block_size,
                     num_kv_heads=spec.num_kv_heads,
                     head_size=spec.head_size,
                     dtype=spec.dtype,
@@ -1494,7 +1496,7 @@ def unify_hybrid_kv_cache_specs(kv_cache_spec: dict[str, KVCacheSpec]):
                 )
             elif isinstance(spec, SlidingWindowSpec):
                 kv_cache_spec[layer_name] = FullAttentionSpec(
-                    block_size=spec.block_size,
+                    block_size=block_size,
                     num_kv_heads=spec.num_kv_heads,
                     head_size=spec.head_size,
                     head_size_v=spec.head_size_v,
@@ -1505,7 +1507,7 @@ def unify_hybrid_kv_cache_specs(kv_cache_spec: dict[str, KVCacheSpec]):
                 )
             elif isinstance(spec, ChunkedLocalAttentionSpec):
                 kv_cache_spec[layer_name] = FullAttentionSpec(
-                    block_size=spec.block_size,
+                    block_size=block_size,
                     num_kv_heads=spec.num_kv_heads,
                     head_size=spec.head_size,
                     dtype=spec.dtype,


### PR DESCRIPTION
## Purpose
Fix test/v1/e2e/general/test_correctness_sliding_window.py::test_sliding_window_retrieval[True-1-5-google/gemma-3-1b-it] meet ValueError: Hybrid KV cache manager is disabled but failed to convert the KV cache specs to one unified type.

Root cause:
Gemma-3 is a hybrid model. It interleaves both types: most layers are sliding-window, but some are full-attention.
#46104 added a sliding_window field to FlashAttentionMetadata (populated from the group's KV-cache spec), it broke the disabled-hybrid mixed-group case in Gemma-3.

FIx:
In unify_hybrid_kv_cache_specs, generalize the existing uniform_block_size logic so that when
full-attention is mixed with sliding-window, the converted specs adopt the full-attention block size