### PR TITLE
fix: defer optional transformers model imports

### DIFF
--- a/tests/model_executor/test_optional_transformers_imports.py
+++ b/tests/model_executor/test_optional_transformers_imports.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import builtins
+import importlib
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import ModuleType
+
+import pytest
+
+
+@contextmanager
+def _without_transformers_module(
+    monkeypatch: pytest.MonkeyPatch,
+    import_name: str,
+    missing_module: str | None = None,
+) -> Iterator[None]:
+    real_import = builtins.__import__
+    missing_module = missing_module or import_name
+
+    def import_without_module(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        if name == import_name or name.startswith(f"{import_name}."):
+            raise ModuleNotFoundError(
+                f"No module named '{missing_module}'", name=missing_module
+            )
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_module)
+    yield
+
+
+def _clear_modules(module_name: str, missing_transformers_module: str):
+    for name in list(sys.modules):
+        if name == module_name or name.startswith(f"{missing_transformers_module}."):
+            sys.modules.pop(name, None)
+    sys.modules.pop(missing_transformers_module, None)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "missing_transformers_module"),
+    [
+        (
+            "vllm.model_executor.models.exaone4_5",
+            "transformers.models.exaone4_5",
+        ),
+        (
+            "vllm.model_executor.models.gemma4_unified",
+            "transformers.models.gemma4_unified",
+        ),
+    ],
+)
+def test_model_module_imports_when_optional_transformers_module_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    module_name: str,
+    missing_transformers_module: str,
+):
+    """Missing optional HF model modules should not break registry import."""
+    _clear_modules(module_name, missing_transformers_module)
+
+    with _without_transformers_module(monkeypatch, missing_transformers_module):
+        module = importlib.import_module(module_name)
+
+    assert module is not None
+
+
+@pytest.mark.parametrize(
+    ("module_name", "missing_transformers_module", "internal_missing_module"),
+    [
+        (
+            "vllm.model_executor.models.exaone4_5",
+            "transformers.models.exaone4_5",
+            "missing_internal_exaone4_5_dependency",
+        ),
+        (
+            "vllm.model_executor.models.gemma4_unified",
+            "transformers.models.gemma4_unified",
+            "missing_internal_gemma4_unified_dependency",
+        ),
+    ],
+)
+def test_model_module_reraises_internal_transformers_import_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    module_name: str,
+    missing_transformers_module: str,
+    internal_missing_module: str,
+):
+    """Only the optional HF module itself should be treated as absent."""
+    _clear_modules(module_name, missing_transformers_module)
+
+    with (
+        _without_transformers_module(
+            monkeypatch,
+            missing_transformers_module,
+            missing_module=internal_missing_module,
+        ),
+        pytest.raises(ModuleNotFoundError) as exc_info,
+    ):
+        importlib.import_module(module_name)
+
+    assert exc_info.value.name == internal_missing_module

--- a/vllm/model_executor/models/exaone4_5.py
+++ b/vllm/model_executor/models/exaone4_5.py
@@ -15,17 +15,44 @@
 # limitations under the License.
 """Inference-only EXAONE-4.5 model compatible with HuggingFace weights."""
 
+from __future__ import annotations
+
 from collections.abc import Callable, Iterable
 from functools import partial
+from typing import TYPE_CHECKING, Any, cast
 
 import einops
 import torch
 import torch.nn as nn
-from transformers.models.exaone4_5 import (
-    Exaone4_5_Config,
-    Exaone4_5_Processor,
-)
-from transformers.models.exaone4_5.configuration_exaone4_5 import Exaone4_5_VisionConfig
+
+if TYPE_CHECKING:
+    from transformers.models.exaone4_5 import (
+        Exaone4_5_Config,
+        Exaone4_5_Processor,
+    )
+    from transformers.models.exaone4_5.configuration_exaone4_5 import (
+        Exaone4_5_VisionConfig,
+    )
+else:
+    try:
+        from transformers.models.exaone4_5 import (
+            Exaone4_5_Config,
+            Exaone4_5_Processor,
+        )
+        from transformers.models.exaone4_5.configuration_exaone4_5 import (
+            Exaone4_5_VisionConfig,
+        )
+    except ModuleNotFoundError as exc:
+        missing_name = exc.name or ""
+        if missing_name != "transformers.models.exaone4_5" and not (
+            missing_name.startswith("transformers.models.exaone4_5.")
+        ):
+            raise
+        Exaone4_5_Config = None
+        Exaone4_5_Processor = None
+        _EXAONE4_5_IMPORT_ERROR = exc
+    else:
+        _EXAONE4_5_IMPORT_ERROR = None
 
 from vllm.compilation.decorators import (
     should_torch_compile_mm_encoder,
@@ -55,6 +82,16 @@ from .qwen2_vl import Qwen2VLMultiModalProcessor as Exaone4_5_MultiModalProcesso
 from .utils import AutoWeightsLoader, init_vllm_registered_model, maybe_prefix
 
 logger = init_logger(__name__)
+
+
+def _require_exaone4_5_transformers() -> tuple[type[Any], type[Any]]:
+    if Exaone4_5_Config is None or Exaone4_5_Processor is None:
+        raise ImportError(
+            "EXAONE-4.5 requires a Transformers version that provides "
+            "`transformers.models.exaone4_5`."
+        ) from _EXAONE4_5_IMPORT_ERROR
+
+    return cast(type[Any], Exaone4_5_Config), cast(type[Any], Exaone4_5_Processor)
 
 
 # === Vision Encoder === #
@@ -301,11 +338,13 @@ class EXAONE4_5_VisionTransformer(Qwen2_5_VisionTransformer):
 
 class Exaone4_5_ProcessingInfo(Qwen2VLProcessingInfo):
     def get_hf_config(self):
-        return self.ctx.get_hf_config(Exaone4_5_Config)
+        config_cls, _ = _require_exaone4_5_transformers()
+        return self.ctx.get_hf_config(config_cls)
 
     def get_hf_processor(self, **kwargs: object) -> Exaone4_5_Processor:
+        _, processor_cls = _require_exaone4_5_transformers()
         return self.ctx.get_hf_processor(
-            Exaone4_5_Processor,
+            processor_cls,
             use_fast=kwargs.pop("use_fast", True),
             **kwargs,
         )

--- a/vllm/model_executor/models/gemma4_unified.py
+++ b/vllm/model_executor/models/gemma4_unified.py
@@ -15,17 +15,41 @@ the language model, MTP integration, bidirectional attention helpers,
 embedding/forward path, and LoRA support are all inherited unchanged.
 """
 
+from __future__ import annotations
+
 import math
 from collections.abc import Iterable, Mapping
+from typing import TYPE_CHECKING, Any, cast
 
 import torch
 from torch import nn
-from transformers.models.gemma4_unified.configuration_gemma4_unified import (
-    Gemma4UnifiedConfig,
-)
-from transformers.models.gemma4_unified.processing_gemma4_unified import (
-    Gemma4UnifiedProcessor,
-)
+
+if TYPE_CHECKING:
+    from transformers.models.gemma4_unified.configuration_gemma4_unified import (
+        Gemma4UnifiedConfig,
+    )
+    from transformers.models.gemma4_unified.processing_gemma4_unified import (
+        Gemma4UnifiedProcessor,
+    )
+else:
+    try:
+        from transformers.models.gemma4_unified.configuration_gemma4_unified import (
+            Gemma4UnifiedConfig,
+        )
+        from transformers.models.gemma4_unified.processing_gemma4_unified import (
+            Gemma4UnifiedProcessor,
+        )
+    except ModuleNotFoundError as exc:
+        missing_name = exc.name or ""
+        if missing_name != "transformers.models.gemma4_unified" and not (
+            missing_name.startswith("transformers.models.gemma4_unified.")
+        ):
+            raise
+        Gemma4UnifiedConfig = None
+        Gemma4UnifiedProcessor = None
+        _GEMMA4_UNIFIED_IMPORT_ERROR = exc
+    else:
+        _GEMMA4_UNIFIED_IMPORT_ERROR = None
 
 from vllm.config import VllmConfig
 from vllm.config.multimodal import VideoDummyOptions
@@ -137,6 +161,19 @@ class Gemma4UnifiedVisionEmbedder(nn.Module):
 # ---------------------------------------------------------------------------
 
 
+def _require_gemma4_unified_transformers() -> tuple[type[Any], type[Any]]:
+    if Gemma4UnifiedConfig is None or Gemma4UnifiedProcessor is None:
+        raise ImportError(
+            "Gemma 4 Unified requires a Transformers version that provides "
+            "`transformers.models.gemma4_unified`."
+        ) from _GEMMA4_UNIFIED_IMPORT_ERROR
+
+    return (
+        cast(type[Any], Gemma4UnifiedConfig),
+        cast(type[Any], Gemma4UnifiedProcessor),
+    )
+
+
 class Gemma4UnifiedProcessingInfo(Gemma4ProcessingInfo):
     """ProcessingInfo for the Gemma4 Unified variant.
 
@@ -149,11 +186,13 @@ class Gemma4UnifiedProcessingInfo(Gemma4ProcessingInfo):
     """
 
     def get_hf_config(self):
-        return self.ctx.get_hf_config(Gemma4UnifiedConfig)
+        config_cls, _ = _require_gemma4_unified_transformers()
+        return self.ctx.get_hf_config(config_cls)
 
     def get_hf_processor(self, **kwargs: object) -> Gemma4UnifiedProcessor:
+        _, processor_cls = _require_gemma4_unified_transformers()
         return self.ctx.get_hf_processor(
-            Gemma4UnifiedProcessor,
+            processor_cls,
             **kwargs,
         )
 


### PR DESCRIPTION
## Summary

- Fixes #48819.
- Defers EXAONE 4.5 and Gemma 4 Unified Transformers submodule access until config/processor use.
- Keeps vLLM model module imports working when optional/new HF model submodules are absent.
- Adds a regression test that simulates missing `transformers.models.exaone4_5` and `transformers.models.gemma4_unified`.

## Affected Transformers scope

Verified package-level scope:

| Transformers version | `transformers.models.exaone4_5` | `transformers.models.gemma4_unified` | Result |
| --- | --- | --- | --- |
| 5.6.0 | missing | missing | affected |
| 5.12.0 | present | present | not affected by this missing-submodule issue |
| 5.14.0 | present | present | not affected by this missing-submodule issue |

I have not verified every intermediate Transformers release between 5.6.0 and 5.12.0, so the exact first non-affected version is intentionally not claimed here.

## Duplicate-work check

I checked open vLLM PRs/issues with:

```bash
gh pr list --repo vllm-project/vllm --state open --search "exaone4_5 transformers ModuleNotFoundError"
gh pr list --repo vllm-project/vllm --state open --search "gemma4_unified transformers ModuleNotFoundError"
gh pr list --repo vllm-project/vllm --state open --search "EXAONE 4.5"
gh pr list --repo vllm-project/vllm --state open --search "Gemma 4 Unified"
gh issue list --repo vllm-project/vllm --state open --search "ModuleNotFoundError transformers.models.exaone4_5"
gh issue list --repo vllm-project/vllm --state open --search "ModuleNotFoundError transformers.models.gemma4_unified"
```

No duplicate PR/issue was found. The closest open PRs are materially different:

- #45584 fixes EXAONE 4.5 `text_config.layer_types` validation.
- #47652 fixes Gemma 4 Unified multi-audio processing.

## Tests

```bash
.venv/bin/python -m pytest tests/model_executor/test_optional_transformers_imports.py -q
.venv/bin/python -m ruff check vllm/model_executor/models/exaone4_5.py vllm/model_executor/models/gemma4_unified.py tests/model_executor/test_optional_transformers_imports.py
.venv/bin/python -m ruff format --check vllm/model_executor/models/exaone4_5.py vllm/model_executor/models/gemma4_unified.py tests/model_executor/test_optional_transformers_imports.py
git diff --check HEAD~1..HEAD
uv run --no-project --python 3.12 --with transformers==5.6.0 python - <<'PY'
import importlib
import transformers
print("transformers", transformers.__version__)
for name in ["transformers.models.exaone4_5", "transformers.models.gemma4_unified"]:
    try:
        importlib.import_module(name)
        print("present", name)
    except Exception as exc:
        print("missing", name, type(exc).__name__, exc)
PY
uv run --no-project --python 3.12 --with transformers==5.12.0 python - <<'PY'
import importlib
import transformers
print("transformers", transformers.__version__)
for name in ["transformers.models.exaone4_5", "transformers.models.gemma4_unified"]:
    try:
        importlib.import_module(name)
        print("present", name)
    except Exception as exc:
        print("missing", name, type(exc).__name__, exc)
PY
```

Results:

- `4 passed, 15 warnings`
- `All checks passed!`
- `3 files already formatted`
- `git diff --check HEAD~1..HEAD` exited 0
- `transformers==5.6.0`: both HF submodules missing
- `transformers==5.12.0`: both HF submodules present

## Model evals

Not run. This change only affects import-time optional dependency handling and does not change model math, output generation, weights, tokenization, or serving behavior for environments where the HF submodules are present.

## AI assistance and review status

AI assistance was used to investigate and prepare this change.

This PR is opened as a draft because vLLM's agent instructions require a human submitter to review every changed line and be able to defend the change end-to-end before proposing it for review. `host452b` should complete that review before marking this PR ready.
