### PR TITLE
[Bugfix][Core] Don't crash EngineCore on stale KV-transfer completion for aborted request

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -421,6 +421,26 @@ def _setup_remote_kv_resume(num_prompt_tokens: int, matched_tokens: int):
     return scheduler
 
 
+@pytest.mark.parametrize("kv_xfer_dir", ["finished_sending", "finished_recving"])
+def test_kv_xfer_finished_skips_untracked_request(kv_xfer_dir):
+    """Regression: a KV-transfer completion reported by the worker connector for
+    a request the scheduler no longer tracks (aborted mid-transfer, e.g. a client
+    disconnect, so its blocks were already freed in finish_requests()) must be
+    ignored, not trip the `assert req_id in self.requests` in
+    `_update_from_kv_xfer_finished`. That assert previously raised inside the
+    EngineCore busy loop and killed the whole engine (EngineDeadError)."""
+    scheduler = create_scheduler(
+        use_kv_connector=mock_kv(matched_tokens=0, is_async=True)
+    )
+    ghost_req_id = "aborted-req"
+    output = KVConnectorOutput(**{kv_xfer_dir: {ghost_req_id}})
+
+    # Must not raise. Pre-fix this raised AssertionError -> EngineDeadError.
+    scheduler._update_from_kv_xfer_finished(output)
+
+    assert ghost_req_id not in scheduler.requests
+
+
 def test_throttle_prefills_excludes_fully_transferred_remote_kv():
     """A remote-KV resume whose whole prompt was transferred (no local prefill
     left, e.g. the decode side of P/D disaggregation) must NOT be throttled by

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2586,7 +2586,12 @@ class Scheduler(SchedulerInterface):
         # KV Connector:: update recv and send status from last step.
         for req_id in kv_connector_output.finished_recving or ():
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            assert req_id in self.requests
+            if req_id not in self.requests:
+                # The request was aborted (e.g. client disconnect) while its KV
+                # recv was still in flight; its blocks were already freed in
+                # finish_requests(). Ignore the now-stale completion instead of
+                # asserting, which would kill the whole EngineCore.
+                continue
             req = self.requests[req_id]
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
@@ -2595,7 +2600,12 @@ class Scheduler(SchedulerInterface):
                 self._free_blocks(self.requests[req_id])
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert req_id in self.requests
+            if req_id not in self.requests:
+                # The request was aborted (e.g. client disconnect) while its KV
+                # send was still in flight; its blocks were already freed in
+                # finish_requests(). Ignore the now-stale completion instead of
+                # asserting, which would kill the whole EngineCore.
+                continue
             self._free_blocks(self.requests[req_id])
 
     def _update_requests_with_invalid_blocks(


### PR DESCRIPTION
## Purpose

`Scheduler._update_from_kv_xfer_finished` hard-asserts that every `req_id` reported in `finished_recving` / `finished_sending` is still tracked in `self.requests`:

```python
for req_id in kv_connector_output.finished_recving or ():
    assert req_id in self.requests
    ...
for req_id in kv_connector_output.finished_sending or ():
    assert req_id in self.requests
    self._free_blocks(self.requests[req_id])
```

When a request is **aborted while a KV-connector transfer is still in flight** (e.g. the client disconnects / Ctrl+C during external cache retrieval), `finish_requests()` frees and removes it from `self.requests`. A subsequent completion signal for that `req_id` then trips `assert req_id in self.requests`. Because this runs inside the EngineCore busy loop with no handler, the `AssertionError` propagates as `EngineDeadError` and **takes down the entire engine** — every in-flight request of every tenant on that replica gets a 500 and the container restarts. One disconnecting client kills the shared engine.

This is easy to hit with an async offloading connector (e.g. LMCache) in `kv_role: kv_both` with APC disabled: each cache-hit request drives an independent RETRIEVE (recv) and STORE (send) op that complete in *different* engine steps. On abort, the first completion frees the request; the second completion for the same id hits the bare assert. `WAITING_FOR_REMOTE_KVS` abort is partly handled by `delay_free_blocks` in `finish_requests()`, but that does not protect against a *second* late completion on the other transfer direction.

Fix: guard both loops — a completion for a request no longer tracked is a stale/duplicate signal for an already-freed request, so it is skipped instead of asserting. A tracked request is still freed exactly as before.

Relates to #25562 (same method, `NixlConnector`).

## Test Plan

Added a regression test `tests/v1/core/test_scheduler.py::test_kv_xfer_finished_skips_untracked_request`, parametrized over both directions (`finished_sending`, `finished_recving`). It builds a real scheduler with an async mock KV connector, feeds a completion for a `req_id` the scheduler no longer tracks, and asserts `_update_from_kv_xfer_finished` does not raise.

```
pytest -q tests/v1/core/test_scheduler.py -k kv_xfer_finished_skips_untracked
```

## Test Result

- **Before the fix:** `2 failed` — both params raise `AssertionError`.
- **After the fix:** `2 passed`.

Verified against a real vLLM 0.24.0 runtime (whose `_update_from_kv_xfer_finished` is identical to the code changed here) using the real `create_scheduler` + mock KV connector: the stock package fails both params with `AssertionError`, and applying this patch makes both pass.

---

### AI assistance disclosure

Per the [AI-assisted contributions policy](https://docs.vllm.ai/en/latest/contributing/#ai-assisted-contributions): this change was drafted with AI assistance (root-cause analysis, patch, and test). A human reproduced the crash on a live deployment, reviewed every changed line, and validated the before/after test results end-to-end. Reflected in the commit trailer `Co-authored-by: Claude`.
