### PR TITLE
fix(security): validate bad_words token IDs against model vocab size

### DIFF
--- a/rust/src/text/src/lower/token_ids.rs
+++ b/rust/src/text/src/lower/token_ids.rs
@@ -99,7 +99,7 @@ pub(crate) fn validate_vocab_range(
         validate_param(
             "bad_words",
             bad_words_token_ids.iter().flatten().copied(),
-            limits.tokenizer_vocab_size,
+            limits.model_vocab_size,
         )?;
     }
 

--- a/tests/test_sampling_params.py
+++ b/tests/test_sampling_params.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import pytest
 
 from vllm import SamplingParams
+from vllm.exceptions import VLLMValidationError
 
 
 @dataclass
@@ -12,9 +13,25 @@ class MockModelConfig:
     is_diffusion: bool = False
     max_logprobs: int = 20
     logits_processors: list | None = None
+    _vocab_size: int = 1024
 
     def get_vocab_size(self) -> int:
-        return 1024
+        return self._vocab_size
+
+
+@dataclass
+class MockTokenizer:
+    """Minimal tokenizer mock for update_from_tokenizer tests."""
+
+    _max_token_id: int = 1023
+    _vocab: dict[str, list[int]] = field(default_factory=dict)
+
+    @property
+    def max_token_id(self) -> int:
+        return self._max_token_id
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        return self._vocab.get(text, [0])
 
 
 @pytest.mark.parametrize(
@@ -48,3 +65,57 @@ def test_diffusion_accepts_top_k_top_p():
 def test_non_diffusion_models_unaffected():
     params = SamplingParams(temperature=0.7, top_k=10, seed=42)
     params.verify(MockModelConfig(), None, None, None)
+
+
+class TestBadWordsVocabValidation:
+    """Regression tests for GHSA-4hhp-h66f-j5j7.
+
+    Multimodal tokenizers can have input-only tokens (e.g. <|audio|>) whose
+    IDs exceed the model's output vocabulary (logits width). Without
+    model-vocab-aware validation, such tokens cause out-of-bounds writes
+    in the BadWords Triton kernel.
+    """
+
+    def test_rejects_token_exceeding_model_vocab(self):
+        tokenizer = MockTokenizer(
+            _max_token_id=128256,
+            _vocab={"<|audio|>": [128256]},
+        )
+        model_config = MockModelConfig(_vocab_size=128256)
+
+        params = SamplingParams(bad_words=["<|audio|>"])
+        with pytest.raises(VLLMValidationError, match="specified as bad"):
+            params.update_from_tokenizer(tokenizer, model_config)
+
+    def test_accepts_token_at_model_vocab_boundary(self):
+        tokenizer = MockTokenizer(
+            _max_token_id=128256,
+            _vocab={"<|reserved|>": [128255]},
+        )
+        model_config = MockModelConfig(_vocab_size=128256)
+
+        params = SamplingParams(bad_words=["<|reserved|>"])
+        params.update_from_tokenizer(tokenizer, model_config)
+        assert params.bad_words_token_ids is not None
+        assert [128255] in params.bad_words_token_ids
+
+    def test_fallback_to_tokenizer_vocab_without_model_config(self):
+        tokenizer = MockTokenizer(
+            _max_token_id=128256,
+            _vocab={"<|audio|>": [128256]},
+        )
+
+        params = SamplingParams(bad_words=["<|audio|>"])
+        params.update_from_tokenizer(tokenizer)
+        assert params.bad_words_token_ids is not None
+
+    def test_rejects_negative_token_ids(self):
+        tokenizer = MockTokenizer(
+            _max_token_id=1023,
+            _vocab={"bad": [-1]},
+        )
+        model_config = MockModelConfig(_vocab_size=1024)
+
+        params = SamplingParams(bad_words=["bad"])
+        with pytest.raises(VLLMValidationError, match="specified as bad"):
+            params.update_from_tokenizer(tokenizer, model_config)

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -656,7 +656,11 @@ class SamplingParams(
                     eos_ids.update(self.stop_token_ids)
                     self.stop_token_ids = list(eos_ids)
 
-    def update_from_tokenizer(self, tokenizer: TokenizerLike) -> None:
+    def update_from_tokenizer(
+        self,
+        tokenizer: TokenizerLike,
+        model_config: ModelConfig | None = None,
+    ) -> None:
         if not self.bad_words:
             return
         self._bad_words_token_ids = []
@@ -680,19 +684,30 @@ class SamplingParams(
                 ):
                     self._bad_words_token_ids.append(prompt_token_ids)
 
+        # Validate against the model's output vocabulary (logits width) when
+        # available; fall back to the tokenizer vocabulary otherwise.
+        # Multimodal tokenizers can contain input-only placeholder tokens
+        # (e.g. <|audio|>) whose IDs fall outside the generation logits.
+        if model_config is not None:
+            vocab_size = model_config.get_vocab_size()
+            max_valid_id = vocab_size - 1
+        else:
+            vocab_size = tokenizer.max_token_id + 1
+            max_valid_id = tokenizer.max_token_id
+
         invalid_token_ids = [
             token_id
             for bad_words_token_ids in self._bad_words_token_ids
             for token_id in bad_words_token_ids
-            if token_id < 0 or token_id > tokenizer.max_token_id
+            if token_id < 0 or token_id > max_valid_id
         ]
         if len(invalid_token_ids) > 0:
             raise VLLMValidationError(
-                f"The model vocabulary size is {tokenizer.max_token_id + 1},"
+                f"The model vocabulary size is {vocab_size},"
                 f" but the following tokens"
                 f" were specified as bad: {invalid_token_ids}."
                 f" All token id values should be integers satisfying:"
-                f" 0 <= token_id <= {tokenizer.max_token_id}.",
+                f" 0 <= token_id <= {max_valid_id}.",
                 parameter="bad_words",
                 value=self.bad_words,
             )

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -325,7 +325,7 @@ class InputProcessor:
                 self.renderer.get_eos_token_id(),
             )
             if self.tokenizer is not None:
-                sampling_params.update_from_tokenizer(self.tokenizer)
+                sampling_params.update_from_tokenizer(self.tokenizer, self.model_config)
         else:
             pooling_params = params.clone()
 

--- a/vllm/v1/worker/gpu/sample/bad_words.py
+++ b/vllm/v1/worker/gpu/sample/bad_words.py
@@ -101,6 +101,7 @@ class BadWordsState:
 def _bad_words_kernel(
     logits_ptr,
     logits_stride,
+    output_width,
     expanded_idx_mapping_ptr,
     bad_word_token_ids_ptr,
     bad_word_token_ids_stride,
@@ -158,7 +159,7 @@ def _bad_words_kernel(
 
         match = match & (expected == actual)
 
-    if match:
+    if match and last_token >= 0 and last_token < output_width:
         tl.store(logits_ptr + token_idx * logits_stride + last_token, -float("inf"))
 
 
@@ -176,9 +177,11 @@ def apply_bad_words(
     max_num_bad_words: int,
 ) -> None:
     num_tokens = logits.shape[0]
+    output_width = logits.shape[1]
     _bad_words_kernel[(num_tokens, max_num_bad_words)](
         logits,
         logits.stride(0),
+        output_width,
         expanded_idx_mapping,
         bad_word_token_ids,
         bad_word_token_ids.stride(0),


### PR DESCRIPTION
Validate bad_words token IDs against the model's output vocabulary (logits width) rather than only the tokenizer vocabulary. Multimodal tokenizers can contain input-only placeholder tokens whose IDs exceed the generation logits width, causing out-of-bounds writes in the BadWords Triton kernel.
- Add model_config parameter to update_from_tokenizer() for model-vocab-aware validation
- Add output_width bounds check in the BadWords Triton kernel as defense in depth
- Fix Rust frontend to validate bad_words against model_vocab_size
- Add regression tests for the vulnerability scenario