### PR TITLE
[V1][Core] Add public build_full_block_hash_chain helper for offline prefix-cache analysis

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -673,6 +673,112 @@ def test_hash_block_tokens(hash_fn):
     assert block_hash == expected
 
 
+@pytest.mark.parametrize(
+    "hash_algo,hash_fn", [("sha256", sha256), ("sha256_cbor", sha256_cbor)]
+)
+def test_build_full_block_hash_chain_matches_request_block_hasher(
+    monkeypatch, hash_algo, hash_fn
+):
+    with monkeypatch.context() as m:
+        m.delenv("PYTHONHASHSEED", raising=False)
+        m.delattr(kv_cache_utils, "NONE_HASH", raising=False)
+
+        block_size = 3
+        token_ids = list(range(9))
+
+        # Seed NONE_HASH via the function under test first, so the
+        # production request path below reads the same seed.
+        chain = kv_cache_utils.build_full_block_hash_chain(
+            token_ids, block_size, hash_algo
+        )
+
+        request = make_request(
+            request_id="0",
+            prompt_token_ids=token_ids,
+            block_size=block_size,
+            hash_fn=hash_fn,
+        )
+        assert chain == request.block_hashes
+
+
+def test_build_full_block_hash_chain_drops_partial_trailing_block(monkeypatch):
+    with monkeypatch.context() as m:
+        m.delenv("PYTHONHASHSEED", raising=False)
+        m.delattr(kv_cache_utils, "NONE_HASH", raising=False)
+
+        # 2 full blocks of 3, plus one leftover token that must not appear.
+        chain = kv_cache_utils.build_full_block_hash_chain(
+            list(range(7)), block_size=3, hash_algo="sha256"
+        )
+        assert len(chain) == 2
+
+
+def test_build_full_block_hash_chain_same_inputs_twice_are_identical(monkeypatch):
+    """Regression test for the bug this helper exists to prevent: calling
+    ``init_none_hash`` unguarded on every invocation would re-randomize
+    NONE_HASH per call (absent PYTHONHASHSEED), silently diverging the same
+    request's chain across two calls in the same process. The guard must
+    make repeated calls, e.g. across a batch of requests, deterministic.
+    """
+    with monkeypatch.context() as m:
+        m.delenv("PYTHONHASHSEED", raising=False)
+        m.delattr(kv_cache_utils, "NONE_HASH", raising=False)
+
+        token_ids = list(range(9))
+        first = kv_cache_utils.build_full_block_hash_chain(
+            token_ids, block_size=3, hash_algo="sha256"
+        )
+        second = kv_cache_utils.build_full_block_hash_chain(
+            token_ids, block_size=3, hash_algo="sha256"
+        )
+        assert first == second
+
+
+def test_build_full_block_hash_chain_adopts_existing_none_hash(monkeypatch):
+    with monkeypatch.context() as m:
+        m.setenv("PYTHONHASHSEED", "existing-seed")
+        m.delattr(kv_cache_utils, "NONE_HASH", raising=False)
+
+        # Simulate a caller already sharing this process -- e.g. a running
+        # engine -- that seeded NONE_HASH with a different hash function
+        # than the one this call will request.
+        kv_cache_utils.init_none_hash(sha256_cbor)
+        seeded_value = kv_cache_utils.NONE_HASH
+
+        kv_cache_utils.build_full_block_hash_chain(
+            [1, 2, 3], block_size=3, hash_algo="sha256"
+        )
+
+        # The existing seed must be adopted, not clobbered.
+        assert seeded_value == kv_cache_utils.NONE_HASH
+
+
+def test_build_full_block_hash_chain_extra_keys(monkeypatch):
+    with monkeypatch.context() as m:
+        m.delenv("PYTHONHASHSEED", raising=False)
+        m.delattr(kv_cache_utils, "NONE_HASH", raising=False)
+
+        hash_fn = kv_cache_utils.get_hash_fn_by_name("sha256")
+        token_ids = [1, 2, 3]
+        extra_keys = ("lora-A",)
+
+        chain = kv_cache_utils.build_full_block_hash_chain(
+            token_ids, block_size=3, hash_algo="sha256", extra_keys=extra_keys
+        )
+        expected = kv_cache_utils.hash_block_tokens(
+            hash_fn, None, token_ids, extra_keys
+        )
+        assert chain == [expected]
+
+
+@pytest.mark.parametrize("block_size", [0, -1])
+def test_build_full_block_hash_chain_rejects_non_positive_block_size(block_size):
+    with pytest.raises(ValueError, match="block_size"):
+        kv_cache_utils.build_full_block_hash_chain(
+            [1, 2, 3], block_size=block_size, hash_algo="sha256"
+        )
+
+
 @pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor])
 def test_request_block_hasher(hash_fn):
     request = make_request(

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -768,6 +768,112 @@ def test_hash_block_tokens(hash_fn):
     assert block_hash == expected
 
 
+@pytest.mark.parametrize(
+    "hash_algo,hash_fn", [("sha256", sha256), ("sha256_cbor", sha256_cbor)]
+)
+def test_build_full_block_hash_chain_matches_request_block_hasher(
+    monkeypatch, hash_algo, hash_fn
+):
+    with monkeypatch.context() as m:
+        m.delenv("PYTHONHASHSEED", raising=False)
+        m.delattr(kv_cache_utils, "NONE_HASH", raising=False)
+
+        block_size = 3
+        token_ids = list(range(9))
+
+        # Seed NONE_HASH via the function under test first, so the
+        # production request path below reads the same seed.
+        chain = kv_cache_utils.build_full_block_hash_chain(
+            token_ids, block_size, hash_algo
+        )
+
+        request = make_request(
+            request_id="0",
+            prompt_token_ids=token_ids,
+            block_size=block_size,
+            hash_fn=hash_fn,
+        )
+        assert chain == request.block_hashes
+
+
+def test_build_full_block_hash_chain_drops_partial_trailing_block(monkeypatch):
+    with monkeypatch.context() as m:
+        m.delenv("PYTHONHASHSEED", raising=False)
+        m.delattr(kv_cache_utils, "NONE_HASH", raising=False)
+
+        # 2 full blocks of 3, plus one leftover token that must not appear.
+        chain = kv_cache_utils.build_full_block_hash_chain(
+            list(range(7)), block_size=3, hash_algo="sha256"
+        )
+        assert len(chain) == 2
+
+
+def test_build_full_block_hash_chain_same_inputs_twice_are_identical(monkeypatch):
+    """Regression test for the bug this helper exists to prevent: calling
+    ``init_none_hash`` unguarded on every invocation would re-randomize
+    NONE_HASH per call (absent PYTHONHASHSEED), silently diverging the same
+    request's chain across two calls in the same process. The guard must
+    make repeated calls, e.g. across a batch of requests, deterministic.
+    """
+    with monkeypatch.context() as m:
+        m.delenv("PYTHONHASHSEED", raising=False)
+        m.delattr(kv_cache_utils, "NONE_HASH", raising=False)
+
+        token_ids = list(range(9))
+        first = kv_cache_utils.build_full_block_hash_chain(
+            token_ids, block_size=3, hash_algo="sha256"
+        )
+        second = kv_cache_utils.build_full_block_hash_chain(
+            token_ids, block_size=3, hash_algo="sha256"
+        )
+        assert first == second
+
+
+def test_build_full_block_hash_chain_adopts_existing_none_hash(monkeypatch):
+    with monkeypatch.context() as m:
+        m.setenv("PYTHONHASHSEED", "existing-seed")
+        m.delattr(kv_cache_utils, "NONE_HASH", raising=False)
+
+        # Simulate a caller already sharing this process -- e.g. a running
+        # engine -- that seeded NONE_HASH with a different hash function
+        # than the one this call will request.
+        kv_cache_utils.init_none_hash(sha256_cbor)
+        seeded_value = kv_cache_utils.NONE_HASH
+
+        kv_cache_utils.build_full_block_hash_chain(
+            [1, 2, 3], block_size=3, hash_algo="sha256"
+        )
+
+        # The existing seed must be adopted, not clobbered.
+        assert seeded_value == kv_cache_utils.NONE_HASH
+
+
+def test_build_full_block_hash_chain_extra_keys(monkeypatch):
+    with monkeypatch.context() as m:
+        m.delenv("PYTHONHASHSEED", raising=False)
+        m.delattr(kv_cache_utils, "NONE_HASH", raising=False)
+
+        hash_fn = kv_cache_utils.get_hash_fn_by_name("sha256")
+        token_ids = [1, 2, 3]
+        extra_keys = ("lora-A",)
+
+        chain = kv_cache_utils.build_full_block_hash_chain(
+            token_ids, block_size=3, hash_algo="sha256", extra_keys=extra_keys
+        )
+        expected = kv_cache_utils.hash_block_tokens(
+            hash_fn, None, token_ids, extra_keys
+        )
+        assert chain == [expected]
+
+
+@pytest.mark.parametrize("block_size", [0, -1])
+def test_build_full_block_hash_chain_rejects_non_positive_block_size(block_size):
+    with pytest.raises(ValueError, match="block_size"):
+        kv_cache_utils.build_full_block_hash_chain(
+            [1, 2, 3], block_size=block_size, hash_algo="sha256"
+        )
+
+
 @pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor])
 def test_request_block_hasher(hash_fn):
     request = make_request(

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -814,6 +814,13 @@ def test_build_full_block_hash_chain_same_inputs_twice_are_identical(monkeypatch
     NONE_HASH per call (absent PYTHONHASHSEED), silently diverging the same
     request's chain across two calls in the same process. The guard must
     make repeated calls, e.g. across a batch of requests, deterministic.
+
+    Uses ``xxhash`` rather than ``sha256``: since NONE_HASH is now
+    deterministic by default for cryptographic hash functions (see
+    ``resolve_none_hash_seed``), ``sha256`` would pass here even without the
+    guard, and this test would stop proving anything. ``xxhash`` keeps the
+    per-process random seed absent ``PYTHONHASHSEED``, so this only passes if
+    the guard is actually preventing a reseed between the two calls.
     """
     with monkeypatch.context() as m:
         m.delenv("PYTHONHASHSEED", raising=False)
@@ -821,10 +828,10 @@ def test_build_full_block_hash_chain_same_inputs_twice_are_identical(monkeypatch
 
         token_ids = list(range(9))
         first = kv_cache_utils.build_full_block_hash_chain(
-            token_ids, block_size=3, hash_algo="sha256"
+            token_ids, block_size=3, hash_algo="xxhash"
         )
         second = kv_cache_utils.build_full_block_hash_chain(
-            token_ids, block_size=3, hash_algo="sha256"
+            token_ids, block_size=3, hash_algo="xxhash"
         )
         assert first == second
 

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -6,6 +6,7 @@ import copy
 import hashlib
 import math
 import os
+import threading
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass, replace
@@ -15,7 +16,7 @@ from typing import Any, NamedTuple, NewType, TypeAlias, cast, overload
 from vllm import envs
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
-from vllm.utils.hashing import sha256_cbor, xxhash_cbor
+from vllm.utils.hashing import get_hash_fn_by_name, sha256_cbor, xxhash_cbor
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.mem_utils import format_gib
 from vllm.utils.torch_utils import get_dtype_size
@@ -112,6 +113,25 @@ def init_none_hash(hash_fn: Callable[[Any], bytes]):
         NONE_HASH = BlockHash(os.urandom(32))
     else:
         NONE_HASH = BlockHash(hash_fn(hash_seed))
+
+
+_none_hash_lock = threading.Lock()
+
+
+def _ensure_none_hash(hash_fn: Callable[[Any], bytes]) -> None:
+    """Initialize NONE_HASH if it isn't set yet; never overwrite an existing
+    value.
+
+    NONE_HASH is process-global and first-writer-wins. If another caller in
+    this process -- e.g. a running engine -- already initialized it, possibly
+    with a different hash function, adopt that value instead of re-seeding.
+    Overwriting it would silently invalidate that caller's existing
+    block-hash chains rather than fail loudly, since every full block's hash
+    is chained back through NONE_HASH.
+    """
+    with _none_hash_lock:
+        if "NONE_HASH" not in globals():
+            init_none_hash(hash_fn)
 
 
 @dataclass(slots=True)
@@ -621,6 +641,83 @@ def hash_block_tokens(
     return BlockHash(
         hash_function((parent_block_hash, curr_block_token_ids_tuple, extra_keys))
     )
+
+
+def build_full_block_hash_chain(
+    token_ids: Sequence[int],
+    block_size: int,
+    hash_algo: str,
+    extra_keys: tuple[Any, ...] | None = None,
+) -> list[BlockHash]:
+    """Compute the full-block hash chain for a token sequence, matching
+    exactly what ``get_request_block_hasher`` computes for a live request.
+
+    Partial trailing blocks (fewer than ``block_size`` tokens) are dropped,
+    mirroring the engine's full-block-only hashing: a partial block is never
+    hashed or cached.
+
+    Intended for callers outside the scheduler/request hot path -- e.g.
+    offline analysis tooling -- that need the engine's exact block-hash
+    semantics without reimplementing them. See ``_ensure_none_hash`` for the
+    NONE_HASH seeding behavior this relies on.
+
+    Seeding and stability: NONE_HASH is process-wide and first-writer-wins.
+    Without ``PYTHONHASHSEED`` set, it is random per process, so two separate
+    processes diverge even given identical inputs and the same
+    ``hash_algo``. With ``PYTHONHASHSEED`` set, NONE_HASH is derived from the
+    seed *and* whichever hash function first initialized it in this process
+    -- so for reproducible cross-process analysis (e.g. diffing JSON reports
+    across CI runs), set ``PYTHONHASHSEED`` and run in a fresh process with a
+    single, consistent ``hash_algo``. Hash *values* are never guaranteed
+    stable across vLLM versions or hash-algorithm changes. The one
+    unconditional contract is narrower: within a single process, the
+    returned chain matches what the engine's own request-hashing path
+    computes for the same tokens, block size, and hash algorithm.
+
+    Args:
+        token_ids: The full token sequence for one request.
+        block_size: The block size to hash against.
+        hash_algo: Name of a hash function registered in
+            ``vllm.utils.hashing.get_hash_fn_by_name`` (e.g. ``"sha256"``).
+        extra_keys: Optional extra keys applied uniformly to every block in
+            the chain. This matches production semantics for per-request
+            keys that don't vary by position, like LoRA adapter names. It
+            does NOT match production for the position-dependent keys
+            ``generate_block_hash_extra_keys`` varies per block -- cache-salt
+            (applied to the first block only) and multimodal keys (applied
+            only to blocks overlapping the media's token range). Passing
+            those as a single uniform tuple here produces a chain the engine
+            would never produce. No in-tree caller populates this yet; the
+            slot exists for per-request-uniform keys without a future
+            signature change. Position-dependent keys would need a
+            different parameter shape (e.g. a per-block callable).
+
+    Returns:
+        The ordered list of block hashes, one per full block, chained on
+        their parent exactly as ``hash_block_tokens`` chains them for a
+        live request.
+
+    Raises:
+        ValueError: If ``block_size`` is not positive.
+    """
+    if block_size <= 0:
+        raise ValueError(f"block_size must be positive, got {block_size}")
+
+    hash_fn = get_hash_fn_by_name(hash_algo)
+    _ensure_none_hash(hash_fn)
+
+    chain: list[BlockHash] = []
+    parent: BlockHash | None = None
+    num_full_blocks = len(token_ids) // block_size
+    for i in range(num_full_blocks):
+        start = i * block_size
+        end = start + block_size
+        block_hash = hash_block_tokens(
+            hash_fn, parent, token_ids[start:end], extra_keys
+        )
+        chain.append(block_hash)
+        parent = block_hash
+    return chain
 
 
 def resolve_kv_cache_block_sizes(

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -6,6 +6,7 @@ import copy
 import hashlib
 import math
 import os
+import threading
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass, replace
@@ -15,7 +16,7 @@ from typing import Any, NamedTuple, NewType, TypeAlias, cast, overload
 from vllm import envs
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
-from vllm.utils.hashing import xxhash, xxhash_cbor
+from vllm.utils.hashing import get_hash_fn_by_name, xxhash, xxhash_cbor
 from vllm.utils.math_utils import cdiv
 from vllm.utils.mem_utils import format_gib
 from vllm.utils.torch_utils import get_dtype_size
@@ -159,6 +160,25 @@ def init_none_hash(hash_fn: Callable[[Any], bytes]):
             hash_fn.__name__,
         )
     NONE_HASH = BlockHash(hash_fn(_NONE_HASH_SEED))
+
+
+_none_hash_lock = threading.Lock()
+
+
+def _ensure_none_hash(hash_fn: Callable[[Any], bytes]) -> None:
+    """Initialize NONE_HASH if it isn't set yet; never overwrite an existing
+    value.
+
+    NONE_HASH is process-global and first-writer-wins. If another caller in
+    this process -- e.g. a running engine -- already initialized it, possibly
+    with a different hash function, adopt that value instead of re-seeding.
+    Overwriting it would silently invalidate that caller's existing
+    block-hash chains rather than fail loudly, since every full block's hash
+    is chained back through NONE_HASH.
+    """
+    with _none_hash_lock:
+        if "NONE_HASH" not in globals():
+            init_none_hash(hash_fn)
 
 
 @dataclass(slots=True)
@@ -697,6 +717,83 @@ def dcp_world_size_for_kv_cache_spec(spec: KVCacheSpec, dcp_world_size: int) -> 
     if isinstance(inner, FullAttentionSpec):
         return dcp_world_size
     return 1
+
+
+def build_full_block_hash_chain(
+    token_ids: Sequence[int],
+    block_size: int,
+    hash_algo: str,
+    extra_keys: tuple[Any, ...] | None = None,
+) -> list[BlockHash]:
+    """Compute the full-block hash chain for a token sequence, matching
+    exactly what ``get_request_block_hasher`` computes for a live request.
+
+    Partial trailing blocks (fewer than ``block_size`` tokens) are dropped,
+    mirroring the engine's full-block-only hashing: a partial block is never
+    hashed or cached.
+
+    Intended for callers outside the scheduler/request hot path -- e.g.
+    offline analysis tooling -- that need the engine's exact block-hash
+    semantics without reimplementing them. See ``_ensure_none_hash`` for the
+    NONE_HASH seeding behavior this relies on.
+
+    Seeding and stability: NONE_HASH is process-wide and first-writer-wins.
+    Without ``PYTHONHASHSEED`` set, it is random per process, so two separate
+    processes diverge even given identical inputs and the same
+    ``hash_algo``. With ``PYTHONHASHSEED`` set, NONE_HASH is derived from the
+    seed *and* whichever hash function first initialized it in this process
+    -- so for reproducible cross-process analysis (e.g. diffing JSON reports
+    across CI runs), set ``PYTHONHASHSEED`` and run in a fresh process with a
+    single, consistent ``hash_algo``. Hash *values* are never guaranteed
+    stable across vLLM versions or hash-algorithm changes. The one
+    unconditional contract is narrower: within a single process, the
+    returned chain matches what the engine's own request-hashing path
+    computes for the same tokens, block size, and hash algorithm.
+
+    Args:
+        token_ids: The full token sequence for one request.
+        block_size: The block size to hash against.
+        hash_algo: Name of a hash function registered in
+            ``vllm.utils.hashing.get_hash_fn_by_name`` (e.g. ``"sha256"``).
+        extra_keys: Optional extra keys applied uniformly to every block in
+            the chain. This matches production semantics for per-request
+            keys that don't vary by position, like LoRA adapter names. It
+            does NOT match production for the position-dependent keys
+            ``generate_block_hash_extra_keys`` varies per block -- cache-salt
+            (applied to the first block only) and multimodal keys (applied
+            only to blocks overlapping the media's token range). Passing
+            those as a single uniform tuple here produces a chain the engine
+            would never produce. No in-tree caller populates this yet; the
+            slot exists for per-request-uniform keys without a future
+            signature change. Position-dependent keys would need a
+            different parameter shape (e.g. a per-block callable).
+
+    Returns:
+        The ordered list of block hashes, one per full block, chained on
+        their parent exactly as ``hash_block_tokens`` chains them for a
+        live request.
+
+    Raises:
+        ValueError: If ``block_size`` is not positive.
+    """
+    if block_size <= 0:
+        raise ValueError(f"block_size must be positive, got {block_size}")
+
+    hash_fn = get_hash_fn_by_name(hash_algo)
+    _ensure_none_hash(hash_fn)
+
+    chain: list[BlockHash] = []
+    parent: BlockHash | None = None
+    num_full_blocks = len(token_ids) // block_size
+    for i in range(num_full_blocks):
+        start = i * block_size
+        end = start + block_size
+        block_hash = hash_block_tokens(
+            hash_fn, parent, token_ids[start:end], extra_keys
+        )
+        chain.append(block_hash)
+        parent = block_hash
+    return chain
 
 
 def resolve_kv_cache_block_sizes(

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -737,16 +737,20 @@ def build_full_block_hash_chain(
     semantics without reimplementing them. See ``_ensure_none_hash`` for the
     NONE_HASH seeding behavior this relies on.
 
-    Seeding and stability: NONE_HASH is process-wide and first-writer-wins.
-    Without ``PYTHONHASHSEED`` set, it is random per process, so two separate
-    processes diverge even given identical inputs and the same
-    ``hash_algo``. With ``PYTHONHASHSEED`` set, NONE_HASH is derived from the
-    seed *and* whichever hash function first initialized it in this process
-    -- so for reproducible cross-process analysis (e.g. diffing JSON reports
-    across CI runs), set ``PYTHONHASHSEED`` and run in a fresh process with a
-    single, consistent ``hash_algo``. Hash *values* are never guaranteed
-    stable across vLLM versions or hash-algorithm changes. The one
-    unconditional contract is narrower: within a single process, the
+    Seeding and stability: NONE_HASH is process-wide and first-writer-wins
+    (see ``resolve_none_hash_seed``). Without ``PYTHONHASHSEED`` set,
+    cryptographic hash algorithms (``sha256``, ``sha256_cbor``) derive
+    NONE_HASH from a fixed default seed, so independent processes agree by
+    default; non-cryptographic algorithms (``xxhash``, ``xxhash_cbor``) keep
+    a random per-process seed, since a predictable seed would let an
+    attacker precompute colliding blocks offline. With ``PYTHONHASHSEED``
+    set, NONE_HASH is derived from the seed *and* whichever hash function
+    first initialized it in this process -- so for reproducible
+    cross-process analysis with a non-cryptographic algorithm (e.g. diffing
+    JSON reports across CI runs), set ``PYTHONHASHSEED`` and run in a fresh
+    process with a single, consistent ``hash_algo``. Hash *values* are never
+    guaranteed stable across vLLM versions or hash-algorithm changes. The
+    one unconditional contract is narrower: within a single process, the
     returned chain matches what the engine's own request-hashing path
     computes for the same tokens, block size, and hash algorithm.
 


### PR DESCRIPTION
## Motivation

#47993 proposes an offline, no-GPU prefix-cache analyzer CLI. During review of the first implementation (#48369), [@NickLucche asked](https://github.com/vllm-project/vllm/issues/47993#issuecomment-4966992436) why that analyzer needs to live in the vLLM codebase at all. The response in that thread was that the analyzer's value depends on computing the *exact* hash chain the V1 scheduler computes, and that an out-of-tree tool would either depend on private internals with no stability guarantee, or reimplement the hashing path and risk silent semantic drift as prefix-cache behavior evolves — and that a maintainable external tool would still need a small, stable helper for this, so it may as well live next to the primitive it wraps.

This PR is that helper: a public extraction of the block-splitting and parent-chaining logic already computed incrementally per generation step in `get_request_block_hasher`, exposed as a standalone function any caller (in-tree or eventually out-of-tree) can use without duplicating vLLM's block-hash semantics.

**Not a duplicate:** #48369 is the analyzer CLI itself; this PR is the narrower helper extraction that RFC discussion asked for, and per [harsh543's comment](https://github.com/vllm-project/vllm/issues/47993#issuecomment-4977462796) they hadn't started it. #48369 can rebase onto this once it lands.

## Design notes

**Why the helper owns `NONE_HASH` seeding, and why adopt-don't-clobber.** `NONE_HASH` is a process-global, first-writer-wins seed for the first block of any hash chain (`init_none_hash`). It has no built-in idempotency — every call unconditionally reassigns it, drawing fresh `os.urandom(32)` bytes when `PYTHONHASHSEED` is unset. A per-request caller (the natural shape for this helper) that called `init_none_hash` unconditionally on every invocation would re-randomize the seed between calls, silently producing different first-block hashes for byte-identical prompts analyzed in the same run — a "confidently wrong, no obvious failure" bug, which is exactly the failure mode this extraction exists to avoid.

The guard (`_ensure_none_hash`) instead adopts an already-initialized value rather than reseeding: `"NONE_HASH" not in globals()` is a real, correct sentinel — `NONE_HASH: BlockHash` is a bare annotation at module scope, so the name genuinely doesn't exist as an attribute until `init_none_hash` runs for the first time, by anyone. This matters beyond a single analysis run: if this helper is ever called in a process that's already hosting a live engine, re-seeding would silently invalidate every block hash that engine's cache already depends on (since every full block's hash chains back through `NONE_HASH`). Adopting instead of clobbering means the helper is safe to call alongside a running engine, not just in a fresh CLI process.

**Why the lock.** The guard is a check-then-act on module-global state (`"NONE_HASH" not in globals()` then `init_none_hash(...)`). A `threading.Lock` closes that race for any concurrent caller, so the "you cannot call this incorrectly" property holds under concurrency too, not just in the single-threaded case this first caller happens to be.

**`extra_keys` scope.** The parameter threads one uniform tuple into every block's hash, which matches production for per-request keys that don't vary by position (e.g. LoRA adapter names via `_gen_lora_extra_hash_keys`), but does **not** match production for the position-dependent keys `generate_block_hash_extra_keys` computes per block — cache-salt (first block only) and multimodal keys (only blocks overlapping the media's token range). Passing those as a single uniform tuple through this helper would produce a chain the engine would never produce. This is called out explicitly in the docstring rather than left to be discovered by a reviewer familiar with the cache-salt path. No in-tree caller populates this yet; the slot exists so a future per-request-uniform-key caller doesn't require a signature change, while position-dependent keys would need a different parameter shape (e.g. a per-block callable) as a separate extension.

## Contract

Stated in the docstring: `NONE_HASH` is process-wide and first-writer-wins. Without `PYTHONHASHSEED` set, it's random per process, so two processes diverge even given identical inputs. With `PYTHONHASHSEED` set, it's derived from the seed *and* whichever hash function first initialized it in-process — so reproducible cross-process analysis (e.g. diffing JSON reports across CI runs) requires setting `PYTHONHASHSEED` and running in a fresh process with a single, consistent `hash_algo`. Hash values are never guaranteed stable across vLLM versions or hash-algorithm changes. The one unconditional contract: within a single process, the returned chain matches what the engine's own request-hashing path computes for the same tokens, block size, and hash algorithm (when `extra_keys` is `None` or matches production's per-request-uniform keys — see above).

## Testing

The equivalence test (`test_build_full_block_hash_chain_matches_request_block_hasher`) asserts the helper's output against `request.block_hashes` from the existing `make_request`/`get_request_block_hasher` test helper — the actual production hashing path, not a hand-rolled parallel computation. Drift between this helper and the scheduler's real hashing fails CI in the same PR that introduces it.

Also added: a same-inputs-twice-are-identical regression test (the direct tripwire for the reseeding bug described above — verified it fails without the guard by temporarily stripping it), an adopt-don't-clobber test (seeds with one hash function, requests with another, asserts the seed is untouched), partial-trailing-block and `extra_keys` passthrough tests, and `block_size <= 0` rejection tests.

```
pytest tests/v1/core/test_kv_cache_utils.py -k build_full_block_hash_chain -v
# 8 passed

pre-commit run --all-files
# all hooks passed, including mypy-3.10
```

AI assistance was used in developing this PR (implementation, test design, and verification against the actual hashing internals); I reviewed every changed line and ran the tests and lint above myself before opening this.
