### PR TITLE
[Doc] Update CPU image references to Docker Hub

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -6,7 +6,13 @@ toc_depth: 2
 
 ## Pre-built images
 
---8<-- "docs/getting_started/installation/gpu.md:pre-built-images"
+=== "GPU"
+
+    --8<-- "docs/getting_started/installation/gpu.md:pre-built-images"
+
+=== "CPU"
+
+    --8<-- "docs/getting_started/installation/cpu.md:pre-built-images"
 
 ## Run as a non-root user
 

--- a/docs/deployment/k8s.md
+++ b/docs/deployment/k8s.md
@@ -68,8 +68,8 @@ Note that you will want to configure your vLLM image based on your processor arc
 ??? console "Config"
 
     ```bash
-    VLLM_IMAGE=public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:latest       # use this for x86_64
-    VLLM_IMAGE=public.ecr.aws/q9t5s3a7/vllm-arm64-cpu-release-repo:latest # use this for arm64
+    VLLM_IMAGE=vllm/vllm-openai-cpu:latest-x86_64 # use this for x86_64
+    VLLM_IMAGE=vllm/vllm-openai-cpu:latest-arm64  # use this for arm64
     cat <<EOF |kubectl apply -f -
     apiVersion: apps/v1
     kind: Deployment

--- a/docs/getting_started/installation/cpu.md
+++ b/docs/getting_started/installation/cpu.md
@@ -109,6 +109,8 @@ VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_VARIANT=cpu VLLM_TARGET_DEVICE=cpu
 
 ### Pre-built images
 
+--8<-- [start:pre-built-images]
+
 === "Intel/AMD x86"
 
     --8<-- "docs/getting_started/installation/cpu.x86.inc.md:pre-built-images"
@@ -124,6 +126,8 @@ VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_VARIANT=cpu VLLM_TARGET_DEVICE=cpu
 === "IBM Z (S390X)"
 
     --8<-- "docs/getting_started/installation/cpu.s390x.inc.md:pre-built-images"
+
+--8<-- [end:pre-built-images]
 
 ### Build image from source
 

--- a/docs/getting_started/installation/cpu.x86.inc.md
+++ b/docs/getting_started/installation/cpu.x86.inc.md
@@ -188,6 +188,15 @@ docker run \
     vllm/vllm-openai-cpu:latest-x86_64 <args...>
 ```
 
+You can also access the latest code with Docker images. These are not intended for production use and are meant for CI and testing only. They will expire after several days.
+
+The latest code can contain bugs and may not be stable. Please use it with caution.
+
+```bash
+export VLLM_COMMIT=<full commit hash from the main branch>
+docker pull public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:${VLLM_COMMIT}-cpu
+```
+
 --8<-- [end:pre-built-images]
 --8<-- [start:build-image-from-source]
 


### PR DESCRIPTION
## Purpose

Follows up on #32032 and #32286 to complete the CPU image documentation migration to Docker Hub.

Related: #33708, #14756

## Changes

- **`docs/deployment/k8s.md`**: Replace ECR CPU image references with `vllm/vllm-openai-cpu:latest-x86_64` and `latest-arm64` on Docker Hub
- **`docs/deployment/docker.md`**: Restructure Pre-built images section into GPU / CPU top-level tabs, so CPU users can discover `vllm/vllm-openai-cpu` from the main Docker deployment page
- **`docs/getting_started/installation/cpu.md`**: Add `pre-built-images` snippet anchor to enable the include from `docker.md`
- **`docs/getting_started/installation/cpu.x86.inc.md`**: Add CI/dev image block documenting `vllm-ci-postmerge-repo:${VLLM_COMMIT}-cpu` (parallel to the existing arm64 section)

## Why this is not a duplicate

#32286 updated the x86 and arm64 CPU installation pages to use Docker Hub but left `k8s.md` still pointing at ECR, and `docker.md` had no CPU image entry at all. This PR addresses both remaining gaps.

## Test plan

- Built docs locally with `mkdocs build` — no new warnings
- Verified `vllm-ci-postmerge-repo:${COMMIT}-cpu` tag exists via `docker manifest inspect`
- Previewed rendered output locally

## AI assistance

This PR was developed with Claude Code assistance. All changed lines reviewed by the submitter.