### PR TITLE
Fix: Restore data_parallel_size > 1 for use_sequence_parallel_moe

### DIFF
--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -652,6 +652,7 @@ class ParallelConfig:
             )
             and self.enable_expert_parallel
             and self.tensor_parallel_size > 1
+            and self.data_parallel_size > 1
         )
 
     @property


### PR DESCRIPTION
## Purpose

Fix memory regression for MoE models on pure TP configurations (DP=1).

**Root cause:** Commit 1ff942965 (PR #48036) removed `and self.data_parallel_size > 1` from `use_sequence_parallel_moe` in `vllm/config/parallel.py`, causing Sequence Parallel MoE to incorrectly enable for TP-only (DP=1) configurations.

SP MoE is designed to avoid token replication **across DP ranks** (see comment lines 633-639 in parallel.py). With DP=1 there's no replication to avoid, but SP buffers still allocate ~5.6 GiB overhead.

**Why the condition was removed:** PR #48036 removed the `data_parallel_size > 1` condition to fix an accuracy issue for DSv3.2 + MTP + Sequence Parallel. The assumption was that enabling SP MoE globally would help MTP correctness.

**Why that was incorrect:** The actual MTP fix was in the MTP code itself (`_restore_full_token_layout_if_needed` in `deepseek_mtp.py`), which properly restores full token layout via `tensor_model_parallel_all_gather` before the MTP block. SP MoE is designed to avoid token replication **across DP ranks** (see comment in parallel.py:633-639), not to fix MTP accuracy.

With DP=1 there's no DP replication to avoid, so SP MoE adds ~5.6 GiB overhead with no benefit for any model (Nemotron, Llama 4, Qwen3 MoE, DeepSeek V2/V3, etc.).

**This fix restores the original intent:** SP MoE only when DP > 1.

**Related issue:** #48656

---

## Test Plan

Run Nemotron 3 Ultra 550B NVFP4 (MoE) with TP=4, DP=1, EP enabled:
```bash
docker run vllm/vllm-openai:nightly-6472131298e7b9ce81651cac90cc2dcc28963b55 \
  --model nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4 \
  --tensor-parallel-size 4 \
  --gpu-memory-utilization 0.985 \
```

Observe "Model loading took X GiB memory" log.

---

## Test Result

| Config | Commit | Memory |
|--------|--------|--------|
| Nightly 14 Jul (GOOD) | 94c0ef300 | **79.71 GiB** |
| Nightly 15 Jul (BAD) | 647213129 | **85.33 GiB** (+5.6 GiB) |
| **This fix** | d8e626ed8 | **79.71 GiB** ✓ |

**Bisect:** `94c0ef300..647213129` (30 commits) → first bad `1ff942965`

**Models affected:** All MoE on pure TP (Nemotron, Llama 4, Qwen3 MoE, DeepSeek V2/V3, Granite MoE, etc.)

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

---

**Signed-off-by:** passtoor-agi <305788622+passtoor-agi@users.noreply.github.com>