### PR TITLE
[Bugfix] Prevent prompt text leaking into streamed output when prompt ends mid-UTF-8

### DIFF
--- a/tests/tokenizers_/test_detokenize.py
+++ b/tests/tokenizers_/test_detokenize.py
@@ -29,6 +29,14 @@ TRUTH = [
     # incomplete UTF-8 characters
     # see https://github.com/vllm-project/vllm/pull/9625
     "ပုံပြင်လေးပြောပြပါ်",
+    # Thai text: tokens frequently begin with combining marks (tone marks,
+    # above/below vowels), so token boundaries split grapheme clusters and
+    # byte-level BPE vocabs fall back to partial-UTF-8 fragments throughout
+    "น้ำประปาที่สะอาดช่วยให้ครูใหญ่มีสุขภาพดี",
+    # Thai with NFD-style decompositions at the tail: decomposed sara am
+    # (U+0E4D + U+0E32, visually identical to precomposed U+0E33) and
+    # yamakkan (U+0E4E) tokenize into incomplete UTF-8 byte fragments
+    "ครูให้คำปรึกษาเรื่องน้ํากับส๎กฤต",
 ] + SPECIAL_TOKS_TRUTH
 
 TOKENIZERS = [
@@ -127,6 +135,88 @@ def test_mistral_edge_case(tokenizer, truth):
     assert out_ids == all_input_ids[starting_index:]
 
 
+@pytest.mark.parametrize(
+    "tokenizer_name",
+    ["openai-community/gpt2", "meta-llama/Llama-3.2-1B-Instruct"],
+)
+@pytest.mark.parametrize(
+    "truth",
+    [
+        # Precomposed sara am (U+0E33): the following token starts with a
+        # tone mark, so the token boundary splits the grapheme cluster
+        "น้ำ",
+        # Visually identical decomposed form (U+0E4D + U+0E32): the nikhahit
+        # tokenizes into incomplete UTF-8 byte fragments, and a naive
+        # prefix-diff streamer emits U+FFFD and then must retract it
+        "น้ํา",
+        # Yamakkan (U+0E4E) also splits into incomplete UTF-8 fragments
+        "ส๎กฤต",
+    ],
+)
+def test_thai_edge_case(tokenizer, truth):
+    """Thai grapheme-cluster and byte-fallback edge cases.
+
+    Thai tokens frequently begin with combining marks, and NFD-style
+    decompositions (sara am, yamakkan) map to tokens holding incomplete
+    UTF-8 byte sequences. The incremental detokenizer must hold those
+    bytes back rather than emitting replacement characters or retracting
+    previously streamed text.
+    """
+    starting_index = 0
+    all_input_ids = tokenizer(truth, add_special_tokens=False).input_ids
+
+    decoded_text, out_ids = _run_incremental_decode(
+        tokenizer,
+        all_input_ids,
+        skip_special_tokens=True,
+        starting_index=starting_index,
+    )
+    assert decoded_text == truth
+    assert out_ids == all_input_ids[starting_index:]
+
+
+@pytest.mark.parametrize("tokenizer_name", ["openai-community/gpt2"])
+@pytest.mark.parametrize(
+    "truth",
+    [
+        # emoji split across byte-level BPE tokens
+        "Hello world 🌶 is spicy",
+        # Thai: every character is byte-fallback in this vocab
+        "สวัสดีครับ",
+    ],
+)
+def test_incomplete_utf8_prompt_no_leak(tokenizer, truth):
+    """Prompt token ids ending mid-UTF-8-character must not leak prompt
+    text into the streamed output.
+
+    ``DecodeStream(ids=...)`` cannot establish its prefix from such a
+    prompt, which made the fast path emit the entire prompt text with the
+    first delta; ``from_new_request`` now routes these requests to the
+    slow detokenizer.
+    """
+    all_input_ids = tokenizer(truth, add_special_tokens=False).input_ids
+    # Split so that the prompt tail decodes with a trailing incomplete
+    # UTF-8 sequence.
+    starting_index = next(
+        i
+        for i in range(len(all_input_ids) - 1, 0, -1)
+        if tokenizer.decode(all_input_ids[:i]).endswith("�")
+    )
+    prompt_text = tokenizer.decode(all_input_ids[:starting_index])
+
+    decoded_text, out_ids = _run_incremental_decode(
+        tokenizer,
+        all_input_ids,
+        skip_special_tokens=True,
+        starting_index=starting_index,
+    )
+
+    full_text = tokenizer.decode(all_input_ids)
+    assert decoded_text == full_text[len(prompt_text) :]
+    assert prompt_text[:-1] not in decoded_text
+    assert out_ids == all_input_ids[starting_index:]
+
+
 @pytest.fixture
 def skip_special_tokens(request, tokenizer_name) -> Generator[bool, Any, None]:
     if "mistral" in tokenizer_name:
@@ -208,6 +298,16 @@ def test_decode_streaming(
         generated = new_truth
         starting_index = 0
         all_input_ids = truth_tokens
+
+    if fast and tokenizer.decode(
+        all_input_ids[:starting_index][-8:],
+        skip_special_tokens=skip_special_tokens,
+    ).endswith("�"):
+        # A forced fast detokenizer cannot handle a prompt ending with an
+        # incomplete UTF-8 sequence (DecodeStream prefill limitation);
+        # IncrementalDetokenizer.from_new_request routes such requests to
+        # the slow path instead (see test_incomplete_utf8_prompt_no_leak).
+        pytest.skip("prompt ends mid-UTF-8 character; fast path not used")
 
     decoded_text, out_ids = _run_incremental_decode(
         tokenizer,

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -57,12 +57,45 @@ class IncrementalDetokenizer:
             # No tokenizer => skipping detokenization.
             return IncrementalDetokenizer()
 
-        if USE_FAST_DETOKENIZER and isinstance(tokenizer, TokenizersBackend):
+        if (
+            USE_FAST_DETOKENIZER
+            and isinstance(tokenizer, TokenizersBackend)
+            and not _prompt_ends_mid_utf8(tokenizer, request)
+        ):
             # Fast tokenizer => use tokenizers library DecodeStream.
             return FastIncrementalDetokenizer(tokenizer, request)
 
         # Fall back to slow python-based incremental detokenization.
         return SlowIncrementalDetokenizer(tokenizer, request)
+
+
+def _prompt_ends_mid_utf8(
+    tokenizer: TokenizerLike, request: EngineCoreRequest
+) -> bool:
+    """Whether the prompt token ids decode to text ending in an incomplete
+    UTF-8 sequence (trailing U+FFFD).
+
+    ``DecodeStream(ids=...)`` cannot establish its text prefix from such a
+    prompt (the lazy prefill in tokenizers' ``step_decode_stream`` requires
+    the decoded prefix to not end with the replacement character), so the
+    entire prompt text would leak into the first streamed delta. Requests
+    like this are routed to ``SlowIncrementalDetokenizer``, whose offset
+    bookkeeping handles incomplete tails. This can happen with token-array
+    prompts whose final tokens hold part of a multi-byte character (e.g.
+    byte-fallback/byte-level BPE tokens for emoji or Thai combining marks).
+    """
+    prompt_ids = request.prompt_token_ids
+    if not prompt_ids:
+        return False
+    assert request.sampling_params is not None
+    # Only the trailing bytes matter: one UTF-8 character spans at most 4
+    # bytes and tokens hold at least one byte each, so an 8-token window is
+    # sufficient even with a few trailing special tokens being skipped.
+    tail = tokenizer.decode(
+        prompt_ids[-8:],
+        skip_special_tokens=request.sampling_params.skip_special_tokens,
+    )
+    return tail.endswith("�")
 
 
 class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):


### PR DESCRIPTION
## Purpose

Fixes #48853

`FastIncrementalDetokenizer` seeds `DecodeStream(ids=request.prompt_token_ids)`. The stream's lazy prefill only establishes its text prefix when the decoded prompt does **not** end with U+FFFD, so a token-array prompt ending with an incomplete UTF-8 sequence (byte-fallback / byte-level BPE tokens holding part of a multi-byte character — Thai combining marks, emoji, CJK on English-centric vocabs) leaves the prefix empty and the first fully-decodable step returns the **entire prompt text** inside the streamed delta. Silent — no exception, so the #19449 guard never fires. See the issue for API-level and class-level repros.

## Fix

Route affected requests to `SlowIncrementalDetokenizer` in `IncrementalDetokenizer.from_new_request` (same pattern as the existing `USE_FAST_DETOKENIZER` version gate from #24159). Detection decodes only the last 8 prompt tokens with the request's `skip_special_tokens` flag and checks for a trailing U+FFFD — O(1) per request, zero change to the fast-path hot code.

Rationale for fallback-over-fast-path-repair:
- The slow path's offset bookkeeping already handles incomplete tails correctly (prompt text structurally unreachable; boundary character held back) — matching TGI/SGLang behavior, which seed a trailing prompt-token window and never emit deltas ending in U+FFFD.
- tokenizers considers the prefill behavior by-design (huggingface/tokenizers#1856 discussion), and the `fastokens` backend ports the same prefill semantics verbatim — a vLLM-side guard covers both backends.
- Trimming/re-stepping prompt tail tokens inside the fast path can still emit fragments of prompt-side text (the partial token's leading complete characters), so it is not leak-free.

## Test Plan

- New regression tests in `tests/tokenizers_/test_detokenize.py`:
  - `test_incomplete_utf8_prompt_no_leak` — factory-mode streams for emoji/Thai prompts split mid-character; asserts the streamed text equals the post-prompt tail and contains no prompt text.
  - `test_thai_edge_case` — Thai grapheme-cluster and byte-fallback round-trips (precomposed vs decomposed sara am U+0E33 vs U+0E4D+U+0E32, yamakkan U+0E4E), mirroring the existing Mistral/Burmese edge-case pattern from #9625.
  - Two Thai entries in the streaming `TRUTH` matrix (tokens frequently begin with combining marks; NFD-style decompositions produce incomplete UTF-8 fragments).
  - Forced-`fast=True` matrix combos whose prompt slice ends mid-character are skipped with a pointer to the factory fallback (a directly-constructed fast detokenizer still has the upstream prefill limitation by design).

## Test Result

- `pytest tests/tokenizers_/test_detokenize.py -k "gpt2 or bloom or opt"`: **260 passed, 0 failed** (the Thai TRUTH entries previously failed 3 bloom fast+with_prompt combos on unpatched code — they catch this exact bug).
- End-to-end audit against a real `vllm serve facebook/opt-125m` server over `/v1/completions` SSE (browser client, no test harness): leaking cases (emoji + Thai token-array prompts) become clean after the fix, and a complete-prompt control request streams **byte-identical** deltas before/after (no regression on the normal path).

---

AI assistance disclosure: developed with assistance from Claude Code (research, implementation, and verification); the failure was reproduced and the fix validated end-to-end on our hardware, and the contributor takes full responsibility for the change. Commit carries a Co-authored-by trailer per the contributing guidelines.