### PR TITLE
[Bugfix] Fix humming crash on ParallelLMHead (output_partition_sizes, has_bias)

### DIFF
--- a/tests/quantization/test_humming_lm_head.py
+++ b/tests/quantization/test_humming_lm_head.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression test for prepare_humming_layer on ParallelLMHead.
+
+ParallelLMHead subclasses VocabParallelEmbedding, not LinearBase, so it has
+none of LinearBase's sharding attributes. prepare_humming_layer previously
+read layer.output_partition_sizes and layer.has_bias unconditionally, so any
+checkpoint that quantizes lm_head through humming (e.g. a compressed-tensors
+"re:.*lm_head$" FP8 target group, as used by third-party REAP/NVFP4 dumps of
+large MoE models) crashed with AttributeError before a single token could be
+generated. This mirrors the existing input_size_per_partition guard for the
+same class of layer.
+"""
+
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from vllm.distributed import init_distributed_environment, initialize_model_parallel
+from vllm.model_executor.layers.quantization.utils.humming_utils import (
+    prepare_humming_layer,
+)
+from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
+
+
+@pytest.fixture
+def dist_init():
+    from tests.utils import ensure_current_vllm_config
+
+    temp_file = tempfile.mkstemp()[1]
+    with ensure_current_vllm_config():
+        init_distributed_environment(
+            world_size=1,
+            rank=0,
+            distributed_init_method=f"file://{temp_file}",
+            local_rank=0,
+            backend="gloo",
+        )
+        initialize_model_parallel(1, 1)
+        yield
+
+
+def test_prepare_humming_layer_on_parallel_lm_head_without_bias(dist_init):
+    layer = ParallelLMHead(
+        num_embeddings=64,
+        embedding_dim=8,
+        bias=False,
+        params_dtype=torch.float16,
+    )
+    assert not hasattr(layer, "output_partition_sizes")
+    assert not hasattr(layer, "has_bias")
+
+    captured = {}
+    weight_schema = MagicMock()
+    weight_schema.convert_humming.side_effect = (
+        lambda tensors, shape_n_stacks, shape_k_stacks, param_dtype: (
+            captured.update(
+                shape_n_stacks=shape_n_stacks, shape_k_stacks=shape_k_stacks
+            )
+            or (MagicMock(), tensors)
+        )
+    )
+
+    with (
+        patch("vllm.utils.humming.BaseWeightSchema") as mock_base_schema,
+        patch("vllm.utils.humming.HummingInputSchema"),
+        patch("vllm.utils.humming.HummingMethod") as mock_method,
+    ):
+        mock_base_schema.from_config.return_value = weight_schema
+        mock_method.prepare_layer_meta.side_effect = lambda **kwargs: captured.update(
+            shape_n=kwargs["shape_n"], has_bias=kwargs["has_bias"]
+        )
+        mock_method.transform_humming_layer.return_value = None
+
+        prepare_humming_layer(layer, quant_config={})
+
+    assert captured["shape_n_stacks"] == [layer.num_embeddings_per_partition]
+    assert captured["shape_n"] == layer.num_embeddings_per_partition
+    assert captured["has_bias"] is False
+
+
+def test_prepare_humming_layer_on_parallel_lm_head_with_bias(dist_init):
+    layer = ParallelLMHead(
+        num_embeddings=64,
+        embedding_dim=8,
+        bias=True,
+        params_dtype=torch.float16,
+    )
+    assert layer.bias is not None
+
+    captured = {}
+    weight_schema = MagicMock()
+    weight_schema.convert_humming.side_effect = (
+        lambda tensors, shape_n_stacks, shape_k_stacks, param_dtype: (
+            MagicMock(),
+            tensors,
+        )
+    )
+
+    with (
+        patch("vllm.utils.humming.BaseWeightSchema") as mock_base_schema,
+        patch("vllm.utils.humming.HummingInputSchema"),
+        patch("vllm.utils.humming.HummingMethod") as mock_method,
+    ):
+        mock_base_schema.from_config.return_value = weight_schema
+        mock_method.prepare_layer_meta.side_effect = lambda **kwargs: captured.update(
+            has_bias=kwargs["has_bias"]
+        )
+        mock_method.transform_humming_layer.return_value = None
+
+        prepare_humming_layer(layer, quant_config={})
+
+    assert captured["has_bias"] is True

--- a/vllm/model_executor/layers/quantization/utils/humming_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/humming_utils.py
@@ -453,15 +453,29 @@ def prepare_humming_layer(
         input_schema = HummingInputSchema()
 
     # ReplicatedLinear has no TP partitioning and so does not set
-    # input_size_per_partition; for it that is just input_size. Use hasattr
-    # rather than getattr's default arg, which is evaluated eagerly and would
-    # raise on layers lacking input_size (e.g. ParallelLMHead).
+    # input_size_per_partition; for it that is just input_size. ParallelLMHead
+    # (a VocabParallelEmbedding, not a LinearBase) has neither attribute --
+    # its create_weights call passes embedding_dim as the equivalent
+    # input-side size (the embedding dimension is never TP-sharded, only the
+    # vocab dimension is). Use hasattr rather than getattr's default arg,
+    # which is evaluated eagerly and would raise on layers lacking input_size.
     if hasattr(layer, "input_size_per_partition"):
         input_size_per_partition = layer.input_size_per_partition
-    else:
+    elif hasattr(layer, "input_size"):
         input_size_per_partition = layer.input_size
+    else:
+        input_size_per_partition = layer.embedding_dim
+
+    # ParallelLMHead (a VocabParallelEmbedding, not a LinearBase) likewise has
+    # no output_partition_sizes; its create_weights call passes
+    # [num_embeddings_per_partition] as the equivalent output-side shard size.
+    if hasattr(layer, "output_partition_sizes"):
+        output_partition_sizes = layer.output_partition_sizes
+    else:
+        output_partition_sizes = [layer.num_embeddings_per_partition]
+
     shape_k_stacks = [input_size_per_partition]
-    shape_n_stacks = layer.output_partition_sizes
+    shape_n_stacks = output_partition_sizes
 
     # Step 1: convert weight to humming standard format
     weight_schema, tensors = weight_schema.convert_humming(
@@ -482,16 +496,21 @@ def prepare_humming_layer(
         param = torch.nn.Parameter(tensor, requires_grad=False)
         setattr(layer, name, param)
 
+    # ParallelLMHead also has no has_bias (LinearBase sets self.has_bias =
+    # bias in __init__); it registers an actual "bias" parameter (or None)
+    # instead, so presence of that parameter is the equivalent signal.
+    has_bias = layer.has_bias if hasattr(layer, "has_bias") else layer.bias is not None
+
     # Step 2: transform weight (humming standard format) for forwarding
     HummingMethod.prepare_layer_meta(
         layer=layer,
-        shape_n=sum(layer.output_partition_sizes),
+        shape_n=sum(output_partition_sizes),
         shape_k=input_size_per_partition,
         weight_schema=weight_schema,
         input_schema=input_schema,
         pad_n_to_multiple=256,
         pad_k_to_multiple=128,
-        has_bias=layer.has_bias,
+        has_bias=has_bias,
         torch_dtype=layer.params_dtype,
     )
 


### PR DESCRIPTION
## Purpose

`prepare_humming_layer` (`vllm/model_executor/layers/quantization/utils/humming_utils.py`) reads several `LinearBase`-only attributes without a guard. `ParallelLMHead` subclasses `VocabParallelEmbedding`, not `LinearBase`, so any checkpoint that routes `lm_head` through humming (e.g. a compressed-tensors `"re:.*lm_head$"` FP8 target group, as used by third-party REAP/NVFP4 dumps of large MoE models) crashes before serving a single token:

```
AttributeError: 'ParallelLMHead' object has no attribute 'output_partition_sizes'
```

#46420 fixed the same class of bug for `input_size_per_partition`/`input_size`, with the comment "layers lacking input_size (e.g. ParallelLMHead)" — but `ParallelLMHead` actually has *neither* attribute. I confirmed live against vllm 0.25.0 that the existing fallback (`layer.input_size`) still raises `AttributeError` for `ParallelLMHead` once the `output_partition_sizes` crash is patched around it. `output_partition_sizes` and `has_bias` have the identical gap:

- `VocabParallelEmbedding.__init__` calls `self.quant_method.create_weights(self, self.embedding_dim, [self.num_embeddings_per_partition], self.embedding_dim, self.num_embeddings_padded, ...)` — i.e. the input-side size is `embedding_dim` and the output-side shard size is `[num_embeddings_per_partition]`.
- `ParallelLMHead` never sets `has_bias` (that's a `LinearBase` attribute); it registers an actual `bias` parameter, or `None`, instead.

This PR extends the existing `input_size_per_partition` guard with an `elif hasattr(layer, "input_size")` branch (falling back to `embedding_dim` only when neither is present), and adds the same `hasattr`-based fallback pattern for `output_partition_sizes` (`→ [layer.num_embeddings_per_partition]`) and `has_bias` (`→ layer.bias is not None`).

Not a duplicate: `gh search issues`/`gh pr list --search` for `output_partition_sizes`, `ParallelLMHead humming`, and `humming lm_head` against this repo returned nothing open or closed besides #46420 (the related-but-incomplete prior fix) and #48507 (a different bug in the same file — `is_layer_skipped` regex matching — not this one).

## Test Plan

Reproduced live on real hardware before writing the fix: `scottgl/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10` (compressed-tensors, `lm_head` FP8-quantized via `"re:.*lm_head$"`) crashing `vllm serve` with the exact traceback above, on an RTX PRO 6000 Blackwell host running vllm 0.25.0. Patched the installed package on that host with this exact fix (same 3 hasattr guards) and confirmed the model now boots and serves `/v1/chat/completions` successfully.

Added `tests/quantization/test_humming_lm_head.py`, a CPU-only (`gloo` backend, `world_size=1`) unit test that constructs a real `ParallelLMHead` (both with and without a bias term) and drives it through `prepare_humming_layer`, mocking only the CUDA/kernel-specific `humming` internals (`BaseWeightSchema`/`HummingInputSchema`/`HummingMethod`) that are irrelevant to the attribute-resolution bug being tested. Follows the existing `dist_init` fixture pattern from `tests/lora/test_layers.py`.

```
$ ruff check vllm/model_executor/layers/quantization/utils/humming_utils.py tests/quantization/test_humming_lm_head.py
All checks passed!
$ ruff format --diff vllm/model_executor/layers/quantization/utils/humming_utils.py tests/quantization/test_humming_lm_head.py
2 files already formatted
```

## Test Result

```
$ python -m pytest tests/quantization/test_humming_lm_head.py -v
test_prepare_humming_layer_on_parallel_lm_head_without_bias PASSED
test_prepare_humming_layer_on_parallel_lm_head_with_bias PASSED
```

(Ran against an installed vllm 0.25.0 with this patch applied, since the real repro hardware doesn't have a source dev environment set up; the test itself is version-independent and targets current `main`'s `prepare_humming_layer`.)

Live repro before the fix (installed vllm 0.25.0, patch not yet applied):

```
AttributeError: 'ParallelLMHead' object has no attribute 'output_partition_sizes'
```

After applying this fix to the same installed package: `scottgl/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10` boots and serves requests successfully on GPU.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
