### PR TITLE
reasoning: treat no-think-block output as content, not reasoning

### DIFF
--- a/tests/reasoning/test_base_thinking_reasoning_parser.py
+++ b/tests/reasoning/test_base_thinking_reasoning_parser.py
@@ -236,25 +236,36 @@ class TestBaseThinkingReasoningParserExtraction:
         assert content == "This is content"
 
     def test_extract_reasoning_no_end_token(self, test_tokenizer):
-        """Test extraction when no end token is present."""
+        """No think block at all: output is content, not reasoning."""
         parser = TestThinkingReasoningParser(test_tokenizer)
         request = ChatCompletionRequest(messages=[], model="test-model")
 
         model_output = "This is just content"
         reasoning, content = parser.extract_reasoning(model_output, request)
 
-        assert reasoning == "This is just content"
+        assert reasoning is None
+        assert content == "This is just content"
+
+    def test_extract_reasoning_start_no_end(self, test_tokenizer):
+        """Start token present but end token absent: incomplete think block."""
+        parser = TestThinkingReasoningParser(test_tokenizer)
+        request = ChatCompletionRequest(messages=[], model="test-model")
+
+        model_output = "<test:think>Truncated thinking without end"
+        reasoning, content = parser.extract_reasoning(model_output, request)
+
+        assert reasoning == "Truncated thinking without end"
         assert content is None
 
     def test_extract_reasoning_empty_output(self, test_tokenizer):
-        """Test extraction with empty output."""
+        """Empty output with no think block returns (None, None)."""
         parser = TestThinkingReasoningParser(test_tokenizer)
         request = ChatCompletionRequest(messages=[], model="test-model")
 
         model_output = ""
         reasoning, content = parser.extract_reasoning(model_output, request)
 
-        assert reasoning == ""
+        assert reasoning is None
         assert content is None
 
     def test_extract_reasoning_only_tokens(self, test_tokenizer):
@@ -433,6 +444,22 @@ class TestBaseThinkingReasoningParserEdgeCases:
         model_output = "<test:thinking>Not a real token</test:thinking>Content"
         reasoning, content = run_reasoning_extraction(parser, [model_output])
 
-        # Should treat as regular content since tokens don't match exactly
-        assert reasoning == ("<test:thinking>Not a real token</test:thinking>Content")
-        assert content is None
+        # Neither start nor end token matched: treat entire output as content
+        assert reasoning is None
+        assert content == "<test:thinking>Not a real token</test:thinking>Content"
+
+    def test_no_think_block_json_output(self, test_tokenizer):
+        """Regression: JSON output with no think block must not become null content.
+
+        When include_reasoning=False is combined with a structured output
+        grammar, vllm prevents <think> generation entirely. The parser must
+        treat the raw JSON as content, not as reasoning.
+        """
+        parser = TestThinkingReasoningParser(test_tokenizer)
+        request = ChatCompletionRequest(messages=[], model="test-model")
+
+        model_output = '{"answer": 42}'
+        reasoning, content = parser.extract_reasoning(model_output, request)
+
+        assert reasoning is None
+        assert content == '{"answer": 42}'

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -166,13 +166,20 @@ class BaseThinkingReasoningParser(ReasoningParser):
         # Check if the start token is present in the model output, remove it
         # if it is present.
         model_output_parts = model_output.partition(self.start_token)
+        start_found = bool(model_output_parts[1])
         model_output = (
-            model_output_parts[2] if model_output_parts[1] else model_output_parts[0]
+            model_output_parts[2] if start_found else model_output_parts[0]
         )
 
-        # For models that may not generate start token,
-        # assume the reasoning content is always at the start.
         if self.end_token not in model_output:
+            if not start_found:
+                # No think block was generated at all (e.g. reasoning was
+                # skipped because include_reasoning=False with structured
+                # output causes grammar to prevent <think> generation).
+                # Treat the entire output as content.
+                return None, model_output or None
+            # Start token was found but end token was not: incomplete think
+            # block (e.g. truncated at max_tokens). Treat as reasoning only.
             return model_output, None
         else:
             reasoning, _, content = model_output.partition(self.end_token)


### PR DESCRIPTION
Fixes #48863

## Problem

When `include_reasoning=False` is combined with a `json_schema` response format, `content` is `null` in the response. Introduced in v0.23.1 (#44301).

`serving.py` sets `reasoning_ended = True` when `include_reasoning=False`, which causes the structured-output grammar to enforce valid JSON from token 1 — so the model never generates a `<think>` block. That part is correct.

The bug is in `basic_parsers.py::extract_reasoning`: when neither `start_token` nor `end_token` is found in the output, the entire output is returned as **reasoning** and content as `None`:

```python
if self.end_token not in model_output:
    return model_output, None  # entire output → reasoning (wrong when no think block)
```

The caller then nulls the reasoning because `include_reasoning=False` → both fields are `None`.

## Fix

Distinguish between two no-end-token cases:

| Case | `start_token` found? | Correct classification |
|------|----------------------|------------------------|
| Grammar prevented think block entirely | No | **content** |
| Think block started but was truncated (max_tokens) | Yes | **reasoning** (existing behavior) |

```python
model_output_parts = model_output.partition(self.start_token)
start_found = bool(model_output_parts[1])
model_output = model_output_parts[2] if start_found else model_output_parts[0]

if self.end_token not in model_output:
    if not start_found:
        return None, model_output or None  # no think block → content
    return model_output, None             # incomplete think → reasoning
```

## Tests

- Updated `test_extract_reasoning_no_end_token`: no start or end token → `(None, content)`
- Added `test_extract_reasoning_start_no_end`: start token present, end absent → `(reasoning, None)` (truncated think)
- Updated `test_extract_reasoning_empty_output`: empty output with no think block → `(None, None)`
- Updated `test_malformed_tokens`: unrecognized tokens → treated as content
- Added `test_no_think_block_json_output`: regression test for the exact bug scenario