### PR TITLE
[Bugfix] Surface engine startup failure diagnostics where startup actually waits

### DIFF
--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -114,13 +114,19 @@ def test_mp_client_uses_env_timeout(monkeypatch: pytest.MonkeyPatch):
     poll_timeouts: list[int] = []
 
     class ShadowSocket:
-        def poll(self, timeout: int) -> int:
-            # Capture the timeout value for each poll call
-            poll_timeouts.append(timeout)
-            return 1
-
         def recv_multipart(self):
             return (b"\x00\x00", b"")
+
+    shadow_socket = ShadowSocket()
+
+    class FakePoller:
+        def register(self, *_args, **_kwargs):
+            pass
+
+        def poll(self, timeout: int):
+            # Capture the timeout value for each poll call
+            poll_timeouts.append(timeout)
+            return [(shadow_socket, core_client_mod.zmq.POLLIN)]
 
     class DummySocket:
         def send_multipart(self, _msg, *, copy: bool = False, track: bool = False):
@@ -142,7 +148,8 @@ def test_mp_client_uses_env_timeout(monkeypatch: pytest.MonkeyPatch):
         def setsockopt(self, *_args, **_kwargs):
             pass
 
-    monkeypatch.setattr(core_client_mod.zmq.Socket, "shadow", lambda *_: ShadowSocket())
+    monkeypatch.setattr(core_client_mod.zmq.Socket, "shadow", lambda *_: shadow_socket)
+    monkeypatch.setattr(core_client_mod.zmq, "Poller", FakePoller)
     monkeypatch.setattr(
         core_client_mod, "make_zmq_socket", lambda *_, **__: DummySocket()
     )
@@ -175,6 +182,65 @@ def test_mp_client_uses_env_timeout(monkeypatch: pytest.MonkeyPatch):
         assert poll_timeouts == [timeout_value * 1000]
     finally:
         client.shutdown()
+
+
+def _make_ready_wait_client(core_client_mod, engine_manager=None):
+    """Build a bare MPClient with just the state _wait_for_engine_ready uses."""
+    client = object.__new__(core_client_mod.MPClient)
+    client.core_engines = [b"\x00\x00"]
+    client.resources = SimpleNamespace(engine_manager=engine_manager)
+    return client
+
+
+def test_ready_wait_timeout_reports_elapsed_and_jit_hint(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    core_client_mod = _reload_core_client_module()
+
+    class TimeoutPoller:
+        def register(self, *_args, **_kwargs):
+            pass
+
+        def poll(self, timeout: int):
+            return []
+
+    monkeypatch.setattr(core_client_mod.zmq, "Poller", TimeoutPoller)
+    client = _make_ready_wait_client(core_client_mod)
+
+    with pytest.raises(TimeoutError, match="VLLM_ENGINE_READY_TIMEOUT_S") as exc_info:
+        client._wait_for_engine_ready(SimpleNamespace())
+    # The message must name JIT compilation as a possible cause (#48031)
+    # and report the actual elapsed wait.
+    assert "JIT" in str(exc_info.value)
+    assert "after" in str(exc_info.value)
+
+
+def test_ready_wait_fails_fast_when_engine_proc_dies(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An engine core proc dying during the ready wait must fail immediately
+    with the proc's name and exit code, not block until the ready timeout."""
+    core_client_mod = _reload_core_client_module()
+
+    dead_proc = SimpleNamespace(sentinel=42, name="EngineCore_DP0", exitcode=-9)
+    proc_manager = object.__new__(CoreEngineProcManager)
+    proc_manager.processes = [dead_proc]
+
+    class DeathPoller:
+        def register(self, *_args, **_kwargs):
+            pass
+
+        def poll(self, timeout: int):
+            # The proc sentinel (not the input socket) becomes ready.
+            return [(dead_proc.sentinel, core_client_mod.zmq.POLLIN)]
+
+    monkeypatch.setattr(core_client_mod.zmq, "Poller", DeathPoller)
+    client = _make_ready_wait_client(core_client_mod, engine_manager=proc_manager)
+
+    with pytest.raises(RuntimeError, match="exited before reporting ready") as exc_info:
+        client._wait_for_engine_ready(SimpleNamespace())
+    assert "EngineCore_DP0" in str(exc_info.value)
+    assert "-9" in str(exc_info.value)
 
 
 def _make_pooling_request(

--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -114,19 +114,15 @@ def test_mp_client_uses_env_timeout(monkeypatch: pytest.MonkeyPatch):
     poll_timeouts: list[int] = []
 
     class ShadowSocket:
+        def poll(self, timeout: int) -> int:
+            # Capture the timeout value for each poll call
+            poll_timeouts.append(timeout)
+            return 1
+
         def recv_multipart(self):
             return (b"\x00\x00", b"")
 
     shadow_socket = ShadowSocket()
-
-    class FakePoller:
-        def register(self, *_args, **_kwargs):
-            pass
-
-        def poll(self, timeout: int):
-            # Capture the timeout value for each poll call
-            poll_timeouts.append(timeout)
-            return [(shadow_socket, core_client_mod.zmq.POLLIN)]
 
     class DummySocket:
         def send_multipart(self, _msg, *, copy: bool = False, track: bool = False):
@@ -149,7 +145,6 @@ def test_mp_client_uses_env_timeout(monkeypatch: pytest.MonkeyPatch):
             pass
 
     monkeypatch.setattr(core_client_mod.zmq.Socket, "shadow", lambda *_: shadow_socket)
-    monkeypatch.setattr(core_client_mod.zmq, "Poller", FakePoller)
     monkeypatch.setattr(
         core_client_mod, "make_zmq_socket", lambda *_, **__: DummySocket()
     )
@@ -184,63 +179,23 @@ def test_mp_client_uses_env_timeout(monkeypatch: pytest.MonkeyPatch):
         client.shutdown()
 
 
-def _make_ready_wait_client(core_client_mod, engine_manager=None):
-    """Build a bare MPClient with just the state _wait_for_engine_ready uses."""
+def test_ready_wait_timeout_reports_elapsed_and_jit_hint():
+    """The ready-wait timeout (operative for externally-managed engines and
+    elastic-EP scale-up) must name JIT compilation as a possible cause
+    (#48031) and report the actual elapsed wait."""
+    core_client_mod = _reload_core_client_module()
+
     client = object.__new__(core_client_mod.MPClient)
     client.core_engines = [b"\x00\x00"]
-    client.resources = SimpleNamespace(engine_manager=engine_manager)
-    return client
 
-
-def test_ready_wait_timeout_reports_elapsed_and_jit_hint(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    core_client_mod = _reload_core_client_module()
-
-    class TimeoutPoller:
-        def register(self, *_args, **_kwargs):
-            pass
-
-        def poll(self, timeout: int):
-            return []
-
-    monkeypatch.setattr(core_client_mod.zmq, "Poller", TimeoutPoller)
-    client = _make_ready_wait_client(core_client_mod)
+    class NeverReadySocket:
+        def poll(self, timeout: int) -> int:
+            return 0
 
     with pytest.raises(TimeoutError, match="VLLM_ENGINE_READY_TIMEOUT_S") as exc_info:
-        client._wait_for_engine_ready(SimpleNamespace())
-    # The message must name JIT compilation as a possible cause (#48031)
-    # and report the actual elapsed wait.
+        client._wait_for_engine_ready(NeverReadySocket())
     assert "JIT" in str(exc_info.value)
     assert "after" in str(exc_info.value)
-
-
-def test_ready_wait_fails_fast_when_engine_proc_dies(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """An engine core proc dying during the ready wait must fail immediately
-    with the proc's name and exit code, not block until the ready timeout."""
-    core_client_mod = _reload_core_client_module()
-
-    dead_proc = SimpleNamespace(sentinel=42, name="EngineCore_DP0", exitcode=-9)
-    proc_manager = object.__new__(CoreEngineProcManager)
-    proc_manager.processes = [dead_proc]
-
-    class DeathPoller:
-        def register(self, *_args, **_kwargs):
-            pass
-
-        def poll(self, timeout: int):
-            # The proc sentinel (not the input socket) becomes ready.
-            return [(dead_proc.sentinel, core_client_mod.zmq.POLLIN)]
-
-    monkeypatch.setattr(core_client_mod.zmq, "Poller", DeathPoller)
-    client = _make_ready_wait_client(core_client_mod, engine_manager=proc_manager)
-
-    with pytest.raises(RuntimeError, match="exited before reporting ready") as exc_info:
-        client._wait_for_engine_ready(SimpleNamespace())
-    assert "EngineCore_DP0" in str(exc_info.value)
-    assert "-9" in str(exc_info.value)
 
 
 def _make_pooling_request(

--- a/tests/v1/engine/test_init_error_messaging.py
+++ b/tests/v1/engine/test_init_error_messaging.py
@@ -1,9 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import multiprocessing
+import os
+import sys
+from types import SimpleNamespace
+
 import pytest
 
 from vllm.v1.core.kv_cache_utils import check_enough_kv_cache_memory
+from vllm.v1.engine.utils import describe_failed_procs
 from vllm.v1.kv_cache_interface import FullAttentionSpec
 
 
@@ -52,3 +58,66 @@ def test_kv_cache_oom_insufficient_memory(monkeypatch):
 
     with pytest.raises(ValueError):
         check_enough_kv_cache_memory(config, spec, 1024**3)  # 1 GiB
+
+
+def _exit_with_code_3():
+    sys.exit(3)
+
+
+def test_describe_failed_procs_reports_name_and_exit_code():
+    """A proc that exited during startup must be reported with its name and
+    exit code, not the bare 'Failed core proc(s): {}' of #48031 / #45626."""
+    proc = multiprocessing.Process(target=_exit_with_code_3, name="EngineCore_0")
+    proc.start()
+    proc.join()
+
+    msg = describe_failed_procs(SimpleNamespace(processes=[proc]), None)
+    assert "EngineCore_0" in msg
+    assert "3" in msg
+
+
+def test_describe_failed_procs_names_proc_when_exit_code_races():
+    """A proc's sentinel can fire before its exit code is collectible; the
+    description must still name the proc instead of reporting an empty dict."""
+    read_fd, write_fd = os.pipe()
+    os.close(write_fd)  # EOF makes the read end (the fake sentinel) ready
+    try:
+        racing_proc = SimpleNamespace(
+            sentinel=read_fd,
+            name="EngineCore_0",
+            exitcode=None,
+            join=lambda timeout=None: None,
+        )
+        msg = describe_failed_procs(SimpleNamespace(processes=[racing_proc]), None)
+        assert "EngineCore_0" in msg
+        assert "unknown" in msg
+    finally:
+        os.close(read_fd)
+
+
+def test_describe_failed_procs_ignores_live_procs():
+    """A live proc (sentinel not ready, no exit code) must not be reported."""
+    live_read_fd, live_write_fd = os.pipe()  # writer open: sentinel not ready
+    coord_read_fd, coord_write_fd = os.pipe()
+    try:
+        live_proc = SimpleNamespace(
+            sentinel=live_read_fd,
+            name="EngineCore_0",
+            exitcode=None,
+            join=lambda timeout=None: None,
+        )
+        exited_coord = SimpleNamespace(
+            sentinel=coord_read_fd,  # readiness unused: exitcode already set
+            name="DPCoordinator",
+            exitcode=-9,
+            join=lambda timeout=None: None,
+        )
+        msg = describe_failed_procs(
+            SimpleNamespace(processes=[live_proc]), exited_coord
+        )
+        assert "DPCoordinator" in msg
+        assert "-9" in msg
+        assert "EngineCore_0" not in msg
+    finally:
+        for fd in (live_read_fd, live_write_fd, coord_read_fd, coord_write_fd):
+            os.close(fd)

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import queue
 import sys
+import time
 import uuid
 import weakref
 from abc import ABC, abstractmethod
@@ -649,24 +650,8 @@ class MPClient(EngineCoreClient):
             ]
 
             # Wait for ready messages from each engine on the input socket.
-            identities = set(self.core_engines)
             sync_input_socket = zmq.Socket.shadow(self.input_socket)
-            while identities:
-                if not sync_input_socket.poll(
-                    timeout=VLLM_ENGINE_READY_TIMEOUT_S * 1000  # convert to ms
-                ):
-                    raise TimeoutError(
-                        f"Timed out waiting for engine core processes to "
-                        f"start. This is often caused by slow weight loading "
-                        f"for large models. Waited "
-                        f"{VLLM_ENGINE_READY_TIMEOUT_S}s (configured by "
-                        f"VLLM_ENGINE_READY_TIMEOUT_S). To increase the "
-                        f"timeout, set the environment variable: "
-                        f"VLLM_ENGINE_READY_TIMEOUT_S=<seconds>"
-                    )
-                identity, payload = sync_input_socket.recv_multipart()
-                identities.remove(identity)
-                self._apply_ready_response(payload)
+            self._wait_for_engine_ready(sync_input_socket)
 
             self.core_engine: EngineIdentity = self.core_engines[0]
             self.utility_results: dict[int, AnyFuture] = {}
@@ -733,6 +718,61 @@ class MPClient(EngineCoreClient):
         Thread(
             target=monitor_engine_cores, daemon=True, name="MPClientEngineMonitor"
         ).start()
+
+    def _wait_for_engine_ready(self, sync_input_socket: zmq.Socket) -> None:
+        """Wait for a ready message from each engine on the input socket.
+
+        Locally-managed engine proc sentinels are polled alongside the socket
+        so that an engine that dies during startup (e.g. OOM-killed while
+        JIT-compiling kernels on first load) fails fast with the real cause,
+        instead of blocking for the full ready timeout and then being
+        misreported as slow weight loading. The engine core monitor only
+        starts after this wait completes, so the death would otherwise go
+        unnoticed here.
+        """
+        identities = set(self.core_engines)
+        ready_poller = zmq.Poller()
+        ready_poller.register(sync_input_socket, zmq.POLLIN)
+        local_proc_manager = (
+            self.resources.engine_manager
+            if isinstance(self.resources.engine_manager, CoreEngineProcManager)
+            else None
+        )
+        if local_proc_manager is not None:
+            for sentinel in local_proc_manager.sentinels():
+                ready_poller.register(sentinel, zmq.POLLIN)
+        wait_start = time.monotonic()
+        while identities:
+            events = ready_poller.poll(
+                timeout=VLLM_ENGINE_READY_TIMEOUT_S * 1000  # convert to ms
+            )
+            if not events:
+                raise TimeoutError(
+                    f"Timed out waiting for engine core processes to start, "
+                    f"after {time.monotonic() - wait_start:.0f}s (limit "
+                    f"{VLLM_ENGINE_READY_TIMEOUT_S}s, configured by "
+                    f"VLLM_ENGINE_READY_TIMEOUT_S). This is often caused by "
+                    f"slow weight loading for large models or cold JIT "
+                    f"kernel compilation (e.g. FlashInfer on new GPU "
+                    f"architectures). To increase the timeout, set the "
+                    f"environment variable: "
+                    f"VLLM_ENGINE_READY_TIMEOUT_S=<seconds>"
+                )
+            if any(sock is not sync_input_socket for sock, _ in events):
+                # A locally-managed engine core process exited before
+                # reporting ready.
+                finished = (
+                    local_proc_manager.finished_procs() if local_proc_manager else {}
+                )
+                raise RuntimeError(
+                    f"Engine core proc(s) exited before reporting ready "
+                    f"(after {time.monotonic() - wait_start:.0f}s), see root "
+                    f"cause above. Exited proc name -> exit code: "
+                    f"{finished or 'unknown (exit code not yet visible)'}"
+                )
+            identity, payload = sync_input_socket.recv_multipart()
+            identities.remove(identity)
+            self._apply_ready_response(payload)
 
     def _apply_ready_response(self, payload: bytes) -> None:
         """Decode an EngineCoreReadyResponse and sync any post-initialization

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -719,36 +719,30 @@ class MPClient(EngineCoreClient):
             target=monitor_engine_cores, daemon=True, name="MPClientEngineMonitor"
         ).start()
 
-    def _wait_for_engine_ready(self, sync_input_socket: zmq.Socket) -> None:
+    def _wait_for_engine_ready(
+        self,
+        sync_input_socket: zmq.Socket,
+        identities: set[bytes] | None = None,
+        what: str = "engine core processes",
+    ) -> None:
         """Wait for a ready message from each engine on the input socket.
 
-        Locally-managed engine proc sentinels are polled alongside the socket
-        so that an engine that dies during startup (e.g. OOM-killed while
-        JIT-compiling kernels on first load) fails fast with the real cause,
-        instead of blocking for the full ready timeout and then being
-        misreported as slow weight loading. The engine core monitor only
-        starts after this wait completes, so the death would otherwise go
-        unnoticed here.
+        In the locally-managed-engines path this runs after
+        ``launch_core_engines`` has already handshaked with every engine (see
+        ``wait_for_engine_startup``), so it normally completes immediately;
+        the timeout below is the operative wait for externally-managed
+        engines (``client_addresses``) and for elastic-EP scale-up, where the
+        engines are started outside this process.
         """
-        identities = set(self.core_engines)
-        ready_poller = zmq.Poller()
-        ready_poller.register(sync_input_socket, zmq.POLLIN)
-        local_proc_manager = (
-            self.resources.engine_manager
-            if isinstance(self.resources.engine_manager, CoreEngineProcManager)
-            else None
-        )
-        if local_proc_manager is not None:
-            for sentinel in local_proc_manager.sentinels():
-                ready_poller.register(sentinel, zmq.POLLIN)
+        if identities is None:
+            identities = set(self.core_engines)
         wait_start = time.monotonic()
         while identities:
-            events = ready_poller.poll(
+            if not sync_input_socket.poll(
                 timeout=VLLM_ENGINE_READY_TIMEOUT_S * 1000  # convert to ms
-            )
-            if not events:
+            ):
                 raise TimeoutError(
-                    f"Timed out waiting for engine core processes to start, "
+                    f"Timed out waiting for {what} to start, "
                     f"after {time.monotonic() - wait_start:.0f}s (limit "
                     f"{VLLM_ENGINE_READY_TIMEOUT_S}s, configured by "
                     f"VLLM_ENGINE_READY_TIMEOUT_S). This is often caused by "
@@ -758,20 +752,8 @@ class MPClient(EngineCoreClient):
                     f"environment variable: "
                     f"VLLM_ENGINE_READY_TIMEOUT_S=<seconds>"
                 )
-            if any(sock is not sync_input_socket for sock, _ in events):
-                # A locally-managed engine core process exited before
-                # reporting ready.
-                finished = (
-                    local_proc_manager.finished_procs() if local_proc_manager else {}
-                )
-                raise RuntimeError(
-                    f"Engine core proc(s) exited before reporting ready "
-                    f"(after {time.monotonic() - wait_start:.0f}s), see root "
-                    f"cause above. Exited proc name -> exit code: "
-                    f"{finished or 'unknown (exit code not yet visible)'}"
-                )
             identity, payload = sync_input_socket.recv_multipart()
-            identities.remove(identity)
+            identities.discard(identity)
             self._apply_ready_response(payload)
 
     def _apply_ready_response(self, payload: bytes) -> None:
@@ -1700,21 +1682,12 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
         return future
 
     def _wait_for_new_engine_ready(self, new_core_engines: list[bytes]) -> None:
-        new_engine_identities = set(new_core_engines)
         sync_input_socket = zmq.Socket.shadow(self.input_socket)
-        while new_engine_identities:
-            if not sync_input_socket.poll(timeout=VLLM_ENGINE_READY_TIMEOUT_S * 1000):
-                raise TimeoutError(
-                    f"Timed out waiting for new engine core processes to "
-                    f"start. Waited "
-                    f"{VLLM_ENGINE_READY_TIMEOUT_S}s (configured by "
-                    f"VLLM_ENGINE_READY_TIMEOUT_S). To increase the "
-                    f"timeout, set the environment variable: "
-                    f"VLLM_ENGINE_READY_TIMEOUT_S=<seconds>"
-                )
-            identity, payload = sync_input_socket.recv_multipart()
-            new_engine_identities.discard(identity)
-            self._apply_ready_response(payload)
+        self._wait_for_engine_ready(
+            sync_input_socket,
+            identities=set(new_core_engines),
+            what="new engine core processes",
+        )
 
     def _setup_elastic_ep_reconfig_bootstrap(self) -> None:
         from vllm.distributed.utils import create_tcp_store

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import queue
 import sys
+import time
 import uuid
 import weakref
 from abc import ABC, abstractmethod
@@ -652,24 +653,8 @@ class MPClient(EngineCoreClient):
             ]
 
             # Wait for ready messages from each engine on the input socket.
-            identities = set(self.core_engines)
             sync_input_socket = zmq.Socket.shadow(self.input_socket)
-            while identities:
-                if not sync_input_socket.poll(
-                    timeout=VLLM_ENGINE_READY_TIMEOUT_S * 1000  # convert to ms
-                ):
-                    raise TimeoutError(
-                        f"Timed out waiting for engine core processes to "
-                        f"start. This is often caused by slow weight loading "
-                        f"for large models. Waited "
-                        f"{VLLM_ENGINE_READY_TIMEOUT_S}s (configured by "
-                        f"VLLM_ENGINE_READY_TIMEOUT_S). To increase the "
-                        f"timeout, set the environment variable: "
-                        f"VLLM_ENGINE_READY_TIMEOUT_S=<seconds>"
-                    )
-                identity, payload = sync_input_socket.recv_multipart()
-                identities.remove(identity)
-                self._apply_ready_response(payload)
+            self._wait_for_engine_ready(sync_input_socket)
 
             self.core_engine: EngineIdentity = self.core_engines[0]
             self.utility_results: dict[int, AnyFuture] = {}
@@ -736,6 +721,61 @@ class MPClient(EngineCoreClient):
         Thread(
             target=monitor_engine_cores, daemon=True, name="MPClientEngineMonitor"
         ).start()
+
+    def _wait_for_engine_ready(self, sync_input_socket: zmq.Socket) -> None:
+        """Wait for a ready message from each engine on the input socket.
+
+        Locally-managed engine proc sentinels are polled alongside the socket
+        so that an engine that dies during startup (e.g. OOM-killed while
+        JIT-compiling kernels on first load) fails fast with the real cause,
+        instead of blocking for the full ready timeout and then being
+        misreported as slow weight loading. The engine core monitor only
+        starts after this wait completes, so the death would otherwise go
+        unnoticed here.
+        """
+        identities = set(self.core_engines)
+        ready_poller = zmq.Poller()
+        ready_poller.register(sync_input_socket, zmq.POLLIN)
+        local_proc_manager = (
+            self.resources.engine_manager
+            if isinstance(self.resources.engine_manager, CoreEngineProcManager)
+            else None
+        )
+        if local_proc_manager is not None:
+            for sentinel in local_proc_manager.sentinels():
+                ready_poller.register(sentinel, zmq.POLLIN)
+        wait_start = time.monotonic()
+        while identities:
+            events = ready_poller.poll(
+                timeout=VLLM_ENGINE_READY_TIMEOUT_S * 1000  # convert to ms
+            )
+            if not events:
+                raise TimeoutError(
+                    f"Timed out waiting for engine core processes to start, "
+                    f"after {time.monotonic() - wait_start:.0f}s (limit "
+                    f"{VLLM_ENGINE_READY_TIMEOUT_S}s, configured by "
+                    f"VLLM_ENGINE_READY_TIMEOUT_S). This is often caused by "
+                    f"slow weight loading for large models or cold JIT "
+                    f"kernel compilation (e.g. FlashInfer on new GPU "
+                    f"architectures). To increase the timeout, set the "
+                    f"environment variable: "
+                    f"VLLM_ENGINE_READY_TIMEOUT_S=<seconds>"
+                )
+            if any(sock is not sync_input_socket for sock, _ in events):
+                # A locally-managed engine core process exited before
+                # reporting ready.
+                finished = (
+                    local_proc_manager.finished_procs() if local_proc_manager else {}
+                )
+                raise RuntimeError(
+                    f"Engine core proc(s) exited before reporting ready "
+                    f"(after {time.monotonic() - wait_start:.0f}s), see root "
+                    f"cause above. Exited proc name -> exit code: "
+                    f"{finished or 'unknown (exit code not yet visible)'}"
+                )
+            identity, payload = sync_input_socket.recv_multipart()
+            identities.remove(identity)
+            self._apply_ready_response(payload)
 
     def _apply_ready_response(self, payload: bytes) -> None:
         """Decode an EngineCoreReadyResponse and sync any post-initialization

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -722,36 +722,30 @@ class MPClient(EngineCoreClient):
             target=monitor_engine_cores, daemon=True, name="MPClientEngineMonitor"
         ).start()
 
-    def _wait_for_engine_ready(self, sync_input_socket: zmq.Socket) -> None:
+    def _wait_for_engine_ready(
+        self,
+        sync_input_socket: zmq.Socket,
+        identities: set[bytes] | None = None,
+        what: str = "engine core processes",
+    ) -> None:
         """Wait for a ready message from each engine on the input socket.
 
-        Locally-managed engine proc sentinels are polled alongside the socket
-        so that an engine that dies during startup (e.g. OOM-killed while
-        JIT-compiling kernels on first load) fails fast with the real cause,
-        instead of blocking for the full ready timeout and then being
-        misreported as slow weight loading. The engine core monitor only
-        starts after this wait completes, so the death would otherwise go
-        unnoticed here.
+        In the locally-managed-engines path this runs after
+        ``launch_core_engines`` has already handshaked with every engine (see
+        ``wait_for_engine_startup``), so it normally completes immediately;
+        the timeout below is the operative wait for externally-managed
+        engines (``client_addresses``) and for elastic-EP scale-up, where the
+        engines are started outside this process.
         """
-        identities = set(self.core_engines)
-        ready_poller = zmq.Poller()
-        ready_poller.register(sync_input_socket, zmq.POLLIN)
-        local_proc_manager = (
-            self.resources.engine_manager
-            if isinstance(self.resources.engine_manager, CoreEngineProcManager)
-            else None
-        )
-        if local_proc_manager is not None:
-            for sentinel in local_proc_manager.sentinels():
-                ready_poller.register(sentinel, zmq.POLLIN)
+        if identities is None:
+            identities = set(self.core_engines)
         wait_start = time.monotonic()
         while identities:
-            events = ready_poller.poll(
+            if not sync_input_socket.poll(
                 timeout=VLLM_ENGINE_READY_TIMEOUT_S * 1000  # convert to ms
-            )
-            if not events:
+            ):
                 raise TimeoutError(
-                    f"Timed out waiting for engine core processes to start, "
+                    f"Timed out waiting for {what} to start, "
                     f"after {time.monotonic() - wait_start:.0f}s (limit "
                     f"{VLLM_ENGINE_READY_TIMEOUT_S}s, configured by "
                     f"VLLM_ENGINE_READY_TIMEOUT_S). This is often caused by "
@@ -761,20 +755,8 @@ class MPClient(EngineCoreClient):
                     f"environment variable: "
                     f"VLLM_ENGINE_READY_TIMEOUT_S=<seconds>"
                 )
-            if any(sock is not sync_input_socket for sock, _ in events):
-                # A locally-managed engine core process exited before
-                # reporting ready.
-                finished = (
-                    local_proc_manager.finished_procs() if local_proc_manager else {}
-                )
-                raise RuntimeError(
-                    f"Engine core proc(s) exited before reporting ready "
-                    f"(after {time.monotonic() - wait_start:.0f}s), see root "
-                    f"cause above. Exited proc name -> exit code: "
-                    f"{finished or 'unknown (exit code not yet visible)'}"
-                )
             identity, payload = sync_input_socket.recv_multipart()
-            identities.remove(identity)
+            identities.discard(identity)
             self._apply_ready_response(payload)
 
     def _apply_ready_response(self, payload: bytes) -> None:
@@ -1716,21 +1698,12 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
         return future
 
     def _wait_for_new_engine_ready(self, new_core_engines: list[bytes]) -> None:
-        new_engine_identities = set(new_core_engines)
         sync_input_socket = zmq.Socket.shadow(self.input_socket)
-        while new_engine_identities:
-            if not sync_input_socket.poll(timeout=VLLM_ENGINE_READY_TIMEOUT_S * 1000):
-                raise TimeoutError(
-                    f"Timed out waiting for new engine core processes to "
-                    f"start. Waited "
-                    f"{VLLM_ENGINE_READY_TIMEOUT_S}s (configured by "
-                    f"VLLM_ENGINE_READY_TIMEOUT_S). To increase the "
-                    f"timeout, set the environment variable: "
-                    f"VLLM_ENGINE_READY_TIMEOUT_S=<seconds>"
-                )
-            identity, payload = sync_input_socket.recv_multipart()
-            new_engine_identities.discard(identity)
-            self._apply_ready_response(payload)
+        self._wait_for_engine_ready(
+            sync_input_socket,
+            identities=set(new_core_engines),
+            what="new engine core processes",
+        )
 
     def _setup_elastic_ep_reconfig_bootstrap(self) -> None:
         from vllm.distributed.utils import create_tcp_store

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -4,6 +4,7 @@
 import contextlib
 import os
 import threading
+import time
 import weakref
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
@@ -40,6 +41,7 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 STARTUP_POLL_PERIOD_MS = 10000
+STARTUP_PROGRESS_LOG_PERIOD_S = 30
 
 
 class CoreEngineState(Enum):
@@ -1203,6 +1205,37 @@ def launch_core_engines(
         )
 
 
+def describe_failed_procs(
+    proc_manager: CoreEngineProcManager | None,
+    coord_process: Process | None,
+) -> str:
+    """Describe which local proc(s) exited, for engine startup failure errors.
+
+    A process's sentinel can become ready slightly before its exit code is
+    collectible, so calling ``finished_procs()`` directly at that moment can
+    race and report an empty dict, masking which process failed entirely
+    (the bare ``Failed core proc(s): {}`` in #48031 / #45626). Briefly join
+    the proc(s) whose sentinels fired so their exit codes become visible, and
+    fall back to naming them with an unknown exit code if the race persists.
+    """
+    procs: list[BaseProcess] = list(proc_manager.processes) if proc_manager else []
+    if coord_process is not None:
+        procs.append(coord_process)
+    exited = set(connection.wait([proc.sentinel for proc in procs], timeout=0))
+    finished: dict[str, int | str] = {}
+    for proc in procs:
+        if proc.exitcode is None and proc.sentinel in exited:
+            # Sentinel fired but the exit code isn't collected yet; reap it.
+            proc.join(timeout=1.0)
+        if proc.exitcode is not None:
+            finished[proc.name] = proc.exitcode
+        elif proc.sentinel in exited:
+            finished[proc.name] = "unknown"
+    if not finished:
+        return "Failed core proc(s): {}"
+    return f"Failed core proc(s): {finished}"
+
+
 def wait_for_engine_startup(
     handshake_socket: zmq.Socket,
     addresses: EngineZmqAddresses,
@@ -1231,6 +1264,8 @@ def wait_for_engine_startup(
             poller.register(sentinel, zmq.POLLIN)
     if coord_process is not None:
         poller.register(coord_process.sentinel, zmq.POLLIN)
+    wait_start = time.monotonic()
+    next_progress_log = wait_start + STARTUP_PROGRESS_LOG_PERIOD_S
     while any(conn_pending) or any(start_pending):
         events = poller.poll(STARTUP_POLL_PERIOD_MS)
         if not events:
@@ -1244,16 +1279,30 @@ def wait_for_engine_startup(
                     "Waiting for %d local, %d remote core engine proc(s) to start.",
                     *start_pending,
                 )
+            # Periodically surface progress at INFO level so a long startup is
+            # attributable (slow weight loading, cold JIT kernel compilation on
+            # first load, ...) rather than looking like a silent hang.
+            now = time.monotonic()
+            if now >= next_progress_log:
+                next_progress_log = now + STARTUP_PROGRESS_LOG_PERIOD_S
+                logger.info(
+                    "Still waiting for engine core proc(s) to start after %.0fs "
+                    "(%d local, %d remote pending). Large models can spend a "
+                    "long time here loading weights or JIT-compiling kernels "
+                    "on first load (e.g. cold FlashInfer cache).",
+                    now - wait_start,
+                    conn_pending[0] + start_pending[0],
+                    conn_pending[1] + start_pending[1],
+                )
             continue
         if len(events) > 1 or events[0][0] != handshake_socket:
             # One of the local core processes exited.
-            finished = proc_manager.finished_procs() if proc_manager else {}
-            if coord_process is not None and coord_process.exitcode is not None:
-                finished[coord_process.name] = coord_process.exitcode
             raise RuntimeError(
                 "Engine core initialization failed. "
                 "See root cause above. "
-                f"Failed core proc(s): {finished}"
+                f"{describe_failed_procs(proc_manager, coord_process)} "
+                f"(startup had been in progress for "
+                f"{time.monotonic() - wait_start:.0f}s)"
             )
 
         # Receive HELLO and READY messages from the input socket.

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -4,6 +4,7 @@
 import contextlib
 import os
 import threading
+import time
 import weakref
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
@@ -41,6 +42,7 @@ logger = init_logger(__name__)
 
 STARTUP_POLL_PERIOD_MS = 10000
 ROCM_ENGINE_PROCESS_SHUTDOWN_TIMEOUT_S = 15.0
+STARTUP_PROGRESS_LOG_PERIOD_S = 30
 
 
 def get_engine_process_shutdown_timeout(
@@ -1247,6 +1249,37 @@ def launch_core_engines(
         )
 
 
+def describe_failed_procs(
+    proc_manager: CoreEngineProcManager | None,
+    coord_process: Process | None,
+) -> str:
+    """Describe which local proc(s) exited, for engine startup failure errors.
+
+    A process's sentinel can become ready slightly before its exit code is
+    collectible, so calling ``finished_procs()`` directly at that moment can
+    race and report an empty dict, masking which process failed entirely
+    (the bare ``Failed core proc(s): {}`` in #48031 / #45626). Briefly join
+    the proc(s) whose sentinels fired so their exit codes become visible, and
+    fall back to naming them with an unknown exit code if the race persists.
+    """
+    procs: list[BaseProcess] = list(proc_manager.processes) if proc_manager else []
+    if coord_process is not None:
+        procs.append(coord_process)
+    exited = set(connection.wait([proc.sentinel for proc in procs], timeout=0))
+    finished: dict[str, int | str] = {}
+    for proc in procs:
+        if proc.exitcode is None and proc.sentinel in exited:
+            # Sentinel fired but the exit code isn't collected yet; reap it.
+            proc.join(timeout=1.0)
+        if proc.exitcode is not None:
+            finished[proc.name] = proc.exitcode
+        elif proc.sentinel in exited:
+            finished[proc.name] = "unknown"
+    if not finished:
+        return "Failed core proc(s): {}"
+    return f"Failed core proc(s): {finished}"
+
+
 def wait_for_engine_startup(
     handshake_socket: zmq.Socket,
     core_engines: list[CoreEngine],
@@ -1283,6 +1316,8 @@ def wait_for_engine_startup(
         frontend_process_by_fd[fd] = proc
         poller.register(fd, zmq.POLLIN)
 
+    wait_start = time.monotonic()
+    next_progress_log = wait_start + STARTUP_PROGRESS_LOG_PERIOD_S
     while any(conn_pending) or any(start_pending):
         events = poller.poll(STARTUP_POLL_PERIOD_MS)
         if not events:
@@ -1296,36 +1331,54 @@ def wait_for_engine_startup(
                     "Waiting for %d local, %d remote core engine proc(s) to start.",
                     *start_pending,
                 )
+            # Periodically surface progress at INFO level so a long startup is
+            # attributable (slow weight loading, cold JIT kernel compilation on
+            # first load, ...) rather than looking like a silent hang.
+            now = time.monotonic()
+            if now >= next_progress_log:
+                next_progress_log = now + STARTUP_PROGRESS_LOG_PERIOD_S
+                logger.info(
+                    "Still waiting for engine core proc(s) to start after %.0fs "
+                    "(%d local, %d remote pending). Large models can spend a "
+                    "long time here loading weights or JIT-compiling kernels "
+                    "on first load (e.g. cold FlashInfer cache).",
+                    now - wait_start,
+                    conn_pending[0] + start_pending[0],
+                    conn_pending[1] + start_pending[1],
+                )
             continue
         if len(events) > 1 or events[0][0] != handshake_socket:
             # One of the local core, coordinator, or watched frontend processes exited.
-            if isinstance(launch.engine_manager, CoreEngineProcManager):
-                finished = launch.engine_manager.finished_procs()
-            else:
-                finished = {}
-            if coord_process is not None and coord_process.exitcode is not None:
-                finished[coord_process.name] = coord_process.exitcode
+            proc_manager = (
+                launch.engine_manager
+                if isinstance(launch.engine_manager, CoreEngineProcManager)
+                else None
+            )
+            core_msg = describe_failed_procs(proc_manager, coord_process)
             failed_frontend_procs = {
                 proc.name: proc.exitcode
                 for fd, proc in frontend_process_by_fd.items()
                 if proc.exitcode is not None
                 or any(event_fd == fd for event_fd, _ in events)
             }
-            if failed_frontend_procs and not finished:
+            elapsed_s = time.monotonic() - wait_start
+            elapsed = f"(startup had been in progress for {elapsed_s:.0f}s)"
+            if failed_frontend_procs and core_msg.endswith("{}"):
                 raise RuntimeError(
                     "Frontend process failed during engine core initialization. "
                     "See root cause above. "
-                    f"Failed frontend proc(s): {failed_frontend_procs}"
+                    f"Failed frontend proc(s): {failed_frontend_procs} {elapsed}"
                 )
             raise RuntimeError(
                 "Engine core initialization failed. "
                 "See root cause above. "
-                f"Failed core proc(s): {finished}"
+                f"{core_msg}"
                 + (
                     f", failed frontend proc(s): {failed_frontend_procs}"
                     if failed_frontend_procs
                     else ""
                 )
+                + f" {elapsed}"
             )
 
         # Receive HELLO and READY messages from the input socket.


### PR DESCRIPTION
## Purpose

Related: #48031, #45626. Complements #45641.

**Update (reshaped per review below):** @pos-ei-don measured on the original #48031 hardware that the first version of this PR improved the wrong wait: in the locally-managed-engines path, `MPClient`'s ready-wait runs after `launch_core_engines.__exit__` → `wait_for_engine_startup()` has already handshaked with every engine, so the improved timeout message could not fire there and the sentinel fail-fast duplicated what `wait_for_engine_startup` already does one layer up. The diagnostics now live where startup actually waits:

1. **`wait_for_engine_startup` (`utils.py`) — the operative wait for locally-managed engines:**
   - Logs progress at INFO every 30s with elapsed time and the likely causes (slow weight loading, cold JIT kernel compilation, e.g. FlashInfer on new GPU architectures), instead of debug-only logs. A multi-minute cold start is attributable instead of looking like a silent hang.
   - On engine proc death, reports proc name -> exit code plus elapsed time via a new `describe_failed_procs` helper. This fixes the `Failed core proc(s): {}` empty-dict race from #48031/#45626: procs whose sentinels fired are briefly joined so their exit code becomes collectible, and are named with an `unknown` exit code if it still isn't.
2. **`MPClient._wait_for_engine_ready` (`core_client.py`):** keeps the improved `TimeoutError` (elapsed time + cold-JIT hint) for the paths where `VLLM_ENGINE_READY_TIMEOUT_S` is actually operative — externally-managed engines (`client_addresses`) and elastic-EP scale-up — and drops the duplicate sentinel polling from the first commit. `_scale_up_elastic_ep` now reuses this method instead of carrying a third copy of the ready-wait loop (message drift between the copies is how the first version of this PR went wrong).

Behavior notes:
- `_wait_for_engine_ready` now uses `identities.discard` (previously `remove` in the main path), matching the elastic-EP copy it absorbed.
- `describe_failed_procs` overlaps in spirit with #45641 (stale since June); happy to rebase or defer if that lands first.

## Test Plan

```bash
pytest tests/v1/engine/test_init_error_messaging.py -v
pytest tests/v1/engine/test_engine_core_client.py -k "env_timeout or ready_wait" -v
```

- `test_describe_failed_procs_reports_name_and_exit_code` (new): a real exited proc is reported with name and exit code.
- `test_describe_failed_procs_names_proc_when_exit_code_races` (new): sentinel fired but exit code not collectible — proc is still named (`unknown`) instead of `{}`.
- `test_describe_failed_procs_ignores_live_procs` (new): live procs are not reported; an exited coordinator is.
- `test_ready_wait_timeout_reports_elapsed_and_jit_hint` (updated): the ready timeout names the env var, elapsed time, and the JIT-compile cause.
- `test_mp_client_uses_env_timeout` (existing, restored to socket-poll form): `VLLM_ENGINE_READY_TIMEOUT_S` reaches the poll in ms.

## Test Result

All pass locally (CPU-only; the changed logic is platform-independent):

```
tests/v1/engine/test_init_error_messaging.py — 5 passed
timeout message OK: Timed out waiting for engine core processes to start, after 0s (limit 600s, configured by VLLM_ENGIN...
```

`ruff check` and `ruff format --check` clean on all four files. The #48031 reporter has offered a real cold-start before/after on GB10/sm_121a against this reshaped version.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
