### PR TITLE
[Helion] Fix fused_qk_norm_rope in-place read-after-write race on B200

### DIFF
--- a/vllm/kernels/helion/configs/fused_qk_norm_rope/nvidia_b200.json
+++ b/vllm/kernels/helion/configs/fused_qk_norm_rope/nvidia_b200.json
@@ -32,31 +32,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "",
-        "last",
-        "first",
-        "",
-        "last",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -94,31 +71,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "last",
-        "last",
-        "first",
-        "first",
-        ""
-      ],
       "num_warps": 4,
       "num_stages": 3,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -156,31 +110,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "",
-        "first",
-        "last",
-        "first",
-        "first",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -217,31 +148,8 @@
       "range_flattens": [
         true
       ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "",
-        "last",
-        "first",
-        "last",
-        "",
-        "last"
-      ],
       "num_warps": 1,
       "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_interleaved",
       "num_sm_multiplier": 4,
@@ -281,31 +189,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "",
-        "first",
-        "last",
-        "first",
-        "first",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -343,31 +228,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "",
-        "first",
-        "last",
-        "first",
-        "first",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -404,31 +266,8 @@
       "range_flattens": [
         false
       ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "last",
-        "last",
-        "first",
-        "last",
-        "",
-        "last"
-      ],
       "num_warps": 8,
       "num_stages": 2,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 4,
@@ -468,31 +307,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "last",
-        "first",
-        "first",
-        "first",
-        "",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -530,31 +346,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "",
-        "first",
-        "last",
-        "first",
-        "first",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -592,31 +385,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        "",
-        "",
-        "last",
-        "last",
-        "first",
-        "first"
-      ],
       "num_warps": 4,
       "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -654,31 +424,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "",
-        "first",
-        "last",
-        "first",
-        "first",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -715,32 +462,9 @@
       ],
       "range_flattens": [
         null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "first",
-        "first",
-        "last",
-        "last",
-        "last",
-        "last"
       ],
       "num_warps": 8,
       "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -778,31 +502,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first",
-        "",
-        "first",
-        "",
-        "",
-        "first"
-      ],
       "num_warps": 2,
       "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -840,31 +541,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "first",
-        "",
-        "first",
-        "first",
-        "",
-        "first"
-      ],
       "num_warps": 2,
       "num_stages": 4,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -901,32 +579,9 @@
       ],
       "range_flattens": [
         null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        "",
-        "",
-        "last",
-        "last",
-        "first",
-        "first"
       ],
       "num_warps": 4,
       "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -964,31 +619,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first",
-        "",
-        "first",
-        "",
-        "",
-        "first"
-      ],
       "num_warps": 2,
       "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1026,31 +658,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "last",
-        "",
-        "last",
-        "last",
-        "",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1088,31 +697,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first",
-        "",
-        "first",
-        "",
-        "",
-        "first"
-      ],
       "num_warps": 2,
       "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1150,31 +736,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first",
-        "",
-        "first",
-        "",
-        "",
-        "first"
-      ],
       "num_warps": 2,
       "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1212,31 +775,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "",
-        "first",
-        "last",
-        "first",
-        "first",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1274,31 +814,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "first",
-        "",
-        "last",
-        "first",
-        "first",
-        "first"
-      ],
       "num_warps": 2,
       "num_stages": 7,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1336,31 +853,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first",
-        "",
-        "first",
-        "",
-        "",
-        "first"
-      ],
       "num_warps": 2,
       "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1398,31 +892,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "",
-        "last",
-        "last",
-        "first",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 7,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1460,31 +931,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "",
-        "last",
-        "first",
-        "",
-        "last",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1522,31 +970,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first",
-        "",
-        "first",
-        "",
-        "",
-        "first"
-      ],
       "num_warps": 2,
       "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1584,31 +1009,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "first",
-        "",
-        "first",
-        "first",
-        "",
-        "first"
-      ],
       "num_warps": 2,
       "num_stages": 4,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1646,31 +1048,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "last",
-        "",
-        "last",
-        "last",
-        "",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1706,31 +1085,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "last",
-        "",
-        "last",
-        "last",
-        "first",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1765,31 +1121,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "last",
-        "first",
-        "first",
-        "last",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 32,
@@ -1828,31 +1161,8 @@
       "range_flattens": [
         false
       ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        "first",
-        "first",
-        "",
-        "first",
-        "last",
-        "last"
-      ],
       "num_warps": 1,
       "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 32
@@ -1888,31 +1198,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "last",
-        "first",
-        "first",
-        "last",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 32,
@@ -1951,31 +1238,8 @@
       "range_flattens": [
         false
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "",
-        "last",
-        "last",
-        "first",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 7,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_interleaved",
       "num_sm_multiplier": 32
@@ -2013,31 +1277,8 @@
       "range_flattens": [
         false
       ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "last",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2075,32 +1316,9 @@
       ],
       "range_flattens": [
         false
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "",
-        "last",
-        "last",
-        "first",
-        ""
       ],
       "num_warps": 1,
       "num_stages": 7,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_interleaved",
       "num_sm_multiplier": 32
@@ -2138,31 +1356,8 @@
       "range_flattens": [
         false
       ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "last",
-        "",
-        "first",
-        "",
-        "first",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_interleaved",
       "num_sm_multiplier": 32
@@ -2200,31 +1395,8 @@
       "range_flattens": [
         false
       ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "last",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2263,31 +1435,8 @@
       "range_flattens": [
         false
       ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "last",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2326,31 +1475,8 @@
       "range_flattens": [
         false
       ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "last",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2389,31 +1515,8 @@
       "range_flattens": [
         false
       ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "last",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2452,31 +1555,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "last",
-        "last"
-      ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2515,31 +1595,8 @@
       "range_flattens": [
         false
       ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "last",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2578,31 +1635,8 @@
       "range_flattens": [
         false
       ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "last",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,

--- a/vllm/kernels/helion/configs/fused_qk_norm_rope/nvidia_h100.json
+++ b/vllm/kernels/helion/configs/fused_qk_norm_rope/nvidia_h100.json
@@ -29,31 +29,8 @@
       "range_flattens": [
         true
       ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first",
-        "",
-        "",
-        "last",
-        "",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 3,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 2
@@ -90,31 +67,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first",
-        "first",
-        "last",
-        "",
-        "last",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -150,31 +104,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        "last",
-        "first",
-        "first",
-        "last",
-        "last",
-        "first"
-      ],
       "num_warps": 2,
       "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -210,31 +141,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "first",
-        "first",
-        "last",
-        "first",
-        "last"
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -270,31 +178,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last",
-        "first",
-        "first",
-        "first",
-        "last",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 8,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -330,31 +215,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "",
-        "",
-        "last",
-        "",
-        "",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -390,31 +252,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        "",
-        "",
-        "last",
-        "last",
-        "",
-        "last"
-      ],
       "num_warps": 1,
       "num_stages": 4,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -450,31 +289,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        "last",
-        "",
-        "first",
-        "",
-        "first",
-        "last"
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -510,31 +326,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        "last",
-        "first",
-        "last",
-        "last",
-        "last",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 2,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -568,31 +361,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "first",
-        "last",
-        "first",
-        "first",
-        "last",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
       "pid_type": "flat",
       "atomic_indexing": [],
       "range_warp_specializes": [],
@@ -630,31 +400,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        "last",
-        "first",
-        "last",
-        "last",
-        "last",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 2,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -690,31 +437,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        "last",
-        "first",
-        "last",
-        "last",
-        "last",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 2,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -750,31 +474,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        "",
-        "",
-        "last",
-        "last",
-        "",
-        "last"
-      ],
       "num_warps": 1,
       "num_stages": 4,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -810,31 +511,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        "last",
-        "first",
-        "last",
-        "last",
-        "last",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 8,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -870,31 +548,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "",
-        "first",
-        "last",
-        "last",
-        "first",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 4,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -929,32 +584,9 @@
       ],
       "range_flattens": [
         null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "first",
-        "last",
-        "",
-        "first",
-        "first"
       ],
       "num_warps": 1,
       "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -988,31 +620,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "",
-        "first",
-        "last",
-        "",
-        "last",
-        "last"
-      ],
       "num_warps": 1,
       "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
       "pid_type": "flat",
       "atomic_indexing": [],
       "range_warp_specializes": [],
@@ -1050,31 +659,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        "last",
-        "last",
-        "first",
-        "last",
-        "first",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 2,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1110,31 +696,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "last",
-        "",
-        "last",
-        "last",
-        "first",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1170,31 +733,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "first",
-        "first",
-        "last",
-        "",
-        "last",
-        "last",
-        "last",
-        "first"
-      ],
       "num_warps": 2,
       "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1229,32 +769,9 @@
       ],
       "range_flattens": [
         null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "last",
-        "last",
-        "last",
-        "first",
-        "first",
-        ""
       ],
       "num_warps": 2,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1289,32 +806,9 @@
       ],
       "range_flattens": [
         null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "last",
-        "",
-        "last",
-        "last",
-        "first",
-        "first"
       ],
       "num_warps": 1,
       "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1350,31 +844,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "",
-        "last",
-        "last",
-        "last",
-        ""
-      ],
       "num_warps": 2,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1410,31 +881,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "",
-        "",
-        "first",
-        "",
-        "first",
-        "first"
-      ],
       "num_warps": 2,
       "num_stages": 2,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1470,31 +918,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "",
-        "last",
-        "last",
-        "last",
-        ""
-      ],
       "num_warps": 2,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1529,31 +954,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "last",
-        "first",
-        "first",
-        "last",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 32,
@@ -1590,31 +992,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "last",
-        "first",
-        "first",
-        "last",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 32,
@@ -1651,31 +1030,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "last",
-        "first",
-        "first",
-        "last",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 32,
@@ -1712,31 +1068,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "last",
-        "first",
-        "first",
-        "last",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 32,
@@ -1773,31 +1106,8 @@
       "range_flattens": [
         true
       ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        "first",
-        "first",
-        "last",
-        "last",
-        "",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_interleaved",
       "num_sm_multiplier": 64,
@@ -1834,31 +1144,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "last",
-        "first",
-        "first",
-        "last",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 32,
@@ -1895,31 +1182,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "last",
-        "first",
-        "first",
-        "last",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 32,
@@ -1955,31 +1219,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first",
-        "last",
-        "",
-        "last",
-        "",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
       "pid_type": "persistent_interleaved",
       "num_sm_multiplier": 128,
       "maxnreg": 64,
@@ -2017,31 +1258,8 @@
       "range_flattens": [
         false
       ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "last",
-        "",
-        "last",
-        "first",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 4,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 64,
@@ -2078,31 +1296,8 @@
       "range_flattens": [
         true
       ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "first",
-        "last",
-        "",
-        "",
-        "last",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 64,
@@ -2139,31 +1334,8 @@
       "range_flattens": [
         true
       ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "first",
-        "last",
-        "",
-        "",
-        "last",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 64,
@@ -2200,31 +1372,8 @@
       "range_flattens": [
         false
       ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "last",
-        "",
-        "last",
-        "first",
-        ""
-      ],
       "num_warps": 1,
       "num_stages": 4,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 64,
@@ -2261,31 +1410,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "last",
-        "",
-        "",
-        "",
-        "",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2322,31 +1448,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "last",
-        "",
-        "",
-        "",
-        "",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2383,31 +1486,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "last",
-        "",
-        "",
-        "",
-        "",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2444,31 +1524,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "last",
-        "",
-        "",
-        "",
-        "",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2505,31 +1562,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "last",
-        "",
-        "",
-        "",
-        "",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2564,32 +1598,9 @@
       ],
       "range_flattens": [
         true
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "last",
-        "",
-        "last",
-        "last",
-        "",
-        ""
       ],
       "num_warps": 1,
       "num_stages": 7,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
       "maxnreg": 64,
@@ -2627,31 +1638,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "last",
-        "",
-        "",
-        "",
-        "",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2688,31 +1676,8 @@
       "range_flattens": [
         null
       ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "last",
-        "",
-        "",
-        "",
-        "",
-        "first"
-      ],
       "num_warps": 1,
       "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,

--- a/vllm/kernels/helion/ops/fused_qk_norm_rope.py
+++ b/vllm/kernels/helion/ops/fused_qk_norm_rope.py
@@ -281,23 +281,16 @@ def fused_qk_norm_rope(
     for tile_m, tile_gn, tile_n in hl.tile(
         [num_tokens, qk_heads, head_dim], block_size=[1, None, head_dim]
     ):
+        # Per-head RMS scale over the full head_dim.
         x_blk = qkv[tile_m, tile_gn, tile_n].to(dtype=torch.float32)
-
         rms = x_blk.pow(2).sum(dim=-1)
-        rms = torch.rsqrt(rms * (1.0 / head_dim) + eps)
+        rms = torch.rsqrt(rms * (1.0 / head_dim) + eps)[:, :, None]
 
         use_q_weight = (tile_gn.index < num_heads_q)[None, :, None]
-        w_blk = torch.where(
-            use_q_weight, q_weight[None, None, tile_n], k_weight[None, None, tile_n]
-        )
-
-        x_blk = (x_blk * rms[:, :, None]).to(qkv.dtype) * w_blk
-
-        qkv[tile_m, tile_gn, tile_n] = x_blk
 
         pos_id = position_ids[tile_m]
-        cos_blk = cos_sin_cache[pos_id, hl.arange(embed_dim)]
-        sin_blk = cos_sin_cache[pos_id, hl.arange(embed_dim) + embed_dim]
+        cos_blk = cos_sin_cache[pos_id, hl.arange(embed_dim)][:, None, :]
+        sin_blk = cos_sin_cache[pos_id, hl.arange(embed_dim) + embed_dim][:, None, :]
 
         if is_neox:
             x1_offset = hl.arange(embed_dim)
@@ -306,11 +299,50 @@ def fused_qk_norm_rope(
             x1_offset = hl.arange(embed_dim) * 2
             x2_offset = x1_offset + 1
 
-        x1_blk = qkv[tile_m, tile_gn, x1_offset]
-        x2_blk = qkv[tile_m, tile_gn, x2_offset]
+        # Read the rotary halves from the *original* qkv and apply RMSNorm inline,
+        # rather than storing the normalized head and reading it back. The former
+        # store/load used different-shaped index tensors (full head_dim vs. an
+        # embed_dim half), so an element written by one thread was read back by
+        # another thread with no barrier in between -- an in-place read-after-write
+        # data race that corrupted ~0.8% of outputs on B200 (num_warps=8). Reading
+        # the (yet-unwritten) original values sidesteps it entirely.
+        w1 = torch.where(
+            use_q_weight,
+            q_weight[None, None, x1_offset],
+            k_weight[None, None, x1_offset],
+        )
+        w2 = torch.where(
+            use_q_weight,
+            q_weight[None, None, x2_offset],
+            k_weight[None, None, x2_offset],
+        )
+        x1_blk = (qkv[tile_m, tile_gn, x1_offset].to(torch.float32) * rms).to(
+            qkv.dtype
+        ) * w1
+        x2_blk = (qkv[tile_m, tile_gn, x2_offset].to(torch.float32) * rms).to(
+            qkv.dtype
+        ) * w2
 
-        o1_blk = x1_blk * cos_blk[:, None, :] - x2_blk * sin_blk[:, None, :]
-        o2_blk = x2_blk * cos_blk[:, None, :] + x1_blk * sin_blk[:, None, :]
+        # RMSNorm covers the whole head; the non-rotary tail (untouched by RoPE)
+        # still needs its normalized value written. Read it from the original qkv
+        # before any store; its region is disjoint from the o1/o2 stores below.
+        if rotary_dim < head_dim:
+            tail_offset = hl.arange(rotary_dim, head_dim)
+            w_tail = torch.where(
+                use_q_weight,
+                q_weight[None, None, tail_offset],
+                k_weight[None, None, tail_offset],
+            )
+            tail_blk = (qkv[tile_m, tile_gn, tail_offset].to(torch.float32) * rms).to(
+                qkv.dtype
+            ) * w_tail
 
+        o1_blk = x1_blk * cos_blk - x2_blk * sin_blk
+        o2_blk = x2_blk * cos_blk + x1_blk * sin_blk
+
+        # Every read above precedes every store below (all reads see the original
+        # qkv), and the store regions are disjoint -- no read-after-write hazard.
         qkv[tile_m, tile_gn, x1_offset] = o1_blk
         qkv[tile_m, tile_gn, x2_offset] = o2_blk
+        if rotary_dim < head_dim:
+            qkv[tile_m, tile_gn, tail_offset] = tail_blk


### PR DESCRIPTION
## Purpose

The Helion `fused_qk_norm_rope` kernel has an in-place read-after-write data race that corrupts a small fraction of outputs on B200 (sm100).

The kernel applies per-head RMSNorm, **stores** the normalized head back into `qkv`, then **re-loads** `qkv` to apply RoPE:

```python
qkv[tile_m, tile_gn, tile_n] = x_blk          # store the full head_dim
...
x1_blk = qkv[tile_m, tile_gn, x1_offset]      # reload an embed_dim half
x2_blk = qkv[tile_m, tile_gn, x2_offset]
```

The store (`tile_n`, full `head_dim`) and the reloads (`x1_offset`/`x2_offset`, an `embed_dim` half) use **different-shaped index tensors**, so Helion/Triton maps elements to threads differently for each. An element written by one thread is read back by a **different** thread within the same program, with no barrier/fence in between — a classic read-after-write race.

### Symptoms
On B200 with the tuned `num_warps=8` config for `(q_heads=64, kv_heads=8, num_tokens=8)`:
- ~0.8% of output elements diverge from the reference, up to ~2.1 absolute error.
- The corrupted count and positions **vary run-to-run on identical inputs** — confirming a race rather than a numeric/codegen bug.

H100 (sm90) happens to hide it under its selected config/scheduling.

## Fix

Read the rotary halves (and the non-rotary tail when `rotary_dim < head_dim`) from the **original** `qkv` and apply the RMS scale + weight inline, instead of storing the normalized head and reloading it. All reads now precede all stores, and the store regions are disjoint, so there is no read-after-write hazard. Output is functionally unchanged and now deterministic.

(Helion can't slice a device-resident intermediate, so the halves are read from global memory rather than sliced out of the already-loaded head — hence the extra loads. The reads are of the yet-unwritten original values, so the layout mismatch is harmless.)

### Config change (required)
The rewrite changes the kernel's memory-op layout, so the tuned configs in `configs/fused_qk_norm_rope/nvidia_b200.json` and `nvidia_h100.json` no longer match: their per-op `indexing` (len 11) and `load_eviction_policies` (len 8) lists were pinned to the old op count, and Helion would reject them with *"exceeds indexing config length"*. Both keys are stripped from every config; all **structural** knobs (block sizes, warps, stages, loop orders, l2 groupings, pid type, …) are unchanged and Helion falls back to default indexing for the new layout. Re-tuning those two per-op knobs is a follow-up.

## Test Plan

Verified on a B200:
- The previously-racing shape `(q=64, kv=8, tokens=8)` is clean across many repeated runs (was ~0.8% bad, non-deterministic).
- A full small-token sweep across `(q,kv) ∈ {(16,8),(32,8),(64,8)}` matches the torch reference.
- A `rotary_dim < head_dim` case (exercising the new tail path) matches the reference.

## Test Result

All checks pass; outputs match the reference within the kernel's `5e-2` tolerance and are now deterministic across runs.