### PR TITLE
[CI] Extend max-model-len for `test_parsable_context` to allow reasoning to finish

### DIFF
--- a/tests/entrypoints/openai/responses/test_parsable_context.py
+++ b/tests/entrypoints/openai/responses/test_parsable_context.py
@@ -38,7 +38,7 @@ def server():
         "--reasoning-parser",
         "qwen3",
         "--max_model_len",
-        "5000",
+        "6000",
         "--structured-outputs-config.backend",
         "xgrammar",
         "--enable-auto-tool-choice",


### PR DESCRIPTION

```
pytest -v -s tests/entrypoints/openai/responses/test_parsable_context.py::test_basic[Qwen/Qwen3-8B]

>       assert response.status == "completed"
E       AssertionError: assert 'incomplete' == 'completed'
E         
E         - completed
E         ?         -
E         + incomplete
E         ? ++
entrypoints/openai/responses/test_parsable_context.py:76: AssertionError
```
https://buildkite.com/vllm/amd-ci/builds/10938/list?sid=019f6a27-b2a8-4674-8c88-d168ad08b0dc&tab=output
https://buildkite.com/vllm/ci/builds/78402/canvas?jid=019f6ae1-71aa-434c-8a50-0a3030a044cd&tab=output

For this test `test_parsable_context.py::test_basic`, the max-model-len was arbitrarily limited to 5000. This is just barely too short to fit the reasoning needed to pass `test_parsable_context.py::test_basic[Qwen/Qwen3-8B]` sometimes. Here we extend the max model len to fit the context. 

This issue manifests on both ROCm and CUDA (see the BK links aboce) in a flaky manner. Sometimes it caps out at the 5000 token limit. After increasing the limit to 6000 tokens, I can see that the test passes reliably while using a max of 5423 tokens. It seems that this test is flaky currently, as it sometimes passes after 3880 tokens. It might be worth looking into the large run-to-run variance in the amount of reasoning needed to finish the test.

I am seeing the test pass reliably with this change:

```
============== 1 passed, 14 warnings in 60.89s (0:01:00) ====================
```

Note that the new max-model-len of 6000 is also arbitrary, so it may be better to just remove that arg completely and let vllm select the default value per test. Let me know what you think.