### PR TITLE
[Model] Add Inkling compressed-tensors dynamic FP8 support

### DIFF
--- a/tests/models/inkling/test_moe_weight_layout.py
+++ b/tests/models/inkling/test_moe_weight_layout.py
@@ -187,6 +187,32 @@ def test_moe_loads_compressed_tensors_global_scale(
     assert loaded == [f"experts.routed_experts.{projection}_{scale_kind}_global_scale"]
 
 
+@pytest.mark.parametrize(("projection", "checkpoint_rows"), [("w13", 8), ("w2", 4)])
+def test_moe_loads_channelwise_scale_for_tp(
+    projection: str, checkpoint_rows: int
+) -> None:
+    param = torch.nn.Parameter(torch.empty(2, 4, 1))
+    experts = SimpleNamespace(
+        **{f"{projection}_weight_scale": param},
+        moe_config=SimpleNamespace(moe_parallel_config=SimpleNamespace(tp_rank=1)),
+    )
+    layer = SimpleNamespace(
+        experts=SimpleNamespace(routed_experts=experts),
+        _local_expert_slots=lambda: {0: 0, 2: 1},
+    )
+    checkpoint_scale = torch.arange(3 * checkpoint_rows).reshape(3, checkpoint_rows, 1)
+
+    loaded = moe.InklingMoE.load_expert_weight(
+        layer, f"experts.{projection}_weight_scale", checkpoint_scale
+    )
+
+    expected = checkpoint_scale[[0, 2]]
+    if projection == "w13":
+        expected = expected[:, 4:].reshape(2, 2, 2, 1).transpose(1, 2).flatten(1, 2)
+    torch.testing.assert_close(param, expected.float())
+    assert loaded == [f"experts.routed_experts.{projection}_weight_scale"]
+
+
 def test_sink_down_projection_is_packed_during_load(monkeypatch) -> None:
     monkeypatch.setattr(moe, "get_tensor_model_parallel_world_size", lambda: 2)
     monkeypatch.setattr(moe, "get_tensor_model_parallel_rank", lambda: 1)

--- a/vllm/models/inkling/nvidia/moe.py
+++ b/vllm/models/inkling/nvidia/moe.py
@@ -589,6 +589,9 @@ class InklingMoE(nn.Module):
             param.data[lids] = vals.reshape(len(gids), *param.shape[1:]).to(
                 param.device
             )
+        elif key == "w2_weight_scale" and weight.shape[-1] == 1:
+            # Per-output-channel scales are replicated across TP ranks.
+            param.data[lids] = weight[gids].to(device=param.device, dtype=param.dtype)
         elif key.startswith("w13"):
             # Checkpoint w13 rows are interleaved [g0, u0, g1, u1, ...]; the
             # fused param layout is [w1(gate); w3(up)]. The TP-local rows form


### PR DESCRIPTION
## Purpose

Add the remaining Inkling weight-loader support needed by
[`RedHatAI/Inkling-FP8-dynamic`](https://huggingface.co/RedHatAI/Inkling-FP8-dynamic)
on top of the Inkling compressed-tensors infrastructure now available on `main`.

The dynamic FP8 checkpoint stores `w2_weight_scale` as per-output-channel
`[experts, output_channels, 1]` scales. Inkling tensor parallelism shards the
`w2` input dimension, so these scales must be replicated on every TP rank.
Previously they fell through to the `w2` weight-sharding path, which attempts
to shard the final dimension.

The existing `w13` loader already handles deinterleaving and TP selection for
its channelwise scales. This PR adds only the missing `w2` case and a focused
test covering both layouts.

The checkpoint ignore patterns have been normalized to vLLM module names on
Hugging Face. Existing `WeightsMapper` and compressed-tensors matching
infrastructure handles them, so no Inkling-specific ignore remapping is added.

Block FP8 experts are intentionally out of scope. Inkling's interleaved
gate/up `w13` rows do not align with the checkpoint's 128x128 scale blocks, so
the block checkpoint requires a separate layout design before it can be
claimed as supported.

## Changes

- Replicate per-output-channel `w2_weight_scale` values across TP ranks.
- Test channelwise `w13` deinterleaving and `w2` replication with nontrivial
  TP rank and expert mapping.
- Rebase the PR onto current `main`, removing the superseded quantization
  plumbing, ignore remapping, block-scale handling, and environment toggle.

## Validation

```bash
.venv/bin/python -m pytest tests/models/inkling/test_moe_weight_layout.py -q
# 29 passed, 4 skipped

pre-commit run ruff-check --files \
  vllm/models/inkling/nvidia/moe.py \
  tests/models/inkling/test_moe_weight_layout.py
pre-commit run ruff-format --files \
  vllm/models/inkling/nvidia/moe.py \
  tests/models/inkling/test_moe_weight_layout.py
pre-commit run mypy-3.12 --files \
  vllm/models/inkling/nvidia/moe.py --hook-stage manual
# all passed
```

The updated dynamic and block checkpoint configs were also checked through
`CompressedTensorsConfig` after applying Inkling's existing mapper:

- layer 2 routed expert gate/up/down projections: ignored
- layer 3 routed expert gate/up/down projections: quantized

TP=4 serving smoke test:

```bash
chg run --gpu-ids 2,3,4,5 --timeout 30m -- \
  .venv/bin/vllm serve RedHatAI/Inkling-FP8-dynamic \
  -tp 4 \
  --load-format dummy \
  --max-model-len 1024 \
  --gpu-memory-utilization 0.95 \
  --kernel-config.enable_flashinfer_autotune=False \
  --tokenizer-mode inkling \
  --limit-mm-per-prompt '{"image":0,"audio":0}' \
  --no-enable-prefix-caching \
  --enforce-eager \
  --port 8100

curl --fail http://127.0.0.1:8100/health
# HTTP 200
```

The model initialized with `quantization=compressed-tensors`, selected the
FP8 MoE backend, and reached API readiness. Dummy loading used 230.95 GiB per
GPU and left 19.64 GiB per GPU for KV cache.

Output quality was not evaluated because the serving smoke test used
`--load-format dummy`. A real-checkpoint accuracy evaluation is still required
before making an output-quality claim.

## Contribution notes

- This updates the existing PR rather than creating a duplicate.
- AI assistance was used to inspect the existing implementations, prepare the
  minimal patch and tests, and run validation. The human submitter reviewed the
  resulting diff and is responsible for the change.
