### PR TITLE
[Core] Add opt-in eager PyNccl TP all-reduce split for PIECEWISE CUDA graphs

### DIFF
--- a/docs/design/cuda_graphs.md
+++ b/docs/design/cuda_graphs.md
@@ -229,6 +229,33 @@ Unfortunately, some custom compile passes have to see the whole graph to be effe
 
 Long term, we've added the ability to partition the graph in Inductor instead of right after Dynamo. It can be enabled with `CompilationConfig.use_inductor_graph_partition=True` but is currently experimental and only available with `torch>=2.9`. This also increases compilation time as it has to compile the whole graph and cannot reuse piecewise compilation artifacts. Once vLLM supports 2.9, we plan to make this the default approach as it will also speed up piecewise cudagraph capture.
 
+### Experimental: eager in-place TP all-reduce split (`enable_eager_tp_all_reduce`)
+
+`CompilationConfig.enable_eager_tp_all_reduce` (default off) keeps compiled `PIECEWISE` CUDA graphs but splits the tensor-parallel all-reduce out of the graphs and runs it eagerly, in place, through PyNccl on vLLM's current model stream. This can stabilize cross-node TP over RDMA (e.g. two GB300 nodes connected only by ConnectX-8) for hybrid Mamba2 models under speculative decoding, where an in-graph collective can stall.
+
+Mechanically, it appends the mutation-only op `vllm::all_reduce_inplace_` (schema `Tensor(a!) tensor, str group_name -> ()`) to the piecewise `splitting_ops` boundaries and routes only the TP group's `all_reduce` to it; all other groups and feature-off behavior are unchanged.
+
+The option changes both the traced operator and the partition topology, so it is serialized to workers and included in the compile-cache key. It is validated against an exact envelope in `VllmConfig._validate_eager_tp_all_reduce` and fails closed (rather than normalizing to `FULL`) unless all hold:
+
+- NVIDIA CUDA platform and `tensor_parallel_size > 1`.
+- `mode=VLLM_COMPILE` and `cudagraph_mode=PIECEWISE` exactly (`FULL`/`FULL_AND_PIECEWISE` rejected).
+- Inductor backend (`""` or `"inductor"`) with `use_inductor_graph_partition=False` (FX partitioning).
+- `VLLM_USE_BREAKABLE_CUDAGRAPH` and `VLLM_DISABLE_PYNCCL` unset/false.
+- `pass_config.fuse_allreduce_rms`, `fuse_attn_quant`, `enable_sp`, and `fuse_gemm_comms` all disabled.
+- `splitting_ops` not set to an explicitly empty list.
+
+O2/O3 optimization defaults enable some of the above fusion passes, so they may require explicit overrides. Launch example (dotted and JSON forms both work):
+
+```bash
+vllm serve <model> --tensor-parallel-size 2 \
+  --compilation-config.mode 3 \
+  --compilation-config.cudagraph_mode PIECEWISE \
+  --compilation-config.enable_eager_tp_all_reduce true \
+  --compilation-config '{"pass_config": {"enable_sp": false, "fuse_gemm_comms": false, "fuse_allreduce_rms": false, "fuse_attn_quant": false}}'
+```
+
+This changes the TP all-reduce only, not every cross-node collective (for example an MTP `eh_proj` all-gather remains captured).
+
 ## About the Performance
 
 See the following links for examples:

--- a/docs/serving/parallelism_scaling.md
+++ b/docs/serving/parallelism_scaling.md
@@ -165,6 +165,8 @@ To set up the cluster to use InfiniBand, append additional arguments like `--pri
 [examples/ray_serving/run_cluster.sh](../../examples/ray_serving/run_cluster.sh) helper script.
 Contact your system administrator for more information about the required flags.
 
+For cross-node tensor parallelism with compiled `PIECEWISE` CUDA graphs (notably hybrid Mamba2 models under speculative decoding over RDMA), the in-graph TP all-reduce can stall. The experimental `CompilationConfig.enable_eager_tp_all_reduce` option runs that all-reduce eagerly and in place via PyNccl outside the CUDA graphs while keeping the rest of the model compiled; see [CUDA Graphs](../design/cuda_graphs.md#experimental-eager-in-place-tp-all-reduce-split-enable_eager_tp_all_reduce) for the supported envelope and a launch example.
+
 ## Enabling GPUDirect RDMA
 
 GPUDirect RDMA (Remote Direct Memory Access) is an NVIDIA technology that allows network adapters to directly access GPU memory, bypassing the CPU and system memory. This direct access reduces latency and CPU overhead, which is beneficial for large data transfers between GPUs across nodes.

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -515,6 +515,23 @@ class CompilationConfig:
 
     If None, defaults to attention ops for piecewise cudagraphs.
     If empty list [], no ops are excluded (suitable for full cudagraphs)."""
+
+    enable_eager_tp_all_reduce: bool = False
+    """Experimental, default off. When True, execute the tensor-parallel
+    all-reduce eagerly and in place through PyNccl on vLLM's current model
+    stream, split out of the piecewise CUDA graphs, instead of the default
+    functional out-of-place all-reduce. This preserves compiled PIECEWISE CUDA
+    graphs for hybrid (e.g. Mamba2) models while running the collective outside
+    the graph, which stabilizes cross-node TP over RDMA. Only the tensor-parallel
+    group is affected; feature-off behavior is unchanged.
+
+    Requires NVIDIA CUDA, tensor_parallel_size > 1, mode=VLLM_COMPILE,
+    cudagraph_mode=PIECEWISE, FX graph partitioning
+    (use_inductor_graph_partition=False), PyNccl enabled, and the
+    all-reduce/RMS/attention/GEMM-communication fusion passes disabled. The
+    supported envelope is validated in
+    `VllmConfig._validate_eager_tp_all_reduce`; O2/O3 defaults may need explicit
+    overrides. See also `set_splitting_ops_for_v1`."""
     compile_mm_encoder: bool = False
     """Whether or not to compile the multimodal encoder.
     Currently, this only works for `Qwen2_5_vl` and `mLLaMa4` models on selected
@@ -1166,6 +1183,14 @@ class CompilationConfig:
                     )
                     self.cudagraph_mode = CUDAGraphMode.FULL
                 self.splitting_ops = []
+
+        if self.enable_eager_tp_all_reduce:
+            # Append (never replace) so the eager in-place TP all-reduce is a
+            # piecewise boundary alongside the attention/Mamba/KV-cache defaults.
+            # Done before any SP/async-TP normalization below can clear the list.
+            assert self.splitting_ops is not None
+            if "vllm::all_reduce_inplace_" not in self.splitting_ops:
+                self.splitting_ops.append("vllm::all_reduce_inplace_")
 
         if (
             not self.use_inductor_graph_partition

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -532,6 +532,23 @@ class CompilationConfig:
 
     If None, defaults to attention ops for piecewise cudagraphs.
     If empty list [], no ops are excluded (suitable for full cudagraphs)."""
+
+    enable_eager_tp_all_reduce: bool = False
+    """Experimental, default off. When True, execute the tensor-parallel
+    all-reduce eagerly and in place through PyNccl on vLLM's current model
+    stream, split out of the piecewise CUDA graphs, instead of the default
+    functional out-of-place all-reduce. This preserves compiled PIECEWISE CUDA
+    graphs for hybrid (e.g. Mamba2) models while running the collective outside
+    the graph, which stabilizes cross-node TP over RDMA. Only the tensor-parallel
+    group is affected; feature-off behavior is unchanged.
+
+    Requires NVIDIA CUDA, tensor_parallel_size > 1, mode=VLLM_COMPILE,
+    cudagraph_mode=PIECEWISE, FX graph partitioning
+    (use_inductor_graph_partition=False), PyNccl enabled, and the
+    all-reduce/RMS/attention/GEMM-communication fusion passes disabled. The
+    supported envelope is validated in
+    `VllmConfig._validate_eager_tp_all_reduce`; O2/O3 defaults may need explicit
+    overrides. See also `set_splitting_ops_for_v1`."""
     compile_mm_encoder: bool = False
     """Whether or not to compile the multimodal encoder.
     Currently, this only works for `Qwen2_5_vl` and `mLLaMa4` models on selected
@@ -1209,6 +1226,14 @@ class CompilationConfig:
                     )
                     self.cudagraph_mode = CUDAGraphMode.FULL
                 self.splitting_ops = []
+
+        if self.enable_eager_tp_all_reduce:
+            # Append (never replace) so the eager in-place TP all-reduce is a
+            # piecewise boundary alongside the attention/Mamba/KV-cache defaults.
+            # Done before any SP/async-TP normalization below can clear the list.
+            assert self.splitting_ops is not None
+            if "vllm::all_reduce_inplace_" not in self.splitting_ops:
+                self.splitting_ops.append("vllm::all_reduce_inplace_")
 
         if (
             not self.use_inductor_graph_partition

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1441,6 +1441,10 @@ class VllmConfig:
         # (e.g., XPU may lower max_num_batched_tokens when MLA is enabled)
         self._set_compile_ranges()
 
+        # Validate the eager TP all-reduce split envelope after platform/default
+        # optimization updates but before splitting_ops are finalized.
+        self._validate_eager_tp_all_reduce()
+
         # Do this after all the updates to compilation_config.mode
         effective_dp_size = (
             self.parallel_config.data_parallel_size
@@ -2201,6 +2205,83 @@ class VllmConfig:
                 "Model Runner V2 does not yet support the thinking_token_budget "
                 "request parameter. Set VLLM_USE_V2_MODEL_RUNNER=0 if this is required."
             )
+
+    def _validate_eager_tp_all_reduce(self) -> None:
+        """Validate the supported envelope for the experimental eager in-place
+        TP all-reduce PIECEWISE split before splitting_ops are finalized.
+
+        Fails closed with a targeted error rather than silently normalizing an
+        incompatible configuration (e.g. into FULL cudagraphs).
+        """
+        comp = self.compilation_config
+        if not comp.enable_eager_tp_all_reduce:
+            return
+
+        from vllm.platforms import current_platform
+
+        def _require(condition: bool, reason: str) -> None:
+            if not condition:
+                raise ValueError(
+                    f"compilation_config.enable_eager_tp_all_reduce is set but "
+                    f"{reason}. This experimental feature requires an exact "
+                    f"configuration; disable it or fix the conflict. See "
+                    f"CompilationConfig.enable_eager_tp_all_reduce."
+                )
+
+        _require(current_platform.is_cuda(), "the platform is not NVIDIA CUDA")
+        _require(
+            self.parallel_config.tensor_parallel_size > 1,
+            "tensor_parallel_size must be greater than 1",
+        )
+        _require(
+            comp.mode == CompilationMode.VLLM_COMPILE,
+            "compilation mode must be VLLM_COMPILE",
+        )
+        _require(
+            comp.cudagraph_mode == CUDAGraphMode.PIECEWISE,
+            "cudagraph_mode must be exactly PIECEWISE (FULL and "
+            "FULL_AND_PIECEWISE can bypass the all-reduce split)",
+        )
+        _require(
+            comp.backend in ("", "inductor"),
+            'compilation backend must be the vLLM Inductor path ("" or "inductor")',
+        )
+        _require(
+            not comp.use_inductor_graph_partition,
+            "use_inductor_graph_partition must be False (the validated path "
+            "uses FX graph partitioning)",
+        )
+        _require(
+            not envs.VLLM_USE_BREAKABLE_CUDAGRAPH,
+            "VLLM_USE_BREAKABLE_CUDAGRAPH must be unset/false (this is not a "
+            "breakable-cudagraph path)",
+        )
+        _require(
+            not envs.VLLM_DISABLE_PYNCCL,
+            "VLLM_DISABLE_PYNCCL must be unset/false (the split executes "
+            "through PyNccl)",
+        )
+        _require(
+            not comp.pass_config.fuse_allreduce_rms,
+            "pass_config.fuse_allreduce_rms must be False",
+        )
+        _require(
+            not comp.pass_config.fuse_attn_quant,
+            "pass_config.fuse_attn_quant must be False",
+        )
+        _require(
+            not comp.pass_config.enable_sp,
+            "pass_config.enable_sp must be False",
+        )
+        _require(
+            not comp.pass_config.fuse_gemm_comms,
+            "pass_config.fuse_gemm_comms must be False",
+        )
+        _require(
+            comp.splitting_ops is None or len(comp.splitting_ops) > 0,
+            "splitting_ops must not be an explicitly empty list (piecewise "
+            "boundaries are required)",
+        )
 
     def validate_block_size(self) -> None:
         """Validate block_size against DCP and mamba constraints.

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1609,6 +1609,10 @@ class VllmConfig:
         # (e.g., XPU may lower max_num_batched_tokens when MLA is enabled)
         self._set_compile_ranges()
 
+        # Validate the eager TP all-reduce split envelope after platform/default
+        # optimization updates but before splitting_ops are finalized.
+        self._validate_eager_tp_all_reduce()
+
         # Do this after all the updates to compilation_config.mode
         effective_dp_size = (
             self.parallel_config.data_parallel_size
@@ -2486,6 +2490,83 @@ class VllmConfig:
             raise ValueError(
                 f"Model Runner V2 does not yet support: {', '.join(unsupported)}"
             )
+
+    def _validate_eager_tp_all_reduce(self) -> None:
+        """Validate the supported envelope for the experimental eager in-place
+        TP all-reduce PIECEWISE split before splitting_ops are finalized.
+
+        Fails closed with a targeted error rather than silently normalizing an
+        incompatible configuration (e.g. into FULL cudagraphs).
+        """
+        comp = self.compilation_config
+        if not comp.enable_eager_tp_all_reduce:
+            return
+
+        from vllm.platforms import current_platform
+
+        def _require(condition: bool, reason: str) -> None:
+            if not condition:
+                raise ValueError(
+                    f"compilation_config.enable_eager_tp_all_reduce is set but "
+                    f"{reason}. This experimental feature requires an exact "
+                    f"configuration; disable it or fix the conflict. See "
+                    f"CompilationConfig.enable_eager_tp_all_reduce."
+                )
+
+        _require(current_platform.is_cuda(), "the platform is not NVIDIA CUDA")
+        _require(
+            self.parallel_config.tensor_parallel_size > 1,
+            "tensor_parallel_size must be greater than 1",
+        )
+        _require(
+            comp.mode == CompilationMode.VLLM_COMPILE,
+            "compilation mode must be VLLM_COMPILE",
+        )
+        _require(
+            comp.cudagraph_mode == CUDAGraphMode.PIECEWISE,
+            "cudagraph_mode must be exactly PIECEWISE (FULL and "
+            "FULL_AND_PIECEWISE can bypass the all-reduce split)",
+        )
+        _require(
+            comp.backend in ("", "inductor"),
+            'compilation backend must be the vLLM Inductor path ("" or "inductor")',
+        )
+        _require(
+            not comp.use_inductor_graph_partition,
+            "use_inductor_graph_partition must be False (the validated path "
+            "uses FX graph partitioning)",
+        )
+        _require(
+            not envs.VLLM_USE_BREAKABLE_CUDAGRAPH,
+            "VLLM_USE_BREAKABLE_CUDAGRAPH must be unset/false (this is not a "
+            "breakable-cudagraph path)",
+        )
+        _require(
+            not envs.VLLM_DISABLE_PYNCCL,
+            "VLLM_DISABLE_PYNCCL must be unset/false (the split executes "
+            "through PyNccl)",
+        )
+        _require(
+            not comp.pass_config.fuse_allreduce_rms,
+            "pass_config.fuse_allreduce_rms must be False",
+        )
+        _require(
+            not comp.pass_config.fuse_attn_quant,
+            "pass_config.fuse_attn_quant must be False",
+        )
+        _require(
+            not comp.pass_config.enable_sp,
+            "pass_config.enable_sp must be False",
+        )
+        _require(
+            not comp.pass_config.fuse_gemm_comms,
+            "pass_config.fuse_gemm_comms must be False",
+        )
+        _require(
+            comp.splitting_ops is None or len(comp.splitting_ops) > 0,
+            "splitting_ops must not be an explicitly empty list (piecewise "
+            "boundaries are required)",
+        )
 
     def validate_block_size(self) -> None:
         """Validate block_size against DCP and mamba constraints.

--- a/vllm/distributed/device_communicators/base_device_communicator.py
+++ b/vllm/distributed/device_communicators/base_device_communicator.py
@@ -191,6 +191,19 @@ class DeviceCommunicatorBase:
         dist.all_reduce(input_, group=self.device_group)
         return input_
 
+    def all_reduce_in_place(self, input_: torch.Tensor) -> None:
+        """In-place all-reduce backing the eager TP all-reduce split.
+
+        Only communicators that can reduce on vLLM's current model stream
+        implement this (see ``CudaCommunicator``). The base class does not fall
+        back to ``torch.distributed`` so the opt-in path fails loudly on
+        platforms without such a backend.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support all_reduce_in_place; "
+            "enable_eager_tp_all_reduce is only supported on CUDA with PyNccl."
+        )
+
     def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:
         if dim < 0:
             # Convert negative dim to positive.

--- a/vllm/distributed/device_communicators/base_device_communicator.py
+++ b/vllm/distributed/device_communicators/base_device_communicator.py
@@ -226,6 +226,19 @@ class DeviceCommunicatorBase:
     def checkpoint_restore(self) -> None:
         """Restore communicator state after checkpoint (default: no-op)."""
 
+    def all_reduce_in_place(self, input_: torch.Tensor) -> None:
+        """In-place all-reduce backing the eager TP all-reduce split.
+
+        Only communicators that can reduce on vLLM's current model stream
+        implement this (see ``CudaCommunicator``). The base class does not fall
+        back to ``torch.distributed`` so the opt-in path fails loudly on
+        platforms without such a backend.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support all_reduce_in_place; "
+            "enable_eager_tp_all_reduce is only supported on CUDA with PyNccl."
+        )
+
     def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:
         if dim < 0:
             # Convert negative dim to positive.

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -338,6 +338,24 @@ class CudaCommunicator(DeviceCommunicatorBase):
             torch.distributed.all_reduce(out, group=self.device_group)
         return out
 
+    def all_reduce_in_place(self, input_: torch.Tensor) -> None:
+        # Opt-in eager TP all-reduce split: reduce ``input_`` in place through
+        # PyNccl on vLLM's current model stream (stream=None selects it). This
+        # deliberately does NOT dispatch to custom/symmetric-memory/FlashInfer
+        # all-reduce or ProcessGroupNCCL; the caller relies on the same-pointer,
+        # void-return contract to keep the collective out of CUDA graphs.
+        pynccl_comm = self.pynccl_comm
+        if pynccl_comm is None or pynccl_comm.disabled:
+            raise RuntimeError(
+                "all_reduce_in_place requires an enabled PyNccl communicator "
+                "(enable_eager_tp_all_reduce is set but PyNccl is unavailable "
+                "or disabled)."
+            )
+        result = pynccl_comm.all_reduce(input_, input_)
+        assert result is input_, (
+            "PyNccl in-place all-reduce must return the input buffer"
+        )
+
     def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:
         # Route uniform dim-0 all-gathers through NVLS symmetric memory when
         # enabled (mirrors reduce_scatter); otherwise fall back to the

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -352,6 +352,24 @@ class CudaCommunicator(DeviceCommunicatorBase):
             return None
         return ca_comm.custom_reduce_scatter(input_.contiguous())
 
+    def all_reduce_in_place(self, input_: torch.Tensor) -> None:
+        # Opt-in eager TP all-reduce split: reduce ``input_`` in place through
+        # PyNccl on vLLM's current model stream (stream=None selects it). This
+        # deliberately does NOT dispatch to custom/symmetric-memory/FlashInfer
+        # all-reduce or ProcessGroupNCCL; the caller relies on the same-pointer,
+        # void-return contract to keep the collective out of CUDA graphs.
+        pynccl_comm = self.pynccl_comm
+        if pynccl_comm is None or pynccl_comm.disabled:
+            raise RuntimeError(
+                "all_reduce_in_place requires an enabled PyNccl communicator "
+                "(enable_eager_tp_all_reduce is set but PyNccl is unavailable "
+                "or disabled)."
+            )
+        result = pynccl_comm.all_reduce(input_, input_)
+        assert result is input_, (
+            "PyNccl in-place all-reduce must return the input buffer"
+        )
+
     def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:
         # Route uniform dim-0 all-gathers through NVLS symmetric memory when
         # enabled (mirrors reduce_scatter); otherwise fall back to the

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -139,6 +139,32 @@ def all_reduce_fake(tensor: torch.Tensor, group_name: str) -> torch.Tensor:
     return torch.empty_like(tensor)
 
 
+def all_reduce_inplace_(tensor: torch.Tensor, group_name: str) -> None:
+    # Mutation-only, void-return TP all-reduce for the opt-in eager PIECEWISE
+    # split (enable_eager_tp_all_reduce). The void ABI (mutates_args + a None
+    # return) is what keeps the following non-integer getitem/slice out of the
+    # eager submodule; a tensor-returning collective reproduces the codegen
+    # stitch assertion (see vllm/compilation/codegen.py).
+    assert group_name in _groups, f"Group {group_name} is not found."
+    group = _groups[group_name]()
+    if group is None:
+        raise ValueError(f"Group {group_name} is destroyed.")
+    if group.device_communicator is None:
+        raise ValueError(f"Group {group_name} has no device communicator.")
+    if tensor.is_cuda and torch.cuda.is_current_stream_capturing():
+        # Reaching CUDA graph capture means FX partitioning failed to split
+        # this op out of the graph; refuse rather than capture the collective.
+        raise RuntimeError(
+            "all_reduce_inplace_ was reached during CUDA graph capture; the "
+            "eager TP all-reduce split must execute outside CUDA graphs."
+        )
+    group.device_communicator.all_reduce_in_place(tensor)
+
+
+def all_reduce_inplace_fake_(tensor: torch.Tensor, group_name: str) -> None:
+    return None
+
+
 def reduce_scatter(
     tensor: torch.Tensor, dim: int, world_size: int, group_name: str
 ) -> torch.Tensor:
@@ -333,6 +359,16 @@ direct_register_custom_op(
     fake_impl=all_reduce_fake,
 )
 
+# Mutation-only variant used only when enable_eager_tp_all_reduce is active.
+# Registered unconditionally; routing to it is gated per-group (TP only).
+direct_register_custom_op(
+    op_name="all_reduce_inplace_",
+    op_func=all_reduce_inplace_,
+    mutates_args=["tensor"],
+    fake_impl=all_reduce_inplace_fake_,
+    tags=(torch._C.Tag.cudagraph_unsafe,),
+)
+
 direct_register_custom_op(
     op_name="reduce_scatter",
     op_func=reduce_scatter,
@@ -392,6 +428,7 @@ class GroupCoordinator:
         use_device_communicator: bool,  # whether to use device communicator
         use_message_queue_broadcaster: bool = False,
         group_name: str | None = None,
+        enable_eager_tp_all_reduce: bool = False,
     ):
         group_name = group_name or "anonymous"
         self.unique_name = _get_unique_name(group_name)
@@ -504,6 +541,18 @@ class GroupCoordinator:
         self.use_custom_op_call = (
             current_platform.is_tpu() or current_platform.use_custom_op_collectives()
         )
+
+        # When True (only the TP group sets this), route all_reduce through the
+        # mutation-only op so the collective is split out of piecewise CUDA
+        # graphs and executed eagerly in place via PyNccl.
+        self.enable_eager_tp_all_reduce = enable_eager_tp_all_reduce
+        if self.enable_eager_tp_all_reduce and self.world_size > 1:
+            logger.info_once(
+                "Experimental eager TP all-reduce PIECEWISE split is active "
+                "for group '%s'; the collective runs eagerly in place via "
+                "PyNccl on the current model stream, outside CUDA graphs.",
+                self.unique_name,
+            )
 
         self.use_cpu_custom_send_recv = (
             current_platform.is_cpu()
@@ -655,6 +704,14 @@ class GroupCoordinator:
         """
         # Bypass the function if we are using only 1 GPU.
         if self.world_size == 1:
+            return input_
+
+        if self.enable_eager_tp_all_reduce and self.use_custom_op_call:
+            # Eager in-place TP all-reduce split (TP group only): the void op
+            # mutates ``input_`` and is kept outside CUDA graphs by FX
+            # partitioning. Return the now-mutated tensor to preserve the
+            # functional Python calling contract.
+            torch.ops.vllm.all_reduce_inplace_(input_, group_name=self.unique_name)
             return input_
 
         if self.use_custom_op_call:
@@ -1302,6 +1359,7 @@ def init_model_parallel_group(
     use_message_queue_broadcaster: bool = False,
     group_name: str | None = None,
     use_device_communicator: bool = True,
+    enable_eager_tp_all_reduce: bool = False,
 ) -> GroupCoordinator:
     return GroupCoordinator(
         group_ranks=group_ranks,
@@ -1310,6 +1368,7 @@ def init_model_parallel_group(
         use_device_communicator=use_device_communicator,
         use_message_queue_broadcaster=use_message_queue_broadcaster,
         group_name=group_name,
+        enable_eager_tp_all_reduce=enable_eager_tp_all_reduce,
     )
 
 
@@ -1816,6 +1875,11 @@ def initialize_model_parallel(
         backend,
         use_message_queue_broadcaster=True,
         group_name="tp",
+        # Only the TP group may use the eager in-place all-reduce split; leave
+        # world, PP, DP, DCP, EP, and other groups on the stock path.
+        enable_eager_tp_all_reduce=(
+            config.compilation_config.enable_eager_tp_all_reduce
+        ),
     )
 
     # Build the DCP model-parallel groups.

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -161,6 +161,32 @@ def all_reduce_fake(tensor: torch.Tensor, group_name: str) -> torch.Tensor:
     return torch.empty_like(tensor)
 
 
+def all_reduce_inplace_(tensor: torch.Tensor, group_name: str) -> None:
+    # Mutation-only, void-return TP all-reduce for the opt-in eager PIECEWISE
+    # split (enable_eager_tp_all_reduce). The void ABI (mutates_args + a None
+    # return) is what keeps the following non-integer getitem/slice out of the
+    # eager submodule; a tensor-returning collective reproduces the codegen
+    # stitch assertion (see vllm/compilation/codegen.py).
+    assert group_name in _groups, f"Group {group_name} is not found."
+    group = _groups[group_name]()
+    if group is None:
+        raise ValueError(f"Group {group_name} is destroyed.")
+    if group.device_communicator is None:
+        raise ValueError(f"Group {group_name} has no device communicator.")
+    if tensor.is_cuda and torch.cuda.is_current_stream_capturing():
+        # Reaching CUDA graph capture means FX partitioning failed to split
+        # this op out of the graph; refuse rather than capture the collective.
+        raise RuntimeError(
+            "all_reduce_inplace_ was reached during CUDA graph capture; the "
+            "eager TP all-reduce split must execute outside CUDA graphs."
+        )
+    group.device_communicator.all_reduce_in_place(tensor)
+
+
+def all_reduce_inplace_fake_(tensor: torch.Tensor, group_name: str) -> None:
+    return None
+
+
 def reduce_scatter(
     tensor: torch.Tensor, dim: int, world_size: int, group_name: str
 ) -> torch.Tensor:
@@ -355,6 +381,16 @@ direct_register_custom_op(
     fake_impl=all_reduce_fake,
 )
 
+# Mutation-only variant used only when enable_eager_tp_all_reduce is active.
+# Registered unconditionally; routing to it is gated per-group (TP only).
+direct_register_custom_op(
+    op_name="all_reduce_inplace_",
+    op_func=all_reduce_inplace_,
+    mutates_args=["tensor"],
+    fake_impl=all_reduce_inplace_fake_,
+    tags=(torch._C.Tag.cudagraph_unsafe,),
+)
+
 direct_register_custom_op(
     op_name="reduce_scatter",
     op_func=reduce_scatter,
@@ -415,6 +451,7 @@ class GroupCoordinator:
         use_message_queue_broadcaster: bool = False,
         group_name: str | None = None,
         use_all2all: bool = False,
+        enable_eager_tp_all_reduce: bool = False,
     ):
         group_name = group_name or "anonymous"
         self.unique_name = _get_unique_name(group_name)
@@ -525,6 +562,18 @@ class GroupCoordinator:
         self.use_custom_op_call = (
             current_platform.is_tpu() or current_platform.use_custom_op_collectives()
         )
+
+        # When True (only the TP group sets this), route all_reduce through the
+        # mutation-only op so the collective is split out of piecewise CUDA
+        # graphs and executed eagerly in place via PyNccl.
+        self.enable_eager_tp_all_reduce = enable_eager_tp_all_reduce
+        if self.enable_eager_tp_all_reduce and self.world_size > 1:
+            logger.info_once(
+                "Experimental eager TP all-reduce PIECEWISE split is active "
+                "for group '%s'; the collective runs eagerly in place via "
+                "PyNccl on the current model stream, outside CUDA graphs.",
+                self.unique_name,
+            )
 
         self.use_cpu_custom_send_recv = (
             current_platform.is_cpu()
@@ -676,6 +725,14 @@ class GroupCoordinator:
         """
         # Bypass the function if we are using only 1 GPU.
         if self.world_size == 1:
+            return input_
+
+        if self.enable_eager_tp_all_reduce and self.use_custom_op_call:
+            # Eager in-place TP all-reduce split (TP group only): the void op
+            # mutates ``input_`` and is kept outside CUDA graphs by FX
+            # partitioning. Return the now-mutated tensor to preserve the
+            # functional Python calling contract.
+            torch.ops.vllm.all_reduce_inplace_(input_, group_name=self.unique_name)
             return input_
 
         if self.use_custom_op_call:
@@ -1320,6 +1377,7 @@ def init_model_parallel_group(
     group_name: str | None = None,
     use_device_communicator: bool = True,
     use_all2all: bool = False,
+    enable_eager_tp_all_reduce: bool = False,
 ) -> GroupCoordinator:
     return GroupCoordinator(
         group_ranks=group_ranks,
@@ -1329,6 +1387,7 @@ def init_model_parallel_group(
         use_message_queue_broadcaster=use_message_queue_broadcaster,
         group_name=group_name,
         use_all2all=use_all2all,
+        enable_eager_tp_all_reduce=enable_eager_tp_all_reduce,
     )
 
 
@@ -1846,6 +1905,11 @@ def initialize_model_parallel(
         backend,
         use_message_queue_broadcaster=True,
         group_name="tp",
+        # Only the TP group may use the eager in-place all-reduce split; leave
+        # world, PP, DP, DCP, EP, and other groups on the stock path.
+        enable_eager_tp_all_reduce=(
+            config.compilation_config.enable_eager_tp_all_reduce
+        ),
     )
 
     # Build the DCP model-parallel groups.


### PR DESCRIPTION
## Purpose

Experimental, **opt-in** (default-off) support for a compiled-**PIECEWISE** tensor-parallel
all-reduce split: the model stays compiled as piecewise CUDA graphs, but the TP all-reduce is
executed **eagerly, in place, through PyNccl on vLLM's current model stream**, split out of the
graphs via FX partitioning.

This stabilizes cross-node TP for hybrid Mamba2 models under speculative decoding over RDMA
(validated on Nemotron-3-Ultra TP=2 + MTP K=3 across two GB300 nodes connected only by
ConnectX-8), where an in-graph host-staged NCCL all-reduce can produce a one-sided stall.

Enabled with `CompilationConfig.enable_eager_tp_all_reduce=true`. When off, behavior is
byte-for-byte the stock functional out-of-place all-reduce.

The execution invariant is:

```
compiled graph piece -> eager mutation-only TP all-reduce (current model stream) -> compiled graph piece
```

The split operator is intentionally **void / mutation-only**
(`vllm::all_reduce_inplace_(Tensor(a!) tensor, str group_name) -> ()`). The `mutates_args` +
`None` return is what keeps the following non-integer `getitem`/slice out of the eager submodule;
a functional tensor-returning collective reproduces the stitch-code assertion in
`vllm/compilation/codegen.py`. Explicit FX `splitting_ops` (not the `cudagraph_unsafe` tag alone)
keep the op outside CUDA graphs on the FX partitioner path.

**Related (not fixed/closed here):**

- #46253 — cross-node CUDA-graph capture failure on the **breakable-cudagraph** path. This PR is a
  different, compiled-PIECEWISE path; it does not claim to resolve #46253.
- #46372 — makes NCCL collectives eager break points in **breakable** cudagraph (BCG). This PR is
  **not** a BCG change: it does not use `VLLM_USE_BREAKABLE_CUDAGRAPH`, and keeps the model in
  compiled PIECEWISE mode via FX partitioning instead.

### Why this is not duplicating an existing PR

The only open PR in this area is #46372, which targets the **breakable-cudagraph** mechanism. This
PR keeps compiled PIECEWISE graphs and splits the collective through explicit FX `splitting_ops` +
a void mutation-only op executed eagerly via PyNccl. No open PR implements the compiled-PIECEWISE
eager in-place PyNccl split (searched: "eager all-reduce piecewise pynccl", "in-place all reduce
tensor parallel cudagraph", and the #46253 / #46372 threads).

## Changes

1. **`CompilationConfig.enable_eager_tp_all_reduce`** (default off) — a *serialized* config field
   (not an env flag), so it propagates to Ray workers and is folded into the compile-cache key via
   `compute_hash`. Both `--compilation-config.enable_eager_tp_all_reduce true` and the JSON form work.
2. **`VllmConfig._validate_eager_tp_all_reduce`** — validates the full supported envelope before
   `set_splitting_ops_for_v1` and **fails closed** (targeted error, never silent normalization to
   FULL): CUDA, TP>1, `VLLM_COMPILE`, exactly `PIECEWISE`, Inductor backend, FX partitioning
   (`use_inductor_graph_partition=False`), `VLLM_USE_BREAKABLE_CUDAGRAPH`/`VLLM_DISABLE_PYNCCL`
   false, `fuse_allreduce_rms`/`fuse_attn_quant`/`enable_sp`/`fuse_gemm_comms` off, and no explicit
   empty `splitting_ops`.
3. **`vllm::all_reduce_inplace_`** — void mutation-only custom op + fake, registered with
   `mutates_args=["tensor"]` and the `cudagraph_unsafe` tag. Refuses to run under CUDA-graph
   capture. Stock `vllm::all_reduce` is untouched.
4. **Communicator interface** — `DeviceCommunicatorBase.all_reduce_in_place` raises (no fallback);
   `CudaCommunicator.all_reduce_in_place` reduces in place via `pynccl_comm.all_reduce(x, x)` on the
   current stream and asserts same-pointer return. Never dispatches to custom / symmetric-memory /
   FlashInfer / ProcessGroupNCCL.
5. **TP-only routing** — a `GroupCoordinator` flag threaded through `init_model_parallel_group`, set
   **only for `_TP`**. `GroupCoordinator.all_reduce` routes to the void op only when the flag and
   `use_custom_op_call` are both true; all other groups and branches are unchanged.
6. **`set_splitting_ops_for_v1`** — idempotently appends `vllm::all_reduce_inplace_` to the
   piecewise boundaries **without** replacing the attention/Mamba/KV-cache defaults.
7. **Docs** — `docs/design/cuda_graphs.md` (envelope + launch example) and
   `docs/serving/parallelism_scaling.md` (cross-node TP caveat).

## Test Plan

> **Draft:** the automated suites below are owned by the validation pass and are **not yet run on
> this branch**. The only check run so far is lint.

- [x] `ruff check` + `ruff format --check` on all changed files — pass.
- [ ] Schema/fake test: registered schema is mutation-only (`Tensor(a!)`) returning `()`; fake
      returns `None` and the op is not DCE'd.
- [ ] Codegen regression: producer → void op → non-integer slice; split on the op; eager partition
      holds only the mutation op; `generate_execution_code` does not hit `codegen.py`.
- [ ] Config tests: default-off unchanged; on/off hash differently; dotted + JSON CLI round-trip;
      append lands after attention/Mamba/KV defaults; every incompatible mode/pass/platform raises.
- [ ] Communicator tests: 2-rank same-pointer numerically-correct SUM; correct ordering on a
      non-default current stream; PyNccl missing/disabled raises with no ProcessGroup fallback.
- [ ] Routing/alias tests: off = out-of-place, no input mutation; on = mutable path for TP only;
      PP/DP/DCP/EP/world stay stock; audit all TP `tensor_model_parallel_all_reduce` call sites.
- [ ] PIECEWISE replay E2E on a tiny 2-GPU model vs. an eager oracle, incl. a negative test for
      `FULL_AND_PIECEWISE`.

## Test / eval evidence (prototype — to be reproduced on this branch)

> Provenance: measured with the v0.25.1 prototype (`patch_compiled_inplace_ar.py`); the diff here is
> the upstreamed, scoped equivalent. Numbers are to be re-validated by the validation pass on this
> branch. Cross-node host-staged RDMA likely cannot run in CI, so GB300 evidence is attached
> manually rather than gated in CI.

Config: `nvidia/Nemotron-3-Ultra` (hybrid Mamba2), TP=2, PP=1, MTP K=3, Ray, FP8 KV cache, compiled
PIECEWISE; FX partitioning; all-reduce/RMS fusion off, attention fusion off, SP off,
GEMM/communication fusion off; capture sizes covering MTP's BS×(K+1) shapes.

- MTP on real prompts: mean acceptance length ≈ **3.0**, ≈ **70%** draft-token acceptance (i.e. MTP
  actually rejects some drafts — not a degenerate 100%).
- Matched single-stream throughput: MTP-on **123.9** vs MTP-off **52.75** output tok/s/user (≈2.3×).
- BS 1/4/8/16 all passed; BS16 ≈ **719** output tok/s aggregate.
- 80 sequential + 16 queued-concurrent requests completed; BS4/8/16 true concurrent batches
  completed; **no PyNccl fallback hits**.

Note: this change empirically eliminated the observed one-sided stall; the precise original
mechanism is not claimed to be proven here.

## AI assistance

AI assistance (Claude) was used to prepare this change. A human submitter has reviewed the diff and
is responsible for defending it end-to-end and completing the validation above before this leaves
draft.

<details>
<summary>Essential Elements checklist</summary>

- [x] Purpose + linked issues
- [x] Test plan (commands)
- [ ] Test results (pending on this branch)
- [x] AI-assistance disclosure
- [x] Non-duplication rationale
</details>
