### PR TITLE
[Distributed] Use NVSHMEM symm-mem backend across nodes

### DIFF
--- a/vllm/distributed/device_communicators/symm_mem.py
+++ b/vllm/distributed/device_communicators/symm_mem.py
@@ -87,6 +87,25 @@ class SymmMemCommunicator:
             self.max_size = SYMM_MEM_ALL_REDUCE_MAX_SIZES[self.device_capability][
                 self.world_size
             ]
+        from vllm.distributed.parallel_state import in_the_same_node_as
+
+        if not all(in_the_same_node_as(self.group, source_rank=0)):
+            # Cross-node group (multi-node NVLink): the default CUDA backend
+            # exchanges CUDA IPC handles, which are same-node only. Select
+            # the NVSHMEM backend before the process's first symm-mem
+            # allocation so rendezvous maps fabric-reachable peer VAs.
+            try:
+                torch_symm_mem.set_backend("NVSHMEM")
+                logger.info_once(
+                    "SymmMemCommunicator: multi-node group, using the "
+                    "NVSHMEM symmetric-memory backend"
+                )
+            except RuntimeError as e:
+                logger.warning_once(
+                    "SymmMemCommunicator: could not select the NVSHMEM "
+                    "backend for a multi-node group: %s",
+                    str(e),
+                )
         try:
             self.buffer = torch_symm_mem.empty(
                 self.max_size // self.dtype.itemsize,


### PR DESCRIPTION
## Summary

- Select the PyTorch NVSHMEM symmetric-memory backend before the first allocation when a process group spans multiple nodes.
- Keep the current backend for same-node groups.
- Preserve the existing communicator-disable fallback if backend selection or allocation is unavailable.

The default CUDA backend exchanges node-local CUDA IPC handles. Multi-node NVLink process groups need NVSHMEM-backed symmetric virtual addresses.

## Duplicate-work check

I searched open PRs for `symm_mem NVSHMEM backend multi-node` and found no open PR implementing this backend selection.

## Validation

- `.venv/bin/python -m pytest tests/distributed/test_symm_mem_allreduce.py::test_symm_mem_allreduce -v`: 1 passed
- `.venv/bin/pre-commit run --files vllm/distributed/device_communicators/symm_mem.py`: passed

## Model evaluation

Not applicable; this changes distributed symmetric-memory backend selection and does not change model computations or output.

## AI assistance

AI assistance was used to extract and validate this change. The human submitter will review every changed line and is responsible for understanding and defending the change end-to-end.