### PR TITLE
[Warmup] Show CuTeDSL compilation progress

### DIFF
--- a/vllm/model_executor/warmup/cutedsl_warmup.py
+++ b/vllm/model_executor/warmup/cutedsl_warmup.py
@@ -10,7 +10,9 @@ from collections.abc import Callable, Hashable, Iterable
 from dataclasses import dataclass
 
 import torch
+from tqdm import tqdm
 
+from vllm.distributed import is_global_first_rank
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.tracing import instrument
@@ -76,6 +78,8 @@ def _compile_cutedsl_warmup_units(
     compile_units: Iterable[CuTeDSLCompileUnit],
 ) -> int:
     compiled = 0
+    if is_global_first_rank():
+        compile_units = tqdm(compile_units, desc="Compiling CuTeDSL kernels")
     with torch.inference_mode():
         for unit in compile_units:
             unit.compile()


### PR DESCRIPTION
## Summary

- Show progress while registered CuTeDSL kernels compile during startup.
- Display the progress bar only on global rank zero to avoid duplicate output from distributed workers.

## Duplicate-work check

I searched open PRs for `CuTeDSL warmup progress tqdm` and `cutedsl_warmup`. PR #48807 changes exception handling around warmup calls and does not overlap with this rank-zero progress reporting.

## Validation

- Focused mocked check of `_compile_cutedsl_warmup_units`: verified rank zero wraps compile units with the expected progress description and nonzero ranks do not create a progress bar
- `.venv/bin/pre-commit run --files vllm/model_executor/warmup/cutedsl_warmup.py`: passed

## Model evaluation

Not applicable; this only changes startup progress reporting.

## AI assistance

AI assistance was used to extract and validate this change. The human submitter will review every changed line and is responsible for understanding and defending the change end-to-end.