### PR TITLE
[KV Connector] Validate HMA children for MultiConnector subclasses

### DIFF
--- a/tests/v1/kv_connector/unit/test_hma_auto_config.py
+++ b/tests/v1/kv_connector/unit/test_hma_auto_config.py
@@ -8,10 +8,17 @@ import pytest
 from vllm.config import DeviceConfig, KVTransferConfig, SchedulerConfig, VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
 from vllm.distributed.kv_transfer.kv_connector.v1 import KVConnectorRole
+from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
+    MultiConnector,
+)
 from vllm.platforms import current_platform
 from vllm.v1.kv_cache_interface import KVCacheConfig
 
 pytestmark = pytest.mark.cpu_test
+
+
+class MockMultiConnector(MultiConnector):
+    pass
 
 
 @pytest.fixture(autouse=True)
@@ -72,8 +79,55 @@ def mock_hybrid_kv_cache_supported(monkeypatch):
             ),
             True,
         ),
+        (  # MultiConnector subclass: all HMA children → HMA stays enabled
+            KVTransferConfig(
+                kv_connector="MockMultiConnector",
+                kv_connector_module_path=__name__,
+                kv_role="kv_both",
+                kv_connector_extra_config={
+                    "connectors": [
+                        {
+                            "kv_connector": "SimpleCPUOffloadConnector",
+                            "kv_role": "kv_both",
+                            "kv_connector_extra_config": {"cpu_bytes_to_use": 1 << 30},
+                        },
+                        {
+                            "kv_connector": "OffloadingConnector",
+                            "kv_role": "kv_both",
+                            "kv_connector_extra_config": {"cpu_bytes_to_use": 1 << 30},
+                        },
+                    ]
+                },
+            ),
+            False,
+        ),
+        (  # MultiConnector subclass: mixed children → HMA is auto-disabled
+            KVTransferConfig(
+                kv_connector="MockMultiConnector",
+                kv_connector_module_path=__name__,
+                kv_role="kv_both",
+                kv_connector_extra_config={
+                    "connectors": [
+                        {
+                            "kv_connector": "SimpleCPUOffloadConnector",
+                            "kv_role": "kv_both",
+                            "kv_connector_extra_config": {"cpu_bytes_to_use": 1 << 30},
+                        },
+                        {"kv_connector": "ExampleConnector", "kv_role": "kv_both"},
+                    ]
+                },
+            ),
+            True,
+        ),
     ],
-    ids=["hma_connector", "non_hma_connector", "multi_all_hma", "multi_mixed"],
+    ids=[
+        "hma_connector",
+        "non_hma_connector",
+        "multi_all_hma",
+        "multi_mixed",
+        "multi_subclass_all_hma",
+        "multi_subclass_mixed",
+    ],
 )
 def test_hma_auto_config(kv_transfer_config, expect_disabled):
     vllm_config = VllmConfig(

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -135,12 +135,12 @@ class KVConnectorFactory:
         SupportsHMA, but effective support depends on every configured child.
         """
         connector_cls = cls.get_connector_class(kv_transfer_config)
-        if kv_transfer_config.kv_connector != "MultiConnector":
-            return supports_hma(connector_cls)
-
         from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
             MultiConnector,
         )
+
+        if not issubclass(connector_cls, MultiConnector):
+            return supports_hma(connector_cls)
 
         return MultiConnector.all_children_support_hma(kv_transfer_config)
 


### PR DESCRIPTION
## Summary

- Validate HMA support from child connectors for every `MultiConnector` subclass.
- Add auto-configuration coverage for custom wrapper subclasses with all-HMA and mixed-HMA child configurations.

## Root cause

`KVConnectorFactory.supports_hma_config()` special-cased the literal connector name `"MultiConnector"`. A subclass inherited `SupportsHMA`, so it passed the plain-connector check without validating its children. A mixed child configuration could therefore leave HMA enabled and fail later during connector initialization.

## Impact

Custom `MultiConnector` wrappers now have the same effective HMA contract as the built-in wrapper: HMA remains enabled only when every configured child supports it.

## Validation

- `.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_hma_auto_config.py -v` — 7 passed
- `.venv/bin/ruff check vllm/distributed/kv_transfer/kv_connector/factory.py tests/v1/kv_connector/unit/test_hma_auto_config.py` — passed

## Duplicate-work check

This is a narrow follow-up to #41847. No open PR was found for HMA validation of `MultiConnector` subclasses; the broad hybrid-offload work in #38261 does not cover this factory classification bug.

## AI assistance

AI assistance was used to implement and validate this change.
