### PR TITLE
[Bugfix][Frontend] Handle custom tool history in Responses API

### DIFF
--- a/tests/entrypoints/openai/responses/test_responses_utils.py
+++ b/tests/entrypoints/openai/responses/test_responses_utils.py
@@ -4,6 +4,10 @@
 from unittest.mock import patch
 
 import pytest
+from openai.types.responses import (
+    ResponseCustomToolCall,
+    ResponseCustomToolCallOutputItem,
+)
 from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
 from openai.types.responses.response_function_tool_call_output_item import (
     ResponseFunctionToolCallOutputItem,
@@ -173,6 +177,44 @@ class TestResponsesUtils:
         assert (
             message["tool_calls"][0]["function"]["arguments"] == '{"code": "123+456"}'
         )
+
+    def test_construct_input_messages_with_custom_tool_history(self):
+        messages = construct_input_messages(
+            request_input=[
+                ResponseCustomToolCall(
+                    call_id="call_exec",
+                    input='text("done")',
+                    name="exec",
+                    type="custom_tool_call",
+                ),
+                ResponseCustomToolCallOutputItem(
+                    call_id="call_exec",
+                    id="output_exec",
+                    output="done",
+                    status="completed",
+                    type="custom_tool_call_output",
+                ),
+                {"role": "user", "content": "Continue"},
+            ]
+        )
+
+        assert messages == [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_exec",
+                        "type": "custom",
+                        "custom": {
+                            "name": "exec",
+                            "input": 'text("done")',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "content": "done", "tool_call_id": "call_exec"},
+            {"role": "user", "content": "Continue"},
+        ]
 
     def test_construct_chat_messages_preserves_single_item_conversions(self):
         item = ResponseReasoningItem(

--- a/tests/entrypoints/openai/responses/test_responses_utils.py
+++ b/tests/entrypoints/openai/responses/test_responses_utils.py
@@ -4,6 +4,10 @@
 from unittest.mock import patch
 
 import pytest
+from openai.types.responses import (
+    ResponseCustomToolCall,
+    ResponseCustomToolCallOutputItem,
+)
 from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
 from openai.types.responses.response_function_tool_call_output_item import (
     ResponseFunctionToolCallOutputItem,
@@ -152,6 +156,44 @@ class TestResponsesUtils:
         assert (
             message["tool_calls"][0]["function"]["arguments"] == '{"code": "123+456"}'
         )
+
+    def test_construct_input_messages_with_custom_tool_history(self):
+        messages = construct_input_messages(
+            request_input=[
+                ResponseCustomToolCall(
+                    call_id="call_exec",
+                    input='text("done")',
+                    name="exec",
+                    type="custom_tool_call",
+                ),
+                ResponseCustomToolCallOutputItem(
+                    call_id="call_exec",
+                    id="output_exec",
+                    output="done",
+                    status="completed",
+                    type="custom_tool_call_output",
+                ),
+                {"role": "user", "content": "Continue"},
+            ]
+        )
+
+        assert messages == [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_exec",
+                        "type": "custom",
+                        "custom": {
+                            "name": "exec",
+                            "input": 'text("done")',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "content": "done", "tool_call_id": "call_exec"},
+            {"role": "user", "content": "Continue"},
+        ]
 
     def test_construct_chat_messages_preserves_single_item_conversions(self):
         item = ResponseReasoningItem(

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -6,13 +6,19 @@ from typing import Any
 
 from openai.types.chat import (
     ChatCompletionAssistantMessageParam,
+    ChatCompletionMessageCustomToolCallParam,
     ChatCompletionMessageToolCallParam,
     ChatCompletionToolMessageParam,
+)
+from openai.types.chat.chat_completion_message_custom_tool_call_param import (
+    Custom as CustomToolCall,
 )
 from openai.types.chat.chat_completion_message_tool_call_param import (
     Function as FunctionCallTool,
 )
 from openai.types.responses import (
+    ResponseCustomToolCall,
+    ResponseCustomToolCallOutputItem,
     ResponseFunctionToolCall,
     ResponseOutputItem,
     ResponseOutputMessage,
@@ -230,6 +236,11 @@ def _construct_message_from_response_item(
         prev_msg if prev_msg and prev_msg.get("role") == "assistant" else None
     )
 
+    tool_call: (
+        ChatCompletionMessageToolCallParam
+        | ChatCompletionMessageCustomToolCallParam
+        | None
+    ) = None
     if isinstance(item, ResponseFunctionToolCall):
         tool_name = item.name
         if item.namespace:
@@ -242,6 +253,14 @@ def _construct_message_from_response_item(
             ),
             type="function",
         )
+    elif isinstance(item, ResponseCustomToolCall):
+        tool_call = ChatCompletionMessageCustomToolCallParam(
+            id=item.call_id,
+            custom=CustomToolCall(name=item.name, input=item.input),
+            type="custom",
+        )
+
+    if tool_call is not None:
         if prev_assistant_msg:
             tool_calls = prev_assistant_msg.get("tool_calls")
             if tool_calls is None:
@@ -267,7 +286,7 @@ def _construct_message_from_response_item(
             role="assistant",
             tool_calls=[tool_call],
         )
-    elif isinstance(item, ResponseReasoningItem):
+    if isinstance(item, ResponseReasoningItem):
         reasoning = ""
         if item.encrypted_content:
             raise ValueError("Encrypted content is not supported.")
@@ -302,7 +321,10 @@ def _construct_message_from_response_item(
             "role": "assistant",
             "content": output_text,
         }
-    elif isinstance(item, ResponseFunctionToolCallOutputItem):
+    elif isinstance(
+        item,
+        (ResponseFunctionToolCallOutputItem, ResponseCustomToolCallOutputItem),
+    ):
         return ChatCompletionToolMessageParam(
             role="tool",
             content=item.output,

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -6,13 +6,19 @@ from typing import Any
 
 from openai.types.chat import (
     ChatCompletionAssistantMessageParam,
+    ChatCompletionMessageCustomToolCallParam,
     ChatCompletionMessageToolCallParam,
     ChatCompletionToolMessageParam,
+)
+from openai.types.chat.chat_completion_message_custom_tool_call_param import (
+    Custom as CustomToolCall,
 )
 from openai.types.chat.chat_completion_message_tool_call_param import (
     Function as FunctionCallTool,
 )
 from openai.types.responses import (
+    ResponseCustomToolCall,
+    ResponseCustomToolCallOutputItem,
     ResponseFunctionToolCall,
     ResponseOutputItem,
     ResponseOutputMessage,
@@ -233,6 +239,11 @@ def _construct_message_from_response_item(
         prev_msg if prev_msg and prev_msg.get("role") == "assistant" else None
     )
 
+    tool_call: (
+        ChatCompletionMessageToolCallParam
+        | ChatCompletionMessageCustomToolCallParam
+        | None
+    ) = None
     if isinstance(item, ResponseFunctionToolCall):
         tool_name = item.name
         if item.namespace:
@@ -245,6 +256,14 @@ def _construct_message_from_response_item(
             ),
             type="function",
         )
+    elif isinstance(item, ResponseCustomToolCall):
+        tool_call = ChatCompletionMessageCustomToolCallParam(
+            id=item.call_id,
+            custom=CustomToolCall(name=item.name, input=item.input),
+            type="custom",
+        )
+
+    if tool_call is not None:
         if prev_assistant_msg:
             tool_calls = prev_assistant_msg.get("tool_calls")
             if tool_calls is None:
@@ -270,7 +289,7 @@ def _construct_message_from_response_item(
             role="assistant",
             tool_calls=[tool_call],
         )
-    elif isinstance(item, ResponseReasoningItem):
+    if isinstance(item, ResponseReasoningItem):
         reasoning = ""
         if item.encrypted_content:
             raise ValueError("Encrypted content is not supported.")
@@ -305,7 +324,10 @@ def _construct_message_from_response_item(
             "role": "assistant",
             "content": output_text,
         }
-    elif isinstance(item, ResponseFunctionToolCallOutputItem):
+    elif isinstance(
+        item,
+        (ResponseFunctionToolCallOutputItem, ResponseCustomToolCallOutputItem),
+    ):
         return ChatCompletionToolMessageParam(
             role="tool",
             content=item.output,


### PR DESCRIPTION
## Purpose

Fix Responses API multi-turn requests that resubmit `custom_tool_call` and `custom_tool_call_output` items.

`ResponsesRequest` validates these input items into `ResponseCustomToolCall` Pydantic models. The non-Harmony message conversion handled function tool models but allowed custom tool models to fall through into the chat message list. On the next item, `_construct_message_from_response_item` called `.get()` on the previous `ResponseCustomToolCall`, causing:

```text
AttributeError: 'ResponseCustomToolCall' object has no attribute 'get'
```

This change converts custom calls into the OpenAI chat message custom-tool representation and converts custom call outputs into tool messages. It preserves the custom tool name, freeform input, and call ID without coercing the call into a function tool.

The regression test covers the public conversion path with a `custom_tool_call -> custom_tool_call_output -> user message` sequence.

Duplicate checks searched open PRs for `ResponseCustomToolCall`, `custom tool history Responses API`, and `custom_tool_call_output Responses API`. No other PR addresses this history-conversion failure. Rechecked after #49724 and #49882: they address initial active custom-tool prompting and output classification on non-Harmony routes, choosing fail-fast rejection for unsupported tools; this PR handles resubmitted custom-tool history, so the scopes are complementary. #35905 concerns the ResponseStore abstraction, while #41834 only matched incidental model text and is unrelated.

No documentation update is needed because this fixes existing Responses API input handling without changing the public interface.

Model evaluation is not applicable. The change is a deterministic frontend protocol conversion and does not modify model weights, sampling, tokenization, tool parsing, or generated output. The focused conversion regression is the relevant validation.

AI assistance was used to diagnose the failure, prepare the focused implementation and test, run duplicate checks, and draft this description. The human submitter is responsible for reviewing and validating the change.

## Test Plan

Run the focused Responses utility regression test and frontend lint/format checks in a configured vLLM environment:

```bash
.venv/bin/python -m pytest -q tests/entrypoints/openai/responses/test_responses_utils.py::TestResponsesUtils::test_construct_input_messages_with_custom_tool_history
pre-commit run ruff-check --files vllm/entrypoints/openai/responses/utils.py tests/entrypoints/openai/responses/test_responses_utils.py
pre-commit run ruff-format --files vllm/entrypoints/openai/responses/utils.py tests/entrypoints/openai/responses/test_responses_utils.py
git diff --check
```

## Test Result

Before the fix, the minimized conversion path reproduced:

```text
AttributeError: 'ResponseCustomToolCall' object has no attribute 'get'
```

After the fix, the same path produced the expected assistant custom tool call, tool result, and user message.

```text
PASS: custom tool history converted to chat messages
All checks passed!
2 files already formatted
```

After rebasing onto the current `main`, the complete Responses utility test file passed in a Python 3.12 `VLLM_TARGET_DEVICE=empty` environment:

```text
41 passed
```

Ruff check, Ruff format check, and `git diff --check` also passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] No documentation update is needed for this bug fix.
</details>
