### PR TITLE
[DO NOT REVIEW][Kernel][Helion] Eager call-site routing for per_token_group_fp8_quant

### DIFF
--- a/tests/kernels/helion/test_per_token_group_fp8_quant.py
+++ b/tests/kernels/helion/test_per_token_group_fp8_quant.py
@@ -220,6 +220,48 @@ class TestPerTokenGroupFp8QuantCorrectness:
 
 
 class TestPerTokenGroupFp8QuantIntegration:
+    def test_eager_route_without_legacy_callsite_router(self, monkeypatch):
+        from unittest.mock import Mock
+
+        from vllm.kernels.helion import routing
+
+        eager_kernel = Mock()
+        monkeypatch.setattr(routing, "_PTG_ROUTER", None)
+        monkeypatch.setattr(
+            routing, "use_helion_per_token_group_fp8_quant", lambda: True
+        )
+        monkeypatch.setattr(routing, "_checked_eager_kernel", lambda _: eager_kernel)
+
+        input = torch.empty((4, 128))
+        output_q = torch.empty_like(input)
+        output_s = torch.empty((4, 1))
+        launched = routing.try_launch_per_token_group_fp8_quant(
+            input,
+            output_q,
+            output_s,
+            128,
+            1e-10,
+            -448.0,
+            448.0,
+            False,
+            False,
+            False,
+        )
+
+        assert launched
+        eager_kernel.assert_called_once_with(
+            input,
+            output_q,
+            output_s,
+            128,
+            1e-10,
+            -448.0,
+            448.0,
+            False,
+            False,
+            False,
+        )
+
     def test_kernel_registration_integration(self):
         from vllm.kernels.helion.register import get_registered_kernels
 

--- a/tests/kernels/helion/test_utils.py
+++ b/tests/kernels/helion/test_utils.py
@@ -15,6 +15,7 @@ from vllm.kernels.helion.utils import canonicalize_gpu_name
         ("NVIDIA H100 80GB HBM3", "nvidia_h100"),
         ("NVIDIA H100 PCIe", "nvidia_h100"),
         ("NVIDIA H100 SXM5", "nvidia_h100"),
+        ("NVIDIA GB200", "nvidia_b200"),
         ("NVIDIA GeForce RTX 4090", "nvidia_geforce_rtx_4090"),
         ("AMD Instinct MI300X", "amd_instinct_mi300x"),
         ("AMD Instinct MI250X / MI250", "amd_instinct_mi250x_mi250"),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -185,6 +185,7 @@ if TYPE_CHECKING:
     VLLM_TPU_BUCKET_PADDING_GAP: int = 0
     VLLM_TPU_MOST_MODEL_LEN: int | None = None
     VLLM_TPU_USING_PATHWAYS: bool = False
+    VLLM_USE_HELION_KERNELS: bool = True
     VLLM_USE_DEEP_GEMM: bool = True
     VLLM_MOE_USE_DEEP_GEMM: bool = True
     VLLM_USE_DEEP_GEMM_E8M0: bool = True
@@ -1495,6 +1496,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Whether using Pathways
     "VLLM_TPU_USING_PATHWAYS": lambda: bool(
         "proxy" in os.getenv("JAX_PLATFORMS", "").lower()
+    ),
+    # Use Helion kernels when the `helion` package is installed.
+    "VLLM_USE_HELION_KERNELS": lambda: bool(
+        int(os.getenv("VLLM_USE_HELION_KERNELS", "1"))
     ),
     # Allow use of DeepGemm kernels for fused moe ops.
     "VLLM_USE_DEEP_GEMM": lambda: bool(int(os.getenv("VLLM_USE_DEEP_GEMM", "1"))),

--- a/vllm/kernels/helion/__init__.py
+++ b/vllm/kernels/helion/__init__.py
@@ -15,6 +15,7 @@ from vllm.kernels.helion.register import (
     get_registered_kernels,
     register_kernel,
     vllm_helion_lib,
+    warmup_registered_kernels,
 )
 from vllm.kernels.helion.utils import canonicalize_gpu_name, get_canonical_gpu_name
 
@@ -31,6 +32,7 @@ __all__ = [
     "get_registered_kernels",
     "register_kernel",
     "vllm_helion_lib",
+    "warmup_registered_kernels",
     # Utilities
     "canonicalize_gpu_name",
     "get_canonical_gpu_name",

--- a/vllm/kernels/helion/configs/per_token_group_fp8_quant/nvidia_h100.json
+++ b/vllm/kernels/helion/configs/per_token_group_fp8_quant/nvidia_h100.json
@@ -1841,8 +1841,7 @@
       ],
       "atomic_indexing": [],
       "pid_type": "persistent_interleaved",
-      "num_sm_multiplier": 128,
-      "maxnreg": 256
+      "num_sm_multiplier": 128
     }
   },
   {

--- a/vllm/kernels/helion/ops/per_token_group_fp8_quant.py
+++ b/vllm/kernels/helion/ops/per_token_group_fp8_quant.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections.abc import Iterable
 from itertools import product
 from typing import Any
 
@@ -77,6 +78,97 @@ def generate_inputs() -> dict[CaseKey, tuple[Any, ...]]:
         )
 
     return inputs
+
+
+def generate_warmup_inputs(
+    config_keys: list[CaseKey],
+    max_num_batched_tokens: int | None,
+    hidden_sizes: list[int] | None,
+) -> Iterable[tuple[Any, ...]]:
+    """Yield eager warmup inputs for every tuned PTG bucket in active configs."""
+
+    in_dtype: torch.dtype = torch.bfloat16
+    out_dtype: torch.dtype = current_platform.fp8_dtype()
+    scale_dtype: torch.dtype = torch.float32
+    fp8_min, fp8_max = get_fp8_min_max()
+    eps = 1e-10
+
+    group_num_tokens: dict[int, set[int]] = {}
+    for key in config_keys:
+        if key.is_default():
+            continue
+        group_num_tokens.setdefault(key["group_size"], set()).add(key["num_tokens"])
+
+    if hidden_sizes:
+        target_hidden_sizes = sorted(set(hidden_sizes))
+    else:
+        target_hidden_sizes = sorted(
+            {key["hidden_size"] for key in config_keys if not key.is_default()}
+        )
+
+    small_decode_limit = 32
+    if max_num_batched_tokens is not None:
+        small_decode_limit = min(small_decode_limit, max_num_batched_tokens)
+    small_decode_num_tokens = set(range(1, small_decode_limit + 1))
+
+    for hidden_size in target_hidden_sizes:
+        for group_size, num_tokens_set in sorted(group_num_tokens.items()):
+            if hidden_size % group_size != 0:
+                continue
+            groups_per_row = hidden_size // group_size
+            warm_num_tokens = set(num_tokens_set)
+            warm_num_tokens.update(small_decode_num_tokens)
+            # The column-major scale path builds tensor descriptors over
+            # output_s (stride (1, num_tokens)), so it specializes on whether
+            # num_tokens keeps that stride 16-byte aligned, i.e. on
+            # num_tokens % 4 == 0. Tuned buckets are all aligned, so without an
+            # unaligned representative the first (typically unaligned) prefill
+            # batch pays a JIT compile at request time. Prime an unaligned
+            # sibling for each aligned value so both classes are warm.
+            warm_num_tokens.update(
+                num_tokens - 1
+                for num_tokens in list(warm_num_tokens)
+                if num_tokens % 4 == 0 and num_tokens - 1 >= 1
+            )
+            if max_num_batched_tokens is not None:
+                warm_num_tokens = {
+                    num_tokens
+                    for num_tokens in warm_num_tokens
+                    if num_tokens <= max_num_batched_tokens
+                }
+            for selected_num_tokens in sorted(warm_num_tokens):
+                input = torch.randn(
+                    selected_num_tokens, hidden_size, device="cuda", dtype=in_dtype
+                )
+
+                for column_major_scales in (False, True):
+                    output_q = torch.empty(
+                        input.shape, device=input.device, dtype=out_dtype
+                    )
+                    if column_major_scales:
+                        output_s = torch.empty(
+                            (groups_per_row, selected_num_tokens),
+                            device=input.device,
+                            dtype=scale_dtype,
+                        ).permute(1, 0)
+                    else:
+                        output_s = torch.empty(
+                            (selected_num_tokens, groups_per_row),
+                            device=input.device,
+                            dtype=scale_dtype,
+                        )
+                    yield (
+                        input,
+                        output_q,
+                        output_s,
+                        group_size,
+                        eps,
+                        fp8_min,
+                        fp8_max,
+                        False,
+                        column_major_scales,
+                        False,
+                    )
 
 
 _pick_cache: dict[tuple[int, int, int], CaseKey | None] = {}
@@ -181,9 +273,12 @@ def baseline(
     mutates_args=["output_q", "output_s"],
     config_picker=pick_config,
     input_generator=generate_inputs,
+    warmup_input_generator=generate_warmup_inputs,
     fake_impl=fake_impl,
     helion_settings=helion.Settings(
         autotune_baseline_fn=baseline,
+        ignore_warnings=[helion.exc.ProcessGroupNameNotFound],
+        triton_do_not_specialize_nonunit_strides=True,
     ),
 )  # type: ignore[misc]
 def per_token_group_fp8_quant(

--- a/vllm/kernels/helion/ops/per_token_group_fp8_quant.py
+++ b/vllm/kernels/helion/ops/per_token_group_fp8_quant.py
@@ -278,7 +278,6 @@ def baseline(
     helion_settings=helion.Settings(
         autotune_baseline_fn=baseline,
         ignore_warnings=[helion.exc.ProcessGroupNameNotFound],
-        triton_do_not_specialize_nonunit_strides=True,
     ),
 )  # type: ignore[misc]
 def per_token_group_fp8_quant(

--- a/vllm/kernels/helion/register.py
+++ b/vllm/kernels/helion/register.py
@@ -38,7 +38,7 @@ Key Classes
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import Any
 
 import torch
@@ -80,6 +80,9 @@ logger = init_logger(__name__)
 vllm_helion_lib = Library("vllm_helion", "FRAGMENT")  # noqa
 
 ConfigPicker = Callable[[tuple[Any, ...], list[CaseKey]], CaseKey | None]
+WarmupInputGenerator = Callable[
+    [list[CaseKey], int | None, list[int] | None], Iterable[tuple[Any, ...]]
+]
 
 
 def validate_helion_settings(
@@ -263,6 +266,7 @@ class HelionKernelWrapper:
         mutates_args: list[str] | None = None,
         helion_settings: helion.Settings | None = None,
         input_generator: (Callable[[], dict[CaseKey, tuple[Any, ...]]] | None) = None,
+        warmup_input_generator: WarmupInputGenerator | None = None,
     ):
         # Validate helion_settings doesn't conflict with our custom autotuner
         validate_helion_settings(helion_settings, op_name)
@@ -273,6 +277,7 @@ class HelionKernelWrapper:
         self.helion_settings = helion_settings
         self._config_picker = config_picker
         self._input_generator = input_generator
+        self._warmup_input_generator = warmup_input_generator
         self._mutates_args = mutates_args
         self._configured_kernel: ConfiguredHelionKernel | None = None
         # TODO(@gmagogsfm): Remove this disable flag once integrated with vLLM IR,
@@ -349,6 +354,46 @@ class HelionKernelWrapper:
             )
         return self._configured_kernel
 
+    def eager_callable(self) -> Callable[..., Any]:
+        """Return the configured Helion kernel for eager/capture routing.
+
+        This bypasses the torch custom-op schema dispatch boundary, which is only
+        needed for compiled FX-swap paths and otherwise adds pure host overhead.
+        """
+        return self.get_configured_op()._decorated_kernel
+
+    def warmup_eager(
+        self,
+        *,
+        max_num_batched_tokens: int | None = None,
+        hidden_sizes: list[int] | None = None,
+    ) -> int:
+        """Compile and prime the eager launch path for representative inputs.
+
+        Kernels opt in by registering ``warmup_input_generator``. Warmup runs the
+        eager callable twice per input so the first iteration covers compilation
+        and the second primes Helion's fused-launch cache for repeat calls.
+        """
+        if self._disabled or self._warmup_input_generator is None:
+            return 0
+
+        configured_kernel = self.get_configured_op()
+        eager_kernel = configured_kernel._decorated_kernel
+        warmup_inputs = self._warmup_input_generator(
+            list(configured_kernel.configs.keys()),
+            max_num_batched_tokens,
+            hidden_sizes,
+        )
+
+        warmed = 0
+        with torch.inference_mode():
+            for args in warmup_inputs:
+                eager_kernel(*args)
+                eager_kernel(*args)
+                warmed += 1
+        torch.cuda.synchronize()
+        return warmed
+
     def _get_or_register_custom_op(self) -> Any:
         if hasattr(torch.ops.vllm_helion, self.op_name):
             return getattr(torch.ops.vllm_helion, self.op_name)
@@ -376,6 +421,28 @@ def get_registered_kernels() -> dict[str, HelionKernelWrapper]:
 
 def get_kernel_by_name(kernel_name: str) -> HelionKernelWrapper | None:
     return _REGISTERED_KERNELS.get(kernel_name)
+
+
+def warmup_registered_kernels(
+    *,
+    max_num_batched_tokens: int | None = None,
+    hidden_sizes: list[int] | None = None,
+) -> int:
+    """Warm registered Helion kernels that opt into eager startup warmup."""
+    warmed = 0
+    for kernel in _REGISTERED_KERNELS.values():
+        try:
+            warmed += kernel.warmup_eager(
+                max_num_batched_tokens=max_num_batched_tokens,
+                hidden_sizes=hidden_sizes,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Skipping Helion eager warmup for '%s': %s",
+                kernel.op_name,
+                exc,
+            )
+    return warmed
 
 
 def infer_fake_impl(
@@ -407,6 +474,7 @@ def register_kernel(
     mutates_args: list[str] | None = None,
     helion_settings: helion.Settings | None = None,
     input_generator: (Callable[[], dict[CaseKey, tuple[Any, ...]]] | None) = None,
+    warmup_input_generator: WarmupInputGenerator | None = None,
 ) -> Callable[[Callable], HelionKernelWrapper]:
     """Register a Helion kernel with pre-tuned config selection.
 
@@ -461,6 +529,7 @@ def register_kernel(
             mutates_args=mutates_args,
             helion_settings=helion_settings,
             input_generator=input_generator,
+            warmup_input_generator=warmup_input_generator,
         )
 
         _REGISTERED_KERNELS[final_op_name] = kernel_wrapper

--- a/vllm/kernels/helion/routing.py
+++ b/vllm/kernels/helion/routing.py
@@ -9,7 +9,7 @@ import importlib
 import sys
 import types
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 import torch
 
@@ -228,10 +228,14 @@ class _RoutingModule(types.ModuleType):
             return
         if name == "_PTG_FAST_LAST":
             router.fast_last = value
-            _remember_last_alias(router.fast_recent, value)
+            _remember_last_alias(
+                router.fast_recent, cast("tuple[Any, ...] | None", value)
+            )
         elif name == "_PTG_CPP_LAST":
             router.cpp_last = value
-            _remember_last_alias(router.cpp_recent, value)
+            _remember_last_alias(
+                router.cpp_recent, cast("tuple[Any, ...] | None", value)
+            )
 
 
 sys.modules[__name__].__class__ = _RoutingModule
@@ -251,11 +255,7 @@ def try_launch_per_token_group_fp8_quant(
     dimensions: tuple[int, int] | None = None,
 ) -> bool:
     """Fast Helion route for vLLM's 2D per-token-group FP8 quant call site."""
-    if (
-        _PTG_ROUTER is None
-        or not use_helion_per_token_group_fp8_quant()
-        or not output_q.is_contiguous()
-    ):
+    if not use_helion_per_token_group_fp8_quant() or not output_q.is_contiguous():
         return False
 
     full_args = (
@@ -273,6 +273,13 @@ def try_launch_per_token_group_fp8_quant(
     dimensions = dimensions if dimensions is not None else _ptg_dimensions(input)
     if dimensions is None:
         return False
+
+    if _PTG_ROUTER is None:
+        kernel = _checked_eager_kernel(_PTG_OP_NAME)
+        if kernel is None:
+            return False
+        kernel(*full_args)
+        return True
 
     fast_key = _ptg_fast_cache_key(*full_args, dimensions=dimensions)
     if _PTG_ROUTER.try_recent_cpp(full_args):

--- a/vllm/kernels/helion/routing.py
+++ b/vllm/kernels/helion/routing.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Call-site routing for eager Helion quant ops."""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import sys
+import types
+from collections.abc import Callable
+from typing import Any
+
+import torch
+
+import vllm.envs as envs
+from vllm.logger import init_logger
+from vllm.utils.deep_gemm import get_tma_aligned_size
+
+logger = init_logger(__name__)
+_is_compiling = torch.compiler.is_compiling
+
+_PTG_OP_NAME = "per_token_group_fp8_quant"
+_ROUTABLE_EAGER_OPS = frozenset({_PTG_OP_NAME})
+
+
+@functools.cache
+def _use_helion_kernels() -> bool:
+    return envs.VLLM_USE_HELION_KERNELS
+
+
+@functools.cache
+def _helion_available(op_name: str) -> bool:
+    try:
+        importlib.import_module(f"vllm.kernels.helion.ops.{op_name}")
+        from vllm.kernels.helion.register import _HOP_AVAILABLE
+
+        ready = (not _HOP_AVAILABLE) and hasattr(torch.ops.vllm_helion, op_name)
+    except Exception:
+        ready = False
+    if not ready:
+        logger.warning_once(
+            "VLLM_USE_HELION_KERNELS is set but Helion kernels are not available "
+            "for '%s'; falling back to the native kernel. Install the `helion` "
+            "package to enable them.",
+            op_name,
+        )
+    return ready
+
+
+@functools.cache
+def _eager_kernel(op_name: str) -> Callable[..., Any]:
+    from vllm.kernels.helion import get_kernel_by_name
+
+    kernel = get_kernel_by_name(op_name)
+    if kernel is None:
+        raise RuntimeError(f"Helion kernel '{op_name}' is not registered")
+    return kernel.eager_callable()
+
+
+@functools.cache
+def _checked_eager_kernel(op_name: str) -> Callable[..., Any] | None:
+    if _helion_available(op_name):
+        return _eager_kernel(op_name)
+    return None
+
+
+def use_helion_per_token_group_fp8_quant() -> bool:
+    return _use_helion_kernels() and not _is_compiling()
+
+
+def _ptg_dimensions(input: torch.Tensor) -> tuple[int, int] | None:
+    if input.__class__ is not torch.Tensor:
+        return None
+    shape = input.shape
+    if len(shape) != 2:
+        return None
+    return shape[0], shape[1]
+
+
+def _ptg_output_s_stride(
+    num_tokens: int,
+    hidden_size: int,
+    group_size: int,
+    scale_transposed: bool,
+    tma_aligned: bool,
+) -> tuple[int, int]:
+    groups_per_row = hidden_size // group_size
+    if scale_transposed:
+        tma_aligned_m = (
+            get_tma_aligned_size(num_tokens, 4) if tma_aligned else num_tokens
+        )
+        return (1, tma_aligned_m)
+    return (groups_per_row, 1)
+
+
+def _ptg_fast_cache_key(
+    input: torch.Tensor,
+    output_q: torch.Tensor,
+    output_s: torch.Tensor,
+    group_size: int,
+    eps: float,
+    fp8_min: float,
+    fp8_max: float,
+    scale_ue8m0: bool,
+    scale_transposed: bool,
+    tma_aligned: bool,
+    dimensions: tuple[int, int] | None = None,
+) -> tuple[Any, ...] | None:
+    if dimensions is None:
+        dimensions = _ptg_dimensions(input)
+        if dimensions is None:
+            return None
+    num_tokens, hidden_size = dimensions
+    if group_size <= 0 or hidden_size % group_size != 0:
+        return None
+    groups_per_row = hidden_size // group_size
+    if input.stride() != (hidden_size, 1) or output_q.stride() != (hidden_size, 1):
+        return None
+    if output_s.shape != (num_tokens, groups_per_row):
+        return None
+    expected_s_stride = _ptg_output_s_stride(
+        num_tokens, hidden_size, group_size, scale_transposed, tma_aligned
+    )
+    if output_s.stride() != expected_s_stride:
+        return None
+    if (input.data_ptr() | output_q.data_ptr() | output_s.data_ptr()) & 15:
+        return None
+    return (
+        num_tokens,
+        hidden_size,
+        input.dtype,
+        input.device,
+        output_q.dtype,
+        output_s.dtype,
+        group_size,
+        eps,
+        fp8_min,
+        fp8_max,
+        scale_ue8m0,
+        scale_transposed,
+        tma_aligned,
+    )
+
+
+def _ptg_cache_key(
+    input: torch.Tensor,
+    output_q: torch.Tensor,
+    output_s: torch.Tensor,
+    group_size: int,
+    eps: float,
+    fp8_min: float,
+    fp8_max: float,
+    scale_ue8m0: bool,
+    scale_transposed: bool,
+    tma_aligned: bool,
+    dimensions: tuple[int, int] | None = None,
+) -> tuple[Any, ...] | None:
+    fast_key = _ptg_fast_cache_key(
+        input,
+        output_q,
+        output_s,
+        group_size,
+        eps,
+        fp8_min,
+        fp8_max,
+        scale_ue8m0,
+        scale_transposed,
+        tma_aligned,
+        dimensions,
+    )
+    if fast_key is None:
+        return None
+    return (*fast_key[:6], output_s.stride(), *fast_key[6:])
+
+
+def _ptg_fast_key_from_args(*args: object) -> tuple[Any, ...] | None:
+    return _ptg_fast_cache_key(*args)  # type: ignore[arg-type]
+
+
+try:
+    from helion.runtime import FusedCallsiteRouter
+
+    _PTG_ROUTER = FusedCallsiteRouter()
+except Exception:
+    _PTG_ROUTER = None
+
+# Compatibility aliases used by the launch-overhead benchmark. The owning
+# implementation lives in Helion's FusedCallsiteRouter.
+_PTG_LAUNCH_CACHE: dict[Any, Any] = (
+    {} if _PTG_ROUTER is None else _PTG_ROUTER.launch_cache
+)
+_PTG_FAST_LAUNCH_CACHE: dict[Any, Any] = (
+    {} if _PTG_ROUTER is None else _PTG_ROUTER.fast_launch_cache
+)
+_PTG_CPP_LAUNCH_CACHE: dict[Any, Any] = (
+    {} if _PTG_ROUTER is None else _PTG_ROUTER.cpp_launch_cache
+)
+_PTG_FAST_LAST: tuple[Any, ...] | None = None
+_PTG_CPP_LAST: tuple[Any, ...] | None = None
+
+
+def _remember_last_alias(
+    recent: list[tuple[Any, ...]],
+    entry: tuple[Any, ...] | None,
+) -> None:
+    if entry is None:
+        recent.clear()
+        return
+    if entry not in recent:
+        recent.insert(0, entry)
+
+
+class _RoutingModule(types.ModuleType):
+    def __getattribute__(self, name: str) -> object:
+        if name in {"_PTG_FAST_LAST", "_PTG_CPP_LAST"}:
+            router = types.ModuleType.__getattribute__(self, "_PTG_ROUTER")
+            if router is not None:
+                if name == "_PTG_FAST_LAST":
+                    return router.fast_last
+                return router.cpp_last
+        return super().__getattribute__(name)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        super().__setattr__(name, value)
+        router = self.__dict__.get("_PTG_ROUTER")
+        if router is None:
+            return
+        if name == "_PTG_FAST_LAST":
+            router.fast_last = value
+            _remember_last_alias(router.fast_recent, value)
+        elif name == "_PTG_CPP_LAST":
+            router.cpp_last = value
+            _remember_last_alias(router.cpp_recent, value)
+
+
+sys.modules[__name__].__class__ = _RoutingModule
+
+
+def try_launch_per_token_group_fp8_quant(
+    input: torch.Tensor,
+    output_q: torch.Tensor,
+    output_s: torch.Tensor,
+    group_size: int,
+    eps: float,
+    fp8_min: float,
+    fp8_max: float,
+    scale_ue8m0: bool,
+    scale_transposed: bool,
+    tma_aligned: bool,
+    dimensions: tuple[int, int] | None = None,
+) -> bool:
+    """Fast Helion route for vLLM's 2D per-token-group FP8 quant call site."""
+    if (
+        _PTG_ROUTER is None
+        or not use_helion_per_token_group_fp8_quant()
+        or not output_q.is_contiguous()
+    ):
+        return False
+
+    full_args = (
+        input,
+        output_q,
+        output_s,
+        group_size,
+        eps,
+        fp8_min,
+        fp8_max,
+        scale_ue8m0,
+        scale_transposed,
+        tma_aligned,
+    )
+    dimensions = dimensions if dimensions is not None else _ptg_dimensions(input)
+    if dimensions is None:
+        return False
+
+    fast_key = _ptg_fast_cache_key(*full_args, dimensions=dimensions)
+    if _PTG_ROUTER.try_recent_cpp(full_args):
+        return True
+
+    cache_key = _ptg_cache_key(*full_args, dimensions=dimensions)
+    kernel = _checked_eager_kernel(_PTG_OP_NAME)
+    if kernel is None:
+        return False
+
+    return _PTG_ROUTER.try_launch(
+        kernel,
+        full_args,
+        cache_key=cache_key,
+        fast_key=fast_key,
+        fast_key_fn=_ptg_fast_key_from_args,
+        tensor_args=(input, output_q, output_s),
+    )
+
+
+def route_quant(op_name: str, fn: Callable[..., Any], *args: object) -> Any:
+    if (
+        op_name in _ROUTABLE_EAGER_OPS
+        and _use_helion_kernels()
+        and not _is_compiling()
+        and (kernel := _checked_eager_kernel(op_name)) is not None
+    ):
+        return kernel(*args)
+    return fn(*args)

--- a/vllm/kernels/helion/utils.py
+++ b/vllm/kernels/helion/utils.py
@@ -24,6 +24,8 @@ logger = init_logger(__name__)
 # to see the normalized name, then add a mapping here if it contains variant
 # suffixes that should be stripped (e.g. Blackwell/Rubin variants).
 _GPU_NAME_ALIASES: dict[str, str] = {
+    # Grace Blackwell reports the superchip name for its B200 GPU.
+    "nvidia_gb200": "nvidia_b200",
     # H100 variants
     "nvidia_h100_pcie": "nvidia_h100",
     "nvidia_h100_sxm5": "nvidia_h100",

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -12,6 +12,7 @@ import torch
 
 import vllm.envs as envs
 from vllm import _custom_ops as ops
+from vllm.kernels.helion import routing as helion_routing
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     get_fp8_min_max,
@@ -635,6 +636,19 @@ def per_token_group_quant_fp8(
     if (
         current_platform.is_cuda_alike() or current_platform.is_xpu()
     ) and x.is_contiguous():
+        if helion_routing.try_launch_per_token_group_fp8_quant(
+            x,
+            x_q,
+            x_s,
+            group_size,
+            eps,
+            fp8_min,
+            fp8_max,
+            use_ue8m0,
+            column_major_scales,
+            tma_aligned_scales,
+        ):
+            return x_q, x_s
         torch.ops._C.per_token_group_fp8_quant(
             x,
             x_q,

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -12,7 +12,6 @@ import torch
 
 import vllm.envs as envs
 from vllm import _custom_ops as ops
-from vllm.kernels.helion import routing as helion_routing
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     get_fp8_min_max,
@@ -34,10 +33,24 @@ from vllm.utils.deep_gemm import (
     is_deep_gemm_e8m0_used,
     transform_sf_into_required_layout,
 )
+from vllm.utils.import_utils import has_helion
 from vllm.utils.platform_utils import get_device_name_as_file_name
 from vllm.utils.torch_utils import direct_register_custom_op
 
 logger = init_logger(__name__)
+
+
+@functools.cache
+def _get_helion_routing() -> Any | None:
+    if not has_helion():
+        logger.warning_once(
+            "VLLM_USE_HELION_KERNELS is set but Helion is not installed; "
+            "falling back to native kernels."
+        )
+        return None
+    from vllm.kernels.helion import routing
+
+    return routing
 
 
 def is_fp8(x: torch.dtype | torch.Tensor) -> bool:
@@ -636,19 +649,23 @@ def per_token_group_quant_fp8(
     if (
         current_platform.is_cuda_alike() or current_platform.is_xpu()
     ) and x.is_contiguous():
-        if helion_routing.try_launch_per_token_group_fp8_quant(
-            x,
-            x_q,
-            x_s,
-            group_size,
-            eps,
-            fp8_min,
-            fp8_max,
-            use_ue8m0,
-            column_major_scales,
-            tma_aligned_scales,
-        ):
-            return x_q, x_s
+        if envs.VLLM_USE_HELION_KERNELS:
+            helion_routing = _get_helion_routing()
+            if helion_routing is not None and (
+                helion_routing.try_launch_per_token_group_fp8_quant(
+                    x,
+                    x_q,
+                    x_s,
+                    group_size,
+                    eps,
+                    fp8_min,
+                    fp8_max,
+                    use_ue8m0,
+                    column_major_scales,
+                    tma_aligned_scales,
+                )
+            ):
+                return x_q, x_s
         torch.ops._C.per_token_group_fp8_quant(
             x,
             x_q,

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -6,6 +6,7 @@ This is useful specifically for JIT'ed kernels as we don't want JIT'ing to
 happen during model execution.
 """
 
+import contextlib
 from typing import TYPE_CHECKING
 
 import torch
@@ -68,6 +69,21 @@ def _warmup_ll_bf16_router_gemm() -> None:
     )
 
 
+def _collect_fp8_linear_input_dims(model: torch.nn.Module) -> list[int]:
+    """Collect input widths of FP8 linear weights used by the loaded model."""
+    fp8_dtype = current_platform.fp8_dtype()
+    hidden_sizes: set[int] = set()
+    for module in model.modules():
+        weight = getattr(module, "weight", None)
+        if (
+            isinstance(weight, torch.Tensor)
+            and weight.ndim == 2
+            and weight.dtype == fp8_dtype
+        ):
+            hidden_sizes.add(int(weight.shape[1]))
+    return sorted(hidden_sizes)
+
+
 def kernel_warmup(worker: "Worker"):
     from vllm.model_executor.warmup.minimax_m3_msa_warmup import (
         minimax_m3_msa_warmup,
@@ -121,6 +137,22 @@ def kernel_warmup(worker: "Worker"):
 
     if current_platform.has_device_capability(90):
         _warmup_ll_bf16_router_gemm()
+
+    if envs.VLLM_USE_HELION_KERNELS:
+        from vllm.kernels.helion import warmup_registered_kernels
+
+        warmup_hidden_sizes = None
+        with contextlib.suppress(Exception):
+            warmup_hidden_sizes = _collect_fp8_linear_input_dims(worker.get_model())
+        warmed_helion_kernels = warmup_registered_kernels(
+            max_num_batched_tokens=worker.scheduler_config.max_num_batched_tokens,
+            hidden_sizes=warmup_hidden_sizes,
+        )
+        if warmed_helion_kernels:
+            logger.info(
+                "Warmed up %d Helion eager kernel input variants.",
+                warmed_helion_kernels,
+            )
 
     # FlashInfer attention warmup
     # Only warmup if the model has FlashInfer attention groups


### PR DESCRIPTION
## Summary

Routes vLLM's `per_token_group_quant_fp8` call site to a Helion kernel in the **eager / non-CUDA-graph path**, where the torch custom-op dispatch boundary is pure per-call host overhead. A generic `FusedCallsiteRouter` caches and replays guarded C++ launchers so warmed calls take a single Python→C++ hop.

Kernels opt into startup warmup via a `warmup_input_generator`. For `per_token_group_fp8_quant` the generator primes both `num_tokens` alignment classes per tuned config bucket. The column-major scale path builds tensor descriptors over `output_s` (stride `(1, num_tokens)`), which specializes on whether that stride stays 16-byte aligned (`num_tokens % 4 == 0`). Tuned buckets are all aligned, so without an unaligned representative the first (typically unaligned) prefill batch paid a **Helion JIT compile at request time** — a large one-time TTFT spike.

```
  Server

  VLLM_USE_HELION_KERNELS={1|0} \
  VLLM_USE_DEEP_GEMM=0 \
  VLLM_DISABLE_COMPILE_CACHE=1 \
  CUDA_VISIBLE_DEVICES=0 \
  .venv/bin/python -m vllm.entrypoints.cli.main serve \
    Qwen/Qwen3-8B-FP8 \
    --enforce-eager \
    --no-enable-prefix-caching \
    --port 8000

  Helion and native each used a fresh server. Prefix caching was disabled, and server startup/warmup time was excluded.

  Client

  .venv/bin/python -m vllm.entrypoints.cli.main bench serve \
    --backend openai \
    --base-url http://127.0.0.1:8000 \
    --model Qwen/Qwen3-8B-FP8 \
    --dataset-name random \
    --input-len 256 \
    --output-len 128 \
    --num-prompts 20 \
    --request-rate inf

  I ran four consecutive clients per server and took the median of the reported Output token throughput, calculated as generated tokens divided by benchmark duration.

      Run    Helion    Native
  ━━━━━━━━  ━━━━━━━━  ━━━━━━━━
        1    471.07    461.60
  ────────  ────────  ────────
        2    463.55    459.08
  ────────  ────────  ────────
        3    464.91    477.22
  ────────  ────────  ────────
        4    524.79    464.10
  ────────  ────────  ────────
   Median    467.99    462.85

  This was on one NVIDIA GB200 (sm_100) using Helion 20760768. 
  ```