### PR TITLE
[WIP] Extend benchmark moe to support more models

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -6,6 +6,7 @@ import gc
 import json
 import os
 import time
+from collections.abc import Iterable
 from contextlib import nullcontext
 from datetime import datetime
 from itertools import product
@@ -748,6 +749,118 @@ def get_weight_block_size_safety(config, default_value=None):
     return default_value
 
 
+# Nested config locations to probe for MoE fields (after the root config).
+# "get_text_config" is a method; the others are attribute names.
+_CONFIG_VIEWS = (
+    "get_text_config",
+    "text_config",
+    "ffn_config",
+    "thinker_config",
+)
+
+# Logical MoE dims -> HF attribute aliases.
+_MOE_FIELDS = {
+    "num_experts": (
+        "num_experts",
+        "n_routed_experts",
+        "num_local_experts",
+        "moe_num_experts",
+    ),
+    "topk": (
+        "moe_topk",
+        "num_experts_per_tok",
+        "top_k_experts",
+        "moe_top_k",
+    ),
+    "intermediate_size": (
+        "moe_intermediate_size",
+        "intermediate_size",
+        "ffn_hidden_size",
+    ),
+    "hidden_size": ("hidden_size",),
+}
+
+
+def _first_moe_value(value: Any) -> Any:
+    """List-valued MoE fields (e.g. per-layer moe_topk) use the first entry."""
+    if isinstance(value, (list, tuple)):
+        if not value:
+            raise AttributeError("empty MoE list field")
+        return value[0]
+    return value
+
+
+def _get_moe_attrs(obj: Any) -> dict[str, Any]:
+    attrs: dict[str, Any] = {}
+    for key, aliases in _MOE_FIELDS.items():
+        present = [
+            (alias, value)
+            for alias in aliases
+            if (value := getattr(obj, alias, None)) is not None
+        ]
+        if not present:
+            continue
+        if len(present) > 1 and key in ("num_experts", "topk"):
+            detail = ", ".join(f"{alias}={value}" for alias, value in present)
+            print(
+                f"WARNING: ambiguous MoE field '{key}': "
+                f"multiple aliases set ({detail}), using the first one",
+                flush=True,
+            )
+        attrs[key] = present[0][1]
+    return attrs
+
+
+def _resolve_config_view(config: Any, name: str) -> Any | None:
+    attr = getattr(config, name, None)
+    if callable(attr):
+        try:
+            return attr()
+        except Exception:
+            return None
+    return attr
+
+
+def _iter_config_views(config: Any) -> Iterable[Any]:
+    yield config
+    seen: set[int] = set()
+    for view in _CONFIG_VIEWS:
+        view = _resolve_config_view(config, view)
+        if view is None:
+            continue
+        if id(view) in seen:
+            continue
+        seen.add(id(view))
+        yield view
+
+
+def extract_moe_shape_from_hf_config(config: Any) -> tuple[int, int, int, int]:
+    incomplete: list[str] = []
+    for view in _iter_config_views(config):
+        attrs = _get_moe_attrs(view)
+        if not attrs:
+            continue
+        if set(attrs) != set(_MOE_FIELDS):
+            missing = [k for k in _MOE_FIELDS if k not in attrs]
+            incomplete.append(
+                f"{type(view).__name__} missing {missing}: "
+                + ", ".join(f"{k}={attrs.get(k)}" for k in _MOE_FIELDS)
+            )
+            continue
+        return (
+            int(_first_moe_value(attrs["num_experts"])),
+            int(_first_moe_value(attrs["topk"])),
+            int(_first_moe_value(attrs["intermediate_size"])),
+            int(_first_moe_value(attrs["hidden_size"])),
+        )
+
+    if incomplete:
+        raise ValueError(
+            "incomplete MoE fields (no complete config view): " + "; ".join(incomplete)
+        )
+    raise AttributeError("HF config missing MoE shape fields")
+
+
 def get_model_params(config):
     architectures = getattr(config, "architectures", None) or [type(config).__name__]
     architecture = architectures[0]
@@ -816,13 +929,17 @@ def get_model_params(config):
         # recurse to get their parameters
         return get_model_params(config.get_text_config())
     else:
-        # Support for llama4
-        config = config.get_text_config()
-        # Default: Mixtral.
-        E = config.num_local_experts
-        topk = config.num_experts_per_tok
-        intermediate_size = config.intermediate_size
-        hidden_size = config.hidden_size
+        # Generic HF MoE schema: Mixtral / Llama4 / omni MoE configs / etc.
+        E, topk, intermediate_size, hidden_size = extract_moe_shape_from_hf_config(
+            config
+        )
+
+    print(
+        f"[benchmark_moe] arch={architecture} "
+        f"E={E} topk={topk} intermediate={intermediate_size} "
+        f"hidden={hidden_size}",
+        flush=True,
+    )
     return E, topk, intermediate_size, hidden_size
 
 


### PR DESCRIPTION



## Purpose
### Summary
benchmark_moe.py resolves MoE shapes (E, topk, intermediate_size, hidden_size) from an architecture name table. Unknown MoE models (e.g. multimodal / omni configs like HunyuanImage3) fall into the Mixtral-only else branch and crash on missing fields such as num_local_experts.

This PR keeps the existing architecture table, and replaces the hard-coded Mixtral fallback with a small HF-config schema lookup.

### What changed
+ Probe common config views (root, get_text_config, text_config, ffn_config, thinker_config).
+ Map logical MoE dims to known HF attribute aliases.
+ Prefer moe_intermediate_size when both dense and MoE intermediate sizes are present.
## Test Plan
Origin model: `Mixtral` / `Llama4`
New model: `LongcatFlashForCausalLM`, `tencent/HunyuanImage-3.0-Instruct`
## Test Result
| Model | arch | E | topk | intermediate | hidden |
|------|------|---|------|--------------|--------|
| Mixtral-8x7B-Instruct | `MixtralForCausalLM` | 8 | 2 | 14336 | 4096 |
| Llama-4-Scout | `Llama4ForConditionalGeneration` | 16 | 1 | 8192 | 5120 |
| LongCat-Flash-Chat |`LongcatFlashForCausalLM` | 512 | 12 | 12288 | 6144 |
| HunyuanImage-3.0-Instruct | `HunyuanImage3ForCausalMM` | 64 | 8 | 3072 | 4096 |
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

