### PR TITLE
[Kernel][Helion] Retune grouped quant schedules

### DIFF
--- a/vllm/kernels/helion/configs/per_token_group_fp8_quant/nvidia_b200.json
+++ b/vllm/kernels/helion/configs/per_token_group_fp8_quant/nvidia_b200.json
@@ -97,7 +97,7 @@
     },
     "config": {
       "block_sizes": [
-        16
+        8
       ],
       "loop_orders": [
         [
@@ -602,17 +602,17 @@
     },
     "config": {
       "block_sizes": [
-        8
+        16
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
       "l2_groupings": [
-        4
+        1
       ],
       "range_unroll_factors": [
         0
@@ -631,9 +631,9 @@
         ""
       ],
       "num_warps": 2,
-      "num_stages": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "tensor_descriptor"
       ],
@@ -1019,8 +1019,8 @@
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
@@ -1041,10 +1041,10 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
-      "num_warps": 2,
-      "num_stages": 8,
+      "num_warps": 4,
+      "num_stages": 1,
       "indexing": [
         "tensor_descriptor",
         "pointer",
@@ -1109,7 +1109,7 @@
     },
     "config": {
       "block_sizes": [
-        16
+        8
       ],
       "loop_orders": [
         [
@@ -1119,7 +1119,7 @@
         ]
       ],
       "l2_groupings": [
-        32
+        16
       ],
       "range_unroll_factors": [
         0
@@ -1135,12 +1135,12 @@
         null
       ],
       "load_eviction_policies": [
-        "first"
+        ""
       ],
       "num_warps": 2,
-      "num_stages": 2,
+      "num_stages": 1,
       "indexing": [
-        "pointer",
+        "tensor_descriptor",
         "tensor_descriptor",
         "tensor_descriptor"
       ],
@@ -1434,7 +1434,7 @@
     },
     "config": {
       "block_sizes": [
-        8
+        16
       ],
       "loop_orders": [
         [
@@ -1444,12 +1444,14 @@
         ]
       ],
       "l2_groupings": [
-        4
+        2
       ],
       "range_unroll_factors": [
         0
       ],
-      "range_warp_specializes": [],
+      "range_warp_specializes": [
+        null
+      ],
       "range_num_stages": [],
       "range_multi_buffers": [
         null
@@ -1460,12 +1462,12 @@
       "load_eviction_policies": [
         "first"
       ],
-      "num_warps": 2,
-      "num_stages": 6,
+      "num_warps": 16,
+      "num_stages": 7,
       "indexing": [
-        "pointer",
         "tensor_descriptor",
-        "pointer"
+        "pointer",
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -1626,12 +1628,14 @@
         ]
       ],
       "l2_groupings": [
-        1
+        32
       ],
       "range_unroll_factors": [
         0
       ],
-      "range_warp_specializes": [],
+      "range_warp_specializes": [
+        null
+      ],
       "range_num_stages": [],
       "range_multi_buffers": [
         null
@@ -1640,13 +1644,13 @@
         null
       ],
       "load_eviction_policies": [
-        "first"
+        "last"
       ],
       "num_warps": 4,
       "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
+        "tensor_descriptor",
         "tensor_descriptor"
       ],
       "atomic_indexing": [],
@@ -1736,10 +1740,10 @@
       "load_eviction_policies": [
         ""
       ],
-      "num_warps": 1,
+      "num_warps": 2,
       "num_stages": 1,
       "indexing": [
-        "pointer",
+        "tensor_descriptor",
         "tensor_descriptor",
         "tensor_descriptor"
       ],

--- a/vllm/kernels/helion/configs/per_token_group_fp8_quant/nvidia_h100.json
+++ b/vllm/kernels/helion/configs/per_token_group_fp8_quant/nvidia_h100.json
@@ -7,7 +7,7 @@
     },
     "config": {
       "block_sizes": [
-        4
+        8
       ],
       "loop_orders": [
         [
@@ -17,7 +17,7 @@
         ]
       ],
       "l2_groupings": [
-        64
+        8
       ],
       "range_unroll_factors": [
         0
@@ -31,10 +31,10 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
       "num_warps": 2,
-      "num_stages": 8,
+      "num_stages": 4,
       "indexing": [
         "pointer",
         "tensor_descriptor",
@@ -52,17 +52,17 @@
     },
     "config": {
       "block_sizes": [
-        4
+        8
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
       "l2_groupings": [
-        4
+        8
       ],
       "range_unroll_factors": [
         0
@@ -76,12 +76,12 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 5,
+      "num_warps": 2,
+      "num_stages": 4,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
         "tensor_descriptor",
         "tensor_descriptor"
       ],
@@ -107,7 +107,7 @@
         ]
       ],
       "l2_groupings": [
-        2
+        8
       ],
       "range_unroll_factors": [
         0
@@ -121,14 +121,14 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 5,
+      "num_warps": 2,
+      "num_stages": 4,
       "indexing": [
         "pointer",
         "tensor_descriptor",
-        "pointer"
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -152,7 +152,7 @@
         ]
       ],
       "l2_groupings": [
-        2
+        8
       ],
       "range_unroll_factors": [
         0
@@ -166,14 +166,14 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 5,
+      "num_warps": 2,
+      "num_stages": 4,
       "indexing": [
         "pointer",
         "tensor_descriptor",
-        "pointer"
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -197,7 +197,7 @@
         ]
       ],
       "l2_groupings": [
-        2
+        8
       ],
       "range_unroll_factors": [
         0
@@ -211,14 +211,14 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 5,
+      "num_warps": 2,
+      "num_stages": 4,
       "indexing": [
         "pointer",
         "tensor_descriptor",
-        "pointer"
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -242,7 +242,7 @@
         ]
       ],
       "l2_groupings": [
-        2
+        8
       ],
       "range_unroll_factors": [
         0
@@ -256,14 +256,14 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 5,
+      "num_warps": 2,
+      "num_stages": 4,
       "indexing": [
         "pointer",
         "tensor_descriptor",
-        "pointer"
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -287,7 +287,7 @@
         ]
       ],
       "l2_groupings": [
-        2
+        8
       ],
       "range_unroll_factors": [
         0
@@ -301,14 +301,14 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 5,
+      "num_warps": 2,
+      "num_stages": 4,
       "indexing": [
         "pointer",
         "tensor_descriptor",
-        "pointer"
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -322,17 +322,17 @@
     },
     "config": {
       "block_sizes": [
-        4
+        8
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
       "l2_groupings": [
-        4
+        8
       ],
       "range_unroll_factors": [
         0
@@ -346,12 +346,12 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 4,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
         "tensor_descriptor",
         "tensor_descriptor"
       ],
@@ -377,7 +377,7 @@
         ]
       ],
       "l2_groupings": [
-        1
+        8
       ],
       "range_unroll_factors": [
         0
@@ -391,13 +391,13 @@
         null
       ],
       "load_eviction_policies": [
-        "first"
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 4,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
+        "tensor_descriptor",
         "tensor_descriptor"
       ],
       "atomic_indexing": [],
@@ -416,13 +416,13 @@
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
       "l2_groupings": [
-        4
+        8
       ],
       "range_unroll_factors": [
         0
@@ -436,14 +436,14 @@
         null
       ],
       "load_eviction_policies": [
-        "first"
+        "last"
       ],
       "num_warps": 2,
-      "num_stages": 6,
+      "num_stages": 4,
       "indexing": [
         "pointer",
         "tensor_descriptor",
-        "pointer"
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -461,13 +461,13 @@
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
       "l2_groupings": [
-        4
+        8
       ],
       "range_unroll_factors": [
         0
@@ -481,14 +481,14 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
       "num_warps": 2,
-      "num_stages": 3,
+      "num_stages": 4,
       "indexing": [
+        "pointer",
         "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -506,13 +506,13 @@
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
       "l2_groupings": [
-        4
+        8
       ],
       "range_unroll_factors": [
         0
@@ -526,14 +526,14 @@
         null
       ],
       "load_eviction_policies": [
-        "first"
+        "last"
       ],
       "num_warps": 2,
-      "num_stages": 6,
+      "num_stages": 4,
       "indexing": [
         "pointer",
         "tensor_descriptor",
-        "pointer"
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -596,13 +596,13 @@
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
       "l2_groupings": [
-        2
+        8
       ],
       "range_unroll_factors": [
         0
@@ -616,12 +616,12 @@
         null
       ],
       "load_eviction_policies": [
-        "first"
+        "last"
       ],
       "num_warps": 2,
       "num_stages": 4,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
         "tensor_descriptor",
         "tensor_descriptor"
       ],
@@ -772,7 +772,7 @@
     },
     "config": {
       "block_sizes": [
-        1
+        8
       ],
       "loop_orders": [
         [
@@ -782,7 +782,7 @@
         ]
       ],
       "l2_groupings": [
-        8
+        16
       ],
       "range_unroll_factors": [
         0
@@ -796,14 +796,14 @@
         null
       ],
       "load_eviction_policies": [
-        "first"
+        "last"
       ],
-      "num_warps": 1,
-      "num_stages": 8,
+      "num_warps": 2,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -866,13 +866,13 @@
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
       "l2_groupings": [
-        2
+        16
       ],
       "range_unroll_factors": [
         0
@@ -886,10 +886,10 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 6,
+      "num_warps": 2,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
@@ -956,13 +956,13 @@
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
       "l2_groupings": [
-        2
+        16
       ],
       "range_unroll_factors": [
         0
@@ -976,10 +976,10 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 6,
+      "num_warps": 2,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
@@ -1001,13 +1001,13 @@
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
       "l2_groupings": [
-        8
+        16
       ],
       "range_unroll_factors": [
         0
@@ -1021,13 +1021,13 @@
         null
       ],
       "load_eviction_policies": [
-        "first"
+        "last"
       ],
       "num_warps": 2,
-      "num_stages": 3,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer"
       ],
       "atomic_indexing": [],
@@ -1052,7 +1052,7 @@
         ]
       ],
       "l2_groupings": [
-        64
+        16
       ],
       "range_unroll_factors": [
         0
@@ -1066,13 +1066,13 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
       "num_warps": 2,
-      "num_stages": 5,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer"
       ],
       "atomic_indexing": [],
@@ -1132,7 +1132,7 @@
     },
     "config": {
       "block_sizes": [
-        16
+        8
       ],
       "loop_orders": [
         [
@@ -1156,14 +1156,14 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 6,
+      "num_warps": 2,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -1181,13 +1181,13 @@
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
       "l2_groupings": [
-        8
+        16
       ],
       "range_unroll_factors": [
         0
@@ -1201,14 +1201,14 @@
         null
       ],
       "load_eviction_policies": [
-        "first"
+        "last"
       ],
       "num_warps": 2,
-      "num_stages": 2,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -1312,13 +1312,13 @@
     },
     "config": {
       "block_sizes": [
-        1
+        8
       ],
       "loop_orders": [
         [
+          2,
           1,
-          0,
-          2
+          0
         ]
       ],
       "l2_groupings": [
@@ -1336,13 +1336,13 @@
         null
       ],
       "load_eviction_policies": [
-        "first"
+        "last"
       ],
-      "num_warps": 1,
+      "num_warps": 2,
       "num_stages": 4,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
+        "tensor_descriptor",
         "tensor_descriptor"
       ],
       "atomic_indexing": [],
@@ -1357,52 +1357,7 @@
     },
     "config": {
       "block_sizes": [
-        2
-      ],
-      "loop_orders": [
-        [
-          1,
-          2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "hidden_size": 5120,
-      "group_size": 128,
-      "num_tokens": 4
-    },
-    "config": {
-      "block_sizes": [
-        4
+        8
       ],
       "loop_orders": [
         [
@@ -1426,12 +1381,57 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
-      "num_warps": 4,
+      "num_warps": 2,
       "num_stages": 4,
       "indexing": [
+        "pointer",
         "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "hidden_size": 5120,
+      "group_size": 128,
+      "num_tokens": 4
+    },
+    "config": {
+      "block_sizes": [
+        8
+      ],
+      "loop_orders": [
+        [
+          2,
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
         "tensor_descriptor",
         "tensor_descriptor"
       ],
@@ -1492,7 +1492,7 @@
     },
     "config": {
       "block_sizes": [
-        4
+        8
       ],
       "loop_orders": [
         [
@@ -1502,7 +1502,7 @@
         ]
       ],
       "l2_groupings": [
-        32
+        8
       ],
       "range_unroll_factors": [
         0
@@ -1516,10 +1516,10 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 4,
       "indexing": [
         "pointer",
         "tensor_descriptor",
@@ -1547,7 +1547,7 @@
         ]
       ],
       "l2_groupings": [
-        2
+        8
       ],
       "range_unroll_factors": [
         0
@@ -1561,14 +1561,14 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 5,
+      "num_warps": 2,
+      "num_stages": 4,
       "indexing": [
         "pointer",
         "tensor_descriptor",
-        "pointer"
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -1586,13 +1586,13 @@
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
       "l2_groupings": [
-        16
+        8
       ],
       "range_unroll_factors": [
         0
@@ -1606,13 +1606,13 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 7,
+      "num_warps": 2,
+      "num_stages": 4,
       "indexing": [
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "tensor_descriptor"
       ],
       "atomic_indexing": [],
@@ -1676,8 +1676,8 @@
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
@@ -1696,14 +1696,14 @@
         null
       ],
       "load_eviction_policies": [
-        "first"
+        "last"
       ],
       "num_warps": 2,
-      "num_stages": 3,
+      "num_stages": 4,
       "indexing": [
         "pointer",
         "tensor_descriptor",
-        "pointer"
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -1721,13 +1721,13 @@
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
       "l2_groupings": [
-        32
+        8
       ],
       "range_unroll_factors": [
         0
@@ -1741,14 +1741,14 @@
         null
       ],
       "load_eviction_policies": [
-        ""
+        "last"
       ],
       "num_warps": 2,
-      "num_stages": 6,
+      "num_stages": 4,
       "indexing": [
         "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"

--- a/vllm/kernels/helion/configs/silu_and_mul_per_block_quant/nvidia_b200.json
+++ b/vllm/kernels/helion/configs/silu_and_mul_per_block_quant/nvidia_b200.json
@@ -314,12 +314,14 @@
         ]
       ],
       "l2_groupings": [
-        16
+        1
       ],
       "range_unroll_factors": [
         0
       ],
-      "range_warp_specializes": [],
+      "range_warp_specializes": [
+        null
+      ],
       "range_num_stages": [],
       "range_multi_buffers": [
         null
@@ -330,16 +332,16 @@
       "load_eviction_policies": [
         "",
         "",
-        "first"
+        ""
       ],
       "num_warps": 4,
-      "num_stages": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -960,7 +962,9 @@
       "range_unroll_factors": [
         0
       ],
-      "range_warp_specializes": [],
+      "range_warp_specializes": [
+        null
+      ],
       "range_num_stages": [],
       "range_multi_buffers": [
         null
@@ -969,16 +973,16 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
         "last",
-        ""
+        "last",
+        "last"
       ],
       "num_warps": 4,
-      "num_stages": 6,
+      "num_stages": 5,
       "indexing": [
+        "pointer",
+        "pointer",
         "tensor_descriptor",
-        "pointer",
-        "pointer",
         "tensor_descriptor",
         "pointer"
       ],
@@ -994,252 +998,7 @@
     },
     "config": {
       "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          1,
-          2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        32
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "first",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 3,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "intermediate_size": 6144,
-      "group_size": 128,
-      "num_tokens": 128
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
         8
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "intermediate_size": 12288,
-      "group_size": 128,
-      "num_tokens": 128
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          1,
-          2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        32
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "first",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 3,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "intermediate_size": 25600,
-      "group_size": 128,
-      "num_tokens": 128
-    },
-    "config": {
-      "block_sizes": [
-        8
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        16
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 2,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "intermediate_size": 6144,
-      "group_size": 128,
-      "num_tokens": 256
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "intermediate_size": 12288,
-      "group_size": 128,
-      "num_tokens": 256
-    },
-    "config": {
-      "block_sizes": [
-        16
       ],
       "loop_orders": [
         [
@@ -1265,8 +1024,59 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
         "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "group_size": 128,
+      "num_tokens": 128
+    },
+    "config": {
+      "block_sizes": [
+        4
+      ],
+      "loop_orders": [
+        [
+          2,
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
         "last"
       ],
       "num_warps": 4,
@@ -1274,6 +1084,206 @@
       "indexing": [
         "tensor_descriptor",
         "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "group_size": 128,
+      "num_tokens": 128
+    },
+    "config": {
+      "block_sizes": [
+        4
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "group_size": 128,
+      "num_tokens": 128
+    },
+    "config": {
+      "block_sizes": [
+        8
+      ],
+      "loop_orders": [
+        [
+          2,
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "group_size": 128,
+      "num_tokens": 256
+    },
+    "config": {
+      "block_sizes": [
+        4
+      ],
+      "loop_orders": [
+        [
+          2,
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "group_size": 128,
+      "num_tokens": 256
+    },
+    "config": {
+      "block_sizes": [
+        4
+      ],
+      "loop_orders": [
+        [
+          2,
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
         "pointer",
         "tensor_descriptor",
         "pointer"
@@ -1545,22 +1555,24 @@
     },
     "config": {
       "block_sizes": [
-        4
+        8
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
       "l2_groupings": [
-        32
+        8
       ],
       "range_unroll_factors": [
         0
       ],
-      "range_warp_specializes": [],
+      "range_warp_specializes": [
+        null
+      ],
       "range_num_stages": [],
       "range_multi_buffers": [
         null
@@ -1569,16 +1581,16 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
         "",
+        "last",
         "last"
       ],
-      "num_warps": 1,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 4,
       "indexing": [
         "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "tensor_descriptor",
         "pointer"
       ],

--- a/vllm/kernels/helion/configs/silu_and_mul_per_block_quant/nvidia_h100.json
+++ b/vllm/kernels/helion/configs/silu_and_mul_per_block_quant/nvidia_h100.json
@@ -850,7 +850,7 @@
         ]
       ],
       "l2_groupings": [
-        16
+        64
       ],
       "range_unroll_factors": [
         0
@@ -864,18 +864,18 @@
         null
       ],
       "load_eviction_policies": [
-        "",
+        "last",
         "first",
-        "last"
+        "first"
       ],
       "num_warps": 4,
-      "num_stages": 3,
+      "num_stages": 8,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "tensor_descriptor",
         "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -1144,7 +1144,7 @@
         ]
       ],
       "l2_groupings": [
-        2
+        16
       ],
       "range_unroll_factors": [
         0
@@ -1158,9 +1158,9 @@
         null
       ],
       "load_eviction_policies": [
+        "last",
         "first",
-        "first",
-        ""
+        "first"
       ],
       "num_warps": 4,
       "num_stages": 2,
@@ -1168,8 +1168,8 @@
         "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
-        "pointer"
+        "pointer",
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -1291,7 +1291,7 @@
         ]
       ],
       "l2_groupings": [
-        8
+        16
       ],
       "range_unroll_factors": [
         0
@@ -1305,18 +1305,18 @@
         null
       ],
       "load_eviction_policies": [
+        "last",
         "first",
-        "first",
-        ""
+        "first"
       ],
       "num_warps": 4,
-      "num_stages": 4,
+      "num_stages": 2,
       "indexing": [
+        "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
         "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"


### PR DESCRIPTION
Reuse stronger existing schedules for per-token group FP8 quant and selected SiLU per-block quant buckets.

Co-authored-by: OpenAI Codex <codex@openai.com>
Signed-off-by: Shangdi Yu <shangdiy@meta.com>




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

