### PR TITLE
[BugFix] Prefer per-spec cache_dtype_str when reshaping KV cache

### DIFF
--- a/tests/v1/worker/test_attn_utils.py
+++ b/tests/v1/worker/test_attn_utils.py
@@ -3,8 +3,15 @@
 
 import torch
 
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVQuantMode
-from vllm.v1.worker.gpu.attn_utils import _reshape_kv_cache
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVQuantMode,
+    MLAAttentionSpec,
+)
+from vllm.v1.worker.gpu.attn_utils import (
+    _reshape_kv_cache,
+    resolve_layer_kv_cache_dtype_str,
+)
 from vllm.v1.worker.utils import AttentionGroup
 
 
@@ -240,3 +247,107 @@ def test_reshape_padded_quantized_kv_cache_preserves_scale_stride():
     assert kv_cache.stride(0) == spec.page_size_bytes
     assert kv_cache.stride(1) == 16 * 1 * 8
     assert kv_cache[1, 1].storage_offset() == spec.page_size_bytes + 16 * 1 * 8
+
+
+class FakeFlashMLASparseBackend:
+    """Minimal FLASHMLA_SPARSE-like backend for fp8_ds_mla layout tests."""
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        # Mirrors FlashMLASparseBackend: packed 656-byte layout only when the
+        # layout string is fp8_ds_mla; otherwise falls back to head_size (576).
+        if cache_dtype_str == "fp8_ds_mla":
+            return (num_blocks, block_size, 656)
+        return (num_blocks, block_size, head_size)
+
+    @staticmethod
+    def get_kv_cache_stride_order(
+        include_num_layers_dimension: bool = False,
+    ) -> tuple[int, ...]:
+        assert not include_num_layers_dimension
+        return (0, 1, 2)
+
+
+def test_resolve_layer_kv_cache_dtype_str_prefers_mla_layout():
+    """MLA specs encode packed layout in cache_dtype_str even when
+    kv_quant_mode is NONE (the pre-#48379 state that crashed profiling).
+    """
+    spec = MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.uint8,
+        cache_dtype_str="fp8_ds_mla",
+        kv_quant_mode=KVQuantMode.NONE,
+    )
+    assert (
+        resolve_layer_kv_cache_dtype_str(spec, default_cache_dtype="fp8")
+        == "fp8_ds_mla"
+    )
+
+
+def test_resolve_layer_kv_cache_dtype_str_skip_layer_is_auto():
+    spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=64,
+        dtype=torch.float16,
+        kv_quant_mode=KVQuantMode.NONE,
+    )
+    assert resolve_layer_kv_cache_dtype_str(spec, default_cache_dtype="fp8") == "auto"
+
+
+def test_reshape_mla_fp8_ds_mla_with_none_quant_mode():
+    """Regression for #48896 / #48378.
+
+    Raw tensors for fp8_ds_mla are allocated with 656 B/token while a buggy
+    reshape path passed ``cache_dtype_str="auto"`` and asked for shape
+    ``[N, 64, 576]``. Preferring ``spec.cache_dtype_str`` keeps the shape
+    consistent with the allocation (including during minimal-KV CUDA-graph
+    profiling).
+    """
+    num_blocks = 32
+    block_size = 64
+    head_size = 576
+    spec = MLAAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=head_size,
+        dtype=torch.uint8,
+        cache_dtype_str="fp8_ds_mla",
+        # Pre-#48379 default; must still reshape correctly.
+        kv_quant_mode=KVQuantMode.NONE,
+    )
+    assert spec.page_size_bytes == block_size * 656
+    assert spec.real_page_size_bytes == block_size * 656
+
+    raw_tensors = {
+        "layer": torch.zeros(spec.page_size_bytes * num_blocks, dtype=torch.int8)
+    }
+    attn_groups = [
+        AttentionGroup(
+            backend=FakeFlashMLASparseBackend,
+            layer_names=["layer"],
+            kv_cache_spec=spec,
+            kv_cache_group_id=0,
+        )
+    ]
+
+    # Global cache dtype as the user-facing flag (fp8), not the canonical
+    # layout string — the resolver must still pick fp8_ds_mla from the spec.
+    kv_cache = _reshape_kv_cache(
+        attn_groups,
+        raw_tensors,
+        "fp8",
+        [spec.block_size],
+        {},
+    )["layer"]
+
+    assert kv_cache.shape == (num_blocks, block_size, 656)
+    assert kv_cache.numel() == raw_tensors["layer"].numel()

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -41,6 +41,36 @@ from vllm.v1.worker.utils import (
 logger = init_logger(__name__)
 
 
+def resolve_layer_kv_cache_dtype_str(
+    kv_cache_spec: AttentionSpec,
+    default_cache_dtype: str,
+) -> str:
+    """Resolve ``cache_dtype_str`` for ``get_kv_cache_shape`` / layout helpers.
+
+    Prefer the per-spec layout string when present (MLA ``fp8_ds_mla``,
+    TurboQuant presets, etc.). Those specs encode the packed page layout in
+    ``cache_dtype_str`` even when ``kv_quant_mode`` is left at ``NONE`` or a
+    generic fp8 mode. Using only ``kv_quant_mode == NONE → "auto"`` forces the
+    unquantized head-size shape (e.g. 576) while raw tensors are allocated with
+    the packed byte layout (e.g. 656 B/token), which crashes reshape during
+    CUDA-graph profiling (see #48896 / #48378).
+
+    Fallbacks:
+    - ``TQFullAttentionSpec`` without ``cache_dtype_str``: use
+      ``default_cache_dtype`` (TurboQuant layout is not "auto").
+    - true skip layers (``kv_quant_mode is NONE``, no layout string): ``"auto"``
+    - otherwise: ``default_cache_dtype``
+    """
+    spec_dtype = getattr(kv_cache_spec, "cache_dtype_str", None)
+    if spec_dtype is not None:
+        return spec_dtype
+    if isinstance(kv_cache_spec, TQFullAttentionSpec):
+        return default_cache_dtype
+    if kv_cache_spec.kv_quant_mode == KVQuantMode.NONE:
+        return "auto"
+    return default_cache_dtype
+
+
 @dataclass(frozen=True)
 class AttentionCGSupportInfo:
     min_cg_support: AttentionCGSupport = AttentionCGSupport.ALWAYS
@@ -306,14 +336,10 @@ def _reshape_kv_cache(
                     kv_cache_spec.storage_block_size // kernel_block_size
                 )
                 kernel_num_blocks = num_blocks * num_blocks_per_kv_block
-                # Skipped layers (--kv-cache-dtype-skip-layers) keep the
-                # unquantized shape; only the quantized primary uses the
-                # quantized cache dtype's (possibly packed) layout.
-                layer_cache_dtype = (
-                    "auto"
-                    if kv_cache_spec.kv_quant_mode == KVQuantMode.NONE
-                    and not isinstance(kv_cache_spec, TQFullAttentionSpec)
-                    else cache_dtype
+                # Prefer per-spec cache_dtype_str (MLA fp8_ds_mla, etc.);
+                # skip layers without a layout string fall back to "auto".
+                layer_cache_dtype = resolve_layer_kv_cache_dtype_str(
+                    kv_cache_spec, cache_dtype
                 )
                 kv_cache_shape = group.backend.get_kv_cache_shape(
                     kernel_num_blocks,
@@ -475,11 +501,8 @@ def _update_hybrid_attention_layout(
         # above. The block-dim index is dtype-independent for current backends
         # (quantization only changes the last dim), so this is a no-op today,
         # but it keeps both call sites consistent for skip layers.
-        layer_cache_dtype = (
-            "auto"
-            if kv_cache_spec.kv_quant_mode == KVQuantMode.NONE
-            and not isinstance(kv_cache_spec, TQFullAttentionSpec)
-            else cache_dtype
+        layer_cache_dtype = resolve_layer_kv_cache_dtype_str(
+            kv_cache_spec, cache_dtype
         )
         block_dim = group.backend.get_kv_cache_block_dim(
             kernel_block_sizes[group.kv_cache_group_id],

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -156,7 +156,6 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheSpec,
     KVCacheSpecKind,
-    KVQuantMode,
     MambaSpec,
     SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
@@ -213,7 +212,10 @@ from vllm.v1.worker.cp_utils import (
 )
 from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
 from vllm.v1.worker.ec_connector_model_runner_mixin import ECConnectorModelRunnerMixin
-from vllm.v1.worker.gpu.attn_utils import _reshape_attention_kv_cache
+from vllm.v1.worker.gpu.attn_utils import (
+    _reshape_attention_kv_cache,
+    resolve_layer_kv_cache_dtype_str,
+)
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
 from vllm.v1.worker.kv_connector_model_runner_mixin import KVConnectorModelRunnerMixin
@@ -7277,17 +7279,10 @@ class GPUModelRunner(
                     else:
                         shape_block_size = kernel_block_size
 
-                    # Skipped layers (--kv-cache-dtype-skip-layers) need
-                    # the unquantized shape.
-                    layer_cache_dtype_str = (
-                        "auto"
-                        if kv_cache_spec.kv_quant_mode == KVQuantMode.NONE
-                        else getattr(
-                            kv_cache_spec,
-                            "cache_dtype_str",
-                            None,
-                        )
-                        or self.cache_config.cache_dtype
+                    # Prefer per-spec cache_dtype_str (MLA fp8_ds_mla, etc.);
+                    # skip layers without a layout string fall back to "auto".
+                    layer_cache_dtype_str = resolve_layer_kv_cache_dtype_str(
+                        kv_cache_spec, self.cache_config.cache_dtype
                     )
                     kv_cache_shape = attn_backend.get_kv_cache_shape(
                         kernel_num_blocks,


### PR DESCRIPTION
## Purpose

Fixes #48896.

On v0.25.x, serving MLA models with `FLASHMLA_SPARSE` + `fp8_ds_mla` (e.g. GLM-5.2-NVFP4) crashes during CUDA-graph memory profiling:

```
RuntimeError: shape '[32, 64, 576]' is invalid for input of size 1343488
```

(`1343488 = 32 × 64 × 656`)

**Root cause:** `_reshape_kv_cache_tensors` / `_reshape_kv_cache` forced `cache_dtype_str="auto"` whenever `kv_quant_mode == NONE`. For MLA `fp8_ds_mla`, the packed page layout is encoded in `MLAAttentionSpec.cache_dtype_str` (656 B/token), while `"auto"` makes `get_kv_cache_shape` return the semantic head size (576). That mismatch fails the contiguous view during `_init_minimal_kv_cache_for_profiling`.

#48379 fixed the common case by setting `kv_quant_mode` on the generic MLA spec so the reshape no longer takes the `"auto"` branch. This PR hardens the reshape path itself:

1. Prefer `spec.cache_dtype_str` when present (layout source of truth for `fp8_ds_mla`, TurboQuant presets, etc.).
2. Fall back to the existing skip-layer `"auto"` / global-dtype heuristic only when the spec has no layout string.
3. Share one resolver between the v1 `GPUModelRunner` path and `gpu/attn_utils._reshape_kv_cache`.
4. Add a unit regression that reproduces the pre-#48379 state (`kv_quant_mode=NONE` + `cache_dtype_str="fp8_ds_mla"`) and asserts the reshape succeeds with shape `[N, 64, 656]`.

This also helps related cases tracked by #47618 / #48177 where layout is encoded in a dtype string rather than `kv_quant_mode`.

## Test Plan

```bash
pytest -q tests/v1/worker/test_attn_utils.py
```

Manual (needs multi-GPU + model weights), as in #48896:

```bash
vllm serve /data/GLM-5.2-NVFP4 \
  --tensor-parallel-size 8 \
  --kv-cache-dtype fp8 \
  --gpu-memory-utilization 0.88 \
  --max-model-len 1048576
```

Expect startup to pass CUDA-graph profiling without the reshape RuntimeError (without requiring `--enforce-eager`).

## Test Result

- Added unit tests:
  - `test_resolve_layer_kv_cache_dtype_str_prefers_mla_layout`
  - `test_resolve_layer_kv_cache_dtype_str_skip_layer_is_auto`
  - `test_reshape_mla_fp8_ds_mla_with_none_quant_mode` (regression for #48896)
- Local full `vllm` import path could not be exercised in this environment (torch too old); CI will run the unit tests.

## Essential Elements Checklist

- [x] Purpose of the PR (link existing issue)
- [x] Test plan
- [x] Test results / expected verification
- [x] DCO sign-off