### PR TITLE
[Bugfix][Spec Decode] Fix DSpark bonus-anchor query width accounting

### DIFF
--- a/tests/v1/spec_decode/test_dflash_lookahead.py
+++ b/tests/v1/spec_decode/test_dflash_lookahead.py
@@ -55,12 +55,14 @@ def _dflash_speculative_config(num_speculative_tokens: int) -> SpeculativeConfig
 def _dspark_speculative_config(
     num_speculative_tokens: int,
     *,
-    bonus_anchor: bool = True,
+    sample_from_anchor: bool | None = None,
 ) -> SpeculativeConfig:
     speculative_config = _dflash_speculative_config(num_speculative_tokens)
     speculative_config.method = "dspark"
-    if bonus_anchor:
-        speculative_config.draft_model_config.hf_config.dspark_bonus_anchor = True
+    if sample_from_anchor is not None:
+        speculative_config.draft_model_config.hf_config.sample_from_anchor = (
+            sample_from_anchor
+        )
     return speculative_config
 
 
@@ -157,7 +159,9 @@ def test_dflash_first_prefill_query_window_fits_allocated_blocks():
 
 def test_bonus_anchor_dspark_reserves_full_query_window(monkeypatch):
     monkeypatch.setattr("vllm.config.vllm.HAS_TRITON", True)
-    speculative_config = _dspark_speculative_config(NUM_SPECULATIVE_TOKENS)
+    speculative_config = _dspark_speculative_config(
+        NUM_SPECULATIVE_TOKENS, sample_from_anchor=False
+    )
     scheduler = _create_parallel_drafter_scheduler(speculative_config)
 
     assert scheduler.num_lookahead_tokens == NUM_SPECULATIVE_TOKENS + 1
@@ -179,13 +183,17 @@ def test_bonus_anchor_dspark_reserves_full_query_window(monkeypatch):
 
 
 def test_dspark_query_width_follows_anchor_layout():
-    bonus_anchor = _dspark_speculative_config(NUM_SPECULATIVE_TOKENS)
-    anchor_as_first = _dspark_speculative_config(
-        NUM_SPECULATIVE_TOKENS, bonus_anchor=False
+    default_anchor_as_first = _dspark_speculative_config(NUM_SPECULATIVE_TOKENS)
+    configured_anchor_as_first = _dspark_speculative_config(
+        NUM_SPECULATIVE_TOKENS, sample_from_anchor=True
+    )
+    bonus_anchor = _dspark_speculative_config(
+        NUM_SPECULATIVE_TOKENS, sample_from_anchor=False
     )
 
+    assert default_anchor_as_first.num_drafter_query_tokens == NUM_SPECULATIVE_TOKENS
+    assert configured_anchor_as_first.num_drafter_query_tokens == NUM_SPECULATIVE_TOKENS
     assert bonus_anchor.num_drafter_query_tokens == NUM_SPECULATIVE_TOKENS + 1
-    assert anchor_as_first.num_drafter_query_tokens == NUM_SPECULATIVE_TOKENS
 
 
 def test_dflash_drafter_window_reserves_bonus_token():
@@ -206,7 +214,7 @@ def test_dflash_drafter_window_reserves_bonus_token():
     dspark_runner = SimpleNamespace(
         effective_drafter_max_model_len=100,
         speculative_config=_dspark_speculative_config(
-            NUM_SPECULATIVE_TOKENS, bonus_anchor=False
+            NUM_SPECULATIVE_TOKENS, sample_from_anchor=True
         ),
     )
     assert input_fits_in_drafter(dspark_runner, SimpleNamespace(max_seq_len=97))
@@ -216,7 +224,9 @@ def test_bonus_anchor_dspark_drafter_window_reserves_bonus_token():
     input_fits_in_drafter = GPUModelRunner._input_fits_in_drafter
     dspark_runner = SimpleNamespace(
         effective_drafter_max_model_len=100,
-        speculative_config=_dspark_speculative_config(NUM_SPECULATIVE_TOKENS),
+        speculative_config=_dspark_speculative_config(
+            NUM_SPECULATIVE_TOKENS, sample_from_anchor=False
+        ),
     )
 
     assert input_fits_in_drafter(dspark_runner, SimpleNamespace(max_seq_len=96))

--- a/tests/v1/spec_decode/test_dflash_lookahead.py
+++ b/tests/v1/spec_decode/test_dflash_lookahead.py
@@ -3,11 +3,13 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from tests.v1.core.utils import create_requests
 from vllm.config import (
     CacheConfig,
+    DeviceConfig,
     ModelConfig,
     ParallelConfig,
     SchedulerConfig,
@@ -22,6 +24,8 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+pytestmark = pytest.mark.skip_global_cleanup
 
 # Matches defaults from tests/v1/spec_decode/test_eagle.py
 DFLASH_TARGET_DIR = "Qwen/Qwen3-8B"
@@ -48,8 +52,24 @@ def _dflash_speculative_config(num_speculative_tokens: int) -> SpeculativeConfig
     )
 
 
-def _create_dflash_scheduler(num_speculative_tokens: int) -> Scheduler:
+def _dspark_speculative_config(
+    num_speculative_tokens: int,
+    *,
+    sample_from_anchor: bool | None = None,
+) -> SpeculativeConfig:
     speculative_config = _dflash_speculative_config(num_speculative_tokens)
+    speculative_config.method = "dspark"
+    hf_config = speculative_config.draft_model_config.hf_config
+    if sample_from_anchor is None:
+        hf_config.dspark_bonus_anchor = True
+    else:
+        hf_config.sample_from_anchor = sample_from_anchor
+    return speculative_config
+
+
+def _create_parallel_drafter_scheduler(
+    speculative_config: SpeculativeConfig,
+) -> Scheduler:
     model_config = speculative_config.target_model_config
     scheduler_config = SchedulerConfig(
         max_num_seqs=16,
@@ -67,6 +87,7 @@ def _create_dflash_scheduler(num_speculative_tokens: int) -> Scheduler:
         scheduler_config=scheduler_config,
         model_config=model_config,
         cache_config=cache_config,
+        device_config=DeviceConfig(device="cpu"),
         parallel_config=ParallelConfig(),
         speculative_config=speculative_config,
     )
@@ -92,6 +113,12 @@ def _create_dflash_scheduler(num_speculative_tokens: int) -> Scheduler:
         block_size=BLOCK_SIZE,
         log_stats=True,
         structured_output_manager=StructuredOutputManager(vllm_config),
+    )
+
+
+def _create_dflash_scheduler(num_speculative_tokens: int) -> Scheduler:
+    return _create_parallel_drafter_scheduler(
+        _dflash_speculative_config(num_speculative_tokens)
     )
 
 
@@ -131,6 +158,45 @@ def test_dflash_first_prefill_query_window_fits_allocated_blocks():
     assert all(pos // BLOCK_SIZE < len(block_ids) for pos in query_positions)
 
 
+def test_bonus_anchor_dspark_reserves_full_query_window(monkeypatch):
+    monkeypatch.setattr("vllm.config.vllm.HAS_TRITON", True)
+    speculative_config = _dspark_speculative_config(NUM_SPECULATIVE_TOKENS)
+    scheduler = _create_parallel_drafter_scheduler(speculative_config)
+
+    assert scheduler.num_lookahead_tokens == NUM_SPECULATIVE_TOKENS + 1
+
+    num_tokens = BLOCK_SIZE - NUM_SPECULATIVE_TOKENS
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=num_tokens,
+        block_size=BLOCK_SIZE,
+    )
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+    block_ids = output.scheduled_new_reqs[0].block_ids[0]
+    query_positions = range(num_tokens, num_tokens + NUM_SPECULATIVE_TOKENS + 1)
+
+    assert len(block_ids) == 2
+    assert all(pos // BLOCK_SIZE < len(block_ids) for pos in query_positions)
+
+
+def test_dspark_query_width_follows_anchor_layout():
+    legacy_bonus_anchor = _dspark_speculative_config(NUM_SPECULATIVE_TOKENS)
+    configured_bonus_anchor = _dspark_speculative_config(
+        NUM_SPECULATIVE_TOKENS, sample_from_anchor=False
+    )
+    sample_from_anchor = _dspark_speculative_config(
+        NUM_SPECULATIVE_TOKENS, sample_from_anchor=True
+    )
+
+    assert legacy_bonus_anchor.num_drafter_query_tokens == NUM_SPECULATIVE_TOKENS + 1
+    assert (
+        configured_bonus_anchor.num_drafter_query_tokens == NUM_SPECULATIVE_TOKENS + 1
+    )
+    assert sample_from_anchor.num_drafter_query_tokens == NUM_SPECULATIVE_TOKENS
+
+
 def test_dflash_drafter_window_reserves_bonus_token():
     # DFlash's drafter window is num_spec + 1 (the extra slot is the bonus token),
     # so max_seq_len + num_spec + 1 must stay within the draft model's max len.
@@ -145,10 +211,22 @@ def test_dflash_drafter_window_reserves_bonus_token():
     assert not input_fits_in_drafter(dflash_runner, SimpleNamespace(max_seq_len=97))
     assert not input_fits_in_drafter(dflash_runner, None)  # no metadata
 
-    # Other drafters don't reserve the bonus token, so 97 fits (97 + 3 == 100).
-    plain_runner = SimpleNamespace(
-        num_spec_tokens=NUM_SPECULATIVE_TOKENS,
+    # Anchor-sampling DSpark has no separate bonus slot, so 97 still fits.
+    dspark_runner = SimpleNamespace(
         effective_drafter_max_model_len=100,
-        speculative_config=SimpleNamespace(use_dflash=lambda: False),
+        speculative_config=_dspark_speculative_config(
+            NUM_SPECULATIVE_TOKENS, sample_from_anchor=True
+        ),
     )
-    assert input_fits_in_drafter(plain_runner, SimpleNamespace(max_seq_len=97))
+    assert input_fits_in_drafter(dspark_runner, SimpleNamespace(max_seq_len=97))
+
+
+def test_bonus_anchor_dspark_drafter_window_reserves_bonus_token():
+    input_fits_in_drafter = GPUModelRunner._input_fits_in_drafter
+    dspark_runner = SimpleNamespace(
+        effective_drafter_max_model_len=100,
+        speculative_config=_dspark_speculative_config(NUM_SPECULATIVE_TOKENS),
+    )
+
+    assert input_fits_in_drafter(dspark_runner, SimpleNamespace(max_seq_len=96))
+    assert not input_fits_in_drafter(dspark_runner, SimpleNamespace(max_seq_len=97))

--- a/tests/v1/spec_decode/test_dflash_lookahead.py
+++ b/tests/v1/spec_decode/test_dflash_lookahead.py
@@ -55,15 +55,12 @@ def _dflash_speculative_config(num_speculative_tokens: int) -> SpeculativeConfig
 def _dspark_speculative_config(
     num_speculative_tokens: int,
     *,
-    sample_from_anchor: bool | None = None,
+    bonus_anchor: bool = True,
 ) -> SpeculativeConfig:
     speculative_config = _dflash_speculative_config(num_speculative_tokens)
     speculative_config.method = "dspark"
-    hf_config = speculative_config.draft_model_config.hf_config
-    if sample_from_anchor is None:
-        hf_config.dspark_bonus_anchor = True
-    else:
-        hf_config.sample_from_anchor = sample_from_anchor
+    if bonus_anchor:
+        speculative_config.draft_model_config.hf_config.dspark_bonus_anchor = True
     return speculative_config
 
 
@@ -182,19 +179,13 @@ def test_bonus_anchor_dspark_reserves_full_query_window(monkeypatch):
 
 
 def test_dspark_query_width_follows_anchor_layout():
-    legacy_bonus_anchor = _dspark_speculative_config(NUM_SPECULATIVE_TOKENS)
-    configured_bonus_anchor = _dspark_speculative_config(
-        NUM_SPECULATIVE_TOKENS, sample_from_anchor=False
-    )
-    sample_from_anchor = _dspark_speculative_config(
-        NUM_SPECULATIVE_TOKENS, sample_from_anchor=True
+    bonus_anchor = _dspark_speculative_config(NUM_SPECULATIVE_TOKENS)
+    anchor_as_first = _dspark_speculative_config(
+        NUM_SPECULATIVE_TOKENS, bonus_anchor=False
     )
 
-    assert legacy_bonus_anchor.num_drafter_query_tokens == NUM_SPECULATIVE_TOKENS + 1
-    assert (
-        configured_bonus_anchor.num_drafter_query_tokens == NUM_SPECULATIVE_TOKENS + 1
-    )
-    assert sample_from_anchor.num_drafter_query_tokens == NUM_SPECULATIVE_TOKENS
+    assert bonus_anchor.num_drafter_query_tokens == NUM_SPECULATIVE_TOKENS + 1
+    assert anchor_as_first.num_drafter_query_tokens == NUM_SPECULATIVE_TOKENS
 
 
 def test_dflash_drafter_window_reserves_bonus_token():
@@ -215,7 +206,7 @@ def test_dflash_drafter_window_reserves_bonus_token():
     dspark_runner = SimpleNamespace(
         effective_drafter_max_model_len=100,
         speculative_config=_dspark_speculative_config(
-            NUM_SPECULATIVE_TOKENS, sample_from_anchor=True
+            NUM_SPECULATIVE_TOKENS, bonus_anchor=False
         ),
     )
     assert input_fits_in_drafter(dspark_runner, SimpleNamespace(max_seq_len=97))

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1344,10 +1344,7 @@ class SpeculativeConfig:
 
         assert self.draft_model_config is not None
         hf_config = self.draft_model_config.hf_config
-        sample_from_anchor = getattr(hf_config, "sample_from_anchor", None)
-        if sample_from_anchor is None:
-            sample_from_anchor = not getattr(hf_config, "dspark_bonus_anchor", False)
-        return num_query_tokens + int(not sample_from_anchor)
+        return num_query_tokens + int(getattr(hf_config, "dspark_bonus_anchor", False))
 
     def uses_dynamic_speculative_decoding(self) -> bool:
         return self.num_speculative_tokens_per_batch_size is not None

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1344,7 +1344,8 @@ class SpeculativeConfig:
 
         assert self.draft_model_config is not None
         hf_config = self.draft_model_config.hf_config
-        return num_query_tokens + int(getattr(hf_config, "dspark_bonus_anchor", False))
+        sample_from_anchor = getattr(hf_config, "sample_from_anchor", True)
+        return num_query_tokens + int(not sample_from_anchor)
 
     def uses_dynamic_speculative_decoding(self) -> bool:
         return self.num_speculative_tokens_per_batch_size is not None

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1333,6 +1333,22 @@ class SpeculativeConfig:
     def use_dspark(self) -> bool:
         return self.method == "dspark"
 
+    @property
+    def num_drafter_query_tokens(self) -> int:
+        """Return the per-request query width used by the draft model."""
+        num_query_tokens = self.num_speculative_tokens
+        if self.use_dflash():
+            return num_query_tokens + 1
+        if not self.use_dspark():
+            return num_query_tokens
+
+        assert self.draft_model_config is not None
+        hf_config = self.draft_model_config.hf_config
+        sample_from_anchor = getattr(hf_config, "sample_from_anchor", None)
+        if sample_from_anchor is None:
+            sample_from_anchor = not getattr(hf_config, "dspark_bonus_anchor", False)
+        return num_query_tokens + int(not sample_from_anchor)
+
     def uses_dynamic_speculative_decoding(self) -> bool:
         return self.num_speculative_tokens_per_batch_size is not None
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1466,10 +1466,7 @@ class SpeculativeConfig:
 
         assert self.draft_model_config is not None
         hf_config = self.draft_model_config.hf_config
-        sample_from_anchor = getattr(hf_config, "sample_from_anchor", None)
-        if sample_from_anchor is None:
-            sample_from_anchor = not getattr(hf_config, "dspark_bonus_anchor", False)
-        return num_query_tokens + int(not sample_from_anchor)
+        return num_query_tokens + int(getattr(hf_config, "dspark_bonus_anchor", False))
 
     def uses_dynamic_speculative_decoding(self) -> bool:
         return self.num_speculative_tokens_per_batch_size is not None

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1455,6 +1455,22 @@ class SpeculativeConfig:
     def use_dspark(self) -> bool:
         return self.method == "dspark"
 
+    @property
+    def num_drafter_query_tokens(self) -> int:
+        """Return the per-request query width used by the draft model."""
+        num_query_tokens = self.num_speculative_tokens
+        if self.use_dflash():
+            return num_query_tokens + 1
+        if not self.use_dspark():
+            return num_query_tokens
+
+        assert self.draft_model_config is not None
+        hf_config = self.draft_model_config.hf_config
+        sample_from_anchor = getattr(hf_config, "sample_from_anchor", None)
+        if sample_from_anchor is None:
+            sample_from_anchor = not getattr(hf_config, "dspark_bonus_anchor", False)
+        return num_query_tokens + int(not sample_from_anchor)
+
     def uses_dynamic_speculative_decoding(self) -> bool:
         return self.num_speculative_tokens_per_batch_size is not None
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1466,7 +1466,8 @@ class SpeculativeConfig:
 
         assert self.draft_model_config is not None
         hf_config = self.draft_model_config.hf_config
-        return num_query_tokens + int(getattr(hf_config, "dspark_bonus_anchor", False))
+        sample_from_anchor = getattr(hf_config, "sample_from_anchor", True)
+        return num_query_tokens + int(not sample_from_anchor)
 
     def uses_dynamic_speculative_decoding(self) -> bool:
         return self.num_speculative_tokens_per_batch_size is not None

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -606,17 +606,8 @@ class VllmConfig:
         speculative_config = self.speculative_config
         if speculative_config is None:
             return 0
-        if speculative_config.use_dflash():
-            # DFlash requires an extra lookahead slot since it uses in-fill-style
-            # decoding instead of standard next-token sampling, so it has a query
-            # for the last sampled token plus queries for each draft token.
-            return self.num_speculative_tokens + 1
         if speculative_config.use_eagle() or speculative_config.uses_draft_model():
-            # DSpark (covered by use_eagle) drafts a block of num_speculative_tokens
-            # query tokens in which the anchor itself is the first prediction
-            # position (no separate bonus query), so it needs exactly
-            # num_speculative_tokens lookahead slots.
-            return self.num_speculative_tokens
+            return speculative_config.num_drafter_query_tokens
         return 0
 
     @property

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -247,16 +247,8 @@ class Scheduler(SchedulerInterface):
                 self.num_lookahead_tokens = self.num_spec_tokens
             if speculative_config.uses_draft_model():
                 self.num_lookahead_tokens = self.num_spec_tokens
-            if speculative_config.use_dflash():
-                # DFlash requires an extra lookahead slot since it uses in-fill-style
-                # decoding instead of standard next-token sampling, so it has a query
-                # for the last sampled token plus queries for each draft token.
-                self.num_lookahead_tokens = self.num_spec_tokens + 1
-            if speculative_config.use_dspark():
-                # DSpark drafts a block of num_spec_tokens query tokens in which the
-                # anchor itself is the first prediction position (no separate bonus
-                # query), so it needs exactly num_spec_tokens lookahead slots.
-                self.num_lookahead_tokens = self.num_spec_tokens
+            if speculative_config.use_dflash() or speculative_config.use_dspark():
+                self.num_lookahead_tokens = speculative_config.num_drafter_query_tokens
 
         # Create the KV cache manager.
         if hash_block_size is None:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -242,12 +242,8 @@ class Scheduler(SchedulerInterface):
                     vllm_max_batch_size=self.scheduler_config.max_num_seqs,
                     vllm_num_speculative_tokens=self.num_spec_tokens,
                 )
-            if speculative_config.use_eagle():
-                self.use_eagle = True
-                self.num_lookahead_tokens = self.num_spec_tokens
-            if speculative_config.uses_draft_model():
-                self.num_lookahead_tokens = self.num_spec_tokens
-            if speculative_config.use_dflash() or speculative_config.use_dspark():
+            self.use_eagle = speculative_config.use_eagle()
+            if self.use_eagle or speculative_config.uses_draft_model():
                 self.num_lookahead_tokens = speculative_config.num_drafter_query_tokens
 
         # Create the KV cache manager.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4483,12 +4483,9 @@ class GPUModelRunner(
         if common_attn_metadata is None:
             return False
         assert self.speculative_config is not None
-        # DFlash queries one extra token (the bonus token) beyond num_spec_tokens
-        num_drafter_query_tokens = self.num_spec_tokens + (
-            1 if self.speculative_config.use_dflash() else 0
-        )
         return (
-            common_attn_metadata.max_seq_len + num_drafter_query_tokens
+            common_attn_metadata.max_seq_len
+            + self.speculative_config.num_drafter_query_tokens
             <= self.effective_drafter_max_model_len
         )
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4625,12 +4625,9 @@ class GPUModelRunner(
         if common_attn_metadata is None:
             return False
         assert self.speculative_config is not None
-        # DFlash queries one extra token (the bonus token) beyond num_spec_tokens
-        num_drafter_query_tokens = self.num_spec_tokens + (
-            1 if self.speculative_config.use_dflash() else 0
-        )
         return (
-            common_attn_metadata.max_seq_len + num_drafter_query_tokens
+            common_attn_metadata.max_seq_len
+            + self.speculative_config.num_drafter_query_tokens
             <= self.effective_drafter_max_model_len
         )
 


### PR DESCRIPTION
## Purpose

Speculators-format DSpark checkpoints use a bonus-anchor layout: producing `N` speculative tokens requires `N + 1` draft queries (one anchor plus `N` mask queries). The DSpark runtime currently identifies this layout through
`dspark_bonus_anchor`.

The scheduler and drafter max-length guard previously reserved and validated only `N` positions for every DSpark request. At a KV block boundary, the extra bonus-anchor query could therefore reference an unallocated block-table entry; near `max_model_len`, drafting could be allowed when the full `N + 1` query window did not fit.

This PR makes scheduler KV allocation and drafter max-length validation follow the current `dspark_bonus_anchor` runtime contract, while preserving the `N`-query anchor-sampling DSpark layout and existing DFlash behavior.

[#48639](https://github.com/vllm-project/vllm/pull/48639) plans to replace this flag with `sample_from_anchor`. When it lands, this query-width accounting should be updated to follow the same new runtime contract.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
