### PR TITLE
 [Perf] Avoid full-vocab sort in the small-batch top-k/top-p sampler path

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -360,6 +360,13 @@ def apply_top_k_top_p(
     return apply_top_k_top_p_pytorch(logits, k, p)
 
 
+# Size of the candidate window used to avoid a full-vocab sort in
+# apply_top_k_top_p_pytorch. Large enough to cover typical top_k values;
+# requests whose top_k exceeds it (or whose top_p nucleus spills past it)
+# fall back to the exact sort-based implementation.
+_TOPK_CANDIDATE_WINDOW = 1024
+
+
 def apply_top_k_top_p_pytorch(
     logits: torch.Tensor,
     k: torch.Tensor | None,
@@ -368,8 +375,10 @@ def apply_top_k_top_p_pytorch(
 ) -> torch.Tensor:
     """Apply top-k and top-p masks to the logits.
 
-    If a top-p is used, this function will sort the logits tensor,
-    which can be slow for large batches.
+    Resolves top-k/top-p from a top-N candidate window instead of sorting
+    the full vocab, falling back to the exact sort-based implementation for
+    the rare cases the window can't resolve exactly (ties at the window
+    boundary, or a top-p nucleus spilling past it).
 
     The logits tensor may be updated in-place.
     """
@@ -381,6 +390,55 @@ def apply_top_k_top_p_pytorch(
             # Avoid sorting vocab for top-k only case.
             return apply_top_k_only(logits, k)
 
+    V = logits.shape[1]
+    n = _TOPK_CANDIDATE_WINDOW
+    if k is not None:
+        n = max(n, int(k.max()))
+    n = min(n, V)
+
+    top_logits, _ = torch.topk(logits, n, dim=-1)
+
+    if k is not None:
+        k_idx = (k.long() - 1).clamp(min=0, max=n - 1).unsqueeze(1)
+        kth_val = top_logits.gather(1, k_idx)
+        if bool((top_logits[:, -1:] == kth_val).any()):
+            # A tied value sits at the window boundary: more ties may exist
+            # outside the window, invisible to us here.
+            return _apply_top_k_top_p_sort(logits, k, p)
+        top_logits = top_logits.masked_fill(top_logits < kth_val, -float("inf"))
+
+    if p is not None:
+        if bool((p >= 1.0).any()):
+            return _apply_top_k_top_p_sort(logits, k, p)
+
+        if k is not None:
+            probs = top_logits.softmax(dim=-1)
+        else:
+            lse = torch.logsumexp(logits, dim=-1, keepdim=True)
+            probs = torch.exp(top_logits - lse)
+        cumsum = probs.cumsum(dim=-1)
+
+        if k is None and bool((cumsum[:, -1] < p).any()):
+            return _apply_top_k_top_p_sort(logits, k, p)
+
+        keep = ((cumsum - probs) < p.unsqueeze(1)) & (top_logits > -float("inf"))
+        thresh = top_logits.masked_fill(~keep, float("inf")).min(
+            dim=-1, keepdim=True
+        ).values
+        return logits.masked_fill_(logits < thresh, -float("inf"))
+
+    thresh = top_logits.masked_fill(
+        top_logits == -float("inf"), float("inf")
+    ).min(dim=-1, keepdim=True).values
+    return logits.masked_fill_(logits < thresh, -float("inf"))
+
+
+def _apply_top_k_top_p_sort(
+    logits: torch.Tensor,
+    k: torch.Tensor | None,
+    p: torch.Tensor | None,
+) -> torch.Tensor:
+    """Exact top-k/top-p via full-vocab sort. Slow for large batches."""
     logits_sort, logits_idx = logits.sort(dim=-1, descending=False)
 
     if k is not None:


### PR DESCRIPTION



## Background

`apply_top_k_top_p_pytorch` is the sampler filter used on the small-batch (`batch_size < 8`) GPU path and on CPU. Whenever top-p is requested it sorts the **entire** vocabulary (`logits.sort` over `[B, V]`, e.g. `V=151936` for Qwen3), which dominates the op's cost. 

## Change

Resolve top-k/top-p from a fixed **top-N candidate window** (`N = 1024`, grown to `k.max()` when a larger top-k is requested) via `torch.topk` instead of a full sort:

- **top-p only**: nucleus found on the top-N candidates; softmax denominator  uses a full-vocab `logsumexp`, so probabilities stay exact.
- **top-k + top-p**: the top-k set fits in the window (`N >= k`), so the candidate softmax is exact.
- **top-k only**: threshold is the k-th largest logit.

The exact sort-based implementation is kept verbatim as `_apply_top_k_top_p_sort` and used as a fallback when the window can't resolve exactly: a tie sits at the window boundary, the top-p nucleus spills past N, or `p >= 1.0`. CPU (`allow_cpu_sync`) behavior is unchanged.

## Testing

- `pytest tests/v1/sample/test_topk_topp_sampler.py` → **95 passed, 36 skipped,  0 failed** (skips are FlashInfer-only, unavailable on the ROCm host). This suite exercises `apply_top_k_top_p_pytorch` directly and as the reference for the Triton kernel tests.
- Correctness vs the sort reference: kept-set matches token-for-token across a large synthetic grid (p/k/vocab/dist/seed/batch) and on real captured  Qwen3-14B logits; residual differences are only exact fp-boundary ties.
- Model eval (real Qwen3-14B, real ShareGPT, small-batch path): generated text is identical to the sort path (no quality change); end-to-end throughput **+6.1%** tok/s.

### Op-level microbenchmark (Qwen3-14B vocab = 151936, p50 latency)

| batch | config          | sort (µs) | topk (µs) | speedup |
|-------|-----------------|-----------|-----------|---------|
| 1     | top_p=0.9       | 149       | 225       | 0.66x   |
| 2     | top_p=0.9       | 643       | 225       | 2.86x   |
| 4     | top_p=0.9       | 710       | 224       | 3.17x   |
| 8     | top_p=0.9       | 622       | 242       | 2.57x   |
| 1     | top_k=50,p=0.9  | 158       | 209       | 0.76x   |
| 2     | top_k=50,p=0.9  | 659       | 218       | 3.02x   |
| 4     | top_k=50,p=0.9  | 722       | 217       | 3.33x   |
| 8     | top_k=50,p=0.9  | 634       | 225       | 2.82x   |


## Test environment

- GPU: AMD Instinct MI355X (gfx950), ROCm 7.2.3
- torch 2.11.0 (ROCm), triton 3.6.0 (ROCm), vLLM 0.25.1


## AI assistance

This change was developed with AI assistance(Claude Sonnet 5). All code and test results were reviewed by a human submitter who understands and can defend the change end-to-end.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

