### PR TITLE
[Doc] Fix stale code references to moved and removed files

### DIFF
--- a/docs/design/fusions.md
+++ b/docs/design/fusions.md
@@ -306,7 +306,7 @@ Supported quantization scheme/hardware combinations:
 
 - Pass: [`vllm/compilation/passes/fusion/rms_quant_fusion.py`](https://github.com/vllm-project/vllm/blob/main/vllm/compilation/passes/fusion/rms_quant_fusion.py)
 - ROCm AITER pass: [`vllm/compilation/passes/fusion/rocm_aiter_fusion.py`](https://github.com/vllm-project/vllm/blob/main/vllm/compilation/passes/fusion/rocm_aiter_fusion.py)
-- CUDA/HIP kernels: [`csrc/layernorm_quant_kernels.cu`](https://github.com/vllm-project/vllm/blob/main/csrc/layernorm_quant_kernels.cu)
+- CUDA/HIP kernels: [`csrc/libtorch_stable/layernorm_quant_kernels.cu`](https://github.com/vllm-project/vllm/blob/main/csrc/libtorch_stable/layernorm_quant_kernels.cu)
 
 ### SiLU+Mul + Quantization (`fuse_act_quant`)
 
@@ -332,7 +332,7 @@ Supported quantization scheme/hardware combinations:
 - Pass: [`vllm/compilation/passes/fusion/act_quant_fusion.py`](https://github.com/vllm-project/vllm/blob/main/vllm/compilation/passes/fusion/act_quant_fusion.py)
 - ROCm AITER pass: [`vllm/compilation/passes/fusion/rocm_aiter_fusion.py`](https://github.com/vllm-project/vllm/blob/main/vllm/compilation/passes/fusion/rocm_aiter_fusion.py)
 - CUDA/HIP kernels: [`csrc/quantization/`](https://github.com/vllm-project/vllm/blob/main/csrc/quantization/)
-- Fused SiLU+Mul+BlockQuant kernel: [`csrc/quantization/fused_kernels/fused_silu_mul_block_quant.cu`](https://github.com/vllm-project/vllm/blob/main/csrc/quantization/fused_kernels/fused_silu_mul_block_quant.cu)
+- Fused SiLU+Mul+BlockQuant kernel: [`csrc/libtorch_stable/quantization/fused_kernels/fused_silu_mul_block_quant.cu`](https://github.com/vllm-project/vllm/blob/main/csrc/libtorch_stable/quantization/fused_kernels/fused_silu_mul_block_quant.cu)
 
 ### RMSNorm + Padding (`fuse_act_padding`)
 

--- a/docs/serving/online_serving/speech_to_text.md
+++ b/docs/serving/online_serving/speech_to_text.md
@@ -67,7 +67,7 @@ The Transcriptions API supports uploading audio files in various formats includi
 - `response_format`: Format of the response ("json", "text") (optional)
 - `temperature`: Sampling temperature between 0 and 1 (optional)
 
-For the complete list of supported parameters including sampling parameters and vLLM extensions, see the [protocol definitions](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/protocol.py#L2182).
+For the complete list of supported parameters including sampling parameters and vLLM extensions, see the [protocol definitions](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/speech_to_text/transcription/protocol.py).
 
 **Response Format:**
 

--- a/docs/usage/troubleshooting.md
+++ b/docs/usage/troubleshooting.md
@@ -75,9 +75,9 @@ If it's not, override the IP address using the environment variable `export VLLM
 
 You might also need to set `export NCCL_SOCKET_IFNAME=<your_network_interface>` and `export GLOO_SOCKET_IFNAME=<your_network_interface>` to specify the network interface for the IP address.
 
-## Error near `self.graph.replay()`
+## Error near `cudagraph.replay()`
 
-If vLLM crashes and the error trace captures it somewhere around `self.graph.replay()` in `vllm/worker/model_runner.py`, it is a CUDA error inside CUDAGraph.
+If vLLM crashes and the error trace captures it somewhere around `cudagraph.replay()` in `vllm/compilation/cuda_graph.py`, it is a CUDA error inside CUDAGraph.
 To identify the particular CUDA operation that causes the error, you can add `--enforce-eager` to the command line, or `enforce_eager=True` to the [LLM][vllm.LLM] class to disable the CUDAGraph optimization and isolate the exact CUDA operation that causes the error.
 
 ## Incorrect hardware/driver


### PR DESCRIPTION
## Purpose

Cleans up four dead code references in the docs, all pointing at files that moved or were deleted:

- `docs/design/fusions.md` linked `csrc/layernorm_quant_kernels.cu` and `csrc/quantization/fused_kernels/fused_silu_mul_block_quant.cu`. Both moved under `csrc/libtorch_stable/` in #46656, so both GitHub links 404 now.
- `docs/usage/troubleshooting.md` told users the CUDA graph crash shows up in `vllm/worker/model_runner.py`, which was removed with the V0 core (#25321). The replay call now lives in `vllm/compilation/cuda_graph.py` (`entry.cudagraph.replay()`), so I updated the section heading and body to match what actually appears in a trace today.
- `docs/serving/online_serving/speech_to_text.md` pointed at `vllm/entrypoints/openai/protocol.py#L2182` for transcription params. That file is gone; `TranscriptionRequest` lives in `vllm/entrypoints/speech_to_text/transcription/protocol.py` now. I dropped the line pin since those rot quickly.

Found these by checking every backticked repo path and `blob/main` link in `docs/` against the working tree. These four were the only dead ones, aside from `design/paged_attention.md` which I left alone on purpose (it has an explicit historical-document warning banner).

Not duplicating existing work: I searched open PRs for these files and keywords (fusions.md, layernorm_quant_kernels, speech_to_text.md, troubleshooting.md) and found none touching them. The docs-audit PR #40062 covers a different set of files from issue #39613, no overlap.

## Test Plan

Docs-only change, so:

```
pre-commit run --files docs/design/fusions.md docs/usage/troubleshooting.md docs/serving/online_serving/speech_to_text.md
```

plus re-running the path/link audit over the touched files to confirm every referenced path resolves.

## Test Result

All pre-commit hooks passed (markdownlint, typos, etc.). Audit re-run comes back clean: every repo path and GitHub link in the three files now points at a file that exists on main.

---

small disclaimer: I'm a college freshman trying my best to contribute for the greater good :) I dug these up and verified each replacement path myself, and used Claude Code to help with the audit tooling and to sanity-check the logic. apologies if anything has an obvious error, I'd genuinely love to learn if you spot mistakes.