### PR TITLE
 Fix Mooncake sender listener startup with IPv6 hosts

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import contextlib
+import threading
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1202,6 +1203,53 @@ def test_register_kv_caches_supports_mixed_mla_and_eagle_shapes():
             "model.layers.1.eagle_attn",
         ]
         assert worker.registered_layer_indices == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_sender_listener_binds_ipv6_address():
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.hostname = "2001:db8::1"
+    worker.async_zmq_ctx = MagicMock()
+    worker.is_kv_consumer = True
+    worker.is_kv_producer = True
+    worker.register_worker_with_bootstrap = AsyncMock(
+        side_effect=RuntimeError("bootstrap failed")
+    )
+
+    sock = MagicMock()
+    sock.bind_to_random_port.return_value = 12345
+    worker.async_zmq_ctx.socket.return_value = sock
+
+    ready_event = threading.Event()
+    startup_error: list[BaseException] = []
+    with pytest.raises(RuntimeError, match="bootstrap failed"):
+        await worker._mooncake_sender_listener(ready_event, startup_error)
+
+    sock.setsockopt.assert_any_call(zmq.IPV6, 1)
+    sock.bind_to_random_port.assert_called_once_with("tcp://[2001:db8::1]")
+    assert ready_event.is_set()
+    assert len(startup_error) == 1
+
+
+@pytest.mark.asyncio
+async def test_sender_listener_reports_startup_error():
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.hostname = "127.0.0.1"
+    worker.async_zmq_ctx = MagicMock()
+    worker.is_kv_consumer = True
+    worker.is_kv_producer = True
+
+    sock = MagicMock()
+    sock.bind_to_random_port.side_effect = RuntimeError("bind failed")
+    worker.async_zmq_ctx.socket.return_value = sock
+
+    ready_event = threading.Event()
+    startup_error: list[BaseException] = []
+    with pytest.raises(RuntimeError, match="bind failed"):
+        await worker._mooncake_sender_listener(ready_event, startup_error)
+
+    assert ready_event.is_set()
+    assert len(startup_error) == 1
 
 
 @pytest.mark.asyncio

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -48,7 +48,12 @@ from vllm.logger import init_logger
 from vllm.model_executor.models.utils import extract_layer_index
 from vllm.platforms import current_platform
 from vllm.utils.math_utils import cdiv
-from vllm.utils.network_utils import get_ip, make_zmq_path, make_zmq_socket
+from vllm.utils.network_utils import (
+    get_ip,
+    is_valid_ipv6_address,
+    make_zmq_path,
+    make_zmq_socket,
+)
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.attention.backends.utils import NULL_BLOCK_ID, get_kv_cache_layout
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -1129,37 +1134,53 @@ class MooncakeConnectorWorker:
                 )
                 raise e
 
-    async def _mooncake_sender_listener(self, ready_event: threading.Event):
+    async def _mooncake_sender_listener(
+        self,
+        ready_event: threading.Event,
+        startup_error: list[BaseException],
+    ):
         """
         Background thread that listens for Mooncake requests, dispatches them
         to a thread pool, and sends acknowledgments upon completion.
         """
 
         sock = self.async_zmq_ctx.socket(zmq.ROUTER)
-        self.side_channel_port = sock.bind_to_random_port(f"tcp://{self.hostname}")
-        logger.debug(
-            "Mooncake sender starting listening on path: tcp://%s:%d",
-            self.hostname,
-            self.side_channel_port,
-        )
-
-        await self.register_worker_with_bootstrap()
-
-        # Create async worker tasks that process items from the queue
-        sender_tasks = [
-            asyncio.create_task(self._sender_worker(sock))
-            for _ in range(self.num_sender_tasks)
-        ]
-
-        ready_event.set()
-
+        sender_tasks = []
         try:
+            try:
+                bind_host = self.hostname
+                if is_valid_ipv6_address(bind_host):
+                    sock.setsockopt(zmq.IPV6, 1)
+                    bind_host = f"[{bind_host}]"
+                self.side_channel_port = sock.bind_to_random_port(f"tcp://{bind_host}")
+                logger.debug(
+                    "Mooncake sender starting listening on path: tcp://%s:%d",
+                    self.hostname,
+                    self.side_channel_port,
+                )
+
+                await self.register_worker_with_bootstrap()
+
+                # Create async worker tasks that process items from the queue
+                sender_tasks = [
+                    asyncio.create_task(self._sender_worker(sock))
+                    for _ in range(self.num_sender_tasks)
+                ]
+
+                ready_event.set()
+            except BaseException as e:
+                startup_error.append(e)
+                ready_event.set()
+                raise
+
             while True:
                 identity, metadata_bytes = await sock.recv_multipart()
                 await self.sender_worker_queue.put((identity, metadata_bytes))
         except zmq.ContextTerminated:
             logger.debug("ZMQ context terminated, exiting Mooncake sender thread.")
         except Exception as e:
+            if startup_error:
+                raise
             logger.error("Error in Mooncake sender thread: %s. Exiting thread.", str(e))
         finally:
             # Clean up worker tasks
@@ -1738,10 +1759,20 @@ class MooncakeConnectorWorker:
             return
 
         ready_event = threading.Event()
-        asyncio.run_coroutine_threadsafe(
-            self._mooncake_sender_listener(ready_event), self.sender_loop
+        startup_error: list[BaseException] = []
+        listener_future = asyncio.run_coroutine_threadsafe(
+            self._mooncake_sender_listener(ready_event, startup_error),
+            self.sender_loop,
         )
-        ready_event.wait()  # Wait for listener ZMQ socket to be ready.
+        if not ready_event.wait(timeout=30):
+            listener_future.cancel()
+            raise RuntimeError(
+                "Mooncake sender listener failed to start in 30 seconds."
+            )
+        if startup_error:
+            raise RuntimeError(
+                "Mooncake sender listener failed to start."
+            ) from startup_error[0]
 
     async def fetch_finished_recving_reqs(self) -> set[ReqId]:
         finished_recving_reqs = self.finished_recving_reqs


### PR DESCRIPTION


  Fix Mooncake producer startup when the sender side-channel listener binds to an IPv6 host.

  ## Purpose

  When VLLM_HOST_IP is an IPv6 address, the Mooncake producer registers KV caches and then starts a ZMQ side-channel listener for decoder pull requests. The listener previously bound with
  tcp://{self.hostname} without enabling zmq.IPV6 or bracketing IPv6 literals.

  If this background coroutine failed before setting ready_event, register_kv_caches() could wait indefinitely, making the engine appear stuck after Registering KV_Caches.

  This PR:

  - Enables zmq.IPV6 for IPv6 Mooncake sender listener binds.
  - Uses bracketed IPv6 ZMQ endpoints, e.g. tcp://[::1].
  - Propagates sender listener startup failures back to register_kv_caches().
  - Adds a startup timeout to avoid indefinite waits.

  ## Test Plan

  PYTHONPATH=/workspace/vllm-pr /root/vllm/bin/python -m pytest \
    tests/v1/kv_connector/unit/test_mooncake_connector.py::test_sender_listener_binds_ipv6_address \
    tests/v1/kv_connector/unit/test_mooncake_connector.py::test_sender_listener_reports_startup_error \
    -q

  env UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uvx ruff check \
    vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py \
    tests/v1/kv_connector/unit/test_mooncake_connector.py

  env UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uvx ruff format --check \
    vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py \
    tests/v1/kv_connector/unit/test_mooncake_connector.py

  /root/vllm/bin/python -m compileall -q \
    vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py \
    tests/v1/kv_connector/unit/test_mooncake_connector.py

  git diff --check

  ## Test Result

  2 passed, 22 warnings in 0.71s
  All checks passed!
  2 files already formatted
  compileall passed
  git diff --check passed

  