### PR TITLE
[Bugfix](sampling): search Qrita top-p pivots in log space

### DIFF
--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -326,27 +326,18 @@ class TestTritonTopkTopp:
 
     @pytest.mark.parametrize("k_value", [None, 32000])
     def test_topp_peaked_logits(self, k_value: int | None):
-        """Top-p pivot search must handle a wide probability dynamic range.
+        """Test the peaked distribution used by the target workload."""
+        from vllm.v1.sample.ops.topk_topp_triton import apply_top_k_top_p_triton
 
-        A few strongly boosted logits model the peaked distributions seen in
-        speculative decoding.  Linear probability-space bisection cannot
-        resolve the nucleus boundary within the kernel's 18-iteration cap.
-        """
         batch_size, vocab_size = 4, 128256
         logits = torch.randn(
             batch_size, vocab_size, generator=self.generator, dtype=torch.float32
         )
-        hot = torch.randint(
-            0,
-            vocab_size,
-            (batch_size, 8),
-            generator=self.generator,
-        )
         boosts = torch.tensor(
             [13.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0],
             dtype=torch.float32,
-        ).expand_as(hot)
-        logits.scatter_add_(1, hot, boosts)
+        )
+        logits[:, :8] += boosts
         k = (
             None
             if k_value is None
@@ -354,40 +345,13 @@ class TestTritonTopkTopp:
         )
         p = torch.full((batch_size,), 0.95, dtype=torch.float32)
 
-        self._compare_results(logits, k=k, p=p)
-
-    def test_topp_extreme_probability_range(self):
-        """Test nucleus boundaries near 1e-9 in probability space.
-
-        Thousands of tail tokens can have nearly identical, tiny
-        probabilities in this case, so probability-mass error is a more
-        meaningful measure than the exact number of retained tokens.
-        """
-        batch_size, vocab_size = 1, 128256
-        logits = torch.randn(
-            batch_size, vocab_size, generator=self.generator, dtype=torch.float32
-        )
-        logits[:, 0] = 20.0
-        p = torch.full((batch_size,), 0.9999, dtype=torch.float32)
-
-        from vllm.v1.sample.ops.topk_topp_triton import apply_top_k_top_p_triton
-
-        reference = apply_top_k_top_p_pytorch(logits.clone(), None, p)
-        result = apply_top_k_top_p_triton(logits.clone(), None, p)
+        reference = apply_top_k_top_p_pytorch(logits.clone(), k, p)
+        result = apply_top_k_top_p_triton(logits.clone(), k, p)
         total_variation = 0.5 * (
             reference.softmax(dim=-1) - result.softmax(dim=-1)
         ).abs().sum(dim=-1)
 
         assert total_variation.max().item() < 1e-4
-
-    def test_topp_near_uniform_logits(self):
-        """A narrow probability range must not look converged too early."""
-        batch_size, vocab_size = 1, 1024
-        row = torch.linspace(9.5e-5, -9.5e-5, vocab_size, dtype=torch.float32)
-        logits = row.expand(batch_size, -1).contiguous()
-        p = torch.full((batch_size,), 0.9, dtype=torch.float32)
-
-        self._compare_results(logits, k=None, p=p)
 
     @pytest.mark.parametrize("batch_size", [1, 8, 32, 128, 512, 1024])
     @pytest.mark.parametrize("vocab_size", [1024, 32000, 128256])

--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -351,6 +351,58 @@ class TestTritonTopkTopp:
 
         self._compare_results(logits, k=None, p=p)
 
+    def test_topk_topp_peaked_logits(self):
+        """Test fused top-k + top-p with a wide probability dynamic range."""
+        batch_size, vocab_size = 8, 128256
+        logits = torch.randn(
+            batch_size, vocab_size, generator=self.generator, dtype=torch.float32
+        )
+        hot = torch.randint(
+            0,
+            vocab_size,
+            (batch_size, 8),
+            generator=self.generator,
+        )
+        boosts = torch.tensor(
+            [13.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0],
+            dtype=torch.float32,
+        ).expand_as(hot)
+        logits.scatter_add_(1, hot, boosts)
+        k = torch.full((batch_size,), 32000, dtype=torch.int32)
+        p = torch.full((batch_size,), 0.95, dtype=torch.float32)
+
+        self._compare_results(logits, k=k, p=p)
+
+    @pytest.mark.parametrize("k_value", [None, 32000])
+    def test_topp_extreme_probability_range(self, k_value: int | None):
+        """Test nucleus boundaries near 1e-9 in probability space.
+
+        Thousands of tail tokens can have nearly identical, tiny
+        probabilities in this case, so probability-mass error is a more
+        meaningful measure than the exact number of retained tokens.
+        """
+        batch_size, vocab_size = 8, 128256
+        logits = torch.randn(
+            batch_size, vocab_size, generator=self.generator, dtype=torch.float32
+        )
+        logits[:, 0] = 20.0
+        k = (
+            None
+            if k_value is None
+            else torch.full((batch_size,), k_value, dtype=torch.int32)
+        )
+        p = torch.full((batch_size,), 0.9999, dtype=torch.float32)
+
+        from vllm.v1.sample.ops.topk_topp_triton import apply_top_k_top_p_triton
+
+        reference = apply_top_k_top_p_pytorch(logits.clone(), k, p)
+        result = apply_top_k_top_p_triton(logits.clone(), k, p)
+        total_variation = 0.5 * (
+            reference.softmax(dim=-1) - result.softmax(dim=-1)
+        ).abs().sum(dim=-1)
+
+        assert total_variation.max().item() < 1e-4
+
     @pytest.mark.parametrize("batch_size", [1, 8, 32, 128, 512, 1024])
     @pytest.mark.parametrize("vocab_size", [1024, 32000, 128256])
     def test_topk_and_topp(self, batch_size: int, vocab_size: int):

--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -324,6 +324,33 @@ class TestTritonTopkTopp:
 
         self._compare_results(logits, k=None, p=p)
 
+    @pytest.mark.parametrize("vocab_size", [32000, 128256])
+    def test_topp_only_peaked_logits(self, vocab_size: int):
+        """Top-p pivot search must handle a wide probability dynamic range.
+
+        A few strongly boosted logits model the peaked distributions seen in
+        speculative decoding.  Linear probability-space bisection cannot
+        resolve the nucleus boundary within the kernel's 18-iteration cap.
+        """
+        batch_size = 8
+        logits = torch.randn(
+            batch_size, vocab_size, generator=self.generator, dtype=torch.float32
+        )
+        hot = torch.randint(
+            0,
+            vocab_size,
+            (batch_size, 8),
+            generator=self.generator,
+        )
+        boosts = torch.tensor(
+            [13.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0],
+            dtype=torch.float32,
+        ).expand_as(hot)
+        logits.scatter_add_(1, hot, boosts)
+        p = torch.full((batch_size,), 0.95, dtype=torch.float32)
+
+        self._compare_results(logits, k=None, p=p)
+
     @pytest.mark.parametrize("batch_size", [1, 8, 32, 128, 512, 1024])
     @pytest.mark.parametrize("vocab_size", [1024, 32000, 128256])
     def test_topk_and_topp(self, batch_size: int, vocab_size: int):

--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -324,15 +324,15 @@ class TestTritonTopkTopp:
 
         self._compare_results(logits, k=None, p=p)
 
-    @pytest.mark.parametrize("vocab_size", [32000, 128256])
-    def test_topp_only_peaked_logits(self, vocab_size: int):
+    @pytest.mark.parametrize("k_value", [None, 32000])
+    def test_topp_peaked_logits(self, k_value: int | None):
         """Top-p pivot search must handle a wide probability dynamic range.
 
         A few strongly boosted logits model the peaked distributions seen in
         speculative decoding.  Linear probability-space bisection cannot
         resolve the nucleus boundary within the kernel's 18-iteration cap.
         """
-        batch_size = 8
+        batch_size, vocab_size = 4, 128256
         logits = torch.randn(
             batch_size, vocab_size, generator=self.generator, dtype=torch.float32
         )
@@ -347,61 +347,47 @@ class TestTritonTopkTopp:
             dtype=torch.float32,
         ).expand_as(hot)
         logits.scatter_add_(1, hot, boosts)
-        p = torch.full((batch_size,), 0.95, dtype=torch.float32)
-
-        self._compare_results(logits, k=None, p=p)
-
-    def test_topk_topp_peaked_logits(self):
-        """Test fused top-k + top-p with a wide probability dynamic range."""
-        batch_size, vocab_size = 8, 128256
-        logits = torch.randn(
-            batch_size, vocab_size, generator=self.generator, dtype=torch.float32
+        k = (
+            None
+            if k_value is None
+            else torch.full((batch_size,), k_value, dtype=torch.int32)
         )
-        hot = torch.randint(
-            0,
-            vocab_size,
-            (batch_size, 8),
-            generator=self.generator,
-        )
-        boosts = torch.tensor(
-            [13.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0],
-            dtype=torch.float32,
-        ).expand_as(hot)
-        logits.scatter_add_(1, hot, boosts)
-        k = torch.full((batch_size,), 32000, dtype=torch.int32)
         p = torch.full((batch_size,), 0.95, dtype=torch.float32)
 
         self._compare_results(logits, k=k, p=p)
 
-    @pytest.mark.parametrize("k_value", [None, 32000])
-    def test_topp_extreme_probability_range(self, k_value: int | None):
+    def test_topp_extreme_probability_range(self):
         """Test nucleus boundaries near 1e-9 in probability space.
 
         Thousands of tail tokens can have nearly identical, tiny
         probabilities in this case, so probability-mass error is a more
         meaningful measure than the exact number of retained tokens.
         """
-        batch_size, vocab_size = 8, 128256
+        batch_size, vocab_size = 1, 128256
         logits = torch.randn(
             batch_size, vocab_size, generator=self.generator, dtype=torch.float32
         )
         logits[:, 0] = 20.0
-        k = (
-            None
-            if k_value is None
-            else torch.full((batch_size,), k_value, dtype=torch.int32)
-        )
         p = torch.full((batch_size,), 0.9999, dtype=torch.float32)
 
         from vllm.v1.sample.ops.topk_topp_triton import apply_top_k_top_p_triton
 
-        reference = apply_top_k_top_p_pytorch(logits.clone(), k, p)
-        result = apply_top_k_top_p_triton(logits.clone(), k, p)
+        reference = apply_top_k_top_p_pytorch(logits.clone(), None, p)
+        result = apply_top_k_top_p_triton(logits.clone(), None, p)
         total_variation = 0.5 * (
             reference.softmax(dim=-1) - result.softmax(dim=-1)
         ).abs().sum(dim=-1)
 
         assert total_variation.max().item() < 1e-4
+
+    def test_topp_near_uniform_logits(self):
+        """A narrow probability range must not look converged too early."""
+        batch_size, vocab_size = 1, 1024
+        row = torch.linspace(9.5e-5, -9.5e-5, vocab_size, dtype=torch.float32)
+        logits = row.expand(batch_size, -1).contiguous()
+        p = torch.full((batch_size,), 0.9, dtype=torch.float32)
+
+        self._compare_results(logits, k=None, p=p)
 
     @pytest.mark.parametrize("batch_size", [1, 8, 32, 128, 512, 1024])
     @pytest.mark.parametrize("vocab_size", [1024, 32000, 128256])

--- a/vllm/v1/sample/ops/topk_topp_triton.py
+++ b/vllm/v1/sample/ops/topk_topp_triton.py
@@ -693,7 +693,15 @@ def _topk_topp_kernel(
 
                     found_pivot = 0
                     while found_pivot == 0:
-                        p_pivot_0 = (max_range - min_range) * 0.5 + min_range
+                        # Search in log-probability space.  An arithmetic
+                        # midpoint needs more than the fixed 18 iterations
+                        # below when a peaked row has max_probability close
+                        # to one but the nucleus boundary is several orders
+                        # of magnitude smaller.  The geometric midpoint
+                        # retains the same iteration cap while making the
+                        # convergence depend on the probability ratio rather
+                        # than its absolute range.
+                        p_pivot_0 = tl.sqrt(max_range * tl.maximum(min_range, 1e-30))
                         p_pivots_sum_0 = 0.0
                         min_larger_0 = 1.0
                         num_min_larger_0 = tl.zeros((), dtype=tl.uint32)
@@ -741,7 +749,7 @@ def _topk_topp_kernel(
 
                         num_iters += 1
                         if (max_range - min_range) < 1e-9 or num_iters >= 18:
-                            p_pivot = (max_range + min_range) / 2.0
+                            p_pivot = tl.sqrt(max_range * tl.maximum(min_range, 1e-30))
                             min_larger_prob = min_larger_0
                             num_min_larger = num_min_larger_0
                             p_pivots_sum = p_pivots_sum_0
@@ -761,7 +769,9 @@ def _topk_topp_kernel(
 
                     found_pivot = 0
                     while found_pivot == 0:
-                        p_pivot_0 = (max_range - min_range) * 0.5 + min_range
+                        # See the outlier-buffer branch above.  Use the same
+                        # log-space search when scanning the full vocabulary.
+                        p_pivot_0 = tl.sqrt(max_range * tl.maximum(min_range, 1e-30))
                         p_pivots_sum_0 = 0.0
                         min_larger_0 = 1.0
                         num_min_larger_0 = tl.zeros((), dtype=tl.uint32)
@@ -807,7 +817,7 @@ def _topk_topp_kernel(
 
                         num_iters += 1
                         if (max_range - min_range) < 1e-9 or num_iters >= 18:
-                            p_pivot = (max_range + min_range) / 2.0
+                            p_pivot = tl.sqrt(max_range * tl.maximum(min_range, 1e-30))
                             min_larger_prob = min_larger_0
                             num_min_larger = num_min_larger_0
                             p_pivots_sum = p_pivots_sum_0

--- a/vllm/v1/sample/ops/topk_topp_triton.py
+++ b/vllm/v1/sample/ops/topk_topp_triton.py
@@ -97,6 +97,12 @@ def _top_p_pivot_midpoint(max_range, min_range):
 
 
 @triton.jit
+def _top_p_search_converged(max_range, min_range):
+    """Require convergence in both absolute and relative probability space."""
+    return (max_range - min_range) < 1e-9 and max_range <= min_range * 1.0001
+
+
+@triton.jit
 def _topk_topp_kernel(
     LOGITS,
     LOGITS_STRIDE_0,
@@ -578,7 +584,10 @@ def _topk_topp_kernel(
                                 max_range = p_pivot_0
 
                             num_iters += 1
-                            if max_range <= min_range * 1.0001 or num_iters >= 18:
+                            if (
+                                _top_p_search_converged(max_range, min_range)
+                                or num_iters >= 18
+                            ):
                                 # Keep the pivot consistent with the
                                 # min-larger statistics computed above.
                                 p_pivot = p_pivot_0
@@ -748,7 +757,10 @@ def _topk_topp_kernel(
                             max_range = p_pivot_0
 
                         num_iters += 1
-                        if max_range <= min_range * 1.0001 or num_iters >= 18:
+                        if (
+                            _top_p_search_converged(max_range, min_range)
+                            or num_iters >= 18
+                        ):
                             # Keep the pivot consistent with the min-larger
                             # statistics computed above.
                             p_pivot = p_pivot_0
@@ -816,7 +828,10 @@ def _topk_topp_kernel(
                             max_range = p_pivot_0
 
                         num_iters += 1
-                        if max_range <= min_range * 1.0001 or num_iters >= 18:
+                        if (
+                            _top_p_search_converged(max_range, min_range)
+                            or num_iters >= 18
+                        ):
                             # Keep the pivot consistent with the min-larger
                             # statistics computed above.
                             p_pivot = p_pivot_0

--- a/vllm/v1/sample/ops/topk_topp_triton.py
+++ b/vllm/v1/sample/ops/topk_topp_triton.py
@@ -91,6 +91,12 @@ def _update_min_larger_stats(data, above_mask, min_larger, num_min_larger, senti
 
 
 @triton.jit
+def _top_p_pivot_midpoint(max_range, min_range):
+    """Return a midpoint that converges uniformly across probability scales."""
+    return tl.sqrt(max_range * tl.maximum(min_range, 1e-30))
+
+
+@triton.jit
 def _topk_topp_kernel(
     LOGITS,
     LOGITS_STRIDE_0,
@@ -524,7 +530,7 @@ def _topk_topp_kernel(
                         # Fifth passes: Search for p_pivot
                         found_pivot = 0
                         while found_pivot == 0:
-                            p_pivot_0 = (max_range - min_range) * 0.5 + min_range
+                            p_pivot_0 = _top_p_pivot_midpoint(max_range, min_range)
                             p_pivots_sum_0 = 0.0
                             min_larger_0 = 1.0
                             num_min_larger_0 = tl.zeros((), dtype=tl.uint32)
@@ -572,8 +578,10 @@ def _topk_topp_kernel(
                                 max_range = p_pivot_0
 
                             num_iters += 1
-                            if (max_range - min_range) < 1e-9 or num_iters >= 18:
-                                p_pivot = (max_range + min_range) / 2.0
+                            if max_range <= min_range * 1.0001 or num_iters >= 18:
+                                # Keep the pivot consistent with the
+                                # min-larger statistics computed above.
+                                p_pivot = p_pivot_0
                                 min_larger_prob = min_larger_0
                                 num_min_larger = num_min_larger_0
                                 p_pivots_sum = p_pivots_sum_0
@@ -693,15 +701,7 @@ def _topk_topp_kernel(
 
                     found_pivot = 0
                     while found_pivot == 0:
-                        # Search in log-probability space.  An arithmetic
-                        # midpoint needs more than the fixed 18 iterations
-                        # below when a peaked row has max_probability close
-                        # to one but the nucleus boundary is several orders
-                        # of magnitude smaller.  The geometric midpoint
-                        # retains the same iteration cap while making the
-                        # convergence depend on the probability ratio rather
-                        # than its absolute range.
-                        p_pivot_0 = tl.sqrt(max_range * tl.maximum(min_range, 1e-30))
+                        p_pivot_0 = _top_p_pivot_midpoint(max_range, min_range)
                         p_pivots_sum_0 = 0.0
                         min_larger_0 = 1.0
                         num_min_larger_0 = tl.zeros((), dtype=tl.uint32)
@@ -748,8 +748,10 @@ def _topk_topp_kernel(
                             max_range = p_pivot_0
 
                         num_iters += 1
-                        if (max_range - min_range) < 1e-9 or num_iters >= 18:
-                            p_pivot = tl.sqrt(max_range * tl.maximum(min_range, 1e-30))
+                        if max_range <= min_range * 1.0001 or num_iters >= 18:
+                            # Keep the pivot consistent with the min-larger
+                            # statistics computed above.
+                            p_pivot = p_pivot_0
                             min_larger_prob = min_larger_0
                             num_min_larger = num_min_larger_0
                             p_pivots_sum = p_pivots_sum_0
@@ -769,9 +771,7 @@ def _topk_topp_kernel(
 
                     found_pivot = 0
                     while found_pivot == 0:
-                        # See the outlier-buffer branch above.  Use the same
-                        # log-space search when scanning the full vocabulary.
-                        p_pivot_0 = tl.sqrt(max_range * tl.maximum(min_range, 1e-30))
+                        p_pivot_0 = _top_p_pivot_midpoint(max_range, min_range)
                         p_pivots_sum_0 = 0.0
                         min_larger_0 = 1.0
                         num_min_larger_0 = tl.zeros((), dtype=tl.uint32)
@@ -816,8 +816,10 @@ def _topk_topp_kernel(
                             max_range = p_pivot_0
 
                         num_iters += 1
-                        if (max_range - min_range) < 1e-9 or num_iters >= 18:
-                            p_pivot = tl.sqrt(max_range * tl.maximum(min_range, 1e-30))
+                        if max_range <= min_range * 1.0001 or num_iters >= 18:
+                            # Keep the pivot consistent with the min-larger
+                            # statistics computed above.
+                            p_pivot = p_pivot_0
                             min_larger_prob = min_larger_0
                             num_min_larger = num_min_larger_0
                             p_pivots_sum = p_pivots_sum_0

--- a/vllm/v1/sample/ops/topk_topp_triton.py
+++ b/vllm/v1/sample/ops/topk_topp_triton.py
@@ -91,18 +91,6 @@ def _update_min_larger_stats(data, above_mask, min_larger, num_min_larger, senti
 
 
 @triton.jit
-def _top_p_pivot_midpoint(max_range, min_range):
-    """Return a midpoint that converges uniformly across probability scales."""
-    return tl.sqrt(max_range * tl.maximum(min_range, 1e-30))
-
-
-@triton.jit
-def _top_p_search_converged(max_range, min_range):
-    """Require convergence in both absolute and relative probability space."""
-    return (max_range - min_range) < 1e-9 and max_range <= min_range * 1.0001
-
-
-@triton.jit
 def _topk_topp_kernel(
     LOGITS,
     LOGITS_STRIDE_0,
@@ -536,7 +524,9 @@ def _topk_topp_kernel(
                         # Fifth passes: Search for p_pivot
                         found_pivot = 0
                         while found_pivot == 0:
-                            p_pivot_0 = _top_p_pivot_midpoint(max_range, min_range)
+                            p_pivot_0 = tl.sqrt(
+                                max_range * tl.maximum(min_range, 1e-30)
+                            )
                             p_pivots_sum_0 = 0.0
                             min_larger_0 = 1.0
                             num_min_larger_0 = tl.zeros((), dtype=tl.uint32)
@@ -585,9 +575,9 @@ def _topk_topp_kernel(
 
                             num_iters += 1
                             if (
-                                _top_p_search_converged(max_range, min_range)
-                                or num_iters >= 18
-                            ):
+                                (max_range - min_range) < 1e-9
+                                and max_range <= min_range * 1.0001
+                            ) or num_iters >= 18:
                                 # Keep the pivot consistent with the
                                 # min-larger statistics computed above.
                                 p_pivot = p_pivot_0
@@ -710,7 +700,7 @@ def _topk_topp_kernel(
 
                     found_pivot = 0
                     while found_pivot == 0:
-                        p_pivot_0 = _top_p_pivot_midpoint(max_range, min_range)
+                        p_pivot_0 = tl.sqrt(max_range * tl.maximum(min_range, 1e-30))
                         p_pivots_sum_0 = 0.0
                         min_larger_0 = 1.0
                         num_min_larger_0 = tl.zeros((), dtype=tl.uint32)
@@ -758,9 +748,9 @@ def _topk_topp_kernel(
 
                         num_iters += 1
                         if (
-                            _top_p_search_converged(max_range, min_range)
-                            or num_iters >= 18
-                        ):
+                            (max_range - min_range) < 1e-9
+                            and max_range <= min_range * 1.0001
+                        ) or num_iters >= 18:
                             # Keep the pivot consistent with the min-larger
                             # statistics computed above.
                             p_pivot = p_pivot_0
@@ -783,7 +773,7 @@ def _topk_topp_kernel(
 
                     found_pivot = 0
                     while found_pivot == 0:
-                        p_pivot_0 = _top_p_pivot_midpoint(max_range, min_range)
+                        p_pivot_0 = tl.sqrt(max_range * tl.maximum(min_range, 1e-30))
                         p_pivots_sum_0 = 0.0
                         min_larger_0 = 1.0
                         num_min_larger_0 = tl.zeros((), dtype=tl.uint32)
@@ -829,9 +819,9 @@ def _topk_topp_kernel(
 
                         num_iters += 1
                         if (
-                            _top_p_search_converged(max_range, min_range)
-                            or num_iters >= 18
-                        ):
+                            (max_range - min_range) < 1e-9
+                            and max_range <= min_range * 1.0001
+                        ) or num_iters >= 18:
                             # Keep the pivot consistent with the min-larger
                             # statistics computed above.
                             p_pivot = p_pivot_0


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Search Qrita top-p pivots in log-probability space to improve accuracy on peaked distributions without regressing performance.

## Test Plan

Run an inline Python benchmark in the vLLM 0.25.0 container that generates and JIT-compiles both the before and after Triton kernels, then compares them against the PyTorch reference and benchmarks the `384 × 154,880` workload:

<details>

```bash
python3 - <<'PY'
import ast
import gc
import importlib.util
import statistics
import sys
import tempfile
from pathlib import Path

import torch
import vllm
import vllm.v1.sample.ops.topk_topp_triton as installed
from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p_pytorch


class QritaVariant(ast.NodeTransformer):
    """Generate the before or after version of PR #48927."""

    def __init__(self, after: bool):
        self.after = after
        self.in_kernel = False
        self.pivots = 0
        self.exits = 0

    @staticmethod
    def expr(source):
        return ast.parse(source, mode="eval").body

    @staticmethod
    def assigns_name(statement, name):
        return (
            isinstance(statement, ast.Assign)
            and len(statement.targets) == 1
            and isinstance(statement.targets[0], ast.Name)
            and statement.targets[0].id == name
        )

    def visit_FunctionDef(self, node):
        old = self.in_kernel
        if node.name == "_topk_topp_kernel":
            self.in_kernel = True
        self.generic_visit(node)
        self.in_kernel = old
        return node

    def visit_Assign(self, node):
        self.generic_visit(node)

        if (
            self.in_kernel
            and len(node.targets) == 1
            and isinstance(node.targets[0], ast.Name)
            and node.targets[0].id == "p_pivot_0"
        ):
            node.value = self.expr(
                "tl.sqrt(max_range * tl.maximum(min_range, 1e-30))"
                if self.after
                else "(max_range - min_range) * 0.5 + min_range"
            )
            self.pivots += 1

        return node

    def visit_If(self, node):
        self.generic_visit(node)

        if not self.in_kernel or "num_iters >= 18" not in ast.unparse(node.test):
            return node

        # Only the three top-p fallback branches assign p_pivot directly.
        pivot_assignment = next(
            (
                statement
                for statement in node.body
                if self.assigns_name(statement, "p_pivot")
            ),
            None,
        )
        if pivot_assignment is None:
            return node

        node.test = self.expr(
            (
                "((max_range - min_range) < 1e-9 "
                "and max_range <= min_range * 1.0001) "
                "or num_iters >= 18"
            )
            if self.after
            else "(max_range - min_range) < 1e-9 or num_iters >= 18"
        )

        pivot_assignment.value = self.expr(
            "p_pivot_0"
            if self.after
            else "(max_range + min_range) / 2.0"
        )
        self.exits += 1
        return node


def load_variant(source, module_name, after, directory):
    tree = ast.parse(source)
    transform = QritaVariant(after)
    tree = transform.visit(tree)
    ast.fix_missing_locations(tree)

    if (transform.pivots, transform.exits) != (3, 3):
        raise RuntimeError(
            "Unexpected Qrita structure: "
            f"pivots={transform.pivots}, exits={transform.exits}"
        )

    path = Path(directory) / f"{module_name}.py"
    path.write_text(ast.unparse(tree))

    spec = importlib.util.spec_from_file_location(module_name, path)
    module = importlib.util.module_from_spec(spec)
    sys.modules[module_name] = module
    spec.loader.exec_module(module)
    return module


def make_peaked_logits(batch, vocab, seed):
    generator = torch.Generator(device="cuda").manual_seed(seed)
    logits = torch.randn(
        batch,
        vocab,
        device="cuda",
        dtype=torch.float32,
        generator=generator,
    )
    hot = torch.randint(
        vocab,
        (batch, 8),
        device="cuda",
        generator=generator,
    )
    boosts = torch.tensor(
        [13.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0],
        device="cuda",
    ).expand_as(hot)
    logits.scatter_add_(1, hot, boosts)
    return logits


@torch.inference_mode()
def accuracy_case(name, logits, k, p, variants):
    reference = apply_top_k_top_p_pytorch(logits.clone(), k, p)
    reference_probs = reference.softmax(dim=-1)

    print(name)
    for variant_name, function in variants:
        output = function(logits.clone(), k, p)
        tv = 0.5 * (
            reference_probs - output.softmax(dim=-1)
        ).abs().sum(dim=-1)

        print(
            f"  {variant_name:6s} "
            f"TV mean={tv.mean().item():.6e}, "
            f"max={tv.max().item():.6e}"
        )

    del reference, reference_probs


@torch.inference_mode()
def latency_case(name, logits, k, p, variants):
    print(name)

    for variant_name, function in variants:
        # Compile and warm up.
        for _ in range(5):
            output = function(logits.clone(), k, p)
        torch.cuda.synchronize()

        samples = []
        for _ in range(20):
            start = torch.cuda.Event(enable_timing=True)
            end = torch.cuda.Event(enable_timing=True)

            start.record()
            output = function(logits.clone(), k, p)
            end.record()
            end.synchronize()

            samples.append(start.elapsed_time(end))

        print(
            f"  {variant_name:6s} "
            f"median={statistics.median(samples):.3f} ms, "
            f"mean={statistics.mean(samples):.3f} ms"
        )


if not torch.cuda.is_available():
    raise RuntimeError("CUDA GPU required")

source_path = Path(installed.__file__)
source = source_path.read_text()

with tempfile.TemporaryDirectory() as directory:
    before_module = load_variant(
        source, "_qrita_before_48927", False, directory
    )
    after_module = load_variant(
        source, "_qrita_after_48927", True, directory
    )

    variants = [
        ("before", before_module.apply_top_k_top_p_triton),
        ("after", after_module.apply_top_k_top_p_triton),
    ]

    vocab = 154_880

    print(f"vLLM: {vllm.__version__}")
    print(f"GPU:   {torch.cuda.get_device_name(0)}")
    print(f"File:  {source_path}")
    print()

    # Fast correctness check: only four rows.
    accuracy_logits = make_peaked_logits(4, vocab, 42)
    accuracy_p = torch.full(
        (4,), 0.95, device="cuda", dtype=torch.float32
    )
    accuracy_k = torch.full(
        (4,), 32_000, device="cuda", dtype=torch.int32
    )

    accuracy_case(
        "Accuracy: standalone top-p",
        accuracy_logits,
        None,
        accuracy_p,
        variants,
    )
    accuracy_case(
        "Accuracy: fused top-k + top-p",
        accuracy_logits,
        accuracy_k,
        accuracy_p,
        variants,
    )

    del accuracy_logits, accuracy_p, accuracy_k
    gc.collect()
    torch.cuda.empty_cache()
    print()

    # PR workload: 384 × 154,880. No slow PyTorch reference here.
    perf_logits = make_peaked_logits(384, vocab, 43)
    perf_p = torch.full(
        (384,), 0.95, device="cuda", dtype=torch.float32
    )
    perf_k = torch.full(
        (384,), 32_000, device="cuda", dtype=torch.int32
    )

    latency_case(
        "Latency: standalone top-p, 384 x 154880",
        perf_logits,
        None,
        perf_p,
        variants,
    )
    latency_case(
        "Latency: fused top-k + top-p, 384 x 154880",
        perf_logits,
        perf_k,
        perf_p,
        variants,
    )
PY
```

</details>

Environment:

```text
vLLM: 0.25.0
GPU: NVIDIA GeForce RTX 5090
```
Workload simulates GLM-5.2 (top_p=0.95) serving at 1024 decode concurrency with DEP8 and MTP3, yielding 384 sampling rows per rank over a 154,880-token vocabulary.

## Test Result

```text
vLLM: 0.25.0
GPU:   50Series
File:  /usr/local/lib/python3.12/dist-packages/vllm/v1/sample/ops/topk_topp_triton.py

Accuracy: standalone top-p
  before TV mean=1.510686e-02, max=2.288285e-02
  after  TV mean=4.230319e-06, max=8.308022e-06
Accuracy: fused top-k + top-p
  before TV mean=1.163947e-02, max=2.188168e-02
  after  TV mean=1.368576e-05, max=2.996346e-05

Latency: standalone top-p, 384 x 154880
  before median=3.012 ms, mean=3.017 ms
  after  median=2.850 ms, mean=2.847 ms
Latency: fused top-k + top-p, 384 x 154880
  before median=1.958 ms, mean=1.958 ms
  after  median=1.967 ms, mean=1.967 ms
```

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

* [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
* [x] The test plan, such as providing test command.
* [x] The test results, such as pasting the results comparison before and after, or e2e results
* [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

</details>
