### PR TITLE
[Spec Decode] Fix speculators-format DSpark loading; mirror repetition penalty on DSpark draft logits

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -283,6 +283,16 @@ class SpeculativeConfig:
     during rejection sampling. This comes at the cost of additional GPU memory
     usage."""
 
+    draft_apply_repetition_penalty: bool = False
+    """Mirror the target's repetition penalty on the draft logits before draft
+    sampling. With draft_sample_method='probabilistic', the rejection test
+    compares the draft distribution p against a target q that has the
+    repetition penalty applied; without the mirror, every context-repeated
+    token has q suppressed but p not, which costs acceptance on
+    repetition-rich outputs (e.g. TTS speech tokens). Only used by drafters
+    that support it (currently DSpark) and only with probabilistic draft
+    sampling. Frequency/presence penalties are not mirrored."""
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,
@@ -1182,6 +1192,17 @@ class SpeculativeConfig:
                 "use_heterogeneous_vocab currently only supports greedy draft "
                 "sampling. Set draft_sample_method='greedy' (the default) or "
                 "omit it."
+            )
+
+        if (
+            self.draft_apply_repetition_penalty
+            and self.draft_sample_method != "probabilistic"
+        ):
+            raise ValueError(
+                "draft_apply_repetition_penalty requires "
+                "draft_sample_method='probabilistic' (greedy rejection "
+                "verifies by exact argmax match, where the penalty mirror "
+                "does not apply)."
             )
 
         if not self.use_heterogeneous_vocab:

--- a/vllm/transformers_utils/configs/speculators/algos.py
+++ b/vllm/transformers_utils/configs/speculators/algos.py
@@ -155,6 +155,15 @@ def update_dspark(config_dict: dict, pre_trained_config: dict) -> None:
     pre_trained_config["eagle_aux_hidden_state_layer_ids"] = aux_layer_ids
     # DSpark indexes target layers as aux_id - 1 (matches the dense configs).
     pre_trained_config["target_layer_ids"] = [i - 1 for i in aux_layer_ids]
+    # DFlashQwen3Model sizes the aux-hidden fc from
+    # drafter_config["target_layer_ids"] (eagle_config | dflash_config) and
+    # otherwise falls back to num_hidden_layers, which only matches when the
+    # draft layer count equals the aux layer count. Mirror update_dflash so
+    # DSpark drafts with num_hidden_layers != len(aux_layer_ids) load.
+    pre_trained_config["dflash_config"] = {
+        "mask_token_id": config_dict["mask_token_id"],
+        "target_layer_ids": [i - 1 for i in aux_layer_ids],
+    }
 
     for key in (
         "draft_vocab_size",

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -347,6 +347,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 vocab_size=self.vocab_size,
                 device=self.device,
             )
+            # Let drafters mirror the target's repetition penalty so
+            # probabilistic rejection sampling compares aligned p/q
+            # distributions (opt-in via VLLM_DRAFT_REP_PENALTY=1).
+            if self.speculator is not None and hasattr(
+                self.speculator, "set_penalties_state"
+            ):
+                self.speculator.set_penalties_state(self.sampler.penalties_state)
 
         if self.is_pooling_model and self.is_last_pp_rank:
             self.pooling_runner = PoolingRunner(self.model)

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -347,17 +347,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 vocab_size=self.vocab_size,
                 device=self.device,
             )
-            # Let drafters mirror the target's repetition penalty and
-            # top-k/top-p so probabilistic rejection sampling compares aligned
-            # p/q distributions (opt-in via VLLM_DRAFT_REP_PENALTY=1 /
-            # VLLM_DRAFT_TOPK_TOPP=1).
+            # Let drafters mirror the target's repetition penalty so
+            # probabilistic rejection sampling compares aligned p/q
+            # distributions (opt-in via VLLM_DRAFT_REP_PENALTY=1).
             if self.speculator is not None and hasattr(
                 self.speculator, "set_penalties_state"
             ):
-                self.speculator.set_penalties_state(
-                    self.sampler.penalties_state,
-                    self.sampler.sampling_states,
-                )
+                self.speculator.set_penalties_state(self.sampler.penalties_state)
 
         if self.is_pooling_model and self.is_last_pp_rank:
             self.pooling_runner = PoolingRunner(self.model)

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -347,13 +347,17 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 vocab_size=self.vocab_size,
                 device=self.device,
             )
-            # Let drafters mirror the target's repetition penalty so
-            # probabilistic rejection sampling compares aligned p/q
-            # distributions (opt-in via VLLM_DRAFT_REP_PENALTY=1).
+            # Let drafters mirror the target's repetition penalty and
+            # top-k/top-p so probabilistic rejection sampling compares aligned
+            # p/q distributions (opt-in via VLLM_DRAFT_REP_PENALTY=1 /
+            # VLLM_DRAFT_TOPK_TOPP=1).
             if self.speculator is not None and hasattr(
                 self.speculator, "set_penalties_state"
             ):
-                self.speculator.set_penalties_state(self.sampler.penalties_state)
+                self.speculator.set_penalties_state(
+                    self.sampler.penalties_state,
+                    self.sampler.sampling_states,
+                )
 
         if self.is_pooling_model and self.is_last_pp_rank:
             self.pooling_runner = PoolingRunner(self.model)

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -349,7 +349,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             )
             # Let drafters mirror the target's repetition penalty so
             # probabilistic rejection sampling compares aligned p/q
-            # distributions (opt-in via VLLM_DRAFT_REP_PENALTY=1).
+            # distributions (opt-in via speculative_config.
+            # draft_apply_repetition_penalty).
             if self.speculator is not None and hasattr(
                 self.speculator, "set_penalties_state"
             ):

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -26,11 +26,10 @@ backbone forward AND the sequential Markov sampling.
 from typing import Any
 
 import torch
-import triton
-import triton.language as tl
 
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
+from vllm.triton_utils import tl, triton
 from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
 from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
 from vllm.v1.worker.gpu.spec_decode.dspark.utils import load_dspark_model

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -145,22 +145,22 @@ class DSparkSpeculator(DFlashSpeculator):
         self._d2t_scatter_index: torch.Tensor | None = None
         self._draft_scatter_buf: torch.Tensor | None = None
 
-        # PATCH (local): draft-side repetition penalty. When enabled (env
-        # VLLM_DRAFT_REP_PENALTY=1 + probabilistic drafting), the drafter
-        # mirrors the target's repetition-penalty logit transform so the
-        # rejection test compares aligned p/q distributions. Without this,
-        # every context-repeated token has q suppressed but p not, which
-        # costs speculation acceptance heavily on repetition-rich outputs
-        # (e.g. TTS speech tokens). Set via set_penalties_state().
+        # Draft-side repetition penalty (speculative_config.
+        # draft_apply_repetition_penalty): the drafter mirrors the target's
+        # repetition-penalty logit transform so the rejection test compares
+        # aligned p/q distributions. Without this, every context-repeated
+        # token has q suppressed but p not, which costs speculation
+        # acceptance heavily on repetition-rich outputs (e.g. TTS speech
+        # tokens). Set via set_penalties_state().
         self._penalties_state = None
 
     def set_penalties_state(self, penalties_state) -> None:
-        import os
-
         if self.draft_logits is None:
-            # Greedy drafting: rejection uses exact match, p/q alignment moot.
+            # Greedy drafting: rejection uses exact match, p/q alignment moot
+            # (draft_apply_repetition_penalty + greedy is rejected at
+            # config time).
             return
-        if os.environ.get("VLLM_DRAFT_REP_PENALTY", "0") == "1":
+        if self.speculative_config.draft_apply_repetition_penalty:
             self._penalties_state = penalties_state
 
     def load_draft_model(
@@ -205,7 +205,7 @@ class DSparkSpeculator(DFlashSpeculator):
         # read via the precomputed persistent index (fixed buffer for capture).
         prev = self.input_buffers.input_ids[self._anchor_idx[:num_reqs]]
 
-        # PATCH (local): per-request state for the draft-side repetition
+        # Per-request state for the draft-side repetition
         # penalty (_draft_penalties_kernel). pen_rows is block-constant; the
         # kernel adds the in-block draft tokens t_0..t_{i-1} per step from
         # self.draft_tokens.
@@ -219,7 +219,7 @@ class DSparkSpeculator(DFlashSpeculator):
             bias = self.model.markov_bias(markov_embed)
             logits_i = base_logits[:, i] + bias
             if self.draft_logits is not None:
-                # PATCH (local): mirror the target's repetition-penalty logit
+                # Mirror the target's repetition-penalty logit
                 # transform on the draft logits (fused triton kernel, mutates
                 # logits_i in place; per-row early exit when rep == 1.0).
                 # Runs BEFORE the d2t scatter so the kernel only touches

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -49,14 +49,21 @@ def _draft_penalties_kernel(
     prompt_bin_mask_stride,
     output_bin_counts_ptr,
     output_bin_counts_stride,
-    vocab_size,
+    d2t_index_ptr,  # [vocab_size] draft column -> target id (HAS_D2T only)
+    vocab_size,  # row width of logits (draft vocab when HAS_D2T)
     BLOCK_SIZE: tl.constexpr,
+    HAS_D2T: tl.constexpr,
 ):
     """Draft-side mirror of the target's _penalties_kernel (rep penalty only).
 
     Penalized set = prompt bin mask | output bin counts | draft tokens
     t_0..t_{step_i-1} sampled earlier in this block — identical to what the
     verify kernel accumulates for the row checking t_{step_i}.
+
+    With HAS_D2T, logits are in the (reduced) draft-vocab space and each
+    column's target id is looked up via d2t_index — the penalty statistics
+    (target-vocab sized) are gathered per element. draft_tokens hold target
+    ids in both modes.
     """
     req_idx = tl.program_id(0).to(tl.int64)
     state_idx = tl.load(rows_ptr + req_idx).to(tl.int64)
@@ -70,25 +77,28 @@ def _draft_penalties_kernel(
     logits = tl.load(logits_ptr + req_idx * logits_stride + block, mask=mask)
     logits = logits.to(tl.float32)
 
+    if HAS_D2T:
+        tgt = tl.load(d2t_index_ptr + block, mask=mask, other=0).to(tl.int64)
+    else:
+        tgt = block.to(tl.int64)
+
     counts = tl.load(
-        output_bin_counts_ptr + state_idx * output_bin_counts_stride + block,
+        output_bin_counts_ptr + state_idx * output_bin_counts_stride + tgt,
         mask=mask,
         other=0,
     )
     pen_mask = counts > 0
 
-    packed_block = block_idx * BLOCK_SIZE // 32 + tl.arange(0, BLOCK_SIZE // 32)
-    packed = tl.load(
-        prompt_bin_mask_ptr + state_idx * prompt_bin_mask_stride + packed_block,
-        mask=packed_block < tl.cdiv(vocab_size, 32),
+    word = tl.load(
+        prompt_bin_mask_ptr + state_idx * prompt_bin_mask_stride + (tgt >> 5),
+        mask=mask,
         other=0,
     )
-    prompt_bits = (packed[:, None] >> (tl.arange(0, 32)[None, :])) & 1
-    pen_mask |= prompt_bits.to(tl.int1).reshape(BLOCK_SIZE)
+    pen_mask |= ((word >> (tgt & 31)) & 1).to(tl.int1)
 
     for j in tl.range(step_i):
         t = tl.load(draft_tokens_ptr + req_idx * draft_tokens_stride + j)
-        pen_mask |= block == t
+        pen_mask |= tgt == t
 
     scale = tl.where(pen_mask, rep, 1.0)
     logits *= tl.where(logits > 0, 1.0 / scale, scale)
@@ -233,18 +243,15 @@ class DSparkSpeculator(DFlashSpeculator):
             bias = self.model.markov_bias(markov_embed)
             logits_i = base_logits[:, i] + bias
             if self.draft_logits is not None:
-                # Probabilistic: sample in target vocab (a reduced draft vocab is
-                # scattered into its target columns; full vocab is already there).
-                if self._d2t_scatter_index is not None:
-                    assert self._draft_scatter_buf is not None
-                    buf = self._draft_scatter_buf[:num_reqs]
-                    buf.index_copy_(1, self._d2t_scatter_index, logits_i.to(buf.dtype))
-                    logits_i = buf
                 # PATCH (local): mirror the target's repetition-penalty logit
                 # transform on the draft logits (fused triton kernel, mutates
                 # logits_i in place; per-row early exit when rep == 1.0).
+                # Runs BEFORE the d2t scatter so the kernel (and the top-k/p
+                # mirror below) only touch draft-vocab-sized rows; target-vocab
+                # penalty statistics are gathered via the d2t index.
                 if pen_rows is not None:
                     ps = self._penalties_state
+                    logits_i = logits_i.contiguous()
                     vocab = logits_i.shape[-1]
                     blk = 8192
                     _draft_penalties_kernel[(num_reqs, triton.cdiv(vocab, blk))](
@@ -259,14 +266,22 @@ class DSparkSpeculator(DFlashSpeculator):
                         ps.prompt_bin_mask.stride(0),
                         ps.output_bin_counts,
                         ps.output_bin_counts.stride(0),
+                        # Placeholder pointer when there is no d2t map; the
+                        # kernel never dereferences it with HAS_D2T=False.
+                        self._d2t_scatter_index
+                        if self._d2t_scatter_index is not None
+                        else self.draft_tokens,
                         vocab,
                         BLOCK_SIZE=blk,
+                        HAS_D2T=self._d2t_scatter_index is not None,
                     )
                 # PATCH (local): mirror the target's top-k/top-p truncation so
                 # the draft never proposes tokens the target has zeroed out.
                 # Order matches the target sampler: penalties -> temperature
                 # -> top-k/top-p (top-p is computed on temperature-scaled
-                # logits within the top-k set).
+                # logits within the top-k set). Also pre-scatter: the d2t
+                # scatter is value-preserving into a -inf background, so
+                # top-k/thresholds computed on the draft vocab are identical.
                 if tk_state is not None:
                     k_eff, k_enabled, within_k, p_req, temp = tk_state
                     vals = torch.topk(
@@ -292,6 +307,13 @@ class DSparkSpeculator(DFlashSpeculator):
                         logits_i,
                         torch.full((), float("-inf"), device=vals.device),
                     )
+                # Probabilistic: sample in target vocab (a reduced draft vocab is
+                # scattered into its target columns; full vocab is already there).
+                if self._d2t_scatter_index is not None:
+                    assert self._draft_scatter_buf is not None
+                    buf = self._draft_scatter_buf[:num_reqs]
+                    buf.index_copy_(1, self._d2t_scatter_index, logits_i.to(buf.dtype))
+                    logits_i = buf
                 # sample_pos is the predicted token's position Q; the target
                 # verifies it with the predecessor's Gumbel key (Q-1). Pass Q-1.
                 draft_sampled_i = gumbel_sample(

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -26,12 +26,73 @@ backbone forward AND the sequential Markov sampling.
 from typing import Any
 
 import torch
+import triton
+import triton.language as tl
 
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
 from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
 from vllm.v1.worker.gpu.spec_decode.dspark.utils import load_dspark_model
+
+
+@triton.jit(do_not_specialize=["step_i"])
+def _draft_penalties_kernel(
+    logits_ptr,
+    logits_stride,
+    rows_ptr,  # [num_reqs] req-state indices
+    draft_tokens_ptr,  # [max_num_reqs, n_spec] tokens sampled so far this block
+    draft_tokens_stride,
+    step_i,  # number of in-block tokens sampled before this step
+    repetition_penalty_ptr,
+    prompt_bin_mask_ptr,
+    prompt_bin_mask_stride,
+    output_bin_counts_ptr,
+    output_bin_counts_stride,
+    vocab_size,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Draft-side mirror of the target's _penalties_kernel (rep penalty only).
+
+    Penalized set = prompt bin mask | output bin counts | draft tokens
+    t_0..t_{step_i-1} sampled earlier in this block — identical to what the
+    verify kernel accumulates for the row checking t_{step_i}.
+    """
+    req_idx = tl.program_id(0).to(tl.int64)
+    state_idx = tl.load(rows_ptr + req_idx).to(tl.int64)
+    rep = tl.load(repetition_penalty_ptr + state_idx)
+    if rep == 1.0:
+        return
+
+    block_idx = tl.program_id(1)
+    block = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = block < vocab_size
+    logits = tl.load(logits_ptr + req_idx * logits_stride + block, mask=mask)
+    logits = logits.to(tl.float32)
+
+    counts = tl.load(
+        output_bin_counts_ptr + state_idx * output_bin_counts_stride + block,
+        mask=mask,
+        other=0,
+    )
+    pen_mask = counts > 0
+
+    packed_block = block_idx * BLOCK_SIZE // 32 + tl.arange(0, BLOCK_SIZE // 32)
+    packed = tl.load(
+        prompt_bin_mask_ptr + state_idx * prompt_bin_mask_stride + packed_block,
+        mask=packed_block < tl.cdiv(vocab_size, 32),
+        other=0,
+    )
+    prompt_bits = (packed[:, None] >> (tl.arange(0, 32)[None, :])) & 1
+    pen_mask |= prompt_bits.to(tl.int1).reshape(BLOCK_SIZE)
+
+    for j in tl.range(step_i):
+        t = tl.load(draft_tokens_ptr + req_idx * draft_tokens_stride + j)
+        pen_mask |= block == t
+
+    scale = tl.where(pen_mask, rep, 1.0)
+    logits *= tl.where(logits > 0, 1.0 / scale, scale)
+    tl.store(logits_ptr + req_idx * logits_stride + block, logits, mask=mask)
 
 
 class DSparkSpeculator(DFlashSpeculator):
@@ -82,51 +143,29 @@ class DSparkSpeculator(DFlashSpeculator):
         # costs speculation acceptance heavily on repetition-rich outputs
         # (e.g. TTS speech tokens). Set via set_penalties_state().
         self._penalties_state = None
-        self._pen_scale_buf: torch.Tensor | None = None
-        self._pen_bit_shifts: torch.Tensor | None = None
+        self._sampling_states = None
+        self._topk_arange: torch.Tensor | None = None
 
-    def set_penalties_state(self, penalties_state) -> None:
+    # Static cap for the draft-side top-k/top-p mirror: requests with
+    # top_k > _TOPK_CAP (or disabled, stored as vocab_size) skip truncation.
+    _TOPK_CAP = 64
+
+    def set_penalties_state(self, penalties_state, sampling_states=None) -> None:
         import os
 
-        if os.environ.get("VLLM_DRAFT_REP_PENALTY", "0") != "1":
-            return
         if self.draft_logits is None:
             # Greedy drafting: rejection uses exact match, p/q alignment moot.
             return
-        self._penalties_state = penalties_state
-        self._pen_scale_buf = torch.ones(
-            self.max_num_reqs,
-            self.vocab_size,
-            dtype=torch.float32,
-            device=self.device,
-        )
-        self._pen_bit_shifts = torch.arange(
-            32, dtype=torch.int32, device=self.device
-        )
-
-    def load_draft_model(
-        self,
-        target_model: torch.nn.Module,
-        target_attn_layer_names: set[str],
-    ) -> torch.nn.Module:
-        model = load_dspark_model(target_model, self.vllm_config)
-        # Reduced draft vocab: probabilistic rejection sampling indexes draft
-        # logits by target id, so precompute the draft->target column map and a
-        # scratch buffer to scatter logits into target vocab before sampling.
-        if self.draft_logits is not None and model.draft_id_to_target_id is not None:
-            d2t = model.draft_id_to_target_id
-            self._d2t_scatter_index = (
-                torch.arange(d2t.shape[0], device=d2t.device) + d2t
+        if os.environ.get("VLLM_DRAFT_REP_PENALTY", "0") == "1":
+            self._penalties_state = penalties_state
+        if (
+            sampling_states is not None
+            and os.environ.get("VLLM_DRAFT_TOPK_TOPP", "0") == "1"
+        ):
+            self._sampling_states = sampling_states
+            self._topk_arange = torch.arange(
+                self._TOPK_CAP, dtype=torch.int64, device=self.device
             )
-            # -inf once; the per-step scatter overwrites the draft->target
-            # columns. Kept separate from draft_logits to avoid aliasing.
-            self._draft_scatter_buf = torch.full(
-                (self.max_num_reqs, self.vocab_size),
-                float("-inf"),
-                dtype=self.draft_logits.dtype,
-                device=self.device,
-            )
-        return model
 
     def load_draft_model(
         self,
@@ -170,33 +209,23 @@ class DSparkSpeculator(DFlashSpeculator):
         # read via the precomputed persistent index (fixed buffer for capture).
         prev = self.input_buffers.input_ids[self._anchor_idx[:num_reqs]]
 
-        # PATCH (local): build the per-request repetition-penalty scale for
-        # this draft round, mirroring _penalties_kernel: penalize tokens in
-        # the prompt bin mask or with nonzero output bin counts; in-block
-        # draft tokens are added below as they are sampled (the verify kernel
-        # accumulates draft tokens t_0..t_{i-1} for the row checking t_i; the
-        # anchor is excluded there too). rep==1.0 rows are no-ops, so this is
-        # safe to run unconditionally inside the captured graph.
-        pen_scale = None
-        pen_rep = None
+        # PATCH (local): per-request state for the draft-side sampling-param
+        # mirrors (repetition penalty via _draft_penalties_kernel; top-k/top-p
+        # truncation). rows/k/p/temp are block-constant; the kernel adds the
+        # in-block draft tokens t_0..t_{i-1} per step from self.draft_tokens.
+        pen_rows = None
         if self._penalties_state is not None and self.draft_logits is not None:
-            ps = self._penalties_state
+            pen_rows = idx_map[:, 0].contiguous()
+        tk_state = None
+        if self._sampling_states is not None and self.draft_logits is not None:
             rows = idx_map[:, 0].to(torch.long)
-            pen_rep = ps.repetition_penalty.gpu[rows].to(torch.float32)
-            base_mask = ps.output_bin_counts[rows] > 0
-            packed = ps.prompt_bin_mask[rows]
-            bits = (packed.unsqueeze(-1) >> self._pen_bit_shifts) & 1
-            base_mask |= (
-                bits.reshape(num_reqs, -1)[:, : self.vocab_size].to(torch.bool)
-            )
-            pen_scale = self._pen_scale_buf[:num_reqs]
-            pen_scale.copy_(
-                torch.where(
-                    base_mask,
-                    pen_rep.unsqueeze(1),
-                    torch.ones((), device=pen_rep.device),
-                )
-            )
+            k_req = self._sampling_states.top_k.gpu[rows]
+            p_req = self._sampling_states.top_p.gpu[rows].to(torch.float32)
+            temp = self.temperature[rows].to(torch.float32).clamp_min(1e-5)
+            k_enabled = (k_req <= self._TOPK_CAP).unsqueeze(1)
+            k_eff = k_req.clamp(min=1, max=self._TOPK_CAP).to(torch.long)
+            within_k = self._topk_arange.unsqueeze(0) < k_eff.unsqueeze(1)
+            tk_state = (k_eff, k_enabled, within_k, p_req, temp)
 
         for i in range(n_spec):
             # Sequential stage: Markov bias from the previously sampled token.
@@ -212,10 +241,56 @@ class DSparkSpeculator(DFlashSpeculator):
                     buf.index_copy_(1, self._d2t_scatter_index, logits_i.to(buf.dtype))
                     logits_i = buf
                 # PATCH (local): mirror the target's repetition-penalty logit
-                # transform on the draft logits (same divide/multiply rule).
-                if pen_scale is not None:
-                    logits_i = logits_i * torch.where(
-                        logits_i > 0, 1.0 / pen_scale, pen_scale
+                # transform on the draft logits (fused triton kernel, mutates
+                # logits_i in place; per-row early exit when rep == 1.0).
+                if pen_rows is not None:
+                    ps = self._penalties_state
+                    vocab = logits_i.shape[-1]
+                    blk = 8192
+                    _draft_penalties_kernel[(num_reqs, triton.cdiv(vocab, blk))](
+                        logits_i,
+                        logits_i.stride(0),
+                        pen_rows,
+                        self.draft_tokens,
+                        self.draft_tokens.stride(0),
+                        i,
+                        ps.repetition_penalty.gpu,
+                        ps.prompt_bin_mask,
+                        ps.prompt_bin_mask.stride(0),
+                        ps.output_bin_counts,
+                        ps.output_bin_counts.stride(0),
+                        vocab,
+                        BLOCK_SIZE=blk,
+                    )
+                # PATCH (local): mirror the target's top-k/top-p truncation so
+                # the draft never proposes tokens the target has zeroed out.
+                # Order matches the target sampler: penalties -> temperature
+                # -> top-k/top-p (top-p is computed on temperature-scaled
+                # logits within the top-k set).
+                if tk_state is not None:
+                    k_eff, k_enabled, within_k, p_req, temp = tk_state
+                    vals = torch.topk(
+                        logits_i.float(), self._TOPK_CAP, dim=-1
+                    ).values
+                    kth = vals.gather(1, (k_eff - 1).unsqueeze(1))
+                    scaled = torch.where(
+                        within_k,
+                        vals / temp.unsqueeze(1),
+                        torch.full((), float("-inf"), device=vals.device),
+                    )
+                    probs = torch.softmax(scaled, dim=-1)
+                    keep = (probs.cumsum(-1) - probs) < p_req.unsqueeze(1)
+                    last = (keep.sum(-1).clamp(min=1) - 1).unsqueeze(1)
+                    thresh = torch.maximum(kth, vals.gather(1, last))
+                    thresh = torch.where(
+                        k_enabled,
+                        thresh,
+                        torch.full((), float("-inf"), device=vals.device),
+                    )
+                    logits_i = torch.where(
+                        logits_i >= thresh,
+                        logits_i,
+                        torch.full((), float("-inf"), device=vals.device),
                     )
                 # sample_pos is the predicted token's position Q; the target
                 # verifies it with the predecessor's Gumbel key (Q-1). Pass Q-1.
@@ -235,15 +310,6 @@ class DSparkSpeculator(DFlashSpeculator):
                     logits_i.argmax(dim=-1)
                 )
             self.draft_tokens[:num_reqs, i] = draft_sampled_i
-            # PATCH (local): the just-sampled draft token joins the penalty
-            # set for subsequent in-block steps (matches the verify kernel's
-            # t_0..t_{i-1} accumulation).
-            if pen_scale is not None:
-                pen_scale.scatter_(
-                    1,
-                    draft_sampled_i.view(-1, 1).to(torch.long),
-                    pen_rep.unsqueeze(1),
-                )
             prev = draft_sampled_i
 
     def _generate_draft(

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -153,14 +153,8 @@ class DSparkSpeculator(DFlashSpeculator):
         # costs speculation acceptance heavily on repetition-rich outputs
         # (e.g. TTS speech tokens). Set via set_penalties_state().
         self._penalties_state = None
-        self._sampling_states = None
-        self._topk_arange: torch.Tensor | None = None
 
-    # Static cap for the draft-side top-k/top-p mirror: requests with
-    # top_k > _TOPK_CAP (or disabled, stored as vocab_size) skip truncation.
-    _TOPK_CAP = 64
-
-    def set_penalties_state(self, penalties_state, sampling_states=None) -> None:
+    def set_penalties_state(self, penalties_state) -> None:
         import os
 
         if self.draft_logits is None:
@@ -168,14 +162,6 @@ class DSparkSpeculator(DFlashSpeculator):
             return
         if os.environ.get("VLLM_DRAFT_REP_PENALTY", "0") == "1":
             self._penalties_state = penalties_state
-        if (
-            sampling_states is not None
-            and os.environ.get("VLLM_DRAFT_TOPK_TOPP", "0") == "1"
-        ):
-            self._sampling_states = sampling_states
-            self._topk_arange = torch.arange(
-                self._TOPK_CAP, dtype=torch.int64, device=self.device
-            )
 
     def load_draft_model(
         self,
@@ -219,23 +205,13 @@ class DSparkSpeculator(DFlashSpeculator):
         # read via the precomputed persistent index (fixed buffer for capture).
         prev = self.input_buffers.input_ids[self._anchor_idx[:num_reqs]]
 
-        # PATCH (local): per-request state for the draft-side sampling-param
-        # mirrors (repetition penalty via _draft_penalties_kernel; top-k/top-p
-        # truncation). rows/k/p/temp are block-constant; the kernel adds the
-        # in-block draft tokens t_0..t_{i-1} per step from self.draft_tokens.
+        # PATCH (local): per-request state for the draft-side repetition
+        # penalty (_draft_penalties_kernel). pen_rows is block-constant; the
+        # kernel adds the in-block draft tokens t_0..t_{i-1} per step from
+        # self.draft_tokens.
         pen_rows = None
         if self._penalties_state is not None and self.draft_logits is not None:
             pen_rows = idx_map[:, 0].contiguous()
-        tk_state = None
-        if self._sampling_states is not None and self.draft_logits is not None:
-            rows = idx_map[:, 0].to(torch.long)
-            k_req = self._sampling_states.top_k.gpu[rows]
-            p_req = self._sampling_states.top_p.gpu[rows].to(torch.float32)
-            temp = self.temperature[rows].to(torch.float32).clamp_min(1e-5)
-            k_enabled = (k_req <= self._TOPK_CAP).unsqueeze(1)
-            k_eff = k_req.clamp(min=1, max=self._TOPK_CAP).to(torch.long)
-            within_k = self._topk_arange.unsqueeze(0) < k_eff.unsqueeze(1)
-            tk_state = (k_eff, k_enabled, within_k, p_req, temp)
 
         for i in range(n_spec):
             # Sequential stage: Markov bias from the previously sampled token.
@@ -246,9 +222,9 @@ class DSparkSpeculator(DFlashSpeculator):
                 # PATCH (local): mirror the target's repetition-penalty logit
                 # transform on the draft logits (fused triton kernel, mutates
                 # logits_i in place; per-row early exit when rep == 1.0).
-                # Runs BEFORE the d2t scatter so the kernel (and the top-k/p
-                # mirror below) only touch draft-vocab-sized rows; target-vocab
-                # penalty statistics are gathered via the d2t index.
+                # Runs BEFORE the d2t scatter so the kernel only touches
+                # draft-vocab-sized rows; target-vocab penalty statistics are
+                # gathered via the d2t index.
                 if pen_rows is not None:
                     ps = self._penalties_state
                     logits_i = logits_i.contiguous()
@@ -274,38 +250,6 @@ class DSparkSpeculator(DFlashSpeculator):
                         vocab,
                         BLOCK_SIZE=blk,
                         HAS_D2T=self._d2t_scatter_index is not None,
-                    )
-                # PATCH (local): mirror the target's top-k/top-p truncation so
-                # the draft never proposes tokens the target has zeroed out.
-                # Order matches the target sampler: penalties -> temperature
-                # -> top-k/top-p (top-p is computed on temperature-scaled
-                # logits within the top-k set). Also pre-scatter: the d2t
-                # scatter is value-preserving into a -inf background, so
-                # top-k/thresholds computed on the draft vocab are identical.
-                if tk_state is not None:
-                    k_eff, k_enabled, within_k, p_req, temp = tk_state
-                    vals = torch.topk(
-                        logits_i.float(), self._TOPK_CAP, dim=-1
-                    ).values
-                    kth = vals.gather(1, (k_eff - 1).unsqueeze(1))
-                    scaled = torch.where(
-                        within_k,
-                        vals / temp.unsqueeze(1),
-                        torch.full((), float("-inf"), device=vals.device),
-                    )
-                    probs = torch.softmax(scaled, dim=-1)
-                    keep = (probs.cumsum(-1) - probs) < p_req.unsqueeze(1)
-                    last = (keep.sum(-1).clamp(min=1) - 1).unsqueeze(1)
-                    thresh = torch.maximum(kth, vals.gather(1, last))
-                    thresh = torch.where(
-                        k_enabled,
-                        thresh,
-                        torch.full((), float("-inf"), device=vals.device),
-                    )
-                    logits_i = torch.where(
-                        logits_i >= thresh,
-                        logits_i,
-                        torch.full((), float("-inf"), device=vals.device),
                     )
                 # Probabilistic: sample in target vocab (a reduced draft vocab is
                 # scattered into its target columns; full vocab is already there).

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -74,6 +74,60 @@ class DSparkSpeculator(DFlashSpeculator):
         self._d2t_scatter_index: torch.Tensor | None = None
         self._draft_scatter_buf: torch.Tensor | None = None
 
+        # PATCH (local): draft-side repetition penalty. When enabled (env
+        # VLLM_DRAFT_REP_PENALTY=1 + probabilistic drafting), the drafter
+        # mirrors the target's repetition-penalty logit transform so the
+        # rejection test compares aligned p/q distributions. Without this,
+        # every context-repeated token has q suppressed but p not, which
+        # costs speculation acceptance heavily on repetition-rich outputs
+        # (e.g. TTS speech tokens). Set via set_penalties_state().
+        self._penalties_state = None
+        self._pen_scale_buf: torch.Tensor | None = None
+        self._pen_bit_shifts: torch.Tensor | None = None
+
+    def set_penalties_state(self, penalties_state) -> None:
+        import os
+
+        if os.environ.get("VLLM_DRAFT_REP_PENALTY", "0") != "1":
+            return
+        if self.draft_logits is None:
+            # Greedy drafting: rejection uses exact match, p/q alignment moot.
+            return
+        self._penalties_state = penalties_state
+        self._pen_scale_buf = torch.ones(
+            self.max_num_reqs,
+            self.vocab_size,
+            dtype=torch.float32,
+            device=self.device,
+        )
+        self._pen_bit_shifts = torch.arange(
+            32, dtype=torch.int32, device=self.device
+        )
+
+    def load_draft_model(
+        self,
+        target_model: torch.nn.Module,
+        target_attn_layer_names: set[str],
+    ) -> torch.nn.Module:
+        model = load_dspark_model(target_model, self.vllm_config)
+        # Reduced draft vocab: probabilistic rejection sampling indexes draft
+        # logits by target id, so precompute the draft->target column map and a
+        # scratch buffer to scatter logits into target vocab before sampling.
+        if self.draft_logits is not None and model.draft_id_to_target_id is not None:
+            d2t = model.draft_id_to_target_id
+            self._d2t_scatter_index = (
+                torch.arange(d2t.shape[0], device=d2t.device) + d2t
+            )
+            # -inf once; the per-step scatter overwrites the draft->target
+            # columns. Kept separate from draft_logits to avoid aliasing.
+            self._draft_scatter_buf = torch.full(
+                (self.max_num_reqs, self.vocab_size),
+                float("-inf"),
+                dtype=self.draft_logits.dtype,
+                device=self.device,
+            )
+        return model
+
     def load_draft_model(
         self,
         target_model: torch.nn.Module,
@@ -116,6 +170,34 @@ class DSparkSpeculator(DFlashSpeculator):
         # read via the precomputed persistent index (fixed buffer for capture).
         prev = self.input_buffers.input_ids[self._anchor_idx[:num_reqs]]
 
+        # PATCH (local): build the per-request repetition-penalty scale for
+        # this draft round, mirroring _penalties_kernel: penalize tokens in
+        # the prompt bin mask or with nonzero output bin counts; in-block
+        # draft tokens are added below as they are sampled (the verify kernel
+        # accumulates draft tokens t_0..t_{i-1} for the row checking t_i; the
+        # anchor is excluded there too). rep==1.0 rows are no-ops, so this is
+        # safe to run unconditionally inside the captured graph.
+        pen_scale = None
+        pen_rep = None
+        if self._penalties_state is not None and self.draft_logits is not None:
+            ps = self._penalties_state
+            rows = idx_map[:, 0].to(torch.long)
+            pen_rep = ps.repetition_penalty.gpu[rows].to(torch.float32)
+            base_mask = ps.output_bin_counts[rows] > 0
+            packed = ps.prompt_bin_mask[rows]
+            bits = (packed.unsqueeze(-1) >> self._pen_bit_shifts) & 1
+            base_mask |= (
+                bits.reshape(num_reqs, -1)[:, : self.vocab_size].to(torch.bool)
+            )
+            pen_scale = self._pen_scale_buf[:num_reqs]
+            pen_scale.copy_(
+                torch.where(
+                    base_mask,
+                    pen_rep.unsqueeze(1),
+                    torch.ones((), device=pen_rep.device),
+                )
+            )
+
         for i in range(n_spec):
             # Sequential stage: Markov bias from the previously sampled token.
             markov_embed = self.model.markov_embed(prev)
@@ -129,6 +211,12 @@ class DSparkSpeculator(DFlashSpeculator):
                     buf = self._draft_scatter_buf[:num_reqs]
                     buf.index_copy_(1, self._d2t_scatter_index, logits_i.to(buf.dtype))
                     logits_i = buf
+                # PATCH (local): mirror the target's repetition-penalty logit
+                # transform on the draft logits (same divide/multiply rule).
+                if pen_scale is not None:
+                    logits_i = logits_i * torch.where(
+                        logits_i > 0, 1.0 / pen_scale, pen_scale
+                    )
                 # sample_pos is the predicted token's position Q; the target
                 # verifies it with the predecessor's Gumbel key (Q-1). Pass Q-1.
                 draft_sampled_i = gumbel_sample(
@@ -147,6 +235,15 @@ class DSparkSpeculator(DFlashSpeculator):
                     logits_i.argmax(dim=-1)
                 )
             self.draft_tokens[:num_reqs, i] = draft_sampled_i
+            # PATCH (local): the just-sampled draft token joins the penalty
+            # set for subsequent in-block steps (matches the verify kernel's
+            # t_0..t_{i-1} accumulation).
+            if pen_scale is not None:
+                pen_scale.scatter_(
+                    1,
+                    draft_sampled_i.view(-1, 1).to(torch.long),
+                    pen_rep.unsqueeze(1),
+                )
             prev = draft_sampled_i
 
     def _generate_draft(

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -51,6 +51,7 @@ def _draft_penalties_kernel(
     output_bin_counts_stride,
     d2t_index_ptr,  # [vocab_size] draft column -> target id (HAS_D2T only)
     vocab_size,  # row width of logits (draft vocab when HAS_D2T)
+    max_num_reqs,  # bound for req-state indices (padded rows may hold junk)
     BLOCK_SIZE: tl.constexpr,
     HAS_D2T: tl.constexpr,
 ):
@@ -67,6 +68,10 @@ def _draft_penalties_kernel(
     """
     req_idx = tl.program_id(0).to(tl.int64)
     state_idx = tl.load(rows_ptr + req_idx).to(tl.int64)
+    # CUDA-graph replays run with a padded request count; padded rows can
+    # carry junk state indices. Clamp so their (ignored) rows never gather
+    # out of bounds.
+    state_idx = tl.minimum(tl.maximum(state_idx, 0), max_num_reqs - 1)
     rep = tl.load(repetition_penalty_ptr + state_idx)
     if rep == 1.0:
         return
@@ -248,6 +253,7 @@ class DSparkSpeculator(DFlashSpeculator):
                         if self._d2t_scatter_index is not None
                         else self.draft_tokens,
                         vocab,
+                        self.max_num_reqs,
                         BLOCK_SIZE=blk,
                         HAS_D2T=self._d2t_scatter_index is not None,
                     )


### PR DESCRIPTION
## Summary

**Bugfix**: the speculators-format DSpark config translator wrote `target_layer_ids` at the top level only, while `DFlashQwen3Model` reads it from `drafter_config` (`eagle_config | dflash_config`) and otherwise sizes the aux-hidden `fc` from `num_hidden_layers`. Any speculators DSpark checkpoint whose draft layer count differs from its aux layer count crashed at weight load (`Tried to load weights of size [896, 2688] to a parameter of size [896, 4480]`). `update_dspark` now also populates `dflash_config`, mirroring `update_dflash`.

**Feature**: with `draft_sample_method="probabilistic"`, the rejection test compares the draft distribution p against a target q that has the repetition penalty applied, while the drafter samples from unpenalized logits — every context-repeated token has q suppressed but p not, which costs acceptance heavily on repetition-rich outputs (e.g. TTS speech tokens). New opt-in `SpeculativeConfig.draft_apply_repetition_penalty` makes the DSpark drafter mirror the target's repetition-penalty transform (same per-request penalty value and statistics from `PenaltiesState`, including in-block draft tokens), via a fused triton kernel that runs on the reduced draft vocabulary before the d2t scatter. CUDA-graph compatible; `repetition_penalty==1.0` requests early-exit per row.

## Measurements

CosyVoice3 0.5B + DSpark draft (8k draft vocab), seed-tts test_zh (2020 voice-clone prompts), temperature 0.8 / top_p 0.95 / top_k 15 / repetition_penalty 1.1:

| | mean acceptance length | wall-time speedup vs no-spec (bs 1/8/16/64) |
|---|---|---|
| without mirror | 2.49 | 1.69x / 1.69x / 1.64x / 1.06x |
| with mirror | **2.98** | **1.90x / 1.91x / 1.73x / 1.23x** |

## Usage

```
--speculative-config '{"model": ..., "method": "dspark", "num_speculative_tokens": 7,
                       "draft_sample_method": "probabilistic",
                       "draft_apply_repetition_penalty": true}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)