### PR TITLE
[Core] Add remaining copy counts to KV removal events

### DIFF
--- a/examples/features/kv_events/kv_events_subscriber.py
+++ b/examples/features/kv_events/kv_events_subscriber.py
@@ -52,6 +52,8 @@ class BlockRemoved(KVCacheEvent):
     medium: str | None
     group_idx: int | None = None
     locality: str | None = None
+    remaining_copy_counts: list[int] | None = None
+    """Copies remaining for each hash after removal; None means unavailable."""
 
 
 class AllBlocksCleared(KVCacheEvent):

--- a/tests/distributed/test_kv_cache_events.py
+++ b/tests/distributed/test_kv_cache_events.py
@@ -39,7 +39,7 @@ class _LegacyBlockRemoved(
     gc=False,  # type: ignore[call-arg]
     tag="BlockRemoved",  # type: ignore[call-arg]
 ):
-    """BlockRemoved wire schema before locality was added."""
+    """BlockRemoved wire schema before optional removal metadata was added."""
 
     block_hashes: list[bytes]
     medium: str | None
@@ -68,12 +68,14 @@ def _make_block_stored(
 def _make_block_removed(
     group_idx: int | None = None,
     locality: str | None = None,
+    remaining_copy_counts: list[int] | None = None,
 ) -> BlockRemoved:
     return BlockRemoved(
         block_hashes=[_FAKE_HASH],
         medium="GPU",
         group_idx=group_idx,
         locality=locality,
+        remaining_copy_counts=remaining_copy_counts,
     )
 
 
@@ -119,6 +121,14 @@ def test_block_removed_hash_same_for_equal_group_idx():
     event_a = _make_block_removed(group_idx=1)
     event_b = _make_block_removed(group_idx=1)
     assert hash(event_a) == hash(event_b)
+
+
+def test_block_removed_hash_differs_by_remaining_copy_counts():
+    copy_remains = _make_block_removed(remaining_copy_counts=[1])
+    last_copy_removed = _make_block_removed(remaining_copy_counts=[0])
+    count_unknown = _make_block_removed()
+
+    assert len({copy_remains, last_copy_removed, count_unknown}) == 3
 
 
 def test_block_stored_hash_differs_by_sliding_window():
@@ -175,11 +185,24 @@ def test_block_stored_locality_is_wire_compatible():
     assert msgspec.msgpack.decode(new_payload, type=_LegacyBlockStored).medium == "GPU"
 
 
-def test_block_removed_locality_is_wire_compatible():
+def test_block_removed_optional_metadata_is_wire_compatible():
     legacy = _LegacyBlockRemoved(block_hashes=[_FAKE_HASH], medium="GPU")
     legacy_payload = msgspec.msgpack.encode(legacy)
     assert msgspec.msgpack.encode(_make_block_removed()) == legacy_payload
     assert msgspec.msgpack.decode(legacy_payload, type=BlockRemoved).locality is None
-    new_payload = msgspec.msgpack.encode(_make_block_removed(locality="REMOTE"))
+    assert (
+        msgspec.msgpack.decode(legacy_payload, type=BlockRemoved).remaining_copy_counts
+        is None
+    )
+    event = BlockRemoved(
+        block_hashes=[_FAKE_HASH, b"\xcd" * 32],
+        medium="GPU",
+        locality="REMOTE",
+        remaining_copy_counts=[2, 0],
+    )
+    new_payload = msgspec.msgpack.encode(event)
     assert msgspec.msgpack.decode(new_payload)["locality"] == "REMOTE"
-    assert msgspec.msgpack.decode(new_payload, type=_LegacyBlockRemoved).medium == "GPU"
+    assert msgspec.msgpack.decode(new_payload)["remaining_copy_counts"] == [2, 0]
+    legacy_decoded = msgspec.msgpack.decode(new_payload, type=_LegacyBlockRemoved)
+    assert legacy_decoded.block_hashes == event.block_hashes
+    assert legacy_decoded.medium == "GPU"

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
@@ -167,6 +167,7 @@ def test_cache_partial_block_kv_cache_events():
     assert isinstance(removed_event, BlockRemoved)
     assert removed_event.block_hashes == stored_event.block_hashes
     assert removed_event.group_idx == kv_cache_group_id
+    assert removed_event.remaining_copy_counts == [0]
 
 
 def test_partial_block_replacement_emits_remove_then_store_events():
@@ -219,6 +220,7 @@ def test_partial_block_replacement_emits_remove_then_store_events():
         kv_cache_utils.maybe_convert_block_hash(partial_hash_8)
     ]
     assert removed_event.group_idx == kv_cache_group_id
+    assert removed_event.remaining_copy_counts == [0]
     assert isinstance(stored_event, BlockStored)
     assert stored_event.block_hashes == [
         kv_cache_utils.maybe_convert_block_hash(partial_hash_10)
@@ -370,6 +372,42 @@ def test_cache_partial_block_duplicate_checks_all_blocks_for_hash():
     )
     assert duplicate_entry_hash == second_entry_hash
     assert pool.cached_block_hashes_by_block == {}
+
+
+def test_partial_block_removal_reports_remaining_copy_counts():
+    hash_block_size = 2
+    block_size = 4
+    kv_cache_group_id = 0
+    req = make_request("0", [0, 0], hash_block_size, sha256)
+    pool = BlockPool(
+        num_gpu_blocks=3,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+        enable_kv_cache_events=True,
+    )
+    blocks = pool.get_new_blocks(2)
+    for block in blocks:
+        pool.cache_partial_block(
+            request=req,
+            block=block,
+            num_tokens=hash_block_size,
+            kv_cache_group_id=kv_cache_group_id,
+            block_size=block_size,
+        )
+
+    pool.take_events()
+    pool.free_blocks(blocks)
+    expected_hash = kv_cache_utils.maybe_convert_block_hash(req.block_hashes[0])
+
+    for remaining_copy_count in (1, 0):
+        pool.get_new_blocks(1)
+        events = pool.take_events()
+        assert len(events) == 1
+        event = events[0]
+        assert isinstance(event, BlockRemoved)
+        assert event.block_hashes == [expected_hash]
+        assert event.group_idx == kv_cache_group_id
+        assert event.remaining_copy_counts == [remaining_copy_count]
 
 
 def test_reset_prefix_cache_clears_partial_entry_metadata():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -2002,7 +2002,12 @@ def test_prefix_cache_stats_disabled():
 
 
 def test_maybe_evict_cached_block():
-    pool = BlockPool(num_gpu_blocks=4, enable_caching=True, hash_block_size=16)
+    pool = BlockPool(
+        num_gpu_blocks=4,
+        enable_caching=True,
+        hash_block_size=16,
+        enable_kv_cache_events=True,
+    )
     block_hash0 = make_block_hash_with_group_id(BlockHash(b"10"), 1000)
     block_hash1 = make_block_hash_with_group_id(BlockHash(b"20"), 2000)
     block_hash2 = make_block_hash_with_group_id(BlockHash(b"30"), 3000)
@@ -2047,6 +2052,35 @@ def test_maybe_evict_cached_block():
     # Evict block3
     pool._maybe_evict_cached_block(block3)
     assert pool.cached_block_hash_to_block._cache == {}
+
+    events = pool.take_events()
+    removed_events = [event for event in events if isinstance(event, BlockRemoved)]
+    assert len(removed_events) == len(events) == 4
+    assert [
+        (event.block_hashes, event.group_idx, event.remaining_copy_counts)
+        for event in removed_events
+    ] == [
+        (
+            [kv_cache_utils.maybe_convert_block_hash(get_block_hash(block_hash1))],
+            2000,
+            [0],
+        ),
+        (
+            [kv_cache_utils.maybe_convert_block_hash(get_block_hash(block_hash0))],
+            1000,
+            [1],
+        ),
+        (
+            [kv_cache_utils.maybe_convert_block_hash(get_block_hash(block_hash2))],
+            3000,
+            [0],
+        ),
+        (
+            [kv_cache_utils.maybe_convert_block_hash(get_block_hash(block_hash0))],
+            1000,
+            [0],
+        ),
+    ]
 
 
 @pytest.mark.parametrize("blocks_to_cache", [2, 3, 10])
@@ -3534,6 +3568,26 @@ def test_block_lookup_cache_multi_blocks_per_key():
     assert cache.pop(key1, 11) is block11
     assert cache.get_one_block(key1) is None
     assert cache.pop(key1, 12) is None
+
+
+def test_block_lookup_cache_pop_with_remaining_count():
+    cache = BlockHashToBlockMap()
+    key = BlockHashWithGroupId(b"hash")
+    blocks = [KVCacheBlock(block_id) for block_id in range(3)]
+    for block in blocks:
+        cache.insert(key, block)
+
+    assert cache.pop_with_remaining_count(key, 100) == (None, 3)
+    assert cache.pop_with_remaining_count(key, 0) == (blocks[0], 2)
+    assert cache.pop_with_remaining_count(key, 1) == (blocks[1], 1)
+    assert cache.pop_with_remaining_count(key, 2) == (blocks[2], 0)
+    assert cache.pop_with_remaining_count(key, 2) == (None, 0)
+
+    single_key = BlockHashWithGroupId(b"single-hash")
+    single_block = KVCacheBlock(3)
+    cache.insert(single_key, single_block)
+    assert cache.pop_with_remaining_count(single_key, 100) == (None, 1)
+    assert cache.pop_with_remaining_count(single_key, 3) == (single_block, 0)
 
 
 def test_can_fit_full_sequence_swa_cap_admits_long_prompt():

--- a/tests/v1/kv_connector/unit/offloading_connector/test_events.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_events.py
@@ -263,6 +263,7 @@ def test_take_events_factor_gt_1_chunk_store_and_remove():
     assert removed[0].block_hashes == expected_hashes
     assert removed[0].medium == _CPU_MEDIUM
     assert removed[0].group_idx == 0
+    assert removed[0].remaining_copy_counts is None
     assert not tracker._pending_event_metadata
 
 

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -101,6 +101,12 @@ class BlockRemoved(KVCacheEvent):
     group_idx: int | None = None
     locality: str | None = None
     """LOCAL or REMOTE relative to the publisher; None means unspecified."""
+    remaining_copy_counts: list[int] | None = None
+    """Physical copies remaining in the publisher's block pool after each
+    corresponding hash removal. Entries align one-to-one with ``block_hashes``;
+    zero means the last known copy was removed, while ``None`` means the
+    publisher did not provide copy counts.
+    """
 
     def __hash__(self) -> int:
         return hash(
@@ -109,6 +115,9 @@ class BlockRemoved(KVCacheEvent):
                 self.medium,
                 self.group_idx,
                 self.locality,
+                tuple(self.remaining_copy_counts)
+                if self.remaining_copy_counts is not None
+                else None,
             )
         )
 

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -107,10 +107,17 @@ class BlockHashToBlockMap:
         """
         Checks if block_hash exists and pop block_id from the cache
         """
+        block, _ = self.pop_with_remaining_count(key, block_id)
+        return block
+
+    def pop_with_remaining_count(
+        self, key: BlockHashWithGroupId, block_id: int
+    ) -> tuple[KVCacheBlock | None, int]:
+        """Pop a block and return how many physical blocks remain for the key."""
         blocks = self._cache.pop(key, None)
         if blocks is None:
             # block_hash not found in the cache
-            return None
+            return None, 0
         # TODO(Jialin): If key is found, block_id should always present
         # in blocks. We currently keep the original behaviour for safety.
         #
@@ -118,20 +125,21 @@ class BlockHashToBlockMap:
         # use del blocks[block_id] instead as followup.
         if isinstance(blocks, KVCacheBlock):
             if blocks.block_id == block_id:
-                return blocks
+                return blocks, 0
             # If the single block ID doesn't match, we should put the
             # block back (it should happen rarely)
             self._cache[key] = blocks
-            return None
+            return None, 1
         if isinstance(blocks, dict):
             # Try to pop block_id from the block dict, and if dict still
             # contain blocks, put back to the cache.
             block = blocks.pop(block_id, None)
-            if len(blocks) > 0:
+            remaining_count = len(blocks)
+            if remaining_count > 0:
                 self._cache[key] = blocks
-            return block
+            return block, remaining_count
         self._unexpected_blocks_type(blocks)
-        return None
+        return None, 0
 
     def __len__(self) -> int:
         return len(self._cache)
@@ -571,7 +579,7 @@ class BlockPool:
     def _remove_cached_block_hashes(
         self,
         block: KVCacheBlock,
-    ) -> list[BlockHashWithGroupId]:
+    ) -> list[tuple[BlockHashWithGroupId, int]]:
         block_hashes: list[BlockHashWithGroupId] = []
         if block.block_hash is not None:
             block_hashes.append(block.block_hash)
@@ -579,28 +587,31 @@ class BlockPool:
         if not block_hashes:
             return []
 
-        removed_hashes: list[BlockHashWithGroupId] = []
+        removed_hashes: list[tuple[BlockHashWithGroupId, int]] = []
         for block_hash in block_hashes:
-            if (
-                self.cached_block_hash_to_block.pop(block_hash, block.block_id)
-                is not None
-            ):
-                removed_hashes.append(block_hash)
+            removed_block, remaining_count = (
+                self.cached_block_hash_to_block.pop_with_remaining_count(
+                    block_hash, block.block_id
+                )
+            )
+            if removed_block is not None:
+                removed_hashes.append((block_hash, remaining_count))
         block.reset_hash()
         return removed_hashes
 
     def _emit_block_removed_events(
         self,
-        block_hashes: list[BlockHashWithGroupId],
+        block_hashes: list[tuple[BlockHashWithGroupId, int]],
     ) -> None:
         if not self.enable_kv_cache_events:
             return
-        for block_hash in block_hashes:
+        for block_hash, remaining_count in block_hashes:
             self.kv_event_queue.append(
                 BlockRemoved(
                     block_hashes=[maybe_convert_block_hash(get_block_hash(block_hash))],
                     medium=MEDIUM_GPU,
                     group_idx=get_group_id(block_hash),
+                    remaining_copy_counts=[remaining_count],
                 )
             )
 
@@ -640,7 +651,7 @@ class BlockPool:
         assert dst_block.block_hash is None
         assert dst_block.block_id not in self.cached_block_hashes_by_block
         num_tokens = src_block.block_hash_num_tokens
-        for block_hash in self._remove_cached_block_hashes(src_block):
+        for block_hash, _ in self._remove_cached_block_hashes(src_block):
             # `num_tokens` only applies to the first (primary) insertion.
             self._insert_block_hash(block_hash, dst_block, num_tokens=num_tokens)
 


### PR DESCRIPTION
## Purpose

A logical block hash may map to multiple physical KV cache blocks because vLLM v1 keeps block tables append-only and does not deduplicate cached blocks. Today, every physical eviction emits a `BlockRemoved` event containing the hash, but consumers cannot tell whether another physical copy of that hash remains. Consumers that track logical cache residency can therefore invalidate a still-cached hash after the first physical copy is removed.

This PR adds an optional `remaining_copy_counts` field to `BlockRemoved`, aligned one-to-one with `block_hashes`. The GPU block pool reports the number of physical copies remaining after each removal. It obtains that count in the same average O(1) `BlockHashToBlockMap` pop operation, while preserving the existing `pop` API and physical-event frequency. Producers that cannot provide the count, including offloading events, leave the field as `None`.

The field is included in event hashing, the subscriber example is updated, and the wire-compatibility tests cover both legacy consumers and multi-hash events. Core tests cover duplicate full-block and partial-prefix copies, including hash/group/count alignment and the final-copy transition from one remaining copy to zero.

This is not a duplicate of an existing PR. I searched open issues and PRs for `BlockRemoved`, remaining copies/counts, duplicate block hashes, and KV cache events. #47715 addresses KV cache metrics event handling, while #43258 addresses hybrid Mamba/Attention hash granularity; neither changes physical-copy removal semantics.

AI assistance from OpenAI Codex was used to adapt the implementation and tests to current upstream `main`. The submitter reviewed the complete diff and test results before submission. This change does not affect model output or accuracy, so model evaluations are not applicable.

## Test Plan

```bash
.venv/bin/python -m pytest tests/distributed/test_kv_cache_events.py -v --confcutdir=tests/distributed

.venv/bin/python -m pytest \
  tests/v1/core/test_prefix_caching.py::test_maybe_evict_cached_block \
  tests/v1/core/test_prefix_caching.py::test_block_lookup_cache_pop_with_remaining_count \
  -v --confcutdir=tests/v1/core

.venv/bin/python -m pytest \
  tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py \
  -v --confcutdir=tests/v1/core

.venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/offloading_connector/test_events.py::test_take_events_factor_gt_1_chunk_store_and_remove \
  -v --confcutdir=tests/v1/kv_connector/unit/offloading_connector

pre-commit run --files \
  examples/features/kv_events/kv_events_subscriber.py \
  tests/distributed/test_kv_cache_events.py \
  tests/v1/core/test_prefix_caching.py \
  tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py \
  tests/v1/kv_connector/unit/offloading_connector/test_events.py \
  vllm/distributed/kv_events.py \
  vllm/v1/core/block_pool.py

git diff --check origin/main...HEAD
```

## Test Result

- KV event schema, hash, and wire compatibility: 16 passed.
- Block map and duplicate full-block eviction behavior: 2 passed.
- Partial-prefix cache primitives, including duplicate-copy removal events: 11 passed.
- Offloading producer fallback behavior: 1 passed.
- All applicable pre-commit hooks passed, including ruff, mypy, DCO sign-off, configuration validation, and forbidden-import checks.
- `git diff --check origin/main...HEAD` passed.

The full editable install is unavailable on macOS arm64 because the precompiled wheel registry does not publish a compatible macOS wheel. The selected pure-Python tests above ran against the source tree in a Python 3.12 `uv` environment with the official common dependencies.
