### PR TITLE
[Model]Fuse MiniMax-M3 dense-layer KV-cache insert into qknorm+rope k…

### DIFF
--- a/csrc/libtorch_stable/fused_minimax_m3_qknorm_rope_kv_insert_kernel.cu
+++ b/csrc/libtorch_stable/fused_minimax_m3_qknorm_rope_kv_insert_kernel.cu
@@ -281,7 +281,7 @@ __device__ __forceinline__ void storeElemsFp8(
 // Slots per token:
 //     Q : nq                            (always — norm+RoPE)
 //     K : nkv                           (always — norm+RoPE; +K-cache insert)
-//     V : nkv  only if kInsertKV        (V-cache insert; no warps in dense)
+//     V : nkv  only if kInsertKV        (V-cache insert)
 //     IQ: niq  only if kProcessIndex    (norm+RoPE)
 //     IK: 1    only if kProcessIndex    (norm+RoPE; +index-cache insert)
 // cache_t/kv_dt: main attention KV-cache dtype (auto/fp8). out_idx_t/kFp8Idx:
@@ -583,9 +583,12 @@ void launchFusedMiniMaxM3(
         LAUNCH(true, false, true, false, scalar_t);  // sparse profiling, bf16
       }
     }
+  } else if (insert_kv) {
+    // Dense layer with the KV insert fused in (the generic Attention layer
+    // skips its own cache update).
+    LAUNCH(false, true, false, false, scalar_t);
   } else {
-    // Dense layer: never has an index branch and never inserts here (the
-    // generic Attention layer owns the KV insert).
+    // Dense layer, norm+RoPE only (profiling run or non-fusable backend).
     LAUNCH(false, false, false, false, scalar_t);
   }
 #undef LAUNCH
@@ -699,11 +702,6 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
                   " + num_index_heads + 1) * 128 for sparse, "
                   "(num_heads + 2*num_kv_heads) * 128 for dense");
 
-  // Only the sparse layer inserts here (dense lets the generic Attention layer
-  // own the KV write); there is no dense+insert kernel instantiation.
-  STD_TORCH_CHECK(
-      !insert_kv || has_index,
-      "insert mode (kv_cache) requires the index branch (sparse layer)");
   STD_TORCH_CHECK(has_index || !skip_index_branch,
                   "skip_index_branch requires sparse qkv rows");
   if (process_index) {

--- a/tests/kernels/test_fused_minimax_m3_qknorm_rope_kv_insert.py
+++ b/tests/kernels/test_fused_minimax_m3_qknorm_rope_kv_insert.py
@@ -137,7 +137,116 @@ def test_dense_norm_rope(num_tokens, num_heads, num_kv_heads):
     torch.testing.assert_close(v_out, v_in, rtol=0, atol=0)
 
 
-# ── Test 2: sparse mode (full: index branch + cache inserts) ─────────────────
+# ── Test 2: dense mode with fused KV insert (no index branch) ────────────────
+
+
+@pytest.mark.parametrize("num_tokens", [1, 7, 64, 513])
+@pytest.mark.parametrize("block_size", [16, 64])
+@pytest.mark.parametrize("cache_layout", ["HND", "NHD"])
+def test_dense_kv_insert(num_tokens, block_size, cache_layout):
+    """Dense rows ([q|k|v], no index tail) with kv_cache: k/v must land in the
+    paged cache like the generic Attention's separate reshape_and_cache would
+    write them, honoring both NHD and HND physical layouts via strides, and
+    padded tokens (slot -1) must be skipped."""
+    torch.manual_seed(2)
+    device, dtype, eps = "cuda", torch.bfloat16, 1e-6
+    base, max_pos = 5_000_000.0, 4096
+    num_heads, num_kv_heads = 16, 4
+
+    q_w = torch.randn(HEAD_DIM, dtype=dtype, device=device) * 0.1
+    k_w = torch.randn(HEAD_DIM, dtype=dtype, device=device) * 0.1
+    cos_sin = make_cos_sin_cache(max_pos, ROTARY_DIM, base, dtype, device)
+    positions = torch.randint(
+        0, max_pos, (num_tokens,), dtype=torch.int64, device=device
+    )
+
+    qsz, kvsz = num_heads * HEAD_DIM, num_kv_heads * HEAD_DIM
+    qkv = torch.randn(num_tokens, qsz + 2 * kvsz, dtype=dtype, device=device)
+    qkv_orig = qkv.clone()
+
+    num_blocks = (num_tokens + block_size - 1) // block_size + 1
+    if cache_layout == "HND":
+        kv_cache = torch.zeros(
+            num_blocks,
+            num_kv_heads,
+            block_size,
+            2 * HEAD_DIM,
+            dtype=dtype,
+            device=device,
+        )
+    else:
+        # Logical [nb, nkv, bs, 2*hd] view over NHD physical storage.
+        kv_cache = torch.zeros(
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            2 * HEAD_DIM,
+            dtype=dtype,
+            device=device,
+        ).permute(0, 2, 1, 3)
+    slot_mapping = torch.randperm(
+        num_blocks * block_size, dtype=torch.int64, device=device
+    )[:num_tokens]
+    if num_tokens > 1:
+        slot_mapping[-1] = -1  # cudagraph-padded / unscheduled token
+
+    ops.fused_minimax_m3_qknorm_rope_kv_insert(
+        qkv,
+        q_w,
+        k_w,
+        cos_sin,
+        positions,
+        num_heads,
+        num_kv_heads,
+        ROTARY_DIM,
+        eps,
+        slot_mapping=slot_mapping,
+        kv_cache=kv_cache,
+        block_size=block_size,
+        kv_cache_dtype="auto",
+    )
+
+    q_out, k_out, v_out = qkv.split([qsz, kvsz, kvsz], dim=-1)
+    q_in, k_in, v_in = qkv_orig.split([qsz, kvsz, kvsz], dim=-1)
+    q_ref = norm_rope_ref(
+        q_in.view(num_tokens, num_heads, HEAD_DIM), q_w, positions, cos_sin, eps
+    ).view(num_tokens, qsz)
+    k_ref = norm_rope_ref(
+        k_in.view(num_tokens, num_kv_heads, HEAD_DIM),
+        k_w,
+        positions,
+        cos_sin,
+        eps,
+    ).view(num_tokens, kvsz)
+    torch.testing.assert_close(q_out, q_ref, rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(k_out, k_ref, rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(v_out, v_in, rtol=0, atol=0)
+
+    # Cache K is the same fp32->bf16 store as the in-place k_out (bit-exact);
+    # V is copied raw.
+    k_out_h = k_out.view(num_tokens, num_kv_heads, HEAD_DIM)
+    v_ref_h = v_in.view(num_tokens, num_kv_heads, HEAD_DIM)
+    written = torch.zeros(num_blocks * block_size, dtype=torch.bool)
+    for t in range(num_tokens):
+        s = slot_mapping[t].item()
+        if s < 0:
+            continue
+        written[s] = True
+        b, pos = s // block_size, s % block_size
+        torch.testing.assert_close(
+            kv_cache[b, :, pos, :HEAD_DIM], k_out_h[t], rtol=0, atol=0
+        )
+        torch.testing.assert_close(
+            kv_cache[b, :, pos, HEAD_DIM:], v_ref_h[t], rtol=0, atol=0
+        )
+    # Slots not in the mapping (including the padded token's) stay zero.
+    untouched = kv_cache.transpose(1, 2).reshape(num_blocks * block_size, -1)[
+        ~written.to(device)
+    ]
+    assert (untouched == 0).all()
+
+
+# ── Test 3: sparse mode (full: index branch + cache inserts) ─────────────────
 
 
 @pytest.mark.parametrize("num_tokens", [1, 7, 64, 513])

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2572,11 +2572,13 @@ def fused_minimax_m3_qknorm_rope_kv_insert(
     - sparse layer (``num_index_heads > 0``): ``[q | k | v | index_q |
       index_k]`` — the index branch is read straight out of ``qkv``.
 
-    When ``kv_cache`` is given (sparse serving), also scatter-inserts the
-    normed/roped k & v into the paged KV cache by ``slot_mapping`` and the
-    index key into ``index_cache`` by ``index_slot_mapping``. ``kv_cache_dtype``
-    selects the cache storage/conversion path. If
-    ``index_slot_mapping`` is omitted, ``slot_mapping`` is used for both caches.
+    When ``kv_cache`` is given (dense or sparse serving), also scatter-inserts
+    the normed/roped k & v into the paged KV cache (logical layout
+    ``[nb, nkv, bs, 2*head_dim]``) by ``slot_mapping``; on sparse layers the
+    index key is likewise inserted into ``index_cache`` by
+    ``index_slot_mapping``. ``kv_cache_dtype`` selects the cache
+    storage/conversion path. If ``index_slot_mapping`` is omitted,
+    ``slot_mapping`` is used for both caches.
 
     If ``q_out`` / ``index_q_out`` (contiguous ``[N, nq*128]`` / ``[N,
     niq*128]``) are given, the normed/roped q / index_q are written there

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -451,6 +451,12 @@ class Attention(nn.Module, AttentionLayerBase):
                 compilation_config.static_forward_context,
             )
         self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
+        # When True, the owning model layer inserts this step's k/v into the
+        # paged cache itself (fused into a preceding kernel), so forward()
+        # skips the separate unified_kv_cache_update. Set post-init by the
+        # owning layer; only valid when the backend performs the KV update as
+        # a separate step (forward_includes_kv_cache_update == False).
+        self.skip_kv_cache_update_by_layer = False
         # Gemma4: clamp mm_prefix bidirectional ranges by the sliding window
         # (read by the Triton backend impl). Default False for all other models.
         self.mm_prefix_clamp_sliding_window = mm_prefix_clamp_sliding_window
@@ -539,10 +545,12 @@ class Attention(nn.Module, AttentionLayerBase):
             value = value.view(-1, self.num_kv_heads, self.head_size_v)
         kv_cache_dummy_dep = None
         if self.use_direct_call:
-            # Skip this if sharing KV cache with an earlier attention layer.
+            # Skip this if sharing KV cache with an earlier attention layer
+            # or if the model layer already inserted k/v itself.
             if (
                 not self.attn_backend.forward_includes_kv_cache_update
                 and self.kv_sharing_target_layer_name is None
+                and not self.skip_kv_cache_update_by_layer
                 and key is not None
                 and value is not None
             ):
@@ -558,11 +566,13 @@ class Attention(nn.Module, AttentionLayerBase):
                 kv_cache_dummy_dep=kv_cache_dummy_dep,
             )
         else:
-            # Skip this if sharing KV cache with an earlier attention layer.
+            # Skip this if sharing KV cache with an earlier attention layer
+            # or if the model layer already inserted k/v itself.
             encoded = _encode_layer_name(self.layer_name)
             if (
                 not self.attn_backend.forward_includes_kv_cache_update
                 and self.kv_sharing_target_layer_name is None
+                and not self.skip_kv_cache_update_by_layer
                 and key is not None
                 and value is not None
             ):

--- a/vllm/models/minimax_m3/nvidia/model.py
+++ b/vllm/models/minimax_m3/nvidia/model.py
@@ -358,6 +358,14 @@ class MiniMaxM3Attention(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.attn",
         )
+        # Fuse the KV insert into the qknorm+rope kernel when the backend runs
+        # the KV update as a separate step this layer can take over. All such
+        # backends keep the paged cache in the [nb, nkv, bs, 2*hd] layout the
+        # kernel writes; its host checks fail loudly otherwise.
+        self.fuse_kv_insert = (
+            not self.attn.attn_backend.forward_includes_kv_cache_update
+        )
+        self.attn.skip_kv_cache_update_by_layer = self.fuse_kv_insert
 
     def forward(
         self,
@@ -366,19 +374,41 @@ class MiniMaxM3Attention(nn.Module):
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         # Fused per-head Gemma QK-norm + partial NeoX RoPE on q/k, in place.
-
-        ops.fused_minimax_m3_qknorm_rope_kv_insert(
-            qkv,
-            self.q_norm.weight,
-            self.k_norm.weight,
-            self.rotary_emb.cos_sin_cache,
-            positions,
-            self.num_heads,
-            self.num_kv_heads,
-            self.rotary_emb.rotary_dim,
-            self.q_norm.variance_epsilon,
-            kv_cache_dtype="auto",
-        )
+        slot_mapping = None
+        if self.fuse_kv_insert:
+            fwd_slot_mapping = get_forward_context().slot_mapping
+            if isinstance(fwd_slot_mapping, dict):
+                slot_mapping = fwd_slot_mapping.get(self.attn.layer_name)
+        if slot_mapping is not None:
+            kv_cache = self.attn.kv_cache
+            ops.fused_minimax_m3_qknorm_rope_kv_insert(
+                qkv,
+                self.q_norm.weight,
+                self.k_norm.weight,
+                self.rotary_emb.cos_sin_cache,
+                positions,
+                self.num_heads,
+                self.num_kv_heads,
+                self.rotary_emb.rotary_dim,
+                self.q_norm.variance_epsilon,
+                slot_mapping=slot_mapping,
+                kv_cache=kv_cache,
+                block_size=kv_cache.size(2),
+                kv_cache_dtype="auto",
+            )
+        else:
+            ops.fused_minimax_m3_qknorm_rope_kv_insert(
+                qkv,
+                self.q_norm.weight,
+                self.k_norm.weight,
+                self.rotary_emb.cos_sin_cache,
+                positions,
+                self.num_heads,
+                self.num_kv_heads,
+                self.rotary_emb.rotary_dim,
+                self.q_norm.variance_epsilon,
+                kv_cache_dtype="auto",
+            )
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)


### PR DESCRIPTION
## Purpose

Dense layers previously ran the fused qknorm+rope kernel without cache args and let the generic Attention layer insert k/v via a separate reshape_and_cache_flash, costing an extra full HBM round-trip of k/v and a kernel launch per dense layer (the majority of M3 layers). The device kernel already supports insert without the index branch; this enables it end to end:

- csrc: instantiate the dense+insert launch (kHasIndex=false, kInsertKV=true) and drop the host check that forbade it.
- Attention: add skip_kv_cache_update_by_layer (default False) so a model layer that inserts k/v itself can skip unified_kv_cache_update  while still passing k/v to the backend impl.
- MiniMaxM3Attention (nvidia only): insert k/v through the fused kernel  when the backend runs the KV update as a separate step  (forward_includes_kv_cache_update=False); all such backends keep the  paged cache in the [nb, nkv, bs, 2*hd] layout the kernel writes, and  its host checks fail loudly otherwise. Falls back to the unfused path  on memory-profiling runs (no slot mapping).

## Test Plan

## Test Result

- Benc command: `vllm bench serve --served-model-name /new-model/MiniMax-M3-MXFP8/ --model /new-model/MiniMax-M3-MXFP8/ --tokenizer /new-model/MiniMax-M3-MXFP8/ --backend openai-chat --endpoint /v1/chat/completions --dataset-name random --random-input 1000 --random-output 100 --seed 130 --base-url http://localhost:8000 --num-prompts 10`
 - Baseline
```
============ Serving Benchmark Result ============
Successful requests:                     10        
Failed requests:                         0         
Benchmark duration (s):                  16.23     
Total input tokens:                      11760     
Total generated tokens:                  1000      
Request throughput (req/s):              0.62      
Output token throughput (tok/s):         61.60     
Peak output token throughput (tok/s):    70.00     
Peak concurrent requests:                10.00     
Total token throughput (tok/s):          785.98    
---------------Time to First Token----------------
Mean TTFT (ms):                          1022.31   
Median TTFT (ms):                        1071.78   
P99 TTFT (ms):                           1250.09   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          153.17    
Median TPOT (ms):                        152.94    
P99 TPOT (ms):                           157.94    
---------------Inter-token Latency----------------
Mean ITL (ms):                           151.64    
Median ITL (ms):                         152.75    
P99 ITL (ms):                            155.78    
==================================================
```

- Optimization bench data
```
============ Serving Benchmark Result ============
Successful requests:                     10        
Failed requests:                         0         
Benchmark duration (s):                  16.09     
Total input tokens:                      11760     
Total generated tokens:                  1000      
Request throughput (req/s):              0.62      
Output token throughput (tok/s):         62.15     
Peak output token throughput (tok/s):    77.00     
Peak concurrent requests:                10.00     
Total token throughput (tok/s):          793.03    
---------------Time to First Token----------------
Mean TTFT (ms):                          1020.01   
Median TTFT (ms):                        1069.64   
P99 TTFT (ms):                           1246.90   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          151.74    
Median TPOT (ms):                        151.50    
P99 TPOT (ms):                           156.53    
---------------Inter-token Latency----------------
Mean ITL (ms):                           150.22    
Median ITL (ms):                         151.40    
P99 ITL (ms):                            154.28    
==================================================
```

- gsm8k test Baseline 
```
Results:
Accuracy: 0.879
Invalid responses: 0.000
Total latency: 121.214 s
Questions per second: 10.882
Total output tokens: 118606
Output tokens per second: 978.483
```

- gsm8k test  Current PR
```
Results:
Accuracy: 0.881
Invalid responses: 0.000
Total latency: 125.443 s
Questions per second: 10.515
Total output tokens: 118157
Output tokens per second: 941.916
```

While ensuring no loss of progress, the optimized TPOT and TTFT show an average performance improvement of 2ms.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

