### PR TITLE
[chore] adjust logo be more friendly to white background terminal

### DIFF
--- a/vllm/entrypoints/serve/utils/api_utils.py
+++ b/vllm/entrypoints/serve/utils/api_utils.py
@@ -325,13 +325,12 @@ def log_version_and_model(lgr: Logger, version: str, model_name: str) -> None:
         message = "vLLM server version %s, serving model %s"
     else:
         logo_template = Template(
-            "\n       ${w}█     █     █▄   ▄█${r}\n"
-            " ${o}▄▄${r} ${b}▄█${r} ${w}█     █     █ ▀▄▀ █${r}  version ${w}%s${r}\n"
-            "  ${o}█${r}${b}▄█▀${r} ${w}█     █     █     █${r}  model   ${w}%s${r}\n"
-            "   ${b}▀▀${r}  ${w}▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀${r}\n"
+            "\n       ${b}█     █     █▄   ▄█${r}\n"
+            " ${o}▄▄${r} ${b}▄█${r} ${b}█     █     █ ▀▄▀ █${r}  version ${b}%s${r}\n"
+            "  ${o}█${r}${b}▄█▀${r} ${b}█     █     █     █${r}  model   ${b}%s${r}\n"
+            "   ${b}▀▀${r}  ${b}▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀${r}\n"
         )
         colors = {
-            "w": "\033[97;1m",  # white
             "o": "\033[93m",  # orange
             "b": "\033[94m",  # blue
             "r": "\033[0m",  # reset


### PR DESCRIPTION



## Purpose
Just a small chore change. By default vllm will log vllm logo and version + model info with colored schema. Currently, the color schema is more friendly to black background terminal. By now, the version and model name and most logo is white which is consistent with white background terminal, thus it is invisible.


Change most color to blue to be more friendly to white background terminal 

## Test Plan
NA
## Test Result
NA
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

