### PR TITLE
[XPU] Bump vllm_xpu_kernels to v0.1.11.1

### DIFF
--- a/requirements/xpu.txt
+++ b/requirements/xpu.txt
@@ -18,4 +18,4 @@ torchvision
 torchcodec >= 0.14 # Required for the torchcodec video decoding backend
 
 auto_round_lib==0.14.1
-vllm_xpu_kernels @ https://github.com/vllm-project/vllm-xpu-kernels/releases/download/v0.1.11/vllm_xpu_kernels-0.1.11-cp38-abi3-manylinux_2_28_x86_64.whl
+vllm_xpu_kernels @ https://github.com/vllm-project/vllm-xpu-kernels/releases/download/v0.1.11.1/vllm_xpu_kernels-0.1.11.1-cp38-abi3-manylinux_2_28_x86_64.whl


### PR DESCRIPTION
## Summary

Bumps `vllm_xpu_kernels` pin from v0.1.11 to v0.1.11.1.

v0.1.11 registers `moe_sum` with the old 2-arg XPU schema. Commit f7aadae5e5 added 2 extra args (`topk_ids`, `expert_map`) to the CUDA-side `moe_sum` op, but the XPU-side registration was never updated to match — every XPU MoE forward pass now crashes:

```
RuntimeError: _moe_C::moe_sum() expected at most 2 argument(s) but received 4 argument(s)
```

v0.1.11.1 includes [vllm-xpu-kernels#462](https://github.com/vllm-project/vllm-xpu-kernels/pull/462), which fixes this.

## Test plan

Verified on B70: reproduced the crash on the currently-pinned v0.1.11, then confirmed the 4-arg call succeeds and is bit-exact against a `torch.sum` reference after installing v0.1.11.1.

AI assistance was used (Claude Code) for this change; the diff and verification above were reviewed and run personally.
