### PR TITLE
[Docs] Add Llama-3.1-8B-Instruct to batch invariance tested models

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -104,7 +104,7 @@ Batch invariance has been tested and verified on the following models:
 - **Qwen3 (Dense)**: `Qwen/Qwen3-1.7B`, `Qwen/Qwen3-8B`, `Qwen/Qwen3-4B-AWQ`, `Qwen/Qwen3-8B-AWQ`
 - **Qwen3 (MoE)**: `Qwen/Qwen3-30B-A3B`, `Qwen/Qwen3-Next-80B-A3B-Instruct`, `Qwen/Qwen3-30B-A3B-Thinking-2507-FP8`
 - **Qwen2.5**: `Qwen/Qwen2.5-0.5B-Instruct`, `Qwen/Qwen2.5-1.5B-Instruct`, `Qwen/Qwen2.5-3B-Instruct`, `Qwen/Qwen2.5-7B-Instruct`, `Qwen/Qwen2.5-14B-Instruct`, `Qwen/Qwen2.5-32B-Instruct`
-- **Llama 3**: Llama3.1 and 3.2 series, `meta-llama/Llama-3.2-3B-Instruct` for example
+- **Llama 3**: Llama3.1 and 3.2 series, `meta-llama/Llama-3.1-8B-Instruct`, `meta-llama/Llama-3.2-3B-Instruct` for example
 - **GPT-OSS**: `openai/gpt-oss-20b`, `openai/gpt-oss-120b`
 - **Mistral**: `mistralai/Mistral-7B-v0.3`
 - **Phi series**: `microsoft/Phi-3.5-mini-instruct`


### PR DESCRIPTION
## Summary
- Add `meta-llama/Llama-3.1-8B-Instruct` as an explicitly cited checkpoint under the **Llama 3** entry in the batch invariance tested-models list, per the model coverage request in #27433.

## Test plan
Ran the full `tests/v1/determinism/test_batch_invariance.py` suite against `meta-llama/Llama-3.1-8B-Instruct`:

```bash
VLLM_TEST_MODEL="meta-llama/Llama-3.1-8B-Instruct" \
VLLM_GPU_MEMORY_UTILIZATION=0.85 \
python -m pytest tests/v1/determinism/test_batch_invariance.py -v -s
```

Covered all three applicable backends: `FLASH_ATTN`, `TRITON_ATTN`, `FLEX_ATTENTION`.

## Test results

| Test | FLASH_ATTN | TRITON_ATTN | FLEX_ATTENTION |
|---|---|---|---|
| `test_simple_generation` | PASS | PASS | PASS |
| `test_logprobs_bitwise_batch_invariance_bs1_vs_bsN` | PASS 2/2 | PASS 2/2 | PASS 2/2 |
| `test_v1_generation_is_deterministic_across_batch_sizes_with_needle` (5 trials, batch size 128) | PASS 5/5 | PASS 5/5 | PASS 5/5 |
| `test_logprobs_without_batch_invariance_should_fail` | PASS | n/a (FLASH_ATTN only in source) | n/a |
| `test_decode_logprobs_match_prefill_logprobs` | PASS | n/a (FLASH_ATTN only in source) | n/a |

Note: the needle test's default `VLLM_GPU_MEMORY_UTILIZATION=0.5` reserves only 12GB on a 24GB GPU, which isn't enough to hold this model's ~15GB of weights, causing a `No available memory for the cache blocks` failure unrelated to determinism. Overriding to `0.85` resolved it — may be worth noting for contributors validating on consumer-class (24GB) GPUs.

## Environment
- GPU: NVIDIA GeForce RTX 4090 (24GB, SM89)
- torch: 2.11.0
- vLLM: 0.25.1 (editable install via `VLLM_USE_PRECOMPILED=1`)

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating docs/features/batch_invariance.md.

</details>