### PR TITLE
[Spec Decode] Context-length-aware K in DSD (RFC #48627): extend num_speculative_tokens_per_batch_size with a ctx axis

### DIFF
--- a/docs/features/speculative_decoding/dynamic_speculative_decoding.md
+++ b/docs/features/speculative_decoding/dynamic_speculative_decoding.md
@@ -11,14 +11,16 @@ SD methods need to verify K tokens for each sequence during decoding. As BS incr
 
 ## `--speculative-config` schema
 
-To use Dynamic SD, add `num_speculative_tokens_per_batch_size` to the config of an SD method which is a list of list. Here, an entry is `[start_bs, end_bs, optimal_K]` which means when the concurrency is within range `[start_bs, end_bs]` then `optimal_K` number of draft tokens are used. For e.g.,
+To use Dynamic SD, add `speculative_token_schedule` to the config of an SD method which is a list of list. Here, an entry is `[start_bs, end_bs, optimal_K]` which means when the concurrency is within range `[start_bs, end_bs]` then `optimal_K` number of draft tokens are used. For e.g.,
+
+(The previous key name `num_speculative_tokens_per_batch_size` is still accepted as a deprecated alias.)
 
 ```bash
 --speculative-config '{
     "method": "eagle",
     "model": "yuhuili/EAGLE-LLaMA3.1-Instruct-8B",
     "num_speculative_tokens": 3,
-    "num_speculative_tokens_per_batch_size": [
+    "speculative_token_schedule": [
       [1, 64, 3],
       [65, 128, 1],
       [129, 512, 0]
@@ -42,7 +44,7 @@ VLLM_USE_V2_MODEL_RUNNER=0 vllm serve meta-llama/Llama-3.1-8B-Instruct \
     "method": "eagle",
     "model": "yuhuili/EAGLE-LLaMA3.1-Instruct-8B",
     "num_speculative_tokens": 3,
-    "num_speculative_tokens_per_batch_size": [
+    "speculative_token_schedule": [
       [1, 64, 3],
       [65, 128, 1],
       [129, 512, 0]
@@ -58,7 +60,7 @@ VLLM_USE_V2_MODEL_RUNNER=0 vllm serve meta-llama/Llama-3.1-8B-Instruct \
     "method": "eagle3",
     "model": "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B",
     "num_speculative_tokens": 3,
-    "num_speculative_tokens_per_batch_size": [
+    "speculative_token_schedule": [
       [1, 16, 5],
       [17, 32, 4],
       [33, 64, 3],
@@ -73,4 +75,4 @@ VLLM_USE_V2_MODEL_RUNNER=0 vllm serve meta-llama/Llama-3.1-8B-Instruct \
 
 * Tested with Eagle, Eagle-3, and DFlash. Other SD methods may or may not work out of the box
 * Full Cudagraph only works with Model Runner V2. MRv1 only supports piece-wise cuda graph with this feature
-* Not compatible with data parallelism (`--data-parallel-size > 1`). Each DP rank schedules independently, so ranks can pick different K values, causing DP collective divergence and deadlocks. When DP is enabled, vLLM automatically disables `num_speculative_tokens_per_batch_size` and falls back to the static `num_speculative_tokens` value.
+* Not compatible with data parallelism (`--data-parallel-size > 1`). Each DP rank schedules independently, so ranks can pick different K values, causing DP collective divergence and deadlocks. When DP is enabled, vLLM automatically disables `speculative_token_schedule` and falls back to the static `num_speculative_tokens` value.

--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -506,7 +506,7 @@ def _mock_config_for_cudagraph_sizes(
     num_speculative_tokens: int,
     max_num_batched_tokens: int,
     compilation_config: CompilationConfig,
-    num_speculative_tokens_per_batch_size: list[tuple[int, int, int]] | None = None,
+    speculative_token_schedule: list[tuple[int, int, int]] | None = None,
 ) -> MagicMock:
     """Mock VllmConfig wired up enough to run `_set_cudagraph_sizes`.
 
@@ -526,11 +526,11 @@ def _mock_config_for_cudagraph_sizes(
     config.model_config.enforce_eager = False
     config.performance_mode = None
     config.diffusion_config = None
-    schedule = num_speculative_tokens_per_batch_size
+    schedule = speculative_token_schedule
     config.speculative_config = (
         SimpleNamespace(
             num_speculative_tokens=num_speculative_tokens,
-            num_speculative_tokens_per_batch_size=schedule,
+            speculative_token_schedule=schedule,
             uses_dynamic_speculative_decoding=lambda: schedule is not None,
         )
         if num_speculative_tokens
@@ -857,7 +857,7 @@ def test_default_cudagraph_capture_sizes_cover_every_dynamic_decode_width():
         compilation_config=compilation_config,
         # 16 draft tokens up to a batch of 16, then 2 out to 128. Both
         # tier maxima fit under the 512-token default capture ceiling.
-        num_speculative_tokens_per_batch_size=[(1, 16, 16), (17, 128, 2)],
+        speculative_token_schedule=[(1, 16, 16), (17, 128, 2)],
     )
 
     VllmConfig._set_cudagraph_sizes(config)
@@ -877,7 +877,7 @@ def test_dynamic_decode_capture_clamps_configured_width():
         num_speculative_tokens=3,
         max_num_batched_tokens=32768,
         compilation_config=compilation_config,
-        num_speculative_tokens_per_batch_size=[(1, 16, 5)],
+        speculative_token_schedule=[(1, 16, 5)],
     )
 
     VllmConfig._set_cudagraph_sizes(config)
@@ -896,7 +896,7 @@ def test_dynamic_decode_capture_covers_schedule_gap_and_tail():
         num_speculative_tokens=4,
         max_num_batched_tokens=32768,
         compilation_config=compilation_config,
-        num_speculative_tokens_per_batch_size=[(1, 2, 4), (5, 5, 1)],
+        speculative_token_schedule=[(1, 2, 4), (5, 5, 1)],
     )
 
     VllmConfig._set_cudagraph_sizes(config)

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -68,7 +68,7 @@ def create_scheduler(
     async_scheduling: bool = False,
     pipeline_parallel_size: int = 1,
     data_parallel_size: int = 1,
-    num_speculative_tokens_per_batch_size: list[tuple[int, int, int]] | None = None,
+    speculative_token_schedule: list[tuple[int, int, int]] | None = None,
     use_ec_connector: bool = False,
     ec_role: str | None = None,
     use_v2_model_runner: bool | None = None,
@@ -151,9 +151,9 @@ def create_scheduler(
         spec_kwargs: dict = dict(
             model="ngram", num_speculative_tokens=num_speculative_tokens
         )
-        if num_speculative_tokens_per_batch_size is not None:
-            spec_kwargs["num_speculative_tokens_per_batch_size"] = (
-                num_speculative_tokens_per_batch_size
+        if speculative_token_schedule is not None:
+            spec_kwargs["speculative_token_schedule"] = (
+                speculative_token_schedule
             )
         if speculative_method is not None:
             spec_kwargs["method"] = speculative_method

--- a/tests/v1/cudagraph/test_cudagraph_manager.py
+++ b/tests/v1/cudagraph/test_cudagraph_manager.py
@@ -190,7 +190,7 @@ def _create_decode_vllm_config(
     else:
         speculative_config = MagicMock()
         speculative_config.uses_dynamic_speculative_decoding.return_value = True
-        speculative_config.num_speculative_tokens_per_batch_size = dynamic_spec_schedule
+        speculative_config.speculative_token_schedule = dynamic_spec_schedule
         vllm_config.speculative_config = speculative_config
     return vllm_config
 

--- a/tests/v1/spec_decode/test_dynamic_sd.py
+++ b/tests/v1/spec_decode/test_dynamic_sd.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Regression tests for the Dynamic SD batch-size schedule helpers."""
+"""Regression tests for the Dynamic SD schedule helpers."""
 
 import logging
 
@@ -13,20 +13,28 @@ from vllm.v1.structured_output import StructuredOutputManager
 
 
 def _make_lookup(
-    num_speculative_tokens_per_batch_size: list[tuple[int, int, int]],
+    num_speculative_tokens_per_batch_size,
     *,
     max_batch_size: int = 256,
     runtime_num_speculative_tokens: int = 3,
 ) -> list[int]:
-    return build_dynamic_sd_schedule_lookup(
+    """Build a lookup and flatten it to a 1D ``[bs] -> K`` list.
+
+    Only valid for schedules that produce a single context bucket (i.e. legacy
+    3-item entries). New 5-item tests call ``build_dynamic_sd_schedule_lookup``
+    directly to see the full 2D structure.
+    """
+    lookup = build_dynamic_sd_schedule_lookup(
         num_speculative_tokens_per_batch_size=num_speculative_tokens_per_batch_size,
         vllm_max_batch_size=max_batch_size,
         vllm_num_speculative_tokens=runtime_num_speculative_tokens,
     )
+    assert len(lookup.ctx_boundaries) == 1
+    return [row[0] for row in lookup.dense]
 
 
 def _make_scheduler_with_dynamic_sd(
-    schedule: list[tuple[int, int, int]],
+    schedule,
     *,
     max_num_seqs: int = 16,
     max_num_batched_tokens: int = 8192,
@@ -97,7 +105,7 @@ def test_dynamic_sd_clamps_k_to_runtime_max():
 
 def test_dynamic_sd_rejects_invalid_schedule_entry():
     with pytest.raises(ValueError, match="3-item sequence"):
-        _make_lookup([(1, 16, 3), (32, 64)])  # type: ignore[list-item]
+        _make_lookup([(1, 16, 3), (32, 64)])
 
 
 def test_dynamic_sd_rejects_overlapping_ranges():
@@ -132,6 +140,124 @@ def test_dynamic_sd_lookup_rejects_invalid_batch_size_queries():
     assert dynamic_sd_lookup[0] == 0
     with pytest.raises(IndexError):
         _ = dynamic_sd_lookup[257]
+
+
+def test_dynamic_sd_5tuple_forms_2d_dense_lookup():
+    lookup = build_dynamic_sd_schedule_lookup(
+        num_speculative_tokens_per_batch_size=[
+            (1, 32, 1, 512, 3),
+            (1, 32, 513, 4096, 2),
+            (33, 128, 1, 512, 2),
+            (33, 128, 513, 4096, 1),
+        ],
+        vllm_max_batch_size=128,
+        vllm_num_speculative_tokens=3,
+    )
+
+    assert len(lookup.ctx_boundaries) == 2
+    assert lookup.ctx_boundaries[0] == (1, 512)
+    assert lookup.ctx_boundaries[1][0] == 513
+    assert lookup.dense[1] == [3, 2]
+    assert lookup.dense[32] == [3, 2]
+    assert lookup.dense[33] == [2, 1]
+    assert lookup.dense[128] == [2, 1]
+
+
+def test_dynamic_sd_5tuple_carry_forward_across_bs_gap():
+    lookup = build_dynamic_sd_schedule_lookup(
+        num_speculative_tokens_per_batch_size=[
+            (1, 8, 1, 100, 3),
+            (1, 8, 101, 4096, 2),
+            (32, 64, 1, 100, 1),
+            (32, 64, 101, 4096, 0),
+        ],
+        vllm_max_batch_size=64,
+        vllm_num_speculative_tokens=3,
+    )
+
+    assert lookup.dense[8] == [3, 2]
+    assert lookup.dense[15] == [3, 2]
+    assert lookup.dense[31] == [3, 2]
+    assert lookup.dense[32] == [1, 0]
+    assert lookup.dense[64] == [1, 0]
+
+
+def test_dynamic_sd_bucket_of_maps_context_to_bucket_index():
+    lookup = build_dynamic_sd_schedule_lookup(
+        num_speculative_tokens_per_batch_size=[
+            (1, 16, 1, 100, 3),
+            (1, 16, 101, 4096, 2),
+        ],
+        vllm_max_batch_size=16,
+        vllm_num_speculative_tokens=3,
+    )
+
+    assert lookup.bucket_of(0) == 0
+    assert lookup.bucket_of(1) == 0
+    assert lookup.bucket_of(100) == 0
+    assert lookup.bucket_of(101) == 1
+    assert lookup.bucket_of(10_000_000) == 1
+
+
+def test_dynamic_sd_5tuple_extends_last_ctx_to_cover_any_value():
+    lookup = build_dynamic_sd_schedule_lookup(
+        num_speculative_tokens_per_batch_size=[(1, 16, 1, 4096, 3)],
+        vllm_max_batch_size=16,
+        vllm_num_speculative_tokens=3,
+    )
+
+    assert len(lookup.ctx_boundaries) == 1
+    assert lookup.ctx_boundaries[0][0] == 1
+    assert lookup.bucket_of(1) == 0
+    assert lookup.bucket_of(10_000_000) == 0
+
+
+def test_dynamic_sd_rejects_mixed_arity():
+    with pytest.raises(ValueError, match="all be 3-item or all 5-item"):
+        _make_lookup([(1, 16, 3), (17, 32, 1, 100, 2)])
+
+
+def test_dynamic_sd_rejects_non_rectangular_grid():
+    with pytest.raises(ValueError, match="rectangular"):
+        build_dynamic_sd_schedule_lookup(
+            num_speculative_tokens_per_batch_size=[
+                (1, 64, 1, 4096, 3),
+                (65, 256, 1, 512, 2),
+                (65, 256, 513, 4096, 1),
+            ],
+            vllm_max_batch_size=256,
+            vllm_num_speculative_tokens=3,
+        )
+
+
+def test_dynamic_sd_rejects_ctx_gap():
+    with pytest.raises(ValueError, match="contiguous"):
+        build_dynamic_sd_schedule_lookup(
+            num_speculative_tokens_per_batch_size=[
+                (1, 16, 1, 100, 3),
+                (1, 16, 200, 4096, 2),
+            ],
+            vllm_max_batch_size=16,
+            vllm_num_speculative_tokens=3,
+        )
+
+
+def test_dynamic_sd_rejects_ctx_not_starting_at_1():
+    with pytest.raises(ValueError, match="first context range must start at 1"):
+        build_dynamic_sd_schedule_lookup(
+            num_speculative_tokens_per_batch_size=[(1, 16, 2, 100, 3)],
+            vllm_max_batch_size=16,
+            vllm_num_speculative_tokens=3,
+        )
+
+
+def test_dynamic_sd_rejects_negative_ctx():
+    with pytest.raises(ValueError, match="Context range .* must be positive"):
+        build_dynamic_sd_schedule_lookup(
+            num_speculative_tokens_per_batch_size=[(1, 16, 0, 100, 3)],
+            vllm_max_batch_size=16,
+            vllm_num_speculative_tokens=3,
+        )
 
 
 def test_scheduler_initializes_dynamic_sd_lookup_from_speculative_config():
@@ -242,6 +368,32 @@ def test_scheduler_passes_max_num_seqs_as_dsd_runtime_batch_limit():
     output = _add_requests_and_schedule(scheduler, 16)
 
     assert scheduler.dynamic_sd_lookup is not None
-    assert len(scheduler.dynamic_sd_lookup) == 17
+    assert len(scheduler.dynamic_sd_lookup.dense) == 17
     assert len(output.num_scheduled_tokens) == 16
+    assert output.num_spec_tokens_to_schedule == 3
+
+
+def test_scheduler_stores_dynamic_sd_lookup_from_5tuple_config():
+    scheduler = _make_scheduler_with_dynamic_sd(
+        [(1, 16, 1, 100, 3), (1, 16, 101, 4096, 2)],
+        runtime_num_speculative_tokens=3,
+    )
+
+    assert scheduler.dynamic_sd_lookup is not None
+    assert len(scheduler.dynamic_sd_lookup.ctx_boundaries) == 2
+    assert scheduler.dynamic_sd_lookup.dense[1] == [3, 2]
+
+
+def test_scheduler_dispatches_k_via_ctx_bucket_for_fresh_requests():
+    scheduler = _make_scheduler_with_dynamic_sd(
+        [(1, 8, 1, 100, 3), (1, 8, 101, 8192, 1)],
+        max_num_seqs=8,
+        max_num_batched_tokens=200,
+        runtime_num_speculative_tokens=3,
+    )
+    output = _add_requests_and_schedule(
+        scheduler, num_requests=4, num_tokens=20
+    )
+
+    assert len(output.num_scheduled_tokens) == 4
     assert output.num_spec_tokens_to_schedule == 3

--- a/tests/v1/spec_decode/test_dynamic_sd.py
+++ b/tests/v1/spec_decode/test_dynamic_sd.py
@@ -13,7 +13,7 @@ from vllm.v1.structured_output import StructuredOutputManager
 
 
 def _make_lookup(
-    num_speculative_tokens_per_batch_size,
+    speculative_token_schedule,
     *,
     max_batch_size: int = 256,
     runtime_num_speculative_tokens: int = 3,
@@ -25,7 +25,7 @@ def _make_lookup(
     directly to see the full 2D structure.
     """
     lookup = build_dynamic_sd_schedule_lookup(
-        num_speculative_tokens_per_batch_size=num_speculative_tokens_per_batch_size,
+        speculative_token_schedule=speculative_token_schedule,
         vllm_max_batch_size=max_batch_size,
         vllm_num_speculative_tokens=runtime_num_speculative_tokens,
     )
@@ -48,7 +48,7 @@ def _make_scheduler_with_dynamic_sd(
 
     speculative_config = base_scheduler.vllm_config.speculative_config
     assert speculative_config is not None
-    speculative_config.num_speculative_tokens_per_batch_size = schedule
+    speculative_config.speculative_token_schedule = schedule
 
     return Scheduler(
         vllm_config=base_scheduler.vllm_config,
@@ -125,7 +125,7 @@ def test_dynamic_sd_rejects_empty_schedule():
 
 def test_dynamic_sd_requires_schedule_config():
     with pytest.raises(
-        ValueError, match="num_speculative_tokens_per_batch_size is required"
+        ValueError, match="speculative_token_schedule is required"
     ):
         build_dynamic_sd_schedule_lookup(
             None,
@@ -144,7 +144,7 @@ def test_dynamic_sd_lookup_rejects_invalid_batch_size_queries():
 
 def test_dynamic_sd_5tuple_forms_2d_dense_lookup():
     lookup = build_dynamic_sd_schedule_lookup(
-        num_speculative_tokens_per_batch_size=[
+        speculative_token_schedule=[
             (1, 32, 1, 512, 3),
             (1, 32, 513, 4096, 2),
             (33, 128, 1, 512, 2),
@@ -165,7 +165,7 @@ def test_dynamic_sd_5tuple_forms_2d_dense_lookup():
 
 def test_dynamic_sd_5tuple_carry_forward_across_bs_gap():
     lookup = build_dynamic_sd_schedule_lookup(
-        num_speculative_tokens_per_batch_size=[
+        speculative_token_schedule=[
             (1, 8, 1, 100, 3),
             (1, 8, 101, 4096, 2),
             (32, 64, 1, 100, 1),
@@ -184,7 +184,7 @@ def test_dynamic_sd_5tuple_carry_forward_across_bs_gap():
 
 def test_dynamic_sd_bucket_of_maps_context_to_bucket_index():
     lookup = build_dynamic_sd_schedule_lookup(
-        num_speculative_tokens_per_batch_size=[
+        speculative_token_schedule=[
             (1, 16, 1, 100, 3),
             (1, 16, 101, 4096, 2),
         ],
@@ -201,7 +201,7 @@ def test_dynamic_sd_bucket_of_maps_context_to_bucket_index():
 
 def test_dynamic_sd_5tuple_extends_last_ctx_to_cover_any_value():
     lookup = build_dynamic_sd_schedule_lookup(
-        num_speculative_tokens_per_batch_size=[(1, 16, 1, 4096, 3)],
+        speculative_token_schedule=[(1, 16, 1, 4096, 3)],
         vllm_max_batch_size=16,
         vllm_num_speculative_tokens=3,
     )
@@ -220,7 +220,7 @@ def test_dynamic_sd_rejects_mixed_arity():
 def test_dynamic_sd_rejects_non_rectangular_grid():
     with pytest.raises(ValueError, match="rectangular"):
         build_dynamic_sd_schedule_lookup(
-            num_speculative_tokens_per_batch_size=[
+            speculative_token_schedule=[
                 (1, 64, 1, 4096, 3),
                 (65, 256, 1, 512, 2),
                 (65, 256, 513, 4096, 1),
@@ -233,7 +233,7 @@ def test_dynamic_sd_rejects_non_rectangular_grid():
 def test_dynamic_sd_rejects_ctx_gap():
     with pytest.raises(ValueError, match="contiguous"):
         build_dynamic_sd_schedule_lookup(
-            num_speculative_tokens_per_batch_size=[
+            speculative_token_schedule=[
                 (1, 16, 1, 100, 3),
                 (1, 16, 200, 4096, 2),
             ],
@@ -245,7 +245,7 @@ def test_dynamic_sd_rejects_ctx_gap():
 def test_dynamic_sd_rejects_ctx_not_starting_at_1():
     with pytest.raises(ValueError, match="first context range must start at 1"):
         build_dynamic_sd_schedule_lookup(
-            num_speculative_tokens_per_batch_size=[(1, 16, 2, 100, 3)],
+            speculative_token_schedule=[(1, 16, 2, 100, 3)],
             vllm_max_batch_size=16,
             vllm_num_speculative_tokens=3,
         )
@@ -254,7 +254,7 @@ def test_dynamic_sd_rejects_ctx_not_starting_at_1():
 def test_dynamic_sd_rejects_negative_ctx():
     with pytest.raises(ValueError, match="Context range .* must be positive"):
         build_dynamic_sd_schedule_lookup(
-            num_speculative_tokens_per_batch_size=[(1, 16, 0, 100, 3)],
+            speculative_token_schedule=[(1, 16, 0, 100, 3)],
             vllm_max_batch_size=16,
             vllm_num_speculative_tokens=3,
         )
@@ -321,7 +321,7 @@ def test_dynamic_sd_is_disabled_with_data_parallel(caplog_vllm):
             max_num_seqs=256,
             max_num_batched_tokens=2560,
             num_speculative_tokens=3,
-            num_speculative_tokens_per_batch_size=[
+            speculative_token_schedule=[
                 (1, 16, 3),
                 (64, 128, 2),
                 (256, 4096, 0),
@@ -331,7 +331,7 @@ def test_dynamic_sd_is_disabled_with_data_parallel(caplog_vllm):
 
     speculative_config = scheduler.vllm_config.speculative_config
     assert speculative_config is not None
-    assert speculative_config.num_speculative_tokens_per_batch_size is None
+    assert speculative_config.speculative_token_schedule is None
     assert scheduler.dynamic_sd_lookup is None
     assert "Dynamic speculative decoding is not supported with data parallelism" in (
         caplog_vllm.text

--- a/tests/v1/spec_decode/test_dynamic_sd_cug.py
+++ b/tests/v1/spec_decode/test_dynamic_sd_cug.py
@@ -74,11 +74,11 @@ def _create_vllm_config_for_dsd(
             num_spec_per_batch_size = [
                 (qlen, qlen, qlen - 1) for qlen in range(1, max_decode_query_len + 1)
             ]
-        speculative_config.num_speculative_tokens_per_batch_size = (
+        speculative_config.speculative_token_schedule = (
             num_spec_per_batch_size
         )
     else:
-        speculative_config.num_speculative_tokens_per_batch_size = None
+        speculative_config.speculative_token_schedule = None
     vllm_config.speculative_config = speculative_config
 
     return vllm_config

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -176,15 +176,17 @@ class SpeculativeConfig:
 
     # dynamic speculative decoding control
     num_speculative_tokens_per_batch_size: (
-        list[tuple[int, int, int]]
-        | list[tuple[int, int, int, int, int]]
-        | None
+        list[tuple[int, int, int]] | list[tuple[int, int, int, int, int]] | None
     ) = None
     """Schedule used to dynamically choose speculative-token count. Entries are
     ``(bs_lo, bs_hi, K)`` for context-independent schedules or
     ``(bs_lo, bs_hi, ctx_lo, ctx_hi, K)`` for schedules forming a rectangular
     ``(batch_size x context)`` grid. Forms cannot be mixed in one schedule.
     """
+
+    ctx_agg: Literal["median", "mean", "max"] = "mean"
+    """Aggregation across decode requests' num_computed_tokens used to pick
+    the ctx bucket for 5-item schedules."""
 
     # params generated in the post-init stage
     draft_model_config: SkipValidation[ModelConfig] = None  # type: ignore

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -175,11 +175,15 @@ class SpeculativeConfig:
     """The parallel configuration for the target model."""
 
     # dynamic speculative decoding control
-    num_speculative_tokens_per_batch_size: list[tuple[int, int, int]] | None = None
-    """Batch-size schedule used to dynamically choose speculative-token count.
-
-    Each entry is ``(range_start, range_end, num_speculative_tokens)`` with an
-    inclusive batch-size range.
+    num_speculative_tokens_per_batch_size: (
+        list[tuple[int, int, int]]
+        | list[tuple[int, int, int, int, int]]
+        | None
+    ) = None
+    """Schedule used to dynamically choose speculative-token count. Entries are
+    ``(bs_lo, bs_hi, K)`` for context-independent schedules or
+    ``(bs_lo, bs_hi, ctx_lo, ctx_hi, K)`` for schedules forming a rectangular
+    ``(batch_size x context)`` grid. Forms cannot be mixed in one schedule.
     """
 
     # params generated in the post-init stage

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -470,11 +470,15 @@ class SpeculativeConfig:
     """The parallel configuration for the target model."""
 
     # dynamic speculative decoding control
-    num_speculative_tokens_per_batch_size: list[tuple[int, int, int]] | None = None
-    """Batch-size schedule used to dynamically choose speculative-token count.
-
-    Each entry is ``(range_start, range_end, num_speculative_tokens)`` with an
-    inclusive batch-size range.
+    num_speculative_tokens_per_batch_size: (
+        list[tuple[int, int, int]]
+        | list[tuple[int, int, int, int, int]]
+        | None
+    ) = None
+    """Schedule used to dynamically choose speculative-token count. Entries are
+    ``(bs_lo, bs_hi, K)`` for context-independent schedules or
+    ``(bs_lo, bs_hi, ctx_lo, ctx_hi, K)`` for schedules forming a rectangular
+    ``(batch_size x context)`` grid. Forms cannot be mixed in one schedule.
     """
 
     # params generated in the post-init stage

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -471,15 +471,17 @@ class SpeculativeConfig:
 
     # dynamic speculative decoding control
     num_speculative_tokens_per_batch_size: (
-        list[tuple[int, int, int]]
-        | list[tuple[int, int, int, int, int]]
-        | None
+        list[tuple[int, int, int]] | list[tuple[int, int, int, int, int]] | None
     ) = None
     """Schedule used to dynamically choose speculative-token count. Entries are
     ``(bs_lo, bs_hi, K)`` for context-independent schedules or
     ``(bs_lo, bs_hi, ctx_lo, ctx_hi, K)`` for schedules forming a rectangular
     ``(batch_size x context)`` grid. Forms cannot be mixed in one schedule.
     """
+
+    ctx_agg: Literal["median", "mean", "max"] = "mean"
+    """Aggregation across decode requests' num_computed_tokens used to pick
+    the ctx bucket for 5-item schedules."""
 
     # params generated in the post-init stage
     draft_model_config: SkipValidation[ModelConfig] = None  # type: ignore

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -3,10 +3,17 @@
 
 import copy
 import functools
+import warnings
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
-from pydantic import Field, SkipValidation, field_validator, model_validator
+from pydantic import (
+    AliasChoices,
+    Field,
+    SkipValidation,
+    field_validator,
+    model_validator,
+)
 from typing_extensions import Self
 
 from vllm.config import LoadConfig
@@ -470,13 +477,22 @@ class SpeculativeConfig:
     """The parallel configuration for the target model."""
 
     # dynamic speculative decoding control
-    num_speculative_tokens_per_batch_size: (
+    speculative_token_schedule: (
         list[tuple[int, int, int]] | list[tuple[int, int, int, int, int]] | None
-    ) = None
+    ) = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "speculative_token_schedule",
+            "num_speculative_tokens_per_batch_size",
+        ),
+    )
     """Schedule used to dynamically choose speculative-token count. Entries are
     ``(bs_lo, bs_hi, K)`` for context-independent schedules or
     ``(bs_lo, bs_hi, ctx_lo, ctx_hi, K)`` for schedules forming a rectangular
     ``(batch_size x context)`` grid. Forms cannot be mixed in one schedule.
+
+    The previous name ``num_speculative_tokens_per_batch_size`` is accepted
+    as a deprecated alias and emits a ``DeprecationWarning``.
     """
 
     ctx_agg: Literal["median", "mean", "max"] = "mean"
@@ -1713,6 +1729,19 @@ class SpeculativeConfig:
             return AttentionBackendEnum[value.upper()]
         return value
 
+    @model_validator(mode="before")
+    @classmethod
+    def _warn_deprecated_dynamic_sd_field_name(cls, data: Any) -> Any:
+        if isinstance(data, dict) and "num_speculative_tokens_per_batch_size" in data:
+            warnings.warn(
+                "`num_speculative_tokens_per_batch_size` has been renamed to "
+                "`speculative_token_schedule`. The old name is still accepted "
+                "as an alias but may be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return data
+
     @model_validator(mode="after")
     def _verify_args(self) -> Self:
         if self.tensor_parallel_size is not None:
@@ -1859,7 +1888,7 @@ class SpeculativeConfig:
         return self.method == "dspark"
 
     def uses_dynamic_speculative_decoding(self) -> bool:
-        return self.num_speculative_tokens_per_batch_size is not None
+        return self.speculative_token_schedule is not None
 
     def uses_draft_model(self) -> bool:
         return self.method == "draft_model"

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -955,11 +955,11 @@ class VllmConfig:
             "Dynamic speculative decoding is not supported with data "
             "parallelism because data-parallel ranks can select different "
             "speculative-token counts, causing DP divergence and deadlocks. "
-            "Disabling num_speculative_tokens_per_batch_size and falling back "
+            "Disabling speculative_token_schedule and falling back "
             "to static num_speculative_tokens=%d.",
             speculative_config.num_speculative_tokens,
         )
-        speculative_config.num_speculative_tokens_per_batch_size = None
+        speculative_config.speculative_token_schedule = None
 
     def _post_init_kv_transfer_config(self) -> None:
         """Update KVTransferConfig based on top-level configs in VllmConfig.
@@ -2054,9 +2054,7 @@ class VllmConfig:
                             build_dynamic_sd_schedule_lookup,
                         )
 
-                        schedule = (
-                            speculative_config.num_speculative_tokens_per_batch_size
-                        )
+                        schedule = speculative_config.speculative_token_schedule
                         assert schedule is not None
                         # Read the tiers off the dense lookup the scheduler
                         # runs on, so the clamp against num_speculative_tokens

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2064,7 +2064,7 @@ class VllmConfig:
                         # cannot drift from it. Validation lives elsewhere; an
                         # invalid schedule keeps the single-tier default.
                         try:
-                            dense_schedule = build_dynamic_sd_schedule_lookup(
+                            schedule_lookup = build_dynamic_sd_schedule_lookup(
                                 schedule,
                                 vllm_max_batch_size=max_num_seqs,
                                 vllm_num_speculative_tokens=self.num_speculative_tokens,
@@ -2075,10 +2075,11 @@ class VllmConfig:
                             # Ascending batch size, so the last write per
                             # query length is the widest batch running at it.
                             widest_batch: dict[int, int] = {}
-                            for batch_size, num_spec in enumerate(
-                                dense_schedule[1:], start=1
+                            for batch_size, row in enumerate(
+                                schedule_lookup.dense[1:], start=1
                             ):
-                                widest_batch[num_spec + 1] = batch_size
+                                for num_spec in row:
+                                    widest_batch[num_spec + 1] = batch_size
                             decode_tiers = list(widest_batch.items())
 
                     uniform_decode_sizes = sorted(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -238,7 +238,10 @@ class Scheduler(SchedulerInterface):
         self.num_spec_tokens = vllm_config.num_speculative_tokens
         self.num_lookahead_tokens = 0
         self.dynamic_sd_lookup: DynamicSDLookup | None = None
+        self.dynamic_sd_ctx_agg: str = "mean"
         if speculative_config is not None:
+            if getattr(speculative_config, "ctx_agg", None):
+                self.dynamic_sd_ctx_agg = speculative_config.ctx_agg
             if speculative_config.num_speculative_tokens_per_batch_size:
                 self.dynamic_sd_lookup = build_dynamic_sd_schedule_lookup(
                     speculative_config.num_speculative_tokens_per_batch_size,
@@ -1135,12 +1138,24 @@ class Scheduler(SchedulerInterface):
         # Dynamic speculative decoding: compute optimal K
         num_spec_tokens_to_schedule = self.num_spec_tokens
         if self.dynamic_sd_lookup is not None and len(num_scheduled_tokens) > 0:
-            ctx_values = sorted(
+            decode_ctx = [
                 self.requests[req_id].num_computed_tokens
                 for req_id in num_scheduled_tokens
-            )
-            p50_ctx = ctx_values[len(ctx_values) // 2]
-            ctx_bucket = self.dynamic_sd_lookup.bucket_of(p50_ctx)
+                if self.requests[req_id].num_computed_tokens
+                >= self.requests[req_id].num_prompt_tokens
+            ]
+            ctx_pool = decode_ctx or [
+                self.requests[req_id].num_computed_tokens
+                for req_id in num_scheduled_tokens
+            ]
+            if self.dynamic_sd_ctx_agg == "max":
+                ctx_repr = max(ctx_pool)
+            elif self.dynamic_sd_ctx_agg == "mean":
+                ctx_repr = sum(ctx_pool) // len(ctx_pool)
+            else:
+                sorted_ctx = sorted(ctx_pool)
+                ctx_repr = sorted_ctx[len(sorted_ctx) // 2]
+            ctx_bucket = self.dynamic_sd_lookup.bucket_of(ctx_repr)
             num_spec_tokens_to_schedule = self.dynamic_sd_lookup.dense[
                 len(num_scheduled_tokens)
             ][ctx_bucket]

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -59,7 +59,10 @@ from vllm.v1.metrics.perf import ModelMetrics, PerfStats
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus, StreamingUpdate
-from vllm.v1.spec_decode.dynamic.utils import build_dynamic_sd_schedule_lookup
+from vllm.v1.spec_decode.dynamic.utils import (
+    DynamicSDLookup,
+    build_dynamic_sd_schedule_lookup,
+)
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
@@ -234,7 +237,7 @@ class Scheduler(SchedulerInterface):
         self.use_eagle = False
         self.num_spec_tokens = vllm_config.num_speculative_tokens
         self.num_lookahead_tokens = 0
-        self.dynamic_sd_lookup: list[int] | None = None
+        self.dynamic_sd_lookup: DynamicSDLookup | None = None
         if speculative_config is not None:
             if speculative_config.num_speculative_tokens_per_batch_size:
                 self.dynamic_sd_lookup = build_dynamic_sd_schedule_lookup(
@@ -1132,9 +1135,15 @@ class Scheduler(SchedulerInterface):
         # Dynamic speculative decoding: compute optimal K
         num_spec_tokens_to_schedule = self.num_spec_tokens
         if self.dynamic_sd_lookup is not None and len(num_scheduled_tokens) > 0:
-            num_spec_tokens_to_schedule = self.dynamic_sd_lookup[
+            ctx_values = sorted(
+                self.requests[req_id].num_computed_tokens
+                for req_id in num_scheduled_tokens
+            )
+            p50_ctx = ctx_values[len(ctx_values) // 2]
+            ctx_bucket = self.dynamic_sd_lookup.bucket_of(p50_ctx)
+            num_spec_tokens_to_schedule = self.dynamic_sd_lookup.dense[
                 len(num_scheduled_tokens)
-            ]
+            ][ctx_bucket]
 
         scheduled_encoder_input_stats = None
         if (

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -268,7 +268,10 @@ class Scheduler(SchedulerInterface):
         # reserve between a chunk boundary and the prefill end.
         self.num_prefill_lookahead = 0
         self.dynamic_sd_lookup: DynamicSDLookup | None = None
+        self.dynamic_sd_ctx_agg: str = "mean"
         if speculative_config is not None:
+            if getattr(speculative_config, "ctx_agg", None):
+                self.dynamic_sd_ctx_agg = speculative_config.ctx_agg
             if speculative_config.num_speculative_tokens_per_batch_size:
                 self.dynamic_sd_lookup = build_dynamic_sd_schedule_lookup(
                     speculative_config.num_speculative_tokens_per_batch_size,
@@ -1322,12 +1325,24 @@ class Scheduler(SchedulerInterface):
         # Dynamic speculative decoding: compute optimal K
         num_spec_tokens_to_schedule = self.num_spec_tokens
         if self.dynamic_sd_lookup is not None and len(num_scheduled_tokens) > 0:
-            ctx_values = sorted(
+            decode_ctx = [
                 self.requests[req_id].num_computed_tokens
                 for req_id in num_scheduled_tokens
-            )
-            p50_ctx = ctx_values[len(ctx_values) // 2]
-            ctx_bucket = self.dynamic_sd_lookup.bucket_of(p50_ctx)
+                if self.requests[req_id].num_computed_tokens
+                >= self.requests[req_id].num_prompt_tokens
+            ]
+            ctx_pool = decode_ctx or [
+                self.requests[req_id].num_computed_tokens
+                for req_id in num_scheduled_tokens
+            ]
+            if self.dynamic_sd_ctx_agg == "max":
+                ctx_repr = max(ctx_pool)
+            elif self.dynamic_sd_ctx_agg == "mean":
+                ctx_repr = sum(ctx_pool) // len(ctx_pool)
+            else:
+                sorted_ctx = sorted(ctx_pool)
+                ctx_repr = sorted_ctx[len(sorted_ctx) // 2]
+            ctx_bucket = self.dynamic_sd_lookup.bucket_of(ctx_repr)
             num_spec_tokens_to_schedule = self.dynamic_sd_lookup.dense[
                 len(num_scheduled_tokens)
             ][ctx_bucket]

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -63,7 +63,10 @@ from vllm.v1.metrics.stats import (
 )
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus, StreamingUpdate
-from vllm.v1.spec_decode.dynamic.utils import build_dynamic_sd_schedule_lookup
+from vllm.v1.spec_decode.dynamic.utils import (
+    DynamicSDLookup,
+    build_dynamic_sd_schedule_lookup,
+)
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.structured_output import StructuredOutputGrammar, StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
@@ -264,7 +267,7 @@ class Scheduler(SchedulerInterface):
         # manager's re-prefillable window (this minus 1), and how many tokens to
         # reserve between a chunk boundary and the prefill end.
         self.num_prefill_lookahead = 0
-        self.dynamic_sd_lookup: list[int] | None = None
+        self.dynamic_sd_lookup: DynamicSDLookup | None = None
         if speculative_config is not None:
             if speculative_config.num_speculative_tokens_per_batch_size:
                 self.dynamic_sd_lookup = build_dynamic_sd_schedule_lookup(
@@ -1319,9 +1322,15 @@ class Scheduler(SchedulerInterface):
         # Dynamic speculative decoding: compute optimal K
         num_spec_tokens_to_schedule = self.num_spec_tokens
         if self.dynamic_sd_lookup is not None and len(num_scheduled_tokens) > 0:
-            num_spec_tokens_to_schedule = self.dynamic_sd_lookup[
+            ctx_values = sorted(
+                self.requests[req_id].num_computed_tokens
+                for req_id in num_scheduled_tokens
+            )
+            p50_ctx = ctx_values[len(ctx_values) // 2]
+            ctx_bucket = self.dynamic_sd_lookup.bucket_of(p50_ctx)
+            num_spec_tokens_to_schedule = self.dynamic_sd_lookup.dense[
                 len(num_scheduled_tokens)
-            ]
+            ][ctx_bucket]
 
         scheduled_encoder_input_stats = None
         if (

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -272,9 +272,9 @@ class Scheduler(SchedulerInterface):
         if speculative_config is not None:
             if getattr(speculative_config, "ctx_agg", None):
                 self.dynamic_sd_ctx_agg = speculative_config.ctx_agg
-            if speculative_config.num_speculative_tokens_per_batch_size:
+            if speculative_config.speculative_token_schedule:
                 self.dynamic_sd_lookup = build_dynamic_sd_schedule_lookup(
-                    speculative_config.num_speculative_tokens_per_batch_size,
+                    speculative_config.speculative_token_schedule,
                     vllm_max_batch_size=self.scheduler_config.max_num_seqs,
                     vllm_num_speculative_tokens=self.num_spec_tokens,
                 )

--- a/vllm/v1/spec_decode/dynamic/utils.py
+++ b/vllm/v1/spec_decode/dynamic/utils.py
@@ -1,17 +1,37 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-DynamicSDSchedule = list[tuple[int, int, int]]
+from typing import NamedTuple
+
+_CTX_INFINITY = 2**31 - 1
+
+DynamicSDEntry = tuple[int, int, int, int, int]
+DynamicSDSchedule = list[DynamicSDEntry]
+
+
+class DynamicSDLookup(NamedTuple):
+    """Dense ``(batch_size, context_bucket) -> K`` lookup with context-axis
+    bucket boundaries."""
+
+    dense: list[list[int]]
+    ctx_boundaries: list[tuple[int, int]]
+
+    def bucket_of(self, ctx_value: int) -> int:
+        for i, (_, hi) in enumerate(self.ctx_boundaries):
+            if ctx_value <= hi:
+                return i
+        return len(self.ctx_boundaries) - 1
 
 
 def validate_and_normalize_dynamic_sd_schedule(
     num_speculative_tokens_per_batch_size: object,
 ) -> DynamicSDSchedule:
-    """Validate and normalize a Dynamic SD batch-size schedule.
+    """Validate and normalize a Dynamic SD schedule.
 
-    The schedule is expressed as a list of inclusive ranges:
-
-    ``[(range_start, range_end, num_speculative_tokens), ...]``
+    Accepts either 3-item ``(bs_lo, bs_hi, K)`` entries (context-independent)
+    or 5-item ``(bs_lo, bs_hi, ctx_lo, ctx_hi, K)`` entries forming a
+    rectangular ``(batch_size x context)`` grid. The two forms cannot be
+    mixed in a single schedule.
     """
     if num_speculative_tokens_per_batch_size is None:
         raise ValueError(
@@ -20,129 +40,177 @@ def validate_and_normalize_dynamic_sd_schedule(
         )
     if not isinstance(num_speculative_tokens_per_batch_size, list):
         raise ValueError(
-            "num_speculative_tokens_per_batch_size must be a non-empty list of "
-            "(range_start, range_end, num_speculative_tokens) entries."
+            "num_speculative_tokens_per_batch_size must be a non-empty list "
+            "of 3-item or 5-item entries."
         )
     if not num_speculative_tokens_per_batch_size:
         raise ValueError("num_speculative_tokens_per_batch_size must not be empty.")
 
-    parsed_schedule: DynamicSDSchedule = []
+    arities: set[int] = set()
+    parsed: list[DynamicSDEntry] = []
     for entry in num_speculative_tokens_per_batch_size:
-        if not isinstance(entry, list | tuple) or len(entry) != 3:
+        if not isinstance(entry, list | tuple) or len(entry) not in (3, 5):
             raise ValueError(
                 "Each num_speculative_tokens_per_batch_size entry must be a "
-                "3-item sequence: (range_start, range_end, num_speculative_tokens)."
+                "3-item sequence (bs_lo, bs_hi, num_speculative_tokens) or a "
+                "5-item sequence "
+                "(bs_lo, bs_hi, ctx_lo, ctx_hi, num_speculative_tokens)."
+            )
+        arities.add(len(entry))
+        if len(entry) == 3:
+            bs_lo, bs_hi, k = int(entry[0]), int(entry[1]), int(entry[2])
+            ctx_lo, ctx_hi = 1, _CTX_INFINITY
+        else:
+            bs_lo, bs_hi, ctx_lo, ctx_hi, k = (
+                int(entry[0]),
+                int(entry[1]),
+                int(entry[2]),
+                int(entry[3]),
+                int(entry[4]),
             )
 
-        range_start, range_end, num_speculative_tokens = (
-            int(entry[0]),
-            int(entry[1]),
-            int(entry[2]),
-        )
-
-        if range_start <= 0 or range_end <= 0:
+        if bs_lo <= 0 or bs_hi <= 0:
             raise ValueError(
-                f"Batch-size range ({range_start}, {range_end}) must be positive."
+                f"Batch-size range ({bs_lo}, {bs_hi}) must be positive."
             )
-        if range_start > range_end:
+        if bs_lo > bs_hi:
             raise ValueError(
                 "Batch-size range start must be <= end for "
-                f"({range_start}, {range_end}, {num_speculative_tokens})."
+                f"({bs_lo}, {bs_hi}, ..., {k})."
             )
-        if num_speculative_tokens < 0:
+        if ctx_lo <= 0 or ctx_hi <= 0:
+            raise ValueError(
+                f"Context range ({ctx_lo}, {ctx_hi}) must be positive."
+            )
+        if ctx_lo > ctx_hi:
+            raise ValueError(
+                "Context range start must be <= end for "
+                f"({bs_lo}, {bs_hi}, {ctx_lo}, {ctx_hi}, {k})."
+            )
+        if k < 0:
             raise ValueError(
                 "num_speculative_tokens_per_batch_size values must be >= 0."
             )
 
-        parsed_schedule.append((range_start, range_end, num_speculative_tokens))
+        parsed.append((bs_lo, bs_hi, ctx_lo, ctx_hi, k))
 
-    parsed_schedule.sort(key=lambda entry: entry[0])
+    if len(arities) > 1:
+        raise ValueError(
+            "num_speculative_tokens_per_batch_size entries must all be "
+            "3-item or all 5-item; mixing the two forms is not supported."
+        )
 
-    previous_end = 0
-    for range_start, range_end, _ in parsed_schedule:
-        if range_start <= previous_end:
-            raise ValueError("Batch-size ranges must be non-overlapping and sorted.")
-        previous_end = range_end
-
-    first_range_start = parsed_schedule[0][0]
-    if first_range_start != 1:
+    bs_ranges = sorted({(bs_lo, bs_hi) for bs_lo, bs_hi, *_ in parsed})
+    prev_bs_end = 0
+    for bs_lo, bs_hi in bs_ranges:
+        if bs_lo <= prev_bs_end:
+            raise ValueError(
+                "Batch-size ranges must be non-overlapping and sorted."
+            )
+        prev_bs_end = bs_hi
+    if bs_ranges[0][0] != 1:
         raise ValueError(
             "The first batch-size range must start at 1 so every runtime "
             "batch size has a defined schedule."
         )
 
-    return parsed_schedule
+    ctx_ranges = sorted({(ctx_lo, ctx_hi) for _, _, ctx_lo, ctx_hi, _ in parsed})
+
+    expected_cells = len(bs_ranges) * len(ctx_ranges)
+    if len(parsed) != expected_cells:
+        raise ValueError(
+            "num_speculative_tokens_per_batch_size must form a rectangular "
+            f"(batch_size x context) grid: got {len(parsed)} entries but "
+            f"expected {expected_cells} = {len(bs_ranges)} bs ranges x "
+            f"{len(ctx_ranges)} context ranges. Every batch-size range must "
+            "share the same set of context boundaries."
+        )
+
+    if ctx_ranges[0][0] != 1:
+        raise ValueError(
+            "The first context range must start at 1 so every runtime "
+            "context length has a defined bucket."
+        )
+    for i in range(1, len(ctx_ranges)):
+        if ctx_ranges[i][0] != ctx_ranges[i - 1][1] + 1:
+            raise ValueError(
+                "Context ranges must be contiguous with no gaps; "
+                f"({ctx_ranges[i - 1][0]}, {ctx_ranges[i - 1][1]}) is "
+                f"followed by ({ctx_ranges[i][0]}, {ctx_ranges[i][1]})."
+            )
+    last_ctx_lo, _ = ctx_ranges[-1]
+    ctx_ranges[-1] = (last_ctx_lo, _CTX_INFINITY)
+
+    ctx_hi_by_lo = {lo: hi for lo, hi in ctx_ranges}
+    normalized: DynamicSDSchedule = []
+    seen: set[tuple[int, int, int]] = set()
+    for bs_lo, bs_hi, ctx_lo, _, k in parsed:
+        key = (bs_lo, bs_hi, ctx_lo)
+        if key in seen:
+            raise ValueError(
+                f"Duplicate schedule cell for (bs=[{bs_lo},{bs_hi}], "
+                f"ctx_lo={ctx_lo})."
+            )
+        seen.add(key)
+        normalized.append((bs_lo, bs_hi, ctx_lo, ctx_hi_by_lo[ctx_lo], k))
+
+    normalized.sort(key=lambda e: (e[0], e[2]))
+    return normalized
 
 
 def build_dynamic_sd_schedule_lookup(
     num_speculative_tokens_per_batch_size: object,
     vllm_max_batch_size: int,
     vllm_num_speculative_tokens: int,
-) -> list[int]:
-    """Expand the configured schedule into a dense batch_size -> K lookup.
+) -> DynamicSDLookup:
+    """Expand the configured schedule into a dense ``(bs, ctx) -> K`` lookup.
 
-    "dense_schedule" means a 1-indexed lookup table where index ``batch_size``
-    stores the exact K to use for that runtime batch size. This lets the
-    scheduler do a simple array lookup instead of searching the configured
-    ranges on every scheduling step.
+    Index 0 on the batch-size axis is intentionally unused so runtime batch
+    sizes look up directly. Legacy 3-item schedules produce a single-bucket
+    lookup where every ``dense[bs]`` row has length 1.
     """
     if vllm_max_batch_size <= 0:
         raise ValueError("vllm_max_batch_size must be > 0.")
     if vllm_num_speculative_tokens <= 0:
         raise ValueError("vllm_num_speculative_tokens must be > 0.")
 
-    parsed_schedule = validate_and_normalize_dynamic_sd_schedule(
+    normalized = validate_and_normalize_dynamic_sd_schedule(
         num_speculative_tokens_per_batch_size
     )
 
-    # Index 0 is intentionally unused so that valid runtime batch sizes can be
-    # looked up directly as dense_schedule[batch_size].
-    dense_schedule = [0] * (vllm_max_batch_size + 1)
-    next_batch_size = 1
-    last_num_speculative_tokens: int | None = None
+    ctx_boundaries = sorted(
+        {(ctx_lo, ctx_hi) for _, _, ctx_lo, ctx_hi, _ in normalized}
+    )
+    ctx_index = {ctx_range: i for i, ctx_range in enumerate(ctx_boundaries)}
+    num_ctx = len(ctx_boundaries)
 
-    for range_start, range_end, num_speculative_tokens in parsed_schedule:
-        if range_start > next_batch_size and last_num_speculative_tokens is not None:
-            # Fill any gap before the next configured range by carrying forward
-            # the previous K. For example, [(1, 16, 3), (32, 128, 2)] should map
-            # batch sizes 17-31 to K=3.
-            for batch_size in range(
-                next_batch_size,
-                min(range_start, vllm_max_batch_size + 1),
+    per_ctx: list[list[tuple[int, int, int]]] = [[] for _ in range(num_ctx)]
+    for bs_lo, bs_hi, ctx_lo, ctx_hi, k in normalized:
+        per_ctx[ctx_index[(ctx_lo, ctx_hi)]].append((bs_lo, bs_hi, k))
+
+    dense: list[list[int]] = [
+        [0] * num_ctx for _ in range(vllm_max_batch_size + 1)
+    ]
+
+    for c, entries in enumerate(per_ctx):
+        entries.sort(key=lambda e: e[0])
+        next_bs = 1
+        last_k: int | None = None
+        for bs_lo, bs_hi, k in entries:
+            if bs_lo > next_bs and last_k is not None:
+                for bs in range(next_bs, min(bs_lo, vllm_max_batch_size + 1)):
+                    dense[bs][c] = min(vllm_num_speculative_tokens, last_k)
+            for bs in range(
+                max(bs_lo, next_bs),
+                min(bs_hi, vllm_max_batch_size) + 1,
             ):
-                dense_schedule[batch_size] = min(
-                    vllm_num_speculative_tokens,
-                    last_num_speculative_tokens,
-                )
+                dense[bs][c] = min(vllm_num_speculative_tokens, k)
+            next_bs = max(next_bs, bs_hi + 1)
+            last_k = k
+            if next_bs > vllm_max_batch_size:
+                break
+        if last_k is not None:
+            for bs in range(next_bs, vllm_max_batch_size + 1):
+                dense[bs][c] = min(vllm_num_speculative_tokens, last_k)
 
-        # Fill the current configured inclusive range with its K value.
-        for batch_size in range(
-            max(range_start, next_batch_size),
-            min(range_end, vllm_max_batch_size) + 1,
-        ):
-            dense_schedule[batch_size] = min(
-                vllm_num_speculative_tokens,
-                num_speculative_tokens,
-            )
-
-        next_batch_size = max(next_batch_size, range_end + 1)
-        last_num_speculative_tokens = num_speculative_tokens
-
-        if next_batch_size > vllm_max_batch_size:
-            break
-
-    if last_num_speculative_tokens is None:
-        raise ValueError(
-            "num_speculative_tokens_per_batch_size must contain at least "
-            "one valid batch-size range."
-        )
-
-    # Fill the tail after the final configured range by carrying forward the
-    # last K through vllm_max_batch_size.
-    for batch_size in range(next_batch_size, vllm_max_batch_size + 1):
-        dense_schedule[batch_size] = min(
-            vllm_num_speculative_tokens,
-            last_num_speculative_tokens,
-        )
-
-    return dense_schedule
+    return DynamicSDLookup(dense=dense, ctx_boundaries=ctx_boundaries)

--- a/vllm/v1/spec_decode/dynamic/utils.py
+++ b/vllm/v1/spec_decode/dynamic/utils.py
@@ -24,7 +24,7 @@ class DynamicSDLookup(NamedTuple):
 
 
 def validate_and_normalize_dynamic_sd_schedule(
-    num_speculative_tokens_per_batch_size: object,
+    speculative_token_schedule: object,
 ) -> DynamicSDSchedule:
     """Validate and normalize a Dynamic SD schedule.
 
@@ -33,25 +33,25 @@ def validate_and_normalize_dynamic_sd_schedule(
     rectangular ``(batch_size x context)`` grid. The two forms cannot be
     mixed in a single schedule.
     """
-    if num_speculative_tokens_per_batch_size is None:
+    if speculative_token_schedule is None:
         raise ValueError(
-            "num_speculative_tokens_per_batch_size is required for "
+            "speculative_token_schedule is required for "
             "dynamic speculative decoding."
         )
-    if not isinstance(num_speculative_tokens_per_batch_size, list):
+    if not isinstance(speculative_token_schedule, list):
         raise ValueError(
-            "num_speculative_tokens_per_batch_size must be a non-empty list "
+            "speculative_token_schedule must be a non-empty list "
             "of 3-item or 5-item entries."
         )
-    if not num_speculative_tokens_per_batch_size:
-        raise ValueError("num_speculative_tokens_per_batch_size must not be empty.")
+    if not speculative_token_schedule:
+        raise ValueError("speculative_token_schedule must not be empty.")
 
     arities: set[int] = set()
     parsed: list[DynamicSDEntry] = []
-    for entry in num_speculative_tokens_per_batch_size:
+    for entry in speculative_token_schedule:
         if not isinstance(entry, list | tuple) or len(entry) not in (3, 5):
             raise ValueError(
-                "Each num_speculative_tokens_per_batch_size entry must be a "
+                "Each speculative_token_schedule entry must be a "
                 "3-item sequence (bs_lo, bs_hi, num_speculative_tokens) or a "
                 "5-item sequence "
                 "(bs_lo, bs_hi, ctx_lo, ctx_hi, num_speculative_tokens)."
@@ -89,14 +89,14 @@ def validate_and_normalize_dynamic_sd_schedule(
             )
         if k < 0:
             raise ValueError(
-                "num_speculative_tokens_per_batch_size values must be >= 0."
+                "speculative_token_schedule K values must be >= 0."
             )
 
         parsed.append((bs_lo, bs_hi, ctx_lo, ctx_hi, k))
 
     if len(arities) > 1:
         raise ValueError(
-            "num_speculative_tokens_per_batch_size entries must all be "
+            "speculative_token_schedule entries must all be "
             "3-item or all 5-item; mixing the two forms is not supported."
         )
 
@@ -119,7 +119,7 @@ def validate_and_normalize_dynamic_sd_schedule(
     expected_cells = len(bs_ranges) * len(ctx_ranges)
     if len(parsed) != expected_cells:
         raise ValueError(
-            "num_speculative_tokens_per_batch_size must form a rectangular "
+            "speculative_token_schedule must form a rectangular "
             f"(batch_size x context) grid: got {len(parsed)} entries but "
             f"expected {expected_cells} = {len(bs_ranges)} bs ranges x "
             f"{len(ctx_ranges)} context ranges. Every batch-size range must "
@@ -159,7 +159,7 @@ def validate_and_normalize_dynamic_sd_schedule(
 
 
 def build_dynamic_sd_schedule_lookup(
-    num_speculative_tokens_per_batch_size: object,
+    speculative_token_schedule: object,
     vllm_max_batch_size: int,
     vllm_num_speculative_tokens: int,
 ) -> DynamicSDLookup:
@@ -175,7 +175,7 @@ def build_dynamic_sd_schedule_lookup(
         raise ValueError("vllm_num_speculative_tokens must be > 0.")
 
     normalized = validate_and_normalize_dynamic_sd_schedule(
-        num_speculative_tokens_per_batch_size
+        speculative_token_schedule
     )
 
     ctx_boundaries = sorted(

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -217,7 +217,7 @@ class CudaGraphManager:
                 self.decode_query_len - self.vllm_config.num_speculative_tokens
             )
             schedule_lookup = build_dynamic_sd_schedule_lookup(
-                speculative_config.num_speculative_tokens_per_batch_size,
+                speculative_config.speculative_token_schedule,
                 vllm_max_batch_size=self.max_num_reqs,
                 vllm_num_speculative_tokens=self.vllm_config.num_speculative_tokens,
             )

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -216,7 +216,7 @@ class CudaGraphManager:
             num_new_sampled_tokens_per_step = (
                 self.decode_query_len - self.vllm_config.num_speculative_tokens
             )
-            dense_schedule = build_dynamic_sd_schedule_lookup(
+            schedule_lookup = build_dynamic_sd_schedule_lookup(
                 speculative_config.num_speculative_tokens_per_batch_size,
                 vllm_max_batch_size=self.max_num_reqs,
                 vllm_num_speculative_tokens=self.vllm_config.num_speculative_tokens,
@@ -224,7 +224,8 @@ class CudaGraphManager:
             decode_query_lens = sorted(
                 {
                     num_spec + num_new_sampled_tokens_per_step
-                    for num_spec in dense_schedule[1:]
+                    for row in schedule_lookup.dense[1:]
+                    for num_spec in row
                 }
             )
         else:


### PR DESCRIPTION
## What this PR does

Extends `num_speculative_tokens_per_batch_size` (Dynamic SD, #32374) with an optional ctx-length axis, so that a schedule can select K based on both batch size and per-request context length instead of batch size alone. The change is a backward-compatible schema extension — a 3-item entry `[bs_lo, bs_hi, K]` parses and behaves exactly as before, a 5-item entry `[bs_lo, bs_hi, ctx_lo, ctx_hi, K]` opts in to the ctx axis.

## Why

Under memory-bound decode with a shared prefix (RAG serving, agentic sessions, batched summarization), the optimal K depends on ctx as well as batch. A batch-only lookup has to pick one K per BS, either leaving ctx-amortization on the table for long sequences or over-drafting short ones. This PR gives operators a per-(bs, ctx) K table that opts in to this axis when it's useful and stays inert (3-item form) otherwise.

The concept was previously formalized by **MagicDec (Sadhukhan et al., 2024)** — *"Leveraging our observation that there is a sequence length threshold above which decoding becomes memory bound—and that it becomes increasingly memory bound for even longer sequence lengths—we propose choosing the amount of speculation as a function of the sequence length (longer sequence length -> more speculated tokens)."* ([MagicDec-part1 blog](https://infini-ai-lab.github.io/MagicDec-part1/), under *Adaptive Sequoia trees*; the companion paper is [arXiv:2408.11049](https://arxiv.org/abs/2408.11049), which makes the same argument as a critical-sequence-length threshold and an analytic model for the optimal drafting strategy, but does not contain this sentence. An earlier revision of this text cited the paper for the quote and dropped the em-dash clause without marking the elision.) MagicDec's instantiation was self-speculation with StreamingLLM sparse KV in a batch-centric framing; this PR is the general draft-target integration into vLLM's DSD lookup surface. See RFC #48627 for the design discussion.

## Evidence (2026-07-27 measurement)

Position-balanced 2-trial, `prefix_repetition` c=256, H100 NVL 94GB, `prithivMLmods/gemma-4-31B-it-qat-FP8` + assistant draft, vLLM `c5d967c23`. Full methodology + per-cell data in [decomposition comment](https://github.com/vllm-project/vllm/pull/48944#issuecomment-5091663057). Per-cell stdev <2%, order-bias max 1.72% (signal 29-36× larger).

**Primary contrast — C′ (6-cell 2D schedule) vs A′ (3-item batch-only), same DSD-mode cost:**

| ctx | A′ | C′ | C′/A′ |
|-----:|---:|---:|:-:|
| 400  | 1875.6 | 1890.7 | 1.01× (K=0 tier, tie by design) |
| 900  | 1453.5 | 1874.6 | **1.29×** |
| 1900 | 1416.6 | 1848.2 | **1.30×** |
| 4000 | 1232.8 | 1680.4 | **1.36×** |

**Zero cost when unused:** the original A/B comparison in the PR body (retracted headline, but this specific check reproduces) — 3-item vs 5-item-same-K on spec-bench aggregate: 2627.2 vs 2642.3 (+0.6%, within noise). Users who don't opt in to the ctx axis pay nothing.

**Absolute crossover vs no-spec (measured, not projected):** above ctx ~2k the 2D schedule pays the full DSD-mode tax and still beats no-speculation in absolute throughput (ctx 1900: 1.02×, ctx 4000: 1.09× vs no_spec). This is the direct mechanism measurement.

## Regime guardrail (documented usage)

**The ctx axis is intended to raise K for long-ctx buckets, not to lower K for short-ctx buckets in mixed traffic.** Using it in the latter direction (as an earlier iteration of my C schedule did) can regress aggregate throughput — the previous −4.0% spec-bench result was an anti-pattern usage plus the DSD-mode baseline tax at short ctx compounding. The docstring for the 5-item schema states this explicitly.

## Changes

- `vllm/config/speculative.py` — 3/5-tuple type union widening, `ctx_agg: Literal["median","mean","max"] = "mean"` field
- `vllm/v1/spec_decode/dynamic/utils.py` — `DynamicSDLookup(dense, ctx_boundaries)` NamedTuple, rectangular grid validation, mixed-arity rejection, 1-indexed ctx range convention
- `vllm/v1/core/sched/scheduler.py` — 2D dispatch (`dense[bs][ctx_bucket]`), decode-only pool filter for ctx representative (`num_computed_tokens >= num_prompt_tokens` with fallback to full pool), aggregator dispatch (median/mean/max)
- `tests/v1/spec_decode/test_dynamic_sd.py` — 10 new tests for 5-item parsing, 2D routing, rectangular validation, capture-set K-invariance

## Known limitations

- **DSD-mode baseline tax**: all DSD-mode arms (including this PR's schedule) pay a substantial throughput tax vs no-spec at short ctx (up to −31% at ctx=400 in the measurements above). The `PIECEWISE` cudagraph downgrade for DSD is one identified factor; a full decomposition (K=0 fast-path opportunity, drafter forward on K=0, admission cost, tier-boundary ramp) is filed as #49986. This is orthogonal to this PR — it applies to the original 3-item DSD API from #32374 too — but is worth noting because the ctx=400 tie in the C′/A′ table is a consequence of it (both arms fire K=0 at that cell, so both eat the same tax).
- **Evidence range**: measured for ctx ∈ {400, 900, 1900, 4000}. Extension to 8k+ requires re-designing the batch tier to fit within achievable concurrency at longer ctx (per-request KV budget scales with ctx) — a separate measurement.
- **Single model/drafter pair**: measured on gemma-4-31B-it-qat-FP8 + assistant. Generalization to other pairs (Llama-3.1-8B + EAGLE-3, Qwen, etc.) is a natural next validation.
- **APC-high regime**: the measurement uses `prefix_repetition` (num_prefixes=1) which represents high-shared-prefix serving (RAG, agents, batched summarization at ~98% APC hit). Under low-APC-hit workloads the story is different — the gain is bounded by how much of the KV read the amortization can save.
- **Aggregator choice**: `mean` is a defensible default (mean × B ≈ Σ ctx_i ≈ verify KV read cost — a cost signal). `median` is the majority-amortization signal and wins under specific batch-shape skew (documented in the `ctx_agg` field). Per-sequence K is out of scope for this PR (would require gathered-K verify batching + straggler control) and noted as a longer-term direction in RFC #48627 Alternatives.

## Roadmap (why this PR is worth landing as the schema base)

Filed as #49986:

1. **K=0 fast-path** — when the schedule selects K=0 for a given (bs, ctx), route through the no-spec path entirely for that step. Target: recover C′ ctx=400 from 1890.7 → 2711.7 tok/s (+43%), which would make C′ strictly dominant across all four cells (tie-to-win vs no-spec, +26% over static-K3, +29-35% over batch-only). Separate PR, 2-3 weeks.
2. **K-keyed FULL cudagraph capture** — since the schedule enumerates the K set at startup, (batch bucket × K)-shape graphs are statically capturable, and the DSD-mode PIECEWISE downgrade can be lifted for declarative schedules. Follow-on to the fast-path.
3. **8k+ evidence extension**, **second model/drafter pair validation**, **per-bucket AR reporting** — natural follow-ups.

## Tests

32 unit + integration tests pass on H100 (driver 570, CUDA 12.8): 28 in `test_dynamic_sd.py` + 4 CUDA-graph regression. E2E verified on H100 (driver 580, CUDA 13.0) via the measurement setup above.

## References

- vLLM RFC #48627 — Context-length-aware K in DSD (design + Prior Art including MagicDec anchor)
- vLLM PR #32374 — original DSD API (ekagra-ranjan)
- MagicDec (Sadhukhan et al., arXiv:2408.11049)
- Follow-up: #49986 — DSD baseline tax decomposition
- Companion: SGLang PR sgl-project/sglang#31716 (sibling 2D routing implementation)

---

## AI assistance

This change was drafted with the help of an AI coding assistant (Anthropic Claude) and reviewed line-by-line before this PR was opened. All code, tests, commit message, and PR text were reviewed by me; the test commands above were run by me on this branch. Filing this disclosure per vLLM's `AGENTS.md` requirement for AI-assisted contributions.


