### PR TITLE
Add Gemma4 B200 FP8 optimized path

### DIFF
--- a/csrc/libtorch_stable/cutlass_extensions/epilogue/scaled_mm_epilogues_c3x.hpp
+++ b/csrc/libtorch_stable/cutlass_extensions/epilogue/scaled_mm_epilogues_c3x.hpp
@@ -2,6 +2,8 @@
 
 #include "cutlass_extensions/epilogue/broadcast_load_epilogue_c3x.hpp"
 #include "cutlass_extensions/epilogue/broadcast_load_epilogue_array_c3x.hpp"
+#include "cutlass/epilogue/thread/activation.h"
+#include "cutlass/epilogue/fusion/sm90_visitor_store_tma_warpspecialized.hpp"
 
 // This header is shared by both _C (unstable ABI) and _C_stable_libtorch
 // (stable ABI) targets. When compiled under the stable ABI target,
@@ -179,6 +181,132 @@ struct ScaledEpilogue
 
     typename EVTCompute0::Arguments evt0_args{b_args, {}, {}};
     return ArgumentType{a_args, evt0_args, {}};
+  }
+};
+
+// Experimental Gemma 4 FC1 epilogue. The weight/output channels are laid out
+// as adjacent [gate, up] pairs. Each pair is replaced by two copies of
+// GELU_tanh(gate) * up so the following quantizer can read one value per pair
+// without materializing and rereading separate gate/up halves.
+template <typename T>
+struct GeluPairDuplicate {
+  CUTLASS_HOST_DEVICE
+  T operator()(T const& value) const { return value; }
+};
+
+template <typename T, int N>
+struct GeluPairDuplicate<cutlass::Array<T, N>> {
+  static_assert(N % 2 == 0, "Gated epilogue fragments must contain pairs");
+
+  CUTLASS_HOST_DEVICE
+  cutlass::Array<T, N> operator()(cutlass::Array<T, N> const& input) const {
+    cutlass::Array<T, N> output;
+    cutlass::epilogue::thread::GELU_taylor<T> gelu;
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < N; i += 2) {
+      T const activated = gelu(input[i]) * input[i + 1];
+      output[i] = activated;
+      output[i + 1] = activated;
+    }
+    return output;
+  }
+};
+
+template <typename ElementAcc, typename ElementD, typename TileShape>
+struct ScaledGeluPairDuplicateEpilogue
+    : private ScaledEpilogueBase<ElementAcc, ElementD, TileShape> {
+ private:
+  using SUPER = ScaledEpilogueBase<ElementAcc, ElementD, TileShape>;
+  using Accum = typename SUPER::Accum;
+  using ScaleA = typename SUPER::template ColOrScalarLoad<float>;
+  using ScaleB = typename SUPER::template RowOrScalarLoad<float>;
+
+  using MultiplyB = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::multiplies, float, float,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+  using ScaledB = cutlass::epilogue::fusion::Sm90EVT<MultiplyB, ScaleB, Accum>;
+
+  using MultiplyA = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::multiplies, float, float,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+  using ScaledAB =
+      cutlass::epilogue::fusion::Sm90EVT<MultiplyA, ScaleA, ScaledB>;
+
+  using PairActivation = cutlass::epilogue::fusion::Sm90Compute<
+      GeluPairDuplicate, ElementD, float,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+ public:
+  using EVTCompute =
+      cutlass::epilogue::fusion::Sm90EVT<PairActivation, ScaledAB>;
+  using ArgumentType = typename EVTCompute::Arguments;
+
+  static ArgumentType prepare_args(TensorType const& a_scales,
+                                   TensorType const& b_scales) {
+    auto a_args = SUPER::template args_from_tensor<ScaleA, float>(a_scales);
+    auto b_args = SUPER::template args_from_tensor<ScaleB, float>(b_scales);
+    typename ScaledB::Arguments scaled_b_args{b_args, {}, {}};
+    typename ScaledAB::Arguments scaled_ab_args{a_args, scaled_b_args, {}};
+    return ArgumentType{scaled_ab_args, {}};
+  }
+};
+
+template <typename T>
+struct MaximumAbsoluteValueReduction
+    : cutlass::maximum_absolute_value_reduction<T, true> {};
+
+template <typename T>
+struct MaximumReduction : cutlass::maximum<T, true> {};
+
+// Additive experiment: preserve the duplicated BF16 output while also
+// reducing its activated values to one FP32 maximum-absolute value per row.
+// The following quantizer can then skip its first full-row read/reduction.
+template <typename ElementAcc, typename ElementD, typename TileShape>
+struct ScaledGeluPairDuplicateAmaxEpilogue
+    : private ScaledEpilogueBase<ElementAcc, ElementD, TileShape> {
+ private:
+  using SUPER = ScaledEpilogueBase<ElementAcc, ElementD, TileShape>;
+  using Accum = typename SUPER::Accum;
+  using ScaleA = typename SUPER::template ColOrScalarLoad<float>;
+  using ScaleB = typename SUPER::template RowOrScalarLoad<float>;
+
+  using MultiplyB = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::multiplies, float, float,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+  using ScaledB = cutlass::epilogue::fusion::Sm90EVT<MultiplyB, ScaleB, Accum>;
+
+  using MultiplyA = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::multiplies, float, float,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+  using ScaledAB =
+      cutlass::epilogue::fusion::Sm90EVT<MultiplyA, ScaleA, ScaledB>;
+
+  using PairActivation = cutlass::epilogue::fusion::Sm90Compute<
+      GeluPairDuplicate, ElementD, float,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+  using Activated =
+      cutlass::epilogue::fusion::Sm90EVT<PairActivation, ScaledAB>;
+
+  using RowAmax = cutlass::epilogue::fusion::Sm90ColReduction<
+      MaximumAbsoluteValueReduction, MaximumReduction,
+      cutlass::atomic_maximum, 0, TileShape, float, float,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+ public:
+  using EVTCompute = cutlass::epilogue::fusion::Sm90EVT<RowAmax, Activated>;
+  using ArgumentType = typename EVTCompute::Arguments;
+
+  static ArgumentType prepare_args(TensorType const& a_scales,
+                                   TensorType const& b_scales,
+                                   TensorType const& row_amax) {
+    auto a_args = SUPER::template args_from_tensor<ScaleA, float>(a_scales);
+    auto b_args = SUPER::template args_from_tensor<ScaleB, float>(b_scales);
+    typename ScaledB::Arguments scaled_b_args{b_args, {}, {}};
+    typename ScaledAB::Arguments scaled_ab_args{a_args, scaled_b_args, {}};
+    typename Activated::Arguments activated_args{scaled_ab_args, {}};
+    typename RowAmax::Arguments row_amax_args{
+        static_cast<float*>(row_amax.data_ptr()), 0.0f, {}};
+    return ArgumentType{activated_args, row_amax_args};
   }
 };
 

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -58,6 +58,18 @@ void cutlass_scaled_mm(torch::stable::Tensor& out,
                        torch::stable::Tensor const& b_scales,
                        std::optional<torch::stable::Tensor> const& bias);
 
+void cutlass_scaled_mm_gemma4_gated(torch::stable::Tensor& out,
+                                    torch::stable::Tensor const& a,
+                                    torch::stable::Tensor const& b,
+                                    torch::stable::Tensor const& a_scales,
+                                    torch::stable::Tensor const& b_scales);
+
+void cutlass_scaled_mm_gemma4_gated_amax(
+    torch::stable::Tensor& out, torch::stable::Tensor& row_amax,
+    torch::stable::Tensor const& a, torch::stable::Tensor const& b,
+    torch::stable::Tensor const& a_scales,
+    torch::stable::Tensor const& b_scales);
+
 void cutlass_moe_mm(torch::stable::Tensor& out_tensors,
                     torch::stable::Tensor const& a_tensors,
                     torch::stable::Tensor const& b_tensors,

--- a/csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_kernels.hpp
+++ b/csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_kernels.hpp
@@ -34,6 +34,17 @@ void cutlass_scaled_mm_sm100_fp8(
     torch::stable::Tensor const& b_scales,
     std::optional<torch::stable::Tensor> const& bias);
 
+void cutlass_scaled_mm_sm100_fp8_gemma4_gated(
+    torch::stable::Tensor& out, torch::stable::Tensor const& a,
+    torch::stable::Tensor const& b, torch::stable::Tensor const& a_scales,
+    torch::stable::Tensor const& b_scales);
+
+void cutlass_scaled_mm_sm100_fp8_gemma4_gated_amax(
+    torch::stable::Tensor& out, torch::stable::Tensor& row_amax,
+    torch::stable::Tensor const& a, torch::stable::Tensor const& b,
+    torch::stable::Tensor const& a_scales,
+    torch::stable::Tensor const& b_scales);
+
 void cutlass_scaled_mm_sm120_fp8(
     torch::stable::Tensor& out, torch::stable::Tensor const& a,
     torch::stable::Tensor const& b, torch::stable::Tensor const& a_scales,

--- a/csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_sm100_fp8.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_sm100_fp8.cu
@@ -30,4 +30,24 @@ void cutlass_scaled_mm_sm100_fp8(
   }
 }
 
+void cutlass_scaled_mm_sm100_fp8_gemma4_gated(
+    torch::stable::Tensor& out, torch::stable::Tensor const& a,
+    torch::stable::Tensor const& b, torch::stable::Tensor const& a_scales,
+    torch::stable::Tensor const& b_scales) {
+  STD_TORCH_CHECK(a_scales.is_contiguous() && b_scales.is_contiguous());
+  return cutlass_scaled_mm_sm100_fp8_gemma4_gated_epilogue(
+      out, a, b, a_scales, b_scales);
+}
+
+void cutlass_scaled_mm_sm100_fp8_gemma4_gated_amax(
+    torch::stable::Tensor& out, torch::stable::Tensor& row_amax,
+    torch::stable::Tensor const& a, torch::stable::Tensor const& b,
+    torch::stable::Tensor const& a_scales,
+    torch::stable::Tensor const& b_scales) {
+  STD_TORCH_CHECK(a_scales.is_contiguous() && b_scales.is_contiguous());
+  STD_TORCH_CHECK(row_amax.is_contiguous());
+  return cutlass_scaled_mm_sm100_fp8_gemma4_gated_amax_epilogue(
+      out, row_amax, a, b, a_scales, b_scales);
+}
+
 }  // namespace vllm

--- a/csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_sm100_fp8_dispatch.cuh
+++ b/csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_sm100_fp8_dispatch.cuh
@@ -115,6 +115,71 @@ struct sm100_fp8_config_default {
 };
 
 template <typename InType, typename OutType, bool EnableBias>
+struct sm100_fp8_config_M2048_gemma4 {
+  // Tuned for the M=2048 Gemma 4 FP8 shapes selected by the serving
+  // scheduler. The two-SM schedule expands the CTA tile to 256x256x128.
+  static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+  using KernelSchedule = cutlass::gemm::KernelTmaWarpSpecialized2SmSm100;
+  using EpilogueSchedule = cutlass::epilogue::TmaWarpSpecialized2Sm;
+  using TileShape = Shape<_256, _256, _128>;
+  using ClusterShape = Shape<_2, _1, _1>;
+  using Cutlass3xGemm =
+      conditional_t<EnableBias,
+                    cutlass_3x_gemm_sm100_fp8<
+                        InType, OutType, c3x::ScaledEpilogueBias, TileShape,
+                        ClusterShape, KernelSchedule, EpilogueSchedule>,
+                    cutlass_3x_gemm_sm100_fp8<
+                        InType, OutType, c3x::ScaledEpilogue, TileShape,
+                        ClusterShape, KernelSchedule, EpilogueSchedule>>;
+};
+
+template <typename InType, typename OutType>
+struct sm100_fp8_config_M2048_gemma4_gated {
+  static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+  using KernelSchedule = cutlass::gemm::KernelTmaWarpSpecialized2SmSm100;
+  using EpilogueSchedule = cutlass::epilogue::TmaWarpSpecialized2Sm;
+  using TileShape = Shape<_256, _256, _128>;
+  using ClusterShape = Shape<_2, _1, _1>;
+  using Cutlass3xGemm = cutlass_3x_gemm_sm100_fp8<
+      InType, OutType, c3x::ScaledGeluPairDuplicateEpilogue, TileShape,
+      ClusterShape, KernelSchedule, EpilogueSchedule>;
+};
+
+template <typename InType, typename OutType>
+struct sm100_fp8_config_default_gemma4_gated {
+  static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+  using KernelSchedule = cutlass::gemm::collective::KernelScheduleAuto;
+  using EpilogueSchedule = cutlass::epilogue::collective::EpilogueScheduleAuto;
+  using TileShape = Shape<_256, _128, _128>;
+  using ClusterShape = Shape<_2, _2, _1>;
+  using Cutlass3xGemm = cutlass_3x_gemm_sm100_fp8<
+      InType, OutType, c3x::ScaledGeluPairDuplicateEpilogue, TileShape,
+      ClusterShape, KernelSchedule, EpilogueSchedule>;
+};
+
+template <typename InType, typename OutType>
+struct sm100_fp8_config_M256_gemma4_gated {
+  static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+  using KernelSchedule = cutlass::gemm::collective::KernelScheduleAuto;
+  using EpilogueSchedule = cutlass::epilogue::collective::EpilogueScheduleAuto;
+  using TileShape = Shape<_128, _128, _128>;
+  using ClusterShape = Shape<_2, _1, _1>;
+  using Cutlass3xGemm = cutlass_3x_gemm_sm100_fp8<
+      InType, OutType, c3x::ScaledGeluPairDuplicateEpilogue, TileShape,
+      ClusterShape, KernelSchedule, EpilogueSchedule>;
+};
+
+template <typename InType, typename OutType, typename TileShape,
+          typename ClusterShape, typename KernelSchedule,
+          typename EpilogueSchedule>
+struct sm100_fp8_config_gemma4_gated_amax {
+  static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+  using Cutlass3xGemm = cutlass_3x_gemm_sm100_fp8<
+      InType, OutType, c3x::ScaledGeluPairDuplicateAmaxEpilogue, TileShape,
+      ClusterShape, KernelSchedule, EpilogueSchedule>;
+};
+
+template <typename InType, typename OutType, bool EnableBias>
 struct sm100_fp8_config_M256 {
   // M in (64, 256]
   static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
@@ -265,9 +330,25 @@ inline void cutlass_gemm_sm100_fp8_dispatch(
   using Cutlass3xGemmM256 =
       typename sm100_fp8_config_M256<InType, OutType,
                                      EnableBias>::Cutlass3xGemm;
-
   uint32_t const m = a.size(0);
+  uint32_t const n = b.size(1);
   uint32_t const k = a.size(1);
+
+  if constexpr (!EnableBias &&
+                std::is_same_v<OutType, cutlass::bfloat16_t>) {
+    using Cutlass3xGemmM2048Gemma4 =
+        typename sm100_fp8_config_M2048_gemma4<InType, OutType,
+                                               EnableBias>::Cutlass3xGemm;
+    bool const is_gemma4_target_shape =
+        (k == 5376 &&
+         (n == 43008 || n == 16384 || n == 20480)) ||
+        (k == 21504 && n == 5376);
+    if (m == 2048 && is_gemma4_target_shape) {
+      return cutlass_gemm_caller_sm100_fp8<Cutlass3xGemmM2048Gemma4>(
+          out, a, b, a_scales, b_scales,
+          std::forward<EpilogueArgs>(args)...);
+    }
+  }
 
   if (m <= 16) {
     // m in [1, 16]
@@ -292,6 +373,86 @@ inline void cutlass_gemm_sm100_fp8_dispatch(
     return cutlass_gemm_caller_sm100_fp8<Cutlass3xGemmDefault>(
         out, a, b, a_scales, b_scales, std::forward<EpilogueArgs>(args)...);
   }
+}
+
+template <typename InType, typename OutType, typename... EpilogueArgs>
+inline void cutlass_gemm_sm100_fp8_gemma4_gated_dispatch(
+    torch::stable::Tensor& out, torch::stable::Tensor const& a,
+    torch::stable::Tensor const& b, torch::stable::Tensor const& a_scales,
+    torch::stable::Tensor const& b_scales, EpilogueArgs&&... args) {
+  static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+  static_assert(std::is_same<OutType, cutlass::bfloat16_t>());
+  STD_TORCH_CHECK(a.scalar_type() ==
+                  torch::headeronly::ScalarType::Float8_e4m3fn);
+  STD_TORCH_CHECK(b.scalar_type() ==
+                  torch::headeronly::ScalarType::Float8_e4m3fn);
+
+  using Cutlass3xGemmM256 =
+      typename sm100_fp8_config_M256_gemma4_gated<InType,
+                                                  OutType>::Cutlass3xGemm;
+  using Cutlass3xGemmM2048 =
+      typename sm100_fp8_config_M2048_gemma4_gated<InType,
+                                                   OutType>::Cutlass3xGemm;
+  using Cutlass3xGemmDefault =
+      typename sm100_fp8_config_default_gemma4_gated<InType,
+                                                     OutType>::Cutlass3xGemm;
+
+  uint32_t const m = a.size(0);
+  if (m <= 256) {
+    return cutlass_gemm_caller_sm100_fp8<Cutlass3xGemmM256>(
+        out, a, b, a_scales, b_scales,
+        std::forward<EpilogueArgs>(args)...);
+  }
+  if (m == 2048) {
+    return cutlass_gemm_caller_sm100_fp8<Cutlass3xGemmM2048>(
+        out, a, b, a_scales, b_scales,
+        std::forward<EpilogueArgs>(args)...);
+  }
+  return cutlass_gemm_caller_sm100_fp8<Cutlass3xGemmDefault>(
+      out, a, b, a_scales, b_scales,
+      std::forward<EpilogueArgs>(args)...);
+}
+
+template <typename InType, typename OutType>
+inline void cutlass_gemm_sm100_fp8_gemma4_gated_amax_dispatch(
+    torch::stable::Tensor& out, torch::stable::Tensor& row_amax,
+    torch::stable::Tensor const& a, torch::stable::Tensor const& b,
+    torch::stable::Tensor const& a_scales,
+    torch::stable::Tensor const& b_scales) {
+  static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+  static_assert(std::is_same<OutType, cutlass::bfloat16_t>());
+  STD_TORCH_CHECK(a.scalar_type() ==
+                  torch::headeronly::ScalarType::Float8_e4m3fn);
+  STD_TORCH_CHECK(b.scalar_type() ==
+                  torch::headeronly::ScalarType::Float8_e4m3fn);
+
+  using AutoKernelSchedule = cutlass::gemm::collective::KernelScheduleAuto;
+  using AutoEpilogueSchedule =
+      cutlass::epilogue::collective::EpilogueScheduleAuto;
+  using M2048KernelSchedule =
+      cutlass::gemm::KernelTmaWarpSpecialized2SmSm100;
+  using M2048EpilogueSchedule = cutlass::epilogue::TmaWarpSpecialized2Sm;
+  using M256Config = sm100_fp8_config_gemma4_gated_amax<
+      InType, OutType, Shape<_128, _128, _128>, Shape<_2, _1, _1>,
+      AutoKernelSchedule, AutoEpilogueSchedule>;
+  using M2048Config = sm100_fp8_config_gemma4_gated_amax<
+      InType, OutType, Shape<_256, _256, _128>, Shape<_2, _1, _1>,
+      M2048KernelSchedule, M2048EpilogueSchedule>;
+  using DefaultConfig = sm100_fp8_config_gemma4_gated_amax<
+      InType, OutType, Shape<_256, _128, _128>, Shape<_2, _2, _1>,
+      AutoKernelSchedule, AutoEpilogueSchedule>;
+
+  uint32_t const m = a.size(0);
+  if (m <= 256) {
+    return cutlass_gemm_caller_sm100_fp8<typename M256Config::Cutlass3xGemm>(
+        out, a, b, a_scales, b_scales, row_amax);
+  }
+  if (m == 2048) {
+    return cutlass_gemm_caller_sm100_fp8<typename M2048Config::Cutlass3xGemm>(
+        out, a, b, a_scales, b_scales, row_amax);
+  }
+  return cutlass_gemm_caller_sm100_fp8<typename DefaultConfig::Cutlass3xGemm>(
+      out, a, b, a_scales, b_scales, row_amax);
 }
 
 template <typename InType, typename OutType, bool EnableBias,
@@ -346,6 +507,29 @@ void cutlass_scaled_mm_sm100_fp8_epilogue(torch::stable::Tensor& out,
         out, a, b, a_scales, b_scales,
         std::forward<EpilogueArgs>(epilogue_args)...);
   }
+}
+
+inline void cutlass_scaled_mm_sm100_fp8_gemma4_gated_epilogue(
+    torch::stable::Tensor& out, torch::stable::Tensor const& a,
+    torch::stable::Tensor const& b, torch::stable::Tensor const& a_scales,
+    torch::stable::Tensor const& b_scales) {
+  STD_TORCH_CHECK(out.scalar_type() ==
+                  torch::headeronly::ScalarType::BFloat16);
+  return cutlass_gemm_sm100_fp8_gemma4_gated_dispatch<
+      cutlass::float_e4m3_t, cutlass::bfloat16_t>(out, a, b, a_scales,
+                                                  b_scales);
+}
+
+inline void cutlass_scaled_mm_sm100_fp8_gemma4_gated_amax_epilogue(
+    torch::stable::Tensor& out, torch::stable::Tensor& row_amax,
+    torch::stable::Tensor const& a, torch::stable::Tensor const& b,
+    torch::stable::Tensor const& a_scales,
+    torch::stable::Tensor const& b_scales) {
+  STD_TORCH_CHECK(out.scalar_type() ==
+                  torch::headeronly::ScalarType::BFloat16);
+  return cutlass_gemm_sm100_fp8_gemma4_gated_amax_dispatch<
+      cutlass::float_e4m3_t, cutlass::bfloat16_t>(
+      out, row_amax, a, b, a_scales, b_scales);
 }
 
 template <bool EnableBias, typename... EpilogueArgs>

--- a/csrc/libtorch_stable/quantization/w8a8/cutlass/scaled_mm_c3x_sm100.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/cutlass/scaled_mm_c3x_sm100.cu
@@ -20,4 +20,21 @@ void cutlass_scaled_mm_sm100(torch::stable::Tensor& c,
                      vllm::cutlass_scaled_mm_blockwise_sm100_fp8);
 }
 
+void cutlass_scaled_mm_sm100_gemma4_gated(
+    torch::stable::Tensor& c, torch::stable::Tensor const& a,
+    torch::stable::Tensor const& b, torch::stable::Tensor const& a_scales,
+    torch::stable::Tensor const& b_scales) {
+  vllm::cutlass_scaled_mm_sm100_fp8_gemma4_gated(c, a, b, a_scales,
+                                                 b_scales);
+}
+
+void cutlass_scaled_mm_sm100_gemma4_gated_amax(
+    torch::stable::Tensor& c, torch::stable::Tensor& row_amax,
+    torch::stable::Tensor const& a, torch::stable::Tensor const& b,
+    torch::stable::Tensor const& a_scales,
+    torch::stable::Tensor const& b_scales) {
+  vllm::cutlass_scaled_mm_sm100_fp8_gemma4_gated_amax(
+      c, row_amax, a, b, a_scales, b_scales);
+}
+
 #endif

--- a/csrc/libtorch_stable/quantization/w8a8/cutlass/scaled_mm_entry.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/cutlass/scaled_mm_entry.cu
@@ -81,6 +81,17 @@ void cutlass_scaled_mm_sm100(torch::stable::Tensor& c,
                              torch::stable::Tensor const& a_scales,
                              torch::stable::Tensor const& b_scales,
                              std::optional<torch::stable::Tensor> const& bias);
+
+void cutlass_scaled_mm_sm100_gemma4_gated(
+    torch::stable::Tensor& c, torch::stable::Tensor const& a,
+    torch::stable::Tensor const& b, torch::stable::Tensor const& a_scales,
+    torch::stable::Tensor const& b_scales);
+
+void cutlass_scaled_mm_sm100_gemma4_gated_amax(
+    torch::stable::Tensor& c, torch::stable::Tensor& row_amax,
+    torch::stable::Tensor const& a, torch::stable::Tensor const& b,
+    torch::stable::Tensor const& a_scales,
+    torch::stable::Tensor const& b_scales);
 #endif
 
 #if (defined(ENABLE_CUTLASS_MOE_SM90) && ENABLE_CUTLASS_MOE_SM90) ||   \
@@ -266,6 +277,80 @@ void cutlass_scaled_mm(torch::stable::Tensor& c, torch::stable::Tensor const& a,
       false,
       "No compiled cutlass_scaled_mm for a compute capability less than "
       "CUDA device capability: ",
+      version_num);
+}
+
+static void check_gemma4_gated_scaled_mm_args(
+    torch::stable::Tensor const& c, torch::stable::Tensor const& a,
+    torch::stable::Tensor const& b, torch::stable::Tensor const& a_scales,
+    torch::stable::Tensor const& b_scales) {
+  STD_TORCH_CHECK(a.dim() == 2 && b.dim() == 2 && c.dim() == 2);
+  STD_TORCH_CHECK(c.size(0) == a.size(0) && a.size(1) == b.size(0) &&
+                  b.size(1) == c.size(1));
+  STD_TORCH_CHECK(b.size(1) % 2 == 0,
+                  "Gemma4 gated epilogue expects interleaved gate/up pairs");
+  STD_TORCH_CHECK(a.stride(1) == 1 && c.stride(1) == 1);
+  STD_TORCH_CHECK(b.stride(0) == 1);
+  STD_TORCH_CHECK(c.stride(0) % 16 == 0 && b.stride(1) % 16 == 0);
+  STD_TORCH_CHECK(a_scales.scalar_type() ==
+                  torch::headeronly::ScalarType::Float);
+  STD_TORCH_CHECK(b_scales.scalar_type() ==
+                  torch::headeronly::ScalarType::Float);
+  STD_TORCH_CHECK((a_scales.numel() == 1 || a_scales.numel() == a.size(0)) &&
+                  (b_scales.numel() == 1 || b_scales.numel() == b.size(1)));
+  STD_TORCH_CHECK(a_scales.is_contiguous() && b_scales.is_contiguous());
+}
+
+void cutlass_scaled_mm_gemma4_gated(torch::stable::Tensor& c,
+                                    torch::stable::Tensor const& a,
+                                    torch::stable::Tensor const& b,
+                                    torch::stable::Tensor const& a_scales,
+                                    torch::stable::Tensor const& b_scales) {
+  check_gemma4_gated_scaled_mm_args(c, a, b, a_scales, b_scales);
+
+  const torch::stable::accelerator::DeviceGuard device_guard(
+      a.get_device_index());
+  int32_t version_num = get_sm_version_num();
+
+#if defined ENABLE_SCALED_MM_SM100 && ENABLE_SCALED_MM_SM100
+  if (version_num >= 100 && version_num < 120) {
+    cutlass_scaled_mm_sm100_gemma4_gated(c, a, b, a_scales, b_scales);
+    return;
+  }
+#endif
+
+  STD_TORCH_CHECK_NOT_IMPLEMENTED(
+      false, "Gemma4 gated FP8 epilogue is only supported on SM100. "
+             "CUDA device capability: ",
+      version_num);
+}
+
+void cutlass_scaled_mm_gemma4_gated_amax(
+    torch::stable::Tensor& c, torch::stable::Tensor& row_amax,
+    torch::stable::Tensor const& a, torch::stable::Tensor const& b,
+    torch::stable::Tensor const& a_scales,
+    torch::stable::Tensor const& b_scales) {
+  check_gemma4_gated_scaled_mm_args(c, a, b, a_scales, b_scales);
+  STD_TORCH_CHECK(row_amax.dim() == 1 && row_amax.numel() == a.size(0));
+  STD_TORCH_CHECK(row_amax.scalar_type() ==
+                  torch::headeronly::ScalarType::Float);
+  STD_TORCH_CHECK(row_amax.is_contiguous());
+
+  const torch::stable::accelerator::DeviceGuard device_guard(
+      a.get_device_index());
+  int32_t version_num = get_sm_version_num();
+
+#if defined ENABLE_SCALED_MM_SM100 && ENABLE_SCALED_MM_SM100
+  if (version_num >= 100 && version_num < 120) {
+    cutlass_scaled_mm_sm100_gemma4_gated_amax(c, row_amax, a, b, a_scales,
+                                              b_scales);
+    return;
+  }
+#endif
+
+  STD_TORCH_CHECK_NOT_IMPLEMENTED(
+      false, "Gemma4 gated FP8 amax epilogue is only supported on SM100. "
+             "CUDA device capability: ",
       version_num);
 }
 

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -117,6 +117,15 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "cutlass_scaled_mm(Tensor! out, Tensor a,"
       "                  Tensor b, Tensor a_scales,"
       "                  Tensor b_scales, Tensor? bias) -> ()");
+  ops.def(
+      "cutlass_scaled_mm_gemma4_gated(Tensor! out, Tensor a,"
+      "                               Tensor b, Tensor a_scales,"
+      "                               Tensor b_scales) -> ()");
+  ops.def(
+      "cutlass_scaled_mm_gemma4_gated_amax(Tensor! out, Tensor! row_amax,"
+      "                                    Tensor a, Tensor b,"
+      "                                    Tensor a_scales,"
+      "                                    Tensor b_scales) -> ()");
 
   // CUTLASS w8a8 GEMM, supporting asymmetric per-tensor or per-row/column
   // quantization.
@@ -629,6 +638,10 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
 #ifndef USE_ROCM
   // CUTLASS scaled_mm ops
   ops.impl("cutlass_scaled_mm", TORCH_BOX(&cutlass_scaled_mm));
+  ops.impl("cutlass_scaled_mm_gemma4_gated",
+           TORCH_BOX(&cutlass_scaled_mm_gemma4_gated));
+  ops.impl("cutlass_scaled_mm_gemma4_gated_amax",
+           TORCH_BOX(&cutlass_scaled_mm_gemma4_gated_amax));
   ops.impl("cutlass_scaled_mm_azp", TORCH_BOX(&cutlass_scaled_mm_azp));
   ops.impl("cutlass_moe_mm", TORCH_BOX(&cutlass_moe_mm));
   ops.impl("get_cutlass_moe_mm_data", TORCH_BOX(&get_cutlass_moe_mm_data));

--- a/docs/gemma4_b200_fp8_optimized_stack.md
+++ b/docs/gemma4_b200_fp8_optimized_stack.md
@@ -1,0 +1,242 @@
+# Gemma4 B200 FP8 Optimized vLLM Path
+
+This branch adds a Gemma4-specific optimized FP8 path for B200/SM100 in vLLM.
+
+The easiest deployment artifact is a prebuilt vLLM runtime image containing this
+branch's rebuilt native extension and Python routing files.
+
+```text
+vllm-gemma4-b200-fp8-opt:<commit_sha>
+```
+
+A tested image was built from `vllm/vllm-openai:latest` with only the optimized
+native vLLM extension and routing files patched into the installed runtime
+package. It keeps the runtime image's existing FlashAttention/FlashInfer stack.
+
+## What This Enables
+
+- Gemma4 gated-MLP fast path for FP8 weights.
+- CUTLASS SM100 tactic dispatches tuned for Gemma4 shapes.
+- Fused gated-MLP GELU duplicate epilogue.
+- Fused row-amax path for the activated gated output before the down projection.
+- Python routing from `Gemma4MLP` into the new custom ops when the model and quantization layout match.
+
+The changes are native CUDA/CUTLASS changes, not Python-only changes. A source
+build or this prebuilt image is required.
+
+## Fast Path: Use A Prebuilt Image
+
+Use this when you want the optimized runtime without rebuilding vLLM.
+
+```bash
+docker run --gpus all --ipc=host --network=host \
+  -e HF_HOME=/models \
+  -v /path/to/model/cache:/models \
+  vllm-gemma4-b200-fp8-opt:<commit_sha> \
+  bash
+```
+
+Inside the container:
+
+```bash
+export HF_HOME=/models
+export HF_HUB_CACHE=${HF_HOME}/hub
+export OMP_NUM_THREADS=8
+unset PYTHONPATH
+
+python3 - <<'PY'
+import torch
+import vllm._C_stable_libtorch  # noqa: F401
+
+for name in [
+    "cutlass_scaled_mm_gemma4_gated",
+    "cutlass_scaled_mm_gemma4_gated_amax",
+]:
+    print(name, hasattr(torch.ops._C, name))
+    assert hasattr(torch.ops._C, name), name
+
+print("registration_ok")
+PY
+
+vllm serve RedHatAI/gemma-4-31B-it-FP8-Dynamic \
+  --served-model-name gemma-4 \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --tensor-parallel-size 1 \
+  --max-model-len 32768 \
+  --max-num-batched-tokens 2048 \
+  --max-num-seqs 128 \
+  --gpu-memory-utilization 0.9292 \
+  --kv-cache-dtype fp8 \
+  --enable-prefix-caching \
+  --enable-chunked-prefill \
+  --attention-backend FLASHINFER \
+  --attention-config '{"use_trtllm_attention": true}' \
+  --hf-overrides '{"text_config":{"use_bidirectional_attention":null}}' \
+  --speculative-config '{"model":"google/gemma-4-31B-it-assistant","num_speculative_tokens":3,"draft_tensor_parallel_size":1}' \
+  --generation-config vllm
+```
+
+## What Runtime-Only Means
+
+The standard `vllm/vllm-openai:latest` image is mainly a runtime image. It is
+built for running an already-compiled vLLM installation with `vllm serve`.
+
+This branch changes native CUDA/CUTLASS code under `csrc/`. Those changes only
+become active after the native vLLM extensions are rebuilt. If you run the normal
+vLLM image without rebuilding or without using the custom image above, you will
+still be running the old precompiled kernels.
+
+So the clean user-facing path is:
+
+1. Build this branch once in a build-capable environment.
+2. Package the built vLLM into an image.
+3. Users run that image exactly like normal vLLM.
+
+## Step-by-Step: Build From This Branch
+
+Use this path if you want to build the optimized vLLM yourself instead of using a prebuilt image.
+
+1. Clone vLLM and check out the optimized branch:
+
+```bash
+git clone <vllm_repo_url> vllm
+cd vllm
+git checkout gemma4-b200-fp8-optimized-stack
+```
+
+2. Start a build-capable CUDA/PyTorch container.
+
+Use an image that contains a compiler, CUDA toolkit, Python headers, CMake/Ninja support, and a PyTorch/CUDA stack compatible with the target runtime. For example, on Slurm/Pyxis:
+
+```bash
+srun \
+  --partition=<partition> \
+  --account=<account> \
+  --gres=gpu:1 \
+  --cpus-per-task=56 \
+  --mem=0 \
+  --container-image=nvcr.io#nvidia/pytorch:26.06-py3 \
+  --container-mounts=$PWD:/workspace/vllm \
+  --container-workdir=/workspace/vllm \
+  --pty bash
+```
+
+3. Build/install vLLM from the branch:
+
+```bash
+python3 -m pip install --upgrade pip
+python3 -m pip install -e . --no-build-isolation
+```
+
+If your environment requires the stable libtorch extension to be built explicitly,
+use:
+
+```bash
+python3 tools/generate_cmake_presets.py --force-overwrite
+cmake --preset release
+cmake --build --preset release --target _C_stable_libtorch.abi3.so
+cmake --install cmake-build-release --prefix "$PWD" --component _C_stable_libtorch
+```
+
+4. Verify that the optimized custom ops are registered:
+
+```bash
+python3 - <<'PY'
+import torch
+import vllm._C_stable_libtorch  # noqa: F401
+
+for name in [
+    "cutlass_scaled_mm_gemma4_gated",
+    "cutlass_scaled_mm_gemma4_gated_amax",
+]:
+    print(name, hasattr(torch.ops._C, name))
+    assert hasattr(torch.ops._C, name), name
+
+print("registration_ok")
+PY
+```
+
+Expected output:
+
+```text
+cutlass_scaled_mm_gemma4_gated True
+cutlass_scaled_mm_gemma4_gated_amax True
+registration_ok
+```
+
+5. Run vLLM with the optimized Gemma4 FP8 path:
+
+```bash
+vllm serve RedHatAI/gemma-4-31B-it-FP8-Dynamic \
+  --served-model-name gemma-4 \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --tensor-parallel-size 1 \
+  --max-model-len 32768 \
+  --max-num-batched-tokens 2048 \
+  --max-num-seqs 128 \
+  --gpu-memory-utilization 0.9292 \
+  --kv-cache-dtype fp8 \
+  --enable-prefix-caching \
+  --enable-chunked-prefill \
+  --attention-backend FLASHINFER \
+  --attention-config '{"use_trtllm_attention": true}' \
+  --hf-overrides '{"text_config":{"use_bidirectional_attention":null}}' \
+  --speculative-config '{"model":"google/gemma-4-31B-it-assistant","num_speculative_tokens":3,"draft_tensor_parallel_size":1}' \
+  --generation-config vllm
+```
+
+## Step-by-Step: Package As A User-Friendly Image
+
+This is the best path for other users.
+
+1. Build vLLM from this branch in a build-capable image.
+2. Verify the optimized ops are registered.
+3. Bake the resulting installed vLLM package and native `.so` files into a runtime image.
+4. Tag the image with the source commit SHA:
+
+```bash
+vllm-gemma4-b200-fp8-opt:<commit_sha>
+```
+
+5. Users then run the image like normal vLLM:
+
+```bash
+vllm serve RedHatAI/gemma-4-31B-it-FP8-Dynamic ...
+```
+
+## Required Runtime Flags
+
+- Hardware: B200 / SM100.
+- Model weights: `RedHatAI/gemma-4-31B-it-FP8-Dynamic`.
+- KV cache: FP8, via `--kv-cache-dtype fp8`.
+- Attention backend: FlashInfer, via `--attention-backend FLASHINFER`.
+- Gemma4 HF override:
+
+```bash
+--hf-overrides '{"text_config":{"use_bidirectional_attention":null}}'
+```
+
+For speculative decoding, use the Gemma assistant draft model:
+
+```bash
+--speculative-config '{"model":"google/gemma-4-31B-it-assistant","num_speculative_tokens":3,"draft_tensor_parallel_size":1}'
+```
+
+## Verification Performed
+
+- Native op registration passed inside the exported image:
+  - `cutlass_scaled_mm_gemma4_gated True`
+  - `cutlass_scaled_mm_gemma4_gated_amax True`
+- Direct-image smoke validation passed with `100/100` requests completed.
+- Server used:
+  - RedHatAI FP8 weights: `RedHatAI/gemma-4-31B-it-FP8-Dynamic`
+  - FlashInfer attention backend
+  - TRT-LLM attention config
+  - FP8 KV cache
+  - Gemma assistant MTP speculative decoding with 3 draft tokens
+- Nsight profiling was collected for the optimized path during development.
+
+Packaging note: the branch is the source of truth; the easiest user-facing
+artifact is a prebuilt image tagged with the source commit SHA.

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -804,6 +804,45 @@ def cutlass_scaled_mm(
     return out.view(*target_shape)
 
 
+def cutlass_scaled_mm_gemma4_gated(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    assert out_dtype is torch.bfloat16
+    assert a.ndim >= 2 and b.ndim == 2
+    assert b.shape[1] % 2 == 0
+
+    target_shape = (*a.shape[:-1], b.shape[1])
+    a = a.view(-1, a.shape[-1])
+    out = torch.empty((a.shape[0], b.shape[1]), dtype=out_dtype, device=a.device)
+    torch.ops._C.cutlass_scaled_mm_gemma4_gated(out, a, b, scale_a, scale_b)
+    return out.view(*target_shape)
+
+
+def cutlass_scaled_mm_gemma4_gated_amax(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    out_dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert out_dtype is torch.bfloat16
+    assert a.ndim >= 2 and b.ndim == 2
+    assert b.shape[1] % 2 == 0
+
+    target_shape = (*a.shape[:-1], b.shape[1])
+    row_amax_shape = a.shape[:-1]
+    a = a.view(-1, a.shape[-1])
+    out = torch.empty((a.shape[0], b.shape[1]), dtype=out_dtype, device=a.device)
+    row_amax = torch.empty((a.shape[0],), dtype=torch.float32, device=a.device)
+    torch.ops._C.cutlass_scaled_mm_gemma4_gated_amax(
+        out, row_amax, a, b, scale_a, scale_b)
+    return out.view(*target_shape), row_amax.view(*row_amax_shape)
+
+
 def cutlass_scaled_mm_azp(
     a: torch.Tensor,
     b: torch.Tensor,

--- a/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
@@ -12,6 +12,7 @@ from vllm.model_executor.layers.quantization.utils import replace_parameter
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
     QuantKey,
+    kFp8DynamicTokenSym,
     kFp8StaticTensorSym,
 )
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
@@ -173,10 +174,12 @@ class CutlassFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
         return True, None
 
     def input_quant_key(self) -> QuantKey | None:
-        """Only static per-tensor activation quantization is supported for external
-        quantization."""
-        if self.config.activation_quant_key == kFp8StaticTensorSym:
-            return kFp8StaticTensorSym
+        """Activation quantization formats this kernel can consume directly."""
+        if self.config.activation_quant_key in (
+            kFp8StaticTensorSym,
+            kFp8DynamicTokenSym,
+        ):
+            return self.config.activation_quant_key
         return None
 
     @staticmethod
@@ -239,6 +242,57 @@ class CutlassFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
                     "weight_loader": self.padded_weight_loader,
                 },
             )
+
+    def apply_gemma4_gated_amax(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+    ):
+        from vllm.model_executor.layers.fusion.quant_activation import (
+            QuantizedActivation,
+        )
+        from vllm.model_executor.layers.quantization.utils.quant_utils import (
+            get_fp8_min_max,
+        )
+
+        assert self.config.activation_quant_key == kFp8DynamicTokenSym
+        assert x.dtype == torch.bfloat16
+        w, w_s, x_s, x_s_ub = self._get_layer_params(layer)
+        orig_shape = x.shape
+        x_2d = x.view(-1, x.shape[-1])
+        x_2d_q, x_s = self.quant_fp8(x_2d, x_s, x_s_ub)
+
+        output_size = self.logical_output_size
+        assert output_size is not None
+        padded_k, padded_n = w.shape
+        pad_k = padded_k - x_2d_q.shape[1]
+        pad_n = padded_n - output_size
+        if pad_k > 0:
+            x_2d_q = self._pad_to_alignment(x_2d_q, dim=1, alignment=16)
+
+        gate_up, row_amax = ops.cutlass_scaled_mm_gemma4_gated_amax(
+            x_2d_q, w, scale_a=x_s, scale_b=w_s, out_dtype=torch.bfloat16
+        )
+        if pad_n > 0:
+            gate_up = gate_up[:, :output_size].contiguous()
+
+        # The epilogue writes duplicate [activated, activated] pairs to retain
+        # a regular CUTLASS store layout. The down projection consumes one lane.
+        activated = gate_up[:, 0::2].contiguous()
+        _, fp8_max = get_fp8_min_max()
+        scale = (row_amax / fp8_max).clamp_min(torch.finfo(torch.float32).tiny)
+        scale = scale.view(-1, 1).contiguous()
+        activated_q, scale = ops.scaled_fp8_quant(
+            activated, scale=scale, group_shape=(1, -1)
+        )
+        compact_shape = torch.Size([*orig_shape[:-1], activated.shape[-1]])
+        return QuantizedActivation(
+            data=activated_q,
+            scale=scale,
+            orig_dtype=x.dtype,
+            orig_shape=compact_shape,
+            quant_key=kFp8DynamicTokenSym,
+        )
 
     def apply_scaled_mm(
         self,

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -43,6 +43,9 @@ from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8DynamicTokenSym,
+)
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
     MergedColumnParallelLinear,
@@ -242,8 +245,18 @@ class Gemma4MLP(nn.Module):
         self.act_fn = get_act_and_mul_fn(hidden_activation)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        gate_up, _ = self.gate_up_proj(x)
-        x = self.act_fn(gate_up)
+        fused_gated = getattr(
+            self.gate_up_proj.quant_method, "apply_gemma4_gated_amax", None
+        )
+        if (
+            fused_gated is not None
+            and getattr(self.down_proj, "input_quant_key", None)
+            == kFp8DynamicTokenSym
+        ):
+            x = fused_gated(self.gate_up_proj, x)
+        else:
+            gate_up, _ = self.gate_up_proj(x)
+            x = self.act_fn(gate_up)
         x, _ = self.down_proj(x)
         return x
 


### PR DESCRIPTION
## Summary

Adds a Gemma4-specific optimized FP8 path for B200/SM100.

This includes:
- gated-MLP FP8 CUTLASS epilogue with GELU pair activation
- row-amax fused path for the activated gated output
- SM100 CUTLASS dispatch tuning for Gemma4 FP8 shapes
- Python routing from Gemma4MLP into the optimized custom ops

## Validation

- Native op registration passed:
  - `cutlass_scaled_mm_gemma4_gated`
  - `cutlass_scaled_mm_gemma4_gated_amax`
- Direct vLLM server smoke test completed 100/100 requests.
- Runtime used:
  - `RedHatAI/gemma-4-31B-it-FP8-Dynamic`
  - B200 / SM100
  - FlashInfer attention backend
  - FP8 KV cache
  - Gemma assistant speculative decoding

## Notes

This is currently a model/shape-specific optimization path and should be treated as a draft for review and broader validation.