### PR TITLE
[Rust Frontend] Fix bad_words handling in /v1/completions

### DIFF
--- a/rust/src/server/src/routes/openai/completions/convert.rs
+++ b/rust/src/server/src/routes/openai/completions/convert.rs
@@ -127,7 +127,7 @@ pub(super) fn prepare_completion_request(
             ignore_eos: request.ignore_eos,
             logit_bias: convert_logit_bias(request.logit_bias)?,
             allowed_token_ids: request.allowed_token_ids,
-            bad_words: None,
+            bad_words: request.bad_words,
             logprob_token_ids: None,
             structured_outputs,
             skip_reading_prefix_cache: None,
@@ -294,6 +294,7 @@ mod tests {
             "frequency_penalty": 0.2,
             "presence_penalty": 0.3,
             "repetition_penalty": 1.1,
+            "bad_words": ["hello"],
             "ignore_eos": true,
             "skip_special_tokens": false
         }))
@@ -328,6 +329,10 @@ mod tests {
         assert_eq!(
             prepared.text_request.sampling_params.repetition_penalty,
             Some(1.1)
+        );
+        assert_eq!(
+            prepared.text_request.sampling_params.bad_words,
+            Some(vec!["hello".to_string()])
         );
         assert!(prepared.text_request.sampling_params.ignore_eos);
         assert!(!prepared.text_request.decode_options.skip_special_tokens);

--- a/rust/src/server/src/routes/openai/completions/types.rs
+++ b/rust/src/server/src/routes/openai/completions/types.rs
@@ -138,6 +138,9 @@ pub struct CompletionRequest {
     /// Restrict output to these token IDs only
     pub allowed_token_ids: Option<Vec<u32>>,
 
+    /// List of bad words to avoid during generation
+    pub bad_words: Option<Vec<String>>,
+
     /// Number of prompt logprobs to return
     pub prompt_logprobs: Option<i32>,
 


### PR DESCRIPTION



## Purpose

  The Rust `/v1/completions` request type did not declare `bad_words`. The field was captured by the flattened extra-fields map, while request conversion always set `SamplingParams.bad_words` to `None`.

  As a result, requests containing `bad_words` succeeded, but the requested filtering was silently not applied.

  Declare `bad_words` as a typed completion request field and forward it into `SamplingParams`. This connects `/v1/completions` to the existing bad-word tokenization and filtering pipeline. It also ensures invalid `bad_words` element types return a request error instead of being silently accepted.

## Test Plan

```
  cargo nextest run -p vllm-server prepare_completion_request_maps_sampling_fields
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

