### PR TITLE
[ROCm][Model] Add Inkling BF16 support

### DIFF
--- a/tests/models/inkling/test_fa4_rel_attention.py
+++ b/tests/models/inkling/test_fa4_rel_attention.py
@@ -27,6 +27,7 @@ from vllm.models.inkling.nvidia.ops.fa4_rel_attention import (
     inkling_fa4_num_splits,
     inkling_fa4_rel_attention,
     inkling_torch_rel_attention,
+    inkling_triton_decode_rel_attention,
 )
 from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
@@ -344,6 +345,30 @@ def test_torch_attention_matches_reference(
         window_left=window_left,
         device="cpu",
         attention_fn=inkling_torch_rel_attention,
+    )
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="requires ROCm")
+@pytest.mark.parametrize("num_heads,num_kv_heads", NUM_HEADS)
+@pytest.mark.parametrize(
+    ("seq_lens", "rel_extent", "window_left"),
+    [
+        ([(1, 50), (1, 7), (1, 200)], 128, None),
+        ([(1, 512), (1, 333)], 1024, None),
+        ([(1, 512), (1, 333)], 128, 127),
+    ],
+)
+@torch.inference_mode()
+def test_triton_decode_attention_matches_reference(
+    seq_lens, rel_extent, window_left, num_heads, num_kv_heads
+):
+    _run_case(
+        seq_lens,
+        num_heads,
+        num_kv_heads,
+        rel_extent=rel_extent,
+        window_left=window_left,
+        attention_fn=inkling_triton_decode_rel_attention,
     )
 
 

--- a/tests/models/inkling/test_fa4_rel_attention.py
+++ b/tests/models/inkling/test_fa4_rel_attention.py
@@ -26,6 +26,7 @@ from vllm.models.inkling.nvidia.ops.fa4_rel_attention import (
     _use_sheared_bias,
     inkling_fa4_num_splits,
     inkling_fa4_rel_attention,
+    inkling_torch_rel_attention,
 )
 from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
@@ -226,9 +227,18 @@ def _ref_rel_attn(
     return out
 
 
-def _run_case(seq_lens, num_heads, num_kv_heads, rel_extent, window_left, seed=0):
+def _run_case(
+    seq_lens,
+    num_heads,
+    num_kv_heads,
+    rel_extent,
+    window_left,
+    seed=0,
+    *,
+    device="cuda",
+    attention_fn=inkling_fa4_rel_attention,
+):
     torch.manual_seed(seed)
-    device = "cuda"
     q_lens = [s[0] for s in seq_lens]
     kv_lens = [s[1] for s in seq_lens]
     total_q = sum(q_lens)
@@ -279,7 +289,7 @@ def _run_case(seq_lens, num_heads, num_kv_heads, rel_extent, window_left, seed=0
         num_kv_heads=num_kv_heads,
         max_kv_len=max(kv_lens),
     )
-    out = inkling_fa4_rel_attention(
+    out = attention_fn(
         q,
         key_cache,
         value_cache,
@@ -312,6 +322,29 @@ def _run_case(seq_lens, num_heads, num_kv_heads, rel_extent, window_left, seed=0
     )
 
     torch.testing.assert_close(out.float(), ref.float(), atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize(
+    ("seq_lens", "window_left"),
+    [
+        ([(17, 17), (9, 33)], None),
+        ([(13, 29), (1, 80)], 15),
+    ],
+)
+@pytest.mark.parametrize("num_heads,num_kv_heads", NUM_HEADS)
+@torch.inference_mode()
+def test_torch_attention_matches_reference(
+    seq_lens, window_left, num_heads, num_kv_heads
+):
+    _run_case(
+        seq_lens,
+        num_heads,
+        num_kv_heads,
+        rel_extent=128,
+        window_left=window_left,
+        device="cpu",
+        attention_fn=inkling_torch_rel_attention,
+    )
 
 
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="requires CUDA")

--- a/vllm/models/inkling/nvidia/attention.py
+++ b/vllm/models/inkling/nvidia/attention.py
@@ -40,6 +40,7 @@ from .ops.fa4_rel_attention import (
     inkling_fa4_num_splits,
     inkling_fa4_rel_attention,
     inkling_torch_rel_attention,
+    inkling_triton_decode_rel_attention,
 )
 from .ops.fa4_warmup import InklingFA4WarmupConfig, register_fa4_warmup
 from .ops.qkvr_prep import fused_qkvr_prep
@@ -318,7 +319,12 @@ class InklingAttention(nn.Module, AttentionLayerBase):
         nt = md.num_actual_tokens
         key_cache, value_cache = self._split_kv_cache()
         if self._use_torch_rel_attention:
-            inkling_torch_rel_attention(
+            attention_fn = (
+                inkling_triton_decode_rel_attention
+                if md.max_query_len == 1
+                else inkling_torch_rel_attention
+            )
+            attention_fn(
                 q[:nt],
                 key_cache,
                 value_cache,

--- a/vllm/models/inkling/nvidia/attention.py
+++ b/vllm/models/inkling/nvidia/attention.py
@@ -17,6 +17,7 @@ from vllm.model_executor.layers.linear import (
     RowParallelLinear,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import (
     canonicalize_singleton_dim_strides,
     kv_cache_dtype_str_to_dtype,
@@ -38,6 +39,7 @@ from .ops.fa4_rel_attention import (
     bucket_max_seqlen_q,
     inkling_fa4_num_splits,
     inkling_fa4_rel_attention,
+    inkling_torch_rel_attention,
 )
 from .ops.fa4_warmup import InklingFA4WarmupConfig, register_fa4_warmup
 from .ops.qkvr_prep import fused_qkvr_prep
@@ -166,6 +168,20 @@ class InklingAttention(nn.Module, AttentionLayerBase):
         self.kv_cache_torch_dtype = kv_cache_dtype_str_to_dtype(
             self.kv_cache_dtype, vllm_config.model_config
         )
+        self._use_torch_rel_attention = current_platform.is_rocm()
+        if self._use_torch_rel_attention:
+            if vllm_config.model_config.dtype != torch.bfloat16:
+                raise ValueError(
+                    "Inkling on ROCm currently supports bfloat16 model dtype only"
+                )
+            if self.kv_cache_torch_dtype != torch.bfloat16:
+                raise ValueError(
+                    "Inkling on ROCm currently supports bfloat16 KV cache only"
+                )
+            if quant_config is not None:
+                raise ValueError(
+                    "Inkling on ROCm currently supports unquantized bfloat16 only"
+                )
         self.register_buffer("k_scale", torch.ones((), dtype=torch.float32))
         self.register_buffer("v_scale", torch.ones((), dtype=torch.float32))
 
@@ -175,24 +191,25 @@ class InklingAttention(nn.Module, AttentionLayerBase):
         compilation_config.static_forward_context[prefix] = self
         self.kv_cache = torch.tensor([])  # replaced by bind_kv_cache
 
-        register_fa4_warmup(
-            InklingFA4WarmupConfig(
-                num_heads=self.num_heads,
-                num_kv_heads=self.num_kv_heads,
-                head_dim=self.head_dim,
-                rel_extent=self.rel_extent,
-                window_size=self.window_size,
-                is_local=self.is_local,
-                max_kv_len=self._max_kv_len,
-                dtype=vllm_config.model_config.dtype,
-                kv_dtype=self.kv_cache_torch_dtype,
-                block_size=vllm_config.cache_config.block_size,
-                max_num_reqs=vllm_config.scheduler_config.max_num_seqs,
-                max_num_batched_tokens=(
-                    vllm_config.scheduler_config.max_num_batched_tokens
-                ),
+        if not self._use_torch_rel_attention:
+            register_fa4_warmup(
+                InklingFA4WarmupConfig(
+                    num_heads=self.num_heads,
+                    num_kv_heads=self.num_kv_heads,
+                    head_dim=self.head_dim,
+                    rel_extent=self.rel_extent,
+                    window_size=self.window_size,
+                    is_local=self.is_local,
+                    max_kv_len=self._max_kv_len,
+                    dtype=vllm_config.model_config.dtype,
+                    kv_dtype=self.kv_cache_torch_dtype,
+                    block_size=vllm_config.cache_config.block_size,
+                    max_num_reqs=vllm_config.scheduler_config.max_num_seqs,
+                    max_num_batched_tokens=(
+                        vllm_config.scheduler_config.max_num_batched_tokens
+                    ),
+                )
             )
-        )
 
     def get_attn_backend(self) -> type[AttentionBackend]:
         return FlashAttentionBackend
@@ -300,6 +317,23 @@ class InklingAttention(nn.Module, AttentionLayerBase):
 
         nt = md.num_actual_tokens
         key_cache, value_cache = self._split_kv_cache()
+        if self._use_torch_rel_attention:
+            inkling_torch_rel_attention(
+                q[:nt],
+                key_cache,
+                value_cache,
+                block_table=md.block_table,
+                cache_seqlens=md.seq_lens,
+                cu_seqlens_q=md.query_start_loc,
+                max_seqlen_q=md.max_query_len,
+                softmax_scale=self.scaling,
+                causal=True,
+                window_size=self.window_size,
+                rel_extent=self.rel_extent,
+                rel_logits=rel_logits[:nt],
+                out=output[:nt],
+            )
+            return
         max_seqlen_q = bucket_max_seqlen_q(md.max_query_len)
         num_splits = inkling_fa4_num_splits(
             is_local=self.is_local,

--- a/vllm/models/inkling/nvidia/model.py
+++ b/vllm/models/inkling/nvidia/model.py
@@ -44,6 +44,7 @@ from vllm.models.inkling.common.mm_preprocess import (
 )
 from vllm.models.inkling.common.towers import InklingAudio, InklingVision
 from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
 from ..configs import InklingMMConfig, InklingModelConfig
@@ -422,11 +423,12 @@ class _TmlForCausalLMBase(nn.Module, SupportsPP, SupportsLoRA):
             prefix=maybe_prefix(prefix, "model"),
             nvfp4_config=self.nvfp4_config,
         )
-        initialize_lamport_rs_conv(
-            text_config.hidden_size,
-            text_config.sconv_kernel_size,
-            vllm_config.scheduler_config.max_num_batched_tokens,
-        )
+        if not current_platform.is_rocm():
+            initialize_lamport_rs_conv(
+                text_config.hidden_size,
+                text_config.sconv_kernel_size,
+                vllm_config.scheduler_config.max_num_batched_tokens,
+            )
         self.lm_head = ParallelLMHead(
             text_config.padded_vocab_size,
             text_config.hidden_size,

--- a/vllm/models/inkling/nvidia/moe.py
+++ b/vllm/models/inkling/nvidia/moe.py
@@ -70,6 +70,7 @@ def _linear_with_fp32_out(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor
         and flat.is_contiguous()
         and weight.is_contiguous()
         and flat.shape[1] % 8 == 0
+        and current_platform.is_cuda()
         and current_platform.has_device_capability(90)
         and ll_bf16.is_available()
     ):

--- a/vllm/models/inkling/nvidia/ops/fa4_rel_attention.py
+++ b/vllm/models/inkling/nvidia/ops/fa4_rel_attention.py
@@ -9,6 +9,7 @@ from typing import Any
 import torch
 
 from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
 
 
 def bucket_max_seqlen_q(max_seqlen_q: int) -> int:
@@ -168,6 +169,233 @@ def inkling_fa4_rel_attention(
     if isinstance(ret, tuple):
         return ret[0]
     return ret
+
+
+@triton.jit
+def _inkling_decode_rel_attention_kernel(
+    q_ptr,
+    key_cache_ptr,
+    value_cache_ptr,
+    block_table_ptr,
+    cache_seqlens_ptr,
+    cu_seqlens_q_ptr,
+    rel_logits_ptr,
+    out_ptr,
+    softmax_scale,
+    stride_q_token: tl.int64,
+    stride_q_head: tl.int64,
+    stride_q_dim: tl.int64,
+    stride_k_block: tl.int64,
+    stride_k_token: tl.int64,
+    stride_k_head: tl.int64,
+    stride_k_dim: tl.int64,
+    stride_v_block: tl.int64,
+    stride_v_token: tl.int64,
+    stride_v_head: tl.int64,
+    stride_v_dim: tl.int64,
+    stride_block_table_seq: tl.int64,
+    stride_rel_token: tl.int64,
+    stride_rel_head: tl.int64,
+    stride_rel_distance: tl.int64,
+    stride_out_token: tl.int64,
+    stride_out_head: tl.int64,
+    stride_out_dim: tl.int64,
+    NUM_HEADS: tl.constexpr,
+    NUM_KV_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    REL_EXTENT: tl.constexpr,
+    WINDOW_LEFT: tl.constexpr,
+):
+    seq_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+
+    query_idx = tl.load(cu_seqlens_q_ptr + seq_idx)
+    query_end = tl.load(cu_seqlens_q_ptr + seq_idx + 1)
+    if query_idx == query_end:
+        return
+
+    kv_len = tl.load(cache_seqlens_ptr + seq_idx)
+    if kv_len <= 0:
+        return
+
+    kv_group_size: tl.constexpr = NUM_HEADS // NUM_KV_HEADS
+    kv_head_idx = head_idx // kv_group_size
+    offs_d = tl.arange(0, BLOCK_D)
+    dim_mask = offs_d < HEAD_DIM
+    q_offsets = (
+        query_idx * stride_q_token + head_idx * stride_q_head + offs_d * stride_q_dim
+    )
+    q = tl.load(q_ptr + q_offsets, mask=dim_mask, other=0.0)
+
+    key_start = 0
+    if WINDOW_LEFT >= 0:
+        key_start = tl.maximum(0, kv_len - WINDOW_LEFT - 1)
+
+    running_max = -float("inf")
+    running_sum = 0.0
+    acc = tl.zeros((BLOCK_D,), dtype=tl.float32)
+
+    for tile_start in range(key_start, kv_len, BLOCK_N):
+        key_idx = tile_start + tl.arange(0, BLOCK_N)
+        key_mask = key_idx < kv_len
+        physical_block = tl.load(
+            block_table_ptr + seq_idx * stride_block_table_seq + key_idx // PAGE_SIZE,
+            mask=key_mask,
+            other=0,
+            cache_modifier=".ca",
+        ).to(tl.int64)
+        page_offset = key_idx % PAGE_SIZE
+
+        key_offsets = (
+            physical_block[:, None] * stride_k_block
+            + page_offset[:, None] * stride_k_token
+            + kv_head_idx * stride_k_head
+            + offs_d[None, :] * stride_k_dim
+        )
+        key = tl.load(
+            key_cache_ptr + key_offsets,
+            mask=key_mask[:, None] & dim_mask[None, :],
+            other=0.0,
+            cache_modifier=".cg",
+        )
+        scores = tl.sum(q[None, :] * key, axis=1) * softmax_scale
+
+        distance = kv_len - 1 - key_idx
+        rel_mask = key_mask & (distance < REL_EXTENT)
+        rel_offsets = (
+            query_idx * stride_rel_token
+            + head_idx * stride_rel_head
+            + distance * stride_rel_distance
+        )
+        relative_bias = tl.load(
+            rel_logits_ptr + rel_offsets,
+            mask=rel_mask,
+            other=0.0,
+            cache_modifier=".ca",
+        )
+        scores += relative_bias
+        scores = tl.where(key_mask, scores, -float("inf"))
+
+        value_offsets = (
+            physical_block[:, None] * stride_v_block
+            + page_offset[:, None] * stride_v_token
+            + kv_head_idx * stride_v_head
+            + offs_d[None, :] * stride_v_dim
+        )
+        value = tl.load(
+            value_cache_ptr + value_offsets,
+            mask=key_mask[:, None] & dim_mask[None, :],
+            other=0.0,
+            cache_modifier=".cg",
+        )
+
+        tile_max = tl.maximum(tl.max(scores, axis=0), running_max)
+        old_scale = tl.exp(running_max - tile_max)
+        probabilities = tl.exp(scores - tile_max)
+        acc = acc * old_scale + tl.sum(probabilities[:, None] * value, axis=0)
+        running_sum = running_sum * old_scale + tl.sum(probabilities, axis=0)
+        running_max = tile_max
+
+    output_offsets = (
+        query_idx * stride_out_token
+        + head_idx * stride_out_head
+        + offs_d * stride_out_dim
+    )
+    tl.store(out_ptr + output_offsets, acc / running_sum, mask=dim_mask)
+
+
+def inkling_triton_decode_rel_attention(
+    q: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    *,
+    block_table: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    max_seqlen_q: int,
+    softmax_scale: float,
+    causal: bool,
+    window_size: tuple[int, int],
+    rel_extent: int,
+    rel_logits: torch.Tensor,
+    num_splits: int = 32,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Fused paged relative attention for a single-token decode step."""
+    del num_splits
+    if max_seqlen_q != 1:
+        raise ValueError("Inkling Triton decode attention requires max_seqlen_q=1")
+    if not causal:
+        raise NotImplementedError(
+            "Inkling Triton decode attention requires causal=True"
+        )
+    if window_size == (-1, -1):
+        window_left = -1
+    elif window_size[0] >= 0 and window_size[1] == 0:
+        window_left = window_size[0]
+    else:
+        raise NotImplementedError(
+            f"Unsupported Inkling Triton attention window: {window_size}"
+        )
+
+    if q.ndim != 3 or key_cache.ndim != 4 or value_cache.ndim != 4:
+        raise ValueError("Expected q to be 3D and paged K/V caches to be 4D")
+    if key_cache.shape != value_cache.shape:
+        raise ValueError("Inkling key and value cache shapes must match")
+    if key_cache.shape[-1] != q.shape[-1]:
+        raise ValueError("Inkling query and KV head dimensions must match")
+    if rel_logits.shape[:2] != q.shape[:2] or rel_logits.shape[2] < rel_extent:
+        raise ValueError("Inkling relative logits have an incompatible shape")
+    if cu_seqlens_q.shape[0] != cache_seqlens.shape[0] + 1:
+        raise ValueError("Inkling varlen query and KV metadata do not match")
+
+    num_heads = q.shape[1]
+    num_kv_heads = key_cache.shape[2]
+    if num_heads % num_kv_heads != 0:
+        raise ValueError("Inkling query heads must be divisible by KV heads")
+
+    result = torch.empty_like(q) if out is None else out
+    if result.shape != q.shape:
+        raise ValueError("Inkling attention output must have the query shape")
+    if q.shape[0] == 0:
+        return result
+
+    head_dim = q.shape[2]
+    block_d = triton.next_power_of_2(head_dim)
+    kv_group_size = num_heads // num_kv_heads
+    num_warps = 1 if kv_group_size > 1 else 4
+    grid = (cache_seqlens.shape[0], num_heads)
+    _inkling_decode_rel_attention_kernel[grid](
+        q,
+        key_cache,
+        value_cache,
+        block_table,
+        cache_seqlens,
+        cu_seqlens_q,
+        rel_logits,
+        result,
+        softmax_scale,
+        *q.stride(),
+        *key_cache.stride(),
+        *value_cache.stride(),
+        block_table.stride(0),
+        *rel_logits.stride(),
+        *result.stride(),
+        NUM_HEADS=num_heads,
+        NUM_KV_HEADS=num_kv_heads,
+        HEAD_DIM=head_dim,
+        BLOCK_D=block_d,
+        BLOCK_N=8,
+        PAGE_SIZE=key_cache.shape[1],
+        REL_EXTENT=rel_extent,
+        WINDOW_LEFT=window_left,
+        num_warps=num_warps,
+        num_stages=2,
+    )
+    return result
 
 
 def inkling_torch_rel_attention(

--- a/vllm/models/inkling/nvidia/ops/fa4_rel_attention.py
+++ b/vllm/models/inkling/nvidia/ops/fa4_rel_attention.py
@@ -130,19 +130,26 @@ def inkling_fa4_rel_attention(
     cute_window = (None, None) if window_size == (-1, -1) else window_size
 
     rel_logits = rel_logits.contiguous()
+    flash_attn_impl: Callable[..., Any]
     if _use_sheared_bias():
-        from vllm.third_party.tml_fa4 import flash_attn_varlen_func
+        from vllm.third_party.tml_fa4 import (
+            flash_attn_varlen_func as tml_flash_attn_varlen_func,
+        )
 
+        flash_attn_impl = tml_flash_attn_varlen_func
         bias_kwargs: dict[str, Any] = {"rel_bias": rel_logits}
     else:
-        from vllm.vllm_flash_attn.cute import flash_attn_varlen_func
+        from vllm.vllm_flash_attn.cute import (
+            flash_attn_varlen_func as cute_flash_attn_varlen_func,
+        )
 
+        flash_attn_impl = cute_flash_attn_varlen_func
         bias_kwargs = {
             "score_mod": _get_score_mod(rel_extent),
             "aux_tensors": [rel_logits],
         }
 
-    ret = flash_attn_varlen_func(
+    ret = flash_attn_impl(
         q=q,
         k=key_cache,
         v=value_cache,
@@ -161,3 +168,179 @@ def inkling_fa4_rel_attention(
     if isinstance(ret, tuple):
         return ret[0]
     return ret
+
+
+def inkling_torch_rel_attention(
+    q: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    *,
+    block_table: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    max_seqlen_q: int,
+    softmax_scale: float,
+    causal: bool,
+    window_size: tuple[int, int],
+    rel_extent: int,
+    rel_logits: torch.Tensor,
+    num_splits: int = 32,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Correctness-first paged relative attention for ROCm.
+
+    This mirrors :func:`inkling_fa4_rel_attention` using bounded-size PyTorch
+    score tensors. It intentionally synchronizes the small varlen metadata to
+    the host and is not intended as a performance path.
+    """
+    del max_seqlen_q, num_splits
+    if not causal:
+        raise NotImplementedError("Inkling PyTorch attention requires causal=True")
+    if window_size == (-1, -1):
+        window_left = None
+    elif window_size[0] >= 0 and window_size[1] == 0:
+        window_left = window_size[0]
+    else:
+        raise NotImplementedError(
+            f"Unsupported Inkling PyTorch attention window: {window_size}"
+        )
+
+    if q.ndim != 3 or key_cache.ndim != 4 or value_cache.ndim != 4:
+        raise ValueError("Expected q to be 3D and paged K/V caches to be 4D")
+    if key_cache.shape != value_cache.shape:
+        raise ValueError("Inkling key and value cache shapes must match")
+    if key_cache.shape[-1] != q.shape[-1]:
+        raise ValueError("Inkling query and KV head dimensions must match")
+    if rel_logits.shape[:2] != q.shape[:2] or rel_logits.shape[2] < rel_extent:
+        raise ValueError("Inkling relative logits have an incompatible shape")
+
+    num_heads = q.shape[1]
+    num_kv_heads = key_cache.shape[2]
+    if num_heads % num_kv_heads != 0:
+        raise ValueError("Inkling query heads must be divisible by KV heads")
+    num_kv_groups = num_heads // num_kv_heads
+    block_size = key_cache.shape[1]
+
+    query_starts = cu_seqlens_q.detach().to("cpu").tolist()
+    kv_lens = cache_seqlens.detach().to("cpu").tolist()
+    if len(query_starts) != len(kv_lens) + 1:
+        raise ValueError("Inkling varlen query and KV metadata do not match")
+    if query_starts[-1] > q.shape[0]:
+        raise ValueError("Inkling query metadata exceeds the query tensor")
+
+    result = torch.empty_like(q) if out is None else out
+    if result.shape != q.shape:
+        raise ValueError("Inkling attention output must have the query shape")
+
+    # Keep each fp32 score tensor at or below roughly 64 MiB.
+    max_score_elements = 16 * 1024 * 1024
+    for seq_idx, kv_len in enumerate(kv_lens):
+        query_start = query_starts[seq_idx]
+        query_end = query_starts[seq_idx + 1]
+        query_len = query_end - query_start
+        if query_len == 0:
+            continue
+        if kv_len < query_len or kv_len <= 0:
+            raise ValueError("Inkling KV length must cover every query token")
+
+        if window_left is None:
+            query_chunk_size = max(
+                1, min(query_len, max_score_elements // (num_heads * kv_len))
+            )
+        else:
+            max_keys_per_query = min(kv_len, window_left + 1)
+            query_chunk_size = max(
+                1,
+                min(
+                    query_len,
+                    max_score_elements // (num_heads * max_keys_per_query),
+                ),
+            )
+            while (
+                num_heads
+                * query_chunk_size
+                * min(kv_len, window_left + query_chunk_size)
+                > max_score_elements
+            ):
+                query_chunk_size = max(1, query_chunk_size // 2)
+
+        for chunk_start in range(0, query_len, query_chunk_size):
+            chunk_end = min(query_len, chunk_start + query_chunk_size)
+            absolute_query_start = kv_len - query_len + chunk_start
+            absolute_query_end = kv_len - query_len + chunk_end
+            key_start = (
+                0 if window_left is None else max(0, absolute_query_start - window_left)
+            )
+            key_end = absolute_query_end
+
+            first_block = key_start // block_size
+            last_block = (key_end + block_size - 1) // block_size
+            physical_blocks = block_table[seq_idx, first_block:last_block].to(
+                dtype=torch.long
+            )
+            if physical_blocks.numel() == 0 or bool((physical_blocks < 0).any()):
+                raise ValueError("Inkling block table is missing required KV pages")
+            page_offset = key_start - first_block * block_size
+            num_keys = key_end - key_start
+
+            key = key_cache.index_select(0, physical_blocks).reshape(
+                -1, num_kv_heads, q.shape[-1]
+            )[page_offset : page_offset + num_keys]
+            value = value_cache.index_select(0, physical_blocks).reshape(
+                -1, num_kv_heads, q.shape[-1]
+            )[page_offset : page_offset + num_keys]
+
+            query = q[query_start + chunk_start : query_start + chunk_end].float()
+            query = query.view(
+                chunk_end - chunk_start,
+                num_kv_heads,
+                num_kv_groups,
+                q.shape[-1],
+            )
+            scores = torch.einsum("qhgd,khd->hgqk", query, key.float())
+            scores = scores.reshape(num_heads, chunk_end - chunk_start, num_keys)
+            scores.mul_(softmax_scale)
+
+            query_positions = torch.arange(
+                absolute_query_start,
+                absolute_query_end,
+                device=q.device,
+            ).view(-1, 1)
+            key_positions = torch.arange(key_start, key_end, device=q.device).view(
+                1, -1
+            )
+            distance = query_positions - key_positions
+            relative_index = distance.clamp(0, rel_extent - 1)
+            relative = rel_logits[
+                query_start + chunk_start : query_start + chunk_end
+            ].float()
+            bias = relative.permute(1, 0, 2).gather(
+                2,
+                relative_index.unsqueeze(0).expand(num_heads, -1, -1),
+            )
+            bias.masked_fill_(
+                ((distance < 0) | (distance >= rel_extent)).unsqueeze(0),
+                0.0,
+            )
+            scores.add_(bias)
+
+            mask = distance < 0
+            if window_left is not None:
+                mask = mask | (distance > window_left)
+            scores.masked_fill_(mask.unsqueeze(0), float("-inf"))
+
+            probabilities = torch.softmax(scores, dim=-1)
+            probabilities = probabilities.view(
+                num_kv_heads,
+                num_kv_groups,
+                chunk_end - chunk_start,
+                num_keys,
+            )
+            attention = torch.einsum(
+                "hgqk,khd->qhgd", probabilities, value.float()
+            ).reshape(chunk_end - chunk_start, num_heads, q.shape[-1])
+            result[query_start + chunk_start : query_start + chunk_end].copy_(
+                attention.to(q.dtype)
+            )
+
+    return result


### PR DESCRIPTION
## Purpose

Enable `thinkingmachines/Inkling` BF16 checkpoint on ROCm using the already-merged shared Inkling implementation.

- add a bounded PyTorch implementation of Inkling's paged causal relative attention for ROCm correctness and prefill;
- add a fused Triton online-softmax kernel for single-token decode, including paged KV, MHA/GQA, global/local windows, and relative logits;
- use the existing RCCL short-convolution path and safe Torch BF16 router GEMM instead of CUDA-only Lamport/CuTe primitives;
- fail closed unless model weights and KV cache are BF16 and unquantized.

CUDA continues to use the existing FA4, Lamport, MTP=1, and LoRA paths.

## Scope and limitations

- ROCm support in this PR is BF16 model weights + BF16 KV cache, without quantization.
- Triton is used only for `max_query_len == 1`; prefill/chunked/mixed batches retain the bounded PyTorch path.
- Device-specific MoE tuning, MXFP4, ROCm MTP, graph/runtime, and speculative decode changes are intentionally excluded.