### PR TITLE
[Bugfix] Fall back to native sampling when FlashInfer cannot target the GPU

### DIFF
--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -235,6 +235,44 @@ def test_flashinfer_sampler():
     )
 
 
+@pytest.mark.skipif(
+    not FLASHINFER_TOPK_TOPP_SUPPORTED,
+    reason="Requires CUDA and flashinfer",
+)
+def test_flashinfer_sampler_fallback_when_jit_cannot_target_gpu(monkeypatch):
+    """FlashInfer swallows arch-detection errors (e.g. SM 12.x with a CUDA
+    toolkit older than 12.9), leaving an empty target-arch set that makes
+    every JIT spec fail with a misleading "requires sm75 or higher" error at
+    first use, killing the engine during startup profiling (issue #42393).
+    The sampler gate must detect this and fall back to native sampling, and
+    surface the real reason when the user explicitly opted in.
+    """
+    import flashinfer.jit.core
+    from flashinfer.compilation_context import CompilationContext
+
+    from vllm.v1.sample.ops.topk_topp_sampler import flashinfer_sampler_supported
+
+    def fake_check_cuda_arch():
+        raise RuntimeError("FlashInfer requires GPUs with sm75 or higher")
+
+    def fake_normalize_cuda_arch(major, minor):
+        raise RuntimeError("SM 12.x requires CUDA >= 12.9")
+
+    monkeypatch.setattr(flashinfer.jit.core, "check_cuda_arch", fake_check_cuda_arch)
+    monkeypatch.setattr(
+        CompilationContext,
+        "_normalize_cuda_arch",
+        staticmethod(fake_normalize_cuda_arch),
+    )
+
+    monkeypatch.delenv("VLLM_USE_FLASHINFER_SAMPLER", raising=False)
+    assert flashinfer_sampler_supported() is False
+
+    monkeypatch.setenv("VLLM_USE_FLASHINFER_SAMPLER", "1")
+    with pytest.raises(RuntimeError, match="SM 12.x requires CUDA >= 12.9"):
+        flashinfer_sampler_supported()
+
+
 # =============================================================================
 # Triton kernel tests
 # =============================================================================

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -10,6 +10,7 @@ from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config.model import PROCESSED_LOGPROBS_MODES, LogprobsMode
 from vllm.logger import init_logger
 from vllm.platforms import CpuArchEnum, current_platform
+from vllm.platforms.interface import DeviceCapability
 from vllm.triton_utils import HAS_TRITON
 
 if HAS_TRITON:
@@ -25,12 +26,46 @@ def _skip_aiter_sampler_on_gfx1250() -> bool:
     return on_gfx1250()
 
 
+def _flashinfer_jit_unsupported_reason(capability: DeviceCapability) -> str | None:
+    """Return why FlashInfer JIT codegen cannot target the current GPU, or
+    None if it can.
+
+    FlashInfer swallows arch-detection errors when building its compilation
+    context (e.g. SM 12.x with a CUDA toolkit older than 12.9), leaving an
+    empty target-arch set that makes every JIT spec fail with a misleading
+    "requires sm75 or higher" error at first use — killing the engine during
+    startup profiling (https://github.com/vllm-project/vllm/issues/42393).
+    """
+    try:
+        from flashinfer.jit.core import check_cuda_arch
+    except ImportError:
+        return None
+    try:
+        check_cuda_arch()
+        return None
+    except RuntimeError as e:
+        reason = str(e)
+    try:
+        # Re-derive the real error that FlashInfer swallowed during arch
+        # detection, e.g. "SM 12.x requires CUDA >= 12.9".
+        from flashinfer.compilation_context import CompilationContext
+
+        CompilationContext._normalize_cuda_arch(capability.major, capability.minor)
+    except RuntimeError as e:
+        reason = str(e)
+    except Exception:
+        # FlashInfer internals changed; keep the original error message.
+        pass
+    return reason
+
+
 def flashinfer_sampler_supported() -> bool:
     """Decide whether FlashInfer's top-p/top-k sampler can be used.
 
     Returns False (with appropriate logging) when ``VLLM_USE_FLASHINFER_SAMPLER``
     is 0, when the platform isn't CUDA, when the GPU's compute capability is
-    unsupported. Raises ``RuntimeError`` if the user explicitly opted in
+    unsupported, or when FlashInfer cannot JIT-compile for the current
+    GPU/CUDA toolchain. Raises ``RuntimeError`` if the user explicitly opted in
     via the env var but FlashInfer is unavailable.
 
     Assumes flashinfer is installed, as guaranteed by ``requirements/cuda.txt``;
@@ -57,6 +92,8 @@ def flashinfer_sampler_supported() -> bool:
         unsupported_reason = (
             f"unsupported compute capability {capability.as_version_str()}"
         )
+    else:
+        unsupported_reason = _flashinfer_jit_unsupported_reason(capability)
 
     if unsupported_reason is None:
         logger.info_once("Using FlashInfer for top-p & top-k sampling.", scope="global")


### PR DESCRIPTION
## Purpose

Fixes #42393.

On SM 12.x GPUs with a CUDA toolkit older than 12.9 (e.g. RTX 5090 + nvcc 12.8), FlashInfer swallows the real arch-detection error while building its compilation context: `_normalize_cuda_arch` raises `"SM 12.x requires CUDA >= 12.9"`, but the `except Exception` in `CompilationContext.__init__` downgrades it to a warning and leaves `TARGET_CUDA_ARCHS` empty. Every subsequent JIT spec then fails `check_cuda_arch()` with a misleading:

```
RuntimeError: FlashInfer requires GPUs with sm75 or higher
```

Since the FlashInfer top-p/top-k sampler is enabled by default on CUDA, this kills the engine during startup profiling — the server never comes up, regardless of the attention backend selected (the reporter was using `--attention-backend flash_attn`).

Changes:

- Add `_flashinfer_jit_unsupported_reason()` to the sampler gate in `vllm/v1/sample/ops/topk_topp_sampler.py`: probe FlashInfer's `check_cuda_arch()`, and when it fails, re-derive the underlying reason by calling `CompilationContext._normalize_cuda_arch` with the current device capability — so the true message (e.g. `"SM 12.x requires CUDA >= 12.9"`) is produced by FlashInfer itself rather than duplicating its version rules in vLLM.
- The existing gate machinery then does the rest: fall back to native sampling with a clear warning by default, or raise an actionable error if the user explicitly set `VLLM_USE_FLASHINFER_SAMPLER=1`.
- The probe is defensive against FlashInfer refactors: if the internals move, it keeps the original error message or skips the check entirely (`ImportError` → no gating change).

The root cause (swallowed exception) lives in FlashInfer — flashinfer-ai/flashinfer#3675 and flashinfer-ai/flashinfer#3945 track the same symptom upstream. This PR makes vLLM degrade gracefully on affected systems either way. The rejection sampler is pure torch, so speculative-decoding configs (as in the issue report) are fully covered by fixing this gate.

## Test Plan

- Unit (mocks the FlashInfer failure mode, so it runs anywhere):

```bash
pytest tests/v1/sample/test_topk_topp_sampler.py -k fallback_when_jit
```

- End-to-end on the affected configuration (RTX 5090 / SM120, system nvcc 12.8), no mocks: offline `LLM(model="Qwen/Qwen3-0.6B", enforce_eager=True)` + `generate` with `temperature=0.8, top_p=0.9, top_k=20`, without setting `VLLM_USE_FLASHINFER_SAMPLER`, on main vs. this branch; plus a run with `VLLM_USE_FLASHINFER_SAMPLER=1` to exercise the explicit opt-in path.
- `pre-commit run --files` on both changed files (ruff check/format, mypy, typos, SPDX, etc.).

## Test Result

- Unit: fails on main (`assert True is False` — the gate reports the sampler usable), passes with the fix. The rest of the suite is unaffected (same pass/fail set as main on the same machine).
- E2E **main**: engine dies during startup profiling with the misleading `sm75` error — exact reproduction of the issue.
- E2E **this branch**: `WARNING ... FlashInfer top-p/top-k sampling unavailable: SM 12.x requires CUDA >= 12.9; falling back. Set VLLM_USE_FLASHINFER_SAMPLER=0 to silence.` — engine starts and generates coherent output with top-k/top-p sampling.
- E2E **`VLLM_USE_FLASHINFER_SAMPLER=1`**: `RuntimeError: FlashInfer top-p/top-k sampling unavailable: SM 12.x requires CUDA >= 12.9. Unset VLLM_USE_FLASHINFER_SAMPLER=1.` — the real reason instead of the misleading one.
- `pre-commit`: all hooks pass on both changed files.

---

### AI-Assisted Work Disclosure (per AGENTS.md)

- **Duplicate check:** no open PR addresses #42393 or FlashInfer sampler gating for untargetable GPUs (`gh pr list` searches by issue number and area keywords, re-run immediately before opening this PR).
- **AI assistance:** this contribution was prepared with AI assistance (Claude Code). I reviewed every changed line and ran the tests above; the end-to-end before/after verification was performed on my hardware, which reproduces the reported configuration exactly.
- **Serving impact:** gating/fallback fix only. On systems where FlashInfer can target the GPU, sampler selection is unchanged. On affected systems, serving goes from crashing at startup to running with the native sampler.
