### PR TITLE
[DSv4 Perf] Skip empty c128 kernel launch, around 2x kernel performance improvement.

### DIFF
--- a/tests/kernels/test_compressor_kv_cache.py
+++ b/tests/kernels/test_compressor_kv_cache.py
@@ -13,6 +13,7 @@ These tests cover:
 """
 
 import math
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -27,6 +28,7 @@ from vllm.models.deepseek_v4.common.ops.fused_compress_quant_cache import (
     _fused_kv_compress_norm_rope_insert_indexer_mxfp4_attn,
     _launch_two_stage_sparse_attn_compressor,
 )
+from vllm.models.deepseek_v4.compressor import _get_c128_boundary
 from vllm.platforms import current_platform
 
 from .test_fused_indexer_q_rope_quant import quantize_to_mxfp4
@@ -56,6 +58,25 @@ def _ue8m0_reference(x: torch.Tensor, block_size: int, fp8_max: float):
         x_fp8[start:end] = quantized.to(torch.float8_e4m3fn)
 
     return x_fp8, scales
+
+
+@pytest.mark.parametrize(
+    ("starts", "query_start_loc", "expected"),
+    [
+        ([0], [0, 127], False),
+        ([0], [0, 128], True),
+        ([127], [0, 1], True),
+        ([128], [0, 127], False),
+        ([1, 255], [0, 1, 2], True),
+        (None, [0, 1], None),
+    ],
+)
+def test_get_c128_boundary(starts, query_start_loc, expected):
+    metadata = SimpleNamespace(
+        _num_computed_tokens_cpu=None if starts is None else torch.tensor(starts),
+        query_start_loc_cpu=torch.tensor(query_start_loc),
+    )
+    assert _get_c128_boundary(metadata) is expected
 
 
 # ── Test A: DeepseekV4 Attention path ──────────────────────────────────────────────

--- a/vllm/models/deepseek_v4/compressor.py
+++ b/vllm/models/deepseek_v4/compressor.py
@@ -7,7 +7,7 @@ from typing import Any, ClassVar, cast
 import torch
 from torch import nn
 
-from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.config import CUDAGraphMode, VllmConfig, get_current_vllm_config
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.layernorm import RMSNorm
@@ -40,6 +40,19 @@ def _prefer_two_stage_compressor() -> bool:
     # Platforms that favor the triton variant of two-stage compressor split.
     # Currently only tested on ROCm
     return current_platform.is_rocm()
+
+
+def _get_c128_boundary(metadata: CommonAttentionMetadata) -> bool | None:
+    starts = metadata._num_computed_tokens_cpu
+    if starts is None:
+        return None
+
+    starts_list = starts.tolist()
+    query_start_loc = metadata.query_start_loc_cpu.tolist()
+    return any(
+        start % 128 + query_start_loc[i + 1] - query_start_loc[i] >= 128
+        for i, start in enumerate(starts_list)
+    )
 
 
 class CompressorBackend(AttentionBackend):
@@ -90,6 +103,7 @@ class CompressorMetadata:
 
     token_to_req_indices: torch.Tensor | None = None  # [num_tokens]
     num_decode_tokens: int | None = None
+    c128_boundary: bool | None = None
 
 
 class CompressorMetadataBuilder(AttentionMetadataBuilder):
@@ -127,6 +141,11 @@ class CompressorMetadataBuilder(AttentionMetadataBuilder):
             block_size=self.block_size,
             token_to_req_indices=token_to_req_indices,
             num_decode_tokens=num_decode_tokens,
+            c128_boundary=(
+                _get_c128_boundary(common_attn_metadata)
+                if self.block_size == 8
+                else None
+            ),
         )
 
 
@@ -317,7 +336,8 @@ class DeepseekCompressor(nn.Module):
         )
 
         # Get the metadata and handle dummy profiling run.
-        attn_metadata = get_forward_context().attn_metadata
+        forward_context = get_forward_context()
+        attn_metadata = forward_context.attn_metadata
         if not isinstance(attn_metadata, dict):
             return
 
@@ -358,6 +378,16 @@ class DeepseekCompressor(nn.Module):
             compress_ratio=self.compress_ratio,
             pdl_kwargs=pdl_kwargs,
         )
+
+        # full graph cannot branch on per-step CPU metadata after capture
+        if (
+            current_platform.is_cuda()
+            and self.head_dim == 512
+            and self.compress_ratio == 128
+            and forward_context.cudagraph_runtime_mode != CUDAGraphMode.FULL
+            and state_metadata.c128_boundary is False
+        ):
+            return
 
         # Fused: compress → RMSNorm → RoPE → FP8 quant → KV cache write.
         # RoPE requirements (kernel applies forward GPT-J style rotation):


### PR DESCRIPTION
## Purpose

We do compress in `SparseAttnCompressC128Block8Kernel` and store in `SparseAttnNormRopeStoreFullKernel`

We will skip it inside the kernel by taking a look at boundary, but this skip could be move ahead to bypass the full kernel.

## Test

Acc covered in unit test

Perf through this AI generated script

```py
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
"""Microbenchmark C128 non-boundary: old path vs save-only path."""

from types import SimpleNamespace

import torch

from vllm.models.deepseek_v4.common.ops.save_partial_states import (
    save_partial_states,
)
from vllm.models.deepseek_v4.nvidia.ops.sparse_attn_compress_cutedsl import (
    compress_norm_rope_store_cutedsl,
)
from vllm.platforms import current_platform

WARMUP = 20
ITERS = 1000
device = "cuda"

position = torch.tensor([126], dtype=torch.int64, device=device)
slot_mapping = position.clone()
token_to_req = torch.zeros(1, dtype=torch.int32, device=device)
block_table = torch.arange(16, dtype=torch.int32, device=device).unsqueeze(0)

kv = torch.randn(1, 512, dtype=torch.float32, device=device)
score = torch.randn_like(kv)
ape = torch.randn(128, 512, dtype=torch.float32, device=device)
state_cache = torch.zeros(16, 8, 1024, dtype=torch.float32, device=device)

kv_cache = torch.zeros(1, 64, 512, dtype=torch.bfloat16, device=device)
kv_slot_mapping = torch.zeros(1, dtype=torch.int64, device=device)
rms_weight = torch.ones(512, dtype=torch.bfloat16, device=device)
cos_sin_cache = torch.randn(128, 64, dtype=torch.float32, device=device)


def save_only() -> None:
    save_partial_states(
        kv=kv,
        score=score,
        ape=ape,
        positions=position,
        state_cache=state_cache,
        slot_mapping=slot_mapping,
        block_size=8,
        state_width=512,
        compress_ratio=128,
        pdl_kwargs={"launch_pdl": False},
    )


def old_path() -> None:
    save_only()
    compress_norm_rope_store_cutedsl(
        state_cache=state_cache,
        num_actual=1,
        token_to_req_indices=token_to_req,
        positions=position,
        slot_mapping=slot_mapping,
        block_table=block_table,
        block_size=8,
        state_width=512,
        cos_sin_cache=cos_sin_cache,
        kv_cache=kv_cache,
        k_cache_metadata=SimpleNamespace(slot_mapping=kv_slot_mapping),
        pdl_kwargs={"launch_pdl": False},
        head_dim=512,
        rope_head_dim=64,
        compress_ratio=128,
        overlap=False,
        use_fp4_cache=False,
        rms_norm_weight=rms_weight,
        rms_norm_eps=1e-6,
        quant_block=64,
        token_stride=576,
        scale_dim=8,
        store_full_kv=True,
    )


def bench(fn) -> float:
    for _ in range(WARMUP):
        fn()
    torch.accelerator.synchronize()
    start = torch.Event(enable_timing=True)
    end = torch.Event(enable_timing=True)
    start.record()
    for _ in range(ITERS):
        fn()
    end.record()
    end.synchronize()
    return start.elapsed_time(end) * 1000 / ITERS


def capture(fn):
    graph = torch.cuda.CUDAGraph()
    torch.accelerator.synchronize()
    with torch.cuda.graph(graph):
        fn()
    return graph.replay


if __name__ == "__main__":
    with torch.inference_mode():
        # Compile both kernels before measuring.
        old_path()
        torch.accelerator.synchronize()

        eager_new = bench(save_only)
        eager_old = bench(old_path)
        graph_new = bench(capture(save_only))
        graph_old = bench(capture(old_path))

    print(current_platform.get_device_name())
    print(
        f"eager:     save-only {eager_new:.3f} us, old {eager_old:.3f} us, "
        f"saved {eager_old - eager_new:.3f} us"
    )
    print(
        f"graph:     save-only {graph_new:.3f} us, old {graph_old:.3f} us, "
        f"saved {graph_old - graph_new:.3f} us"
    )
```

And we get 

```bash
python benchmarks/kernels/benchmark_dsv4_c128_skip.py 
NVIDIA B300 SXM6 AC
eager:     save-only 17.041 us, old 51.676 us, saved 34.635 us
graph:     save-only 3.356 us, old 6.150 us, saved 2.794 us
```