### PR TITLE
[ROCm][MoE] Avoid redundant AITER MXFP8 MoE output copy

### DIFF
--- a/tests/kernels/moe/test_mxfp8_aiter_backend_selection.py
+++ b/tests/kernels/moe/test_mxfp8_aiter_backend_selection.py
@@ -9,9 +9,12 @@ expert_mask) and skipped (native fallback) when the device/package is missing.
 """
 
 import dataclasses
+import sys
+import types
 from unittest.mock import patch
 
 import pytest
+import torch
 
 from vllm.platforms import current_platform
 
@@ -133,3 +136,75 @@ def test_explicit_moe_backend_aiter():
         pytest.raises(ValueError, match="flydsl package"),
     ):
         _select_kernel_cls(Fp8MoeBackend.AITER_MXFP8, _config(1))
+
+
+@pytest.mark.parametrize("output_kind", ["owning", "view", "noncontiguous"])
+def test_aiter_mxfp8_rebinds_output_only_when_safe(monkeypatch, output_kind):
+    """Owning outputs adopt AITER storage; views retain their storage."""
+    from vllm._aiter_ops import rocm_aiter_ops
+
+    def _enum_value(value):
+        return types.SimpleNamespace(value=value)
+
+    fake_aiter = types.ModuleType("aiter")
+    fake_aiter.__dict__["ActivationType"] = types.SimpleNamespace(Swiglu=_enum_value(1))
+    fake_aiter.__dict__["QuantType"] = types.SimpleNamespace(per_1x32=_enum_value(2))
+    fake_aiter_ops = types.ModuleType("aiter.ops")
+    fake_flydsl = types.ModuleType("aiter.ops.flydsl")
+    fake_moe_common = types.ModuleType("aiter.ops.flydsl.moe_common")
+    fake_moe_common.__dict__["GateMode"] = types.SimpleNamespace(
+        INTERLEAVE=_enum_value("interleave")
+    )
+    monkeypatch.setitem(sys.modules, "aiter", fake_aiter)
+    monkeypatch.setitem(sys.modules, "aiter.ops", fake_aiter_ops)
+    monkeypatch.setitem(sys.modules, "aiter.ops.flydsl", fake_flydsl)
+    monkeypatch.setitem(sys.modules, "aiter.ops.flydsl.moe_common", fake_moe_common)
+
+    experts = object.__new__(AiterMxfp8Experts)
+    experts.moe_config = types.SimpleNamespace(rocm_aiter_fmoe_enabled=False)
+    experts.quant_config = types.SimpleNamespace(gemm1_clamp_limit=None)
+    experts.w1_scale_val = None
+    experts.w2_scale_val = None
+
+    result = torch.randn(4, 16, dtype=torch.bfloat16)
+    if output_kind == "owning":
+        output = torch.empty_like(result)
+    elif output_kind == "view":
+        output = torch.empty(8, 16, dtype=result.dtype)[:4]
+    else:
+        output = torch.empty(4, 32, dtype=result.dtype)[:, ::2]
+    original_output_ptr = output.data_ptr()
+    original_output_stride = output.stride()
+
+    def _fake_fused_moe(*args, **kwargs):
+        assert kwargs["output_dtype"] == output.dtype
+        return result
+
+    monkeypatch.setattr(rocm_aiter_ops, "fused_moe", _fake_fused_moe)
+
+    experts.apply(
+        output=output,
+        hidden_states=torch.empty_like(result),
+        w1=torch.empty(1),
+        w2=torch.empty(1),
+        topk_weights=torch.ones(4, 2),
+        topk_ids=torch.zeros(4, 2, dtype=torch.int32),
+        activation=None,
+        global_num_experts=1,
+        expert_map=None,
+        a1q_scale=None,
+        a2_scale=None,
+        workspace13=torch.empty(0),
+        workspace2=torch.empty(0),
+        expert_tokens_meta=None,
+        apply_router_weight_on_input=False,
+    )
+
+    if output_kind == "owning":
+        assert output.data_ptr() == result.data_ptr()
+        assert output.data_ptr() != original_output_ptr
+    else:
+        assert output.data_ptr() == original_output_ptr
+        assert output.data_ptr() != result.data_ptr()
+        assert output.stride() == original_output_stride
+    assert torch.equal(output, result)

--- a/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp8_moe.py
@@ -146,7 +146,7 @@ class AiterMxfp8Experts(Mxfp8TritonExpertsBase):
         # call is captured under HIP graphs / torch.compile (a direct
         # ``aiter.fused_moe`` is opaque to the dispatcher). aiter requires FP32
         # routing weights / INT32 ids.
-        out = rocm_aiter_ops.fused_moe(
+        result = rocm_aiter_ops.fused_moe(
             hidden_states,
             w1,
             w2,
@@ -164,4 +164,18 @@ class AiterMxfp8Experts(Mxfp8TritonExpertsBase):
             swiglu_limit=swiglu_limit,
             output_dtype=output.dtype,
         )
-        output.copy_(out.to(output.dtype))
+        result = result if result.dtype == output.dtype else result.to(output.dtype)
+        # Match the generic AITER MoE path: adopt the returned storage when the
+        # caller provided an owning contiguous output. Views and incompatible
+        # layouts retain copy semantics.
+        if (
+            output.shape == result.shape
+            and output.dtype == result.dtype
+            and output.device == result.device
+            and output.is_contiguous()
+            and result.is_contiguous()
+            and output._base is None
+        ):
+            output.set_(result)
+        else:
+            output.copy_(result)


### PR DESCRIPTION
## Purpose

The AITER MXFP8 MoE kernel returns the final output tensor, but `AiterMxfp8Experts.apply()` always copies that result into the output tensor allocated by the modular MoE runner. This adds one device-to-device BF16 copy per MoE layer.

This change follows the existing generic AITER MoE behavior:

- adopt the AITER result storage when the caller output is owning and both tensors have matching shape, dtype, device, and contiguous layout;
- preserve the existing copy behavior for views, non-contiguous tensors, or incompatible layouts.

The runtime path is limited to ROCm with the AITER MXFP8 MoE backend on MX-capable hardware. CUDA, Triton, and non-AITER MoE paths are unchanged.