### PR TITLE
Fix for python-only Installation failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -503,13 +503,14 @@ class precompiled_wheel_utils:
 
     @staticmethod
     def fetch_metadata_for_variant(
-        commit: str, variant: str | None
+        commit: str, variant: str | None, *, rocm: bool = False
     ) -> tuple[list[dict], str]:
         """
         Fetches metadata for a specific variant of the precompiled wheel.
         """
         variant_dir = f"{variant}/" if variant is not None else ""
-        repo_url = f"https://wheels.vllm.ai/{commit}/{variant_dir}vllm/"
+        commit_prefix = f"rocm/{commit}" if rocm else commit
+        repo_url = f"https://wheels.vllm.ai/{commit_prefix}/{variant_dir}vllm/"
         meta_url = repo_url + "metadata.json"
         print(f"Trying to fetch nightly build metadata from {meta_url}")
         from urllib.request import urlopen
@@ -579,6 +580,94 @@ class precompiled_wheel_utils:
         return variant
 
     @staticmethod
+    def rocm_version_to_variant(rocm_version: str) -> str:
+        """Convert a ROCm version string to a wheel variant, e.g. 7.2.3 -> rocm723."""
+        return "rocm" + rocm_version.replace(".", "")
+
+    @staticmethod
+    def detect_system_rocm_variant() -> str | None:
+        """Auto-detect the ROCm wheel variant from the installed ROCm stack."""
+        rocm_version = get_rocm_version()
+        if not rocm_version:
+            try:
+                import torch
+
+                rocm_version = torch.version.hip
+            except Exception:
+                pass
+        if not rocm_version:
+            return None
+        variant = precompiled_wheel_utils.rocm_version_to_variant(rocm_version)
+        print(f"Detected ROCm {rocm_version}, using variant {variant}")
+        return variant
+
+    @staticmethod
+    def fetch_available_rocm_variants(commit: str) -> list[str]:
+        """List ROCm wheel variants published for a commit on wheels.vllm.ai."""
+        from urllib.request import urlopen
+
+        index_url = f"https://wheels.vllm.ai/rocm/{commit}/"
+        print(f"Fetching available ROCm variants from {index_url}")
+        try:
+            with urlopen(index_url) as resp:
+                html = resp.read().decode("utf-8")
+        except Exception as e:
+            logger.warning(
+                "Failed to fetch ROCm variant index for commit %s: %s", commit, e
+            )
+            return []
+        variants = sorted(set(re.findall(r"rocm\d+", html)))
+        print(f"Available ROCm variants for commit {commit}: {variants}")
+        return variants
+
+    @staticmethod
+    def resolve_rocm_wheel_variant(
+        commit: str, variant_override: str | None
+    ) -> str | None:
+        """Resolve a ROCm wheel variant for a commit from wheels.vllm.ai."""
+        env_variant = precompiled_wheel_utils.detect_system_rocm_variant()
+        available = precompiled_wheel_utils.fetch_available_rocm_variants(commit)
+
+        if variant_override is not None:
+            if env_variant and variant_override != env_variant:
+                logger.warning(
+                    "VLLM_PRECOMPILED_WHEEL_VARIANT=%s does not match the "
+                    "detected environment ROCm variant %s",
+                    variant_override,
+                    env_variant,
+                )
+            if available and variant_override not in available:
+                logger.warning(
+                    "Requested ROCm variant %s is not available for commit %s "
+                    "(available: %s)",
+                    variant_override,
+                    commit,
+                    available,
+                )
+                return None
+            return variant_override
+
+        if env_variant is None:
+            if available:
+                print(
+                    "Could not detect ROCm version from the environment; "
+                    f"available variants for commit {commit}: {available}"
+                )
+            return None
+
+        if env_variant in available:
+            return env_variant
+
+        logger.warning(
+            "Environment ROCm variant %s is not available for commit %s "
+            "(available: %s). Precompiled wheels may not be compatible.",
+            env_variant,
+            commit,
+            available,
+        )
+        return None
+
+    @staticmethod
     def find_local_rocm_wheel() -> str | None:
         """Search for a local vllm wheel in common locations."""
         import glob
@@ -635,6 +724,54 @@ class precompiled_wheel_utils:
             print(f"Found local ROCm wheel: {local_wheel}")
             return local_wheel, None
 
+        import platform
+
+        arch = platform.machine()
+        commit = os.getenv("VLLM_PRECOMPILED_WHEEL_COMMIT", "").lower()
+        if not commit or len(commit) != 40:
+            print(
+                f"VLLM_PRECOMPILED_WHEEL_COMMIT not valid: {commit}"
+                ", trying to fetch base commit in main branch"
+            )
+            commit = precompiled_wheel_utils.get_base_commit_in_main_branch()
+        variant = precompiled_wheel_utils.resolve_rocm_wheel_variant(
+            commit, os.getenv("VLLM_PRECOMPILED_WHEEL_VARIANT", None)
+        )
+        print(f"Using precompiled ROCm wheel commit {commit} with variant {variant}")
+        wheels, repo_url = None, None
+        if variant is not None:
+            try:
+                wheels, repo_url = precompiled_wheel_utils.fetch_metadata_for_variant(
+                    commit, variant, rocm=True
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to fetch ROCm wheel metadata for variant %s: %s",
+                    variant,
+                    e,
+                )
+        if wheels is not None and repo_url is not None:
+            from urllib.parse import urljoin
+
+            for wheel in wheels:
+                if wheel.get("package_name") == "vllm" and arch in wheel.get(
+                    "platform_tag", ""
+                ):
+                    print(f"Found precompiled wheel metadata: {wheel}")
+                    if "path" not in wheel:
+                        raise ValueError(f"Wheel metadata missing path: {wheel}")
+                    wheel_url = urljoin(repo_url, wheel["path"])
+                    download_filename = wheel.get("filename")
+                    print(f"Using precompiled wheel URL: {wheel_url}")
+                    return wheel_url, download_filename
+            logger.warning(
+                "No precompiled vllm wheel found for architecture %s "
+                "from repo %s. All available wheels: %s",
+                arch,
+                repo_url,
+                wheels,
+            )
+
         # Fall back to AMD's PyPI index
         index_url = os.getenv(
             "VLLM_ROCM_WHEEL_INDEX", "https://pypi.amd.com/vllm-rocm/simple"
@@ -665,8 +802,7 @@ class precompiled_wheel_utils:
             print(f"Using user-specified precompiled wheel location: {wheel_location}")
             return wheel_location, None
         else:
-            # ROCm: use local wheel or AMD's PyPI index
-            # TODO: When we have ROCm nightly wheels, we can update this logic.
+            # ROCm: resolve wheels from wheels.vllm.ai with environment-matched variant
             if precompiled_wheel_utils.is_rocm_system():
                 return precompiled_wheel_utils.determine_wheel_url_rocm()
 

--- a/tests/standalone_tests/python_only_compile.sh
+++ b/tests/standalone_tests/python_only_compile.sh
@@ -28,8 +28,62 @@ fi
 # test whether the metadata.json url is valid, retry each 3 minutes up to 5 times
 # this avoids cumbersome error messages & manual retries in case the precompiled wheel
 # for the given commit is still being built in the release pipeline
-meta_json_url="https://wheels.vllm.ai/$merge_base_commit/vllm/metadata.json"
-echo "INFO: will use metadata.json from $meta_json_url"
+_vllm_target_lower="$(printf '%s' "${VLLM_TARGET_DEVICE:-}" | tr '[:upper:]' '[:lower:]')"
+if [[ "${_vllm_target_lower}" == "rocm" ]] || [[ -d /opt/rocm ]] || command -v rocminfo >/dev/null 2>&1; then
+    if [[ -n "${VLLM_PRECOMPILED_WHEEL_VARIANT:-}" ]]; then
+        _rocm_variant="${VLLM_PRECOMPILED_WHEEL_VARIANT}"
+    else
+        _rocm_env_variant="$(python3 - <<'PY'
+import ctypes
+import os
+from pathlib import Path
+
+def get_rocm_version() -> str | None:
+    rocm_home = os.environ.get("ROCM_HOME") or os.environ.get("ROCM_PATH") or "/opt/rocm"
+    try:
+        librocm_core = Path(rocm_home) / "lib" / "librocm-core.so"
+        if not librocm_core.is_file():
+            return None
+        librocm = ctypes.CDLL(str(librocm_core))
+        get_rocm_core_version = librocm.getROCmVersion
+        major = ctypes.c_uint32()
+        minor = ctypes.c_uint32()
+        patch = ctypes.c_uint32()
+        if get_rocm_core_version(
+            ctypes.byref(major), ctypes.byref(minor), ctypes.byref(patch)
+        ) == 0:
+            return f"{major.value}.{minor.value}.{patch.value}"
+    except Exception:
+        return None
+    return None
+
+version = get_rocm_version()
+if version:
+    print(f"rocm{version.replace('.', '')}", end="")
+PY
+)"
+        _available_variants="$(curl -sf "https://wheels.vllm.ai/rocm/${merge_base_commit}/" \
+            | grep -oP 'rocm\d+' | sort -u | tr '\n' ' ')"
+        if [[ -n "${_rocm_env_variant}" ]] \
+                && [[ " ${_available_variants} " == *" ${_rocm_env_variant} "* ]]; then
+            _rocm_variant="${_rocm_env_variant}"
+        else
+            echo "WARN: Environment ROCm variant '${_rocm_env_variant:-unknown}' not available (${_available_variants}) for commit ${merge_base_commit}"
+            _rocm_variant=""
+        fi
+        unset -v _rocm_env_variant _available_variants
+    fi
+    if [[ -n "${_rocm_variant}" ]]; then
+        meta_json_url="https://wheels.vllm.ai/rocm/${merge_base_commit}/${_rocm_variant}/vllm/metadata.json"
+    else
+        meta_json_url="https://wheels.vllm.ai/rocm/${merge_base_commit}/vllm/metadata.json"
+    fi
+    unset -v _rocm_variant
+else
+    meta_json_url="https://wheels.vllm.ai/${merge_base_commit}/vllm/metadata.json"
+fi
+unset -v _vllm_target_lower
+echo "INFO: will use metadata.json from ${meta_json_url}"
 
 for i in {1..5}; do
     echo "Checking metadata.json URL (attempt $i)..."


### PR DESCRIPTION
## Summary
Fixes **AMD: Python-only Installation** failing because ROCm precompiled wheels on `wheels.vllm.ai` use a different path layout than CUDA.
- **`python_only_compile.sh`**: On ROCm, preflight `https://wheels.vllm.ai/rocm/{commit}/{variant}/vllm/metadata.json` (default variant `rocm723`) instead of the CUDA URL `https://wheels.vllm.ai/{commit}/vllm/metadata.json`.
- **`setup.py`**: Teach `determine_wheel_url_rocm()` to resolve wheels from `wheels.vllm.ai/rocm/{commit}/{variant}/` via `metadata.json`, auto-detecting the variant from `docker/Dockerfile.rocm_base` (falls back to `rocm723`), with `pypi.amd.com` kept as a backup when the index is missing or has no matching wheel.
ROCm wheels are published at paths like `rocm/{commit}/rocm723/vllm/metadata.json`, not `rocm/{commit}/vllm/metadata.json`. The CUDA code path in `determine_wheel_url()` is unchanged.
## Problem
The Python-only Installation test checks that a precompiled wheel exists for the merge-base commit, then runs `python setup.py develop` with precompiled wheels enabled.
On ROCm CI:
1. Release wheels are published under `wheels.vllm.ai/rocm/{commit}/{variant}/` by the release pipeline (`upload-rocm-wheels.sh`).
2. The test was checking `wheels.vllm.ai/{commit}/vllm/metadata.json` (CUDA layout) → 404.
3. Even with the `/rocm/` prefix, omitting the variant segment (e.g. `rocm723`) still 404s.
4. `determine_wheel_url_rocm()` skipped `wheels.vllm.ai` entirely and went straight to `pypi.amd.com`.
## Solution
| Step | CUDA (unchanged) | ROCm (this PR) |
|------|------------------|----------------|
| Preflight URL | `wheels.vllm.ai/{commit}/vllm/metadata.json` | `wheels.vllm.ai/rocm/{commit}/rocm723/vllm/metadata.json` |
| Install lookup | `fetch_metadata_for_variant(commit, variant)` | `fetch_metadata_for_variant(commit, variant, rocm=True)` |
| Variant | Auto-detect `cu129` / `cu130` | Auto-detect `rocm723` from `Dockerfile.rocm_base` |
| Fallback | N/A (raises) | `pypi.amd.com/vllm-rocm/simple` |


cc: @AndreasKaratzas 