### PR TITLE
[DO NOT REVIEW][Kernel][Helion] Retune SiLU FP8 schedules on H100

### DIFF
--- a/vllm/kernels/helion/configs/silu_mul_fp8/nvidia_h100.json
+++ b/vllm/kernels/helion/configs/silu_mul_fp8/nvidia_h100.json
@@ -6,8 +6,8 @@
     },
     "config": {
       "block_sizes": [
-        64,
-        32
+        1,
+        512
       ],
       "loop_orders": [
         [
@@ -16,7 +16,7 @@
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
         1
@@ -36,16 +36,16 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
+        "last",
         ""
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 3,
       "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     }
@@ -57,8 +57,8 @@
     },
     "config": {
       "block_sizes": [
-        256,
-        32
+        1,
+        4096
       ],
       "loop_orders": [
         [
@@ -70,7 +70,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -86,17 +86,17 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 8,
-      "num_stages": 1,
+      "num_stages": 7,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     }
@@ -156,8 +156,8 @@
     },
     "config": {
       "block_sizes": [
-        256,
-        64
+        1,
+        8192
       ],
       "loop_orders": [
         [
@@ -166,10 +166,10 @@
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
-        1
+        4
       ],
       "range_unroll_factors": [
         0
@@ -185,15 +185,15 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
+        "first",
+        "last",
         ""
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 16,
+      "num_stages": 6,
       "indexing": [
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
         "pointer"
       ],
@@ -208,7 +208,7 @@
     "config": {
       "block_sizes": [
         8,
-        4096
+        256
       ],
       "loop_orders": [
         [
@@ -237,14 +237,14 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
-        ""
+        "last",
+        "first"
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 3,
       "indexing": [
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer"
       ],
@@ -258,8 +258,8 @@
     },
     "config": {
       "block_sizes": [
-        64,
-        32
+        1,
+        4096
       ],
       "loop_orders": [
         [
@@ -271,7 +271,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        16
       ],
       "range_unroll_factors": [
         0
@@ -287,15 +287,15 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
+        "last",
+        "first",
         ""
       ],
       "num_warps": 2,
-      "num_stages": 1,
+      "num_stages": 3,
       "indexing": [
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer"
       ],
@@ -1482,8 +1482,8 @@
     },
     "config": {
       "block_sizes": [
-        2,
-        1024
+        1,
+        8192
       ],
       "loop_orders": [
         [
@@ -1492,10 +1492,10 @@
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
-        16
+        4
       ],
       "range_unroll_factors": [
         0
@@ -1515,12 +1515,12 @@
         "last",
         ""
       ],
-      "num_warps": 1,
-      "num_stages": 8,
+      "num_warps": 16,
+      "num_stages": 6,
       "indexing": [
         "tensor_descriptor",
-        "pointer",
         "tensor_descriptor",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -2349,7 +2349,7 @@
     },
     "config": {
       "block_sizes": [
-        4,
+        1,
         4096
       ],
       "loop_orders": [
@@ -2362,7 +2362,58 @@
         true
       ],
       "l2_groupings": [
-        16
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate": 8192,
+      "numtokens": 32
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
       ],
       "range_unroll_factors": [
         0
@@ -2382,64 +2433,13 @@
         "last",
         ""
       ],
-      "num_warps": 32,
-      "num_stages": 5,
+      "num_warps": 16,
+      "num_stages": 6,
       "indexing": [
-        "pointer",
+        "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
         "pointer"
-      ],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "intermediate": 8192,
-      "numtokens": 32
-    },
-    "config": {
-      "block_sizes": [
-        4,
-        1024
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 3,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
       ],
       "pid_type": "flat"
     }
@@ -3473,8 +3473,8 @@
     },
     "config": {
       "block_sizes": [
-        64,
-        32
+        1,
+        512
       ],
       "loop_orders": [
         [
@@ -3483,7 +3483,7 @@
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
         1
@@ -3503,16 +3503,16 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
+        "last",
         ""
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 3,
       "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     }
@@ -3575,8 +3575,8 @@
     },
     "config": {
       "block_sizes": [
-        64,
-        32
+        1,
+        4096
       ],
       "loop_orders": [
         [
@@ -3588,7 +3588,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -3604,17 +3604,17 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 8,
-      "num_stages": 1,
+      "num_stages": 7,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     }
@@ -3626,8 +3626,8 @@
     },
     "config": {
       "block_sizes": [
-        64,
-        64
+        1,
+        8192
       ],
       "loop_orders": [
         [
@@ -3636,10 +3636,10 @@
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
-        1
+        4
       ],
       "range_unroll_factors": [
         0
@@ -3655,15 +3655,15 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
+        "first",
+        "last",
         ""
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 16,
+      "num_stages": 6,
       "indexing": [
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
         "pointer"
       ],
@@ -3728,8 +3728,8 @@
     },
     "config": {
       "block_sizes": [
-        16,
-        512
+        8,
+        256
       ],
       "loop_orders": [
         [
@@ -3741,7 +3741,7 @@
         true
       ],
       "l2_groupings": [
-        16
+        1
       ],
       "range_unroll_factors": [
         0
@@ -3758,16 +3758,16 @@
       ],
       "load_eviction_policies": [
         "",
-        "first",
-        ""
+        "last",
+        "first"
       ],
-      "num_warps": 4,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 3,
       "indexing": [
         "pointer",
         "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     }
@@ -5921,8 +5921,8 @@
     },
     "config": {
       "block_sizes": [
-        128,
-        16
+        1,
+        512
       ],
       "loop_orders": [
         [
@@ -5931,7 +5931,7 @@
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
         1
@@ -5951,16 +5951,16 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
+        "last",
         ""
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 3,
       "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     }
@@ -6023,8 +6023,8 @@
     },
     "config": {
       "block_sizes": [
-        128,
-        32
+        1,
+        4096
       ],
       "loop_orders": [
         [
@@ -6036,7 +6036,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -6052,17 +6052,17 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 8,
-      "num_stages": 1,
+      "num_stages": 7,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     }
@@ -6074,8 +6074,8 @@
     },
     "config": {
       "block_sizes": [
-        128,
-        64
+        1,
+        8192
       ],
       "loop_orders": [
         [
@@ -6084,61 +6084,10 @@
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "intermediate": 11008,
-      "numtokens": 128
-    },
-    "config": {
-      "block_sizes": [
-        2,
-        1024
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        64
+        4
       ],
       "range_unroll_factors": [
         0
@@ -6155,13 +6104,64 @@
       ],
       "load_eviction_policies": [
         "first",
-        "",
-        "last"
+        "last",
+        ""
       ],
-      "num_warps": 2,
-      "num_stages": 1,
+      "num_warps": 16,
+      "num_stages": 6,
       "indexing": [
         "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate": 11008,
+      "numtokens": 128
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
         "tensor_descriptor",
         "pointer",
         "pointer"
@@ -6176,8 +6176,8 @@
     },
     "config": {
       "block_sizes": [
-        4,
-        4096
+        8,
+        256
       ],
       "loop_orders": [
         [
@@ -6206,14 +6206,14 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
-        ""
+        "last",
+        "first"
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 3,
       "indexing": [
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer"
       ],
@@ -15409,8 +15409,8 @@
     },
     "config": {
       "block_sizes": [
-        512,
-        16
+        1,
+        512
       ],
       "loop_orders": [
         [
@@ -15419,7 +15419,7 @@
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
         1
@@ -15439,16 +15439,16 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
+        "last",
         ""
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 3,
       "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     }
@@ -15511,8 +15511,8 @@
     },
     "config": {
       "block_sizes": [
-        8,
-        128
+        1,
+        4096
       ],
       "loop_orders": [
         [
@@ -15522,57 +15522,6 @@
       ],
       "flatten_loops": [
         true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        "last"
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "intermediate": 8192,
-      "numtokens": 512
-    },
-    "config": {
-      "block_sizes": [
-        1,
-        2048
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        false
       ],
       "l2_groupings": [
         64
@@ -15591,15 +15540,66 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
+        "last",
+        "last",
         "last"
       ],
-      "num_warps": 4,
-      "num_stages": 4,
+      "num_warps": 8,
+      "num_stages": 7,
       "indexing": [
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate": 8192,
+      "numtokens": 512
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
         "pointer"
       ],
@@ -15623,10 +15623,10 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        1
+        16
       ],
       "range_unroll_factors": [
         0
@@ -15642,17 +15642,17 @@
         null
       ],
       "load_eviction_policies": [
+        "last",
         "first",
-        "",
-        "first"
+        ""
       ],
-      "num_warps": 16,
-      "num_stages": 7,
+      "num_warps": 2,
+      "num_stages": 3,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
         "tensor_descriptor",
         "pointer",
-        "tensor_descriptor"
+        "pointer"
       ],
       "pid_type": "flat"
     }


### PR DESCRIPTION
Reuse the 320-token schedules for selected H100 buckets with lower measured latency.

  - 21 buckets improved
  - 1.46× geomean versus previous configs
  - Per-shape improvement: 1.08–3.03×


## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

