### PR TITLE
[Bugfix] Do not auto-select CUTLASS-based NVFP4 kernels on SM 12x

### DIFF
--- a/tests/kernels/quantization/test_nvfp4_kernel_selection.py
+++ b/tests/kernels/quantization/test_nvfp4_kernel_selection.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for NVFP4 linear kernel auto-selection.
+
+On SM 12x the CUTLASS-based NVFP4 kernels produce incorrect output
+(https://github.com/vllm-project/vllm/issues/48898) and FlashInfer's JIT can
+fail to target consumer 12x CUDA toolchains at engine startup. Auto-selection
+must prefer Marlin there while both kernels remain reachable via an explicit
+``--linear-backend`` opt-in.
+"""
+
+import pytest
+
+import vllm.model_executor.kernels.linear as linear_kernels
+from vllm.model_executor.kernels.linear import init_nvfp4_linear_kernel
+from vllm.model_executor.kernels.linear.nvfp4.cutlass import (
+    CutlassNvFp4LinearKernel,
+)
+from vllm.model_executor.kernels.linear.nvfp4.flashinfer import (
+    FlashInferCuteDslNvFp4LinearKernel,
+    FlashInferCutlassNvFp4LinearKernel,
+)
+from vllm.model_executor.kernels.linear.nvfp4.marlin import (
+    MarlinNvFp4LinearKernel,
+)
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="CUDA-only kernel selection"
+)
+
+
+@pytest.fixture
+def nvfp4_kernels_supported(monkeypatch):
+    """Pretend every CUTLASS/Marlin NVFP4 kernel is supported so selection is
+    decided purely by the priority list and the SM 12x exclusion."""
+
+    def supported(cls, compute_capability=None):
+        return True, None
+
+    def implementable(cls, config):
+        return True, None
+
+    for kernel in (
+        FlashInferCutlassNvFp4LinearKernel,
+        CutlassNvFp4LinearKernel,
+        MarlinNvFp4LinearKernel,
+    ):
+        monkeypatch.setattr(kernel, "is_supported", classmethod(supported))
+        monkeypatch.setattr(kernel, "can_implement", classmethod(implementable))
+    monkeypatch.setattr(
+        FlashInferCuteDslNvFp4LinearKernel,
+        "is_supported",
+        classmethod(lambda cls, compute_capability=None: (False, "requires sm_10x")),
+    )
+
+
+def _set_family(monkeypatch, family: int | None):
+    monkeypatch.setattr(
+        current_platform,
+        "is_device_capability_family",
+        lambda capability, device_id=0: capability == family,
+    )
+
+
+def test_auto_selection_prefers_marlin_on_sm12x(monkeypatch, nvfp4_kernels_supported):
+    _set_family(monkeypatch, 120)
+    kernel = init_nvfp4_linear_kernel()
+    assert isinstance(kernel, MarlinNvFp4LinearKernel)
+
+
+def test_auto_selection_unchanged_off_sm12x(monkeypatch, nvfp4_kernels_supported):
+    _set_family(monkeypatch, 100)
+    kernel = init_nvfp4_linear_kernel()
+    assert isinstance(kernel, FlashInferCutlassNvFp4LinearKernel)
+
+
+def test_explicit_backend_opt_in_preserved_on_sm12x(
+    monkeypatch, nvfp4_kernels_supported
+):
+    """--linear-backend flashinfer_cutlass must still work on SM 12x for
+    debugging and evidence-gathering (as used in #48898)."""
+    _set_family(monkeypatch, 120)
+    monkeypatch.setattr(
+        linear_kernels, "_get_linear_backend", lambda: "flashinfer_cutlass"
+    )
+    kernel = init_nvfp4_linear_kernel()
+    assert isinstance(kernel, FlashInferCutlassNvFp4LinearKernel)

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -937,6 +937,18 @@ def init_nvfp4_linear_kernel(use_a16: bool = False) -> NvFp4LinearKernel:
     platform = current_platform._enum
     possible = list(_POSSIBLE_NVFP4_KERNELS.get(platform, []))
 
+    # The CUTLASS-based NVFP4 kernels produce incorrect output on SM 12x
+    # (https://github.com/vllm-project/vllm/issues/48898), and FlashInfer's
+    # JIT can fail to target consumer 12x CUDA toolchains at engine startup.
+    # Prefer Marlin there; both kernels remain available via an explicit
+    # --linear-backend opt-in.
+    if linear_backend == "auto" and current_platform.is_device_capability_family(120):
+        possible = [
+            k
+            for k in possible
+            if k not in (FlashInferCutlassNvFp4LinearKernel, CutlassNvFp4LinearKernel)
+        ]
+
     # Apply --linear-backend filtering when set.
     if linear_backend != "auto":
         filtered = _filter_kernels_by_backend(linear_backend, possible)


### PR DESCRIPTION
## Purpose

Fixes #48898.

On SM 12x, the NVFP4 linear kernel auto-selection picks `FlashInferCutlassNvFp4LinearKernel`, which fails in two independently documented ways:

1. **Silent incorrect output** (#48898): on 8x RTX 6000D (SM120, CUDA 13.0), the auto-selected kernel produces byte garbage — GSM8K 0.0 and MMMU 0.07, vs 0.8867 / 0.683 with `--linear-backend marlin` (matching the BF16 baseline). The reporter ruled out local JIT compilation as the cause by reproducing with the official prebuilt `flashinfer-jit-cache` cubins. The native `CutlassNvFp4LinearKernel` (next in priority) is also incorrect there (fluent but unrelated output).
2. **Engine death at startup** on consumer 12x toolchains: with a CUDA toolkit < 12.9 (e.g. RTX 5090 laptop + system nvcc 12.8), FlashInfer's JIT raises `RuntimeError: No supported CUDA architectures found for major versions [12].` inside `torch.ops.vllm.flashinfer_mm_fp4` during startup, killing the engine (same swallowed-arch-detection root cause as #42393 / #48956, surfacing through the GEMM path).

`MarlinNvFp4LinearKernel` produces correct output in both settings (#48898's full evals; verified end-to-end on SM120 consumer hardware below).

Change: exclude both CUTLASS-based kernels from **auto-selection** on SM 12x (`is_device_capability_family(120)`), so selection falls through to Marlin. This mirrors the existing `FlashInferB12x` auto-selection exclusion in the same registry. An explicit `--linear-backend flashinfer_cutlass|cutlass` still selects them — preserving the debugging workflow used to gather the evidence in #48898 (guarded by a dedicated test).

Known limitations (intentionally out of scope):
- `VLLM_BATCH_INVARIANT` still forces the CUTLASS backend on 12x (pre-existing behavior; worth a follow-up once the kernels are fixed).
- The underlying kernel incorrectness is an upstream kernel bug (FlashInfer CUTLASS wrapper / native CUTLASS path); this PR fixes the default users get, not the kernels.

## Test Plan

- Unit (no GPU-specific behavior; selection logic only):

```bash
pytest tests/kernels/quantization/test_nvfp4_kernel_selection.py
```

Three cases: SM 12x auto-selection prefers Marlin; non-12x auto-selection unchanged (FlashInferCutlass still wins); explicit `--linear-backend flashinfer_cutlass` opt-in still selects FlashInferCutlass on 12x.

- End-to-end on RTX 5090 Laptop GPU (SM120, 24 GB, system nvcc 12.8): serve a ModelOpt NVFP4 Gemma 4 31B checkpoint (`quant_algo=NVFP4`, group_size 16) with no kernel-related flags, greedy `"What is 15 + 27?"`.

## Test Result

- Unit: the SM 12x case fails on main (FlashInferCutlass selected), passes with the fix; the other two pass on both (no behavior change off 12x, opt-in preserved).
- E2E **main**: `Using FlashInferCutlassNvFp4LinearKernel for NVFP4 GEMM` → engine dies during startup with `RuntimeError: No supported CUDA architectures found for major versions [12].`
- E2E **this branch**: `Using MarlinNvFp4LinearKernel for NVFP4 GEMM` → engine starts, greedy answer `'42'`.
- Accuracy evidence for the garbage mode is in #48898 (GSM8K/MMMU full evals on 8x RTX 6000D; Marlin matches BF16).
- `pre-commit` (ruff check/format, mypy, typos, SPDX, etc.): all hooks pass on both changed files.

---

### AI-Assisted Work Disclosure (per AGENTS.md)

- **Duplicate check:** #48898 has no linked PRs and no assignee (checked immediately before opening); `gh pr list` searches for NVFP4/SM120 selection came back with only unrelated PRs (#47577 targets MoE backend selection, a different layer).
- **AI assistance:** this contribution was prepared with AI assistance (Claude Code). I reviewed every changed line and ran the tests above; the end-to-end before/after verification was performed on my SM120 hardware.
- **Serving impact:** on SM 12x with NVFP4 checkpoints, serving goes from crashing at startup (consumer toolchains) or silently producing garbage (#48898) to correct output via Marlin. Off SM 12x, kernel selection is unchanged. Model evaluation: correctness restoration is documented by #48898's GSM8K/MMMU runs (Marlin = BF16 baseline); this PR makes that verified-correct kernel the default on 12x.
