### PR TITLE
Add pushed-based ZMQ metrics logger support

### DIFF
--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -1,14 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from vllm.v1.core.sched.output import ScheduledEncoderInputStats, SchedulerOutput
-from vllm.v1.engine import EngineCoreOutputs, FinishReason
-
 from dataclasses import fields
 from unittest.mock import MagicMock, patch
+
 import msgspec
 
 from vllm.config import VllmConfig
-from vllm.v1.engine import FinishReason
+from vllm.v1.core.sched.output import ScheduledEncoderInputStats, SchedulerOutput
+from vllm.v1.engine import EngineCoreOutputs, FinishReason
 from vllm.v1.metrics.loggers import StatLoggerManager, ZmqStatLogger
 from vllm.v1.metrics.stats import (
     IterationStats,

--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -2,6 +2,14 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from vllm.v1.core.sched.output import ScheduledEncoderInputStats, SchedulerOutput
 from vllm.v1.engine import EngineCoreOutputs, FinishReason
+
+from dataclasses import fields
+from unittest.mock import MagicMock, patch
+import msgspec
+
+from vllm.config import VllmConfig
+from vllm.v1.engine import FinishReason
+from vllm.v1.metrics.loggers import StatLoggerManager, ZmqStatLogger
 from vllm.v1.metrics.stats import (
     IterationStats,
     PrefillStats,
@@ -9,6 +17,7 @@ from vllm.v1.metrics.stats import (
     RequestStateStats,
     SchedulerIterationDetails,
     SchedulerStats,
+    ZmqMetricsStats,
 )
 from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
 from vllm.v1.utils import compute_iteration_details
@@ -288,3 +297,123 @@ def test_prompt_token_stats_full_external_transfer_recompute():
     assert stats.external_kv_transfer == 999
     assert stats.cached_tokens == 999
     assert stats.total == 1000
+
+
+REQUIRED_ZMQ_METRICS_STATS_FIELDS = {
+    "num_requests_running",
+    "num_requests_waiting",
+    "kv_cache_usage_perc",
+    "cache_config_info",
+    "engine_id",
+}
+
+
+def test_zmq_metrics_stats_encoding_decoding():
+    """Test ZmqMetricsStats encoding and decoding with custom values,
+
+    verifying that the message has all and only the required fields.
+    """
+    stats = ZmqMetricsStats(
+        num_requests_running=5,
+        num_requests_waiting=10,
+        kv_cache_usage_perc=0.75,
+        cache_config_info={"block_size": 16, "num_gpu_blocks": 100},
+        engine_id="engine-0",
+    )
+
+    # Verify dataclass fields match REQUIRED_ZMQ_METRICS_STATS_FIELDS
+    dataclass_field_names = {f.name for f in fields(ZmqMetricsStats)}
+    assert dataclass_field_names == REQUIRED_ZMQ_METRICS_STATS_FIELDS
+
+    # Encode message
+    encoder = msgspec.msgpack.Encoder()
+    payload = encoder.encode(stats)
+
+    # Decode payload into a dict and verify keys
+    decoded_dict = msgspec.msgpack.decode(payload)
+    assert isinstance(decoded_dict, dict)
+    assert set(decoded_dict.keys()) == REQUIRED_ZMQ_METRICS_STATS_FIELDS
+
+    # Verify content
+    assert decoded_dict["num_requests_running"] == 5
+    assert decoded_dict["num_requests_waiting"] == 10
+    assert decoded_dict["kv_cache_usage_perc"] == 0.75
+    assert decoded_dict["cache_config_info"] == {
+        "block_size": 16,
+        "num_gpu_blocks": 100,
+    }
+    assert decoded_dict["engine_id"] == "engine-0"
+
+    # Decode into ZmqMetricsStats dataclass
+    decoded_stats = msgspec.msgpack.decode(payload, type=ZmqMetricsStats)
+    assert decoded_stats == stats
+
+
+def test_zmq_metrics_stats_defaults_encoding_decoding():
+    """Test default ZmqMetricsStats encoding and decoding."""
+    stats = ZmqMetricsStats()
+
+    encoder = msgspec.msgpack.Encoder()
+    payload = encoder.encode(stats)
+
+    decoded_dict = msgspec.msgpack.decode(payload)
+    assert set(decoded_dict.keys()) == REQUIRED_ZMQ_METRICS_STATS_FIELDS
+
+    assert decoded_dict["num_requests_running"] == 0
+    assert decoded_dict["num_requests_waiting"] == 0
+    assert decoded_dict["kv_cache_usage_perc"] == 0.0
+    assert decoded_dict["cache_config_info"] is None
+    assert decoded_dict["engine_id"] is None
+
+    decoded_stats = msgspec.msgpack.decode(payload, type=ZmqMetricsStats)
+    assert decoded_stats == stats
+
+
+def test_zmq_stat_logger_record():
+    """Test ZmqStatLogger record method for single engine."""
+    vllm_config = MagicMock(spec=VllmConfig)
+    vllm_config.cache_config = None
+    vllm_config.observability_config.zmq_metrics_port = 5555
+
+    with patch("zmq.Context.instance"):
+        logger_inst = ZmqStatLogger(vllm_config, engine_indexes=[0])
+        sched_stats = SchedulerStats(
+            num_running_reqs=3,
+            num_waiting_reqs=7,
+            kv_cache_usage=0.42,
+        )
+        logger_inst.record(
+            scheduler_stats=sched_stats, iteration_stats=None, engine_idx=0
+        )
+
+        msg = logger_inst.queue.get_nowait()
+        assert msg is not None
+        assert msg.num_requests_running == 3
+        assert msg.num_requests_waiting == 7
+        assert msg.kv_cache_usage_perc == 0.42
+        assert msg.engine_id == "0"
+        logger_inst.shutdown()
+
+
+def test_stat_logger_manager_multi_engine_disables_zmq(caplog):
+    """Test StatLoggerManager disables ZmqStatLogger when engine_idxs > 1."""
+    vllm_config = MagicMock(spec=VllmConfig)
+    vllm_config.observability_config.enable_zmq_metrics = True
+    vllm_config.kv_transfer_config = None
+    vllm_config.speculative_config = None
+    vllm_config.model_config.served_model_name = "test-model"
+    vllm_config.model_config.max_model_len = 100
+    vllm_config.model_config.is_diffusion = False
+
+    mgr = StatLoggerManager(
+        vllm_config=vllm_config,
+        engine_idxs=[0, 1],
+        enable_default_loggers=False,
+    )
+    assert not any(
+        isinstance(logger_item, ZmqStatLogger) for logger_item in mgr.stat_loggers
+    )
+    assert (
+        "disabling it as ZMQ metrics logger only supports a single engine"
+        in caplog.text
+    )

--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -373,10 +373,15 @@ def test_zmq_stat_logger_record():
     """Test ZmqStatLogger record method for single engine."""
     vllm_config = MagicMock(spec=VllmConfig)
     vllm_config.cache_config = None
-    vllm_config.observability_config.zmq_metrics_port = 5555
+    vllm_config.observability_config.zmq_metrics_endpoint = "tcp://*:5555"
 
-    with patch("zmq.Context.instance"):
+    with patch("zmq.Context.instance") as mock_ctx_inst:
+        mock_socket = MagicMock()
+        mock_ctx_inst.return_value.socket.return_value = mock_socket
+
         logger_inst = ZmqStatLogger(vllm_config, engine_indexes=[0])
+        mock_socket.bind.assert_called_once_with("tcp://*:5555")
+
         sched_stats = SchedulerStats(
             num_running_reqs=3,
             num_waiting_reqs=7,
@@ -392,6 +397,16 @@ def test_zmq_stat_logger_record():
         assert msg.num_requests_waiting == 7
         assert msg.kv_cache_usage_perc == 0.42
         assert msg.engine_id == "0"
+        logger_inst.shutdown()
+
+    # Test connect mode
+    vllm_config.observability_config.zmq_metrics_endpoint = "tcp://127.0.0.1:5555"
+    with patch("zmq.Context.instance") as mock_ctx_inst:
+        mock_socket = MagicMock()
+        mock_ctx_inst.return_value.socket.return_value = mock_socket
+
+        logger_inst = ZmqStatLogger(vllm_config, engine_indexes=[0])
+        mock_socket.connect.assert_called_once_with("tcp://127.0.0.1:5555")
         logger_inst.shutdown()
 
 

--- a/vllm/config/observability.py
+++ b/vllm/config/observability.py
@@ -83,6 +83,12 @@ class ObservabilityConfig:
     """Log every monitored JIT compile with runtime details. This can emit many
     logs and add overhead, so it is intended for debugging."""
 
+    enable_zmq_metrics: bool = False
+    """Enable publishing metrics via ZMQ."""
+
+    zmq_metrics_port: int = 5556
+    """Port to bind the ZMQ PUB socket to."""
+
     @cached_property
     def collect_model_forward_time(self) -> bool:
         """Whether to collect model forward time for the request."""

--- a/vllm/config/observability.py
+++ b/vllm/config/observability.py
@@ -86,8 +86,8 @@ class ObservabilityConfig:
     enable_zmq_metrics: bool = False
     """Enable publishing metrics via ZMQ."""
 
-    zmq_metrics_port: int = 5556
-    """Port to bind the ZMQ PUB socket to."""
+    zmq_metrics_endpoint: str = "tcp://*:5556"
+    """Endpoint to bind/connect the ZMQ PUB socket to."""
 
     @cached_property
     def collect_model_forward_time(self) -> bool:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -653,6 +653,8 @@ class EngineArgs:
     jit_monitor_mode: Literal["warn", "error"] = ObservabilityConfig.jit_monitor_mode
     jit_monitor_verbose: bool = ObservabilityConfig.jit_monitor_verbose
     enable_mm_processor_stats: bool = ObservabilityConfig.enable_mm_processor_stats
+    enable_zmq_metrics: bool = ObservabilityConfig.enable_zmq_metrics
+    zmq_metrics_port: int = ObservabilityConfig.zmq_metrics_port
     scheduling_policy: SchedulerPolicy = SchedulerConfig.policy
     scheduler_cls: str | type[object] | None = SchedulerConfig.scheduler_cls
 
@@ -1437,6 +1439,14 @@ class EngineArgs:
             "--jit-monitor-verbose",
             **observability_kwargs["jit_monitor_verbose"],
         )
+        observability_group.add_argument(
+            "--enable-zmq-metrics",
+            **observability_kwargs["enable_zmq_metrics"],
+        )
+        observability_group.add_argument(
+            "--zmq-metrics-port",
+            **observability_kwargs["zmq_metrics_port"],
+        )
 
         # Scheduler arguments
         scheduler_kwargs = get_kwargs(SchedulerConfig)
@@ -1861,6 +1871,8 @@ class EngineArgs:
             enable_logging_iteration_details=self.enable_logging_iteration_details,
             jit_monitor_mode=self.jit_monitor_mode,
             jit_monitor_verbose=self.jit_monitor_verbose,
+            enable_zmq_metrics=self.enable_zmq_metrics,
+            zmq_metrics_port=self.zmq_metrics_port,
         )
 
     def create_engine_config(

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -654,7 +654,7 @@ class EngineArgs:
     jit_monitor_verbose: bool = ObservabilityConfig.jit_monitor_verbose
     enable_mm_processor_stats: bool = ObservabilityConfig.enable_mm_processor_stats
     enable_zmq_metrics: bool = ObservabilityConfig.enable_zmq_metrics
-    zmq_metrics_port: int = ObservabilityConfig.zmq_metrics_port
+    zmq_metrics_endpoint: str = ObservabilityConfig.zmq_metrics_endpoint
     scheduling_policy: SchedulerPolicy = SchedulerConfig.policy
     scheduler_cls: str | type[object] | None = SchedulerConfig.scheduler_cls
 
@@ -1444,8 +1444,8 @@ class EngineArgs:
             **observability_kwargs["enable_zmq_metrics"],
         )
         observability_group.add_argument(
-            "--zmq-metrics-port",
-            **observability_kwargs["zmq_metrics_port"],
+            "--zmq-metrics-endpoint",
+            **observability_kwargs["zmq_metrics_endpoint"],
         )
 
         # Scheduler arguments
@@ -1872,7 +1872,7 @@ class EngineArgs:
             jit_monitor_mode=self.jit_monitor_mode,
             jit_monitor_verbose=self.jit_monitor_verbose,
             enable_zmq_metrics=self.enable_zmq_metrics,
-            zmq_metrics_port=self.zmq_metrics_port,
+            zmq_metrics_endpoint=self.zmq_metrics_endpoint,
         )
 
     def create_engine_config(

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -261,6 +261,7 @@ class AsyncLLM(EngineClient):
         """Shutdown, cleaning up the background proc and IPC."""
         if logger_manager := getattr(self, "logger_manager", None):
             logger_manager.shutdown()
+            self.logger_manager = None
 
         shutdown_prometheus()
 

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -259,6 +259,9 @@ class AsyncLLM(EngineClient):
 
     def shutdown(self, timeout: float | None = None) -> None:
         """Shutdown, cleaning up the background proc and IPC."""
+        if logger_manager := getattr(self, "logger_manager", None):
+            logger_manager.shutdown()
+
         shutdown_prometheus()
 
         if renderer := getattr(self, "renderer", None):

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -442,7 +442,15 @@ class LLMEngine:
             if isinstance(module, TorchCompileWithNoGuardsWrapper):
                 module.cleanup()
 
-    def __del__(self):
+    def shutdown(self):
+        if self.logger_manager is not None:
+            self.logger_manager.shutdown()
+            self.logger_manager = None
+
         dp_group = getattr(self, "dp_group", None)
         if dp_group is not None and not self.external_launcher_dp:
             stateless_destroy_torch_distributed_process_group(dp_group)
+            self.dp_group = None
+
+    def __del__(self):
+        self.shutdown()

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -443,8 +443,8 @@ class LLMEngine:
                 module.cleanup()
 
     def shutdown(self):
-        if self.logger_manager is not None:
-            self.logger_manager.shutdown()
+        if logger_manager := getattr(self, "logger_manager", None):
+            logger_manager.shutdown()
             self.logger_manager = None
 
         dp_group = getattr(self, "dp_group", None)

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -2,10 +2,15 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import logging
+import queue
+import threading
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable
+from typing import Any
 
+import msgspec
+import zmq
 from prometheus_client import Counter, Gauge, Histogram
 
 import vllm.envs as envs
@@ -26,6 +31,7 @@ from vllm.v1.metrics.stats import (
     MultiModalCacheStats,
     PromptTokenStats,
     SchedulerStats,
+    ZmqMetricsStats,
 )
 from vllm.v1.metrics.utils import create_metric_per_engine
 from vllm.v1.spec_decode.metrics import SpecDecodingLogging, SpecDecodingProm
@@ -68,6 +74,9 @@ class StatLoggerBase(ABC):
         pass
 
     def record_sleep_state(self, is_awake: int, level: int):  # noqa
+        pass
+
+    def shutdown(self):  # noqa
         pass
 
 
@@ -1308,6 +1317,132 @@ def build_1_2_5_buckets(max_value: int) -> list[int]:
     return build_buckets([1, 2, 5], max_value)
 
 
+class ZmqStatLogger(AggregateStatLoggerBase):
+    SHUTDOWN_TIMEOUT: float = 1.0
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        engine_indexes: list[int],
+    ):
+        self.vllm_config = vllm_config
+        self.engine_indexes = engine_indexes
+        self.last_scheduler_stats_dict: dict[int, SchedulerStats] = {
+            idx: SchedulerStats() for idx in self.engine_indexes
+        }
+        self.cache_config_info: dict[str, Any] | None = None
+        if vllm_config.cache_config is not None:
+            self.cache_config_info = vllm_config.cache_config.metrics_info()
+
+        self.queue: queue.Queue[ZmqMetricsStats | None] = queue.Queue()
+        self.running = True
+
+        # ZMQ setup
+        self._ctx = zmq.Context.instance()
+        self._pub = self._ctx.socket(zmq.PUB)
+
+        port = vllm_config.observability_config.zmq_metrics_port
+        endpoint = f"tcp://*:{port}"
+        logger.info("Binding ZMQ metrics publisher to %s", endpoint)
+        self._pub.bind(endpoint)
+
+        self._thread = threading.Thread(
+            target=self._publisher_thread,
+            daemon=True,
+            name="zmq-metrics-publisher",
+        )
+        self._thread.start()
+
+    def record(
+        self,
+        scheduler_stats: SchedulerStats | None,
+        iteration_stats: IterationStats | None,
+        mm_cache_stats: MultiModalCacheStats | None = None,
+        engine_idx: int = 0,
+    ):
+        if not self.running:
+            return
+
+        if scheduler_stats is not None:
+            self.last_scheduler_stats_dict[engine_idx] = scheduler_stats
+
+        num_running = sum(
+            s.num_running_reqs for s in self.last_scheduler_stats_dict.values()
+        )
+        num_waiting = sum(
+            s.num_waiting_reqs for s in self.last_scheduler_stats_dict.values()
+        )
+        kv_usage = sum(
+            s.kv_cache_usage for s in self.last_scheduler_stats_dict.values()
+        ) / len(self.engine_indexes)
+
+        msg = ZmqMetricsStats(
+            num_requests_running=num_running,
+            num_requests_waiting=num_waiting,
+            kv_cache_usage_perc=kv_usage,
+            cache_config_info=self.cache_config_info,
+            engine_id=str(engine_idx),
+        )
+        self.queue.put(msg)
+
+    def log_engine_initialized(self):
+        pass
+
+    def _publisher_thread(self) -> None:
+        encoder = msgspec.msgpack.Encoder()
+
+        while self.running:
+            try:
+                msg = self.queue.get()
+                if msg is None:
+                    break
+
+                # Drain the queue to get the latest message
+                latest_msg = msg
+                try:
+                    while True:
+                        next_item = self.queue.get_nowait()
+                        if next_item is None:
+                            return
+                        latest_msg = next_item
+                except queue.Empty:
+                    pass
+
+                payload = encoder.encode(latest_msg)
+                self._pub.send(payload)
+
+            except Exception as e:
+                logger.exception("Error in ZMQ metrics publisher thread: %s", e)
+
+    def shutdown(self):
+        """Stop the publisher thread and clean up resources."""
+        self.running = False
+        self.queue.put_nowait(None)
+
+        start = time.time()
+        pending_items = True
+        while pending_items and (time.time() - start < self.SHUTDOWN_TIMEOUT):
+            pending_items = not self.queue.empty()
+            if pending_items:
+                time.sleep(0.1)
+
+        if pending_items:
+            logger.warning(
+                "Warning: Queue still has %s items after %s seconds timeout",
+                self.queue.qsize(),
+                self.SHUTDOWN_TIMEOUT,
+            )
+
+        if self._thread.is_alive():
+            self._thread.join(timeout=self.SHUTDOWN_TIMEOUT)
+
+        try:
+            if self._pub is not None:
+                self._pub.close(linger=0)
+        except Exception as e:
+            logger.error("Error closing ZMQ socket: %s", e)
+
+
 class StatLoggerManager:
     """
     StatLoggerManager:
@@ -1371,6 +1506,8 @@ class StatLoggerManager:
             self.stat_loggers.append(
                 PrometheusStatLogger(vllm_config, self.engine_indexes)
             )
+        if vllm_config.observability_config.enable_zmq_metrics:
+            self.stat_loggers.append(ZmqStatLogger(vllm_config, self.engine_indexes))
 
     def record(
         self,
@@ -1400,3 +1537,7 @@ class StatLoggerManager:
     def log_engine_initialized(self):
         for agg_logger in self.stat_loggers:
             agg_logger.log_engine_initialized()
+
+    def shutdown(self):
+        for logger in self.stat_loggers:
+            logger.shutdown()

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1327,9 +1327,6 @@ class ZmqStatLogger(AggregateStatLoggerBase):
     ):
         self.vllm_config = vllm_config
         self.engine_indexes = engine_indexes
-        self.last_scheduler_stats_dict: dict[int, SchedulerStats] = {
-            idx: SchedulerStats() for idx in self.engine_indexes
-        }
         self.cache_config_info: dict[str, Any] | None = None
         if vllm_config.cache_config is not None:
             self.cache_config_info = vllm_config.cache_config.metrics_info()
@@ -1360,26 +1357,13 @@ class ZmqStatLogger(AggregateStatLoggerBase):
         mm_cache_stats: MultiModalCacheStats | None = None,
         engine_idx: int = 0,
     ):
-        if not self.running:
+        if not self.running or scheduler_stats is None:
             return
 
-        if scheduler_stats is not None:
-            self.last_scheduler_stats_dict[engine_idx] = scheduler_stats
-
-        num_running = sum(
-            s.num_running_reqs for s in self.last_scheduler_stats_dict.values()
-        )
-        num_waiting = sum(
-            s.num_waiting_reqs for s in self.last_scheduler_stats_dict.values()
-        )
-        kv_usage = sum(
-            s.kv_cache_usage for s in self.last_scheduler_stats_dict.values()
-        ) / len(self.engine_indexes)
-
         msg = ZmqMetricsStats(
-            num_requests_running=num_running,
-            num_requests_waiting=num_waiting,
-            kv_cache_usage_perc=kv_usage,
+            num_requests_running=scheduler_stats.num_running_reqs,
+            num_requests_waiting=scheduler_stats.num_waiting_reqs,
+            kv_cache_usage_perc=scheduler_stats.kv_cache_usage,
             cache_config_info=self.cache_config_info,
             engine_id=str(engine_idx),
         )
@@ -1507,7 +1491,16 @@ class StatLoggerManager:
                 PrometheusStatLogger(vllm_config, self.engine_indexes)
             )
         if vllm_config.observability_config.enable_zmq_metrics:
-            self.stat_loggers.append(ZmqStatLogger(vllm_config, self.engine_indexes))
+            if client_count > 1 or len(self.engine_indexes) > 1:
+                logger.warning(
+                    "ZmqStatLogger created with api_server_count or engine count "
+                    "more than 1; disabling it as ZMQ metrics logger only supports "
+                    "a single engine."
+                )
+            else:
+                self.stat_loggers.append(
+                    ZmqStatLogger(vllm_config, self.engine_indexes)
+                )
 
     def record(
         self,

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1338,10 +1338,18 @@ class ZmqStatLogger(AggregateStatLoggerBase):
         self._ctx = zmq.Context.instance()
         self._pub = self._ctx.socket(zmq.PUB)
 
-        port = vllm_config.observability_config.zmq_metrics_port
-        endpoint = f"tcp://*:{port}"
-        logger.info("Binding ZMQ metrics publisher to %s", endpoint)
-        self._pub.bind(endpoint)
+        endpoint = vllm_config.observability_config.zmq_metrics_endpoint
+        if endpoint and (
+            "*" in endpoint
+            or "::" in endpoint
+            or endpoint.startswith("ipc://")
+            or endpoint.startswith("inproc://")
+        ):
+            logger.info("Binding ZMQ metrics publisher to %s", endpoint)
+            self._pub.bind(endpoint)
+        elif endpoint:
+            logger.info("Connecting ZMQ metrics publisher to %s", endpoint)
+            self._pub.connect(endpoint)
 
         self._thread = threading.Thread(
             target=self._publisher_thread,

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -561,3 +561,14 @@ class LoRARequestStates:
         for lora_name, stats in self.requests.items():
             scheduler_stats.waiting_lora_adapters[lora_name] = len(stats.waiting)
             scheduler_stats.running_lora_adapters[lora_name] = len(stats.running)
+
+
+@dataclass
+class ZmqMetricsStats:
+    """Snapshot of metrics published over ZMQ."""
+
+    num_requests_running: int = 0
+    num_requests_waiting: int = 0
+    kv_cache_usage_perc: float = 0.0
+    cache_config_info: dict[str, Any] | None = None
+    engine_id: str | None = None


### PR DESCRIPTION



## Purpose
Fixes #43643

This PR introduces an optional ZeroMQ (ZMQ) metrics logger (`ZmqStatLogger`) allowing external monitoring systems to subscribe to real-time engine telemetry over a `zmq.PUB` socket. The eventual goal is to provide a lightweight alternative to Prometheus (by calling `/metrics`).

Key Changes:
1. `ZmqStatLogger` & `ZmqMetricsStats`:
    - `ZmqStatLogger` drains a queue and broadcasts `msgspec`-encoded telemetry payloads over a ZMQ PUB socket in a background thread.
    - Publishes running request count, waiting request count, KV cache usage percentage, cache configuration info, and engine ID. This is an incomplete set of fields to showcase the design; more fields will be added in the future.
2. Observability & CLI Configuration:
    - Added `enable_zmq_metrics: bool = False` and `zmq_metrics_port: int = 5556` flags to `ObservabilityConfig`.
3. Engine Shutdown & Lifecycle Management:
    - Added `shutdown()` to `StatLoggerBase`, `StatLoggerManager`, `LLMEngine`, and `AsyncLLM` to cleanly close ZMQ sockets and join background publisher threads during server shutdown.

_Note:_ The current implementation does not support DP yet; it assumes there is only one engine `engine_id=0`.

## Test Plan

A [local standalone script](https://gist.github.com/azamikram/f91f5c329f3e0c698daa2c60e553ebd8) to test out the subscriber side:
```bash
python3 subscribe_zmq_metrics.py --hosts host1:5556 host2:5556
```

## Test Result

We added the subscriber support to `llm-d-router`. The following results are on three H100 nodes (TP=2) serving `Qwen/Qwen3-32B` under a bursty load. The HTTP baseline refers to the existing pull-based mechanism where the router periodically (after 50ms) polls the state from `/metrics`. The ZMQ implementation refers to the proposed push-based design. For HTTP baseline, we tried both Python and the Rust frontend for vLLM.

Latency CDFs
<img width="2525" height="770" alt="image" src="https://github.com/user-attachments/assets/9bcd7718-87a4-42e2-a84e-a8d86c5780ac" />

Throughput and CPU usage
<img width="908" height="645" alt="image" src="https://github.com/user-attachments/assets/ee41e32b-7761-4925-a027-4977a04c6260" />


The key takeaways are that compared to HTTP-Python, push-based ZMQ metric support can:
1. **Reduce Tail Latency:** TTFT P99 improved by 16.20% (from 54.92s to 46.02s) and End-to-End P99 latency improved by 15.18%.
2. **Increase System Throughput:** Overall cluster token throughput rose by 18.44%.
3. **Lower Router Overhead:** Streaming binary msgpack frames over persistent sockets reduced the router CPU consumption by 64.51% and lowered P90 scheduling decision latency by 11.58%.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

