### PR TITLE
[Bugfix][Reasoning] Olmo3: keep literal think tags in streamed content

### DIFF
--- a/tests/reasoning/test_olmo3_reasoning_parser.py
+++ b/tests/reasoning/test_olmo3_reasoning_parser.py
@@ -59,6 +59,20 @@ REASONING_ONLY_END_THINK = {
     "content": "No thoughts!",
 }
 
+# Literal <think>/</think> in content (only the first pair is markup) must not
+# restart the streaming state machine.
+LITERAL_START_THINK_IN_CONTENT = {
+    "output": f"{START_REASONING}realreason{END_REASONING}see {START_REASONING} tag",
+    "reasoning": "realreason",
+    "content": f"see {START_REASONING} tag",
+}
+
+LITERAL_END_THINK_IN_CONTENT = {
+    "output": f"{START_REASONING}realreason{END_REASONING}answer {END_REASONING} tail",
+    "reasoning": "realreason",
+    "content": f"answer {END_REASONING} tail",
+}
+
 TEST_CASES = [
     pytest.param(
         False,  # not streaming
@@ -134,6 +148,26 @@ TEST_CASES = [
         True,  # enable streaming
         REASONING_ONLY_END_THINK,
         id="yes_reasoning_only_end_think_streaming",
+    ),
+    pytest.param(
+        False,  # not streaming
+        LITERAL_START_THINK_IN_CONTENT,
+        id="literal_start_think_in_content",
+    ),
+    pytest.param(
+        True,  # enable streaming
+        LITERAL_START_THINK_IN_CONTENT,
+        id="literal_start_think_in_content_streaming",
+    ),
+    pytest.param(
+        False,  # not streaming
+        LITERAL_END_THINK_IN_CONTENT,
+        id="literal_end_think_in_content",
+    ),
+    pytest.param(
+        True,  # enable streaming
+        LITERAL_END_THINK_IN_CONTENT,
+        id="literal_end_think_in_content_streaming",
     ),
 ]
 

--- a/vllm/reasoning/olmo3_reasoning_parser.py
+++ b/vllm/reasoning/olmo3_reasoning_parser.py
@@ -86,6 +86,12 @@ class Olmo3ReasoningBuffer:
     state: Olmo3ReasoningState = Olmo3ReasoningState.REASONING
 
     def process_buffer(self) -> DeltaMessage | None:
+        if self.state == Olmo3ReasoningState.CONTENT:
+            # Reasoning ended: rest is verbatim content. Re-scanning would let
+            # literal <think>/</think> tags in content restart the state machine.
+            text_buffer, self.buffer = self.buffer, ""
+            return DeltaMessage(content=text_buffer)
+
         start_think_idx = self.buffer.find(self.think_start)
 
         if start_think_idx >= 0:


### PR DESCRIPTION
## Purpose

Olmo3 does not use special tokens for reasoning. It tokenizes `<think>` and `</think>` as normal vocabulary entries, so the model can output them as literal text inside the content. Non-streaming parsing handles this correctly: `extract_reasoning` uses a regex that treats only the first `<think>...</think>` pair as markup, and everything after the first `</think>` is content.

Streaming parsing does not. `Olmo3ReasoningBuffer.process_buffer` scans the buffer for `<think>` and `</think>` on every tick, without checking the current state. So when reasoning is already finished and a literal `<think>` or `</think>` appears in the content, it restarts the state machine. A literal `<think>` switches the state back to reasoning, the following content is emitted as reasoning, and the tag itself is removed. A literal `</think>` is treated as a boundary and also removed. The streaming output then differs from the non-streaming output, and some content is lost or placed in the wrong field.

The fix makes `process_buffer` state aware. Once the parser is in the CONTENT state, it returns the rest of the buffer as content and does not scan again, same as non-streaming.

This is a different problem than #48160, which only drains trailing content after the first real `</think>`. With that fix the literal-tag case is still broken, because the state is flipped before the drain runs.

## Test Plan

`pytest tests/reasoning/test_olmo3_reasoning_parser.py`. Two new cases are added, each run in streaming and non-streaming mode. The first is `<think>realreason</think>see <think> tag` (a literal `<think>` in the content). The second is `<think>realreason</think>answer </think> tail` (a literal `</think>` in the content).

## Test Result

Before the fix, the two streaming cases fail: the content is placed into reasoning and the literal tag is deleted. The non-streaming cases already pass. After the fix, all four pass and streaming matches non-streaming. The rest of the file still passes.

```
Before fix:

FAILED test_olmo3_reasoning_parser.py::test_reasoning[literal_start_think_in_content_streaming]
FAILED test_olmo3_reasoning_parser.py::test_reasoning[literal_end_think_in_content_streaming]
2 failed, 2 passed

After fix:

4 passed
```
