### PR TITLE
[Bugfix][Parser] Ignore trailing text in Mistral v11 tool args

### DIFF
--- a/tests/tool_parsers/test_mistral_tool_parser.py
+++ b/tests/tool_parsers/test_mistral_tool_parser.py
@@ -526,6 +526,24 @@ def test_extract_tool_calls_v11_without_args_skipped(mistral_tool_parser):
     )
 
 
+def test_extract_tool_calls_v11_ignores_trailing_text():
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.get_vocab.return_value = {"[TOOL_CALLS]": 1, "[ARGS]": 2}
+    parser = MistralToolParser(mock_tokenizer)
+
+    result = parser.extract_tool_calls(
+        '[TOOL_CALLS]get_weather{"city":"San Francisco"}Estimating the weather...',
+        request=_DUMMY_REQUEST,
+    )
+
+    assert result.tools_called
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].function.name == "get_weather"
+    assert result.tool_calls[0].function.arguments == json.dumps(
+        {"city": "San Francisco"}
+    )
+
+
 def _test_extract_tool_calls_streaming(
     tool_parser, tokenizer, model_output, tools, expected_tool_calls, expected_content
 ):

--- a/vllm/tool_parsers/mistral_tool_parser.py
+++ b/vllm/tool_parsers/mistral_tool_parser.py
@@ -304,10 +304,14 @@ class MistralToolParser(ToolParser):
                     continue
 
                 end_name = raw_tool_call.find("{")
-                tool_name, args = (
-                    raw_tool_call[:end_name],
-                    raw_tool_call[end_name:],
-                )
+                tool_name = raw_tool_call[:end_name]
+                args = raw_tool_call[end_name:]
+                try:
+                    parsed_args, _ = json.JSONDecoder().raw_decode(args)
+                except json.JSONDecodeError:
+                    pass
+                else:
+                    args = json.dumps(parsed_args, ensure_ascii=False)
 
                 # HF tokenizers may include [ARGS] in the text
                 tool_name = tool_name.replace("[ARGS]", "")


### PR DESCRIPTION
## Purpose

Fixes #48975.

For Mistral tokenizer versions 11 and newer, parse the first complete JSON
value in a tool call's arguments instead of forwarding trailing model text as
part of `function.arguments`. If the arguments are genuinely malformed, retain
the existing fallback behavior and return the attempted tool call unchanged.

This does not duplicate an existing contribution. I searched open and closed
issues and open pull requests for the issue number, Mistral v11 trailing tool
arguments, and the Mistral parser `raw_decode` path; no existing fix covers the
v11+ non-streaming parser.

AI assistance was used to investigate the failure, write the regression test,
and implement the fix. The human submitter reviewed every changed line and can
explain and defend the change.

## Test Plan

- Reproduce the failure with a v11-equivalent mock tokenizer and a completed
  tool call containing valid JSON followed by prose.
- Run the complete Mistral tool parser unit test suite.
- Run all pre-commit hooks on the staged Python files.

## Test Result

- Before the fix, the regression test returned
  `{"city":"San Francisco"}Estimating the weather...` as the arguments and
  failed.
- After the fix, the same response returns `{"city": "San Francisco"}`.
- `.venv/bin/python -m pytest tests/tool_parsers/test_mistral_tool_parser.py -q`
  — 76 passed, 1 unrelated deprecation warning.
- `.venv/bin/pre-commit run` — all applicable hooks passed, including Ruff,
  mypy, typos, SPDX, and repository-specific validation hooks.

Model-serving evaluation before the fix reproduced trailing prose in
`mistralai/Magistral-Small-2509` tool arguments for required tool choice on
A100 and H100, and for auto tool choice on H100. The new unit test uses the
same response shape and verifies that the patched parser returns executable
JSON. A post-change GPU model evaluation was not run locally because no patched
vLLM serving image is available; upstream CI is expected to provide the next
integration validation layer.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including the issue it resolves.
- [x] The test plan and exact commands are included.
- [x] The before-and-after test results and model evaluation evidence are included.
- [x] No documentation update is required for this parser bug fix.
</details>
