### PR TITLE
Fix rocm sync nightly wheels index

### DIFF
--- a/.buildkite/scripts/upload-rocm-wheels.sh
+++ b/.buildkite/scripts/upload-rocm-wheels.sh
@@ -113,10 +113,13 @@ $PYTHON .buildkite/scripts/generate-nightly-index.py \
 echo "Uploading indices to $S3_COMMIT_PREFIX"
 aws s3 cp --recursive "$INDICES_OUTPUT_DIR/" "$S3_COMMIT_PREFIX"
 
-# Only scheduled nightly builds should update the moving nightly index.
-if [[ "${NIGHTLY:-0}" == "1" ]]; then
-    echo "Updating rocm/nightly/ index..."
+UPDATED_ROCM_NIGHTLY=0
+if [[ "${UPDATE_NIGHTLY_INDEX:-1}" == "1" && \
+      "$BUILDKITE_BRANCH" == "main" && \
+      "$BUILDKITE_PULL_REQUEST" == "false" ]]; then
+    echo "Uploading indices to overwrite rocm/nightly/"
     aws s3 cp --recursive "$INDICES_OUTPUT_DIR/" "s3://$BUCKET/rocm/nightly/"
+    UPDATED_ROCM_NIGHTLY=1
 fi
 
 # Extract version from vLLM wheel and update version-specific index
@@ -147,7 +150,7 @@ echo ""
 echo "Install command (by commit):"
 echo "  pip install vllm --extra-index-url https://${BUCKET}.s3.amazonaws.com/$ROCM_SUBPATH/"
 echo ""
-if [[ "${NIGHTLY:-0}" == "1" ]]; then
+if [[ "$UPDATED_ROCM_NIGHTLY" == "1" ]]; then
     echo "Install command (nightly):"
     echo "  pip install vllm --extra-index-url https://${BUCKET}.s3.amazonaws.com/rocm/nightly/"
 fi


### PR DESCRIPTION
## Summary
Syncs the ROCm moving nightly index on `wheels.vllm.ai` to match CUDA behavior: whenever ROCm wheels are uploaded for a **main, non-PR** release build, also refresh `rocm/nightly/`.
- **`upload-rocm-wheels.sh`**: Replace the `NIGHTLY=1`-only gate with the same `UPDATE_NIGHTLY_INDEX` + `main` + non-PR conditions used by CUDA's `generate-and-upload-nightly-index.sh`.
## Problem
When the release pipeline publishes ROCm wheels, it uploads:
- `wheels.vllm.ai/rocm/{commit}/` — wheels and indices for that build
- `wheels.vllm.ai/rocm/nightly/` — a fixed URL that should point at the latest main wheels
CUDA refreshes `/nightly/` on every main non-PR upload. ROCm only updated `rocm/nightly/` when `NIGHTLY=1`, so manually unblocked or non-scheduled main uploads could publish per-commit wheels without moving the nightly pointer.
## Solution
After uploading indices to `rocm/{commit}/`, also copy them to `rocm/nightly/` when:
- `UPDATE_NIGHTLY_INDEX` is not disabled (default: enabled)
- `BUILDKITE_BRANCH == main`
- `BUILDKITE_PULL_REQUEST == false`
This connects per-commit ROCm uploads to the stable nightly install URL:
```bash
pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/nightly/
```
ROCm nightly metadata lives at `rocm/nightly/rocm723/vllm/metadata.json` (variant subdirectory), not `rocm/nightly/vllm/metadata.json` directly.
