### PR TITLE
[Bugfix][Structured Output] Wire whitespace_pattern through V1 backends

### DIFF
--- a/tests/v1/spec_decode/test_mtp_structured_output.py
+++ b/tests/v1/spec_decode/test_mtp_structured_output.py
@@ -288,6 +288,7 @@ def _setup_boundary_request(backend: str):
     structured_req.__dict__["structured_output_key"] = (
         StructuredOutputOptions.STRUCTURAL_TAG,
         "",
+        None,
     )
     manager.reasoner_cls = _MarkerReasoner
     structured_req.reasoner = _MarkerReasoner(marker)

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -227,6 +227,7 @@ class TestReasoningStructuredOutput:
         structured_req.structured_output_key = (
             StructuredOutputOptions.STRUCTURAL_TAG,
             "{}",
+            None,
         )
         reasoner = MockReasoner(tokenizer=Mock())
         reasoner.is_reasoning_end_streaming.return_value = True

--- a/tests/v1/structured_output/test_whitespace_pattern.py
+++ b/tests/v1/structured_output/test_whitespace_pattern.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests that per-request whitespace_pattern is threaded through the V1
+structured output path (regression from V0). See closed PR #34790."""
+
+import outlines_core.json_schema as json_schema
+import pytest
+
+from vllm.sampling_params import StructuredOutputsParams
+from vllm.v1.structured_output.backend_types import StructuredOutputOptions
+from vllm.v1.structured_output.request import get_structured_output_key
+
+pytestmark = pytest.mark.cpu_test
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {"a": {"type": "integer"}},
+    "required": ["a"],
+}
+
+
+def test_whitespace_pattern_makes_key_cache_distinct():
+    p1 = StructuredOutputsParams(json=_SCHEMA, whitespace_pattern=None)
+    p2 = StructuredOutputsParams(json=_SCHEMA, whitespace_pattern=r"[\n ]*")
+
+    k1 = get_structured_output_key(p1)
+    k2 = get_structured_output_key(p2)
+
+    # key is now a 3-tuple carrying whitespace_pattern
+    assert len(k1) == 3
+    assert k1[0] == StructuredOutputOptions.JSON
+    assert k1[2] is None
+    assert k2[2] == r"[\n ]*"
+    # same schema, different whitespace -> distinct cache keys
+    assert k1 != k2
+
+
+def test_whitespace_pattern_changes_outlines_regex():
+    _, spec, ws = get_structured_output_key(
+        StructuredOutputsParams(json=_SCHEMA, whitespace_pattern=r"[\n ]*")
+    )
+    default_regex = json_schema.build_regex_from_schema(spec)
+    custom_regex = json_schema.build_regex_from_schema(
+        spec, whitespace_pattern=ws
+    )
+    assert default_regex != custom_regex
+
+
+def test_non_json_key_has_none_whitespace():
+    key = get_structured_output_key(StructuredOutputsParams(regex="[0-9]+"))
+    assert key == (StructuredOutputOptions.REGEX, "[0-9]+", None)

--- a/vllm/entrypoints/generate/beam_search/offline.py
+++ b/vllm/entrypoints/generate/beam_search/offline.py
@@ -407,14 +407,16 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
         Returns None for beams where the grammar has terminated.
         """
         vocab_size = self.model_config.get_vocab_size()
-        request_type, grammar_spec = structured_output_key
+        request_type, grammar_spec, whitespace_pattern = structured_output_key
         result: list[tuple[SamplingParams, list[int]] | None] = []
 
         for beam in beams:
             # Fresh grammar per beam, replaying generated tokens.
             # Backends don't support cloning grammar state, so
             # replay is needed to reconstruct the FSM position.
-            grammar = backend.compile_grammar(request_type, grammar_spec)
+            grammar = backend.compile_grammar(
+                request_type, grammar_spec, whitespace_pattern
+            )
             assert beam.orig_prompt["type"] != "enc_dec"
             prompt_len = len(beam.orig_prompt["prompt_token_ids"])
             generated_tokens = beam.tokens[prompt_len:]

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -178,10 +178,12 @@ class StructuredOutputManager:
         #
         # TODO: we still need to handle xgrammar compilation failures,
         # though it should be unlikely as we test that up front as well.
-        request_type, grammar_spec = key
+        request_type, grammar_spec, whitespace_pattern = key
 
         assert self.backend is not None
-        return self.backend.compile_grammar(request_type, grammar_spec)
+        return self.backend.compile_grammar(
+            request_type, grammar_spec, whitespace_pattern
+        )
 
     def _fill_bitmasks(
         self, batch: Iterable[tuple[StructuredOutputGrammar, int, bool]]

--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -106,8 +106,16 @@ class GuidanceBackend(StructuredOutputBackend):
             )
 
     def compile_grammar(
-        self, request_type: StructuredOutputOptions, grammar_spec: str
+        self,
+        request_type: StructuredOutputOptions,
+        grammar_spec: str,
+        whitespace_pattern: str | None = None,
     ) -> StructuredOutputGrammar:
+        if whitespace_pattern is not None:
+            logger.warning_once(
+                "whitespace_pattern is only honored by the outlines structured "
+                "outputs backend; it is ignored by the guidance backend."
+            )
         self.serialized_grammar = serialize_guidance_grammar(
             request_type,
             grammar_spec,
@@ -296,7 +304,7 @@ def validate_guidance_grammar(
     # if structured output is not enabled, there is nothing to validate
     if sampling_params.structured_outputs is None:
         return
-    tp, grm = get_structured_output_key(sampling_params.structured_outputs)
+    tp, grm, _ = get_structured_output_key(sampling_params.structured_outputs)
     guidance_grm = serialize_guidance_grammar(tp, grm)
     err = llguidance.LLMatcher.validate_grammar(guidance_grm, tokenizer)
     if err:

--- a/vllm/v1/structured_output/backend_lm_format_enforcer.py
+++ b/vllm/v1/structured_output/backend_lm_format_enforcer.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import torch
 from transformers import PreTrainedTokenizerBase
 
+from vllm.logger import init_logger
 from vllm.sampling_params import SamplingParams
 from vllm.utils.import_utils import LazyLoader
 from vllm.utils.torch_utils import PIN_MEMORY
@@ -18,6 +19,8 @@ from vllm.v1.structured_output.backend_types import (
     StructuredOutputOptions,
 )
 from vllm.v1.structured_output.utils import compile_regex_with_timeout
+
+logger = init_logger(__name__)
 
 if TYPE_CHECKING:
     import lmformatenforcer
@@ -99,8 +102,16 @@ class LMFormatEnforcerBackend(StructuredOutputBackend):
         )
 
     def compile_grammar(
-        self, request_type: StructuredOutputOptions, grammar_spec: str
+        self,
+        request_type: StructuredOutputOptions,
+        grammar_spec: str,
+        whitespace_pattern: str | None = None,
     ) -> StructuredOutputGrammar:
+        if whitespace_pattern is not None:
+            logger.warning_once(
+                "whitespace_pattern is only honored by the outlines structured "
+                "outputs backend; it is ignored by the lm-format-enforcer backend."
+            )
         character_level_parser: lmformatenforcer.CharacterLevelParser
         if request_type == StructuredOutputOptions.JSON:
             spec_dict = json.loads(grammar_spec)

--- a/vllm/v1/structured_output/backend_outlines.py
+++ b/vllm/v1/structured_output/backend_outlines.py
@@ -71,10 +71,18 @@ class OutlinesBackend(StructuredOutputBackend):
         return index
 
     def compile_grammar(
-        self, request_type: StructuredOutputOptions, grammar_spec: str
+        self,
+        request_type: StructuredOutputOptions,
+        grammar_spec: str,
+        whitespace_pattern: str | None = None,
     ) -> StructuredOutputGrammar:
         if request_type == StructuredOutputOptions.JSON:
-            regex = json_schema.build_regex_from_schema(grammar_spec)
+            if whitespace_pattern is not None:
+                regex = json_schema.build_regex_from_schema(
+                    grammar_spec, whitespace_pattern=whitespace_pattern
+                )
+            else:
+                regex = json_schema.build_regex_from_schema(grammar_spec)
         elif request_type == StructuredOutputOptions.REGEX:
             regex = grammar_spec
         elif request_type == StructuredOutputOptions.CHOICE:

--- a/vllm/v1/structured_output/backend_types.py
+++ b/vllm/v1/structured_output/backend_types.py
@@ -25,7 +25,7 @@ class StructuredOutputOptions(enum.Enum):
     STRUCTURAL_TAG = enum.auto()
 
 
-StructuredOutputKey = tuple[StructuredOutputOptions, str]
+StructuredOutputKey = tuple[StructuredOutputOptions, str, str | None]
 
 
 class StructuredOutputGrammar(ABC):
@@ -105,7 +105,10 @@ class StructuredOutputBackend(ABC):
 
     @abstractmethod
     def compile_grammar(
-        self, request_type: StructuredOutputOptions, grammar_spec: str
+        self,
+        request_type: StructuredOutputOptions,
+        grammar_spec: str,
+        whitespace_pattern: str | None = None,
     ) -> StructuredOutputGrammar:
         """
         Compiles a grammar specification into a structured output grammar.
@@ -114,6 +117,9 @@ class StructuredOutputBackend(ABC):
             request_type (StructuredOutputOptions): The type of structured
                 output request.
             grammar_spec (str): The grammar specification to compile.
+            whitespace_pattern (str | None): Optional pattern controlling the
+                whitespace allowed between JSON tokens. Only honored by the
+                outlines backend; other backends emit a warning if it is set.
 
         Returns:
             StructuredOutputGrammar: The compiled structured output grammar.

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -76,8 +76,16 @@ class XgrammarBackend(StructuredOutputBackend):
             )
 
     def compile_grammar(
-        self, request_type: StructuredOutputOptions, grammar_spec: str
+        self,
+        request_type: StructuredOutputOptions,
+        grammar_spec: str,
+        whitespace_pattern: str | None = None,
     ) -> StructuredOutputGrammar:
+        if whitespace_pattern is not None:
+            logger.warning_once(
+                "whitespace_pattern is only honored by the outlines structured "
+                "outputs backend; it is ignored by the xgrammar backend."
+            )
         if request_type == StructuredOutputOptions.JSON:
             ctx = self.compiler.compile_json_schema(
                 grammar_spec, any_whitespace=not self.disable_any_whitespace

--- a/vllm/v1/structured_output/request.py
+++ b/vllm/v1/structured_output/request.py
@@ -86,19 +86,19 @@ def get_structured_output_key(params: StructuredOutputsParams) -> StructuredOutp
             json_str = json.dumps(params.json)
         else:
             json_str = params.json
-        return StructuredOutputOptions.JSON, json_str
+        return StructuredOutputOptions.JSON, json_str, params.whitespace_pattern
     if params.json_object:
-        return StructuredOutputOptions.JSON_OBJECT, ""
+        return StructuredOutputOptions.JSON_OBJECT, "", None
     if params.regex is not None:
-        return StructuredOutputOptions.REGEX, params.regex
+        return StructuredOutputOptions.REGEX, params.regex, None
     if params.choice is not None:
         if not isinstance(params.choice, str):
             json_str = json.dumps(params.choice)
         else:
             json_str = params.choice
-        return StructuredOutputOptions.CHOICE, json_str
+        return StructuredOutputOptions.CHOICE, json_str, None
     if params.grammar is not None:
-        return StructuredOutputOptions.GRAMMAR, params.grammar
+        return StructuredOutputOptions.GRAMMAR, params.grammar, None
     if params.structural_tag is not None:
-        return StructuredOutputOptions.STRUCTURAL_TAG, params.structural_tag
+        return StructuredOutputOptions.STRUCTURAL_TAG, params.structural_tag, None
     raise ValueError("No valid structured output parameter found")


### PR DESCRIPTION
The per-request StructuredOutputsParams.whitespace_pattern field was accepted and documented but silently ignored in the V1 structured-output path (a regression from V0). It never reached any grammar backend.

Thread whitespace_pattern through the structured-output cache key (now a 3-tuple) into compile_grammar, and pass it to
outlines_core build_regex_from_schema for the JSON case. xgrammar, guidance and lm-format-enforcer warn_once that the field is only honored by the outlines backend instead of dropping it silently.

Adds tests/v1/structured_output/test_whitespace_pattern.py.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

