### PR TITLE
[Bugfix] Restore kv_b_proj LoRA in absorbed MLA

### DIFF
--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -12,6 +12,7 @@ from vllm.config import ModelConfig, VllmConfig
 from vllm.config.lora import LoRAConfig
 from vllm.lora.layers import (
     ColumnParallelLinearWithLoRA,
+    ColumnParallelLinearWithShardedLoRA,
     MergedColumnParallelLinearWithLoRA,
     ReplicatedLinearWithLoRA,
     RowParallelLinearWithLoRA,
@@ -28,6 +29,7 @@ from vllm.lora.peft_helper import PEFTHelper
 from vllm.lora.request import LoRARequest
 from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager, WorkerLoRAManager
 from vllm.model_executor.layers.fused_moe import GateLinear
+from vllm.model_executor.layers.linear import ColumnParallelLinear
 from vllm.platforms import current_platform
 
 from .utils import create_peft_lora
@@ -133,6 +135,39 @@ def test_replace_submodules(default_vllm_config, dist_init, dummy_model):
     )
     assert isinstance(model.get_submodule("dense2"), RowParallelLinearWithLoRA)
     assert isinstance(model.get_submodule("layer1.dense2"), RowParallelLinearWithLoRA)
+
+
+def test_mla_kv_b_proj_keeps_replicated_lora_a(
+    default_vllm_config, dist_init, dummy_model
+):
+    model = dummy_model
+    model.add_module("kv_b_proj", ColumnParallelLinear(16, 32))
+    manager = LoRAModelManager(
+        model,
+        1,
+        1,
+        1,
+        LoRAConfig(
+            max_lora_rank=8,
+            max_cpu_loras=1,
+            max_loras=1,
+            lora_dtype=DEFAULT_DTYPE,
+            fully_sharded_loras=True,
+            target_modules=["dense1", "kv_b_proj"],
+        ),
+        torch.device(DEVICES[0]),
+        default_vllm_config,
+    )
+
+    assert isinstance(
+        manager.model.get_submodule("dense1"), ColumnParallelLinearWithShardedLoRA
+    )
+    kv_b_proj = manager.model.get_submodule("kv_b_proj")
+    assert isinstance(kv_b_proj, ColumnParallelLinearWithLoRA)
+    assert not isinstance(
+        kv_b_proj,
+        ColumnParallelLinearWithShardedLoRA,
+    )
 
 
 def test_wrap_replicated_linear_subclasses(default_vllm_config, dist_init, dummy_model):

--- a/tests/lora/test_punica_ops.py
+++ b/tests/lora/test_punica_ops.py
@@ -636,3 +636,136 @@ def test_add_lora_fused_moe_early_exit(device):
     assert torch.equal(y, y_snapshot), (
         "add_lora_fused_moe modified output tensor despite no_lora_flag_cpu=True"
     )
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(), reason="MLA LoRA kernels require CUDA"
+)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_mla_kv_b_lora_correction(dtype):
+    device = DEVICES[0]
+    torch.set_default_device(device)
+    torch.accelerator.set_device_index(device)
+    set_random_seed(0)
+
+    num_tokens = 19
+    num_mqa_tokens = 11
+    num_heads = 3
+    qk_nope_head_dim = 8
+    v_head_dim = 8
+    kv_lora_rank = 16
+    lora_rank = 8
+    num_loras = 2
+    full_head_dim = qk_nope_head_dim + v_head_dim
+
+    token_mapping = torch.tensor(
+        [0, 1, -1, 0, 1, 1, -1, 0, 0, 1, -1, 1, 1, 0, -1, 0, 1, 0, -1],
+        dtype=torch.int32,
+        device=device,
+    )
+    metadata = LoRAKernelMeta.make(num_loras, num_tokens, device)
+    metadata.prepare_tensors(token_mapping)
+    metadata_args = metadata.meta_args(num_tokens, specialize_active_lora=False)
+
+    lora_a = torch.randn(
+        num_loras,
+        1,
+        lora_rank,
+        kv_lora_rank,
+        dtype=dtype,
+        device=device,
+    )
+    lora_b = torch.randn(
+        num_loras,
+        1,
+        num_heads * full_head_dim,
+        lora_rank,
+        dtype=dtype,
+        device=device,
+    )
+    q_nope = torch.randn(
+        num_mqa_tokens,
+        num_heads,
+        qk_nope_head_dim,
+        dtype=dtype,
+        device=device,
+    )
+    latent_output = torch.randn(
+        num_mqa_tokens,
+        num_heads,
+        kv_lora_rank,
+        dtype=dtype,
+        device=device,
+    )
+    q_output = torch.randn_like(latent_output)
+    v_output = torch.randn(
+        num_mqa_tokens,
+        num_heads,
+        v_head_dim,
+        dtype=dtype,
+        device=device,
+    )
+    expected_q = q_output.clone()
+    expected_v = v_output.clone()
+
+    b_by_head = lora_b[:, 0].view(num_loras, num_heads, full_head_dim, lora_rank)
+    for token_idx in range(num_mqa_tokens):
+        lora_id = token_mapping[token_idx].item()
+        if lora_id == -1:
+            continue
+        a = lora_a[lora_id, 0]
+        b_k = b_by_head[lora_id, :, :qk_nope_head_dim]
+        b_v = b_by_head[lora_id, :, qk_nope_head_dim:]
+        expected_q[token_idx] += torch.einsum(
+            "hp,hpr,rl->hl", q_nope[token_idx], b_k, a
+        )
+        expected_v[token_idx] += torch.einsum(
+            "hl,rl,hvr->hv", latent_output[token_idx], a, b_v
+        )
+
+    triton_ops.mla_kv_b_lora_q(
+        q_nope,
+        lora_a,
+        lora_b,
+        q_output,
+        *metadata_args,
+        qk_nope_head_dim,
+        v_head_dim,
+    )
+    triton_ops.mla_kv_b_lora_v(
+        latent_output,
+        lora_a,
+        lora_b,
+        v_output,
+        *metadata_args,
+        qk_nope_head_dim,
+        v_head_dim,
+    )
+
+    torch.testing.assert_close(q_output, expected_q, rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(v_output, expected_v, rtol=3e-2, atol=3e-2)
+
+    metadata.prepare_tensors(torch.full_like(token_mapping, -1))
+    metadata_args = metadata.meta_args(num_tokens, specialize_active_lora=False)
+    q_snapshot = q_output.clone()
+    v_snapshot = v_output.clone()
+    triton_ops.mla_kv_b_lora_q(
+        q_nope,
+        lora_a,
+        lora_b,
+        q_output,
+        *metadata_args,
+        qk_nope_head_dim,
+        v_head_dim,
+    )
+    triton_ops.mla_kv_b_lora_v(
+        latent_output,
+        lora_a,
+        lora_b,
+        v_output,
+        *metadata_args,
+        qk_nope_head_dim,
+        v_head_dim,
+    )
+    torch.testing.assert_close(q_output, q_snapshot)
+    torch.testing.assert_close(v_output, v_snapshot)

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -157,6 +157,76 @@ class ColumnParallelLinearWithLoRA(BaseLinearLayerWithLoRA):
         output_bias = self.base_layer.bias if self.base_layer.skip_bias_add else None
         return output, output_bias
 
+    def apply_mla_kv_b_lora_q(
+        self,
+        q_nope: torch.Tensor,
+        output: torch.Tensor,
+        v_head_dim: int,
+    ) -> None:
+        from vllm.lora.ops.triton_ops.mla_kv_b_lora import (
+            apply_mla_kv_b_lora_native,
+            mla_kv_b_lora_q,
+        )
+
+        metadata = getattr(self.punica_wrapper, "token_mapping_meta", None)
+        if metadata is None:
+            apply_mla_kv_b_lora_native(
+                q_nope,
+                self.lora_a_stacked[0],
+                self.lora_b_stacked[0],
+                output,
+                self.punica_wrapper.token_lora_indices,
+                q_nope.shape[-1],
+                query_side=True,
+            )
+            return
+
+        num_tokens = self.punica_wrapper.token_lora_indices.shape[0]
+        mla_kv_b_lora_q(
+            q_nope,
+            self.lora_a_stacked[0],
+            self.lora_b_stacked[0],
+            output,
+            *metadata.meta_args(num_tokens, self.lora_config.specialize_active_lora),
+            q_nope.shape[-1],
+            v_head_dim,
+        )
+
+    def apply_mla_kv_b_lora_v(
+        self,
+        latent_output: torch.Tensor,
+        output: torch.Tensor,
+        qk_nope_head_dim: int,
+    ) -> None:
+        from vllm.lora.ops.triton_ops.mla_kv_b_lora import (
+            apply_mla_kv_b_lora_native,
+            mla_kv_b_lora_v,
+        )
+
+        metadata = getattr(self.punica_wrapper, "token_mapping_meta", None)
+        if metadata is None:
+            apply_mla_kv_b_lora_native(
+                latent_output,
+                self.lora_a_stacked[0],
+                self.lora_b_stacked[0],
+                output,
+                self.punica_wrapper.token_lora_indices,
+                qk_nope_head_dim,
+                query_side=False,
+            )
+            return
+
+        num_tokens = self.punica_wrapper.token_lora_indices.shape[0]
+        mla_kv_b_lora_v(
+            latent_output,
+            self.lora_a_stacked[0],
+            self.lora_b_stacked[0],
+            output,
+            *metadata.meta_args(num_tokens, self.lora_config.specialize_active_lora),
+            qk_nope_head_dim,
+            output.shape[-1],
+        )
+
     @classmethod
     @_not_fully_sharded_can_replace
     def can_replace_layer(

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -10,6 +10,7 @@ from torch import nn
 
 from vllm.config import VllmConfig
 from vllm.config.lora import LoRAConfig
+from vllm.config.utils import replace as replace_config
 from vllm.logger import init_logger
 from vllm.lora.layers import (
     BaseLayerWithLoRA,
@@ -454,13 +455,20 @@ class LoRAModelManager:
                 # LoRA weights of w1 and w3 have already been fused on disk.
 
                 packed_moduled_lst = ["w13"] if self._is_3d_moe_model else ["w1", "w3"]
+            module_lora_config = self.lora_config
+            if self.lora_config.fully_sharded_loras and module_name.endswith(
+                "kv_b_proj"
+            ):
+                module_lora_config = replace_config(
+                    self.lora_config, fully_sharded_loras=False
+                )
             new_module = replace_submodule(
                 self.model,
                 module_name,
                 from_layer(
                     module,
                     self.lora_slots,
-                    self.lora_config,
+                    module_lora_config,
                     packed_moduled_lst,
                     self.model.config,
                 ),

--- a/vllm/lora/ops/triton_ops/__init__.py
+++ b/vllm/lora/ops/triton_ops/__init__.py
@@ -17,6 +17,10 @@ from vllm.lora.ops.triton_ops.lora_expand_op import lora_expand
 from vllm.lora.ops.triton_ops.lora_kernel_metadata import LoRAKernelMeta
 from vllm.lora.ops.triton_ops.lora_shrink_fp8_op import lora_shrink_fp8
 from vllm.lora.ops.triton_ops.lora_shrink_op import lora_shrink
+from vllm.lora.ops.triton_ops.mla_kv_b_lora import (
+    mla_kv_b_lora_q,
+    mla_kv_b_lora_v,
+)
 
 __all__ = [
     "lora_expand",
@@ -24,6 +28,8 @@ __all__ = [
     "lora_shrink",
     "lora_shrink_fp8",
     "LoRAKernelMeta",
+    "mla_kv_b_lora_q",
+    "mla_kv_b_lora_v",
     "fused_moe_lora",
     "fused_moe_lora_shrink",
     "fused_moe_lora_expand",

--- a/vllm/lora/ops/triton_ops/mla_kv_b_lora.py
+++ b/vllm/lora/ops/triton_ops/mla_kv_b_lora.py
@@ -1,0 +1,494 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""LoRA corrections for absorbed MLA ``kv_b_proj`` weights.
+
+Absorbed MLA replaces ``kv_b_proj.forward()`` with BMMs using its base K/V
+weights. These kernels add the routed low-rank delta without materializing it.
+"""
+
+from contextlib import suppress
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+
+_BLOCK_M = 16
+_STEP_A_BLOCK_K = 64
+_STEP_A_BLOCK_N = 16
+_STEP_B_BLOCK_K = 16
+_STEP_B_BLOCK_N = 64
+
+
+@triton.jit
+def _mla_lora_step_a_kernel(
+    x,
+    weight,
+    output,
+    num_rows,
+    contraction_size,
+    output_size,
+    x_stride_m,
+    x_stride_h,
+    x_stride_k,
+    weight_stride_l,
+    weight_stride_row,
+    weight_stride_col,
+    output_stride_m,
+    output_stride_h,
+    output_stride_n,
+    token_indices_sorted_by_lora_ids,
+    num_tokens_per_lora,
+    lora_token_start_loc,
+    lora_ids,
+    full_head_dim: tl.constexpr,
+    weight_is_k_slice: tl.constexpr,
+    block_m: tl.constexpr,
+    block_n: tl.constexpr,
+    block_k: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    head_id = tl.program_id(axis=1)
+    lora_idx = tl.program_id(axis=2)
+
+    lora_id = tl.load(lora_ids + lora_idx)
+    if lora_id == -1:
+        return
+
+    num_pid_n = tl.cdiv(output_size, block_n)
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    lora_num_tokens = tl.load(num_tokens_per_lora + lora_idx)
+    group_offset = pid_m * block_m
+    if group_offset >= lora_num_tokens:
+        return
+
+    offsets_m = group_offset + tl.arange(0, block_m)
+    offsets_n = pid_n * block_n + tl.arange(0, block_n)
+    group_start = tl.load(lora_token_start_loc + lora_idx)
+    token_rows = tl.load(
+        token_indices_sorted_by_lora_ids + group_start + offsets_m,
+        mask=offsets_m < lora_num_tokens,
+        other=0,
+    )
+    row_mask = (offsets_m < lora_num_tokens) & (token_rows < num_rows)
+    safe_rows = tl.minimum(token_rows, num_rows - 1)
+    safe_n = tl.minimum(offsets_n, output_size - 1)
+
+    accumulator = tl.zeros((block_m, block_n), dtype=tl.float32)
+    offsets_k = tl.arange(0, block_k)
+    for k_block in range(0, tl.cdiv(contraction_size, block_k)):
+        current_k = k_block * block_k + offsets_k
+        k_mask = current_k < contraction_size
+        safe_k = tl.minimum(current_k, contraction_size - 1)
+        x_tile = tl.load(
+            x
+            + safe_rows[:, None] * x_stride_m
+            + head_id * x_stride_h
+            + safe_k[None, :] * x_stride_k,
+            mask=row_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        )
+
+        if weight_is_k_slice:
+            weight_rows = head_id * full_head_dim + safe_k[:, None]
+            weight_cols = safe_n[None, :]
+        else:
+            weight_rows = safe_n[None, :]
+            weight_cols = safe_k[:, None]
+        weight_tile = tl.load(
+            weight
+            + lora_id * weight_stride_l
+            + weight_rows * weight_stride_row
+            + weight_cols * weight_stride_col,
+            mask=k_mask[:, None] & (offsets_n[None, :] < output_size),
+            other=0.0,
+        )
+        accumulator += tl.dot(x_tile, weight_tile)
+
+    output_offsets = (
+        safe_rows[:, None] * output_stride_m
+        + head_id * output_stride_h
+        + safe_n[None, :] * output_stride_n
+    )
+    output_mask = row_mask[:, None] & (offsets_n[None, :] < output_size)
+    tl.store(output + output_offsets, accumulator, mask=output_mask)
+
+
+@triton.jit
+def _mla_lora_step_b_kernel(
+    x,
+    weight,
+    output,
+    num_rows,
+    contraction_size,
+    output_size,
+    x_stride_m,
+    x_stride_h,
+    x_stride_k,
+    weight_stride_l,
+    weight_stride_row,
+    weight_stride_col,
+    output_stride_m,
+    output_stride_h,
+    output_stride_n,
+    token_indices_sorted_by_lora_ids,
+    num_tokens_per_lora,
+    lora_token_start_loc,
+    lora_ids,
+    full_head_dim: tl.constexpr,
+    value_offset: tl.constexpr,
+    weight_is_v_slice: tl.constexpr,
+    block_m: tl.constexpr,
+    block_n: tl.constexpr,
+    block_k: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    head_id = tl.program_id(axis=1)
+    lora_idx = tl.program_id(axis=2)
+
+    lora_id = tl.load(lora_ids + lora_idx)
+    if lora_id == -1:
+        return
+
+    num_pid_n = tl.cdiv(output_size, block_n)
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    lora_num_tokens = tl.load(num_tokens_per_lora + lora_idx)
+    group_offset = pid_m * block_m
+    if group_offset >= lora_num_tokens:
+        return
+
+    offsets_m = group_offset + tl.arange(0, block_m)
+    offsets_n = pid_n * block_n + tl.arange(0, block_n)
+    group_start = tl.load(lora_token_start_loc + lora_idx)
+    token_rows = tl.load(
+        token_indices_sorted_by_lora_ids + group_start + offsets_m,
+        mask=offsets_m < lora_num_tokens,
+        other=0,
+    )
+    row_mask = (offsets_m < lora_num_tokens) & (token_rows < num_rows)
+    safe_rows = tl.minimum(token_rows, num_rows - 1)
+    safe_n = tl.minimum(offsets_n, output_size - 1)
+
+    accumulator = tl.zeros((block_m, block_n), dtype=tl.float32)
+    offsets_k = tl.arange(0, block_k)
+    for k_block in range(0, tl.cdiv(contraction_size, block_k)):
+        current_k = k_block * block_k + offsets_k
+        k_mask = current_k < contraction_size
+        safe_k = tl.minimum(current_k, contraction_size - 1)
+        x_tile = tl.load(
+            x
+            + safe_rows[:, None] * x_stride_m
+            + head_id * x_stride_h
+            + safe_k[None, :] * x_stride_k,
+            mask=row_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        )
+
+        if weight_is_v_slice:
+            weight_rows = head_id * full_head_dim + value_offset + safe_n[None, :]
+            weight_cols = safe_k[:, None]
+        else:
+            weight_rows = safe_k[:, None]
+            weight_cols = safe_n[None, :]
+        weight_tile = tl.load(
+            weight
+            + lora_id * weight_stride_l
+            + weight_rows * weight_stride_row
+            + weight_cols * weight_stride_col,
+            mask=k_mask[:, None] & (offsets_n[None, :] < output_size),
+            other=0.0,
+        )
+        accumulator += tl.dot(x_tile, weight_tile)
+
+    output_offsets = (
+        safe_rows[:, None] * output_stride_m
+        + head_id * output_stride_h
+        + safe_n[None, :] * output_stride_n
+    )
+    output_mask = row_mask[:, None] & (offsets_n[None, :] < output_size)
+    accumulator += tl.load(output + output_offsets, mask=output_mask, other=0.0)
+    tl.store(output + output_offsets, accumulator, mask=output_mask)
+
+
+def _launch_step_a(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    token_indices_sorted_by_lora_ids: torch.Tensor,
+    num_tokens_per_lora: torch.Tensor,
+    lora_token_start_loc: torch.Tensor,
+    lora_ids: torch.Tensor,
+    num_active_loras: torch.Tensor,
+    *,
+    full_head_dim: int,
+    weight_is_k_slice: bool,
+) -> None:
+    num_rows, num_heads, contraction_size = x.shape
+    output_size = output.shape[-1]
+    total_tokens = token_indices_sorted_by_lora_ids.shape[0]
+    grid = (
+        triton.cdiv(total_tokens, _BLOCK_M) * triton.cdiv(output_size, _STEP_A_BLOCK_N),
+        num_heads,
+        num_active_loras.item(),
+    )
+    _mla_lora_step_a_kernel[grid](
+        x,
+        weight,
+        output,
+        num_rows,
+        contraction_size,
+        output_size,
+        x.stride(0),
+        x.stride(1),
+        x.stride(2),
+        weight.stride(0),
+        weight.stride(1),
+        weight.stride(2),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        token_indices_sorted_by_lora_ids,
+        num_tokens_per_lora,
+        lora_token_start_loc,
+        lora_ids,
+        full_head_dim=full_head_dim,
+        weight_is_k_slice=weight_is_k_slice,
+        block_m=_BLOCK_M,
+        block_n=_STEP_A_BLOCK_N,
+        block_k=_STEP_A_BLOCK_K,
+    )
+
+
+def _launch_step_b(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    token_indices_sorted_by_lora_ids: torch.Tensor,
+    num_tokens_per_lora: torch.Tensor,
+    lora_token_start_loc: torch.Tensor,
+    lora_ids: torch.Tensor,
+    num_active_loras: torch.Tensor,
+    *,
+    full_head_dim: int,
+    value_offset: int,
+    weight_is_v_slice: bool,
+) -> None:
+    num_rows, num_heads, contraction_size = x.shape
+    output_size = output.shape[-1]
+    total_tokens = token_indices_sorted_by_lora_ids.shape[0]
+    grid = (
+        triton.cdiv(total_tokens, _BLOCK_M) * triton.cdiv(output_size, _STEP_B_BLOCK_N),
+        num_heads,
+        num_active_loras.item(),
+    )
+    _mla_lora_step_b_kernel[grid](
+        x,
+        weight,
+        output,
+        num_rows,
+        contraction_size,
+        output_size,
+        x.stride(0),
+        x.stride(1),
+        x.stride(2),
+        weight.stride(0),
+        weight.stride(1),
+        weight.stride(2),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        token_indices_sorted_by_lora_ids,
+        num_tokens_per_lora,
+        lora_token_start_loc,
+        lora_ids,
+        full_head_dim=full_head_dim,
+        value_offset=value_offset,
+        weight_is_v_slice=weight_is_v_slice,
+        block_m=_BLOCK_M,
+        block_n=_STEP_B_BLOCK_N,
+        block_k=_STEP_B_BLOCK_K,
+    )
+
+
+def apply_mla_kv_b_lora_native(
+    x: torch.Tensor,
+    lora_a: torch.Tensor,
+    lora_b: torch.Tensor,
+    output: torch.Tensor,
+    token_lora_mapping: torch.Tensor,
+    qk_nope_head_dim: int,
+    *,
+    query_side: bool,
+) -> None:
+    num_heads = x.shape[1]
+    full_head_dim = lora_b.shape[2] // num_heads
+    b_by_head = lora_b[:, 0].view(
+        lora_b.shape[0], num_heads, full_head_dim, lora_b.shape[-1]
+    )
+    for lora_id in range(lora_a.shape[0]):
+        token_mask = token_lora_mapping[: x.shape[0]] == lora_id
+        if not torch.any(token_mask):
+            continue
+        a = lora_a[lora_id, 0]
+        if query_side:
+            b_k = b_by_head[lora_id, :, :qk_nope_head_dim]
+            correction = torch.einsum("mhp,hpr,rl->mhl", x[token_mask], b_k, a)
+        else:
+            b_v = b_by_head[lora_id, :, qk_nope_head_dim:]
+            correction = torch.einsum("mhl,rl,hvr->mhv", x[token_mask], a, b_v)
+        output[token_mask] += correction
+
+
+@torch.inference_mode()
+def _mla_kv_b_lora_q(
+    q_nope: torch.Tensor,
+    lora_a: torch.Tensor,
+    lora_b: torch.Tensor,
+    output: torch.Tensor,
+    token_lora_mapping: torch.Tensor,
+    token_indices_sorted_by_lora_ids: torch.Tensor,
+    num_tokens_per_lora: torch.Tensor,
+    lora_token_start_loc: torch.Tensor,
+    lora_ids: torch.Tensor,
+    no_lora_flag_cpu: torch.Tensor,
+    num_active_loras: torch.Tensor,
+    qk_nope_head_dim: int,
+    v_head_dim: int,
+) -> None:
+    if no_lora_flag_cpu.item():
+        return
+    if not current_platform.is_cuda_alike():
+        apply_mla_kv_b_lora_native(
+            q_nope,
+            lora_a,
+            lora_b,
+            output,
+            token_lora_mapping,
+            qk_nope_head_dim,
+            query_side=True,
+        )
+        return
+
+    a = lora_a.squeeze(1)
+    b = lora_b.squeeze(1)
+    intermediate = torch.empty(
+        (*q_nope.shape[:2], b.shape[-1]),
+        dtype=q_nope.dtype,
+        device=q_nope.device,
+    )
+    full_head_dim = qk_nope_head_dim + v_head_dim
+    _launch_step_a(
+        q_nope,
+        b,
+        intermediate,
+        token_indices_sorted_by_lora_ids,
+        num_tokens_per_lora,
+        lora_token_start_loc,
+        lora_ids,
+        num_active_loras,
+        full_head_dim=full_head_dim,
+        weight_is_k_slice=True,
+    )
+    _launch_step_b(
+        intermediate,
+        a,
+        output,
+        token_indices_sorted_by_lora_ids,
+        num_tokens_per_lora,
+        lora_token_start_loc,
+        lora_ids,
+        num_active_loras,
+        full_head_dim=0,
+        value_offset=0,
+        weight_is_v_slice=False,
+    )
+
+
+@torch.inference_mode()
+def _mla_kv_b_lora_v(
+    latent_output: torch.Tensor,
+    lora_a: torch.Tensor,
+    lora_b: torch.Tensor,
+    output: torch.Tensor,
+    token_lora_mapping: torch.Tensor,
+    token_indices_sorted_by_lora_ids: torch.Tensor,
+    num_tokens_per_lora: torch.Tensor,
+    lora_token_start_loc: torch.Tensor,
+    lora_ids: torch.Tensor,
+    no_lora_flag_cpu: torch.Tensor,
+    num_active_loras: torch.Tensor,
+    qk_nope_head_dim: int,
+    v_head_dim: int,
+) -> None:
+    if no_lora_flag_cpu.item():
+        return
+    if not current_platform.is_cuda_alike():
+        apply_mla_kv_b_lora_native(
+            latent_output,
+            lora_a,
+            lora_b,
+            output,
+            token_lora_mapping,
+            qk_nope_head_dim,
+            query_side=False,
+        )
+        return
+
+    a = lora_a.squeeze(1)
+    b = lora_b.squeeze(1)
+    intermediate = torch.empty(
+        (*latent_output.shape[:2], a.shape[1]),
+        dtype=latent_output.dtype,
+        device=latent_output.device,
+    )
+    full_head_dim = qk_nope_head_dim + v_head_dim
+    _launch_step_a(
+        latent_output,
+        a,
+        intermediate,
+        token_indices_sorted_by_lora_ids,
+        num_tokens_per_lora,
+        lora_token_start_loc,
+        lora_ids,
+        num_active_loras,
+        full_head_dim=0,
+        weight_is_k_slice=False,
+    )
+    _launch_step_b(
+        intermediate,
+        b,
+        output,
+        token_indices_sorted_by_lora_ids,
+        num_tokens_per_lora,
+        lora_token_start_loc,
+        lora_ids,
+        num_active_loras,
+        full_head_dim=full_head_dim,
+        value_offset=qk_nope_head_dim,
+        weight_is_v_slice=True,
+    )
+
+
+def _mla_kv_b_lora_fake(*args, **kwargs) -> None:
+    return
+
+
+for op_name, op_func in (
+    ("mla_kv_b_lora_q", _mla_kv_b_lora_q),
+    ("mla_kv_b_lora_v", _mla_kv_b_lora_v),
+):
+    with suppress(AttributeError):
+        direct_register_custom_op(
+            op_name=op_name,
+            op_func=op_func,
+            mutates_args=["output"],
+            fake_impl=_mla_kv_b_lora_fake,
+            tags=(torch.Tag.flexible_layout,),
+        )
+
+mla_kv_b_lora_q = getattr(torch.ops.vllm, "mla_kv_b_lora_q", _mla_kv_b_lora_q)
+mla_kv_b_lora_v = getattr(torch.ops.vllm, "mla_kv_b_lora_v", _mla_kv_b_lora_v)

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -778,7 +778,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             )
 
             # Convert from (B, N, P) to (N, B, P)
-            mqa_q_nope = mqa_q_nope.transpose(0, 1)
+            mqa_q_nope_t = mqa_q_nope.transpose(0, 1)
 
             if self.q_pad_num_heads is not None:
                 B, N, L = mqa_q_pe.shape
@@ -791,7 +791,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 from aiter.ops.triton.batched_gemm_a16wfp4 import batched_gemm_a16wfp4
 
                 mqa_ql_nope = batched_gemm_a16wfp4(
-                    mqa_q_nope,
+                    mqa_q_nope_t,
                     self.W_K,
                     self.W_K_scale,
                     transpose_bm=True,
@@ -801,7 +801,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             elif self.is_aiter_triton_fp8_bmm_enabled:
                 # Multiply+Transpose (N, B, P)x(N, P, L)->(N, B, L)->(B, N, L)
                 mqa_ql_nope = rocm_aiter_ops.triton_fp8_bmm(
-                    mqa_q_nope,
+                    mqa_q_nope_t,
                     self.W_K,
                     self.W_K_scale,
                     group_size=128,
@@ -809,7 +809,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 )
             else:
                 # Pads the head_dim if necessary (for the underlying kernel)
-                N, B, P = mqa_q_nope.shape
+                N, B, P = mqa_q_nope_t.shape
                 _, _, L = self.W_UK_T.shape
 
                 if self.q_pad_num_heads is not None:
@@ -819,10 +819,14 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                     mqa_ql_nope = mqa_q_nope.new_empty((N, B, L))
 
                 # Multiply (N, B, P) x (N, P, L) -> (N, B, L)
-                torch.bmm(mqa_q_nope, self.W_UK_T, out=mqa_ql_nope)
+                torch.bmm(mqa_q_nope_t, self.W_UK_T, out=mqa_ql_nope)
 
                 # Convert from (N, B, L) to (B, N, L)
                 mqa_ql_nope = mqa_ql_nope.transpose(0, 1)
+
+            apply_q_lora = getattr(self.kv_b_proj, "apply_mla_kv_b_lora_q", None)
+            if apply_q_lora is not None:
+                apply_q_lora(mqa_q_nope, mqa_ql_nope, self.v_head_dim)
 
             if fp8_attention and self.impl.supports_quant_query_input:
                 assert mqa_ql_nope.shape[0] == mqa_q_pe.shape[0]
@@ -1047,7 +1051,8 @@ class MLAAttention(nn.Module, AttentionLayerBase):
 
     def _v_up_proj(self, x: torch.Tensor, out: torch.Tensor):
         # Convert from (B, N, L) to (N, B, L)
-        x = x.view(-1, self.num_heads, self.kv_lora_rank).transpose(0, 1)
+        latent_output = x.view(-1, self.num_heads, self.kv_lora_rank)
+        x = latent_output.transpose(0, 1)
         out = out.view(-1, self.num_heads, self.v_head_dim)
         if self.is_aiter_triton_fp4_bmm_enabled:
             out = rocm_aiter_ops.batched_gemm_a16wfp4(
@@ -1068,6 +1073,10 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         else:
             # Multiply + Transpose (N, B, L) x (N, L, V)->(N, B, V)->(B, N, V)
             torch.bmm(x, self.W_UV, out=out.transpose(0, 1))
+
+        apply_v_lora = getattr(self.kv_b_proj, "apply_mla_kv_b_lora_v", None)
+        if apply_v_lora is not None:
+            apply_v_lora(latent_output, out, self.qk_nope_head_dim)
 
 
 def unified_mla_kv_cache_update(


### PR DESCRIPTION
> [!IMPORTANT]
> This is an AI-assisted draft. Human line-by-line review is pending; do not mark ready for review or merge until the accountability checklist below is complete.

## Purpose

Addresses the absorbed/MQA half of #48974.

Absorbed MLA bypasses `kv_b_proj.forward()` and directly applies the base K/V up-projection weights with BMMs. When `kv_b_proj` is wrapped with LoRA, that bypass silently drops its low-rank delta.

Add per-token, per-adapter corrections for both absorbed paths:

- Query: `q_nope @ B_K @ A`
- Value: `latent @ A.T @ B_V.T`

The correction is factored at the LoRA rank boundary, so it does not materialize `B @ A`. It uses existing `LoRAKernelMeta` routing and supports mixed LoRA/base tokens and multiple active adapters.

This follows the mechanism independently implemented by SGLang in `deepseek_mla_correction.py` and `kv_b_lora_absorbed.py`.

### Scope limitation: dense MHA prefill

This PR corrects tokens routed through the absorbed/MQA path: decode tokens and prefills that sparse MLA forces through MQA. It does **not** yet correct dense MHA prefill.

The MHA implementation stores the original `kv_b_proj` object during model construction. Because the implementation object is not an `nn.Module`, the LoRA manager does not rewire that reference when it wraps module-tree aliases. MHA prefill therefore continues to call the base projection. Merely rewiring the reference is insufficient:

- Mixed decode/prefill batches slice prefill rows after decode rows, while the standard LoRA wrapper starts routing at token-mapping row zero.
- Chunked-context projection expands cached latent tokens whose rows do not correspond to the current scheduler token mapping; it needs per-request adapter IDs expanded over context lengths.

Dense MLA models such as DeepSeek V2/V3 therefore retain a prefill gap after this PR. Sparse MLA configurations such as GLM DSA normally force most prefills through the corrected MQA path. Kimi models using the common wrapper receive the absorbed/decode correction but may retain the same dense-prefill gap.

## Duplicate Work Check

Ran before opening this draft:

```bash
gh issue view 48974 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search "48974 in:body"
gh pr list --repo vllm-project/vllm --state open --search "kv_b_proj LoRA MLA"
```

No open PR references #48974 or addresses the same `kv_b_proj` absorbed-MLA correction.

## Implementation

- Add routed Triton kernels for the two-stage query and value corrections.
- Invoke them after the absorbed K and V BMMs.
- Preserve native fallbacks for non-CUDA platforms.
- Keep LoRA A replicated specifically for `kv_b_proj` when `fully_sharded_loras=True`; sharding A is incompatible with the local per-head correction without an extra collective.
- Add numerical coverage for FP16/BF16, mixed adapters, base-only tokens, and scheduler mappings larger than the active MLA token slice.
- Add wrapper coverage for the fully-sharded configuration exception.

## Test Plan

```bash
.venv/bin/pre-commit run --files \
  tests/lora/test_lora_manager.py \
  tests/lora/test_punica_ops.py \
  vllm/lora/layers/column_parallel_linear.py \
  vllm/lora/model_manager.py \
  vllm/lora/ops/triton_ops/__init__.py \
  vllm/lora/ops/triton_ops/mla_kv_b_lora.py \
  vllm/model_executor/layers/attention/mla_attention.py

.venv/bin/pre-commit run mypy-3.12 --hook-stage manual --files \
  tests/lora/test_lora_manager.py \
  tests/lora/test_punica_ops.py \
  vllm/lora/layers/column_parallel_linear.py \
  vllm/lora/model_manager.py \
  vllm/lora/ops/triton_ops/__init__.py \
  vllm/lora/ops/triton_ops/mla_kv_b_lora.py \
  vllm/model_executor/layers/attention/mla_attention.py

CUDA_VISIBLE_DEVICES=0 .venv/bin/python -m pytest \
  tests/lora/test_punica_ops.py -k mla_kv_b_lora_correction -vv -s

CUDA_VISIBLE_DEVICES=0 .venv/bin/python -m pytest \
  tests/lora/test_lora_manager.py::test_mla_kv_b_proj_keeps_replicated_lora_a -vv

CUDA_VISIBLE_DEVICES=0 .venv/bin/python -m pytest \
  tests/lora/test_deepseekv2_tp.py::test_deepseekv2 -vv -s

CUDA_VISIBLE_DEVICES=0,1 .venv/bin/python -m pytest \
  tests/lora/test_deepseekv2_tp.py::test_deepseekv2_tp2 -vv -s
```

## Test Result

Tests ran on an 8x H100 80GB workstation, using one or two GPUs as indicated.

- Triton numerical regression: `2 passed` (FP16 and BF16).
- Fully-sharded wrapper regression: `1 passed`.
- DeepSeek-V2-Lite-Chat LoRA, `FLASH_ATTN_MLA`, eager, TP1: passed.
- DeepSeek-V2-Lite-Chat LoRA, `FLASH_ATTN_MLA`, eager, TP2: passed.
- DeepSeek-V2-Lite-Chat LoRA with default `torch.compile`, piecewise CUDA graphs, and full CUDA graphs: passed.
- Pre-commit hooks, Python 3.10/3.12 mypy, and `git diff --check`: passed.

Model evaluation used `wuchen01/DeepSeek-V2-Lite-Chat-All-LoRA`, whose target modules include `kv_b_proj`. TP1, TP2, eager, and compiled runs all generated the expected deterministic adapter response:

```text
I am 张子豪, an AI assistant developed by 陈士栋. How can I assist you today?
```

Because this adapter also targets several non-MLA modules, this end-to-end result validates runtime integration and absorbed-kernel execution, not standalone `kv_b_proj` prefill correctness. The focused numerical test validates the `kv_b_proj` absorbed correction itself.

## AI Assistance

OpenAI Codex was used for issue analysis, implementation, test orchestration, and drafting this description. The commit includes a `Co-authored-by` trailer.

## Accountability

- [ ] Human submitter has reviewed every changed line.
- [ ] Human submitter understands and can defend the correction algebra, routing, tensor-parallel behavior, tests, and dense-prefill limitation.
- [x] Relevant focused tests and model evaluations were run and results are documented above.
- [x] Duplicate-work searches were run and found no competing open PR.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose and scope are linked to an existing issue.
- [x] The test plan provides exact commands.
- [x] Test and model evaluation results are included with their limitation.
- [x] No documentation update is needed for the absorbed-path correction.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>**
