### PR TITLE
[Attention][MiniMax-M3] Add FlashInfer MSA backend for SM120/SM121

### DIFF
--- a/tests/kernels/attention/test_minimax_m3.py
+++ b/tests/kernels/attention/test_minimax_m3.py
@@ -589,9 +589,9 @@ def _has_flashinfer_msa_platform() -> bool:
     return current_platform.is_device_capability_family(120) and has_flashinfer_msa()
 
 
-# Parity of the SM120/SM121 FlashInfer indexer against the Triton impl,
-# driven through the real metadata builders. The short decode request covers
-# the -1 clamp; local_blocks=1 covers the local-window bias, with cache values
+# The SM120/SM121 FlashInfer indexer must match the Triton impl when driven
+# through the real metadata builders. The short decode request covers the -1
+# clamp; local_blocks=1 covers the local-window bias, with cache values
 # decreasing by block id so the window never wins on score alone.
 @pytest.mark.skipif(
     not _has_flashinfer_msa_platform(),

--- a/tests/kernels/attention/test_minimax_m3.py
+++ b/tests/kernels/attention/test_minimax_m3.py
@@ -673,7 +673,6 @@ def test_flashinfer_indexer_impl_matches_triton(local_blocks, index_dtype, monke
         local_blocks=local_blocks,
     )
 
-    # Both impls write the shared buffer token-major [T, H, topk].
     (fi_impl, triton_impl), _ = _run_indexer_impl_pair(
         vllm_config,
         device,

--- a/tests/kernels/attention/test_minimax_m3.py
+++ b/tests/kernels/attention/test_minimax_m3.py
@@ -420,6 +420,39 @@ def test_fmha_sm100_indexer_matches_reference(q_lens, prefix_lens, index_dtype):
     _assert_topk_indices_equal_unordered(actual, expected)
 
 
+def _run_indexer_impl_pair(
+    vllm_config, device, common, index_cache, index_q, impl_kwargs, specs
+):
+    """Construct, wire, and run indexer impls on the same metadata; each spec
+    is (impl_cls, builder_cls, prefix, topk_indices_buffer). Returns the impls
+    and their forward results, in spec order."""
+    from vllm.config import set_current_vllm_config
+    from vllm.forward_context import set_forward_context
+
+    kv_spec = MLAAttentionSpec(
+        block_size=BLOCK_SIZE,
+        num_kv_heads=1,
+        head_size=impl_kwargs["index_head_dim"],
+        dtype=DTYPE,
+    )
+    impls, builders = [], []
+    with set_current_vllm_config(vllm_config):
+        for impl_cls, builder_cls, prefix, _ in specs:
+            impl = impl_cls(prefix=prefix, **impl_kwargs)
+            impls.append(impl)
+            builders.append(
+                builder_cls(kv_spec, [impl.index_cache.prefix], vllm_config, device)
+            )
+    attn_metadata = {}
+    for impl, builder, (_, _, _, buf) in zip(impls, builders, specs):
+        impl.index_cache.kv_cache = index_cache
+        impl.topk_indices_buffer = buf
+        attn_metadata[impl.index_cache.prefix] = builder.build(0, common)
+    with set_forward_context(attn_metadata, vllm_config):
+        results = [impl(index_q) for impl in impls]
+    return impls, results
+
+
 # Full impl-level parity: drive both MiniMaxM3IndexerMSAImpl (fmha/CuteDSL score
 # + unified top-k) and MiniMaxM3IndexerTritonImpl through their real metadata
 # builders on the SAME CommonAttentionMetadata + index cache, and assert the
@@ -440,8 +473,6 @@ def test_msa_indexer_impl_matches_triton(topk, index_dtype, monkeypatch):
         create_common_attn_metadata,
         create_vllm_config,
     )
-    from vllm.config import set_current_vllm_config
-    from vllm.forward_context import set_forward_context
     from vllm.models.minimax_m3.common.indexer import (
         MiniMaxM3IndexerTritonImpl,
         MiniMaxM3IndexerTritonMetadataBuilder,
@@ -494,9 +525,6 @@ def test_msa_indexer_impl_matches_triton(topk, index_dtype, monkeypatch):
         num_tokens, num_idx_heads * head_dim, device=device, dtype=index_dtype
     )
 
-    spec = MLAAttentionSpec(
-        block_size=BLOCK_SIZE, num_kv_heads=1, head_size=head_dim, dtype=DTYPE
-    )
     impl_kwargs = dict(
         num_kv_heads=num_idx_heads,
         scale=head_dim**-0.5,
@@ -508,38 +536,39 @@ def test_msa_indexer_impl_matches_triton(topk, index_dtype, monkeypatch):
         local_blocks=0,
     )
 
-    with set_current_vllm_config(vllm_config):
-        msa_impl = MiniMaxM3IndexerMSAImpl(prefix="idx_msa", **impl_kwargs)
-        triton_impl = MiniMaxM3IndexerTritonImpl(prefix="idx_triton", **impl_kwargs)
-        msa_builder = MiniMaxM3IndexerMSAMetadataBuilder(
-            spec, [msa_impl.index_cache.prefix], vllm_config, device
-        )
-        triton_builder = MiniMaxM3IndexerTritonMetadataBuilder(
-            spec, [triton_impl.index_cache.prefix], vllm_config, device
-        )
-
-    # Both impls score against the same index keys.
-    msa_impl.index_cache.kv_cache = index_cache
-    triton_impl.index_cache.kv_cache = index_cache
-
     # Exercise the shared persistent top-k buffer for BOTH impls: each must write
     # decode ([:nd]) and prefill ([nd:]) into its token-major buffer and (Triton
     # only) return views. Separate buffers so the two forwards don't clobber.
     nd = sum(q for q in batch.query_lens if q <= 1)
-    msa_impl.topk_indices_buffer = torch.full(
-        (num_tokens, num_idx_heads, topk), -2, dtype=torch.int32, device=device
-    )
-    triton_impl.topk_indices_buffer = torch.full(
-        (num_tokens, num_idx_heads, topk), -2, dtype=torch.int32, device=device
-    )
 
-    attn_metadata = {
-        msa_impl.index_cache.prefix: msa_builder.build(0, common),
-        triton_impl.index_cache.prefix: triton_builder.build(0, common),
-    }
-    with set_forward_context(attn_metadata, vllm_config):
-        msa_decode, msa_prefill = msa_impl(index_q)
-        tri_decode, tri_prefill = triton_impl(index_q)
+    def _buf():
+        return torch.full(
+            (num_tokens, num_idx_heads, topk), -2, dtype=torch.int32, device=device
+        )
+
+    (msa_impl, triton_impl), results = _run_indexer_impl_pair(
+        vllm_config,
+        device,
+        common,
+        index_cache,
+        index_q,
+        impl_kwargs,
+        [
+            (
+                MiniMaxM3IndexerMSAImpl,
+                MiniMaxM3IndexerMSAMetadataBuilder,
+                "idx_msa",
+                _buf(),
+            ),
+            (
+                MiniMaxM3IndexerTritonImpl,
+                MiniMaxM3IndexerTritonMetadataBuilder,
+                "idx_triton",
+                _buf(),
+            ),
+        ],
+    )
+    (msa_decode, msa_prefill), (tri_decode, tri_prefill) = results
 
     # MSA's return is vestigial; the attend reads its buffer directly.
     assert msa_decode is None and msa_prefill is None
@@ -552,6 +581,135 @@ def test_msa_indexer_impl_matches_triton(topk, index_dtype, monkeypatch):
     buf_htk = triton_impl.topk_indices_buffer.transpose(0, 1)
     assert tri_decode.data_ptr() == buf_htk[:, :nd, :].data_ptr()
     assert tri_prefill.data_ptr() == buf_htk[:, nd:, :].data_ptr()
+
+
+def _has_flashinfer_msa_platform() -> bool:
+    from vllm.utils.flashinfer import has_flashinfer_msa
+
+    return current_platform.is_device_capability_family(120) and has_flashinfer_msa()
+
+
+# Parity of the SM120/SM121 FlashInfer indexer against the Triton impl,
+# driven through the real metadata builders. The short decode request covers
+# the -1 clamp; local_blocks=1 covers the local-window bias, with cache values
+# decreasing by block id so the window never wins on score alone.
+@pytest.mark.skipif(
+    not _has_flashinfer_msa_platform(),
+    reason="FlashInfer MSA indexer requires SM120/SM121 and flashinfer.msa_ops.",
+)
+@pytest.mark.parametrize("local_blocks", [0, 1])
+@pytest.mark.parametrize("index_dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_flashinfer_indexer_impl_matches_triton(local_blocks, index_dtype, monkeypatch):
+    import vllm.models.minimax_m3.common.indexer as indexer_mod
+    from tests.v1.attention.utils import (
+        BatchSpec,
+        create_common_attn_metadata,
+        create_vllm_config,
+    )
+    from vllm.models.minimax_m3.common.indexer import (
+        MiniMaxM3IndexerTritonImpl,
+        MiniMaxM3IndexerTritonMetadataBuilder,
+    )
+    from vllm.models.minimax_m3.nvidia.indexer_flashinfer import (
+        MiniMaxM3IndexerFlashInferImpl,
+        MiniMaxM3IndexerFlashInferMetadataBuilder,
+    )
+
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    num_idx_heads, head_dim, topk = 4, HEAD_DIM, TOPK
+    # TP=1: avoid requiring an initialized distributed group in a unit test.
+    monkeypatch.setattr(indexer_mod, "get_tensor_model_parallel_world_size", lambda: 1)
+
+    vllm_config = create_vllm_config(
+        block_size=BLOCK_SIZE, max_model_len=8192, max_num_batched_tokens=8192
+    )
+    vllm_config.model_config.hf_config.sparse_attention_config = {
+        "sparse_num_index_heads": num_idx_heads,
+        "sparse_local_block": local_blocks,
+    }
+
+    # Decode-first mixed batch: one short and one long decode request, then
+    # two prefill requests whose prefixes exceed topk causal blocks.
+    batch = BatchSpec(seq_lens=[300, 2561, 2624, 2720], query_lens=[1, 1, 64, 96])
+    common = create_common_attn_metadata(
+        batch, BLOCK_SIZE, device, arange_block_indices=True
+    )
+    num_tokens = batch.compute_num_tokens()
+    # The production model runner always provides positions; the test helper
+    # does not.
+    common.positions = torch.cat(
+        [
+            torch.arange(s - q, s, dtype=torch.int64, device=device)
+            for s, q in zip(batch.seq_lens, batch.query_lens)
+        ]
+    )
+
+    # Distinct e4m3-exact per-block values, decreasing with the block id.
+    block_table = common.block_table_tensor
+    num_pages = int(block_table.max().item()) + 1
+    max_blocks = (max(batch.seq_lens) + BLOCK_SIZE - 1) // BLOCK_SIZE
+    assert max_blocks <= len(_E4M3_EXACT_VALUES)
+    index_cache = torch.zeros(
+        num_pages, BLOCK_SIZE, head_dim, device=device, dtype=index_dtype
+    )
+    for r, seq_len in enumerate(batch.seq_lens):
+        for b in range((seq_len + BLOCK_SIZE - 1) // BLOCK_SIZE):
+            index_cache[block_table[r, b]] = float(
+                _E4M3_EXACT_VALUES[max_blocks - 1 - b]
+            )
+    index_q = torch.ones(
+        num_tokens, num_idx_heads * head_dim, device=device, dtype=index_dtype
+    )
+
+    impl_kwargs = dict(
+        num_kv_heads=num_idx_heads,
+        scale=head_dim**-0.5,
+        topk_blocks=topk,
+        sparse_block_size=BLOCK_SIZE,
+        num_index_heads=num_idx_heads,
+        index_head_dim=head_dim,
+        init_blocks=0,
+        local_blocks=local_blocks,
+    )
+
+    # Both impls write the shared buffer token-major [T, H, topk].
+    (fi_impl, triton_impl), _ = _run_indexer_impl_pair(
+        vllm_config,
+        device,
+        common,
+        index_cache,
+        index_q,
+        impl_kwargs,
+        [
+            (
+                MiniMaxM3IndexerFlashInferImpl,
+                MiniMaxM3IndexerFlashInferMetadataBuilder,
+                "idx_fi",
+                torch.full(
+                    (num_tokens, num_idx_heads, topk),
+                    -2,
+                    dtype=torch.int32,
+                    device=device,
+                ),
+            ),
+            (
+                MiniMaxM3IndexerTritonImpl,
+                MiniMaxM3IndexerTritonMetadataBuilder,
+                "idx_triton",
+                torch.full(
+                    (num_tokens, num_idx_heads, topk),
+                    -2,
+                    dtype=torch.int32,
+                    device=device,
+                ),
+            ),
+        ],
+    )
+
+    _assert_topk_indices_equal_unordered(
+        fi_impl.topk_indices_buffer, triton_impl.topk_indices_buffer
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/kernels/attention/test_minimax_m3.py
+++ b/tests/kernels/attention/test_minimax_m3.py
@@ -1062,6 +1062,124 @@ def test_prefill_sparse_attention_correctness(
     assert error.max().item() < 1.7e-2
 
 
+def _has_flashinfer_msa_packed_kv_platform() -> bool:
+    if not _has_flashinfer_msa_platform():
+        return False
+    from vllm.utils.flashinfer import has_flashinfer_msa_packed_kv
+
+    return has_flashinfer_msa_packed_kv()
+
+
+# FlashInfer attend vs the Triton kernels' reference, at the impl's call shape.
+@pytest.mark.skipif(
+    not _has_flashinfer_msa_packed_kv_platform(),
+    reason="FlashInfer MSA attend requires SM120/SM121 and packed-KV support.",
+)
+@pytest.mark.parametrize("kv_layout", ["NHD", "HND"], indirect=True)
+@pytest.mark.parametrize(
+    ("q_lens", "kv_lens"),
+    [
+        ((129, 257), (129, 257)),
+        ((65, 129, 257), (129, 257, 385)),
+        ((1, 1, 1), (129, 257, 385)),  # decode path
+    ],
+)
+def test_flashinfer_sparse_attention_matches_reference(
+    kv_layout: str,
+    q_lens: tuple[int, ...],
+    kv_lens: tuple[int, ...],
+):
+    from flashinfer.msa_ops import (
+        msa_sparse_attention,
+        msa_sparse_decode_attention,
+    )
+
+    assert all(kv_len >= q_len for q_len, kv_len in zip(q_lens, kv_lens))
+    is_decode = all(q_len == 1 for q_len in q_lens)
+
+    batch = len(q_lens)
+    pages_per_req = [(kv_len + BLOCK_SIZE - 1) // BLOCK_SIZE for kv_len in kv_lens]
+    max_blocks = max(pages_per_req)
+    num_pages = sum(pages_per_req)
+    physical_pages = torch.randperm(num_pages, device="cuda", dtype=torch.int32)
+    block_table = torch.zeros(batch, max_blocks, device="cuda", dtype=torch.int32)
+    base_page = 0
+    for req_id, num_req_pages in enumerate(pages_per_req):
+        block_table[req_id, :num_req_pages] = physical_pages[
+            base_page : base_page + num_req_pages
+        ]
+        base_page += num_req_pages
+
+    q_lens_t = torch.tensor(q_lens, device="cuda", dtype=torch.int32)
+    seq_lens = torch.tensor(kv_lens, device="cuda", dtype=torch.int32)
+    prefix_lens = seq_lens - q_lens_t
+    cu_seqlens = torch.zeros(batch + 1, device="cuda", dtype=torch.int32)
+    cu_seqlens[1:] = q_lens_t.cumsum(0)
+    total_q = sum(q_lens)
+
+    q = torch.randn(total_q, NUM_Q_HEADS, HEAD_DIM, device="cuda", dtype=DTYPE)
+    kv_cache = _allocate_main_kv_via_contract(num_pages)
+    k_cache, v_cache = kv_cache.split(HEAD_DIM, dim=-1)
+
+    topk_shape = (NUM_KV_HEADS, total_q, TOPK)
+    topk_idx = torch.full(topk_shape, -1, device="cuda", dtype=torch.int32)
+    q_start = 0
+    for q_len, prefix_len in zip(q_lens_t.tolist(), prefix_lens.tolist()):
+        for local_q in range(q_len):
+            current_block = (prefix_len + local_q) // BLOCK_SIZE
+            older_blocks = torch.randperm(
+                current_block, device="cuda", dtype=torch.int32
+            )
+            selected = torch.cat(
+                [
+                    torch.tensor([current_block], device="cuda", dtype=torch.int32),
+                    older_blocks[: TOPK - 1],
+                ]
+            )
+            topk_idx[:, q_start + local_q, : selected.numel()] = selected
+        q_start += q_len
+
+    if is_decode:
+        actual = msa_sparse_decode_attention(
+            q,
+            k_cache,
+            v_cache,
+            topk_idx,
+            page_table=block_table,
+            seqused_k=seq_lens,
+            seqlen_q=1,
+            causal=True,
+            softmax_scale=SM_SCALE,
+        )
+    else:
+        actual = msa_sparse_attention(
+            q,
+            k_cache,
+            v_cache,
+            topk_idx,
+            cu_seqlens,
+            causal=True,
+            softmax_scale=SM_SCALE,
+            page_table=block_table,
+            seqused_k=seq_lens,
+        )
+
+    expected = _reference_sparse_attn(
+        q,
+        kv_cache,
+        topk_idx,
+        block_table,
+        q_lens_t,
+        seq_lens,
+        prefix_lens,
+    )
+    torch.accelerator.synchronize()
+
+    error = (actual.float() - expected.float()).abs()
+    assert error.mean().item() < 2.5e-4
+    assert error.max().item() < 1.7e-2
+
+
 def test_main_backend_layout_contract():
     """The main sparse backend exposes the logical-NHD shape and the
     flash_attn-style stride order for each layout."""

--- a/vllm/models/minimax_m3/common/indexer.py
+++ b/vllm/models/minimax_m3/common/indexer.py
@@ -477,12 +477,15 @@ def select_indexer_impl_cls(
     *,
     topk_blocks: int,
     indexer_kv_dtype: IndexerKVDType = "bf16",
+    use_flashinfer_msa: bool = False,
 ) -> type[MiniMaxM3IndexerImpl]:
     """Pick the indexer impl off the platform, top-k count, and cache dtype.
 
     On Blackwell (SM100) with ``topk_blocks == 16`` (the only width fmha_sm100's
     ``sparse_topk_select`` kernel supports), the fmha_sm100 score + top-k path is
-    used for both bf16 and fp8 index caches. Everything else falls back to the
+    used for both bf16 and fp8 index caches. On SM120/SM121, the
+    flashinfer.msa_ops impl is used when the caller passes the
+    ``minimax_m3_use_flashinfer_msa`` verdict. Everything else falls back to the
     Triton indexer (bf16 only).
     """
     if indexer_kv_dtype in ("mxfp4", "nvfp4"):
@@ -511,6 +514,19 @@ def select_indexer_impl_cls(
             indexer_kv_dtype,
         )
         return MiniMaxM3IndexerMSAImpl
+    if use_flashinfer_msa:
+        # Lazy import so non-SM12x / flashinfer-less setups never import it.
+        from vllm.models.minimax_m3.nvidia.indexer_flashinfer import (
+            MiniMaxM3IndexerFlashInferImpl,
+        )
+
+        logger.info_once(
+            "MiniMax M3 indexer: selected FlashInfer MSA (proxy score + top-k) "
+            "[topk_blocks=%d, indexer_kv_dtype=%s]",
+            topk_blocks,
+            indexer_kv_dtype,
+        )
+        return MiniMaxM3IndexerFlashInferImpl
     if indexer_kv_dtype != "bf16":
         raise NotImplementedError(
             f"indexer_kv_dtype={indexer_kv_dtype!r} is not supported by the "
@@ -549,11 +565,13 @@ class MiniMaxM3Indexer(nn.Module):
         cache_config: CacheConfig | None = None,
         indexer_kv_dtype: IndexerKVDType = "bf16",
         topk_indices_buffer: torch.Tensor | None = None,
+        use_flashinfer_msa: bool = False,
     ) -> None:
         super().__init__()
         impl_cls = select_indexer_impl_cls(
             topk_blocks=topk_blocks,
             indexer_kv_dtype=indexer_kv_dtype,
+            use_flashinfer_msa=use_flashinfer_msa,
         )
         self.impl = impl_cls(
             num_kv_heads=num_kv_heads,

--- a/vllm/models/minimax_m3/common/sparse_attention.py
+++ b/vllm/models/minimax_m3/common/sparse_attention.py
@@ -27,6 +27,7 @@ from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.models.minimax_m3.common.ops.sparse_attn import SPARSE_BLOCK_SIZE
 from vllm.platforms import current_platform
+from vllm.utils.flashinfer import has_flashinfer_msa_packed_kv
 
 # AMD/ROCm uses the gfx942/gfx950-optimized block-sparse kernels in amd.ops;
 # every other platform uses the generic common.ops implementation.
@@ -450,19 +451,48 @@ class MiniMaxM3SparseTritonImpl(MiniMaxM3SparseImpl):
         return output
 
 
+def minimax_m3_use_flashinfer_msa(
+    *,
+    topk_blocks: int,
+    kv_cache_dtype: str,
+    num_heads: int,
+    num_kv_heads: int,
+    indexer_kv_dtype: str,
+) -> bool:
+    """Whether to use the flashinfer.msa_ops impls on SM120/SM121.
+
+    One predicate feeds both selectors: the FlashInfer indexer and attend
+    share the top-k buffer token-major while the Triton impls read it
+    head-major, so they must be selected together or not at all.
+    """
+    return (
+        current_platform.is_cuda()
+        and current_platform.is_device_capability_family(120)
+        and topk_blocks == 16  # msa_topk_select constraint
+        and kv_cache_dtype != "fp8_e5m2"
+        and indexer_kv_dtype in ("bf16", "fp8", "fp8_e4m3")
+        # The decode kernel takes GQA group sizes up to 16.
+        and num_heads % num_kv_heads == 0
+        and num_heads // num_kv_heads <= 16
+        and has_flashinfer_msa_packed_kv()
+    )
+
+
 def select_main_backend_and_impl_cls(
     *,
     topk_blocks: int,
     kv_cache_dtype: str,
     num_kv_heads: int,
+    use_flashinfer_msa: bool = False,
 ) -> tuple[type[MiniMaxM3SparseBackend], type[MiniMaxM3SparseImpl]]:
     """Pick the main attention backend and implementation.
 
     Blackwell (SM100) uses the MSA attend for supported top-k block counts
-    when the KV cache is BF16 or FP8 E4M3; MI355 uses AITER sparse PA
-    with shuffle KV cache layout; Other platforms and FP8 E5M2 fall
-    back to Triton. The MSA modules are imported lazily to avoid import errors
-    on unsupported platforms.
+    when the KV cache is BF16 or FP8 E4M3; SM120/SM121 uses the FlashInfer
+    MSA attend when the caller passes the ``minimax_m3_use_flashinfer_msa``
+    verdict; MI355 uses AITER sparse PA with shuffle KV cache layout; Other
+    platforms and FP8 E5M2 fall back to Triton. The MSA/FlashInfer modules
+    are imported lazily to avoid import errors on unsupported platforms.
     """
     use_aiter_sparse_pa = minimax_m3_use_aiter_sparse_pa(num_kv_heads)
     use_msa = (
@@ -471,9 +501,15 @@ def select_main_backend_and_impl_cls(
         and topk_blocks in (4, 8, 16, 32)
         and kv_cache_dtype != "fp8_e5m2"
     )
-    selected = (
-        "AITER_SPARSE_PA" if use_aiter_sparse_pa else ("MSA" if use_msa else "Triton")
-    )
+    use_flashinfer_msa = use_flashinfer_msa and not use_msa and not use_aiter_sparse_pa
+    if use_aiter_sparse_pa:
+        selected = "AITER_SPARSE_PA"
+    elif use_msa:
+        selected = "MSA"
+    elif use_flashinfer_msa:
+        selected = "FlashInfer MSA"
+    else:
+        selected = "Triton"
     logger.info_once(
         "MiniMax M3 sparse attention selected %s (kv_cache_dtype=%s, topk_blocks=%s)",
         selected,
@@ -493,6 +529,12 @@ def select_main_backend_and_impl_cls(
         )
 
         return MiniMaxM3SparseMSABackend, MiniMaxM3SparseMSAImpl
+    if use_flashinfer_msa:
+        from vllm.models.minimax_m3.nvidia.sparse_attention_flashinfer import (
+            MiniMaxM3SparseFlashInferImpl,
+        )
+
+        return MiniMaxM3SparseBackend, MiniMaxM3SparseFlashInferImpl
     return MiniMaxM3SparseBackend, MiniMaxM3SparseTritonImpl
 
 
@@ -501,10 +543,12 @@ def select_main_impl_cls(
     topk_blocks: int,
     kv_cache_dtype: str,
     num_kv_heads: int,
+    use_flashinfer_msa: bool = False,
 ) -> type[MiniMaxM3SparseImpl]:
     """Backward-compatible implementation-only selector."""
     return select_main_backend_and_impl_cls(
         topk_blocks=topk_blocks,
         kv_cache_dtype=kv_cache_dtype,
         num_kv_heads=num_kv_heads,
+        use_flashinfer_msa=use_flashinfer_msa,
     )[1]

--- a/vllm/models/minimax_m3/common/sparse_attention.py
+++ b/vllm/models/minimax_m3/common/sparse_attention.py
@@ -461,9 +461,9 @@ def minimax_m3_use_flashinfer_msa(
 ) -> bool:
     """Whether to use the flashinfer.msa_ops impls on SM120/SM121.
 
-    One predicate feeds both selectors: the FlashInfer indexer and attend
-    share the top-k buffer token-major while the Triton impls read it
-    head-major, so they must be selected together or not at all.
+    One predicate feeds both selectors so the FlashInfer indexer and attend
+    engage together or not at all. Mixed FlashInfer/Triton pairs are
+    unsupported.
     """
     return (
         current_platform.is_cuda()

--- a/vllm/models/minimax_m3/common/sparse_attention.py
+++ b/vllm/models/minimax_m3/common/sparse_attention.py
@@ -27,7 +27,10 @@ from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.models.minimax_m3.common.ops.sparse_attn import SPARSE_BLOCK_SIZE
 from vllm.platforms import current_platform
-from vllm.utils.flashinfer import has_flashinfer_msa_packed_kv
+from vllm.utils.flashinfer import (
+    has_flashinfer_msa_packed_kv,
+    has_flashinfer_msa_per_token_topk,
+)
 
 # AMD/ROCm uses the gfx942/gfx950-optimized block-sparse kernels in amd.ops;
 # every other platform uses the generic common.ops implementation.
@@ -475,6 +478,9 @@ def minimax_m3_use_flashinfer_msa(
         and num_heads % num_kv_heads == 0
         and num_heads // num_kv_heads <= 16
         and has_flashinfer_msa_packed_kv()
+        # The indexer passes num_valid_pages per token, which older flashinfer
+        # builds reject at runtime.
+        and has_flashinfer_msa_per_token_topk()
     )
 
 

--- a/vllm/models/minimax_m3/nvidia/indexer_flashinfer.py
+++ b/vllm/models/minimax_m3/nvidia/indexer_flashinfer.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FlashInfer indexer impl for MiniMax M3 on SM120/SM121.
+
+One whole-batch ``msa_proxy_score`` call plus one ``msa_topk_select`` call, no
+decode/prefill split. flashinfer's top-k takes only batch-wide scalars, so the
+per-token local window and causal-range clamp are recovered in Python (see
+``forward``). Imported only when ``minimax_m3_use_flashinfer_msa`` passes.
+"""
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+import torch
+from flashinfer.msa_ops import msa_proxy_score, msa_topk_select
+
+from vllm.config import VllmConfig
+from vllm.forward_context import get_forward_context
+from vllm.models.minimax_m3.common.indexer import (
+    MiniMaxM3IndexerBackend,
+    MiniMaxM3IndexerImpl,
+    MiniMaxM3IndexerMetadata,
+    MiniMaxM3IndexerMetadataBuilder,
+)
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    CommonAttentionMetadata,
+)
+from vllm.v1.attention.backends.utils import split_decodes_and_prefills
+from vllm.v1.kv_cache_interface import AttentionSpec
+
+# KV page size == sparse block size == flashinfer's MSA block size.
+PAGE_SIZE = 128
+
+# Force-include bias: the max finite float outranks every real score.
+_FORCE_SCORE = torch.finfo(torch.float32).max
+
+
+class MiniMaxM3IndexerFlashInferBackend(MiniMaxM3IndexerBackend):
+    """Indexer side-cache backend selecting the FlashInfer builder."""
+
+    @staticmethod
+    def get_builder_cls() -> type["MiniMaxM3IndexerFlashInferMetadataBuilder"]:
+        return MiniMaxM3IndexerFlashInferMetadataBuilder
+
+
+@dataclass
+class MiniMaxM3IndexerFlashInferMetadata(MiniMaxM3IndexerMetadata):
+    """Whole-batch proxy/top-k inputs; ``prefill``/``decode`` stay ``None``."""
+
+    proxy_cu_seqlens_q: torch.Tensor | None = None  # [num_reqs + 1] int32
+    proxy_seqused_k: torch.Tensor | None = None  # [num_reqs] int32
+    proxy_page_table: torch.Tensor | None = None  # [num_reqs, max_pages] int32
+    proxy_max_seqlen_q: int = 0
+    max_k_tiles: int = 0
+    # Per-token last-block indices [local_blocks, total_q]; None when the
+    # model has no local window.
+    local_force_index: torch.Tensor | None = None
+    num_valid_pages: torch.Tensor | None = None  # [total_q] int32
+
+
+class MiniMaxM3IndexerFlashInferMetadataBuilder(MiniMaxM3IndexerMetadataBuilder):
+    """Whole-batch metadata; the impl runs under the eager cudagraph break,
+    so nothing here needs a stable address."""
+
+    def __init__(
+        self,
+        kv_cache_spec: AttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ) -> None:
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        hf_config = vllm_config.model_config.hf_config
+        text_config = getattr(hf_config, "text_config", hf_config)
+        sparse_cfg = text_config.sparse_attention_config
+        self.local_blocks = sparse_cfg.get("sparse_local_block", 0)
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> MiniMaxM3IndexerFlashInferMetadata:
+        num_reqs = common_attn_metadata.num_reqs
+        num_tokens = common_attn_metadata.num_actual_tokens
+        query_start_loc = common_attn_metadata.query_start_loc
+        seq_lens = common_attn_metadata.seq_lens
+        block_table = common_attn_metadata.block_table_tensor
+
+        num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
+            split_decodes_and_prefills(
+                common_attn_metadata,
+                decode_threshold=self.reorder_batch_threshold,
+                require_uniform=True,
+            )
+        )
+
+        positions = common_attn_metadata.positions
+        assert positions is not None
+        num_valid_pages = self.num_valid_pages_buffer[:num_tokens]
+        num_valid_pages.copy_(positions[:num_tokens] // PAGE_SIZE + 1)
+
+        local_force_index: torch.Tensor | None = None
+        if self.local_blocks > 0:
+            # A token's local window is its last causal blocks; tokens with
+            # fewer blocks than the window clamp onto block 0 (harmless).
+            offsets = torch.arange(
+                self.local_blocks, device=num_valid_pages.device, dtype=torch.int64
+            )
+            local_force_index = (
+                num_valid_pages.to(torch.int64).unsqueeze(0) - 1 - offsets.unsqueeze(1)
+            ).clamp_(min=0)
+
+        return MiniMaxM3IndexerFlashInferMetadata(
+            seq_lens=seq_lens,
+            max_seq_len=common_attn_metadata.max_seq_len,
+            slot_mapping=common_attn_metadata.slot_mapping,
+            num_actual_tokens=num_tokens,
+            num_decodes=num_decodes,
+            num_decode_tokens=num_decode_tokens,
+            num_prefills=num_prefills,
+            num_prefill_tokens=num_prefill_tokens,
+            proxy_cu_seqlens_q=query_start_loc[: num_reqs + 1].to(torch.int32),
+            proxy_seqused_k=seq_lens[:num_reqs].to(torch.int32),
+            proxy_page_table=block_table[:num_reqs],
+            proxy_max_seqlen_q=common_attn_metadata.max_query_len,
+            max_k_tiles=(common_attn_metadata.max_seq_len + PAGE_SIZE - 1) // PAGE_SIZE,
+            local_force_index=local_force_index,
+            num_valid_pages=num_valid_pages,
+        )
+
+
+class MiniMaxM3IndexerFlashInferImpl(MiniMaxM3IndexerImpl):
+    """One flashinfer proxy-score + top-k pair over the whole batch."""
+
+    indexer_backend_cls: ClassVar[type[AttentionBackend]] = (
+        MiniMaxM3IndexerFlashInferBackend
+    )
+
+    def forward(
+        self,
+        index_query: torch.Tensor,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        attn_metadata = get_forward_context().attn_metadata
+        if not isinstance(attn_metadata, dict):
+            return None, None  # profiling run; caches unbound
+        md = attn_metadata[self.index_cache.prefix]
+        assert isinstance(md, MiniMaxM3IndexerFlashInferMetadata)
+
+        num_tokens = md.num_actual_tokens
+        index_q = index_query[:num_tokens].view(
+            -1, self.num_index_heads, self.index_head_dim
+        )
+        # The proxy takes bf16/fp16 queries only.
+        if index_q.dtype == torch.float8_e4m3fn:
+            index_q = index_q.to(torch.bfloat16)
+        # Index-K cache viewed as a paged MQA cache.
+        kv = self.index_cache.kv_cache
+        k_pages = kv.view(kv.shape[0], 1, PAGE_SIZE, self.index_head_dim)
+        buf = self.topk_indices_buffer
+        assert buf is not None
+
+        # The default q_offset right-aligns tokens, matching vLLM's positions.
+        # Scores are unscaled; a positive scale cannot change the ranking.
+        scores = msa_proxy_score(
+            index_q,
+            k_pages,
+            md.proxy_cu_seqlens_q,
+            page_table=md.proxy_page_table,
+            seqused_k=md.proxy_seqused_k,
+            causal=True,
+            max_seqlen_q=md.proxy_max_seqlen_q,
+            max_k_tiles=md.max_k_tiles,
+        )
+
+        # The scalar force_end_blocks cannot express a per-token local window,
+        # so bias each token's last block(s) instead.
+        if md.local_force_index is not None:
+            scores.scatter_(
+                1,
+                md.local_force_index.unsqueeze(0).expand(scores.shape[0], -1, -1),
+                _FORCE_SCORE,
+            )
+
+        # Clamped so msa_topk_select's force-region checks cannot raise.
+        force_begin = min(self.init_blocks, md.max_k_tiles, self.topk_blocks)
+        msa_topk_select(
+            scores,
+            self.topk_blocks,
+            force_begin_blocks=force_begin,
+            output=buf[:num_tokens],
+        )
+
+        # Clear above-causal selections to -1 like the other impls.
+        selected = buf[:num_tokens]
+        assert md.num_valid_pages is not None
+        selected.masked_fill_(selected >= md.num_valid_pages.view(num_tokens, 1, 1), -1)
+        if force_begin > 0:
+            # Forced begin blocks can turn into front -1s for short tokens;
+            # restore the ascending, -1-tail-padded contract.
+            tmp = selected.masked_fill(selected == -1, torch.iinfo(torch.int32).max)
+            tmp, _ = tmp.sort(dim=-1)
+            tmp.masked_fill_(tmp == torch.iinfo(torch.int32).max, -1)
+            selected.copy_(tmp)
+
+        # The attend reads the shared buffer directly.
+        return None, None

--- a/vllm/models/minimax_m3/nvidia/indexer_flashinfer.py
+++ b/vllm/models/minimax_m3/nvidia/indexer_flashinfer.py
@@ -32,9 +32,6 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 # KV page size == sparse block size == flashinfer's MSA block size.
 PAGE_SIZE = 128
 
-# Force-include bias: the max finite float outranks every real score.
-_FORCE_SCORE = torch.finfo(torch.float32).max
-
 
 class MiniMaxM3IndexerFlashInferBackend(MiniMaxM3IndexerBackend):
     """Indexer side-cache backend selecting the FlashInfer builder."""
@@ -53,10 +50,9 @@ class MiniMaxM3IndexerFlashInferMetadata(MiniMaxM3IndexerMetadata):
     proxy_page_table: torch.Tensor | None = None  # [num_reqs, max_pages] int32
     proxy_max_seqlen_q: int = 0
     max_k_tiles: int = 0
-    # Per-token last-block indices [local_blocks, total_q]; None when the
-    # model has no local window.
-    local_force_index: torch.Tensor | None = None
     num_valid_pages: torch.Tensor | None = None  # [total_q] int32
+    # Trailing local window, forced into every token's own selection.
+    local_blocks: int = 0
 
 
 class MiniMaxM3IndexerFlashInferMetadataBuilder(MiniMaxM3IndexerMetadataBuilder):
@@ -100,17 +96,9 @@ class MiniMaxM3IndexerFlashInferMetadataBuilder(MiniMaxM3IndexerMetadataBuilder)
         assert positions is not None
         num_valid_pages = self.num_valid_pages_buffer[:num_tokens]
         num_valid_pages.copy_(positions[:num_tokens] // PAGE_SIZE + 1)
-
-        local_force_index: torch.Tensor | None = None
-        if self.local_blocks > 0:
-            # A token's local window is its last causal blocks; tokens with
-            # fewer blocks than the window clamp onto block 0 (harmless).
-            offsets = torch.arange(
-                self.local_blocks, device=num_valid_pages.device, dtype=torch.int64
-            )
-            local_force_index = (
-                num_valid_pages.to(torch.int64).unsqueeze(0) - 1 - offsets.unsqueeze(1)
-            ).clamp_(min=0)
+        # msa_topk_select wants int32. .to() is a no-op when the shared buffer
+        # already is, and this runs once per step rather than once per layer.
+        num_valid_pages = num_valid_pages.to(torch.int32)
 
         return MiniMaxM3IndexerFlashInferMetadata(
             seq_lens=seq_lens,
@@ -126,8 +114,8 @@ class MiniMaxM3IndexerFlashInferMetadataBuilder(MiniMaxM3IndexerMetadataBuilder)
             proxy_page_table=block_table[:num_reqs],
             proxy_max_seqlen_q=common_attn_metadata.max_query_len,
             max_k_tiles=(common_attn_metadata.max_seq_len + PAGE_SIZE - 1) // PAGE_SIZE,
-            local_force_index=local_force_index,
             num_valid_pages=num_valid_pages,
+            local_blocks=self.local_blocks,
         )
 
 
@@ -174,35 +162,20 @@ class MiniMaxM3IndexerFlashInferImpl(MiniMaxM3IndexerImpl):
             max_k_tiles=md.max_k_tiles,
         )
 
-        # The scalar force_end_blocks cannot express a per-token local window,
-        # so bias each token's last block(s) instead.
-        if md.local_force_index is not None:
-            scores.scatter_(
-                1,
-                md.local_force_index.unsqueeze(0).expand(scores.shape[0], -1, -1),
-                _FORCE_SCORE,
-            )
-
-        # Clamped so msa_topk_select's force-region checks cannot raise.
+        # Per-token valid-page counts carry both the causal clamp and the
+        # trailing local window into the kernel, so nothing needs repairing
+        # afterwards: no selected index can exceed its own token's extent, and
+        # the ascending, -1-tail-padded contract holds by construction.
+        assert md.num_valid_pages is not None
         force_begin = min(self.init_blocks, md.max_k_tiles, self.topk_blocks)
         msa_topk_select(
             scores,
             self.topk_blocks,
+            num_valid_pages=md.num_valid_pages,
             force_begin_blocks=force_begin,
+            force_end_blocks=md.local_blocks,
             output=buf[:num_tokens],
         )
-
-        # Clear above-causal selections to -1 like the other impls.
-        selected = buf[:num_tokens]
-        assert md.num_valid_pages is not None
-        selected.masked_fill_(selected >= md.num_valid_pages.view(num_tokens, 1, 1), -1)
-        if force_begin > 0:
-            # Forced begin blocks can turn into front -1s for short tokens;
-            # restore the ascending, -1-tail-padded contract.
-            tmp = selected.masked_fill(selected == -1, torch.iinfo(torch.int32).max)
-            tmp, _ = tmp.sort(dim=-1)
-            tmp.masked_fill_(tmp == torch.iinfo(torch.int32).max, -1)
-            selected.copy_(tmp)
 
         # The attend reads the shared buffer directly.
         return None, None

--- a/vllm/models/minimax_m3/nvidia/indexer_flashinfer.py
+++ b/vllm/models/minimax_m3/nvidia/indexer_flashinfer.py
@@ -167,13 +167,15 @@ class MiniMaxM3IndexerFlashInferImpl(MiniMaxM3IndexerImpl):
         # afterwards: no selected index can exceed its own token's extent, and
         # the ascending, -1-tail-padded contract holds by construction.
         assert md.num_valid_pages is not None
+        # Both clamped so msa_topk_select's force-region checks cannot raise.
         force_begin = min(self.init_blocks, md.max_k_tiles, self.topk_blocks)
+        force_end = min(md.local_blocks, self.topk_blocks - force_begin)
         msa_topk_select(
             scores,
             self.topk_blocks,
             num_valid_pages=md.num_valid_pages,
             force_begin_blocks=force_begin,
-            force_end_blocks=md.local_blocks,
+            force_end_blocks=force_end,
             output=buf[:num_tokens],
         )
 

--- a/vllm/models/minimax_m3/nvidia/indexer_flashinfer.py
+++ b/vllm/models/minimax_m3/nvidia/indexer_flashinfer.py
@@ -3,9 +3,10 @@
 """FlashInfer indexer impl for MiniMax M3 on SM120/SM121.
 
 One whole-batch ``msa_proxy_score`` call plus one ``msa_topk_select`` call, no
-decode/prefill split. flashinfer's top-k takes only batch-wide scalars, so the
-per-token local window and causal-range clamp are recovered in Python (see
-``forward``). Imported only when ``minimax_m3_use_flashinfer_msa`` passes.
+decode/prefill split. Each token's causal extent and trailing local window go
+to the top-k kernel through the per-token ``num_valid_pages`` tensor and
+``force_end_blocks``. Imported only when ``minimax_m3_use_flashinfer_msa``
+passes.
 """
 
 from dataclasses import dataclass

--- a/vllm/models/minimax_m3/nvidia/model.py
+++ b/vllm/models/minimax_m3/nvidia/model.py
@@ -79,6 +79,7 @@ from vllm.models.minimax_m3.common.mm_preprocess import (
 from vllm.models.minimax_m3.common.sparse_attention import (
     MiniMaxM3SparseBackend,
     MiniMaxM3SparseImpl,
+    minimax_m3_use_flashinfer_msa,
     select_main_backend_and_impl_cls,
 )
 from vllm.models.minimax_m3.common.vision_tower import MiniMaxVLVisionModel
@@ -505,12 +506,21 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
         # Python value, which would freeze at capture).
         self.topk_indices_buffer = topk_indices_buffer
         # Indexer (top-k selection) and main attention are separate impls, each
-        # picking Triton vs MSA off its cache dtype. impl is AttentionImplBase
+        # picking Triton vs MSA off its cache dtype; the FlashInfer verdict is
+        # computed once so both selectors agree. impl is AttentionImplBase
         # (broader than the AttentionImpl that AttentionLayerBase annotates).
+        use_flashinfer_msa = minimax_m3_use_flashinfer_msa(
+            topk_blocks=sparse_cfg["sparse_topk_blocks"],
+            kv_cache_dtype=self.kv_cache_dtype,
+            num_heads=self.num_heads,
+            num_kv_heads=self.num_kv_heads,
+            indexer_kv_dtype=self.indexer_kv_dtype,
+        )
         self.attn_backend, impl_cls = select_main_backend_and_impl_cls(
             topk_blocks=sparse_cfg["sparse_topk_blocks"],
             kv_cache_dtype=self.kv_cache_dtype,
             num_kv_heads=self.num_kv_heads,
+            use_flashinfer_msa=use_flashinfer_msa,
         )
         self.impl: MiniMaxM3SparseImpl = impl_cls(  # type: ignore[assignment]
             self.num_heads,
@@ -539,6 +549,7 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
             cache_config=cache_config,
             indexer_kv_dtype=self.indexer_kv_dtype,
             topk_indices_buffer=topk_indices_buffer,
+            use_flashinfer_msa=use_flashinfer_msa,
         )
 
         # Register the main K/V cache so the KV-cache manager allocates it.

--- a/vllm/models/minimax_m3/nvidia/model.py
+++ b/vllm/models/minimax_m3/nvidia/model.py
@@ -79,6 +79,7 @@ from vllm.models.minimax_m3.common.mm_preprocess import (
 from vllm.models.minimax_m3.common.sparse_attention import (
     MiniMaxM3SparseBackend,
     MiniMaxM3SparseImpl,
+    minimax_m3_use_flashinfer_msa,
     select_main_backend_and_impl_cls,
 )
 from vllm.models.minimax_m3.common.vision_tower import MiniMaxVLVisionModel
@@ -507,12 +508,21 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
         # Python value, which would freeze at capture).
         self.topk_indices_buffer = topk_indices_buffer
         # Indexer (top-k selection) and main attention are separate impls, each
-        # picking Triton vs MSA off its cache dtype. impl is AttentionImplBase
+        # picking Triton vs MSA off its cache dtype; the FlashInfer verdict is
+        # computed once so both selectors agree. impl is AttentionImplBase
         # (broader than the AttentionImpl that AttentionLayerBase annotates).
+        use_flashinfer_msa = minimax_m3_use_flashinfer_msa(
+            topk_blocks=sparse_cfg["sparse_topk_blocks"],
+            kv_cache_dtype=self.kv_cache_dtype,
+            num_heads=self.num_heads,
+            num_kv_heads=self.num_kv_heads,
+            indexer_kv_dtype=self.indexer_kv_dtype,
+        )
         self.attn_backend, impl_cls = select_main_backend_and_impl_cls(
             topk_blocks=sparse_cfg["sparse_topk_blocks"],
             kv_cache_dtype=self.kv_cache_dtype,
             num_kv_heads=self.num_kv_heads,
+            use_flashinfer_msa=use_flashinfer_msa,
         )
         self.impl: MiniMaxM3SparseImpl = impl_cls(  # type: ignore[assignment]
             self.num_heads,
@@ -541,6 +551,7 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
             cache_config=cache_config,
             indexer_kv_dtype=self.indexer_kv_dtype,
             topk_indices_buffer=topk_indices_buffer,
+            use_flashinfer_msa=use_flashinfer_msa,
         )
 
         # Register the main K/V cache so the KV-cache manager allocates it.

--- a/vllm/models/minimax_m3/nvidia/sparse_attention_flashinfer.py
+++ b/vllm/models/minimax_m3/nvidia/sparse_attention_flashinfer.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FlashInfer block-sparse attend for MiniMax M3 on SM120/SM121.
+
+K and V are views split from the packed-content KV cache, so this impl
+requires flashinfer's packed-KV support (``has_flashinfer_msa_packed_kv``).
+Imported only when ``minimax_m3_use_flashinfer_msa`` passes.
+"""
+
+import torch
+from flashinfer.msa_ops import (
+    msa_sparse_attention,
+    msa_sparse_decode_attention,
+)
+
+from vllm.forward_context import get_forward_context
+from vllm.models.minimax_m3.common.sparse_attention import (
+    MiniMaxM3SparseImpl,
+    MiniMaxM3SparseMetadata,
+)
+from vllm.v1.attention.backend import AttentionLayer
+
+
+class MiniMaxM3SparseFlashInferImpl(MiniMaxM3SparseImpl):
+    """flashinfer msa_ops block-sparse attend (prefill + decode)."""
+
+    def forward(
+        self,
+        layer: AttentionLayer,
+        query: torch.Tensor,
+        kv_cache: torch.Tensor,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        attn_metadata = get_forward_context().attn_metadata
+        if not isinstance(attn_metadata, dict):
+            return output  # profiling run; caches unbound
+        main_md = attn_metadata[layer.layer_name]  # type: ignore[attr-defined]
+        assert isinstance(main_md, MiniMaxM3SparseMetadata)
+
+        nd = main_md.num_decode_tokens
+        num_tokens = main_md.num_actual_tokens
+        # The shared top-k buffer is token-major; the kernels need a
+        # contiguous head-major copy.
+        topk = layer.topk_indices_buffer  # type: ignore[attr-defined]
+        assert topk is not None
+        hd = self.head_size
+        q = query[:num_tokens].view(-1, self.num_heads, hd)
+        out = output[:num_tokens].view(-1, self.num_heads, hd)
+        kv_cache = (
+            kv_cache.view(self.kv_cache_fp8_dtype) if self.use_fp8_kv else kv_cache
+        )
+        k_cache, v_cache = kv_cache.split(hd, dim=-1)
+        softmax_scale = self.scale
+        v_scale = None
+        if self.use_fp8_kv:
+            # Logits are linear in K and the output in V, so the fp8 descales
+            # fold exactly into the softmax scale and the kernel output scale.
+            softmax_scale *= layer._k_scale_float  # type: ignore[attr-defined]
+            v_scale = layer._v_scale_float  # type: ignore[attr-defined]
+
+        # Both kernels use the default q_offset, which right-aligns tokens to
+        # match vLLM's positions.
+        if main_md.num_decodes > 0:
+            d = main_md.decode
+            assert d is not None
+            o = msa_sparse_decode_attention(
+                q[:nd],
+                k_cache,
+                v_cache,
+                topk[:nd].transpose(0, 1).contiguous(),
+                page_table=d.block_table,
+                seqused_k=d.seq_lens,
+                seqlen_q=d.decode_query_len,
+                causal=True,
+                softmax_scale=softmax_scale,
+                v_global_scale=v_scale,
+            )
+            out[:nd].copy_(o)
+
+        if main_md.num_prefills > 0:
+            p = main_md.prefill
+            assert p is not None
+            o = msa_sparse_attention(
+                q[nd:],
+                k_cache,
+                v_cache,
+                topk[nd:num_tokens].transpose(0, 1).contiguous(),
+                p.cu_seqlens_q,
+                causal=True,
+                softmax_scale=softmax_scale,
+                page_table=p.block_table,
+                seqused_k=p.seq_lens,
+                v_global_scale=v_scale,
+            )
+            out[nd:].copy_(o)
+        return output

--- a/vllm/models/minimax_m3/nvidia/sparse_attention_flashinfer.py
+++ b/vllm/models/minimax_m3/nvidia/sparse_attention_flashinfer.py
@@ -30,6 +30,8 @@ class MiniMaxM3SparseFlashInferImpl(MiniMaxM3SparseImpl):
         query: torch.Tensor,
         kv_cache: torch.Tensor,
         output: torch.Tensor,
+        *,
+        query_fp8: torch.Tensor | None = None,
     ) -> torch.Tensor:
         attn_metadata = get_forward_context().attn_metadata
         if not isinstance(attn_metadata, dict):

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -233,6 +233,44 @@ def has_flashinfer_sparse_mla_sm120() -> bool:
 
 
 @functools.cache
+def has_flashinfer_msa() -> bool:
+    """Return ``True`` if FlashInfer MiniMax Sparse Attention (MSA) ops for
+    SM120/SM121 (Consumer Blackwell) are available."""
+    if not has_flashinfer():
+        return False
+    try:
+        from flashinfer.msa_ops import (
+            msa_proxy_score,
+            msa_sparse_attention,
+            msa_sparse_decode_attention,
+            msa_topk_select,
+        )
+    except ImportError:
+        return False
+    return all(
+        callable(fn)
+        for fn in (
+            msa_proxy_score,
+            msa_topk_select,
+            msa_sparse_attention,
+            msa_sparse_decode_attention,
+        )
+    )
+
+
+@functools.cache
+def has_flashinfer_msa_packed_kv() -> bool:
+    """Return ``True`` if the FlashInfer MSA attention kernels accept K/V
+    views split from vLLM's packed-content KV cache, advertised by the
+    ``SUPPORTS_PACKED_KV`` flag on ``flashinfer.msa_ops``."""
+    if not has_flashinfer_msa():
+        return False
+    import flashinfer.msa_ops as msa_ops
+
+    return bool(getattr(msa_ops, "SUPPORTS_PACKED_KV", False))
+
+
+@functools.cache
 def has_flashinfer_cutedsl() -> bool:
     """Return ``True`` if FlashInfer cutedsl module is available."""
     return (

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -271,6 +271,21 @@ def has_flashinfer_msa_packed_kv() -> bool:
 
 
 @functools.cache
+def has_flashinfer_msa_per_token_topk() -> bool:
+    """Return ``True`` if ``flashinfer.msa_ops.msa_topk_select`` accepts a
+    per-token ``num_valid_pages`` tensor. Detected from the parameter's type
+    annotation, since flashinfer exposes no capability flag for it."""
+    if not has_flashinfer_msa():
+        return False
+    import inspect
+
+    from flashinfer.msa_ops import msa_topk_select
+
+    ann = inspect.signature(msa_topk_select).parameters["num_valid_pages"].annotation
+    return "Tensor" in str(ann)
+
+
+@functools.cache
 def has_flashinfer_cutedsl() -> bool:
     """Return ``True`` if FlashInfer cutedsl module is available."""
     return (

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -254,6 +254,44 @@ def has_flashinfer_sparse_mla_sm120_config(num_q_heads: int, top_k: int) -> bool
 
 
 @functools.cache
+def has_flashinfer_msa() -> bool:
+    """Return ``True`` if FlashInfer MiniMax Sparse Attention (MSA) ops for
+    SM120/SM121 (Consumer Blackwell) are available."""
+    if not has_flashinfer():
+        return False
+    try:
+        from flashinfer.msa_ops import (
+            msa_proxy_score,
+            msa_sparse_attention,
+            msa_sparse_decode_attention,
+            msa_topk_select,
+        )
+    except ImportError:
+        return False
+    return all(
+        callable(fn)
+        for fn in (
+            msa_proxy_score,
+            msa_topk_select,
+            msa_sparse_attention,
+            msa_sparse_decode_attention,
+        )
+    )
+
+
+@functools.cache
+def has_flashinfer_msa_packed_kv() -> bool:
+    """Return ``True`` if the FlashInfer MSA attention kernels accept K/V
+    views split from vLLM's packed-content KV cache, advertised by the
+    ``SUPPORTS_PACKED_KV`` flag on ``flashinfer.msa_ops``."""
+    if not has_flashinfer_msa():
+        return False
+    import flashinfer.msa_ops as msa_ops
+
+    return bool(getattr(msa_ops, "SUPPORTS_PACKED_KV", False))
+
+
+@functools.cache
 def has_flashinfer_cutedsl() -> bool:
     """Return ``True`` if FlashInfer cutedsl module is available."""
     return (

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -292,6 +292,21 @@ def has_flashinfer_msa_packed_kv() -> bool:
 
 
 @functools.cache
+def has_flashinfer_msa_per_token_topk() -> bool:
+    """Return ``True`` if ``flashinfer.msa_ops.msa_topk_select`` accepts a
+    per-token ``num_valid_pages`` tensor. Detected from the parameter's type
+    annotation, since flashinfer exposes no capability flag for it."""
+    if not has_flashinfer_msa():
+        return False
+    import inspect
+
+    from flashinfer.msa_ops import msa_topk_select
+
+    ann = inspect.signature(msa_topk_select).parameters["num_valid_pages"].annotation
+    return "Tensor" in str(ann)
+
+
+@functools.cache
 def has_flashinfer_cutedsl() -> bool:
     """Return ``True`` if FlashInfer cutedsl module is available."""
     return (


### PR DESCRIPTION
## Purpose

> **Note: this PR waits on FlashInfer v0.6.18.** The kernels it calls need per-token top-k bounds ([flashinfer-ai/flashinfer#4324](https://github.com/flashinfer-ai/flashinfer/pull/4324)), whose first release will be v0.6.18 (currently at rc). With vLLM's current `flashinfer-python==0.6.17` pin the feature probes keep every configuration on the existing Triton fallback, so the PR is safe to merge ahead of the pin bump but stays inactive until it.

Give MiniMax-M3 sparse attention a fast path on consumer Blackwell (SM120/SM121). These GPUs currently run the Triton fallback for both the lightning indexer and the block-sparse attend, since the vendored MSA kernels are SM100-only. FlashInfer v0.6.16 ships MSA kernels for SM120/SM121 ([flashinfer-ai/flashinfer#3655](https://github.com/flashinfer-ai/flashinfer/pull/3655)). This PR wires them into the existing impl dispatch, selected the same way as the SM100 MSA path; every other configuration keeps the Triton fallback.

Design:

- The indexer issues one scoring call and one top-k call for the entire batch, prefill and decode tokens together, so kernel-launch overhead stays constant per step and there is no separate decode/prefill code path.
- Each token's causal extent and trailing local window go to FlashInfer's top-k kernel through its per-token `num_valid_pages` and `force_end_blocks` arguments (added in [flashinfer-ai/flashinfer#4324](https://github.com/flashinfer-ai/flashinfer/pull/4324)), so no per-token masking happens in Python. The commit pushing the bounds into the kernel is authored by @rmhaskarnvidia.
- The attend runs the FlashInfer prefill and decode kernels on vLLM's paged KV cache exactly as stored, so the path adds no per-step copy or re-layout of KV data; fp8 KV scales fold into the kernels' existing scale arguments.
- The FlashInfer indexer and attend must be enabled together: they exchange top-k results in a different buffer layout than the Triton pair, and a mixed pairing would attend to the wrong blocks without any error. A single predicate (`minimax_m3_use_flashinfer_msa`) therefore drives both selections.
- Three feature probes in `vllm/utils/flashinfer.py` gate the path; older FlashInfer releases keep the Triton fallback.

Dependencies:

- `flashinfer.msa_ops` with packed KV-cache support ([flashinfer-ai/flashinfer#4039](https://github.com/flashinfer-ai/flashinfer/pull/4039), shipped in v0.6.17, vLLM's current pin): the attend reads K/V views split from vLLM's packed KV cache, advertised as `msa_ops.SUPPORTS_PACKED_KV`.
- Per-token `msa_topk_select` bounds ([flashinfer-ai/flashinfer#4324](https://github.com/flashinfer-ai/flashinfer/pull/4324)), first release will be v0.6.18. Until vLLM's pin reaches it, the probes keep every configuration on the Triton fallback, so this PR is inert-but-safe to merge ahead of the pin bump.

Scope notes:

- The FlashInfer path engages only for `sparse_topk_blocks == 16` and decode GQA group sizes up to 16, narrower than the Triton path; M3 configurations satisfy both limits, and anything outside them keeps the Triton fallback.
- `fp8_e5m2` KV caches and `nvfp4` indexer caches also stay on the Triton fallback.

## Test Plan

Both new tests are in `tests/kernels/attention/test_minimax_m3.py`:

- `test_flashinfer_indexer_impl_matches_triton`: runs the FlashInfer and Triton indexer impls on the same batches through their real metadata builders and asserts they select the same blocks, over bf16/fp8 index caches and local-window settings, including a short decode request.
- `test_flashinfer_sparse_attention_matches_reference`: runs the FlashInfer attend at the impl's exact call shape (K/V views split from the contract-allocated cache) against the same reference the Triton kernels are tested with, over both KV-cache layouts, mixed prefill batches, and decode.
- End-to-end and performance runs wait on a FlashInfer release containing #4324 (v0.6.18); results will be posted in this thread.

## Test Result

- Indexer and attend parity: all kernel-level cases pass on RTX 5080 (SM120) with FlashInfer built from source (#4039 branch, now released in v0.6.17, plus the #4324 branch); the full stack was re-validated after folding in the per-token top-k commit (15/15 per-token, 63/63 msa_ops, 57 pass / 15 SM100-only skips in test_minimax_m3).
- On FlashInfer releases without the required features the probes keep the Triton fallback, and a manual mismatch fails loudly at call time instead of producing wrong results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
