### PR TITLE
[Bugfix] Suppress spurious EngineDeadError log during intentional AsyncLLM shutdown

### DIFF
--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -258,6 +258,10 @@ class AsyncLLM(EngineClient):
 
     def shutdown(self, timeout: float | None = None) -> None:
         """Shutdown, cleaning up the background proc and IPC."""
+        # Set before teardown, so it's visible in time.
+        shutdown_initiated = getattr(self, "_shutdown_initiated", None)
+        if shutdown_initiated is not None:
+            shutdown_initiated[0] = True
         shutdown_prometheus()
 
         if renderer := getattr(self, "renderer", None):
@@ -653,6 +657,13 @@ class AsyncLLM(EngineClient):
         renderer = self.renderer
         chunk_size = envs.VLLM_V1_OUTPUT_PROC_CHUNK_SIZE
 
+        # Track whether shutdown() has been called intentionally
+        # to distinguish between real engine crash
+        # from the EngineDeadError poison pill
+        # Use a mutable list to avoid circular reference
+        shutdown_initiated = [False]
+        self._shutdown_initiated = shutdown_initiated
+
         async def output_handler():
             try:
                 while True:
@@ -700,6 +711,14 @@ class AsyncLLM(EngineClient):
                             iteration_stats=iteration_stats,
                             mm_cache_stats=renderer.stat_mm_cache(),
                         )
+            except EngineDeadError as e:
+                # only log loudly if shutdown wasn't requested
+                if shutdown_initiated[0]:
+                    logger.debug("output_handler exiting: engine client shut down")
+                    return
+                logger.exception("AsyncLLM output_handler failed.")
+                output_processor.propagate_error(e)
+
             except Exception as e:
                 logger.exception("AsyncLLM output_handler failed.")
                 output_processor.propagate_error(e)


### PR DESCRIPTION
  <!-- markdownlint-disable -->
  ## Purpose
  
  Fixes #48745.
  
  On an intentional shutdown (SIGTERM/SIGINT), AsyncLLM.shutdown() tears down the engine core before cancelling the output_handler task. AsyncMPClient's output queue task (process_outputs_socket) reacts to its own cancellation by pushing an EngineDeadError poison pill into outputs_queue, intended to unblock any pending request waiters. If output_handler is still alive and observes this pill before its own cancellation lands, it logs the error as AsyncLLM output_handler failed. with a full traceback, even though the shutdown is proceeding normally and completes successfully. This is a race: whichever
  cancellation the event loop processes first determines whether the error is logged.
  
  This adds a _shutdown_initiated flag, set as the first statement of AsyncLLM.shutdown(), before any teardown can occur. output_handler checks this flag specifically when it catches EngineDeadError: if a shutdown was requested, it logs at DEBUG and exits quietly; otherwise (a real engine crash, or any other exception type) it logs loudly and propagates the error as before. Since the flag is set before teardown begins, output_handler can never observe the poison pill before the flag is visible to it, closing the race deterministically.
  
  ## Test Plan
  
  1. Ran the server locally (vllm serve Qwen/Qwen3-Embedding-0.6B --runner pooling --max-model-len 1024 --gpu-memory-utilization 0.25 --enforce-eager), sent a real request, then sent SIGTERM, repeated 15 times.
  2. Ran the same scenario with SIGINT (Ctrl+C) as well. 
  3. Simulated a real crash by sending kill -9 directly to the EngineCore process (not the API server) while idle, to confirm the fix doesn't suppress genuine crashes.
  4. Ran pytest tests/v1/engine/ -k "async_llm or shutdown" --ignore=tests/v1/engine/test_engine_core_client.py. test_background_resources_passes_worker_shutdown_timeout passed. Most test_async_llm.py tests failed locally due to lack of credentials for a gated HF model (meta-llama/Llama-3.2-1B-Instruct) used as test fixture data, unrelated to this change. This is confirmed via git stash that the same tests fail identically on unmodified main.
  
  ## Test Result
  
  1. **Before the fix**: intentional shutdown intermittently (~50%) logged a spurious ERROR ... AsyncLLM output_handler failed. / EngineDeadError traceback despite completing cleanly.
  ```
  (APIServer pid=59556) INFO 07-15 15:34:23 [core_client.py:662] [shutdown] MPClient: complete
  (APIServer pid=59556) ERROR 07-15 15:34:23 [async_llm.py:704] AsyncLLM output_handler failed.
  (APIServer pid=59556) ERROR 07-15 15:34:23 [async_llm.py:704] Traceback (most recent call last): ....
  (APIServer pid=59556) ERROR 07-15 15:34:23 [async_llm.py:704] vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue. See stack trace (above) for the root cause.
  ```
  2. **After the fix**: 15/15 intentional SIGTERM and SIGINT shutdowns (with a real request sent beforehand) completed with no spurious ERROR log.
  ```
  (EngineCore pid=199786) INFO 07-17 22:35:31 [core.py:1223] [shutdown] EngineCore: trigger received signal=SIGINT ...
  (APIServer pid=199386) INFO 07-17 22:35:31 [core_client.py:662] [shutdown] MPClient: complete
  (APIServer pid=199386) INFO 07-17 22:35:31 [launcher.py:125] [shutdown] API server: engine client stopped
  (APIServer pid=199386) INFO 07-17 22:35:31 [launcher.py:128] [shutdown] API server: signalling HTTP server shutdown
  (APIServer pid=199386) INFO 07-17 22:35:31 [launcher.py:149] [shutdown] API server: shutting down FastAPI HTTP server
  (APIServer pid=199386) INFO:     Shutting down
  (APIServer pid=199386) INFO:     Waiting for application shutdown.
  (APIServer pid=199386) INFO:     Application shutdown complete.
  ```
  
  3. Real crash (kill -9 on EngineCore) still logs EngineCore exited unexpectedly and the AsyncLLM output_handler failed. ERROR as before. This confirms the fix is scoped to the intentional-shutdown case only.
  ```
  (APIServer pid=218722) INFO 07-17 23:12:29 [core_client.py:662] [shutdown] MPClient: complete
  (APIServer pid=218722) ERROR 07-17 23:12:29 [async_llm.py:712] AsyncLLM output_handler failed.
  (APIServer pid=218722) ERROR 07-17 23:12:29 [async_llm.py:712] Traceback (most recent call last): ...
  (APIServer pid=218722) ERROR 07-17 23:12:29 [async_llm.py:712] vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue. See stack trace (above) for the root cause.
  ```
**Note:** Parts of this PR (root-cause investigation, drafting, and testing script assistance) were developed with the help of Claude (Anthropic). All code was reviewed, understood, and verified by me before submission.

  ---
  <details>
  <summary> Essential Elements of an Effective PR Description Checklist </summary>
  
  - [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
  - [x] The test plan, such as providing test command.
  - [x] The test results, such as pasting the results comparison before and after, or e2e results
  - [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
  </details>