### PR TITLE
[Bugfix] Retry config read to survive concurrent HF cache refresh

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -731,13 +731,17 @@ def get_config(
             raise ValueError(error_message) from e
 
     config_parser = get_config_parser(config_format)
-    config_dict, config = config_parser.parse(
-        model,
-        trust_remote_code=trust_remote_code,
-        revision=revision,
-        code_revision=code_revision,
-        hf_overrides=hf_overrides_kw or hf_overrides_fn,
-        **kwargs,
+    # Retry to tolerate a concurrent HF cache refresh briefly hiding config.json.
+    config_dict, config = with_retry(
+        lambda: config_parser.parse(
+            model,
+            trust_remote_code=trust_remote_code,
+            revision=revision,
+            code_revision=code_revision,
+            hf_overrides=hf_overrides_kw or hf_overrides_fn,
+            **kwargs,
+        ),
+        f"Error parsing config for {model}",
     )
 
     # Architecture mapping for models without explicit architectures field


### PR DESCRIPTION
## Purpose

`tests/v1/distributed/test_external_lb_dp.py` intermittently fails on ROCm CI (`Distributed DP Tests (2 GPUs)`) with the `[4]` (`api_server_count=4`) cases erroring as `Exception: Servers failed to start`. The real cause, hidden one level down in the server log, is one API-server process dying during startup with `pydantic ... Value error, Unrecognized model in ibm-research/PowerMoE-3b. Should have a model_type key in its config.json`, while its sibling processes resolve the same model fine.

Root cause: with `--api-server-count N`, each API server is a separate spawned process that independently calls `get_config`, so N processes read the shared HF cache `config.json` at once. `huggingface_hub` recreates a cached file's snapshot symlink non-atomically - `_create__
symlink` does `os.remove(dst)` followed by `os.symlink(...)` - so during a cache refresh (online etag revalidation, aggravated by HF Hub 429 throttling seen in the CI log) there is a brief window where `config.json` is missing or empty. A peer process that opens the file in tt
hat window gets back a content-less dict and raises the misleading "Unrecognized model" error, which cascades to the generic "Servers failed to start".

Fix: retry the whole parse in `get_config` (config.json can be read more than once per parse - `get_config_dict` and then `AutoConfig.from_pretrained`), reusing the existing `with_retry` helper. The transient read surfaces as an exception, so no config-content inspection is nn
eeded. The read self-heals because the underlying file is valid before and after the sub-millisecond swap window. A genuinely empty or malformed config still raises after retries, so real errors are not masked.

Not a duplicate: no open PR or issue addresses concurrent config-read failures under `api-server-count` (checked open PRs for config/read/retry and "Unrecognized model config.json race").

AI assistance: this change was prepared with AI assistance (Claude). The root cause was diagnosed from the CI log and confirmed by reproducing the exact error locally; a human should review every line and re-run the checks below before merge.

## Test Plan

Distributed test that flakes in CI (2 GPUs, ROCm gfx942, from `.buildkite/test-amd.yaml`):

```
export NCCL_CUMEM_HOST_ENABLE=0
TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_external_lb_dp.py
```

Because the race is rare in a natural run (the distributed test passed 48/48 times locally), the mechanism was fault-injected to trigger it on demand: 4 threads call `get_config("ibm-research/PowerMoE-3b")` while a background thread loops `huggingface_hub.file_download._create_symlink` on the cached `config.json`, spaced ~50 ms apart to mimic a real cache refresh. The failure rate below is a property of this injection harness, not the natural CI reproduction rate - it exists to reproduce the exact error and to show the fix eliminates it.

## Test Result

Distributed test passes:

```
6 passed, 16 warnings in 164.57s
```

Injection harness (~800 symlink swaps per run):

```
before fix:  627 reads, 4 failures (2x "Unrecognized model", 2x FileNotFoundError)
after fix:   523 reads, 0 failures
```

"before fix" reproduces the exact CI error (`Unrecognized model`); "after fix" eliminates it across repeated runs.

Regression / fail-closed checks: a valid warm model still loads with no retries triggered (`get_config` returns `granitemoe`); a genuinely empty `{}` config still raises after exhausting retries rather than hanging or being silently accepted.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

