### PR TITLE
[Bugfix] Detect CUDA via the driver API when NVML is unavailable

### DIFF
--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -98,8 +98,41 @@ def cuda_platform_plugin() -> str | None:
                 "/sys/class/tegra-firmware"
             )
 
+        def cuda_driver_api_usable() -> bool:
+            # NVML can be absent or non-functional while the CUDA driver API
+            # works, e.g. WSL2 setups whose driver exposes working libcuda
+            # stubs but whose NVML cannot communicate with the driver. Probe
+            # the driver API in a subprocess so CUDA is never initialized in
+            # this process before workers may fork.
+            import subprocess
+            import sys
+
+            probe = (
+                "import ctypes, sys; "
+                "lib = ctypes.CDLL('libcuda.so.1'); "
+                "count = ctypes.c_int(0); "
+                "sys.exit(0 if lib.cuInit(0) == 0 "
+                "and lib.cuDeviceGetCount(ctypes.byref(count)) == 0 "
+                "and count.value > 0 else 1)"
+            )
+            try:
+                result = subprocess.run(
+                    [sys.executable, "-c", probe],
+                    capture_output=True,
+                    timeout=60,
+                )
+            except (OSError, subprocess.SubprocessError):
+                return False
+            return result.returncode == 0
+
         if cuda_is_jetson():
             logger.debug("Confirmed CUDA platform is available on Jetson.")
+            is_cuda = True
+        elif not vllm_version_matches_substr("cpu") and cuda_driver_api_usable():
+            logger.debug(
+                "Confirmed CUDA platform is available via the CUDA driver "
+                "API; NVML is not functional in this environment."
+            )
             is_cuda = True
         else:
             logger.debug("CUDA platform is not available because: %s", str(e))


### PR DESCRIPTION
## Purpose

Fix CUDA platform detection in environments where NVML is absent or non-functional while the CUDA driver API works.

`cuda_platform_plugin()` currently detects CUDA exclusively through `pynvml`, with a Jetson file-marker check as the only non-NVML fallback. There are environments where `nvmlInit()` fails ("Driver Not Loaded") while `libcuda` is fully functional — a reproducible case is certain WSL2 setups where the GPU driver injects working `libcuda` stubs into `/usr/lib/wsl/lib` but NVML cannot communicate with the driver (`nvidia-smi` fails the same way). In those environments vLLM exits with:

```
RuntimeError: Failed to infer device type
```

even though CUDA is fully usable — `NonNvmlCudaPlatform` in `vllm/platforms/cuda.py` already supports serving without NVML once the platform is selected; it's only the *detection* step that is NVML-only.

This PR adds a driver-API fallback probe (`cuInit` + `cuDeviceGetCount`) in the NVML-failure branch, mirroring the existing Jetson special case. Design notes:

- The probe runs in a **short-lived subprocess**, so CUDA is never initialized in the parent process before workers may fork (the reason detection avoids the CUDA runtime in the first place; see also #44252 / #47078 for the fork-poisoning class of issues).
- It only executes on the existing NVML-failure path — zero behavior/overhead change for machines where NVML works, for CPU-only machines (`libcuda.so.1` missing → probe returns `False`), and for cpu builds (existing `vllm_version_matches_substr("cpu")` guard applied).
- The related `import vllm` circular-import crash on WSL is **not** addressed here — it is already covered by #48444; this change is complementary (after #48444 fixes the import, platform detection is the next failure on NVML-less systems).

**Why this is not duplicating an existing PR:** searched open PRs/issues for `cuda_platform_plugin`, "NVML platform detection", "Failed to infer device type", and WSL detection fixes. #48444 fixes the WSL pin-memory circular import (different bug, see above); #38434 / #41585 are ROCm detection; #44252 / #47078 address CUDA-init-before-fork (this PR deliberately avoids introducing that problem via the subprocess probe). No open PR touches NVML-less CUDA *detection*.

**AI assistance disclosure:** this change was developed with AI assistance (Claude). The submitter has reviewed every changed line and run the validation below.

## Test Plan

1. Environment where the bug reproduces (WSL2, working `libcuda`, non-functional NVML — `nvidia-smi` reports "couldn't communicate with the NVIDIA driver"):
   ```bash
   python -c "from vllm.platforms import current_platform; print(current_platform.device_type)"
   ```
   Before: `RuntimeError: Failed to infer device type`. After: `cuda` (resolves to `NonNvmlCudaPlatform`).
2. Probe unit behavior, standalone:
   - On the affected WSL2 environment: probe subprocess exits 0 (usable).
   - On a machine without `libcuda.so.1` (macOS/CPU-only): probe exits non-zero (not usable) — detection outcome unchanged.
3. Regression: on a standard Linux + NVML machine the NVML path succeeds first and the new code never runs.
4. Lint: `pre-commit run --files vllm/platforms/__init__.py` — all hooks pass (including ruff check/format and the no-new-`torch.cuda`-calls check).

## Test Result

- Affected WSL2 environment (NVML non-functional): probe subprocess returncode `0` → platform resolves to `NonNvmlCudaPlatform` / `cuda`. With a functionally identical patch applied to a v0.25.1 venv on that machine, `vllm serve Qwen/Qwen3-8B-FP8` started and completed a full OpenAI-serving benchmark grid (ISL 1k/8k × concurrency 1/2/4, 140/140 requests, CUDA graphs enabled), where unpatched vLLM cannot pass platform detection at all.
- macOS host without libcuda: probe returncode `1` → no CUDA platform (unchanged).
- `pre-commit run --files vllm/platforms/__init__.py`: Passed.
