### PR TITLE
[Bugfix] Apply kv_b_proj LoRA across MLA paths

### DIFF
--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -12,6 +12,7 @@ from vllm.config import ModelConfig, VllmConfig
 from vllm.config.lora import LoRAConfig
 from vllm.lora.layers import (
     ColumnParallelLinearWithLoRA,
+    ColumnParallelLinearWithShardedLoRA,
     MergedColumnParallelLinearWithLoRA,
     ReplicatedLinearWithLoRA,
     RowParallelLinearWithLoRA,
@@ -28,6 +29,7 @@ from vllm.lora.peft_helper import PEFTHelper
 from vllm.lora.request import LoRARequest
 from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager, WorkerLoRAManager
 from vllm.model_executor.layers.fused_moe import GateLinear
+from vllm.model_executor.layers.linear import ColumnParallelLinear
 from vllm.platforms import current_platform
 
 from .utils import create_peft_lora
@@ -133,6 +135,36 @@ def test_replace_submodules(default_vllm_config, dist_init, dummy_model):
     )
     assert isinstance(model.get_submodule("dense2"), RowParallelLinearWithLoRA)
     assert isinstance(model.get_submodule("layer1.dense2"), RowParallelLinearWithLoRA)
+
+
+def test_mla_kv_b_proj_keeps_replicated_lora_a(
+    default_vllm_config, dist_init, dummy_model
+):
+    model = dummy_model
+    model.add_module("kv_b_proj", ColumnParallelLinear(16, 32))
+    manager = LoRAModelManager(
+        model,
+        1,
+        1,
+        1,
+        LoRAConfig(
+            max_lora_rank=8,
+            max_cpu_loras=1,
+            max_loras=1,
+            lora_dtype=DEFAULT_DTYPE,
+            fully_sharded_loras=True,
+            target_modules=["dense1", "kv_b_proj"],
+        ),
+        torch.device(DEVICES[0]),
+        default_vllm_config,
+    )
+
+    assert isinstance(
+        manager.model.get_submodule("dense1"), ColumnParallelLinearWithShardedLoRA
+    )
+    kv_b_proj = manager.model.get_submodule("kv_b_proj")
+    assert isinstance(kv_b_proj, ColumnParallelLinearWithLoRA)
+    assert not isinstance(kv_b_proj, ColumnParallelLinearWithShardedLoRA)
 
 
 def test_wrap_replicated_linear_subclasses(default_vllm_config, dist_init, dummy_model):

--- a/tests/lora/test_punica_ops.py
+++ b/tests/lora/test_punica_ops.py
@@ -636,3 +636,140 @@ def test_add_lora_fused_moe_early_exit(device):
     assert torch.equal(y, y_snapshot), (
         "add_lora_fused_moe modified output tensor despite no_lora_flag_cpu=True"
     )
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(), reason="MLA LoRA kernels require CUDA"
+)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_mla_kv_b_lora_uses_explicit_token_mapping(dtype):
+    device = f"{DEVICE_TYPE}:0"
+    set_random_seed(0)
+    num_tokens = 7
+    num_heads = 3
+    kv_lora_rank = 16
+    qk_nope_head_dim = 8
+    v_head_dim = 8
+    lora_rank = 4
+    num_loras = 2
+    full_head_dim = qk_nope_head_dim + v_head_dim
+    mapping = torch.tensor([1, -1, 0, 1, 0, -1, 1], device=device)
+    no_lora_flag_cpu = torch.tensor([False], dtype=torch.bool, device="cpu")
+
+    lora_a = torch.randn(
+        num_loras, 1, lora_rank, kv_lora_rank, dtype=dtype, device=device
+    )
+    lora_b = torch.randn(
+        num_loras,
+        1,
+        num_heads * full_head_dim,
+        lora_rank,
+        dtype=dtype,
+        device=device,
+    )
+    b_by_head = lora_b[:, 0].view(num_loras, num_heads, full_head_dim, lora_rank)
+
+    x = torch.randn(num_tokens, kv_lora_rank, dtype=dtype, device=device)
+    linear_output = torch.randn(
+        num_tokens, num_heads * full_head_dim, dtype=dtype, device=device
+    )
+    expected_linear = linear_output.clone()
+    q_nope = torch.randn(
+        num_tokens,
+        num_heads,
+        qk_nope_head_dim,
+        dtype=dtype,
+        device=device,
+    )
+    q_output = torch.randn(
+        num_tokens, num_heads, kv_lora_rank, dtype=dtype, device=device
+    )
+    expected_q = q_output.clone()
+    latent_output = torch.randn_like(q_output)
+    v_output = torch.randn(
+        num_tokens, num_heads, v_head_dim, dtype=dtype, device=device
+    )
+    expected_v = v_output.clone()
+
+    for token_idx, lora_id in enumerate(mapping.tolist()):
+        if lora_id == -1:
+            continue
+        a = lora_a[lora_id, 0]
+        b = lora_b[lora_id, 0]
+        expected_linear[token_idx] = (
+            expected_linear[token_idx].float()
+            + x[token_idx].float() @ a.float().T @ b.float().T
+        ).to(dtype)
+        expected_q[token_idx] = (
+            expected_q[token_idx].float()
+            + torch.einsum(
+                "hp,hpr,rl->hl",
+                q_nope[token_idx].float(),
+                b_by_head[lora_id, :, :qk_nope_head_dim].float(),
+                a.float(),
+            )
+        ).to(dtype)
+        expected_v[token_idx] = (
+            expected_v[token_idx].float()
+            + torch.einsum(
+                "hl,rl,hvr->hv",
+                latent_output[token_idx].float(),
+                a.float(),
+                b_by_head[lora_id, :, qk_nope_head_dim:].float(),
+            )
+        ).to(dtype)
+
+    triton_ops.mla_kv_b_lora_linear(
+        x, lora_a, lora_b, linear_output, mapping, no_lora_flag_cpu
+    )
+    triton_ops.mla_kv_b_lora_q(
+        q_nope,
+        lora_a,
+        lora_b,
+        q_output,
+        mapping,
+        no_lora_flag_cpu,
+        v_head_dim,
+    )
+    triton_ops.mla_kv_b_lora_v(
+        latent_output,
+        lora_a,
+        lora_b,
+        v_output,
+        mapping,
+        no_lora_flag_cpu,
+        qk_nope_head_dim,
+    )
+
+    torch.testing.assert_close(linear_output, expected_linear, rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(q_output, expected_q, rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(v_output, expected_v, rtol=3e-2, atol=3e-2)
+
+    no_lora_flag_cpu.fill_(True)
+    linear_snapshot = linear_output.clone()
+    q_snapshot = q_output.clone()
+    v_snapshot = v_output.clone()
+    triton_ops.mla_kv_b_lora_linear(
+        x, lora_a, lora_b, linear_output, mapping, no_lora_flag_cpu
+    )
+    triton_ops.mla_kv_b_lora_q(
+        q_nope,
+        lora_a,
+        lora_b,
+        q_output,
+        mapping,
+        no_lora_flag_cpu,
+        v_head_dim,
+    )
+    triton_ops.mla_kv_b_lora_v(
+        latent_output,
+        lora_a,
+        lora_b,
+        v_output,
+        mapping,
+        no_lora_flag_cpu,
+        qk_nope_head_dim,
+    )
+    torch.testing.assert_close(linear_output, linear_snapshot)
+    torch.testing.assert_close(q_output, q_snapshot)
+    torch.testing.assert_close(v_output, v_snapshot)

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+from typing import Any, cast
+
 import torch
 import torch.nn as nn
 from transformers import PretrainedConfig
@@ -156,6 +158,61 @@ class ColumnParallelLinearWithLoRA(BaseLinearLayerWithLoRA):
 
         output_bias = self.base_layer.bias if self.base_layer.skip_bias_add else None
         return output, output_bias
+
+    def apply_mla_kv_b_lora_linear(
+        self,
+        input_: torch.Tensor,
+        output: torch.Tensor,
+        token_lora_mapping: torch.Tensor,
+    ) -> None:
+        from vllm.lora.ops.triton_ops.mla_kv_b_lora import mla_kv_b_lora_linear
+
+        mla_kv_b_lora_linear(
+            input_,
+            self.lora_a_stacked[0],
+            self.lora_b_stacked[0],
+            output,
+            token_lora_mapping,
+            cast(Any, self.punica_wrapper).token_mapping_meta.no_lora_flag_cpu,
+        )
+
+    def apply_mla_kv_b_lora_q(
+        self,
+        q_nope: torch.Tensor,
+        output: torch.Tensor,
+        token_lora_mapping: torch.Tensor,
+        v_head_dim: int,
+    ) -> None:
+        from vllm.lora.ops.triton_ops.mla_kv_b_lora import mla_kv_b_lora_q
+
+        mla_kv_b_lora_q(
+            q_nope,
+            self.lora_a_stacked[0],
+            self.lora_b_stacked[0],
+            output,
+            token_lora_mapping,
+            cast(Any, self.punica_wrapper).token_mapping_meta.no_lora_flag_cpu,
+            v_head_dim,
+        )
+
+    def apply_mla_kv_b_lora_v(
+        self,
+        latent_output: torch.Tensor,
+        output: torch.Tensor,
+        token_lora_mapping: torch.Tensor,
+        qk_nope_head_dim: int,
+    ) -> None:
+        from vllm.lora.ops.triton_ops.mla_kv_b_lora import mla_kv_b_lora_v
+
+        mla_kv_b_lora_v(
+            latent_output,
+            self.lora_a_stacked[0],
+            self.lora_b_stacked[0],
+            output,
+            token_lora_mapping,
+            cast(Any, self.punica_wrapper).token_mapping_meta.no_lora_flag_cpu,
+            qk_nope_head_dim,
+        )
 
     @classmethod
     @_not_fully_sharded_can_replace

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -10,6 +10,7 @@ from torch import nn
 
 from vllm.config import VllmConfig
 from vllm.config.lora import LoRAConfig
+from vllm.config.utils import replace as replace_config
 from vllm.logger import init_logger
 from vllm.lora.layers import (
     BaseLayerWithLoRA,
@@ -454,13 +455,23 @@ class LoRAModelManager:
                 # LoRA weights of w1 and w3 have already been fused on disk.
 
                 packed_moduled_lst = ["w13"] if self._is_3d_moe_model else ["w1", "w3"]
+            module_lora_config = self.lora_config
+            if self.lora_config.fully_sharded_loras and module_name.endswith(
+                "kv_b_proj"
+            ):
+                # MLA decode applies this adapter after the base K/V weights
+                # have been absorbed. Keep A replicated so the routed
+                # correction is local on every tensor-parallel rank.
+                module_lora_config = replace_config(
+                    self.lora_config, fully_sharded_loras=False
+                )
             new_module = replace_submodule(
                 self.model,
                 module_name,
                 from_layer(
                     module,
                     self.lora_slots,
-                    self.lora_config,
+                    module_lora_config,
                     packed_moduled_lst,
                     self.model.config,
                 ),

--- a/vllm/lora/ops/triton_ops/__init__.py
+++ b/vllm/lora/ops/triton_ops/__init__.py
@@ -17,6 +17,11 @@ from vllm.lora.ops.triton_ops.lora_expand_op import lora_expand
 from vllm.lora.ops.triton_ops.lora_kernel_metadata import LoRAKernelMeta
 from vllm.lora.ops.triton_ops.lora_shrink_fp8_op import lora_shrink_fp8
 from vllm.lora.ops.triton_ops.lora_shrink_op import lora_shrink
+from vllm.lora.ops.triton_ops.mla_kv_b_lora import (
+    mla_kv_b_lora_linear,
+    mla_kv_b_lora_q,
+    mla_kv_b_lora_v,
+)
 
 __all__ = [
     "lora_expand",
@@ -24,6 +29,9 @@ __all__ = [
     "lora_shrink",
     "lora_shrink_fp8",
     "LoRAKernelMeta",
+    "mla_kv_b_lora_linear",
+    "mla_kv_b_lora_q",
+    "mla_kv_b_lora_v",
     "fused_moe_lora",
     "fused_moe_lora_shrink",
     "fused_moe_lora_expand",

--- a/vllm/lora/ops/triton_ops/__init__.py
+++ b/vllm/lora/ops/triton_ops/__init__.py
@@ -22,6 +22,7 @@ from vllm.lora.ops.triton_ops.mla_kv_b_lora import (
     mla_kv_b_lora_q,
     mla_kv_b_lora_v,
 )
+from vllm.lora.ops.triton_ops.routed_lora_matmul import routed_lora_two_stage
 
 __all__ = [
     "lora_expand",
@@ -32,6 +33,7 @@ __all__ = [
     "mla_kv_b_lora_linear",
     "mla_kv_b_lora_q",
     "mla_kv_b_lora_v",
+    "routed_lora_two_stage",
     "fused_moe_lora",
     "fused_moe_lora_shrink",
     "fused_moe_lora_expand",

--- a/vllm/lora/ops/triton_ops/mla_kv_b_lora.py
+++ b/vllm/lora/ops/triton_ops/mla_kv_b_lora.py
@@ -1,0 +1,351 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Explicitly routed LoRA corrections for MLA ``kv_b_proj``.
+
+MLA does not always execute ``kv_b_proj.forward``. Dense prefill keeps a
+reference to the original linear layer, while decode uses K/V weights that
+were absorbed during model initialization. The helpers in this module apply
+the missing low-rank delta with a token-to-adapter mapping supplied by the
+caller. Using an explicit mapping is important for mixed prefill/decode
+batches and for context tokens gathered from the KV cache.
+"""
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+
+_BLOCK_K = 64
+_BLOCK_N = 64
+
+
+@triton.jit
+def _routed_matmul_kernel(
+    x,
+    weight,
+    output,
+    token_lora_mapping,
+    num_tokens,
+    num_heads: tl.constexpr,
+    contraction_size: tl.constexpr,
+    output_size: tl.constexpr,
+    x_stride_m,
+    x_stride_h,
+    x_stride_k,
+    weight_stride_l,
+    weight_stride_h,
+    weight_stride_k,
+    weight_stride_n,
+    weight_offset,
+    output_stride_m,
+    output_stride_h,
+    output_stride_n,
+    add_output: tl.constexpr,
+    block_k: tl.constexpr,
+    block_n: tl.constexpr,
+):
+    token_head = tl.program_id(0)
+    token_id = token_head // num_heads
+    head_id = token_head % num_heads
+    output_offsets = tl.program_id(1) * block_n + tl.arange(0, block_n)
+    output_mask = output_offsets < output_size
+
+    lora_id = tl.load(token_lora_mapping + token_id)
+    if lora_id == -1:
+        return
+
+    accumulator = tl.zeros((block_n,), dtype=tl.float32)
+    contraction_offsets = tl.arange(0, block_k)
+    for contraction_start in range(0, contraction_size, block_k):
+        current_k = contraction_start + contraction_offsets
+        contraction_mask = current_k < contraction_size
+        x_values = tl.load(
+            x + token_id * x_stride_m + head_id * x_stride_h + current_k * x_stride_k,
+            mask=contraction_mask,
+            other=0.0,
+        ).to(tl.float32)
+        weight_values = tl.load(
+            weight
+            + weight_offset
+            + lora_id * weight_stride_l
+            + head_id * weight_stride_h
+            + current_k[:, None] * weight_stride_k
+            + output_offsets[None, :] * weight_stride_n,
+            mask=contraction_mask[:, None] & output_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        accumulator += tl.sum(x_values[:, None] * weight_values, axis=0)
+
+    output_ptr = (
+        output
+        + token_id * output_stride_m
+        + head_id * output_stride_h
+        + output_offsets * output_stride_n
+    )
+    if add_output:
+        accumulator += tl.load(output_ptr, mask=output_mask, other=0.0)
+    tl.store(output_ptr, accumulator, mask=output_mask)
+
+
+def _routed_matmul(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    token_lora_mapping: torch.Tensor,
+    *,
+    weight_stride_h: int,
+    weight_stride_k: int,
+    weight_stride_n: int,
+    weight_offset: int = 0,
+    add_output: bool,
+) -> None:
+    assert x.ndim == output.ndim == 3
+    assert x.shape[:2] == output.shape[:2]
+    num_tokens, num_heads, contraction_size = x.shape
+    output_size = output.shape[-1]
+    assert token_lora_mapping.shape[0] >= num_tokens
+    grid = (num_tokens * num_heads, triton.cdiv(output_size, _BLOCK_N))
+    _routed_matmul_kernel[grid](
+        x,
+        weight,
+        output,
+        token_lora_mapping,
+        num_tokens,
+        num_heads=num_heads,
+        contraction_size=contraction_size,
+        output_size=output_size,
+        x_stride_m=x.stride(0),
+        x_stride_h=x.stride(1),
+        x_stride_k=x.stride(2),
+        weight_stride_l=weight.stride(0),
+        weight_stride_h=weight_stride_h,
+        weight_stride_k=weight_stride_k,
+        weight_stride_n=weight_stride_n,
+        weight_offset=weight_offset,
+        output_stride_m=output.stride(0),
+        output_stride_h=output.stride(1),
+        output_stride_n=output.stride(2),
+        add_output=add_output,
+        block_k=_BLOCK_K,
+        block_n=_BLOCK_N,
+    )
+
+
+def _native_routed_matmul(
+    x: torch.Tensor,
+    weights: torch.Tensor,
+    output: torch.Tensor,
+    token_lora_mapping: torch.Tensor,
+    *,
+    add_output: bool,
+) -> None:
+    result = torch.zeros_like(output)
+    for lora_id in range(weights.shape[0]):
+        mask = token_lora_mapping[: x.shape[0]] == lora_id
+        if torch.any(mask):
+            result[mask] = torch.einsum(
+                "mhk,hkn->mhn", x[mask].float(), weights[lora_id].float()
+            ).to(output.dtype)
+    if add_output:
+        output.add_(result)
+    else:
+        output.copy_(result)
+
+
+def _linear_weights(
+    lora_a: torch.Tensor, lora_b: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return lora_a[:, 0].transpose(1, 2), lora_b[:, 0].transpose(1, 2)
+
+
+@torch.inference_mode()
+def _mla_kv_b_lora_linear(
+    x: torch.Tensor,
+    lora_a: torch.Tensor,
+    lora_b: torch.Tensor,
+    output: torch.Tensor,
+    token_lora_mapping: torch.Tensor,
+    no_lora_flag_cpu: torch.Tensor,
+) -> None:
+    """Add ``x @ A.T @ B.T`` to a materialized base projection."""
+    if no_lora_flag_cpu.item():
+        return
+    x = x.view(-1, 1, x.shape[-1])
+    output = output.view(-1, 1, output.shape[-1])
+    rank = lora_a.shape[-2]
+    intermediate = torch.empty(
+        (x.shape[0], 1, rank), dtype=torch.float32, device=x.device
+    )
+    if not current_platform.is_cuda_alike():
+        a, b = _linear_weights(lora_a, lora_b)
+        _native_routed_matmul(
+            x, a.unsqueeze(1), intermediate, token_lora_mapping, add_output=False
+        )
+        _native_routed_matmul(
+            intermediate, b.unsqueeze(1), output, token_lora_mapping, add_output=True
+        )
+    else:
+        _routed_matmul(
+            x,
+            lora_a,
+            intermediate,
+            token_lora_mapping,
+            weight_stride_h=0,
+            weight_stride_k=lora_a.stride(3),
+            weight_stride_n=lora_a.stride(2),
+            add_output=False,
+        )
+        _routed_matmul(
+            intermediate,
+            lora_b,
+            output,
+            token_lora_mapping,
+            weight_stride_h=0,
+            weight_stride_k=lora_b.stride(3),
+            weight_stride_n=lora_b.stride(2),
+            add_output=True,
+        )
+
+
+@torch.inference_mode()
+def _mla_kv_b_lora_q(
+    q_nope: torch.Tensor,
+    lora_a: torch.Tensor,
+    lora_b: torch.Tensor,
+    output: torch.Tensor,
+    token_lora_mapping: torch.Tensor,
+    no_lora_flag_cpu: torch.Tensor,
+    v_head_dim: int,
+) -> None:
+    """Add the absorbed query correction ``q_nope @ B_K @ A``."""
+    if no_lora_flag_cpu.item():
+        return
+    num_heads = q_nope.shape[1]
+    rank = lora_a.shape[-2]
+    full_head_dim = lora_b.shape[-2] // num_heads
+    assert full_head_dim == q_nope.shape[-1] + v_head_dim
+    intermediate = torch.empty(
+        (*q_nope.shape[:2], rank), dtype=torch.float32, device=q_nope.device
+    )
+    if not current_platform.is_cuda_alike():
+        b = lora_b[:, 0].view(lora_b.shape[0], num_heads, full_head_dim, rank)[
+            :, :, : q_nope.shape[-1]
+        ]
+        a = lora_a[:, 0].unsqueeze(1).expand(-1, num_heads, -1, -1)
+        _native_routed_matmul(
+            q_nope, b, intermediate, token_lora_mapping, add_output=False
+        )
+        _native_routed_matmul(
+            intermediate, a, output, token_lora_mapping, add_output=True
+        )
+        return
+    _routed_matmul(
+        q_nope,
+        lora_b,
+        intermediate,
+        token_lora_mapping,
+        weight_stride_h=full_head_dim * lora_b.stride(2),
+        weight_stride_k=lora_b.stride(2),
+        weight_stride_n=lora_b.stride(3),
+        add_output=False,
+    )
+    _routed_matmul(
+        intermediate,
+        lora_a,
+        output,
+        token_lora_mapping,
+        weight_stride_h=0,
+        weight_stride_k=lora_a.stride(2),
+        weight_stride_n=lora_a.stride(3),
+        add_output=True,
+    )
+
+
+@torch.inference_mode()
+def _mla_kv_b_lora_v(
+    latent_output: torch.Tensor,
+    lora_a: torch.Tensor,
+    lora_b: torch.Tensor,
+    output: torch.Tensor,
+    token_lora_mapping: torch.Tensor,
+    no_lora_flag_cpu: torch.Tensor,
+    qk_nope_head_dim: int,
+) -> None:
+    """Add the absorbed value correction ``latent @ A.T @ B_V.T``."""
+    if no_lora_flag_cpu.item():
+        return
+    num_heads = latent_output.shape[1]
+    rank = lora_a.shape[-2]
+    full_head_dim = lora_b.shape[-2] // num_heads
+    assert full_head_dim == qk_nope_head_dim + output.shape[-1]
+    intermediate = torch.empty(
+        (*latent_output.shape[:2], rank),
+        dtype=torch.float32,
+        device=latent_output.device,
+    )
+    if not current_platform.is_cuda_alike():
+        a = lora_a[:, 0].transpose(1, 2).unsqueeze(1).expand(-1, num_heads, -1, -1)
+        b = (
+            lora_b[:, 0]
+            .view(lora_b.shape[0], num_heads, full_head_dim, rank)[
+                :, :, qk_nope_head_dim:
+            ]
+            .transpose(2, 3)
+        )
+        _native_routed_matmul(
+            latent_output, a, intermediate, token_lora_mapping, add_output=False
+        )
+        _native_routed_matmul(
+            intermediate, b, output, token_lora_mapping, add_output=True
+        )
+        return
+    _routed_matmul(
+        latent_output,
+        lora_a,
+        intermediate,
+        token_lora_mapping,
+        weight_stride_h=0,
+        weight_stride_k=lora_a.stride(3),
+        weight_stride_n=lora_a.stride(2),
+        add_output=False,
+    )
+    _routed_matmul(
+        intermediate,
+        lora_b,
+        output,
+        token_lora_mapping,
+        weight_stride_h=full_head_dim * lora_b.stride(2),
+        weight_stride_k=lora_b.stride(3),
+        weight_stride_n=lora_b.stride(2),
+        weight_offset=qk_nope_head_dim * lora_b.stride(2),
+        add_output=True,
+    )
+
+
+def _fake(*args, **kwargs) -> None:
+    return None
+
+
+try:
+    for _name, _func in (
+        ("mla_kv_b_lora_linear", _mla_kv_b_lora_linear),
+        ("mla_kv_b_lora_q", _mla_kv_b_lora_q),
+        ("mla_kv_b_lora_v", _mla_kv_b_lora_v),
+    ):
+        direct_register_custom_op(
+            op_name=_name,
+            op_func=_func,
+            mutates_args=["output"],
+            fake_impl=_fake,
+            tags=(torch.Tag.flexible_layout,),
+        )
+
+    mla_kv_b_lora_linear = torch.ops.vllm.mla_kv_b_lora_linear
+    mla_kv_b_lora_q = torch.ops.vllm.mla_kv_b_lora_q
+    mla_kv_b_lora_v = torch.ops.vllm.mla_kv_b_lora_v
+except AttributeError:
+    mla_kv_b_lora_linear = _mla_kv_b_lora_linear
+    mla_kv_b_lora_q = _mla_kv_b_lora_q
+    mla_kv_b_lora_v = _mla_kv_b_lora_v

--- a/vllm/lora/ops/triton_ops/mla_kv_b_lora.py
+++ b/vllm/lora/ops/triton_ops/mla_kv_b_lora.py
@@ -1,167 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""Explicitly routed LoRA corrections for MLA ``kv_b_proj``.
-
-MLA does not always execute ``kv_b_proj.forward``. Dense prefill keeps a
-reference to the original linear layer, while decode uses K/V weights that
-were absorbed during model initialization. The helpers in this module apply
-the missing low-rank delta with a token-to-adapter mapping supplied by the
-caller. Using an explicit mapping is important for mixed prefill/decode
-batches and for context tokens gathered from the KV cache.
-"""
+"""Explicitly routed LoRA corrections for MLA ``kv_b_proj``."""
 
 import torch
 
-from vllm.platforms import current_platform
-from vllm.triton_utils import tl, triton
-from vllm.utils.torch_utils import direct_register_custom_op
-
-_BLOCK_K = 64
-_BLOCK_N = 64
+from vllm.lora.ops.triton_ops.routed_lora_matmul import routed_lora_two_stage
 
 
-@triton.jit
-def _routed_matmul_kernel(
-    x,
-    weight,
-    output,
-    token_lora_mapping,
-    num_tokens,
-    num_heads: tl.constexpr,
-    contraction_size: tl.constexpr,
-    output_size: tl.constexpr,
-    x_stride_m,
-    x_stride_h,
-    x_stride_k,
-    weight_stride_l,
-    weight_stride_h,
-    weight_stride_k,
-    weight_stride_n,
-    weight_offset,
-    output_stride_m,
-    output_stride_h,
-    output_stride_n,
-    add_output: tl.constexpr,
-    block_k: tl.constexpr,
-    block_n: tl.constexpr,
-):
-    token_head = tl.program_id(0)
-    token_id = token_head // num_heads
-    head_id = token_head % num_heads
-    output_offsets = tl.program_id(1) * block_n + tl.arange(0, block_n)
-    output_mask = output_offsets < output_size
-
-    lora_id = tl.load(token_lora_mapping + token_id)
-    if lora_id == -1:
-        return
-
-    accumulator = tl.zeros((block_n,), dtype=tl.float32)
-    contraction_offsets = tl.arange(0, block_k)
-    for contraction_start in range(0, contraction_size, block_k):
-        current_k = contraction_start + contraction_offsets
-        contraction_mask = current_k < contraction_size
-        x_values = tl.load(
-            x + token_id * x_stride_m + head_id * x_stride_h + current_k * x_stride_k,
-            mask=contraction_mask,
-            other=0.0,
-        ).to(tl.float32)
-        weight_values = tl.load(
-            weight
-            + weight_offset
-            + lora_id * weight_stride_l
-            + head_id * weight_stride_h
-            + current_k[:, None] * weight_stride_k
-            + output_offsets[None, :] * weight_stride_n,
-            mask=contraction_mask[:, None] & output_mask[None, :],
-            other=0.0,
-        ).to(tl.float32)
-        accumulator += tl.sum(x_values[:, None] * weight_values, axis=0)
-
-    output_ptr = (
-        output
-        + token_id * output_stride_m
-        + head_id * output_stride_h
-        + output_offsets * output_stride_n
-    )
-    if add_output:
-        accumulator += tl.load(output_ptr, mask=output_mask, other=0.0)
-    tl.store(output_ptr, accumulator, mask=output_mask)
-
-
-def _routed_matmul(
-    x: torch.Tensor,
-    weight: torch.Tensor,
-    output: torch.Tensor,
-    token_lora_mapping: torch.Tensor,
-    *,
-    weight_stride_h: int,
-    weight_stride_k: int,
-    weight_stride_n: int,
-    weight_offset: int = 0,
-    add_output: bool,
-) -> None:
-    assert x.ndim == output.ndim == 3
-    assert x.shape[:2] == output.shape[:2]
-    num_tokens, num_heads, contraction_size = x.shape
-    output_size = output.shape[-1]
-    assert token_lora_mapping.shape[0] >= num_tokens
-    grid = (num_tokens * num_heads, triton.cdiv(output_size, _BLOCK_N))
-    _routed_matmul_kernel[grid](
-        x,
-        weight,
-        output,
-        token_lora_mapping,
-        num_tokens,
-        num_heads=num_heads,
-        contraction_size=contraction_size,
-        output_size=output_size,
-        x_stride_m=x.stride(0),
-        x_stride_h=x.stride(1),
-        x_stride_k=x.stride(2),
-        weight_stride_l=weight.stride(0),
-        weight_stride_h=weight_stride_h,
-        weight_stride_k=weight_stride_k,
-        weight_stride_n=weight_stride_n,
-        weight_offset=weight_offset,
-        output_stride_m=output.stride(0),
-        output_stride_h=output.stride(1),
-        output_stride_n=output.stride(2),
-        add_output=add_output,
-        block_k=_BLOCK_K,
-        block_n=_BLOCK_N,
-    )
-
-
-def _native_routed_matmul(
-    x: torch.Tensor,
-    weights: torch.Tensor,
-    output: torch.Tensor,
-    token_lora_mapping: torch.Tensor,
-    *,
-    add_output: bool,
-) -> None:
-    result = torch.zeros_like(output)
-    for lora_id in range(weights.shape[0]):
-        mask = token_lora_mapping[: x.shape[0]] == lora_id
-        if torch.any(mask):
-            result[mask] = torch.einsum(
-                "mhk,hkn->mhn", x[mask].float(), weights[lora_id].float()
-            ).to(output.dtype)
-    if add_output:
-        output.add_(result)
-    else:
-        output.copy_(result)
-
-
-def _linear_weights(
-    lora_a: torch.Tensor, lora_b: torch.Tensor
-) -> tuple[torch.Tensor, torch.Tensor]:
-    return lora_a[:, 0].transpose(1, 2), lora_b[:, 0].transpose(1, 2)
-
-
-@torch.inference_mode()
-def _mla_kv_b_lora_linear(
+def mla_kv_b_lora_linear(
     x: torch.Tensor,
     lora_a: torch.Tensor,
     lora_b: torch.Tensor,
@@ -170,47 +17,19 @@ def _mla_kv_b_lora_linear(
     no_lora_flag_cpu: torch.Tensor,
 ) -> None:
     """Add ``x @ A.T @ B.T`` to a materialized base projection."""
-    if no_lora_flag_cpu.item():
-        return
-    x = x.view(-1, 1, x.shape[-1])
-    output = output.view(-1, 1, output.shape[-1])
-    rank = lora_a.shape[-2]
-    intermediate = torch.empty(
-        (x.shape[0], 1, rank), dtype=torch.float32, device=x.device
+    first_weight = lora_a.transpose(2, 3)
+    second_weight = lora_b.transpose(2, 3)
+    routed_lora_two_stage(
+        x.view(-1, 1, x.shape[-1]),
+        first_weight,
+        second_weight,
+        output.view(-1, 1, output.shape[-1]),
+        token_lora_mapping,
+        no_lora_flag_cpu,
     )
-    if not current_platform.is_cuda_alike():
-        a, b = _linear_weights(lora_a, lora_b)
-        _native_routed_matmul(
-            x, a.unsqueeze(1), intermediate, token_lora_mapping, add_output=False
-        )
-        _native_routed_matmul(
-            intermediate, b.unsqueeze(1), output, token_lora_mapping, add_output=True
-        )
-    else:
-        _routed_matmul(
-            x,
-            lora_a,
-            intermediate,
-            token_lora_mapping,
-            weight_stride_h=0,
-            weight_stride_k=lora_a.stride(3),
-            weight_stride_n=lora_a.stride(2),
-            add_output=False,
-        )
-        _routed_matmul(
-            intermediate,
-            lora_b,
-            output,
-            token_lora_mapping,
-            weight_stride_h=0,
-            weight_stride_k=lora_b.stride(3),
-            weight_stride_n=lora_b.stride(2),
-            add_output=True,
-        )
 
 
-@torch.inference_mode()
-def _mla_kv_b_lora_q(
+def mla_kv_b_lora_q(
     q_nope: torch.Tensor,
     lora_a: torch.Tensor,
     lora_b: torch.Tensor,
@@ -220,51 +39,24 @@ def _mla_kv_b_lora_q(
     v_head_dim: int,
 ) -> None:
     """Add the absorbed query correction ``q_nope @ B_K @ A``."""
-    if no_lora_flag_cpu.item():
-        return
+    num_loras = lora_b.shape[0]
     num_heads = q_nope.shape[1]
-    rank = lora_a.shape[-2]
     full_head_dim = lora_b.shape[-2] // num_heads
     assert full_head_dim == q_nope.shape[-1] + v_head_dim
-    intermediate = torch.empty(
-        (*q_nope.shape[:2], rank), dtype=torch.float32, device=q_nope.device
-    )
-    if not current_platform.is_cuda_alike():
-        b = lora_b[:, 0].view(lora_b.shape[0], num_heads, full_head_dim, rank)[
-            :, :, : q_nope.shape[-1]
-        ]
-        a = lora_a[:, 0].unsqueeze(1).expand(-1, num_heads, -1, -1)
-        _native_routed_matmul(
-            q_nope, b, intermediate, token_lora_mapping, add_output=False
-        )
-        _native_routed_matmul(
-            intermediate, a, output, token_lora_mapping, add_output=True
-        )
-        return
-    _routed_matmul(
+    first_weight = lora_b[:, 0].view(
+        num_loras, num_heads, full_head_dim, lora_b.shape[-1]
+    )[:, :, : q_nope.shape[-1]]
+    routed_lora_two_stage(
         q_nope,
-        lora_b,
-        intermediate,
-        token_lora_mapping,
-        weight_stride_h=full_head_dim * lora_b.stride(2),
-        weight_stride_k=lora_b.stride(2),
-        weight_stride_n=lora_b.stride(3),
-        add_output=False,
-    )
-    _routed_matmul(
-        intermediate,
+        first_weight,
         lora_a,
         output,
         token_lora_mapping,
-        weight_stride_h=0,
-        weight_stride_k=lora_a.stride(2),
-        weight_stride_n=lora_a.stride(3),
-        add_output=True,
+        no_lora_flag_cpu,
     )
 
 
-@torch.inference_mode()
-def _mla_kv_b_lora_v(
+def mla_kv_b_lora_v(
     latent_output: torch.Tensor,
     lora_a: torch.Tensor,
     lora_b: torch.Tensor,
@@ -274,78 +66,23 @@ def _mla_kv_b_lora_v(
     qk_nope_head_dim: int,
 ) -> None:
     """Add the absorbed value correction ``latent @ A.T @ B_V.T``."""
-    if no_lora_flag_cpu.item():
-        return
+    num_loras = lora_b.shape[0]
     num_heads = latent_output.shape[1]
-    rank = lora_a.shape[-2]
     full_head_dim = lora_b.shape[-2] // num_heads
     assert full_head_dim == qk_nope_head_dim + output.shape[-1]
-    intermediate = torch.empty(
-        (*latent_output.shape[:2], rank),
-        dtype=torch.float32,
-        device=latent_output.device,
+    first_weight = lora_a.transpose(2, 3)
+    second_weight = (
+        lora_b[:, 0]
+        .view(num_loras, num_heads, full_head_dim, lora_b.shape[-1])[
+            :, :, qk_nope_head_dim:
+        ]
+        .transpose(2, 3)
     )
-    if not current_platform.is_cuda_alike():
-        a = lora_a[:, 0].transpose(1, 2).unsqueeze(1).expand(-1, num_heads, -1, -1)
-        b = (
-            lora_b[:, 0]
-            .view(lora_b.shape[0], num_heads, full_head_dim, rank)[
-                :, :, qk_nope_head_dim:
-            ]
-            .transpose(2, 3)
-        )
-        _native_routed_matmul(
-            latent_output, a, intermediate, token_lora_mapping, add_output=False
-        )
-        _native_routed_matmul(
-            intermediate, b, output, token_lora_mapping, add_output=True
-        )
-        return
-    _routed_matmul(
+    routed_lora_two_stage(
         latent_output,
-        lora_a,
-        intermediate,
-        token_lora_mapping,
-        weight_stride_h=0,
-        weight_stride_k=lora_a.stride(3),
-        weight_stride_n=lora_a.stride(2),
-        add_output=False,
-    )
-    _routed_matmul(
-        intermediate,
-        lora_b,
+        first_weight,
+        second_weight,
         output,
         token_lora_mapping,
-        weight_stride_h=full_head_dim * lora_b.stride(2),
-        weight_stride_k=lora_b.stride(3),
-        weight_stride_n=lora_b.stride(2),
-        weight_offset=qk_nope_head_dim * lora_b.stride(2),
-        add_output=True,
+        no_lora_flag_cpu,
     )
-
-
-def _fake(*args, **kwargs) -> None:
-    return None
-
-
-try:
-    for _name, _func in (
-        ("mla_kv_b_lora_linear", _mla_kv_b_lora_linear),
-        ("mla_kv_b_lora_q", _mla_kv_b_lora_q),
-        ("mla_kv_b_lora_v", _mla_kv_b_lora_v),
-    ):
-        direct_register_custom_op(
-            op_name=_name,
-            op_func=_func,
-            mutates_args=["output"],
-            fake_impl=_fake,
-            tags=(torch.Tag.flexible_layout,),
-        )
-
-    mla_kv_b_lora_linear = torch.ops.vllm.mla_kv_b_lora_linear
-    mla_kv_b_lora_q = torch.ops.vllm.mla_kv_b_lora_q
-    mla_kv_b_lora_v = torch.ops.vllm.mla_kv_b_lora_v
-except AttributeError:
-    mla_kv_b_lora_linear = _mla_kv_b_lora_linear
-    mla_kv_b_lora_q = _mla_kv_b_lora_q
-    mla_kv_b_lora_v = _mla_kv_b_lora_v

--- a/vllm/lora/ops/triton_ops/routed_lora_matmul.py
+++ b/vllm/lora/ops/triton_ops/routed_lora_matmul.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Two-stage LoRA matmul with explicit token-to-adapter routing."""
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+
+_BLOCK_K = 64
+_BLOCK_N = 64
+
+
+@triton.jit
+def _routed_matmul_kernel(
+    x,
+    weight,
+    output,
+    token_lora_mapping,
+    num_heads: tl.constexpr,
+    contraction_size: tl.constexpr,
+    output_size: tl.constexpr,
+    x_stride_m,
+    x_stride_h,
+    x_stride_k,
+    weight_stride_l,
+    weight_stride_h,
+    weight_stride_k,
+    weight_stride_n,
+    output_stride_m,
+    output_stride_h,
+    output_stride_n,
+    add_output: tl.constexpr,
+    block_k: tl.constexpr,
+    block_n: tl.constexpr,
+):
+    token_head = tl.program_id(0)
+    token_id = token_head // num_heads
+    head_id = token_head % num_heads
+    output_offsets = tl.program_id(1) * block_n + tl.arange(0, block_n)
+    output_mask = output_offsets < output_size
+
+    lora_id = tl.load(token_lora_mapping + token_id)
+    if lora_id == -1:
+        return
+
+    accumulator = tl.zeros((block_n,), dtype=tl.float32)
+    contraction_offsets = tl.arange(0, block_k)
+    for contraction_start in range(0, contraction_size, block_k):
+        current_k = contraction_start + contraction_offsets
+        contraction_mask = current_k < contraction_size
+        x_values = tl.load(
+            x + token_id * x_stride_m + head_id * x_stride_h + current_k * x_stride_k,
+            mask=contraction_mask,
+            other=0.0,
+        ).to(tl.float32)
+        weight_values = tl.load(
+            weight
+            + lora_id * weight_stride_l
+            + head_id * weight_stride_h
+            + current_k[:, None] * weight_stride_k
+            + output_offsets[None, :] * weight_stride_n,
+            mask=contraction_mask[:, None] & output_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        accumulator += tl.sum(x_values[:, None] * weight_values, axis=0)
+
+    output_ptr = (
+        output
+        + token_id * output_stride_m
+        + head_id * output_stride_h
+        + output_offsets * output_stride_n
+    )
+    if add_output:
+        accumulator += tl.load(output_ptr, mask=output_mask, other=0.0)
+    tl.store(output_ptr, accumulator, mask=output_mask)
+
+
+def _routed_matmul(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    token_lora_mapping: torch.Tensor,
+    *,
+    add_output: bool,
+) -> None:
+    num_tokens, num_heads, contraction_size = x.shape
+    output_size = output.shape[-1]
+    grid = (num_tokens * num_heads, triton.cdiv(output_size, _BLOCK_N))
+    _routed_matmul_kernel[grid](
+        x,
+        weight,
+        output,
+        token_lora_mapping,
+        num_heads=num_heads,
+        contraction_size=contraction_size,
+        output_size=output_size,
+        x_stride_m=x.stride(0),
+        x_stride_h=x.stride(1),
+        x_stride_k=x.stride(2),
+        weight_stride_l=weight.stride(0),
+        weight_stride_h=0 if weight.shape[1] == 1 else weight.stride(1),
+        weight_stride_k=weight.stride(2),
+        weight_stride_n=weight.stride(3),
+        output_stride_m=output.stride(0),
+        output_stride_h=output.stride(1),
+        output_stride_n=output.stride(2),
+        add_output=add_output,
+        block_k=_BLOCK_K,
+        block_n=_BLOCK_N,
+    )
+
+
+def _native_routed_matmul(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    token_lora_mapping: torch.Tensor,
+    *,
+    add_output: bool,
+) -> None:
+    result = torch.zeros_like(output)
+    for lora_id in range(weight.shape[0]):
+        mask = token_lora_mapping[: x.shape[0]] == lora_id
+        if torch.any(mask):
+            adapter_weight = weight[lora_id].expand(x.shape[1], -1, -1)
+            result[mask] = torch.einsum(
+                "mhk,hkn->mhn", x[mask].float(), adapter_weight.float()
+            ).to(output.dtype)
+    if add_output:
+        output.add_(result)
+    else:
+        output.copy_(result)
+
+
+def _validate_shapes(
+    x: torch.Tensor,
+    first_weight: torch.Tensor,
+    second_weight: torch.Tensor,
+    output: torch.Tensor,
+    token_lora_mapping: torch.Tensor,
+) -> None:
+    assert x.ndim == output.ndim == 3
+    assert first_weight.ndim == second_weight.ndim == 4
+    assert x.shape[:2] == output.shape[:2]
+    assert first_weight.shape[0] == second_weight.shape[0]
+    assert first_weight.shape[1] in (1, x.shape[1])
+    assert second_weight.shape[1] in (1, x.shape[1])
+    assert first_weight.shape[2] == x.shape[2]
+    assert first_weight.shape[3] == second_weight.shape[2]
+    assert second_weight.shape[3] == output.shape[2]
+    assert token_lora_mapping.shape[0] >= x.shape[0]
+
+
+@torch.inference_mode()
+def _routed_lora_two_stage(
+    x: torch.Tensor,
+    first_weight: torch.Tensor,
+    second_weight: torch.Tensor,
+    output: torch.Tensor,
+    token_lora_mapping: torch.Tensor,
+    no_lora_flag_cpu: torch.Tensor,
+) -> None:
+    """Add a routed ``x @ first_weight @ second_weight`` to ``output``.
+
+    Both weights use the logical layout ``(loras, heads, input, output)``.
+    A singleton head dimension broadcasts the same matrix across all heads.
+    """
+    if no_lora_flag_cpu.item():
+        return
+    _validate_shapes(x, first_weight, second_weight, output, token_lora_mapping)
+    intermediate = torch.empty(
+        (*x.shape[:2], first_weight.shape[-1]),
+        dtype=torch.float32,
+        device=x.device,
+    )
+    matmul = _routed_matmul
+    if not current_platform.is_cuda_alike():
+        matmul = _native_routed_matmul
+    matmul(
+        x,
+        first_weight,
+        intermediate,
+        token_lora_mapping,
+        add_output=False,
+    )
+    matmul(
+        intermediate,
+        second_weight,
+        output,
+        token_lora_mapping,
+        add_output=True,
+    )
+
+
+def _fake(*args, **kwargs) -> None:
+    return None
+
+
+try:
+    direct_register_custom_op(
+        op_name="routed_lora_two_stage",
+        op_func=_routed_lora_two_stage,
+        mutates_args=["output"],
+        fake_impl=_fake,
+        tags=(torch.Tag.flexible_layout,),
+    )
+    routed_lora_two_stage = torch.ops.vllm.routed_lora_two_stage
+except AttributeError:
+    routed_lora_two_stage = _routed_lora_two_stage

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -767,6 +767,10 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 self._k_scale,
                 output=mha_output[num_mqa_tokens:num_actual_toks],
                 output_scale=mha_output_scale,
+                kv_b_proj_lora=self.kv_b_proj,
+                token_lora_mapping=self._kv_b_proj_lora_mapping(
+                    num_mqa_tokens, num_actual_toks
+                ),
             )
 
         if num_mqa_tokens > 0:
@@ -824,6 +828,16 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 # Convert from (N, B, L) to (B, N, L)
                 mqa_ql_nope = mqa_ql_nope.transpose(0, 1)
 
+            apply_q_lora = getattr(self.kv_b_proj, "apply_mla_kv_b_lora_q", None)
+            mqa_lora_mapping = self._kv_b_proj_lora_mapping(0, num_mqa_tokens)
+            if apply_q_lora is not None and mqa_lora_mapping is not None:
+                apply_q_lora(
+                    mqa_q_nope.transpose(0, 1),
+                    mqa_ql_nope,
+                    mqa_lora_mapping,
+                    self.v_head_dim,
+                )
+
             if fp8_attention and self.impl.supports_quant_query_input:
                 assert mqa_ql_nope.shape[0] == mqa_q_pe.shape[0]
                 assert mqa_ql_nope.shape[1] == mqa_q_pe.shape[1]
@@ -862,7 +876,11 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                     )
 
             # v_up projection
-            self._v_up_proj(attn_out, out=mqa_output_slice)
+            self._v_up_proj(
+                attn_out,
+                out=mqa_output_slice,
+                token_lora_mapping=mqa_lora_mapping,
+            )
 
         if quant_key is not None:
             quant_idx = num_mqa_tokens if mha_use_quant_output else num_actual_toks
@@ -1045,9 +1063,21 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
         )
 
-    def _v_up_proj(self, x: torch.Tensor, out: torch.Tensor):
+    def _kv_b_proj_lora_mapping(self, start: int, end: int) -> torch.Tensor | None:
+        punica_wrapper = getattr(self.kv_b_proj, "punica_wrapper", None)
+        if punica_wrapper is None:
+            return None
+        return punica_wrapper.token_lora_indices[start:end]
+
+    def _v_up_proj(
+        self,
+        x: torch.Tensor,
+        out: torch.Tensor,
+        token_lora_mapping: torch.Tensor | None = None,
+    ):
         # Convert from (B, N, L) to (N, B, L)
-        x = x.view(-1, self.num_heads, self.kv_lora_rank).transpose(0, 1)
+        latent_output = x.view(-1, self.num_heads, self.kv_lora_rank)
+        x = latent_output.transpose(0, 1)
         out = out.view(-1, self.num_heads, self.v_head_dim)
         if self.is_aiter_triton_fp4_bmm_enabled:
             out = rocm_aiter_ops.batched_gemm_a16wfp4(
@@ -1068,6 +1098,15 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         else:
             # Multiply + Transpose (N, B, L) x (N, L, V)->(N, B, V)->(B, N, V)
             torch.bmm(x, self.W_UV, out=out.transpose(0, 1))
+
+        apply_v_lora = getattr(self.kv_b_proj, "apply_mla_kv_b_lora_v", None)
+        if apply_v_lora is not None and token_lora_mapping is not None:
+            apply_v_lora(
+                latent_output,
+                out,
+                token_lora_mapping,
+                self.qk_nope_head_dim,
+            )
 
 
 def unified_mla_kv_cache_update(
@@ -2101,6 +2140,8 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
         kv_c_and_k_pe_cache: torch.Tensor,
         attn_metadata: MLACommonMetadata,
         k_scale: torch.Tensor,
+        kv_b_proj_lora: object | None,
+        request_lora_mapping: torch.Tensor | None,
     ):
         assert attn_metadata.prefill is not None
         prefill_metadata = attn_metadata.prefill
@@ -2173,6 +2214,14 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
             kv_nope = self.kv_b_proj(kv_c_normed)[0].view(
                 -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim
             )
+            apply_lora = getattr(kv_b_proj_lora, "apply_mla_kv_b_lora_linear", None)
+            if apply_lora is not None and request_lora_mapping is not None:
+                token_to_seq = prefill_metadata.chunked_context.token_to_seq[i]
+                apply_lora(
+                    kv_c_normed,
+                    kv_nope,
+                    request_lora_mapping[token_to_seq[:toks].long()],
+                )
 
             # To Do: Use epilogue of kv_b_proj to generate fp8 kv_nope.
             if use_fp8_prefill:
@@ -2218,6 +2267,8 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
         attn_metadata: MLACommonMetadata,
         k_scale: torch.Tensor,
         dcp_world_size: int,
+        kv_b_proj_lora: object | None,
+        request_lora_mapping: torch.Tensor | None,
     ):
         assert attn_metadata.prefill is not None
         prefill_metadata = attn_metadata.prefill
@@ -2326,6 +2377,23 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
             kv_nope = self.kv_b_proj(kv_c_normed)[0].view(
                 -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim
             )
+            apply_lora = getattr(kv_b_proj_lora, "apply_mla_kv_b_lora_linear", None)
+            if apply_lora is not None and request_lora_mapping is not None:
+                cu_seq_lens = prefill_metadata.chunked_context.cu_seq_lens_lst[i]
+                context_lora_mapping = torch.cat(
+                    [
+                        request_lora_mapping[seq_idx].expand(seq_end - seq_start)
+                        for seq_idx, (seq_start, seq_end) in enumerate(
+                            zip(cu_seq_lens[:-1], cu_seq_lens[1:], strict=True)
+                        )
+                    ]
+                )
+                assert context_lora_mapping.shape[0] == kv_c_normed.shape[0]
+                apply_lora(
+                    kv_c_normed,
+                    kv_nope,
+                    context_lora_mapping,
+                )
             if use_fp8_prefill:
                 kv_nope = kv_nope.to(prefill_metadata.q_data_type)
                 k_pe = k_pe.to(prefill_metadata.q_data_type)
@@ -2371,6 +2439,8 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
         k_scale: torch.Tensor,
         output: torch.Tensor,
         output_scale: torch.Tensor | None = None,
+        kv_b_proj_lora: object | None = None,
+        token_lora_mapping: torch.Tensor | None = None,
     ) -> None:
         assert attn_metadata.prefill is not None
         assert self.dcp_world_size != -1
@@ -2391,6 +2461,9 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
         kv_nope = self.kv_b_proj(kv_c_normed)[0].view(
             -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim
         )
+        apply_lora = getattr(kv_b_proj_lora, "apply_mla_kv_b_lora_linear", None)
+        if apply_lora is not None and token_lora_mapping is not None:
+            apply_lora(kv_c_normed, kv_nope, token_lora_mapping)
         k_nope, v = kv_nope.split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
         k = self._concat_k_nope_k_pe(k_nope, k_pe)
 
@@ -2413,6 +2486,11 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
 
         if has_context:
             assert prefill_metadata.chunked_context is not None
+            request_lora_mapping = None
+            if token_lora_mapping is not None:
+                request_lora_mapping = token_lora_mapping[
+                    prefill_metadata.query_start_loc[:-1].long()
+                ]
             suffix_output, suffix_lse = output_prefill
             if self.dcp_world_size > 1:
                 context_output, context_lse = (
@@ -2422,11 +2500,18 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
                         attn_metadata,
                         k_scale=k_scale,
                         dcp_world_size=self.dcp_world_size,
+                        kv_b_proj_lora=kv_b_proj_lora,
+                        request_lora_mapping=request_lora_mapping,
                     )
                 )
             else:
                 context_output, context_lse = self._compute_prefill_context(
-                    q, kv_c_and_k_pe_cache, attn_metadata, k_scale
+                    q,
+                    kv_c_and_k_pe_cache,
+                    attn_metadata,
+                    k_scale,
+                    kv_b_proj_lora,
+                    request_lora_mapping,
                 )
 
             context_output = context_output[..., : self.v_head_dim]


### PR DESCRIPTION
> [!IMPORTANT]
> This is an AI-assisted draft. Human line-by-line review is pending; do not
> mark ready for review or merge until the accountability checklist below is
> complete.

## Purpose

Fixes #48974.

MLA bypasses the LoRA-wrapped `kv_b_proj` in two different ways: absorbed/MQA
decode consumes base K/V projections split during model initialization, while
dense MHA prefill and chunked context call a stale reference to the original
linear layer. An adapter could therefore load successfully while contributing
no `kv_b_proj` delta to inference.

This change applies explicitly routed corrections across both paths:

- dense MHA prefill/context: `x @ A.T @ B.T`
- absorbed query: `q_nope @ B_K @ A`
- absorbed value: `latent @ A.T @ B_V.T`

The routed kernels use the scheduler's token-to-adapter mapping, including
mixed base/adapter batches and cached context tokens. `kv_b_proj` keeps LoRA A
replicated when `fully_sharded_loras=True`, while its B projection remains
tensor-parallel sliced.

## Reuse and design

The three correction paths now share one `routed_lora_two_stage` primitive.
It accepts the raw token-to-adapter mapping and logical
`(loras, heads, input, output)` weight views, with singleton-head broadcast and
non-contiguous per-head slices. `mla_kv_b_lora.py` is consequently limited to
constructing the dense, K-half, and V-half views.

The existing vLLM `lora_shrink` / `lora_expand` kernels were considered first,
but they require precomputed sorted `LoRAKernelMeta` plus contiguous LoRA
matrices. MLA creates slice- and chunk-specific mappings inside attention, and
its `B_K` / `B_V` matrices are head-strided views; constructing and sorting new
metadata there would also be incompatible with CUDA Graph capture.

SGLang independently handles the same absorbed-MLA problem with four dedicated
segment-routed kernels in
[sglang#25001](https://github.com/sgl-project/sglang/pull/25001). This PR reuses
the useful factorization and logical head-view idea, but does not port SGLang's
backend-specific segment/permutation/rank machinery. The smaller vLLM primitive
serves all three paths with the scheduler mapping already available here.

## Duplicate Work Check

Ran before opening this draft:

```bash
gh issue view 48974 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search "48974 in:body"
gh pr list --repo vllm-project/vllm --state open --search "kv_b_proj LoRA MLA"
```

The issue command is broken with the installed `gh` 2.4 client because its
GraphQL query requests the retired Classic Projects field, so the issue and
comments were also read through `gh api`. Both open-PR searches returned no
matches.

This does not duplicate closed, unmerged draft #48986. That draft intentionally
covered only the absorbed/MQA half and documented dense MHA prefill and chunked
context as unsupported. This PR covers those paths as well as the absorbed
path, and validates dynamic adapter replacement against a merged checkpoint.

## Tests

```bash
uvx pre-commit run --files \
  tests/lora/test_lora_manager.py \
  tests/lora/test_punica_ops.py \
  vllm/lora/layers/column_parallel_linear.py \
  vllm/lora/model_manager.py \
  vllm/lora/ops/triton_ops/__init__.py \
  vllm/lora/ops/triton_ops/mla_kv_b_lora.py \
  vllm/lora/ops/triton_ops/routed_lora_matmul.py \
  vllm/model_executor/layers/attention/mla_attention.py

uv run --no-project --python /usr/bin/python3.12 python -m pytest -q \
  tests/lora/test_punica_ops.py::test_mla_kv_b_lora_uses_explicit_token_mapping \
  tests/lora/test_lora_manager.py::test_mla_kv_b_proj_keeps_replicated_lora_a

git diff --check
```

Results:

- Focused CUDA pytest: `3 passed` (BF16, FP16, and fully-sharded wrapper).
- Final post-refactor commit hooks passed, including ruff, format, mypy, SPDX,
  forbidden-import, and CUDA-API checks.
- Post-refactor H200 BF16 numerical smoke passed for dense projection,
  absorbed query, and absorbed value with mixed adapter/base token routing.
- `git diff --check` passed.

## Model Evaluation

Two-H200 end-to-end validation used the exact released image and source:

- image: `vllm/vllm-openai:v0.25.1`
- digest: `sha256:e4f88a835143cd22aee2397a26ec6bb80b3a4a6fe0c882bcbc63822904766089`
- vLLM commit: `752a3a504485790a2e8491cacbb35c137339ad34`
- model: `Moonlight-16B-A3B-Instruct`
- topology: TP2, `fully_sharded_loras=True`
- execution: FULL and PIECEWISE CUDA Graph modes
- adapter: rank-8 BF16 LoRA targeting only layer-0 `kv_b_proj`

Stock v0.25.1 accepted adapter load/update requests but produced exactly zero
fixed-token logprob change for both base-to-A and A-to-B transitions.

With the final reuse refactor, the same lifecycle passed:

- base repeat and prefix-cache repeat: bitwise identical
- base to adapter A max fixed-token logprob diff: `0.9733700752`
- in-place adapter A to B diff: `1.2628855705`
- in-place B to A reload: bitwise identical to the first A snapshot
- concurrent mixed base/adapter routing: stable across repeated rounds
- merged-BF16 oracle: identical generated tokens; adapter output was 4.6x
  closer to the merged checkpoint than the base output

Additional development lanes passed TP1 eager, TP2 eager, long-prefix cache,
and same-mode graph execution.

## AI Assistance

OpenAI Codex was used for issue analysis, implementation, test orchestration,
and drafting this description. The commits include `Co-authored-by` trailers.

## Accountability

- [ ] Human submitter has reviewed every changed line.
- [ ] Human submitter understands and can defend the correction algebra,
  scheduler routing, tensor-parallel behavior, and test oracle.
- [x] Relevant focused tests and model evaluations were run and documented.
- [x] Duplicate-work searches found no competing open PR.
