### PR TITLE
Fix Qwen3 Omni weight mapping without thinker prefix

### DIFF
--- a/tests/models/test_qwen3_omni_moe_mapper.py
+++ b/tests/models/test_qwen3_omni_moe_mapper.py
@@ -1,0 +1,66 @@
+from vllm.model_executor.models.qwen3_omni_moe_thinker import (
+    Qwen3OmniMoeThinkerForConditionalGeneration,
+)
+
+
+def test_qwen3_omni_hf_to_vllm_mapper_dict():
+
+    mapper = (
+        Qwen3OmniMoeThinkerForConditionalGeneration
+        .hf_to_vllm_mapper
+    )
+
+    weights = {
+        # ModelSlim exported checkpoint format
+        "model.layers.0.self_attn.q_proj.weight": 1,
+        "model.embed_tokens.weight": 2,
+        "lm_head.weight": 3,
+
+        # Existing Qwen3 Omni format
+        "thinker.model.layers.0.self_attn.q_proj.weight": 4,
+        "thinker.lm_head.weight": 5,
+
+        # Should not be modified
+        "visual.blocks.0.attn.qkv.weight": 6,
+        "audio_tower.layers.0.weight": 7,
+    }
+
+    mapped = mapper.apply_dict(weights)
+
+    # New mapping
+    assert (
+        "language_model.model.layers.0.self_attn.q_proj.weight"
+        in mapped
+    )
+
+    assert (
+        "language_model.model.embed_tokens.weight"
+        in mapped
+    )
+
+    assert (
+        "language_model.lm_head.weight"
+        in mapped
+    )
+
+    # Existing mapping
+    assert (
+        "language_model.model.layers.0.self_attn.q_proj.weight"
+        in mapped
+    )
+
+    assert (
+        "language_model.lm_head.weight"
+        in mapped
+    )
+
+    # Multimodal modules unchanged
+    assert (
+        "visual.blocks.0.attn.qkv.weight"
+        in mapped
+    )
+
+    assert (
+        "audio_tower.layers.0.weight"
+        in mapped
+    )

--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -1611,7 +1611,9 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={
             "thinker.lm_head.": "language_model.lm_head.",
+            "lm_head.": "language_model.lm_head.",
             "thinker.model.": "language_model.model.",
+            "model.": "language_model.model.",
             "thinker.": "",
         }
     )


### PR DESCRIPTION


## Description

Fix Qwen3 Omni checkpoint loading when weights do not contain the
`thinker.` prefix.

Some Qwen3 Omni checkpoints use:

```text
model.*
lm_head.*
```

while the vLLM model implementation expects:

```text
language_model.model.*
language_model.lm_head.*
```

This change extends the Qwen3 Omni `hf_to_vllm_mapper` to support
these checkpoint formats.

Existing checkpoints using the `thinker.` prefix remain supported.

## Purpose

Some Qwen3 Omni checkpoints do not preserve the original `thinker.`
prefix for language model weights.

For example:

```text
model.layers.0.xxx
lm_head.weight
```

instead of:

```text
thinker.model.layers.0.xxx
thinker.lm_head.weight
```

The Qwen3 Omni vLLM model wraps the language model under
`language_model`, so these checkpoint keys need to be mapped before
loading.

This change keeps the mapping logic in the model implementation layer
through `hf_to_vllm_mapper`, rather than adding model-specific handling
to backend implementations.

## Test Plan

Added unit tests covering Qwen3 Omni weight prefix mapping.

The test verifies:

- `thinker.model.*` -> `language_model.model.*`
- `thinker.lm_head.*` -> `language_model.lm_head.*`
- `model.*` -> `language_model.model.*`
- `lm_head.*` -> `language_model.lm_head.*`

## Test Result

Passed:

```text
pytest tests/models/test_qwen3_omni_moe_mapper.py -v
```

Verified that both existing Qwen3 Omni checkpoint formats and
checkpoints without the `thinker.` prefix are correctly mapped.

---