### PR TITLE
[Bugfix] Qwen3-VL/Qwen-Omni: honor max_pixels/min_pixels for video prompts

### DIFF
--- a/vllm/model_executor/models/qwen2_5_omni_thinker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_thinker.py
@@ -509,6 +509,23 @@ class Qwen2_5OmniThinkerMultiModalProcessor(
                 **mm_kwargs,
             )
 
+        merged = self.info.ctx.get_merged_mm_kwargs(mm_kwargs)
+        if mm_data.get("videos") and (
+            merged.keys() & {"size", "min_pixels", "max_pixels"}
+        ):
+            mm_kwargs = dict(mm_kwargs)
+            video_size = dict(self.info.get_hf_processor().video_processor.size)
+            size_override = merged.get("size")
+            if size_override is not None:
+                video_size = video_size | size_override
+            min_pixels = merged.get("min_pixels")
+            if min_pixels is not None:
+                video_size["shortest_edge"] = min_pixels
+            max_pixels = merged.get("max_pixels")
+            if max_pixels is not None:
+                video_size["longest_edge"] = max_pixels
+            mm_kwargs["size"] = video_size
+
         hf_inputs = super()._call_hf_processor(
             prompt=prompt,
             mm_data=mm_data,

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1272,6 +1272,19 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
                 # NOTE: a copy of is created to update do_sample_frames,
                 # otherwise mm_hash for the object will be incorrect.
                 video_mm_kwargs = dict(**mm_kwargs)
+                merged = self.info.ctx.get_merged_mm_kwargs(mm_kwargs)
+                if merged.keys() & {"size", "min_pixels", "max_pixels"}:
+                    video_size = dict(self.info.get_video_processor().size)
+                    size_override = merged.get("size")
+                    if size_override is not None:
+                        video_size = video_size | size_override
+                    min_pixels = merged.get("min_pixels")
+                    if min_pixels is not None:
+                        video_size["shortest_edge"] = min_pixels
+                    max_pixels = merged.get("max_pixels")
+                    if max_pixels is not None:
+                        video_size["longest_edge"] = max_pixels
+                    video_mm_kwargs["size"] = video_size
                 sampled_fps = video_mm_kwargs.get("fps")
                 if is_list_of(sampled_fps, float):
                     video_mm_kwargs["fps"] = sampled_fps[item_idx]


### PR DESCRIPTION
Fixes #48733.

## Problem
For Qwen3-VL and the Qwen-Omni thinkers (Qwen2.5-Omni, Qwen3-Omni), video `mm_processor_kwargs={"max_pixels": ...}` (and `min_pixels`) is silently dropped, so the prompt uses the uncapped native resolution and `prompt_tokens` are inflated.

Two things combine:
1. HF video processors read the per-frame pixel budget only from `size.{longest,shortest}_edge`, not `max_pixels`.
2. In the engine, `max_pixels` is not part of the HF processor signature, so `get_allowed_kwarg_only_overrides` strips it before `_call_hf_processor` runs — the `mm_kwargs` the processor receives is empty. The profiling path (`_get_vision_info`) still sees it because it reads `ctx.get_merged_mm_kwargs(...)`, which creates a profiling-vs-actual inconsistency.

## Fix
In the video branch of `_call_hf_processor`, read the budget from `ctx.get_merged_mm_kwargs(...)` (where the engine keeps it) and translate `size`/`min_pixels`/`max_pixels` into `size.{longest,shortest}_edge` — a valid kwarg that survives the filter. No-op when no budget is passed (uncapped unchanged).
- `qwen3_vl.py` (`Qwen3VLMultiModalProcessor`) → **Qwen3-VL**
- `qwen2_5_omni_thinker.py` (`Qwen2_5OmniThinkerMultiModalProcessor`) → **Qwen2.5-Omni + Qwen3-Omni** (Qwen3-Omni inherits this base)

## E2E verification (real `LLM.generate`, actual `prompt_tokens`)
```python
import numpy as np, imageio.v2 as imageio
from vllm import LLM, SamplingParams

# decode a clip, pre-sample to a fixed frame set (do_sample_frames=False) so the
# only variable is the spatial pixel budget:
rdr = imageio.get_reader(VIDEO); fps = rdr.get_meta_data()["fps"]
frames = np.stack(list(rdr)); n = len(frames)
idx = np.linspace(0, n - 1, 16).round().astype(int)
meta = {"fps": fps, "total_num_frames": n, "duration": n / fps,
        "frames_indices": idx.tolist(), "video_backend": "opencv",
        "do_sample_frames": False}

mmk = {"max_pixels": CAP}         # or {} for uncapped
llm = LLM(model=MODEL, mm_processor_kwargs=mmk, limit_mm_per_prompt={"video": 1},
          enforce_eager=True)
out = llm.generate({"prompt": VIDEO_PLACEHOLDER + "Describe.",
                    "multi_modal_data": {"video": (frames[idx], meta)}},
                   SamplingParams(max_tokens=1))
print(len(out[0].prompt_token_ids))
```

| model | config | prompt_tokens (before) | prompt_tokens (after) |
|---|---|---|---|
| Qwen3-VL-4B (1280x720) | `max_pixels=393216` | 12044 | **324** |
| Qwen3-VL-4B (1280x720) | uncapped | 12044 | 12044 |
| Qwen2.5-Omni-3B (480x832) | `max_pixels=50176` | 4086 | **486** |
| Qwen2.5-Omni-3B (480x832) | uncapped | 4086 | 4086 |

Before: `max_pixels` == uncapped (dropped). After: `max_pixels` caps the tokens; uncapped unchanged (no regression). Qwen3-Omni uses the same Qwen2.5-Omni processor path, so it is covered by the base-class fix.

## Not a duplicate
Searched open PRs for `48733` and `qwen video max_pixels` — none address this (only unrelated #43403 on ViT CUDA-graph video fallback).



## Tests
Existing Qwen multimodal-processing tests (exercise the changed processors), run against a built vLLM with this change:

```
$ pytest tests/models/multimodal/processing/test_qwen3_vl.py \
         tests/models/multimodal/processing/test_qwen3_omni.py \
         tests/models/multimodal/processing/test_qwen2_vl.py -v

collecting ... collected 25 items
tests/models/multimodal/processing/test_qwen3_vl.py::test_processor_num_frames_timestamp[8-Qwen/Qwen3-VL-4B-Instruct] PASSED [  4%]
tests/models/multimodal/processing/test_qwen3_vl.py::test_processor_num_frames_timestamp[16-Qwen/Qwen3-VL-4B-Instruct] PASSED [  8%]
tests/models/multimodal/processing/test_qwen3_vl.py::test_processor_multi_video[2-Qwen/Qwen3-VL-4B-Instruct] PASSED [ 12%]
tests/models/multimodal/processing/test_qwen3_vl.py::test_processor_multi_video[4-Qwen/Qwen3-VL-4B-Instruct] PASSED [ 16%]
tests/models/multimodal/processing/test_qwen3_vl.py::test_processor_multi_video_list_kwargs[hf_mm_kwargs0-Qwen/Qwen3-VL-4B-Instruct] PASSED [ 20%]
tests/models/multimodal/processing/test_qwen3_vl.py::test_processor_multi_video_list_kwargs[hf_mm_kwargs1-Qwen/Qwen3-VL-4B-Instruct] PASSED [ 24%]
tests/models/multimodal/processing/test_qwen3_omni.py::test_processor_with_audio_sample_rate[16000-1.0-Qwen/Qwen3-Omni-30B-A3B-Instruct] PASSED [ 28%]
tests/models/multimodal/processing/test_qwen3_omni.py::test_processor_with_audio_sample_rate[16000-2.0-Qwen/Qwen3-Omni-30B-A3B-Instruct] PASSED [ 32%]
tests/models/multimodal/processing/test_qwen3_omni.py::test_longer_audio_generates_more_tokens[Qwen/Qwen3-Omni-30B-A3B-Instruct] PASSED [ 36%]
tests/models/multimodal/processing/test_qwen2_vl.py::test_processor_override[True-1-mm_processor_kwargs0-1426-expected_pixels_shape0-Qwen/Qwen2-VL-2B-Instruct] PASSED [ 40%]
tests/models/multimodal/processing/test_qwen2_vl.py::test_processor_override[True-1-mm_processor_kwargs1-330-expected_pixels_shape1-Qwen/Qwen2-VL-2B-Instruct] PASSED [ 44%]
tests/models/multimodal/processing/test_qwen2_vl.py::test_processor_override[True-1-mm_processor_kwargs2-330-expected_pixels_shape2-Qwen/Qwen2-VL-2B-Instruct] PASSED [ 48%]
tests/models/multimodal/processing/test_qwen2_vl.py::test_processor_override[True-2-mm_processor_kwargs0-1426-expected_pixels_shape0-Qwen/Qwen2-VL-2B-Instruct] PASSED [ 52%]
tests/models/multimodal/processing/test_qwen2_vl.py::test_processor_override[True-2-mm_processor_kwargs1-330-expected_pixels_shape1-Qwen/Qwen2-VL-2B-Instruct] PASSED [ 56%]
tests/models/multimodal/processing/test_qwen2_vl.py::test_processor_override[True-2-mm_processor_kwargs2-330-expected_pixels_shape2-Qwen/Qwen2-VL-2B-Instruct] PASSED [ 60%]
tests/models/multimodal/processing/test_qwen2_vl.py::test_processor_override[False-1-mm_processor_kwargs0-1426-expected_pixels_shape0-Qwen/Qwen2-VL-2B-Instruct] PASSED [ 64%]
tests/models/multimodal/processing/test_qwen2_vl.py::test_processor_override[False-1-mm_processor_kwargs1-330-expected_pixels_shape1-Qwen/Qwen2-VL-2B-Instruct] PASSED [ 68%]
tests/models/multimodal/processing/test_qwen2_vl.py::test_processor_override[False-1-mm_processor_kwargs2-330-expected_pixels_shape2-Qwen/Qwen2-VL-2B-Instruct] PASSED [ 72%]
tests/models/multimodal/processing/test_qwen2_vl.py::test_processor_override[False-2-mm_processor_kwargs0-1426-expected_pixels_shape0-Qwen/Qwen2-VL-2B-Instruct] PASSED [ 76%]
tests/models/multimodal/processing/test_qwen2_vl.py::test_processor_override[False-2-mm_processor_kwargs1-330-expected_pixels_shape1-Qwen/Qwen2-VL-2B-Instruct] PASSED [ 80%]
tests/models/multimodal/processing/test_qwen2_vl.py::test_processor_override[False-2-mm_processor_kwargs2-330-expected_pixels_shape2-Qwen/Qwen2-VL-2B-Instruct] PASSED [ 84%]
tests/models/multimodal/processing/test_qwen2_vl.py::test_get_image_size_with_most_features[mm_processor_kwargs0-Qwen/Qwen2-VL-2B-Instruct] PASSED [ 88%]
tests/models/multimodal/processing/test_qwen2_vl.py::test_get_image_size_with_most_features[mm_processor_kwargs1-Qwen/Qwen2-VL-2B-Instruct] PASSED [ 92%]
tests/models/multimodal/processing/test_qwen2_vl.py::test_get_image_size_with_most_features[mm_processor_kwargs2-Qwen/Qwen2-VL-2B-Instruct] PASSED [ 96%]
tests/models/multimodal/processing/test_qwen2_vl.py::test_get_image_size_with_most_features[mm_processor_kwargs3-Qwen/Qwen2-VL-2B-Instruct] PASSED [100%]
================== 25 passed, 21 warnings in 90.24s (0:01:30) ==================
```
