### PR TITLE
[Bugfix] Isolate scoring preprocessing from renderer executor

### DIFF
--- a/tests/entrypoints/pooling/scoring/test_serving.py
+++ b/tests/entrypoints/pooling/scoring/test_serving.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from vllm.entrypoints.pooling.base.serving import PoolingServing
+from vllm.entrypoints.pooling.scoring.serving import ServingScores
+
+
+def test_scoring_preprocessing_uses_dedicated_executor():
+    renderer_executor = ThreadPoolExecutor(max_workers=1)
+
+    def init_pooling_serving(self, *args, **kwargs):
+        self._executor = renderer_executor
+        self._preprocessing = lambda *args, **kwargs: None
+
+    model_config = SimpleNamespace(
+        architecture="XLMRobertaForSequenceClassification",
+        renderer_num_workers=2,
+        get_pooling_task=lambda _: "classify",
+    )
+    engine_client = SimpleNamespace(model_config=model_config)
+
+    try:
+        with patch.object(PoolingServing, "__init__", init_pooling_serving):
+            serving = ServingScores(
+                engine_client,
+                supported_tasks=("classify",),
+            )
+
+        assert serving._score_preprocessing_executor is not renderer_executor
+        assert serving._score_preprocessing_executor._max_workers == 2
+
+        serving.shutdown()
+        assert serving._score_preprocessing_executor._shutdown
+    finally:
+        renderer_executor.shutdown(wait=False)

--- a/vllm/entrypoints/pooling/scoring/serving.py
+++ b/vllm/entrypoints/pooling/scoring/serving.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from concurrent.futures import ThreadPoolExecutor
+
 from fastapi.responses import JSONResponse, Response
 
 from vllm import PoolingParams
@@ -9,6 +11,7 @@ from vllm.entrypoints.openai.engine.protocol import UsageInfo
 from vllm.logger import init_logger
 from vllm.outputs import PoolingRequestOutput, ScoringRequestOutput
 from vllm.tasks import SCORE_TYPE_MAP, SupportedTask
+from vllm.utils.async_utils import make_async
 from vllm.v1.pool.late_interaction import (
     build_late_interaction_doc_params,
     build_late_interaction_query_params,
@@ -61,6 +64,20 @@ class ServingScores(PoolingServing):
             self.enable_flash_late_interaction = False
 
         super().__init__(engine_client, *args, **kwargs)
+
+        # Scoring requests can contain hundreds of document pairs. Keep their
+        # CPU preprocessing off the renderer executor so long-running scoring
+        # batches do not delay renderer work needed to submit ready requests.
+        self._score_preprocessing_executor = ThreadPoolExecutor(
+            max_workers=engine_client.model_config.renderer_num_workers,
+            thread_name_prefix="score-preprocess",
+        )
+        self._preprocessing_async = make_async(
+            self._preprocessing, executor=self._score_preprocessing_executor
+        )
+
+    def shutdown(self) -> None:
+        self._score_preprocessing_executor.shutdown(wait=False)
 
     def init_io_processor(self, *args, **kwargs) -> PoolingIOProcessor:
         return ScoringIOProcessors[self.io_processor_name](*args, **kwargs)

--- a/vllm/entrypoints/serve/utils/server_utils.py
+++ b/vllm/entrypoints/serve/utils/server_utils.py
@@ -562,6 +562,7 @@ async def lifespan(app: FastAPI):
             for attr_name in (
                 "openai_serving_transcription",
                 "openai_serving_translation",
+                "serving_scores",
             ):
                 serving = getattr(app.state, attr_name, None)
                 if serving is not None and hasattr(serving, "shutdown"):


### PR DESCRIPTION
## Summary

Fixes #43444.

Online scoring preprocessing currently shares the renderer executor with other
renderer work. A scoring request can contain hundreds of query-document pairs,
so its monolithic CPU preprocessing job can occupy that executor long enough to
delay other requests from reaching the engine. This preserves aggregate
throughput, but couples request latency and removes the early-completion behavior
seen in v0.19.1.

This PR:

- gives `ServingScores` a dedicated preprocessing executor;
- keeps the existing monolithic preprocessing logic and result ordering;
- sizes the executor from `renderer_num_workers`;
- shuts the executor down with the server lifespan; and
- adds a focused unit test for executor isolation, worker count, and shutdown.

This is intentionally smaller than parallelizing individual score pairs. The
A/B tests showed that executor isolation is the decisive variable; per-item
tasks on the shared renderer executor did not remove the latency coupling.

## Validation

All comparisons used the same RTX 4090, Python 3.12, PyTorch 2.11.0+cu130,
model cache, compiled extensions, and benchmark client.

### Request-size ramp

22 concurrent `/v1/score` requests, 100 documents per request, with request
sizes ramping from 64 to 1024 words:

| Variant | Wall (s) | Mean latency (s) | Min latency (s) | Max latency (s) |
| --- | ---: | ---: | ---: | ---: |
| v0.19.1 | 9.116 | 3.516 | 0.468 | 9.090 |
| v0.20.2 baseline | 8.994 | 5.176 | 4.346 | 8.962 |
| v0.20.2 with dedicated executor | 8.974 | 3.429 | 0.342 | 8.946 |

### Long-context issue shape

Server configured with `--max-model-len 8000 --async-scheduling`. Each of 22
concurrent requests contained 100 documents distributed from 64 to 7900
tokenizer tokens:

| Variant | Wall (s) | Mean (s) | Min (s) | p50 (s) | p95 (s) | Max (s) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| v0.19.1 | 72.619 | 38.388 | 4.402 | 38.338 | 66.010 | 72.508 |
| v0.20.2 baseline | 72.521 | 39.986 | 18.136 | 38.282 | 65.971 | 72.357 |
| Patched | 72.531 | 38.319 | 4.363 | 38.275 | 65.869 | 72.497 |

The patch leaves wall time effectively unchanged (+0.01%) while reducing the
first completed request latency from 18.136 s to 4.363 s (-75.94%), closely
matching v0.19.1. This supports executor contention as the cause of the
request-level latency coupling, rather than a GPU throughput regression.

The long-context workload uses deterministic synthetic text because the
reporter's original `rerank.json` dataset is not public.

<details>
<summary>Long-context benchmark reproduction</summary>

Start the server:

```bash
vllm serve BAAI/bge-reranker-v2-m3 \
  --max-model-len 8000 \
  --async-scheduling
```

Run the deterministic benchmark client against each variant:

```bash
python benchmark_score.py \
  --model BAAI/bge-reranker-v2-m3 \
  --documents 100 \
  --document-tokens 7900 \
  --min-tokens-within-request 64 \
  --concurrency 22 \
  --requests-per-case 22 \
  --warmup 1 \
  --timeout 600 \
  --output results/issue_shape.json
```

</details>

## Tests

- `ruff check` on all changed Python files
- `ruff format --check` on all changed Python files
- `pytest -q --confcutdir=tests/entrypoints/pooling/scoring tests/entrypoints/pooling/scoring/test_serving.py`
  - 1 passed
- GPU A/B benchmarks described above

## Related work

#47699 overlaps preprocessing and engine execution for offline pooling
inference. This PR addresses the online scoring path, where preprocessing still
shares the renderer executor.