### PR TITLE
[Doc] Correct gRPC and OpenTelemetry flag names in security and metrics docs

### DIFF
--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -655,7 +655,7 @@ fall under the more general heading of "Observability".
 vLLM has support for OpenTelemetry tracing:
 
 - Added by <https://github.com/vllm-project/vllm/pull/4687> and reinstated by <https://github.com/vllm-project/vllm/pull/20372>
-- Configured with `--oltp-traces-endpoint` and `--collect-detailed-traces`
+- Configured with `--otlp-traces-endpoint` and `--collect-detailed-traces`
 - [OpenTelemetry blog post](https://opentelemetry.io/blog/2024/llm-observability/)
 - [User-facing docs](../../examples/observability/opentelemetry/README.md)
 - [Blog post](https://medium.com/@ronen.schaffer/follow-the-trail-supercharging-vllm-with-opentelemetry-distributed-tracing-aa655229b46f)

--- a/docs/usage/security.md
+++ b/docs/usage/security.md
@@ -344,7 +344,7 @@ vLLM supports loading out-of-tree HTTP routes via the `vllm.endpoint_plugins` en
 
 ## gRPC Interface
 
-vLLM provides an optional gRPC Generate service on a separate TCP port, enabled via the `--grpc-port` flag. When not specified, no gRPC server is started. The gRPC listener binds to the same host address as the HTTP server.
+vLLM provides an optional gRPC Generate service, enabled by passing the `--grpc` flag to `vllm serve` (requires `pip install vllm[grpc]`). When enabled, the gRPC server is launched instead of the HTTP OpenAI-compatible server and listens on the address configured by `--host` and `--port`. When the flag is not passed, no gRPC server is started.
 
 **Warning:** The gRPC interface is **insecure by default** — it does not implement authentication, authorization, or encryption. It should be considered a private, internal interface intended for use only between co-located services within a trusted network. Do not expose the gRPC port to the public internet or untrusted clients. If you enable the gRPC interface, protect it via network-level access controls such as firewall rules, network segmentation, or deployment on an isolated private network.
 
@@ -358,7 +358,7 @@ An attacker who can reach the gRPC port can:
 
 ### Recommendations
 
-- Only enable `--grpc-port` when you have a specific need for gRPC-based inference
+- Only enable `--grpc` when you have a specific need for gRPC-based inference
 - Ensure the gRPC port is only accessible from trusted hosts or services
 - Use firewall rules to block external access to the gRPC port
 - Consider deploying the gRPC interface on a dedicated internal network interface


### PR DESCRIPTION
## Purpose

Two docs pages reference CLI flags that do not exist:

- `docs/usage/security.md` (gRPC Interface section) says the service is enabled via a `--grpc-port` flag on a separate TCP port next to the HTTP server. The actual interface (added in #36169) is a boolean `--grpc` flag on `vllm serve` that launches the gRPC server instead of the HTTP one, listening on the standard `--host`/`--port` address (see `vllm/entrypoints/openai/cli_args.py` and the early return in `vllm/entrypoints/cli/serve.py`). `docs/deployment/k8s.md` already describes it correctly, so this brings security.md in line. All the security warnings and recommendations in the section are untouched, only the flag name and the architecture sentence changed.
- `docs/design/metrics.md` spells the tracing flag `--oltp-traces-endpoint`. The config field is `otlp_traces_endpoint` (`vllm/config/observability.py`), OTLP as in OpenTelemetry Protocol, so anyone copying the flag from this page gets an argparse error.

Found while auditing every `--flag` mentioned in `docs/` against the current parsers. Checked for duplicates first: searched open PRs for grpc-port, oltp, and security.md; the open gRPC PRs (#42721, #48033, #36102) touch server code, none touch these doc lines.

## Test Plan

Docs-only change:

```
pre-commit run --files docs/design/metrics.md docs/usage/security.md
```

plus verifying the corrected flag names against source: `--grpc` is defined in `vllm/entrypoints/openai/cli_args.py` and `otlp_traces_endpoint` in `vllm/config/observability.py`. There is no `grpc_port` or `oltp` anywhere in `vllm/`.

## Test Result

All pre-commit hooks pass (markdownlint, typos, filename checks). Both corrected names resolve to real definitions in the source files above.

---

quick note: freshman here, still finding my feet in this codebase and trying to contribute for the greater good :) I traced the flags through the parsers myself and leaned on Claude Code for the audit script and to double check my reasoning. if I misread how the gRPC entrypoint works I would honestly love the correction.