### PR TITLE
[Bugfix] Ignore Eagle groups in offloading block-size validation

### DIFF
--- a/tests/v1/kv_offload/test_factory.py
+++ b/tests/v1/kv_offload/test_factory.py
@@ -425,6 +425,70 @@ def _full_attention_spec(block_size: int = 16) -> FullAttentionSpec:
     )
 
 
+@pytest.mark.parametrize(
+    ("target_block_size", "eagle_block_size", "connector_block_size"),
+    [
+        (256, 64, 256),
+        (16, 8, 32),
+    ],
+)
+def test_block_size_ignores_eagle_group_block_size(
+    target_block_size: int,
+    eagle_block_size: int,
+    connector_block_size: int,
+):
+    config = _make_layout_vllm_config(extra_config={"block_size": connector_block_size})
+    kv_cache_config = KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["target_layer"], _full_attention_spec(target_block_size)),
+            KVCacheGroupSpec(
+                ["eagle_layer"],
+                _full_attention_spec(eagle_block_size),
+                is_eagle_group=True,
+            ),
+        ],
+    )
+
+    offloading_config = build_offloading_config(config, kv_cache_config)
+
+    assert tuple(group.layer_names for group in offloading_config.groups) == (
+        ("target_layer",),
+        ("eagle_layer",),
+    )
+    assert tuple(group.tokens_per_block for group in offloading_config.groups) == (
+        target_block_size,
+        eagle_block_size,
+    )
+    assert (
+        offloading_config.cache.blocks_per_chunk
+        == connector_block_size // target_block_size
+    )
+
+
+def test_block_size_still_rejects_heterogeneous_non_eagle_groups():
+    config = _make_layout_vllm_config(extra_config={"block_size": 32})
+    kv_cache_config = KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["target_layer_0"], _full_attention_spec(16)),
+            KVCacheGroupSpec(["target_layer_1"], _full_attention_spec(8)),
+            KVCacheGroupSpec(
+                ["eagle_layer"],
+                _full_attention_spec(4),
+                is_eagle_group=True,
+            ),
+        ],
+    )
+
+    with pytest.raises(
+        AssertionError, match="all groups must have the same block size"
+    ):
+        build_offloading_config(config, kv_cache_config)
+
+
 def _parallelism_agnostic(kv_cache_groups: list[KVCacheGroupSpec]) -> bool:
     config = _make_layout_vllm_config()
     kv_cache_config = KVCacheConfig(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
@@ -76,7 +76,17 @@ def build_offloading_config(
     elif tokens_per_chunk is not None:
         tokens_per_chunk_int = int(tokens_per_chunk)
 
-        unique_tokens_per_block = {group.tokens_per_block for group in groups}
+        reference_groups = (
+            tuple(
+                group
+                for group, kv_cache_group in zip(
+                    groups, kv_cache_config.kv_cache_groups, strict=True
+                )
+                if not kv_cache_group.is_eagle_group
+            )
+            or groups
+        )
+        unique_tokens_per_block = {group.tokens_per_block for group in reference_groups}
 
         assert len(unique_tokens_per_block) == 1, (
             "If 'block_size' is specified in kv_connector_extra_config, "


### PR DESCRIPTION
## Summary

Fixes #48919.

When `kv_connector_extra_config["block_size"]` is specified,
`build_offloading_config()` currently requires all KV-cache groups to
have the same effective block size.

DeepSeek-V4 speculative decoding may add an explicitly marked Eagle
draft group whose block size differs from the target-model KV-cache
groups. Including that group in the uniformity check causes CPU
offloading initialization to fail.

## Changes

This PR:

- uses non-Eagle KV-cache groups as the reference groups for the legacy
  `block_size` uniformity validation;
- derives `blocks_per_chunk` from the non-Eagle reference block size;
- falls back to all groups when no explicitly non-Eagle group exists,
  preserving the previous behavior;
- keeps the complete `OffloadingConfig.groups` tuple unchanged and in
  its original order;
- continues to reject heterogeneous non-Eagle KV-cache groups.

## Tests

Added CPU-only regression coverage for:

- target block size `256`, Eagle block size `64`, connector block size
  `256`;
- target block size `16`, Eagle block size `8`, connector block size
  `32`;
- heterogeneous non-Eagle groups continuing to fail validation.

Validation performed:

```text
Focused regression tests: 3 passed
tests/v1/kv_offload/test_factory.py: 33 passed
Ruff lint: passed
Ruff format: passed
git diff --check: passed