### PR TITLE
[Bugfix][Platform] sm12x: add FLASHMLA_SPARSE (Triton sparse-MLA) to the MLA-sparse backend candidate list — flashinfer sparse_mla_sm120 livelocks on GB10

### DIFF
--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -8,8 +8,6 @@ import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
-from vllm.config import get_current_vllm_config
-from vllm.distributed import get_dcp_group
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
@@ -23,7 +21,6 @@ from vllm.utils.deep_gemm import (
     fp8_fp4_paged_mqa_logits,
     has_deep_gemm,
 )
-from vllm.utils.import_utils import has_cutedsl
 from vllm.utils.torch_utils import (
     LayerNameType,
     _encode_layer_name,
@@ -40,87 +37,14 @@ logger = init_logger(__name__)
 
 RADIX_TOPK_WORKSPACE_SIZE = 1024 * 1024
 
+def _sparse_indexer_requires_deep_gemm() -> bool:
+    return current_platform.is_cuda() and not (
+        current_platform.is_device_capability_family(120)
+    )
+
+
 # MXFP4 layout: 2 values packed per byte, ue8m0 (1-byte) scale per block of 32.
 MXFP4_BLOCK_SIZE = 32
-
-
-def _assert_cutedsl_dcp_merge_supported(
-    logits: torch.Tensor,
-    topk_indices: torch.Tensor,
-    k: int,
-) -> None:
-    # The DCP merge only supports the CuteDSL path (Triton pack kernel + CuteDSL
-    # stable-topk selector); there is no PyTorch fallback. The first cut targets
-    # Blackwell/Hopper with index_topk in (512, 1024, 2048) (the selector's radix
-    # sizing); the Triton pack itself has no shape/topk constraints.
-    if not has_cutedsl():
-        raise RuntimeError(
-            "DCP sparse-indexer merge requires CuteDSL; install it or disable DCP."
-        )
-    if logits.device.type != "cuda":
-        raise RuntimeError("DCP sparse-indexer merge requires CUDA tensors.")
-    if logits.dtype != torch.float32 or topk_indices.dtype != torch.int32:
-        raise RuntimeError(
-            "DCP sparse-indexer merge requires fp32 logits and int32 indices."
-        )
-    if k not in (512, 1024, 2048):
-        raise RuntimeError(
-            f"DCP sparse-indexer merge requires index_topk in (512, 1024, 2048); "
-            f"got {k}."
-        )
-
-
-def _merge_dcp_topk_global(
-    logits: torch.Tensor,
-    topk_indices: torch.Tensor,
-    topk_tokens: int,
-    dcp_rank: int,
-    dcp_world_size: int,
-    cp_interleave: int,
-    row_starts: torch.Tensor | None = None,
-) -> None:
-    """Merge each DCP rank's local top-K into the global top-K.
-
-    ``topk_indices`` are this rank's local top-K positions into its 1/N KV
-    shard. A token in the global top-K must also be in its owning rank's local
-    top-K (at most ``topk_tokens - 1`` tokens rank globally above it, hence at
-    most that many on its own rank), so exchanging only the per-rank local
-    candidates is exact -- equivalent to all-gathering the full logit matrix,
-    but it ships ``dcp_world_size * topk_tokens`` candidates instead of the whole
-    score row. Overwrites ``topk_indices`` with global token ids (``-1`` for
-    padding); the attention backend localizes them back to physical slots per
-    rank.
-    """
-    if dcp_world_size <= 1:
-        return
-
-    # CuteDSL-only path (no PyTorch fallback): Triton-pack each rank's
-    # (score, global_id) candidates on-device, all-gather, then the CuteDSL
-    # stable-topk selector.
-    _assert_cutedsl_dcp_merge_supported(logits, topk_indices, topk_tokens)
-    from vllm.model_executor.kernels.attention.dsa.dcp_indexer_cutedsl import (
-        pack_dcp_topk_candidates_cutedsl,
-        stable_topk_from_gathered_candidates_cutedsl,
-    )
-
-    packed = torch.empty(
-        (*topk_indices.shape, 2),
-        dtype=torch.float32,
-        device=topk_indices.device,
-    )
-    pack_dcp_topk_candidates_cutedsl(
-        logits,
-        topk_indices,
-        packed,
-        dcp_rank,
-        dcp_world_size,
-        cp_interleave,
-        row_starts,
-    )
-    gathered = get_dcp_group().all_gather(packed, dim=1)
-    stable_topk_from_gathered_candidates_cutedsl(
-        gathered, topk_tokens, out=topk_indices
-    )
 
 
 @triton.jit
@@ -309,10 +233,6 @@ def sparse_attn_indexer(
     topk_indices_buffer: torch.Tensor,
     skip_k_cache_insert: bool,
     use_fp4_cache: bool = False,
-    dcp_rank: int = 0,
-    dcp_world_size: int = 1,
-    cp_kv_cache_interleave_size: int = 1,
-    skip_topk_buffer_clear: bool = False,
 ) -> torch.Tensor:
     # careful! this will be None in dummy run
     attn_metadata = get_forward_context().attn_metadata
@@ -389,13 +309,7 @@ def sparse_attn_indexer(
             scale_fmt,
         )
 
-    # The buffer must be pre-filled with -1 (the "no token" sentinel) before the
-    # top-k kernels scatter valid indices into it. On the fused deepseek_v32
-    # nvidia path, _fused_norm_rope_kernel already cleared the same
-    # [:num_tokens, :topk] region earlier in this forward, so skip the redundant
-    # fill.
-    if not skip_topk_buffer_clear:
-        topk_indices_buffer[: hidden_states.shape[0]] = -1
+    topk_indices_buffer[: hidden_states.shape[0]] = -1
     if has_prefill:
         prefill_metadata = attn_metadata_narrowed.prefill
         assert prefill_metadata is not None
@@ -413,18 +327,16 @@ def sparse_attn_indexer(
             scales_spec,
         )
         for chunk in prefill_metadata.chunks:
-            cu_seqlen_ks = chunk.cu_seqlen_ks
-            cu_seqlen_ke = chunk.cu_seqlen_ke
-            assert chunk.local_cu_seq_lens is not None
-            k_quant = k_quant_full[: chunk.max_local_total_seq_lens]
-            k_scale = k_scale_full[: chunk.max_local_total_seq_lens]
-            if not chunk.skip_kv_gather and chunk.local_total_seq_lens > 0:
+            k_quant = k_quant_full[: chunk.total_seq_lens]
+            k_scale = k_scale_full[: chunk.total_seq_lens]
+
+            if not chunk.skip_kv_gather:
                 ops.cp_gather_indexer_k_quant_cache(
                     kv_cache,
                     k_quant,
                     k_scale,
                     chunk.block_table,
-                    chunk.local_cu_seq_lens,
+                    chunk.cu_seq_lens,
                 )
 
             q_slice = q_quant[chunk.token_start : chunk.token_end]
@@ -433,64 +345,51 @@ def sparse_attn_indexer(
                 if q_scale is not None
                 else None
             )
+            # DeepGEMM scalar-type tags (zero-copy): MXFP4 values → int8
+            # (kPackedFP4), scales → int32 squeezed to 1-D kv_sf / 2-D q_sf.
+            if use_fp4_cache:
+                q_slice_cast = q_slice.view(torch.int8)
+                k_quant_cast = k_quant.view(torch.int8)
+                k_scale_cast = k_scale.view(torch.int32).squeeze(-1)
+            else:
+                q_slice_cast = q_slice
+                k_quant_cast = k_quant
+                k_scale_cast = k_scale.view(torch.float32).squeeze(-1)
+            if current_platform.is_xpu():
+                if q_scale_slice is not None:
+                    raise RuntimeError("XPU fp8_mqa_logits does not support FP4 Q")
+                logits = torch.ops.vllm.xpu_fp8_mqa_logits(
+                    q_slice_cast,
+                    k_quant_cast,
+                    k_scale_cast,
+                    weights[chunk.token_start : chunk.token_end],
+                    chunk.cu_seqlen_ks,
+                    chunk.cu_seqlen_ke,
+                )
+            else:
+                logits = fp8_fp4_mqa_logits(
+                    (q_slice_cast, q_scale_slice),
+                    (k_quant_cast, k_scale_cast),
+                    weights[chunk.token_start : chunk.token_end],
+                    chunk.cu_seqlen_ks,
+                    chunk.cu_seqlen_ke,
+                    clean_logits=False,
+                )
+            num_rows = logits.shape[0]
+
             topk_indices = topk_indices_buffer[
                 chunk.token_start : chunk.token_end, :topk_tokens
             ]
 
-            if chunk.local_total_seq_lens == 0:
-                logits = q_slice.new_empty((q_slice.shape[0], 0), dtype=torch.float32)
-                topk_indices.fill_(-1)
-            else:
-                # DeepGEMM scalar-type tags (zero-copy): MXFP4 values → int8
-                # (kPackedFP4), scales → int32 squeezed to 1-D kv_sf / 2-D q_sf.
-                if use_fp4_cache:
-                    q_slice_cast = q_slice.view(torch.int8)
-                    k_quant_cast = k_quant.view(torch.int8)
-                    k_scale_cast = k_scale.view(torch.int32).squeeze(-1)
-                else:
-                    q_slice_cast = q_slice
-                    k_quant_cast = k_quant
-                    k_scale_cast = k_scale.view(torch.float32).squeeze(-1)
-                if current_platform.is_xpu():
-                    if q_scale_slice is not None:
-                        raise RuntimeError("XPU fp8_mqa_logits does not support FP4 Q")
-                    logits = torch.ops.vllm.xpu_fp8_mqa_logits(
-                        q_slice_cast,
-                        k_quant_cast,
-                        k_scale_cast,
-                        weights[chunk.token_start : chunk.token_end],
-                        cu_seqlen_ks,
-                        cu_seqlen_ke,
-                    )
-                else:
-                    logits = fp8_fp4_mqa_logits(
-                        (q_slice_cast, q_scale_slice),
-                        (k_quant_cast, k_scale_cast),
-                        weights[chunk.token_start : chunk.token_end],
-                        cu_seqlen_ks,
-                        cu_seqlen_ke,
-                        clean_logits=False,
-                    )
-                num_rows = logits.shape[0]
-                ops.top_k_per_row_prefill(
-                    logits,
-                    cu_seqlen_ks,
-                    cu_seqlen_ke,
-                    topk_indices,
-                    num_rows,
-                    logits.stride(0),
-                    logits.stride(1),
-                    topk_tokens,
-                )
-
-            _merge_dcp_topk_global(
+            ops.top_k_per_row_prefill(
                 logits,
+                chunk.cu_seqlen_ks,
+                chunk.cu_seqlen_ke,
                 topk_indices,
+                num_rows,
+                logits.stride(0),
+                logits.stride(1),
                 topk_tokens,
-                dcp_rank,
-                dcp_world_size,
-                cp_kv_cache_interleave_size,
-                row_starts=chunk.cu_seqlen_ks,
             )
 
     if has_decode:
@@ -572,33 +471,7 @@ def sparse_attn_indexer(
         num_rows = logits.shape[0]
         topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
 
-        use_cooperative_topk = (
-            current_platform.is_cuda()
-            and topk_tokens in (512, 1024, 2048)
-            and num_rows <= 32
-            and logits.stride(0) % 4 == 0  # TMA 16-byte alignment
-            and current_platform.has_device_capability(90)
-            and not current_platform.is_device_capability_family(120)
-        )
-        use_persistent_topk = current_platform.is_cuda() and topk_tokens in (
-            512,
-            1024,
-            2048,
-        )
-        if use_cooperative_topk:
-            workspace_manager = current_workspace_manager()
-            (topk_workspace,) = workspace_manager.get_simultaneous(
-                ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
-            )
-            torch.ops._C.cooperative_topk(
-                logits,
-                seq_lens,
-                topk_indices,
-                topk_workspace,
-                topk_tokens,
-                attn_metadata_narrowed.max_seq_len,
-            )
-        elif use_persistent_topk:
+        if current_platform.is_cuda() and topk_tokens in (512, 1024, 2048):
             workspace_manager = current_workspace_manager()
             (topk_workspace,) = workspace_manager.get_simultaneous(
                 ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
@@ -609,7 +482,7 @@ def sparse_attn_indexer(
                 topk_indices,
                 topk_workspace,
                 topk_tokens,
-                logits.shape[1],
+                attn_metadata_narrowed.max_seq_len,
             )
         else:
             ops.top_k_per_row_decode(
@@ -621,16 +494,6 @@ def sparse_attn_indexer(
                 logits.stride(0),
                 logits.stride(1),
                 topk_tokens,
-            )
-
-        if decode_metadata.global_seq_lens is not None:
-            _merge_dcp_topk_global(
-                logits,
-                topk_indices,
-                topk_tokens,
-                dcp_rank,
-                dcp_world_size,
-                cp_kv_cache_interleave_size,
             )
 
         if decode_metadata.requires_padding:
@@ -664,10 +527,6 @@ def sparse_attn_indexer_fake(
     topk_indices_buffer: torch.Tensor | None,
     skip_k_cache_insert: bool,
     use_fp4_cache: bool = False,
-    dcp_rank: int = 0,
-    dcp_world_size: int = 1,
-    cp_kv_cache_interleave_size: int = 1,
-    skip_topk_buffer_clear: bool = False,
 ) -> torch.Tensor:
     return topk_indices_buffer
 
@@ -718,14 +577,7 @@ class SparseAttnIndexer(CustomOp):
         self.topk_indices_buffer = topk_indices_buffer
         self.skip_k_cache_insert = skip_k_cache_insert
         self.use_fp4_cache = use_fp4_cache
-        # DCP scalars are constant for the run; resolve them here (config is set
-        # during model construction) and pass them into the custom op, rather
-        # than threading them through per-step metadata.
-        parallel_config = get_current_vllm_config().parallel_config
-        self.dcp_world_size = parallel_config.decode_context_parallel_size
-        self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
-        self.cp_kv_cache_interleave_size = parallel_config.cp_kv_cache_interleave_size
-        if current_platform.is_cuda() and not has_deep_gemm():
+        if _sparse_indexer_requires_deep_gemm() and not has_deep_gemm():
             raise RuntimeError(
                 "Sparse Attention Indexer CUDA op requires DeepGEMM support in "
                 "the current vLLM environment."
@@ -778,9 +630,6 @@ class SparseAttnIndexer(CustomOp):
             self.topk_indices_buffer,
             self.skip_k_cache_insert,
             self.use_fp4_cache,
-            self.dcp_rank,
-            self.dcp_world_size,
-            self.cp_kv_cache_interleave_size,
         )
 
     def forward_xpu(

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -10,6 +10,7 @@ from transformers import PretrainedConfig
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
+from vllm.distributed import tensor_model_parallel_all_gather
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
@@ -119,6 +120,20 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
             hidden_states=hidden_states,
             residual=None,
         )
+        # Under sequence-parallel MoE (expert-parallel + TP>1) mtp_block
+        # reduce-scatters to a per-rank token shard. Restore full tokens before
+        # shared_head/compute_logits so the vocab-parallel all_gather sees a
+        # consistent token count on every rank (else it deadlocks). Mirrors
+        # DeepseekV2Model.forward and the Qwen MTP fix #48429.
+        if hidden_states.shape[0] != positions.shape[0]:
+            combined_states = torch.cat([hidden_states, residual], dim=-1)
+            combined_states = tensor_model_parallel_all_gather(combined_states, 0)
+            combined_states = combined_states[: positions.shape[0]]
+            hidden_states, residual = combined_states.split(
+                [self.config.hidden_size, self.config.hidden_size], dim=-1
+            )
+            # fused_add_rms_norm requires a contiguous residual
+            residual = residual.contiguous()
         hidden_states = residual + hidden_states  # pre-final-norm (logits hidden)
         # Recycle the post-final-norm hidden into the next draft step.
         # compute_logits applies shared_head (== final norm) to the pre-norm

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -42,11 +42,10 @@ from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_gather,
-    tensor_model_parallel_reduce_scatter,
 )
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul
-from vllm.model_executor.layers.attention import Attention, RSWAAttention
+from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.fused_moe import (
     FusedMoE,
@@ -117,19 +116,6 @@ from .utils import (
 logger = init_logger(__name__)
 
 
-def _get_moe_router_dtype(
-    config: DeepseekV2Config | DeepseekV3Config,
-) -> torch.dtype | None:
-    router_dtype = getattr(config, "moe_router_dtype", None)
-    if getattr(config, "model_type", None) == "glm_moe_dsa":
-        # Older GLM-5/5.2 configs require fp32 routing but do not expose
-        # moe_router_dtype yet.
-        return torch.float32
-    if router_dtype == "float32":
-        return torch.float32
-    return None
-
-
 class DeepseekAttention(nn.Module):
     """Normal MHA implementation used by Deepseek v1."""
 
@@ -142,7 +128,6 @@ class DeepseekAttention(nn.Module):
         max_position_embeddings: int = 8192,
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
-        reduce_results: bool = True,
         prefix: str = "",
         **kwargs,
     ) -> None:
@@ -181,7 +166,6 @@ class DeepseekAttention(nn.Module):
             self.total_num_heads * self.head_dim,
             hidden_size,
             bias=False,
-            reduce_results=reduce_results,
             quant_config=quant_config,
         )
 
@@ -190,28 +174,15 @@ class DeepseekAttention(nn.Module):
             max_position=max_position_embeddings,
             rope_parameters=config.rope_parameters,
         )
-        rswa_window = getattr(vllm_config.model_config.hf_config, "rswa_window", None)
-        if rswa_window is not None:
-            self.attn = RSWAAttention(
-                self.num_heads,
-                self.head_dim,
-                self.scaling,
-                num_kv_heads=self.num_kv_heads,
-                cache_config=cache_config,
-                quant_config=quant_config,
-                prefix=f"{prefix}.attn",
-                rswa_window=rswa_window,
-            )
-        else:
-            self.attn = Attention(
-                self.num_heads,
-                self.head_dim,
-                self.scaling,
-                num_kv_heads=self.num_kv_heads,
-                cache_config=cache_config,
-                quant_config=quant_config,
-                prefix=f"{prefix}.attn",
-            )
+        self.attn = Attention(
+            self.num_heads,
+            self.head_dim,
+            self.scaling,
+            num_kv_heads=self.num_kv_heads,
+            cache_config=cache_config,
+            quant_config=quant_config,
+            prefix=f"{prefix}.attn",
+        )
 
     def forward(
         self,
@@ -301,13 +272,9 @@ class DeepseekV2MoE(nn.Module):
                 "Only silu is supported for now."
             )
 
-        self.router_dtype = _get_moe_router_dtype(config)
         self.gate = GateLinear(
             config.hidden_size,
             config.n_routed_experts,
-            params_dtype=self.router_dtype,
-            out_dtype=self.router_dtype,
-            force_fp32_compute=self.router_dtype == torch.float32,
             prefix=f"{prefix}.gate",
         )
         if getattr(config, "topk_method", None) == "noaux_tc":
@@ -338,7 +305,6 @@ class DeepseekV2MoE(nn.Module):
         if (
             self.is_rocm_aiter_moe_enabled
             and self.gate.e_score_correction_bias is not None
-            and self.gate.out_dtype is None
         ):
             # Accumulates in fp32; avoids bf16->fp32 cast.
             self.gate.set_out_dtype(self.gate.weight.dtype)
@@ -393,17 +359,15 @@ class DeepseekV2MoE(nn.Module):
                 self.gate.e_score_correction_bias.data.to(self.gate.out_dtype)
             )
 
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        already_sequence_parallel: bool = False,
-    ) -> torch.Tensor:
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         num_tokens, hidden_dim = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_dim)
 
         # Chunk the hidden states so they aren't replicated across TP ranks.
         # This avoids duplicate computation in self.experts.
-        if self.is_sequence_parallel and not already_sequence_parallel:
+        # TODO: We can replace the all_reduce at the end of attn with a
+        # reduce_scatter instead of chunking here.
+        if self.is_sequence_parallel:
             hidden_states = sequence_parallel_chunk(hidden_states)
 
         if self.experts.is_internal_router:
@@ -416,7 +380,7 @@ class DeepseekV2MoE(nn.Module):
                 hidden_states=hidden_states, router_logits=router_logits
             )
 
-        if self.is_sequence_parallel and not already_sequence_parallel:
+        if self.is_sequence_parallel:
             final_hidden_states = tensor_model_parallel_all_gather(
                 final_hidden_states, 0
             )
@@ -459,7 +423,6 @@ class DeepseekV2Attention(nn.Module):
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
         topk_indices_buffer: torch.Tensor | None = None,
-        reduce_results: bool = True,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -526,7 +489,6 @@ class DeepseekV2Attention(nn.Module):
             self.num_heads * self.v_head_dim,
             self.hidden_size,
             bias=False,
-            reduce_results=reduce_results,
             quant_config=quant_config,
             prefix=f"{prefix}.o_proj",
         )
@@ -626,12 +588,12 @@ class DeepseekV32IndexerCache(torch.nn.Module, AttentionLayerBase):
         compilation_config.static_forward_context[prefix] = self
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        return MLAAttentionSpec(
+        return MLAAttentionSpec(  # Only has one vector instead of K + V
             block_size=self.cache_config.block_size,
             num_kv_heads=1,
             head_size=self.head_dim,
             dtype=self.dtype,
-        )  # Only has one vector instead of K + V
+        )
 
     def forward(self): ...
 
@@ -975,7 +937,6 @@ class DeepseekV2MLAAttention(nn.Module):
         prefix: str = "",
         topk_indices_buffer: torch.Tensor | None = None,
         input_size: int | None = None,
-        reduce_results: bool = True,
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -1044,7 +1005,6 @@ class DeepseekV2MLAAttention(nn.Module):
             self.num_heads * self.v_head_dim,
             self.hidden_size,
             bias=False,
-            reduce_results=reduce_results,
             quant_config=quant_config,
             prefix=f"{prefix}.o_proj",
         )
@@ -1077,30 +1037,24 @@ class DeepseekV2MLAAttention(nn.Module):
         # IndexCache config
         # Refer: https://arxiv.org/abs/2603.12201 for more details.
         _skip_topk = False
-        is_mtp_layer = False
-        if self.is_v32:
-            _index_topk_freq = getattr(config, "index_topk_freq", 1)
-            _index_topk_pattern = getattr(config, "index_topk_pattern", None)
-            _index_skip_topk_offset = getattr(config, "index_skip_topk_offset", 2)
-            layer_id = extract_layer_index(prefix)
+        _index_topk_freq = getattr(config, "index_topk_freq", 1)
+        _index_topk_pattern = getattr(config, "index_topk_pattern", None)
+        _index_skip_topk_offset = getattr(config, "index_skip_topk_offset", 2)
+        layer_id = extract_layer_index(prefix)
 
-            if _index_topk_pattern is None:
-                _skip_topk = (
-                    max(layer_id - _index_skip_topk_offset + 1, 0) % _index_topk_freq
-                    != 0
-                )
-            elif 0 <= layer_id < len(_index_topk_pattern):
-                _skip_topk = _index_topk_pattern[layer_id] == "S"
-
-            # The skip pattern only governs backbone layers. MTP/nextn
-            # layers (layer_id >= num_hidden_layers) always build a full
-            # indexer: they compute indices at draft step 0 and toggle
-            # at runtime via set_skip_topk
-            # (index_share_for_mtp_iteration).
-            _num_hidden_layers = getattr(config, "num_hidden_layers", None)
-            is_mtp_layer = (
-                _num_hidden_layers is not None and layer_id >= _num_hidden_layers
+        if _index_topk_pattern is None:
+            _skip_topk = (
+                max(layer_id - _index_skip_topk_offset + 1, 0) % _index_topk_freq != 0
             )
+        elif 0 <= layer_id < len(_index_topk_pattern):
+            _skip_topk = _index_topk_pattern[layer_id] == "S"
+
+        # The skip pattern only governs backbone layers. MTP/nextn layers
+        # (layer_id >= num_hidden_layers) always build a full indexer: they
+        # compute indices at draft step 0 and toggle at runtime via
+        # set_skip_topk (index_share_for_mtp_iteration).
+        _num_hidden_layers = getattr(config, "num_hidden_layers", None)
+        is_mtp_layer = _num_hidden_layers is not None and layer_id >= _num_hidden_layers
 
         if self.is_v32 and (not _skip_topk or is_mtp_layer):
             self.indexer_rope_emb = get_rope(
@@ -1211,18 +1165,6 @@ class DeepseekV2DecoderLayer(nn.Module):
             attn_cls = DeepseekV2MLAAttention
         else:
             attn_cls = DeepseekV2Attention
-        is_moe_layer = (
-            config.n_routed_experts is not None
-            and layer_idx >= config.first_k_dense_replace
-            and layer_idx % moe_layer_freq == 0
-        )
-        # TODO(wentao): enable SP MoE with PP after the PP boundary logic can safely
-        # send/receive sequence-parallel hidden_states across stages.
-        self.use_sequence_parallel_moe = (
-            parallel_config.use_sequence_parallel_moe
-            and parallel_config.pipeline_parallel_size == 1
-            and is_moe_layer
-        )
         self.self_attn = attn_cls(
             vllm_config=vllm_config,
             config=config,
@@ -1238,10 +1180,13 @@ class DeepseekV2DecoderLayer(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.self_attn",
             topk_indices_buffer=topk_indices_buffer,
-            reduce_results=not self.use_sequence_parallel_moe,
         )
 
-        if is_moe_layer:
+        if (
+            config.n_routed_experts is not None
+            and layer_idx >= config.first_k_dense_replace
+            and layer_idx % moe_layer_freq == 0
+        ):
             self.mlp = DeepseekV2MoE(
                 config=config,
                 parallel_config=parallel_config,
@@ -1269,23 +1214,12 @@ class DeepseekV2DecoderLayer(nn.Module):
         residual: torch.Tensor | None,
         llama_4_scaling: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        full_num_tokens = positions.shape[0]
-        input_is_sequence_parallel = (
-            self.use_sequence_parallel_moe
-            and residual is not None
-            and hidden_states.shape[0] != full_num_tokens
-        )
-
         # Self Attention
         if residual is None:
-            residual = hidden_states
+            residual = hidden_states.clone()
             hidden_states = self.input_layernorm(hidden_states)
         else:
             hidden_states, residual = self.input_layernorm(hidden_states, residual)
-
-        if input_is_sequence_parallel:
-            hidden_states = tensor_model_parallel_all_gather(hidden_states, 0)
-            hidden_states = hidden_states[:full_num_tokens]
 
         attn_kwargs = {
             "positions": positions,
@@ -1308,29 +1242,9 @@ class DeepseekV2DecoderLayer(nn.Module):
                 # first layer.
                 residual *= 1.0 / self.routed_scaling_factor
 
-        if self.use_sequence_parallel_moe:
-            sp_remainder = (
-                hidden_states.shape[0] % get_tensor_model_parallel_world_size()
-            )
-            # pad if not divisible by world size
-            if sp_remainder:
-                sp_pad = get_tensor_model_parallel_world_size() - sp_remainder
-                hidden_states = torch.nn.functional.pad(
-                    hidden_states, (0, 0, 0, sp_pad)
-                )
-            hidden_states = tensor_model_parallel_reduce_scatter(hidden_states, 0)
-            if not input_is_sequence_parallel:
-                residual = sequence_parallel_chunk(residual)
-
         # Fully Connected
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
-        if self.use_sequence_parallel_moe:
-            hidden_states = self.mlp(
-                hidden_states,
-                already_sequence_parallel=True,
-            )
-        else:
-            hidden_states = self.mlp(hidden_states)
+        hidden_states = self.mlp(hidden_states)
 
         if isinstance(self.mlp, DeepseekV2MLP) and hidden_states.dtype == torch.float16:
             # Fix FP16 overflow
@@ -1354,7 +1268,7 @@ class DeepseekV2Model(nn.Module):
         quant_config = vllm_config.quant_config
         self.config = config
         self.device = current_platform.device_type
-        self.hidden_size = config.hidden_size
+
         self.vocab_size = config.vocab_size
         self.is_v32 = hasattr(config, "index_topk")
         if self.is_v32:
@@ -1371,7 +1285,7 @@ class DeepseekV2Model(nn.Module):
         if get_pp_group().is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
                 config.vocab_size,
-                self.hidden_size,
+                config.hidden_size,
                 quant_config=quant_config,
                 prefix=f"{prefix}.embed_tokens",
             )
@@ -1388,11 +1302,11 @@ class DeepseekV2Model(nn.Module):
         )
 
         if get_pp_group().is_last_rank:
-            self.norm = RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         else:
             self.norm = PPMissingLayer()
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
-            ["hidden_states", "residual"], self.hidden_size
+            ["hidden_states", "residual"], config.hidden_size
         )
 
         self.aux_hidden_state_layers = tuple[int, ...]()
@@ -1452,27 +1366,8 @@ class DeepseekV2Model(nn.Module):
             islice(self.layers, self.start_layer, self.end_layer),
             start=self.start_layer,
         ):
-            # all gather if we need to use the whole states
-            if (
-                hidden_states.shape[0] != positions.shape[0]
-                and not layer.use_sequence_parallel_moe
-            ):
-                combined_states = torch.cat([hidden_states, residual], dim=-1)
-                combined_states = tensor_model_parallel_all_gather(combined_states, 0)
-                combined_states = combined_states[: positions.shape[0]]
-                hidden_states, residual = combined_states.split(
-                    [self.hidden_size, self.hidden_size], dim=-1
-                )
-                # fused_add_rms_norm requires a contiguous residual
-                residual = residual.contiguous()
             if idx in self.aux_hidden_state_layers:
-                aux_hidden_state = hidden_states + residual
-                if aux_hidden_state.shape[0] != positions.shape[0]:
-                    aux_hidden_state = tensor_model_parallel_all_gather(
-                        aux_hidden_state, 0
-                    )
-                    aux_hidden_state = aux_hidden_state[: positions.shape[0]]
-                aux_hidden_states.append(aux_hidden_state)
+                aux_hidden_states.append(hidden_states + residual)
             hidden_states, residual = layer(
                 positions, hidden_states, residual, llama_4_scaling
             )
@@ -1481,19 +1376,6 @@ class DeepseekV2Model(nn.Module):
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )
-
-        if hidden_states.shape[0] != positions.shape[0]:
-            combined_states = torch.cat([hidden_states, residual], dim=-1)
-            combined_states = tensor_model_parallel_all_gather(combined_states, 0)
-            combined_states = combined_states[: positions.shape[0]]
-            hidden_states, residual = combined_states.split(
-                [self.hidden_size, self.hidden_size], dim=-1
-            )
-            # fused_add_rms_norm requires a contiguous residual
-            residual = residual.contiguous()
-
-        if self.end_layer in self.aux_hidden_state_layers:
-            aux_hidden_states.append(hidden_states + residual)
 
         hidden_states, _ = self.norm(hidden_states, residual)
         if len(aux_hidden_states) > 0:
@@ -1550,11 +1432,6 @@ class DeepseekV2Model(nn.Module):
         pp_missing_layer_names = get_pp_missing_layer_names(self)
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
-        # With index_topk_freq>1 only some layers build an indexer, yet the
-        # checkpoint ships indexer weights for all of them; track the built ones.
-        indexer_present_prefixes = {
-            n.rsplit(".indexer.", 1)[0] for n in params_dict if ".indexer." in n
-        }
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
                 continue
@@ -1562,11 +1439,6 @@ class DeepseekV2Model(nn.Module):
             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
             if spec_layer is not None:
                 continue  # skip spec decode layers for main model
-
-            if ".indexer." in name and (
-                name.rsplit(".indexer.", 1)[0] not in indexer_present_prefixes
-            ):
-                continue  # this layer has no indexer; drop its checkpoint weights
 
             is_fusion_moe_shared_experts_layer = (
                 rocm_aiter_moe_shared_expert_enabled and ("mlp.shared_experts" in name)
@@ -1842,6 +1714,8 @@ class DeepseekV2ForCausalLM(
         self.set_moe_parameters()
 
     def set_moe_parameters(self):
+        self.expert_weights = []
+
         self.num_expert_groups = getattr(self.config, "n_group", 1)
 
         self.moe_layers = []

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -16,7 +16,7 @@ from vllm.model_executor.layers.attention.mla_attention import (
 from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils.platform_utils import num_compute_units
-from vllm.utils.torch_utils import is_quantized_kv_cache, np_to_pinned_tensor
+from vllm.utils.torch_utils import is_quantized_kv_cache
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
@@ -36,6 +36,10 @@ from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
     split_prefill_chunks,
 )
+# --- SM12x: activate portable Triton sparse-MLA before the native ops are
+# copied into this module's namespace (must precede the import below). ---
+from vllm.v1.attention.backends.mla import patch_flashmla_ops as _sm12x_pfo  # noqa: E402
+_sm12x_pfo.apply()
 from vllm.v1.attention.ops.flashmla import (
     FlashMLASchedMeta,
     flash_mla_sparse_fwd,
@@ -127,7 +131,7 @@ class FlashMLASparseBackend(AttentionBackend):
 
     @classmethod
     def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
-        return capability.major in [9, 10]
+        return capability.major in [9, 10, 12]
 
     @staticmethod
     def get_kv_cache_shape(
@@ -137,7 +141,7 @@ class FlashMLASparseBackend(AttentionBackend):
         head_size: int,
         cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
-        if cache_dtype_str == "fp8_ds_mla":
+        if head_size == 576:  # fp8_ds_mla V3.2: 576 latent + 80 meta = 656
             # V3.2 main MLA: 656-byte custom storage format. See module docstring.
             return (num_blocks, block_size, 656)
         else:
@@ -503,7 +507,7 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
         # Zero-fill for cudagraphs
         self.req_id_per_token_buffer.fill_(0)
         self.req_id_per_token_buffer[: req_id_per_token.shape[0]].copy_(
-            np_to_pinned_tensor(req_id_per_token), non_blocking=True
+            torch.from_numpy(req_id_per_token), non_blocking=True
         )
         req_id_per_token = self.req_id_per_token_buffer[:num_tokens]
 
@@ -540,8 +544,28 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
 class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
     @staticmethod
     def _compute_fp8_decode_padded_heads(num_heads: int) -> int:
-        # FP8 decode kernel only supports h_q = 64 or 128
-        # Compute padded head count for decode
+        # Raw FlashMLA fp8 decode kernel supports h_q = 64 or 128 only, but the
+        # b12x / Triton sm12x sparse-MLA path used on GB10 (sm_121) accepts
+        # %16 alignment (b12x_sparse_helpers falls to mg_n_hg=1 when %32 != 0).
+        # At high TP the per-rank head count is small (GLM-5.2: 64 heads ->
+        # 16/rank @ TP=4), so padding 16 -> 64 wasted 75% of the fp8 attention
+        # compute; padding to 16 (i.e. not at all at TP=4) eliminates it.
+        #
+        # GB10 4-node TP=4 bench (GLM-5.2 QuantTrio, in-ckpt MTP k=4, cudagraph
+        # FULL, kv fp8_ds_mla, llama-benchy) prefill tok/s, 64-pad -> 32 -> 16:
+        #   depth 0    498 -> 666 -> 722
+        #   depth 8k   509 -> 671 -> 736
+        #   depth 32k  461 -> 592 -> 626
+        # Decode is unchanged between 32 and 16 once normalized for spec-decode
+        # acceptance variance; output coherence verified at both. Credit:
+        # back199640 (GB10 user forum) for the original 64->32 fix; the 32->16
+        # step exploits the helper's mg_n_hg=1 path.
+        # WARNING: below 32 heads the raw-FlashMLA fallback (h_q 64/128) is no
+        # longer reachable -- b12x must be installed for the fp8 decode path.
+        if num_heads <= 16:
+            return 16
+        if num_heads <= 32:
+            return 32
         return 64 if num_heads <= 64 else 128
 
     def __init__(
@@ -800,17 +824,39 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
             q_padded[:, :, :actual_num_heads, :] = q
             q = q_padded
 
-        out, lse = flash_mla_with_kvcache(
-            q=q,
-            k_cache=kv_c_and_k_pe_cache.view(torch.uint8).unsqueeze(-2),
-            block_table=kernel_metadata.dummy_block_table,
-            head_dim_v=512,
-            cache_seqlens=kernel_metadata.cache_lens,
-            tile_scheduler_metadata=kernel_metadata.scheduler_metadata,
-            is_fp8_kvcache=True,
-            indices=topk_indices,
-            softmax_scale=self.softmax_scale,
-        )
+        kv_cache_uint8 = kv_c_and_k_pe_cache.view(torch.uint8)
+        b12x_result = None
+        try:
+            from vllm.v1.attention.ops.deepseek_v4_ops.b12x_sparse_helpers import (
+                b12x_glm_mla_attention,
+            )
+
+            b12x_result = b12x_glm_mla_attention(
+                q=q,
+                kv_cache=kv_cache_uint8,
+                topk_indices=topk_indices,
+                softmax_scale=self.softmax_scale,
+            )
+        except Exception as exc:
+            logger.warning_once(
+                "B12x GLM sparse MLA failed; falling back to SM12x path: %r",
+                exc,
+            )
+
+        if b12x_result is None:
+            out, lse = flash_mla_with_kvcache(
+                q=q,
+                k_cache=kv_cache_uint8.unsqueeze(-2),
+                block_table=kernel_metadata.dummy_block_table,
+                head_dim_v=512,
+                cache_seqlens=kernel_metadata.cache_lens,
+                tile_scheduler_metadata=kernel_metadata.scheduler_metadata,
+                is_fp8_kvcache=True,
+                indices=topk_indices,
+                softmax_scale=self.softmax_scale,
+            )
+        else:
+            out, lse = b12x_result
 
         # Slice output back to actual head count if we padded
         if actual_num_heads < padded_num_heads:

--- a/vllm/v1/attention/backends/mla/patch_flashmla_ops.py
+++ b/vllm/v1/attention/backends/mla/patch_flashmla_ops.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Runtime monkeypatch: route the native FlashMLA *sparse* ops to Triton.
+
+On consumer Blackwell (sm_121 / SM12x) the compiled ``vllm._flashmla_C``
+extension does not exist, so ``vllm.v1.attention.ops.flashmla`` binds
+``flash_mla_sparse_fwd`` and ``flash_mla_with_kvcache`` to a stub that raises
+``"vllm._flashmla_C is not available"``.  The V3.2 sparse-MLA backend
+(``flashmla_sparse.py``) crashes on the first real request.
+
+Importing this module (e.g. very early in engine startup, or via a vLLM plugin
+entrypoint) rebinds those two names to the portable Triton implementations in
+``sm12x_sparse_mla_attn.py`` whenever:
+
+    * ``is_triton_sparse_mla_enabled()`` is true (auto on sm12x, or forced via
+      ``VLLM_TRITON_MLA_SPARSE=1``), OR
+    * ``vllm._flashmla_C`` is unavailable (the stub is currently bound).
+
+It also makes the backend believe sparse is supported by patching
+``is_flashmla_sparse_supported`` to return ``True`` on SM12x, and registers the
+``VLLM_TRITON_MLA_SPARSE*`` env vars into ``vllm.envs`` if the running image's
+``envs.py`` predates them (so the copied ``sparse_mla_env.py`` /
+``sparse_mla_kernels.py`` import cleanly without editing ``envs.py``).
+
+Idempotent: calling ``apply()`` more than once is safe.
+"""
+
+from __future__ import annotations
+
+import os
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_APPLIED = False
+
+
+# ---------------------------------------------------------------------------
+# 1. Backfill VLLM_TRITON_MLA_SPARSE* env vars if the image predates them.
+# ---------------------------------------------------------------------------
+def _ensure_envs() -> None:
+    import vllm.envs as envs
+
+    def _opt_bool(name: str):
+        raw = os.getenv(name)
+        if raw is None:
+            return None
+        return bool(int(raw))
+
+    def _opt_int(name: str):
+        raw = os.getenv(name)
+        if raw is None:
+            return None
+        return int(raw)
+
+    defaults: dict[str, object] = {
+        # None => auto-select (sparse_mla_env decides per-device).
+        "VLLM_TRITON_MLA_SPARSE": lambda: _opt_bool("VLLM_TRITON_MLA_SPARSE"),
+        "VLLM_TRITON_MLA_SPARSE_TOPK_CHUNK_SIZE": lambda: int(
+            os.getenv("VLLM_TRITON_MLA_SPARSE_TOPK_CHUNK_SIZE", "512")
+        ),
+        "VLLM_TRITON_MLA_SPARSE_QUERY_CHUNK_SIZE": lambda: int(
+            os.getenv("VLLM_TRITON_MLA_SPARSE_QUERY_CHUNK_SIZE", "256")
+        ),
+        "VLLM_TRITON_MLA_SPARSE_HEAD_BLOCK_SIZE": lambda: _opt_int(
+            "VLLM_TRITON_MLA_SPARSE_HEAD_BLOCK_SIZE"
+        ),
+        "VLLM_TRITON_MLA_SPARSE_MATMUL_DECODE": lambda: _opt_bool(
+            "VLLM_TRITON_MLA_SPARSE_MATMUL_DECODE"
+        ),
+    }
+    registry = getattr(envs, "environment_variables", None)
+    if registry is None:
+        logger.warning(
+            "vllm.envs has no environment_variables registry; cannot backfill "
+            "VLLM_TRITON_MLA_SPARSE* env vars."
+        )
+        return
+    for name, fn in defaults.items():
+        if name not in registry:
+            registry[name] = fn
+            logger.info("Registered missing env var %s into vllm.envs", name)
+
+
+# ---------------------------------------------------------------------------
+# 2. Decide whether to enable the Triton sparse path.
+# ---------------------------------------------------------------------------
+def _should_enable() -> bool:
+    from vllm.v1.attention.ops import flashmla as ops_flashmla
+
+    # Stub currently bound (i.e. _flashmla_C unavailable) -> always enable, we
+    # have no alternative.
+    native_available, _ = ops_flashmla._is_flashmla_available()
+    if not native_available:
+        return True
+
+    # Native available but user/device wants Triton (e.g. SM12x with a partial
+    # _flashmla_C, or forced via env).
+    try:
+        from vllm.v1.attention.backends.mla.sparse_mla_env import (
+            is_triton_sparse_mla_enabled_for_platform,
+        )
+
+        return bool(is_triton_sparse_mla_enabled_for_platform())
+    except Exception:  # pragma: no cover - defensive
+        return False
+
+
+# ---------------------------------------------------------------------------
+# 3. Apply the rebind.
+# ---------------------------------------------------------------------------
+def apply(force: bool = False) -> bool:
+    """Rebind the native sparse ops to Triton. Returns True if applied."""
+    global _APPLIED
+    if _APPLIED and not force:
+        return True
+
+    _ensure_envs()
+
+    if not force and not _should_enable():
+        logger.info(
+            "Native FlashMLA sparse ops available and Triton path not requested; "
+            "leaving flash_mla_sparse_fwd / flash_mla_with_kvcache untouched."
+        )
+        return False
+
+    from vllm.v1.attention.ops import flashmla as ops_flashmla
+
+    # Import the adapter. When this file lives inside
+    # vllm/v1/attention/backends/mla/ the package-relative import works; the
+    # fallbacks let it also run as a loose module (e.g. in the validation
+    # container) where it is importable by bare name.
+    try:
+        from .sm12x_sparse_mla_attn import (
+            flash_mla_sparse_fwd_triton,
+            flash_mla_with_kvcache_triton,
+        )
+    except ImportError:
+        try:
+            from vllm.v1.attention.backends.mla.sm12x_sparse_mla_attn import (
+                flash_mla_sparse_fwd_triton,
+                flash_mla_with_kvcache_triton,
+            )
+        except ImportError:
+            from sm12x_sparse_mla_attn import (
+                flash_mla_sparse_fwd_triton,
+                flash_mla_with_kvcache_triton,
+            )
+
+    ops_flashmla.flash_mla_sparse_fwd = flash_mla_sparse_fwd_triton
+    ops_flashmla.flash_mla_with_kvcache = flash_mla_with_kvcache_triton
+
+    # SM12x: get_mla_metadata computes the NATIVE FlashMLA tile-scheduler
+    # metadata (needs _flashmla_C). The fp8-mixed-batch decode metadata builder
+    # (flashmla_sparse.py _build_fp8_mixed_decode_prefill) calls it, but our
+    # Triton kernels self-schedule and ignore tile_scheduler_metadata (it's a
+    # None-default arg). Return (None, None) so no native call is made.
+    def _sm12x_get_mla_metadata(*args, **kwargs):  # noqa: ANN001, ANN002
+        return None, None
+
+    ops_flashmla.get_mla_metadata = _sm12x_get_mla_metadata
+
+    # The V3.2 backend test gate is `flashmla.is_flashmla_sparse_supported()`;
+    # report supported on SM12x so the backend is actually selected.
+    _orig_supported = ops_flashmla.is_flashmla_sparse_supported
+
+    def _patched_is_flashmla_sparse_supported() -> tuple[bool, str | None]:
+        try:
+            from vllm.platforms import current_platform
+
+            if current_platform.is_device_capability_family(120):
+                return True, None
+        except Exception:  # pragma: no cover - defensive
+            pass
+        return _orig_supported()
+
+    ops_flashmla.is_flashmla_sparse_supported = _patched_is_flashmla_sparse_supported
+
+    _APPLIED = True
+    logger.info(
+        "Patched vllm.v1.attention.ops.flashmla: flash_mla_sparse_fwd and "
+        "flash_mla_with_kvcache now use portable Triton sparse-MLA kernels "
+        "(SM12x / no _flashmla_C)."
+    )
+    return True
+
+
+# Auto-apply on import for convenience. Callers that want explicit control can
+# import ``apply`` and invoke it themselves (it is idempotent).
+try:  # pragma: no cover - exercised at runtime on the cluster
+    apply()
+except Exception as exc:  # pragma: no cover - never hard-fail import
+    logger.warning("patch_flashmla_ops auto-apply failed: %s", exc)

--- a/vllm/v1/attention/backends/mla/sm12x_sparse_mla_attn.py
+++ b/vllm/v1/attention/backends/mla/sm12x_sparse_mla_attn.py
@@ -1,0 +1,994 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Drop-in Triton replacements for the native FlashMLA *sparse* CUDA ops.
+
+These functions reproduce, on consumer Blackwell (sm_121 / SM12x) where the
+compiled ``vllm._flashmla_C`` extension does not exist, the exact behaviour of
+the two native ops that the V3.2 sparse-MLA attention backend
+(``vllm/v1/attention/backends/mla/flashmla_sparse.py`` ::
+``FlashMLASparseImpl``) calls:
+
+  * ``flash_mla_sparse_fwd``        -- BF16 sparse *prefill*  kernel
+  * ``flash_mla_with_kvcache``      -- FP8  sparse *decode*   kernel
+       (``fp8_ds_mla`` 656-byte cache format)
+
+The heavy lifting is done by the portable Triton kernels in
+``sparse_mla_kernels.py`` (copied verbatim from jasl/vllm's deepseek_v4 path).
+This module only adapts the *layouts* expected by the V3.2 backend to those
+kernels.
+
+----------------------------------------------------------------------------
+Native semantics being reproduced (from FlashMLA/flash_mla_interface.py)
+----------------------------------------------------------------------------
+
+flash_mla_sparse_fwd(q, kv, indices, sm_scale, d_v=512, attn_sink=None,
+                     topk_length=None) -> (output, max_logits, lse)
+    q       : [s_q, h_q, d_qk]  bfloat16   (d_qk = 576 = 512 NoPE + 64 RoPE)
+    kv      : [s_kv, h_kv, d_qk] bfloat16  (h_kv = 1)
+    indices : [s_q, h_kv, topk] int32      (-1 or >= s_kv == invalid)
+    score   = (q . kv) * sm_scale          over the full d_qk (576)
+    softmax over valid candidates; output = sum(p * kv[:, :d_v])
+    attn_sink (optional, [h_q] f32): output *= exp(lse) / (exp(lse)+exp(sink))
+    topk_length (optional, [s_q] int32): per-query cap on #candidates.
+    returns output [s_q, h_q, d_v] bf16, max_logits [s_q, h_q] f32,
+            lse [s_q, h_q] f32.
+
+flash_mla_with_kvcache(q, k_cache, block_table, cache_seqlens, head_dim_v,
+                       tile_scheduler_metadata, num_splits=None,
+                       softmax_scale=None, causal=False, is_fp8_kvcache=False,
+                       indices=None, attn_sink=None, extra_k_cache=None,
+                       extra_indices_in_kvcache=None, topk_length=None,
+                       extra_topk_length=None) -> (out, softmax_lse)
+    For the V3.2 fp8 sparse decode call site (see ``_fp8_flash_mla_kernel`` in
+    flashmla_sparse.py):
+        q       : [b, s_q, h_q(padded 64/128), 576] bf16
+        k_cache : [num_blocks, block_size, 1, 656] uint8  (fp8_ds_mla)
+        indices : [b, s_q, topk] int32  (already converted to GLOBAL slot ids
+                                         by triton_convert_req_index_to_global_index;
+                                         -1 / >= total_slots == invalid)
+        head_dim_v = 512, is_fp8_kvcache = True
+        attn_sink / topk_length: NOT passed by V3.2 (None).
+    returns out [b, s_q, h_q, 512] bf16, lse [b, h_q, s_q] f32.
+
+The fp8_ds_mla 656-byte per-token cache layout (kv_lora_rank=512, rope=64):
+    bytes [  0:512]  : 512 x float8_e4m3   (quantized NoPE latent)
+    bytes [512:528]  : 4   x float32        (scale, one per 128-elem tile)
+    bytes [528:656]  : 64  x bfloat16       (RoPE, not quantized)
+    dequant_nope[i] = float(fp8[i]) * scale[i // 128]   (direct fp32 multiply)
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import next_power_of_2
+from vllm.v1.attention.backends.mla.sparse_mla_kernels import (
+    accumulate_indexed_sparse_mla_attention_chunk,
+    finish_sparse_mla_attention_with_sink,
+)
+
+logger = init_logger(__name__)
+
+# fp8_ds_mla 656-byte layout constants (DeepSeek V3.2 main MLA).
+_FP8DS_NOPE_DIM = 512          # number of fp8 NoPE values
+_FP8DS_ROPE_DIM = 64           # number of bf16 RoPE values
+_FP8DS_QUANT_TILE = 128        # one fp32 scale per 128 fp8 values
+_FP8DS_NUM_SCALES = _FP8DS_NOPE_DIM // _FP8DS_QUANT_TILE  # 4
+_FP8DS_ENTRY_BYTES = (
+    _FP8DS_NOPE_DIM + 4 * _FP8DS_NUM_SCALES + 2 * _FP8DS_ROPE_DIM
+)  # 512 + 16 + 128 = 656
+_DQK = _FP8DS_NOPE_DIM + _FP8DS_ROPE_DIM  # 576
+_DV = _FP8DS_NOPE_DIM  # 512
+
+
+def _profile_enabled() -> bool:
+    return os.getenv("GLM52_PREFILL_PROFILE", "0").lower() not in {
+        "",
+        "0",
+        "false",
+        "no",
+    }
+
+
+def _cuda_capture_active() -> bool:
+    is_capturing = getattr(torch.cuda, "is_current_stream_capturing", None)
+    return bool(is_capturing and is_capturing())
+
+
+class _CudaProfileRegion:
+    def __init__(self, region: str, **fields: object) -> None:
+        self.region = region
+        self.fields = fields
+        self.enabled = (
+            _profile_enabled()
+            and torch.cuda.is_available()
+            and not _cuda_capture_active()
+        )
+        self.start_event: torch.cuda.Event | None = None
+        self.end_event: torch.cuda.Event | None = None
+
+    def start(self) -> None:
+        if not self.enabled:
+            return
+        torch.cuda.nvtx.range_push(f"glm52:{self.region}")
+        self.start_event = torch.cuda.Event(enable_timing=True)
+        self.end_event = torch.cuda.Event(enable_timing=True)
+        self.start_event.record()
+
+    def stop(self) -> None:
+        if not self.enabled or self.start_event is None or self.end_event is None:
+            return
+        self.end_event.record()
+        torch.cuda.synchronize()
+        torch.cuda.nvtx.range_pop()
+        details = " ".join(f"{key}={value}" for key, value in self.fields.items())
+        logger.info(
+            "GLM52_PREFILL_PROFILE region=%s elapsed_ms=%.3f %s",
+            self.region,
+            self.start_event.elapsed_time(self.end_event),
+            details,
+        )
+
+
+# ---------------------------------------------------------------------------
+# BF16 sparse prefill : flash_mla_sparse_fwd
+# ---------------------------------------------------------------------------
+def flash_mla_sparse_fwd_triton(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    d_v: int = 512,
+    attn_sink: torch.Tensor | None = None,
+    topk_length: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Triton BF16 sparse-MLA prefill, drop-in for ``flash_mla_sparse_fwd``.
+
+    Args mirror the native op exactly:
+        q       : [s_q, h_q, d_qk]   bf16
+        kv      : [s_kv, h_kv, d_qk] bf16   (h_kv == 1)
+        indices : [s_q, h_kv, topk]  int32  (-1 or >= s_kv invalid)
+        sm_scale: float
+        d_v     : value dim (512)
+        attn_sink: optional [h_q] f32
+        topk_length: optional [s_q] int32 per-query candidate cap
+        out     : optional pre-allocated output [s_q, h_q, d_v]
+    Returns (output [s_q, h_q, d_v] bf16, max_logits [s_q, h_q] f32,
+             lse [s_q, h_q] f32).
+
+    Implementation note on the d_qk vs d_v split: the indexed accumulate kernel
+    scores ``q . kv`` over the *full* head_dim (= d_qk = 576, including RoPE)
+    and accumulates the value as the full ``kv`` row.  Because the value
+    accumulation is per-dimension independent, the first ``d_v`` (512) columns
+    of the accumulator are *exactly* the NoPE-part value reduction we want; we
+    simply slice them off.  The RoPE columns (512:576) of the accumulator are
+    discarded (wasted compute, correct result).
+    """
+    assert q.dim() == 3, f"expected q [s_q, h_q, d_qk], got {q.shape}"
+    assert kv.dim() == 3, f"expected kv [s_kv, h_kv, d_qk], got {kv.shape}"
+    assert indices.dim() == 3, f"expected indices [s_q, h_kv, topk], got {indices.shape}"
+    assert kv.shape[1] == 1, "sparse MLA requires h_kv == 1"
+    assert indices.shape[1] == 1, "sparse MLA requires h_kv == 1 on indices"
+    s_q, h_q, d_qk = q.shape
+    s_kv = kv.shape[0]
+    topk = indices.shape[2]
+    assert kv.shape[2] == d_qk
+    assert indices.shape[0] == s_q
+
+    device = q.device
+    kv_flat = kv.reshape(s_kv, d_qk)              # [s_kv, d_qk]
+    idx2d = indices.reshape(s_q, topk).contiguous()  # [s_q, topk] int32
+
+    # Per-query candidate count (lens). The accumulate kernel iterates
+    # ``min(num_candidates, max(lens - candidate_offset, 0))`` and still
+    # individually skips negative sentinels, so:
+    #   * If topk_length is given, lens = topk_length (matches native cap).
+    #   * Otherwise lens = topk (full width); -1 entries are skipped per-cell.
+    if topk_length is not None:
+        lens = topk_length.to(device=device, dtype=torch.int32).contiguous()
+        assert lens.shape[0] == s_q
+    else:
+        lens = torch.full((s_q,), topk, dtype=torch.int32, device=device)
+
+    profile = _CudaProfileRegion(
+        "attention.bf16_sparse_prefill",
+        q_shape=tuple(q.shape),
+        kv_shape=tuple(kv.shape),
+        topk=topk,
+        topk_length="set" if topk_length is not None else "none",
+    )
+    profile.start()
+
+    # State buffers for the online-softmax accumulation (fp32).
+    max_score = torch.full((s_q, h_q), float("-inf"), dtype=torch.float32, device=device)
+    denom = torch.zeros((s_q, h_q), dtype=torch.float32, device=device)
+    acc = torch.zeros((s_q, h_q, d_qk), dtype=torch.float32, device=device)
+
+    # Single chunk over all candidates (correctness-first; chunking is a
+    # perf-only refinement that the V4 wrapper does for very large topk).
+    accumulate_indexed_sparse_mla_attention_chunk(
+        q=q,
+        kv_flat=kv_flat,
+        indices=idx2d,
+        lens=lens,
+        scale=float(sm_scale),
+        max_score=max_score,
+        denom=denom,
+        acc=acc,
+        candidate_offset=0,
+    )
+
+    # max_logits / lse are computed from the online-softmax state.
+    # max_logits[t, h] = running_max (over valid candidates), -inf if none.
+    # lse[t, h]        = log(denom) + running_max.
+    max_logits = max_score.clone()
+    safe_max = torch.where(denom > 0, max_score, torch.zeros_like(max_score))
+    lse = torch.where(
+        denom > 0,
+        torch.log(denom.clamp_min(1e-30)) + safe_max,
+        torch.full_like(max_score, float("-inf")),
+    )
+
+    if out is None:
+        out = torch.empty((s_q, h_q, _DV), dtype=q.dtype, device=device)
+    assert out.shape[0] == s_q and out.shape[2] == _DV
+
+    # attn_sink handling: finish_sparse_mla_attention_with_sink applies the
+    #   output *= exp(running_max - merge_max) / (denom*... + exp(sink-...))
+    # which is algebraically identical to the documented
+    #   output *= exp(lse) / (exp(lse) + exp(attn_sink)).
+    # When attn_sink is None we pass a -inf sink (no effect) per the native
+    # docstring ("-inf has no effect").
+    if attn_sink is None:
+        sink = torch.full((h_q,), float("-inf"), dtype=torch.float32, device=device)
+    else:
+        sink = attn_sink.to(device=device, dtype=torch.float32).contiguous()
+        assert sink.shape[0] >= h_q
+
+    # finish reads acc over its last dim; slice to d_v (NoPE value part).
+    acc_v = acc[:, :, :_DV].contiguous()
+    finish_sparse_mla_attention_with_sink(
+        max_score,
+        denom,
+        acc_v,
+        sink,
+        output=out,
+    )
+    profile.stop()
+    return out, max_logits, lse
+
+
+# ---------------------------------------------------------------------------
+# fp8_ds_mla dequant-gather kernel (for the FP8 sparse decode path)
+# ---------------------------------------------------------------------------
+@triton.jit
+def _gather_dequant_fp8ds_kernel(
+    cache_ptr,            # uint8 [total_slots, 656] (or strided view)
+    indices_ptr,          # int32 [T, K] global slot ids, -1 invalid
+    out_ptr,              # bf16  [T, K, 576] gathered dequantized kv
+    stride_cache_s,
+    stride_idx_t: tl.constexpr,
+    stride_idx_k: tl.constexpr,
+    stride_out_t: tl.constexpr,
+    stride_out_k: tl.constexpr,
+    stride_out_d: tl.constexpr,
+    total_slots,
+    nope_dim: tl.constexpr,       # 512
+    rope_dim: tl.constexpr,       # 64
+    quant_tile: tl.constexpr,     # 128
+    scale_byte_off: tl.constexpr,  # 512
+    rope_byte_off: tl.constexpr,   # 528
+    BLOCK_D: tl.constexpr,        # >= 576 (head_dim)
+):
+    # int64 program ids: the gathered-KV ``out`` tensor is [T, K, 576] and for
+    # the cluster's mixed-batch prefill (T=2048, K=2048) its per-token stride
+    # (K*576) times ``t`` overflows int32 (>2^31) around t~1821, wrapping the
+    # store address negative -> illegal global write. Promote the row/col ids to
+    # int64 so every ``t*stride`` / ``k*stride`` offset below is computed in
+    # int64. (stride_idx_* are small but the out_ptr offset is the one that
+    # overflows; keep both 64-bit for safety.)
+    t = tl.program_id(0).to(tl.int64)
+    k = tl.program_id(1).to(tl.int64)
+
+    slot = tl.load(indices_ptr + t * stride_idx_t + k * stride_idx_k)
+    is_valid = (slot >= 0) & (slot < total_slots)
+
+    dim_offsets = tl.arange(0, BLOCK_D)
+    head_dim = nope_dim + rope_dim
+    dim_mask = dim_offsets < head_dim
+    nope_mask = dim_offsets < nope_dim
+    rope_mask = (dim_offsets >= nope_dim) & dim_mask
+
+    base = cache_ptr + slot.to(tl.int64) * stride_cache_s
+
+    # ---- NoPE: fp8_e4m3 bytes [0:512] dequantized by per-128 float32 scale ----
+    fp8_bytes = tl.load(
+        base + dim_offsets,
+        mask=nope_mask & is_valid,
+        other=0,
+    )
+    fp8_vals = fp8_bytes.to(tl.float8e4nv, bitcast=True).to(tl.float32)
+    # scales: 4 float32 at byte offset 512; tile index = dim // 128
+    scale_tile = dim_offsets // quant_tile  # 0..3 within nope region
+    scale_byte = scale_byte_off + scale_tile * 4
+    # load each of the 4 scale-bytes as a float32 (little-endian assemble)
+    b0 = tl.load(base + scale_byte + 0, mask=nope_mask & is_valid, other=0).to(tl.int32)
+    b1 = tl.load(base + scale_byte + 1, mask=nope_mask & is_valid, other=0).to(tl.int32)
+    b2 = tl.load(base + scale_byte + 2, mask=nope_mask & is_valid, other=0).to(tl.int32)
+    b3 = tl.load(base + scale_byte + 3, mask=nope_mask & is_valid, other=0).to(tl.int32)
+    scale_bits = (b0 & 0xFF) | ((b1 & 0xFF) << 8) | ((b2 & 0xFF) << 16) | ((b3 & 0xFF) << 24)
+    scale_f32 = scale_bits.to(tl.float32, bitcast=True)
+    nope = fp8_vals * scale_f32
+
+    # ---- RoPE: bf16 values [528:656] -> elements [0:64] over nope:nope+64 ----
+    rope_elem = tl.maximum(dim_offsets - nope_dim, 0)  # 0..63 for rope region
+    rope_ptr = (base + rope_byte_off).to(tl.pointer_type(tl.bfloat16))
+    rope = tl.load(rope_ptr + rope_elem, mask=rope_mask & is_valid, other=0.0).to(
+        tl.float32
+    )
+
+    kv = tl.where(nope_mask, nope, rope)
+    kv = tl.where(dim_mask & is_valid, kv, 0.0)
+
+    tl.store(
+        out_ptr + t * stride_out_t + k * stride_out_k + dim_offsets * stride_out_d,
+        kv.to(out_ptr.dtype.element_ty),
+        mask=dim_mask,
+    )
+
+
+def _gather_dequant_fp8ds(
+    cache_flat: torch.Tensor,   # uint8 [total_slots, 656]
+    indices: torch.Tensor,      # int32 [T, K] global slot ids
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Gather + dequantize fp8_ds_mla cache rows selected by ``indices``.
+
+    Returns (kv [T, K, 576] bf16, valid [T, K] bool).
+    Invalid (-1 / out-of-range) rows are zero-filled and marked invalid.
+    """
+    assert cache_flat.dtype == torch.uint8
+    assert cache_flat.dim() == 2 and cache_flat.shape[1] == _FP8DS_ENTRY_BYTES, (
+        f"expected fp8_ds_mla cache [total_slots, {_FP8DS_ENTRY_BYTES}], "
+        f"got {tuple(cache_flat.shape)}"
+    )
+    assert indices.dim() == 2
+    T, K = indices.shape
+    total_slots = cache_flat.shape[0]
+    device = cache_flat.device
+
+    out = torch.empty((T, K, _DQK), dtype=torch.bfloat16, device=device)
+    idx_c = indices.contiguous()
+    # valid mask is a pure function of the (already global) indices; compute on
+    # the host to avoid scalar-indexing inside the kernel.
+    valid = (idx_c >= 0) & (idx_c < total_slots)
+    block_d = max(64, next_power_of_2(_DQK))  # 1024 (>= 576)
+    grid = (T, K)
+    _gather_dequant_fp8ds_kernel[grid](
+        cache_flat,
+        idx_c,
+        out,
+        cache_flat.stride(0),
+        idx_c.stride(0),
+        idx_c.stride(1),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        total_slots,
+        _FP8DS_NOPE_DIM,
+        _FP8DS_ROPE_DIM,
+        _FP8DS_QUANT_TILE,
+        _FP8DS_NOPE_DIM,            # scale_byte_off = 512
+        _FP8DS_NOPE_DIM + 4 * _FP8DS_NUM_SCALES,  # rope_byte_off = 528
+        BLOCK_D=block_d,
+        num_warps=4,
+    )
+    return out, valid
+
+
+# ---------------------------------------------------------------------------
+# FUSED gather-dequant + online-softmax attention (no [T,K,576] materialization)
+# ---------------------------------------------------------------------------
+# The materialized path (``_gather_dequant_fp8ds`` -> ``_materialized_attn_kernel``)
+# writes a dense [T, K, 576] bf16 tensor (~4.83 GB at T=K=2048) then reads it
+# back. Profiling on a 5090 (T=K=2048, H=24) showed the *attend* pass dominates
+# (~90%), not the gather (~10%): the materialized attend kernel walks one
+# candidate at a time with a scalar ``tl.sum(q*kv)`` reduction and a
+# data-dependent ``if is_valid`` branch, which is both low-occupancy and
+# memory-bound on the 4.83 GB re-read. The fused kernel below (a) never
+# materializes the [T,K,576] tensor (dequant happens in-tile, in registers),
+# eliminating that ~4.83 GB write+read of HBM traffic, and (b) tiles the
+# candidate axis (BLOCK_N) so the QK score becomes a ``tl.dot`` (tensor-core)
+# matmul and the per-candidate loop overhead is amortized by BLOCK_N.
+#
+# *** NoPE/RoPE D-split layout (2026-06-20 tuning) ***
+# The head_dim is 576 = 512 NoPE + 64 RoPE. A naive single-tile layout has to
+# round 576 up to the next power of two (1024) for ``tl.arange``/``tl.dot``,
+# which (a) dots over 1024 columns instead of 576 (~1.78x wasted tensor-core
+# FLOPs on QK) and (b) makes the per-candidate KV tile 1024*2 B wide, so at
+# num_warps=4 the 99 KB opt-in shared-mem budget caps BLOCK_N at 16. By handling
+# NoPE (512, already pow2) and RoPE (64, pow2) as two *separate* sub-blocks the
+# QK score becomes ``q_nope.kv_nopeᵀ + q_rope.kv_ropeᵀ`` over exactly 512+64=576
+# effective columns (no 1024 padding), the KV tile shrinks to (512+64)*2 B, and
+# BLOCK_N=32 now fits in 99 KB. The value accumulation is over the NoPE block
+# only (the RoPE columns are never part of the output value), so the PV dot is
+# 512-wide instead of 1024-wide. Net: ~3.4-3.6x over the BLOCK_N=16 single-tile
+# baseline at the cluster prefill shape (T=2048/4096, H=24). Pinned config (no
+# runtime autotune): BLOCK_N=32, HEAD_BLOCK=16, num_warps=4, num_stages=1 — the
+# only config that both fits 99 KB smem and maximizes throughput in the local
+# sweep; num_stages>=2 overflows smem (~109 KB), BLOCK_N>=64 overflows, and
+# HEAD_BLOCK=32 wastes lanes at H=24. See NOTES.md "Throughput tuning" section.
+#
+# Numerics are kept identical (within bf16 reduction-order tol) to the
+# materialized path, verified against the fp64 reference (max err 1.5e-4 at the
+# cluster shape, <=1.3e-3 across the suite, all << 2e-2 bf16 tol):
+#   * the dequant math is copied verbatim from ``_gather_dequant_fp8ds_kernel``
+#     (fp8 NoPE * per-128 fp32 scale; bf16 RoPE; -1/out-of-range -> zero row);
+#   * the online-softmax recurrence is the same as ``_materialized_attn_kernel``,
+#     just applied to a BLOCK_N tile at a time (a flash-style block reduction,
+#     algebraically equivalent to the one-at-a-time recurrence);
+#   * invalid (sentinel / OOB) candidates contribute a -inf score (zero weight),
+#     exactly as the materialized path skips them via the ``valid`` mask.
+# The int64 offset-promotion fix is preserved (slot*stride is computed in int64).
+@triton.jit
+def _fused_gather_dequant_attn_kernel(
+    q_ptr,                # bf16 [T, H, D]
+    cache_ptr,            # uint8 [total_slots, 656] (flattened paged cache)
+    indices_ptr,          # int32 [T, K] global slot ids, -1 / >= total invalid
+    lens_ptr,             # int32 [T] per-token valid-candidate count
+    max_score_ptr,        # f32  [T, H] (pre-filled -inf)
+    denom_ptr,            # f32  [T, H] (pre-zeroed)
+    acc_ptr,              # f32  [T, H, D] (pre-zeroed; only [:, :, :512] written)
+    stride_q_t,
+    stride_q_h: tl.constexpr,
+    stride_q_d: tl.constexpr,
+    stride_cache_s,
+    stride_idx_t,
+    stride_idx_k: tl.constexpr,
+    stride_state_t,
+    stride_state_h: tl.constexpr,
+    stride_acc_t,
+    stride_acc_h: tl.constexpr,
+    stride_acc_d: tl.constexpr,
+    total_slots,
+    num_heads: tl.constexpr,
+    nope_dim: tl.constexpr,        # 512 (pow2 -> BLOCK_NOPE)
+    rope_dim: tl.constexpr,        # 64  (pow2 -> BLOCK_ROPE)
+    quant_tile: tl.constexpr,      # 128
+    scale_byte_off: tl.constexpr,  # 512
+    rope_byte_off: tl.constexpr,   # 528
+    num_candidates,
+    scale: tl.constexpr,
+    HEAD_BLOCK: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_NOPE: tl.constexpr,      # 512
+    BLOCK_ROPE: tl.constexpr,      # 64
+):
+    # int64 token id: matches the materialized kernels' offset-promotion fix.
+    # (q/acc here are [T,H,D] so per-token offsets are small, but keep 64-bit
+    # for parity and safety; the slot*stride below is the genuinely large one.)
+    token_idx = tl.program_id(0).to(tl.int64)
+    head_block_idx = tl.program_id(1)
+    head_offsets = head_block_idx * HEAD_BLOCK + tl.arange(0, HEAD_BLOCK)
+    head_mask = head_offsets < num_heads
+    nope_off = tl.arange(0, BLOCK_NOPE)            # 0..511
+    rope_off = tl.arange(0, BLOCK_ROPE)            # 0..63
+    nope_dmask = nope_off < nope_dim
+    rope_dmask = rope_off < rope_dim
+    scale_tile = nope_off // quant_tile            # per-128 scale index (0..3)
+
+    # q split into NoPE [HEAD_BLOCK, 512] and RoPE [HEAD_BLOCK, 64] bf16 (tensor-
+    # core dot operands), loaded once. Masked dims load as 0 (contribute nothing,
+    # matching the materialized path which zero-pads q beyond head_dim).
+    q_nope = tl.load(
+        q_ptr + token_idx * stride_q_t
+        + head_offsets[:, None] * stride_q_h + nope_off[None, :] * stride_q_d,
+        mask=head_mask[:, None] & nope_dmask[None, :], other=0.0,
+    ).to(tl.bfloat16)
+    q_rope = tl.load(
+        q_ptr + token_idx * stride_q_t
+        + head_offsets[:, None] * stride_q_h + (nope_dim + rope_off[None, :]) * stride_q_d,
+        mask=head_mask[:, None] & rope_dmask[None, :], other=0.0,
+    ).to(tl.bfloat16)
+
+    running_max = tl.full((HEAD_BLOCK,), -float("inf"), tl.float32)
+    running_denom = tl.zeros((HEAD_BLOCK,), tl.float32)
+    running_acc = tl.zeros((HEAD_BLOCK, BLOCK_NOPE), tl.float32)  # value = NoPE only
+
+    # Per-token valid candidate count (matches the materialized path's
+    # ``valid = valid & (col < lens)`` cap): only iterate tiles that can hold a
+    # valid candidate. Per-cell sentinel/OOB masking still applied below.
+    valid_len = tl.load(lens_ptr + token_idx)
+
+    cand_base = tl.arange(0, BLOCK_N)
+    for n0 in range(0, num_candidates, BLOCK_N):
+        cand = n0 + cand_base                       # [BLOCK_N] candidate cols
+        cand_in_range = cand < num_candidates
+        slot = tl.load(
+            indices_ptr + token_idx * stride_idx_t + cand * stride_idx_k,
+            mask=cand_in_range,
+            other=-1,
+        )
+        # Native semantics: invalid when slot<0 OR slot>=total_slots OR the
+        # candidate is past the per-token valid length (topk_length cap).
+        cand_valid = (slot >= 0) & (slot < total_slots) & (cand < valid_len)
+
+        # int64 row offset (the overflow-prone term). base: [BLOCK_N, 1] ptrs.
+        base = cache_ptr + slot.to(tl.int64)[:, None] * stride_cache_s
+
+        # ---- NoPE [BLOCK_N, 512]: fp8_e4m3 bytes [0:512] * per-128 fp32 scale ----
+        nmask = cand_valid[:, None] & nope_dmask[None, :]
+        fp8_bytes = tl.load(base + nope_off[None, :], mask=nmask, other=0)
+        fp8_vals = fp8_bytes.to(tl.float8e4nv, bitcast=True).to(tl.float32)
+        scale_byte = scale_byte_off + scale_tile[None, :] * 4
+        b0 = tl.load(base + scale_byte + 0, mask=nmask, other=0).to(tl.int32)
+        b1 = tl.load(base + scale_byte + 1, mask=nmask, other=0).to(tl.int32)
+        b2 = tl.load(base + scale_byte + 2, mask=nmask, other=0).to(tl.int32)
+        b3 = tl.load(base + scale_byte + 3, mask=nmask, other=0).to(tl.int32)
+        scale_bits = (
+            (b0 & 0xFF)
+            | ((b1 & 0xFF) << 8)
+            | ((b2 & 0xFF) << 16)
+            | ((b3 & 0xFF) << 24)
+        )
+        scale_f32 = scale_bits.to(tl.float32, bitcast=True)
+        kv_nope = tl.where(nmask, fp8_vals * scale_f32, 0.0).to(tl.bfloat16)  # [BLOCK_N, 512]
+
+        # ---- RoPE [BLOCK_N, 64]: bf16 values at byte offset 528 ----
+        rmask = cand_valid[:, None] & rope_dmask[None, :]
+        rope_ptr = (base + rope_byte_off).to(tl.pointer_type(tl.bfloat16))
+        kv_rope = tl.load(rope_ptr + rope_off[None, :], mask=rmask, other=0.0)
+        kv_rope = tl.where(rmask, kv_rope, 0.0).to(tl.bfloat16)               # [BLOCK_N, 64]
+
+        # ---- scores: q_nope.kv_nopeᵀ + q_rope.kv_ropeᵀ over 512+64=576 ----
+        # bf16xbf16 -> fp32 accumulate (matches the materialized path which
+        # scored q.float() * kv.float(): the kv values are bf16 either way, so
+        # the two bf16 dots reproduce the same 576-d inner product up to fp32
+        # accumulation).
+        scores = (
+            tl.dot(q_nope, tl.trans(kv_nope))
+            + tl.dot(q_rope, tl.trans(kv_rope))
+        ).to(tl.float32) * scale                        # [HEAD_BLOCK, BLOCK_N]
+        # Invalid candidates -> -inf so they get zero softmax weight (and a zero
+        # kv row, so they also contribute nothing to the value accumulation).
+        scores = tl.where(cand_valid[None, :], scores, -float("inf"))
+
+        # ---- flash-style online-softmax block update over BLOCK_N ----
+        tile_max = tl.max(scores, axis=1)               # [HEAD_BLOCK]
+        next_max = tl.maximum(running_max, tile_max)
+        # If a head has seen no valid candidate yet, next_max may be -inf; guard
+        # exp(-inf - -inf)=exp(nan). When next_max is -inf the whole tile is
+        # empty for this head, so previous_weight and p are forced to 0.
+        safe_next = tl.where(next_max == -float("inf"), 0.0, next_max)
+        previous_weight = tl.exp(running_max - safe_next)
+        previous_weight = tl.where(running_max == -float("inf"), 0.0, previous_weight)
+        p = tl.exp(scores - safe_next[:, None])         # [HEAD_BLOCK, BLOCK_N]
+        p = tl.where(cand_valid[None, :], p, 0.0)
+        tile_denom = tl.sum(p, axis=1)                  # [HEAD_BLOCK]
+        # value accumulation over the NoPE block only (512); RoPE is not a value
+        # dim, so the PV dot is 512-wide (was 1024-wide in the single-tile path).
+        running_acc = running_acc * previous_weight[:, None] + tl.dot(
+            p.to(tl.bfloat16), kv_nope
+        ).to(tl.float32)
+        running_denom = running_denom * previous_weight + tile_denom
+        running_max = next_max
+
+    state_base = token_idx * stride_state_t
+    tl.store(
+        max_score_ptr + state_base + head_offsets * stride_state_h,
+        running_max,
+        mask=head_mask,
+    )
+    tl.store(
+        denom_ptr + state_base + head_offsets * stride_state_h,
+        running_denom,
+        mask=head_mask,
+    )
+    # store the value accumulator into the first 512 (NoPE) cols of the
+    # [T, H, D=576] acc tensor; cols 512:576 stay zero (pre-zeroed) and are
+    # discarded by the d_v=512 slice in the host wrapper, exactly as before.
+    tl.store(
+        acc_ptr
+        + token_idx * stride_acc_t
+        + head_offsets[:, None] * stride_acc_h
+        + nope_off[None, :] * stride_acc_d,
+        running_acc,
+        mask=head_mask[:, None] & nope_dmask[None, :],
+    )
+
+
+# --- Pinned launch config for the fused kernel (local 5090 sm_120 sweep, valid
+# on GB10 sm_121: identical 99 KB opt-in shared mem). This is a STATIC pin, NOT a
+# runtime autotuner -- only this one (BLOCK_N, HEAD_BLOCK, num_warps, num_stages)
+# is ever compiled, so the cluster warmup compiles exactly one kernel for the
+# warmup shape (no autotune config explosion / re-benchmark stall on startup).
+# BLOCK_N=32 is the largest candidate tile that fits 99 KB smem in the NoPE/RoPE
+# split layout (BLOCK_N>=64 or num_stages>=2 overflow ~109 KB+). Override only for
+# experiments via the kwargs below; production always uses the defaults.
+_FUSED_BLOCK_N = 32
+_FUSED_HEAD_BLOCK = 16
+_FUSED_NUM_WARPS = 4
+_FUSED_NUM_STAGES = 1
+
+
+def _fused_gather_dequant_attend(
+    q: torch.Tensor,         # [T, H, D] bf16
+    cache_flat: torch.Tensor,  # [total_slots, 656] uint8
+    indices: torch.Tensor,   # [T, K] int32 global slot ids
+    lens: torch.Tensor,      # [T] int32 per-token valid candidate count
+    scale: float,
+    max_score: torch.Tensor,  # [T, H] f32 (pre-filled -inf)
+    denom: torch.Tensor,      # [T, H] f32 (pre-zeroed)
+    acc: torch.Tensor,        # [T, H, D] f32 (pre-zeroed)
+    *,
+    block_n: int = _FUSED_BLOCK_N,
+    head_block: int | None = None,
+    num_warps: int = _FUSED_NUM_WARPS,
+    num_stages: int = _FUSED_NUM_STAGES,
+) -> None:
+    """Fused gather+dequant+online-softmax over the fp8_ds_mla paged cache.
+
+    Equivalent (within bf16 tol) to ``_gather_dequant_fp8ds`` followed by
+    ``_materialized_indexed_accumulate``, but never materializes the
+    ``[T, K, 576]`` KV tensor. Uses the NoPE/RoPE D-split layout (no 1024-pad
+    waste) with the pinned BLOCK_N=32 config; ~3.4-3.6x over the BLOCK_N=16
+    single-tile path at the cluster prefill shape.
+    """
+    T, H, D = q.shape
+    K = indices.shape[1]
+    total_slots = cache_flat.shape[0]
+    assert cache_flat.dtype == torch.uint8
+    assert cache_flat.shape[1] == _FP8DS_ENTRY_BYTES
+    assert D == _DQK, f"fused path expects head_dim {_DQK}, got {D}"
+    assert max_score.shape == (T, H) and denom.shape == (T, H)
+    assert acc.shape[:2] == (T, H)
+    assert acc.shape[2] >= _DV
+    if head_block is None:
+        # tl.dot needs the M dim >= 16; pad small head counts up to 16.
+        head_block = _FUSED_HEAD_BLOCK if H >= 16 else next_power_of_2(max(H, 1))
+        head_block = max(head_block, 16)
+    grid = (T, triton.cdiv(H, head_block))
+    _fused_gather_dequant_attn_kernel[grid](
+        q,
+        cache_flat,
+        indices,
+        lens,
+        max_score,
+        denom,
+        acc,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        cache_flat.stride(0),
+        indices.stride(0),
+        indices.stride(1),
+        max_score.stride(0),
+        max_score.stride(1),
+        acc.stride(0),
+        acc.stride(1),
+        acc.stride(2),
+        total_slots,
+        H,
+        _FP8DS_NOPE_DIM,                          # nope_dim = 512
+        _FP8DS_ROPE_DIM,                          # rope_dim = 64
+        _FP8DS_QUANT_TILE,
+        _FP8DS_NOPE_DIM,                          # scale_byte_off = 512
+        _FP8DS_NOPE_DIM + 4 * _FP8DS_NUM_SCALES,  # rope_byte_off = 528
+        K,
+        float(scale),
+        HEAD_BLOCK=head_block,
+        BLOCK_N=block_n,
+        BLOCK_NOPE=_FP8DS_NOPE_DIM,               # 512 (pow2)
+        BLOCK_ROPE=_FP8DS_ROPE_DIM,               # 64 (pow2)
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+
+
+# Default to the fused path; set VLLM_SPARSE_MLA_FUSED=0 to fall back to the
+# original materialized (gather-then-attend) path for debug/A-B comparison.
+def _fused_enabled() -> bool:
+    return os.getenv("VLLM_SPARSE_MLA_FUSED", "1") != "0"
+
+
+# ---------------------------------------------------------------------------
+# FP8 sparse decode : flash_mla_with_kvcache
+# ---------------------------------------------------------------------------
+def flash_mla_with_kvcache_triton(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    block_table: torch.Tensor | None,
+    cache_seqlens: torch.Tensor | None = None,
+    head_dim_v: int = 512,
+    tile_scheduler_metadata=None,
+    num_splits=None,
+    softmax_scale: float | None = None,
+    causal: bool = False,
+    is_fp8_kvcache: bool = False,
+    indices: torch.Tensor | None = None,
+    attn_sink: torch.Tensor | None = None,
+    extra_k_cache: torch.Tensor | None = None,
+    extra_indices_in_kvcache: torch.Tensor | None = None,
+    topk_length: torch.Tensor | None = None,
+    extra_topk_length: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Triton FP8 sparse-MLA decode, drop-in for ``flash_mla_with_kvcache``.
+
+    Only the *sparse fp8* path used by the V3.2 backend is implemented:
+      q       : [b, s_q, h_q, 576] bf16
+      k_cache : [num_blocks, block_size, 1, 656] uint8  (fp8_ds_mla)
+                (the V3.2 backend passes ``cache.view(uint8).unsqueeze(-2)``)
+      indices : [b, s_q, topk] int32  GLOBAL slot ids, -1 / >= total invalid
+      head_dim_v == 512, is_fp8_kvcache == True
+    Returns (out [b, s_q, h_q, 512] bf16, lse [b, h_q, s_q] f32).
+
+    extra_k_cache / extra_indices / *_topk_length are the DeepSeek-V4 SWA
+    arguments; the V3.2 backend never sets them and they are asserted None.
+    """
+    assert indices is not None, "Triton flash_mla_with_kvcache only supports sparse mode"
+    assert is_fp8_kvcache, "Triton decode path requires is_fp8_kvcache=True (fp8_ds_mla)"
+    assert head_dim_v == _DV, f"head_dim_v must be {_DV}, got {head_dim_v}"
+    assert extra_k_cache is None and extra_indices_in_kvcache is None, (
+        "V3.2 sparse decode does not use extra_k_cache / extra_indices "
+        "(those are DeepSeek-V4 SWA-only arguments)"
+    )
+    assert extra_topk_length is None
+    assert not causal, "sparse attention requires causal=False"
+
+    # q: [b, s_q, h_q, d_qk] -> flatten batch*seq to T tokens.
+    assert q.dim() == 4, f"expected q [b, s_q, h_q, d_qk], got {q.shape}"
+    b, s_q, h_q, d_qk = q.shape
+    assert d_qk == _DQK, f"expected d_qk == {_DQK}, got {d_qk}"
+    q_flat = q.reshape(b * s_q, h_q, d_qk)
+
+    # indices: [b, s_q, topk] -> [T, topk]
+    assert indices.dim() == 3, f"expected indices [b, s_q, topk], got {indices.shape}"
+    assert indices.shape[0] == b and indices.shape[1] == s_q
+    topk = indices.shape[2]
+    idx2d = indices.reshape(b * s_q, topk).contiguous()
+    T = b * s_q
+
+    if softmax_scale is None:
+        softmax_scale = d_qk ** (-0.5)
+
+    # k_cache may arrive as [num_blocks, block_size, 1, 656] (uint8) per the
+    # V3.2 call site (``.view(uint8).unsqueeze(-2)``). Flatten to
+    # [total_slots, 656]; global indices index into this flattened slot space
+    # exactly as triton_convert_req_index_to_global_index produced them
+    # (block_id * block_size + offset).
+    kc = k_cache
+    assert kc.dtype == torch.uint8, "fp8_ds_mla decode cache must be uint8"
+    cache_flat = kc.reshape(-1, _FP8DS_ENTRY_BYTES)
+
+    device = q.device
+    # Per-token valid candidate count: topk_length when given (native cap),
+    # else the full topk width (per-cell -1 / out-of-range masking still applies
+    # in the kernels). Used by both the fused and the materialized paths.
+    if topk_length is not None:
+        lens = topk_length.reshape(-1).to(device=device, dtype=torch.int32).contiguous()
+        assert lens.shape[0] == T
+    else:
+        lens = torch.full((T,), topk, dtype=torch.int32, device=device)
+
+    fused_enabled = _fused_enabled()
+    profile = _CudaProfileRegion(
+        "attention.fp8_sparse_decode_or_mixed",
+        q_shape=tuple(q.shape),
+        k_cache_shape=tuple(k_cache.shape),
+        topk=topk,
+        fused=fused_enabled,
+        topk_length="set" if topk_length is not None else "none",
+    )
+    profile.start()
+
+    # State for online softmax over the gathered candidates (fp32).
+    max_score = torch.full((T, h_q), float("-inf"), dtype=torch.float32, device=device)
+    denom = torch.zeros((T, h_q), dtype=torch.float32, device=device)
+
+    if fused_enabled:
+        # FUSED path (default): gather+dequant+attend in-tile, no [T,K,576]
+        # materialization. Only the 512 NoPE value dims are accumulated, which
+        # avoids a 576-wide fp32 state tensor and a post-kernel contiguous copy.
+        acc_v = torch.zeros((T, h_q, _DV), dtype=torch.float32, device=device)
+        _fused_gather_dequant_attend(
+            q_flat,
+            cache_flat,
+            idx2d,
+            lens,
+            float(softmax_scale),
+            max_score,
+            denom,
+            acc_v,
+        )
+    else:
+        # Legacy materialized path (VLLM_SPARSE_MLA_FUSED=0): gather the dense
+        # [T, topk, 576] bf16 tensor then attend over it. Kept for debug / A-B.
+        acc = torch.zeros((T, h_q, d_qk), dtype=torch.float32, device=device)
+        kv_gathered, valid = _gather_dequant_fp8ds(cache_flat, idx2d)
+        if topk_length is not None:
+            col = torch.arange(topk, device=device, dtype=torch.int32)
+            valid = valid & (col[None, :] < lens[:, None])
+        _materialized_indexed_accumulate(
+            q_flat, kv_gathered, valid, float(softmax_scale), max_score, denom, acc
+        )
+        acc_v = acc[:, :, :_DV].contiguous()
+
+    # lse for return value (native returns lse [b, h_q, s_q]).
+    safe_max = torch.where(denom > 0, max_score, torch.zeros_like(max_score))
+    lse = torch.where(
+        denom > 0,
+        torch.log(denom.clamp_min(1e-30)) + safe_max,
+        torch.full_like(max_score, float("-inf")),
+    )
+
+    if attn_sink is None:
+        sink = torch.full((h_q,), float("-inf"), dtype=torch.float32, device=device)
+    else:
+        sink = attn_sink.to(device=device, dtype=torch.float32).contiguous()
+        assert sink.shape[0] >= h_q
+
+    if out is None:
+        out = torch.empty((b, s_q, h_q, _DV), dtype=q.dtype, device=device)
+    out_flat = out.reshape(T, h_q, _DV)
+
+    finish_sparse_mla_attention_with_sink(
+        max_score, denom, acc_v, sink, output=out_flat
+    )
+
+    # lse return shape: [b, h_q, s_q]
+    lse_out = lse.reshape(b, s_q, h_q).permute(0, 2, 1).contiguous()
+    profile.stop()
+    return out, lse_out
+
+
+@triton.jit
+def _materialized_attn_kernel(
+    q_ptr,           # bf16 [T, H, D]
+    kv_ptr,          # bf16 [T, K, D] (per-query gathered)
+    valid_ptr,       # bool [T, K]
+    max_score_ptr,   # f32  [T, H]
+    denom_ptr,       # f32  [T, H]
+    acc_ptr,         # f32  [T, H, D]
+    stride_q_t: tl.constexpr,
+    stride_q_h: tl.constexpr,
+    stride_q_d: tl.constexpr,
+    stride_kv_t: tl.constexpr,
+    stride_kv_k: tl.constexpr,
+    stride_kv_d: tl.constexpr,
+    stride_valid_t: tl.constexpr,
+    stride_valid_k: tl.constexpr,
+    stride_state_t: tl.constexpr,
+    stride_state_h: tl.constexpr,
+    stride_acc_t: tl.constexpr,
+    stride_acc_h: tl.constexpr,
+    stride_acc_d: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    num_candidates,
+    scale: tl.constexpr,
+    HEAD_BLOCK: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    # int64 token id: the per-query gathered ``kv`` tensor is [T, K, D] and its
+    # per-token stride (K*D) times ``token_idx`` overflows int32 for the
+    # cluster's mixed-batch prefill (T=K=2048) exactly as in the gather kernel.
+    # Promote so every ``token_idx*stride`` offset (q/kv/state/acc) is int64.
+    token_idx = tl.program_id(0).to(tl.int64)
+    head_block_idx = tl.program_id(1)
+    head_offsets = head_block_idx * HEAD_BLOCK + tl.arange(0, HEAD_BLOCK)
+    dim_offsets = tl.arange(0, BLOCK_D)
+    head_mask = head_offsets < num_heads
+    dim_mask = dim_offsets < head_dim
+
+    q = tl.load(
+        q_ptr
+        + token_idx * stride_q_t
+        + head_offsets[:, None] * stride_q_h
+        + dim_offsets[None, :] * stride_q_d,
+        mask=head_mask[:, None] & dim_mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+
+    running_max = tl.full((HEAD_BLOCK,), -float("inf"), tl.float32)
+    running_denom = tl.zeros((HEAD_BLOCK,), tl.float32)
+    running_acc = tl.zeros((HEAD_BLOCK, BLOCK_D), tl.float32)
+
+    for candidate_idx in range(0, num_candidates):
+        is_valid = tl.load(
+            valid_ptr + token_idx * stride_valid_t + candidate_idx * stride_valid_k
+        )
+        if is_valid:
+            kv = tl.load(
+                kv_ptr
+                + token_idx * stride_kv_t
+                + candidate_idx * stride_kv_k
+                + dim_offsets * stride_kv_d,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            scores = tl.sum(q * kv[None, :], axis=1) * scale
+            next_max = tl.maximum(running_max, scores)
+            previous_weight = tl.exp(running_max - next_max)
+            candidate_weight = tl.exp(scores - next_max)
+            running_acc = (
+                running_acc * previous_weight[:, None]
+                + kv[None, :] * candidate_weight[:, None]
+            )
+            running_denom = running_denom * previous_weight + candidate_weight
+            running_max = next_max
+
+    state_base = token_idx * stride_state_t
+    tl.store(
+        max_score_ptr + state_base + head_offsets * stride_state_h,
+        running_max,
+        mask=head_mask,
+    )
+    tl.store(
+        denom_ptr + state_base + head_offsets * stride_state_h,
+        running_denom,
+        mask=head_mask,
+    )
+    tl.store(
+        acc_ptr
+        + token_idx * stride_acc_t
+        + head_offsets[:, None] * stride_acc_h
+        + dim_offsets[None, :] * stride_acc_d,
+        running_acc,
+        mask=head_mask[:, None] & dim_mask[None, :],
+    )
+
+
+def _materialized_indexed_accumulate(
+    q: torch.Tensor,         # [T, H, D]
+    kv: torch.Tensor,        # [T, K, D]  per-query gathered + dequantized
+    valid: torch.Tensor,     # [T, K] bool
+    scale: float,
+    max_score: torch.Tensor,  # [T, H] f32 (pre-filled -inf)
+    denom: torch.Tensor,      # [T, H] f32 (pre-zeroed)
+    acc: torch.Tensor,        # [T, H, D] f32 (pre-zeroed)
+) -> None:
+    """Online-softmax accumulation over per-query materialized KV.
+
+    Equivalent semantics to ``accumulate_indexed_sparse_mla_attention_chunk``
+    but reads a *per-query* dequantized KV tensor (the decode case where each
+    query attends to its own gathered candidate set) rather than a shared
+    ``kv_flat`` indexed by global ids.
+    """
+    T, H, D = q.shape
+    K = kv.shape[1]
+    head_block = 8 if H >= 8 else 1
+    block_d = min(1024, next_power_of_2(D))
+    grid = (T, triton.cdiv(H, head_block))
+    _materialized_attn_kernel[grid](
+        q,
+        kv,
+        valid,
+        max_score,
+        denom,
+        acc,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        kv.stride(0),
+        kv.stride(1),
+        kv.stride(2),
+        valid.stride(0),
+        valid.stride(1),
+        max_score.stride(0),
+        max_score.stride(1),
+        acc.stride(0),
+        acc.stride(1),
+        acc.stride(2),
+        H,
+        D,
+        K,
+        scale,
+        HEAD_BLOCK=head_block,
+        BLOCK_D=block_d,
+        num_warps=4,
+    )

--- a/vllm/v1/attention/backends/mla/sparse_mla_env.py
+++ b/vllm/v1/attention/backends/mla/sparse_mla_env.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Environment controls for the portable Triton sparse MLA path."""
+
+import os
+
+import torch
+
+import vllm.envs as envs
+from vllm.platforms import current_platform
+
+
+def _is_sm12x_device(device: torch.device) -> bool:
+    if not current_platform.is_cuda():
+        return False
+    index = (
+        device.index
+        if device.index is not None
+        else torch.accelerator.current_device_index()
+    )
+    capability = current_platform.get_device_capability(device_id=index)
+    return capability is not None and capability[0] == 12
+
+
+def triton_sparse_mla_configured() -> bool | None:
+    return envs.VLLM_TRITON_MLA_SPARSE
+
+
+def is_triton_sparse_mla_enabled_for_platform() -> bool:
+    configured = triton_sparse_mla_configured()
+    if configured is not None:
+        return configured
+    return current_platform.is_device_capability_family(120)
+
+
+def is_triton_sparse_mla_enabled(device: torch.device) -> bool:
+    configured = triton_sparse_mla_configured()
+    if configured is not None:
+        return configured
+    return _is_sm12x_device(device)
+
+
+def triton_sparse_mla_topk_chunk_size() -> int:
+    return envs.VLLM_TRITON_MLA_SPARSE_TOPK_CHUNK_SIZE
+
+
+def triton_sparse_mla_prefill_topk_chunk_size(
+    *,
+    combined_topk_size: int,
+    compress_ratio: int,
+    request_count: int,
+) -> int:
+    """Choose the Triton sparse MLA prefill topk chunk size.
+
+    Keep explicit user overrides authoritative. The auto path uses a larger
+    chunk for SM12x C128A single-request prefill to reduce per-request loop
+    overhead, but keeps a smaller chunk for the multi-request shape that is
+    unstable near 128K context.
+    """
+
+    configured_topk = triton_sparse_mla_topk_chunk_size()
+    if os.getenv("VLLM_TRITON_MLA_SPARSE_TOPK_CHUNK_SIZE") is not None:
+        return min(combined_topk_size, configured_topk)
+    if current_platform.is_device_capability_family(120) and compress_ratio == 128:
+        if request_count > 1 and combined_topk_size > 1024:
+            configured_topk = min(configured_topk, 256)
+        elif request_count == 1 and combined_topk_size > 1024:
+            configured_topk = max(configured_topk, 1024)
+    return min(combined_topk_size, configured_topk)
+
+
+def triton_sparse_mla_query_chunk_size() -> int:
+    return envs.VLLM_TRITON_MLA_SPARSE_QUERY_CHUNK_SIZE
+
+
+def triton_sparse_mla_head_block_size() -> int | None:
+    value = envs.VLLM_TRITON_MLA_SPARSE_HEAD_BLOCK_SIZE
+    if value in (1, 2, 4):
+        return value
+    return None
+
+
+def triton_sparse_mla_matmul_decode_enabled() -> bool:
+    configured = envs.VLLM_TRITON_MLA_SPARSE_MATMUL_DECODE
+    if configured is not None:
+        return configured
+    return current_platform.is_device_capability_family(120)

--- a/vllm/v1/attention/backends/mla/sparse_mla_kernels.py
+++ b/vllm/v1/attention/backends/mla/sparse_mla_kernels.py
@@ -1,0 +1,3567 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Portable sparse MLA Triton kernels."""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import next_power_of_2
+from vllm.v1.attention.backends.mla.sparse_mla_env import (
+    triton_sparse_mla_head_block_size,
+)
+
+
+def sparse_mla_decode_head_block_size(num_decode_tokens: int) -> int:
+    """Choose the SM12x sparse MLA head grouping for decode kernels.
+
+    Single-token decode is latency sensitive and does best with one head per
+    program. Once there are enough query tokens, grouping heads lets the kernel
+    reuse each dequantized KV row across multiple heads.
+    """
+
+    configured_head_block_size = triton_sparse_mla_head_block_size()
+    if configured_head_block_size is not None:
+        return configured_head_block_size
+    if num_decode_tokens <= 4:
+        return 1
+    if num_decode_tokens < 16:
+        return 2
+    return 4
+
+
+@triton.jit
+def _merge_two_subsets_with_sink_kernel(
+    out0_ptr,
+    lse0_ptr,
+    out1_ptr,
+    lse1_ptr,
+    sink_ptr,
+    output_ptr,
+    stride_out0_t: tl.constexpr,
+    stride_out0_h: tl.constexpr,
+    stride_out0_d: tl.constexpr,
+    stride_lse0_t: tl.constexpr,
+    stride_lse0_h: tl.constexpr,
+    stride_out1_t: tl.constexpr,
+    stride_out1_h: tl.constexpr,
+    stride_out1_d: tl.constexpr,
+    stride_lse1_t: tl.constexpr,
+    stride_lse1_h: tl.constexpr,
+    stride_output_t: tl.constexpr,
+    stride_output_h: tl.constexpr,
+    stride_output_d: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_head = tl.program_id(0)
+    block_d = tl.program_id(1)
+    token_idx = token_head // num_heads
+    head_idx = token_head - token_idx * num_heads
+    offsets = block_d * BLOCK_D + tl.arange(0, BLOCK_D)
+    mask = offsets < head_dim
+
+    lse0 = tl.load(lse0_ptr + token_idx * stride_lse0_t + head_idx * stride_lse0_h)
+    lse1 = tl.load(lse1_ptr + token_idx * stride_lse1_t + head_idx * stride_lse1_h)
+    sink = tl.load(sink_ptr + head_idx)
+    merge_max = tl.maximum(tl.maximum(lse0, lse1), sink)
+
+    weight0 = tl.exp(lse0 - merge_max)
+    weight1 = tl.exp(lse1 - merge_max)
+    weight_sink = tl.exp(sink - merge_max)
+    denom = weight0 + weight1 + weight_sink
+
+    out0 = tl.load(
+        out0_ptr
+        + token_idx * stride_out0_t
+        + head_idx * stride_out0_h
+        + offsets * stride_out0_d,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    out1 = tl.load(
+        out1_ptr
+        + token_idx * stride_out1_t
+        + head_idx * stride_out1_h
+        + offsets * stride_out1_d,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    merged = (out0 * weight0 + out1 * weight1) / denom
+    tl.store(
+        output_ptr
+        + token_idx * stride_output_t
+        + head_idx * stride_output_h
+        + offsets * stride_output_d,
+        merged,
+        mask=mask,
+    )
+
+
+def merge_two_sparse_mla_subsets_with_sink(
+    subset0_output: torch.Tensor,
+    subset0_lse: torch.Tensor,
+    subset1_output: torch.Tensor,
+    subset1_lse: torch.Tensor,
+    attn_sink: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    assert subset0_output.shape == subset1_output.shape
+    assert subset0_output.shape == output.shape
+    assert subset0_lse.shape == subset1_lse.shape
+    assert subset0_lse.shape == subset0_output.shape[:2]
+    assert attn_sink.shape[0] == subset0_output.shape[1]
+    assert subset0_output.is_cuda
+    assert subset1_output.is_cuda
+    assert output.is_cuda
+
+    num_tokens, num_heads, head_dim = subset0_output.shape
+    block_d = min(128, next_power_of_2(head_dim))
+    grid = (num_tokens * num_heads, triton.cdiv(head_dim, block_d))
+    _merge_two_subsets_with_sink_kernel[grid](
+        subset0_output,
+        subset0_lse,
+        subset1_output,
+        subset1_lse,
+        attn_sink,
+        output,
+        subset0_output.stride(0),
+        subset0_output.stride(1),
+        subset0_output.stride(2),
+        subset0_lse.stride(0),
+        subset0_lse.stride(1),
+        subset1_output.stride(0),
+        subset1_output.stride(1),
+        subset1_output.stride(2),
+        subset1_lse.stride(0),
+        subset1_lse.stride(1),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        num_heads,
+        head_dim,
+        BLOCK_D=block_d,
+        num_warps=4,
+    )
+
+
+@triton.jit
+def _merge_single_subset_with_sink_kernel(
+    subset_output_ptr,
+    subset_lse_ptr,
+    sink_ptr,
+    output_ptr,
+    stride_subset_t: tl.constexpr,
+    stride_subset_h: tl.constexpr,
+    stride_subset_d: tl.constexpr,
+    stride_lse_t: tl.constexpr,
+    stride_lse_h: tl.constexpr,
+    stride_output_t: tl.constexpr,
+    stride_output_h: tl.constexpr,
+    stride_output_d: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_head = tl.program_id(0)
+    block_d = tl.program_id(1)
+    token_idx = token_head // num_heads
+    head_idx = token_head - token_idx * num_heads
+    offsets = block_d * BLOCK_D + tl.arange(0, BLOCK_D)
+    mask = offsets < head_dim
+
+    subset_lse = tl.load(
+        subset_lse_ptr + token_idx * stride_lse_t + head_idx * stride_lse_h
+    )
+    sink = tl.load(sink_ptr + head_idx)
+    merge_max = tl.maximum(subset_lse, sink)
+
+    subset_weight = tl.exp(subset_lse - merge_max)
+    sink_weight = tl.exp(sink - merge_max)
+    denom = subset_weight + sink_weight
+    subset_output = tl.load(
+        subset_output_ptr
+        + token_idx * stride_subset_t
+        + head_idx * stride_subset_h
+        + offsets * stride_subset_d,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    merged = subset_output * subset_weight / denom
+    tl.store(
+        output_ptr
+        + token_idx * stride_output_t
+        + head_idx * stride_output_h
+        + offsets * stride_output_d,
+        merged,
+        mask=mask,
+    )
+
+
+def merge_sparse_mla_subset_with_sink(
+    subset_output: torch.Tensor,
+    subset_lse: torch.Tensor,
+    attn_sink: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    assert subset_output.shape == output.shape
+    assert subset_lse.shape == subset_output.shape[:2]
+    assert attn_sink.shape[0] == subset_output.shape[1]
+    assert subset_output.is_cuda
+    assert subset_lse.is_cuda
+    assert attn_sink.is_cuda
+    assert output.is_cuda
+
+    num_tokens, num_heads, head_dim = subset_output.shape
+    block_d = min(128, next_power_of_2(head_dim))
+    grid = (num_tokens * num_heads, triton.cdiv(head_dim, block_d))
+    _merge_single_subset_with_sink_kernel[grid](
+        subset_output,
+        subset_lse,
+        attn_sink,
+        output,
+        subset_output.stride(0),
+        subset_output.stride(1),
+        subset_output.stride(2),
+        subset_lse.stride(0),
+        subset_lse.stride(1),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        num_heads,
+        head_dim,
+        BLOCK_D=block_d,
+        num_warps=4,
+    )
+
+
+@triton.jit
+def _build_combined_decode_valid_mask_kernel(
+    output_ptr,
+    slot_ids_ptr,
+    topk_lens_ptr,
+    swa_lens_ptr,
+    stride_output_t: tl.constexpr,
+    stride_output_c: tl.constexpr,
+    stride_slot_t: tl.constexpr,
+    stride_slot_c: tl.constexpr,
+    num_compressed_candidates: tl.constexpr,
+    num_candidates: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_C)
+    candidate_mask = offsets < num_candidates
+
+    topk_lens = tl.load(topk_lens_ptr + token_idx)
+    swa_lens = tl.load(swa_lens_ptr + token_idx)
+    is_compressed = offsets < num_compressed_candidates
+    swa_offsets = offsets - num_compressed_candidates
+    slot_ids = tl.load(
+        slot_ids_ptr + token_idx * stride_slot_t + offsets * stride_slot_c,
+        mask=is_compressed,
+        other=-1,
+    )
+    valid_compressed = is_compressed & (offsets < topk_lens) & (slot_ids >= 0)
+    valid_swa = (~is_compressed) & (swa_offsets < swa_lens)
+    valid = valid_compressed | valid_swa
+    tl.store(
+        output_ptr + token_idx * stride_output_t + offsets * stride_output_c,
+        valid,
+        mask=candidate_mask,
+    )
+
+
+def build_combined_sparse_mla_decode_valid_mask(
+    output: torch.Tensor,
+    compressed_slot_ids: torch.Tensor,
+    topk_lens: torch.Tensor,
+    swa_lens: torch.Tensor,
+) -> None:
+    """Build `[compressed, SWA]` validity mask for SM12x decode."""
+    if compressed_slot_ids.dim() == 3:
+        assert compressed_slot_ids.shape[1] == 1
+        compressed_slot_ids = compressed_slot_ids[:, 0, :]
+
+    assert output.dim() == 2
+    assert output.dtype == torch.bool
+    assert compressed_slot_ids.dim() == 2
+    assert output.shape[0] == compressed_slot_ids.shape[0]
+    assert output.shape[0] == topk_lens.shape[0]
+    assert output.shape[0] == swa_lens.shape[0]
+    assert output.shape[1] >= compressed_slot_ids.shape[1]
+    assert output.is_cuda
+    assert compressed_slot_ids.is_cuda
+    assert topk_lens.is_cuda
+    assert swa_lens.is_cuda
+
+    num_candidates = output.shape[1]
+    block_c = next_power_of_2(num_candidates)
+    _build_combined_decode_valid_mask_kernel[(output.shape[0],)](
+        output,
+        compressed_slot_ids,
+        topk_lens,
+        swa_lens,
+        output.stride(0),
+        output.stride(1),
+        compressed_slot_ids.stride(0),
+        compressed_slot_ids.stride(1),
+        compressed_slot_ids.shape[1],
+        num_candidates,
+        BLOCK_C=block_c,
+        num_warps=4,
+    )
+
+
+def matmul_sparse_mla_attention_with_sink(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    valid_tokens: torch.Tensor,
+    scale: float,
+    attn_sink: torch.Tensor,
+    output: torch.Tensor,
+    num_heads: int | None = None,
+    score_buffer: torch.Tensor | None = None,
+    head_block_size: int = 1,
+    value_block_size: int | None = None,
+    candidate_block_size: int | None = None,
+) -> None:
+    """Compute sink-aware sparse MLA over materialized BF16 KV.
+
+    This path intentionally dequantizes/gathers KV once, computes scores with
+    batched matrix multiplication, and finishes the sink-aware value reduction
+    in Triton. It is useful for the SM12x decode path where the direct Triton
+    kernel otherwise repeats fp8_ds_mla dequantization once per head group.
+    """
+    if q.dim() == 4:
+        assert q.shape[1] == 1
+        q = q[:, 0]
+
+    assert q.dim() == 3, f"Expected q shape [T, H, D], got {q.shape}"
+    assert kv.dim() == 3, f"Expected kv shape [T, K, D], got {kv.shape}"
+    assert valid_tokens.shape == kv.shape[:2]
+    assert q.shape[0] == kv.shape[0]
+    assert q.shape[-1] == kv.shape[-1]
+    assert output.shape[0] == q.shape[0]
+    assert output.shape[2] == q.shape[-1]
+    assert q.is_cuda and kv.is_cuda and valid_tokens.is_cuda
+    assert attn_sink.is_cuda and output.is_cuda
+
+    active_heads = num_heads if num_heads is not None else output.shape[1]
+    assert active_heads <= q.shape[1]
+    assert active_heads <= output.shape[1]
+    assert active_heads <= attn_sink.shape[0]
+
+    q_active = q[:, :active_heads]
+    num_tokens = q.shape[0]
+    num_candidates = kv.shape[1]
+    if score_buffer is None:
+        score_buffer = torch.empty(
+            (num_tokens, active_heads, num_candidates),
+            dtype=torch.float32,
+            device=q.device,
+        )
+    assert score_buffer.shape == (num_tokens, active_heads, num_candidates)
+    assert score_buffer.device == q.device
+    assert score_buffer.dtype in (torch.float32, torch.bfloat16)
+    if score_buffer.dtype == torch.float32:
+        q_score = q_active.float()
+        kv_score = kv.float()
+    else:
+        q_score = q_active.to(score_buffer.dtype)
+        kv_score = kv.to(score_buffer.dtype)
+    torch.bmm(q_score, kv_score.transpose(1, 2), out=score_buffer)
+    score_buffer.mul_(scale)
+    finish_materialized_sparse_mla_scores_with_sink(
+        score_buffer,
+        kv,
+        valid_tokens,
+        attn_sink,
+        output,
+        num_heads=active_heads,
+        head_block_size=head_block_size,
+        value_block_size=value_block_size,
+        candidate_block_size=candidate_block_size,
+    )
+
+
+@triton.jit
+def _finish_materialized_scores_with_sink_kernel(
+    scores_ptr,
+    kv_ptr,
+    valid_tokens_ptr,
+    attn_sink_ptr,
+    output_ptr,
+    stride_scores_t: tl.constexpr,
+    stride_scores_h: tl.constexpr,
+    stride_scores_c: tl.constexpr,
+    stride_kv_t: tl.constexpr,
+    stride_kv_c: tl.constexpr,
+    stride_kv_d: tl.constexpr,
+    stride_valid_t: tl.constexpr,
+    stride_valid_c: tl.constexpr,
+    stride_out_t: tl.constexpr,
+    stride_out_h: tl.constexpr,
+    stride_out_d: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    num_candidates: tl.constexpr,
+    HEAD_BLOCK: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_block_idx = tl.program_id(1)
+    head_offsets = head_block_idx * HEAD_BLOCK + tl.arange(0, HEAD_BLOCK)
+    dim_offsets = tl.arange(0, BLOCK_D)
+    head_mask = head_offsets < num_heads
+    dim_mask = dim_offsets < head_dim
+    matrix_mask = head_mask[:, None] & dim_mask[None, :]
+
+    running_max = tl.load(attn_sink_ptr + head_offsets, mask=head_mask, other=0.0).to(
+        tl.float32
+    )
+    running_denom = tl.full((HEAD_BLOCK,), 1.0, tl.float32)
+    running_acc = tl.zeros((HEAD_BLOCK, BLOCK_D), tl.float32)
+
+    for candidate_idx in range(0, num_candidates):
+        is_valid = tl.load(
+            valid_tokens_ptr
+            + token_idx * stride_valid_t
+            + candidate_idx * stride_valid_c
+        )
+        if is_valid:
+            score = tl.load(
+                scores_ptr
+                + token_idx * stride_scores_t
+                + head_offsets * stride_scores_h
+                + candidate_idx * stride_scores_c,
+                mask=head_mask,
+                other=-float("inf"),
+            ).to(tl.float32)
+            kv = tl.load(
+                kv_ptr
+                + token_idx * stride_kv_t
+                + candidate_idx * stride_kv_c
+                + dim_offsets * stride_kv_d,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            next_max = tl.maximum(running_max, score)
+            previous_weight = tl.exp(running_max - next_max)
+            candidate_weight = tl.exp(score - next_max)
+            running_acc = (
+                running_acc * previous_weight[:, None]
+                + kv[None, :] * candidate_weight[:, None]
+            )
+            running_denom = running_denom * previous_weight + candidate_weight
+            running_max = next_max
+
+    result = running_acc / running_denom[:, None]
+    tl.store(
+        output_ptr
+        + token_idx * stride_out_t
+        + head_offsets[:, None] * stride_out_h
+        + dim_offsets[None, :] * stride_out_d,
+        result,
+        mask=matrix_mask,
+    )
+
+
+@triton.jit
+def _finish_materialized_scores_with_sink_candidate_block_kernel(
+    scores_ptr,
+    kv_ptr,
+    valid_tokens_ptr,
+    attn_sink_ptr,
+    output_ptr,
+    stride_scores_t: tl.constexpr,
+    stride_scores_h: tl.constexpr,
+    stride_scores_c: tl.constexpr,
+    stride_kv_t: tl.constexpr,
+    stride_kv_c: tl.constexpr,
+    stride_kv_d: tl.constexpr,
+    stride_valid_t: tl.constexpr,
+    stride_valid_c: tl.constexpr,
+    stride_out_t: tl.constexpr,
+    stride_out_h: tl.constexpr,
+    stride_out_d: tl.constexpr,
+    head_dim: tl.constexpr,
+    num_candidates: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    dim_block_idx = tl.program_id(2)
+    candidate_offsets = tl.arange(0, BLOCK_K)
+    dim_offsets = dim_block_idx * BLOCK_D + tl.arange(0, BLOCK_D)
+    dim_mask = dim_offsets < head_dim
+
+    max_score = tl.load(attn_sink_ptr + head_idx).to(tl.float32)
+    for candidate_start in range(0, num_candidates, BLOCK_K):
+        candidates = candidate_start + candidate_offsets
+        candidate_mask = candidates < num_candidates
+        is_valid = tl.load(
+            valid_tokens_ptr + token_idx * stride_valid_t + candidates * stride_valid_c,
+            mask=candidate_mask,
+            other=0,
+        ).to(tl.int1)
+        scores = tl.load(
+            scores_ptr
+            + token_idx * stride_scores_t
+            + head_idx * stride_scores_h
+            + candidates * stride_scores_c,
+            mask=candidate_mask & is_valid,
+            other=-float("inf"),
+        ).to(tl.float32)
+        max_score = tl.maximum(max_score, tl.max(scores, axis=0))
+
+    denom = tl.exp(tl.load(attn_sink_ptr + head_idx).to(tl.float32) - max_score)
+    acc = tl.zeros((BLOCK_D,), tl.float32)
+    for candidate_start in range(0, num_candidates, BLOCK_K):
+        candidates = candidate_start + candidate_offsets
+        candidate_mask = candidates < num_candidates
+        is_valid = tl.load(
+            valid_tokens_ptr + token_idx * stride_valid_t + candidates * stride_valid_c,
+            mask=candidate_mask,
+            other=0,
+        ).to(tl.int1)
+        scores = tl.load(
+            scores_ptr
+            + token_idx * stride_scores_t
+            + head_idx * stride_scores_h
+            + candidates * stride_scores_c,
+            mask=candidate_mask & is_valid,
+            other=-float("inf"),
+        ).to(tl.float32)
+        weights = tl.exp(scores - max_score)
+        denom += tl.sum(weights, axis=0)
+        kv = tl.load(
+            kv_ptr
+            + token_idx * stride_kv_t
+            + candidates[:, None] * stride_kv_c
+            + dim_offsets[None, :] * stride_kv_d,
+            mask=(candidate_mask & is_valid)[:, None] & dim_mask[None, :],
+            other=0.0,
+        )
+        acc += tl.sum(kv.to(tl.float32) * weights[:, None], axis=0)
+
+    tl.store(
+        output_ptr
+        + token_idx * stride_out_t
+        + head_idx * stride_out_h
+        + dim_offsets * stride_out_d,
+        acc / denom,
+        mask=dim_mask,
+    )
+
+
+@triton.jit
+def _finish_materialized_scores_with_sink_value_block_kernel(
+    scores_ptr,
+    kv_ptr,
+    valid_tokens_ptr,
+    attn_sink_ptr,
+    output_ptr,
+    stride_scores_t: tl.constexpr,
+    stride_scores_h: tl.constexpr,
+    stride_scores_c: tl.constexpr,
+    stride_kv_t: tl.constexpr,
+    stride_kv_c: tl.constexpr,
+    stride_kv_d: tl.constexpr,
+    stride_valid_t: tl.constexpr,
+    stride_valid_c: tl.constexpr,
+    stride_out_t: tl.constexpr,
+    stride_out_h: tl.constexpr,
+    stride_out_d: tl.constexpr,
+    head_dim: tl.constexpr,
+    num_candidates: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    dim_block_idx = tl.program_id(2)
+    dim_offsets = dim_block_idx * BLOCK_D + tl.arange(0, BLOCK_D)
+    dim_mask = dim_offsets < head_dim
+
+    running_max = tl.load(attn_sink_ptr + head_idx).to(tl.float32)
+    running_denom = tl.full((), 1.0, tl.float32)
+    running_acc = tl.zeros((BLOCK_D,), tl.float32)
+
+    for candidate_idx in range(0, num_candidates):
+        is_valid = tl.load(
+            valid_tokens_ptr
+            + token_idx * stride_valid_t
+            + candidate_idx * stride_valid_c
+        )
+        if is_valid:
+            score = tl.load(
+                scores_ptr
+                + token_idx * stride_scores_t
+                + head_idx * stride_scores_h
+                + candidate_idx * stride_scores_c
+            ).to(tl.float32)
+            kv = tl.load(
+                kv_ptr
+                + token_idx * stride_kv_t
+                + candidate_idx * stride_kv_c
+                + dim_offsets * stride_kv_d,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            next_max = tl.maximum(running_max, score)
+            previous_weight = tl.exp(running_max - next_max)
+            candidate_weight = tl.exp(score - next_max)
+            running_acc = running_acc * previous_weight + kv * candidate_weight
+            running_denom = running_denom * previous_weight + candidate_weight
+            running_max = next_max
+
+    result = running_acc / running_denom
+    tl.store(
+        output_ptr
+        + token_idx * stride_out_t
+        + head_idx * stride_out_h
+        + dim_offsets * stride_out_d,
+        result,
+        mask=dim_mask,
+    )
+
+
+def finish_materialized_sparse_mla_scores_with_sink(
+    scores: torch.Tensor,
+    kv: torch.Tensor,
+    valid_tokens: torch.Tensor,
+    attn_sink: torch.Tensor,
+    output: torch.Tensor,
+    num_heads: int | None = None,
+    head_block_size: int = 1,
+    value_block_size: int | None = None,
+    candidate_block_size: int | None = None,
+) -> None:
+    assert scores.dim() == 3
+    assert kv.dim() == 3
+    assert valid_tokens.shape == kv.shape[:2]
+    assert scores.shape[0] == kv.shape[0]
+    assert scores.shape[2] == kv.shape[1]
+    assert output.shape[0] == kv.shape[0]
+    assert output.shape[2] == kv.shape[2]
+    assert scores.dtype in (torch.float32, torch.bfloat16)
+    assert head_block_size in (1, 2, 4)
+    if value_block_size is not None:
+        assert value_block_size in (64, 128, 256, 512)
+    if candidate_block_size is not None:
+        assert candidate_block_size in (16, 32, 64, 128)
+    assert scores.is_cuda and kv.is_cuda and valid_tokens.is_cuda
+    assert attn_sink.is_cuda and output.is_cuda
+
+    active_heads = num_heads if num_heads is not None else output.shape[1]
+    assert active_heads <= scores.shape[1]
+    assert active_heads <= output.shape[1]
+    assert active_heads <= attn_sink.shape[0]
+
+    num_tokens, _, num_candidates = scores.shape
+    head_dim = kv.shape[2]
+    # Clamp BLOCK_D to the smallest power-of-2 >= head_dim (among the allowed
+    # {64, 128, 256, 512}). Without this, a caller-supplied value_block_size
+    # larger than head_dim wastes work on masked-off positions — e.g. DSv4
+    # head_dim=192 with value_block_size=512 masks off 62.5% of D-axis work
+    # in every program. Smaller caller values (intentional fine-grained
+    # splits along D) are respected.
+    def _smallest_block_d_covering(hd: int) -> int:
+        for cand in (64, 128, 256, 512):
+            if cand >= hd:
+                return cand
+        return 512  # head_dim > 512: BLOCK_D=512, grid splits along D
+
+    if candidate_block_size is not None:
+        target_block_d = _smallest_block_d_covering(head_dim)
+        if value_block_size is None:
+            block_d = target_block_d
+        else:
+            block_d = min(value_block_size, target_block_d)
+        candidate_grid = (num_tokens, active_heads, triton.cdiv(head_dim, block_d))
+        _finish_materialized_scores_with_sink_candidate_block_kernel[candidate_grid](
+            scores,
+            kv,
+            valid_tokens,
+            attn_sink,
+            output,
+            scores.stride(0),
+            scores.stride(1),
+            scores.stride(2),
+            kv.stride(0),
+            kv.stride(1),
+            kv.stride(2),
+            valid_tokens.stride(0),
+            valid_tokens.stride(1),
+            output.stride(0),
+            output.stride(1),
+            output.stride(2),
+            head_dim,
+            num_candidates,
+            BLOCK_K=candidate_block_size,
+            BLOCK_D=block_d,
+            num_warps=8,
+        )
+        if output.shape[1] > active_heads:
+            output[:, active_heads:].zero_()
+        return
+
+    if value_block_size is not None and value_block_size < head_dim:
+        value_grid = (
+            num_tokens,
+            active_heads,
+            triton.cdiv(head_dim, value_block_size),
+        )
+        _finish_materialized_scores_with_sink_value_block_kernel[value_grid](
+            scores,
+            kv,
+            valid_tokens,
+            attn_sink,
+            output,
+            scores.stride(0),
+            scores.stride(1),
+            scores.stride(2),
+            kv.stride(0),
+            kv.stride(1),
+            kv.stride(2),
+            valid_tokens.stride(0),
+            valid_tokens.stride(1),
+            output.stride(0),
+            output.stride(1),
+            output.stride(2),
+            head_dim,
+            num_candidates,
+            BLOCK_D=value_block_size,
+            num_warps=4,
+        )
+        if output.shape[1] > active_heads:
+            output[:, active_heads:].zero_()
+        return
+
+    block_d = min(1024, next_power_of_2(head_dim))
+    head_grid = (num_tokens, triton.cdiv(active_heads, head_block_size))
+    _finish_materialized_scores_with_sink_kernel[head_grid](
+        scores,
+        kv,
+        valid_tokens,
+        attn_sink,
+        output,
+        scores.stride(0),
+        scores.stride(1),
+        scores.stride(2),
+        kv.stride(0),
+        kv.stride(1),
+        kv.stride(2),
+        valid_tokens.stride(0),
+        valid_tokens.stride(1),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        active_heads,
+        head_dim,
+        num_candidates,
+        HEAD_BLOCK=head_block_size,
+        BLOCK_D=block_d,
+        num_warps=8,
+    )
+    if output.shape[1] > active_heads:
+        output[:, active_heads:].zero_()
+
+
+@triton.jit
+def _accumulate_gathered_attention_chunk_kernel(
+    q_ptr,
+    kv_ptr,
+    slot_ids_ptr,
+    lens_ptr,
+    max_score_ptr,
+    denom_ptr,
+    acc_ptr,
+    stride_q_t: tl.constexpr,
+    stride_q_h: tl.constexpr,
+    stride_q_d: tl.constexpr,
+    stride_kv_t: tl.constexpr,
+    stride_kv_c: tl.constexpr,
+    stride_kv_d: tl.constexpr,
+    stride_slot_t: tl.constexpr,
+    stride_slot_c: tl.constexpr,
+    stride_state_t: tl.constexpr,
+    stride_state_h: tl.constexpr,
+    stride_acc_t: tl.constexpr,
+    stride_acc_h: tl.constexpr,
+    stride_acc_d: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    num_candidates,
+    candidate_offset,
+    scale: tl.constexpr,
+    HAS_SLOT_IDS: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    offsets = tl.arange(0, BLOCK_D)
+    dim_mask = offsets < head_dim
+
+    q = tl.load(
+        q_ptr + token_idx * stride_q_t + head_idx * stride_q_h + offsets * stride_q_d,
+        mask=dim_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    state_offset = token_idx * stride_state_t + head_idx * stride_state_h
+    acc_offset = (
+        token_idx * stride_acc_t + head_idx * stride_acc_h + offsets * stride_acc_d
+    )
+    running_max = tl.load(max_score_ptr + state_offset)
+    running_denom = tl.load(denom_ptr + state_offset)
+    running_acc = tl.load(acc_ptr + acc_offset, mask=dim_mask, other=0.0).to(tl.float32)
+    valid_len = tl.load(lens_ptr + token_idx)
+    # Per-token early-loop-exit (see indexed kernel comment).
+    local_eff = tl.minimum(
+        num_candidates,
+        tl.maximum(valid_len - candidate_offset, 0),
+    )
+
+    # ``candidate_offset + candidate_idx < valid_len`` is structurally
+    # guaranteed by the ``local_eff`` cap above, so the only remaining
+    # gate is ``slot_id >= 0`` when slot ids are present.
+    for candidate_idx in range(0, local_eff):
+        if HAS_SLOT_IDS:
+            slot_id = tl.load(
+                slot_ids_ptr + token_idx * stride_slot_t + candidate_idx * stride_slot_c
+            )
+            is_valid = slot_id >= 0
+        else:
+            is_valid = True
+
+        if is_valid:
+            kv = tl.load(
+                kv_ptr
+                + token_idx * stride_kv_t
+                + candidate_idx * stride_kv_c
+                + offsets * stride_kv_d,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            score = tl.sum(q * kv, axis=0) * scale
+            next_max = tl.maximum(running_max, score)
+            previous_weight = tl.exp(running_max - next_max)
+            candidate_weight = tl.exp(score - next_max)
+            running_acc = running_acc * previous_weight + kv * candidate_weight
+            running_denom = running_denom * previous_weight + candidate_weight
+            running_max = next_max
+
+    tl.store(max_score_ptr + state_offset, running_max)
+    tl.store(denom_ptr + state_offset, running_denom)
+    tl.store(acc_ptr + acc_offset, running_acc, mask=dim_mask)
+
+
+def accumulate_gathered_sparse_mla_attention_chunk(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    lens: torch.Tensor,
+    scale: float,
+    max_score: torch.Tensor,
+    denom: torch.Tensor,
+    acc: torch.Tensor,
+    candidate_offset: int = 0,
+    slot_ids: torch.Tensor | None = None,
+) -> None:
+    if q.dim() == 4:
+        assert q.shape[1] == 1
+        q = q[:, 0]
+    assert q.dim() == 3, f"Expected q shape [T, H, D], got {q.shape}"
+    assert kv.dim() == 3, f"Expected kv shape [T, K, D], got {kv.shape}"
+    assert q.shape[0] == kv.shape[0]
+    assert q.shape[-1] == kv.shape[-1]
+    assert lens.shape[0] == q.shape[0]
+    assert max_score.shape[0] == q.shape[0]
+    assert max_score.shape[1] <= q.shape[1]
+    assert denom.shape == max_score.shape
+    assert acc.shape == (*max_score.shape, q.shape[-1])
+    assert max_score.dtype == torch.float32
+    assert denom.dtype == torch.float32
+    assert acc.dtype == torch.float32
+    assert q.is_cuda and kv.is_cuda and lens.is_cuda
+    assert max_score.is_cuda and denom.is_cuda and acc.is_cuda
+
+    if slot_ids is not None:
+        if slot_ids.dim() == 3:
+            assert slot_ids.shape[1] == 1
+            slot_ids = slot_ids[:, 0]
+        assert slot_ids.dim() == 2
+        assert slot_ids.shape == kv.shape[:2]
+        assert slot_ids.is_cuda
+
+    num_tokens, _, head_dim = q.shape
+    num_heads = max_score.shape[1]
+    num_candidates = kv.shape[1]
+    block_d = min(1024, next_power_of_2(head_dim))
+    grid = (num_tokens, num_heads)
+    _accumulate_gathered_attention_chunk_kernel[grid](
+        q,
+        kv,
+        slot_ids,
+        lens,
+        max_score,
+        denom,
+        acc,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        kv.stride(0),
+        kv.stride(1),
+        kv.stride(2),
+        slot_ids.stride(0) if slot_ids is not None else 0,
+        slot_ids.stride(1) if slot_ids is not None else 0,
+        max_score.stride(0),
+        max_score.stride(1),
+        acc.stride(0),
+        acc.stride(1),
+        acc.stride(2),
+        num_heads,
+        head_dim,
+        num_candidates,
+        candidate_offset,
+        scale,
+        HAS_SLOT_IDS=slot_ids is not None,
+        BLOCK_D=block_d,
+        num_warps=8,
+    )
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=4, num_stages=2),
+        triton.Config({}, num_warps=4, num_stages=3),
+        triton.Config({}, num_warps=8, num_stages=2),
+        triton.Config({}, num_warps=8, num_stages=3),
+    ],
+    key=["num_candidates"],
+)
+@triton.jit
+def _accumulate_indexed_attention_chunk_kernel(
+    q_ptr,
+    kv_flat_ptr,
+    indices_ptr,
+    lens_ptr,
+    max_score_ptr,
+    denom_ptr,
+    acc_ptr,
+    stride_q_t: tl.constexpr,
+    stride_q_h: tl.constexpr,
+    stride_q_d: tl.constexpr,
+    stride_kv_t,
+    stride_kv_d: tl.constexpr,
+    stride_indices_t: tl.constexpr,
+    stride_indices_c: tl.constexpr,
+    stride_state_t: tl.constexpr,
+    stride_state_h: tl.constexpr,
+    stride_acc_t: tl.constexpr,
+    stride_acc_h: tl.constexpr,
+    stride_acc_d: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    num_kv_rows,
+    num_candidates,
+    candidate_offset,
+    scale: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    offsets = tl.arange(0, BLOCK_D)
+    dim_mask = offsets < head_dim
+
+    q = tl.load(
+        q_ptr + token_idx * stride_q_t + head_idx * stride_q_h + offsets * stride_q_d,
+        mask=dim_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    state_offset = token_idx * stride_state_t + head_idx * stride_state_h
+    acc_offset = (
+        token_idx * stride_acc_t + head_idx * stride_acc_h + offsets * stride_acc_d
+    )
+    running_max = tl.load(max_score_ptr + state_offset)
+    running_denom = tl.load(denom_ptr + state_offset)
+    running_acc = tl.load(acc_ptr + acc_offset, mask=dim_mask, other=0.0).to(tl.float32)
+    valid_len = tl.load(lens_ptr + token_idx)
+    # Per-token early-loop-exit: the combine_topk_swa_indices kernel writes
+    # ``[topk_len_t | swa_len_t | -1 padding]`` and stores
+    # ``lens[t] = topk_len_t + swa_len_t``. The existing ``is_valid`` guard
+    # already gates the heavy work past ``valid_len``, but the outer loop
+    # still iterates the full ``num_candidates`` (= chunk width). Capping
+    # the loop at ``min(num_candidates, valid_len - candidate_offset)``
+    # saves the per-iteration index load + compare overhead on the dead
+    # tail. CUDA-graph-safe because ``lens_ptr`` is a stable address and
+    # the loaded value updates per call from the metadata builder.
+    local_eff = tl.minimum(
+        num_candidates,
+        tl.maximum(valid_len - candidate_offset, 0),
+    )
+
+    # ``candidate_offset + candidate_idx < valid_len`` is structurally
+    # guaranteed by the ``local_eff`` cap above; only the per-cell
+    # sentinel check (``kv_index >= 0``) is still meaningful.
+    for candidate_idx in range(0, local_eff):
+        kv_index = tl.load(
+            indices_ptr
+            + token_idx * stride_indices_t
+            + candidate_idx * stride_indices_c
+        )
+        # Native flash_mla_sparse_fwd semantics: an index is invalid when it is
+        # negative (-1 sentinel) OR >= s_kv (out of range). The upper-bound
+        # check is essential in the sparse regime (topk < seqlen): the indexer
+        # may select token positions that, after global-index conversion, fall
+        # outside the gathered KV rows. Without it the kv_flat gather below
+        # reads out of bounds -> CUDA illegal memory access. In the dense
+        # regime every selected index is < seqlen <= s_kv so it is a no-op.
+        is_valid = (kv_index >= 0) & (kv_index < num_kv_rows)
+
+        if is_valid:
+            kv = tl.load(
+                kv_flat_ptr
+                + kv_index.to(tl.int64) * stride_kv_t
+                + offsets * stride_kv_d,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            score = tl.sum(q * kv, axis=0) * scale
+            next_max = tl.maximum(running_max, score)
+            previous_weight = tl.exp(running_max - next_max)
+            candidate_weight = tl.exp(score - next_max)
+            running_acc = running_acc * previous_weight + kv * candidate_weight
+            running_denom = running_denom * previous_weight + candidate_weight
+            running_max = next_max
+
+    tl.store(max_score_ptr + state_offset, running_max)
+    tl.store(denom_ptr + state_offset, running_denom)
+    tl.store(acc_ptr + acc_offset, running_acc, mask=dim_mask)
+
+
+_PREFILL_INDEXED_HEAD_BLOCK = 8
+
+
+@triton.jit
+def _accumulate_indexed_attention_chunk_multihead_kernel(
+    q_ptr,
+    kv_flat_ptr,
+    indices_ptr,
+    lens_ptr,
+    max_score_ptr,
+    denom_ptr,
+    acc_ptr,
+    stride_q_t: tl.constexpr,
+    stride_q_h: tl.constexpr,
+    stride_q_d: tl.constexpr,
+    stride_kv_t,
+    stride_kv_d: tl.constexpr,
+    stride_indices_t: tl.constexpr,
+    stride_indices_c: tl.constexpr,
+    stride_state_t: tl.constexpr,
+    stride_state_h: tl.constexpr,
+    stride_acc_t: tl.constexpr,
+    stride_acc_h: tl.constexpr,
+    stride_acc_d: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    num_kv_rows,
+    num_candidates,
+    candidate_offset,
+    scale: tl.constexpr,
+    HEAD_BLOCK: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_block_idx = tl.program_id(1)
+    head_offsets = head_block_idx * HEAD_BLOCK + tl.arange(0, HEAD_BLOCK)
+    dim_offsets = tl.arange(0, BLOCK_D)
+    head_mask = head_offsets < num_heads
+    dim_mask = dim_offsets < head_dim
+
+    q = tl.load(
+        q_ptr
+        + token_idx * stride_q_t
+        + head_offsets[:, None] * stride_q_h
+        + dim_offsets[None, :] * stride_q_d,
+        mask=head_mask[:, None] & dim_mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+
+    state_base = token_idx * stride_state_t
+    running_max = tl.load(
+        max_score_ptr + state_base + head_offsets * stride_state_h,
+        mask=head_mask,
+        other=float("-inf"),
+    )
+    running_denom = tl.load(
+        denom_ptr + state_base + head_offsets * stride_state_h,
+        mask=head_mask,
+        other=0.0,
+    )
+    acc_base = token_idx * stride_acc_t
+    running_acc = tl.load(
+        acc_ptr
+        + acc_base
+        + head_offsets[:, None] * stride_acc_h
+        + dim_offsets[None, :] * stride_acc_d,
+        mask=head_mask[:, None] & dim_mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+
+    valid_len = tl.load(lens_ptr + token_idx)
+    local_eff = tl.minimum(
+        num_candidates,
+        tl.maximum(valid_len - candidate_offset, 0),
+    )
+
+    for candidate_idx in range(0, local_eff):
+        kv_index = tl.load(
+            indices_ptr
+            + token_idx * stride_indices_t
+            + candidate_idx * stride_indices_c
+        )
+        # Native flash_mla_sparse_fwd semantics: an index is invalid when it is
+        # negative (-1 sentinel) OR >= s_kv (out of range). The upper-bound
+        # check is essential in the sparse regime (topk < seqlen): the indexer
+        # may select token positions that, after global-index conversion, fall
+        # outside the gathered KV rows. Without it the kv_flat gather below
+        # reads out of bounds -> CUDA illegal memory access. In the dense
+        # regime every selected index is < seqlen <= s_kv so it is a no-op.
+        is_valid = (kv_index >= 0) & (kv_index < num_kv_rows)
+
+        if is_valid:
+            kv = tl.load(
+                kv_flat_ptr
+                + kv_index.to(tl.int64) * stride_kv_t
+                + dim_offsets * stride_kv_d,
+                mask=dim_mask,
+                other=0.0,
+            ).to(tl.float32)
+            scores = tl.sum(q * kv[None, :], axis=1) * scale
+            next_max = tl.maximum(running_max, scores)
+            previous_weight = tl.exp(running_max - next_max)
+            candidate_weight = tl.exp(scores - next_max)
+            running_acc = (
+                running_acc * previous_weight[:, None]
+                + kv[None, :] * candidate_weight[:, None]
+            )
+            running_denom = running_denom * previous_weight + candidate_weight
+            running_max = next_max
+
+    tl.store(
+        max_score_ptr + state_base + head_offsets * stride_state_h,
+        running_max,
+        mask=head_mask,
+    )
+    tl.store(
+        denom_ptr + state_base + head_offsets * stride_state_h,
+        running_denom,
+        mask=head_mask,
+    )
+    tl.store(
+        acc_ptr
+        + acc_base
+        + head_offsets[:, None] * stride_acc_h
+        + dim_offsets[None, :] * stride_acc_d,
+        running_acc,
+        mask=head_mask[:, None] & dim_mask[None, :],
+    )
+
+
+def accumulate_indexed_sparse_mla_attention_chunk(
+    q: torch.Tensor,
+    kv_flat: torch.Tensor,
+    indices: torch.Tensor,
+    lens: torch.Tensor,
+    scale: float,
+    max_score: torch.Tensor,
+    denom: torch.Tensor,
+    acc: torch.Tensor,
+    candidate_offset: int = 0,
+) -> None:
+    if q.dim() == 4:
+        assert q.shape[1] == 1
+        q = q[:, 0]
+
+    assert q.dim() == 3, f"Expected q shape [T, H, D], got {q.shape}"
+    assert kv_flat.dim() == 2
+    assert indices.dim() == 2
+    assert indices.shape[0] == q.shape[0]
+    assert kv_flat.shape[-1] == q.shape[-1]
+    assert lens.shape[0] == q.shape[0]
+    assert max_score.shape[0] == q.shape[0]
+    assert max_score.shape[1] <= q.shape[1]
+    assert denom.shape == max_score.shape
+    assert acc.shape == (*max_score.shape, q.shape[-1])
+    assert max_score.dtype == torch.float32
+    assert denom.dtype == torch.float32
+    assert acc.dtype == torch.float32
+    assert q.is_cuda and kv_flat.is_cuda and indices.is_cuda and lens.is_cuda
+    assert max_score.is_cuda and denom.is_cuda and acc.is_cuda
+
+    num_tokens, _, head_dim = q.shape
+    num_heads = max_score.shape[1]
+    num_candidates = indices.shape[1]
+    # Row count of kv_flat: any index >= this is out of range and must be
+    # skipped (native flash_mla_sparse_fwd treats >= s_kv as invalid). Passed
+    # to the kernel so the per-candidate gather is bounds-checked in the sparse
+    # regime (topk < seqlen) where selected global indices can exceed s_kv.
+    num_kv_rows = kv_flat.shape[0]
+    block_d = min(1024, next_power_of_2(head_dim))
+    head_block = _PREFILL_INDEXED_HEAD_BLOCK
+
+    if num_heads >= head_block:
+        grid = (num_tokens, triton.cdiv(num_heads, head_block))
+        _accumulate_indexed_attention_chunk_multihead_kernel[grid](
+            q,
+            kv_flat,
+            indices,
+            lens,
+            max_score,
+            denom,
+            acc,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            kv_flat.stride(0),
+            kv_flat.stride(1),
+            indices.stride(0),
+            indices.stride(1),
+            max_score.stride(0),
+            max_score.stride(1),
+            acc.stride(0),
+            acc.stride(1),
+            acc.stride(2),
+            num_heads,
+            head_dim,
+            num_kv_rows,
+            num_candidates,
+            candidate_offset,
+            scale,
+            HEAD_BLOCK=head_block,
+            BLOCK_D=block_d,
+            num_warps=4,
+            num_stages=2,
+        )
+    else:
+        grid = (num_tokens, num_heads)
+        _accumulate_indexed_attention_chunk_kernel[grid](
+            q,
+            kv_flat,
+            indices,
+            lens,
+            max_score,
+            denom,
+            acc,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            kv_flat.stride(0),
+            kv_flat.stride(1),
+            indices.stride(0),
+            indices.stride(1),
+            max_score.stride(0),
+            max_score.stride(1),
+            acc.stride(0),
+            acc.stride(1),
+            acc.stride(2),
+            num_heads,
+            head_dim,
+            num_kv_rows,
+            num_candidates,
+            candidate_offset,
+            scale,
+            BLOCK_D=block_d,
+        )
+
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=4, num_stages=2),
+        triton.Config({}, num_warps=4, num_stages=3),
+        triton.Config({}, num_warps=8, num_stages=2),
+        triton.Config({}, num_warps=8, num_stages=3),
+    ],
+    key=["num_candidates"],
+)
+@triton.jit
+def _accumulate_fp8ds_global_slots_attention_chunk_kernel(
+    q_ptr,
+    k_cache_ptr,
+    slot_ids_ptr,
+    lens_ptr,
+    max_score_ptr,
+    denom_ptr,
+    acc_ptr,
+    stride_q_t: tl.constexpr,
+    stride_q_h: tl.constexpr,
+    stride_q_d: tl.constexpr,
+    stride_slot_t: tl.constexpr,
+    stride_slot_c: tl.constexpr,
+    stride_state_t: tl.constexpr,
+    stride_state_h: tl.constexpr,
+    stride_acc_t: tl.constexpr,
+    stride_acc_h: tl.constexpr,
+    stride_acc_d: tl.constexpr,
+    cache_block_size: tl.constexpr,
+    token_data_size: tl.constexpr,
+    block_stride: tl.constexpr,
+    fp8_dim: tl.constexpr,
+    scale_dim: tl.constexpr,
+    quant_block: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    num_candidates,
+    candidate_offset,
+    scale: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    offsets = tl.arange(0, BLOCK_D)
+    dim_mask = offsets < head_dim
+
+    q = tl.load(
+        q_ptr + token_idx * stride_q_t + head_idx * stride_q_h + offsets * stride_q_d,
+        mask=dim_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    state_offset = token_idx * stride_state_t + head_idx * stride_state_h
+    acc_offset = (
+        token_idx * stride_acc_t + head_idx * stride_acc_h + offsets * stride_acc_d
+    )
+    running_max = tl.load(max_score_ptr + state_offset)
+    running_denom = tl.load(denom_ptr + state_offset)
+    running_acc = tl.load(acc_ptr + acc_offset, mask=dim_mask, other=0.0).to(tl.float32)
+    valid_len = tl.load(lens_ptr + token_idx)
+    # Per-token early-loop-exit (see indexed kernel comment).
+    local_eff = tl.minimum(
+        num_candidates,
+        tl.maximum(valid_len - candidate_offset, 0),
+    )
+
+    fp8_mask = offsets < fp8_dim
+    rope_mask = (offsets >= fp8_dim) & dim_mask
+    rope_offsets = tl.maximum(offsets - fp8_dim, 0)
+
+    # ``candidate_offset + candidate_idx < valid_len`` is structurally
+    # guaranteed by the ``local_eff`` cap above; only the per-cell
+    # sentinel check (``slot_id >= 0``) is still meaningful.
+    for candidate_idx in range(0, local_eff):
+        slot_id = tl.load(
+            slot_ids_ptr + token_idx * stride_slot_t + candidate_idx * stride_slot_c
+        )
+        is_valid = slot_id >= 0
+
+        if is_valid:
+            block_idx = slot_id // cache_block_size
+            pos_in_block = slot_id % cache_block_size
+            cache_block_ptr = k_cache_ptr + block_idx.to(tl.int64) * block_stride
+            token_data_ptr = cache_block_ptr + pos_in_block * token_data_size
+            token_scale_ptr = (
+                cache_block_ptr
+                + cache_block_size * token_data_size
+                + pos_in_block * scale_dim
+            )
+
+            x_uint8 = tl.load(token_data_ptr + offsets, mask=fp8_mask, other=0)
+            x_fp8 = x_uint8.to(tl.float8e4nv, bitcast=True)
+            x_float = x_fp8.to(tl.float32)
+            scale_offsets = offsets // quant_block
+            encoded_scale = tl.load(
+                token_scale_ptr + scale_offsets,
+                mask=fp8_mask,
+                other=127,
+            )
+            dequant_scale = tl.exp2(encoded_scale.to(tl.float32) - 127.0)
+            x_dequant = x_float * dequant_scale
+
+            rope_ptr = (token_data_ptr + fp8_dim).to(tl.pointer_type(tl.bfloat16))
+            rope = tl.load(rope_ptr + rope_offsets, mask=rope_mask, other=0.0).to(
+                tl.float32
+            )
+            kv = tl.where(fp8_mask, x_dequant, rope)
+            kv = tl.where(dim_mask, kv, 0.0)
+
+            score = tl.sum(q * kv, axis=0) * scale
+            next_max = tl.maximum(running_max, score)
+            previous_weight = tl.exp(running_max - next_max)
+            candidate_weight = tl.exp(score - next_max)
+            running_acc = running_acc * previous_weight + kv * candidate_weight
+            running_denom = running_denom * previous_weight + candidate_weight
+            running_max = next_max
+
+    tl.store(max_score_ptr + state_offset, running_max)
+    tl.store(denom_ptr + state_offset, running_denom)
+    tl.store(acc_ptr + acc_offset, running_acc, mask=dim_mask)
+
+
+def accumulate_fp8ds_global_slots_sparse_mla_attention_chunk(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    slot_ids: torch.Tensor,
+    lens: torch.Tensor,
+    block_size: int,
+    scale: float,
+    max_score: torch.Tensor,
+    denom: torch.Tensor,
+    acc: torch.Tensor,
+    candidate_offset: int = 0,
+) -> None:
+    if q.dim() == 4:
+        assert q.shape[1] == 1
+        q = q[:, 0]
+    if slot_ids.dim() == 3:
+        assert slot_ids.shape[1] == 1
+        slot_ids = slot_ids[:, 0]
+
+    assert q.dim() == 3, f"Expected q shape [T, H, D], got {q.shape}"
+    assert q.shape[-1] == 512
+    assert slot_ids.dim() == 2
+    assert slot_ids.shape[0] == q.shape[0]
+    assert lens.shape[0] == q.shape[0]
+    assert max_score.shape[0] == q.shape[0]
+    assert max_score.shape[1] <= q.shape[1]
+    assert denom.shape == max_score.shape
+    assert acc.shape == (*max_score.shape, q.shape[-1])
+    assert max_score.dtype == torch.float32
+    assert denom.dtype == torch.float32
+    assert acc.dtype == torch.float32
+    assert k_cache.dtype == torch.uint8
+    assert q.is_cuda and k_cache.is_cuda and slot_ids.is_cuda and lens.is_cuda
+    assert max_score.is_cuda and denom.is_cuda and acc.is_cuda
+
+    token_fp8_dim = 448
+    token_bf16_dim = 64
+    token_scale_dim = 8
+    quant_block_size = 64
+    token_data_size = token_fp8_dim + token_bf16_dim * 2
+
+    num_tokens, _, head_dim = q.shape
+    num_heads = max_score.shape[1]
+    num_candidates = slot_ids.shape[1]
+    block_d = min(1024, next_power_of_2(head_dim))
+    grid = (num_tokens, num_heads)
+    _accumulate_fp8ds_global_slots_attention_chunk_kernel[grid](
+        q,
+        k_cache,
+        slot_ids,
+        lens,
+        max_score,
+        denom,
+        acc,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        slot_ids.stride(0),
+        slot_ids.stride(1),
+        max_score.stride(0),
+        max_score.stride(1),
+        acc.stride(0),
+        acc.stride(1),
+        acc.stride(2),
+        block_size,
+        token_data_size,
+        k_cache.stride(0),
+        token_fp8_dim,
+        token_scale_dim,
+        quant_block_size,
+        num_heads,
+        head_dim,
+        num_candidates,
+        candidate_offset,
+        scale,
+        BLOCK_D=block_d,
+        # num_warps / num_stages supplied by @triton.autotune above.
+    )
+
+
+@triton.jit
+def _accumulate_fp8ds_global_slots_attention_chunk_multihead_kernel(
+    q_ptr,
+    k_cache_ptr,
+    slot_ids_ptr,
+    lens_ptr,
+    max_score_ptr,
+    denom_ptr,
+    acc_ptr,
+    stride_q_t: tl.constexpr,
+    stride_q_h: tl.constexpr,
+    stride_q_d: tl.constexpr,
+    stride_slot_t: tl.constexpr,
+    stride_slot_c: tl.constexpr,
+    stride_state_t: tl.constexpr,
+    stride_state_h: tl.constexpr,
+    stride_acc_t: tl.constexpr,
+    stride_acc_h: tl.constexpr,
+    stride_acc_d: tl.constexpr,
+    cache_block_size: tl.constexpr,
+    token_data_size: tl.constexpr,
+    block_stride: tl.constexpr,
+    fp8_dim: tl.constexpr,
+    scale_dim: tl.constexpr,
+    quant_block: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    num_candidates,
+    candidate_offset,
+    scale: tl.constexpr,
+    HEAD_BLOCK: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_block_idx = tl.program_id(1)
+    head_offsets = head_block_idx * HEAD_BLOCK + tl.arange(0, HEAD_BLOCK)
+    dim_offsets = tl.arange(0, BLOCK_D)
+    head_mask = head_offsets < num_heads
+    dim_mask = dim_offsets < head_dim
+    matrix_mask = head_mask[:, None] & dim_mask[None, :]
+
+    q = tl.load(
+        q_ptr
+        + token_idx * stride_q_t
+        + head_offsets[:, None] * stride_q_h
+        + dim_offsets[None, :] * stride_q_d,
+        mask=matrix_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    state_offsets = token_idx * stride_state_t + head_offsets * stride_state_h
+    acc_offsets = (
+        token_idx * stride_acc_t
+        + head_offsets[:, None] * stride_acc_h
+        + dim_offsets[None, :] * stride_acc_d
+    )
+    running_max = tl.load(
+        max_score_ptr + state_offsets,
+        mask=head_mask,
+        other=-float("inf"),
+    )
+    running_denom = tl.load(denom_ptr + state_offsets, mask=head_mask, other=0.0)
+    running_acc = tl.load(acc_ptr + acc_offsets, mask=matrix_mask, other=0.0).to(
+        tl.float32
+    )
+    valid_len = tl.load(lens_ptr + token_idx)
+    # Per-token early-loop-exit: ``lens[t] = topk_len_t + swa_len_t`` (set
+    # by combine_topk_swa_indices). Iterating past ``valid_len`` only
+    # incurs the per-iter index-load + compare cost on padding-tail; cap
+    # the outer loop at ``valid_len - candidate_offset`` to skip the dead
+    # tail. CUDA-graph-safe because ``lens_ptr`` is a stable address.
+    local_eff = tl.minimum(
+        num_candidates,
+        tl.maximum(valid_len - candidate_offset, 0),
+    )
+
+    fp8_mask = dim_offsets < fp8_dim
+    rope_mask = (dim_offsets >= fp8_dim) & dim_mask
+    rope_offsets = tl.maximum(dim_offsets - fp8_dim, 0)
+
+    # ``candidate_offset + candidate_idx < valid_len`` is structurally
+    # guaranteed by the ``local_eff`` cap above; only the per-cell
+    # sentinel check (``slot_id >= 0``) is still meaningful.
+    for candidate_idx in range(0, local_eff):
+        slot_id = tl.load(
+            slot_ids_ptr + token_idx * stride_slot_t + candidate_idx * stride_slot_c
+        )
+        is_valid = slot_id >= 0
+
+        if is_valid:
+            block_idx = slot_id // cache_block_size
+            pos_in_block = slot_id % cache_block_size
+            cache_block_ptr = k_cache_ptr + block_idx.to(tl.int64) * block_stride
+            token_data_ptr = cache_block_ptr + pos_in_block * token_data_size
+            token_scale_ptr = (
+                cache_block_ptr
+                + cache_block_size * token_data_size
+                + pos_in_block * scale_dim
+            )
+
+            x_uint8 = tl.load(token_data_ptr + dim_offsets, mask=fp8_mask, other=0)
+            x_fp8 = x_uint8.to(tl.float8e4nv, bitcast=True)
+            x_float = x_fp8.to(tl.float32)
+            scale_offsets = dim_offsets // quant_block
+            encoded_scale = tl.load(
+                token_scale_ptr + scale_offsets,
+                mask=fp8_mask,
+                other=127,
+            )
+            dequant_scale = tl.exp2(encoded_scale.to(tl.float32) - 127.0)
+            x_dequant = x_float * dequant_scale
+
+            rope_ptr = (token_data_ptr + fp8_dim).to(tl.pointer_type(tl.bfloat16))
+            rope = tl.load(rope_ptr + rope_offsets, mask=rope_mask, other=0.0).to(
+                tl.float32
+            )
+            kv = tl.where(fp8_mask, x_dequant, rope)
+            kv = tl.where(dim_mask, kv, 0.0)
+
+            score = tl.sum(q * kv[None, :], axis=1) * scale
+            next_max = tl.maximum(running_max, score)
+            previous_weight = tl.exp(running_max - next_max)
+            candidate_weight = tl.exp(score - next_max)
+            running_acc = (
+                running_acc * previous_weight[:, None]
+                + kv[None, :] * candidate_weight[:, None]
+            )
+            running_denom = running_denom * previous_weight + candidate_weight
+            running_max = next_max
+
+    tl.store(max_score_ptr + state_offsets, running_max, mask=head_mask)
+    tl.store(denom_ptr + state_offsets, running_denom, mask=head_mask)
+    tl.store(acc_ptr + acc_offsets, running_acc, mask=matrix_mask)
+
+
+def accumulate_fp8ds_global_slots_sparse_mla_attention_chunk_multihead(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    slot_ids: torch.Tensor,
+    lens: torch.Tensor,
+    block_size: int,
+    scale: float,
+    max_score: torch.Tensor,
+    denom: torch.Tensor,
+    acc: torch.Tensor,
+    candidate_offset: int = 0,
+    head_block_size: int = 2,
+) -> None:
+    if q.dim() == 4:
+        assert q.shape[1] == 1
+        q = q[:, 0]
+    if slot_ids.dim() == 3:
+        assert slot_ids.shape[1] == 1
+        slot_ids = slot_ids[:, 0]
+
+    assert q.dim() == 3, f"Expected q shape [T, H, D], got {q.shape}"
+    assert q.shape[-1] == 512
+    assert slot_ids.dim() == 2
+    assert slot_ids.shape[0] == q.shape[0]
+    assert lens.shape[0] == q.shape[0]
+    assert max_score.shape[0] == q.shape[0]
+    assert max_score.shape[1] <= q.shape[1]
+    assert denom.shape == max_score.shape
+    assert acc.shape == (*max_score.shape, q.shape[-1])
+    assert head_block_size in (1, 2, 4)
+    assert max_score.dtype == torch.float32
+    assert denom.dtype == torch.float32
+    assert acc.dtype == torch.float32
+    assert k_cache.dtype == torch.uint8
+    assert q.is_cuda and k_cache.is_cuda and slot_ids.is_cuda and lens.is_cuda
+    assert max_score.is_cuda and denom.is_cuda and acc.is_cuda
+
+    token_fp8_dim = 448
+    token_bf16_dim = 64
+    token_scale_dim = 8
+    quant_block_size = 64
+    token_data_size = token_fp8_dim + token_bf16_dim * 2
+
+    num_tokens, _, head_dim = q.shape
+    num_heads = max_score.shape[1]
+    num_candidates = slot_ids.shape[1]
+    block_d = min(1024, next_power_of_2(head_dim))
+    grid = (num_tokens, triton.cdiv(num_heads, head_block_size))
+    _accumulate_fp8ds_global_slots_attention_chunk_multihead_kernel[grid](
+        q,
+        k_cache,
+        slot_ids,
+        lens,
+        max_score,
+        denom,
+        acc,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        slot_ids.stride(0),
+        slot_ids.stride(1),
+        max_score.stride(0),
+        max_score.stride(1),
+        acc.stride(0),
+        acc.stride(1),
+        acc.stride(2),
+        block_size,
+        token_data_size,
+        k_cache.stride(0),
+        token_fp8_dim,
+        token_scale_dim,
+        quant_block_size,
+        num_heads,
+        head_dim,
+        num_candidates,
+        candidate_offset,
+        scale,
+        HEAD_BLOCK=head_block_size,
+        BLOCK_D=block_d,
+        num_warps=8,
+    )
+
+
+
+@triton.jit
+def _indexed_d512_split_score_kernel(
+    q_ptr,
+    kv_flat_ptr,
+    indices_ptr,
+    lens_ptr,
+    scores_ptr,
+    stride_q_t: tl.constexpr,
+    stride_q_h: tl.constexpr,
+    stride_q_d: tl.constexpr,
+    stride_kv_t,
+    stride_kv_d: tl.constexpr,
+    stride_indices_t: tl.constexpr,
+    stride_indices_c: tl.constexpr,
+    stride_scores_t: tl.constexpr,
+    stride_scores_h: tl.constexpr,
+    stride_scores_c: tl.constexpr,
+    num_heads: tl.constexpr,
+    num_kv_rows,
+    num_candidates: tl.constexpr,
+    scale: tl.constexpr,
+    HEAD_BLOCK: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_block_idx = tl.program_id(1)
+    candidate_block = tl.program_id(2)
+    head_offsets = head_block_idx * HEAD_BLOCK + tl.arange(0, HEAD_BLOCK)
+    candidate_offsets = candidate_block * BLOCK_C + tl.arange(0, BLOCK_C)
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    head_mask = head_offsets < num_heads
+    valid_len = tl.load(lens_ptr + token_idx)
+    if candidate_block * BLOCK_C >= tl.minimum(valid_len, num_candidates):
+        return
+    candidate_mask = candidate_offsets < tl.minimum(valid_len, num_candidates)
+
+    q = tl.load(
+        q_ptr
+        + token_idx * stride_q_t
+        + head_offsets[:, None] * stride_q_h
+        + dim_offsets[None, :] * stride_q_d,
+        mask=head_mask[:, None],
+        other=0.0,
+    )
+    kv_indices = tl.load(
+        indices_ptr
+        + token_idx * stride_indices_t
+        + candidate_offsets * stride_indices_c,
+        mask=candidate_mask,
+        other=-1,
+    )
+    # Native flash_mla_sparse_fwd semantics: an index is invalid when it is
+    # negative (-1 sentinel) OR >= s_kv (out of range). The upper-bound check
+    # against num_kv_rows is essential in the sparse regime (topk < seqlen):
+    # converted global indices may exceed s_kv, and without it the kv_flat
+    # gather below reads out of bounds -> CUDA illegal memory access. This
+    # mirrors the bound on the scalar/multihead indexed kernels.
+    valid_kv = (kv_indices >= 0) & (kv_indices < num_kv_rows)
+    kv = tl.load(
+        kv_flat_ptr
+        + kv_indices[None, :].to(tl.int64) * stride_kv_t
+        + dim_offsets[:, None] * stride_kv_d,
+        mask=valid_kv[None, :],
+        other=0.0,
+    )
+    scores = tl.dot(q, kv) * scale
+    tl.store(
+        scores_ptr
+        + token_idx * stride_scores_t
+        + head_offsets[:, None] * stride_scores_h
+        + candidate_offsets[None, :] * stride_scores_c,
+        scores,
+        mask=head_mask[:, None] & candidate_mask[None, :],
+    )
+
+
+@triton.jit
+def _indexed_d512_split_stats_kernel(
+    scores_ptr,
+    lens_ptr,
+    max_score_ptr,
+    denom_ptr,
+    stride_scores_t: tl.constexpr,
+    stride_scores_h: tl.constexpr,
+    stride_scores_c: tl.constexpr,
+    stride_state_t: tl.constexpr,
+    stride_state_h: tl.constexpr,
+    num_candidates: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    candidate_offsets = tl.arange(0, BLOCK_C)
+    valid_len = tl.load(lens_ptr + token_idx)
+    candidate_mask = candidate_offsets < tl.minimum(valid_len, num_candidates)
+    scores = tl.load(
+        scores_ptr
+        + token_idx * stride_scores_t
+        + head_idx * stride_scores_h
+        + candidate_offsets * stride_scores_c,
+        mask=candidate_mask,
+        other=-float("inf"),
+    ).to(tl.float32)
+    running_max = tl.max(scores, axis=0)
+    safe_max = tl.where(valid_len > 0, running_max, 0.0)
+    weights = tl.where(candidate_mask, tl.exp(scores - safe_max), 0.0)
+    running_denom = tl.sum(weights, axis=0)
+
+    tl.store(
+        max_score_ptr + token_idx * stride_state_t + head_idx * stride_state_h,
+        running_max,
+    )
+    tl.store(
+        denom_ptr + token_idx * stride_state_t + head_idx * stride_state_h,
+        running_denom,
+    )
+
+
+@triton.jit
+def _indexed_d512_split_value_kernel(
+    scores_ptr,
+    kv_flat_ptr,
+    indices_ptr,
+    lens_ptr,
+    max_score_ptr,
+    acc_ptr,
+    stride_scores_t: tl.constexpr,
+    stride_scores_h: tl.constexpr,
+    stride_scores_c: tl.constexpr,
+    stride_kv_t,
+    stride_kv_d: tl.constexpr,
+    stride_indices_t: tl.constexpr,
+    stride_indices_c: tl.constexpr,
+    stride_state_t: tl.constexpr,
+    stride_state_h: tl.constexpr,
+    stride_acc_t: tl.constexpr,
+    stride_acc_h: tl.constexpr,
+    stride_acc_d: tl.constexpr,
+    num_heads: tl.constexpr,
+    num_kv_rows,
+    num_candidates: tl.constexpr,
+    head_dim: tl.constexpr,
+    HEAD_BLOCK: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_block_idx = tl.program_id(1)
+    dim_block = tl.program_id(2)
+    head_offsets = head_block_idx * HEAD_BLOCK + tl.arange(0, HEAD_BLOCK)
+    candidate_offsets = tl.arange(0, BLOCK_C)
+    dim_offsets = dim_block * BLOCK_D + tl.arange(0, BLOCK_D)
+    head_mask = head_offsets < num_heads
+    dim_mask = dim_offsets < head_dim
+    valid_len = tl.load(lens_ptr + token_idx)
+    max_score = tl.load(
+        max_score_ptr
+        + token_idx * stride_state_t
+        + head_offsets * stride_state_h,
+        mask=head_mask,
+        other=0.0,
+    ).to(tl.float32)
+    safe_max = tl.where(valid_len > 0, max_score, 0.0)
+    acc = tl.zeros((HEAD_BLOCK, BLOCK_D), tl.float32)
+
+    for candidate_start in range(0, num_candidates, BLOCK_C):
+        if candidate_start < tl.minimum(valid_len, num_candidates):
+            candidates = candidate_start + candidate_offsets
+            candidate_mask = candidates < tl.minimum(valid_len, num_candidates)
+            kv_indices = tl.load(
+                indices_ptr
+                + token_idx * stride_indices_t
+                + candidates * stride_indices_c,
+                mask=candidate_mask,
+                other=-1,
+            )
+            # Bound-check converted global indices against the gathered KV row
+            # count (see _indexed_d512_split_score_kernel): >= num_kv_rows is
+            # out of range and must not be gathered or it reads kv_flat OOB.
+            valid_kv = (kv_indices >= 0) & (kv_indices < num_kv_rows)
+            scores = tl.load(
+                scores_ptr
+                + token_idx * stride_scores_t
+                + head_offsets[:, None] * stride_scores_h
+                + candidates[None, :] * stride_scores_c,
+                mask=head_mask[:, None] & candidate_mask[None, :],
+                other=-float("inf"),
+            ).to(tl.float32)
+            weights = tl.where(
+                candidate_mask[None, :],
+                tl.exp(scores - safe_max[:, None]),
+                0.0,
+            )
+            values = tl.load(
+                kv_flat_ptr
+                + kv_indices[:, None].to(tl.int64) * stride_kv_t
+                + dim_offsets[None, :] * stride_kv_d,
+                mask=valid_kv[:, None] & dim_mask[None, :],
+                other=0.0,
+            )
+            acc += tl.dot(weights.to(tl.bfloat16), values)
+
+    tl.store(
+        acc_ptr
+        + token_idx * stride_acc_t
+        + head_offsets[:, None] * stride_acc_h
+        + dim_offsets[None, :] * stride_acc_d,
+        acc,
+        mask=head_mask[:, None] & dim_mask[None, :],
+    )
+
+
+def accumulate_indexed_d512_split_sparse_mla_attention(
+    q: torch.Tensor,
+    kv_flat: torch.Tensor,
+    indices: torch.Tensor,
+    lens: torch.Tensor,
+    scale: float,
+    scores: torch.Tensor,
+    max_score: torch.Tensor,
+    denom: torch.Tensor,
+    acc: torch.Tensor,
+    head_block_size: int = 32,
+    candidate_block_size: int = 64,
+    value_block_size: int = 128,
+) -> None:
+    if q.dim() == 4:
+        assert q.shape[1] == 1
+        q = q[:, 0]
+
+    assert q.dim() == 3, f"Expected q shape [T, H, D], got {q.shape}"
+    assert kv_flat.dim() == 2
+    assert indices.dim() == 2
+    assert indices.shape[0] == q.shape[0]
+    assert lens.shape[0] == q.shape[0]
+    assert kv_flat.shape[-1] == q.shape[-1]
+    assert q.shape[-1] == 512
+    assert scores.shape == (q.shape[0], max_score.shape[1], indices.shape[1])
+    assert denom.shape == max_score.shape
+    assert acc.shape == (*max_score.shape, q.shape[-1])
+    assert max_score.dtype == torch.float32
+    assert denom.dtype == torch.float32
+    assert acc.dtype == torch.float32
+    assert scores.dtype == torch.float32
+    assert q.is_cuda and kv_flat.is_cuda and indices.is_cuda and lens.is_cuda
+    assert scores.is_cuda and max_score.is_cuda and denom.is_cuda and acc.is_cuda
+    assert head_block_size in (8, 16, 32)
+    assert candidate_block_size in (32, 64, 128)
+    assert value_block_size in (32, 64, 128)
+    assert indices.shape[1] <= 1152
+
+    num_tokens, _, head_dim = q.shape
+    num_heads = max_score.shape[1]
+    num_candidates = indices.shape[1]
+    # Row count of kv_flat: any converted global index >= this is out of range
+    # and must be skipped (native flash_mla_sparse_fwd treats >= s_kv as
+    # invalid). Passed to the split kernels so the per-candidate gather is
+    # bounds-checked in the sparse regime (topk < seqlen).
+    num_kv_rows = kv_flat.shape[0]
+    score_grid = (
+        num_tokens,
+        triton.cdiv(num_heads, head_block_size),
+        triton.cdiv(num_candidates, candidate_block_size),
+    )
+    _indexed_d512_split_score_kernel[score_grid](
+        q,
+        kv_flat,
+        indices,
+        lens,
+        scores,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        kv_flat.stride(0),
+        kv_flat.stride(1),
+        indices.stride(0),
+        indices.stride(1),
+        scores.stride(0),
+        scores.stride(1),
+        scores.stride(2),
+        num_heads,
+        num_kv_rows,
+        num_candidates,
+        scale,
+        HEAD_BLOCK=head_block_size,
+        BLOCK_C=candidate_block_size,
+        HEAD_DIM=head_dim,
+        num_warps=8,
+        num_stages=3,
+    )
+
+    stats_grid = (num_tokens, num_heads)
+    stats_block_c = next_power_of_2(num_candidates)
+    _indexed_d512_split_stats_kernel[stats_grid](
+        scores,
+        lens,
+        max_score,
+        denom,
+        scores.stride(0),
+        scores.stride(1),
+        scores.stride(2),
+        max_score.stride(0),
+        max_score.stride(1),
+        num_candidates,
+        BLOCK_C=stats_block_c,
+        num_warps=4,
+        num_stages=3,
+    )
+
+    value_grid = (
+        num_tokens,
+        triton.cdiv(num_heads, head_block_size),
+        triton.cdiv(head_dim, value_block_size),
+    )
+    _indexed_d512_split_value_kernel[value_grid](
+        scores,
+        kv_flat,
+        indices,
+        lens,
+        max_score,
+        acc,
+        scores.stride(0),
+        scores.stride(1),
+        scores.stride(2),
+        kv_flat.stride(0),
+        kv_flat.stride(1),
+        indices.stride(0),
+        indices.stride(1),
+        max_score.stride(0),
+        max_score.stride(1),
+        acc.stride(0),
+        acc.stride(1),
+        acc.stride(2),
+        num_heads,
+        num_kv_rows,
+        num_candidates,
+        head_dim,
+        HEAD_BLOCK=head_block_size,
+        BLOCK_C=candidate_block_size,
+        BLOCK_D=value_block_size,
+        num_warps=4,
+        num_stages=3,
+    )
+
+
+@triton.jit
+def _indexed_d512_chunked_merge_acc_kernel(
+    max_score_ptr,
+    acc_ptr,
+    chunk_max_score_ptr,
+    chunk_acc_ptr,
+    stride_state_t: tl.constexpr,
+    stride_state_h: tl.constexpr,
+    stride_acc_t: tl.constexpr,
+    stride_acc_h: tl.constexpr,
+    stride_acc_d: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    HEAD_BLOCK: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_block_idx = tl.program_id(1)
+    dim_block = tl.program_id(2)
+    head_offsets = head_block_idx * HEAD_BLOCK + tl.arange(0, HEAD_BLOCK)
+    dim_offsets = dim_block * BLOCK_D + tl.arange(0, BLOCK_D)
+    head_mask = head_offsets < num_heads
+    dim_mask = dim_offsets < head_dim
+
+    running_max = tl.load(
+        max_score_ptr + token_idx * stride_state_t + head_offsets * stride_state_h,
+        mask=head_mask,
+        other=-float("inf"),
+    ).to(tl.float32)
+    chunk_max = tl.load(
+        chunk_max_score_ptr
+        + token_idx * stride_state_t
+        + head_offsets * stride_state_h,
+        mask=head_mask,
+        other=-float("inf"),
+    ).to(tl.float32)
+    next_max = tl.maximum(running_max, chunk_max)
+    running_valid = running_max != -float("inf")
+    chunk_valid = chunk_max != -float("inf")
+    running_scale = tl.where(running_valid, tl.exp(running_max - next_max), 0.0)
+    chunk_scale = tl.where(chunk_valid, tl.exp(chunk_max - next_max), 0.0)
+
+    running_acc = tl.load(
+        acc_ptr
+        + token_idx * stride_acc_t
+        + head_offsets[:, None] * stride_acc_h
+        + dim_offsets[None, :] * stride_acc_d,
+        mask=head_mask[:, None] & dim_mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+    chunk_acc = tl.load(
+        chunk_acc_ptr
+        + token_idx * stride_acc_t
+        + head_offsets[:, None] * stride_acc_h
+        + dim_offsets[None, :] * stride_acc_d,
+        mask=head_mask[:, None] & dim_mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+    merged_acc = (
+        running_acc * running_scale[:, None] + chunk_acc * chunk_scale[:, None]
+    )
+    tl.store(
+        acc_ptr
+        + token_idx * stride_acc_t
+        + head_offsets[:, None] * stride_acc_h
+        + dim_offsets[None, :] * stride_acc_d,
+        merged_acc,
+        mask=head_mask[:, None] & dim_mask[None, :],
+    )
+
+
+@triton.jit
+def _indexed_d512_chunked_merge_state_kernel(
+    max_score_ptr,
+    denom_ptr,
+    chunk_max_score_ptr,
+    chunk_denom_ptr,
+    stride_state_t: tl.constexpr,
+    stride_state_h: tl.constexpr,
+    num_heads: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    head_mask = head_idx < num_heads
+
+    running_max = tl.load(
+        max_score_ptr + token_idx * stride_state_t + head_idx * stride_state_h,
+        mask=head_mask,
+        other=-float("inf"),
+    ).to(tl.float32)
+    running_denom = tl.load(
+        denom_ptr + token_idx * stride_state_t + head_idx * stride_state_h,
+        mask=head_mask,
+        other=0.0,
+    ).to(tl.float32)
+    chunk_max = tl.load(
+        chunk_max_score_ptr + token_idx * stride_state_t + head_idx * stride_state_h,
+        mask=head_mask,
+        other=-float("inf"),
+    ).to(tl.float32)
+    chunk_denom = tl.load(
+        chunk_denom_ptr + token_idx * stride_state_t + head_idx * stride_state_h,
+        mask=head_mask,
+        other=0.0,
+    ).to(tl.float32)
+    next_max = tl.maximum(running_max, chunk_max)
+    running_valid = running_max != -float("inf")
+    chunk_valid = chunk_max != -float("inf")
+    running_scale = tl.where(running_valid, tl.exp(running_max - next_max), 0.0)
+    chunk_scale = tl.where(chunk_valid, tl.exp(chunk_max - next_max), 0.0)
+    next_denom = running_denom * running_scale + chunk_denom * chunk_scale
+
+    tl.store(
+        max_score_ptr + token_idx * stride_state_t + head_idx * stride_state_h,
+        next_max,
+        mask=head_mask,
+    )
+    tl.store(
+        denom_ptr + token_idx * stride_state_t + head_idx * stride_state_h,
+        next_denom,
+        mask=head_mask,
+    )
+
+
+def accumulate_indexed_d512_chunked_sparse_mla_attention(
+    q: torch.Tensor,
+    kv_flat: torch.Tensor,
+    indices: torch.Tensor,
+    lens: torch.Tensor,
+    scale: float,
+    scores: torch.Tensor,
+    max_score: torch.Tensor,
+    denom: torch.Tensor,
+    acc: torch.Tensor,
+    chunk_max_score: torch.Tensor,
+    chunk_denom: torch.Tensor,
+    chunk_acc: torch.Tensor,
+    head_block_size: int = 32,
+    candidate_block_size: int = 64,
+    value_block_size: int = 128,
+) -> None:
+    if q.dim() == 4:
+        assert q.shape[1] == 1
+        q = q[:, 0]
+
+    assert q.dim() == 3, f"Expected q shape [T, H, D], got {q.shape}"
+    assert kv_flat.dim() == 2
+    assert indices.dim() == 2
+    assert indices.shape[0] == q.shape[0]
+    assert lens.shape[0] == q.shape[0]
+    assert kv_flat.shape[-1] == q.shape[-1]
+    assert q.shape[-1] == 512
+    assert scores.shape[0] == q.shape[0]
+    assert scores.shape[1] == max_score.shape[1]
+    assert 0 < scores.shape[2] <= 1152
+    assert max_score.shape == denom.shape == chunk_max_score.shape == chunk_denom.shape
+    assert acc.shape == chunk_acc.shape == (*max_score.shape, q.shape[-1])
+    assert max_score.dtype == torch.float32
+    assert denom.dtype == torch.float32
+    assert acc.dtype == torch.float32
+    assert chunk_max_score.dtype == torch.float32
+    assert chunk_denom.dtype == torch.float32
+    assert chunk_acc.dtype == torch.float32
+    assert scores.dtype == torch.float32
+    assert q.is_cuda and kv_flat.is_cuda and indices.is_cuda and lens.is_cuda
+    assert scores.is_cuda and max_score.is_cuda and denom.is_cuda and acc.is_cuda
+    assert chunk_max_score.is_cuda and chunk_denom.is_cuda and chunk_acc.is_cuda
+    assert head_block_size in (8, 16, 32)
+    assert candidate_block_size in (32, 64, 128)
+    assert value_block_size in (32, 64, 128)
+
+    num_tokens, _, head_dim = q.shape
+    num_heads = max_score.shape[1]
+    chunk_size = scores.shape[2]
+    max_score.fill_(float("-inf"))
+    denom.zero_()
+    acc.zero_()
+
+    merge_acc_grid = (
+        num_tokens,
+        triton.cdiv(num_heads, head_block_size),
+        triton.cdiv(head_dim, value_block_size),
+    )
+    merge_state_grid = (num_tokens, num_heads)
+    for candidate_start in range(0, indices.shape[1], chunk_size):
+        candidate_end = min(candidate_start + chunk_size, indices.shape[1])
+        chunk_candidates = candidate_end - candidate_start
+        chunk_lens = torch.clamp(
+            lens - candidate_start,
+            min=0,
+            max=chunk_candidates,
+        )
+        accumulate_indexed_d512_split_sparse_mla_attention(
+            q=q,
+            kv_flat=kv_flat,
+            indices=indices[:, candidate_start:candidate_end],
+            lens=chunk_lens,
+            scale=scale,
+            scores=scores[:, :, :chunk_candidates],
+            max_score=chunk_max_score,
+            denom=chunk_denom,
+            acc=chunk_acc,
+            head_block_size=head_block_size,
+            candidate_block_size=candidate_block_size,
+            value_block_size=value_block_size,
+        )
+        _indexed_d512_chunked_merge_acc_kernel[merge_acc_grid](
+            max_score,
+            acc,
+            chunk_max_score,
+            chunk_acc,
+            max_score.stride(0),
+            max_score.stride(1),
+            acc.stride(0),
+            acc.stride(1),
+            acc.stride(2),
+            num_heads,
+            head_dim,
+            HEAD_BLOCK=head_block_size,
+            BLOCK_D=value_block_size,
+            num_warps=4,
+            num_stages=3,
+        )
+        _indexed_d512_chunked_merge_state_kernel[merge_state_grid](
+            max_score,
+            denom,
+            chunk_max_score,
+            chunk_denom,
+            max_score.stride(0),
+            max_score.stride(1),
+            num_heads,
+            num_warps=4,
+            num_stages=3,
+        )
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=4, num_stages=2),
+        triton.Config({}, num_warps=4, num_stages=3),
+        triton.Config({}, num_warps=8, num_stages=2),
+        triton.Config({}, num_warps=8, num_stages=3),
+    ],
+    key=["num_candidates"],
+)
+@triton.jit
+def _accumulate_fp8ds_paged_attention_chunk_kernel(
+    q_ptr,
+    k_cache_ptr,
+    seq_lens_ptr,
+    gather_lens_ptr,
+    block_table_ptr,
+    max_score_ptr,
+    denom_ptr,
+    acc_ptr,
+    stride_q_t: tl.constexpr,
+    stride_q_h: tl.constexpr,
+    stride_q_d: tl.constexpr,
+    stride_block_table_t,
+    stride_state_t: tl.constexpr,
+    stride_state_h: tl.constexpr,
+    stride_acc_t: tl.constexpr,
+    stride_acc_h: tl.constexpr,
+    stride_acc_d: tl.constexpr,
+    cache_block_size: tl.constexpr,
+    token_data_size: tl.constexpr,
+    block_stride: tl.constexpr,
+    fp8_dim: tl.constexpr,
+    scale_dim: tl.constexpr,
+    quant_block: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    num_candidates,
+    candidate_offset,
+    scale: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    offsets = tl.arange(0, BLOCK_D)
+    dim_mask = offsets < head_dim
+
+    q = tl.load(
+        q_ptr + token_idx * stride_q_t + head_idx * stride_q_h + offsets * stride_q_d,
+        mask=dim_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    state_offset = token_idx * stride_state_t + head_idx * stride_state_h
+    acc_offset = (
+        token_idx * stride_acc_t + head_idx * stride_acc_h + offsets * stride_acc_d
+    )
+    running_max = tl.load(max_score_ptr + state_offset)
+    running_denom = tl.load(denom_ptr + state_offset)
+    running_acc = tl.load(acc_ptr + acc_offset, mask=dim_mask, other=0.0).to(tl.float32)
+
+    seq_len = tl.load(seq_lens_ptr + token_idx)
+    gather_len = tl.load(gather_lens_ptr + token_idx)
+    start_pos = seq_len - gather_len
+    fp8_mask = offsets < fp8_dim
+    rope_mask = (offsets >= fp8_dim) & dim_mask
+    rope_offsets = tl.maximum(offsets - fp8_dim, 0)
+    # Per-token early-loop-exit (see indexed kernel comment).
+    local_eff = tl.minimum(
+        num_candidates,
+        tl.maximum(gather_len - candidate_offset, 0),
+    )
+
+    # ``gather_idx < gather_len`` is structurally guaranteed by the
+    # ``local_eff`` cap above; the body is unconditional.
+    for candidate_idx in range(0, local_eff):
+        gather_idx = candidate_offset + candidate_idx
+        pos = start_pos + gather_idx
+        block_in_seq = pos // cache_block_size
+        pos_in_block = pos % cache_block_size
+        physical_block = tl.load(
+            block_table_ptr + token_idx * stride_block_table_t + block_in_seq
+        )
+        cache_block_ptr = k_cache_ptr + physical_block.to(tl.int64) * block_stride
+        token_data_ptr = cache_block_ptr + pos_in_block * token_data_size
+        token_scale_ptr = (
+            cache_block_ptr
+            + cache_block_size * token_data_size
+            + pos_in_block * scale_dim
+        )
+
+        x_uint8 = tl.load(token_data_ptr + offsets, mask=fp8_mask, other=0)
+        x_fp8 = x_uint8.to(tl.float8e4nv, bitcast=True)
+        x_float = x_fp8.to(tl.float32)
+        scale_offsets = offsets // quant_block
+        encoded_scale = tl.load(
+            token_scale_ptr + scale_offsets,
+            mask=fp8_mask,
+            other=127,
+        )
+        dequant_scale = tl.exp2(encoded_scale.to(tl.float32) - 127.0)
+        x_dequant = x_float * dequant_scale
+
+        rope_ptr = (token_data_ptr + fp8_dim).to(tl.pointer_type(tl.bfloat16))
+        rope = tl.load(rope_ptr + rope_offsets, mask=rope_mask, other=0.0).to(
+            tl.float32
+        )
+        kv = tl.where(fp8_mask, x_dequant, rope)
+        kv = tl.where(dim_mask, kv, 0.0)
+
+        score = tl.sum(q * kv, axis=0) * scale
+        next_max = tl.maximum(running_max, score)
+        previous_weight = tl.exp(running_max - next_max)
+        candidate_weight = tl.exp(score - next_max)
+        running_acc = running_acc * previous_weight + kv * candidate_weight
+        running_denom = running_denom * previous_weight + candidate_weight
+        running_max = next_max
+
+    tl.store(max_score_ptr + state_offset, running_max)
+    tl.store(denom_ptr + state_offset, running_denom)
+    tl.store(acc_ptr + acc_offset, running_acc, mask=dim_mask)
+
+
+def accumulate_fp8ds_paged_sparse_mla_attention_chunk(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    scale: float,
+    max_score: torch.Tensor,
+    denom: torch.Tensor,
+    acc: torch.Tensor,
+    candidate_offset: int,
+    num_candidates: int,
+) -> None:
+    if q.dim() == 4:
+        assert q.shape[1] == 1
+        q = q[:, 0]
+
+    assert q.dim() == 3, f"Expected q shape [T, H, D], got {q.shape}"
+    assert q.shape[-1] == 512
+    assert seq_lens.shape[0] == q.shape[0]
+    assert gather_lens.shape[0] == q.shape[0]
+    assert block_table.shape[0] == q.shape[0]
+    assert max_score.shape[0] == q.shape[0]
+    assert max_score.shape[1] <= q.shape[1]
+    assert denom.shape == max_score.shape
+    assert acc.shape == (*max_score.shape, q.shape[-1])
+    assert max_score.dtype == torch.float32
+    assert denom.dtype == torch.float32
+    assert acc.dtype == torch.float32
+    assert k_cache.dtype == torch.uint8
+    assert q.is_cuda and k_cache.is_cuda
+    assert seq_lens.is_cuda and gather_lens.is_cuda and block_table.is_cuda
+    assert max_score.is_cuda and denom.is_cuda and acc.is_cuda
+
+    token_fp8_dim = 448
+    token_bf16_dim = 64
+    token_scale_dim = 8
+    quant_block_size = 64
+    token_data_size = token_fp8_dim + token_bf16_dim * 2
+
+    num_tokens, _, head_dim = q.shape
+    num_heads = max_score.shape[1]
+    block_d = min(1024, next_power_of_2(head_dim))
+    grid = (num_tokens, num_heads)
+    _accumulate_fp8ds_paged_attention_chunk_kernel[grid](
+        q,
+        k_cache,
+        seq_lens,
+        gather_lens,
+        block_table,
+        max_score,
+        denom,
+        acc,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        block_table.stride(0),
+        max_score.stride(0),
+        max_score.stride(1),
+        acc.stride(0),
+        acc.stride(1),
+        acc.stride(2),
+        block_size,
+        token_data_size,
+        k_cache.stride(0),
+        token_fp8_dim,
+        token_scale_dim,
+        quant_block_size,
+        num_heads,
+        head_dim,
+        num_candidates,
+        candidate_offset,
+        scale,
+        BLOCK_D=block_d,
+        # num_warps / num_stages supplied by @triton.autotune above.
+    )
+
+
+@triton.jit
+def _accumulate_fp8ds_paged_attention_chunk_multihead_kernel(
+    q_ptr,
+    k_cache_ptr,
+    seq_lens_ptr,
+    gather_lens_ptr,
+    block_table_ptr,
+    max_score_ptr,
+    denom_ptr,
+    acc_ptr,
+    stride_q_t: tl.constexpr,
+    stride_q_h: tl.constexpr,
+    stride_q_d: tl.constexpr,
+    stride_block_table_t,
+    stride_state_t: tl.constexpr,
+    stride_state_h: tl.constexpr,
+    stride_acc_t: tl.constexpr,
+    stride_acc_h: tl.constexpr,
+    stride_acc_d: tl.constexpr,
+    cache_block_size: tl.constexpr,
+    token_data_size: tl.constexpr,
+    block_stride: tl.constexpr,
+    fp8_dim: tl.constexpr,
+    scale_dim: tl.constexpr,
+    quant_block: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    num_candidates,
+    candidate_offset,
+    scale: tl.constexpr,
+    HEAD_BLOCK: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_block_idx = tl.program_id(1)
+    head_offsets = head_block_idx * HEAD_BLOCK + tl.arange(0, HEAD_BLOCK)
+    dim_offsets = tl.arange(0, BLOCK_D)
+    head_mask = head_offsets < num_heads
+    dim_mask = dim_offsets < head_dim
+    matrix_mask = head_mask[:, None] & dim_mask[None, :]
+
+    q = tl.load(
+        q_ptr
+        + token_idx * stride_q_t
+        + head_offsets[:, None] * stride_q_h
+        + dim_offsets[None, :] * stride_q_d,
+        mask=matrix_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    state_offsets = token_idx * stride_state_t + head_offsets * stride_state_h
+    acc_offsets = (
+        token_idx * stride_acc_t
+        + head_offsets[:, None] * stride_acc_h
+        + dim_offsets[None, :] * stride_acc_d
+    )
+    running_max = tl.load(
+        max_score_ptr + state_offsets,
+        mask=head_mask,
+        other=-float("inf"),
+    )
+    running_denom = tl.load(denom_ptr + state_offsets, mask=head_mask, other=0.0)
+    running_acc = tl.load(acc_ptr + acc_offsets, mask=matrix_mask, other=0.0).to(
+        tl.float32
+    )
+
+    seq_len = tl.load(seq_lens_ptr + token_idx)
+    gather_len = tl.load(gather_lens_ptr + token_idx)
+    start_pos = seq_len - gather_len
+    fp8_mask = dim_offsets < fp8_dim
+    rope_mask = (dim_offsets >= fp8_dim) & dim_mask
+    rope_offsets = tl.maximum(dim_offsets - fp8_dim, 0)
+    # Per-token early-loop-exit: ``gather_len`` is the per-token count of
+    # cached entries available for this paged read; the existing
+    # ``is_valid`` guard skips heavy work past that, but we can also skip
+    # the per-iter index load + branch by capping the loop. CUDA-graph-
+    # safe because ``gather_lens_ptr`` is a stable address.
+    local_eff = tl.minimum(
+        num_candidates,
+        tl.maximum(gather_len - candidate_offset, 0),
+    )
+
+    # ``gather_idx < gather_len`` is structurally guaranteed by the
+    # ``local_eff`` cap above; the body is unconditional.
+    for candidate_idx in range(0, local_eff):
+        gather_idx = candidate_offset + candidate_idx
+        pos = start_pos + gather_idx
+        block_in_seq = pos // cache_block_size
+        pos_in_block = pos % cache_block_size
+        physical_block = tl.load(
+            block_table_ptr + token_idx * stride_block_table_t + block_in_seq
+        )
+        cache_block_ptr = k_cache_ptr + physical_block.to(tl.int64) * block_stride
+        token_data_ptr = cache_block_ptr + pos_in_block * token_data_size
+        token_scale_ptr = (
+            cache_block_ptr
+            + cache_block_size * token_data_size
+            + pos_in_block * scale_dim
+        )
+
+        x_uint8 = tl.load(token_data_ptr + dim_offsets, mask=fp8_mask, other=0)
+        x_fp8 = x_uint8.to(tl.float8e4nv, bitcast=True)
+        x_float = x_fp8.to(tl.float32)
+        scale_offsets = dim_offsets // quant_block
+        encoded_scale = tl.load(
+            token_scale_ptr + scale_offsets,
+            mask=fp8_mask,
+            other=127,
+        )
+        dequant_scale = tl.exp2(encoded_scale.to(tl.float32) - 127.0)
+        x_dequant = x_float * dequant_scale
+
+        rope_ptr = (token_data_ptr + fp8_dim).to(tl.pointer_type(tl.bfloat16))
+        rope = tl.load(rope_ptr + rope_offsets, mask=rope_mask, other=0.0).to(
+            tl.float32
+        )
+        kv = tl.where(fp8_mask, x_dequant, rope)
+        kv = tl.where(dim_mask, kv, 0.0)
+
+        score = tl.sum(q * kv[None, :], axis=1) * scale
+        next_max = tl.maximum(running_max, score)
+        previous_weight = tl.exp(running_max - next_max)
+        candidate_weight = tl.exp(score - next_max)
+        running_acc = (
+            running_acc * previous_weight[:, None]
+            + kv[None, :] * candidate_weight[:, None]
+        )
+        running_denom = running_denom * previous_weight + candidate_weight
+        running_max = next_max
+
+    tl.store(max_score_ptr + state_offsets, running_max, mask=head_mask)
+    tl.store(denom_ptr + state_offsets, running_denom, mask=head_mask)
+    tl.store(acc_ptr + acc_offsets, running_acc, mask=matrix_mask)
+
+
+def accumulate_fp8ds_paged_sparse_mla_attention_chunk_multihead(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    scale: float,
+    max_score: torch.Tensor,
+    denom: torch.Tensor,
+    acc: torch.Tensor,
+    candidate_offset: int,
+    num_candidates: int,
+    head_block_size: int = 2,
+) -> None:
+    if q.dim() == 4:
+        assert q.shape[1] == 1
+        q = q[:, 0]
+
+    assert q.dim() == 3, f"Expected q shape [T, H, D], got {q.shape}"
+    assert q.shape[-1] == 512
+    assert seq_lens.shape[0] == q.shape[0]
+    assert gather_lens.shape[0] == q.shape[0]
+    assert block_table.shape[0] == q.shape[0]
+    assert max_score.shape[0] == q.shape[0]
+    assert max_score.shape[1] <= q.shape[1]
+    assert denom.shape == max_score.shape
+    assert acc.shape == (*max_score.shape, q.shape[-1])
+    assert head_block_size in (1, 2, 4)
+    assert max_score.dtype == torch.float32
+    assert denom.dtype == torch.float32
+    assert acc.dtype == torch.float32
+    assert k_cache.dtype == torch.uint8
+    assert q.is_cuda and k_cache.is_cuda
+    assert seq_lens.is_cuda and gather_lens.is_cuda and block_table.is_cuda
+    assert max_score.is_cuda and denom.is_cuda and acc.is_cuda
+
+    token_fp8_dim = 448
+    token_bf16_dim = 64
+    token_scale_dim = 8
+    quant_block_size = 64
+    token_data_size = token_fp8_dim + token_bf16_dim * 2
+
+    num_tokens, _, head_dim = q.shape
+    num_heads = max_score.shape[1]
+    block_d = min(1024, next_power_of_2(head_dim))
+    grid = (num_tokens, triton.cdiv(num_heads, head_block_size))
+    _accumulate_fp8ds_paged_attention_chunk_multihead_kernel[grid](
+        q,
+        k_cache,
+        seq_lens,
+        gather_lens,
+        block_table,
+        max_score,
+        denom,
+        acc,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        block_table.stride(0),
+        max_score.stride(0),
+        max_score.stride(1),
+        acc.stride(0),
+        acc.stride(1),
+        acc.stride(2),
+        block_size,
+        token_data_size,
+        k_cache.stride(0),
+        token_fp8_dim,
+        token_scale_dim,
+        quant_block_size,
+        num_heads,
+        head_dim,
+        num_candidates,
+        candidate_offset,
+        scale,
+        HEAD_BLOCK=head_block_size,
+        BLOCK_D=block_d,
+        num_warps=8,
+    )
+
+
+@triton.jit
+def _fp8ds_paged_attention_with_sink_multihead_kernel(
+    q_ptr,
+    k_cache_ptr,
+    seq_lens_ptr,
+    gather_lens_ptr,
+    block_table_ptr,
+    sink_ptr,
+    output_ptr,
+    stride_q_t: tl.constexpr,
+    stride_q_h: tl.constexpr,
+    stride_q_d: tl.constexpr,
+    stride_block_table_t,
+    stride_output_t: tl.constexpr,
+    stride_output_h: tl.constexpr,
+    stride_output_d: tl.constexpr,
+    cache_block_size: tl.constexpr,
+    token_data_size: tl.constexpr,
+    block_stride: tl.constexpr,
+    fp8_dim: tl.constexpr,
+    scale_dim: tl.constexpr,
+    quant_block: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    candidate_offset: tl.constexpr,
+    num_candidates: tl.constexpr,
+    scale: tl.constexpr,
+    HEAD_BLOCK: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_block_idx = tl.program_id(1)
+    head_offsets = head_block_idx * HEAD_BLOCK + tl.arange(0, HEAD_BLOCK)
+    dim_offsets = tl.arange(0, BLOCK_D)
+    head_mask = head_offsets < num_heads
+    dim_mask = dim_offsets < head_dim
+    matrix_mask = head_mask[:, None] & dim_mask[None, :]
+
+    q = tl.load(
+        q_ptr
+        + token_idx * stride_q_t
+        + head_offsets[:, None] * stride_q_h
+        + dim_offsets[None, :] * stride_q_d,
+        mask=matrix_mask,
+        other=0.0,
+    ).to(tl.float32)
+    running_max = tl.full((HEAD_BLOCK,), -float("inf"), tl.float32)
+    running_denom = tl.zeros((HEAD_BLOCK,), tl.float32)
+    running_acc = tl.zeros((HEAD_BLOCK, BLOCK_D), tl.float32)
+
+    seq_len = tl.load(seq_lens_ptr + token_idx)
+    gather_len = tl.load(gather_lens_ptr + token_idx)
+    start_pos = seq_len - gather_len
+    fp8_mask = dim_offsets < fp8_dim
+    rope_mask = (dim_offsets >= fp8_dim) & dim_mask
+    rope_offsets = tl.maximum(dim_offsets - fp8_dim, 0)
+    # Per-token early-loop-exit: ``gather_len`` is the per-token count of
+    # cached entries available for this paged read; the existing
+    # ``is_valid`` guard skips heavy work past that, but we can also skip
+    # the per-iter index load + branch by capping the loop. CUDA-graph-
+    # safe because ``gather_lens_ptr`` is a stable address.
+    local_eff = tl.minimum(
+        num_candidates,
+        tl.maximum(gather_len - candidate_offset, 0),
+    )
+
+    # ``gather_idx < gather_len`` is structurally guaranteed by the
+    # ``local_eff`` cap above; the body is unconditional.
+    for candidate_idx in range(0, local_eff):
+        gather_idx = candidate_offset + candidate_idx
+        pos = start_pos + gather_idx
+        block_in_seq = pos // cache_block_size
+        pos_in_block = pos % cache_block_size
+        physical_block = tl.load(
+            block_table_ptr + token_idx * stride_block_table_t + block_in_seq
+        )
+        cache_block_ptr = k_cache_ptr + physical_block.to(tl.int64) * block_stride
+        token_data_ptr = cache_block_ptr + pos_in_block * token_data_size
+        token_scale_ptr = (
+            cache_block_ptr
+            + cache_block_size * token_data_size
+            + pos_in_block * scale_dim
+        )
+
+        x_uint8 = tl.load(token_data_ptr + dim_offsets, mask=fp8_mask, other=0)
+        x_fp8 = x_uint8.to(tl.float8e4nv, bitcast=True)
+        x_float = x_fp8.to(tl.float32)
+        scale_offsets = dim_offsets // quant_block
+        encoded_scale = tl.load(
+            token_scale_ptr + scale_offsets,
+            mask=fp8_mask,
+            other=127,
+        )
+        dequant_scale = tl.exp2(encoded_scale.to(tl.float32) - 127.0)
+        x_dequant = x_float * dequant_scale
+
+        rope_ptr = (token_data_ptr + fp8_dim).to(tl.pointer_type(tl.bfloat16))
+        rope = tl.load(rope_ptr + rope_offsets, mask=rope_mask, other=0.0).to(
+            tl.float32
+        )
+        kv = tl.where(fp8_mask, x_dequant, rope)
+        kv = tl.where(dim_mask, kv, 0.0)
+
+        score = tl.sum(q * kv[None, :], axis=1) * scale
+        next_max = tl.maximum(running_max, score)
+        previous_weight = tl.exp(running_max - next_max)
+        candidate_weight = tl.exp(score - next_max)
+        running_acc = (
+            running_acc * previous_weight[:, None]
+            + kv[None, :] * candidate_weight[:, None]
+        )
+        running_denom = running_denom * previous_weight + candidate_weight
+        running_max = next_max
+
+    sink = tl.load(sink_ptr + head_offsets, mask=head_mask, other=-float("inf"))
+    has_tokens = running_denom > 0.0
+    has_sink = sink > -float("inf")
+    valid_max = tl.where(has_tokens, running_max, -float("inf"))
+    valid_sink = tl.where(has_sink, sink, -float("inf"))
+    merge_max = tl.maximum(valid_max, valid_sink)
+    has_any = has_tokens | has_sink
+    safe_merge_max = tl.where(has_any, merge_max, 0.0)
+    safe_running_max = tl.where(has_tokens, running_max, safe_merge_max)
+    safe_sink = tl.where(has_sink, sink, safe_merge_max)
+    subset_scale = tl.where(has_tokens, tl.exp(safe_running_max - safe_merge_max), 0.0)
+    sink_weight = tl.where(has_sink, tl.exp(safe_sink - safe_merge_max), 0.0)
+    total_weight = running_denom * subset_scale + sink_weight
+    inv_total = tl.where(total_weight > 0.0, 1.0 / total_weight, 0.0)
+    final = running_acc * subset_scale[:, None] * inv_total[:, None]
+
+    tl.store(
+        output_ptr
+        + token_idx * stride_output_t
+        + head_offsets[:, None] * stride_output_h
+        + dim_offsets[None, :] * stride_output_d,
+        final,
+        mask=matrix_mask,
+    )
+
+
+def fp8ds_paged_sparse_mla_attention_with_sink_multihead(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    candidate_offset: int,
+    num_candidates: int,
+    scale: float,
+    attn_sink: torch.Tensor,
+    output: torch.Tensor,
+    head_block_size: int = 1,
+    num_heads: int | None = None,
+) -> None:
+    if q.dim() == 4:
+        assert q.shape[1] == 1
+        q = q[:, 0]
+
+    assert q.dim() == 3, f"Expected q shape [T, H, D], got {q.shape}"
+    assert q.shape[-1] == 512
+    assert seq_lens.shape[0] == q.shape[0]
+    assert gather_lens.shape[0] == q.shape[0]
+    assert block_table.shape[0] == q.shape[0]
+    assert output.shape[0] == q.shape[0]
+    assert output.shape[2] == q.shape[-1]
+    assert head_block_size in (1, 2, 4)
+    assert k_cache.dtype == torch.uint8
+    assert q.is_cuda and k_cache.is_cuda
+    assert seq_lens.is_cuda and gather_lens.is_cuda and block_table.is_cuda
+    assert attn_sink.is_cuda and output.is_cuda
+
+    token_fp8_dim = 448
+    token_bf16_dim = 64
+    token_scale_dim = 8
+    quant_block_size = 64
+    token_data_size = token_fp8_dim + token_bf16_dim * 2
+
+    num_tokens, _, head_dim = q.shape
+    active_heads = num_heads if num_heads is not None else output.shape[1]
+    assert active_heads <= q.shape[1]
+    assert active_heads <= output.shape[1]
+    assert active_heads <= attn_sink.shape[0]
+    block_d = min(1024, next_power_of_2(head_dim))
+    grid = (num_tokens, triton.cdiv(active_heads, head_block_size))
+    _fp8ds_paged_attention_with_sink_multihead_kernel[grid](
+        q,
+        k_cache,
+        seq_lens,
+        gather_lens,
+        block_table,
+        attn_sink,
+        output,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        block_table.stride(0),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        block_size,
+        token_data_size,
+        k_cache.stride(0),
+        token_fp8_dim,
+        token_scale_dim,
+        quant_block_size,
+        active_heads,
+        head_dim,
+        candidate_offset,
+        num_candidates,
+        scale,
+        HEAD_BLOCK=head_block_size,
+        BLOCK_D=block_d,
+        num_warps=8,
+    )
+
+
+@triton.jit
+def _fp8ds_global_paged_attention_with_sink_multihead_kernel(
+    q_ptr,
+    compressed_k_cache_ptr,
+    slot_ids_ptr,
+    topk_lens_ptr,
+    swa_k_cache_ptr,
+    seq_lens_ptr,
+    gather_lens_ptr,
+    block_table_ptr,
+    sink_ptr,
+    output_ptr,
+    stride_q_t: tl.constexpr,
+    stride_q_h: tl.constexpr,
+    stride_q_d: tl.constexpr,
+    stride_slot_t: tl.constexpr,
+    stride_slot_c: tl.constexpr,
+    stride_block_table_t,
+    stride_output_t: tl.constexpr,
+    stride_output_h: tl.constexpr,
+    stride_output_d: tl.constexpr,
+    compressed_cache_block_size: tl.constexpr,
+    compressed_block_stride: tl.constexpr,
+    swa_cache_block_size: tl.constexpr,
+    swa_block_stride: tl.constexpr,
+    token_data_size: tl.constexpr,
+    fp8_dim: tl.constexpr,
+    scale_dim: tl.constexpr,
+    quant_block: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    num_compressed_candidates: tl.constexpr,
+    num_swa_candidates: tl.constexpr,
+    scale: tl.constexpr,
+    HEAD_BLOCK: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_block_idx = tl.program_id(1)
+    head_offsets = head_block_idx * HEAD_BLOCK + tl.arange(0, HEAD_BLOCK)
+    dim_offsets = tl.arange(0, BLOCK_D)
+    head_mask = head_offsets < num_heads
+    dim_mask = dim_offsets < head_dim
+    matrix_mask = head_mask[:, None] & dim_mask[None, :]
+
+    q = tl.load(
+        q_ptr
+        + token_idx * stride_q_t
+        + head_offsets[:, None] * stride_q_h
+        + dim_offsets[None, :] * stride_q_d,
+        mask=matrix_mask,
+        other=0.0,
+    ).to(tl.float32)
+    running_max = tl.full((HEAD_BLOCK,), -float("inf"), tl.float32)
+    running_denom = tl.zeros((HEAD_BLOCK,), tl.float32)
+    running_acc = tl.zeros((HEAD_BLOCK, BLOCK_D), tl.float32)
+
+    fp8_mask = dim_offsets < fp8_dim
+    rope_mask = (dim_offsets >= fp8_dim) & dim_mask
+    rope_offsets = tl.maximum(dim_offsets - fp8_dim, 0)
+    topk_len = tl.load(topk_lens_ptr + token_idx)
+
+    for candidate_idx in range(0, num_compressed_candidates):
+        slot_id = tl.load(
+            slot_ids_ptr + token_idx * stride_slot_t + candidate_idx * stride_slot_c
+        )
+        is_valid = (candidate_idx < topk_len) & (slot_id >= 0)
+        if is_valid:
+            block_idx = slot_id // compressed_cache_block_size
+            pos_in_block = slot_id % compressed_cache_block_size
+            cache_block_ptr = (
+                compressed_k_cache_ptr
+                + block_idx.to(tl.int64) * compressed_block_stride
+            )
+            token_data_ptr = cache_block_ptr + pos_in_block * token_data_size
+            token_scale_ptr = (
+                cache_block_ptr
+                + compressed_cache_block_size * token_data_size
+                + pos_in_block * scale_dim
+            )
+
+            x_uint8 = tl.load(token_data_ptr + dim_offsets, mask=fp8_mask, other=0)
+            x_fp8 = x_uint8.to(tl.float8e4nv, bitcast=True)
+            x_float = x_fp8.to(tl.float32)
+            scale_offsets = dim_offsets // quant_block
+            encoded_scale = tl.load(
+                token_scale_ptr + scale_offsets,
+                mask=fp8_mask,
+                other=127,
+            )
+            dequant_scale = tl.exp2(encoded_scale.to(tl.float32) - 127.0)
+            x_dequant = x_float * dequant_scale
+            rope_ptr = (token_data_ptr + fp8_dim).to(tl.pointer_type(tl.bfloat16))
+            rope = tl.load(rope_ptr + rope_offsets, mask=rope_mask, other=0.0).to(
+                tl.float32
+            )
+            kv = tl.where(fp8_mask, x_dequant, rope)
+            kv = tl.where(dim_mask, kv, 0.0)
+
+            score = tl.sum(q * kv[None, :], axis=1) * scale
+            next_max = tl.maximum(running_max, score)
+            previous_weight = tl.exp(running_max - next_max)
+            candidate_weight = tl.exp(score - next_max)
+            running_acc = (
+                running_acc * previous_weight[:, None]
+                + kv[None, :] * candidate_weight[:, None]
+            )
+            running_denom = running_denom * previous_weight + candidate_weight
+            running_max = next_max
+
+    seq_len = tl.load(seq_lens_ptr + token_idx)
+    gather_len = tl.load(gather_lens_ptr + token_idx)
+    start_pos = seq_len - gather_len
+    for candidate_idx in range(0, num_swa_candidates):
+        is_valid = candidate_idx < gather_len
+        if is_valid:
+            pos = start_pos + candidate_idx
+            block_in_seq = pos // swa_cache_block_size
+            pos_in_block = pos % swa_cache_block_size
+            physical_block = tl.load(
+                block_table_ptr + token_idx * stride_block_table_t + block_in_seq
+            )
+            cache_block_ptr = (
+                swa_k_cache_ptr + physical_block.to(tl.int64) * swa_block_stride
+            )
+            token_data_ptr = cache_block_ptr + pos_in_block * token_data_size
+            token_scale_ptr = (
+                cache_block_ptr
+                + swa_cache_block_size * token_data_size
+                + pos_in_block * scale_dim
+            )
+
+            x_uint8 = tl.load(token_data_ptr + dim_offsets, mask=fp8_mask, other=0)
+            x_fp8 = x_uint8.to(tl.float8e4nv, bitcast=True)
+            x_float = x_fp8.to(tl.float32)
+            scale_offsets = dim_offsets // quant_block
+            encoded_scale = tl.load(
+                token_scale_ptr + scale_offsets,
+                mask=fp8_mask,
+                other=127,
+            )
+            dequant_scale = tl.exp2(encoded_scale.to(tl.float32) - 127.0)
+            x_dequant = x_float * dequant_scale
+            rope_ptr = (token_data_ptr + fp8_dim).to(tl.pointer_type(tl.bfloat16))
+            rope = tl.load(rope_ptr + rope_offsets, mask=rope_mask, other=0.0).to(
+                tl.float32
+            )
+            kv = tl.where(fp8_mask, x_dequant, rope)
+            kv = tl.where(dim_mask, kv, 0.0)
+
+            score = tl.sum(q * kv[None, :], axis=1) * scale
+            next_max = tl.maximum(running_max, score)
+            previous_weight = tl.exp(running_max - next_max)
+            candidate_weight = tl.exp(score - next_max)
+            running_acc = (
+                running_acc * previous_weight[:, None]
+                + kv[None, :] * candidate_weight[:, None]
+            )
+            running_denom = running_denom * previous_weight + candidate_weight
+            running_max = next_max
+
+    sink = tl.load(sink_ptr + head_offsets, mask=head_mask, other=-float("inf"))
+    has_tokens = running_denom > 0.0
+    has_sink = sink > -float("inf")
+    valid_max = tl.where(has_tokens, running_max, -float("inf"))
+    valid_sink = tl.where(has_sink, sink, -float("inf"))
+    merge_max = tl.maximum(valid_max, valid_sink)
+    has_any = has_tokens | has_sink
+    safe_merge_max = tl.where(has_any, merge_max, 0.0)
+    safe_running_max = tl.where(has_tokens, running_max, safe_merge_max)
+    safe_sink = tl.where(has_sink, sink, safe_merge_max)
+    subset_scale = tl.where(has_tokens, tl.exp(safe_running_max - safe_merge_max), 0.0)
+    sink_weight = tl.where(has_sink, tl.exp(safe_sink - safe_merge_max), 0.0)
+    total_weight = running_denom * subset_scale + sink_weight
+    inv_total = tl.where(total_weight > 0.0, 1.0 / total_weight, 0.0)
+    final = running_acc * subset_scale[:, None] * inv_total[:, None]
+
+    tl.store(
+        output_ptr
+        + token_idx * stride_output_t
+        + head_offsets[:, None] * stride_output_h
+        + dim_offsets[None, :] * stride_output_d,
+        final,
+        mask=matrix_mask,
+    )
+
+
+def fp8ds_global_paged_sparse_mla_attention_with_sink_multihead(
+    q: torch.Tensor,
+    compressed_k_cache: torch.Tensor,
+    slot_ids: torch.Tensor,
+    topk_lens: torch.Tensor,
+    compressed_block_size: int,
+    swa_k_cache: torch.Tensor,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    swa_block_size: int,
+    num_compressed_candidates: int,
+    num_swa_candidates: int,
+    scale: float,
+    attn_sink: torch.Tensor,
+    output: torch.Tensor,
+    head_block_size: int = 1,
+    num_heads: int | None = None,
+) -> None:
+    if q.dim() == 4:
+        assert q.shape[1] == 1
+        q = q[:, 0]
+    if slot_ids.dim() == 3:
+        assert slot_ids.shape[1] == 1
+        slot_ids = slot_ids[:, 0]
+
+    assert q.dim() == 3, f"Expected q shape [T, H, D], got {q.shape}"
+    assert q.shape[-1] == 512
+    assert slot_ids.dim() == 2
+    assert slot_ids.shape[0] == q.shape[0]
+    assert topk_lens.shape[0] == q.shape[0]
+    assert seq_lens.shape[0] == q.shape[0]
+    assert gather_lens.shape[0] == q.shape[0]
+    assert block_table.shape[0] == q.shape[0]
+    assert output.shape[0] == q.shape[0]
+    assert output.shape[2] == q.shape[-1]
+    assert head_block_size in (1, 2, 4)
+    assert compressed_k_cache.dtype == torch.uint8
+    assert swa_k_cache.dtype == torch.uint8
+    assert q.is_cuda and compressed_k_cache.is_cuda and swa_k_cache.is_cuda
+    assert slot_ids.is_cuda and topk_lens.is_cuda
+    assert seq_lens.is_cuda and gather_lens.is_cuda and block_table.is_cuda
+    assert attn_sink.is_cuda and output.is_cuda
+
+    token_fp8_dim = 448
+    token_bf16_dim = 64
+    token_scale_dim = 8
+    quant_block_size = 64
+    token_data_size = token_fp8_dim + token_bf16_dim * 2
+
+    num_tokens, _, head_dim = q.shape
+    active_heads = num_heads if num_heads is not None else output.shape[1]
+    assert active_heads <= q.shape[1]
+    assert active_heads <= output.shape[1]
+    assert active_heads <= attn_sink.shape[0]
+    block_d = min(1024, next_power_of_2(head_dim))
+    grid = (num_tokens, triton.cdiv(active_heads, head_block_size))
+    _fp8ds_global_paged_attention_with_sink_multihead_kernel[grid](
+        q,
+        compressed_k_cache,
+        slot_ids,
+        topk_lens,
+        swa_k_cache,
+        seq_lens,
+        gather_lens,
+        block_table,
+        attn_sink,
+        output,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        slot_ids.stride(0),
+        slot_ids.stride(1),
+        block_table.stride(0),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        compressed_block_size,
+        compressed_k_cache.stride(0),
+        swa_block_size,
+        swa_k_cache.stride(0),
+        token_data_size,
+        token_fp8_dim,
+        token_scale_dim,
+        quant_block_size,
+        active_heads,
+        head_dim,
+        num_compressed_candidates,
+        num_swa_candidates,
+        scale,
+        HEAD_BLOCK=head_block_size,
+        BLOCK_D=block_d,
+        num_warps=8,
+    )
+
+
+@triton.jit
+def _finish_attention_state_kernel(
+    max_score_ptr,
+    denom_ptr,
+    acc_ptr,
+    output_ptr,
+    lse_ptr,
+    stride_state_t: tl.constexpr,
+    stride_state_h: tl.constexpr,
+    stride_acc_t: tl.constexpr,
+    stride_acc_h: tl.constexpr,
+    stride_acc_d: tl.constexpr,
+    stride_output_t: tl.constexpr,
+    stride_output_h: tl.constexpr,
+    stride_output_d: tl.constexpr,
+    stride_lse_t: tl.constexpr,
+    stride_lse_h: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_head = tl.program_id(0)
+    block_d = tl.program_id(1)
+    token_idx = token_head // num_heads
+    head_idx = token_head - token_idx * num_heads
+    offsets = block_d * BLOCK_D + tl.arange(0, BLOCK_D)
+    dim_mask = offsets < head_dim
+
+    state_offset = token_idx * stride_state_t + head_idx * stride_state_h
+    running_max = tl.load(max_score_ptr + state_offset)
+    running_denom = tl.load(denom_ptr + state_offset)
+    is_valid = running_denom > 0.0
+    inv_denom = tl.where(is_valid, 1.0 / running_denom, 0.0)
+    subset_lse = tl.where(
+        is_valid,
+        running_max + tl.log(running_denom),
+        -float("inf"),
+    )
+
+    acc = tl.load(
+        acc_ptr
+        + token_idx * stride_acc_t
+        + head_idx * stride_acc_h
+        + offsets * stride_acc_d,
+        mask=dim_mask,
+        other=0.0,
+    ).to(tl.float32)
+    subset_output = acc * inv_denom
+    tl.store(
+        output_ptr
+        + token_idx * stride_output_t
+        + head_idx * stride_output_h
+        + offsets * stride_output_d,
+        subset_output,
+        mask=dim_mask,
+    )
+    if block_d == 0:
+        tl.store(
+            lse_ptr + token_idx * stride_lse_t + head_idx * stride_lse_h,
+            subset_lse,
+        )
+
+
+def finish_gathered_sparse_mla_attention(
+    max_score: torch.Tensor,
+    denom: torch.Tensor,
+    acc: torch.Tensor,
+    output: torch.Tensor,
+    lse: torch.Tensor,
+) -> None:
+    assert max_score.shape == denom.shape
+    assert acc.shape[:2] == max_score.shape
+    assert output.shape == acc.shape
+    assert lse.shape == max_score.shape
+    assert max_score.dtype == torch.float32
+    assert denom.dtype == torch.float32
+    assert acc.dtype == torch.float32
+    assert output.dtype == torch.float32
+    assert lse.dtype == torch.float32
+    assert max_score.is_cuda and denom.is_cuda and acc.is_cuda
+    assert output.is_cuda and lse.is_cuda
+
+    num_tokens, num_heads, head_dim = acc.shape
+    block_d = min(128, next_power_of_2(head_dim))
+    grid = (num_tokens * num_heads, triton.cdiv(head_dim, block_d))
+    _finish_attention_state_kernel[grid](
+        max_score,
+        denom,
+        acc,
+        output,
+        lse,
+        max_score.stride(0),
+        max_score.stride(1),
+        acc.stride(0),
+        acc.stride(1),
+        acc.stride(2),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        lse.stride(0),
+        lse.stride(1),
+        num_heads,
+        head_dim,
+        BLOCK_D=block_d,
+        num_warps=4,
+    )
+
+
+@triton.jit
+def _finish_attention_state_with_sink_kernel(
+    max_score_ptr,
+    denom_ptr,
+    acc_ptr,
+    sink_ptr,
+    output_ptr,
+    stride_state_t: tl.constexpr,
+    stride_state_h: tl.constexpr,
+    stride_acc_t: tl.constexpr,
+    stride_acc_h: tl.constexpr,
+    stride_acc_d: tl.constexpr,
+    stride_output_t: tl.constexpr,
+    stride_output_h: tl.constexpr,
+    stride_output_d: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_head = tl.program_id(0)
+    block_d = tl.program_id(1)
+    token_idx = token_head // num_heads
+    head_idx = token_head - token_idx * num_heads
+    offsets = block_d * BLOCK_D + tl.arange(0, BLOCK_D)
+    dim_mask = offsets < head_dim
+
+    state_offset = token_idx * stride_state_t + head_idx * stride_state_h
+    running_max = tl.load(max_score_ptr + state_offset)
+    running_denom = tl.load(denom_ptr + state_offset)
+    sink = tl.load(sink_ptr + head_idx)
+    has_tokens = running_denom > 0.0
+    has_sink = sink > -float("inf")
+    valid_max = tl.where(has_tokens, running_max, -float("inf"))
+    valid_sink = tl.where(has_sink, sink, -float("inf"))
+    merge_max = tl.maximum(valid_max, valid_sink)
+    has_any = has_tokens | has_sink
+    safe_merge_max = tl.where(has_any, merge_max, 0.0)
+    safe_running_max = tl.where(has_tokens, running_max, safe_merge_max)
+    safe_sink = tl.where(has_sink, sink, safe_merge_max)
+    subset_scale = tl.where(has_tokens, tl.exp(safe_running_max - safe_merge_max), 0.0)
+    subset_weight = running_denom * subset_scale
+    sink_weight = tl.where(has_sink, tl.exp(safe_sink - safe_merge_max), 0.0)
+    total_weight = subset_weight + sink_weight
+    inv_total = tl.where(total_weight > 0.0, 1.0 / total_weight, 0.0)
+
+    acc_values = tl.load(
+        acc_ptr
+        + token_idx * stride_acc_t
+        + head_idx * stride_acc_h
+        + offsets * stride_acc_d,
+        mask=dim_mask,
+        other=0.0,
+    ).to(tl.float32)
+    acc_values = tl.where(has_tokens, acc_values, 0.0)
+    output = acc_values * subset_scale * inv_total
+    tl.store(
+        output_ptr
+        + token_idx * stride_output_t
+        + head_idx * stride_output_h
+        + offsets * stride_output_d,
+        output,
+        mask=dim_mask,
+    )
+
+
+@triton.jit
+def _finish_two_attention_states_with_sink_kernel(
+    max0_ptr,
+    denom0_ptr,
+    acc0_ptr,
+    max1_ptr,
+    denom1_ptr,
+    acc1_ptr,
+    sink_ptr,
+    output_ptr,
+    stride_state0_t: tl.constexpr,
+    stride_state0_h: tl.constexpr,
+    stride_acc0_t: tl.constexpr,
+    stride_acc0_h: tl.constexpr,
+    stride_acc0_d: tl.constexpr,
+    stride_state1_t: tl.constexpr,
+    stride_state1_h: tl.constexpr,
+    stride_acc1_t: tl.constexpr,
+    stride_acc1_h: tl.constexpr,
+    stride_acc1_d: tl.constexpr,
+    stride_output_t: tl.constexpr,
+    stride_output_h: tl.constexpr,
+    stride_output_d: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_head = tl.program_id(0)
+    block_d = tl.program_id(1)
+    token_idx = token_head // num_heads
+    head_idx = token_head - token_idx * num_heads
+    offsets = block_d * BLOCK_D + tl.arange(0, BLOCK_D)
+    dim_mask = offsets < head_dim
+
+    state0_offset = token_idx * stride_state0_t + head_idx * stride_state0_h
+    state1_offset = token_idx * stride_state1_t + head_idx * stride_state1_h
+    max0 = tl.load(max0_ptr + state0_offset)
+    denom0 = tl.load(denom0_ptr + state0_offset)
+    max1 = tl.load(max1_ptr + state1_offset)
+    denom1 = tl.load(denom1_ptr + state1_offset)
+    sink = tl.load(sink_ptr + head_idx)
+
+    has0 = denom0 > 0.0
+    has1 = denom1 > 0.0
+    has_sink = sink > -float("inf")
+    valid_max0 = tl.where(has0, max0, -float("inf"))
+    valid_max1 = tl.where(has1, max1, -float("inf"))
+    valid_sink = tl.where(has_sink, sink, -float("inf"))
+    merge_max = tl.maximum(tl.maximum(valid_max0, valid_max1), valid_sink)
+    has_any = has0 | has1 | has_sink
+    safe_merge_max = tl.where(has_any, merge_max, 0.0)
+    safe_max0 = tl.where(has0, max0, safe_merge_max)
+    safe_max1 = tl.where(has1, max1, safe_merge_max)
+    safe_sink = tl.where(has_sink, sink, safe_merge_max)
+    scale0 = tl.where(has0, tl.exp(safe_max0 - safe_merge_max), 0.0)
+    scale1 = tl.where(has1, tl.exp(safe_max1 - safe_merge_max), 0.0)
+    sink_weight = tl.where(has_sink, tl.exp(safe_sink - safe_merge_max), 0.0)
+    total_weight = denom0 * scale0 + denom1 * scale1 + sink_weight
+    inv_total = tl.where(total_weight > 0.0, 1.0 / total_weight, 0.0)
+
+    acc0 = tl.load(
+        acc0_ptr
+        + token_idx * stride_acc0_t
+        + head_idx * stride_acc0_h
+        + offsets * stride_acc0_d,
+        mask=dim_mask,
+        other=0.0,
+    ).to(tl.float32)
+    acc1 = tl.load(
+        acc1_ptr
+        + token_idx * stride_acc1_t
+        + head_idx * stride_acc1_h
+        + offsets * stride_acc1_d,
+        mask=dim_mask,
+        other=0.0,
+    ).to(tl.float32)
+    acc0 = tl.where(has0, acc0, 0.0)
+    acc1 = tl.where(has1, acc1, 0.0)
+    output = (acc0 * scale0 + acc1 * scale1) * inv_total
+    tl.store(
+        output_ptr
+        + token_idx * stride_output_t
+        + head_idx * stride_output_h
+        + offsets * stride_output_d,
+        output,
+        mask=dim_mask,
+    )
+
+
+def finish_two_sparse_mla_attention_states_with_sink(
+    max_score0: torch.Tensor,
+    denom0: torch.Tensor,
+    acc0: torch.Tensor,
+    max_score1: torch.Tensor,
+    denom1: torch.Tensor,
+    acc1: torch.Tensor,
+    attn_sink: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    assert max_score0.shape == denom0.shape
+    assert max_score1.shape == denom1.shape
+    assert max_score0.shape == max_score1.shape
+    assert acc0.shape == acc1.shape
+    assert acc0.shape[:2] == max_score0.shape
+    assert output.shape[0] == acc0.shape[0]
+    assert output.shape[1] >= acc0.shape[1]
+    assert output.shape[2] == acc0.shape[2]
+    assert attn_sink.shape[0] >= acc0.shape[1]
+    assert max_score0.dtype == torch.float32
+    assert denom0.dtype == torch.float32
+    assert acc0.dtype == torch.float32
+    assert max_score1.dtype == torch.float32
+    assert denom1.dtype == torch.float32
+    assert acc1.dtype == torch.float32
+    assert max_score0.is_cuda and denom0.is_cuda and acc0.is_cuda
+    assert max_score1.is_cuda and denom1.is_cuda and acc1.is_cuda
+    assert attn_sink.is_cuda and output.is_cuda
+
+    num_tokens, num_heads, head_dim = acc0.shape
+    block_d = min(128, next_power_of_2(head_dim))
+    grid = (num_tokens * num_heads, triton.cdiv(head_dim, block_d))
+    _finish_two_attention_states_with_sink_kernel[grid](
+        max_score0,
+        denom0,
+        acc0,
+        max_score1,
+        denom1,
+        acc1,
+        attn_sink,
+        output,
+        max_score0.stride(0),
+        max_score0.stride(1),
+        acc0.stride(0),
+        acc0.stride(1),
+        acc0.stride(2),
+        max_score1.stride(0),
+        max_score1.stride(1),
+        acc1.stride(0),
+        acc1.stride(1),
+        acc1.stride(2),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        num_heads,
+        head_dim,
+        BLOCK_D=block_d,
+        num_warps=4,
+    )
+
+
+def finish_sparse_mla_attention_with_sink(
+    max_score: torch.Tensor,
+    denom: torch.Tensor,
+    acc: torch.Tensor,
+    attn_sink: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    assert max_score.shape == denom.shape
+    assert acc.shape[:2] == max_score.shape
+    assert output.shape[0] == acc.shape[0]
+    assert output.shape[1] >= acc.shape[1]
+    assert output.shape[2] == acc.shape[2]
+    assert attn_sink.shape[0] >= acc.shape[1]
+    assert max_score.dtype == torch.float32
+    assert denom.dtype == torch.float32
+    assert acc.dtype == torch.float32
+    assert max_score.is_cuda and denom.is_cuda and acc.is_cuda
+    assert attn_sink.is_cuda and output.is_cuda
+
+    num_tokens, num_heads, head_dim = acc.shape
+    block_d = min(128, next_power_of_2(head_dim))
+    grid = (num_tokens * num_heads, triton.cdiv(head_dim, block_d))
+    _finish_attention_state_with_sink_kernel[grid](
+        max_score,
+        denom,
+        acc,
+        attn_sink,
+        output,
+        max_score.stride(0),
+        max_score.stride(1),
+        acc.stride(0),
+        acc.stride(1),
+        acc.stride(2),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        num_heads,
+        head_dim,
+        BLOCK_D=block_d,
+        num_warps=4,
+    )

--- a/vllm/v1/attention/ops/deepseek_v4_ops/__init__.py
+++ b/vllm/v1/attention/ops/deepseek_v4_ops/__init__.py
@@ -1,0 +1,2 @@
+# Auto-created by glm52-sm12x-sparse mod — provides deepseek_v4_ops package
+# for SM12x Triton sparse-MLA kernels.

--- a/vllm/v1/attention/ops/deepseek_v4_ops/b12x_sparse_helpers.py
+++ b/vllm/v1/attention/ops/deepseek_v4_ops/b12x_sparse_helpers.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Optional B12x sparse-MLA helpers for GLM fp8_ds_mla cache experiments."""
+
+from __future__ import annotations
+
+import os
+import math
+
+import torch
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_GLM_HEAD_DIM = 576
+_GLM_VALUE_DIM = 512
+_GLM_RECORD_BYTES = 656
+
+
+def b12x_mla_enabled() -> bool:
+    return os.getenv("GLM52_B12X_MLA", "0").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _profile_enabled() -> bool:
+    return os.getenv("GLM52_PREFILL_PROFILE", "0").lower() not in {
+        "",
+        "0",
+        "false",
+        "no",
+    }
+
+
+def _cuda_capture_active() -> bool:
+    is_capturing = getattr(torch.cuda, "is_current_stream_capturing", None)
+    return bool(is_capturing and is_capturing())
+
+
+class _CudaProfileRegion:
+    def __init__(self, region: str, **fields: object) -> None:
+        self.region = region
+        self.fields = fields
+        self.enabled = (
+            _profile_enabled()
+            and torch.cuda.is_available()
+            and not _cuda_capture_active()
+        )
+        self.start_event: torch.cuda.Event | None = None
+        self.end_event: torch.cuda.Event | None = None
+
+    def start(self) -> None:
+        if not self.enabled:
+            return
+        torch.cuda.nvtx.range_push(f"glm52:{self.region}")
+        self.start_event = torch.cuda.Event(enable_timing=True)
+        self.end_event = torch.cuda.Event(enable_timing=True)
+        self.start_event.record()
+
+    def stop(self) -> None:
+        if not self.enabled or self.start_event is None or self.end_event is None:
+            return
+        self.end_event.record()
+        torch.cuda.synchronize()
+        torch.cuda.nvtx.range_pop()
+        details = " ".join(f"{key}={value}" for key, value in self.fields.items())
+        logger.info(
+            "GLM52_PREFILL_PROFILE region=%s elapsed_ms=%.3f %s",
+            self.region,
+            self.start_event.elapsed_time(self.end_event),
+            details,
+        )
+
+
+def b12x_glm_mla_attention(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    topk_indices: torch.Tensor,
+    softmax_scale: float,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """Run B12x GLM_NSA sparse MLA over global-slot top-k indices.
+
+    Args:
+        q: [batch, seq, heads, 576] bf16 query tensor.
+        kv_cache: fp8_ds_mla cache, either [blocks, block, 656] or
+            [blocks, block, 1, 656] uint8-compatible storage.
+        topk_indices: [batch, seq, topk] int32 global physical slot ids.
+        softmax_scale: attention scale.
+
+    Returns:
+        (out [batch, seq, heads, 512], lse [batch, heads, seq]) or None when the
+        optional B12x package/path is unavailable or the shape is unsupported.
+    """
+    if not b12x_mla_enabled():
+        return None
+    if q.dim() != 4 or q.shape[-1] != _GLM_HEAD_DIM:
+        return None
+    if topk_indices.dim() != 3:
+        return None
+    if kv_cache.dtype != torch.uint8:
+        kv_cache = kv_cache.view(torch.uint8)
+    if kv_cache.shape[-1] != _GLM_RECORD_BYTES:
+        return None
+
+    batch, seq_len, num_heads, _ = q.shape
+    if num_heads % 16 != 0:
+        logger.warning_once(
+            "B12x GLM sparse MLA skipped: num_heads=%s is not divisible by 16",
+            num_heads,
+        )
+        return None
+
+    try:
+        from b12x.attention.mla.prefill_mg import run_unified_prefill_mg
+        from b12x.attention.mla.traits import ComputeMode, ModelType, ScaleFormat
+    except Exception as exc:
+        logger.warning_once("B12x GLM sparse MLA unavailable: %r", exc)
+        return None
+
+    q_flat = q.reshape(batch * seq_len, num_heads, _GLM_HEAD_DIM).contiguous()
+    indices_flat = topk_indices.reshape(batch * seq_len, topk_indices.shape[-1])
+    indices_flat = indices_flat.to(device=q.device, dtype=torch.int32).contiguous()
+    kv_flat = kv_cache.reshape(-1, 1, _GLM_RECORD_BYTES).contiguous()
+    mg_n_hg = 2 if num_heads % 32 == 0 else 1
+
+    profile = _CudaProfileRegion(
+        "attention.b12x_glm_mla",
+        q_shape=tuple(q.shape),
+        kv_shape=tuple(kv_cache.shape),
+        topk=topk_indices.shape[-1],
+        mg_n_hg=mg_n_hg,
+    )
+    profile.start()
+    try:
+        out, lse = run_unified_prefill_mg(
+            q=q_flat,
+            kv_cache=kv_flat,
+            topk_indices=indices_flat,
+            sm_scale=float(softmax_scale),
+            page_block_size=1,
+            compute_mode=ComputeMode.FP8,
+            mg_n_hg=mg_n_hg,
+            model_type=ModelType.GLM_NSA,
+            scale_format=ScaleFormat.ARBITRARY_FP32,
+        )
+    finally:
+        profile.stop()
+    out = out.reshape(batch, seq_len, num_heads, _GLM_VALUE_DIM)
+    lse = lse.mul(math.log(2.0))
+    lse = lse.reshape(batch, seq_len, num_heads).permute(0, 2, 1).contiguous()
+    return out, lse

--- a/vllm/v1/attention/ops/deepseek_v4_ops/sm12x_deep_gemm_fallbacks.py
+++ b/vllm/v1/attention/ops/deepseek_v4_ops/sm12x_deep_gemm_fallbacks.py
@@ -1,0 +1,683 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""SM12x fallback implementations for DeepGEMM-only interfaces."""
+
+import os
+import torch
+
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+
+logger = init_logger(__name__)
+
+_SM120_MQA_LOGITS_MAX_SCORE_BYTES = 64 * 1024 * 1024
+_SM120_PAGED_MQA_TOPK_CHUNK_SIZE = 8192
+
+
+def _profile_enabled() -> bool:
+    return os.getenv("GLM52_PREFILL_PROFILE", "0").lower() not in {
+        "",
+        "0",
+        "false",
+        "no",
+    }
+
+
+def _mqa_logits_triton_enabled() -> bool:
+    return os.getenv("GLM52_MQA_LOGITS_TRITON", "1").lower() not in {
+        "",
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def _paged_mqa_triton_enabled() -> bool:
+    return os.getenv("GLM52_PAGED_MQA_TRITON", "1").lower() not in {
+        "",
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def _paged_mqa_topk_chunk_size() -> int:
+    configured = os.getenv("GLM52_PAGED_MQA_TOPK_CHUNK_SIZE")
+    if configured is None:
+        return _SM120_PAGED_MQA_TOPK_CHUNK_SIZE
+    try:
+        parsed = int(configured)
+    except ValueError:
+        logger.warning_once(
+            "Invalid GLM52_PAGED_MQA_TOPK_CHUNK_SIZE=%r; using default %s",
+            configured,
+            _SM120_PAGED_MQA_TOPK_CHUNK_SIZE,
+        )
+        return _SM120_PAGED_MQA_TOPK_CHUNK_SIZE
+    return max(1, parsed)
+
+
+def _cuda_capture_active() -> bool:
+    is_capturing = getattr(torch.cuda, "is_current_stream_capturing", None)
+    return bool(is_capturing and is_capturing())
+
+
+class _CudaProfileRegion:
+    def __init__(self, region: str, **fields: object) -> None:
+        self.region = region
+        self.fields = fields
+        self.enabled = (
+            _profile_enabled()
+            and torch.cuda.is_available()
+            and not _cuda_capture_active()
+        )
+        self.start_event: torch.cuda.Event | None = None
+        self.end_event: torch.cuda.Event | None = None
+
+    def start(self) -> None:
+        if not self.enabled:
+            return
+        torch.cuda.nvtx.range_push(f"glm52:{self.region}")
+        self.start_event = torch.cuda.Event(enable_timing=True)
+        self.end_event = torch.cuda.Event(enable_timing=True)
+        self.start_event.record()
+
+    def stop(self) -> None:
+        if not self.enabled or self.start_event is None or self.end_event is None:
+            return
+        self.end_event.record()
+        torch.cuda.synchronize()
+        torch.cuda.nvtx.range_pop()
+        details = " ".join(f"{key}={value}" for key, value in self.fields.items())
+        logger.info(
+            "GLM52_PREFILL_PROFILE region=%s elapsed_ms=%.3f %s",
+            self.region,
+            self.start_event.elapsed_time(self.end_event),
+            details,
+        )
+
+
+def _fp8_mqa_logits_head_chunk_size(
+    seq_len: int,
+    seq_len_kv: int,
+    num_heads: int,
+) -> int:
+    # The SM120 torch path is used on long prefill paths where materializing
+    # [head_chunk, M, N] scores can otherwise allocate multiple GiB. Keep the
+    # transient score tensor bounded, while still using larger head chunks for
+    # short prompts where they are faster.
+    score_elems_per_head = max(1, seq_len * seq_len_kv)
+    max_heads = _SM120_MQA_LOGITS_MAX_SCORE_BYTES // (score_elems_per_head * 4)
+    return max(1, min(8, num_heads, max_heads))
+
+
+def _fp8_mqa_logits_k_chunk_size(
+    seq_len: int,
+    seq_len_kv: int,
+    head_chunk_size: int,
+) -> int:
+    score_elems_per_key = max(1, seq_len * head_chunk_size)
+    max_keys = _SM120_MQA_LOGITS_MAX_SCORE_BYTES // (score_elems_per_key * 4)
+    return max(1, min(seq_len_kv, max_keys))
+
+
+def _fp8_mqa_logits_torch(
+    q: tuple[torch.Tensor, torch.Tensor | None],
+    kv: tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+    clean_logits: bool,
+) -> torch.Tensor:
+    q_values, q_scale = q
+    if q_scale is not None:
+        raise NotImplementedError("SM120 MQA logits torch path only supports FP8 Q")
+
+    k_values, k_scales = kv
+    k_f32 = k_values.to(torch.float32)
+    k_f32.mul_(k_scales.reshape(-1, 1).to(torch.float32))
+    k_t = k_f32.transpose(0, 1).contiguous()
+
+    seq_len, num_heads, _ = q_values.shape
+    seq_len_kv = k_f32.shape[0]
+    logits = torch.zeros(
+        (seq_len, seq_len_kv), device=q_values.device, dtype=torch.float32
+    )
+    head_chunk_size = _fp8_mqa_logits_head_chunk_size(seq_len, seq_len_kv, num_heads)
+
+    for head_start in range(0, num_heads, head_chunk_size):
+        head_end = min(head_start + head_chunk_size, num_heads)
+        q_chunk = q_values[:, head_start:head_end, :].to(torch.float32)
+        q_chunk = q_chunk.transpose(0, 1).contiguous()
+        head_weights = weights[:, head_start:head_end].transpose(0, 1).unsqueeze(-1)
+        k_chunk_size = _fp8_mqa_logits_k_chunk_size(
+            seq_len, seq_len_kv, head_end - head_start
+        )
+        for k_start in range(0, seq_len_kv, k_chunk_size):
+            k_end = min(k_start + k_chunk_size, seq_len_kv)
+            scores = torch.matmul(q_chunk, k_t[:, k_start:k_end])
+            scores.relu_()
+            scores.mul_(head_weights)
+            logits[:, k_start:k_end].add_(
+                scores[0] if scores.shape[0] == 1 else scores.sum(dim=0)
+            )
+
+    if clean_logits:
+        offsets = torch.arange(seq_len_kv, device=q_values.device)
+        valid = (offsets[None, :] >= cu_seqlen_ks[:, None]) & (
+            offsets[None, :] < cu_seqlen_ke[:, None]
+        )
+        logits = logits.masked_fill(~valid, float("-inf"))
+
+    return logits
+
+
+def _fp8_mqa_logits_topk_torch(
+    q: tuple[torch.Tensor, torch.Tensor | None],
+    kv: tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+    topk_tokens: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    q_values, q_scale = q
+    if q_scale is not None:
+        raise NotImplementedError("SM120 MQA top-k torch path only supports FP8 Q")
+
+    k_values, k_scales = kv
+    k_f32 = k_values.to(torch.float32)
+    k_f32.mul_(k_scales.reshape(-1, 1).to(torch.float32))
+    k_t = k_f32.transpose(0, 1).contiguous()
+
+    seq_len, num_heads, _ = q_values.shape
+    seq_len_kv = k_f32.shape[0]
+    if out is None:
+        out = torch.empty(
+            (seq_len, topk_tokens), device=q_values.device, dtype=torch.int32
+        )
+    else:
+        assert out.shape == (seq_len, topk_tokens)
+        assert out.dtype == torch.int32
+    out.fill_(-1)
+
+    best_values = torch.full(
+        (seq_len, topk_tokens),
+        float("-inf"),
+        device=q_values.device,
+        dtype=torch.float32,
+    )
+    head_chunk_size = _fp8_mqa_logits_head_chunk_size(seq_len, seq_len_kv, num_heads)
+    k_chunk_size = _fp8_mqa_logits_k_chunk_size(seq_len, seq_len_kv, head_chunk_size)
+    max_chunk_topk = min(topk_tokens, k_chunk_size)
+    chunk_values_buf = torch.empty(
+        (seq_len, max_chunk_topk),
+        device=q_values.device,
+        dtype=torch.float32,
+    )
+    chunk_indices_buf = torch.empty(
+        (seq_len, max_chunk_topk),
+        device=q_values.device,
+        dtype=torch.int64,
+    )
+    chunk_indices_i32 = torch.empty(
+        (seq_len, max_chunk_topk),
+        device=q_values.device,
+        dtype=torch.int32,
+    )
+    candidate_values = torch.empty(
+        (seq_len, topk_tokens + max_chunk_topk),
+        device=q_values.device,
+        dtype=torch.float32,
+    )
+    candidate_indices = torch.empty(
+        (seq_len, topk_tokens + max_chunk_topk),
+        device=q_values.device,
+        dtype=torch.int32,
+    )
+    next_best_values = torch.empty_like(best_values)
+    selected = torch.empty(
+        (seq_len, topk_tokens),
+        device=q_values.device,
+        dtype=torch.int64,
+    )
+
+    for k_start in range(0, seq_len_kv, k_chunk_size):
+        k_end = min(k_start + k_chunk_size, seq_len_kv)
+        chunk_logits = torch.zeros(
+            (seq_len, k_end - k_start),
+            device=q_values.device,
+            dtype=torch.float32,
+        )
+        for head_start in range(0, num_heads, head_chunk_size):
+            head_end = min(head_start + head_chunk_size, num_heads)
+            q_chunk = q_values[:, head_start:head_end, :].to(torch.float32)
+            q_chunk = q_chunk.transpose(0, 1).contiguous()
+            head_weights = weights[:, head_start:head_end].transpose(0, 1).unsqueeze(-1)
+            scores = torch.matmul(q_chunk, k_t[:, k_start:k_end])
+            scores.relu_()
+            scores.mul_(head_weights)
+            chunk_logits.add_(scores[0] if scores.shape[0] == 1 else scores.sum(dim=0))
+
+        offsets = torch.arange(k_start, k_end, device=q_values.device)
+        valid = (offsets[None, :] >= cu_seqlen_ks[:, None]) & (
+            offsets[None, :] < cu_seqlen_ke[:, None]
+        )
+        chunk_logits.masked_fill_(~valid, float("-inf"))
+
+        chunk_topk = min(topk_tokens, k_end - k_start)
+        chunk_values = chunk_values_buf[:, :chunk_topk]
+        chunk_indices = chunk_indices_buf[:, :chunk_topk]
+        torch.topk(chunk_logits, chunk_topk, dim=1, out=(chunk_values, chunk_indices))
+        chunk_indices_out = chunk_indices_i32[:, :chunk_topk]
+        chunk_indices_out.copy_(chunk_indices)
+        chunk_indices_out.add_(k_start)
+
+        candidate_cols = topk_tokens + chunk_topk
+        candidate_values_view = candidate_values[:, :candidate_cols]
+        candidate_indices_view = candidate_indices[:, :candidate_cols]
+        candidate_values_view[:, :topk_tokens].copy_(best_values)
+        candidate_values_view[:, topk_tokens:candidate_cols].copy_(chunk_values)
+        candidate_indices_view[:, :topk_tokens].copy_(out)
+        candidate_indices_view[:, topk_tokens:candidate_cols].copy_(chunk_indices_out)
+        torch.topk(
+            candidate_values_view,
+            topk_tokens,
+            dim=1,
+            out=(next_best_values, selected),
+        )
+        torch.gather(candidate_indices_view, 1, selected, out=out)
+        best_values, next_best_values = next_best_values, best_values
+        out.masked_fill_(~torch.isfinite(best_values), -1)
+
+    return out
+
+
+def fp8_fp4_mqa_topk_indices(
+    q: tuple[torch.Tensor, torch.Tensor | None],
+    kv: tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+    topk_indices: torch.Tensor,
+) -> bool:
+    """Write SM120 FP8 MQA top-k indices without materializing full logits."""
+    q_values, q_scale = q
+    profile = _CudaProfileRegion(
+        "indexer.mqa_topk",
+        q_shape=tuple(q_values.shape),
+        kv_shape=tuple(kv[0].shape),
+        topk=topk_indices.shape[1],
+        q_scale="set" if q_scale is not None else "none",
+    )
+    profile.start()
+    if not (
+        current_platform.is_cuda()
+        and current_platform.is_device_capability_family(120)
+        and q_scale is None
+    ):
+        profile.stop()
+        return False
+    _fp8_mqa_logits_topk_torch(
+        q,
+        kv,
+        weights,
+        cu_seqlen_ks,
+        cu_seqlen_ke,
+        topk_indices.shape[1],
+        out=topk_indices,
+    )
+    profile.stop()
+    return True
+
+
+def _fp8_mqa_logits_sm12x(
+    q: tuple[torch.Tensor, torch.Tensor | None],
+    kv: tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+    clean_logits: bool,
+) -> torch.Tensor:
+    q_values, q_scale = q
+    profile = _CudaProfileRegion(
+        "indexer.mqa_logits",
+        q_shape=tuple(q_values.shape),
+        kv_shape=tuple(kv[0].shape),
+        clean_logits=clean_logits,
+        q_scale="set" if q_scale is not None else "none",
+    )
+    profile.start()
+    triton_enabled = _mqa_logits_triton_enabled()
+    use_triton = (
+        triton_enabled and q_scale is None and q_values.dim() == 3 and kv[0].dim() == 2
+    )
+    profile.fields["triton_enabled"] = "1" if triton_enabled else "0"
+    if use_triton:
+        from vllm.v1.attention.ops.deepseek_v4_ops.sm12x_mqa import (
+            fp8_mqa_logits_triton,
+        )
+
+        profile.fields["backend"] = "triton"
+        profile.fields["mask"] = "clean" if clean_logits else "none"
+        result = fp8_mqa_logits_triton(
+            q_values,
+            kv,
+            weights,
+            cu_seqlen_ks,
+            cu_seqlen_ke,
+            clean_logits=clean_logits,
+        )
+    else:
+        profile.fields["backend"] = "torch"
+        result = _fp8_mqa_logits_torch(
+            q, kv, weights, cu_seqlen_ks, cu_seqlen_ke, clean_logits
+        )
+    profile.stop()
+    return result
+
+
+def _fp8_paged_mqa_logits_torch(
+    q: tuple[torch.Tensor, torch.Tensor | None],
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    max_model_len: int,
+) -> torch.Tensor:
+    q_values, q_scale = q
+    if q_scale is not None:
+        raise NotImplementedError("SM120 paged MQA torch path only supports FP8 Q")
+
+    batch_size, next_n, num_heads, head_dim = q_values.shape
+    head_dim_with_scale = kv_cache.shape[-1]
+    assert head_dim_with_scale > head_dim
+    assert weights.shape == (batch_size * next_n, num_heads)
+    assert context_lens.shape == (batch_size, next_n)
+
+    from vllm.v1.attention.ops.deepseek_v4_ops.sm12x_mqa import (
+        _view_packed_fp8_paged_mqa_kv_cache,
+    )
+
+    kv_values, kv_scales = _view_packed_fp8_paged_mqa_kv_cache(kv_cache, head_dim)
+    _, block_kv, _, _ = kv_values.shape
+    logits = torch.full(
+        (batch_size * next_n, max_model_len),
+        float("-inf"),
+        device=q_values.device,
+        dtype=torch.float32,
+    )
+
+    q_f32 = q_values.float()
+    score_bytes = _SM120_MQA_LOGITS_MAX_SCORE_BYTES
+    max_tokens_per_chunk = max(1, score_bytes // max(1, num_heads * 4))
+    token_offsets_cache: dict[int, torch.Tensor] = {}
+
+    for batch_idx in range(batch_size):
+        for next_idx in range(next_n):
+            row = batch_idx * next_n + next_idx
+            context_len = int(context_lens[batch_idx, next_idx].item())
+            if context_len <= 0:
+                continue
+
+            q_row = q_f32[batch_idx, next_idx]
+            row_weights = weights[row]
+            for token_start in range(0, context_len, max_tokens_per_chunk):
+                token_end = min(context_len, token_start + max_tokens_per_chunk)
+                chunk_len = token_end - token_start
+                token_offsets = token_offsets_cache.get(chunk_len)
+                if token_offsets is None or token_offsets.device != q_values.device:
+                    token_offsets = torch.arange(
+                        chunk_len, device=q_values.device, dtype=torch.long
+                    )
+                    token_offsets_cache[chunk_len] = token_offsets
+                token_ids = token_start + token_offsets
+                logical_blocks = token_ids // block_kv
+                token_in_block = token_ids - logical_blocks * block_kv
+                physical_blocks = block_tables[batch_idx, logical_blocks]
+                kv_chunk = kv_values[physical_blocks, token_in_block, 0].float()
+                scale_chunk = kv_scales[physical_blocks, token_in_block, 0].squeeze(-1)
+                kv_chunk.mul_(scale_chunk[:, None])
+                scores = torch.matmul(q_row, kv_chunk.T)
+                scores.relu_()
+                scores.mul_(row_weights[:, None])
+                logits[row, token_start:token_end] = scores.sum(dim=0)
+
+    return logits
+
+
+def _fp8_paged_mqa_logits_sm12x(
+    q: tuple[torch.Tensor, torch.Tensor | None],
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    max_model_len: int,
+) -> torch.Tensor:
+    q_values, q_scale = q
+    profile = _CudaProfileRegion(
+        "indexer.paged_mqa_logits",
+        q_shape=tuple(q_values.shape),
+        kv_cache_shape=tuple(kv_cache.shape),
+        max_model_len=max_model_len,
+        q_scale="set" if q_scale is not None else "none",
+    )
+    profile.start()
+    triton_enabled = _paged_mqa_triton_enabled()
+    use_triton = (
+        triton_enabled
+        and q_scale is None
+        and q_values.dim() == 4
+        and kv_cache.dtype == torch.uint8
+        and kv_cache.shape[-1] == q_values.shape[-1] + 4
+    )
+    profile.fields["triton_enabled"] = "1" if triton_enabled else "0"
+    if use_triton:
+        from vllm.v1.attention.ops.deepseek_v4_ops.sm12x_mqa import (
+            fp8_paged_mqa_logits_triton,
+        )
+
+        profile.fields["backend"] = "triton"
+        result = fp8_paged_mqa_logits_triton(
+            q_values, kv_cache, weights, context_lens, block_tables, max_model_len
+        )
+    else:
+        profile.fields["backend"] = "torch"
+        logger.warning_once(
+            "SM12x paged-MQA falling back to the torch reference path "
+            "(triton_enabled=%s, q_scale=%s, q.dim=%s, kv_cache.dtype=%s, "
+            "kv_cache.shape[-1]=%s, q_values.shape[-1]=%s). "
+            "This path is intended for correctness checks "
+            "and is not graph-compatible; expect a large per-step latency.",
+            triton_enabled,
+            "set" if q_scale is not None else "None",
+            q_values.dim(),
+            kv_cache.dtype,
+            kv_cache.shape[-1] if kv_cache.dim() else None,
+            q_values.shape[-1],
+        )
+        result = _fp8_paged_mqa_logits_torch(
+            q, kv_cache, weights, context_lens, block_tables, max_model_len
+        )
+    profile.stop()
+    return result
+
+
+def fp8_fp4_paged_mqa_topk_indices(
+    q: tuple[torch.Tensor, torch.Tensor | None],
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    max_model_len: int,
+    topk_indices: torch.Tensor,
+) -> bool:
+    """Write SM120 FP8 paged MQA top-k indices without full logits."""
+    q_values, q_scale = q
+    profile = _CudaProfileRegion(
+        "indexer.paged_mqa_topk",
+        q_shape=tuple(q_values.shape),
+        kv_cache_shape=tuple(kv_cache.shape),
+        max_model_len=max_model_len,
+        topk=topk_indices.shape[1],
+        q_scale="set" if q_scale is not None else "none",
+    )
+    profile.start()
+    triton_enabled = _paged_mqa_triton_enabled()
+    profile.fields["triton_enabled"] = "1" if triton_enabled else "0"
+    if not (
+        triton_enabled
+        and current_platform.is_cuda()
+        and current_platform.is_device_capability_family(120)
+        and q_scale is None
+        and q_values.dim() == 4
+        and kv_cache.dtype == torch.uint8
+        and kv_cache.shape[-1] == q_values.shape[-1] + 4
+    ):
+        profile.fields["backend"] = "skip"
+        profile.stop()
+        return False
+
+    profile.fields["backend"] = "triton"
+    num_rows = q_values.shape[0] * q_values.shape[1]
+    topk_tokens = topk_indices.shape[1]
+    assert topk_indices.shape == (num_rows, topk_tokens)
+    assert topk_indices.dtype == torch.int32
+    topk_indices.fill_(-1)
+    if num_rows == 0 or topk_tokens == 0 or max_model_len == 0:
+        profile.stop()
+        return True
+
+    best_values = torch.full(
+        (num_rows, topk_tokens),
+        float("-inf"),
+        device=q_values.device,
+        dtype=torch.float32,
+    )
+    chunk_size = _paged_mqa_topk_chunk_size()
+    profile.fields["chunk_size"] = chunk_size
+    profile.fields["chunks"] = (max_model_len + chunk_size - 1) // chunk_size
+    max_chunk_topk = min(topk_tokens, chunk_size)
+    chunk_values_buf = torch.empty(
+        (num_rows, max_chunk_topk),
+        device=q_values.device,
+        dtype=torch.float32,
+    )
+    chunk_indices_buf = torch.empty(
+        (num_rows, max_chunk_topk),
+        device=q_values.device,
+        dtype=torch.int64,
+    )
+    chunk_indices_i32 = torch.empty(
+        (num_rows, max_chunk_topk),
+        device=q_values.device,
+        dtype=torch.int32,
+    )
+    candidate_values = torch.empty(
+        (num_rows, topk_tokens + max_chunk_topk),
+        device=q_values.device,
+        dtype=torch.float32,
+    )
+    candidate_indices = torch.empty(
+        (num_rows, topk_tokens + max_chunk_topk),
+        device=q_values.device,
+        dtype=torch.int32,
+    )
+    next_best_values = torch.empty_like(best_values)
+    selected = torch.empty(
+        (num_rows, topk_tokens),
+        device=q_values.device,
+        dtype=torch.int64,
+    )
+
+    from vllm.v1.attention.ops.deepseek_v4_ops.sm12x_mqa import (
+        fp8_paged_mqa_logits_triton,
+    )
+
+    for token_start in range(0, max_model_len, chunk_size):
+        token_count = min(chunk_size, max_model_len - token_start)
+        chunk_logits = fp8_paged_mqa_logits_triton(
+            q_values,
+            kv_cache,
+            weights,
+            context_lens,
+            block_tables,
+            max_model_len,
+            token_start=token_start,
+            token_count=token_count,
+        )
+        chunk_topk = min(topk_tokens, token_count)
+        chunk_values = chunk_values_buf[:, :chunk_topk]
+        chunk_indices = chunk_indices_buf[:, :chunk_topk]
+        torch.topk(chunk_logits, chunk_topk, dim=1, out=(chunk_values, chunk_indices))
+        chunk_indices_out = chunk_indices_i32[:, :chunk_topk]
+        chunk_indices_out.copy_(chunk_indices)
+        chunk_indices_out.add_(token_start)
+
+        candidate_cols = topk_tokens + chunk_topk
+        candidate_values_view = candidate_values[:, :candidate_cols]
+        candidate_indices_view = candidate_indices[:, :candidate_cols]
+        candidate_values_view[:, :topk_tokens].copy_(best_values)
+        candidate_values_view[:, topk_tokens:candidate_cols].copy_(chunk_values)
+        candidate_indices_view[:, :topk_tokens].copy_(topk_indices)
+        candidate_indices_view[:, topk_tokens:candidate_cols].copy_(chunk_indices_out)
+        torch.topk(
+            candidate_values_view,
+            topk_tokens,
+            dim=1,
+            out=(next_best_values, selected),
+        )
+        torch.gather(candidate_indices_view, 1, selected, out=topk_indices)
+        best_values, next_best_values = next_best_values, best_values
+        topk_indices.masked_fill_(~torch.isfinite(best_values), -1)
+
+    profile.stop()
+    return True
+
+
+def _tf32_hc_prenorm_gemm_torch(
+    x: torch.Tensor,
+    fn: torch.Tensor,
+    out: torch.Tensor,
+    sqrsum: torch.Tensor,
+    num_split: int,
+) -> torch.Tensor:
+    """Portable SM12x HyperConnection prenorm GEMM fallback.
+
+    DeepGEMM's split ABI only requires that downstream consumers recover the
+    full result by summing over the split dimension. Keep the implementation
+    simple by writing the full product to split zero and clearing the rest.
+    """
+    del num_split
+    product = x.float() @ fn.float().T
+    norm = x.float().square().sum(dim=-1)
+
+    if out.dim() == 3:
+        out.zero_()
+        sqrsum.zero_()
+        out[0].copy_(product)
+        sqrsum[0].copy_(norm)
+    else:
+        out.copy_(product)
+        sqrsum.copy_(norm)
+    return out
+
+
+def _tf32_hc_prenorm_gemm_sm12x(
+    x: torch.Tensor,
+    fn: torch.Tensor,
+    out: torch.Tensor,
+    sqrsum: torch.Tensor,
+    num_split: int,
+) -> torch.Tensor:
+    if out.dim() == 3 and sqrsum.dim() == 2:
+        from vllm.v1.attention.ops.deepseek_v4_ops.sm12x_mqa import (
+            tf32_hc_prenorm_gemm_triton,
+        )
+
+        tf32_hc_prenorm_gemm_triton(x, fn, out, sqrsum, num_split)
+        return out
+
+    return _tf32_hc_prenorm_gemm_torch(x, fn, out, sqrsum, num_split)

--- a/vllm/v1/attention/ops/deepseek_v4_ops/sm12x_mqa.py
+++ b/vllm/v1/attention/ops/deepseek_v4_ops/sm12x_mqa.py
@@ -1,0 +1,727 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Triton fallback kernels used by the local DeepSeek V4 path."""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+
+def _view_packed_fp8_paged_mqa_kv_cache(
+    kv_cache: torch.Tensor,
+    head_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return FP8 values and fp32 scales from indexer cache block storage."""
+    if kv_cache.dtype != torch.uint8:
+        raise TypeError(f"Expected uint8 kv_cache, got {kv_cache.dtype}")
+    if kv_cache.dim() == 3:
+        num_blocks, block_size, head_dim_with_scale = kv_cache.shape
+        num_kv_heads = 1
+    elif kv_cache.dim() == 4:
+        num_blocks, block_size, num_kv_heads, head_dim_with_scale = kv_cache.shape
+    else:
+        raise ValueError(
+            f"Expected 3D or 4D kv_cache, got {kv_cache.dim()} dimensions"
+        )
+    if num_kv_heads != 1:
+        raise ValueError(f"Expected one KV head, got {num_kv_heads}")
+
+    scale_bytes = head_dim_with_scale - head_dim
+    if scale_bytes <= 0 or scale_bytes % torch.float32.itemsize != 0:
+        raise ValueError(
+            "Expected kv_cache last dimension to contain FP8 values followed "
+            f"by fp32 scale bytes; got head_dim={head_dim}, "
+            f"last_dim={head_dim_with_scale}"
+        )
+
+    block_stride = kv_cache.stride(0)
+    base_storage_offset = kv_cache.storage_offset()
+    scale_elems = scale_bytes // torch.float32.itemsize
+    kv_values = torch.as_strided(
+        kv_cache,
+        size=(num_blocks, block_size, 1, head_dim),
+        stride=(block_stride, head_dim, head_dim, 1),
+        storage_offset=base_storage_offset,
+    ).view(torch.float8_e4m3fn)
+    kv_scale = torch.as_strided(
+        kv_cache,
+        size=(num_blocks, block_size, 1, scale_bytes),
+        stride=(block_stride, scale_bytes, scale_bytes, 1),
+        storage_offset=base_storage_offset + block_size * head_dim,
+    ).view(torch.float32)
+    return kv_values, kv_scale[..., :scale_elems]
+
+
+@triton.jit
+def _fp8_mqa_logits_kernel(
+    q_ptr,
+    k_ptr,
+    scale_ptr,
+    weights_ptr,
+    cu_seqlen_ks_ptr,
+    cu_seqlen_ke_ptr,
+    logits_ptr,
+    num_q: tl.constexpr,
+    seq_len_kv: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    stride_qm: tl.constexpr,
+    stride_qh: tl.constexpr,
+    stride_qd: tl.constexpr,
+    stride_kn: tl.constexpr,
+    stride_kd: tl.constexpr,
+    stride_wm: tl.constexpr,
+    stride_wh: tl.constexpr,
+    stride_lm: tl.constexpr,
+    stride_ln: tl.constexpr,
+    CLEAN_LOGITS: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, BLOCK_D)
+
+    valid_m = offs_m < num_q
+    valid_n = offs_n < seq_len_kv
+    if CLEAN_LOGITS:
+        seq_start = tl.load(cu_seqlen_ks_ptr + offs_m, mask=valid_m, other=0)
+        seq_end = tl.load(cu_seqlen_ke_ptr + offs_m, mask=valid_m, other=0)
+        seq_mask = (offs_n[None, :] >= seq_start[:, None]) & (
+            offs_n[None, :] < seq_end[:, None]
+        )
+    else:
+        seq_mask = valid_m[:, None] & valid_n[None, :]
+
+    logits = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for h in tl.range(0, num_heads):
+        scores = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        for d0 in tl.range(0, head_dim, BLOCK_D):
+            d = d0 + offs_d
+            q = tl.load(
+                q_ptr
+                + offs_m[:, None] * stride_qm
+                + h * stride_qh
+                + d[None, :] * stride_qd,
+                mask=valid_m[:, None] & (d[None, :] < head_dim),
+                other=0.0,
+            ).to(tl.float32)
+            k = tl.load(
+                k_ptr + offs_n[:, None] * stride_kn + d[None, :] * stride_kd,
+                mask=valid_n[:, None] & (d[None, :] < head_dim),
+                other=0.0,
+            ).to(tl.float32)
+            scores += tl.dot(q, tl.trans(k), input_precision="tf32")
+        scale = tl.load(scale_ptr + offs_n, mask=valid_n, other=0.0)
+        weighted = tl.maximum(scores * scale[None, :], 0.0)
+        weight = tl.load(
+            weights_ptr + offs_m * stride_wm + h * stride_wh,
+            mask=valid_m,
+            other=0.0,
+        )
+        logits += weighted * weight[:, None]
+
+    store_mask = valid_m[:, None] & valid_n[None, :]
+    logits = tl.where(seq_mask & store_mask, logits, float("-inf"))
+    tl.store(
+        logits_ptr + offs_m[:, None] * stride_lm + offs_n[None, :] * stride_ln,
+        logits,
+        mask=store_mask,
+    )
+
+
+def fp8_mqa_logits_triton(
+    q: torch.Tensor,
+    kv: tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+    clean_logits: bool = True,
+) -> torch.Tensor:
+    k_fp8, scale = kv
+    num_q, num_heads, head_dim = q.shape
+    seq_len_kv = k_fp8.shape[0]
+    logits = torch.empty(
+        (num_q, seq_len_kv),
+        device=q.device,
+        dtype=torch.float32,
+    )
+    if num_q == 0 or seq_len_kv == 0:
+        return logits
+
+    grid = (triton.cdiv(num_q, 8), triton.cdiv(seq_len_kv, 64))
+    _fp8_mqa_logits_kernel[grid](
+        q,
+        k_fp8,
+        scale,
+        weights,
+        cu_seqlen_ks,
+        cu_seqlen_ke,
+        logits,
+        num_q,
+        seq_len_kv,
+        num_heads,
+        head_dim,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        k_fp8.stride(0),
+        k_fp8.stride(1),
+        weights.stride(0),
+        weights.stride(1),
+        logits.stride(0),
+        logits.stride(1),
+        CLEAN_LOGITS=clean_logits,
+        BLOCK_M=8,
+        BLOCK_N=64,
+        BLOCK_D=64,
+        num_warps=4,
+    )
+    return logits
+
+
+@triton.jit
+def _fp8_paged_mqa_logits_kernel(
+    q_ptr,
+    kv_ptr,
+    scale_ptr,
+    weights_ptr,
+    context_lens_ptr,
+    block_tables_ptr,
+    logits_ptr,
+    token_start,
+    num_rows: tl.constexpr,
+    logits_width: tl.constexpr,
+    next_n: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    block_size: tl.constexpr,
+    stride_qb: tl.constexpr,
+    stride_qn: tl.constexpr,
+    stride_qh: tl.constexpr,
+    stride_qd: tl.constexpr,
+    stride_kvb: tl.constexpr,
+    stride_kvs: tl.constexpr,
+    stride_kvd: tl.constexpr,
+    stride_sb: tl.constexpr,
+    stride_ss: tl.constexpr,
+    stride_wm: tl.constexpr,
+    stride_wh: tl.constexpr,
+    stride_clb: tl.constexpr,
+    stride_cln: tl.constexpr,
+    stride_btb: tl.constexpr,
+    stride_btk: tl.constexpr,
+    stride_lm: tl.constexpr,
+    stride_ln: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_local_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_n = token_start + offs_local_n
+    offs_d = tl.arange(0, BLOCK_D)
+
+    valid_m = offs_m < num_rows
+    valid_n = offs_local_n < logits_width
+    batch = offs_m // next_n
+    q_pos = offs_m - batch * next_n
+    context_len = tl.load(
+        context_lens_ptr + batch * stride_clb + q_pos * stride_cln,
+        mask=valid_m,
+        other=0,
+    )
+    context_mask = valid_n[None, :] & (offs_n[None, :] < context_len[:, None])
+
+    block_rank = offs_n // block_size
+    block_offset = offs_n - block_rank * block_size
+    block_idx = tl.load(
+        block_tables_ptr
+        + batch[:, None] * stride_btb
+        + block_rank[None, :] * stride_btk,
+        mask=valid_m[:, None] & valid_n[None, :],
+        other=0,
+    )
+
+    logits = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    scale = tl.load(
+        scale_ptr + block_idx * stride_sb + block_offset[None, :] * stride_ss,
+        mask=context_mask,
+        other=0.0,
+    )
+    for h in tl.range(0, num_heads):
+        scores = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        for d0 in tl.range(0, head_dim, BLOCK_D):
+            d = d0 + offs_d
+            q = tl.load(
+                q_ptr
+                + batch[:, None] * stride_qb
+                + q_pos[:, None] * stride_qn
+                + h * stride_qh
+                + d[None, :] * stride_qd,
+                mask=valid_m[:, None] & (d[None, :] < head_dim),
+                other=0.0,
+            ).to(tl.float32)
+            k = tl.load(
+                kv_ptr
+                + block_idx[:, :, None] * stride_kvb
+                + block_offset[None, :, None] * stride_kvs
+                + d[None, None, :] * stride_kvd,
+                mask=context_mask[:, :, None] & (d[None, None, :] < head_dim),
+                other=0.0,
+            ).to(tl.float32)
+            scores += tl.sum(q[:, None, :] * k, axis=2)
+        weighted = tl.maximum(scores * scale, 0.0)
+        weight = tl.load(
+            weights_ptr + offs_m * stride_wm + h * stride_wh,
+            mask=valid_m,
+            other=0.0,
+        )
+        logits += weighted * weight[:, None]
+
+    store_mask = valid_m[:, None] & valid_n[None, :]
+    logits = tl.where(context_mask & store_mask, logits, float("-inf"))
+    tl.store(
+        logits_ptr + offs_m[:, None] * stride_lm + offs_local_n[None, :] * stride_ln,
+        logits,
+        mask=store_mask,
+    )
+
+
+@triton.jit
+def _fp8_paged_mqa_logits_rowwise_kernel(
+    q_ptr,
+    kv_ptr,
+    scale_ptr,
+    weights_ptr,
+    context_lens_ptr,
+    block_tables_ptr,
+    logits_ptr,
+    token_start,
+    num_rows: tl.constexpr,
+    logits_width: tl.constexpr,
+    next_n: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    block_size: tl.constexpr,
+    stride_qb: tl.constexpr,
+    stride_qn: tl.constexpr,
+    stride_qh: tl.constexpr,
+    stride_qd: tl.constexpr,
+    stride_kvb: tl.constexpr,
+    stride_kvs: tl.constexpr,
+    stride_kvd: tl.constexpr,
+    stride_sb: tl.constexpr,
+    stride_ss: tl.constexpr,
+    stride_wm: tl.constexpr,
+    stride_wh: tl.constexpr,
+    stride_clb: tl.constexpr,
+    stride_cln: tl.constexpr,
+    stride_btb: tl.constexpr,
+    stride_btk: tl.constexpr,
+    stride_lm: tl.constexpr,
+    stride_ln: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    """Per-row paged-MQA logits kernel optimised for long ``token_count``.
+
+    Each Triton program handles one logical row (``batch * next_n + q_pos``)
+    across a ``BLOCK_N``-wide window of token positions. Q is loaded once per
+    head tile and reused for every K element in the window, which preserves
+    L2 / register locality and avoids the M-axis padding waste of the
+    generic 2D-tiled kernel at long contexts (mt-bench c=1 MTP=2 num_rows=3
+    with token_count=131072 launches 12k programs of 128 logits each rather
+    than 8k programs of 64 logits with 25 % M-axis waste).
+    """
+    row = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_local_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_n = token_start + offs_local_n
+    offs_d = tl.arange(0, BLOCK_D)
+
+    valid_row = row < num_rows
+    valid_n = offs_local_n < logits_width
+    batch = row // next_n
+    q_pos = row - batch * next_n
+    context_len = tl.load(
+        context_lens_ptr + batch * stride_clb + q_pos * stride_cln,
+        mask=valid_row,
+        other=0,
+    )
+    if token_start + pid_n * BLOCK_N >= context_len:
+        logits = tl.full((BLOCK_N,), float("-inf"), dtype=tl.float32)
+        tl.store(
+            logits_ptr + row * stride_lm + offs_local_n * stride_ln,
+            logits,
+            mask=valid_row & valid_n,
+        )
+        return
+    context_mask = valid_n & (offs_n < context_len)
+
+    block_rank = offs_n // block_size
+    block_offset = offs_n - block_rank * block_size
+    block_idx = tl.load(
+        block_tables_ptr + batch * stride_btb + block_rank * stride_btk,
+        mask=valid_row & context_mask,
+        other=0,
+    )
+
+    scale = tl.load(
+        scale_ptr + block_idx * stride_sb + block_offset * stride_ss,
+        mask=context_mask,
+        other=0.0,
+    )
+    logits = tl.zeros((BLOCK_N,), dtype=tl.float32)
+
+    for h0 in tl.range(0, num_heads, BLOCK_H):
+        heads = h0 + tl.arange(0, BLOCK_H)
+        valid_h = heads < num_heads
+        scores = tl.zeros((BLOCK_H, BLOCK_N), dtype=tl.float32)
+        for d0 in tl.range(0, head_dim, BLOCK_D):
+            d = d0 + offs_d
+            q = tl.load(
+                q_ptr
+                + batch * stride_qb
+                + q_pos * stride_qn
+                + heads[:, None] * stride_qh
+                + d[None, :] * stride_qd,
+                mask=valid_row & valid_h[:, None] & (d[None, :] < head_dim),
+                other=0.0,
+            ).to(tl.float32)
+            k = tl.load(
+                kv_ptr
+                + block_idx[None, :] * stride_kvb
+                + block_offset[None, :] * stride_kvs
+                + d[:, None] * stride_kvd,
+                mask=context_mask[None, :] & (d[:, None] < head_dim),
+                other=0.0,
+            ).to(tl.float32)
+            scores += tl.dot(q, k, input_precision="tf32")
+
+        weighted = tl.maximum(scores * scale[None, :], 0.0)
+        weight = tl.load(
+            weights_ptr + row * stride_wm + heads * stride_wh,
+            mask=valid_row & valid_h,
+            other=0.0,
+        )
+        logits += tl.sum(weighted * weight[:, None], axis=0)
+
+    logits = tl.where(context_mask & valid_row, logits, float("-inf"))
+    tl.store(
+        logits_ptr + row * stride_lm + offs_local_n * stride_ln,
+        logits,
+        mask=valid_row & valid_n,
+    )
+
+
+def fp8_paged_mqa_logits_rowwise_triton(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    max_model_len: int,
+    token_start: int = 0,
+    token_count: int | None = None,
+) -> torch.Tensor:
+    """Rowwise paged-MQA logits wrapper.
+
+    Pre-condition: ``head_dim % 64 == 0`` and ``num_heads % 4 == 0`` so the
+    ``tl.dot`` inside ``_fp8_paged_mqa_logits_rowwise_kernel`` lands on
+    tensor-core friendly tile shapes. DSv4-Flash (head_dim=128,
+    num_heads=64) satisfies both and is the only model that exercises this
+    path today; the generic 2D kernel below remains the fallback for
+    misaligned shapes.
+    """
+    batch_size, next_n, num_heads, head_dim = q.size()
+    kv_values, kv_scale = _view_packed_fp8_paged_mqa_kv_cache(kv_cache, head_dim)
+    _, block_size, _, _ = kv_values.size()
+    num_rows = batch_size * next_n
+    if token_count is None:
+        token_count = max_model_len - token_start
+    assert token_start >= 0
+    assert token_count >= 0
+    assert token_start + token_count <= max_model_len
+    logits = torch.empty(
+        (num_rows, token_count),
+        device=q.device,
+        dtype=torch.float32,
+    )
+    if num_rows == 0 or token_count == 0:
+        return logits
+
+    context_lens_2d = context_lens.reshape(batch_size, -1)
+    if context_lens_2d.shape[1] == 1 and next_n != 1:
+        context_lens_2d = context_lens_2d.expand(batch_size, next_n).contiguous()
+    block_n = 128
+    grid = (num_rows, triton.cdiv(token_count, block_n))
+    _fp8_paged_mqa_logits_rowwise_kernel[grid](
+        q,
+        kv_values,
+        kv_scale,
+        weights,
+        context_lens_2d,
+        block_tables,
+        logits,
+        token_start,
+        num_rows,
+        token_count,
+        next_n,
+        num_heads,
+        head_dim,
+        block_size,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        kv_values.stride(0),
+        kv_values.stride(1),
+        kv_values.stride(3),
+        kv_scale.stride(0),
+        kv_scale.stride(1),
+        weights.stride(0),
+        weights.stride(1),
+        context_lens_2d.stride(0),
+        context_lens_2d.stride(1),
+        block_tables.stride(0),
+        block_tables.stride(1),
+        logits.stride(0),
+        logits.stride(1),
+        BLOCK_N=block_n,
+        BLOCK_D=64,
+        BLOCK_H=8,
+        num_warps=4,
+    )
+    return logits
+
+
+def fp8_paged_mqa_logits_triton(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    max_model_len: int,
+    token_start: int = 0,
+    token_count: int | None = None,
+) -> torch.Tensor:
+    batch_size, next_n, num_heads, head_dim = q.size()
+    # Aligned head shapes (DSv4-Flash and any future MQA model with
+    # ``head_dim % 64 == 0`` and ``num_heads % 4 == 0``) get the rowwise
+    # kernel, which keeps long-context decode (>100K tokens) on a per-row
+    # grid that re-uses Q across the full token window. The generic 2D
+    # kernel below still handles misaligned shapes and remains the canonical
+    # reference for the rowwise variant.
+    if head_dim % 64 == 0 and num_heads % 4 == 0:
+        return fp8_paged_mqa_logits_rowwise_triton(
+            q,
+            kv_cache,
+            weights,
+            context_lens,
+            block_tables,
+            max_model_len,
+            token_start=token_start,
+            token_count=token_count,
+        )
+
+    kv_values, kv_scale = _view_packed_fp8_paged_mqa_kv_cache(kv_cache, head_dim)
+    _, block_size, _, _ = kv_values.size()
+    num_rows = batch_size * next_n
+    if token_count is None:
+        token_count = max_model_len - token_start
+    assert token_start >= 0
+    assert token_count >= 0
+    assert token_start + token_count <= max_model_len
+    logits = torch.empty(
+        (num_rows, token_count),
+        device=q.device,
+        dtype=torch.float32,
+    )
+    if num_rows == 0 or token_count == 0:
+        return logits
+
+    context_lens_2d = context_lens.reshape(batch_size, -1)
+    if context_lens_2d.shape[1] == 1 and next_n != 1:
+        context_lens_2d = context_lens_2d.expand(batch_size, next_n).contiguous()
+    # Adaptive BLOCK_M: the kernel masks off positions >= num_rows, so a fixed
+    # BLOCK_M=4 wastes ~75% of M-axis work in the common single-stream decode
+    # case (num_rows=1). Pick the smallest power-of-2 tile that still covers
+    # num_rows so we keep one grid-program for typical decode while still
+    # benefiting from larger tiles when batch / MTP push num_rows higher.
+    if num_rows <= 1:
+        block_m = 1
+    elif num_rows <= 2:
+        block_m = 2
+    elif num_rows <= 4:
+        block_m = 4
+    else:
+        block_m = 8
+    grid = (triton.cdiv(num_rows, block_m), triton.cdiv(token_count, 64))
+    _fp8_paged_mqa_logits_kernel[grid](
+        q,
+        kv_values,
+        kv_scale,
+        weights,
+        context_lens_2d,
+        block_tables,
+        logits,
+        token_start,
+        num_rows,
+        token_count,
+        next_n,
+        num_heads,
+        head_dim,
+        block_size,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        kv_values.stride(0),
+        kv_values.stride(1),
+        kv_values.stride(3),
+        kv_scale.stride(0),
+        kv_scale.stride(1),
+        weights.stride(0),
+        weights.stride(1),
+        context_lens_2d.stride(0),
+        context_lens_2d.stride(1),
+        block_tables.stride(0),
+        block_tables.stride(1),
+        logits.stride(0),
+        logits.stride(1),
+        BLOCK_M=block_m,
+        BLOCK_N=64,
+        BLOCK_D=64,
+        num_warps=4,
+    )
+    return logits
+
+
+@triton.jit
+def _tf32_hc_prenorm_gemm_kernel(
+    x_ptr,
+    fn_ptr,
+    out_ptr,
+    sqrsum_ptr,
+    M: tl.constexpr,
+    K: tl.constexpr,
+    N: tl.constexpr,
+    stride_xm: tl.constexpr,
+    stride_xk: tl.constexpr,
+    stride_fnn: tl.constexpr,
+    stride_fnk: tl.constexpr,
+    stride_outs: tl.constexpr,
+    stride_outm: tl.constexpr,
+    stride_outn: tl.constexpr,
+    stride_sqs: tl.constexpr,
+    stride_sqm: tl.constexpr,
+    NUM_SPLIT: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    pid_s = tl.program_id(2)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+
+    split_k = tl.cdiv(K, NUM_SPLIT)
+    split_begin = pid_s * split_k
+    split_end = tl.minimum(split_begin + split_k, K)
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    sq = tl.zeros((BLOCK_M,), dtype=tl.float32)
+
+    for k0 in tl.range(0, split_k, BLOCK_K):
+        k = split_begin + k0 + offs_k
+        k_mask = k < split_end
+        x = tl.load(
+            x_ptr + offs_m[:, None] * stride_xm + k[None, :] * stride_xk,
+            mask=(offs_m[:, None] < M) & k_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        fn = tl.load(
+            fn_ptr + offs_n[None, :] * stride_fnn + k[:, None] * stride_fnk,
+            mask=(offs_n[None, :] < N) & k_mask[:, None],
+            other=0.0,
+        ).to(tl.float32)
+
+        acc += tl.dot(x, fn, input_precision="tf32", out_dtype=tl.float32)
+        sq += tl.sum(x * x, axis=1)
+
+    tl.store(
+        out_ptr
+        + pid_s * stride_outs
+        + offs_m[:, None] * stride_outm
+        + offs_n[None, :] * stride_outn,
+        acc,
+        mask=(offs_m[:, None] < M) & (offs_n[None, :] < N),
+    )
+
+    if pid_n == 0:
+        tl.store(
+            sqrsum_ptr + pid_s * stride_sqs + offs_m * stride_sqm,
+            sq,
+            mask=offs_m < M,
+        )
+
+
+def tf32_hc_prenorm_gemm_triton(
+    x: torch.Tensor,
+    fn: torch.Tensor,
+    out: torch.Tensor,
+    sqrsum: torch.Tensor,
+    num_split: int,
+) -> None:
+    assert x.dim() == 2
+    assert fn.dim() == 2
+    assert out.dim() == 3
+    assert sqrsum.dim() == 2
+
+    m, k = x.shape
+    n = fn.shape[0]
+    assert fn.shape[1] == k
+    assert out.shape == (num_split, m, n)
+    assert sqrsum.shape == (num_split, m)
+
+    if m == 0:
+        return
+
+    block_m = 16
+    block_n = triton.next_power_of_2(n)
+    block_n = min(max(block_n, 16), 32)
+    block_k = 64
+    grid = (triton.cdiv(m, block_m), triton.cdiv(n, block_n), num_split)
+    _tf32_hc_prenorm_gemm_kernel[grid](
+        x,
+        fn,
+        out,
+        sqrsum,
+        m,
+        k,
+        n,
+        x.stride(0),
+        x.stride(1),
+        fn.stride(0),
+        fn.stride(1),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        sqrsum.stride(0),
+        sqrsum.stride(1),
+        num_split,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        BLOCK_K=block_k,
+        num_warps=4,
+    )


### PR DESCRIPTION
## Summary
FlashInfer's sparse-MLA attention kernels (`sparse_mla_sm120`) livelock GB10 (sm_121) GPUs under cold-prefill load, wedging entire TP clusters with no host-side recovery path. This PR makes the Triton sparse-MLA route (`FLASHMLA_SPARSE`) selectable on sm12x, so affected deployments can bypass the livelocking kernels with a single backend flag. The root-cause evidence (cuda-gdb on a live wedge), validation receipts (560+ clean sessions), and full write-up live in [the evidence repo](https://github.com/marksunner/glm52-dgx-spark-deadlock-evidence) and [RFC #48720](https://github.com/vllm-project/vllm/issues/48720).

On capability-12 devices the MLA-sparse candidate list currently resolves to `[TRITON_MLA, FLASHINFER_MLA_SPARSE_SM120]` (`vllm/platforms/cuda.py:130` in 0.23.1rc1.dev893+gd3a66aa7e); for sparse-MLA models (e.g. GLM-5.2 / DeepSeek-lineage MTP configs) the flashinfer sm120 path is the only viable pick — boot log receipt: `Using FLASHINFER_MLA_SPARSE_SM120 … out of potential backends: ['FLASHINFER_MLA_SPARSE_SM120']` — so affected hardware has no escape hatch.

Enum-to-implementation map, for reviewers cold to the sparse-MLA backend zoo: `FLASHINFER_MLA_SPARSE_SM120` is the flashinfer `sparse_mla_sm120` CUDA kernel family (the livelocking one). `FLASHMLA_SPARSE` upstream binds the native FlashMLA CUDA extension (`vllm._flashmla_C`), which does not build/exist on sm12x; on our deployment the sm12x Triton drop-ins rebind its two sparse ops (`flash_mla_sparse_fwd`, `flash_mla_with_kvcache`) to portable Triton implementations — the Triton kernels come verbatim from the deepseek_v4 path of jasl's vLLM fork (credit @jasl) — so selecting `FLASHMLA_SPARSE` routes to Triton there. `TRITON_MLA` is the dense-MLA Triton backend, not a sparse-MLA implementation, so it is not viable for this model class — which is why the flashinfer path is today's sole effective candidate.

**Ask:** make the Triton sparse-MLA implementation (`FLASHMLA_SPARSE` backend enum) a member of the sm12x candidate list (ranked above the flashinfer sm120 path until the kernel race is fixed), or at minimum honor `--attention-backend FLASHMLA_SPARSE` for the **main model** on sm12x. The Triton kernels have no inter-block mbarrier/TMA dependencies and are structurally immune to this livelock class.

## Evidence (cuda-gdb on a live wedge, 2026-07-17)
- Spinning device kernel: `sparse_mla_prefill_kernel<(ModelType)2,(ComputeMode)0,16,2048,64>` (flashinfer `sparse_mla_sm120` family, `csrc/sparse_mla_sm120_prefill.cu`), param type `PrefillColdParams`.
- Grid (120,1,1) with **one resident block**, warps 8–11 all lanes active, non-divergent, spinning at `SYNCS.PHASECHK.TRANS64.TRYWAIT P0[UR8+0x14980]` → `@P0 BRA` loop — an **mbarrier phase TRYWAIT spin: TMA/expect-tx arrive-wait race**.
- Device signature during wedge: 96 % GPU util at ~18 W, 0 % memory utilization, clocks P0; host threads piled in `cuLaunchKernel` behind the jammed queue (making innocent kernels — marlin GEMMs, Triton ops — look guilty in host stacks; they were bystanders).
- Exonerations by receipt: RoCE fabric hw_counters all zero during a live wedge; driver/kernel identical pre/post-reboot (NVRM 580.159.03, kernel 6.17.0-1026); memory headroom falsified as cause (froze with 4.4–7.1 GB free); chunk size (8192→2048), max_num_seqs (6→3), served ceiling (200K→120K) all falsified as remedies, n≥2 each.
- Blast radius: 8 distinct freeze incidents across 2 days, on fresh boots, all previously misattributed (marlin/UMA, memory exhaustion, single-node hardware). One incident wedged on the FP8 decode-kernel route as well (MIN_HEADS reroute) — the race lives in shared sm120-family machinery, not one kernel.
- Full dossier (attach or link): `nvidia-addendum/sparse-mla-sm120-mbarrier-livelock-20260717.md`; NVIDIA bug filed separately.

## Fix validated (route swap = the only variable)
Deployment fact, stated precisely: the sm12x Triton drop-ins were installed and exercised by the **drafter** throughout the campaign — a constant, present in every round on both sides of the swap — and the flipped variable was the **main model's backend selection only**. Routing the main model to the Triton sparse-MLA stack (`--attention-backend FLASHMLA_SPARSE`) with everything else pinned:
- The failing regime (cold staged prefill) went from 8/8 wedges to clean on the first attempt: 64-stage climb through 119,856 tok, every stage OK.
- 90 consecutive context-ceiling sessions (seq = ceiling−3..ceiling, temp 1.2) across all three drafter-gate modes, zero wedges; extended to **500 consecutive ceiling sessions** overnight, zero wedges.
- Determinism spot-check (not a general correctness proof): the smoke completion — fixed prompt `"The capital of France is"`, temperature 0, max_tokens 16 — returned byte-identical text across every healthy boot pre- and post-route-swap; the comparison scope is that single 16-token greedy completion.
- The drafter had run the same Triton route at every decode step of the campaign — long-baked-in evidence of stability.

## Proposed change (shape)
1. `vllm/platforms/cuda.py` (capability-12 MLA-sparse selection): add `FLASHMLA_SPARSE`'s Triton implementation to the candidate list for sm12x, preferred over `FLASHINFER_MLA_SPARSE_SM120` until the mbarrier race is resolved upstream; keep flashinfer selectable explicitly.
2. Ensure `--attention-backend FLASHMLA_SPARSE` is honored for the main model on sm12x (today it is effectively reachable only via spec-config `attention_backend` for the drafter).
3. Log the fallback reason when flashinfer sm120 is skipped/deprioritized on sm12x so users can correlate with this issue.

## Caveats / honest scope
- The livelock is probabilistic per cold-prefill tile count: quiet short-context or warm-cache serving will NOT reproduce it; staged cold prefill at ≥2.4K-token deltas reproduced it within seconds on our fleet.
- Perf: Triton route throughput vs the flashinfer baseline is measured in our write-up (the cure's cost is a number, stated there); selector preference may want a perf note.
- Generalization, softened to what we actually know: the race is in kernel-internal barrier logic and plausibly family-wide across sm12x; our validation covers only one model family (GLM-5.2 int4-int8mix, TP=4, MTP spec=4) on GB10 4× DGX Spark; other sm12x targets are untested.

## Validation context and base
All validation above was performed on our production deployment, which is built from the jasl fork lineage (vLLM 0.23.1rc1.dev893+gd3a66aa7e). This branch is the port of that change onto upstream main at 3775d5f.

The port is compile-checked but has not been re-executed against the upstream base; happy to rebase onto current main on maintainer request.

## AI-assistance disclosure (per AGENTS.md §1 Accountability)

**AI assistance was used throughout this contribution.** The investigation, evidence collection (cuda-gdb captures, RAS monitoring, soak testing), root-cause analysis, and drafting of this PR involved AI agents (Claude, operating as orchestrator and technical writer) under continuous human direction and review by @marksunner. All claims are backed by the linked [evidence pack](https://github.com/marksunner/glm52-dgx-spark-deadlock-evidence/tree/main/evidence-pack); every receipt cited in this PR description is a real artifact from the investigation.

**Not duplicating an existing PR:** No open PR addresses the sm12x sparse-MLA backend selection gap or the flashinfer `sparse_mla_sm120` livelock. The closest related issues are #48720 (this RFC, filed by us) and #41725 (sampler event-sync hang — a separate bug class on the same platform).

**Testing:** Validation was performed on a 4× DGX Spark production deployment (GLM-5.2 int4-int8mix, TP=4, MTP spec=4). The branch is ported onto upstream main at 3775d5f and compile-checked; full re-execution results are from the jasl fork lineage deployment as disclosed in "Validation context and base" above. 560+ clean ceiling sessions, 500 consecutive under enforce, a 15-hour unattended overnight, and a cold staged climb to 200K tokens — all zero wedges. No model evaluation regression observed (decode throughput ≥25 tok/s, at or above the flashinfer baseline).

## Refs
- RFC vllm-project/vllm #48720 (this campaign's RFC; §4/§5 mechanism material, results update posted alongside this PR).
- Issue #41725 (sm_12x sampler event-sync hang — separate disease, same platform; comment cross-posted).
- NVIDIA dossier: sparse-mla-sm120 mbarrier livelock (filed separately; kernel fix is theirs, this PR is the vLLM-side escape hatch).


