### PR TITLE
[Bugfix][Tool Parser] Implement streaming for phi4_mini_json parser

### DIFF
--- a/tests/tool_parsers/test_phi4mini_tool_parser.py
+++ b/tests/tool_parsers/test_phi4mini_tool_parser.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -9,7 +10,9 @@ from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
+from tests.tool_parsers.utils import run_tool_extraction_streaming
 from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers import ToolParser, ToolParserManager
 
 
 class TestPhi4MiniToolParser(ToolParserTests):
@@ -85,18 +88,7 @@ Would you like to know more?""",
             parallel_tool_calls_names=["get_weather", "get_time"],
             parallel_tool_calls_expected_content=None,
             # xfail markers
-            xfail_streaming={
-                "test_no_tool_calls": "Phi4 Mini streaming not implemented",
-                "test_single_tool_call_simple_args": (
-                    "Phi4 Mini streaming not implemented"
-                ),
-                "test_parallel_tool_calls": "Phi4 Mini streaming not implemented",
-                "test_various_data_types": "Phi4 Mini streaming not implemented",
-                "test_empty_arguments": "Phi4 Mini streaming not implemented",
-                "test_surrounding_text": "Phi4 Mini streaming not implemented",
-                "test_escaped_strings": "Phi4 Mini streaming not implemented",
-                "test_streaming_reconstruction": "Phi4 Mini streaming not implemented",
-            },
+            xfail_streaming={},
             xfail_nonstreaming={
                 "test_various_data_types": (
                     "Phi4MiniJsonToolParser regex has nesting limitations "
@@ -108,3 +100,74 @@ Would you like to know more?""",
                 ),
             },
         )
+
+
+@pytest.fixture
+def phi4mini_parser(default_tokenizer: TokenizerLike) -> ToolParser:
+    return ToolParserManager.get_tool_parser("phi4_mini_json")(default_tokenizer)
+
+
+def test_streaming_split_marker_is_not_emitted_as_content(
+    phi4mini_parser: ToolParser,
+) -> None:
+    """The `functools` marker spans several tokens and must not leak."""
+    deltas = [
+        "func",
+        "tools",
+        "[",
+        '{"name": "get_weather", ',
+        '"arguments": {"city": ',
+        '"Tokyo"}}]',
+    ]
+
+    reconstructor = run_tool_extraction_streaming(phi4mini_parser, deltas)
+
+    assert reconstructor.other_content == "", (
+        f"Marker leaked into content: {reconstructor.other_content!r}"
+    )
+    assert len(reconstructor.tool_calls) == 1, (
+        f"Expected 1 tool call, got {len(reconstructor.tool_calls)}"
+    )
+    assert reconstructor.tool_calls[0].function.name == "get_weather"
+    assert json.loads(reconstructor.tool_calls[0].function.arguments) == {
+        "city": "Tokyo"
+    }
+
+
+def test_streaming_parameters_key_is_streamed_as_arguments(
+    phi4mini_parser: ToolParser,
+) -> None:
+    """phi-4-mini templates emit either `arguments` or `parameters`."""
+    deltas = [
+        'functools[{"name": "get_time", ',
+        '"parameters": {"timezone": "Asia/Tokyo"}}]',
+    ]
+
+    reconstructor = run_tool_extraction_streaming(phi4mini_parser, deltas)
+
+    assert len(reconstructor.tool_calls) == 1, (
+        f"Expected 1 tool call, got {len(reconstructor.tool_calls)}"
+    )
+    assert reconstructor.tool_calls[0].function.name == "get_time"
+    assert json.loads(reconstructor.tool_calls[0].function.arguments) == {
+        "timezone": "Asia/Tokyo"
+    }
+
+
+def test_streaming_text_before_marker_is_preserved(
+    phi4mini_parser: ToolParser,
+) -> None:
+    """Content preceding the marker must still reach the client."""
+    deltas = [
+        "Let me check that.\n",
+        'functools[{"name": "get_weather", "arguments": {"city": "Tokyo"}}]',
+    ]
+
+    reconstructor = run_tool_extraction_streaming(phi4mini_parser, deltas)
+
+    assert reconstructor.other_content == "Let me check that.\n", (
+        f"Expected leading content to be preserved, got {reconstructor.other_content!r}"
+    )
+    assert len(reconstructor.tool_calls) == 1, (
+        f"Expected 1 tool call, got {len(reconstructor.tool_calls)}"
+    )

--- a/vllm/tool_parsers/phi4mini_tool_parser.py
+++ b/vllm/tool_parsers/phi4mini_tool_parser.py
@@ -6,6 +6,8 @@ from collections.abc import Sequence
 from typing import Any
 
 import regex as re
+from partial_json_parser.core.exceptions import MalformedJSON
+from partial_json_parser.core.options import Allow
 from transformers import PreTrainedTokenizerBase
 
 from vllm.entrypoints.chat_utils import make_tool_call_id
@@ -13,7 +15,9 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
 )
 from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
     DeltaMessage,
+    DeltaToolCall,
     ExtractedToolCallInformation,
     FunctionCall,
     ToolCall,
@@ -23,8 +27,26 @@ from vllm.tool_parsers.abstract_tool_parser import (
     Tool,
     ToolParser,
 )
+from vllm.tool_parsers.utils import (
+    find_common_prefix,
+    partial_json_loads,
+)
 
 logger = init_logger(__name__)
+
+
+def _partial_bot_token_len(text: str, bot_token: str) -> int:
+    """Length of the longest suffix of ``text`` that starts ``bot_token``.
+
+    The ``functools`` marker is not a special token, so it is split across
+    several ordinary tokens while streaming. Any trailing text that could still
+    grow into the marker is held back instead of being emitted as content.
+    """
+    max_len = min(len(text), len(bot_token) - 1)
+    for length in range(max_len, 0, -1):
+        if bot_token.startswith(text[-length:]):
+            return length
+    return 0
 
 
 class Phi4MiniJsonToolParser(ToolParser):
@@ -35,6 +57,8 @@ class Phi4MiniJsonToolParser(ToolParser):
     Used when --enable-auto-tool-choice --tool-call-parser phi4_mini_json
     are all set
     """
+
+    json_decoder: json.JSONDecoder = json.JSONDecoder()
 
     def __init__(
         self,
@@ -51,6 +75,8 @@ class Phi4MiniJsonToolParser(ToolParser):
             str
         ] = []  # map what has been streamed for each tool so far to a list
         self.bot_token: str = "functools"
+        # number of leading characters already streamed back as content
+        self.streamed_content_len: int = 0
 
     def extract_tool_calls(
         self, model_output: str, request: ChatCompletionRequest
@@ -113,6 +139,98 @@ class Phi4MiniJsonToolParser(ToolParser):
                 tools_called=False, tool_calls=[], content=model_output
             )
 
+    def _stream_content(self, current_text: str, up_to: int) -> DeltaMessage | None:
+        """Emit the not-yet-streamed content in ``current_text[:up_to]``."""
+        if up_to <= self.streamed_content_len:
+            return None
+        content = current_text[self.streamed_content_len : up_to]
+        self.streamed_content_len = up_to
+        return DeltaMessage(content=content)
+
+    def _parse_partial_tool_calls(
+        self, tool_calls_text: str, flags: Allow
+    ) -> tuple[list[dict[str, Any]], list[bool]]:
+        """Parse the (possibly incomplete) ``[...]`` array after the marker.
+
+        Returns the tool call objects decoded so far along with, for each of
+        them, whether its JSON object was already terminated.
+        """
+        tool_call_arr: list[dict[str, Any]] = []
+        is_complete: list[bool] = []
+
+        start_idx = 1 if tool_calls_text.startswith("[") else 0
+        while start_idx < len(tool_calls_text):
+            while (
+                start_idx < len(tool_calls_text)
+                and tool_calls_text[start_idx] in " \t\r\n,"
+            ):
+                start_idx += 1
+            if start_idx >= len(tool_calls_text) or tool_calls_text[start_idx] == "]":
+                break
+
+            remainder = tool_calls_text[start_idx:]
+            try:
+                # A terminated object is decoded directly; this also keeps the
+                # array's closing bracket away from the partial JSON parser,
+                # which cannot cope with an unmatched closing bracket.
+                obj, end_idx = self.json_decoder.raw_decode(remainder)
+                complete = True
+            except json.JSONDecodeError:
+                try:
+                    obj, end_idx = partial_json_loads(remainder, flags)
+                except (MalformedJSON, ValueError, IndexError):
+                    # Not enough tokens to parse into JSON yet, or the model
+                    # emitted something that is not a tool call at all.
+                    break
+                complete = False
+
+            if end_idx <= 0:
+                break
+
+            # phi-4-mini templates emit either "arguments" or "parameters"
+            if "parameters" in obj and "arguments" not in obj:
+                obj["arguments"] = obj["parameters"]
+
+            tool_call_arr.append(obj)
+            is_complete.append(complete)
+            start_idx += end_idx
+
+        return tool_call_arr, is_complete
+
+    def _argument_diff(
+        self, tool_call: dict[str, Any], is_complete: bool
+    ) -> str | None:
+        """Arguments of ``tool_call`` that have not been streamed yet."""
+        cur_arguments = tool_call.get("arguments")
+        if not cur_arguments:
+            return None
+
+        cur_args_json = json.dumps(cur_arguments, ensure_ascii=False)
+        sent = len(self.streamed_args_for_tool[self.current_tool_id])
+
+        if is_complete:
+            argument_diff = cur_args_json[sent:]
+        else:
+            prev_arguments = None
+            if self.current_tool_id < len(self.prev_tool_call_arr):
+                prev_arguments = self.prev_tool_call_arr[self.current_tool_id].get(
+                    "arguments"
+                )
+            if not prev_arguments:
+                return None
+            prev_args_json = json.dumps(prev_arguments, ensure_ascii=False)
+            if cur_args_json == prev_args_json:
+                return None
+            # Only stream the part both parses agree on, so that closing
+            # quotes and braces are not sent prematurely.
+            argument_diff = find_common_prefix(prev_args_json, cur_args_json)[sent:]
+
+        if not argument_diff:
+            return None
+
+        self.streamed_args_for_tool[self.current_tool_id] += argument_diff
+        return argument_diff
+
     def extract_tool_calls_streaming(
         self,
         previous_text: str,
@@ -123,4 +241,106 @@ class Phi4MiniJsonToolParser(ToolParser):
         delta_token_ids: Sequence[int],
         request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
-        return None
+        if not previous_text:
+            # a new response is starting, drop any state left from the last one
+            self.prev_tool_call_arr = []
+            self.current_tool_id = -1
+            self.current_tool_name_sent = False
+            self.streamed_args_for_tool = []
+            self.streamed_content_len = 0
+
+        bot_index = current_text.find(self.bot_token)
+
+        # No tool call started yet: stream everything as content, holding back
+        # any trailing text that could still grow into the marker.
+        if bot_index == -1:
+            safe_end = len(current_text) - _partial_bot_token_len(
+                current_text, self.bot_token
+            )
+            return self._stream_content(current_text, safe_end)
+
+        # Any text before the marker is regular content and must be flushed
+        # before the tool call deltas are emitted.
+        content_delta = self._stream_content(current_text, bot_index)
+        if content_delta is not None:
+            return content_delta
+
+        # bit mask flags for partial JSON parsing. If the name hasn't been
+        # sent yet, don't allow sending an incomplete string since OpenAI only
+        # ever allows sending the entire tool/function name at once.
+        flags = Allow.ALL if self.current_tool_name_sent else Allow.ALL & ~Allow.STR
+        tool_calls_text = current_text[bot_index + len(self.bot_token) :]
+
+        try:
+            tool_call_arr, is_complete = self._parse_partial_tool_calls(
+                tool_calls_text, flags
+            )
+
+            # case: nothing but the opening bracket has been streamed yet
+            if len(tool_call_arr) == 0:
+                return None
+
+            # case: we are starting a new tool in the array. Any arguments of
+            # the previous tool that were completed by the same chunk must be
+            # flushed before the cursor moves on.
+            if len(tool_call_arr) > self.current_tool_id + 1:
+                pending = None
+                if self.current_tool_id >= 0 and self.current_tool_name_sent:
+                    pending = self._argument_diff(
+                        tool_call_arr[self.current_tool_id], is_complete=True
+                    )
+
+                self.current_tool_id = len(tool_call_arr) - 1
+                self.current_tool_name_sent = False
+                self.streamed_args_for_tool.append("")
+                logger.debug("starting on new tool %d", self.current_tool_id)
+
+                if pending is not None:
+                    self.prev_tool_call_arr = tool_call_arr
+                    return pending
+
+            current_tool_call: dict = tool_call_arr[self.current_tool_id]
+
+            function_name = None
+            if not self.current_tool_name_sent:
+                function_name = current_tool_call.get("name")
+                if not function_name:
+                    self.prev_tool_call_arr = tool_call_arr
+                    return None
+                self.current_tool_name_sent = True
+
+            # The name and the first arguments chunk may be emitted together,
+            # but only once the object is terminated: while it is still partial
+            # the arguments were parsed with string values suppressed, so the
+            # diff would not be a prefix of the final arguments.
+            argument_diff = None
+            if function_name is None or is_complete[self.current_tool_id]:
+                argument_diff = self._argument_diff(
+                    current_tool_call, is_complete[self.current_tool_id]
+                )
+
+            self.prev_tool_call_arr = tool_call_arr
+
+            if function_name is None and argument_diff is None:
+                return None
+
+            return DeltaMessage(
+                tool_calls=[
+                    DeltaToolCall(
+                        index=self.current_tool_id,
+                        type="function" if function_name else None,
+                        id=make_tool_call_id() if function_name else None,
+                        function=DeltaFunctionCall(
+                            name=function_name,
+                            arguments=argument_diff,
+                        ).model_dump(exclude_none=True),
+                    )
+                ]
+            )
+
+        except Exception:
+            logger.exception("Error trying to handle streaming tool call.")
+            logger.debug(
+                "Skipping chunk as a result of tool streaming extraction error"
+            )
+            return None

--- a/vllm/tool_parsers/phi4mini_tool_parser.py
+++ b/vllm/tool_parsers/phi4mini_tool_parser.py
@@ -6,11 +6,15 @@ from collections.abc import Sequence
 from typing import Any
 
 import regex as re
+from partial_json_parser.core.exceptions import MalformedJSON
+from partial_json_parser.core.options import Allow
 from transformers import PreTrainedTokenizerBase
 
 from vllm.entrypoints.chat_utils import make_tool_call_id
 from vllm.entrypoints.generate.base.protocol import (
+    DeltaFunctionCall,
     DeltaMessage,
+    DeltaToolCall,
     ExtractedToolCallInformation,
     FunctionCall,
     ToolCall,
@@ -23,8 +27,26 @@ from vllm.tool_parsers.abstract_tool_parser import (
     Tool,
     ToolParser,
 )
+from vllm.tool_parsers.utils import (
+    find_common_prefix,
+    partial_json_loads,
+)
 
 logger = init_logger(__name__)
+
+
+def _partial_bot_token_len(text: str, bot_token: str) -> int:
+    """Length of the longest suffix of ``text`` that starts ``bot_token``.
+
+    The ``functools`` marker is not a special token, so it is split across
+    several ordinary tokens while streaming. Any trailing text that could still
+    grow into the marker is held back instead of being emitted as content.
+    """
+    max_len = min(len(text), len(bot_token) - 1)
+    for length in range(max_len, 0, -1):
+        if bot_token.startswith(text[-length:]):
+            return length
+    return 0
 
 
 class Phi4MiniJsonToolParser(ToolParser):
@@ -35,6 +57,8 @@ class Phi4MiniJsonToolParser(ToolParser):
     Used when --enable-auto-tool-choice --tool-call-parser phi4_mini_json
     are all set
     """
+
+    json_decoder: json.JSONDecoder = json.JSONDecoder()
 
     def __init__(
         self,
@@ -51,6 +75,8 @@ class Phi4MiniJsonToolParser(ToolParser):
             str
         ] = []  # map what has been streamed for each tool so far to a list
         self.bot_token: str = "functools"
+        # number of leading characters already streamed back as content
+        self.streamed_content_len: int = 0
 
     def extract_tool_calls(
         self, model_output: str, request: ChatCompletionRequest
@@ -113,6 +139,98 @@ class Phi4MiniJsonToolParser(ToolParser):
                 tools_called=False, tool_calls=[], content=model_output
             )
 
+    def _stream_content(self, current_text: str, up_to: int) -> DeltaMessage | None:
+        """Emit the not-yet-streamed content in ``current_text[:up_to]``."""
+        if up_to <= self.streamed_content_len:
+            return None
+        content = current_text[self.streamed_content_len : up_to]
+        self.streamed_content_len = up_to
+        return DeltaMessage(content=content)
+
+    def _parse_partial_tool_calls(
+        self, tool_calls_text: str, flags: Allow
+    ) -> tuple[list[dict[str, Any]], list[bool]]:
+        """Parse the (possibly incomplete) ``[...]`` array after the marker.
+
+        Returns the tool call objects decoded so far along with, for each of
+        them, whether its JSON object was already terminated.
+        """
+        tool_call_arr: list[dict[str, Any]] = []
+        is_complete: list[bool] = []
+
+        start_idx = 1 if tool_calls_text.startswith("[") else 0
+        while start_idx < len(tool_calls_text):
+            while (
+                start_idx < len(tool_calls_text)
+                and tool_calls_text[start_idx] in " \t\r\n,"
+            ):
+                start_idx += 1
+            if start_idx >= len(tool_calls_text) or tool_calls_text[start_idx] == "]":
+                break
+
+            remainder = tool_calls_text[start_idx:]
+            try:
+                # A terminated object is decoded directly; this also keeps the
+                # array's closing bracket away from the partial JSON parser,
+                # which cannot cope with an unmatched closing bracket.
+                obj, end_idx = self.json_decoder.raw_decode(remainder)
+                complete = True
+            except json.JSONDecodeError:
+                try:
+                    obj, end_idx = partial_json_loads(remainder, flags)
+                except (MalformedJSON, ValueError, IndexError):
+                    # Not enough tokens to parse into JSON yet, or the model
+                    # emitted something that is not a tool call at all.
+                    break
+                complete = False
+
+            if end_idx <= 0:
+                break
+
+            # phi-4-mini templates emit either "arguments" or "parameters"
+            if "parameters" in obj and "arguments" not in obj:
+                obj["arguments"] = obj["parameters"]
+
+            tool_call_arr.append(obj)
+            is_complete.append(complete)
+            start_idx += end_idx
+
+        return tool_call_arr, is_complete
+
+    def _argument_diff(
+        self, tool_call: dict[str, Any], is_complete: bool
+    ) -> str | None:
+        """Arguments of ``tool_call`` that have not been streamed yet."""
+        cur_arguments = tool_call.get("arguments")
+        if not cur_arguments:
+            return None
+
+        cur_args_json = json.dumps(cur_arguments, ensure_ascii=False)
+        sent = len(self.streamed_args_for_tool[self.current_tool_id])
+
+        if is_complete:
+            argument_diff = cur_args_json[sent:]
+        else:
+            prev_arguments = None
+            if self.current_tool_id < len(self.prev_tool_call_arr):
+                prev_arguments = self.prev_tool_call_arr[self.current_tool_id].get(
+                    "arguments"
+                )
+            if not prev_arguments:
+                return None
+            prev_args_json = json.dumps(prev_arguments, ensure_ascii=False)
+            if cur_args_json == prev_args_json:
+                return None
+            # Only stream the part both parses agree on, so that closing
+            # quotes and braces are not sent prematurely.
+            argument_diff = find_common_prefix(prev_args_json, cur_args_json)[sent:]
+
+        if not argument_diff:
+            return None
+
+        self.streamed_args_for_tool[self.current_tool_id] += argument_diff
+        return argument_diff
+
     def extract_tool_calls_streaming(
         self,
         previous_text: str,
@@ -123,4 +241,106 @@ class Phi4MiniJsonToolParser(ToolParser):
         delta_token_ids: Sequence[int],
         request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
-        return None
+        if not previous_text:
+            # a new response is starting, drop any state left from the last one
+            self.prev_tool_call_arr = []
+            self.current_tool_id = -1
+            self.current_tool_name_sent = False
+            self.streamed_args_for_tool = []
+            self.streamed_content_len = 0
+
+        bot_index = current_text.find(self.bot_token)
+
+        # No tool call started yet: stream everything as content, holding back
+        # any trailing text that could still grow into the marker.
+        if bot_index == -1:
+            safe_end = len(current_text) - _partial_bot_token_len(
+                current_text, self.bot_token
+            )
+            return self._stream_content(current_text, safe_end)
+
+        # Any text before the marker is regular content and must be flushed
+        # before the tool call deltas are emitted.
+        content_delta = self._stream_content(current_text, bot_index)
+        if content_delta is not None:
+            return content_delta
+
+        # bit mask flags for partial JSON parsing. If the name hasn't been
+        # sent yet, don't allow sending an incomplete string since OpenAI only
+        # ever allows sending the entire tool/function name at once.
+        flags = Allow.ALL if self.current_tool_name_sent else Allow.ALL & ~Allow.STR
+        tool_calls_text = current_text[bot_index + len(self.bot_token) :]
+
+        try:
+            tool_call_arr, is_complete = self._parse_partial_tool_calls(
+                tool_calls_text, flags
+            )
+
+            # case: nothing but the opening bracket has been streamed yet
+            if len(tool_call_arr) == 0:
+                return None
+
+            # case: we are starting a new tool in the array. Any arguments of
+            # the previous tool that were completed by the same chunk must be
+            # flushed before the cursor moves on.
+            if len(tool_call_arr) > self.current_tool_id + 1:
+                pending = None
+                if self.current_tool_id >= 0 and self.current_tool_name_sent:
+                    pending = self._argument_diff(
+                        tool_call_arr[self.current_tool_id], is_complete=True
+                    )
+
+                self.current_tool_id = len(tool_call_arr) - 1
+                self.current_tool_name_sent = False
+                self.streamed_args_for_tool.append("")
+                logger.debug("starting on new tool %d", self.current_tool_id)
+
+                if pending is not None:
+                    self.prev_tool_call_arr = tool_call_arr
+                    return pending
+
+            current_tool_call: dict = tool_call_arr[self.current_tool_id]
+
+            function_name = None
+            if not self.current_tool_name_sent:
+                function_name = current_tool_call.get("name")
+                if not function_name:
+                    self.prev_tool_call_arr = tool_call_arr
+                    return None
+                self.current_tool_name_sent = True
+
+            # The name and the first arguments chunk may be emitted together,
+            # but only once the object is terminated: while it is still partial
+            # the arguments were parsed with string values suppressed, so the
+            # diff would not be a prefix of the final arguments.
+            argument_diff = None
+            if function_name is None or is_complete[self.current_tool_id]:
+                argument_diff = self._argument_diff(
+                    current_tool_call, is_complete[self.current_tool_id]
+                )
+
+            self.prev_tool_call_arr = tool_call_arr
+
+            if function_name is None and argument_diff is None:
+                return None
+
+            return DeltaMessage(
+                tool_calls=[
+                    DeltaToolCall(
+                        index=self.current_tool_id,
+                        type="function" if function_name else None,
+                        id=make_tool_call_id() if function_name else None,
+                        function=DeltaFunctionCall(
+                            name=function_name,
+                            arguments=argument_diff,
+                        ).model_dump(exclude_none=True),
+                    )
+                ]
+            )
+
+        except Exception:
+            logger.exception("Error trying to handle streaming tool call.")
+            logger.debug(
+                "Skipping chunk as a result of tool streaming extraction error"
+            )
+            return None


### PR DESCRIPTION
## Purpose

`Phi4MiniJsonToolParser.extract_tool_calls_streaming()` is a stub that unconditionally returns `None`. `ParserManager.extract_tool_calls_streaming()` forwards that return value straight to the serving layer, so with `--tool-call-parser phi4_mini_json` and `"stream": true` every delta is discarded: the client receives neither tool calls nor the assistant's plain-text content. Only the non-streaming path works today.

This was reported in #18257 (Phi-4 function calling with streaming) and closed as stale without a fix.

The Rust frontend already implements streaming for this parser (`rust/src/parser/src/tool/json/phi4mini.rs`, covered by `phi4mini_streaming_emits_argument_deltas` and `phi4mini_streaming_handles_split_markers`), so this is a Python/Rust parity gap. `VLLM_USE_RUST_FRONTEND` defaults to `0`, which means the broken Python path is the default one.

## Modification

`extract_tool_calls_streaming()` is implemented following the existing `Llama3JsonToolParser` pattern, which handles the same "JSON array of `{name, arguments}` objects behind a marker" shape, reusing `partial_json_loads` and `find_common_prefix` from `vllm/tool_parsers/utils.py`:

- Text before the `functools` marker is streamed as content. The marker is not a special token, so it arrives split across several ordinary tokens; trailing text that is still a prefix of the marker is held back so it never leaks into `content`.
- After the marker, the `[...]` array is decoded incrementally. Terminated objects go through `JSONDecoder.raw_decode`, which also keeps the array's closing bracket away from the partial JSON parser (it raises `IndexError` on an unmatched closing bracket). Objects still being generated fall back to `partial_json_loads`.
- The function name is emitted once with the tool call id; argument deltas are then streamed against the previous partial parse via `find_common_prefix` so premature closing quotes and braces are not sent. The name and the first arguments chunk are emitted together when the object is already terminated, which keeps the output correct regardless of how the text is chunked.
- Both the `arguments` and `parameters` key variants are handled, matching the non-streaming path and the Rust implementation.
- Parallel tool calls advance the tool index and flush any unstreamed arguments of the previous call first.

The non-streaming `extract_tool_calls()` is deliberately left untouched: the nested-array truncation there is being fixed separately in #48795, so these two changes do not overlap.

## Test Plan

`tests/tool_parsers/common_tests.py` already contains full streaming coverage for this parser, but all eight streaming tests were marked `xfail(strict=True)` with the reason "Phi4 Mini streaming not implemented". Those markers are removed, so the shared suite itself becomes the regression test. Three phi-4-specific tests are added for cases the shared suite does not exercise: the marker split across deltas, the `parameters` key variant, and content preceding the marker.

```bash
pytest tests/tool_parsers/test_phi4mini_tool_parser.py -v
pytest tests/tool_parsers/ -q
ruff check vllm/tool_parsers/phi4mini_tool_parser.py tests/tool_parsers/test_phi4mini_tool_parser.py
ruff format --check vllm/tool_parsers/phi4mini_tool_parser.py tests/tool_parsers/test_phi4mini_tool_parser.py
mypy vllm/tool_parsers/phi4mini_tool_parser.py
```

## Test Result

Before (this branch's tests against the unmodified parser), 11 failures:

```
FAILED tests/tool_parsers/test_phi4mini_tool_parser.py::TestPhi4MiniToolParser::test_no_tool_calls[True]
FAILED tests/tool_parsers/test_phi4mini_tool_parser.py::TestPhi4MiniToolParser::test_single_tool_call_simple_args[True]
FAILED tests/tool_parsers/test_phi4mini_tool_parser.py::TestPhi4MiniToolParser::test_parallel_tool_calls[True]
FAILED tests/tool_parsers/test_phi4mini_tool_parser.py::TestPhi4MiniToolParser::test_various_data_types[True]
FAILED tests/tool_parsers/test_phi4mini_tool_parser.py::TestPhi4MiniToolParser::test_empty_arguments[True]
FAILED tests/tool_parsers/test_phi4mini_tool_parser.py::TestPhi4MiniToolParser::test_surrounding_text[True]
FAILED tests/tool_parsers/test_phi4mini_tool_parser.py::TestPhi4MiniToolParser::test_escaped_strings[True]
FAILED tests/tool_parsers/test_phi4mini_tool_parser.py::TestPhi4MiniToolParser::test_streaming_reconstruction
FAILED tests/tool_parsers/test_phi4mini_tool_parser.py::test_streaming_split_marker_is_not_emitted_as_content
FAILED tests/tool_parsers/test_phi4mini_tool_parser.py::test_streaming_parameters_key_is_streamed_as_arguments
FAILED tests/tool_parsers/test_phi4mini_tool_parser.py::test_streaming_text_before_marker_is_preserved
11 failed, 7 passed, 2 xfailed in 7.04s
```

After:

```
18 passed, 2 xfailed in 6.66s
```

The two remaining xfails are the pre-existing non-streaming ones, which are out of scope here.

Full parser suite:

```
901 passed, 1 skipped, 26 xfailed, 15 errors in 452.86s
```

The 15 errors are all in `test_llama3_json_tool_parser.py` and are environmental: the fixture downloads the gated `meta-llama/Llama-3.2-1B-Instruct` repo and gets HTTP 401 without HF credentials. They reproduce identically on an unmodified checkout.

Lint and types:

```
ruff check   -> All checks passed!
ruff format  -> 2 files already formatted
mypy         -> Success: no issues found in 1 source file
```

No end-to-end serving run: the available GPU (8 GB) cannot hold Phi-4-mini alongside the KV cache. The change is confined to parser logic, which the unit suite covers in both streaming and non-streaming modes.

---

Duplicate-work check: no open PR addresses phi-4-mini streaming. `gh pr list --repo vllm-project/vllm --state open --search "phi4mini"` returns only #48795, which is scoped to the non-streaming regex in the same file. #18257 is closed and unfixed.

AI assistance was used in preparing this change; all code and test results were reviewed by the submitter.
