### PR TITLE
Revert "[Bugfix] Fix activation quantization dispatch for WNA4Int/WNA8Int" (#48785)

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa4.py
@@ -96,7 +96,7 @@ class CompressedTensorsWNA4Int(CompressedTensorsScheme):
         return 75
 
     def _build_input_quant_config(self) -> dict | None:
-        """Build the config dict that BaseInputSchema.from_config expects."""
+        """Build the config dict that HummingInputSchema.from_config expects."""
         if self.input_quant is None:
             return None
         iq = self.input_quant
@@ -112,7 +112,7 @@ class CompressedTensorsWNA4Int(CompressedTensorsScheme):
             "dynamic": iq.dynamic,
             "group_size": iq.group_size or 0,
             "quant_method": "compressed-tensors",
-            "format": "int-quantized",
+            "format": self.quant_format,
         }
 
     def create_weights(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa8.py
@@ -96,7 +96,7 @@ class CompressedTensorsWNA8Int(CompressedTensorsScheme):
         return 75
 
     def _build_input_quant_config(self) -> dict | None:
-        """Build the config dict that BaseInputSchema.from_config expects."""
+        """Build the config dict that HummingInputSchema.from_config expects."""
         if self.input_quant is None:
             return None
         iq = self.input_quant
@@ -112,7 +112,7 @@ class CompressedTensorsWNA8Int(CompressedTensorsScheme):
             "dynamic": iq.dynamic,
             "group_size": iq.group_size or 0,
             "quant_method": "compressed-tensors",
-            "format": "int-quantized",
+            "format": self.quant_format,
         }
 
     def create_weights(

--- a/vllm/model_executor/layers/quantization/utils/humming_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/humming_utils.py
@@ -441,7 +441,6 @@ def prepare_humming_layer(
     input_quant_config: dict | None = None,
 ):
     from vllm.utils.humming import (
-        BaseInputSchema,
         BaseWeightSchema,
         HummingInputSchema,
         HummingMethod,
@@ -449,7 +448,7 @@ def prepare_humming_layer(
 
     weight_schema = BaseWeightSchema.from_config(quant_config)
     if input_quant_config is not None:
-        input_schema = BaseInputSchema.from_config(input_quant_config)
+        input_schema = HummingInputSchema.from_config(input_quant_config)
     else:
         input_schema = HummingInputSchema()
 
@@ -464,15 +463,9 @@ def prepare_humming_layer(
     shape_k_stacks = [input_size_per_partition]
     shape_n_stacks = layer.output_partition_sizes
 
-    # Step 1: convert weight and input schemas to humming standard format
+    # Step 1: convert weight to humming standard format
     weight_schema, tensors = weight_schema.convert_humming(
         tensors=dict(layer.named_parameters()),
-        shape_n_stacks=shape_n_stacks,
-        shape_k_stacks=shape_k_stacks,
-        param_dtype=layer.params_dtype,
-    )
-    input_schema, _ = input_schema.convert_humming(
-        tensors={},
         shape_n_stacks=shape_n_stacks,
         shape_k_stacks=shape_k_stacks,
         param_dtype=layer.params_dtype,


### PR DESCRIPTION
Reverts vllm-project/vllm#48785 ("[Bugfix] Fix activation quantization dispatch for WNA4Int/WNA8Int").

**Reason:** This PR is linked to **1** new nightly CI failure in build [#78700](https://buildkite.com/vllm/ci/builds/78700):
- `LM Eval Humming Act fp8/int8 (H100 - TEMPORARY)`

The `Qwen3-4B-mixed-quant-RTN-humming` server crashed at startup (profile_run) with an `AssertionError` in the humming WNA4Int kernel dispatch (`assert meta.a_dtype in cls.b4_allowed_dtypes`), triggered from `CompressedTensorsWNA4Int.apply_weights`. This PR modified exactly the files/functions in the crash traceback (`compressed_tensors_wNa4.py`, `humming_utils.py`).

Failure is deterministic (server startup crash), not an infra/flaky issue.

Auto-generated by CI failure analyzer.