### PR TITLE
fix: handle missing parent modules in _has_module

### DIFF
--- a/tests/utils_/test_import_utils.py
+++ b/tests/utils_/test_import_utils.py
@@ -87,11 +87,15 @@ class TestHasModule:
         """``find_spec`` itself can raise for dotted names whose parent package
         fails to import. This should be treated as the module being unavailable.
         """
-        with patch(
-            "vllm.utils.import_utils.importlib.util.find_spec",
-            side_effect=ModuleNotFoundError("No module named 'fake_parent'"),
+        with (
+            patch(
+                "vllm.utils.import_utils.importlib.util.find_spec",
+                side_effect=ModuleNotFoundError("No module named 'fake_parent'"),
+            ),
+            patch("vllm.utils.import_utils.logger.warning") as mock_warning,
         ):
             assert _has_module("fake_parent.child") is False
+            mock_warning.assert_not_called()
 
     def test_result_is_cached(self):
         """Verify the @cache decorator prevents repeated imports."""

--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -401,8 +401,14 @@ def _has_module(module_name: str) -> bool:
     for the same module incur no additional overhead.
     """
     try:
-        if importlib.util.find_spec(module_name) is None:
-            return False
+        module_spec = importlib.util.find_spec(module_name)
+    except ModuleNotFoundError:
+        return False
+
+    if module_spec is None:
+        return False
+
+    try:
         importlib.import_module(module_name)
     except Exception:
         logger.warning(


### PR DESCRIPTION
## Problem

`importlib.util.find_spec()` can raise `ModuleNotFoundError` for a dotted optional dependency when its parent package is absent. `_has_module()` should report that dependency as unavailable instead of failing the caller.

## Fix

Catch `ModuleNotFoundError` only around the specification lookup and return `False`. Keep the existing warning behavior for exceptions raised while importing a module whose spec exists.

## Validation

- Added regression coverage for a missing parent package and verified that the expected absence does not emit a warning.
- `ruff check vllm/utils/import_utils.py tests/utils_/test_import_utils.py`
- `ruff format --check vllm/utils/import_utils.py tests/utils_/test_import_utils.py`
- `python3 -m compileall -q vllm/utils/import_utils.py tests/utils_/test_import_utils.py`

This is an optional-dependency correctness fix and makes no performance claim.\n\n### Current-head validation (2026-07-26)\n\n- Rebased onto upstream `main` `0ba2aa35a81dcc3246b26291368b53fa2389c7d7`.\n- Exact PR head: `ecfb38de74b91079599922aca2c6d0e5bea01f2e`.\n- `TestHasModule`: 5 passed with backend auto-loading disabled; the only full-file failure was the source-checkout metadata expectation outside this change.\n- Ruff check, Ruff format check, and `git diff --check` passed.\n\n\n## Contribution disclosure

- Duplicate-work check: an open-PR search for _has_module missing parent found only this PR.
- AI assistance was used for implementation support, test execution, rebase maintenance, and drafting this description. The human submitter remains responsible for reviewing and defending the change.
