### PR TITLE
fix(spec_decode): bypass embedding dim check for MTP speculative decoding methods

### DIFF
--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1487,7 +1487,7 @@ class SpecDecodeBaseProposer:
                 ):
                     target_dim = target_embed_tokens.weight.shape[-1]
                     draft_dim = draft_embed.weight.shape[-1]
-                    if target_dim != draft_dim:
+                    if target_dim != draft_dim and self.method != "mtp":
                         share_embeddings = False
                         logger.info(
                             "Target embedding dim (%d) differs from draft "


### PR DESCRIPTION
## Description
This PR resolves a regression introduced in version 0.25.1 where Gemma4 MTP speculative decoding fails at engine initialization with a `RuntimeError: a and b must have same reduction dim, but got [s47, 3840] X [5632, 1024]` shape validation exception.

### Root Cause
A recent linter safeguard designed to prevent shared text-embedding crashes (introduced during Eagle3/XPU updates) enforces that a draft model must fall back to its own layout if its embedding dimension differs from the target model. 

However, Gemma4 MTP architecture intentionally utilizes the target model's embedding size (`1,792`) and concatenates it with the hidden states (`3,840`) to form the required input features vector (`5,632`) entering `pre_projection`. Because the safeguard inadvertently severed the link to the target's embeddings, the engine only passed the bare `3,840` tensor array down to the linear mapping, causing structural dimension layout failures during compilation and lazy graph execution traces.

### Solution
Modified the shared-embedding guard clause in `vllm/v1/spec_decode/llm_base_proposer.py` to check for and bypass dimension mismatch overrides if the chosen speculative inference framework method is strictly set to `"mtp"`. This restores parity with the original initialization mapping from `0.21.0` while maintaining full stability protection for Eagle3 modules.

Fixes #48848

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation / Testing

## How Has This Been Tested?
1. Initialized serving node with `coder3101/gemma-4-26B-A4B-it-heretic` (--quantization fp8) as target and `google/gemma-4-26B-A4B-it-assistant` as MTP speculator.
2. Verified the engine successfully clears lazy tracing pipelines and triggers runtime deployment parameters under the V1 Model Runner without needing `VLLM_USE_V2_MODEL_RUNNER=1` environment flags.