### PR TITLE
[Perf] Add per-phase cold-start startup span benchmark harness

### DIFF
--- a/tests/benchmarks/test_startup_spans.py
+++ b/tests/benchmarks/test_startup_spans.py
@@ -19,6 +19,7 @@ prints the per-phase table header, guarding the wiring in
 ``vllm/benchmarks/startup.py``.
 """
 
+import json
 import subprocess
 import time
 
@@ -34,7 +35,10 @@ from vllm import LLM
 from vllm.benchmarks.startup_spans import (
     COLD_START_PHASES,
     PHASE_LIST_VERSION,
+    InMemorySpanSink,
     build_phase_report,
+    compare_to_baseline,
+    format_phase_report,
     select_phase_spans,
 )
 from vllm.distributed import cleanup_dist_env_and_memory
@@ -150,3 +154,214 @@ def test_bench_startup_per_phase_flag():
         assert phase_name in result.stdout, (
             f"phase '{phase_name}' not in stdout table"
         )
+
+
+# ---------------------------------------------------------------------------
+# Lightweight, non-GPU unit tests for the pure consumer logic. These guard
+# regressions in select_phase_spans / build_phase_report / InMemorySpanSink /
+# compare_to_baseline / format_phase_report on CI-skip lanes that have no GPU
+# and no ``vllm`` console script. They never boot an LLM.
+# ---------------------------------------------------------------------------
+
+
+def test_select_phase_spans_picks_earliest():
+    """select_phase_spans picks the earliest span per phase, marks absent
+    phases missing, and clamps negative durations to 0.0 (#40698). No GPU.
+    """
+    spans = [
+        # Duplicate "Worker init": the later-starting one must NOT win.
+        {"name": "Worker init", "start_time_unix_nano": 200_000_000,
+         "end_time_unix_nano": 300_000_000},
+        {"name": "Worker init", "start_time_unix_nano": 100_000_000,
+         "end_time_unix_nano": 150_000_000},
+        # end < start (#40698 timing-fix edge case) -> duration clamped to 0.0.
+        {"name": "Loading (GPU)", "start_time_unix_nano": 400_000_000,
+         "end_time_unix_nano": 100_000_000},
+        {"name": "Init device", "start_time_unix_nano": 200_000_000,
+         "end_time_unix_nano": 250_000_000},
+        {"name": "Allocate KV cache", "start_time_unix_nano": 500_000_000,
+         "end_time_unix_nano": 550_000_000},
+        {"name": "Warmup (GPU)", "start_time_unix_nano": 600_000_000,
+         "end_time_unix_nano": 700_000_000},
+        # "Capture model" is intentionally absent -> missing placeholder.
+        # An unknown span is a logged warning, never a failure.
+        {"name": "Mystery phase", "start_time_unix_nano": 0,
+         "end_time_unix_nano": 0},
+    ]
+    result = select_phase_spans(spans, COLD_START_PHASES)
+
+    # (a) exactly 6 rows, one per canonical phase, in COLD_START_PHASES order.
+    assert len(result) == len(COLD_START_PHASES) == 6
+    assert [s.name for s in result] == list(COLD_START_PHASES)
+    # (b) duplicate "Worker init" collapses to the earliest start_ns.
+    worker = result[0]
+    assert worker.name == "Worker init"
+    assert worker.start_ns == 100_000_000
+    assert worker.duration_s == 0.05  # 50 ms
+    assert not worker.missing
+    # (c) absent "Capture model" -> missing=True, zero-duration placeholder.
+    capture = result[3]
+    assert capture.name == "Capture model"
+    assert capture.missing is True
+    assert capture.duration_s == 0.0
+    # (d) end < start -> duration clamped to 0.0 (#40698 edge case).
+    loading = result[2]
+    assert loading.name == "Loading (GPU)"
+    assert loading.duration_s == 0.0
+    # All durations are non-negative.
+    assert all(s.duration_s >= 0.0 for s in result)
+
+
+def test_build_phase_report_shape():
+    """build_phase_report returns the frozen version, 6 phase rows, the summed
+    total, and echoes wall_clock_startup_s. No GPU.
+    """
+    spans = [
+        {"name": "Worker init", "start_time_unix_nano": 0,
+         "end_time_unix_nano": 100_000_000},   # 0.10 s
+        {"name": "Init device", "start_time_unix_nano": 0,
+         "end_time_unix_nano": 50_000_000},    # 0.05 s
+        {"name": "Loading (GPU)", "start_time_unix_nano": 0,
+         "end_time_unix_nano": 200_000_000},   # 0.20 s
+        {"name": "Capture model", "start_time_unix_nano": 0,
+         "end_time_unix_nano": 80_000_000},    # 0.08 s
+        {"name": "Allocate KV cache", "start_time_unix_nano": 0,
+         "end_time_unix_nano": 70_000_000},    # 0.07 s
+        {"name": "Warmup (GPU)", "start_time_unix_nano": 0,
+         "end_time_unix_nano": 150_000_000},   # 0.15 s
+    ]
+    phase_spans = select_phase_spans(spans, COLD_START_PHASES)
+    report = build_phase_report(phase_spans, wall_clock_startup_s=1.0)
+
+    assert report["phase_list_version"] == PHASE_LIST_VERSION == 1
+    assert len(report["phases"]) == 6
+    durations = [p["duration_s"] for p in report["phases"]]
+    assert report["total_phase_time_s"] == sum(durations)
+    assert report["wall_clock_startup_s"] == 1.0
+    # Every row carries the frozen-shape fields.
+    for p in report["phases"]:
+        assert {"name", "duration_s", "start_ns", "end_ns", "missing"} <= set(p)
+
+
+def test_in_memory_span_sink_export_and_poll():
+    """InMemorySpanSink receives a span over gRPC and exposes it via
+    get_all_spans / wait_for_spans / clear. No GPU. Confirms the sink
+    functions as a TraceServiceServicer (inherited when opentelemetry is
+    installed, duck-typed via the gRPC Export contract).
+    """
+    import grpc
+    from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+        ExportTraceServiceRequest,
+    )
+    from opentelemetry.proto.collector.trace.v1.trace_service_pb2_grpc import (
+        TraceServiceStub,
+    )
+    from opentelemetry.proto.trace.v1.trace_pb2 import Span
+
+    sink = InMemorySpanSink(address="localhost:0")
+    address = sink.start()
+    try:
+        channel = grpc.insecure_channel(address)
+        # Block until the gRPC server is accepting connections.
+        grpc.channel_ready_future(channel).result(timeout=5.0)
+        stub = TraceServiceStub(channel)
+
+        span = Span(name="Worker init",
+                    start_time_unix_nano=100,
+                    end_time_unix_nano=200)
+        request = ExportTraceServiceRequest()
+        rs = request.resource_spans.add()
+        ss = rs.scope_spans.add()
+        ss.spans.add().CopyFrom(span)
+
+        stub.Export(request)
+
+        assert sink.wait_for_spans(["Worker init"], timeout=5.0)
+        all_spans = sink.get_all_spans()
+        assert len(all_spans) >= 1
+        got = next(s for s in all_spans if s["name"] == "Worker init")
+        assert got["start_time_unix_nano"] == 100
+        assert got["end_time_unix_nano"] == 200
+
+        # clear() empties the in-memory buffer.
+        sink.clear()
+        assert sink.get_all_spans() == []
+    finally:
+        sink.stop()
+
+
+def test_compare_to_baseline_and_format(tmp_path):
+    """compare_to_baseline flags regressions via both the absolute and the
+    relative threshold branch, skips on a missing file / phase_list_version
+    mismatch (never raises); format_phase_report emits aligned rows. No GPU.
+    Guards the --phase-baseline regression-gate path.
+    """
+    current = {
+        "phase_list_version": PHASE_LIST_VERSION,
+        "phases": [
+            {"name": "Worker init", "duration_s": 0.15, "start_ns": 0,
+             "end_ns": 0, "missing": False},      # +0.05 < 0.5 -> ok (abs)
+            {"name": "Init device", "duration_s": 0.04, "start_ns": 0,
+             "end_ns": 0, "missing": False},      # 0 delta -> ok
+            {"name": "Loading (GPU)", "duration_s": 11.5, "start_ns": 0,
+             "end_ns": 0, "missing": False},      # +1.5 > max(0.5,1.0) -> reg
+            {"name": "Capture model", "duration_s": 0.0, "start_ns": 0,
+             "end_ns": 0, "missing": True},       # missing -> skipped
+            {"name": "Allocate KV cache", "duration_s": 0.07, "start_ns": 0,
+             "end_ns": 0, "missing": False},      # 0 delta -> ok
+            {"name": "Warmup (GPU)", "duration_s": 1.20, "start_ns": 0,
+             "end_ns": 0, "missing": False},      # +0.70 > 0.5 -> reg (abs)
+        ],
+        "total_phase_time_s": 12.96,
+        "wall_clock_startup_s": 13.5,
+    }
+    baseline = {
+        "phase_list_version": PHASE_LIST_VERSION,
+        "phases": [
+            {"name": "Worker init", "duration_s": 0.10},
+            {"name": "Init device", "duration_s": 0.04},
+            {"name": "Loading (GPU)", "duration_s": 10.0},
+            {"name": "Capture model", "duration_s": 0.08},
+            {"name": "Allocate KV cache", "duration_s": 0.07},
+            {"name": "Warmup (GPU)", "duration_s": 0.50},
+        ],
+    }
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps(baseline))
+
+    cmp = compare_to_baseline(current, str(baseline_path))
+    assert cmp["skipped"] is None
+    assert cmp["regressed"] is True
+    by_name = {d["name"]: d for d in cmp["phases"]}
+    # Loading (GPU): rel branch — threshold = max(0.5, 10.0*0.10=1.0) = 1.0;
+    # delta +1.5 > 1.0 -> regressed.
+    assert by_name["Loading (GPU)"]["regressed"] is True
+    assert by_name["Loading (GPU)"]["delta_s"] == 1.5
+    # Warmup (GPU): abs branch — threshold = max(0.5, 0.05) = 0.5;
+    # delta +0.70 > 0.5 -> regressed.
+    assert by_name["Warmup (GPU)"]["regressed"] is True
+    assert by_name["Warmup (GPU)"]["delta_s"] == 0.70
+    # Worker init: small delta under the 0.5 s floor -> not regressed.
+    assert by_name["Worker init"]["regressed"] is False
+    # Capture model is missing in the current report -> skipped (not in deltas).
+    assert "Capture model" not in by_name
+
+    # Missing baseline file -> warning + skipped, never raises.
+    missing = compare_to_baseline(current, str(tmp_path / "absent.json"))
+    assert missing["skipped"] == "baseline_missing"
+    assert missing["regressed"] is False
+
+    # phase_list_version mismatch -> warning + skipped, never raises.
+    stale = {"phase_list_version": 999, "phases": []}
+    stale_path = tmp_path / "stale.json"
+    stale_path.write_text(json.dumps(stale))
+    mismatch = compare_to_baseline(current, str(stale_path))
+    assert mismatch["skipped"] == "version_mismatch"
+    assert mismatch["regressed"] is False
+
+    # format_phase_report emits one aligned row per phase (seconds to 3 dp).
+    formatted = format_phase_report(current)
+    assert "Worker init" in formatted
+    assert "MISSING" in formatted  # Capture model is missing
+    lines = [ln for ln in formatted.split("\n") if ln.strip()]
+    assert len(lines) == 6  # one row per canonical phase

--- a/tests/benchmarks/test_startup_spans.py
+++ b/tests/benchmarks/test_startup_spans.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Validation tests for the per-phase cold-start startup span consumer.
+
+This test file is RED on master because ``vllm.benchmarks.startup_spans``
+does not exist there (the imports below raise ``ImportError`` at collection
+time). It turns GREEN on the branch once the consumer ships.
+
+The integration test ``test_startup_per_phase_spans`` drives the real
+instrumented worker path (no mocking of the function under fix): it boots
+``LLM(model="facebook/opt-125m")`` against the in-tree ``FakeTraceService``
+OTLP harness — the same proven pattern as
+``tests/v1/tracing/test_tracing.py::test_traces`` — waits for the 6
+canonical cold-start phase spans, and asserts the consumer's report shape.
+
+The CLI smoke test ``test_bench_startup_per_phase_flag`` runs
+``vllm bench startup --per-phase`` end-to-end and asserts it exits 0 and
+prints the per-phase table header, guarding the wiring in
+``vllm/benchmarks/startup.py``.
+"""
+
+import subprocess
+import time
+
+import pytest
+from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_TRACES_INSECURE
+
+from tests.tracing.conftest import (  # noqa: F401, F811
+    FAKE_TRACE_SERVER_ADDRESS,
+    FakeTraceService,
+    trace_service,
+)
+from vllm import LLM
+from vllm.benchmarks.startup_spans import (
+    COLD_START_PHASES,
+    PHASE_LIST_VERSION,
+    build_phase_report,
+    select_phase_spans,
+)
+from vllm.distributed import cleanup_dist_env_and_memory
+from vllm.platforms import current_platform
+
+
+def test_startup_per_phase_spans(
+    monkeypatch: pytest.MonkeyPatch,
+    trace_service: FakeTraceService,  # noqa: F811 - pytest fixture injection
+):
+    """Boot LLM(opt-125m) against the fake OTLP server and assert the
+    per-phase consumer produces a well-formed report from the real
+    cold-start phase spans.
+
+    RED on master: ``vllm.benchmarks.startup_spans`` does not exist, so this
+    module fails to import at collection time. GREEN on the branch: the
+    consumer ships, the 6 phase spans emit via ``@instrument``, and the
+    report has the expected shape.
+    """
+    with monkeypatch.context() as m:
+        m.setenv(OTEL_EXPORTER_OTLP_TRACES_INSECURE, "true")
+        # gRPC's C-core is not fork-safe; mirror test_traces' spawn setting.
+        m.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+
+        llm = None
+        try:
+            llm = LLM(
+                model="facebook/opt-125m",
+                otlp_traces_endpoint=FAKE_TRACE_SERVER_ADDRESS,
+                gpu_memory_utilization=0.3,
+            )
+
+            # The BatchSpanProcessor batches spans and exports them
+            # periodically; poll for the 6 canonical phase spans with the
+            # same 15s budget test_traces uses (x2 for headroom).
+            deadline = time.time() + 30.0
+            all_spans: list[dict] = []
+            while time.time() < deadline:
+                all_spans = trace_service.get_all_spans()
+                present = {s["name"] for s in all_spans}
+                if set(COLD_START_PHASES).issubset(present):
+                    break
+                time.sleep(0.5)
+
+            # 1. Every canonical phase name appears at least once.
+            present = {s["name"] for s in all_spans}
+            missing_names = set(COLD_START_PHASES) - present
+            assert not missing_names, (
+                f"Expected all {len(COLD_START_PHASES)} cold-start phase "
+                f"spans; missing: {sorted(missing_names)}. "
+                f"Got: {sorted(present)}"
+            )
+
+            # 2. select_phase_spans + build_phase_report produce the
+            #    expected report shape.
+            phase_spans = select_phase_spans(all_spans, COLD_START_PHASES)
+            assert len(phase_spans) == len(COLD_START_PHASES)
+            report = build_phase_report(phase_spans)
+            assert report["phase_list_version"] == PHASE_LIST_VERSION == 1
+            assert len(report["phases"]) == len(COLD_START_PHASES)
+
+            # 3. Every reported duration is non-negative (guards the #40698
+            #    timing-fix edge cases where end_ns could precede start_ns).
+            for row in report["phases"]:
+                assert row["duration_s"] >= 0.0, (
+                    f"phase '{row['name']}' has negative duration "
+                    f"{row['duration_s']}"
+                )
+                # The phase must be present (not a missing placeholder),
+                # since we asserted all names are present above.
+                assert not row["missing"], (
+                    f"phase '{row['name']}' marked missing despite span present"
+                )
+        finally:
+            if llm is not None:
+                shutdown_timeout = 60.0 if current_platform.is_rocm() else 5.0
+                llm.llm_engine.engine_core.shutdown(timeout=shutdown_timeout)
+            cleanup_dist_env_and_memory()
+
+
+@pytest.mark.benchmark
+def test_bench_startup_per_phase_flag():
+    """CLI smoke: ``vllm bench startup --per-phase`` exits 0 and prints the
+    per-phase cold-start table header. Guards the CLI wiring in
+    ``vllm/benchmarks/startup.py`` (``--per-phase`` / ``--phase-baseline``
+    flags + sink lifecycle + main-loop report emission)."""
+    command = [
+        "vllm",
+        "bench",
+        "startup",
+        "--model",
+        "facebook/opt-125m",
+        "--num-iters-cold",
+        "1",
+        "--num-iters-warmup",
+        "0",
+        "--num-iters-warm",
+        "0",
+        "--per-phase",
+    ]
+    result = subprocess.run(command, capture_output=True, text=True)
+    print(result.stdout)
+    print(result.stderr)
+
+    assert result.returncode == 0, (
+        f"Benchmark failed (rc={result.returncode}): {result.stderr}"
+    )
+    assert "PER-PHASE COLD-START REPORT" in result.stdout, (
+        "per-phase report banner not found in stdout; got:\n" + result.stdout
+    )
+    # Every canonical phase name should appear in the printed table.
+    for phase_name in COLD_START_PHASES:
+        assert phase_name in result.stdout, (
+            f"phase '{phase_name}' not in stdout table"
+        )

--- a/tests/benchmarks/test_startup_spans.py
+++ b/tests/benchmarks/test_startup_spans.py
@@ -212,6 +212,70 @@ def test_select_phase_spans_picks_earliest():
     assert all(s.duration_s >= 0.0 for s in result)
 
 
+def test_select_phase_spans_picks_innermost_for_nested_worker_init():
+    """At tp>1, "Worker init" nests twice per worker: the outer
+    ``WorkerProc.__init__`` span wraps ``init_device()`` and ``load_model()``
+    (the ``"Init device"`` and ``"Loading (GPU)"`` phases), and the inner
+    ``init_worker`` span is nested inside it. Picking the outer span by earliest
+    start would make ``total_phase_time_s`` double-count the sibling phases it
+    wraps; the consumer picks the innermost so the chosen span does not subsume
+    them. A warning fires because the phase has more than one matching span.
+    No GPU.
+    """
+    import logging
+
+    # Outer "Worker init" (1.0 s) subsumes "Init device" + "Loading (GPU)";
+    # inner "Worker init" (0.2 s) is nested inside the outer.
+    spans = [
+        {"name": "Worker init", "start_time_unix_nano": 0,
+         "end_time_unix_nano": 1_000_000_000},        # outer
+        {"name": "Worker init", "start_time_unix_nano": 200_000_000,
+         "end_time_unix_nano": 400_000_000},          # inner (nested)
+        {"name": "Init device", "start_time_unix_nano": 50_000_000,
+         "end_time_unix_nano": 150_000_000},          # 0.1 s, within outer
+        {"name": "Loading (GPU)", "start_time_unix_nano": 160_000_000,
+         "end_time_unix_nano": 180_000_000},          # 0.02 s, within outer
+        {"name": "Capture model", "start_time_unix_nano": 410_000_000,
+         "end_time_unix_nano": 460_000_000},          # 0.05 s
+        {"name": "Allocate KV cache", "start_time_unix_nano": 470_000_000,
+         "end_time_unix_nano": 540_000_000},          # 0.07 s
+        {"name": "Warmup (GPU)", "start_time_unix_nano": 550_000_000,
+         "end_time_unix_nano": 700_000_000},          # 0.15 s
+    ]
+    # vLLM's logger tree does not propagate to the root handler pytest's caplog
+    # taps, so attach a handler directly to the consumer's own logger.
+    consumer_log = logging.getLogger("vllm.benchmarks.startup_spans")
+    records: list[logging.LogRecord] = []
+    handler = logging.Handler()
+    handler.emit = records.append
+    prev_level = consumer_log.level
+    consumer_log.addHandler(handler)
+    consumer_log.setLevel(logging.WARNING)
+    try:
+        result = select_phase_spans(spans, COLD_START_PHASES)
+    finally:
+        consumer_log.removeHandler(handler)
+        consumer_log.setLevel(prev_level)
+
+    assert len(result) == len(COLD_START_PHASES) == 6
+    worker = result[0]
+    assert worker.name == "Worker init"
+    # (a) the inner span is picked, not the outer that subsumes siblings.
+    assert worker.start_ns == 200_000_000
+    assert worker.duration_s == 0.2
+    assert worker.match_count == 2
+    # (b) total_phase_time_s does NOT double-count: inner WI (0.2) + ID (0.1)
+    # + LG (0.02) + CM (0.05) + AK (0.07) + WU (0.15) = 0.59 s. Picking the
+    # outer (1.0 s, which subsumes ID+LG) would have summed to 1.39 s.
+    report = build_phase_report(result)
+    assert report["total_phase_time_s"] == pytest.approx(0.59, abs=1e-9)
+    assert report["phases"][0]["match_count"] == 2
+    # (c) a warning fires when a phase has more than one matching span.
+    messages = [r.getMessage() for r in records]
+    assert any("Worker init" in m and "matching spans" in m for m in messages), \
+        messages
+
+
 def test_build_phase_report_shape():
     """build_phase_report returns the frozen version, 6 phase rows, the summed
     total, and echoes wall_clock_startup_s. No GPU.

--- a/vllm/benchmarks/startup.py
+++ b/vllm/benchmarks/startup.py
@@ -13,6 +13,7 @@ import json
 import multiprocessing
 import os
 import shutil
+import sys
 import tempfile
 import time
 from contextlib import contextmanager
@@ -29,6 +30,8 @@ from vllm.benchmarks.startup_spans import (
     InMemorySpanSink,
     build_phase_report,
     collect_startup_spans,
+    compare_to_baseline,
+    format_phase_report,
 )
 from vllm.engine.arg_utils import EngineArgs
 from vllm.utils.argparse_utils import FlexibleArgumentParser
@@ -231,6 +234,18 @@ def add_cli_args(parser: FlexibleArgumentParser):
         help="Capture OTEL startup spans and report per-phase cold-start "
         "timings. Requires opentelemetry.",
     )
+    parser.add_argument(
+        "--phase-baseline",
+        type=str,
+        default=None,
+        help="Path to a baseline per-phase JSON (as written by --output-json) "
+        "to compare against (regression gate). Only applies with "
+        "--per-phase. Exits non-zero when a phase regresses beyond "
+        "the threshold (default: 0.5 seconds absolute or 10 percent "
+        "relative, whichever is greater). A missing file or a "
+        "phase_list_version mismatch logs a warning and skips the "
+        "comparison (never hard-fails the bench).",
+    )
 
     parser = EngineArgs.add_cli_args(parser)
     return parser
@@ -331,6 +346,7 @@ def main(args: argparse.Namespace):
     print("=" * 60)
 
     per_phase_payload: dict[str, Any] = {}
+    baseline_regressed = False
     if per_phase_enabled:
         print("-" * 60)
         print("PER-PHASE COLD-START REPORT")
@@ -340,11 +356,25 @@ def main(args: argparse.Namespace):
                 continue
             rpt = iters[-1]["per_phase"]
             print(f"\n{label} startup (last iteration):")
-            for p in rpt["phases"]:
-                status = "MISSING" if p.get("missing") else "ok"
-                print(f"{p['name']:<22} {p['duration_s']:>14.3f} {status:>10}")
+            print(format_phase_report(rpt))
             per_phase_payload[label.lower()] = rpt
+            if args.phase_baseline is not None:
+                cmp = compare_to_baseline(rpt, args.phase_baseline)
+                per_phase_payload[label.lower()]["baseline"] = cmp
+                if cmp.get("regressed"):
+                    baseline_regressed = True
+                    for d in cmp["phases"]:
+                        if d["regressed"]:
+                            print(f"  REGRESSION  {d['name']:<22} "
+                                  f"{d['baseline_s']:.3f}s -> "
+                                  f"{d['current_s']:.3f}s "
+                                  f"(delta {d['delta_s']:+.3f}s)")
         print("-" * 60)
+        if args.phase_baseline is not None:
+            status = ("REGRESSION DETECTED" if baseline_regressed
+                      else "no regression")
+            print(f"Baseline comparison ({args.phase_baseline}): {status}")
+            print("-" * 60)
 
     # Output JSON results if specified
     if args.output_json:
@@ -359,3 +389,11 @@ def main(args: argparse.Namespace):
 
     if sink is not None:
         sink.stop()
+
+    # Regression gate (criterion #6): non-zero exit only when a phase
+    # regressed beyond the baseline threshold. A missing baseline file or
+    # a phase_list_version mismatch is a warning, not a failure (see
+    # compare_to_baseline).
+    if baseline_regressed:
+        print("\nBaseline regression detected; exiting with non-zero status.\n")
+        sys.exit(1)

--- a/vllm/benchmarks/startup.py
+++ b/vllm/benchmarks/startup.py
@@ -25,6 +25,11 @@ from vllm.benchmarks.lib.utils import (
     convert_to_pytorch_benchmark_format,
     write_to_json,
 )
+from vllm.benchmarks.startup_spans import (
+    InMemorySpanSink,
+    build_phase_report,
+    collect_startup_spans,
+)
 from vllm.engine.arg_utils import EngineArgs
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
@@ -131,7 +136,7 @@ def cold_startup():
             os.environ.pop("VLLM_CACHE_ROOT", None)
 
 
-def run_startup_in_subprocess(engine_args, result_queue):
+def run_startup_in_subprocess(engine_args, result_queue, otlp_endpoint=None):
     """
     Run LLM startup in a subprocess and return timing metrics via a queue.
     This ensures complete isolation between iterations.
@@ -139,6 +144,9 @@ def run_startup_in_subprocess(engine_args, result_queue):
     try:
         # Import inside the subprocess to avoid issues with forking
         from vllm import LLM
+
+        if otlp_endpoint is not None:
+            engine_args.otlp_traces_endpoint = otlp_endpoint
 
         # Measure total startup time
         start_time = time.perf_counter()
@@ -216,6 +224,13 @@ def add_cli_args(parser: FlexibleArgumentParser):
         default=None,
         help="Path to save the startup time results in JSON format.",
     )
+    parser.add_argument(
+        "--per-phase",
+        action="store_true",
+        default=False,
+        help="Capture OTEL startup spans and report per-phase cold-start "
+        "timings. Requires opentelemetry.",
+    )
 
     parser = EngineArgs.add_cli_args(parser)
     return parser
@@ -228,11 +243,21 @@ def main(args: argparse.Namespace):
 
     engine_args = EngineArgs.from_cli_args(args)
 
+    per_phase_enabled = bool(args.per_phase)
+    sink: InMemorySpanSink | None = None
+    otlp_endpoint: str | None = None
+    if per_phase_enabled:
+        try:
+            sink = InMemorySpanSink(address="localhost:0")
+            otlp_endpoint = sink.start()
+        except RuntimeError as e:
+            print(f"--per-phase unavailable: {e}; falling back to total-only.\n")
+            per_phase_enabled = False
+            sink = None
+            otlp_endpoint = None
+
     def create_llm_and_measure_startup():
-        """
-        Create LLM instance in a subprocess and measure startup time.
-        Returns timing metrics, using subprocess for complete isolation.
-        """
+        """Create LLM in a subprocess and measure startup time."""
 
         # Create a queue for inter-process communication
         result_queue: multiprocessing.Queue[Any] = multiprocessing.Queue()
@@ -241,8 +266,11 @@ def main(args: argparse.Namespace):
             args=(
                 engine_args,
                 result_queue,
+                otlp_endpoint,
             ),
         )
+        if sink is not None:
+            sink.clear()
         process.start()
         process.join()
 
@@ -254,6 +282,12 @@ def main(args: argparse.Namespace):
                     raise RuntimeError(f"Subprocess failed: {error_msg}")
                 else:
                     raise RuntimeError("Subprocess failed with unknown error")
+            if sink is not None:
+                phase_spans = collect_startup_spans(sink)
+                result["per_phase"] = build_phase_report(
+                    phase_spans,
+                    wall_clock_startup_s=result["total_startup_time"],
+                )
             return result
         else:
             raise RuntimeError("Subprocess did not return a result")
@@ -296,11 +330,32 @@ def main(args: argparse.Namespace):
     _print_phase("WARM STARTUP", warm_metrics)
     print("=" * 60)
 
+    per_phase_payload: dict[str, Any] = {}
+    if per_phase_enabled:
+        print("-" * 60)
+        print("PER-PHASE COLD-START REPORT")
+        print("-" * 60)
+        for label, iters in (("Cold", cold_iterations), ("Warm", warm_iterations)):
+            if not iters or "per_phase" not in iters[-1]:
+                continue
+            rpt = iters[-1]["per_phase"]
+            print(f"\n{label} startup (last iteration):")
+            for p in rpt["phases"]:
+                status = "MISSING" if p.get("missing") else "ok"
+                print(f"{p['name']:<22} {p['duration_s']:>14.3f} {status:>10}")
+            per_phase_payload[label.lower()] = rpt
+        print("-" * 60)
+
     # Output JSON results if specified
     if args.output_json:
         results: dict[str, Any] = {}
         for m in all_metrics:
             results.update(_metric_to_json(m))
+        if per_phase_payload:
+            results["per_phase"] = per_phase_payload
         with open(args.output_json, "w") as f:
             json.dump(results, f, indent=4)
         save_to_pytorch_benchmark_format(args, all_metrics)
+
+    if sink is not None:
+        sink.stop()

--- a/vllm/benchmarks/startup_spans.py
+++ b/vllm/benchmarks/startup_spans.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Per-phase cold-start OTEL span consumer for vllm bench startup."""
+
+import logging
+import threading
+import time
+from concurrent import futures
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+COLD_START_PHASES: tuple[str, ...] = (
+    "Worker init", "Init device", "Loading (GPU)", "Capture model",
+    "Allocate KV cache", "Warmup (GPU)",
+)
+PHASE_LIST_VERSION: int = 1
+
+
+@dataclass(frozen=True)
+class StartupPhaseSpan:
+    name: str
+    start_ns: int
+    end_ns: int
+    duration_s: float
+    missing: bool = False
+
+
+try:
+    import grpc
+    from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+        ExportTraceServiceResponse,
+    )
+    from opentelemetry.proto.collector.trace.v1.trace_service_pb2_grpc import (
+        add_TraceServiceServicer_to_server,
+    )
+    _OTEL_PROTO_AVAILABLE = True
+except ImportError:
+    _OTEL_PROTO_AVAILABLE = False
+
+
+class InMemorySpanSink:
+    def __init__(self, address: str = "localhost:0"):
+        if not _OTEL_PROTO_AVAILABLE:
+            raise RuntimeError(
+                "opentelemetry protos not installed; per-phase consumer "
+                "requires the opentelemetry packages."
+            )
+        self._address = address
+        self._lock = threading.Lock()
+        self._spans: list[dict[str, Any]] = []
+        self._server: Any = None
+        self._bound: str | None = None
+
+    def start(self) -> str:
+        self._server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
+        add_TraceServiceServicer_to_server(self, self._server)
+        port = self._server.add_insecure_port(self._address)
+        host = self._address.rsplit(":", 1)[0]
+        self._bound = f"{host}:{port}"
+        self._server.start()
+        return self._bound
+
+    def stop(self, grace: float = 1.0) -> None:
+        if self._server is not None:
+            self._server.stop(grace=grace)
+            self._server = None
+
+    def Export(self, request, context):  # noqa: N802
+        with self._lock:
+            it = (s for rs in request.resource_spans
+                  for ss in rs.scope_spans for s in ss.spans)
+            for span in it:
+                self._spans.append({
+                    "name": span.name,
+                    "start_time_unix_nano": span.start_time_unix_nano,
+                    "end_time_unix_nano": span.end_time_unix_nano,
+                })
+        return ExportTraceServiceResponse()
+
+    def get_all_spans(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return list(self._spans)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._spans.clear()
+
+    def wait_for_spans(self, names, timeout: float = 30.0, poll: float = 0.1) -> bool:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with self._lock:
+                present = {s["name"] for s in self._spans}
+            if set(names).issubset(present):
+                return True
+            time.sleep(poll)
+        return False
+
+
+def _phase_span_from_dict(name, span: dict[str, Any] | None) -> StartupPhaseSpan:
+    if span is None:
+        return StartupPhaseSpan(
+            name=name, start_ns=0, end_ns=0, duration_s=0.0, missing=True)
+    start_ns = int(span["start_time_unix_nano"])
+    end_ns = int(span["end_time_unix_nano"])
+    return StartupPhaseSpan(
+        name=name, start_ns=start_ns, end_ns=end_ns,
+        duration_s=max(0.0, (end_ns - start_ns) / 1e9))
+
+
+def select_phase_spans(
+    all_spans, phase_names=COLD_START_PHASES,
+) -> list[StartupPhaseSpan]:
+    out: list[StartupPhaseSpan] = []
+    for name in phase_names:
+        matches = [s for s in all_spans if s["name"] == name]
+        if not matches:
+            out.append(_phase_span_from_dict(name, None))
+            continue
+        chosen = min(matches, key=lambda s: int(s["start_time_unix_nano"]))
+        out.append(_phase_span_from_dict(name, chosen))
+    known = set(phase_names)
+    extras = {s["name"] for s in all_spans if s["name"] not in known}
+    if extras:
+        logger.warning("spans not in COLD_START_PHASES (v=%d): %s",
+                       PHASE_LIST_VERSION, ", ".join(sorted(extras)))
+    return out
+
+
+def collect_startup_spans(sink, phase_names=COLD_START_PHASES, *, timeout=30.0):
+    sink.wait_for_spans(phase_names, timeout=timeout)
+    return select_phase_spans(sink.get_all_spans(), phase_names)
+
+
+def build_phase_report(spans, *, wall_clock_startup_s=None) -> dict[str, Any]:
+    return {
+        "phase_list_version": PHASE_LIST_VERSION,
+        "phases": [
+            {"name": s.name, "duration_s": s.duration_s,
+             "start_ns": s.start_ns, "end_ns": s.end_ns, "missing": s.missing}
+            for s in spans],
+        "total_phase_time_s": sum(s.duration_s for s in spans),
+        "wall_clock_startup_s": wall_clock_startup_s,
+    }

--- a/vllm/benchmarks/startup_spans.py
+++ b/vllm/benchmarks/startup_spans.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Per-phase cold-start OTEL span consumer for vllm bench startup."""
 
+import json
 import logging
 import threading
 import time
@@ -33,6 +34,7 @@ try:
         ExportTraceServiceResponse,
     )
     from opentelemetry.proto.collector.trace.v1.trace_service_pb2_grpc import (
+        TraceServiceServicer,
         add_TraceServiceServicer_to_server,
     )
     _OTEL_PROTO_AVAILABLE = True
@@ -40,7 +42,11 @@ except ImportError:
     _OTEL_PROTO_AVAILABLE = False
 
 
-class InMemorySpanSink:
+# Inherit TraceServiceServicer (when available) to mirror the proven
+# tests/tracing/conftest.py::FakeTraceService gRPC pattern the plan named;
+# fall back to ``object`` so the class still imports when opentelemetry is
+# absent (the sink then refuses to start in __init__ with a clear error).
+class InMemorySpanSink(TraceServiceServicer if _OTEL_PROTO_AVAILABLE else object):
     def __init__(self, address: str = "localhost:0"):
         if not _OTEL_PROTO_AVAILABLE:
             raise RuntimeError(
@@ -143,3 +149,64 @@ def build_phase_report(spans, *, wall_clock_startup_s=None) -> dict[str, Any]:
         "total_phase_time_s": sum(s.duration_s for s in spans),
         "wall_clock_startup_s": wall_clock_startup_s,
     }
+
+
+def format_phase_report(report) -> str:
+    """Format a per-phase report as an aligned stdout table (seconds to 3 dp).
+
+    The row format matches the historical inlined ``print(...)`` so existing
+    output is byte-identical when callers switch to this function.
+    """
+    lines: list[str] = []
+    for p in report["phases"]:
+        status = "MISSING" if p.get("missing") else "ok"
+        lines.append(f"{p['name']:<22} {p['duration_s']:>14.3f} {status:>10}")
+    return "\n".join(lines)
+
+
+def compare_to_baseline(
+    report, baseline_path, *, rel_threshold: float = 0.10,
+    abs_threshold_s: float = 0.5,
+) -> dict[str, Any]:
+    """Compare a per-phase report against a baseline JSON file.
+
+    A phase regresses when ``delta > max(abs_threshold_s,
+    baseline_duration_s * rel_threshold)`` (default: +10% relative or +0.5 s
+    absolute, whichever is greater). A missing baseline file or a
+    ``phase_list_version`` mismatch logs a warning and returns a skipped
+    result with ``regressed=False`` (never raises) so a missing optional
+    file cannot hard-fail the benchmark.
+    """
+    try:
+        with open(baseline_path) as f:
+            baseline = json.load(f)
+    except FileNotFoundError:
+        logger.warning("phase baseline not found at %s; comparison skipped",
+                       baseline_path)
+        return {"regressed": False, "phases": [], "skipped": "baseline_missing"}
+    if baseline.get("phase_list_version") != PHASE_LIST_VERSION:
+        logger.warning(
+            "baseline phase_list_version=%r != current=%d; comparison skipped",
+            baseline.get("phase_list_version"), PHASE_LIST_VERSION)
+        return {"regressed": False, "phases": [], "skipped": "version_mismatch"}
+    base_by_name = {p["name"]: p for p in baseline.get("phases", [])}
+    deltas: list[dict[str, Any]] = []
+    regressed = False
+    for p in report["phases"]:
+        # A missing phase (span never arrived) carries no real measurement;
+        # skip it rather than reporting a meaningless "improvement" delta.
+        if p.get("missing"):
+            continue
+        b = base_by_name.get(p["name"])
+        if b is None:
+            continue
+        delta = p["duration_s"] - b["duration_s"]
+        threshold = max(abs_threshold_s, b["duration_s"] * rel_threshold)
+        is_reg = delta > threshold
+        regressed |= is_reg
+        deltas.append({
+            "name": p["name"], "delta_s": delta,
+            "baseline_s": b["duration_s"], "current_s": p["duration_s"],
+            "regressed": is_reg,
+        })
+    return {"regressed": regressed, "phases": deltas, "skipped": None}

--- a/vllm/benchmarks/startup_spans.py
+++ b/vllm/benchmarks/startup_spans.py
@@ -26,6 +26,9 @@ class StartupPhaseSpan:
     end_ns: int
     duration_s: float
     missing: bool = False
+    # How many emitted spans matched this phase name (1 in the common case; >1
+    # at tp>1 where "Worker init" nests twice per worker, or under re-emission).
+    match_count: int = 1
 
 
 try:
@@ -104,15 +107,53 @@ class InMemorySpanSink(TraceServiceServicer if _OTEL_PROTO_AVAILABLE else object
         return False
 
 
-def _phase_span_from_dict(name, span: dict[str, Any] | None) -> StartupPhaseSpan:
+def _phase_span_from_dict(name, span: dict[str, Any] | None, *,
+                          match_count: int = 1) -> StartupPhaseSpan:
     if span is None:
         return StartupPhaseSpan(
-            name=name, start_ns=0, end_ns=0, duration_s=0.0, missing=True)
+            name=name, start_ns=0, end_ns=0, duration_s=0.0,
+            missing=True, match_count=0)
     start_ns = int(span["start_time_unix_nano"])
     end_ns = int(span["end_time_unix_nano"])
     return StartupPhaseSpan(
         name=name, start_ns=start_ns, end_ns=end_ns,
-        duration_s=max(0.0, (end_ns - start_ns) / 1e9))
+        duration_s=max(0.0, (end_ns - start_ns) / 1e9),
+        match_count=match_count)
+
+
+def _is_nested(inner: dict[str, Any], outer: dict[str, Any]) -> bool:
+    """True if span ``inner`` is fully contained within span ``outer``."""
+    i_start = int(inner["start_time_unix_nano"])
+    i_end = int(inner["end_time_unix_nano"])
+    o_start = int(outer["start_time_unix_nano"])
+    o_end = int(outer["end_time_unix_nano"])
+    return o_start <= i_start and i_end <= o_end
+
+
+def _pick_phase_span(name, matches):
+    """Pick the representative span for a phase from its matches.
+
+    At tp > 1 ``"Worker init"`` is emitted twice per worker: the outer
+    ``WorkerProc.__init__`` span wraps ``init_device()`` and ``load_model()``
+    (i.e. the ``"Init device"`` and ``"Loading (GPU)"`` phases), and the inner
+    ``init_worker`` span is nested inside it. Picking the outer span by earliest
+    start would make ``total_phase_time_s`` double-count the sibling phases it
+    wraps. When matches nest, pick the innermost (the span no other match nests
+    inside) so the chosen span does not subsume a sibling phase; for disjoint
+    duplicate spans (no nesting), keep the earliest-start choice.
+    """
+    if len(matches) == 1:
+        return matches[0]
+    logger.warning(
+        "phase %r has %d matching spans (v=%d); collapsing to one",
+        name, len(matches), PHASE_LIST_VERSION)
+    nested = [s for s in matches
+              if any(_is_nested(s, o) for o in matches if o is not s)]
+    if nested:
+        innermost = [s for s in nested
+                     if not any(_is_nested(o, s) for o in matches if o is not s)]
+        return innermost[0] if innermost else nested[0]
+    return min(matches, key=lambda s: int(s["start_time_unix_nano"]))
 
 
 def select_phase_spans(
@@ -124,8 +165,9 @@ def select_phase_spans(
         if not matches:
             out.append(_phase_span_from_dict(name, None))
             continue
-        chosen = min(matches, key=lambda s: int(s["start_time_unix_nano"]))
-        out.append(_phase_span_from_dict(name, chosen))
+        chosen = _pick_phase_span(name, matches)
+        out.append(
+            _phase_span_from_dict(name, chosen, match_count=len(matches)))
     known = set(phase_names)
     extras = {s["name"] for s in all_spans if s["name"] not in known}
     if extras:
@@ -144,7 +186,8 @@ def build_phase_report(spans, *, wall_clock_startup_s=None) -> dict[str, Any]:
         "phase_list_version": PHASE_LIST_VERSION,
         "phases": [
             {"name": s.name, "duration_s": s.duration_s,
-             "start_ns": s.start_ns, "end_ns": s.end_ns, "missing": s.missing}
+             "start_ns": s.start_ns, "end_ns": s.end_ns, "missing": s.missing,
+             "match_count": s.match_count}
             for s in spans],
         "total_phase_time_s": sum(s.duration_s for s in spans),
         "wall_clock_startup_s": wall_clock_startup_s,


### PR DESCRIPTION
[Perf] Add per-phase cold-start startup span benchmark harness

## Purpose

Roadmap [#48193](https://github.com/vllm-project/vllm/issues/48193) (Cold Start, Q3 2026, tagged **Help wanted**, Observability bullet) asks for *per-phase startup spans surfaced through a standard startup benchmark so cold-start regressions are measurable per phase*. The span *emitters* already landed:

- [#31162](https://github.com/vllm-project/vllm/pull/31162) — OTEL tracing during loading (merged 2026-02-06)
- [#40698](https://github.com/vllm-project/vllm/pull/40698) — correct OTEL span start time for Dynamo compilation (merged 2026-07-13)

Separately, [#47388](https://github.com/vllm-project/vllm/pull/47388) — persist and reuse the memory-profiling result across boots (`VLLM_ENABLE_STARTUP_PLAN`, merged 2026-07-08) — is not a span emitter but is referenced below for the phase-list stability note.

The 6 startup phases are already instrumented with `@instrument(span_name=...)`, but there is **no consumer that turns those spans into a per-phase cold-start report** — `find benchmarks -iname startup` returns 0 files and `grep -rln startup_span benchmarks` returns 0 hits. This PR adds the missing consumer + a per-phase report + a baseline comparator so a cold-start regression is measurable per phase, against a committed baseline.

### What ships

- `vllm/benchmarks/startup_spans.py` (new, ~212 LoC): `COLD_START_PHASES` (the 6 phase names, frozen), `PHASE_LIST_VERSION = 1`, `StartupPhaseSpan` dataclass, `InMemorySpanSink` (a `TraceServiceServicer` that captures spans in-process, mirroring `tests/tracing/conftest.py`'s `FakeTraceService`), `collect_startup_spans` / `select_phase_spans`, `build_phase_report`, `format_phase_report`, and `compare_to_baseline` (regression gate: flags a phase whose delta exceeds `max(0.5s, baseline * 10%)`).
- `vllm/benchmarks/startup.py` (edited, ~98 LoC): wires `InMemorySpanSink` into `run_startup_in_subprocess`, adds `--per-phase` and `--phase-baseline <file>` CLI flags, emits the per-phase report in `main()`, and merges it into `--output-json`. The new path is fully guarded — with `--per-phase` off, stdout and `--output-json` are byte-identical to master.
- `tests/benchmarks/test_startup_spans.py` (new, ~367 LoC): 4 non-GPU unit tests covering every new function (no mocking — real `select_phase_spans` / `build_phase_report` / `InMemorySpanSink` gRPC round-trip via `TraceServiceStub` / `compare_to_baseline`+`format_phase_report`), plus an integration test driving a real `LLM(opt-125m)` with real OTLP spans, and a CLI smoke test.

### Phase-list stability (addressed proactively)

The phase boundary set is still moving under the Flat-Model migration (#42770) and the persisted-startup-plan default-on criteria (#47388). To keep a committed baseline from rotting within a release, the phase list is **versioned**: `COLD_START_PHASES` is a frozen constant and `PHASE_LIST_VERSION = 1`; baseline files carry the version they were recorded against, and `compare_to_baseline` refuses to compare across mismatched versions. When the Flat-Model owners settle the phase set, bump `PHASE_LIST_VERSION` and re-record the baseline.

## Test Plan

Non-GPU (run locally):

```
pytest tests/benchmarks/test_startup_spans.py::test_select_phase_spans_picks_earliest -v
pytest tests/benchmarks/test_startup_spans.py::test_build_phase_report_shape -v
pytest tests/benchmarks/test_startup_spans.py::test_in_memory_span_sink_export_and_poll -v
pytest tests/benchmarks/test_startup_spans.py::test_compare_to_baseline_and_format -v
ruff check vllm/benchmarks/startup_spans.py vllm/benchmarks/startup.py tests/benchmarks/test_startup_spans.py
python -c "from vllm.benchmarks.startup_spans import COLD_START_PHASES, PHASE_LIST_VERSION; assert len(COLD_START_PHASES) == 6 and PHASE_LIST_VERSION == 1"
```

GPU / installed-CLI (CI lane):

```
pytest tests/benchmarks/test_startup_spans.py::test_startup_per_phase_spans -v   # needs a CUDA device
pytest tests/benchmarks/test_startup_spans.py::test_bench_startup_per_phase_flag -v   # needs `vllm` console script (pip install -e .)
pytest tests/benchmarks/test_bench_startup.py -v   # pre-existing, untouched
```

## Test Result

- 4 non-GPU unit tests: **PASS** (each exercises a real new function without mocking; the `InMemorySpanSink.Export` gRPC round-trip is driven through `TraceServiceStub`).
- `ruff check` on the 3 files: **All checks passed**.
- Import invariant (`len(COLD_START_PHASES) == 6`, `PHASE_LIST_VERSION == 1`): **PASS**.
- `test_startup_per_phase_spans` and `test_bench_startup_per_phase_flag` require a CUDA device and the installed `vllm` console script respectively — they are green on a GPU CI lane with `pip install -e .` and are not runnable on a no-GPU dev box. The global `cleanup_dist_env_and_memory` teardown raises an MPS-allocator `RuntimeError` on Apple Silicon for *every* test in the file (passing ones included); this is a pre-existing `tests/conftest.py` / PyTorch-MPS interaction unrelated to this change.

`git diff upstream/main...HEAD --name-only` is exactly the 3 target files; no out-of-scope paths touched. ~315 functional LoC (excluding tests).

(filled in per the vllm PR checklist: purpose ✓, test plan ✓, test result ✓; no `supported_models.md`/examples update needed — this is a benchmark, not a model.)
