### PR TITLE
[Rust Frontend] Fix macro-based content format detection

### DIFF
--- a/rust/src/chat/src/renderer/hf/format.rs
+++ b/rust/src/chat/src/renderer/hf/format.rs
@@ -236,9 +236,10 @@ fn has_content_item_loop(root: &Stmt<'_>) -> bool {
 
     loops.into_iter().any(|loop_ast| {
         matches!(loop_ast.target, Expr::Var(_))
-            && message_varnames
-                .iter()
-                .any(|varname| is_var_or_elems_access(&loop_ast.iter, varname, Some("content")))
+            && (is_var_access(&loop_ast.iter, "content")
+                || message_varnames.iter().any(|varname| {
+                    is_var_or_elems_access(&loop_ast.iter, varname, Some("content"))
+                }))
     })
 }
 
@@ -310,6 +311,16 @@ mod tests {
         assert_eq!(
             detect(
                 "{% for message in messages %}{% for content in message['content'] %}{{ content }}{% endfor %}{% endfor %}"
+            ),
+            ChatTemplateContentFormat::OpenAi
+        );
+    }
+
+    #[test]
+    fn detects_openai_template_with_content_parameter_loop() {
+        assert_eq!(
+            detect(
+                "{% macro render(content) %}{% for item in content %}{{ item }}{% endfor %}{% endmacro %}{% for message in messages %}{{ render(message.content) }}{% endfor %}"
             ),
             ChatTemplateContentFormat::OpenAi
         );

--- a/rust/src/chat/src/renderer/hf/mod.rs
+++ b/rust/src/chat/src/renderer/hf/mod.rs
@@ -1310,6 +1310,26 @@ mod tests {
     }
 
     #[test]
+    fn qwen35_template_auto_detects_openai_multimodal_content() {
+        let mut request = image_request();
+        request.chat_options.generation_prompt_mode = GenerationPromptMode::NoGenerationPrompt;
+
+        let rendered = render_mm(
+            QWEN3_5_0_8B_TEMPLATE,
+            &request,
+            ChatTemplateContentFormatOption::Auto,
+        )
+        .unwrap();
+
+        expect![[r#"
+            Text(
+                "<|im_start|>user\na<|vision_start|><|image_pad|><|vision_end|>b<|im_end|>\n",
+            )
+        "#]]
+        .assert_debug_eq(&rendered.prompt);
+    }
+
+    #[test]
     fn qwen35_template_renders_closed_empty_reasoning_span_when_thinking_disabled() {
         let mut request = sample_request(vec![ChatMessage::text(ChatRole::User, "hello")]);
         request


### PR DESCRIPTION



## Purpose
  The Rust chat template detector only recognized loops directly over
  `message.content`. It missed templates that pass the content into a macro and
  iterate with `{% for item in content %}`.

  Qwen3.5 uses the macro form, causing `auto` mode to incorrectly select the
  string content format. Multimodal messages consequently lost the
  `<|vision_start|>` and `<|vision_end|>` wrappers around `<|image_pad|>`, which
  could produce incorrect prompt tokens and multimodal positions.

  Recognize loops over a `content` parameter while preserving the existing
  direct `message.content` detection. Add regression coverage using both a
  minimal macro template and the repository's Qwen3.5 template.

  The corrected auto-detection matches the explicit OpenAI content format and
  the corresponding Python detector behavior.

## Test Plan

```
  cargo nextest run \
    -p vllm-chat \
    -E 'test(detects_openai_template_with_content_parameter_loop) | test(qwen35_template_auto_detects_openai_multimodal_content)'
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

