### PR TITLE
[Doc] Document SimpleCPUOffloadConnector in the KV offloading guide

### DIFF
--- a/docs/features/kv_offloading_usage.md
+++ b/docs/features/kv_offloading_usage.md
@@ -5,6 +5,8 @@ This guide covers configuration of the [`OffloadingConnector`](disagg_prefill.md
 !!! note
     The `OffloadingConnector` currently supports CUDA, ROCm, and XPU only.
 
+vLLM also ships a second, CPU-only offloading connector, [`SimpleCPUOffloadConnector`](#simplecpuoffloadconnector-cpu-only-alternative), documented at the end of this guide.
+
 ## Overview
 
 Two specs are available, selected by the `spec_name` key in `kv_connector_extra_config`:
@@ -206,6 +208,39 @@ Example (OpenAI-compatible completions request):
   }
 }
 ```
+
+## SimpleCPUOffloadConnector (CPU-Only Alternative)
+
+`SimpleCPUOffloadConnector` is a separate, minimal CPU offloading connector. Instead of the pluggable spec/tier framework above, it drives a second instance of vLLM's core KV cache machinery (`KVCacheCoordinator` and `BlockPool`) for host memory, so prefix hashing and LRU eviction behave exactly like the GPU prefix cache. It supports the hybrid memory allocator (HMA) and requires prefix caching to be enabled (it disables itself with a warning otherwise). There are no secondary tiers.
+
+```bash
+vllm serve <model> \
+  --kv-transfer-config '{
+    "kv_connector": "SimpleCPUOffloadConnector",
+    "kv_role": "kv_both",
+    "kv_connector_extra_config": {
+      "cpu_bytes_to_use": 8589934592
+    }
+  }'
+```
+
+### `kv_connector_extra_config` Reference
+
+| Key | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `cpu_bytes_to_use` | no | `8589934592` (8 GiB) | Total bytes of host memory for the CPU cache across all workers; divided by world size for the per-rank capacity. Same key name and semantics as `OffloadingConnector`. |
+| `cpu_bytes_to_use_per_rank` | no | `cpu_bytes_to_use / world_size` | Explicit per-rank capacity. Takes precedence; a warning is logged if it disagrees with the derived value. |
+| `lazy_offload` | no | `false` | `false` (eager): blocks are offloaded to CPU as requests store them. `true` (lazy): offloading is deferred; the scheduler scans the GPU free queue and offloads blocks only as they approach eviction, keeping a target number of blocks ready to free. |
+
+### Choosing Between the Two Connectors
+
+| | `OffloadingConnector` | `SimpleCPUOffloadConnector` |
+| --- | --- | --- |
+| Tiers | CPU, plus optional filesystem/object-store/P2P secondary tiers | CPU only |
+| Eviction | Configurable (`lru` or `arc`) | `BlockPool` LRU (same as the GPU prefix cache) |
+| Offload timing | Immediate as blocks complete (`offload_prompt_only` to restrict) | Eager per-request store, or lazy eviction-driven (`lazy_offload`) |
+| KV events | Opt-in self-describing events, per-tier events | Standard `BlockPool` events for the CPU cache, when KV cache events are enabled |
+| Configuration surface | Larger (specs, tiers, thresholds) | Three keys |
 
 ## Further Reading
 


### PR DESCRIPTION
## Purpose

`SimpleCPUOffloadConnector` (added in #37160, since extended with PCP/DCP support in #39831 and packed HMA layouts in #46205) has no user-facing documentation at all: zero references under `docs/` or `examples/`. Right now the only way to find out it exists is to read the connector factory. This adds a section to `docs/features/kv_offloading_usage.md` covering it, plus a short neutral comparison with `OffloadingConnector` so operators can pick between the two.

Every documented key was verified against what the connector actually parses in `vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py` (`cpu_bytes_to_use` with its 8 GiB default, `cpu_bytes_to_use_per_rank` precedence and the mismatch warning, `lazy_offload`) and `vllm/v1/simple_kv_offload/manager.py` (eager vs lazy semantics, the prefix-caching requirement, KV events delegating to the CPU BlockPool via `take_events`).

Duplicate check: searched open PRs and issues for SimpleCPUOffload and kv_offloading_usage; the open SimpleCPUOffload PRs (#47324, #42615, #41777) are all code fixes, none touch docs.

## Test Plan

Docs-only change:

```
pre-commit run --files docs/features/kv_offloading_usage.md
```

plus checking each claim against the connector and manager source on current main.

## Test Result

All pre-commit hooks pass (markdownlint etc.). Config keys, defaults, and mode semantics match the parsing code cited above.

---

small note: freshman contributor here, doing my best for the greater good :) I worked through the connector code myself and used Claude Code to help cross-check every config key against the source before writing it down. if the maintainers of either connector would phrase the comparison differently I am very happy to adjust.