### PR TITLE
[Docs] quantized_kvcache: add measured performance section, replace deprecated gated example model

### DIFF
--- a/docs/features/quantization/quantized_kvcache.md
+++ b/docs/features/quantization/quantized_kvcache.md
@@ -68,6 +68,32 @@ llm = LLM(
 
 ---
 
+## Performance Considerations
+
+FP8 halves the KV cache's per-token footprint relative to FP16/BF16, which has two measurable effects:
+
+- **KV cache capacity doubles.** At the same `gpu_memory_utilization`, the engine can hold twice as many tokens. The engine startup log reports both numbers for your configuration (`GPU KV cache size` and `Maximum concurrency`). Measured example — `Qwen/Qwen3-4B` on a 24 GB NVIDIA L4 (vLLM 0.25.1, `--max-model-len 32768`, 11.47 GiB KV reservation in both cases):
+
+  | `kv_cache_dtype` | GPU KV cache size | Max concurrency (32,768-token requests) |
+  |---|---|---|
+  | `auto` (BF16) | 83,488 tokens | 2.55x |
+  | `fp8` | 166,992 tokens | 5.10x |
+
+- **Decode throughput improves with context length.** Decoding at low batch sizes is dominated by reading the KV cache each step, so halving its size raises throughput — and the gain grows as the cache does. Same setup as above, batch size 1, prefix caching disabled:
+
+  | Context length | `auto` (BF16) | `fp8` | Speedup |
+  |---|---|---|---|
+  | 2k | 29.1 tok/s | 29.4 tok/s | +1% |
+  | 8k | 26.4 tok/s | 27.9 tok/s | +6% |
+  | 16k | 23.6 tok/s | 26.2 tok/s | +11% |
+  | 32k | 19.4 tok/s | 23.4 tok/s | +21% |
+
+  Absolute gains depend on the GPU, attention backend, and workload — measure on your own stack before relying on these numbers.
+
+- **Accuracy depends on scale calibration.** With the default scales (`1.0`, no calibration), quantization error can degrade output quality. For quality-sensitive workloads, use calibrated scales via `llm-compressor` (see the calibration example below).
+
+---
+
 ## Examples
 
 ### 1. No Calibration (`kv_cache_dtype="fp8"`)
@@ -79,7 +105,7 @@ from vllm import LLM, SamplingParams
 
 sampling_params = SamplingParams(temperature=0.7, top_p=0.8)
 llm = LLM(
-    model="meta-llama/Llama-2-7b-chat-hf",
+    model="Qwen/Qwen3-4B",
     kv_cache_dtype="fp8",
 )
 prompt = "London is the capital of"
@@ -89,7 +115,27 @@ print(out)
 
 ---
 
-### 2. **[Recommended] Calibration Using a Dataset (with `llm-compressor`)**
+### 2. Random Token Calibration (`kv_cache_dtype="fp8"`, `calculate_kv_scales=True`)
+
+Scales are automatically estimated from a single batch of tokens during warmup.
+
+```python
+from vllm import LLM, SamplingParams
+
+sampling_params = SamplingParams(temperature=0.7, top_p=0.8)
+llm = LLM(
+    model="Qwen/Qwen3-4B",
+    kv_cache_dtype="fp8",
+    calculate_kv_scales=True,
+)
+prompt = "London is the capital of"
+out = llm.generate(prompt, sampling_params)[0].outputs[0].text
+print(out)
+```
+
+---
+
+### 3. **[Recommended] Calibration Using a Dataset (with `llm-compressor`)**
 
 For the highest-quality quantization, we recommend calibrating against a dataset using `llm-compressor`. This enables advanced strategies such as per-attention-head quantization.
 


### PR DESCRIPTION
## Purpose

`docs/features/quantization/quantized_kvcache.md` explains how to enable the FP8 KV cache but gives no guidance on what it buys or costs, and recurring confusion in issues (#48786, #46985) suggests users can't predict its behavior from the page. This PR:

1. Adds a **Performance Considerations** section with measured numbers: KV cache capacity doubles exactly at the same reservation (both values readable from the engine startup log, so users can verify on their own configuration), and batch-1 decode throughput gains grow with context length (+1% at 2k → +21% at 32k) since decode is dominated by reading the cache. Includes the accuracy-vs-calibration caveat pointing at the existing llm-compressor example.
2. Replaces `meta-llama/Llama-2-7b-chat-hf` in both runnable examples — it is gated and deprecated, so the examples fail for new users as written — with `Qwen/Qwen3-4B`, verified to run in both snippets.

## Test Plan

NVIDIA L4 24 GB, vLLM 0.25.1 (pip install), Qwen/Qwen3-4B:

```bash
vllm serve Qwen/Qwen3-4B --max-model-len 32768 --max-num-seqs 1 \
  --gpu-memory-utilization 0.90 --no-enable-prefix-caching  # ± --kv-cache-dtype fp8
```

- 4 context lengths (2k/8k/16k/32k) × 3 recorded passes in interleaved order after a discarded warmup pass; decode tok/s token-counted via the server's `usage` field, not stream chunks.
- Both updated example snippets executed verbatim (offline `LLM()` API).

## Test Result

- Capacity: `GPU KV cache size` 83,488 → 166,992 tokens at the identical 11.47 GiB reservation; `Maximum concurrency` 2.55x → 5.10x (engine startup log).
- Decode (batch 1): 29.1→29.4 tok/s at 2k, 26.4→27.9 at 8k, 23.6→26.2 at 16k, 19.4→23.4 at 32k.
- Both example snippets produce output with the replacement model.
- Raw data, startup logs, and the sweep client: https://github.com/robertlangdonn/kv-cache-tax/tree/main/l4_docs_run

## Why this is not duplicating an existing PR

No open PR touches `quantized_kvcache.md` or adds FP8-KV-cache performance documentation. Searched open PR bodies for the filename, "kv cache docs performance", and the old example model name; nearest matches are kernel/connector PRs, none documentation.

## AI assistance

AI assistance was used for the measurement harness and drafting; all changes reviewed, and the measurements run, by the human submitter.
