### PR TITLE
[Bugfix] Gate DeepGEMM selection on JIT toolchain viability

### DIFF
--- a/tests/utils_/test_deep_gemm_utils.py
+++ b/tests/utils_/test_deep_gemm_utils.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Toolchain gating for DeepGEMM backend selection.
+
+DeepGEMM JIT-compiles kernels at first use and its compiler asserts on
+nvcc older than 12.3 — long after backend selection, mid-weight-load.
+``is_deep_gemm_supported`` must therefore reject a positively identified
+too-old toolchain up front, and only then.
+"""
+
+import pytest
+
+from vllm.utils import deep_gemm as dg_utils
+
+pytestmark = pytest.mark.cpu_test
+
+
+@pytest.fixture
+def deep_gemm_otherwise_supported(monkeypatch):
+    monkeypatch.setattr(dg_utils.envs, "VLLM_USE_DEEP_GEMM", True)
+    monkeypatch.setattr(dg_utils, "has_deep_gemm", lambda: True)
+    monkeypatch.setattr(dg_utils.current_platform, "support_deep_gemm", lambda: True)
+
+
+@pytest.mark.parametrize(
+    ("nvcc_version", "expected"),
+    [
+        ((12, 1), False),  # positively too old -> rejected
+        ((12, 3), True),  # exact minimum -> allowed
+        ((13, 2), True),  # newer -> allowed
+        (None, True),  # unknown toolchain must not disqualify
+    ],
+)
+def test_nvcc_gate(deep_gemm_otherwise_supported, monkeypatch, nvcc_version, expected):
+    monkeypatch.setattr(dg_utils, "_nvcc_version", lambda: nvcc_version)
+    assert dg_utils.is_deep_gemm_supported() is expected
+
+
+def test_arch_and_env_gates_still_apply(monkeypatch):
+    monkeypatch.setattr(dg_utils, "_nvcc_version", lambda: (13, 2))
+    monkeypatch.setattr(dg_utils.envs, "VLLM_USE_DEEP_GEMM", True)
+    monkeypatch.setattr(dg_utils, "has_deep_gemm", lambda: True)
+    monkeypatch.setattr(dg_utils.current_platform, "support_deep_gemm", lambda: False)
+    assert dg_utils.is_deep_gemm_supported() is False
+
+
+def test_nvcc_version_parses_or_returns_none():
+    version = dg_utils._nvcc_version.__wrapped__()
+    assert version is None or (
+        isinstance(version, tuple)
+        and len(version) == 2
+        and all(isinstance(part, int) for part in version)
+    )

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -9,6 +9,9 @@ import contextlib
 import functools
 import importlib
 import os
+import re
+import shutil
+import subprocess
 from collections.abc import Callable
 from enum import Enum
 from typing import Any, NoReturn
@@ -91,12 +94,65 @@ class DeepGemmQuantScaleFMT(Enum):
 
 
 @functools.cache
+@functools.cache
+def _nvcc_version() -> tuple[int, int] | None:
+    """Best-effort version of the local toolkit's nvcc.
+
+    Locates the toolkit via torch's standard ``CUDA_HOME`` resolution
+    (CUDA_HOME/CUDA_PATH env, nvcc on PATH, /usr/local/cuda) — the same
+    discovery JIT backends effectively use. ``torch.version.cuda`` is the
+    build-time CUDA of the wheel and says nothing about the local
+    toolchain, so the version must come from running nvcc itself.
+
+    Returns ``None`` when nvcc cannot be located or parsed — callers must
+    treat that as "unknown", not as a failure.
+    """
+    from torch.utils.cpp_extension import CUDA_HOME
+
+    candidates = []
+    if CUDA_HOME:
+        candidates.append(os.path.join(CUDA_HOME, "bin", "nvcc"))
+    which_nvcc = shutil.which("nvcc")
+    if which_nvcc:
+        candidates.append(which_nvcc)
+    for nvcc in candidates:
+        try:
+            out = subprocess.run(
+                [nvcc, "--version"], capture_output=True, text=True, timeout=10
+            ).stdout
+        except (OSError, subprocess.SubprocessError):
+            continue
+        match = re.search(r"release (\d+)\.(\d+)", out)
+        if match:
+            return int(match.group(1)), int(match.group(2))
+    return None
+
+
+# Minimum toolchain DeepGEMM's JIT accepts; older nvcc trips an assertion
+# in its compiler.hpp at first kernel compile, long after backend selection.
+_DEEP_GEMM_MIN_NVCC = (12, 3)
+
+
 def is_deep_gemm_supported() -> bool:
     """Return `True` if DeepGEMM is supported on the current platform.
     Currently, only Hopper and Blackwell GPUs are supported.
     """
     is_supported_arch = current_platform.support_deep_gemm()
-    return envs.VLLM_USE_DEEP_GEMM and has_deep_gemm() and is_supported_arch
+    if not (envs.VLLM_USE_DEEP_GEMM and has_deep_gemm() and is_supported_arch):
+        return False
+    # DeepGEMM JIT-compiles kernels at first use; a toolchain its compiler
+    # rejects would otherwise crash mid-weight-load. Only a positively
+    # identified too-old nvcc disqualifies — unknown means supported.
+    nvcc_version = _nvcc_version()
+    if nvcc_version is not None and nvcc_version < _DEEP_GEMM_MIN_NVCC:
+        logger.warning_once(
+            "DeepGEMM disabled: found nvcc %d.%d but DeepGEMM's JIT requires "
+            ">= %d.%d. Set CUDA_HOME to a newer toolkit to enable it.",
+            *nvcc_version,
+            *_DEEP_GEMM_MIN_NVCC,
+        )
+        return False
+    return True
 
 
 @functools.cache


### PR DESCRIPTION
## Purpose

`is_deep_gemm_supported()` gates on the env flag, package presence and GPU arch — but DeepGEMM JIT-compiles kernels at first use. With an nvcc older than 12.3 on `PATH`/`CUDA_HOME`, backend selection commits to DeepGEMM and the first compile detonates mid-weight-load with a raw assertion from its `compiler.hpp`:

```
RuntimeError: Assertion error (.../jit/compiler.hpp:187):
(major > 12 or (major == 12 and minor >= 3)) and "NVCC version should be >= 12.3"
```

Reproduced deterministically with `XiaomiMiMo/MiMo-V2.5-Pro` (fp8) in `test_can_initialize_large_subset` on consumer Blackwell (RTX 5090, sm_120) with nvcc 12.1.

Fix: add a best-effort nvcc probe to `is_deep_gemm_supported()`, locating the toolkit via torch's standard `CUDA_HOME` resolution (env vars, PATH, `/usr/local/cuda`) and running `nvcc --version` — `torch.version.cuda` is the wheel's build-time CUDA and cannot detect a stale local toolchain. Only a **positively identified** too-old toolchain disqualifies, with a warning pointing at `CUDA_HOME`; an undetectable nvcc never blocks, so CI and properly-provisioned hosts are unaffected.

This is interim hardening for one concrete crash; the general probe-before-commit design for JIT backends is RFC #47456, and this change is written to be subsumed by it.

## Test Plan

```bash
pytest tests/utils_/test_deep_gemm_utils.py
```

## Test Result

```
6 passed
```

(too-old rejected / minimum allowed / newer allowed / unknown never blocks / other gates still apply / probe parses or returns None.)

End-to-end on the machine that exposed the bug (RTX 5090, nvcc 12.1): before the gate, MiMo-V2.5-Pro initialization crashes with the assertion above; with the gate, DeepGEMM is skipped with a clear warning, vLLM falls back to the next fp8 backend, and the same test passes (`1 passed in 10.18s`).

No open PR covers this (searched deepgemm/nvcc/toolchain; #48190 is JIT cache keys, #41062 is SM12x device gates). Written with AI assistance; I reviewed every changed line and ran the tests above.
