### PR TITLE
[Bugfix] Reject negative --device-ids indices instead of selecting the wrong device

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -707,6 +707,17 @@ class TestDeviceIds:
         with pytest.raises(ValueError, match="out of range"):
             args._resolve_device_ids()
 
+    def test_device_ids_with_cvd_negative_index(self, monkeypatch):
+        """A negative --device-ids index raises instead of silently
+        negative-indexing into the CVD set and selecting the wrong device."""
+        from vllm.platforms import current_platform
+
+        key = current_platform.device_control_env_var
+        monkeypatch.setenv(key, "4,5")
+        args = EngineArgs(model="m", device_ids=[-1])
+        with pytest.raises(ValueError, match="out of range"):
+            args._resolve_device_ids()
+
     def test_device_ids_with_cvd_resolve_to_physical_ids(self, monkeypatch):
         """--device-ids are CVD-local indices resolved to physical ids."""
         from vllm.platforms import current_platform

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1811,7 +1811,7 @@ class EngineArgs:
                 for x in cvd.split(",")
             ]
             for i in int_ids:
-                if i >= len(cvd_ids):
+                if not 0 <= i < len(cvd_ids):
                     raise ValueError(
                         f"--device-ids index {i} is out of range for "
                         f"{current_platform.device_control_env_var}"


### PR DESCRIPTION
## Purpose

`EngineArgs._resolve_device_ids` composes `--device-ids` with `CUDA_VISIBLE_DEVICES`: when CVD is set, each `--device-ids` value is treated as an index into the visible set. The range check only guarded the upper bound:

```python
for i in int_ids:
    if i >= len(cvd_ids):
        raise ValueError(f"--device-ids index {i} is out of range ...")
return [cvd_ids[i] for i in int_ids]
```

A negative index (for example `--device-ids -1`) makes `i >= len(cvd_ids)` evaluate to `False`, so no error is raised and `cvd_ids[i]` silently negative-indexes into the list, resolving to a valid-but-wrong physical device. With `CUDA_VISIBLE_DEVICES=4,5` and `--device-ids -1`, the method returns physical device `[5]` instead of rejecting the input.

This completes the bounds check to `not 0 <= i < len(cvd_ids)` so an out-of-range negative index raises the same "out of range" `ValueError` as a too-large one, matching the intent of the existing `test_device_ids_with_cvd_out_of_range` test.

This changes only input validation (silent mis-selection becomes a clear error); it does not affect model output, accuracy, or serving numerics, so no model-evaluation results apply.

**Not a duplicate:** the only open PRs touching this area, #46132 and #41776, add MIG/UUID parsing for `CUDA_VISIBLE_DEVICES`; neither changes the `_resolve_device_ids` index bounds check. No open issue tracks this.

## Test Plan

Added `tests/engine/test_arg_utils.py::TestDeviceIds::test_device_ids_with_cvd_negative_index`, mirroring the existing `test_device_ids_with_cvd_out_of_range`:

```bash
pytest tests/engine/test_arg_utils.py::TestDeviceIds -q
```

## Test Result

`_resolve_device_ids` does not load a model, so I validated the exact logic on CPU by executing the method against a stubbed platform (a full CUDA build was not available on my machine); the added test runs in CI:

- Before: `EngineArgs(model="m", device_ids=[-1])` with `CUDA_VISIBLE_DEVICES=4,5` returned `[5]` (no error raised).
- After: it raises `ValueError: --device-ids index -1 is out of range for CUDA_VISIBLE_DEVICES=4,5 (2 devices visible)`.
- Unchanged for valid input: `device_ids=[0, 1]` still resolves to `[4, 5]`.

---

**AI assistance disclosure:** AI assistance was used to help identify and prepare this change, per the repository's contribution policy. The fix is a single bounds-check completion plus a regression test, and I have reviewed every changed line.
