### PR TITLE
[Bugfix] Emit a valid media type from encode_{audio,image,video}_url

### DIFF
--- a/tests/multimodal/test_utils.py
+++ b/tests/multimodal/test_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import pytest
 import torch
+from PIL import Image
 
 from vllm.multimodal.inputs import (
     MultiModalBatchedField,
@@ -10,7 +11,11 @@ from vllm.multimodal.inputs import (
     MultiModalSharedField,
     PlaceholderRange,
 )
-from vllm.multimodal.utils import argsort_mm_positions, group_and_batch_mm_items
+from vllm.multimodal.utils import (
+    argsort_mm_positions,
+    encode_image_url,
+    group_and_batch_mm_items,
+)
 
 
 @pytest.mark.parametrize(
@@ -222,6 +227,16 @@ def test_group_and_batch_mm_items_splits_shared_data_by_dtype():
     )
 
     assert [num_items for num_items, _ in res] == [1, 1, 1]
+
+
+def test_encode_image_url_uncommon_format_has_valid_mimetype():
+    """A format missing from mimetypes.types_map must still produce a
+    well-formed type/subtype media type, not a bare 'image'."""
+    # ".tga" is not registered in mimetypes.types_map, so it exercises the
+    # fallback path; Pillow can still encode it.
+    url = encode_image_url(Image.new("RGB", (2, 2)), format="TGA")
+    mimetype = url.removeprefix("data:").split(";", 1)[0]
+    assert mimetype == "image/tga"
 
 
 def test_group_and_batch_mm_items_split_by_shared_data():

--- a/vllm/multimodal/utils.py
+++ b/vllm/multimodal/utils.py
@@ -57,7 +57,7 @@ def encode_audio_url(
 ) -> str:
     """Encode audio as a data URL."""
     audio_b64 = encode_audio_base64(audio, sampling_rate, format=format)
-    mimetype = mimetypes.types_map.get("." + format.lower(), "audio")
+    mimetype = mimetypes.types_map.get("." + format.lower(), f"audio/{format.lower()}")
     return f"data:{mimetype};base64,{audio_b64}"
 
 
@@ -90,7 +90,7 @@ def encode_image_url(
     Pass `image_mode=None` to keep the original image mode.
     """
     image_b64 = encode_image_base64(image, image_mode=image_mode, format=format)
-    mimetype = mimetypes.types_map.get("." + format.lower(), "image")
+    mimetype = mimetypes.types_map.get("." + format.lower(), f"image/{format.lower()}")
     return f"data:{mimetype};base64,{image_b64}"
 
 
@@ -114,7 +114,9 @@ def encode_video_url(
     if format.lower() == "jpeg":
         mimetype = "video/jpeg"
     else:
-        mimetype = mimetypes.types_map.get("." + format.lower(), "video")
+        mimetype = mimetypes.types_map.get(
+            "." + format.lower(), f"video/{format.lower()}"
+        )
 
     return f"data:{mimetype};base64,{video_b64}"
 


### PR DESCRIPTION
## Purpose

`encode_audio_url`, `encode_image_url` and `encode_video_url` in `vllm/multimodal/utils.py` build a data URL and resolve its media type with:

```python
mimetype = mimetypes.types_map.get("." + format.lower(), "image")  # or "audio"/"video"
return f"data:{mimetype};base64,{...}"
```

When the format's extension is not registered in `mimetypes.types_map`, the fallback is a bare top-level type (`"image"`, `"audio"`, `"video"`). A media type with no subtype is not well-formed, so formats missing from the table produce an invalid data URL such as `data:image;base64,...`. This is reachable with formats Pillow/soundfile can encode but that Python's `mimetypes` does not register, for example `TGA`/`PCX` images or `CAF`/`W64` audio.

This changes the fallback to `"<kind>/<format>"` (e.g. `image/tga`), so the media type is always a well-formed `type/subtype`. Registered formats are unchanged (e.g. `PNG` still resolves to `image/png`).

This only affects the media-type string of the generated data URL (a request-construction helper); it does not touch model output, accuracy, or serving numerics, so no model-evaluation results apply.

**Not a duplicate:** I searched open PRs for `encode_image_url`/`encode_audio_url`, `mimetype`, and `multimodal/utils.py`; the open multimodal PRs (#43638, #46947, #44474, #29034, ...) touch examples, spec-decode embeddings, and video URL loading, none change the `encode_*_url` media-type fallback. No open issue tracks this.

## Test Plan

Added `tests/multimodal/test_utils.py::test_encode_image_url_uncommon_format_has_valid_mimetype`, which encodes a Pillow image with `format="TGA"` (`.tga` is not in `mimetypes.types_map`) and asserts the media type is `image/tga`:

```bash
pytest tests/multimodal/test_utils.py::test_encode_image_url_uncommon_format_has_valid_mimetype -q
```

## Test Result

A full CUDA build was not available on my machine, so I validated the exact fixed function bodies on CPU by extracting `encode_{audio,image,video}_url` from the module and executing them with the base64 encoders stubbed (the media-type logic is independent of encoding). The added test runs in CI.

- Before, uncommon formats produced bare types: `encode_image_url(img, format="TGA")` -> `data:image;base64,...`, `encode_video_url(frames, format="MKV")` -> `data:video;base64,...`.
- After: `data:image/tga;base64,...`, `data:audio/caf;base64,...`, `data:video/mkv;base64,...` (all well-formed `type/subtype`).
- Registered formats unchanged: `PNG` -> `image/png`, `WAV` -> `audio/x-wav`.

Ran `ruff check` and `ruff format --check` on both changed files: clean.

---

**AI assistance disclosure:** AI assistance was used to help identify and prepare this change, per the repository's contribution policy. The fix updates a one-line fallback in three sibling helpers plus a regression test, and I have reviewed every changed line.
