### PR TITLE
[Bugfix] Fix false boolean values in YAML CLI configuration

### DIFF
--- a/tests/utils_/test_argparse_utils.py
+++ b/tests/utils_/test_argparse_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # ruff: noqa
 
+import argparse
 import json
 import os
 
@@ -377,6 +378,85 @@ def test_load_config_file(tmp_path):
     # Assert that the processed arguments match the expected output
     assert processed_args == expected_args
     os.remove(str(config_file_path))
+
+
+@pytest.mark.parametrize(
+    ("action", "default", "config_value"),
+    [
+        (argparse.BooleanOptionalAction, True, False),
+        (argparse.BooleanOptionalAction, False, True),
+        ("store_true", False, True),
+        ("store_true", False, False),
+        ("store_false", True, True),
+        ("store_false", True, False),
+    ],
+)
+@pytest.mark.parametrize("use_subparser", [False, True])
+def test_load_config_file_boolean_values(
+    tmp_path, action, default, config_value, use_subparser
+):
+    config_file_path = tmp_path / "config.yaml"
+    config_file_path.write_text(yaml.safe_dump({"enable_feature": config_value}))
+
+    parser = FlexibleArgumentParser()
+    cli_args: list[str] = []
+    target_parser = parser
+    if use_subparser:
+        target_parser = parser.add_subparsers().add_parser("serve")
+        target_parser.add_argument("model")
+        cli_args.extend(("serve", "model"))
+
+    target_parser.add_argument("--config")
+    target_parser.add_argument("--enable-feature", action=action, default=default)
+
+    args = parser.parse_args([*cli_args, "--config", str(config_file_path)])
+
+    assert args.enable_feature is config_value
+
+
+def test_load_config_file_selects_registered_negative_option(tmp_path):
+    config_file_path = tmp_path / "config.yaml"
+    config_file_path.write_text(yaml.safe_dump({"enable_feature": False}))
+
+    parser = FlexibleArgumentParser()
+    action = parser.add_argument(
+        "--enable-feature", action=argparse.BooleanOptionalAction
+    )
+    negative_option = next(
+        option for option in action.option_strings if option.startswith("--no-")
+    )
+
+    assert parser.load_config_file(str(config_file_path)) == [negative_option]
+
+
+@pytest.mark.parametrize("use_subparser", [False, True])
+def test_cli_overrides_boolean_config_value(tmp_path, use_subparser):
+    config_file_path = tmp_path / "config.yaml"
+    config_file_path.write_text(yaml.safe_dump({"enable_feature": False}))
+
+    parser = FlexibleArgumentParser()
+    cli_args: list[str] = []
+    target_parser = parser
+    if use_subparser:
+        target_parser = parser.add_subparsers().add_parser("serve")
+        target_parser.add_argument("model")
+        cli_args.extend(("serve", "model"))
+
+    target_parser.add_argument("--config")
+    target_parser.add_argument(
+        "--enable-feature", action=argparse.BooleanOptionalAction, default=True
+    )
+
+    args = parser.parse_args(
+        [
+            *cli_args,
+            "--config",
+            str(config_file_path),
+            "--enable-feature",
+        ]
+    )
+
+    assert args.enable_feature is True
 
 
 def test_load_config_file_nested(tmp_path):

--- a/vllm/utils/argparse_utils.py
+++ b/vllm/utils/argparse_utils.py
@@ -484,7 +484,15 @@ class FlexibleArgumentParser(ArgumentParser):
 
         file_path = args[index + 1]
 
-        config_args = self.load_config_file(file_path)
+        config_parser = self
+        for action in self._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                subparser = action.choices.get(args[0])
+                if isinstance(subparser, FlexibleArgumentParser):
+                    config_parser = subparser
+                break
+
+        config_args = config_parser.load_config_file(file_path)
 
         # 0th index might be the sub command {serve,chat,complete,...}
         # optionally followed by model_tag (only for serve)
@@ -571,8 +579,35 @@ class FlexibleArgumentParser(ArgumentParser):
 
         for key, value in config.items():
             if isinstance(value, bool):
-                if value:
-                    processed_args.append("--" + key)
+                option = "--" + key
+                normalized_option = option.replace("_", "-")
+                action = self._option_string_actions.get(normalized_option)
+
+                if isinstance(action, argparse.BooleanOptionalAction):
+                    if value:
+                        processed_args.append(option)
+                    else:
+                        negative_option = next(
+                            (
+                                option_string
+                                for option_string in action.option_strings
+                                if option_string.startswith("--no-")
+                                and option_string.removeprefix("--no-")
+                                == normalized_option.removeprefix("--")
+                            ),
+                            None,
+                        )
+                        if negative_option is not None:
+                            processed_args.append(negative_option)
+                elif (
+                    action is not None
+                    and action.nargs == 0
+                    and isinstance(action.const, bool)
+                ):
+                    if action.const is value:
+                        processed_args.append(option)
+                elif value:
+                    processed_args.append(option)
             elif isinstance(value, list):
                 if value:
                     processed_args.append("--" + key)


### PR DESCRIPTION
## Summary

Fix YAML configuration handling for boolean CLI options whose value is `false`.

Previously, false-valued YAML entries could be discarded while configuration
values were converted into command-line arguments. This prevented YAML
configuration from disabling options whose effective default was `true`.

The updated handling:

- resolves the active `serve` subparser
- supports `argparse.BooleanOptionalAction`
- supports `store_true` and `store_false`
- selects registered negative option strings instead of inventing them
- preserves explicit CLI-over-config precedence
- preserves existing unknown-option behavior

## Tests

Coverage includes:

- direct parser boolean cases
- `serve` subparser boolean cases
- `BooleanOptionalAction`
- `store_true`
- `store_false`
- true and false YAML values
- registered negative-option selection
- explicit CLI-over-config precedence

Validation performed:

- `.venv/bin/python /tmp/vllm-run-focused-argparse-test.py` — 19 passed
- `PYTHONPATH=. .venv/bin/python /tmp/vllm-validate-yaml-bools.py` — passed
- `PRE_COMMIT_HOME=/tmp/vllm-pre-commit-cache .venv/bin/pre-commit run --files vllm/utils/argparse_utils.py tests/utils_/test_argparse_utils.py` — passed all applicable hooks, including Ruff, formatting, typos, mypy 3.10, and repository policy checks
- `PRE_COMMIT_HOME=/tmp/vllm-pre-commit-cache .venv/bin/pre-commit run mypy-3.12 --hook-stage manual --files vllm/utils/argparse_utils.py tests/utils_/test_argparse_utils.py` — passed
- `git diff --check upstream/main...HEAD` — passed

## Notes

The ordinary test-file command could not collect in the lightweight local CPU
environment:

- `.venv/bin/python -m pytest -q tests/utils_/test_argparse_utils.py` — unavailable because `tblib` is not installed
- `.venv/bin/python -m pytest -q --confcutdir=tests/utils_ tests/utils_/test_argparse_utils.py` — unavailable because the shared `tests.utils` module imports `anthropic`

No complete test-file or full-suite success is claimed.

This does not duplicate merged PR #9533, which added true-valued flag handling
and support for a former custom boolean action but left false values omitted for
default-true argparse actions. Open PR #43548 only expands YAML when config is
passed with `--config=<path>` and does not change boolean-value translation.

Model evaluation is not applicable because this change is limited to CLI
argument parsing and does not modify model execution, accuracy, or output.

OpenAI Codex provided non-trivial assistance in reviewing and preparing this
contribution; the commit includes corresponding attribution.
