### PR TITLE
[Quant] Add online NVFP4 dense-linear quantization (W4A16 + W4A4)

### DIFF
--- a/tests/quantization/test_online.py
+++ b/tests/quantization/test_online.py
@@ -18,6 +18,8 @@ from vllm.model_executor.layers.quantization.online.fp8 import (
 )
 from vllm.model_executor.layers.quantization.online.nvfp4 import (
     Nvfp4OnlineMoEMethod,
+    Nvfp4W4A4OnlineLinearMethod,
+    Nvfp4W4A16OnlineLinearMethod,
 )
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer_trtllm_fused_moe
@@ -179,6 +181,107 @@ def test_online_nvfp4_per_token_moe(vllm_runner, monkeypatch) -> None:
         llm.apply_model(check_model)
         outputs = llm.generate_greedy(["Hello my name is"], max_tokens=4)
         print(outputs[0][1])
+
+
+@pytest.mark.skipif(
+    not (current_platform.is_cuda() and current_platform.has_device_capability(75)),
+    reason="Online NVFP4 W4A16 needs the FP4 Marlin kernel (CUDA SM>=75).",
+)
+def test_online_nvfp4_w4a16_linear(vllm_runner, monkeypatch) -> None:
+    """Online NVFP4 W4A16 quantizes dense linear layers to FP4 at load time.
+
+    Weight-only path: activations stay bf16/fp16 and Marlin dequantizes on the
+    fly, so this runs on any SM>=75 GPU (not just Blackwell).
+    """
+    monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+
+    with vllm_runner(
+        "ibm-granite/granite-3.0-1b-a400m-base",
+        quantization="nvfp4",
+        enforce_eager=True,
+    ) as llm:
+
+        def check_model(model):
+            o_proj = model.model.layers[0].self_attn.o_proj
+            assert isinstance(o_proj.quant_method, Nvfp4W4A16OnlineLinearMethod)
+            # Weights are packed FP4 (two values per uint8 byte).
+            assert o_proj.weight.dtype == torch.uint8
+            assert hasattr(o_proj, "weight_global_scale")
+            # MoE stays unquantized under the linear-only "nvfp4" shorthand.
+            moe = model.model.layers[0].block_sparse_moe.experts
+            if moe is not None:
+                assert not isinstance(moe._quant_method, Nvfp4OnlineMoEMethod)
+
+        llm.apply_model(check_model)
+        outputs = llm.generate_greedy(["Hello my name is"], max_tokens=4)
+        print(outputs[0][1])
+
+
+def _nvfp4_w4a4_supported() -> bool:
+    if not current_platform.is_cuda():
+        return False
+    try:
+        from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
+            cutlass_fp4_supported,
+        )
+    except Exception:
+        return False
+    return cutlass_fp4_supported()
+
+
+@pytest.mark.skipif(
+    not _nvfp4_w4a4_supported(),
+    reason="Online NVFP4 W4A4 needs a native FP4 W4A4 GEMM kernel (Blackwell).",
+)
+def test_online_nvfp4_w4a4_cudagraph_dynamic_scale() -> None:
+    """W4A4's dynamic activation scale must replay against the live input.
+
+    The old ``.data.copy_`` refresh captured the warmup activation's scale once
+    and replayed it stale under CUDA graphs, yielding garbage. The explicit
+    dataflow fix computes the scale as fresh graph-visible ops threaded into the
+    kernel, so a captured graph replayed on a materially different input must
+    match eager on that same input (a stale scale would not).
+    """
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    out_features, in_features = 256, 512
+
+    layer = torch.nn.Module()
+    layer.output_size_per_partition = out_features
+    layer.input_size_per_partition = in_features
+    layer.params_dtype = torch.bfloat16
+    weight = torch.randn(out_features, in_features, device=device, dtype=torch.bfloat16)
+    layer.weight = torch.nn.Parameter(weight, requires_grad=False)
+
+    method = Nvfp4W4A4OnlineLinearMethod()
+    method.process_weights_after_loading(layer)
+
+    # Two inputs with materially different amax -> different dynamic scale.
+    x_small = torch.randn(8, in_features, device=device, dtype=torch.bfloat16) * 0.1
+    x_large = torch.randn(8, in_features, device=device, dtype=torch.bfloat16) * 8.0
+
+    eager_small = method.apply(layer, x_small).clone()
+    eager_large = method.apply(layer, x_large).clone()
+    # Distinct scales must produce meaningfully distinct outputs.
+    assert not torch.allclose(eager_small, eager_large, atol=1e-2)
+
+    # Capture a graph on x_small, then replay on x_large's data.
+    static_in = x_small.clone()
+    method.apply(layer, static_in)  # warmup
+    torch.accelerator.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        static_out = method.apply(layer, static_in)
+
+    static_in.copy_(x_large)
+    graph.replay()
+    torch.accelerator.synchronize()
+
+    # If the scale replayed stale (bug), the graph output would match the
+    # captured x_small scale instead of x_large's eager result.
+    assert torch.allclose(static_out, eager_large, atol=5e-2, rtol=5e-2)
+    assert not torch.allclose(static_out, eager_small, atol=1e-2)
 
 
 @pytest.mark.skipif(

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -18,6 +18,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kInt8StaticChannelSym,
     kMxfp4Dynamic,
     kMxfp8Dynamic,
+    kNvfp4Dynamic,
     kNvfp4Static,
 )
 
@@ -31,6 +32,8 @@ QUANT_KEY_NAMES: dict[str, QuantKey] = {
     "fp8_per_block_dynamic": kFp8Dynamic128Sym,
     "mxfp8": kMxfp8Dynamic,
     "mxfp4": kMxfp4Dynamic,
+    "nvfp4_w4a16": kNvfp4Static,
+    "nvfp4_w4a4": kNvfp4Dynamic,
     "int8_per_channel_static": kInt8StaticChannelSym,
 }
 
@@ -139,6 +142,16 @@ _ONLINE_SHORTHANDS: dict[str, QuantizationConfigArgs] = {
     # FlashInfer TRTLLM only); linear stays unquantized (no `linear` field).
     "nvfp4_per_token": QuantizationConfigArgs(
         moe=QuantSpec(weight=kNvfp4Static),
+    ),
+    # Online NVFP4 weight-only (W4A16) on dense linear. Portable: Marlin FP4
+    # runs on any SM>=75. MoE stays unquantized (no `moe` field).
+    "nvfp4": QuantizationConfigArgs(
+        linear=QuantSpec(weight=kNvfp4Static),
+    ),
+    # Online NVFP4 W4A4 on dense linear: FP4 weights + dynamic per-token FP4
+    # activation quant. CUTLASS/FlashInfer FP4, Blackwell SM>=100.
+    "nvfp4_w4a4": QuantizationConfigArgs(
+        linear=QuantSpec(weight=kNvfp4Dynamic),
     ),
 }
 

--- a/vllm/model_executor/kernels/linear/nvfp4/base.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/base.py
@@ -71,6 +71,16 @@ class NvFp4LinearKernel(ABC):
         layer: torch.nn.Module,
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
+        *,
+        input_global_scale_inv: torch.Tensor | None = None,
+        alpha: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        """Run the quantized GEMM."""
+        """Run the quantized GEMM.
+
+        ``input_global_scale_inv`` and ``alpha`` optionally override the
+        persistent ``layer.input_global_scale_inv`` / ``layer.alpha``
+        parameters. Online W4A4 passes freshly computed per-forward tensors
+        (graph-visible dynamic activation scale); calibrated/pre-quantized
+        callers leave them ``None`` to use the layer's static values.
+        """
         raise NotImplementedError

--- a/vllm/model_executor/kernels/linear/nvfp4/cutlass.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/cutlass.py
@@ -47,15 +47,48 @@ class CutlassNvFp4LinearKernel(NvFp4LinearKernel):
         layer: torch.nn.Module,
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
+        *,
+        input_global_scale_inv: torch.Tensor | None = None,
+        alpha: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        input_global_scale_inv = (
+            layer.input_global_scale_inv
+            if input_global_scale_inv is None
+            else input_global_scale_inv
+        )
+        alpha = layer.alpha if alpha is None else alpha
         output_size = layer.output_size_per_partition
         output_dtype = x.dtype
         output_shape = [*x.shape[:-1], output_size]
         weights_padding_bytes = getattr(layer, "weights_padding_cols", 0)
 
+        # input_global_scale_inv is the FP4 quant multiplier (2688 / amax):
+        # scalar for the per-tensor path, length-M for the per-token path.
+        # Per-token is required for CUDA-graph correctness (a per-tensor amax
+        # reduces over the padded graph buffer, and padding rows corrupt real
+        # rows' scale). The GEMM epilogue only takes a scalar alpha, so for the
+        # per-token path we pre-scale each row, quantize with a unit global
+        # scale (each row's block scale then comes from its own amax), and apply
+        # the per-row factor as a post-GEMM row multiply -- identical to a
+        # per-row epilogue alpha and CUDA-graph-safe (elementwise on graph
+        # tensors). A fused per-row epilogue is future CUTLASS work.
+        per_row = input_global_scale_inv.numel() != 1
+        if per_row:
+            quant_input = x * input_global_scale_inv.reshape(*x.shape[:-1], 1).to(
+                x.dtype
+            )
+            quant_global_scale = x.new_ones((), dtype=torch.float32)
+            # alpha[i] = input_global_scale[i] * weight_global_scale; the shared
+            # weight factor goes to the GEMM, the per-row part is applied after.
+            gemm_alpha = layer.weight_global_scale.reshape(()).to(torch.float32)
+        else:
+            quant_input = x
+            quant_global_scale = input_global_scale_inv
+            gemm_alpha = alpha
+
         x_fp4, x_blockscale = scaled_fp4_quant(
-            x,
-            layer.input_global_scale_inv,
+            quant_input,
+            quant_global_scale,
             is_sf_swizzled_layout=True,
             backend="cutlass",
             padded_n=x.shape[-1] + weights_padding_bytes * 2,
@@ -66,9 +99,15 @@ class CutlassNvFp4LinearKernel(NvFp4LinearKernel):
             layer.weight,
             x_blockscale,
             layer.weight_scale,
-            layer.alpha,
+            gemm_alpha,
             output_dtype,
         )
+
+        if per_row:
+            # Recover the per-row input scale (GEMM already applied the shared
+            # weight factor) and multiply each output row by it.
+            per_row_scale = (alpha / gemm_alpha).reshape(-1, 1)
+            out = (out.to(torch.float32) * per_row_scale).to(output_dtype)
 
         out = slice_nvfp4_output(out, output_size)
 

--- a/vllm/model_executor/kernels/linear/nvfp4/fbgemm.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/fbgemm.py
@@ -39,16 +39,25 @@ class FbgemmNvFp4LinearKernel(NvFp4LinearKernel):
         layer: torch.nn.Module,
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
+        *,
+        input_global_scale_inv: torch.Tensor | None = None,
+        alpha: torch.Tensor | None = None,
     ) -> torch.Tensor:
         import fbgemm_gpu  # noqa: F401 - registers torch.ops.fbgemm.*
 
+        input_global_scale_inv = (
+            layer.input_global_scale_inv
+            if input_global_scale_inv is None
+            else input_global_scale_inv
+        )
+        alpha = layer.alpha if alpha is None else alpha
         output_size = layer.output_size_per_partition
         output_dtype = x.dtype
         output_shape = [*x.shape[:-1], output_size]
 
         x_fp4, x_blockscale = scaled_fp4_quant(
             x,
-            layer.input_global_scale_inv,
+            input_global_scale_inv,
             is_sf_swizzled_layout=True,
             backend="fbgemm",
         )
@@ -58,7 +67,7 @@ class FbgemmNvFp4LinearKernel(NvFp4LinearKernel):
             layer.weight,
             x_blockscale.view(-1).view(torch.uint8),
             layer.weight_scale,
-            layer.alpha,
+            alpha,
             use_mx=False,
         ).to(output_dtype)
 

--- a/vllm/model_executor/kernels/linear/nvfp4/flashinfer.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/flashinfer.py
@@ -61,14 +61,23 @@ class FlashInferCuteDslNvFp4LinearKernel(NvFp4LinearKernel):
         layer: torch.nn.Module,
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
+        *,
+        input_global_scale_inv: torch.Tensor | None = None,
+        alpha: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        input_global_scale_inv = (
+            layer.input_global_scale_inv
+            if input_global_scale_inv is None
+            else input_global_scale_inv
+        )
+        alpha = layer.alpha if alpha is None else alpha
         output_size = layer.output_size_per_partition
         output_dtype = x.dtype
         output_shape = [*x.shape[:-1], output_size]
 
         x_fp4, x_blockscale = scaled_fp4_quant(
             x,
-            layer.input_global_scale_inv,
+            input_global_scale_inv,
             is_sf_swizzled_layout=True,
             backend="flashinfer-cutedsl",
         )
@@ -82,7 +91,7 @@ class FlashInferCuteDslNvFp4LinearKernel(NvFp4LinearKernel):
             layer.weight,
             x_blockscale,
             layer.weight_scale,
-            layer.alpha,
+            alpha,
             output_dtype,
             backend="cute-dsl",
         )
@@ -137,7 +146,16 @@ class FlashInferCutlassNvFp4LinearKernel(NvFp4LinearKernel):
         layer: torch.nn.Module,
         x: torch.Tensor | QuantizedActivation,
         bias: torch.Tensor | None = None,
+        *,
+        input_global_scale_inv: torch.Tensor | None = None,
+        alpha: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        input_global_scale_inv = (
+            layer.input_global_scale_inv
+            if input_global_scale_inv is None
+            else input_global_scale_inv
+        )
+        alpha = layer.alpha if alpha is None else alpha
         output_size = layer.output_size_per_partition
         weights_padding_bytes = getattr(layer, "weights_padding_cols", 0)
 
@@ -153,7 +171,7 @@ class FlashInferCutlassNvFp4LinearKernel(NvFp4LinearKernel):
             output_shape = [*x.shape[:-1], output_size]
             x_fp4, x_blockscale = scaled_fp4_quant(
                 x,
-                layer.input_global_scale_inv,
+                input_global_scale_inv,
                 is_sf_swizzled_layout=True,
                 backend="flashinfer-cutlass",
                 padded_n=x.shape[-1] + weights_padding_bytes * 2,
@@ -164,7 +182,7 @@ class FlashInferCutlassNvFp4LinearKernel(NvFp4LinearKernel):
             layer.weight,
             x_blockscale,
             layer.weight_scale,
-            layer.alpha,
+            alpha,
             output_dtype,
             backend="cutlass",
         )
@@ -214,14 +232,23 @@ class FlashInferTrtllmNvFp4LinearKernel(NvFp4LinearKernel):
         layer: torch.nn.Module,
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
+        *,
+        input_global_scale_inv: torch.Tensor | None = None,
+        alpha: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        input_global_scale_inv = (
+            layer.input_global_scale_inv
+            if input_global_scale_inv is None
+            else input_global_scale_inv
+        )
+        alpha = layer.alpha if alpha is None else alpha
         output_size = layer.output_size_per_partition
         output_dtype = x.dtype
         output_shape = [*x.shape[:-1], output_size]
 
         x_fp4, x_blockscale = scaled_fp4_quant(
             x,
-            layer.input_global_scale_inv,
+            input_global_scale_inv,
             is_sf_swizzled_layout=True,
             backend="flashinfer-trtllm",
         )
@@ -231,7 +258,7 @@ class FlashInferTrtllmNvFp4LinearKernel(NvFp4LinearKernel):
             layer.weight,
             x_blockscale,
             layer.weight_scale,
-            layer.alpha,
+            alpha,
             output_dtype,
             backend="trtllm",
         )
@@ -274,7 +301,16 @@ class FlashInferCudnnNvFp4LinearKernel(NvFp4LinearKernel):
         layer: torch.nn.Module,
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
+        *,
+        input_global_scale_inv: torch.Tensor | None = None,
+        alpha: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        input_global_scale_inv = (
+            layer.input_global_scale_inv
+            if input_global_scale_inv is None
+            else input_global_scale_inv
+        )
+        alpha = layer.alpha if alpha is None else alpha
         output_size = layer.output_size_per_partition
         output_dtype = x.dtype
         output_shape = [*x.shape[:-1], output_size]
@@ -282,7 +318,7 @@ class FlashInferCudnnNvFp4LinearKernel(NvFp4LinearKernel):
 
         x_fp4, x_blockscale = scaled_fp4_quant(
             x,
-            layer.input_global_scale_inv,
+            input_global_scale_inv,
             is_sf_swizzled_layout=True,
             backend="flashinfer-cudnn",
             padded_n=x.shape[-1] + weights_padding_bytes * 2,
@@ -293,7 +329,7 @@ class FlashInferCudnnNvFp4LinearKernel(NvFp4LinearKernel):
             layer.weight,
             x_blockscale,
             layer.weight_scale,
-            layer.alpha,
+            alpha,
             output_dtype,
             backend="cudnn",
         )
@@ -339,14 +375,23 @@ class FlashInferB12xNvFp4LinearKernel(NvFp4LinearKernel):
         layer: torch.nn.Module,
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
+        *,
+        input_global_scale_inv: torch.Tensor | None = None,
+        alpha: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        input_global_scale_inv = (
+            layer.input_global_scale_inv
+            if input_global_scale_inv is None
+            else input_global_scale_inv
+        )
+        alpha = layer.alpha if alpha is None else alpha
         output_size = layer.output_size_per_partition
         output_dtype = x.dtype
         output_shape = [*x.shape[:-1], output_size]
 
         x_fp4, x_blockscale = scaled_fp4_quant(
             x,
-            layer.input_global_scale_inv,
+            input_global_scale_inv,
             is_sf_swizzled_layout=True,
             backend="b12x",
         )
@@ -360,7 +405,7 @@ class FlashInferB12xNvFp4LinearKernel(NvFp4LinearKernel):
             layer.weight,
             x_blockscale,
             layer.weight_scale,
-            layer.alpha,
+            alpha,
             output_dtype,
             backend="b12x",
         )

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -43,6 +43,8 @@ QuantizationMethods = Literal[
     "fp8_per_channel",
     "int8_per_channel_weight_only",
     "nvfp4_per_token",
+    "nvfp4",
+    "nvfp4_w4a4",
     "mxfp8",
 ]
 QUANTIZATION_METHODS: list[str] = list(get_args(QuantizationMethods))

--- a/vllm/model_executor/layers/quantization/online/base.py
+++ b/vllm/model_executor/layers/quantization/online/base.py
@@ -42,6 +42,8 @@ from vllm.model_executor.layers.quantization.online.mxfp8 import (
 )
 from vllm.model_executor.layers.quantization.online.nvfp4 import (
     Nvfp4OnlineMoEMethod,
+    Nvfp4W4A4OnlineLinearMethod,
+    Nvfp4W4A16OnlineLinearMethod,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
@@ -50,6 +52,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
     kInt8StaticChannelSym,
     kMxfp8Dynamic,
+    kNvfp4Dynamic,
     kNvfp4Static,
 )
 
@@ -64,6 +67,10 @@ _ONLINE_LINEAR_METHODS: dict[QuantKey, type] = {
     kFp8Static128BlockSym: Fp8PerBlockOnlineLinearMethod,
     kFp8StaticChannelSym: Fp8PtpcOnlineLinearMethod,
     kMxfp8Dynamic: Mxfp8OnlineLinearMethod,
+    # NVFP4 weight-only (activations stay bf16/fp16) -> Marlin, any SM>=75.
+    kNvfp4Static: Nvfp4W4A16OnlineLinearMethod,
+    # NVFP4 W4A4 (dynamic activation quant) -> CUTLASS, Blackwell SM>=100.
+    kNvfp4Dynamic: Nvfp4W4A4OnlineLinearMethod,
 }
 
 _ONLINE_MOE_METHODS: dict[QuantKey, type] = {

--- a/vllm/model_executor/layers/quantization/online/nvfp4.py
+++ b/vllm/model_executor/layers/quantization/online/nvfp4.py
@@ -2,9 +2,16 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import torch
-from torch.nn import Module
+from torch.nn import Module, Parameter
 
 from vllm._custom_ops import scaled_fp4_quant
+from vllm.logger import init_logger
+from vllm.model_executor.kernels.linear import (
+    MarlinNvFp4LinearKernel,
+    NvFp4LinearLayerConfig,
+    init_nvfp4_linear_kernel,
+)
+from vllm.model_executor.kernels.linear.nvfp4 import NvFp4LinearKernel
 from vllm.model_executor.layers.fused_moe import RoutedExperts
 from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
 from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
@@ -13,11 +20,15 @@ from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
     make_nvfp4_moe_quant_config,
     select_nvfp4_moe_backend,
 )
+from vllm.model_executor.layers.quantization.online.fp8 import (
+    _Fp8OnlineLinearBase,
+)
 from vllm.model_executor.layers.quantization.online.moe_base import (
     OnlineMoEMethodBase,
 )
 from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import (
     FLOAT4_E2M1_MAX,
+    ref_nvfp4_quant,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kNvfp4Dynamic,
@@ -26,7 +37,95 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
 
+logger = init_logger(__name__)
+
 FLOAT8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
+
+# NVFP4 global scale maps a tensor's amax into the representable range of the
+# FP8-E4M3 block scale times the FP4 element max (448 * 6 = 2688). Kernels store
+# the global scale in *divisor* form (amax / 2688); ``scaled_fp4_quant`` takes
+# its reciprocal (the *multiplier*).
+_NVFP4_GLOBAL_SCALE_DENOM = FLOAT4_E2M1_MAX * FLOAT8_E4M3_MAX
+_NVFP4_GROUP_SIZE = 16
+
+# E2M1 magnitudes, indexed by the 3-bit FP4 magnitude field. The sign bit is
+# 0x08. Used to pack ref_nvfp4_quant's dequantized-float output back into the
+# 4-bit codes when the native packing kernel is unavailable for this arch.
+_E2M1_MAGNITUDES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+
+
+def _nvfp4_global_scale(amax: torch.Tensor) -> torch.Tensor:
+    """Per-tensor global scale in divisor form (amax / 2688)."""
+    return (amax.to(torch.float32) / _NVFP4_GLOBAL_SCALE_DENOM).clamp_min(
+        torch.finfo(torch.float32).tiny
+    )
+
+
+def _pack_nvfp4_reference(
+    weight: torch.Tensor, global_scale_mult: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Arch-independent NVFP4 packer built on ``ref_nvfp4_quant``.
+
+    ``ref_nvfp4_quant`` (Triton on CUDA) is the ground-truth quantizer: it
+    returns the per-element FP4 value as a float plus the positive FP8-E4M3
+    per-group block scale. We map the float FP4 values back to their 4-bit
+    codes (sign bit 0x08 + 3-bit E2M1 magnitude index) and pack two per byte,
+    low nibble first, matching the layout the Marlin FP4 kernel and
+    ``dequantize_to_dtype(swizzle=False)`` expect.
+    """
+    n, k = weight.shape
+    fp4_f, block_scale = ref_nvfp4_quant(
+        weight.float(), global_scale_mult, _NVFP4_GROUP_SIZE
+    )
+    absv = fp4_f.abs()
+    idx = torch.zeros_like(absv, dtype=torch.long)
+    for i, mag in enumerate(_E2M1_MAGNITUDES):
+        idx = torch.where(absv == mag, torch.full_like(idx, i), idx)
+    sign = (fp4_f < 0).to(torch.long) * 0x08
+    nibbles = (sign | idx).to(torch.uint8).view(n, k // 2, 2)
+    packed_weight = (nibbles[..., 0] | (nibbles[..., 1] << 4)).to(torch.uint8)
+    return packed_weight, block_scale.to(torch.float8_e4m3fn)
+
+
+def _pack_nvfp4(
+    weight: torch.Tensor, global_scale_mult: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pack a BF16/FP16 weight to NVFP4 (uint8 + non-swizzled FP8 block scale).
+
+    Prefers the native ``scaled_fp4_quant`` CUDA op. Some builds compile that
+    quantization kernel only for Blackwell (it raises "No compiled nvfp4
+    quantization kernel for SM XX"), even though the FP4 *packing* is pure
+    arithmetic and the Marlin GEMM runs on SM>=75. In that case fall back to a
+    reference packer that runs on any CUDA arch.
+    """
+    try:
+        return scaled_fp4_quant(
+            weight.contiguous(),
+            global_scale_mult,
+            is_sf_swizzled_layout=False,
+        )
+    except RuntimeError as e:
+        if "quantization kernel" not in str(e):
+            raise
+        return _pack_nvfp4_reference(weight, global_scale_mult)
+
+
+def _quantize_weight_to_nvfp4(
+    weight: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Quantize a dense BF16/FP16 weight ``[N, K]`` to NVFP4 storage format.
+
+    Returns ``(packed_weight, block_scale, weight_global_scale)`` where
+    ``packed_weight`` is uint8 ``[N, K/2]`` (two FP4 values per byte),
+    ``block_scale`` is FP8-E4M3 ``[N, K/16]`` in the non-swizzled layout the
+    NVFP4 kernels' ``process_weights_after_loading`` expects, and
+    ``weight_global_scale`` is the fp32 per-tensor divisor scale.
+    """
+    weight_global_scale = _nvfp4_global_scale(weight.abs().max())
+    # scaled_fp4_quant takes the multiplier (reciprocal of the divisor scale).
+    global_scale_mult = (1.0 / weight_global_scale).to(torch.float32)
+    packed_weight, block_scale = _pack_nvfp4(weight, global_scale_mult)
+    return packed_weight, block_scale, weight_global_scale
 
 
 def _quantize_moe_weight_to_nvfp4(
@@ -168,4 +267,164 @@ class Nvfp4OnlineMoEMethod(OnlineMoEMethodBase):
             a2_scale=layer.w2_input_scale,
             swiglu_limit=getattr(layer, "swiglu_limit", None),
             layer=layer,
+        )
+
+
+class _Nvfp4OnlineLinearBase(_Fp8OnlineLinearBase):
+    """Shared setup for online NVFP4 dense linear methods.
+
+    Reuses the online meta-device weight loader from ``_Fp8OnlineLinearBase``
+    (bf16/fp16 weights are materialized just-in-time, then quantized in
+    ``process_weights_after_loading``). Subclasses pick the kernel (Marlin for
+    W4A16, CUTLASS for W4A4).
+    """
+
+    kernel: NvFp4LinearKernel
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        if input_size_per_partition % _NVFP4_GROUP_SIZE != 0:
+            raise ValueError(
+                f"NVFP4 requires input_size_per_partition "
+                f"({input_size_per_partition}) to be divisible by "
+                f"{_NVFP4_GROUP_SIZE}."
+            )
+        super().create_weights(
+            layer,
+            input_size_per_partition,
+            output_partition_sizes,
+            input_size,
+            output_size,
+            params_dtype,
+            **extra_weight_attrs,
+        )
+        layer.params_dtype = params_dtype
+
+    def _quantize_and_store_weight(self, layer: Module) -> None:
+        packed_weight, block_scale, weight_global_scale = _quantize_weight_to_nvfp4(
+            layer.weight
+        )
+        replace_parameter(layer, "weight", packed_weight)
+        replace_parameter(layer, "weight_scale", block_scale)
+        layer.weight_global_scale = Parameter(weight_global_scale, requires_grad=False)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return self.kernel.apply_weights(layer, x, bias)
+
+
+class Nvfp4W4A16OnlineLinearMethod(_Nvfp4OnlineLinearBase):
+    """Online weight-only NVFP4 (W4A16) dense linear.
+
+    Weights are quantized to FP4 at load time; activations stay bf16/fp16 and
+    the Marlin FP4 kernel dequantizes on the fly. Runs on any SM>=75 GPU (the
+    non-Blackwell path).
+    """
+
+    def __init__(self):
+        super().__init__()
+        # Pin Marlin directly: init_nvfp4_linear_kernel() can pick a W4A4 kernel
+        # (e.g. under VLLM_BATCH_INVARIANT / --linear-backend) that expects a
+        # runtime activation scale this weight-only path never sets. Matches
+        # ModelOptNvFp4W4A16LinearMethod.
+        self.kernel = MarlinNvFp4LinearKernel(NvFp4LinearLayerConfig())
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        if getattr(layer, "_already_called_process_weights_after_loading", False):
+            return
+
+        self._quantize_and_store_weight(layer)
+        # Marlin repacks the weight/scales into its own layout.
+        self.kernel.process_weights_after_loading(layer)
+
+        layer._already_called_process_weights_after_loading = True
+
+
+class Nvfp4W4A4OnlineLinearMethod(_Nvfp4OnlineLinearBase):
+    """Online NVFP4 W4A4 dense linear with dynamic activation quant.
+
+    Weights are quantized to FP4 once at load time; activations are quantized to
+    FP4 per forward using a dynamically computed per-tensor global scale (no
+    calibration data). The CUTLASS FP4 GEMM runs only on Blackwell (SM>=100)
+    tensor cores.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.kernel = init_nvfp4_linear_kernel(use_a16=False)
+        # Fail closed: without a native FP4-activation kernel the selector falls
+        # back to Marlin (weight-only), which would silently serve W4A16 instead
+        # of the requested W4A4.
+        if isinstance(self.kernel, MarlinNvFp4LinearKernel):
+            raise ValueError(
+                "nvfp4_w4a4 (W4A4 with dynamic per-token FP4 activation "
+                "quantization) requires a native NVFP4 W4A4 GEMM kernel "
+                "(CUTLASS/FlashInfer on Blackwell SM>=100); none is available on "
+                "this platform. Use '--quantization nvfp4' for the weight-only "
+                "(W4A16) path, which runs on any SM>=75 via Marlin."
+            )
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        if getattr(layer, "_already_called_process_weights_after_loading", False):
+            return
+
+        self._quantize_and_store_weight(layer)
+
+        # Seed the activation global scale with a neutral value; it is refreshed
+        # per-forward in apply() since there is no calibration data.
+        wgs = layer.weight_global_scale
+        layer.input_global_scale = Parameter(wgs.clone(), requires_grad=False)
+        layer.input_global_scale_inv = Parameter(
+            (1.0 / wgs).to(torch.float32), requires_grad=False
+        )
+        layer.alpha = Parameter(layer.input_global_scale * wgs, requires_grad=False)
+
+        # CUTLASS swizzles the block scale and pads the weight.
+        self.kernel.process_weights_after_loading(layer)
+
+        layer._already_called_process_weights_after_loading = True
+
+    def _activation_scale_args(
+        self, layer: torch.nn.Module, x: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Dynamic per-row (per-token) activation scales as (inv, alpha).
+
+        Each token scales from its own amax, not a shared per-tensor amax:
+        under CUDA graphs the padded capture buffer's padding rows would inflate
+        a per-tensor amax and corrupt real rows' scales. Computed with plain
+        (non in-place) ops so the x -> amax -> scale dataflow is captured and
+        replays against the live activation.
+        """
+        x2d = x.reshape(-1, x.shape[-1])
+        amax_row = x2d.abs().amax(dim=-1)
+        input_global_scale = _nvfp4_global_scale(amax_row)
+        input_global_scale_inv = (1.0 / input_global_scale).to(torch.float32)
+        alpha = (input_global_scale * layer.weight_global_scale).to(torch.float32)
+        return input_global_scale_inv, alpha
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        input_global_scale_inv, alpha = self._activation_scale_args(layer, x)
+        return self.kernel.apply_weights(
+            layer,
+            x,
+            bias,
+            input_global_scale_inv=input_global_scale_inv,
+            alpha=alpha,
         )


### PR DESCRIPTION
# [Quant] Online NVFP4 dense-linear quantization (W4A16 + W4A4)

## Purpose

Extend vLLM's online quantization framework to quantize **dense linear** weights to NVFP4 at load time from a plain BF16/FP16 checkpoint — no pre-quantized checkpoint, no calibration. Two schemes:

- **`--quantization nvfp4`** — weight-only **W4A16**. Weights FP4, activations stay bf16/fp16, served by the FP4 **Marlin** kernel. Runs on **any SM≥75** (including Hopper), so it is the portable path.
- **`--quantization nvfp4_w4a4`** — **W4A4**. FP4 weights + dynamically FP4-quantized activations with a **per-token** activation scale (required for CUDA-graph correctness — see below), served by the native **CUTLASS/FlashInfer** FP4 GEMM on **Blackwell (SM≥100)**.

## Why this is not a duplicate

PR #48538 ("[Quant] Add `nvfp4_per_token` online MoE quantization") merged online NVFP4 for **MoE layers only, and Blackwell only**. This PR is the complementary, non-overlapping half:

| | #48538 (merged) | This PR |
|---|---|---|
| Layer type | MoE experts | **Dense linear** |
| Hardware | Blackwell SM≥100 only | **W4A16 on any SM≥75** + W4A4 on Blackwell |
| Shorthand | `nvfp4_per_token` | `nvfp4`, `nvfp4_w4a4` |

It composes with #48538 (adds linear entries to the same `online/nvfp4.py`, `_ONLINE_LINEAR_METHODS`, and CLI shorthand tables; MoE path untouched). No open PR adds dense-linear online NVFP4.

## Implementation notes

- Global scale is per-tensor `amax / (FP4_MAX·FP8_MAX) = amax/2688`; `scaled_fp4_quant` takes the reciprocal multiplier. Verified consistent with vLLM's reference `ref_nvfp4_quant`.
- **Arch-independent packer:** when the native `scaled_fp4_quant` CUDA kernel is not compiled for the running arch (e.g. Hopper), fall back to a packer built on `ref_nvfp4_quant` (Triton) so W4A16 works on non-Blackwell.
- **W4A16 pins the Marlin kernel directly** rather than routing through `init_nvfp4_linear_kernel()` — the generic selector can return a CUTLASS/emulation W4A4 kernel (under `VLLM_BATCH_INVARIANT` or explicit `--linear-backend`) that expects a runtime activation scale the weight-only path never sets, crashing on first forward. Matches `ModelOptNvFp4W4A16LinearMethod`.
- **W4A4 fails closed:** raises a clear error when no native FP4-activation kernel exists (non-Blackwell), instead of silently degrading to bf16 activations (i.e. W4A16), directing the user to `--quantization nvfp4`.

## Test commands and results

Unit (extends `tests/quantization/test_online.py`):
```
pytest tests/quantization/test_online.py::test_online_nvfp4_w4a16_linear
pytest tests/quantization/test_online.py::test_online_nvfp4_w4a4_cudagraph_dynamic_scale
```

E2E (`vllm serve` + OpenAI client), GPU-validated:
- **W4A16 on H200 (SM90, Marlin)** — `vllm serve --quantization nvfp4`, completions + chat + `/v1/models` all coherent; loads under `VLLM_BATCH_INVARIANT=1` (previously crashed, now fixed).
- **W4A4 on RTX PRO 6000 Blackwell (SM120, CUTLASS FP4)** — `vllm serve --quantization nvfp4_w4a4` with CUDA graphs on, coherent across prompt lengths. A/B under a padded concurrent batch of 8: per-token activation scale 8/8 coherent, per-tensor 8/8 garbage — confirming the per-token scale is required for CUDA-graph correctness.

## Latency + memory (before/after, `vllm serve`, single-request decode TPOT)

**Non-Blackwell — H200 (Hopper SM9.0), Qwen3-32B, TP2:**

| Scheme | TPOT | Weight/rank | KV cache | 
|---|---|---|---|
| bf16 | 29.2 ms | 30.6 GiB | 714k tok |
| nvfp4 W4A16 | 32.4 ms (+11%) | **10.8 GiB (2.8×↓)** | **876k tok (+23%)** |

On Hopper (no FP4 tensor cores) W4A16 is a **memory win with a small latency cost** — Marlin dequantizes FP4→bf16 then runs bf16 math. The 2.8× smaller weights + 23% more KV headroom are the value.

**Blackwell — RTX PRO 6000 (SM12.0), Qwen2.5-7B, TP1, CUDA graphs on:**

Batch=1 decode (before → after, weight/KV identical across FP4 schemes at
5.5 GiB / 1.27M tok):

| Scheme | batch=1 TPOT | Kernel |
|---|---|---|
| bf16 | 25.6 ms | — |
| nvfp4 W4A16 | **4.83 ms (5.3× faster)** | Marlin |
| nvfp4_w4a4 (W4A4) | 7.88 ms | CUTLASS FP4 |

### W4A16 vs W4A4 — when to use which

W4A16 and W4A4 are *not* an upgrade path; they trade off by workload. Measured decode throughput (tok/s) across concurrency:

| Concurrency | W4A16 | W4A4 | W4A4 vs W4A16 |
|---|---|---|---|
| batch 1 (TPOT) | **4.83 ms** | 7.88 ms | −63% |
| 32 | **5693** | 4019 | −29% |
| 64 | **8970** | 7849 | −12% |
| 128 | 12070 | **13756** | +14% |
| 256 | 14299 | **20971** | +47% |
| 512 | 16028 | **24119** | **+50%** |

Long-prefill TTFT (2098-tok prompt) and batched pure-prefill both favor W4A16 by ~5–10% (W4A4's FP4-tensor-core edge does not overcome its activation-quant overhead for prefill-shaped GEMMs).

**Guidance:**
- **W4A16 is the default** — faster for interactive / low-QPS serving (batch=1 and prefill), quality-neutral at scale, and portable (SM≥75). Same weight compression as W4A4.
- **W4A4 only for high-concurrency decode** (batch ≥ ~128, up to +50% throughput at batch 512), where many concurrent decode steps aggregate into compute-bound GEMMs that the native FP4 tensor cores accelerate — accepting the FP4-activation accuracy cost (see evals) and Blackwell-only support.

## Model evaluation results (gsm8k, exact-match, via `vllm serve` + client)

| Model | Scheme | Accuracy |
|---|---|---|
| **Qwen2.5-7B** (n=200) | **bf16** | **90.0%** |
| **Qwen2.5-7B** (n=200) | **nvfp4 W4A16** | **91.0%** (+1.0) |
| **Qwen2.5-7B** (n=200) | **nvfp4_w4a4 (W4A4)** | **89.5%** (−0.5) |
| Qwen3-32B (n=100) | bf16 | 69.0% |
| Qwen3-32B (n=100) | nvfp4 W4A16 | 70.0% |
| Qwen2.5-0.5B (n=200) | bf16 | 37.0% |
| Qwen2.5-0.5B (n=200) | nvfp4 W4A16 | 27.0% |
| Qwen2.5-0.5B (n=50) | nvfp4 W4A16 | 44.0% |
| Qwen2.5-0.5B (n=50) | nvfp4_w4a4 (W4A4) | 16.0% |

**Both schemes are quality-neutral at production scale.** At 7B all three cluster within ~1.5 pts (gsm8k sampling noise at n=200): W4A16 +1.0, **W4A4 −0.5** vs bf16. W4A16 is also neutral at 32B (70 vs 69). The dramatic 0.5B numbers (W4A16 −10pt; W4A4 16% vs 44%) are inherent 4-bit sensitivity on a tiny model, not a bug — the packing matches vLLM's reference quantizer exactly — and do **not** reproduce at 7B+. In particular W4A4's activation-quant hit shrinks from catastrophic at 0.5B to within-noise at 7B, so **W4A4 is safe at rollout scale (7B+)** — see the W4A16-vs-W4A4 guidance for when its high-concurrency throughput win justifies it.

## Limitations

- W4A4 requires Blackwell (SM≥100); refuses cleanly elsewhere. It only wins at high-concurrency decode (see table) and is slower for batch=1 / prefill.
- W4A16 on Hopper uses Marlin dequant (memory/capacity win, smaller latency gain there); the largest speedups need Blackwell.
- Linear only (MoE online NVFP4 is #48538's `nvfp4_per_token`).
- W4A4 uses a **per-token** activation scale (per-row amax), required for CUDA-graph correctness: a per-tensor scale reduces over the padded cudagraph buffer and the padding rows corrupt the real rows' scale. The per-row factor is applied as a post-GEMM row multiply because the dense FP4 GEMM epilogue takes only a scalar alpha; a fused per-row-alpha block-scaled epilogue (to drop that multiply) is future CUTLASS work.
- W4A16 weight-quant uses a per-tensor global scale; per-output-channel could further help small models (future work).

## AI assistance disclosure

AI assistance (Claude) was used in developing this change, including the implementation, the arch-fallback packer, GPU/E2E debugging, and the accuracy evals.


