### PR TITLE
[Bugfix][Quantization] Respect explicit WNA16 MoE backend

### DIFF
--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -934,6 +934,72 @@ def test_wna16_marlin_moe_w2_scale_sharding(actorder, group_size, part, full, ex
     assert result == expected
 
 
+@pytest.mark.parametrize(
+    ("moe_backend", "expected_method"),
+    [("auto", "marlin"), ("marlin", "marlin"), ("triton", "triton")],
+)
+def test_wna16_moe_respects_backend(monkeypatch, moe_backend, expected_method):
+    from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa: E501
+        compressed_tensors_moe,
+    )
+
+    weight_quant = QuantizationArgs(
+        num_bits=4,
+        type=QuantizationType.INT,
+        strategy=QuantizationStrategy.GROUP,
+        group_size=128,
+        symmetric=True,
+        dynamic=False,
+    )
+    quant_config = Mock()
+    quant_config.get_scheme_dict.return_value = {
+        "weights": weight_quant,
+        "input_activations": None,
+        "format": "pack-quantized",
+    }
+    quant_config._is_mxfp4.return_value = False
+    quant_config._is_mxfp8.return_value = False
+    quant_config._is_wNa16_group_channel.return_value = True
+    layer = Mock()
+
+    class DummyMarlinMethod:
+        def __init__(self, *_args):
+            self.name = "marlin"
+
+    class DummyTritonMethod:
+        def __init__(self, *_args):
+            self.name = "triton"
+
+    monkeypatch.setattr(
+        compressed_tensors_moe,
+        "get_current_vllm_config",
+        lambda: Mock(kernel_config=Mock(moe_backend=moe_backend), lora_config=None),
+    )
+    monkeypatch.setattr(
+        compressed_tensors_moe,
+        "check_moe_marlin_supports_layer",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.compressed_tensors."
+        "compressed_tensors_moe.compressed_tensors_moe_wna16_marlin."
+        "CompressedTensorsWNA16MarlinMoEMethod",
+        DummyMarlinMethod,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.compressed_tensors."
+        "compressed_tensors_moe.compressed_tensors_moe_wna16."
+        "CompressedTensorsWNA16MoEMethod",
+        DummyTritonMethod,
+    )
+
+    method = compressed_tensors_moe.CompressedTensorsMoEMethod.get_moe_method(
+        quant_config, layer, "model.layers.0.mlp.experts"
+    )
+
+    assert method.name == expected_method
+
+
 @pytest.mark.skipif(
     not current_platform.is_cuda() or not current_platform.has_device_capability(80),
     reason="MXFP4 requires ampere or newer",

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe.py
@@ -95,18 +95,21 @@ class CompressedTensorsMoEMethod(FusedMoEMethodBase):
                     f" and bits: {weight_quant.num_bits}",
                 )
 
-            # Prefer to use the MarlinMoE kernel when it is supported.
+            vllm_config = get_current_vllm_config()
+            moe_backend = vllm_config.kernel_config.moe_backend
             is_actorder = (
                 weight_quant.strategy == QuantizationStrategy.GROUP
                 and weight_quant.actorder
                 in (ActivationOrdering.GROUP, ActivationOrdering.DYNAMIC)
             )
-            if (
-                not check_moe_marlin_supports_layer(
+            use_marlin = (
+                moe_backend in ("auto", "marlin")
+                and check_moe_marlin_supports_layer(
                     layer, group_size, allow_tile_padding=not is_actorder
                 )
-                or current_platform.is_rocm()
-            ):
+                and not current_platform.is_rocm()
+            )
+            if not use_marlin:
                 if is_actorder:
                     raise ValueError(
                         "WNA16MoE is not supported with actorder=group/dynamic."
@@ -122,9 +125,7 @@ class CompressedTensorsMoEMethod(FusedMoEMethodBase):
                         )
                     from vllm.platforms.rocm import on_gfx950
 
-                    vllm_config = get_current_vllm_config()
                     is_lora_disabled = vllm_config.lora_config is None
-                    moe_backend = vllm_config.kernel_config.moe_backend
                     if (
                         weight_quant.strategy == QuantizationStrategy.GROUP
                         and weight_quant.type == QuantizationType.INT


### PR DESCRIPTION
## Summary

- honor an explicit `moe_backend=triton` for compressed-tensors WNA16 MoE
- keep `auto` and explicit `marlin` selecting Marlin when the layer is supported
- add focused coverage for all three selections

## Root cause

The WNA16 selector chose Marlin whenever the layer supported it, before consulting `kernel_config.moe_backend`. As a result, an explicit Triton request was silently overridden.

## Fix

Marlin is selected only when the requested backend is `auto` or `marlin`, the layer is supported, and the platform is not ROCm. Other paths continue through the existing WNA16 backend selection.

## Validation

- full pre-commit passed
- focused test added for `auto -> marlin`, `marlin -> marlin`, and `triton -> triton`
- the focused pytest command could not run on the host because its system Python does not have pytest installed

AI assistance was used. The submitter reviewed every changed line.
