### PR TITLE
[Bugfix] Fix swap_dict_values when a key holds an explicit None value

### DIFF
--- a/tests/utils_/test_collection_utils.py
+++ b/tests/utils_/test_collection_utils.py
@@ -45,3 +45,16 @@ def test_swap_dict_values(obj, key1, key2):
         assert obj[key1] == original_obj[key2]
     else:
         assert key1 not in obj
+@pytest.mark.parametrize(
+    ("obj", "key1", "key2", "expected"),
+    [
+        # A key holding an explicit None is still a present key and must
+        # be swapped, not cause the other key to be deleted.
+        ({"a": None, "b": "Y"}, "a", "b", {"a": "Y", "b": None}),
+        ({"a": "X", "b": None}, "a", "b", {"a": None, "b": "X"}),
+        ({"a": None, "b": None}, "a", "b", {"a": None, "b": None}),
+    ],
+)
+def test_swap_dict_values_preserves_none(obj, key1, key2, expected):
+    swap_dict_values(obj, key1, key2)
+    assert obj == expected

--- a/vllm/utils/collection_utils.py
+++ b/vllm/utils/collection_utils.py
@@ -122,13 +122,15 @@ def full_groupby(values: Iterable[_V], *, key: Callable[[_V], _K]):
 
 def swap_dict_values(obj: dict[_K, _V], key1: _K, key2: _K) -> None:
     """Swap values between two keys."""
-    v1 = obj.get(key1)
-    v2 = obj.get(key2)
-    if v1 is not None:
+    has1 = key1 in obj
+    has2 = key2 in obj
+    v1 = obj[key1] if has1 else None
+    v2 = obj[key2] if has2 else None
+    if has1:
         obj[key2] = v1
     else:
         obj.pop(key2, None)
-    if v2 is not None:
+    if has2:
         obj[key1] = v2
     else:
         obj.pop(key1, None)


### PR DESCRIPTION
## Motivation

`vllm.utils.collection_utils.swap_dict_values` is used by
`vllm/v1/worker/gpu_input_batch.py` and `tpu_input_batch.py` to swap
per-request fields (e.g. `generators`, `min_tokens`,
`bad_words_token_ids`) by request index. These fields can legitimately
be `None` for a given request.

The implementation used `obj.get(key)` together with an `is not None`
check:

```python
v1 = obj.get(key1)
...
if v1 is not None:
    obj[key2] = v1
else:
    obj.pop(key2, None)   # <-- deletes the OTHER key
```

This conflates "value is `None`" with "key is missing". When one of
the two keys holds an explicit `None` value, the function deletes the
*other* key's entry instead of swapping the `None` through:

```python
obj = {"a": None, "b": "Y"}
swap_dict_values(obj, "a", "b")
# before fix -> {"a": "Y"}      # "b" silently dropped
# after  fix -> {"a": "Y", "b": None}
```

For request-index swapping this is silent data corruption: a `None`
field on one request can wipe out the corresponding field on another.

## Change

Rewrite `swap_dict_values` to decide presence with `key in obj`
instead of `is not None`, then swap the actual values. This matches
the documented "swap values between two keys" contract and preserves
both keys when one value happens to be `None`. All previously tested
behaviours (both present / one absent / both absent) are unchanged.

## Test

Added `test_swap_dict_values_preserves_none` to
`tests/utils_/test_collection_utils.py` covering the three
None-valued permutations. Pure-logic, CPU-only, no GPU / weights.

```bash
pytest tests/utils_/test_collection_utils.py -v
```
