### PR TITLE
[Bugfix] Forward FlashInfer skip ops to sparse MLA warmup

### DIFF
--- a/tests/v1/worker/test_mixed_warmup_gate.py
+++ b/tests/v1/worker/test_mixed_warmup_gate.py
@@ -1,12 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Tests for the max_num_reqs gate on the V2 mixed prefill+decode warmup."""
+"""Tests for mixed prefill+decode warmup behavior."""
 
-from types import SimpleNamespace
+import contextlib
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
+import vllm.distributed.parallel_state as parallel_state
+from vllm.model_executor.warmup import (
+    flashinfer_sparse_mla_warmup as sparse_mla_warmup,
+)
 from vllm.v1.worker.gpu.warmup import run_mixed_prefill_decode_warmup
+
+pytestmark = pytest.mark.skip_global_cleanup
 
 
 def _fail(*args, **kwargs):
@@ -28,3 +37,73 @@ def test_mixed_warmup_skipped_for_single_seq(max_num_reqs):
         )
         is False
     )
+
+
+def test_sparse_mla_autotune_forwards_skip_ops(monkeypatch, tmp_path):
+    captured = []
+
+    @contextlib.contextmanager
+    def fake_autotune(tune_mode, **kwargs):
+        captured.append((tune_mode, kwargs))
+        yield
+
+    class Backend:
+        @staticmethod
+        def get_name():
+            return "FLASHINFER_MLA_SPARSE_DSV4"
+
+    class AutotunerModule(ModuleType):
+        AutoTuner = object
+
+    runner = SimpleNamespace(
+        attn_groups=[[SimpleNamespace(backend=Backend())]],
+        vllm_config=SimpleNamespace(use_v2_model_runner=False),
+        _dummy_run=Mock(),
+    )
+    worker = SimpleNamespace(
+        model_runner=runner,
+        vllm_config=SimpleNamespace(
+            kernel_config=SimpleNamespace(enable_flashinfer_autotune=True)
+        ),
+    )
+    world = SimpleNamespace(
+        rank_in_group=0,
+        broadcast_object=lambda value, src: value,
+        barrier=lambda: None,
+    )
+    autotuner_module = AutotunerModule("flashinfer.autotuner")
+
+    monkeypatch.setitem(sys.modules, "flashinfer.autotuner", autotuner_module)
+    monkeypatch.setattr(sparse_mla_warmup, "has_flashinfer", lambda: True)
+    monkeypatch.setattr(
+        sparse_mla_warmup,
+        "current_platform",
+        SimpleNamespace(is_device_capability_family=lambda capability: True),
+    )
+    monkeypatch.setattr(sparse_mla_warmup, "flashinfer_autotune", fake_autotune)
+    monkeypatch.setattr(
+        sparse_mla_warmup,
+        "resolve_flashinfer_autotune_file",
+        lambda runner: tmp_path / "cache",
+    )
+    monkeypatch.setattr(parallel_state, "get_world_group", lambda: world)
+
+    skip_ops = {
+        "trtllm::fused_moe::gemm1",
+        "trtllm::fused_moe::gemm2",
+    }
+    assert sparse_mla_warmup._run_flashinfer_sparse_mla_decode_autotune(
+        worker,
+        16,
+        sparse_mla_warmup._DEEPSEEK_V4_FLASHINFER_MLA_SPARSE_BACKENDS,
+        skip_ops,
+    )
+    assert captured == [
+        (
+            True,
+            {
+                "cache": str(tmp_path / "cache"),
+                "skip_ops": skip_ops,
+            },
+        )
+    ]

--- a/vllm/model_executor/warmup/flashinfer_sparse_mla_warmup.py
+++ b/vllm/model_executor/warmup/flashinfer_sparse_mla_warmup.py
@@ -86,6 +86,7 @@ def _run_flashinfer_sparse_mla_decode_autotune(
     worker: "Worker",
     num_tokens: int,
     allowed_backends: frozenset[str],
+    skip_ops: set[str] | None = None,
 ) -> bool:
     """Autotune FlashInfer's SM120 sparse-MLA decode path."""
     runner = worker.model_runner
@@ -111,6 +112,9 @@ def _run_flashinfer_sparse_mla_decode_autotune(
     world = get_world_group()
     is_leader = world.rank_in_group == 0
     cache_path = resolve_flashinfer_autotune_file(runner)
+    autotune_kwargs: dict[str, object] = {"cache": str(cache_path)}
+    if skip_ops:
+        autotune_kwargs["skip_ops"] = skip_ops
 
     dummy_run_kwargs = dict(
         num_tokens=num_tokens,
@@ -137,11 +141,11 @@ def _run_flashinfer_sparse_mla_decode_autotune(
                     worker.execute_model,
                     worker.sample_tokens,
                     num_tokens,
-                    mixed_step_context=flashinfer_autotune(True, cache=str(cache_path)),
+                    mixed_step_context=flashinfer_autotune(True, **autotune_kwargs),
                     req_id_prefix="_sparse_mla_v2_warmup",
                 )
             else:
-                with flashinfer_autotune(True, cache=str(cache_path)):
+                with flashinfer_autotune(True, **autotune_kwargs):
                     runner._dummy_run(**dummy_run_kwargs)
         else:
             if _uses_v2_model_runner(runner) and runner.max_num_reqs >= 2:
@@ -191,22 +195,30 @@ def _run_flashinfer_sparse_mla_decode_autotune(
 def _flashinfer_sparse_mla_decode_autotune(
     worker: "Worker",
     num_tokens: int,
+    skip_ops: set[str] | None = None,
 ) -> bool:
     return _run_flashinfer_sparse_mla_decode_autotune(
-        worker, num_tokens, _FLASHINFER_MLA_SPARSE_BACKENDS
+        worker, num_tokens, _FLASHINFER_MLA_SPARSE_BACKENDS, skip_ops
     )
 
 
 def _deepseek_v4_sparse_mla_decode_autotune(
     worker: "Worker",
     num_tokens: int,
+    skip_ops: set[str] | None = None,
 ) -> bool:
     return _run_flashinfer_sparse_mla_decode_autotune(
-        worker, num_tokens, _DEEPSEEK_V4_FLASHINFER_MLA_SPARSE_BACKENDS
+        worker,
+        num_tokens,
+        _DEEPSEEK_V4_FLASHINFER_MLA_SPARSE_BACKENDS,
+        skip_ops,
     )
 
 
-def flashinfer_sparse_mla_decode_autotune_warmup(worker: "Worker") -> None:
+def flashinfer_sparse_mla_decode_autotune_warmup(
+    worker: "Worker",
+    skip_ops: set[str] | None = None,
+) -> None:
     """Autotune generic FlashInfer sparse MLA decode when selected."""
     runner = worker.model_runner
     if runner.is_pooling_model:
@@ -216,10 +228,13 @@ def flashinfer_sparse_mla_decode_autotune_warmup(worker: "Worker") -> None:
     mixed_tokens = _clamp_warmup_tokens(_SPARSE_MLA_MIXED_WARMUP_TOKENS, max_tokens)
     if mixed_tokens <= 0:
         return
-    _flashinfer_sparse_mla_decode_autotune(worker, mixed_tokens)
+    _flashinfer_sparse_mla_decode_autotune(worker, mixed_tokens, skip_ops)
 
 
-def deepseek_v4_sparse_mla_attention_warmup(worker: "Worker") -> None:
+def deepseek_v4_sparse_mla_attention_warmup(
+    worker: "Worker",
+    skip_ops: set[str] | None = None,
+) -> None:
     """Warm DSv4 sparse-MLA mixed prefill+decode attention."""
     runner = worker.model_runner
     if runner.is_pooling_model or not _has_deepseek_v4_sparse_mla_backend(runner):
@@ -234,7 +249,9 @@ def deepseek_v4_sparse_mla_attention_warmup(worker: "Worker") -> None:
         "Warming up DeepSeek V4 sparse MLA attention for mixed tokens=%s.",
         mixed_tokens,
     )
-    mixed_warmup_done = _deepseek_v4_sparse_mla_decode_autotune(worker, mixed_tokens)
+    mixed_warmup_done = _deepseek_v4_sparse_mla_decode_autotune(
+        worker, mixed_tokens, skip_ops
+    )
     if not mixed_warmup_done:
         if _uses_v2_model_runner(runner) and runner.max_num_reqs >= 2:
             v2_runner = cast("V2GPUModelRunner", runner)

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -97,8 +97,16 @@ def kernel_warmup(worker: "Worker"):
     )
 
     # Run next so input-prep kernels JIT against pristine runner state.
-    flashinfer_sparse_mla_decode_autotune_warmup(worker)
-    deepseek_v4_sparse_mla_attention_warmup(worker)
+    enable_flashinfer_autotune = (
+        worker.vllm_config.kernel_config.enable_flashinfer_autotune
+    )
+    flashinfer_skip_ops = (
+        _flashinfer_autotune_skip_ops(worker.model_runner)
+        if enable_flashinfer_autotune is True
+        else None
+    )
+    flashinfer_sparse_mla_decode_autotune_warmup(worker, flashinfer_skip_ops)
+    deepseek_v4_sparse_mla_attention_warmup(worker, flashinfer_skip_ops)
 
     # Deep GEMM warmup
     do_deep_gemm_warmup = (
@@ -113,9 +121,6 @@ def kernel_warmup(worker: "Worker"):
 
     minimax_m3_msa_warmup(worker)
 
-    enable_flashinfer_autotune = (
-        worker.vllm_config.kernel_config.enable_flashinfer_autotune
-    )
     # FlashInfer autotune for Hopper (SM 9.0) and Blackwell (SM 10.0) GPUs
     if enable_flashinfer_autotune is False:
         logger.info("Skipping FlashInfer autotune because it is disabled.")


### PR DESCRIPTION
## Purpose

Sparse-MLA mixed-token warmup opens two leader-rank FlashInfer autotune contexts without the exclusions computed by `_flashinfer_autotune_skip_ops()`.

Pass the existing result into both contexts. This applies the same configured and automatic exclusions used by the general FlashInfer warmup. No exclusion names or defaults are added.

This is the vLLM-side control used for flashinfer-ai/flashinfer#4049; it does not fix the FlashInfer failure.

## Duplicate check

Open-PR searches for `VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS` and sparse-MLA `skip_ops` forwarding returned only this PR.

## Tests

- `uv run --active --no-sync python -m pytest tests/v1/worker/test_mixed_warmup_gate.py -v`: 3 passed.
- `uv run --active --no-sync pre-commit run --files vllm/model_executor/warmup/kernel_warmup.py vllm/model_executor/warmup/flashinfer_sparse_mla_warmup.py tests/v1/worker/test_mixed_warmup_gate.py`: passed.
- Integration validation on the `c233d90`-based SM120 build, TP=2: the configured fused-MoE operations were excluded, sparse-MLA tuning persisted 24 configurations, startup and CUDA-graph capture completed, and the server became Ready with zero restarts.

## Model evaluation

Not run. The change affects startup autotune exclusions and does not modify model inputs or outputs.

Created with AI assistance.
