### PR TITLE
[Bugfix] Fix swap_dict_values when a key holds an explicit None value

### DIFF
--- a/tests/utils_/test_collection_utils.py
+++ b/tests/utils_/test_collection_utils.py
@@ -45,6 +45,8 @@ def test_swap_dict_values(obj, key1, key2):
         assert obj[key1] == original_obj[key2]
     else:
         assert key1 not in obj
+
+
 @pytest.mark.parametrize(
     ("obj", "key1", "key2", "expected"),
     [

--- a/tests/utils_/test_collection_utils.py
+++ b/tests/utils_/test_collection_utils.py
@@ -45,3 +45,14 @@ def test_swap_dict_values(obj, key1, key2):
         assert obj[key1] == original_obj[key2]
     else:
         assert key1 not in obj
+@pytest.mark.parametrize(
+    ("obj", "key1", "key2", "expected"),
+    [
+        ({"a": None, "b": "Y"}, "a", "b", {"a": "Y", "b": None}),
+        ({"a": "X", "b": None}, "a", "b", {"a": None, "b": "X"}),
+        ({"a": None, "b": None}, "a", "b", {"a": None, "b": None}),
+    ],
+)
+def test_swap_dict_values_preserves_none(obj, key1, key2, expected):
+    swap_dict_values(obj, key1, key2)
+    assert obj == expected

--- a/vllm/utils/collection_utils.py
+++ b/vllm/utils/collection_utils.py
@@ -124,13 +124,11 @@ def swap_dict_values(obj: dict[_K, _V], key1: _K, key2: _K) -> None:
     """Swap values between two keys."""
     has1 = key1 in obj
     has2 = key2 in obj
-    v1 = obj[key1] if has1 else None
-    v2 = obj[key2] if has2 else None
-    if has1:
-        obj[key2] = v1
-    else:
-        obj.pop(key2, None)
-    if has2:
-        obj[key1] = v2
-    else:
-        obj.pop(key1, None)
+    if has1 and has2:
+        obj[key1], obj[key2] = obj[key2], obj[key1]
+    elif has1:
+        obj[key2] = obj[key1]
+        obj.pop(key1)
+    elif has2:
+        obj[key1] = obj[key2]
+        obj.pop(key2)

--- a/vllm/utils/collection_utils.py
+++ b/vllm/utils/collection_utils.py
@@ -122,13 +122,15 @@ def full_groupby(values: Iterable[_V], *, key: Callable[[_V], _K]):
 
 def swap_dict_values(obj: dict[_K, _V], key1: _K, key2: _K) -> None:
     """Swap values between two keys."""
-    v1 = obj.get(key1)
-    v2 = obj.get(key2)
-    if v1 is not None:
+    has1 = key1 in obj
+    has2 = key2 in obj
+    v1 = obj[key1] if has1 else None
+    v2 = obj[key2] if has2 else None
+    if has1:
         obj[key2] = v1
     else:
         obj.pop(key2, None)
-    if v2 is not None:
+    if has2:
         obj[key1] = v2
     else:
         obj.pop(key1, None)


### PR DESCRIPTION
## Motivation

`vllm.utils.collection_utils.swap_dict_values` is used by
`vllm/v1/worker/gpu_input_batch.py` and `tpu_input_batch.py` to swap
per-request fields (e.g. `generators`, `min_tokens`,
`bad_words_token_ids`) by request index. These fields can legitimately
be `None` for a given request.

The implementation used `obj.get(key)` together with an `is not None`
check, which conflates "value is `None`" with "key is missing", so
swapping a None-valued key silently deletes the *other* key:

```python
{"a": None, "b": "Y"} -> {"a": "Y"}   # "b" dropped (before fix)
{"a": None, "b": "Y"} -> {"a": "Y", "b": None}  # after fix
```

## Change

Decide presence with `key in obj` and swap the actual values,
matching the documented "swap values between two keys" contract. All
previously tested behaviours (both present / one absent / both absent)
are unchanged.

## Test

Added `test_swap_dict_values_preserves_none` to
`tests/utils_/test_collection_utils.py` (pure-logic, CPU-only).

Signed-off-by: xiaoyaoqilan <155608604+xiaoyaoqilan@users.noreply.github.com>
