### PR TITLE
fix(security): validate allowed_token_ids against model output vocab size

### DIFF
--- a/rust/src/text/src/lower.rs
+++ b/rust/src/text/src/lower.rs
@@ -991,7 +991,7 @@ mod tests {
     fn lower_sampling_params_rejects_out_of_vocab_allowed_token_ids() {
         let error = lower_sampling_params_with_limits(
             SamplingParams {
-                allowed_token_ids: Some(vec![1999, 2000]),
+                allowed_token_ids: Some(vec![999, 1000]),
                 ..Default::default()
             },
             sample_sampling_limits(),
@@ -1003,8 +1003,8 @@ mod tests {
             Error::TokenIds(TokenIdsError::OutOfVocab {
                 parameter: "allowed_token_ids",
                 token_ids,
-                vocab_size: 2000,
-            }) if token_ids == vec![2000]
+                vocab_size: 1000,
+            }) if token_ids == vec![1000]
         ));
     }
 

--- a/rust/src/text/src/lower/token_ids.rs
+++ b/rust/src/text/src/lower/token_ids.rs
@@ -75,7 +75,7 @@ pub(crate) fn validate_vocab_range(
         validate_param(
             "allowed_token_ids",
             token_ids.iter().copied(),
-            limits.tokenizer_vocab_size,
+            limits.model_vocab_size,
         )?;
     }
 
@@ -122,5 +122,49 @@ mod tests {
                 vocab_size: 1000,
             } if token_ids == vec![1000, 1001]
         ));
+    }
+
+    #[test]
+    fn allowed_token_ids_validated_against_model_vocab_size() {
+        // Simulates a multimodal model where tokenizer has 128257 tokens
+        // but model output vocab is only 128256.
+        let limits = SamplingLimits {
+            max_model_len: 2048,
+            max_logprobs: 20,
+            model_vocab_size: 128256,
+            tokenizer_vocab_size: 128257,
+        };
+
+        let mut params = EngineCoreSamplingParams::default();
+        // ID 128256 is valid in the tokenizer but invalid for model output.
+        params.allowed_token_ids = Some(vec![128256]);
+
+        let result = validate_vocab_range(&params, &limits);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(
+            err,
+            TokenIdsError::OutOfVocab {
+                parameter: "allowed_token_ids",
+                token_ids,
+                vocab_size: 128256,
+            } if token_ids == vec![128256]
+        ));
+    }
+
+    #[test]
+    fn allowed_token_ids_accepts_last_valid_model_id() {
+        let limits = SamplingLimits {
+            max_model_len: 2048,
+            max_logprobs: 20,
+            model_vocab_size: 128256,
+            tokenizer_vocab_size: 128257,
+        };
+
+        let mut params = EngineCoreSamplingParams::default();
+        params.allowed_token_ids = Some(vec![128255]);
+
+        let result = validate_vocab_range(&params, &limits);
+        assert!(result.is_ok());
     }
 }

--- a/tests/test_sampling_params.py
+++ b/tests/test_sampling_params.py
@@ -48,3 +48,52 @@ def test_diffusion_accepts_top_k_top_p():
 def test_non_diffusion_models_unaffected():
     params = SamplingParams(temperature=0.7, top_k=10, seed=42)
     params.verify(MockModelConfig(), None, None, None)
+
+
+class TestAllowedTokenIdsVocabValidation:
+    """Regression tests for GHSA-wr27-mx79-rg6c: allowed_token_ids must be
+    validated against model output vocab size, not tokenizer length."""
+
+    def test_accept_last_valid_id(self):
+        config = MockModelConfig()
+        vocab_size = config.get_vocab_size()
+        params = SamplingParams(allowed_token_ids=[vocab_size - 1])
+        params.verify(config, None, None, None)
+
+    def test_reject_id_equal_to_vocab_size(self):
+        config = MockModelConfig()
+        vocab_size = config.get_vocab_size()
+        params = SamplingParams(allowed_token_ids=[vocab_size])
+        with pytest.raises(ValueError, match="out-of-vocab"):
+            params.verify(config, None, None, None)
+
+    def test_reject_id_exceeding_vocab_size(self):
+        config = MockModelConfig()
+        vocab_size = config.get_vocab_size()
+        params = SamplingParams(allowed_token_ids=[vocab_size + 100])
+        with pytest.raises(ValueError, match="out-of-vocab"):
+            params.verify(config, None, None, None)
+
+    def test_reject_negative_id(self):
+        config = MockModelConfig()
+        params = SamplingParams(allowed_token_ids=[-1])
+        with pytest.raises(ValueError, match="out-of-vocab"):
+            params.verify(config, None, None, None)
+
+    def test_reject_mixed_valid_and_invalid(self):
+        config = MockModelConfig()
+        vocab_size = config.get_vocab_size()
+        params = SamplingParams(allowed_token_ids=[0, vocab_size])
+        with pytest.raises(ValueError, match="out-of-vocab"):
+            params.verify(config, None, None, None)
+
+    def test_reject_empty_list(self):
+        config = MockModelConfig()
+        params = SamplingParams(allowed_token_ids=[])
+        with pytest.raises(ValueError, match="empty"):
+            params.verify(config, None, None, None)
+
+    def test_accept_valid_ids(self):
+        config = MockModelConfig()
+        params = SamplingParams(allowed_token_ids=[0, 1, 512, 1023])
+        params.verify(config, None, None, None)

--- a/tests/v1/sample/test_logit_bias_oob.py
+++ b/tests/v1/sample/test_logit_bias_oob.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression test for GHSA-wr27-mx79-rg6c: out-of-range allowed_token_ids
+must not corrupt adjacent logits rows via the Triton _bias_kernel."""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+VOCAB_SIZE = 128
+NUM_ROWS = 2
+MAX_ALLOWED = 4
+
+
+@pytest.mark.skipif(
+    not current_platform.has_device_capability(80),
+    reason="Triton kernel requires compute capability >= 8.0",
+)
+def test_oob_allowed_token_id_no_cross_row_corruption():
+    """An out-of-range allowed_token_id (== vocab_size) must not alter the
+    adjacent row's logits. The kernel's id_mask should prevent any
+    load/store at the invalid index."""
+    from vllm.v1.worker.gpu.sample.logit_bias import apply_logit_bias
+
+    device = torch.device(f"{current_platform.device_type}:0")
+
+    logits = torch.randn(NUM_ROWS, VOCAB_SIZE, dtype=torch.float32, device=device)
+    row1_original = logits[1].clone()
+
+    expanded_idx_mapping = torch.arange(NUM_ROWS, dtype=torch.int32, device=device)
+    pos = torch.zeros(NUM_ROWS, dtype=torch.int32, device=device)
+
+    num_allowed = torch.zeros(NUM_ROWS, dtype=torch.int32, device=device)
+    num_allowed[0] = 1
+
+    allowed_ids = torch.zeros(NUM_ROWS, MAX_ALLOWED, dtype=torch.int32, device=device)
+    # Row 0: one-past-end ID (== vocab_size), which would index into row 1
+    allowed_ids[0, 0] = VOCAB_SIZE
+
+    num_logit_bias = torch.zeros(NUM_ROWS, dtype=torch.int32, device=device)
+    logit_bias_token_ids = torch.zeros(
+        NUM_ROWS, MAX_ALLOWED, dtype=torch.int32, device=device
+    )
+    logit_bias_values = torch.zeros(
+        NUM_ROWS, MAX_ALLOWED, dtype=torch.float32, device=device
+    )
+
+    min_lens = torch.zeros(NUM_ROWS, dtype=torch.int32, device=device)
+    num_stop = torch.zeros(NUM_ROWS, dtype=torch.int32, device=device)
+    stop_ids = torch.zeros(NUM_ROWS, MAX_ALLOWED, dtype=torch.int32, device=device)
+
+    apply_logit_bias(
+        logits,
+        expanded_idx_mapping,
+        pos,
+        num_allowed,
+        allowed_ids,
+        num_logit_bias,
+        logit_bias_token_ids,
+        logit_bias_values,
+        min_lens,
+        num_stop,
+        stop_ids,
+    )
+
+    # Row 0 should be all -inf (no valid allowed IDs after bounds check)
+    assert torch.all(logits[0] == float("-inf")), (
+        "Row 0 should be all -inf since the only allowed ID is out of range"
+    )
+
+    # Row 1 must be completely untouched
+    assert torch.equal(logits[1], row1_original), (
+        "Row 1 was corrupted by row 0's out-of-range allowed_token_id"
+    )
+
+
+@pytest.mark.skipif(
+    not current_platform.has_device_capability(80),
+    reason="Triton kernel requires compute capability >= 8.0",
+)
+def test_valid_allowed_token_ids_still_work():
+    """Sanity check: valid allowed_token_ids correctly restrict output."""
+    from vllm.v1.worker.gpu.sample.logit_bias import apply_logit_bias
+
+    device = torch.device(f"{current_platform.device_type}:0")
+
+    logits = torch.randn(NUM_ROWS, VOCAB_SIZE, dtype=torch.float32, device=device)
+    original_val_row0_token5 = logits[0, 5].item()
+
+    expanded_idx_mapping = torch.arange(NUM_ROWS, dtype=torch.int32, device=device)
+    pos = torch.zeros(NUM_ROWS, dtype=torch.int32, device=device)
+
+    num_allowed = torch.zeros(NUM_ROWS, dtype=torch.int32, device=device)
+    num_allowed[0] = 1
+
+    allowed_ids = torch.zeros(NUM_ROWS, MAX_ALLOWED, dtype=torch.int32, device=device)
+    allowed_ids[0, 0] = 5  # Valid token ID
+
+    num_logit_bias = torch.zeros(NUM_ROWS, dtype=torch.int32, device=device)
+    logit_bias_token_ids = torch.zeros(
+        NUM_ROWS, MAX_ALLOWED, dtype=torch.int32, device=device
+    )
+    logit_bias_values = torch.zeros(
+        NUM_ROWS, MAX_ALLOWED, dtype=torch.float32, device=device
+    )
+
+    min_lens = torch.zeros(NUM_ROWS, dtype=torch.int32, device=device)
+    num_stop = torch.zeros(NUM_ROWS, dtype=torch.int32, device=device)
+    stop_ids = torch.zeros(NUM_ROWS, MAX_ALLOWED, dtype=torch.int32, device=device)
+
+    apply_logit_bias(
+        logits,
+        expanded_idx_mapping,
+        pos,
+        num_allowed,
+        allowed_ids,
+        num_logit_bias,
+        logit_bias_token_ids,
+        logit_bias_values,
+        min_lens,
+        num_stop,
+        stop_ids,
+    )
+
+    # Token 5 should be preserved, all others should be -inf
+    assert logits[0, 5].item() == pytest.approx(original_val_row0_token5), (
+        "Valid allowed token's logit was not preserved"
+    )
+    for i in range(VOCAB_SIZE):
+        if i != 5:
+            assert logits[0, i].item() == float("-inf"), (
+                f"Token {i} should be -inf but got {logits[0, i].item()}"
+            )

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -745,7 +745,7 @@ class SamplingParams(
         self._validate_logprobs(model_config)
         self._validate_logit_bias(model_config)
         self._validate_logits_processors(model_config)
-        self._validate_allowed_token_ids(tokenizer)
+        self._validate_allowed_token_ids(model_config)
         self._validate_spec_decode(speculative_config)
         self._validate_diffusion(model_config)
         self._validate_structured_outputs(
@@ -841,7 +841,7 @@ class SamplingParams(
 
         validate_logits_processors_parameters(model_config.logits_processors, self)
 
-    def _validate_allowed_token_ids(self, tokenizer: TokenizerLike | None) -> None:
+    def _validate_allowed_token_ids(self, model_config: ModelConfig) -> None:
         allowed_token_ids = self.allowed_token_ids
         if allowed_token_ids is None:
             return
@@ -853,19 +853,19 @@ class SamplingParams(
                 value=allowed_token_ids,
             )
 
-        if tokenizer is not None:
-            vocab_size = len(tokenizer)
-            invalid_token_ids = [
-                token_id
-                for token_id in allowed_token_ids
-                if token_id < 0 or token_id >= vocab_size
-            ]
-            if invalid_token_ids:
-                raise VLLMValidationError(
-                    "allowed_token_ids contains out-of-vocab token id!",
-                    parameter="allowed_token_ids",
-                    value=invalid_token_ids,
-                )
+        vocab_size = model_config.get_vocab_size()
+        invalid_token_ids = [
+            token_id
+            for token_id in allowed_token_ids
+            if token_id < 0 or token_id >= vocab_size
+        ]
+        if invalid_token_ids:
+            raise VLLMValidationError(
+                f"allowed_token_ids contains out-of-vocab token id(s). "
+                f"Vocabulary size: {vocab_size}",
+                parameter="allowed_token_ids",
+                value=invalid_token_ids,
+            )
 
     def _validate_spec_decode(
         self,

--- a/vllm/v1/worker/gpu/sample/logit_bias.py
+++ b/vllm/v1/worker/gpu/sample/logit_bias.py
@@ -184,9 +184,13 @@ def _bias_kernel(
         allowed_token_ids = tl.load(
             allowed_token_ids_ptr + req_state_idx * allowed_token_ids_stride + block,
             mask=mask,
+            other=0,
         )
+        id_mask = mask & (allowed_token_ids >= 0) & (allowed_token_ids < vocab_size)
         logits = tl.load(
-            logits_ptr + token_idx * logits_stride + allowed_token_ids, mask=mask
+            logits_ptr + token_idx * logits_stride + allowed_token_ids,
+            mask=id_mask,
+            other=-float("inf"),
         )
 
         tl.debug_barrier()  # save must read original logits before the -inf overwrite
@@ -206,7 +210,7 @@ def _bias_kernel(
         tl.store(
             logits_ptr + token_idx * logits_stride + allowed_token_ids,
             logits,
-            mask=mask,
+            mask=id_mask,
         )
 
     # Logit bias.


### PR DESCRIPTION
Validate allowed_token_ids against model_config.get_vocab_size() instead of len(tokenizer) to prevent tokenizer-valid but output-vocab-invalid IDs from reaching the GPU logit-bias kernel.

For multimodal models (e.g., Ultravox), the tokenizer may contain input-only placeholder tokens whose IDs exceed the model's output vocabulary width. Using these IDs as logits column indices causes out-of-bounds access in the Triton _bias_kernel, enabling cross-request logits corruption and token allowlist bypass (GHSA-wr27-mx79-rg6c).

Changes:
- SamplingParams._validate_allowed_token_ids now uses model_config
- _bias_kernel adds per-ID bounds mask (defense-in-depth)
- Rust frontend validates against model_vocab_size
- Regression tests for validation and kernel bounds

