### PR TITLE
fix(security): add token-domain bounds check to penalty bincount kernel

### DIFF
--- a/tests/v1/sample/test_penalty_bincount_oob.py
+++ b/tests/v1/sample/test_penalty_bincount_oob.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for OOB prompt-presence bitset write in penalty bincount.
+
+An out-of-range token ID (>= vocab_size) in processed prompts must not
+corrupt the adjacent request's penalty state row."""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.utils.math_utils import cdiv
+
+VOCAB_SIZE = 128
+NUM_ROWS = 2
+MAX_MODEL_LEN = 64
+
+
+@pytest.mark.skipif(
+    not current_platform.has_device_capability(80),
+    reason="Triton kernel requires compute capability >= 8.0",
+)
+def test_oob_prompt_token_no_cross_row_bitset_corruption():
+    """Token ID == vocab_size must not write to the adjacent request's
+    prompt_bin_mask row."""
+    from vllm.v1.worker.gpu.sample.penalties import bincount
+
+    device = torch.device(f"{current_platform.device_type}:0")
+
+    num_words = cdiv(VOCAB_SIZE, 32)
+    prompt_bin_mask = torch.zeros(NUM_ROWS, num_words, dtype=torch.int32, device=device)
+    output_bin_counts = torch.zeros(
+        NUM_ROWS, VOCAB_SIZE, dtype=torch.int32, device=device
+    )
+
+    all_token_ids = torch.zeros(
+        NUM_ROWS, MAX_MODEL_LEN, dtype=torch.int32, device=device
+    )
+    # Row 0: prompt with valid token (5) and OOB token (== vocab_size)
+    all_token_ids[0, 0] = 5
+    all_token_ids[0, 1] = VOCAB_SIZE  # OOB: one-past-end
+
+    prompt_len = torch.zeros(NUM_ROWS, dtype=torch.int32, device=device)
+    prompt_len[0] = 2  # 2 prompt tokens for row 0
+
+    prefill_len = torch.zeros(NUM_ROWS, dtype=torch.int32, device=device)
+    prefill_len[0] = 2  # same as prompt_len (no output tokens in prefill)
+
+    expanded_idx_mapping = torch.tensor([0], dtype=torch.int32, device=device)
+
+    bincount(
+        expanded_idx_mapping,
+        all_token_ids,
+        prompt_len,
+        prefill_len,
+        prompt_bin_mask,
+        output_bin_counts,
+        max_prefill_len=2,
+    )
+
+    # Row 0: valid token 5 should be set (word 0, bit 5)
+    assert (prompt_bin_mask[0, 0].item() & (1 << 5)) != 0, (
+        "Valid token 5 was not recorded in row 0's prompt_bin_mask"
+    )
+
+    # Row 1: must be completely untouched
+    assert torch.all(prompt_bin_mask[1] == 0), (
+        "Row 1's prompt_bin_mask was corrupted by row 0's OOB token"
+    )
+    assert torch.all(output_bin_counts[1] == 0), (
+        "Row 1's output_bin_counts was corrupted"
+    )
+
+
+@pytest.mark.skipif(
+    not current_platform.has_device_capability(80),
+    reason="Triton kernel requires compute capability >= 8.0",
+)
+def test_oob_output_token_no_cross_row_counts_corruption():
+    """Token ID == vocab_size in the output portion must not write to
+    the adjacent request's output_bin_counts row."""
+    from vllm.v1.worker.gpu.sample.penalties import bincount
+
+    device = torch.device(f"{current_platform.device_type}:0")
+
+    num_words = cdiv(VOCAB_SIZE, 32)
+    prompt_bin_mask = torch.zeros(NUM_ROWS, num_words, dtype=torch.int32, device=device)
+    output_bin_counts = torch.zeros(
+        NUM_ROWS, VOCAB_SIZE, dtype=torch.int32, device=device
+    )
+
+    all_token_ids = torch.zeros(
+        NUM_ROWS, MAX_MODEL_LEN, dtype=torch.int32, device=device
+    )
+    # Row 0: 1 prompt token (valid), then 1 output token (OOB)
+    all_token_ids[0, 0] = 10  # prompt token (valid)
+    all_token_ids[0, 1] = VOCAB_SIZE  # output token (OOB)
+
+    prompt_len = torch.zeros(NUM_ROWS, dtype=torch.int32, device=device)
+    prompt_len[0] = 1
+
+    prefill_len = torch.zeros(NUM_ROWS, dtype=torch.int32, device=device)
+    prefill_len[0] = 2  # includes 1 output token
+
+    expanded_idx_mapping = torch.tensor([0], dtype=torch.int32, device=device)
+
+    bincount(
+        expanded_idx_mapping,
+        all_token_ids,
+        prompt_len,
+        prefill_len,
+        prompt_bin_mask,
+        output_bin_counts,
+        max_prefill_len=2,
+    )
+
+    # Row 0: prompt token 10 should be set
+    assert (prompt_bin_mask[0, 0].item() & (1 << 10)) != 0, (
+        "Valid prompt token 10 was not recorded"
+    )
+
+    # Row 0: OOB output token should NOT be counted
+    # (If it were written at index vocab_size, it would be in row 1's space)
+    assert output_bin_counts[0].sum().item() == 0, (
+        "OOB output token should not be counted in row 0"
+    )
+
+    # Row 1: must be completely untouched
+    assert torch.all(output_bin_counts[1] == 0), (
+        "Row 1's output_bin_counts was corrupted by row 0's OOB output token"
+    )
+    assert torch.all(prompt_bin_mask[1] == 0), "Row 1's prompt_bin_mask was corrupted"
+
+
+@pytest.mark.skipif(
+    not current_platform.has_device_capability(80),
+    reason="Triton kernel requires compute capability >= 8.0",
+)
+def test_boundary_valid_token_correctly_recorded():
+    """Token ID == vocab_size - 1 (the last valid token) should be
+    correctly recorded without any issues."""
+    from vllm.v1.worker.gpu.sample.penalties import bincount
+
+    device = torch.device(f"{current_platform.device_type}:0")
+
+    num_words = cdiv(VOCAB_SIZE, 32)
+    prompt_bin_mask = torch.zeros(NUM_ROWS, num_words, dtype=torch.int32, device=device)
+    output_bin_counts = torch.zeros(
+        NUM_ROWS, VOCAB_SIZE, dtype=torch.int32, device=device
+    )
+
+    all_token_ids = torch.zeros(
+        NUM_ROWS, MAX_MODEL_LEN, dtype=torch.int32, device=device
+    )
+    # Row 0: prompt with the last valid token
+    last_valid = VOCAB_SIZE - 1  # 127
+    all_token_ids[0, 0] = last_valid
+
+    prompt_len = torch.zeros(NUM_ROWS, dtype=torch.int32, device=device)
+    prompt_len[0] = 1
+
+    prefill_len = torch.zeros(NUM_ROWS, dtype=torch.int32, device=device)
+    prefill_len[0] = 1
+
+    expanded_idx_mapping = torch.tensor([0], dtype=torch.int32, device=device)
+
+    bincount(
+        expanded_idx_mapping,
+        all_token_ids,
+        prompt_len,
+        prefill_len,
+        prompt_bin_mask,
+        output_bin_counts,
+        max_prefill_len=1,
+    )
+
+    # Last valid token should be set: word = 127//32 = 3, bit = 127%32 = 31
+    expected_word = last_valid // 32
+    expected_bit = last_valid % 32
+    assert (prompt_bin_mask[0, expected_word].item() & (1 << expected_bit)) != 0, (
+        f"Last valid token {last_valid} was not recorded in prompt_bin_mask"
+    )
+
+    # Row 1: must be untouched
+    assert torch.all(prompt_bin_mask[1] == 0), (
+        "Row 1 was modified when only row 0 was processed"
+    )

--- a/vllm/v1/worker/gpu/input_batch.py
+++ b/vllm/v1/worker/gpu/input_batch.py
@@ -493,7 +493,11 @@ def _post_update_kernel(
             token_id,
         )
 
-        if output_bin_counts_ptr is not None:
+        if (
+            output_bin_counts_ptr is not None
+            and token_id >= 0
+            and token_id < output_bin_counts_stride
+        ):
             token_ptr = (
                 output_bin_counts_ptr
                 + req_state_idx * output_bin_counts_stride

--- a/vllm/v1/worker/gpu/sample/penalties.py
+++ b/vllm/v1/worker/gpu/sample/penalties.py
@@ -226,6 +226,7 @@ def _bincount_kernel(
     prompt_bin_mask_stride,
     output_bin_counts_ptr,
     output_bin_counts_stride,
+    vocab_size,
     BLOCK_SIZE: tl.constexpr,
 ):
     token_idx = tl.program_id(0)
@@ -243,13 +244,14 @@ def _bincount_kernel(
         prompt_tokens = tl.load(
             all_token_ids_ptr + req_state_idx * all_token_ids_stride + block, mask=mask
         )
+        valid_mask = mask & (prompt_tokens >= 0) & (prompt_tokens < vocab_size)
         idx = prompt_tokens // 32
         bit_idx = prompt_tokens % 32
         bit = tl.full((BLOCK_SIZE,), 1, tl.int32) << bit_idx
         tl.atomic_or(
             prompt_bin_mask_ptr + req_state_idx * prompt_bin_mask_stride + idx,
             bit,
-            mask=mask,
+            mask=valid_mask,
         )
 
     if (block_idx + 1) * BLOCK_SIZE >= prompt_len:
@@ -258,12 +260,13 @@ def _bincount_kernel(
         output_tokens = tl.load(
             all_token_ids_ptr + req_state_idx * all_token_ids_stride + block, mask=mask
         )
+        valid_mask = mask & (output_tokens >= 0) & (output_tokens < vocab_size)
         tl.atomic_add(
             output_bin_counts_ptr
             + req_state_idx * output_bin_counts_stride
             + output_tokens,
             1,
-            mask=mask,
+            mask=valid_mask,
         )
 
 
@@ -281,6 +284,7 @@ def bincount(
     prompt_bin_mask.index_fill_(0, idx_long, 0)
     output_bin_counts.index_fill_(0, idx_long, 0)
     num_tokens = expanded_idx_mapping.shape[0]
+    vocab_size = output_bin_counts.shape[1]
     BLOCK_SIZE = 1024
     num_blocks = triton.cdiv(max_prefill_len, BLOCK_SIZE)
     _bincount_kernel[(num_tokens, num_blocks)](
@@ -293,6 +297,7 @@ def bincount(
         prompt_bin_mask.stride(0),
         output_bin_counts,
         output_bin_counts.stride(0),
+        vocab_size,
         BLOCK_SIZE=BLOCK_SIZE,
     )
 


### PR DESCRIPTION
Add vocab_size validation to _bincount_kernel so that only tokens satisfying 0 <= token_id < vocab_size are written to the prompt-presence bitset and output-count arrays.
For multimodal models (e.g., Ultravox), processed prompts contain input-only tokens (ID 128256) that exceed the generation vocabulary size (128256). Without bounds checking, the packed bitset atomic_or writes one word past the request's row, corrupting the adjacent request's prompt-presence state and causing incorrect repetition penalty application.