### PR TITLE
fix(v1): skip full GC during EngineCore process exit

### DIFF
--- a/tests/v1/engine/test_process_exit_cleanup.py
+++ b/tests/v1/engine/test_process_exit_cleanup.py
@@ -334,6 +334,9 @@ def test_v1_model_runner_shutdown_forwards_gc_lifecycle(monkeypatch, collect_gc:
     monkeypatch.setattr(
         model_runner_v1_module.current_platform, "is_rocm", lambda: False
     )
+    monkeypatch.setattr(
+        model_runner_v1_module.current_platform, "is_xpu", lambda: False
+    )
     runner, layer = _v1_model_runner()
 
     runner.shutdown(collect_gc=collect_gc)
@@ -386,7 +389,9 @@ def test_distributed_cleanup_gc_lifecycle(monkeypatch, collect_gc: bool):
     mock_platform.is_cpu.return_value = False
     monkeypatch.setattr(platforms, "current_platform", mock_platform)
     monkeypatch.setattr(parallel_state.torch.accelerator, "empty_cache", empty_cache)
-    monkeypatch.setattr(parallel_state.torch._C, "_host_emptyCache", host_empty_cache)
+    monkeypatch.setattr(
+        parallel_state.torch._C, "_host_emptyCache", host_empty_cache, raising=False
+    )
 
     parallel_state.cleanup_dist_env_and_memory(collect_gc=collect_gc)
 

--- a/tests/v1/engine/test_process_exit_cleanup.py
+++ b/tests/v1/engine/test_process_exit_cleanup.py
@@ -1,0 +1,399 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock, call
+
+import pytest
+
+import vllm.distributed.parallel_state as parallel_state
+import vllm.platforms as platforms
+import vllm.v1.engine.core as core_module
+import vllm.v1.worker.gpu.model_runner as model_runner_v2_module
+import vllm.v1.worker.gpu_model_runner as model_runner_v1_module
+import vllm.v1.worker.gpu_worker as gpu_worker_module
+import vllm.v1.worker.xpu_worker as xpu_worker_module
+from vllm.v1.engine.core import EngineCore
+from vllm.v1.executor.abstract import Executor
+from vllm.v1.executor.uniproc_executor import UniProcExecutor
+from vllm.v1.worker.gpu_worker import Worker
+from vllm.v1.worker.worker_base import WorkerBase, WorkerWrapperBase
+
+
+def _engine_core(executor: Mock, scheduler: Mock) -> EngineCore:
+    engine_core = EngineCore.__new__(EngineCore)
+    engine_core.structured_output_manager = Mock()
+    engine_core.model_executor = executor
+    engine_core.scheduler = scheduler
+    return engine_core
+
+
+def _v1_model_runner() -> tuple[object, SimpleNamespace]:
+    runner = object.__new__(model_runner_v1_module.GPUModelRunner)
+    layer = SimpleNamespace(
+        kv_cache=["cache"],
+        impl=SimpleNamespace(_k_scale_cache=object(), _v_scale_cache=object()),
+    )
+    runner.kv_caches = ["cache"]
+    runner.cross_layers_kv_cache = "cache"
+    runner.cross_layers_attn_backend = "backend"
+    runner.attn_groups = [Mock()]
+    runner.kv_cache_config = Mock()
+    runner.cache_config = SimpleNamespace(num_gpu_blocks=1)
+    runner.compilation_config = SimpleNamespace(static_forward_context={"layer": layer})
+    runner.model = Mock()
+    return runner, layer
+
+
+@pytest.mark.parametrize("process_exiting", [False, True])
+def test_engine_core_shutdown_gc_lifecycle(monkeypatch, process_exiting: bool):
+    executor = Mock()
+    scheduler = Mock()
+    cleanup = Mock()
+    unfreeze = Mock()
+    monkeypatch.setattr(core_module, "cleanup_dist_env_and_memory", cleanup)
+    monkeypatch.setattr(core_module.gc, "unfreeze", unfreeze)
+
+    _engine_core(executor, scheduler).shutdown(process_exiting=process_exiting)
+
+    if process_exiting:
+        executor.shutdown_for_process_exit.assert_called_once_with()
+        executor.shutdown.assert_not_called()
+        unfreeze.assert_not_called()
+    else:
+        executor.shutdown.assert_called_once_with()
+        executor.shutdown_for_process_exit.assert_not_called()
+        unfreeze.assert_called_once_with()
+    scheduler.shutdown.assert_called_once_with()
+    cleanup.assert_called_once_with(collect_gc=not process_exiting)
+
+
+def test_engine_core_process_entry_marks_process_exiting(monkeypatch):
+    shutdown = Mock()
+    run_engine_core = core_module.EngineCoreProc.run_engine_core
+    busy_loop_outcomes = [None, SystemExit, RuntimeError("engine failed")]
+
+    class FakeEngineCoreProc:
+        def __init__(self, *args, **kwargs):
+            self.input_queue = Mock()
+            self.shutdown_state = None
+            self._send_engine_dead = Mock()
+
+        def run_busy_loop(self):
+            outcome = busy_loop_outcomes.pop(0)
+            if outcome is not None:
+                raise outcome
+
+        def shutdown(self, **kwargs):
+            shutdown(**kwargs)
+
+    class FakeSignalCallback:
+        def __init__(self, callback):
+            self.callback = callback
+
+        def stop(self):
+            pass
+
+    parallel_config = SimpleNamespace(
+        data_parallel_size=1,
+        data_parallel_rank_local=0,
+        data_parallel_index=0,
+        numa_bind=False,
+        model_config=SimpleNamespace(is_moe=False),
+    )
+    vllm_config = SimpleNamespace(
+        parallel_config=parallel_config,
+        model_config=SimpleNamespace(is_moe=False),
+        kv_transfer_config=None,
+    )
+    monkeypatch.setattr(core_module, "EngineCoreProc", FakeEngineCoreProc)
+    monkeypatch.setattr(core_module, "SignalCallback", FakeSignalCallback)
+    monkeypatch.setattr(core_module, "maybe_register_config_serialize_by_value", Mock())
+    monkeypatch.setattr(core_module, "set_process_title", Mock())
+    monkeypatch.setattr(core_module, "maybe_init_worker_tracer", Mock())
+    monkeypatch.setattr(core_module, "decorate_logs", Mock())
+    monkeypatch.setattr(core_module.signal, "signal", Mock())
+
+    run_engine_core(vllm_config=vllm_config, executor_class=Mock)
+    with pytest.raises(SystemExit):
+        run_engine_core(vllm_config=vllm_config, executor_class=Mock)
+    with pytest.raises(RuntimeError, match="engine failed"):
+        run_engine_core(vllm_config=vllm_config, executor_class=Mock)
+
+    assert shutdown.call_args_list == [
+        call(process_exiting=True),
+        call(process_exiting=True),
+        call(process_exiting=True),
+    ]
+
+
+def test_dp_engine_core_shutdown_forwards_process_exiting(monkeypatch):
+    parent_shutdown = Mock()
+    destroy_process_group = Mock()
+
+    def fake_parent_shutdown(self, *, process_exiting: bool = False) -> None:
+        parent_shutdown(self, process_exiting=process_exiting)
+
+    monkeypatch.setattr(core_module.EngineCoreProc, "shutdown", fake_parent_shutdown)
+    monkeypatch.setattr(
+        core_module,
+        "stateless_destroy_torch_distributed_process_group",
+        destroy_process_group,
+    )
+    regular_engine_core = object.__new__(core_module.DPEngineCoreProc)
+    terminal_engine_core = object.__new__(core_module.DPEngineCoreProc)
+    dp_group = object()
+    terminal_engine_core.dp_group = dp_group
+
+    regular_engine_core.shutdown()
+    terminal_engine_core.shutdown(process_exiting=True)
+
+    assert parent_shutdown.call_args_list == [
+        call(regular_engine_core, process_exiting=False),
+        call(terminal_engine_core, process_exiting=True),
+    ]
+    destroy_process_group.assert_called_once_with(dp_group)
+
+
+def test_executor_process_exit_shutdown_falls_back_to_shutdown():
+    shutdown = Mock()
+    Executor.shutdown_for_process_exit(SimpleNamespace(shutdown=shutdown))
+    shutdown.assert_called_once_with()
+
+
+def test_uniproc_executor_process_exit_shutdown_uses_worker_helper():
+    worker = Mock()
+    UniProcExecutor.shutdown_for_process_exit(SimpleNamespace(driver_worker=worker))
+    worker.shutdown_for_process_exit.assert_called_once_with()
+    worker.shutdown.assert_not_called()
+
+
+def test_worker_process_exit_shutdown_falls_back_for_non_gpu_runner():
+    shutdown = Mock()
+    worker = SimpleNamespace(model_runner=object(), shutdown=shutdown)
+
+    Worker.shutdown_for_process_exit(worker)
+
+    shutdown.assert_called_once_with()
+
+
+def test_worker_base_process_exit_shutdown_falls_back_to_shutdown():
+    shutdown = Mock()
+
+    WorkerBase.shutdown_for_process_exit(SimpleNamespace(shutdown=shutdown))
+
+    shutdown.assert_called_once_with()
+
+
+def test_worker_wrapper_process_exit_shutdown_forwards_to_worker():
+    worker = Mock()
+
+    WorkerWrapperBase.shutdown_for_process_exit(SimpleNamespace(worker=worker))
+
+    worker.shutdown_for_process_exit.assert_called_once_with()
+    worker.shutdown.assert_not_called()
+
+
+def test_xpu_worker_process_exit_shutdown_uses_full_fallback():
+    shutdown = Mock()
+
+    xpu_worker_module.XPUWorker.shutdown_for_process_exit(
+        SimpleNamespace(shutdown=shutdown)
+    )
+
+    shutdown.assert_called_once_with()
+
+
+@pytest.mark.parametrize("collect_gc", [True, False])
+def test_gpu_worker_shutdown_gc_lifecycle(monkeypatch, collect_gc: bool):
+    unfreeze = Mock()
+    monkeypatch.setattr("vllm.v1.worker.gpu_worker.gc.unfreeze", unfreeze)
+    connector = Mock()
+    ec_connector = Mock()
+    profiler = Mock()
+    transfer = Mock()
+    model_runner = Mock()
+    cumem_allocator = Mock()
+    worker = object.__new__(Worker)
+    worker.profiler = profiler
+    worker.weight_transfer_engine = transfer
+    worker.model_runner = model_runner
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu_worker.ensure_kv_transfer_shutdown", connector
+    )
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu_worker.ensure_ec_transfer_shutdown", ec_connector
+    )
+    monkeypatch.setattr(
+        gpu_worker_module.current_platform, "is_cuda_alike", lambda: True
+    )
+    monkeypatch.setattr(
+        "vllm.device_allocator.cumem.CuMemAllocator.instance", cumem_allocator
+    )
+
+    if collect_gc:
+        Worker.shutdown(worker)
+    else:
+        Worker.shutdown_for_process_exit(worker)
+
+    assert unfreeze.call_count == int(collect_gc)
+    connector.assert_called_once_with()
+    ec_connector.assert_called_once_with()
+    profiler.shutdown.assert_called_once_with()
+    transfer.shutdown.assert_called_once_with()
+    if collect_gc:
+        model_runner.shutdown.assert_called_once_with()
+    else:
+        model_runner.shutdown.assert_called_once_with(collect_gc=False)
+    cumem_allocator.release_pools.assert_called_once_with()
+
+
+@pytest.mark.parametrize("collect_gc", [True, False])
+def test_v2_model_runner_shutdown_gc_lifecycle(monkeypatch, collect_gc: bool):
+    collect = Mock()
+    empty_cache = Mock()
+    synchronize = Mock()
+    monkeypatch.setattr(model_runner_v2_module.gc, "collect", collect)
+    monkeypatch.setattr(
+        model_runner_v2_module.torch.accelerator, "empty_cache", empty_cache
+    )
+    monkeypatch.setattr(
+        model_runner_v2_module.torch.accelerator, "synchronize", synchronize
+    )
+    monkeypatch.setattr(model_runner_v2_module, "free_before_shutdown", Mock())
+    runner = SimpleNamespace(
+        kv_caches=[],
+        attn_groups=[],
+        kv_cache_config=Mock(),
+        vllm_config=Mock(),
+        model=Mock(),
+    )
+
+    model_runner_v2_module.GPUModelRunner.shutdown(runner, collect_gc=collect_gc)
+
+    assert collect.call_count == int(collect_gc)
+    assert not hasattr(runner, "model")
+    assert not hasattr(runner, "kv_cache_config")
+    empty_cache.assert_called_once_with()
+
+
+def test_v2_model_runner_process_exit_shutdown_forwards_collect_gc():
+    shutdown = Mock()
+
+    model_runner_v2_module.GPUModelRunner.shutdown_for_process_exit(
+        SimpleNamespace(shutdown=shutdown)
+    )
+
+    shutdown.assert_called_once_with(collect_gc=False)
+
+
+def test_v1_model_runner_profiling_cleanup_still_collects(monkeypatch):
+    collect = Mock()
+    empty_cache = Mock()
+    synchronize = Mock()
+    monkeypatch.setattr(model_runner_v1_module.gc, "collect", collect)
+    monkeypatch.setattr(
+        model_runner_v1_module.torch.accelerator, "empty_cache", empty_cache
+    )
+    monkeypatch.setattr(
+        model_runner_v1_module.torch.accelerator, "synchronize", synchronize
+    )
+    runner, layer = _v1_model_runner()
+
+    runner._cleanup_profiling_kv_cache()
+
+    collect.assert_called_once_with()
+    assert runner.cache_config.num_gpu_blocks is None
+    assert runner.kv_caches == []
+    assert runner.cross_layers_kv_cache is None
+    assert runner.cross_layers_attn_backend is None
+    assert runner.attn_groups == []
+    assert not hasattr(runner, "kv_cache_config")
+    assert layer.kv_cache == []
+    assert layer.impl._k_scale_cache is None
+    assert layer.impl._v_scale_cache is None
+    empty_cache.assert_called_once_with()
+
+
+@pytest.mark.parametrize("collect_gc", [True, False])
+def test_v1_model_runner_shutdown_forwards_gc_lifecycle(monkeypatch, collect_gc: bool):
+    collect = Mock()
+    empty_cache = Mock()
+    synchronize = Mock()
+    reset_workspace_manager = Mock()
+    monkeypatch.setattr(model_runner_v1_module.gc, "collect", collect)
+    monkeypatch.setattr(
+        model_runner_v1_module.torch.accelerator, "empty_cache", empty_cache
+    )
+    monkeypatch.setattr(
+        model_runner_v1_module.torch.accelerator, "synchronize", synchronize
+    )
+    monkeypatch.setattr(
+        "vllm.v1.worker.workspace.reset_workspace_manager", reset_workspace_manager
+    )
+    monkeypatch.setattr(
+        model_runner_v1_module.current_platform, "is_rocm", lambda: False
+    )
+    runner, layer = _v1_model_runner()
+
+    runner.shutdown(collect_gc=collect_gc)
+
+    assert collect.call_count == int(collect_gc)
+    assert runner.kv_caches == []
+    assert runner.cross_layers_kv_cache is None
+    assert runner.cross_layers_attn_backend is None
+    assert runner.attn_groups == []
+    assert not hasattr(runner, "kv_cache_config")
+    assert layer.kv_cache == []
+    assert runner.compilation_config.static_forward_context == {}
+    assert runner.model is None
+    empty_cache.assert_called_once_with()
+    reset_workspace_manager.assert_called_once_with()
+
+
+def test_v1_model_runner_process_exit_shutdown_forwards_collect_gc():
+    shutdown = Mock()
+
+    model_runner_v1_module.GPUModelRunner.shutdown_for_process_exit(
+        SimpleNamespace(shutdown=shutdown)
+    )
+
+    shutdown.assert_called_once_with(collect_gc=False)
+
+
+@pytest.mark.parametrize("collect_gc", [True, False])
+def test_distributed_cleanup_gc_lifecycle(monkeypatch, collect_gc: bool):
+    unfreeze = Mock()
+    collect = Mock()
+    destroy_model_parallel = Mock()
+    destroy_distributed_environment = Mock()
+    disable_envs_cache = Mock()
+    empty_cache = Mock()
+    host_empty_cache = Mock()
+    monkeypatch.setattr(parallel_state.gc, "unfreeze", unfreeze)
+    monkeypatch.setattr(parallel_state.gc, "collect", collect)
+    monkeypatch.setattr(parallel_state.envs, "disable_envs_cache", disable_envs_cache)
+    monkeypatch.setattr(
+        parallel_state, "destroy_model_parallel", destroy_model_parallel
+    )
+    monkeypatch.setattr(
+        parallel_state,
+        "destroy_distributed_environment",
+        destroy_distributed_environment,
+    )
+    mock_platform = Mock()
+    mock_platform.is_rocm.return_value = False
+    mock_platform.is_cpu.return_value = False
+    monkeypatch.setattr(platforms, "current_platform", mock_platform)
+    monkeypatch.setattr(parallel_state.torch.accelerator, "empty_cache", empty_cache)
+    monkeypatch.setattr(parallel_state.torch._C, "_host_emptyCache", host_empty_cache)
+
+    parallel_state.cleanup_dist_env_and_memory(collect_gc=collect_gc)
+
+    assert unfreeze.call_count == int(collect_gc)
+    assert collect.call_count == int(collect_gc)
+    disable_envs_cache.assert_called_once_with()
+    destroy_model_parallel.assert_called_once_with()
+    destroy_distributed_environment.assert_called_once_with()
+    empty_cache.assert_called_once_with()
+    host_empty_cache.assert_called_once_with()

--- a/tests/v1/engine/test_process_exit_cleanup.py
+++ b/tests/v1/engine/test_process_exit_cleanup.py
@@ -100,6 +100,7 @@ def test_engine_core_process_entry_marks_process_exiting(monkeypatch):
         data_parallel_index=0,
         numa_bind=False,
         model_config=SimpleNamespace(is_moe=False),
+        reconfigure_for_independent_dp_rank=Mock(),
     )
     vllm_config = SimpleNamespace(
         parallel_config=parallel_config,
@@ -217,6 +218,7 @@ def test_gpu_worker_shutdown_gc_lifecycle(monkeypatch, collect_gc: bool):
     worker = object.__new__(Worker)
     worker.profiler = profiler
     worker.weight_transfer_engine = transfer
+    worker.elastic_ep_executor = Mock()
     worker.model_runner = model_runner
     monkeypatch.setattr(
         "vllm.v1.worker.gpu_worker.ensure_kv_transfer_shutdown", connector
@@ -241,6 +243,7 @@ def test_gpu_worker_shutdown_gc_lifecycle(monkeypatch, collect_gc: bool):
     ec_connector.assert_called_once_with()
     profiler.shutdown.assert_called_once_with()
     transfer.shutdown.assert_called_once_with()
+    worker.elastic_ep_executor.shutdown.assert_called_once_with()
     if collect_gc:
         model_runner.shutdown.assert_called_once_with()
     else:
@@ -334,6 +337,9 @@ def test_v1_model_runner_shutdown_forwards_gc_lifecycle(monkeypatch, collect_gc:
     monkeypatch.setattr(
         model_runner_v1_module.current_platform, "is_rocm", lambda: False
     )
+    monkeypatch.setattr(
+        model_runner_v1_module.current_platform, "is_xpu", lambda: False
+    )
     runner, layer = _v1_model_runner()
 
     runner.shutdown(collect_gc=collect_gc)
@@ -386,7 +392,12 @@ def test_distributed_cleanup_gc_lifecycle(monkeypatch, collect_gc: bool):
     mock_platform.is_cpu.return_value = False
     monkeypatch.setattr(platforms, "current_platform", mock_platform)
     monkeypatch.setattr(parallel_state.torch.accelerator, "empty_cache", empty_cache)
-    monkeypatch.setattr(parallel_state.torch._C, "_host_emptyCache", host_empty_cache)
+    monkeypatch.setattr(
+        parallel_state.torch.accelerator,
+        "empty_host_cache",
+        host_empty_cache,
+        raising=False,
+    )
 
     parallel_state.cleanup_dist_env_and_memory(collect_gc=collect_gc)
 

--- a/tests/v1/engine/test_startup_watch_processes.py
+++ b/tests/v1/engine/test_startup_watch_processes.py
@@ -113,7 +113,7 @@ def test_freeze_gc_after_clean_rocm_engine_core_shutdown(
         raise SystemExit(exit_code)
 
     proc.run_busy_loop = run_busy_loop
-    proc.shutdown = lambda: calls.append("shutdown")
+    proc.shutdown = lambda *, process_exiting: calls.append("shutdown")
     parallel_config = SimpleNamespace(
         data_parallel_size=1,
         numa_bind=False,

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -2104,7 +2104,7 @@ def destroy_distributed_environment():
         torch.distributed.destroy_process_group()
 
 
-def cleanup_dist_env_and_memory(shutdown_ray: bool = False):
+def cleanup_dist_env_and_memory(shutdown_ray: bool = False, *, collect_gc: bool = True):
     logger.debug(
         "[shutdown] Distributed: cleanup start shutdown_ray=%s",
         shutdown_ray,
@@ -2122,8 +2122,9 @@ def cleanup_dist_env_and_memory(shutdown_ray: bool = False):
 
         rocm_aiter_ops.refresh_env_variables()
 
-    # Ensure all objects are not frozen before cleanup
-    gc.unfreeze()
+    if collect_gc:
+        # Ensure all objects are not frozen before cleanup.
+        gc.unfreeze()
 
     destroy_model_parallel()
     destroy_distributed_environment()
@@ -2131,7 +2132,8 @@ def cleanup_dist_env_and_memory(shutdown_ray: bool = False):
         import ray  # Lazy import Ray
 
         ray.shutdown()
-    gc.collect()
+    if collect_gc:
+        gc.collect()
     from vllm.platforms import current_platform
 
     if not current_platform.is_cpu():

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -2130,7 +2130,7 @@ def destroy_distributed_environment():
         torch.distributed.destroy_process_group()
 
 
-def cleanup_dist_env_and_memory(shutdown_ray: bool = False):
+def cleanup_dist_env_and_memory(shutdown_ray: bool = False, *, collect_gc: bool = True):
     logger.debug(
         "[shutdown] Distributed: cleanup start shutdown_ray=%s",
         shutdown_ray,
@@ -2148,8 +2148,9 @@ def cleanup_dist_env_and_memory(shutdown_ray: bool = False):
 
         rocm_aiter_ops.refresh_env_variables()
 
-    # Ensure all objects are not frozen before cleanup
-    gc.unfreeze()
+    if collect_gc:
+        # Ensure all objects are not frozen before cleanup.
+        gc.unfreeze()
 
     destroy_model_parallel()
     destroy_distributed_environment()
@@ -2157,7 +2158,8 @@ def cleanup_dist_env_and_memory(shutdown_ray: bool = False):
         import ray  # Lazy import Ray
 
         ray.shutdown()
-    gc.collect()
+    if collect_gc:
+        gc.collect()
     from vllm.platforms import current_platform
 
     if not current_platform.is_cpu():

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -740,22 +740,26 @@ class EngineCore:
             # More efficient to abort all as a single batch.
             self.abort_requests(request_ids)
 
-    def shutdown(self):
+    def shutdown(self, *, process_exiting: bool = False) -> None:
         logger.debug_once("[shutdown] EngineCore: tearing down local resources")
         self.structured_output_manager.clear_backend()
         if self.model_executor:
-            self.model_executor.shutdown()
+            if process_exiting:
+                self.model_executor.shutdown_for_process_exit()
+            else:
+                self.model_executor.shutdown()
         if self.scheduler:
             self.scheduler.shutdown()
 
-        # Undo the gc.freeze() from __init__ so that the objects allocated
-        # during engine startup (model weights, KV caches, etc.) become
-        # visible to the garbage collector again. Without this, deleting
-        # the engine in-process (e.g. unit tests) leaks GPU memory.
-        gc.unfreeze()
+        if not process_exiting:
+            # Undo the gc.freeze() from __init__ so that the objects allocated
+            # during engine startup (model weights, KV caches, etc.) become
+            # visible to the garbage collector again. Without this, deleting
+            # the engine in-process (e.g. unit tests) leaks GPU memory.
+            gc.unfreeze()
         # Tear down distributed state initialized in this EngineCore process
         # before it exits and release cached memory.
-        cleanup_dist_env_and_memory()
+        cleanup_dist_env_and_memory(collect_gc=not process_exiting)
         logger.debug_once("[shutdown] EngineCore: local resource teardown complete")
 
     def profile(self, is_start: bool = True, profile_prefix: str | None = None):
@@ -1338,7 +1342,7 @@ class EngineCoreProc(EngineCore):
             if signal_callback is not None:
                 signal_callback.stop()
             if engine_core is not None:
-                engine_core.shutdown()
+                engine_core.shutdown(process_exiting=True)
 
     def _init_data_parallel(self, vllm_config: VllmConfig):
         pass
@@ -1909,8 +1913,8 @@ class DPEngineCoreProc(EngineCoreProc):
         dp_group, dp_store = parallel_config.stateless_init_dp_group(return_store=True)
         self.dp_group, self.dp_store = dp_group, dp_store
 
-    def shutdown(self):
-        super().shutdown()
+    def shutdown(self, *, process_exiting: bool = False) -> None:
+        super().shutdown(process_exiting=process_exiting)
         if dp_group := getattr(self, "dp_group", None):
             stateless_destroy_torch_distributed_process_group(dp_group)
 
@@ -2350,6 +2354,8 @@ class EngineCoreActorMixin:
             logger.exception("EngineCore encountered a fatal error.")
             raise
         finally:
+            # Ray actors can remain alive after run() returns, so this is not
+            # a process-exit path. Keep the full in-process cleanup semantics.
             self.shutdown()  # type: ignore[attr-defined]
 
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -747,22 +747,26 @@ class EngineCore:
             # More efficient to abort all as a single batch.
             self.abort_requests(request_ids)
 
-    def shutdown(self):
+    def shutdown(self, *, process_exiting: bool = False) -> None:
         logger.debug_once("[shutdown] EngineCore: tearing down local resources")
         self.structured_output_manager.clear_backend()
         if self.model_executor:
-            self.model_executor.shutdown()
+            if process_exiting:
+                self.model_executor.shutdown_for_process_exit()
+            else:
+                self.model_executor.shutdown()
         if self.scheduler:
             self.scheduler.shutdown()
 
-        # Undo the gc.freeze() from __init__ so that the objects allocated
-        # during engine startup (model weights, KV caches, etc.) become
-        # visible to the garbage collector again. Without this, deleting
-        # the engine in-process (e.g. unit tests) leaks GPU memory.
-        gc.unfreeze()
+        if not process_exiting:
+            # Undo the gc.freeze() from __init__ so that the objects allocated
+            # during engine startup (model weights, KV caches, etc.) become
+            # visible to the garbage collector again. Without this, deleting
+            # the engine in-process (e.g. unit tests) leaks GPU memory.
+            gc.unfreeze()
         # Tear down distributed state initialized in this EngineCore process
         # before it exits and release cached memory.
-        cleanup_dist_env_and_memory()
+        cleanup_dist_env_and_memory(collect_gc=not process_exiting)
         logger.debug_once("[shutdown] EngineCore: local resource teardown complete")
 
     def profile(self, is_start: bool = True, profile_prefix: str | None = None):
@@ -1362,7 +1366,7 @@ class EngineCoreProc(EngineCore):
             if signal_callback is not None:
                 signal_callback.stop()
             if engine_core is not None:
-                engine_core.shutdown()
+                engine_core.shutdown(process_exiting=True)
             if clean_shutdown:
                 from vllm.platforms import current_platform
 
@@ -2050,8 +2054,8 @@ class DPEngineCoreProc(EngineCoreProc):
         dp_group, dp_store = parallel_config.stateless_init_dp_group(return_store=True)
         self.dp_group, self.dp_store = dp_group, dp_store
 
-    def shutdown(self):
-        super().shutdown()
+    def shutdown(self, *, process_exiting: bool = False) -> None:
+        super().shutdown(process_exiting=process_exiting)
         if dp_group := getattr(self, "dp_group", None):
             stateless_destroy_torch_distributed_process_group(dp_group)
 
@@ -2513,6 +2517,8 @@ class EngineCoreActorMixin:
             logger.exception("EngineCore encountered a fatal error.")
             raise
         finally:
+            # Ray actors can remain alive after run() returns, so this is not
+            # a process-exit path. Keep the full in-process cleanup semantics.
             self.shutdown()  # type: ignore[attr-defined]
 
 

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -277,6 +277,15 @@ class Executor(ABC):
         """Shutdown the executor."""
         self.collective_rpc("shutdown")
 
+    def shutdown_for_process_exit(self) -> None:
+        """Shutdown the executor when its hosting process will exit.
+
+        Executors whose workers run in another process keep the normal
+        shutdown behavior. Executors with an in-process worker may override
+        this to avoid cleanup work that only matters if Python stays alive.
+        """
+        self.shutdown()
+
     def init_kv_output_aggregator(self, connector: "KVConnectorBase") -> None:
         """Init KVOutputAggregator"""
         self.kv_output_aggregator = KVOutputAggregator.from_connector(

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -279,6 +279,15 @@ class Executor(ABC):
         """Shutdown the executor."""
         self.collective_rpc("shutdown")
 
+    def shutdown_for_process_exit(self) -> None:
+        """Shutdown the executor when its hosting process will exit.
+
+        Executors whose workers run in another process keep the normal
+        shutdown behavior. Executors with an in-process worker may override
+        this to avoid cleanup work that only matters if Python stays alive.
+        """
+        self.shutdown()
+
     def init_kv_output_aggregator(self, connector: "KVConnectorBase") -> None:
         """Init KVOutputAggregator"""
         self.kv_output_aggregator = KVOutputAggregator.from_connector(

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -142,6 +142,10 @@ class UniProcExecutor(Executor):
         if worker := self.driver_worker:
             worker.shutdown()
 
+    def shutdown_for_process_exit(self) -> None:
+        if worker := self.driver_worker:
+            worker.shutdown_for_process_exit()
+
     @classmethod
     def supports_async_scheduling(cls) -> bool:
         return True

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -153,6 +153,10 @@ class UniProcExecutor(Executor):
         if worker := self.driver_worker:
             worker.shutdown()
 
+    def shutdown_for_process_exit(self) -> None:
+        if worker := self.driver_worker:
+            worker.shutdown_for_process_exit()
+
     @classmethod
     def supports_async_scheduling(cls) -> bool:
         return True

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1586,7 +1586,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             input_batch.query_start_loc,
         )
 
-    def shutdown(self) -> None:
+    def shutdown(self, collect_gc: bool = True) -> None:
         """Release GPU tensors (model weights, KV caches, workspace) so that
         memory is reclaimable when running in the same process."""
         torch.accelerator.synchronize()
@@ -1604,9 +1604,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if hasattr(self, "model"):
             del self.model
 
-        gc.collect()
+        if collect_gc:
+            gc.collect()
         torch.accelerator.empty_cache()
         logger.debug("Cleaned up model weights, KV caches, and workspace")
+
+    def shutdown_for_process_exit(self) -> None:
+        self.shutdown(collect_gc=False)
 
     ########### EPLB methods start ###########
     @property

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1917,7 +1917,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             input_batch.query_start_loc,
         )
 
-    def shutdown(self) -> None:
+    def shutdown(self, collect_gc: bool = True) -> None:
         """Release GPU tensors (model weights, KV caches, workspace) so that
         memory is reclaimable when running in the same process."""
         torch.accelerator.synchronize()
@@ -1938,9 +1938,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if hasattr(self, "model"):
             del self.model
 
-        gc.collect()
+        if collect_gc:
+            gc.collect()
         torch.accelerator.empty_cache()
         logger.debug("Cleaned up model weights, KV caches, and workspace")
+
+    def shutdown_for_process_exit(self) -> None:
+        self.shutdown(collect_gc=False)
 
     ########### EPLB methods start ###########
     @property

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6478,14 +6478,14 @@ class GPUModelRunner(
                 gc.unfreeze()
                 gc.collect()
 
-    def shutdown(self) -> None:
+    def shutdown(self, collect_gc: bool = True) -> None:
         """Release GPU tensors (model weights, KV caches, workspace) so that
         memory is reclaimable when running in the same process."""
         from vllm.model_executor.layers.rotary_embedding import _ROPE_DICT
         from vllm.v1.worker.workspace import reset_workspace_manager
 
         # Calls torch.accelerator.synchronize()
-        self._cleanup_profiling_kv_cache()
+        self._cleanup_profiling_kv_cache_for_shutdown(collect_gc=collect_gc)
         if current_platform.is_rocm():
             # Drop captured graphs before distributed teardown. On ROCm, delayed
             # graph destruction can surface HSA faults in the next engine startup.
@@ -6498,11 +6498,18 @@ class GPUModelRunner(
 
         reset_workspace_manager()
         if current_platform.is_rocm() or current_platform.is_xpu():
-            gc.collect()
+            if collect_gc:
+                gc.collect()
             torch.accelerator.empty_cache()
             torch.accelerator.synchronize()
 
+    def shutdown_for_process_exit(self) -> None:
+        self.shutdown(collect_gc=False)
+
     def _cleanup_profiling_kv_cache(self) -> None:
+        self._cleanup_profiling_kv_cache_for_shutdown(collect_gc=True)
+
+    def _cleanup_profiling_kv_cache_for_shutdown(self, collect_gc: bool) -> None:
         torch.accelerator.synchronize()
         if hasattr(self, "kv_caches") and self.kv_caches:
             for i in range(len(self.kv_caches)):
@@ -6531,7 +6538,8 @@ class GPUModelRunner(
                 if hasattr(layer.impl, "_v_scale_cache"):
                     layer.impl._v_scale_cache = None
 
-        gc.collect()
+        if collect_gc:
+            gc.collect()
         torch.accelerator.empty_cache()
 
         logger.debug("Cleaned up profiling KV cache and CUDA graphs")

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6677,14 +6677,14 @@ class GPUModelRunner(
                     else:
                         gc.disable()
 
-    def shutdown(self) -> None:
+    def shutdown(self, collect_gc: bool = True) -> None:
         """Release GPU tensors (model weights, KV caches, workspace) so that
         memory is reclaimable when running in the same process."""
         from vllm.model_executor.layers.rotary_embedding import _ROPE_DICT
         from vllm.v1.worker.workspace import reset_workspace_manager
 
         # Calls torch.accelerator.synchronize()
-        self._cleanup_profiling_kv_cache()
+        self._cleanup_profiling_kv_cache_for_shutdown(collect_gc=collect_gc)
         if current_platform.is_rocm():
             # Drop captured graphs before distributed teardown. On ROCm, delayed
             # graph destruction can surface HSA faults in the next engine startup.
@@ -6697,11 +6697,18 @@ class GPUModelRunner(
 
         reset_workspace_manager()
         if current_platform.is_rocm() or current_platform.is_xpu():
-            gc.collect()
+            if collect_gc:
+                gc.collect()
             torch.accelerator.empty_cache()
             torch.accelerator.synchronize()
 
+    def shutdown_for_process_exit(self) -> None:
+        self.shutdown(collect_gc=False)
+
     def _cleanup_profiling_kv_cache(self) -> None:
+        self._cleanup_profiling_kv_cache_for_shutdown(collect_gc=True)
+
+    def _cleanup_profiling_kv_cache_for_shutdown(self, collect_gc: bool) -> None:
         torch.accelerator.synchronize()
         if hasattr(self, "kv_caches") and self.kv_caches:
             for i in range(len(self.kv_caches)):
@@ -6730,7 +6737,8 @@ class GPUModelRunner(
                 if hasattr(layer.impl, "_v_scale_cache"):
                     layer.impl._v_scale_cache = None
 
-        gc.collect()
+        if collect_gc:
+            gc.collect()
         torch.accelerator.empty_cache()
 
         logger.debug("Cleaned up profiling KV cache and CUDA graphs")

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1376,8 +1376,9 @@ class Worker(WorkerBase):
         self.weight_transfer_engine.reset_weight_update_target()
         self._weight_update_active = False
 
-    def shutdown(self) -> None:
-        gc.unfreeze()
+    def shutdown(self, collect_gc: bool = True) -> None:
+        if collect_gc:
+            gc.unfreeze()
 
         # has_kv_transfer_group can be None during interpreter shutdown.
         if ensure_kv_transfer_shutdown is not None:
@@ -1393,7 +1394,10 @@ class Worker(WorkerBase):
         # Release GPU resources held by the model runner so that memory
         # can be reclaimed when running in-process
         if model_runner := getattr(self, "model_runner", None):
-            model_runner.shutdown()
+            if collect_gc:
+                model_runner.shutdown()
+            else:
+                model_runner.shutdown(collect_gc=False)
 
         # Release kept-alive cumem pools while the pluggable allocator wrappers
         # and callbacks are still alive, so MemPool teardown is not deferred to
@@ -1403,6 +1407,15 @@ class Worker(WorkerBase):
 
             if CuMemAllocator.instance is not None:
                 CuMemAllocator.instance.release_pools()
+
+    def shutdown_for_process_exit(self) -> None:
+        model_runner = getattr(self, "model_runner", None)
+        if callable(getattr(model_runner, "shutdown_for_process_exit", None)):
+            self.shutdown(collect_gc=False)
+        else:
+            # CPU, XPU, and out-of-tree workers inherit this class but do not
+            # use the GPU model runners whose full GC can be skipped here.
+            self.shutdown()
 
     def elastic_ep_execute(self, execute_method: str, *args, **kwargs):
         return self.elastic_ep_executor.execute(execute_method, *args, **kwargs)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1362,8 +1362,9 @@ class Worker(WorkerBase):
         if not self._weight_update_is_draft:
             self.model_runner.reset_lora_state()
 
-    def shutdown(self) -> None:
-        gc.unfreeze()
+    def shutdown(self, collect_gc: bool = True) -> None:
+        if collect_gc:
+            gc.unfreeze()
 
         # has_kv_transfer_group can be None during interpreter shutdown.
         if ensure_kv_transfer_shutdown is not None:
@@ -1381,7 +1382,10 @@ class Worker(WorkerBase):
         # Release GPU resources held by the model runner so that memory
         # can be reclaimed when running in-process
         if model_runner := getattr(self, "model_runner", None):
-            model_runner.shutdown()
+            if collect_gc:
+                model_runner.shutdown()
+            else:
+                model_runner.shutdown(collect_gc=False)
 
         # Release kept-alive cumem pools while the pluggable allocator wrappers
         # and callbacks are still alive, so MemPool teardown is not deferred to
@@ -1391,6 +1395,15 @@ class Worker(WorkerBase):
 
             if CuMemAllocator.instance is not None:
                 CuMemAllocator.instance.release_pools()
+
+    def shutdown_for_process_exit(self) -> None:
+        model_runner = getattr(self, "model_runner", None)
+        if callable(getattr(model_runner, "shutdown_for_process_exit", None)):
+            self.shutdown(collect_gc=False)
+        else:
+            # CPU, XPU, and out-of-tree workers inherit this class but do not
+            # use the GPU model runners whose full GC can be skipped here.
+            self.shutdown()
 
     def elastic_ep_execute(self, execute_method: str, *args, **kwargs):
         return self.elastic_ep_executor.execute(execute_method, *args, **kwargs)

--- a/vllm/v1/worker/worker_base.py
+++ b/vllm/v1/worker/worker_base.py
@@ -183,6 +183,10 @@ class WorkerBase:
         """Clean up resources held by the worker."""
         return
 
+    def shutdown_for_process_exit(self) -> None:
+        """Clean up resources when the hosting process will exit."""
+        self.shutdown()
+
 
 class WorkerWrapperBase:
     """
@@ -218,6 +222,10 @@ class WorkerWrapperBase:
     def shutdown(self) -> None:
         if self.worker is not None:
             self.worker.shutdown()
+
+    def shutdown_for_process_exit(self) -> None:
+        if self.worker is not None:
+            self.worker.shutdown_for_process_exit()
 
     def update_environment_variables(
         self,

--- a/vllm/v1/worker/worker_base.py
+++ b/vllm/v1/worker/worker_base.py
@@ -187,6 +187,10 @@ class WorkerBase:
         """Clean up resources held by the worker."""
         return
 
+    def shutdown_for_process_exit(self) -> None:
+        """Clean up resources when the hosting process will exit."""
+        self.shutdown()
+
 
 class WorkerWrapperBase:
     """
@@ -222,6 +226,10 @@ class WorkerWrapperBase:
     def shutdown(self) -> None:
         if self.worker is not None:
             self.worker.shutdown()
+
+    def shutdown_for_process_exit(self) -> None:
+        if self.worker is not None:
+            self.worker.shutdown_for_process_exit()
 
     def update_environment_variables(
         self,

--- a/vllm/v1/worker/xpu_worker.py
+++ b/vllm/v1/worker/xpu_worker.py
@@ -179,3 +179,8 @@ class XPUWorker(Worker):
             self.rank,
             self.local_rank,
         )
+
+    def shutdown_for_process_exit(self) -> None:
+        # XPU terminal GC skipping is not covered by this optimization.
+        # Preserve the existing full XPU shutdown semantics.
+        self.shutdown()


### PR DESCRIPTION
## Summary

Skip explicit full-heap garbage collection when the V1 EngineCore child process is definitively exiting.

The normal in-process shutdown behavior is preserved. Only the terminal child-process path propagates process-exit semantics through:

```
EngineCoreProc
  -> EngineCore
  -> UniProcExecutor
  -> GPUWorker
  -> GPUModelRunner
  -> distributed cleanup
```

This avoids unfreezing and scanning the frozen startup heap immediately before the operating system reclaims the process.

Fixes #48620.

## Changes

- Add `process_exiting` semantics to `EngineCore.shutdown()`.
- Mark `EngineCoreProc.run_engine_core()` final shutdown as terminal.
- Preserve default cleanup for reusable paths such as Ray actors.
- Add backward-compatible process-exit shutdown fallbacks to Executor and WorkerBase.
- Propagate terminal shutdown only through UniProcExecutor.
- Allow V1 and V2 GPU model runners to skip explicit GC during terminal teardown.
- Preserve connector, profiler, cache, allocator, worker, and distributed cleanup.
- Preserve full-GC behavior for normal in-process shutdown and V1 profiling cleanup.
- Add deterministic default and terminal cleanup tests.

## Validation

### Regression tests

```text
tests/v1/engine/test_process_exit_cleanup.py
21 passed, 20 warnings
```

The focused regression suite covers normal, SystemExit, and exception
EngineCore exits; normal and terminal shutdown; DPEngineCoreProc forwarding;
Executor, WorkerBase, WorkerWrapper, and XPUWorker fallbacks/forwarding;
UniProc propagation; GPUWorker; V1/V2 GPU model-runner terminal forwarding;
V1 profiling cleanup; and distributed cleanup with and without explicit GC.

### Patch coverage

```text
Changed executable lines: 53
Covered lines: 51
Patch coverage: 96.2%
```

The only uncovered changed lines are the ROCm/XPU-specific GC branch in
`vllm/v1/worker/gpu_model_runner.py`. The platform behavior was not mocked
solely to inflate coverage.

### End-to-end Docker validation

The base and PR head were built in isolated Docker images from:

```text
base: e6d1310b2ac52e56e266450693af9de12a871a51

Runtime validation was performed on:
db0c6ab28ac32bd8a28ff5924b24488ed554c34f
```

Both images used the same precompiled native-extension wheel commit:

```text
e6d1310b2ac52e56e266450693af9de12a871a51
```

This kept the native extensions constant while varying the Python source
between the base and PR head.

A subsequent test-only commit made the cleanup mocks portable to PyTorch
builds where XPU platform branches are active or
torch._C._host_emptyCache is unavailable. No runtime code changed.

Environment:

- Model: Qwen2.5-7B
- GPU: NVIDIA RTX 4090
- Python: 3.12.13
- PyTorch: 2.11.0+cu130
- CUDA: 13.0
- Attention backend: TRITON_ATTN
- External flash_attn package: not installed
- vLLM FA2/FA3 extensions: available

Both runs resolved to the default single-GPU executor topology:

```text
distributed_executor_backend=uni
```

Both images successfully loaded the model, generated output, exited with
status 0, produced no traceback, and left no EngineCore or Worker processes
behind.

#### Terminal GC call tracing

A diagnostic sitecustomize wrapper traced gc.freeze, gc.unfreeze, and
gc.collect using direct os.write output so that the evidence did not depend
on logging during interpreter teardown.

Each wrapper recorded the call and stack, immediately invoked the saved
original function exactly once, and returned the original result.

During terminal EngineCore teardown, the base executed:

```text
EngineCore.shutdown
  -> UniProcExecutor.shutdown
  -> GPUWorker.shutdown
  -> gc.unfreeze()

EngineCore.shutdown
  -> UniProcExecutor.shutdown
  -> GPUWorker.shutdown
  -> GPUModelRunner.shutdown
  -> gc.collect()
```

The PR head executed neither terminal `gc.unfreeze()` nor terminal
`gc.collect()`.

This directly confirms that the process-exit propagation removes the targeted
explicit GC calls on the default single-GPU UniProc path while preserving
successful generation and process exit.

#### Non-instrumented timing observation

A single non-instrumented run observed:

```text
base process_exit_begin -> process exit: 8.816 s
head process_exit_begin -> process exit: 4.283 s
```

These values are reported only as a local observation. They are not a general
performance benchmark, and no percentage improvement is claimed.

## Validation limitations

The non-instrumented exit timings are from a single local run and are
reported as observations rather than a general benchmark.

The GC tracer changes teardown timing and was used only to establish the
presence or absence of explicit GC calls; tracer-run timings were not used.

Full pre-commit hooks were not completed locally because external hook
environments could not be initialized. CI should run the repository-standard
lint and test checks.

### Additional observation

In the PR-head runs, the frontend occasionally logged:

```text
MPClient: engine core exited unexpectedly; starting cleanup
```

The message appeared after the EngineCore had entered terminal shutdown and
before the MPClient cleanup sequence. The process still exited with status 0,
produced no traceback, completed MPClient cleanup, and left no residual
processes.

The ordering is consistent with the EngineCore exiting before the frontend
monitor/finalizer has completed its normal-shutdown state transition. This
validation does not establish whether that warning should be handled in this
PR or separately.

## Compatibility

The default behavior remains unchanged:

- Normal in-process shutdown still performs explicit GC.
- Reusable actors do not receive terminal shutdown semantics.
- Out-of-tree/custom executors and workers fall back to their existing `shutdown()` implementation.
- CPU, XPU, and custom model runners are not passed GPU-specific cleanup arguments.

The optimized terminal propagation applies to UniProcExecutor, where the
GPU worker lives in the exiting EngineCore process. Executors with workers in
separate processes, including MultiprocExecutor, retain their existing full
worker-shutdown behavior.

## AI assistance disclosure

This change was developed with AI assistance. The human submitter reviewed the changed lines and validation results.
