### PR TITLE
[Feature] Add IndexCache support for DeepSeek V4 on Hopper

### DIFF
--- a/tests/models/test_deepseek_v4_index_cache.py
+++ b/tests/models/test_deepseek_v4_index_cache.py
@@ -1,0 +1,300 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for DeepSeek V4 IndexCache layer selection."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+import vllm.models.deepseek_v4.attention as dsv4_attn_mod
+import vllm.models.deepseek_v4.nvidia.model as dsv4_nvidia_model
+from vllm.models.deepseek_v4.attention import (
+    DeepseekV4Attention,
+    compute_dsv4_index_cache_skip_flags,
+)
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+COMPRESS_RATIOS = [128, 128, 4, 128, 4, 128, 4, 4, 128, 4]
+NUM_HIDDEN_LAYERS = len(COMPRESS_RATIOS)
+
+
+def _skipped_layer_ids(flags: tuple[bool, ...]) -> list[int]:
+    return [idx for idx, skip in enumerate(flags) if skip]
+
+
+def test_index_cache_default_freq_skips_no_layers():
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS,
+        NUM_HIDDEN_LAYERS,
+    )
+    assert _skipped_layer_ids(flags) == []
+
+
+def test_index_cache_freq_one_skips_no_layers():
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS,
+        NUM_HIDDEN_LAYERS,
+        index_topk_freq=1,
+    )
+    assert _skipped_layer_ids(flags) == []
+
+
+def test_index_cache_freq_four_uses_default_offset_two():
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS,
+        NUM_HIDDEN_LAYERS,
+        index_topk_freq=4,
+    )
+    assert _skipped_layer_ids(flags) == [6, 7, 9]
+
+
+def test_index_cache_offset_one_matches_fsss_pattern():
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS,
+        NUM_HIDDEN_LAYERS,
+        index_topk_freq=4,
+        index_skip_topk_offset=1,
+    )
+    assert _skipped_layer_ids(flags) == [4, 6, 7]
+
+
+def test_index_cache_custom_pattern_maps_to_c4_layers_only():
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS,
+        NUM_HIDDEN_LAYERS,
+        index_topk_pattern="FSFSS",
+    )
+    assert _skipped_layer_ids(flags) == [4, 7, 9]
+
+
+def test_non_c4_layers_are_never_skipped():
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS,
+        NUM_HIDDEN_LAYERS,
+        index_topk_pattern="FSSSS",
+    )
+    assert all(
+        not flags[idx] for idx, ratio in enumerate(COMPRESS_RATIOS) if ratio != 4
+    )
+
+
+def test_extra_compress_ratios_do_not_affect_backbone_mapping():
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS + [4, 4, 4],
+        NUM_HIDDEN_LAYERS,
+        index_topk_pattern="FSFSS",
+    )
+    assert len(flags) == NUM_HIDDEN_LAYERS
+    assert _skipped_layer_ids(flags) == [4, 7, 9]
+
+
+def test_each_pp_stage_first_local_c4_layer_is_forced_full():
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS,
+        NUM_HIDDEN_LAYERS,
+        index_topk_pattern="FSSSS",
+        local_start_layer=3,
+        local_end_layer=8,
+    )
+    assert _skipped_layer_ids(flags) == [6, 7, 9]
+    assert not flags[4]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"index_topk_freq": 0}, "index_topk_freq must be positive"),
+        ({"index_skip_topk_offset": 0}, "index_skip_topk_offset must be at least 1"),
+        ({"index_topk_pattern": "FXFSS"}, "only supports 'F'.*'S'"),
+        ({"index_topk_pattern": "FSS"}, "length must match"),
+        ({"index_topk_pattern": "SFFFF"}, "must start with 'F'"),
+    ],
+)
+def test_invalid_index_cache_config_raises(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        compute_dsv4_index_cache_skip_flags(
+            COMPRESS_RATIOS,
+            NUM_HIDDEN_LAYERS,
+            **kwargs,
+        )
+
+
+def test_short_compress_ratios_raises():
+    with pytest.raises(ValueError, match="at least num_hidden_layers"):
+        compute_dsv4_index_cache_skip_flags(
+            [4, 128],
+            3,
+        )
+
+
+def test_invalid_local_range_raises():
+    with pytest.raises(ValueError, match="local layer range"):
+        compute_dsv4_index_cache_skip_flags(
+            COMPRESS_RATIOS,
+            NUM_HIDDEN_LAYERS,
+            local_start_layer=8,
+            local_end_layer=7,
+        )
+
+
+class _TestDeepseekV4Attention(DeepseekV4Attention):
+    @classmethod
+    def get_padded_num_q_heads(cls, num_heads: int) -> int:
+        return num_heads
+
+    def forward_mqa(
+        self,
+        q: torch.Tensor,
+        kv: torch.Tensor,
+        positions: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        pass
+
+    def _o_proj(self, o: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
+        return o
+
+
+def _make_attention(skip_topk: bool) -> _TestDeepseekV4Attention:
+    attn = object.__new__(_TestDeepseekV4Attention)
+    attn.indexer = Mock(name="indexer")
+    attn.skip_topk = skip_topk
+    attn.compressor = Mock(name="compressor")
+    attn.aux_stream_list = None
+    attn.ln_events = [None, None, None, None]
+    attn.n_local_heads = 1
+    attn.head_dim = 2
+    attn.wq_b = Mock(return_value=torch.zeros(1, 2))
+    attn._fused_qnorm_rope_kv_insert = Mock(side_effect=lambda q, *_args: q)
+    attn.forward_mqa = Mock()
+    attn.indexer_rotary_emb = object()
+    attn.rotary_emb = object()
+    return attn
+
+
+@pytest.fixture()
+def _patch_attention_helpers(monkeypatch):
+    monkeypatch.setattr(
+        dsv4_attn_mod,
+        "get_forward_context",
+        lambda: type("Context", (), {"attn_metadata": {}})(),
+    )
+    monkeypatch.setattr(
+        dsv4_attn_mod,
+        "execute_in_parallel",
+        lambda main_fn, fns, *_args, **_kwargs: (
+            main_fn(),
+            [fn() if fn is not None else None for fn in fns],
+        ),
+    )
+    monkeypatch.setattr(
+        dsv4_attn_mod,
+        "maybe_execute_in_parallel",
+        lambda first_fn, second_fn, *_args, **_kwargs: (first_fn(), second_fn()),
+    )
+
+
+def test_skip_topk_bypasses_indexer_but_keeps_main_compressor(_patch_attention_helpers):
+    attn = _make_attention(skip_topk=True)
+
+    attn.attention_impl(
+        torch.zeros(1, 4),
+        torch.zeros(1, 4),
+        torch.zeros(1, 2),
+        torch.zeros(1, 2),
+        None,
+        None,
+        torch.zeros(1, dtype=torch.long),
+        torch.zeros(1, 1, 2),
+    )
+
+    attn.indexer.assert_not_called()
+    attn.compressor.assert_called_once()
+    attn.forward_mqa.assert_called_once()
+
+
+def test_full_topk_path_calls_indexer_and_compressor(_patch_attention_helpers):
+    attn = _make_attention(skip_topk=False)
+
+    attn.attention_impl(
+        torch.zeros(1, 4),
+        torch.zeros(1, 4),
+        torch.zeros(1, 2),
+        torch.zeros(1, 2),
+        torch.zeros(1, 2),
+        torch.zeros(1, 1),
+        torch.zeros(1, dtype=torch.long),
+        torch.zeros(1, 1, 2),
+    )
+
+    attn.indexer.assert_called_once()
+    attn.compressor.assert_called_once()
+    attn.forward_mqa.assert_called_once()
+
+
+def test_index_cache_platform_guard_ignores_no_skipped_layers(monkeypatch):
+    monkeypatch.setattr(
+        dsv4_nvidia_model.current_platform,
+        "get_device_capability",
+        lambda: None,
+    )
+
+    dsv4_nvidia_model._validate_dsv4_index_cache_platform(False)
+
+
+def test_index_cache_platform_guard_allows_hopper(monkeypatch):
+    monkeypatch.setattr(
+        dsv4_nvidia_model.current_platform,
+        "get_device_capability",
+        lambda: SimpleNamespace(major=9),
+    )
+
+    dsv4_nvidia_model._validate_dsv4_index_cache_platform(True)
+
+
+def test_index_cache_platform_guard_rejects_non_hopper(monkeypatch):
+    monkeypatch.setattr(
+        dsv4_nvidia_model.current_platform,
+        "get_device_capability",
+        lambda: SimpleNamespace(major=12),
+    )
+
+    with pytest.raises(NotImplementedError, match="only on Hopper"):
+        dsv4_nvidia_model._validate_dsv4_index_cache_platform(True)
+
+
+def test_index_cache_ubatching_guard_ignores_no_skipped_layers():
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(use_ubatching=True),
+    )
+
+    dsv4_nvidia_model._validate_dsv4_index_cache_ubatching(False, vllm_config)
+
+
+def test_index_cache_ubatching_guard_rejects_enabled_ubatching():
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(use_ubatching=True),
+    )
+
+    with pytest.raises(NotImplementedError, match="does not support ubatching"):
+        dsv4_nvidia_model._validate_dsv4_index_cache_ubatching(True, vllm_config)
+
+
+def test_skipped_indexer_weight_filter_matches_only_omitted_indexers():
+    skipped_layer_ids = frozenset({6, 7})
+
+    assert dsv4_nvidia_model._is_dsv4_skipped_indexer_weight(
+        "model.layers.6.attn.indexer.wk_weights_proj.weight",
+        skipped_layer_ids,
+    )
+    assert not dsv4_nvidia_model._is_dsv4_skipped_indexer_weight(
+        "model.layers.6.attn.compressor.fused_wkv_wgate.weight",
+        skipped_layer_ids,
+    )
+    assert not dsv4_nvidia_model._is_dsv4_skipped_indexer_weight(
+        "model.layers.16.attn.indexer.wk_weights_proj.weight",
+        skipped_layer_ids,
+    )

--- a/tests/models/test_deepseek_v4_index_cache.py
+++ b/tests/models/test_deepseek_v4_index_cache.py
@@ -12,6 +12,7 @@ import vllm.models.deepseek_v4.attention as dsv4_attn_mod
 import vllm.models.deepseek_v4.nvidia.model as dsv4_nvidia_model
 from vllm.models.deepseek_v4.attention import (
     DeepseekV4Attention,
+    DeepseekV4Indexer,
     compute_dsv4_index_cache_skip_flags,
 )
 
@@ -158,7 +159,63 @@ class _TestDeepseekV4Attention(DeepseekV4Attention):
         return o
 
 
-def _make_attention(skip_topk: bool) -> _TestDeepseekV4Attention:
+def test_skip_topk_attention_still_constructs_indexer(monkeypatch):
+    class FakeLayer:
+        def __init__(self, *_args, **kwargs):
+            self.skip_topk = kwargs.get("skip_topk")
+
+    monkeypatch.setattr(
+        dsv4_attn_mod,
+        "get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+    for layer_cls in (
+        "MergedColumnParallelLinear",
+        "ColumnParallelLinear",
+        "RowParallelLinear",
+        "RMSNorm",
+        "DeepseekV4Indexer",
+        "DeepseekV4SWACache",
+        "DeepseekCompressor",
+    ):
+        monkeypatch.setattr(dsv4_attn_mod, layer_cls, FakeLayer)
+    monkeypatch.setattr(dsv4_attn_mod, "build_deepseek_v4_rope", FakeLayer)
+    monkeypatch.setattr(torch.cuda, "Event", Mock)
+
+    config = SimpleNamespace(
+        hidden_size=256,
+        num_attention_heads=4,
+        q_lora_rank=64,
+        o_lora_rank=64,
+        head_dim=128,
+        qk_rope_head_dim=64,
+        o_groups=1,
+        sliding_window=128,
+        num_hidden_layers=2,
+        compress_ratios=[128, 4],
+        rms_norm_eps=1e-6,
+        max_position_embeddings=1024,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(hf_config=config, max_model_len=1024),
+        quant_config=None,
+        cache_config=SimpleNamespace(cache_dtype="fp8"),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=1024),
+        compilation_config=SimpleNamespace(static_forward_context={}),
+    )
+
+    attn = _TestDeepseekV4Attention(
+        vllm_config,
+        prefix="model.layers.1.attn",
+        topk_indices_buffer=torch.empty(8, dtype=torch.int32),
+        skip_topk=True,
+    )
+
+    assert attn.indexer is not None
+    assert attn.indexer.skip_topk
+
+
+def _make_attention(skip_topk: bool) -> tuple[_TestDeepseekV4Attention, Mock]:
     attn = object.__new__(_TestDeepseekV4Attention)
     attn.indexer = Mock(name="indexer")
     attn.skip_topk = skip_topk
@@ -169,10 +226,11 @@ def _make_attention(skip_topk: bool) -> _TestDeepseekV4Attention:
     attn.head_dim = 2
     attn.wq_b = Mock(return_value=torch.zeros(1, 2))
     attn._fused_qnorm_rope_kv_insert = Mock(side_effect=lambda q, *_args: q)
-    attn.forward_mqa = Mock()
+    forward_mqa = Mock()
+    object.__setattr__(attn, "forward_mqa", forward_mqa)
     attn.indexer_rotary_emb = object()
     attn.rotary_emb = object()
-    return attn
+    return attn, forward_mqa
 
 
 @pytest.fixture()
@@ -198,7 +256,7 @@ def _patch_attention_helpers(monkeypatch):
 
 
 def test_skip_topk_bypasses_indexer_but_keeps_main_compressor(_patch_attention_helpers):
-    attn = _make_attention(skip_topk=True)
+    attn, forward_mqa = _make_attention(skip_topk=True)
 
     attn.attention_impl(
         torch.zeros(1, 4),
@@ -213,11 +271,11 @@ def test_skip_topk_bypasses_indexer_but_keeps_main_compressor(_patch_attention_h
 
     attn.indexer.assert_not_called()
     attn.compressor.assert_called_once()
-    attn.forward_mqa.assert_called_once()
+    forward_mqa.assert_called_once()
 
 
 def test_full_topk_path_calls_indexer_and_compressor(_patch_attention_helpers):
-    attn = _make_attention(skip_topk=False)
+    attn, forward_mqa = _make_attention(skip_topk=False)
 
     attn.attention_impl(
         torch.zeros(1, 4),
@@ -232,7 +290,65 @@ def test_full_topk_path_calls_indexer_and_compressor(_patch_attention_helpers):
 
     attn.indexer.assert_called_once()
     attn.compressor.assert_called_once()
-    attn.forward_mqa.assert_called_once()
+    forward_mqa.assert_called_once()
+
+
+def test_skip_topk_indexer_keeps_cache_with_meta_weights(monkeypatch):
+    init_devices = []
+    quant_configs = []
+
+    class FakeLinear:
+        def __init__(self, *_args, quant_config=None, **_kwargs):
+            init_devices.append(torch.empty(0).device.type)
+            quant_configs.append(quant_config)
+
+    class FakeIndexerCache:
+        def __init__(self, *_args, prefix, **_kwargs):
+            self.prefix = prefix
+
+    class FakeCompressor:
+        def __init__(self, *_args, **_kwargs):
+            init_devices.append(torch.empty(0).device.type)
+
+    monkeypatch.setattr(dsv4_attn_mod, "ReplicatedLinear", FakeLinear)
+    monkeypatch.setattr(dsv4_attn_mod, "DeepseekV4IndexerCache", FakeIndexerCache)
+    monkeypatch.setattr(dsv4_attn_mod, "DeepseekCompressor", FakeCompressor)
+    monkeypatch.setattr(
+        dsv4_attn_mod,
+        "get_max_prefill_buffer_size",
+        lambda _vllm_config: 1024,
+    )
+    monkeypatch.setattr(torch.cuda, "Event", Mock)
+
+    vllm_config = SimpleNamespace(
+        attention_config=SimpleNamespace(use_fp4_indexer_cache=False),
+        model_config=SimpleNamespace(max_model_len=1024),
+    )
+    config = SimpleNamespace(
+        index_topk=8,
+        index_n_heads=4,
+        index_head_dim=128,
+        qk_rope_head_dim=64,
+    )
+
+    indexer = DeepseekV4Indexer(
+        vllm_config,
+        config=config,
+        hidden_size=256,
+        q_lora_rank=64,
+        quant_config=object(),
+        cache_config=object(),
+        topk_indices_buffer=torch.empty(8, dtype=torch.int32),
+        compress_ratio=4,
+        prefix="model.layers.1.attn.indexer",
+        skip_topk=True,
+    )
+
+    assert indexer.k_cache.prefix.endswith(".k_cache")
+    assert indexer.indexer_op is None
+    assert indexer.aux_stream is None
+    assert init_devices == ["meta", "meta", "meta"]
+    assert quant_configs == [None, None]
 
 
 def test_index_cache_platform_guard_ignores_no_skipped_layers(monkeypatch):

--- a/tests/models/test_deepseek_v4_index_cache.py
+++ b/tests/models/test_deepseek_v4_index_cache.py
@@ -12,6 +12,7 @@ import vllm.models.deepseek_v4.attention as dsv4_attn_mod
 import vllm.models.deepseek_v4.nvidia.model as dsv4_nvidia_model
 from vllm.models.deepseek_v4.attention import (
     DeepseekV4Attention,
+    DeepseekV4Indexer,
     compute_dsv4_index_cache_skip_flags,
 )
 
@@ -158,21 +159,98 @@ class _TestDeepseekV4Attention(DeepseekV4Attention):
         return o
 
 
-def _make_attention(skip_topk: bool) -> _TestDeepseekV4Attention:
+def test_skip_topk_attention_still_constructs_indexer(monkeypatch):
+    class FakeLayer:
+        def __init__(self, *_args, **kwargs):
+            self.skip_topk = kwargs.get("skip_topk")
+
+    monkeypatch.setattr(
+        dsv4_attn_mod,
+        "get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+    for layer_cls in (
+        "MergedColumnParallelLinear",
+        "ColumnParallelLinear",
+        "RowParallelLinear",
+        "RMSNorm",
+        "DeepseekV4Indexer",
+        "DeepseekV4SWACache",
+        "DeepseekCompressor",
+    ):
+        monkeypatch.setattr(dsv4_attn_mod, layer_cls, FakeLayer)
+    monkeypatch.setattr(dsv4_attn_mod, "build_deepseek_v4_rope", FakeLayer)
+    monkeypatch.setattr(torch.cuda, "Event", Mock)
+
+    config = SimpleNamespace(
+        hidden_size=256,
+        num_attention_heads=4,
+        q_lora_rank=64,
+        o_lora_rank=64,
+        head_dim=128,
+        qk_rope_head_dim=64,
+        o_groups=1,
+        sliding_window=128,
+        num_hidden_layers=2,
+        compress_ratios=[128, 4],
+        rms_norm_eps=1e-6,
+        max_position_embeddings=1024,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(hf_config=config, max_model_len=1024),
+        quant_config=None,
+        cache_config=SimpleNamespace(cache_dtype="fp8"),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=1024),
+        compilation_config=SimpleNamespace(static_forward_context={}),
+        use_v2_model_runner=True,
+    )
+
+    attn = _TestDeepseekV4Attention(
+        vllm_config,
+        prefix="model.layers.1.attn",
+        topk_indices_buffer=torch.empty(8, dtype=torch.int32),
+        skip_topk=True,
+    )
+
+    assert attn.indexer is not None
+    assert attn.indexer.skip_topk
+
+
+def _make_attention(skip_topk: bool) -> tuple[_TestDeepseekV4Attention, Mock]:
     attn = object.__new__(_TestDeepseekV4Attention)
     attn.indexer = Mock(name="indexer")
+    attn.indexer.return_value = (
+        torch.zeros(1, 2),
+        None,
+        torch.zeros(1, 1),
+    )
     attn.skip_topk = skip_topk
     attn.compressor = Mock(name="compressor")
     attn.aux_stream_list = None
     attn.ln_events = [None, None, None, None]
+    attn.q_lora_rank = 2
     attn.n_local_heads = 1
+    attn.padded_heads = 1
     attn.head_dim = 2
+    attn.eps = 1e-6
+    attn.q_norm = SimpleNamespace(weight=SimpleNamespace(data=torch.ones(2)))
+    attn.kv_norm = SimpleNamespace(weight=SimpleNamespace(data=torch.ones(2)))
+    attn._run_parallel_input_projections = Mock(
+        return_value=(
+            torch.zeros(1, 4),
+            torch.zeros(1, 2),
+            torch.zeros(1, 2),
+            torch.zeros(1, 1),
+        )
+    )
+    attn._prepare_and_attn_fn = attn._prepare_and_attn
     attn.wq_b = Mock(return_value=torch.zeros(1, 2))
     attn._fused_qnorm_rope_kv_insert = Mock(side_effect=lambda q, *_args: q)
-    attn.forward_mqa = Mock()
+    forward_mqa = Mock()
+    object.__setattr__(attn, "forward_mqa", forward_mqa)
     attn.indexer_rotary_emb = object()
     attn.rotary_emb = object()
-    return attn
+    return attn, forward_mqa
 
 
 @pytest.fixture()
@@ -195,44 +273,98 @@ def _patch_attention_helpers(monkeypatch):
         "maybe_execute_in_parallel",
         lambda first_fn, second_fn, *_args, **_kwargs: (first_fn(), second_fn()),
     )
+    monkeypatch.setattr(
+        dsv4_attn_mod,
+        "fused_q_kv_rmsnorm",
+        lambda qr, kv, *_args: (qr, kv),
+    )
 
 
 def test_skip_topk_bypasses_indexer_but_keeps_main_compressor(_patch_attention_helpers):
-    attn = _make_attention(skip_topk=True)
+    attn, forward_mqa = _make_attention(skip_topk=True)
 
-    attn.attention_impl(
-        torch.zeros(1, 4),
-        torch.zeros(1, 4),
-        torch.zeros(1, 2),
-        torch.zeros(1, 2),
-        None,
-        None,
+    attn.forward(
         torch.zeros(1, dtype=torch.long),
-        torch.zeros(1, 1, 2),
+        torch.zeros(1, 4),
     )
 
     attn.indexer.assert_not_called()
+    attn.indexer.indexer_op.assert_not_called()
     attn.compressor.assert_called_once()
-    attn.forward_mqa.assert_called_once()
+    forward_mqa.assert_called_once()
 
 
 def test_full_topk_path_calls_indexer_and_compressor(_patch_attention_helpers):
-    attn = _make_attention(skip_topk=False)
+    attn, forward_mqa = _make_attention(skip_topk=False)
 
-    attn.attention_impl(
-        torch.zeros(1, 4),
-        torch.zeros(1, 4),
-        torch.zeros(1, 2),
-        torch.zeros(1, 2),
-        torch.zeros(1, 2),
-        torch.zeros(1, 1),
+    attn.forward(
         torch.zeros(1, dtype=torch.long),
-        torch.zeros(1, 1, 2),
+        torch.zeros(1, 4),
     )
 
     attn.indexer.assert_called_once()
+    attn.indexer.indexer_op.assert_called_once()
     attn.compressor.assert_called_once()
-    attn.forward_mqa.assert_called_once()
+    forward_mqa.assert_called_once()
+
+
+def test_skip_topk_indexer_keeps_cache_with_meta_weights(monkeypatch):
+    init_devices = []
+    quant_configs = []
+
+    class FakeLinear:
+        def __init__(self, *_args, quant_config=None, **_kwargs):
+            init_devices.append(torch.empty(0).device.type)
+            quant_configs.append(quant_config)
+
+    class FakeIndexerCache:
+        def __init__(self, *_args, prefix, **_kwargs):
+            self.prefix = prefix
+
+    class FakeCompressor:
+        def __init__(self, *_args, **_kwargs):
+            init_devices.append(torch.empty(0).device.type)
+
+    monkeypatch.setattr(dsv4_attn_mod, "ReplicatedLinear", FakeLinear)
+    monkeypatch.setattr(dsv4_attn_mod, "DeepseekV4IndexerCache", FakeIndexerCache)
+    monkeypatch.setattr(dsv4_attn_mod, "DeepseekCompressor", FakeCompressor)
+    monkeypatch.setattr(
+        dsv4_attn_mod,
+        "get_max_prefill_buffer_size",
+        lambda _vllm_config: 1024,
+    )
+    monkeypatch.setattr(dsv4_attn_mod, "dsa_indexer_uses_fp4", lambda _config: False)
+    monkeypatch.setattr(torch.cuda, "Event", Mock)
+
+    vllm_config = SimpleNamespace(
+        attention_config=SimpleNamespace(use_fp4_indexer_cache=False),
+        model_config=SimpleNamespace(max_model_len=1024),
+    )
+    config = SimpleNamespace(
+        index_topk=8,
+        index_n_heads=4,
+        index_head_dim=128,
+        qk_rope_head_dim=64,
+    )
+
+    indexer = DeepseekV4Indexer(
+        vllm_config,
+        config=config,
+        hidden_size=256,
+        q_lora_rank=64,
+        quant_config=object(),
+        cache_config=object(),
+        topk_indices_buffer=torch.empty(8, dtype=torch.int32),
+        compress_ratio=4,
+        prefix="model.layers.1.attn.indexer",
+        skip_topk=True,
+    )
+
+    assert indexer.k_cache.prefix.endswith(".k_cache")
+    assert indexer.indexer_op is None
+    assert indexer.aux_stream is None
+    assert init_devices == ["meta", "meta", "meta"]
+    assert quant_configs == [None, None]
 
 
 def test_index_cache_platform_guard_ignores_no_skipped_layers(monkeypatch):

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -150,9 +150,7 @@ def compute_dsv4_index_cache_skip_flags(
             skip_flags[layer_id] = pattern[c4_rank] == "S"
     else:
         if index_topk_freq <= 0:
-            raise ValueError(
-                f"index_topk_freq must be positive, got {index_topk_freq}"
-            )
+            raise ValueError(f"index_topk_freq must be positive, got {index_topk_freq}")
         if index_skip_topk_offset < 1:
             raise ValueError(
                 "index_skip_topk_offset must be at least 1, got "
@@ -811,10 +809,8 @@ class DeepseekV4Indexer(nn.Module):
         self.q_lora_rank = q_lora_rank  # 1536
         self.compress_ratio = compress_ratio
         self.use_fp4_kv = self.vllm_config.attention_config.use_fp4_indexer_cache
-        # When skip_top=True this indexer exists only to produce the C4I
-        # KVCacheSpec (via self.k_cache); its GEMM weights and kernel are
-        # never invoked, so they are allocated on the meta device and the
-        # indexer_op handle is skipped.
+        # Skipped indexers still register their KV cache specs, but keep unused
+        # weights on the meta device.
         self.skip_topk = skip_topk
         logger.info_once(
             "Using %s indexer cache for Lightning Indexer.",
@@ -822,13 +818,12 @@ class DeepseekV4Indexer(nn.Module):
         )
 
         # no tensor parallel, just replicated
-        gemm_ctx = torch.device("meta") if self.skip_topk else nullcontext()
-        with gemm_ctx:
+        with torch.device("meta") if self.skip_topk else nullcontext():
             self.wq_b = ReplicatedLinear(
                 self.q_lora_rank,
                 self.head_dim * self.n_head,
                 bias=False,
-                quant_config=quant_config,
+                quant_config=None if self.skip_topk else quant_config,
                 prefix=f"{prefix}.wq_b",
             )
             self.weights_proj = ReplicatedLinear(
@@ -871,22 +866,7 @@ class DeepseekV4Indexer(nn.Module):
             cache_config=cache_config,
             compress_ratio=self.compress_ratio,
         )
-        if self.skip_topk:
-            # Compressor's KV projection is never used on skip layers; build it
-            # on meta to avoid allocating indexer-side GEMM weights
-            with torch.devcie('meta'):
-                self.compressor = DeepseekCompressor(
-                    vllm_config=vllm_config,
-                    compress_ratio=self.compress_ratio,
-                    hidden_size=hidden_size,
-                    head_dim=self.head_dim,
-                    rotate=True,
-                    prefix=f"{prefix}.compressor",
-                    k_cache_prefix=self.k_cache.prefix,
-                    use_fp4_cache=self.use_fp4_kv,
-                )
-            self.indexer_op = None
-        else:
+        with torch.device("meta") if self.skip_topk else nullcontext():
             self.compressor = DeepseekCompressor(
                 vllm_config=vllm_config,
                 compress_ratio=self.compress_ratio,
@@ -898,6 +878,8 @@ class DeepseekV4Indexer(nn.Module):
                 use_fp4_cache=self.use_fp4_kv,
             )
 
+        self.indexer_op: SparseAttnIndexer | None = None
+        if not self.skip_topk:
             self.indexer_op = SparseAttnIndexer(
                 self.k_cache,
                 self.quant_block_size,
@@ -913,11 +895,7 @@ class DeepseekV4Indexer(nn.Module):
 
         # None on ROCm — maybe_execute_in_parallel falls back to sequential.
         self.aux_stream = None if self.skip_topk else aux_stream
-        # ln_events must keep 4 entries (fan-out + 3 aux done) regardless of
-        # skip_topk: execute_in_parallel always slices [0] and [1:4].
         self.ln_events: list[torch.cuda.Event] = [
-            torch.cuda.Event(),
-            torch.cuda.Event(),
             torch.cuda.Event(),
             torch.cuda.Event(),
         ]
@@ -979,4 +957,5 @@ class DeepseekV4Indexer(nn.Module):
             self.ln_events[1],
             self.aux_stream,
         )
+        assert self.indexer_op is not None
         return self.indexer_op(hidden_states, q_quant, k, weights)

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -5,7 +5,7 @@ DeepseekV4 MLA Attention Layer
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import torch
@@ -84,6 +84,93 @@ def _fill_short_context_topk_indices(
         tl.where(offsets < num_compressed, offsets, -1),
         mask=offsets < TOP_K,
     )
+
+
+def compute_dsv4_index_cache_skip_flags(
+    compress_ratios: Sequence[int],
+    num_hidden_layers: int,
+    *,
+    index_topk_freq: int = 1,
+    index_topk_pattern: str | Sequence[str] | None = None,
+    index_skip_topk_offset: int = 2,
+    local_start_layer: int = 0,
+    local_end_layer: int | None = None,
+) -> tuple[bool, ...]:
+    """Compute DeepSeek V4 C4-layer IndexCache skip decisions.
+
+    The returned tuple is indexed by global decoder layer id. Only backbone C4
+    layers (``compress_ratio == 4``) may be marked as skipped. Pipeline stages
+    have rank-local top-k buffers, so the first local C4 layer is always forced
+    to compute top-k.
+    """
+    if num_hidden_layers < 0:
+        raise ValueError(
+            f"num_hidden_layers must be non-negative, got {num_hidden_layers}"
+        )
+
+    ratios = list(compress_ratios[:num_hidden_layers])
+    if len(ratios) != num_hidden_layers:
+        raise ValueError(
+            "compress_ratios must contain at least num_hidden_layers entries, "
+            f"got {len(compress_ratios)} for {num_hidden_layers} layers"
+        )
+
+    if local_end_layer is None:
+        local_end_layer = num_hidden_layers
+    if not (0 <= local_start_layer <= local_end_layer <= num_hidden_layers):
+        raise ValueError(
+            "local layer range must satisfy "
+            "0 <= local_start_layer <= local_end_layer <= num_hidden_layers, "
+            f"got [{local_start_layer}, {local_end_layer}) for "
+            f"{num_hidden_layers} layers"
+        )
+
+    skip_flags = [False] * num_hidden_layers
+    c4_layer_ids = [layer_id for layer_id, ratio in enumerate(ratios) if ratio == 4]
+    if not c4_layer_ids:
+        return tuple(skip_flags)
+
+    if index_topk_pattern is not None:
+        pattern = list(index_topk_pattern)
+        invalid_values = set(pattern) - {"F", "S"}
+        if invalid_values:
+            raise ValueError(
+                "index_topk_pattern only supports 'F' for full indexer "
+                f"layers and 'S' for shared layers, got {sorted(invalid_values)}"
+            )
+        if len(pattern) != len(c4_layer_ids):
+            raise ValueError(
+                "index_topk_pattern length must match the number of C4 layers "
+                f"({len(c4_layer_ids)}), got {len(pattern)}"
+            )
+        if pattern[0] != "F":
+            raise ValueError("index_topk_pattern must start with 'F'")
+        for c4_rank, layer_id in enumerate(c4_layer_ids):
+            skip_flags[layer_id] = pattern[c4_rank] == "S"
+    else:
+        if index_topk_freq <= 0:
+            raise ValueError(
+                f"index_topk_freq must be positive, got {index_topk_freq}"
+            )
+        if index_skip_topk_offset < 1:
+            raise ValueError(
+                "index_skip_topk_offset must be at least 1, got "
+                f"{index_skip_topk_offset}"
+            )
+        for c4_rank, layer_id in enumerate(c4_layer_ids):
+            skip_flags[layer_id] = (
+                max(c4_rank - index_skip_topk_offset + 1, 0) % index_topk_freq != 0
+            )
+
+    local_c4_layer_ids = [
+        layer_id
+        for layer_id in c4_layer_ids
+        if local_start_layer <= layer_id < local_end_layer
+    ]
+    if local_c4_layer_ids:
+        skip_flags[local_c4_layer_ids[0]] = False
+
+    return tuple(skip_flags)
 
 
 def _resolve_dsv4_kv_cache_dtype(
@@ -181,6 +268,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         prefix: str,
         topk_indices_buffer: torch.Tensor | None = None,
         aux_stream_list: list[torch.cuda.Stream] | None = None,
+        skip_topk: bool = False,
     ) -> None:
         super().__init__()
         config = vllm_config.model_config.hf_config
@@ -209,6 +297,12 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
             self.compress_ratio = max(1, config.compress_ratios[layer_id])
         else:
             self.compress_ratio = 1
+        self.skip_topk = skip_topk
+        if self.skip_topk:
+            if self.compress_ratio != 4:
+                raise ValueError("skip_topk is only valid for C4/indexer layers")
+            if topk_indices_buffer is None:
+                raise ValueError("skip_topk requires topk_indices_buffer")
         self.eps = config.rms_norm_eps
         self.scale = self.head_dim**-0.5
 
@@ -271,7 +365,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         self.topk_indices_buffer = topk_indices_buffer
 
         self.indexer = None
-        if self.compress_ratio == 4:
+        if self.compress_ratio == 4 and not self.skip_topk:
             # Only C4A uses sparse attention and hence has indexer.
             # aux_stream_list[2] is free here (outer GEMMs joined) for the inner
             # overlap of wq_b+fused_indexer_q_rope_quant vs compressor. None on
@@ -415,7 +509,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
 
             aux_fns[0] = compressor_kv_score
 
-        if self.indexer is not None:
+        if self.indexer is not None and not self.skip_topk:
             indexer = self.indexer
 
             def indexer_weights_proj() -> torch.Tensor:
@@ -457,8 +551,8 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         qr: torch.Tensor,
         kv: torch.Tensor,
         kv_score: torch.Tensor,
-        indexer_kv_score: torch.Tensor,
-        indexer_weights: torch.Tensor,
+        indexer_kv_score: torch.Tensor | None,
+        indexer_weights: torch.Tensor | None,
         positions: torch.Tensor,
         out: torch.Tensor,  # [num_tokens, padded_heads, head_dim], written in place
     ) -> None:
@@ -469,9 +563,11 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         # on the default stream so q stays on its consumer stream (forward_mqa
         # downstream reads q on default). Indexer/compressor go on aux for
         # overlap with default's GEMM + cache write.
-        if self.indexer is not None:
+        if self.indexer is not None and not self.skip_topk:
             aux_streams = self.aux_stream_list
             indexer = self.indexer
+            assert indexer_kv_score is not None
+            assert indexer_weights is not None
             # Local ref so the closure keeps a non-None type for mypy.
             assert self.compressor is not None
             compressor = self.compressor

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -6,6 +6,7 @@ DeepseekV4 MLA Attention Layer
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
+from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import torch
@@ -384,6 +385,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
                 compress_ratio=self.compress_ratio,
                 prefix=f"{prefix}.indexer",
                 aux_stream=indexer_aux_stream,
+                skip_topk=self.skip_topk,
             )
 
         # Will be None on ROCm for now.
@@ -795,6 +797,7 @@ class DeepseekV4Indexer(nn.Module):
         compress_ratio: int = 1,
         prefix: str = "",
         aux_stream: torch.cuda.Stream | None = None,
+        skip_topk: bool = False,
     ):
         super().__init__()
         self.vllm_config = vllm_config
@@ -808,26 +811,33 @@ class DeepseekV4Indexer(nn.Module):
         self.q_lora_rank = q_lora_rank  # 1536
         self.compress_ratio = compress_ratio
         self.use_fp4_kv = self.vllm_config.attention_config.use_fp4_indexer_cache
+        # When skip_top=True this indexer exists only to produce the C4I
+        # KVCacheSpec (via self.k_cache); its GEMM weights and kernel are
+        # never invoked, so they are allocated on the meta device and the
+        # indexer_op handle is skipped.
+        self.skip_topk = skip_topk
         logger.info_once(
             "Using %s indexer cache for Lightning Indexer.",
             "MXFP4" if self.use_fp4_kv else "FP8",
         )
 
         # no tensor parallel, just replicated
-        self.wq_b = ReplicatedLinear(
-            self.q_lora_rank,
-            self.head_dim * self.n_head,
-            bias=False,
-            quant_config=quant_config,
-            prefix=f"{prefix}.wq_b",
-        )
-        self.weights_proj = ReplicatedLinear(
-            hidden_size,
-            self.n_head,
-            bias=False,
-            quant_config=None,
-            prefix=f"{prefix}.weights_proj",
-        )
+        gemm_ctx = torch.device("meta") if self.skip_topk else nullcontext()
+        with gemm_ctx:
+            self.wq_b = ReplicatedLinear(
+                self.q_lora_rank,
+                self.head_dim * self.n_head,
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.wq_b",
+            )
+            self.weights_proj = ReplicatedLinear(
+                hidden_size,
+                self.n_head,
+                bias=False,
+                quant_config=None,
+                prefix=f"{prefix}.weights_proj",
+            )
         self.softmax_scale = self.head_dim**-0.5
 
         self.scale_fmt = "ue8m0"
@@ -861,33 +871,53 @@ class DeepseekV4Indexer(nn.Module):
             cache_config=cache_config,
             compress_ratio=self.compress_ratio,
         )
-        self.compressor = DeepseekCompressor(
-            vllm_config=vllm_config,
-            compress_ratio=self.compress_ratio,
-            hidden_size=hidden_size,
-            head_dim=self.head_dim,
-            rotate=True,
-            prefix=f"{prefix}.compressor",
-            k_cache_prefix=self.k_cache.prefix,
-            use_fp4_cache=self.use_fp4_kv,
-        )
+        if self.skip_topk:
+            # Compressor's KV projection is never used on skip layers; build it
+            # on meta to avoid allocating indexer-side GEMM weights
+            with torch.devcie('meta'):
+                self.compressor = DeepseekCompressor(
+                    vllm_config=vllm_config,
+                    compress_ratio=self.compress_ratio,
+                    hidden_size=hidden_size,
+                    head_dim=self.head_dim,
+                    rotate=True,
+                    prefix=f"{prefix}.compressor",
+                    k_cache_prefix=self.k_cache.prefix,
+                    use_fp4_cache=self.use_fp4_kv,
+                )
+            self.indexer_op = None
+        else:
+            self.compressor = DeepseekCompressor(
+                vllm_config=vllm_config,
+                compress_ratio=self.compress_ratio,
+                hidden_size=hidden_size,
+                head_dim=self.head_dim,
+                rotate=True,
+                prefix=f"{prefix}.compressor",
+                k_cache_prefix=self.k_cache.prefix,
+                use_fp4_cache=self.use_fp4_kv,
+            )
 
-        self.indexer_op = SparseAttnIndexer(
-            self.k_cache,
-            self.quant_block_size,
-            self.scale_fmt,
-            self.topk_tokens,
-            self.head_dim,
-            self.max_model_len,
-            self.max_total_seq_len,
-            self.topk_indices_buffer,
-            skip_k_cache_insert=True,
-            use_fp4_cache=self.use_fp4_kv,
-        )
+            self.indexer_op = SparseAttnIndexer(
+                self.k_cache,
+                self.quant_block_size,
+                self.scale_fmt,
+                self.topk_tokens,
+                self.head_dim,
+                self.max_model_len,
+                self.max_total_seq_len,
+                self.topk_indices_buffer,
+                skip_k_cache_insert=True,
+                use_fp4_cache=self.use_fp4_kv,
+            )
 
         # None on ROCm — maybe_execute_in_parallel falls back to sequential.
-        self.aux_stream = aux_stream
+        self.aux_stream = None if self.skip_topk else aux_stream
+        # ln_events must keep 4 entries (fan-out + 3 aux done) regardless of
+        # skip_topk: execute_in_parallel always slices [0] and [1:4].
         self.ln_events: list[torch.cuda.Event] = [
+            torch.cuda.Event(),
+            torch.cuda.Event(),
             torch.cuda.Event(),
             torch.cuda.Event(),
         ]

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -365,7 +365,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         self.topk_indices_buffer = topk_indices_buffer
 
         self.indexer = None
-        if self.compress_ratio == 4 and not self.skip_topk:
+        if self.compress_ratio == 4:
             # Only C4A uses sparse attention and hence has indexer.
             # aux_stream_list[2] is free here (outer GEMMs joined) for the inner
             # overlap of wq_b+fused_indexer_q_rope_quant vs compressor. None on

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -368,7 +368,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         self.topk_indices_buffer = topk_indices_buffer
 
         self.indexer = None
-        if self.compress_ratio == 4 and not self.skip_topk:
+        if self.compress_ratio == 4:
             # Only C4A uses sparse attention and hence has indexer.
             # aux_stream_list[2] is free here (outer GEMMs joined) for the inner
             # overlap of wq_b+fused_indexer_q_rope_quant vs compressor. None on

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -5,7 +5,7 @@ DeepseekV4 MLA Attention Layer
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import torch
@@ -85,6 +85,93 @@ def _fill_short_context_topk_indices(
         tl.where(offsets < num_compressed, offsets, -1),
         mask=offsets < TOP_K,
     )
+
+
+def compute_dsv4_index_cache_skip_flags(
+    compress_ratios: Sequence[int],
+    num_hidden_layers: int,
+    *,
+    index_topk_freq: int = 1,
+    index_topk_pattern: str | Sequence[str] | None = None,
+    index_skip_topk_offset: int = 2,
+    local_start_layer: int = 0,
+    local_end_layer: int | None = None,
+) -> tuple[bool, ...]:
+    """Compute DeepSeek V4 C4-layer IndexCache skip decisions.
+
+    The returned tuple is indexed by global decoder layer id. Only backbone C4
+    layers (``compress_ratio == 4``) may be marked as skipped. Pipeline stages
+    have rank-local top-k buffers, so the first local C4 layer is always forced
+    to compute top-k.
+    """
+    if num_hidden_layers < 0:
+        raise ValueError(
+            f"num_hidden_layers must be non-negative, got {num_hidden_layers}"
+        )
+
+    ratios = list(compress_ratios[:num_hidden_layers])
+    if len(ratios) != num_hidden_layers:
+        raise ValueError(
+            "compress_ratios must contain at least num_hidden_layers entries, "
+            f"got {len(compress_ratios)} for {num_hidden_layers} layers"
+        )
+
+    if local_end_layer is None:
+        local_end_layer = num_hidden_layers
+    if not (0 <= local_start_layer <= local_end_layer <= num_hidden_layers):
+        raise ValueError(
+            "local layer range must satisfy "
+            "0 <= local_start_layer <= local_end_layer <= num_hidden_layers, "
+            f"got [{local_start_layer}, {local_end_layer}) for "
+            f"{num_hidden_layers} layers"
+        )
+
+    skip_flags = [False] * num_hidden_layers
+    c4_layer_ids = [layer_id for layer_id, ratio in enumerate(ratios) if ratio == 4]
+    if not c4_layer_ids:
+        return tuple(skip_flags)
+
+    if index_topk_pattern is not None:
+        pattern = list(index_topk_pattern)
+        invalid_values = set(pattern) - {"F", "S"}
+        if invalid_values:
+            raise ValueError(
+                "index_topk_pattern only supports 'F' for full indexer "
+                f"layers and 'S' for shared layers, got {sorted(invalid_values)}"
+            )
+        if len(pattern) != len(c4_layer_ids):
+            raise ValueError(
+                "index_topk_pattern length must match the number of C4 layers "
+                f"({len(c4_layer_ids)}), got {len(pattern)}"
+            )
+        if pattern[0] != "F":
+            raise ValueError("index_topk_pattern must start with 'F'")
+        for c4_rank, layer_id in enumerate(c4_layer_ids):
+            skip_flags[layer_id] = pattern[c4_rank] == "S"
+    else:
+        if index_topk_freq <= 0:
+            raise ValueError(
+                f"index_topk_freq must be positive, got {index_topk_freq}"
+            )
+        if index_skip_topk_offset < 1:
+            raise ValueError(
+                "index_skip_topk_offset must be at least 1, got "
+                f"{index_skip_topk_offset}"
+            )
+        for c4_rank, layer_id in enumerate(c4_layer_ids):
+            skip_flags[layer_id] = (
+                max(c4_rank - index_skip_topk_offset + 1, 0) % index_topk_freq != 0
+            )
+
+    local_c4_layer_ids = [
+        layer_id
+        for layer_id in c4_layer_ids
+        if local_start_layer <= layer_id < local_end_layer
+    ]
+    if local_c4_layer_ids:
+        skip_flags[local_c4_layer_ids[0]] = False
+
+    return tuple(skip_flags)
 
 
 def _resolve_dsv4_kv_cache_dtype(
@@ -184,6 +271,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         prefix: str,
         topk_indices_buffer: torch.Tensor | None = None,
         aux_stream_list: list[torch.cuda.Stream] | None = None,
+        skip_topk: bool = False,
     ) -> None:
         super().__init__()
         config = vllm_config.model_config.hf_config
@@ -212,6 +300,12 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
             self.compress_ratio = max(1, config.compress_ratios[layer_id])
         else:
             self.compress_ratio = 1
+        self.skip_topk = skip_topk
+        if self.skip_topk:
+            if self.compress_ratio != 4:
+                raise ValueError("skip_topk is only valid for C4/indexer layers")
+            if topk_indices_buffer is None:
+                raise ValueError("skip_topk requires topk_indices_buffer")
         self.eps = config.rms_norm_eps
         self.scale = self.head_dim**-0.5
 
@@ -274,7 +368,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         self.topk_indices_buffer = topk_indices_buffer
 
         self.indexer = None
-        if self.compress_ratio == 4:
+        if self.compress_ratio == 4 and not self.skip_topk:
             # Only C4A uses sparse attention and hence has indexer.
             # aux_stream_list[2] is free here (outer GEMMs joined) for the inner
             # overlap of wq_b+fused_indexer_q_rope_quant vs compressor. None on
@@ -539,7 +633,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
 
             aux_fns[0] = compressor_kv_score
 
-        if self.indexer is not None:
+        if self.indexer is not None and not self.skip_topk:
             indexer = self.indexer
 
             def indexer_weights_proj() -> torch.Tensor:

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -6,6 +6,7 @@ DeepseekV4 MLA Attention Layer
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
+from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import torch
@@ -387,6 +388,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
                 compress_ratio=self.compress_ratio,
                 prefix=f"{prefix}.indexer",
                 aux_stream=indexer_aux_stream,
+                skip_topk=self.skip_topk,
             )
 
         self._prepare_and_attn_fn = self._prepare_and_attn
@@ -550,7 +552,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         # Keep Q projection and KV insertion on the default stream. The indexer
         # and MLA compressor use aux streams 0 and 1; aux 2 is internal to the
         # indexer. ROCm runs the same work sequentially without aux streams.
-        if indexer is not None:
+        if indexer is not None and not self.skip_topk:
             assert compressor is not None
             q, (indexer_inputs, _) = execute_in_parallel(
                 project_query_and_cache_kv,
@@ -876,6 +878,7 @@ class DeepseekV4Indexer(nn.Module):
         compress_ratio: int = 1,
         prefix: str = "",
         aux_stream: torch.cuda.Stream | None = None,
+        skip_topk: bool = False,
     ):
         super().__init__()
         self.vllm_config = vllm_config
@@ -889,26 +892,33 @@ class DeepseekV4Indexer(nn.Module):
         self.q_lora_rank = q_lora_rank  # 1536
         self.compress_ratio = compress_ratio
         self.use_fp4_kv = dsa_indexer_uses_fp4(vllm_config)
+        # When skip_top=True this indexer exists only to produce the C4I
+        # KVCacheSpec (via self.k_cache); its GEMM weights and kernel are
+        # never invoked, so they are allocated on the meta device and the
+        # indexer_op handle is skipped.
+        self.skip_topk = skip_topk
         logger.info_once(
             "Using %s indexer cache for Lightning Indexer.",
             "MXFP4" if self.use_fp4_kv else "FP8",
         )
 
         # no tensor parallel, just replicated
-        self.wq_b = ReplicatedLinear(
-            self.q_lora_rank,
-            self.head_dim * self.n_head,
-            bias=False,
-            quant_config=quant_config,
-            prefix=f"{prefix}.wq_b",
-        )
-        self.weights_proj = ReplicatedLinear(
-            hidden_size,
-            self.n_head,
-            bias=False,
-            quant_config=None,
-            prefix=f"{prefix}.weights_proj",
-        )
+        gemm_ctx = torch.device("meta") if self.skip_topk else nullcontext()
+        with gemm_ctx:
+            self.wq_b = ReplicatedLinear(
+                self.q_lora_rank,
+                self.head_dim * self.n_head,
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.wq_b",
+            )
+            self.weights_proj = ReplicatedLinear(
+                hidden_size,
+                self.n_head,
+                bias=False,
+                quant_config=None,
+                prefix=f"{prefix}.weights_proj",
+            )
         self.softmax_scale = self.head_dim**-0.5
 
         self.scale_fmt = "ue8m0"
@@ -942,34 +952,41 @@ class DeepseekV4Indexer(nn.Module):
             cache_config=cache_config,
             compress_ratio=self.compress_ratio,
         )
-        self.compressor = DeepseekCompressor(
-            vllm_config=vllm_config,
-            compress_ratio=self.compress_ratio,
-            hidden_size=hidden_size,
-            head_dim=self.head_dim,
-            rotate=True,
-            prefix=f"{prefix}.compressor",
-            k_cache_prefix=self.k_cache.prefix,
-            use_fp4_cache=self.use_fp4_kv,
-        )
+        with torch.device("meta") if self.skip_topk else nullcontext():
+            self.compressor = DeepseekCompressor(
+                vllm_config=vllm_config,
+                compress_ratio=self.compress_ratio,
+                hidden_size=hidden_size,
+                head_dim=self.head_dim,
+                rotate=True,
+                prefix=f"{prefix}.compressor",
+                k_cache_prefix=self.k_cache.prefix,
+                use_fp4_cache=self.use_fp4_kv,
+            )
 
-        self.indexer_op = SparseAttnIndexer(
-            self.k_cache,
-            self.quant_block_size,
-            self.scale_fmt,
-            self.topk_tokens,
-            self.head_dim,
-            self.max_model_len,
-            self.max_total_seq_len,
-            self.topk_indices_buffer,
-            skip_k_cache_insert=True,
-            use_fp4_cache=self.use_fp4_kv,
-            compress_ratio=self.compress_ratio,
-        )
+        self.indexer_op: SparseAttnIndexer | None = None
+        if not self.skip_topk:
+            self.indexer_op = SparseAttnIndexer(
+                self.k_cache,
+                self.quant_block_size,
+                self.scale_fmt,
+                self.topk_tokens,
+                self.head_dim,
+                self.max_model_len,
+                self.max_total_seq_len,
+                self.topk_indices_buffer,
+                skip_k_cache_insert=True,
+                use_fp4_cache=self.use_fp4_kv,
+                compress_ratio=self.compress_ratio,
+            )
 
         # None on ROCm — maybe_execute_in_parallel falls back to sequential.
-        self.aux_stream = aux_stream
+        self.aux_stream = None if self.skip_topk else aux_stream
+        # ln_events must keep 4 entries (fan-out + 3 aux done) regardless of
+        # skip_topk: execute_in_parallel always slices [0] and [1:4].
         self.ln_events: list[torch.cuda.Event] = [
+            torch.cuda.Event(),
+            torch.cuda.Event(),
             torch.cuda.Event(),
             torch.cuda.Event(),
         ]

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -151,9 +151,7 @@ def compute_dsv4_index_cache_skip_flags(
             skip_flags[layer_id] = pattern[c4_rank] == "S"
     else:
         if index_topk_freq <= 0:
-            raise ValueError(
-                f"index_topk_freq must be positive, got {index_topk_freq}"
-            )
+            raise ValueError(f"index_topk_freq must be positive, got {index_topk_freq}")
         if index_skip_topk_offset < 1:
             raise ValueError(
                 "index_skip_topk_offset must be at least 1, got "
@@ -679,6 +677,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
     ) -> None:
         if self.indexer is not None and index_q is not None:
             assert index_weights is not None
+            assert self.indexer.indexer_op is not None
             q_quant = (index_q, index_q_scale) if index_q_scale is not None else index_q
             self.indexer.indexer_op(
                 hidden_states,
@@ -892,10 +891,8 @@ class DeepseekV4Indexer(nn.Module):
         self.q_lora_rank = q_lora_rank  # 1536
         self.compress_ratio = compress_ratio
         self.use_fp4_kv = dsa_indexer_uses_fp4(vllm_config)
-        # When skip_top=True this indexer exists only to produce the C4I
-        # KVCacheSpec (via self.k_cache); its GEMM weights and kernel are
-        # never invoked, so they are allocated on the meta device and the
-        # indexer_op handle is skipped.
+        # Skipped indexers still register their KV cache specs, but keep unused
+        # weights on the meta device.
         self.skip_topk = skip_topk
         logger.info_once(
             "Using %s indexer cache for Lightning Indexer.",
@@ -903,13 +900,12 @@ class DeepseekV4Indexer(nn.Module):
         )
 
         # no tensor parallel, just replicated
-        gemm_ctx = torch.device("meta") if self.skip_topk else nullcontext()
-        with gemm_ctx:
+        with torch.device("meta") if self.skip_topk else nullcontext():
             self.wq_b = ReplicatedLinear(
                 self.q_lora_rank,
                 self.head_dim * self.n_head,
                 bias=False,
-                quant_config=quant_config,
+                quant_config=None if self.skip_topk else quant_config,
                 prefix=f"{prefix}.wq_b",
             )
             self.weights_proj = ReplicatedLinear(
@@ -982,11 +978,7 @@ class DeepseekV4Indexer(nn.Module):
 
         # None on ROCm — maybe_execute_in_parallel falls back to sequential.
         self.aux_stream = None if self.skip_topk else aux_stream
-        # ln_events must keep 4 entries (fan-out + 3 aux done) regardless of
-        # skip_topk: execute_in_parallel always slices [0] and [1:4].
         self.ln_events: list[torch.cuda.Event] = [
-            torch.cuda.Event(),
-            torch.cuda.Event(),
             torch.cuda.Event(),
             torch.cuda.Event(),
         ]

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1534,13 +1534,16 @@ class DeepseekV4ForCausalLM(
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self, skip_substrs=["mtp."])
-        # skipped_layer_ids = self.model.index_cache_skipped_layer_ids
-        # if skipped_layer_ids:
-        #     weights = (
-        #         (name, weight)
-        #         for name, weight in weights
-        #         if not _is_dsv4_skipped_indexer_weight(name, skipped_layer_ids)
-        #     )
+        # skip_topk layers carry their indexer GEMM weights (wq_b /
+        # weights_proj / compressor KV projection) on the meta device; the
+        # checkpoint still ships them, so filter them out before loading.
+        skipped_layer_ids = self.model.index_cache_skipped_layer_ids
+        if skipped_layer_ids:
+            weights = (
+                (name, weight)
+                for name, weight in weights
+                if not _is_dsv4_skipped_indexer_weight(name, skipped_layer_ids)
+            )
         loaded_params = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
         self.model.finalize_mega_moe_weights()
         self.model.finalize_mhc_broadcast_weights()

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1534,13 +1534,13 @@ class DeepseekV4ForCausalLM(
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self, skip_substrs=["mtp."])
-        skipped_layer_ids = self.model.index_cache_skipped_layer_ids
-        if skipped_layer_ids:
-            weights = (
-                (name, weight)
-                for name, weight in weights
-                if not _is_dsv4_skipped_indexer_weight(name, skipped_layer_ids)
-            )
+        # skipped_layer_ids = self.model.index_cache_skipped_layer_ids
+        # if skipped_layer_ids:
+        #     weights = (
+        #         (name, weight)
+        #         for name, weight in weights
+        #         if not _is_dsv4_skipped_indexer_weight(name, skipped_layer_ids)
+        #     )
         loaded_params = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
         self.model.finalize_mega_moe_weights()
         self.model.finalize_mhc_broadcast_weights()

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -17,6 +17,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
 )
 from vllm.distributed.eplb.eplb_state import EplbLayerState
+from vllm.distributed.utils import get_pp_indices
 from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.model_executor.kernels.mhc.tilelang import (
     hc_head_fused_kernel_tilelang,
@@ -65,7 +66,10 @@ from vllm.model_executor.models.utils import (
     maybe_prefix,
 )
 from vllm.model_executor.utils import set_weight_attrs
-from vllm.models.deepseek_v4.attention import DeepseekV4Attention
+from vllm.models.deepseek_v4.attention import (
+    DeepseekV4Attention,
+    compute_dsv4_index_cache_skip_flags,
+)
 from vllm.models.deepseek_v4.nvidia.flashinfer_sparse import (
     DeepseekV4FlashInferMLAAttention,
     DeepseekV4FlashInferSM120Attention,
@@ -791,6 +795,36 @@ def _select_dsv4_attn_cls(vllm_config: VllmConfig) -> type[DeepseekV4Attention]:
     return DeepseekV4FlashMLAAttention
 
 
+def _validate_dsv4_index_cache_platform(skip_topk: bool) -> None:
+    if not skip_topk:
+        return
+    device_capability = current_platform.get_device_capability()
+    if device_capability is None or device_capability.major != 9:
+        raise NotImplementedError(
+            "DeepSeek V4 IndexCache is currently supported only on Hopper "
+            "(SM90). Set index_topk_freq=1 or run on H100/H200."
+        )
+
+
+def _validate_dsv4_index_cache_ubatching(skip_topk: bool, vllm_config) -> None:
+    if not skip_topk or not vllm_config.parallel_config.use_ubatching:
+        return
+    raise NotImplementedError(
+        "DeepSeek V4 IndexCache does not support ubatching yet because "
+        "skipped layers reuse a shared topk_indices_buffer. Set "
+        "index_topk_freq=1 or disable DBO/ubatching."
+    )
+
+
+def _is_dsv4_skipped_indexer_weight(
+    weight_name: str, skipped_layer_ids: frozenset[int]
+) -> bool:
+    return any(
+        f"layers.{layer_id}.attn.indexer." in weight_name
+        for layer_id in skipped_layer_ids
+    )
+
+
 class DeepseekV4DecoderLayer(nn.Module):
     def __init__(
         self,
@@ -798,6 +832,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         prefix,
         topk_indices_buffer: torch.Tensor | None = None,
         aux_stream_list: list[torch.cuda.Stream] | None = None,
+        skip_topk: bool = False,
     ):
         super().__init__()
 
@@ -810,6 +845,7 @@ class DeepseekV4DecoderLayer(nn.Module):
             prefix=f"{prefix}.attn",
             topk_indices_buffer=topk_indices_buffer,
             aux_stream_list=aux_stream_list,
+            skip_topk=skip_topk,
         )
         self.ffn = DeepseekV4MoE(vllm_config, prefix=f"{prefix}.ffn")
 
@@ -993,6 +1029,31 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             config.index_topk,
             dtype=torch.int32,
         )
+        start_layer, end_layer = get_pp_indices(
+            config.num_hidden_layers,
+            get_pp_group().rank_in_group,
+            get_pp_group().world_size,
+        )
+        index_cache_skip_flags = compute_dsv4_index_cache_skip_flags(
+            config.compress_ratios,
+            config.num_hidden_layers,
+            index_topk_freq=getattr(config, "index_topk_freq", 1),
+            index_topk_pattern=getattr(config, "index_topk_pattern", None),
+            index_skip_topk_offset=getattr(config, "index_skip_topk_offset", 2),
+            local_start_layer=start_layer,
+            local_end_layer=end_layer,
+        )
+        local_index_cache_skip_flags = index_cache_skip_flags[start_layer:end_layer]
+        local_uses_index_cache = any(local_index_cache_skip_flags)
+        _validate_dsv4_index_cache_platform(local_uses_index_cache)
+        _validate_dsv4_index_cache_ubatching(local_uses_index_cache, vllm_config)
+        self.index_cache_skipped_layer_ids = frozenset(
+            layer_id
+            for layer_id, skip in enumerate(
+                index_cache_skip_flags[start_layer:end_layer], start=start_layer
+            )
+            if skip
+        )
 
         if get_pp_group().is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
@@ -1011,6 +1072,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 prefix=prefix,
                 topk_indices_buffer=self.topk_indices_buffer,
                 aux_stream_list=aux_stream_list,
+                skip_topk=index_cache_skip_flags[extract_layer_index(prefix)],
             ),
             prefix=f"{prefix}.layers",
         )
@@ -1472,6 +1534,13 @@ class DeepseekV4ForCausalLM(
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self, skip_substrs=["mtp."])
+        skipped_layer_ids = self.model.index_cache_skipped_layer_ids
+        if skipped_layer_ids:
+            weights = (
+                (name, weight)
+                for name, weight in weights
+                if not _is_dsv4_skipped_indexer_weight(name, skipped_layer_ids)
+            )
         loaded_params = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
         self.model.finalize_mega_moe_weights()
         self.model.finalize_mhc_broadcast_weights()

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -19,6 +19,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
 )
 from vllm.distributed.eplb.eplb_state import EplbLayerState
+from vllm.distributed.utils import get_pp_indices
 from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.logger import init_logger
 from vllm.model_executor.kernels.mhc.tilelang import (
@@ -75,7 +76,10 @@ from vllm.models.common.ops.sequence_parallel import (
     sp_reduce_scatter,
     sp_shard,
 )
-from vllm.models.deepseek_v4.attention import DeepseekV4Attention
+from vllm.models.deepseek_v4.attention import (
+    DeepseekV4Attention,
+    compute_dsv4_index_cache_skip_flags,
+)
 from vllm.models.deepseek_v4.nvidia.flashinfer_sparse import (
     DeepseekV4FlashInferMLAAttention,
     DeepseekV4FlashInferSM120Attention,
@@ -1063,6 +1067,36 @@ def _use_sequence_parallel(vllm_config: VllmConfig) -> bool:
     )
 
 
+def _validate_dsv4_index_cache_platform(skip_topk: bool) -> None:
+    if not skip_topk:
+        return
+    device_capability = current_platform.get_device_capability()
+    if device_capability is None or device_capability.major != 9:
+        raise NotImplementedError(
+            "DeepSeek V4 IndexCache is currently supported only on Hopper "
+            "(SM90). Set index_topk_freq=1 or run on H100/H200."
+        )
+
+
+def _validate_dsv4_index_cache_ubatching(skip_topk: bool, vllm_config) -> None:
+    if not skip_topk or not vllm_config.parallel_config.use_ubatching:
+        return
+    raise NotImplementedError(
+        "DeepSeek V4 IndexCache does not support ubatching yet because "
+        "skipped layers reuse a shared topk_indices_buffer. Set "
+        "index_topk_freq=1 or disable DBO/ubatching."
+    )
+
+
+def _is_dsv4_skipped_indexer_weight(
+    weight_name: str, skipped_layer_ids: frozenset[int]
+) -> bool:
+    return any(
+        f"layers.{layer_id}.attn.indexer." in weight_name
+        for layer_id in skipped_layer_ids
+    )
+
+
 class DeepseekV4DecoderLayer(nn.Module):
     def __init__(
         self,
@@ -1070,6 +1104,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         prefix,
         topk_indices_buffer: torch.Tensor | None = None,
         aux_stream_list: list[torch.cuda.Stream] | None = None,
+        skip_topk: bool = False,
     ):
         super().__init__()
 
@@ -1083,6 +1118,7 @@ class DeepseekV4DecoderLayer(nn.Module):
             prefix=f"{prefix}.attn",
             topk_indices_buffer=topk_indices_buffer,
             aux_stream_list=aux_stream_list,
+            skip_topk=skip_topk,
         )
         if self.use_sequence_parallel:
             self.attn.wo_b.reduce_results = False
@@ -1275,6 +1311,31 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             config.index_topk,
             dtype=torch.int32,
         )
+        start_layer, end_layer = get_pp_indices(
+            config.num_hidden_layers,
+            get_pp_group().rank_in_group,
+            get_pp_group().world_size,
+        )
+        index_cache_skip_flags = compute_dsv4_index_cache_skip_flags(
+            config.compress_ratios,
+            config.num_hidden_layers,
+            index_topk_freq=getattr(config, "index_topk_freq", 1),
+            index_topk_pattern=getattr(config, "index_topk_pattern", None),
+            index_skip_topk_offset=getattr(config, "index_skip_topk_offset", 2),
+            local_start_layer=start_layer,
+            local_end_layer=end_layer,
+        )
+        local_index_cache_skip_flags = index_cache_skip_flags[start_layer:end_layer]
+        local_uses_index_cache = any(local_index_cache_skip_flags)
+        _validate_dsv4_index_cache_platform(local_uses_index_cache)
+        _validate_dsv4_index_cache_ubatching(local_uses_index_cache, vllm_config)
+        self.index_cache_skipped_layer_ids = frozenset(
+            layer_id
+            for layer_id, skip in enumerate(
+                index_cache_skip_flags[start_layer:end_layer], start=start_layer
+            )
+            if skip
+        )
 
         if get_pp_group().is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
@@ -1293,6 +1354,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 prefix=prefix,
                 topk_indices_buffer=self.topk_indices_buffer,
                 aux_stream_list=aux_stream_list,
+                skip_topk=index_cache_skip_flags[extract_layer_index(prefix)],
             ),
             prefix=f"{prefix}.layers",
         )
@@ -1812,6 +1874,13 @@ class DeepseekV4ForCausalLM(
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
+        skipped_layer_ids = self.model.index_cache_skipped_layer_ids
+        if skipped_layer_ids:
+            weights = (
+                (name, weight)
+                for name, weight in weights
+                if not _is_dsv4_skipped_indexer_weight(name, skipped_layer_ids)
+            )
         loaded_params = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
         self.process_weights_after_loading()
         return loaded_params

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1874,13 +1874,16 @@ class DeepseekV4ForCausalLM(
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
-        # skipped_layer_ids = self.model.index_cache_skipped_layer_ids
-        # if skipped_layer_ids:
-        #     weights = (
-        #         (name, weight)
-        #         for name, weight in weights
-        #         if not _is_dsv4_skipped_indexer_weight(name, skipped_layer_ids)
-        #     )
+        # skip_topk layers carry their indexer GEMM weights (wq_b /
+        # weights_proj / compressor KV projection) on the meta device; the
+        # checkpoint still ships them, so filter them out before loading.
+        skipped_layer_ids = self.model.index_cache_skipped_layer_ids
+        if skipped_layer_ids:
+            weights = (
+                (name, weight)
+                for name, weight in weights
+                if not _is_dsv4_skipped_indexer_weight(name, skipped_layer_ids)
+            )
         loaded_params = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
         self.process_weights_after_loading()
         return loaded_params

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1874,13 +1874,13 @@ class DeepseekV4ForCausalLM(
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
-        skipped_layer_ids = self.model.index_cache_skipped_layer_ids
-        if skipped_layer_ids:
-            weights = (
-                (name, weight)
-                for name, weight in weights
-                if not _is_dsv4_skipped_indexer_weight(name, skipped_layer_ids)
-            )
+        # skipped_layer_ids = self.model.index_cache_skipped_layer_ids
+        # if skipped_layer_ids:
+        #     weights = (
+        #         (name, weight)
+        #         for name, weight in weights
+        #         if not _is_dsv4_skipped_indexer_weight(name, skipped_layer_ids)
+        #     )
         loaded_params = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
         self.process_weights_after_loading()
         return loaded_params


### PR DESCRIPTION
## Purpose

Co-authored-by: @zzz3bbb3

Add IndexCache support for DeepSeek V4 sparse MLA C4 layers.

DeepSeek V4 C4 layers use sparse MLA indexer top-k selection. Adjacent C4 layers can reuse selected top-k indices to avoid recomputing the sparse indexer on every C4 layer. This PR adds static layer-selection logic for C4 layers, keeps non-C4 layers unchanged, and preserves full top-k computation where required for correctness.

IndexCache is enabled only when the model config, or `hf_overrides`, sets `index_topk_freq > 1` or provides `index_topk_pattern`. The default `index_topk_freq=1` keeps existing behavior and recomputes top-k for every C4
layer.

The implementation also handles pipeline-parallel local stages by forcing each PP rank's first local C4 layer to compute full top-k, filters skipped indexer weights at load time, and rejects unsupported DBO/ubatching usage with IndexCache.

This PR addresses #45350. I searched the current vLLM repository and have not found an existing PR that implements IndexCache for DeepSeek V4 on Hopper. If another PR lands before this one with the same feature scope, this PR will be closed.

### Follow-up fix and attribution

Thanks to @zzz3bbb3 for identifying that skipped C4 layers must still register their indexer KV-cache specs in #49286.

I adapted the fix and meta-device initialization approach from zzz3bbb3/vllm@823cf00 into this PR. Skipped indexers now preserve the required KV-cache structure while keeping their unused linear weights on the meta device.

## Test Plan

Hardware:

- Single server with H20 * 8 GPUs

Software:

- Image: vllm/vllm-openai:v0.25.1-x86_64-ubuntu2404
- Model: DeepSeek-V4-Flash

vLLM serve command:

```bash
vllm serve /data00/models/DeepSeek-V4-Flash \
  --host 0.0.0.0 \
  --port 8000 \
  --served-model-name deepseek-v4-flash \
  --trust-remote-code \
  --tokenizer-mode deepseek_v4 \
  --tool-call-parser deepseek_v4 \
  --enable-auto-tool-choice \
  --reasoning-parser deepseek_v4 \
  --kv-cache-dtype fp8 \
  --block-size 256 \
  --data-parallel-size 1 \
  --tensor-parallel-size 8 \
  --max-model-len 8192 \
  --max-num-batched-tokens 8192 \
  --max-num-seqs 80 \
  --gpu-memory-utilization 0.85 \
  --renderer-num-workers 4 \
  --api-server-count 1 \
  --moe-backend auto \
  --all2all-backend deepep_high_throughput \
  --speculative-config '{"method":"mtp","num_speculative_tokens":1}' \
  --hf-overrides '{"index_topk_freq":4}' \
  --aggregate-engine-logging \
  --enable-expert-parallel \
  --enforce-eager \
  --no-disable-hybrid-kv-cache-manager \
  --disable-uvicorn-access-log
```

Benchmark command, where `N` is the concurrency:

```bash
env NO_PROXY="*" no_proxy="*" vllm bench serve \
  --backend vllm \
  --base-url http://deepseek-v4-flash-single-node:8000 \
  --endpoint /v1/completions \
  --model /data/models/DeepSeek-V4-Flash \
  --served-model-name deepseek-v4-flash \
  --tokenizer /data/models/DeepSeek-V4-Flash \
  --tokenizer-mode deepseek_v4 \
  --trust-remote-code \
  --dataset-name prefix_repetition \
  --prefix-repetition-num-prefixes 1 \
  --prefix-repetition-prefix-len 3500 \
  --prefix-repetition-suffix-len 64 \
  --prefix-repetition-output-len 1500 \
  --num-prompts $((2 * N)) \
  --max-concurrency N \
  --request-rate inf \
  --temperature 0 \
  --ignore-eos \
  --percentile-metrics ttft,tpot,itl \
  --save-result \
  --save-detailed
```


## Test Result

Performance benchmark:

| Concurrency | Num prompts | Baseline output tok/s | IndexCache output tok/s | Change | Baseline TTFT ms | IndexCache TTFT ms | Baseline TPOT ms | IndexCache TPOT ms |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 4 | 8 | 62.57 | 68.19 | +8.99% | 378.72 | 333.25 | 62.66 | 57.64 |
| 8 | 16 | 124.40 | 130.94 | +5.26% | 461.06 | 424.92 | 62.42 | 58.67 |
| 16 | 32 | 223.02 | 241.44 | +8.26% | 577.03 | 532.13 | 69.83 | 63.70 |
| 32 | 64 | 437.83 | 462.01 | +5.52% | 802.98 | 802.31 | 70.43 | 65.05 |
| 64 | 128 | 866.55 | 910.10 | +5.03% | 1107.26 | 1095.27 | 70.64 | 65.19 |

Full GSM8K and GPQA:

| Config | GSM8K flexible | GSM8K strict |
| --- | ---: | ---: |
| IndexCache on (`index_topk_freq=4`) | 0.9545 ± 0.0057 | 0.9553 ± 0.0057 |
| IndexCache off | 0.9560 ± 0.0056 | 0.9568 ± 0.0056 |
| Delta (on - off) | -0.0015 | -0.0015 |
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

