### PR TITLE
[ROCm][feature] Add new moe backends supporting int4/int8 weight-only…

### DIFF
--- a/tests/kernels/quantization/test_int4_emulation_moe.py
+++ b/tests/kernels/quantization/test_int4_emulation_moe.py
@@ -3,10 +3,17 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Correctness tests for Int4EmulationTritonExperts MoE backend.
 
-Tests the weight dequantization helpers (_unpack_and_dequant_int4_gptq,
-_unpack_and_dequant_int4_awq) and full MoE forward pass
-(_process_weights_emulation_gptq, _process_weights_emulation_awq)
-for both symmetric and asymmetric zero-point cases.
+Int4EmulationTritonExperts is one of the fallback backends under EMULATION
+(after TritonWNA16OTFExperts). It handles kInt4Static, kInt4Static32,
+kInt4StaticAsym, and kInt4Static32Asym (GPTQ/AWQ int4, sym and asym).
+Weights are dequantized from packed int4 to BF16 once at load time.
+
+Tests:
+  - _unpack_and_dequant_int4_gptq/_int4_awq: vs reference dequant
+  - _process_weights_emulation_gptq/_awq: output shapes and values
+  - End-to-end forward: sym and asym (GPTQ/AWQ) vs float reference, EP
+  - _supports_quant_scheme: int4 accepted, int8 and unquantized rejected
+  - Position within EMULATION backend: comes after TritonWNA16OTFExperts
 
 Run `pytest tests/kernels/quantization/test_int4_emulation_moe.py`.
 """
@@ -35,12 +42,17 @@ from vllm.model_executor.layers.fused_moe.oracle.int_wna16 import (
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     awq_pack,
     gptq_pack,
+    kInt4Static,
+    kInt4Static32,
+    kInt4Static32Asym,
+    kInt4StaticAsym,
+    kInt8Static,
 )
 from vllm.platforms import current_platform
 
 pytestmark = pytest.mark.skipif(
     not current_platform.is_cuda_alike(),
-    reason="Int4EmulationTritonExperts requires CUDA.",
+    reason="Int4EmulationTritonExperts requires CUDA/ROCm.",
 )
 
 device = "cuda"
@@ -634,6 +646,8 @@ def test_gptq_vs_awq_forward_agree(E, K, N, top_k, group_size, num_tokens):
     w13_gptq, w2_gptq = gptq_res[0], gptq_res[1]
     w13_awq, w2_awq = awq_res[0], awq_res[1]
 
+    # Int4EmulationTritonExperts nulls out scale fields in __init__;
+    # dummy value is fine since weights are already dequantized before apply().
     dummy_scale = torch.ones(1, dtype=torch.float16, device=device)
     experts_gptq = Int4EmulationTritonExperts(
         moe_config, int4_w4a16_moe_quant_config(dummy_scale, dummy_scale)
@@ -964,7 +978,7 @@ def test_ep_partial_rank_no_active_experts(
     )
     w13_all, w2_all = res[0], res[1]
 
-    # Force topk_ids to only use experts in [0, num_local) — rank 0's slice
+    # Force topk_ids to only use experts in [0, num_local) -- rank 0's slice
     topk_ids = torch.zeros(num_tokens, top_k, dtype=torch.int32, device=device)
     topk_weights = torch.softmax(
         torch.randn(num_tokens, top_k, dtype=torch.float32, device=device), dim=-1
@@ -1186,4 +1200,136 @@ def test_emulation_output_close_to_bf16_reference(
         torch.norm(out_emulation.float() - ref.float())
         / torch.norm(ref.float()).clamp(min=1e-6)
     ).item()
-    assert rel_l2 < 0.15, f"[{fmt}] relative L2 = {rel_l2:.4f} (threshold 0.15)"
+    # 1% threshold: weights are already dequantized to BF16 before the kernel,
+    # so the only error source is BF16 GEMM reduction order vs the reference loop.
+    assert rel_l2 < 0.01, f"[{fmt}] relative L2 = {rel_l2:.4f} (threshold 0.01)"
+
+
+@pytest.mark.parametrize("E, K, N, top_k, group_size, num_tokens", E2E_CONFIGS)
+@pytest.mark.parametrize("fmt", ["gptq", "awq"])
+def test_emulation_asym_output_close_to_bf16_reference(
+    E, K, N, top_k, group_size, num_tokens, fmt
+):
+    """Asym emulation output is close to a direct BF16 MoE forward."""
+    torch.manual_seed(12)
+    moe_config = _make_moe_config(E, K, N)
+
+    w13_fp = torch.randn(E, K, 2 * N, dtype=torch.bfloat16, device=device) * 0.02
+    w2_fp = torch.randn(E, N, K, dtype=torch.bfloat16, device=device) * 0.02
+
+    packed13_list, scales13_list, zeros13_list = [], [], []
+    packed2_list, scales2_list, zeros2_list = [], [], []
+    for e in range(E):
+        q13, s13, z13 = _quantize_asym(w13_fp[e].float(), group_size)
+        q2, s2, z2 = _quantize_asym(w2_fp[e].float(), group_size)
+        if fmt == "gptq":
+            packed13_list.append(gptq_pack(q13, 4, K, 2 * N))
+            packed2_list.append(gptq_pack(q2, 4, N, K))
+            zeros13_list.append(_pack_gptq_zeros(z13, 2 * N))
+            zeros2_list.append(_pack_gptq_zeros(z2, K))
+        else:
+            packed13_list.append(awq_pack(q13, 4, K, 2 * N))
+            packed2_list.append(awq_pack(q2, 4, N, K))
+            zeros13_list.append(_pack_awq_zeros(z13, 2 * N))
+            zeros2_list.append(_pack_awq_zeros(z2, K))
+        scales13_list.append(s13)
+        scales2_list.append(s2)
+
+    process_fn = (
+        _process_weights_emulation_gptq
+        if fmt == "gptq"
+        else _process_weights_emulation_awq
+    )
+    res = process_fn(
+        torch.stack(packed13_list),
+        torch.stack(packed2_list),
+        torch.stack(scales13_list),
+        torch.stack(scales2_list),
+        torch.stack(zeros13_list),
+        torch.stack(zeros2_list),
+    )
+    w13_bf16, w2_bf16 = res[0], res[1]
+
+    # Int4EmulationTritonExperts nulls out scale fields; dummy value is fine.
+    dummy_scale = torch.ones(1, dtype=torch.float16, device=device)
+    experts = Int4EmulationTritonExperts(
+        moe_config, int4_w4a16_moe_quant_config(dummy_scale, dummy_scale)
+    )
+
+    hidden_states = torch.randn(num_tokens, K, dtype=torch.bfloat16, device=device)
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, top_k, dtype=torch.float32, device=device), dim=-1
+    )
+    topk_ids = torch.stack(
+        [torch.randperm(E, device=device)[:top_k] for _ in range(num_tokens)]
+    ).to(torch.int32)
+
+    out_emulation = _run_emulation_forward(
+        experts, w13_bf16, w2_bf16, hidden_states, topk_weights, topk_ids, E, K, N
+    )
+
+    ref = torch.zeros(num_tokens, K, dtype=torch.bfloat16, device=device)
+    for m in range(num_tokens):
+        acc = torch.zeros(K, dtype=torch.float32, device=device)
+        for k in range(top_k):
+            e = topk_ids[m, k].item()
+            w = topk_weights[m, k].item()
+            gate_up = hidden_states[m] @ w13_bf16[e].T
+            gate, up = gate_up.chunk(2)
+            act = F.silu(gate) * up
+            acc += w * (act @ w2_bf16[e].T).float()
+        ref[m] = acc.bfloat16()
+
+    rel_l2 = (
+        torch.norm(out_emulation.float() - ref.float())
+        / torch.norm(ref.float()).clamp(min=1e-6)
+    ).item()
+    # 1% threshold: weights are already dequantized to BF16 before the kernel,
+    # so the only error source is BF16 GEMM reduction order vs the reference loop.
+    assert rel_l2 < 0.01, f"[{fmt} asym] relative L2 = {rel_l2:.4f} (threshold 0.01)"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _supports_quant_scheme
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "wk,ak,expected",
+    [
+        (kInt4Static, None, True),  # GPTQ int4 sym
+        (kInt4Static32, None, True),  # GPTQ int4 sym gs=32
+        (kInt4StaticAsym, None, True),  # GPTQ/AWQ int4 asym
+        (kInt4Static32Asym, None, True),  # int4 asym gs=32
+        (kInt8Static, None, False),  # int8: handled by Int8Emulation, not here
+        (None, None, False),  # unquantized: not supported
+        (kInt4Static, kInt4Static, False),  # W4A4: not supported
+    ],
+)
+def test_supports_quant_scheme(wk, ak, expected):
+    assert Int4EmulationTritonExperts._supports_quant_scheme(wk, ak) == expected
+
+
+# ---------------------------------------------------------------------------
+# Tests: position within EMULATION backend
+# ---------------------------------------------------------------------------
+
+
+def test_int4_emulation_position_in_emulation_backend():
+    """Int4EmulationTritonExperts must come after TritonWNA16OTFExperts in EMULATION."""
+    from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
+        TritonWNA16OTFExperts,
+    )
+    from vllm.model_executor.layers.fused_moe.oracle.int_wna16 import (
+        WNA16MoEBackend,
+        backend_to_kernel_cls,
+    )
+
+    classes = backend_to_kernel_cls(WNA16MoEBackend.EMULATION)
+    assert Int4EmulationTritonExperts in classes
+    idx_int4 = classes.index(Int4EmulationTritonExperts)
+    idx_otf = classes.index(TritonWNA16OTFExperts)
+    assert idx_otf < idx_int4, (
+        f"TritonWNA16OTFExperts (idx={idx_otf}) must precede "
+        f"Int4EmulationTritonExperts (idx={idx_int4})"
+    )

--- a/tests/kernels/quantization/test_int8_emulation_moe.py
+++ b/tests/kernels/quantization/test_int8_emulation_moe.py
@@ -1,0 +1,641 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness tests for Int8EmulationTritonExperts MoE backend.
+
+Int8EmulationTritonExperts is a fallback under the EMULATION backend,
+after TritonWNA16OTFExperts. It handles kInt8Static (GPTQ int8 symmetric)
+only -- no AWQ, no asymmetric.
+Weights are dequantized from packed int8 to BF16/FP16 once at load time.
+
+Tests:
+  - _unpack_and_dequant_int8_gptq: PyTorch and Triton paths vs reference
+  - _process_weights_emulation_int8: output shapes and values
+  - End-to-end forward: vs dequantized reference and vs original float weights
+  - _supports_quant_scheme: int8 accepted, int4 and W4A4 rejected
+  - Position within EMULATION backend: comes after TritonWNA16OTFExperts
+
+Run `pytest tests/kernels/quantization/test_int8_emulation_moe.py`.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEConfig,
+    FusedMoEParallelConfig,
+    RoutingMethodType,
+    int8_w8a16_moe_quant_config,
+)
+from vllm.model_executor.layers.fused_moe.experts.int8_emulation_moe import (
+    Int8EmulationTritonExperts,
+)
+from vllm.model_executor.layers.fused_moe.oracle.int_wna16 import (
+    _process_weights_emulation_int8,
+    _unpack_and_dequant_int8_gptq,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    gptq_pack,
+    kInt4Static,
+    kInt8Static,
+)
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Int8EmulationTritonExperts requires CUDA/ROCm.",
+)
+
+device = "cuda"
+
+# (E, K, N, group_size)
+SHAPES = [
+    pytest.param(2, 64, 32, 32, id="tiny-gs32"),
+    pytest.param(4, 128, 64, 64, id="small-gs64"),
+    pytest.param(4, 256, 128, 128, id="medium-gs128"),
+]
+
+E2E_CONFIGS = [
+    pytest.param(4, 64, 32, 2, 32, 8, id="tiny"),
+    pytest.param(8, 128, 64, 2, 64, 16, id="small"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _quantize_sym_int8(w_fp: torch.Tensor, group_size: int):
+    """Quantize [K, N] float to int8 symmetric (uint8b128).
+
+    Returns:
+        q:     [K, N] int32, values in [0, 255]  (uint8b128: val + 128)
+        scale: [K//gs, N] float16
+    """
+    K, N = w_fp.shape
+    assert K % group_size == 0
+    n_groups = K // group_size
+    w_grouped = w_fp.reshape(n_groups, group_size, N)
+    scale = w_grouped.abs().amax(dim=1) / 127.0
+    scale = scale.clamp(min=1e-6)
+    w_quant = (w_grouped / scale.unsqueeze(1)).round().clamp(-128, 127)
+    q = (w_quant + 128).to(torch.int32).reshape(K, N)
+    return q, scale.to(torch.float16)
+
+
+def _dequantize_ref_int8(
+    q: torch.Tensor,
+    scale: torch.Tensor,
+    output_dtype: torch.dtype = torch.bfloat16,
+):
+    """Reference dequant for a single [K, N] int8 slice.
+
+    Multiplies in float32 then casts, matching both the PyTorch fallback
+    and the Triton kernel arithmetic exactly.
+    """
+    K, N = q.shape
+    n_groups = scale.shape[0]
+    group_size = K // n_groups
+    w = q.reshape(n_groups, group_size, N).to(torch.float32)
+    s = scale.unsqueeze(1).to(torch.float32)
+    return ((w - 128) * s).to(output_dtype).reshape(K, N)
+
+
+def _pack_int8_gptq(q: torch.Tensor, K: int, N: int) -> torch.Tensor:
+    """Pack [K, N] int32 (uint8 values 0-255) into [K//4, N] int32."""
+    return gptq_pack(q, 8, K, N)
+
+
+def _make_moe_config(E, K, N, in_dtype=torch.bfloat16):
+    return FusedMoEConfig(
+        num_experts=E,
+        experts_per_token=2,
+        hidden_dim=K,
+        intermediate_size=N,
+        num_local_experts=E,
+        num_logical_experts=E,
+        moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
+        activation=MoEActivation.SILU,
+        in_dtype=in_dtype,
+        device=device,
+        routing_method=RoutingMethodType.TopK,
+        max_num_tokens=512,
+    )
+
+
+def _make_int8_moe_weights(E, K, N, group_size, output_dtype=torch.bfloat16):
+    """Build w13/w2 in GPTQ int8 MoE format and return float references."""
+    torch.manual_seed(5)
+    w13_fp = torch.randn(E, K, 2 * N, dtype=torch.float16, device=device)
+    w2_fp = torch.randn(E, N, K, dtype=torch.float16, device=device)
+
+    w13_list, w13s_list, w13_ref_list = [], [], []
+    w2_list, w2s_list, w2_ref_list = [], [], []
+
+    for e in range(E):
+        q13, s13 = _quantize_sym_int8(w13_fp[e], group_size)
+        w13_list.append(_pack_int8_gptq(q13, K, 2 * N))
+        w13s_list.append(s13)
+        w13_ref_list.append(_dequantize_ref_int8(q13, s13, output_dtype))
+
+        q2, s2 = _quantize_sym_int8(w2_fp[e], group_size)
+        w2_list.append(_pack_int8_gptq(q2, N, K))
+        w2s_list.append(s2)
+        w2_ref_list.append(_dequantize_ref_int8(q2, s2, output_dtype))
+
+    return (
+        torch.stack(w13_list),
+        torch.stack(w13s_list),
+        torch.stack(w13_ref_list),  # [E, K, 2N]
+        torch.stack(w2_list),
+        torch.stack(w2s_list),
+        torch.stack(w2_ref_list),  # [E, N, K]
+    )
+
+
+def _run_emulation_forward(
+    experts, w13_out, w2_out, hidden_states, topk_weights, topk_ids, E, K, N
+):
+    ws13_size = hidden_states.shape[0] * topk_ids.shape[1] * max(N, K)
+    ws2_size = hidden_states.shape[0] * topk_ids.shape[1] * max(2 * N, K)
+    workspace13 = torch.zeros(ws13_size, dtype=hidden_states.dtype, device=device)
+    workspace2 = torch.zeros(ws2_size, dtype=hidden_states.dtype, device=device)
+    output = torch.zeros(
+        hidden_states.shape[0], K, dtype=hidden_states.dtype, device=device
+    )
+    experts.apply(
+        output=output,
+        hidden_states=hidden_states,
+        w1=w13_out,
+        w2=w2_out,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=MoEActivation.SILU,
+        global_num_experts=E,
+        expert_map=None,
+        a1q_scale=None,
+        a2_scale=None,
+        workspace13=workspace13,
+        workspace2=workspace2,
+        expert_tokens_meta=None,
+        apply_router_weight_on_input=False,
+    )
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Tests: _unpack_and_dequant_int8_gptq (PyTorch path vs reference)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("E, K, N, group_size", SHAPES)
+def test_unpack_int8_symmetric_values(E, K, N, group_size):
+    """PyTorch unpacker produces values matching the per-expert reference."""
+    torch.manual_seed(0)
+    w_fp = torch.randn(E, K, N, dtype=torch.float16, device=device)
+
+    packed_list, scale_list, ref_list = [], [], []
+    for e in range(E):
+        q, s = _quantize_sym_int8(w_fp[e], group_size)
+        packed_list.append(_pack_int8_gptq(q, K, N))
+        scale_list.append(s)
+        ref_list.append(_dequantize_ref_int8(q, s, torch.float32))
+
+    w_packed = torch.stack(packed_list)
+    scale = torch.stack(scale_list)
+    ref = torch.stack(ref_list)
+
+    out = _unpack_and_dequant_int8_gptq(
+        w_packed,
+        scale,
+        transpose_output=False,
+        output_dtype=torch.float32,
+        force_torch=True,
+    )
+
+    assert out.shape == (E, K, N)
+    assert torch.allclose(out, ref, atol=0), (
+        f"max diff: {(out - ref).abs().max().item()}"
+    )
+
+
+@pytest.mark.parametrize("E, K, N, group_size", SHAPES)
+def test_unpack_int8_transpose_output(E, K, N, group_size):
+    """transpose_output=True gives [E, N, K] with correct values."""
+    torch.manual_seed(1)
+    w_fp = torch.randn(E, K, N, dtype=torch.float16, device=device)
+
+    packed_list, scale_list = [], []
+    for e in range(E):
+        q, s = _quantize_sym_int8(w_fp[e], group_size)
+        packed_list.append(_pack_int8_gptq(q, K, N))
+        scale_list.append(s)
+
+    w_packed = torch.stack(packed_list)
+    scale = torch.stack(scale_list)
+
+    out_normal = _unpack_and_dequant_int8_gptq(
+        w_packed, scale, False, torch.float32, force_torch=True
+    )
+    out_transposed = _unpack_and_dequant_int8_gptq(
+        w_packed, scale, True, torch.float32, force_torch=True
+    )
+
+    assert out_transposed.shape == (E, N, K)
+    assert torch.allclose(
+        out_transposed, out_normal.permute(0, 2, 1).contiguous(), atol=0
+    )
+
+
+@pytest.mark.parametrize(
+    "output_dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"]
+)
+def test_unpack_int8_output_dtype(output_dtype):
+    """Output dtype is honoured."""
+    E, K, N, gs = 2, 64, 32, 32
+    torch.manual_seed(2)
+    w_fp = torch.randn(E, K, N, dtype=torch.float16, device=device)
+    packed_list, scale_list = [], []
+    for e in range(E):
+        q, s = _quantize_sym_int8(w_fp[e], gs)
+        packed_list.append(_pack_int8_gptq(q, K, N))
+        scale_list.append(s)
+    out = _unpack_and_dequant_int8_gptq(
+        torch.stack(packed_list),
+        torch.stack(scale_list),
+        False,
+        output_dtype,
+        force_torch=True,
+    )
+    assert out.dtype == output_dtype
+
+
+# ---------------------------------------------------------------------------
+# Tests: Triton vs PyTorch agreement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("E, K, N, group_size", SHAPES)
+@pytest.mark.parametrize(
+    "output_dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"]
+)
+def test_triton_matches_torch(E, K, N, group_size, output_dtype):
+    """Triton and PyTorch unpackers produce bit-identical results."""
+    torch.manual_seed(3)
+    w_fp = torch.randn(E, K, N, dtype=torch.float16, device=device)
+
+    packed_list, scale_list = [], []
+    for e in range(E):
+        q, s = _quantize_sym_int8(w_fp[e], group_size)
+        packed_list.append(_pack_int8_gptq(q, K, N))
+        scale_list.append(s)
+
+    w_packed = torch.stack(packed_list)
+    scale = torch.stack(scale_list)
+
+    out_torch = _unpack_and_dequant_int8_gptq(
+        w_packed, scale, False, output_dtype, force_torch=True
+    )
+    out_triton = _unpack_and_dequant_int8_gptq(
+        w_packed, scale, False, output_dtype, force_torch=False
+    )
+
+    assert out_triton.shape == out_torch.shape
+    assert out_triton.dtype == output_dtype
+    assert torch.allclose(out_triton, out_torch, atol=0), (
+        f"max diff: {(out_triton - out_torch).abs().max().item()}"
+    )
+
+
+@pytest.mark.parametrize("E, K, N, group_size", SHAPES)
+def test_triton_transpose_matches_torch(E, K, N, group_size):
+    """Triton transposed output matches PyTorch transposed output."""
+    torch.manual_seed(4)
+    w_fp = torch.randn(E, K, N, dtype=torch.float16, device=device)
+
+    packed_list, scale_list = [], []
+    for e in range(E):
+        q, s = _quantize_sym_int8(w_fp[e], group_size)
+        packed_list.append(_pack_int8_gptq(q, K, N))
+        scale_list.append(s)
+
+    w_packed = torch.stack(packed_list)
+    scale = torch.stack(scale_list)
+
+    out_torch = _unpack_and_dequant_int8_gptq(
+        w_packed, scale, True, torch.bfloat16, force_torch=True
+    )
+    out_triton = _unpack_and_dequant_int8_gptq(
+        w_packed, scale, True, torch.bfloat16, force_torch=False
+    )
+
+    assert out_triton.shape == (E, N, K)
+    assert torch.allclose(out_triton, out_torch, atol=0), (
+        f"max diff: {(out_triton - out_torch).abs().max().item()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: _process_weights_emulation_int8
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("E, K, N, group_size", SHAPES)
+@pytest.mark.parametrize(
+    "output_dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"]
+)
+def test_process_weights_int8_shapes_and_values(E, K, N, group_size, output_dtype):
+    """Output shapes match TritonExperts layout and values match reference."""
+    w13, w13s, w13_ref, w2, w2s, w2_ref = _make_int8_moe_weights(
+        E, K, N, group_size, output_dtype
+    )
+
+    result = _process_weights_emulation_int8(
+        w13, w2, w13s, w2s, output_dtype=output_dtype
+    )
+    w13_out, w2_out = result[0], result[1]
+
+    assert w13_out.shape == (E, 2 * N, K), f"w13 shape: {w13_out.shape}"
+    assert w2_out.shape == (E, K, N), f"w2 shape: {w2_out.shape}"
+    assert w13_out.dtype == output_dtype
+    assert w2_out.dtype == output_dtype
+
+    expected_w13 = w13_ref.permute(0, 2, 1)
+    expected_w2 = w2_ref.permute(0, 2, 1)
+
+    assert torch.allclose(w13_out, expected_w13, atol=1e-2), (
+        f"w13 max diff: {(w13_out - expected_w13).abs().max().item()}"
+    )
+    assert torch.allclose(w2_out, expected_w2, atol=1e-2), (
+        f"w2 max diff: {(w2_out - expected_w2).abs().max().item()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end MoE forward pass tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("E, K, N, top_k, group_size, num_tokens", E2E_CONFIGS)
+@pytest.mark.parametrize(
+    "model_dtype", [torch.bfloat16, torch.float16], ids=["bf16", "fp16"]
+)
+def test_int8_emulation_forward_close_to_reference(
+    E, K, N, top_k, group_size, num_tokens, model_dtype
+):
+    """Emulation output is close to a direct float dense MoE forward."""
+    torch.manual_seed(10)
+    moe_config = _make_moe_config(E, K, N, model_dtype)
+
+    w13_fp = torch.randn(E, K, 2 * N, dtype=torch.float16, device=device) * 0.02
+    w2_fp = torch.randn(E, N, K, dtype=torch.float16, device=device) * 0.02
+
+    packed_list13, scale_list13 = [], []
+    packed_list2, scale_list2 = [], []
+    for e in range(E):
+        q13, s13 = _quantize_sym_int8(w13_fp[e], group_size)
+        packed_list13.append(_pack_int8_gptq(q13, K, 2 * N))
+        scale_list13.append(s13)
+        q2, s2 = _quantize_sym_int8(w2_fp[e], group_size)
+        packed_list2.append(_pack_int8_gptq(q2, N, K))
+        scale_list2.append(s2)
+
+    res = _process_weights_emulation_int8(
+        torch.stack(packed_list13),
+        torch.stack(packed_list2),
+        torch.stack(scale_list13),
+        torch.stack(scale_list2),
+        output_dtype=model_dtype,
+    )
+    w13_out, w2_out = res[0], res[1]
+
+    # Int8EmulationTritonExperts nulls out scale fields in __init__ since
+    # weights are already dequantized before apply(); dummy value is fine.
+    dummy_scale = torch.ones(1, dtype=torch.float16, device=device)
+    quant_cfg = int8_w8a16_moe_quant_config(dummy_scale, dummy_scale)
+    experts = Int8EmulationTritonExperts(moe_config, quant_cfg)
+
+    hidden_states = torch.randn(num_tokens, K, dtype=model_dtype, device=device)
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, top_k, dtype=torch.float32, device=device),
+        dim=-1,
+    )
+    topk_ids = torch.stack(
+        [torch.randperm(E, device=device)[:top_k] for _ in range(num_tokens)]
+    ).to(torch.int32)
+
+    out_emulation = _run_emulation_forward(
+        experts,
+        w13_out,
+        w2_out,
+        hidden_states,
+        topk_weights,
+        topk_ids,
+        E,
+        K,
+        N,
+    )
+
+    # Dense reference using the dequantized BF16 weights directly
+    ref = torch.zeros(num_tokens, K, dtype=model_dtype, device=device)
+    for m in range(num_tokens):
+        acc = torch.zeros(K, dtype=torch.float32, device=device)
+        for k in range(top_k):
+            e = topk_ids[m, k].item()
+            w = topk_weights[m, k].item()
+            gate_up = hidden_states[m] @ w13_out[e].T
+            gate, up = gate_up.chunk(2)
+            act = F.silu(gate) * up
+            acc += w * (act @ w2_out[e].T).float()
+        ref[m] = acc.to(model_dtype)
+
+    rel_l2 = (
+        torch.norm(out_emulation.float() - ref.float())
+        / torch.norm(ref.float()).clamp(min=1e-6)
+    ).item()
+    assert rel_l2 < 0.01, f"[{model_dtype}] relative L2 = {rel_l2:.4f} (threshold 0.01)"
+
+
+@pytest.mark.parametrize("E, K, N, top_k, group_size, num_tokens", E2E_CONFIGS)
+def test_int8_emulation_fp16_bf16_agree(E, K, N, top_k, group_size, num_tokens):
+    """FP16 and BF16 emulation produce close outputs for the same weights."""
+    torch.manual_seed(11)
+
+    w13_fp = torch.randn(E, K, 2 * N, dtype=torch.float16, device=device) * 0.02
+    w2_fp = torch.randn(E, N, K, dtype=torch.float16, device=device) * 0.02
+
+    packed_list13, scale_list13 = [], []
+    packed_list2, scale_list2 = [], []
+    for e in range(E):
+        q13, s13 = _quantize_sym_int8(w13_fp[e], group_size)
+        packed_list13.append(_pack_int8_gptq(q13, K, 2 * N))
+        scale_list13.append(s13)
+        q2, s2 = _quantize_sym_int8(w2_fp[e], group_size)
+        packed_list2.append(_pack_int8_gptq(q2, N, K))
+        scale_list2.append(s2)
+
+    w13_packed = torch.stack(packed_list13)
+    w13_scales = torch.stack(scale_list13)
+    w2_packed = torch.stack(packed_list2)
+    w2_scales = torch.stack(scale_list2)
+
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, top_k, dtype=torch.float32, device=device),
+        dim=-1,
+    )
+    topk_ids = torch.stack(
+        [torch.randperm(E, device=device)[:top_k] for _ in range(num_tokens)]
+    ).to(torch.int32)
+
+    # Sample hidden_states once in float32, cast to each dtype -- both runs
+    # see the same input values so the diff measures only dtype arithmetic.
+    hidden_states_f32 = torch.randn(num_tokens, K, dtype=torch.float32, device=device)
+
+    outputs = {}
+    for dtype in (torch.bfloat16, torch.float16):
+        res = _process_weights_emulation_int8(
+            w13_packed,
+            w2_packed,
+            w13_scales,
+            w2_scales,
+            output_dtype=dtype,
+        )
+        # dummy scale: nulled out by Int8EmulationTritonExperts.__init__
+        dummy_scale = torch.ones(1, dtype=torch.float16, device=device)
+        quant_cfg = int8_w8a16_moe_quant_config(dummy_scale, dummy_scale)
+        experts = Int8EmulationTritonExperts(
+            _make_moe_config(E, K, N, dtype), quant_cfg
+        )
+        outputs[dtype] = _run_emulation_forward(
+            experts,
+            res[0],
+            res[1],
+            hidden_states_f32.to(dtype),
+            topk_weights,
+            topk_ids,
+            E,
+            K,
+            N,
+        ).float()
+
+    rel_l2 = (
+        torch.norm(outputs[torch.bfloat16] - outputs[torch.float16])
+        / torch.norm(outputs[torch.bfloat16]).clamp(min=1e-6)
+    ).item()
+    assert rel_l2 < 0.01, f"bf16 vs fp16 relative L2 = {rel_l2:.4f} (threshold 0.01)"
+
+
+@pytest.mark.parametrize("E, K, N, top_k, group_size, num_tokens", E2E_CONFIGS)
+def test_int8_emulation_output_close_to_float_weights(
+    E, K, N, top_k, group_size, num_tokens
+):
+    """Emulation output is close to a forward using the original float weights."""
+    torch.manual_seed(15)
+    moe_config = _make_moe_config(E, K, N)
+
+    w13_fp = torch.randn(E, K, 2 * N, dtype=torch.float32, device=device) * 0.02
+    w2_fp = torch.randn(E, N, K, dtype=torch.float32, device=device) * 0.02
+
+    packed_list13, scale_list13 = [], []
+    packed_list2, scale_list2 = [], []
+    for e in range(E):
+        q13, s13 = _quantize_sym_int8(w13_fp[e], group_size)
+        packed_list13.append(_pack_int8_gptq(q13, K, 2 * N))
+        scale_list13.append(s13)
+        q2, s2 = _quantize_sym_int8(w2_fp[e], group_size)
+        packed_list2.append(_pack_int8_gptq(q2, N, K))
+        scale_list2.append(s2)
+
+    res = _process_weights_emulation_int8(
+        torch.stack(packed_list13),
+        torch.stack(packed_list2),
+        torch.stack(scale_list13),
+        torch.stack(scale_list2),
+        output_dtype=torch.bfloat16,
+    )
+    w13_out, w2_out = res[0], res[1]
+
+    # Int8EmulationTritonExperts nulls out scale fields; dummy value is fine.
+    dummy_scale = torch.ones(1, dtype=torch.float16, device=device)
+    quant_cfg = int8_w8a16_moe_quant_config(dummy_scale, dummy_scale)
+    experts = Int8EmulationTritonExperts(moe_config, quant_cfg)
+
+    hidden_states = torch.randn(num_tokens, K, dtype=torch.bfloat16, device=device)
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, top_k, dtype=torch.float32, device=device), dim=-1
+    )
+    topk_ids = torch.stack(
+        [torch.randperm(E, device=device)[:top_k] for _ in range(num_tokens)]
+    ).to(torch.int32)
+
+    out_emulation = _run_emulation_forward(
+        experts, w13_out, w2_out, hidden_states, topk_weights, topk_ids, E, K, N
+    )
+
+    # Reference: dense forward with original float32 weights (no quantization).
+    ref = torch.zeros(num_tokens, K, dtype=torch.float32, device=device)
+    for m in range(num_tokens):
+        acc = torch.zeros(K, dtype=torch.float32, device=device)
+        for k in range(top_k):
+            e = topk_ids[m, k].item()
+            w = topk_weights[m, k].item()
+            gate_up = hidden_states[m].float() @ w13_fp[e]  # [K] @ [K, 2N] = [2N]
+            gate, up = gate_up.chunk(2)
+            act = F.silu(gate) * up
+            acc += w * (act @ w2_fp[e])  # [N] @ [N, K] = [K]
+        ref[m] = acc
+
+    rel_l2 = (
+        torch.norm(out_emulation.float() - ref) / torch.norm(ref).clamp(min=1e-6)
+    ).item()
+    # 5% threshold: int8 quantization error is ~0.4% per layer; two GEMM layers
+    # accumulate to ~1-2% rel_l2 at group_size=32..128 for these small sizes.
+    assert rel_l2 < 0.05, (
+        f"int8 emulation vs float weights rel_l2={rel_l2:.4f} (threshold 0.05)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: _supports_quant_scheme
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "wk,ak,expected",
+    [
+        (kInt8Static, None, True),  # int8 GPTQ symmetric: supported
+        (kInt4Static, None, False),  # int4: handled by OTF or Int4Emulation, not here
+        (kInt8Static, kInt8Static, False),  # W8A8: not supported (W-only)
+        (None, None, False),  # unquantized: not supported
+    ],
+)
+def test_supports_quant_scheme(wk, ak, expected):
+    assert Int8EmulationTritonExperts._supports_quant_scheme(wk, ak) == expected
+
+
+# ---------------------------------------------------------------------------
+# Tests: position within EMULATION backend
+# ---------------------------------------------------------------------------
+
+
+def test_int8_emulation_position_in_emulation_backend():
+    """Int8EmulationTritonExperts must come after TritonWNA16OTFExperts in EMULATION."""
+    from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
+        TritonWNA16OTFExperts,
+    )
+    from vllm.model_executor.layers.fused_moe.oracle.int_wna16 import (
+        WNA16MoEBackend,
+        backend_to_kernel_cls,
+    )
+
+    classes = backend_to_kernel_cls(WNA16MoEBackend.EMULATION)
+    assert Int8EmulationTritonExperts in classes
+    idx_int8 = classes.index(Int8EmulationTritonExperts)
+    idx_otf = classes.index(TritonWNA16OTFExperts)
+    assert idx_otf < idx_int8, (
+        f"TritonWNA16OTFExperts (idx={idx_otf}) must precede "
+        f"Int8EmulationTritonExperts (idx={idx_int8})"
+    )

--- a/tests/kernels/quantization/test_triton_wna16_otf_moe.py
+++ b/tests/kernels/quantization/test_triton_wna16_otf_moe.py
@@ -1,0 +1,1143 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness tests for TritonWNA16OTFExperts MoE backend.
+
+TritonWNA16OTFExperts keeps weights in packed int4/int8 format and dequantizes
+on-the-fly each forward pass (unlike Int4/Int8EmulationTritonExperts which
+dequantize at load time to BF16).  Tests verify:
+
+  - _process_weights_triton_wna16: weight layout for GPTQ/AWQ, sym and asym.
+  - End-to-end forward: GPTQ sym/asym, AWQ sym/asym, int8 GPTQ sym vs reference.
+  - EP correctness: expert_map output matches full forward.
+  - TritonWNA16OTFExperts._supports_* returns correct values.
+  - make_group_size_adjusted_weight_loader: w2 scale expansion, w13/weight passthrough.
+  - OTF forward when N % group_size != 0 (e.g. N=192, gs=128, tp=8).
+
+Run: pytest tests/kernels/quantization/test_triton_wna16_otf_moe.py
+"""
+
+import numpy
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEConfig,
+    FusedMoEParallelConfig,
+    RoutingMethodType,
+    int4_w4a16_moe_quant_config,
+)
+from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
+    TritonWNA16OTFExperts,
+)
+from vllm.model_executor.layers.fused_moe.oracle.int_wna16 import (
+    _process_weights_emulation_awq,
+    _process_weights_emulation_gptq,
+    _process_weights_emulation_int8,
+    _process_weights_triton_wna16,
+    make_group_size_adjusted_weight_loader,
+)
+from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    awq_pack,
+    gptq_pack,
+    kInt4Static,
+    kInt4Static32,
+    kInt4Static32Asym,
+    kInt4StaticAsym,
+    kInt8Static,
+)
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="TritonWNA16OTFExperts requires CUDA/ROCm.",
+)
+
+device = "cuda"
+
+# (E, K, N, group_size)
+SHAPES_LIST = [
+    pytest.param(2, 64, 32, 32, id="tiny-gs32"),
+    pytest.param(4, 128, 64, 64, id="small-gs64"),
+    pytest.param(4, 256, 128, 128, id="medium-gs128"),
+]
+
+# (E, K, N, top_k, group_size, num_tokens)
+E2E_CONFIGS_LIST = [
+    pytest.param(4, 64, 32, 2, 32, 8, id="tiny"),
+    pytest.param(8, 128, 64, 2, 64, 16, id="small"),
+]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _quantize_sym_int4(w_fp: torch.Tensor, group_size: int):
+    K, N = w_fp.shape
+    assert K % group_size == 0
+    n_groups = K // group_size
+    w_grouped = w_fp.reshape(n_groups, group_size, N)
+    scale = w_grouped.abs().amax(dim=1) / 7.0
+    scale = scale.clamp(min=1e-6)
+    w_quant = (w_grouped / scale.unsqueeze(1)).round().clamp(-8, 7)
+    q = (w_quant + 8).to(torch.int32).reshape(K, N)
+    return q, scale.to(torch.float16)
+
+
+def _quantize_asym_int4(w_fp: torch.Tensor, group_size: int):
+    K, N = w_fp.shape
+    assert K % group_size == 0
+    n_groups = K // group_size
+    w_grouped = w_fp.reshape(n_groups, group_size, N)
+    wmin = w_grouped.amin(dim=1)
+    wmax = w_grouped.amax(dim=1)
+    scale = (wmax - wmin) / 15.0
+    scale = scale.clamp(min=1e-6)
+    zero = (-wmin / scale).round().clamp(0, 15).to(torch.int32)
+    w_quant = ((w_grouped - wmin.unsqueeze(1)) / scale.unsqueeze(1)).round()
+    q = w_quant.clamp(0, 15).to(torch.int32).reshape(K, N)
+    return q, scale.to(torch.float16), zero
+
+
+def _dequantize_ref_int4(w_uint, scale, zero=None, output_dtype=torch.bfloat16):
+    K, N = w_uint.shape
+    n_groups = scale.shape[0]
+    gs = K // n_groups
+    w = w_uint.reshape(n_groups, gs, N).to(output_dtype)
+    s = scale.unsqueeze(1).to(output_dtype)
+    if zero is None:
+        return ((w - 8) * s).reshape(K, N)
+    z = zero.unsqueeze(1).to(output_dtype)
+    return ((w - z) * s).reshape(K, N)
+
+
+def _pack_gptq_zeros(zero: torch.Tensor, N: int) -> torch.Tensor:
+    n_groups, _ = zero.shape
+    z = zero.to(torch.int32).cpu().numpy().astype(numpy.uint32)
+    packed = numpy.zeros((n_groups, N // 8), dtype=numpy.uint32)
+    for i in range(8):
+        packed |= z[:, i::8] << (i * 4)
+    return torch.from_numpy(packed.astype(numpy.int32)).to(device)
+
+
+def _pack_awq_zeros(zero: torch.Tensor, N: int) -> torch.Tensor:
+    n_groups, _ = zero.shape
+    interleave = numpy.array([0, 2, 4, 6, 1, 3, 5, 7])
+    z = zero.to(torch.int32).cpu().numpy().astype(numpy.uint32)
+    z_interleaved = z.reshape(-1, 8)[:, interleave].reshape(n_groups, N)
+    packed = numpy.zeros((n_groups, N // 8), dtype=numpy.uint32)
+    for i in range(8):
+        packed |= z_interleaved[:, i::8] << (i * 4)
+    return torch.from_numpy(packed.astype(numpy.int32)).to(device)
+
+
+def _make_moe_config(E, K, N):
+    return FusedMoEConfig(
+        num_experts=E,
+        experts_per_token=2,
+        hidden_dim=K,
+        intermediate_size=N,
+        num_local_experts=E,
+        num_logical_experts=E,
+        moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
+        activation=MoEActivation.SILU,
+        in_dtype=torch.bfloat16,
+        device=device,
+        routing_method=RoutingMethodType.TopK,
+        max_num_tokens=512,
+    )
+
+
+class _FakeGPTQConfig:
+    """Minimal quant config stub for _process_weights_triton_wna16 (int4)."""
+
+    weight_bits = 4
+    num_bits = 4
+
+
+class _FakeGPTQInt8Config:
+    """Minimal quant config stub for _process_weights_triton_wna16 (int8)."""
+
+    weight_bits = 8
+    num_bits = 8
+
+
+def _make_gptq_tensors(E, K, N, group_size, asym=False):
+    """Build GPTQ-format w13/w2 tensors [E, K//8, 2N] int32."""
+    torch.manual_seed(42)
+    w13_fp = torch.randn(E, K, 2 * N, dtype=torch.float16, device=device) * 0.1
+    w2_fp = torch.randn(E, N, K, dtype=torch.float16, device=device) * 0.1
+
+    w13_list, w13s_list, w13z_list = [], [], []
+    w2_list, w2s_list, w2z_list = [], [], []
+
+    for e in range(E):
+        if asym:
+            q13, s13, z13 = _quantize_asym_int4(w13_fp[e], group_size)
+            q2, s2, z2 = _quantize_asym_int4(w2_fp[e], group_size)
+            w13z_list.append(_pack_gptq_zeros(z13, 2 * N))  # [gs, 2N//8]
+            w2z_list.append(_pack_gptq_zeros(z2, K))  # [gs, K//8]
+        else:
+            q13, s13 = _quantize_sym_int4(w13_fp[e], group_size)
+            q2, s2 = _quantize_sym_int4(w2_fp[e], group_size)
+        w13_list.append(gptq_pack(q13, 4, K, 2 * N))  # [K//8, 2N]
+        w13s_list.append(s13)  # [K//gs, 2N]
+        w2_list.append(gptq_pack(q2, 4, N, K))  # [N//8, K]
+        w2s_list.append(s2)  # [N//gs, K]
+
+    w13 = torch.stack(w13_list)
+    w2 = torch.stack(w2_list)
+    w13_scale = torch.stack(w13s_list)
+    w2_scale = torch.stack(w2s_list)
+    w13_qzeros = torch.stack(w13z_list) if asym else None
+    w2_qzeros = torch.stack(w2z_list) if asym else None
+    return w13, w2, w13_scale, w2_scale, w13_qzeros, w2_qzeros, w13_fp, w2_fp
+
+
+def _make_awq_config(group_size: int, zero_point: bool) -> AutoAWQConfig:
+    return AutoAWQConfig(
+        weight_bits=4,
+        group_size=group_size,
+        zero_point=zero_point,
+        lm_head_quantized=False,
+    )
+
+
+def _make_awq_tensors(E, K, N, group_size, asym=False):
+    """Build AWQ-format w13/w2 tensors and float references.
+
+    AWQ packs along N: w13 [E, K, 2N//8] int32, w2 [E, N, K//8] int32.
+    Scales are column-parallel: w13_scale [E, K//gs, 2N], w2_scale [E, N//gs, K].
+    """
+    torch.manual_seed(43)
+    w13_fp = torch.randn(E, K, 2 * N, dtype=torch.float16, device=device) * 0.1
+    w2_fp = torch.randn(E, N, K, dtype=torch.float16, device=device) * 0.1
+
+    w13_list, w13s_list, w13z_list = [], [], []
+    w2_list, w2s_list, w2z_list = [], [], []
+
+    for e in range(E):
+        if asym:
+            q13, s13, z13 = _quantize_asym_int4(w13_fp[e], group_size)
+            q2, s2, z2 = _quantize_asym_int4(w2_fp[e], group_size)
+            w13z_list.append(_pack_awq_zeros(z13, 2 * N))
+            w2z_list.append(_pack_awq_zeros(z2, K))
+        else:
+            q13, s13 = _quantize_sym_int4(w13_fp[e], group_size)
+            q2, s2 = _quantize_sym_int4(w2_fp[e], group_size)
+        w13_list.append(awq_pack(q13, 4, K, 2 * N))  # [K, 2N//8]
+        w13s_list.append(s13)  # [K//gs, 2N]
+        w2_list.append(awq_pack(q2, 4, N, K))  # [N, K//8]
+        w2s_list.append(s2)  # [N//gs, K]
+
+    w13 = torch.stack(w13_list)
+    w2 = torch.stack(w2_list)
+    w13_scale = torch.stack(w13s_list)
+    w2_scale = torch.stack(w2s_list)
+    w13_qzeros = torch.stack(w13z_list) if asym else None
+    w2_qzeros = torch.stack(w2z_list) if asym else None
+    return w13, w2, w13_scale, w2_scale, w13_qzeros, w2_qzeros, w13_fp, w2_fp
+
+
+def _quantize_sym_int8(w_fp: torch.Tensor, group_size: int):
+    """Quantize [K, N] float to int8 symmetric (uint8b128)."""
+    K, N = w_fp.shape
+    assert K % group_size == 0
+    n_groups = K // group_size
+    w_grouped = w_fp.reshape(n_groups, group_size, N)
+    scale = w_grouped.abs().amax(dim=1) / 127.0
+    scale = scale.clamp(min=1e-6)
+    w_quant = (w_grouped / scale.unsqueeze(1)).round().clamp(-128, 127)
+    q = (w_quant + 128).to(torch.int32).reshape(K, N)
+    return q, scale.to(torch.float16)
+
+
+def _make_gptq_int8_tensors(E, K, N, group_size):
+    """Build GPTQ-format int8 w13/w2 tensors."""
+    torch.manual_seed(44)
+    w13_fp = torch.randn(E, K, 2 * N, dtype=torch.float32, device=device) * 0.1
+    w2_fp = torch.randn(E, N, K, dtype=torch.float32, device=device) * 0.1
+
+    w13_list, w13s_list = [], []
+    w2_list, w2s_list = [], []
+    for e in range(E):
+        q13, s13 = _quantize_sym_int8(w13_fp[e], group_size)
+        w13_list.append(gptq_pack(q13, 8, K, 2 * N))
+        w13s_list.append(s13)
+        q2, s2 = _quantize_sym_int8(w2_fp[e], group_size)
+        w2_list.append(gptq_pack(q2, 8, N, K))
+        w2s_list.append(s2)
+
+    return (
+        torch.stack(w13_list),
+        torch.stack(w2_list),
+        torch.stack(w13s_list),
+        torch.stack(w2s_list),
+        w13_fp,
+        w2_fp,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: _supports_* static methods
+# ---------------------------------------------------------------------------
+
+
+def test_supports_current_device():
+    assert TritonWNA16OTFExperts._supports_current_device()
+
+
+@pytest.mark.parametrize(
+    "wk,ak,expected",
+    [
+        (kInt4Static, None, True),
+        (kInt4Static32, None, True),
+        (kInt4StaticAsym, None, True),
+        (kInt4Static32Asym, None, True),
+        (kInt8Static, None, True),
+        (None, None, False),  # unquantized not supported
+        (kInt4Static, kInt4Static, False),  # W4A4 not supported
+    ],
+)
+def test_supports_quant_scheme(wk, ak, expected):
+    assert TritonWNA16OTFExperts._supports_quant_scheme(wk, ak) == expected
+
+
+def test_supports_no_act_and_mul():
+    assert TritonWNA16OTFExperts._supports_no_act_and_mul() is True
+
+
+def test_supports_activation():
+    assert TritonWNA16OTFExperts._supports_activation(MoEActivation.SILU) is True
+    assert TritonWNA16OTFExperts._supports_activation(MoEActivation.GELU) is True
+    assert TritonWNA16OTFExperts._supports_activation(MoEActivation.GELU_TANH) is True
+    assert TritonWNA16OTFExperts._supports_activation(MoEActivation.SWIGLUOAI) is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: _process_weights_triton_wna16 layout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("E, K, N, group_size", SHAPES_LIST)
+def test_gptq_sym_weight_layout(E, K, N, group_size):
+    """GPTQ sym: repacked w1/w2 have correct shape and dtype."""
+    w13, w2, w13_scale, w2_scale, w13_qzeros, w2_qzeros, _, _ = _make_gptq_tensors(
+        E, K, N, group_size, asym=False
+    )
+
+    result = _process_weights_triton_wna16(
+        _FakeGPTQConfig(), w13, w2, w13_scale, w2_scale, None, None
+    )
+    w1_out, w2_out, s1_out, s2_out = result[0], result[1], result[2], result[3]
+
+    # Kernel expects [E, 2*N, K//2] uint8 and [E, K, N//2] uint8
+    assert w1_out.shape == (E, 2 * N, K // 2), f"w1 shape: {w1_out.shape}"
+    assert w2_out.shape == (E, K, N // 2), f"w2 shape: {w2_out.shape}"
+    assert w1_out.dtype == torch.uint8
+    assert w2_out.dtype == torch.uint8
+    # Scales transposed: [E, 2*N, K//gs] and [E, K, N//gs]
+    assert s1_out.shape == (E, 2 * N, K // group_size)
+    assert s2_out.shape == (E, K, N // group_size)
+    # No zero points for symmetric
+    assert result[8] is None
+    assert result[9] is None
+
+
+@pytest.mark.parametrize("E, K, N, group_size", SHAPES_LIST)
+def test_gptq_asym_weight_layout(E, K, N, group_size):
+    """GPTQ asym: repacked w1/w2 and zero points have correct shapes."""
+    w13, w2, w13_scale, w2_scale, w13_qzeros, w2_qzeros, _, _ = _make_gptq_tensors(
+        E, K, N, group_size, asym=True
+    )
+
+    result = _process_weights_triton_wna16(
+        _FakeGPTQConfig(), w13, w2, w13_scale, w2_scale, w13_qzeros, w2_qzeros
+    )
+    w1_out, w2_out = result[0], result[1]
+    w1_zp, w2_zp = result[8], result[9]
+
+    assert w1_out.shape == (E, 2 * N, K // 2)
+    assert w2_out.shape == (E, K, N // 2)
+    # Zero points: [E, 2*N//2, K//gs] = [E, N, K//gs]
+    assert w1_zp is not None and w1_zp.dtype == torch.uint8
+    assert w2_zp is not None and w2_zp.dtype == torch.uint8
+    assert w1_zp.shape == (E, N, K // group_size), f"w1_zp shape: {w1_zp.shape}"
+    assert w2_zp.shape == (E, K // 2, N // group_size), f"w2_zp shape: {w2_zp.shape}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _process_weights_triton_wna16 layout (AWQ)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("E, K, N, group_size", SHAPES_LIST)
+def test_awq_sym_weight_layout(E, K, N, group_size):
+    """AWQ sym: repacked w1/w2 have correct shape and dtype."""
+    w13, w2, w13_scale, w2_scale, _, _, _, _ = _make_awq_tensors(
+        E, K, N, group_size, asym=False
+    )
+    result = _process_weights_triton_wna16(
+        _make_awq_config(group_size, zero_point=False),
+        w13,
+        w2,
+        w13_scale,
+        w2_scale,
+        None,
+        None,
+    )
+    w1_out, w2_out, s1_out, s2_out = result[0], result[1], result[2], result[3]
+
+    assert w1_out.shape == (E, 2 * N, K // 2), f"w1 shape: {w1_out.shape}"
+    assert w2_out.shape == (E, K, N // 2), f"w2 shape: {w2_out.shape}"
+    assert w1_out.dtype == torch.uint8
+    assert w2_out.dtype == torch.uint8
+    assert s1_out.shape == (E, 2 * N, K // group_size)
+    assert s2_out.shape == (E, K, N // group_size)
+    assert result[8] is None
+    assert result[9] is None
+
+
+@pytest.mark.parametrize("E, K, N, group_size", SHAPES_LIST)
+def test_awq_asym_weight_layout(E, K, N, group_size):
+    """AWQ asym: repacked w1/w2 and zero points have correct shapes."""
+    w13, w2, w13_scale, w2_scale, w13_qzeros, w2_qzeros, _, _ = _make_awq_tensors(
+        E, K, N, group_size, asym=True
+    )
+    result = _process_weights_triton_wna16(
+        _make_awq_config(group_size, zero_point=True),
+        w13,
+        w2,
+        w13_scale,
+        w2_scale,
+        w13_qzeros,
+        w2_qzeros,
+    )
+    w1_out, w2_out = result[0], result[1]
+    w1_zp, w2_zp = result[8], result[9]
+
+    assert w1_out.shape == (E, 2 * N, K // 2)
+    assert w2_out.shape == (E, K, N // 2)
+    assert w1_zp is not None and w1_zp.dtype == torch.uint8
+    assert w2_zp is not None and w2_zp.dtype == torch.uint8
+    assert w1_zp.shape == (E, N, K // group_size), f"w1_zp shape: {w1_zp.shape}"
+    assert w2_zp.shape == (E, K // 2, N // group_size), f"w2_zp shape: {w2_zp.shape}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: OTF forward matches emulation reference
+# ---------------------------------------------------------------------------
+
+
+def _run_otf_forward(
+    experts,
+    w1_out,
+    w2_out,
+    w1_scale,
+    w2_scale,
+    w1_zp,
+    w2_zp,
+    group_size,
+    hidden_states,
+    topk_weights,
+    topk_ids,
+    E,
+    K,
+    N,
+):
+    """Run TritonWNA16OTFExperts.apply() and return output."""
+    ws13_size = hidden_states.shape[0] * topk_ids.shape[1] * max(N, K)
+    ws2_size = hidden_states.shape[0] * topk_ids.shape[1] * max(2 * N, K)
+    workspace13 = torch.zeros(ws13_size, dtype=hidden_states.dtype, device=device)
+    workspace2 = torch.zeros(ws2_size, dtype=hidden_states.dtype, device=device)
+    output = torch.zeros(
+        hidden_states.shape[0], K, dtype=hidden_states.dtype, device=device
+    )
+    experts.apply(
+        output=output,
+        hidden_states=hidden_states,
+        w1=w1_out,
+        w2=w2_out,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=MoEActivation.SILU,
+        global_num_experts=E,
+        expert_map=None,
+        a1q_scale=None,
+        a2_scale=None,
+        workspace13=workspace13,
+        workspace2=workspace2,
+        expert_tokens_meta=None,
+        apply_router_weight_on_input=False,
+    )
+    return output
+
+
+@pytest.mark.parametrize("E, K, N, top_k, group_size, num_tokens", E2E_CONFIGS_LIST)
+def test_otf_forward_matches_emulation_sym(E, K, N, top_k, group_size, num_tokens):
+    """OTF sym forward matches Int4Emulation reference output."""
+    w13, w2, w13_scale, w2_scale, _, _, w13_fp, w2_fp = _make_gptq_tensors(
+        E, K, N, group_size, asym=False
+    )
+
+    # Emulation: dequantize at load, use BF16 weights
+    emul_result = _process_weights_emulation_gptq(
+        w13, w2, w13_scale, w2_scale, None, None, output_dtype=torch.bfloat16
+    )
+    w13_bf16, w2_bf16 = emul_result[0], emul_result[1]
+    # w13_bf16: [E, 2N, K], w2_bf16: [E, K, N]
+
+    # OTF: keep quantized, build quant config for kernel
+    otf_result = _process_weights_triton_wna16(
+        _FakeGPTQConfig(), w13, w2, w13_scale, w2_scale, None, None
+    )
+    w1_out, w2_out = otf_result[0], otf_result[1]
+    s1_out, s2_out = otf_result[2], otf_result[3]
+
+    moe_config = _make_moe_config(E, K, N)
+    quant_cfg = int4_w4a16_moe_quant_config(
+        w1_scale=s1_out,
+        w2_scale=s2_out,
+        block_shape=[0, group_size],
+    )
+    experts = TritonWNA16OTFExperts(moe_config, quant_cfg)
+
+    torch.manual_seed(0)
+    hidden_states = torch.randn(num_tokens, K, dtype=torch.bfloat16, device=device)
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, top_k, dtype=torch.float32, device=device), dim=-1
+    )
+    topk_ids = torch.stack(
+        [torch.randperm(E, device=device)[:top_k] for _ in range(num_tokens)]
+    ).to(torch.int32)
+
+    out_otf = _run_otf_forward(
+        experts,
+        w1_out,
+        w2_out,
+        s1_out,
+        s2_out,
+        None,
+        None,
+        group_size,
+        hidden_states,
+        topk_weights,
+        topk_ids,
+        E,
+        K,
+        N,
+    )
+
+    # Reference: dense float32 forward using the dequantized BF16 weights.
+    # This is the ground truth -- it avoids kernel-vs-kernel numerical differences
+    # and tests only quantization error (which for int4 gs=32..128 should be small).
+    ref = torch.zeros(num_tokens, K, dtype=torch.float32, device=device)
+    # w13_bf16: [E, 2N, K], w2_bf16: [E, K, N]
+    for m in range(num_tokens):
+        acc = torch.zeros(K, dtype=torch.float32, device=device)
+        for k in range(top_k):
+            e = topk_ids[m, k].item()
+            w = topk_weights[m, k].item()
+            gate_up = hidden_states[m].float() @ w13_bf16[e].float().T  # [2N]
+            gate, up = gate_up.chunk(2)
+            act = F.silu(gate) * up  # [N]
+            acc += w * (act @ w2_bf16[e].float().T)  # [K]
+        ref[m] = acc
+
+    rel_l2 = (
+        torch.norm(out_otf.float() - ref) / torch.norm(ref).clamp(min=1e-6)
+    ).item()
+    # 1% threshold: reflects int4 quantization error only. Tighter than the
+    # raw quantization noise bound (~0.5% for K=64) to catch numerical bugs.
+    assert rel_l2 < 0.01, f"OTF vs float32 ref rel_l2={rel_l2:.4f} (threshold 0.01)"
+
+
+@pytest.mark.parametrize("E, K, N, top_k, group_size, num_tokens", E2E_CONFIGS_LIST)
+def test_otf_forward_matches_emulation_asym_gptq(
+    E, K, N, top_k, group_size, num_tokens
+):
+    """OTF asym GPTQ forward matches Int4Emulation dequant reference."""
+    w13, w2, w13_scale, w2_scale, w13_qzeros, w2_qzeros, _, _ = _make_gptq_tensors(
+        E, K, N, group_size, asym=True
+    )
+
+    emul_result = _process_weights_emulation_gptq(
+        w13,
+        w2,
+        w13_scale,
+        w2_scale,
+        w13_qzeros,
+        w2_qzeros,
+        output_dtype=torch.bfloat16,
+    )
+    w13_bf16, w2_bf16 = emul_result[0], emul_result[1]
+
+    otf_result = _process_weights_triton_wna16(
+        _FakeGPTQConfig(), w13, w2, w13_scale, w2_scale, w13_qzeros, w2_qzeros
+    )
+    w1_out, w2_out = otf_result[0], otf_result[1]
+    s1_out, s2_out = otf_result[2], otf_result[3]
+    zp1_out, zp2_out = otf_result[8], otf_result[9]
+
+    moe_config = _make_moe_config(E, K, N)
+    quant_cfg = int4_w4a16_moe_quant_config(
+        w1_scale=s1_out,
+        w2_scale=s2_out,
+        w1_zp=zp1_out,
+        w2_zp=zp2_out,
+        block_shape=[0, group_size],
+    )
+    experts = TritonWNA16OTFExperts(moe_config, quant_cfg)
+
+    torch.manual_seed(2)
+    hidden_states = torch.randn(num_tokens, K, dtype=torch.bfloat16, device=device)
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, top_k, dtype=torch.float32, device=device), dim=-1
+    )
+    topk_ids = torch.stack(
+        [torch.randperm(E, device=device)[:top_k] for _ in range(num_tokens)]
+    ).to(torch.int32)
+
+    out_otf = _run_otf_forward(
+        experts,
+        w1_out,
+        w2_out,
+        s1_out,
+        s2_out,
+        zp1_out,
+        zp2_out,
+        group_size,
+        hidden_states,
+        topk_weights,
+        topk_ids,
+        E,
+        K,
+        N,
+    )
+
+    ref = torch.zeros(num_tokens, K, dtype=torch.float32, device=device)
+    for m in range(num_tokens):
+        acc = torch.zeros(K, dtype=torch.float32, device=device)
+        for k in range(top_k):
+            e = topk_ids[m, k].item()
+            w = topk_weights[m, k].item()
+            gate_up = hidden_states[m].float() @ w13_bf16[e].float().T
+            gate, up = gate_up.chunk(2)
+            act = F.silu(gate) * up
+            acc += w * (act @ w2_bf16[e].float().T)
+        ref[m] = acc
+
+    rel_l2 = (
+        torch.norm(out_otf.float() - ref) / torch.norm(ref).clamp(min=1e-6)
+    ).item()
+    assert rel_l2 < 0.01, f"asym GPTQ OTF vs ref rel_l2={rel_l2:.4f} (threshold 0.01)"
+
+
+@pytest.mark.parametrize("E, K, N, top_k, group_size, num_tokens", E2E_CONFIGS_LIST)
+@pytest.mark.parametrize("asym", [False, True], ids=["sym", "asym"])
+def test_otf_forward_matches_emulation_awq(
+    E, K, N, top_k, group_size, num_tokens, asym
+):
+    """OTF AWQ forward (sym and asym) matches Int4Emulation dequant reference."""
+    w13, w2, w13_scale, w2_scale, w13_qzeros, w2_qzeros, _, _ = _make_awq_tensors(
+        E, K, N, group_size, asym=asym
+    )
+
+    emul_result = _process_weights_emulation_awq(
+        w13,
+        w2,
+        w13_scale,
+        w2_scale,
+        w13_qzeros if asym else None,
+        w2_qzeros if asym else None,
+        output_dtype=torch.bfloat16,
+    )
+    w13_bf16, w2_bf16 = emul_result[0], emul_result[1]
+
+    otf_result = _process_weights_triton_wna16(
+        _make_awq_config(group_size, zero_point=asym),
+        w13,
+        w2,
+        w13_scale,
+        w2_scale,
+        w13_qzeros if asym else None,
+        w2_qzeros if asym else None,
+    )
+    w1_out, w2_out = otf_result[0], otf_result[1]
+    s1_out, s2_out = otf_result[2], otf_result[3]
+    zp1_out, zp2_out = otf_result[8], otf_result[9]
+
+    moe_config = _make_moe_config(E, K, N)
+    quant_cfg = int4_w4a16_moe_quant_config(
+        w1_scale=s1_out,
+        w2_scale=s2_out,
+        w1_zp=zp1_out,
+        w2_zp=zp2_out,
+        block_shape=[0, group_size],
+    )
+    experts = TritonWNA16OTFExperts(moe_config, quant_cfg)
+
+    torch.manual_seed(3)
+    hidden_states = torch.randn(num_tokens, K, dtype=torch.bfloat16, device=device)
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, top_k, dtype=torch.float32, device=device), dim=-1
+    )
+    topk_ids = torch.stack(
+        [torch.randperm(E, device=device)[:top_k] for _ in range(num_tokens)]
+    ).to(torch.int32)
+
+    out_otf = _run_otf_forward(
+        experts,
+        w1_out,
+        w2_out,
+        s1_out,
+        s2_out,
+        zp1_out,
+        zp2_out,
+        group_size,
+        hidden_states,
+        topk_weights,
+        topk_ids,
+        E,
+        K,
+        N,
+    )
+
+    ref = torch.zeros(num_tokens, K, dtype=torch.float32, device=device)
+    for m in range(num_tokens):
+        acc = torch.zeros(K, dtype=torch.float32, device=device)
+        for k in range(top_k):
+            e = topk_ids[m, k].item()
+            w = topk_weights[m, k].item()
+            gate_up = hidden_states[m].float() @ w13_bf16[e].float().T
+            gate, up = gate_up.chunk(2)
+            act = F.silu(gate) * up
+            acc += w * (act @ w2_bf16[e].float().T)
+        ref[m] = acc
+
+    rel_l2 = (
+        torch.norm(out_otf.float() - ref) / torch.norm(ref).clamp(min=1e-6)
+    ).item()
+    label = "asym" if asym else "sym"
+    assert rel_l2 < 0.01, f"AWQ {label} OTF vs ref rel_l2={rel_l2:.4f} (threshold 0.01)"
+
+
+@pytest.mark.parametrize("E, K, N, top_k, group_size, num_tokens", E2E_CONFIGS_LIST)
+def test_otf_int8_forward_matches_emulation(E, K, N, top_k, group_size, num_tokens):
+    """OTF int8 forward matches Int8Emulation dequant reference."""
+    w13, w2, w13_scale, w2_scale, w13_fp, w2_fp = _make_gptq_int8_tensors(
+        E, K, N, group_size
+    )
+
+    emul_result = _process_weights_emulation_int8(
+        w13, w2, w13_scale, w2_scale, output_dtype=torch.bfloat16
+    )
+    w13_bf16, w2_bf16 = emul_result[0], emul_result[1]
+
+    otf_result = _process_weights_triton_wna16(
+        _FakeGPTQInt8Config(), w13, w2, w13_scale, w2_scale, None, None
+    )
+    w1_out, w2_out = otf_result[0], otf_result[1]
+    s1_out, s2_out = otf_result[2], otf_result[3]
+
+    from vllm.model_executor.layers.fused_moe.config import int8_w8a16_moe_quant_config
+
+    moe_config = _make_moe_config(E, K, N)
+    quant_cfg = int8_w8a16_moe_quant_config(
+        w1_scale=s1_out, w2_scale=s2_out, block_shape=[0, group_size]
+    )
+    experts = TritonWNA16OTFExperts(moe_config, quant_cfg)
+
+    torch.manual_seed(4)
+    hidden_states = torch.randn(num_tokens, K, dtype=torch.bfloat16, device=device)
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, top_k, dtype=torch.float32, device=device), dim=-1
+    )
+    topk_ids = torch.stack(
+        [torch.randperm(E, device=device)[:top_k] for _ in range(num_tokens)]
+    ).to(torch.int32)
+
+    ws13 = torch.zeros(
+        num_tokens * top_k * max(N, K), dtype=torch.bfloat16, device=device
+    )
+    ws2 = torch.zeros(
+        num_tokens * top_k * max(2 * N, K), dtype=torch.bfloat16, device=device
+    )
+    out_otf = torch.zeros(num_tokens, K, dtype=torch.bfloat16, device=device)
+    experts.apply(
+        output=out_otf,
+        hidden_states=hidden_states,
+        w1=w1_out,
+        w2=w2_out,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=MoEActivation.SILU,
+        global_num_experts=E,
+        expert_map=None,
+        a1q_scale=None,
+        a2_scale=None,
+        workspace13=ws13,
+        workspace2=ws2,
+        expert_tokens_meta=None,
+        apply_router_weight_on_input=False,
+    )
+
+    # Reference: dense float32 forward using the dequantized BF16 weights.
+    ref = torch.zeros(num_tokens, K, dtype=torch.float32, device=device)
+    for m in range(num_tokens):
+        acc = torch.zeros(K, dtype=torch.float32, device=device)
+        for k in range(top_k):
+            e = topk_ids[m, k].item()
+            w = topk_weights[m, k].item()
+            gate_up = hidden_states[m].float() @ w13_bf16[e].float().T
+            gate, up = gate_up.chunk(2)
+            act = F.silu(gate) * up
+            acc += w * (act @ w2_bf16[e].float().T)
+        ref[m] = acc
+
+    rel_l2 = (
+        torch.norm(out_otf.float() - ref) / torch.norm(ref).clamp(min=1e-6)
+    ).item()
+    # 1% threshold: int8 quantization is finer than int4; deviation from
+    # the dequantized reference reflects only kernel arithmetic rounding.
+    assert rel_l2 < 0.01, f"int8 OTF vs ref rel_l2={rel_l2:.4f} (threshold 0.01)"
+
+
+@pytest.mark.parametrize("E, K, N, top_k, group_size, num_tokens", E2E_CONFIGS_LIST)
+def test_otf_ep_matches_full_forward(E, K, N, top_k, group_size, num_tokens):
+    """OTF with expert_map (EP) produces same sum as full forward on local experts."""
+    # Split E experts across 2 "ranks" -- test rank 0 (experts 0..E//2-1)
+    num_local = E // 2
+    expert_map = torch.full((E,), -1, dtype=torch.int32, device=device)
+    expert_map[:num_local] = torch.arange(num_local, dtype=torch.int32, device=device)
+
+    w13, w2, w13_scale, w2_scale, _, _, _, _ = _make_gptq_tensors(
+        E, K, N, group_size, asym=False
+    )
+    otf_result = _process_weights_triton_wna16(
+        _FakeGPTQConfig(), w13, w2, w13_scale, w2_scale, None, None
+    )
+    # Use only local experts' weights
+    w1_local = otf_result[0][:num_local]
+    w2_local = otf_result[1][:num_local]
+    s1_local = otf_result[2][:num_local]
+    s2_local = otf_result[3][:num_local]
+
+    moe_config_local = FusedMoEConfig(
+        num_experts=E,
+        experts_per_token=top_k,
+        hidden_dim=K,
+        intermediate_size=N,
+        num_local_experts=num_local,
+        num_logical_experts=E,
+        moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
+        activation=MoEActivation.SILU,
+        in_dtype=torch.bfloat16,
+        device=device,
+        routing_method=RoutingMethodType.TopK,
+        max_num_tokens=512,
+    )
+    quant_cfg = int4_w4a16_moe_quant_config(
+        w1_scale=s1_local, w2_scale=s2_local, block_shape=[0, group_size]
+    )
+    experts = TritonWNA16OTFExperts(moe_config_local, quant_cfg)
+
+    torch.manual_seed(1)
+    hidden_states = torch.randn(num_tokens, K, dtype=torch.bfloat16, device=device)
+    # Route all tokens to local experts only
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, top_k, dtype=torch.float32, device=device), dim=-1
+    )
+    topk_ids = torch.stack(
+        [torch.randperm(num_local, device=device)[:top_k] for _ in range(num_tokens)]
+    ).to(torch.int32)
+
+    ws13 = torch.zeros(
+        num_tokens * top_k * max(N, K), dtype=torch.bfloat16, device=device
+    )
+    ws2 = torch.zeros(
+        num_tokens * top_k * max(2 * N, K), dtype=torch.bfloat16, device=device
+    )
+    out_ep = torch.zeros(num_tokens, K, dtype=torch.bfloat16, device=device)
+    experts.apply(
+        output=out_ep,
+        hidden_states=hidden_states,
+        w1=w1_local,
+        w2=w2_local,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=MoEActivation.SILU,
+        global_num_experts=E,
+        expert_map=expert_map,
+        a1q_scale=None,
+        a2_scale=None,
+        workspace13=ws13,
+        workspace2=ws2,
+        expert_tokens_meta=None,
+        apply_router_weight_on_input=False,
+    )
+
+    # Compute reference without expert_map (all experts local, same routing)
+    moe_config_full = _make_moe_config(E, K, N)
+    quant_cfg_full = int4_w4a16_moe_quant_config(
+        w1_scale=otf_result[2], w2_scale=otf_result[3], block_shape=[0, group_size]
+    )
+    experts_full = TritonWNA16OTFExperts(moe_config_full, quant_cfg_full)
+    out_full = _run_otf_forward(
+        experts_full,
+        otf_result[0],
+        otf_result[1],
+        otf_result[2],
+        otf_result[3],
+        None,
+        None,
+        group_size,
+        hidden_states,
+        topk_weights,
+        topk_ids,
+        E,
+        K,
+        N,
+    )
+
+    # Same kernel, same weights, same token routing -- output must be bit-identical
+    # (or differ only by floating-point reordering in reduction, which is < 1 ULP).
+    torch.testing.assert_close(
+        out_ep.float(),
+        out_full.float(),
+        atol=1e-4,
+        rtol=1e-4,
+        msg="EP (expert_map) output differs from full forward"
+        " -- same routing should be identical",
+    )
+
+
+def test_triton_wna16_otf_precedes_emulation_classes():
+    """TritonWNA16OTFExperts must be the first kernel class under EMULATION."""
+    from vllm.model_executor.layers.fused_moe.experts.int4_emulation_moe import (
+        Int4EmulationTritonExperts,
+    )
+    from vllm.model_executor.layers.fused_moe.experts.int8_emulation_moe import (
+        Int8EmulationTritonExperts,
+    )
+    from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
+        TritonWNA16OTFExperts,
+    )
+    from vllm.model_executor.layers.fused_moe.oracle.int_wna16 import (
+        WNA16MoEBackend,
+        backend_to_kernel_cls,
+    )
+
+    classes = backend_to_kernel_cls(WNA16MoEBackend.EMULATION)
+    assert classes[0] is TritonWNA16OTFExperts, (
+        f"TritonWNA16OTFExperts must be first in EMULATION kernel list,"
+        f" got {classes[0]}"
+    )
+    assert Int4EmulationTritonExperts in classes
+    assert Int8EmulationTritonExperts in classes
+    idx_otf = classes.index(TritonWNA16OTFExperts)
+    idx_int4 = classes.index(Int4EmulationTritonExperts)
+    idx_int8 = classes.index(Int8EmulationTritonExperts)
+    assert idx_otf < idx_int4, (
+        f"TritonWNA16OTFExperts (idx={idx_otf}) must precede "
+        f"Int4EmulationTritonExperts (idx={idx_int4})"
+    )
+    assert idx_otf < idx_int8, (
+        f"TritonWNA16OTFExperts (idx={idx_otf}) must precede "
+        f"Int8EmulationTritonExperts (idx={idx_int8})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: make_group_size_adjusted_weight_loader
+# ---------------------------------------------------------------------------
+
+
+def test_group_size_adjusted_loader_passthrough_when_factor_is_one():
+    """factor=1 returns the original loader unchanged."""
+    sentinel = object()
+
+    def original(
+        param, loaded_weight, weight_name, shard_id, expert_id, return_success=False
+    ):
+        return sentinel
+
+    wrapped = make_group_size_adjusted_weight_loader(original, group_size_div_factor=1)
+    assert wrapped is original
+
+
+def test_group_size_adjusted_loader_expands_scale_rows():
+    """w2 scale/zero-point rows are expanded; w13 scales and weights are unchanged."""
+    calls = []
+
+    def capturing_loader(
+        param, loaded_weight, weight_name, shard_id, expert_id, return_success=False
+    ):
+        calls.append((weight_name, loaded_weight.shape))
+
+    wrapped = make_group_size_adjusted_weight_loader(
+        capturing_loader, group_size_div_factor=2
+    )
+
+    scale = torch.zeros(4, 128, device=device)  # 4 scale groups
+    zeros = torch.zeros(4, 16, device=device)  # 4 zero-point groups
+    weight = torch.zeros(16, 128, device=device)  # weight tensor
+
+    w13_scale = torch.zeros(2, 256, device=device)  # w13 scale: not expanded
+
+    wrapped(None, scale, "w2_scales", "w2", 0)
+    wrapped(None, zeros, "w2_qzeros", "w2", 0)
+    wrapped(None, weight, "w2_qweight", "w2", 0)
+    wrapped(None, w13_scale, "w13_scales", "w1", 0)
+
+    # w2 scale and zeros expanded to 8 rows; w2 weight and w13 scale unchanged
+    assert calls[0] == ("w2_scales", (8, 128)), f"w2 scale not expanded: {calls[0]}"
+    assert calls[1] == ("w2_qzeros", (8, 16)), f"w2 zeros not expanded: {calls[1]}"
+    assert calls[2] == ("w2_qweight", (16, 128)), (
+        f"w2 weight wrongly changed: {calls[2]}"
+    )
+    assert calls[3] == ("w13_scales", (2, 256)), (
+        f"w13 scale wrongly expanded: {calls[3]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: OTF forward when N % group_size != 0 (group-size adjustment path)
+# ---------------------------------------------------------------------------
+# Triggered by e.g. QuantTrio-Qwen3-235B-A22B-GPTQ-Int8 with tp=8:
+#   moe_intermediate_size=1536, N_per_tp=192, group_size=128 -> 192%128=64!=0
+#   adjusted_gs=64, factor=2
+
+
+@pytest.mark.parametrize(
+    "E, K, N, top_k, group_size, num_tokens",
+    [
+        # N=192, gs=128: 192%128=64, adjusted_gs=64, factor=2 (the real trigger case)
+        pytest.param(4, 256, 192, 2, 128, 8, id="N192_gs128"),
+        # N=384, gs=256: 384%256=128, adjusted_gs=128, factor=2
+        pytest.param(4, 256, 384, 2, 256, 8, id="N384_gs256"),
+    ],
+)
+def test_otf_forward_n_not_divisible_by_group_size(
+    E, K, N, top_k, group_size, num_tokens
+):
+    """OTF forward is correct when N % group_size != 0.
+
+    Simulates what make_group_size_adjusted_weight_loader produces:
+    w13 scales are from the checkpoint at original group_size (K divides evenly).
+    w2 weights are quantized at adjusted_gs; w2 scales come from the checkpoint
+    (quantized at group_size, N//group_size rows) then repeat_interleave(factor).
+    """
+    adjusted_gs = group_size
+    while N % adjusted_gs != 0:
+        adjusted_gs //= 2
+    div_factor = group_size // adjusted_gs
+
+    torch.manual_seed(7)
+    w13_fp = torch.randn(E, K, 2 * N, dtype=torch.float16, device=device) * 0.1
+    w2_fp = torch.randn(E, N, K, dtype=torch.float16, device=device) * 0.1
+
+    w13_list, w13s_list, w2_list, w2s_list = [], [], [], []
+    for e in range(E):
+        # w13: quantize at original group_size (K is always divisible)
+        q13, s13 = _quantize_sym_int4(w13_fp[e], group_size)
+        w13_list.append(gptq_pack(q13, 4, K, 2 * N))
+        w13s_list.append(s13)  # [K//group_size, 2N] -- no expansion needed
+        # w2: weights quantized at adjusted_gs; scales simulated from the
+        # checkpoint (group_size) then expanded by repeat_interleave(factor),
+        # matching exactly what make_group_size_adjusted_weight_loader produces.
+        q2, s2_fine = _quantize_sym_int4(w2_fp[e], adjusted_gs)
+        w2_list.append(gptq_pack(q2, 4, N, K))
+        _, s2_ckpt = _quantize_sym_int4(w2_fp[e], group_size)  # checkpoint rows
+        s2_expanded = s2_ckpt.repeat_interleave(div_factor, dim=0)
+        w2s_list.append(s2_expanded)  # [N//adjusted_gs, K]
+
+    w13 = torch.stack(w13_list)
+    w2 = torch.stack(w2_list)
+    w13_scale = torch.stack(w13s_list)
+    w2_scale = torch.stack(w2s_list)
+
+    otf_result = _process_weights_triton_wna16(
+        _FakeGPTQConfig(), w13, w2, w13_scale, w2_scale, None, None
+    )
+    w1_out, w2_out = otf_result[0], otf_result[1]
+    s1_out, s2_out = otf_result[2], otf_result[3]
+
+    # gs_eff derived from repacked scale shapes
+    gs_eff = w2_out.shape[1] // s1_out.shape[2] if s1_out.shape[2] > 0 else adjusted_gs
+
+    moe_config = _make_moe_config(E, K, N)
+    quant_cfg = int4_w4a16_moe_quant_config(
+        w1_scale=s1_out, w2_scale=s2_out, block_shape=[0, gs_eff]
+    )
+    experts = TritonWNA16OTFExperts(moe_config, quant_cfg)
+
+    torch.manual_seed(8)
+    hidden_states = torch.randn(num_tokens, K, dtype=torch.bfloat16, device=device)
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, top_k, dtype=torch.float32, device=device), dim=-1
+    )
+    topk_ids = torch.stack(
+        [torch.randperm(E, device=device)[:top_k] for _ in range(num_tokens)]
+    ).to(torch.int32)
+
+    out_otf = _run_otf_forward(
+        experts,
+        w1_out,
+        w2_out,
+        s1_out,
+        s2_out,
+        None,
+        None,
+        gs_eff,
+        hidden_states,
+        topk_weights,
+        topk_ids,
+        E,
+        K,
+        N,
+    )
+
+    # Reference: dequantize using the same expanded scales
+    emul_result = _process_weights_emulation_gptq(
+        w13, w2, w13_scale, w2_scale, None, None, output_dtype=torch.bfloat16
+    )
+    w13_bf16, w2_bf16 = emul_result[0], emul_result[1]
+
+    ref = torch.zeros(num_tokens, K, dtype=torch.float32, device=device)
+    for m in range(num_tokens):
+        acc = torch.zeros(K, dtype=torch.float32, device=device)
+        for k in range(top_k):
+            e = topk_ids[m, k].item()
+            w = topk_weights[m, k].item()
+            gate_up = hidden_states[m].float() @ w13_bf16[e].float().T
+            gate, up = gate_up.chunk(2)
+            act = F.silu(gate) * up
+            acc += w * (act @ w2_bf16[e].float().T)
+        ref[m] = acc
+
+    rel_l2 = (
+        torch.norm(out_otf.float() - ref) / torch.norm(ref).clamp(min=1e-6)
+    ).item()
+    assert rel_l2 < 0.01, (
+        f"[N={N}, gs={group_size}, adj_gs={adjusted_gs}] "
+        f"rel_l2={rel_l2:.4f} (threshold 0.01)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Note: OTF forward with N < group_size (e.g. N=64, group_size=128, TP=8)
+# ---------------------------------------------------------------------------
+# This configuration is unsupported.  When N_per_rank < group_size, the
+# checkpoint w2 scale has N_full//group_size rows total; TP sharding gives
+# each rank N_full//group_size//tp_size = 0 rows, so there is no data to
+# expand via repeat_interleave.  AutoGPTQMoEMethod and AutoAWQMoEMethod raise
+# a ValueError at create_weights time, which is the correct behavior.
+# The correct remedy is to reduce --tensor-parallel-size so that
+# N_per_rank >= group_size.
+# Correctness of the weight loader wrapper for the N % group_size != 0
+# (but N >= group_size) case is covered by test_group_size_adjusted_loader_*.

--- a/vllm/model_executor/layers/fused_moe/__init__.py
+++ b/vllm/model_executor/layers/fused_moe/__init__.py
@@ -111,7 +111,7 @@ if HAS_TRITON:
     )
     from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
         TritonExperts,
-        TritonWNA16Experts,
+        TritonWNA16OTFExperts,
     )
     from vllm.model_executor.layers.fused_moe.experts.xpu_moe import (
         XPUExperts,
@@ -139,7 +139,7 @@ if HAS_TRITON:
         "CutlassBatchedExpertsFp8",
         "CutlassExpertsW4A8Fp8",
         "TritonExperts",
-        "TritonWNA16Experts",
+        "TritonWNA16OTFExperts",
         "BatchedTritonExperts",
         "DeepGemmExperts",
         "BatchedDeepGemmExperts",

--- a/vllm/model_executor/layers/fused_moe/experts/int4_emulation_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/int4_emulation_moe.py
@@ -43,10 +43,10 @@ class Int4EmulationTritonExperts(TritonExperts):
         super().__init__(moe_config, quant_config)
         logger.warning_once(
             "Using Int4EmulationTritonExperts MoE backend. Int4 weights are "
-            "dequantized to BF16 at load time "
+            "dequantized to BF16 at load time."
         )
         # Weights are dequantized to BF16 before apply() is called, so
-        # TritonExperts must see them as plain float — clear the int4 dtype
+        # TritonExperts must see them as plain float -- clear the int4 dtype
         # and scales so the hidden-size assertion and kernel dispatch treat
         # them as unquantized.
         self.quant_config._w1.dtype = None

--- a/vllm/model_executor/layers/fused_moe/experts/int8_emulation_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/int8_emulation_moe.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Int8 weight-only quantization emulation for MoE.
+
+Weights are dequantized from packed int8 to BF16 once at load time;
+the forward pass then runs plain TritonExperts in BF16.
+
+Weight layout (GPTQ int8, pack_factor=4):
+  w13_int32: [E, K//4, 2*N]  int32  packed LSB-first along K (gate+up stacked on dim 2)
+  w2_int32:  [E, N//4, K]    int32  packed LSB-first along N
+  w13_scale: [E, K//group_size, 2*N]  float16 | bfloat16
+  w2_scale:  [E, N//group_size, K]    float16 | bfloat16
+"""
+
+import torch
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEConfig,
+    FusedMoEQuantConfig,
+)
+from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
+    kInt8Static,
+)
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+
+logger = init_logger(__name__)
+
+
+@triton.jit
+def _int8_dequant_kernel(
+    w_ptr,  # [E, K_packed, N] int32
+    s_ptr,  # [E, n_groups, N] fp16/bf16
+    out_ptr,  # [E, N, K] or [E, K, N] fp16/bf16
+    w_stride_e,
+    w_stride_k,
+    w_stride_n,
+    s_stride_e,
+    s_stride_g,
+    s_stride_n,
+    out_stride_e,
+    out_stride_row,
+    out_stride_col,
+    E,
+    K_packed,
+    N,
+    group_size,
+    TRANSPOSE_OUTPUT: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    OUTPUT_DTYPE: tl.constexpr,
+):
+    """
+    Grid: (E, cdiv(K_packed, BLOCK_K), cdiv(N, BLOCK_N))
+    Each program handles one [BLOCK_K*4, BLOCK_N] dequantized tile
+    for one expert.
+    """
+    pid_e = tl.program_id(0).to(tl.int64)
+    pid_k = tl.program_id(1)
+    pid_n = tl.program_id(2)
+
+    k_offs = pid_k * BLOCK_K + tl.arange(0, BLOCK_K)
+    n_offs = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    k_mask = k_offs < K_packed
+    n_mask = n_offs < N
+
+    w_ptrs = (
+        w_ptr
+        + pid_e * w_stride_e
+        + k_offs[:, None] * w_stride_k
+        + n_offs[None, :] * w_stride_n
+    )
+    w_tile = tl.load(w_ptrs, mask=k_mask[:, None] & n_mask[None, :], other=0)
+
+    for b in tl.static_range(4):
+        byte_val = (w_tile >> (b * 8)) & 0xFF
+        w_fp = (byte_val - 128).to(tl.float32)
+
+        k_rows = k_offs * 4 + b
+        k_row_mask = k_mask & (k_rows < K_packed * 4)
+        # Clamp g_idx so out-of-bounds k_offs don't produce a pointer that
+        # escapes the scale tensor (Triton computes the address speculatively
+        # before applying the mask, which causes an illegal memory access).
+        n_groups = K_packed * 4 // group_size
+        g_idx = tl.minimum(k_rows // group_size, n_groups - 1)
+
+        s_ptrs = (
+            s_ptr
+            + pid_e * s_stride_e
+            + g_idx[:, None] * s_stride_g
+            + n_offs[None, :] * s_stride_n
+        )
+        scale = tl.load(s_ptrs, mask=k_row_mask[:, None] & n_mask[None, :], other=0.0)
+
+        dequant = (w_fp * scale.to(tl.float32)).to(OUTPUT_DTYPE)
+
+        if TRANSPOSE_OUTPUT:
+            out_ptrs = (
+                out_ptr
+                + pid_e * out_stride_e
+                + n_offs[:, None] * out_stride_row
+                + k_rows[None, :] * out_stride_col
+            )
+            tl.store(
+                out_ptrs, tl.trans(dequant), mask=n_mask[:, None] & k_row_mask[None, :]
+            )
+        else:
+            out_ptrs = (
+                out_ptr
+                + pid_e * out_stride_e
+                + k_rows[:, None] * out_stride_row
+                + n_offs[None, :] * out_stride_col
+            )
+            tl.store(out_ptrs, dequant, mask=k_row_mask[:, None] & n_mask[None, :])
+
+
+def triton_unpack_and_dequant_int8_gptq(
+    w_int32: torch.Tensor,
+    scale: torch.Tensor,
+    transpose_output: bool,
+    output_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Triton kernel: unpack GPTQ int8 weights and dequantize.
+
+    Args:
+        w_int32: [E, K_packed, N] int32, 4 int8 per int32, LSB-first along K.
+        scale:   [E, K//group_size, N] float16 or bfloat16.
+        transpose_output: True -> [E, N, K]; False -> [E, K, N].
+        output_dtype: torch.float16 or torch.bfloat16.
+    """
+    E, K_packed, N = w_int32.shape
+    K = K_packed * 4
+    group_size = K // scale.shape[1]
+
+    out_shape = (E, N, K) if transpose_output else (E, K, N)
+    out = torch.empty(out_shape, dtype=output_dtype, device=w_int32.device)
+
+    tl_dtype = tl.float16 if output_dtype == torch.float16 else tl.bfloat16
+    BLOCK_K, BLOCK_N = 32, 32
+
+    _int8_dequant_kernel[(E, triton.cdiv(K_packed, BLOCK_K), triton.cdiv(N, BLOCK_N))](
+        w_int32,
+        scale,
+        out,
+        w_int32.stride(0),
+        w_int32.stride(1),
+        w_int32.stride(2),
+        scale.stride(0),
+        scale.stride(1),
+        scale.stride(2),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        E,
+        K_packed,
+        N,
+        group_size,
+        TRANSPOSE_OUTPUT=transpose_output,
+        BLOCK_K=BLOCK_K,
+        BLOCK_N=BLOCK_N,
+        OUTPUT_DTYPE=tl_dtype,
+    )
+    return out
+
+
+class Int8EmulationTritonExperts(TritonExperts):
+    """Int8 W-only MoE that dequantizes weights to BF16 at load time.
+
+    Weights arrive already dequantized (convert_to_wna16_moe_kernel_format
+    does the unpacking); apply() simply forwards to TritonExperts.
+    """
+
+    def __init__(
+        self,
+        moe_config: FusedMoEConfig,
+        quant_config: FusedMoEQuantConfig,
+    ):
+        super().__init__(moe_config, quant_config)
+        logger.warning_once(
+            "Using Int8EmulationTritonExperts MoE backend. Int8 weights are "
+            "dequantized to BF16 at load time; this uses more memory than a "
+            "native int8 kernel and is intended for devices or configurations "
+            "where a native W8A16 kernel is unavailable."
+        )
+        # Weights are dequantized to BF16 before apply() is called, so
+        # TritonExperts must see them as plain float -- clear the int8 dtype
+        # and scales so the hidden-size assertion and kernel dispatch treat
+        # them as unquantized.
+        self.quant_config._w1.dtype = None
+        self.quant_config._w2.dtype = None
+        self.quant_config._w1.scale = None
+        self.quant_config._w2.scale = None
+
+    @staticmethod
+    def _supports_current_device() -> bool:
+        return current_platform.is_cuda_alike()
+
+    @staticmethod
+    def _supports_quant_scheme(
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> bool:
+        return weight_key == kInt8Static and activation_key is None
+
+    @property
+    def quant_dtype(self) -> torch.dtype | str | None:
+        return None
+
+    @property
+    def block_shape(self) -> list[int] | None:
+        return None
+
+    @property
+    def expects_unquantized_inputs(self) -> bool:
+        return True
+
+    def apply(
+        self,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        a2_scale: torch.Tensor | None,
+        workspace13: torch.Tensor,
+        workspace2: torch.Tensor,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        apply_router_weight_on_input: bool,
+    ):
+        if w1.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+            raise RuntimeError(
+                "Int8EmulationTritonExperts.apply() received non-float weights "
+                f"(dtype={w1.dtype}). Weights must be dequantized to BF16 before "
+                "the forward pass via convert_to_wna16_moe_kernel_format."
+            )
+        return super().apply(
+            output=output,
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation=activation,
+            global_num_experts=global_num_experts,
+            expert_map=expert_map,
+            a1q_scale=None,
+            a2_scale=None,
+            workspace13=workspace13,
+            workspace2=workspace2,
+            expert_tokens_meta=expert_tokens_meta,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+        )

--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -18,11 +18,7 @@ from vllm.model_executor.layers.fused_moe.experts.lora_experts_mixin import (
 from vllm.model_executor.layers.fused_moe.fused_moe import (
     _prepare_expert_assignment,
     invoke_fused_moe_triton_kernel,
-    invoke_fused_moe_wna16_triton_kernel,
     try_get_optimal_moe_config,
-)
-from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
-    moe_align_block_size,
 )
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
@@ -43,7 +39,12 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8Static128BlockSym,
     kFp8StaticChannelSym,
     kFp8StaticTensorSym,
+    kInt4Static,
+    kInt4Static32,
+    kInt4Static32Asym,
+    kInt4StaticAsym,
     kInt8DynamicTokenSym,
+    kInt8Static,
     kInt8StaticChannelSym,
 )
 from vllm.platforms import current_platform
@@ -539,44 +540,63 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
         ops.moe_sum(input, output)
 
 
-class TritonWNA16Experts(TritonExperts):
+class TritonWNA16OTFExperts(TritonExperts):
+    """Modular WNA16 MoE expert: keeps weights quantized, dequantizes on-the-fly.
+
+    Unlike Int4/Int8EmulationTritonExperts (which dequantize at load time),
+    this class passes packed int4/int8 weights directly to
+    invoke_fused_moe_wna16_triton_kernel and lets the Triton kernel handle
+    dequantization each forward pass - trading lower memory for higher compute.
+
+    Supports int4 (symmetric + asymmetric) and int8 (symmetric) weight-only
+    quantization. LoRA and EP are inherited from TritonExperts.
+    """
+
     @staticmethod
     def _supports_current_device() -> bool:
-        raise NotImplementedError(
-            "TritonWNA16Experts is not yet used by an Oracle. "
-            "This method should not be called."
-        )
+        return current_platform.is_cuda_alike()
 
     @staticmethod
     def _supports_no_act_and_mul() -> bool:
-        raise NotImplementedError(
-            "TritonWNA16Experts is not yet used by an Oracle. "
-            "This method should not be called."
-        )
+        return True
 
     @staticmethod
     def _supports_quant_scheme(
         weight_key: QuantKey | None,
         activation_key: QuantKey | None,
     ) -> bool:
-        raise NotImplementedError(
-            "TritonWNA16Experts is not yet used by an Oracle. "
-            "This method should not be called."
+        SUPPORTED_W = (
+            kInt4Static,
+            kInt4Static32,
+            kInt4StaticAsym,
+            kInt4Static32Asym,
+            kInt8Static,
         )
+        return weight_key in SUPPORTED_W and activation_key is None
 
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
-        raise NotImplementedError(
-            "TritonWNA16Experts is not yet used by an Oracle. "
-            "This method should not be called."
+        # SWIGLUOAI_UNINTERLEAVE requires clamp_limit which fused_experts_impl
+        # does not pass to apply_moe_activation.
+        # Models using it (e.g. MiniMax-M3) fall back
+        # to Int4/Int8EmulationTritonExperts.
+        return activation in (
+            MoEActivation.SILU,
+            MoEActivation.GELU,
+            MoEActivation.GELU_TANH,
+            MoEActivation.SWIGLUOAI,
         )
 
     @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
-        raise NotImplementedError(
-            "TritonWNA16Experts is not yet used by an Oracle. "
-            "This method should not be called."
-        )
+        return True
+
+    @property
+    def quant_dtype(self) -> torch.dtype | str | None:
+        # WNA16 is weight-only: activations stay in BF16/FP16 and must NOT
+        # be quantized by prepare_finalize.prepare(). Returning None causes
+        # moe_kernel_quantize_input to skip activation quantization.
+        return None
 
     def apply(
         self,
@@ -596,119 +616,20 @@ class TritonWNA16Experts(TritonExperts):
         expert_tokens_meta: mk.ExpertTokensMetadata | None,
         apply_router_weight_on_input: bool,
     ):
-        # Check constraints.
-        if self.quant_config.use_int4_w4a16:
-            assert hidden_states.size(-1) // 2 == w1.size(2), "Hidden size mismatch"
-        else:
-            assert hidden_states.size(-1) == w1.size(2), (
-                f"Hidden size mismatch {hidden_states.size(-1)} != {w1.size(2)}"
-            )
+        # WNA16 on-the-fly dequant forward pass.
+        # Weights are uint8-packed (int4: [E,2N,K//2], int8: [E,2N,K]).
+        from vllm.model_executor.layers.fused_moe import fused_experts
 
-        assert hidden_states.is_contiguous(), "Hidden_states must be contiguous"
-        assert hidden_states.dim() == 2
-        assert w1.stride(-1) == 1, "Stride of last dimension must be 1"
-        assert w2.stride(-1) == 1, "Stride of last dimension must be 1"
-        assert hidden_states.dtype in [
-            torch.float32,
-            torch.float16,
-            torch.bfloat16,
-            torch.float8_e4m3fn,
-            torch.float8_e4m3fnuz,
-        ]
-
-        E, num_tokens, N, K, top_k_num = self.moe_problem_size(
-            hidden_states, w1, w2, topk_ids
-        )
-
-        if global_num_experts == -1:
-            global_num_experts = E
-
-        config = try_get_optimal_moe_config(
-            w1.size(),
-            w2.size(),
-            top_k_num,
-            self.quant_config.config_name(hidden_states.dtype),
-            num_tokens,
-            block_shape=self.block_shape,
-        )
-
-        if hidden_states.dtype == torch.bfloat16:
-            compute_type = tl.bfloat16
-        elif hidden_states.dtype == torch.float16:
-            compute_type = tl.float16
-        elif hidden_states.dtype == torch.float32:
-            compute_type = tl.float32
-        elif (
-            hidden_states.dtype == torch.float8_e4m3fn
-            or hidden_states.dtype == torch.float8_e4m3fnuz
-        ):
-            compute_type = tl.bfloat16
-        else:
-            raise ValueError(f"Unsupported compute_type: {hidden_states.dtype}")
-
-        # Note that the output tensor might be in workspace1
-        intermediate_cache1 = _resize_cache(workspace2, (num_tokens, top_k_num, N))
-        activation_out_dim = self.adjust_N_for_activation(N, activation)
-        intermediate_cache2 = _resize_cache(
-            workspace13, (num_tokens * top_k_num, activation_out_dim)
-        )
-        intermediate_cache3 = _resize_cache(workspace2, (num_tokens, top_k_num, K))
-
-        sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
-            topk_ids, config["BLOCK_SIZE_M"], global_num_experts, expert_map
-        )
-
-        invoke_fused_moe_wna16_triton_kernel(
+        result = fused_experts(
             hidden_states,
             w1,
-            intermediate_cache1,
-            self.w1_scale,
-            self.quant_config.w1_zp,
-            None,  # topk_weights
-            sorted_token_ids,
-            expert_ids,
-            num_tokens_post_padded,
-            False,  # mul_routed_weights
-            top_k_num,
-            config,
-            compute_type=compute_type,
-            use_int8_w8a16=self.quant_config.use_int8_w8a16,
-            use_int4_w4a16=self.quant_config.use_int4_w4a16,
-            block_shape=self.block_shape,
-        )
-
-        self.activation(
-            activation, intermediate_cache2, intermediate_cache1.view(-1, N)
-        )
-
-        a2q_scale: torch.Tensor | None = None
-
-        qintermediate_cache2, a2q_scale = moe_kernel_quantize_input(
-            intermediate_cache2,
-            a2_scale,
-            self.quant_dtype,
-            self.per_act_token_quant,
-            self.block_shape,
-        )
-
-        invoke_fused_moe_wna16_triton_kernel(
-            qintermediate_cache2,
             w2,
-            intermediate_cache3,
-            self.w2_scale,
-            self.quant_config.w2_zp,
-            topk_weights,
-            sorted_token_ids,
-            expert_ids,
-            num_tokens_post_padded,
-            not apply_router_weight_on_input,
-            1,
-            config,
-            compute_type=compute_type,
-            use_int8_w8a16=self.quant_config.use_int8_w8a16,
-            use_int4_w4a16=self.quant_config.use_int4_w4a16,
-            block_shape=self.block_shape,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation=activation,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            global_num_experts=global_num_experts,
+            expert_map=expert_map,
+            quant_config=self.quant_config,
         )
-
-        # separate function is required for MoE + LoRA
-        self.moe_sum(intermediate_cache3, output)
+        output.copy_(result)

--- a/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
@@ -57,7 +57,7 @@ class WNA16MoEBackend(Enum):
 def backend_to_kernel_cls(
     backend: WNA16MoEBackend,
 ) -> list[type[mk.FusedMoEExperts]]:
-    """Return the experts class for the given backend, or None for NONE."""
+    """Return the list of experts classes for the given backend."""
     if backend == WNA16MoEBackend.HUMMING:
         from vllm.model_executor.layers.fused_moe.experts.fused_humming_moe import (
             BatchedHummingGroupedExperts,
@@ -92,8 +92,22 @@ def backend_to_kernel_cls(
         from vllm.model_executor.layers.fused_moe.experts.int4_emulation_moe import (
             Int4EmulationTritonExperts,
         )
+        from vllm.model_executor.layers.fused_moe.experts.int8_emulation_moe import (
+            Int8EmulationTritonExperts,
+        )
+        from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
+            TritonWNA16OTFExperts,
+        )
 
-        return [Int4EmulationTritonExperts]
+        # Oracle tries each in order; _supports_quant_scheme selects the right one.
+        # TritonWNA16OTFExperts is tried first: it keeps weights quantized
+        # (lower memory than emulation) and falls back to Int4/Int8Emulation
+        # for quant schemes it does not support.
+        return [
+            TritonWNA16OTFExperts,
+            Int4EmulationTritonExperts,
+            Int8EmulationTritonExperts,
+        ]
     else:
         raise ValueError(f"Unknown WNA16 MoE backend: {backend.value}")
 
@@ -145,7 +159,7 @@ def select_wna16_moe_backend(
                     Must have int4 or int8 type.
 
     Returns:
-        A tuple of (``WNA16MoEBackend``, experts class or ``None``).
+        A tuple of (``WNA16MoEBackend``, experts class).
     """
 
     activation_format = (
@@ -154,7 +168,12 @@ def select_wna16_moe_backend(
         else mk.FusedMoEActivationFormat.Standard
     )
 
-    def _make_log_backend(backend: WNA16MoEBackend):
+    def _make_log_backend(
+        backend: WNA16MoEBackend,
+        k_cls: type[mk.FusedMoEExperts] | None = None,
+    ) -> str:
+        if backend == WNA16MoEBackend.EMULATION and k_cls is not None:
+            return f"Using '{backend.value}' WNA16 MoE backend ({k_cls.__name__})."
         return f"Using '{backend.value}' WNA16 MoE backend."
 
     def _make_log_unsupported(backend: WNA16MoEBackend, reason: str | None) -> str:
@@ -181,7 +200,7 @@ def select_wna16_moe_backend(
                 k_cls, config, weight_key, activation_key, activation_format
             )
             if supported:
-                logger.info_once(_make_log_backend(backend), scope="local")
+                logger.info_once(_make_log_backend(backend, k_cls), scope="local")
                 return backend, k_cls
         raise ValueError(_make_log_unsupported(backend, reason))
 
@@ -189,9 +208,34 @@ def select_wna16_moe_backend(
     runner_backend = config.moe_backend
     if runner_backend != "auto":
         requested_backend = map_wna16_backend(runner_backend)
-        return _return_or_raise(
-            requested_backend, config, weight_key, None, activation_format
-        )
+        kernel_classes = backend_to_kernel_cls(requested_backend)
+
+        # First check: does this backend run on the current platform at all?
+        # If no kernel supports the current device, warn and fall back to auto.
+        platform_ok = any(k_cls._supports_current_device() for k_cls in kernel_classes)
+        if not platform_ok:
+            logger.warning(
+                "moe_backend='%s' is not supported on platform '%s'; "
+                "falling back to auto backend selection.",
+                runner_backend,
+                current_platform.device_name,
+            )
+        else:
+            # Platform is supported. If the quant config is incompatible,
+            # raise so the user knows to fix their configuration.
+            for k_cls in kernel_classes:
+                supported, _ = k_cls.is_supported_config(
+                    k_cls, config, weight_key, None, activation_format
+                )
+                if supported:
+                    return _return_or_raise(
+                        requested_backend, config, weight_key, None, activation_format
+                    )
+            raise ValueError(
+                f"moe_backend='{runner_backend}' does not support the "
+                f"quantization configuration (weight_key={weight_key}). "
+                "Use moe_backend='auto' to let vLLM select a compatible backend."
+            )
 
     # Select kernels in order of backend.
     AVAILABLE_BACKENDS = _get_priority_backends()
@@ -203,7 +247,7 @@ def select_wna16_moe_backend(
                 k_cls, config, weight_key, activation_key, activation_format
             )
             if supported:
-                logger.info_once(_make_log_backend(backend), scope="local")
+                logger.info_once(_make_log_backend(backend, k_cls), scope="local")
                 return backend, k_cls
             else:
                 logger.debug_once(_make_log_unsupported(backend, reason), scope="local")
@@ -284,13 +328,20 @@ def make_wna16_moe_kernel(
     from vllm.model_executor.layers.fused_moe.experts.int4_emulation_moe import (
         Int4EmulationTritonExperts,
     )
+    from vllm.model_executor.layers.fused_moe.experts.int8_emulation_moe import (
+        Int8EmulationTritonExperts,
+    )
+    from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
+        TritonWNA16OTFExperts,
+    )
     from vllm.model_executor.layers.fused_moe.experts.xpu_moe import (
         XPUExpertsWNA16,
     )
 
     # Currently, we only support TrtLlmMxint4ExpertsMonolithic, MarlinExperts,
     # BatchedMarlinExperts, XPUExpertsWNA16, CPUExpertsInt4, the Humming
-    # grouped/indexed experts, and Int4EmulationTritonExperts
+    # grouped/indexed experts, Int4EmulationTritonExperts,
+    # Int8EmulationTritonExperts, and TritonWNA16OTFExperts
     allowed_experts: tuple[type[mk.FusedMoEExperts], ...] = (
         MarlinExperts,
         BatchedMarlinExperts,
@@ -298,6 +349,8 @@ def make_wna16_moe_kernel(
         XPUExpertsWNA16,
         CPUExpertsInt4,
         Int4EmulationTritonExperts,
+        Int8EmulationTritonExperts,
+        TritonWNA16OTFExperts,
     )
     if backend == WNA16MoEBackend.HUMMING:
         allowed_experts += tuple(backend_to_kernel_cls(WNA16MoEBackend.HUMMING))
@@ -397,8 +450,7 @@ def _process_weights_flashinfer(
 ]:
     """Flashinfer (TRT-LLM MXINT4) weight post-processing.
 
-    Steps
-    -----
+    Steps:
     1. Transform weights/scales via ``prepare_static_weights_for_trtllm_mxint4_moe``.
     2. Return transformed tensors, passing through g_idx/bias unchanged.
     """
@@ -495,8 +547,7 @@ def _process_weights_marlin(
     """Standard Marlin weight post-processing shared by MARLIN and
     BATCHED_MARLIN backends.
 
-    Steps
-    -----
+    Steps:
     1. Optional FP8 preprocessing of packed weights / scales.
     2. Sort / reset g_idx tensors for act-order handling.
     3. Repack weights via ``gptq_marlin_moe_repack``.
@@ -978,21 +1029,21 @@ def _process_weights_xpu(
         w2:  [E, N // 8, K] int32
         w2_scales:  [E, N // group_size, K] params_dtype
 
-    Transpose dim 1 ↔ dim 2 then view int32 → uint8 to recover sequential
+    Transpose dim 1 <-> dim 2 then view int32 -> uint8 to recover sequential
     int4-packed bytes along the input dim. Each packed int32 holds 8 nibbles
     `(n7<<28)|(n6<<24)|...|(n1<<4)|n0` in ascending K order; on a
-    little-endian host the int32→uint8 view exposes them as bytes
+    little-endian host the int32->uint8 view exposes them as bytes
     `[n1<<4|n0, n3<<4|n2, n5<<4|n4, n7<<4|n6]`, i.e. two nibbles per byte
     with the lower nibble = lower input-K index. xpu_fused_moe(is_int4=True)
     expects this convention; on a big-endian host the byte order reverses
     and the kernel would silently miscompute, so we hard-fail.
     """
-    del layer, quant_config  # unused — kept for parity with the marlin helper
+    del layer, quant_config  # unused -- kept for parity with the marlin helper
 
     if sys.byteorder != "little":
         raise NotImplementedError(
             "_process_weights_xpu requires a little-endian host: the GPTQ "
-            "int32 → uint8 nibble repack relies on LE byte ordering."
+            "int32 -> uint8 nibble repack relies on LE byte ordering."
         )
 
     w13_xpu = w13_qweight.transpose(1, 2).contiguous().view(torch.uint8)
@@ -1073,6 +1124,12 @@ def _unpack_and_dequant_int4_gptq(
     # Reshape to [E, K, N]: fuse K_packed and nibble index (dim 1 and 3)
     w = nibbles.permute(0, 1, 3, 2).reshape(E, K, N).to(torch.int16)
 
+    if scale.shape[1] == 0:
+        raise ValueError(
+            "_unpack_and_dequant_int4_gptq: scale has 0 groups (shape[1]==0). "
+            "This happens when intermediate_size_per_partition < group_size "
+            "due to tensor parallelism. Check create_weights in auto_gptq.py."
+        )
     if qzeros is None:
         # Symmetric uint4b8: subtract bias so the range is [-8, 7]
         w = w - 8
@@ -1168,7 +1225,208 @@ def _unpack_and_dequant_int4_awq(
     return w_dequant.contiguous()  # [E, K, N]
 
 
-def _process_weights_emulation_gptq(
+def _unpack_and_dequant_int8_gptq(
+    w_int32: torch.Tensor,
+    scale: torch.Tensor,
+    transpose_output: bool,
+    output_dtype: torch.dtype = torch.bfloat16,
+    force_torch: bool = False,
+) -> torch.Tensor:
+    """Unpack GPTQ-packed int8 weights and dequantize to output_dtype.
+
+    GPTQ packs 4 int8 values per int32, LSB-first along the K (row) dimension.
+    Uses a Triton kernel when available (no intermediate allocations on GPU);
+    falls back to a pure-PyTorch implementation otherwise.
+
+    Args:
+        w_int32: packed weights, shape [E, K_packed, N] where K_packed = K//4.
+        scale:   per-group scales, shape [E, K//group_size, N], float16.
+        transpose_output: if True return [E, N, K]; if False return [E, K, N].
+        output_dtype: target floating-point dtype (bfloat16 or float16).
+        force_torch: force to use torch int8 dequant instead of Triton version.
+
+    Returns:
+        Dequantized weight tensor in the requested layout.
+    """
+
+    if not force_torch:
+        from vllm.model_executor.layers.fused_moe.experts.int8_emulation_moe import (
+            triton_unpack_and_dequant_int8_gptq,
+        )
+
+        return triton_unpack_and_dequant_int8_gptq(
+            w_int32, scale, transpose_output, output_dtype
+        )
+
+    # PyTorch fallback
+    E, K_packed, N = w_int32.shape
+    K = K_packed * 4
+
+    # Unpack: [E, K_packed, N] -> [E, K_packed, N, 4] via byte extraction.
+    # Each int32 holds 4 uint8 values (0..255) packed LSB-first along K.
+    shifts = torch.arange(4, device=w_int32.device, dtype=torch.int32) * 8
+    bytes_ = (w_int32.unsqueeze(-1) >> shifts) & 0xFF  # [E, K_packed, N, 4]
+
+    # Fuse K_packed and byte index into K: permute to [E, K_packed, 4, N]
+    w = bytes_.permute(0, 1, 3, 2).reshape(E, K, N).to(torch.int16)
+
+    # uint8b128: subtract bias 128 so range is [-128, 127]
+    w = w - 128
+
+    # Broadcast scale [E, K//gs, N] -> [E, K, N]
+    # Multiply in float32 (same as Triton kernel) then cast, so both paths
+    # produce identical results for the same input.
+    gs = K // scale.shape[1]
+    scale_broadcast = scale.repeat_interleave(gs, dim=1).to(torch.float32)
+
+    w_dequant = (w.to(torch.float32) * scale_broadcast).to(output_dtype)  # [E, K, N]
+
+    if transpose_output:
+        return w_dequant.permute(0, 2, 1).contiguous()  # [E, N, K]
+    return w_dequant.contiguous()  # [E, K, N]
+
+
+def _process_weights_emulation_int8(
+    w13: torch.Tensor,
+    w2: torch.Tensor,
+    w13_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    output_dtype: torch.dtype = torch.bfloat16,
+) -> tuple:
+    """Dequantize int8 weights for the emulation backend.
+
+    Inputs are in GPTQ packed format (pack_factor=4):
+        w13: [E, K//4, 2*N]   int32  (gate+up proj stacked on dim 2)
+        w2:  [E, N//4, K]     int32
+        w13_scale: [E, K//gs, 2*N]  float16
+        w2_scale:  [E, N//gs, K]    float16
+
+    Outputs (what TritonExperts expects):
+        w13_out: [E, 2*N, K]  output_dtype
+        w2_out:  [E, K, N]    output_dtype
+    """
+    # w13: packed along K (dim 1), cols are 2*N (dim 2)
+    # transpose_output=True yields [E, 2*N, K]
+    w13_bf16 = _unpack_and_dequant_int8_gptq(
+        w13, w13_scale, transpose_output=True, output_dtype=output_dtype
+    )
+
+    # w2: packed along N (dim 1 is N//4), cols are K (dim 2)
+    # After unpacking get [E, N, K]; permute to [E, K, N] for TritonExperts
+    w2_unpacked = _unpack_and_dequant_int8_gptq(
+        w2, w2_scale, transpose_output=False, output_dtype=output_dtype
+    )  # [E, N, K]
+    w2_bf16 = w2_unpacked.permute(0, 2, 1).contiguous()  # [E, K, N]
+
+    dummy = torch.ones(1, dtype=torch.float16, device=w13.device)
+    return (
+        w13_bf16,
+        w2_bf16,
+        dummy,  # w13_scales  (unused; nulled in Int8EmulationTritonExperts)
+        dummy,  # w2_scales   (unused)
+        None,  # w13_g_idx
+        None,  # w2_g_idx
+        None,  # w13_g_idx_sort_indices
+        None,  # w2_g_idx_sort_indices
+        None,  # w13_qzeros
+        None,  # w2_qzeros
+        None,  # w13_input_global_scale
+        None,  # w2_input_global_scale
+        None,  # w13_bias
+        None,  # w2_bias
+    )
+
+
+def _infer_num_bits(
+    quant_config,
+    w13: torch.Tensor,
+    w13_scale: torch.Tensor,
+) -> int:
+    """Infer weight bit-width for the emulation path.
+
+    Reads from quant_config (num_bits or weight_bits attribute). If neither is
+    available, infers from the packed/scale shape ratio:
+      int4: pack_factor=8 -> K_packed = K//8, ratio K_packed/n_groups = gs/8
+      int8: pack_factor=4 -> K_packed = K//4, ratio K_packed/n_groups = gs/4
+    The ratio for int8 is exactly 2 times that of int4 for the same group_size,
+    so if K_packed * 8 % n_groups == 0 we assume int4, else int8.
+    """
+    for attr in ("num_bits", "weight_bits"):
+        val = getattr(quant_config, attr, None)
+        if val is not None:
+            return int(val)
+    # Shape-based fallback: w13=[E, K_packed, 2N], scale=[E, n_groups, 2N]
+    # K_packed * pack_factor = K = n_groups * group_size
+    # int4: K_packed * 8 = n_groups * group_size -> K_packed/n_groups = gs/8
+    # int8: K_packed * 4 = n_groups * group_size -> K_packed/n_groups = gs/4
+    # For any valid group_size that is a multiple of 8, int4 always satisfies
+    # K_packed * 8 % n_groups == 0.  If it doesn't, it must be int8.
+    K_packed = w13.shape[1]
+    n_groups = w13_scale.shape[1]
+    if n_groups > 0 and (K_packed * 8) % n_groups == 0:
+        return 4
+    return 8
+
+
+def _convert_gptq_int4_qzeros_to_uint8(qzeros: torch.Tensor) -> torch.Tensor:
+    """Convert GPTQ int32-packed int4 qzeros to kernel uint8 zero-point layout.
+
+    GPTQ qzeros are packed as 8 nibbles per int32, LSB-first.  The nibble value
+    is the actual zero point (the value to subtract from the unpacked weight).
+    No offset adjustment is applied here -- the kernel subtracts the stored
+    value directly, matching the emulation path in _unpack_and_dequant_int4_gptq.
+
+    Input:  [A, B] int32 -- A = n_groups, B = N//8
+    Output: [N//2, n_groups] uint8 -- transposed, repacked 2 nibbles/byte
+    """
+    t = qzeros.view(torch.uint8)  # [A, 4*B] uint8
+    shifter = torch.tensor([0, 4], dtype=torch.uint8, device=t.device)
+    t = (t[:, :, None] >> shifter) & 0xF  # [A, 4*B, 2]
+    t = t[:, :, 0] + t[:, :, 1] * 16  # repack [A, 4*B] uint8
+    return t.T.contiguous()  # [4*B, A] = [N//2, n_groups]
+
+
+def _convert_awq_qweight_to_uint8(w: torch.Tensor) -> torch.Tensor:
+    """Convert AWQ int32-packed qweight to kernel uint8 layout.
+
+    AWQ packs int4 nibbles along N (columns), with interleave [0,2,4,6,1,3,5,7].
+    Kernel expects: [N, K//2] uint8, nibbles packed 2 per byte LSB-first along K.
+
+    Input:  [K, N//8] int32
+    Output: [N, K//2] uint8
+    """
+    size0 = w.size(0)
+    t = w.view(torch.uint8)  # [K, 4*(N//8)] = [K, N//2]
+    shifter = torch.tensor([0, 4], dtype=torch.uint8, device=t.device)
+    t = (t[:, :, None] >> shifter) & 0xF  # [K, N//2, 2] -> [K, N]
+    reverse_awq = [0, 4, 1, 5, 2, 6, 3, 7]
+    t = t.view(-1, 8)[:, reverse_awq]
+    t = t.view(size0, -1)  # [K, N] nibbles, AWQ-deinterleaved
+    t = t.T.contiguous()  # [N, K]
+    t = t[:, 1::2] * 16 + t[:, ::2]  # repack 2 nibbles/byte [N, K//2]
+    return t
+
+
+def _convert_awq_qzeros_to_uint8(qz: torch.Tensor) -> torch.Tensor:
+    """Convert AWQ int32-packed qzeros to kernel uint8 zero-point layout.
+
+    Input:  [n_groups, N//8] int32
+    Output: [N//2, n_groups] uint8
+    """
+    size0 = qz.size(0)
+    t = qz.view(torch.uint8)  # [n_groups, N//2]
+    shifter = torch.tensor([0, 4], dtype=torch.uint8, device=t.device)
+    t = (t[:, :, None] >> shifter) & 0xF  # [n_groups, N//2, 2]
+    reverse_awq = [0, 4, 1, 5, 2, 6, 3, 7]
+    t = t.view(-1, 8)[:, reverse_awq]
+    t = t.view(size0, -1)  # [n_groups, N]
+    t = t.T.contiguous()  # [N, n_groups]
+    t = t[1::2, :] * 16 + t[::2, :]  # repack [N//2, n_groups]
+    return t
+
+
+def _process_weights_triton_wna16(
+    quant_config,
     w13: torch.Tensor,
     w2: torch.Tensor,
     w13_scale: torch.Tensor,
@@ -1176,7 +1434,130 @@ def _process_weights_emulation_gptq(
     w13_qzeros: torch.Tensor | None,
     w2_qzeros: torch.Tensor | None,
 ) -> tuple:
-    """Dequantize int4 weights to BF16 for the emulation backend.
+    """Convert checkpoint weights to uint8 layout for TritonWNA16OTFExperts.
+
+    fused_moe_kernel_gptq_awq expects uint8-packed weights where each byte
+    holds 2 int4 nibbles (int4) or 1 int8 byte:
+        w1:      [E, 2*N, K//2]  uint8  (int4) or [E, 2*N, K] uint8 (int8)
+        w2:      [E, K, N//2]    uint8  (int4) or [E, K, N]    uint8 (int8)
+        w1_scale:[E, 2*N, K//gs] float16
+        w2_scale:[E, K, N//gs]   float16
+        w1_zp:   [E, N, K//gs] uint8 or None,
+                 (int4 asym only; N = 2*N_single//2 packed bytes)
+        w2_zp:   [E, K//2, N//gs]   uint8 or None
+
+    The kernel uses stride_bk in uint8 units. For int4 it steps offs_k//2
+    uint8 positions (each byte holds 2 nibbles); for int8 it steps offs_k
+    uint8 positions (each byte holds 1 value). Total bytes accessed matches
+    the buffer size exactly.
+
+    Input layouts:
+        AutoGPTQ/compressed-tensors: w13 [E, K//pack32, 2*N] int32
+        AutoAWQ:                     w13 [E, K, 2*N//pack32]  int32
+    """
+    from math import gcd
+
+    from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
+
+    E = w13.shape[0]
+    is_awq = isinstance(quant_config, AutoAWQConfig)
+    num_bits = _infer_num_bits(quant_config, w13, w13_scale)
+
+    # --- Step 1: convert weights to uint8 layout [E, 2N, K//pack8] ---
+    if is_awq:
+        # AWQ: w13 [E, K, 2N//pack32] int32, N packed at last dim.
+        w13_out = torch.stack([_convert_awq_qweight_to_uint8(w13[e]) for e in range(E)])
+        w2_out = torch.stack([_convert_awq_qweight_to_uint8(w2[e]) for e in range(E)])
+        K_real = w13.shape[1]
+        N_real = w13.shape[2] * (32 // num_bits) // 2
+    else:
+        # GPTQ / compressed-tensors: w13 [E, K//pack32, 2N] int32.
+        w13_out = w13.permute(0, 2, 1).contiguous().view(torch.uint8)
+        w2_out = w2.permute(0, 2, 1).contiguous().view(torch.uint8)
+        K_real = w13.shape[1] * (32 // num_bits)
+        N_real = w13.shape[2] // 2
+
+    # --- Step 2: transpose scales [E, K//gs, 2N] -> [E, 2N, K//gs] ---
+    w13_scale_out = w13_scale.permute(0, 2, 1).contiguous()
+    w2_scale_out = w2_scale.permute(0, 2, 1).contiguous()
+
+    # --- Step 3: adjust group_size so it divides both K and N ---
+    # The kernel uses a single group_size for both GEMMs. When N_real is
+    # not divisible by the original group_size (e.g. N=192, gs=128 gives
+    # 1 group but ceil(192/128)=2 are needed), we find adjusted_gs =
+    # gcd(gs_w1, gs_w2) and expand scales via repeat_interleave.
+    gs_w1 = K_real // max(w13_scale_out.shape[2], 1)
+    gs_w2 = (
+        N_real // max(w2_scale_out.shape[2], 1) if w2_scale_out.shape[2] > 0 else N_real
+    )
+    adjusted_gs = gcd(gs_w1, gs_w2)
+    while K_real % adjusted_gs != 0 or (N_real > 0 and N_real % adjusted_gs != 0):
+        adjusted_gs //= 2
+        if adjusted_gs < 1:
+            adjusted_gs = 1
+            break
+
+    repeat_w1 = gs_w1 // adjusted_gs
+    repeat_w2 = gs_w2 // adjusted_gs
+    # Expand only when needed: repeat_w > 1 means the original group_size
+    # does not divide evenly, so scales must cover finer groups.
+    if repeat_w1 > 1:
+        w13_scale_out = w13_scale_out.repeat_interleave(repeat_w1, dim=2)
+    if repeat_w2 > 1:
+        w2_scale_out = w2_scale_out.repeat_interleave(repeat_w2, dim=2)
+
+    # --- Step 4: convert and expand zero points (asymmetric only) ---
+    if w13_qzeros is not None and w2_qzeros is not None:
+        if is_awq:
+            w13_zp_out = torch.stack(
+                [_convert_awq_qzeros_to_uint8(w13_qzeros[e]) for e in range(E)]
+            )
+            w2_zp_out = torch.stack(
+                [_convert_awq_qzeros_to_uint8(w2_qzeros[e]) for e in range(E)]
+            )
+        else:
+            w13_zp_out = torch.stack(
+                [_convert_gptq_int4_qzeros_to_uint8(w13_qzeros[e]) for e in range(E)]
+            )
+            w2_zp_out = torch.stack(
+                [_convert_gptq_int4_qzeros_to_uint8(w2_qzeros[e]) for e in range(E)]
+            )
+        if repeat_w1 > 1:
+            w13_zp_out = w13_zp_out.repeat_interleave(repeat_w1, dim=2)
+        if repeat_w2 > 1:
+            w2_zp_out = w2_zp_out.repeat_interleave(repeat_w2, dim=2)
+    else:
+        w13_zp_out = None
+        w2_zp_out = None
+
+    return (
+        w13_out,
+        w2_out,
+        w13_scale_out,
+        w2_scale_out,
+        None,  # w13_g_idx
+        None,  # w2_g_idx
+        None,  # w13_g_idx_sort_indices
+        None,  # w2_g_idx_sort_indices
+        w13_zp_out,
+        w2_zp_out,
+        None,  # w13_input_global_scale
+        None,  # w2_input_global_scale
+        None,  # w13_bias
+        None,  # w2_bias
+    )
+
+
+def _process_weights_emulation_gptq(
+    w13: torch.Tensor,
+    w2: torch.Tensor,
+    w13_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    w13_qzeros: torch.Tensor | None,
+    w2_qzeros: torch.Tensor | None,
+    output_dtype: torch.dtype = torch.bfloat16,
+) -> tuple:
+    """Dequantize int4 weights for the emulation backend.
 
     Inputs are in GPTQ packed format:
         w13: [E, K//8, 2*N]   int32  (gate+up proj stacked on dim 2)
@@ -1185,20 +1566,20 @@ def _process_weights_emulation_gptq(
         w2_scale:  [E, N//gs, K]    float16
 
     Outputs (what TritonExperts expects):
-        w13_out: [E, 2*N, K]  bfloat16
-        w2_out:  [E, K, N]    bfloat16
+        w13_out: [E, 2*N, K]  output_dtype
+        w2_out:  [E, K, N]    output_dtype
     """
     # w13: packed along K (dim 1), output cols are 2*N (dim 2)
     # transpose_output=True yields [E, 2*N, K]
     w13_bf16 = _unpack_and_dequant_int4_gptq(
-        w13, w13_scale, w13_qzeros, transpose_output=True
+        w13, w13_scale, w13_qzeros, transpose_output=True, output_dtype=output_dtype
     )
 
     # w2: packed along N (dim 1 is N//8), output cols are K (dim 2)
     # After unpacking we get [E, N, K]; we want [E, K, N] for TritonExperts
     # transpose_output=False gives [E, N, K], then we permute once more
     w2_unpacked = _unpack_and_dequant_int4_gptq(
-        w2, w2_scale, w2_qzeros, transpose_output=False
+        w2, w2_scale, w2_qzeros, transpose_output=False, output_dtype=output_dtype
     )  # [E, N, K]
     w2_bf16 = w2_unpacked.permute(0, 2, 1).contiguous()  # [E, K, N]
 
@@ -1228,8 +1609,9 @@ def _process_weights_emulation_awq(
     w2_scale: torch.Tensor,
     w13_qzeros: torch.Tensor | None,
     w2_qzeros: torch.Tensor | None,
+    output_dtype: torch.dtype = torch.bfloat16,
 ) -> tuple:
-    """Dequantize AWQ int4 weights to BF16 for the emulation backend.
+    """Dequantize AWQ int4 weights for the emulation backend.
 
     AWQ inputs:
         w13: [E, K, 2*N//8]       int32  (packed along N, gate+up on dim 2)
@@ -1238,22 +1620,23 @@ def _process_weights_emulation_awq(
         w2_scale:  [E, N//gs, K]    float16
 
     Outputs (what TritonExperts expects):
-        w13_out: [E, 2*N, K]  bfloat16
-        w2_out:  [E, K, N]    bfloat16
+        w13_out: [E, 2*N, K]  output_dtype
+        w2_out:  [E, K, N]    output_dtype
     """
     # w13: AWQ-packed along N (dim 2), K is unpacked in dim 1
     # _unpack_and_dequant_int4_awq with transpose_output=True yields [E, 2*N, K]
     w13_bf16 = _unpack_and_dequant_int4_awq(
-        w13, w13_scale, w13_qzeros, transpose_output=True
+        w13, w13_scale, w13_qzeros, transpose_output=True, output_dtype=output_dtype
     )
 
-    # w2: AWQ packs along K (dim 2 is K//8), N is unpacked in dim 1.
-    # AWQ w2 is [E, N, K//8] — same column-pack format applied to the K dim.
+    # w2: AWQ w2 is [E, N, K//8] int32; K is packed at dim 2 using the same
+    # AWQ nibble interleave. _unpack_and_dequant_int4_awq treats dim 2 as
+    # the packed dim, giving [E, N, K], then permute to [E, K, N].
     # _unpack_and_dequant_int4_awq expects [E, rows, N_packed] where the
     # packed dim is columns. Treat dim 1 as rows and dim 2 as N_packed:
     # unpacking gives [E, N, K]. Then permute to [E, K, N].
     w2_unpacked = _unpack_and_dequant_int4_awq(
-        w2, w2_scale, w2_qzeros, transpose_output=False
+        w2, w2_scale, w2_qzeros, transpose_output=False, output_dtype=output_dtype
     )  # [E, N, K]
     w2_bf16 = w2_unpacked.permute(0, 2, 1).contiguous()  # [E, K, N]
 
@@ -1276,6 +1659,67 @@ def _process_weights_emulation_awq(
     )
 
 
+def make_group_size_adjusted_weight_loader(
+    weight_loader,
+    group_size_div_factor: int,
+):
+    """Wrap a weight loader to expand scale/zero-point rows for a finer group size.
+
+    When intermediate_size_per_partition % group_size != 0 (but
+    intermediate_size_per_partition >= group_size), the adjusted group size is
+    smaller than the checkpoint group size.  The checkpoint scale has fewer rows
+    than the parameter buffer expects (one row per original group, but the buffer
+    is allocated for the finer adjusted group size).  This wrapper applies
+    repeat_interleave(group_size_div_factor, dim=0) to w2 (down-proj) scale and
+    zero-point checkpoint tensors before passing to the generic loader, so each
+    original scale row is replicated to cover the finer sub-groups.  Only w2
+    tensors are expanded: w13 (gate+up proj) groups along K (hidden_size) which
+    always divides evenly by the original group_size.  All weight tensors are
+    passed through unmodified.
+
+    Note: this does NOT handle intermediate_size_per_partition < group_size.
+    That case has 0 checkpoint scale rows for the TP rank and cannot be
+    recovered; a ValueError is raised at create_weights time instead.
+
+    Args:
+        weight_loader: the original weight_loader callable.
+        group_size_div_factor: original_group_size // adjusted_group_size.
+    """
+    if group_size_div_factor <= 1:
+        return weight_loader
+
+    def _adjusted_loader(
+        param,
+        loaded_weight,
+        weight_name: str,
+        shard_id: str,
+        expert_id: int,
+        return_success: bool = False,
+    ):
+        # Only expand w2 (down-proj) scales/zeros: the group-size mismatch
+        # is in the N (intermediate) dimension sharded by TP, which belongs
+        # to w2.  w13 groups along K (hidden_size) which divides evenly.
+        is_w2_scale_or_zero = (
+            "w2" in weight_name
+            and ("scale" in weight_name or "zeros" in weight_name)
+            and "weight" not in weight_name
+        )
+        if is_w2_scale_or_zero:
+            loaded_weight = loaded_weight.repeat_interleave(
+                group_size_div_factor, dim=0
+            )
+        return weight_loader(
+            param,
+            loaded_weight,
+            weight_name,
+            shard_id,
+            expert_id,
+            return_success=return_success,
+        )
+
+    return _adjusted_loader
+
+
 def convert_to_wna16_moe_kernel_format(
     backend: WNA16MoEBackend,
     layer: torch.nn.Module,
@@ -1291,6 +1735,7 @@ def convert_to_wna16_moe_kernel_format(
     w2_qzeros: torch.Tensor | None = None,
     w13_bias: torch.Tensor | None = None,
     w2_bias: torch.Tensor | None = None,
+    experts_cls: type | None = None,
 ) -> (
     tuple[
         torch.Tensor,  # w13_qweight
@@ -1321,6 +1766,9 @@ def convert_to_wna16_moe_kernel_format(
         layer: the ``FusedMoE`` layer whose parameters are being prepared.
         quant_config: the ``QuantizationConfig`` for this layer.
         input_dtype: optional activation dtype, usually should be 16 bit.
+        experts_cls: the experts class selected by the oracle. Used by the
+            EMULATION backend to dispatch to the OTF path when
+            ``TritonWNA16OTFExperts`` was chosen instead of dequant.
     """
     if backend == WNA16MoEBackend.HUMMING:
         from vllm.model_executor.layers.quantization.utils.humming_utils import (
@@ -1455,7 +1903,7 @@ def convert_to_wna16_moe_kernel_format(
             empty,  # w2_g_idx
             empty,  # w13_g_idx_sort_indices
             empty,  # w2_g_idx_sort_indices
-            None,  # w13_qzeros — sym int4 on XPU has none; kernel does uint4b8→s4
+            None,  # w13_qzeros -- sym int4 on XPU has none; kernel does uint4b8->s4
             None,  # w2_qzeros
             None,  # w13_input_global_scale
             None,  # w2_input_global_scale
@@ -1463,6 +1911,40 @@ def convert_to_wna16_moe_kernel_format(
             w2_bias_out,
         )
     elif backend == WNA16MoEBackend.EMULATION:
+        from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
+            TritonWNA16OTFExperts,
+        )
+
+        # When the oracle selected TritonWNA16OTFExperts under the EMULATION
+        # backend, use the OTF (uint8-packed) weight path, not the dequant path.
+        if experts_cls is TritonWNA16OTFExperts:
+            return _process_weights_triton_wna16(
+                quant_config,
+                w13,
+                w2,
+                w13_scale,
+                w2_scale,
+                w13_qzeros,
+                w2_qzeros,
+            )
+
+        # Use the model's activation dtype (FusedMoEConfig.in_dtype) so weights
+        # and activations share the same dtype at forward time, avoiding a
+        # per-call cast in apply(). in_dtype is always set on FusedMoEConfig;
+        # input_dtype is unreliable (callers may set it to None).
+        float_dtypes = (torch.float16, torch.bfloat16, torch.float32)
+        in_dtype = getattr(getattr(layer, "moe_config", None), "in_dtype", None)
+        output_dtype = in_dtype if in_dtype in float_dtypes else torch.bfloat16
+        num_bits = _infer_num_bits(quant_config, w13, w13_scale)
+        if num_bits == 8:
+            return _process_weights_emulation_int8(
+                w13,
+                w2,
+                w13_scale,
+                w2_scale,
+                output_dtype=output_dtype,
+            )
+        # int4 path (AWQ or GPTQ)
         from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
 
         if isinstance(quant_config, AutoAWQConfig):
@@ -1473,6 +1955,7 @@ def convert_to_wna16_moe_kernel_format(
                 w2_scale,
                 w13_qzeros,
                 w2_qzeros,
+                output_dtype=output_dtype,
             )
         return _process_weights_emulation_gptq(
             w13,
@@ -1481,6 +1964,7 @@ def convert_to_wna16_moe_kernel_format(
             w2_scale,
             w13_qzeros,
             w2_qzeros,
+            output_dtype=output_dtype,
         )
     else:
         raise ValueError(f"Unsupported wna16 MoE backend: {backend.value}")

--- a/vllm/model_executor/layers/quantization/auto_awq.py
+++ b/vllm/model_executor/layers/quantization/auto_awq.py
@@ -28,6 +28,7 @@ from vllm.model_executor.layers.fused_moe import (
 from vllm.model_executor.layers.fused_moe.oracle.int_wna16 import (
     WNA16MoEBackend,
     convert_to_wna16_moe_kernel_format,
+    make_group_size_adjusted_weight_loader,
     make_wna16_moe_kernel,
     make_wna16_moe_quant_config,
     select_wna16_moe_backend,
@@ -46,7 +47,6 @@ from vllm.model_executor.layers.quantization.utils import replace_parameter
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     check_marlin_supported,
     check_marlin_supports_layer,
-    check_moe_marlin_supports_layer,
     get_marlin_input_dtype,
     marlin_make_workspace_new,
     verify_marlin_supported,
@@ -54,6 +54,7 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     is_layer_skipped,
     kInt4Static,
+    kInt4StaticAsym,
 )
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.model_executor.parameter import (
@@ -110,12 +111,12 @@ def _convert_awq_to_standard_format(
     )
     shifts = torch.arange(0, 32, size_bits, dtype=torch.int32, device=device)
 
-    # --- Convert qweight: (K, N // pack) packed_dim=1 → (K // pack, N) packed_dim=0
+    # --- Convert qweight: (K, N // pack) packed_dim=1 -> (K // pack, N) packed_dim=0
     qw = getattr(layer, w_q_name).data
     K, N_packed = qw.shape
     N = N_packed * pack_factor
 
-    # Unpack int32 → individual values, fix AWQ ordering
+    # Unpack int32 -> individual values, fix AWQ ordering
     unpacked = (qw.unsqueeze(-1) >> shifts) & mask  # (K, N_packed, pack_factor)
     unpacked = unpacked[:, :, reverse_order]
     unpacked = unpacked.reshape(K, N)  # (K, N)
@@ -243,8 +244,8 @@ class AutoAWQConfig(QuantizationConfig):
         modules_to_not_convert = cls.get_from_keys_or(
             config, ["modules_to_not_convert"], None
         )
-        # Ensure full_config uses "awq" as quant_method for MoE fallback compatibility.
-        # MoeWNA16Config only accepts "gptq" or "awq", so we normalize here.
+        # Normalize quant_method so downstream config consumers see a
+        # consistent value ("awq") regardless of the source checkpoint format.
         full_config = config.copy()
         full_config["quant_method"] = "awq"
         return cls(
@@ -340,21 +341,9 @@ class AutoAWQConfig(QuantizationConfig):
             ):
                 return UnquantizedFusedMoEMethod(layer.moe_config)
 
-            if not check_moe_marlin_supports_layer(
-                layer, self.group_size, allow_tile_padding=True
-            ):
-                logger.warning_once(
-                    f"Layer '{prefix}' is not supported by AutoAWQMoEMarlin. "
-                    "Falling back to Moe WNA16 kernels."
-                )
-                from vllm.model_executor.layers.quantization.moe_wna16 import (
-                    MoeWNA16Config,
-                )
-
-                return MoeWNA16Config.from_config(self.full_config).get_quant_method(
-                    layer, prefix
-                )
-
+            # AutoAWQMoEMethod calls select_wna16_moe_backend which reads
+            # FusedMoEConfig.moe_backend, so --moe-backend is fully honoured
+            # on all platforms including ROCm.
             return AutoAWQMoEMethod(self, layer.moe_config)
 
         return None
@@ -557,9 +546,10 @@ class AutoAWQMoEMethod(FusedMoEMethodBase):
         self.quant_type = scalar_types.uint4
         self.input_dtype = None
         self.use_marlin = True
+        weight_key = kInt4StaticAsym if self.quant_config.zero_point else kInt4Static
         self.wna16_moe_backend, self.experts_cls = select_wna16_moe_backend(
             moe,
-            kInt4Static,
+            weight_key,
         )
 
     def create_weights(
@@ -578,7 +568,6 @@ class AutoAWQMoEMethod(FusedMoEMethodBase):
                 "quant_method": FusedMoeWeightScaleSupported.GROUP.value,
             }
         )
-
         intermediate_size_full = extra_weight_attrs.pop(
             "intermediate_size_full", intermediate_size_per_partition
         )
@@ -609,9 +598,40 @@ class AutoAWQMoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w2_qweight, extra_weight_attrs)
 
         num_groups_w13 = hidden_size // self.quant_config.group_size
-        num_groups_w2 = intermediate_size_per_partition // self.quant_config.group_size
+        # When intermediate_size_per_partition % group_size != 0 (but
+        # intermediate_size_per_partition >= group_size), find the largest
+        # adjusted_gs that divides it, then expand scale rows at load time.
+        # When intermediate_size_per_partition < group_size, raise -- the
+        # checkpoint has 0 scale rows for this TP rank and cannot be recovered.
+        if intermediate_size_per_partition < self.quant_config.group_size:
+            raise ValueError(
+                f"MoE expert w2 (down proj) intermediate_size_per_partition "
+                f"({intermediate_size_per_partition}) is smaller than group_size "
+                f"({self.quant_config.group_size}). The TP sharding splits "
+                f"a single quantization group across ranks; the checkpoint "
+                f"scale has 0 rows for this rank and cannot be recovered. "
+                f"Reduce --tensor-parallel-size so that "
+                f"moe_intermediate_size / tp >= group_size."
+            )
+        adjusted_gs = self.quant_config.group_size
+        while intermediate_size_per_partition % adjusted_gs != 0:
+            adjusted_gs //= 2
+            assert adjusted_gs >= 1, (
+                f"Cannot find a valid adjusted group_size for "
+                f"intermediate_size_per_partition={intermediate_size_per_partition}"
+            )
+        group_size_div_factor = self.quant_config.group_size // adjusted_gs
+        num_groups_w2 = intermediate_size_per_partition // adjusted_gs
         layer.num_groups_w13 = num_groups_w13
         layer.num_groups_w2 = num_groups_w2
+        layer.group_size_div_factor = group_size_div_factor
+        if group_size_div_factor > 1:
+            weight_loader = extra_weight_attrs["weight_loader"]
+            extra_weight_attrs["weight_loader"] = (
+                make_group_size_adjusted_weight_loader(
+                    weight_loader, group_size_div_factor
+                )
+            )
 
         # WEIGHT_SCALES
         # Allocate 2 scales for w1 and w3 respectively.
@@ -660,8 +680,9 @@ class AutoAWQMoEMethod(FusedMoEMethodBase):
         layer.register_parameter("w2_qzeros", w2_qzeros)
         set_weight_attrs(w2_qzeros, extra_weight_attrs)
 
-        device = layer.w13_qweight.device
-        layer.workspace = marlin_make_workspace_new(device, 4)
+        if self.wna16_moe_backend != WNA16MoEBackend.EMULATION:
+            device = layer.w13_qweight.device
+            layer.workspace = marlin_make_workspace_new(device, 4)
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
         converted = convert_to_wna16_moe_kernel_format(
@@ -677,6 +698,7 @@ class AutoAWQMoEMethod(FusedMoEMethodBase):
             w2_qzeros=layer.w2_qzeros,
             w13_bias=getattr(layer, "w13_bias", None),
             w2_bias=getattr(layer, "w2_bias", None),
+            experts_cls=self.experts_cls,
         )
 
         if converted is None:
@@ -759,6 +781,32 @@ class AutoAWQMoEMethod(FusedMoEMethodBase):
             )
 
             return get_humming_moe_quant_config(layer)
+
+        from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
+            TritonWNA16OTFExperts,
+        )
+
+        if self.experts_cls is TritonWNA16OTFExperts:
+            from vllm.model_executor.layers.fused_moe.config import (
+                int4_w4a16_moe_quant_config,
+            )
+
+            gs_eff = (
+                layer.w2_qweight.shape[1] // layer.w13_scales.shape[2]
+                if layer.w13_scales.shape[2] > 0
+                else self.quant_config.group_size
+            )
+            use_zp = self.quant_config.zero_point
+            return int4_w4a16_moe_quant_config(
+                w1_scale=layer.w13_scales,
+                w2_scale=layer.w2_scales,
+                w1_zp=getattr(layer, "w13_qzeros", None) if use_zp else None,
+                w2_zp=getattr(layer, "w2_qzeros", None) if use_zp else None,
+                w1_bias=getattr(layer, "w13_bias", None),
+                w2_bias=getattr(layer, "w2_bias", None),
+                block_shape=[0, gs_eff],
+            )
+
         return make_wna16_moe_quant_config(
             w1_scale=layer.w13_scales,
             w2_scale=layer.w2_scales,

--- a/vllm/model_executor/layers/quantization/auto_awq.py
+++ b/vllm/model_executor/layers/quantization/auto_awq.py
@@ -111,12 +111,12 @@ def _convert_awq_to_standard_format(
     )
     shifts = torch.arange(0, 32, size_bits, dtype=torch.int32, device=device)
 
-    # --- Convert qweight: (K, N // pack) packed_dim=1 -> (K // pack, N) packed_dim=0
+    # --- Convert qweight: (K, N // pack) packed_dim=1 → (K // pack, N) packed_dim=0
     qw = getattr(layer, w_q_name).data
     K, N_packed = qw.shape
     N = N_packed * pack_factor
 
-    # Unpack int32 -> individual values, fix AWQ ordering
+    # Unpack int32 → individual values, fix AWQ ordering
     unpacked = (qw.unsqueeze(-1) >> shifts) & mask  # (K, N_packed, pack_factor)
     unpacked = unpacked[:, :, reverse_order]
     unpacked = unpacked.reshape(K, N)  # (K, N)
@@ -244,8 +244,8 @@ class AutoAWQConfig(QuantizationConfig):
         modules_to_not_convert = cls.get_from_keys_or(
             config, ["modules_to_not_convert"], None
         )
-        # Normalize quant_method so downstream config consumers see a
-        # consistent value ("awq") regardless of the source checkpoint format.
+        # Ensure full_config uses "awq" as quant_method for MoE fallback compatibility.
+        # MoeWNA16Config only accepts "gptq" or "awq", so we normalize here.
         full_config = config.copy()
         full_config["quant_method"] = "awq"
         return cls(

--- a/vllm/model_executor/layers/quantization/auto_gptq.py
+++ b/vllm/model_executor/layers/quantization/auto_gptq.py
@@ -27,6 +27,7 @@ from vllm.model_executor.layers.fused_moe import (
 from vllm.model_executor.layers.fused_moe.oracle.int_wna16 import (
     WNA16MoEBackend,
     convert_to_wna16_moe_kernel_format,
+    make_group_size_adjusted_weight_loader,
     make_wna16_moe_kernel,
     select_wna16_moe_backend,
 )
@@ -241,24 +242,18 @@ class AutoGPTQConfig(QuantizationConfig):
         self, layer: torch.nn.Module, prefix: str
     ) -> "QuantizeMethodBase | None":
         if isinstance(layer, RoutedExperts):
-            from vllm.model_executor.layers.quantization.moe_wna16 import MoeWNA16Config
-
-            if not check_moe_marlin_supports_layer(
-                layer, self.group_size, allow_tile_padding=not self.desc_act
-            ):
-                logger.warning_once(
-                    f"Layer '{prefix}' is not supported by GPTQMoeMarlin. "
-                    "Falling back to Moe WNA16 kernels."
-                )
-                return MoeWNA16Config.from_config(self.full_config).get_quant_method(
-                    layer, prefix
-                )
+            # AutoGPTQMoEMethod calls select_wna16_moe_backend which reads
+            # FusedMoEConfig.moe_backend, so --moe-backend is fully honoured
+            # on all platforms including ROCm.
             moe_quant_method = get_moe_quant_method(
                 self, layer, prefix, AutoGPTQMoEMethod
             )
             if moe_quant_method is None:
                 return None
-            moe_quant_method.input_dtype = get_marlin_input_dtype(prefix)
+            if check_moe_marlin_supports_layer(
+                layer, self.group_size, allow_tile_padding=not self.desc_act
+            ):
+                moe_quant_method.input_dtype = get_marlin_input_dtype(prefix)
             return moe_quant_method
 
         quant_method = get_linear_quant_method(
@@ -521,17 +516,55 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
                 if self.quant_config.desc_act
                 else intermediate_size_per_partition
             )
-            scales_size2 = w2_scales_size // self.quant_config.group_size
+            # When w2_scales_size % group_size != 0 (but >= group_size), find
+            # the largest adjusted_gs that divides it and expand scale rows at
+            # load time via make_group_size_adjusted_weight_loader.
+            # When w2_scales_size < group_size, raise -- the checkpoint has 0
+            # scale rows for this TP rank and cannot be recovered.
+            if w2_scales_size < self.quant_config.group_size:
+                size_label = (
+                    "intermediate_size_full"
+                    if self.quant_config.desc_act
+                    else "intermediate_size_per_partition"
+                )
+                raise ValueError(
+                    f"MoE expert w2 (down proj) {size_label} "
+                    f"({w2_scales_size}) is smaller than group_size "
+                    f"({self.quant_config.group_size}). The TP sharding splits "
+                    f"a single quantization group across ranks; the checkpoint "
+                    f"scale has 0 rows for this rank and cannot be recovered. "
+                    f"Reduce --tensor-parallel-size so that "
+                    f"moe_intermediate_size / tp >= group_size."
+                )
+            adjusted_gs = self.quant_config.group_size
+            while w2_scales_size % adjusted_gs != 0:
+                adjusted_gs //= 2
+                assert adjusted_gs >= 1, (
+                    f"Cannot find a valid adjusted group_size for "
+                    f"intermediate_size_per_partition={w2_scales_size}"
+                )
+            group_size_div_factor = self.quant_config.group_size // adjusted_gs
+            scales_size2 = w2_scales_size // adjusted_gs
             strategy = FusedMoeWeightScaleSupported.GROUP.value
         else:
+            adjusted_gs = -1
+            group_size_div_factor = 1
             scales_size13 = 1
             scales_size2 = 1
             strategy = FusedMoeWeightScaleSupported.CHANNEL.value
 
         layer.num_groups_w13 = scales_size13
         layer.num_groups_w2 = scales_size2
+        layer.group_size_div_factor = group_size_div_factor
 
         extra_weight_attrs.update({"quant_method": strategy, "is_transposed": True})
+        if group_size_div_factor > 1:
+            weight_loader = extra_weight_attrs["weight_loader"]
+            extra_weight_attrs["weight_loader"] = (
+                make_group_size_adjusted_weight_loader(
+                    weight_loader, group_size_div_factor
+                )
+            )
         # Fused gate_up_proj (column parallel)
         w13_qweight = torch.nn.Parameter(
             torch.empty(
@@ -577,7 +610,7 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w2_scales, extra_weight_attrs)
         # don't shard the w2 scales when running act order
         set_weight_attrs(w2_scales, {"load_full_w2": self.quant_config.desc_act})
-        # up_proj scales
+        # up_proj zero points
         w13_qzeros = torch.nn.Parameter(
             torch.empty(
                 num_experts,
@@ -589,7 +622,7 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
         )
         layer.register_parameter("w13_qzeros", w13_qzeros)
         set_weight_attrs(w13_qzeros, extra_weight_attrs)
-        # down_proj scales
+        # down_proj zero points
         w2_qzeros = torch.nn.Parameter(
             torch.empty(
                 num_experts,
@@ -644,8 +677,10 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
         layer.register_parameter("w2_g_idx_sort_indices", w2_g_idx_sort_indices)
         set_weight_attrs(w2_g_idx_sort_indices, extra_weight_attrs)
 
-        if self.experts_cls is not None and issubclass(
-            self.experts_cls, FusedMoEExpertsModular
+        if (
+            self.experts_cls is not None
+            and issubclass(self.experts_cls, FusedMoEExpertsModular)
+            and self.wna16_moe_backend != WNA16MoEBackend.EMULATION
         ):
             device = layer.w13_qweight.device
             layer.workspace = marlin_make_workspace_new(device, 4)
@@ -671,6 +706,7 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
             w2_g_idx=layer.w2_g_idx,
             w13_bias=getattr(layer, "w13_bias", None),
             w2_bias=getattr(layer, "w2_bias", None),
+            experts_cls=self.experts_cls,
         )
 
         if converted is None:
@@ -771,6 +807,49 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
             )
 
             return get_humming_moe_quant_config(layer)
+
+        from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
+            TritonWNA16OTFExperts,
+        )
+
+        if self.experts_cls is TritonWNA16OTFExperts:
+            # TritonWNA16OTFExperts requires block_shape[0] == 0,
+            # which int4/int8_w*a16_moe_quant_config produce (unlike
+            # gptq_marlin_moe_quant_config which sets block_shape[0] = 1).
+            # They have different interpretations for this value.
+            from vllm.model_executor.layers.fused_moe.config import (
+                int4_w4a16_moe_quant_config,
+                int8_w8a16_moe_quant_config,
+            )
+
+            # Derive gs_eff from the repacked scale shape.
+            # After _process_weights_triton_wna16:
+            #   w13_scales = [E, 2N, K//gs_eff]  so K//gs_eff = w13_scales.shape[2]
+            #   w2_qweight = [E, K, N//pack8]     so K = w2_qweight.shape[1]
+            # Therefore: gs_eff = K / (K//gs_eff)
+            #                   = w2_qweight.shape[1] / w13_scales.shape[2]
+            # This correctly reflects any repeat-interleave applied to scales in
+            # _process_weights_triton_wna16 when gs_w1 != gs_w2.
+            gs_eff = (
+                layer.w2_qweight.shape[1] // layer.w13_scales.shape[2]
+                if layer.w13_scales.shape[2] > 0
+                else self.quant_config.group_size
+            )
+            use_zp = not self.quant_config.is_sym
+            config_builder = (
+                int4_w4a16_moe_quant_config
+                if self.quant_config.weight_bits == 4
+                else int8_w8a16_moe_quant_config
+            )
+            return config_builder(
+                w1_scale=layer.w13_scales,
+                w2_scale=layer.w2_scales,
+                w1_zp=getattr(layer, "w13_qzeros", None) if use_zp else None,
+                w2_zp=getattr(layer, "w2_qzeros", None) if use_zp else None,
+                w1_bias=getattr(layer, "w13_bias", None),
+                w2_bias=getattr(layer, "w2_bias", None),
+                block_shape=[0, gs_eff],
+            )
 
         from vllm.model_executor.layers.fused_moe.config import (
             gptq_marlin_moe_quant_config,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe.py
@@ -88,11 +88,10 @@ class CompressedTensorsMoEMethod(FusedMoEMethodBase):
 
             if not valid_format_and_bits:
                 raise ValueError(
-                    "For Fused MoE layers, only format: ",
-                    f"{CompressionFormat.pack_quantized.value} ",
-                    f" and bits: {WNA16_SUPPORTED_BITS} is supported ",
-                    f"but got format: {CompressionFormat.pack_quantized.value} "
-                    f" and bits: {weight_quant.num_bits}",
+                    f"For Fused MoE layers, only format "
+                    f"{CompressionFormat.pack_quantized.value!r} and bits "
+                    f"{WNA16_SUPPORTED_BITS} are supported, "
+                    f"but got format {format!r} and bits {weight_quant.num_bits}."
                 )
 
             # Prefer to use the MarlinMoE kernel when it is supported.
@@ -142,32 +141,22 @@ class CompressedTensorsMoEMethod(FusedMoEMethodBase):
                         return CompressedTensorsW4A16FlydslMoEMethod(
                             weight_quant, input_quant, layer.moe_config
                         )
-                    elif moe_backend == "emulation":
-                        # Although this is called 'Marlin', actually it selects
-                        # emulation backend by calling select_wna16_moe_backend.
-                        # TODO: we need to update CompressedTensorsWNA16MoeMethod
-                        # to honor "--moe-backend" option
-                        from .compressed_tensors_moe_wna16_marlin import (
-                            CompressedTensorsWNA16MarlinMoEMethod,
-                        )
 
-                        logger.info_once(
-                            "Using CompressedTensorsWNA16MarlinMoEMethod "
-                            "(emulation backend requested)"
-                        )
-                        return CompressedTensorsWNA16MarlinMoEMethod(
-                            weight_quant, input_quant, layer.moe_config, layer_name
-                        )
-
-                from .compressed_tensors_moe_wna16 import (
-                    CompressedTensorsWNA16MoEMethod,
+                # Route through the oracle-based method.
+                # CompressedTensorsWNA16MarlinMoEMethod calls
+                # select_wna16_moe_backend which reads moe_backend from
+                # FusedMoEConfig, so --moe-backend is fully honoured.
+                from .compressed_tensors_moe_wna16_marlin import (
+                    CompressedTensorsWNA16MarlinMoEMethod,
                 )
 
-                logger.info_once("Using CompressedTensorsWNA16MoEMethod")
-                return CompressedTensorsWNA16MoEMethod(
-                    weight_quant, input_quant, layer.moe_config
+                logger.info_once("Using CompressedTensorsWNA16MarlinMoEMethod")
+                return CompressedTensorsWNA16MarlinMoEMethod(
+                    weight_quant, input_quant, layer.moe_config, layer_name
                 )
             else:
+                # CompressedTensorsWNA16MarlinMoEMethod also honours
+                # --moe-backend on CUDA via select_wna16_moe_backend.
                 from .compressed_tensors_moe_wna16_marlin import (
                     CompressedTensorsWNA16MarlinMoEMethod,
                 )

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
@@ -240,11 +240,11 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
             from vllm.triton_utils import HAS_TRITON
 
             if HAS_TRITON:
-                from vllm.model_executor.layers.fused_moe import TritonWNA16Experts
+                from vllm.model_executor.layers.fused_moe import TritonWNA16OTFExperts
 
                 layer.w13_weight = layer.w13_weight_packed
                 layer.w2_weight = layer.w2_weight_packed
-                return TritonWNA16Experts(
+                return TritonWNA16OTFExperts(
                     moe_config=self.moe, quant_config=self.moe_quant_config
                 )
             else:

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16_marlin.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16_marlin.py
@@ -429,6 +429,7 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
             w2_g_idx=layer.w2_weight_g_idx,
             w13_qzeros=getattr(layer, "w13_weight_zero_point", None),
             w2_qzeros=getattr(layer, "w2_weight_zero_point", None),
+            experts_cls=self.experts_cls,
         )
         if converted is None:
             # In-place backends (e.g. Humming) are not wired through this
@@ -490,7 +491,7 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
                     torch.nn.Parameter(w2_input_global_scale, requires_grad=False),
                 )
 
-            # Marlin workspace — only needed for Marlin-family backends, not emulation.
+            # Marlin workspace -- only needed for Marlin-family backends, not emulation.
             if (
                 self.experts_cls is not None
                 and issubclass(self.experts_cls, FusedMoEExpertsModular)

--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -91,7 +91,7 @@ class ScaleDesc:
         }
         group_shape = d.get(self.group_shape, str(self.group_shape))
         return (
-            f"{fx.graph.dtype_abbrs[self.dtype]},"
+            f"{fx.graph.dtype_abbrs.get(self.dtype, str(self.dtype))},"
             f"{'static' if self.static else 'dynamic'},{group_shape}"
         )
 
@@ -114,7 +114,7 @@ class QuantKey:
     def __str__(self):
         scale2_str = f"scale2({self.scale2})," if self.scale2 else ""
         return (
-            f"QuantKey({fx.graph.dtype_abbrs[self.dtype]},"
+            f"QuantKey({fx.graph.dtype_abbrs.get(self.dtype, str(self.dtype))},"
             f"scale({self.scale}),{scale2_str}"
             f"{'a' if not self.symmetric else ''}symmetric)"
         )


### PR DESCRIPTION
## Purpose
1. Add Int8EmulationTritonExperts and TritonWNA16OTFExperts to EMULATION MoE backend to support int4/int8 quantization for WNA16;
  1.1 Int8EmulationTritonExperts: dequant at load time;
  1.2 TritonWNA16OTFExperts: dequant on-the-fly, supporint sym/asym/static/dynamic int4 quantization schemes, and also int8 quantization;
  1.3 TritonWNA16OTFExperts is added to replace legacy MoeWNA16Method (same functionality with different structure to enable LoRA/EP/DP);

2.  Update moe backend selection logic to honor --moe-backend cmd option for WNA16 case for ROCm branch

