### PR TITLE
[Bugfix] Guard scaled_fp4_quant against non-contiguous input

### DIFF
--- a/tests/kernels/quantization/test_nvfp4_quant.py
+++ b/tests/kernels/quantization/test_nvfp4_quant.py
@@ -306,3 +306,29 @@ def test_quantize_to_fp4_padded_no_sf_swizzled(pad_shape: tuple[int, int]) -> No
     out_ans = cast_from_fp4(out, m, n)
     torch.testing.assert_close(out_ans, out_ref)
     torch.testing.assert_close(scale_ans, scale_ref)
+
+
+@pytest.mark.parametrize("shape", [(2, 512), (16, 1024), (128, 4096)])
+@torch.inference_mode()
+def test_quantize_to_fp4_noncontiguous_input(shape: tuple[int, int]) -> None:
+    """A strided (non-contiguous) view must quantize the same as its
+    contiguous copy; previously the kernel read the view's buffer linearly
+    and silently quantized the wrong memory for every row past the first."""
+    dtype = torch.float16
+    set_random_seed(42)
+    torch.set_default_device("cuda:0")
+
+    m, n = shape
+
+    wide = torch.randn((m, 2 * n), dtype=dtype)
+    x_strided = wide[:, :n]
+    assert not x_strided.is_contiguous()
+
+    tensor_amax = torch.abs(x_strided).max().to(torch.float32)
+    global_scale = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / tensor_amax
+
+    out_ref, scale_ref = ops.scaled_fp4_quant(x_strided.contiguous(), global_scale)
+    out, out_scale = ops.scaled_fp4_quant(x_strided, global_scale)
+
+    torch.testing.assert_close(out, out_ref)
+    torch.testing.assert_close(out_scale, scale_ref)

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1556,6 +1556,13 @@ def scaled_fp4_quant(
     assert input.ndim >= 1, f"input.ndim needs to be >= 1, but got {input.ndim}."
     other_dims = 1 if input.ndim == 1 else -1
     input = input.reshape(other_dims, input.shape[-1])
+    if not input.is_contiguous():
+        # The quant kernels read the input buffer linearly. reshape() keeps
+        # a strided view whenever it can (e.g. for a column-sliced tensor),
+        # in which case the kernel would silently quantize the wrong memory:
+        # row 0 comes out right and every following row is garbage, with no
+        # error raised.
+        input = input.contiguous()
     m, n = input.shape
     block_size = 16
 


### PR DESCRIPTION
## Purpose

`scaled_fp4_quant`'s Python wrapper does `input.reshape(other_dims, input.shape[-1])`, which keeps a **strided view** whenever it can (e.g. for a column-sliced tensor), and `torch.ops._C.scaled_fp4_quant.out` reads the input buffer linearly with no stride/contiguity check. A non-contiguous input is therefore silently quantized from the **wrong memory**: row 0 comes out correct and every following row is garbage, with no error raised.

Found while auditing NVFP4 numerics on SM120 for #48898 (this is not that bug's root cause — in-engine activations turned out to be contiguous — but it is a latent silent-corruption hazard for any caller passing a view).

## Changes

- `vllm/_custom_ops.py`: fall back to `.contiguous()` when the reshaped input is not contiguous.
- `tests/kernels/quantization/test_nvfp4_quant.py`: regression test comparing a column-sliced strided view against its contiguous copy.

## Duplicate check

`gh pr list --state open --search "scaled_fp4_quant contiguous"` returns only this PR; no open PR touches this wrapper's input handling.

## Test

`pytest tests/kernels/quantization/test_nvfp4_quant.py -v -k noncontiguous` on RTX 6000D (SM120), CUDA 13.0, torch 2.11 cu130.

Before the fix (same wrapper on 0.25.1 and current main), packed-byte match between a strided view and a contiguous copy of identical values:

```
M=1: 1.0000   M=2: 0.5018   M=16: 0.0664   M=128: 0.0120   (row 0 always correct, no error)
```

After the fix: 1.0000 at every M. The new test fails before this change and passes after. No effect on contiguous inputs (the guard is a no-op for them), so no model-eval delta expected; GSM8K (limit 50) with NVFP4 Qwen2.5-VL-72B on the touched path was 0.66 flex before/after on TP1.

An additional `TORCH_CHECK(input.is_contiguous())` in the csrc kernel entry would also protect non-wrapper callers; happy to add it here or as a follow-up if preferred.

---
AI assistance was used for the investigation and drafting of this change; I reviewed every changed line and ran the tests above.