### PR TITLE
[Bugfix] Gate FlashInferTrtllmNvFp4LinearKernel on sm_10x

### DIFF
--- a/vllm/model_executor/kernels/linear/nvfp4/flashinfer.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/flashinfer.py
@@ -183,6 +183,11 @@ class FlashInferTrtllmNvFp4LinearKernel(NvFp4LinearKernel):
     def is_supported(
         cls, compute_capability: int | None = None
     ) -> tuple[bool, str | None]:
+        if not current_platform.is_device_capability_family(100):
+            # FlashInfer rejects the trtllm backend on other architectures at
+            # dispatch time (BackendSupportedError), e.g. on SM120, so
+            # advertising support would guarantee a runtime crash.
+            return False, "FlashInfer TRTLLM NVFP4 GEMM requires sm_10x"
         if has_flashinfer():
             return True, None
         return False, "FlashInfer required"


### PR DESCRIPTION
## Purpose

`FlashInferTrtllmNvFp4LinearKernel.is_supported()` only checks FlashInfer availability, so the kernel advertises support on SM120 (RTX 50-series / RTX PRO 6000 / RTX 6000D) where FlashInfer hard-rejects the trtllm backend at dispatch time:

```
BackendSupportedError: mm_fp4 does not support backend 'trtllm' with compute capability 120
```

Forcing this kernel on an SM120 GPU therefore crashes at the first forward pass instead of being filtered out during kernel selection. Found while auditing the NVFP4 linear-kernel matrix on SM120 for #48898 (verified on RTX 6000D with vLLM 0.25.1 + flashinfer 0.6.12/0.6.13: `is_supported()` returns `True`, `apply` raises).

## Changes

Gate on `is_device_capability_family(100)` with a clear reason string, matching the neighboring `FlashInferCuteDslNvFp4LinearKernel` idiom in the same file.

## Duplicate check

`gh pr list --state open --search "FlashInferTrtllm capability"` and `--search "nvfp4 sm120 gate"` return no PR touching this kernel's `is_supported` (#47577 is MoE-side b12x selection, #41738 touches cutlass_moe only).

## Test

Selection-logic change only (one early return). On SM120 the kernel is now filtered with the reason string instead of crashing at dispatch; on sm_10x behavior is unchanged (gate passes, FlashInfer check as before). Verified on RTX 6000D that forcing the backend pre-change raises `BackendSupportedError` at `apply`, and post-change the kernel is excluded during selection with AUTO falling back to FlashInferCutlass as before.

---
AI assistance was used for the investigation and drafting of this change; I reviewed every changed line and verified the behavior above.