### PR TITLE
[Bugfix][Granite4Vision] Fix deepstack buffer causing decode slowdown in compiled mode

### DIFF
--- a/vllm/model_executor/models/granite4_vision.py
+++ b/vllm/model_executor/models/granite4_vision.py
@@ -887,9 +887,10 @@ class Granite4VisionForConditionalGeneration(
             and get_pp_group().is_first_rank
             and self._ds_layer_indices
         ):
+            n = inputs_embeds.size(0)
             ds: IntermediateTensors | None = IntermediateTensors(
                 {
-                    f"ds_{llm_layer}": self._ds_buffers[lvl]
+                    f"ds_{llm_layer}": self._ds_buffers[lvl][:n]
                     for lvl, llm_layer in enumerate(self._ds_layer_indices)
                 }
             )


### PR DESCRIPTION

- Root cause: full (max_num_batched_tokens, hidden) buffers were passed into the @support_torch_compile-decorated LLM model, causing inductor to generate kernels that process all 8192 rows during every decode step instead of the actual batch size
- Symptom: 100% SM utilization during single-sequence decode (should be ~5%), 5x lower generation throughput in compiled vs eager mode
- Fix: slice [:n] before constructing IntermediateTensors, matching the pattern in Qwen3VL._get_deepstack_input_embeds
- Numbers: 13 tok/s → ~63 tok/s
