### PR TITLE
[Bugfix][Frontend] Plain text speech-to-text in response_format=text

### DIFF
--- a/tests/entrypoints/speech_to_text/test_response_format_text.py
+++ b/tests/entrypoints/speech_to_text/test_response_format_text.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm.entrypoints.speech_to_text.transcription.api_router import (
+    router as transcription_router,
+)
+from vllm.entrypoints.speech_to_text.transcription.protocol import (
+    TranscriptionResponse,
+    TranscriptionUsageAudio,
+)
+from vllm.entrypoints.speech_to_text.translation.api_router import (
+    router as translation_router,
+)
+from vllm.entrypoints.speech_to_text.translation.protocol import TranslationResponse
+
+
+class _StubSpeechToTextServing:
+    def __init__(self, response: TranscriptionResponse | TranslationResponse) -> None:
+        self.response = response
+
+    async def create_transcription(self, *args: Any) -> TranscriptionResponse:
+        assert isinstance(self.response, TranscriptionResponse)
+        return self.response
+
+    async def create_translation(self, *args: Any) -> TranslationResponse:
+        assert isinstance(self.response, TranslationResponse)
+        return self.response
+
+
+@pytest.mark.parametrize(
+    ("router", "handler_attr", "path", "response"),
+    [
+        (
+            transcription_router,
+            "openai_serving_transcription",
+            "/v1/audio/transcriptions",
+            TranscriptionResponse(
+                text="The transcribed text.",
+                usage=TranscriptionUsageAudio(seconds=1),
+            ),
+        ),
+        (
+            translation_router,
+            "openai_serving_translation",
+            "/v1/audio/translations",
+            TranslationResponse(text="The translated text."),
+        ),
+    ],
+)
+@pytest.mark.parametrize("response_format", ["text", "json"])
+def test_non_streaming_response_format(
+    router,
+    handler_attr,
+    path,
+    response,
+    response_format,
+):
+    app = FastAPI()
+    app.include_router(router)
+    setattr(app.state, handler_attr, _StubSpeechToTextServing(response))
+
+    client = TestClient(app)
+    result = client.post(
+        path,
+        data={"response_format": response_format},
+        files={"file": ("audio.wav", b"audio", "audio/wav")},
+    )
+
+    if response_format == "text":
+        assert result.headers["content-type"] == "text/plain; charset=utf-8"
+        assert result.text == response.text
+    else:
+        assert result.headers["content-type"] == "application/json"
+        assert result.json() == response.model_dump()

--- a/vllm/entrypoints/speech_to_text/transcription/api_router.py
+++ b/vllm/entrypoints/speech_to_text/transcription/api_router.py
@@ -6,7 +6,7 @@ from http import HTTPStatus
 from typing import Annotated
 
 from fastapi import APIRouter, Form, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.entrypoints.serve.utils.api_utils import (
@@ -56,6 +56,8 @@ async def create_transcriptions(
         )
 
     elif isinstance(generator, TranscriptionResponseVariant):
+        if request.response_format == "text":
+            return PlainTextResponse(content=generator.text)
         return JSONResponse(content=generator.model_dump())
 
     return StreamingResponse(content=generator, media_type="text/event-stream")

--- a/vllm/entrypoints/speech_to_text/translation/api_router.py
+++ b/vllm/entrypoints/speech_to_text/translation/api_router.py
@@ -6,7 +6,7 @@ from http import HTTPStatus
 from typing import Annotated
 
 from fastapi import APIRouter, Form, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.entrypoints.serve.utils.api_utils import (
@@ -56,6 +56,8 @@ async def create_translations(
         )
 
     elif isinstance(generator, TranslationResponseVariant):
+        if request.response_format == "text":
+            return PlainTextResponse(content=generator.text)
         return JSONResponse(content=generator.model_dump())
 
     return StreamingResponse(content=generator, media_type="text/event-stream")


### PR DESCRIPTION
## Purpose

Fixes #49095

Return `text/plain; charset=utf-8` with the raw transcription or translation for non-streaming requests using `response_format=text`.

`json`, streaming, and error responses retain their existing behavior.

## Test Plan

```console
.venv/bin/python -m pytest -v \
  tests/entrypoints/speech_to_text/test_response_format_text.py
```

Manual endpoint validation:

```bash
curl --fail-with-body http://localhost:8000/v1/audio/transcriptions \
  -F "file=@audio.wav" \
  -F "response_format=text"
```

## Test Result

```console
tests/entrypoints/speech_to_text/test_response_format_text.py::test_non_streaming_response_format[text-router0-openai_serving_transcription-/v1/audio/transcriptions-response0] PASSED [ 25%]
tests/entrypoints/speech_to_text/test_response_format_text.py::test_non_streaming_response_format[text-router1-openai_serving_translation-/v1/audio/translations-response1] PASSED [ 50%]
tests/entrypoints/speech_to_text/test_response_format_text.py::test_non_streaming_response_format[json-router0-openai_serving_transcription-/v1/audio/transcriptions-response0] PASSED [ 75%]
tests/entrypoints/speech_to_text/test_response_format_text.py::test_non_streaming_response_format[json-router1-openai_serving_translation-/v1/audio/translations-response1] PASSED [100%]
```

The endpoint returned the transcription as a raw `text/plain; charset=utf-8`
response, without a JSON envelope:

```text
My gosh, you've already produced a PowerPoint presentation. I think it's already on, actually. God, how do I make this thing work? ...
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>