### PR TITLE
Improve Marlin MoE wide-N alignment

### DIFF
--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -40,6 +40,7 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     marlin_permute_bias,
 )
 from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
+    _get_nvfp4_moe_padding,
     rand_marlin_weight_mxfp4_like,
     rand_marlin_weight_nvfp4_like,
 )
@@ -1162,6 +1163,95 @@ def test_fused_marlin_moe_non_gated(
         activation=activation,
     )
 
+    torch.testing.assert_close(marlin_output, torch_output, atol=1e-1, rtol=0)
+
+
+@pytest.mark.flaky(reruns=2)
+@pytest.mark.slow_test
+@pytest.mark.skipif(
+    not current_platform.is_device_capability(90),
+    reason="Requires an SM90 GPU for the NVFP4 Marlin wide-N target.",
+)
+@pytest.mark.usefixtures("default_vllm_config")
+def test_fused_marlin_moe_non_gated_wide_n_target():
+    """Compare the exact wide-N target with the independent Torch oracle."""
+    set_random_seed(42)
+
+    m, n, k, e, topk = 22, 1856, 2688, 128, 6
+    activation = MoEActivation.RELU2_NO_MUL
+    padded_n, use_wide_n_tile = _get_nvfp4_moe_padding(
+        num_experts=e,
+        hidden_size=k,
+        intermediate_size=n,
+        top_k=topk,
+        activation=activation,
+        is_act_and_mul=False,
+        is_sm90=True,
+    )
+    assert (padded_n, use_wide_n_tile) == (1920, True)
+
+    dtype = torch.bfloat16
+    quant_type = scalar_types.float4_e2m1f
+    a = torch.randn((m, k), device="cuda", dtype=dtype) / 10
+
+    w1 = torch.zeros((e, padded_n, k), device="cuda", dtype=dtype)
+    w1[:, :n].normal_().div_(10)
+    w1_data = MarlinMoEWeightData.make(
+        w=w1,
+        quant_type=quant_type,
+        group_size=16,
+        act_order=False,
+    )
+    del w1
+
+    w2 = torch.zeros((e, k, padded_n), device="cuda", dtype=dtype)
+    w2[:, :, :n].normal_().div_(10)
+    w2_data = MarlinMoEWeightData.make(
+        w=w2,
+        quant_type=quant_type,
+        group_size=16,
+        act_order=False,
+    )
+    del w2
+
+    expected_routes = torch.arange(m * topk, device="cuda").remainder(e)
+    expected_routes = expected_routes.view(m, topk)
+    score = torch.full((m, e), -100.0, device="cuda", dtype=dtype)
+    score.scatter_(1, expected_routes, 100.0)
+    topk_weights, topk_ids, _ = fused_topk(a, score, topk, False)
+    assert torch.unique(topk_ids).numel() == e
+
+    with set_current_vllm_config(vllm_config):
+        torch_output = torch_moe(
+            a,
+            w1_data.w_ref,
+            w2_data.w_ref,
+            score,
+            topk,
+            activation=activation,
+        )
+
+    marlin_output = fused_marlin_moe(
+        a,
+        w1_data.qweight,
+        w2_data.qweight,
+        None,
+        None,
+        w1_data.scales,
+        w2_data.scales,
+        topk_weights,
+        topk_ids,
+        global_num_experts=e,
+        expert_map=None,
+        global_scale1=w1_data.global_scale,
+        global_scale2=w2_data.global_scale,
+        quant_type_id=quant_type.id,
+        is_k_full=True,
+        activation=activation,
+    )
+
+    assert marlin_output.shape == (m, k)
+    assert torch.isfinite(marlin_output).all()
     torch.testing.assert_close(marlin_output, torch_output, atol=1e-1, rtol=0)
 
 

--- a/tests/kernels/quantization/test_marlin_tile_padding.py
+++ b/tests/kernels/quantization/test_marlin_tile_padding.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 
 from vllm import _custom_ops as ops
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     GPTQ_MARLIN_TILE,
     apply_gptq_marlin_linear,
@@ -25,6 +26,10 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     marlin_zero_points,
 )
 from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
+    _get_nvfp4_moe_padding,
+    _nvfp4_compute_scale_factor,
+    _pad_nvfp4_moe_w2,
+    _pad_nvfp4_moe_w13,
     apply_fp4_marlin_linear,
     is_fp4_marlin_supported,
     prepare_fp4_layer_for_marlin,
@@ -184,6 +189,171 @@ def test_marlin_moe_pad_helpers_shapes():
     bias_shards = padded.view(E, 2, padded_N)
     assert torch.equal(bias_shards[..., :N], bias.view(E, 2, N))
     assert bias_shards[..., N:].abs().sum() == 0
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected"),
+    [
+        pytest.param({}, (1920, True), id="panda-nano-sm90-relu2"),
+        pytest.param({"is_sm90": False}, (1856, False), id="non-sm90"),
+        pytest.param(
+            {
+                "activation": MoEActivation.RELU2,
+                "is_act_and_mul": True,
+            },
+            (1856, False),
+            id="gated",
+        ),
+        pytest.param(
+            {"activation": MoEActivation.GELU_NO_MUL},
+            (1856, False),
+            id="other-activation",
+        ),
+        pytest.param({"num_experts": 64}, (1856, False), id="other-num-experts"),
+        pytest.param({"hidden_size": 2816}, (1856, False), id="other-hidden-size"),
+        pytest.param(
+            {"intermediate_size": 1792},
+            (1792, False),
+            id="other-intermediate-size",
+        ),
+        pytest.param({"top_k": 4}, (1856, False), id="other-top-k"),
+        pytest.param(
+            {
+                "num_experts": 8,
+                "hidden_size": 256,
+                "intermediate_size": 97,
+                "top_k": 2,
+                "activation": MoEActivation.SILU,
+                "is_act_and_mul": True,
+            },
+            (128, False),
+            id="legacy-k128-tile",
+        ),
+        pytest.param(
+            {
+                "num_experts": 8,
+                "hidden_size": 192,
+                "intermediate_size": 129,
+                "top_k": 2,
+                "activation": MoEActivation.SILU,
+                "is_act_and_mul": True,
+            },
+            (256, False),
+            id="legacy-k64-tile",
+        ),
+    ],
+)
+def test_nvfp4_moe_padding_policy(overrides, expected):
+    params = {
+        "num_experts": 128,
+        "hidden_size": 2688,
+        "intermediate_size": 1856,
+        "top_k": 6,
+        "activation": MoEActivation.RELU2_NO_MUL,
+        "is_act_and_mul": False,
+        "is_sm90": True,
+    }
+    params.update(overrides)
+
+    assert _get_nvfp4_moe_padding(**params) == expected
+
+
+def test_nvfp4_moe_padding_rejects_unsupported_hidden_size():
+    with pytest.raises(AssertionError, match="hidden_size = 96"):
+        _get_nvfp4_moe_padding(
+            num_experts=8,
+            hidden_size=96,
+            intermediate_size=128,
+            top_k=2,
+            activation=MoEActivation.SILU,
+            is_act_and_mul=True,
+            is_sm90=True,
+        )
+
+
+@pytest.mark.parametrize("num_shards", [1, 2])
+def test_pad_nvfp4_moe_w13_preserves_shards(num_shards):
+    num_experts, intermediate_size, padded_size, columns = 2, 1856, 1920, 3
+    original = torch.arange(
+        num_experts * num_shards * intermediate_size * columns,
+        dtype=torch.float32,
+    ).reshape(num_experts, num_shards * intermediate_size, columns)
+
+    padded = _pad_nvfp4_moe_w13(
+        original,
+        num_experts=num_experts,
+        num_shards=num_shards,
+        intermediate_size=intermediate_size,
+        padded_intermediate_size=padded_size,
+    )
+
+    actual_shards = padded.view(num_experts, num_shards, padded_size, columns)
+    original_shards = original.view(num_experts, num_shards, intermediate_size, columns)
+    assert torch.equal(actual_shards[:, :, :intermediate_size], original_shards)
+    assert actual_shards[:, :, intermediate_size:].abs().sum() == 0
+    assert (
+        _pad_nvfp4_moe_w13(
+            original,
+            num_experts=num_experts,
+            num_shards=num_shards,
+            intermediate_size=intermediate_size,
+            padded_intermediate_size=intermediate_size,
+        )
+        is original
+    )
+
+
+@pytest.mark.parametrize("packing", [2, 16])
+def test_pad_nvfp4_moe_w2_preserves_packed_values(packing):
+    num_experts, rows = 2, 3
+    intermediate_size, padded_size = 1856, 1920
+    original = torch.arange(
+        num_experts * rows * intermediate_size // packing,
+        dtype=torch.float32,
+    ).reshape(num_experts, rows, intermediate_size // packing)
+
+    padded = _pad_nvfp4_moe_w2(
+        original,
+        intermediate_size=intermediate_size,
+        padded_intermediate_size=padded_size,
+        packing=packing,
+    )
+
+    original_columns = intermediate_size // packing
+    assert padded.shape == (num_experts, rows, padded_size // packing)
+    assert torch.equal(padded[:, :, :original_columns], original)
+    assert padded[:, :, original_columns:].abs().sum() == 0
+    assert (
+        _pad_nvfp4_moe_w2(
+            original,
+            intermediate_size=intermediate_size,
+            padded_intermediate_size=intermediate_size,
+            packing=packing,
+        )
+        is original
+    )
+
+
+def test_pad_nvfp4_moe_scales_preserves_global_normalization():
+    num_experts, intermediate_size, padded_size = 2, 1856, 1920
+    scales = torch.linspace(
+        0.25,
+        1.0,
+        num_experts * intermediate_size,
+        dtype=torch.float32,
+    ).reshape(num_experts, intermediate_size, 1)
+
+    padded = _pad_nvfp4_moe_w13(
+        scales,
+        num_experts=num_experts,
+        num_shards=1,
+        intermediate_size=intermediate_size,
+        padded_intermediate_size=padded_size,
+    )
+
+    assert _nvfp4_compute_scale_factor(
+        padded, torch.bfloat16
+    ) == _nvfp4_compute_scale_factor(scales, torch.bfloat16)
 
 
 def _gpu_marlin_unsupported() -> bool:

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -6,6 +6,7 @@ import torch
 
 import vllm._custom_ops as ops
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     USE_FP32_REDUCE_DEFAULT,
@@ -337,6 +338,65 @@ def _repack_marlin_experts(
     return out
 
 
+def _get_nvfp4_moe_padding(
+    *,
+    num_experts: int,
+    hidden_size: int,
+    intermediate_size: int,
+    top_k: int,
+    activation: MoEActivation,
+    is_act_and_mul: bool,
+    is_sm90: bool,
+) -> tuple[int, bool]:
+    """Return the padded intermediate size and wide-N tuning decision."""
+    use_wide_n_tile = (
+        is_sm90
+        and not is_act_and_mul
+        and activation == MoEActivation.RELU2_NO_MUL
+        and (num_experts, hidden_size, intermediate_size, top_k) == (128, 2688, 1856, 6)
+    )
+    if use_wide_n_tile:
+        return round_up(intermediate_size, 128), True
+    if hidden_size % 128 == 0:
+        return round_up(intermediate_size, 64), False
+    assert hidden_size % 64 == 0, (
+        f"hidden_size = {hidden_size} unsupported by Marlin tiles"
+    )
+    return round_up(intermediate_size, 128), False
+
+
+def _pad_nvfp4_moe_w13(
+    x: torch.Tensor,
+    *,
+    num_experts: int,
+    num_shards: int,
+    intermediate_size: int,
+    padded_intermediate_size: int,
+) -> torch.Tensor:
+    """Zero-pad each gate/up shard to the padded intermediate size."""
+    if padded_intermediate_size == intermediate_size:
+        return x
+    x = x.view(num_experts, num_shards, intermediate_size, x.size(-1))
+    x = torch.nn.functional.pad(
+        x, (0, 0, 0, padded_intermediate_size - intermediate_size)
+    )
+    return x.reshape(num_experts, num_shards * padded_intermediate_size, -1)
+
+
+def _pad_nvfp4_moe_w2(
+    x: torch.Tensor,
+    *,
+    intermediate_size: int,
+    padded_intermediate_size: int,
+    packing: int,
+) -> torch.Tensor:
+    """Zero-pad the packed intermediate dimension of a down projection."""
+    if padded_intermediate_size == intermediate_size:
+        return x
+    padding = (padded_intermediate_size - intermediate_size) // packing
+    return torch.nn.functional.pad(x, (0, padding))
+
+
 def prepare_nvfp4_moe_layer_for_marlin(
     layer: RoutedExperts,
     w13: torch.Tensor,
@@ -369,27 +429,19 @@ def prepare_nvfp4_moe_layer_for_marlin(
     # Pad the rank-local intermediate size to satisfy Marlin thread tiles:
     # N is an output extent of w13 (per gate/up shard) and the input extent
     # of w2, so the padded region never reaches the MoE output.
-    if K % 128 == 0:
-        padded_N = round_up(N, 64)
-    else:
-        assert K % 64 == 0, f"hidden_size = {K} unsupported by Marlin tiles"
-        padded_N = round_up(N, 128)
-
-    def pad_w13(x: torch.Tensor) -> torch.Tensor:
-        """Zero-pad each gate/up shard of a (E, num_shards * N, cols)
-        tensor to padded_N rows."""
-        if padded_N == N:
-            return x
-        x = x.view(E, num_shards, N, x.size(-1))
-        x = torch.nn.functional.pad(x, (0, 0, 0, padded_N - N))
-        return x.reshape(E, num_shards * padded_N, -1)
-
-    def pad_w2(x: torch.Tensor, packing: int) -> torch.Tensor:
-        """Zero-pad the packed N (last) dim of a (E, K, N / packing)
-        tensor."""
-        if padded_N == N:
-            return x
-        return torch.nn.functional.pad(x, (0, (padded_N - N) // packing))
+    padded_N, use_wide_n_tile = _get_nvfp4_moe_padding(
+        num_experts=E,
+        hidden_size=K,
+        intermediate_size=N,
+        top_k=layer.top_k,
+        activation=layer.activation,
+        is_act_and_mul=is_act_and_mul,
+        is_sm90=current_platform.is_device_capability(90),
+    )
+    if use_wide_n_tile:
+        logger.info_once(
+            "NVFP4 Marlin MoE wide-N padding engaged: N=1856->1920, K=2688"
+        )
 
     device = w13.device
     param_dtype = layer.params_dtype
@@ -405,12 +457,23 @@ def prepare_nvfp4_moe_layer_for_marlin(
         if "w13" in name:
             size_n, size_k = N * num_shards, K
             assert weight.shape == (E, size_n, size_k // 2)
-            weight = pad_w13(weight)
+            weight = _pad_nvfp4_moe_w13(
+                weight,
+                num_experts=E,
+                num_shards=num_shards,
+                intermediate_size=N,
+                padded_intermediate_size=padded_N,
+            )
             size_n = padded_N * num_shards
         else:
             size_n, size_k = K, N
             assert weight.shape == (E, size_n, size_k // 2)
-            weight = pad_w2(weight, packing=2)
+            weight = _pad_nvfp4_moe_w2(
+                weight,
+                intermediate_size=N,
+                padded_intermediate_size=padded_N,
+                packing=2,
+            )
             size_k = padded_N
 
         return _repack_marlin_experts(weight, size_n, size_k, perm, is_a_8bit)
@@ -427,10 +490,21 @@ def prepare_nvfp4_moe_layer_for_marlin(
 
         tensor_list = []
         if "w13" in name:
-            scales = pad_w13(scales)
+            scales = _pad_nvfp4_moe_w13(
+                scales,
+                num_experts=E,
+                num_shards=num_shards,
+                intermediate_size=N,
+                padded_intermediate_size=padded_N,
+            )
             size_n, size_k = padded_N * num_shards, K
         else:
-            scales = pad_w2(scales, packing=GROUP_SIZE)
+            scales = _pad_nvfp4_moe_w2(
+                scales,
+                intermediate_size=N,
+                padded_intermediate_size=padded_N,
+                packing=GROUP_SIZE,
+            )
             size_n, size_k = K, padded_N
 
         # All experts share one global_scale, so compute the max


### PR DESCRIPTION
Improves Marlin MoE throughput for SM90 W4A16 NemotronH models with non-gated squared-ReLU routed experts.

For the NVIDIA Nemotron-3 Nano configuration, this pads the intermediate dimension from 1,856 to 1,920 during Marlin weight preparation, enabling a wider N tile without changing the model's logical shapes or
outputs. The original 1,856-wide shape remains valid; this padding is specifically a performance optimization for SM90.

### Results for [nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4)

| Backend             | Output tok/s | TTFT         | GSM8K              |
|---------------------|-------------:|-------------:|--------------------|
| Marlin              |     4,266.40 | 21,750.91 ms | 1209/1319 (91.66%) |
| Marlin + wide-N pad |     4,408.65 | 19,608.07 ms | 1207/1319 (91.51%) |
| Difference          |      +3.334% |      -9.852% | Equivalent         |

<details>
<summary>Full reproduction commands</summary>

Run the same commands from the baseline revision and from this PR.

Server:

```bash
export MODEL=nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4
export REVISION=ce1b118ae66ec705d02c241525192832eb045fd3
export VLLM_MOE_ROUTING_SIMULATION_STRATEGY=uniform_random # For AIPerf only; leave unset for GSM8K
vllm serve "$MODEL" --revision "$REVISION" --served-model-name "$MODEL" --tensor-parallel-size 1 --max-model-len 52000 --max-num-seqs 512 --max-num-batched-tokens 32768 --trust-remote-code --quantization
modelopt_fp4 --kv-cache-dtype fp8 --mamba-backend flashinfer --mamba-ssm-cache-dtype float16 --enable-mamba-cache-stochastic-rounding --mamba-cache-philox-rounds 5 --enable-prefix-caching --async-scheduling
--enable-logging-iteration-details --seed 0 --host 127.0.0.1 --port "$PORT" --moe-backend marlin
```

AIPerf client:

```bash
aiperf profile --model "$MODEL" --url "http://127.0.0.1:$PORT" --endpoint-type chat --ui-type None --streaming --concurrency 512 --request-count 1024 --warmup-request-count 16 --num-prompts 1024
--dataset-sampling-strategy sequential --isl 2000 --isl-stddev 0 --osl 1000 --osl-stddev 0 --random-seed 42 --shared-system-prompt-length 47000 --use-server-token-count --tokenizer "$MODEL"
--tokenizer-revision "$REVISION" --tokenizer-trust-remote-code --extra-inputs temperature:0 --extra-inputs ignore_eos:true --profile-export-level records --artifact-dir "$ARTIFACT_DIR"
```

GSM8K:

```bash
python -m nemo_skills.inference.generate ++skip_filled=False "++input_file=$GSM8K" "++output_file=$OUTPUT" "++server.base_url=http://127.0.0.1:$PORT/v1" "++server.model=$MODEL" ++server.server_type=vllm +
+prompt_config=generic/math ++eval_type=math ++eval_config.split=test ++inference.endpoint_type=chat ++inference.tokens_to_generate=4096 ++inference.temperature=1.0 ++inference.top_p=0.95 +
+inference.timeout=36000 ++max_concurrent_requests=512 ++chat_template_kwargs.enable_thinking=True ++inference.extra_body.skip_special_tokens=False
```

</details>

### AI assistance

AI assistance was used for implementation, tests, validation, and drafting. I reviewed every changed line and the reported results.
