### PR TITLE
Fix response_format=text for speech-to-text endpoints

### DIFF
--- a/vllm/entrypoints/speech_to_text/transcription/api_router.py
+++ b/vllm/entrypoints/speech_to_text/transcription/api_router.py
@@ -6,7 +6,11 @@ from http import HTTPStatus
 from typing import Annotated
 
 from fastapi import APIRouter, Form, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import (
+    JSONResponse,
+    PlainTextResponse,
+    StreamingResponse,
+)
 
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.entrypoints.serve.utils.api_utils import (
@@ -56,6 +60,9 @@ async def create_transcriptions(
         )
 
     elif isinstance(generator, TranscriptionResponseVariant):
+        if request.response_format == "text":
+            return PlainTextResponse(content=generator.text)
+
         return JSONResponse(content=generator.model_dump())
 
     return StreamingResponse(content=generator, media_type="text/event-stream")

--- a/vllm/entrypoints/speech_to_text/translation/api_router.py
+++ b/vllm/entrypoints/speech_to_text/translation/api_router.py
@@ -6,7 +6,11 @@ from http import HTTPStatus
 from typing import Annotated
 
 from fastapi import APIRouter, Form, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import (
+    JSONResponse,
+    PlainTextResponse,
+    StreamingResponse,
+)
 
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.entrypoints.serve.utils.api_utils import (
@@ -56,6 +60,9 @@ async def create_translations(
         )
 
     elif isinstance(generator, TranslationResponseVariant):
+        if request.response_format == "text":
+            return PlainTextResponse(content=generator.text)
+
         return JSONResponse(content=generator.model_dump())
 
     return StreamingResponse(content=generator, media_type="text/event-stream")


### PR DESCRIPTION
## Summary

This PR fixes the `response_format="text"` behavior for the speech-to-text API endpoints.

Previously, both `/v1/audio/transcriptions` and `/v1/audio/translations` always returned a `JSONResponse`, even when `response_format="text"` was requested. As a result, the response body was serialized as JSON instead of returning plain text.

## Changes

- Updated the transcription API router to return `PlainTextResponse(content=generator.text)` when `request.response_format == "text"`.
- Updated the translation API router to return `PlainTextResponse(content=generator.text)` when `request.response_format == "text"`.
- Preserved the existing `JSONResponse` behavior for all other response formats.

## Before

Request:

```http
POST /v1/audio/transcriptions
response_format=text
```

Response:

```json
{
  "text": "Hello world"
}
```

## After

Request:

```http
POST /v1/audio/transcriptions
response_format=text
```

Response:

```text
Hello world
```

The same behavior is now applied to `/v1/audio/translations`.

Fixes #49095