### PR TITLE
[Bugfix] Preserve pooling token-ID state during batch reordering

### DIFF
--- a/tests/v1/worker/test_gpu_input_batch.py
+++ b/tests/v1/worker/test_gpu_input_batch.py
@@ -474,6 +474,80 @@ def test_placeholder_spec_token_ids_written_verbatim():
     assert input_batch.token_ids_cpu[0, 3:6].tolist() == [13, -1, -1]
 
 
+def test_condense_preserves_pooling_token_id_requirement():
+    """A pooling request keeps its token-ID requirement after condense."""
+    from vllm.pooling_params import PoolingParams
+
+    input_batch = InputBatch(
+        max_num_reqs=2,
+        max_model_len=MAX_PROMPT_SIZE + NUM_OUTPUT_TOKENS,
+        max_num_batched_tokens=2 * (MAX_PROMPT_SIZE + NUM_OUTPUT_TOKENS),
+        device=torch.device("cpu"),
+        vocab_size=VOCAB_SIZE,
+        block_sizes=[16],
+        kernel_block_sizes=[16],
+        max_num_blocks_per_req=[64],
+        is_pooling_model=True,
+    )
+    classify_request = _construct_pooling_request(0, PoolingParams(task="classify"))
+    token_classify_request = _construct_pooling_request(
+        1, PoolingParams(task="token_classify", requires_token_ids=True)
+    )
+
+    input_batch.add_request(classify_request)
+    input_batch.add_request(token_classify_request)
+    assert input_batch.logits_processing_needs_token_ids[:2].tolist() == [False, True]
+
+    input_batch.remove_request(classify_request.req_id)
+    input_batch.condense()
+    input_batch.refresh_metadata()
+
+    assert input_batch.req_ids == [token_classify_request.req_id]
+    assert input_batch.logits_processing_needs_token_ids[0]
+    metadata = input_batch.get_pooling_metadata()
+    assert metadata.prompt_token_ids is not None
+    assert metadata.get_prompt_token_ids()[0].tolist() == (
+        token_classify_request.prompt_token_ids
+    )
+
+
+def test_swap_states_preserves_pooling_token_id_requirement():
+    """Swapping pooling requests keeps token-ID metadata with each request."""
+    from vllm.pooling_params import PoolingParams
+
+    input_batch = InputBatch(
+        max_num_reqs=2,
+        max_model_len=MAX_PROMPT_SIZE + NUM_OUTPUT_TOKENS,
+        max_num_batched_tokens=2 * (MAX_PROMPT_SIZE + NUM_OUTPUT_TOKENS),
+        device=torch.device("cpu"),
+        vocab_size=VOCAB_SIZE,
+        block_sizes=[16],
+        kernel_block_sizes=[16],
+        max_num_blocks_per_req=[64],
+        is_pooling_model=True,
+    )
+    classify_request = _construct_pooling_request(0, PoolingParams(task="classify"))
+    token_classify_request = _construct_pooling_request(
+        1, PoolingParams(task="token_classify", requires_token_ids=True)
+    )
+
+    input_batch.add_request(classify_request)
+    input_batch.add_request(token_classify_request)
+    input_batch.swap_states(0, 1)
+    input_batch.refresh_metadata()
+
+    assert input_batch.req_ids == [
+        token_classify_request.req_id,
+        classify_request.req_id,
+    ]
+    assert input_batch.logits_processing_needs_token_ids[:2].tolist() == [True, False]
+    metadata = input_batch.get_pooling_metadata()
+    assert metadata.prompt_token_ids is not None
+    assert metadata.get_prompt_token_ids()[0].tolist() == (
+        token_classify_request.prompt_token_ids
+    )
+
+
 @pytest.mark.parametrize(
     ("pooling_params", "expect_device_prompt_token_ids", "expect_cpu_prompt_token_ids"),
     [

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -616,6 +616,10 @@ class InputBatch:
             [i2, i1], :max_active_token_count
         ]
 
+        self.logits_processing_needs_token_ids[[i1, i2]] = (
+            self.logits_processing_needs_token_ids[[i2, i1]]
+        )
+
         # Swap prompt embeddings if they exist
         embeds_i1 = self.req_prompt_embeds.get(i1)
         embeds_i2 = self.req_prompt_embeds.get(i2)
@@ -746,6 +750,9 @@ class InputBatch:
             self.is_token_ids[empty_index, :num_tokens] = self.is_token_ids[
                 last_req_index, :num_tokens
             ]
+            self.logits_processing_needs_token_ids[empty_index] = (
+                self.logits_processing_needs_token_ids[last_req_index]
+            )
             if last_req_index in self.req_prompt_embeds:
                 self.req_prompt_embeds[empty_index] = self.req_prompt_embeds.pop(
                     last_req_index


### PR DESCRIPTION
## Purpose

`InputBatch` stores `PoolingParams.requires_token_ids` in the per-slot `logits_processing_needs_token_ids` array. When a pooling request is moved by `condense()` or `swap_states()`, the existing code moves the request and token buffers but leaves this array at its old slot.

After compaction, a `token_classify` request can therefore occupy an active slot marked as not requiring token IDs. `_make_sampling_metadata()` may then omit `prompt_token_ids`, even though the pooler requires them.

## Changes

- Move `logits_processing_needs_token_ids` together with requests in `InputBatch.condense()`.
- Swap the same per-slot state in `InputBatch.swap_states()`.
- Add regression tests for both state-movement paths.

## Duplicate-work check

I searched the open issue and PR tracker using `logits_processing_needs_token_ids`, `requires_token_ids condense`, and `token_classify swap_states`; I found no open issue or PR addressing this pooling token-ID state.

The related [`#43931`](https://github.com/vllm-project/vllm/pull/43931) and [`#48419`](https://github.com/vllm-project/vllm/pull/48419) concern a separate `allowed_token_ids` mask state. The earlier closed [`#32157`](https://github.com/vllm-project/vllm/pull/32157) was a broader `SamplingParams` interface proposal; it did not land and does not fix the existing `PoolingParams` path here.

## Test Plan

```bash
pytest -q tests/v1/worker/test_gpu_input_batch.py
```

## Test Result

Before the fix, the two new regression tests fail:

```text
2 failed
```

After the fix:

```text
2 passed
```

The complete relevant test file passes:

```text
11 passed
```

The changed Python files also pass `ruff-check` and `ruff-format`.

## Model evaluation

The regression is in the request-batch metadata state immediately before the pooler is invoked; the targeted tests exercise the production `InputBatch` and `PoolingParams` path through both reordering operations.

I also ran a ROCm/WSL pooling `classify` smoke test on an AMD Radeon RX 7900 XT, using `Alibaba-NLP/gte-reranker-modernbert-base` with eager execution and fp16. vLLM loaded the model, reported `Supported pooling task: classify`, and completed one request with `ClassificationRequestOutput` / `ClassificationOutput(num_classes=1)`.

This smoke test confirms real ROCm model loading and serving. The targeted regression tests remain the proof for the mixed-request reordering invariant, because this model exposes `classify` but not the `token_classify` task needed to construct that exact sequence through the public API.

## Scope

This is an internal batch-state correctness fix. It does not change the public API or require documentation updates.

AI assistance: OpenAI Codex assisted with code exploration and drafting. I reviewed every changed line, verified the failing and passing regression results above, and ran the stated test plan.