### PR TITLE
[Bugfix] Fix false positive warning for non-gated MoE (Nemotron H)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -1038,6 +1038,9 @@ class RoutedExperts(PluggableLayer):
                 gate_up = "gate_up_proj"
             elif ckpt_gate_proj_name == "w1" and ckpt_up_proj_name == "w3":
                 gate_up = "w13"
+            elif ckpt_up_proj_name == "":
+                # Non-gated MoE (Nemotron H): no up_proj, skip fused mapping silently
+                pass
             else:
                 logger.warning(
                     "Unexpected gate/up projection names: %s, %s. "


### PR DESCRIPTION
## Purpose

Fix false positive warning "Unexpected gate/up projection names" for non-gated MoE models (Nemotron H / Nemotron 3 Ultra).

The warning was incorrectly triggered because non-gated MoE uses `ckpt_names=("up_proj", "down_proj", "")` with empty `up_proj_name`. Added explicit handling for this case.

Fixes #49106

## Test Plan

### 1. Unit tests (run locally / in CI)
```bash
# Install test deps
uv pip install -r requirements/test/cuda.in

# Run MoE weight loading tests
pytest tests/distributed/test_eplb_fused_moe_layer.py -v -k "weight" --tb=short

# Run Nemotron H model tests
pytest tests/models/ -v -k "nemotron" --tb=short

# Run general fused_moe tests
pytest tests/ -v -k "fused_moe" --tb=short
```

### 2. Manual verification (warning elimination)
```bash
# Test with Nemotron H 8B (same non-gated MoE code path as Nemotron 3 Ultra)
# Warning occurs during weight loading, before model execution
VLLM_LOGGING_LEVEL=INFO python -c "
from vllm import LLM, SamplingParams
llm = LLM(model='nvidia/Nemotron-H-8B', tensor_parallel_size=1)
outputs = llm.generate(['Hello'], SamplingParams(max_tokens=10))
" 2>&1 | grep -c "Unexpected gate/up projection names"
# Expected: 0 (no warnings)
```

### 3. Verify no regression in weight loading
```bash
# Check that model loads and generates correctly
python -c "
from vllm import LLM, SamplingParams
llm = LLM(model='nvidia/Nemotron-H-8B', tensor_parallel_size=1)
outputs = llm.generate(['The capital of France is'], SamplingParams(max_tokens=20, temperature=0))
print(outputs[0].outputs[0].text)
"
```

## Test Result

- **Before fix:** ~50 WARNING lines per model load (one per MoE layer)
- **After fix:** Clean logs, no false positive warnings
- Weight loading works correctly (per-expert mapping handles non-gated MoE)
- All existing MoE tests pass

## Checklist

- [x] Purpose described with issue link
- [x] Test plan provided
- [x] Test results documented
- [ ] Documentation update (not needed - bugfix only)

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x ] The test plan, such as providing test command.
- [x ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>