### PR TITLE
[Bugfix][Rust Frontend] Map missing prompt logprobs for single-token prompts in chat and raw generate

### DIFF
--- a/rust/src/server/src/routes/inference/generate.rs
+++ b/rust/src/server/src/routes/inference/generate.rs
@@ -238,13 +238,18 @@ fn collect_generate(
         None
     };
     let prompt_logprobs = if include_prompt_logprobs {
-        let prompt_logprobs = collected.prompt_logprobs.as_ref().ok_or_else(|| {
-            ApiError::server_error(
-                "raw generate response requested prompt_logprobs but generation returned none"
-                    .to_string(),
-            )
-        })?;
-        Some(raw_prompt_logprobs_to_maps(prompt_logprobs))
+        match collected.prompt_logprobs.as_ref() {
+            Some(prompt_logprobs) => Some(raw_prompt_logprobs_to_maps(prompt_logprobs)),
+            // A single-token prompt has no scored positions; same mapping
+            // as /v1/completions.
+            None if collected.prompt_token_ids.len() == 1 => Some(vec![None]),
+            None => {
+                return Err(ApiError::server_error(
+                    "raw generate response requested prompt_logprobs but generation returned none"
+                        .to_string(),
+                ));
+            }
+        }
     } else {
         None
     };
@@ -471,5 +476,49 @@ mod tests {
                 .map(|details| details.cached_tokens),
             Some(2)
         );
+    }
+
+    #[test]
+    fn collect_generate_maps_prompt_logprobs_for_single_token_prompt() {
+        let output_without_payload = |prompt_token_ids: Vec<u32>| CollectedGenerateOutput {
+            request_id: "raw-1".to_string(),
+            prompt_logprobs: None,
+            token_ids: vec![3],
+            logprobs: None,
+            finish_reason: FinishReason::stop_eos(),
+            usage: vllm_llm::TokenUsage {
+                prompt_token_count: prompt_token_ids.len(),
+                output_token_count: 1,
+                cached_token_count: 0,
+            },
+            kv_transfer_params: None,
+            ec_transfer_params: None,
+            prompt_token_ids,
+        };
+
+        let response = collect_generate(
+            output_without_payload(vec![9707]),
+            "raw-1".to_string(),
+            ApiServerOptions::default(),
+            ResponseOptions {
+                include_prompt_logprobs: true,
+                ..Default::default()
+            },
+        )
+        .expect("single-token prompt without payload maps to [None]");
+        let prompt_logprobs = response.prompt_logprobs.expect("prompt logprobs present");
+        assert_eq!(prompt_logprobs.len(), 1);
+        assert!(prompt_logprobs[0].is_none());
+
+        collect_generate(
+            output_without_payload(vec![9707, 11]),
+            "raw-2".to_string(),
+            ApiServerOptions::default(),
+            ResponseOptions {
+                include_prompt_logprobs: true,
+                ..Default::default()
+            },
+        )
+        .expect_err("multi-token prompt without payload is an engine failure");
     }
 }

--- a/rust/src/server/src/routes/openai/chat_completions.rs
+++ b/rust/src/server/src/routes/openai/chat_completions.rs
@@ -35,7 +35,7 @@ use crate::routes::openai::chat_completions::types::{
     ChatMessageDelta,
 };
 use crate::routes::openai::utils::logprobs::{
-    decoded_logprobs_to_openai_chat, decoded_prompt_logprobs_to_maps,
+    decoded_logprobs_to_openai_chat, prompt_logprobs_to_maps,
 };
 use crate::routes::openai::utils::types::{
     ChatLogProbs, FunctionCallDelta, FunctionCallResponse, ToolCall, ToolCallDelta, Usage,
@@ -181,14 +181,11 @@ async fn collect_chat_completion(
         None
     };
     let prompt_logprobs = if include_prompt_logprobs {
-        Some(decoded_prompt_logprobs_to_maps(
-            prompt_logprobs.as_ref().ok_or_else(|| {
-                server_error!(
-                    "chat response requested prompt_logprobs but generation returned none"
-                )
-            })?,
+        Some(prompt_logprobs_to_maps(
+            prompt_logprobs.as_ref(),
+            &prompt_token_ids,
             return_tokens_as_token_ids,
-        ))
+        )?)
     } else {
         None
     };

--- a/rust/src/server/src/routes/openai/completions.rs
+++ b/rust/src/server/src/routes/openai/completions.rs
@@ -5,7 +5,6 @@ mod convert;
 mod types;
 mod validate;
 
-use std::collections::HashMap;
 use std::convert::Infallible;
 use std::result::Result;
 use std::sync::Arc;
@@ -29,8 +28,8 @@ use vllm_text::{
 
 use self::convert::{ResponseOptions, prepare_completion_request};
 use super::utils::logprobs::{
-    collected_logprobs_to_openai, decoded_logprobs_to_openai, decoded_prompt_logprobs_to_maps,
-    decoded_prompt_logprobs_to_openai, text_len,
+    collected_logprobs_to_openai, decoded_logprobs_to_openai, decoded_prompt_logprobs_to_openai,
+    prompt_logprobs_to_maps, text_len,
 };
 use super::utils::types::Usage;
 use crate::config::ApiServerOptions;
@@ -502,27 +501,6 @@ fn prompt_only_logprobs_to_openai(
 
     Err(server_error!(
         "prompt-only completion requested logprobs but generation returned none"
-    ))
-}
-
-fn prompt_logprobs_to_maps(
-    prompt_logprobs: Option<&DecodedPromptLogprobs>,
-    prompt_token_ids: &[u32],
-    return_tokens_as_token_ids: bool,
-) -> Result<Vec<Option<HashMap<String, f32>>>, ApiError> {
-    if let Some(prompt_logprobs) = prompt_logprobs {
-        return Ok(decoded_prompt_logprobs_to_maps(
-            prompt_logprobs,
-            return_tokens_as_token_ids,
-        ));
-    }
-
-    if let [_token_id] = prompt_token_ids {
-        return Ok(vec![None]);
-    }
-
-    Err(server_error!(
-        "completion response requested prompt_logprobs but generation returned none"
     ))
 }
 

--- a/rust/src/server/src/routes/openai/utils/logprobs.rs
+++ b/rust/src/server/src/routes/openai/utils/logprobs.rs
@@ -100,20 +100,31 @@ pub fn decoded_prompt_logprobs_to_openai(
     })
 }
 
-/// Convert decoded prompt logprobs into the vLLM-style prompt-logprobs response
-/// shape.
-pub fn decoded_prompt_logprobs_to_maps(
-    prompt_logprobs: &DecodedPromptLogprobs,
+/// Map decoded prompt logprobs into vLLM-style per-position maps, treating a
+/// missing single-token payload as `[None]`.
+pub fn prompt_logprobs_to_maps(
+    prompt_logprobs: Option<&DecodedPromptLogprobs>,
+    prompt_token_ids: &[u32],
     return_tokens_as_token_ids: bool,
-) -> Vec<Option<HashMap<String, f32>>> {
-    std::iter::once(None)
-        .chain(prompt_logprobs.scored_positions.iter().map(|position| {
-            Some(position_top_logprobs_map(
-                position,
-                return_tokens_as_token_ids,
-            ))
-        }))
-        .collect()
+) -> Result<Vec<Option<HashMap<String, f32>>>, ApiError> {
+    if let Some(prompt_logprobs) = prompt_logprobs {
+        return Ok(std::iter::once(None)
+            .chain(prompt_logprobs.scored_positions.iter().map(|position| {
+                Some(position_top_logprobs_map(
+                    position,
+                    return_tokens_as_token_ids,
+                ))
+            }))
+            .collect());
+    }
+
+    if let [_token_id] = prompt_token_ids {
+        return Ok(vec![None]);
+    }
+
+    Err(server_error!(
+        "prompt_logprobs were requested but generation returned none"
+    ))
 }
 
 /// Convert decoded token-position logprobs into the OpenAI chat `logprobs`
@@ -275,7 +286,13 @@ pub fn clamp_logprob(logprob: f32) -> f32 {
 mod tests {
     use vllm_text::{DecodedLogprobs, DecodedPositionLogprobs, DecodedTokenLogprob};
 
-    use super::decoded_logprobs_to_openai_chat;
+    use super::{decoded_logprobs_to_openai_chat, prompt_logprobs_to_maps};
+
+    #[test]
+    fn prompt_logprobs_maps_reject_missing_multi_token_payload() {
+        prompt_logprobs_to_maps(None, &[9707, 11], false)
+            .expect_err("multi-token prompt without payload is an engine failure");
+    }
 
     fn sample_logprobs() -> DecodedLogprobs {
         DecodedLogprobs {


### PR DESCRIPTION
## Purpose

A single-token prompt has no scored prompt-logprobs positions, and the two model runners represent that case differently: Model Runner V1 returns an empty `[0, k+1]` tensor that decodes to zero scored positions, while Model Runner V2 omits the payload entirely (`gpu/sample/prompt_logprob.py` hits `start_idx >= end_idx` after excluding the unscored leading token and never writes the request into `prompt_logprobs_dict`). `/v1/completions` already normalizes the missing payload for a single-token prompt to a leading `[null]` entry (#44938), but `/v1/chat/completions` and `/inference/v1/generate` treat the same condition as an engine failure. A raw generate request with one token id and `prompt_logprobs` set therefore completes generation and then deterministically returns HTTP 500 under Model Runner V2.

This PR applies the completions mapping to both routes: a missing payload for a single-token prompt maps to `[null]`; a missing payload for a multi-token prompt is still a server error. The completions helper moves to `routes/openai/utils/logprobs.rs` (absorbing `decoded_prompt_logprobs_to_maps`, which had become its only caller) and is shared by completions and chat; raw generate keeps its own mapping since it uses a different response shape.

Not a duplicate of #44938: that PR added the prompt-only/single-token contract for `/v1/completions` only; this PR extends the same contract to `/v1/chat/completions` and `/inference/v1/generate`, which still return HTTP 500. No open PR addresses these two routes.

No model evaluation is needed: logits, sampling, and generated tokens are unchanged — the change is response assembly only, and the live A/B below covers it against an unmodified engine. AI assistance was used for this change; the submitter reviewed every changed line and ran the tests below.

## Test Plan

Unit tests and lints:

```
cd rust
cargo nextest run -p vllm-server
cargo clippy -p vllm-server --all-targets -- -D warnings
```

New tests: `collect_generate_maps_prompt_logprobs_for_single_token_prompt` (raw generate: single-token fallback plus multi-token fail-loud) and `prompt_logprobs_maps_reject_missing_multi_token_payload` (the shared helper's fail-loud arm, unreachable through normal collector flows since a healthy engine always sends the multi-token payload).

Live A/B on one GPU (Qwen3-4B, Model Runner V2 selected by default), base b6ff8a2 vs this branch:

```
vllm-rs serve <model> --port 18081 --served-model-name m --max-model-len 512 -- --enforce-eager --gpu-memory-utilization 0.5

curl -s -o resp.json -w 'HTTP:%{http_code}\n' http://127.0.0.1:18081/inference/v1/generate \
    -H 'Content-Type: application/json' \
    -d '{"token_ids":[9707],"sampling_params":{"max_tokens":2,"prompt_logprobs":1}}'
```

Controls on both binaries: the same request with a multi-token prompt, and single-token `/v1/completions` with `prompt_logprobs=1`.


## Test Result

307 tests run, 306 passed, clippy clean (the one failure is a pre-existing TLS handshake-timing test, identical on the unmodified base).

Before (base b6ff8a2):

```
HTTP:500
{"error":{"message":"raw generate response requested prompt_logprobs but generation returned none","type":"server_error","param":null,"code":"server_error"}}
```

After (this branch), same request (response abridged to the relevant fields):

```
HTTP:200
{"choices":[{"index":0,"finish_reason":"length",...}],"prompt_logprobs":[null],...}
```

Controls, unchanged by this branch: multi-token raw generate with `prompt_logprobs=1` returns identical scored payload content on both binaries; single-token `/v1/completions` with `prompt_logprobs=1` returns `"prompt_logprobs":[null]` on both.