### PR TITLE
[Bugfix]: move FlashInfer MoE autotune before memory profiling + logging

### DIFF
--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -219,7 +219,7 @@ def _flashinfer_autotune_skip_ops(runner: "GPUModelRunner") -> set[str] | None:
     return None
 
 
-def flashinfer_autotune(runner: "GPUModelRunner") -> None:
+def flashinfer_autotune(runner: "GPUModelRunner", skip_attn: bool = False) -> None:
     """
     Autotune FlashInfer operations.
     FlashInfer have many implementations for the same operation,
@@ -228,6 +228,12 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     future calls to FlashInfer will use the best implementation.
     Without autotuning, FlashInfer will rely on heuristics, which may
     be significantly slower.
+
+    Args:
+        runner: The GPU model runner (V1 or V2).
+        skip_attn: If True, skip attention layers (run MoE only).
+            Used when KV cache is not yet allocated (before memory profiling).
+            When False, runs full autotune including attention (used during warmup).
 
     Tuning is performed only on rank 0. The resulting cache is broadcast
     to every rank so all ranks dispatch the same kernel tactic.
@@ -250,13 +256,26 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     if get_world_group().world_size > 1:
         use_persistent_cache = False
 
+    # V1 runner (model_runner.py) uses `skip_attn` parameter.
+    # V2 runner (gpu_model_runner.py) uses `force_attention` parameter (inverted logic).
+    is_v2_runner = runner.__class__.__module__.endswith("gpu_model_runner")
+
     if not use_persistent_cache:
         with torch.inference_mode(), fi_utils.autotune(**autotune_kwargs):
-            runner._dummy_run(
-                num_tokens=runner.scheduler_config.max_num_batched_tokens,
-                skip_eplb=True,
-                is_profile=True,
-            )
+            if is_v2_runner:
+                runner._dummy_run(
+                    num_tokens=runner.scheduler_config.max_num_batched_tokens,
+                    skip_eplb=True,
+                    is_profile=True,
+                    force_attention=not skip_attn,
+                )
+            else:
+                runner._dummy_run(
+                    num_tokens=runner.scheduler_config.max_num_batched_tokens,
+                    skip_eplb=True,
+                    is_profile=True,
+                    skip_attn=skip_attn,
+                )
         get_world_group().barrier()
         return
 
@@ -276,6 +295,10 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
         skip_eplb=True,
         is_profile=True,
     )
+    if is_v2_runner:
+        dummy_run_kwargs["force_attention"] = not skip_attn
+    else:
+        dummy_run_kwargs["skip_attn"] = skip_attn
 
     with torch.inference_mode():
         if is_leader:
@@ -306,7 +329,16 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
         from flashinfer.autotuner import AutoTuner
 
         AutoTuner.get().load_configs(str(cache_path))
-        logger.info_once(
+        tuner = AutoTuner.get()
+        tuned_ops = len(tuner.get_tuned_ops()) if hasattr(tuner, "get_tuned_ops") else 0
+        op_names = tuner.get_tuned_ops() if hasattr(tuner, "get_tuned_ops") else []
+        logger.info(
+            "=== FlashInfer autotune summary: %d ops tuned (%s), cache: %s ===",
+            tuned_ops,
+            ", ".join(op_names) if op_names else "none",
+            cache_path,
+        )
+        logger.info(
             "FlashInfer autotune cache loaded on rank %d from %s.",
             world.rank_in_group,
             cache_path,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -495,6 +495,44 @@ class Worker(WorkerBase):
                 getattr(self.parallel_config, "_api_process_count", 1),
             )
 
+        # Run FlashInfer MoE autotune before memory profiling to avoid OOM.
+        # This runs with skip_attn=True since KV cache is not yet allocated.
+        # Running it here ensures its memory usage is captured in the memory
+        # profiling baseline (before_profile), so it's accounted for in the
+        # available KV cache memory calculation.
+        if self.vllm_config.kernel_config.enable_flashinfer_autotune:
+            from vllm.model_executor.warmup.kernel_warmup import flashinfer_autotune
+            from vllm.utils.flashinfer import has_flashinfer
+
+            if has_flashinfer() and current_platform.has_device_capability(90):
+                logger.info(
+                    "=== STAGE 1: FlashInfer autotune (MoE, skip_attn=True, "
+                    "includes Inductor compilation) ==="
+                )
+                logger.info(
+                    "Running FlashInfer MoE autotune before memory profiling..."
+                )
+                import time
+
+                start = time.perf_counter()
+                flashinfer_autotune(self.model_runner, skip_attn=True)
+                duration = time.perf_counter() - start
+                # Reset peak stats so compilation peak doesn't inflate
+                # non_kv_cache_memory calculation, but persistent FlashInfer
+                # allocations remain and are captured in baseline.
+                torch.accelerator.reset_peak_memory_stats(self.device)
+                persistent_mem = (
+                    torch.accelerator.memory_allocated(self.device) / 1024**3
+                )
+                logger.info(
+                    "FlashInfer MoE autotune completed in %.1fs (persistent: %.2f GiB)",
+                    duration,
+                    persistent_mem,
+                )
+                logger.info(
+                    "=== STAGE 2: Memory profiling (Inductor compilation cached) ==="
+                )
+
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
         with memory_profiling(


### PR DESCRIPTION
- Move FlashInfer MoE autotune before memory profiling to account for its persistent memory (~2.7 GiB observed, varies by model) in KV cache calculation
- Move compilation peak (~6 GiB observed, varies by model) before KV cache allocation
- Add V1/V2 runner compatibility (skip_attn / force_attention)
- Add STAGE 1/2 log markers for clear initialization phases
- Add summary log showing ops tuned count and cache path

This fixes OOM with enable_flashinfer_autotune=true:
- when using num_gpu_blocks_override (autotune was skipped entirely)
- in auto-profiling mode (autotune ran after profiling, missing persistent memory in baseline)


## Purpose

[Bugfix] Move FlashInfer MoE autotune before memory profiling to fix OOM when `enable_flashinfer_autotune=true`.

**Root cause**: FlashInfer MoE autotune ran *after* memory profiling, so its persistent memory (~2.7 GiB) and Inductor compilation peak (~6 GiB) weren't accounted for in the KV cache baseline. This caused OOM in two scenarios:
1. With `num_gpu_blocks_override` — autotune was skipped entirely
2. In auto-profiling mode — autotune ran after profiling, missing persistent memory in baseline

**Fix**: Run autotune in `determine_available_memory()` *before* memory profiling with `skip_attn=True` (KV cache not yet allocated). Reset peak stats after autotune so compilation peak doesn't inflate `non_kv_cache_memory`, but persistent allocations remain in baseline.

## Test Plan

1. **Log verification**
   - Run vLLM with `enable_flashinfer_autotune=true`
   - Verify logs show:
     - `=== STAGE 1: FlashInfer autotune (MoE, skip_attn=True, ...) ===`
     - `FlashInfer MoE autotune completed in X.Xs (persistent: Y.YY GiB)`
     - `=== STAGE 2: Memory profiling (Inductor compilation cached) ===`
   - Verify no OOM on models that previously failed (e.g. DeepSeek-V3 MoE, Mixtral)
2. **Memory accounting**: Check that `non_kv_cache_memory` includes FlashInfer persistent allocs but excludes compilation peak


## Test Result

## Test Result

- **Manual GPU test**: Pending —  `enable_flashinfer_autotune=true` to verify:
  1. STAGE 1/2 logs appear in correct order
  2. Persistent memory logged (~2-3 GiB typical)
  3. No OOM on MoE models 
  4. `non_kv_cache_memory` correctly accounts for persistent FlashInfer allocs
  
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
