### PR TITLE
[Bugfix][Frontend] Use OpenAI transcript events for transcription streaming

### DIFF
--- a/tests/entrypoints/speech_to_text/transcription/test_transcription_inter_chunk_spacing.py
+++ b/tests/entrypoints/speech_to_text/transcription/test_transcription_inter_chunk_spacing.py
@@ -32,6 +32,9 @@ from vllm.entrypoints.speech_to_text.transcription.protocol import Transcription
 from vllm.entrypoints.speech_to_text.transcription.serving import (
     OpenAIServingTranscription,
 )
+from vllm.entrypoints.speech_to_text.translation.serving import (
+    OpenAIServingTranslation,
+)
 from vllm.model_executor.models.interfaces import (
     StreamingTranscriptionPostProcessor,
     SupportsTranscription,
@@ -178,21 +181,25 @@ def _request_output(text: str, finish_reason: str | None = "stop") -> RequestOut
     )
 
 
-def _sse_delta_contents(sse_body: str) -> list[str]:
-    """Extract ``choices[0].delta.content`` from each ``data:`` line (streaming API)."""
-    contents: list[str] = []
+def _sse_events(sse_body: str) -> list[dict]:
+    """Extract JSON payloads from an SSE response."""
+    events: list[dict] = []
     for line in sse_body.splitlines():
         if not line.startswith("data: "):
             continue
         payload = line.removeprefix("data: ").strip()
         if payload == "[DONE]":
             continue
-        obj = json.loads(payload)
-        for choice in obj.get("choices") or []:
-            delta = choice.get("delta") or {}
-            if "content" in delta:
-                contents.append(delta["content"])
-    return contents
+        events.append(json.loads(payload))
+    return events
+
+
+def _sse_delta_contents(sse_body: str) -> list[str]:
+    return [
+        event["delta"]
+        for event in _sse_events(sse_body)
+        if event["type"] == "transcript.text.delta"
+    ]
 
 
 @pytest.mark.asyncio
@@ -227,7 +234,7 @@ async def test_transcription_stream_generator_english_inserts_space_between_chun
         result_generator=[gen_hello(), gen_world()],
         request_id="test-req",
         request_metadata=RequestResponseMetadata(request_id="test-req"),
-        audio_duration_s=1.0,
+        audio_duration_s=1.1,
         separator=sep,
     )
     async for line in agen:
@@ -235,6 +242,24 @@ async def test_transcription_stream_generator_english_inserts_space_between_chun
     sse = "".join(out_lines)
     combined = "".join(_sse_delta_contents(sse))
     assert combined.strip() == "hello world"
+    events = _sse_events(sse)
+    assert [event["type"] for event in events] == [
+        "transcript.text.delta",
+        "transcript.text.delta",
+        "transcript.text.done",
+    ]
+    assert all("choices" not in event for event in events)
+    assert events[-1] == {
+        "type": "transcript.text.done",
+        "text": "hello world",
+        "usage": {
+            "type": "tokens",
+            "input_tokens": 0,
+            "output_tokens": 6,
+            "total_tokens": 6,
+        },
+    }
+    assert sse.endswith("data: [DONE]\n\n")
 
 
 @pytest.mark.asyncio
@@ -274,6 +299,42 @@ async def test_transcription_stream_generator_chinese_no_space_between_chunks():
         out_lines.append(line)
     combined = "".join(_sse_delta_contents("".join(out_lines)))
     assert combined == "你好世界"
+
+
+@pytest.mark.asyncio
+async def test_translation_stream_generator_preserves_chat_completion_events():
+    async def gen_hello() -> AsyncGenerator[RequestOutput, None]:
+        yield _request_output("hello")
+
+    serving = OpenAIServingTranslation.__new__(OpenAIServingTranslation)
+    serving.enable_force_include_usage = False
+    serving.model_cls = _StubTranscriptionModel
+    serving.streaming_post_processor_cls = (
+        _StubTranscriptionModel.get_streaming_post_processor_cls()
+    )
+    serving.task_type = "translate"
+    request = SimpleNamespace(
+        model="stub-model",
+        stream_include_usage=False,
+        stream_continuous_usage_stats=False,
+    )
+
+    events = []
+    agen = OpenAIServingTranslation.translation_stream_generator(
+        serving,
+        request=request,
+        result_generator=[gen_hello()],
+        request_id="test-req",
+        request_metadata=RequestResponseMetadata(request_id="test-req"),
+        audio_duration_s=1.0,
+        separator=" ",
+    )
+    async for line in agen:
+        if line != "data: [DONE]\n\n":
+            events.append(json.loads(line.removeprefix("data: ")))
+
+    assert events[0]["object"] == "translation.chunk"
+    assert events[0]["choices"][0]["delta"]["content"] == "hello"
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/speech_to_text/transcription/test_transcription_validation_whisper.py
+++ b/tests/entrypoints/speech_to_text/transcription/test_transcription_validation_whisper.py
@@ -11,6 +11,10 @@ import openai
 import pytest
 import pytest_asyncio
 import soundfile as sf
+from openai.types.audio import (
+    TranscriptionTextDeltaEvent,
+    TranscriptionTextDoneEvent,
+)
 
 from tests.utils import RemoteOpenAIServer
 from vllm.multimodal.media.audio import load_audio
@@ -206,16 +210,25 @@ async def test_streaming_response(winning_call, whisper_client):
         stream=True,
         timeout=30,
     )
-    # Reconstruct from chunks and validate
-    async for chunk in res:
-        text = chunk.choices[0]["delta"]["content"]
-        transcription += text
+    done_event = None
+    async for event in res:
+        if isinstance(event, TranscriptionTextDeltaEvent):
+            transcription += event.delta
+        else:
+            assert isinstance(event, TranscriptionTextDoneEvent)
+            done_event = event
 
     assert transcription == res_no_stream.text
+    assert done_event is not None
+    assert done_event.text == res_no_stream.text
+    assert done_event.usage is not None
+    assert done_event.usage.type == "tokens"
 
 
 @pytest.mark.asyncio
-async def test_stream_options(winning_call, whisper_client):
+async def test_stream_options_preserve_transcription_event_contract(
+    winning_call, whisper_client
+):
     res = await whisper_client.audio.transcriptions.create(
         model=MODEL_NAME,
         file=winning_call,
@@ -225,15 +238,17 @@ async def test_stream_options(winning_call, whisper_client):
         extra_body=dict(stream_include_usage=True, stream_continuous_usage_stats=True),
         timeout=30,
     )
-    final = False
-    continuous = True
-    async for chunk in res:
-        if not len(chunk.choices):
-            # final usage sent
-            final = True
-        else:
-            continuous = continuous and hasattr(chunk, "usage")
-    assert final and continuous
+    done_events = []
+    async for event in res:
+        assert isinstance(
+            event, TranscriptionTextDeltaEvent | TranscriptionTextDoneEvent
+        )
+        if isinstance(event, TranscriptionTextDoneEvent):
+            done_events.append(event)
+
+    assert len(done_events) == 1
+    assert done_events[0].usage is not None
+    assert done_events[0].usage.type == "tokens"
 
 
 @pytest.mark.asyncio

--- a/vllm/entrypoints/speech_to_text/base/serving.py
+++ b/vllm/entrypoints/speech_to_text/base/serving.py
@@ -47,6 +47,9 @@ from ..transcription.protocol import (
     TranscriptionResponseVerbose,
     TranscriptionSegment,
     TranscriptionStreamResponse,
+    TranscriptionTextDeltaEvent,
+    TranscriptionTextDoneEvent,
+    TranscriptionUsageTokens,
 )
 from ..translation.protocol import (
     TranslationResponse,
@@ -679,13 +682,18 @@ class SpeechToTextBaseServing(GenerateBaseServing):
         | type[TranslationStreamResponse],
         separator: str,
     ) -> AsyncGenerator[str, None]:
-        created_time = int(time.time())
-        model_name = request.model
+        is_transcription = self.task_type == "transcribe"
+        if not is_transcription:
+            created_time = int(time.time())
+            model_name = request.model
 
         completion_tokens = 0
         num_prompt_tokens = 0
+        transcript_text_parts: list[str] | None = [] if is_transcription else None
 
-        include_usage = self.enable_force_include_usage or request.stream_include_usage
+        include_usage = not is_transcription and (
+            self.enable_force_include_usage or request.stream_include_usage
+        )
         include_continuous_usage = (
             request.stream_continuous_usage_stats
             if include_usage and request.stream_continuous_usage_stats
@@ -730,42 +738,61 @@ class SpeechToTextBaseServing(GenerateBaseServing):
                         completion_tokens += len(output.token_ids)
                         continue
 
-                    delta_message = DeltaMessage(content=output_text)
                     completion_tokens += len(output.token_ids)
 
-                    if output.finish_reason is None:
-                        # Still generating, send delta update.
-                        choice_data = response_stream_choice_class(delta=delta_message)
+                    if is_transcription:
+                        if output_text:
+                            assert transcript_text_parts is not None
+                            transcript_text_parts.append(output_text)
+                            delta_event = TranscriptionTextDeltaEvent(delta=output_text)
+                            yield f"data: {delta_event.model_dump_json()}\n\n"
                     else:
-                        # Model is finished generating.
-                        choice_data = response_stream_choice_class(
-                            delta=delta_message,
-                            finish_reason=output.finish_reason,
-                            stop_reason=output.stop_reason,
+                        delta_message = DeltaMessage(content=output_text)
+                        if output.finish_reason is None:
+                            # Still generating, send delta update.
+                            choice_data = response_stream_choice_class(
+                                delta=delta_message
+                            )
+                        else:
+                            # Model is finished generating.
+                            choice_data = response_stream_choice_class(
+                                delta=delta_message,
+                                finish_reason=output.finish_reason,
+                                stop_reason=output.stop_reason,
+                            )
+
+                        chunk = stream_response_class(
+                            id=request_id,
+                            object=chunk_object_type,
+                            created=created_time,
+                            choices=[choice_data],
+                            model=model_name,
                         )
 
-                    chunk = stream_response_class(
-                        id=request_id,
-                        object=chunk_object_type,
-                        created=created_time,
-                        choices=[choice_data],
-                        model=model_name,
-                    )
+                        # handle usage stats if requested & if continuous
+                        if include_continuous_usage:
+                            chunk.usage = UsageInfo(
+                                prompt_tokens=num_prompt_tokens,
+                                completion_tokens=completion_tokens,
+                                total_tokens=num_prompt_tokens + completion_tokens,
+                            )
 
-                    # handle usage stats if requested & if continuous
-                    if include_continuous_usage:
-                        chunk.usage = UsageInfo(
-                            prompt_tokens=num_prompt_tokens,
-                            completion_tokens=completion_tokens,
-                            total_tokens=num_prompt_tokens + completion_tokens,
-                        )
+                        data = chunk.model_dump_json(exclude_unset=True)
+                        yield f"data: {data}\n\n"
 
-                    data = chunk.model_dump_json(exclude_unset=True)
-                    yield f"data: {data}\n\n"
-
-            # Once the final token is handled, if stream_options.include_usage
-            # is sent, send the usage.
-            if include_usage:
+            if is_transcription:
+                assert transcript_text_parts is not None
+                done_event = TranscriptionTextDoneEvent(
+                    text="".join(transcript_text_parts),
+                    usage=TranscriptionUsageTokens(
+                        input_tokens=num_prompt_tokens,
+                        output_tokens=completion_tokens,
+                        total_tokens=num_prompt_tokens + completion_tokens,
+                    ),
+                )
+                yield f"data: {done_event.model_dump_json()}\n\n"
+            elif include_usage:
+                # Once the final token is handled, send requested usage.
                 final_usage = UsageInfo(
                     prompt_tokens=num_prompt_tokens,
                     completion_tokens=completion_tokens,

--- a/vllm/entrypoints/speech_to_text/transcription/protocol.py
+++ b/vllm/entrypoints/speech_to_text/transcription/protocol.py
@@ -108,9 +108,7 @@ class TranscriptionRequest(OpenAIBaseModel):
     """
 
     stream: bool | None = False
-    """When set, it will enable output to be streamed in a similar fashion
-    as the Chat Completion endpoint.
-    """
+    """When set, stream transcription events as server-sent events."""
     # --8<-- [start:transcription-extra-params]
     # Flattened stream option to simplify form data.
     stream_include_usage: bool | None = False
@@ -322,6 +320,28 @@ class TranscriptionRequest(OpenAIBaseModel):
 class TranscriptionUsageAudio(OpenAIBaseModel):
     type: Literal["duration"] = "duration"
     seconds: int
+
+
+class TranscriptionUsageTokens(OpenAIBaseModel):
+    type: Literal["tokens"] = "tokens"
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+
+
+class TranscriptionTextDeltaEvent(OpenAIBaseModel):
+    """A text delta emitted by a streaming transcription."""
+
+    type: Literal["transcript.text.delta"] = "transcript.text.delta"
+    delta: str
+
+
+class TranscriptionTextDoneEvent(OpenAIBaseModel):
+    """The final event emitted by a streaming transcription."""
+
+    type: Literal["transcript.text.done"] = "transcript.text.done"
+    text: str
+    usage: TranscriptionUsageTokens
 
 
 class TranscriptionResponse(OpenAIBaseModel):


### PR DESCRIPTION
## Purpose

Fixes #49116

Update `/v1/audio/transcriptions` streaming responses to use the OpenAI Transcriptions SSE contract:

- emit `transcript.text.delta` events while transcription is generated;
- emit exactly one `transcript.text.done` event after all internally split audio chunks are assembled;
- preserve the existing streaming behavior of `/v1/audio/translations`.

This replaces the previous Chat Completions-like `transcription.chunk` events, which OpenAI SDKs cannot deserialize as transcription stream events.

## Test Plan

```console
.venv/bin/python -m pytest -q \
  tests/entrypoints/speech_to_text/transcription/test_transcription_inter_chunk_spacing.py \
  tests/entrypoints/speech_to_text/transcription/test_transcription_validation_whisper.py
```

Additionally, exercised streaming `/v1/audio/transcriptions` and `/v1/audio/translations` requests with `openai/whisper-large-v3-turbo`.

## Test Result

All automated checks above passed.

The transcription endpoint now returns OpenAI transcription events:

```text
data: {"type":"transcript.text.delta","delta":" My"}

...

data: {"type":"transcript.text.done","text":" My gosh, you've already produced a PowerPoint presentation. ...","usage":{"type":"tokens","input_tokens":9004,"output_tokens":143,"total_tokens":9147}}

data: [DONE]
```

The translation endpoint retains its existing stream format:

```text
data: {"id":"translate-...","object":"translation.chunk","created":...,"model":"openai/whisper-large-v3-turbo","choices":[{"delta":{"content":" My"}}]}

...

data: {"id":"translate-...","object":"translation.chunk","created":...,"model":"openai/whisper-large-v3-turbo","choices":[{"delta":{"content":""},"finish_reason":"stop","stop_reason":null}]}

data: [DONE]
```

For transcription, 139 delta events were emitted, followed by exactly one done event. The concatenated deltas matched `done.text`, and no legacy `choices`, `object`, or `finish_reason` fields were emitted.

## Note

`transcript.text.done.usage` is optional in the OpenAI contract. This PR emits token usage because it is supported by the event schema. For the evaluated audio, vLLM's input-token count reflects its internal ASR processing estimate,
which differs from OpenAI's vendor-specific billing count. If it is preferable not to expose that model-specific accounting, `usage` can be omitted without affecting stream compatibility.

<details>
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

