### PR TITLE
Add SparDA lookahead KV connector

### DIFF
--- a/tests/v1/kv_connector/unit/test_sparda_lookahead_connector.py
+++ b/tests/v1/kv_connector/unit/test_sparda_lookahead_connector.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.config import KVTransferConfig
+from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
+from vllm.distributed.kv_transfer.kv_connector.v1 import KVConnectorRole
+from vllm.distributed.kv_transfer.kv_connector.v1.sparda_lookahead_connector import (
+    SparDALookaheadConnector,
+    SparDALookaheadMetadata,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _config(*, extra_config=None):
+    return SimpleNamespace(
+        kv_transfer_config=KVTransferConfig(
+            kv_connector="SparDALookaheadConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config=extra_config or {},
+        )
+    )
+
+
+def test_connector_is_registered():
+    cls = KVConnectorFactory.get_connector_class_by_name("SparDALookaheadConnector")
+
+    assert cls is SparDALookaheadConnector
+
+
+def test_wait_for_layer_load_schedules_next_layer():
+    connector = SparDALookaheadConnector(
+        _config(),
+        KVConnectorRole.WORKER,
+        kv_cache_config=None,
+    )
+    connector.bind_connector_metadata(
+        SparDALookaheadMetadata(
+            layer_names=("model.layers.0.self_attn", "model.layers.1.self_attn")
+        )
+    )
+
+    connector.start_load_kv(forward_context=None)
+    connector.wait_for_layer_load("model.layers.0.self_attn")
+
+    assert connector.loaded_layers == frozenset({"model.layers.0.self_attn"})
+    assert connector.scheduled_layers == (
+        "model.layers.0.self_attn",
+        "model.layers.1.self_attn",
+    )
+
+
+def test_prefetch_distance_skips_ahead():
+    connector = SparDALookaheadConnector(
+        _config(extra_config={"prefetch_distance": 2}),
+        KVConnectorRole.WORKER,
+        kv_cache_config=None,
+    )
+    connector.bind_connector_metadata(
+        SparDALookaheadMetadata(
+            layer_names=(
+                "model.layers.0.self_attn",
+                "model.layers.1.self_attn",
+                "model.layers.2.self_attn",
+            ),
+            prefetch_distance=2,
+        )
+    )
+
+    connector.start_load_kv(forward_context=None)
+    connector.wait_for_layer_load("model.layers.0.self_attn")
+
+    assert connector.scheduled_layers == (
+        "model.layers.0.self_attn",
+        "model.layers.2.self_attn",
+    )
+
+
+def test_prefetch_plan_is_attached_to_next_layer():
+    connector = SparDALookaheadConnector(
+        _config(),
+        KVConnectorRole.WORKER,
+        kv_cache_config=None,
+    )
+    connector.bind_connector_metadata(
+        SparDALookaheadMetadata(
+            layer_names=("model.layers.0.self_attn", "model.layers.1.self_attn"),
+            prefetch_plan={"model.layers.0.self_attn": (4, 7)},
+        )
+    )
+
+    connector.start_load_kv(forward_context=None)
+    connector.wait_for_layer_load("model.layers.0.self_attn")
+
+    assert connector.scheduled_prefetches["model.layers.1.self_attn"] == (4, 7)
+
+
+def test_piecewise_cudagraph_required_by_default():
+    assert SparDALookaheadConnector.requires_piecewise_for_cudagraph({})
+    assert not SparDALookaheadConnector.requires_piecewise_for_cudagraph(
+        {"enable_layer_prefetch": False}
+    )
+
+
+def test_rejects_invalid_prefetch_distance():
+    with pytest.raises(ValueError, match="prefetch_distance"):
+        SparDALookaheadConnector(
+            _config(extra_config={"prefetch_distance": 0}),
+            KVConnectorRole.WORKER,
+            kv_cache_config=None,
+        )

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -210,6 +210,12 @@ KVConnectorFactory.register_connector(
 )
 
 KVConnectorFactory.register_connector(
+    "SparDALookaheadConnector",
+    "vllm.distributed.kv_transfer.kv_connector.v1.sparda_lookahead_connector",
+    "SparDALookaheadConnector",
+)
+
+KVConnectorFactory.register_connector(
     "DecodeBenchConnector",
     "vllm.distributed.kv_transfer.kv_connector.v1.decode_bench_connector",
     "DecodeBenchConnector",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/sparda_lookahead_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/sparda_lookahead_connector.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Experimental layer-ahead KV connector for SparDA lookahead prefetch."""
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_events import KVCacheEvent
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorBase_V1,
+    KVConnectorMetadata,
+    KVConnectorRole,
+    SupportsHMA,
+)
+from vllm.v1.core.sched.output import SchedulerOutput
+
+if TYPE_CHECKING:
+    from vllm.forward_context import ForwardContext
+    from vllm.v1.attention.backend import AttentionMetadata
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.request import Request
+
+
+@dataclass
+class SparDALookaheadMetadata(KVConnectorMetadata):
+    """Worker metadata for deterministic layer-ahead prefetch planning."""
+
+    layer_names: tuple[str, ...] = ()
+    prefetch_distance: int = 1
+    prefetch_plan: dict[str, tuple[int, ...]] = field(default_factory=dict)
+
+
+class SparDALookaheadConnector(KVConnectorBase_V1, SupportsHMA):
+    """Connector shell for experimenting with layer-ahead KV prefetch.
+
+    The first implementation keeps the prefetch selector deterministic and
+    metadata-driven. Forecast projection can later populate ``prefetch_plan``
+    without changing the per-layer connector control flow.
+    """
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        role: KVConnectorRole,
+        kv_cache_config: "KVCacheConfig",
+    ):
+        super().__init__(
+            vllm_config=vllm_config,
+            role=role,
+            kv_cache_config=kv_cache_config,
+        )
+        extra_config = self._kv_transfer_config.kv_connector_extra_config or {}
+        self._configured_layer_names = tuple(extra_config.get("layer_names", ()))
+        self._prefetch_distance = int(extra_config.get("prefetch_distance", 1))
+        if self._prefetch_distance < 1:
+            raise ValueError("prefetch_distance must be >= 1")
+
+        self._active_layer_names: tuple[str, ...] = ()
+        self._prefetch_plan: dict[str, tuple[int, ...]] = {}
+        self._scheduled_prefetches: dict[str, tuple[int, ...]] = {}
+        self._scheduled_layers: list[str] = []
+        self._pending_layers: set[str] = set()
+        self._loaded_layers: set[str] = set()
+
+    @classmethod
+    def requires_piecewise_for_cudagraph(cls, extra_config: dict[str, Any]) -> bool:
+        return bool(extra_config.get("enable_layer_prefetch", True))
+
+    def bind_connector_metadata(
+        self,
+        connector_metadata: KVConnectorMetadata,
+    ) -> None:
+        super().bind_connector_metadata(connector_metadata)
+        assert isinstance(connector_metadata, SparDALookaheadMetadata)
+        self._active_layer_names = (
+            connector_metadata.layer_names or self._configured_layer_names
+        )
+        self._prefetch_distance = connector_metadata.prefetch_distance
+        self._prefetch_plan = dict(connector_metadata.prefetch_plan)
+        self._scheduled_prefetches.clear()
+        self._scheduled_layers.clear()
+        self._pending_layers.clear()
+        self._loaded_layers.clear()
+
+    def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
+        if self._active_layer_names:
+            self._schedule_layer(self._active_layer_names[0], ())
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        if layer_name in self._pending_layers:
+            self._pending_layers.remove(layer_name)
+            self._loaded_layers.add(layer_name)
+        self._schedule_next_layer(layer_name)
+
+    def save_kv_layer(
+        self,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: "AttentionMetadata",
+        **kwargs: Any,
+    ) -> None:
+        return
+
+    def wait_for_save(self) -> None:
+        return
+
+    def get_num_new_matched_tokens(
+        self,
+        request: "Request",
+        num_computed_tokens: int,
+    ) -> tuple[int | None, bool]:
+        return 0, False
+
+    def update_state_after_alloc(
+        self,
+        request: "Request",
+        blocks: "KVCacheBlocks",
+        num_external_tokens: int,
+    ) -> None:
+        return
+
+    def build_connector_meta(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> KVConnectorMetadata:
+        return SparDALookaheadMetadata(
+            layer_names=self._configured_layer_names,
+            prefetch_distance=self._prefetch_distance,
+        )
+
+    def request_finished(
+        self,
+        request: "Request",
+        block_ids: list[int],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        return False, None
+
+    def request_finished_all_groups(
+        self,
+        request: "Request",
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        return False, None
+
+    def take_events(self) -> Iterable[KVCacheEvent]:
+        return ()
+
+    @property
+    def scheduled_layers(self) -> tuple[str, ...]:
+        return tuple(self._scheduled_layers)
+
+    @property
+    def loaded_layers(self) -> frozenset[str]:
+        return frozenset(self._loaded_layers)
+
+    @property
+    def scheduled_prefetches(self) -> dict[str, tuple[int, ...]]:
+        return dict(self._scheduled_prefetches)
+
+    def _schedule_next_layer(self, layer_name: str) -> None:
+        next_layer = self._layer_after(layer_name, self._prefetch_distance)
+        if next_layer is not None:
+            self._schedule_layer(next_layer, self._prefetch_plan.get(layer_name, ()))
+
+    def _layer_after(self, layer_name: str, distance: int) -> str | None:
+        try:
+            index = self._active_layer_names.index(layer_name)
+        except ValueError:
+            return None
+        next_index = index + distance
+        if next_index >= len(self._active_layer_names):
+            return None
+        return self._active_layer_names[next_index]
+
+    def _schedule_layer(self, layer_name: str, block_ids: tuple[int, ...]) -> None:
+        if layer_name in self._loaded_layers or layer_name in self._pending_layers:
+            return
+        self._pending_layers.add(layer_name)
+        self._scheduled_prefetches[layer_name] = block_ids
+        self._scheduled_layers.append(layer_name)


### PR DESCRIPTION
## Purpose

This PR starts an experimental path for SparDA-style layer-ahead KV prefetch in vLLM.

The goal is to reduce KV offload stalls during long-context decoding by letting a connector begin loading likely-needed KV blocks for a future layer before that layer is invoked. If the prefetch decision is accurate, the attention layer can spend less time waiting on CPU-to-GPU KV movement.

The implementation is intentionally added as a dedicated connector instead of modifying `OffloadingConnector`, following the discussion in #48445. The existing offloading connector is built around asynchronous multi-layer transfers, while SparDA-style prefetch needs conditional decisions at per-layer boundaries.

## Summary

Adding an experimental `SparDALookaheadConnector` as a dedicated KV connector for layer-ahead KV prefetch experiments.

## Advantages

- Creates a narrow testbed for SparDA-style Forecast projection without disrupting existing KV offloading behavior.
- Uses the existing `wait_for_layer_load()` per-layer connector hook, which matches the timing needed for layer-ahead prefetch.
- Provides a metadata surface for passing predicted block ids into future prefetch work.
- Makes it easier to benchmark prefetch hit rate, latency impact, and correctness before integrating model-driven prediction.


## Existing Offloading Flow

```mermaid
flowchart LR
    S["Scheduler step"] --> M["Build connector metadata"]
    M --> W["Worker start_load_kv()"]
    W --> A["Async multi-layer KV transfer"]
    A --> L0["Layer 0 attention"]
    A --> L1["Layer 1 attention"]
    A --> L2["Layer 2 attention"]
    L0 --> D["Decode continues"]
    L1 --> D
    L2 --> D
```

##Proposed Flow 

```mermaid
flowchart LR
    S["Scheduler step"] --> M["Build lookahead metadata"]
    M --> W["Worker start_load_kv()"]
    W --> P0["Prefetch layer 0 KV"]
    P0 --> L0["Layer 0 attention"]
    L0 --> F0["Forecast / select likely blocks"]
    F0 --> P1["Prefetch layer 1 KV"]
    P1 --> L1["Layer 1 attention"]
    L1 --> F1["Forecast / select likely blocks"]
    F1 --> P2["Prefetch layer 2 KV"]
    P2 --> L2["Layer 2 attention"]
    L2 --> D["Decode continues"]
```

## Why a Dedicated Connector?


```mermaid
flowchart TB
    subgraph Existing["Existing OffloadingConnector"]
        E1["start_load_kv()"] --> E2["Async multi-layer transfer"]
        E2 --> E3["Layers consume loaded KV"]
    end

    subgraph New["SparDALookaheadConnector"]
        N1["Layer N waits for KV"] --> N2["Predict blocks for layer N+1"]
        N2 --> N3["Prefetch layer N+1 KV"]
        N3 --> N4["Next layer starts with less transfer stall"]
    end
```

## Changes

- Register `SparDALookaheadConnector`
- Add metadata for deterministic layer-ahead prefetch planning
- Add per-layer scheduling through `start_load_kv()` and `wait_for_layer_load()`
- Add unit coverage for registration, prefetch distance, layer scheduling, and planned block propagation


## Notes

This PR does not add the Forecast projection model implementation yet. It establishes the dedicated connector path and metadata surface for validating layer-ahead prefetch behavior before wiring in model-driven block prediction.