### PR TITLE
[Kernel] Avoid materializing FP32 rotary Q/K tensors

### DIFF
--- a/tests/kernels/core/test_apply_rotary_emb.py
+++ b/tests/kernels/core/test_apply_rotary_emb.py
@@ -11,7 +11,9 @@ ApplyRotaryEmb methods based on the calling context:
 3. RotaryEmbedding.forward_hip() -> ApplyRotaryEmb.forward() (auto-dispatch)
 """
 
+import sys
 from dataclasses import dataclass
+from types import ModuleType
 
 import pytest
 import torch
@@ -22,9 +24,45 @@ from vllm.config import (
     get_cached_compilation_config,
     set_current_vllm_config,
 )
+from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
 from vllm.platforms import current_platform
 
 CUDA_DEVICES = ["cuda:0"]
+
+
+def test_cuda_fp32_compute_preserves_input_storage(
+    default_vllm_config,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Keep Q/K in their original storage dtype for the CUDA kernel."""
+    captured: dict[str, torch.Tensor] = {}
+
+    def apply_rotary_emb(
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        interleaved: bool,
+    ) -> torch.Tensor:
+        captured.update(x=x, cos=cos, sin=sin)
+        return torch.empty_like(x)
+
+    rotary_module = ModuleType("vllm.vllm_flash_attn.layers.rotary")
+    rotary_module.__dict__["apply_rotary_emb"] = apply_rotary_emb
+    monkeypatch.setitem(sys.modules, rotary_module.__name__, rotary_module)
+
+    x = torch.randn(2, 8, 3, 80, dtype=torch.bfloat16)
+    cos = torch.randn(8, 39, dtype=torch.float32)
+    sin = torch.randn(8, 39, dtype=torch.float32)
+    op = ApplyRotaryEmb(enforce_enable=True, enable_fp32_compute=True)
+
+    output = op.forward_cuda(x, cos, sin)
+
+    assert captured["x"].dtype == x.dtype
+    assert captured["x"].data_ptr() == x.data_ptr()
+    assert captured["cos"].dtype == torch.float32
+    assert captured["sin"].dtype == torch.float32
+    assert output.shape == x.shape
+    assert output.dtype == x.dtype
 
 
 @dataclass

--- a/vllm/model_executor/layers/rotary_embedding/common.py
+++ b/vllm/model_executor/layers/rotary_embedding/common.py
@@ -189,6 +189,8 @@ class ApplyRotaryEmb(CustomOp):
         x: torch.Tensor,
         cos: torch.Tensor,
         sin: torch.Tensor,
+        *,
+        upcast_input: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Size, torch.dtype]:
         origin_shape = x.shape
         if len(origin_shape) == 3:
@@ -197,7 +199,8 @@ class ApplyRotaryEmb(CustomOp):
 
         origin_dtype = x.dtype
         if self.enable_fp32_compute:
-            x = x.float()
+            if upcast_input:
+                x = x.float()
             cos = cos.float()
             sin = sin.float()
 
@@ -234,7 +237,9 @@ class ApplyRotaryEmb(CustomOp):
     ) -> torch.Tensor:
         from vllm.vllm_flash_attn.layers.rotary import apply_rotary_emb
 
-        x, cos, sin, origin_shape, origin_dtype = self._pre_process(x, cos, sin)
+        x, cos, sin, origin_shape, origin_dtype = self._pre_process(
+            x, cos, sin, upcast_input=False
+        )
 
         """
         Arguments of apply_rotary_emb() in vllm_flash_attn:

--- a/vllm/models/minimax_m3/common/vision_tower.py
+++ b/vllm/models/minimax_m3/common/vision_tower.py
@@ -126,8 +126,8 @@ class MiniMaxVLAttention(nn.Module):
         )
         # ApplyRotaryEmb handles the internal cos/sin repeat and partial
         # rotation (ro_dim = half_rot_dim * 2 < head_dim for MiniMax).
-        # enable_fp32_compute=True runs the rotation in fp32 (q/k upcast,
-        # fp32 cos/sin), matching the reference ``_minimax_rope_applier``.
+        # enable_fp32_compute=True keeps cos/sin and rotary arithmetic in fp32,
+        # matching the reference ``_minimax_rope_applier``.
         self.apply_rotary_emb = ApplyRotaryEmb(
             enforce_enable=True, enable_fp32_compute=True
         )


### PR DESCRIPTION
## Purpose

Avoid materializing full FP32 Q/K tensors when
`ApplyRotaryEmb(enable_fp32_compute=True)` uses the CUDA Triton kernel.

MiniMax-M3 profiles a pre-merge vision sequence with Q/K shape
`(2, 768000, 16, 80)`. The existing preprocessing converts that BF16 tensor
to FP32, and the kernel then allocates an FP32 `empty_like` output. The observed
OOM attempted exactly 7.32 GiB at that allocation. Including the final BF16
downcast, the theoretical Q/K peak is about 21.97 GiB.

The Triton kernel already converts each loaded tile to FP32 for arithmetic.
This change therefore keeps CUDA Q/K in their original storage dtype while
retaining FP32 cos/sin tables. The theoretical Q/K peak becomes about 7.32 GiB,
a 14.65 GiB reduction. HIP and native behavior are unchanged.

This is a stacked Draft depending on
[vllm-project/flash-attention#167](https://github.com/vllm-project/flash-attention/pull/167).
After that PR merges, this branch must update the pinned FlashAttention SHA
before it is ready for review or merge.

## Duplicate check

Open-PR searches for `ApplyRotaryEmb`, `rotary mixed dtype`, and
`MiniMax OOM rotary` found no overlapping change as of 2026-07-19. PR #40180
addresses XDRoPE cache dtype matching; PR #38060 addresses import fallback.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/kernels/core/test_apply_rotary_emb.py::test_cuda_fp32_compute_preserves_input_storage \
  -q -p no:randomly
```

Before marking ready, also run the upstream CUDA tests, a real vLLM rotary
numerical comparison, MiniMax-M3 dummy initialization/profile, and the relevant
model evaluation.

## Test Result

Completed on the rebased branch:

- Regression test: `1 passed` (the old implementation failed by passing an
  FP32 copy with different storage)
- Ruff 0.14.0 check and format: passed
- mypy 1.20.2: passed
- typos 1.43.5 and `git diff --check`: passed

GPU tests, MiniMax initialization, and model evaluation are pending. No result
for those is claimed in this Draft.

## AI assistance

OpenAI Codex assisted with diagnosis, implementation, and test design. The
human submitter will review every changed line and GPU result before marking
this PR ready.
