### PR TITLE
[ROCm][CI] Fix sparse MLA metadata sync fixture

### DIFF
--- a/tests/kernels/attention/test_rocm_aiter_mla_sparse_metadata_sync.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_sparse_metadata_sync.py
@@ -58,6 +58,7 @@ def _make_builder():
         max_num_batched_tokens + 1, dtype=torch.int32, device="cpu"
     )
     builder._num_attention_heads = 16
+    builder._num_compute_units = 8
     builder._mla_work_meta_data = torch.empty(1, dtype=torch.int32, device="cpu")
     builder._mla_work_indptr = torch.empty(1, dtype=torch.int32, device="cpu")
     builder._mla_work_info_set = torch.empty(1, dtype=torch.int32, device="cpu")
@@ -116,6 +117,7 @@ def test_sparse_persistent_metadata_syncs_only_after_recompute(monkeypatch):
 
     assert events == ["metadata", "sync"]
     assert fake_get_mla_metadata_v1_mock.call_count == 1
+    assert fake_get_mla_metadata_v1_mock.call_args.kwargs["max_split_per_batch"] == 1
 
     events.clear()
 

--- a/tests/kernels/attention/test_rocm_aiter_mla_sparse_metadata_sync.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_sparse_metadata_sync.py
@@ -58,7 +58,7 @@ def _make_builder():
         max_num_batched_tokens + 1, dtype=torch.int32, device="cpu"
     )
     builder._num_attention_heads = 16
-    builder._num_compute_units = 8
+    builder._num_compute_units = current_platform.num_compute_units()
     builder._mla_work_meta_data = torch.empty(1, dtype=torch.int32, device="cpu")
     builder._mla_work_indptr = torch.empty(1, dtype=torch.int32, device="cpu")
     builder._mla_work_info_set = torch.empty(1, dtype=torch.int32, device="cpu")


### PR DESCRIPTION
The [failing AMD CI run](https://buildkite.com/vllm/amd-ci/builds/11018/list?jid=019f799a-f6b0-4579-9197-1c495ef92071&tab=output) raised `AttributeError: _num_compute_units` in the synthetic sparse-MLA builder fixture. `git bisect` from `c233d90aa826df072872df47b201450059be8e71` to `b6ff8a2f509cc7ac9c58176f5115a836aa1e08bd` identified `e94243893dd30256f58644ad4ecf779be757dff8`, introduced by regression PR [#46832](https://github.com/vllm-project/vllm/pull/46832), as the first bad commit. Production construction already initializes the new field; this test intentionally bypasses `__init__` with `object.__new__`. Initialize the fixture's compute-unit count and assert that the derived split cap reaches AITER. The [earlier good CI run](https://buildkite.com/vllm/amd-ci/builds/11005/list?jid=019f7474-7ea6-4c86-9956-3431fc3b0777&tab=output) passed before that constructor dependency was added.