### PR TITLE
[Bugfix] Handle empty or refusal content when reconstructing Responses input messages

### DIFF
--- a/tests/entrypoints/openai/responses/test_responses_utils.py
+++ b/tests/entrypoints/openai/responses/test_responses_utils.py
@@ -9,6 +9,7 @@ from openai.types.responses.response_function_tool_call_output_item import (
     ResponseFunctionToolCallOutputItem,
 )
 from openai.types.responses.response_output_message import ResponseOutputMessage
+from openai.types.responses.response_output_refusal import ResponseOutputRefusal
 from openai.types.responses.response_output_text import ResponseOutputText
 from openai.types.responses.response_reasoning_item import (
     Content,
@@ -921,3 +922,37 @@ class TestConstructInputMessagesInstructionsLeak:
         assert len(msgs) == 2
         assert msgs[0] == {"role": "system", "content": "be helpful"}
         assert msgs[1] == {"role": "user", "content": "hello"}
+
+
+class TestOutputMessageContent:
+    """An assistant ResponseOutputMessage may carry empty content or a refusal
+    block (which has no ``text``); reconstructing the input must not crash."""
+
+    def test_empty_content_yields_empty_string(self):
+        item = ResponseOutputMessage(
+            id="msg_empty",
+            content=[],
+            role="assistant",
+            status="completed",
+            type="message",
+        )
+        message = _single_chat_message(item)
+        assert message["role"] == "assistant"
+        assert message["content"] == ""
+
+    def test_refusal_content_uses_refusal_text(self):
+        item = ResponseOutputMessage(
+            id="msg_refusal",
+            content=[
+                ResponseOutputRefusal(
+                    refusal="I can't help with that.",
+                    type="refusal",
+                )
+            ],
+            role="assistant",
+            status="completed",
+            type="message",
+        )
+        message = _single_chat_message(item)
+        assert message["role"] == "assistant"
+        assert message["content"] == "I can't help with that."

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -292,7 +292,13 @@ def _construct_message_from_response_item(
             "reasoning": reasoning,
         }
     elif isinstance(item, ResponseOutputMessage):
-        output_text = item.content[0].text
+        # content may be empty, and each block is either a ResponseOutputText (``text``)
+        # or a ResponseOutputRefusal (``refusal``); indexing ``content[0].text`` blindly
+        # raises IndexError on empty content and AttributeError on a refusal block.
+        output_text = ""
+        if item.content:
+            first = item.content[0]
+            output_text = getattr(first, "text", None) or getattr(first, "refusal", "")
         if prev_assistant_msg:
             previous_content = prev_assistant_msg.get("content")
             if previous_content is None:


### PR DESCRIPTION
## Purpose

The Responses API returns an unhandled **HTTP 500** when a client replays a prior assistant
turn whose content is a refusal or is empty.

`_construct_message_from_response_item` (`vllm/entrypoints/openai/responses/utils.py`) reads
`item.content[0].text` unguarded for a `ResponseOutputMessage`:

```python
elif isinstance(item, ResponseOutputMessage):
    output_text = item.content[0].text
```

Two ordinary inputs break this:
- `content` is `List[Content]` with no minimum length, so an assistant message with
  `content=[]` raises `IndexError`.
- A content block may be a `ResponseOutputRefusal` (fields `refusal`/`type`, **no** `text`),
  so replaying a refusal turn raises `AttributeError`.

The request-level `input_item_parsing` validator coerces assistant dicts with list content
into typed `ResponseOutputMessage`s, so both reach this branch and are not caught by the
guarded dict-fallback path. Its sibling reasoning branch already guards (`elif item.content
and len(item.content) >= 1`); this branch now does too.

```python
elif isinstance(item, ResponseOutputMessage):
    output_text = ""
    if item.content:
        first = item.content[0]
        output_text = getattr(first, "text", None) or getattr(first, "refusal", "")
```

Empty content → `""`; a refusal block → its refusal text; a normal text block → unchanged.

## Test Plan

Added `TestOutputMessageContent` to
`tests/entrypoints/openai/responses/test_responses_utils.py`:
- `test_empty_content_yields_empty_string`
- `test_refusal_content_uses_refusal_text`

```
pytest tests/entrypoints/openai/responses/test_responses_utils.py -k OutputMessageContent
```

## Test Result

Both new tests pass with the fix and fail against the current code (`IndexError` /
`AttributeError` respectively). Verified the exact old vs. new expressions against the real
`openai` (2.46.0) types: for a text block both yield the same string; for a refusal block the
old code raises `AttributeError` while the new returns the refusal text; for empty content the
old code raises `IndexError` while the new returns `""`. `ruff check` and `ruff format --check`
pass on both files. (`test_responses_utils.py` is a CPU-only module — no GPU required.)
