### PR TITLE
[Bugfix][KVConnector] Release executor and lock fds in ExampleHiddenS…

### DIFF
--- a/tests/v1/kv_connector/unit/test_hidden_states_connector_shutdown.py
+++ b/tests/v1/kv_connector/unit/test_hidden_states_connector_shutdown.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only regression test for ExampleHiddenStatesConnector.shutdown().
+
+Without a shutdown() override the connector inherits the no-op base
+implementation, leaking the async-write ThreadPoolExecutor threads and any
+open .lock fds (held with LOCK_EX). This test constructs the connector
+without its GPU/config-dependent __init__ (via __new__) and checks that
+shutdown() drains the executor and closes the lock fds.
+"""
+
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from vllm.distributed.kv_transfer.kv_connector.v1.example_hidden_states_connector import (  # noqa: E501
+    ExampleHiddenStatesConnector,
+)
+
+
+def test_shutdown_releases_executor_and_locks(tmp_path):
+    # Build the connector without __init__ (which needs a VllmConfig + CUDA).
+    conn = ExampleHiddenStatesConnector.__new__(ExampleHiddenStatesConnector)
+    conn._executor = ThreadPoolExecutor(max_workers=1)
+    lock_fd = os.open(str(tmp_path / "r0.lock"), os.O_CREAT | os.O_RDWR)
+    conn._lock_fds = {"r0": lock_fd}
+
+    conn.shutdown()
+
+    # Executor is shut down: it rejects new work.
+    with pytest.raises(RuntimeError):
+        conn._executor.submit(lambda: None)
+
+    # The lock fd was closed: fstat on it now fails.
+    with pytest.raises(OSError):
+        os.fstat(lock_fd)
+
+    # Tracking dict is cleared.
+    assert conn._lock_fds == {}

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import contextlib
 import fcntl
 import os
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -429,6 +430,24 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         self._req_copy_events[pending.req_id] = copy_done
         self._req_futures[pending.req_id] = future
         future.add_done_callback(partial(self._on_write_done, pending.req_id))
+
+    def shutdown(self):
+        """Release the async-write thread pool and any held lock fds.
+
+        Called on worker teardown (see ``KVConnectorBase_V1.shutdown``).
+        Without this override the ThreadPoolExecutor's worker threads and
+        any still-open ``.lock`` fds holding ``LOCK_EX`` leak on shutdown,
+        which can also leave clients blocked on ``LOCK_SH`` hanging.
+        """
+        # Drain in-flight writes so their LOCK_EX is released normally,
+        # then tear down the pool's worker threads.
+        self._executor.shutdown(wait=True)
+        # Close any lock fds that were pre-created in wait_for_save but
+        # never consumed by _submit_async_write (e.g. request aborted).
+        for lock_fd in self._lock_fds.values():
+            with contextlib.suppress(OSError):
+                os.close(lock_fd)
+        self._lock_fds.clear()
 
     # ==============================
     # Scheduler-side methods


### PR DESCRIPTION
*Purpose*

`ExampleHiddenStatesConnector` spins up worker-side async-write infrastructure in
`__init__` -- a `ThreadPoolExecutor` (`self._executor`) and per-request `.lock`
file descriptors held with `LOCK_EX` (`self._lock_fds`) -- but never overrides
`KVConnectorBase_V1.shutdown()`. The base implementation is a no-op:

```python
def shutdown(self):
    """
    Shutdown the connector. This is called when the worker process
    is shutting down to ensure that all the async operations are
    completed and the connector is cleaned up properly.
    """
    return None
```
So on worker teardown the executor's worker threads and any still-open lock fds
leak. A leaked `LOCK_EX` fd is especially bad here: a client blocked on
`LOCK_SH` in `load_hidden_states()` waits for the writer to release its
exclusive lock, so a fd that is never closed can leave that client hanging.

Peer connectors that own similar resources already honor this contract
(`OffloadingConnector.shutdown`, `MultiConnector.shutdown`).

*Fix*

Add a `shutdown()` override to `ExampleHiddenStatesConnector` that:

1. Drains and tears down the write thread pool via `self._executor.shutdown(wait=True)`
   (in-flight writes complete and release their `LOCK_EX` normally).
2. Closes any lock fds pre-created in `wait_for_save` but never consumed by
   `_submit_async_write` (e.g. aborted requests), then clears `self._lock_fds`.

The change is confined to a single new method; no existing behavior is modified.

*Test Plan*

New CPU-only unit test
`tests/v1/kv_connector/unit/test_hidden_states_connector_shutdown.py`. It builds
the connector via `__new__` (skipping the GPU/config-dependent `__init__`),
wires a real `ThreadPoolExecutor` and a real lock fd, calls `shutdown()`, and
asserts the executor rejects new work, the fd is closed (`os.fstat` raises), and
`_lock_fds` is cleared. No GPU required.

*Test Result*
```python
$ python -m pytest tests/v1/kv_connector/unit/test_hidden_states_connector_shutdown.py -v
tests/v1/kv_connector/unit/test_hidden_states_connector_shutdown.py::test_shutdown_releases_executor_and_locks PASSED
1 passed

Confirmed as a genuine regression test: with the shutdown() override removed
(falling back to the base no-op) the test fails (DID NOT RAISE RuntimeError --
the executor is not shut down); with the override it passes.
````