### PR TITLE
[Bugfix][Spec Decode] DSpark: build draft under its own model/quant config (NVFP4 target corrupts MXFP4 draft experts)

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -942,6 +942,14 @@ class SpeculativeConfig:
                         "DSparkDraftModel"
                     ]
                     self.update_arch_()
+                    # hf_config_override had rewritten model_type to
+                    # "deepseek_mtp" before ModelConfig._verify_quantization
+                    # ran, so the deepseek_v4_fp8 override never matched and
+                    # the draft quantization resolved to plain "fp8". Restore
+                    # it so draft MoE experts dispatch on the draft
+                    # checkpoint's expert_dtype (MXFP4 vs NVFP4 vs FP8).
+                    if self.draft_model_config.quantization == "fp8":
+                        self.draft_model_config.quantization = "deepseek_v4_fp8"
                 elif (
                     self.method == "dspark"
                     and "Gemma4DSparkModel" in self.draft_model_config.architectures

--- a/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
@@ -22,6 +22,18 @@ def load_dspark_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
 
     draft_vllm_config = replace(
         vllm_config,
+        # Build the draft under its own model/quant config. Quantization
+        # dispatch can resolve lazily from the current vllm_config's model
+        # hf_config and memoize on the quant_config instance
+        # (e.g. DeepseekV4FP8Config.expert_dtype / moe_quant_algo), so
+        # reusing the target's quant_config builds the draft MoE with the
+        # target's expert format: a modelopt-NVFP4 target silently loads
+        # the natively-MXFP4 DSpark experts as NVFP4 (same shapes, ue8m0
+        # scales read as e4m3), producing garbage draft logits.
+        model_config=draft_model_config,
+        quant_config=VllmConfig.get_quantization_config(
+            draft_model_config, vllm_config.load_config
+        ),
         attention_config=replace(
             vllm_config.attention_config,
             use_non_causal=dflash_has_any_non_causal(draft_model_config.hf_config),


### PR DESCRIPTION
## Purpose

Fix silent numerical corruption of the DSpark drafter when the target model is quantized differently from the draft checkpoint — most visibly, a modelopt-NVFP4 DeepSeek-V4 target (`nvidia/DeepSeek-V4-{Flash,Pro}-NVFP4`) paired with the official DSpark drafter (`deepseek-ai/DeepSeek-V4-{Flash,Pro}-DSpark`, natively MXFP4 experts).

**Symptom**: with an NVFP4 target, acceptance length collapses — DeepSeek-V4-Pro drops to exactly **AL = 1.0** (the drafter proposes token id 0 at every position; zero drafts accepted over 80k+ steps), DeepSeek-V4-Flash drops to **2.57** vs 3.55 with the FP8 target. No error or warning is emitted anywhere.

## Root cause (two layers)

1. **Draft `quantization` resolves to plain `fp8` instead of `deepseek_v4_fp8`.** `SpeculativeConfig.hf_config_override` rewrites the draft `hf_config.model_type` from `deepseek_v4` to `deepseek_mtp` (for MTP arch resolution) *before* `ModelConfig._verify_quantization` runs, so `DeepseekV4FP8Config.override_quantization_method` (which requires `model_type == "deepseek_v4"`) never matches. The DSpark branch later restores `model_type = "deepseek_v4"`, but `quantization` is already frozen at `"fp8"`.

2. **The draft is built under the target's config context.** `load_dspark_model` constructs the draft with the target's `vllm_config`, so the draft modules reuse the **target's `quant_config` instance**, and `DeepseekV4FP8Config.expert_dtype` / `moe_quant_algo` resolve lazily from `get_current_vllm_config().model_config.hf_config` (the *target's*) and are memoized. With an NVFP4-experts target (`moe_quant_algo: "NVFP4"`), the draft's MXFP4 experts are constructed with `ModelOptNvFp4FusedMoE`. The ue8m0 scales load into e4m3 scale buffers with matching shapes, so **weight loading succeeds silently** and the draft MoE computes garbage.

Diagnostic tell in the logs: with an FP8 target the draft build prints `Using 'FLASHINFER_TRTLLM_MXFP4_MXFP8' Mxfp4 MoE backend`; with an NVFP4 target that line never appears, and instrumentation shows the draft's `routed_experts` quant method is `ModelOptNvFp4FusedMoE` and its greedy draft output degenerates to constant token id 0 (Pro).

## Fix (2 files, +20 lines)

- `vllm/config/speculative.py`: after the DSpark branch restores `model_type = "deepseek_v4"`, restore the draft quantization to `deepseek_v4_fp8` so expert-dtype-aware MoE dispatch applies to the draft.
- `vllm/v1/worker/gpu/spec_decode/dspark/utils.py`: build the draft under its own `model_config` and a freshly derived `quant_config` (`VllmConfig.get_quantization_config(draft_model_config, load_config)`) instead of inheriting the target's.

Both parts are required: (2) alone regresses FP8 targets (draft would resolve plain `Fp8Config` → `KeyError: ...w13_weight_scale` at load), which is exactly what (1) prevents. Non-DeepSeek DSpark drafters (Qwen3/Gemma4 `*DSparkModel` architectures) are unaffected by (1); (2) is strictly more correct for them (an unquantized drafter no longer inherits a quantized target's quant config).

## Test Plan

Hardware: 1× node, 8× B300 (TP8/EP8), fp8 KV cache, greedy (temp 0), `num_speculative_tokens=5` (`dspark_block_size=5`).

```
--speculative-config '{"method":"dspark","model":"deepseek-ai/DeepSeek-V4-Pro-DSpark","num_speculative_tokens":5,"draft_sample_method":"greedy"}'
```

Ran MT-Bench (80 prompts × 2 turns, 1024 output tokens) through an `AsyncLLM` acceptance-length harness, plus smoke runs with this exact patch verifying (a) the draft experts get `Mxfp4MoEMethod` / `FLASHINFER_TRTLLM_MXFP4_MXFP8`, (b) FP8-target no-regression, (c) healthy acceptance histograms.

## Model evaluation results

MT-Bench average acceptance length (higher is better):

| Target | Draft | AL before | AL after |
|---|---|---|---|
| DeepSeek-V4-Flash (FP8) | Flash-DSpark | 3.554 | 3.554 (unchanged) |
| DeepSeek-V4-Flash-NVFP4 | Flash-DSpark | 2.572 | **3.577** |
| DeepSeek-V4-Pro-DSpark (FP8, self) | Pro-DSpark | 3.525 | 3.525 (unchanged) |
| DeepSeek-V4-Pro-NVFP4 | Pro-DSpark | **1.000** | **3.492** |

Per-position conditional acceptance rates for the NVFP4 targets recover to parity with FP8 (≈0.70–0.79 at positions 2–6). Generated text quality is unaffected (target-side verification is unchanged; this only fixes the drafter).

## Duplicate-work check

Searched open PRs/issues for `dspark`, `dspark quantization`, `dspark nvfp4`: no open PR addresses draft quant-config resolution. Closest issue (#47934, DSpark + FP4 target launch failure on GLM 5.2) had its content removed and is likely a different path (GLM DSpark drafters don't take the deepseek_v4 branch), though (2) may also help such cases.

## AI assistance disclosure

This bug was root-caused, fixed, and validated with AI assistance (Claude Code). The submitter reproduced the issue, reviewed every changed line, and ran all validation jobs end-to-end on 8×B300 hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
