### PR TITLE
[Performance] Enable MLA RoPE KV-cache fusion by default

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -288,6 +288,15 @@ def test_splitting_ops_dynamic():
     # is unchanged.
     assert config.compilation_config.cudagraph_mode == CUDAGraphMode.PIECEWISE
 
+    compilation_config = CompilationConfig(
+        mode=CompilationMode.VLLM_COMPILE,
+        pass_config=PassConfig(),
+    )
+    compilation_config.pass_config.fuse_rope_kvcache_cat_mla = True
+    compilation_config.set_splitting_ops_for_v1(all2all_backend="naive")
+    assert "vllm::unified_kv_cache_update" in compilation_config.splitting_ops
+    assert "vllm::unified_mla_kv_cache_update" not in compilation_config.splitting_ops
+
 
 def test_moe_splitting_ops_deepep_ht_inductor_partition():
     # Inductor partition case: user-provided splitting_ops should be

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -1172,7 +1172,8 @@ class CompilationConfig:
                         )
                         self.pass_config.fuse_qk_norm_rope_kvcache = False
                     self.splitting_ops.append("vllm::unified_kv_cache_update")
-                    self.splitting_ops.append("vllm::unified_mla_kv_cache_update")
+                    if not self.pass_config.fuse_rope_kvcache_cat_mla:
+                        self.splitting_ops.append("vllm::unified_mla_kv_cache_update")
 
             elif len(self.splitting_ops) == 0:
                 if (

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -168,12 +168,15 @@ def enable_rope_kvcache_fusion(cfg: "VllmConfig") -> bool:
 
 
 def enable_rope_kvcache_mla_fusion(cfg: "VllmConfig") -> bool:
-    """Enable if use_inductor_graph_partition is enabled."""
+    """Enable MLA RoPE + KV cache fusion when supported by the platform.
 
-    return (
-        cfg.compilation_config.use_inductor_graph_partition
-        or not cfg.compilation_config.splitting_ops_contain_kv_cache_update()
-    )
+    The MLA fusion pass replaces ``unified_mla_kv_cache_update`` with a fused
+    op, so it must be allowed to run before the cache-update op is split out of
+    the compiled graph.
+    """
+    from vllm.platforms import current_platform
+
+    return current_platform.is_cuda_alike()
 
 
 def enable_norm_pad_fusion(cfg: "VllmConfig") -> bool:


### PR DESCRIPTION
## Purpose
Fixes MLA RoPE + KV-cache fusion not being enabled by default on CUDA.
The MLA fused op/path already exists, and the fusion pass can match the pattern when enabled. 

  This PR enables `fuse_rope_kvcache_cat_mla` by default on CUDA-like platforms and keeps `vllm::unified_mla_kv_cache_update` inside the compiled graph when that fusion is enabled.

  ## Test Plan

* .venv/bin/python -m pytest tests/compile/test_config.py::test_splitting_ops_dynamic -q : `Verifies V1 splitting ops are configured correctly, including keeping unified_mla_kv_cache_update inside the graph when MLA RoPE+KV fusion is enabled.`
* .venv/bin/python -m pytest \tests/compile/passes/test_mla_rope_kvcache_cat_fusion.py \ -q -s -k "TRITON_MLA" : `Verifies the MLA RoPE+KV-cache fusion pass matches and replaces the pattern for the Triton MLA backend.`
* .venv/bin/python -m pytest \tests/compile/passes/test_mla_rope_kvcache_cat_fusion.py \ -q -s -k "not (FLASH_ATTN_MLA and fp8)" : `Runs the supported MLA fusion test combinations while excluding the known unsupported FlashAttn MLA + FP8 KV-cache case.`
* Runtime validation was also run with deepseek-ai/DeepSeek-V2-Lite on 1x H100 using V1 compile mode.
* Ran a small 100-request serving benchmark on DeepSeek-V2-Lite on 1x H100


  ## Test Result

  * tests/compile/test_config.py::test_splitting_ops_dynamic passed
  * tests/compile/passes/test_mla_rope_kvcache_cat_fusion.py -k "TRITON_MLA" - 4 passed, 4 deselected, 16 warnings
  * tests/compile/passes/test_mla_rope_kvcache_cat_fusion.py -k "not (FLASH_ATTN_MLA and fp8)" - 6 passed, 2 deselected, 16 warnings 
  * Runtime validation showed the fusion enabled and matched:
```
  Enabled custom fusions: rope_kvcache_cat_mla
  'fuse_rope_kvcache_cat_mla': True
  'splitting_ops': [..., 'vllm::unified_kv_cache_update']
  fusion pass matches: {'mla_rope_kv_cache_fusion_pass': 1}
  fusion pass matches: {'mla_rope_kv_cache_fusion_pass': 2}
  fusion pass matches: {'mla_rope_kv_cache_fusion_pass': 3}
```

*  Performance benchmark

```bash
.venv/bin/python bench_mla_serving.py
```

**100-request serving benchmark on `deepseek-ai/DeepSeek-V2-Lite` (1× H100):**

| Config | Successful requests | Output tokens | Total tokens | Output throughput | Total throughput | Mean TPOT |
|--------|--------------------:|--------------:|-------------:|------------------:|-----------------:|----------:|
| `main` (baseline) | 100 | 6400 | 7100 | **5959.83 tok/s** | **6611.69 tok/s** | **0.168 ms** |
| `feature` (run 1) | 100 | 6400 | 7100 | **10596.56 tok/s** | **11755.56 tok/s** | **0.094 ms** |
| `feature` (run 2) | 100 | 6400 | 7100 | **11135.59 tok/s** | **12353.54 tok/s** | **0.090 ms** |

Fix #46979