### PR TITLE
[Bugfix][KV Offloading] Handle queued request aborts without allocated KV blocks

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -12,6 +12,9 @@ from tests.v1.kv_connector.unit.offloading_connector.utils import (
 )
 from tests.v1.kv_connector.unit.utils import EOS_TOKEN_ID
 from vllm.distributed.kv_events import MEDIUM_CPU, BlockRemoved, BlockStored
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
+    OffloadingConnectorMetadata,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
     OffloadingConnectorStats,
     _ConnectorMetricName,
@@ -106,6 +109,40 @@ def test_last_block_offloaded_at_request_finish(
         "req_status was deleted but should be kept alive "
         "for _build_store_jobs to process finished_req_ids."
     )
+
+
+@pytest.mark.parametrize("async_scheduling", [True, False])
+def test_abort_queued_request_does_not_build_store_job(
+    request_runner, async_scheduling: bool
+):
+    """Aborting a never-scheduled request must not store unallocated KV."""
+    block_size = 4
+    runner = request_runner(
+        block_size=block_size,
+        num_gpu_blocks=8,
+        async_scheduling=async_scheduling,
+    )
+
+    runner.new_request(token_ids=[0] * (block_size * 4))
+    runner.scheduler.schedule()
+
+    runner.new_request(token_ids=[1] * (block_size * 4))
+    queued_req_id = str(runner.req_id)
+    assert any(
+        request.request_id == queued_req_id for request in runner.scheduler.waiting
+    )
+
+    runner.scheduler.finish_requests(queued_req_id, RequestStatus.FINISHED_ABORTED)
+    req_status = runner.connector_scheduler._req_status[queued_req_id]
+    assert all(group_state.offload_keys for group_state in req_status.group_states)
+    assert all(not group_state.block_ids for group_state in req_status.group_states)
+
+    scheduler_output = runner.scheduler.schedule()
+
+    metadata = scheduler_output.kv_connector_metadata
+    assert isinstance(metadata, OffloadingConnectorMetadata)
+    assert all(job.req_id != queued_req_id for job in metadata.store_jobs.values())
+    assert queued_req_id not in runner.connector_scheduler._req_status
 
 
 def test_scheduler_reports_lookup_sync_delay(request_runner):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -327,6 +327,21 @@ class RequestOffloadState:
             num_chunks = max(0, num_chunks - 1)
         return num_chunks
 
+    def storable_allocated_chunks(
+        self,
+        group_config: "GroupOffloadConfig",
+        group_state: RequestGroupState,
+        num_offloadable_tokens: int,
+    ) -> int:
+        """Number of storable chunks backed by complete GPU block mappings."""
+        num_allocated_chunks = (
+            len(group_state.block_ids) // self.config.blocks_per_chunk
+        )
+        return min(
+            self.storable_chunks(group_config, num_offloadable_tokens),
+            num_allocated_chunks,
+        )
+
     def advance_stored_idx(self, num_offloadable_tokens: int) -> None:
         # max(): at the prefill->decode transition of a chunk-aligned prompt,
         # storable_chunks drops by one (the eagle exclusion kicks in), and the
@@ -336,7 +351,9 @@ class RequestOffloadState:
         ):
             group_state.next_stored_chunk_idx = max(
                 group_state.next_stored_chunk_idx,
-                self.storable_chunks(group_config, num_offloadable_tokens),
+                self.storable_allocated_chunks(
+                    group_config, group_state, num_offloadable_tokens
+                ),
             )
 
     def update_num_hit_chunks(self, num_cached_tokens: int) -> None:
@@ -970,8 +987,8 @@ class OffloadingConnectorScheduler:
             for group_config, group_state in zip(
                 self.config.kv_group_configs, req_status.group_states
             ):
-                num_chunks = req_status.storable_chunks(
-                    group_config, num_offloadable_tokens
+                num_chunks = req_status.storable_allocated_chunks(
+                    group_config, group_state, num_offloadable_tokens
                 )
 
                 start_chunk_idx = group_state.next_stored_chunk_idx
@@ -1047,8 +1064,8 @@ class OffloadingConnectorScheduler:
                 is_sliding_window = (
                     group_config.sliding_window_size_in_chunks is not None
                 )
-                num_chunks = req_status.storable_chunks(
-                    group_config, num_offloadable_tokens
+                num_chunks = req_status.storable_allocated_chunks(
+                    group_config, group_state, num_offloadable_tokens
                 )
                 start_chunk_idx = group_state.next_stored_chunk_idx
                 block_ids = group_state.block_ids

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -306,9 +306,12 @@ class RequestOffloadState:
             group_state.block_ids.extend(new_blocks)
 
     def storable_chunks(
-        self, group_config: "GroupOffloadConfig", num_offloadable_tokens: int
+        self,
+        group_config: "GroupOffloadConfig",
+        group_state: RequestGroupState,
+        num_offloadable_tokens: int,
     ) -> int:
-        """Number of leading offloaded chunks eligible for store.
+        """Number of allocated leading offloaded chunks eligible for store.
 
         For eagle/MTP groups the volatile trailing chunk of the offloadable
         range is excluded while decoding: the draft-layer KV of the last
@@ -325,22 +328,10 @@ class RequestOffloadState:
         is_decoding = num_offloadable_tokens > self.req.num_prompt_tokens
         if group_config.is_eagle_group and is_decoding:
             num_chunks = max(0, num_chunks - 1)
-        return num_chunks
-
-    def storable_allocated_chunks(
-        self,
-        group_config: "GroupOffloadConfig",
-        group_state: RequestGroupState,
-        num_offloadable_tokens: int,
-    ) -> int:
-        """Number of storable chunks backed by complete GPU block mappings."""
         num_allocated_chunks = (
             len(group_state.block_ids) // self.config.blocks_per_chunk
         )
-        return min(
-            self.storable_chunks(group_config, num_offloadable_tokens),
-            num_allocated_chunks,
-        )
+        return min(num_chunks, num_allocated_chunks)
 
     def advance_stored_idx(self, num_offloadable_tokens: int) -> None:
         # max(): at the prefill->decode transition of a chunk-aligned prompt,
@@ -351,9 +342,7 @@ class RequestOffloadState:
         ):
             group_state.next_stored_chunk_idx = max(
                 group_state.next_stored_chunk_idx,
-                self.storable_allocated_chunks(
-                    group_config, group_state, num_offloadable_tokens
-                ),
+                self.storable_chunks(group_config, group_state, num_offloadable_tokens),
             )
 
     def update_num_hit_chunks(self, num_cached_tokens: int) -> None:
@@ -987,7 +976,7 @@ class OffloadingConnectorScheduler:
             for group_config, group_state in zip(
                 self.config.kv_group_configs, req_status.group_states
             ):
-                num_chunks = req_status.storable_allocated_chunks(
+                num_chunks = req_status.storable_chunks(
                     group_config, group_state, num_offloadable_tokens
                 )
 
@@ -1064,7 +1053,7 @@ class OffloadingConnectorScheduler:
                 is_sliding_window = (
                     group_config.sliding_window_size_in_chunks is not None
                 )
-                num_chunks = req_status.storable_allocated_chunks(
+                num_chunks = req_status.storable_chunks(
                     group_config, group_state, num_offloadable_tokens
                 )
                 start_chunk_idx = group_state.next_stored_chunk_idx


### PR DESCRIPTION
Fix https://github.com/vllm-project/vllm/issues/49118

## Purpose
Handle queued request aborts without allocated KV blocks
## Test Plan
```
CUDA_VISIBLE_DEVICES=4,5,6,7 \
  vllm serve /mnt/data3/models/Qwen/Qwen3.6-35B-A3B \
    --served-model-name Qwen3.6-35B-A3B \
    --host 0.0.0.0 \
    --port 8840 \
    --tensor-parallel-size 4 \
    --language-model-only \
    --dtype bfloat16 \
    --max-model-len 180000 \
    --max-num-seqs 4 \
      --max-num-batched-tokens 4224 \
    --gpu-memory-utilization 0.90 \
    --kv-cache-dtype fp8_e4m3 \
    --enable-prefix-caching \
    --enable-chunked-prefill \
    --reasoning-parser qwen3 \
    --kv-transfer-config '{
      "kv_connector": "OffloadingConnector",
      "kv_role": "kv_both",
      "kv_connector_extra_config": {
        "cpu_bytes_to_use": 8589934592
      }
    }'

```

```

import json
import socket
import sys
import time
import urllib.error
import urllib.request
from concurrent.futures import ThreadPoolExecutor

BASE_URL = "http://127.0.0.1:8840"
MODEL = "Qwen3.6-35B-A3B"

PROMPT_CHARS = 220_000
REQUEST_TIMEOUT = 900


def make_prompt(seed: str, chars: int = PROMPT_CHARS) -> str:
    fragment = f"[{seed}] filler text for a long queued request. "
    return (fragment * (chars // len(fragment) + 1))[:chars]


def chat(prompt: str, timeout: float = REQUEST_TIMEOUT) -> dict:
    payload = {
        "model": MODEL,
        "messages": [{"role": "user", "content": prompt}],
        "max_tokens": 16,
        "temperature": 0,
    }
    request = urllib.request.Request(
        f"{BASE_URL}/v1/chat/completions",
        data=json.dumps(payload).encode(),
        headers={"Content-Type": "application/json"},
        method="POST",
    )
    with urllib.request.urlopen(request, timeout=timeout) as response:
        return json.load(response)


def abort_queued_request(prompt: str) -> str:
    try:
        chat(prompt, timeout=1.0)
    except (
        urllib.error.URLError,
        socket.timeout,
        TimeoutError,
        ConnectionError,
    ) as exc:
        return f"aborted ({type(exc).__name__})"
    return "unexpectedly completed"


def check_health() -> None:
    with urllib.request.urlopen(f"{BASE_URL}/health", timeout=5) as response:
        if response.status != 200:
            raise RuntimeError(f"health check returned {response.status}")


def main() -> int:
    check_health()
    print("Server is healthy; starting queued-abort reproduction.")
    busy_errors = []
    # max-num-seqs=4:

    with ThreadPoolExecutor(max_workers=8) as executor:
        busy = [
            executor.submit(chat, make_prompt(f"busy-{index}")) for index in range(5)
        ]
        time.sleep(0.5)
        aborted = [
            executor.submit(
                abort_queued_request,
                make_prompt(f"abort-{index}"),
            )
            for index in range(3)
        ]
        for index, future in enumerate(aborted):
            try:
                print(f"abort-{index}: {future.result()}")
            except Exception as exc:
                print(f"abort-{index}: client error: {exc!r}")

        for index, future in enumerate(busy):
            try:
                future.result()
                print(f"busy-{index}: completed")
            except Exception as exc:
                busy_errors.append(exc)
                print(f"busy-{index}: failed: {exc!r}")
    time.sleep(1)
    try:
        check_health()
    except Exception as exc:
        print()
        print("REPRODUCED: EngineCore is no longer healthy.")
        print(f"Health error: {exc!r}")
        return 1
    if busy_errors:
        print()
        print("Server is healthy, but one or more in-flight requests failed.")
        return 2
    final = chat("Reply with only the digit 4: what is 2+2?", timeout=60)
    content = final["choices"][0]["message"]["content"]
    print()
    print(f"PASS: EngineCore survived. Final response: {content!r}")
    return 0


if __name__ == "__main__":
    sys.exit(main())


```
## Test Result
before:

```
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332] EngineCore encountered a fatal error.
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332] Traceback (most recent call last):
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]   File "/mnt/data4/jxy/vllm/vllm/v1/engine/core.py", line 1323, in run_engine_core
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]     engine_core.run_busy_loop()
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]   File "/mnt/data4/jxy/vllm/vllm/v1/engine/core.py", line 1364, in run_busy_loop
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]     self._process_engine_step()
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]   File "/mnt/data4/jxy/vllm/vllm/v1/engine/core.py", line 1403, in _process_engine_step
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]     outputs, model_executed = self.step_fn()
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]                               ^^^^^^^^^^^^^^
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]   File "/mnt/data4/jxy/vllm/vllm/v1/engine/core.py", line 645, in step_with_batch_queue
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]     scheduler_output = self.scheduler.schedule(self._should_throttle_prefills())
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]   File "/mnt/data4/jxy/vllm/vllm/v1/core/sched/scheduler.py", line 1170, in schedule
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]     meta = self._build_kv_connector_meta(self.connector, scheduler_output)
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]   File "/mnt/data4/jxy/vllm/vllm/v1/core/sched/scheduler.py", line 1192, in _build_kv_connector_meta
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]     return connector.build_connector_meta(scheduler_output)
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]   File "/mnt/data4/jxy/vllm/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py", line 157, in build_connector_meta
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]     return self.connector_scheduler.build_connector_meta(scheduler_output)
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]   File "/mnt/data4/jxy/vllm/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py", line 1157, in build_connector_meta
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]     store_jobs=self._build_store_jobs(scheduler_output),
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]   File "/mnt/data4/jxy/vllm/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py", line 975, in _build_store_jobs
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]     assert len(offload_keys) == len(offload_block_ids)
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=909178) ERROR 07-20 11:15:01 [core.py:1332] AssertionError
(Worker_TP0 pid=911359) INFO 07-20 11:15:01 [multiproc_executor.py:793] Parent process exited, terminating worker queues
(EngineCore pid=909178) INFO 07-20 11:15:01 [multiproc_executor.py:429] [shutdown] Executor: waiting for worker exit count=4
(APIServer pid=905233) ERROR 07-20 11:15:01 [async_llm.py:704] AsyncLLM output_handler failed.
(APIServer pid=905233) ERROR 07-20 11:15:01 [async_llm.py:704] Traceback (most recent call last):
(APIServer pid=905233) ERROR 07-20 11:15:01 [async_llm.py:704]   File "/mnt/data4/jxy/vllm/vllm/v1/engine/async_llm.py", line 660, in output_handler
(APIServer pid=905233) ERROR 07-20 11:15:01 [async_llm.py:704]     outputs = await engine_core.get_output_async()
(APIServer pid=905233) ERROR 07-20 11:15:01 [async_llm.py:704]               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=905233) ERROR 07-20 11:15:01 [async_llm.py:704]   File "/mnt/data4/jxy/vllm/vllm/v1/engine/core_client.py", line 1061, in get_output_async
(APIServer pid=905233) ERROR 07-20 11:15:01 [async_llm.py:704]     raise self._format_exception(outputs) from None
(APIServer pid=905233) ERROR 07-20 11:15:01 [async_llm.py:704] vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue. See stack trace (above) for the root cause.
(APIServer pid=905233) INFO:     127.0.0.1:60860 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
(APIServer pid=905233) INFO:     127.0.0.1:60870 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
(APIServer pid=905233) INFO:     127.0.0.1:60884 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
(APIServer pid=905233) INFO:     127.0.0.1:60890 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
(APIServer pid=905233) INFO:     127.0.0.1:60892 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
(APIServer pid=905233) INFO:     Shutting down
(APIServer pid=905233) INFO:     Waiting for application shutdown.
(APIServer pid=905233) INFO:     Application shutdown complete.

```


after:
```
(APIServer pid=1344642) INFO:     127.0.0.1:48516 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=1344642) INFO 07-20 11:42:12 [loggers.py:310] Engine 000: Avg prompt throughput: 11919.6 tokens/s, Avg generation throughput: 1.8 tokens/s, Running: 2 reqs, Waiting: 2 reqs, GPU KV cache usage: 0.6%, Prefix cache hit rate: 0.0%, External prefix cache hit rate:0.0%
(APIServer pid=1344642) INFO 07-20 11:42:12 [metrics.py:103] KV Transfer metrics: vllm:kv_offload_lookup_sync_delay_seconds_count=22, vllm:kv_offload_lookup_sync_delay_seconds_sum=0.00020857341587543488, vllm:kv_offload_cpu_cache_usage_perc=0.030226700251889168, vllm:kv_offload_cpu_allocation_size_count=35, vllm:kv_offload_cpu_allocation_size_sum=226, vllm:kv_offload_cpu_cache_write_usage_perc=0.030226700251889168, vllm:kv_offload_cpu_cache_read_usage_perc=0.0, vllm:kv_offload_store_bytes=4611932160, vllm:kv_offload_store_time=0.09642745602130891, vllm:kv_offload_store_size_count=132, vllm:kv_offload_store_size_sum=4611932160
(APIServer pid=1344642) INFO:     127.0.0.1:48530 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=1344642) INFO:     127.0.0.1:48538 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=1344642) INFO:     127.0.0.1:48554 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=1344642) INFO:     127.0.0.1:48566 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=1344642) INFO:     127.0.0.1:59012 - "GET /health HTTP/1.1" 200 OK
(APIServer pid=1344642) INFO:     127.0.0.1:59016 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=1344642) INFO 07-20 11:42:22 [loggers.py:310] Engine 000: Avg prompt throughput: 17879.9 tokens/s, Avg generation throughput: 7.8 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%, External prefix cache hit rate:0.0%
(APIServer pid=1344642) INFO 07-20 11:42:22 [metrics.py:103] KV Transfer metrics: vllm:kv_offload_lookup_sync_delay_seconds_count=32, vllm:kv_offload_lookup_sync_delay_seconds_sum=0.00022306758910417557, vllm:kv_offload_store_bytes=6981058560, vllm:kv_offload_store_time=0.14641644805669782, vllm:kv_offload_store_size_count=212, vllm:kv_offload_store_size_sum=6981058560, vllm:kv_offload_cpu_cache_usage_perc=0.0, vllm:kv_offload_cpu_allocation_size_count=51, vllm:kv_offload_cpu_allocation_size_sum=312, vllm:kv_offload_cpu_cache_write_usage_perc=0.0, vllm:kv_offload_cpu_cache_read_usage_perc=0.0
(APIServer pid=1344642) INFO 07-20 11:42:32 [loggers.py:310] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%, External prefix cache hit rate: 0.0%
(APIServer pid=1344642) INFO:     127.0.0.1:47952 - "GET /health HTTP/1.1" 200 OK
(APIServer pid=1344642) INFO:     127.0.0.1:47962 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=1344642) INFO:     127.0.0.1:47972 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=1344642) INFO:     127.0.0.1:47978 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=1344642) INFO:     127.0.0.1:47984 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=1344642) INFO:     127.0.0.1:48000 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

