### PR TITLE
[Perf] Avoid per-step pinned staging allocation in apply_grammar_bitmask

### DIFF
--- a/tests/v1/structured_output/test_apply_grammar_bitmask.py
+++ b/tests/v1/structured_output/test_apply_grammar_bitmask.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+
+@dataclass
+class _GrammarOutput:
+    structured_output_request_ids: list[str]
+    grammar_bitmask: np.ndarray
+
+
+class _SchedulerOutput:
+    pass
+
+
+class _LRUCache(dict):
+    def __init__(self, maxsize: int):
+        super().__init__()
+        self.maxsize = maxsize
+
+
+def _async_tensor_h2d(data, device, dtype=None):
+    if isinstance(data, np.ndarray):
+        data = torch.from_numpy(data)
+    elif not isinstance(data, torch.Tensor):
+        data = torch.tensor(data, dtype=dtype, device="cpu")
+    return data.to(device=device, dtype=dtype, non_blocking=True)
+
+
+def _load_utils_module(monkeypatch: pytest.MonkeyPatch):
+    def init_logger(_name: str):
+        return SimpleNamespace()
+
+    def lazy_loader(_name: str, _globals: dict, _module_name: str):
+        return SimpleNamespace()
+
+    stubs = {
+        "cachetools": SimpleNamespace(LRUCache=_LRUCache),
+        "vllm": types.ModuleType("vllm"),
+        "vllm.envs": SimpleNamespace(VLLM_REGEX_COMPILATION_TIMEOUT_S=0),
+        "vllm.logger": SimpleNamespace(init_logger=init_logger),
+        "vllm.utils": types.ModuleType("vllm.utils"),
+        "vllm.utils.import_utils": SimpleNamespace(LazyLoader=lazy_loader),
+        "vllm.utils.torch_utils": SimpleNamespace(async_tensor_h2d=_async_tensor_h2d),
+        "vllm.v1": types.ModuleType("vllm.v1"),
+        "vllm.v1.core": types.ModuleType("vllm.v1.core"),
+        "vllm.v1.core.sched": types.ModuleType("vllm.v1.core.sched"),
+        "vllm.v1.core.sched.output": SimpleNamespace(
+            GrammarOutput=_GrammarOutput, SchedulerOutput=_SchedulerOutput
+        ),
+    }
+    for name, module in stubs.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    module_path = (
+        Path(__file__).parents[3] / "vllm" / "v1" / "structured_output" / "utils.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "_test_vllm_structured_output_utils", module_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeXGrammar:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def apply_token_bitmask_inplace(self, logits, bitmask, indices=None) -> None:
+        if bitmask.is_cuda or (isinstance(indices, torch.Tensor) and indices.is_cuda):
+            torch.accelerator.synchronize()
+        indices_cpu = (
+            indices.detach().cpu().tolist() if torch.is_tensor(indices) else indices
+        )
+        bitmask_cpu = bitmask.detach().cpu().clone()
+        self.calls.append(
+            {
+                "bitmask": bitmask_cpu,
+                "indices": indices_cpu,
+                "bitmask_device": bitmask.device.type,
+                "bitmask_dtype": bitmask.dtype,
+            }
+        )
+        rows = range(logits.shape[0]) if indices_cpu is None else indices_cpu
+        for row in rows:
+            logits[row, 0] = bitmask_cpu[row, 0].to(logits.dtype)
+
+
+def _mask(rows: int, width: int = 4, base: int = 0) -> np.ndarray:
+    return np.arange(base, base + rows * width, dtype=np.int32).reshape(rows, width)
+
+
+def _expected_sorted_bitmask(
+    req_ids: list[str],
+    structured_ids: list[str],
+    grammar_bitmask: np.ndarray,
+    spec_tokens: dict[str, list[int]],
+    logits_rows: int,
+) -> tuple[torch.Tensor, list[int]]:
+    structured_id_set = set(structured_ids)
+    batch_indices: dict[str, int] = {}
+    cumulative_offset = 0
+    for batch_index, req_id in enumerate(req_ids):
+        logit_index = batch_index + cumulative_offset
+        cumulative_offset += len(spec_tokens.get(req_id, ()))
+        if req_id in structured_id_set:
+            batch_indices[req_id] = logit_index
+
+    sorted_bitmask = np.full(
+        (logits_rows, grammar_bitmask.shape[1]), -1, dtype=grammar_bitmask.dtype
+    )
+    out_indices: list[int] = []
+    cumulative_index = 0
+    for req_id in structured_ids:
+        num_spec_tokens = len(spec_tokens.get(req_id, ()))
+        if (logit_idx := batch_indices.get(req_id)) is not None:
+            for i in range(1 + num_spec_tokens):
+                bitmask_index = logit_idx + i
+                sorted_bitmask[bitmask_index] = grammar_bitmask[cumulative_index + i]
+                out_indices.append(bitmask_index)
+        cumulative_index += 1 + num_spec_tokens
+    return torch.from_numpy(sorted_bitmask), out_indices
+
+
+def _torch_full_reference(
+    req_ids: list[str],
+    structured_ids: list[str],
+    grammar_bitmask: np.ndarray,
+    spec_tokens: dict[str, list[int]],
+    logits: torch.Tensor,
+) -> tuple[torch.Tensor, list[int] | None, torch.Tensor]:
+    expected_host, out_indices = _expected_sorted_bitmask(
+        req_ids, structured_ids, grammar_bitmask, spec_tokens, logits.shape[0]
+    )
+    sorted_bitmask_tensor = torch.full(
+        expected_host.shape,
+        -1,
+        dtype=torch.from_numpy(grammar_bitmask[:0]).dtype,
+        pin_memory=logits.is_cuda,
+    )
+    sorted_bitmask_tensor.copy_(expected_host)
+    device_bitmask = sorted_bitmask_tensor.to(logits.device, non_blocking=True)
+
+    indices = None if len(out_indices) == logits.shape[0] else out_indices
+    expected_logits = torch.zeros_like(logits)
+    bitmask_on_device = expected_host.to(logits.device)
+    rows = range(logits.shape[0]) if indices is None else indices
+    for row in rows:
+        expected_logits[row, 0] = bitmask_on_device[row, 0].to(logits.dtype)
+    if logits.is_cuda:
+        torch.accelerator.synchronize()
+    return device_bitmask.detach().cpu(), indices, expected_logits
+
+
+def _run_and_compare_to_torch_full_reference(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    req_ids: list[str],
+    structured_ids: list[str],
+    grammar_bitmask: np.ndarray,
+    spec_tokens: dict[str, list[int]] | None = None,
+    device: str = "cuda",
+    dtype: torch.dtype = torch.float32,
+) -> _FakeXGrammar:
+    if device == "cuda" and torch.accelerator.device_count() == 0:
+        pytest.skip("CUDA is required for this test")
+
+    spec_tokens = spec_tokens or {}
+    logits_rows = len(req_ids) + sum(len(v) for v in spec_tokens.values())
+    logits = torch.zeros((logits_rows, 8), dtype=dtype, device=device)
+    ref_bitmask, ref_indices, ref_logits = _torch_full_reference(
+        req_ids, structured_ids, grammar_bitmask, spec_tokens, logits
+    )
+
+    utils = _load_utils_module(monkeypatch)
+    fake_xgr = _FakeXGrammar()
+    utils.xgr = fake_xgr
+    utils.apply_grammar_bitmask(
+        SimpleNamespace(scheduled_spec_decode_tokens=spec_tokens),
+        _GrammarOutput(structured_ids, grammar_bitmask),
+        SimpleNamespace(req_ids=req_ids),
+        logits,
+    )
+    if device == "cuda":
+        torch.accelerator.synchronize()
+
+    assert len(fake_xgr.calls) == 1
+    call = fake_xgr.calls[0]
+    torch.testing.assert_close(call["bitmask"], ref_bitmask, rtol=0, atol=0)
+    assert call["indices"] == ref_indices
+    assert call["bitmask_dtype"] == torch.int32
+    assert call["bitmask_device"] == torch.device(device).type
+    torch.testing.assert_close(logits, ref_logits, rtol=0, atol=0)
+    return fake_xgr
+
+
+@pytest.mark.skipif(torch.accelerator.device_count() == 0, reason="CUDA is required")
+@pytest.mark.parametrize(
+    ("req_ids", "structured_ids", "grammar_bitmask", "spec_tokens", "indices"),
+    [
+        pytest.param(
+            ["a", "b"],
+            [],
+            np.empty((0, 4), dtype=np.int32),
+            {},
+            [],
+            id="empty",
+        ),
+        pytest.param(
+            ["a", "b", "c"],
+            ["a", "b", "c"],
+            _mask(3, base=10),
+            {},
+            None,
+            id="all-active",
+        ),
+        pytest.param(
+            ["a", "b", "c", "d"],
+            ["d", "a"],
+            _mask(2, base=100),
+            {},
+            [3, 0],
+            id="reordered-mixed",
+        ),
+        pytest.param(
+            ["a", "b", "c"],
+            ["c", "a"],
+            _mask(5, base=200),
+            {"a": [11, 12], "c": [13]},
+            [4, 5, 0, 1, 2],
+            id="speculative-offsets",
+        ),
+    ],
+)
+def test_cuda_bitmask_rows_match_torch_full_reference(
+    monkeypatch, req_ids, structured_ids, grammar_bitmask, spec_tokens, indices
+):
+    fake_xgr = _run_and_compare_to_torch_full_reference(
+        monkeypatch,
+        req_ids=req_ids,
+        structured_ids=structured_ids,
+        grammar_bitmask=grammar_bitmask,
+        spec_tokens=spec_tokens,
+    )
+    assert fake_xgr.calls[0]["indices"] == indices
+
+
+@pytest.mark.skipif(torch.accelerator.device_count() == 0, reason="CUDA is required")
+def test_cuda_repeated_calls_do_not_reuse_stale_rows(monkeypatch):
+    _run_and_compare_to_torch_full_reference(
+        monkeypatch,
+        req_ids=["a", "b", "c", "d"],
+        structured_ids=["a", "c"],
+        grammar_bitmask=_mask(2, base=300),
+    )
+    fake_xgr = _run_and_compare_to_torch_full_reference(
+        monkeypatch,
+        req_ids=["a", "b", "c", "d"],
+        structured_ids=["b"],
+        grammar_bitmask=_mask(1, base=500),
+    )
+    expected = torch.full((4, 4), -1, dtype=torch.int32)
+    expected[1] = torch.from_numpy(_mask(1, base=500)[0])
+    torch.testing.assert_close(fake_xgr.calls[0]["bitmask"], expected, rtol=0, atol=0)
+
+
+def test_cpu_path_preserves_logits_dtype_and_matches_torch_full_reference(monkeypatch):
+    _run_and_compare_to_torch_full_reference(
+        monkeypatch,
+        req_ids=["a", "b", "c"],
+        structured_ids=["c", "a"],
+        grammar_bitmask=_mask(2, base=700),
+        device="cpu",
+        dtype=torch.float16,
+    )

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -11,6 +11,7 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from typing import TYPE_CHECKING, TypeVar
 
+import numpy as np
 import regex as re
 import torch
 from cachetools import LRUCache
@@ -18,7 +19,7 @@ from cachetools import LRUCache
 import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.utils.import_utils import LazyLoader
-from vllm.utils.torch_utils import PIN_MEMORY, async_tensor_h2d
+from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 
 if TYPE_CHECKING:
@@ -123,13 +124,11 @@ def apply_grammar_bitmask(
     out_indices = []
 
     # Reorder the bitmask to match the order of the requests in the batch.
-    sorted_bitmask_tensor = torch.full(
-        (logits.shape[0], grammar_bitmask.shape[1]),
-        -1,
-        dtype=torch.from_numpy(grammar_bitmask[:0]).dtype,
-        pin_memory=PIN_MEMORY,
+    sorted_bitmask = np.full(
+        shape=(logits.shape[0], grammar_bitmask.shape[1]),
+        fill_value=-1,
+        dtype=grammar_bitmask.dtype,
     )
-    sorted_bitmask = sorted_bitmask_tensor.numpy()
     cumulative_index = 0
     for req_id in grammar_output.structured_output_request_ids:
         num_spec_tokens = len(spec_tokens.get(req_id, ()))
@@ -140,8 +139,10 @@ def apply_grammar_bitmask(
                 out_indices.append(bitmask_index)
         cumulative_index += 1 + num_spec_tokens
 
-    # Copy async to device.
-    grammar_bitmask = sorted_bitmask_tensor.to(logits.device, non_blocking=True)
+    # Copy to target device.
+    grammar_bitmask = torch.from_numpy(sorted_bitmask).to(
+        logits.device, non_blocking=True
+    )
 
     # If the length of out indices and the logits have the same shape
     # we don't need to pass indices to the kernel,


### PR DESCRIPTION
Fixes #49013

## Purpose

Avoid the per-step pinned `torch.full(...).numpy()` staging allocation in
`apply_grammar_bitmask`. The grammar bitmask already arrives from the scheduler
as `np.ndarray[np.int32]`, so this restores NumPy host staging, preserves the
existing structured-output row reordering and speculative-token offsets, and
keeps the existing `async_tensor_h2d(out_indices, ...)` behavior.

This PR does not add a pinned ring, cache, global state, or compact mask path.
The device copy still uses `non_blocking=True`, but this PR does not claim that
pageable NumPy memory guarantees asynchronous H2D behavior.

Duplicate-work check: GitHub connector searches for `49013 grammar bitmask`,
`apply_grammar_bitmask pinned staging structured output`, related open PRs, and
related branches found no duplicate open PR or branch. The issue remains open.

AI assistance was used to prepare this change. The local `reports/issue_49013/`
benchmark and validation evidence is not included in the submitted patch.

## Test Plan

- `git diff --check`
- `.venv/bin/python -m py_compile vllm/v1/structured_output/utils.py tests/v1/structured_output/test_apply_grammar_bitmask.py`
- `.venv/bin/pre-commit run --files vllm/v1/structured_output/utils.py tests/v1/structured_output/test_apply_grammar_bitmask.py`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -q --confcutdir=tests/v1/structured_output tests/v1/structured_output/test_apply_grammar_bitmask.py -k cpu_path`
- `CUDA_VISIBLE_DEVICES=0 PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -q --confcutdir=tests/v1/structured_output tests/v1/structured_output/test_apply_grammar_bitmask.py -k cuda`
- CUDA stress: 10 repeated CUDA pytest rounds with `CUDA_VISIBLE_DEVICES=0`
- `/tmp/codex-uv-bin/uv pip check --python .venv/bin/python`

## Test Result

All final checks passed locally.

Correctness tests compare the final device bitmask/logits against the previous
torch-full staging reference for empty, all-active, reordered mixed,
speculative-offset, repeated-call, CPU, and CUDA cases. No model quality change
is expected; this is a staging-only change and correctness is exact-match.

Focused environment:

- Python 3.12.3
- torch 2.11.0+cu128, CUDA runtime 12.8
- torchaudio 2.11.0+cu128
- torchvision 0.26.0+cu128
- numpy 2.4.4
- xgrammar 0.2.3
- NVIDIA A100-SXM4-80GB, with CUDA tests run under `CUDA_VISIBLE_DEVICES=0`

Local ordinary synchronized microbenchmark, issue shape:

| case | torch_full | numpy_full | speedup | exact |
|---|---:|---:|---:|---|
| issue_384x8192_all_structured_spec5 | 3.166 ms | 2.182 ms | 1.45x | yes |
| medium_128x2048_all_structured_spec1 | 0.380 ms | 0.215 ms | 1.77x | yes |
| mixed_128x2048_every_third_spec1 | 0.151 ms | 0.135 ms | 1.12x | yes |
| mixed_384x8192_half_structured_spec5 | 1.571 ms | 1.677 ms | 0.94x | yes |
| small_32x1024_all_structured_nospec | 0.043 ms | 0.040 ms | 1.07x | yes |

Event-instrumented timing is a separate mode and should not be mixed with the
ordinary microbenchmark values. In the event-instrumented issue-shape run,
`numpy_full` total mean was 2.799 ms, with CPU staging mean 1.930 ms and H2D
event mean 0.820 ms.

The issue author's approximately 2x end-to-end recovery is from the issue
reproduction, not a local end-to-end result from this PR.

