### PR TITLE
[Bugfix][Memory] Load weights outside the CuMem pool and re-home them for sleep mode

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -95,6 +95,102 @@ if TYPE_CHECKING:
     from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 
+@contextmanager
+def _pool_routing_suspended(device_index: int, mem_pool):
+    """Temporarily stop routing this thread's allocations to ``mem_pool``.
+
+    Pool routing registers in the caching allocator's ``captures_underway``
+    machinery, and while any entry is present the allocator refuses to release
+    cached blocks device-wide — ``empty_cache`` is silently a no-op. Suspending
+    (end WITHOUT ``_cuda_releasePool``) empties ``captures_underway`` so a real
+    ``empty_cache`` can hand freed memory back to the driver, then resumes the
+    SAME pool. (Creating a second ``MemPool`` for a tag instead is unsound: the
+    orphaned pool's destructor fires mid-load and trips the
+    ``captures_underway.empty()`` internal assert.)
+    """
+    from torch.cuda.memory import (
+        _cuda_beginAllocateCurrentThreadToPool,
+        _cuda_endAllocateToPool,
+    )
+
+    _cuda_endAllocateToPool(device_index, mem_pool.id)
+    try:
+        yield
+    finally:
+        _cuda_beginAllocateCurrentThreadToPool(device_index, mem_pool.id)
+
+
+def _rehome_model_into_mem_pool(model: nn.Module, allocator) -> int:
+    """Copy every CUDA parameter/buffer storage into the CuMem weights MemPool.
+
+    Called AFTER the model was loaded and converted entirely with the default
+    caching allocator. Sleep mode can only offload/discard pool-owned memory,
+    so the finished weights must be re-homed into the pool. Works inside ONE
+    ``use_memory_pool`` context; every ~1 GiB it suspends pool routing and
+    calls ``empty_cache`` so the just-freed originals return to the driver —
+    on small-VRAM cards the pool's growth must be fed by exactly that memory.
+    Storage-granular copying preserves tensors that share a storage (tied
+    weights) and bounds double-residency to one chunk. Returns bytes moved.
+    """
+    # Collect re-home targets first (owner, name, tensor, is_param); slots are
+    # nulled as they are processed — the list must not keep originals alive, or
+    # the between-chunk empty_cache would have nothing to release.
+    targets: list[tuple[nn.Module, str, torch.Tensor, bool] | None] = []
+    for mod in model.modules():
+        for name, p in mod._parameters.items():
+            if p is not None and p.data.is_cuda:
+                targets.append((mod, name, p.data, True))
+        for name, b in mod._buffers.items():
+            if b is not None and b.is_cuda:
+                targets.append((mod, name, b, False))
+
+    moved_bytes = 0
+    chunk_bytes = 0
+    chunk_limit = 1 << 30  # purge freed originals every ~1 GiB moved
+    # old storage base ptr -> pool-resident replacement storage
+    replacements: dict[int, torch.UntypedStorage] = {}
+
+    def pool_storage_for(t: torch.Tensor) -> torch.UntypedStorage:
+        nonlocal moved_bytes, chunk_bytes
+        src = t.untyped_storage()
+        base = src.data_ptr()
+        if base in replacements:
+            return replacements[base]
+        buf = torch.empty(src.nbytes(), dtype=torch.uint8, device=t.device)
+        dst = buf.untyped_storage()
+        dst.copy_(src)
+        replacements[base] = dst
+        moved_bytes += src.nbytes()
+        chunk_bytes += src.nbytes()
+        return dst
+
+    def rehomed(t: torch.Tensor) -> torch.Tensor:
+        new_t = torch.empty([0], dtype=t.dtype, device=t.device)
+        new_t.set_(pool_storage_for(t), t.storage_offset(), t.size(), t.stride())
+        return new_t
+
+    device_index = torch.cuda.current_device()
+    with allocator.use_memory_pool(tag="weights"):
+        mem_pool = allocator.allocator_and_pools["weights"][0]
+        for i in range(len(targets)):
+            if chunk_bytes >= chunk_limit:
+                # Hand the freed originals back to the driver so the next
+                # chunk's pool growth has physical memory to map.
+                with _pool_routing_suspended(device_index, mem_pool):
+                    torch.cuda.empty_cache()
+                chunk_bytes = 0
+            mod, name, t, is_param = targets[i]  # type: ignore[misc]
+            if is_param:
+                mod._parameters[name].data = rehomed(t)
+            else:
+                mod._buffers[name] = rehomed(t)
+            targets[i] = None  # drop the last reference to the original
+            del mod, name, t
+    # Final purge of whatever the last chunk freed (pool context closed now).
+    torch.cuda.empty_cache()
+    return moved_bytes
+
+
 class AsyncIntermediateTensors(IntermediateTensors):
     """IntermediateTensors with lazy comm synchronization"""
 
@@ -422,13 +518,43 @@ class Worker(WorkerBase):
     # FIXME(youkaichao & ywang96): Use TorchDispatchMode instead of memory pool
     # to hijack tensor allocation.
     def load_model(self, *, load_dummy_weights: bool = False) -> None:
-        with (
-            self._maybe_get_memory_pool_context(tag="weights"),
-            set_current_vllm_config(self.vllm_config),
-            # 20 MiB is the minimum PyTorch allows for max_split_size_mb.
-            self._scoped_allocator_max_split(max_split_size_mb=20),
-        ):
-            self.model_runner.load_model(load_dummy_weights=load_dummy_weights)
+        pool_ctx = self._maybe_get_memory_pool_context(tag="weights")
+        if isinstance(pool_ctx, nullcontext):
+            with (
+                pool_ctx,
+                set_current_vllm_config(self.vllm_config),
+                # 20 MiB is the minimum PyTorch allows for max_split_size_mb.
+                self._scoped_allocator_max_split(max_split_size_mb=20),
+            ):
+                self.model_runner.load_model(load_dummy_weights=load_dummy_weights)
+        else:
+            # Sleep mode (CuMem): loading and converting weights INSIDE a live
+            # MemPool strands every freed buffer — a live pool can neither
+            # release emptied segments nor reuse them for differently-sized
+            # requests (pytorch/pytorch#159674) — so quantized checkpoints
+            # whose post-load conversion replaces each weight with a slightly
+            # larger one (e.g. modelopt NVFP4 MoE padding) leak the entire
+            # original copy per layer and OOM 16 GiB cards (#48680).
+            # Instead: run the whole load + conversion with the default
+            # caching allocator (identical to the non-sleep path, where freed
+            # memory is reusable and returned to the driver), then RE-HOME the
+            # finished weights into the pool, one storage at a time, so sleep
+            # can still offload/discard them. Peak overhead over the non-sleep
+            # path is a single chunk's double-residency.
+            with set_current_vllm_config(self.vllm_config):
+                self.model_runner.load_model(load_dummy_weights=load_dummy_weights)
+            # Return the conversion churn (cached-free segments) to the driver
+            # BEFORE the pool starts growing — the pool's cuMem mappings must
+            # be fed by exactly this memory on small cards.
+            torch.cuda.empty_cache()
+            moved_bytes = _rehome_model_into_mem_pool(
+                self.model_runner.get_model(), get_mem_allocator_instance()
+            )
+            logger.info(
+                "Sleep mode: re-homed %.2f GiB of weights into the CuMem pool "
+                "after out-of-pool loading",
+                moved_bytes / (1024**3),
+            )
 
         if self.vllm_config.weight_transfer_config is not None:
             self.weight_transfer_engine = WeightTransferEngineFactory.create_engine(


### PR DESCRIPTION
## Purpose

FIX #48680 (`--enable-sleep-mode` OOMs loading an NVFP4 (modelopt) 30B on 16 GB SM120 cards where the identical model loads fine without it).

Root cause, pinned down by per-module instrumentation on the reproducing hardware: weight loading with sleep mode runs the whole load — including `process_weights_after_loading` — inside a live CuMem `MemPool`. A live pool can neither release emptied segments nor reuse freed blocks for larger requests (pytorch/pytorch#159674). The NVFP4 MoE conversion *replaces* each layer's weights with slightly larger (padded) tensors, so the pool strands ~one full weight copy: instrumented, the pool grows 9.18 → 14.44 GiB during conversion while torch-live memory grows only 9.08 → 9.61 GiB. That +5.2 GiB is the OOM — not per-op transient peaks, which is why the transient-reduction reworks in #48701 didn't resolve it (validated on the same hardware in that thread).

Two further allocator behaviors constrain the fix (established with small standalone probes, happy to share):

1. While a pool context is active, `torch.cuda.empty_cache()` is a device-wide no-op from **any** thread: pool routing registers in the caching allocator's `captures_underway` machinery, and while non-empty the allocator refuses to release cached blocks. Freed memory cannot reach the driver mid-context.
2. Creating a second `MemPool` for the same tag (e.g. re-entering `use_memory_pool` per chunk) is unsound: the orphaned pool's destructor fires mid-load and trips the `captures_underway.empty()` internal assert. Releasing "empty" pool segments behind torch's back mid-context causes illegal memory access (torch still caches those blocks).

## The fix

`vllm/v1/worker/gpu_worker.py` only. When `enable_cumem_allocator` is set:

1. Run the entire load + weight conversion with the default caching allocator — identical to the proven non-sleep path, where freed/transient memory is reusable and reclaimable.
2. `empty_cache()` to hand the conversion churn back to the driver.
3. Enter `use_memory_pool(tag="weights")` **once** and re-home the finished model storage-by-storage into the pool (sleep can only offload/discard pool-owned memory). Storage-granular copying preserves tensors that share a storage (tied weights).
4. Every ~1 GiB, suspend pool routing on the same pool (`_cuda_endAllocateToPool` without `_cuda_releasePool`), `empty_cache()`, resume (`_cuda_beginAllocateCurrentThreadToPool`). Without this the pool's growth has no physical memory to map on 16 GiB cards; with it, free VRAM holds constant while the pool grows (probe: 1 GiB/round for 10 rounds vs OOM at round 5 without).

Peak overhead vs the non-sleep path is a single chunk's double-residency. The non-sleep path is unchanged.

## Test Plan

Reproducing hardware from #48680: 2x RTX 5070 Ti 16 GB (SM120), driver 595.71.05, torch 2.11.0+cu130, flashinfer 0.6.13. Original failing configuration: `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4`, TP=2, `--max-model-len 32768`, `--max-num-seqs 64`, `--gpu-memory-utilization 0.85`, `--enable-sleep-mode`, `VLLM_USE_FLASHINFER_MOE_FP4=1`.

- Load with sleep mode; compare KV budget vs non-sleep control on the same stack.
- Greedy completion before sleep; `POST /sleep?level=1`; VRAM check; `POST /wake_up`; identical greedy completion after wake; longer generation.
- Sanity: non-sleep path byte-unchanged (gated behind `isinstance(pool_ctx, nullcontext)`).

## Test Result

- Load completes: `Sleep mode: re-homed 9.82 GiB of weights into the CuMem pool after out-of-pool loading` on both TP workers. Previously: deterministic `torch.OutOfMemoryError` during conversion (168 MiB request, ~130 MiB free, 4.85–5.20 GiB stranded in private pools across #48701's revisions).
- KV cache: 1,004,885 tokens with sleep mode vs 980,309 tokens non-sleep control — sleep mode now costs ~0 KV budget on this setup.
- `POST /sleep?level=1`: 14.3 → 2.1 GiB per GPU. `POST /wake_up`: restored; greedy completion **byte-identical** to pre-sleep; longer generation coherent.
- Fix is independent of the #48701 flashinfer rework: validated with the stock file (results above) and with that PR's version (same load success, KV 953,002).

Caveats for review: (a) `_cuda_endAllocateToPool` / `_cuda_beginAllocateCurrentThreadToPool` are private torch APIs — though `torch.cuda.use_mem_pool` itself is implemented on exactly these; (b) tensors stored as plain module attributes (not in `_parameters`/`_buffers`) stay outside the pool and won't be offloaded on sleep — none found that matter on this model class; (c) `wake_up(level=2)` + reload paths deserve CI exercise.

Credit: the investigation in #48701 (@hubunt) — especially its revisions isolating the TRTLLM branch and the `max_split_size_mb` policy — is what let us falsify the transient-peak hypotheses on hardware and converge on the pool-ratchet mechanism.
