### PR TITLE
[Kernel][Attention] Pipeline Triton prefill-attention K/V loads for long BF16/FP16 prefills

### DIFF
--- a/tests/kernels/attention/test_triton_prefill_attention.py
+++ b/tests/kernels/attention/test_triton_prefill_attention.py
@@ -6,9 +6,94 @@ import torch
 import torch.nn.functional as F
 
 from vllm.platforms import current_platform
-from vllm.v1.attention.ops.triton_prefill_attention import context_attention_fwd
+from vllm.v1.attention.ops.triton_prefill_attention import (
+    _select_num_stages,
+    context_attention_fwd,
+)
 
 DEVICE_TYPE = current_platform.device_type
+
+# num_stages > 1 is only enabled on the exact CUDA capabilities the launch policy was
+# validated on (SM80 A100-class, SM90 H100-class); everywhere else context_attention_fwd
+# forces num_stages=1. Tests that mean to exercise the pipelined launch guard on this.
+STAGE3_PIPELINE_SUPPORTED = current_platform.is_cuda() and (
+    current_platform.is_device_capability(80)
+    or current_platform.is_device_capability(90)
+)
+
+
+# block_n is passed explicitly (the launch block for that dtype on sm80+: fp32 -> 32,
+# otherwise 128) so the expected num_stages is deterministic regardless of the platform
+# running the test.
+@pytest.mark.parametrize(
+    "dtype,head_dim,max_input_len,block_n,sliding_window_q,expected",
+    [
+        # fp32 always keeps the historical single stage.
+        (torch.float32, 128, 4096, 32, 0, 1),
+        # head_dim <= 64: tiny tiles, pipelining regresses -> single stage.
+        (torch.bfloat16, 64, 4096, 128, 0, 1),
+        # head_dim > 128 (e.g. 256): num_stages>1 would exceed A100 shared memory.
+        (torch.bfloat16, 256, 4096, 128, 0, 1),
+        # Short prefill (< 8 KV iterations): too few to fill a pipeline.
+        (torch.bfloat16, 128, 128, 128, 0, 1),
+        (torch.bfloat16, 128, 512, 128, 0, 1),
+        # Low end of the band (8-15 KV iters, ~1024-2047) -> depth 2.
+        (torch.bfloat16, 128, 1024, 128, 0, 2),
+        (torch.float16, 128, 1536, 128, 0, 2),
+        # Long BF16/FP16 prefill (>= 16 KV iters) -> depth 3 (the big win).
+        (torch.float16, 96, 2048, 128, 0, 3),
+        (torch.bfloat16, 128, 4096, 128, 0, 3),
+        (torch.float16, 128, 8192, 128, 0, 3),
+        # A backward sliding window bounds the loop regardless of sequence length: since
+        # #50776 the kernel starts at the first block that is not fully masked, so a
+        # 1024-wide window walks ceil(1024/128) + 1 = 9 blocks whether the prefill is
+        # 2048 or 8192 tokens long. 9 lands in the 8-15 band -> depth 2, not depth 3.
+        (torch.bfloat16, 128, 2048, 128, 1024, 2),
+        (torch.bfloat16, 128, 8192, 128, 1024, 2),
+        # A window narrow enough to leave < 8 blocks cannot fill a pipeline at all.
+        (torch.bfloat16, 128, 8192, 128, 256, 1),
+        # A window wide enough to still leave >= 16 blocks keeps depth 3...
+        (torch.bfloat16, 128, 8192, 128, 4096, 3),
+        # ...but the cap never *raises* the estimate above the sequence itself.
+        (torch.bfloat16, 128, 512, 128, 8192, 1),
+    ],
+)
+def test_select_num_stages(
+    dtype, head_dim, max_input_len, block_n, sliding_window_q, expected
+):
+    """The launch policy is a pure function of shape/dtype; validate its bands.
+
+    Runs on CPU (no GPU needed): guards that the conservative fallbacks (fp32, tiny /
+    large head dims, short sequences -> num_stages=1) and the pipelined band
+    (64 < head_dim <= 128 BF16/FP16 -> depth 2 for a moderate prefill, depth 3 for a
+    long one) stay as intended, including the sliding-window iteration cap.
+    """
+    assert (
+        _select_num_stages(
+            dtype=dtype,
+            head_dim=head_dim,
+            max_input_len=max_input_len,
+            block_n=block_n,
+            sliding_window_q=sliding_window_q,
+        )
+        == expected
+    )
+
+
+def test_select_num_stages_forward_window_does_not_cap():
+    """``sliding_window_k`` must NOT shrink the iteration estimate.
+
+    With no backward window the loop still starts at block 0, so later query tiles walk
+    the whole prefix even when a forward window truncates the tail. The policy therefore
+    only takes ``sliding_window_q`` -- this test pins that asymmetry, since capping on
+    the forward window would under-pipeline ordinary causal prefills.
+    """
+    assert (
+        _select_num_stages(
+            dtype=torch.bfloat16, head_dim=128, max_input_len=8192, block_n=128
+        )
+        == 3
+    )
 
 
 def ref_masked_attention(
@@ -79,9 +164,15 @@ def ref_masked_attention(
 @pytest.mark.parametrize("max_seq_len", [1024])
 @pytest.mark.parametrize("H_Q", [32])
 @pytest.mark.parametrize("H_KV", [32, 8])
-@pytest.mark.parametrize("D", [128])
+# D=256 exercises the large-head-dim path, where the launch policy must keep
+# num_stages=1 (num_stages>1 would exceed shared memory / OutOfResources).
+@pytest.mark.parametrize("D", [128, 256])
 @pytest.mark.parametrize("is_causal", [True, False])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+# float16 and bfloat16 are the dtypes the num_stages policy actually pipelines
+# (at D=128, max_seq_len=1024 -> num_stages=2), so both must exercise the real kernel
+# launch, not just the pure-policy test above. The num_stages=3 path (>=16 KV iters) is
+# covered by test_context_attention_stage3_launch below.
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
 def test_context_attention(
     B: int,
     max_seq_len: int,
@@ -230,3 +321,49 @@ def test_context_attention_sliding_window(
 
     # Compare outputs
     torch.testing.assert_close(o, o_ref, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.skipif(
+    not STAGE3_PIPELINE_SUPPORTED,
+    reason="num_stages=3 is enabled only on SM80/SM90 CUDA",
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_context_attention_stage3_launch(dtype):
+    """Compile and launch the num_stages=3 pipelined configuration on a GPU.
+
+    The parametrized tests above use max_seq_len=1024, which now selects num_stages=2;
+    this longer single sequence (>=16 K/V-loop iterations at BLOCK=128 on SM80/SM90)
+    selects num_stages=3, so it provides regression protection that the depth-3 launch
+    compiles, runs, and stays correct. B=1 with a small head count keeps it cheap.
+    """
+    torch.manual_seed(0)
+    H_Q = H_KV = 8
+    D = 128
+    seq = 2048
+    assert (
+        _select_num_stages(dtype=dtype, head_dim=D, max_input_len=seq, block_n=128) == 3
+    )
+
+    q = torch.randn(seq, H_Q, D, dtype=dtype, device=DEVICE_TYPE)
+    k = torch.randn(seq, H_KV, D, dtype=dtype, device=DEVICE_TYPE)
+    v = torch.randn(seq, H_KV, D, dtype=dtype, device=DEVICE_TYPE)
+    o = torch.zeros_like(q)
+
+    b_start_loc = torch.zeros(1, dtype=torch.int32, device=DEVICE_TYPE)
+    b_seq_len = torch.tensor([seq], dtype=torch.int32, device=DEVICE_TYPE)
+
+    context_attention_fwd(
+        q,
+        k,
+        v,
+        o,
+        b_start_loc,
+        b_seq_len,
+        seq,
+        is_causal=True,
+        sliding_window_q=None,
+        sliding_window_k=None,
+    )
+
+    o_ref = ref_masked_attention(q, k, v, is_causal=True)
+    torch.testing.assert_close(o, o_ref, rtol=1e-2, atol=1e-2)

--- a/vllm/v1/attention/ops/triton_prefill_attention.py
+++ b/vllm/v1/attention/ops/triton_prefill_attention.py
@@ -204,6 +204,62 @@ def get_block_size(dtype: torch.dtype) -> int:
         return 64
 
 
+def _select_num_stages(
+    dtype: torch.dtype,
+    head_dim: int,
+    max_input_len: int,
+    block_n: int,
+    sliding_window_q: int = 0,
+) -> int:
+    """Pick a Triton ``num_stages`` for the prefill-attention launch.
+
+    Historically this kernel always launched with ``num_stages=1``, i.e. no software
+    pipelining of the global K/V loads across the online-softmax loop, so every
+    iteration stalls on HBM latency. Enabling pipelining for long BF16/FP16 prefills is
+    a sizeable throughput win (measured up to ~1.3x on A100/H100), but it is only
+    beneficial -- and only feasible -- for a specific band of shapes, so the policy is
+    deliberately conservative and falls back to the previous single stage everywhere
+    else. This function only decides based on dtype/shape; the *architecture* gate (only
+    enable on the validated SM80/SM90 CUDA families, never ROCm) is applied by the
+    caller.
+
+      * fp32 uses 32-wide tiles and the ieee dot path; keep the single stage.
+      * ``head_dim <= 64``: tiles are tiny and the loop is short-latency, so pipelining
+        only adds prologue/epilogue overhead (measured as a regression) -> single stage.
+      * ``head_dim > 128`` (e.g. 256): the per-stage K/V tiles are so large that even
+        ``num_stages=2`` exceeds the A100 shared-memory budget (OutOfResources), so
+        pipelining would additionally require shrinking ``BLOCK_N`` -> single stage.
+      * A pipeline only overlaps iterations of the K/V loop, so a short prefill with
+        fewer than 8 iterations (``max_input_len`` < ~1024 at ``BLOCK_N=128``) cannot
+        fill it and the prologue/epilogue overhead can slightly regress -> single stage.
+      * A *backward* sliding window bounds the loop independently of
+        ``max_input_len``. Since #50776 ``_fwd_kernel`` starts at the first block that
+        is not fully masked, so a query tile walks only
+        ``ceil(sliding_window_q / BLOCK_N) + 1`` blocks however long the sequence is;
+        the estimate is capped accordingly. Without the cap a windowed 8192-token
+        prefill is scored as 64 iterations when the loop really runs ~9, and it would be
+        given a depth the loop cannot fill. A *forward* window (``sliding_window_k``) is
+        deliberately not used here: with no backward window the loop still starts at
+        block 0, so later query tiles do walk the full prefix.
+      * At the low end of the band (8-15 iterations) depth 3 overshoots and can regress
+        on A100, so use depth 2 (a win on both A100 and H100).
+      * For long prefills (``>= 16`` iterations) use depth 3 -- the big win, measured
+        1.1-1.5x on A100/H100 across causal, encoder, sliding-window and GQA, with no
+        regressions.
+    """
+    if dtype not in (torch.float16, torch.bfloat16):
+        return 1
+    if head_dim <= 64 or head_dim > 128:
+        return 1
+    kv_iters = max(1, triton.cdiv(max_input_len, block_n))
+    if sliding_window_q > 0:
+        # +1 for the query tile's own block; see the sliding-window note above.
+        kv_iters = min(kv_iters, triton.cdiv(sliding_window_q, block_n) + 1)
+    if kv_iters < 8:
+        return 1
+    return 2 if kv_iters < 16 else 3
+
+
 def context_attention_fwd(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -243,6 +299,28 @@ def context_attention_fwd(
     sliding_window_q = sliding_window_q if sliding_window_q is not None else 0
     sliding_window_k = sliding_window_k if sliding_window_k is not None else 0
 
+    # Software-pipeline the global K/V loads for long BF16/FP16 prefills, but only on
+    # the CUDA architectures where the policy has been validated: SM80 (A100/A30) and
+    # SM90 (H100/H200-class). Everything else -- ROCm (RocmAttentionImpl also calls this
+    # kernel), SM86/SM89, and future/untested architectures -- keeps the historical
+    # single stage until benchmarked, since num_stages is resource-sensitive (larger
+    # tiles already hit OutOfResources).
+    pipeline_supported = current_platform.is_cuda() and (
+        current_platform.is_device_capability(80)
+        or current_platform.is_device_capability(90)
+    )
+    num_stages = (
+        _select_num_stages(
+            dtype=q.dtype,
+            head_dim=Lk,
+            max_input_len=max_input_len,
+            block_n=BLOCK,
+            sliding_window_q=sliding_window_q,
+        )
+        if pipeline_supported
+        else 1
+    )
+
     _fwd_kernel[grid](
         q,
         k,
@@ -269,6 +347,6 @@ def context_attention_fwd(
         SLIDING_WINDOW_K=sliding_window_k,
         USE_SINKS=sinks is not None,
         num_warps=num_warps,
-        num_stages=1,
+        num_stages=num_stages,
         Lk=Lk,
     )


### PR DESCRIPTION
## Purpose

`context_attention_fwd` in `vllm/v1/attention/ops/triton_prefill_attention.py` — the
Triton attention backend's prefill/encoder path (also used by the ViT attention wrapper)
— always launches `_fwd_kernel` with a hard-coded **`num_stages=1`**. That disables
Triton's software pipelining of the global K/V loads across the online-softmax loop, so
every loop iteration stalls on HBM latency.

This PR adds a small, conservative launch policy `_select_num_stages(...)` that raises
`num_stages` for the band of shapes where pipelining is both *feasible* and *measured to
help* — BF16/FP16 prefills with `64 < head_dim <= 128` — and keeps the existing single
stage everywhere else. **The kernel body, block sizes, warp count, grid, and numerics are
unchanged**; only the `num_stages` launch metaparameter varies.

```python
kv_iters = cdiv(max_input_len, BLOCK)
if sliding_window_q > 0:                       # backward window bounds the loop
    kv_iters = min(kv_iters, cdiv(sliding_window_q, BLOCK) + 1)
num_stages = 3   if dtype in {fp16, bf16} and 64 < head_dim <= 128 and kv_iters >= 16
           = 2   if dtype in {fp16, bf16} and 64 < head_dim <= 128 and 8 <= kv_iters < 16
           = 1   otherwise
```

The two-tier depth matters: at the low end of the band (`kv_iters` 8–15, seq ~1024–2047)
`num_stages=3` overshoots and can regress on A100, whereas `num_stages=2` is a win on both
A100 and H100; long prefills (`kv_iters >= 16`) take depth 3, the largest win.

The pipelined path is additionally **gated by architecture in the caller**: it is only
enabled on the CUDA compute capabilities where it was validated — **SM80** (A100/A30-class)
and **SM90** (H100/H200-class). ROCm (which also calls this kernel via
`RocmAttentionImpl`), SM86/SM89, and any future/untested architecture keep `num_stages=1`
until they are benchmarked. Because stage count is resource-sensitive (larger tiles
already hit `OutOfResources`), this "opt-in only where measured" gate is deliberate.

### Sliding-window iteration cap (interaction with #50776)

Since #50776 `_fwd_kernel` starts the K/V loop at the first block that is not fully
masked (`start_n_limit`), so a **backward** window bounds the loop *independently of
sequence length*: a query tile walks only `ceil(sliding_window_q / BLOCK_N) + 1` blocks
however long the prefill is. Estimating `kv_iters` from `max_input_len` alone therefore
overcounts badly for windowed shapes — a 1024-wide window over an 8192-token prefill
scores 64 iterations when the loop really runs 9 — and would hand the loop a depth it
cannot fill. The estimate is capped accordingly, which moves the windowed d128 configs
from depth 3 to depth 2.

A **forward** window (`sliding_window_k`) is deliberately *not* used as a cap: with no
backward window the loop still starts at block 0, so later query tiles do walk the full
prefix, and capping on it would under-pipeline ordinary causal prefills.
`test_select_num_stages_forward_window_does_not_cap` pins that asymmetry.

The cap is the conservative choice on the two validated arches: for the windowed configs
depth 2 is the *measured optimum on A100* (1.25–1.29× vs 1.21–1.24× at depth 3), while on
H100 depth 3 would have been ~4–7% better still (1.38–1.45× vs the 1.32–1.36× depth 2
delivers). Both depths are solid wins over the baseline; the policy prefers the one that
does not regress on either arch.

### Why each fallback to `num_stages=1`

Measured with a full `num_stages ∈ {1,2,3}` sweep on A100-SXM4-80GB and H100-80GB-HBM3:

- **fp32** — 32-wide tiles + ieee dot path; keep the single stage.
- **`head_dim <= 64`** — tiny tiles and a short-latency loop; pipelining adds
  prologue/epilogue overhead and *regresses* (e.g. ~0.84× on a d64 encoder shape).
- **`head_dim > 128` (e.g. 256)** — the per-stage K/V tiles are large enough that even
  `num_stages=2` **exceeds A100/H100 shared memory** and raises `OutOfResources`. Keeping
  `1` here is a correctness/safety requirement — the policy must never select a stage
  count that would fail to launch.
- **short prefill (`< 8` KV-loop iterations, `max_input_len < ~1024`)** — too few
  iterations to fill the pipeline; the extra prologue/epilogue can slightly regress.
- **moderate prefill (`8 <= kv_iters < 16`)** — uses depth 2 rather than 3, since 3
  overshoots and regresses on A100 at this length while 2 wins on both archs.

### Risk / scope

- Triton attention is **not** the default backend for every NVIDIA vLLM deployment, so
  this benefits users who select or fall back to it (encoder attention, ViT, the Triton
  backend), not all deployments.
- No public API, signature, or output change; the win is purely from the launch
  metaparameter. The pipelined path is dtype/shape-gated **and** restricted to the
  SM80/SM90 CUDA families it was validated on, so it never selects a `num_stages` that
  would exceed the shared-memory budget on hardware it is enabled for; every other
  platform is byte-for-byte the previous `num_stages=1` launch.

## Test Plan

```bash
pytest tests/kernels/attention/test_triton_prefill_attention.py -v
```

- `test_select_num_stages` (new, CPU-only): asserts the policy bands — fp32, `head_dim`
  ≤64 / >128, and short sequences stay `num_stages=1`; the BF16/FP16 `64 < head_dim <=
  128` band selects `2` (8–15 KV iters) or `3` (≥16 KV iters). Also covers the
  sliding-window cap: a 1024-wide window drops an 8192-token prefill from depth 3 to
  depth 2, a 256-wide window drops it to depth 1, a 4096-wide window still leaves depth
  3, and the cap never *raises* the estimate above the sequence itself.
- `test_select_num_stages_forward_window_does_not_cap` (new, CPU-only): pins that
  `sliding_window_k` must **not** shrink the estimate.
- `test_context_attention` (extended): now runs **`float16`** in addition to `bfloat16`
  and `float32`, and adds **`D=256`**. The fp16/bf16 rows exercise the real pipelined
  kernel launch (at `D=128`, seq 1024 → `num_stages=2`); the `D=256` rows guard that the
  large-head-dim path stays `num_stages=1` and launches without `OutOfResources`, all
  while matching the SDPA reference.
- `test_context_attention_stage3_launch` (new, GPU): a single long sequence (`D=128`, seq
  2048 → `num_stages=3`) so the depth-3 pipelined configuration is compiled, launched, and
  checked against the reference — the parametrized cases above only reach depth 2.
- Existing `test_context_attention_sliding_window` also covers the pipelined path.

Performance was measured on the **post-#50776 baseline**. Median of 50 timed iterations ×
5 repeats; correctness = `allclose` vs a per-sequence `F.scaled_dot_product_attention`
reference. 28-config matrix: head dims {64, 96, 128, 256}; causal-GQA,
bidirectional-encoder (MHA), and causal sliding-window; bf16 and fp16; seq lengths
{512, 1024, 2048, 8192}; two highly-ragged batches (one long seq + several short);
plus fp32. On A100-SXM4-80GB and H100 80GB HBM3, torch 2.12.0+cu130 / triton 3.7.0 /
cuda 13.0.

## Test Result

| GPU | correct | geomean speedup (14 pipelined configs) | range | peak |
|---|---|---|---|---|
| A100-SXM4-80GB | 28/28 | **1.212×** | 1.047–1.332× | 1.332× (causal GQA d128 s2048, fp16) |
| H100 80GB HBM3 | 28/28 | **1.292×** | 1.120–1.387× | 1.387× (causal GQA d96 s8192) |

The largest wins are long causal / encoder / sliding-window `head_dim=128` prefills.
**No pipelined config regresses** on either GPU — the worst pipelined case is 1.047×
(A100) / 1.120× (H100). The highly-ragged batches (one 8192-token sequence mixed with
several ~128-token ones) win 1.05–1.30× with correct output on every sequence —
confirming that applying the launch-wide `num_stages` derived from `max_input_len` to a
batch that also contains short sequences is safe. All 14 configurations outside the
pipelined band (fp32, `head_dim` 64/256, short sequences) take the identical previous
`num_stages=1` launch and measure exactly 1.00×.

## Notes

- The numbers above are the **2026-08-04 re-measurement against the post-#50776
  baseline**, not the original ones (#50776 shortened the K/V loop for
  backward-sliding-window prefills, which made the original iteration estimate wrong for
  those shapes — hence the window cap). The branch still cherry-picks cleanly onto current
  `main`, and the only subsequent change to this kernel is the `SINKS_BIAS_KEY0` path,
  which is a `tl.constexpr` branch that compiles away when unused. Happy to re-run the
  matrix if a maintainer would like a fresher baseline before merge.
- `pre-commit run --files <changed files>` is clean.

## AI assistance disclosure

This change was prepared with AI assistance (Claude). A human reviewed every changed line
and ran the tests and benchmarks above on A100 and H100 hardware.
