### PR TITLE
[DSv4 Perf] Right-size gather-k workers to the reachable token count and use num_…

### DIFF
--- a/vllm/models/deepseek_v4/common/ops/cache_utils.py
+++ b/vllm/models/deepseek_v4/common/ops/cache_utils.py
@@ -353,7 +353,12 @@ def dequantize_and_gather_k_cache_triton(
     TOKEN_DATA_SIZE = TOKEN_FP8_DIM + TOKEN_BF16_DIM * 2
 
     num_reqs = seq_lens.shape[0]
-    NUM_WORKERS = 128
+    max_tokens = out.shape[1]
+
+    # Size workers to the reachable token count (not the over-allocated buffer
+    # width); num_reqs already provides batch parallelism.
+    reachable = min(int(block_table.shape[1]) * int(block_size), int(max_tokens))
+    NUM_WORKERS = min(8192, max(32, triton.next_power_of_2(reachable)))
     _dequantize_and_gather_k_kernel[(num_reqs, NUM_WORKERS)](
         out,
         out.stride(0),
@@ -375,6 +380,7 @@ def dequantize_and_gather_k_cache_triton(
         fp8_max=FP8_MAX,
         n_quant_blocks=7,
         use_fnuz=use_fnuz,
+        num_warps=1,
     )
 
 


### PR DESCRIPTION
This pull request improves the performance and efficiency of the `dequantize_and_gather_k_cache_triton` function in `cache_utils.py` by dynamically sizing the number of worker threads and updating kernel launch parameters. The main changes are:

**Performance and Resource Management:**

* The number of worker threads (`NUM_WORKERS`) is now dynamically determined based on the actual number of reachable tokens, rather than being fixed at 128. This helps better utilize resources and scale to the workload.

**Kernel Launch Parameters:**

* The kernel launch for `_dequantize_and_gather_k_kernel` now explicitly sets `num_warps=1`, which can improve per-work-group resource use, maximizing concurrent work-groups and in-flight memory request to saturate DRAM bandwidth (and avoiding cross-warp reduction sync)

## Test Result
This is bench result on intel B60:
|        scenario |       seq |   gather |   new_us   |  old_us   |   old/new    |
|-----------------|-----------|----------|------------|-----------|--------------|
|        SWA-only |       128 |      128 |        8.7 |       8.7 |        1.00x |
|        SWA-only |       512 |      512 |        9.7 |      17.4 |        1.79x |
|        SWA-only |      1024 |     1024 |       11.3 |      28.6 |        2.53x |
|        SWA-only |      8192 |     8192 |       48   |     185   |        3.85x |
|        SWA-only |     16384 |    16384 |       86.9 |     363.6 |        4.19x |
|        SWA-only |     32768 |    32768 |      163.3 |     719.8 |        4.41x |
|        SWA-only |     65536 |    65536 |      317   |    1432.3 |        4.52x |
|        SWA-only |    102400 |   102400 |      490.1 |    2234   |        4.56x |
|   C4-compressed |        32 |     full |        8.2 |       7.8 |        0.96x |
|   C4-compressed |       512 |     full |        9.3 |      16.8 |        1.81x |
|   C4-compressed |      1024 |     full |       11   |      28.1 |        2.54x |
|   C4-compressed |      2048 |     full |       17.3 |      50.5 |        2.91x |
|   C4-compressed |      4096 |     full |       27.8 |      94.7 |        3.41x |
|   C4-compressed |      8192 |     full |       47.7 |     183.2 |        3.84x |
|   C4-compressed |     16384 |     full |       86.6 |     358.9 |        4.14x |
|   C4-compressed |     25600 |     full |      129.2 |     558.2 |        4.32x |
| C128-compressed |        64 |     full |        8.3 |       7.9 |        0.96x |
| C128-compressed |       128 |     full |        8.2 |       8.2 |        0.99x |
| C128-compressed |       256 |     full |        8.4 |      10.9 |        1.30x |
| C128-compressed |       512 |     full |        9.5 |      17.1 |        1.80x |
| C128-compressed |       800 |     full |       10.4 |      24.5 |        2.35x |
