### PR TITLE
[DSv4 Perf] Stream sparse-attn compress softmax to cut register pressure and lift…

### DIFF
--- a/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py
+++ b/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py
@@ -166,50 +166,59 @@ def _fused_kv_compress_norm_rope_insert_sparse_attn(
 
     req_idx = tl.load(token_to_req_indices_ptr + token_idx)
 
-    # ── Gather state cache entries ────────────────────────────────────
-    start = position - (1 + OVERLAP) * COMPRESS_RATIO + 1
-    tokens = tl.arange(0, (1 + OVERLAP) * COMPRESS_RATIO)
-    pos = start + tokens
-    mask_pos = pos >= 0
-
-    block_indices = pos // block_size
-    block_numbers = tl.load(
-        block_table_ptr + req_idx * block_table_stride + block_indices,
-        mask=mask_pos,
-        other=0,
-    )
-    block_offsets = pos % block_size
-    head_offset = (tokens >= COMPRESS_RATIO).to(tl.int32) * HEAD_SIZE
+    # ── Gather state cache entries + streaming (online) softmax ───────
+    # Stream the window in EFF_TILE-row tiles with a running max/sum to avoid
+    # materializing the full [N_GATHER, HEAD_SIZE] tiles (register spill at
+    # large compress ratios). Overlap layers stay single-tile.
+    N_GATHER: tl.constexpr = (1 + OVERLAP) * COMPRESS_RATIO
+    EFF_TILE: tl.constexpr = N_GATHER if OVERLAP else 4
+    start = position - N_GATHER + 1
 
     block = tl.arange(0, TRITON_BLOCK_SIZE)
     mask = block < HEAD_SIZE
-    block_numbers_i64 = block_numbers.to(tl.int64)
 
-    # Precomputed row base shared by score and kv loads
-    row_base = (
-        state_cache_ptr
-        + block_numbers_i64 * state_cache_stride0
-        + block_offsets * state_cache_stride1
-        + head_offset
-    )
+    m_run = tl.full((TRITON_BLOCK_SIZE,), float("-inf"), tl.float32)
+    l_run = tl.zeros((TRITON_BLOCK_SIZE,), tl.float32)
+    acc = tl.zeros((TRITON_BLOCK_SIZE,), tl.float32)
 
-    combined_mask = mask_pos[:, None] & mask[None, :]
+    for base in tl.static_range(0, N_GATHER, EFF_TILE):
+        tokens = base + tl.arange(0, EFF_TILE)
+        pos = start + tokens
+        mask_pos = pos >= 0
 
-    # ── Softmax + weighted sum ───────────────────────────────────────
-    score = tl.load(
-        row_base[:, None] + STATE_WIDTH + block[None, :],
-        mask=combined_mask,
-        other=float("-inf"),
-    )
-    score = tl.softmax(score, dim=0)
+        block_numbers = tl.load(
+            block_table_ptr + req_idx * block_table_stride + pos // block_size,
+            mask=mask_pos,
+            other=0,
+        )
+        head_offset = (tokens >= COMPRESS_RATIO).to(tl.int32) * HEAD_SIZE
+        row_base = (
+            state_cache_ptr
+            + block_numbers.to(tl.int64) * state_cache_stride0
+            + (pos % block_size) * state_cache_stride1
+            + head_offset
+        )
+        combined_mask = mask_pos[:, None] & mask[None, :]
 
-    kv = tl.load(
-        row_base[:, None] + block[None, :],
-        mask=combined_mask,
-        other=0.0,
-    )
+        score = tl.load(
+            row_base[:, None] + STATE_WIDTH + block[None, :],
+            mask=combined_mask,
+            other=float("-inf"),
+        )
+        kv = tl.load(
+            row_base[:, None] + block[None, :],
+            mask=combined_mask,
+            other=0.0,
+        )
 
-    compressed_kv = tl.sum(kv * score, axis=0)  # [TRITON_BLOCK_SIZE] fp32
+        m_new = tl.maximum(m_run, tl.max(score, axis=0))
+        alpha = tl.exp(m_run - m_new)
+        p = tl.exp(score - m_new[None, :])
+        l_run = l_run * alpha + tl.sum(p, axis=0)
+        acc = acc * alpha + tl.sum(p * kv, axis=0)
+        m_run = m_new
+
+    compressed_kv = acc / l_run  # [TRITON_BLOCK_SIZE] fp32
 
     # ── RMSNorm (fp32 throughout) ──────────────────────────────────────
     rms_w = tl.load(rms_norm_weight_ptr + block, mask=mask, other=0.0)


### PR DESCRIPTION
## Purpose
This pull request refactors the streaming softmax computation in the `_fused_kv_compress_norm_rope_insert_sparse_attn` kernel to improve memory efficiency and avoid register spilling at high compression ratios. The main change is to implement a streaming (online) softmax and weighted sum, processing the window in tiles rather than materializing the full set of tiles at once.

## Test Result
Test result on Intel B60:
| layer      | num_tok   | new_us  |  old_us  |  old/new  |
|------------|---------------|-------------|------------|--------------|
| B_cr128  |         1      | 154.64    |  300.36     |   1.94 |
| B_cr128  |         4      | 152.50    |  305.73     |    2.00 |
| B_cr128  |        16     | 143.39    |  359.04     |    2.50 |
| B_cr128  |        64     | 193.28    |  733.65     |    3.80 |
| B_cr128  |       128    | 301.77    | 1297.08    |    4.30 |
| B_cr128  |       256    | 429.06    |  2484.69   |    5.79 |
| B_cr128  |      1024   | 1414.09  |  9631.15   |   6.81 |
| B_cr128  |      2048   | 2683.02  | 19132.86  |   7.13 |
| B_cr128  |      4096   | 5253.54  | 38138.85  |   7.26 |
