### PR TITLE
[Benchmarks] Add speculative K schedule tuner

### DIFF
--- a/docs/benchmarking/sweeps.md
+++ b/docs/benchmarking/sweeps.md
@@ -237,6 +237,39 @@ vllm bench sweep plot $EXPERIMENT_DIR \
 !!! tip
     You can use `--dry-run` to preview the figures to be plotted.
 
+### Speculative K schedule
+
+`vllm bench sweep tune_speculative_k` analyzes repeated `sweep serve` results
+whose server configurations force different speculative-token counts. It
+selects K from a conservative estimate of the configured objective at each
+`max_concurrency` anchor and writes a `num_speculative_tokens_per_batch_size`
+schedule. Output TPS is maximized by default:
+
+```bash
+vllm bench sweep tune_speculative_k results/spec-k \
+  --max-batch-size 64
+```
+
+To minimize TPOT instead, add
+`--objective-var mean_tpot_ms --objective-direction minimize`. To optimize an
+SLO-aware serving metric, run `vllm bench serve` with `--goodput` and maximize
+`request_goodput`. The default K source is
+`speculative_config.num_speculative_tokens_per_batch_size`; each benchmark
+server should retain the same global `num_speculative_tokens` and use a fixed
+one-range schedule for the candidate being measured. The default selection
+penalizes noisy measurements, treats candidates within 1% as tied, and prefers
+the smaller K. Candidate K values are selected independently because optimal K
+can be non-monotonic for some architectures.
+It fails when an anchor is missing candidates or when `--max-batch-size` was not
+measured, rather than extrapolating a K into an untested load range. Standard
+serving records are also rejected when they report failed requests or fewer
+completed requests than requested.
+`max_concurrency` is a load ceiling, so use saturated, fixed-length workloads
+where it closely tracks the scheduled request batch size. The tuner optimizes
+one scalar metric at a time; encode latency SLOs in `request_goodput` or filter
+ineligible candidate results before tuning.
+See [Dynamic Speculative Decoding](../features/speculative_decoding/dynamic_speculative_decoding.md#offline-k-schedule-tuning) for a complete sweep setup.
+
 ### Pareto chart
 
 `vllm bench sweep plot_pareto` helps pick configurations that balance per-user and per-GPU throughput.

--- a/docs/features/speculative_decoding/dynamic_speculative_decoding.md
+++ b/docs/features/speculative_decoding/dynamic_speculative_decoding.md
@@ -32,6 +32,84 @@ implies that:
 * K=1 will be used when the concurrency is in range [65, 128]
 * K=0 will be used when the concurrency is in range [129, 512], i.e., no draft tokens will be produced.
 
+## Offline K schedule tuning
+
+`vllm bench sweep tune_speculative_k` converts repeated serving sweep results
+into `num_speculative_tokens_per_batch_size`. Keep the global maximum K fixed
+across runs and force each candidate through a one-range batch-size schedule so
+KV-cache and worker-buffer sizing remain comparable. For example, one entry in
+`serve_params.json` for candidate K=3 is:
+
+```json
+{
+  "speculative_config": {
+    "method": "eagle",
+    "model": "yuhuili/EAGLE-LLaMA3.1-Instruct-8B",
+    "num_speculative_tokens": 7,
+    "num_speculative_tokens_per_batch_size": [[1, 64, 3]]
+  }
+}
+```
+
+Add equivalent entries for every candidate, including K=0 when desired. Put
+the tuning anchors in `bench_params.json`:
+
+```json
+[
+  {"max_concurrency": 1},
+  {"max_concurrency": 8},
+  {"max_concurrency": 32},
+  {"max_concurrency": 64}
+]
+```
+
+Run at least three repetitions per combination, then generate the schedule:
+
+```bash
+vllm bench sweep serve \
+  --serve-cmd 'vllm serve meta-llama/Llama-3.1-8B-Instruct' \
+  --bench-cmd 'vllm bench serve --backend vllm --model meta-llama/Llama-3.1-8B-Instruct --request-rate inf --num-prompts 256 --ignore-eos' \
+  --serve-params serve_params.json \
+  --bench-params bench_params.json \
+  --num-runs 3 \
+  --output-dir results \
+  --experiment-name spec-k
+
+vllm bench sweep tune_speculative_k results/spec-k --max-batch-size 64
+```
+
+The tuner maximizes median output TPS minus a median-absolute-deviation
+uncertainty penalty by default. It can instead minimize a latency metric, for
+example `--objective-var mean_tpot_ms --objective-direction minimize`; the
+uncertainty penalty is then added to the median. Candidates within 1% of the
+best conservative objective are treated as tied and the smaller K is
+preferred. Candidate K values are selected independently because MoE and other
+architectures can have a non-monotonic optimum. Adjacent equal-K ranges are
+merged, and the command writes
+`speculative_k_schedule.json` in the experiment directory.
+Pass `--acceptance-var spec_decode_acceptance_length` to include acceptance
+stability diagnostics, and `--strict-acceptance-stability` to reject unstable
+positive-K candidates. Acceptance is undefined for K=0 because no draft model
+runs, so missing or null K=0 acceptance values are allowed.
+Every batch-size anchor must contain the same candidate set, and the deployment
+maximum must be a measured anchor; the tuner rejects missing candidates and
+unmeasured tail extrapolation. With the default vLLM result fields, it also
+rejects candidate K values above the configured global maximum and sweeps that
+change the global maximum between candidates. The output records both the
+configured global maximum and the largest measured candidate; keep the former
+unchanged when deploying the generated schedule so allocation and graph
+coverage match the sweep.
+Use a representative prompt/output distribution and the same GPU topology,
+model, drafter, compilation mode, and latency constraints as production.
+Because `max_concurrency` is a ceiling rather than a scheduler batch-size trace,
+keep the benchmark saturated with fixed-length requests and verify that it is a
+reasonable proxy for the runtime batch sizes being tuned. To optimize under a
+latency SLO, pass `--goodput tpot:<milliseconds>` (and any other SLOs) to
+`vllm bench serve`, then tune with
+`--objective-var request_goodput --objective-direction maximize`. The tuner
+optimizes one scalar metric at a time; alternatively exclude candidates that
+violate deployment constraints before tuning.
+
 ## Online Examples
 
 ### Dynamic SD Eagle Drafter

--- a/tests/benchmarks/sweep/test_tune_speculative_k.py
+++ b/tests/benchmarks/sweep/test_tune_speculative_k.py
@@ -1,0 +1,521 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+from typing import cast
+
+import pytest
+
+from vllm.benchmarks.sweep.tune_speculative_k import (
+    SpecKMeasurement,
+    SweepTuneSpeculativeKArgs,
+    _extract_k,
+    aggregate_measurements,
+    build_schedule,
+    run_main,
+    select_k_by_batch_size,
+    tune_speculative_k,
+)
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+
+def _record(batch_size: int, k: int, throughput: float, acceptance: float = 2.0):
+    return {
+        "max_concurrency": batch_size,
+        "output_throughput": throughput,
+        "acceptance_length": acceptance,
+        "speculative_config": {
+            "num_speculative_tokens": 7,
+            "num_speculative_tokens_per_batch_size": [[1, 64, k]],
+        },
+    }
+
+
+def _measurement(batch_size: int, k: int, objective: float) -> SpecKMeasurement:
+    return SpecKMeasurement(
+        batch_size=batch_size,
+        k=k,
+        num_runs=3,
+        median_objective=objective,
+        mad_objective=0.0,
+        conservative_objective=objective,
+        objective_relative_mad=0.0,
+    )
+
+
+def test_extract_k_from_nested_schedule_with_gap_and_tail():
+    record: dict[str, object] = {
+        "speculative_config": {
+            "num_speculative_tokens_per_batch_size": [
+                [1, 4, 7],
+                [9, 16, 3],
+            ]
+        }
+    }
+
+    assert (
+        _extract_k(
+            record, "speculative_config.num_speculative_tokens_per_batch_size", 6
+        )
+        == 7
+    )
+    assert (
+        _extract_k(
+            record, "speculative_config.num_speculative_tokens_per_batch_size", 32
+        )
+        == 3
+    )
+
+
+def test_aggregate_measurements_uses_median_and_mad():
+    measurements = aggregate_measurements(
+        [_record(1, 3, value) for value in [100.0, 102.0, 200.0]],
+        batch_size_var="max_concurrency",
+        k_var="speculative_config.num_speculative_tokens_per_batch_size",
+        objective_var="output_throughput",
+        objective_direction="maximize",
+        acceptance_var="acceptance_length",
+        min_runs=3,
+        uncertainty_penalty=1.0,
+        max_objective_relative_mad=1.0,
+        max_acceptance_relative_mad=0.1,
+        strict_acceptance_stability=True,
+    )
+
+    assert len(measurements) == 1
+    assert measurements[0].median_objective == 102.0
+    assert measurements[0].mad_objective == 2.0
+    assert measurements[0].conservative_objective == pytest.approx(99.0348)
+
+
+def test_aggregate_measurements_rejects_unstable_objective():
+    with pytest.raises(ValueError, match="Unstable objective"):
+        aggregate_measurements(
+            [_record(1, 3, value) for value in [50.0, 100.0, 150.0]],
+            batch_size_var="max_concurrency",
+            k_var="speculative_config.num_speculative_tokens_per_batch_size",
+            objective_var="output_throughput",
+            objective_direction="maximize",
+            acceptance_var=None,
+            min_runs=3,
+            uncertainty_penalty=1.0,
+            max_objective_relative_mad=0.1,
+            max_acceptance_relative_mad=0.1,
+            strict_acceptance_stability=False,
+        )
+
+
+def test_aggregate_measurements_can_require_stable_acceptance():
+    records = [_record(1, 3, 100.0, acceptance) for acceptance in [1.0, 2.0, 3.0]]
+
+    with pytest.raises(ValueError, match="Unstable acceptance"):
+        aggregate_measurements(
+            records,
+            batch_size_var="max_concurrency",
+            k_var="speculative_config.num_speculative_tokens_per_batch_size",
+            objective_var="output_throughput",
+            objective_direction="maximize",
+            acceptance_var="acceptance_length",
+            min_runs=3,
+            uncertainty_penalty=1.0,
+            max_objective_relative_mad=0.1,
+            max_acceptance_relative_mad=0.1,
+            strict_acceptance_stability=True,
+        )
+
+
+def test_aggregate_measurements_accepts_stable_zero_acceptance():
+    measurements = aggregate_measurements(
+        [_record(1, 0, 100.0, acceptance=0.0) for _ in range(3)],
+        batch_size_var="max_concurrency",
+        k_var="speculative_config.num_speculative_tokens_per_batch_size",
+        objective_var="output_throughput",
+        objective_direction="maximize",
+        acceptance_var="acceptance_length",
+        min_runs=3,
+        uncertainty_penalty=1.0,
+        max_objective_relative_mad=0.1,
+        max_acceptance_relative_mad=0.1,
+        strict_acceptance_stability=True,
+    )
+
+    assert measurements[0].median_acceptance == 0.0
+    assert measurements[0].acceptance_relative_mad == 0.0
+
+
+@pytest.mark.parametrize("missing_value", [None, "absent"])
+def test_aggregate_measurements_allows_undefined_k0_acceptance(missing_value):
+    records = [_record(1, 0, 100.0) for _ in range(3)]
+    for record in records:
+        if missing_value is None:
+            record["acceptance_length"] = None
+        else:
+            del record["acceptance_length"]
+
+    measurements = aggregate_measurements(
+        records,
+        batch_size_var="max_concurrency",
+        k_var="speculative_config.num_speculative_tokens_per_batch_size",
+        objective_var="output_throughput",
+        objective_direction="maximize",
+        acceptance_var="acceptance_length",
+        min_runs=3,
+        uncertainty_penalty=1.0,
+        max_objective_relative_mad=0.1,
+        max_acceptance_relative_mad=0.1,
+        strict_acceptance_stability=True,
+    )
+
+    assert measurements[0].median_acceptance is None
+    assert measurements[0].acceptance_relative_mad is None
+
+
+def test_aggregate_measurements_requires_positive_k_acceptance():
+    records = [_record(1, 3, 100.0) for _ in range(3)]
+    records[0]["acceptance_length"] = None
+
+    with pytest.raises(ValueError, match="Expected numeric acceptance_length"):
+        aggregate_measurements(
+            records,
+            batch_size_var="max_concurrency",
+            k_var="speculative_config.num_speculative_tokens_per_batch_size",
+            objective_var="output_throughput",
+            objective_direction="maximize",
+            acceptance_var="acceptance_length",
+            min_runs=3,
+            uncertainty_penalty=1.0,
+            max_objective_relative_mad=0.1,
+            max_acceptance_relative_mad=0.1,
+            strict_acceptance_stability=True,
+        )
+
+
+def test_maximize_objective_allows_zero_goodput_candidate():
+    measurements = aggregate_measurements(
+        [_record(1, 0, 0.0) for _ in range(3)]
+        + [_record(1, 3, 10.0) for _ in range(3)],
+        batch_size_var="max_concurrency",
+        k_var="speculative_config.num_speculative_tokens_per_batch_size",
+        objective_var="output_throughput",
+        objective_direction="maximize",
+        acceptance_var=None,
+        min_runs=3,
+        uncertainty_penalty=1.0,
+        max_objective_relative_mad=0.1,
+        max_acceptance_relative_mad=0.1,
+        strict_acceptance_stability=False,
+    )
+
+    assert select_k_by_batch_size(
+        measurements,
+        objective_direction="maximize",
+        relative_tolerance=0.01,
+    ) == {1: 3}
+
+
+def test_selection_rejects_all_zero_maximize_objectives():
+    with pytest.raises(ValueError, match="No positive conservative objective"):
+        select_k_by_batch_size(
+            [_measurement(1, 0, 0.0), _measurement(1, 3, 0.0)],
+            objective_direction="maximize",
+            relative_tolerance=0.01,
+        )
+
+
+def test_aggregate_measurements_rejects_negative_acceptance():
+    with pytest.raises(ValueError, match="non-negative acceptance"):
+        aggregate_measurements(
+            [_record(1, 3, 100.0, acceptance=-1.0) for _ in range(3)],
+            batch_size_var="max_concurrency",
+            k_var="speculative_config.num_speculative_tokens_per_batch_size",
+            objective_var="output_throughput",
+            objective_direction="maximize",
+            acceptance_var="acceptance_length",
+            min_runs=3,
+            uncertainty_penalty=1.0,
+            max_objective_relative_mad=0.1,
+            max_acceptance_relative_mad=0.1,
+            strict_acceptance_stability=True,
+        )
+
+
+def test_aggregate_measurements_rejects_failed_requests():
+    records = [_record(1, 3, 100.0) for _ in range(3)]
+    records[0]["failed"] = 1
+
+    with pytest.raises(ValueError, match="contains 1 failed request"):
+        aggregate_measurements(
+            records,
+            batch_size_var="max_concurrency",
+            k_var="speculative_config.num_speculative_tokens_per_batch_size",
+            objective_var="output_throughput",
+            objective_direction="maximize",
+            acceptance_var=None,
+            min_runs=3,
+            uncertainty_penalty=1.0,
+            max_objective_relative_mad=0.1,
+            max_acceptance_relative_mad=0.1,
+            strict_acceptance_stability=False,
+        )
+
+
+def test_aggregate_measurements_rejects_incomplete_requests():
+    records = [_record(1, 3, 100.0) for _ in range(3)]
+    records[0].update({"failed": 0, "completed": 31, "num_prompts": 32})
+
+    with pytest.raises(ValueError, match="completed 31 of 32 prompts"):
+        aggregate_measurements(
+            records,
+            batch_size_var="max_concurrency",
+            k_var="speculative_config.num_speculative_tokens_per_batch_size",
+            objective_var="output_throughput",
+            objective_direction="maximize",
+            acceptance_var=None,
+            min_runs=3,
+            uncertainty_penalty=1.0,
+            max_objective_relative_mad=0.1,
+            max_acceptance_relative_mad=0.1,
+            strict_acceptance_stability=False,
+        )
+
+
+def test_aggregate_measurements_rejects_k_above_global_maximum():
+    records = [_record(1, 7, 100.0) for _ in range(3)]
+    for record in records:
+        record["speculative_config"]["num_speculative_tokens"] = 3
+
+    with pytest.raises(ValueError, match="K=7 exceeds configured global K=3"):
+        aggregate_measurements(
+            records,
+            batch_size_var="max_concurrency",
+            k_var="speculative_config.num_speculative_tokens_per_batch_size",
+            objective_var="output_throughput",
+            objective_direction="maximize",
+            acceptance_var=None,
+            min_runs=3,
+            uncertainty_penalty=1.0,
+            max_objective_relative_mad=0.1,
+            max_acceptance_relative_mad=0.1,
+            strict_acceptance_stability=False,
+        )
+
+
+def test_aggregate_measurements_requires_fixed_global_maximum():
+    records = [_record(1, 3, 100.0) for _ in range(3)]
+    records[0]["speculative_config"]["num_speculative_tokens"] = 3
+
+    with pytest.raises(ValueError, match=r"found \[3, 7\]"):
+        aggregate_measurements(
+            records,
+            batch_size_var="max_concurrency",
+            k_var="speculative_config.num_speculative_tokens_per_batch_size",
+            objective_var="output_throughput",
+            objective_direction="maximize",
+            acceptance_var=None,
+            min_runs=3,
+            uncertainty_penalty=1.0,
+            max_objective_relative_mad=0.1,
+            max_acceptance_relative_mad=0.1,
+            strict_acceptance_stability=False,
+        )
+
+
+def test_selection_prefers_smaller_k_within_tolerance():
+    selected = select_k_by_batch_size(
+        [_measurement(1, 0, 100.0), _measurement(1, 7, 100.5)],
+        objective_direction="maximize",
+        relative_tolerance=0.01,
+    )
+
+    assert selected == {1: 0}
+
+
+def test_selection_can_minimize_objective():
+    selected = select_k_by_batch_size(
+        [_measurement(1, 0, 10.0), _measurement(1, 3, 8.0)],
+        objective_direction="minimize",
+        relative_tolerance=0.0,
+    )
+
+    assert selected == {1: 3}
+
+
+def test_minimize_objective_penalizes_upward_uncertainty():
+    measurements = aggregate_measurements(
+        [_record(1, 3, value) for value in [100.0, 102.0, 200.0]],
+        batch_size_var="max_concurrency",
+        k_var="speculative_config.num_speculative_tokens_per_batch_size",
+        objective_var="output_throughput",
+        objective_direction="minimize",
+        acceptance_var=None,
+        min_runs=3,
+        uncertainty_penalty=1.0,
+        max_objective_relative_mad=1.0,
+        max_acceptance_relative_mad=0.1,
+        strict_acceptance_stability=False,
+    )
+
+    assert measurements[0].conservative_objective == pytest.approx(104.9652)
+
+
+def test_selection_preserves_nonmonotonic_local_optima():
+    measurements = [
+        _measurement(1, 1, 100.0),
+        _measurement(1, 3, 70.0),
+        _measurement(8, 1, 80.0),
+        _measurement(8, 3, 100.0),
+    ]
+
+    selected = select_k_by_batch_size(
+        measurements,
+        objective_direction="maximize",
+        relative_tolerance=0.0,
+    )
+
+    assert selected == {1: 1, 8: 3}
+
+
+def test_selection_requires_same_candidates_at_every_batch_size():
+    with pytest.raises(ValueError, match=r"expected \[1, 3\]"):
+        select_k_by_batch_size(
+            [
+                _measurement(1, 1, 100.0),
+                _measurement(1, 3, 110.0),
+                _measurement(8, 1, 120.0),
+            ],
+            objective_direction="maximize",
+            relative_tolerance=0.01,
+        )
+
+
+def test_build_schedule_fills_gaps_tail_and_merges_equal_k():
+    assert build_schedule({1: 7, 8: 7, 32: 3, 64: 0}, 128) == [
+        [1, 31, 7],
+        [32, 63, 3],
+        [64, 128, 0],
+    ]
+
+
+def test_tune_speculative_k_emits_runtime_schedule():
+    records: list[dict[str, object]] = []
+    for batch_size, values in {
+        1: {0: 90.0, 3: 100.0, 7: 120.0},
+        8: {0: 100.0, 3: 130.0, 7: 125.0},
+        32: {0: 140.0, 3: 135.0, 7: 100.0},
+    }.items():
+        for k, throughput in values.items():
+            records.extend(_record(batch_size, k, throughput) for _ in range(3))
+
+    result = tune_speculative_k(
+        records,
+        batch_size_var="max_concurrency",
+        k_var="speculative_config.num_speculative_tokens_per_batch_size",
+        objective_var="output_throughput",
+        objective_direction="maximize",
+        acceptance_var="acceptance_length",
+        min_runs=3,
+        uncertainty_penalty=1.0,
+        max_objective_relative_mad=0.1,
+        max_acceptance_relative_mad=0.1,
+        strict_acceptance_stability=True,
+        relative_tolerance=0.01,
+        max_batch_size=32,
+    )
+
+    assert result["num_speculative_tokens_per_batch_size"] == [
+        [1, 7, 7],
+        [8, 31, 3],
+        [32, 32, 0],
+    ]
+    assert result["configured_global_num_speculative_tokens"] == 7
+    assert result["max_num_speculative_tokens_observed"] == 7
+    batch_decisions = cast(list[dict[str, object]], result["batch_decisions"])
+    selection = cast(dict[str, object], result["selection"])
+    assert batch_decisions[0]["selected_vs_k0_percent"] == pytest.approx(
+        100.0 * (120.0 / 90.0 - 1.0)
+    )
+    assert batch_decisions[1]["selected_vs_best_percent"] == 0.0
+    assert selection["acceptance_metric"] == "acceptance_length"
+    assert selection["min_runs"] == 3
+    assert selection["strict_acceptance_stability"] is True
+    assert selection["max_batch_size"] == 32
+
+
+def test_tuner_rejects_unmeasured_tail_extrapolation():
+    records: list[dict[str, object]] = []
+    for batch_size in [1, 8]:
+        for k in [0, 3]:
+            records.extend(_record(batch_size, k, 100.0 + k) for _ in range(3))
+
+    with pytest.raises(ValueError, match="largest tuned batch-size anchor"):
+        tune_speculative_k(
+            records,
+            batch_size_var="max_concurrency",
+            k_var="speculative_config.num_speculative_tokens_per_batch_size",
+            objective_var="output_throughput",
+            objective_direction="maximize",
+            acceptance_var=None,
+            min_runs=3,
+            uncertainty_penalty=1.0,
+            max_objective_relative_mad=0.1,
+            max_acceptance_relative_mad=0.1,
+            strict_acceptance_stability=False,
+            relative_tolerance=0.01,
+            max_batch_size=64,
+        )
+
+
+def test_run_main_reads_sweep_summaries_and_writes_json(tmp_path):
+    records: list[dict[str, object]] = []
+    for batch_size, values in {1: {0: 90.0, 3: 100.0}, 8: {0: 110.0, 3: 100.0}}.items():
+        for k, throughput in values.items():
+            records.extend(_record(batch_size, k, throughput) for _ in range(3))
+    result_dir = tmp_path / "case"
+    result_dir.mkdir()
+    (result_dir / "summary.json").write_text(json.dumps(records))
+    output_path = tmp_path / "schedule.json"
+
+    result = run_main(
+        SweepTuneSpeculativeKArgs(
+            experiment_dir=tmp_path,
+            output_json=output_path,
+            batch_size_var="max_concurrency",
+            k_var="speculative_config.num_speculative_tokens_per_batch_size",
+            objective_var="output_throughput",
+            objective_direction="maximize",
+            acceptance_var=None,
+            min_runs=3,
+            uncertainty_penalty=1.0,
+            max_objective_relative_mad=0.1,
+            max_acceptance_relative_mad=0.1,
+            strict_acceptance_stability=False,
+            relative_tolerance=0.01,
+            max_batch_size=8,
+        )
+    )
+
+    assert result["num_speculative_tokens_per_batch_size"] == [
+        [1, 7, 3],
+        [8, 8, 0],
+    ]
+    assert result["input_summary_files"] == ["case/summary.json"]
+    assert json.loads(output_path.read_text()) == result
+
+
+def test_cli_can_minimize_tpot(tmp_path):
+    parser = FlexibleArgumentParser()
+    SweepTuneSpeculativeKArgs.add_cli_args(parser)
+
+    namespace = parser.parse_args(
+        [
+            str(tmp_path),
+            "--objective-var",
+            "mean_tpot_ms",
+            "--objective-direction",
+            "minimize",
+        ]
+    )
+    args = SweepTuneSpeculativeKArgs.from_cli_args(namespace)
+
+    assert args.objective_var == "mean_tpot_ms"
+    assert args.objective_direction == "minimize"

--- a/vllm/benchmarks/sweep/cli.py
+++ b/vllm/benchmarks/sweep/cli.py
@@ -15,6 +15,8 @@ from .serve_workload import SweepServeWorkloadArgs
 from .serve_workload import main as serve_workload_main
 from .startup import SweepStartupArgs
 from .startup import main as startup_main
+from .tune_speculative_k import SweepTuneSpeculativeKArgs
+from .tune_speculative_k import main as tune_speculative_k_main
 
 SUBCOMMANDS = (
     (SweepServeArgs, serve_main),
@@ -22,6 +24,7 @@ SUBCOMMANDS = (
     (SweepStartupArgs, startup_main),
     (SweepPlotArgs, plot_main),
     (SweepPlotParetoArgs, plot_pareto_main),
+    (SweepTuneSpeculativeKArgs, tune_speculative_k_main),
 )
 
 

--- a/vllm/benchmarks/sweep/tune_speculative_k.py
+++ b/vllm/benchmarks/sweep/tune_speculative_k.py
@@ -1,0 +1,597 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import argparse
+import contextlib
+import json
+import math
+import statistics
+import warnings
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import ClassVar
+
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+from vllm.v1.spec_decode.dynamic.utils import (
+    validate_and_normalize_dynamic_sd_schedule,
+)
+
+DEFAULT_K_VAR = "speculative_config.num_speculative_tokens_per_batch_size"
+DEFAULT_GLOBAL_K_VAR = "speculative_config.num_speculative_tokens"
+
+
+@dataclass(frozen=True)
+class SpecKMeasurement:
+    batch_size: int
+    k: int
+    num_runs: int
+    median_objective: float
+    mad_objective: float
+    conservative_objective: float
+    objective_relative_mad: float
+    median_acceptance: float | None = None
+    acceptance_relative_mad: float | None = None
+
+
+def _get_nested(record: dict[str, object], key: str) -> object:
+    if key in record:
+        return record[key]
+
+    value: object = record
+    for part in key.split("."):
+        if not isinstance(value, dict):
+            break
+        for candidate in (part, part.replace("-", "_"), part.replace("_", "-")):
+            if candidate in value:
+                value = value[candidate]
+                break
+        else:
+            break
+    else:
+        return value
+
+    raise ValueError(f"Cannot find {key!r} in result keys {sorted(record)}")
+
+
+def _finite_float(value: object, name: str) -> float:
+    try:
+        result = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Expected numeric {name}, got {value!r}") from exc
+    if not math.isfinite(result):
+        raise ValueError(f"Expected finite {name}, got {value!r}")
+    return result
+
+
+def _positive_int(value: object, name: str) -> int:
+    numeric = _finite_float(value, name)
+    result = int(numeric)
+    if result != numeric or result <= 0:
+        raise ValueError(f"Expected positive integer {name}, got {value!r}")
+    return result
+
+
+def _non_negative_int(value: object, name: str) -> int:
+    numeric = _finite_float(value, name)
+    result = int(numeric)
+    if result != numeric or result < 0:
+        raise ValueError(f"Expected non-negative integer {name}, got {value!r}")
+    return result
+
+
+def _extract_k(record: dict[str, object], k_var: str, batch_size: int) -> int:
+    value = _get_nested(record, k_var)
+    if isinstance(value, str):
+        with contextlib.suppress(json.JSONDecodeError):
+            value = json.loads(value)
+
+    if isinstance(value, int | float):
+        numeric = _finite_float(value, k_var)
+        k = int(numeric)
+        if k != numeric or k < 0:
+            raise ValueError(f"Expected non-negative integer K, got {value!r}")
+        return k
+
+    schedule = validate_and_normalize_dynamic_sd_schedule(value)
+    selected_k = schedule[0][2]
+    for range_start, _, range_k in schedule:
+        if range_start > batch_size:
+            break
+        selected_k = range_k
+    return selected_k
+
+
+def _median_and_mad(values: list[float]) -> tuple[float, float, float]:
+    median = statistics.median(values)
+    mad = statistics.median(abs(value - median) for value in values)
+    relative_mad = mad / abs(median) if median != 0 else (0.0 if mad == 0 else math.inf)
+    return median, mad, relative_mad
+
+
+def aggregate_measurements(
+    records: list[dict[str, object]],
+    *,
+    batch_size_var: str,
+    k_var: str,
+    objective_var: str,
+    objective_direction: str,
+    acceptance_var: str | None,
+    min_runs: int,
+    uncertainty_penalty: float,
+    max_objective_relative_mad: float,
+    max_acceptance_relative_mad: float,
+    strict_acceptance_stability: bool,
+) -> list[SpecKMeasurement]:
+    if min_runs <= 0:
+        raise ValueError("min_runs must be positive")
+    if uncertainty_penalty < 0:
+        raise ValueError("uncertainty_penalty must be non-negative")
+    if objective_direction not in {"maximize", "minimize"}:
+        raise ValueError("objective_direction must be 'maximize' or 'minimize'")
+    if max_objective_relative_mad < 0 or max_acceptance_relative_mad < 0:
+        raise ValueError("relative MAD thresholds must be non-negative")
+
+    grouped: dict[tuple[int, int], list[tuple[float, float | None]]] = defaultdict(list)
+    global_ks: set[int] = set()
+    for record in records:
+        if "failed" in record:
+            failed = _non_negative_int(record["failed"], "failed")
+            if failed:
+                raise ValueError(
+                    f"Sweep record contains {failed} failed request(s); "
+                    "only complete benchmark runs can be tuned"
+                )
+        if "completed" in record and "num_prompts" in record:
+            completed = _non_negative_int(record["completed"], "completed")
+            num_prompts = _positive_int(record["num_prompts"], "num_prompts")
+            if completed != num_prompts:
+                raise ValueError(
+                    f"Sweep record completed {completed} of {num_prompts} prompts; "
+                    "only complete benchmark runs can be tuned"
+                )
+        batch_size = _positive_int(_get_nested(record, batch_size_var), batch_size_var)
+        k = _extract_k(record, k_var, batch_size)
+        if k_var == DEFAULT_K_VAR:
+            global_k = _positive_int(
+                _get_nested(record, DEFAULT_GLOBAL_K_VAR), DEFAULT_GLOBAL_K_VAR
+            )
+            if k > global_k:
+                raise ValueError(
+                    f"Scheduled K={k} exceeds configured global K={global_k}"
+                )
+            global_ks.add(global_k)
+        objective = _finite_float(_get_nested(record, objective_var), objective_var)
+        if objective < 0 or (objective_direction == "minimize" and objective == 0):
+            expectation = (
+                "non-negative" if objective_direction == "maximize" else "positive"
+            )
+            raise ValueError(f"Expected {expectation} objective, got {objective!r}")
+        acceptance = None
+        if acceptance_var is not None:
+            try:
+                acceptance_value = _get_nested(record, acceptance_var)
+            except ValueError:
+                if k != 0:
+                    raise
+            else:
+                if acceptance_value is None:
+                    if k != 0:
+                        raise ValueError(f"Expected numeric {acceptance_var}, got None")
+                else:
+                    acceptance = _finite_float(acceptance_value, acceptance_var)
+        if acceptance is not None and acceptance < 0:
+            raise ValueError(f"Expected non-negative acceptance, got {acceptance!r}")
+        grouped[(batch_size, k)].append((objective, acceptance))
+
+    if len(global_ks) > 1:
+        raise ValueError(
+            "All sweep records must use the same global num_speculative_tokens; "
+            f"found {sorted(global_ks)}"
+        )
+
+    measurements = []
+    for (batch_size, k), samples in sorted(grouped.items()):
+        if len(samples) < min_runs:
+            raise ValueError(
+                f"batch_size={batch_size}, K={k} has {len(samples)} runs; "
+                f"at least {min_runs} are required"
+            )
+
+        median_objective, mad_objective, objective_relative_mad = _median_and_mad(
+            [sample[0] for sample in samples]
+        )
+        if objective_relative_mad > max_objective_relative_mad:
+            raise ValueError(
+                f"Unstable objective for batch_size={batch_size}, K={k}: "
+                f"relative MAD {objective_relative_mad:.3f} exceeds "
+                f"{max_objective_relative_mad:.3f}"
+            )
+
+        median_acceptance = None
+        acceptance_relative_mad = None
+        if acceptance_var is not None:
+            acceptances = [sample[1] for sample in samples]
+            if any(value is not None for value in acceptances):
+                if not all(value is not None for value in acceptances):
+                    raise ValueError(
+                        f"Inconsistent missing {acceptance_var} values for "
+                        f"batch_size={batch_size}, K={k}"
+                    )
+                median_acceptance, _, acceptance_relative_mad = _median_and_mad(
+                    [float(value) for value in acceptances if value is not None]
+                )
+                if acceptance_relative_mad > max_acceptance_relative_mad:
+                    message = (
+                        f"Unstable acceptance for batch_size={batch_size}, K={k}: "
+                        f"relative MAD {acceptance_relative_mad:.3f} exceeds "
+                        f"{max_acceptance_relative_mad:.3f}"
+                    )
+                    if strict_acceptance_stability:
+                        raise ValueError(message)
+                    warnings.warn(message, stacklevel=2)
+
+        # 1.4826 scales MAD to standard deviation for a normal distribution.
+        uncertainty = uncertainty_penalty * 1.4826 * mad_objective
+        conservative_objective = (
+            max(median_objective - uncertainty, 0.0)
+            if objective_direction == "maximize"
+            else median_objective + uncertainty
+        )
+        measurements.append(
+            SpecKMeasurement(
+                batch_size=batch_size,
+                k=k,
+                num_runs=len(samples),
+                median_objective=median_objective,
+                mad_objective=mad_objective,
+                conservative_objective=conservative_objective,
+                objective_relative_mad=objective_relative_mad,
+                median_acceptance=median_acceptance,
+                acceptance_relative_mad=acceptance_relative_mad,
+            )
+        )
+
+    if not measurements:
+        raise ValueError("No benchmark measurements found")
+    return measurements
+
+
+def select_k_by_batch_size(
+    measurements: list[SpecKMeasurement],
+    *,
+    objective_direction: str,
+    relative_tolerance: float,
+) -> dict[int, int]:
+    if objective_direction not in {"maximize", "minimize"}:
+        raise ValueError("objective_direction must be 'maximize' or 'minimize'")
+    if not 0.0 <= relative_tolerance < 1.0:
+        raise ValueError("relative_tolerance must be in [0, 1)")
+
+    by_batch: dict[int, list[SpecKMeasurement]] = defaultdict(list)
+    for measurement in measurements:
+        by_batch[measurement.batch_size].append(measurement)
+
+    batch_sizes = sorted(by_batch)
+    if batch_sizes[0] != 1:
+        raise ValueError("The smallest tuned batch size must be 1")
+    expected_ks = {item.k for item in by_batch[batch_sizes[0]]}
+    for batch_size in batch_sizes[1:]:
+        actual_ks = {item.k for item in by_batch[batch_size]}
+        if actual_ks != expected_ks:
+            raise ValueError(
+                f"batch_size={batch_size} has K candidates {sorted(actual_ks)}, "
+                f"expected {sorted(expected_ks)}"
+            )
+
+    utility: dict[tuple[int, int], float] = {}
+    for batch_size, candidates in by_batch.items():
+        conservative_values = [
+            candidate.conservative_objective for candidate in candidates
+        ]
+        if objective_direction == "maximize" and max(conservative_values) <= 0:
+            raise ValueError(
+                f"No positive conservative objective for batch_size={batch_size}"
+            )
+        if objective_direction == "minimize" and any(
+            value <= 0 for value in conservative_values
+        ):
+            raise ValueError(
+                f"No positive conservative objective for batch_size={batch_size}"
+            )
+        best_objective = (
+            max(conservative_values)
+            if objective_direction == "maximize"
+            else min(conservative_values)
+        )
+        for candidate in candidates:
+            ratio = (
+                candidate.conservative_objective / best_objective
+                if objective_direction == "maximize"
+                else best_objective / candidate.conservative_objective
+            )
+            utility[(batch_size, candidate.k)] = (
+                1.0 if ratio >= 1.0 - relative_tolerance else ratio
+            )
+
+    return {
+        batch_size: min(
+            by_batch[batch_size],
+            key=lambda item: (-utility[(batch_size, item.k)], item.k),
+        ).k
+        for batch_size in batch_sizes
+    }
+
+
+def build_schedule(selected_k: dict[int, int], max_batch_size: int) -> list[list[int]]:
+    batch_sizes = sorted(selected_k)
+    if not batch_sizes or batch_sizes[0] != 1:
+        raise ValueError("Selected batch sizes must start at 1")
+    if max_batch_size < batch_sizes[-1]:
+        raise ValueError("max_batch_size must cover the largest tuned batch size")
+
+    schedule: list[list[int]] = []
+    for index, range_start in enumerate(batch_sizes):
+        range_end = (
+            batch_sizes[index + 1] - 1
+            if index + 1 < len(batch_sizes)
+            else max_batch_size
+        )
+        k = selected_k[range_start]
+        if schedule and schedule[-1][2] == k:
+            schedule[-1][1] = range_end
+        else:
+            schedule.append([range_start, range_end, k])
+    return schedule
+
+
+def tune_speculative_k(
+    records: list[dict[str, object]],
+    *,
+    batch_size_var: str,
+    k_var: str,
+    objective_var: str,
+    objective_direction: str,
+    acceptance_var: str | None,
+    min_runs: int,
+    uncertainty_penalty: float,
+    max_objective_relative_mad: float,
+    max_acceptance_relative_mad: float,
+    strict_acceptance_stability: bool,
+    relative_tolerance: float,
+    max_batch_size: int | None,
+) -> dict[str, object]:
+    measurements = aggregate_measurements(
+        records,
+        batch_size_var=batch_size_var,
+        k_var=k_var,
+        objective_var=objective_var,
+        objective_direction=objective_direction,
+        acceptance_var=acceptance_var,
+        min_runs=min_runs,
+        uncertainty_penalty=uncertainty_penalty,
+        max_objective_relative_mad=max_objective_relative_mad,
+        max_acceptance_relative_mad=max_acceptance_relative_mad,
+        strict_acceptance_stability=strict_acceptance_stability,
+    )
+    selected = select_k_by_batch_size(
+        measurements,
+        objective_direction=objective_direction,
+        relative_tolerance=relative_tolerance,
+    )
+    resolved_max_batch_size = (
+        max(selected) if max_batch_size is None else max_batch_size
+    )
+    if resolved_max_batch_size != max(selected):
+        raise ValueError(
+            "max_batch_size must be the largest tuned batch-size anchor; "
+            "add a measurement at the deployment maximum instead of extrapolating"
+        )
+    schedule = build_schedule(selected, resolved_max_batch_size)
+    configured_global_k = (
+        _positive_int(
+            _get_nested(records[0], DEFAULT_GLOBAL_K_VAR), DEFAULT_GLOBAL_K_VAR
+        )
+        if k_var == DEFAULT_K_VAR
+        else None
+    )
+
+    by_batch: dict[int, list[SpecKMeasurement]] = defaultdict(list)
+    for measurement in measurements:
+        by_batch[measurement.batch_size].append(measurement)
+    decisions = []
+    for batch_size in sorted(selected):
+        candidates = sorted(by_batch[batch_size], key=lambda item: item.k)
+        selected_measurement = next(
+            item for item in candidates if item.k == selected[batch_size]
+        )
+        best_objective = (
+            max(item.conservative_objective for item in candidates)
+            if objective_direction == "maximize"
+            else min(item.conservative_objective for item in candidates)
+        )
+        k0_measurement = next((item for item in candidates if item.k == 0), None)
+        decisions.append(
+            {
+                "batch_size": batch_size,
+                "selected_k": selected[batch_size],
+                "selected_median_objective": selected_measurement.median_objective,
+                "selected_conservative_objective": (
+                    selected_measurement.conservative_objective
+                ),
+                "selected_vs_best_percent": 100.0
+                * (
+                    (
+                        selected_measurement.conservative_objective / best_objective
+                        if objective_direction == "maximize"
+                        else best_objective
+                        / selected_measurement.conservative_objective
+                    )
+                    - 1.0
+                ),
+                "selected_vs_k0_percent": (
+                    None
+                    if k0_measurement is None
+                    or k0_measurement.conservative_objective == 0
+                    else 100.0
+                    * (
+                        (
+                            selected_measurement.conservative_objective
+                            / k0_measurement.conservative_objective
+                            if objective_direction == "maximize"
+                            else k0_measurement.conservative_objective
+                            / selected_measurement.conservative_objective
+                        )
+                        - 1.0
+                    )
+                ),
+                "candidates": [asdict(candidate) for candidate in candidates],
+            }
+        )
+
+    return {
+        "num_speculative_tokens_per_batch_size": schedule,
+        "configured_global_num_speculative_tokens": configured_global_k,
+        "max_num_speculative_tokens_observed": max(item.k for item in measurements),
+        "selection": {
+            "batch_size_metric": batch_size_var,
+            "k_metric": k_var,
+            "objective_metric": objective_var,
+            "objective_direction": objective_direction,
+            "acceptance_metric": acceptance_var,
+            "min_runs": min_runs,
+            "relative_tolerance": relative_tolerance,
+            "uncertainty_penalty": uncertainty_penalty,
+            "max_objective_relative_mad": max_objective_relative_mad,
+            "max_acceptance_relative_mad": max_acceptance_relative_mad,
+            "strict_acceptance_stability": strict_acceptance_stability,
+            "max_batch_size": resolved_max_batch_size,
+        },
+        "batch_decisions": decisions,
+    }
+
+
+@dataclass
+class SweepTuneSpeculativeKArgs:
+    experiment_dir: Path
+    output_json: Path
+    batch_size_var: str
+    k_var: str
+    objective_var: str
+    objective_direction: str
+    acceptance_var: str | None
+    min_runs: int
+    uncertainty_penalty: float
+    max_objective_relative_mad: float
+    max_acceptance_relative_mad: float
+    strict_acceptance_stability: bool
+    relative_tolerance: float
+    max_batch_size: int | None
+
+    parser_name: ClassVar[str] = "tune_speculative_k"
+    parser_help: ClassVar[str] = (
+        "Generate a dynamic speculative-decoding K schedule from sweep results."
+    )
+
+    @classmethod
+    def from_cli_args(cls, args: argparse.Namespace):
+        experiment_dir = Path(args.EXPERIMENT_DIR)
+        if not experiment_dir.exists():
+            raise ValueError(f"No parameter sweep results under {experiment_dir}")
+        output_json = (
+            Path(args.output_json)
+            if args.output_json
+            else experiment_dir / "speculative_k_schedule.json"
+        )
+        return cls(
+            experiment_dir=experiment_dir,
+            output_json=output_json,
+            batch_size_var=args.batch_size_var,
+            k_var=args.k_var,
+            objective_var=args.objective_var,
+            objective_direction=args.objective_direction,
+            acceptance_var=args.acceptance_var,
+            min_runs=args.min_runs,
+            uncertainty_penalty=args.uncertainty_penalty,
+            max_objective_relative_mad=args.max_objective_relative_mad,
+            max_acceptance_relative_mad=args.max_acceptance_relative_mad,
+            strict_acceptance_stability=args.strict_acceptance_stability,
+            relative_tolerance=args.relative_tolerance,
+            max_batch_size=args.max_batch_size,
+        )
+
+    @classmethod
+    def add_cli_args(cls, parser: FlexibleArgumentParser):
+        parser.add_argument("EXPERIMENT_DIR", type=str)
+        parser.add_argument("--output-json", type=str)
+        parser.add_argument("--batch-size-var", default="max_concurrency")
+        parser.add_argument(
+            "--k-var",
+            default=DEFAULT_K_VAR,
+        )
+        parser.add_argument("--objective-var", default="output_throughput")
+        parser.add_argument(
+            "--objective-direction",
+            choices=("maximize", "minimize"),
+            default="maximize",
+        )
+        parser.add_argument("--acceptance-var")
+        parser.add_argument("--min-runs", type=int, default=3)
+        parser.add_argument("--uncertainty-penalty", type=float, default=1.0)
+        parser.add_argument("--max-objective-relative-mad", type=float, default=0.1)
+        parser.add_argument("--max-acceptance-relative-mad", type=float, default=0.1)
+        parser.add_argument("--strict-acceptance-stability", action="store_true")
+        parser.add_argument("--relative-tolerance", type=float, default=0.01)
+        parser.add_argument("--max-batch-size", type=int)
+        return parser
+
+
+def run_main(args: SweepTuneSpeculativeKArgs) -> dict[str, object]:
+    summary_paths = sorted(args.experiment_dir.rglob("summary.json"))
+    records = [
+        record for path in summary_paths for record in json.loads(path.read_bytes())
+    ]
+    result = tune_speculative_k(
+        records,
+        batch_size_var=args.batch_size_var,
+        k_var=args.k_var,
+        objective_var=args.objective_var,
+        objective_direction=args.objective_direction,
+        acceptance_var=args.acceptance_var,
+        min_runs=args.min_runs,
+        uncertainty_penalty=args.uncertainty_penalty,
+        max_objective_relative_mad=args.max_objective_relative_mad,
+        max_acceptance_relative_mad=args.max_acceptance_relative_mad,
+        strict_acceptance_stability=args.strict_acceptance_stability,
+        relative_tolerance=args.relative_tolerance,
+        max_batch_size=args.max_batch_size,
+    )
+    result["input_summary_files"] = [
+        str(path.relative_to(args.experiment_dir)) for path in summary_paths
+    ]
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    with args.output_json.open("w") as output:
+        json.dump(result, output, indent=2)
+        output.write("\n")
+    print(json.dumps(result["num_speculative_tokens_per_batch_size"]))
+    decisions = result["batch_decisions"]
+    assert isinstance(decisions, list)
+    for decision in decisions:
+        assert isinstance(decision, dict)
+        print(
+            "batch_size={batch_size}: K={selected_k}, "
+            "conservative_objective={selected_conservative_objective:.2f}, "
+            "vs_best={selected_vs_best_percent:.2f}%, "
+            "vs_k0={selected_vs_k0_percent}".format(**decision)
+        )
+    print(f"Wrote {args.output_json}")
+    return result
+
+
+def main(args: argparse.Namespace):
+    run_main(SweepTuneSpeculativeKArgs.from_cli_args(args))
+
+
+if __name__ == "__main__":
+    parser = FlexibleArgumentParser(description=SweepTuneSpeculativeKArgs.parser_help)
+    SweepTuneSpeculativeKArgs.add_cli_args(parser)
+    main(parser.parse_args())


### PR DESCRIPTION
## Purpose

Add `vllm bench sweep tune_speculative_k`, an offline tuner that converts
repeated serving sweep results into a deployable
`num_speculative_tokens_per_batch_size` schedule.

Dynamic speculative decoding currently requires users to choose the mapping in
advance. The command makes that choice from measured serving behavior while
leaving runtime scheduling unchanged.

The selection policy:

- groups repeated results by batch-size anchor and effective K;
- uses the median objective with a configurable MAD uncertainty penalty;
- rejects noisy measurements above a relative-MAD threshold;
- treats candidates within 1% of the best conservative result as tied and
  chooses the smaller K;
- preserves non-monotonic local optima instead of assuming K must decrease;
- requires the same candidate set at every anchor, including batch 1 and the
  measured deployment maximum;
- rejects serving records with failed or incomplete requests when the standard
  benchmark health fields are present;
- rejects candidate K above the configured global maximum and sweeps that
  change the global maximum between candidates; and
- optionally reports or strictly enforces acceptance-metric stability, while
  correctly allowing undefined K=0 acceptance.

Output TPS is maximized by default. Users can minimize TPOT or maximize
latency-SLO-aware `request_goodput`. The JSON output includes the merged
schedule, all candidate statistics, selection parameters, and input-summary
provenance. It also records both the configured global speculative-token
maximum and the largest measured candidate, so deployment configuration does
not silently drift when a sweep covers only a subset of valid K values.

No open PR or issue found by the required duplicate-work searches implements a
sweep-result-to-dynamic-K tuner. #48692 consumes a user-provided batch-size
schedule but does not choose one.

## Test Plan

```bash
pytest -q tests/benchmarks/sweep

mypy \
  vllm/benchmarks/sweep/tune_speculative_k.py \
  tests/benchmarks/sweep/test_tune_speculative_k.py

vllm bench sweep tune_speculative_k results/spec-k \
  --max-batch-size 256 \
  --acceptance-var spec_decode_acceptance_length
```

Relevant Ruff, Ruff format, typos, and Markdownlint hooks were run on all
changed files.

## Test Result

- Tuner plus existing sweep tests: 48 passed.
- Mypy: no issues.
- Relevant pre-commit hooks: passed.
- CLI help, parser registration, JSON generation, and default output path:
  passed.

### Official serving sweep

A single-H100 `vllm bench sweep serve` run covers K=0/1/3/7 and concurrency
1/64/128/256, with three repetitions per combination (48 runs total), async
scheduling, compiled CUDA graphs, fixed 128-token input/output lengths, and
zero failed requests.

Random-token continuation gives very low draft acceptance (positive-K
acceptance length 1.09-1.15). TPS, goodput under `tpot:50`, and TPOT objectives
all correctly select:

```json
[[1, 256, 0]]
```

For example, robust output TPS at batch 256 is 5016.94 for K=0 versus 2118.30,
2005.52, and 1776.67 for K=1/3/7. This is a negative control showing that the
tuner disables harmful speculation rather than assuming positive K wins.

### Standard Sonnet serving validation

A second single-H100 serving sweep uses vLLM's standard Sonnet dataset with
550-token inputs, 128-token outputs, and the same 48-run K/load matrix. All
runs complete with zero failed requests. TPS, `tpot:50` goodput, and mean TPOT
independently select:

```json
[[1, 63, 7], [64, 256, 0]]
```

At concurrency 1, K=7 robust TPS is 317.27 versus 204.33 for K=0 (+55.3%). At
concurrency 64, K=0 is 3511.24 versus 3042.50 for the best positive candidate,
K=3. Acceptance length remains approximately load-invariant for each fixed K,
so the transition comes from measured end-to-end serving efficiency rather
than an acceptance-only rule.

### Natural-text validation

An independent mixed natural-prompt matrix contains 84 records: batch sizes
1/8/32, K=0/1/3/7, and seven repeats per point. The final CLI selects:

```json
[[1, 32, 7]]
```

K=7 robust TPS improves over K=0 by 207.28%, 162.38%, and 95.76% at the three
anchors. A separate five-repeat high-load A/B finds local throughput optima
K=7 at batch 64, K=3 at batch 128, and K=0 at batch 256 even though acceptance
length remains approximately batch-invariant for each fixed K. This supports
measuring TPS instead of deriving K from acceptance alone.

## Limitations

The generated schedule is specific to the measured hardware, model/drafter,
workload, compilation mode, and latency constraints. `max_concurrency` is a
load ceiling, not a scheduler trace, so the documentation requires saturated,
fixed-length traffic and production validation. The tuner optimizes one scalar
metric and does not replace workload selection or SLO design.

## AI assistance

This patch was developed with OpenAI Codex assistance and the commit includes
the required attribution trailer. This is a Draft PR; the human submitter must
review every changed line and confirm the test/benchmark evidence before
marking it ready for review.
