### PR TITLE
[Spec Decode] Make DFlash draft compute honor dynamic K

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
@@ -184,6 +184,7 @@ def test_v2_sample_tokens_runs_eplb_on_non_last_pp_rank(monkeypatch):
         hidden_states=None,
         aux_hidden_states=None,
         finished_req_ids=set(),
+        num_spec_tokens_to_schedule=0,
         num_tokens_across_dp=None,
     )
     runner.req_states = SimpleNamespace()

--- a/tests/v1/worker/test_gpu_model_runner_v2_spec_decode.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_spec_decode.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.v1.worker.gpu import model_runner as mrv2
+
+
+@pytest.mark.parametrize(
+    ("scheduled_k", "supports_dynamic_draft_shapes", "proposal_width"),
+    [(0, True, 0), (3, True, 3), (3, False, 7)],
+)
+def test_sample_tokens_honors_scheduled_speculative_k(
+    monkeypatch, scheduled_k, supports_dynamic_draft_shapes, proposal_width
+):
+    runner: Any = mrv2.GPUModelRunner.__new__(mrv2.GPUModelRunner)
+    input_batch: Any = SimpleNamespace(
+        num_reqs=2,
+        req_ids=["req-0", "req-1"],
+        idx_mapping=torch.tensor([1, 0]),
+        query_start_loc=torch.tensor([0, 1, 2]),
+    )
+    hidden_states = torch.zeros(2, 4)
+    runner.execute_model_state = mrv2.ExecuteModelState(
+        input_batch=input_batch,
+        attn_metadata=None,
+        slot_mappings_by_layer=None,
+        hidden_states=hidden_states,
+        aux_hidden_states=None,
+        finished_req_ids=set(),
+        num_spec_tokens_to_schedule=scheduled_k,
+    )
+    runner.is_last_pp_rank = True
+    runner.pcp_manager = None
+    runner.pp_handler = None
+    runner.main_stream = None
+    runner.output_copy_stream = None
+    runner.model = SimpleNamespace(compute_logits=Mock())
+    runner.prompt_logprobs_worker = SimpleNamespace(
+        compute_prompt_logprobs=Mock(return_value={})
+    )
+    runner.sample = Mock(
+        return_value=(
+            SimpleNamespace(sampled_token_ids=torch.zeros(2, 1, dtype=torch.long)),
+            torch.ones(2, dtype=torch.int32),
+            torch.zeros(2, dtype=torch.int32),
+        )
+    )
+    runner.postprocess_sampled = Mock()
+    runner.model_state = SimpleNamespace(gather_mm_embeddings=Mock())
+    runner.sampler = SimpleNamespace(
+        sampling_states=SimpleNamespace(
+            temperature=SimpleNamespace(gpu=torch.ones(2)),
+            seeds=SimpleNamespace(gpu=torch.zeros(2, dtype=torch.long)),
+        )
+    )
+    proposed_tokens = torch.arange(2 * proposal_width).reshape(2, proposal_width)
+    runner.speculator = SimpleNamespace(
+        supports_mm_inputs=False,
+        supports_dynamic_draft_shapes=supports_dynamic_draft_shapes,
+        propose=Mock(return_value=proposed_tokens),
+    )
+    runner.req_states = SimpleNamespace(
+        all_token_ids=SimpleNamespace(gpu=torch.zeros(2, 1, dtype=torch.long)),
+        num_computed_tokens=SimpleNamespace(gpu=torch.zeros(2, dtype=torch.int32)),
+        prompt_len=SimpleNamespace(np=torch.zeros(2, dtype=torch.int32).numpy()),
+        last_sampled_tokens=torch.zeros(2, dtype=torch.long),
+        next_prefill_tokens=torch.zeros(2, dtype=torch.long),
+        draft_tokens=torch.full((2, 7), -1, dtype=torch.long),
+    )
+    runner.num_speculative_steps = 7
+    runner.draft_tokens_handler = SimpleNamespace(set_draft_tokens=Mock())
+    runner.kv_connector = SimpleNamespace(post_forward=Mock(return_value=None))
+    runner.eplb = SimpleNamespace(step=Mock())
+
+    monkeypatch.setattr(
+        mrv2.pcp,
+        "maybe_restore_pcp_for_sampling",
+        lambda _manager, states, batch: (states, batch),
+    )
+    monkeypatch.setattr(mrv2, "AsyncOutput", lambda **_: object())
+
+    mrv2.GPUModelRunner.sample_tokens(runner, None)
+
+    if scheduled_k == 0:
+        runner.speculator.propose.assert_not_called()
+    elif supports_dynamic_draft_shapes:
+        assert (
+            runner.speculator.propose.call_args.kwargs["num_speculative_tokens"]
+            == scheduled_k
+        )
+    else:
+        assert (
+            "num_speculative_tokens" not in runner.speculator.propose.call_args.kwargs
+        )
+    published_tokens = runner.draft_tokens_handler.set_draft_tokens.call_args.args[1]
+    assert published_tokens.shape == (2, scheduled_k)
+    if scheduled_k > 0:
+        torch.testing.assert_close(published_tokens, proposed_tokens[:, :scheduled_k])

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1383,6 +1383,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             hidden_states=hidden_states,
             aux_hidden_states=aux_hidden_states,
             finished_req_ids=finished_req_ids,
+            num_spec_tokens_to_schedule=scheduler_output.num_spec_tokens_to_schedule,
         )
 
         if not self.is_last_pp_rank:
@@ -1405,6 +1406,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         hidden_states = self.execute_model_state.hidden_states
         aux_hidden_states = self.execute_model_state.aux_hidden_states
         finished_req_ids = self.execute_model_state.finished_req_ids
+        num_spec_tokens_to_schedule = (
+            self.execute_model_state.num_spec_tokens_to_schedule
+        )
         self.execute_model_state = None
 
         if not self.is_last_pp_rank:
@@ -1494,7 +1498,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             input_batch.query_start_loc,
         )
 
-        if self.speculator is not None:
+        if self.speculator is not None and num_spec_tokens_to_schedule > 0:
             assert self.sampler is not None
             # Let the target override the hidden state fed to the drafter
             # (e.g. DeepSeek V4 MTP needs the pre-hc_head residual). The
@@ -1504,6 +1508,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if hasattr(self.model, "get_mtp_target_hidden_states"):
                 pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
                 spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
+            propose_kwargs = (
+                {"num_speculative_tokens": num_spec_tokens_to_schedule}
+                if self.speculator.supports_dynamic_draft_shapes
+                else {}
+            )
             draft_tokens = self.speculator.propose(
                 input_batch,
                 attn_metadata,
@@ -1517,16 +1526,24 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 self.sampler.sampling_states.temperature.gpu,
                 self.sampler.sampling_states.seeds.gpu,
                 mm_inputs=mm_inputs,
+                **propose_kwargs,
             )
-            self.req_states.draft_tokens[input_batch.idx_mapping] = draft_tokens
+            num_proposed_tokens = draft_tokens.shape[1]
+            self.req_states.draft_tokens[
+                input_batch.idx_mapping, :num_proposed_tokens
+            ] = draft_tokens
 
         if self.num_speculative_steps > 0:
             # Spec-decode and diffusion LLMs both use draft tokens but the latter does
             # not have a speculator (i.e. self.speculator is None)
-            self.draft_tokens_handler.set_draft_tokens(
-                input_batch,
-                self.req_states.draft_tokens[input_batch.idx_mapping],
+            draft_tokens = (
+                self.req_states.draft_tokens[input_batch.idx_mapping]
+                if self.speculator is None
+                else self.req_states.draft_tokens[
+                    input_batch.idx_mapping, :num_spec_tokens_to_schedule
+                ]
             )
+            self.draft_tokens_handler.set_draft_tokens(input_batch, draft_tokens)
 
         # Post-step KV connector related operations.
         kv_connector_output = self.kv_connector.post_forward(finished_req_ids)
@@ -1647,6 +1664,7 @@ class ExecuteModelState(NamedTuple):
     hidden_states: torch.Tensor | None
     aux_hidden_states: list[torch.Tensor] | None
     finished_req_ids: set[str]
+    num_spec_tokens_to_schedule: int
 
 
 def sort_batch_req_ids(

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -147,6 +147,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         temperature: torch.Tensor,
         # [max_num_reqs]
         seeds: torch.Tensor,
+        num_speculative_tokens: int | None = None,
         num_tokens_across_dp: torch.Tensor | None = None,
         dummy_run: bool = False,
         skip_attn_for_dummy_run: bool = False,

--- a/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Mapping
 
 import torch
 
+from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import (
@@ -63,6 +64,27 @@ class DFlashCudaGraphManager(CudaGraphManager):
     """DFlash CudaGraphManager for the parallel-drafting query forward,
     building its own attention metadata from scratch."""
 
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        device: torch.device,
+        cudagraph_mode: CUDAGraphMode,
+        decode_query_len: int,
+        lora_capture_cases: list[int] | None = None,
+        *,
+        query_len_offset: int,
+        dynamic_draft_shapes: bool,
+    ) -> None:
+        super().__init__(
+            vllm_config,
+            device,
+            cudagraph_mode,
+            decode_query_len,
+            lora_capture_cases,
+        )
+        self.query_len_offset = query_len_offset
+        self.dynamic_draft_shapes = dynamic_draft_shapes
+
     def capture(
         self,
         forward_fn: Callable,
@@ -80,6 +102,16 @@ class DFlashCudaGraphManager(CudaGraphManager):
         ) -> Callable[[CUDAGraphMode], None]:
             num_tokens = desc.num_tokens
             num_reqs = desc.num_reqs or min(num_tokens, self.max_num_reqs)
+            num_query_per_req = desc.uniform_token_count or num_tokens // num_reqs
+            scheduled_k = num_query_per_req - self.query_len_offset
+            # K=0 skips the drafter at runtime. Preserve the existing dummy
+            # capture behavior for that unreachable drafter graph.
+            num_speculative_tokens = (
+                scheduled_k
+                if self.dynamic_draft_shapes and scheduled_k > 0
+                else self.vllm_config.num_speculative_tokens
+            )
+            assert num_speculative_tokens > 0
             num_tokens_across_dp = (
                 torch.full((self.dp_size,), num_tokens, dtype=torch.int32, device="cpu")
                 if self.dp_size > 1
@@ -104,6 +136,7 @@ class DFlashCudaGraphManager(CudaGraphManager):
                 attn_metadata,
                 slot_mappings,
                 num_tokens_across_dp,
+                num_speculative_tokens,
                 cg_mode,
             )
 

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -30,6 +30,7 @@ logger = init_logger(__name__)
 
 class DFlashSpeculator(DraftModelSpeculator):
     _speculator_name = "DFlash"  # For logging, so we can share methods with subclasses
+    supports_dynamic_draft_shapes = True
 
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         super().__init__(vllm_config, device)
@@ -79,9 +80,12 @@ class DFlashSpeculator(DraftModelSpeculator):
         )
         # [0, 1, ..., N-1, 0, 1, ..., N-1, ...] -> the per-token column index into
         # draft_logits[req, step, :].
-        self.sample_col = torch.arange(
-            self.num_speculative_steps, dtype=torch.int32, device=device
-        ).repeat(self.max_num_reqs)
+        self.sample_cols = {
+            k: torch.arange(k, dtype=torch.int32, device=device).repeat(
+                self.max_num_reqs
+            )
+            for k in range(1, self.num_speculative_steps + 1)
+        }
 
         self.query_cudagraph_manager: DFlashCudaGraphManager | None = None
         self.draft_kv_cache_group_id: int = -1
@@ -116,11 +120,14 @@ class DFlashSpeculator(DraftModelSpeculator):
         else:
             cudagraph_mode = CUDAGraphMode.NONE
 
+        query_len_offset = 0 if self.sample_from_anchor else 1
         self.query_cudagraph_manager = DFlashCudaGraphManager(
             self.vllm_config,
             self.device,
             cudagraph_mode,
             decode_query_len=self.num_query_per_req,
+            query_len_offset=query_len_offset,
+            dynamic_draft_shapes=self.supports_dynamic_draft_shapes,
         )
 
     def capture(self) -> None:
@@ -237,6 +244,7 @@ class DFlashSpeculator(DraftModelSpeculator):
         attn_metadata: dict[str, Any] | None,
         slot_mappings: dict[str, torch.Tensor] | None,
         num_tokens_across_dp: torch.Tensor | None,
+        num_speculative_tokens: int,
         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
     ) -> None:
         last_hidden_states = self._run_model(
@@ -247,7 +255,7 @@ class DFlashSpeculator(DraftModelSpeculator):
             cudagraph_runtime_mode,
         )
 
-        num_sample = num_reqs * self.num_speculative_steps
+        num_sample = num_reqs * num_speculative_tokens
         sample_hidden_states = last_hidden_states[self.sample_indices[:num_sample]]
         # sample_pos is the predicted token's position Q; verification keys
         # Gumbel by the predecessor (Q-1). sample_draft adds +1, so pass Q-2.
@@ -257,11 +265,11 @@ class DFlashSpeculator(DraftModelSpeculator):
             self.sample_idx_mapping[:num_sample],
             self.temperature,
             self.seeds,
-            self.sample_col[:num_sample],
+            self.sample_cols[num_speculative_tokens][:num_sample],
             self.draft_logits,
         )
-        self.draft_tokens[:num_reqs] = draft_tokens.view(
-            num_reqs, self.num_speculative_steps
+        self.draft_tokens[:num_reqs, :num_speculative_tokens] = draft_tokens.view(
+            num_reqs, num_speculative_tokens
         )
 
     def _build_draft_attn_metadata(
@@ -274,12 +282,13 @@ class DFlashSpeculator(DraftModelSpeculator):
     ) -> dict[str, Any] | None:
         if not self.draft_attn_layer_names:
             return None
-        assert num_query_per_req is None  # Omitted for DFlash, read from self instead
+        if num_query_per_req is None:
+            num_query_per_req = self.num_query_per_req
         return super()._build_draft_attn_metadata(
             num_reqs,
             num_reqs_padded,
             num_tokens_padded,
-            num_query_per_req=self.num_query_per_req,
+            num_query_per_req=num_query_per_req,
             causal=causal,
         )
 
@@ -305,18 +314,29 @@ class DFlashSpeculator(DraftModelSpeculator):
         temperature: torch.Tensor,
         # [max_num_reqs]
         seeds: torch.Tensor,
+        num_speculative_tokens: int | None = None,
         num_tokens_across_dp: torch.Tensor | None = None,
         dummy_run: bool = False,
         skip_attn_for_dummy_run: bool = False,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
     ) -> torch.Tensor:
+        if num_speculative_tokens is None:
+            num_speculative_tokens = self.num_speculative_steps
+        if not 0 < num_speculative_tokens <= self.num_speculative_steps:
+            raise ValueError(
+                "num_speculative_tokens must be between 1 and "
+                f"{self.num_speculative_steps}, got {num_speculative_tokens}"
+            )
         num_reqs = input_batch.num_reqs
         num_target_tokens = input_batch.num_tokens
-        num_query_tokens = num_reqs * self.num_query_per_req
+        num_query_per_req = num_speculative_tokens + (
+            0 if self.sample_from_anchor else 1
+        )
+        num_query_tokens = num_reqs * num_query_per_req
         max_seq_len = input_batch.seq_lens_cpu_upper_bound[:num_reqs].max().item()
         self.draft_max_seq_len = min(
-            max_seq_len + self.num_query_per_req, self.max_model_len
+            max_seq_len + num_query_per_req, self.max_model_len
         )
 
         # NOTE: To avoid CPU-GPU synchronization without CPU knowing the
@@ -355,9 +375,10 @@ class DFlashSpeculator(DraftModelSpeculator):
                 attn_metadata=None,
                 slot_mappings=None,
                 num_tokens_across_dp=num_tokens_across_dp,
+                num_speculative_tokens=num_speculative_tokens,
                 cudagraph_runtime_mode=CUDAGraphMode.NONE,
             )
-            return self.draft_tokens[:num_reqs]
+            return self.draft_tokens[:num_reqs, :num_speculative_tokens]
 
         # The query slot mapping is written into the shared BlockTables slot_mappings.
         # That buffer's address is what the captured CUDA graph reads from at replay.
@@ -380,8 +401,8 @@ class DFlashSpeculator(DraftModelSpeculator):
                 self.block_tables.input_block_tables[gid],
                 self.block_tables.kernel_block_sizes[gid],
                 self.parallel_drafting_token_id,
-                self.num_query_per_req,
-                self.num_speculative_steps,
+                num_query_per_req,
+                num_speculative_tokens,
                 self.max_num_reqs,
                 self.max_num_tokens,
                 self.max_model_len,
@@ -412,7 +433,7 @@ class DFlashSpeculator(DraftModelSpeculator):
             self.query_cudagraph_manager,
             num_reqs,
             num_query_tokens,
-            uniform_token_count=self.num_query_per_req,
+            uniform_token_count=num_query_per_req,
             dp_size=self.dp_size,
             dp_rank=self.dp_rank,
             need_eager=is_profile,
@@ -427,6 +448,7 @@ class DFlashSpeculator(DraftModelSpeculator):
             num_reqs=num_reqs,
             num_reqs_padded=num_reqs_padded,
             num_tokens_padded=num_tokens_padded,
+            num_query_per_req=num_query_per_req,
             causal=self._group_causal,
         )
         draft_slot_mappings_by_layer = build_slot_mappings_by_layer(
@@ -448,10 +470,11 @@ class DFlashSpeculator(DraftModelSpeculator):
                 draft_attn_metadata,
                 draft_slot_mappings_by_layer,
                 num_tokens_across_dp=num_tokens_across_dp,
+                num_speculative_tokens=num_speculative_tokens,
                 cudagraph_runtime_mode=batch_desc.cg_mode,
             )
 
-        return self.draft_tokens[:num_reqs]
+        return self.draft_tokens[:num_reqs, :num_speculative_tokens]
 
 
 @triton.jit

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -36,6 +36,7 @@ from vllm.v1.worker.gpu.spec_decode.dspark.utils import load_dspark_model
 
 class DSparkSpeculator(DFlashSpeculator):
     _speculator_name = "DSpark"
+    supports_dynamic_draft_shapes = False
 
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         super().__init__(vllm_config, device)
@@ -154,10 +155,12 @@ class DSparkSpeculator(DFlashSpeculator):
         attn_metadata: dict[str, Any] | None,
         slot_mappings: dict[str, torch.Tensor] | None,
         num_tokens_across_dp: torch.Tensor | None,
+        num_speculative_tokens: int,
         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
     ) -> None:
         # Full draft step (captured under CUDA graph): parallel backbone forward
         # then sequential Markov sampling over its hidden state outputs.
+        assert num_speculative_tokens == self.num_speculative_steps
         head_hidden = self._run_model(
             num_tokens_padded,
             attn_metadata,

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -27,6 +27,8 @@ logger = init_logger(__name__)
 
 
 class BaseSpeculator(ABC):
+    supports_dynamic_draft_shapes = False
+
     @abstractmethod
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         pass
@@ -57,6 +59,7 @@ class BaseSpeculator(ABC):
         temperature: torch.Tensor,
         # [max_num_reqs]
         seeds: torch.Tensor,
+        num_speculative_tokens: int | None = None,
         num_tokens_across_dp: torch.Tensor | None = None,
         dummy_run: bool = False,
         skip_attn_for_dummy_run: bool = False,


### PR DESCRIPTION
## Purpose

Make DFlash's physical draft workload honor the batch-uniform speculative K
selected by the existing dynamic speculative-decoding scheduler.

Today the scheduler can request fewer than the configured maximum draft
tokens, but DFlash still builds and executes its maximum query shape before
the worker discards unused proposals. This change:

- carries the scheduled K in `ExecuteModelState`, binding it to the matching
  execute/sample iteration under async scheduling;
- skips proposal generation for K=0;
- advertises dynamic physical shapes as a speculator capability, enabled only
  for DFlash;
- sizes DFlash query inputs, attention metadata, sampling buffers, and CUDA
  graph dispatch from the scheduled K; and
- publishes exactly K proposals while retaining the configured global maximum
  for allocation and graph coverage.

Unsupported speculators keep their existing maximum physical shape. DSpark
explicitly opts out because its sequential head needs separate model-specific
validation. The common K=0 skip applies to all speculators.

### Related work

This does not duplicate #48692. That PR implements per-request adaptive
verification and explicitly initializes DFlash with
`allow_dynamic_decode_shapes=False`; this PR shortens the batch-uniform
DFlash drafter computation selected by the existing scheduler. It is also
separate from the per-request proposal API in #48202/#48204.

PR #47737 handles DSpark K=0 graph capture, #46399 disables dynamic schedules
for fixed-K proposers, and #48329 addresses autoregressive graph selection.
This PR does not replace those changes.

## Test Plan

```bash
pytest -q \
  tests/v1/worker/test_gpu_model_runner_v2_spec_decode.py \
  tests/v1/worker/test_gpu_model_runner_v2_eplb.py

mypy tests/v1/worker/test_gpu_model_runner_v2_spec_decode.py
```

Relevant Ruff, Ruff format, and typos pre-commit hooks were run on every
changed file.

GPU validation uses one NVIDIA H100 80GB, Qwen3.5-4B with
Qwen3.5-4B-DFlash, Model Runner V2, async scheduling, compiled CUDA graphs,
and K=0/1/3/7. The serving matrix covers concurrency 1/64/128/256 with three
repeats per point.

## Test Result

- Worker tests: 7 passed.
- Mypy: no issues.
- Relevant pre-commit hooks: passed.
- Serving smoke: 48/48 runs completed, zero failed requests, and DFlash full
  CUDA graph capture/replay succeeded for K=1/3/7; K=0 skipped the drafter.

A five-repeat natural mixed-prompt A/B isolates the physical-shape change:

| Batch | K=0 TPS delta | K=1 TPS delta | K=3 TPS delta | K=7 control |
|---:|---:|---:|---:|---:|
| 64 | +37.3% | +15.3% | +2.3% | -3.7% |
| 128 | +40.0% | +5.1% | +4.4% | -2.6% |
| 256 | +36.9% | +6.2% | +4.6% | +0.4% |

K=7 retains the original maximum physical shape and is the no-op control; its
small positive/negative deltas indicate run/system variance. The lower-K gains
come from removing unused drafter work. Acceptance length for each fixed K is
stable across batch sizes (K=1: 1.879-1.882, K=3: 3.158-3.160, K=7:
4.415-4.429).

An independent standard Sonnet serving sweep covers K=0/1/3/7 and concurrency
1/64/128/256 with three repeats per point (48 runs, zero failures). At
concurrency 1, robust TPS rises from 204.33 at K=0 to 317.27 at K=7 (+55.3%).
At concurrency 64, K=0 reaches 3511.24 while the best positive candidate,
K=3, reaches 3042.50. TPS, `tpot:50` goodput, and mean TPOT therefore all
select the genuinely dynamic schedule `[[1, 63, 7], [64, 256, 0]]`.

The global maximum K still controls worker allocation, scheduler lookahead,
and KV-cache reservation. This patch reduces draft compute, not reserved KV
memory, and does not add an online K-selection policy.

## AI assistance

This patch was developed with OpenAI Codex assistance and the commit includes
the required attribution trailer. This is a Draft PR; the human submitter must
review every changed line and confirm the test/benchmark evidence before
marking it ready for review.
