### PR TITLE
observability: Make prefix cache hit-rate sliding window size configurable

### DIFF
--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -288,7 +288,8 @@ every 5 seconds with some key metrics:
   seconds
 - The number of new tokens generated per second over the past 5
   seconds
-- The prefix cache hit rate over the most recent 1k kv-cache block queries
+- The prefix cache hit rate over the most recent N requests
+  (configurable via `--prefix-cache-hit-rate-window`, default: 1000)
 
 ### Metrics Publishing - Prometheus
 

--- a/tests/v1/engine/test_engine_args.py
+++ b/tests/v1/engine/test_engine_args.py
@@ -4,6 +4,7 @@
 from argparse import ArgumentError
 
 import pytest
+from pydantic import ValidationError
 
 from vllm.config import VllmConfig
 from vllm.engine.arg_utils import EngineArgs
@@ -128,3 +129,24 @@ def test_mm_prefix_lm_raises_batched_tokens_floor():
         vllm_config = engine_args.create_engine_config(UsageContext.OPENAI_API_SERVER)
 
     assert vllm_config.scheduler_config.max_num_batched_tokens >= 2496
+
+
+def test_prefix_cache_hit_rate_window_from_cli():
+    """CLI flag --prefix-cache-hit-rate-window propagates to ObservabilityConfig."""
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+
+    # Default value is 1000 (backward compatible)
+    args = parser.parse_args([])
+    vllm_config = EngineArgs.from_cli_args(args=args).create_engine_config()
+    assert vllm_config.observability_config.prefix_cache_hit_rate_window == 1000
+
+    # Custom value propagates correctly end-to-end
+    args = parser.parse_args(["--prefix-cache-hit-rate-window", "500"])
+    vllm_config = EngineArgs.from_cli_args(args=args).create_engine_config()
+    assert vllm_config.observability_config.prefix_cache_hit_rate_window == 500
+
+    # Invalid value (zero) is rejected by Pydantic Field(gt=0)
+    parser.exit_on_error = False
+    with pytest.raises(ValidationError):
+        args = parser.parse_args(["--prefix-cache-hit-rate-window", "0"])
+        EngineArgs.from_cli_args(args=args).create_engine_config()

--- a/tests/v1/engine/test_engine_args.py
+++ b/tests/v1/engine/test_engine_args.py
@@ -4,6 +4,7 @@
 from argparse import ArgumentError
 
 import pytest
+from pydantic import ValidationError
 
 from vllm.engine.arg_utils import EngineArgs
 from vllm.usage.usage_lib import UsageContext
@@ -101,6 +102,7 @@ def test_mm_prefix_lm_raises_batched_tokens_floor():
     assert vllm_config.scheduler_config.max_num_batched_tokens >= 2496
 
 
+<<<<<<< HEAD
 def test_data_parallel_start_rank_zero_infers_hybrid_lb():
     """An explicit --data-parallel-start-rank 0 must be treated the same as
     any other explicit start rank when inferring hybrid LB mode, not as
@@ -116,3 +118,24 @@ def test_data_parallel_start_rank_zero_infers_hybrid_lb():
 
     assert vllm_config.parallel_config.data_parallel_hybrid_lb is True
     assert vllm_config.parallel_config.data_parallel_rank == 0
+=======
+def test_prefix_cache_hit_rate_window_from_cli():
+    """CLI flag --prefix-cache-hit-rate-window propagates to ObservabilityConfig."""
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+
+    # Default value is 1000 (backward compatible)
+    args = parser.parse_args([])
+    vllm_config = EngineArgs.from_cli_args(args=args).create_engine_config()
+    assert vllm_config.observability_config.prefix_cache_hit_rate_window == 1000
+
+    # Custom value propagates correctly end-to-end
+    args = parser.parse_args(["--prefix-cache-hit-rate-window", "500"])
+    vllm_config = EngineArgs.from_cli_args(args=args).create_engine_config()
+    assert vllm_config.observability_config.prefix_cache_hit_rate_window == 500
+
+    # Invalid value (zero) is rejected by Pydantic Field(gt=0)
+    parser.exit_on_error = False
+    with pytest.raises(ValidationError):
+        args = parser.parse_args(["--prefix-cache-hit-rate-window", "0"])
+        EngineArgs.from_cli_args(args=args).create_engine_config()
+>>>>>>> a3a6eb77c (observability: make prefix cache hit-rate window configurable)

--- a/vllm/config/observability.py
+++ b/vllm/config/observability.py
@@ -53,6 +53,9 @@ class ObservabilityConfig:
     kv_cache_metrics_sample: float = Field(default=0.01, gt=0, le=1)
     """Sampling rate for KV cache metrics (0.0, 1.0]. Default 0.01 = 1% of blocks."""
 
+    prefix_cache_hit_rate_window: int = Field(default=1000, gt=0)
+    """Window size (number of recent requests) for calculating prefix cache hit rate."""
+
     cudagraph_metrics: bool = False
     """Enable CUDA graph metrics (number of padded/unpadded tokens, runtime cudagraph
     dispatch modes, and their observed frequencies at every logging interval)."""

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -636,6 +636,9 @@ class EngineArgs:
     kv_cache_metrics_sample: float = get_field(
         ObservabilityConfig, "kv_cache_metrics_sample"
     )
+    prefix_cache_hit_rate_window: int = get_field(
+        ObservabilityConfig, "prefix_cache_hit_rate_window"
+    )
     cudagraph_metrics: bool = ObservabilityConfig.cudagraph_metrics
     enable_layerwise_nvtx_tracing: bool = (
         ObservabilityConfig.enable_layerwise_nvtx_tracing
@@ -1369,6 +1372,10 @@ class EngineArgs:
             **observability_kwargs["kv_cache_metrics_sample"],
         )
         observability_group.add_argument(
+            "--prefix-cache-hit-rate-window",
+            **observability_kwargs["prefix_cache_hit_rate_window"],
+        )
+        observability_group.add_argument(
             "--cudagraph-metrics",
             **observability_kwargs["cudagraph_metrics"],
         )
@@ -1799,6 +1806,7 @@ class EngineArgs:
             collect_detailed_traces=self.collect_detailed_traces,
             kv_cache_metrics=self.kv_cache_metrics,
             kv_cache_metrics_sample=self.kv_cache_metrics_sample,
+            prefix_cache_hit_rate_window=self.prefix_cache_hit_rate_window,
             cudagraph_metrics=self.cudagraph_metrics,
             enable_layerwise_nvtx_tracing=self.enable_layerwise_nvtx_tracing,
             enable_mfu_metrics=self.enable_mfu_metrics,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -656,6 +656,9 @@ class EngineArgs:
     kv_cache_metrics_sample: float = get_field(
         ObservabilityConfig, "kv_cache_metrics_sample"
     )
+    prefix_cache_hit_rate_window: int = get_field(
+        ObservabilityConfig, "prefix_cache_hit_rate_window"
+    )
     cudagraph_metrics: bool = ObservabilityConfig.cudagraph_metrics
     enable_layerwise_nvtx_tracing: bool = (
         ObservabilityConfig.enable_layerwise_nvtx_tracing
@@ -1477,6 +1480,10 @@ class EngineArgs:
             **observability_kwargs["kv_cache_metrics_sample"],
         )
         observability_group.add_argument(
+            "--prefix-cache-hit-rate-window",
+            **observability_kwargs["prefix_cache_hit_rate_window"],
+        )
+        observability_group.add_argument(
             "--cudagraph-metrics",
             **observability_kwargs["cudagraph_metrics"],
         )
@@ -1929,6 +1936,7 @@ class EngineArgs:
             collect_detailed_traces=self.collect_detailed_traces,
             kv_cache_metrics=self.kv_cache_metrics,
             kv_cache_metrics_sample=self.kv_cache_metrics_sample,
+            prefix_cache_hit_rate_window=self.prefix_cache_hit_rate_window,
             cudagraph_metrics=self.cudagraph_metrics,
             enable_layerwise_nvtx_tracing=self.enable_layerwise_nvtx_tracing,
             enable_mfu_metrics=self.enable_mfu_metrics,

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -105,10 +105,18 @@ class LoggingStatLogger(StatLoggerBase):
         self.last_scheduler_stats = SchedulerStats()
 
         # Caching metrics. This cannot be reset.
-        # TODO: Make the interval configurable.
-        self.prefix_caching_metrics = CachingMetrics()
-        self.connector_prefix_caching_metrics = CachingMetrics()
-        self.mm_caching_metrics = CachingMetrics()
+        prefix_cache_window = (
+            vllm_config.observability_config.prefix_cache_hit_rate_window
+        )
+        self.prefix_caching_metrics = CachingMetrics(
+            max_recent_requests=prefix_cache_window
+        )
+        self.connector_prefix_caching_metrics = CachingMetrics(
+            max_recent_requests=prefix_cache_window
+        )
+        self.mm_caching_metrics = CachingMetrics(
+            max_recent_requests=prefix_cache_window
+        )
 
         model_config = self.vllm_config.model_config
         is_diffusion = model_config is not None and model_config.is_diffusion


### PR DESCRIPTION
## Summary

Expose the prefix cache hit-rate sliding window size as a user-configurable parameter, resolving the `# TODO: Make the interval configurable.` in `vllm/v1/metrics/loggers.py`.

## Motivation

`LoggingStatLogger` constructs three `CachingMetrics` instances with a hardcoded `max_recent_requests=1000`. This value controls the rolling window over which the prefix cache hit rate is calculated and reported in stdout logs.

For workloads with significantly fewer or more requests per logging interval, users had no way to tune this window without modifying source code.

## Implementation

- **`vllm/config/observability.py`**: Added `prefix_cache_hit_rate_window: int = Field(default=1000, gt=0)` to `ObservabilityConfig`.
- **`vllm/engine/arg_utils.py`**: Wired the new field through `EngineArgs` class attribute, CLI registration (`--prefix-cache-hit-rate-window`), and `create_observability_config()` builder.
- **`vllm/v1/metrics/loggers.py`**: Reads `vllm_config.observability_config.prefix_cache_hit_rate_window` and passes it to the three `CachingMetrics` instances. Removed the resolved TODO comment.
- **`docs/design/metrics.md`**: Updated the description of the `LoggingStatLogger` output to reflect that the window is now configurable rather than fixed at 1k.

## Backward Compatibility

The default value is `1000`, matching the previous hardcoded value. Existing configurations are unaffected unless the user explicitly passes `--prefix-cache-hit-rate-window`.

## Testing

Added `test_prefix_cache_hit_rate_window_from_cli` to `tests/v1/engine/test_engine_args.py`. The test verifies:
- Default value is `1000`
- A custom value (`500`) propagates correctly end-to-end
- An invalid value (`0`) is rejected with `pydantic.ValidationError` (enforced by `Field(gt=0)`)
