### PR TITLE
[XPU][UT] Fix encoder scoring vision UT drift with XPU-specific text-only tolerance

### DIFF
--- a/tests/entrypoints/pooling/scoring/test_cross_encoder_online_vision.py
+++ b/tests/entrypoints/pooling/scoring/test_cross_encoder_online_vision.py
@@ -45,9 +45,12 @@ BACKEND_TOL: dict[str, float] = {
 # ~0.10 text-vs-text value. Keep the relative tolerances tight and add only a
 # small absolute floor for the affected backends.
 # TRITON_ATTN: gfx942/ROCm 7.2 drifts ~0.008 abs on text-vs-text (~7.9% rel).
+# XPU(auto): observed text-vs-text drift ~0.0119 abs (~11.9% rel).
+# Apply this only to text-vs-text checks; keep image-related abs tol unchanged.
 BACKEND_ABS_TOL: dict[str, float] = {
     "default": 0.0,
     "auto": 0.007,
+    "XPU": 0.012,
     "ROCM_AITER_FA": 0.005,
     "TRITON_ATTN": 0.009,
     "FLEX_ATTENTION": 0.006,
@@ -76,9 +79,15 @@ def get_abs_tol(backend: str) -> float:
     return BACKEND_ABS_TOL.get(backend, BACKEND_ABS_TOL["default"])
 
 
+def is_text_vs_text_label(label: str) -> bool:
+    return label == "text_vs_text" or label.endswith("_text_vs_text")
+
+
 def assert_score(actual: float, expected: float, backend: str, label: str):
     tol = get_tol(backend)
     abs_tol = get_abs_tol(backend)
+    if current_platform.is_xpu() and is_text_vs_text_label(label):
+        abs_tol = BACKEND_ABS_TOL["XPU"]
     diff = abs(actual - expected)
     rel_diff = diff / abs(expected) if expected != 0 else diff
     print(


### PR DESCRIPTION
## Summary
This PR fixes XPU UT failures in cross-encoder online vision scoring by applying an XPU-specific absolute tolerance only to text-vs-text assertions, while keeping image-related thresholds unchanged.

## What changed

- Add XPU tolerance entry in tests/entrypoints/pooling/scoring/test_cross_encoder_online_vision.py
- Introduce text-only label gating so XPU override is applied only to text-vs-text checks
- Keep existing image and text+image tolerance behavior unchanged

## Root cause
On XPU (auto backend), text-vs-text scores show a stable absolute drift (~0.0119) versus the golden baseline, while image-related checks remain within tolerance. This makes the existing `abs_tol=0.007` too strict for text-only paths and causes deterministic assertion failures:

```text
AssertionError: [auto] text_vs_text: score mismatch — actual=0.112317, expected=0.100404, rel_diff=0.1187, tol=0.05, abs_tol=0.007
E       assert 0.11231671273708344 == 0.10040374100208282 ± 0.007
```

and similarly for list/rerank text paths (`list[0]_text_vs_text`, `rerank[0]_text_vs_text`, `paired[0]_text_vs_text`).


## Example to reproduce (without this PR)
```text
VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -sv tests/entrypoints/pooling/scoring/test_cross_encoder_online_vision.py::test_score_api_queries_str_documents_str[auto]
```

Also reproducible in list/rerank text-vs-text paths:
```text
VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -sv tests/entrypoints/pooling/scoring/test_cross_encoder_online_vision.py::test_score_api_queries_str_documents_list[auto]
VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -sv tests/entrypoints/pooling/scoring/test_cross_encoder_online_vision.py::test_rerank_api_queries_str_documents_list[auto]
VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -sv tests/entrypoints/pooling/scoring/test_cross_encoder_online_vision.py::test_score_api_queries_list_documents_list[auto]
```