### PR TITLE
[Bench][Bugfix] Avoid forcing ignore_eos for structured-output benchmarks

### DIFF
--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -66,6 +66,19 @@ def _merge_overrides(base: dict | None, override: dict | None) -> dict | None:
     return {**(base or {}), **(override or {})}
 
 
+def _has_structured_output(extra_body: dict[str, Any] | None) -> bool:
+    if not extra_body:
+        return False
+    if "structured_outputs" in extra_body:
+        return True
+
+    response_format = extra_body.get("response_format")
+    return isinstance(response_format, dict) and response_format.get("type") in (
+        "json_object",
+        "json_schema",
+    )
+
+
 TERM_PLOTLIB_AVAILABLE = (importlib.util.find_spec("termplotlib") is not None) and (
     shutil.which("gnuplot") is not None
 )
@@ -2009,11 +2022,13 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
         args.spec_bench_output_len = args.output_len
         args.prefix_repetition_output_len = args.output_len
 
-    # when using random datasets, default to ignoring EOS
-    # so generation runs to the requested length
+    # When using random datasets, default to ignoring EOS so generation runs
+    # to the requested length. Structured-output requests must stop when their
+    # grammar completes; forcing them past EOS produces invalid trailing tokens.
     if (
         args.dataset_name in ("random", "random-mm")
         and args.backend in OPENAI_COMPATIBLE_BACKENDS
+        and not _has_structured_output(args.extra_body)
     ):
         args.ignore_eos = True
 


### PR DESCRIPTION


## Purpose
 Avoid forcing ignore_eos for structured-output benchmarks.
When benchmarking the performance of `structured_outputs`, I kept running into FSM errors. After investigating, I found that https://github.com/vllm-project/vllm/pull/28227 forces `ignore_eos` to be enabled for the random dataset, which causes the FSM to enter an invalid state.



## Test Plan

```
vllm bench serve \
    --backend openai-chat \
    --base-url http://127.0.0.1:8001 \
    --endpoint /v1/chat/completions \
    --dataset-name random \
    --random-input-len 64 \
    --random-output-len 64 \
    --num-prompts 200 \
    --request-rate inf \
    --max-concurrency 32 \
    --temperature 0 \
    --extra-body \
   '{"chat_template_kwargs":{"enable_thinking":false},"structured_outputs":{"json":{"type":"object","properties":{"name":{"type":"string","minLength":1,"maxLength":16},"age":{"type":"integer","minimum":0,"maximum":120},"active":{"type":"boolean"}},"required":["name","age","active"],"additionalProperties":false}}}' \
    --save-result \
    --save-detailed \
    --result-dir ./tmp \
    --result-filename structured-output-e2e.json
```
```
(APIServer pid=978473) INFO:     127.0.0.1:54074 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(EngineCore pid=983460) ERROR 07-20 16:44:28 [scheduler.py:1744] Unexpected: grammar rejected tokens [198] for request chatcmpl-bench-dbc09e64-64-87a592b8. Terminating request.
(APIServer pid=978473) ERROR 07-20 16:44:28 [serving.py:173] Request chatcmpl-bench-dbc09e64-64 failed with an internal error during generation
(APIServer pid=978473) INFO:     127.0.0.1:54036 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(EngineCore pid=983460) ERROR 07-20 16:44:28 [scheduler.py:1744] Unexpected: grammar rejected tokens [198] for request chatcmpl-bench-dbc09e64-65-820da3f0. Terminating request.
(APIServer pid=978473) ERROR 07-20 16:44:28 [serving.py:173] Request chatcmpl-bench-dbc09e64-65 failed with an internal error during generation
(APIServer pid=978473) INFO:     127.0.0.1:53880 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(EngineCore pid=983460) ERROR 07-20 16:44:28 [scheduler.py:1744] Unexpected: grammar rejected tokens [198] for request chatcmpl-bench-dbc09e64-68-9bca436f. Terminating request.
(EngineCore pid=983460) ERROR 07-20 16:44:28 [scheduler.py:1744] Unexpected: grammar rejected tokens [198] for request chatcmpl-bench-dbc09e64-75-a29920c2. Terminating request.
(EngineCore pid=983460) ERROR 07-20 16:44:28 [scheduler.py:1744] Unexpected: grammar rejected tokens [198] for request chatcmpl-bench-dbc09e64-82-8c67e573. Terminating request.

```
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

