### PR TITLE
[v1][DP] Propagate KV cache usage to DP load balancer

### DIFF
--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -139,7 +139,7 @@ class DPCoordinator:
 
 class EngineState:
     def __init__(self):
-        self.request_counts = [0, 0]  # [waiting, running]
+        self.request_counts = [0, 0, 0.0]  # [waiting, running, kv_cache_usage]
 
 
 class DPCoordinatorProc:
@@ -400,6 +400,7 @@ class DPCoordinatorProc:
                             )
                         stats[0] = scheduler_stats.num_waiting_reqs
                         stats[1] = scheduler_stats.num_running_reqs
+                        stats[2] = scheduler_stats.kv_cache_usage
                         stats_changed = True
 
                     # Wave coordination: handle wave completion and start notifications
@@ -452,8 +453,8 @@ class DPCoordinatorProc:
         wave_encoded = msgspec.msgpack.encode((wave, exclude_engine_index))
         socket.send_multipart((EngineCoreRequestType.START_DP_WAVE.value, wave_encoded))
 
-    def _get_engine_counts(self, do_copy=False) -> list[list[int]]:
-        """Return list of [waiting, running] count lists for each engine."""
+    def _get_engine_counts(self, do_copy=False) -> list[list[int | float]]:
+        """Return list of [waiting, running, kv_cache_usage] for each engine."""
         if do_copy:
             return [copy.copy(e.request_counts) for e in self.engines]
         return [e.request_counts for e in self.engines]

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1221,9 +1221,11 @@ class DPAsyncMPClient(AsyncMPClient):
             client_index,
         )
 
-        # List of [waiting, running] pair per engine.
+        # List of [waiting, running, kv_cache_usage] per engine.
         # Used only by DPLBAsyncMPClient subclass.
-        self.lb_engines: list[list[int]] = [[0, 0] for _ in self.core_engines]
+        self.lb_engines: list[list[int | float]] = [
+            [0, 0, 0.0] for _ in self.core_engines
+        ]
 
         self.eep_scaling_cache: ElasticScalingCache | None = None
 
@@ -1301,7 +1303,7 @@ class DPAsyncMPClient(AsyncMPClient):
                             )
                             if len(self.lb_engines) < new_engine_count:
                                 self.lb_engines = self.lb_engines + [
-                                    [0, 0]
+                                    [0, 0, 0.0]
                                     for _ in range(
                                         new_engine_count - len(self.lb_engines)
                                     )
@@ -1421,15 +1423,20 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
             # TODO use P2C alg for larger DP sizes
             num_engines = len(current_counts)
             min_score = sys.maxsize
+            min_kv_usage = float("inf")
             eng_index = 0
             for i in range(num_engines):
                 # Start from client_index to help with balancing when engines
                 # are empty.
                 idx = (self.eng_start_index + i) % num_engines
-                waiting, running = current_counts[idx]
+                waiting, running, kv_usage = current_counts[idx]
                 score = waiting * 4 + running
                 if score < min_score:
                     min_score = score
+                    min_kv_usage = kv_usage
+                    eng_index = idx
+                elif score == min_score and kv_usage < min_kv_usage:
+                    min_kv_usage = kv_usage
                     eng_index = idx
             # Increment local waiting count for better balancing between stats
             # updates from the coordinator (which happen every 100ms).


### PR DESCRIPTION
Fixes #48808

## Summary

This PR propagates `kv_cache_usage` from the scheduler to the DP load balancer and uses it as an additional routing signal.

Previously, the DP load balancer only had access to the number of waiting and running requests for each engine. This change extends the per-engine state to also include KV cache usage.

## Changes

* Propagate `scheduler_stats.kv_cache_usage` through the DP coordinator.
* Extend the per-engine state from:

  * `[waiting, running]`
  * to `[waiting, running, kv_cache_usage]`
* Update the DP client to store the additional metric for each engine.
* Use `kv_cache_usage` as a tie-breaker when multiple engines have the same routing score.
* Update related type hints and comments.

## Routing Behavior

The existing routing policy remains unchanged:

* Primary routing score: `waiting * 4 + running`
* If multiple engines have the same score, the engine with lower `kv_cache_usage` is selected.
