### PR TITLE
[ROCm][CI] Language Models tests setup update

### DIFF
--- a/tests/models/language/generation/conftest.py
+++ b/tests/models/language/generation/conftest.py
@@ -2,36 +2,23 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Pytest configuration for vLLM language generation tests."""
 
-import os
 import warnings
 
+import pytest
 import torch
 
 from vllm.platforms import current_platform
 
 
-def pytest_configure(config):
-    """Early ROCm configuration that must happen before test collection."""
+@pytest.fixture(scope="package", autouse=True)
+def rocm_sdp_config():
     if not current_platform.is_rocm():
+        yield
         return
 
-    # Disable skinny GEMM on ROCm to avoid non-deterministic results
-    # from atomic reductions in wvSplitKrc kernel.
-    # See: https://github.com/vllm-project/vllm/pull/33493#issuecomment-3906083975
-    os.environ["VLLM_ROCM_USE_SKINNY_GEMM"] = "0"
-    warnings.warn(
-        "ROCm: Set VLLM_ROCM_USE_SKINNY_GEMM=0 to avoid non-deterministic "
-        "results from skinny GEMM atomic reductions",
-        UserWarning,
-        stacklevel=1,
-    )
-
-
-def pytest_sessionstart(session):
-    """Configure ROCm-specific settings before test session starts."""
-    if not current_platform.is_rocm():
-        return
-
+    prev_flash = torch.backends.cuda.flash_sdp_enabled()
+    prev_mem = torch.backends.cuda.mem_efficient_sdp_enabled()
+    prev_math = torch.backends.cuda.math_sdp_enabled()
     # Disable Flash/MemEfficient SDP on ROCm to avoid HF Transformers
     # accuracy issues: https://github.com/vllm-project/vllm/issues/30167
     # TODO: Remove once ROCm SDP accuracy issues are resolved on HuggingFace
@@ -44,3 +31,26 @@ def pytest_sessionstart(session):
         UserWarning,
         stacklevel=1,
     )
+
+    try:
+        yield
+    finally:
+        torch.backends.cuda.enable_flash_sdp(prev_flash)
+        torch.backends.cuda.enable_mem_efficient_sdp(prev_mem)
+        torch.backends.cuda.enable_math_sdp(prev_math)
+
+
+@pytest.fixture(autouse=True)
+def rocm_skinny_gemm_config(monkeypatch):
+    # Disable skinny GEMM on ROCm to avoid non-deterministic results
+    # from atomic reductions in wvSplitKrc kernel.
+    # See: https://github.com/vllm-project/vllm/pull/33493#issuecomment-3906083975
+    if current_platform.is_rocm():
+        monkeypatch.setenv("VLLM_ROCM_USE_SKINNY_GEMM", "0")
+        warnings.warn(
+            "ROCm: Set VLLM_ROCM_USE_SKINNY_GEMM=0 to avoid non-deterministic "
+            "results from skinny GEMM atomic reductions",
+            UserWarning,
+            stacklevel=1,
+        )
+    yield

--- a/tests/models/language/pooling/conftest.py
+++ b/tests/models/language/pooling/conftest.py
@@ -4,16 +4,22 @@
 
 import warnings
 
+import pytest
 import torch
 
 from vllm.platforms import current_platform
 
 
-def pytest_sessionstart(session):
-    """Configure ROCm-specific settings before test session starts."""
+@pytest.fixture(scope="package", autouse=True)
+def rocm_sdp_config():
     if not current_platform.is_rocm():
+        yield
         return
 
+    prev_flash = torch.backends.cuda.flash_sdp_enabled()
+    prev_mem = torch.backends.cuda.mem_efficient_sdp_enabled()
+    prev_math = torch.backends.cuda.math_sdp_enabled()
+    prev_matmul = torch.get_float32_matmul_precision()
     # Disable Flash/MemEfficient SDP on ROCm to avoid HF Transformers
     # accuracy issues: https://github.com/vllm-project/vllm/issues/30167
     # TODO: Remove once ROCm SDP accuracy issues are resolved on HuggingFace
@@ -27,3 +33,11 @@ def pytest_sessionstart(session):
         UserWarning,
         stacklevel=1,
     )
+
+    try:
+        yield
+    finally:
+        torch.backends.cuda.enable_flash_sdp(prev_flash)
+        torch.backends.cuda.enable_mem_efficient_sdp(prev_mem)
+        torch.backends.cuda.enable_math_sdp(prev_math)
+        torch.set_float32_matmul_precision(prev_matmul)


### PR DESCRIPTION
## Purpose
Fix failing TitanML/tiny-mixtral tests in mi355_1:Language Models Tests (Standard)

The test command for mi355_1:Language Models Tests is `pytest -v -s models/language -m 'core_model and (not slow_test)'`, referenced to as the `bulk` command in the rest of the text.
Two tests fail in this TG:
 - models/language/generation/test_common.py::test_models[True-True-5-32-TitanML/tiny-mixtral] - AssertionError: Test3
 - models/language/generation/test_common.py::test_models[False-True-5-32-TitanML/tiny-mixtral] - AssertionError: Test3

However when the failing tests are launched individually via `pytest -s -v "models/language/generation/test_common.py::test_models[True-True-5-32-TitanML/tiny-mixtral]"`
they both pass. 

This is caused by the necessary setup in language/generation/conftest.py not being applied when the tests are launched in `bulk`.
SDP flags are set in `pytest_sessionstart`, which gets applied when the tests are launched individually. 
According to pytest docs `pytest_sessionstart` is [("Called after the Session object has been created and before performing collection and entering the run test loop.")](https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_sessionstart). The conftest.py of `models/language/generation` is not parsed until *after* collection starts for the `bulk` command(the root directory for the `bulk` command is /models/language), so the `pytest_startsession` generation defines is not executed.
The `pytest_configure` will be [executed](https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_configure), however the issue with using `pytest_configure` for the `bulk` command is that it will modify global state not only for the `generation` tests but also for the `pooling` tests, some of which also get invoked by the `bulk` command, leading to state pollution.

The PR avoids the two issues by using appropriately scoped test fixtures so that necessary changes get applied regardless of the way the tests get collected.

The same TG is run on MI300 hardware as well, where it previously passed, and it still passes with the changes, so MI300 is unaffected.

The pooling conftest has also been updated for consistency.

## Test Plan
`pytest -v -s models/language -m 'core_model and (not slow_test)'`

## Test Result
Previously:
=================================================================== short test summary info ====================================================================
FAILED models/language/generation/test_common.py::test_models[True-True-5-32-TitanML/tiny-mixtral] - AssertionError: Test3:
FAILED models/language/generation/test_common.py::test_models[False-True-5-32-TitanML/tiny-mixtral] - AssertionError: Test3:
======================================= 2 failed, 13 passed, 9 skipped, 349 deselected, 72 warnings in 980.17s (0:16:20) =======================================

Now:
========================================= 15 passed, 9 skipped, 349 deselected, 105 warnings in 631.09s (0:10:31) ==========================================
