### PR TITLE
[Bugfix] Disable DeepGEMM on GH200 to workaround illegal memory access

### DIFF
--- a/tests/cuda/test_platform_capabilities.py
+++ b/tests/cuda/test_platform_capabilities.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Test platform capability detection for DeepGEMM support."""
+
+from unittest.mock import patch
+
+from vllm.platforms.cuda import CudaPlatform
+
+
+def test_gh200_excluded_from_deep_gemm():
+    """GH200 (integrated GPU, capability 90) should not support DeepGEMM."""
+    with (
+        patch.object(
+            CudaPlatform,
+            "is_integrated_gpu",
+            classmethod(lambda cls, device_id=0: True),
+        ),
+        patch.object(
+            CudaPlatform,
+            "is_device_capability",
+            classmethod(lambda cls, cap, device_id=0: cap == 90),
+        ),
+        patch.object(
+            CudaPlatform,
+            "is_device_capability_family",
+            classmethod(lambda cls, cap, device_id=0: False),
+        ),
+    ):
+        assert CudaPlatform.support_deep_gemm() is False
+
+
+def test_hopper_discrete_supports_deep_gemm():
+    """Discrete Hopper (non-integrated, capability 90) supports DeepGEMM."""
+    with (
+        patch.object(
+            CudaPlatform,
+            "is_integrated_gpu",
+            classmethod(lambda cls, device_id=0: False),
+        ),
+        patch.object(
+            CudaPlatform,
+            "is_device_capability",
+            classmethod(lambda cls, cap, device_id=0: cap == 90),
+        ),
+        patch.object(
+            CudaPlatform,
+            "is_device_capability_family",
+            classmethod(lambda cls, cap, device_id=0: False),
+        ),
+    ):
+        assert CudaPlatform.support_deep_gemm() is True
+
+
+def test_dgx_spark_blackwell_uma_supports_deep_gemm():
+    """DGX Spark (integrated GPU, SM 100 family) should support DeepGEMM."""
+    with (
+        patch.object(
+            CudaPlatform,
+            "is_integrated_gpu",
+            classmethod(lambda cls, device_id=0: True),
+        ),
+        patch.object(
+            CudaPlatform,
+            "is_device_capability",
+            classmethod(lambda cls, cap, device_id=0: False),
+        ),
+        patch.object(
+            CudaPlatform,
+            "is_device_capability_family",
+            classmethod(lambda cls, cap, device_id=0: cap == 100),
+        ),
+    ):
+        assert CudaPlatform.support_deep_gemm() is True

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -662,7 +662,22 @@ class CudaPlatformBase(Platform):
 
     @classmethod
     def support_deep_gemm(cls) -> bool:
-        """Currently, only Hopper and Blackwell GPUs are supported."""
+        """Check if DeepGEMM is supported on the current platform.
+
+        Discrete Hopper and Blackwell GPUs are supported. GH200 (SM 9.0
+        integrated GPU with UMA) is excluded because DeepGEMM JIT kernels
+        fail on this platform. See GH issue #49158.
+        """
+        # FIXME: This is a temporary workaround for a DeepGEMM bug: its JIT
+        # kernels trigger illegal memory accesses on GH200 (SM 9.0 integrated
+        # GPU / UMA). Remove this check once DeepGEMM upstream fixes GH200
+        # support. See vllm-project/vllm#49158.
+        if cls.is_device_capability(90) and cls.is_integrated_gpu():
+            logger.warning_once(
+                "DeepGEMM is disabled on GH200 (SM 9.0 UMA). "
+                "Falling back to alternative FP8 GEMM kernels."
+            )
+            return False
         return (
             cls.is_device_capability(90)
             or cls.is_device_capability_family(100)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

> **Note:** I haven't verified this in a real GH200 environment yet. I'll first
> rely on GitHub CI for regression testing. Once I get access to a GH200 machine,
> I'll run the end-to-end check below and update this note.

## Purpose

Fix #49158.

Running `MiniMaxAI/MiniMax-M2.7` with TP2 and FP8 KV cache on NVIDIA GH200NVL2
(SM 9.0 integrated GPU / UMA) crashes during vLLM 0.25.1 startup:

```
RuntimeError: CUDA driver error (.../deepgemm-src/.../runtime_utils.hpp:144): 700
(CUDA_ERROR_ILLEGAL_ADDRESS, an illegal memory access was encountered)
```

The stack trace ends in `vllm.utils.deep_gemm.fp8_gemm_nt` → `_fp8_gemm_nt_impl`,
i.e. **DeepGEMM's JIT kernel triggers an illegal memory access on GH200**. This
is a compatibility issue in the third-party DeepGEMM library with GH200's UMA
architecture, not a bug in vLLM model code.

### Duplicate-Work Check

Searched open PRs on `vllm-project/vllm` before submitting:

```bash
# by issue reference
gh pr list --repo vllm-project/vllm --state open --search "49158 in:body"      # 0 results
# by area keywords
gh pr list --repo vllm-project/vllm --state open --search "GH200 DeepGEMM"     # 0 results
gh pr list --repo vllm-project/vllm --state open --search "support_deep_gemm"  # 2 results
```

No open PR addresses this GH200 crash. The two open PRs touching
`support_deep_gemm()` are unrelated in intent:

- #41062 — extends DeepGEMM device gates to SM 12.x consumer Blackwell (enables
  more GPUs; does not touch GH200 / SM 9.0 integrated).
- #45470 — DeepSeek V4 hardware-agnostic model definition (unrelated).

This PR is therefore not a duplicate.

### Fix

Add a GH200 check in `CudaPlatformBase.support_deep_gemm()`: when the GPU is
both SM 9.0 and integrated (`is_integrated_gpu()`), return `False` and emit a
one-time warning so that vLLM falls back to alternative FP8 GEMM kernels
(e.g. Cutlass / Triton).

```python
if cls.is_device_capability(90) and cls.is_integrated_gpu():
    logger.warning_once(
        "DeepGEMM is disabled on GH200 (SM 9.0 UMA). "
        "Falling back to alternative FP8 GEMM kernels."
    )
    return False
```

**This is a temporary workaround.** A `FIXME` comment has been added in the code:

```python
# FIXME: This is a temporary workaround for a DeepGEMM bug: its JIT
# kernels trigger illegal memory accesses on GH200 (SM 9.0 integrated
# GPU / UMA). Remove this check once DeepGEMM upstream fixes GH200
# support. See vllm-project/vllm#49158.
```

This check should be removed once DeepGEMM upstream fixes GH200 support.

### Impact

- **GH200 users**: Fixes #49158; models using FP8 block-scaled linear layers such
  as MiniMax-M2.7 can now start successfully.
- **Other platforms**: No impact.
  - Discrete Hopper (H100/H200, SM 9.0 non-integrated) continues to support
    DeepGEMM.
  - Blackwell (B100/B200/DGX Spark, SM 100/120 family) continues to support
    DeepGEMM.
- **Kernel selection**: `FlashInferFp8DeepGEMMDynamicBlockScaledKernel` uses
  `DeepGemmFp8BlockScaledMMKernel` as its fallback. When DeepGEMM is unsupported,
  the dynamic kernel is also marked unsupported and vLLM falls back to
  `CutlassFp8BlockScaledMMKernel`, etc.

## Test Plan

Added `tests/cuda/test_platform_capabilities.py` covering three scenarios:

- GH200 (SM90 + integrated) → `support_deep_gemm()` returns `False`
- Discrete Hopper (SM90 non-integrated) → `support_deep_gemm()` returns `True`
- DGX Spark Blackwell UMA (SM100 integrated) → `support_deep_gemm()` returns `True`

Run the new unit test:

```bash
.venv/bin/python -m pytest tests/cuda/test_platform_capabilities.py -v
```

End-to-end verification on GH200 (to be done once a machine is available):

```bash
VLLM_USE_DEEP_GEMM=1 vllm serve MiniMaxAI/MiniMax-M2.7 \
  --tensor-parallel-size 2 \
  --kv-cache-dtype fp8
```

## Test Result

**Unit test — all 3 tests pass:**

```bash
.venv/bin/python -m pytest tests/cuda/test_platform_capabilities.py -v
# test_gh200_excluded_from_deep_gemm            PASSED
# test_hopper_discrete_supports_deep_gemm       PASSED
# test_dgx_spark_blackwell_uma_supports_deep_gemm PASSED
# ========================= 3 passed in 1.56s =========================
```

Note: `tests/cuda/test_platform_capabilities.py` imports `vllm.platforms.cuda`,
which loads the native custom-ops extension `vllm._C_stable_libtorch` at module
import time. The test therefore requires a built/installed vLLM (or the native
extension stubbed in `sys.modules`); the function under test itself is pure
Python and does not call into the extension.

**End-to-end / model evaluation:** Not yet verified on real GH200 hardware. CI
will be used for regression testing. Once a GH200 machine is available, the
end-to-end serve command above will be run and the results pasted here.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)