### PR TITLE
[MRV2] Capture routed experts from supported monolithic MoE kernels

### DIFF
--- a/tests/model_executor/test_routed_experts_capture.py
+++ b/tests/model_executor/test_routed_experts_capture.py
@@ -286,7 +286,8 @@ def test_gpu_model_runner_v2_skips_unsupported_monolithic_capture(monkeypatch):
     )
     RoutedExpertsCaptureHelper().bind(runner, types.SimpleNamespace())
     assert not hasattr(
-        runner.compilation_config.static_forward_context["dummy"].quant_method
-        .moe_kernel.fused_experts,
+        runner.compilation_config.static_forward_context[
+            "dummy"
+        ].quant_method.moe_kernel.fused_experts,
         "capture_fn",
     )

--- a/tests/model_executor/test_routed_experts_capture.py
+++ b/tests/model_executor/test_routed_experts_capture.py
@@ -198,3 +198,60 @@ def test_gpu_model_runner_v2_binds_router_capture(monkeypatch):
     layer_id, topk_ids = capturer.calls[0]
     assert layer_id == 13
     assert torch.equal(topk_ids, torch.tensor([[7, 8]]))
+
+
+def test_gpu_model_runner_v2_binds_supported_monolithic_capture(monkeypatch):
+    from vllm.v1.worker.gpu.routed_experts_utils import RoutedExpertsCaptureHelper
+
+    class DummyMonolithicExperts:
+        def supports_routing_replay_capture(self):
+            return True
+
+        def set_routing_replay_capture_fn(self, capture_fn):
+            self.capture_fn = capture_fn
+
+    class DummyFusedMoE:
+        def __init__(self):
+            self.layer_id = 17
+            self.router = None
+            self.quant_method = types.SimpleNamespace(
+                moe_kernel=types.SimpleNamespace(
+                    fused_experts=DummyMonolithicExperts()
+                )
+            )
+
+    class DummyCapturer:
+        def __init__(self):
+            self.calls = []
+
+        def capture(self, layer_id, topk_ids):
+            self.calls.append((layer_id, topk_ids))
+
+    dummy_module = DummyFusedMoE()
+    import vllm.model_executor.layers.fused_moe.layer as fused_moe_layer
+    import vllm.model_executor.layers.fused_moe.modular_kernel as modular_kernel
+
+    monkeypatch.setattr(fused_moe_layer, "FusedMoE", DummyFusedMoE)
+    monkeypatch.setattr(
+        modular_kernel,
+        "FusedMoEExpertsMonolithic",
+        DummyMonolithicExperts,
+    )
+
+    dummy_self = types.SimpleNamespace(
+        compilation_config=types.SimpleNamespace(
+            static_forward_context={"dummy": dummy_module}
+        )
+    )
+    capturer = DummyCapturer()
+    RoutedExpertsCaptureHelper().bind(dummy_self, capturer)
+
+    dummy_module.quant_method.moe_kernel.fused_experts.capture_fn(
+        torch.tensor([[12, 13]])
+    )
+    assert dummy_module.quant_method.moe_kernel.fused_experts.capture_fn is not None
+    assert dummy_module.quant_method.moe_kernel.fused_experts.capture_fn
+    assert len(capturer.calls) == 1
+    layer_id, topk_ids = capturer.calls[0]
+    assert layer_id == 17
+    assert torch.equal(topk_ids, torch.tensor([[12, 13]]))

--- a/tests/model_executor/test_routed_experts_capture.py
+++ b/tests/model_executor/test_routed_experts_capture.py
@@ -215,9 +215,7 @@ def test_gpu_model_runner_v2_binds_supported_monolithic_capture(monkeypatch):
             self.layer_id = 17
             self.router = None
             self.quant_method = types.SimpleNamespace(
-                moe_kernel=types.SimpleNamespace(
-                    fused_experts=DummyMonolithicExperts()
-                )
+                moe_kernel=types.SimpleNamespace(fused_experts=DummyMonolithicExperts())
             )
 
     class DummyCapturer:
@@ -268,9 +266,7 @@ def test_gpu_model_runner_v2_skips_unsupported_monolithic_capture(monkeypatch):
         layer_id = 19
         router = None
         quant_method = types.SimpleNamespace(
-            moe_kernel=types.SimpleNamespace(
-                fused_experts=DummyMonolithicExperts()
-            )
+            moe_kernel=types.SimpleNamespace(fused_experts=DummyMonolithicExperts())
         )
 
     import vllm.model_executor.layers.fused_moe.layer as fused_moe_layer
@@ -290,7 +286,7 @@ def test_gpu_model_runner_v2_skips_unsupported_monolithic_capture(monkeypatch):
     )
     RoutedExpertsCaptureHelper().bind(runner, types.SimpleNamespace())
     assert not hasattr(
-        runner.compilation_config.static_forward_context["dummy"]
-        .quant_method.moe_kernel.fused_experts,
+        runner.compilation_config.static_forward_context["dummy"].quant_method
+        .moe_kernel.fused_experts,
         "capture_fn",
     )

--- a/tests/model_executor/test_routed_experts_capture.py
+++ b/tests/model_executor/test_routed_experts_capture.py
@@ -255,3 +255,42 @@ def test_gpu_model_runner_v2_binds_supported_monolithic_capture(monkeypatch):
     layer_id, topk_ids = capturer.calls[0]
     assert layer_id == 17
     assert torch.equal(topk_ids, torch.tensor([[12, 13]]))
+
+
+def test_gpu_model_runner_v2_skips_unsupported_monolithic_capture(monkeypatch):
+    from vllm.v1.worker.gpu.routed_experts_utils import RoutedExpertsCaptureHelper
+
+    class DummyMonolithicExperts:
+        def supports_routing_replay_capture(self):
+            return False
+
+    class DummyFusedMoE:
+        layer_id = 19
+        router = None
+        quant_method = types.SimpleNamespace(
+            moe_kernel=types.SimpleNamespace(
+                fused_experts=DummyMonolithicExperts()
+            )
+        )
+
+    import vllm.model_executor.layers.fused_moe.layer as fused_moe_layer
+    import vllm.model_executor.layers.fused_moe.modular_kernel as modular_kernel
+
+    monkeypatch.setattr(fused_moe_layer, "FusedMoE", DummyFusedMoE)
+    monkeypatch.setattr(
+        modular_kernel,
+        "FusedMoEExpertsMonolithic",
+        DummyMonolithicExperts,
+    )
+
+    runner = types.SimpleNamespace(
+        compilation_config=types.SimpleNamespace(
+            static_forward_context={"dummy": DummyFusedMoE()}
+        )
+    )
+    RoutedExpertsCaptureHelper().bind(runner, types.SimpleNamespace())
+    assert not hasattr(
+        runner.compilation_config.static_forward_context["dummy"]
+        .quant_method.moe_kernel.fused_experts,
+        "capture_fn",
+    )

--- a/vllm/v1/worker/gpu/routed_experts_utils.py
+++ b/vllm/v1/worker/gpu/routed_experts_utils.py
@@ -87,11 +87,11 @@ class RoutedExpertsCaptureHelper:
             supports_capture = getattr(
                 fused_experts, "supports_routing_replay_capture", None
             )
-            set_capture = getattr(
-                fused_experts, "set_routing_replay_capture_fn", None
-            )
-            if supports_capture is not None and supports_capture() and callable(
-                set_capture
+            set_capture = getattr(fused_experts, "set_routing_replay_capture_fn", None)
+            if (
+                supports_capture is not None
+                and supports_capture()
+                and callable(set_capture)
             ):
                 set_capture(_capture_fn)
 

--- a/vllm/v1/worker/gpu/routed_experts_utils.py
+++ b/vllm/v1/worker/gpu/routed_experts_utils.py
@@ -57,18 +57,38 @@ class RoutedExpertsCaptureHelper:
 
     def bind(self, runner: Any, capturer: RoutedExpertsCapturer) -> None:
         from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+        from vllm.model_executor.layers.fused_moe.modular_kernel import (
+            FusedMoEExpertsMonolithic,
+        )
         from vllm.model_executor.layers.fused_moe.router.base_router import (
             BaseRouter,
         )
 
         for module in runner.compilation_config.static_forward_context.values():
-            if isinstance(module, FusedMoE) and isinstance(module.router, BaseRouter):
-                layer_id = module.layer_id
+            if not isinstance(module, FusedMoE):
+                continue
+            layer_id = module.layer_id
 
-                def _capture_fn(topk_ids, _layer_id=layer_id, _capturer=capturer):
-                    _capturer.capture(_layer_id, topk_ids)
+            def _capture_fn(topk_ids, _layer_id=layer_id, _capturer=capturer):
+                _capturer.capture(_layer_id, topk_ids)
 
+            if isinstance(module.router, BaseRouter):
                 module.router.set_capture_fn(_capture_fn)
+
+            # Monolithic kernels run routing inside the expert kernel and
+            # therefore bypass BaseRouter.capture_fn. Only bind kernels that
+            # explicitly support the routing_replay_out callback; unsupported
+            # kernels must continue to run without an R3 capture callback.
+            quant_method = getattr(module, "quant_method", None)
+            moe_kernel = getattr(quant_method, "moe_kernel", None)
+            fused_experts = getattr(moe_kernel, "fused_experts", None)
+            if not isinstance(fused_experts, FusedMoEExpertsMonolithic):
+                continue
+            supports_capture = getattr(
+                fused_experts, "supports_routing_replay_capture", None
+            )
+            if supports_capture is not None and supports_capture():
+                fused_experts.set_routing_replay_capture_fn(_capture_fn)
 
     def before_execute(self) -> None:
         if not self._initialized:

--- a/vllm/v1/worker/gpu/routed_experts_utils.py
+++ b/vllm/v1/worker/gpu/routed_experts_utils.py
@@ -87,8 +87,13 @@ class RoutedExpertsCaptureHelper:
             supports_capture = getattr(
                 fused_experts, "supports_routing_replay_capture", None
             )
-            if supports_capture is not None and supports_capture():
-                fused_experts.set_routing_replay_capture_fn(_capture_fn)
+            set_capture = getattr(
+                fused_experts, "set_routing_replay_capture_fn", None
+            )
+            if supports_capture is not None and supports_capture() and callable(
+                set_capture
+            ):
+                set_capture(_capture_fn)
 
     def before_execute(self) -> None:
         if not self._initialized:


### PR DESCRIPTION
Stacked on #38163. Model Runner V2 currently binds only BaseRouter capture callbacks, so it misses monolithic MoE kernels that perform routing inside the expert kernel. This follow-up binds the monolithic replay callback only when the expert advertises supports_routing_replay_capture(). It depends on #38163 and the monolithic support introduced by #44214. Tests in the vllm/vllm-openai:nightly container: 2 passed, 4 deselected for the V2 binding tests; py_compile and git diff --check pass. AI assistance was used; please review every changed line.