### PR TITLE
[Bugfix] Preserve explicit None values in swap_dict_values

### DIFF
--- a/tests/utils_/test_collection_utils.py
+++ b/tests/utils_/test_collection_utils.py
@@ -45,3 +45,15 @@ def test_swap_dict_values(obj, key1, key2):
         assert obj[key1] == original_obj[key2]
     else:
         assert key1 not in obj
+
+@pytest.mark.parametrize(
+    ("obj", "key1", "key2", "expected"),
+    [
+        ({"a": None, "b": "Y"}, "a", "b", {"a": "Y", "b": None}),
+        ({"a": "X", "b": None}, "a", "b", {"a": None, "b": "X"}),
+        ({"a": None, "b": None}, "a", "b", {"a": None, "b": None}),
+    ],
+)
+def test_swap_dict_values_preserves_none(obj, key1, key2, expected):
+    swap_dict_values(obj, key1, key2)
+    assert obj == expected

--- a/vllm/utils/collection_utils.py
+++ b/vllm/utils/collection_utils.py
@@ -122,13 +122,9 @@ def full_groupby(values: Iterable[_V], *, key: Callable[[_V], _K]):
 
 def swap_dict_values(obj: dict[_K, _V], key1: _K, key2: _K) -> None:
     """Swap values between two keys."""
-    v1 = obj.get(key1)
-    v2 = obj.get(key2)
-    if v1 is not None:
-        obj[key2] = v1
-    else:
-        obj.pop(key2, None)
-    if v2 is not None:
-        obj[key1] = v2
-    else:
-        obj.pop(key1, None)
+    if key1 in obj and key2 in obj:
+        obj[key1], obj[key2] = obj[key2], obj[key1]
+    elif key1 in obj:
+        obj[key2] = obj.pop(key1)
+    elif key2 in obj:
+        obj[key1] = obj.pop(key2)


### PR DESCRIPTION
## Summary
Fix swap_dict_values so an explicitly stored None is treated as a present value rather than as a missing key.\n\n## Root cause
The previous dict.get() plus is not None logic conflated a missing key with a key whose value is None, allowing a swap to silently remove the other key.\n\n## Validation
- Added three explicit-None permutations to 	est_swap_dict_values_preserves_none.
- Verified the three cases with a direct Python behavioral check.
- pytest tests/utils_/test_collection_utils.py -v is blocked locally because the checkout is missing the test dependency 	blib; upstream CI should run the full configured suite.\n\nSigned-off-by: 起岚 <155608604+xiaoyaoqilan@users.noreply.github.com>