### PR TITLE
[Quark] Treat MTP/nextn draft layers as unquantized for fp4 checkpoints

### DIFF
--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import fnmatch
+import re
 from typing import TYPE_CHECKING, Any, cast
 
 import torch
@@ -74,6 +75,38 @@ class QuarkConfig(QuantizationConfig):
         # that come from shifting to mxfp4. It is left here in case
         # we want to re-enable it in the future.
         self.dynamic_mxfp4_quant = False
+        # Layer indices of the MTP / nextn speculative-decoding draft blocks.
+        # Some fp4/mxfp4 checkpoints (e.g. amd/GLM-5.1-NVFP4) keep these draft
+        # MoE layers unquantized (bf16) but omit the corresponding `exclude`
+        # entries, which makes vLLM allocate quantized experts and crash while
+        # loading the bf16 weights. Tracking the indices lets us treat those
+        # FusedMoE modules as unquantized without editing the checkpoint.
+        self.mtp_layer_indices: set[int] = set()
+
+    def _record_mtp_layer_indices(self, hf_config: PretrainedConfig | None) -> None:
+        if hf_config is None:
+            return
+        num_hidden_layers = getattr(hf_config, "num_hidden_layers", None)
+        num_nextn = getattr(hf_config, "num_nextn_predict_layers", 0) or 0
+        if num_hidden_layers is None or num_nextn <= 0:
+            return
+        self.mtp_layer_indices = set(
+            range(num_hidden_layers, num_hidden_layers + num_nextn)
+        )
+
+    def _is_unquantized_mtp_layer(self, prefix: str) -> bool:
+        """Whether ``prefix`` addresses a module inside an MTP draft layer.
+
+        These draft layers are stored unquantized in the checkpoint even
+        though the config's global quant scheme is fp4, so their weights
+        must fall back to the unquantized methods.
+        """
+        if not self.mtp_layer_indices:
+            return False
+        match = re.search(r"\.layers\.(\d+)\.", prefix)
+        if match is None:
+            return False
+        return int(match.group(1)) in self.mtp_layer_indices
 
     def maybe_update_config(
         self,
@@ -85,6 +118,8 @@ class QuarkConfig(QuantizationConfig):
 
         if hf_config is None:
             return
+
+        self._record_mtp_layer_indices(hf_config)
 
         if (
             getattr(hf_config, "model_type", None)
@@ -146,6 +181,19 @@ class QuarkConfig(QuantizationConfig):
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
     ) -> "QuantizeMethodBase | None":
+        # MTP / nextn speculative-decoding draft blocks are shipped fully
+        # unquantized (bf16) in some fp4 checkpoints (e.g. amd/GLM-5.1-NVFP4)
+        # even though the config's global scheme is fp4 and no matching
+        # `exclude` entries are provided. Force their MoE experts and linear
+        # projections to the unquantized methods so vLLM does not allocate fp4
+        # tensors and crash while loading the bf16 weights. Attention modules
+        # still go through the normal path (kv-cache quant is independent).
+        if self._is_unquantized_mtp_layer(prefix):
+            if isinstance(layer, RoutedExperts):
+                return UnquantizedFusedMoEMethod(layer.moe_config)
+            if isinstance(layer, LinearBase):
+                return UnquantizedLinearMethod()
+
         # Check if the layer is skipped for quantization.
         exclude_layers = cast(list[str], self.quant_config.get("exclude"))
         if should_ignore_layer(


### PR DESCRIPTION
## Purpose

Some NVFP4/FP4 Quark checkpoints ship their MTP (Multi-Token Prediction /
`nextn`) speculative-decoding draft layers **unquantized (bf16)**, even though
the config's global quant scheme is fp4, and — unlike the MXFP4 checkpoints
handled by #46757 — do **not** list those draft layers under `exclude`.

When loading such a checkpoint, vLLM allocates fp4-quantized experts / linear
layers for these draft blocks and then crashes while loading the bf16 weights,
e.g.:

```
RuntimeError: size mismatch ... (128 vs 256)
```

This affects e.g. `amd/GLM-5.1-NVFP4` and `amd/GLM-5.2-NVFP4`
(`model_type: glm_moe_dsa`), whose single `nextn` draft block is stored in
bf16 with no corresponding `exclude` entry.

#46757 fixed the closely-related MXFP4 case by recognizing a `RoutedExperts`
parent as ignored when its children are listed in `exclude`
(`should_ignore_layer(check_children=True)`). That mechanism does not fire for
these NVFP4 checkpoints because there is **no** `exclude` entry for the MTP
layers at all. This PR complements #46757 by auto-detecting the draft-layer
indices from the HF config so the checkpoint does not need to be edited.

## Changes

- `QuarkConfig` records the MTP/nextn draft-layer indices from `hf_config`
  (`num_hidden_layers .. num_hidden_layers + num_nextn_predict_layers`) in
  `maybe_update_config`.
- `get_quant_method` short-circuits modules inside those draft layers:
  `RoutedExperts` -> `UnquantizedFusedMoEMethod`,
  `LinearBase` -> `UnquantizedLinearMethod`. Attention modules are untouched
  (kv-cache quant is handled independently).
- No behavior change for checkpoints that have no MTP layers or that already
  list them under `exclude` (the #46757 path).

## Test Plan

- Load `amd/GLM-5.1-NVFP4` and `amd/GLM-5.2-NVFP4` (`glm_moe_dsa`) with and
  without MTP speculative decoding on AMD Instinct MI350 (gfx950), TP=8, and
  confirm they load without the tensor size-mismatch error.
- Run gsm8k (5-shot, lm_eval) against the OpenAI-compatible endpoint.

## Test Result

Model loads successfully; no size-mismatch crash. gsm8k (5-shot, lm_eval via
`/v1/completions`), MI350 (gfx950), TP=8. Both filters (flexible-extract /
strict-match) reported identical values:

| Model         | Mode    | exact_match     |
|---------------|---------|-----------------|
| GLM-5.1-NVFP4 | non-MTP | 0.9507 ± 0.0060 |
| GLM-5.1-NVFP4 | MTP     | 0.9492 ± 0.0060 |
| GLM-5.2-NVFP4 | non-MTP | 0.9462 ± 0.0062 |
| GLM-5.2-NVFP4 | MTP     | 0.9507 ± 0.0060 |

MTP speculative decoding preserves accuracy (on par within stderr) for both
models.

vLLM commit: v0.23.1rc1.dev1286+g6790a33be
