### PR TITLE
[ROCm][MLA] Enable AITER sparse MLA decode + MQA-only prefill for GLM DSA

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -536,6 +536,23 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 vllm_config=vllm_config,
             )
 
+        # Some sparse MLA implementations only provide the top-k MQA path
+        # (forward_mqa) and no dense-MHA prefill (forward_mha), e.g. the ROCm
+        # aiter sparse backend. For those, drop the dense-MHA prefill backend
+        # so prefill also flows through the MQA path instead of hitting an
+        # unimplemented forward_mha.
+        if (
+            self.prefill_backend is not None
+            and self.impl.is_sparse
+            and not getattr(self.impl, "supports_mha_prefill", True)
+        ):
+            logger.warning_once(
+                "Sparse MLA impl %s does not implement dense-MHA prefill; "
+                "routing prefill through the top-k MQA path.",
+                type(self.impl).__name__,
+            )
+            self.prefill_backend = None
+
         self.kv_cache = torch.tensor([])
 
         self.use_sparse = use_sparse

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
 import torch
@@ -27,6 +27,7 @@ from vllm.v1.attention.backend import (
     MLAAttentionImpl,
     MultipleOf,
 )
+from vllm.v1.attention.backends.utils import split_decodes_and_prefills
 from vllm.v1.attention.backends.mla.rocm_aiter_mla import (
     AiterMLAHelper,
 )
@@ -332,6 +333,18 @@ class ROCMAiterMLASparseMetadata(AttentionMetadata):
 
     block_size: int = 1
     topk_tokens: int = 2048
+    # Decode/prefill split counters and prefill metadata consumed by the
+    # generic MLAAttention.forward_impl / unified_mla_kv_cache_update path.
+    # Other sparse MLA metadata classes (e.g. FlashMLASparseMetadata) expose
+    # the same fields; the ROCm aiter sparse backend was missing them.
+    # The batch is reordered so decode tokens come first.
+    num_decodes: int = 0
+    num_prefills: int = 0
+    num_decode_tokens: int = 0
+    prefill_max_seq_len: int = 0
+    # The ROCm aiter sparse impl handles prefill and decode through the same
+    # MQA path (see forward_mqa), so no separate prefill metadata is produced.
+    prefill: Any | None = None
 
     # Persistent MLA metadata (only populated when persistent mode is enabled,
     # i.e. when the aiter sparse decode kernel supports work-stealing splits).
@@ -488,6 +501,13 @@ class ROCMAiterMLASparseMetadataBuilder(
         fast_build: bool = False,
     ) -> ROCMAiterMLASparseMetadata:
         num_tokens = common_attn_metadata.num_actual_tokens
+        num_decodes, num_prefills, num_decode_tokens, _ = split_decodes_and_prefills(
+            common_attn_metadata,
+            decode_threshold=self.reorder_batch_threshold,
+        )
+        prefill_max_seq_len = (
+            int(common_attn_metadata.max_seq_len) if num_prefills > 0 else 0
+        )
         starts = np.asarray(common_attn_metadata.query_start_loc_cpu, dtype=np.int32)
         seg_lengths = np.diff(starts)
         req_id_per_token = np.repeat(
@@ -604,6 +624,10 @@ class ROCMAiterMLASparseMetadataBuilder(
             block_size=self.kv_cache_spec.block_size,
             attn_out_dtype=self.model_dtype,
             topk_tokens=self.topk_tokens,
+            num_decodes=num_decodes,
+            num_prefills=num_prefills,
+            num_decode_tokens=num_decode_tokens,
+            prefill_max_seq_len=prefill_max_seq_len,
             qo_indptr=qo_indptr,
             paged_kv_last_page_len=paged_kv_last_page_len,
             paged_kv_indices=paged_kv_indices,
@@ -649,6 +673,9 @@ def reference_mla_sparse_prefill(
 
 class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
     is_sparse = True
+    # This impl only implements the top-k MQA path (forward_mqa), which handles
+    # both prefill and decode; it has no dense-MHA prefill (forward_mha).
+    supports_mha_prefill = False
 
     def __init__(
         self,


### PR DESCRIPTION
## Purpose

Enables the ROCm AITER sparse MLA backend (`ROCM_AITER_MLA_SPARSE`) used by
GLM DSA (Deepseek Sparse Attention) models to run end-to-end.

Two issues were blocking it:

1. **Missing decode/prefill metadata.** The generic `MLAAttention` /
   `unified_mla_kv_cache_update` path expects the attention metadata to expose
   the decode/prefill split counters and prefill metadata (`num_decodes`,
   `num_prefills`, `num_decode_tokens`, `prefill_max_seq_len`, `prefill`). The
   ROCm aiter sparse metadata class did not define these, raising
   `AttributeError` at runtime. Other sparse MLA metadata classes (e.g.
   `FlashMLASparseMetadata`) already expose them.

2. **No dense-MHA prefill.** The ROCm aiter sparse impl only implements the
   top-k MQA path (`forward_mqa`), which handles **both** prefill and decode; it
   has no dense-MHA prefill (`forward_mha`). The generic path still tried to
   build a dense prefill backend and eventually hit `NotImplementedError`.

> Note: this change is code-independent from the Quark MTP-unquantized fix
> (#49187), but that fix is required at runtime to *load* the
> `GLM-5.x-NVFP4` checkpoints used to validate this PR.

## Changes

- `rocm_aiter_mla_sparse.py`
  - Add `num_decodes`, `num_prefills`, `num_decode_tokens`,
    `prefill_max_seq_len`, and `prefill` to `ROCMAiterMLASparseMetadata`.
  - Compute them in the metadata builder via `split_decodes_and_prefills`.
  - Add `supports_mha_prefill = False` to `ROCMAiterMLASparseImpl` to advertise
    that it has no dense-MHA prefill path.
- `mla_attention.py`
  - In `MLAAttention.__init__`, when the impl is sparse and does not support
    dense-MHA prefill (`supports_mha_prefill == False`), set
    `prefill_backend = None` so prefill flows through the top-k MQA path instead
    of an unimplemented `forward_mha`.

## Test Plan

- Serve `amd/GLM-5.1-NVFP4` and `amd/GLM-5.2-NVFP4` (GLM DSA) on AMD Instinct
  MI350 (gfx950), TP=8, with `VLLM_ROCM_USE_AITER=1`.
- Run gsm8k (5-shot, lm_eval) against the OpenAI-compatible endpoint, with and
  without MTP speculative decoding.

## Test Result

Model serves without `AttributeError` / `NotImplementedError`. gsm8k (5-shot,
lm_eval via `/v1/completions`), MI350 (gfx950), TP=8. Both filters
(flexible-extract / strict-match) reported identical values:

| Model         | Mode    | exact_match     |
|---------------|---------|-----------------|
| GLM-5.1-NVFP4 | non-MTP | 0.9507 ± 0.0060 |
| GLM-5.1-NVFP4 | MTP     | 0.9492 ± 0.0060 |
| GLM-5.2-NVFP4 | non-MTP | 0.9462 ± 0.0062 |
| GLM-5.2-NVFP4 | MTP     | 0.9507 ± 0.0060 |

vLLM commit: v0.23.1rc1.dev1286+g6790a33be
