### PR TITLE
[Bugfix][Test] Quantize q to fp8 in test_flashmla_dense_fp8_decode_unified_slot_view

### DIFF
--- a/tests/kernels/attention/test_mla_cross_layer_kernel_equivalence.py
+++ b/tests/kernels/attention/test_mla_cross_layer_kernel_equivalence.py
@@ -443,6 +443,7 @@ def test_flashmla_dense_fp8_decode_unified_slot_view():
     layer = 1
 
     q = torch.randn(bs, 1, h_q, head_dim, device=dev, dtype=torch.bfloat16) * 0.1
+    q = q.to(torch.float8_e4m3fn)
     kv_data = (torch.randn(num_blocks, page, head_dim, device=dev) * 0.1).to(
         torch.float8_e4m3fn
     )


### PR DESCRIPTION
## Summary
`tests/kernels/attention/test_mla_cross_layer_kernel_equivalence.py::test_flashmla_dense_fp8_decode_unified_slot_view` raises `RuntimeError: Expected q.dtype() == torch::kFloat8_e4m3fn` when run on hardware with FlashMLA dense-fp8 support (SM90).

## Root cause
The test builds the query `q` in **bfloat16** and passes it to `flash_mla_with_kvcache_fp8`, whose kernel `fwd_kvcache_mla_fp8` asserts `q.dtype()==float8_e4m3fn`; the wrapper does not cast `q`. The case is guarded by `is_flashmla_dense_supported()`, so it is latent on CI runners lacking SM90 dense-fp8 and surfaces on SM90/H20.

## Fix
Quantize `q` to `float8_e4m3fn` before the call (the fp8 decode kernel expects a pre-quantized fp8 query with `descale_q`).

## Test
Reproduced the `RuntimeError` and verified the fix passes on stock `vllm==0.25.1` on an SM90 (H20) GPU.

Searched existing issues/PRs — no duplicate (#39787 touches a different file, `test_flashmla.py`).

AI assistance (Claude) was used; reviewed and defended by the submitter.