### PR TITLE
[Bugfix][Test] Stub config in encoder cudagraph test helper _make_manager_with_budgets

### DIFF
--- a/tests/v1/cudagraph/test_encoder_cudagraph.py
+++ b/tests/v1/cudagraph/test_encoder_cudagraph.py
@@ -12,6 +12,7 @@ Test organization:
     - TestEncoderCudaGraphVideoReplay   — video modality capture, replay
 """
 
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -105,6 +106,7 @@ def _make_manager_with_budgets(budgets: list[int]) -> EncoderCudaGraphManager:
     by patching the attributes directly after construction.
     """
     mgr = object.__new__(EncoderCudaGraphManager)
+    mgr.config = SimpleNamespace(enable_dual_path_graph=False)
     mgr.token_budgets = sorted(budgets)
     mgr.max_batch_size = 16
     mgr.use_dp = False


### PR DESCRIPTION
## Summary
`tests/v1/cudagraph/test_encoder_cudagraph.py::TestFindBudgetGraph::test_num_graphs_to_capture_tracks_budgets` raises `AttributeError: 'EncoderCudaGraphManager' object has no attribute 'config'`.

## Root cause
`EncoderCudaGraphManager.get_num_graphs_to_capture()` reads `self.config.enable_dual_path_graph`. The lightweight helper `_make_manager_with_budgets` builds the manager via `object.__new__(...)` (skipping `__init__`) and patches attributes by hand, but never sets `config` (only `_make_manager_for_gpu` does). So any test calling `get_num_graphs_to_capture()` on a helper-built manager fails.

## Fix
Stub the attribute the method reads (dual-path off), matching the helper's existing manual-patch pattern.

## Test
`pytest tests/v1/cudagraph/test_encoder_cudagraph.py::TestFindBudgetGraph -q` passes (was AttributeError). Reproduced the AttributeError and verified the fix on stock `vllm==0.25.1`.

Searched existing issues/PRs (`get_num_graphs_to_capture`, `_make_manager_with_budgets`) — no duplicate.

AI assistance (Claude) was used; reviewed and defended by the submitter.