### PR TITLE
[Bugfix] Return HTTP 500 for non-streaming generate errors

### DIFF
--- a/tests/entrypoints/scale_out/token_in_token_out/test_generate_stream.py
+++ b/tests/entrypoints/scale_out/token_in_token_out/test_generate_stream.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from vllm.config.multimodal import MultiModalConfig
-from vllm.entrypoints.openai.engine.protocol import StreamOptions
+from vllm.entrypoints.openai.engine.protocol import GenerationError, StreamOptions
 from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.scale_out.token_in_token_out.protocol import (
@@ -227,6 +227,30 @@ async def test_serve_tokens_threads_session_id_header_to_engine():
     await serving.serve_tokens(request, raw_request)
 
     assert engine.generate.call_args.kwargs["session_id"] == "header-session"
+
+
+@pytest.mark.asyncio
+async def test_non_stream_error():
+    """finish_reason='error' raises for the HTTP exception handler."""
+    engine = _mock_engine()
+
+    async def mock_generate(*args, **kwargs):
+        yield _make_request_output(
+            "req-1", token_ids=[], finish_reason="error", finished=True
+        )
+
+    engine.generate = MagicMock(side_effect=mock_generate)
+    serving = _build_serving_tokens(engine)
+
+    request = GenerateRequest(
+        token_ids=[1, 2, 3],
+        sampling_params=SamplingParams(max_tokens=10),
+        model=MODEL_NAME,
+        stream=False,
+    )
+
+    with pytest.raises(GenerationError):
+        await serving.serve_tokens(request)
 
 
 @pytest.mark.asyncio

--- a/vllm/entrypoints/scale_out/token_in_token_out/serving.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/serving.py
@@ -266,6 +266,8 @@ class ServingTokens(GenerateBaseServing):
         choices: list[GenerateResponseChoice] = []
         num_generated_tokens = 0
         for output in final_res.outputs:
+            self._raise_if_error(output.finish_reason, request_id)
+
             token_ids = output.token_ids
             out_logprobs = output.logprobs
 


### PR DESCRIPTION
## Purpose

Fixes #49181.

The non-streaming `/inference/v1/generate` path serialized an engine `finish_reason="error"` as a successful HTTP 200 response. This reuses the established `_raise_if_error` path so FastAPI's registered `GenerationError` handler returns HTTP 500 instead. Streaming behavior is unchanged and continues to report errors in-band after headers are sent.

I checked the issue thread and open PRs by issue number and area keywords immediately before implementation and again before opening; no competing change exists.

## Test Plan

- Reproduce the public HTTP response against stock `main` and the patched branch with the same mocked engine error.
- Run the token-serving unit tests and adjacent protocol tests.
- Run pre-commit on both changed files.
- Review the current diff independently for error-path and streaming regressions.

## Test Result

- Runtime A/B: stock returned HTTP 200 with `finish_reason: "error"`; patched returned HTTP 500 with `InternalServerError`.
- `PYTHONPATH=. .venv/bin/python -m pytest -q tests/entrypoints/scale_out/token_in_token_out/test_generate_stream.py tests/entrypoints/scale_out/token_in_token_out/test_protocol.py`: 16 passed.
- `.venv/bin/pre-commit run --files vllm/entrypoints/scale_out/token_in_token_out/serving.py tests/entrypoints/scale_out/token_in_token_out/test_generate_stream.py`: passed.
- Independent diff review: no correctness or streaming-regression findings.
- Model evaluation is not applicable because this changes only HTTP error propagation and does not affect generated output.

AI assistance was used. I reviewed every changed line and verified the behavior and tests above.
