### PR TITLE
[Bug Fix] DiffusionGemma get different outputs compared with transformers version (mismatch sliding window attention)

### DIFF
--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -40,6 +40,7 @@ def ref_paged_attn(
     scale: float,
     sliding_window: int | None = None,
     soft_cap: float | None = None,
+    diffusion_rect_swa: list[bool] | None = None,
 ) -> torch.Tensor:
     num_seqs = len(query_lens)
     block_tables = block_tables.cpu().numpy()
@@ -76,6 +77,12 @@ def ref_paged_attn(
                 .logical_not()
             )
             mask |= sliding_window_mask
+        if diffusion_rect_swa is not None and diffusion_rect_swa[i]:
+            assert sliding_window is not None
+            context_len = kv_len - query_len
+            rect_start = max(context_len - sliding_window, 0)
+            mask = torch.ones(query_len, kv_len, dtype=torch.bool)
+            mask[:, rect_start:kv_len] = False
         if soft_cap is not None and soft_cap > 0:
             attn = soft_cap * torch.tanh(attn / soft_cap)
         attn.masked_fill_(mask, float("-inf"))
@@ -643,3 +650,85 @@ def test_triton_unified_attn_use_td_tile_clamp(
         soft_cap=None,
         seq_threshold_3D=0,
     )
+
+
+@torch.inference_mode()
+def test_triton_unified_attn_diffusion_rect_swa() -> None:
+    """Every diffusion canvas row sees one fixed prefix window."""
+    torch.set_default_device(DEVICE_TYPE)
+    set_random_seed(0)
+
+    query_len = 32
+    context_len = 96
+    kv_len = context_len + query_len
+    sliding_window = 64
+    num_query_heads = 4
+    num_kv_heads = 2
+    head_size = 128
+    block_size = 16
+    num_blocks = kv_len // block_size
+    scale = head_size**-0.5
+
+    query = torch.randn(query_len, num_query_heads, head_size, dtype=torch.bfloat16)
+    key_cache = torch.randn(
+        num_blocks,
+        block_size,
+        num_kv_heads,
+        head_size,
+        dtype=torch.bfloat16,
+    )
+    value_cache = torch.randn_like(key_cache)
+    block_tables = torch.arange(num_blocks, dtype=torch.int32).unsqueeze(0)
+    cu_query_lens = torch.tensor([0, query_len], dtype=torch.int32)
+    kv_lens = torch.tensor([kv_len], dtype=torch.int32)
+    causal = torch.tensor([False], dtype=torch.bool)
+    diffusion_rect_swa = torch.tensor([True], dtype=torch.bool)
+    output = torch.empty_like(query)
+
+    num_par_softmax_segments = 16
+    softmax_segm_output = torch.empty(
+        (0, num_query_heads, num_par_softmax_segments, head_size),
+        dtype=torch.float32,
+    )
+    softmax_segm_max = torch.empty(
+        (0, num_query_heads, num_par_softmax_segments), dtype=torch.float32
+    )
+    softmax_segm_expsum = torch.empty_like(softmax_segm_max)
+
+    unified_attention(
+        q=query,
+        k=key_cache,
+        v=value_cache,
+        out=output,
+        cu_seqlens_q=cu_query_lens,
+        max_seqlen_q=query_len,
+        seqused_k=kv_lens,
+        max_seqlen_k=kv_len,
+        softmax_scale=scale,
+        causal=causal,
+        diffusion_rect_swa=diffusion_rect_swa,
+        window_size=(sliding_window - 1, 0),
+        block_table=block_tables,
+        softcap=0,
+        q_descale=None,
+        k_descale=None,
+        v_descale=None,
+        seq_threshold_3D=0,
+        num_par_softmax_segments=num_par_softmax_segments,
+        softmax_segm_output=softmax_segm_output,
+        softmax_segm_max=softmax_segm_max,
+        softmax_segm_expsum=softmax_segm_expsum,
+    )
+
+    ref_output = ref_paged_attn(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        query_lens=[query_len],
+        kv_lens=[kv_len],
+        block_tables=block_tables,
+        scale=scale,
+        sliding_window=sliding_window,
+        diffusion_rect_swa=[True],
+    )
+    torch.testing.assert_close(output, ref_output, atol=1.5e-2, rtol=1e-2)

--- a/vllm/model_executor/models/diffusion_gemma.py
+++ b/vllm/model_executor/models/diffusion_gemma.py
@@ -17,6 +17,7 @@ via Gemma4MultimodalEmbedder.
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
 
@@ -52,7 +53,10 @@ from vllm.v1.outputs import LogprobsTensors
 from vllm.v1.worker.gpu.attn_utils import build_attn_metadata
 from vllm.v1.worker.gpu.buffer_utils import UvaBackedTensor, async_copy_to_gpu
 from vllm.v1.worker.gpu.input_batch import InputBatch
-from vllm.v1.worker.gpu.model_states.interface import ModelState
+from vllm.v1.worker.gpu.model_states.interface import (
+    ModelSpecificAttnMetadata,
+    ModelState,
+)
 from vllm.v1.worker.gpu.sample.logprob import compute_topk_scores
 from vllm.v1.worker.gpu.sample.output import SamplerOutput
 from vllm.v1.worker.gpu.sample.penalties import use_penalty
@@ -65,6 +69,18 @@ from .interfaces import (
 )
 
 logger = init_logger(__name__)
+
+
+@dataclass
+class DiffusionGemmaAttnMetadata(ModelSpecificAttnMetadata):
+    diffusion_rect_swa: torch.Tensor
+
+    def get_extra_common_attn_kwargs(
+        self,
+        kv_cache_group_id: int,
+        num_reqs: int,
+    ) -> dict[str, Any]:
+        return {"diffusion_rect_swa": self.diffusion_rect_swa[:num_reqs]}
 
 
 class DiffusionGemmaSelfConditioning(nn.Module):
@@ -786,6 +802,7 @@ class DiffusionGemmaModelState(ModelState):
 
         text_config = self.model_config.hf_text_config
         self.gen_config = self.model_config.try_get_generation_config()
+        self.gen_config.update(self.model_config.override_generation_config)
         max_denoising_steps = (
             diffusion_config.max_denoising_steps if diffusion_config else None
         ) or self.gen_config.get("max_denoising_steps", 48)
@@ -806,6 +823,9 @@ class DiffusionGemmaModelState(ModelState):
         # Persistent buffer for per-request causal flags, updated in-place
         # so FULL CUDA graph replay sees the latest values.
         self._causal_buf = torch.zeros(
+            self.max_num_reqs, dtype=torch.bool, device=device
+        )
+        self._diffusion_rect_swa_buf = torch.zeros(
             self.max_num_reqs, dtype=torch.bool, device=device
         )
 
@@ -1012,6 +1032,17 @@ class DiffusionGemmaModelState(ModelState):
             self._causal_buf[actual_num_reqs:num_reqs] = False
         causal: bool | torch.Tensor = self._causal_buf[:num_reqs]
 
+        # HF uses a fixed sliding-window prefix for every denoising canvas row,
+        # followed by the complete bidirectional canvas.
+        self._diffusion_rect_swa_buf[:actual_num_reqs] = ~self._causal_buf[
+            :actual_num_reqs
+        ]
+        if actual_num_reqs < num_reqs:
+            self._diffusion_rect_swa_buf[actual_num_reqs:num_reqs] = False
+        model_specific_attn_metadata = DiffusionGemmaAttnMetadata(
+            diffusion_rect_swa=self._diffusion_rect_swa_buf[:num_reqs]
+        )
+
         return build_attn_metadata(
             attn_groups=attn_groups,
             num_reqs=num_reqs,
@@ -1025,6 +1056,7 @@ class DiffusionGemmaModelState(ModelState):
             slot_mappings=slot_mappings,
             kv_cache_config=kv_cache_config,
             causal=causal,
+            model_specific_attn_metadata=model_specific_attn_metadata,
         )
 
     num_new_sampled_tokens_per_step: int = 0

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -439,6 +439,10 @@ class CommonAttentionMetadata:
 
     causal: bool | torch.Tensor = True
 
+    diffusion_rect_swa: torch.Tensor | None = None
+    """(batch_size,) bool tensor selecting a fixed sliding-window prefix
+    plus the complete bidirectional diffusion canvas."""
+
     # Needed by FastPrefillAttentionBuilder
     logits_indices_padded: torch.Tensor | None = None
     num_logits_indices: int | None = None

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -81,6 +81,7 @@ class TritonAttentionMetadata:
     softmax_segm_expsum: torch.Tensor
 
     causal: bool | torch.Tensor
+    diffusion_rect_swa: torch.Tensor | None
 
     # For cascade attention.
     use_cascade: bool
@@ -234,6 +235,7 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             block_table=block_table_tensor,
             slot_mapping=slot_mapping,
             causal=common_attn_metadata.causal,
+            diffusion_rect_swa=common_attn_metadata.diffusion_rect_swa,
             use_cascade=use_cascade,
             common_prefix_len=common_prefix_len,
             cu_prefix_query_lens=cu_prefix_query_lens,
@@ -699,6 +701,7 @@ class TritonAttentionImpl(AttentionImpl):
             max_seqlen_k=max_seqlen_k,
             softmax_scale=self.scale,
             causal=attn_metadata.causal,
+            diffusion_rect_swa=attn_metadata.diffusion_rect_swa,
             alibi_slopes=self.alibi_slopes,
             use_alibi_sqrt=self.use_alibi_sqrt,
             window_size=self.sliding_window,

--- a/vllm/v1/attention/ops/int4_per_token_head.py
+++ b/vllm/v1/attention/ops/int4_per_token_head.py
@@ -473,6 +473,7 @@ def _attn_packed(
 
     loop_lo, loop_hi, max_seq_prefix_len = compute_tile_loop_bounds(
         context_len,
+        seq_idx,
         seq_len,
         cur_batch_query_len,
         q_block_local_idx,

--- a/vllm/v1/attention/ops/triton_attention_helpers.py
+++ b/vllm/v1/attention/ops/triton_attention_helpers.py
@@ -141,6 +141,7 @@ def init_softmax_M(
 @triton.jit
 def compute_tile_loop_bounds(
     context_len,
+    seq_idx,
     seq_len,
     cur_batch_query_len,
     q_block_local_idx,
@@ -157,6 +158,8 @@ def compute_tile_loop_bounds(
     USE_PER_SEQ_CAUSAL: tl.constexpr = False,
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
+    USE_DIFFUSION_RECT_SWA: tl.constexpr = False,
+    diffusion_rect_swa_ptr=None,
 ):
     """Compute the tile-loop bounds ``(loop_lo, loop_hi)`` and the
     derived ``max_seq_prefix_len`` used for per-tile masking.
@@ -212,6 +215,9 @@ def compute_tile_loop_bounds(
         # The union of allowed key positions for this Q-block is:
         # [context_len + qpos_lo - SLIDING_WINDOW + 1, context_len + qpos_hi]
         q_abs = context_len + qpos_lo
+        use_rect_swa = False
+        if USE_DIFFUSION_RECT_SWA:
+            use_rect_swa = tl.load(diffusion_rect_swa_ptr + seq_idx)
         if CHUNK_LOOKBACK > -1:
             first_allowed_key = ((q_abs // CHUNK_SIZE) - CHUNK_LOOKBACK) * CHUNK_SIZE
         else:
@@ -224,6 +230,11 @@ def compute_tile_loop_bounds(
             )
         else:
             last_allowed_key = context_len + qpos_hi
+        if USE_DIFFUSION_RECT_SWA:
+            first_allowed_key = tl.where(
+                use_rect_swa, context_len - SLIDING_WINDOW, first_allowed_key
+            )
+            last_allowed_key = tl.where(use_rect_swa, seq_len - 1, last_allowed_key)
         # Convert to tile indices and clamp
         tile_start = tl.maximum(0, first_allowed_key // TILE_SIZE)
         tile_end = tl.minimum((last_allowed_key // TILE_SIZE) + 1, num_tiles)
@@ -287,6 +298,9 @@ def compute_kv_seq_mask(
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
     MM_PREFIX_CLAMP_SW: tl.constexpr = False,
+    USE_DIFFUSION_RECT_SWA: tl.constexpr = False,
+    diffusion_rect_swa_ptr=None,
+    context_len=None,
 ):
     """Build the KV mask for one tile.
 
@@ -335,6 +349,12 @@ def compute_kv_seq_mask(
             seq_mask = seq_mask & sw_left & sw_right
         else:
             seq_mask = seq_mask & sw_left
+        if USE_DIFFUSION_RECT_SWA:
+            use_rect_swa = tl.load(diffusion_rect_swa_ptr + seq_idx)
+            rect_mask = (seq_offset[None, :] >= context_len - SLIDING_WINDOW) & (
+                seq_offset[None, :] < seq_len
+            )
+            seq_mask = tl.where(use_rect_swa, rect_mask, seq_mask)
 
     if USE_R_SWA:
         prefix_len = tl.load(rswa_prefix_lens_ptr + seq_idx)

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -218,6 +218,8 @@ def kernel_unified_attention(
     USE_CAUSAL: tl.constexpr,  # bool
     USE_PER_SEQ_CAUSAL: tl.constexpr,  # bool
     per_seq_causal_ptr,  # [num_seqs] bool, or None
+    USE_DIFFUSION_RECT_SWA: tl.constexpr,  # bool
+    diffusion_rect_swa_ptr,  # [num_seqs] bool, or None
     USE_MM_PREFIX: tl.constexpr,  # bool
     MAX_MM_RANGES: tl.constexpr,  # int
     mm_prefix_range_ptr,
@@ -398,6 +400,7 @@ def kernel_unified_attention(
 
     loop_lo, loop_hi, max_seq_prefix_len = compute_tile_loop_bounds(
         context_len,
+        seq_idx,
         seq_len,
         cur_batch_query_len,
         q_block_local_idx,
@@ -414,6 +417,8 @@ def kernel_unified_attention(
         USE_PER_SEQ_CAUSAL,
         CHUNK_LOOKBACK,
         CHUNK_SIZE,
+        USE_DIFFUSION_RECT_SWA,
+        diffusion_rect_swa_ptr,
     )
 
     # iterate through tiles (now limited to the sliding window range)
@@ -530,6 +535,9 @@ def kernel_unified_attention(
             CHUNK_LOOKBACK,
             CHUNK_SIZE,
             MM_PREFIX_CLAMP_SW,
+            USE_DIFFUSION_RECT_SWA,
+            diffusion_rect_swa_ptr,
+            context_len,
         )
 
         # S : (BLOCK_M, TILE_SIZE)
@@ -575,6 +583,12 @@ def kernel_unified_attention(
                 sw_mask_v = dist < SLIDING_WINDOW
             else:
                 sw_mask_v = (dist < SLIDING_WINDOW) & (dist > -SLIDING_WINDOW)
+            if USE_DIFFUSION_RECT_SWA:
+                use_rect_swa = tl.load(diffusion_rect_swa_ptr + seq_idx)
+                rect_mask_v = (seq_offset[:, None] >= context_len - SLIDING_WINDOW) & (
+                    seq_offset[:, None] < seq_len
+                )
+                sw_mask_v = tl.where(use_rect_swa, rect_mask_v, sw_mask_v)
             V = tl.where(sw_mask_v, V, 0.0)
         if USE_PER_TOKEN_HEAD_SCALES:
             # Per-token-head quant: apply v_scale to P instead of V.
@@ -828,6 +842,7 @@ def unified_attention(
     sinks=None,
     # Optional tensor for prefix lengths (PrefixLM support)
     mm_prefix_range=None,
+    diffusion_rect_swa=None,
     # R-SWA support: prefix tokens stay globally visible, generated tokens use
     # a fixed sliding window.
     rswa_prefix_lens=None,
@@ -852,6 +867,8 @@ def unified_attention(
     use_per_seq_causal = isinstance(causal, torch.Tensor)
     use_causal = bool(causal) if not use_per_seq_causal else True
     per_seq_causal_ptr = causal if use_per_seq_causal else None
+    use_diffusion_rect_swa = diffusion_rect_swa is not None
+    diffusion_rect_swa_ptr = diffusion_rect_swa if use_diffusion_rect_swa else seqused_k
 
     # Sub-byte packed mode (INT4) needs a bespoke kernel (split-dot +
     # sub-byte unpack); everything else goes through the core kernel below.
@@ -1129,6 +1146,8 @@ def unified_attention(
         USE_CAUSAL=use_causal,
         USE_PER_SEQ_CAUSAL=use_per_seq_causal,
         per_seq_causal_ptr=per_seq_causal_ptr,
+        USE_DIFFUSION_RECT_SWA=use_diffusion_rect_swa,
+        diffusion_rect_swa_ptr=diffusion_rect_swa_ptr,
         USE_MM_PREFIX=use_mm_prefix,
         MAX_MM_RANGES=max_mm_ranges,
         mm_prefix_range_ptr=mm_prefix_range,

--- a/vllm/v1/attention/ops/triton_unified_attention_diffkv.py
+++ b/vllm/v1/attention/ops/triton_unified_attention_diffkv.py
@@ -172,6 +172,7 @@ def kernel_unified_attention_diffkv(
 
     loop_lo, loop_hi, max_seq_prefix_len = compute_tile_loop_bounds(
         context_len,
+        seq_idx,
         seq_len,
         cur_batch_query_len,
         q_block_local_idx,


### PR DESCRIPTION
## Purpose

Fix DiffusionGemma sliding-window attention behavior in the Triton unified attention backend.

When DiffusionGemma enters the denoising / reasoning phase, the canvas attention is bidirectional, but it should not use the same symmetric sliding-window mask as a normal non-causal sequence. The Transformers implementation lets every canvas row attend to:

1. the same fixed sliding-window prefix range before the canvas, and
2. the complete current denoising canvas.

vLLM’s Triton path previously treated non-causal sliding-window attention symmetrically around each query row. As generation proceeds and the reasoning canvas moves past a certain token length, later canvas rows can see a different / smaller prefix window than Transformers. This causes vLLM outputs to diverge from the Transformers implementation, and can reproduce as different reasoning text or tool-call behavior once the generated reasoning exceeds enough tokens.

## How to fix

This PR adds DiffusionGemma-specific attention metadata so denoising requests can explicitly select the rectangular sliding-window mask. The Triton attention kernel then uses that metadata to apply the fixed-prefix-plus-full-canvas mask only for DiffusionGemma denoising rows, while preserving the existing behavior for regular causal / non-causal attention, R-SWA, and multimodal prefix masking.

This also means inference must correctly pass the attention mode metadata: DiffusionGemma encoder/prompt phases remain causal, while denoising/reasoning phases are marked for rectangular SWA.

Note: this fix applies to the Triton attention backend. When starting the vLLM server for DiffusionGemma, pass:

```bash
--attention-backend "${ATTENTION_BACKEND}"