### PR TITLE
[Misc] Use VLLMValidationError in chat completion tool and batch validators

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -687,9 +687,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
             skip_special_tokens=self.skip_special_tokens,
             spaces_between_special_tokens=self.spaces_between_special_tokens,
             include_stop_str_in_output=self.include_stop_str_in_output,
-            output_kind=RequestOutputKind.DELTA
-            if self.stream
-            else RequestOutputKind.FINAL_ONLY,
+            output_kind=(
+                RequestOutputKind.DELTA if self.stream else RequestOutputKind.FINAL_ONLY
+            ),
             structured_outputs=self.extract_structured_outputs(),
             logit_bias=self.logit_bias,
             bad_words=self.bad_words,
@@ -849,9 +849,10 @@ class ChatCompletionRequest(OpenAIBaseModel):
 
         # Reject empty tools array, matching OpenAI API behavior
         if data.get("tools") == []:
-            raise ValueError(
+            raise VLLMValidationError(
                 "`tools` must not be an empty array. "
-                "Either provide at least one tool or omit the field entirely."
+                "Either provide at least one tool or omit the field entirely.",
+                parameter="tools",
             )
 
         # if "tool_choice" is not specified but tools are provided,
@@ -1075,13 +1076,15 @@ class BatchChatCompletionRequest(OpenAIBaseModel):
         if isinstance(data, BatchChatCompletionRequest):
             data = data.model_dump(exclude_unset=True)
         if data.get("use_beam_search"):
-            raise ValueError(
+            raise VLLMValidationError(
                 "Batch chat completions do not support beam search. "
-                "Please set `use_beam_search` to False."
+                "Please set `use_beam_search` to False.",
+                parameter="use_beam_search",
             )
         if data.get("logprob_token_ids") and not data.get("logprobs"):
-            raise ValueError(
-                "when using `logprob_token_ids`, `logprobs` must be set to true."
+            raise VLLMValidationError(
+                "when using `logprob_token_ids`, `logprobs` must be set to true.",
+                parameter="logprob_token_ids",
             )
         response_format = data.get("response_format")
         rf_type = (
@@ -1095,8 +1098,10 @@ class BatchChatCompletionRequest(OpenAIBaseModel):
             validate_structured_outputs_structural_tag(structured_outputs)
         n = data.get("n", 1)
         if n is not None and n != 1:
-            raise ValueError(
-                "Batch chat completions do not support `n > 1`. Please set `n` to 1."
+            raise VLLMValidationError(
+                "Batch chat completions do not support `n > 1`. Please set `n` to 1.",
+                parameter="n",
+                value=n,
             )
         return data
 


### PR DESCRIPTION
## Purpose

Follow-up to #36254, continuing the migration of user-facing request validation in the OpenAI-compatible protocol layer to `VLLMValidationError`.

A few checks in `ChatCompletionRequest.check_tool_usage` and `BatchChatCompletionRequest.check_batch_mode` still raised plain `ValueError`, while sibling checks in the same validators already use `VLLMValidationError`. The custom exception carries a `parameter` name (and optional `value`) so the API layer can build structured error responses, so leaving these as bare `ValueError` is an inconsistency.

Notably, the `logprob_token_ids` / `logprobs` check in `check_batch_mode` raises the exact same message that `check_logprobs` already raises as `VLLMValidationError(parameter="logprob_token_ids")`, so the target parameter name is unambiguous.

### Changes
- `check_tool_usage`: empty `tools` array → `parameter="tools"`
- `check_batch_mode`: beam search → `parameter="use_beam_search"`
- `check_batch_mode`: `logprob_token_ids` without `logprobs` → `parameter="logprob_token_ids"`
- `check_batch_mode`: `n > 1` → `parameter="n"` (with `value`)

No change to error message text, validation logic, or HTTP status codes (all already return 400). `VLLMValidationError` subclasses `ValueError`, so existing `except ValueError` handling is unaffected.

## Test Plan

Existing validation tests already cover the empty-`tools` path and assert on the message via `pytest.raises(ValueError, match="must not be an empty array")`:

```
pytest tests/tool_use/test_chat_completion_request_validations.py
pytest tests/entrypoints/openai/chat_completion/test_chat_error.py
```

## Test Result

Since `VLLMValidationError` subclasses `ValueError` and the message text is unchanged, the existing `pytest.raises(ValueError, match=...)` assertions still pass. Verified locally that each migrated check now surfaces the correct `parameter`:

| check | `parameter` | message preserved |
|---|---|---|
| empty `tools` | `tools` | yes |
| beam search | `use_beam_search` | yes |
| `logprob_token_ids` w/o `logprobs` | `logprob_token_ids` | yes |
| `n > 1` | `n` | yes |

`pre-commit run --files vllm/entrypoints/openai/chat_completion/protocol.py` passes (ruff, ruff-format, typos, mypy).
