### PR TITLE
[CPU][Perf] Fuse GDN decode core

### DIFF
--- a/csrc/cpu/sgl-kernels/conv.cpp
+++ b/csrc/cpu/sgl-kernels/conv.cpp
@@ -429,25 +429,23 @@ void causal_conv1d_update_kernel_impl(
             TORCH_CHECK(false, "Unexpected block size, ", width, " x ", nb_size);
         }
 
+        scalar_t* state =
+            conv_states + conv_state_index * conv_state_slot_stride + nb_start;
+        for (int64_t w = 1; w < width - 1; ++w) {
+          std::memcpy(
+              state + (w - 1) * dim,
+              state + w * dim,
+              nb_size * sizeof(scalar_t));
+        }
+        std::memcpy(
+            state + (width - 2) * dim,
+            input + bs * dim + nb_start,
+            nb_size * sizeof(scalar_t));
+
         // move to the next index
         data_index_step(bs, batch, nb, NB);
       }
     });
-  });
-
-#define CONV_STATE_INDEXR(w) conv_states + conv_state_index*conv_state_slot_stride + (w) * dim
-
-  // update conv_states
-  at::parallel_for(0, batch, 0, [&](int64_t begin, int64_t end) {
-    for (int64_t bs = begin; bs < end; ++bs) {
-      // update old states, range [1, width - 1)
-      int32_t conv_state_index = has_conv_indices ? conv_indices[bs] : bs;
-      for (int64_t w = 1; w < width - 1; ++w) {
-        std::memcpy(CONV_STATE_INDEXR(w - 1), CONV_STATE_INDEXR(w), dim * sizeof(scalar_t));
-      }
-      // copy new states
-      std::memcpy(CONV_STATE_INDEXR(width - 2), input + bs * dim, dim * sizeof(scalar_t));
-    }
   });
 }
 

--- a/csrc/cpu/sgl-kernels/fla.cpp
+++ b/csrc/cpu/sgl-kernels/fla.cpp
@@ -8,6 +8,17 @@
 #include "vec.h"
 #include "vec_pack.h"
 
+at::Tensor causal_conv1d_update_cpu(
+    const at::Tensor& x,
+    const at::Tensor& conv_states,
+    const at::Tensor& weight,
+    const std::optional<at::Tensor>& bias,
+    bool silu_activation,
+    const std::optional<at::Tensor>& cache_seqlens,
+    const std::optional<at::Tensor>& conv_state_indices,
+    int64_t pad_slot_id,
+    bool is_vnni);
+
 namespace {
 // For this cpu kernel, we have some innovations aside from the existing gpu kernels:
 // 1) Use less parallel loops, i.e. 4 including l2_norm.
@@ -1656,6 +1667,127 @@ at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
             softplus_threshold);
       });
   return core_attn_out;
+}
+
+void fused_gdn_decode_cpu(
+    const at::Tensor& mixed_qkv,
+    at::Tensor& conv_states,
+    const at::Tensor& packed_conv_weight,
+    const std::optional<at::Tensor>& bias,
+    bool silu_activation,
+    const at::Tensor& A_log,
+    const at::Tensor& dt_bias,
+    const at::Tensor& a,
+    const at::Tensor& b,
+    at::Tensor& ssm_state,
+    const at::Tensor& state_indices,
+    int64_t num_tokens,
+    at::Tensor& output) {
+  CHECK_DIM(2, mixed_qkv);
+  CHECK_CONTIGUOUS(mixed_qkv);
+  CHECK_CONTIGUOUS(packed_conv_weight);
+  CHECK_DIM(2, a);
+  CHECK_DIM(2, b);
+  CHECK_DIM(4, ssm_state);
+  CHECK_DIM(1, state_indices);
+  CHECK_DIM(3, output);
+  CHECK_CONTIGUOUS(a);
+  CHECK_CONTIGUOUS(b);
+  CHECK_CONTIGUOUS(state_indices);
+  CHECK_CONTIGUOUS(output);
+  TORCH_CHECK(mixed_qkv.scalar_type() == at::kBFloat16,
+              "fused_gdn_decode_cpu supports only BF16");
+  TORCH_CHECK(num_tokens > 0 && num_tokens <= mixed_qkv.size(0),
+              "invalid num_tokens: ", num_tokens);
+
+  int64_t packed_dim = mixed_qkv.size(1);
+  int64_t v_num_heads = A_log.size(0);
+  int64_t head_dim = ssm_state.size(2);
+  int64_t v_head_dim = ssm_state.size(3);
+  int64_t v_dim = v_num_heads * v_head_dim;
+  int64_t qk_dim = packed_dim - v_dim;
+  TORCH_CHECK(qk_dim > 0 && qk_dim % 2 == 0,
+              "invalid packed QKV dimension: ", packed_dim);
+  int64_t q_dim = qk_dim / 2;
+  TORCH_CHECK(q_dim % head_dim == 0,
+              "query dimension must be divisible by head_dim");
+  int64_t num_heads = q_dim / head_dim;
+
+  CHECK_EQ(packed_conv_weight.size(0), packed_dim);
+  CHECK_EQ(packed_conv_weight.size(1), 4);
+  CHECK_EQ(a.size(1), v_num_heads);
+  CHECK_EQ(b.size(1), v_num_heads);
+  CHECK(a.size(0) >= num_tokens);
+  CHECK(b.size(0) >= num_tokens);
+  CHECK_INPUT_SHAPE_DTYPE<true>(dt_bias, {v_num_heads}, mixed_qkv.scalar_type());
+  CHECK_INPUT_SHAPE_DTYPE<true>(state_indices, {num_tokens}, at::kInt);
+  CHECK_INPUT_SHAPE_DTYPE<true>(
+      ssm_state,
+      {ssm_state.size(0), v_num_heads, head_dim, v_head_dim},
+      at::kFloat);
+  CHECK_EQ(v_num_heads % num_heads, 0);
+  TORCH_CHECK(A_log.sizes() == at::IntArrayRef({v_num_heads}));
+  TORCH_CHECK(output.size(0) >= num_tokens);
+  CHECK_EQ(output.size(1), v_num_heads);
+  CHECK_EQ(output.size(2), v_head_dim);
+  CHECK_EQ(output.scalar_type(), mixed_qkv.scalar_type());
+
+  at::Tensor conv_input = mixed_qkv.narrow(0, 0, num_tokens);
+  at::Tensor conv_out = causal_conv1d_update_cpu(
+      conv_input,
+      conv_states,
+      packed_conv_weight,
+      bias,
+      silu_activation,
+      std::nullopt,
+      state_indices,
+      -1,
+      true);
+
+  at::Tensor qk_scale_buf = at::empty({2, num_tokens, num_heads}, at::kFloat);
+
+  int64_t state_slot_stride = ssm_state.stride(0);
+  CPU_DISPATCH_REDUCED_FLOATING_TYPES_EXT(
+      mixed_qkv.scalar_type(),
+      A_log.scalar_type(),
+      "fused_gdn_decode_cpu",
+      [&] {
+        const scalar_t* packed = conv_out.data_ptr<scalar_t>();
+        const scalar_t* query = packed;
+        const scalar_t* key = packed + q_dim;
+        const scalar_t* value = packed + 2 * q_dim;
+
+        fused_sigmoid_gating_delta_rule_update_kernel_impl<scalar_t, param_t>(
+            query,
+            key,
+            value,
+            A_log.data_ptr<param_t>(),
+            a.data_ptr<scalar_t>(),
+            dt_bias.data_ptr<scalar_t>(),
+            b.data_ptr<scalar_t>(),
+            state_indices.data_ptr<int32_t>(),
+            ssm_state.data_ptr<float>(),
+            output.data_ptr<scalar_t>(),
+            qk_scale_buf.data_ptr<float>(),
+            1,
+            num_tokens,
+            num_heads,
+            head_dim,
+            v_num_heads,
+            v_head_dim,
+            packed_dim,
+            packed_dim * num_tokens,
+            head_dim,
+            packed_dim,
+            packed_dim * num_tokens,
+            head_dim,
+            packed_dim,
+            packed_dim * num_tokens,
+            v_head_dim,
+            state_slot_stride,
+            true,
+            20.0);
+      });
 }
 
 // Speculative-decode update (multi-token, multi-slot rollback).

--- a/csrc/cpu/torch_bindings.cpp
+++ b/csrc/cpu/torch_bindings.cpp
@@ -128,6 +128,15 @@ at::Tensor fused_sigmoid_gating_delta_rule_update_spec_cpu(
     const at::Tensor& cu_seqlens, bool use_qk_l2norm_in_kernel,
     double softplus_beta = 1.0, double softplus_threshold = 20.0);
 
+void fused_gdn_decode_cpu(const at::Tensor& mixed_qkv, at::Tensor& conv_states,
+                          const at::Tensor& packed_conv_weight,
+                          const std::optional<at::Tensor>& bias,
+                          bool silu_activation, const at::Tensor& A_log,
+                          const at::Tensor& dt_bias, const at::Tensor& a,
+                          const at::Tensor& b, at::Tensor& ssm_state,
+                          const at::Tensor& state_indices, int64_t num_tokens,
+                          at::Tensor& output);
+
 std::tuple<at::Tensor, at::Tensor> fused_gdn_gating_cpu(
     const at::Tensor& A_log, const at::Tensor& a, const at::Tensor& b,
     const at::Tensor& dt_bias);
@@ -479,6 +488,12 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "Tensor? cache_seqlens, Tensor? conv_state_indices, int pad_slot_id, "
       "bool is_vnni) -> Tensor");
   ops.impl("causal_conv1d_update_cpu", torch::kCPU, &causal_conv1d_update_cpu);
+  ops.def(
+      "fused_gdn_decode_cpu(Tensor mixed_qkv, Tensor(a!) conv_states, Tensor "
+      "packed_conv_weight, Tensor? bias, bool silu_activation, Tensor A_log, "
+      "Tensor dt_bias, Tensor a, Tensor b, Tensor(b!) ssm_state, Tensor "
+      "state_indices, int num_tokens, Tensor(c!) output) -> ()");
+  ops.impl("fused_gdn_decode_cpu", torch::kCPU, &fused_gdn_decode_cpu);
 #endif
 
 #if (defined(__AVX512BF16__) && defined(__AVX512F__) && \

--- a/tests/kernels/mamba/cpu/test_cpu_gdn_ops.py
+++ b/tests/kernels/mamba/cpu/test_cpu_gdn_ops.py
@@ -2,12 +2,17 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import functools
+from types import SimpleNamespace
 
 import pytest
 import torch
 import torch.nn.functional as F
 
 import vllm._custom_ops as ops
+from vllm.model_executor.layers.mamba.ops.cpu.gdn_attention import (
+    _can_use_fused_gdn_decode,
+    _split_packed_qkv,
+)
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
@@ -513,6 +518,207 @@ def test_causal_conv1d_fwd_cpu_two_call_split(total_tokens: int, split: int) -> 
     out_split = torch.cat([out1, out2], dim=1)
 
     torch.testing.assert_close(out_split, out_full, atol=1e-2, rtol=1e-2)
+
+
+@torch.inference_mode()
+def test_split_packed_qkv_preserves_strided_rows() -> None:
+    num_tokens = 4
+    num_qk_heads = 8
+    num_v_heads = 16
+    head_dim = 128
+    q_dim = num_qk_heads * head_dim
+    v_dim = num_v_heads * head_dim
+    packed_dim = 2 * q_dim + v_dim
+    storage = torch.randn(num_tokens, packed_dim + 17, dtype=torch.bfloat16)
+    packed = storage[:, :packed_dim]
+    layer = SimpleNamespace(
+        key_dim=q_dim * 2,
+        value_dim=v_dim * 2,
+        tp_size=2,
+        head_k_dim=head_dim,
+        head_v_dim=head_dim,
+    )
+
+    query, key, value = _split_packed_qkv(layer, packed)
+    q_ref, k_ref, v_ref = packed.split([q_dim, q_dim, v_dim], dim=-1)
+
+    assert packed.stride(0) == packed_dim + 17
+    assert query.stride(-1) == key.stride(-1) == value.stride(-1) == 1
+    torch.testing.assert_close(
+        query, q_ref.contiguous().view(1, num_tokens, num_qk_heads, head_dim)
+    )
+    torch.testing.assert_close(
+        key, k_ref.contiguous().view(1, num_tokens, num_qk_heads, head_dim)
+    )
+    torch.testing.assert_close(
+        value, v_ref.contiguous().view(1, num_tokens, num_v_heads, head_dim)
+    )
+
+
+@pytest.mark.skipif(
+    not torch.cpu._is_amx_tile_supported(),
+    reason="fused_gdn_decode_cpu requires AMX/AVX512",
+)
+@pytest.mark.parametrize("num_tokens", [1, 4, 8])
+@torch.inference_mode()
+def test_fused_gdn_decode_cpu_matches_existing_pipeline(num_tokens: int) -> None:
+    num_qk_heads = 8
+    num_v_heads = 16
+    head_dim = 128
+    q_dim = num_qk_heads * head_dim
+    v_dim = num_v_heads * head_dim
+    conv_dim = 2 * q_dim + v_dim
+    num_slots = 2 * num_tokens + 3
+    state_indices = torch.arange(1, 2 * num_tokens + 1, 2, dtype=torch.int32)
+    mixed_qkv = torch.randn(num_tokens, conv_dim, dtype=torch.bfloat16)
+    weight = torch.randn(conv_dim, CONV_KERNEL, dtype=torch.bfloat16)
+    packed_weight = ops.causal_conv1d_weight_pack(weight)
+    bias = torch.randn(conv_dim, dtype=torch.bfloat16)
+    a = torch.randn(num_tokens, num_v_heads, dtype=torch.bfloat16)
+    b = torch.randn_like(a)
+    A_log = torch.randn(num_v_heads, dtype=torch.float32)
+    dt_bias = torch.randn(num_v_heads, dtype=torch.bfloat16)
+
+    conv_state = torch.randn(num_slots, CONV_KERNEL - 1, conv_dim, dtype=torch.bfloat16)
+    conv_state_ref = conv_state.clone().transpose(1, 2)
+    conv_state_out = conv_state.clone().transpose(1, 2)
+    ssm_state = torch.randn(
+        num_slots, num_v_heads, head_dim, head_dim, dtype=torch.float32
+    )
+    ssm_state_ref = ssm_state.clone()
+    ssm_state_out = ssm_state.clone()
+
+    conv_out_ref = ops.causal_conv1d_update_cpu(
+        mixed_qkv,
+        conv_state_ref,
+        packed_weight,
+        bias,
+        True,
+        state_indices,
+        True,
+    )
+    layer = SimpleNamespace(
+        key_dim=q_dim * 2,
+        value_dim=v_dim * 2,
+        tp_size=2,
+        head_k_dim=head_dim,
+        head_v_dim=head_dim,
+    )
+    query, key, value = _split_packed_qkv(layer, conv_out_ref)
+    attn_out_ref = ops.fused_sigmoid_gating_delta_rule_update_cpu(
+        A_log,
+        dt_bias,
+        query,
+        key,
+        value,
+        a,
+        b,
+        ssm_state_ref,
+        state_indices,
+        torch.arange(num_tokens + 1, dtype=torch.int32),
+        True,
+    )
+    output_ref = torch.zeros(
+        num_tokens + 2, num_v_heads, head_dim, dtype=torch.bfloat16
+    )
+    output_ref[:num_tokens] = attn_out_ref.squeeze(1)
+
+    output = torch.zeros_like(output_ref)
+    ops.fused_gdn_decode_cpu(
+        mixed_qkv,
+        conv_state_out,
+        packed_weight,
+        bias,
+        True,
+        A_log,
+        dt_bias,
+        a,
+        b,
+        ssm_state_out,
+        state_indices,
+        num_tokens,
+        output,
+    )
+
+    torch.testing.assert_close(output[:num_tokens], output_ref[:num_tokens])
+    torch.testing.assert_close(
+        output[num_tokens:], torch.zeros_like(output[num_tokens:])
+    )
+    torch.testing.assert_close(conv_state_out, conv_state_ref)
+    torch.testing.assert_close(ssm_state_out, ssm_state_ref, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(
+    not torch.cpu._is_amx_tile_supported(),
+    reason="causal_conv1d_update_cpu requires AMX/AVX512",
+)
+@torch.inference_mode()
+def test_causal_conv1d_update_cpu_coalesces_selected_state_update() -> None:
+    from vllm.model_executor.layers.mamba.ops.cpu.causal_conv1d import (
+        causal_conv1d_update_torch,
+    )
+
+    batch_size = 4
+    num_slots = 11
+    state_indices = torch.tensor([1, 4, 7, 9], dtype=torch.int32)
+    x, weight, bias = _conv_inputs(batch_size)
+    packed_weight = ops.causal_conv1d_weight_pack(weight)
+    initial_state = torch.randn(
+        num_slots, CONV_KERNEL - 1, CONV_DIM, dtype=torch.bfloat16
+    )
+    native_state = initial_state.clone().transpose(1, 2)
+    ref_state = initial_state.clone().transpose(1, 2)
+
+    native_out = ops.causal_conv1d_update_cpu(
+        x,
+        native_state,
+        packed_weight,
+        bias,
+        True,
+        state_indices,
+        True,
+    )
+    selected_ref_state = ref_state[state_indices].contiguous()
+    ref_out = causal_conv1d_update_torch(
+        x=x.unsqueeze(-1),
+        conv_state=selected_ref_state,
+        weight=weight,
+        bias=bias,
+        activation="silu",
+    ).squeeze(-1)
+    ref_state[state_indices] = selected_ref_state
+
+    torch.testing.assert_close(native_out, ref_out, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(native_state, ref_state)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {},
+        {"num_prefills": 1},
+        {"speculative": True},
+        {"is_amx": False},
+        {"is_dim_first": True},
+        {"dtype": torch.float32},
+        {"width": 3},
+        {"num_decode_tokens": 3},
+    ],
+)
+def test_fused_gdn_decode_dispatch(overrides: dict) -> None:
+    inputs = {
+        "dtype": torch.bfloat16,
+        "is_amx": True,
+        "is_dim_first": False,
+        "width": 4,
+        "num_decodes": 4,
+        "num_decode_tokens": 4,
+        "num_prefills": 0,
+        "speculative": False,
+    }
+    inputs.update(overrides)
+    expected = not overrides
+    assert _can_use_fused_gdn_decode(**inputs) is expected
 
 
 @torch.inference_mode()

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -3400,6 +3400,38 @@ def causal_conv1d_update_cpu(
     )
 
 
+def fused_gdn_decode_cpu(
+    mixed_qkv: torch.Tensor,
+    conv_states: torch.Tensor,
+    packed_conv_weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    silu_activation: bool,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    ssm_state: torch.Tensor,
+    state_indices: torch.Tensor,
+    num_tokens: int,
+    output: torch.Tensor,
+) -> None:
+    torch.ops._C.fused_gdn_decode_cpu(
+        mixed_qkv,
+        conv_states,
+        packed_conv_weight,
+        bias,
+        silu_activation,
+        A_log,
+        dt_bias,
+        a,
+        b,
+        ssm_state,
+        state_indices,
+        num_tokens,
+        output,
+    )
+
+
 class CPUDNNLGEMMHandler:
     def __init__(self) -> None:
         self.handler_tensor: torch.Tensor | None = None

--- a/vllm/model_executor/layers/mamba/ops/cpu/gdn_attention.py
+++ b/vllm/model_executor/layers/mamba/ops/cpu/gdn_attention.py
@@ -23,6 +23,41 @@ from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 _CPU_GDN_ATTENTION_OPS_REGISTERED = False
 
 
+def _split_packed_qkv(layer, mixed_qkv: torch.Tensor):
+    num_tokens = mixed_qkv.size(0)
+    q_dim = layer.key_dim // layer.tp_size
+    v_dim = layer.value_dim // layer.tp_size
+    query, key, value = mixed_qkv.split([q_dim, q_dim, v_dim], dim=-1)
+    return (
+        query.view(1, num_tokens, -1, layer.head_k_dim),
+        key.view(1, num_tokens, -1, layer.head_k_dim),
+        value.view(1, num_tokens, -1, layer.head_v_dim),
+    )
+
+
+def _can_use_fused_gdn_decode(
+    *,
+    dtype: torch.dtype,
+    is_amx: bool,
+    is_dim_first: bool,
+    width: int,
+    num_decodes: int,
+    num_decode_tokens: int,
+    num_prefills: int,
+    speculative: bool,
+) -> bool:
+    return (
+        dtype == torch.bfloat16
+        and is_amx
+        and not is_dim_first
+        and width == 4
+        and num_decodes > 0
+        and num_decode_tokens == num_decodes
+        and num_prefills == 0
+        and not speculative
+    )
+
+
 def cpu_gdn_attention_core(
     mixed_qkv: torch.Tensor,
     b: torch.Tensor,
@@ -128,6 +163,34 @@ def _cpu_gdn_attention_nonspec(
     num_prefills = attn_metadata_i.num_prefills
     num_prefill_tokens = attn_metadata_i.num_prefill_tokens
 
+    if _can_use_fused_gdn_decode(
+        dtype=mixed_qkv.dtype,
+        is_amx=is_amx,
+        is_dim_first=is_conv_state_dim_first(),
+        width=layer.conv1d.weight.size(-1),
+        num_decodes=num_decodes,
+        num_decode_tokens=num_decode_tokens,
+        num_prefills=num_prefills,
+        speculative=False,
+    ):
+        decode_state_indices = state_indices_tensor[:num_decodes]
+        ops.fused_gdn_decode_cpu(
+            mixed_qkv=mixed_qkv,
+            conv_states=conv_state,
+            packed_conv_weight=layer.conv1d.weight,
+            bias=layer.conv1d.bias,
+            silu_activation=layer.activation == "silu",
+            A_log=layer.A_log,
+            dt_bias=layer.dt_bias,
+            a=a,
+            b=b,
+            ssm_state=ssm_state,
+            state_indices=decode_state_indices,
+            num_tokens=num_decode_tokens,
+            output=core_attn_out,
+        )
+        return
+
     # all decode requests (batched)
     if num_decodes > 0:
         decode_mixed_qkv = mixed_qkv[:num_decode_tokens]
@@ -156,7 +219,7 @@ def _cpu_gdn_attention_nonspec(
             ).squeeze(-1)
             conv_state[decode_state_indices] = decode_conv_state
 
-        query, key, value = layer.rearrange_mixed_qkv(decode_mixed_qkv)
+        query, key, value = _split_packed_qkv(layer, decode_mixed_qkv)
 
         attn_out = ops.fused_sigmoid_gating_delta_rule_update_cpu(
             A_log=layer.A_log,
@@ -432,10 +495,10 @@ def _spec_forward(
     # Single fused kernel call: it runs the recurrence over each sequence's
     # draft tokens internally, resumes from slot ``num_accepted-1`` and stores
     # the state after token ``t`` into slot ``t`` (rollback for the next step).
-    query, key, value = layer.rearrange_mixed_qkv(conv_out)
-    query = query.squeeze(0).contiguous()
-    key = key.squeeze(0).contiguous()
-    value = value.squeeze(0).contiguous()
+    query, key, value = _split_packed_qkv(layer, conv_out)
+    query = query.squeeze(0)
+    key = key.squeeze(0)
+    value = value.squeeze(0)
     spec_idx = spec_state_indices[:num_spec_decodes].to(torch.int32).contiguous()
     num_acc = num_accepted[:num_spec_decodes].to(torch.int32).contiguous()
     cu = spec_qsl[: num_spec_decodes + 1].to(torch.int32).contiguous()
@@ -507,12 +570,7 @@ def _spec_aware_nonspec(
         ).squeeze(-1)
         conv_buf[decode_state_indices, :, : width - 1] = decode_conv_state
 
-        query, key, value = layer.rearrange_mixed_qkv(decode_mixed_qkv)
-        # rearrange_mixed_qkv can return views whose last dim is not
-        # contiguous; the fused CPU kernel requires a contiguous last dim.
-        query = query.contiguous()
-        key = key.contiguous()
-        value = value.contiguous()
+        query, key, value = _split_packed_qkv(layer, decode_mixed_qkv)
         attn_out = ops.fused_sigmoid_gating_delta_rule_update_cpu(
             A_log=layer.A_log,
             dt_bias=layer.dt_bias,


### PR DESCRIPTION
## Summary

Add a guarded CPU fast path that combines the non-speculative GDN decode core behind one C++ custom-op boundary.

The fast path:

- runs the existing causal-convolution update;
- consumes the resulting packed QKV buffer directly in the existing gated-delta recurrence;
- writes recurrence output directly into the caller-provided output;
- avoids Python-side QKV materialization, `torch.cat`, and the final output copy; and
- coalesces convolution-state maintenance into the existing block-parallel loop.

Dispatch remains restricted to BF16 AMX, width-4 convolution, SD state layout, pure non-speculative decode, and one token per active sequence. All other cases retain the existing fallback.

## Draft status and sequencing

This is a holding draft so the work and benchmark evidence are not lost.

PR #48577 is the current priority and overlaps `conv.cpp`, `gdn_attention.py`, `_custom_ops.py`, and the CPU GDN tests. This draft should remain blocked until #48577 lands. It must then be rebased onto current `main`, adapted to the final speculative-convolution structure, hardened, and revalidated before review.

In particular, the shared `conv.cpp` state-update change should be independently justified after the rebase or removed from this PR.

## Why

The prior decode pipeline launched causal convolution and gated-delta recurrence as separate custom operations, materialized packed QKV through `rearrange_mixed_qkv`, and copied the returned attention tensor into the caller output. Profiling showed that this orchestration and tensor plumbing dominated the small-batch CPU GDN decode core.

## Performance

Qwen3.6-35B-A3B-FP8, TP2, per-rank GDN shape: 8 Q/K heads, 16 V heads, head dimension 128, 4096 packed convolution channels, width 4.

| Decode batch | Unfused core | Fused core | Reduction |
| ---: | ---: | ---: | ---: |
| 1 | 33.479 us | 17.105 us | 48.9% |
| 4 | 45.256 us | 21.466 us | 52.6% |
| 8 | 79.647 us | 30.020 us | 62.3% |

TP2 no-compile-cache throughput medians:

| Concurrency | Baseline | Fused | Improvement |
| ---: | ---: | ---: | ---: |
| 1 | 34.2226 ms/token | 29.8319 ms/token | 12.8% |
| 4 | 12.9210 ms/token | 11.9914 ms/token | 7.2% |
| 8 | 8.1365 ms/token | 7.5442 ms/token | 7.3% |

Profile analysis found no decode-path `aten::cat` below the fused operation. Inclusive GDN-core time fell by 49.9% and 42.6% on the two TP ranks.

## Correctness and model evaluation

The focused parity harness produced exact decode output, convolution state, and FP32 SSM state over 256 consecutive steps at decode batches 1, 4, and 8.

GSM8K-250 used `kv_cache_dtype=auto` because the checkpoint does not provide calibrated FP8 KV-cache scales:

| Path | Strict match | Invalid responses |
| --- | ---: | ---: |
| Fallback | 0.968 | 4 |
| Fused | 0.964 | 3 |

The `-0.004` delta passed the predefined maximum regression of `-0.01`.

## Tests

```bash
PRE_COMMIT_HOME=/tmp/pre-commit .venv/bin/pre-commit run --files \
  csrc/cpu/sgl-kernels/conv.cpp \
  csrc/cpu/sgl-kernels/fla.cpp \
  csrc/cpu/torch_bindings.cpp \
  vllm/_custom_ops.py \
  vllm/model_executor/layers/mamba/ops/cpu/gdn_attention.py \
  tests/kernels/mamba/cpu/test_cpu_gdn_ops.py
```

Passed.

```bash
numactl -m 5 -N 5 taskset -c 160-191 \
  .venv/bin/python -m pytest \
  tests/kernels/mamba/cpu/test_cpu_gdn_ops.py \
  tests/kernels/mamba/test_cpu_short_conv.py \
  tests/v1/attention/test_gdn_metadata_builder.py -v
```

Result: `104 passed, 16 warnings`.

These results predate the required rebase onto current `main` and must be rerun before this draft is marked ready.

## Duplicate-work check

Searched open vLLM PRs for `CPU GDN decode fusion`, `fused_gdn_decode_cpu`, and related CPU GDN optimization terms. No open PR implements this non-speculative CPU decode-core fusion. PR #48577 is related and overlaps files, but optimizes the speculative-decode convolution path rather than this pure-decode core.

## AI assistance

AI assistance was used to implement, test, benchmark, and draft this change. The human submitter reviewed the committed changes and is responsible for understanding and defending them.
