### PR TITLE
feat: expose __commit__ for fix-containment checks

### DIFF
--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -4,7 +4,7 @@
 
 # The version.py should be independent library, and we always import the
 # version library first.  Such assumption is critical for some customization.
-from .version import __version__, __version_tuple__  # isort:skip
+from .version import __commit__, __version__, __version_tuple__  # isort:skip
 
 import typing
 
@@ -76,6 +76,7 @@ else:
 __all__ = [
     "__version__",
     "__version_tuple__",
+    "__commit__",
     "LLM",
     "ModelRegistry",
     "PromptType",

--- a/vllm/version.py
+++ b/vllm/version.py
@@ -1,6 +1,32 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
+from typing import Any
+
+
+def _commit_from_version_tuple(version_tuple: tuple[Any, ...]) -> str:
+    """Extract a git commit hash from a setuptools-scm version tuple.
+
+    Dev builds typically end with a local segment like ``gabcdef`` or
+    ``gabcdef.dYYYYMMDD``. Return the short hash without the leading ``g``.
+    """
+    if not version_tuple:
+        return ""
+    local = version_tuple[-1]
+    if not isinstance(local, str) or not local.startswith("g"):
+        return ""
+    # Strip the leading 'g' and any trailing local date segment.
+    body = local[1:]
+    if "." in body:
+        body = body.split(".", 1)[0]
+    # setuptools-scm short hashes are hex; reject empty/malformed leftovers.
+    if not body or any(c not in "0123456789abcdef" for c in body.lower()):
+        return ""
+    return body
+
+
 try:
     from ._version import __version__, __version_tuple__
 except Exception as e:
@@ -10,6 +36,9 @@ except Exception as e:
 
     __version__ = "dev"
     __version_tuple__ = (0, 0, __version__)
+
+# Public commit id for fix-containment checks (empty when unavailable).
+__commit__ = _commit_from_version_tuple(__version_tuple__)
 
 
 def _prev_minor_version_was(version_str):


### PR DESCRIPTION
## Summary
Dev version strings like `0.25.1.dev24` do not reliably indicate whether a specific fix commit is present. This adds a public `vllm.__commit__` string derived from the setuptools-scm local segment already present in `__version_tuple__` (e.g. `gabcdef1` → `abcdef1`).

### Changes
- `vllm/version.py`: parse commit hash into `__commit__` (empty when unavailable / non-dev builds)
- `vllm/__init__.py`: re-export `__commit__`

## Testing
- Helper unit checks for `gabcdef`, `gabcdef.dYYYYMMDD`, release tuples, and `dev`
- Full package import tests not run in sparse checkout environment

Fixes #49215
