### PR TITLE
[KV-offload][FS]: Batching for read/write threads

### DIFF
--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -443,10 +443,8 @@ def test_store_load_roundtrip_without_o_direct(tmp_path, monkeypatch):
         tier.shutdown()
 
 
-def test_wait_idle_blocks_until_tasks_complete(monkeypatch):
+def test_wait_idle_blocks_until_tasks_complete():
     """wait_idle must not return while a task is still in flight."""
-
-    import vllm.v1.kv_offload.tiering.fs.manager as mgr_mod
 
     # Make batch_store_block blocking
     gate = threading.Event()
@@ -454,7 +452,6 @@ def test_wait_idle_blocks_until_tasks_complete(monkeypatch):
     def blocking_batch_store_block(*args, **kwargs):
         gate.wait(timeout=5.0)
 
-    monkeypatch.setattr(mgr_mod, "batch_store_block", blocking_batch_store_block)
     # dummy task
     task = Task(path="unused", offset=0)
 
@@ -463,7 +460,7 @@ def test_wait_idle_blocks_until_tasks_complete(monkeypatch):
         job_id=1,
         n_tasks=1,
         tasks=[task],
-        make_batch_fn=lambda batch: mgr_mod.batch_store_block,
+        make_batch_fn=lambda batch: blocking_batch_store_block,
     )
 
     waiter = threading.Thread(target=pool.wait_idle)

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -40,7 +40,7 @@ from vllm.v1.kv_offload.tiering.factory import SecondaryTierFactory
 from vllm.v1.kv_offload.tiering.fs.manager import (
     FileSystemTierManager,
 )
-from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
+from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool, Task
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -443,11 +443,28 @@ def test_store_load_roundtrip_without_o_direct(tmp_path, monkeypatch):
         tier.shutdown()
 
 
-def test_wait_idle_blocks_until_tasks_complete():
+def test_wait_idle_blocks_until_tasks_complete(monkeypatch):
     """wait_idle must not return while a task is still in flight."""
-    pool = DualQueueThreadPool(n_read_threads=1, n_write_threads=1)
+
+    import vllm.v1.kv_offload.tiering.fs.manager as mgr_mod
+
+    # Make batch_store_block blocking
     gate = threading.Event()
-    pool.enqueue_store(job_id=1, n_tasks=1, tasks=[lambda: gate.wait(timeout=5.0)])
+
+    def blocking_batch_store_block(*args, **kwargs):
+        gate.wait(timeout=5.0)
+
+    monkeypatch.setattr(mgr_mod, "batch_store_block", blocking_batch_store_block)
+    # dummy task
+    task = Task(path="unused", offset=0)
+
+    pool = DualQueueThreadPool(n_read_threads=1, n_write_threads=1)
+    pool.enqueue_store(
+        job_id=1,
+        n_tasks=1,
+        tasks=[task],
+        make_batch_fn=lambda batch: mgr_mod.batch_store_block,
+    )
 
     waiter = threading.Thread(target=pool.wait_idle)
     waiter.start()
@@ -461,6 +478,59 @@ def test_wait_idle_blocks_until_tasks_complete():
         gate.set()
         pool.shutdown(wait=True)
         waiter.join(timeout=5.0)
+
+
+@pytest.mark.parametrize(
+    ("n_tasks", "n_threads", "expected_sizes"),
+    [
+        (7, 3, [3, 2, 2]),
+        (6, 3, [2, 2, 2]),
+        (2, 5, [1, 1]),
+        (0, 3, []),
+    ],
+)
+def test_batch_tasks_distribution(n_tasks, n_threads, expected_sizes):
+    """_batch_tasks splits tasks evenly across n_threads (largest remainder
+    first), preserving order and accounting for every task."""
+    pool = DualQueueThreadPool(n_read_threads=1, n_write_threads=1)
+    try:
+        tasks = [Task(path=f"p{i}", offset=i) for i in range(n_tasks)]
+        batches = list(pool._batch_tasks(tasks, n_threads))
+        assert [len(b) for b in batches] == expected_sizes
+        assert [t for b in batches for t in b] == tasks
+    finally:
+        pool.shutdown(wait=True)
+
+
+def test_store_job_parallelized_across_threads():
+    """A single job's batches must be serviced by multiple threads at once,
+    not funneled through a single thread."""
+    n_threads = 4
+    barrier = threading.Barrier(n_threads, timeout=5.0)
+    seen_threads: set[str] = set()
+    lock = threading.Lock()
+
+    def make_batch_fn(batch: list[Task]):
+        def run() -> None:
+            with lock:
+                seen_threads.add(threading.current_thread().name)
+            barrier.wait()
+
+        return run
+
+    pool = DualQueueThreadPool(n_read_threads=0, n_write_threads=n_threads)
+    try:
+        tasks = [Task(path=f"p{i}", offset=i) for i in range(n_threads)]
+        pool.enqueue_store(
+            job_id=1,
+            n_tasks=n_threads,
+            tasks=tasks,
+            make_batch_fn=make_batch_fn,
+        )
+        pool.wait_idle()
+        assert len(seen_threads) == n_threads
+    finally:
+        pool.shutdown(wait=True)
 
 
 def test_batch_lookup_c_extension(tmp_path):

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -475,6 +475,59 @@ def test_wait_idle_blocks_until_tasks_complete(monkeypatch):
         waiter.join(timeout=5.0)
 
 
+@pytest.mark.parametrize(
+    ("n_tasks", "n_threads", "expected_sizes"),
+    [
+        (7, 3, [3, 2, 2]),
+        (6, 3, [2, 2, 2]),
+        (2, 5, [1, 1]),
+        (0, 3, []),
+    ],
+)
+def test_batch_tasks_distribution(n_tasks, n_threads, expected_sizes):
+    """_batch_tasks splits tasks evenly across n_threads (largest remainder
+    first), preserving order and accounting for every task."""
+    pool = DualQueueThreadPool(n_read_threads=1, n_write_threads=1)
+    try:
+        tasks = [Task(path=f"p{i}", offset=i) for i in range(n_tasks)]
+        batches = list(pool._batch_tasks(tasks, n_threads))
+        assert [len(b) for b in batches] == expected_sizes
+        assert [t for b in batches for t in b] == tasks
+    finally:
+        pool.shutdown(wait=True)
+
+
+def test_store_job_parallelized_across_threads():
+    """A single job's batches must be serviced by multiple threads at once,
+    not funneled through a single thread."""
+    n_threads = 4
+    barrier = threading.Barrier(n_threads, timeout=5.0)
+    seen_threads: set[str] = set()
+    lock = threading.Lock()
+
+    def make_batch_fn(batch: list[Task]):
+        def run() -> None:
+            with lock:
+                seen_threads.add(threading.current_thread().name)
+            barrier.wait()
+
+        return run
+
+    pool = DualQueueThreadPool(n_read_threads=0, n_write_threads=n_threads)
+    try:
+        tasks = [Task(path=f"p{i}", offset=i) for i in range(n_threads)]
+        pool.enqueue_store(
+            job_id=1,
+            n_tasks=n_threads,
+            tasks=tasks,
+            make_batch_fn=make_batch_fn,
+        )
+        pool.wait_idle()
+        assert len(seen_threads) == n_threads
+    finally:
+        pool.shutdown(wait=True)
+
+
 def test_batch_lookup_c_extension(tmp_path):
     """Validates batch_lookup_C: empty, single, all-existing, all-missing,
     mixed ordering, and input type validation."""

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -453,7 +453,7 @@ def test_wait_idle_blocks_until_tasks_complete():
         gate.wait(timeout=5.0)
 
     # dummy task
-    task = Task(path="unused", offset=0)
+    task = Task(key=key(0), offset=0)
 
     pool = DualQueueThreadPool(n_read_threads=1, n_write_threads=1)
     pool.enqueue_store(
@@ -491,7 +491,7 @@ def test_batch_tasks_distribution(n_tasks, n_threads, expected_sizes):
     first), preserving order and accounting for every task."""
     pool = DualQueueThreadPool(n_read_threads=1, n_write_threads=1)
     try:
-        tasks = [Task(path=f"p{i}", offset=i) for i in range(n_tasks)]
+        tasks = [Task(key=key(i), offset=i) for i in range(n_tasks)]
         batches = list(pool._batch_tasks(tasks, n_threads))
         assert [len(b) for b in batches] == expected_sizes
         assert [t for b in batches for t in b] == tasks
@@ -517,7 +517,7 @@ def test_store_job_parallelized_across_threads():
 
     pool = DualQueueThreadPool(n_read_threads=0, n_write_threads=n_threads)
     try:
-        tasks = [Task(path=f"p{i}", offset=i) for i in range(n_threads)]
+        tasks = [Task(key=key(i), offset=i) for i in range(n_threads)]
         pool.enqueue_store(
             job_id=1,
             n_tasks=n_threads,
@@ -701,7 +701,7 @@ def test_batched_partial_load_failure_keeps_loaded_blocks(
     results = drain(tier)
     # (a) the job fails but reports the two blocks that loaded before the bad one.
     assert len(results) == 1 and not results[0].success
-    assert tuple(results[0].successful_keys) == (key(1), key(2))
+    assert sorted(results[0].successful_keys) == [key(1), key(2)]
 
     # (b) Only the failed tail is a miss; the loaded blocks stay HIT on the same
     # request, and nothing was re-probed.
@@ -726,34 +726,50 @@ def test_batched_partial_load_failure_keeps_loaded_blocks(
 
 @pytest.mark.parametrize("use_c_ext", [True, False])
 def test_batched_load_first_block_fails_marks_whole_batch(
-    fs_tier, monkeypatch, use_c_ext
+    tmp_path, monkeypatch, use_c_ext
 ):
     """When the FIRST block fails, nothing loaded before it: the job reports no
     successful_keys (None) and the whole batch is marked a miss for the
-    request."""
+    request.
+
+    Uses a single read thread so all 3 tasks land in one batch/thread call:
+    the "no partial success" guarantee only holds within a single sequential
+    batch_load_block call, not across independently-scheduled threads."""
     import vllm.v1.kv_offload.tiering.fs.io as io_mod
 
     if use_c_ext and not io_mod._HAS_FSIO_C:
         pytest.skip("fs_io_C extension not built")
     monkeypatch.setattr(io_mod, "_HAS_FSIO_C", use_c_ext)
 
-    tier, _ = fs_tier
-    keys = [key(1), key(2), key(3)]  # first one is the "bad" block
-    tier.submit_store(make_job(1, keys, [0, 1, 2]))
-    assert all(r.success for r in drain(tier))
+    tensor = _page_aligned_zero_tensor(_NUM_BLOCKS, _BLOCK_ELEMENTS)
+    mock_view = memoryview(tensor.numpy())
+    tier = FileSystemTierManager(
+        offloading_spec=_MOCK_OFFLOADING_SPEC,
+        primary_kv_view=mock_view,
+        tier_type="fs",
+        root_dir=str(tmp_path),
+        n_read_threads=1,
+        n_write_threads=1,
+    )
+    try:
+        keys = [key(1), key(2), key(3)]  # first one is the "bad" block
+        tier.submit_store(make_job(1, keys, [0, 1, 2]))
+        assert all(r.success for r in drain(tier))
 
-    ctx = ReqContext(req_id="batch-first-fail")
-    assert lookup_and_wait(tier, keys, ctx=ctx) == [LookupResult.HIT] * 3
+        ctx = ReqContext(req_id="batch-first-fail")
+        assert lookup_and_wait(tier, keys, ctx=ctx) == [LookupResult.HIT] * 3
 
-    with open(tier.file_mapper.get_file_name(key(1)), "wb") as f:
-        f.write(b"x" * 10)
-    tier.submit_load(make_job(2, keys, [0, 1, 2], is_promotion=True))
-    results = drain(tier)
-    assert len(results) == 1 and not results[0].success
-    # Nothing loaded before the failure -> no partial success reported.
-    assert results[0].successful_keys is None
-    # The whole batch is a miss for this request.
-    assert [tier.lookup(k, ctx) for k in keys] == [LookupResult.MISS] * 3
+        with open(tier.file_mapper.get_file_name(key(1)), "wb") as f:
+            f.write(b"x" * 10)
+        tier.submit_load(make_job(2, keys, [0, 1, 2], is_promotion=True))
+        results = drain(tier)
+        assert len(results) == 1 and not results[0].success
+        # Nothing loaded before the failure -> no partial success reported.
+        assert results[0].successful_keys is None
+        # The whole batch is a miss for this request.
+        assert [tier.lookup(k, ctx) for k in keys] == [LookupResult.MISS] * 3
+    finally:
+        tier.shutdown()
 
 
 @pytest.mark.parametrize("use_c_ext", [True, False])

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -40,7 +40,7 @@ from vllm.v1.kv_offload.tiering.factory import SecondaryTierFactory
 from vllm.v1.kv_offload.tiering.fs.manager import (
     FileSystemTierManager,
 )
-from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
+from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool, Task
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -438,11 +438,28 @@ def test_store_load_roundtrip_without_o_direct(tmp_path, monkeypatch):
         tier.shutdown()
 
 
-def test_wait_idle_blocks_until_tasks_complete():
+def test_wait_idle_blocks_until_tasks_complete(monkeypatch):
     """wait_idle must not return while a task is still in flight."""
-    pool = DualQueueThreadPool(n_read_threads=1, n_write_threads=1)
+
+    import vllm.v1.kv_offload.tiering.fs.manager as mgr_mod
+
+    # Make batch_store_block blocking
     gate = threading.Event()
-    pool.enqueue_store(job_id=1, n_tasks=1, tasks=[lambda: gate.wait(timeout=5.0)])
+
+    def blocking_batch_store_block(*args, **kwargs):
+        gate.wait(timeout=5.0)
+
+    monkeypatch.setattr(mgr_mod, "batch_store_block", blocking_batch_store_block)
+    # dummy task
+    task = Task(path="unused", offset=0)
+
+    pool = DualQueueThreadPool(n_read_threads=1, n_write_threads=1)
+    pool.enqueue_store(
+        job_id=1,
+        n_tasks=1,
+        tasks=[task],
+        make_batch_fn=lambda batch: mgr_mod.batch_store_block,
+    )
 
     waiter = threading.Thread(target=pool.wait_idle)
     waiter.start()

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -453,7 +453,7 @@ def test_wait_idle_blocks_until_tasks_complete():
         gate.wait(timeout=5.0)
 
     # dummy task
-    task = Task(key=key(0), offset=0)
+    task = Task(key=key(0), path="0", offset=0)
 
     pool = DualQueueThreadPool(n_read_threads=1, n_write_threads=1)
     pool.enqueue_store(
@@ -491,7 +491,7 @@ def test_batch_tasks_distribution(n_tasks, n_threads, expected_sizes):
     first), preserving order and accounting for every task."""
     pool = DualQueueThreadPool(n_read_threads=1, n_write_threads=1)
     try:
-        tasks = [Task(key=key(i), offset=i) for i in range(n_tasks)]
+        tasks = [Task(key=key(i), path=str(i), offset=i) for i in range(n_tasks)]
         batches = list(pool._batch_tasks(tasks, n_threads))
         assert [len(b) for b in batches] == expected_sizes
         assert [t for b in batches for t in b] == tasks
@@ -517,7 +517,7 @@ def test_store_job_parallelized_across_threads():
 
     pool = DualQueueThreadPool(n_read_threads=0, n_write_threads=n_threads)
     try:
-        tasks = [Task(key=key(i), offset=i) for i in range(n_threads)]
+        tasks = [Task(key=key(i), path=str(i), offset=i) for i in range(n_threads)]
         pool.enqueue_store(
             job_id=1,
             n_tasks=n_threads,

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -259,7 +259,7 @@ class FileSystemTierManager(SecondaryTierManager):
                         block_size=self._block_size,
                         use_o_direct=self._use_o_direct,
                     )
-                except OSError as exc:
+                except Exception as exc:
                     # Record number of successful loads.
                     num_succeeded = getattr(exc, "num_succeeded", 0)
                     failed_q = self._load_job_failed_keys[job_id]

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -18,7 +18,8 @@ File naming:  <base_path>_r<rank>/<hhh>/<hh>_g<group_idx>/<hash_hex>.bin
 import functools
 import json
 import os
-from collections.abc import Iterable
+from queue import SimpleQueue
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, ClassVar
 
 try:
@@ -54,7 +55,7 @@ from vllm.v1.kv_offload.tiering.fs.io import (
     batch_store_block,
     probe_o_direct,
 )
-from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
+from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool, Task
 
 if TYPE_CHECKING:
     from vllm.v1.kv_offload.base import OffloadingSpec
@@ -151,13 +152,11 @@ class FileSystemTierManager(SecondaryTierManager):
         # Keys of in-flight load (promotion) jobs, so a failed load can mark
         # its own cached lookup verdicts False (see get_finished_jobs).
         self._load_job_keys: dict[JobId, list[OffloadKey]] = {}
-        # Per load job: how many blocks loaded before a failure (partial keep).
+        # Per load job: Set of keys that failed the load.
         # Written by the pool worker inside the load task before it raises (so
-        # before task_done publishes the job); read on the scheduler thread in
-        # get_finished_jobs only for job ids the finished queue returned. Under
-        # the GIL that read cannot observe the finished job without the prior
-        # write, so no extra lock is needed (get_finished is itself lock-free).
-        self._load_progress: dict[JobId, int] = {}
+        # before task_done publishes the job); Need a thread-safe SimpleQueue
+        # as multiple threads can finish parts of a job simultaneously.
+        self._load_job_failed_keys: dict[JobId, SimpleQueue] = {}
 
         # Extract block size from primary view
         assert primary_kv_view.strides is not None, (
@@ -213,59 +212,78 @@ class FileSystemTierManager(SecondaryTierManager):
             return LookupResult.RETRY
         return LookupResult.HIT if result else LookupResult.MISS
 
+    def _tasks_from_jobmetadata(self, job_metadata: TransferJob) -> Iterable[Task]:
+        for key, bid in zip(job_metadata.keys, job_metadata.block_ids):
+            yield Task(
+                key=key,
+                offset=int(bid) * self._block_size,
+            )
+
     @override
     def submit_store(self, job_metadata: TransferJob) -> None:
         keys = list(job_metadata.keys)
         if self.events is not None:
             self._store_job_keys[job_metadata.job_id] = keys
-        task = functools.partial(
-            batch_store_block,
-            [self.file_mapper.get_file_name(key) for key in keys],
-            self._primary_kv_view,
-            [int(bid) * self._block_size for bid in job_metadata.block_ids],
-            self._block_size,
-            self._use_o_direct,
+
+        def make_batch_fn(batch: list[Task]) -> Callable[[], None]:
+            return functools.partial(
+                batch_store_block,
+                paths=[self.file_mapper.get_file_name(t.key) for t in batch],
+                offsets=[t.offset for t in batch],
+                view=self._primary_kv_view,
+                block_size=self._block_size,
+                use_o_direct=self._use_o_direct,
+            )
+
+        self._pool.enqueue_store(
+            job_metadata.job_id,
+            len(job_metadata.keys),
+            self._tasks_from_jobmetadata(job_metadata),
+            make_batch_fn=make_batch_fn,
         )
-        self._pool.enqueue_store(job_metadata.job_id, 1, [task])
 
     @override
     def submit_load(self, job_metadata: TransferJob) -> None:
         job_id = job_metadata.job_id
-        # Track this load's keys so a failed promotion can mark only its failed
-        # keys as a miss (see get_finished_jobs).
         keys = list(job_metadata.keys)
-        self._load_job_keys[job_id] = keys
-        paths = [self.file_mapper.get_file_name(key) for key in keys]
-        offsets = [int(bid) * self._block_size for bid in job_metadata.block_ids]
+        self._load_job_keys[job_metadata.job_id] = keys
+        self._load_job_failed_keys[job_metadata.job_id] = SimpleQueue()
 
-        def load_task() -> None:
-            try:
-                batch_load_block(
-                    paths,
-                    self._primary_kv_view,
-                    offsets,
-                    self._block_size,
-                    self._use_o_direct,
-                )
-            except OSError as exc:
-                # Runs on the pool worker thread. Record how many blocks loaded
-                # before the failure so get_finished_jobs can keep them; this
-                # write precedes task_done, so the scheduler reads it safely
-                # under the GIL once the finished queue hands back this job.
-                num_succeeded = getattr(exc, "num_succeeded", 0)
-                self._load_progress[job_id] = num_succeeded
-                # Surfaces errno (e.g. EMFILE "Too many open files") for both
-                # the C and Python load paths.
-                logger.debug(
-                    "Load of %d blocks for job %s failed at block %d: %s",
-                    len(paths),
-                    job_id,
-                    num_succeeded,
-                    exc,
-                )
-                raise
+        def make_batch_fn(batch: list[Task]) -> Callable[[], None]:
+            def load_task() -> None:
+                try:
+                    batch_load_block(
+                        paths=[self.file_mapper.get_file_name(t.key) for t in batch],
+                        offsets=[t.offset for t in batch],
+                        view=self._primary_kv_view,
+                        block_size=self._block_size,
+                        use_o_direct=self._use_o_direct,
+                    )
+                except OSError as exc:
+                    # Record number of successful loads.
+                    num_succeeded = getattr(exc, "num_succeeded", 0)
+                    failed_q = self._load_job_failed_keys[job_id]
+                    for t in batch[num_succeeded:]:
+                        failed_q.put(t.key)
+                    # Surfaces errno (e.g. EMFILE "Too many open files") for both
+                    # the C and Python load paths.
+                    logger.debug(
+                        "Load of %d blocks for job %s failed at block %d: %s",
+                        len(batch),
+                        job_id,
+                        num_succeeded,
+                        exc,
+                    )
+                    raise
 
-        self._pool.enqueue_load(job_id, 1, [load_task])
+            return load_task
+
+        self._pool.enqueue_load(
+            job_metadata.job_id,
+            len(job_metadata.keys),
+            self._tasks_from_jobmetadata(job_metadata),
+            make_batch_fn=make_batch_fn,
+        )
 
     @override
     def get_finished_jobs(self) -> Iterable[JobResult]:
@@ -285,14 +303,13 @@ class FileSystemTierManager(SecondaryTierManager):
                         )
                     )
             load_keys = self._load_job_keys.pop(job_id, None)
-            num_succeeded = self._load_progress.pop(job_id, 0)
+            failed_q = self._load_job_failed_keys.pop(job_id, None)
             if load_keys is not None and not success:
-                # A batched load stops at the first bad block and reports how
-                # many loaded before it. Those earlier blocks are kept in the
-                # primary tier (reported via successful_keys); only this block
-                # and the ones after it are marked a miss and recomputed.
-                successful = load_keys[:num_succeeded]
-                failed = load_keys[num_succeeded:]
+                failed: list[OffloadKey] = []
+                if failed_q is not None:
+                    while not failed_q.empty():
+                        failed.append(failed_q.get_nowait())
+                successful = set(load_keys) - set(failed)
                 self._lookup_manager.mark_miss(failed)
                 results.append(
                     JobResult(

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -18,8 +18,8 @@ File naming:  <base_path>_r<rank>/<hhh>/<hh>_g<group_idx>/<hash_hex>.bin
 import functools
 import json
 import os
-from queue import SimpleQueue
 from collections.abc import Callable, Iterable
+from queue import SimpleQueue
 from typing import TYPE_CHECKING, ClassVar
 
 try:

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -238,7 +238,7 @@ class FileSystemTierManager(SecondaryTierManager):
 
         self._pool.enqueue_store(
             job_metadata.job_id,
-            len(job_metadata.keys),
+            len(keys),
             self._tasks_from_jobmetadata(job_metadata),
             make_batch_fn=make_batch_fn,
         )
@@ -280,8 +280,8 @@ class FileSystemTierManager(SecondaryTierManager):
             return load_task
 
         self._pool.enqueue_load(
-            job_metadata.job_id,
-            len(job_metadata.keys),
+            job_id,
+            len(keys),
             self._tasks_from_jobmetadata(job_metadata),
             make_batch_fn=make_batch_fn,
         )

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -15,7 +15,6 @@ File naming:  <base_path>_r<rank>/<hhh>/<hh>_g<group_idx>/<hash_hex>.bin
               (hash-based subdirectories to limit directory fan-out)
 """
 
-import functools
 import json
 import os
 from collections.abc import Iterable
@@ -50,11 +49,9 @@ from vllm.v1.kv_offload.tiering.base import (
     SecondaryTierManager,
 )
 from vllm.v1.kv_offload.tiering.fs.io import (
-    batch_load_block,
-    batch_store_block,
     probe_o_direct,
 )
-from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
+from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool, Task
 
 if TYPE_CHECKING:
     from vllm.v1.kv_offload.base import OffloadingSpec
@@ -203,32 +200,33 @@ class FileSystemTierManager(SecondaryTierManager):
             return LookupResult.RETRY
         return LookupResult.HIT if result else LookupResult.MISS
 
+    def _tasks_from_jobmetadata(self, job_metadata: JobMetadata) -> Iterable[Task]:
+        for key, bid in zip(job_metadata.keys, job_metadata.block_ids):
+            yield Task(
+                path=self.file_mapper.get_file_name(key),
+                view=self._primary_kv_view,
+                offset=int(bid) * self._block_size,
+                block_size=self._block_size,
+                use_o_direct=self._use_o_direct,
+            )
+
     @override
     def submit_store(self, job_metadata: JobMetadata) -> None:
         if self.events is not None:
             self._store_job_keys[job_metadata.job_id] = list(job_metadata.keys)
-        task = functools.partial(
-            batch_store_block,
-            [self.file_mapper.get_file_name(key) for key in job_metadata.keys],
-            self._primary_kv_view,
-            [int(bid) * self._block_size for bid in job_metadata.block_ids],
-            self._block_size,
-            self._use_o_direct,
+        self._pool.enqueue_store(
+            job_metadata.job_id,
+            len(job_metadata.keys),
+            self._tasks_from_jobmetadata(job_metadata),
         )
-        self._pool.enqueue_store(job_metadata.job_id, 1, [task])
 
     @override
     def submit_load(self, job_metadata: JobMetadata) -> None:
-        task = functools.partial(
-            batch_load_block,
-            [self.file_mapper.get_file_name(key) for key in job_metadata.keys],
-            self._primary_kv_view,
-            [int(bid) * self._block_size for bid in job_metadata.block_ids],
-            self._block_size,
-            self._use_o_direct,
+        self._pool.enqueue_load(
+            job_metadata.job_id,
+            len(job_metadata.keys),
+            self._tasks_from_jobmetadata(job_metadata),
         )
-
-        self._pool.enqueue_load(job_metadata.job_id, 1, [task])
 
     @override
     def get_finished_jobs(self) -> Iterable[JobResult]:

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -15,9 +15,10 @@ File naming:  <base_path>_r<rank>/<hhh>/<hh>_g<group_idx>/<hash_hex>.bin
               (hash-based subdirectories to limit directory fan-out)
 """
 
+import functools
 import json
 import os
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, ClassVar
 
 try:
@@ -49,6 +50,8 @@ from vllm.v1.kv_offload.tiering.base import (
     SecondaryTierManager,
 )
 from vllm.v1.kv_offload.tiering.fs.io import (
+    batch_load_block,
+    batch_store_block,
     probe_o_direct,
 )
 from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool, Task
@@ -204,28 +207,48 @@ class FileSystemTierManager(SecondaryTierManager):
         for key, bid in zip(job_metadata.keys, job_metadata.block_ids):
             yield Task(
                 path=self.file_mapper.get_file_name(key),
-                view=self._primary_kv_view,
                 offset=int(bid) * self._block_size,
-                block_size=self._block_size,
-                use_o_direct=self._use_o_direct,
             )
 
     @override
     def submit_store(self, job_metadata: JobMetadata) -> None:
         if self.events is not None:
             self._store_job_keys[job_metadata.job_id] = list(job_metadata.keys)
+
+        def make_batch_fn(batch: list[Task]) -> Callable[[], None]:
+            return functools.partial(
+                batch_store_block,
+                paths=[t.path for t in batch],
+                offsets=[t.offset for t in batch],
+                view=self._primary_kv_view,
+                block_size=self._block_size,
+                use_o_direct=self._use_o_direct,
+            )
+
         self._pool.enqueue_store(
             job_metadata.job_id,
             len(job_metadata.keys),
             self._tasks_from_jobmetadata(job_metadata),
+            make_batch_fn=make_batch_fn,
         )
 
     @override
     def submit_load(self, job_metadata: JobMetadata) -> None:
+        def make_batch_fn(batch: list[Task]) -> Callable[[], None]:
+            return functools.partial(
+                batch_load_block,
+                paths=[t.path for t in batch],
+                offsets=[t.offset for t in batch],
+                view=self._primary_kv_view,
+                block_size=self._block_size,
+                use_o_direct=self._use_o_direct,
+            )
+
         self._pool.enqueue_load(
             job_metadata.job_id,
             len(job_metadata.keys),
             self._tasks_from_jobmetadata(job_metadata),
+            make_batch_fn=make_batch_fn,
         )
 
     @override

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -216,6 +216,7 @@ class FileSystemTierManager(SecondaryTierManager):
         for key, bid in zip(job_metadata.keys, job_metadata.block_ids):
             yield Task(
                 key=key,
+                path=self.file_mapper.get_file_name(key),
                 offset=int(bid) * self._block_size,
             )
 
@@ -228,7 +229,7 @@ class FileSystemTierManager(SecondaryTierManager):
         def make_batch_fn(batch: list[Task]) -> Callable[[], None]:
             return functools.partial(
                 batch_store_block,
-                paths=[self.file_mapper.get_file_name(t.key) for t in batch],
+                paths=[t.path for t in batch],
                 offsets=[t.offset for t in batch],
                 view=self._primary_kv_view,
                 block_size=self._block_size,
@@ -253,7 +254,7 @@ class FileSystemTierManager(SecondaryTierManager):
             def load_task() -> None:
                 try:
                     batch_load_block(
-                        paths=[self.file_mapper.get_file_name(t.key) for t in batch],
+                        paths=[t.path for t in batch],
                         offsets=[t.offset for t in batch],
                         view=self._primary_kv_view,
                         block_size=self._block_size,

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -196,6 +196,7 @@ class FileSystemTierManager(SecondaryTierManager):
         self._pool = DualQueueThreadPool(
             n_read_threads,
             n_write_threads,
+            self._block_size,
             thread_name_prefix="vllm_kv_py_fs",
         )
 
@@ -310,6 +311,8 @@ class FileSystemTierManager(SecondaryTierManager):
                 if failed_q is not None:
                     while not failed_q.empty():
                         failed.append(failed_q.get_nowait())
+                # load_keys ordering is not preserved. If needed, this is can be
+                # updated to filter successful keys in a for-loop.
                 successful = set(load_keys) - set(failed)
                 self._lookup_manager.mark_miss(failed)
                 results.append(

--- a/vllm/v1/kv_offload/tiering/fs/thread_pool.py
+++ b/vllm/v1/kv_offload/tiering/fs/thread_pool.py
@@ -15,8 +15,8 @@ from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 
 from vllm.logger import init_logger
+from vllm.v1.kv_offload.base import OffloadKey
 from vllm.v1.kv_offload.tiering.base import JobId
-from vllm.v1.kv_offload.base import (OffloadKey)
 
 logger = init_logger(__name__)
 
@@ -69,6 +69,7 @@ class JobState:
             if not success:
                 self._success = False
             return self._completed == self._n_tasks, self._success, self._transfer_time
+
 
 class DualQueueThreadPool:
     """
@@ -152,7 +153,7 @@ class DualQueueThreadPool:
     ) -> None:
         """Batch `tasks` and append (fn, state, batch_size) entries to `queue`."""
         if n_tasks == 0:
-            self._finished_q.append((job_id, True))
+            self._finished_q.append((job_id, True, 0.0))
             return
         state = JobState(job_id, n_tasks)
         task_lst = list(tasks)  # Materialize tasks out of self._condition
@@ -255,7 +256,9 @@ class DualQueueThreadPool:
                 start_time = time.monotonic()
                 fn()
                 transfer_time = time.monotonic() - start_time
-                job_finished, success, total_time = state.task_done(batch_size, True, transfer_time)
+                job_finished, success, total_time = state.task_done(
+                    batch_size, True, transfer_time
+                )
             except Exception as exc:
                 transfer_time = time.monotonic() - start_time
                 logger.error(

--- a/vllm/v1/kv_offload/tiering/fs/thread_pool.py
+++ b/vllm/v1/kv_offload/tiering/fs/thread_pool.py
@@ -11,12 +11,24 @@ Thread pool:
 import threading
 import time
 from collections import deque
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass
 
 from vllm.logger import init_logger
 from vllm.v1.kv_offload.tiering.base import JobId
+from vllm.v1.kv_offload.base import (OffloadKey)
 
 logger = init_logger(__name__)
+
+
+@dataclass
+class Task:
+    """
+    I/O Task inputs
+    """
+
+    key: OffloadKey
+    offset: int
 
 
 class JobState:
@@ -48,16 +60,15 @@ class JobState:
         return self._job_id
 
     def task_done(
-        self, success: bool, transfer_time: float
+        self, batch_size: int, success: bool, transfer_time: float
     ) -> tuple[bool, bool, float]:
         """Returns if job completed and success flag"""
         with self._lock:
-            self._completed += 1
+            self._completed += batch_size
             self._transfer_time += transfer_time
             if not success:
                 self._success = False
             return self._completed == self._n_tasks, self._success, self._transfer_time
-
 
 class DualQueueThreadPool:
     """
@@ -74,6 +85,8 @@ class DualQueueThreadPool:
         n_write_threads: int,
         thread_name_prefix: str = "fs_secondary_tier",
     ) -> None:
+        self._n_read_threads = n_read_threads
+        self._n_write_threads = n_write_threads
         self._load_q: deque = deque()
         self._store_q: deque = deque()
         self._condition = threading.Condition(threading.Lock())
@@ -82,7 +95,9 @@ class DualQueueThreadPool:
         self._finished_q: deque[tuple[JobId, bool, float]] = deque()
         self._inflight_jobs = 0  # guarded by _condition
 
-        for i in range(n_read_threads):
+        assert self.total_threads > 0, "ThreadPool needs atleast one thread"
+
+        for i in range(self._n_read_threads):
             t = threading.Thread(
                 target=self._worker,
                 args=(True,),
@@ -92,7 +107,7 @@ class DualQueueThreadPool:
             t.start()
             self._threads.append(t)
 
-        for i in range(n_write_threads):
+        for i in range(self._n_write_threads):
             t = threading.Thread(
                 target=self._worker,
                 args=(False,),
@@ -102,33 +117,93 @@ class DualQueueThreadPool:
             t.start()
             self._threads.append(t)
 
+    @property
+    def total_threads(self) -> int:
+        return self._n_read_threads + self._n_write_threads
+
+    def _batch_tasks(
+        self,
+        tasks: list[Task],
+        n_threads: int,
+    ) -> Iterator[list[Task]]:
+        """
+        Batch tasks so that the request's tasks are split evenly across the
+        n_threads.
+        """
+        assert n_threads > 0
+
+        n_tasks = len(tasks)
+        q, r = divmod(n_tasks, n_threads)
+        batch_sizes = [q + 1 if i < r else q for i in range(n_threads)]
+        assert sum(batch_sizes) == n_tasks
+        start = 0
+        for bs in batch_sizes[: min(n_tasks, n_threads)]:
+            yield tasks[start : start + bs]
+            start += bs
+
+    def _enqueue(
+        self,
+        queue: deque,
+        make_batch_fn: Callable[[list[Task]], Callable[[], None]],
+        job_id: JobId,
+        tasks: Iterable[Task],
+        n_tasks: int,
+        n_threads: int,
+    ) -> None:
+        """Batch `tasks` and append (fn, state, batch_size) entries to `queue`."""
+        if n_tasks == 0:
+            self._finished_q.append((job_id, True))
+            return
+        state = JobState(job_id, n_tasks)
+        task_lst = list(tasks)  # Materialize tasks out of self._condition
+        assert len(task_lst) == n_tasks, "Unaccounted tasks"
+        n_batches = 0
+        with self._condition:
+            self._inflight_jobs += 1
+            for batch in self._batch_tasks(task_lst, n_threads):
+                queue.append((make_batch_fn(batch), len(batch), state))
+                n_batches += 1
+            self._condition.notify(n_batches)
+
     def enqueue_load(
         self,
         job_id: JobId,
         n_tasks: int,
-        tasks: Iterable[Callable],
+        tasks: Iterable[Task],
+        make_batch_fn: Callable[[list[Task]], Callable[[], None]],
     ) -> None:
         """Enqueue load tasks for a job (high-priority for load-priority threads)."""
-        state = JobState(job_id, n_tasks)
-        with self._condition:
-            self._inflight_jobs += 1
-            for fn in tasks:
-                self._load_q.append((fn, state))
-            self._condition.notify(n_tasks)
+
+        self._enqueue(
+            self._load_q,
+            make_batch_fn,
+            job_id,
+            tasks,
+            n_tasks=n_tasks,
+            n_threads=self._n_read_threads
+            if self._n_read_threads > 0
+            else self.total_threads,
+        )
 
     def enqueue_store(
         self,
         job_id: JobId,
         n_tasks: int,
-        tasks: Iterable[Callable],
+        tasks: Iterable[Task],
+        make_batch_fn: Callable[[list[Task]], Callable[[], None]],
     ) -> None:
         """Enqueue store tasks for a job (high-priority for store-priority threads)."""
-        state = JobState(job_id, n_tasks)
-        with self._condition:
-            self._inflight_jobs += 1
-            for fn in tasks:
-                self._store_q.append((fn, state))
-            self._condition.notify(n_tasks)
+
+        self._enqueue(
+            self._store_q,
+            make_batch_fn,
+            job_id,
+            tasks,
+            n_tasks=n_tasks,
+            n_threads=self._n_write_threads
+            if self._n_write_threads > 0
+            else self.total_threads,
+        )
 
     def get_finished(self) -> list[tuple[JobId, bool, float]]:
         # No lock needed: deque is thread-safe for concurrent append/popleft,
@@ -173,12 +248,14 @@ class DualQueueThreadPool:
                     return
                 primary = self._load_q if load_priority else self._store_q
                 secondary = self._store_q if load_priority else self._load_q
-                task, state = primary.popleft() if primary else secondary.popleft()
+                fn, batch_size, state = (
+                    primary.popleft() if primary else secondary.popleft()
+                )
             try:
                 start_time = time.monotonic()
-                task()
+                fn()
                 transfer_time = time.monotonic() - start_time
-                job_finished, success, total_time = state.task_done(True, transfer_time)
+                job_finished, success, total_time = state.task_done(batch_size, True, transfer_time)
             except Exception as exc:
                 transfer_time = time.monotonic() - start_time
                 logger.error(
@@ -187,7 +264,7 @@ class DualQueueThreadPool:
                     exc,
                 )
                 job_finished, success, total_time = state.task_done(
-                    False, transfer_time
+                    batch_size, False, transfer_time
                 )
 
             if job_finished:

--- a/vllm/v1/kv_offload/tiering/fs/thread_pool.py
+++ b/vllm/v1/kv_offload/tiering/fs/thread_pool.py
@@ -8,7 +8,6 @@ Thread pool:
     Load jobs are enqueued to the load queue; store jobs to the store queue.
 """
 
-import itertools
 import threading
 from collections import deque
 from collections.abc import Callable, Iterable, Iterator
@@ -84,6 +83,8 @@ class DualQueueThreadPool:
         self._finished_q: deque[tuple[JobId, bool]] = deque()
         self._inflight_jobs = 0  # guarded by _condition
 
+        assert self.total_threads > 0, "ThreadPool needs atleast one thread"
+
         for i in range(self._n_read_threads):
             t = threading.Thread(
                 target=self._worker,
@@ -104,25 +105,29 @@ class DualQueueThreadPool:
             t.start()
             self._threads.append(t)
 
+    @property
+    def total_threads(self) -> int:
+        return self._n_read_threads + self._n_write_threads
+
     def _batch_tasks(
         self,
-        tasks: Iterable[Task],
-        n_tasks: int,
+        tasks: list[Task],
         n_threads: int,
     ) -> Iterator[list[Task]]:
         """
         Batch tasks so that the request's tasks are split evenly across the
         n_threads.
         """
-        tasks = iter(tasks)
+        assert n_threads > 0
+
+        n_tasks = len(tasks)
         q, r = divmod(n_tasks, n_threads)
         batch_sizes = [q + 1 if i < r else q for i in range(n_threads)]
+        assert sum(batch_sizes) == n_tasks
+        start = 0
         for bs in batch_sizes[: min(n_tasks, n_threads)]:
-            batch = list(itertools.islice(tasks, bs))
-            assert len(batch) == bs
-            yield batch
-
-        assert next(tasks, None) is None, "Unaccounted tasks"
+            yield tasks[start : start + bs]
+            start += bs
 
     def _enqueue(
         self,
@@ -138,10 +143,12 @@ class DualQueueThreadPool:
             self._finished_q.append((job_id, True))
             return
         state = JobState(job_id, n_tasks)
+        task_lst = list(tasks)  # Materialize tasks out of self._condition
+        assert len(task_lst) == n_tasks, "Unaccounted tasks"
         n_batches = 0
         with self._condition:
             self._inflight_jobs += 1
-            for batch in self._batch_tasks(tasks, n_tasks, n_threads):
+            for batch in self._batch_tasks(task_lst, n_threads):
                 queue.append((make_batch_fn(batch), len(batch), state))
                 n_batches += 1
             self._condition.notify(n_batches)
@@ -161,7 +168,9 @@ class DualQueueThreadPool:
             job_id,
             tasks,
             n_tasks=n_tasks,
-            n_threads=self._n_read_threads,
+            n_threads=self._n_read_threads
+            if self._n_read_threads > 0
+            else self.total_threads,
         )
 
     def enqueue_store(
@@ -179,7 +188,9 @@ class DualQueueThreadPool:
             job_id,
             tasks,
             n_tasks=n_tasks,
-            n_threads=self._n_write_threads,
+            n_threads=self._n_write_threads
+            if self._n_write_threads > 0
+            else self.total_threads,
         )
 
     def get_finished(self) -> list[tuple[JobId, bool]]:

--- a/vllm/v1/kv_offload/tiering/fs/thread_pool.py
+++ b/vllm/v1/kv_offload/tiering/fs/thread_pool.py
@@ -96,7 +96,7 @@ class DualQueueThreadPool:
         self._finished_q: deque[tuple[JobId, bool, float]] = deque()
         self._inflight_jobs = 0  # guarded by _condition
 
-        assert self.total_threads > 0, "ThreadPool needs atleast one thread"
+        assert self.total_threads > 0, "ThreadPool needs at least one thread"
 
         for i in range(self._n_read_threads):
             t = threading.Thread(

--- a/vllm/v1/kv_offload/tiering/fs/thread_pool.py
+++ b/vllm/v1/kv_offload/tiering/fs/thread_pool.py
@@ -8,14 +8,30 @@ Thread pool:
     Load jobs are enqueued to the load queue; store jobs to the store queue.
 """
 
+import functools
 import threading
 from collections import deque
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass
 
 from vllm.logger import init_logger
 from vllm.v1.kv_offload.tiering.base import JobId
+from vllm.v1.kv_offload.tiering.fs.io import batch_load_block, batch_store_block
 
 logger = init_logger(__name__)
+
+
+@dataclass
+class Task:
+    """
+    I/O Task inputs
+    """
+
+    path: str
+    view: memoryview
+    offset: int
+    block_size: int
+    use_o_direct: bool
 
 
 class JobState:
@@ -38,10 +54,10 @@ class JobState:
     def job_id(self) -> JobId:
         return self._job_id
 
-    def task_done(self, success: bool) -> tuple[bool, bool]:
+    def task_done(self, batch_size: int, success: bool) -> tuple[bool, bool]:
         """Returns if job completed and success flag"""
         with self._lock:
-            self._completed += 1
+            self._completed += batch_size
             if not success:
                 self._success = False
             return self._completed == self._n_tasks, self._success
@@ -62,6 +78,8 @@ class DualQueueThreadPool:
         n_write_threads: int,
         thread_name_prefix: str = "fs_secondary_tier",
     ) -> None:
+        self._n_read_threads = n_read_threads
+        self._n_write_threads = n_write_threads
         self._load_q: deque = deque()
         self._store_q: deque = deque()
         self._condition = threading.Condition(threading.Lock())
@@ -70,7 +88,7 @@ class DualQueueThreadPool:
         self._finished_q: deque[tuple[JobId, bool]] = deque()
         self._inflight_jobs = 0  # guarded by _condition
 
-        for i in range(n_read_threads):
+        for i in range(self._n_read_threads):
             t = threading.Thread(
                 target=self._worker,
                 args=(True,),
@@ -80,7 +98,7 @@ class DualQueueThreadPool:
             t.start()
             self._threads.append(t)
 
-        for i in range(n_write_threads):
+        for i in range(self._n_write_threads):
             t = threading.Thread(
                 target=self._worker,
                 args=(False,),
@@ -90,33 +108,101 @@ class DualQueueThreadPool:
             t.start()
             self._threads.append(t)
 
+    def _batch_tasks(
+        self, tasks: Iterable[Task], batch_size: int
+    ) -> Iterator[list[Task]]:
+        """Chunk tasks into lists of at most `batch_size` tasks."""
+        batch: list[Task] = []
+        for task in tasks:
+            batch.append(task)
+            assert batch[0].view is task.view
+            assert batch[0].block_size == task.block_size
+            assert batch[0].use_o_direct == task.use_o_direct
+            if len(batch) >= batch_size:
+                yield batch
+                batch = []
+        if batch:
+            yield batch
+
+    def _enqueue(
+        self,
+        queue: deque,
+        make_fn: Callable[[list[Task]], Callable[[], None]],
+        job_id: JobId,
+        n_tasks: int,
+        tasks: Iterable[Task],
+        batch_size: int,
+    ) -> None:
+        """Batch `tasks` and append (fn, state, batch_size) entries to `queue`."""
+        if n_tasks == 0:
+            self._finished_q.append((job_id, True))
+            return
+        state = JobState(job_id, n_tasks)
+        n_batches = 0
+        with self._condition:
+            self._inflight_jobs += 1
+            for batch in self._batch_tasks(tasks, batch_size):
+                queue.append((make_fn(batch), len(batch), state))
+                n_batches += 1
+            self._condition.notify(n_batches)
+
     def enqueue_load(
         self,
         job_id: JobId,
         n_tasks: int,
-        tasks: Iterable[Callable],
+        tasks: Iterable[Task],
     ) -> None:
         """Enqueue load tasks for a job (high-priority for load-priority threads)."""
-        state = JobState(job_id, n_tasks)
-        with self._condition:
-            self._inflight_jobs += 1
-            for fn in tasks:
-                self._load_q.append((fn, state))
-            self._condition.notify(n_tasks)
+
+        def make_fn(batch: list[Task]) -> Callable[[], None]:
+            t0 = batch[0]
+            view, block_size, use_o_direct = t0.view, t0.block_size, t0.use_o_direct
+            return functools.partial(
+                batch_load_block,
+                paths=[t.path for t in batch],
+                view=view,
+                offsets=[t.offset for t in batch],
+                block_size=block_size,
+                use_o_direct=use_o_direct,
+            )
+
+        self._enqueue(
+            self._load_q,
+            make_fn,
+            job_id,
+            n_tasks,
+            tasks,
+            batch_size=max(1, n_tasks // self._n_read_threads),
+        )
 
     def enqueue_store(
         self,
         job_id: JobId,
         n_tasks: int,
-        tasks: Iterable[Callable],
+        tasks: Iterable[Task],
     ) -> None:
         """Enqueue store tasks for a job (high-priority for store-priority threads)."""
-        state = JobState(job_id, n_tasks)
-        with self._condition:
-            self._inflight_jobs += 1
-            for fn in tasks:
-                self._store_q.append((fn, state))
-            self._condition.notify(n_tasks)
+
+        def make_fn(batch: list[Task]) -> Callable[[], None]:
+            t0 = batch[0]
+            view, block_size, use_o_direct = t0.view, t0.block_size, t0.use_o_direct
+            return functools.partial(
+                batch_store_block,
+                paths=[t.path for t in batch],
+                view=view,
+                offsets=[t.offset for t in batch],
+                block_size=block_size,
+                use_o_direct=use_o_direct,
+            )
+
+        self._enqueue(
+            self._store_q,
+            make_fn,
+            job_id,
+            n_tasks,
+            tasks,
+            batch_size=max(1, n_tasks // self._n_write_threads),
+        )
 
     def get_finished(self) -> list[tuple[JobId, bool]]:
         # No lock needed: deque is thread-safe for concurrent append/popleft,
@@ -161,17 +247,19 @@ class DualQueueThreadPool:
                     return
                 primary = self._load_q if load_priority else self._store_q
                 secondary = self._store_q if load_priority else self._load_q
-                task, state = primary.popleft() if primary else secondary.popleft()
+                fn, batch_size, state = (
+                    primary.popleft() if primary else secondary.popleft()
+                )
             try:
-                task()
-                job_finished, success = state.task_done(True)
+                fn()
+                job_finished, success = state.task_done(batch_size, True)
             except Exception as exc:
                 logger.error(
                     "Job %s block I/O failed: %s",
                     state.job_id,
                     exc,
                 )
-                job_finished, success = state.task_done(False)
+                job_finished, success = state.task_done(batch_size, False)
 
             if job_finished:
                 with self._condition:

--- a/vllm/v1/kv_offload/tiering/fs/thread_pool.py
+++ b/vllm/v1/kv_offload/tiering/fs/thread_pool.py
@@ -28,6 +28,7 @@ class Task:
     """
 
     key: OffloadKey
+    path: str
     offset: int
 
 

--- a/vllm/v1/kv_offload/tiering/fs/thread_pool.py
+++ b/vllm/v1/kv_offload/tiering/fs/thread_pool.py
@@ -8,7 +8,6 @@ Thread pool:
     Load jobs are enqueued to the load queue; store jobs to the store queue.
 """
 
-import functools
 import threading
 from collections import deque
 from collections.abc import Callable, Iterable, Iterator
@@ -16,7 +15,6 @@ from dataclasses import dataclass
 
 from vllm.logger import init_logger
 from vllm.v1.kv_offload.tiering.base import JobId
-from vllm.v1.kv_offload.tiering.fs.io import batch_load_block, batch_store_block
 
 logger = init_logger(__name__)
 
@@ -28,10 +26,7 @@ class Task:
     """
 
     path: str
-    view: memoryview
     offset: int
-    block_size: int
-    use_o_direct: bool
 
 
 class JobState:
@@ -115,9 +110,6 @@ class DualQueueThreadPool:
         batch: list[Task] = []
         for task in tasks:
             batch.append(task)
-            assert batch[0].view is task.view
-            assert batch[0].block_size == task.block_size
-            assert batch[0].use_o_direct == task.use_o_direct
             if len(batch) >= batch_size:
                 yield batch
                 batch = []
@@ -127,7 +119,7 @@ class DualQueueThreadPool:
     def _enqueue(
         self,
         queue: deque,
-        make_fn: Callable[[list[Task]], Callable[[], None]],
+        make_batch_fn: Callable[[list[Task]], Callable[[], None]],
         job_id: JobId,
         n_tasks: int,
         tasks: Iterable[Task],
@@ -142,7 +134,7 @@ class DualQueueThreadPool:
         with self._condition:
             self._inflight_jobs += 1
             for batch in self._batch_tasks(tasks, batch_size):
-                queue.append((make_fn(batch), len(batch), state))
+                queue.append((make_batch_fn(batch), len(batch), state))
                 n_batches += 1
             self._condition.notify(n_batches)
 
@@ -151,24 +143,13 @@ class DualQueueThreadPool:
         job_id: JobId,
         n_tasks: int,
         tasks: Iterable[Task],
+        make_batch_fn: Callable[[list[Task]], Callable[[], None]],
     ) -> None:
         """Enqueue load tasks for a job (high-priority for load-priority threads)."""
 
-        def make_fn(batch: list[Task]) -> Callable[[], None]:
-            t0 = batch[0]
-            view, block_size, use_o_direct = t0.view, t0.block_size, t0.use_o_direct
-            return functools.partial(
-                batch_load_block,
-                paths=[t.path for t in batch],
-                view=view,
-                offsets=[t.offset for t in batch],
-                block_size=block_size,
-                use_o_direct=use_o_direct,
-            )
-
         self._enqueue(
             self._load_q,
-            make_fn,
+            make_batch_fn,
             job_id,
             n_tasks,
             tasks,
@@ -180,24 +161,13 @@ class DualQueueThreadPool:
         job_id: JobId,
         n_tasks: int,
         tasks: Iterable[Task],
+        make_batch_fn: Callable[[list[Task]], Callable[[], None]],
     ) -> None:
         """Enqueue store tasks for a job (high-priority for store-priority threads)."""
 
-        def make_fn(batch: list[Task]) -> Callable[[], None]:
-            t0 = batch[0]
-            view, block_size, use_o_direct = t0.view, t0.block_size, t0.use_o_direct
-            return functools.partial(
-                batch_store_block,
-                paths=[t.path for t in batch],
-                view=view,
-                offsets=[t.offset for t in batch],
-                block_size=block_size,
-                use_o_direct=use_o_direct,
-            )
-
         self._enqueue(
             self._store_q,
-            make_fn,
+            make_batch_fn,
             job_id,
             n_tasks,
             tasks,

--- a/vllm/v1/kv_offload/tiering/fs/thread_pool.py
+++ b/vllm/v1/kv_offload/tiering/fs/thread_pool.py
@@ -111,8 +111,8 @@ class DualQueueThreadPool:
         n_threads: int,
     ) -> Iterator[list[Task]]:
         """
-        Batch tasks so that the request's tasks are split evenly
-        across the n_threads. This is important for load-balancing and TTFT.
+        Batch tasks so that the request's tasks are split evenly across the
+        n_threads.
         """
         tasks = iter(tasks)
         q, r = divmod(n_tasks, n_threads)

--- a/vllm/v1/kv_offload/tiering/fs/thread_pool.py
+++ b/vllm/v1/kv_offload/tiering/fs/thread_pool.py
@@ -8,6 +8,7 @@ Thread pool:
     Load jobs are enqueued to the load queue; store jobs to the store queue.
 """
 
+import itertools
 import threading
 from collections import deque
 from collections.abc import Callable, Iterable, Iterator
@@ -104,26 +105,33 @@ class DualQueueThreadPool:
             self._threads.append(t)
 
     def _batch_tasks(
-        self, tasks: Iterable[Task], batch_size: int
+        self,
+        tasks: Iterable[Task],
+        n_tasks: int,
+        n_threads: int,
     ) -> Iterator[list[Task]]:
-        """Chunk tasks into lists of at most `batch_size` tasks."""
-        batch: list[Task] = []
-        for task in tasks:
-            batch.append(task)
-            if len(batch) >= batch_size:
-                yield batch
-                batch = []
-        if batch:
+        """
+        Batch tasks so that the request's tasks are split evenly
+        across the n_threads. This is important for load-balancing and TTFT.
+        """
+        tasks = iter(tasks)
+        q, r = divmod(n_tasks, n_threads)
+        batch_sizes = [q + 1 if i < r else q for i in range(n_threads)]
+        for bs in batch_sizes[: min(n_tasks, n_threads)]:
+            batch = list(itertools.islice(tasks, bs))
+            assert len(batch) == bs
             yield batch
+
+        assert next(tasks, None) is None, "Unaccounted tasks"
 
     def _enqueue(
         self,
         queue: deque,
         make_batch_fn: Callable[[list[Task]], Callable[[], None]],
         job_id: JobId,
-        n_tasks: int,
         tasks: Iterable[Task],
-        batch_size: int,
+        n_tasks: int,
+        n_threads: int,
     ) -> None:
         """Batch `tasks` and append (fn, state, batch_size) entries to `queue`."""
         if n_tasks == 0:
@@ -133,7 +141,7 @@ class DualQueueThreadPool:
         n_batches = 0
         with self._condition:
             self._inflight_jobs += 1
-            for batch in self._batch_tasks(tasks, batch_size):
+            for batch in self._batch_tasks(tasks, n_tasks, n_threads):
                 queue.append((make_batch_fn(batch), len(batch), state))
                 n_batches += 1
             self._condition.notify(n_batches)
@@ -151,9 +159,9 @@ class DualQueueThreadPool:
             self._load_q,
             make_batch_fn,
             job_id,
-            n_tasks,
             tasks,
-            batch_size=max(1, n_tasks // self._n_read_threads),
+            n_tasks=n_tasks,
+            n_threads=self._n_read_threads,
         )
 
     def enqueue_store(
@@ -169,9 +177,9 @@ class DualQueueThreadPool:
             self._store_q,
             make_batch_fn,
             job_id,
-            n_tasks,
             tasks,
-            batch_size=max(1, n_tasks // self._n_write_threads),
+            n_tasks=n_tasks,
+            n_threads=self._n_write_threads,
         )
 
     def get_finished(self) -> list[tuple[JobId, bool]]:

--- a/vllm/v1/kv_offload/tiering/fs/thread_pool.py
+++ b/vllm/v1/kv_offload/tiering/fs/thread_pool.py
@@ -44,7 +44,8 @@ class JobState:
         "_n_tasks",
         "_completed",
         "_success",
-        "_transfer_time",
+        "_start_time",
+        "_finish_time",
         "_lock",
     )
 
@@ -53,23 +54,33 @@ class JobState:
         self._n_tasks = n_tasks
         self._completed = 0
         self._success = True
-        self._transfer_time = 0.0
+        self._start_time: float | None = None
+        self._finish_time: float = 0.0
         self._lock = threading.Lock()
 
     @property
     def job_id(self) -> JobId:
         return self._job_id
 
+    def maybe_start(self) -> None:
+        """Record when the first parallel task starts transferring data."""
+        with self._lock:
+            if self._start_time is None:
+                self._start_time = time.monotonic()
+
     def task_done(
-        self, batch_size: int, success: bool, transfer_time: float
+        self, batch_size: int, success: bool, finish_time: float
     ) -> tuple[bool, bool, float]:
         """Returns if job completed and success flag"""
         with self._lock:
             self._completed += batch_size
-            self._transfer_time += transfer_time
             if not success:
                 self._success = False
-            return self._completed == self._n_tasks, self._success, self._transfer_time
+
+            self._finish_time = max(self._finish_time, finish_time)
+            assert self._start_time is not None
+            transfer_time = self._finish_time - self._start_time
+            return self._completed == self._n_tasks, self._success, transfer_time
 
 
 class DualQueueThreadPool:
@@ -280,21 +291,19 @@ class DualQueueThreadPool:
                     primary.popleft() if primary else secondary.popleft()
                 )
             try:
-                start_time = time.monotonic()
+                state.maybe_start()
                 fn()
-                transfer_time = time.monotonic() - start_time
                 job_finished, success, total_time = state.task_done(
-                    batch_size, True, transfer_time
+                    batch_size, True, finish_time=time.monotonic()
                 )
             except Exception as exc:
-                transfer_time = time.monotonic() - start_time
                 logger.error(
                     "Job %s block I/O failed: %s",
                     state.job_id,
                     exc,
                 )
                 job_finished, success, total_time = state.task_done(
-                    batch_size, False, transfer_time
+                    batch_size, False, finish_time=time.monotonic()
                 )
 
             if job_finished:

--- a/vllm/v1/kv_offload/tiering/fs/thread_pool.py
+++ b/vllm/v1/kv_offload/tiering/fs/thread_pool.py
@@ -85,10 +85,12 @@ class DualQueueThreadPool:
         self,
         n_read_threads: int,
         n_write_threads: int,
+        block_size: int | None = None,
         thread_name_prefix: str = "fs_secondary_tier",
     ) -> None:
         self._n_read_threads = n_read_threads
         self._n_write_threads = n_write_threads
+        self._block_size = block_size
         self._load_q: deque = deque()
         self._store_q: deque = deque()
         self._condition = threading.Condition(threading.Lock())
@@ -96,6 +98,11 @@ class DualQueueThreadPool:
         self._threads: list[threading.Thread] = []
         self._finished_q: deque[tuple[JobId, bool, float]] = deque()
         self._inflight_jobs = 0  # guarded by _condition
+
+        # fanout_target_bytes is the number of bytes sufficient to saturate the
+        # device bandwidth with a single read/write call. This factors into
+        # how Job tasks are batched.
+        self._fanout_target_bytes = 32 * (2**20)  # 32MiB
 
         assert self.total_threads > 0, "ThreadPool needs at least one thread"
 
@@ -143,6 +150,24 @@ class DualQueueThreadPool:
             yield tasks[start : start + bs]
             start += bs
 
+    def _fanout_degree(self, n_tasks: int, n_threads: int) -> int:
+        """How many batches to split a job of ``n_tasks`` blocks into.
+
+        Splitting only pays while the device is not already saturated. A large
+        block keeps it busy on its own, and once enough jobs are in flight the
+        threads are busy regardless; in both regimes extra batches only add
+        queue entries, wake-ups and GIL round-trips without moving more bytes.
+
+        Callers must hold ``self._condition``.
+        """
+        if self._block_size is None:
+            return min(n_tasks, n_threads)
+        budget = -(-self._fanout_target_bytes // self._block_size)
+        # No more reads can be outstanding than there are workers to issue them.
+        budget = min(budget, self.total_threads)
+        jobs = max(1, self._inflight_jobs)
+        return max(1, min(-(-budget // jobs), n_tasks, n_threads))
+
     def _enqueue(
         self,
         queue: deque,
@@ -162,6 +187,7 @@ class DualQueueThreadPool:
         n_batches = 0
         with self._condition:
             self._inflight_jobs += 1
+            n_threads = self._fanout_degree(n_tasks, n_threads)
             for batch in self._batch_tasks(task_lst, n_threads):
                 queue.append((make_batch_fn(batch), len(batch), state))
                 n_batches += 1


### PR DESCRIPTION
PR #49152  introduced batched C versions of load_block / store_block. The batching was request-level, i.e. each thread in the thread_pool receives all the keys for a request and loads/stores them one after another. 

If there are 16 requests, each with say 100 keys to load, and we have 16 threads. Each thread will work on a separate request. This is less desirable as read jobs for different requests are interleaved on the disk, increasing any single request's total read time. 

This PR: 
device-saturation driven batching : We batch based on 2 factors,
 1. File size: Batch for small files. When file size is large, we already saturate the device bandwidth without batching. 
 2. inflight_jobs: When we see inflight_jobs piling up, we don't batch as aggressively. 
 Note that the decision to batch is not discrete. Based on the factors mentioned above, the degree of batching varies. 

### Benchmarks
Look at PR comments. 

### Eval 
```
vllm serve openai/gpt-oss-120b --tensor-parallel-size=2 --kv-transfer-config '{                                                           
  "kv_connector": "OffloadingConnector",                                                                                                     
  "kv_role": "kv_both",                                                                                                                      
  "kv_connector_extra_config": {                                                                                                             
    "spec_name": "TieringOffloadingSpec",
    "cpu_bytes_to_use": 150930000000,
    "eviction_policy": "lru",
    "secondary_tiers": [{
       "type": "fs",
       "root_dir": "/mnt/nvme-storage/",
       "n_read_threads": 16,
       "n_write_threads": 16
    }]
    ,"enable_cross_layers_blocks" : "True"
  }
}' --enable-prefix-caching --no-disable-hybrid-kv-cache-manager --port 8000
```
```
TARGET_URL="http://127.0.0.1:8000"
MODEL="openai/gpt-oss-120b"
LM_EVAL_NUM_CONCURRENT=1000
LM_EVAL_TASKS="gsm8k"


lm_eval \
  --model local-completions \
  --model_args "base_url=${TARGET_URL}/v1/completions,model=${MODEL},tokenized_requests=False,num_concurrent=${LM_EVAL_NUM_CONCURRENT},trust_remote_code=True" \
  --tasks ${LM_EVAL_TASKS} \
  --seed 42 \
  --num_fewshot 25 \
  --gen_kwargs temperature=0.0
```

### Eval results 
#### Run1 : cold disk
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|                                                                    
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|                                                                    
|gsm8k|      3|flexible-extract|    25|exact_match|↑  |0.6353|±  |0.0133|                                                                    
|     |       |strict-match    |    25|exact_match|↑  |0.4200|±  |0.0136| 
```
#### Run2: warm disk 
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|                                                                    
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|                                                                    
|gsm8k|      3|flexible-extract|    25|exact_match|↑  |0.6323|±  |0.0133|                                                                    
|     |       |strict-match    |    25|exact_match|↑  |0.4481|±  |0.0137|
```
#### Run3: warm disk
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|                                                                    
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|                                                                    
|gsm8k|      3|flexible-extract|    25|exact_match|↑  |0.6164|±  |0.0134|                                                                    
|     |       |strict-match    |    25|exact_match|↑  |0.4253|±  |0.0136|    
```


  
 