### PR TITLE
[Bugfix][Structured Output] Mask request stop tokens in xgrammar until grammar terminates

### DIFF
--- a/tests/v1/structured_output/test_backend_xgrammar_stop_tokens.py
+++ b/tests/v1/structured_output/test_backend_xgrammar_stop_tokens.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for issue #42403.
+
+A request's stop-token set (the generation_config eos list plus any
+user-supplied ``stop_token_ids``) is invisible to xgrammar, which only knows
+the tokenizer's single eos. Such tokens can therefore escape the grammar
+bitmask while the FSM is still mid-object and truncate structured output.
+``compile_grammar`` now forwards ``all_stop_token_ids`` to the matcher as
+``override_stop_tokens`` so xgrammar masks them until the grammar completes.
+"""
+
+import pytest
+from transformers import AutoTokenizer
+
+from vllm.config import StructuredOutputsConfig, VllmConfig
+from vllm.v1.structured_output.backend_types import StructuredOutputOptions
+from vllm.v1.structured_output.backend_xgrammar import XgrammarBackend
+
+TOKENIZER = "openai-community/gpt2"
+VOCAB_SIZE = 50257
+
+# gpt2 token ids used to drive a `{"type": "string"}` grammar deterministically.
+EOS = 50256  # <|endoftext|> -- the tokenizer's only default stop token
+QUOTE = 1  # standalone `"`; opens then closes the JSON string
+LETTER = 55  # `X`: valid string content, not a special/stop token by default
+
+
+def _token_allowed(row, token_id: int) -> bool:
+    word = int(row[token_id // 32].item()) & 0xFFFFFFFF
+    return bool(word & (1 << (token_id % 32)))
+
+
+@pytest.fixture(scope="module")
+def backend() -> XgrammarBackend:
+    vllm_config = VllmConfig(
+        structured_outputs_config=StructuredOutputsConfig(backend="xgrammar")
+    )
+    return XgrammarBackend(
+        vllm_config,
+        tokenizer=AutoTokenizer.from_pretrained(TOKENIZER),
+        vocab_size=VOCAB_SIZE,
+    )
+
+
+def test_request_stop_tokens_gated_to_grammar_terminal(backend: XgrammarBackend):
+    schema = '{"type": "string"}'
+    default = backend.compile_grammar(StructuredOutputOptions.JSON, schema)
+    override = backend.compile_grammar(
+        StructuredOutputOptions.JSON, schema, stop_token_ids={EOS, LETTER}
+    )
+
+    # Open the string: both grammars are now in a non-terminal state.
+    for grammar in (default, override):
+        assert grammar.accept_tokens("req", [QUOTE])
+
+    bm_default = backend.allocate_token_bitmask(1)
+    bm_override = backend.allocate_token_bitmask(1)
+    default.fill_bitmask(bm_default, 0)
+    override.fill_bitmask(bm_override, 0)
+
+    # Mid-string, the plain token is valid content, so the default grammar
+    # leaves it samplable -- this is the leak. Registering it as a stop token
+    # masks it until the grammar can terminate.
+    assert _token_allowed(bm_default[0], LETTER)
+    assert not _token_allowed(bm_override[0], LETTER)
+
+    # Close the string -> accepting state (grammar complete, not yet terminated).
+    for grammar in (default, override):
+        assert grammar.accept_tokens("req", [QUOTE])
+        assert not grammar.is_terminated()
+
+    default.fill_bitmask(bm_default, 0)
+    override.fill_bitmask(bm_override, 0)
+
+    # The extra stop token may now terminate under the override, never under
+    # the default grammar -- and the tokenizer's own eos still terminates both,
+    # so default termination is preserved.
+    assert not _token_allowed(bm_default[0], LETTER)
+    assert _token_allowed(bm_override[0], LETTER)
+    assert _token_allowed(bm_default[0], EOS)
+    assert _token_allowed(bm_override[0], EOS)

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -181,7 +181,14 @@ class StructuredOutputManager:
         request_type, grammar_spec = key
 
         assert self.backend is not None
-        return self.backend.compile_grammar(request_type, grammar_spec)
+        stop_token_ids = (
+            request.sampling_params.all_stop_token_ids
+            if request.sampling_params is not None
+            else None
+        )
+        return self.backend.compile_grammar(
+            request_type, grammar_spec, stop_token_ids=stop_token_ids
+        )
 
     def _fill_bitmasks(
         self, batch: Iterable[tuple[StructuredOutputGrammar, int, bool]]

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -184,7 +184,14 @@ class StructuredOutputManager:
         try:
             request_type, grammar_spec = struct_request.structured_output_key
             assert self.backend is not None
-            return self.backend.compile_grammar(request_type, grammar_spec)
+            stop_token_ids = (
+                request.sampling_params.all_stop_token_ids
+                if request.sampling_params is not None
+                else None
+            )
+            return self.backend.compile_grammar(
+                request_type, grammar_spec, stop_token_ids=stop_token_ids
+            )
         except Exception:
             logger.exception(
                 "Failed to compile grammar for request %s", request.request_id

--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -106,7 +106,10 @@ class GuidanceBackend(StructuredOutputBackend):
             )
 
     def compile_grammar(
-        self, request_type: StructuredOutputOptions, grammar_spec: str
+        self,
+        request_type: StructuredOutputOptions,
+        grammar_spec: str,
+        stop_token_ids: set[int] | None = None,
     ) -> StructuredOutputGrammar:
         self.serialized_grammar = serialize_guidance_grammar(
             request_type,

--- a/vllm/v1/structured_output/backend_lm_format_enforcer.py
+++ b/vllm/v1/structured_output/backend_lm_format_enforcer.py
@@ -99,7 +99,10 @@ class LMFormatEnforcerBackend(StructuredOutputBackend):
         )
 
     def compile_grammar(
-        self, request_type: StructuredOutputOptions, grammar_spec: str
+        self,
+        request_type: StructuredOutputOptions,
+        grammar_spec: str,
+        stop_token_ids: set[int] | None = None,
     ) -> StructuredOutputGrammar:
         character_level_parser: lmformatenforcer.CharacterLevelParser
         if request_type == StructuredOutputOptions.JSON:

--- a/vllm/v1/structured_output/backend_outlines.py
+++ b/vllm/v1/structured_output/backend_outlines.py
@@ -71,7 +71,10 @@ class OutlinesBackend(StructuredOutputBackend):
         return index
 
     def compile_grammar(
-        self, request_type: StructuredOutputOptions, grammar_spec: str
+        self,
+        request_type: StructuredOutputOptions,
+        grammar_spec: str,
+        stop_token_ids: set[int] | None = None,
     ) -> StructuredOutputGrammar:
         if request_type == StructuredOutputOptions.JSON:
             regex = json_schema.build_regex_from_schema(grammar_spec)

--- a/vllm/v1/structured_output/backend_types.py
+++ b/vllm/v1/structured_output/backend_types.py
@@ -105,7 +105,10 @@ class StructuredOutputBackend(ABC):
 
     @abstractmethod
     def compile_grammar(
-        self, request_type: StructuredOutputOptions, grammar_spec: str
+        self,
+        request_type: StructuredOutputOptions,
+        grammar_spec: str,
+        stop_token_ids: set[int] | None = None,
     ) -> StructuredOutputGrammar:
         """
         Compiles a grammar specification into a structured output grammar.
@@ -114,6 +117,9 @@ class StructuredOutputBackend(ABC):
             request_type (StructuredOutputOptions): The type of structured
                 output request.
             grammar_spec (str): The grammar specification to compile.
+            stop_token_ids (set[int] | None): The request's EOS and user
+                stop-token ids (``SamplingParams.all_stop_token_ids``), masked
+                until the grammar terminates.
 
         Returns:
             StructuredOutputGrammar: The compiled structured output grammar.

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -76,7 +76,10 @@ class XgrammarBackend(StructuredOutputBackend):
             )
 
     def compile_grammar(
-        self, request_type: StructuredOutputOptions, grammar_spec: str
+        self,
+        request_type: StructuredOutputOptions,
+        grammar_spec: str,
+        stop_token_ids: set[int] | None = None,
     ) -> StructuredOutputGrammar:
         if request_type == StructuredOutputOptions.JSON:
             ctx = self.compiler.compile_json_schema(
@@ -119,6 +122,7 @@ class XgrammarBackend(StructuredOutputBackend):
         return XgrammarGrammar(
             matcher=xgr.GrammarMatcher(
                 ctx,
+                override_stop_tokens=list(stop_token_ids) if stop_token_ids else None,
                 max_rollback_tokens=self.num_speculative_tokens,
             ),
             vocab_size=self.vocab_size,


### PR DESCRIPTION
## Purpose
Fixes #42403.

With structured outputs (e.g. JSON schema), a model can sample a stop token *while the grammar FSM is still mid-object*, truncating generation into invalid JSON. On Gemma this is `<end_of_turn>` (id 106).

Root cause: xgrammar only knows the tokenizer's **single** eos, but a request's real stop set is `generation_config`'s eos list **plus** any user `stop_token_ids`. On Gemma-4 that gap is concrete — `generation_config` eos is `[1, 106, 50]` while the tokenizer eos is just `<eos>` (1). Tokens 106/50 are invisible to the grammar, so they escape the bitmask in non-terminal states.

## Fix
Forward the request's `sampling_params.all_stop_token_ids` through `compile_grammar(...)` into xgrammar's native
`GrammarMatcher(override_stop_tokens=...)`. xgrammar then gates every one of the request's stop tokens to the grammar-terminal state — masked mid-object, allowed only once the schema is satisfied.

## Test Plan
```
 vllm serve google/gemma-4-31B-it \
  --served-model-name gemma4 \
  --structured-outputs-config '{"backend":"xgrammar"}' 
```
Force <end_of_turn> (id 106) via logit_bias + greedy:
```
from openai import OpenAI
c = OpenAI(base_url="http://localhost:8000/v1", api_key="x")
schema = {"type":"object","properties":{"name":{"type":"string"},
          "bio":{"type":"string"}},"required":["name","bio"]}
r = c.chat.completions.create(
    model="gemma4", temperature=0, max_tokens=128, logit_bias={"106": 100},
    messages=[{"role":"user","content":"Return a person as JSON: name and a one-line bio."}],
    extra_body={"structured_outputs": {"json": schema}})
print(r.choices[0].message.content, "| stop_reason:", r.choices[0].stop_reason)
```
## Test Result
|  | Output | valid JSON |
| --- | --- | --- |
| before | `{"name": " (truncated, stop_reason=106)` | ❌ |
| after | `{"name": "Elara Vance", "bio": "..."} (stop_reason=106)` | ✅ |