### PR TITLE
[MiniMax-M3] Retune decode indexer launch grid for occupancy

### DIFF
--- a/vllm/models/minimax_m3/common/ops/index_topk.py
+++ b/vllm/models/minimax_m3/common/ops/index_topk.py
@@ -812,7 +812,7 @@ def minimax_m3_index_decode_score(
         )
     # split-K over seq blocks; chunk count depends only on shape constants so
     # the grid is fixed within a cuda graph.
-    TARGET_GRID = 512
+    TARGET_GRID = 4096
     MAX_NUM_KV_CHUNKS = 256
     # Use the configured max decode length to avoid Triton recompiles when
     # switching between qlen=1 and spec-decode verification batches.
@@ -911,7 +911,7 @@ def minimax_m3_index_decode(
         )
     # Chunk count is shape-constant (cudagraph-safe), capped so the merge sorts
     # pow2(num_topk_chunks * pow2(topk)) candidates.
-    TOPK_TARGET_GRID = 64
+    TOPK_TARGET_GRID = 512
     MAX_NUM_TOPK_CHUNKS = 16
     topk_target = max(
         1, min(MAX_NUM_TOPK_CHUNKS, TOPK_TARGET_GRID // max(1, batch * num_idx_heads))


### PR DESCRIPTION
## Purpose

Cherry-pick public vLLM commit [`8b00f41`](https://github.com/vllm-project/vllm/commit/8b00f4123776a47a6d8e315242ee5f0dd0b817cf) to retune the MiniMax-M3 decode indexer launch grids:

- `TARGET_GRID`: 512 → 4096
- `TOPK_TARGET_GRID`: 64 → 512

While testing MiniMax-M3 on B300-agg with TP4 at concurrency 24 using a large agentic benchmark client, I observed total throughput improve from 26.5K to 38.2K TPS/GPU (+44%) and mean ITL improve from 38.2 ms to 26.0 ms (-32%). The larger grids expose more parallel work for the decode indexer on high-SM-count GPUs.

Duplicate check: searches for open PRs mentioning the MiniMax-M3 decode indexer, `TARGET_GRID`, or MiniMax occupancy found no matching change. The referenced commit is not in upstream `main` at the time of opening.

AI assistance disclosure: OpenAI Codex assisted with the cherry-pick, duplicate checks, validation command, and PR description.

## Test Plan

- Run the repository pre-commit hooks on the changed file.
- Compare B300-agg TP4 concurrency-24 performance before and after the change with the same benchmark setup.

## Test Result

- `.venv/bin/pre-commit run --files vllm/models/minimax_m3/common/ops/index_topk.py`: passed.
- B300-agg TP4, concurrency 24: 26.5K → 38.2K TPS/GPU (+44%); mean ITL 38.2 ms → 26.0 ms (-32%).