### PR TITLE
[CI] Exercise FA3 FP8 attention on SM90

### DIFF
--- a/tests/quantization/test_fp8.py
+++ b/tests/quantization/test_fp8.py
@@ -93,9 +93,6 @@ def test_online_quantization(
     use_rocm_aiter: bool,
     monkeypatch,
 ) -> None:
-    if kv_cache_dtype == "fp8" and current_platform.is_device_capability_family(90):
-        pytest.skip("FA3 currently rejects FP8 KV cache output dtype on SM90")
-
     if use_rocm_aiter:
         monkeypatch.setenv("VLLM_ROCM_USE_AITER", "1")
 
@@ -105,9 +102,15 @@ def test_online_quantization(
     if force_marlin:
         monkeypatch.setenv("VLLM_TEST_FORCE_FP8_MARLIN", "1")
 
+    model_dtype = "auto"
+    if kv_cache_dtype == "fp8" and current_platform.is_device_capability_family(90):
+        # FA3 requires BF16 output when the query input is FP8.
+        model_dtype = "bfloat16"
+
     with vllm_runner(
         "facebook/opt-125m",
         quantization="fp8",
+        dtype=model_dtype,
         enforce_eager=True,
         kv_cache_dtype=kv_cache_dtype,
     ) as llm:


### PR DESCRIPTION
## Purpose

Follow up on the review feedback in https://github.com/vllm-project/vllm/pull/43024#discussion_r3614823352.

The H200 migration had skipped `test_online_quantization[..., kv_cache_dtype=fp8]` on SM90 with the claim that FlashAttention 3 did not support FP8 attention. FA3 does support FP8 query input. Its implementation [selects BF16 output when Q is FP8 and validates a supplied output tensor against that dtype](https://github.com/vllm-project/flash-attention/blob/168920233059c48de6199e2cda74003b2ce3d199/hopper/flash_api.cpp#L910-L915). The test model defaults to FP16, while vLLM [records that FP16 output dtype before quantizing Q to FP8](https://github.com/vllm-project/vllm/blob/b23bd73f540175f9e117eaee5029cd7d8df63964/vllm/model_executor/layers/attention/attention.py#L512-L531), so the failing run supplied an FP16 output tensor to FA3's FP8-Q path.

This change keeps the existing model dtype everywhere else, uses BF16 only for the SM90 + FP8 KV-cache case, and removes the skip so that H100/H200 CI exercises FA3 FP8 attention.

This is not duplicate work: searches for open PRs referencing #43024, `FA3 FP8 attention`, and `test_online_quantization fp8` found no PR addressing this test coverage gap.

## Test Plan

- Run static validation locally.
- Run `tests/quantization/test_fp8.py::test_online_quantization` on H200 CI to validate the FA3 FP8 path.

## Test Result

Local checks passed:

- `git diff --check`
- `../vllm/.venv/bin/python -m py_compile tests/quantization/test_fp8.py`
- `uvx ruff check tests/quantization/test_fp8.py`
- `uvx ruff format --check tests/quantization/test_fp8.py`

Buildkite #78557 reproduced the pre-fix failure in `_vllm_fa3_C.fwd` with FA3's exact dtype error: `For FP8 input, output must have dtype BF16`.

The post-fix H200 GPU test is pending CI. Model evaluation is not applicable because this is a test-only change and does not alter serving behavior or model outputs.

AI assistance was used to inspect the original Buildkite failure, trace the FA3 dtype contract, and prepare this patch. The human submitter must review every changed line and validate the H200 test before merge.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. (Not applicable: test-only change.)
</details>
