### PR TITLE
[Bugfix] Dispatch python builtin tool call in ParsableContext

### DIFF
--- a/tests/entrypoints/openai/responses/test_parsable_context_unit.py
+++ b/tests/entrypoints/openai/responses/test_parsable_context_unit.py
@@ -7,7 +7,7 @@ Parser (via parse) and properly builds response output items.
 """
 
 from collections.abc import Sequence
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -361,3 +361,41 @@ def test_num_init_messages_offset():
     items = ctx.make_response_output_items()
     assert len(items) == 1
     assert items[0].type == "message"
+
+
+# ---------------------------------------------------------------------------
+# Tests: builtin tool dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool_name", ["code_interpreter", "python"])
+async def test_call_tool_dispatches_python(tool_name):
+    """A function call named ``code_interpreter`` or ``python`` is dispatched
+    to ``call_python_tool``.
+
+    ``need_builtin_tool_call`` accepts both names, so ``call_tool`` must
+    dispatch both; otherwise a ``python`` call is silently dropped.
+    """
+    ctx = _make_context(_NoOpParser)
+    ctx._tool_sessions = {"python": MagicMock()}
+    ctx.call_python_tool = AsyncMock(return_value=[])
+    ctx.response_messages = [MagicMock(type="function_call")]
+    # ``name`` is reserved by MagicMock's constructor, so set it explicitly.
+    ctx.response_messages[-1].name = tool_name
+
+    await ctx.call_tool()
+
+    ctx.call_python_tool.assert_awaited_once()
+    assert ctx.call_python_tool.await_args.args[0] is ctx._tool_sessions["python"]
+
+
+@pytest.mark.parametrize("tool_name", ["code_interpreter", "python"])
+def test_need_builtin_and_call_tool_agree_on_python(tool_name):
+    """``need_builtin_tool_call`` and ``call_tool`` must recognize the same
+    set of builtin names, so a call the loop waits on is actually executed."""
+    ctx = _make_context(_NoOpParser, available_tools={"python"})
+    ctx.response_messages = [MagicMock(type="function_call")]
+    ctx.response_messages[-1].name = tool_name
+
+    assert ctx.need_builtin_tool_call() is True

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -523,7 +523,7 @@ class ParsableContext(ConversationContext):
         # change this to a mcp_ function call
         last_msg.id = f"{MCP_PREFIX}{random_uuid()}"
         self.response_messages[-1] = last_msg
-        if last_msg.name == "code_interpreter":
+        if last_msg.name in ("code_interpreter", "python"):
             return await self.call_python_tool(self._tool_sessions["python"], last_msg)
         elif last_msg.name == "web_search_preview":
             return await self.call_search_tool(self._tool_sessions["browser"], last_msg)


### PR DESCRIPTION
## Purpose

`ParsableContext.need_builtin_tool_call()` treats a function call named either `code_interpreter` **or** `python` as a python/code-interpreter builtin:

```python
if last_message.name in ("code_interpreter", "python"):
    return "python" in self.available_tools
```

But `call_tool()` only dispatched `code_interpreter`, so a call named `python` fell through to the empty `return []`:

```python
if last_msg.name == "code_interpreter":
    return await self.call_python_tool(self._tool_sessions["python"], last_msg)
elif last_msg.name == "web_search_preview":
    ...
return []          # name == "python" lands here
```

When the model emits a call named `python` (a name `need_builtin_tool_call` explicitly accepts, and which `HarmonyContext` handles symmetrically in both methods), the generation loop keeps waiting for a tool result that is never produced — `call_tool()` returns `[]`, `append_tool_output([])` is a no-op, and the tool call is silently dropped.

### Fix
Dispatch `python` to `call_python_tool` as well, so `call_tool()` recognizes the same set of names as `need_builtin_tool_call()` (and matches `HarmonyContext`):

```python
if last_msg.name in ("code_interpreter", "python"):
    return await self.call_python_tool(self._tool_sessions["python"], last_msg)
```

One-line change; no behavior change for any other tool name.

## Test Plan

Added a regression test in `tests/entrypoints/openai/responses/test_parsable_context_unit.py`:
- `test_call_tool_dispatches_python[code_interpreter|python]` — asserts `call_tool()` dispatches both names to `call_python_tool`.
- `test_need_builtin_and_call_tool_agree_on_python[code_interpreter|python]` — asserts `need_builtin_tool_call()` accepts both names.

```
pytest tests/entrypoints/openai/responses/test_parsable_context_unit.py
```

## Test Result

Against the current code (before the fix), `test_call_tool_dispatches_python[python]` fails (the `python` call is dropped) while `[code_interpreter]` passes — confirming the test catches the bug. With the fix, all tests pass:

```
14 passed
```

`pre-commit run` passes on both files (ruff, ruff-format, typos, mypy).
