### PR TITLE
[Bugfix][KV Connector] Fix incorrect recompute on KV-load-failure recovery (sync + async)

### DIFF
--- a/tests/v1/kv_connector/unit/reject_recompute_connector.py
+++ b/tests/v1/kv_connector/unit/reject_recompute_connector.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""A minimal KVConnectorBase_V1 that promises a block-aligned prefix and then
+rejects the load (serves zero bytes, reports the blocks as load errors).
+
+Used by test_kv_load_reject_recompute.py to check that
+kv_load_failure_policy="recompute" recovers to the no-connector baseline.
+"""
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorBase_V1,
+    KVConnectorMetadata,
+    KVConnectorRole,
+)
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.forward_context import ForwardContext
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.core.sched.output import SchedulerOutput
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.request import Request
+
+
+@dataclass
+class RejectRecomputeMetadata(KVConnectorMetadata):
+    # (req_id, block_ids) for each request promised-then-rejected this step.
+    reqs: list[tuple[str, list[int]]] = field(default_factory=list)
+
+
+class RejectRecomputeConnector(KVConnectorBase_V1):
+    """Promises a block-aligned prefix synchronously, then rejects the load."""
+
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        role: KVConnectorRole,
+        kv_cache_config: "KVCacheConfig",
+    ):
+        super().__init__(
+            vllm_config=vllm_config, role=role, kv_cache_config=kv_cache_config
+        )
+        self._block_size = vllm_config.cache_config.block_size
+        self._need_load: dict[str, bool] = {}
+        self._load_errors: set[int] = set()
+
+    # ---- scheduler role ----
+    def get_num_new_matched_tokens(
+        self, request: "Request", num_computed_tokens: int
+    ) -> tuple[int | None, bool]:
+        n_prompt = len(request.prompt_token_ids or [])
+        # Largest block-aligned prefix strictly below the prompt (>= 1 tail token).
+        matched = ((n_prompt - 1) // self._block_size) * self._block_size
+        new = matched - num_computed_tokens
+        if new <= 0:
+            return 0, False
+        return new, False  # load_async=False -> synchronous load
+
+    def update_state_after_alloc(
+        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+    ) -> None:
+        if num_external_tokens > 0:
+            self._need_load[request.request_id] = True
+
+    def build_connector_meta(
+        self, scheduler_output: "SchedulerOutput"
+    ) -> KVConnectorMetadata:
+        meta = RejectRecomputeMetadata()
+        for new_req in scheduler_output.scheduled_new_reqs:
+            if new_req.req_id in self._need_load:
+                meta.reqs.append((new_req.req_id, list(new_req.block_ids[0])))
+        self._need_load.clear()
+        return meta
+
+    # ---- worker role ----
+    def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
+        meta = self._get_connector_metadata()
+        assert isinstance(meta, RejectRecomputeMetadata)
+        for _req_id, block_ids in meta.reqs:
+            # Reject: load nothing, mark the promised blocks as failed loads.
+            self._load_errors.update(block_ids)
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        errs, self._load_errors = self._load_errors, set()
+        return errs
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        return
+
+    def save_kv_layer(
+        self, layer_name: str, kv_layer, attn_metadata, **kwargs: Any
+    ) -> None:
+        return
+
+    def wait_for_save(self) -> None:
+        return

--- a/tests/v1/kv_connector/unit/test_kv_load_reject_recompute.py
+++ b/tests/v1/kv_connector/unit/test_kv_load_reject_recompute.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for correct recompute when a KV connector rejects a
+synchronous load (kv_load_failure_policy="recompute").
+
+Two bugs are covered:
+  * Worker (V2 GPU model runner): a KV-load-failure recompute moves
+    num_computed_tokens backward, but it was written only to the optimistic CPU
+    mirror and not the GPU tensor, so the recompute gathered tokens/positions from
+    a stale offset. Covered end-to-end by test_reject_recompute_matches_baseline
+    (GPU).
+  * Scheduler (async scheduling): the failed request's in-flight
+    num_output_placeholders were not rolled back, inflating the recompute's
+    scheduled token count. Covered by test_recompute_rolls_back_async_placeholders
+    (CPU).
+"""
+
+from collections.abc import Callable
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.v1.request import Request
+
+from .utils import (
+    create_model_runner_output,
+    create_request,
+    create_scheduler,
+    create_vllm_config,
+)
+
+
+def _make_get_num_new_matched_tokens(
+    req_num_new_matched_tokens: dict[str, int],
+    async_load: bool,
+) -> Callable[[Request, int], tuple[int, bool]]:
+    def get_num_new_matched_tokens(request: Request, _: int) -> tuple[int, bool]:
+        return req_num_new_matched_tokens.get(request.request_id, 0), async_load
+
+    return get_num_new_matched_tokens
+
+
+@pytest.mark.cpu_test
+def test_recompute_rolls_back_async_placeholders():
+    """A rejected sync KV load must roll back the failed request's in-flight
+    async output placeholders during recompute recovery.
+
+    Otherwise the recompute is scheduled with num_tokens + num_output_placeholders
+    tokens and appends garbage past the prompt. Exactly one in-flight frame is the
+    one consumed by the recovery skip in the same step, so the number of stale
+    future frames to discard is num_output_placeholders - 1 (discarding one more
+    drops the recompute's first output token -> off-by-one shift).
+    """
+    vllm_config = create_vllm_config(kv_load_failure_policy="recompute")
+    scheduler = create_scheduler(vllm_config)
+
+    num_external = 3 * scheduler.block_size
+    num_prompt_tokens = 4 * scheduler.block_size
+    request = create_request(num_tokens=num_prompt_tokens)
+    scheduler.add_request(request=request)
+
+    scheduler.connector = Mock()
+    scheduler.connector.get_num_new_matched_tokens.side_effect = (
+        _make_get_num_new_matched_tokens(
+            {request.request_id: num_external}, async_load=False
+        )
+    )
+    scheduler.connector.request_finished.return_value = (False, None)
+    scheduler.connector.take_events.return_value = ()
+
+    scheduler_output = scheduler.schedule()
+    assert len(scheduler.running) == 1
+
+    # num_output_placeholders is normally set by AsyncScheduler. Set it directly to
+    # simulate two async output frames in flight (a completed prefill's sampled
+    # token plus one decode) reserved before the load failure surfaced.
+    request.num_output_placeholders = 2
+    request.async_tokens_to_discard = 0
+
+    # Fail all of the request's blocks -> num_computed_tokens truncates to 0.
+    req_block_ids = scheduler_output.scheduled_new_reqs[0].block_ids[0]
+    model_runner_output = create_model_runner_output(
+        [request], invalid_block_ids=set(req_block_ids), use_eos=True
+    )
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    # The request is rescheduled to recompute from a truncated prefix...
+    assert request.request_id in scheduler.requests
+    assert request.num_computed_tokens == 0
+    # ...with its in-flight placeholders rolled back and num_output_placeholders - 1
+    # stale frames marked for discard.
+    assert request.num_output_placeholders == 0
+    assert request.async_tokens_to_discard == 1
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="end-to-end reject->recompute correctness test requires a GPU",
+)
+@pytest.mark.parametrize("async_scheduling", [False, True])
+def test_reject_recompute_matches_baseline(async_scheduling: bool):
+    """End-to-end: a connector that promises a block-aligned prefix then rejects
+    the load must recompute to the SAME greedy output as no connector at all,
+    under both synchronous and asynchronous scheduling.
+
+    Run from the repo root so the worker can import the connector module path.
+    """
+    from vllm import LLM, SamplingParams
+    from vllm.config import KVTransferConfig
+
+    model = "facebook/opt-125m"  # non-MoE -> V2 GPU model runner (the affected path)
+    prompt = (
+        "The quick brown fox jumps over the lazy dog near the river while the "
+        "sun sets slowly behind the distant mountains at the end of a long day"
+    )
+    sampling = SamplingParams(temperature=0.0, max_tokens=8)
+
+    def run(kv_transfer_config: "KVTransferConfig | None") -> list[int]:
+        llm = LLM(
+            model=model,
+            enforce_eager=True,
+            enable_prefix_caching=False,
+            async_scheduling=async_scheduling,
+            gpu_memory_utilization=0.3,
+            kv_transfer_config=kv_transfer_config,
+        )
+        out = list(llm.generate([prompt], sampling)[0].outputs[0].token_ids)
+        del llm
+        return out
+
+    baseline = run(None)
+    recovered = run(
+        KVTransferConfig(
+            kv_connector="RejectRecomputeConnector",
+            kv_connector_module_path=(
+                "tests.v1.kv_connector.unit.reject_recompute_connector"
+            ),
+            kv_role="kv_both",
+            kv_load_failure_policy="recompute",
+        )
+    )
+
+    assert recovered == baseline, (
+        f"reject->recompute {recovered} != baseline {baseline} "
+        f"(async_scheduling={async_scheduling})"
+    )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2735,6 +2735,26 @@ class Scheduler(SchedulerInterface):
                     )
                     request.num_computed_tokens = req_num_computed_tokens
 
+                # Under async scheduling, output frames already in flight when the
+                # KV load failed are stale: the request is being recomputed from a
+                # truncated prefix, so their placeholders must be rolled back or
+                # they inflate the number of tokens scheduled for the recompute.
+                # One in-flight frame is the one consumed (and skipped) in this same
+                # recovery step's output loop, so the others must be discarded.
+                # NOTE: num_output_placeholders counts TOKENS, while
+                # async_tokens_to_discard is consumed one-per-FRAME
+                # (_update_request_with_output). With one token per frame -- the
+                # common case, including pipeline parallelism -- that is
+                # num_output_placeholders - 1. With speculative decoding / diffusion
+                # a frame carries multiple tokens, so this over-discards; a general
+                # fix needs the true in-flight frame count. reset_prefix_cache has
+                # the same token-vs-frame conflation.
+                if request.num_output_placeholders > 0:
+                    request.async_tokens_to_discard += (
+                        request.num_output_placeholders - 1
+                    )
+                    request.num_output_placeholders = 0
+
                 affected_req_ids.add(request.request_id)
 
         return affected_req_ids, total_affected_tokens, blocks_to_evict

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -839,15 +839,30 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # Add new blocks and update num_computed_tokens for the existing requests.
         reqs = scheduler_output.scheduled_cached_reqs
         num_computed_tokens_np = self.req_states.num_computed_tokens_np
+        gpu_num_computed_reset = False
         for req_id, num_computed_tokens, req_new_block_ids in zip(
             reqs.req_ids, reqs.num_computed_tokens, reqs.new_block_ids
         ):
             req_index = self.req_states.req_id_to_index[req_id]
+            # num_computed_tokens_np is an optimistic CPU mirror; the GPU tensor
+            # is advanced forward-only by post_update_num_computed_tokens. On a
+            # KV-load-failure recompute the scheduler moves num_computed_tokens
+            # BACKWARD, and writing it only to the CPU mirror leaves the GPU
+            # tensor stale, so prepare_prefill_inputs / prepare_pos_seq_lens gather
+            # the recompute's tokens and positions from the wrong offset. Push the
+            # backward correction to the GPU tensor explicitly.
+            if num_computed_tokens < num_computed_tokens_np[req_index]:
+                self.req_states.num_computed_tokens.stage_write_elem(
+                    req_index, num_computed_tokens
+                )
+                gpu_num_computed_reset = True
             num_computed_tokens_np[req_index] = num_computed_tokens
             if req_new_block_ids is not None:
                 self.block_tables.append_block_ids(
                     req_index, req_new_block_ids, overwrite=False
                 )
+        if gpu_num_computed_reset:
+            self.req_states.num_computed_tokens.apply_write()
 
         # Update CPU num_computed_prefill_tokens.
         np.minimum(


### PR DESCRIPTION
## Summary

Fixes #49250. `kv_load_failure_policy="recompute"` did not produce a correct recompute when a KV connector rejected a promised synchronous load, on the V2 GPU model runner (the default for non-MoE generative models).

Two independent bugs:

1. V2 GPU model runner (`update_requests`): a recompute's backward `num_computed_tokens` truncation was written only to the optimistic CPU mirror, leaving the GPU tensor stale, so the recompute gathered tokens and positions from the wrong offset. Affects both scheduling modes.
2. Scheduler (`_update_requests_with_invalid_blocks`, async scheduling only): the failed request's in-flight `num_output_placeholders` were not rolled back, inflating the recompute's scheduled token count.

## Verification

With both fixes, the reject-then-recompute output is byte-identical to the no-connector baseline under both `--async-scheduling` and `--no-async-scheduling` (Qwen3-8B-AWQ, single GPU, V2 runner), independently re-verified on a clean install with the recovery path confirmed to fire in both connector runs. Added `test_recompute_rolls_back_async_placeholders` (CPU unit test for the scheduler fix) and `test_reject_recompute_matches_baseline` (GPU end-to-end test, both scheduling modes).

## Scope and notes for reviewers

**Part 1** only fires on the recompute path. The guard `num_computed_tokens < num_computed_tokens_np[req_index]` cannot trip for resumed or preempted requests (they take the V2 new-request path and are not in `scheduled_cached_reqs`), nor for decode, chunked prefill, or spec decode, which advance `num_computed_tokens` strictly forward. The staged GPU write does not race `post_update_num_computed_tokens` (a Triton kernel, not the staging list), and `apply_write` is idempotent and guarded.

**Part 2**'s `- 1` is a frame count derived from a token count. `num_output_placeholders` is incremented in tokens (`num_sampled_tokens_per_step + cur_num_spec_tokens`), but `async_tokens_to_discard` is consumed one per frame. So `- 1` is exact at one token per frame, which covers the vanilla case and pipeline parallelism (the increment has no PP term). With speculative decoding or diffusion a frame carries `1 + k` tokens, so `- 1` over-discards by `k` and shifts the recompute output. This PR keeps `- 1` and scopes correctness to the non-spec-decode and non-diffusion case; a general fix needs the true in-flight frame count. Simply zeroing the counter and discarding nothing is not correct either, since that under-discards at pipeline-parallel depth greater than 1.

Pre-existing and related: `reset_prefix_cache` has the same token-versus-frame conflation (`async_tokens_to_discard = num_output_placeholders`, with the comment "1 + spec/PP frames"). It was the only user of `async_tokens_to_discard`, and this PR adds a second, so generalizing the mechanism to a frame count would fix both.
