### PR TITLE
DO NOT MERGE

### DIFF
--- a/.buildkite/ci_config.yaml
+++ b/.buildkite/ci_config.yaml
@@ -1,8 +1,6 @@
 name: vllm_ci
 job_dirs:
   - ".buildkite/image_build"
-  - ".buildkite/test_areas"
-  - ".buildkite/hardware_tests"
 run_all_patterns:
   - "docker/Dockerfile"
   - "CMakeLists.txt"

--- a/.buildkite/image_build/image_build.yaml
+++ b/.buildkite/image_build/image_build.yaml
@@ -5,61 +5,7 @@ steps:
     depends_on: []
     timeout_in_minutes: 600
     commands:
-    - if [[ "$BUILDKITE_BRANCH" == "main" ]]; then .buildkite/image_build/image_build.sh $REGISTRY $REPO $BUILDKITE_COMMIT $BRANCH $IMAGE_TAG $IMAGE_TAG_LATEST; else .buildkite/image_build/image_build.sh $REGISTRY $REPO $BUILDKITE_COMMIT $BRANCH $IMAGE_TAG; fi
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: -10  # Agent was lost
-          limit: 2
-
-  - label: ":docker: :smoking: Non-root smoke tests"
-    key: image-build-smoke-test
-    depends_on:
-      - image-build
-    commands:
-    # Smoke 1: the default (root) image must still be importable
-    # under a non-root UID via `--user 2000:0`. Validates the `vllm` passwd
-    # entry + group-0-writable /home/vllm + uv path cleanup from #31959.
-    # Uses `import vllm` rather than `vllm serve --help` because the latter
-    # instantiates `VllmConfig` which requires a GPU attached to the
-    # container.
-    - docker run --rm --user 2000:0 --entrypoint python3 "$IMAGE_TAG" -c "import vllm; print(vllm.__version__)"
-    # Smoke 2: assert the non-root enabling invariants are baked
-    # into the image. Runs as UID 2000:0 via a shell so we can verify
-    # filesystem perms + passwd/group file state + wrapper presence without
-    # triggering vLLM's GPU-requiring config-init path. The opt-in
-    # `vllm-openai-nonroot` target adds only `USER vllm`, `WORKDIR
-    # /home/vllm`, and an `ENTRYPOINT` override on top of these invariants;
-    # its build correctness is reviewed at the Dockerfile level. Wrapper
-    # logic is covered separately by the pre-commit hook
-    # `test-nonroot-entrypoint` (see .pre-commit-config.yaml).
-    - |
-      docker run --rm --user 2000:0 --entrypoint /bin/sh "$IMAGE_TAG" -ec '
-        if ! getent passwd 2000 | grep -q ^vllm:; then
-          echo FAIL: UID 2000 != vllm
-          exit 1
-        fi
-        if ! id -gn 2>/dev/null | grep -qx root; then
-          echo FAIL: GID 0 not root group
-          exit 1
-        fi
-        touch /home/vllm/.smoke && rm /home/vllm/.smoke
-        touch /opt/uv/cache/.smoke && rm /opt/uv/cache/.smoke
-        if ! test -x /usr/local/bin/vllm-nonroot-entrypoint.sh; then
-          echo FAIL: wrapper missing
-          exit 1
-        fi
-        if ! test -w /etc/passwd; then
-          echo FAIL: /etc/passwd not group-writable
-          exit 1
-        fi
-        if ! test -w /etc/group; then
-          echo FAIL: /etc/group not group-writable
-          exit 1
-        fi
-        echo non-root invariants OK
-      '
+    - 'echo "Skipping CUDA image build for AMD MI325 shadow testing"'
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
@@ -71,7 +17,7 @@ steps:
     key: image-build-cpu
     depends_on: []
     commands:
-    - .buildkite/image_build/image_build_cpu.sh $REGISTRY $REPO $BUILDKITE_COMMIT
+    - 'echo "Skipping CPU image build for AMD MI325 shadow testing"'
     env:
       DOCKER_BUILDKIT: "1"
     retry:
@@ -86,7 +32,7 @@ steps:
     depends_on: []
     key: image-build-hpu
     commands:
-    - .buildkite/image_build/image_build_hpu.sh $REGISTRY $REPO $BUILDKITE_COMMIT
+    - 'echo "Skipping HPU image build for AMD MI325 shadow testing"'
     env:
       DOCKER_BUILDKIT: "1"
     retry:
@@ -101,7 +47,7 @@ steps:
     depends_on: []
     optional: true
     commands:
-    - .buildkite/image_build/image_build_cpu_arm64.sh $REGISTRY $REPO $BUILDKITE_COMMIT
+    - 'echo "Skipping CPU arm64 image build for AMD MI325 shadow testing"'
     env:
       DOCKER_BUILDKIT: "1"
     retry:
@@ -119,7 +65,7 @@ steps:
       - ".buildkite/image_build/image_build_arm64.sh"
       - "docker/Dockerfile"
     commands:
-    - .buildkite/image_build/image_build_arm64.sh $REGISTRY $REPO $BUILDKITE_COMMIT
+    - 'echo "Skipping arm64 image build for AMD MI325 shadow testing"'
     env:
       DOCKER_BUILDKIT: "1"
     retry:

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -117,7 +117,7 @@ steps:
 
 - label: PyTorch Fullgraph Smoke Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -127,7 +127,7 @@ steps:
 
 - label: Pipeline + Context Parallelism (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -139,7 +139,7 @@ steps:
 
 - label: Kernels Helion Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -148,7 +148,7 @@ steps:
 
 - label: Kernels Mamba Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -158,7 +158,7 @@ steps:
 
 - label: Basic Models Test (Other CPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   no_gpu: true
   working_dir: "/vllm-workspace/tests"
@@ -169,7 +169,7 @@ steps:
 
 - label: Language Models Test (MTEB) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -177,7 +177,7 @@ steps:
 
 - label: Language Models Test (PPL) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -187,7 +187,7 @@ steps:
 
 - label: Batch Invariance (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -198,7 +198,7 @@ steps:
 
 - label: Cudagraph # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -207,7 +207,7 @@ steps:
 
 - label: e2e Core (1 GPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -217,7 +217,7 @@ steps:
 
 - label: Async Engine, Inputs, Utils, Worker, Config (CPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   no_gpu: true
   working_dir: "/vllm-workspace/tests"
@@ -241,7 +241,7 @@ steps:
 
 - label: Rust Frontend Cargo Style + Clippy # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   no_gpu: true
   working_dir: "/vllm-workspace"
@@ -250,7 +250,7 @@ steps:
 
 - label: Rust Frontend Cargo Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   no_gpu: true
   working_dir: "/vllm-workspace"
@@ -261,7 +261,7 @@ steps:
 
 - label: Docker Build Metadata (ROCm) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   no_gpu: true
   working_dir: "/vllm-workspace/tests"
@@ -278,7 +278,7 @@ steps:
 
 - label: Basic Correctness # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -290,7 +290,7 @@ steps:
 
 - label: Distributed Model Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -307,7 +307,7 @@ steps:
 
 - label: Benchmarks CLI Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -317,7 +317,7 @@ steps:
 
 - label: PyTorch Compilation Unit Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -325,7 +325,7 @@ steps:
 
 - label: Fusion E2E Config Sweep (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   num_gpus: 1
   working_dir: "/vllm-workspace/"
@@ -335,7 +335,7 @@ steps:
 
 - label: Fusion E2E Quick (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   num_gpus: 1
   working_dir: "/vllm-workspace/"
@@ -348,7 +348,7 @@ steps:
 
 - label: PyTorch Compilation Passes Unit Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -356,7 +356,7 @@ steps:
 
 - label: PyTorch Fullgraph # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -364,7 +364,7 @@ steps:
 
 - label: Pytorch Nightly Dependency Override Check # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   soft_fail: true
   working_dir: "/vllm-workspace/tests"
@@ -373,7 +373,7 @@ steps:
 
 - label: Distributed Compile Unit Tests (2xH100-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/"
@@ -386,7 +386,7 @@ steps:
 
 - label: Platform Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -397,7 +397,7 @@ steps:
 
 - label: Async Engine, Inputs, Utils, Worker # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -409,7 +409,7 @@ steps:
 
 - label: Distributed Comm Ops # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -421,7 +421,7 @@ steps:
 
 - label: EPLB Algorithm # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -430,7 +430,7 @@ steps:
 
 - label: EPLB Execution # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -440,7 +440,7 @@ steps:
 
 - label: Distributed Tests (2xH100-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/"
@@ -455,7 +455,7 @@ steps:
 
 - label: Distributed Tests (4xA100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -467,7 +467,7 @@ steps:
 
 - label: Distributed Torchrun + Examples (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -485,7 +485,7 @@ steps:
 
 - label: Elastic EP Scaling Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -494,7 +494,7 @@ steps:
 
 - label: RayExecutorV2 (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -507,7 +507,7 @@ steps:
 
 - label: Distributed Tests (8xH100-8xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_8
   num_gpus: 8
   working_dir: "/vllm-workspace/tests"
@@ -518,7 +518,7 @@ steps:
 
 - label: Entrypoints Unit Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -528,7 +528,7 @@ steps:
 
 - label: Entrypoints Integration (LLM) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -540,7 +540,7 @@ steps:
 
 - label: Entrypoints Integration (API Server) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -552,7 +552,7 @@ steps:
 
 - label: Entrypoints Integration (API Server OpenAI - Part 1) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -562,7 +562,7 @@ steps:
 
 - label: Entrypoints Integration (API Server OpenAI - Part 2) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -573,7 +573,7 @@ steps:
 
 - label: Entrypoints Integration (API Server Generate) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -586,7 +586,7 @@ steps:
 
 - label: Entrypoints Integration (Responses API) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -596,7 +596,7 @@ steps:
 
 - label: Entrypoints Integration (Speech to Text) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -606,7 +606,7 @@ steps:
 
 - label: Entrypoints Integration (Multimodal)
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -616,7 +616,7 @@ steps:
 
 - label: Entrypoints Integration (Pooling) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -626,7 +626,7 @@ steps:
 
 - label: OpenAI API correctness # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -637,7 +637,7 @@ steps:
 
 - label: DeepSeek V2-Lite Prefetch Offload Accuracy (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   num_gpus: 1
   working_dir: "/vllm-workspace"
@@ -646,7 +646,7 @@ steps:
 
 - label: LM Eval Small Models # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -654,7 +654,7 @@ steps:
 
 - label: MRCR Eval Small Models # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -662,7 +662,7 @@ steps:
 
 - label: LM Eval Small Models (MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
   commands:
@@ -670,7 +670,7 @@ steps:
 
 - label: Multi-Modal Accuracy Eval (Small Models) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
   commands:
@@ -678,7 +678,7 @@ steps:
 
 - label: GPQA Eval (GPT-OSS) (2xH100-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -688,7 +688,7 @@ steps:
 
 - label: LM Eval Small Models (2xB200-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -697,7 +697,7 @@ steps:
 
 - label: DeepSeek V2-Lite Sync EPLB Accuracy (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace"
@@ -706,7 +706,7 @@ steps:
 
 - label: LM Eval Large Models (4xA100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
@@ -716,7 +716,7 @@ steps:
 
 - label: Qwen3-30B-A3B-FP8-block Sync EPLB Accuracy (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace"
@@ -725,7 +725,7 @@ steps:
 
 - label: Qwen3-30B-A3B-FP8 DP4 Async EPLB Accuracy (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace"
@@ -734,7 +734,7 @@ steps:
 
 - label: Qwen3-Next-80B-A3B-Instruct MTP Async EPLB Accuracy # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace"
@@ -743,7 +743,7 @@ steps:
 
 - label: LM Eval Large Models (8xH200-8xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_8
   num_gpus: 8
   working_dir: "/vllm-workspace/tests"
@@ -753,7 +753,7 @@ steps:
 
 - label: ROCm LM Eval Large Models (8 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_8
   num_gpus: 8
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
@@ -765,7 +765,7 @@ steps:
 
 - label: Examples # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/examples"
   commands:
@@ -795,7 +795,7 @@ steps:
 
 - label: vLLM IR Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/"
   commands:
@@ -804,7 +804,7 @@ steps:
 
 - label: Kernels Attention Test %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 2
   working_dir: "/vllm-workspace/tests"
@@ -813,7 +813,7 @@ steps:
 
 - label: Kernels Core Operation Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -821,7 +821,7 @@ steps:
 
 - label: Kernels KDA Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -829,7 +829,7 @@ steps:
 
 - label: Kernels MoE Test %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 5
   working_dir: "/vllm-workspace/tests"
@@ -839,7 +839,7 @@ steps:
 
 - label: Kernels Quantization Test %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 2
   working_dir: "/vllm-workspace/tests"
@@ -848,7 +848,7 @@ steps:
 
 - label: Kernels FP8 MoE Test (2xH100-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -859,7 +859,7 @@ steps:
 
 - label: LoRA %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 4
   working_dir: "/vllm-workspace/tests"
@@ -868,7 +868,7 @@ steps:
 
 - label: LoRA TP (Distributed) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -884,7 +884,7 @@ steps:
 
 - label: Model Executor # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -897,7 +897,7 @@ steps:
 
 - label: Model Runner V2 Core Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -911,7 +911,7 @@ steps:
 
 - label: Model Runner V2 Examples # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/examples"
   commands:
@@ -933,7 +933,7 @@ steps:
 
 - label: Model Runner V2 Distributed (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -946,7 +946,7 @@ steps:
 
 - label: Model Runner V2 Pipeline Parallelism (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -958,7 +958,7 @@ steps:
 
 - label: Model Runner V2 Spec Decode # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -973,7 +973,7 @@ steps:
 
 - label: Basic Models Tests (Extra Initialization) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 6
   working_dir: "/vllm-workspace/tests"
@@ -982,7 +982,7 @@ steps:
 
 - label: Basic Models Tests (Initialization) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -990,7 +990,7 @@ steps:
 
 - label: Basic Models Tests (Other) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1000,7 +1000,7 @@ steps:
 
 - label: Language Models Test (Extended Pooling)  # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1008,7 +1008,7 @@ steps:
 
 - label: Language Models Tests (Standard) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1017,7 +1017,7 @@ steps:
 
 - label: Language Models Tests (Extra Standard) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 2
   working_dir: "/vllm-workspace/tests"
@@ -1029,7 +1029,7 @@ steps:
 
 - label: Multi-Modal Models (Extended Generation 1) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1038,7 +1038,7 @@ steps:
 
 - label: Multi-Modal Models (Extended Generation 2) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1047,7 +1047,7 @@ steps:
 
 - label: Multi-Modal Models (Extended Generation 3) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1055,7 +1055,7 @@ steps:
 
 - label: "Multi-Modal Models (Standard) 1: qwen2" # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1064,7 +1064,7 @@ steps:
 
 - label: "Multi-Modal Models (Standard) 3: llava + qwen2_vl" # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1073,7 +1073,7 @@ steps:
 
 - label: "Multi-Modal Models (Standard) 4: other + whisper" # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1083,7 +1083,7 @@ steps:
 
 - label: Multi-Modal Processor # 1h 42m
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1091,7 +1091,7 @@ steps:
 
 - label: Multi-Modal Processor (CPU) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 4
   working_dir: "/vllm-workspace/tests"
@@ -1102,7 +1102,7 @@ steps:
 
 - label: Quantized Models Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1112,7 +1112,7 @@ steps:
 
 - label: Transformers Nightly Models (Shardable) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 4
   working_dir: "/vllm-workspace/"
@@ -1123,7 +1123,7 @@ steps:
 
 - label: Transformers Nightly Models (Single) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/"
   commands:
@@ -1138,7 +1138,7 @@ steps:
 
 - label: Plugin Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -1184,7 +1184,7 @@ steps:
 
 - label: GGUF Plugin # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   soft_fail: true
   working_dir: "/vllm-workspace/tests"
@@ -1196,7 +1196,7 @@ steps:
 
 - label: Rust Frontend OpenAI Coverage # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1212,7 +1212,7 @@ steps:
 
 - label: Rust Frontend Serve Admin Coverage # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1226,7 +1226,7 @@ steps:
 
 - label: Rust Frontend Core Correctness # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1236,7 +1236,7 @@ steps:
 
 - label: Rust Frontend Tool Use # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1246,7 +1246,7 @@ steps:
 
 - label: Rust Frontend Distributed # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -1261,7 +1261,7 @@ steps:
 
 - label: Quantization # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1281,7 +1281,7 @@ steps:
 
 - label: ROCm AITER Ops Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1291,7 +1291,7 @@ steps:
 
 - label: Samplers Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1301,7 +1301,7 @@ steps:
 
 - label: Regression # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1312,7 +1312,7 @@ steps:
 
 - label: Ray Dependency Compatibility Check # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/"
   commands:
@@ -1322,7 +1322,7 @@ steps:
 
 - label: Acceptance Length Test (Large Models) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1331,7 +1331,7 @@ steps:
 
 - label: e2e Scheduling (1 GPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1339,7 +1339,7 @@ steps:
 
 - label: Engine (1 GPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1348,7 +1348,7 @@ steps:
 
 - label: Spec Decode Draft Model # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1356,7 +1356,7 @@ steps:
 
 - label: Spec Decode Eagle # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1364,7 +1364,7 @@ steps:
 
 - label: Spec Decode Ngram + Suffix # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1372,7 +1372,7 @@ steps:
 
 - label: Spec Decode Speculators + MTP # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1380,7 +1380,7 @@ steps:
 
 - label: Speculators Correctness # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1389,7 +1389,7 @@ steps:
 
 - label: V1 Spec Decode # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1397,7 +1397,7 @@ steps:
 
 - label: Extract Hidden States Integration # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -1407,7 +1407,7 @@ steps:
 
 - label: V1 attention (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1415,7 +1415,7 @@ steps:
 
 - label: V1 Core + KV + Metrics # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1432,7 +1432,7 @@ steps:
 
 - label: V1 others (CPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1444,7 +1444,7 @@ steps:
 
 - label: V1 Sample + Logits # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1456,7 +1456,7 @@ steps:
 
 - label: Distributed DP Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -1469,7 +1469,7 @@ steps:
 
 - label: Metrics, Tracing (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -1483,7 +1483,7 @@ steps:
 
 - label: V1 e2e (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -1492,7 +1492,7 @@ steps:
 
 - label: NixlConnector PD + Spec Decode acceptance (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -1502,7 +1502,7 @@ steps:
 
 - label: CrossLayer KV layout Distributed NixlConnector PD accuracy tests (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -1512,7 +1512,7 @@ steps:
 
 - label: Distributed DP Tests (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -1528,7 +1528,7 @@ steps:
 
 - label: Distributed NixlConnector PD accuracy (4 GPUs)  # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -1538,7 +1538,7 @@ steps:
 
 - label: DP EP Distributed NixlConnector PD accuracy tests (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -1548,7 +1548,7 @@ steps:
 
 - label: Hybrid SSM NixlConnector PD accuracy tests (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -1558,7 +1558,7 @@ steps:
 
 - label: Hybrid SSM NixlConnector PD prefix cache test (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -1568,7 +1568,7 @@ steps:
 
 - label: MultiConnector (Nixl+Offloading) PD accuracy (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -1578,7 +1578,7 @@ steps:
 
 - label: MultiConnector (Nixl+Offloading) PD edge cases (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -1588,7 +1588,7 @@ steps:
 
 - label: V1 e2e (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -1597,7 +1597,7 @@ steps:
 
 - label: V1 e2e (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   commands:
@@ -1607,7 +1607,7 @@ steps:
 
 - label: Weight Loading Multiple GPU # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -1616,7 +1616,7 @@ steps:
 
 - label: Weight Loading Multiple GPU - Large Models # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -1633,7 +1633,7 @@ steps:
 
 - label: Distributed Compile + RPC Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -1646,7 +1646,7 @@ steps:
 
 - label: Distributed Torchrun + Shutdown Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -1658,7 +1658,7 @@ steps:
 
 - label: Distributed Compile + Comm (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -1673,7 +1673,7 @@ steps:
 
 - label: Engine # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1683,7 +1683,7 @@ steps:
 
 - label: LM Eval Large Models (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
@@ -1695,7 +1695,7 @@ steps:
 
 - label: Language Models Test (Extended Generation) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1705,7 +1705,7 @@ steps:
 
 - label: Language Models Tests (Hybrid) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 2
   working_dir: "/vllm-workspace/tests"
@@ -1718,7 +1718,7 @@ steps:
 
 - label: Multi-Modal Models (Extended Pooling) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1726,7 +1726,7 @@ steps:
 
 - label: "Multi-Modal Models (Standard) 2: qwen3 + gemma" # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1737,7 +1737,7 @@ steps:
 
 - label: Python-only Installation # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1760,7 +1760,7 @@ steps:
 
 - label: COPY A PyTorch Fullgraph Smoke Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1770,7 +1770,7 @@ steps:
 
 - label: COPY A Pipeline + Context Parallelism (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -1782,7 +1782,7 @@ steps:
 
 - label: COPY A Kernels Helion Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1791,7 +1791,7 @@ steps:
 
 - label: COPY A Kernels Mamba Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1801,7 +1801,7 @@ steps:
 
 - label: COPY A Basic Models Test (Other CPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   no_gpu: true
   working_dir: "/vllm-workspace/tests"
@@ -1812,7 +1812,7 @@ steps:
 
 - label: COPY A Language Models Test (MTEB) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1820,7 +1820,7 @@ steps:
 
 - label: COPY A Language Models Test (PPL) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1830,7 +1830,7 @@ steps:
 
 - label: COPY A Batch Invariance (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1841,7 +1841,7 @@ steps:
 
 - label: COPY A Cudagraph # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1850,7 +1850,7 @@ steps:
 
 - label: COPY A e2e Core (1 GPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1860,7 +1860,7 @@ steps:
 
 - label: COPY A Async Engine, Inputs, Utils, Worker, Config (CPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   no_gpu: true
   working_dir: "/vllm-workspace/tests"
@@ -1884,7 +1884,7 @@ steps:
 
 - label: COPY A Rust Frontend Cargo Style + Clippy # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   no_gpu: true
   working_dir: "/vllm-workspace"
@@ -1893,7 +1893,7 @@ steps:
 
 - label: COPY A Rust Frontend Cargo Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   no_gpu: true
   working_dir: "/vllm-workspace"
@@ -1904,7 +1904,7 @@ steps:
 
 - label: COPY A Docker Build Metadata (ROCm) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   no_gpu: true
   working_dir: "/vllm-workspace/tests"
@@ -1921,7 +1921,7 @@ steps:
 
 - label: COPY A Basic Correctness # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -1933,7 +1933,7 @@ steps:
 
 - label: COPY A Distributed Model Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -1950,7 +1950,7 @@ steps:
 
 - label: COPY A Benchmarks CLI Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1960,7 +1960,7 @@ steps:
 
 - label: COPY A PyTorch Compilation Unit Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1968,7 +1968,7 @@ steps:
 
 - label: COPY A Fusion E2E Config Sweep (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   num_gpus: 1
   working_dir: "/vllm-workspace/"
@@ -1978,7 +1978,7 @@ steps:
 
 - label: COPY A Fusion E2E Quick (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   num_gpus: 1
   working_dir: "/vllm-workspace/"
@@ -1991,7 +1991,7 @@ steps:
 
 - label: COPY A PyTorch Compilation Passes Unit Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -1999,7 +1999,7 @@ steps:
 
 - label: COPY A PyTorch Fullgraph # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2007,7 +2007,7 @@ steps:
 
 - label: COPY A Pytorch Nightly Dependency Override Check # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   soft_fail: true
   working_dir: "/vllm-workspace/tests"
@@ -2016,7 +2016,7 @@ steps:
 
 - label: COPY A Distributed Compile Unit Tests (2xH100-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/"
@@ -2029,7 +2029,7 @@ steps:
 
 - label: COPY A Platform Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2040,7 +2040,7 @@ steps:
 
 - label: COPY A Async Engine, Inputs, Utils, Worker # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2052,7 +2052,7 @@ steps:
 
 - label: COPY A Distributed Comm Ops # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -2064,7 +2064,7 @@ steps:
 
 - label: COPY A EPLB Algorithm # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2073,7 +2073,7 @@ steps:
 
 - label: COPY A EPLB Execution # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -2083,7 +2083,7 @@ steps:
 
 - label: COPY A Distributed Tests (2xH100-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/"
@@ -2098,7 +2098,7 @@ steps:
 
 - label: COPY A Distributed Tests (4xA100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -2110,7 +2110,7 @@ steps:
 
 - label: COPY A Distributed Torchrun + Examples (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -2128,7 +2128,7 @@ steps:
 
 - label: COPY A Elastic EP Scaling Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -2137,7 +2137,7 @@ steps:
 
 - label: COPY A RayExecutorV2 (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -2150,7 +2150,7 @@ steps:
 
 - label: COPY A Distributed Tests (8xH100-8xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_8
   num_gpus: 8
   working_dir: "/vllm-workspace/tests"
@@ -2161,7 +2161,7 @@ steps:
 
 - label: COPY A Entrypoints Unit Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -2171,7 +2171,7 @@ steps:
 
 - label: COPY A Entrypoints Integration (LLM) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -2183,7 +2183,7 @@ steps:
 
 - label: COPY A Entrypoints Integration (API Server) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -2195,7 +2195,7 @@ steps:
 
 - label: COPY A Entrypoints Integration (API Server OpenAI - Part 1) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -2205,7 +2205,7 @@ steps:
 
 - label: COPY A Entrypoints Integration (API Server OpenAI - Part 2) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -2216,7 +2216,7 @@ steps:
 
 - label: COPY A Entrypoints Integration (API Server Generate) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -2229,7 +2229,7 @@ steps:
 
 - label: COPY A Entrypoints Integration (Responses API) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -2239,7 +2239,7 @@ steps:
 
 - label: COPY A Entrypoints Integration (Speech to Text) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -2249,7 +2249,7 @@ steps:
 
 - label: COPY A Entrypoints Integration (Multimodal)
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -2259,7 +2259,7 @@ steps:
 
 - label: COPY A Entrypoints Integration (Pooling) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -2269,7 +2269,7 @@ steps:
 
 - label: COPY A OpenAI API correctness # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2280,7 +2280,7 @@ steps:
 
 - label: COPY A DeepSeek V2-Lite Prefetch Offload Accuracy (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   num_gpus: 1
   working_dir: "/vllm-workspace"
@@ -2289,7 +2289,7 @@ steps:
 
 - label: COPY A LM Eval Small Models # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2297,7 +2297,7 @@ steps:
 
 - label: COPY A MRCR Eval Small Models # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2305,7 +2305,7 @@ steps:
 
 - label: COPY A LM Eval Small Models (MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
   commands:
@@ -2313,7 +2313,7 @@ steps:
 
 - label: COPY A Multi-Modal Accuracy Eval (Small Models) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
   commands:
@@ -2321,7 +2321,7 @@ steps:
 
 - label: COPY A GPQA Eval (GPT-OSS) (2xH100-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -2331,7 +2331,7 @@ steps:
 
 - label: COPY A LM Eval Small Models (2xB200-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -2340,7 +2340,7 @@ steps:
 
 - label: COPY A DeepSeek V2-Lite Sync EPLB Accuracy (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace"
@@ -2349,7 +2349,7 @@ steps:
 
 - label: COPY A LM Eval Large Models (4xA100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
@@ -2359,7 +2359,7 @@ steps:
 
 - label: COPY A Qwen3-30B-A3B-FP8-block Sync EPLB Accuracy (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace"
@@ -2368,7 +2368,7 @@ steps:
 
 - label: COPY A Qwen3-30B-A3B-FP8 DP4 Async EPLB Accuracy (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace"
@@ -2377,7 +2377,7 @@ steps:
 
 - label: COPY A Qwen3-Next-80B-A3B-Instruct MTP Async EPLB Accuracy # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace"
@@ -2386,7 +2386,7 @@ steps:
 
 - label: COPY A LM Eval Large Models (8xH200-8xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_8
   num_gpus: 8
   working_dir: "/vllm-workspace/tests"
@@ -2396,7 +2396,7 @@ steps:
 
 - label: COPY A ROCm LM Eval Large Models (8 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_8
   num_gpus: 8
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
@@ -2408,7 +2408,7 @@ steps:
 
 - label: COPY A Examples # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/examples"
   commands:
@@ -2438,7 +2438,7 @@ steps:
 
 - label: COPY A vLLM IR Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/"
   commands:
@@ -2447,7 +2447,7 @@ steps:
 
 - label: COPY A Kernels Attention Test %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 2
   working_dir: "/vllm-workspace/tests"
@@ -2456,7 +2456,7 @@ steps:
 
 - label: COPY A Kernels Core Operation Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2464,7 +2464,7 @@ steps:
 
 - label: COPY A Kernels KDA Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2472,7 +2472,7 @@ steps:
 
 - label: COPY A Kernels MoE Test %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 5
   working_dir: "/vllm-workspace/tests"
@@ -2482,7 +2482,7 @@ steps:
 
 - label: COPY A Kernels Quantization Test %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 2
   working_dir: "/vllm-workspace/tests"
@@ -2491,7 +2491,7 @@ steps:
 
 - label: COPY A Kernels FP8 MoE Test (2xH100-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -2502,7 +2502,7 @@ steps:
 
 - label: COPY A LoRA %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 4
   working_dir: "/vllm-workspace/tests"
@@ -2511,7 +2511,7 @@ steps:
 
 - label: COPY A LoRA TP (Distributed) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -2527,7 +2527,7 @@ steps:
 
 - label: COPY A Model Executor # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2540,7 +2540,7 @@ steps:
 
 - label: COPY A Model Runner V2 Core Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2554,7 +2554,7 @@ steps:
 
 - label: COPY A Model Runner V2 Examples # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/examples"
   commands:
@@ -2576,7 +2576,7 @@ steps:
 
 - label: COPY A Model Runner V2 Distributed (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -2589,7 +2589,7 @@ steps:
 
 - label: COPY A Model Runner V2 Pipeline Parallelism (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -2601,7 +2601,7 @@ steps:
 
 - label: COPY A Model Runner V2 Spec Decode # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2616,7 +2616,7 @@ steps:
 
 - label: COPY A Basic Models Tests (Extra Initialization) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 6
   working_dir: "/vllm-workspace/tests"
@@ -2625,7 +2625,7 @@ steps:
 
 - label: COPY A Basic Models Tests (Initialization) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2633,7 +2633,7 @@ steps:
 
 - label: COPY A Basic Models Tests (Other) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2643,7 +2643,7 @@ steps:
 
 - label: COPY A Language Models Test (Extended Pooling)  # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2651,7 +2651,7 @@ steps:
 
 - label: COPY A Language Models Tests (Standard) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2660,7 +2660,7 @@ steps:
 
 - label: COPY A Language Models Tests (Extra Standard) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 2
   working_dir: "/vllm-workspace/tests"
@@ -2672,7 +2672,7 @@ steps:
 
 - label: COPY A Multi-Modal Models (Extended Generation 1) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2681,7 +2681,7 @@ steps:
 
 - label: COPY A Multi-Modal Models (Extended Generation 2) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2690,7 +2690,7 @@ steps:
 
 - label: COPY A Multi-Modal Models (Extended Generation 3) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2698,7 +2698,7 @@ steps:
 
 - label: "COPY A Multi-Modal Models (Standard) 1: qwen2" # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2707,7 +2707,7 @@ steps:
 
 - label: "COPY A Multi-Modal Models (Standard) 3: llava + qwen2_vl" # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2716,7 +2716,7 @@ steps:
 
 - label: "COPY A Multi-Modal Models (Standard) 4: other + whisper" # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2726,7 +2726,7 @@ steps:
 
 - label: COPY A Multi-Modal Processor # 1h 42m
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2734,7 +2734,7 @@ steps:
 
 - label: COPY A Multi-Modal Processor (CPU) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 4
   working_dir: "/vllm-workspace/tests"
@@ -2745,7 +2745,7 @@ steps:
 
 - label: COPY A Quantized Models Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2755,7 +2755,7 @@ steps:
 
 - label: COPY A Transformers Nightly Models (Shardable) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 4
   working_dir: "/vllm-workspace/"
@@ -2766,7 +2766,7 @@ steps:
 
 - label: COPY A Transformers Nightly Models (Single) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/"
   commands:
@@ -2781,7 +2781,7 @@ steps:
 
 - label: COPY A Plugin Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -2827,7 +2827,7 @@ steps:
 
 - label: COPY A GGUF Plugin # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   soft_fail: true
   working_dir: "/vllm-workspace/tests"
@@ -2839,7 +2839,7 @@ steps:
 
 - label: COPY A Rust Frontend OpenAI Coverage # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2855,7 +2855,7 @@ steps:
 
 - label: COPY A Rust Frontend Serve Admin Coverage # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2869,7 +2869,7 @@ steps:
 
 - label: COPY A Rust Frontend Core Correctness # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2879,7 +2879,7 @@ steps:
 
 - label: COPY A Rust Frontend Tool Use # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2889,7 +2889,7 @@ steps:
 
 - label: COPY A Rust Frontend Distributed # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -2904,7 +2904,7 @@ steps:
 
 - label: COPY A Quantization # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2924,7 +2924,7 @@ steps:
 
 - label: COPY A ROCm AITER Ops Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2934,7 +2934,7 @@ steps:
 
 - label: COPY A Samplers Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2944,7 +2944,7 @@ steps:
 
 - label: COPY A Regression # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2955,7 +2955,7 @@ steps:
 
 - label: COPY A Ray Dependency Compatibility Check # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/"
   commands:
@@ -2965,7 +2965,7 @@ steps:
 
 - label: COPY A Acceptance Length Test (Large Models) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2974,7 +2974,7 @@ steps:
 
 - label: COPY A e2e Scheduling (1 GPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2982,7 +2982,7 @@ steps:
 
 - label: COPY A Engine (1 GPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2991,7 +2991,7 @@ steps:
 
 - label: COPY A Spec Decode Draft Model # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -2999,7 +2999,7 @@ steps:
 
 - label: COPY A Spec Decode Eagle # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3007,7 +3007,7 @@ steps:
 
 - label: COPY A Spec Decode Ngram + Suffix # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3015,7 +3015,7 @@ steps:
 
 - label: COPY A Spec Decode Speculators + MTP # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3023,7 +3023,7 @@ steps:
 
 - label: COPY A Speculators Correctness # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3032,7 +3032,7 @@ steps:
 
 - label: COPY A V1 Spec Decode # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3040,7 +3040,7 @@ steps:
 
 - label: COPY A Extract Hidden States Integration # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -3050,7 +3050,7 @@ steps:
 
 - label: COPY A V1 attention (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3058,7 +3058,7 @@ steps:
 
 - label: COPY A V1 Core + KV + Metrics # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3075,7 +3075,7 @@ steps:
 
 - label: COPY A V1 others (CPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3087,7 +3087,7 @@ steps:
 
 - label: COPY A V1 Sample + Logits # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3099,7 +3099,7 @@ steps:
 
 - label: COPY A Distributed DP Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -3112,7 +3112,7 @@ steps:
 
 - label: COPY A Metrics, Tracing (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -3126,7 +3126,7 @@ steps:
 
 - label: COPY A V1 e2e (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -3135,7 +3135,7 @@ steps:
 
 - label: COPY A NixlConnector PD + Spec Decode acceptance (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -3145,7 +3145,7 @@ steps:
 
 - label: COPY A CrossLayer KV layout Distributed NixlConnector PD accuracy tests (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -3155,7 +3155,7 @@ steps:
 
 - label: COPY A Distributed DP Tests (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -3171,7 +3171,7 @@ steps:
 
 - label: COPY A Distributed NixlConnector PD accuracy (4 GPUs)  # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -3181,7 +3181,7 @@ steps:
 
 - label: COPY A DP EP Distributed NixlConnector PD accuracy tests (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -3191,7 +3191,7 @@ steps:
 
 - label: COPY A Hybrid SSM NixlConnector PD accuracy tests (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -3201,7 +3201,7 @@ steps:
 
 - label: COPY A Hybrid SSM NixlConnector PD prefix cache test (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -3211,7 +3211,7 @@ steps:
 
 - label: COPY A MultiConnector (Nixl+Offloading) PD accuracy (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -3221,7 +3221,7 @@ steps:
 
 - label: COPY A MultiConnector (Nixl+Offloading) PD edge cases (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -3231,7 +3231,7 @@ steps:
 
 - label: COPY A V1 e2e (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -3240,7 +3240,7 @@ steps:
 
 - label: COPY A V1 e2e (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   commands:
@@ -3250,7 +3250,7 @@ steps:
 
 - label: COPY A Weight Loading Multiple GPU # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -3259,7 +3259,7 @@ steps:
 
 - label: COPY A Weight Loading Multiple GPU - Large Models # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -3276,7 +3276,7 @@ steps:
 
 - label: COPY A Distributed Compile + RPC Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -3289,7 +3289,7 @@ steps:
 
 - label: COPY A Distributed Torchrun + Shutdown Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -3301,7 +3301,7 @@ steps:
 
 - label: COPY A Distributed Compile + Comm (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -3316,7 +3316,7 @@ steps:
 
 - label: COPY A Engine # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3326,7 +3326,7 @@ steps:
 
 - label: COPY A LM Eval Large Models (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
@@ -3338,7 +3338,7 @@ steps:
 
 - label: COPY A Language Models Test (Extended Generation) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3348,7 +3348,7 @@ steps:
 
 - label: COPY A Language Models Tests (Hybrid) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 2
   working_dir: "/vllm-workspace/tests"
@@ -3361,7 +3361,7 @@ steps:
 
 - label: COPY A Multi-Modal Models (Extended Pooling) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3369,7 +3369,7 @@ steps:
 
 - label: "COPY A Multi-Modal Models (Standard) 2: qwen3 + gemma" # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3380,7 +3380,7 @@ steps:
 
 - label: COPY A Python-only Installation # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3403,7 +3403,7 @@ steps:
 
 - label: COPY B PyTorch Fullgraph Smoke Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3413,7 +3413,7 @@ steps:
 
 - label: COPY B Pipeline + Context Parallelism (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -3425,7 +3425,7 @@ steps:
 
 - label: COPY B Kernels Helion Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3434,7 +3434,7 @@ steps:
 
 - label: COPY B Kernels Mamba Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3444,7 +3444,7 @@ steps:
 
 - label: COPY B Language Models Test (MTEB) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3452,7 +3452,7 @@ steps:
 
 - label: COPY B Language Models Test (PPL) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3462,7 +3462,7 @@ steps:
 
 - label: COPY B Batch Invariance (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3473,7 +3473,7 @@ steps:
 
 - label: COPY B Cudagraph # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3482,7 +3482,7 @@ steps:
 
 - label: COPY B e2e Core (1 GPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3492,7 +3492,7 @@ steps:
 
 - label: COPY B Docker Build Metadata (ROCm) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   no_gpu: true
   working_dir: "/vllm-workspace/tests"
@@ -3509,7 +3509,7 @@ steps:
 
 - label: COPY B Basic Correctness # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -3521,7 +3521,7 @@ steps:
 
 - label: COPY B Distributed Model Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -3538,7 +3538,7 @@ steps:
 
 - label: COPY B Benchmarks CLI Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3548,7 +3548,7 @@ steps:
 
 - label: COPY B PyTorch Compilation Unit Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3556,7 +3556,7 @@ steps:
 
 - label: COPY B Fusion E2E Config Sweep (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   num_gpus: 1
   working_dir: "/vllm-workspace/"
@@ -3566,7 +3566,7 @@ steps:
 
 - label: COPY B Fusion E2E Quick (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   num_gpus: 1
   working_dir: "/vllm-workspace/"
@@ -3579,7 +3579,7 @@ steps:
 
 - label: COPY B PyTorch Compilation Passes Unit Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3587,7 +3587,7 @@ steps:
 
 - label: COPY B PyTorch Fullgraph # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3595,7 +3595,7 @@ steps:
 
 - label: COPY B Pytorch Nightly Dependency Override Check # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   soft_fail: true
   working_dir: "/vllm-workspace/tests"
@@ -3604,7 +3604,7 @@ steps:
 
 - label: COPY B Distributed Compile Unit Tests (2xH100-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/"
@@ -3617,7 +3617,7 @@ steps:
 
 - label: COPY B Platform Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3628,7 +3628,7 @@ steps:
 
 - label: COPY B Async Engine, Inputs, Utils, Worker # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3640,7 +3640,7 @@ steps:
 
 - label: COPY B Distributed Comm Ops # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -3652,7 +3652,7 @@ steps:
 
 - label: COPY B EPLB Algorithm # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3661,7 +3661,7 @@ steps:
 
 - label: COPY B EPLB Execution # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -3671,7 +3671,7 @@ steps:
 
 - label: COPY B Distributed Tests (2xH100-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/"
@@ -3686,7 +3686,7 @@ steps:
 
 - label: COPY B Distributed Tests (4xA100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -3698,7 +3698,7 @@ steps:
 
 - label: COPY B Distributed Torchrun + Examples (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -3716,7 +3716,7 @@ steps:
 
 - label: COPY B Elastic EP Scaling Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -3725,7 +3725,7 @@ steps:
 
 - label: COPY B RayExecutorV2 (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -3738,7 +3738,7 @@ steps:
 
 - label: COPY B Distributed Tests (8xH100-8xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_8
   num_gpus: 8
   working_dir: "/vllm-workspace/tests"
@@ -3749,7 +3749,7 @@ steps:
 
 - label: COPY B Entrypoints Unit Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -3759,7 +3759,7 @@ steps:
 
 - label: COPY B Entrypoints Integration (LLM) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -3771,7 +3771,7 @@ steps:
 
 - label: COPY B Entrypoints Integration (API Server) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -3783,7 +3783,7 @@ steps:
 
 - label: COPY B Entrypoints Integration (API Server OpenAI - Part 1) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -3793,7 +3793,7 @@ steps:
 
 - label: COPY B Entrypoints Integration (API Server OpenAI - Part 2) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -3804,7 +3804,7 @@ steps:
 
 - label: COPY B Entrypoints Integration (API Server Generate) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -3817,7 +3817,7 @@ steps:
 
 - label: COPY B Entrypoints Integration (Responses API) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -3827,7 +3827,7 @@ steps:
 
 - label: COPY B Entrypoints Integration (Speech to Text) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -3837,7 +3837,7 @@ steps:
 
 - label: COPY B Entrypoints Integration (Multimodal)
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -3847,7 +3847,7 @@ steps:
 
 - label: COPY B Entrypoints Integration (Pooling) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
@@ -3857,7 +3857,7 @@ steps:
 
 - label: COPY B OpenAI API correctness # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3868,7 +3868,7 @@ steps:
 
 - label: COPY B DeepSeek V2-Lite Prefetch Offload Accuracy (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   num_gpus: 1
   working_dir: "/vllm-workspace"
@@ -3877,7 +3877,7 @@ steps:
 
 - label: COPY B LM Eval Small Models # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3885,7 +3885,7 @@ steps:
 
 - label: COPY B MRCR Eval Small Models # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -3893,7 +3893,7 @@ steps:
 
 - label: COPY B LM Eval Small Models (MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
   commands:
@@ -3901,7 +3901,7 @@ steps:
 
 - label: COPY B Multi-Modal Accuracy Eval (Small Models) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
   commands:
@@ -3909,7 +3909,7 @@ steps:
 
 - label: COPY B GPQA Eval (GPT-OSS) (2xH100-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -3919,7 +3919,7 @@ steps:
 
 - label: COPY B LM Eval Small Models (2xB200-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -3928,7 +3928,7 @@ steps:
 
 - label: COPY B DeepSeek V2-Lite Sync EPLB Accuracy (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace"
@@ -3937,7 +3937,7 @@ steps:
 
 - label: COPY B LM Eval Large Models (4xA100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
@@ -3947,7 +3947,7 @@ steps:
 
 - label: COPY B Qwen3-30B-A3B-FP8-block Sync EPLB Accuracy (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace"
@@ -3956,7 +3956,7 @@ steps:
 
 - label: COPY B Qwen3-30B-A3B-FP8 DP4 Async EPLB Accuracy (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace"
@@ -3965,7 +3965,7 @@ steps:
 
 - label: COPY B Qwen3-Next-80B-A3B-Instruct MTP Async EPLB Accuracy # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace"
@@ -3974,7 +3974,7 @@ steps:
 
 - label: COPY B LM Eval Large Models (8xH200-8xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_8
   num_gpus: 8
   working_dir: "/vllm-workspace/tests"
@@ -3984,7 +3984,7 @@ steps:
 
 - label: COPY B ROCm LM Eval Large Models (8 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_8
   num_gpus: 8
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
@@ -3996,7 +3996,7 @@ steps:
 
 - label: COPY B Examples # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/examples"
   commands:
@@ -4026,7 +4026,7 @@ steps:
 
 - label: COPY B vLLM IR Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/"
   commands:
@@ -4035,7 +4035,7 @@ steps:
 
 - label: COPY B Kernels Attention Test %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 2
   working_dir: "/vllm-workspace/tests"
@@ -4044,7 +4044,7 @@ steps:
 
 - label: COPY B Kernels Core Operation Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4052,7 +4052,7 @@ steps:
 
 - label: COPY B Kernels KDA Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4060,7 +4060,7 @@ steps:
 
 - label: COPY B Kernels MoE Test %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 5
   working_dir: "/vllm-workspace/tests"
@@ -4070,7 +4070,7 @@ steps:
 
 - label: COPY B Kernels Quantization Test %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 2
   working_dir: "/vllm-workspace/tests"
@@ -4079,7 +4079,7 @@ steps:
 
 - label: COPY B Kernels FP8 MoE Test (2xH100-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -4090,7 +4090,7 @@ steps:
 
 - label: COPY B LoRA %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 4
   working_dir: "/vllm-workspace/tests"
@@ -4099,7 +4099,7 @@ steps:
 
 - label: COPY B LoRA TP (Distributed) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -4115,7 +4115,7 @@ steps:
 
 - label: COPY B Model Executor # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4128,7 +4128,7 @@ steps:
 
 - label: COPY B Model Runner V2 Core Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4142,7 +4142,7 @@ steps:
 
 - label: COPY B Model Runner V2 Examples # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/examples"
   commands:
@@ -4164,7 +4164,7 @@ steps:
 
 - label: COPY B Model Runner V2 Distributed (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -4177,7 +4177,7 @@ steps:
 
 - label: COPY B Model Runner V2 Pipeline Parallelism (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -4189,7 +4189,7 @@ steps:
 
 - label: COPY B Model Runner V2 Spec Decode # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4204,7 +4204,7 @@ steps:
 
 - label: COPY B Basic Models Tests (Extra Initialization) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 6
   working_dir: "/vllm-workspace/tests"
@@ -4213,7 +4213,7 @@ steps:
 
 - label: COPY B Basic Models Tests (Initialization) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4221,7 +4221,7 @@ steps:
 
 - label: COPY B Basic Models Tests (Other) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4231,7 +4231,7 @@ steps:
 
 - label: COPY B Language Models Test (Extended Pooling)  # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4239,7 +4239,7 @@ steps:
 
 - label: COPY B Language Models Tests (Standard) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4248,7 +4248,7 @@ steps:
 
 - label: COPY B Language Models Tests (Extra Standard) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 2
   working_dir: "/vllm-workspace/tests"
@@ -4260,7 +4260,7 @@ steps:
 
 - label: COPY B Multi-Modal Models (Extended Generation 1) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4269,7 +4269,7 @@ steps:
 
 - label: COPY B Multi-Modal Models (Extended Generation 2) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4278,7 +4278,7 @@ steps:
 
 - label: COPY B Multi-Modal Models (Extended Generation 3) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4286,7 +4286,7 @@ steps:
 
 - label: "COPY B Multi-Modal Models (Standard) 1: qwen2" # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4295,7 +4295,7 @@ steps:
 
 - label: "COPY B Multi-Modal Models (Standard) 3: llava + qwen2_vl" # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4304,7 +4304,7 @@ steps:
 
 - label: "COPY B Multi-Modal Models (Standard) 4: other + whisper" # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4314,7 +4314,7 @@ steps:
 
 - label: COPY B Multi-Modal Processor # 1h 42m
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4322,7 +4322,7 @@ steps:
 
 - label: COPY B Multi-Modal Processor (CPU) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 4
   working_dir: "/vllm-workspace/tests"
@@ -4333,7 +4333,7 @@ steps:
 
 - label: COPY B Quantized Models Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4343,7 +4343,7 @@ steps:
 
 - label: COPY B Transformers Nightly Models (Shardable) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 4
   working_dir: "/vllm-workspace/"
@@ -4354,7 +4354,7 @@ steps:
 
 - label: COPY B Transformers Nightly Models (Single) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/"
   commands:
@@ -4369,7 +4369,7 @@ steps:
 
 - label: COPY B Plugin Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -4415,7 +4415,7 @@ steps:
 
 - label: COPY B GGUF Plugin # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   soft_fail: true
   working_dir: "/vllm-workspace/tests"
@@ -4427,7 +4427,7 @@ steps:
 
 - label: COPY B Rust Frontend OpenAI Coverage # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4443,7 +4443,7 @@ steps:
 
 - label: COPY B Rust Frontend Serve Admin Coverage # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4457,7 +4457,7 @@ steps:
 
 - label: COPY B Rust Frontend Core Correctness # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4467,7 +4467,7 @@ steps:
 
 - label: COPY B Rust Frontend Tool Use # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4477,7 +4477,7 @@ steps:
 
 - label: COPY B Rust Frontend Distributed # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -4492,7 +4492,7 @@ steps:
 
 - label: COPY B Quantization # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4512,7 +4512,7 @@ steps:
 
 - label: COPY B ROCm AITER Ops Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4522,7 +4522,7 @@ steps:
 
 - label: COPY B Samplers Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4532,7 +4532,7 @@ steps:
 
 - label: COPY B Regression # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4543,7 +4543,7 @@ steps:
 
 - label: COPY B Ray Dependency Compatibility Check # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/"
   commands:
@@ -4553,7 +4553,7 @@ steps:
 
 - label: COPY B Acceptance Length Test (Large Models) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4562,7 +4562,7 @@ steps:
 
 - label: COPY B e2e Scheduling (1 GPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4570,7 +4570,7 @@ steps:
 
 - label: COPY B Engine (1 GPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4579,7 +4579,7 @@ steps:
 
 - label: COPY B Spec Decode Draft Model # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4587,7 +4587,7 @@ steps:
 
 - label: COPY B Spec Decode Eagle # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4595,7 +4595,7 @@ steps:
 
 - label: COPY B Spec Decode Ngram + Suffix # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4603,7 +4603,7 @@ steps:
 
 - label: COPY B Spec Decode Speculators + MTP # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4611,7 +4611,7 @@ steps:
 
 - label: COPY B Speculators Correctness # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4620,7 +4620,7 @@ steps:
 
 - label: COPY B V1 Spec Decode # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4628,7 +4628,7 @@ steps:
 
 - label: COPY B Extract Hidden States Integration # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -4638,7 +4638,7 @@ steps:
 
 - label: COPY B V1 attention (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4646,7 +4646,7 @@ steps:
 
 - label: COPY B V1 Core + KV + Metrics # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4663,7 +4663,7 @@ steps:
 
 - label: COPY B V1 others (CPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4675,7 +4675,7 @@ steps:
 
 - label: COPY B V1 Sample + Logits # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4687,7 +4687,7 @@ steps:
 
 - label: COPY B Distributed DP Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -4700,7 +4700,7 @@ steps:
 
 - label: COPY B Metrics, Tracing (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -4714,7 +4714,7 @@ steps:
 
 - label: COPY B V1 e2e (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -4723,7 +4723,7 @@ steps:
 
 - label: COPY B NixlConnector PD + Spec Decode acceptance (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -4733,7 +4733,7 @@ steps:
 
 - label: COPY B CrossLayer KV layout Distributed NixlConnector PD accuracy tests (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -4743,7 +4743,7 @@ steps:
 
 - label: COPY B Distributed DP Tests (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -4759,7 +4759,7 @@ steps:
 
 - label: COPY B Distributed NixlConnector PD accuracy (4 GPUs)  # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -4769,7 +4769,7 @@ steps:
 
 - label: COPY B DP EP Distributed NixlConnector PD accuracy tests (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -4779,7 +4779,7 @@ steps:
 
 - label: COPY B Hybrid SSM NixlConnector PD accuracy tests (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -4789,7 +4789,7 @@ steps:
 
 - label: COPY B Hybrid SSM NixlConnector PD prefix cache test (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -4799,7 +4799,7 @@ steps:
 
 - label: COPY B MultiConnector (Nixl+Offloading) PD accuracy (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -4809,7 +4809,7 @@ steps:
 
 - label: COPY B MultiConnector (Nixl+Offloading) PD edge cases (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -4819,7 +4819,7 @@ steps:
 
 - label: COPY B V1 e2e (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -4828,7 +4828,7 @@ steps:
 
 - label: COPY B V1 e2e (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   commands:
@@ -4838,7 +4838,7 @@ steps:
 
 - label: COPY B Weight Loading Multiple GPU # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -4847,7 +4847,7 @@ steps:
 
 - label: COPY B Weight Loading Multiple GPU - Large Models # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -4864,7 +4864,7 @@ steps:
 
 - label: COPY B Distributed Compile + RPC Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -4877,7 +4877,7 @@ steps:
 
 - label: COPY B Distributed Torchrun + Shutdown Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
@@ -4889,7 +4889,7 @@ steps:
 
 - label: COPY B Distributed Compile + Comm (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
@@ -4904,7 +4904,7 @@ steps:
 
 - label: COPY B Engine # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4914,7 +4914,7 @@ steps:
 
 - label: COPY B LM Eval Large Models (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
@@ -4926,7 +4926,7 @@ steps:
 
 - label: COPY B Language Models Test (Extended Generation) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4936,7 +4936,7 @@ steps:
 
 - label: COPY B Language Models Tests (Hybrid) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   parallelism: 2
   working_dir: "/vllm-workspace/tests"
@@ -4949,7 +4949,7 @@ steps:
 
 - label: COPY B Multi-Modal Models (Extended Pooling) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4957,7 +4957,7 @@ steps:
 
 - label: "COPY B Multi-Modal Models (Standard) 2: qwen3 + gemma" # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:
@@ -4968,7 +4968,7 @@ steps:
 
 - label: COPY B Python-only Installation # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdshadow]
+  mirror_hardwares: [amdexperimental, amdproduction, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
   commands:

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -40,7 +40,7 @@
 #####################################################################################################################################
 #                                                                                                                                   #
 # IMPORTANT:                                                                                                                        #
-#   * Currently AMD CI has MI250 agents, MI300 agents, MI325 agents, and MI355 agents. All upcoming feature improvements are        #
+#   * Currently AMD CI runs test groups on MI325 agents. All upcoming feature improvements are                                      #
 #         tracked in: https://github.com/vllm-project/vllm/issues/34994                                                             #
 #                                                                                                                                   #
 #-----------------------------------------------------------------------------------------------------------------------------------#
@@ -109,151 +109,87 @@ steps:
 
 #########################################################################################################################################
 #                                                                                                                                       #
-#                                                         MI250 (gfx90a) tests                                                          #
+#                                                         MI325 (gfx942) tests                                                          #
 #                                                                                                                                       #
 #########################################################################################################################################
 
-#----------------------------------------------------------  mi250 · compile  ----------------------------------------------------------#
+#----------------------------------------------------------  mi325 · compile  ----------------------------------------------------------#
 
 - label: PyTorch Fullgraph Smoke Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/compilation/
-  - vllm/model_executor/
-  - vllm/v1/attention/
-  - vllm/config/compilation.py
-  - csrc/
-  - tests/compile
-  - vllm/platforms/rocm.py
   commands:
   - "find compile/fullgraph/ -name 'test_*.py' -not -name 'test_full_graph.py' -exec pytest -s -v {} \\\\;"
 
-#--------------------------------------------------------  mi250 · distributed  --------------------------------------------------------#
+#--------------------------------------------------------  mi325 · distributed  --------------------------------------------------------#
 
 - label: Pipeline + Context Parallelism (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/distributed/
-  - vllm/engine/
-  - vllm/executor/
-  - vllm/model_executor/models/
-  - vllm/model_executor/layers/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - tests/distributed/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s distributed/test_pp_cudagraph.py
   - pytest -v -s distributed/test_pipeline_parallel.py
 
-#----------------------------------------------------------  mi250 · kernels  ----------------------------------------------------------#
+#----------------------------------------------------------  mi325 · kernels  ----------------------------------------------------------#
 
 - label: Kernels Helion Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/utils/import_utils.py
-  - tests/kernels/helion/
-  - vllm/platforms/rocm.py
   commands:
   - pip install helion==1.1.0
   - pytest -v -s kernels/helion/
 
 - label: Kernels Mamba Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - csrc/mamba/
-  - tests/kernels/mamba
-  - vllm/model_executor/layers/mamba/ops
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s kernels/mamba
 
-#------------------------------------------------------  mi250 · models / basic  -------------------------------------------------------#
+#------------------------------------------------------  mi325 · models / basic  -------------------------------------------------------#
 
 - label: Basic Models Test (Other CPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   no_gpu: true
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/test_utils.py
-  - tests/models/test_vision.py
   commands:
   - pytest -v -s models/test_utils.py models/test_vision.py
 
-#-----------------------------------------------------  mi250 · models / language  -----------------------------------------------------#
+#-----------------------------------------------------  mi325 · models / language  -----------------------------------------------------#
 
 - label: Language Models Test (MTEB) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/language/pooling_mteb_test
   commands:
   - pytest -v -s models/language/pooling_mteb_test
 
 - label: Language Models Test (PPL) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/language/generation_ppl_test
   commands:
   - pytest -v -s models/language/generation_ppl_test
 
-#----------------------------------------------------  mi250 · models / multimodal  ----------------------------------------------------#
+#------------------------------------------------------------  mi325 · v1  -------------------------------------------------------------#
 
-- label: "Multi-Modal Models (Standard) 3: llava + qwen2_vl" # TBD
+- label: Batch Invariance (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/multimodal
-  commands:
-  - pytest -v -s models/multimodal/generation/test_common.py -m core_model -k "not qwen2 and not qwen3 and not gemma"
-  - pytest -v -s models/multimodal/generation/test_qwen2_vl.py -m core_model
-
-#------------------------------------------------------------  mi250 · v1  -------------------------------------------------------------#
-
-- label: Batch Invariance (H100-MI250) # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
-  optional: true
-  working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/v1/attention
-  - vllm/model_executor/layers
-  - tests/v1/determinism/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pip install pytest-timeout pytest-forked
@@ -262,136 +198,29 @@ steps:
 
 - label: Cudagraph # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - tests/v1/cudagraph
-  - vllm/v1/cudagraph_dispatcher.py
-  - vllm/config/compilation.py
-  - vllm/compilation
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s v1/cudagraph/test_cudagraph_dispatch.py
   - pytest -v -s v1/cudagraph/test_cudagraph_mode.py
 
 - label: e2e Core (1 GPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/v1/
-  - tests/v1/e2e/general/
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s v1/e2e/general --ignore v1/e2e/general/test_async_scheduling.py
 
-- label: e2e Scheduling (1 GPU) # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
-  optional: true
-  working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/v1/
-  - tests/v1/e2e/general/
-  - vllm/platforms/rocm.py
-  commands:
-  - pytest -v -s v1/e2e/general/test_async_scheduling.py
-
-- label: Engine (1 GPU) # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
-  optional: true
-  working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/v1/
-  - tests/v1/engine/
-  - vllm/platforms/rocm.py
-  commands:
-  - pytest -v -s v1/engine/test_preprocess_error_handling.py
-  - pytest -v -s v1/engine --ignore v1/engine/test_preprocess_error_handling.py
-
-- label: Spec Decode Draft Model # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
-  optional: true
-  working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/v1/spec_decode/
-  - vllm/v1/worker/gpu/spec_decode/
-  - vllm/model_executor/model_loader/
-  - vllm/v1/sample/
-  - vllm/model_executor/layers/
-  - tests/v1/e2e/spec_decode/
-  - vllm/platforms/rocm.py
-  commands:
-  - pytest -v -s v1/e2e/spec_decode -k "draft_model or no_sync or batch_inference"
-
-- label: Spec Decode Speculators + MTP # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
-  optional: true
-  working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/v1/spec_decode/
-  - vllm/v1/worker/gpu/spec_decode/
-  - vllm/model_executor/model_loader/
-  - vllm/v1/sample/
-  - vllm/model_executor/layers/
-  - vllm/transformers_utils/configs/speculators/
-  - tests/v1/e2e/spec_decode/
-  - vllm/platforms/rocm.py
-  commands:
-  - pytest -v -s v1/e2e/spec_decode -k "speculators or mtp_correctness"
-
-- label: V1 attention (H100-MI250) # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
-  working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/config/attention.py
-  - vllm/model_executor/layers/attention
-  - vllm/v1/attention
-  - tests/v1/attention
-  - vllm/_aiter_ops.py
-  - vllm/envs.py
-  - vllm/platforms/rocm.py
-  commands:
-  - pytest -v -s v1/attention
-
-#-------------------------------------------------------------  mi250 · misc  ------------------------------------------------------------#
+#-------------------------------------------------------------  mi325 · misc  ------------------------------------------------------------#
 
 - label: Async Engine, Inputs, Utils, Worker, Config (CPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   no_gpu: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/test_inputs.py
-  - tests/test_outputs.py
-  - tests/test_pooling_params.py
-  - tests/test_ray_env.py
-  - tests/test_sampling_params.py
-  - tests/multimodal
-  - tests/renderers
-  - tests/standalone_tests/lazy_imports.py
-  - tests/tokenizers_
-  - tests/reasoning
-  - tests/tool_parsers
-  - tests/parser
-  - tests/transformers_utils
-  - tests/config
   commands:
   - python3 standalone_tests/lazy_imports.py
   - pytest -v -s test_inputs.py
@@ -408,105 +237,65 @@ steps:
   - pytest -v -s transformers_utils
   - pytest -v -s config
 
-#------------------------------------------------------------  mi250 · rust  -----------------------------------------------------------#
+#------------------------------------------------------------  mi325 · rust  -----------------------------------------------------------#
 
 - label: Rust Frontend Cargo Style + Clippy # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   no_gpu: true
   working_dir: "/vllm-workspace"
-  source_file_dependencies:
-  - rust/
-  - rust-toolchain.toml
-  - .buildkite/test_areas/rust_frontend_cargo.yaml
-  - .buildkite/scripts/run-rust-frontend-cargo-ci.sh
   commands:
   - bash .buildkite/scripts/run-rust-frontend-cargo-ci.sh style-clippy
 
 - label: Rust Frontend Cargo Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   no_gpu: true
   working_dir: "/vllm-workspace"
-  source_file_dependencies:
-  - rust/
-  - rust-toolchain.toml
-  - .buildkite/test_areas/rust_frontend_cargo.yaml
-  - .buildkite/scripts/run-rust-frontend-cargo-ci.sh
   commands:
   - bash .buildkite/scripts/run-rust-frontend-cargo-ci.sh test
 
-#-----------------------------------------------------------  mi250 · docker  ----------------------------------------------------------#
+#-----------------------------------------------------------  mi325 · docker  ----------------------------------------------------------#
 
 - label: Docker Build Metadata (ROCm) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   no_gpu: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - .buildkite/scripts/docker-build-metadata-args.sh
-  - .buildkite/scripts/ci-bake-rocm.sh
-  - docker/Dockerfile
-  - docker/Dockerfile.cpu
-  - docker/Dockerfile.rocm
-  - docker/Dockerfile.rocm_base
-  - docker/ci-rocm.hcl
-  - docker/docker-bake.hcl
-  - docker/docker-bake-rocm.hcl
-  - tests/tools/test_docker_build_metadata_args.py
   commands:
   - pytest -v -s tools/test_docker_build_metadata_args.py
 
 #########################################################################################################################################
 #                                                                                                                                       #
-#                                                         MI300 (gfx942) tests                                                          #
+#                                                         MI325 (gfx942) tests                                                          #
 #                                                                                                                                       #
 #########################################################################################################################################
 
-#-----------------------------------------------------  mi300 · basic_correctness  -----------------------------------------------------#
+#-----------------------------------------------------  mi325 · basic_correctness  -----------------------------------------------------#
 
 - label: Basic Correctness # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/basic_correctness/test_basic_correctness
-  - tests/basic_correctness/test_cpu_offload
-  - tests/basic_correctness/test_mem.py
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s basic_correctness/test_mem.py
-  - VLLM_TARGET_TEST_SUITE=MI300 pytest -v -s basic_correctness/test_basic_correctness.py
+  - VLLM_TARGET_TEST_SUITE=MI325 pytest -v -s basic_correctness/test_basic_correctness.py
   - pytest -v -s basic_correctness/test_cpu_offload.py
 
 - label: Distributed Model Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/model_executor/model_loader/sharded_state_loader.py
-  - vllm/model_executor/models/
-  - vllm/model_executor/layers/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
-  - tests/basic_correctness/
-  - tests/model_executor/model_loader/test_sharded_state_loader.py
-  - tests/models/
   commands:
-  - TARGET_TEST_SUITE=MI300 pytest basic_correctness/ -v -s -m 'distributed(num_gpus=2)'
+  - TARGET_TEST_SUITE=MI325 pytest basic_correctness/ -v -s -m 'distributed(num_gpus=2)'
   - CUDA_VISIBLE_DEVICES=0,1 pytest -v -s model_executor/model_loader/test_sharded_state_loader.py -m '(not slow_test)'
   - pytest models/transformers/test_backend.py -v -s -m 'distributed(num_gpus=2)'
   - pytest models/language -v -s -m 'distributed(num_gpus=2)'
@@ -514,79 +303,42 @@ steps:
   - pytest models/multimodal/generation/test_phi4siglip.py -v -s -m 'distributed(num_gpus=2)'
   - VLLM_WORKER_MULTIPROC_METHOD=spawn pytest models/multimodal/generation/test_whisper.py -v -s -m 'distributed(num_gpus=2)'
 
-#--------------------------------------------------------  mi300 · benchmarks  ---------------------------------------------------------#
+#--------------------------------------------------------  mi325 · benchmarks  ---------------------------------------------------------#
 
 - label: Benchmarks CLI Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/benchmarks/
   commands:
   - pytest -v -s benchmarks/
 
-#----------------------------------------------------------  mi300 · compile  ----------------------------------------------------------#
+#----------------------------------------------------------  mi325 · compile  ----------------------------------------------------------#
 
 - label: PyTorch Compilation Unit Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/compilation/
-  - vllm/model_executor/layers/
-  - vllm/v1/worker/
-  - vllm/v1/attention/
-  - vllm/v1/cudagraph_dispatcher.py
-  - vllm/config/compilation.py
-  - csrc/
-  - tests/compile
-  - vllm/platforms/rocm.py
   commands:
   - "find compile/ -maxdepth 1 -name 'test_*.py' -print0 | xargs -0 -n1 -I{} pytest -s -v '{}'"
 
-- label: Fusion E2E Config Sweep (H100-MI300) # TBD
+- label: Fusion E2E Config Sweep (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   num_gpus: 1
   working_dir: "/vllm-workspace/"
-  source_file_dependencies:
-  - csrc/quantization/
-  - vllm/compilation/
-  - vllm/model_executor/layers/layernorm.py
-  - vllm/model_executor/layers/activation.py
-  - vllm/model_executor/layers/attention/attention.py
-  - vllm/model_executor/layers/quantization/input_quant_fp8.py
-  - tests/compile/fusions_e2e/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - rocm-smi
   - pytest -v -s tests/compile/fusions_e2e/test_tp1_quant.py -k "llama-3"
 
-- label: Fusion E2E Quick (H100-MI300) # TBD
+- label: Fusion E2E Quick (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   num_gpus: 1
   working_dir: "/vllm-workspace/"
-  source_file_dependencies:
-  - csrc/quantization/
-  - vllm/model_executor/
-  - vllm/v1/attention/
-  - vllm/compilation/
-  - tests/compile/fusions_e2e/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - rocm-smi
   # Run all models and attn backends but only Inductor partition and native custom ops
@@ -596,113 +348,71 @@ steps:
 
 - label: PyTorch Compilation Passes Unit Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/compile/passes
   commands:
   - pytest -s -v compile/passes --ignore compile/passes/distributed
 
 - label: PyTorch Fullgraph # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/compilation/
-  - vllm/model_executor/
-  - vllm/v1/attention/
-  - vllm/config/compilation.py
-  - csrc/
-  - tests/compile
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s compile/fullgraph/test_full_graph.py -k 'not test_fp8_kv_scale_compile'
 
 - label: Pytorch Nightly Dependency Override Check # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   soft_fail: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - requirements/test/nightly-torch.txt
-  - vllm/platforms/rocm.py
   commands:
   - bash standalone_tests/pytorch_nightly_dependency.sh
 
-- label: Distributed Compile Unit Tests (2xH100-2xMI300) # TBD
+- label: Distributed Compile Unit Tests (2xH100-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/"
-  source_file_dependencies:
-  - vllm/compilation/
-  - vllm/model_executor/layers
-  - tests/compile/passes/distributed/
-  - tests/compile/fusions_e2e/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - export VLLM_TEST_CLEAN_GPU_MEMORY=1
   - VLLM_TEST_CLEAN_GPU_MEMORY=1 pytest -v -s tests/compile/passes/distributed/test_async_tp.py
   - pytest -v -s tests/compile/fusions_e2e/test_tp2_ar_rms.py::test_tp2_ar_rms_fusions
 
-#-----------------------------------------------------------  mi300 · cuda  ------------------------------------------------------------#
+#-----------------------------------------------------------  mi325 · cuda  ------------------------------------------------------------#
 
 - label: Platform Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/cuda
   commands:
   - pytest -v -s cuda/test_cuda_context.py
   - pytest -v -s cuda/test_platform_no_cuda_init.py
 
-#--------------------------------------------------------  mi300 · detokenizer  --------------------------------------------------------#
+#--------------------------------------------------------  mi325 · detokenizer  --------------------------------------------------------#
 
 - label: Async Engine, Inputs, Utils, Worker # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/detokenizer
-  - tests/multimodal
-  - tests/utils_
   commands:
   - pytest -v -s detokenizer
   - pytest -v -s -m 'not cpu_test' multimodal
   - pytest -v -s utils_
 
-#--------------------------------------------------------  mi300 · distributed  --------------------------------------------------------#
+#--------------------------------------------------------  mi325 · distributed  --------------------------------------------------------#
 
 - label: Distributed Comm Ops # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/distributed
-  - tests/distributed
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s distributed/test_comm_ops.py
   - pytest -v -s distributed/test_shm_broadcast.py
@@ -711,54 +421,29 @@ steps:
 
 - label: EPLB Algorithm # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/distributed/eplb
-  - tests/distributed/test_eplb_algo.py
-  - tests/distributed/test_eplb_utils.py
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s distributed/test_eplb_algo.py
   - pytest -v -s distributed/test_eplb_utils.py
 
 - label: EPLB Execution # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/distributed/eplb
-  - tests/distributed/test_eplb_execute.py
-  - tests/distributed/test_eplb_spec_decode.py
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s distributed/test_eplb_execute.py
   - pytest -v -s distributed/test_eplb_spec_decode.py
 
-- label: Distributed Tests (2xH100-2xMI300) # TBD
+- label: Distributed Tests (2xH100-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/"
-  source_file_dependencies:
-  - vllm/distributed/
-  - vllm/v1/distributed/
-  - vllm/model_executor/layers/fused_moe/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - tests/v1/distributed/test_dbo.py
-  - tests/distributed/test_context_parallel.py
-  - examples/features/data_parallel/data_parallel_offline.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s tests/distributed/test_context_parallel.py
   - VLLM_ALLOW_INSECURE_SERIALIZATION=1 python3 examples/rl/rlhf_async_new_apis.py
@@ -768,36 +453,24 @@ steps:
   - VLLM_ALLOW_INSECURE_SERIALIZATION=1 pytest -v -s tests/distributed/test_weight_transfer.py
   - pytest -v -s tests/distributed/test_packed_tensor.py
 
-- label: Distributed Tests (4xA100-4xMI300) # TBD
+- label: Distributed Tests (4xA100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
   commands:
   - pytest -v -s distributed/test_custom_all_reduce.py
   - torchrun --nproc_per_node=2 distributed/test_ca_buffer_sharing.py
-  - TARGET_TEST_SUITE=MI300 pytest basic_correctness/ -v -s -m 'distributed(num_gpus=2)'
+  - TARGET_TEST_SUITE=MI325 pytest basic_correctness/ -v -s -m 'distributed(num_gpus=2)'
   - pytest -v -s -x lora/test_mixtral.py
 
 - label: Distributed Torchrun + Examples (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/distributed/
-  - tests/distributed/test_torchrun_example.py
-  - tests/distributed/test_torchrun_example_moe.py
-  - examples/rl/
-  - tests/examples/features/data_parallel/data_parallel_offline.py
-  - vllm/platforms/rocm.py
   commands:
   - torchrun --nproc-per-node=4 distributed/test_torchrun_example.py
   - PP_SIZE=2 torchrun --nproc-per-node=4 distributed/test_torchrun_example.py
@@ -812,38 +485,19 @@ steps:
 
 - label: Elastic EP Scaling Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/distributed/
-  - vllm/engine/
-  - vllm/executor/
-  - vllm/compilation/
-  - tests/distributed/
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s distributed/test_elastic_ep.py
 
 - label: RayExecutorV2 (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/v1/executor/ray_executor_v2.py
-  - vllm/v1/executor/abstract.py
-  - vllm/v1/executor/multiproc_executor.py
-  - tests/distributed/test_ray_v2_executor.py
-  - tests/distributed/test_ray_v2_executor_e2e.py
-  - tests/distributed/test_pipeline_parallel.py
-  - tests/basic_correctness/test_basic_correctness.py
-  - vllm/platforms/rocm.py
   commands:
   - export VLLM_USE_RAY_V2_EXECUTOR_BACKEND=1
   - pytest -v -s distributed/test_ray_v2_executor.py
@@ -851,54 +505,33 @@ steps:
   - pytest -v -s distributed/test_pipeline_parallel.py -k "ray"
   - TARGET_TEST_SUITE=L4 pytest -v -s basic_correctness/test_basic_correctness.py -k "ray"
 
-- label: Distributed Tests (8xH100-8xMI300) # TBD
+- label: Distributed Tests (8xH100-8xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_8
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_8
   num_gpus: 8
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - examples/features/torchrun/torchrun_dp_example_offline.py
-  - vllm/config/parallel.py
-  - vllm/distributed/
-  - vllm/v1/engine/llm_engine.py
-  - vllm/v1/executor/uniproc_executor.py
-  - vllm/v1/worker/gpu_worker.py
-  - vllm/platforms/rocm.py
   commands:
   - torchrun --nproc-per-node=8 ../examples/features/torchrun/torchrun_dp_example_offline.py --tp-size=2 --pp-size=1 --dp-size=4 --enable-ep
 
-#--------------------------------------------------------  mi300 · entrypoints  --------------------------------------------------------#
+#--------------------------------------------------------  mi325 · entrypoints  --------------------------------------------------------#
 
 - label: Entrypoints Unit Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/entrypoints
-  - tests/entrypoints/unit_tests
-  - tests/entrypoints/weight_transfer
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s entrypoints/unit_tests
   - pytest -v -s entrypoints/weight_transfer
 
 - label: Entrypoints Integration (LLM) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/entrypoints/llm
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s entrypoints/llm --ignore=entrypoints/llm/test_generate.py --ignore=entrypoints/llm/test_collective_rpc.py --ignore=entrypoints/llm/offline_mode
@@ -907,16 +540,10 @@ steps:
 
 - label: Entrypoints Integration (API Server) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/entrypoints/serve
-  - tests/entrypoints/scale_out
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s entrypoints/serve --ignore=entrypoints/serve/dev/rpc
@@ -925,32 +552,20 @@ steps:
 
 - label: Entrypoints Integration (API Server OpenAI - Part 1) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   fast_check: true
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/entrypoints/openai
-  - tests/entrypoints/test_chat_utils
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s entrypoints/openai/ --ignore=entrypoints/openai/completion --ignore=entrypoints/openai/chat_completion --ignore=entrypoints/openai/responses --ignore=entrypoints/openai/correctness
 
 - label: Entrypoints Integration (API Server OpenAI - Part 2) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   fast_check: true
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/entrypoints/openai
-  - tests/entrypoints/test_chat_utils
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s entrypoints/openai/chat_completion
@@ -958,18 +573,10 @@ steps:
 
 - label: Entrypoints Integration (API Server Generate) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/tool_use
-  - tests/entrypoints/tool_parsers
-  - tests/entrypoints/anthropic
-  - tests/entrypoints/generate
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s tool_use
@@ -979,386 +586,188 @@ steps:
 
 - label: Entrypoints Integration (Responses API) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/entrypoints/openai/responses
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s entrypoints/openai/responses
 
 - label: Entrypoints Integration (Speech to Text) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/entrypoints/speech_to_text
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s entrypoints/speech_to_text
 
 - label: Entrypoints Integration (Multimodal)
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/entrypoints/multimodal
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s entrypoints/multimodal
 
 - label: Entrypoints Integration (Pooling) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/entrypoints/pooling
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s entrypoints/pooling
 
 - label: OpenAI API correctness # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - csrc/
-  - vllm/entrypoints/openai/
-  - vllm/model_executor/layers/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
-  - vllm/model_executor/model_loader/
   commands:
   - bash ../tools/install_torchcodec_rocm.sh || exit 1
   - pytest -s entrypoints/openai/correctness/
 
-#-----------------------------------------------------------  mi300 · evals  -----------------------------------------------------------#
+#-----------------------------------------------------------  mi325 · evals  -----------------------------------------------------------#
 
-- label: DeepSeek V2-Lite Prefetch Offload Accuracy (H100-MI300) # TBD
+- label: DeepSeek V2-Lite Prefetch Offload Accuracy (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   num_gpus: 1
   working_dir: "/vllm-workspace"
-  source_file_dependencies:
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/model_executor/layers/fused_moe/
-  - vllm/model_executor/layers/quantization/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/backends/mla/
-  - vllm/v1/attention/selector.py
-  - .buildkite/scripts/scheduled_integration_test/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - bash .buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_prefetch_offload.sh 0.25 200 8030
 
 - label: LM Eval Small Models # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - csrc/
-  - vllm/model_executor/layers/quantization
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-small.txt
 
 - label: MRCR Eval Small Models # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
-  - tests/evals/mrcr/
   commands:
   - pytest -s -v evals/mrcr/test_mrcr_correctness.py --config-list-file=evals/mrcr/configs/models-small.txt
 
-- label: LM Eval Small Models (MI300) # TBD
+- label: LM Eval Small Models (MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
-  source_file_dependencies:
-  - csrc/
-  - vllm/model_executor/layers/quantization
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-small-rocm.txt
 
 - label: Multi-Modal Accuracy Eval (Small Models) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
-  source_file_dependencies:
-  - vllm/multimodal/
-  - vllm/inputs/
-  - vllm/v1/core/
-  - vllm/platforms/rocm.py
-  - vllm/model_executor/model_loader/
   commands:
   - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-mm-small.txt --tp-size=1
 
-- label: GPQA Eval (GPT-OSS) (2xH100-2xMI300) # TBD
+- label: GPQA Eval (GPT-OSS) (2xH100-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - csrc/
-  - vllm/model_executor/layers/quantization
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/model_executor/layers/fused_moe/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
-  - tests/evals/gpt_oss/
   commands:
     - uv pip install --system 'gpt-oss[eval]==0.0.5'
     - pytest -s -v evals/gpt_oss/test_gpqa_correctness.py --config-list-file=configs/models-gfx942.txt
 
-- label: LM Eval Small Models (2xB200-2xMI300) # TBD
+- label: LM Eval Small Models (2xB200-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - csrc/
-  - vllm/model_executor/layers/quantization
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-mi3xx-fp8-and-mixed.txt
 
-- label: DeepSeek V2-Lite Sync EPLB Accuracy (4xH100-4xMI300) # TBD
+- label: DeepSeek V2-Lite Sync EPLB Accuracy (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
-  optional: true
   working_dir: "/vllm-workspace"
-  source_file_dependencies:
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/distributed/eplb
-  - vllm/model_executor/layers/fused_moe/
-  - vllm/model_executor/layers/quantization/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/backends/mla/
-  - vllm/v1/attention/selector.py
-  - .buildkite/scripts/scheduled_integration_test/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - bash .buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_ep_eplb.sh 0.25 200 8010
 
-- label: LM Eval Large Models (4xA100-4xMI300) # TBD
+- label: LM Eval Large Models (4xA100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
-  optional: true
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
-  source_file_dependencies:
-  - csrc/
-  - vllm/model_executor/layers/quantization
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large.txt --tp-size=4
 
-- label: Qwen3-30B-A3B-FP8-block Sync EPLB Accuracy (4xH100-4xMI300) # TBD
+- label: Qwen3-30B-A3B-FP8-block Sync EPLB Accuracy (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
-  optional: true
   working_dir: "/vllm-workspace"
-  source_file_dependencies:
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/model_executor/layers/quantization/
-  - vllm/distributed/eplb
-  - vllm/model_executor/layers/fused_moe/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - .buildkite/scripts/scheduled_integration_test/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_block_ep_eplb.sh 0.8 200 8020
 
-- label: Qwen3-30B-A3B-FP8 DP4 Async EPLB Accuracy (4xH100-4xMI300) # TBD
+- label: Qwen3-30B-A3B-FP8 DP4 Async EPLB Accuracy (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
-  optional: true
   working_dir: "/vllm-workspace"
-  source_file_dependencies:
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/model_executor/layers/quantization/
-  - vllm/distributed/eplb
-  - vllm/model_executor/layers/fused_moe/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - .buildkite/scripts/scheduled_integration_test/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_dp4_async_eplb.sh 0.8 200 8050
 
 - label: Qwen3-Next-80B-A3B-Instruct MTP Async EPLB Accuracy # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
-  optional: true
   working_dir: "/vllm-workspace"
-  source_file_dependencies:
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/v1/spec_decode/
-  - vllm/distributed/eplb
-  - vllm/model_executor/layers/fused_moe/
-  - vllm/model_executor/layers/quantization/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - .buildkite/scripts/scheduled_integration_test/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - bash .buildkite/scripts/scheduled_integration_test/qwen3_next_mtp_async_eplb.sh 0.8 1319 8040
 
-- label: LM Eval Large Models (8xH200-8xMI300) # TBD
+- label: LM Eval Large Models (8xH200-8xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_8
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_8
   num_gpus: 8
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/model_executor/layers/quantization/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/model_executor/layers/layernorm.py
-  - csrc/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
-  - tests/evals/
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-mi3xx.txt
 
 - label: ROCm LM Eval Large Models (8 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_8
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_8
   num_gpus: 8
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
-  source_file_dependencies:
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/model_executor/layers/quantization/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/model_executor/layers/layernorm.py
-  - csrc/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large-rocm.txt --tp-size=8
 
-#---------------------------------------------------------  mi300 · examples  ----------------------------------------------------------#
+#---------------------------------------------------------  mi325 · examples  ----------------------------------------------------------#
 
 - label: Examples # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/examples"
-  source_file_dependencies:
-  - vllm/entrypoints
-  - vllm/multimodal
-  - examples/
-  - vllm/platforms/rocm.py
   commands:
     - pip install tensorizer
     # Basic
@@ -1382,164 +791,87 @@ steps:
     - python3 features/speculative_decoding/spec_decode_offline.py --test --method eagle --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 2048
     - python3 features/speculative_decoding/spec_decode_offline.py --test --method eagle3 --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 1536
 
-#----------------------------------------------------------  mi300 · kernels  ----------------------------------------------------------#
+#----------------------------------------------------------  mi325 · kernels  ----------------------------------------------------------#
 
 - label: vLLM IR Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/"
-  source_file_dependencies:
-  - vllm/ir
-  - vllm/kernels
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s tests/ir
   - pytest -v -s tests/kernels/ir
 
 - label: Kernels Attention Test %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   parallelism: 2
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - csrc/attention/
-  - vllm/v1/attention
-  - vllm/model_executor/layers/attention
-  - tests/kernels/attention
-  - vllm/_aiter_ops.py
-  - vllm/envs.py
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s kernels/attention --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
 
 - label: Kernels Core Operation Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - csrc/
-  - tests/kernels/core
-  - tests/kernels/test_top_k_per_row.py
-  - tests/kernels/test_concat_mla_q.py
-  - vllm/model_executor/layers/rotary_embedding/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s kernels/core --ignore=kernels/core/test_minimax_reduce_rms.py  kernels/test_concat_mla_q.py kernels/test_top_k_per_row.py
 
 - label: Kernels KDA Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/third_party/flash_linear_attention/ops/kda.py
-  - vllm/third_party/flash_linear_attention/ops/chunk_delta_h.py
-  - vllm/third_party/flash_linear_attention/ops/l2norm.py
-  - tests/kernels/test_kda.py
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s kernels/test_kda.py
 
 - label: Kernels MoE Test %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   parallelism: 5
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - csrc/quantization/cutlass_w8a8/moe/
-  - csrc/moe/
-  - tests/kernels/moe
-  - vllm/model_executor/layers/fused_moe/
-  - vllm/distributed/device_communicators/
-  - vllm/envs.py
-  - vllm/config
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s kernels/moe --ignore=kernels/moe/test_modular_oai_triton_moe.py --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
   - pytest -v -s kernels/moe/test_modular_oai_triton_moe.py --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
 
 - label: Kernels Quantization Test %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   parallelism: 2
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - csrc/quantization/
-  - vllm/model_executor/layers/quantization
-  - tests/kernels/quantization
-  - tests/kernels/quantization/test_rocm_skinny_gemms.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
-  - vllm/model_executor/kernels/
   commands:
   - pytest -v -s kernels/quantization --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
 
-- label: Kernels FP8 MoE Test (2xH100-2xMI300) # TBD
+- label: Kernels FP8 MoE Test (2xH100-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - csrc/moe/
-  - csrc/quantization/w8a8/cutlass/moe/
-  - vllm/model_executor/layers/fused_moe/
-  - tests/kernels/moe/test_deepep_moe.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
-  - vllm/envs.py
   commands:
     - pytest -v -s kernels/moe/test_deepep_moe.py
 
-#-----------------------------------------------------------  mi300 · lora  ------------------------------------------------------------#
+#-----------------------------------------------------------  mi325 · lora  ------------------------------------------------------------#
 
 - label: LoRA %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   parallelism: 4
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/lora
-  - tests/lora
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s lora --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --ignore=lora/test_chatglm3_tp.py --ignore=lora/test_llama_tp.py --ignore=lora/test_qwen3_with_multi_loras.py --ignore=lora/test_olmoe_tp.py --ignore=lora/test_deepseekv2_tp.py --ignore=lora/test_gptoss_tp.py --ignore=lora/test_qwen3moe_tp.py --ignore=lora/test_qwen35_densemodel_lora.py
 
 - label: LoRA TP (Distributed) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/lora
-  - tests/lora
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s -x lora/test_chatglm3_tp.py
   - pytest -v -s -x lora/test_llama_tp.py
@@ -1548,47 +880,26 @@ steps:
   - pytest -v -s -x lora/test_gptoss_tp.py
   - pytest -v -s -x lora/test_qwen35_densemodel_lora.py
 
-#------------------------------------------------------  mi300 · model_executor  -------------------------------------------------------#
+#------------------------------------------------------  mi325 · model_executor  -------------------------------------------------------#
 
 - label: Model Executor # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/engine/arg_utils.py
-  - vllm/config/model.py
-  - vllm/model_executor
-  - tests/model_executor
-  - tests/entrypoints/openai/completion/test_tensorizer_entrypoint.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - apt-get update && apt-get install -y curl libsodium23
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s model_executor -m '(not slow_test)'
   - pytest -v -s entrypoints/openai/completion/test_tensorizer_entrypoint.py
 
-#----------------------------------------------------  mi300 · model_runner_v2  -------------------------------------------------------#
+#----------------------------------------------------  mi325 · model_runner_v2  -------------------------------------------------------#
 
 - label: Model Runner V2 Core Tests # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/v1/worker/gpu/
-  - vllm/v1/worker/gpu_worker.py
-  - vllm/v1/core/sched/
-  - vllm/v1/attention/
-  - tests/v1/engine/test_llm_engine.py
-  - tests/v1/e2e/
-  - tests/entrypoints/llm/test_struct_output_generate.py
-  - vllm/platforms/rocm.py
   commands:
   - set -x
   - export VLLM_USE_V2_MODEL_RUNNER=1
@@ -1600,22 +911,9 @@ steps:
 
 - label: Model Runner V2 Examples # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/examples"
-  source_file_dependencies:
-  - vllm/v1/worker/gpu/
-  - vllm/v1/core/sched/
-  - vllm/v1/worker/gpu_worker.py
-  - examples/basic/offline_inference/
-  - examples/generate/multimodal/
-  - examples/features/
-  - examples/pooling/embed/vision_embedding_offline.py
-  - examples/features/tensorize_vllm_model.py
-  - examples/deployment/llm_engine_example.py
-  - vllm/platforms/rocm.py
   commands:
   - set -x
   - export VLLM_USE_V2_MODEL_RUNNER=1
@@ -1635,40 +933,23 @@ steps:
 
 - label: Model Runner V2 Distributed (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/v1/worker/gpu/
-  - vllm/v1/worker/gpu_worker.py
-  - tests/basic_correctness/test_basic_correctness.py
-  - tests/v1/distributed/test_async_llm_dp.py
-  - tests/v1/distributed/test_eagle_dp.py
-  - vllm/platforms/rocm.py
   commands:
   - set -x
   - export VLLM_USE_V2_MODEL_RUNNER=1
-  - TARGET_TEST_SUITE=MI300 pytest -v -s basic_correctness/test_basic_correctness.py -m 'distributed(num_gpus=2)' -k "not ray and not True"
+  - TARGET_TEST_SUITE=MI325 pytest -v -s basic_correctness/test_basic_correctness.py -m 'distributed(num_gpus=2)' -k "not ray and not True"
   - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_async_llm_dp.py -k "not ray"
   - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_eagle_dp.py
 
 - label: Model Runner V2 Pipeline Parallelism (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/v1/worker/gpu/
-  - vllm/v1/worker/gpu_worker.py
-  - tests/distributed/test_pipeline_parallel.py
-  - tests/distributed/test_pp_cudagraph.py
-  - vllm/platforms/rocm.py
   commands:
   - set -x
   - export VLLM_USE_V2_MODEL_RUNNER=1
@@ -1677,19 +958,9 @@ steps:
 
 - label: Model Runner V2 Spec Decode # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/v1/worker/gpu/
-  - vllm/v1/worker/gpu_worker.py
-  - tests/v1/spec_decode/test_max_len.py
-  - tests/v1/spec_decode/test_rejection_sampler_utils.py
-  - tests/v1/spec_decode/test_synthetic_rejection_sampler_utils.py
-  - tests/v1/e2e/spec_decode/test_spec_decode.py
-  - vllm/platforms/rocm.py
   commands:
   - set -x
   - export VLLM_USE_V2_MODEL_RUNNER=1
@@ -1698,188 +969,113 @@ steps:
   - pytest -v -s v1/spec_decode/test_synthetic_rejection_sampler_utils.py
   - pytest -v -s v1/e2e/spec_decode/test_spec_decode.py -k "eagle or mtp"
 
-#------------------------------------------------------  mi300 · models / basic  -------------------------------------------------------#
+#------------------------------------------------------  mi325 · models / basic  -------------------------------------------------------#
 
 - label: Basic Models Tests (Extra Initialization) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   parallelism: 6
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/model_executor/models/
-  - vllm/model_executor/layers/
-  - tests/models/test_initialization.py
-  - tests/models/registry.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s models/test_initialization.py -k 'not test_can_initialize_small_subset' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
 
 - label: Basic Models Tests (Initialization) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/test_initialization.py
-  - tests/models/registry.py
   commands:
   - pytest -v -s models/test_initialization.py::test_can_initialize_small_subset
 
 - label: Basic Models Tests (Other) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/test_terratorch.py
-  - tests/models/transformers/test_backend.py
-  - tests/models/test_registry.py
   commands:
   - pytest -v -s models/test_terratorch.py models/transformers/test_backend.py models/test_registry.py
 
-#-----------------------------------------------------  mi300 · models / language  -----------------------------------------------------#
+#-----------------------------------------------------  mi325 · models / language  -----------------------------------------------------#
 
 - label: Language Models Test (Extended Pooling)  # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/language/pooling
   commands:
   - pytest -v -s models/language/pooling -m 'not core_model'
 
 - label: Language Models Tests (Standard) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/language
   commands:
   - pip freeze | grep -E 'torch'
   - pytest -v -s models/language -m 'core_model and (not slow_test)'
 
 - label: Language Models Tests (Extra Standard) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   parallelism: 2
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/model_executor/layers/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - tests/models/language/pooling/test_embedding.py
-  - tests/models/language/generation/test_common.py
-  - tests/models/language/pooling/test_classification.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - pip freeze | grep -E 'torch'
   - pytest -v -s models/language -m 'core_model and slow_test' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
 
-#----------------------------------------------------  mi300 · models / multimodal  ----------------------------------------------------#
+#----------------------------------------------------  mi325 · models / multimodal  ----------------------------------------------------#
 
 - label: Multi-Modal Models (Extended Generation 1) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/multimodal/generation
-  - tests/models/multimodal/test_mapping.py
   commands:
   - pytest -v -s models/multimodal/generation -m 'not core_model' --ignore models/multimodal/generation/test_common.py
   - pytest -v -s models/multimodal/test_mapping.py
 
 - label: Multi-Modal Models (Extended Generation 2) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/multimodal/generation
   commands:
   - pytest -v -s models/multimodal/generation/test_common.py -m 'split(group=0) and not core_model'
 
 
 - label: Multi-Modal Models (Extended Generation 3) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/multimodal/generation
   commands:
   - pytest -v -s models/multimodal/generation/test_common.py -m 'split(group=1) and not core_model'
 
 - label: "Multi-Modal Models (Standard) 1: qwen2" # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/multimodal
   commands:
   - pytest -v -s models/multimodal/generation/test_common.py -m core_model -k "qwen2"
   - pytest -v -s models/multimodal/generation/test_ultravox.py -m core_model
 
 - label: "Multi-Modal Models (Standard) 3: llava + qwen2_vl" # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/multimodal/generation
-  - tests/models/multimodal/test_mapping.py
   commands:
   - pytest -v -s models/multimodal/generation/test_common.py -m core_model -k "not qwen2 and not qwen3 and not gemma"
   - pytest -v -s models/multimodal/generation/test_qwen2_vl.py -m core_model
 
 - label: "Multi-Modal Models (Standard) 4: other + whisper" # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/multimodal/generation
-  - tests/models/multimodal/test_mapping.py
   commands:
   - pytest -v -s models/multimodal -m core_model --ignore models/multimodal/generation/test_common.py --ignore models/multimodal/generation/test_ultravox.py --ignore models/multimodal/generation/test_qwen2_5_vl.py --ignore models/multimodal/generation/test_qwen2_vl.py --ignore models/multimodal/generation/test_whisper.py  --ignore models/multimodal/generation/test_memory_leak.py --ignore models/multimodal/processing
   - pytest -v -s models/multimodal/generation/test_memory_leak.py -m core_model
@@ -1887,70 +1083,39 @@ steps:
 
 - label: Multi-Modal Processor # 1h 42m
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/multimodal
-  - tests/models/registry.py
   commands:
   - pytest -v -s models/multimodal/processing/test_tensor_schema.py
 
 - label: Multi-Modal Processor (CPU) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   parallelism: 4
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/multimodal
-  - tests/models/registry.py
   commands:
   - pytest -v -s models/multimodal/processing --ignore models/multimodal/processing/test_tensor_schema.py --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
 
-#-----------------------------------------------------  mi300 · models / quantized  -----------------------------------------------------#
+#-----------------------------------------------------  mi325 · models / quantized  -----------------------------------------------------#
 
 - label: Quantized Models Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/model_executor/layers/quantization
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
-  - tests/models/quantization
-  - vllm/model_executor/model_loader/
   commands:
   - pytest -v -s models/quantization
 
-#--------------------------------------------------  mi300 · models / transformers  ---------------------------------------------------#
+#--------------------------------------------------  mi325 · models / transformers  ---------------------------------------------------#
 
 - label: Transformers Nightly Models (Shardable) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   parallelism: 4
-  optional: true
   working_dir: "/vllm-workspace/"
-  source_file_dependencies:
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/multimodal/
-  - vllm/model_executor/layers/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
-  - tests/models/
   commands:
   - pip install --upgrade git+https://github.com/huggingface/transformers
   - pytest -v -s tests/models/test_initialization.py --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
@@ -1958,22 +1123,9 @@ steps:
 
 - label: Transformers Nightly Models (Single) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/"
-  source_file_dependencies:
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/multimodal/
-  - vllm/model_executor/layers/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
-  - tests/models/
-  - examples/
   commands:
   - pip install --upgrade git+https://github.com/huggingface/transformers
   - pytest -v -s tests/models/transformers/test_backend.py
@@ -1982,20 +1134,14 @@ steps:
   - python3 examples/generate/multimodal/vision_language_offline.py --model-type qwen2_5_vl
   - VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/generate/multimodal/audio_language_offline.py --model-type whisper
 
-#----------------------------------------------------------  mi300 · plugins  ----------------------------------------------------------#
+#----------------------------------------------------------  mi325 · plugins  ----------------------------------------------------------#
 
 - label: Plugin Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/plugins/
-  - tests/plugins/
-  - vllm/platforms/rocm.py
   commands:
   # BEGIN: platform plugin and general plugin tests, all the code in-between runs on dummy platform
   - pip install -e ./plugins/vllm_add_dummy_platform
@@ -2038,45 +1184,21 @@ steps:
 
 - label: GGUF Plugin # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   soft_fail: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/model_executor/layers/quantization
-  - tests/plugins_tests/test_gguf_plugin.py
-  - tests/plugins_tests/gguf
-  - vllm/platforms/rocm.py
   commands:
   - pip install "vllm-gguf-plugin >= 0.0.2"
   - pytest -v -s plugins_tests/gguf
 
-#-------------------------------------------------------  mi300 · rust_frontend  -------------------------------------------------------#
+#-------------------------------------------------------  mi325 · rust_frontend  -------------------------------------------------------#
 
 - label: Rust Frontend OpenAI Coverage # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - rust/
-  - vllm/benchmarks/
-  - vllm/entrypoints/openai/
-  - vllm/entrypoints/serve/
-  - vllm/v1/sample/
-  - tests/utils.py
-  - tests/benchmarks/test_serve_cli.py
-  - tests/entrypoints/openai/chat_completion/test_chat_completion.py
-  - tests/entrypoints/openai/chat_completion/test_chat_logit_bias_validation.py
-  - tests/entrypoints/openai/completion/test_shutdown.py
-  - tests/entrypoints/openai/test_return_token_ids.py
-  - tests/entrypoints/openai/test_uds.py
-  - tests/v1/sample/test_logprobs_e2e.py
-  - vllm/platforms/rocm.py
   commands:
   - export VLLM_USE_RUST_FRONTEND=1
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
@@ -2090,23 +1212,9 @@ steps:
 
 - label: Rust Frontend Serve Admin Coverage # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - rust/
-  - vllm/entrypoints/openai/
-  - vllm/entrypoints/serve/
-  - vllm/v1/engine/
-  - tests/utils.py
-  - tests/entrypoints/serve/dev/rpc/test_collective_rpc.py
-  - tests/entrypoints/scale_out/token_in_token_out/test_serving_tokens.py
-  - tests/entrypoints/serve/instrumentator/test_basic.py
-  - tests/entrypoints/serve/instrumentator/test_metrics.py
-  - tests/entrypoints/serve/tokenize/test_tokenization.py
-  - vllm/platforms/rocm.py
   commands:
   - export VLLM_USE_RUST_FRONTEND=1
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
@@ -2118,17 +1226,9 @@ steps:
 
 - label: Rust Frontend Core Correctness # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - rust/
-  - vllm/entrypoints/openai/
-  - tests/utils.py
-  - tests/entrypoints/openai/correctness/test_lmeval.py
-  - vllm/platforms/rocm.py
   commands:
   - export VLLM_USE_RUST_FRONTEND=1
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
@@ -2136,18 +1236,9 @@ steps:
 
 - label: Rust Frontend Tool Use # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - rust/
-  - vllm/entrypoints/openai/
-  - vllm/tool_parsers/
-  - tests/utils.py
-  - tests/tool_use/
-  - vllm/platforms/rocm.py
   commands:
   - export VLLM_USE_RUST_FRONTEND=1
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
@@ -2155,24 +1246,10 @@ steps:
 
 - label: Rust Frontend Distributed # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - rust/
-  - vllm/distributed/
-  - vllm/engine/
-  - vllm/executor/
-  - vllm/v1/engine/
-  - vllm/v1/worker/
-  - tests/utils.py
-  - tests/v1/distributed/test_external_lb_dp.py
-  - tests/v1/distributed/test_hybrid_lb_dp.py
-  - tests/v1/distributed/test_internal_lb_dp.py
-  - vllm/platforms/rocm.py
   commands:
   - export VLLM_USE_RUST_FRONTEND=1
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
@@ -2180,20 +1257,13 @@ steps:
   - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_external_lb_dp.py -k "not 4 and not server_info"
   - TP_SIZE=1 DP_SIZE=4 pytest -v -s v1/distributed/test_hybrid_lb_dp.py -k "not 4 and not server_info"
 
-#-------------------------------------------------------  mi300 · quantization  --------------------------------------------------------#
+#-------------------------------------------------------  mi325 · quantization  --------------------------------------------------------#
 
 - label: Quantization # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - csrc/
-  - vllm/model_executor/layers/quantization
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
-  - tests/quantization
   commands:
 
   # temporary install here since we need nightly, will move to requirements/test.in
@@ -2207,304 +1277,147 @@ steps:
   - uv pip install --system conch-triton-kernels
   - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py
 
-#-----------------------------------------------------------  mi300 · rocm  ------------------------------------------------------------#
+#-----------------------------------------------------------  mi325 · rocm  ------------------------------------------------------------#
 
 - label: ROCm AITER Ops Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/_aiter_ops.py
-  - vllm/envs.py
-  - vllm/platforms/rocm.py
-  - tests/rocm/aiter/
-  - vllm/v1/attention/backends/mla/rocm_aiter_mla.py
-  - vllm/v1/attention/selector.py
   commands:
   - pytest -v -s rocm/aiter/
 
-#---------------------------------------------------------  mi300 · samplers  ----------------------------------------------------------#
+#---------------------------------------------------------  mi325 · samplers  ----------------------------------------------------------#
 
 - label: Samplers Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/model_executor/layers
-  - vllm/sampling_metadata.py
-  - vllm/v1/sample/
-  - vllm/entrypoints/generate/beam_search/
-  - tests/samplers
-  - tests/conftest.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s samplers
 
-#------------------------------------------------------------  mi300 · misc  ------------------------------------------------------------#
+#------------------------------------------------------------  mi325 · misc  ------------------------------------------------------------#
 
 - label: Regression # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/test_regression
   commands:
   - pip install 'modelscope<1.38'
   - pytest -v -s test_regression.py
 
-#---------------------------------------------------------  mi300 · ray_compat  ---------------------------------------------------------#
+#---------------------------------------------------------  mi325 · ray_compat  ---------------------------------------------------------#
 
 - label: Ray Dependency Compatibility Check # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/"
-  source_file_dependencies:
-  - requirements/
-  - setup.py
-  - vllm/platforms/rocm.py
   commands:
   - bash /vllm-workspace/.buildkite/scripts/check-ray-compatibility.sh
 
-#------------------------------------------------------------  mi300 · v1  -------------------------------------------------------------#
+#------------------------------------------------------------  mi325 · v1  -------------------------------------------------------------#
 
 - label: Acceptance Length Test (Large Models) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/v1/spec_decode/
-  - vllm/model_executor/models/mlp_speculator.py
-  - tests/v1/spec_decode/test_acceptance_length.py
-  - vllm/platforms/rocm.py
   commands:
   - export VLLM_ALLOW_INSECURE_SERIALIZATION=1
   - pytest -v -s v1/spec_decode/test_acceptance_length.py -m slow_test
 
 - label: e2e Scheduling (1 GPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/v1/
-  - tests/v1/e2e/general/
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s v1/e2e/general/test_async_scheduling.py
 
 - label: Engine (1 GPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/v1/engine/
-  - tests/v1/engine/
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s v1/engine/test_preprocess_error_handling.py
   - pytest -v -s v1/engine --ignore v1/engine/test_preprocess_error_handling.py
 
 - label: Spec Decode Draft Model # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/v1/spec_decode/
-  - vllm/v1/worker/gpu/spec_decode/
-  - vllm/model_executor/model_loader/
-  - vllm/v1/sample/
-  - vllm/model_executor/layers/
-  - tests/v1/e2e/spec_decode/
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s v1/e2e/spec_decode -k "draft_model or no_sync or batch_inference"
 
 - label: Spec Decode Eagle # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/v1/spec_decode/
-  - vllm/v1/worker/gpu/spec_decode/
-  - vllm/model_executor/model_loader/
-  - vllm/v1/sample/
-  - vllm/model_executor/layers/
-  - tests/v1/e2e/spec_decode/
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s v1/e2e/spec_decode -k "eagle_correctness"
 
 - label: Spec Decode Ngram + Suffix # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/v1/spec_decode/
-  - vllm/v1/worker/gpu/spec_decode/
-  - vllm/model_executor/model_loader/
-  - vllm/v1/sample/
-  - vllm/model_executor/layers/
-  - tests/v1/e2e/spec_decode/
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s v1/e2e/spec_decode -k "ngram or suffix"
 
 - label: Spec Decode Speculators + MTP # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/v1/spec_decode/
-  - vllm/v1/worker/gpu/spec_decode/
-  - vllm/model_executor/model_loader/
-  - vllm/v1/sample/
-  - vllm/model_executor/layers/
-  - vllm/transformers_utils/configs/speculators/
-  - tests/v1/e2e/spec_decode/
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s v1/e2e/spec_decode -k "speculators or mtp_correctness"
 
 - label: Speculators Correctness # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/config/speculative.py
-  - vllm/engine/arg_utils.py
-  - vllm/transformers_utils/config.py
-  - vllm/transformers_utils/configs/speculators/
-  - vllm/v1/spec_decode/
-  - vllm/v1/worker/gpu/spec_decode/
-  - vllm/v1/worker/gpu_model_runner.py
-  - vllm/v1/sample/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/model_executor/model_loader/
-  - vllm/model_executor/layers/
-  - vllm/model_executor/models/llama_eagle3.py
-  - vllm/model_executor/models/qwen3.py
-  - vllm/model_executor/models/qwen3_dflash.py
-  - vllm/model_executor/models/registry.py
-  - vllm/_aiter_ops.py
-  - tests/evals/gsm8k/
-  - tests/v1/spec_decode/test_speculators_correctness.py
-  - vllm/platforms/rocm.py
   commands:
   - export VLLM_ALLOW_INSECURE_SERIALIZATION=1
   - pytest -v -s v1/spec_decode/test_speculators_correctness.py -m slow_test
 
 - label: V1 Spec Decode # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/v1/spec_decode
   commands:
   - pytest -v -s -m 'not slow_test' v1/spec_decode
 
 - label: Extract Hidden States Integration # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/config/speculative.py
-  - vllm/distributed/kv_transfer/kv_connector/
-  - vllm/model_executor/layers/attention/
-  - vllm/model_executor/layers/mamba/
-  - vllm/model_executor/model_loader/
-  - vllm/model_executor/models/extract_hidden_states.py
-  - vllm/model_executor/models/llama.py
-  - vllm/model_executor/models/qwen3_5.py
-  - vllm/model_executor/models/qwen3_next.py
-  - vllm/model_executor/models/registry.py
-  - vllm/transformers_utils/configs/extract_hidden_states.py
-  - vllm/transformers_utils/configs/qwen3_5.py
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/v1/kv_cache_interface.py
-  - vllm/v1/spec_decode/extract_hidden_states.py
-  - vllm/v1/worker/gpu_model_runner.py
-  - vllm/_aiter_ops.py
-  - tests/v1/kv_connector/extract_hidden_states_integration/
-  - vllm/platforms/rocm.py
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s v1/kv_connector/extract_hidden_states_integration
 
-- label: V1 attention (H100-MI300) # TBD
+- label: V1 attention (H100-MI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/config/attention.py
-  - vllm/model_executor/layers/attention
-  - vllm/v1/attention
-  - tests/v1/attention
-  - vllm/_aiter_ops.py
-  - vllm/envs.py
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s v1/attention
 
 - label: V1 Core + KV + Metrics # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/v1/core
-  - tests/v1/executor
-  - tests/v1/kv_offload
-  - tests/v1/worker
-  - tests/v1/kv_connector/unit
-  - tests/v1/metrics
-  - tests/entrypoints/openai/correctness/test_lmeval.py
   commands:
   - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
   - pytest -v -s -m 'not cpu_test' v1/core
@@ -2519,14 +1432,9 @@ steps:
 
 - label: V1 others (CPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/v1
   commands:
   - pytest -v -s -m 'cpu_test' v1/core
   - pytest -v -s v1/structured_output
@@ -2536,18 +1444,9 @@ steps:
 
 - label: V1 Sample + Logits # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/v1/sample
-  - tests/v1/logits_processors
-  - tests/v1/test_oracle.py
-  - tests/v1/test_request.py
-  - tests/v1/test_outputs.py
   commands:
   - pytest -v -s v1/sample
   - pytest -v -s v1/logits_processors
@@ -2557,22 +1456,10 @@ steps:
 
 - label: Distributed DP Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/distributed/
-  - vllm/engine/
-  - vllm/executor/
-  - vllm/worker/worker_base.py
-  - vllm/v1/engine/
-  - vllm/v1/worker/
-  - tests/v1/distributed
-  - tests/entrypoints/openai/test_multi_api_servers.py
-  - vllm/platforms/rocm.py
   commands:
   - export NCCL_CUMEM_HOST_ENABLE=0
   - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_async_llm_dp.py
@@ -2582,15 +1469,10 @@ steps:
 
 - label: Metrics, Tracing (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/v1/tracing
   commands:
   - "pip install \
       'opentelemetry-sdk>=1.26.0' \
@@ -2601,64 +1483,39 @@ steps:
 
 - label: V1 e2e (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/v1/e2e
   commands:
     - pytest -v -s v1/e2e/spec_decode/test_spec_decode.py -k "tensor_parallelism"
 
 - label: NixlConnector PD + Spec Decode acceptance (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
-  - vllm/v1/worker/kv_connector_model_runner_mixin.py
-  - tests/v1/kv_connector/nixl_integration/
-  - vllm/platforms/rocm.py
   commands:
   - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
   - KV_CACHE_MEMORY_BYTES=8G ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/config_sweep_spec_decode_test.sh
 
 - label: CrossLayer KV layout Distributed NixlConnector PD accuracy tests (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
-  - tests/v1/kv_connector/nixl_integration/
-  - vllm/platforms/rocm.py
   commands:
   - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
   - CROSS_LAYERS_BLOCKS=True ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
 
 - label: Distributed DP Tests (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/distributed/
-  - tests/v1/distributed
-  - tests/v1/engine/test_engine_core_client.py
-  - tests/distributed/test_utils
-  - vllm/platforms/rocm.py
   commands:
   - export NCCL_CUMEM_HOST_ENABLE=0
   - TP_SIZE=2 DP_SIZE=2 pytest -v -s v1/distributed/test_async_llm_dp.py
@@ -2671,162 +1528,98 @@ steps:
 
 - label: Distributed NixlConnector PD accuracy (4 GPUs)  # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
-  - tests/v1/kv_connector/nixl_integration/
-  - vllm/platforms/rocm.py
   commands:
   - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
   - ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
 
 - label: DP EP Distributed NixlConnector PD accuracy tests (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
-  - tests/v1/kv_connector/nixl_integration/
-  - vllm/platforms/rocm.py
   commands:
   - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
   - DP_EP=1 ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
 
 - label: Hybrid SSM NixlConnector PD accuracy tests (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
-  - tests/v1/kv_connector/nixl_integration/
-  - vllm/platforms/rocm.py
   commands:
   - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
   - HYBRID_SSM=1 ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
 
 - label: Hybrid SSM NixlConnector PD prefix cache test (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
-  - vllm/v1/core/sched/
-  - vllm/v1/core/kv_cache_coordinator.py
-  - tests/v1/kv_connector/nixl_integration/
-  - vllm/platforms/rocm.py
   commands:
   - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
   - ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/run_mamba_prefix_cache_test.sh
 
 - label: MultiConnector (Nixl+Offloading) PD accuracy (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
-  - vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
-  - vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
-  - vllm/distributed/kv_transfer/kv_connector/v1/offloading/
-  - tests/v1/kv_connector/nixl_integration/
-  - vllm/platforms/rocm.py
   commands:
   - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
   - ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/run_multi_connector_accuracy_test.sh
 
 - label: MultiConnector (Nixl+Offloading) PD edge cases (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
-  - vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
-  - vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
-  - vllm/distributed/kv_transfer/kv_connector/v1/offloading/
-  - tests/v1/kv_connector/nixl_integration/
-  - vllm/platforms/rocm.py
   commands:
   - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
   - ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/run_multi_connector_edge_case_test.sh
 
 - label: V1 e2e (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/v1/e2e
   commands:
     - pytest -v -s v1/e2e/spec_decode/test_spec_decode.py -k "eagle_correctness_heavy"
 
-- label: V1 e2e (4xH100-4xMI300) # TBD
+- label: V1 e2e (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
-  optional: true
-  source_file_dependencies:
-    - vllm/v1/attention/backends/utils.py
-    - vllm/v1/worker/gpu_model_runner.py
-    - tests/v1/e2e/test_hybrid_chunked_prefill.py
   commands:
     - pytest -v -s v1/e2e/test_hybrid_chunked_prefill.py
 
-#------------------------------------------------------  mi300 · weight_loading  -------------------------------------------------------#
+#------------------------------------------------------  mi325 · weight_loading  -------------------------------------------------------#
 
 - label: Weight Loading Multiple GPU # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/weight_loading
   commands:
   - bash weight_loading/run_model_weight_loading_test.sh -c weight_loading/models-amd.txt
 
 - label: Weight Loading Multiple GPU - Large Models # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/weight_loading
   commands:
   - bash weight_loading/run_model_weight_loading_test.sh -c weight_loading/models-large-amd.txt
 
@@ -2840,22 +1633,10 @@ steps:
 
 - label: Distributed Compile + RPC Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi325]
+  mirror_hardwares: [amdexperimental, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/compilation/
-  - vllm/distributed/
-  - vllm/engine/
-  - vllm/executor/
-  - vllm/worker/worker_base.py
-  - vllm/v1/engine/
-  - vllm/v1/worker/
-  - tests/compile/fullgraph/test_basic_correctness.py
-  - tests/compile/test_wrapper.py
-  - tests/entrypoints/llm/test_collective_rpc.py
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s entrypoints/llm/test_collective_rpc.py
   - pytest -v -s ./compile/fullgraph/test_basic_correctness.py
@@ -2865,21 +1646,10 @@ steps:
 
 - label: Distributed Torchrun + Shutdown Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi325]
+  mirror_hardwares: [amdexperimental, amdshadow]
   agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/distributed/
-  - vllm/engine/
-  - vllm/executor/
-  - vllm/worker/worker_base.py
-  - vllm/v1/engine/
-  - vllm/v1/worker/
-  - tests/distributed/
-  - tests/v1/shutdown
-  - tests/v1/worker/test_worker_memory_snapshot.py
-  - vllm/platforms/rocm.py
   commands:
   - VLLM_TEST_SAME_HOST=1 torchrun --nproc-per-node=4 distributed/test_same_node.py | grep 'Same node test passed'
   - VLLM_TEST_SAME_HOST=1 VLLM_TEST_WITH_DEFAULT_DEVICE_SET=1 torchrun --nproc-per-node=4 distributed/test_same_node.py | grep 'Same node test passed'
@@ -2888,18 +1658,10 @@ steps:
 
 - label: Distributed Compile + Comm (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi325]
+  mirror_hardwares: [amdexperimental, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/distributed/
-  - tests/distributed/test_pynccl
-  - tests/distributed/test_events
-  - tests/compile/fullgraph/test_basic_correctness.py
-  - tests/distributed/test_symm_mem_allreduce.py
-  - tests/distributed/test_multiproc_executor.py
-  - vllm/platforms/rocm.py
   commands:
   - pytest -v -s compile/fullgraph/test_basic_correctness.py
   - pytest -v -s distributed/test_pynccl.py
@@ -2911,17 +1673,9 @@ steps:
 
 - label: Engine # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi325]
+  mirror_hardwares: [amdexperimental, amdshadow]
   agent_pool: mi325_1
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/engine
-  - tests/test_sequence
-  - tests/test_config
-  - tests/test_logger
-  - tests/test_vllm_port
   commands:
   - pytest -v -s engine test_sequence.py test_config.py test_logger.py test_vllm_port.py test_jit_monitor.py
 
@@ -2929,20 +1683,10 @@ steps:
 
 - label: LM Eval Large Models (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi325]
+  mirror_hardwares: [amdexperimental, amdshadow]
   agent_pool: mi325_4
   num_gpus: 4
-  optional: true
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
-  source_file_dependencies:
-  - csrc/
-  - vllm/model_executor/layers/quantization
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - export VLLM_USE_DEEP_GEMM=0
   - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large-rocm-fp8.txt --tp-size=4
@@ -2951,12 +1695,9 @@ steps:
 
 - label: Language Models Test (Extended Generation) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi325]
+  mirror_hardwares: [amdexperimental, amdshadow]
   agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/language/generation
   commands:
   - uv pip install --system --no-build-isolation 'git+https://github.com/AndreasKaratzas/mamba@fix-rocm-7.0-warp-size-constexpr'
   - uv pip install --system --no-build-isolation 'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0'
@@ -2964,14 +1705,10 @@ steps:
 
 - label: Language Models Tests (Hybrid) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi325]
+  mirror_hardwares: [amdexperimental, amdshadow]
   agent_pool: mi325_1
   parallelism: 2
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/language/generation
   commands:
   - uv pip install --system --no-build-isolation 'git+https://github.com/AndreasKaratzas/mamba@fix-rocm-7.0-warp-size-constexpr'
   - uv pip install --system --no-build-isolation 'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0'
@@ -2981,25 +1718,17 @@ steps:
 
 - label: Multi-Modal Models (Extended Pooling) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi325]
+  mirror_hardwares: [amdexperimental, amdshadow]
   agent_pool: mi325_1
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/multimodal/pooling
   commands:
   - pytest -v -s models/multimodal/pooling -m 'not core_model'
 
 - label: "Multi-Modal Models (Standard) 2: qwen3 + gemma" # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi325]
+  mirror_hardwares: [amdexperimental, amdshadow]
   agent_pool: mi325_1
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/multimodal
   commands:
   - pytest -v -s models/multimodal/generation/test_common.py -m core_model -k "qwen3 or gemma"
   - pytest -v -s models/multimodal/generation/test_qwen2_5_vl.py -m core_model
@@ -3008,146 +1737,489 @@ steps:
 
 - label: Python-only Installation # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi325]
+  mirror_hardwares: [amdexperimental, amdshadow]
   agent_pool: mi325_1
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - tests/standalone_tests/python_only_compile.sh
-  - setup.py
-  - vllm/platforms/rocm.py
   commands:
   - bash standalone_tests/python_only_compile.sh
 
 #########################################################################################################################################
 #                                                                                                                                       #
-#                                                         MI355 (gfx950) tests                                                          #
+#                                                                COPY A                                                                 #
 #                                                                                                                                       #
 #########################################################################################################################################
 
-#--------------------------------------------------------  mi355 · benchmarks  ---------------------------------------------------------#
 
-- label: Attention Benchmarks Smoke Test (B200-MI355) # TBD
+#########################################################################################################################################
+#                                                                                                                                       #
+#                                                         MI325 (gfx942) tests                                                          #
+#                                                                                                                                       #
+#########################################################################################################################################
+
+#----------------------------------------------------------  mi325 · compile  ----------------------------------------------------------#
+
+- label: COPY A PyTorch Fullgraph Smoke Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_2
-  num_gpus: 2
-  working_dir: "/vllm-workspace/"
-  source_file_dependencies:
-  - benchmarks/attention_benchmarks/
-  - vllm/v1/attention/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
   commands:
-  - python3 benchmarks/attention_benchmarks/benchmark.py --backends ROCM_ATTN ROCM_AITER_FA ROCM_AITER_UNIFIED_ATTN --batch-specs "8q1s1k"
+  - "find compile/fullgraph/ -name 'test_*.py' -not -name 'test_full_graph.py' -exec pytest -s -v {} \\\\;"
 
-#--------------------------------------------------------  mi355 · distributed  --------------------------------------------------------#
+#--------------------------------------------------------  mi325 · distributed  --------------------------------------------------------#
 
-- label: Distributed Tests (2xH100-2xMI355) # TBD
+- label: COPY A Pipeline + Context Parallelism (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_2
-  num_gpus: 2
-  optional: true
-  working_dir: "/vllm-workspace/"
-  source_file_dependencies:
-  - csrc/custom_quickreduce.cu
-  - csrc/ops.h
-  - csrc/torch_bindings.cpp
-  - vllm/distributed/
-  - vllm/model_executor/layers/
-  - vllm/entrypoints/llm.py
-  - vllm/config/parallel.py
-  - vllm/model_executor/layers/fused_moe/
-  - vllm/v1/engine/
-  - vllm/v1/executor/
-  - vllm/v1/worker/
-  - vllm/v1/distributed/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/_aiter_ops.py
-  - vllm/_custom_ops.py
-  - vllm/platforms/rocm.py
-  - vllm/envs.py
-  - examples/offline_inference/data_parallel.py
-  - tests/distributed/test_context_parallel.py
-  - tests/distributed/test_rocm_aiter_custom_ar.py
-  - tests/distributed/test_rocm_quick_reduce.py
-  - tests/distributed/test_quick_all_reduce.py
-  - tests/v1/e2e/general/test_rocm_aiter_custom_ar.py
-  - tests/v1/distributed/test_dbo.py
-  - tests/utils.py
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
   commands:
-  - pytest -v -s tests/distributed/test_context_parallel.py
-  - pytest -v -s tests/distributed/test_rocm_aiter_custom_ar.py
-  - pytest -v -s tests/v1/e2e/general/test_rocm_aiter_custom_ar.py
-  - pytest -v -s tests/distributed/test_rocm_quick_reduce.py
-  - pytest -v -s tests/distributed/test_quick_all_reduce.py
-  - pytest -v -s tests/v1/distributed/test_dbo.py
+  - pytest -v -s distributed/test_pp_cudagraph.py
+  - pytest -v -s distributed/test_pipeline_parallel.py
 
-#--------------------------------------------------------  mi355 · entrypoints  --------------------------------------------------------#
+#----------------------------------------------------------  mi325 · kernels  ----------------------------------------------------------#
 
-- label: Entrypoints Integration (API Server) # TBD
+- label: COPY A Kernels Helion Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pip install helion==1.1.0
+  - pytest -v -s kernels/helion/
+
+- label: COPY A Kernels Mamba Test # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s kernels/mamba
+
+#------------------------------------------------------  mi325 · models / basic  -------------------------------------------------------#
+
+- label: COPY A Basic Models Test (Other CPU) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  no_gpu: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/test_utils.py models/test_vision.py
+
+#-----------------------------------------------------  mi325 · models / language  -----------------------------------------------------#
+
+- label: COPY A Language Models Test (MTEB) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/language/pooling_mteb_test
+
+- label: COPY A Language Models Test (PPL) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/language/generation_ppl_test
+
+#------------------------------------------------------------  mi325 · v1  -------------------------------------------------------------#
+
+- label: COPY A Batch Invariance (H100-MI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pip install pytest-timeout pytest-forked
+  - pytest -v -s v1/determinism/test_batch_invariance.py
+  - pytest -v -s v1/determinism/test_rms_norm_batch_invariant.py
+
+- label: COPY A Cudagraph # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s v1/cudagraph/test_cudagraph_dispatch.py
+  - pytest -v -s v1/cudagraph/test_cudagraph_mode.py
+
+- label: COPY A e2e Core (1 GPU) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s v1/e2e/general --ignore v1/e2e/general/test_async_scheduling.py
+
+#-------------------------------------------------------------  mi325 · misc  ------------------------------------------------------------#
+
+- label: COPY A Async Engine, Inputs, Utils, Worker, Config (CPU) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  no_gpu: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - python3 standalone_tests/lazy_imports.py
+  - pytest -v -s test_inputs.py
+  - pytest -v -s test_outputs.py
+  - pytest -v -s test_pooling_params.py
+  - pytest -v -s test_ray_env.py
+  - pytest -v -s test_sampling_params.py
+  - pytest -v -s -m 'cpu_test' multimodal
+  - pytest -v -s renderers
+  - pytest -v -s tokenizers_
+  - pytest -v -s reasoning
+  - pytest -v -s tool_parsers
+  - pytest -v -s parser
+  - pytest -v -s transformers_utils
+  - pytest -v -s config
+
+#------------------------------------------------------------  mi325 · rust  -----------------------------------------------------------#
+
+- label: COPY A Rust Frontend Cargo Style + Clippy # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  no_gpu: true
+  working_dir: "/vllm-workspace"
+  commands:
+  - bash .buildkite/scripts/run-rust-frontend-cargo-ci.sh style-clippy
+
+- label: COPY A Rust Frontend Cargo Tests # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  no_gpu: true
+  working_dir: "/vllm-workspace"
+  commands:
+  - bash .buildkite/scripts/run-rust-frontend-cargo-ci.sh test
+
+#-----------------------------------------------------------  mi325 · docker  ----------------------------------------------------------#
+
+- label: COPY A Docker Build Metadata (ROCm) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  no_gpu: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s tools/test_docker_build_metadata_args.py
+
+#########################################################################################################################################
+#                                                                                                                                       #
+#                                                         MI325 (gfx942) tests                                                          #
+#                                                                                                                                       #
+#########################################################################################################################################
+
+#-----------------------------------------------------  mi325 · basic_correctness  -----------------------------------------------------#
+
+- label: COPY A Basic Correctness # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/entrypoints/serve
-  - tests/entrypoints/scale_out
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s basic_correctness/test_mem.py
+  - VLLM_TARGET_TEST_SUITE=MI325 pytest -v -s basic_correctness/test_basic_correctness.py
+  - pytest -v -s basic_correctness/test_cpu_offload.py
+
+- label: COPY A Distributed Model Tests (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - TARGET_TEST_SUITE=MI325 pytest basic_correctness/ -v -s -m 'distributed(num_gpus=2)'
+  - CUDA_VISIBLE_DEVICES=0,1 pytest -v -s model_executor/model_loader/test_sharded_state_loader.py -m '(not slow_test)'
+  - pytest models/transformers/test_backend.py -v -s -m 'distributed(num_gpus=2)'
+  - pytest models/language -v -s -m 'distributed(num_gpus=2)'
+  - pytest models/multimodal -v -s -m 'distributed(num_gpus=2)' --ignore models/multimodal/generation/test_whisper.py --ignore models/multimodal/generation/test_phi4siglip.py
+  - pytest models/multimodal/generation/test_phi4siglip.py -v -s -m 'distributed(num_gpus=2)'
+  - VLLM_WORKER_MULTIPROC_METHOD=spawn pytest models/multimodal/generation/test_whisper.py -v -s -m 'distributed(num_gpus=2)'
+
+#--------------------------------------------------------  mi325 · benchmarks  ---------------------------------------------------------#
+
+- label: COPY A Benchmarks CLI Test # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s benchmarks/
+
+#----------------------------------------------------------  mi325 · compile  ----------------------------------------------------------#
+
+- label: COPY A PyTorch Compilation Unit Tests # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - "find compile/ -maxdepth 1 -name 'test_*.py' -print0 | xargs -0 -n1 -I{} pytest -s -v '{}'"
+
+- label: COPY A Fusion E2E Config Sweep (H100-MI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  num_gpus: 1
+  working_dir: "/vllm-workspace/"
+  commands:
+  - rocm-smi
+  - pytest -v -s tests/compile/fusions_e2e/test_tp1_quant.py -k "llama-3"
+
+- label: COPY A Fusion E2E Quick (H100-MI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  num_gpus: 1
+  working_dir: "/vllm-workspace/"
+  commands:
+  - rocm-smi
+  # Run all models and attn backends but only Inductor partition and native custom ops
+  - "pytest -v -s tests/compile/fusions_e2e/test_tp1_quant.py -k 'inductor_partition and not +rms_norm and not +quant_fp8'"
+  # Different from CUDA, Qwen requires +rms_norm and +quant_fp8 as rms+quant fusion is only supported on AITER
+  - "pytest -v -s tests/compile/fusions_e2e/test_tp1_quant.py -k 'inductor_partition and +rms_norm and +quant_fp8 and qwen3'"
+
+- label: COPY A PyTorch Compilation Passes Unit Tests # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -s -v compile/passes --ignore compile/passes/distributed
+
+- label: COPY A PyTorch Fullgraph # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s compile/fullgraph/test_full_graph.py -k 'not test_fp8_kv_scale_compile'
+
+- label: COPY A Pytorch Nightly Dependency Override Check # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  soft_fail: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - bash standalone_tests/pytorch_nightly_dependency.sh
+
+- label: COPY A Distributed Compile Unit Tests (2xH100-2xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/"
+  commands:
+  - export VLLM_TEST_CLEAN_GPU_MEMORY=1
+  - VLLM_TEST_CLEAN_GPU_MEMORY=1 pytest -v -s tests/compile/passes/distributed/test_async_tp.py
+  - pytest -v -s tests/compile/fusions_e2e/test_tp2_ar_rms.py::test_tp2_ar_rms_fusions
+
+#-----------------------------------------------------------  mi325 · cuda  ------------------------------------------------------------#
+
+- label: COPY A Platform Tests # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s cuda/test_cuda_context.py
+  - pytest -v -s cuda/test_platform_no_cuda_init.py
+
+#--------------------------------------------------------  mi325 · detokenizer  --------------------------------------------------------#
+
+- label: COPY A Async Engine, Inputs, Utils, Worker # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s detokenizer
+  - pytest -v -s -m 'not cpu_test' multimodal
+  - pytest -v -s utils_
+
+#--------------------------------------------------------  mi325 · distributed  --------------------------------------------------------#
+
+- label: COPY A Distributed Comm Ops # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s distributed/test_comm_ops.py
+  - pytest -v -s distributed/test_shm_broadcast.py
+  - pytest -v -s distributed/test_shm_buffer.py
+  - pytest -v -s distributed/test_shm_storage.py
+
+- label: COPY A EPLB Algorithm # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s distributed/test_eplb_algo.py
+  - pytest -v -s distributed/test_eplb_utils.py
+
+- label: COPY A EPLB Execution # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s distributed/test_eplb_execute.py
+  - pytest -v -s distributed/test_eplb_spec_decode.py
+
+- label: COPY A Distributed Tests (2xH100-2xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/"
+  commands:
+  - pytest -v -s tests/distributed/test_context_parallel.py
+  - VLLM_ALLOW_INSECURE_SERIALIZATION=1 python3 examples/rl/rlhf_async_new_apis.py
+  - VLLM_LOGGING_LEVEL=DEBUG python3 examples/features/data_parallel/data_parallel_offline.py --model=Qwen/Qwen1.5-MoE-A2.7B -tp=1 -dp=2 --max-model-len=2048 --all2all-backend=deepep_high_throughput
+  - VLLM_LOGGING_LEVEL=DEBUG python3 examples/features/data_parallel/data_parallel_offline.py --model=Qwen/Qwen1.5-MoE-A2.7B -tp=1 -dp=2 --max-model-len=2048 --all2all-backend=allgather_reducescatter --disable-nccl-for-dp-synchronization
+  - pytest -v -s tests/v1/distributed/test_dbo.py
+  - VLLM_ALLOW_INSECURE_SERIALIZATION=1 pytest -v -s tests/distributed/test_weight_transfer.py
+  - pytest -v -s tests/distributed/test_packed_tensor.py
+
+- label: COPY A Distributed Tests (4xA100-4xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s distributed/test_custom_all_reduce.py
+  - torchrun --nproc_per_node=2 distributed/test_ca_buffer_sharing.py
+  - TARGET_TEST_SUITE=MI325 pytest basic_correctness/ -v -s -m 'distributed(num_gpus=2)'
+  - pytest -v -s -x lora/test_mixtral.py
+
+- label: COPY A Distributed Torchrun + Examples (4 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - torchrun --nproc-per-node=4 distributed/test_torchrun_example.py
+  - PP_SIZE=2 torchrun --nproc-per-node=4 distributed/test_torchrun_example.py
+  - TP_SIZE=4 torchrun --nproc-per-node=4 distributed/test_torchrun_example_moe.py
+  - PP_SIZE=2 TP_SIZE=2 torchrun --nproc-per-node=4 distributed/test_torchrun_example_moe.py
+  - DP_SIZE=4 ENABLE_EP=1 torchrun --nproc-per-node=4 distributed/test_torchrun_example_moe.py
+  - TP_SIZE=2 DP_SIZE=2 ENABLE_EP=1 torchrun --nproc-per-node=4 distributed/test_torchrun_example_moe.py
+  - python3 ../examples/features/data_parallel/data_parallel_offline.py --enforce-eager
+  # rlhf examples
+  - VLLM_ALLOW_INSECURE_SERIALIZATION=1 python3 ../examples/rl/rlhf_nccl.py
+  - VLLM_ALLOW_INSECURE_SERIALIZATION=1 python3 ../examples/rl/rlhf_ipc.py
+
+- label: COPY A Elastic EP Scaling Test # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s distributed/test_elastic_ep.py
+
+- label: COPY A RayExecutorV2 (4 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_USE_RAY_V2_EXECUTOR_BACKEND=1
+  - pytest -v -s distributed/test_ray_v2_executor.py
+  - pytest -v -s distributed/test_ray_v2_executor_e2e.py
+  - pytest -v -s distributed/test_pipeline_parallel.py -k "ray"
+  - TARGET_TEST_SUITE=L4 pytest -v -s basic_correctness/test_basic_correctness.py -k "ray"
+
+- label: COPY A Distributed Tests (8xH100-8xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_8
+  num_gpus: 8
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - torchrun --nproc-per-node=8 ../examples/features/torchrun/torchrun_dp_example_offline.py --tp-size=2 --pp-size=1 --dp-size=4 --enable-ep
+
+#--------------------------------------------------------  mi325 · entrypoints  --------------------------------------------------------#
+
+- label: COPY A Entrypoints Unit Tests # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  fast_check: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s entrypoints/unit_tests
+  - pytest -v -s entrypoints/weight_transfer
+
+- label: COPY A Entrypoints Integration (LLM) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  fast_check: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s entrypoints/llm --ignore=entrypoints/llm/test_generate.py --ignore=entrypoints/llm/test_collective_rpc.py --ignore=entrypoints/llm/offline_mode
+  - pytest -v -s entrypoints/llm/test_generate.py # it needs a clean process
+  - pytest -v -s entrypoints/llm/offline_mode # Needs to avoid interference with other tests
+
+- label: COPY A Entrypoints Integration (API Server) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  fast_check: true
+  working_dir: "/vllm-workspace/tests"
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s entrypoints/serve --ignore=entrypoints/serve/dev/rpc
   - PYTHONPATH=/vllm-workspace pytest -v -s entrypoints/serve/dev/rpc
   - pytest -v -s entrypoints/scale_out
 
-- label: Entrypoints Integration (API Server OpenAI - Part 1) # TBD
+- label: COPY A Entrypoints Integration (API Server OpenAI - Part 1) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   fast_check: true
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/entrypoints/openai
-  - tests/entrypoints/test_chat_utils
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
-  - pytest -v -s entrypoints/openai --ignore=entrypoints/openai/completion --ignore=entrypoints/openai/chat_completion --ignore=entrypoints/openai/responses --ignore=entrypoints/openai/correctness
+  - pytest -v -s entrypoints/openai/ --ignore=entrypoints/openai/completion --ignore=entrypoints/openai/chat_completion --ignore=entrypoints/openai/responses --ignore=entrypoints/openai/correctness
 
-- label: Entrypoints Integration (API Server OpenAI - Part 2) # TBD
+- label: COPY A Entrypoints Integration (API Server OpenAI - Part 2) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   fast_check: true
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/entrypoints/openai
-  - tests/entrypoints/test_chat_utils
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s entrypoints/openai/chat_completion
   - pytest -v -s entrypoints/openai/completion --ignore=entrypoints/openai/completion/test_tensorizer_entrypoint.py
 
-- label: Entrypoints Integration (API Server Generate) # TBD
+- label: COPY A Entrypoints Integration (API Server Generate) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   fast_check: true
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/tool_use
-  - tests/entrypoints/tool_parsers
-  - tests/entrypoints/anthropic
-  - tests/entrypoints/generate
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s tool_use
@@ -3155,509 +2227,840 @@ steps:
   - pytest -v -s entrypoints/generate
   - pytest -v -s entrypoints/anthropic
 
-- label: Entrypoints Integration (Speech to Text) # TBD
+- label: COPY A Entrypoints Integration (Responses API) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi355]
-  agent_pool: mi355_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/entrypoints/speech_to_text
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s entrypoints/openai/responses
+
+- label: COPY A Entrypoints Integration (Speech to Text) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  fast_check: true
+  working_dir: "/vllm-workspace/tests"
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s entrypoints/speech_to_text
 
-- label: Entrypoints Integration (Multimodal)
+- label: COPY A Entrypoints Integration (Multimodal)
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi355]
-  agent_pool: mi355_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/entrypoints/multimodal
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s entrypoints/multimodal
 
-- label: Entrypoints Integration (Pooling) # TBD
+- label: COPY A Entrypoints Integration (Pooling) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   fast_check: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/entrypoints/pooling
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s entrypoints/pooling
 
-#-----------------------------------------------------------  mi355 · evals  -----------------------------------------------------------#
-
-- label: GPQA Eval (GPT-OSS) (2xB200-2xMI355) # TBD
+- label: COPY A OpenAI API correctness # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_2
-  num_gpus: 2
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - csrc/
-  - vllm/model_executor/layers/quantization
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/model_executor/layers/fused_moe/
-  - tests/evals/gpt_oss/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
+  commands:
+  - bash ../tools/install_torchcodec_rocm.sh || exit 1
+  - pytest -s entrypoints/openai/correctness/
+
+#-----------------------------------------------------------  mi325 · evals  -----------------------------------------------------------#
+
+- label: COPY A DeepSeek V2-Lite Prefetch Offload Accuracy (H100-MI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  num_gpus: 1
+  working_dir: "/vllm-workspace"
+  commands:
+  - bash .buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_prefetch_offload.sh 0.25 200 8030
+
+- label: COPY A LM Eval Small Models # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-small.txt
+
+- label: COPY A MRCR Eval Small Models # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -s -v evals/mrcr/test_mrcr_correctness.py --config-list-file=evals/mrcr/configs/models-small.txt
+
+- label: COPY A LM Eval Small Models (MI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
+  commands:
+  - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-small-rocm.txt
+
+- label: COPY A Multi-Modal Accuracy Eval (Small Models) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
+  commands:
+  - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-mm-small.txt --tp-size=1
+
+- label: COPY A GPQA Eval (GPT-OSS) (2xH100-2xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
   commands:
     - uv pip install --system 'gpt-oss[eval]==0.0.5'
-    - pytest -s -v evals/gpt_oss/test_gpqa_correctness.py --config-list-file=configs/models-gfx950.txt
+    - pytest -s -v evals/gpt_oss/test_gpqa_correctness.py --config-list-file=configs/models-gfx942.txt
 
-- label: LM Eval Qwen3-5 Models (B200-MI355) # TBD
+- label: COPY A LM Eval Small Models (2xB200-2xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
-  optional: true
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/model_executor/models/qwen3_5.py
-  - vllm/model_executor/models/qwen3_5_mtp.py
-  - vllm/transformers_utils/configs/qwen3_5.py
-  - vllm/transformers_utils/configs/qwen3_5_moe.py
-  - vllm/model_executor/models/qwen2.py
-  - vllm/model_executor/models/qwen3.py
-  - vllm/model_executor/models/qwen3_next.py
-  - vllm/model_executor/models/qwen3_next_mtp.py
-  - vllm/third_party/flash_linear_attention/ops/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
-  commands:
-  - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-qwen35-mi355.txt
-
-- label: LM Eval Small Models (2xB200-2xMI355) # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_2
-  num_gpus: 2
-  optional: true
-  working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - csrc/
-  - vllm/model_executor/layers/quantization
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
   commands:
   - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-mi3xx-fp8-and-mixed.txt
 
-- label: Qwen3-30B-A3B-FP8-block Sync EPLB Accuracy (B200-MI355) # TBD
+- label: COPY A DeepSeek V2-Lite Sync EPLB Accuracy (4xH100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_2
-  num_gpus: 2
-  working_dir: "/vllm-workspace"
-  source_file_dependencies:
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/model_executor/layers/quantization/
-  - vllm/model_executor/layers/fused_moe/
-  - vllm/distributed/eplb
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - .buildkite/scripts/scheduled_integration_test/
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
-  commands:
-  - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_block_ep_eplb.sh 0.8 200 8020 2 1
-
-- label: LM Eval Large Models (4xH100-4xMI355) # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_4
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
   num_gpus: 4
-  optional: true
-  working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
-  source_file_dependencies:
-  - csrc/
-  - vllm/model_executor/layers/quantization
-  - vllm/model_executor/models/
-  - vllm/model_executor/model_loader/
-  - vllm/v1/attention/backends/
-  - vllm/v1/attention/selector.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
+  working_dir: "/vllm-workspace"
   commands:
-  - export VLLM_USE_DEEP_GEMM=0
-  - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large-rocm-fp8.txt --tp-size=4
+  - bash .buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_ep_eplb.sh 0.25 200 8010
 
-#---------------------------------------------------------  mi355 · examples  ----------------------------------------------------------#
-
-- label: Examples # TBD
+- label: COPY A LM Eval Large Models (4xA100-4xMI325) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
-  working_dir: "/vllm-workspace/examples"
-  source_file_dependencies:
-  - vllm/entrypoints
-  - vllm/multimodal
-  - examples/
-  - vllm/platforms/rocm.py
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
   commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large.txt --tp-size=4
+
+- label: COPY A Qwen3-30B-A3B-FP8-block Sync EPLB Accuracy (4xH100-4xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace"
+  commands:
+  - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_block_ep_eplb.sh 0.8 200 8020
+
+- label: COPY A Qwen3-30B-A3B-FP8 DP4 Async EPLB Accuracy (4xH100-4xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace"
+  commands:
+  - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_dp4_async_eplb.sh 0.8 200 8050
+
+- label: COPY A Qwen3-Next-80B-A3B-Instruct MTP Async EPLB Accuracy # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace"
+  commands:
+  - bash .buildkite/scripts/scheduled_integration_test/qwen3_next_mtp_async_eplb.sh 0.8 1319 8040
+
+- label: COPY A LM Eval Large Models (8xH200-8xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_8
+  num_gpus: 8
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-mi3xx.txt
+
+- label: COPY A ROCm LM Eval Large Models (8 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_8
+  num_gpus: 8
+  working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large-rocm.txt --tp-size=8
+
+#---------------------------------------------------------  mi325 · examples  ----------------------------------------------------------#
+
+- label: COPY A Examples # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/examples"
+  commands:
+    - pip install tensorizer
+    # Basic
+    - python3 basic/offline_inference/chat.py
+    - python3 basic/offline_inference/generate.py --model facebook/opt-125m
+    - python3 basic/offline_inference/generate.py --model meta-llama/Llama-2-13b-chat-hf --cpu-offload-gb 10
+    - python3 basic/offline_inference/classify.py
+    - python3 basic/offline_inference/embed.py
+    - python3 basic/offline_inference/score.py
+    # Multi-modal models
+    - python3 generate/multimodal/audio_language_offline.py --seed 0
+    - python3 generate/multimodal/vision_language_offline.py --seed 0
+    - python3 generate/multimodal/vision_language_multi_image_offline.py --seed 0
+    - python3 generate/multimodal/encoder_decoder_multimodal_offline.py --model-type whisper --seed 0
+    # Pooling models
+    - python3 pooling/embed/vision_embedding_offline.py --seed 0
+    # Features demo
+    - python3 features/automatic_prefix_caching/prefix_caching_offline.py
+    - python3 deployment/llm_engine_example.py
+    - python3 features/tensorize_vllm_model.py --model facebook/opt-125m serialize --serialized-directory /tmp/ --suffix v1 && python3 features/tensorize_vllm_model.py --model facebook/opt-125m deserialize --path-to-tensors /tmp/vllm/facebook/opt-125m/v1/model.tensors
+    - python3 features/speculative_decoding/spec_decode_offline.py --test --method eagle --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 2048
+    - python3 features/speculative_decoding/spec_decode_offline.py --test --method eagle3 --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 1536
+
+#----------------------------------------------------------  mi325 · kernels  ----------------------------------------------------------#
+
+- label: COPY A vLLM IR Tests # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/"
+  commands:
+  - pytest -v -s tests/ir
+  - pytest -v -s tests/kernels/ir
+
+- label: COPY A Kernels Attention Test %N # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  parallelism: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s kernels/attention --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
+
+- label: COPY A Kernels Core Operation Test # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s kernels/core --ignore=kernels/core/test_minimax_reduce_rms.py  kernels/test_concat_mla_q.py kernels/test_top_k_per_row.py
+
+- label: COPY A Kernels KDA Test # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s kernels/test_kda.py
+
+- label: COPY A Kernels MoE Test %N # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  parallelism: 5
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s kernels/moe --ignore=kernels/moe/test_modular_oai_triton_moe.py --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
+  - pytest -v -s kernels/moe/test_modular_oai_triton_moe.py --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
+
+- label: COPY A Kernels Quantization Test %N # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  parallelism: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s kernels/quantization --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
+
+- label: COPY A Kernels FP8 MoE Test (2xH100-2xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+    - pytest -v -s kernels/moe/test_deepep_moe.py
+
+#-----------------------------------------------------------  mi325 · lora  ------------------------------------------------------------#
+
+- label: COPY A LoRA %N # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  parallelism: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s lora --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --ignore=lora/test_chatglm3_tp.py --ignore=lora/test_llama_tp.py --ignore=lora/test_qwen3_with_multi_loras.py --ignore=lora/test_olmoe_tp.py --ignore=lora/test_deepseekv2_tp.py --ignore=lora/test_gptoss_tp.py --ignore=lora/test_qwen3moe_tp.py --ignore=lora/test_qwen35_densemodel_lora.py
+
+- label: COPY A LoRA TP (Distributed) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s -x lora/test_chatglm3_tp.py
+  - pytest -v -s -x lora/test_llama_tp.py
+  - pytest -v -s -x lora/test_qwen3_with_multi_loras.py
+  - pytest -v -s -x lora/test_olmoe_tp.py
+  - pytest -v -s -x lora/test_gptoss_tp.py
+  - pytest -v -s -x lora/test_qwen35_densemodel_lora.py
+
+#------------------------------------------------------  mi325 · model_executor  -------------------------------------------------------#
+
+- label: COPY A Model Executor # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - apt-get update && apt-get install -y curl libsodium23
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s model_executor -m '(not slow_test)'
+  - pytest -v -s entrypoints/openai/completion/test_tensorizer_entrypoint.py
+
+#----------------------------------------------------  mi325 · model_runner_v2  -------------------------------------------------------#
+
+- label: COPY A Model Runner V2 Core Tests # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - set -x
+  - export VLLM_USE_V2_MODEL_RUNNER=1
+  - pytest -v -s v1/engine/test_llm_engine.py -k "not test_engine_metrics"
+  - ENFORCE_EAGER=1 pytest -v -s v1/e2e/general/test_async_scheduling.py -k "not ngram"
+  - pytest -v -s v1/e2e/general/test_context_length.py
+  - pytest -v -s v1/e2e/general/test_min_tokens.py
+  - pytest -v -s entrypoints/llm/test_struct_output_generate.py -k "xgrammar and not speculative_config6 and not speculative_config7 and not speculative_config8 and not speculative_config0"
+
+- label: COPY A Model Runner V2 Examples # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/examples"
+  commands:
+  - set -x
+  - export VLLM_USE_V2_MODEL_RUNNER=1
   - pip install tensorizer
-  # Basic
   - python3 basic/offline_inference/chat.py
   - python3 basic/offline_inference/generate.py --model facebook/opt-125m
-  - python3 basic/offline_inference/generate.py --model meta-llama/Llama-2-13b-chat-hf --cpu-offload-gb 10
-  - python3 basic/offline_inference/classify.py
-  - python3 basic/offline_inference/embed.py
-  - python3 basic/offline_inference/score.py
-  # Multi-modal models
   - python3 generate/multimodal/audio_language_offline.py --seed 0
   - python3 generate/multimodal/vision_language_offline.py --seed 0
   - python3 generate/multimodal/vision_language_multi_image_offline.py --seed 0
   - python3 generate/multimodal/encoder_decoder_multimodal_offline.py --model-type whisper --seed 0
-  # Pooling models
   - python3 pooling/embed/vision_embedding_offline.py --seed 0
-  # Features demo
   - python3 features/automatic_prefix_caching/prefix_caching_offline.py
   - python3 deployment/llm_engine_example.py
   - python3 features/tensorize_vllm_model.py --model facebook/opt-125m serialize --serialized-directory /tmp/ --suffix v1 && python3 features/tensorize_vllm_model.py --model facebook/opt-125m deserialize --path-to-tensors /tmp/vllm/facebook/opt-125m/v1/model.tensors
   - python3 features/speculative_decoding/spec_decode_offline.py --test --method eagle --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 2048
   - python3 features/speculative_decoding/spec_decode_offline.py --test --method eagle3 --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 1536
 
-#----------------------------------------------------------  mi355 · kernels  ----------------------------------------------------------#
-
-- label: Kernels (B200-MI355) # TBD
+- label: COPY A Model Runner V2 Distributed (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
-  working_dir: "/vllm-workspace/"
-  source_file_dependencies:
-  - csrc/quantization/fp4/
-  - csrc/attention/mla/
-  - csrc/quantization/cutlass_w8a8/moe/
-  - vllm/model_executor/layers/fused_moe/cutlass_moe.py
-  - vllm/v1/attention/backends/triton_attn.py
-  - vllm/v1/attention/backends/rocm_attn.py
-  - vllm/v1/attention/backends/rocm_aiter_fa.py
-  - vllm/v1/attention/backends/rocm_aiter_unified_attn.py
-  - vllm/v1/attention/backends/mla/aiter_triton_mla.py
-  - vllm/v1/attention/backends/mla/rocm_aiter_mla.py
-  - vllm/v1/attention/selector.py
-  - vllm/platforms/rocm.py
-  - vllm/_aiter_ops.py
-  commands:
-  - rocm-smi
-  - python3 examples/basic/offline_inference/chat.py --attention-backend TRITON_ATTN
-  - pytest -v -s tests/kernels/attention/test_attention_selector.py
-  - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_decode_metadata.py
-
-- label: Kernels Attention Test %N # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
-  parallelism: 2
-  working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - csrc/attention/
-  - vllm/v1/attention
-  - vllm/model_executor/layers/attention
-  - tests/kernels/attention
-  - vllm/_aiter_ops.py
-  - vllm/envs.py
-  - vllm/platforms/rocm.py
-  commands:
-  - pytest -v -s kernels/attention --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
-
-- label: Kernels MoE Test %N # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
-  parallelism: 5
-  working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - csrc/quantization/cutlass_w8a8/moe/
-  - csrc/moe/
-  - tests/kernels/moe
-  - vllm/model_executor/layers/fused_moe/
-  - vllm/distributed/device_communicators/
-  - vllm/envs.py
-  - vllm/config
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
-  commands:
-  - pytest -v -s kernels/moe --ignore=kernels/moe/test_modular_oai_triton_moe.py --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
-  - pytest -v -s kernels/moe/test_modular_oai_triton_moe.py --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
-
-- label: Kernels Quantization Test %N # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
-  parallelism: 2
-  working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - csrc/quantization/
-  - vllm/model_executor/layers/quantization
-  - tests/kernels/quantization
-  - tests/kernels/quantization/test_rocm_skinny_gemms.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
-  - vllm/model_executor/kernels/
-  commands:
-  - pytest -v -s kernels/quantization --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
-
-- label: Kernels FP8 MoE Test (2xH100-2xMI355) # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - csrc/moe/
-  - csrc/quantization/w8a8/cutlass/moe/
-  - vllm/model_executor/layers/fused_moe/
-  - tests/kernels/moe/test_deepep_moe.py
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
-  - vllm/envs.py
   commands:
-    - pytest -v -s kernels/moe/test_deepep_moe.py
+  - set -x
+  - export VLLM_USE_V2_MODEL_RUNNER=1
+  - TARGET_TEST_SUITE=MI325 pytest -v -s basic_correctness/test_basic_correctness.py -m 'distributed(num_gpus=2)' -k "not ray and not True"
+  - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_async_llm_dp.py -k "not ray"
+  - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_eagle_dp.py
 
-#-----------------------------------------------------  mi355 · models / language  -----------------------------------------------------#
-
-- label: Language Models Test (Extended Generation) # TBD
+- label: COPY A Model Runner V2 Pipeline Parallelism (4 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/language/generation
   commands:
-  - uv pip install --system --no-build-isolation 'git+https://github.com/AndreasKaratzas/mamba@rocm-7.0-v2.3.0'
-  - uv pip install --system --no-build-isolation 'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0'
-  - pytest -v -s models/language/generation -m '(not core_model) and (not hybrid_model)'
+  - set -x
+  - export VLLM_USE_V2_MODEL_RUNNER=1
+  - pytest -v -s distributed/test_pipeline_parallel.py -k "not ray and not Jamba"
+  - pytest -v -s distributed/test_pp_cudagraph.py -k "not ray"
 
-- label: Language Models Test (Extended Pooling) # TBD
+- label: COPY A Model Runner V2 Spec Decode # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/language/pooling
+  commands:
+  - set -x
+  - export VLLM_USE_V2_MODEL_RUNNER=1
+  - pytest -v -s v1/spec_decode/test_max_len.py -k "eagle or mtp"
+  - pytest -v -s v1/spec_decode/test_rejection_sampler_utils.py
+  - pytest -v -s v1/spec_decode/test_synthetic_rejection_sampler_utils.py
+  - pytest -v -s v1/e2e/spec_decode/test_spec_decode.py -k "eagle or mtp"
+
+#------------------------------------------------------  mi325 · models / basic  -------------------------------------------------------#
+
+- label: COPY A Basic Models Tests (Extra Initialization) %N # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  parallelism: 6
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/test_initialization.py -k 'not test_can_initialize_small_subset' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+
+- label: COPY A Basic Models Tests (Initialization) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/test_initialization.py::test_can_initialize_small_subset
+
+- label: COPY A Basic Models Tests (Other) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/test_terratorch.py models/transformers/test_backend.py models/test_registry.py
+
+#-----------------------------------------------------  mi325 · models / language  -----------------------------------------------------#
+
+- label: COPY A Language Models Test (Extended Pooling)  # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
   commands:
   - pytest -v -s models/language/pooling -m 'not core_model'
 
-- label: Language Models Test (PPL) # TBD
+- label: COPY A Language Models Tests (Standard) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/model_executor/models/qwen3_5.py
-  - vllm/model_executor/models/qwen3_5_mtp.py
-  - vllm/transformers_utils/configs/qwen3_5.py
-  - vllm/transformers_utils/configs/qwen3_5_moe.py
-  - vllm/model_executor/models/qwen2.py
-  - vllm/model_executor/models/qwen3.py
-  - vllm/model_executor/models/qwen3_next.py
-  - vllm/model_executor/models/qwen3_next_mtp.py
-  - vllm/third_party/flash_linear_attention/ops/
-  - vllm/_aiter_ops.py
-  - vllm/v1/attention/backends/triton_attn.py
-  - vllm/v1/attention/backends/rocm_attn.py
-  - vllm/v1/attention/backends/rocm_aiter_unified_attn.py
-  - vllm/v1/attention/backends/rocm_aiter_fa.py
-  - vllm/v1/attention/backends/flex_attention.py
-  - vllm/v1/attention/ops/
-  - vllm/platforms/rocm.py
-  - tests/models/language/generation_ppl_test
-  commands:
-  - pytest -v -s models/language/generation_ppl_test
-
-- label: Language Models Tests (Standard) # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
-  working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/language
   commands:
   - pip freeze | grep -E 'torch'
   - pytest -v -s models/language -m 'core_model and (not slow_test)'
 
-#----------------------------------------------------  mi355 · models / multimodal  ----------------------------------------------------#
-
-- label: Multi-Modal Models (Extended Generation 1) # TBD
+- label: COPY A Language Models Tests (Extra Standard) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  parallelism: 2
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/multimodal/generation
-  - tests/models/multimodal/test_mapping.py
+  commands:
+  - pip freeze | grep -E 'torch'
+  - pytest -v -s models/language -m 'core_model and slow_test' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+
+#----------------------------------------------------  mi325 · models / multimodal  ----------------------------------------------------#
+
+- label: COPY A Multi-Modal Models (Extended Generation 1) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
   commands:
   - pytest -v -s models/multimodal/generation -m 'not core_model' --ignore models/multimodal/generation/test_common.py
   - pytest -v -s models/multimodal/test_mapping.py
 
-- label: Multi-Modal Models (Extended Generation 3) # TBD
+- label: COPY A Multi-Modal Models (Extended Generation 2) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/multimodal/generation
+  commands:
+  - pytest -v -s models/multimodal/generation/test_common.py -m 'split(group=0) and not core_model'
+
+
+- label: COPY A Multi-Modal Models (Extended Generation 3) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
   commands:
   - pytest -v -s models/multimodal/generation/test_common.py -m 'split(group=1) and not core_model'
 
-- label: Multi-Modal Models (Extended Pooling) # TBD
+- label: "COPY A Multi-Modal Models (Standard) 1: qwen2" # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/multimodal/pooling
-  commands:
-  - pytest -v -s models/multimodal/pooling -m 'not core_model'
-
-- label: "Multi-Modal Models (Standard) 1: qwen2" # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
-  optional: true
-  working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/multimodal
   commands:
   - pytest -v -s models/multimodal/generation/test_common.py -m core_model -k "qwen2"
   - pytest -v -s models/multimodal/generation/test_ultravox.py -m core_model
 
-- label: "Multi-Modal Models (Standard) 4: other + whisper" # TBD
+- label: "COPY A Multi-Modal Models (Standard) 3: llava + qwen2_vl" # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/multimodal/generation
+  commands:
+  - pytest -v -s models/multimodal/generation/test_common.py -m core_model -k "not qwen2 and not qwen3 and not gemma"
+  - pytest -v -s models/multimodal/generation/test_qwen2_vl.py -m core_model
+
+- label: "COPY A Multi-Modal Models (Standard) 4: other + whisper" # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
   commands:
   - pytest -v -s models/multimodal -m core_model --ignore models/multimodal/generation/test_common.py --ignore models/multimodal/generation/test_ultravox.py --ignore models/multimodal/generation/test_qwen2_5_vl.py --ignore models/multimodal/generation/test_qwen2_vl.py --ignore models/multimodal/generation/test_whisper.py  --ignore models/multimodal/generation/test_memory_leak.py --ignore models/multimodal/processing
   - pytest -v -s models/multimodal/generation/test_memory_leak.py -m core_model
   - cd .. && VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -v -s tests/models/multimodal/generation/test_whisper.py -m core_model
 
-#-----------------------------------------------------  mi355 · models / quantized  -----------------------------------------------------#
-
-- label: Quantized Models Test # TBD
+- label: COPY A Multi-Modal Processor # 1h 42m
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/model_executor/layers/quantization
-  - tests/models/quantization
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
-  - vllm/model_executor/model_loader/
+  commands:
+  - pytest -v -s models/multimodal/processing/test_tensor_schema.py
+
+- label: COPY A Multi-Modal Processor (CPU) %N # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  parallelism: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/multimodal/processing --ignore models/multimodal/processing/test_tensor_schema.py --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+
+#-----------------------------------------------------  mi325 · models / quantized  -----------------------------------------------------#
+
+- label: COPY A Quantized Models Test # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
   commands:
   - pytest -v -s models/quantization
 
-#-------------------------------------------------------  mi355 · quantization  --------------------------------------------------------#
+#--------------------------------------------------  mi325 · models / transformers  ---------------------------------------------------#
 
-- label: Quantization # TBD
+- label: COPY A Transformers Nightly Models (Shardable) %N # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
-  working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - csrc/
-  - vllm/model_executor/layers/quantization
-  - tests/quantization
-  - vllm/_aiter_ops.py
-  - vllm/platforms/rocm.py
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  parallelism: 4
+  working_dir: "/vllm-workspace/"
   commands:
+  - pip install --upgrade git+https://github.com/huggingface/transformers
+  - pytest -v -s tests/models/test_initialization.py --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+  - pytest -v -s tests/models/multimodal/processing/ --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+
+- label: COPY A Transformers Nightly Models (Single) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/"
+  commands:
+  - pip install --upgrade git+https://github.com/huggingface/transformers
+  - pytest -v -s tests/models/transformers/test_backend.py
+  - pytest -v -s tests/models/multimodal/test_mapping.py
+  - python3 examples/basic/offline_inference/chat.py
+  - python3 examples/generate/multimodal/vision_language_offline.py --model-type qwen2_5_vl
+  - VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/generate/multimodal/audio_language_offline.py --model-type whisper
+
+#----------------------------------------------------------  mi325 · plugins  ----------------------------------------------------------#
+
+- label: COPY A Plugin Tests (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  # BEGIN: platform plugin and general plugin tests, all the code in-between runs on dummy platform
+  - pip install -e ./plugins/vllm_add_dummy_platform
+  - pytest -v -s plugins_tests/test_platform_plugins.py
+  - pip uninstall vllm_add_dummy_platform -y
+  # END: platform plugin tests
+  # BEGIN: `io_processor` plugins test, all the code in between uses the `prithvi_io_processor` plugin
+  - pip install -e ./plugins/prithvi_io_processor_plugin
+  - pytest -v -s plugins_tests/test_io_processor_plugins.py
+  - pytest -v -s plugins_tests/test_terratorch_io_processor_plugins.py
+  - pip uninstall prithvi_io_processor_plugin -y
+  # END: `io_processor` plugins test
+  # BEGIN: `bge_m3_sparse io_processor` test
+  - pip install -e ./plugins/bge_m3_sparse_plugin
+  - pytest -v -s plugins_tests/test_bge_m3_sparse_io_processor_plugins.py
+  - pip uninstall bge_m3_sparse_plugin -y
+  # END: `bge_m3_sparse io_processor` test
+  # BEGIN: `colbert_query io_processor` test
+  - pip install -e ./plugins/colbert_query_plugin
+  - pytest -v -s plugins_tests/test_colbert_query_io_processor_plugins.py
+  - pip uninstall colbert_query_plugin -y
+  # END: `colbert_query io_processor` test
+  # BEGIN: `stat_logger` plugins test
+  - pip install -e ./plugins/vllm_add_dummy_stat_logger
+  - pytest -v -s plugins_tests/test_stats_logger_plugins.py
+  - pip uninstall dummy_stat_logger -y
+  # END: `stat_logger` plugins test
+  # BEGIN: `endpoint` plugins test
+  - pip install -e ./plugins/vllm_add_dummy_endpoint_plugin
+  - pytest -v -s plugins_tests/test_endpoint_plugins.py
+  - pip uninstall vllm_add_dummy_endpoint_plugin -y
+  # END: `endpoint` plugins test
+  # BEGIN: other tests
+  - pytest -v -s plugins_tests/test_scheduler_plugins.py
+  - pip install -e ./plugins/vllm_add_dummy_model
+  - pytest -v -s distributed/test_distributed_oot.py
+  - pytest -v -s plugins_tests/test_oot_registration_online.py # it needs a clean process
+  - pytest -v -s plugins_tests/test_oot_registration_offline.py # it needs a clean process
+  - pytest -v -s plugins_tests/lora_resolvers # unit tests for in-tree lora resolver plugins
+
+- label: COPY A GGUF Plugin # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  soft_fail: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pip install "vllm-gguf-plugin >= 0.0.2"
+  - pytest -v -s plugins_tests/gguf
+
+#-------------------------------------------------------  mi325 · rust_frontend  -------------------------------------------------------#
+
+- label: COPY A Rust Frontend OpenAI Coverage # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_USE_RUST_FRONTEND=1
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s benchmarks/test_serve_cli.py -k "not insecure and not (test_bench_serve and not test_bench_serve_chat)"
+  - pytest -v -s entrypoints/openai/chat_completion/test_chat_completion.py -k "not test_invalid_json_schema and not test_invalid_regex"
+  - pytest -v -s entrypoints/openai/chat_completion/test_chat_logit_bias_validation.py -k "not multiple"
+  - pytest -v -s entrypoints/openai/completion/test_shutdown.py -k "not engine_failure and not test_abort_timeout_exits_quickly"
+  - pytest -v -s entrypoints/openai/test_return_token_ids.py -k "not test_comparison"
+  - pytest -v -s entrypoints/openai/test_uds.py
+  - pytest -v -s v1/sample/test_logprobs_e2e.py -k "test_prompt_logprobs_e2e_server"
+
+- label: COPY A Rust Frontend Serve Admin Coverage # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_USE_RUST_FRONTEND=1
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - PYTHONPATH=/vllm-workspace pytest -v -s entrypoints/serve/dev/rpc/test_collective_rpc.py
+  - pytest -v -s entrypoints/serve/instrumentator/test_basic.py -k "not show_version and not server_load"
+  - pytest -v -s entrypoints/scale_out/token_in_token_out/test_serving_tokens.py -k "not stream and not lora and not test_generate_logprobs and not stop_string_workflow"
+  - pytest -v -s entrypoints/serve/instrumentator/test_metrics.py -k "text and not show and not run_batch and not test_metrics_counts and not test_metrics_exist"
+  - pytest -v -s entrypoints/serve/tokenize/test_tokenization.py -k "not tokenizer_info"
+
+- label: COPY A Rust Frontend Core Correctness # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_USE_RUST_FRONTEND=1
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -s entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine
+
+- label: COPY A Rust Frontend Tool Use # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_USE_RUST_FRONTEND=1
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s tool_use --ignore=tool_use/mistral --models llama3.2 -k "not test_response_format_with_tool_choice_required and not test_parallel_tool_calls_false and not test_tool_call_and_choice"
+
+- label: COPY A Rust Frontend Distributed # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_USE_RUST_FRONTEND=1
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - TP_SIZE=1 DP_SIZE=4 pytest -v -s v1/distributed/test_internal_lb_dp.py -k "not 4 and not server_info"
+  - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_external_lb_dp.py -k "not 4 and not server_info"
+  - TP_SIZE=1 DP_SIZE=4 pytest -v -s v1/distributed/test_hybrid_lb_dp.py -k "not 4 and not server_info"
+
+#-------------------------------------------------------  mi325 · quantization  --------------------------------------------------------#
+
+- label: COPY A Quantization # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+
+  # temporary install here since we need nightly, will move to requirements/test.in
+  # after torchao 0.12 release, and pin a working version of torchao nightly here
+
+  # since torchao nightly is only compatible with torch nightly currently
+  # https://github.com/pytorch/ao/issues/2919, we'll have to skip new torchao tests for now
+  # we can only upgrade after this is resolved
+  # TODO(jerryzh168): resolve the above comment
   - uv pip install --system torchao==0.17.0
   - uv pip install --system conch-triton-kernels
   - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py
 
-# - label: Quantized MoE Test (B200-MI355) # TBD
-#   timeout_in_minutes: 180
-#   mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-#   agent_pool: mi355_1
-#   working_dir: "/vllm-workspace/"
-#   source_file_dependencies:
-#   - tests/quantization/test_gfx950_moe.py
-#   - vllm/model_executor/models/deepseek_v2.py
-#   - vllm/model_executor/models/gpt_oss.py
-#   - vllm/model_executor/models/llama4.py
-#   - vllm/model_executor/layers/fused_moe
-#   - vllm/model_executor/layers/quantization/compressed_tensors
-#   - vllm/model_executor/layers/quantization/modelopt.py
-#   - vllm/model_executor/layers/quantization/mxfp4.py
-#   - vllm/v1/attention/backends/triton_attn.py
-#   - vllm/v1/attention/backends/rocm_attn.py
-#   - vllm/v1/attention/backends/rocm_aiter_fa.py
-#   - vllm/v1/attention/backends/mla/
-#   - vllm/v1/attention/selector.py
-#   - vllm/model_executor/layers/layernorm.py
-#   - vllm/_aiter_ops.py
-#   - vllm/platforms/rocm.py
-#   - vllm/model_executor/model_loader/
-#   commands:
-#   - pytest -s -v tests/quantization/test_gfx950_moe.py
+#-----------------------------------------------------------  mi325 · rocm  ------------------------------------------------------------#
 
-#------------------------------------------------------------  mi355 · v1  -------------------------------------------------------------#
-
-- label: V1 attention (B200-MI355) # TBD
+- label: COPY A ROCm AITER Ops Test # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/config/attention.py
-  - vllm/model_executor/layers/attention
-  - vllm/v1/attention
-  - tests/v1/attention
-  - vllm/_aiter_ops.py
-  - vllm/envs.py
-  - vllm/platforms/rocm.py
+  commands:
+  - pytest -v -s rocm/aiter/
+
+#---------------------------------------------------------  mi325 · samplers  ----------------------------------------------------------#
+
+- label: COPY A Samplers Test # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s samplers
+
+#------------------------------------------------------------  mi325 · misc  ------------------------------------------------------------#
+
+- label: COPY A Regression # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pip install 'modelscope<1.38'
+  - pytest -v -s test_regression.py
+
+#---------------------------------------------------------  mi325 · ray_compat  ---------------------------------------------------------#
+
+- label: COPY A Ray Dependency Compatibility Check # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/"
+  commands:
+  - bash /vllm-workspace/.buildkite/scripts/check-ray-compatibility.sh
+
+#------------------------------------------------------------  mi325 · v1  -------------------------------------------------------------#
+
+- label: COPY A Acceptance Length Test (Large Models) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_ALLOW_INSECURE_SERIALIZATION=1
+  - pytest -v -s v1/spec_decode/test_acceptance_length.py -m slow_test
+
+- label: COPY A e2e Scheduling (1 GPU) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s v1/e2e/general/test_async_scheduling.py
+
+- label: COPY A Engine (1 GPU) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s v1/engine/test_preprocess_error_handling.py
+  - pytest -v -s v1/engine --ignore v1/engine/test_preprocess_error_handling.py
+
+- label: COPY A Spec Decode Draft Model # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s v1/e2e/spec_decode -k "draft_model or no_sync or batch_inference"
+
+- label: COPY A Spec Decode Eagle # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s v1/e2e/spec_decode -k "eagle_correctness"
+
+- label: COPY A Spec Decode Ngram + Suffix # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s v1/e2e/spec_decode -k "ngram or suffix"
+
+- label: COPY A Spec Decode Speculators + MTP # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s v1/e2e/spec_decode -k "speculators or mtp_correctness"
+
+- label: COPY A Speculators Correctness # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_ALLOW_INSECURE_SERIALIZATION=1
+  - pytest -v -s v1/spec_decode/test_speculators_correctness.py -m slow_test
+
+- label: COPY A V1 Spec Decode # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s -m 'not slow_test' v1/spec_decode
+
+- label: COPY A Extract Hidden States Integration # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s v1/kv_connector/extract_hidden_states_integration
+
+- label: COPY A V1 attention (H100-MI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
   commands:
   - pytest -v -s v1/attention
 
-- label: V1 Core + KV + Metrics # TBD
+- label: COPY A V1 Core + KV + Metrics # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/v1/core
-  - tests/v1/executor
-  - tests/v1/kv_offload
-  - tests/v1/worker
-  - tests/v1/kv_connector/unit
-  - tests/v1/metrics
-  - tests/entrypoints/openai/correctness/test_lmeval.py
   commands:
   - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
   - pytest -v -s -m 'not cpu_test' v1/core
@@ -3667,21 +3070,26 @@ steps:
   - pytest -v -s -m 'not cpu_test' v1/kv_connector/unit
   - pytest -v -s -m 'not cpu_test' v1/metrics
   - pip install -U git+https://github.com/vllm-project/lm-evaluation-harness.git@streaming-api
+  # - export HSA_NO_SCRATCH_RECLAIM=1
   - pytest -v -s entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine
 
-- label: V1 Sample + Logits # TBD
+- label: COPY A V1 others (CPU) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/v1/sample
-  - tests/v1/logits_processors
-  - tests/v1/test_oracle.py
-  - tests/v1/test_request.py
-  - tests/v1/test_outputs.py
+  commands:
+  - pytest -v -s -m 'cpu_test' v1/core
+  - pytest -v -s v1/structured_output
+  - pytest -v -s v1/test_serial_utils.py
+  - pytest -v -s -m 'cpu_test' v1/kv_connector/unit
+  - pytest -v -s -m 'cpu_test' v1/metrics
+
+- label: COPY A V1 Sample + Logits # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
   commands:
   - pytest -v -s v1/sample
   - pytest -v -s v1/logits_processors
@@ -3689,55 +3097,1879 @@ steps:
   - pytest -v -s v1/test_request.py
   - pytest -v -s v1/test_outputs.py
 
-- label: V1 Spec Decode # TBD
+- label: COPY A Distributed DP Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
-  working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/v1/spec_decode
-  commands:
-  - pytest -v -s -m 'not slow_test' v1/spec_decode
-
-#------------------------------------------------------  mi355 · weight_loading  -------------------------------------------------------#
-
-- label: Weight Loading Multiple GPU # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_2
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/weight_loading
+  commands:
+  - export NCCL_CUMEM_HOST_ENABLE=0
+  - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_async_llm_dp.py
+  - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_eagle_dp.py
+  - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_external_lb_dp.py
+  - DP_SIZE=2 pytest -v -s entrypoints/openai/test_multi_api_servers.py
+
+- label: COPY A Metrics, Tracing (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - "pip install \
+      'opentelemetry-sdk>=1.26.0' \
+      'opentelemetry-api>=1.26.0' \
+      'opentelemetry-exporter-otlp>=1.26.0' \
+      'opentelemetry-semantic-conventions-ai>=0.4.1'"
+  - pytest -v -s v1/tracing
+
+- label: COPY A V1 e2e (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+    - pytest -v -s v1/e2e/spec_decode/test_spec_decode.py -k "tensor_parallelism"
+
+- label: COPY A NixlConnector PD + Spec Decode acceptance (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
+  - KV_CACHE_MEMORY_BYTES=8G ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/config_sweep_spec_decode_test.sh
+
+- label: COPY A CrossLayer KV layout Distributed NixlConnector PD accuracy tests (4 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
+  - CROSS_LAYERS_BLOCKS=True ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+
+- label: COPY A Distributed DP Tests (4 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export NCCL_CUMEM_HOST_ENABLE=0
+  - TP_SIZE=2 DP_SIZE=2 pytest -v -s v1/distributed/test_async_llm_dp.py
+  - TP_SIZE=2 DP_SIZE=2 pytest -v -s v1/distributed/test_eagle_dp.py
+  - TP_SIZE=2 DP_SIZE=2 pytest -v -s v1/distributed/test_external_lb_dp.py
+  - TP_SIZE=1 DP_SIZE=4 pytest -v -s v1/distributed/test_internal_lb_dp.py
+  - TP_SIZE=1 DP_SIZE=4 pytest -v -s v1/distributed/test_hybrid_lb_dp.py
+  - pytest -v -s v1/engine/test_engine_core_client.py::test_kv_cache_events_dp
+  - pytest -v -s distributed/test_utils.py
+
+- label: COPY A Distributed NixlConnector PD accuracy (4 GPUs)  # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
+  - ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+
+- label: COPY A DP EP Distributed NixlConnector PD accuracy tests (4 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
+  - DP_EP=1 ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+
+- label: COPY A Hybrid SSM NixlConnector PD accuracy tests (4 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
+  - HYBRID_SSM=1 ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+
+- label: COPY A Hybrid SSM NixlConnector PD prefix cache test (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
+  - ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/run_mamba_prefix_cache_test.sh
+
+- label: COPY A MultiConnector (Nixl+Offloading) PD accuracy (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
+  - ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/run_multi_connector_accuracy_test.sh
+
+- label: COPY A MultiConnector (Nixl+Offloading) PD edge cases (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
+  - ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/run_multi_connector_edge_case_test.sh
+
+- label: COPY A V1 e2e (4 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+    - pytest -v -s v1/e2e/spec_decode/test_spec_decode.py -k "eagle_correctness_heavy"
+
+- label: COPY A V1 e2e (4xH100-4xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  commands:
+    - pytest -v -s v1/e2e/test_hybrid_chunked_prefill.py
+
+#------------------------------------------------------  mi325 · weight_loading  -------------------------------------------------------#
+
+- label: COPY A Weight Loading Multiple GPU # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
   commands:
   - bash weight_loading/run_model_weight_loading_test.sh -c weight_loading/models-amd.txt
 
-- label: Weight Loading Multiple GPU - Large Models # TBD
+- label: COPY A Weight Loading Multiple GPU - Large Models # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_2
-  working_dir: "/vllm-workspace/tests"
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
   num_gpus: 2
-  optional: true
-  source_file_dependencies:
-  - vllm/
-  - tests/weight_loading
+  working_dir: "/vllm-workspace/tests"
   commands:
   - bash weight_loading/run_model_weight_loading_test.sh -c weight_loading/models-large-amd.txt
 
-#-----------------------------------------------------------  mi355 · misc  ------------------------------------------------------------#
+#########################################################################################################################################
+#                                                                                                                                       #
+#                                                         MI325 (gfx942) tests                                                          #
+#                                                                                                                                       #
+#########################################################################################################################################
 
-- label: Regression # TBD
+#----------------------------------------------------------  mi325 · compile  ----------------------------------------------------------#
+
+- label: COPY A Distributed Compile + RPC Tests (2 GPUs) # TBD
   timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
-  agent_pool: mi355_1
-  optional: true
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
   working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/test_regression
+  commands:
+  - pytest -v -s entrypoints/llm/test_collective_rpc.py
+  - pytest -v -s ./compile/fullgraph/test_basic_correctness.py
+  - pytest -v -s ./compile/test_wrapper.py
+
+#--------------------------------------------------------  mi325 · distributed  --------------------------------------------------------#
+
+- label: COPY A Distributed Torchrun + Shutdown Tests (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - VLLM_TEST_SAME_HOST=1 torchrun --nproc-per-node=4 distributed/test_same_node.py | grep 'Same node test passed'
+  - VLLM_TEST_SAME_HOST=1 VLLM_TEST_WITH_DEFAULT_DEVICE_SET=1 torchrun --nproc-per-node=4 distributed/test_same_node.py | grep 'Same node test passed'
+  - CUDA_VISIBLE_DEVICES=0,1 pytest -v -s v1/shutdown
+  - pytest -v -s v1/worker/test_worker_memory_snapshot.py
+
+- label: COPY A Distributed Compile + Comm (4 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s compile/fullgraph/test_basic_correctness.py
+  - pytest -v -s distributed/test_pynccl.py
+  - pytest -v -s distributed/test_events.py
+  - pytest -v -s distributed/test_symm_mem_allreduce.py
+  - pytest -v -s distributed/test_multiproc_executor.py::test_multiproc_executor_multi_node
+
+#----------------------------------------------------------  mi325 · engine  -----------------------------------------------------------#
+
+- label: COPY A Engine # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s engine test_sequence.py test_config.py test_logger.py test_vllm_port.py test_jit_monitor.py
+
+#-----------------------------------------------------------  mi325 · evals  -----------------------------------------------------------#
+
+- label: COPY A LM Eval Large Models (4xH100-4xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
+  commands:
+  - export VLLM_USE_DEEP_GEMM=0
+  - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large-rocm-fp8.txt --tp-size=4
+
+#-----------------------------------------------------  mi325 · models / language  -----------------------------------------------------#
+
+- label: COPY A Language Models Test (Extended Generation) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system --no-build-isolation 'git+https://github.com/AndreasKaratzas/mamba@fix-rocm-7.0-warp-size-constexpr'
+  - uv pip install --system --no-build-isolation 'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0'
+  - pytest -v -s models/language/generation -m '(not core_model) and (not hybrid_model)'
+
+- label: COPY A Language Models Tests (Hybrid) %N # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  parallelism: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system --no-build-isolation 'git+https://github.com/AndreasKaratzas/mamba@fix-rocm-7.0-warp-size-constexpr'
+  - uv pip install --system --no-build-isolation 'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0'
+  - pytest -v -s models/language/generation -m hybrid_model --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+
+#----------------------------------------------------  mi325 · models / multimodal  ----------------------------------------------------#
+
+- label: COPY A Multi-Modal Models (Extended Pooling) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/multimodal/pooling -m 'not core_model'
+
+- label: "COPY A Multi-Modal Models (Standard) 2: qwen3 + gemma" # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/multimodal/generation/test_common.py -m core_model -k "qwen3 or gemma"
+  - pytest -v -s models/multimodal/generation/test_qwen2_5_vl.py -m core_model
+
+#-----------------------------------------------------------  mi325 · misc  ------------------------------------------------------------#
+
+- label: COPY A Python-only Installation # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - bash standalone_tests/python_only_compile.sh
+
+#########################################################################################################################################
+#                                                                                                                                       #
+#                                                                COPY B                                                                 #
+#                                                                                                                                       #
+#########################################################################################################################################
+
+
+#########################################################################################################################################
+#                                                                                                                                       #
+#                                                         MI325 (gfx942) tests                                                          #
+#                                                                                                                                       #
+#########################################################################################################################################
+
+#----------------------------------------------------------  mi325 · compile  ----------------------------------------------------------#
+
+- label: COPY B PyTorch Fullgraph Smoke Test # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - "find compile/fullgraph/ -name 'test_*.py' -not -name 'test_full_graph.py' -exec pytest -s -v {} \\\\;"
+
+#--------------------------------------------------------  mi325 · distributed  --------------------------------------------------------#
+
+- label: COPY B Pipeline + Context Parallelism (4 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s distributed/test_pp_cudagraph.py
+  - pytest -v -s distributed/test_pipeline_parallel.py
+
+#----------------------------------------------------------  mi325 · kernels  ----------------------------------------------------------#
+
+- label: COPY B Kernels Helion Test # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pip install helion==1.1.0
+  - pytest -v -s kernels/helion/
+
+- label: COPY B Kernels Mamba Test # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s kernels/mamba
+
+#-----------------------------------------------------  mi325 · models / language  -----------------------------------------------------#
+
+- label: COPY B Language Models Test (MTEB) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/language/pooling_mteb_test
+
+- label: COPY B Language Models Test (PPL) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/language/generation_ppl_test
+
+#------------------------------------------------------------  mi325 · v1  -------------------------------------------------------------#
+
+- label: COPY B Batch Invariance (H100-MI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pip install pytest-timeout pytest-forked
+  - pytest -v -s v1/determinism/test_batch_invariance.py
+  - pytest -v -s v1/determinism/test_rms_norm_batch_invariant.py
+
+- label: COPY B Cudagraph # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s v1/cudagraph/test_cudagraph_dispatch.py
+  - pytest -v -s v1/cudagraph/test_cudagraph_mode.py
+
+- label: COPY B e2e Core (1 GPU) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s v1/e2e/general --ignore v1/e2e/general/test_async_scheduling.py
+
+#-----------------------------------------------------------  mi325 · docker  ----------------------------------------------------------#
+
+- label: COPY B Docker Build Metadata (ROCm) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  no_gpu: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s tools/test_docker_build_metadata_args.py
+
+#########################################################################################################################################
+#                                                                                                                                       #
+#                                                         MI325 (gfx942) tests                                                          #
+#                                                                                                                                       #
+#########################################################################################################################################
+
+#-----------------------------------------------------  mi325 · basic_correctness  -----------------------------------------------------#
+
+- label: COPY B Basic Correctness # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  fast_check: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s basic_correctness/test_mem.py
+  - VLLM_TARGET_TEST_SUITE=MI325 pytest -v -s basic_correctness/test_basic_correctness.py
+  - pytest -v -s basic_correctness/test_cpu_offload.py
+
+- label: COPY B Distributed Model Tests (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - TARGET_TEST_SUITE=MI325 pytest basic_correctness/ -v -s -m 'distributed(num_gpus=2)'
+  - CUDA_VISIBLE_DEVICES=0,1 pytest -v -s model_executor/model_loader/test_sharded_state_loader.py -m '(not slow_test)'
+  - pytest models/transformers/test_backend.py -v -s -m 'distributed(num_gpus=2)'
+  - pytest models/language -v -s -m 'distributed(num_gpus=2)'
+  - pytest models/multimodal -v -s -m 'distributed(num_gpus=2)' --ignore models/multimodal/generation/test_whisper.py --ignore models/multimodal/generation/test_phi4siglip.py
+  - pytest models/multimodal/generation/test_phi4siglip.py -v -s -m 'distributed(num_gpus=2)'
+  - VLLM_WORKER_MULTIPROC_METHOD=spawn pytest models/multimodal/generation/test_whisper.py -v -s -m 'distributed(num_gpus=2)'
+
+#--------------------------------------------------------  mi325 · benchmarks  ---------------------------------------------------------#
+
+- label: COPY B Benchmarks CLI Test # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s benchmarks/
+
+#----------------------------------------------------------  mi325 · compile  ----------------------------------------------------------#
+
+- label: COPY B PyTorch Compilation Unit Tests # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - "find compile/ -maxdepth 1 -name 'test_*.py' -print0 | xargs -0 -n1 -I{} pytest -s -v '{}'"
+
+- label: COPY B Fusion E2E Config Sweep (H100-MI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  num_gpus: 1
+  working_dir: "/vllm-workspace/"
+  commands:
+  - rocm-smi
+  - pytest -v -s tests/compile/fusions_e2e/test_tp1_quant.py -k "llama-3"
+
+- label: COPY B Fusion E2E Quick (H100-MI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  num_gpus: 1
+  working_dir: "/vllm-workspace/"
+  commands:
+  - rocm-smi
+  # Run all models and attn backends but only Inductor partition and native custom ops
+  - "pytest -v -s tests/compile/fusions_e2e/test_tp1_quant.py -k 'inductor_partition and not +rms_norm and not +quant_fp8'"
+  # Different from CUDA, Qwen requires +rms_norm and +quant_fp8 as rms+quant fusion is only supported on AITER
+  - "pytest -v -s tests/compile/fusions_e2e/test_tp1_quant.py -k 'inductor_partition and +rms_norm and +quant_fp8 and qwen3'"
+
+- label: COPY B PyTorch Compilation Passes Unit Tests # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -s -v compile/passes --ignore compile/passes/distributed
+
+- label: COPY B PyTorch Fullgraph # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s compile/fullgraph/test_full_graph.py -k 'not test_fp8_kv_scale_compile'
+
+- label: COPY B Pytorch Nightly Dependency Override Check # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  soft_fail: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - bash standalone_tests/pytorch_nightly_dependency.sh
+
+- label: COPY B Distributed Compile Unit Tests (2xH100-2xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/"
+  commands:
+  - export VLLM_TEST_CLEAN_GPU_MEMORY=1
+  - VLLM_TEST_CLEAN_GPU_MEMORY=1 pytest -v -s tests/compile/passes/distributed/test_async_tp.py
+  - pytest -v -s tests/compile/fusions_e2e/test_tp2_ar_rms.py::test_tp2_ar_rms_fusions
+
+#-----------------------------------------------------------  mi325 · cuda  ------------------------------------------------------------#
+
+- label: COPY B Platform Tests # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s cuda/test_cuda_context.py
+  - pytest -v -s cuda/test_platform_no_cuda_init.py
+
+#--------------------------------------------------------  mi325 · detokenizer  --------------------------------------------------------#
+
+- label: COPY B Async Engine, Inputs, Utils, Worker # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s detokenizer
+  - pytest -v -s -m 'not cpu_test' multimodal
+  - pytest -v -s utils_
+
+#--------------------------------------------------------  mi325 · distributed  --------------------------------------------------------#
+
+- label: COPY B Distributed Comm Ops # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s distributed/test_comm_ops.py
+  - pytest -v -s distributed/test_shm_broadcast.py
+  - pytest -v -s distributed/test_shm_buffer.py
+  - pytest -v -s distributed/test_shm_storage.py
+
+- label: COPY B EPLB Algorithm # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s distributed/test_eplb_algo.py
+  - pytest -v -s distributed/test_eplb_utils.py
+
+- label: COPY B EPLB Execution # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s distributed/test_eplb_execute.py
+  - pytest -v -s distributed/test_eplb_spec_decode.py
+
+- label: COPY B Distributed Tests (2xH100-2xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/"
+  commands:
+  - pytest -v -s tests/distributed/test_context_parallel.py
+  - VLLM_ALLOW_INSECURE_SERIALIZATION=1 python3 examples/rl/rlhf_async_new_apis.py
+  - VLLM_LOGGING_LEVEL=DEBUG python3 examples/features/data_parallel/data_parallel_offline.py --model=Qwen/Qwen1.5-MoE-A2.7B -tp=1 -dp=2 --max-model-len=2048 --all2all-backend=deepep_high_throughput
+  - VLLM_LOGGING_LEVEL=DEBUG python3 examples/features/data_parallel/data_parallel_offline.py --model=Qwen/Qwen1.5-MoE-A2.7B -tp=1 -dp=2 --max-model-len=2048 --all2all-backend=allgather_reducescatter --disable-nccl-for-dp-synchronization
+  - pytest -v -s tests/v1/distributed/test_dbo.py
+  - VLLM_ALLOW_INSECURE_SERIALIZATION=1 pytest -v -s tests/distributed/test_weight_transfer.py
+  - pytest -v -s tests/distributed/test_packed_tensor.py
+
+- label: COPY B Distributed Tests (4xA100-4xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s distributed/test_custom_all_reduce.py
+  - torchrun --nproc_per_node=2 distributed/test_ca_buffer_sharing.py
+  - TARGET_TEST_SUITE=MI325 pytest basic_correctness/ -v -s -m 'distributed(num_gpus=2)'
+  - pytest -v -s -x lora/test_mixtral.py
+
+- label: COPY B Distributed Torchrun + Examples (4 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - torchrun --nproc-per-node=4 distributed/test_torchrun_example.py
+  - PP_SIZE=2 torchrun --nproc-per-node=4 distributed/test_torchrun_example.py
+  - TP_SIZE=4 torchrun --nproc-per-node=4 distributed/test_torchrun_example_moe.py
+  - PP_SIZE=2 TP_SIZE=2 torchrun --nproc-per-node=4 distributed/test_torchrun_example_moe.py
+  - DP_SIZE=4 ENABLE_EP=1 torchrun --nproc-per-node=4 distributed/test_torchrun_example_moe.py
+  - TP_SIZE=2 DP_SIZE=2 ENABLE_EP=1 torchrun --nproc-per-node=4 distributed/test_torchrun_example_moe.py
+  - python3 ../examples/features/data_parallel/data_parallel_offline.py --enforce-eager
+  # rlhf examples
+  - VLLM_ALLOW_INSECURE_SERIALIZATION=1 python3 ../examples/rl/rlhf_nccl.py
+  - VLLM_ALLOW_INSECURE_SERIALIZATION=1 python3 ../examples/rl/rlhf_ipc.py
+
+- label: COPY B Elastic EP Scaling Test # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s distributed/test_elastic_ep.py
+
+- label: COPY B RayExecutorV2 (4 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_USE_RAY_V2_EXECUTOR_BACKEND=1
+  - pytest -v -s distributed/test_ray_v2_executor.py
+  - pytest -v -s distributed/test_ray_v2_executor_e2e.py
+  - pytest -v -s distributed/test_pipeline_parallel.py -k "ray"
+  - TARGET_TEST_SUITE=L4 pytest -v -s basic_correctness/test_basic_correctness.py -k "ray"
+
+- label: COPY B Distributed Tests (8xH100-8xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_8
+  num_gpus: 8
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - torchrun --nproc-per-node=8 ../examples/features/torchrun/torchrun_dp_example_offline.py --tp-size=2 --pp-size=1 --dp-size=4 --enable-ep
+
+#--------------------------------------------------------  mi325 · entrypoints  --------------------------------------------------------#
+
+- label: COPY B Entrypoints Unit Tests # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  fast_check: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s entrypoints/unit_tests
+  - pytest -v -s entrypoints/weight_transfer
+
+- label: COPY B Entrypoints Integration (LLM) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  fast_check: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s entrypoints/llm --ignore=entrypoints/llm/test_generate.py --ignore=entrypoints/llm/test_collective_rpc.py --ignore=entrypoints/llm/offline_mode
+  - pytest -v -s entrypoints/llm/test_generate.py # it needs a clean process
+  - pytest -v -s entrypoints/llm/offline_mode # Needs to avoid interference with other tests
+
+- label: COPY B Entrypoints Integration (API Server) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  fast_check: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s entrypoints/serve --ignore=entrypoints/serve/dev/rpc
+  - PYTHONPATH=/vllm-workspace pytest -v -s entrypoints/serve/dev/rpc
+  - pytest -v -s entrypoints/scale_out
+
+- label: COPY B Entrypoints Integration (API Server OpenAI - Part 1) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  fast_check: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s entrypoints/openai/ --ignore=entrypoints/openai/completion --ignore=entrypoints/openai/chat_completion --ignore=entrypoints/openai/responses --ignore=entrypoints/openai/correctness
+
+- label: COPY B Entrypoints Integration (API Server OpenAI - Part 2) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  fast_check: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s entrypoints/openai/chat_completion
+  - pytest -v -s entrypoints/openai/completion --ignore=entrypoints/openai/completion/test_tensorizer_entrypoint.py
+
+- label: COPY B Entrypoints Integration (API Server Generate) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  fast_check: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s tool_use
+  - pytest -v -s entrypoints/tool_parsers
+  - pytest -v -s entrypoints/generate
+  - pytest -v -s entrypoints/anthropic
+
+- label: COPY B Entrypoints Integration (Responses API) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  fast_check: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s entrypoints/openai/responses
+
+- label: COPY B Entrypoints Integration (Speech to Text) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  fast_check: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s entrypoints/speech_to_text
+
+- label: COPY B Entrypoints Integration (Multimodal)
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  fast_check: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s entrypoints/multimodal
+
+- label: COPY B Entrypoints Integration (Pooling) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  fast_check: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s entrypoints/pooling
+
+- label: COPY B OpenAI API correctness # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - bash ../tools/install_torchcodec_rocm.sh || exit 1
+  - pytest -s entrypoints/openai/correctness/
+
+#-----------------------------------------------------------  mi325 · evals  -----------------------------------------------------------#
+
+- label: COPY B DeepSeek V2-Lite Prefetch Offload Accuracy (H100-MI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  num_gpus: 1
+  working_dir: "/vllm-workspace"
+  commands:
+  - bash .buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_prefetch_offload.sh 0.25 200 8030
+
+- label: COPY B LM Eval Small Models # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-small.txt
+
+- label: COPY B MRCR Eval Small Models # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -s -v evals/mrcr/test_mrcr_correctness.py --config-list-file=evals/mrcr/configs/models-small.txt
+
+- label: COPY B LM Eval Small Models (MI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
+  commands:
+  - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-small-rocm.txt
+
+- label: COPY B Multi-Modal Accuracy Eval (Small Models) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
+  commands:
+  - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-mm-small.txt --tp-size=1
+
+- label: COPY B GPQA Eval (GPT-OSS) (2xH100-2xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+    - uv pip install --system 'gpt-oss[eval]==0.0.5'
+    - pytest -s -v evals/gpt_oss/test_gpqa_correctness.py --config-list-file=configs/models-gfx942.txt
+
+- label: COPY B LM Eval Small Models (2xB200-2xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-mi3xx-fp8-and-mixed.txt
+
+- label: COPY B DeepSeek V2-Lite Sync EPLB Accuracy (4xH100-4xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace"
+  commands:
+  - bash .buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_ep_eplb.sh 0.25 200 8010
+
+- label: COPY B LM Eval Large Models (4xA100-4xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large.txt --tp-size=4
+
+- label: COPY B Qwen3-30B-A3B-FP8-block Sync EPLB Accuracy (4xH100-4xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace"
+  commands:
+  - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_block_ep_eplb.sh 0.8 200 8020
+
+- label: COPY B Qwen3-30B-A3B-FP8 DP4 Async EPLB Accuracy (4xH100-4xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace"
+  commands:
+  - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_dp4_async_eplb.sh 0.8 200 8050
+
+- label: COPY B Qwen3-Next-80B-A3B-Instruct MTP Async EPLB Accuracy # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace"
+  commands:
+  - bash .buildkite/scripts/scheduled_integration_test/qwen3_next_mtp_async_eplb.sh 0.8 1319 8040
+
+- label: COPY B LM Eval Large Models (8xH200-8xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_8
+  num_gpus: 8
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-mi3xx.txt
+
+- label: COPY B ROCm LM Eval Large Models (8 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_8
+  num_gpus: 8
+  working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large-rocm.txt --tp-size=8
+
+#---------------------------------------------------------  mi325 · examples  ----------------------------------------------------------#
+
+- label: COPY B Examples # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/examples"
+  commands:
+    - pip install tensorizer
+    # Basic
+    - python3 basic/offline_inference/chat.py
+    - python3 basic/offline_inference/generate.py --model facebook/opt-125m
+    - python3 basic/offline_inference/generate.py --model meta-llama/Llama-2-13b-chat-hf --cpu-offload-gb 10
+    - python3 basic/offline_inference/classify.py
+    - python3 basic/offline_inference/embed.py
+    - python3 basic/offline_inference/score.py
+    # Multi-modal models
+    - python3 generate/multimodal/audio_language_offline.py --seed 0
+    - python3 generate/multimodal/vision_language_offline.py --seed 0
+    - python3 generate/multimodal/vision_language_multi_image_offline.py --seed 0
+    - python3 generate/multimodal/encoder_decoder_multimodal_offline.py --model-type whisper --seed 0
+    # Pooling models
+    - python3 pooling/embed/vision_embedding_offline.py --seed 0
+    # Features demo
+    - python3 features/automatic_prefix_caching/prefix_caching_offline.py
+    - python3 deployment/llm_engine_example.py
+    - python3 features/tensorize_vllm_model.py --model facebook/opt-125m serialize --serialized-directory /tmp/ --suffix v1 && python3 features/tensorize_vllm_model.py --model facebook/opt-125m deserialize --path-to-tensors /tmp/vllm/facebook/opt-125m/v1/model.tensors
+    - python3 features/speculative_decoding/spec_decode_offline.py --test --method eagle --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 2048
+    - python3 features/speculative_decoding/spec_decode_offline.py --test --method eagle3 --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 1536
+
+#----------------------------------------------------------  mi325 · kernels  ----------------------------------------------------------#
+
+- label: COPY B vLLM IR Tests # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/"
+  commands:
+  - pytest -v -s tests/ir
+  - pytest -v -s tests/kernels/ir
+
+- label: COPY B Kernels Attention Test %N # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  parallelism: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s kernels/attention --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
+
+- label: COPY B Kernels Core Operation Test # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s kernels/core --ignore=kernels/core/test_minimax_reduce_rms.py  kernels/test_concat_mla_q.py kernels/test_top_k_per_row.py
+
+- label: COPY B Kernels KDA Test # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s kernels/test_kda.py
+
+- label: COPY B Kernels MoE Test %N # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  parallelism: 5
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s kernels/moe --ignore=kernels/moe/test_modular_oai_triton_moe.py --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
+  - pytest -v -s kernels/moe/test_modular_oai_triton_moe.py --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
+
+- label: COPY B Kernels Quantization Test %N # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  parallelism: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s kernels/quantization --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
+
+- label: COPY B Kernels FP8 MoE Test (2xH100-2xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+    - pytest -v -s kernels/moe/test_deepep_moe.py
+
+#-----------------------------------------------------------  mi325 · lora  ------------------------------------------------------------#
+
+- label: COPY B LoRA %N # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  parallelism: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s lora --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --ignore=lora/test_chatglm3_tp.py --ignore=lora/test_llama_tp.py --ignore=lora/test_qwen3_with_multi_loras.py --ignore=lora/test_olmoe_tp.py --ignore=lora/test_deepseekv2_tp.py --ignore=lora/test_gptoss_tp.py --ignore=lora/test_qwen3moe_tp.py --ignore=lora/test_qwen35_densemodel_lora.py
+
+- label: COPY B LoRA TP (Distributed) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s -x lora/test_chatglm3_tp.py
+  - pytest -v -s -x lora/test_llama_tp.py
+  - pytest -v -s -x lora/test_qwen3_with_multi_loras.py
+  - pytest -v -s -x lora/test_olmoe_tp.py
+  - pytest -v -s -x lora/test_gptoss_tp.py
+  - pytest -v -s -x lora/test_qwen35_densemodel_lora.py
+
+#------------------------------------------------------  mi325 · model_executor  -------------------------------------------------------#
+
+- label: COPY B Model Executor # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - apt-get update && apt-get install -y curl libsodium23
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s model_executor -m '(not slow_test)'
+  - pytest -v -s entrypoints/openai/completion/test_tensorizer_entrypoint.py
+
+#----------------------------------------------------  mi325 · model_runner_v2  -------------------------------------------------------#
+
+- label: COPY B Model Runner V2 Core Tests # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - set -x
+  - export VLLM_USE_V2_MODEL_RUNNER=1
+  - pytest -v -s v1/engine/test_llm_engine.py -k "not test_engine_metrics"
+  - ENFORCE_EAGER=1 pytest -v -s v1/e2e/general/test_async_scheduling.py -k "not ngram"
+  - pytest -v -s v1/e2e/general/test_context_length.py
+  - pytest -v -s v1/e2e/general/test_min_tokens.py
+  - pytest -v -s entrypoints/llm/test_struct_output_generate.py -k "xgrammar and not speculative_config6 and not speculative_config7 and not speculative_config8 and not speculative_config0"
+
+- label: COPY B Model Runner V2 Examples # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/examples"
+  commands:
+  - set -x
+  - export VLLM_USE_V2_MODEL_RUNNER=1
+  - pip install tensorizer
+  - python3 basic/offline_inference/chat.py
+  - python3 basic/offline_inference/generate.py --model facebook/opt-125m
+  - python3 generate/multimodal/audio_language_offline.py --seed 0
+  - python3 generate/multimodal/vision_language_offline.py --seed 0
+  - python3 generate/multimodal/vision_language_multi_image_offline.py --seed 0
+  - python3 generate/multimodal/encoder_decoder_multimodal_offline.py --model-type whisper --seed 0
+  - python3 pooling/embed/vision_embedding_offline.py --seed 0
+  - python3 features/automatic_prefix_caching/prefix_caching_offline.py
+  - python3 deployment/llm_engine_example.py
+  - python3 features/tensorize_vllm_model.py --model facebook/opt-125m serialize --serialized-directory /tmp/ --suffix v1 && python3 features/tensorize_vllm_model.py --model facebook/opt-125m deserialize --path-to-tensors /tmp/vllm/facebook/opt-125m/v1/model.tensors
+  - python3 features/speculative_decoding/spec_decode_offline.py --test --method eagle --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 2048
+  - python3 features/speculative_decoding/spec_decode_offline.py --test --method eagle3 --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 1536
+
+- label: COPY B Model Runner V2 Distributed (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - set -x
+  - export VLLM_USE_V2_MODEL_RUNNER=1
+  - TARGET_TEST_SUITE=MI325 pytest -v -s basic_correctness/test_basic_correctness.py -m 'distributed(num_gpus=2)' -k "not ray and not True"
+  - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_async_llm_dp.py -k "not ray"
+  - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_eagle_dp.py
+
+- label: COPY B Model Runner V2 Pipeline Parallelism (4 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - set -x
+  - export VLLM_USE_V2_MODEL_RUNNER=1
+  - pytest -v -s distributed/test_pipeline_parallel.py -k "not ray and not Jamba"
+  - pytest -v -s distributed/test_pp_cudagraph.py -k "not ray"
+
+- label: COPY B Model Runner V2 Spec Decode # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - set -x
+  - export VLLM_USE_V2_MODEL_RUNNER=1
+  - pytest -v -s v1/spec_decode/test_max_len.py -k "eagle or mtp"
+  - pytest -v -s v1/spec_decode/test_rejection_sampler_utils.py
+  - pytest -v -s v1/spec_decode/test_synthetic_rejection_sampler_utils.py
+  - pytest -v -s v1/e2e/spec_decode/test_spec_decode.py -k "eagle or mtp"
+
+#------------------------------------------------------  mi325 · models / basic  -------------------------------------------------------#
+
+- label: COPY B Basic Models Tests (Extra Initialization) %N # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  parallelism: 6
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/test_initialization.py -k 'not test_can_initialize_small_subset' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+
+- label: COPY B Basic Models Tests (Initialization) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/test_initialization.py::test_can_initialize_small_subset
+
+- label: COPY B Basic Models Tests (Other) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/test_terratorch.py models/transformers/test_backend.py models/test_registry.py
+
+#-----------------------------------------------------  mi325 · models / language  -----------------------------------------------------#
+
+- label: COPY B Language Models Test (Extended Pooling)  # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/language/pooling -m 'not core_model'
+
+- label: COPY B Language Models Tests (Standard) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pip freeze | grep -E 'torch'
+  - pytest -v -s models/language -m 'core_model and (not slow_test)'
+
+- label: COPY B Language Models Tests (Extra Standard) %N # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  parallelism: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pip freeze | grep -E 'torch'
+  - pytest -v -s models/language -m 'core_model and slow_test' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+
+#----------------------------------------------------  mi325 · models / multimodal  ----------------------------------------------------#
+
+- label: COPY B Multi-Modal Models (Extended Generation 1) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/multimodal/generation -m 'not core_model' --ignore models/multimodal/generation/test_common.py
+  - pytest -v -s models/multimodal/test_mapping.py
+
+- label: COPY B Multi-Modal Models (Extended Generation 2) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/multimodal/generation/test_common.py -m 'split(group=0) and not core_model'
+
+
+- label: COPY B Multi-Modal Models (Extended Generation 3) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/multimodal/generation/test_common.py -m 'split(group=1) and not core_model'
+
+- label: "COPY B Multi-Modal Models (Standard) 1: qwen2" # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/multimodal/generation/test_common.py -m core_model -k "qwen2"
+  - pytest -v -s models/multimodal/generation/test_ultravox.py -m core_model
+
+- label: "COPY B Multi-Modal Models (Standard) 3: llava + qwen2_vl" # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/multimodal/generation/test_common.py -m core_model -k "not qwen2 and not qwen3 and not gemma"
+  - pytest -v -s models/multimodal/generation/test_qwen2_vl.py -m core_model
+
+- label: "COPY B Multi-Modal Models (Standard) 4: other + whisper" # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/multimodal -m core_model --ignore models/multimodal/generation/test_common.py --ignore models/multimodal/generation/test_ultravox.py --ignore models/multimodal/generation/test_qwen2_5_vl.py --ignore models/multimodal/generation/test_qwen2_vl.py --ignore models/multimodal/generation/test_whisper.py  --ignore models/multimodal/generation/test_memory_leak.py --ignore models/multimodal/processing
+  - pytest -v -s models/multimodal/generation/test_memory_leak.py -m core_model
+  - cd .. && VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -v -s tests/models/multimodal/generation/test_whisper.py -m core_model
+
+- label: COPY B Multi-Modal Processor # 1h 42m
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/multimodal/processing/test_tensor_schema.py
+
+- label: COPY B Multi-Modal Processor (CPU) %N # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  parallelism: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/multimodal/processing --ignore models/multimodal/processing/test_tensor_schema.py --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+
+#-----------------------------------------------------  mi325 · models / quantized  -----------------------------------------------------#
+
+- label: COPY B Quantized Models Test # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/quantization
+
+#--------------------------------------------------  mi325 · models / transformers  ---------------------------------------------------#
+
+- label: COPY B Transformers Nightly Models (Shardable) %N # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  parallelism: 4
+  working_dir: "/vllm-workspace/"
+  commands:
+  - pip install --upgrade git+https://github.com/huggingface/transformers
+  - pytest -v -s tests/models/test_initialization.py --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+  - pytest -v -s tests/models/multimodal/processing/ --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+
+- label: COPY B Transformers Nightly Models (Single) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/"
+  commands:
+  - pip install --upgrade git+https://github.com/huggingface/transformers
+  - pytest -v -s tests/models/transformers/test_backend.py
+  - pytest -v -s tests/models/multimodal/test_mapping.py
+  - python3 examples/basic/offline_inference/chat.py
+  - python3 examples/generate/multimodal/vision_language_offline.py --model-type qwen2_5_vl
+  - VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/generate/multimodal/audio_language_offline.py --model-type whisper
+
+#----------------------------------------------------------  mi325 · plugins  ----------------------------------------------------------#
+
+- label: COPY B Plugin Tests (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  # BEGIN: platform plugin and general plugin tests, all the code in-between runs on dummy platform
+  - pip install -e ./plugins/vllm_add_dummy_platform
+  - pytest -v -s plugins_tests/test_platform_plugins.py
+  - pip uninstall vllm_add_dummy_platform -y
+  # END: platform plugin tests
+  # BEGIN: `io_processor` plugins test, all the code in between uses the `prithvi_io_processor` plugin
+  - pip install -e ./plugins/prithvi_io_processor_plugin
+  - pytest -v -s plugins_tests/test_io_processor_plugins.py
+  - pytest -v -s plugins_tests/test_terratorch_io_processor_plugins.py
+  - pip uninstall prithvi_io_processor_plugin -y
+  # END: `io_processor` plugins test
+  # BEGIN: `bge_m3_sparse io_processor` test
+  - pip install -e ./plugins/bge_m3_sparse_plugin
+  - pytest -v -s plugins_tests/test_bge_m3_sparse_io_processor_plugins.py
+  - pip uninstall bge_m3_sparse_plugin -y
+  # END: `bge_m3_sparse io_processor` test
+  # BEGIN: `colbert_query io_processor` test
+  - pip install -e ./plugins/colbert_query_plugin
+  - pytest -v -s plugins_tests/test_colbert_query_io_processor_plugins.py
+  - pip uninstall colbert_query_plugin -y
+  # END: `colbert_query io_processor` test
+  # BEGIN: `stat_logger` plugins test
+  - pip install -e ./plugins/vllm_add_dummy_stat_logger
+  - pytest -v -s plugins_tests/test_stats_logger_plugins.py
+  - pip uninstall dummy_stat_logger -y
+  # END: `stat_logger` plugins test
+  # BEGIN: `endpoint` plugins test
+  - pip install -e ./plugins/vllm_add_dummy_endpoint_plugin
+  - pytest -v -s plugins_tests/test_endpoint_plugins.py
+  - pip uninstall vllm_add_dummy_endpoint_plugin -y
+  # END: `endpoint` plugins test
+  # BEGIN: other tests
+  - pytest -v -s plugins_tests/test_scheduler_plugins.py
+  - pip install -e ./plugins/vllm_add_dummy_model
+  - pytest -v -s distributed/test_distributed_oot.py
+  - pytest -v -s plugins_tests/test_oot_registration_online.py # it needs a clean process
+  - pytest -v -s plugins_tests/test_oot_registration_offline.py # it needs a clean process
+  - pytest -v -s plugins_tests/lora_resolvers # unit tests for in-tree lora resolver plugins
+
+- label: COPY B GGUF Plugin # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  soft_fail: true
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pip install "vllm-gguf-plugin >= 0.0.2"
+  - pytest -v -s plugins_tests/gguf
+
+#-------------------------------------------------------  mi325 · rust_frontend  -------------------------------------------------------#
+
+- label: COPY B Rust Frontend OpenAI Coverage # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_USE_RUST_FRONTEND=1
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s benchmarks/test_serve_cli.py -k "not insecure and not (test_bench_serve and not test_bench_serve_chat)"
+  - pytest -v -s entrypoints/openai/chat_completion/test_chat_completion.py -k "not test_invalid_json_schema and not test_invalid_regex"
+  - pytest -v -s entrypoints/openai/chat_completion/test_chat_logit_bias_validation.py -k "not multiple"
+  - pytest -v -s entrypoints/openai/completion/test_shutdown.py -k "not engine_failure and not test_abort_timeout_exits_quickly"
+  - pytest -v -s entrypoints/openai/test_return_token_ids.py -k "not test_comparison"
+  - pytest -v -s entrypoints/openai/test_uds.py
+  - pytest -v -s v1/sample/test_logprobs_e2e.py -k "test_prompt_logprobs_e2e_server"
+
+- label: COPY B Rust Frontend Serve Admin Coverage # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_USE_RUST_FRONTEND=1
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - PYTHONPATH=/vllm-workspace pytest -v -s entrypoints/serve/dev/rpc/test_collective_rpc.py
+  - pytest -v -s entrypoints/serve/instrumentator/test_basic.py -k "not show_version and not server_load"
+  - pytest -v -s entrypoints/scale_out/token_in_token_out/test_serving_tokens.py -k "not stream and not lora and not test_generate_logprobs and not stop_string_workflow"
+  - pytest -v -s entrypoints/serve/instrumentator/test_metrics.py -k "text and not show and not run_batch and not test_metrics_counts and not test_metrics_exist"
+  - pytest -v -s entrypoints/serve/tokenize/test_tokenization.py -k "not tokenizer_info"
+
+- label: COPY B Rust Frontend Core Correctness # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_USE_RUST_FRONTEND=1
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -s entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine
+
+- label: COPY B Rust Frontend Tool Use # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_USE_RUST_FRONTEND=1
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s tool_use --ignore=tool_use/mistral --models llama3.2 -k "not test_response_format_with_tool_choice_required and not test_parallel_tool_calls_false and not test_tool_call_and_choice"
+
+- label: COPY B Rust Frontend Distributed # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_USE_RUST_FRONTEND=1
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - TP_SIZE=1 DP_SIZE=4 pytest -v -s v1/distributed/test_internal_lb_dp.py -k "not 4 and not server_info"
+  - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_external_lb_dp.py -k "not 4 and not server_info"
+  - TP_SIZE=1 DP_SIZE=4 pytest -v -s v1/distributed/test_hybrid_lb_dp.py -k "not 4 and not server_info"
+
+#-------------------------------------------------------  mi325 · quantization  --------------------------------------------------------#
+
+- label: COPY B Quantization # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+
+  # temporary install here since we need nightly, will move to requirements/test.in
+  # after torchao 0.12 release, and pin a working version of torchao nightly here
+
+  # since torchao nightly is only compatible with torch nightly currently
+  # https://github.com/pytorch/ao/issues/2919, we'll have to skip new torchao tests for now
+  # we can only upgrade after this is resolved
+  # TODO(jerryzh168): resolve the above comment
+  - uv pip install --system torchao==0.17.0
+  - uv pip install --system conch-triton-kernels
+  - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py
+
+#-----------------------------------------------------------  mi325 · rocm  ------------------------------------------------------------#
+
+- label: COPY B ROCm AITER Ops Test # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s rocm/aiter/
+
+#---------------------------------------------------------  mi325 · samplers  ----------------------------------------------------------#
+
+- label: COPY B Samplers Test # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s samplers
+
+#------------------------------------------------------------  mi325 · misc  ------------------------------------------------------------#
+
+- label: COPY B Regression # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
   commands:
   - pip install 'modelscope<1.38'
   - pytest -v -s test_regression.py
+
+#---------------------------------------------------------  mi325 · ray_compat  ---------------------------------------------------------#
+
+- label: COPY B Ray Dependency Compatibility Check # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/"
+  commands:
+  - bash /vllm-workspace/.buildkite/scripts/check-ray-compatibility.sh
+
+#------------------------------------------------------------  mi325 · v1  -------------------------------------------------------------#
+
+- label: COPY B Acceptance Length Test (Large Models) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_ALLOW_INSECURE_SERIALIZATION=1
+  - pytest -v -s v1/spec_decode/test_acceptance_length.py -m slow_test
+
+- label: COPY B e2e Scheduling (1 GPU) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s v1/e2e/general/test_async_scheduling.py
+
+- label: COPY B Engine (1 GPU) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s v1/engine/test_preprocess_error_handling.py
+  - pytest -v -s v1/engine --ignore v1/engine/test_preprocess_error_handling.py
+
+- label: COPY B Spec Decode Draft Model # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s v1/e2e/spec_decode -k "draft_model or no_sync or batch_inference"
+
+- label: COPY B Spec Decode Eagle # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s v1/e2e/spec_decode -k "eagle_correctness"
+
+- label: COPY B Spec Decode Ngram + Suffix # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s v1/e2e/spec_decode -k "ngram or suffix"
+
+- label: COPY B Spec Decode Speculators + MTP # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s v1/e2e/spec_decode -k "speculators or mtp_correctness"
+
+- label: COPY B Speculators Correctness # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_ALLOW_INSECURE_SERIALIZATION=1
+  - pytest -v -s v1/spec_decode/test_speculators_correctness.py -m slow_test
+
+- label: COPY B V1 Spec Decode # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s -m 'not slow_test' v1/spec_decode
+
+- label: COPY B Extract Hidden States Integration # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s v1/kv_connector/extract_hidden_states_integration
+
+- label: COPY B V1 attention (H100-MI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s v1/attention
+
+- label: COPY B V1 Core + KV + Metrics # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
+  - pytest -v -s -m 'not cpu_test' v1/core
+  - pytest -v -s v1/executor
+  - pytest -v -s v1/kv_offload
+  - pytest -v -s v1/worker
+  - pytest -v -s -m 'not cpu_test' v1/kv_connector/unit
+  - pytest -v -s -m 'not cpu_test' v1/metrics
+  - pip install -U git+https://github.com/vllm-project/lm-evaluation-harness.git@streaming-api
+  # - export HSA_NO_SCRATCH_RECLAIM=1
+  - pytest -v -s entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine
+
+- label: COPY B V1 others (CPU) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s -m 'cpu_test' v1/core
+  - pytest -v -s v1/structured_output
+  - pytest -v -s v1/test_serial_utils.py
+  - pytest -v -s -m 'cpu_test' v1/kv_connector/unit
+  - pytest -v -s -m 'cpu_test' v1/metrics
+
+- label: COPY B V1 Sample + Logits # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s v1/sample
+  - pytest -v -s v1/logits_processors
+  - pytest -v -s v1/test_oracle.py
+  - pytest -v -s v1/test_request.py
+  - pytest -v -s v1/test_outputs.py
+
+- label: COPY B Distributed DP Tests (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export NCCL_CUMEM_HOST_ENABLE=0
+  - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_async_llm_dp.py
+  - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_eagle_dp.py
+  - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_external_lb_dp.py
+  - DP_SIZE=2 pytest -v -s entrypoints/openai/test_multi_api_servers.py
+
+- label: COPY B Metrics, Tracing (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - "pip install \
+      'opentelemetry-sdk>=1.26.0' \
+      'opentelemetry-api>=1.26.0' \
+      'opentelemetry-exporter-otlp>=1.26.0' \
+      'opentelemetry-semantic-conventions-ai>=0.4.1'"
+  - pytest -v -s v1/tracing
+
+- label: COPY B V1 e2e (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+    - pytest -v -s v1/e2e/spec_decode/test_spec_decode.py -k "tensor_parallelism"
+
+- label: COPY B NixlConnector PD + Spec Decode acceptance (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
+  - KV_CACHE_MEMORY_BYTES=8G ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/config_sweep_spec_decode_test.sh
+
+- label: COPY B CrossLayer KV layout Distributed NixlConnector PD accuracy tests (4 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
+  - CROSS_LAYERS_BLOCKS=True ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+
+- label: COPY B Distributed DP Tests (4 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - export NCCL_CUMEM_HOST_ENABLE=0
+  - TP_SIZE=2 DP_SIZE=2 pytest -v -s v1/distributed/test_async_llm_dp.py
+  - TP_SIZE=2 DP_SIZE=2 pytest -v -s v1/distributed/test_eagle_dp.py
+  - TP_SIZE=2 DP_SIZE=2 pytest -v -s v1/distributed/test_external_lb_dp.py
+  - TP_SIZE=1 DP_SIZE=4 pytest -v -s v1/distributed/test_internal_lb_dp.py
+  - TP_SIZE=1 DP_SIZE=4 pytest -v -s v1/distributed/test_hybrid_lb_dp.py
+  - pytest -v -s v1/engine/test_engine_core_client.py::test_kv_cache_events_dp
+  - pytest -v -s distributed/test_utils.py
+
+- label: COPY B Distributed NixlConnector PD accuracy (4 GPUs)  # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
+  - ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+
+- label: COPY B DP EP Distributed NixlConnector PD accuracy tests (4 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
+  - DP_EP=1 ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+
+- label: COPY B Hybrid SSM NixlConnector PD accuracy tests (4 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
+  - HYBRID_SSM=1 ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+
+- label: COPY B Hybrid SSM NixlConnector PD prefix cache test (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
+  - ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/run_mamba_prefix_cache_test.sh
+
+- label: COPY B MultiConnector (Nixl+Offloading) PD accuracy (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
+  - ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/run_multi_connector_accuracy_test.sh
+
+- label: COPY B MultiConnector (Nixl+Offloading) PD edge cases (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
+  - ATTENTION_BACKEND=TRITON_ATTN bash v1/kv_connector/nixl_integration/run_multi_connector_edge_case_test.sh
+
+- label: COPY B V1 e2e (4 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+    - pytest -v -s v1/e2e/spec_decode/test_spec_decode.py -k "eagle_correctness_heavy"
+
+- label: COPY B V1 e2e (4xH100-4xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  commands:
+    - pytest -v -s v1/e2e/test_hybrid_chunked_prefill.py
+
+#------------------------------------------------------  mi325 · weight_loading  -------------------------------------------------------#
+
+- label: COPY B Weight Loading Multiple GPU # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - bash weight_loading/run_model_weight_loading_test.sh -c weight_loading/models-amd.txt
+
+- label: COPY B Weight Loading Multiple GPU - Large Models # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - bash weight_loading/run_model_weight_loading_test.sh -c weight_loading/models-large-amd.txt
+
+#########################################################################################################################################
+#                                                                                                                                       #
+#                                                         MI325 (gfx942) tests                                                          #
+#                                                                                                                                       #
+#########################################################################################################################################
+
+#----------------------------------------------------------  mi325 · compile  ----------------------------------------------------------#
+
+- label: COPY B Distributed Compile + RPC Tests (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s entrypoints/llm/test_collective_rpc.py
+  - pytest -v -s ./compile/fullgraph/test_basic_correctness.py
+  - pytest -v -s ./compile/test_wrapper.py
+
+#--------------------------------------------------------  mi325 · distributed  --------------------------------------------------------#
+
+- label: COPY B Distributed Torchrun + Shutdown Tests (2 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - VLLM_TEST_SAME_HOST=1 torchrun --nproc-per-node=4 distributed/test_same_node.py | grep 'Same node test passed'
+  - VLLM_TEST_SAME_HOST=1 VLLM_TEST_WITH_DEFAULT_DEVICE_SET=1 torchrun --nproc-per-node=4 distributed/test_same_node.py | grep 'Same node test passed'
+  - CUDA_VISIBLE_DEVICES=0,1 pytest -v -s v1/shutdown
+  - pytest -v -s v1/worker/test_worker_memory_snapshot.py
+
+- label: COPY B Distributed Compile + Comm (4 GPUs) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s compile/fullgraph/test_basic_correctness.py
+  - pytest -v -s distributed/test_pynccl.py
+  - pytest -v -s distributed/test_events.py
+  - pytest -v -s distributed/test_symm_mem_allreduce.py
+  - pytest -v -s distributed/test_multiproc_executor.py::test_multiproc_executor_multi_node
+
+#----------------------------------------------------------  mi325 · engine  -----------------------------------------------------------#
+
+- label: COPY B Engine # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s engine test_sequence.py test_config.py test_logger.py test_vllm_port.py test_jit_monitor.py
+
+#-----------------------------------------------------------  mi325 · evals  -----------------------------------------------------------#
+
+- label: COPY B LM Eval Large Models (4xH100-4xMI325) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_4
+  num_gpus: 4
+  working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
+  commands:
+  - export VLLM_USE_DEEP_GEMM=0
+  - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-large-rocm-fp8.txt --tp-size=4
+
+#-----------------------------------------------------  mi325 · models / language  -----------------------------------------------------#
+
+- label: COPY B Language Models Test (Extended Generation) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system --no-build-isolation 'git+https://github.com/AndreasKaratzas/mamba@fix-rocm-7.0-warp-size-constexpr'
+  - uv pip install --system --no-build-isolation 'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0'
+  - pytest -v -s models/language/generation -m '(not core_model) and (not hybrid_model)'
+
+- label: COPY B Language Models Tests (Hybrid) %N # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  parallelism: 2
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - uv pip install --system --no-build-isolation 'git+https://github.com/AndreasKaratzas/mamba@fix-rocm-7.0-warp-size-constexpr'
+  - uv pip install --system --no-build-isolation 'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0'
+  - pytest -v -s models/language/generation -m hybrid_model --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+
+#----------------------------------------------------  mi325 · models / multimodal  ----------------------------------------------------#
+
+- label: COPY B Multi-Modal Models (Extended Pooling) # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/multimodal/pooling -m 'not core_model'
+
+- label: "COPY B Multi-Modal Models (Standard) 2: qwen3 + gemma" # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - pytest -v -s models/multimodal/generation/test_common.py -m core_model -k "qwen3 or gemma"
+  - pytest -v -s models/multimodal/generation/test_qwen2_5_vl.py -m core_model
+
+#-----------------------------------------------------------  mi325 · misc  ------------------------------------------------------------#
+
+- label: COPY B Python-only Installation # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdshadow]
+  agent_pool: mi325_1
+  working_dir: "/vllm-workspace/tests"
+  commands:
+  - bash standalone_tests/python_only_compile.sh

--- a/.buildkite/test_areas/benchmarks.yaml
+++ b/.buildkite/test_areas/benchmarks.yaml
@@ -13,8 +13,7 @@ steps:
   - pytest -v -s benchmarks/
   mirror:
     amd:
-      dind: false
-      device: mi300_1
+      device: mi325_1
       depends_on:
       - image-build-amd
 

--- a/.buildkite/test_areas/disaggregated.yaml
+++ b/.buildkite/test_areas/disaggregated.yaml
@@ -15,8 +15,7 @@ steps:
     - bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
   mirror:
     amd:
-      dind: false
-      device: mi300_4
+      device: mi325_4
       timeout_in_minutes: 85
       depends_on:
         - image-build-amd
@@ -66,8 +65,7 @@ steps:
     - DP_EP=1 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
   mirror:
     amd:
-      dind: false
-      device: mi300_4
+      device: mi325_4
       timeout_in_minutes: 60
       depends_on:
         - image-build-amd
@@ -92,8 +90,7 @@ steps:
     - CROSS_LAYERS_BLOCKS=True bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
   mirror:
     amd:
-      dind: false
-      device: mi300_4
+      device: mi325_4
       timeout_in_minutes: 85
       depends_on:
         - image-build-amd
@@ -118,8 +115,7 @@ steps:
     - HYBRID_SSM=1 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
   mirror:
     amd:
-      dind: false
-      device: mi300_4
+      device: mi325_4
       timeout_in_minutes: 80
       depends_on:
         - image-build-amd
@@ -175,8 +171,7 @@ steps:
     - bash v1/kv_connector/nixl_integration/config_sweep_spec_decode_test.sh
   mirror:
     amd:
-      dind: false
-      device: mi300_2
+      device: mi325_2
       timeout_in_minutes: 70
       depends_on:
         - image-build-amd

--- a/.buildkite/test_areas/distributed.yaml
+++ b/.buildkite/test_areas/distributed.yaml
@@ -39,8 +39,7 @@ steps:
   - DP_SIZE=2 pytest -v -s entrypoints/openai/test_multi_api_servers.py
   mirror:
     amd:
-      dind: false
-      device: mi300_2
+      device: mi325_2
       depends_on:
       - image-build-amd
       source_file_dependencies:

--- a/.buildkite/test_areas/engine.yaml
+++ b/.buildkite/test_areas/engine.yaml
@@ -114,8 +114,7 @@ steps:
     - pytest -v -s v1/e2e/spec_decode/test_spec_decode.py -k "tensor_parallelism"
   mirror:
     amd:
-      dind: false
-      device: mi300_2
+      device: mi325_2
       depends_on:
       - image-build-amd
 

--- a/.buildkite/test_areas/expert_parallelism.yaml
+++ b/.buildkite/test_areas/expert_parallelism.yaml
@@ -16,8 +16,7 @@ steps:
   - pytest -v -s distributed/test_eplb_utils.py
   mirror:
     amd:
-      dind: false
-      device: mi300_1
+      device: mi325_1
       depends_on:
       - image-build-amd
       source_file_dependencies:

--- a/.buildkite/test_areas/lm_eval.yaml
+++ b/.buildkite/test_areas/lm_eval.yaml
@@ -139,8 +139,7 @@ steps:
     - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-h200.txt
   mirror:
     amd:
-      dind: false
-      device: mi300_8
+      device: mi325_8
       timeout_in_minutes: 60
       depends_on:
       - image-build-amd

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -23,8 +23,7 @@ steps:
     - pytest -v -s -m 'not slow_test' v1/spec_decode
   mirror:
     amd:
-      dind: false
-      device: mi300_1
+      device: mi325_1
       timeout_in_minutes: 75
       depends_on:
       - image-build-amd

--- a/.buildkite/test_areas/model_executor.yaml
+++ b/.buildkite/test_areas/model_executor.yaml
@@ -28,8 +28,7 @@ steps:
     - pytest -v -s entrypoints/openai/completion/test_tensorizer_entrypoint.py --timeout=900 --timeout-method=thread
   mirror:
     amd:
-      dind: false
-      device: mi300_1
+      device: mi325_1
       depends_on:
       - image-build-amd
       source_file_dependencies:

--- a/.buildkite/test_areas/models_language.yaml
+++ b/.buildkite/test_areas/models_language.yaml
@@ -15,8 +15,7 @@ steps:
     - pytest -v -s models/language -m 'core_model and (not slow_test)'
   mirror:
     amd:
-      dind: false
-      device: mi300_1
+      device: mi325_1
       depends_on:
       - image-build-amd
 
@@ -37,8 +36,7 @@ steps:
   parallelism: 2
   mirror:
     amd:
-      dind: false
-      device: mi300_1
+      device: mi325_1
       depends_on:
       - image-build-amd
       source_file_dependencies:

--- a/.buildkite/test_areas/models_multimodal.yaml
+++ b/.buildkite/test_areas/models_multimodal.yaml
@@ -107,8 +107,7 @@ steps:
   - pytest -s -v test_lm_eval_correctness.py --config-list-file=configs/models-mm-small.txt --tp-size=1
   mirror:
     amd:
-      dind: false
-      device: mi300_1
+      device: mi325_1
       depends_on:
       - image-build-amd
       source_file_dependencies:

--- a/.buildkite/test_areas/pytorch.yaml
+++ b/.buildkite/test_areas/pytorch.yaml
@@ -109,8 +109,7 @@ steps:
   - pytest -s -v compile/passes --ignore compile/passes/distributed
   mirror:
     amd:
-      dind: false
-      device: mi300_1
+      device: mi325_1
       timeout_in_minutes: 65
       depends_on:
       - image-build-amd
@@ -234,8 +233,7 @@ steps:
   - bash standalone_tests/pytorch_nightly_dependency.sh
   mirror:
     amd:
-      dind: false
-      device: mi300_1
+      device: mi325_1
       depends_on:
       - image-build-amd
       source_file_dependencies:

--- a/.buildkite/test_areas/weight_loading.yaml
+++ b/.buildkite/test_areas/weight_loading.yaml
@@ -15,8 +15,7 @@ steps:
     - bash weight_loading/run_model_weight_loading_test.sh -c weight_loading/models.txt
   mirror:
     amd:
-      dind: false
-      device: mi300_2
+      device: mi325_2
       depends_on:
       - image-build-amd
       commands:


### PR DESCRIPTION
Shadow testing MI325 cluster, analogous to #46653 for MI300.

- Route the compatible AMD suite and AMD test-area mirrors to `mi325_{1,2,4,8}` queues through the automatic `amdproduction` selector while retaining `amdexperimental` and `amdshadow` support.
- Run 431 surge definitions, expanding to 497 MI325 test jobs across the queue sizes.
- Keep MI325 on the default Docker-in-Docker path (`dind: true` by omission).
- Temporarily suppress ordinary non-AMD jobs so the branch is dedicated to the surge effort.

## Validation

- Live webhook verification: [AMD CI #11062](https://buildkite.com/vllm/amd-ci/builds/11062) uploaded all 431 MI325 test definitions / 497 expanded test jobs with no approval blocks.
- Queue distribution: 356 x `amd_mi325_1`, 63 x `amd_mi325_2`, 69 x `amd_mi325_4`, and 9 x `amd_mi325_8`.
- Current ci-infra render: exactly 500 jobs including the 3 AMD image builders; unique labels/keys and default DinD environment verified.
- Targeted pre-commit hooks: passed.

This is not duplicate work: #46653 targets MI300, while this PR targets the new MI325 cluster.

AI assistance was used to adapt the surge configuration, diagnose the Buildkite selector mismatch, and validate the generated pipeline. The human submitter must review and be able to explain every changed line before merge.
