### PR TITLE
[Bugfix][KV Offload] Namespace persistent cache by model revision

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_config.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_config.py
@@ -41,6 +41,9 @@ def _make_vllm_config(
     config.cache_config.prefix_match_unit = None
     config.cache_config.cache_dtype = torch.float16
     config.model_config.model = "test-model"
+    config.model_config.hf_config_path = None
+    config.model_config.revision = None
+    config.model_config.hf_config._commit_hash = None
     config.model_config.use_mla = False
     world_size = (
         tensor_parallel_size * pipeline_parallel_size * prefill_context_parallel_size
@@ -274,6 +277,36 @@ def test_preserves_data_parallel_index():
     offloading_config = build_offloading_config(config, _make_kv_cache_config())
 
     assert offloading_config.parallel.data_parallel_index == 2
+
+
+@pytest.mark.parametrize(
+    ("hf_config_path", "requested_revision", "resolved_revision", "expected"),
+    [
+        (None, "requested-branch", "resolved-commit", "resolved-commit"),
+        (None, "requested-commit", None, "requested-commit"),
+        (
+            "org/separate-config",
+            "weights-revision",
+            "config-commit",
+            "weights-revision",
+        ),
+        ("org/separate-config", None, "config-commit", None),
+    ],
+)
+def test_model_revision_uses_weights_source(
+    hf_config_path: str | None,
+    requested_revision: str | None,
+    resolved_revision: str | None,
+    expected: str | None,
+):
+    config = _make_vllm_config()
+    config.model_config.hf_config_path = hf_config_path
+    config.model_config.revision = requested_revision
+    config.model_config.hf_config._commit_hash = resolved_revision
+
+    offloading_config = build_offloading_config(config, _make_kv_cache_config())
+
+    assert offloading_config.model.revision == expected
 
 
 def test_resolves_heterogeneous_hybrid_block_sizes():

--- a/tests/v1/kv_offload/test_file_mapper.py
+++ b/tests/v1/kv_offload/test_file_mapper.py
@@ -36,6 +36,7 @@ def make_mapper_from_offloading_spec(**kwargs) -> FileMapper:
         model=OffloadingModelConfig(
             name=kwargs.get("model_name", "test-model"),
             dtype=kwargs.get("dtype", "float16"),
+            revision=kwargs.get("model_revision"),
         ),
         cache=OffloadingCacheConfig(
             tokens_per_hash=kwargs.get("tokens_per_hash", 16),
@@ -127,6 +128,18 @@ def test_get_config_file_path():
     fm = make_mapper_from_offloading_spec()
     config_path = fm.get_config_file_path()
     assert config_path == f"{fm.base_path}/config.json"
+
+
+def test_model_revision_separates_persistent_namespaces():
+    revision_a = make_mapper_from_offloading_spec(model_revision="commit-a")
+    revision_b = make_mapper_from_offloading_spec(model_revision="commit-b")
+    same_revision = make_mapper_from_offloading_spec(model_revision="commit-a")
+    unavailable = make_mapper_from_offloading_spec()
+
+    assert revision_a.base_path != revision_b.base_path
+    assert revision_a.base_path == same_revision.base_path
+    assert revision_a.fields["model_revision"] == "commit-a"
+    assert "model_revision" not in unavailable.fields
 
 
 def test_hybrid_file_identity_uses_resolved_tokens_per_hash():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
@@ -16,7 +16,21 @@ from vllm.v1.kv_offload.config import (
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+    from vllm.config.model import ModelConfig
     from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheTensor
+
+
+def _get_model_weights_revision(model_config: "ModelConfig") -> str | None:
+    """Return the best available identity for the loaded model weights."""
+    requested_revision = model_config.revision
+    config_source = model_config.hf_config_path or model_config.model
+    if config_source == model_config.model:
+        resolved_revision = getattr(model_config.hf_config, "_commit_hash", None)
+        if isinstance(resolved_revision, str) and resolved_revision:
+            return resolved_revision
+    if isinstance(requested_revision, str) and requested_revision:
+        return requested_revision
+    return None
 
 
 def is_kv_cache_tensor_packed(kv_cache_tensor: "KVCacheTensor") -> bool:
@@ -34,6 +48,9 @@ def build_offloading_config(
     extra_config = kv_transfer_config.kv_connector_extra_config
     assert kv_transfer_config.engine_id is not None
     engine_id = kv_transfer_config.engine_id
+
+    model_config = vllm_config.model_config
+    model_revision = _get_model_weights_revision(model_config)
 
     parallel_config = vllm_config.parallel_config
     groups = tuple(
@@ -153,8 +170,9 @@ def build_offloading_config(
         extra_config=extra_config,
         engine_id=engine_id,
         model=OffloadingModelConfig(
-            name=vllm_config.model_config.model,
+            name=model_config.model,
             dtype=str(cache_dtype).removeprefix("torch."),
+            revision=model_revision,
         ),
         cache=OffloadingCacheConfig(
             tokens_per_hash=tokens_per_hash,

--- a/vllm/v1/kv_offload/config.py
+++ b/vllm/v1/kv_offload/config.py
@@ -22,6 +22,8 @@ class OffloadingModelConfig:
     name: str
     # KV cache data type (e.g. "float16").
     dtype: str
+    # Resolved model revision when available.
+    revision: str | None = None
 
 
 @dataclass(frozen=True)

--- a/vllm/v1/kv_offload/file_mapper.py
+++ b/vllm/v1/kv_offload/file_mapper.py
@@ -35,6 +35,7 @@ class FileMapper:
         kv_cache_groups: list[dict] | None = None,
         inference_engine: str = "vllm",
         parallel_agnostic: bool = False,
+        model_revision: str | None = None,
     ):
         """
         Initialize the file mapper. Each worker constructs its own, but
@@ -60,6 +61,8 @@ class FileMapper:
         }
         if not parallel_agnostic:
             self.fields["parallel_agnostic"] = False
+        if model_revision is not None:
+            self.fields["model_revision"] = model_revision
         self.base_path: str = self._compute_base_path(root_dir, self.fields)
 
     @classmethod
@@ -93,6 +96,7 @@ class FileMapper:
             dtype=config.model.dtype,
             kv_cache_groups=kv_cache_groups,
             parallel_agnostic=(parallel_agnostic and parallel.is_parallelism_agnostic),
+            model_revision=config.model.revision,
         )
 
     def get_file_name(self, key: OffloadKey) -> str:


### PR DESCRIPTION
## Purpose

Closes #49261.

Persistent native KV-offloading tiers derive their cache namespace from
`FileMapper.fields`. The namespace includes the model name and cache layout,
but not the model revision. Deployments using different revisions of the same
model repository can therefore reuse persistent KV entries produced by
different weights.

This change propagates the best available model-weights revision into
`OffloadingModelConfig` and includes it in the `FileMapper` fingerprint. When
the Hugging Face config comes from the model repository, its resolved immutable
commit hash is preferred over the requested revision. When `hf_config_path`
points elsewhere, the config commit is not treated as the weights commit and
the requested model revision is used instead.

If no weights revision is available, such as for a local model or a separate
config source without an explicit model revision, the field is omitted so the
existing cache path remains unchanged. Existing callers remain compatible
because the new optional `FileMapper` argument is appended.

## Relationship to recent namespace fixes

This patch is complementary to two related fixes that landed after this PR was
opened:

- #49438 namespaces `cache_dtype="auto"` by its effective dtype, separating
  incompatible KV representations.
- #49440 fingerprints non-parallelism-agnostic layouts, separating incompatible
  V1 and V2 model-runner byte layouts.
- This PR separates KV values produced by different model-weight revisions.

All three fixes harden the same persistent namespace along independent identity
axes. This branch is rebased onto the latest `main` and preserves the effective
dtype and `parallel_agnostic` behavior from #49438 and #49440.

## Duplicate-work check

I searched open PRs for #49261 and for combinations of KV offload, model
revision, cache namespace, and `FileMapper`. I did not find another PR that
namespaces persistent offload caches by model revision. #49438 and #49440
explicitly cover different namespace inputs and do not supersede this change.

## Test plan and results

Focused configuration and mapper tests:

```bash
.venv/bin/python -m pytest -q \
  tests/v1/kv_connector/unit/offloading_connector/test_config.py \
  tests/v1/kv_offload/test_file_mapper.py
```

Result: `51 passed`.

CPU-independent KV-offload suite:

```bash
.venv/bin/python -m pytest -q tests/v1/kv_offload \
  --ignore=tests/v1/kv_offload/cpu/test_gpu_worker.py
```

Result: `394 passed, 3 skipped`.

The full suite including `test_gpu_worker.py` was also attempted. The same 394
tests passed and 3 skipped; 32 parameterized GPU-worker cases could not enter
their test bodies because the reused environment registered
`UnspecifiedPlatform` and raised `Failed to infer device type` during fixture
setup.

```bash
ruff check <changed files>
ruff format --check <changed files>
git diff --check
```

Result: all checks passed.

An earlier probe using `facebook/opt-125m` with no requested revision resolved
the immutable model commit
`27dcfa74d334bc871f3234de431e71c6eeba5dd6` and selected it as the offload
namespace revision.

A model-level output replay was not run in the rebase environment because it
does not expose a recognized accelerator. The change only selects the
persistent namespace: same-revision execution is unchanged, while the focused
tests verify that different revisions cannot select the same namespace.

## AI assistance

OpenAI Codex was used to assist with investigation, implementation, regression
tests, rebase conflict resolution, and PR preparation. I reviewed every changed
line and understand the change end-to-end.
