### PR TITLE
Update BGE-M3 token expectations for leading spaces

### DIFF
--- a/tests/plugins_tests/test_bge_m3_sparse_io_processor_plugins.py
+++ b/tests/plugins_tests/test_bge_m3_sparse_io_processor_plugins.py
@@ -48,12 +48,12 @@ def _check_dense_embedding(data, index=0):
 def _check_sparse_embedding(data, check_tokens=False):
     expected_weights = [
         {"token_id": 32, "weight": 0.0552978515625, "token": "?"},
-        {"token_id": 70, "weight": 0.09808349609375, "token": "the"},
-        {"token_id": 83, "weight": 0.08154296875, "token": "is"},
-        {"token_id": 111, "weight": 0.11810302734375, "token": "of"},
-        {"token_id": 4865, "weight": 0.1171875, "token": "What"},
-        {"token_id": 9942, "weight": 0.292236328125, "token": "France"},
-        {"token_id": 10323, "weight": 0.2802734375, "token": "capital"},
+        {"token_id": 70, "weight": 0.09808349609375, "token": " the"},
+        {"token_id": 83, "weight": 0.08154296875, "token": " is"},
+        {"token_id": 111, "weight": 0.11810302734375, "token": " of"},
+        {"token_id": 4865, "weight": 0.1171875, "token": " What"},
+        {"token_id": 9942, "weight": 0.292236328125, "token": " France"},
+        {"token_id": 10323, "weight": 0.2802734375, "token": " capital"},
     ]
     expected_embed = {x["token_id"]: x for x in expected_weights}
 


### PR DESCRIPTION
## Summary

Update the BGE-M3 sparse plugin expectation for the leading spaces restored by #48674.

The shared `_check_sparse_embedding()` expectation covers the online and offline `return_tokens=True` paths. The production helper and all other code remain unchanged in this PR.

## Root cause

SentencePiece pieces such as `▁What` now decode to `" What"` so distinct token IDs remain distinguishable. The old test expected `"What"`, `"the"`, and similar strings without the word-boundary space.

## Validation

- `uvx pre-commit run ruff-format --files tests/plugins_tests/test_bge_m3_sparse_io_processor_plugins.py`
- `uvx pre-commit run ruff-check --files tests/plugins_tests/test_bge_m3_sparse_io_processor_plugins.py`
- `git diff --check`

No existing open PR was found for issue #44319 or this regression. AI assistance was used.