### PR TITLE
[Kernel][MoE] Add opt-in DeepGEMM BF16 grouped-GEMM MoE backend (contiguous + masked)

### DIFF
--- a/tests/kernels/moe/test_deepgemm_bf16_moe.py
+++ b/tests/kernels/moe/test_deepgemm_bf16_moe.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the DeepGEMM bf16 (unquantized) MoE backend.
+
+Compares the DeepGEMM bf16 experts against the Triton reference on a single
+GPU, and checks that the ``DEEP_GEMM`` unquantized backend is opt-in only.
+
+Run: ``pytest tests/kernels/moe/test_deepgemm_bf16_moe.py``.
+"""
+
+import pytest
+import torch
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from tests.kernels.moe.utils import make_dummy_moe_config
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.all2all_utils import (
+    maybe_make_prepare_finalize,
+)
+from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
+from vllm.model_executor.layers.fused_moe.experts.deep_gemm_bf16_moe import (
+    DeepGemmBf16BatchedExperts,
+    DeepGemmBf16Experts,
+)
+from vllm.model_executor.layers.fused_moe.experts.fused_batched_moe import (
+    BatchedTritonExperts,
+)
+from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts
+from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
+    UnquantizedMoeBackend,
+    backend_to_kernel_cls,
+    map_unquantized_backend,
+)
+from vllm.model_executor.layers.fused_moe.prepare_finalize.batched import (
+    BatchedPrepareAndFinalize,
+)
+from vllm.utils.deep_gemm import (
+    calc_diff,
+    is_deep_gemm_bf16_grouped_supported,
+    is_deep_gemm_bf16_masked_supported,
+)
+
+
+def _bf16_moe_weights(e: int, n: int, k: int):
+    """(w1, w2) unquantized bf16 expert weights: w1 (E, 2N, K), w2 (E, K, N)."""
+    dtype = torch.bfloat16
+    w1 = torch.randn(e, 2 * n, k, device="cuda", dtype=dtype) / 10
+    w2 = torch.randn(e, k, n, device="cuda", dtype=dtype) / 10
+    return w1, w2
+
+
+# N, K aligned to 128 (DeepGEMM contiguous requirement); M >= 128.
+CONTIG_MNKS = [
+    (1024, 768, 128),
+    (2048, 768, 512),
+    (512, 1024, 1024),
+]
+
+
+@pytest.mark.parametrize(("m", "n", "k"), CONTIG_MNKS)
+@pytest.mark.parametrize("topk", [2, 6])
+@pytest.mark.parametrize("num_experts", [32])
+@pytest.mark.skipif(
+    not is_deep_gemm_bf16_grouped_supported(),
+    reason="Requires DeepGEMM bf16 grouped kernel",
+)
+def test_deepgemm_bf16_contiguous_vs_triton(
+    m, n, k, topk, num_experts, monkeypatch, workspace_init
+):
+    """DeepGemmBf16Experts (Standard) == Triton reference."""
+    with monkeypatch.context() as mp:
+        mp.setenv("VLLM_USE_DEEP_GEMM", "1")
+
+        tokens = torch.randn(m, k, device="cuda", dtype=torch.bfloat16).clamp_(-1, 1)
+        w1, w2 = _bf16_moe_weights(num_experts, n, k)
+
+        router_logits = torch.randn(m, num_experts, device="cuda", dtype=torch.float32)
+        topk_weights, topk_ids = torch.topk(router_logits, k=topk, dim=-1)
+        topk_weights = torch.nn.functional.softmax(topk_weights, dim=-1)
+
+        quant_config = FusedMoEQuantConfig.make()  # unquantized
+        moe_config = make_dummy_moe_config()
+
+        deepgemm_kernel = mk.FusedMoEKernel(
+            prepare_finalize=maybe_make_prepare_finalize(
+                moe=moe_config,
+                quant_config=quant_config,
+                allow_new_interface=True,
+                use_monolithic=False,
+            ),
+            fused_experts=DeepGemmBf16Experts(
+                moe_config=moe_config,
+                quant_config=quant_config,
+            ),
+        )
+
+        out_triton = fused_experts(
+            hidden_states=tokens,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            quant_config=quant_config,
+        )
+        out_deepgemm = deepgemm_kernel.apply(
+            hidden_states=tokens,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            global_num_experts=num_experts,
+            activation=MoEActivation.SILU,
+            apply_router_weight_on_input=False,
+            expert_map=None,
+        )
+        diff = calc_diff(out_deepgemm, out_triton)
+        assert diff < 1e-3, f"contiguous diff too large: {diff}"
+
+
+@pytest.mark.parametrize("E", [16, 32])
+@pytest.mark.parametrize("T", [256])
+@pytest.mark.parametrize("K", [256])
+@pytest.mark.parametrize("N", [512, 1024])
+@pytest.mark.parametrize("topk", [2, 4])
+@pytest.mark.skipif(
+    not is_deep_gemm_bf16_masked_supported(),
+    reason="Requires DeepGEMM bf16 masked kernel",
+)
+def test_deepgemm_bf16_masked_vs_triton(E, T, K, N, topk, monkeypatch, workspace_init):
+    """DeepGemmBf16BatchedExperts (BatchedExperts) == BatchedTriton reference."""
+    with monkeypatch.context() as mp:
+        mp.setenv("VLLM_USE_DEEP_GEMM", "1")
+
+        w1, w2 = _bf16_moe_weights(E, N, K)
+        M = E * T
+        a = torch.randn(M, K, device="cuda", dtype=torch.bfloat16) / 10.0
+
+        router_logits = torch.randn(M, E, device="cuda", dtype=torch.float32)
+        topk_weights, topk_ids = torch.topk(router_logits, k=topk, dim=-1)
+        topk_weights = torch.nn.functional.softmax(topk_weights, dim=-1)
+
+        cnt = torch.bincount(topk_ids.flatten(), minlength=E)
+        max_num_tokens = 1 << (int(cnt.max().item()) - 1).bit_length()
+
+        prep_finalize = BatchedPrepareAndFinalize(
+            max_num_tokens=max_num_tokens,
+            num_local_experts=E,
+            num_dispatchers=1,
+            rank=0,
+        )
+        quant_config = FusedMoEQuantConfig.make()  # unquantized
+        moe_config = make_dummy_moe_config()
+
+        common = dict(
+            hidden_states=a,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation=MoEActivation.SILU,
+            global_num_experts=E,
+            expert_map=None,
+            apply_router_weight_on_input=False,
+        )
+
+        out_triton = mk.FusedMoEKernel(
+            prep_finalize,
+            BatchedTritonExperts(
+                max_num_tokens=max_num_tokens,
+                num_dispatchers=1,
+                quant_config=quant_config,
+                moe_config=moe_config,
+            ),
+        ).apply(**common)
+
+        out_deepgemm = mk.FusedMoEKernel(
+            prep_finalize,
+            DeepGemmBf16BatchedExperts(
+                max_num_tokens=max_num_tokens,
+                num_dispatchers=1,
+                quant_config=quant_config,
+                moe_config=moe_config,
+            ),
+        ).apply(**common)
+
+        diff = calc_diff(out_deepgemm, out_triton)
+        assert diff < 1e-3, f"masked diff too large: {diff}"
+
+
+def test_deep_gemm_backend_is_opt_in():
+    """DEEP_GEMM must never be auto-selected, only via moe_backend='deep_gemm'."""
+    from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
+        _get_priority_backends,
+    )
+
+    moe_config = make_dummy_moe_config(
+        num_experts=8, experts_per_token=2, hidden_dim=2048, intermediate_size=1024
+    )
+    # Not in the auto-priority list.
+    assert UnquantizedMoeBackend.DEEP_GEMM not in _get_priority_backends(moe_config)
+    # Reachable only by explicit request.
+    assert map_unquantized_backend("deep_gemm") == UnquantizedMoeBackend.DEEP_GEMM
+    names = [c.__name__ for c in backend_to_kernel_cls(UnquantizedMoeBackend.DEEP_GEMM)]
+    assert names == ["DeepGemmBf16Experts", "DeepGemmBf16BatchedExperts"]

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -186,7 +186,8 @@ class KernelConfig:
 
     - "auto": Automatically select the best backend based on model and hardware
     - "triton": Use Triton-based fused MoE kernels
-    - "deep_gemm": Use DeepGEMM kernels (FP8 block-quantized only)
+    - "deep_gemm": Use DeepGEMM kernels (FP8 block-quantized, or
+      grouped BF16 GEMM for unquantized bf16 MoE)
     - "deep_gemm_mega_moe": Use DeepGEMM mega MoE kernels
     - "cutlass": Use vLLM CUTLASS kernels
     - "flashinfer_trtllm": Use FlashInfer with TRTLLM-GEN kernels

--- a/vllm/model_executor/layers/fused_moe/__init__.py
+++ b/vllm/model_executor/layers/fused_moe/__init__.py
@@ -97,6 +97,10 @@ if HAS_TRITON:
         CutlassExpertsFp8,
         CutlassExpertsW4A8Fp8,
     )
+    from vllm.model_executor.layers.fused_moe.experts.deep_gemm_bf16_moe import (  # noqa: E501
+        DeepGemmBf16BatchedExperts,
+        DeepGemmBf16Experts,
+    )
     from vllm.model_executor.layers.fused_moe.experts.deep_gemm_moe import (
         DeepGemmExperts,
     )
@@ -142,6 +146,8 @@ if HAS_TRITON:
         "TritonWNA16Experts",
         "BatchedTritonExperts",
         "DeepGemmExperts",
+        "DeepGemmBf16Experts",
+        "DeepGemmBf16BatchedExperts",
         "BatchedDeepGemmExperts",
         "TritonOrDeepGemmExperts",
         "XPUExperts",

--- a/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py
@@ -180,6 +180,7 @@ def _fwd_kernel_ep_scatter_2(
     topk_num: tl.constexpr,
     expert_map,
     HAS_EXPERT_MAP: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
     HIDDEN_SIZE: tl.constexpr,
     HIDDEN_SIZE_PAD: tl.constexpr,
     SCALE_HIDDEN_SIZE: tl.constexpr,
@@ -207,7 +208,7 @@ def _fwd_kernel_ep_scatter_2(
     for token_id in range(start_token_id, total_token_num, grid_num):
         to_copy = tl.load(recv_x + token_id * recv_x_stride0 + offset_in, mask=mask)
 
-        if PACK_UE8M0:
+        if HAS_SCALE and PACK_UE8M0:
             # Pack 4 UE8M0 bytes into one int32 (byte j = group 4*pk+j).
             base_s = recv_x_scale + token_id * recv_x_scale_stride0
             g0, g1 = offs_pk * 4, offs_pk * 4 + 1
@@ -230,7 +231,7 @@ def _fwd_kernel_ep_scatter_2(
                 | (b2.to(tl.int32) << 16)
                 | (b3.to(tl.int32) << 24)
             )
-        else:
+        elif HAS_SCALE:
             to_copy_s = tl.load(
                 recv_x_scale + token_id * recv_x_scale_stride0 + offset_in_s,
                 mask=mask_s,
@@ -257,13 +258,13 @@ def _fwd_kernel_ep_scatter_2(
                 output_tensor_scale_ptr = (
                     output_tensor_scale + dest_token_index * output_tensor_scale_stride0
                 )
-                if PACK_UE8M0:
+                if HAS_SCALE and PACK_UE8M0:
                     tl.store(
                         output_tensor_scale_ptr + offs_pk * output_tensor_scale_stride1,
                         packed_s,
                         mask=mask_pk,
                     )
-                else:
+                elif HAS_SCALE:
                     tl.store(
                         output_tensor_scale_ptr + offset_in_s, to_copy_s, mask=mask_s
                     )
@@ -272,13 +273,13 @@ def _fwd_kernel_ep_scatter_2(
 @torch.no_grad()
 def ep_scatter(
     recv_x: torch.Tensor,
-    recv_x_scale: torch.Tensor,
+    recv_x_scale: torch.Tensor | None,
     recv_topk: torch.Tensor,
     num_recv_tokens_per_expert: torch.Tensor,
     expert_map: torch.Tensor | None,
     expert_start_loc: torch.Tensor,
     output_tensor: torch.Tensor,
-    output_tensor_scale: torch.Tensor,
+    output_tensor_scale: torch.Tensor | None,
     m_indices: torch.Tensor,
     output_index: torch.Tensor,
     align_m: int = 128,
@@ -291,6 +292,13 @@ def ep_scatter(
     num_warps = 8
     num_experts = num_recv_tokens_per_expert.shape[0]
     hidden_size = recv_x.shape[1]
+    # BF16 (unquantized) permute has no activation scales; pass dummy tensors
+    # so the kernel's HAS_SCALE-guarded loads/stores stay valid but inert.
+    has_scale = recv_x_scale is not None
+    if not has_scale:
+        _dummy_scale = torch.empty((1, 1), device=recv_x.device, dtype=torch.float32)
+        recv_x_scale = _dummy_scale
+        output_tensor_scale = _dummy_scale
     # grid = (triton.cdiv(hidden_size, BLOCK_D), num_experts)
     grid = num_experts
 
@@ -298,7 +306,7 @@ def ep_scatter(
     assert expert_start_loc.shape[0] == num_experts
 
     # pack_ue8m0: scatter packs 4 UE8M0 bytes per int32; else copies scales as-is.
-    scale_hidden_size = hidden_size // BLOCK_D
+    scale_hidden_size = hidden_size // BLOCK_D if has_scale else 1
     scale_packed_size = (scale_hidden_size + 3) // 4 if pack_ue8m0 else 1
 
     _fwd_kernel_ep_scatter_1[(grid,)](
@@ -338,6 +346,7 @@ def ep_scatter(
         topk_num=recv_topk.shape[1],
         expert_map=expert_map,
         HAS_EXPERT_MAP=expert_map is not None,
+        HAS_SCALE=has_scale,
         num_warps=num_warps,
         HIDDEN_SIZE=hidden_size,
         HIDDEN_SIZE_PAD=triton.next_power_of_2(hidden_size),
@@ -456,7 +465,7 @@ def ep_gather(
 
 def deepgemm_moe_permute(
     aq: torch.Tensor,
-    aq_scale: torch.Tensor,
+    aq_scale: torch.Tensor | None,
     topk_ids: torch.Tensor,
     local_num_experts: int,
     expert_map: torch.Tensor | None,
@@ -493,9 +502,13 @@ def deepgemm_moe_permute(
 
     # uint8 UE8M0 (MXFP8) -> scatter packs into DeepGEMM's int32 MN-major
     # TMA-aligned layout; float32 (FP8/FP4) scattered row-major as-is.
-    pack_ue8m0 = aq_scale.dtype == torch.uint8
+    # BF16 (unquantized) has no scales: aq_scale is None -> no scale output.
+    has_scale = aq_scale is not None
+    pack_ue8m0 = has_scale and aq_scale.dtype == torch.uint8
     sf_k = H // block_k
-    if pack_ue8m0:
+    if not has_scale:
+        aq_scale_out = None
+    elif pack_ue8m0:
         packed_sf_k = (sf_k + 3) // 4
         tma_aligned_mn = round_up(M_sum, 4)
         aq_scale_out = torch.empty_strided(

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_bf16_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_bf16_moe.py
@@ -1,0 +1,434 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DeepGEMM BF16 grouped-GEMM MoE experts (unquantized).
+
+Mirrors the FP8 ``DeepGemmExperts`` (``deep_gemm_moe.py``) but runs entirely in
+bfloat16 using DeepGEMM's ``m_grouped_bf16_gemm_nt_contiguous`` grouped kernel,
+with a plain silu-and-mul in between (no quantization). This is the ``Standard``
+(contiguous) activation-format path, selected via the opt-in ``deep_gemm`` MoE
+backend for unquantized bf16 MoE weights.
+"""
+
+import torch
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.forward_context import (
+    get_forward_context,
+    is_forward_context_available,
+)
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEConfig,
+    FusedMoEParallelConfig,
+    FusedMoEQuantConfig,
+)
+from vllm.model_executor.layers.fused_moe.deep_gemm_utils import (
+    compute_aligned_M_and_alignment,
+    deepgemm_moe_permute,
+    deepgemm_unpermute_and_reduce,
+)
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceDelegate,
+    TopKWeightAndReduceNoOP,
+)
+from vllm.model_executor.layers.fused_moe.utils import _resize_cache
+from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
+from vllm.utils.deep_gemm import (
+    get_mk_alignment_for_contiguous_layout,
+    is_deep_gemm_bf16_grouped_supported,
+    is_deep_gemm_bf16_masked_supported,
+    m_grouped_bf16_gemm_nt_contiguous,
+    m_grouped_bf16_gemm_nt_masked,
+    mk_alignment_scope,
+)
+from vllm.utils.import_utils import has_deep_gemm
+from vllm.utils.math_utils import round_up
+
+logger = init_logger(__name__)
+
+
+def _valid_deep_gemm_bf16_shape(M: int, N: int, K: int) -> bool:
+    align = get_mk_alignment_for_contiguous_layout()[0]
+    return align <= M and N % align == 0 and K % align == 0
+
+
+def _valid_deep_gemm_bf16(
+    hidden_states: torch.Tensor, w1: torch.Tensor, w2: torch.Tensor
+) -> bool:
+    """Whether the bf16 DeepGEMM grouped contiguous kernel supports this problem.
+
+    All of M, N, K must be aligned to
+    ``get_mk_alignment_for_contiguous_layout()`` (128) and every tensor must be
+    contiguous bfloat16.
+    """
+    if not has_deep_gemm():
+        logger.debug_once("DeepGemm(bf16) disabled: deep_gemm not available.")
+        return False
+
+    M = hidden_states.size(0)
+    _, K, N = w2.size()
+    align = get_mk_alignment_for_contiguous_layout()[0]
+
+    if not _valid_deep_gemm_bf16_shape(M, N, K):
+        logger.debug_once(
+            "DeepGemm(bf16) disabled due to unaligned problem size. "
+            "M=%s N=%s K=%s (need M>=%s and N,K multiples of %s). "
+            "Falling back to the default backend.",
+            M,
+            N,
+            K,
+            align,
+            align,
+        )
+        return False
+
+    if (
+        hidden_states.dtype != torch.bfloat16
+        or w1.dtype != torch.bfloat16
+        or w2.dtype != torch.bfloat16
+    ):
+        logger.debug_once(
+            "DeepGemm(bf16) disabled: expected bfloat16 activations and weights. "
+            "hidden_states=%s w1=%s w2=%s",
+            hidden_states.dtype,
+            w1.dtype,
+            w2.dtype,
+        )
+        return False
+
+    if not (
+        hidden_states.is_contiguous() and w1.is_contiguous() and w2.is_contiguous()
+    ):
+        logger.debug_once(
+            "DeepGemm(bf16) disabled: activations or weights not contiguous."
+        )
+        return False
+
+    return True
+
+
+class DeepGemmBf16Experts(mk.FusedMoEExpertsModular):
+    """DeepGEMM-based fused MoE experts for unquantized bf16 weights.
+
+    Uses ``m_grouped_bf16_gemm_nt_contiguous`` for both grouped GEMMs, with a
+    plain silu-and-mul in between. This is the ``Standard`` (contiguous)
+    activation-format analogue of the FP8 :class:`DeepGemmExperts`.
+    """
+
+    def __init__(self, moe_config: FusedMoEConfig, quant_config: FusedMoEQuantConfig):
+        super().__init__(moe_config=moe_config, quant_config=quant_config)
+        # Unquantized only: no weight/activation scales, no block quant.
+        assert quant_config.quant_dtype is None, (
+            "DeepGemmBf16Experts only supports unquantized (bf16) weights."
+        )
+        assert not quant_config.per_act_token_quant
+        assert not quant_config.per_out_ch_quant
+
+    @staticmethod
+    def activation_format() -> mk.FusedMoEActivationFormat:
+        return mk.FusedMoEActivationFormat.Standard
+
+    @staticmethod
+    def _supports_current_device() -> bool:
+        return is_deep_gemm_bf16_grouped_supported()
+
+    @staticmethod
+    def _supports_no_act_and_mul() -> bool:
+        return False
+
+    @staticmethod
+    def _supports_quant_scheme(
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> bool:
+        # Unquantized bf16 only: the oracle passes (None, None) for this path.
+        return weight_key is None and activation_key is None
+
+    @staticmethod
+    def _supports_activation(activation: MoEActivation) -> bool:
+        # Phase 1: plain gated SiLU only (silu_and_mul). Other gated variants
+        # (e.g. swigluoai) can be added later.
+        return activation == MoEActivation.SILU
+
+    @staticmethod
+    def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
+        # Match DeepGemmExperts: exclude the FlashInfer NVL fused kernels.
+        return not (
+            moe_parallel_config.use_fi_nvl_two_sided_kernels
+            or moe_parallel_config.use_fi_nvl_one_sided_kernels
+        )
+
+    def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
+        return TopKWeightAndReduceNoOP()
+
+    def workspace_shapes(
+        self,
+        M: int,
+        N: int,
+        K: int,
+        topk: int,
+        global_num_experts: int,
+        local_num_experts: int,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        activation: MoEActivation,
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        block_m = get_mk_alignment_for_contiguous_layout()[0]
+        M_sum, align_used = compute_aligned_M_and_alignment(
+            M, topk, local_num_experts, block_m, expert_tokens_meta
+        )
+        assert M_sum % align_used == 0
+
+        activation_out_dim = self.adjust_N_for_activation(N, activation)
+        # workspace13 holds the permuted bf16 activations (M_sum, K) and later
+        # the post-activation input (M_sum, activation_out_dim); workspace2
+        # holds either grouped-GEMM output (M_sum, N) or (M_sum, K).
+        workspace1 = (M_sum, max(activation_out_dim, K))
+        workspace2 = (M_sum, max(N, K))
+        output = (M, K)
+        return (workspace1, workspace2, output)
+
+    def apply(
+        self,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        a2_scale: torch.Tensor | None,
+        workspace13: torch.Tensor,
+        workspace2: torch.Tensor,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        apply_router_weight_on_input: bool,
+    ):
+        # Unquantized bf16: no activation scales are produced by prepare/finalize.
+        assert a1q_scale is None
+        assert a2_scale is None
+
+        a1 = hidden_states
+        _, N, K = w1.size()
+
+        local_num_experts = w1.size(0)
+        if global_num_experts == -1:
+            global_num_experts = local_num_experts
+
+        assert w2.size(1) == K
+
+        M_sum, _ = compute_aligned_M_and_alignment(
+            M=topk_ids.size(0),
+            num_topk=topk_ids.size(1),
+            local_num_experts=local_num_experts,
+            alignment=get_mk_alignment_for_contiguous_layout()[0],
+            expert_tokens_meta=expert_tokens_meta,
+        )
+
+        # Permute bf16 activations into the per-expert contiguous layout and
+        # build m_indices (expert_ids). No scale scatter for bf16.
+        a1_perm = _resize_cache(workspace13, (M_sum, K))
+        a1, _, expert_ids, inv_perm, align_used = deepgemm_moe_permute(
+            aq=a1,
+            aq_scale=None,
+            topk_ids=topk_ids,
+            local_num_experts=local_num_experts,
+            expert_map=expert_map,
+            expert_tokens_meta=expert_tokens_meta,
+            aq_out=a1_perm,
+        )
+        assert a1.size(0) == M_sum
+
+        # Cap DG's BLOCK_M heuristic at the workspace's per-expert alignment;
+        # see DeepGemmExperts.apply for the IMA-under-cudagraph rationale.
+        with mk_alignment_scope(align_used):
+            mm1_out = _resize_cache(workspace2, (M_sum, N))
+            m_grouped_bf16_gemm_nt_contiguous(a1, w1, mm1_out, expert_ids)
+
+            activation_out_dim = self.adjust_N_for_activation(N, activation)
+            act_out = _resize_cache(workspace13, (M_sum, activation_out_dim))
+            # Plain (bf16) silu-and-mul; no requantization.
+            self.activation(activation, act_out, mm1_out.view(-1, N))
+
+            mm2_out = _resize_cache(workspace2, (M_sum, K))
+            m_grouped_bf16_gemm_nt_contiguous(act_out, w2, mm2_out, expert_ids)
+
+        if apply_router_weight_on_input:
+            topk_weights = torch.ones_like(topk_weights)
+
+        deepgemm_unpermute_and_reduce(
+            a=mm2_out,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            inv_perm=inv_perm,
+            expert_map=expert_map,
+            output=output,
+        )
+
+
+class DeepGemmBf16BatchedExperts(mk.FusedMoEExpertsModular):
+    """DeepGEMM bf16 masked grouped-GEMM experts (``BatchedExperts`` / EP format).
+
+    Unquantized bf16 analogue of ``BatchedDeepGemmExperts``: uses
+    ``m_grouped_bf16_gemm_nt_masked`` for both grouped GEMMs with a plain
+    silu-and-mul in between (no fp8 quantization). Selected via the opt-in
+    ``deep_gemm`` MoE backend when the layer runs in the batched activation
+    format (expert/data parallel with an all2all dispatcher).
+    """
+
+    def __init__(
+        self,
+        moe_config: FusedMoEConfig,
+        quant_config: FusedMoEQuantConfig,
+        max_num_tokens: int,
+        num_dispatchers: int,
+    ):
+        super().__init__(
+            moe_config=moe_config,
+            quant_config=quant_config,
+            max_num_tokens=max_num_tokens,
+            num_dispatchers=num_dispatchers,
+        )
+        assert quant_config.quant_dtype is None, (
+            "DeepGemmBf16BatchedExperts only supports unquantized (bf16) weights."
+        )
+
+    @staticmethod
+    def activation_format() -> mk.FusedMoEActivationFormat:
+        return mk.FusedMoEActivationFormat.BatchedExperts
+
+    @staticmethod
+    def _supports_current_device() -> bool:
+        return is_deep_gemm_bf16_masked_supported()
+
+    @staticmethod
+    def _supports_no_act_and_mul() -> bool:
+        return False
+
+    @staticmethod
+    def _supports_quant_scheme(
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> bool:
+        return weight_key is None and activation_key is None
+
+    @staticmethod
+    def _supports_activation(activation: MoEActivation) -> bool:
+        return activation == MoEActivation.SILU
+
+    @staticmethod
+    def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
+        return True
+
+    def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
+        # Let PrepareAndFinalize::finalize() decide the reduce impl.
+        return TopKWeightAndReduceDelegate()
+
+    def workspace_shapes(
+        self,
+        M: int,
+        N: int,
+        K: int,
+        topk: int,
+        global_num_experts: int,
+        local_num_experts: int,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        activation: MoEActivation,
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        assert self.num_dispatchers is not None
+        assert self.max_num_tokens is not None
+        num_dispatchers = self.num_dispatchers
+        num_experts = local_num_experts
+        max_num_tokens = M if self.max_num_tokens is None else self.max_num_tokens
+        activation_out_dim = self.adjust_N_for_activation(N, activation)
+        workspace13 = (num_experts, max_num_tokens * num_dispatchers, max(K, N))
+        workspace2 = (num_experts, max_num_tokens * num_dispatchers, activation_out_dim)
+        output = (num_experts, max_num_tokens * num_dispatchers, K)
+        return (workspace13, workspace2, output)
+
+    def estimate_expected_m(
+        self, global_num_experts: int, max_tokens_per_expert: int, topk: int
+    ) -> int:
+        dp_meta = (
+            get_forward_context().dp_metadata
+            if is_forward_context_available()
+            else None
+        )
+        if dp_meta is None:
+            logger.warning_once(
+                "DPMetadata unavailable. Defaulting expected_m to "
+                f"{max_tokens_per_expert}.",
+            )
+            return max_tokens_per_expert
+
+        total_num_tokens = dp_meta.num_tokens_across_dp_cpu.sum().item()
+        total_num_tokens_replicated = total_num_tokens * topk
+
+        # Assume even load balancing across experts.
+        assert global_num_experts != 0
+        estimate = round_up(int(total_num_tokens_replicated // global_num_experts), 16)
+        estimate = max(estimate, 16)
+        estimate = min(max_tokens_per_expert, estimate)
+        return estimate
+
+    def apply(
+        self,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        a2_scale: torch.Tensor | None,
+        workspace13: torch.Tensor,
+        workspace2: torch.Tensor,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        apply_router_weight_on_input: bool,
+    ):
+        # Unquantized bf16: no activation scales.
+        assert a1q_scale is None
+        assert a2_scale is None
+        assert expert_tokens_meta is not None
+        expert_num_tokens = expert_tokens_meta.expert_num_tokens
+
+        assert hidden_states.ndim == 3
+        a1 = hidden_states
+
+        E, max_num_tokens, N, K, _ = self.moe_problem_size(
+            hidden_states, w1, w2, topk_ids
+        )
+        assert w2.size(1) == K
+
+        workspace1 = _resize_cache(workspace13, (E, max_num_tokens, N))
+
+        expected_m = self.estimate_expected_m(
+            global_num_experts=global_num_experts,
+            max_tokens_per_expert=max_num_tokens,
+            topk=topk_ids.size(-1),
+        )
+
+        # GroupGemm-0: (E, T, K) x (E, N, K) -> (E, T, N)
+        m_grouped_bf16_gemm_nt_masked(a1, w1, workspace1, expert_num_tokens, expected_m)
+
+        # Plain (bf16) silu-and-mul over the full padded batch. Rows past
+        # expert_num_tokens are junk but are never read by the masked
+        # down-GEMM below (it is gated by expert_num_tokens), so no masked
+        # activation kernel is required.
+        activation_out_dim = self.adjust_N_for_activation(N, activation)
+        act_out = _resize_cache(workspace2, (E, max_num_tokens, activation_out_dim))
+        self.activation(
+            activation,
+            act_out.view(-1, activation_out_dim),
+            workspace1.view(-1, N),
+        )
+
+        # GroupGemm-1: (E, T, N//2) x (E, K, N//2) -> (E, T, K)
+        m_grouped_bf16_gemm_nt_masked(
+            act_out, w2, output, expert_num_tokens, expected_m
+        )

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -39,6 +39,7 @@ class UnquantizedMoeBackend(Enum):
     AITER = "ROCm AITER"
     TRITON = "TRITON"
     BATCHED_TRITON = "BATCHED_TRITON"
+    DEEP_GEMM = "DeepGEMM BF16"
     CPU = "CPU"
     XPU = "XPU"
     TPU = "TPU"
@@ -138,6 +139,14 @@ def backend_to_kernel_cls(
 
         return [BatchedTritonExperts]
 
+    elif backend == UnquantizedMoeBackend.DEEP_GEMM:
+        from vllm.model_executor.layers.fused_moe.experts.deep_gemm_bf16_moe import (  # noqa: E501
+            DeepGemmBf16BatchedExperts,
+            DeepGemmBf16Experts,
+        )
+
+        return [DeepGemmBf16Experts, DeepGemmBf16BatchedExperts]
+
     elif backend == UnquantizedMoeBackend.XPU:
         from vllm.model_executor.layers.fused_moe.experts.xpu_moe import XPUExperts
 
@@ -154,6 +163,7 @@ def map_unquantized_backend(runner_backend: MoEBackend) -> UnquantizedMoeBackend
         "flashinfer_trtllm": UnquantizedMoeBackend.FLASHINFER_TRTLLM,
         "flashinfer_cutlass": UnquantizedMoeBackend.FLASHINFER_CUTLASS,
         "aiter": UnquantizedMoeBackend.AITER,
+        "deep_gemm": UnquantizedMoeBackend.DEEP_GEMM,
     }
     if backend := mapping.get(runner_backend):
         return backend

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -99,6 +99,26 @@ def is_deep_gemm_supported() -> bool:
     return envs.VLLM_USE_DEEP_GEMM and has_deep_gemm() and is_supported_arch
 
 
+def is_deep_gemm_bf16_grouped_supported() -> bool:
+    """Return ``True`` if the DeepGEMM bf16 grouped contiguous GEMM kernel
+    is available on this platform (used by the bf16 MoE experts backend).
+    """
+    if not is_deep_gemm_supported():
+        return False
+    _lazy_init()
+    return _grouped_bf16_impl is not None
+
+
+def is_deep_gemm_bf16_masked_supported() -> bool:
+    """Return ``True`` if the DeepGEMM bf16 masked grouped GEMM kernel is
+    available (used by the batched/EP bf16 MoE experts backend).
+    """
+    if not is_deep_gemm_supported():
+        return False
+    _lazy_init()
+    return _grouped_bf16_masked_impl is not None
+
+
 @functools.cache
 def is_deep_gemm_e8m0_used() -> bool:
     """Return `True` if vLLM is configured to use DeepGEMM "
@@ -138,6 +158,9 @@ _fp8_gemm_nt_impl: Callable[..., Any] | None = None
 _fp8_einsum_impl: Callable[..., Any] | None = None
 _grouped_impl: Callable[..., Any] | None = None
 _grouped_masked_impl: Callable[..., Any] | None = None
+_grouped_bf16_impl: Callable[..., Any] | None = None
+_grouped_bf16_masked_impl: Callable[..., Any] | None = None
+_bf16_gemm_nt_impl: Callable[..., Any] | None = None
 _grouped_fp4_impl: Callable[..., Any] | None = None
 _fp8_fp4_mqa_logits_impl: Callable[..., Any] | None = None
 _fp8_fp4_paged_mqa_logits_impl: Callable[..., Any] | None = None
@@ -213,6 +236,7 @@ def _lazy_init() -> None:
     global _cublaslt_gemm_nt_impl
     global _fp8_gemm_nt_impl, _fp8_einsum_impl
     global _grouped_impl, _grouped_masked_impl, _grouped_fp4_impl
+    global _grouped_bf16_impl, _grouped_bf16_masked_impl, _bf16_gemm_nt_impl
     global _fp8_fp4_mqa_logits_impl, _fp8_fp4_paged_mqa_logits_impl
     global _get_paged_mqa_logits_metadata_impl
     global _tf32_hc_prenorm_gemm_impl
@@ -230,6 +254,9 @@ def _lazy_init() -> None:
         or _fp8_einsum_impl is not None
         or _grouped_impl is not None
         or _grouped_masked_impl is not None
+        or _grouped_bf16_impl is not None
+        or _grouped_bf16_masked_impl is not None
+        or _bf16_gemm_nt_impl is not None
         or _grouped_fp4_impl is not None
         or _fp8_fp4_mqa_logits_impl is not None
         or _fp8_fp4_paged_mqa_logits_impl is not None
@@ -265,6 +292,9 @@ def _lazy_init() -> None:
     _fp8_einsum_impl = getattr(_dg, "fp8_einsum", None)
     _grouped_impl = getattr(_dg, "m_grouped_fp8_gemm_nt_contiguous", None)
     _grouped_masked_impl = getattr(_dg, "fp8_m_grouped_gemm_nt_masked", None)
+    _grouped_bf16_impl = getattr(_dg, "m_grouped_bf16_gemm_nt_contiguous", None)
+    _grouped_bf16_masked_impl = getattr(_dg, "m_grouped_bf16_gemm_nt_masked", None)
+    _bf16_gemm_nt_impl = getattr(_dg, "bf16_gemm_nt", None)
     _grouped_fp4_impl = getattr(_dg, "m_grouped_fp8_fp4_gemm_nt_contiguous", None)
     # DeepGEMM exposes fp8_fp4_*_mqa_logits as the canonical symbols that
     # handle both the FP8 and FP4 Q/K paths via a tuple-typed `q`.
@@ -467,6 +497,31 @@ def m_grouped_fp8_gemm_nt_contiguous(*args, **kwargs):
     return _grouped_impl(
         *args, disable_ue8m0_cast=not is_deep_gemm_e8m0_used(), **kwargs
     )
+
+
+def m_grouped_bf16_gemm_nt_contiguous(*args, **kwargs):
+    # BF16 grouped GEMM: activations/weights are plain bf16 tensors, so there
+    # are no block scales and no ue8m0 cast to disable (unlike the fp8 path).
+    _lazy_init()
+    if _grouped_bf16_impl is None:
+        return _missing(*args, **kwargs)
+    return _grouped_bf16_impl(*args, **kwargs)
+
+
+def m_grouped_bf16_gemm_nt_masked(*args, **kwargs):
+    # BF16 masked grouped GEMM (batched/EP layout): plain bf16 tensors, no
+    # scales and no ue8m0 cast (unlike fp8_m_grouped_gemm_nt_masked).
+    _lazy_init()
+    if _grouped_bf16_masked_impl is None:
+        return _missing(*args, **kwargs)
+    return _grouped_bf16_masked_impl(*args, **kwargs)
+
+
+def bf16_gemm_nt(*args, **kwargs):
+    _lazy_init()
+    if _bf16_gemm_nt_impl is None:
+        return _missing(*args, **kwargs)
+    return _bf16_gemm_nt_impl(*args, **kwargs)
 
 
 def m_grouped_fp8_fp4_gemm_nt_contiguous(*args, **kwargs):
@@ -725,6 +780,11 @@ __all__ = [
     "fp8_gemm_nt",
     "fp8_einsum",
     "m_grouped_fp8_gemm_nt_contiguous",
+    "m_grouped_bf16_gemm_nt_contiguous",
+    "m_grouped_bf16_gemm_nt_masked",
+    "bf16_gemm_nt",
+    "is_deep_gemm_bf16_grouped_supported",
+    "is_deep_gemm_bf16_masked_supported",
     "m_grouped_fp8_fp4_gemm_nt_contiguous",
     "fp8_m_grouped_gemm_nt_masked",
     "fp8_fp4_mqa_logits",


### PR DESCRIPTION
## Purpose

vLLM integrates DeepGEMM's **FP8** grouped-GEMM kernels for fused MoE, but not
its **BF16** grouped-GEMM kernels. This PR adds an **opt-in** DeepGEMM bf16 MoE
backend for **unquantized bf16** MoE weights, covering both activation formats:

- **Contiguous** (`Standard` format, TP / single-GPU) — `DeepGemmBf16Experts`,
  mirroring the FP8 `DeepGemmExperts`.
- **Masked** (`BatchedExperts` format, EP + DeepEP low-latency) —
  `DeepGemmBf16BatchedExperts`, mirroring `BatchedDeepGemmExperts`.

It is the bf16 counterpart of the existing FP8 DeepGEMM path and matches the
approach SGLang uses for bf16 MoE (`m_grouped_bf16_gemm_nt_{contiguous,masked}`
+ a separate silu-and-mul).

Resolves #49271.

## Design

A DeepGEMM bf16 MoE forward is the FP8 flow with quantization removed:
`permute → m_grouped_bf16_gemm_nt_contiguous → silu_and_mul →
m_grouped_bf16_gemm_nt_contiguous → unpermute/reduce` (contiguous), and the
masked analogue for the batched/EP path. Workspaces stay bf16 (no fp8 view), so
it is strictly simpler than the FP8 class. The one new piece of glue is a
scale-free permute: a compile-time `HAS_SCALE` guard threaded through the
existing `ep_scatter` Triton kernel (FP8 codegen unchanged), so the bf16 path
skips activation-scale scatter.

## Changes

- `vllm/utils/deep_gemm.py`: expose `m_grouped_bf16_gemm_nt_contiguous`,
  `m_grouped_bf16_gemm_nt_masked`, `bf16_gemm_nt` wrappers (no
  `disable_ue8m0_cast` — bf16 has no block scales) + `is_deep_gemm_bf16_*_supported()`.
- `deep_gemm_utils.py`: `HAS_SCALE` guard in the scatter kernel;
  `ep_scatter` / `deepgemm_moe_permute` accept `None` scales (scale-free permute).
- `experts/deep_gemm_bf16_moe.py` (new): `DeepGemmBf16Experts` (Standard) and
  `DeepGemmBf16BatchedExperts` (BatchedExperts).
- `oracle/unquantized.py`: new `DEEP_GEMM` backend, returned only via
  `--moe-backend deep_gemm`; **not** added to the auto-priority list.
- `config/kernel.py`: doc note that `deep_gemm` now also covers unquantized bf16.
- `tests/kernels/moe/test_deepgemm_bf16_moe.py` (new).

Opt-in only: `--moe-backend deep_gemm`. Default behavior is unchanged.

## Test

`tests/kernels/moe/test_deepgemm_bf16_moe.py` (single-GPU, passes on H200):
contiguous `DeepGemmBf16Experts` vs Triton `fused_experts`, masked
`DeepGemmBf16BatchedExperts` vs `BatchedTritonExperts` (both `calc_diff < 1e-3`),
and an oracle test asserting `DEEP_GEMM` is never auto-selected but is chosen on
`--moe-backend deep_gemm`.

End-to-end accuracy (Qwen3.5-35B-A3B, bf16, gsm8k, 5-shot, 200 samples):
| backend | flexible | strict |
|---|---|---|
| deep_gemm (masked, DP8/EP8) | 0.89 | 0.88 |
| BatchedTriton (masked, DP8/EP8) | 0.87 | 0.865 |

## Benchmarks (8×H200, Hopper; informational, `--load-format` real weights)

**Raw grouped-GEMM microbench** (single H200, 397B MoE shapes, kernel-only):
DeepGEMM `m_grouped_bf16_gemm_nt_contiguous` is **1.3–1.9× faster** than
FlashInfer's grouped GEMM (`SegmentGEMMWrapper`, cutlass).

**End-to-end serving** (Qwen3.5-35B-A3B, DP8/EP8, random 1024→256, 800 prompts):
| backend | all2all / format | total tok/s | TPOT |
|---|---|---|---|
| flashinfer_cutlass | ag_rs / Standard | 136,884 | 19.9 ms |
| **deep_gemm (this PR, contiguous)** | ag_rs / Standard | 105,125 | 25.5 ms |
| **deep_gemm (this PR, masked)** | DeepEP-LL / batched | 61,260 | 23.6 ms |
| BatchedTriton | DeepEP-LL / batched | 18,072 | 81.2 ms |

Takeaways (honest):
- In the **DeepEP low-latency / batched** path (where FlashInfer's fused MoE
  cannot run), deep_gemm masked is **~3.4× faster than BatchedTriton**.
- With the **same all2all** (ag_rs, Standard), FlashInfer's fused CUTLASS MoE is
  **~1.30× faster end-to-end** than the (unfused) DeepGEMM grouped-GEMM +
  permute path, despite DeepGEMM's raw matmul being faster — the gap is fusion
  (FlashInfer fuses gate_up+act+down+scatter into one kernel).
- On single node, DeepEP-LL is slower than ag_rs (it targets multi-node
  low-latency decode); large-scale multi-node EP is not benchmarked here.

So this is **not** a single-node speed win over FlashInfer. It adds the
DeepGEMM bf16 path for parity/ecosystem, covers the batched/DeepEP-LL EP regime
FlashInfer can't serve, and is fully opt-in.

<details><summary>Environment</summary>
8×H200, CUDA 13, torch 2.11 cu130, vendored `vllm.third_party.deep_gemm`.
</details>