### PR TITLE
[XPU][Bugfix] Fall back to native mem_get_info when sysman getMemoryInfo reports free=0

### DIFF
--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -94,6 +94,19 @@ def get_mem_info_wrapper(
     # Call the underlying C++ implementation
     free, total = torch.ops._C_cache_ops.getMemoryInfo(device)
 
+    # Some Level-Zero sysman builds report free=0 (memory telemetry
+    # unavailable) even though the device has free memory. Fall back to the
+    # native query, which reads mem info directly instead of via sysman.
+    if free == 0 and total > 0:
+        native_free, native_total = torch.xpu.mem_get_info(device)
+        if native_free > 0:
+            logger.warning_once(
+                "torch.ops._C_cache_ops.getMemoryInfo reported free=0 "
+                "(likely missing Level-Zero sysman memory telemetry on this "
+                "driver); falling back to torch.xpu.mem_get_info."
+            )
+            return native_free, native_total
+
     return free, total
 
 


### PR DESCRIPTION
## Purpose

My Intel Arc B-series/Battlemage read free=0 here. Claude traced this to a slightly earlier library version. This fix expands the test to cover this version as well without losing coverage.

### Details

This repo's docker/Dockerfile.xpu pins intel-opencl-icd/libze-intel-gpu1 at 26.18.38308.1, which presumably works, but is only available directly from Github releases -- not yet on Intel's apt GPU repo (my version, still at 26.14.37833.4).

torch.accelerator.get_memory_info on XPU is monkeypatched (#47134) to call torch.ops._C_cache_ops.getMemoryInfo, reading free/total memory via Level-Zero sysman telemetry. #47134 did this because torch.xpu.mem_get_info itself had a real bug on Battlemage after a NEO/compute-runtime update (see vllm-xpu-kernels tests/test_get_memory_info.py, which documents the issue).

Trouble is, my version doesn't populate memory telemetry from sysman, even setting ZES_ENABLE_SYSMAN=1 before process start made no difference (still free=0).  That op unconditionally returns free=0 for a device with memory available, violating its own `free > 0` test invariant. Every XPUWorker then fails `init_device()` with "Free memory ... is less than desired GPU memory utilization", no matter how low `gpu_memory_utilization` is set -- XPU is simply unusable on affected driver builds.

Torch worked around sysman's nonsense independently. Torch's libc10_xpu.so resolves free-memory queries to SYCL's ext::intel::info::device::free_memory — a DPC++ compiler-runtime code path, with zero zes* (Level-Zero sysman) symbols anywhere in its XPU libraries. It never touches sysman at all. vLLM's custom op is the one going through compute-runtime's sysman layer directly, and that's the specific layer that's behind on my system. It's not a missing config on this system, it's memory telemetry that's unimplemented/unpopulated for this GPU in compute-runtime 26.14.37833.4, not fixed until the 26.18.38308.1 build the Dockerfile pins.

Reverting to torch.xpu.mem_get_info() unconditionally would regress the Battlemage issue #47134 fixed. So this falls back to it only when the sysman-backed op reports a free=0/total>0 split, which is never a legitimate reading for a device with memory installed.

This PR includes AI-assisted changes (Claude Code) for root-cause diagnosis and the fallback implementation. I reviewed the change, built vLLM from source on the affected hardware (Intel Arc B-series/Battlemage), reproduced the failure, and verified the fix end-to-end. At no point did Claude suggest I should update libze...

## Test Plan

  - `ruff check` / `ruff format --check` on the changed file.
  - Built vLLM from source for XPU on bare metal (Ubuntu/Mint 24.04 base, oneAPI 2025.3, torch 2.12.0+xpu) with the affected driver stack.
  - Before: `LLM(model="facebook/opt-125m", ...)` fails at `init_device()` with `ValueError: Free memory on device xpu:0 (0.0/30.3 GiB) ...` at every `gpu_memory_utilization` setting. 
  - After: same call succeeds; engine starts and `llm.generate(...)` produces output on the GPU.

## Test Result

Before:
ValueError: Free memory on device xpu:0 (0.0/30.3 GiB) on startup is less
than desired GPU memory utilization (0.5, 15.15 GiB). Decrease GPU memory
utilization or reduce GPU memory used by other processes.

After:
PROMPT: The capital of France is
OUTPUT:  getting its final proposal from a country's mayor who wants to create a permanent terminal hotel as
(opt-125m is a tiny/weak base model -- output quality isn't the point, successful engine startup and generation on XPU is.)

Branch: https://github.com/frobnitzem/vllm/pull/new/fix-xpu-sysman-memory-info-fallback

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

