### PR TITLE
[Rust Frontend] Allow media placeholder target to be a list of tokens

### DIFF
--- a/rust/src/chat/src/multimodal.rs
+++ b/rust/src/chat/src/multimodal.rs
@@ -152,8 +152,8 @@ impl ResolvedMultimodalSpec {
 #[derive(Debug, Clone)]
 struct ResolvedPlaceholder {
     token: String,
-    /// The token ID emitted for `token` in the rendered prompt.
-    marker_token_id: u32,
+    /// The token IDs emitted for `token` in the rendered prompt.
+    marker_token_ids: Vec<u32>,
     /// The model-declared embed token ID marked in `is_embed` masks.
     embed_token_id: u32,
 }
@@ -166,18 +166,21 @@ impl ResolvedPlaceholder {
     ) -> Result<Self> {
         let metadata = context.metadata();
         let token = raw.placeholder_token_for(&metadata, modality)?;
-        // This is the rendered prompt marker, so resolve it from the token
-        // string itself. Do not use `ModelProcessorSpec::placeholder_token_id_for()`:
-        // for some specs that ID is the replacement vision/patch token,
-        // not necessarily the token ID of the placeholder token.
-        let marker_token_id = context.tokenizer().token_to_id(&token).ok_or_else(|| {
-            multimodal!("placeholder token `{token}` is not in the tokenizer vocabulary")
-        })?;
+        // This is the rendered prompt marker. It may be ordinary text that
+        // encodes to multiple tokens, while `placeholder_token_id_for()` is
+        // the model's replacement vision/patch token ID.
+        let marker_token_ids = context
+            .tokenizer()
+            .token_to_id(&token)
+            .map(|token_id| vec![token_id])
+            .or_else(|| context.tokenizer().encode(&token, false).ok())
+            .filter(|token_ids| !token_ids.is_empty())
+            .ok_or_else(|| multimodal!("placeholder `{token}` could not be tokenized"))?;
         let embed_token_id = raw.placeholder_token_id_for(&metadata, modality)? as u32;
 
         Ok(Self {
             token,
-            marker_token_id,
+            marker_token_ids,
             embed_token_id,
         })
     }
@@ -409,10 +412,12 @@ impl MultimodalModelInfo {
         });
 
         let video = resolve_placeholder(Modality::Video).and_then(|placeholder| {
-            // Placeholder expansion attributes markers to modalities by token
-            // ID, so a marker shared with the image modality is ambiguous.
-            let image_marker = image.as_ref().map(|image| image.placeholder.marker_token_id);
-            if image_marker == Some(placeholder.marker_token_id) {
+            // Placeholder expansion attributes marker sequences to modalities,
+            // so a marker shared with the image modality is ambiguous.
+            let image_marker = image
+                .as_ref()
+                .map(|image| &image.placeholder.marker_token_ids);
+            if image_marker == Some(&placeholder.marker_token_ids) {
                 warn!(
                     model_id = context.model_id,
                     token = placeholder.token,
@@ -808,8 +813,8 @@ mod tests {
             Some("<|video_pad|>")
         );
         assert_ne!(
-            info.image.as_ref().unwrap().placeholder.marker_token_id,
-            info.video.as_ref().unwrap().placeholder.marker_token_id,
+            info.image.as_ref().unwrap().placeholder.marker_token_ids,
+            info.video.as_ref().unwrap().placeholder.marker_token_ids,
         );
     }
 

--- a/rust/src/chat/src/multimodal.rs
+++ b/rust/src/chat/src/multimodal.rs
@@ -495,11 +495,7 @@ pub(crate) async fn finalize_rendered_prompt(
     }
     let info = info.ok_or(Error::UnsupportedMultimodalRenderer)?;
     let mut prompt_token_ids = match rendered.prompt {
-        Prompt::Text(prompt) => info
-            .context
-            .tokenizer()
-            .encode(&prompt, request.add_special_tokens)
-            .map_err(|error| multimodal!("{error}"))?,
+        Prompt::Text(prompt) => info.tokenize_prompt(&prompt, request.add_special_tokens)?,
         Prompt::TokenIds(token_ids) => token_ids,
     };
     let media_parts = extract_media_parts(request)?;
@@ -573,6 +569,74 @@ fn input_audio_data_url(data: &str, format: Option<&str>) -> Result<String> {
 }
 
 impl MultimodalModelInfo {
+    fn tokenize_prompt(&self, prompt: &str, add_special_tokens: bool) -> Result<Vec<u32>> {
+        let tokenizer = self.context.tokenizer();
+        let placeholders = [
+            self.image.as_ref().map(|support| &support.placeholder),
+            self.video.as_ref().map(|support| &support.placeholder),
+            self.audio.as_ref().map(|support| &support.placeholder),
+        ]
+        .into_iter()
+        .flatten()
+        .filter(|placeholder| placeholder.marker_token_ids.len() > 1)
+        .collect::<Vec<_>>();
+
+        if placeholders.is_empty() {
+            return tokenizer
+                .encode(prompt, add_special_tokens)
+                .map_err(|error| multimodal!("{error}"));
+        }
+
+        let mut token_ids = Vec::new();
+        let mut cursor = 0;
+        while cursor < prompt.len() {
+            let next = placeholders
+                .iter()
+                .filter_map(|placeholder| {
+                    prompt[cursor..]
+                        .find(&placeholder.token)
+                        .map(|offset| (cursor + offset, *placeholder))
+                })
+                .min_by_key(|(offset, _)| *offset);
+            let Some((offset, placeholder)) = next else {
+                break;
+            };
+
+            token_ids.extend(
+                tokenizer
+                    .encode(&prompt[cursor..offset], false)
+                    .map_err(|error| multimodal!("{error}"))?,
+            );
+            token_ids.extend_from_slice(&placeholder.marker_token_ids);
+            cursor = offset + placeholder.token.len();
+        }
+        token_ids.extend(
+            tokenizer
+                .encode(&prompt[cursor..], false)
+                .map_err(|error| multimodal!("{error}"))?,
+        );
+
+        if !add_special_tokens {
+            return Ok(token_ids);
+        }
+
+        let plain = tokenizer.encode(prompt, false).map_err(|error| multimodal!("{error}"))?;
+        let with_special =
+            tokenizer.encode(prompt, true).map_err(|error| multimodal!("{error}"))?;
+        let Some(content_offset) =
+            with_special.windows(plain.len()).position(|window| window == plain)
+        else {
+            return Ok(with_special);
+        };
+
+        let mut wrapped =
+            Vec::with_capacity(with_special.len().saturating_sub(plain.len()) + token_ids.len());
+        wrapped.extend_from_slice(&with_special[..content_offset]);
+        wrapped.extend(token_ids);
+        wrapped.extend_from_slice(&with_special[content_offset + plain.len()..]);
+        Ok(wrapped)
+    }
+
     /// Run media fetch, per-modality preprocessing, prompt expansion, and
     /// feature build.
     ///

--- a/rust/src/chat/src/multimodal/audio.rs
+++ b/rust/src/chat/src/multimodal/audio.rs
@@ -161,7 +161,10 @@ mod tests {
             info.placeholder_token(Modality::Audio),
             Some("<|content_audio_input|>")
         );
-        assert_eq!(support.placeholder.marker_token_id, INKLING_AUDIO_MARKER_ID);
+        assert_eq!(
+            support.placeholder.marker_token_ids,
+            vec![INKLING_AUDIO_MARKER_ID]
+        );
         assert_eq!(
             support.placeholder.embed_token_id,
             INKLING_AUDIO_EMBED_ID as u32
@@ -195,7 +198,7 @@ mod tests {
             info.placeholder_token(Modality::Audio),
             Some("<|audio_pad|>")
         );
-        assert_eq!(support.placeholder.marker_token_id, AUDIO_PAD_ID);
+        assert_eq!(support.placeholder.marker_token_ids, vec![AUDIO_PAD_ID]);
         assert_eq!(support.placeholder.embed_token_id, AUDIO_PAD_ID);
         assert!(matches!(
             support.spec.field_layouts.encoder_input,

--- a/rust/src/chat/src/multimodal/expand.rs
+++ b/rust/src/chat/src/multimodal/expand.rs
@@ -16,9 +16,9 @@ use crate::error::{Error, Result, bail_multimodal};
 /// expansion.
 struct ExpansionLane<'a> {
     modality: Modality,
-    marker_token_id: u32,
+    marker_token_ids: &'a [u32],
     embed_token_id: u32,
-    placeholder_token: String,
+    placeholder_token: &'a str,
     replacements: VecDeque<&'a PromptReplacement>,
 }
 
@@ -30,9 +30,9 @@ impl<'a> ExpansionLane<'a> {
 
         Some(Self {
             modality: media.modality,
-            marker_token_id: media.placeholder.marker_token_id,
+            marker_token_ids: &media.placeholder.marker_token_ids,
             embed_token_id: media.placeholder.embed_token_id,
-            placeholder_token: media.placeholder.token.clone(),
+            placeholder_token: &media.placeholder.token,
             replacements: media.replacements.iter().collect(),
         })
     }
@@ -56,26 +56,31 @@ pub(super) fn expand_prompt_token_ids(
         return Ok(HashMap::new());
     }
 
-    let replacement_growth = lanes
-        .iter()
-        .flat_map(|lane| lane.replacements.iter())
-        .fold(0usize, |total, replacement| {
-            total.saturating_add(replacement.tokens.len().saturating_sub(1))
-        });
+    let replacement_growth = lanes.iter().fold(0usize, |total, lane| {
+        lane.replacements.iter().fold(total, |total, replacement| {
+            total.saturating_add(
+                replacement.tokens.len().saturating_sub(lane.marker_token_ids.len()),
+            )
+        })
+    });
     let expanded_len = prompt_token_ids.len().saturating_add(replacement_growth);
 
     let mut expanded = Vec::with_capacity(expanded_len);
     let mut ranges = HashMap::<Modality, Vec<PlaceholderRange>>::new();
 
-    for &token in prompt_token_ids.iter() {
-        let lane = lanes
-            .iter_mut()
-            .find(|lane| lane.marker_token_id == token && !lane.replacements.is_empty());
+    let mut prompt_index = 0;
+    while prompt_index < prompt_token_ids.len() {
+        let lane = lanes.iter_mut().find(|lane| {
+            !lane.replacements.is_empty()
+                && prompt_token_ids[prompt_index..].starts_with(lane.marker_token_ids)
+        });
         let Some(lane) = lane else {
-            expanded.push(token);
+            expanded.push(prompt_token_ids[prompt_index]);
+            prompt_index += 1;
             continue;
         };
 
+        prompt_index += lane.marker_token_ids.len();
         let replacement = lane.replacements.pop_front().expect("lane queue is non-empty");
         debug_assert_eq!(replacement.modality, lane.modality);
         if replacement.tokens.is_empty() {
@@ -145,12 +150,43 @@ mod tests {
             modality,
             placeholder: ResolvedPlaceholder {
                 token: placeholder_token.to_string(),
-                marker_token_id,
+                marker_token_ids: vec![marker_token_id],
                 embed_token_id,
             },
             replacements,
             items: Vec::new(),
         }
+    }
+
+    #[test]
+    fn expand_prompt_tokens_matches_multi_token_placeholder() {
+        let marker_token_ids = vec![40, 41, 42];
+        let replacement = PromptReplacement::repeated(
+            Modality::Image,
+            "<image-placeholder>",
+            QWEN3_IMAGE_PAD_ID as TokenId,
+            2,
+        );
+        let prepared = vec![PreparedMedia {
+            modality: Modality::Image,
+            placeholder: ResolvedPlaceholder {
+                token: "<image-placeholder>".to_string(),
+                marker_token_ids: marker_token_ids.clone(),
+                embed_token_id: QWEN3_IMAGE_PAD_ID,
+            },
+            replacements: vec![replacement],
+            items: Vec::new(),
+        }];
+        let mut prompt_token_ids = vec![1, 40, 41, 42, 2];
+
+        let ranges = expand_prompt_token_ids(&mut prompt_token_ids, &prepared).unwrap();
+
+        assert_eq!(
+            prompt_token_ids,
+            vec![1, QWEN3_IMAGE_PAD_ID, QWEN3_IMAGE_PAD_ID, 2]
+        );
+        assert_eq!(ranges[&Modality::Image][0].offset, 1);
+        assert_eq!(ranges[&Modality::Image][0].length, 2);
     }
 
     /// Llama4 image prepared media: the `<|image|>` marker expands to


### PR DESCRIPTION



## Purpose
- For some models, their image placeholder like `<image>` will be tokenized as `'<' + 'image' + '>'`, which is corresponded to three tokens, so we can't assume image placeholder a single token in frontend.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

