### PR TITLE
[Frontend][Responses] Apply reasoning.context on the input path

### DIFF
--- a/tests/entrypoints/openai/responses/test_responses_utils.py
+++ b/tests/entrypoints/openai/responses/test_responses_utils.py
@@ -18,9 +18,11 @@ from openai.types.responses.response_reasoning_item import (
 
 from vllm.entrypoints.openai.responses.utils import (
     _construct_message_from_response_item,
+    _is_reasoning_item,
     construct_chat_messages_with_tool_call,
     construct_input_messages,
     convert_tool_responses_to_completions_format,
+    filter_reasoning_by_context,
     should_continue_final_message,
 )
 
@@ -921,3 +923,92 @@ class TestConstructInputMessagesInstructionsLeak:
         assert len(msgs) == 2
         assert msgs[0] == {"role": "system", "content": "be helpful"}
         assert msgs[1] == {"role": "user", "content": "hello"}
+
+
+def make_user_message(text: str) -> dict:
+    return {"role": "user", "type": "message", "content": text}
+
+
+def make_assistant_dict_message(text: str) -> dict:
+    # Assistant messages also carry type=="message"; used to check the turn
+    # boundary keys on role, not type.
+    return {"role": "assistant", "type": "message", "content": text}
+
+
+class TestFilterReasoningByContext:
+    """`reasoning.context` handling on the Responses input path.
+
+    `current_turn` drops reasoning carried in from earlier turns (so it is not
+    re-rendered into the prompt and re-verbalized by reasoning parsers), while
+    keeping the active turn's reasoning. `all_turns`/`auto`/`None` preserve all
+    reasoning (current behavior).
+    """
+
+    def _items(self):
+        # turn 1: user -> reasoning -> answer ; turn 2: user -> reasoning
+        return [
+            make_user_message("q1"),
+            make_reasoning_item(content_text="prior thinking", id="r1"),
+            make_output_message("a1", id="m1"),
+            make_user_message("q2"),
+            make_reasoning_item(content_text="current thinking", id="r2"),
+        ]
+
+    def test_current_turn_drops_prior_reasoning_keeps_active(self):
+        out = filter_reasoning_by_context(self._items(), "current_turn")
+        ids = [getattr(i, "id", None) for i in out if _is_reasoning_item(i)]
+        assert ids == ["r2"], "prior-turn reasoning dropped, current-turn kept"
+        # non-reasoning items are untouched
+        assert len(out) == 4
+
+    @pytest.mark.parametrize("ctx", ["all_turns", "auto", None])
+    def test_non_current_turn_preserves_all_reasoning(self, ctx):
+        out = filter_reasoning_by_context(self._items(), ctx)
+        assert out == self._items()
+
+    def test_current_turn_with_no_user_message_keeps_all(self):
+        # No user boundary -> everything is "after" -1 -> all kept.
+        items = [make_reasoning_item(content_text="t", id="r1")]
+        assert filter_reasoning_by_context(items, "current_turn") == items
+
+    def test_current_turn_dict_form_reasoning(self):
+        items = [
+            {"type": "reasoning", "id": "r1", "content": []},
+            make_user_message("q"),
+            {"type": "reasoning", "id": "r2", "content": []},
+        ]
+        out = filter_reasoning_by_context(items, "current_turn")
+        assert [i["id"] for i in out if _is_reasoning_item(i)] == ["r2"]
+
+    def test_current_turn_dict_assistant_message_is_not_a_boundary(self):
+        # Assistant/system messages also have type=="message"; the turn boundary
+        # must key on role, not type, or current-turn reasoning after an
+        # assistant dict message would be wrongly dropped.
+        items = [
+            make_user_message("q1"),
+            make_reasoning_item(content_text="prior", id="r1"),
+            make_user_message("q2"),
+            make_reasoning_item(content_text="cur1", id="r2"),
+            make_assistant_dict_message("partial"),
+            make_reasoning_item(content_text="cur2", id="r3"),
+        ]
+        out = filter_reasoning_by_context(items, "current_turn")
+        ids = [getattr(i, "id", None) for i in out if _is_reasoning_item(i)]
+        assert ids == ["r2", "r3"], "both current-turn reasoning items kept"
+
+    def test_end_to_end_no_reasoning_rendered_for_dropped_item(self):
+        # Through construct_input_messages, the dropped prior reasoning must not
+        # surface as a `reasoning` assistant field in the rendered messages.
+        msgs = construct_input_messages(
+            request_input=self._items(),
+            reasoning_context="current_turn",
+        )
+        reasonings = [m.get("reasoning") for m in msgs if isinstance(m, dict)]
+        assert "prior thinking" not in reasonings
+        assert "current thinking" in reasonings
+
+    def test_end_to_end_default_renders_all_reasoning(self):
+        msgs = construct_input_messages(request_input=self._items())
+        reasonings = [m.get("reasoning") for m in msgs if isinstance(m, dict)]
+        assert "prior thinking" in reasonings
+        assert "current thinking" in reasonings

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -285,6 +285,23 @@ class ResponsesRequest(OpenAIBaseModel):
     )
     # --8<-- [end:responses-extra-params]
 
+    @property
+    def reasoning_context(self) -> str | None:
+        """The ``reasoning.context`` value (``auto``/``current_turn``/
+        ``all_turns``), if the client set it.
+
+        The OpenAI ``Reasoning`` type does not yet declare ``context`` as a
+        formal field, so it arrives as an extra field; read it defensively so
+        this works whether or not the SDK adds it later.
+        """
+        reasoning = self.reasoning
+        if reasoning is None:
+            return None
+        context = getattr(reasoning, "context", None)
+        if context is None and reasoning.model_extra is not None:
+            context = reasoning.model_extra.get("context")
+        return context
+
     def build_chat_params(
         self,
         default_template: str | None,

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -617,6 +617,7 @@ class OpenAIServingResponses(GenerateBaseServing):
             request_input=request.input,
             prev_msg=self.msg_store.get(prev_response.id) if prev_response else None,
             prev_response_output=prev_response.output if prev_response else None,
+            reasoning_context=request.reasoning_context,
         )
         chat_template_kwargs = self._effective_chat_template_kwargs(request)
         _, engine_inputs = await self.online_renderer.preprocess_chat(

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -155,12 +155,70 @@ def should_continue_final_message(
     return False
 
 
+def _is_reasoning_item(item: ResponseInputOutputItem) -> bool:
+    """True if a response input item is a reasoning item (typed or dict form)."""
+    if isinstance(item, ResponseReasoningItem):
+        return True
+    return isinstance(item, dict) and item.get("type") == "reasoning"
+
+
+def _is_user_message(item: ResponseInputOutputItem) -> bool:
+    """True if a response input item is a user-role message.
+
+    Marks a turn boundary in the flat `input` list: reasoning items after the
+    last user message belong to the current turn, earlier ones to prior turns.
+    """
+    # Key on role only: assistant/system messages also carry type=="message",
+    # so a type-based check would misplace the boundary.
+    if isinstance(item, dict):
+        return item.get("role") == "user"
+    return getattr(item, "role", None) == "user"
+
+
+def filter_reasoning_by_context(
+    input_items: list[ResponseInputOutputItem],
+    reasoning_context: str | None,
+) -> list[ResponseInputOutputItem]:
+    """Apply ``reasoning.context`` to the input items before rendering.
+
+    ``current_turn`` keeps only reasoning from the active (final) turn and drops
+    reasoning items carried in from earlier turns, so they are not re-rendered
+    into the prompt (and re-verbalized by reasoning parsers). ``all_turns``,
+    ``auto`` and ``None`` preserve every reasoning item (current behavior).
+
+    The turn boundary is the last user message in ``input_items``: reasoning
+    after it is current-turn; reasoning before it is prior-turn.
+
+    Args:
+        input_items: The request's ``input`` items, in order.
+        reasoning_context: The ``reasoning.context`` value, if any.
+
+    Returns:
+        The input items with prior-turn reasoning removed when
+        ``reasoning_context == "current_turn"``; otherwise the input unchanged.
+    """
+    if reasoning_context != "current_turn":
+        return input_items
+
+    last_user_idx = -1
+    for idx, item in enumerate(input_items):
+        if _is_user_message(item):
+            last_user_idx = idx
+
+    return [
+        item
+        for idx, item in enumerate(input_items)
+        if idx > last_user_idx or not _is_reasoning_item(item)
+    ]
+
+
 def construct_input_messages(
     *,
     request_instructions: str | None = None,
     request_input: str | list[ResponseInputOutputItem],
     prev_msg: list[ChatCompletionMessageParam] | None = None,
     prev_response_output: list[ResponseOutputItem] | None = None,
+    reasoning_context: str | None = None,
 ):
     messages: list[ChatCompletionMessageParam] = []
     if request_instructions:
@@ -195,6 +253,7 @@ def construct_input_messages(
     if isinstance(request_input, str):
         messages.append({"role": "user", "content": request_input})
     else:
+        request_input = filter_reasoning_by_context(request_input, reasoning_context)
         input_messages = construct_chat_messages_with_tool_call(request_input)
         messages.extend(input_messages)
     return messages


### PR DESCRIPTION
Fixes #49281.

## Issue

`/v1/responses` accepts `reasoning.context` (`auto`/`current_turn`/`all_turns`) but never reads it on input. Prior-turn `reasoning` items in the request `input` are always re-rendered into the next prompt, and reasoning parsers (e.g. Qwen3) re-emit them as `<think>...</think>` on the visible `output_text` channel.

## Fix

Honor `reasoning.context` in `construct_input_messages`:
- `current_turn` — drop reasoning items from earlier turns (before the last user message); keep the active turn's.
- `all_turns` / `auto` / unset — unchanged (no-op default).

`context` is read defensively from the reasoning object's extra fields, since the openai `Reasoning` type doesn't declare it yet. Applied only to client-supplied `input` (`_make_request`); the `previous_response_id` path already skips reasoning, and intra-request tool-loop reasoning is legitimately current-turn so it's left intact.

## Tests

- `pytest tests/entrypoints/openai/responses/test_responses_utils.py` — **50 passed** (9 new + 41 existing), covering `current_turn` drops prior / keeps active, `all_turns`/`auto`/`None` preserve, dict-form items, no-user-message, and that an assistant `type=="message"` isn't a turn boundary.
- Live (GPU, `vllm/vllm-openai:latest`, Qwen3-30B-A3B-FP8): on the real input path, `current_turn` drops the prior reasoning item from the rendered input; `all_turns`/unset keep it.
- `ruff check` + `ruff format --check` clean.

---
AI-assisted (Claude); reviewed line-by-line and tested as above. No open PR addresses `reasoning.context` on the Responses input path (#35907 is Harmony-only). Open question for reviewers: the `current_turn` turn boundary (last user message) and whether intra-request tool-loop reasoning should also be covered.
