### PR TITLE
[Bug Fix] Indexer Cache need indexer num equal to attention num

### DIFF
--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -5,7 +5,7 @@ DeepseekV4 MLA Attention Layer
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import torch
@@ -63,6 +63,93 @@ from vllm.v1.kv_cache_interface import (
 )
 
 logger = init_logger(__name__)
+
+
+def compute_dsv4_index_cache_skip_flags(
+    compress_ratios: Sequence[int],
+    num_hidden_layers: int,
+    *,
+    index_topk_freq: int = 1,
+    index_topk_pattern: str | Sequence[str] | None = None,
+    index_skip_topk_offset: int = 2,
+    local_start_layer: int = 0,
+    local_end_layer: int | None = None,
+) -> tuple[bool, ...]:
+    """Compute DeepSeek V4 C4-layer IndexCache skip decisions.
+
+    The returned tuple is indexed by global decoder layer id. Only backbone C4
+    layers (``compress_ratio == 4``) may be marked as skipped. Pipeline stages
+    have rank-local top-k buffers, so the first local C4 layer is always forced
+    to compute top-k.
+    """
+    if num_hidden_layers < 0:
+        raise ValueError(
+            f"num_hidden_layers must be non-negative, got {num_hidden_layers}"
+        )
+
+    ratios = list(compress_ratios[:num_hidden_layers])
+    if len(ratios) != num_hidden_layers:
+        raise ValueError(
+            "compress_ratios must contain at least num_hidden_layers entries, "
+            f"got {len(compress_ratios)} for {num_hidden_layers} layers"
+        )
+
+    if local_end_layer is None:
+        local_end_layer = num_hidden_layers
+    if not (0 <= local_start_layer <= local_end_layer <= num_hidden_layers):
+        raise ValueError(
+            "local layer range must satisfy "
+            "0 <= local_start_layer <= local_end_layer <= num_hidden_layers, "
+            f"got [{local_start_layer}, {local_end_layer}) for "
+            f"{num_hidden_layers} layers"
+        )
+
+    skip_flags = [False] * num_hidden_layers
+    c4_layer_ids = [layer_id for layer_id, ratio in enumerate(ratios) if ratio == 4]
+    if not c4_layer_ids:
+        return tuple(skip_flags)
+
+    if index_topk_pattern is not None:
+        pattern = list(index_topk_pattern)
+        invalid_values = set(pattern) - {"F", "S"}
+        if invalid_values:
+            raise ValueError(
+                "index_topk_pattern only supports 'F' for full indexer "
+                f"layers and 'S' for shared layers, got {sorted(invalid_values)}"
+            )
+        if len(pattern) != len(c4_layer_ids):
+            raise ValueError(
+                "index_topk_pattern length must match the number of C4 layers "
+                f"({len(c4_layer_ids)}), got {len(pattern)}"
+            )
+        if pattern[0] != "F":
+            raise ValueError("index_topk_pattern must start with 'F'")
+        for c4_rank, layer_id in enumerate(c4_layer_ids):
+            skip_flags[layer_id] = pattern[c4_rank] == "S"
+    else:
+        if index_topk_freq <= 0:
+            raise ValueError(
+                f"index_topk_freq must be positive, got {index_topk_freq}"
+            )
+        if index_skip_topk_offset < 1:
+            raise ValueError(
+                "index_skip_topk_offset must be at least 1, got "
+                f"{index_skip_topk_offset}"
+            )
+        for c4_rank, layer_id in enumerate(c4_layer_ids):
+            skip_flags[layer_id] = (
+                max(c4_rank - index_skip_topk_offset + 1, 0) % index_topk_freq != 0
+            )
+
+    local_c4_layer_ids = [
+        layer_id
+        for layer_id in c4_layer_ids
+        if local_start_layer <= layer_id < local_end_layer
+    ]
+    if local_c4_layer_ids:
+        skip_flags[local_c4_layer_ids[0]] = False
+
+    return tuple(skip_flags)
 
 
 def _resolve_dsv4_kv_cache_dtype(
@@ -160,6 +247,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         prefix: str,
         topk_indices_buffer: torch.Tensor | None = None,
         aux_stream_list: list[torch.cuda.Stream] | None = None,
+        skip_topk: bool = False,
     ) -> None:
         super().__init__()
         config = vllm_config.model_config.hf_config
@@ -188,6 +276,12 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
             self.compress_ratio = max(1, config.compress_ratios[layer_id])
         else:
             self.compress_ratio = 1
+        self.skip_topk = skip_topk
+        if self.skip_topk:
+            if self.compress_ratio != 4:
+                raise ValueError("skip_topk is only valid for C4/indexer layers")
+            if topk_indices_buffer is None:
+                raise ValueError("skip_topk requires topk_indices_buffer")
         self.eps = config.rms_norm_eps
         self.scale = self.head_dim**-0.5
 
@@ -394,7 +488,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
 
             aux_fns[0] = compressor_kv_score
 
-        if self.indexer is not None:
+        if self.indexer is not None and not self.skip_topk:
             indexer = self.indexer
 
             def indexer_weights_proj() -> torch.Tensor:
@@ -436,8 +530,8 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         qr: torch.Tensor,
         kv: torch.Tensor,
         kv_score: torch.Tensor,
-        indexer_kv_score: torch.Tensor,
-        indexer_weights: torch.Tensor,
+        indexer_kv_score: torch.Tensor | None,
+        indexer_weights: torch.Tensor | None,
         positions: torch.Tensor,
         out: torch.Tensor,  # [num_tokens, padded_heads, head_dim], written in place
     ) -> None:
@@ -448,9 +542,11 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         # on the default stream so q stays on its consumer stream (forward_mqa
         # downstream reads q on default). Indexer/compressor go on aux for
         # overlap with default's GEMM + cache write.
-        if self.indexer is not None:
+        if self.indexer is not None and not self.skip_topk:
             aux_streams = self.aux_stream_list
             indexer = self.indexer
+            assert indexer_kv_score is not None
+            assert indexer_weights is not None
             # Local ref so the closure keeps a non-None type for mypy.
             assert self.compressor is not None
             compressor = self.compressor

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -6,6 +6,7 @@ DeepseekV4 MLA Attention Layer
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
+from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import torch
@@ -363,6 +364,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
                 compress_ratio=self.compress_ratio,
                 prefix=f"{prefix}.indexer",
                 aux_stream=indexer_aux_stream,
+                skip_topk=self.skip_topk,
             )
 
         # Will be None on ROCm for now.
@@ -774,6 +776,7 @@ class DeepseekV4Indexer(nn.Module):
         compress_ratio: int = 1,
         prefix: str = "",
         aux_stream: torch.cuda.Stream | None = None,
+        skip_topk: bool = False,
     ):
         super().__init__()
         self.vllm_config = vllm_config
@@ -787,26 +790,33 @@ class DeepseekV4Indexer(nn.Module):
         self.q_lora_rank = q_lora_rank  # 1536
         self.compress_ratio = compress_ratio
         self.use_fp4_kv = self.vllm_config.attention_config.use_fp4_indexer_cache
+        # When skip_top=True this indexer exists only to produce the C4I
+        # KVCacheSpec (via self.k_cache); its GEMM weights and kernel are
+        # never invoked, so they are allocated on the meta device and the
+        # indexer_op handle is skipped.
+        self.skip_topk = skip_topk
         logger.info_once(
             "Using %s indexer cache for Lightning Indexer.",
             "MXFP4" if self.use_fp4_kv else "FP8",
         )
 
         # no tensor parallel, just replicated
-        self.wq_b = ReplicatedLinear(
-            self.q_lora_rank,
-            self.head_dim * self.n_head,
-            bias=False,
-            quant_config=quant_config,
-            prefix=f"{prefix}.wq_b",
-        )
-        self.weights_proj = ReplicatedLinear(
-            hidden_size,
-            self.n_head,
-            bias=False,
-            quant_config=None,
-            prefix=f"{prefix}.weights_proj",
-        )
+        gemm_ctx = torch.device("meta") if self.skip_topk else nullcontext()
+        with gemm_ctx:
+            self.wq_b = ReplicatedLinear(
+                self.q_lora_rank,
+                self.head_dim * self.n_head,
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.wq_b",
+            )
+            self.weights_proj = ReplicatedLinear(
+                hidden_size,
+                self.n_head,
+                bias=False,
+                quant_config=None,
+                prefix=f"{prefix}.weights_proj",
+            )
         self.softmax_scale = self.head_dim**-0.5
 
         self.scale_fmt = "ue8m0"
@@ -835,33 +845,53 @@ class DeepseekV4Indexer(nn.Module):
             cache_config=cache_config,
             compress_ratio=self.compress_ratio,
         )
-        self.compressor = DeepseekCompressor(
-            vllm_config=vllm_config,
-            compress_ratio=self.compress_ratio,
-            hidden_size=hidden_size,
-            head_dim=self.head_dim,
-            rotate=True,
-            prefix=f"{prefix}.compressor",
-            k_cache_prefix=self.k_cache.prefix,
-            use_fp4_cache=self.use_fp4_kv,
-        )
+        if self.skip_topk:
+            # Compressor's KV projection is never used on skip layers; build it
+            # on meta to avoid allocating indexer-side GEMM weights
+            with torch.devcie('meta'):
+                self.compressor = DeepseekCompressor(
+                    vllm_config=vllm_config,
+                    compress_ratio=self.compress_ratio,
+                    hidden_size=hidden_size,
+                    head_dim=self.head_dim,
+                    rotate=True,
+                    prefix=f"{prefix}.compressor",
+                    k_cache_prefix=self.k_cache.prefix,
+                    use_fp4_cache=self.use_fp4_kv,
+                )
+            self.indexer_op = None
+        else:
+            self.compressor = DeepseekCompressor(
+                vllm_config=vllm_config,
+                compress_ratio=self.compress_ratio,
+                hidden_size=hidden_size,
+                head_dim=self.head_dim,
+                rotate=True,
+                prefix=f"{prefix}.compressor",
+                k_cache_prefix=self.k_cache.prefix,
+                use_fp4_cache=self.use_fp4_kv,
+            )
 
-        self.indexer_op = SparseAttnIndexer(
-            self.k_cache,
-            self.quant_block_size,
-            self.scale_fmt,
-            self.topk_tokens,
-            self.head_dim,
-            self.max_model_len,
-            self.max_total_seq_len,
-            self.topk_indices_buffer,
-            skip_k_cache_insert=True,
-            use_fp4_cache=self.use_fp4_kv,
-        )
+            self.indexer_op = SparseAttnIndexer(
+                self.k_cache,
+                self.quant_block_size,
+                self.scale_fmt,
+                self.topk_tokens,
+                self.head_dim,
+                self.max_model_len,
+                self.max_total_seq_len,
+                self.topk_indices_buffer,
+                skip_k_cache_insert=True,
+                use_fp4_cache=self.use_fp4_kv,
+            )
 
         # None on ROCm — maybe_execute_in_parallel falls back to sequential.
-        self.aux_stream = aux_stream
+        self.aux_stream = None if self.skip_topk else aux_stream
+        # ln_events must keep 4 entries (fan-out + 3 aux done) regardless of
+        # skip_topk: execute_in_parallel always slices [0] and [1:4].
         self.ln_events: list[torch.cuda.Event] = [
+            torch.cuda.Event(),
+            torch.cuda.Event(),
             torch.cuda.Event(),
             torch.cuda.Event(),
         ]

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -17,6 +17,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
 )
 from vllm.distributed.eplb.eplb_state import EplbLayerState
+from vllm.distributed.utils import get_pp_indices
 from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.model_executor.kernels.mhc.tilelang import (
     hc_head_fused_kernel_tilelang,
@@ -65,7 +66,10 @@ from vllm.model_executor.models.utils import (
     maybe_prefix,
 )
 from vllm.model_executor.utils import set_weight_attrs
-from vllm.models.deepseek_v4.attention import DeepseekV4Attention
+from vllm.models.deepseek_v4.attention import (
+    DeepseekV4Attention,
+    compute_dsv4_index_cache_skip_flags,
+)
 from vllm.models.deepseek_v4.nvidia.flashinfer_sparse import (
     DeepseekV4FlashInferMLAAttention,
     DeepseekV4FlashInferSM120Attention,
@@ -791,6 +795,36 @@ def _select_dsv4_attn_cls(vllm_config: VllmConfig) -> type[DeepseekV4Attention]:
     return DeepseekV4FlashMLAAttention
 
 
+def _validate_dsv4_index_cache_platform(skip_topk: bool) -> None:
+    if not skip_topk:
+        return
+    device_capability = current_platform.get_device_capability()
+    if device_capability is None or device_capability.major != 9:
+        raise NotImplementedError(
+            "DeepSeek V4 IndexCache is currently supported only on Hopper "
+            "(SM90). Set index_topk_freq=1 or run on H100/H200."
+        )
+
+
+def _validate_dsv4_index_cache_ubatching(skip_topk: bool, vllm_config) -> None:
+    if not skip_topk or not vllm_config.parallel_config.use_ubatching:
+        return
+    raise NotImplementedError(
+        "DeepSeek V4 IndexCache does not support ubatching yet because "
+        "skipped layers reuse a shared topk_indices_buffer. Set "
+        "index_topk_freq=1 or disable DBO/ubatching."
+    )
+
+
+def _is_dsv4_skipped_indexer_weight(
+    weight_name: str, skipped_layer_ids: frozenset[int]
+) -> bool:
+    return any(
+        f"layers.{layer_id}.attn.indexer." in weight_name
+        for layer_id in skipped_layer_ids
+    )
+
+
 class DeepseekV4DecoderLayer(nn.Module):
     def __init__(
         self,
@@ -798,6 +832,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         prefix,
         topk_indices_buffer: torch.Tensor | None = None,
         aux_stream_list: list[torch.cuda.Stream] | None = None,
+        skip_topk: bool = False,
     ):
         super().__init__()
 
@@ -810,6 +845,7 @@ class DeepseekV4DecoderLayer(nn.Module):
             prefix=f"{prefix}.attn",
             topk_indices_buffer=topk_indices_buffer,
             aux_stream_list=aux_stream_list,
+            skip_topk=skip_topk,
         )
         self.ffn = DeepseekV4MoE(vllm_config, prefix=f"{prefix}.ffn")
 
@@ -993,6 +1029,31 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             config.index_topk,
             dtype=torch.int32,
         )
+        start_layer, end_layer = get_pp_indices(
+            config.num_hidden_layers,
+            get_pp_group().rank_in_group,
+            get_pp_group().world_size,
+        )
+        index_cache_skip_flags = compute_dsv4_index_cache_skip_flags(
+            config.compress_ratios,
+            config.num_hidden_layers,
+            index_topk_freq=getattr(config, "index_topk_freq", 1),
+            index_topk_pattern=getattr(config, "index_topk_pattern", None),
+            index_skip_topk_offset=getattr(config, "index_skip_topk_offset", 2),
+            local_start_layer=start_layer,
+            local_end_layer=end_layer,
+        )
+        local_index_cache_skip_flags = index_cache_skip_flags[start_layer:end_layer]
+        local_uses_index_cache = any(local_index_cache_skip_flags)
+        _validate_dsv4_index_cache_platform(local_uses_index_cache)
+        _validate_dsv4_index_cache_ubatching(local_uses_index_cache, vllm_config)
+        self.index_cache_skipped_layer_ids = frozenset(
+            layer_id
+            for layer_id, skip in enumerate(
+                index_cache_skip_flags[start_layer:end_layer], start=start_layer
+            )
+            if skip
+        )
 
         if get_pp_group().is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
@@ -1011,6 +1072,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 prefix=prefix,
                 topk_indices_buffer=self.topk_indices_buffer,
                 aux_stream_list=aux_stream_list,
+                skip_topk=index_cache_skip_flags[extract_layer_index(prefix)],
             ),
             prefix=f"{prefix}.layers",
         )
@@ -1467,6 +1529,13 @@ class DeepseekV4ForCausalLM(
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self, skip_substrs=["mtp."])
+        # skipped_layer_ids = self.model.index_cache_skipped_layer_ids
+        # if skipped_layer_ids:
+        #     weights = (
+        #         (name, weight)
+        #         for name, weight in weights
+        #         if not _is_dsv4_skipped_indexer_weight(name, skipped_layer_ids)
+        #     )
         loaded_params = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
         self.model.finalize_mega_moe_weights()
         self.model.finalize_mhc_broadcast_weights()

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1529,13 +1529,16 @@ class DeepseekV4ForCausalLM(
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self, skip_substrs=["mtp."])
-        # skipped_layer_ids = self.model.index_cache_skipped_layer_ids
-        # if skipped_layer_ids:
-        #     weights = (
-        #         (name, weight)
-        #         for name, weight in weights
-        #         if not _is_dsv4_skipped_indexer_weight(name, skipped_layer_ids)
-        #     )
+        # skip_topk layers carry their indexer GEMM weights (wq_b /
+        # weights_proj / compressor KV projection) on the meta device; the
+        # checkpoint still ships them, so filter them out before loading.
+        skipped_layer_ids = self.model.index_cache_skipped_layer_ids
+        if skipped_layer_ids:
+            weights = (
+                (name, weight)
+                for name, weight in weights
+                if not _is_dsv4_skipped_indexer_weight(name, skipped_layer_ids)
+            )
         loaded_params = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
         self.model.finalize_mega_moe_weights()
         self.model.finalize_mhc_broadcast_weights()


### PR DESCRIPTION
Thank you for the submission by [wangyicong52](https://github.com/vllm-project/vllm/pull/49085), but I found a bug during use: the inconsistency between the number of C4I and C4A leads to an error in `vllm/v1/core/kv_utils.py`, `assert len(set(len(layers)) for layers in layers_per_size.values())) == 1`. 

Therefore, the current solution is to create an indexer without any restrictions

Follow-up work: We plan to create the skip's indexer on `torch.device('meta')` to save "dummy" GPU memory
