### PR TITLE
[Bugfix][Attention] Keep model-dtype query for FlashInfer builders serving non-causal attention

### DIFF
--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -847,6 +847,12 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         if self.vllm_config.attention_config.disable_flashinfer_q_quantization:
             return self.model_config.dtype
 
+        # Builders serving non-causal layers (e.g. DFlash drafters) route
+        # prefill to FlashInfer's fa2 path, which cannot consume FP8 queries;
+        # keep the model dtype for Q there.
+        if self.vllm_config.attention_config.use_non_causal:
+            return self.model_config.dtype
+
         # self.cache_dtype is resolved per KV-cache group: it is "auto" when
         # this group is unquantized (e.g. --kv-cache-dtype-skip-layers), even
         # if cache_config requests a quantized dtype globally.
@@ -1597,6 +1603,7 @@ class FlashInferImpl(AttentionImpl):
             and current_platform.is_device_capability_family(100)
             and vllm_config is not None
             and not vllm_config.attention_config.disable_flashinfer_q_quantization
+            and not vllm_config.attention_config.use_non_causal
         )
         self.bmm1_scale: float | None = None
         self.bmm2_scale: float | None = None


### PR DESCRIPTION
## Purpose

Fix serving an NVFP4 target with a DFlash drafter on SM100, which fails at startup with `fp8 tensor core is not supported in fa2 backend` because the ModelOpt checkpoint forces FP8 KV cache. Related: #48234, #46105.

- Keep queries in model dtype when a FlashInfer builder serves non-causal layers: trtllm-gen is causal-only, so those layers route to fa2, which cannot consume FP8 queries
- Causal FP8 paths (target model, MTP) unchanged; relax once FlashInfer's non-causal spec-decode kernels land (#46105)

## Test Plan

- Serve `nvidia/Qwen3.6-27B-NVFP4` + `z-lab/Qwen3.6-27B-DFlash` on B200 with `VLLM_USE_V2_MODEL_RUNNER=1`, 8 concurrent chat streams for 5 minutes
- Serve the same target without spec decode as a causal regression check

## Test Result

- Before: startup assert regardless of `--kv-cache-dtype`
- After: 116/116 requests OK, 0 errors, spec decoding active, ~382 tok/s
- Causal-only serving: unchanged
