### PR TITLE
[Misc][Docs] Fix XPU compute-runtime driver link version mismatch

### DIFF
--- a/docs/getting_started/installation/gpu.xpu.inc.md
+++ b/docs/getting_started/installation/gpu.xpu.inc.md
@@ -27,7 +27,7 @@ Currently, there are no pre-built XPU wheels.
 
 - First, install required [driver](https://dgpu-docs.intel.com/driver/installation.html#installing-gpu-drivers).
 - Second, install Python packages for vLLM XPU backend building (Intel OneAPI dependencies are installed automatically as part of `torch-xpu`, see [PyTorch XPU get started](https://docs.pytorch.org/docs/stable/notes/get_start_xpu.html)):
-- Start from vllm-xpu-kernels v0.1.10, we recommend user upgrade driver to [compute runtime 26.18](https://github.com/intel/compute-runtime/releases/tag/26.14.37833.4) release, to avoid potential compatibility issue.
+- Start from vllm-xpu-kernels v0.1.10, we recommend user upgrade driver to [compute runtime 26.18](https://github.com/intel/compute-runtime/releases/tag/26.18.38308.1) release, to avoid potential compatibility issue.
 
 ```bash
 git clone https://github.com/vllm-project/vllm.git


### PR DESCRIPTION
## Purpose

The XPU installation guide (`docs/getting_started/installation/gpu.xpu.inc.md`) links the text "compute runtime 26.18" to release tag `26.14.37833.4`, which matches neither the link text nor the driver version actually installed in `docker/Dockerfile.xpu` (`26.18.38308.1`).

This updates the link to point at the matching `26.18.38308.1` release so users install the recommended driver version.

## Test Plan

Docs-only change; verified the link target matches the compute-runtime version installed in `docker/Dockerfile.xpu`.

Made with [Cursor](https://cursor.com)