### PR TITLE
[mooncake] support CUSTOM_MEM_POOL in vllm

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -229,6 +229,8 @@ class _FakeKVTransferConfig:
 class _FakeModelConfig:
     model = "test-model"
     use_mla = False
+    enable_sleep_mode = False
+    enable_cumem_allocator = False
 
     def get_num_layers(self, parallel_config) -> int:
         return 1
@@ -323,6 +325,64 @@ def _patch_worker_runtime(
     monkeypatch.setattr(worker, "get_dcp_group", lambda: dcp_group)
     monkeypatch.setattr(worker, "get_ip", lambda: local_ip)
     monkeypatch.setattr(worker, "LookupKeyServer", MagicMock())
+
+
+def test_create_mem_pool_returns_none_when_unconfigured():
+    assert worker.MooncakeStoreWorker._create_mem_pool({}, _FakeModelConfig()) is None
+
+
+def test_create_mem_pool_rejects_unknown_pool():
+    with pytest.raises(
+        ValueError,
+        match="Unsupported custom_mem_pool='UNKNOWN'",
+    ):
+        worker.MooncakeStoreWorker._create_mem_pool(
+            {"custom_mem_pool": "unknown"}, _FakeModelConfig()
+        )
+
+
+@pytest.mark.parametrize(
+    "conflicting_option", ["enable_sleep_mode", "enable_cumem_allocator"]
+)
+def test_create_mem_pool_rejects_cumem_conflicts(conflicting_option):
+    model_config = _FakeModelConfig()
+    setattr(model_config, conflicting_option, True)
+
+    with pytest.raises(ValueError, match="custom_mem_pool is incompatible"):
+        worker.MooncakeStoreWorker._create_mem_pool(
+            {"custom_mem_pool": "NVLINK"}, model_config
+        )
+
+
+@pytest.mark.parametrize(
+    ("pool_type", "allocator_name"),
+    [("nvlink", "NVLinkAllocator"), ("barex", "BarexAllocator")],
+)
+def test_create_mem_pool_uses_mooncake_allocator(
+    monkeypatch, pool_type, allocator_name
+):
+    allocator_cls = MagicMock()
+    allocator = allocator_cls.get_allocator.return_value
+    allocator_module = types.ModuleType("mooncake.allocator")
+    setattr(allocator_module, allocator_name, allocator_cls)
+    mooncake_module = types.ModuleType("mooncake")
+    mooncake_module.allocator = allocator_module  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "mooncake", mooncake_module)
+    monkeypatch.setitem(sys.modules, "mooncake.allocator", allocator_module)
+
+    monkeypatch.setattr(torch.accelerator, "current_device_index", lambda: 2)
+    mem_pool = MagicMock()
+    mem_pool_ctor = MagicMock(return_value=mem_pool)
+    monkeypatch.setattr(torch.cuda, "MemPool", mem_pool_ctor)
+
+    result = worker.MooncakeStoreWorker._create_mem_pool(
+        {"custom_mem_pool": pool_type}, _FakeModelConfig()
+    )
+
+    assert result is mem_pool
+    allocator_cls.get_allocator.assert_called_once_with(torch.device("cuda", 2))
+    allocator.allocator.assert_called_once_with()
+    mem_pool_ctor.assert_called_once_with(allocator.allocator.return_value)
 
 
 def test_pool_key_to_string_without_prefix_is_unchanged():

--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -177,6 +177,33 @@ def mc() -> MultiConnector:
     return mc
 
 
+def test_multi_connector_mem_pool_context_none(mc: MultiConnector):
+    assert mc.get_mem_pool_context() is None
+
+
+def test_multi_connector_forwards_mem_pool_context(mc: MultiConnector):
+    context = MagicMock()
+    provider = MagicMock()
+    provider.get_mem_pool_context.return_value = context
+    mc._connectors = [mc._connectors[0], provider]
+
+    assert mc.get_mem_pool_context() is context
+    provider.get_mem_pool_context.assert_called_once_with()
+
+
+def test_multi_connector_rejects_multiple_mem_pool_contexts(mc: MultiConnector):
+    providers = [MagicMock(), MagicMock()]
+    for provider in providers:
+        provider.get_mem_pool_context.return_value = MagicMock()
+    mc._connectors = providers
+
+    with pytest.raises(
+        ValueError,
+        match="Multiple connectors provide a KV cache memory pool",
+    ):
+        mc.get_mem_pool_context()
+
+
 # Helper function to compare directories recursively
 def _compare_directories(dir1: Path, dir2: Path) -> bool:
     """Compares two directories recursively for identical content."""

--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -64,6 +64,7 @@ class MockConnector(KVConnectorBase_V1):
         # Override just build_kv_connector_stats
         mock.build_kv_connector_stats = cls.build_kv_connector_stats
         mock.get_kv_connector_stats.return_value = None
+        mock.get_mem_pool_context.return_value = None
         return mock
 
     @classmethod
@@ -183,7 +184,7 @@ def test_multi_connector_mem_pool_context_none(mc: MultiConnector):
 
 def test_multi_connector_forwards_mem_pool_context(mc: MultiConnector):
     context = MagicMock()
-    provider = MagicMock()
+    provider = MagicMock(spec_set=KVConnectorBase_V1)
     provider.get_mem_pool_context.return_value = context
     mc._connectors = [mc._connectors[0], provider]
 
@@ -192,7 +193,10 @@ def test_multi_connector_forwards_mem_pool_context(mc: MultiConnector):
 
 
 def test_multi_connector_rejects_multiple_mem_pool_contexts(mc: MultiConnector):
-    providers = [MagicMock(), MagicMock()]
+    providers = [
+        MagicMock(spec_set=KVConnectorBase_V1),
+        MagicMock(spec_set=KVConnectorBase_V1),
+    ]
     for provider in providers:
         provider.get_mem_pool_context.return_value = MagicMock()
     mc._connectors = providers

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -43,6 +43,7 @@ The class provides the following primitives:
 import enum
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
+from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING, Any, Literal
 
 import torch
@@ -220,6 +221,13 @@ class KVConnectorBase_V1(ABC):
     # ==============================
     # Worker-side methods
     # ==============================
+
+    def get_mem_pool_context(self) -> AbstractContextManager | None:
+        """Return a custom KV cache allocation context, if configured.
+
+        Returning None uses the engine's default memory pool.
+        """
+        return None
 
     def bind_connector_metadata(self, connector_metadata: KVConnectorMetadata) -> None:
         """Set the connector metadata from the scheduler.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
@@ -12,6 +12,7 @@ enabling prefix caching via hash-based deduplication.
 """
 
 from collections.abc import Iterable
+from contextlib import AbstractContextManager
 from typing import Any
 
 import torch
@@ -257,6 +258,17 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
     # ============================================================
     # Worker-side methods
     # ============================================================
+
+    def get_mem_pool_context(self) -> AbstractContextManager | None:
+        """Return a context manager for the custom MemPool, or None.
+
+        Called by the Worker before ``initialize_kv_cache`` so that KV
+        cache is allocated from the Mooncake-managed pool when
+        ``custom_mem_pool`` is set in ``kv_connector_extra_config``.
+        """
+        if self.connector_worker is None:
+            return None
+        return self.connector_worker.get_mem_pool_context()
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         assert self.connector_worker is not None

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
@@ -12,6 +12,7 @@ enabling prefix caching via hash-based deduplication.
 """
 
 from collections.abc import Iterable
+from contextlib import AbstractContextManager
 from typing import Any
 
 import torch
@@ -274,6 +275,17 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
     # ============================================================
     # Worker-side methods
     # ============================================================
+
+    def get_mem_pool_context(self) -> AbstractContextManager | None:
+        """Return a context manager for the custom MemPool, or None.
+
+        Called by the Worker before ``initialize_kv_cache`` so that KV
+        cache is allocated from the Mooncake-managed pool when
+        ``custom_mem_pool`` is set in ``kv_connector_extra_config``.
+        """
+        if self.connector_worker is None:
+            return None
+        return self.connector_worker.get_mem_pool_context()
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         assert self.connector_worker is not None

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -20,6 +20,7 @@ import time
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from typing import Any, Literal, TypeVar
 
@@ -1094,6 +1095,40 @@ class MooncakeStoreWorker:
             else None
         )
 
+        # Custom memory pool for KV cache allocation (NVLink / BAREX).
+        # When set, KV cache is allocated from a Mooncake-managed pool
+        # instead of the default CUDA or CuMem allocator.
+        self._mem_pool: torch.cuda.MemPool | None = None
+        pool_type = str(extra_config.get("custom_mem_pool", "")).upper()
+        if pool_type:
+            if model_config.enable_cumem_allocator:
+                raise ValueError(
+                    "custom_mem_pool is incompatible with "
+                    "enable_cumem_allocator; both use "
+                    "torch.cuda.MemPool but with different allocators."
+                )
+            if model_config.enable_sleep_mode:
+                raise ValueError(
+                    "custom_mem_pool is incompatible with "
+                    "enable_sleep_mode; sleep/wake relies on "
+                    "CuMemAllocator which cannot see the custom pool."
+                )
+            if pool_type == "NVLINK":
+                from mooncake.allocator import NVLinkAllocator
+
+                allocator = NVLinkAllocator.get_allocator(self.device)
+            elif pool_type == "BAREX":
+                from mooncake.allocator import BarexAllocator
+
+                allocator = BarexAllocator.get_allocator(self.device)
+            else:
+                raise ValueError(
+                    f"Unsupported custom_mem_pool={pool_type!r}, "
+                    "expected 'NVLINK' or 'BAREX'"
+                )
+            self._mem_pool = torch.cuda.MemPool(allocator.allocator())
+            logger.info("Using Mooncake custom memory pool: %s", pool_type)
+
         # Start lookup server on rank 0 for scheduler-side prefix queries
         self.lookup_server: LookupKeyServer | None = None
         if vllm_config.parallel_config.rank == 0:
@@ -1153,6 +1188,13 @@ class MooncakeStoreWorker:
             for g_idx, g in enumerate(self._kv_cache_groups)
         ]
         self._init_lookup_key_prefixes()
+
+    def get_mem_pool_context(self) -> AbstractContextManager | None:
+        """Return a context manager for the custom MemPool, or None if
+        no custom pool is configured."""
+        if self._mem_pool is None:
+            return None
+        return torch.cuda.use_mem_pool(self._mem_pool)
 
     def _init_lookup_key_prefixes(self) -> None:
         """Prepare per-group key prefixes across parallel rank namespaces."""

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -19,6 +19,7 @@ import threading
 import time
 from collections.abc import Callable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from typing import Any, Literal, TypeVar
 
@@ -1475,6 +1476,38 @@ class MooncakeStoreWorker:
 
         # Initialize MooncakeDistributedStore with its own TransferEngine
         store_config = MooncakeStoreConfig.load_from_config()
+        # Validate and create the custom memory pool before initializing the
+        # store so failures cannot leak a partially initialized store handle.
+        self._mem_pool: torch.cuda.MemPool | None = None
+        pool_type = str(extra_config.get("custom_mem_pool") or "").upper()
+        if pool_type:
+            if pool_type not in ("NVLINK", "BAREX"):
+                raise ValueError(
+                    f"Unsupported custom_mem_pool={pool_type!r}, "
+                    "expected 'NVLINK' or 'BAREX'"
+                )
+            if model_config.enable_sleep_mode or model_config.enable_cumem_allocator:
+                raise ValueError(
+                    "custom_mem_pool is incompatible with enable_sleep_mode "
+                    "or enable_cumem_allocator; CuMemAllocator cannot manage "
+                    "allocations from the custom pool."
+                )
+            try:
+                if pool_type == "NVLINK":
+                    from mooncake.allocator import NVLinkAllocator as allocator_cls
+                else:  # pool_type == "BAREX"
+                    from mooncake.allocator import BarexAllocator as allocator_cls
+            except ImportError as e:
+                raise ImportError(
+                    f"custom_mem_pool={pool_type!r} requires "
+                    "mooncake-transfer-engine>=0.3.8. Please upgrade Mooncake."
+                ) from e
+
+            device = torch.device("cuda", torch.cuda.current_device())
+            allocator = allocator_cls.get_allocator(device)
+            self._mem_pool = torch.cuda.MemPool(allocator.allocator())
+            logger.info("Using Mooncake custom memory pool: %s", pool_type)
+
         self.store = MooncakeDistributedStore()
         local_ip = get_ip()
         local_hostname = rdma_utils.get_requester_local_hostname(local_ip)
@@ -1639,6 +1672,13 @@ class MooncakeStoreWorker:
             for g_idx, g in enumerate(self._kv_cache_groups)
         ]
         self._init_lookup_key_prefixes()
+
+    def get_mem_pool_context(self) -> AbstractContextManager | None:
+        """Return a context manager for the custom MemPool, or None if
+        no custom pool is configured."""
+        if self._mem_pool is None:
+            return None
+        return torch.cuda.use_mem_pool(self._mem_pool)
 
     def _spec_tp_replication_factor(self, spec: KVCacheSpec) -> int:
         if self.dcp_size > 1:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -28,7 +28,7 @@ import torch
 import zmq
 
 import vllm.envs as envs
-from vllm.config import VllmConfig
+from vllm.config import ModelConfig, VllmConfig
 from vllm.distributed import (
     get_dcp_group,
     get_pcp_group,
@@ -1420,6 +1420,41 @@ class KVCacheStoreRecvingThread(KVTransferThread):
 class MooncakeStoreWorker:
     """Worker-side component for MooncakeStoreConnector."""
 
+    @staticmethod
+    def _create_mem_pool(
+        extra_config: dict[str, Any], model_config: ModelConfig
+    ) -> torch.cuda.MemPool | None:
+        pool_type = str(extra_config.get("custom_mem_pool") or "").upper()
+        if not pool_type:
+            return None
+        if pool_type not in ("NVLINK", "BAREX"):
+            raise ValueError(
+                f"Unsupported custom_mem_pool={pool_type!r}, "
+                "expected 'NVLINK' or 'BAREX'"
+            )
+        if model_config.enable_sleep_mode or model_config.enable_cumem_allocator:
+            raise ValueError(
+                "custom_mem_pool is incompatible with enable_sleep_mode "
+                "or enable_cumem_allocator; CuMemAllocator cannot manage "
+                "allocations from the custom pool."
+            )
+        try:
+            if pool_type == "NVLINK":
+                from mooncake.allocator import NVLinkAllocator as allocator_cls
+            else:  # pool_type == "BAREX"
+                from mooncake.allocator import BarexAllocator as allocator_cls
+        except ImportError as e:
+            raise ImportError(
+                f"custom_mem_pool={pool_type!r} requires "
+                "mooncake-transfer-engine>=0.3.8. Please upgrade Mooncake."
+            ) from e
+
+        device = torch.device("cuda", torch.accelerator.current_device_index())
+        allocator = allocator_cls.get_allocator(device)
+        mem_pool = torch.cuda.MemPool(allocator.allocator())
+        logger.info("Using Mooncake custom memory pool: %s", pool_type)
+        return mem_pool
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -1478,35 +1513,7 @@ class MooncakeStoreWorker:
         store_config = MooncakeStoreConfig.load_from_config()
         # Validate and create the custom memory pool before initializing the
         # store so failures cannot leak a partially initialized store handle.
-        self._mem_pool: torch.cuda.MemPool | None = None
-        pool_type = str(extra_config.get("custom_mem_pool") or "").upper()
-        if pool_type:
-            if pool_type not in ("NVLINK", "BAREX"):
-                raise ValueError(
-                    f"Unsupported custom_mem_pool={pool_type!r}, "
-                    "expected 'NVLINK' or 'BAREX'"
-                )
-            if model_config.enable_sleep_mode or model_config.enable_cumem_allocator:
-                raise ValueError(
-                    "custom_mem_pool is incompatible with enable_sleep_mode "
-                    "or enable_cumem_allocator; CuMemAllocator cannot manage "
-                    "allocations from the custom pool."
-                )
-            try:
-                if pool_type == "NVLINK":
-                    from mooncake.allocator import NVLinkAllocator as allocator_cls
-                else:  # pool_type == "BAREX"
-                    from mooncake.allocator import BarexAllocator as allocator_cls
-            except ImportError as e:
-                raise ImportError(
-                    f"custom_mem_pool={pool_type!r} requires "
-                    "mooncake-transfer-engine>=0.3.8. Please upgrade Mooncake."
-                ) from e
-
-            device = torch.device("cuda", torch.cuda.current_device())
-            allocator = allocator_cls.get_allocator(device)
-            self._mem_pool = torch.cuda.MemPool(allocator.allocator())
-            logger.info("Using Mooncake custom memory pool: %s", pool_type)
+        self._mem_pool = self._create_mem_pool(extra_config, model_config)
 
         self.store = MooncakeDistributedStore()
         local_ip = get_ip()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -292,10 +292,7 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         """
         found: list[tuple[str, AbstractContextManager]] = []
         for connector in self._connectors:
-            get_ctx = getattr(connector, "get_mem_pool_context", None)
-            if get_ctx is None:
-                continue
-            if (ctx := get_ctx()) is not None:
+            if (ctx := connector.get_mem_pool_context()) is not None:
                 found.append((type(connector).__name__, ctx))
 
         if len(found) > 1:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import copy
 from collections.abc import Callable, Iterable
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
@@ -283,6 +284,29 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
     # ==============================
     # Worker-side methods
     # ==============================
+    def get_mem_pool_context(self) -> AbstractContextManager | None:
+        """Forward a custom KV cache memory pool from a child connector.
+
+        KV cache is allocated once and can only live in one pool, so at
+        most one child may provide a context.
+        """
+        found: list[tuple[str, AbstractContextManager]] = []
+        for connector in self._connectors:
+            get_ctx = getattr(connector, "get_mem_pool_context", None)
+            if get_ctx is None:
+                continue
+            if (ctx := get_ctx()) is not None:
+                found.append((type(connector).__name__, ctx))
+
+        if len(found) > 1:
+            names = [name for name, _ in found]
+            raise ValueError(
+                f"Multiple connectors provide a KV cache memory pool {names}; "
+                "KV cache is allocated once and can only live in one pool. "
+                "Configure custom_mem_pool on at most one connector."
+            )
+        return found[0][1] if found else None
+
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         for c in self._connectors:
             c.start_load_kv(forward_context, **kwargs)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -212,6 +212,7 @@ if TYPE_CHECKING:
     VLLM_EC_SIDE_CHANNEL_HOST: str = "localhost"
     VLLM_EC_SIDE_CHANNEL_PORT: int = 5601
     VLLM_MOONCAKE_BOOTSTRAP_PORT: int = 8998
+    VLLM_MOONCAKE_CUSTOM_MEM_POOL: str | None = None
     VLLM_MOONCAKE_STORE_TIER_LOG: bool = False
     VLLM_MOONCAKE_LOAD_RECV_THREADS: int = 1
     VLLM_MOONCAKE_DISK_STAGING_USABLE_RATIO: float = 0.9
@@ -1708,6 +1709,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Timeout (in seconds) for MooncakeConnector in PD disaggregated setup.
     "VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT": lambda: int(
         os.getenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", "480")
+    ),
+    # Custom memory pool type for Mooncake PD disaggregation.
+    # Supported values: "NVLINK", "BAREX". Default: None (disabled).
+    # "NVLINK" uses NVLinkAllocator for NVLink-based GPU memory pool.
+    # "BAREX" uses BarexAllocator for RDMA-capable bare-device memory pool.
+    "VLLM_MOONCAKE_CUSTOM_MEM_POOL": lambda: os.getenv(
+        "VLLM_MOONCAKE_CUSTOM_MEM_POOL", None
     ),
     # If set, it means we pre-downloaded cubin files and flashinfer will
     # read the cubin files directly.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -212,7 +212,6 @@ if TYPE_CHECKING:
     VLLM_EC_SIDE_CHANNEL_HOST: str = "localhost"
     VLLM_EC_SIDE_CHANNEL_PORT: int = 5601
     VLLM_MOONCAKE_BOOTSTRAP_PORT: int = 8998
-    VLLM_MOONCAKE_CUSTOM_MEM_POOL: str | None = None
     VLLM_MOONCAKE_STORE_TIER_LOG: bool = False
     VLLM_MOONCAKE_LOAD_RECV_THREADS: int = 1
     VLLM_MOONCAKE_DISK_STAGING_USABLE_RATIO: float = 0.9
@@ -1709,13 +1708,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Timeout (in seconds) for MooncakeConnector in PD disaggregated setup.
     "VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT": lambda: int(
         os.getenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", "480")
-    ),
-    # Custom memory pool type for Mooncake PD disaggregation.
-    # Supported values: "NVLINK", "BAREX". Default: None (disabled).
-    # "NVLINK" uses NVLinkAllocator for NVLink-based GPU memory pool.
-    # "BAREX" uses BarexAllocator for RDMA-capable bare-device memory pool.
-    "VLLM_MOONCAKE_CUSTOM_MEM_POOL": lambda: os.getenv(
-        "VLLM_MOONCAKE_CUSTOM_MEM_POOL", None
     ),
     # If set, it means we pre-downloaded cubin files and flashinfer will
     # read the cubin files directly.

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -247,6 +247,23 @@ class Worker(WorkerBase):
             self.model_runner.post_kv_cache_wake_up()
 
     def _maybe_get_memory_pool_context(self, tag: str) -> AbstractContextManager:
+        # Mooncake custom memory pool (NVLink / BAREX) only applies to KV
+        # cache allocation, not weights.
+        if tag == "kv_cache":
+            pool_type = (envs.VLLM_MOONCAKE_CUSTOM_MEM_POOL or "").upper()
+            if pool_type == "NVLINK":
+                from mooncake.allocator import NVLinkAllocator
+
+                allocator = NVLinkAllocator.get_allocator(self.device)
+                mem_pool = torch.cuda.MemPool(allocator.allocator())
+                return torch.cuda.use_mem_pool(mem_pool)
+            elif pool_type == "BAREX":
+                from mooncake.allocator import BarexAllocator
+
+                allocator = BarexAllocator.get_allocator(self.device)
+                mem_pool = torch.cuda.MemPool(allocator.allocator())
+                return torch.cuda.use_mem_pool(mem_pool)
+
         if (
             current_platform.is_cuda_alike()
             and not self.vllm_config.model_config.enable_cumem_allocator

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -247,23 +247,6 @@ class Worker(WorkerBase):
             self.model_runner.post_kv_cache_wake_up()
 
     def _maybe_get_memory_pool_context(self, tag: str) -> AbstractContextManager:
-        # Mooncake custom memory pool (NVLink / BAREX) only applies to KV
-        # cache allocation, not weights.
-        if tag == "kv_cache":
-            pool_type = (envs.VLLM_MOONCAKE_CUSTOM_MEM_POOL or "").upper()
-            if pool_type == "NVLINK":
-                from mooncake.allocator import NVLinkAllocator
-
-                allocator = NVLinkAllocator.get_allocator(self.device)
-                mem_pool = torch.cuda.MemPool(allocator.allocator())
-                return torch.cuda.use_mem_pool(mem_pool)
-            elif pool_type == "BAREX":
-                from mooncake.allocator import BarexAllocator
-
-                allocator = BarexAllocator.get_allocator(self.device)
-                mem_pool = torch.cuda.MemPool(allocator.allocator())
-                return torch.cuda.use_mem_pool(mem_pool)
-
         if (
             current_platform.is_cuda_alike()
             and not self.vllm_config.model_config.enable_cumem_allocator
@@ -733,7 +716,18 @@ class Worker(WorkerBase):
         # related to kv cache connector (e.g. kv cache sharing layers).
         ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
 
-        with self._maybe_get_memory_pool_context(tag="kv_cache"):
+        # If the connector provides a custom memory pool (e.g. Mooncake
+        # NVLink/BAREX), use it for KV cache allocation; otherwise fall
+        # back to the standard CuMem pool.
+        connector = get_kv_transfer_group()
+        cm = (
+            connector.get_mem_pool_context()
+            if hasattr(connector, "get_mem_pool_context")
+            else None
+        )
+        if cm is None:
+            cm = self._maybe_get_memory_pool_context(tag="kv_cache")
+        with cm:
             self.model_runner.initialize_kv_cache(kv_cache_config)
 
         if self.model_config.enable_return_routed_experts:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -730,12 +730,11 @@ class Worker(WorkerBase):
         # If the connector provides a custom memory pool (e.g. Mooncake
         # NVLink/BAREX), use it for KV cache allocation; otherwise fall
         # back to the standard CuMem pool.
-        mem_pool_context = None
-        if has_kv_transfer_group():
-            connector = get_kv_transfer_group()
-            get_ctx = getattr(connector, "get_mem_pool_context", None)
-            if get_ctx is not None:
-                mem_pool_context = get_ctx()
+        mem_pool_context = (
+            get_kv_transfer_group().get_mem_pool_context()
+            if has_kv_transfer_group()
+            else None
+        )
         if mem_pool_context is None:
             mem_pool_context = self._maybe_get_memory_pool_context(tag="kv_cache")
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -727,11 +727,21 @@ class Worker(WorkerBase):
         # related to kv cache connector (e.g. kv cache sharing layers).
         ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
 
+        # If the connector provides a custom memory pool (e.g. Mooncake
+        # NVLink/BAREX), use it for KV cache allocation; otherwise fall
+        # back to the standard CuMem pool.
+        mem_pool_context = None
+        if has_kv_transfer_group():
+            connector = get_kv_transfer_group()
+            get_ctx = getattr(connector, "get_mem_pool_context", None)
+            if get_ctx is not None:
+                mem_pool_context = get_ctx()
+        if mem_pool_context is None:
+            mem_pool_context = self._maybe_get_memory_pool_context(tag="kv_cache")
+
         self.model_runner.initialize_kv_cache(
             kv_cache_config,
-            kv_cache_allocation_context=self._maybe_get_memory_pool_context(
-                tag="kv_cache"
-            ),
+            kv_cache_allocation_context=mem_pool_context,
         )
 
         if self.model_config.enable_return_routed_experts:


### PR DESCRIPTION
### Purpose
Add support for Mooncake custom memory pools (NVLINK / BAREX) when allocating KV cache in vLLM. This enables KV cache to use NVLink or BAR-exposed device memory instead of the default CUDA allocator, which is required by some MooncakeStoreConnector deployments for RDMA-based KV-cache transfer.When custom_mem_pool is configured in kv_connector_extra_config, MooncakeStoreConnector creates a torch.cuda.MemPool using the corresponding Mooncake allocator (NVLinkAllocator / BarexAllocator). When unset, the existing CuMem/default allocator behavior remains unchanged.Custom pools are incompatible with CuMem allocation and sleep mode. These conflicting configurations are rejected during connector initialization.In some scenarios, a specific allocator is required due to hardware limitations.
### Changes:
-mooncake/store/worker.py: Validate custom_mem_pool, create and retain the Mooncake memory pool, detect CuMem/sleep-mode conflicts, and provide actionable errors for unsupported Mooncake versions.
-mooncake/store/connector.py: Expose the custom memory-pool context to the GPU worker.
-multi_connector.py: Forward a custom pool from child connectors and reject configurations where multiple children provide pools.
-vllm/v1/worker/gpu_worker.py: Use a connector-provided pool during KV-cache allocation, while preserving the existing fallback behavior.
-test_multi_connector.py: Add coverage for no pool, single-pool forwarding, and multiple-pool conflicts.