### PR TITLE
[Bugfix] Bound hidden-state export staging memory

### DIFF
--- a/docs/features/speculative_decoding/extract_hidden_states.md
+++ b/docs/features/speculative_decoding/extract_hidden_states.md
@@ -110,6 +110,7 @@ The `kv_connector_extra_config` dict accepts these server-level options:
 | --- | --- | --- |
 | `shared_storage_path` | `/tmp` | Directory where hidden state files are saved (used when `hidden_states_path` is not set per-request) |
 | `allow_custom_save_path` | `False` | Allow API clients to specify custom file paths via `hidden_states_path`. When disabled, client-provided paths are ignored with a warning. Enable only with trusted clients — custom paths can write to arbitrary locations on the server. |
+| `max_device_staging_bytes` | `268435456` (256 MiB) | Maximum gathered hidden-state payload per device chunk. Reduce this value when exporting long contexts under tight device-memory headroom. Indexing may require additional backend-specific workspace. |
 | `num_writer_threads` | `8` | Thread pool size for async disk writes |
 | `use_synchronization_lock` | `True` | Use file locks so concurrent readers block until writes complete. Can be disabled for batch generation where synchronization is not needed. |
 

--- a/tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py
+++ b/tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py
@@ -117,6 +117,8 @@ def test_extract_hidden_states_with_predictable_dummy_model(
             "kv_connector_extra_config": {
                 "shared_storage_path": tmp_path,
                 "allow_custom_save_path": True,
+                # Force 64-token BF16 staging chunks through the production path.
+                "max_device_staging_bytes": 64 * 2 * num_layers * 256,
             },
         },
         max_model_len=1024,

--- a/tests/v1/kv_connector/unit/test_hidden_states_connector.py
+++ b/tests/v1/kv_connector/unit/test_hidden_states_connector.py
@@ -1,14 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""CPU-only unit tests for ExampleHiddenStatesConnector KV-cache-group logic."""
+"""CPU-only unit tests for ExampleHiddenStatesConnector."""
 
+from contextlib import nullcontext
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 import torch
 
-from vllm.distributed.kv_transfer.kv_connector.v1.example_hidden_states_connector import (  # noqa: E501
-    ExampleHiddenStatesConnector,
+from vllm.distributed.kv_transfer.kv_connector.v1 import (
+    example_hidden_states_connector as connector,
 )
 from vllm.v1.core.kv_cache_utils import get_kv_cache_groups
 from vllm.v1.kv_cache_interface import (
@@ -18,6 +20,126 @@ from vllm.v1.kv_cache_interface import (
     MLAAttentionSpec,
     SlidingWindowMLASpec,
 )
+
+ExampleHiddenStatesConnector = connector.ExampleHiddenStatesConnector
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_copy_from_kv_cache_in_chunks_bounds_staging_and_preserves_output(
+    monkeypatch, dtype
+):
+    kv_cache = torch.arange(4 * 3 * 2 * 2, dtype=dtype).reshape(4, 3, 2, 2)
+    slot_mapping = torch.tensor([0, 5, 2, 7, 9, 1, 11, 4, 8, 3, 6, 10])
+    num_tokens = 10
+    output = torch.empty((num_tokens, 2, 2), dtype=kv_cache.dtype)
+    bytes_per_token = 2 * 2 * kv_cache.element_size()
+    staging_tokens = 3
+
+    chunk_slots = []
+    original_extract = connector.extract_from_kv_cache
+
+    def recorded_extract(kv_cache, slot_mapping, num_tokens):
+        chunk_slots.append(slot_mapping.tolist())
+        return original_extract(kv_cache, slot_mapping, num_tokens)
+
+    monkeypatch.setattr(connector, "extract_from_kv_cache", recorded_extract)
+    connector._copy_from_kv_cache_in_chunks(
+        kv_cache,
+        slot_mapping,
+        output,
+        max_device_staging_bytes=staging_tokens * bytes_per_token,
+    )
+
+    expected = kv_cache.flatten(0, 1)[slot_mapping[:num_tokens]]
+    torch.testing.assert_close(output, expected)
+    assert chunk_slots == [[0, 5, 2], [7, 9, 1], [11, 4, 8], [3]]
+
+
+@pytest.mark.parametrize("budget", [0, 7])
+def test_copy_from_kv_cache_in_chunks_rejects_invalid_budget(budget):
+    kv_cache = torch.empty((1, 2, 1, 2), dtype=torch.float32)
+    slot_mapping = torch.tensor([0, 1])
+    output = torch.empty((2, 1, 2), dtype=kv_cache.dtype)
+
+    with pytest.raises(ValueError, match="max_device_staging_bytes"):
+        connector._copy_from_kv_cache_in_chunks(
+            kv_cache, slot_mapping, output, max_device_staging_bytes=budget
+        )
+
+
+def test_submit_async_write_uses_bounded_gather_chunks(monkeypatch, tmp_path):
+    kv_cache = torch.arange(4 * 3 * 2 * 2, dtype=torch.float32).reshape(4, 3, 2, 2)
+    token_ids = torch.arange(10)
+    bytes_per_token = 2 * 2 * kv_cache.element_size()
+    timeline = []
+
+    class FakeEvent:
+        def record(self, stream=None):
+            timeline.append(("event", stream))
+
+    class FakeStream:
+        def wait_event(self, event):
+            timeline.append(("wait", event))
+
+    fake_stream = FakeStream()
+    fake_future = MagicMock()
+    fake_executor = MagicMock()
+    fake_executor.submit.return_value = fake_future
+    instance = object.__new__(connector.ExampleHiddenStatesConnector)
+    instance._is_tp_rank_zero = True
+    instance._kv_cache = kv_cache
+    instance._block_size = kv_cache.shape[1]
+    instance._max_device_staging_bytes = 3 * bytes_per_token
+    instance._get_copy_stream = lambda: fake_stream
+    instance._executor = fake_executor
+    instance._req_futures = {}
+    instance._req_copy_events = {}
+    instance._lock_fds = {}
+    instance.use_lock = False
+
+    original_empty = torch.empty
+    original_empty_like = torch.empty_like
+    original_extract = connector.extract_from_kv_cache
+
+    def unpinned_empty(*args, **kwargs):
+        kwargs.pop("pin_memory", None)
+        return original_empty(*args, **kwargs)
+
+    def unpinned_empty_like(*args, **kwargs):
+        kwargs.pop("pin_memory", None)
+        return original_empty_like(*args, **kwargs)
+
+    def recorded_extract(kv_cache, slot_mapping, num_tokens):
+        timeline.append(("gather", num_tokens))
+        return original_extract(kv_cache, slot_mapping, num_tokens)
+
+    monkeypatch.setattr(connector.torch, "empty", unpinned_empty)
+    monkeypatch.setattr(connector.torch, "empty_like", unpinned_empty_like)
+    monkeypatch.setattr(
+        connector, "extract_from_kv_cache", MagicMock(side_effect=recorded_extract)
+    )
+    monkeypatch.setattr(connector.torch.cuda, "Event", FakeEvent)
+    monkeypatch.setattr(
+        connector.torch.cuda, "stream", lambda stream: nullcontext(stream)
+    )
+
+    pending = connector.PendingSave(
+        req_id="request-0",
+        filename=str(tmp_path / "hidden-states.safetensors"),
+        token_ids=token_ids,
+        block_ids=[0, 1, 2, 3],
+    )
+    instance._submit_async_write(pending)
+
+    assert [item[1] for item in timeline if item[0] == "gather"] == [3, 3, 3, 1]
+    assert timeline[-1] == ("event", fake_stream)
+    fake_executor.submit.assert_called_once()
+
+    tensors = fake_executor.submit.call_args.args[1]
+    expected_slots = torch.arange(12)[: token_ids.numel()]
+    expected = kv_cache.flatten(0, 1)[expected_slots]
+    torch.testing.assert_close(tensors["hidden_states"], expected)
 
 
 def _full(block_size: int) -> FullAttentionSpec:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
@@ -6,6 +6,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from functools import partial
 from importlib.metadata import version
+from math import prod
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -31,6 +32,8 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+_DEFAULT_MAX_DEVICE_STAGING_BYTES = 256 * 1024 * 1024
+
 
 def extract_from_kv_cache(
     kv_cache: torch.Tensor,
@@ -40,6 +43,48 @@ def extract_from_kv_cache(
     """Extract data from KV cache."""
     block_size = kv_cache.shape[1]
     return kv_cache[slot_mapping // block_size, slot_mapping % block_size][:num_tokens]
+
+
+def _copy_from_kv_cache_in_chunks(
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    output: torch.Tensor,
+    max_device_staging_bytes: int,
+) -> None:
+    """Copy cached hidden states without materializing the full device tensor."""
+    if (
+        not isinstance(max_device_staging_bytes, int)
+        or isinstance(max_device_staging_bytes, bool)
+        or max_device_staging_bytes <= 0
+    ):
+        raise ValueError("max_device_staging_bytes must be a positive integer")
+
+    num_tokens = output.shape[0]
+    if slot_mapping.numel() < num_tokens:
+        raise ValueError(
+            f"slot_mapping has {slot_mapping.numel()} entries, but output "
+            f"requires {num_tokens} tokens"
+        )
+    if num_tokens == 0:
+        return
+
+    bytes_per_token = prod(kv_cache.shape[2:]) * kv_cache.element_size()
+    if max_device_staging_bytes < bytes_per_token:
+        raise ValueError(
+            "max_device_staging_bytes must fit at least one hidden-state token "
+            f"({bytes_per_token} bytes required)"
+        )
+    tokens_per_chunk = max_device_staging_bytes // bytes_per_token
+
+    for start in range(0, num_tokens, tokens_per_chunk):
+        end = min(start + tokens_per_chunk, num_tokens)
+        hidden_states_chunk = extract_from_kv_cache(
+            kv_cache, slot_mapping[start:end], end - start
+        )
+        output[start:end].copy_(hidden_states_chunk, non_blocking=True)
+        # Gather and D2H run on the same stream, so any allocator reuse is
+        # ordered after the queued copy has consumed the staging buffer.
+        del hidden_states_chunk
 
 
 def load_hidden_states(path: str) -> dict[str, torch.Tensor]:
@@ -196,6 +241,16 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         self._pending_saves: dict[str, PendingSave] = {}
         self._request_filenames: dict[str, str] = {}
 
+        self._max_device_staging_bytes = self._kv_transfer_config.get_from_extra_config(
+            "max_device_staging_bytes", _DEFAULT_MAX_DEVICE_STAGING_BYTES
+        )
+        if (
+            not isinstance(self._max_device_staging_bytes, int)
+            or isinstance(self._max_device_staging_bytes, bool)
+            or self._max_device_staging_bytes <= 0
+        ):
+            raise ValueError("max_device_staging_bytes must be a positive integer")
+
         # Worker-side state (set by register_kv_caches).
         self._kv_cache: torch.Tensor | None = None
 
@@ -308,6 +363,13 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         )
         self._kv_cache = kv_caches[self.cache_layers[0]]
 
+        bytes_per_token = prod(self._kv_cache.shape[2:]) * self._kv_cache.element_size()
+        if self._max_device_staging_bytes < bytes_per_token:
+            raise ValueError(
+                "max_device_staging_bytes must fit at least one hidden-state token "
+                f"({bytes_per_token} bytes required)"
+            )
+
         # Block size must match the indexed buffer, else reads hit the wrong
         # slots. Raise (not assert) so the check survives `python -O`.
         if self._block_size != self._kv_cache.shape[1]:
@@ -386,14 +448,18 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
             slot_mapping_gpu = slot_mapping.to(
                 device=self._kv_cache.device, non_blocking=True
             )
-            hidden_states_gpu = extract_from_kv_cache(
-                self._kv_cache, slot_mapping_gpu, num_tokens
+            pinned_hs = torch.empty(
+                (num_tokens, *self._kv_cache.shape[2:]),
+                dtype=self._kv_cache.dtype,
+                device="cpu",
+                pin_memory=True,
             )
-            # Async DtoH copy into pinned host memory.
-            pinned_hs = torch.empty_like(
-                hidden_states_gpu, device="cpu", pin_memory=True
+            _copy_from_kv_cache_in_chunks(
+                self._kv_cache,
+                slot_mapping_gpu,
+                pinned_hs,
+                self._max_device_staging_bytes,
             )
-            pinned_hs.copy_(hidden_states_gpu, non_blocking=True)
 
         # Record completion of this copy on the copy stream.
         copy_done = torch.cuda.Event()


### PR DESCRIPTION
Fixes #49310

## Purpose

Bound the temporary device memory used by `ExampleHiddenStatesConnector` when
exporting long-context hidden states.

The connector currently gathers every requested token into one device tensor
before copying it to pinned host memory. The temporary allocation therefore
grows with the full context length. For four BF16 hidden-state layers of width
7168, the gather result alone is:

```text
49,152 tokens: 2.625 GiB
65,536 tokens: 3.500 GiB
```

This PR allocates the final pinned-host output first, then gathers and copies
the device data in bounded chunks on the existing copy stream. The default
device staging budget is 256 MiB and can be configured with
`kv_connector_extra_config.max_device_staging_bytes`. The output format, token
order, and total D2H payload are unchanged.

### Root cause and production evidence

A downstream EAGLE hidden-state deployment failed while exporting a 49,152
token prefix. The indexed gather attempted the exact calculated allocation:

```text
torch.OutOfMemoryError: NPU out of memory. Tried to allocate 2.63 GiB
ExampleHiddenStatesConnector -> extract_from_kv_cache
    -> kv_cache.flatten(0, 1)[slot_mapping]
```

The worker failure propagated as `EngineDeadError` and an HTTP 500 response.
The incident used a downstream connector revision, but the current upstream
`_submit_async_write()` retains the same full-result advanced-indexing pattern.
Chunked prefill does not bound this final gather.

### Hardware A/B validation

Both runs used the same four-layer BF16 extraction workload, TP8 x DP2,
65,536 maximum context, 8,192 scheduler chunks, and 0.95 device-memory
utilization.

| Connector | Request | Result |
| --- | ---: | --- |
| Unpatched | 47,509 prompt tokens | Full gather attempted 1.75 GiB with 1.60 GiB free; worker OOM, `EngineDeadError`, HTTP 500 |
| Bounded 256 MiB staging | 47,509 prompt tokens | HTTP 200, hidden-state file published, service remained healthy |

The unpatched downstream revision exported accumulated prefixes during
prefill, so it failed at the 32,768-token (1.75 GiB) gather before reaching the
final prompt length. Upstream main already exports only after request
completion; this PR is limited to the remaining full-gather memory spike. The
hardware A/B validates the bounded gather/D2H implementation under memory
pressure, while the unit regression test covers the current upstream call
path directly.

### Duplicate-work check

I searched open and closed issues/PRs for `ExampleHiddenStatesConnector`,
`extract_hidden_states`, `hidden_states_gpu OOM`, and bounded/chunked hidden
state gather. I found no existing change that bounds this allocation.

This is a narrow follow-up to #37374 (copy stream, pinned D2H, background
write) and #43805 (single export after request completion, HMA block lifetime,
TP0 writer). It does not reimplement those changes. Open PR #49132 touches the
same connector but addresses shutdown and file-descriptor cleanup, not device
staging memory.

## Test Plan

```bash
PYTHONPATH=. .venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/test_hidden_states_connector.py -v

.venv/bin/pre-commit run --files \
  vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py \
  tests/v1/kv_connector/unit/test_hidden_states_connector.py \
  tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py \
  docs/features/speculative_decoding/extract_hidden_states.md
```

The existing predictable-model integration test now uses a small staging
budget, forcing multiple chunks through the production extraction path. It was
not run locally because this development host has no supported GPU runtime; it
is intended for the normal GPU CI job.

## Test Result

```text
14 passed, 1 warning in 0.10s
```

All applicable pre-commit hooks passed, including ruff, formatting, typos,
markdownlint, mypy, SPDX checks, forbidden-import checks, and configuration
validation.

The unit tests verify:

- exact FP32 and BF16 output equivalence with shuffled slots;
- a non-divisible final chunk;
- rejection of invalid and sub-token staging budgets;
- production `_submit_async_write()` uses `[3, 3, 3, 1]` token gathers rather
  than one 10-token gather;
- the completion event is recorded after all chunk copies are enqueued.

No model-quality evaluation was run because this change only restructures the
gather/D2H transfer and does not affect model execution or generated tokens.
The hardware A/B result above validates the affected serving path.

## AI assistance

AI assistance was used for implementation, test design, and duplicate search.
The human submitter remains responsible for reviewing every changed line and
verifying the reported results.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this
  PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after,
  or e2e results.
- [x] (Optional) The necessary documentation update, such as updating
  `supported_models.md` and `examples` for a new model.

</details>
