### PR TITLE
[XPU] [SP] Support  Sequence Parallelism for mxfp8 on XPU

### DIFF
--- a/.buildkite/intel_jobs/test-intel.yaml
+++ b/.buildkite/intel_jobs/test-intel.yaml
@@ -169,3 +169,28 @@ steps:
         bash .buildkite/scripts/hardware_ci/run-intel-test.sh
         'cd tests &&
         pytest -v -s quantization/test_compressed_tensors.py::test_compressed_tensors_fp8'
+  - label: "XPU compile distributed passes"
+    depends_on:
+      - image-build-xpu
+    timeout_in_minutes: 60
+    device: intel_gpu
+    agent_tags:
+      label: production
+      gpu: 2+
+      mem: 16+
+    no_plugin: true
+    env:
+      REGISTRY: "public.ecr.aws/q9t5s3a7"
+      REPO: "vllm-ci-test-repo"
+      VLLM_TEST_DEVICE: "xpu"
+    source_file_dependencies:
+      - vllm/compilation/
+      - vllm/model_executor/layers/quantization/
+      - tests/compile/passes/distributed/test_sequence_parallelism.py
+      - tests/utils.py
+      - .buildkite/intel_jobs/test-intel.yaml
+    commands:
+      - >-
+        bash .buildkite/scripts/hardware_ci/run-intel-test.sh
+        'cd tests &&
+        pytest -v -s compile/passes/distributed/test_sequence_parallelism.py::test_sequence_parallelism_pass_xpu_mxfp8'

--- a/.buildkite/intel_jobs/test-intel.yaml
+++ b/.buildkite/intel_jobs/test-intel.yaml
@@ -218,7 +218,7 @@ steps:
     agent_tags:
       label: production
       gpu: 2+
-      mem: 32+
+      mem: 24+
     no_plugin: true
     env:
       REGISTRY: "public.ecr.aws/q9t5s3a7"

--- a/.buildkite/intel_jobs/test-intel.yaml
+++ b/.buildkite/intel_jobs/test-intel.yaml
@@ -210,3 +210,28 @@ steps:
         python3 examples/basic/offline_inference/generate.py --model INCModel/Qwen3-30B-A3B-Instruct-2507-MXFP4-CT-AutoRound --max-model-len 4096'
       # Temporarily disabled (multi-GPU/MXFP8 not yet supported with XPU Graph):
       # python3 examples/basic/offline_inference/generate.py --model INCModel/Qwen3-30B-A3B-Instruct-2507-MXFP8-CT-AutoRound -tp 2 --max-model-len 4096
+  - label: "XPU sequence parallelism test"
+    depends_on:
+      - image-build-xpu
+    timeout_in_minutes: 90
+    device: intel_gpu
+    agent_tags:
+      label: production
+      gpu: 2+
+      mem: 32+
+    no_plugin: true
+    env:
+      REGISTRY: "public.ecr.aws/q9t5s3a7"
+      REPO: "vllm-ci-test-repo"
+      VLLM_TEST_DEVICE: "xpu"
+    source_file_dependencies:
+      - vllm/compilation/passes/fusion/sequence_parallelism.py
+      - tests/compile/passes/distributed/test_sequence_parallelism.py
+      - tests/compile/correctness_e2e/test_sequence_parallel.py
+      - .buildkite/intel_jobs/test-intel.yaml
+    commands:
+      - >-
+        bash .buildkite/scripts/hardware_ci/run-intel-test.sh
+        'cd tests &&
+        pytest -v -s compile/passes/distributed/test_sequence_parallelism.py &&
+        pytest -v -s compile/correctness_e2e/test_sequence_parallel.py::test_tp_sp_xpu_mxfp8_generation'

--- a/tests/compile/correctness_e2e/test_sequence_parallel.py
+++ b/tests/compile/correctness_e2e/test_sequence_parallel.py
@@ -29,6 +29,8 @@ logger = init_logger("test_sequence_parallel")
 VLLM_MULTI_NODE = os.getenv("VLLM_MULTI_NODE", "0") == "1"
 NVFP4_MODEL_ID = "nvidia/Llama-3.1-8B-Instruct-NVFP4"
 NVFP4_MODEL_INFO = _HfExamplesInfo(NVFP4_MODEL_ID)
+XPU_MXFP8_MODEL_ID = "INCModel/Qwen3-32B-MXFP8-CT-AutoRound"
+XPU_MXFP8_MODEL_INFO = _HfExamplesInfo(XPU_MXFP8_MODEL_ID)
 
 
 class ParallelSetup(NamedTuple):
@@ -405,6 +407,42 @@ def test_tp_sp_nvfp4_generation(num_gpus_available: int):
     )
     _compare_sp_settings(
         NVFP4_MODEL_ID,
+        [] if comparison is None else [comparison],
+        method="generate",
+    )
+
+
+@create_new_process_for_each_test()
+def test_tp_sp_xpu_mxfp8_generation(num_gpus_available: int):
+    if not current_platform.is_xpu():
+        pytest.skip("MXFP8 sequence parallelism is only supported on XPU")
+
+    comparison = _build_sp_args(
+        XPU_MXFP8_MODEL_ID,
+        ParallelSetup(
+            tp_size=2,
+            pp_size=1,
+            # MXFP8 has no fused rms_norm+quant kernel yet, so norm/act
+            # quant fusion must stay disabled.
+            fuse_norm_quant=False,
+            fuse_act_quant=False,
+            eager_mode=True,
+        ),
+        "mp",
+        "auto",
+        SPTestOptions(
+            multi_node_only=False,
+            load_format=None,
+            model_info=XPU_MXFP8_MODEL_INFO,
+        ),
+        num_gpus_available,
+        use_inductor_graph_partition=False,
+        fuse_gemm_comms=False,
+        enable_prompt_embeds=False,
+        is_multimodal=False,
+    )
+    _compare_sp_settings(
+        XPU_MXFP8_MODEL_ID,
         [] if comparison is None else [comparison],
         method="generate",
     )

--- a/tests/compile/passes/distributed/test_sequence_parallelism.py
+++ b/tests/compile/passes/distributed/test_sequence_parallelism.py
@@ -6,7 +6,7 @@ import torch
 
 import vllm.envs as envs
 from tests.compile.backend import TestBackend
-from tests.utils import TestFP8Layer, multi_gpu_test
+from tests.utils import TestFP8Layer, TestMXFP8Layer, multi_gpu_test
 from vllm.compilation.passes.fusion.rms_quant_fusion import RMSNormQuantFusionPass
 from vllm.compilation.passes.fusion.sequence_parallelism import SequenceParallelismPass
 from vllm.compilation.passes.utility.noop_elimination import NoOpEliminationPass
@@ -38,7 +38,10 @@ from vllm.utils.torch_utils import set_random_seed
 
 DEVICE_TYPE = current_platform.device_type
 
-pytestmark = pytest.mark.skipif(not current_platform.is_cuda(), reason="Only test CUDA")
+pytestmark = pytest.mark.skipif(
+    not (current_platform.is_cuda() or current_platform.is_xpu()),
+    reason="Only test on CUDA or XPU",
+)
 
 FP8_DTYPE = current_platform.fp8_dtype()
 prompts = [
@@ -80,6 +83,9 @@ class TestAllReduceRMSNormModel(torch.nn.Module):
 
     def ops_in_model_before(self):
         return [torch.ops.vllm.all_reduce.default]
+
+    def ops_count_after(self, op) -> int:
+        return 4
 
     def ops_in_model_after(self):
         return [
@@ -145,6 +151,9 @@ class TestAllReduceRMSNormStaticQuantFP8Model(torch.nn.Module):
             torch.ops.vllm.all_reduce.default,
         ]
 
+    def ops_count_after(self, op) -> int:
+        return 4
+
     def ops_in_model(self):
         if self.vllm_config.compilation_config.pass_config.fuse_norm_quant:
             return [torch.ops._C.fused_add_rms_norm_static_fp8_quant.default]
@@ -159,6 +168,110 @@ class TestAllReduceRMSNormStaticQuantFP8Model(torch.nn.Module):
                 torch.ops.vllm_ir.fused_add_rms_norm,
                 *quant_ops,
             ]
+
+
+class TestAllReduceRMSNormXPUMxFP8Model(torch.nn.Module):
+    """Model with all_reduce → rms_norm/fused_add_rms_norm → xpu_mxfp8_quantize.
+
+    Tests FirstAllReduceRMSNormXPUMxFP8Pattern (layer 0) and
+    MiddleAllReduceRMSNormXPUMxFP8Pattern (layers 1-3).
+    hidden_size must be divisible by 32 (MXFP8 block size).
+    """
+
+    def __init__(self, hidden_size=32, eps=1e-6):
+        super().__init__()
+        self.vllm_config = get_current_vllm_config()
+        self.hidden_size = hidden_size
+        self.eps = eps
+        self.dtype = torch.bfloat16
+        self.norm = [RMSNorm(hidden_size, eps) for _ in range(4)]
+        self.mxfp8_linear_layers = [
+            TestMXFP8Layer(
+                hidden_size=hidden_size,
+            )
+            for _ in range(4)
+        ]
+
+    def forward(self, hidden_states):
+        z = torch.relu(hidden_states)
+        x = resid = tensor_model_parallel_all_reduce(z)
+        y = self.norm[0](x)
+        # First pattern: rms_norm → xpu_mxfp8_quantize
+        z2 = self.mxfp8_linear_layers[0](y)
+
+        x2 = tensor_model_parallel_all_reduce(z2)
+        y2, resid = self.norm[1](x2, resid)
+        # Middle pattern 1
+        z3 = self.mxfp8_linear_layers[1](y2)
+
+        x3 = tensor_model_parallel_all_reduce(z3)
+        y3, resid = self.norm[2](x3, resid)
+        # Middle pattern 2
+        z4 = self.mxfp8_linear_layers[2](y3)
+
+        x4 = tensor_model_parallel_all_reduce(z4)
+        y4, resid = self.norm[3](x4, resid)
+        # Middle pattern 3: fp8_gemm uses both fp8 and scale; return resid so
+        # residual_out has a consumer → full 3-tuple pattern matches (2 all_gathers)
+        z5 = self.mxfp8_linear_layers[3](y4)
+        return z5, resid
+
+    def ops_in_model_after(self):
+        return [
+            torch.ops.vllm.all_gather.default,
+            torch.ops.vllm.reduce_scatter.default,
+        ]
+
+    def ops_count_after(self, op) -> int:
+        # After SP pass: reduce_scatter × 4, all_gather × 8 (fp8 + scale per layer,
+        # all 4 layers match the full 3-tuple pattern variant)
+        if op == torch.ops.vllm.all_gather.default:
+            return 8
+        return 4
+
+    def ops_in_model_before(self):
+        return [
+            torch.ops.vllm.all_reduce.default,
+        ]
+
+    def ops_in_model(self):
+        return [
+            torch.ops.vllm_ir.rms_norm,
+            torch.ops.vllm_ir.fused_add_rms_norm,
+            torch.ops.vllm.xpu_mxfp8_quantize.default,
+        ]
+
+
+def _run_sequence_parallelism_pass_test(
+    test_model_cls: type[torch.nn.Module],
+    custom_ops: str,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    fuse_norm_quant: bool,
+    dynamic: bool,
+    model_name: str,
+):
+    # need to use torch.mp.spawn otherwise will have problems with
+    # torch.distributed and cuda
+    num_processes = 2
+    torch.multiprocessing.spawn(
+        sequence_parallelism_pass_on_test_model,
+        args=(
+            num_processes,
+            test_model_cls,
+            custom_ops,
+            batch_size,
+            seq_len,
+            hidden_size,
+            dtype,
+            fuse_norm_quant,
+            dynamic,
+            model_name,
+        ),
+        nprocs=num_processes,
+    )
 
 
 @multi_gpu_test(num_gpus=2)
@@ -190,28 +303,61 @@ def test_sequence_parallelism_pass(
     fuse_norm_quant: bool,
     dynamic: bool,
 ):
-    num_processes = 2
+    _run_sequence_parallelism_pass_test(
+        test_model_cls,
+        custom_ops,
+        batch_size,
+        seq_len,
+        hidden_size,
+        dtype,
+        fuse_norm_quant,
+        dynamic,
+        "RedHatAI/Llama-3.2-1B-Instruct-FP8",
+    )
 
-    def run_torch_spawn(fn, nprocs):
-        # need to use torch.mp.spawn otherwise will have problems with
-        # torch.distributed and cuda
-        torch.multiprocessing.spawn(
-            fn,
-            args=(
-                num_processes,
-                test_model_cls,
-                custom_ops,
-                batch_size,
-                seq_len,
-                hidden_size,
-                dtype,
-                fuse_norm_quant,
-                dynamic,
-            ),
-            nprocs=nprocs,
-        )
 
-    run_torch_spawn(sequence_parallelism_pass_on_test_model, num_processes)
+@multi_gpu_test(num_gpus=2)
+@pytest.mark.parametrize(
+    "test_model_cls, custom_ops",
+    [
+        (
+            TestAllReduceRMSNormXPUMxFP8Model,
+            "+rms_norm",
+        ),
+        (
+            TestAllReduceRMSNormXPUMxFP8Model,
+            "-rms_norm",
+        ),
+    ],
+)
+@pytest.mark.parametrize("batch_size", [8])
+@pytest.mark.parametrize("seq_len", [16])
+@pytest.mark.parametrize("hidden_size", [32])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dynamic", [False, True])
+@pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["xpu"], reason="Only test on XPU")
+def test_sequence_parallelism_pass_xpu_mxfp8(
+    test_model_cls: type[torch.nn.Module],
+    custom_ops: str,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    dynamic: bool,
+):
+    # MXFP8 has no fused rms_norm+quant kernel yet, so fuse_norm_quant
+    # doesn't change the traced graph; keep it fixed at False.
+    _run_sequence_parallelism_pass_test(
+        test_model_cls,
+        custom_ops,
+        batch_size,
+        seq_len,
+        hidden_size,
+        dtype,
+        False,
+        dynamic,
+        "INCModel/Qwen3-30B-A3B-Instruct-2507-MXFP8-CT-AutoRound",
+    )
 
 
 def test_sequence_parallelism_pass_requires_full_graph_compilation():
@@ -243,6 +389,7 @@ def sequence_parallelism_pass_on_test_model(
     dtype: torch.dtype,
     fuse_norm_quant: bool,
     dynamic: bool,
+    model_name: str,
 ):
     set_random_seed(0)
 
@@ -262,7 +409,7 @@ def sequence_parallelism_pass_on_test_model(
     )
 
     # initialize distributed
-    init_distributed_environment()
+    init_distributed_environment(backend=current_platform.dist_backend)
 
     # configure vllm config for SequenceParallelismPass
     custom_ops_list = custom_ops.split(",") if custom_ops else []
@@ -280,7 +427,6 @@ def sequence_parallelism_pass_on_test_model(
 
     # this is a fake model name to construct the model config
     # in the vllm_config, it's not really used.
-    model_name = "RedHatAI/Llama-3.2-1B-Instruct-FP8"
     model_config = ModelConfig(
         model=model_name, trust_remote_code=True, dtype=dtype, seed=42
     )
@@ -337,7 +483,7 @@ def sequence_parallelism_pass_on_test_model(
         # In post-nodes, reduce scatter and all gather should be there,
         # all reduce should not
         for op in model.ops_in_model_after():
-            assert backend.op_count(op, before=False) == 4
+            assert backend.op_count(op, before=False) == model.ops_count_after(op)
 
         for op in model.ops_in_model():
             assert backend.op_count(op, before=False) > 0

--- a/tests/compile/passes/distributed/test_sequence_parallelism.py
+++ b/tests/compile/passes/distributed/test_sequence_parallelism.py
@@ -6,7 +6,7 @@ import torch
 
 import vllm.envs as envs
 from tests.compile.backend import TestBackend
-from tests.utils import TestFP8Layer, multi_gpu_test
+from tests.utils import TestFP8Layer, TestMXFP8Layer, multi_gpu_test
 from vllm.compilation.passes.fusion.rms_quant_fusion import RMSNormQuantFusionPass
 from vllm.compilation.passes.fusion.sequence_parallelism import SequenceParallelismPass
 from vllm.compilation.passes.utility.noop_elimination import NoOpEliminationPass
@@ -38,7 +38,10 @@ from vllm.utils.torch_utils import set_random_seed
 
 DEVICE_TYPE = current_platform.device_type
 
-pytestmark = pytest.mark.skipif(not current_platform.is_cuda(), reason="Only test CUDA")
+pytestmark = pytest.mark.skipif(
+    not (current_platform.is_cuda() or current_platform.is_xpu()),
+    reason="Only test on CUDA or XPU",
+)
 
 FP8_DTYPE = current_platform.fp8_dtype()
 prompts = [
@@ -80,6 +83,9 @@ class TestAllReduceRMSNormModel(torch.nn.Module):
 
     def ops_in_model_before(self):
         return [torch.ops.vllm.all_reduce.default]
+
+    def ops_count_after(self, op) -> int:
+        return 4
 
     def ops_in_model_after(self):
         return [
@@ -145,6 +151,9 @@ class TestAllReduceRMSNormStaticQuantFP8Model(torch.nn.Module):
             torch.ops.vllm.all_reduce.default,
         ]
 
+    def ops_count_after(self, op) -> int:
+        return 4
+
     def ops_in_model(self):
         if self.vllm_config.compilation_config.pass_config.fuse_norm_quant:
             return [torch.ops._C.fused_add_rms_norm_static_fp8_quant.default]
@@ -159,6 +168,110 @@ class TestAllReduceRMSNormStaticQuantFP8Model(torch.nn.Module):
                 torch.ops.vllm_ir.fused_add_rms_norm,
                 *quant_ops,
             ]
+
+
+class TestAllReduceRMSNormXPUMxFP8Model(torch.nn.Module):
+    """Model with all_reduce → rms_norm/fused_add_rms_norm → xpu_mxfp8_quantize.
+
+    Tests FirstAllReduceRMSNormXPUMxFP8Pattern (layer 0) and
+    MiddleAllReduceRMSNormXPUMxFP8Pattern (layers 1-3).
+    hidden_size must be divisible by 32 (MXFP8 block size).
+    """
+
+    def __init__(self, hidden_size=32, eps=1e-6):
+        super().__init__()
+        self.vllm_config = get_current_vllm_config()
+        self.hidden_size = hidden_size
+        self.eps = eps
+        self.dtype = torch.bfloat16
+        self.norm = [RMSNorm(hidden_size, eps) for _ in range(4)]
+        self.mxfp8_linear_layers = [
+            TestMXFP8Layer(
+                hidden_size=hidden_size,
+            )
+            for _ in range(4)
+        ]
+
+    def forward(self, hidden_states):
+        z = torch.relu(hidden_states)
+        x = resid = tensor_model_parallel_all_reduce(z)
+        y = self.norm[0](x)
+        # First pattern: rms_norm → xpu_mxfp8_quantize
+        z2 = self.mxfp8_linear_layers[0](y)
+
+        x2 = tensor_model_parallel_all_reduce(z2)
+        y2, resid = self.norm[1](x2, resid)
+        # Middle pattern 1
+        z3 = self.mxfp8_linear_layers[1](y2)
+
+        x3 = tensor_model_parallel_all_reduce(z3)
+        y3, resid = self.norm[2](x3, resid)
+        # Middle pattern 2
+        z4 = self.mxfp8_linear_layers[2](y3)
+
+        x4 = tensor_model_parallel_all_reduce(z4)
+        y4, resid = self.norm[3](x4, resid)
+        # Middle pattern 3: fp8_gemm uses both fp8 and scale; return resid so
+        # residual_out has a consumer → full 3-tuple pattern matches (2 all_gathers)
+        z5 = self.mxfp8_linear_layers[3](y4)
+        return z5, resid
+
+    def ops_in_model_after(self):
+        return [
+            torch.ops.vllm.all_gather.default,
+            torch.ops.vllm.reduce_scatter.default,
+        ]
+
+    def ops_count_after(self, op) -> int:
+        # After SP pass: reduce_scatter × 4, all_gather × 8 (fp8 + scale per layer,
+        # all 4 layers match the full 3-tuple pattern variant)
+        if op == torch.ops.vllm.all_gather.default:
+            return 8
+        return 4
+
+    def ops_in_model_before(self):
+        return [
+            torch.ops.vllm.all_reduce.default,
+        ]
+
+    def ops_in_model(self):
+        return [
+            torch.ops.vllm_ir.rms_norm,
+            torch.ops.vllm_ir.fused_add_rms_norm,
+            torch.ops.vllm.xpu_mxfp8_quantize.default,
+        ]
+
+
+def _run_sequence_parallelism_pass_test(
+    test_model_cls: type[torch.nn.Module],
+    custom_ops: str,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    fuse_norm_quant: bool,
+    dynamic: bool,
+    model_name: str,
+):
+    # need to use torch.mp.spawn otherwise will have problems with
+    # torch.distributed and cuda
+    num_processes = 2
+    torch.multiprocessing.spawn(
+        sequence_parallelism_pass_on_test_model,
+        args=(
+            num_processes,
+            test_model_cls,
+            custom_ops,
+            batch_size,
+            seq_len,
+            hidden_size,
+            dtype,
+            fuse_norm_quant,
+            dynamic,
+            model_name,
+        ),
+        nprocs=num_processes,
+    )
 
 
 @multi_gpu_test(num_gpus=2)
@@ -190,28 +303,61 @@ def test_sequence_parallelism_pass(
     fuse_norm_quant: bool,
     dynamic: bool,
 ):
-    num_processes = 2
+    _run_sequence_parallelism_pass_test(
+        test_model_cls,
+        custom_ops,
+        batch_size,
+        seq_len,
+        hidden_size,
+        dtype,
+        fuse_norm_quant,
+        dynamic,
+        "RedHatAI/Llama-3.2-1B-Instruct-FP8",
+    )
 
-    def run_torch_spawn(fn, nprocs):
-        # need to use torch.mp.spawn otherwise will have problems with
-        # torch.distributed and cuda
-        torch.multiprocessing.spawn(
-            fn,
-            args=(
-                num_processes,
-                test_model_cls,
-                custom_ops,
-                batch_size,
-                seq_len,
-                hidden_size,
-                dtype,
-                fuse_norm_quant,
-                dynamic,
-            ),
-            nprocs=nprocs,
-        )
 
-    run_torch_spawn(sequence_parallelism_pass_on_test_model, num_processes)
+@multi_gpu_test(num_gpus=2)
+@pytest.mark.parametrize(
+    "test_model_cls, custom_ops",
+    [
+        (
+            TestAllReduceRMSNormXPUMxFP8Model,
+            "+rms_norm",
+        ),
+        (
+            TestAllReduceRMSNormXPUMxFP8Model,
+            "-rms_norm",
+        ),
+    ],
+)
+@pytest.mark.parametrize("batch_size", [8])
+@pytest.mark.parametrize("seq_len", [16])
+@pytest.mark.parametrize("hidden_size", [32])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dynamic", [False, True])
+@pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["xpu"], reason="Only test on XPU")
+def test_sequence_parallelism_pass_xpu_mxfp8(
+    test_model_cls: type[torch.nn.Module],
+    custom_ops: str,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    dynamic: bool,
+):
+    # MXFP8 has no fused rms_norm+quant kernel yet, so fuse_norm_quant
+    # doesn't change the traced graph; keep it fixed at False.
+    _run_sequence_parallelism_pass_test(
+        test_model_cls,
+        custom_ops,
+        batch_size,
+        seq_len,
+        hidden_size,
+        dtype,
+        False,
+        dynamic,
+        "INCModel/Qwen3-32B-MXFP8-CT-AutoRound",
+    )
 
 
 def test_sequence_parallelism_pass_requires_full_graph_compilation():
@@ -243,6 +389,7 @@ def sequence_parallelism_pass_on_test_model(
     dtype: torch.dtype,
     fuse_norm_quant: bool,
     dynamic: bool,
+    model_name: str,
 ):
     set_random_seed(0)
 
@@ -262,7 +409,7 @@ def sequence_parallelism_pass_on_test_model(
     )
 
     # initialize distributed
-    init_distributed_environment()
+    init_distributed_environment(backend=current_platform.dist_backend)
 
     # configure vllm config for SequenceParallelismPass
     custom_ops_list = custom_ops.split(",") if custom_ops else []
@@ -280,7 +427,6 @@ def sequence_parallelism_pass_on_test_model(
 
     # this is a fake model name to construct the model config
     # in the vllm_config, it's not really used.
-    model_name = "RedHatAI/Llama-3.2-1B-Instruct-FP8"
     model_config = ModelConfig(
         model=model_name, trust_remote_code=True, dtype=dtype, seed=42
     )
@@ -337,7 +483,7 @@ def sequence_parallelism_pass_on_test_model(
         # In post-nodes, reduce scatter and all gather should be there,
         # all reduce should not
         for op in model.ops_in_model_after():
-            assert backend.op_count(op, before=False) == 4
+            assert backend.op_count(op, before=False) == model.ops_count_after(op)
 
         for op in model.ops_in_model():
             assert backend.op_count(op, before=False) > 0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -50,6 +50,10 @@ from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear import (
     _KernelT,
     init_fp8_linear_kernel,
+    init_mxfp8_linear_kernel,
+)
+from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+    MXFP8_BLOCK_SIZE,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
@@ -2369,6 +2373,34 @@ class TestFP8Layer(torch.nn.Module):
 
     def is_quant_fp8_enabled(self) -> bool:
         return self.kernel.quant_fp8.enabled()
+
+    def forward(
+        self, y: torch.Tensor, bias: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        return self.kernel.apply_weights(self, y, bias)
+
+
+class TestMXFP8Layer(torch.nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        block_size: int = MXFP8_BLOCK_SIZE,
+        scale_exp_range: tuple[int, int] = (118, 138),
+        device: torch.device | None = None,
+    ):
+        super().__init__()
+        self.weight = torch.rand([hidden_size, hidden_size], device=device).to(
+            dtype=FP8_DTYPE
+        )
+        self.weight_scale = torch.randint(
+            scale_exp_range[0],
+            scale_exp_range[1],
+            (hidden_size, hidden_size // block_size),
+            dtype=torch.uint8,
+            device=device,
+        )
+        self.kernel = init_mxfp8_linear_kernel()
+        self.kernel.process_weights_after_loading(self)
 
     def forward(
         self, y: torch.Tensor, bias: torch.Tensor | None = None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -46,6 +46,12 @@ from vllm.distributed import (
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.entrypoints.cli.serve import ServeSubcommand
 from vllm.logger import init_logger
+from vllm.model_executor.kernels.linear import (
+    init_mxfp8_linear_kernel,
+)
+from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+    MXFP8_BLOCK_SIZE,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
 )
@@ -2430,6 +2436,34 @@ class TestFP8Layer(torch.nn.Module):
 
     def is_quant_fp8_enabled(self) -> bool:
         return self.kernel.quant_fp8.enabled()
+
+    def forward(
+        self, y: torch.Tensor, bias: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        return self.kernel.apply_weights(self, y, bias)
+
+
+class TestMXFP8Layer(torch.nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        block_size: int = MXFP8_BLOCK_SIZE,
+        scale_exp_range: tuple[int, int] = (118, 138),
+        device: torch.device | None = None,
+    ):
+        super().__init__()
+        self.weight = torch.rand([hidden_size, hidden_size], device=device).to(
+            dtype=FP8_DTYPE
+        )
+        self.weight_scale = torch.randint(
+            scale_exp_range[0],
+            scale_exp_range[1],
+            (hidden_size, hidden_size // block_size),
+            dtype=torch.uint8,
+            device=device,
+        )
+        self.kernel = init_mxfp8_linear_kernel()
+        self.kernel.process_weights_after_loading(self)
 
     def forward(
         self, y: torch.Tensor, bias: torch.Tensor | None = None

--- a/vllm/_xpu_ops.py
+++ b/vllm/_xpu_ops.py
@@ -42,6 +42,21 @@ if hasattr(torch.ops._xpu_C, "fp8_gemm"):
         return torch.empty((M, N), dtype=out_dtype, device=q_input.device)
 
 
+if hasattr(torch.ops._xpu_C, "fp8_gemm_out"):
+
+    @register_fake("_xpu_C::fp8_gemm_out")
+    def _fp8_gemm_out_fake(
+        out: torch.Tensor,
+        q_input: torch.Tensor,
+        q_weight: torch.Tensor,
+        out_dtype: torch.dtype,
+        input_scales: torch.Tensor,
+        weight_scale: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return out
+
+
 if hasattr(torch.ops._xpu_C, "fp8_gemm_w8a16"):
 
     @register_fake("_xpu_C::fp8_gemm_w8a16")

--- a/vllm/_xpu_ops.py
+++ b/vllm/_xpu_ops.py
@@ -42,21 +42,6 @@ if hasattr(torch.ops._xpu_C, "fp8_gemm"):
         return torch.empty((M, N), dtype=out_dtype, device=q_input.device)
 
 
-if hasattr(torch.ops._xpu_C, "fp8_gemm_out"):
-
-    @register_fake("_xpu_C::fp8_gemm_out")
-    def _fp8_gemm_out_fake(
-        out: torch.Tensor,
-        q_input: torch.Tensor,
-        q_weight: torch.Tensor,
-        out_dtype: torch.dtype,
-        input_scales: torch.Tensor,
-        weight_scale: torch.Tensor,
-        bias: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        return out
-
-
 if hasattr(torch.ops._xpu_C, "fp8_gemm_w8a16"):
 
     @register_fake("_xpu_C::fp8_gemm_w8a16")

--- a/vllm/compilation/passes/fusion/sequence_parallelism.py
+++ b/vllm/compilation/passes/fusion/sequence_parallelism.py
@@ -23,6 +23,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
 )
+from vllm.platforms import current_platform
 
 from ..inductor_pass import enable_fake_mode
 from ..utility.noop_elimination import NoOpEliminationPass
@@ -70,7 +71,6 @@ def get_sequence_parallelism_threshold(
     Formula: min_token_num = (min_per_gpu_size_mb * tp_size * MiB) //
              (hidden_size * element_size)
     """
-    from vllm.platforms import current_platform
 
     if current_platform.is_xpu():
         min_hidden_size = 4096
@@ -495,6 +495,122 @@ class MiddleAllReduceRMSNormStaticNVFP4Pattern(_SequenceParallelPatternHelper):
         )
 
 
+class FirstAllReduceRMSNormXPUMxFP8Pattern(_SequenceParallelPatternHelper):
+    def get_inputs(self) -> list[torch.Tensor]:
+        # Input width must be >= 32 (MXFP8 block size) so the scale tensor
+        # [tokens, width//32] is non-degenerate during pattern tracing.
+        return [self.empty([8, 32]), self.empty([32])]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            all_reduce = self._all_reduce(input)
+            rms = vllm.ir.ops.rms_norm(all_reduce, weight, self.epsilon)
+            quant = torch.ops.vllm.xpu_mxfp8_quantize(rms)
+            # `rms` (a plain bf16/fp16 tensor) is returned first so torch's
+            # PatternMatcherPass anchors this MultiOutputPattern on the
+            # rms_norm node. If quant[0]/quant[1] (a getitem unpacking
+            # xpu_mxfp8_quantize's tuple output) were returned first instead,
+            # the anchor would fall on that getitem node. Any getitem whose
+            # producer's fake-tensor metadata contains torch.float8_e8m0fnu
+            # (the MXFP8 scale dtype) is unconditionally treated as
+            # "unsupported" by torch's fallback_node_due_to_unsupported_type
+            # check in PatternMatcherPass.apply() - because operator.getitem
+            # is a plain builtin, not an OpOverload, it is never in the
+            # narrow whitelist (aten.view.dtype/cat/clone/_scaled_mm) that
+            # bypasses this check. That would cause this pattern to be
+            # skipped entirely, before any match is even attempted.
+            return rms, all_reduce, quant[0], quant[1]
+
+        def replacement(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            reduce_scatter = self._reduce_scatter(input)
+            rms = vllm.ir.ops.rms_norm(reduce_scatter, weight, self.epsilon)
+            quant = torch.ops.vllm.xpu_mxfp8_quantize(rms)
+            all_gather_fp8 = self._all_gather(quant[0])
+            # XCCL does not support f8e8m0fnu. For the collective, reinterpret it as
+            # uint8 (since f8e8m0fnu is unsigned, uint8 is the natural bitwise alias),
+            # then restore the view after gathering.
+            all_gather_scale = self._all_gather(quant[1].view(torch.uint8)).view(
+                torch.float8_e8m0fnu
+            )
+            return (
+                rms,
+                reduce_scatter,
+                all_gather_fp8,
+                all_gather_scale,
+            )
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
+class MiddleAllReduceRMSNormXPUMxFP8Pattern(_SequenceParallelPatternHelper):
+    def get_inputs(self) -> list[torch.Tensor]:
+        mm_1 = torch.empty([8, 32])
+        residual = torch.empty([8, 32])
+        rms_norm_weights = torch.empty([32])
+        return [residual, mm_1, rms_norm_weights]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            residual: torch.Tensor,
+            mm_1: torch.Tensor,
+            rms_norm_weights: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            all_reduce = self._all_reduce(mm_1)
+            rms, residual_out = vllm.ir.ops.fused_add_rms_norm(
+                all_reduce, residual, rms_norm_weights, self.epsilon
+            )
+            quant = torch.ops.vllm.xpu_mxfp8_quantize(rms)
+            # Same reasoning as in FirstAllReduceRMSNormXPUMxFP8Pattern above:
+            # `rms`/`residual_out` must come first in the returned tuple so
+            # the pattern is anchored on the fused_add_rms_norm node (bf16/
+            # fp16 output) rather than on the getitem unpacking fp8/scale
+            # from xpu_mxfp8_quantize. Anchoring on that getitem would make
+            # torch's PatternMatcherPass skip the whole pattern via
+            # fallback_node_due_to_unsupported_type, since the scale output
+            # is torch.float8_e8m0fnu and getitem is never in the small
+            # OpOverload whitelist that bypasses that check.
+            return rms, residual_out, quant[0], quant[1]
+
+        def replacement(
+            residual: torch.Tensor,
+            mm_1: torch.Tensor,
+            rms_norm_weights: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            # Keep this slice in sync with the non-quantized SP replacement:
+            # once the previous SP pattern fires, it becomes a no-op.
+            reduce_scatter = self._reduce_scatter(mm_1)
+            residual = residual[0 : reduce_scatter.size(0), ...]
+            rms, residual_out = vllm.ir.ops.fused_add_rms_norm(
+                reduce_scatter, residual, rms_norm_weights, self.epsilon
+            )
+            quant = torch.ops.vllm.xpu_mxfp8_quantize(rms)
+            all_gather_fp8 = self._all_gather(quant[0])
+            # XCCL does not support f8e8m0fnu. For the collective, reinterpret it as
+            # uint8 (since f8e8m0fnu is unsigned, uint8 is the natural bitwise alias),
+            # then restore the view after gathering.
+            all_gather_scale = self._all_gather(quant[1].view(torch.uint8)).view(
+                torch.float8_e8m0fnu
+            )
+            return (
+                rms,
+                residual_out,
+                all_gather_fp8,
+                all_gather_scale,
+            )
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
 class SequenceParallelismPass(VllmPatternMatcherPass):
     """
     This pass enables sequence parallelism for models.
@@ -575,6 +691,14 @@ class SequenceParallelismPass(VllmPatternMatcherPass):
                     epsilon, self.model_dtype, self.device
                 ).register(self.patterns)
                 MiddleAllReduceRMSNormStaticNVFP4Pattern(
+                    epsilon, self.model_dtype, self.device
+                ).register(self.patterns)
+
+            if hasattr(torch.ops.vllm, "xpu_mxfp8_quantize"):
+                FirstAllReduceRMSNormXPUMxFP8Pattern(
+                    epsilon, self.model_dtype, self.device
+                ).register(self.patterns)
+                MiddleAllReduceRMSNormXPUMxFP8Pattern(
                     epsilon, self.model_dtype, self.device
                 ).register(self.patterns)
 

--- a/vllm/compilation/passes/fusion/sequence_parallelism.py
+++ b/vllm/compilation/passes/fusion/sequence_parallelism.py
@@ -495,6 +495,122 @@ class MiddleAllReduceRMSNormStaticNVFP4Pattern(_SequenceParallelPatternHelper):
         )
 
 
+class FirstAllReduceRMSNormXPUMxFP8Pattern(_SequenceParallelPatternHelper):
+    def get_inputs(self) -> list[torch.Tensor]:
+        # Input width must be >= 32 (MXFP8 block size) so the scale tensor
+        # [tokens, width//32] is non-degenerate during pattern tracing.
+        return [self.empty([8, 32]), self.empty([32])]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            all_reduce = self._all_reduce(input)
+            rms = vllm.ir.ops.rms_norm(all_reduce, weight, self.epsilon)
+            quant = torch.ops.vllm.xpu_mxfp8_quantize(rms)
+            # `rms` (a plain bf16/fp16 tensor) is returned first so torch's
+            # PatternMatcherPass anchors this MultiOutputPattern on the
+            # rms_norm node. If quant[0]/quant[1] (a getitem unpacking
+            # xpu_mxfp8_quantize's tuple output) were returned first instead,
+            # the anchor would fall on that getitem node. Any getitem whose
+            # producer's fake-tensor metadata contains torch.float8_e8m0fnu
+            # (the MXFP8 scale dtype) is unconditionally treated as
+            # "unsupported" by torch's fallback_node_due_to_unsupported_type
+            # check in PatternMatcherPass.apply() - because operator.getitem
+            # is a plain builtin, not an OpOverload, it is never in the
+            # narrow whitelist (aten.view.dtype/cat/clone/_scaled_mm) that
+            # bypasses this check. That would cause this pattern to be
+            # skipped entirely, before any match is even attempted.
+            return rms, all_reduce, quant[0], quant[1]
+
+        def replacement(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            reduce_scatter = self._reduce_scatter(input)
+            rms = vllm.ir.ops.rms_norm(reduce_scatter, weight, self.epsilon)
+            quant = torch.ops.vllm.xpu_mxfp8_quantize(rms)
+            all_gather_fp8 = self._all_gather(quant[0])
+            # XCCL does not support f8e8m0fnu. For the collective, reinterpret it as
+            # uint8 (since f8e8m0fnu is unsigned, uint8 is the natural bitwise alias),
+            # then restore the view after gathering.
+            all_gather_scale = self._all_gather(quant[1].view(torch.uint8)).view(
+                torch.float8_e8m0fnu
+            )
+            return (
+                rms,
+                reduce_scatter,
+                all_gather_fp8,
+                all_gather_scale,
+            )
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
+class MiddleAllReduceRMSNormXPUMxFP8Pattern(_SequenceParallelPatternHelper):
+    def get_inputs(self) -> list[torch.Tensor]:
+        mm_1 = torch.empty([8, 32])
+        residual = torch.empty([8, 32])
+        rms_norm_weights = torch.empty([32])
+        return [residual, mm_1, rms_norm_weights]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            residual: torch.Tensor,
+            mm_1: torch.Tensor,
+            rms_norm_weights: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            all_reduce = self._all_reduce(mm_1)
+            rms, residual_out = vllm.ir.ops.fused_add_rms_norm(
+                all_reduce, residual, rms_norm_weights, self.epsilon
+            )
+            quant = torch.ops.vllm.xpu_mxfp8_quantize(rms)
+            # Same reasoning as in FirstAllReduceRMSNormXPUMxFP8Pattern above:
+            # `rms`/`residual_out` must come first in the returned tuple so
+            # the pattern is anchored on the fused_add_rms_norm node (bf16/
+            # fp16 output) rather than on the getitem unpacking fp8/scale
+            # from xpu_mxfp8_quantize. Anchoring on that getitem would make
+            # torch's PatternMatcherPass skip the whole pattern via
+            # fallback_node_due_to_unsupported_type, since the scale output
+            # is torch.float8_e8m0fnu and getitem is never in the small
+            # OpOverload whitelist that bypasses that check.
+            return rms, residual_out, quant[0], quant[1]
+
+        def replacement(
+            residual: torch.Tensor,
+            mm_1: torch.Tensor,
+            rms_norm_weights: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            # Keep this slice in sync with the non-quantized SP replacement:
+            # once the previous SP pattern fires, it becomes a no-op.
+            reduce_scatter = self._reduce_scatter(mm_1)
+            residual = residual[0 : reduce_scatter.size(0), ...]
+            rms, residual_out = vllm.ir.ops.fused_add_rms_norm(
+                reduce_scatter, residual, rms_norm_weights, self.epsilon
+            )
+            quant = torch.ops.vllm.xpu_mxfp8_quantize(rms)
+            all_gather_fp8 = self._all_gather(quant[0])
+            # XCCL does not support f8e8m0fnu. For the collective, reinterpret it as
+            # uint8 (since f8e8m0fnu is unsigned, uint8 is the natural bitwise alias),
+            # then restore the view after gathering.
+            all_gather_scale = self._all_gather(quant[1].view(torch.uint8)).view(
+                torch.float8_e8m0fnu
+            )
+            return (
+                rms,
+                residual_out,
+                all_gather_fp8,
+                all_gather_scale,
+            )
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
 class SequenceParallelismPass(VllmPatternMatcherPass):
     """
     This pass enables sequence parallelism for models.
@@ -575,6 +691,14 @@ class SequenceParallelismPass(VllmPatternMatcherPass):
                     epsilon, self.model_dtype, self.device
                 ).register(self.patterns)
                 MiddleAllReduceRMSNormStaticNVFP4Pattern(
+                    epsilon, self.model_dtype, self.device
+                ).register(self.patterns)
+
+            if hasattr(torch.ops.vllm, "xpu_mxfp8_quantize"):
+                FirstAllReduceRMSNormXPUMxFP8Pattern(
+                    epsilon, self.model_dtype, self.device
+                ).register(self.patterns)
+                MiddleAllReduceRMSNormXPUMxFP8Pattern(
                     epsilon, self.model_dtype, self.device
                 ).register(self.patterns)
 

--- a/vllm/compilation/passes/fusion/sequence_parallelism.py
+++ b/vllm/compilation/passes/fusion/sequence_parallelism.py
@@ -694,7 +694,9 @@ class SequenceParallelismPass(VllmPatternMatcherPass):
                     epsilon, self.model_dtype, self.device
                 ).register(self.patterns)
 
-            if hasattr(torch.ops.vllm, "xpu_mxfp8_quantize"):
+            if current_platform.is_xpu() and hasattr(
+                torch.ops.vllm, "xpu_mxfp8_quantize"
+            ):
                 FirstAllReduceRMSNormXPUMxFP8Pattern(
                     epsilon, self.model_dtype, self.device
                 ).register(self.patterns)

--- a/vllm/compilation/passes/fusion/sequence_parallelism.py
+++ b/vllm/compilation/passes/fusion/sequence_parallelism.py
@@ -23,7 +23,6 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
 )
-from vllm.platforms import current_platform
 
 from ..inductor_pass import enable_fake_mode
 from ..utility.noop_elimination import NoOpEliminationPass
@@ -71,6 +70,8 @@ def get_sequence_parallelism_threshold(
     Formula: min_token_num = (min_per_gpu_size_mb * tp_size * MiB) //
              (hidden_size * element_size)
     """
+    from vllm.platforms import current_platform
+
     if current_platform.is_xpu():
         min_hidden_size = 4096
         min_per_gpu_size_mb = 8.0
@@ -694,6 +695,8 @@ class SequenceParallelismPass(VllmPatternMatcherPass):
                 MiddleAllReduceRMSNormStaticNVFP4Pattern(
                     epsilon, self.model_dtype, self.device
                 ).register(self.patterns)
+
+            from vllm.platforms import current_platform
 
             if current_platform.is_xpu():
                 FirstAllReduceRMSNormXPUMxFP8Pattern(

--- a/vllm/compilation/passes/fusion/sequence_parallelism.py
+++ b/vllm/compilation/passes/fusion/sequence_parallelism.py
@@ -23,6 +23,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
 )
+from vllm.platforms import current_platform
 
 from ..inductor_pass import enable_fake_mode
 from ..utility.noop_elimination import NoOpEliminationPass
@@ -70,8 +71,6 @@ def get_sequence_parallelism_threshold(
     Formula: min_token_num = (min_per_gpu_size_mb * tp_size * MiB) //
              (hidden_size * element_size)
     """
-    from vllm.platforms import current_platform
-
     if current_platform.is_xpu():
         min_hidden_size = 4096
         min_per_gpu_size_mb = 8.0
@@ -535,6 +534,7 @@ class FirstAllReduceRMSNormXPUMxFP8Pattern(_SequenceParallelPatternHelper):
             # XCCL does not support f8e8m0fnu. For the collective, reinterpret it as
             # uint8 (since f8e8m0fnu is unsigned, uint8 is the natural bitwise alias),
             # then restore the view after gathering.
+            # TODO: Remove this cast and restore normal view once XCCL adds support.
             all_gather_scale = self._all_gather(quant[1].view(torch.uint8)).view(
                 torch.float8_e8m0fnu
             )
@@ -596,6 +596,7 @@ class MiddleAllReduceRMSNormXPUMxFP8Pattern(_SequenceParallelPatternHelper):
             # XCCL does not support f8e8m0fnu. For the collective, reinterpret it as
             # uint8 (since f8e8m0fnu is unsigned, uint8 is the natural bitwise alias),
             # then restore the view after gathering.
+            # TODO: Remove this cast and restore normal view once XCCL adds support.
             all_gather_scale = self._all_gather(quant[1].view(torch.uint8)).view(
                 torch.float8_e8m0fnu
             )
@@ -694,9 +695,7 @@ class SequenceParallelismPass(VllmPatternMatcherPass):
                     epsilon, self.model_dtype, self.device
                 ).register(self.patterns)
 
-            if current_platform.is_xpu() and hasattr(
-                torch.ops.vllm, "xpu_mxfp8_quantize"
-            ):
+            if current_platform.is_xpu():
                 FirstAllReduceRMSNormXPUMxFP8Pattern(
                     epsilon, self.model_dtype, self.device
                 ).register(self.patterns)


### PR DESCRIPTION
## Purpose

Enable sequence parallelism (SP) for MXFP8 (W8A8, e8m0 block-scale) quantized models on XPU, allowing the SP compilation pass (`enable_sp`) to be turned on for this quant path via `--compilation-config`.

## Test Plan

Model: `INCModel/Qwen3-32B-MXFP8-CT-AutoRound` (dense, MXFP8 W8A8), tp=4.

### Server 

```bash
# sp_on
VLLM_XPU_FUSED_MOE_USE_REF=1 VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 VLLM_WORKER_MULTIPROC_METHOD=spawn \
python3 -m vllm.entrypoints.openai.api_server \
    --model INCModel/Qwen3-32B-MXFP8-CT-AutoRound --port 8072 --host 0.0.0.0 \
    --trust-remote-code --gpu-memory-util=0.9 --no-enable-prefix-caching \
    --max-num-batched-tokens=8192 --max-model-len=6000 --block-size 64 -tp=4 \
    --compilation-config '{"pass_config":{"enable_sp":true},"use_inductor_graph_partition":true}'

# sp_off
VLLM_XPU_FUSED_MOE_USE_REF=1 VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 VLLM_WORKER_MULTIPROC_METHOD=spawn \
python3 -m vllm.entrypoints.openai.api_server \
    --model INCModel/Qwen3-32B-MXFP8-CT-AutoRound --port 8072 --host 0.0.0.0 \
    --trust-remote-code --gpu-memory-util=0.9 --no-enable-prefix-caching \
    --max-num-batched-tokens=8192 --max-model-len=6000 --block-size 64 -tp=4

# eager
VLLM_XPU_FUSED_MOE_USE_REF=1 VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 VLLM_WORKER_MULTIPROC_METHOD=spawn \
python3 -m vllm.entrypoints.openai.api_server \
    --model INCModel/Qwen3-32B-MXFP8-CT-AutoRound --port 8072 --host 0.0.0.0 \
    --trust-remote-code --gpu-memory-util=0.9 --no-enable-prefix-caching \
    --max-num-batched-tokens=8192 --max-model-len=6000 --block-size 64 -tp=4 --enforce-eager
```

### Client 

```bash
timeout -s KILL 6000000s python3 -m vllm.entrypoints.cli.main bench serve \
    --model INCModel/Qwen3-32B-MXFP8-CT-AutoRound \
    --ready-check-timeout-sec 1 --temperature=0 \
    --dataset-name random --random-input-len=4096 --random-output-len=1024 \
    --ignore-eos --port=8072 --host 0.0.0.0 \
    --num-prompt 55 --request-rate inf --backend vllm --trust-remote-code \
    --max-concurrency 11
```

## Test Result

### Accuracy (GSM8K, 5-shot, 250 questions)

| Case   | Accuracy | Invalid rate |
|--------|----------|--------------|
| eager (baseline) | 0.544 | 0.0 |
| sp_off | 0.516 | 0.0 |
| sp_on  | 0.504  | 0.0 |

### Benchmark: sp_on vs sp_off (direct comparison)

Workload: 55 prompts, input_len=4096, output_len=1024, concurrency=11. Positive % = improvement (higher throughput / lower latency).

| Metric | sp_off | sp_on | Improvement |
|--------|--------|-------|-------------|
| Output throughput (tok/s) | 47.57 | 48.20 | **+1.32% ↑** |
| Mean TTFT (ms) | 35802 | 34160 | **+4.58% ↑** |
| Median TTFT (ms) | 35596 | 33764 | **+5.14% ↑** |
| P99 TTFT (ms) | 77326 | 72264 | **+6.55% ↑** |
| Mean TPOT (ms) | 196.36 | 194.95 | **+0.72% ↑** |
| P99 TPOT (ms) | 224.75 | 222.35 | **+1.07% ↑** |

SP improves TTFT by 4–6.5% on prefill-heavy workloads by distributing long-sequence prefill computation across TP ranks via reduce-scatter/all-gather fusion.

### Benchmark: all configurations vs eager baseline

| Case | Output throughput (tok/s) | Mean TTFT (ms) | Median TTFT (ms) | P99 TTFT (ms) | Mean TPOT (ms) | P99 TPOT (ms) |
|------|---------------------------|----------------|-------------------|----------------|-----------------|-----------------|
| eager (baseline) | 50.58 | 33829 | 34229 | 74376 | 184.54 | 211.63 |
| sp_off (compile, no SP) | 47.57 (-5.95%) | 35802 (-5.83%) | 35596 (-3.99%) | 77326 (-3.97%) | 196.36 (-6.41%) | 224.75 (-6.20%) |
| sp_on (compile + SP) | 48.20 (-4.71%) | 34160 (-0.98%) | 33764 (+1.36%) | 72264 (+2.84%) | 194.95 (-5.64%) | 222.35 (-5.07%) |

> **Note**: `sp_off` (compile without SP) shows a regression vs eager due to torch.compile overhead on XPU for this model size. Enabling SP (`sp_on`) recovers most of that regression, particularly for TTFT where the prefill-phase reduce-scatter fusion is active.
