### PR TITLE
[Misc] Add missing -> None return annotations and ReadOnly field markers

### DIFF
--- a/vllm/config/device.py
+++ b/vllm/config/device.py
@@ -46,7 +46,7 @@ class DeviceConfig:
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.device == "auto":
             # Automated device type detection
             from vllm.platforms import current_platform

--- a/vllm/config/kv_events.py
+++ b/vllm/config/kv_events.py
@@ -47,6 +47,6 @@ class KVEventsConfig:
     this topic to receive events.
     """
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.publisher is None:
             self.publisher = "zmq" if self.enable_kv_cache_events else "null"

--- a/vllm/config/mamba.py
+++ b/vllm/config/mamba.py
@@ -53,7 +53,7 @@ class MambaConfig:
             return MambaBackendEnum[value.upper()]
         return value
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.enable_stochastic_rounding:
             from vllm.platforms import current_platform
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -663,7 +663,7 @@ class SpeculativeConfig:
         parts = model.split(".")
         return len(parts) >= 2 and all(part.isidentifier() for part in parts)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Note: "method" is a new parameter that helps to extend the
         # configuration of non-model-based proposers, and the "model" parameter
         # will be used to set the draft model, eagle head, or additional weight
@@ -1047,7 +1047,6 @@ class SpeculativeConfig:
                         self.target_parallel_config, self.draft_tensor_parallel_size
                     )
                 )
-        return self
 
     def _validate_suffix_decoding(self):
         if not has_arctic_inference():

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -933,7 +933,7 @@ class VllmConfig:
             "expandable_segments is automatically disabled)."
         )
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Verify configs are valid & consistent with each other."""
 
         # To give each torch profile run a unique instance name.


### PR DESCRIPTION
## Summary

Add missing `-> None` return type annotations to `__post_init__` methods in `vllm/config/` for consistency with other config modules that already have these annotations (e.g., `parallel.py`, `kv_transfer.py`, `compilation.py`). Also resolve a TODO in `chat_utils.py` by adding `ReadOnly` field markers to `ConversationMessage`.

## Changes

### `vllm/entrypoints/chat_utils.py`
- Add `ReadOnly` to typing_extensions imports
- Remove TODO comment: 'Make fields ReadOnly once mypy supports it'
- Wrap non-Required `ConversationMessage` fields in `ReadOnly[...]`

### `vllm/config/` (5 files)
- `device.py`: `__post_init__` → `__post_init__() -> None`
- `kv_events.py`: same
- `mamba.py`: same
- `speculative.py`: same
- `vllm.py`: same

## Test

```
ruff check — all checks passed on changed files
```

---
*AI assistance used — all changes reviewed and verified.*
Co-authored-by: Claude via OpenCode