### PR TITLE
[KV Offload] Add vllm:kv_offload_cpu_total_blocks capacity metric

### DIFF
--- a/tests/v1/kv_offload/cpu/test_manager.py
+++ b/tests/v1/kv_offload/cpu/test_manager.py
@@ -40,9 +40,11 @@ def make_cpu_manager(
     enable_events: bool = False,
     store_threshold: int = 0,
     max_tracker_size: int = 64_000,
+    blocks_per_chunk: int = 1,
 ) -> CPUOffloadingManager:
     return CPUOffloadingManager(
         num_blocks=num_blocks,
+        blocks_per_chunk=blocks_per_chunk,
         cache_policy=cache_policy,
         enable_events=enable_events,
         store_threshold=store_threshold,
@@ -257,6 +259,28 @@ def test_cpu_manager_reports_cache_usage_gauge():
     # and usage drops.
     manager.complete_store(to_keys([3, 4]), _EMPTY_REQ_CTX)
     check_usage_stats(manager, 0.0)
+
+
+def test_cpu_manager_reports_total_blocks_gauge():
+    def total_blocks(manager: CPUOffloadingManager) -> float:
+        stats = manager.get_stats()
+        assert stats is not None
+        return stats.reduce()[CPUOffloadingMetrics.CPU_TOTAL_BLOCKS]
+
+    # Zero-capacity manager reports 0.
+    assert total_blocks(make_cpu_manager(num_blocks=0)) == 0
+
+    # blocks_per_chunk defaults to 1: total == num_blocks.
+    assert total_blocks(make_cpu_manager(num_blocks=4)) == 4
+
+    # Capacity is reported in GPU-block-equivalent units:
+    # total == num_blocks * blocks_per_chunk.
+    manager = make_cpu_manager(num_blocks=4, blocks_per_chunk=8)
+    assert total_blocks(manager) == 32
+
+    # The gauge is a static capacity: it does not change as blocks fill up.
+    manager.prepare_store(to_keys([1, 2]), _EMPTY_REQ_CTX)
+    assert total_blocks(manager) == 32
 
 
 def test_cpu_manager_reports_allocation_size_histogram():

--- a/vllm/v1/kv_offload/cpu/common.py
+++ b/vllm/v1/kv_offload/cpu/common.py
@@ -9,6 +9,7 @@ class CPUOffloadingMetrics:
     CPU_ALLOCATION_SIZE = "vllm:kv_offload_cpu_allocation_size"
     CPU_CACHE_WRITE_USAGE_PERC = "vllm:kv_offload_cpu_cache_write_usage_perc"
     CPU_CACHE_READ_USAGE_PERC = "vllm:kv_offload_cpu_cache_read_usage_perc"
+    CPU_TOTAL_BLOCKS = "vllm:kv_offload_cpu_total_blocks"
 
 
 class CPULoadStoreSpec(BlockIDsLoadStoreSpec):

--- a/vllm/v1/kv_offload/cpu/manager.py
+++ b/vllm/v1/kv_offload/cpu/manager.py
@@ -47,6 +47,7 @@ class CPUOffloadingManager(OffloadingManager):
     def __init__(
         self,
         num_blocks: int,
+        blocks_per_chunk: int = 1,
         cache_policy: Literal["lru", "arc"] = "lru",
         enable_events: bool = False,
         store_threshold: int = 1,
@@ -54,6 +55,9 @@ class CPUOffloadingManager(OffloadingManager):
     ):
         self.medium: str = MEDIUM_CPU
         self._num_blocks: int = num_blocks
+        # GPU blocks coalesced into one offload chunk. Used to report the
+        # total offload capacity in GPU-block-equivalent units.
+        self._blocks_per_chunk: int = blocks_per_chunk
         self._num_allocated_blocks: int = 0
         self._free_list: list[int] = []
         self.events: list[OffloadingEvent] | None = [] if enable_events else None
@@ -308,6 +312,14 @@ class CPUOffloadingManager(OffloadingManager):
         )
         usage = num_used / self._num_blocks if self._num_blocks > 0 else 0.0
         stats.set_gauge(CPUOffloadingMetrics.CPU_CACHE_USAGE_PERC, usage)
+
+        # Total offload capacity in GPU-block-equivalent units (constant after
+        # init). Reported for observability alongside the usage gauges;
+        # multiply by the cache block_size for a token count.
+        stats.set_gauge(
+            CPUOffloadingMetrics.CPU_TOTAL_BLOCKS,
+            self._num_blocks * self._blocks_per_chunk,
+        )
 
         for allocation_size in self.allocation_sizes_in_current_batch:
             stats.observe_histogram(

--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -52,6 +52,14 @@ class CPUOffloadingSpec(OffloadingSpec):
                     "completed (0.0 = idle, 1.0 = saturated)."
                 ),
             ),
+            CPUOffloadingMetrics.CPU_TOTAL_BLOCKS: OffloadingGaugeMetadata(
+                documentation=(
+                    "Total CPU KV-cache offload capacity, in GPU-block "
+                    "equivalents (the same unit as num_gpu_blocks; multiply "
+                    "by the cache block_size for a token count). 0 when CPU "
+                    "offloading is disabled or too small to hold a block."
+                ),
+            ),
             CPUOffloadingMetrics.CPU_ALLOCATION_SIZE: OffloadingHistogramMetadata(
                 documentation=(
                     "Histogram of the number of CPU blocks requested by each "
@@ -125,6 +133,7 @@ class CPUOffloadingSpec(OffloadingSpec):
 
             self._manager = CPUOffloadingManager(
                 num_blocks=self.num_blocks,
+                blocks_per_chunk=self.blocks_per_chunk,
                 cache_policy=self.eviction_policy,  # type: ignore[arg-type]
                 enable_events=self.kv_events_config.enable_kv_cache_events,
                 store_threshold=store_threshold,


### PR DESCRIPTION
The native CPU OffloadingConnector reported usage fractions but had no metric for the offload tier's total size. Add a gauge reporting the total capacity in GPU-block-equivalent units (same unit as num_gpu_blocks; multiply by the cache block_size for a token count), emitted alongside the existing usage gauges so the CPU offload tier's capacity is observable. Thread blocks_per_chunk into CPUOffloadingManager for the conversion and cover it with a manager unit test.

## Purpose

The native CPU KV `OffloadingConnector` reports usage-fraction gauges
(`vllm:kv_offload_cpu_cache_usage_perc`, `vllm:kv_offload_cpu_cache_write_usage_perc`,
`vllm:kv_offload_cpu_cache_read_usage_perc`) but exposes no metric for the offload
tier's total size, so its capacity is not observable on `/metrics`.

This PR adds a gauge, `vllm:kv_offload_cpu_total_blocks`, reporting the total CPU
offload capacity in GPU-block-equivalent units — the same unit as `num_gpu_blocks`;
multiply by the cache `block_size` for a token count. The value
(`num_blocks * blocks_per_chunk`) is already computed by the connector at init, so
this only surfaces it: `blocks_per_chunk` is threaded into `CPUOffloadingManager`
and the gauge is emitted alongside the existing usage gauges via the same
`OffloadingConnectorStats` / `KVConnectorProm` path.

Scope: the native `OffloadingConnector` only. `SimpleCPUOffloadConnector` is
unchanged, and `lmcache`'s capacity is owned by an external process and not
reported here. No behavior change beyond the added metric.

## Test Plan

- Unit tests: `pytest tests/v1/kv_offload/cpu/test_manager.py`
  - New `test_cpu_manager_reports_total_blocks_gauge` asserts the gauge equals
    `num_blocks * blocks_per_chunk` (0 → 0; 4×1 → 4; 4×8 → 32) and stays constant
    as blocks fill up.
- Lint / type (pre-commit): `pre-commit run --files vllm/v1/kv_offload/cpu/common.py vllm/v1/kv_offload/cpu/spec.py vllm/v1/kv_offload/cpu/manager.py tests/v1/kv_offload/cpu/test_manager.py`
- (Optional, manual e2e) Serve with `--kv-offloading-size <GiB>` and confirm
  `vllm:kv_offload_cpu_total_blocks` appears on `/metrics` with a non-zero value
  that scales with the configured size.

## Test Result

Unit tests:

$ pytest tests/v1/kv_offload/cpu/test_manager.py
.........................                                                [100%]
25 passed, 1 warning in 2.20s



pre-commit (ruff check, ruff format, typos, mypy, SPDX headers, forbidden-imports,
config-docstring validation): all hooks passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update — n/a: the sibling CPU-offload connector gauges are not listed in `docs/design/metrics.md`, so this metric follows the existing (undocumented) pattern.
</details>