### PR TITLE
[Bugfix] Handle MLA fallback during FA4 JIT warmup

### DIFF
--- a/vllm/model_executor/warmup/fa4_cutedsl_warmup.py
+++ b/vllm/model_executor/warmup/fa4_cutedsl_warmup.py
@@ -21,7 +21,11 @@ def fa4_cutedsl_warmup(worker: Worker) -> None:
     if not vllm_config.model_config.use_mla:
         return
 
-    backend_cls = get_mla_prefill_backend(vllm_config)
+    try:
+        backend_cls = get_mla_prefill_backend(vllm_config)
+    except ValueError:
+        # fall back to top-k MQA prefill path.
+        return
     if backend_cls.get_name() != "FLASH_ATTN":
         return
 


### PR DESCRIPTION
Follow-up to #47451. As @mgoin correctly noted in https://github.com/vllm-project/vllm/pull/47451#discussion_r3616102551, JIT warmup must handle models for which no generic MLA prefill backend is available.

Related auto-revert PR: #49268.