### PR TITLE
Add vllm:kv_offload_cpu_total_blocks capacity metric

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_metrics.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_metrics.py
@@ -24,8 +24,13 @@ from vllm.v1.kv_offload.base import (
     OffloadingGaugeMetadata,
     OffloadingHistogramMetadata,
 )
+from vllm.v1.kv_offload.cpu.common import (
+    CPU_CONFIG_INFO_LABELS,
+    CPUOffloadingMetrics,
+)
 from vllm.v1.kv_offload.factory import OffloadingSpecFactory
 
+CPU_CONFIG_INFO = CPUOffloadingMetrics.CPU_CONFIG_INFO
 LOAD_BYTES = _TransferMetricName.LOAD_BYTES
 LOAD_TIME = _TransferMetricName.LOAD_TIME
 LOAD_SIZE = _TransferMetricName.LOAD_SIZE
@@ -622,6 +627,39 @@ def test_prom_metrics_gauges_collapse_multiprocess_fanout():
     assert metric_defs[PENDING_STORES].kwargs["multiprocess_mode"] == "mostrecent"
     assert "multiprocess_mode" not in metric_defs[STORES_SKIPPED].kwargs
     assert "multiprocess_mode" not in metric_defs[LOOKUP_LATENCY].kwargs
+
+
+def test_prom_metrics_record_config_info():
+    """Static config is emitted at startup as a gauge pinned to 1, carrying the
+    config in its labels (cache_config_info-style), with no stats/observe."""
+    prom_metrics = OffloadPromMetrics(
+        vllm_config=_FakeVllmConfig(store_threshold=0),  # type: ignore[arg-type]
+        metric_types={
+            Gauge: _FakeMetric,
+            Counter: _FakeMetric,
+            Histogram: _FakeMetric,
+        },
+        labelnames=["model_name", "engine"],
+        per_engine_labelvalues={0: ["model", "0"]},
+    )
+
+    labels = {
+        "num_blocks": "4",
+        "blocks_per_chunk": "8",
+        "kv_bytes_per_chunk": "1024",
+        "cpu_page_size_per_worker": "512",
+        "eviction_policy": "lru",
+    }
+    # Metrics this prom does not own are skipped, so MultiConnector can fan the
+    # merged config info out to every child prom.
+    prom_metrics.record_config_info(
+        {CPU_CONFIG_INFO: labels, "vllm:someone_elses_config_info": {}}
+    )
+
+    labelvalues = tuple(labels[name] for name in CPU_CONFIG_INFO_LABELS)
+    gauge = prom_metrics.offloading_metrics[(0, CPU_CONFIG_INFO, labelvalues)]
+    assert gauge.set_values == [1]
+    assert gauge.labelvalues == ("model", "0", *labelvalues)
 
 
 def test_prom_metrics_lazily_observes_labeled_metric():

--- a/tests/v1/kv_connector/unit/offloading_connector/test_metrics.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_metrics.py
@@ -593,6 +593,37 @@ def test_prom_metrics_observes_manager_gauge_and_histogram():
     assert histogram_def.kwargs["buckets"] == (0.1, 1.0)
 
 
+def test_prom_metrics_gauges_collapse_multiprocess_fanout():
+    """Gauges must not fan out per pid: they are point-in-time values for one
+    engine that every API-server process reports. Counters and histograms are
+    per-process cumulative and stay summed."""
+    metric_definitions = {
+        PENDING_STORES: OffloadingGaugeMetadata(documentation="pending stores"),
+        STORES_SKIPPED: OffloadingCounterMetadata(documentation="stores skipped"),
+        LOOKUP_LATENCY: OffloadingHistogramMetadata(documentation="lookup latency"),
+    }
+    with patch.object(
+        OffloadingSpecFactory,
+        "get_spec_cls",
+        return_value=_spec_cls_with_metric_definitions(metric_definitions),
+    ):
+        prom_metrics = OffloadPromMetrics(
+            vllm_config=_FakeVllmConfig(store_threshold=0),  # type: ignore[arg-type]
+            metric_types={
+                Gauge: _FakeMetric,
+                Counter: _FakeMetric,
+                Histogram: _FakeMetric,
+            },
+            labelnames=["model_name", "engine"],
+            per_engine_labelvalues={0: ["model", "0"]},
+        )
+
+    metric_defs = prom_metrics._offloading_metric_defs
+    assert metric_defs[PENDING_STORES].kwargs["multiprocess_mode"] == "mostrecent"
+    assert "multiprocess_mode" not in metric_defs[STORES_SKIPPED].kwargs
+    assert "multiprocess_mode" not in metric_defs[LOOKUP_LATENCY].kwargs
+
+
 def test_prom_metrics_lazily_observes_labeled_metric():
     metric_definitions = {
         MY_COUNTER: OffloadingCounterMetadata(

--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -879,6 +879,23 @@ def test_multi_connector_prefer_cross_layer_blocks(mc):
     assert mc.prefer_cross_layer_blocks is True
 
 
+def test_multi_connector_aggregates_config_info(mc):
+    """Nested connectors' startup config info is merged flat (metric_name ->
+    labels), so a wrapped connector still emits it at startup."""
+    mc._connectors[0].get_config_info = lambda: None
+    mc._connectors[1].get_config_info = lambda: None
+    assert mc.get_config_info() is None
+
+    mc._connectors[0].get_config_info = lambda: {"vllm:first_info": {"a": "1"}}
+    assert mc.get_config_info() == {"vllm:first_info": {"a": "1"}}
+
+    mc._connectors[1].get_config_info = lambda: {"vllm:second_info": {"b": "2"}}
+    assert mc.get_config_info() == {
+        "vllm:first_info": {"a": "1"},
+        "vllm:second_info": {"b": "2"},
+    }
+
+
 def test_multi_connector_worker_metadata(mc):
     class MockConnectorWorkerMetadata(KVConnectorWorkerMetadata):
         def __init__(self, data: set[str]):

--- a/tests/v1/kv_offload/cpu/test_manager.py
+++ b/tests/v1/kv_offload/cpu/test_manager.py
@@ -41,9 +41,11 @@ def make_cpu_manager(
     enable_events: bool = False,
     store_threshold: int = 0,
     max_tracker_size: int = 64_000,
+    config_info: dict[str, str] | None = None,
 ) -> CPUOffloadingManager:
     return CPUOffloadingManager(
         num_blocks=num_blocks,
+        config_info=config_info,
         cache_policy=cache_policy,
         cache_policy_module_path=cache_policy_module_path,
         enable_events=enable_events,
@@ -259,6 +261,33 @@ def test_cpu_manager_reports_cache_usage_gauge():
     # and usage drops.
     manager.complete_store(to_keys([3, 4]), _EMPTY_REQ_CTX)
     check_usage_stats(manager, 0.0)
+
+
+def test_cpu_manager_reports_config_info():
+    config_info = {
+        "num_blocks": "4",
+        "blocks_per_chunk": "8",
+        "kv_bytes_per_chunk": "1024",
+        "cpu_page_size_per_worker": "512",
+        "eviction_policy": "lru",
+    }
+    manager = make_cpu_manager(num_blocks=4, config_info=config_info)
+
+    # Exposed for one-shot startup emission via get_config_info(), keyed by
+    # metric name.
+    assert manager.get_config_info() == {
+        CPUOffloadingMetrics.CPU_CONFIG_INFO: config_info
+    }
+
+    # It is NOT put on the per-interval stats path: emitting a constant gauge
+    # every interval would re-serialize it over IPC for no reason; startup
+    # emission covers it instead (and the gauge persists).
+    stats = manager.get_stats()
+    assert stats is not None
+    assert CPUOffloadingMetrics.CPU_CONFIG_INFO not in stats._values
+
+    # A manager created without config info exposes nothing.
+    assert make_cpu_manager().get_config_info() is None
 
 
 def test_cpu_manager_reports_allocation_size_histogram():

--- a/tests/v1/kv_offload/test_factory.py
+++ b/tests/v1/kv_offload/test_factory.py
@@ -588,3 +588,65 @@ def test_build_metric_definitions_returns_counter_at_threshold():
     metrics = spec_cls.build_metric_definitions(extra_config)
 
     assert CPUOffloadingMetrics.STORES_SKIPPED in metrics
+
+
+def test_cpu_config_info_wiring_matches_declared_labels():
+    """The config info the spec hands the manager must line up exactly with the
+    declared CPU_CONFIG_INFO labels.
+
+    Guards two things record_config_info() relies on but the manager-level test
+    cannot see: the keys equal the label set (a drift would KeyError at emit
+    time) and the values reflect the spec's computed static config.
+    """
+    from vllm.v1.kv_offload.cpu.common import (
+        CPU_CONFIG_INFO_LABELS,
+        CPUOffloadingMetrics,
+    )
+
+    config = _make_offloading_config()
+    spec = OffloadingSpecFactory.create_spec(config)
+    config_info = spec.get_manager().get_config_info()
+
+    assert config_info is not None
+    labels = config_info[CPUOffloadingMetrics.CPU_CONFIG_INFO]
+    assert set(labels) == set(CPU_CONFIG_INFO_LABELS)
+    assert labels == {
+        "num_blocks": str(spec.num_blocks),
+        "blocks_per_chunk": str(spec.blocks_per_chunk),
+        "kv_bytes_per_chunk": str(spec.kv_bytes_per_chunk),
+        "cpu_page_size_per_worker": str(spec.cpu_page_size_per_worker),
+        "eviction_policy": spec.eviction_policy,
+    }
+
+    metrics = type(spec).build_metric_definitions(config.extra_config)
+    assert (
+        tuple(metrics[CPUOffloadingMetrics.CPU_CONFIG_INFO].labelnames)
+        == CPU_CONFIG_INFO_LABELS
+    )
+
+
+def test_cpu_config_info_reflects_world_size_sizing():
+    """The emitted labels carry the world-size-folded sizing (and the mmap
+    padding), not the single-rank numbers -- same geometry as
+    test_cpu_spec_sizes_normalized_worker_layout."""
+    from vllm.v1.kv_offload.cpu.common import CPUOffloadingMetrics
+
+    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+    spec = _create_spec(
+        cpu_bytes_to_use=alignment * 3,
+        worker_kv_bytes_per_block=16,
+        blocks_per_chunk=2,
+        world_size=6,
+        tp_size=3,
+        pp_size=2,
+    )
+
+    assert spec.get_manager().get_config_info() == {
+        CPUOffloadingMetrics.CPU_CONFIG_INFO: {
+            "num_blocks": "3",
+            "blocks_per_chunk": "2",
+            "kv_bytes_per_chunk": str(alignment),
+            "cpu_page_size_per_worker": "32",
+            "eviction_policy": "lru",
+        }
+    }

--- a/vllm/config/kv_transfer.py
+++ b/vllm/config/kv_transfer.py
@@ -71,6 +71,13 @@ class KVTransferConfig:
     'recompute': reschedule the request to recompute failed blocks
     'fail': immediately fail the request with an error finish reason (default)"""
 
+    kv_connector_config_info: dict[str, dict[str, str]] | None = field(
+        default=None, init=False
+    )
+    """Runtime-populated (not a CLI arg): static per-connector config, mapping
+    metric_name -> {label: value}, propagated from the engine-core handshake so
+    it can be emitted as Info-style metrics at startup."""
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -418,6 +418,16 @@ class KVConnectorBase_V1(ABC):
         """
         return None
 
+    def get_config_info(self) -> dict[str, dict[str, str]] | None:
+        """
+        Static, per-connector configuration to emit once at engine startup as
+        Info-style gauges, mapping ``metric_name -> {label: value}``. Mirrors
+        ``vllm:cache_config_info`` so a connector's static config is observable
+        on ``/metrics`` before any request. Returns None when there is nothing
+        to expose.
+        """
+        return None
+
     def get_kv_connector_kv_cache_events(self) -> "KVConnectorKVEvents | None":
         """
         Get the KV connector kv cache events collected during the last interval.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -135,6 +135,15 @@ class KVConnectorPromMetrics:
         """
         raise NotImplementedError
 
+    def record_config_info(
+        self, config_info: dict[str, dict[str, str]], engine_idx: int = 0
+    ):
+        """
+        Emit the connector's static config as Info-style gauges once at engine
+        startup, mapping ``metric_name -> {label: value}`` (each set to 1).
+        Default no-op; connectors with startup config override this.
+        """
+
 
 class KVConnectorProm:
     """
@@ -173,3 +182,10 @@ class KVConnectorProm:
         if self.prom_metrics is None:
             return
         self.prom_metrics.observe(transfer_stats_data, engine_idx)
+
+    def record_config_info(
+        self, config_info: dict[str, dict[str, str]], engine_idx: int = 0
+    ):
+        if self.prom_metrics is None:
+            return
+        self.prom_metrics.record_config_info(config_info, engine_idx)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -124,6 +124,15 @@ class MultiKVConnectorPromMetrics(KVConnectorPromMetrics):
             )
             self._prom_metrics[connector_id].observe(stats_data["data"], engine_idx)
 
+    def record_config_info(
+        self, config_info: dict[str, dict[str, str]], engine_idx: int = 0
+    ):
+        # config_info is flat (metric_name -> labels), merged across children;
+        # hand it to every child prom, each of which emits only the metrics it
+        # owns (unknown metric names are skipped).
+        for prom in self._prom_metrics.values():
+            prom.record_config_info(config_info, engine_idx)
+
 
 class MultiConnector(KVConnectorBase_V1, SupportsHMA):
     """
@@ -636,6 +645,19 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             else:
                 stats_by_connector[connector_id] = stats
         return stats_by_connector
+
+    def get_config_info(self) -> dict[str, dict[str, str]] | None:
+        # Merge nested connectors' startup config-info (metric_name -> labels)
+        # so a connector wrapped inside MultiConnector still emits at startup.
+        merged: dict[str, dict[str, str]] | None = None
+        for c in self._connectors:
+            info = c.get_config_info()
+            if info is None:
+                continue
+            if merged is None:
+                merged = {}
+            merged.update(info)
+        return merged
 
     @classmethod
     def build_prom_metrics(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/metrics.py
@@ -505,3 +505,15 @@ class OffloadPromMetrics(KVConnectorPromMetrics):
                     raise AssertionError(
                         f"Unknown metric type '{type_str}' for key: {key}"
                     )
+
+    def record_config_info(
+        self, config_info: dict[str, dict[str, str]], engine_idx: int = 0
+    ):
+        """Emit each config-info metric once as a gauge pinned to 1, with the
+        static config carried in the labels (cache_config_info-style)."""
+        for metric_name, labels in config_info.items():
+            metadata = self._offloading_metric_metadata.get(metric_name)
+            if metadata is None:
+                continue
+            labelvalues = tuple(labels[name] for name in metadata.labelnames)
+            self._set_gauge(metric_name, 1, labelvalues, engine_idx)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/metrics.py
@@ -395,6 +395,9 @@ class OffloadPromMetrics(KVConnectorPromMetrics):
             metric_cls = self._counter_cls
         elif isinstance(metadata, OffloadingGaugeMetadata):
             metric_cls = self._gauge_cls
+            # Counters and histograms are per-process cumulative and must stay
+            # summed; only gauges collapse (see OffloadingGaugeMetadata).
+            kwargs["multiprocess_mode"] = metadata.multiprocess_mode
         elif isinstance(metadata, OffloadingHistogramMetadata):
             metric_cls = self._histogram_cls
             if metadata.buckets is not None:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -206,6 +206,11 @@ class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
             return self.connector_scheduler.get_stats()
         return None
 
+    def get_config_info(self) -> dict[str, dict[str, str]] | None:
+        if self.connector_scheduler is not None:
+            return self.connector_scheduler.manager.get_config_info()
+        return None
+
     @classmethod
     def build_kv_connector_stats(
         cls, data: dict[str, Any] | None = None

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -92,6 +92,10 @@ class EngineCoreReadyResponse:
     kv_cache_size_tokens: int | None = None
     kv_cache_max_concurrency: float | None = None
     kv_events_config: KVEventsConfig | None = None
+    # Static per-connector config to emit as Info-style metrics at startup,
+    # mapping metric_name -> {label: value}. None when no KV connector or the
+    # connector exposes no startup config.
+    kv_connector_config_info: dict[str, dict[str, str]] | None = None
 
 
 class EngineCoreRequest(

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1619,6 +1619,7 @@ class EngineCoreProc(EngineCore):
     def _make_ready_response(self) -> EngineCoreReadyResponse:
         parallel_config = self.vllm_config.parallel_config
         scheduler_config = self.vllm_config.scheduler_config
+        connector = self.scheduler.get_kv_connector()
         return EngineCoreReadyResponse(
             max_model_len=self.vllm_config.model_config.max_model_len,
             num_gpu_blocks=self.vllm_config.cache_config.num_gpu_blocks or 0,
@@ -1640,6 +1641,9 @@ class EngineCoreProc(EngineCore):
             max_num_batched_tokens=scheduler_config.max_num_batched_tokens,
             instance_id=self.vllm_config.instance_id,
             kv_events_config=self.scheduler.get_kv_event_publisher_config(),
+            kv_connector_config_info=(
+                connector.get_config_info() if connector is not None else None
+            ),
         )
 
     def process_input_sockets(

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -767,6 +767,17 @@ class MPClient(EngineCoreClient):
             else response.kv_cache_max_concurrency
         )
 
+        # Static per-connector config (metric_name -> {label: value}), emitted
+        # as Info-style metrics at startup. Per-engine (last writer wins), not
+        # summed across DP; identical across replicas.
+        if (
+            response.kv_connector_config_info is not None
+            and vllm_config.kv_transfer_config is not None
+        ):
+            vllm_config.kv_transfer_config.kv_connector_config_info = (
+                response.kv_connector_config_info
+            )
+
         # In external DP LB mode, the coordinator address that the
         # front-end procs connect to is obtained by each engine via it's
         # initial handshake with the rank 0 front-end.

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -395,6 +395,11 @@ class OffloadingManager(ABC):
         """Return collected metrics since last call, or None if disabled."""
         return None
 
+    def get_config_info(self) -> dict[str, dict[str, str]] | None:
+        """Static config to emit once at startup as Info-style gauges,
+        mapping ``metric_name -> {label: value}``. None when unavailable."""
+        return None
+
     def shutdown(self) -> None:
         """Shutdown the manager and release any resources."""
         return

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -199,7 +199,13 @@ class OffloadingCounterMetadata(OffloadingMetricMetadata):
 
 @dataclass(frozen=True)
 class OffloadingGaugeMetadata(OffloadingMetricMetadata):
-    pass
+    # Prometheus multiprocess aggregation mode. Offloading gauges are
+    # point-in-time values for a single engine that every API-server process
+    # reports, so collapse the per-pid fan-out to one series per engine (as
+    # vllm:kv_cache_usage_perc and the other vLLM gauges already do). With
+    # api_server_count > 1 the prometheus_client default ("all") would emit one
+    # row per process instead.
+    multiprocess_mode: str = "mostrecent"
 
 
 @dataclass(frozen=True)

--- a/vllm/v1/kv_offload/cpu/common.py
+++ b/vllm/v1/kv_offload/cpu/common.py
@@ -9,6 +9,20 @@ class CPUOffloadingMetrics:
     CPU_ALLOCATION_SIZE = "vllm:kv_offload_cpu_allocation_size"
     CPU_CACHE_WRITE_USAGE_PERC = "vllm:kv_offload_cpu_cache_write_usage_perc"
     CPU_CACHE_READ_USAGE_PERC = "vllm:kv_offload_cpu_cache_read_usage_perc"
+    CPU_CONFIG_INFO = "vllm:kv_offload_cpu_config_info"
+
+
+# Label names for the CPU_CONFIG_INFO metric. build_metric_definitions()
+# declares these as the metric's labels, and CPUOffloadingManager.get_config_info()
+# returns a matching {label: value} dict that record_config_info() emits once at
+# startup, reading the values back out in this label order.
+CPU_CONFIG_INFO_LABELS = (
+    "num_blocks",
+    "blocks_per_chunk",
+    "kv_bytes_per_chunk",
+    "cpu_page_size_per_worker",
+    "eviction_policy",
+)
 
 
 class CPULoadStoreSpec(BlockIDsLoadStoreSpec):

--- a/vllm/v1/kv_offload/cpu/manager.py
+++ b/vllm/v1/kv_offload/cpu/manager.py
@@ -42,6 +42,7 @@ class CPUOffloadingManager(OffloadingManager):
     def __init__(
         self,
         num_blocks: int,
+        config_info: dict[str, str] | None = None,
         cache_policy: str = "lru",
         cache_policy_module_path: str | None = None,
         enable_events: bool = False,
@@ -50,6 +51,9 @@ class CPUOffloadingManager(OffloadingManager):
     ):
         self.medium: Medium = Medium.CPU
         self._num_blocks: int = num_blocks
+        # Static per-tier config emitted as the CPU_CONFIG_INFO metric labels
+        # (None when the caller does not report config info, e.g. in tests).
+        self._config_info: dict[str, str] | None = config_info
         self._num_allocated_blocks: int = 0
         self._free_list: list[int] = []
         self.events: list[OffloadingEvent] | None = [] if enable_events else None
@@ -325,3 +329,8 @@ class CPUOffloadingManager(OffloadingManager):
             self.stores_skipped_in_current_batch = 0
 
         return stats
+
+    def get_config_info(self) -> dict[str, dict[str, str]] | None:
+        if self._config_info is None:
+            return None
+        return {CPUOffloadingMetrics.CPU_CONFIG_INFO: self._config_info}

--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -18,7 +18,10 @@ from vllm.v1.kv_offload.base import (
     OffloadingWorker,
 )
 from vllm.v1.kv_offload.config import OffloadingConfig
-from vllm.v1.kv_offload.cpu.common import CPUOffloadingMetrics
+from vllm.v1.kv_offload.cpu.common import (
+    CPU_CONFIG_INFO_LABELS,
+    CPUOffloadingMetrics,
+)
 from vllm.v1.kv_offload.cpu.gpu_worker import CPUOffloadingWorker
 from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
 from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
@@ -53,6 +56,19 @@ class CPUOffloadingSpec(OffloadingSpec):
                     "in-flight loads that have not yet "
                     "completed (0.0 = idle, 1.0 = saturated)."
                 ),
+            ),
+            CPUOffloadingMetrics.CPU_CONFIG_INFO: OffloadingGaugeMetadata(
+                documentation=(
+                    "Static configuration of the CPU KV offload tier; the "
+                    "value is always 1 and the config is carried in the "
+                    "labels. num_blocks is the offload capacity in offload "
+                    "blocks and blocks_per_chunk the number of GPU blocks per "
+                    "offload block (num_gpu_blocks equivalents = num_blocks * "
+                    "blocks_per_chunk); kv_bytes_per_chunk is the byte size of "
+                    "one offload block, cpu_page_size_per_worker the per-worker "
+                    "page size in bytes, and eviction_policy the cache policy."
+                ),
+                labelnames=CPU_CONFIG_INFO_LABELS,
             ),
             CPUOffloadingMetrics.CPU_ALLOCATION_SIZE: OffloadingHistogramMetadata(
                 documentation=(
@@ -133,6 +149,13 @@ class CPUOffloadingSpec(OffloadingSpec):
 
             self._manager = CPUOffloadingManager(
                 num_blocks=self.num_blocks,
+                config_info={
+                    "num_blocks": str(self.num_blocks),
+                    "blocks_per_chunk": str(self.blocks_per_chunk),
+                    "kv_bytes_per_chunk": str(self.kv_bytes_per_chunk),
+                    "cpu_page_size_per_worker": str(self.cpu_page_size_per_worker),
+                    "eviction_policy": self.eviction_policy,
+                },
                 cache_policy=self.eviction_policy,
                 cache_policy_module_path=self.cache_policy_module_path,
                 enable_events=self.kv_events_config.enable_kv_cache_events,

--- a/vllm/v1/kv_offload/tiering/manager.py
+++ b/vllm/v1/kv_offload/tiering/manager.py
@@ -843,6 +843,11 @@ class TieringOffloadingManager(OffloadingManager):
 
         return stats
 
+    def get_config_info(self) -> dict[str, dict[str, str]] | None:
+        # Only the CPU primary tier carries startup config-info; secondary
+        # (storage) tiers expose none. Surfaces it for startup emission.
+        return self.primary_tier.get_config_info()
+
     @override
     def shutdown(self) -> None:
         """Shutdown all tiers and release resources."""

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1280,6 +1280,19 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
     def log_engine_initialized(self):
         self.log_metrics_info("cache_config", self.vllm_config.cache_config)
 
+        # Emit per-connector static config as Info-style metrics at startup,
+        # so they are visible on /metrics before any request (mirrors
+        # cache_config_info). Values arrive via the engine-core handshake.
+        kv_transfer_config = self.vllm_config.kv_transfer_config
+        if (
+            kv_transfer_config is not None
+            and kv_transfer_config.kv_connector_config_info is not None
+        ):
+            for engine_index in self.engine_indexes:
+                self.kv_connector_prom.record_config_info(
+                    kv_transfer_config.kv_connector_config_info, engine_index
+                )
+
 
 def build_buckets(mantissa_lst: list[int], max_value: int) -> list[int]:
     """


### PR DESCRIPTION
The native CPU `OffloadingConnector` reported usage fractions but exposed no metric for the offload tier's static configuration or capacity. Add `vllm:kv_offload_cpu_config_info`, a `cache_config_info`-style Info gauge (value always 1; config carried in the labels) reporting `num_blocks`, `blocks_per_chunk` (num_gpu_blocks-equivalent capacity = `num_blocks * blocks_per_chunk`; multiply by the cache `block_size` for a token count), `kv_bytes_per_chunk`, `cpu_page_size_per_worker` and `eviction_policy`. Emit it once at engine startup via a new `KVConnectorBase_V1.get_config_info()` hook and the `EngineCoreReadyResponse` handshake, covering standalone, `MultiConnector`-nested (PD) and tiering-primary connectors, and cover it with manager and startup-emission unit tests.

## Purpose

The native CPU KV `OffloadingConnector` reports usage-fraction gauges
(`vllm:kv_offload_cpu_cache_usage_perc`, `vllm:kv_offload_cpu_cache_write_usage_perc`,
`vllm:kv_offload_cpu_cache_read_usage_perc`) but exposes no metric for the offload
tier's static configuration or capacity, so none of it is observable on `/metrics`.

This PR adds an Info gauge, `vllm:kv_offload_cpu_config_info`, whose value is always 1
and whose labels carry the tier's static config: `num_blocks` (offload capacity in
offload blocks), `blocks_per_chunk` (GPU blocks per offload block — num_gpu_blocks
equivalents = `num_blocks * blocks_per_chunk`; multiply by the cache `block_size` for
a token count), `kv_bytes_per_chunk`, `cpu_page_size_per_worker` and `eviction_policy`.
This mirrors how the GPU tier's config, including `num_gpu_blocks`, is exposed via
`vllm:cache_config_info`.

The metric is emitted once at engine startup (before any request) and deliberately
not on the per-interval connector-stats path — re-serializing a constant gauge over
IPC every interval is wasted work, and the Prometheus gauge persists once set. A new
generic `KVConnectorBase_V1.get_config_info()` hook exposes a connector's static
config, the values ride the `EngineCoreReadyResponse` handshake into the frontend
(stored on `KVTransferConfig`), and `PrometheusStatLogger` emits them in
`log_engine_initialized`. `MultiConnector` aggregates its nested children's config
(and its prom fans the emission to each child), and `TieringOffloadingManager`
surfaces its CPU primary tier's config — so an `OffloadingConnector` standalone,
nested in a `MultiConnector` (PD), or as a tiering primary tier all emit at startup.
Offloading gauges default to `multiprocess_mode="mostrecent"`, so the static gauge
(and the existing per-engine usage gauges) collapse to one series per engine under
data-parallel + `api_server_count > 1` instead of one duplicate row per API-server
process; per-process transfer counters and histograms stay summed.

Scope: the native `OffloadingConnector` only (standalone, `MultiConnector`-nested,
tiering primary tier). No behavior change beyond the added metric and the
`multiprocess_mode` correction on the existing offloading gauges.

## Test Plan

- Unit tests: `pytest tests/v1/kv_offload/cpu/test_manager.py tests/v1/kv_offload/test_factory.py`
  - New `test_cpu_manager_reports_config_info` asserts `get_config_info()` returns
    `{CPU_CONFIG_INFO: {...}}` and that config_info is not placed on the per-interval
    stats path.
  - New `test_cpu_config_info_wiring_matches_declared_labels`, `test_cpu_config_info_reflects_tensor_parallel_sizing`,
    `test_kv_offload_cpu_config_info_startup_emission` and `..._via_multi_connector`
    cover label/dict anti-drift, TP/PP sizing, and end-to-end startup emission
    (standalone and `MultiConnector`-nested) with the gauge built as `mostrecent`.
- Lint / type (pre-commit): `pre-commit run --files $(git diff --name-only origin/main...HEAD)`
- (Optional, manual e2e) Serve with `--kv-offloading-size <GiB>` and confirm
  `vllm:kv_offload_cpu_config_info` appears on `/metrics` at startup with value 1 and
  labels whose `num_blocks * blocks_per_chunk` scales with the configured size.

## Test Result

Unit tests:

$ pytest tests/v1/kv_offload/cpu/test_manager.py
.........................                                                [100%]
25 passed, 1 warning in 2.05s

$ pytest tests/v1/kv_offload/test_factory.py
..................................                                       [100%]
34 passed, 15 warnings in 12.38s



pre-commit (ruff check, ruff format, typos, mypy, SPDX headers, forbidden-imports,
config-docstring validation): all hooks passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update — n/a: the sibling CPU-offload connector gauges are not listed in `docs/design/metrics.md`, so this metric follows the existing (undocumented) pattern.
</details>
