### PR TITLE
[cleanup] Add missing Exception handlers in Responses API serving paths

### DIFF
--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -794,6 +794,9 @@ class OpenAIServingResponses(GenerateBaseServing):
                     pass
             except asyncio.CancelledError:
                 return self.create_error_response("Client disconnected")
+            except Exception as e:
+                logger.exception("Error in responses full generator.")
+                return self.create_error_response(e)
 
         # NOTE: Implementation of status is still WIP, but for now
         # we guarantee that if the status is not "completed", it is accurate.
@@ -1522,6 +1525,13 @@ class OpenAIServingResponses(GenerateBaseServing):
                     yield event_data
             except GenerationError as e:
                 error_json = self._convert_generation_error_to_streaming_response(e)
+                yield _increment_sequence_number_and_return(
+                    TypeAdapter(StreamingResponsesResponse).validate_json(error_json)
+                )
+                return
+            except Exception as e:
+                logger.exception("Error in responses stream generator.")
+                error_json = self.create_streaming_error_response(e)
                 yield _increment_sequence_number_and_return(
                     TypeAdapter(StreamingResponsesResponse).validate_json(error_json)
                 )


### PR DESCRIPTION
## Summary

The Responses API serving code had incomplete exception handling in two paths, leaving room for unhandled exceptions to crash connections:

- **Streaming path** — only caught `GenerationError`, letting any other unexpected exception (`ValueError`, `TypeError`, etc.) crash the streaming connection.
- **Non-streaming path** — only caught `asyncio.CancelledError`, leaving exceptions from `_initialize_tool_sessions` and `result_generator` iteration unhandled.

Both `completion/serving.py` and `chat_completion/serving.py` already have the `except Exception` fallback in their equivalent paths — this PR brings `responses/serving.py` to parity.

## Changes

`vllm/entrypoints/openai/responses/serving.py`:

1. **Streaming path** (\`_stream_responses\`): Add `except Exception` handler after `GenerationError`, logging via `logger.exception` and yielding a streaming error response.

2. **Non-streaming path** (\`responses_full_generator\`): Add `except Exception` handler after `asyncio.CancelledError`, logging and returning an `ErrorResponse`.

## Test

\`\`\`
ruff check — passed
\`\`\`

---
*AI assistance used — all changes reviewed and verified.*
Co-authored-by: OpenCode <noreply@opencode.ai>