### PR TITLE
[MoE][Kernel] Add optional HPC BF16xFP32 router GEMM

### DIFF
--- a/tests/kernels/test_hpc_router_gemm.py
+++ b/tests/kernels/test_hpc_router_gemm.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm._custom_ops import fp32_router_gemm
+from vllm.model_executor.layers.fused_moe.router.gate_linear import (
+    hpc_gemm_bf16xfp32_dispatch_impl,
+)
+from vllm.utils.hpc import has_hpc_bf16xfp32_gemm
+
+SHAPES = [
+    (4096, 192),
+    (3072, 256),
+    (6144, 128),
+]
+FP32_ROUTER_SHAPES = [
+    (3072, 256),
+    (6144, 128),
+    (6144, 256),
+]
+TOKEN_COUNTS = [1, 2, 8, 16, 32, 128, 512]
+
+ATOL = 1e-1
+RTOL = 8e-2
+MAX_RELATIVE_L2 = 2e-3
+
+
+def _requires_hpc_sm90() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    if torch.cuda.get_device_capability() != (9, 0):
+        pytest.skip("HPC BF16xFP32 router GEMM requires SM90")
+    if not has_hpc_bf16xfp32_gemm():
+        pytest.skip("HPC BF16xFP32 GEMM is unavailable")
+
+
+@pytest.mark.parametrize("hidden_size,num_experts", SHAPES)
+@pytest.mark.parametrize("num_tokens", TOKEN_COUNTS)
+@pytest.mark.parametrize("seed", [1, 17, 42])
+def test_hpc_router_gemm_numerics(
+    hidden_size: int,
+    num_experts: int,
+    num_tokens: int,
+    seed: int,
+) -> None:
+    _requires_hpc_sm90()
+    torch.manual_seed(seed)
+
+    x = torch.randn(
+        num_tokens,
+        hidden_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    weight = (
+        torch.randn(
+            num_experts,
+            hidden_size,
+            device="cuda",
+            dtype=torch.float32,
+        )
+        * 0.02
+    )
+
+    output = hpc_gemm_bf16xfp32_dispatch_impl(x, weight)
+
+    # FP64 reference avoids TF32/cuBLAS FP32 reference uncertainty.
+    reference = torch.nn.functional.linear(
+        x.double(),
+        weight.double(),
+    ).float()
+
+    assert output.dtype == torch.float32
+    assert output.shape == reference.shape
+    assert torch.isfinite(output).all()
+
+    torch.testing.assert_close(
+        output,
+        reference,
+        atol=ATOL,
+        rtol=RTOL,
+    )
+
+    error_l2 = torch.linalg.vector_norm((output - reference).double())
+    reference_l2 = torch.linalg.vector_norm(reference.double())
+    relative_l2 = error_l2 / reference_l2.clamp_min(1e-12)
+    assert relative_l2.item() < MAX_RELATIVE_L2
+
+
+@pytest.mark.parametrize("hidden_size,num_experts", FP32_ROUTER_SHAPES)
+@pytest.mark.parametrize("num_tokens", [1, 8, 32, 128, 512])
+@pytest.mark.parametrize("seed", range(5))
+def test_hpc_vs_native_router(
+    hidden_size: int,
+    num_experts: int,
+    num_tokens: int,
+    seed: int,
+) -> None:
+    _requires_hpc_sm90()
+    torch.manual_seed(1000 + seed)
+
+    x = torch.randn(
+        num_tokens,
+        hidden_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    weight = (
+        torch.randn(
+            num_experts,
+            hidden_size,
+            device="cuda",
+            dtype=torch.float32,
+        )
+        * 0.02
+    )
+
+    hpc_output = hpc_gemm_bf16xfp32_dispatch_impl(x, weight)
+    reference = torch.nn.functional.linear(
+        x.double(),
+        weight.double(),
+    )
+
+    hpc_error = torch.linalg.vector_norm((hpc_output - reference).double())
+    reference_norm = torch.linalg.vector_norm(reference.double()).clamp_min(1e-12)
+
+    assert (hpc_error / reference_norm).item() < MAX_RELATIVE_L2
+
+    if num_tokens <= 32:
+        native_output = fp32_router_gemm(x, weight)
+        native_error = torch.linalg.vector_norm((native_output - reference).double())
+        assert (native_error / reference_norm).item() < MAX_RELATIVE_L2

--- a/tests/kernels/test_hpc_router_gemm.py
+++ b/tests/kernels/test_hpc_router_gemm.py
@@ -5,15 +5,15 @@ import pytest
 import torch
 
 from vllm._custom_ops import fp32_router_gemm
-from vllm.model_executor.layers.fused_moe.router.gate_linear import (
-    hpc_gemm_bf16xfp32_dispatch_impl,
+from vllm.utils.hpc import (
+    has_hpc_bf16xfp32_gemm,
+    hpc_gemm_bf16xfp32,
 )
-from vllm.utils.hpc import has_hpc_bf16xfp32_gemm
 
 SHAPES = [
-    (4096, 192),
     (3072, 256),
     (6144, 128),
+    (6144, 256),
 ]
 FP32_ROUTER_SHAPES = [
     (3072, 256),
@@ -25,6 +25,27 @@ TOKEN_COUNTS = [1, 2, 8, 16, 32, 128, 512]
 ATOL = 1e-1
 RTOL = 8e-2
 MAX_RELATIVE_L2 = 2e-3
+HPC_GEMM_WEIGHT_SCALE = 1.0 / 256.0
+
+
+HPC_GEMM_WEIGHT_SCALE = 1.0 / 256.0
+
+
+def _run_hpc_gemm(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    weight_high = weight.to(torch.bfloat16)
+    weight_low = ((weight - weight_high.float()) / HPC_GEMM_WEIGHT_SCALE).to(
+        torch.bfloat16
+    )
+    import hpc
+
+    split_flag = hpc.get_gemm_bf16xfp32_workspace(weight.shape[0])
+    return hpc_gemm_bf16xfp32(
+        x=x,
+        weight_high=weight_high,
+        weight_low=weight_low,
+        scale=HPC_GEMM_WEIGHT_SCALE,
+        split_flag=split_flag,
+    )
 
 
 def _requires_hpc_sm90() -> None:
@@ -64,7 +85,7 @@ def test_hpc_router_gemm_numerics(
         * 0.02
     )
 
-    output = hpc_gemm_bf16xfp32_dispatch_impl(x, weight)
+    output = _run_hpc_gemm(x, weight)
 
     # FP64 reference avoids TF32/cuBLAS FP32 reference uncertainty.
     reference = torch.nn.functional.linear(
@@ -117,7 +138,7 @@ def test_hpc_vs_native_router(
         * 0.02
     )
 
-    hpc_output = hpc_gemm_bf16xfp32_dispatch_impl(x, weight)
+    hpc_output = _run_hpc_gemm(x, weight)
     reference = torch.nn.functional.linear(
         x.double(),
         weight.double(),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -271,6 +271,7 @@ if TYPE_CHECKING:
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
     VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD: int = 256
     VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 1024
+    VLLM_ENABLE_HPC_ROUTER_GEMM: bool = False
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
     VLLM_USE_V2_MODEL_RUNNER: bool | None = None
     VLLM_LOG_MODEL_INSPECTION: bool = False
@@ -1911,6 +1912,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # for the default value of 1024 tokens.
     "VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD": lambda: int(
         os.getenv("VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD", "1024")
+    ),
+    # Enable the experimental HPC BF16xFP32 router GEMM path on Hopper.
+    "VLLM_ENABLE_HPC_ROUTER_GEMM": lambda: bool(
+        int(os.getenv("VLLM_ENABLE_HPC_ROUTER_GEMM", "0"))
     ),
     # Format for saving torch.compile cache artifacts
     # - "binary": saves as binary file

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -288,6 +288,7 @@ if TYPE_CHECKING:
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
     VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD: int = 256
     VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 1024
+    VLLM_ENABLE_HPC_ROUTER_GEMM: bool = False
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
     VLLM_USE_V2_MODEL_RUNNER: bool | None = None
     VLLM_LOG_MODEL_INSPECTION: bool = False
@@ -2009,6 +2010,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # for the default value of 1024 tokens.
     "VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD": lambda: int(
         os.getenv("VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD", "1024")
+    ),
+    # Enable the experimental HPC BF16xFP32 router GEMM path on Hopper.
+    "VLLM_ENABLE_HPC_ROUTER_GEMM": lambda: bool(
+        int(os.getenv("VLLM_ENABLE_HPC_ROUTER_GEMM", "0"))
     ),
     # Format for saving torch.compile cache artifacts
     # - "binary": saves as binary file

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -4,11 +4,16 @@ import torch
 from torch.nn.parameter import Parameter
 
 import vllm._custom_ops as ops
+import vllm.envs as envs
 from vllm.config import get_current_vllm_config_or_none
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.platforms import current_platform
+from vllm.utils.hpc import (
+    has_hpc_bf16xfp32_gemm,
+    hpc_gemm_bf16xfp32,
+)
 from vllm.utils.torch_utils import direct_register_custom_op
 
 logger = init_logger(__name__)
@@ -136,6 +141,21 @@ class GateLinear(ReplicatedLinear):
                 and is_available()
             )
 
+        self.allow_hpc_router_gemm = (
+            envs.VLLM_ENABLE_HPC_ROUTER_GEMM
+            and not bias
+            and self.weight.dtype == torch.float32
+            and current_platform.is_cuda()
+            and is_hopper
+            and input_size % 8 == 0
+            and output_size % 64 == 0
+            and has_hpc_bf16xfp32_gemm()
+            and out_dtype == torch.float32
+        )
+
+        if self.allow_hpc_router_gemm:
+            logger.info_once("Enabled HPC BF16xFP32 router GEMM.")
+
     def set_out_dtype(self, out_dtype: torch.dtype) -> None:
         """Set output dtype for the router logits after init.
 
@@ -183,6 +203,19 @@ class GateLinear(ReplicatedLinear):
                 hidden_states=x,
                 router_weight=self.weight,
                 output_dtype=self.out_dtype,
+            )
+            return output, None
+
+        # HPC BF16 activation x FP32 router weight.
+        if (
+            self.allow_hpc_router_gemm
+            and x.ndim == 2
+            and x.dtype == torch.bfloat16
+            and x.shape[0] > _FP32_ROUTER_GEMM_MAX_TOKENS
+        ):
+            output = torch.ops.vllm.hpc_gemm_bf16xfp32_dispatch(
+                x,
+                self.weight,
             )
             return output, None
 
@@ -261,4 +294,91 @@ direct_register_custom_op(
     op_name="fp32_router_gemm_dispatch",
     op_func=fp32_router_gemm_dispatch_impl,
     fake_impl=fp32_router_gemm_dispatch_fake,
+)
+
+
+_HPC_GEMM_WEIGHT_CACHE_ATTR = "_vllm_bf16xfp32_weight_cache"
+# The HPC-Ops bf16xfp32 GEMM consumes the fp32 weight decomposed into two
+# bf16 halves: w_high = w.bf16 and w_low = ((w - w_high) / scale).bf16 with
+# scale = 1/256, so that w ~= w_high + scale * w_low.
+_HPC_GEMM_WEIGHT_SCALE = 1.0 / 256.0
+
+
+def _get_bf16xfp32_weight_split(
+    y: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Split the fp32 weight for the HPC-Ops kernel and cache the result
+    (plus the split-K flag workspace, which the kernel leaves zeroed) on the
+    weight tensor."""
+    import hpc
+
+    cache_key = (
+        y.data_ptr(),
+        y._version,
+        tuple(y.shape),
+        tuple(y.stride()),
+        y.device.index,
+        y.dtype,
+    )
+    cache = getattr(y, _HPC_GEMM_WEIGHT_CACHE_ATTR, None)
+    if cache is not None and cache[0] == cache_key:
+        return cache[1], cache[2], cache[3]
+
+    with torch.no_grad():
+        w_high = y.to(torch.bfloat16)
+        w_low = ((y - w_high.float()) / _HPC_GEMM_WEIGHT_SCALE).to(torch.bfloat16)
+    split_flag = hpc.get_gemm_bf16xfp32_workspace(y.shape[0])
+    setattr(y, _HPC_GEMM_WEIGHT_CACHE_ATTR, (cache_key, w_high, w_low, split_flag))
+    return w_high, w_low, split_flag
+
+
+def _can_use_hpc_gemm_bf16xfp32(
+    x: torch.Tensor, weight: torch.Tensor, *, min_m: int = 32
+) -> bool:
+    if x.dim() != 2 or weight.dim() != 2 or x.shape[1] != weight.shape[1]:
+        return False
+    if x.shape[0] < min_m:
+        return False
+    if not (x.is_cuda and weight.is_cuda):
+        return False
+    if x.dtype != torch.bfloat16 or weight.dtype != torch.float32:
+        return False
+    if not (x.is_contiguous() and weight.is_contiguous()):
+        return False
+    if weight.shape[0] % 64 != 0:
+        return False
+    return has_hpc_bf16xfp32_gemm()
+
+
+def hpc_gemm_bf16xfp32_dispatch_impl(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    if not _can_use_hpc_gemm_bf16xfp32(x, weight):
+        return torch.nn.functional.linear(x.float(), weight)
+
+    weight_high, weight_low, split_flag = _get_bf16xfp32_weight_split(weight)
+    return hpc_gemm_bf16xfp32(
+        x=x,
+        weight_high=weight_high,
+        weight_low=weight_low,
+        scale=_HPC_GEMM_WEIGHT_SCALE,
+        split_flag=split_flag,
+    )
+
+
+def hpc_gemm_bf16xfp32_dispatch_fake(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    return x.new_empty(
+        (x.shape[0], weight.shape[0]),
+        dtype=torch.float32,
+    )
+
+
+direct_register_custom_op(
+    op_name="hpc_gemm_bf16xfp32_dispatch",
+    op_func=hpc_gemm_bf16xfp32_dispatch_impl,
+    fake_impl=hpc_gemm_bf16xfp32_dispatch_fake,
 )

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -107,6 +107,11 @@ class GateLinear(ReplicatedLinear):
             vllm_config is not None
             and vllm_config.kernel_config.enable_bf16x3_router_gemm
         )
+        self._hpc_workspace_max_tokens = (
+            vllm_config.scheduler_config.max_num_batched_tokens
+            if vllm_config is not None
+            else _HPC_GEMM_DEFAULT_MAX_TOKENS
+        )
         self.allow_fp32_router_gemm = (
             not bias
             and self.weight.dtype == torch.float32
@@ -155,21 +160,30 @@ class GateLinear(ReplicatedLinear):
                 and is_available()
             )
 
-        self.allow_hpc_router_gemm = (
-            envs.VLLM_ENABLE_HPC_ROUTER_GEMM
-            and not bias
-            and self.weight.dtype == torch.float32
-            and current_platform.is_cuda()
-            and is_hopper
-            and input_size % 8 == 0
-            and output_size % 64 == 0
-            and has_hpc_bf16xfp32_gemm()
-            and out_dtype == torch.float32
-        )
+        self._is_hopper = is_hopper
+        self.allow_hpc_router_gemm = self._compute_allow_hpc_router_gemm()
 
         if self.allow_hpc_router_gemm:
             self.quant_method = GateLinearWeightProcess()
             logger.info_once("Enabled HPC BF16xFP32 router GEMM.")
+
+    def _compute_allow_hpc_router_gemm(self) -> bool:
+        """HPC BF16xFP32 router GEMM eligibility.
+
+        Shared by __init__ and set_out_dtype() since out_dtype may only be
+        known after construction.
+        """
+        return (
+            envs.VLLM_ENABLE_HPC_ROUTER_GEMM
+            and self._router_gemm_no_bias
+            and self.weight.dtype == torch.float32
+            and current_platform.is_cuda()
+            and self._is_hopper
+            and self.input_size % 8 == 0
+            and self.output_size % 64 == 0
+            and has_hpc_bf16xfp32_gemm()
+            and self.out_dtype == torch.float32
+        )
 
     def set_out_dtype(self, out_dtype: torch.dtype) -> None:
         """Set output dtype for the router logits after init.
@@ -203,17 +217,34 @@ class GateLinear(ReplicatedLinear):
                 and is_available()
             )
 
-    def _process_gate_weights_after_loading(self):
+        # out_dtype may start as None -> recompute HPC eligibility here too
+        self.allow_hpc_router_gemm = self._compute_allow_hpc_router_gemm()
         if self.allow_hpc_router_gemm:
-            import hpc
+            self.quant_method = GateLinearWeightProcess()
+            logger.info_once("Enabled HPC BF16xFP32 router GEMM.")
 
-            with torch.no_grad():
-                y = self.weight.data
-                self.hpc_w_high = y.to(torch.bfloat16)
-                self.hpc_w_low = (
-                    (y - self.hpc_w_high.float()) / _HPC_GEMM_WEIGHT_SCALE
-                ).to(torch.bfloat16)
-                self.hpc_split_flag = hpc.get_gemm_bf16xfp32_workspace(y.shape[0])
+    def _process_gate_weights_after_loading(self):
+        if not self.allow_hpc_router_gemm:
+            return
+
+        import hpc
+
+        with torch.no_grad():
+            y = self.weight.data
+            w_high = y.to(torch.bfloat16)
+            w_low = ((y - w_high.float()) / _HPC_GEMM_WEIGHT_SCALE).to(torch.bfloat16)
+
+            if getattr(self, "hpc_w_high", None) is None:
+                # Allocate once: CUDA graph capture and weight-reload flows
+                # depend on these storage addresses staying stable.
+                self.hpc_w_high = w_high
+                self.hpc_w_low = w_low
+                self.hpc_split_flag = hpc.get_gemm_bf16xfp32_workspace(
+                    y.shape[0], max_tokens=self._hpc_workspace_max_tokens
+                )
+            else:
+                self.hpc_w_high.copy_(w_high)
+                self.hpc_w_low.copy_(w_low)
 
     def forward(
         self, x: torch.Tensor
@@ -242,6 +273,7 @@ class GateLinear(ReplicatedLinear):
             and x.ndim == 2
             and x.dtype == torch.bfloat16
             and x.shape[0] > _FP32_ROUTER_GEMM_MAX_TOKENS
+            and x.shape[0] <= self._hpc_workspace_max_tokens
         ):
             output = hpc_gemm_bf16xfp32(
                 x=x,
@@ -334,3 +366,7 @@ direct_register_custom_op(
 # bf16 halves: w_high = w.bf16 and w_low = ((w - w_high) / scale).bf16 with
 # scale = 1/256, so that w ~= w_high + scale * w_low.
 _HPC_GEMM_WEIGHT_SCALE = 1.0 / 256.0
+
+# hpc.get_gemm_bf16xfp32_workspace()'s own default when no vLLM config is
+# available to size the split-K workspace from.
+_HPC_GEMM_DEFAULT_MAX_TOKENS = 131072

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -8,7 +8,7 @@ import vllm.envs as envs
 from vllm.config import get_current_vllm_config_or_none
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
-from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.linear import ReplicatedLinear, UnquantizedLinearMethod
 from vllm.platforms import current_platform
 from vllm.utils.hpc import (
     has_hpc_bf16xfp32_gemm,
@@ -17,6 +17,12 @@ from vllm.utils.hpc import (
 from vllm.utils.torch_utils import direct_register_custom_op
 
 logger = init_logger(__name__)
+
+
+class GateLinearWeightProcess(UnquantizedLinearMethod):
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        layer._process_gate_weights_after_loading()
+        super().process_weights_after_loading(layer)
 
 
 @PluggableLayer.register("gate_linear")
@@ -162,6 +168,7 @@ class GateLinear(ReplicatedLinear):
         )
 
         if self.allow_hpc_router_gemm:
+            self.quant_method = GateLinearWeightProcess()
             logger.info_once("Enabled HPC BF16xFP32 router GEMM.")
 
     def set_out_dtype(self, out_dtype: torch.dtype) -> None:
@@ -196,6 +203,18 @@ class GateLinear(ReplicatedLinear):
                 and is_available()
             )
 
+    def _process_gate_weights_after_loading(self):
+        if self.allow_hpc_router_gemm:
+            import hpc
+
+            with torch.no_grad():
+                y = self.weight.data
+                self.hpc_w_high = y.to(torch.bfloat16)
+                self.hpc_w_low = (
+                    (y - self.hpc_w_high.float()) / _HPC_GEMM_WEIGHT_SCALE
+                ).to(torch.bfloat16)
+                self.hpc_split_flag = hpc.get_gemm_bf16xfp32_workspace(y.shape[0])
+
     def forward(
         self, x: torch.Tensor
     ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
@@ -224,9 +243,12 @@ class GateLinear(ReplicatedLinear):
             and x.dtype == torch.bfloat16
             and x.shape[0] > _FP32_ROUTER_GEMM_MAX_TOKENS
         ):
-            output = torch.ops.vllm.hpc_gemm_bf16xfp32_dispatch(
-                x,
-                self.weight,
+            output = hpc_gemm_bf16xfp32(
+                x=x,
+                weight_high=self.hpc_w_high,
+                weight_low=self.hpc_w_low,
+                scale=_HPC_GEMM_WEIGHT_SCALE,
+                split_flag=self.hpc_split_flag,
             )
             return output, None
 
@@ -308,88 +330,7 @@ direct_register_custom_op(
 )
 
 
-_HPC_GEMM_WEIGHT_CACHE_ATTR = "_vllm_bf16xfp32_weight_cache"
 # The HPC-Ops bf16xfp32 GEMM consumes the fp32 weight decomposed into two
 # bf16 halves: w_high = w.bf16 and w_low = ((w - w_high) / scale).bf16 with
 # scale = 1/256, so that w ~= w_high + scale * w_low.
 _HPC_GEMM_WEIGHT_SCALE = 1.0 / 256.0
-
-
-def _get_bf16xfp32_weight_split(
-    y: torch.Tensor,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Split the fp32 weight for the HPC-Ops kernel and cache the result
-    (plus the split-K flag workspace, which the kernel leaves zeroed) on the
-    weight tensor."""
-    import hpc
-
-    cache_key = (
-        y.data_ptr(),
-        y._version,
-        tuple(y.shape),
-        tuple(y.stride()),
-        y.device.index,
-        y.dtype,
-    )
-    cache = getattr(y, _HPC_GEMM_WEIGHT_CACHE_ATTR, None)
-    if cache is not None and cache[0] == cache_key:
-        return cache[1], cache[2], cache[3]
-
-    with torch.no_grad():
-        w_high = y.to(torch.bfloat16)
-        w_low = ((y - w_high.float()) / _HPC_GEMM_WEIGHT_SCALE).to(torch.bfloat16)
-    split_flag = hpc.get_gemm_bf16xfp32_workspace(y.shape[0])
-    setattr(y, _HPC_GEMM_WEIGHT_CACHE_ATTR, (cache_key, w_high, w_low, split_flag))
-    return w_high, w_low, split_flag
-
-
-def _can_use_hpc_gemm_bf16xfp32(
-    x: torch.Tensor, weight: torch.Tensor, *, min_m: int = 32
-) -> bool:
-    if x.dim() != 2 or weight.dim() != 2 or x.shape[1] != weight.shape[1]:
-        return False
-    if x.shape[0] < min_m:
-        return False
-    if not (x.is_cuda and weight.is_cuda):
-        return False
-    if x.dtype != torch.bfloat16 or weight.dtype != torch.float32:
-        return False
-    if not (x.is_contiguous() and weight.is_contiguous()):
-        return False
-    if weight.shape[0] % 64 != 0:
-        return False
-    return has_hpc_bf16xfp32_gemm()
-
-
-def hpc_gemm_bf16xfp32_dispatch_impl(
-    x: torch.Tensor,
-    weight: torch.Tensor,
-) -> torch.Tensor:
-    if not _can_use_hpc_gemm_bf16xfp32(x, weight):
-        return torch.nn.functional.linear(x.float(), weight)
-
-    weight_high, weight_low, split_flag = _get_bf16xfp32_weight_split(weight)
-    return hpc_gemm_bf16xfp32(
-        x=x,
-        weight_high=weight_high,
-        weight_low=weight_low,
-        scale=_HPC_GEMM_WEIGHT_SCALE,
-        split_flag=split_flag,
-    )
-
-
-def hpc_gemm_bf16xfp32_dispatch_fake(
-    x: torch.Tensor,
-    weight: torch.Tensor,
-) -> torch.Tensor:
-    return x.new_empty(
-        (x.shape[0], weight.shape[0]),
-        dtype=torch.float32,
-    )
-
-
-direct_register_custom_op(
-    op_name="hpc_gemm_bf16xfp32_dispatch",
-    op_func=hpc_gemm_bf16xfp32_dispatch_impl,
-    fake_impl=hpc_gemm_bf16xfp32_dispatch_fake,
-)

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -4,11 +4,16 @@ import torch
 from torch.nn.parameter import Parameter
 
 import vllm._custom_ops as ops
+import vllm.envs as envs
 from vllm.config import get_current_vllm_config_or_none
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.platforms import current_platform
+from vllm.utils.hpc import (
+    has_hpc_bf16xfp32_gemm,
+    hpc_gemm_bf16xfp32,
+)
 from vllm.utils.torch_utils import direct_register_custom_op
 
 logger = init_logger(__name__)
@@ -144,6 +149,21 @@ class GateLinear(ReplicatedLinear):
                 and is_available()
             )
 
+        self.allow_hpc_router_gemm = (
+            envs.VLLM_ENABLE_HPC_ROUTER_GEMM
+            and not bias
+            and self.weight.dtype == torch.float32
+            and current_platform.is_cuda()
+            and is_hopper
+            and input_size % 8 == 0
+            and output_size % 64 == 0
+            and has_hpc_bf16xfp32_gemm()
+            and out_dtype == torch.float32
+        )
+
+        if self.allow_hpc_router_gemm:
+            logger.info_once("Enabled HPC BF16xFP32 router GEMM.")
+
     def set_out_dtype(self, out_dtype: torch.dtype) -> None:
         """Set output dtype for the router logits after init.
 
@@ -194,6 +214,19 @@ class GateLinear(ReplicatedLinear):
                 hidden_states=x,
                 router_weight=self.weight,
                 output_dtype=self.out_dtype,
+            )
+            return output, None
+
+        # HPC BF16 activation x FP32 router weight.
+        if (
+            self.allow_hpc_router_gemm
+            and x.ndim == 2
+            and x.dtype == torch.bfloat16
+            and x.shape[0] > _FP32_ROUTER_GEMM_MAX_TOKENS
+        ):
+            output = torch.ops.vllm.hpc_gemm_bf16xfp32_dispatch(
+                x,
+                self.weight,
             )
             return output, None
 
@@ -272,4 +305,91 @@ direct_register_custom_op(
     op_name="fp32_router_gemm_dispatch",
     op_func=fp32_router_gemm_dispatch_impl,
     fake_impl=fp32_router_gemm_dispatch_fake,
+)
+
+
+_HPC_GEMM_WEIGHT_CACHE_ATTR = "_vllm_bf16xfp32_weight_cache"
+# The HPC-Ops bf16xfp32 GEMM consumes the fp32 weight decomposed into two
+# bf16 halves: w_high = w.bf16 and w_low = ((w - w_high) / scale).bf16 with
+# scale = 1/256, so that w ~= w_high + scale * w_low.
+_HPC_GEMM_WEIGHT_SCALE = 1.0 / 256.0
+
+
+def _get_bf16xfp32_weight_split(
+    y: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Split the fp32 weight for the HPC-Ops kernel and cache the result
+    (plus the split-K flag workspace, which the kernel leaves zeroed) on the
+    weight tensor."""
+    import hpc
+
+    cache_key = (
+        y.data_ptr(),
+        y._version,
+        tuple(y.shape),
+        tuple(y.stride()),
+        y.device.index,
+        y.dtype,
+    )
+    cache = getattr(y, _HPC_GEMM_WEIGHT_CACHE_ATTR, None)
+    if cache is not None and cache[0] == cache_key:
+        return cache[1], cache[2], cache[3]
+
+    with torch.no_grad():
+        w_high = y.to(torch.bfloat16)
+        w_low = ((y - w_high.float()) / _HPC_GEMM_WEIGHT_SCALE).to(torch.bfloat16)
+    split_flag = hpc.get_gemm_bf16xfp32_workspace(y.shape[0])
+    setattr(y, _HPC_GEMM_WEIGHT_CACHE_ATTR, (cache_key, w_high, w_low, split_flag))
+    return w_high, w_low, split_flag
+
+
+def _can_use_hpc_gemm_bf16xfp32(
+    x: torch.Tensor, weight: torch.Tensor, *, min_m: int = 32
+) -> bool:
+    if x.dim() != 2 or weight.dim() != 2 or x.shape[1] != weight.shape[1]:
+        return False
+    if x.shape[0] < min_m:
+        return False
+    if not (x.is_cuda and weight.is_cuda):
+        return False
+    if x.dtype != torch.bfloat16 or weight.dtype != torch.float32:
+        return False
+    if not (x.is_contiguous() and weight.is_contiguous()):
+        return False
+    if weight.shape[0] % 64 != 0:
+        return False
+    return has_hpc_bf16xfp32_gemm()
+
+
+def hpc_gemm_bf16xfp32_dispatch_impl(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    if not _can_use_hpc_gemm_bf16xfp32(x, weight):
+        return torch.nn.functional.linear(x.float(), weight)
+
+    weight_high, weight_low, split_flag = _get_bf16xfp32_weight_split(weight)
+    return hpc_gemm_bf16xfp32(
+        x=x,
+        weight_high=weight_high,
+        weight_low=weight_low,
+        scale=_HPC_GEMM_WEIGHT_SCALE,
+        split_flag=split_flag,
+    )
+
+
+def hpc_gemm_bf16xfp32_dispatch_fake(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    return x.new_empty(
+        (x.shape[0], weight.shape[0]),
+        dtype=torch.float32,
+    )
+
+
+direct_register_custom_op(
+    op_name="hpc_gemm_bf16xfp32_dispatch",
+    op_func=hpc_gemm_bf16xfp32_dispatch_impl,
+    fake_impl=hpc_gemm_bf16xfp32_dispatch_fake,
 )

--- a/vllm/utils/hpc.py
+++ b/vllm/utils/hpc.py
@@ -216,8 +216,42 @@ def hpc_fuse_moe_blockwise(
     )
 
 
+@functools.cache
+def has_hpc_bf16xfp32_gemm() -> bool:
+    """Return whether the optional HPC bf16xfp32 GEMM API is available."""
+    if not has_hpc():
+        return False
+
+    import hpc
+
+    required_apis = ("gemm_bf16xfp32", "get_gemm_bf16xfp32_workspace")
+    return all(hasattr(hpc, name) for name in required_apis)
+
+
+def hpc_gemm_bf16xfp32(
+    x: torch.Tensor,
+    weight_high: torch.Tensor,
+    weight_low: torch.Tensor,
+    scale: float,
+    split_flag: torch.Tensor,
+) -> torch.Tensor:
+    import hpc
+
+    return hpc.gemm_bf16xfp32(
+        x,
+        weight_high,
+        weight_low,
+        scale,
+        use_fp32_output=True,
+        use_splitk=True,
+        split_flag=split_flag,
+    )
+
+
 __all__ = [
     "has_hpc",
+    "has_hpc_bf16xfp32_gemm",
     "hpc_fuse_moe",
     "hpc_fuse_moe_blockwise",
+    "hpc_gemm_bf16xfp32",
 ]


### PR DESCRIPTION
## Purpose

Issues: https://github.com/vllm-project/vllm/issues/49277

Add an opt-in HPC BF16xFP32 GEMM path for FP32 MoE router weights on SM90 GPUs.

Guard the path by HPC availability, device capability, dtype, layout, and shape requirements. Cache the BF16 high/low weight
decomposition and preserve the existing router GEMM fallback when the HPC kernel is unavailable or ineligible.

## Reproduce

1. install hpc-ops
```
git clone https://github.com/Tencent/hpc-ops.git
cd hpc-ops

# build packages
make wheel
python3 -m pip install dist/*.whl
```

2. start vllm serve
```
export VLLM_ENABLE_HPC_ROUTER_GEMM=1
$ vllm serve --model /new-model/MiniMax-M3-MXFP8/ --trust-remote-code --block-size 128 --tensor-parallel-size 8 --tool-call-parser minimax_m3 --enable-auto-tool-choice --reasoning-parser minimax_m3 --max-model-len 65535
```

3. vllm bench
```
vllm bench serve --served-model-name /new-model/MiniMax-M3-MXFP8/ --model /new-model/MiniMax-M3-MXFP8/ --tokenizer /new-model/MiniMax-M3-MXFP8/ --backend openai-chat --endpoint /v1/chat/completions --dataset-name random --random-input 10000 --random-output 1 --seed 131 --base-url http://localhost:8000 --num-prompts 100
```

## Performance
Model: MiniMax-M3-MXFP8
Workload: 100 concurrent requests

### Prefill-heavy workload
```
Input:  10000 tokens
Output: 1 token
```

|Metric | Original | HPC | Change|
|-- | -- | -- | --|
Total throughput | 8471.53 tok/s | 8667.48 tok/s | +2.31%
Mean TTFT | 61938.32 ms | 60540.02 ms | +2.26%
Median TTFT | 62196.86 ms | 60783.03 ms | +2.27%
P99 TTFT | 119626.03 ms | 116913.21 ms | +2.27%

<img width="48%"  height="1058" alt="image" src="https://github.com/user-attachments/assets/6aafba28-6939-44f8-a8a7-a2e640e82e01" />
<img width="48%"  height="1052" alt="image" src="https://github.com/user-attachments/assets/c82c4d62-b90f-4e8e-833b-183d8125e947" />




### Decode-heavy workload
```
Input:  1 token
Output: 100 tokens
```

|Metric | Original | HPC | Change|
|-- | -- | -- | --|
Mean TPOT | 64.03 ms | 63.04 ms | +1.55%
Median TPOT | 63.97 ms | 62.99 ms | +1.53%
P99 TPOT | 64.03 ms | 63.05 ms | +1.53%
Mean ITL | 63.83 ms | 62.76 ms | +1.68%
Total throughput | 3251.03 tok/s | 3340.22 tok/s | +2.74%

<img width="48%"  height="1048" alt="image" src="https://github.com/user-attachments/assets/8f685e12-b96a-44a9-aeb7-d8f01bd91e78" /> <img width="48%" height="1048" alt="image" src="https://github.com/user-attachments/assets/7ab762ed-2569-4d75-97ea-3d1d84c60058" />


### Model Evaluation

GSM8K 5-shot evaluation was run on all 1,319 questions using
MiniMax-M3-MXFP8.

| Metric | Original | HPC | Change |
|---|---:|---:|---:|
| Accuracy | 0.879 | 0.882 | +0.003 |
| Invalid responses | 0.000 | 0.000 | No change |
| Total latency | 121.214 s | 118.726 s | -2.05% |
| Questions per second | 10.882 | 11.110 | +2.10% |
| Output tokens per second | 978.483 | 997.535 | +1.95% |

No accuracy regression was observed. The 0.3 percentage-point difference is small relative to the expected run-to-run variation and is not treated as a statistically significant accuracy improvement.

The HPC run improved evaluation throughput by approximately 2%.


### lm_eval 
```
$ lm_eval   --model local-completions   --model_args "pretrained=/new-model/MiniMax-M3-MXFP8/,tokenizer=/new-model/MiniMax-M3-MXFP8/,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=50,max_retries=3"   --tasks gsm8k   --num_fewshot 5   --apply_chat_template   --fewshot_as_multiturn   --seed 0
```

- disable hpc-ops

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9515|±  |0.0059|
|     |       |strict-match    |     5|exact_match|↑  |0.9507|±  |0.0060|

- enable hpc-ops

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9522|±  |0.0059|
|     |       |strict-match    |     5|exact_match|↑  |0.9522|±  |0.0059|

## Test Plan

- Prefill test
```
vllm bench serve --served-model-name /new-model/MiniMax-M3-MXFP8/ --model /new-model/MiniMax-M3-MXFP8/ --tokenizer /new-model/MiniMax-M3-MXFP8/ --backend openai-chat --endpoint /v1/chat/completions --dataset-name random --random-input 10000 --random-output 1 --seed 131 --base-url http://localhost:8000 --num-prompts 100
```

- Decode test
```
vllm bench serve --served-model-name /new-model/MiniMax-M3-MXFP8/ --model /new-model/MiniMax-M3-MXFP8/ --tokenizer /new-model/MiniMax-M3-MXFP8/ --backend openai-chat --endpoint /v1/chat/completions --dataset-name random --random-input 1 --random-output 100 --seed 132 --base-url http://localhost:8000 --num-prompts 100
```

## 3 * Benchmark
- benchmark command
```
vllm bench serve --served-model-name /new-model/MiniMax-M3-MXFP8/ --model /new-model/MiniMax-M3-MXFP8/ --tokenizer /new-model/MiniMax-M3-MXFP8/ --backend openai-chat --endpoint /v1/chat/completions --dataset-name random --random-input 1 --random-output 100 --seed 132 --base-url http://localhost:8000 --num-prompts 100
```

### disable hpc-ops
- one
```
============ Serving Benchmark Result ============
Successful requests:                     100       
Failed requests:                         0         
Benchmark duration (s):                  13.37     
Total input tokens:                      117600    
Total generated tokens:                  1000      
Request throughput (req/s):              7.48      
Output token throughput (tok/s):         74.78     
Peak output token throughput (tok/s):    371.00    
Peak concurrent requests:                100.00    
Total token throughput (tok/s):          8868.88   
---------------Time to First Token----------------
Mean TTFT (ms):                          7082.05   
Median TTFT (ms):                        7244.71   
P99 TTFT (ms):                           12051.08  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          555.21    
Median TPOT (ms):                        547.82    
P99 TPOT (ms):                           836.48    
---------------Inter-token Latency----------------
Mean ITL (ms):                           499.69    
Median ITL (ms):                         627.93    
P99 ITL (ms):                            846.17    
==================================================
```
- two
```
============ Serving Benchmark Result ============
Successful requests:                     100       
Failed requests:                         0         
Benchmark duration (s):                  12.14     
Total input tokens:                      117600    
Total generated tokens:                  1000      
Request throughput (req/s):              8.24      
Output token throughput (tok/s):         82.40     
Peak output token throughput (tok/s):    394.00    
Peak concurrent requests:                100.00    
Total token throughput (tok/s):          9772.63   
---------------Time to First Token----------------
Mean TTFT (ms):                          5904.29   
Median TTFT (ms):                        6021.40   
P99 TTFT (ms):                           10822.47  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          549.59    
Median TPOT (ms):                        545.39    
P99 TPOT (ms):                           830.11    
---------------Inter-token Latency----------------
Mean ITL (ms):                           494.63    
Median ITL (ms):                         641.32    
P99 ITL (ms):                            837.92    
==================================================
```
- three
```
============ Serving Benchmark Result ============
Successful requests:                     100       
Failed requests:                         0         
Benchmark duration (s):                  12.11     
Total input tokens:                      117600    
Total generated tokens:                  1000      
Request throughput (req/s):              8.25      
Output token throughput (tok/s):         82.55     
Peak output token throughput (tok/s):    394.00    
Peak concurrent requests:                100.00    
Total token throughput (tok/s):          9790.00   
---------------Time to First Token----------------
Mean TTFT (ms):                          5895.77   
Median TTFT (ms):                        6019.90   
P99 TTFT (ms):                           10804.74  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          548.48    
Median TPOT (ms):                        543.73    
P99 TPOT (ms):                           827.84    
---------------Inter-token Latency----------------
Mean ITL (ms):                           493.63    
Median ITL (ms):                         645.86    
P99 ITL (ms):                            831.84    
==================================================
```

### enable hpc-ops
- one
```
============ Serving Benchmark Result ============
Successful requests:                     100       
Failed requests:                         0         
Benchmark duration (s):                  11.87     
Total input tokens:                      117600    
Total generated tokens:                  1000      
Request throughput (req/s):              8.43      
Output token throughput (tok/s):         84.25     
Peak output token throughput (tok/s):    313.00    
Peak concurrent requests:                100.00    
Total token throughput (tok/s):          9992.63   
---------------Time to First Token----------------
Mean TTFT (ms):                          5795.40   
Median TTFT (ms):                        5846.14   
P99 TTFT (ms):                           10573.04  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          534.39    
Median TPOT (ms):                        536.62    
P99 TPOT (ms):                           807.26    
---------------Inter-token Latency----------------
Mean ITL (ms):                           480.95    
Median ITL (ms):                         688.79    
P99 ITL (ms):                            810.45    
==================================================
```

- two 
```
============ Serving Benchmark Result ============
Successful requests:                     100       
Failed requests:                         0         
Benchmark duration (s):                  11.85     
Total input tokens:                      117600    
Total generated tokens:                  1000      
Request throughput (req/s):              8.44      
Output token throughput (tok/s):         84.41     
Peak output token throughput (tok/s):    308.00    
Peak concurrent requests:                100.00    
Total token throughput (tok/s):          10011.11  
---------------Time to First Token----------------
Mean TTFT (ms):                          5750.25   
Median TTFT (ms):                        5872.34   
P99 TTFT (ms):                           10549.47  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          536.50    
Median TPOT (ms):                        531.89    
P99 TPOT (ms):                           807.10    
---------------Inter-token Latency----------------
Mean ITL (ms):                           482.85    
Median ITL (ms):                         640.96    
P99 ITL (ms):                            809.80    
==================================================
```

- three
```
============ Serving Benchmark Result ============
Successful requests:                     100       
Failed requests:                         0         
Benchmark duration (s):                  11.86     
Total input tokens:                      117600    
Total generated tokens:                  1000      
Request throughput (req/s):              8.44      
Output token throughput (tok/s):         84.35     
Peak output token throughput (tok/s):    308.00    
Peak concurrent requests:                100.00    
Total token throughput (tok/s):          10004.17  
---------------Time to First Token----------------
Mean TTFT (ms):                          5755.36   
Median TTFT (ms):                        5874.58   
P99 TTFT (ms):                           10556.14  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          536.73    
Median TPOT (ms):                        532.49    
P99 TPOT (ms):                           807.43    
---------------Inter-token Latency----------------
Mean ITL (ms):                           483.05    
Median ITL (ms):                         642.68    
P99 ITL (ms):                            810.22    
==================================================
```


## Test Result



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

