### PR TITLE
[Quark] Online-requant unquantized layers via quantization_config ove…

### DIFF
--- a/docs/features/quantization/online.md
+++ b/docs/features/quantization/online.md
@@ -139,3 +139,69 @@ llm = LLM(
 
 !!! note
     For fused layers (e.g., `qkv_proj` which fuses `q_proj`, `k_proj`, `v_proj`), the ignore pattern must match the **unfused** shard names (`q_proj`, `k_proj`, `v_proj`), not the fused name.
+
+### Re-quantizing Unquantized Layers of a Pre-quantized Checkpoint
+
+Some pre-quantized checkpoints are *mixed precision*: they ship a subset of
+layers unquantized (fp16/bf16). For example a Quark MXFP4 MoE checkpoint stores
+its experts as MXFP4 but keeps the attention and dense-MLP projections in bf16.
+
+When a checkpoint is loaded with such a native quantization method (e.g.
+`quark`), you can pass a `quantization_config` overlay to online-requantize
+*only* the layers the checkpoint left unquantized, using the online schemes
+above. The overlay's `linear` spec selects the online method, and its `ignore`
+patterns scope which unquantized layers are re-quantized. Layers already
+quantized by the checkpoint, and any layer matched by `ignore`, are untouched.
+
+```python
+from vllm import LLM
+
+# Quark MXFP4 MoE checkpoint: experts stay MXFP4, bf16 attention / dense-MLP
+# projections are online-requantized to FP8 (per-token-activation,
+# per-channel-weight). The MoE gate and lm_head are left in bf16 via `ignore`
+# (exact names or `re:` regex, same as elsewhere on this page). MoE experts are
+# handled by the checkpoint and never routed here.
+llm = LLM(
+    "amd/Qwen3.5-35B-A3B-MXFP4",
+    quantization_config={
+        "linear": "fp8_per_channel",
+        "ignore": [
+            "lm_head",
+            "re:.*mlp\\.gate$",
+        ],
+    },
+)
+```
+
+The same overlay can be passed on the CLI:
+
+```bash
+vllm serve amd/Qwen3.5-35B-A3B-MXFP4 \
+  --quantization-config '{"linear":"fp8_per_channel","ignore":["lm_head","re:.*mlp\\.gate$"]}'
+```
+
+For MLA checkpoints (e.g. DeepSeek), the attention up-projection `kv_b_proj`
+is numerically sensitive and should stay in bf16, so add it to `ignore`
+alongside the router `gate` and `lm_head`:
+
+```python
+from vllm import LLM
+
+# Quark MXFP4 DeepSeek (MLA) checkpoint: experts stay MXFP4, the bf16 attention
+# / dense-MLP projections are online-requantized to FP8, while the router gate,
+# lm_head and the MLA kv_b_proj are kept in bf16 via `ignore`.
+llm = LLM(
+    "amd/DeepSeek-R1-0528-MXFP4",
+    quantization_config={
+        "linear": "fp8_per_channel",
+        "ignore": [
+            "lm_head",
+            "re:.*mlp\\.gate$",
+            "re:.*kv_b_proj.*",
+        ],
+    },
+)
+```
+
+!!! note
+    This path is opt-in: with no `quantization_config` overlay, the unquantized layers stay in their original checkpoint dtype.

--- a/tests/quantization/test_quark_online_overlay.py
+++ b/tests/quantization/test_quark_online_overlay.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for Quark's online-requant overlay routing.
+
+Routing-only tests for the ``--quantization-config`` overlay that
+re-quantizes a Quark mixed-precision checkpoint's unquantized layers via the
+shared online methods. Kept in a dedicated module so they run without the
+heavy (``lm_eval`` / network) imports in ``test_quark.py``.
+
+The overlay's online method (``Fp8PtpcOnlineLinearMethod``) is not instantiated
+directly: its ``__init__`` reads ``get_current_vllm_config().model_config.dtype``
+which needs a real model path. So the "routed" case patches the method map with
+a sentinel and asserts the routing/ignore logic instead (mirrors the note in
+``test_modelopt.py::test_modelopt_mixed_precision_dispatches_w4a16_layer``).
+
+Run `pytest tests/quantization/test_quark_online_overlay.py`.
+"""
+
+from unittest.mock import patch
+
+from vllm.config.quantization import QuantizationConfigArgs
+from vllm.model_executor.layers.quantization.online.base import (
+    _ONLINE_LINEAR_METHODS,
+)
+from vllm.model_executor.layers.quantization.online.fp8 import (
+    Fp8PtpcOnlineLinearMethod,
+)
+from vllm.model_executor.layers.quantization.quark.quark import QuarkConfig
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8StaticChannelSym,
+)
+
+FUSED_MAPPING = {
+    "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+    "gate_up_proj": ["gate_proj", "up_proj"],
+}
+
+
+class _SentinelMethod:
+    """Stand-in for the online method so routing can be tested without a real
+    vLLM config context (the real method's ``__init__`` reads model_config)."""
+
+
+def _config() -> QuarkConfig:
+    config = QuarkConfig(quant_config={})
+    config.packed_modules_mapping = FUSED_MAPPING
+    return config
+
+
+def test_fp8_per_channel_shorthand_maps_to_ptpc():
+    # Contract: the ``fp8_per_channel`` overlay resolves to online PTPC FP8.
+    overlay = QuantizationConfigArgs(linear="fp8_per_channel")
+    assert overlay.linear.weight is kFp8StaticChannelSym
+    assert _ONLINE_LINEAR_METHODS[kFp8StaticChannelSym] is Fp8PtpcOnlineLinearMethod
+
+
+def test_overlay_routes_non_ignored_linear():
+    config = _config()
+    overlay = QuantizationConfigArgs(
+        linear="fp8_per_channel",
+        ignore=["lm_head", "re:.*kv_b_proj.*"],
+    )
+    with patch.dict(
+        _ONLINE_LINEAR_METHODS, {kFp8StaticChannelSym: _SentinelMethod}
+    ):
+        method = config._online_requant_method(
+            overlay, "model.layers.0.self_attn.q_proj"
+        )
+    assert isinstance(method, _SentinelMethod)
+
+
+def test_overlay_ignore_leaves_layer_unquantized():
+    config = _config()
+    overlay = QuantizationConfigArgs(
+        linear="fp8_per_channel",
+        ignore=["lm_head", "re:.*kv_b_proj.*"],
+    )
+    # ``kv_b_proj`` must stay bf16 (MLA BMM consumes the raw weight), and the
+    # exact ``lm_head`` name is excluded too. Ignored => None (no method built,
+    # so no config context is required).
+    assert (
+        config._online_requant_method(
+            overlay, "model.layers.0.self_attn.kv_b_proj"
+        )
+        is None
+    )
+    assert config._online_requant_method(overlay, "lm_head") is None
+
+
+def test_overlay_without_linear_spec_is_inactive():
+    # No ``linear`` spec => no overlay; default Quark behavior is unchanged.
+    overlay = QuantizationConfigArgs(ignore=["lm_head"])
+    assert overlay.linear is None

--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -43,6 +43,7 @@ from vllm.model_executor.models.utils import WeightsMapper
 from vllm.platforms import current_platform
 
 if TYPE_CHECKING:
+    from vllm.config.quantization import QuantizationConfigArgs
     from vllm.model_executor.models.utils import WeightsMapper
 
 __all__ = ["QuarkLinearMethod"]
@@ -52,6 +53,31 @@ logger = init_logger(__name__)
 # model_type values that use dynamic MXFP4 re-quantization for
 # OCP MX fp4 Quark checkpoints
 _DEEPSEEK_V3_FAMILY_MODEL_TYPES = frozenset({"deepseek_v3", "deepseek_v32"})
+
+
+def _online_requant_overlay() -> "QuantizationConfigArgs | None":
+    """User-supplied online-requant overlay for a Quark (mixed-precision)
+    checkpoint's unquantized (bf16/fp16) layers.
+
+    Set via ``--quantization-config`` (a ``QuantizationConfigArgs`` with a
+    ``linear`` spec + ``ignore`` patterns), it lets a checkpoint that ships some
+    layers unquantized re-quantize those layers on the fly using the shared
+    online methods in ``quantization/online`` -- e.g. FP8 ptpc for the bf16 MLA
+    / dense-MLP projections of a Quark MXFP4 MoE checkpoint. The actual quant
+    lives in ``online/fp8.py``; Quark only routes to it (per the maintainer
+    guidance on PR #31672 that online quant must not live inside the loader).
+
+    Returns None unless an overlay with a linear spec is present, so default
+    Quark behavior is unchanged. Mirrors the MXFP4 MoE oracle's use of
+    ``quantization_config`` for activation overrides.
+    """
+    from vllm.config import get_current_vllm_config
+    from vllm.config.quantization import QuantizationConfigArgs
+
+    args = get_current_vllm_config().model_config.quantization_config
+    if isinstance(args, QuantizationConfigArgs) and args.linear is not None:
+        return args
+    return None
 
 
 class QuarkConfig(QuantizationConfig):
@@ -143,6 +169,39 @@ class QuarkConfig(QuantizationConfig):
 
         self.quant_config = quant_config_with_hf_to_vllm_mapper
 
+    def _online_requant_method(
+        self, overlay: "QuantizationConfigArgs", prefix: str
+    ) -> "QuantizeMethodBase | None":
+        """Route an unquantized (bf16/fp16) Linear layer to a shared online
+        quant method per the user overlay, or None if the overlay's ``ignore``
+        patterns exclude it (so it stays unquantized)."""
+        if should_ignore_layer(
+            prefix,
+            ignore=overlay.ignore,
+            fused_mapping=self.packed_modules_mapping,
+        ):
+            return None
+
+        from vllm.model_executor.layers.quantization.online.base import (
+            _ONLINE_LINEAR_METHODS,
+        )
+
+        weight_key = overlay.linear.weight
+        method_cls = _ONLINE_LINEAR_METHODS.get(weight_key)
+        if method_cls is None:
+            raise ValueError(
+                f"online requant weight={weight_key} is not supported for "
+                f"Quark unquantized layers; supported weight keys: "
+                f"{sorted(str(k) for k in _ONLINE_LINEAR_METHODS)}"
+            )
+        logger.info_once(
+            "Quark online-requant active: unquantized layers -> %s "
+            "(e.g. %s); scoped by quantization_config.ignore.",
+            method_cls.__name__,
+            prefix,
+        )
+        return method_cls()
+
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
     ) -> "QuantizeMethodBase | None":
@@ -154,8 +213,20 @@ class QuarkConfig(QuantizationConfig):
             fused_mapping=self.packed_modules_mapping,
             check_children=isinstance(layer, RoutedExperts),
         ):
+            # This layer ships unquantized (bf16/fp16) in the checkpoint.
             if isinstance(layer, RoutedExperts):
                 return UnquantizedFusedMoEMethod(layer.moe_config)
+
+            # Optional user overlay (--quantization-config): online-requant the
+            # unquantized Linear layers via the shared online methods, scoped by
+            # the overlay's own ``ignore`` patterns. No model-specific logic;
+            # default Quark behavior is unchanged when no overlay is set.
+            overlay = _online_requant_overlay()
+            if overlay is not None and isinstance(layer, LinearBase):
+                method = self._online_requant_method(overlay, prefix)
+                if method is not None:
+                    return method
+
             if (
                 "self_attn" not in prefix  # only quantize attention projections
                 or not getattr(self, "dynamic_mxfp4_quant", False)


### PR DESCRIPTION
## Purpose

Quark mixed-precision checkpoints (e.g. GLM-5.2 MXFP4 MoE) ship some layers
unquantized (the bf16 MLA / dense-MLP projections), so today those layers fall
back to `UnquantizedLinearMethod` and there is no supported way to re-quantize
them without a fully pre-quantized checkpoint.

This PR adds an **opt-in** path: when the user passes a `--quantization-config`
overlay (`QuantizationConfigArgs` with a `linear` spec + `ignore` patterns),
Quark routes the checkpoint's unquantized `LinearBase` layers to the shared
online methods in `quantization/online` (e.g. FP8 ptpc), scoped by the
overlay's own `ignore` patterns.

- The quant logic stays in `quantization/online` — Quark only routes to it,
  per the maintainer guidance on #31672 that online quant must not live inside
  the loader.
- Fully backward compatible: when no overlay is set, `_online_requant_overlay()`
  returns `None` and default Quark behavior is unchanged.
- `RoutedExperts` and any layer matched by `ignore` (`lm_head`, embeddings,
  router `gate`, MoE experts, MLA `kv_b_proj`) are left untouched.

## Test Plan

Serve a Quark MXFP4 mixed-precision checkpoint with and without the overlay.

**Baseline (unchanged path, no overlay):**

```bash
# Baseline
vllm serve <GLM-5.2-MXFP4> --tensor-parallel-size 4 --trust-remote-code \
  --kv-cache-dtype fp8

# Online-requant the bf16 attn/dense projections to FP8 ptpc:
vllm serve <GLM-5.2-MXFP4> --tensor-parallel-size 4 --trust-remote-code \
  --kv-cache-dtype fp8 \
  --quantization-config '{"linear":"fp8_per_channel","ignore":["lm_head","re:.*embed_tokens.*","re:.*mlp\\.gate$","re:.*expert.*","re:.*kv_b_proj.*"]}'

#Unit test for the routing / ignore logic:
pytest tests/quantization/test_quark_online_overlay.py -q

```
Verify the overlay is picked up and correctness is preserved.

## Test Result
With the overlay, the unquantized projections are routed to Fp8PtpcOnlineLinearMethod (confirmed via the 
```
Quark online-requant active: unquantized layers -> ... log), 
```
while MoE experts stay MXFP4 and kv_b_proj / router / embeddings stay bf16.

Without the overlay, output and layer methods are identical to main (no behavioral change).

Correctness sanity-checked on GLM-5.2 MXFP4 (TP4, MI355X); generations match the baseline.

## Essential Elements of an Effective PR Description Checklist
 The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
 The test plan, such as providing test command.
 The test results, such as pasting the results comparison before and after, or e2e results
 (Optional) The necessary documentation update, such as updating supported_models.md and examples for a new model.


