### PR TITLE
fix(sampler): fall back to native sampling when flashinfer is absent

### DIFF
--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -112,6 +112,37 @@ def test_rocm_aiter_sampler_defers_import_when_generators_force_native(
     assert logits_to_return is None
 
 
+def test_flashinfer_sampler_supported_degrades_when_flashinfer_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """flashinfer is optional and unavailable on some CUDA platforms (e.g.
+    aarch64). When it is absent, flashinfer_sampler_supported() must fall back
+    to native sampling instead of crashing engine init with
+    ModuleNotFoundError from the unguarded backend import.
+    """
+    import vllm.utils.flashinfer as flashinfer_utils
+    from vllm.v1.sample.ops import topk_topp_sampler
+
+    class MockCudaPlatform:
+        @staticmethod
+        def is_cuda():
+            return True
+
+    monkeypatch.setattr(topk_topp_sampler, "current_platform", MockCudaPlatform())
+    monkeypatch.setattr(flashinfer_utils, "has_flashinfer", lambda: False)
+
+    # Default (sampler enabled by default) with flashinfer absent: fall back
+    # to native sampling, do not raise.
+    monkeypatch.delenv("VLLM_USE_FLASHINFER_SAMPLER", raising=False)
+    assert topk_topp_sampler.flashinfer_sampler_supported() is False
+
+    # Explicit opt-in with flashinfer absent: a clear RuntimeError, not the
+    # raw ModuleNotFoundError from the import.
+    monkeypatch.setenv("VLLM_USE_FLASHINFER_SAMPLER", "1")
+    with pytest.raises(RuntimeError, match="flashinfer is not installed"):
+        topk_topp_sampler.flashinfer_sampler_supported()
+
+
 def test_random_sample_uses_fp64_exponential_race_when_requested():
     torch.set_default_device(DEVICE_TYPE)
     probs = torch.tensor(

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -26,8 +26,10 @@ def flashinfer_sampler_supported() -> bool:
     unsupported. Raises ``RuntimeError`` if the user explicitly opted in
     via the env var but FlashInfer is unavailable.
 
-    Assumes flashinfer is installed, as guaranteed by ``requirements/cuda.txt``;
-    otherwise importing the FlashInfer backend below raises ``ImportError``.
+    Returns False (falling back to native sampling) when flashinfer is not
+    installed, rather than raising ``ImportError`` -- flashinfer is not
+    available on every CUDA platform (e.g. aarch64), and the rest of the
+    codebase treats it as optional via ``has_flashinfer()``.
 
     Note: callers must additionally ensure ``logprobs_mode`` doesn't require
     post-top-k/top-p logits/logprobs for any request whose logprobs will be
@@ -41,15 +43,20 @@ def flashinfer_sampler_supported() -> bool:
             "VLLM_USE_FLASHINFER_SAMPLER=0."
         )
         return False
-    from vllm.v1.attention.backends.flashinfer import FlashInferBackend
+    from vllm.utils.flashinfer import has_flashinfer
 
-    capability = current_platform.get_device_capability()
-    assert capability is not None
     unsupported_reason: str | None = None
-    if not FlashInferBackend.supports_compute_capability(capability):
-        unsupported_reason = (
-            f"unsupported compute capability {capability.as_version_str()}"
-        )
+    if not has_flashinfer():
+        unsupported_reason = "flashinfer is not installed"
+    else:
+        from vllm.v1.attention.backends.flashinfer import FlashInferBackend
+
+        capability = current_platform.get_device_capability()
+        assert capability is not None
+        if not FlashInferBackend.supports_compute_capability(capability):
+            unsupported_reason = (
+                f"unsupported compute capability {capability.as_version_str()}"
+            )
 
     if unsupported_reason is None:
         logger.info_once("Using FlashInfer for top-p & top-k sampling.", scope="global")


### PR DESCRIPTION
`flashinfer_sampler_supported()` imports the FlashInfer backend unconditionally when `VLLM_USE_FLASHINFER_SAMPLER` is on (the default). flashinfer isn't available on every CUDA platform (e.g. aarch64), so on a build without it the import raises `ModuleNotFoundError` and **crashes engine init** instead of falling back to native sampling — even though the rest of the codebase treats flashinfer as optional via `has_flashinfer()`.

Hit this on a from-source build on **GB10 (sm121, aarch64)** where flashinfer isn't installed:
```
ModuleNotFoundError: No module named 'flashinfer'   # from Sampler.__init__ -> flashinfer_sampler_supported()
```

Fix: guard the import with `has_flashinfer()` and route absence through the existing "unsupported" path — warn + degrade by default, or a clear `RuntimeError` if the user explicitly set `VLLM_USE_FLASHINFER_SAMPLER=1` (instead of the raw import error). No change when flashinfer is present.

Verified on GB10: engine now starts and generates with top-p/top-k sampling. Added a regression test (mock CUDA platform + absent flashinfer).