### PR TITLE
[Bugfix][Parser] kimi_k2: route streaming through arg_converter so schema type coercion applies

### DIFF
--- a/tests/parser/engine/test_kimi_k2_streaming.py
+++ b/tests/parser/engine/test_kimi_k2_streaming.py
@@ -1,0 +1,295 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for Kimi K2 streaming tool-argument type coercion.
+
+Kimi K2 emits tool-call arguments as raw JSON and (before this fix) was
+the only parser engine backend without an ``arg_converter``.  The
+converter-less streaming path skipped ``_fix_arg_types``, so streamed
+argument deltas kept the model's raw value types (e.g. the string
+``"3"``) while the non-streaming path coerced them to the schema type
+(the integer ``3``).  Because streamed deltas are append-only, the raw
+wrong-typed characters could not be retracted once emitted.
+
+These tests assert that the concatenation of streamed argument deltas is
+byte-for-byte identical to the non-streaming ``extract_tool_calls``
+output, across several chunk boundaries.  They fail on the unpatched
+backend (streaming keeps ``"3"``, non-streaming yields ``3``) and pass
+once the arguments are normalised and coerced consistently.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.parser.engine.conftest import make_mock_tokenizer
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionToolsParam,
+)
+from vllm.entrypoints.openai.engine.protocol import FunctionDefinition
+from vllm.parser.kimi_k2 import KimiK2Parser
+
+SECTION_BEGIN = "<|tool_calls_section_begin|>"
+SECTION_END = "<|tool_calls_section_end|>"
+TOOL_BEGIN = "<|tool_call_begin|>"
+TOOL_END = "<|tool_call_end|>"
+ARG_BEGIN = "<|tool_call_argument_begin|>"
+
+_VOCAB = {
+    "<think>": 200,
+    "</think>": 201,
+    SECTION_BEGIN: 300,
+    SECTION_END: 301,
+    TOOL_BEGIN: 302,
+    TOOL_END: 303,
+    ARG_BEGIN: 304,
+}
+
+
+def _tokenizer() -> MagicMock:
+    return make_mock_tokenizer(_VOCAB)
+
+
+def _make_tool(name: str, properties: dict) -> ChatCompletionToolsParam:
+    return ChatCompletionToolsParam(
+        type="function",
+        function=FunctionDefinition(
+            name=name,
+            parameters={"type": "object", "properties": properties},
+        ),
+    )
+
+
+def _make_request(tools) -> ChatCompletionRequest:
+    req = MagicMock(spec=ChatCompletionRequest)
+    req.tools = tools
+    req.tool_choice = "auto"
+    req.include_reasoning = True
+    return req
+
+
+def _sub_chunks(text: str, size: int) -> list[str]:
+    return [text[i : i + size] for i in range(0, len(text), size)]
+
+
+def _build_stream_chunks(specs: list[tuple[str, str]], arg_chunk: int) -> list[str]:
+    """Build the streamed chunk list for one or more tool calls.
+
+    Special tokens are delivered as their own chunks (mirroring how the
+    real tokenizer emits them) while each argument body is split into
+    ``arg_chunk``-sized pieces to vary the chunk boundaries.
+    """
+    chunks = [SECTION_BEGIN]
+    for tool_id, args in specs:
+        chunks.append(TOOL_BEGIN)
+        chunks.append(f"{tool_id} ")
+        chunks.append(ARG_BEGIN)
+        chunks.extend(_sub_chunks(args, arg_chunk))
+        chunks.append(TOOL_END)
+    chunks.append(SECTION_END)
+    return chunks
+
+
+def _token_ids_for(chunk: str) -> list[int]:
+    return [tid for text, tid in _VOCAB.items() if text in chunk]
+
+
+def _non_streaming_args(tools, specs: list[tuple[str, str]]) -> list[str]:
+    parser = KimiK2Parser(_tokenizer(), tools=tools)
+    body = (
+        SECTION_BEGIN
+        + "".join(
+            f"{TOOL_BEGIN}{tool_id} {ARG_BEGIN}{args}{TOOL_END}"
+            for tool_id, args in specs
+        )
+        + SECTION_END
+    )
+    result = parser.extract_tool_calls(body, _make_request(tools))
+    return [tc.function.arguments for tc in result.tool_calls]
+
+
+def _streaming_args(tools, chunks: list[str]) -> list[str]:
+    parser = KimiK2Parser(_tokenizer(), tools=tools)
+    req = _make_request(tools)
+    prev_text = ""
+    prev_ids: list[int] = []
+    collected: dict[int, str] = {}
+
+    def _absorb(delta):
+        if not delta or not delta.tool_calls:
+            return
+        for tc in delta.tool_calls:
+            if tc.function and tc.function.arguments:
+                collected[tc.index] = (
+                    collected.get(tc.index, "") + tc.function.arguments
+                )
+
+    for chunk in chunks:
+        cur_text = prev_text + chunk
+        d_ids = _token_ids_for(chunk)
+        cur_ids = prev_ids + d_ids
+        _absorb(
+            parser.extract_tool_calls_streaming(
+                previous_text=prev_text,
+                current_text=cur_text,
+                delta_text=chunk,
+                previous_token_ids=tuple(prev_ids),
+                current_token_ids=tuple(cur_ids),
+                delta_token_ids=tuple(d_ids),
+                request=req,
+            )
+        )
+        prev_text = cur_text
+        prev_ids = cur_ids
+    # Real serving performs a final flush when generation ends.
+    _absorb(parser.finish_streaming())
+    return [collected[idx] for idx in sorted(collected)]
+
+
+ARG_CHUNK_SIZES = [1, 3, 1000]
+
+
+class TestKimiK2StreamingCoercion:
+    """Streaming argument bytes must equal the non-streaming output."""
+
+    @pytest.mark.parametrize("arg_chunk", ARG_CHUNK_SIZES)
+    @pytest.mark.parametrize(
+        "schema_type, raw_value, py_value",
+        [
+            ("integer", '"3"', 3),
+            ("boolean", '"true"', True),
+            ("number", '"1.5"', 1.5),
+        ],
+        ids=["integer", "boolean", "number"],
+    )
+    def test_single_nonstring_field(self, schema_type, raw_value, py_value, arg_chunk):
+        tools = [_make_tool("f", {"v": {"type": schema_type}})]
+        specs = [("functions.f:0", '{"v":' + raw_value + "}")]
+
+        ns = _non_streaming_args(tools, specs)
+        st = _streaming_args(tools, _build_stream_chunks(specs, arg_chunk))
+
+        assert st == ns, f"streaming {st!r} != non-streaming {ns!r}"
+        # The coercion actually happened (not just that both agree raw).
+        assert json.loads(st[0])["v"] == py_value
+        assert type(json.loads(st[0])["v"]) is type(py_value)
+
+    @pytest.mark.parametrize("arg_chunk", ARG_CHUNK_SIZES)
+    def test_middle_nonstring_field(self, arg_chunk):
+        """A non-string field followed by more JSON (the hard case).
+
+        The coerced middle value shrinks (``"5"`` -> ``5``); the trailing
+        field must still stream correctly after it.
+        """
+        tools = [
+            _make_tool(
+                "f",
+                {
+                    "count": {"type": "integer"},
+                    "loc": {"type": "string"},
+                },
+            )
+        ]
+        specs = [("functions.f:0", '{"count":"5","loc":"NYC"}')]
+
+        ns = _non_streaming_args(tools, specs)
+        st = _streaming_args(tools, _build_stream_chunks(specs, arg_chunk))
+
+        assert st == ns, f"streaming {st!r} != non-streaming {ns!r}"
+        parsed = json.loads(st[0])
+        assert parsed == {"count": 5, "loc": "NYC"}
+        assert type(parsed["count"]) is int
+
+    @pytest.mark.parametrize("arg_chunk", ARG_CHUNK_SIZES)
+    def test_nested_nonstring_field(self, arg_chunk):
+        tools = [
+            _make_tool(
+                "f",
+                {
+                    "inner": {
+                        "type": "object",
+                        "properties": {"n": {"type": "integer"}},
+                    },
+                    "loc": {"type": "string"},
+                },
+            )
+        ]
+        specs = [("functions.f:0", '{"inner":{"n":"7"},"loc":"NYC"}')]
+
+        ns = _non_streaming_args(tools, specs)
+        st = _streaming_args(tools, _build_stream_chunks(specs, arg_chunk))
+
+        assert st == ns, f"streaming {st!r} != non-streaming {ns!r}"
+        parsed = json.loads(st[0])
+        assert parsed == {"inner": {"n": 7}, "loc": "NYC"}
+        assert type(parsed["inner"]["n"]) is int
+
+    @pytest.mark.parametrize("arg_chunk", ARG_CHUNK_SIZES)
+    def test_parallel_tool_calls(self, arg_chunk):
+        tools = [_make_tool("get_weather", {"count": {"type": "integer"}})]
+        specs = [
+            ("functions.get_weather:0", '{"count":"3"}'),
+            ("functions.get_weather:1", '{"count":"7"}'),
+        ]
+
+        ns = _non_streaming_args(tools, specs)
+        st = _streaming_args(tools, _build_stream_chunks(specs, arg_chunk))
+
+        assert st == ns, f"streaming {st!r} != non-streaming {ns!r}"
+        assert [json.loads(a) for a in st] == [{"count": 3}, {"count": 7}]
+        assert all(type(json.loads(a)["count"]) is int for a in st)
+
+    @pytest.mark.parametrize("arg_chunk", ARG_CHUNK_SIZES)
+    def test_string_field_with_numeric_literal(self, arg_chunk):
+        """A string-typed field emitted as a bare number must gain quotes."""
+        tools = [_make_tool("f", {"id": {"type": "string"}})]
+        specs = [("functions.f:0", '{"id":42}')]
+
+        ns = _non_streaming_args(tools, specs)
+        st = _streaming_args(tools, _build_stream_chunks(specs, arg_chunk))
+
+        assert st == ns, f"streaming {st!r} != non-streaming {ns!r}"
+        assert json.loads(st[0]) == {"id": "42"}
+        assert type(json.loads(st[0])["id"]) is str
+
+    @pytest.mark.parametrize("arg_chunk", ARG_CHUNK_SIZES)
+    def test_already_correct_types_unchanged(self, arg_chunk):
+        """Correctly-typed input must still round-trip identically."""
+        tools = [_make_tool("f", {"count": {"type": "integer"}})]
+        specs = [("functions.f:0", '{"count":5}')]
+
+        ns = _non_streaming_args(tools, specs)
+        st = _streaming_args(tools, _build_stream_chunks(specs, arg_chunk))
+
+        assert st == ns, f"streaming {st!r} != non-streaming {ns!r}"
+        assert json.loads(st[0]) == {"count": 5}
+
+    @pytest.mark.parametrize("arg_chunk", [1, 3, 1000])
+    def test_truncated_arguments_flush_consistently(self, arg_chunk):
+        """Stream ending mid-value (no closing token) must still agree.
+
+        ``finish_streaming`` injects the TOOL_CALL_END the model never
+        emitted; both paths complete and coerce the partial object.
+        """
+        tools = [_make_tool("f", {"count": {"type": "integer"}})]
+        raw = '{"count":"3'  # never closed
+        body = SECTION_BEGIN + TOOL_BEGIN + "functions.f:0 " + ARG_BEGIN + raw
+
+        parser = KimiK2Parser(_tokenizer(), tools=tools)
+        ns = [
+            tc.function.arguments
+            for tc in parser.extract_tool_calls(body, _make_request(tools)).tool_calls
+        ]
+
+        chunks = [
+            SECTION_BEGIN,
+            TOOL_BEGIN,
+            "functions.f:0 ",
+            ARG_BEGIN,
+        ] + _sub_chunks(raw, arg_chunk)
+        st = _streaming_args(tools, chunks)
+
+        assert st == ns, f"streaming {st!r} != non-streaming {ns!r}"

--- a/vllm/parser/kimi_k2.py
+++ b/vllm/parser/kimi_k2.py
@@ -16,12 +16,14 @@ call id. The function name is the final component before ``:N``.
 from __future__ import annotations
 
 import functools
+import json
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
+import partial_json_parser
 import regex as re
+from partial_json_parser.core.options import Allow
 
-from vllm.entrypoints.openai.engine.protocol import DeltaFunctionCall, DeltaToolCall
 from vllm.parser.engine.events import EventType
 from vllm.parser.engine.parser_engine import ParserEngine
 from vllm.parser.engine.parser_engine_config import (
@@ -34,6 +36,7 @@ if TYPE_CHECKING:
     from vllm.entrypoints.openai.chat_completion.protocol import (
         ChatCompletionRequest,
     )
+    from vllm.entrypoints.openai.engine.protocol import DeltaToolCall
     from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
     from vllm.tokenizers import TokenizerLike
     from vllm.tool_parsers.abstract_tool_parser import Tool
@@ -47,6 +50,36 @@ TOOL_CALL_END = "<|tool_call_end|>"
 TOOL_ARG_START = "<|tool_call_argument_begin|>"
 
 _TOOL_ID_RE = re.compile(r"(?P<id>.+:\d+)")
+
+
+def _kimi_k2_arg_converter(raw_args: str, partial: bool) -> str:
+    """Normalise Kimi K2's raw JSON arguments to canonical JSON.
+
+    Kimi emits tool-call arguments as JSON text directly.  Re-serialising
+    through ``json.dumps`` (completing incomplete objects with
+    :mod:`partial_json_parser` while ``partial`` is True) gives the parser
+    engine a stable, coercible representation on every streaming tick, so
+    the schema type coercion in ``_fix_arg_types`` applies identically to
+    the streaming and non-streaming paths.  Unparsable text is returned
+    unchanged so no argument bytes are lost.
+    """
+    raw_args = raw_args.strip()
+    if not raw_args:
+        return ""
+
+    obj: object | None
+    try:
+        obj = json.loads(raw_args)
+    except (json.JSONDecodeError, ValueError):
+        try:
+            obj = partial_json_parser.loads(raw_args, Allow.ALL)
+        except Exception:
+            obj = None
+
+    if not isinstance(obj, dict):
+        return raw_args
+
+    return json.dumps(obj, ensure_ascii=False)
 
 
 @functools.cache
@@ -140,6 +173,7 @@ def kimi_k2_config(thinking: bool = True) -> ParserEngineConfig:
         },
         stream_arg_deltas=True,
         tool_args_json=True,
+        arg_converter=_kimi_k2_arg_converter,
         strip_trailing_reasoning_whitespace=True,
         drop_whitespace_only_content_before_tools=True,
         strip_content_whitespace_with_tools=False,
@@ -213,25 +247,6 @@ class KimiK2Parser(ParserEngine):
                 self._tool_slots[idx].id = tool_id or ""
                 self._tool_slots[idx].name = tool_name
         super()._handle_tool_end(event, deltas)
-
-    def _handle_arg_chunk(self, event, deltas) -> None:
-        idx = event.tool_index
-        name_sent_before = (
-            0 <= idx < len(self._tool_slots) and self._tool_slots[idx].name_sent
-        )
-        super()._handle_arg_chunk(event, deltas)
-        if (
-            event.value
-            and not name_sent_before
-            and 0 <= idx < len(self._tool_slots)
-            and self._tool_slots[idx].name_sent
-        ):
-            deltas.append(
-                DeltaToolCall(
-                    index=idx,
-                    function=DeltaFunctionCall(arguments=event.value),
-                )
-            )
 
     def _extract_args_json(self, raw_args: str, func_name: str) -> str:
         return raw_args.strip() or "{}"


### PR DESCRIPTION
## Summary
kimi_k2 was the only Streaming Parser Engine backend with `tool_args_json=True` and no `arg_converter`. Because `_compute_arg_delta` and `_flush_arg_converter` both return early when `arg_converter is None` (before ever reaching `_fix_arg_types`), streaming emitted the model's raw JSON value types unchanged, while non-streaming always coerces to the tool schema via `_build_extracted_result`. Same model output, different typed values depending on whether the client streams or not — silent, since the output is still valid JSON.

Full root cause and reproduction: #49316

## Fix
Entirely in `vllm/parser/kimi_k2.py`. Zero changes to `parser_engine.py`.

- Added `_kimi_k2_arg_converter(raw_args, partial)`: normalizes kimi's raw JSON to canonical `json.dumps` output, using `partial_json_parser` (already a project dependency — see `requirements/common.txt`, used by 7 other tool parsers) to complete incomplete objects when `json.loads` fails on partial input. Unparsable text is returned unchanged so no argument bytes are lost.
- Wired it in via `arg_converter=_kimi_k2_arg_converter` in `kimi_k2_config`.
- Removed the now-incompatible `_handle_arg_chunk` override, which emitted the first arg chunk as raw `event.value`, bypassing any converter. Once a converter exists this duplicated output.

## Why this approach
Once kimi has a converter, it flows through the same converter-present machinery PR #48706 already hardened: `_fix_arg_types` coercion, `_safe_arg_prefix`'s withholding of unstable trailing values, and the `startswith` prefix invariant. Because the converter re-emits canonical `json.dumps` output on every tick (both partial and flush), and non-streaming routes through the same converter, both paths produce byte-identical concatenated output by construction, rather than needing to be kept in sync by hand.

### Alternative considered and rejected: raw-text withholding
Adapting PR #48706's `non_string_clip` idea directly to the no-converter path (withhold non-string field values from the raw stream, emit them corrected at flush) was the first approach tried. It doesn't work: once a field coerces, `_fix_arg_types` re-serializes the entire object with `json.dumps` spacing (`{"a":"x",...}` → `{"a": "x", ...}`), but partial raw JSON can't be run through `_fix_arg_types` mid-stream (it isn't valid JSON yet), so the raw no-space prefix already streamed is never a valid prefix of the eventual coerced-and-spaced output. The `startswith` check then fails and silently truncates — reproducing the exact #48702 failure mode in a new place. The only prefix that's safe under both outcomes turns out to be the opening `{"firstkey":`, which defeats progressive streaming entirely. This is unavoidable specifically because of middle (not just trailing) non-string fields — verified by direct construction, not just argued.

### Alternative considered and rejected: minimal in-place coercion
Coercing values in place while preserving the model's original raw formatting (no re-spacing) would require either changing `_fix_arg_types` itself (shared with the converter-present path — out of scope and risks regressing #48706's behavior) or accepting that kimi's non-streaming output diverges from the canonical format everywhere else in the engine.

## Known behavior change (intentional, flagged for review)
Non-streaming output for untyped/already-correct fields is now whitespace-normalized (`{"city":"Tokyo"}` → `{"city": "Tokyo"}`) — a direct consequence of routing both paths through the same canonical `json.dumps` converter. Already-coerced field output is unchanged (`{"count": 3}` stays `{"count": 3}`). No existing test asserts on the old compact non-streaming format for kimi_k2 (checked: `tests/parser/`, `tests/reasoning/test_kimi_k2_reasoning_parser.py`, `tests/entrypoints/unit_tests/test_chat_utils.py` all pass unchanged). Flagging this explicitly in case a maintainer considers exact non-streaming byte format a compatibility concern.

## Testing
- New file: `tests/parser/engine/test_kimi_k2_streaming.py`, 27 deterministic, byte-level tests at chunk sizes 1/3/1000, covering: single non-string field (int/bool/number), middle (non-trailing) non-string field, nested non-string field, parallel tool calls, string field with a numeric-looking literal, already-correct-types control, and truncated/never-closed JSON.
- Confirmed red→green directly: `git stash` + run → 21/27 fail on unpatched `main` (every coercion scenario); `git stash pop` + run → 27/27 pass.
- Independently verified with a probe script written before this fix existed (not authored alongside it) — all cases now match streaming/non-streaming, including a parallel-tool-calls case.
- Full existing suite: `tests/parser/engine/` — 3699 passed, 0 regressions (includes all converter-present deepseek/qwen/gemma streaming tests, confirming this change doesn't touch that path's behavior).
- `tests/parser/test_parse.py`, `tests/parser/test_streaming.py`, `tests/reasoning/test_kimi_k2_reasoning_parser.py`: pass, unchanged.
- `tests/entrypoints/unit_tests/test_chat_utils.py`: 12 failed / 7 errored, identically with and without this change applied (confirmed via stash-diff) — pre-existing environment gap (missing Torchvision), not a regression.
- `ruff check` + `ruff format`: clean.

## Not yet verified
Real-tokenizer reasoning/tool-parser suites requiring `moonshotai/*` tokenizer download couldn't be run in this environment (no network access to HuggingFace from the dev machine). Logic exercised is the same code path covered by the mock-tokenizer tests above, but a maintainer with the model cached should run these before merge.

## Not a duplicate of
- #48702 / #48706 — related but different mechanism: that bug is in the `arg_converter`-present path (`_flush_arg_converter`'s `startswith(prev)` invariant breaking when coercion shrinks JSON). This bug is in the `arg_converter is None` path, which never calls `_fix_arg_types` at all, regardless of any prefix invariant. Confirmed no code overlap: `git diff` of #48706 contains no reference to the `arg_converter is None` branch this PR modifies.
- #47643 — different bug (Python-repr `None` coercion).
