### PR TITLE
[Bugfix] Fix empty logprob_token_ids silently bypassing validation via truthy checks

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_logprob_token_ids.py
+++ b/tests/entrypoints/openai/chat_completion/test_logprob_token_ids.py
@@ -98,6 +98,90 @@ def test_completion_rejects_explicit_token_ids_without_generated_tokens():
         )
 
 
+@pytest.mark.parametrize(
+    ("logprob_token_ids", "expect_error", "match"),
+    [
+        # Field absent: always fine
+        pytest.param(
+            "OMIT", False, None,
+            id="omitted-no-error",
+        ),
+        # Field explicitly None: treated as absent, fine
+        pytest.param(
+            None, False, None,
+            id="none-no-error",
+        ),
+        # Empty list was the bug: used to silently pass, must now be rejected
+        pytest.param(
+            [], True, "must not be an empty list",
+            id="empty-list-rejected",
+        ),
+        # Non-empty without logprobs: correctly rejected both before and after fix
+        pytest.param(
+            [1, 2, 3], True, r"logprobs.*must be set to true",
+            id="nonempty-without-logprobs-rejected",
+        ),
+    ],
+)
+def test_chat_logprob_token_ids_validation(
+    logprob_token_ids, expect_error, match
+):
+    """Regression: [] must be rejected, not silently discarded."""
+    kwargs: dict = dict(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "Hello"}],
+        logprobs=False,
+    )
+    if logprob_token_ids != "OMIT":
+        kwargs["logprob_token_ids"] = logprob_token_ids
+
+    if expect_error:
+        with pytest.raises(ValidationError, match=match):
+            ChatCompletionRequest(**kwargs)
+    else:
+        ChatCompletionRequest(**kwargs)  # must not raise
+
+
+@pytest.mark.parametrize(
+    ("logprob_token_ids", "expect_error", "match"),
+    [
+        pytest.param(
+            "OMIT", False, None,
+            id="omitted-no-error",
+        ),
+        pytest.param(
+            None, False, None,
+            id="none-no-error",
+        ),
+        pytest.param(
+            [], True, "must not be an empty list",
+            id="empty-list-rejected",
+        ),
+        pytest.param(
+            [1, 2, 3], True, r"logprobs.*must be set",
+            id="nonempty-without-logprobs-rejected",
+        ),
+    ],
+)
+def test_completion_logprob_token_ids_validation(
+    logprob_token_ids, expect_error, match
+):
+    """Regression: [] must be rejected on /v1/completions too."""
+    kwargs: dict = dict(
+        model=MODEL_NAME,
+        prompt="Hello",
+        # logprobs omitted → None, so "logprobs must be set" guard fires
+    )
+    if logprob_token_ids != "OMIT":
+        kwargs["logprob_token_ids"] = logprob_token_ids
+
+    if expect_error:
+        with pytest.raises(ValidationError, match=match):
+            CompletionRequest(**kwargs)
+    else:
+        CompletionRequest(**kwargs)  # must not raise
+
+
 def test_requests_reject_explicit_token_ids_with_beam_search():
     with pytest.raises(ValidationError, match="not supported with beam search"):
         ChatCompletionRequest(

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -676,11 +676,11 @@ class ChatCompletionRequest(OpenAIBaseModel):
             stop_token_ids=stop_token_ids,
             logprobs=(
                 self.top_logprobs
-                if self.logprobs and not self.logprob_token_ids
+                if self.logprobs and self.logprob_token_ids is None
                 else None
             ),
             prompt_logprobs=prompt_logprobs,
-            logprob_token_ids=self.logprob_token_ids or None,
+            logprob_token_ids=self.logprob_token_ids,
             ignore_eos=self.ignore_eos,
             max_tokens=max_tokens,
             min_tokens=self.min_tokens,
@@ -745,17 +745,22 @@ class ChatCompletionRequest(OpenAIBaseModel):
     @model_validator(mode="before")
     @classmethod
     def check_logprobs(cls, data):
-        if data.get("logprob_token_ids") and data.get("use_beam_search"):
-            raise VLLMValidationError(
-                "`logprob_token_ids` is not supported with beam search.",
-                parameter="logprob_token_ids",
-            )
-
-        if data.get("logprob_token_ids") and not data.get("logprobs"):
-            raise VLLMValidationError(
-                "when using `logprob_token_ids`, `logprobs` must be set to true.",
-                parameter="logprob_token_ids",
-            )
+        if data.get("logprob_token_ids") is not None:
+            if len(data["logprob_token_ids"]) == 0:
+                raise VLLMValidationError(
+                    "`logprob_token_ids` must not be an empty list.",
+                    parameter="logprob_token_ids",
+                )
+            if data.get("use_beam_search"):
+                raise VLLMValidationError(
+                    "`logprob_token_ids` is not supported with beam search.",
+                    parameter="logprob_token_ids",
+                )
+            if not data.get("logprobs"):
+                raise VLLMValidationError(
+                    "when using `logprob_token_ids`, `logprobs` must be set to true.",
+                    parameter="logprob_token_ids",
+                )
 
         # These fields are integers, but `mode="before"` runs on the raw
         # request data, so a non-numeric value (e.g. a JSON string) would
@@ -1081,11 +1086,15 @@ class BatchChatCompletionRequest(OpenAIBaseModel):
                 "Please set `use_beam_search` to False.",
                 parameter="use_beam_search",
             )
-        if data.get("logprob_token_ids") and not data.get("logprobs"):
-            raise VLLMValidationError(
-                "when using `logprob_token_ids`, `logprobs` must be set to true.",
-                parameter="logprob_token_ids",
-            )
+        if data.get("logprob_token_ids") is not None:
+            if len(data["logprob_token_ids"]) == 0:
+                raise ValueError(
+                    "`logprob_token_ids` must not be an empty list."
+                )
+            if not data.get("logprobs"):
+                raise ValueError(
+                    "when using `logprob_token_ids`, `logprobs` must be set to true."
+                )
         response_format = data.get("response_format")
         rf_type = (
             response_format.get("type")

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -353,12 +353,12 @@ class CompletionRequest(OpenAIBaseModel):
             seed=self.seed,
             stop=self.stop,
             stop_token_ids=stop_token_ids,
-            logprobs=None if self.logprob_token_ids else self.logprobs,
+            logprobs=None if self.logprob_token_ids is not None else self.logprobs,
             ignore_eos=self.ignore_eos,
             max_tokens=max_tokens if not echo_without_generation else 1,
             min_tokens=self.min_tokens,
             prompt_logprobs=prompt_logprobs,
-            logprob_token_ids=self.logprob_token_ids or None,
+            logprob_token_ids=self.logprob_token_ids,
             skip_special_tokens=self.skip_special_tokens,
             spaces_between_special_tokens=self.spaces_between_special_tokens,
             include_stop_str_in_output=self.include_stop_str_in_output,
@@ -445,28 +445,28 @@ class CompletionRequest(OpenAIBaseModel):
     @model_validator(mode="before")
     @classmethod
     def check_logprobs(cls, data):
-        if data.get("logprob_token_ids") and data.get("use_beam_search"):
-            raise VLLMValidationError(
-                "`logprob_token_ids` is not supported with beam search.",
-                parameter="logprob_token_ids",
-            )
-
-        if (
-            data.get("logprob_token_ids")
-            and data.get("echo")
-            and data.get("max_tokens") == 0
-        ):
-            raise VLLMValidationError(
-                "`logprob_token_ids` is not supported when `echo=True` and "
-                "`max_tokens=0` because no output tokens are generated.",
-                parameter="logprob_token_ids",
-            )
-
-        if data.get("logprob_token_ids") and data.get("logprobs") is None:
-            raise VLLMValidationError(
-                "when using `logprob_token_ids`, `logprobs` must be set.",
-                parameter="logprob_token_ids",
-            )
+        if data.get("logprob_token_ids") is not None:
+            if len(data["logprob_token_ids"]) == 0:
+                raise VLLMValidationError(
+                    "`logprob_token_ids` must not be an empty list.",
+                    parameter="logprob_token_ids",
+                )
+            if data.get("use_beam_search"):
+                raise VLLMValidationError(
+                    "`logprob_token_ids` is not supported with beam search.",
+                    parameter="logprob_token_ids",
+                )
+            if data.get("echo") and data.get("max_tokens") == 0:
+                raise VLLMValidationError(
+                    "`logprob_token_ids` is not supported when `echo=True` and "
+                    "`max_tokens=0` because no output tokens are generated.",
+                    parameter="logprob_token_ids",
+                )
+            if data.get("logprobs") is None:
+                raise VLLMValidationError(
+                    "when using `logprob_token_ids`, `logprobs` must be set.",
+                    parameter="logprob_token_ids",
+                )
 
         # These fields are integers, but `mode="before"` runs on the raw
         # request data, so a non-numeric value (e.g. a JSON string) would


### PR DESCRIPTION
## Purpose

Fixes #49319.

`logprob_token_ids` is typed `list[int] | None`. All validation guards in the Chat Completions and
Completions protocol validators used Python truthy checks (`if data.get("logprob_token_ids") and ...`)
instead of explicit `is not None` checks.

Because an empty list `[]` is falsy, a request carrying `logprob_token_ids: []` silently bypassed every
guard:
- the "logprobs must be set" rejection never fired
- the beam-search and echo+max_tokens=0 rejections never fired
- `self.logprob_token_ids or None` discarded the field downstream

The same root cause affected `to_sampling_params` in both endpoints:
- chat: `if self.logprobs and not self.logprob_token_ids` branched incorrectly for `[]` (falsy → treated
  as absent)
- completion: `None if self.logprob_token_ids else ...` same error
- both: `self.logprob_token_ids or None` silently coerced `[]` → `None`

Fix: consolidate each endpoint's three separate `if data.get(...) and` guards under a single
`if data.get(...) is not None:` block, add an explicit empty-list rejection (mirroring
`allowed_token_ids`), and replace the `or None` discard patterns with direct assignment /
`is not None` ternaries.

Affected locations (10 total, 2 files):
- `vllm/entrypoints/openai/chat_completion/protocol.py`: lines 679, 683, 748–762
  (`ChatCompletionRequest`), 1087–1094 (`BatchChatCompletionRequest`)
- `vllm/entrypoints/openai/completion/protocol.py`: lines 356, 361, 448–468 (`CompletionRequest`)

## Test Plan

```bash
python3 -m pytest tests/entrypoints/openai/chat_completion/test_logprob_token_ids.py -v
```

Regression tests added covering omitted / `None` / `[]` / `[1,2,3]` for both endpoints.

## Test Result

```
12 passed
```

Confirmed live against a running server before this fix:
```
POST /v1/chat/completions with logprob_token_ids=[] returned 200 OK,
logprobs: null — request was silently ignored.
```
Same pattern confirmed on `/v1/completions`. After the fix, the same request is correctly rejected with
a clear validation error instead of silently succeeding.

## Related
- #48098 — same general bug family (unguarded optional/falsy request field bypassing validation),
  different field (`parallel_tool_calls`), merged.