### PR TITLE
[Feature][MoE]W4A16 cold-expert CPU offload via in-graph HIP gather (experimental)

### DIFF
--- a/EXPERT_OFFLOAD.md
+++ b/EXPERT_OFFLOAD.md
@@ -1,0 +1,166 @@
+# W4A16 Cold-Expert CPU Offload (RDNA3 / gfx1100)
+
+Run a MoE model whose expert weights exceed VRAM by keeping the full expert set
+in **CPU pinned RAM** and streaming a fixed-size **hot subset onto the GPU** each
+forward. Targets W4A16 (compressed-tensors, `pack-quantized` int4) MoE on AMD
+RDNA3 using the native `moe_gptq_gemm_rdna3` kernel. Proven end-to-end on the
+full **Qwen3.5-122B-A10B** (256 experts / top-8 / 48 layers) on 2×24 GB.
+
+Depends only on the upstream RDNA3 W4A16 MoE kernel (`moe_gptq_gemm_rdna3`) and
+the `CompressedTensorsWNA16RDNA3MoEMethod` path — no other RDNA3-stack changes.
+
+---
+
+## How to use
+
+Set one environment variable — the number of experts kept resident **per layer,
+per rank**:
+
+```bash
+VLLM_MOE_EXPERT_CACHE_SIZE=64      # 0 (default) = disabled, normal all-resident path
+```
+
+That is the only knob. When `> 0`, the RDNA3 W4A16 MoE method automatically:
+loads experts to pinned CPU, builds a `C`-slot GPU cache, and streams experts in
+per step. When `0` / unset, behaviour is unchanged (all experts on GPU).
+
+### Full serving example (122B on 2×24 GB)
+
+```python
+import os
+os.environ["VLLM_MOE_EXPERT_CACHE_SIZE"] = "64"
+
+# IMPORTANT (tp>1): precompile the runtime kernel in the MAIN process before
+# LLM() spawns workers, or the two workers race to JIT-compile it -> ninja-lock
+# deadlock. See "Gotchas".
+import importlib.util, sys
+_spec = importlib.util.spec_from_file_location(
+    "expert_gather",
+    "<vllm>/model_executor/layers/fused_moe/expert_gather.py")
+_eg = importlib.util.module_from_spec(_spec); sys.modules["_egpre"] = _eg
+_spec.loader.exec_module(_eg); _eg._mod()          # compiles / loads the .so
+
+from vllm import LLM
+llm = LLM(
+    model="/models/Qwen3.5-122B-A10B-4bit",
+    tensor_parallel_size=2,
+    kv_cache_dtype="int8_per_token_head",   # frees VRAM for the cache (+ enforce_eager, see below)
+    language_model_only=True,               # multimodal model -> skip vision tower
+    max_model_len=2048,
+    gpu_memory_utilization=0.85,
+    trust_remote_code=True,
+    # enforce_eager=True,                   # REQUIRED if kv_cache_dtype=int8 in this container build
+)
+```
+
+### Parameter cheat-sheet
+
+| Parameter | Where | Meaning / recommended |
+|---|---|---|
+| `VLLM_MOE_EXPERT_CACHE_SIZE` | env | **The knob.** Experts resident per layer/rank. `0`=off. `64`≈8 GB/rank cache on the 122B (fits 2×24 GB with KV). `128`≈16 GB/rank (does **not** fit alongside model+KV on 24 GB). |
+| `tensor_parallel_size` | LLM | `2` recommended. TP is transparent to the cache (routing is TP-invariant; each rank caches its own shard, no cross-rank coordination). tp=1 works but is slower here (2× compute > the AR it avoids). |
+| `kv_cache_dtype` | LLM | `int8_per_token_head` recommended for hybrid/large models — halves KV so the cache fits. In this container build int8 KV **requires `enforce_eager=True`** (int8+cudagraph = page-fault; fix lives on `rdna3_full_stack` but not in the installed `.so`). |
+| `enforce_eager` | LLM | Cudagraph **is** supported by the offload (the gather is capturable — see below). Only forced to `True` when using int8 KV in this build. |
+| `language_model_only` | LLM | `True` for multimodal checkpoints (Qwen3.5-*) to skip the vision tower. |
+| `gpu_memory_utilization` | LLM | ~0.85. The GPU cache is allocated out-of-band during weight processing; leave headroom. |
+
+**Sizing rule of thumb** (per rank, per layer, C experts): cache VRAM ≈
+`C × per_expert_bytes × num_layers`. For the 122B (per-expert ≈ 175 MB/layer at
+the 4 gathered planes for the given TP shard): `C=64 → ~8.4 GB/rank`,
+`C=32 → ~4.2 GB/rank`. CPU pinned master holds **all** E experts ≈ 32 GB/rank
+(64 GB total for the 122B) — this is the model itself and is unavoidable.
+
+---
+
+## How it is implemented
+
+Three pieces. The cache is generic over W4A16 (agnostic to the int4 layout — it
+only slices dim-0 of the fused expert tensors) and is consumed by the RDNA3
+kernel unchanged.
+
+### 1. Runtime-compiled HIP gather kernels — `fused_moe/expert_gather.py`
+
+Two kernels, both **HIP-graph capturable** (fixed launch shapes, no host sync),
+compiled at import via `torch.utils.cpp_extension.load_inline` (**no `_rocm_C`
+rebuild**):
+
+- **`ec_plan`** (1 workgroup): dedup the step's needed experts; on a *hit* freshen
+  the slot's LRU clock; on a *miss* pick a clock-LRU victim (current-step experts
+  are auto-protected because hits/just-loaded slots are freshened to the max
+  clock this step, so the argmin never selects them); update the persistent
+  `slot_of_expert[E]` / `expert_of_slot[C]` maps; emit an `(expert→slot)` copy
+  plan padded to a fixed length.
+- **`ec_copy`** (1 block per plan entry): for each valid entry, **zero-copy** the
+  expert's row block from device-mapped pinned host memory into its GPU slot
+  (vectorized `int4`); padded entries are skipped by a per-thread branch.
+
+The skip-on-hit **reuse** happens *inside* the kernel (SIMT branch), not via CUDA
+graph control flow — which is why it captures on HIP even though HIP has no
+conditional graph nodes. Measured on gfx1100: in-kernel zero-copy from pinned
+host = **~26 GB/s (== DMA)**, all-hit overhead ≈ 0.007 ms/layer.
+
+`ExpertOffloadCache` (same file) ties it together: pinned master + GPU slots per
+plane + the state tensors; `ensure(topk_ids)` runs `plan` + one `copy` per plane
+and returns `topk_ids` remapped into slot space `[0, C)`.
+
+### 2. Wiring — `compressed_tensors_moe/compressed_tensors_moe_wna16_rdna3.py`
+
+- **`create_weights`**: when the env is set, allocates the big expert params on
+  **CPU pinned** (via a `with torch.device("cpu")` context) so the full E-expert
+  set never has to fit in VRAM at load.
+- **`_process_weights_offload`**: vLLM's `device_loading_context` moves each
+  layer's params to the GPU before this runs, so it shuffles the packed weights
+  **in-place on the GPU** (fast), moves each prepared plane to a CPU pinned
+  master, and **frees the GPU param** (`p.data = empty`) — freeing is essential
+  or the 48 layers pile up on the GPU. Zero-points are identical across experts,
+  so they are a single static `[C, …]` GPU tensor (not gathered). 4 planes are
+  gathered: `w13/w2_weight_packed`, `w13/w2_weight_scale`.
+- **`_rdna3_fused_moe`**: on the offload path — `ec.ensure(topk_ids)` → remap →
+  `moe_align_block_size(..., global_num_experts=C)` → the existing
+  `moe_gptq_gemm_rdna3` GEMM over the `[C,…]` cache tensors. For batches whose
+  working set could exceed `C` it **chunks the tokens** so each chunk needs ≤ C
+  experts.
+
+---
+
+## Status (2026-07-03)
+
+- **Works E2E**: full 122B, TP2, coherent output. **Cudagraph proven** (capture +
+  500 replays of `ensure()` correct; full-model capture also succeeds — needs
+  `C≤48` to fit graph pools alongside model+KV on 24 GB).
+- **Speed**: ~13.6 tok/s decode @ C=64 cudagraph. Bound by compute + copy, near
+  the model/box ceiling (the TP all-reduce is NOT the bottleneck — profiler
+  "all_reduce 55%" is wait time; isolated AR is 56 µs).
+- **Quality preserved** (offload is numerically transparent — the gather is
+  correct and deterministic).
+
+## Known limitations
+
+- **Prefill thrashing (biggest gap):** offload is decode-optimized (bs=1, small
+  working set). Long-prompt / high-concurrency **prefill** has a working set ≫ C
+  → the token-chunk loop reloads the cache repeatedly (an 8192-token forward can
+  copy terabytes → RPC timeout). Mitigate with small `max_num_batched_tokens`
+  (e.g. 256) + low `max_num_seqs`. **v2 fix:** process prefill *expert-major*
+  (load each unique expert once, GEMM all its tokens; reuse the `moe_align`
+  grouping).
+- **C sizing on 24 GB:** `C=128` (16 GB cache) does not fit with model + KV;
+  `C=64` (8 GB) is the practical operating point.
+- **RAM:** the pinned master = full model experts (~64 GB for the 122B). Pinned
+  memory is non-swappable; this is the price of cudagraph (an mmap/pageable
+  master would need copies outside capture).
+
+## Gotchas (all hit during bring-up)
+
+- **tp>1 kernel JIT deadlock:** both workers race to `load_inline`-compile the
+  same extension → ninja lock deadlock. **Precompile in the main process** before
+  `LLM()` (see example). Also delete stale locks:
+  `find /root/.cache/torch_extensions -name lock -delete`.
+- **`device_loading_context` GPU pile-up:** do **not** keep a reference to the
+  GPU param as the master — free it and hold a CPU pinned copy (fixed in
+  `_process_weights_offload`).
+- **int8 KV + cudagraph = page fault** in the installed build → use
+  `enforce_eager=True` with int8 KV (or fp16 KV + cudagraph if it fits).
+- Kill stray `VLLM::` workers by that name, not the script name (spawn detaches
+  them); `-9`-killed workers leak pinned RAM — reclaim with
+  `echo 3 > /proc/sys/vm/drop_caches`.
+- `datasets` 5.x needs `"openai/openai_humaneval"`, not bare `"openai_humaneval"`.

--- a/vllm/model_executor/layers/fused_moe/expert_gather.py
+++ b/vllm/model_executor/layers/fused_moe/expert_gather.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Runtime-compiled HIP gather kernels for W4A16 cold-expert offload (arch A).
+
+Two HIP-graph-capturable kernels (no host sync, fixed launch shapes):
+
+  ec_plan : one block. Dedup the step's needed experts, freshen LRU on hits,
+            pick a clock-LRU victim on misses (current-step protection is
+            automatic — hits and just-loaded slots are freshened to the max
+            clock this step, so argmin never selects them while an older slot
+            exists), update slot_of_expert / expert_of_slot, emit an
+            (expert -> slot) copy plan padded to max_m.
+  ec_copy : one block per plan entry. Valid entries zero-copy the expert's row
+            block from device-mapped pinned host master into its GPU slot;
+            padded entries are skipped by a SIMT branch.
+
+Measured on gfx1100: in-kernel zero-copy reads from device-mapped pinned host
+run at ~26 GB/s (== DMA), and the all-hit path is ~0.007 ms/layer.
+
+Compiled at import via torch cpp_extension so we do NOT rebuild vLLM's _rocm_C.
+"""
+
+from __future__ import annotations
+
+import functools
+
+import torch
+
+_CPP_SRC = r"""
+#include <torch/extension.h>
+int64_t ec_device_ptr(torch::Tensor pinned);
+void ec_plan(torch::Tensor topk_ids, torch::Tensor slot_of_expert,
+             torch::Tensor expert_of_slot, torch::Tensor lru_last,
+             torch::Tensor clk, int64_t cache_size, torch::Tensor plan_expert,
+             torch::Tensor plan_slot);
+void ec_copy(torch::Tensor plan_expert, torch::Tensor plan_slot,
+             int64_t master_devptr, torch::Tensor cache, int64_t row_u4);
+"""
+
+_CUDA_SRC = r"""
+#include <torch/extension.h>
+#include <c10/cuda/CUDAStream.h>
+
+__global__ void ec_plan_k(const int* __restrict__ topk_ids, int n_sel,
+                          int* __restrict__ slot_of_expert,
+                          int* __restrict__ expert_of_slot,
+                          long long* __restrict__ lru_last,
+                          long long* __restrict__ clk, int cache_size, int max_m,
+                          int* __restrict__ plan_expert,
+                          int* __restrict__ plan_slot) {
+  if (threadIdx.x != 0 || blockIdx.x != 0) return;
+  long long now = *clk;
+  int pc = 0;
+  for (int i = 0; i < n_sel; i++) {
+    int e = topk_ids[i];
+    if (e < 0) continue;
+    int s = slot_of_expert[e];
+    if (s >= 0) { lru_last[s] = now; continue; }  // hit: freshen
+    bool dup = false;
+    for (int j = 0; j < pc; j++) if (plan_expert[j] == e) { dup = true; break; }
+    if (dup) continue;
+    int victim = 0; long long best = lru_last[0];
+    for (int c = 1; c < cache_size; c++)
+      if (lru_last[c] < best) { best = lru_last[c]; victim = c; }
+    int ve = expert_of_slot[victim];
+    if (ve >= 0) slot_of_expert[ve] = -1;
+    expert_of_slot[victim] = e;
+    slot_of_expert[e] = victim;
+    lru_last[victim] = now;
+    plan_expert[pc] = e; plan_slot[pc] = victim; pc++;
+  }
+  for (int j = pc; j < max_m; j++) { plan_expert[j] = -1; plan_slot[j] = -1; }
+  *clk = now + 1;
+}
+
+__global__ void ec_copy_k(const int* __restrict__ plan_expert,
+                          const int* __restrict__ plan_slot,
+                          const int4* __restrict__ master,
+                          int4* __restrict__ cache, int row_u4) {
+  int m = blockIdx.x;
+  int e = plan_expert[m];
+  if (e < 0) return;  // padded: skip
+  int s = plan_slot[m];
+  const int4* src = master + (long long)e * row_u4;
+  int4* dst = cache + (long long)s * row_u4;
+  for (int i = threadIdx.x; i < row_u4; i += blockDim.x) dst[i] = src[i];
+}
+
+// Resolve a device-accessible pointer for a pinned host tensor (once, at setup).
+int64_t ec_device_ptr(torch::Tensor pinned) {
+  void* dptr = nullptr;
+  cudaHostGetDevicePointer(&dptr, pinned.data_ptr(), 0);
+  return reinterpret_cast<int64_t>(dptr);
+}
+
+// Plan the step's residency (dedup + evict + update maps + emit copy plan).
+// Fully on-device -> HIP-graph capturable. Call ONCE per MoE step; the plan is
+// shared by all weight planes.
+void ec_plan(torch::Tensor topk_ids, torch::Tensor slot_of_expert,
+             torch::Tensor expert_of_slot, torch::Tensor lru_last,
+             torch::Tensor clk, int64_t cache_size, torch::Tensor plan_expert,
+             torch::Tensor plan_slot) {
+  int n_sel = topk_ids.numel();
+  int max_m = plan_expert.numel();
+  auto stream = at::cuda::getCurrentCUDAStream();
+  ec_plan_k<<<1, 64, 0, stream>>>(
+      topk_ids.data_ptr<int>(), n_sel, slot_of_expert.data_ptr<int>(),
+      expert_of_slot.data_ptr<int>(),
+      reinterpret_cast<long long*>(lru_last.data_ptr<int64_t>()),
+      reinterpret_cast<long long*>(clk.data_ptr<int64_t>()), (int)cache_size,
+      max_m, plan_expert.data_ptr<int>(), plan_slot.data_ptr<int>());
+}
+
+// Zero-copy the planned experts' rows for ONE weight plane (contiguous [C,..]).
+// row_u4 = bytes_per_expert_row / 16. Call once per plane with the same plan.
+void ec_copy(torch::Tensor plan_expert, torch::Tensor plan_slot,
+             int64_t master_devptr, torch::Tensor cache, int64_t row_u4) {
+  int max_m = plan_expert.numel();
+  auto stream = at::cuda::getCurrentCUDAStream();
+  ec_copy_k<<<max_m, 256, 0, stream>>>(
+      plan_expert.data_ptr<int>(), plan_slot.data_ptr<int>(),
+      reinterpret_cast<const int4*>(master_devptr),
+      reinterpret_cast<int4*>(cache.data_ptr()), (int)row_u4);
+}
+"""
+
+
+@functools.lru_cache(maxsize=1)
+def _mod():
+    from torch.utils.cpp_extension import load_inline
+
+    return load_inline(
+        name="vllm_expert_gather",
+        cpp_sources=_CPP_SRC,
+        cuda_sources=_CUDA_SRC,
+        functions=["ec_device_ptr", "ec_plan", "ec_copy"],
+        with_cuda=True,
+        verbose=False,
+    )
+
+
+def device_ptr(pinned: torch.Tensor) -> int:
+    return _mod().ec_device_ptr(pinned)
+
+
+def plan(
+    topk_ids: torch.Tensor,
+    slot_of_expert: torch.Tensor,
+    expert_of_slot: torch.Tensor,
+    lru_last: torch.Tensor,
+    clk: torch.Tensor,
+    cache_size: int,
+    plan_expert: torch.Tensor,
+    plan_slot: torch.Tensor,
+) -> None:
+    _mod().ec_plan(
+        topk_ids, slot_of_expert, expert_of_slot, lru_last, clk,
+        cache_size, plan_expert, plan_slot,
+    )
+
+
+def copy(
+    plan_expert: torch.Tensor,
+    plan_slot: torch.Tensor,
+    master_devptr: int,
+    cache: torch.Tensor,
+    row_u4: int,
+) -> None:
+    _mod().ec_copy(plan_expert, plan_slot, master_devptr, cache, row_u4)
+
+
+class ExpertOffloadCache:
+    """Per-layer W4A16 cold-expert cache: pinned master of all E experts +
+    fixed GPU cache of C slots, backed by the plan/copy HIP kernels.
+
+    Each per-expert weight plane is stored as a contiguous, uint4-aligned pinned
+    master ``[E, row_ints]`` (device-mapped) and a GPU cache ``[C, row_ints]``.
+    :meth:`ensure` plans residency for a step's ``topk_ids`` (expert space) and
+    returns ``topk_ids`` remapped to slot space ``[0, C)`` for the GEMM.
+    """
+
+    def __init__(self, num_experts: int, cache_size: int, max_sel: int,
+                 device: torch.device):
+        self.E = num_experts
+        self.C = min(cache_size, num_experts)
+        self.device = device
+        self.planes: dict[str, dict] = {}  # name -> {master, cache, dptr, row_u4}
+        self.slot_of_expert = torch.full((self.E,), -1, dtype=torch.int32,
+                                         device=device)
+        self.expert_of_slot = torch.full((self.C,), -1, dtype=torch.int32,
+                                         device=device)
+        self.lru_last = torch.zeros(self.C, dtype=torch.int64, device=device)
+        self.clk = torch.ones(1, dtype=torch.int64, device=device)
+        self.plan_e = torch.full((max_sel,), -1, dtype=torch.int32, device=device)
+        self.plan_s = torch.full((max_sel,), -1, dtype=torch.int32, device=device)
+
+    def add_plane(self, name: str, master_pinned: torch.Tensor,
+                  cache_gpu: torch.Tensor) -> None:
+        """master_pinned [E, *shape] (pinned), cache_gpu [C, *shape] (device).
+        Both must be contiguous and uint4 (16B) aligned per expert row."""
+        row_bytes = master_pinned[0].numel() * master_pinned.element_size()
+        assert row_bytes % 16 == 0, f"{name} row {row_bytes} not 16B-aligned"
+        self.planes[name] = {
+            "master": master_pinned,
+            "cache": cache_gpu,
+            "dptr": device_ptr(master_pinned),
+            "row_u4": row_bytes // 16,
+        }
+
+    def cache_tensor(self, name: str) -> torch.Tensor:
+        return self.planes[name]["cache"]
+
+    def warm(self, expert_ids: list[int]) -> None:
+        """Preload experts into slots (host-side, one-time at load)."""
+        for slot, e in enumerate(expert_ids[: self.C]):
+            self.slot_of_expert[e] = slot
+            self.expert_of_slot[slot] = e
+            self.lru_last[slot] = 0
+            for p in self.planes.values():
+                p["cache"][slot].copy_(p["master"][e], non_blocking=True)
+
+    def ensure(self, topk_ids: torch.Tensor) -> torch.Tensor:
+        """Make the step's experts resident; return slot-space topk_ids."""
+        flat = topk_ids.reshape(-1).to(torch.int32)
+        plan(flat, self.slot_of_expert, self.expert_of_slot, self.lru_last,
+             self.clk, self.C, self.plan_e, self.plan_s)
+        for p in self.planes.values():
+            copy(self.plan_e, self.plan_s, p["dptr"], p["cache"], p["row_u4"])
+        return self.slot_of_expert[topk_ids.long()].to(topk_ids.dtype)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16_rdna3.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16_rdna3.py
@@ -11,6 +11,8 @@ Weight format (per expert, same as dense RDNA3 W4A16):
   - Zero points ``[E, groups, N/8]`` packed int32 (synthesized)
 """
 
+import os
+
 import torch
 
 from vllm import _custom_ops as ops
@@ -54,15 +56,72 @@ def _synthesize_qzeros(
     return pack_quantized_values_into_int32(zeros, scalar_types.uint4b8, packed_dim=1)
 
 
+def _expert_cache_size() -> int:
+    """Cold-expert offload cache size (# experts kept resident per layer/rank).
+
+    0 (default) disables offloading -> all experts resident on GPU (unchanged).
+    """
+    try:
+        return int(os.environ.get("VLLM_MOE_EXPERT_CACHE_SIZE", "0"))
+    except ValueError:
+        return 0
+
+
 class CompressedTensorsWNA16RDNA3MoEMethod(CompressedTensorsWNA16MoEMethod):
     """W4A16 MoE using the fused RDNA3 HIP kernel (moe_gptq_gemm_rdna3).
 
     Weights are in RDNA3 format (shuffled int32 [E, K/8, N]),
     NOT Triton format (transposed uint8). apply() dispatches through
     the fused HIP kernel directly.
+
+    When ``VLLM_MOE_EXPERT_CACHE_SIZE > 0`` the experts are offloaded to pinned
+    CPU RAM and a fixed GPU cache of that many experts is streamed in per step
+    by the in-graph gather kernel (see expert_gather.ExpertOffloadCache).
     """
 
+    def create_weights(
+        self,
+        layer,
+        num_experts,
+        hidden_size,
+        intermediate_size_per_partition,
+        params_dtype,
+        **extra_weight_attrs,
+    ):
+        # Offload: allocate the (large) expert params on CPU pinned so the full
+        # E-expert set never has to fit in VRAM during load. torch.device('cpu')
+        # context makes the base create_weights' torch.empty land on CPU.
+        if _expert_cache_size() > 0:
+            with torch.device("cpu"):
+                super().create_weights(
+                    layer,
+                    num_experts,
+                    hidden_size,
+                    intermediate_size_per_partition,
+                    params_dtype,
+                    **extra_weight_attrs,
+                )
+            for name in (
+                "w13_weight_packed",
+                "w2_weight_packed",
+                "w13_weight_scale",
+                "w2_weight_scale",
+            ):
+                p = getattr(layer, name)
+                p.data = p.data.pin_memory()
+        else:
+            super().create_weights(
+                layer,
+                num_experts,
+                hidden_size,
+                intermediate_size_per_partition,
+                params_dtype,
+                **extra_weight_attrs,
+            )
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if _expert_cache_size() > 0:
+            return self._process_weights_offload(layer)
         device = layer.w13_weight_packed.device
         num_experts = layer.w13_weight_packed.shape[0]
         empty_g_idx = torch.empty(0, dtype=torch.int32, device=device)
@@ -122,6 +181,96 @@ class CompressedTensorsWNA16RDNA3MoEMethod(CompressedTensorsWNA16MoEMethod):
             max_decode_tokens, hidden_size, dtype=act_dtype, device=device
         )
         layer.rdna3_empty_tw = torch.empty(0, device=device)
+        layer.expert_cache = None
+
+    def _process_weights_offload(self, layer: torch.nn.Module) -> None:
+        """Move experts to pinned CPU masters + build the GPU cache.
+
+        vLLM's ``device_loading_context`` has already moved this layer's params
+        onto the GPU before we run, so we shuffle the packed weights IN-PLACE on
+        the GPU (fast, no per-expert H2D), then move each prepared plane to a
+        CPU pinned master and FREE the GPU param (``p.data = empty``). Freeing is
+        essential: if we kept a reference to the GPU tensor, the 48 layers would
+        pile up on the GPU (the device_loading_context move-back can't reclaim a
+        referenced tensor). Zero-points are identical across experts -> a single
+        static [C, ...] GPU tensor, not gathered.
+        """
+        from vllm.model_executor.layers.fused_moe.expert_gather import (
+            ExpertOffloadCache,
+        )
+
+        device = torch.device(f"cuda:{torch.cuda.current_device()}")
+        E = layer.w13_weight_packed.shape[0]
+        C = min(_expert_cache_size(), E)
+        act_dtype = layer.w13_weight_scale.dtype
+        empty_g_idx = torch.empty(0, dtype=torch.int32, device=device)
+
+        gw13 = (layer.w13_weight_packed.shape[1] * 8) // self.group_size
+        w13_N = layer.w13_weight_packed.shape[2]
+        gw2 = (layer.w2_weight_packed.shape[1] * 8) // self.group_size
+        w2_N = layer.w2_weight_packed.shape[2]
+
+        # shuffle packed weights in-place on the GPU-resident params
+        for e in range(E):
+            ops.gptq_shuffle(layer.w13_weight_packed.data[e], empty_g_idx, 4)
+            ops.gptq_shuffle(layer.w2_weight_packed.data[e], empty_g_idx, 4)
+
+        # move each prepared plane to a CPU pinned master, then free the GPU param
+        cache = ExpertOffloadCache(E, C, max_sel=C, device=device)
+        for name in (
+            "w13_weight_packed",
+            "w2_weight_packed",
+            "w13_weight_scale",
+            "w2_weight_scale",
+        ):
+            p = getattr(layer, name)
+            src = p.data
+            if name.endswith("scale") and src.dtype != act_dtype:
+                src = src.to(act_dtype)
+            master = src.to("cpu").pin_memory()
+            p.data = torch.empty(0, device=device)  # free GPU (avoid pile-up)
+            shape = master.shape[1:]
+            cache.add_plane(
+                name,
+                master,
+                torch.empty(C, *shape, dtype=master.dtype, device=device),
+            )
+        cache.warm(list(range(C)))
+        layer.expert_cache = cache
+
+        # zero-points: identical for every expert -> one static [C, ...] tensor
+        qz13 = _synthesize_qzeros(gw13, w13_N, device)
+        qz2 = _synthesize_qzeros(gw2, w2_N, device)
+        layer.w13_qzeros = qz13.unsqueeze(0).expand(C, -1, -1).contiguous()
+        layer.w2_qzeros = qz2.unsqueeze(0).expand(C, -1, -1).contiguous()
+
+        # decode scratch buffers
+        intermediate = w13_N // 2
+        buf = 16 * 8
+        layer.rdna3_w1_buf = torch.zeros(buf, w13_N, dtype=act_dtype, device=device)
+        layer.rdna3_act_buf = torch.empty(
+            buf, intermediate, dtype=act_dtype, device=device
+        )
+        layer.rdna3_out_buf = torch.zeros(16, w2_N, dtype=act_dtype, device=device)
+        layer.rdna3_empty_tw = torch.empty(0, device=device)
+        # per-layer resident cache bytes (cache tensors already sized [C, ...])
+        per_layer = (
+            sum(
+                p["cache"].numel() * p["cache"].element_size()
+                for p in cache.planes.values()
+            )
+            + layer.w13_qzeros.numel() * 4
+            + layer.w2_qzeros.numel() * 4
+        )
+        logger.info_once(
+            "[expert-offload] cache C=%d / E=%d experts, "
+            "%.0f MB/layer (%.1f GB/rank over %d layers est.)",
+            C,
+            E,
+            per_layer / 1e6,
+            per_layer * 48 / 1e9,
+            48,
+        )
 
     def apply(
         self,
@@ -169,16 +318,54 @@ def _rdna3_fused_moe(
     """
     num_tokens = hidden_states.shape[0]
     top_k = topk_ids.shape[1]
+
+    # --- cold-expert offload: chunk tokens so a step's working set <= C, then
+    # gather the needed experts into cache slots and remap topk to slot space ---
+    ec = getattr(layer, "expert_cache", None)
+    if ec is not None:
+        max_tok = max(1, ec.C // top_k)
+        if num_tokens > max_tok:
+            outs = [
+                _rdna3_fused_moe(
+                    hidden_states[i : i + max_tok],
+                    topk_weights[i : i + max_tok],
+                    topk_ids[i : i + max_tok],
+                    layer,
+                    activation,
+                    apply_router_weight_on_input,
+                    global_num_experts,
+                    expert_map,
+                )
+                for i in range(0, num_tokens, max_tok)
+            ]
+            return torch.cat(outs, dim=0)
+        topk_ids = ec.ensure(topk_ids)  # -> slot space [0, C)
+        w13_packed = ec.cache_tensor("w13_weight_packed")
+        w2_packed = ec.cache_tensor("w2_weight_packed")
+        w13_scale = ec.cache_tensor("w13_weight_scale")
+        w2_scale = ec.cache_tensor("w2_weight_scale")
+        w13_qzeros = layer.w13_qzeros  # static [C, ...] (shared across experts)
+        w2_qzeros = layer.w2_qzeros
+        global_num_experts = ec.C
+        expert_map = None
+    else:
+        w13_packed = layer.w13_weight_packed
+        w2_packed = layer.w2_weight_packed
+        w13_scale = layer.w13_weight_scale
+        w2_scale = layer.w2_weight_scale
+        w13_qzeros = layer.w13_qzeros
+        w2_qzeros = layer.w2_qzeros
+
     total_tokens = num_tokens * top_k
-    N_gate_up = layer.w13_weight_packed.shape[2]
-    hidden_size = layer.w2_weight_packed.shape[2]
+    N_gate_up = w13_packed.shape[2]
+    hidden_size = w2_packed.shape[2]
     dtype = hidden_states.dtype
     device = hidden_states.device
 
     intermediate_size = N_gate_up // 2 if activation.is_gated else N_gate_up
 
     if global_num_experts <= 0:
-        global_num_experts = layer.w13_weight_packed.shape[0]
+        global_num_experts = w13_packed.shape[0]
 
     # BLOCK_SIZE_M=1 for decode (small M), 4 for prefill
     block_size_m = 1 if num_tokens <= 4 else 4
@@ -218,9 +405,9 @@ def _rdna3_fused_moe(
     ops.moe_gptq_gemm_rdna3(
         hidden_states,
         w1_out,
-        layer.w13_weight_packed,
-        layer.w13_weight_scale,
-        layer.w13_qzeros,
+        w13_packed,
+        w13_scale,
+        w13_qzeros,
         topk_w_float if apply_router_weight_on_input else empty_tw,
         sorted_token_ids,
         expert_ids,
@@ -246,9 +433,9 @@ def _rdna3_fused_moe(
     ops.moe_gptq_gemm_rdna3(
         act_out,
         out,
-        layer.w2_weight_packed,
-        layer.w2_weight_scale,
-        layer.w2_qzeros,
+        w2_packed,
+        w2_scale,
+        w2_qzeros,
         topk_w_float if not apply_router_weight_on_input else empty_tw,
         sorted_token_ids,
         expert_ids,


### PR DESCRIPTION
> ⚠️ **Experimental / work-in-progress.** RDNA3 (gfx1100) only. I'm opening it
> early to get feedback — it's not meant to be merged as-is.

## What it does

This lets you run a **W4A16 MoE that's too big to fit in VRAM**. The idea is
simple: keep the whole set of experts in CPU RAM, and only stream the handful
that are actually needed onto the GPU on each forward pass. It targets AMD RDNA3
(gfx1100) and the native `moe_gptq_gemm_rdna3` kernel.

There's a single knob to turn it on:

```
VLLM_MOE_EXPERT_CACHE_SIZE = N   # how many experts to keep on the GPU per layer/rank
                                 # 0 (the default) = off, nothing changes
```

For example, Qwen3.5-122B-A10B has 256 experts but only routes to 8 per token, so
most of them just sit there idle. With this, the cold ones live in CPU memory and
a small hot cache lives on the GPU — enough to fit the full 122B onto 2×24 GB.

## How it works

The key idea is that the cache is just a **weight provider**: as far as the GEMM
kernel is concerned, nothing has changed — it still gets a normal weight tensor
and doesn't know or care that it came from CPU.

**When the model loads**, the expert weights are placed in pinned CPU memory
instead of on the GPU. Each layer is prepared on the GPU (the usual weight
shuffle), then copied out to its CPU home and the GPU copy is freed — this last
part matters, because otherwise all 48 layers would slowly pile up in VRAM and
defeat the whole point. A small fixed-size GPU cache is set aside for the hot
experts. (Zero-points happen to be identical for every expert, so they stay as a
single shared tensor rather than being streamed.)

**On each forward pass**, we look at which experts the current tokens route to,
copy just those into the GPU cache slots, and renumber the routing so it points
at the cache instead of the full expert list. From there the existing kernel runs
exactly as before. If a batch happens to need more experts than the cache can
hold, we split it into smaller chunks that each fit.

**Why stream on demand instead of predicting ahead:** the natural idea is to
guess which experts the next layer will want and prefetch them. But on the 122B I
measured how often an expert used in one layer predicts the experts used in the
next — it was only about **3.4%**. Routing is essentially flat, so prefetching
buys almost nothing over just fetching what's needed when it's needed. (Smaller
models report much higher prediction rates, so this seems to depend on model
size.) So instead of a prediction pipeline, it uses a small runtime-compiled HIP
gather kernel that pulls the current layer's experts in on the fly.

## Status

It runs end-to-end today on the full Qwen3.5-122B-A10B (TP2, 2×24 GB): output is
coherent, quality is preserved (the streaming is numerically exact — same weights,
just moved around), and it does roughly 35–40 tok/s decode with a 128-expert
cache. It's RDNA3 / W4A16 only for now.
