### PR TITLE
[Loader] Support prefetch in multi-thread safetensors loader

### DIFF
--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -113,10 +113,11 @@ class DefaultModelLoader(BaseModelLoader):
             "enable_weights_track", None
         )
 
-        # The multi-thread loader ignores safetensors_load_strategy, so reject
-        # the combination instead of silently dropping the requested strategy.
+        # Multi-thread loader now supports safetensors_load_strategy via
+        # _prefetch_all_checkpoints when the strategy is "prefetch".
+        # Keep the validation only for unsupported strategies.
         if extra_config.get("enable_multithread_load") and (
-            load_config.safetensors_load_strategy not in (None, "lazy")
+            load_config.safetensors_load_strategy not in (None, "lazy", "prefetch")
         ):
             raise ValueError(
                 "enable_multithread_load does not support "
@@ -281,6 +282,15 @@ class DefaultModelLoader(BaseModelLoader):
                         self.load_config.use_tqdm_on_load,
                         max_workers=extra_config.get(
                             "num_threads", self.DEFAULT_NUM_THREADS
+                        ),
+                        safetensors_load_strategy=(
+                            self.load_config.safetensors_load_strategy
+                        ),
+                        safetensors_prefetch_num_threads=(
+                            self.load_config.safetensors_prefetch_num_threads
+                        ),
+                        safetensors_prefetch_block_size=(
+                            self.load_config.safetensors_prefetch_block_size
                         ),
                     )
                 else:

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -978,17 +978,36 @@ def multi_thread_safetensors_weights_iterator(
     hf_weights_files: list[str],
     use_tqdm_on_load: bool,
     max_workers: int = 4,
+    safetensors_load_strategy: str | None = None,
+    *,
+    safetensors_prefetch_num_threads: int = DEFAULT_SAFETENSORS_PREFETCH_NUM_THREADS,
+    safetensors_prefetch_block_size: int = DEFAULT_SAFETENSORS_PREFETCH_BLOCK_SIZE,
 ) -> Generator[tuple[str, torch.Tensor], None, None]:
-    """Multi-Thread iterate over the weights in the model safetensor files."""
+    """Multi-Thread iterate over the weights in the model safetensor files.
+
+    When *safetensors_load_strategy* is ``"prefetch"``, checkpoint files are
+    pre-warmed into the OS page cache before the multi-thread loader starts,
+    which reduces storage-level I/O contention on network filesystems.
+    """
 
     def _load_file(st_file: str):
         result = load_file(st_file, device="cpu")
         return result
 
+    sorted_hf_weights_files = sorted(hf_weights_files, key=_natural_sort_key)
+    if safetensors_load_strategy == "prefetch":
+        _prefetch_all_checkpoints(
+            sorted_hf_weights_files,
+            num_prefetch_threads=safetensors_prefetch_num_threads,
+            block_size=safetensors_prefetch_block_size,
+        )
+
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         # Note to use generator here so we do not store all the loaded files in memory
         # at the same time, which can cause OOM for large models.
-        futures = (executor.submit(_load_file, st_file) for st_file in hf_weights_files)
+        futures = (
+            executor.submit(_load_file, st_file) for st_file in sorted_hf_weights_files
+        )
         futures_iter = tqdm(
             concurrent.futures.as_completed(futures),
             total=len(hf_weights_files),


### PR DESCRIPTION
## Purpose

When using `--model-loader-extra-config='{"enable_multithread_load": true}'` with `--safetensors-load-strategy prefetch`, vLLM raises:

```
ValueError: enable_multithread_load does not support safetensors_load_strategy='prefetch'
```

This validation (introduced in PR #45196) was added because the multi-thread loader (`multi_thread_safetensors_weights_iterator`) ignored the `safetensors_load_strategy` parameter entirely, and the combination would have been silently dropped. 

However, in TP/EP scenarios on network filesystems, both mechanisms are valuable and complementary. Without prefetch, all TP ranks simultaneously read the same checkpoint files from NFS, causing severe I/O contention.

Enabling prefetch before multi-thread loading eliminates this duplication:
`_prefetch_all_checkpoints` internally shards files across ranks (by `sorted_files[rank::world_size]`), so each file is read from NFS exactly once into OS page cache, rather than once per TP rank. The ThreadPoolExecutor then reads from local page cache.

`multi_thread_safetensors_weights_iterator` now accepts `safetensors_load_strategy`. When the strategy is `"prefetch"`, it calls `_prefetch_all_checkpoints()` before starting the ThreadPoolExecutor, and sorts input files for consistent prefetch/load order. 

## Test Plan

Manual smoke test, verified:

*  `--safetensors-load-strategy prefetch` + `--model-loader-extra-config='{"enable_multithread_load": true}'`
*  `--model-loader-extra-config='{"enable_multithread_load": true}'` only

## Test Result

Passed.

