### PR TITLE
[CI] Wire tests/models/inkling into a B200 job

### DIFF
--- a/.buildkite/test_areas/models_basic.yaml
+++ b/.buildkite/test_areas/models_basic.yaml
@@ -46,6 +46,19 @@ steps:
       depends_on:
       - image-build-amd
 
+- label: Inkling Unit Tests (B200)
+  key: inkling-unit-tests-b200
+  timeout_in_minutes: 40
+  device: b200-k8s
+  source_file_dependencies:
+  - vllm/models/inkling/
+  - vllm/cute_utils/
+  - cmake/external_projects/tml_fa4.cmake
+  - tests/models/inkling/
+  commands:
+    # FA4 kernel tests require SM100; the suite skips them elsewhere.
+    - pytest -v -s models/inkling
+
 - label: Basic Models Test (Other CPU) # 5min
   key: basic-models-test-other-cpu
   depends_on:


### PR DESCRIPTION
The tests/models/inkling suite (8 files: FA4 kernels, sconv metadata, MoE weight layout, contract validation, MTP input fusion, QKV prep, MM towers) was not referenced by any CI job, so none of it ran in CI - including the contract-validation tests that #48822 itself modified. Add a B200 job (the FA4 tests require SM100; they skip elsewhere) to the Models - Basic group.

Suite runs in ~6.5 min on 1 GPU; validated 194/194 passing at current main on GB200.
