### PR TITLE
[XPU][LoRA] Fix fused MoE LoRA shrink BLOCK_SIZE_N for small ranks

### DIFF
--- a/.buildkite/intel_jobs/lora_intel.yaml
+++ b/.buildkite/intel_jobs/lora_intel.yaml
@@ -133,6 +133,7 @@ steps:
       pytest -v -s lora/test_quant_model.py --deselect="tests/lora/test_quant_model.py::test_quant_model_lora[model0]" --deselect="tests/lora/test_quant_model.py::test_quant_model_lora[model1]" --deselect="tests/lora/test_quant_model.py::test_quant_model_tp_equality[model0]" &&
       pytest -v -s lora/test_transformers_model.py &&
       pytest -v -s lora/test_chatglm3_tp.py &&
+      pytest -v -s lora/test_olmoe_tp.py &&
       pytest -v -s lora/test_llama_tp.py::test_llama_lora &&
       pytest -s -v lora/test_minicpmv_tp.py'
 

--- a/vllm/lora/layers/utils.py
+++ b/vllm/lora/layers/utils.py
@@ -121,10 +121,19 @@ def try_get_optimal_moe_lora_config(
         "fused_moe_lora_w2_shrink",
     ]:
         block_size_n = config.get("BLOCK_SIZE_N")
-        config["BLOCK_SIZE_N"] = min(
+        new_block_size_n = min(
             block_size_n if block_size_n is not None else 64,
             next_power_of_2(rank),
         )
+        if current_platform.is_xpu():
+            # Triton's tl.dot on Intel XPU (PVC) requires N >= 16 (the
+            # systolic array's execution_size), or compilation fails with
+            # a CompilationError; CUDA/ROCm only require N >= 1, so only
+            # clamp this floor on XPU. Without it, small LoRA ranks (e.g.
+            # rank < 16, the common default rank=8) shrink BLOCK_SIZE_N
+            # below 16 via next_power_of_2(rank) and crash on XPU.
+            new_block_size_n = max(16, new_block_size_n)
+        config["BLOCK_SIZE_N"] = new_block_size_n
     elif op_type in [
         "fused_moe_lora_w13_expand",
         "fused_moe_lora_w2_expand",


### PR DESCRIPTION
**Problem**
When the LoRA rank is below 16 (e.g., the common default rank=8), try_get_optimal_moe_lora_config() computes the shrink stage’s BLOCK_SIZE_N as min(64, next_power_of_2(rank)), yielding values like 8. This violates Triton’s tl.dot constraint that N must be at least 16, triggering a compilation‑time assertion:


AssertionError: **Input shapes should have M >= 1, N >= 16 and K >= 16.0**
This causes a triton.compiler.errors.CompilationError, which surfaces in vLLM as EngineDeadError, making any fused‑MoE‑LoRA model using a rank‑<16 adapter completely unusable.

**Root cause**
The shrink path lacks a floor guard on BLOCK_SIZE_N, whereas the expand path already applies max(16, ...) to its BLOCK_SIZE_K to avoid exactly this kind of violation.

**Fix**
Apply the same max(16, ...) floor to the shrink path’s BLOCK_SIZE_N, ensuring it never drops below 16, thus matching the expand path’s defensive logic.