### PR TITLE
[Test] Force enforce_eager for pythia-70m in test_models to avoid compile-vs-eager drift

### DIFF
--- a/tests/models/language/generation/test_common.py
+++ b/tests/models/language/generation/test_common.py
@@ -198,8 +198,18 @@ def test_models(
         # builder and layer consistent and preserves the L4 test path.
         vllm_kwargs["attention_config"] = {"flash_attn_version": 2}
 
+    # pythia-70m is tiny enough that many candidate tokens have near-uniform
+    # logits under bf16 (the default "auto" dtype). torch.compile's fused
+    # kernels use a different reduction order than eager PyTorch, and the
+    # resulting sub-ULP rounding difference is enough to flip the top-1 token
+    # vs. the HF eager baseline after 32 autoregressive decode steps. This is
+    # not XPU-specific: the same divergence has been confirmed to reproduce
+    # on CUDA as well. Force eager mode for this one model to avoid the
+    # flake; other models still exercise the compiled path.
+    enforce_eager = model == "EleutherAI/pythia-70m"
     with vllm_runner(
         model,
+        enforce_eager=enforce_eager,
         tokenizer_name=model_info.tokenizer or model,
         tokenizer_mode=model_info.tokenizer_mode,
         revision=model_info.revision,


### PR DESCRIPTION
**Purpose**
Fix an intermittent test failure for EleutherAI/pythia-70m where greedy decoding produces a top‑1 token mismatch against the HF eager baseline.

**Root cause**
Under bf16, torch.compile (Inductor) uses a different floating‑point reduction order than eager PyTorch. This causes sub‑ULP rounding errors that flip the decoded token after 32 autoregressive steps. The issue is not XPU‑specific; it also reproduces on CUDA, and follows the same precedent already set for other numerically sensitive tiny models (e.g., starcoder2-3b, tiny-mixtral).

**Fix**
Force enforce_eager=True for pythia-70m only in the test suite, leaving all other models to run with compilation as before.