### PR TITLE
[Bugfix][MoE] Swizzle mxfp8 activation scales after DP/EP dispatch for FlashInfer CUTLASS

### DIFF
--- a/tests/kernels/moe/test_mxfp8_dp_scale_swizzle.py
+++ b/tests/kernels/moe/test_mxfp8_dp_scale_swizzle.py
@@ -29,9 +29,9 @@ from vllm.utils.flashinfer import has_flashinfer
 if not current_platform.is_cuda():
     pytest.skip("CUDA required", allow_module_level=True)
 
-if current_platform.has_device_capability(100) and not has_flashinfer():
-    # mxfp8_e4m3_quantize dispatches to flashinfer on >=SM100.
-    pytest.skip("flashinfer required on SM100+", allow_module_level=True)
+if not has_flashinfer():
+    # restore_dispatched_scale_layout uses flashinfer's block_scale_interleave.
+    pytest.skip("flashinfer required", allow_module_level=True)
 
 
 def _quantize_both_layouts(

--- a/tests/kernels/moe/test_mxfp8_dp_scale_swizzle.py
+++ b/tests/kernels/moe/test_mxfp8_dp_scale_swizzle.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression test for the mxfp8 activation-scale layout in the naive DP/EP
+prepare path.
+
+The naive DP/EP prepare quantizes activations with row-major ([M, K//32])
+scales so the scale tensor keeps one row per token and can be dispatched
+alongside the hidden states. Kernels that declare
+``is_scale_swizzled=True`` (e.g. FlashInfer CUTLASS MXFP4_MXFP8) expect the
+F8_128x4 interleaved layout, so ``_unwrap_scale_and_prepare_for_moe`` must
+restore it after the a2a — exactly like the pre-existing nvfp4 branch.
+Without this, the CUTLASS kernel reads misplaced e8m0 block exponents and
+produces NaN logits whenever ``data_parallel_size > 1``.
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.fused_moe.config import (
+    mxfp4_mxfp8_moe_quant_config,
+)
+from vllm.model_executor.layers.fused_moe.prepare_finalize.naive_dp_ep import (
+    _unwrap_scale_and_prepare_for_moe,
+)
+from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+    mxfp8_e4m3_quantize,
+)
+from vllm.platforms import current_platform
+
+if not current_platform.is_cuda():
+    pytest.skip("CUDA required", allow_module_level=True)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 5, 37, 128, 300, 511])
+@pytest.mark.parametrize("hidden_size", [2048, 7168])
+@torch.inference_mode()
+def test_unwrap_restores_swizzled_mxfp8_scales(
+    num_tokens: int, hidden_size: int
+) -> None:
+    torch.manual_seed(0)
+    x = torch.randn(num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16)
+
+    # The layout the kernel expects (what the no-DP path produces directly).
+    _, want = mxfp8_e4m3_quantize(x, is_sf_swizzled_layout=True)
+    # The layout the naive DP path quantizes to before the dispatch.
+    _, linear = mxfp8_e4m3_quantize(x, is_sf_swizzled_layout=False)
+    if linear.ndim == 1:
+        linear = linear.view(num_tokens, -1)
+
+    quant_config = mxfp4_mxfp8_moe_quant_config(
+        w1_scale=torch.empty(1),
+        w2_scale=torch.empty(1),
+        is_scale_swizzled=True,
+    )
+    got = _unwrap_scale_and_prepare_for_moe([linear], quant_config)
+
+    assert torch.equal(
+        got.view(torch.uint8).flatten(), want.view(torch.uint8).flatten()
+    )

--- a/tests/kernels/moe/test_mxfp8_dp_scale_swizzle.py
+++ b/tests/kernels/moe/test_mxfp8_dp_scale_swizzle.py
@@ -1,16 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Regression test for the mxfp8 activation-scale layout in the naive DP/EP
-prepare path.
+"""Tests for restore_dispatched_scale_layout on mxfp8 activation scales.
 
-The naive DP/EP prepare quantizes activations with row-major ([M, K//32])
-scales so the scale tensor keeps one row per token and can be dispatched
-alongside the hidden states. Kernels that declare
-``is_scale_swizzled=True`` (e.g. FlashInfer CUTLASS MXFP4_MXFP8) expect the
-F8_128x4 interleaved layout, so ``_unwrap_scale_and_prepare_for_moe`` must
-restore it after the a2a — exactly like the pre-existing nvfp4 branch.
-Without this, the CUTLASS kernel reads misplaced e8m0 block exponents and
-produces NaN logits whenever ``data_parallel_size > 1``.
+The DP/EP prepare paths quantize with row-major scales for the a2a and
+restore the swizzled 128x4 layout afterwards; the result must be
+bit-identical to quantizing directly into the swizzled layout, and scales
+for kernels that take row-major scales must pass through unchanged.
 """
 
 import pytest
@@ -22,30 +17,63 @@ from vllm.model_executor.layers.fused_moe.config import (
 from vllm.model_executor.layers.fused_moe.prepare_finalize.naive_dp_ep import (
     _unwrap_scale_and_prepare_for_moe,
 )
+from vllm.model_executor.layers.fused_moe.utils import (
+    restore_dispatched_scale_layout,
+)
 from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
     mxfp8_e4m3_quantize,
 )
 from vllm.platforms import current_platform
+from vllm.utils.flashinfer import has_flashinfer
 
 if not current_platform.is_cuda():
     pytest.skip("CUDA required", allow_module_level=True)
 
+if current_platform.has_device_capability(100) and not has_flashinfer():
+    # mxfp8_e4m3_quantize dispatches to flashinfer on >=SM100.
+    pytest.skip("flashinfer required on SM100+", allow_module_level=True)
 
-@pytest.mark.parametrize("num_tokens", [1, 5, 37, 128, 300, 511])
-@pytest.mark.parametrize("hidden_size", [2048, 7168])
-@torch.inference_mode()
-def test_unwrap_restores_swizzled_mxfp8_scales(
+
+def _quantize_both_layouts(
     num_tokens: int, hidden_size: int
-) -> None:
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return (swizzled reference, row-major) mxfp8 scales for one input."""
     torch.manual_seed(0)
     x = torch.randn(num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16)
 
     # The layout the kernel expects (what the no-DP path produces directly).
     _, want = mxfp8_e4m3_quantize(x, is_sf_swizzled_layout=True)
-    # The layout the naive DP path quantizes to before the dispatch.
+    # The layout the DP paths quantize to before the dispatch.
     _, linear = mxfp8_e4m3_quantize(x, is_sf_swizzled_layout=False)
-    if linear.ndim == 1:
-        linear = linear.view(num_tokens, -1)
+    return want, linear
+
+
+@pytest.mark.parametrize("num_tokens", [1, 5, 37, 128, 300, 511])
+@pytest.mark.parametrize("hidden_size", [2048, 7168])
+@torch.inference_mode()
+def test_swizzle_dispatched_mxfp8_scales(num_tokens: int, hidden_size: int):
+    want, linear = _quantize_both_layouts(num_tokens, hidden_size)
+
+    got = restore_dispatched_scale_layout(
+        linear, quant_dtype="mxfp8", is_scale_swizzled=True
+    )
+
+    assert got is not None
+    assert torch.equal(
+        got.view(torch.uint8).flatten(), want.view(torch.uint8).flatten()
+    )
+
+    # Unswizzled consumers (e.g. FLASHINFER_TRTLLM_MXFP4_MXFP8) are untouched.
+    passthrough = restore_dispatched_scale_layout(
+        linear, quant_dtype="mxfp8", is_scale_swizzled=False
+    )
+    assert passthrough is linear
+
+
+@torch.inference_mode()
+def test_naive_dp_ep_unwrap_swizzles_mxfp8_scales():
+    """The naive DP/EP prepare path must hand the MoE kernel swizzled scales."""
+    want, linear = _quantize_both_layouts(300, 7168)
 
     quant_config = mxfp4_mxfp8_moe_quant_config(
         w1_scale=torch.empty(1),

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py
@@ -130,7 +130,7 @@ class FlashInferNVLinkOneSidedPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeMo
         )
         if a1q_scale is not None:
             a1q_recv, a1q_scale_recv, topk_ids_recv, topk_weights_recv = recv_payloads
-            # Apply scale interleaving only for CUTLASS (not TRT-LLM)
+            # Swizzle after the A2A if the MoE kernel expects swizzled scales.
             a1q_scale_recv = restore_dispatched_scale_layout(
                 a1q_scale_recv.view(-1, a1q_scale_recv.shape[-1]),
                 quant_config.quant_dtype,

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py
@@ -9,8 +9,10 @@ from vllm.distributed.device_communicators.base_device_communicator import (
 )
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
-from vllm.model_executor.layers.fused_moe.utils import moe_kernel_quantize_input
-from vllm.utils.flashinfer import nvfp4_block_scale_interleave
+from vllm.model_executor.layers.fused_moe.utils import (
+    moe_kernel_quantize_input,
+    restore_dispatched_scale_layout,
+)
 
 
 def get_local_sizes():
@@ -129,10 +131,12 @@ class FlashInferNVLinkOneSidedPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeMo
         if a1q_scale is not None:
             a1q_recv, a1q_scale_recv, topk_ids_recv, topk_weights_recv = recv_payloads
             # Apply scale interleaving only for CUTLASS (not TRT-LLM)
-            if quant_config.quant_dtype == "nvfp4" and quant_config.is_scale_swizzled:
-                a1q_scale_recv = a1q_scale_recv.view(-1, a1q_scale_recv.shape[-1])
-                a1q_scale_recv = a1q_scale_recv.view(torch.uint8)
-                a1q_scale_recv = nvfp4_block_scale_interleave(a1q_scale_recv)
+            a1q_scale_recv = restore_dispatched_scale_layout(
+                a1q_scale_recv.view(-1, a1q_scale_recv.shape[-1]),
+                quant_config.quant_dtype,
+                quant_config.is_scale_swizzled,
+            )
+            assert a1q_scale_recv is not None
             assert self.scale_elems_per_token > 0
             a1q_scale_recv = a1q_scale_recv.view(-1, self.scale_elems_per_token)
         else:

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_two_sided.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_two_sided.py
@@ -10,8 +10,10 @@ from vllm.distributed.device_communicators.base_device_communicator import (
 )
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
-from vllm.model_executor.layers.fused_moe.utils import moe_kernel_quantize_input
-from vllm.utils.flashinfer import nvfp4_block_scale_interleave
+from vllm.model_executor.layers.fused_moe.utils import (
+    moe_kernel_quantize_input,
+    restore_dispatched_scale_layout,
+)
 
 
 def get_local_sizes():
@@ -195,14 +197,9 @@ def flashinfer_alltoall_dispatch(
             )
 
         # Swizzle after the A2A if MoE kernel expects swizzled scales.
-        if (
-            x_sf is not None
-            and quant_config.quant_dtype == "nvfp4"
-            and quant_config.is_scale_swizzled
-        ):
-            if x_sf.element_size() == 1:
-                x_sf = x_sf.view(torch.uint8)
-            x_sf = nvfp4_block_scale_interleave(x_sf)
+        x_sf = restore_dispatched_scale_layout(
+            x_sf, quant_config.quant_dtype, quant_config.is_scale_swizzled
+        )
     else:
         # Block-scale path: pass activations through without quantization
         x_sf = None

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/naive_dp_ep.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/naive_dp_ep.py
@@ -9,12 +9,10 @@ from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceContiguous,
     TopKWeightAndReduceDelegate,
 )
-from vllm.model_executor.layers.fused_moe.utils import moe_kernel_quantize_input
-from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
-    MXFP8_BLOCK_SIZE,
-    swizzle_mxfp8_scale,
+from vllm.model_executor.layers.fused_moe.utils import (
+    moe_kernel_quantize_input,
+    restore_dispatched_scale_layout,
 )
-from vllm.utils.flashinfer import nvfp4_block_scale_interleave
 
 
 def _quantize_and_setup_dispatch(
@@ -61,25 +59,11 @@ def _unwrap_scale_and_prepare_for_moe(
     quant_config: FusedMoEQuantConfig,
 ) -> torch.Tensor:
     assert scales is not None and len(scales) == 1
-    a1q_scale = scales[0]
     # Apply swizzling after a2a if the MoE kernel needs it.
-    if quant_config.quant_dtype == "nvfp4" and quant_config.is_scale_swizzled:
-        assert a1q_scale is not None
-        if a1q_scale.element_size() == 1:
-            a1q_scale = a1q_scale.view(torch.uint8)
-        a1q_scale = nvfp4_block_scale_interleave(a1q_scale)
-    elif quant_config.quant_dtype == "mxfp8" and quant_config.is_scale_swizzled:
-        # The mxfp8 scales were quantized row-major ([M, K//32]) so they could
-        # be dispatched alongside the hidden states; kernels that expect the
-        # F8_128x4 swizzled layout (e.g. FlashInfer CUTLASS) need them
-        # interleaved after the a2a, same as the nvfp4 branch above.
-        assert a1q_scale is not None and a1q_scale.ndim == 2
-        a1q_scale = swizzle_mxfp8_scale(
-            a1q_scale,
-            M=a1q_scale.shape[0],
-            K=a1q_scale.shape[1] * MXFP8_BLOCK_SIZE,
-        )
-
+    a1q_scale = restore_dispatched_scale_layout(
+        scales[0], quant_config.quant_dtype, quant_config.is_scale_swizzled
+    )
+    assert a1q_scale is not None
     return a1q_scale
 
 

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/naive_dp_ep.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/naive_dp_ep.py
@@ -10,6 +10,10 @@ from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceDelegate,
 )
 from vllm.model_executor.layers.fused_moe.utils import moe_kernel_quantize_input
+from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+    MXFP8_BLOCK_SIZE,
+    swizzle_mxfp8_scale,
+)
 from vllm.utils.flashinfer import nvfp4_block_scale_interleave
 
 
@@ -64,6 +68,17 @@ def _unwrap_scale_and_prepare_for_moe(
         if a1q_scale.element_size() == 1:
             a1q_scale = a1q_scale.view(torch.uint8)
         a1q_scale = nvfp4_block_scale_interleave(a1q_scale)
+    elif quant_config.quant_dtype == "mxfp8" and quant_config.is_scale_swizzled:
+        # The mxfp8 scales were quantized row-major ([M, K//32]) so they could
+        # be dispatched alongside the hidden states; kernels that expect the
+        # F8_128x4 swizzled layout (e.g. FlashInfer CUTLASS) need them
+        # interleaved after the a2a, same as the nvfp4 branch above.
+        assert a1q_scale is not None and a1q_scale.ndim == 2
+        a1q_scale = swizzle_mxfp8_scale(
+            a1q_scale,
+            M=a1q_scale.shape[0],
+            K=a1q_scale.shape[1] * MXFP8_BLOCK_SIZE,
+        )
 
     return a1q_scale
 

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -34,6 +34,12 @@ from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
+
+# despite its name, this is flashinfer's generic block_scale_interleave
+# and handles mxfp8 scale vectors as well
+from vllm.utils.flashinfer import (
+    nvfp4_block_scale_interleave as block_scale_interleave,
+)
 from vllm.utils.math_utils import cdiv
 
 if TYPE_CHECKING:
@@ -359,8 +365,9 @@ def moe_kernel_quantize_input(
         return A, A_scale
 
 
-# Quant dtypes whose activation scales use the swizzled 128x4 layout
-# when the kernel declares is_scale_swizzled=True.
+# Quant dtypes whose activation scales use the swizzled 128x4 layout when the
+# kernel declares is_scale_swizzled=True. Must cover every quant_dtype branch in
+# moe_kernel_quantize_input that honors is_scale_swizzled.
 _SWIZZLED_SCALE_DTYPES = ("nvfp4", "mxfp8")
 
 
@@ -384,12 +391,6 @@ def restore_dispatched_scale_layout(
         or quant_dtype not in _SWIZZLED_SCALE_DTYPES
     ):
         return a1q_scale
-    # despite its name, this is flashinfer's generic block_scale_interleave
-    # and handles mxfp8 scale vectors as well
-    from vllm.utils.flashinfer import (
-        nvfp4_block_scale_interleave as block_scale_interleave,
-    )
-
     if a1q_scale.element_size() == 1:
         a1q_scale = a1q_scale.view(torch.uint8)
     return block_scale_interleave(a1q_scale)

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -34,6 +34,9 @@ from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
+from vllm.utils.flashinfer import (
+    nvfp4_block_scale_interleave as block_scale_interleave,
+)
 from vllm.utils.math_utils import cdiv
 
 if TYPE_CHECKING:
@@ -385,14 +388,10 @@ def restore_dispatched_scale_layout(
         or quant_dtype not in _SWIZZLED_SCALE_DTYPES
     ):
         return a1q_scale
-    # despite its name, this is flashinfer's generic block_scale_interleave
-    # and handles mxfp8 scale vectors as well
-    from vllm.utils.flashinfer import (
-        nvfp4_block_scale_interleave as block_scale_interleave,
-    )
-
     if a1q_scale.element_size() == 1:
         a1q_scale = a1q_scale.view(torch.uint8)
+    # despite its name, this is flashinfer's generic block_scale_interleave
+    # and handles mxfp8 scale vectors as well
     return block_scale_interleave(a1q_scale)
 
 

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -34,12 +34,6 @@ from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
-
-# despite its name, this is flashinfer's generic block_scale_interleave
-# and handles mxfp8 scale vectors as well
-from vllm.utils.flashinfer import (
-    nvfp4_block_scale_interleave as block_scale_interleave,
-)
 from vllm.utils.math_utils import cdiv
 
 if TYPE_CHECKING:
@@ -391,6 +385,12 @@ def restore_dispatched_scale_layout(
         or quant_dtype not in _SWIZZLED_SCALE_DTYPES
     ):
         return a1q_scale
+    # despite its name, this is flashinfer's generic block_scale_interleave
+    # and handles mxfp8 scale vectors as well
+    from vllm.utils.flashinfer import (
+        nvfp4_block_scale_interleave as block_scale_interleave,
+    )
+
     if a1q_scale.element_size() == 1:
         a1q_scale = a1q_scale.view(torch.uint8)
     return block_scale_interleave(a1q_scale)

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -359,6 +359,42 @@ def moe_kernel_quantize_input(
         return A, A_scale
 
 
+# Quant dtypes whose activation scales use the swizzled 128x4 layout
+# when the kernel declares is_scale_swizzled=True.
+_SWIZZLED_SCALE_DTYPES = ("nvfp4", "mxfp8")
+
+
+def restore_dispatched_scale_layout(
+    a1q_scale: torch.Tensor | None,
+    quant_dtype: None | torch.dtype | str,
+    is_scale_swizzled: bool,
+) -> torch.Tensor | None:
+    """Swizzle activation scales after an a2a dispatch, if the kernel
+    expects it.
+
+    Dispatch paths quantize with is_scale_swizzled=False, since the swizzled
+    layout is padded and would not line up row-for-row with the hidden states
+    in the a2a. For kernels that expect swizzled scales, convert the
+    dispatched row-major scales to the swizzled 128x4 layout here; otherwise
+    return the scales unchanged.
+    """
+    if (
+        a1q_scale is None
+        or not is_scale_swizzled
+        or quant_dtype not in _SWIZZLED_SCALE_DTYPES
+    ):
+        return a1q_scale
+    # despite its name, this is flashinfer's generic block_scale_interleave
+    # and handles mxfp8 scale vectors as well
+    from vllm.utils.flashinfer import (
+        nvfp4_block_scale_interleave as block_scale_interleave,
+    )
+
+    if a1q_scale.element_size() == 1:
+        a1q_scale = a1q_scale.view(torch.uint8)
+    return block_scale_interleave(a1q_scale)
+
+
 def normalize_scales_shape(scales: torch.Tensor | None) -> torch.Tensor | None:
     if scales is not None:
         if scales.numel() == 1:


### PR DESCRIPTION
FIX #42118

## Purpose

`FLASHINFER_CUTLASS_MXFP4_MXFP8` returns NaN logits for every request when
`data_parallel_size > 1`. The failure is silent: the server stays healthy and generates
at full speed, but completions decode to empty strings and GSM8K scores 0.000. The
quickest check is a completions request with `"logprobs"`, which fails with HTTP 400
("Out of range float values are not JSON compliant: nan").

The CUTLASS kernel expects mxfp8 activation scales in the swizzled 128x4 layout. The
DP/EP prepare paths quantize with row-major scales so they can ride the a2a next to the
hidden states, then swizzle afterwards, but that step only handled nvfp4. So mxfp8
scales reached the kernel row-major and it read wrong e8m0 block exponents. With dp=1
the scales are quantized directly into the swizzled layout, which is why the existing
tests never caught this.

The same gap exists in `naive_dp_ep.py` and in both `flashinfer_nvlink` prepare/finalize
backends. This PR moves the nvfp4-only restore logic into a shared
`restore_dispatched_scale_layout()` in `fused_moe/utils.py`, routes all three backends
through it, and enables it for mxfp8 using the same fused `block_scale_interleave`
kernel the nvfp4 path already used (bit-identical to quantizing directly into the
swizzled layout, covered by the new test). Backends that take row-major scales
(`FLASHINFER_TRTLLM_MXFP4_MXFP8`) pass through unchanged, and nvfp4 behavior is
unchanged.

Not a duplicate: #42133 addresses the same issue but has been conflicted and inactive
since May, predates the prepare_finalize restructure and the NVLink backends, and uses
a multi-pass torch swizzle where this PR reuses the existing fused kernel. Checked
`gh pr list --state open` for "mxfp8 scale swizzle", "block_scale_interleave", and the
issue number; #42133 is the only overlap. #47733 touches the same nvlink
prepare/finalize files for a different scale bug (per-tensor FP8); happy to rebase
whichever lands second.

AI disclosure: developed with AI assistance (Claude). I reviewed every changed line and
validated the change end-to-end on hardware; test commands and results below.

## Test Plan

New regression test (fails on main, passes with this PR; needs a CUDA GPU with
flashinfer installed):

```bash
pytest tests/kernels/moe/test_mxfp8_dp_scale_swizzle.py
```

End-to-end repro on 2 GPUs with open weights:

```bash
vllm serve openai/gpt-oss-20b \
  --moe-backend flashinfer_cutlass \
  --quantization-config '{"moe":{"activation":"mxfp8"}}' \
  --tensor-parallel-size 1 --data-parallel-size 2 --enable-expert-parallel \
  --max-model-len 4096 --disable-custom-all-reduce

curl localhost:8000/v1/completions -H 'Content-Type: application/json' \
  -d '{"model":"openai/gpt-oss-20b","prompt":"17*23=","max_tokens":8,"temperature":0,"logprobs":2}'
```

The `--quantization-config` override is needed because plain `flashinfer_cutlass`
selects the BF16-activation variant for gpt-oss, which does not boot on sm_120.

## Test Result

Verified fail to pass against main `5b3762a7f`, with serve logs gated on
`Using 'FLASHINFER_CUTLASS_MXFP4_MXFP8'`:

| platform | config | main | this PR |
|---|---|---|---|
| 8x RTX 5090 (sm_120) | gpt-oss-20b, DP4 and DP2 | HTTP 400 nan | pass |
| 2x B200 (sm_100) | gpt-oss-20b, DP2, `--enforce-eager` | HTTP 400 nan | pass |
| 8x RTX 5090 (sm_120) | gpt-oss-20b, TP4 dp=1 control | pass (bug is DP-only) | pass |

Model eval: GSM8K on DeepSeek-V4-Flash (stock MXFP4, DP4xTP2+EP, the config this was
found in) scores 0.000 with the bug and matches its TP8 baseline within noise with
this PR.

Regression checks: the nvfp4 path (DeepSeek-V4-Flash-NVFP4 under the same DP topology)
behaves identically with and without this PR, and the unit test covers the TRTLLM
row-major passthrough.

The NVLink backends use the same unit-tested helper but were not serve-tested for lack
of hardware access; a check on B200/GB200 with
`--all2all-backend flashinfer_nvlink_{one,two}_sided` would be welcome.
