### PR TITLE
[CI] Fix and wire encoder/manager cudagraph unit tests

### DIFF
--- a/.buildkite/test_areas/cuda.yaml
+++ b/.buildkite/test_areas/cuda.yaml
@@ -26,7 +26,10 @@ steps:
   - vllm/v1/cudagraph_dispatcher.py
   - vllm/config/compilation.py
   - vllm/compilation
+  - vllm/v1/worker/encoder_cudagraph.py
+  - vllm/v1/worker/encoder_cudagraph_defs.py
   commands:
     - pytest -v -s v1/cudagraph/test_cudagraph_dispatch.py
     - pytest -v -s v1/cudagraph/test_cudagraph_mode.py
     - pytest -v -s v1/cudagraph/test_breakable_cudagraph.py
+    - pytest -v -s v1/cudagraph/test_encoder_cudagraph.py

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -143,6 +143,7 @@ steps:
     - pytest -v -s -m 'cpu_test' v1/core
     - pytest -v -s v1/structured_output
     - pytest -v -s v1/test_serial_utils.py
+    - pytest -v -s v1/cudagraph/test_cudagraph_manager.py
     - pytest -v -s -m 'cpu_test' v1/kv_connector/unit
     - pytest -v -s -m 'cpu_test' v1/metrics
 

--- a/tests/v1/cudagraph/test_encoder_cudagraph.py
+++ b/tests/v1/cudagraph/test_encoder_cudagraph.py
@@ -108,6 +108,11 @@ def _make_manager_with_budgets(budgets: list[int]) -> EncoderCudaGraphManager:
     mgr.token_budgets = sorted(budgets)
     mgr.max_batch_size = 16
     mgr.use_dp = False
+    mgr.config = EncoderCudaGraphConfig(
+        modalities=["image"],
+        buffer_keys=[],
+        out_hidden_size=32,
+    )
     mgr.budget_graphs = {"default": {}}
     mgr.graph_pool = None
     mgr.graph_hits = 0


### PR DESCRIPTION
`tests/v1/cudagraph/test_encoder_cudagraph.py` and `test_cudagraph_manager.py` were not referenced by any Buildkite job, so they never ran.

The encoder test was also broken: `get_num_graphs_to_capture()` reads `self.config.enable_dual_path_graph` (added with dual-path ViT graph support), but the `_make_manager_with_budgets` test helper builds the manager via `object.__new__` without setting `self.config`, raising `AttributeError` in `test_num_graphs_to_capture_tracks_budgets`.

Set config in the helper, then wire both tests:
- `test_encoder_cudagraph.py` into the Cudagraph GPU job (+ its source modules as trigger deps).
- `test_cudagraph_manager.py` (cpu_test) into the V1 Test others (CPU) job.

Validated on GB200: encoder 51/51, manager 1/1.