### PR TITLE
[Bugfix][KV Connector][NIXL] Support matching DCP layouts with PCP

### DIFF
--- a/tests/v1/kv_connector/unit/test_handshake_pp_aggregation.py
+++ b/tests/v1/kv_connector/unit/test_handshake_pp_aggregation.py
@@ -21,7 +21,7 @@ class _Metadata(KVConnectorHandshakeMetadata):
 
 class _FakeExecutor:
     handshake_metadata_src: (
-        list[dict[tuple[int, int], KVConnectorHandshakeMetadata] | None] | None
+        list[dict[tuple[int, int, int], KVConnectorHandshakeMetadata] | None] | None
     )
     last_instance: "_FakeExecutor | None" = None
 
@@ -36,7 +36,7 @@ class _FakeExecutor:
 
     def get_kv_connector_handshake_metadata(
         self,
-    ) -> list[dict[tuple[int, int], KVConnectorHandshakeMetadata] | None] | None:
+    ) -> list[dict[tuple[int, int, int], KVConnectorHandshakeMetadata] | None] | None:
         self.handshake_calls += 1
         return self.handshake_metadata
 
@@ -49,7 +49,7 @@ def _run_engine_core_handshake(
     connector: KVConnectorBase_V1,
     *,
     handshake_metadata: (
-        list[dict[tuple[int, int], KVConnectorHandshakeMetadata] | None] | None
+        list[dict[tuple[int, int, int], KVConnectorHandshakeMetadata] | None] | None
     ),
 ) -> _FakeExecutor:
     class _FakeScheduler:
@@ -161,11 +161,12 @@ class _PPAwareConnector(_LegacyConnector):
     def __init__(self) -> None:
         super().__init__()
         self.pp_aware_metadata: (
-            dict[tuple[int, int], KVConnectorHandshakeMetadata] | None
+            dict[tuple[int, int, int], KVConnectorHandshakeMetadata] | None
         ) = None
 
     def set_xfer_handshake_metadata_pp_aware(
-        self, metadata: dict[tuple[int, int], KVConnectorHandshakeMetadata]
+        self,
+        metadata: dict[tuple[int, int, int], KVConnectorHandshakeMetadata],
     ) -> None:
         self.pp_aware_metadata = metadata
 
@@ -173,9 +174,9 @@ class _PPAwareConnector(_LegacyConnector):
 def test_engine_unwraps_handshake_metadata_for_legacy_connector(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Engine core always asks workers for `(pp_rank, tp_rank)`-keyed metadata,
+    """Engine core asks workers for `(pp_rank, tp_rank, pcp_rank)` metadata,
     then unwraps to `{tp_rank: metadata}` for a connector that has not opted
-    into PP-aware handshake (single-PP producer, all `pp_rank == 0`)."""
+    into PP-aware handshake (all PP and PCP ranks are zero)."""
     metadata_0 = _Metadata()
     metadata_1 = _Metadata()
     connector = _LegacyConnector()
@@ -184,9 +185,9 @@ def test_engine_unwraps_handshake_metadata_for_legacy_connector(
         monkeypatch,
         connector,
         handshake_metadata=[
-            {(0, 0): metadata_0},
+            {(0, 0, 0): metadata_0},
             None,
-            {(0, 1): metadata_1},
+            {(0, 1, 0): metadata_1},
         ],
     )
 
@@ -205,15 +206,17 @@ def test_engine_rejects_pp_producer_for_legacy_connector(
         _run_engine_core_handshake(
             monkeypatch,
             connector,
-            handshake_metadata=[{(0, 0): _Metadata()}, {(1, 0): _Metadata()}],
+            handshake_metadata=[
+                {(0, 0, 0): _Metadata()},
+                {(1, 0, 0): _Metadata()},
+            ],
         )
 
 
 def test_engine_passes_handshake_metadata_through_for_pp_aware_connector(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A PP-aware connector receives the full `(pp_rank, tp_rank)`-keyed dict
-    unchanged."""
+    """A PP-aware connector receives the full worker-keyed dict unchanged."""
     metadata_0 = _Metadata()
     metadata_1 = _Metadata()
     connector = _PPAwareConnector()
@@ -221,12 +224,12 @@ def test_engine_passes_handshake_metadata_through_for_pp_aware_connector(
     executor = _run_engine_core_handshake(
         monkeypatch,
         connector,
-        handshake_metadata=[{(0, 0): metadata_0}, {(1, 0): metadata_1}],
+        handshake_metadata=[{(0, 0, 0): metadata_0}, {(1, 0, 0): metadata_1}],
     )
 
     assert executor.handshake_calls == 1
     assert connector.legacy_metadata is None
     assert connector.pp_aware_metadata == {
-        (0, 0): metadata_0,
-        (1, 0): metadata_1,
+        (0, 0, 0): metadata_0,
+        (1, 0, 0): metadata_1,
     }

--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -408,10 +408,9 @@ def test_kv_transfer_handshake(dist_init):
         decoder = msgspec.msgpack.Decoder(NixlAgentMetadata)
         expected_agent_metadata = decoder.decode(metadata.agent_metadata_bytes)
 
-        # The scheduler connector expects metadata keyed by
-        # (pp_rank, tp_rank).
+        # The scheduler connector expects metadata keyed by worker rank.
         scheduler_connector = scheduler.get_kv_connector()
-        scheduler_connector.set_xfer_handshake_metadata_pp_aware({(0, 0): metadata})
+        scheduler_connector.set_xfer_handshake_metadata_pp_aware({(0, 0, 0): metadata})
 
         # Simulate a request that finishes prefill, which returns
         # corresponding NixlConnectorMetadata for decode instance.
@@ -495,6 +494,8 @@ class FakeNixlConnectorWorker(NixlConnectorWorker):
             total_num_kv_heads=self.model_config.get_total_num_kv_heads(),
             attn_backends=self.attn_backends,
             tensor_shape=test_shape,
+            dcp_rank=self.dcp_rank,
+            dcp_size=self.dcp_size,
         )
 
         self.compat_hash = compute_nixl_compatibility_hash(
@@ -508,8 +509,10 @@ class FakeNixlConnectorWorker(NixlConnectorWorker):
         remote_tp_size: int,
         expected_engine_id: str,
         remote_pp_size: int = 1,
+        remote_dcp_size: int = 1,
+        remote_pcp_size: int = 1,
         notif_agents_only: bool = False,
-    ) -> tuple[dict[tuple[int, int], str], float]:
+    ) -> tuple[dict[tuple[int, int, int], str], float]:
         # Mimic slow _nixl_handshake, as well as bypass zmq communication.
         time.sleep(self._hand_shake_latency)
         # These should've been done in register_kv_caches(), called by
@@ -539,7 +542,7 @@ class FakeNixlConnectorWorker(NixlConnectorWorker):
         # When remote tp_size > local tp_size, handshake with multiple
         # remote ranks.
         num_handshakes = 1 if tp_ratio > 0 else -tp_ratio
-        remote_agents: dict[tuple[int, int], str] = {}
+        remote_agents: dict[tuple[int, int, int], str] = {}
         for remote_tp_rank in range(num_handshakes):
             remote_agent_name = self.add_remote_agent(
                 NixlAgentMetadata(
@@ -559,13 +562,77 @@ class FakeNixlConnectorWorker(NixlConnectorWorker):
                 ),
                 remote_tp_rank=remote_tp_rank,
                 remote_tp_size=remote_tp_size,
+                remote_dcp_size=remote_dcp_size,
+                remote_pcp_size=remote_pcp_size,
             )
-            remote_agents[(0, remote_tp_rank)] = remote_agent_name
+            remote_agents[(0, remote_tp_rank, 0)] = remote_agent_name
         # Handshake bypasses zmq, so report a zero clock offset to the peer.
         return remote_agents, 0.0
 
 
 class TestNixlHandshake:
+    def test_consumer_rejects_pcp(self):
+        vllm_config = create_vllm_config(kv_role="kv_consumer")
+        vllm_config.parallel_config.prefill_context_parallel_size = 2
+
+        with pytest.raises(
+            NotImplementedError,
+            match="consumer.*prefill_context_parallel_size",
+        ):
+            NixlConnector(
+                vllm_config,
+                KVConnectorRole.SCHEDULER,
+                make_kv_cache_config(block_size=16),
+            )
+
+    @patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker.NixlWrapper",
+        FakeNixlWrapper,
+    )
+    def test_pcp_producer_publishes_one_replica_per_dcp_rank(
+        self, default_vllm_config, dist_init
+    ):
+        vllm_config = create_vllm_config(kv_role="kv_producer")
+        connector = NixlConnector(
+            vllm_config,
+            KVConnectorRole.WORKER,
+            make_kv_cache_config(block_size=16),
+        )
+        payload = MagicMock(spec=NixlHandshakePayload)
+        worker = connector.connector_worker
+        assert worker is not None
+        worker.xfer_handshake_metadata = payload
+
+        worker.pcp_rank = 0
+        assert connector.get_handshake_metadata() is payload
+
+        worker.pcp_rank = 1
+        assert connector.get_handshake_metadata() is None
+
+        vllm_config.parallel_config.decode_context_parallel_size = 2
+        assert connector.get_handshake_metadata() is payload
+
+        worker.pcp_rank = 2
+        assert connector.get_handshake_metadata() is None
+
+    def test_pcp_producer_waits_only_for_published_replicas(
+        self, default_vllm_config, dist_init
+    ):
+        vllm_config = create_vllm_config(kv_role="kv_producer")
+        vllm_config.parallel_config.tensor_parallel_size = 2
+        vllm_config.parallel_config.prefill_context_parallel_size = 2
+        vllm_config.parallel_config.pipeline_parallel_size = 2
+        connector = NixlConnector(
+            vllm_config,
+            KVConnectorRole.SCHEDULER,
+            make_kv_cache_config(block_size=16),
+        )
+
+        assert connector.get_finished_count() == 4
+
+        vllm_config.parallel_config.decode_context_parallel_size = 2
+        assert connector.get_finished_count() == 8
+
     @patch(
         "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker.NixlWrapper",
         FakeNixlWrapper,
@@ -759,19 +826,23 @@ class TestNixlHandshake:
 
         def check_handshake(remote_tp_size: int):
             tp_ratio = remote_tp_size // local_tp_size
-            assert set(remote_agents.keys()) == {(0, r) for r in range(tp_ratio)}
+            expected_worker_keys = {(rank, 0) for rank in range(tp_ratio)}
+            expected_agent_keys = {(0, *key) for key in expected_worker_keys}
+            assert set(remote_agents) == expected_agent_keys
 
             remote_engine_id = worker.REMOTE_ENGINE_ID
             remote_info = worker.transfer_topo.get_engine_info(remote_engine_id)
             assert remote_info.remote_tp_size == remote_tp_size
             assert -tp_ratio == worker.transfer_topo.tp_ratio(remote_tp_size)
-            # ensure src_xfer_handles_by_tp_ratio is populated with tpratio chunks
+            # Each remote TP rank has an explicitly addressed split handle.
             split_key = (-tp_ratio, worker.block_size)
             assert split_key in worker.src_xfer_handles_by_tp_ratio
-            assert len(worker.src_xfer_handles_by_tp_ratio[split_key]) == tp_ratio
-            assert remote_engine_id in worker.dst_xfer_side_handles
-            assert set(worker.dst_xfer_side_handles[remote_engine_id].keys()) == set(
+            assert set(worker.src_xfer_handles_by_tp_ratio[split_key]) == set(
                 range(tp_ratio)
+            )
+            assert remote_engine_id in worker.dst_xfer_side_handles
+            assert set(worker.dst_xfer_side_handles[remote_engine_id]) == (
+                expected_worker_keys
             )
 
         remote_agents, _ = worker._nixl_handshake(
@@ -2140,9 +2211,9 @@ def test_shutdown_cleans_up_resources(default_vllm_config, dist_init):
         # Mock register_kv_cache which registers local handle
         worker.src_xfer_handles_by_block_size = {worker.block_size: 455}
         # P TP = 2 * D TP case, we should register 2 local handles
-        worker.src_xfer_handles_by_tp_ratio = {(-2, 16): [456, 457]}
+        worker.src_xfer_handles_by_tp_ratio = {(-2, 16): {0: 456, 1: 457}}
         worker.dst_xfer_side_handles = {"engine1": {0: 789}}
-        worker._remote_agents = {"engine1": {(0, 0): "agent1"}}
+        worker._remote_agents = {"engine1": {(0, 0, 0): "agent1"}}
         # _cleanup_remote_engine (called by shutdown) also clears these:
         worker.kv_caches_base_addr["engine1"] = {0: [0xABC]}
         worker.dst_num_blocks["engine1"] = 50
@@ -2195,7 +2266,10 @@ def _setup_worker_with_remote_engine(
     )
 
     engine_id = "remote-engine-1"
-    worker._remote_agents[engine_id] = {(0, 0): "agent_0", (0, 1): "agent_1"}
+    worker._remote_agents[engine_id] = {
+        (0, 0, 0): "agent_0",
+        (0, 1, 0): "agent_1",
+    }
     worker.dst_xfer_side_handles[engine_id] = {0: 100, 1: 200}
     worker.kv_caches_base_addr[engine_id] = {0: [0xABC]}
     worker.dst_num_blocks[engine_id] = 50
@@ -3097,10 +3171,10 @@ def test_handshake_decode_errors(default_vllm_config, dist_init, error_scenario)
             local_block_len=worker.block_size * 4096,
         )
         worker._remote_agents[remote_engine_id] = {
-            (0, rank): f"agent_p{rank}" for rank in range(prefill_tp_size)
+            (0, rank, 0): f"agent_p{rank}" for rank in range(prefill_tp_size)
         }
         worker.dst_xfer_side_handles = {
-            remote_engine_id: {rank: 100 + rank for rank in range(prefill_tp_size)}
+            remote_engine_id: {(rank, 0): 100 + rank for rank in range(prefill_tp_size)}
         }
         # Sanity: D TP=1, P TP=4 => tp_ratio = -4 (P > D).
         assert worker.transfer_topo.tp_ratio(prefill_tp_size) == -prefill_tp_size
@@ -3141,14 +3215,14 @@ def test_handshake_decode_errors(default_vllm_config, dist_init, error_scenario)
 
         # MLA: read once from rank 0 and broadcast to the other ranks.
         worker._read_blocks.assert_called_once()
-        assert worker._read_blocks.call_args.kwargs["remote_rank"] == 0
+        assert worker._read_blocks.call_args.kwargs["read_spec"].remote_rank == 0
         assert (
             worker._read_blocks.call_args.kwargs["remote_request_id"] == prefill_req_id
         )
 
         # Broadcast goes to ranks {1, 2, 3} only, never to the read target.
         expected_recipients = {
-            worker._remote_agents[remote_engine_id][(0, r)]
+            worker._remote_agents[remote_engine_id][(0, r, 0)]
             for r in range(1, prefill_tp_size)
         }
         assert {agent for agent, _ in send_notif_calls} == expected_recipients

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -212,6 +212,7 @@ def test_read_blocks_for_req_expands_remote_ids(
     worker._physical_blocks_per_logical_kv_block = local_physical_per_logical
     worker._engine_last_active = {}
     worker._bidirectional_kv_xfer_enabled = False
+    worker._done_recving_without_xfer = set()
 
     has_mamba = any(t is MambaSpec for t in resolved_types)
     has_swa = any(t is SlidingWindowSpec for t in resolved_types)

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -1634,8 +1634,8 @@ def test_push_write_hybrid_mla_replicates_attention():
             rank_offset_factor=0,
         )
     }
-    worker.dst_xfer_side_handles = {engine_id: {0: 100, 1: 101}}
-    worker.src_xfer_handles_by_tp_ratio = {(-2, 4): [200, 201]}
+    worker.dst_xfer_side_handles = {engine_id: {(0, 0): 100, (1, 0): 101}}
+    worker.src_xfer_handles_by_tp_ratio = {(-2, 4): {0: 200, 1: 201}}
     worker.src_xfer_handles_by_block_size = {4: 300}
     worker._sending_transfers = defaultdict(list)
     worker._sending_transfers_lock = threading.Lock()

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -1058,9 +1058,9 @@ class TestPushWriterMlaReplication:
             )
         }
         w._logical_to_kernel_block_ids = lambda block_ids, ratio: block_ids
-        w.dst_xfer_side_handles = {engine_id: {r: 1000 + r for r in d_ranks}}
+        w.dst_xfer_side_handles = {engine_id: {(r, 0): 1000 + r for r in d_ranks}}
         w.src_xfer_handles_by_block_size = {16: 2000}
-        w._remote_agents = {engine_id: {(0, r): f"agent-{r}" for r in d_ranks}}
+        w._remote_agents = {engine_id: {(0, r, 0): f"agent-{r}" for r in d_ranks}}
         return w, engine_id
 
     def test_mla_hetero_tp_writes_every_d_rank(self):

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -6,7 +6,7 @@ KV cache helper for store.
 
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 
 import torch
 
@@ -409,6 +409,24 @@ class EngineTransferInfo:
 # ---- Transfer topology ----
 
 
+class RemoteWorkerTarget(NamedTuple):
+    """A remote worker this local worker transfers with.
+
+    A worker is addressed two ways: NIXL routes by `(tp_rank, dcp_rank)`,
+    while handshake metadata is published under the producer's
+    `(pp_rank, tp_rank, pcp_rank)` identity.
+    """
+
+    tp_rank: int
+    dcp_rank: int
+    pcp_rank: int
+
+    @property
+    def key(self) -> tuple[int, int]:
+        """Routing identity, as keyed by `dst_xfer_side_handles`."""
+        return (self.tp_rank, self.dcp_rank)
+
+
 @dataclass
 class TransferTopology:
     """Single source of truth for local TP identity and per-engine remote info."""
@@ -604,26 +622,42 @@ class TransferTopology:
         abs_ratio = -tp_ratio
         return [self.tp_rank * abs_ratio + i for i in range(abs_ratio)]
 
-    def get_target_remote_worker_keys(
+    def get_target_remote_workers(
         self,
         remote_tp_size: int,
         remote_dcp_size: int,
         remote_pcp_size: int,
-    ) -> list[tuple[int, int]]:
+    ) -> list[RemoteWorkerTarget]:
+        """Remote workers whose KV head coverage and DCP token slice overlap
+        this local worker.
+
+        A remote worker `(tp_rank, pcp_rank)` owns DCP rank
+        `(tp_rank * pcp_size + pcp_rank) % dcp_size`, so at most one PCP rank
+        per remote TP rank holds this worker's shard.
+        """
         if remote_dcp_size != self.dcp_size:
             raise ValueError(
                 "NIXL requires matching DCP sizes, but got "
                 f"local_dcp_size={self.dcp_size} and "
                 f"remote_dcp_size={remote_dcp_size}."
             )
-        worker_keys = []
+        targets = []
         for remote_tp_rank in self.handshake_target_ranks(remote_tp_size):
-            remote_pcp_rank = (
-                self.dcp_rank - remote_tp_rank * remote_pcp_size
-            ) % self.dcp_size
-            if remote_pcp_rank < remote_pcp_size:
-                worker_keys.append((remote_tp_rank, self.dcp_rank))
-        return worker_keys
+            # Only PCP ranks below dcp_size publish a replica, one per distinct
+            # DCP shard; see NixlBaseConnector.get_finished_count.
+            for remote_pcp_rank in range(min(remote_pcp_size, remote_dcp_size)):
+                remote_dcp_rank = (
+                    remote_tp_rank * remote_pcp_size + remote_pcp_rank
+                ) % remote_dcp_size
+                if remote_dcp_rank == self.dcp_rank:
+                    targets.append(
+                        RemoteWorkerTarget(
+                            tp_rank=remote_tp_rank,
+                            dcp_rank=remote_dcp_rank,
+                            pcp_rank=remote_pcp_rank,
+                        )
+                    )
+        return targets
 
     def calculate_local_consumer_count(
         self,

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -399,6 +399,12 @@ class EngineTransferInfo:
     end_layer: int = 0
     """Exclusive global index after the last layer owned by this PP rank."""
 
+    remote_dcp_size: int = 1
+    """Remote decode context parallel size."""
+
+    remote_pcp_size: int = 1
+    """Remote prefill context parallel size."""
+
 
 # ---- Transfer topology ----
 
@@ -415,6 +421,8 @@ class TransferTopology:
     is_mamba: bool
     total_num_kv_heads: int
     attn_backends: list[type[AttentionBackend]]
+    dcp_rank: int = 0
+    dcp_size: int = 1
     tensor_shape: torch.Size | None = None
 
     def __post_init__(self):
@@ -595,6 +603,57 @@ class TransferTopology:
         # remote TP > local TP: read from |tp_ratio| remote workers
         abs_ratio = -tp_ratio
         return [self.tp_rank * abs_ratio + i for i in range(abs_ratio)]
+
+    def get_target_remote_worker_keys(
+        self,
+        remote_tp_size: int,
+        remote_dcp_size: int,
+        remote_pcp_size: int,
+    ) -> list[tuple[int, int]]:
+        if remote_dcp_size != self.dcp_size:
+            raise ValueError(
+                "NIXL requires matching DCP sizes, but got "
+                f"local_dcp_size={self.dcp_size} and "
+                f"remote_dcp_size={remote_dcp_size}."
+            )
+        worker_keys = []
+        for remote_tp_rank in self.handshake_target_ranks(remote_tp_size):
+            remote_pcp_rank = (
+                self.dcp_rank - remote_tp_rank * remote_pcp_size
+            ) % self.dcp_size
+            if remote_pcp_rank < remote_pcp_size:
+                worker_keys.append((remote_tp_rank, self.dcp_rank))
+        return worker_keys
+
+    def calculate_local_consumer_count(
+        self,
+        remote_engine_id: EngineId,
+        remote_worker_key: tuple[int, int],
+        remote_pp_rank: int = 0,
+    ) -> int:
+        """Count local workers that will notify a remote worker."""
+        info = self._engines[(remote_engine_id, remote_pp_rank)]
+        remote_tp_rank, remote_dcp_rank = remote_worker_key
+        if info.remote_dcp_size != self.dcp_size:
+            raise ValueError(
+                "NIXL requires matching DCP sizes, but got "
+                f"local_dcp_size={self.dcp_size} and "
+                f"remote_dcp_size={info.remote_dcp_size}."
+            )
+        tp_ratio = self.tp_ratio(info.remote_tp_size)
+        if tp_ratio > 0:
+            local_tp_ranks = range(
+                remote_tp_rank * tp_ratio,
+                (remote_tp_rank + 1) * tp_ratio,
+            )
+        else:
+            local_tp_rank = remote_tp_rank // -tp_ratio
+            local_tp_ranks = range(local_tp_rank, local_tp_rank + 1)
+
+        return sum(
+            local_tp_rank % self.dcp_size == remote_dcp_rank
+            for local_tp_rank in local_tp_ranks
+        )
 
     def describe(self, remote_engine_id: EngineId, remote_pp_rank: int = 0) -> str:
         """One-line summary of transfer config for logging."""

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -674,20 +674,26 @@ class KVConnectorBase_V1(ABC):
         return None
 
     def set_xfer_handshake_metadata_pp_aware(
-        self, metadata: dict[tuple[int, int], KVConnectorHandshakeMetadata]
+        self,
+        metadata: dict[tuple[int, int, int], KVConnectorHandshakeMetadata],
     ) -> None:
         """
-        Set handshake metadata keyed by (pp_rank, tp_rank).
-        - Default implementation assumes pp_rank is always 0
+        Set handshake metadata keyed by (pp_rank, tp_rank, pcp_rank).
+        - Default implementation assumes pp_rank and pcp_rank are always 0
         - PP-aware connectors override this to consume all PP producer shards.
         """
-        if any(pp_rank != 0 for pp_rank, _ in metadata):
+        if any(pp_rank != 0 for pp_rank, _, _ in metadata):
             raise ValueError(
                 f"{type(self).__name__} received pp_rank > 0 handshake metadata "
                 "but does not support PP-disaggregated KV transfer."
             )
+        if any(pcp_rank != 0 for _, _, pcp_rank in metadata):
+            raise ValueError(
+                f"{type(self).__name__} received pcp_rank > 0 handshake metadata "
+                "but does not support PCP-disaggregated KV transfer."
+            )
         self.set_xfer_handshake_metadata(
-            {tp_rank: meta for (_, tp_rank), meta in metadata.items()}
+            {tp_rank: meta for (_, tp_rank, _), meta in metadata.items()}
         )
 
     @classmethod

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -475,7 +475,8 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             c.set_xfer_handshake_metadata(metadata)
 
     def set_xfer_handshake_metadata_pp_aware(
-        self, metadata: dict[tuple[int, int], KVConnectorHandshakeMetadata]
+        self,
+        metadata: dict[tuple[int, int, int], KVConnectorHandshakeMetadata],
     ) -> None:
         for c in self._connectors:
             c.set_xfer_handshake_metadata_pp_aware(metadata)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -200,6 +200,8 @@ class NixlBaseConnectorScheduler:
         port = params.get("remote_port")
         tp_size = params.get("tp_size")
         pp_size = params.get("pp_size", 1)
+        dcp_size = params.get("dcp_size", 1)
+        pcp_size = params.get("pcp_size", 1)
         if (
             remote_engine_id is None
             or remote_request_id is None
@@ -215,6 +217,8 @@ class NixlBaseConnectorScheduler:
                 port=port,
                 tp_size=tp_size,
                 pp_size=pp_size,
+                dcp_size=dcp_size,
+                pcp_size=pcp_size,
             )
         self._heartbeat_by_engine[remote_engine_id].req_ids.add(remote_request_id)
         self._heartbeat_req_engine[request.request_id] = (
@@ -279,7 +283,8 @@ class NixlBaseConnectorScheduler:
         return tuple(clipped)
 
     def set_xfer_handshake_metadata(
-        self, metadata: dict[tuple[int, int], KVConnectorHandshakeMetadata]
+        self,
+        metadata: dict[tuple[int, int, int], KVConnectorHandshakeMetadata],
     ) -> None:
         """
         Set the KV connector handshake metadata for this connector.
@@ -287,20 +292,19 @@ class NixlBaseConnectorScheduler:
         Args:
             metadata (dict): the handshake metadata to set.
         """
-        encoded_data: dict[tuple[int, int], bytes] = {}
+        encoded_data: dict[tuple[int, int, int], bytes] = {}
         encoder = msgspec.msgpack.Encoder()
-        for (pp_rank, tp_rank), rank_metadata in metadata.items():
+        for worker_key, rank_metadata in metadata.items():
             if not isinstance(rank_metadata, NixlHandshakePayload):
                 raise ValueError(
                     "NixlConnectorScheduler expects NixlHandshakePayload for "
                     "handshake metadata."
                 )
-            encoded_data[(pp_rank, tp_rank)] = encoder.encode(rank_metadata)
+            encoded_data[worker_key] = encoder.encode(rank_metadata)
             logger.debug(
-                "PP rank %d, TP rank %d: encoded NixlHandshakePayload size: %s bytes",
-                pp_rank,
-                tp_rank,
-                str(len(encoded_data[(pp_rank, tp_rank)])),
+                "Worker %s: encoded NixlHandshakePayload size: %s bytes",
+                worker_key,
+                str(len(encoded_data[worker_key])),
             )
 
         # Only start the listener when we have metadata to serve.
@@ -323,7 +327,7 @@ class NixlBaseConnectorScheduler:
 
     @staticmethod
     def _nixl_handshake_listener(
-        encoded_data: dict[tuple[int, int], Any],
+        encoded_data: dict[tuple[int, int, int], Any],
         ready_event: threading.Event,
         stop_event: threading.Event,
         host: str,
@@ -346,12 +350,14 @@ class NixlBaseConnectorScheduler:
                     if stop_event.is_set():
                         break
                     continue
-                # Decode (GET_META_MSG, pp_rank, tp_rank).
-                msg, target_pp_rank, target_tp_rank = msgspec.msgpack.decode(msg)
+                # Decode (GET_META_MSG, pp_rank, tp_rank, pcp_rank).
+                msg, target_pp_rank, target_tp_rank, target_pcp_rank = (
+                    msgspec.msgpack.decode(msg)
+                )
+                worker_key = (target_pp_rank, target_tp_rank, target_pcp_rank)
                 logger.debug(
-                    "Received message for pp rank %s, tp rank %s",
-                    target_pp_rank,
-                    target_tp_rank,
+                    "Received message for worker %s",
+                    worker_key,
                 )
                 if msg != GET_META_MSG:
                     logger.warning("Connection listener got unexpected message %s", msg)
@@ -360,9 +366,7 @@ class NixlBaseConnectorScheduler:
                 # listener must run in the same process that stamps the block
                 # expiry deadline (`_reqs_need_send`).
                 ts = msgspec.msgpack.encode(time.perf_counter())
-                sock.send_multipart(
-                    (identity, b"", encoded_data[(target_pp_rank, target_tp_rank)], ts)
-                )
+                sock.send_multipart((identity, b"", encoded_data[worker_key], ts))
 
     def _get_remote_prefill_token_count(self, num_prompt_tokens: int) -> int:
         """D-side only. Returns N-1 for Mamba models since the decoder

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -365,7 +365,8 @@ class NixlBaseConnectorWorker:
         self.tp_rank = get_tensor_model_parallel_rank()
         self.world_size = get_tensor_model_parallel_world_size()
         self.dcp_size = vllm_config.parallel_config.decode_context_parallel_size
-        self.pcp_rank = get_pcp_group().rank_in_group
+        self.pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
+        self.pcp_rank = get_pcp_group().rank_in_group if self.pcp_size > 1 else 0
         self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_size > 1 else 0
         self.local_worker_key: tuple[int, int] = (self.tp_rank, self.dcp_rank)
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -613,7 +613,7 @@ class NixlBaseConnectorWorker:
         # Handshake only with remote workers whose KV head coverage and DCP
         # token slice overlap this local worker.
         assert self.transfer_topo is not None
-        remote_worker_keys = self.transfer_topo.get_target_remote_worker_keys(
+        remote_workers = self.transfer_topo.get_target_remote_workers(
             remote_tp_size,
             remote_dcp_size,
             remote_pcp_size,
@@ -627,20 +627,15 @@ class NixlBaseConnectorWorker:
         best_offset: float | None = None
 
         with zmq_ctx(zmq.REQ, path) as sock:
-            for remote_pp_rank, remote_worker_key in itertools.product(
-                range(remote_pp_size), remote_worker_keys
+            for remote_pp_rank, remote_worker in itertools.product(
+                range(remote_pp_size), remote_workers
             ):
-                remote_tp_rank, remote_dcp_rank = remote_worker_key
-                remote_pcp_rank = self._tp_dcp_to_pcp_rank(
-                    remote_tp_rank,
-                    remote_dcp_rank,
-                    remote_pcp_size,
-                    remote_dcp_size,
-                )
+                remote_tp_rank = remote_worker.tp_rank
+                remote_dcp_rank = remote_worker.dcp_rank
                 handshake_key = (
                     remote_pp_rank,
                     remote_tp_rank,
-                    remote_pcp_rank,
+                    remote_worker.pcp_rank,
                 )
                 logger.debug(
                     "Querying metadata on path: %s for worker %s",
@@ -747,7 +742,7 @@ class NixlBaseConnectorWorker:
                     setup_agent_time - got_metadata_time,
                     notif_agents_only,
                 )
-                remote_worker_to_agent_name[(remote_pp_rank, *remote_worker_key)] = (
+                remote_worker_to_agent_name[(remote_pp_rank, *remote_worker.key)] = (
                     remote_agent_name
                 )
 
@@ -785,24 +780,6 @@ class NixlBaseConnectorWorker:
             ),
         )
         return self.nixl_wrapper.add_remote_agent(metadata.agent_metadata)
-
-    @staticmethod
-    def _tp_dcp_to_pcp_rank(
-        tp_rank: int,
-        dcp_rank: int,
-        pcp_size: int,
-        dcp_size: int,
-    ) -> int:
-        if not 0 <= dcp_rank < dcp_size:
-            raise ValueError(f"Invalid dcp_rank={dcp_rank} for dcp_size={dcp_size}")
-
-        pcp_rank = (dcp_rank - tp_rank * pcp_size) % dcp_size
-        if pcp_rank >= pcp_size:
-            raise ValueError(
-                f"No worker for tp_rank={tp_rank}, dcp_rank={dcp_rank}, "
-                f"pcp_size={pcp_size}, dcp_size={dcp_size}"
-            )
-        return pcp_rank
 
     def initialize_host_xfer_buffer(self, kv_caches: dict[str, torch.Tensor]) -> None:
         """

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -62,6 +62,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils import
 )
 from vllm.distributed.nixl_utils import NixlWrapper, nixl_agent_config
 from vllm.distributed.parallel_state import (
+    get_dcp_group,
+    get_pcp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
@@ -351,10 +353,9 @@ class NixlBaseConnectorWorker:
             )
 
         self.nixl_wrapper = nixl_wrapper_cls(str(uuid.uuid4()), config)
-        # Map of engine_id -> {(pp_rank, tp_rank): agent_name, ...}.
-        # non-PP remote uses pp_rank 0, i.e. (0, tp_rank).
-        self._remote_agents: dict[EngineId, dict[tuple[int, int], str]] = defaultdict(
-            dict
+        # Map of engine_id -> {(pp_rank, tp_rank, dcp_rank): agent_name}.
+        self._remote_agents: dict[EngineId, dict[tuple[int, int, int], str]] = (
+            defaultdict(dict)
         )
         # Map of engine_id -> clock offset.
         self._engine_clock_offset: dict[EngineId, float] = {}
@@ -363,6 +364,10 @@ class NixlBaseConnectorWorker:
         self.engine_id: EngineId = engine_id
         self.tp_rank = get_tensor_model_parallel_rank()
         self.world_size = get_tensor_model_parallel_world_size()
+        self.dcp_size = vllm_config.parallel_config.decode_context_parallel_size
+        self.pcp_rank = get_pcp_group().rank_in_group
+        self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_size > 1 else 0
+        self.local_worker_key: tuple[int, int] = (self.tp_rank, self.dcp_rank)
 
         self.num_blocks = kv_cache_config.num_blocks
         self.enable_permute_local_kv = False
@@ -424,8 +429,10 @@ class NixlBaseConnectorWorker:
         # Map of engine_id -> kv_caches_base_addr. For TP case, each local
         self.device_id: int = 0
         # Current rank may pull from multiple remote TP workers.
-        # EngineId, dict[int, list[int]] -> engine_id, tp_rank, base_addr_for_layer
-        self.kv_caches_base_addr = defaultdict[EngineId, dict[int, list[int]]](dict)
+        # EngineId, dict[(tp_rank, dcp_rank), list[int]] -> base_addr_for_layer
+        self.kv_caches_base_addr = defaultdict[
+            EngineId, dict[tuple[int, int], list[int]]
+        ](dict)
 
         # Number of NIXL regions. Currently one region per cache
         # (so 1 per layer for MLA, otherwise 2 per layer)
@@ -456,10 +463,13 @@ class NixlBaseConnectorWorker:
         # kept for building per-tp-ratio splits at the same granularity.
         self.src_blocks_data_by_block_size: dict[int, np.ndarray] = {}
         # Populated dynamically during handshake based on remote configuration.
-        # Per-source split handles, keyed by (tp_ratio, remote_block_size).
-        self.src_xfer_handles_by_tp_ratio: dict[tuple[int, int], list[int]] = {}
-        # Map of engine_id -> {tp_rank: nixl_prepped_dlist_handle (int)}.
-        self.dst_xfer_side_handles = defaultdict[EngineId, dict[int, int]](dict)
+        # Per-source split handles, keyed by (tp_ratio, remote_block_size),
+        # then remote TP rank.
+        self.src_xfer_handles_by_tp_ratio: dict[tuple[int, int], dict[int, int]] = {}
+        # Map of engine_id -> {(tp_rank, dcp_rank): nixl_prepped_dlist_handle}.
+        self.dst_xfer_side_handles = defaultdict[EngineId, dict[tuple[int, int], int]](
+            dict
+        )
 
         # Map of engine_id -> num_blocks. All ranks in the same deployment will
         # have the same number of blocks.
@@ -492,10 +502,11 @@ class NixlBaseConnectorWorker:
         )
         self._ready_requests = queue.Queue[tuple[ReqId, ReqMeta]]()
         self._handshake_futures: dict[
-            EngineId, Future[tuple[dict[tuple[int, int], str], float]]
+            EngineId, Future[tuple[dict[tuple[int, int, int], str], float]]
         ] = {}
         # Protects _handshake_futures and _remote_agents.
         self._handshake_lock = threading.RLock()
+        self._done_recving_without_xfer: set[ReqId] = set()
 
         # TTL-based eviction of stale remote engine state.
         self._engine_last_active: dict[EngineId, float] = {}
@@ -581,8 +592,10 @@ class NixlBaseConnectorWorker:
         remote_tp_size: int,
         expected_engine_id: str,
         remote_pp_size: int = 1,
+        remote_dcp_size: int = 1,
+        remote_pcp_size: int = 1,
         notif_agents_only: bool = False,
-    ) -> tuple[dict[tuple[int, int], str], float]:
+    ) -> tuple[dict[tuple[int, int, int], str], float]:
         """Do a NIXL handshake with a remote instance."""
 
         # the first time we connect to a remote agent.
@@ -597,14 +610,15 @@ class NixlBaseConnectorWorker:
         if not self.use_host_buffer:
             current_platform.set_device(self.device_id)
 
-        # When target instance TP > local TP, we need to perform multiple
-        # handshakes. Do it in a single background job for simplicity.
-        # Regardless, only handshake with the remote TP rank(s) that current
-        # local rank will read from. Note that With homogeneous TP,
-        # this happens to be the same single rank_i.
+        # Handshake only with remote workers whose KV head coverage and DCP
+        # token slice overlap this local worker.
         assert self.transfer_topo is not None
-        p_remote_ranks = self.transfer_topo.handshake_target_ranks(remote_tp_size)
-        remote_rank_to_agent_name: dict[tuple[int, int], str] = {}
+        remote_worker_keys = self.transfer_topo.get_target_remote_worker_keys(
+            remote_tp_size,
+            remote_dcp_size,
+            remote_pcp_size,
+        )
+        remote_worker_to_agent_name: dict[tuple[int, int, int], str] = {}
         path = make_zmq_path("tcp", host, port)
         # Clock offset to the peer, estimated from the handshake round-trip.
         # Keep the lowest-RTT sample: hop cost is ~uniform across ranks, so a
@@ -613,20 +627,29 @@ class NixlBaseConnectorWorker:
         best_offset: float | None = None
 
         with zmq_ctx(zmq.REQ, path) as sock:
-            for remote_pp_rank, remote_rank in itertools.product(
-                range(remote_pp_size), p_remote_ranks
+            for remote_pp_rank, remote_worker_key in itertools.product(
+                range(remote_pp_size), remote_worker_keys
             ):
-                logger.debug(
-                    "Querying metadata on path: %s at remote pp rank %s, tp rank %s",
-                    path,
+                remote_tp_rank, remote_dcp_rank = remote_worker_key
+                remote_pcp_rank = self._tp_dcp_to_pcp_rank(
+                    remote_tp_rank,
+                    remote_dcp_rank,
+                    remote_pcp_size,
+                    remote_dcp_size,
+                )
+                handshake_key = (
                     remote_pp_rank,
-                    remote_rank,
+                    remote_tp_rank,
+                    remote_pcp_rank,
+                )
+                logger.debug(
+                    "Querying metadata on path: %s for worker %s",
+                    path,
+                    handshake_key,
                 )
 
                 # Send query for the request.
-                msg = msgspec.msgpack.encode(
-                    (GET_META_MSG, remote_pp_rank, remote_rank)
-                )
+                msg = msgspec.msgpack.encode((GET_META_MSG, *handshake_key))
                 # Set receive timeout to 5 seconds to avoid hanging on dead server
                 sock.setsockopt(zmq.RCVTIMEO, 5000)  # milliseconds
                 start_time = time.perf_counter()
@@ -701,15 +724,22 @@ class NixlBaseConnectorWorker:
                         f"Expected {expected_engine_id},"
                         f"received {metadata.engine_id}."
                     )
-
                 # Register Remote agent.
                 if notif_agents_only:
                     remote_agent_name = self._add_notif_only_remote_agent(
-                        metadata, remote_tp_size
+                        metadata,
+                        remote_tp_size,
+                        remote_dcp_size,
+                        remote_pcp_size,
                     )
                 else:
                     remote_agent_name = self.add_remote_agent(
-                        metadata, remote_rank, remote_tp_size
+                        metadata,
+                        remote_tp_rank,
+                        remote_tp_size,
+                        remote_dcp_rank,
+                        remote_dcp_size,
+                        remote_pcp_size,
                     )
                 setup_agent_time = time.perf_counter()
                 logger.debug(
@@ -717,14 +747,24 @@ class NixlBaseConnectorWorker:
                     setup_agent_time - got_metadata_time,
                     notif_agents_only,
                 )
-                remote_ranks = (remote_pp_rank, remote_rank)
-                remote_rank_to_agent_name[remote_ranks] = remote_agent_name
+                remote_worker_to_agent_name[(remote_pp_rank, *remote_worker_key)] = (
+                    remote_agent_name
+                )
 
         assert best_offset is not None
-        return remote_rank_to_agent_name, best_offset
+        if not remote_worker_to_agent_name:
+            raise RuntimeError(
+                "Handshake completed but found no remote worker with overlapping "
+                "KV cache coverage."
+            )
+        return remote_worker_to_agent_name, best_offset
 
     def _add_notif_only_remote_agent(
-        self, metadata: NixlAgentMetadata, remote_tp_size: int
+        self,
+        metadata: NixlAgentMetadata,
+        remote_tp_size: int,
+        remote_dcp_size: int,
+        remote_pcp_size: int,
     ) -> str:
         """Load a remote agent for notifs only on the push-mode decode side.
 
@@ -740,9 +780,29 @@ class NixlBaseConnectorWorker:
                 remote_physical_blocks_per_logical=(
                     metadata.physical_blocks_per_logical_kv_block
                 ),
+                remote_dcp_size=remote_dcp_size,
+                remote_pcp_size=remote_pcp_size,
             ),
         )
         return self.nixl_wrapper.add_remote_agent(metadata.agent_metadata)
+
+    @staticmethod
+    def _tp_dcp_to_pcp_rank(
+        tp_rank: int,
+        dcp_rank: int,
+        pcp_size: int,
+        dcp_size: int,
+    ) -> int:
+        if not 0 <= dcp_rank < dcp_size:
+            raise ValueError(f"Invalid dcp_rank={dcp_rank} for dcp_size={dcp_size}")
+
+        pcp_rank = (dcp_rank - tp_rank * pcp_size) % dcp_size
+        if pcp_rank >= pcp_size:
+            raise ValueError(
+                f"No worker for tp_rank={tp_rank}, dcp_rank={dcp_rank}, "
+                f"pcp_size={pcp_size}, dcp_size={dcp_size}"
+            )
+        return pcp_rank
 
     def initialize_host_xfer_buffer(self, kv_caches: dict[str, torch.Tensor]) -> None:
         """
@@ -857,8 +917,10 @@ class NixlBaseConnectorWorker:
         port: int,
         tp_size: int,
         pp_size: int = 1,
+        dcp_size: int = 1,
+        pcp_size: int = 1,
         notif_agents_only: bool = False,
-    ) -> Future[tuple[dict[tuple[int, int], str], float]] | None:
+    ) -> Future[tuple[dict[tuple[int, int, int], str], float]] | None:
         """
         Ensure a handshake is in-flight (or already done) for *engine_id*.
 
@@ -882,12 +944,14 @@ class NixlBaseConnectorWorker:
                 tp_size,
                 engine_id,
                 pp_size,
+                dcp_size,
+                pcp_size,
                 notif_agents_only,
             )
             self._handshake_futures[engine_id] = fut
 
             def done_callback(
-                f: Future[tuple[dict[tuple[int, int], str], float]],
+                f: Future[tuple[dict[tuple[int, int, int], str], float]],
                 eid=engine_id,
             ):
                 with self._handshake_lock:
@@ -918,6 +982,8 @@ class NixlBaseConnectorWorker:
             meta.remote.host,
             meta.remote.port,
             meta.tp_size,
+            dcp_size=meta.dcp_size,
+            pcp_size=meta.pcp_size,
         )
         if fut is None:
             # Already handshaked — only happens if caller does not pre-check.
@@ -971,6 +1037,8 @@ class NixlBaseConnectorWorker:
             attn_backends=self.attn_backends,
             tensor_shape=None,
             is_mamba=self._has_mamba,
+            dcp_rank=self.dcp_rank,
+            dcp_size=self.dcp_size,
         )
         self.compat_hash = compute_nixl_compatibility_hash(
             self.vllm_config,
@@ -998,7 +1066,7 @@ class NixlBaseConnectorWorker:
         self.block_len_per_layer = [block_stride]
         self.num_regions = 1
         self.num_descs = self.num_blocks
-        self.kv_caches_base_addr[self.engine_id][self.tp_rank] = [base_addr]
+        self.kv_caches_base_addr[self.engine_id][self.local_worker_key] = [base_addr]
 
         descs = self.nixl_wrapper.get_reg_descs(caches_data, self.nixl_memory_type)
         self.nixl_wrapper.register_memory(descs, backends=self.nixl_backends)
@@ -1014,9 +1082,9 @@ class NixlBaseConnectorWorker:
             engine_id=self.engine_id,
             agent_metadata=self.nixl_wrapper.get_agent_metadata(),
             device_id=self.device_id,
-            kv_caches_base_addr=(
-                self.kv_caches_base_addr[self.engine_id][self.tp_rank]
-            ),
+            kv_caches_base_addr=self.kv_caches_base_addr[self.engine_id][
+                self.local_worker_key
+            ],
             num_blocks=self.num_blocks,
             block_lens=self.block_len_per_layer,
             kv_cache_layout=self.kv_cache_layout,
@@ -1064,6 +1132,8 @@ class NixlBaseConnectorWorker:
             if not self._has_mamba
             else None,
             is_mamba=self._has_mamba,
+            dcp_rank=self.dcp_rank,
+            dcp_size=self.dcp_size,
         )
         self.compat_hash = compute_nixl_compatibility_hash(
             self.vllm_config, self.backend_name, self.transfer_topo.cross_layers_blocks
@@ -1207,7 +1277,9 @@ class NixlBaseConnectorWorker:
             == len(self._region_is_mla)
         )
 
-        self.kv_caches_base_addr[self.engine_id][self.tp_rank] = seen_base_addresses
+        self.kv_caches_base_addr[self.engine_id][self.local_worker_key] = (
+            seen_base_addresses
+        )
         self.num_regions = len(caches_data)
 
         if self.pp_size > 1:
@@ -1255,7 +1327,9 @@ class NixlBaseConnectorWorker:
             engine_id=self.engine_id,
             agent_metadata=self.nixl_wrapper.get_agent_metadata(),
             device_id=self.device_id,
-            kv_caches_base_addr=self.kv_caches_base_addr[self.engine_id][self.tp_rank],
+            kv_caches_base_addr=self.kv_caches_base_addr[self.engine_id][
+                self.local_worker_key
+            ],
             num_blocks=self.num_blocks,
             block_lens=self.block_len_per_layer,
             kv_cache_layout=self.kv_cache_layout
@@ -1461,7 +1535,9 @@ class NixlBaseConnectorWorker:
         """
         assert self.transfer_topo is not None
         block_size_ratio = self.block_size // block_size
-        local_base_addresses = self.kv_caches_base_addr[self.engine_id][self.tp_rank]
+        local_base_addresses = self.kv_caches_base_addr[self.engine_id][
+            self.local_worker_key
+        ]
 
         blocks_data = self._build_fa_local(local_base_addresses, block_size_ratio)
         logger.debug(
@@ -1492,6 +1568,9 @@ class NixlBaseConnectorWorker:
         nixl_agent_meta: NixlAgentMetadata,
         remote_tp_rank: int = 0,
         remote_tp_size: int = 1,
+        remote_dcp_rank: int = 0,
+        remote_dcp_size: int = 1,
+        remote_pcp_size: int = 1,
     ) -> str:
         """
         Add the remote NIXL agent and prepare the descriptors for reading cache
@@ -1537,15 +1616,17 @@ class NixlBaseConnectorWorker:
         tp_ratio < 0 (P_TP > D_TP) are supported by the 3-read transfer.
         """  # noqa: E501
         engine_id = nixl_agent_meta.engine_id
+        remote_worker_key: tuple[int, int] = (remote_tp_rank, remote_dcp_rank)
+        remote_agent_key = (0, *remote_worker_key)
         # TODO re-evaluate refreshing for scaling/recovery
-        if (0, remote_tp_rank) in self._remote_agents.get(engine_id, {}):
+        if remote_agent_key in self._remote_agents.get(engine_id, {}):
             logger.debug(
                 "Remote agent with engine_id %s and rank"
                 "%s already exchanged metadata, skip handshake.",
                 engine_id,
-                remote_tp_rank,
+                remote_agent_key,
             )
-            return self._remote_agents[engine_id][(0, remote_tp_rank)]
+            return self._remote_agents[engine_id][remote_agent_key]
 
         # Number of physical regions registered locally (one per layer/tensor).
         num_local_regions = len(self.block_len_per_layer)
@@ -1575,6 +1656,8 @@ class NixlBaseConnectorWorker:
             remote_block_size=nixl_agent_meta.block_size,
             remote_block_len=nixl_agent_meta.block_lens[0],
             remote_physical_blocks_per_logical=physical_blocks_per_logical,
+            remote_dcp_size=remote_dcp_size,
+            remote_pcp_size=remote_pcp_size,
         )
         transfer_topo.register_remote_engine(engine_id, transfer_info)
         logger.info("Transfer plan: %s", transfer_topo.describe(engine_id))
@@ -1602,10 +1685,15 @@ class NixlBaseConnectorWorker:
             self.dst_num_blocks[engine_id] = nixl_agent_meta.num_blocks
 
         # Keep track of remote agent kv caches base addresses.
-        self.kv_caches_base_addr[engine_id][remote_tp_rank] = (
+        self.kv_caches_base_addr[engine_id][remote_worker_key] = (
             nixl_agent_meta.kv_caches_base_addr
         )
-        self._validate_remote_agent_handshake(nixl_agent_meta, remote_tp_size)
+        self._validate_remote_agent_handshake(
+            nixl_agent_meta,
+            remote_tp_size,
+            remote_dcp_size,
+            remote_pcp_size,
+        )
 
         # This is 1 when P and D `--tensor-parallel-size` match. Otherwise,
         # this is the ratio between the two sizes.
@@ -1614,7 +1702,7 @@ class NixlBaseConnectorWorker:
         logger.debug(
             "Registering remote agent (%s, rank %s) memory regions with tp_ratio %s",
             engine_id,
-            remote_tp_rank,
+            remote_worker_key,
             tp_ratio,
         )
 
@@ -1637,7 +1725,7 @@ class NixlBaseConnectorWorker:
         split_key = (tp_ratio, remote_block_size)
         if (
             tp_ratio < 0
-            and (not self.use_mla or len(plan.all_source_ranks) > 1)
+            and (not self.use_mla or self._has_mamba)
             and split_key not in self.src_xfer_handles_by_tp_ratio
         ):
             # Remote tp_size > local tp_size: read from multiple remote ranks.
@@ -1645,19 +1733,23 @@ class NixlBaseConnectorWorker:
             # MLA+SSM also needs this path: MLA is replicated and read once,
             # while the SSM state is sharded across every remote TP rank.
             # We only do this once per remote (tp_size, block_size).
-            self.src_xfer_handles_by_tp_ratio[split_key] = []
+            split_handles = self.src_xfer_handles_by_tp_ratio[split_key] = {}
 
-            for handle_data in self._build_local_splits_from_plan(
-                plan,
-                src_blocks_data,
-                self.num_descs * block_size_ratio,
-                block_size_ratio,
+            for remote_tp_rank, handle_data in zip(
+                plan.all_source_ranks,
+                self._build_local_splits_from_plan(
+                    plan,
+                    src_blocks_data,
+                    self.num_descs * block_size_ratio,
+                    block_size_ratio,
+                ),
+                strict=True,
             ):
                 descs = self.nixl_wrapper.get_xfer_descs(
                     handle_data, self.nixl_memory_type
                 )
                 handle = self.nixl_wrapper.prep_xfer_dlist("NIXL_INIT_AGENT", descs)
-                self.src_xfer_handles_by_tp_ratio[split_key].append(handle)
+                split_handles[remote_tp_rank] = handle
 
         ### Register remote agent memory regions
         # With homogeneous TP, D pulls the whole kv cache from corresponding rank. With
@@ -1689,14 +1781,18 @@ class NixlBaseConnectorWorker:
 
         # Register with NIXL.
         descs = self.nixl_wrapper.get_xfer_descs(blocks_data, self.nixl_memory_type)
-        self.dst_xfer_side_handles[engine_id][remote_tp_rank] = (
+        self.dst_xfer_side_handles[engine_id][remote_worker_key] = (
             self.nixl_wrapper.prep_xfer_dlist(remote_agent_name, descs)
         )
 
         return remote_agent_name
 
     def _validate_remote_agent_handshake(
-        self, nixl_agent_meta: NixlAgentMetadata, remote_tp_size: int
+        self,
+        nixl_agent_meta: NixlAgentMetadata,
+        remote_tp_size: int,
+        remote_dcp_size: int = 1,
+        remote_pcp_size: int = 1,
     ):
         """
         Validate the remote agent handshake metadata ensuring the
@@ -1707,6 +1803,8 @@ class NixlBaseConnectorWorker:
         assert self.transfer_topo is not None
         remote_info = self.transfer_topo.get_engine_info(remote_engine_id)
         assert remote_info.remote_tp_size == remote_tp_size
+        assert remote_info.remote_dcp_size == remote_dcp_size
+        assert remote_info.remote_pcp_size == remote_pcp_size
 
         tp_ratio = self.transfer_topo.tp_ratio(remote_tp_size)
         block_size_ratio = self.transfer_topo.block_size_ratio(
@@ -2050,6 +2148,8 @@ class NixlBaseConnectorWorker:
         assert self.transfer_topo is not None
         done_sending = self._get_new_notifs()
         done_recving = self._pop_done_transfers(self._recving_transfers)
+        done_recving.update(self._done_recving_without_xfer)
+        self._done_recving_without_xfer.clear()
 
         # Drain queue of requests where handshake or transfer setup failed.
         failed_recv_reqs = set[ReqId]()
@@ -2285,8 +2385,12 @@ class NixlBaseConnectorWorker:
                     hb_info.host,
                     hb_info.port,
                     hb_info.tp_size,
-                    hb_info.pp_size,
-                    self._hb_handshake_notif_only and hb_info.pp_size > 1,
+                    pp_size=hb_info.pp_size,
+                    dcp_size=hb_info.dcp_size,
+                    pcp_size=hb_info.pcp_size,
+                    notif_agents_only=(
+                        self._hb_handshake_notif_only and hb_info.pp_size > 1
+                    ),
                 )
                 is not None
             ):
@@ -2580,15 +2684,15 @@ class NixlBaseConnectorWorker:
             # error happens during init, no need to shutdown
             return
         self._handshake_initiation_executor.shutdown(wait=False)
-        for handles in self._recving_transfers.values():
-            for handle in handles:
+        for transfer_handles in self._recving_transfers.values():
+            for handle in transfer_handles:
                 self.nixl_wrapper.release_xfer_handle(handle)
         self._recving_transfers.clear()
         for handle in self.src_xfer_handles_by_block_size.values():
             self.nixl_wrapper.release_dlist_handle(handle)
         self.src_xfer_handles_by_block_size.clear()
-        for handles in self.src_xfer_handles_by_tp_ratio.values():
-            for handle in handles:
+        for split_handles in self.src_xfer_handles_by_tp_ratio.values():
+            for handle in split_handles.values():
                 self.nixl_wrapper.release_dlist_handle(handle)
         self.src_xfer_handles_by_tp_ratio.clear()
         for engine_id in list(self._remote_agents):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py
@@ -119,6 +119,15 @@ class NixlBaseConnector(KVConnectorBase_V1, SupportsHMA):
         assert vllm_config.kv_transfer_config is not None
         assert vllm_config.kv_transfer_config.engine_id is not None
 
+        if (
+            vllm_config.kv_transfer_config.is_kv_consumer
+            and vllm_config.parallel_config.prefill_context_parallel_size > 1
+        ):
+            raise NotImplementedError(
+                "NixlConnector consumer (decode) does not support "
+                "prefill_context_parallel_size > 1."
+            )
+
         if vllm_config.kv_transfer_config.kv_role == "kv_both":
             logger.warning_once(
                 "Using kv_role='kv_both' with NixlConnector is deprecated "
@@ -159,6 +168,23 @@ class NixlBaseConnector(KVConnectorBase_V1, SupportsHMA):
     ############################################################
     # Scheduler Side Methods
     ############################################################
+
+    def get_finished_count(self) -> int | None:
+        parallel_config = self._vllm_config.parallel_config
+        if (
+            self.kv_transfer_config.kv_role == "kv_producer"
+            and parallel_config.prefill_context_parallel_size > 1
+        ):
+            publishing_pcp_replica_count = min(
+                parallel_config.prefill_context_parallel_size,
+                parallel_config.decode_context_parallel_size,
+            )
+            return (
+                parallel_config.tensor_parallel_size
+                * parallel_config.pipeline_parallel_size
+                * publishing_pcp_replica_count
+            )
+        return None
 
     def get_num_new_matched_tokens(
         self, request: "Request", num_computed_tokens: int
@@ -208,10 +234,11 @@ class NixlBaseConnector(KVConnectorBase_V1, SupportsHMA):
         return self.connector_scheduler.request_finished(request, block_ids)
 
     def set_xfer_handshake_metadata_pp_aware(
-        self, metadata: dict[tuple[int, int], KVConnectorHandshakeMetadata]
+        self,
+        metadata: dict[tuple[int, int, int], KVConnectorHandshakeMetadata],
     ) -> None:
         """
-        Set handshake metadata keyed by (pp_rank, tp_rank) so the side
+        Set handshake metadata keyed by (pp_rank, tp_rank, pcp_rank) so the side
         channel can serve every PP stage's agent metadata.
 
         Args:
@@ -240,7 +267,14 @@ class NixlBaseConnector(KVConnectorBase_V1, SupportsHMA):
     def get_finished(self, finished_req_ids: set[str]) -> tuple[set[str], set[str]]:
         """Get the finished recving and sending requests."""
         assert self.connector_worker is not None
-        return self.connector_worker.get_finished()
+        done_sending, done_recving = self.connector_worker.get_finished()
+        if (
+            self.kv_transfer_config.kv_role == "kv_producer"
+            and self.connector_worker.pcp_rank
+            >= self._vllm_config.parallel_config.decode_context_parallel_size
+        ):
+            done_sending.clear()
+        return done_sending, done_recving
 
     def get_block_ids_with_load_errors(self) -> set[int]:
         """Get block IDs that failed to load via NIXL."""
@@ -316,6 +350,12 @@ class NixlBaseConnector(KVConnectorBase_V1, SupportsHMA):
             None if no handshake metadata is available.
         """
         assert self.connector_worker is not None
+        if (
+            self.kv_transfer_config.kv_role == "kv_producer"
+            and self.connector_worker.pcp_rank
+            >= self._vllm_config.parallel_config.decode_context_parallel_size
+        ):
+            return None
         return self.connector_worker.xfer_handshake_metadata
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -41,8 +41,9 @@ PUSH_REG_NOTIF_PREFIX = b"PUSH_REG:"
 #   4: Add KV block lease renewal through heartbeats
 #   5: Add remote_blocks_expiry_time to kv_transfer_params + handshake
 #      clock-sync timestamp
+#   6: Add DCP/PCP worker addressing for context-parallel KV transfer
 #
-NIXL_CONNECTOR_VERSION: int = 5
+NIXL_CONNECTOR_VERSION: int = 6
 
 
 @dataclass
@@ -150,6 +151,8 @@ class HeartbeatInfo:
     port: int
     tp_size: int
     pp_size: int = 1
+    dcp_size: int = 1
+    pcp_size: int = 1
 
 
 @dataclass
@@ -168,6 +171,8 @@ class ReqMeta:
     # To be used when logical block size does not match the kernel block size
     local_physical_block_ids: BlockIds
     tp_size: int
+    dcp_size: int = 1
+    pcp_size: int = 1
     remote: RemoteMeta | None = None
     # Remote block size, discovered during NIXL handshake (push mode).
     remote_block_size: int | None = None
@@ -205,10 +210,12 @@ class NixlConnectorMetadata(KVConnectorMetadata):
         return ReqMeta(
             local_block_ids=local_block_ids,
             local_physical_block_ids=local_block_ids,
-            # P workers don't need to receive tp_size from proxy here.
+            # P workers don't need to receive these from proxy here.
             tp_size=kv_transfer_params.get("tp_size", 1),
             remote_block_size=kv_transfer_params.get("remote_block_size"),
             pp_size=kv_transfer_params.get("pp_size", 1),
+            dcp_size=kv_transfer_params.get("dcp_size", 1),
+            pcp_size=kv_transfer_params.get("pcp_size", 1),
         )
 
     def add_new_req_to_save(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
@@ -275,6 +275,8 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
             remote_host=self.side_channel_host,
             remote_port=self.side_channel_port,
             tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
+            dcp_size=self.vllm_config.parallel_config.decode_context_parallel_size,
+            pcp_size=self.vllm_config.parallel_config.prefill_context_parallel_size,
             remote_num_tokens=remote_num_tokens,
             remote_blocks_expiry_time=blocks_expiry_time,
         )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -144,11 +144,14 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         remote_info = self.transfer_topo.get_engine_info(engine_id)
         tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
 
-        remote_worker_keys = self.transfer_topo.get_target_remote_worker_keys(
-            remote_info.remote_tp_size,
-            remote_info.remote_dcp_size,
-            remote_info.remote_pcp_size,
-        )
+        remote_worker_keys = [
+            worker.key
+            for worker in self.transfer_topo.get_target_remote_workers(
+                remote_info.remote_tp_size,
+                remote_info.remote_dcp_size,
+                remote_info.remote_pcp_size,
+            )
+        ]
         meta.remote.block_ids = self._logical_to_kernel_block_ids(
             meta.remote.block_ids,
             remote_info.remote_physical_blocks_per_logical,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -144,6 +144,11 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         remote_info = self.transfer_topo.get_engine_info(engine_id)
         tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
 
+        remote_worker_keys = self.transfer_topo.get_target_remote_worker_keys(
+            remote_info.remote_tp_size,
+            remote_info.remote_dcp_size,
+            remote_info.remote_pcp_size,
+        )
         meta.remote.block_ids = self._logical_to_kernel_block_ids(
             meta.remote.block_ids,
             remote_info.remote_physical_blocks_per_logical,
@@ -151,6 +156,10 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         remote_block_ids = meta.remote.block_ids
         local_block_ids = meta.local_physical_block_ids
         num_groups = len(local_block_ids)
+        remote_worker_by_tp_rank = {key[0]: key for key in remote_worker_keys}
+        transfer_worker_keys = remote_worker_keys
+        if self.use_mla and tp_ratio < 0 and not self._has_mamba:
+            transfer_worker_keys = remote_worker_keys[:1]
         read_specs = [
             ReadSpec(
                 remote_rank=rank,
@@ -167,31 +176,31 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                     for g in range(num_groups)
                 ],
             )
-            for rank in plan.all_source_ranks
+            for rank, _ in transfer_worker_keys
         ]
 
-        # D may have to perform multiple reads from different remote ranks.
-        # Pure MLA reads once because its cache is replicated. Hybrid
-        # MLA+SSM still needs one read per SSM source rank.
-        if self.use_mla and tp_ratio < 0 and not self._has_mamba:
-            assert len(read_specs) == 1
-
-        for i, spec in enumerate(read_specs):
+        launched_read = False
+        for spec in read_specs:
+            remote_worker_key = remote_worker_by_tp_rank[spec.remote_rank]
+            if any(len(group) > 0 for group in spec.local_block_ids):
+                launched_read = True
             remote_block_size = remote_info.remote_block_size
             logger.debug(
                 "Remote agent %s available, calling _read_blocks"
-                " on remote rank %s with remote block size %s for req %s",
+                " on remote worker %s with remote block size %s for req %s",
                 meta.remote.engine_id,
-                spec.remote_rank,
+                remote_worker_key,
                 remote_block_size,
                 req_id,
             )
             # Get side handles.
-            if tp_ratio < 0 and (not self.use_mla or len(read_specs) > 1):
+            if tp_ratio < 0 and (not self.use_mla or self._has_mamba):
                 # Remote tp_size > local tp_size: we must perform multiple
                 # reads. Get the memory chunk onto which we will write to.
                 split_key = (tp_ratio, remote_block_size)
-                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[split_key][i]
+                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[split_key][
+                    spec.remote_rank
+                ]
             else:
                 # Single read from remote, we write to the whole memory region.
                 # Also handle remote block size different from local block size.
@@ -199,10 +208,14 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                     remote_block_size
                 ]
 
-            # Destination handle: remote_engine_id -> remote_rank -> handle.
+            # Destination handle: remote_engine_id -> (tp_rank, dcp_rank) -> handle.
             remote_xfer_side_handle = self.dst_xfer_side_handles[meta.remote.engine_id][
-                spec.remote_rank
+                remote_worker_key
             ]
+            expected_consumers = self.transfer_topo.calculate_local_consumer_count(
+                engine_id,
+                remote_worker_key,
+            )
 
             self._read_blocks(
                 read_spec=spec,
@@ -211,16 +224,21 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 remote_request_id=meta.remote.request_id,
                 local_xfer_side_handle=local_xfer_side_handle,
                 remote_xfer_side_handle=remote_xfer_side_handle,
+                remote_worker_key=remote_worker_key,
+                expected_consumers=expected_consumers,
             )
 
-        if self.use_mla and tp_ratio < 0 and len(read_specs) == 1:
-            # ..but we still need to notify the other remote ranks that we
-            # have the blocks we need so they can update the request state.
-            notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
-            remote_agents = self._remote_agents[meta.remote.engine_id]
-            for rank_to_notify, agent in remote_agents.items():
-                if rank_to_notify != (0, read_specs[0].remote_rank):
-                    self.nixl_wrapper.send_notif(agent, notif_msg=notif_id)
+        for remote_worker_key in remote_worker_keys[len(transfer_worker_keys) :]:
+            expected_consumers = self.transfer_topo.calculate_local_consumer_count(
+                engine_id,
+                remote_worker_key,
+            )
+            notif_id = f"{meta.remote.request_id}:{expected_consumers}".encode()
+            agent_name = self._remote_agents[engine_id][(0, *remote_worker_key)]
+            self.nixl_wrapper.send_notif(agent_name, notif_msg=notif_id)
+
+        if not launched_read:
+            self._done_recving_without_xfer.add(req_id)
 
     def _read_blocks(
         self,
@@ -230,15 +248,39 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         remote_request_id: str,
         local_xfer_side_handle: int,
         remote_xfer_side_handle: int,
+        remote_worker_key: tuple[int, int],
+        expected_consumers: int,
     ):
         """
         Post a READ point-to-point xfer request from a single local worker to
         a single remote worker.
         """
         assert self.transfer_topo is not None
-        remote_rank = read_spec.remote_rank
         local_block_ids = read_spec.local_block_ids
         remote_block_ids = read_spec.remote_block_ids
+        # Number of local workers that will notify this producer worker.
+        notif_id = f"{remote_request_id}:{expected_consumers}".encode()
+
+        # Full prefix cache hit: do not need to read remote blocks,
+        # just notify P worker that we have the blocks we need.
+        if not any(len(group) > 0 for group in local_block_ids):
+            # A full prefix cache hit is indicated with an empty list.
+            agent_name = self._remote_agents[dst_engine_id][(0, *remote_worker_key)]
+            try:
+                self.nixl_wrapper.send_notif(agent_name, notif_msg=notif_id)
+            except Exception as e:
+                self._log_failure(
+                    failure_type="notification_failed",
+                    msg="P worker blocks will be freed after timeout. "
+                    "This may indicate network issues.",
+                    req_id=request_id,
+                    error=e,
+                    dst_engine_id=dst_engine_id,
+                    remote_worker_key=remote_worker_key,
+                    remote_agent_name=agent_name,
+                )
+                self.xfer_stats.record_failed_notification()
+            return
 
         remote_info = self.transfer_topo.get_engine_info(dst_engine_id)
         block_size_ratio = self.transfer_topo.block_size_ratio(
@@ -258,31 +300,6 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
 
         # NOTE(rob): according to nvidia the staging blocks are used to
         # saturate IB with heterogeneous TP sizes.
-
-        # Number of D TP workers that will read from dst P. Propagate info
-        # on notification so that dst worker can wait before freeing blocks.
-        notif_id = f"{remote_request_id}:{self.world_size}".encode()
-
-        # Full prefix cache hit: do not need to read remote blocks,
-        # just notify P worker that we have the blocks we need.
-        if len(local_block_ids) == 0:
-            # A full prefix cache hit is indicated with an empty list.
-            agent_name = self._remote_agents[dst_engine_id][(0, remote_rank)]
-            try:
-                self.nixl_wrapper.send_notif(agent_name, notif_msg=notif_id)
-            except Exception as e:
-                self._log_failure(
-                    failure_type="notification_failed",
-                    msg="P worker blocks will be freed after timeout. "
-                    "This may indicate network issues.",
-                    req_id=request_id,
-                    error=e,
-                    dst_engine_id=dst_engine_id,
-                    remote_rank=remote_rank,
-                    remote_agent_name=agent_name,
-                )
-                self.xfer_stats.record_failed_notification()
-            return
 
         assert (
             len(remote_block_ids)
@@ -339,7 +356,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 msg="Marking blocks as invalid",
                 error=e,
                 dst_engine_id=dst_engine_id,
-                remote_rank=remote_rank,
+                remote_worker_key=remote_worker_key,
             )
             self._handle_failed_transfer(request_id, handle)
 
@@ -363,7 +380,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                     self._handle_heartbeat(msg[3:])
                     continue
 
-                req_id, tp_size = msg.rsplit(":", 1)
+                req_id, expected_consumers = msg.rsplit(":", 1)
                 if (
                     req_id not in self._reqs_to_send
                     and req_id not in self._reqs_to_process
@@ -376,16 +393,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                     )
                     continue
 
-                # NOTE: `tp_ratio` is the opposite when swapping local<>remote
-                n_consumers = int(tp_size)
-                tp_ratio = self.transfer_topo.tp_ratio(n_consumers)
-
-                # Number of reads *per producer* to wait for.
-                # When remote D TP > local P TP we expect `tp_ratio` reads.
-                consumers_per_producer = (
-                    -tp_ratio if n_consumers > self.world_size else 1
-                )
-
+                consumers_per_producer = int(expected_consumers)
                 self.consumer_notification_counts_by_req[req_id] += 1
                 # Wait all consumers (D) to be done reading before freeing.
                 if (

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
@@ -289,6 +289,8 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
             remote_port=self.side_channel_port,
             tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
             pp_size=self.vllm_config.parallel_config.pipeline_parallel_size,
+            dcp_size=self.vllm_config.parallel_config.decode_context_parallel_size,
+            pcp_size=self.vllm_config.parallel_config.prefill_context_parallel_size,
             remote_num_tokens=remote_num_tokens,
         )
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -318,7 +318,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             return
 
         def _on_handshake(
-            f: Future[tuple[dict[tuple[int, int], str], float]],
+            f: Future[tuple[dict[tuple[int, int, int], str], float]],
             rid: str = req_id,
             rd: dict[str, Any] = reg_data,
         ) -> None:
@@ -434,7 +434,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         if fut is not None:
 
             def _on_handshake(
-                f: Future[tuple[dict[tuple[int, int], str], float]],
+                f: Future[tuple[dict[tuple[int, int, int], str], float]],
                 rid: str = request_id,
                 blocks: BlockIds = local_block_ids,
                 rd: dict[str, Any] = registration_data,
@@ -514,6 +514,10 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         remote_block_ids = meta.remote.block_ids
         local_block_ids = meta.local_physical_block_ids
         num_groups = len(local_block_ids)
+        remote_worker_by_tp_rank = {
+            worker_key[0]: worker_key
+            for worker_key in self.dst_xfer_side_handles[engine_id]
+        }
 
         # MLA latent is replicated across D's TP ranks: the tp-mapping
         # collapses it to one rank (fine for reads), but push must WRITE every
@@ -524,9 +528,13 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         replicate_attn = self.use_mla and tp_ratio < 0
         if replicate_attn and not self._has_mamba:
             assert len(plan.all_source_ranks) == 1
-            write_ranks = sorted(self.dst_xfer_side_handles[engine_id])
+            write_ranks = sorted(remote_worker_by_tp_rank)
         else:
-            write_ranks = list(plan.all_source_ranks)
+            write_ranks = [
+                rank
+                for rank in plan.all_source_ranks
+                if rank in remote_worker_by_tp_rank
+            ]
 
         def group_ids(block_ids: BlockIds, rank: int) -> BlockIds:
             return [
@@ -547,7 +555,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         ]
 
         handles: list[int] = []
-        for i, spec in enumerate(read_specs):
+        for spec in read_specs:
             remote_block_size = remote_info.remote_block_size
             logger.debug(
                 "Remote agent %s available, calling _xfer_blocks"
@@ -557,19 +565,22 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 remote_block_size,
                 req_id,
             )
-            if tp_ratio < 0 and (not self.use_mla or len(plan.all_source_ranks) > 1):
+            if tp_ratio < 0 and (not self.use_mla or self._has_mamba):
                 # Multiple targets: write each rank its chunk of local memory.
                 # Hybrid MLA+SSM also lands here: its split handles replicate
                 # the attention descriptors and chunk only the SSM state.
                 split_key = (tp_ratio, remote_block_size)
-                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[split_key][i]
+                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[split_key][
+                    spec.remote_rank
+                ]
             else:
                 local_xfer_side_handle = self.src_xfer_handles_by_block_size[
                     remote_block_size
                 ]
 
+            remote_worker_key = remote_worker_by_tp_rank[spec.remote_rank]
             remote_xfer_side_handle = self.dst_xfer_side_handles[meta.remote.engine_id][
-                spec.remote_rank
+                remote_worker_key
             ]
 
             handle = self._xfer_blocks(

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -191,9 +191,9 @@ class EngineCore:
 
             if xfer_handshake_metadata:
                 # xfer_handshake_metadata is list of dicts from workers
-                # Each dict already has structure {(pp_rank, tp_rank): metadata}
+                # Each dict is keyed by (pp_rank, tp_rank, pcp_rank).
                 # Merge all worker dicts into a single dict
-                content: dict[tuple[int, int], Any] = {}
+                content: dict[tuple[int, int, int], Any] = {}
                 for worker_dict in xfer_handshake_metadata:
                     if worker_dict is not None:
                         content.update(worker_dict)

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -203,7 +203,7 @@ class Executor(ABC):
 
     def get_kv_connector_handshake_metadata(
         self,
-    ) -> list[dict[tuple[int, int], KVConnectorHandshakeMetadata]]:
+    ) -> list[dict[tuple[int, int, int], KVConnectorHandshakeMetadata]]:
         return self.collective_rpc("get_kv_connector_handshake_metadata")
 
     @overload

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -43,6 +43,7 @@ from vllm.distributed.parallel_state import (
     Handle,
     checkpoint_prepare_distributed_state,
     checkpoint_restore_distributed_state,
+    get_pcp_group,
     get_pp_group,
     get_tp_group,
 )
@@ -612,10 +613,10 @@ class Worker(WorkerBase):
 
     def get_kv_connector_handshake_metadata(
         self,
-    ) -> dict[tuple[int, int], KVConnectorHandshakeMetadata] | None:
+    ) -> dict[tuple[int, int, int], KVConnectorHandshakeMetadata] | None:
         """Get KV connector metadata from this worker if available.
 
-        Returned dict is keyed by `(pp_rank, tp_rank)`.
+        Returned dict is keyed by `(pp_rank, tp_rank, pcp_rank)`.
         """
 
         if not has_kv_transfer_group():
@@ -629,7 +630,8 @@ class Worker(WorkerBase):
 
         pp_rank = get_pp_group().rank_in_group
         tp_rank = get_tp_group().rank_in_group
-        return {(pp_rank, tp_rank): metadata}
+        pcp_rank = get_pcp_group().rank_in_group
+        return {(pp_rank, tp_rank, pcp_rank): metadata}
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         return self.model_runner.get_kv_cache_spec()


### PR DESCRIPTION
> Note: this PR intentionally supports matching producer and consumer DCP sizes with PCP disabled on the consumer; unequal-DCP remapping and decoder-side PCP remain out of scope.

## Purpose

Add DCP-aware NIXL P/D transfer support that composes with prefill PCP without changing attention or token-interleaving behavior.

This change:

- uses explicit `(pp_rank, tp_rank, pcp_rank)` handshake keys and `(pp_rank, tp_rank, dcp_rank)` remote-agent keys;
- routes each consumer to producer workers with the same DCP rank while preserving the existing TP transfer plan;
- rejects mismatched producer and consumer DCP sizes;
- rejects PCP on KV consumers, allowing consumer fan-in to use the direct `tp_rank % dcp_size` mapping;
- publishes one PCP producer replica per distinct DCP shard and counts completion only from those published replicas;
- preserves one-copy MLA pulls while notifying the other producer workers involved in the request.

The connector remains layout-opaque: it selects matching workers and copies KV blocks. PCP/DCP attention chunking, empty attention shards, decoder-side PCP, and unequal-DCP token-position remapping are outside this PR.

## Related work and duplicate check

Open-PR searches for NIXL PCP/DCP and context-parallel NIXL changes found #38433, #45340, and this draft; no other open PR combines the reduced equal-DCP transfer path with PCP replica ownership.

- #38433 is the generalized unequal-DCP implementation. This PR is intentionally smaller: it accepts only matching DCP layouts and adds PCP publication/completion behavior.
- #45340 changes scheduler-side CP-scaled block accounting while leaving transfer-worker routing unchanged.

## Test plan and results

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_nixl_connector.py tests/v1/kv_connector/unit/test_nixl_push_connector.py -k "not abort_timeout_on_prefiller and not register_kv_caches and not reqs_to_send_deadline_rebased_to_worker_clock" -q
# 102 passed, 7 deselected
```

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_handshake_pp_aggregation.py tests/v1/kv_connector/unit/test_nixl_connector.py::TestNixlHandshake::test_consumer_rejects_pcp tests/v1/kv_connector/unit/test_nixl_connector.py::TestNixlHandshake::test_pcp_producer_publishes_one_replica_per_dcp_rank tests/v1/kv_connector/unit/test_nixl_connector.py::TestNixlHandshake::test_pcp_producer_waits_only_for_published_replicas tests/v1/kv_connector/unit/test_nixl_connector.py::TestNixlHandshake::test_prefill_tp_size_greater_than_decode_tp_size tests/v1/kv_connector/unit/test_nixl_connector.py::TestNixlHandshake::test_prefill_tp_size_greater_than_decode_tp_size_mla tests/v1/kv_connector/unit/test_nixl_push_connector.py::TestPushPipelineParallel tests/v1/kv_connector/unit/test_nixl_push_connector.py::TestPushWriterMlaReplication tests/v1/kv_connector/unit/test_transfer_topology_sharded.py -q
# 17 passed
```

```bash
.venv/bin/pre-commit run --files $(git diff --name-only upstream/main)
# passed
```

A final-branch four-GPU TP1+PCP2+DCP2+EP2 prefiller to TP2+DCP2 decoder run was attempted. NIXL initialized and model loading completed, but current `main` deadlocked before the first transfer during PCP×DCP attention warmup: the non-empty PCP worker entered the DCP collective while its empty-context peer skipped it. Because this is a core PCP×DCP attention issue rather than connector behavior, this PR does not add a failing integration job for that topology.

Earlier development on a larger superset branch completed both 1,319-example DeepSeek-V2-Lite-Chat GSM8K evaluations for TP1+PCP2+DCP2 to TP2+DCP2 and TP2+PCP2+DCP4 to TP4+DCP4 within the required accuracy band. Those runs also contained separate attention and MRV2 fixes that are not in this connector PR, so they are not final-branch validation.

## AI assistance disclosure

OpenAI Codex assisted with investigation, implementation, testing, and drafting this PR.

Reviewed by the human submitter