### PR TITLE
fix: accept empty tool call list in case of none required tool_choice

### DIFF
--- a/tests/tool_use/test_chat_completion_request_validations.py
+++ b/tests/tool_use/test_chat_completion_request_validations.py
@@ -26,15 +26,57 @@ def test_chat_completion_request_with_no_tools():
     )
     assert request.tool_choice == "none"
 
-    # tools key present but empty -- should be rejected
-    with pytest.raises(ValueError, match="must not be an empty array"):
-        ChatCompletionRequest.model_validate(
-            {
-                "messages": [{"role": "user", "content": "Hello"}],
-                "model": "facebook/opt-125m",
-                "tools": [],
-            }
-        )
+    # tools key present but empty -- accepted
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "model": "facebook/opt-125m",
+            "tools": [],
+        }
+    )
+    assert request.tool_choice == "none"
+
+
+@pytest.mark.parametrize(
+    "tool_choice,tools,expect_ok",
+    [
+        # tool_choice / tools matrix
+        ("auto", None, False),
+        ("auto", [], True),
+        ("required", None, False),
+        ("required", [], False),
+        ("none", None, False),
+        ("none", [], True),
+        # tool_choice omitted
+        (None, None, True),
+        (None, [], True),
+        # tools-only rows (no tool_choice key)
+        ("only_tools", [], True),
+        ("only_tools", None, True),
+    ],
+)
+def test_tool_choice_tools_matrix(tool_choice, tools, expect_ok):
+    payload = {
+        "messages": [{"role": "user", "content": "Hello"}],
+        "model": "facebook/opt-125m",
+    }
+    only_tools = tool_choice == "only_tools"
+    if not only_tools and tool_choice is not None:
+        payload["tool_choice"] = tool_choice
+    payload["tools"] = tools
+
+    if expect_ok:
+        request = ChatCompletionRequest.model_validate(payload)
+        if only_tools or tool_choice is None:
+            assert request.tool_choice == "none"
+        else:
+            assert request.tool_choice == tool_choice
+    else:
+        with pytest.raises(
+            ValueError,
+            match=r"When using `tool_choice`, `tools` must be set\.",
+        ):
+            ChatCompletionRequest.model_validate(payload)
 
 
 @pytest.mark.parametrize("tool_choice", ["auto", "required"])

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -847,27 +847,24 @@ class ChatCompletionRequest(OpenAIBaseModel):
         if not isinstance(data, dict):
             return data
 
-        # Reject empty tools array, matching OpenAI API behavior
-        if data.get("tools") == []:
-            raise VLLMValidationError(
-                "`tools` must not be an empty array. "
-                "Either provide at least one tool or omit the field entirely.",
-                parameter="tools",
-            )
-
         # if "tool_choice" is not specified but tools are provided,
         # default to "auto" tool_choice
         if "tool_choice" not in data and data.get("tools"):
             data["tool_choice"] = "auto"
 
-        # if "tool_choice" is "none" -- no validation is needed for tools
-        if "tool_choice" in data and data["tool_choice"] == "none":
+        # match OpenAI behavior and return early in case of empty tools list to
+        # ignore absence of tools
+        if data.get("tools") == [] and data.get("tool_choice") == "auto":
+            return data
+
+        # match OpenAI behavior and skip validation only if tools are defined
+        if data.get("tool_choice") == "none" and data.get("tools") is not None:
             return data
 
         # if "tool_choice" is specified -- validation
         if "tool_choice" in data and data["tool_choice"] is not None:
-            # ensure that if "tool choice" is specified, tools are present
-            if "tools" not in data or data["tools"] is None:
+            # ensure that if "tool choice" is specified, tools are present and not empty
+            if "tools" not in data or data["tools"] is None or data["tools"] == []:
                 raise VLLMValidationError(
                     "When using `tool_choice`, `tools` must be set.",
                     parameter="tool_choice",


### PR DESCRIPTION



## Purpose

Fix tool call compliance behavior with OpenAI

When passing an empty tool call list, request must not systematically get rejected with  a 400 

Correct this [pr](https://github.com/vllm-project/vllm/pull/39780) which introduced a breaking change

## Test Plan

`python -m pytest tests/tool_use/test_chat_completion_request_validations.py`

## Test Result

`======================================================== 19 passed, 2 warnings in 1.95s ========================================================`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

