### PR TITLE
[ROCm][CI] skip moe weight padding for eplb

### DIFF
--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -139,10 +139,13 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
 
     def _maybe_pad_weight(self, weight: torch.Tensor) -> torch.Tensor:
         # Pad the weight tensor. This is an optimization on ROCm platform, which
-        # can benefit from tensors located far enough from one another in memory
+        # can benefit from tensors located far enough from one another in memory.
+        # Skip padding when EPLB is enabled because EPLB requires contiguous
+        # weights for the view/rearrangement operations.
         if (
             envs.VLLM_ROCM_MOE_PADDING
             and current_platform.is_rocm()
+            and not self.moe.moe_parallel_config.enable_eplb
             and weight.stride(-1) == 1
             and (weight.stride(-2) * weight.element_size()) % 512 == 0
         ):


### PR DESCRIPTION
This PR skips moe padding for eplb as contiguous weights are required, following a refactoring.

`pytest -s -v tests/distributed/test_elastic_ep.py::test_elastic_ep_scaling[sync_eplb]`

This PR is the 3rd piece for solving this test case.
1. https://github.com/vllm-project/vllm/pull/47206 -> Fixes the weight transfer issue.
2. https://github.com/vllm-project/vllm/pull/49251 -> Resolves the final accuracy.
3. This PR -> Fixes the moe api refactoring issue.