### PR TITLE
[CI][Bugfix] Reduce max_model_len in OOT embedding test to fix KV-cache OOM on small GPUs

### DIFF
--- a/tests/plugins_tests/test_oot_registration_offline.py
+++ b/tests/plugins_tests/test_oot_registration_offline.py
@@ -50,7 +50,7 @@ def test_oot_registration_embedding(
         m.setenv("VLLM_PLUGINS", "register_dummy_model")
         prompts = ["Hello, my name is", "The text does not matter"]
         llm = LLM(
-            model=dummy_gemma2_embedding_path, load_format="dummy", max_model_len=2048
+            model=dummy_gemma2_embedding_path, load_format="dummy", max_model_len=512
         )
         outputs = llm.embed(prompts)
 


### PR DESCRIPTION
## Purpose
Fixes https://github.com/vllm-project/vllm/issues/49333

`test_oot_registration_embedding` fails at engine startup on the L4 CI GPU - ValueError: To serve at least one request with the model's max seq len (2048), 0.66 GiB KV cache is needed, which is larger than the available KV cache memory (0.64 GiB).

After the 9B Gemma2 embedding model's weights and the CUDA-graph memory profiler's ~0.5 GiB reservation (default since #38284), only 0.64 GiB is left for the KV cache — ~20 MiB short of what `max_model_len=2048` requires. It passes on large GPUs, so the failure is hardware-dependent.

The test embeds two ~7-token prompts and asserts all-zero embeddings; it never uses long sequences, so `max_model_len=2048` is arbitrary headroom. Lowering it to **512** drops the KV requirement to ~0.17 GiB (well under 0.64 GiB), keeps the output identical, and makes startup deterministic across GPU sizes.