### PR TITLE
[CI][Bugfix] Fix and wire streaming-input tests

### DIFF
--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -90,6 +90,7 @@ steps:
     - tests/v1/kv_offload
     - tests/v1/simple_kv_offload
     - tests/v1/worker
+    - tests/v1/streaming_input
     - tests/v1/kv_connector/unit
     - tests/v1/ec_connector/unit
     - tests/v1/metrics
@@ -103,6 +104,7 @@ steps:
     - pytest -v -s v1/kv_offload
     - pytest -v -s v1/simple_kv_offload
     - pytest -v -s v1/worker
+    - pytest -v -s v1/streaming_input
     - pytest -v -s -m 'not cpu_test' v1/kv_connector/unit
     - pytest -v -s -m 'not cpu_test' v1/ec_connector/unit
     - pytest -v -s -m 'not cpu_test' v1/metrics

--- a/tests/v1/streaming_input/test_gpu_model_runner_streaming.py
+++ b/tests/v1/streaming_input/test_gpu_model_runner_streaming.py
@@ -16,7 +16,8 @@ from vllm.sampling_params import SamplingParams
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
-pytestmark = pytest.mark.cpu_test
+# Not cpu_test: InputBatch allocates pinned (UVA) memory, which requires a
+# CUDA device even though the batch tensors live on the CPU.
 
 
 @pytest.fixture
@@ -28,6 +29,7 @@ def mock_model_runner_with_input_batch():
     runner.requests = {}
     runner.max_num_reqs = 10
     runner.max_model_len = 1024
+    runner.late_interaction_runner = Mock()
 
     # Create a real InputBatch for e2e testing
     runner.input_batch = InputBatch(

--- a/tests/v1/streaming_input/test_gpu_model_runner_v2_streaming.py
+++ b/tests/v1/streaming_input/test_gpu_model_runner_v2_streaming.py
@@ -16,7 +16,8 @@ from vllm.v1.core.sched.output import (
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner
 from vllm.v1.worker.gpu.states import RequestState
 
-pytestmark = pytest.mark.cpu_test
+# Not cpu_test: RequestState allocates pinned (UVA) memory, which requires a
+# CUDA device even though the request state itself lives on the CPU.
 
 
 @pytest.fixture
@@ -31,13 +32,12 @@ def mock_model_runner_with_req_states():
         num_speculative_steps=0,
         vocab_size=32000,
         device=torch.device("cpu"),
-        model_dtype=torch.float32,
-        cache_draft_logits=False,
     )
     runner.encoder_cache = None
     runner.model_state = Mock()
     runner.block_tables = Mock()
     runner.lora_state = Mock()
+    runner.pp_handler = None
     runner.sampler = None
     runner.prompt_logprobs_worker = None
     runner.is_last_pp_rank = False

--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -53,6 +53,8 @@ def create_scheduler() -> Scheduler:
     vllm_config.model_config = MagicMock()
     vllm_config.model_config.skip_tokenizer_init = True
     vllm_config.model_config.is_multimodal_model = False
+    vllm_config.model_config.is_encoder_decoder = False
+    vllm_config.model_config.is_diffusion = False
     vllm_config.model_config.max_model_len = 1024
     vllm_config.model_config.enable_return_routed_experts = False
     vllm_config.cache_config = MagicMock()
@@ -496,7 +498,9 @@ class TestStreamingScheduler(unittest.TestCase):
         eco_cycle2 = eco_dict_cycle2[session.client_index].outputs[0]
         assert eco_cycle2.finish_reason == FinishReason.STOP
         assert session.status == RequestStatus.WAITING_FOR_STREAMING_REQ
-        assert session in scheduler.waiting
+        # Sessions paused for streaming input are blocked-waiting, so they
+        # live in the skipped_waiting queue rather than the main waiting queue.
+        assert session in scheduler.skipped_waiting
         assert session._all_token_ids == [1, 2, 3, 10, STOP_TOKEN]
 
         # CRITICAL ASSERTION: Cached prompt_token_ids STILL must not have changed


### PR DESCRIPTION
The `tests/v1/streaming_input/` suite ran in no CI job and had drifted out of sync with the code:

- `test_scheduler_streaming.py`: the create_scheduler() mock's model_config lacked is_encoder_decoder/is_diffusion, so the truthy MagicMock tripped the scheduler's encoder-decoder assertion; and one assertion checked scheduler.waiting, but paused streaming sessions now route to the skipped_waiting (blocked-waiting) queue.
- `test_gpu_model_runner_streaming.py`: fixture missing late_interaction_runner, now used by _update_streaming_request.
- `test_gpu_model_runner_v2_streaming.py`: passed removed RequestState kwargs (model_dtype/cache_draft_logits) and lacked pp_handler, read by _remove_request on the streaming-update path.

Wire all four files into the "V1 Core + KV + Metrics" GPU job. The two model_runner tests were mismarked cpu_test but require a CUDA device: `RequestState`/`InputBatch` allocate pinned (UVA) memory, which fails on a pure-CPU host. Drop those inaccurate marks so they run on GPU.

Validated 14/14 on GB200. AI assistance (Claude) was used for this change.