### PR TITLE
[BugFix] bound FlashMLA sparse decode intermediate tensors size

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
     VLLM_XLA_CACHE_PATH: str = os.path.join(VLLM_CACHE_ROOT, "xla_cache")
     VLLM_XLA_CHECK_RECOMPILATION: bool = False
     VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: int = 512
+    VLLM_FLASHMLA_SPARSE_MAX_SCRATCH_MB: int = 512
     VLLM_ADAPTIVE_VERIFICATION_PROFILE_CONTEXT_LEN: int = 8192
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: Literal["auto", "nccl", "shm"] = "auto"
     VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM: bool = False
@@ -1077,6 +1078,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Default: 512 MB
     "VLLM_SPARSE_INDEXER_MAX_LOGITS_MB": lambda: int(
         os.getenv("VLLM_SPARSE_INDEXER_MAX_LOGITS_MB", "512")
+    ),
+    # Maximum size (in MB) for the scratch buffer in FlashMLA sparse mixed-batch path.
+    # Bounds how many tokens are sent to the kernel per call to prevent CUDA OOM
+    # on long prefill.
+    # Default: 512 MB
+    "VLLM_FLASHMLA_SPARSE_MAX_SCRATCH_MB": lambda: int(
+        os.getenv("VLLM_FLASHMLA_SPARSE_MAX_SCRATCH_MB", "512")
     ),
     # KV context length each adaptive-verification profiling request pretends to
     # carry, so the profiled step reads a realistic amount of cache.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
     VLLM_XLA_CACHE_PATH: str = os.path.join(VLLM_CACHE_ROOT, "xla_cache")
     VLLM_XLA_CHECK_RECOMPILATION: bool = False
     VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: int = 512
+    VLLM_FLASHMLA_SPARSE_MAX_SCRATCH_MB: int = 512
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: Literal["auto", "nccl", "shm"] = "auto"
     VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM: bool = False
     VLLM_USE_RAY_WRAPPED_PP_COMM: bool = True
@@ -1051,6 +1052,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Default: 512 MB
     "VLLM_SPARSE_INDEXER_MAX_LOGITS_MB": lambda: int(
         os.getenv("VLLM_SPARSE_INDEXER_MAX_LOGITS_MB", "512")
+    ),
+    # Maximum size (in MB) for the scratch buffer in FlashMLA sparse mixed-batch path.
+    # Bounds how many tokens are sent to the kernel per call to prevent CUDA OOM
+    # on long prefill.
+    # Default: 512 MB
+    "VLLM_FLASHMLA_SPARSE_MAX_SCRATCH_MB": lambda: int(
+        os.getenv("VLLM_FLASHMLA_SPARSE_MAX_SCRATCH_MB", "512")
     ),
     # If set, the OpenAI API server will stay alive even after the underlying
     # AsyncLLMEngine errors and stops serving requests

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, ClassVar
 
 import torch
 
-from vllm import envs
 from vllm import _custom_ops as ops
+from vllm import envs
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.config.cache import CacheDType
 from vllm.logger import init_logger

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 import torch
 
+from vllm import envs
 from vllm import _custom_ops as ops
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.config.cache import CacheDType
@@ -59,6 +60,14 @@ logger = init_logger(__name__)
 # so when the per-rank head count is below MIN_HEADS_FOR_BF16_PREFILL we use the mixed
 # batch mode (#1).
 MIN_HEADS_FOR_BF16_PREFILL = 32
+
+# Max tokens the FP8 sparse decode kernel (flash_mla_cuda.sparse_decode_fwd)
+# processes per call in mixed-batch mode.
+# ref. https://github.com/vllm-project/FlashMLA/blob/a8f794d1251cbfd88a5011445dd5582289c727e4/csrc/api/sparse_decode.h#L463-L466
+MAX_SCRATCH_CHUNK_TOKENS = max(
+    1,
+    (envs.VLLM_FLASHMLA_SPARSE_MAX_SCRATCH_MB * 1024 * 1024) // (2 * 64 * 512 * 4),
+)
 
 """
 NOTE: FlashMLA Sparse uses an fp8 cache with the following format
@@ -215,7 +224,12 @@ class FlashMLASparseMetadata(AttentionMetadata):
         decode: Decode | None = None
         prefill: Prefill | None = None
 
-    fp8_extra_metadata: FP8SeparatePrefillDecode | FP8KernelMetadata | None = None
+    fp8_extra_metadata: (
+        FP8SeparatePrefillDecode
+        | FP8KernelMetadata
+        | list[tuple[slice, FP8KernelMetadata]]  # For mixed-batch subchunks
+        | None
+    ) = None
     fp8_use_mixed_batch: bool = False
 
 
@@ -227,6 +241,13 @@ def get_prefill_workspace_size(max_model_len: int):
     #            5 * 163840 * 576 * 2 = ~900 MB
     # This fits nicely below the typical MoE workspace size of >2GB so this is "free"
     return max_model_len * 5
+
+
+def fp8_mixed_batch_chunk_slices(num_tokens: int) -> list[slice]:
+    return [
+        slice(start, min(start + MAX_SCRATCH_CHUNK_TOKENS, num_tokens))
+        for start in range(0, num_tokens, MAX_SCRATCH_CHUNK_TOKENS)
+    ]
 
 
 class FlashMLASparseMetadataBuilder(
@@ -316,7 +337,7 @@ class FlashMLASparseMetadataBuilder(
     def _build_fp8_mixed_decode_prefill(
         self,
         common_attn_metadata: CommonAttentionMetadata,
-    ) -> "FlashMLASparseMetadata.FP8KernelMetadata":
+    ) -> list[tuple[slice, "FlashMLASparseMetadata.FP8KernelMetadata"]]:
         """Build FP8 metadata treating MQA tokens as one batch.
 
         The scheduler initializes lazily from the runtime query shape, which may
@@ -329,22 +350,26 @@ class FlashMLASparseMetadataBuilder(
         padded_heads = self.fp8_decode_padded_heads
 
         # Build metadata for all tokens as a single batch
-        scheduler_metadata, _ = get_mla_metadata(
-            cache_seqlens=self.topk_tokens_tensor[:1],  # Single batch
-            num_q_tokens_per_head_k=num_tokens * padded_heads,
-            topk=self.topk_tokens,
-            num_heads_q=padded_heads,
-            num_heads_k=1,
-            is_fp8_kvcache=True,
-        )
+        chunks = []
+        for token_slice in fp8_mixed_batch_chunk_slices(num_tokens):
+            chunk_num_tokens = token_slice.stop - token_slice.start
+            scheduler_metadata, _ = get_mla_metadata(
+                cache_seqlens=self.topk_tokens_tensor[:1],  # Single batch
+                num_q_tokens_per_head_k=chunk_num_tokens * padded_heads,
+                topk=self.topk_tokens,
+                num_heads_q=padded_heads,
+                num_heads_k=1,
+                is_fp8_kvcache=True,
+            )
 
-        fp8_metadata = FlashMLASparseMetadata.FP8KernelMetadata(
-            scheduler_metadata=scheduler_metadata,
-            cache_lens=self.max_model_len_tensor[:1],
-            dummy_block_table=self.dummy_block_table[:1],
-        )
+            fp8_metadata = FlashMLASparseMetadata.FP8KernelMetadata(
+                scheduler_metadata=scheduler_metadata,
+                cache_lens=self.max_model_len_tensor[:1],
+                dummy_block_table=self.dummy_block_table[:1],
+            )
+            chunks.append((token_slice, fp8_metadata))
 
-        return fp8_metadata
+        return chunks
 
     def _build_fp8_separate_prefill_decode(
         self,
@@ -745,20 +770,23 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         )
 
         assert attn_metadata.fp8_extra_metadata is not None
-        assert isinstance(
-            attn_metadata.fp8_extra_metadata, FlashMLASparseMetadata.FP8KernelMetadata
-        )
-        fp8_metadata = attn_metadata.fp8_extra_metadata
+        assert isinstance(attn_metadata.fp8_extra_metadata, list)
+        attn_out = q.new_empty((*q.shape[:-1], 512))
 
-        _attn_out, _ = self._fp8_flash_mla_kernel(
-            q=q.unsqueeze(0),  # unsqueeze to add batch_dim: (T, H, D) -> (1, T, H, D)
-            kv_c_and_k_pe_cache=kv_c_and_k_pe_cache,
-            topk_indices=topk_indices.unsqueeze(0),  # (T, topk) -> (1, T, topk)
-            kernel_metadata=fp8_metadata,
-        )
+        for token_slice, fp8_metadata in attn_metadata.fp8_extra_metadata:
+            _attn_out, _ = self._fp8_flash_mla_kernel(
+                # unsqueeze to add batch_dim: (T_i, H, D) -> (1, T_i, H, D)
+                q=q[token_slice].unsqueeze(0),
+                kv_c_and_k_pe_cache=kv_c_and_k_pe_cache,
+                # (T_i, topk) -> (1, T_i, topk)
+                topk_indices=topk_indices[token_slice].unsqueeze(0),
+                kernel_metadata=fp8_metadata,
+            )
 
-        # Output is (1, T, H, D_v), squeeze back to (T, H, D_v)
-        return _attn_out.squeeze(0)
+            # Output is (1, T_i, H, D_v), squeeze back to (T_i, H, D_v)
+            attn_out[token_slice] = _attn_out.squeeze(0)
+
+        return attn_out
 
     def _fp8_flash_mla_kernel(
         self,

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -377,6 +377,7 @@ class FlashMLASparseMetadataBuilder(
     def _build_fp8_mixed_decode_prefill(
         self,
         common_attn_metadata: CommonAttentionMetadata,
+        metadata: FlashMLASparseMetadata,
     ) -> list[tuple[slice, "FlashMLASparseMetadata.FP8KernelMetadata"]]:
         """Build FP8 metadata treating MQA tokens as one batch.
 
@@ -384,7 +385,11 @@ class FlashMLASparseMetadataBuilder(
         be the full batch or only decodes when prefills use dense MHA. This avoids
         the BF16 prefill kernel's head-padding overhead at high TP.
         """
-        num_tokens = common_attn_metadata.num_actual_tokens
+        num_tokens = (
+            metadata.num_decode_tokens
+            if bool(getattr(metadata.prefill, "use_dense_mha", False))
+            else common_attn_metadata.num_actual_tokens
+        )
 
         # Use padded head count since that's what the kernel will see
         padded_heads = self.fp8_decode_padded_heads
@@ -565,7 +570,7 @@ class FlashMLASparseMetadataBuilder(
         if self.use_fp8_kv_cache:
             if self.fp8_use_mixed_batch:
                 metadata.fp8_extra_metadata = self._build_fp8_mixed_decode_prefill(
-                    common_attn_metadata
+                    common_attn_metadata, metadata
                 )
             else:
                 metadata.fp8_extra_metadata = self._build_fp8_separate_prefill_decode(

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -384,6 +384,9 @@ class FlashMLASparseMetadataBuilder(
         The scheduler initializes lazily from the runtime query shape, which may
         be the full batch or only decodes when prefills use dense MHA. This avoids
         the BF16 prefill kernel's head-padding overhead at high TP.
+
+        The batch is split into chunks so the kernel's internal o_accum scratch stays
+        bounded regardless of the actual query token count.
         """
         num_tokens = (
             metadata.num_decode_tokens

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -371,10 +371,10 @@ class FlashMLASparseMetadataBuilder(
         self,
         chunk_num_tokens: int,
         padded_heads: int,
-        full_chunk_fp8_metadata: "FlashMLASparseMetadata.FP8KernelMetadata",
+        full_chunk_fp8_metadata: FlashMLASparseMetadata.FP8KernelMetadata | None,
     ) -> tuple[
-        "FlashMLASparseMetadata.FP8KernelMetadata",
-        "FlashMLASparseMetadata.FP8KernelMetadata",
+        FlashMLASparseMetadata.FP8KernelMetadata,
+        FlashMLASparseMetadata.FP8KernelMetadata | None,
     ]:
         is_full_chunk = chunk_num_tokens == MAX_SCRATCH_CHUNK_TOKENS
         if full_chunk_fp8_metadata is not None and is_full_chunk:
@@ -399,7 +399,7 @@ class FlashMLASparseMetadataBuilder(
 
     def _build_fp8_mixed_batch_chunks(
         self, num_tokens: int, padded_heads: int
-    ) -> list[tuple[slice, "FlashMLASparseMetadata.FP8KernelMetadata"]]:
+    ) -> list[tuple[slice, FlashMLASparseMetadata.FP8KernelMetadata]]:
         chunks = []
         full_chunk_fp8_metadata = None
         for start in range(0, num_tokens, MAX_SCRATCH_CHUNK_TOKENS):
@@ -414,7 +414,7 @@ class FlashMLASparseMetadataBuilder(
         self,
         common_attn_metadata: CommonAttentionMetadata,
         metadata: FlashMLASparseMetadata,
-    ) -> list[tuple[slice, "FlashMLASparseMetadata.FP8KernelMetadata"]]:
+    ) -> list[tuple[slice, FlashMLASparseMetadata.FP8KernelMetadata]]:
         """Build FP8 metadata treating MQA tokens as one batch.
 
         The scheduler initializes lazily from the runtime query shape, which may

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -344,6 +344,9 @@ class FlashMLASparseMetadataBuilder(
         The scheduler initializes lazily from the runtime query shape, which may
         be the full batch or only decodes when prefills use dense MHA. This avoids
         the BF16 prefill kernel's head-padding overhead at high TP.
+
+        The batch is split into chunks so the kernel's internal o_accum scratch stays
+        bounded regardless of the actual query token count.
         """
         num_tokens = (
             metadata.num_decode_tokens

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -244,13 +244,6 @@ def get_prefill_workspace_size(max_model_len: int):
     return max_model_len * 5
 
 
-def fp8_mixed_batch_chunk_slices(num_tokens: int) -> list[slice]:
-    return [
-        slice(start, min(start + MAX_SCRATCH_CHUNK_TOKENS, num_tokens))
-        for start in range(0, num_tokens, MAX_SCRATCH_CHUNK_TOKENS)
-    ]
-
-
 class FlashMLASparseMetadataBuilder(
     SparseMLACommonMetadataBuilder[FlashMLASparseMetadata]
 ):
@@ -374,6 +367,49 @@ class FlashMLASparseMetadataBuilder(
                     f"{gathered_padded_heads})"
                 )
 
+    def _build_fp8_kernel_metadata(
+        self,
+        chunk_num_tokens: int,
+        padded_heads: int,
+        full_chunk_fp8_metadata: "FlashMLASparseMetadata.FP8KernelMetadata",
+    ) -> tuple[
+        "FlashMLASparseMetadata.FP8KernelMetadata",
+        "FlashMLASparseMetadata.FP8KernelMetadata",
+    ]:
+        is_full_chunk = chunk_num_tokens == MAX_SCRATCH_CHUNK_TOKENS
+        if full_chunk_fp8_metadata is not None and is_full_chunk:
+            return full_chunk_fp8_metadata, full_chunk_fp8_metadata
+
+        scheduler_metadata, _ = get_mla_metadata(
+            cache_seqlens=self.topk_tokens_tensor[:1],  # Single batch
+            num_q_tokens_per_head_k=chunk_num_tokens * padded_heads,
+            topk=self.topk_tokens,
+            num_heads_q=padded_heads,
+            num_heads_k=1,
+            is_fp8_kvcache=True,
+        )
+        metadata = FlashMLASparseMetadata.FP8KernelMetadata(
+            scheduler_metadata=scheduler_metadata,
+            cache_lens=self.max_model_len_tensor[:1],
+            dummy_block_table=self.dummy_block_table[:1],
+        )
+        if is_full_chunk:
+            full_chunk_fp8_metadata = metadata
+        return metadata, full_chunk_fp8_metadata
+
+    def _build_fp8_mixed_batch_chunks(
+        self, num_tokens: int, padded_heads: int
+    ) -> list[tuple[slice, "FlashMLASparseMetadata.FP8KernelMetadata"]]:
+        chunks = []
+        full_chunk_fp8_metadata = None
+        for start in range(0, num_tokens, MAX_SCRATCH_CHUNK_TOKENS):
+            stop = min(start + MAX_SCRATCH_CHUNK_TOKENS, num_tokens)
+            fp8_metadata, full_chunk_fp8_metadata = self._build_fp8_kernel_metadata(
+                stop - start, padded_heads, full_chunk_fp8_metadata
+            )
+            chunks.append((slice(start, stop), fp8_metadata))
+        return chunks
+
     def _build_fp8_mixed_decode_prefill(
         self,
         common_attn_metadata: CommonAttentionMetadata,
@@ -395,29 +431,9 @@ class FlashMLASparseMetadataBuilder(
         )
 
         # Use padded head count since that's what the kernel will see
-        padded_heads = self.fp8_decode_padded_heads
-
-        # Build metadata for all tokens as a single batch
-        chunks = []
-        for token_slice in fp8_mixed_batch_chunk_slices(num_tokens):
-            chunk_num_tokens = token_slice.stop - token_slice.start
-            scheduler_metadata, _ = get_mla_metadata(
-                cache_seqlens=self.topk_tokens_tensor[:1],  # Single batch
-                num_q_tokens_per_head_k=chunk_num_tokens * padded_heads,
-                topk=self.topk_tokens,
-                num_heads_q=padded_heads,
-                num_heads_k=1,
-                is_fp8_kvcache=True,
-            )
-
-            fp8_metadata = FlashMLASparseMetadata.FP8KernelMetadata(
-                scheduler_metadata=scheduler_metadata,
-                cache_lens=self.max_model_len_tensor[:1],
-                dummy_block_table=self.dummy_block_table[:1],
-            )
-            chunks.append((token_slice, fp8_metadata))
-
-        return chunks
+        return self._build_fp8_mixed_batch_chunks(
+            num_tokens, self.fp8_decode_padded_heads
+        )
 
     def _build_fp8_separate_prefill_decode(
         self,

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -337,6 +337,7 @@ class FlashMLASparseMetadataBuilder(
     def _build_fp8_mixed_decode_prefill(
         self,
         common_attn_metadata: CommonAttentionMetadata,
+        metadata: FlashMLASparseMetadata,
     ) -> list[tuple[slice, "FlashMLASparseMetadata.FP8KernelMetadata"]]:
         """Build FP8 metadata treating MQA tokens as one batch.
 
@@ -344,7 +345,11 @@ class FlashMLASparseMetadataBuilder(
         be the full batch or only decodes when prefills use dense MHA. This avoids
         the BF16 prefill kernel's head-padding overhead at high TP.
         """
-        num_tokens = common_attn_metadata.num_actual_tokens
+        num_tokens = (
+            metadata.num_decode_tokens
+            if bool(getattr(metadata.prefill, "use_dense_mha", False))
+            else common_attn_metadata.num_actual_tokens
+        )
 
         # Use padded head count since that's what the kernel will see
         padded_heads = self.fp8_decode_padded_heads
@@ -526,7 +531,7 @@ class FlashMLASparseMetadataBuilder(
         if self.use_fp8_kv_cache:
             if fp8_use_mixed_batch:
                 metadata.fp8_extra_metadata = self._build_fp8_mixed_decode_prefill(
-                    common_attn_metadata
+                    common_attn_metadata, metadata
                 )
             else:
                 metadata.fp8_extra_metadata = self._build_fp8_separate_prefill_decode(

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 import torch
 
+from vllm import envs
 from vllm import _custom_ops as ops
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.config.cache import CacheDType
@@ -60,6 +61,14 @@ logger = init_logger(__name__)
 # so when the per-rank head count is below MIN_HEADS_FOR_BF16_PREFILL we use the mixed
 # batch mode (#1).
 MIN_HEADS_FOR_BF16_PREFILL = 32
+
+# Max tokens the FP8 sparse decode kernel (flash_mla_cuda.sparse_decode_fwd)
+# processes per call in mixed-batch mode.
+# ref. https://github.com/vllm-project/FlashMLA/blob/a8f794d1251cbfd88a5011445dd5582289c727e4/csrc/api/sparse_decode.h#L463-L466
+MAX_SCRATCH_CHUNK_TOKENS = max(
+    1,
+    (envs.VLLM_FLASHMLA_SPARSE_MAX_SCRATCH_MB * 1024 * 1024) // (2 * 64 * 512 * 4),
+)
 
 """
 NOTE: FlashMLA Sparse uses an fp8 cache with the following format
@@ -216,7 +225,12 @@ class FlashMLASparseMetadata(AttentionMetadata):
         decode: Decode | None = None
         prefill: Prefill | None = None
 
-    fp8_extra_metadata: FP8SeparatePrefillDecode | FP8KernelMetadata | None = None
+    fp8_extra_metadata: (
+        FP8SeparatePrefillDecode
+        | FP8KernelMetadata
+        | list[tuple[slice, FP8KernelMetadata]]  # For mixed-batch subchunks
+        | None
+    ) = None
     fp8_use_mixed_batch: bool = False
 
 
@@ -228,6 +242,13 @@ def get_prefill_workspace_size(max_model_len: int):
     #            5 * 163840 * 576 * 2 = ~900 MB
     # This fits nicely below the typical MoE workspace size of >2GB so this is "free"
     return max_model_len * 5
+
+
+def fp8_mixed_batch_chunk_slices(num_tokens: int) -> list[slice]:
+    return [
+        slice(start, min(start + MAX_SCRATCH_CHUNK_TOKENS, num_tokens))
+        for start in range(0, num_tokens, MAX_SCRATCH_CHUNK_TOKENS)
+    ]
 
 
 class FlashMLASparseMetadataBuilder(
@@ -356,7 +377,7 @@ class FlashMLASparseMetadataBuilder(
     def _build_fp8_mixed_decode_prefill(
         self,
         common_attn_metadata: CommonAttentionMetadata,
-    ) -> "FlashMLASparseMetadata.FP8KernelMetadata":
+    ) -> list[tuple[slice, "FlashMLASparseMetadata.FP8KernelMetadata"]]:
         """Build FP8 metadata treating MQA tokens as one batch.
 
         The scheduler initializes lazily from the runtime query shape, which may
@@ -369,22 +390,26 @@ class FlashMLASparseMetadataBuilder(
         padded_heads = self.fp8_decode_padded_heads
 
         # Build metadata for all tokens as a single batch
-        scheduler_metadata, _ = get_mla_metadata(
-            cache_seqlens=self.topk_tokens_tensor[:1],  # Single batch
-            num_q_tokens_per_head_k=num_tokens * padded_heads,
-            topk=self.topk_tokens,
-            num_heads_q=padded_heads,
-            num_heads_k=1,
-            is_fp8_kvcache=True,
-        )
+        chunks = []
+        for token_slice in fp8_mixed_batch_chunk_slices(num_tokens):
+            chunk_num_tokens = token_slice.stop - token_slice.start
+            scheduler_metadata, _ = get_mla_metadata(
+                cache_seqlens=self.topk_tokens_tensor[:1],  # Single batch
+                num_q_tokens_per_head_k=chunk_num_tokens * padded_heads,
+                topk=self.topk_tokens,
+                num_heads_q=padded_heads,
+                num_heads_k=1,
+                is_fp8_kvcache=True,
+            )
 
-        fp8_metadata = FlashMLASparseMetadata.FP8KernelMetadata(
-            scheduler_metadata=scheduler_metadata,
-            cache_lens=self.max_model_len_tensor[:1],
-            dummy_block_table=self.dummy_block_table[:1],
-        )
+            fp8_metadata = FlashMLASparseMetadata.FP8KernelMetadata(
+                scheduler_metadata=scheduler_metadata,
+                cache_lens=self.max_model_len_tensor[:1],
+                dummy_block_table=self.dummy_block_table[:1],
+            )
+            chunks.append((token_slice, fp8_metadata))
 
-        return fp8_metadata
+        return chunks
 
     def _build_fp8_separate_prefill_decode(
         self,
@@ -814,22 +839,27 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
             )
 
         assert attn_metadata.fp8_extra_metadata is not None
-        assert isinstance(
-            attn_metadata.fp8_extra_metadata, FlashMLASparseMetadata.FP8KernelMetadata
-        )
-        fp8_metadata = attn_metadata.fp8_extra_metadata
+        assert isinstance(attn_metadata.fp8_extra_metadata, list)
+        out = q.new_empty((*q.shape[:-1], 512))
+        lse = q.new_empty(q.shape[:-1]) if self.need_to_return_lse_for_decode else None
 
-        _attn_out, _lse = self._fp8_flash_mla_kernel(
-            q=q.unsqueeze(0),  # unsqueeze to add batch_dim: (T, H, D) -> (1, T, H, D)
-            kv_c_and_k_pe_cache=kv_c_and_k_pe_cache,
-            topk_indices=topk_indices.unsqueeze(0),  # (T, topk) -> (1, T, topk)
-            kernel_metadata=fp8_metadata,
-        )
-        # Output is (1, T, H, D_v), squeeze back to (T, H, D_v)
-        out = _attn_out.squeeze(0)
+        for token_slice, fp8_metadata in attn_metadata.fp8_extra_metadata:
+            _attn_out, _lse = self._fp8_flash_mla_kernel(
+                # unsqueeze to add batch_dim: (T_i, H, D) -> (1, T_i, H, D)
+                q=q[token_slice].unsqueeze(0),
+                kv_c_and_k_pe_cache=kv_c_and_k_pe_cache,
+                # (T_i, topk) -> (1, T_i, topk)
+                topk_indices=topk_indices[token_slice].unsqueeze(0),
+                kernel_metadata=fp8_metadata,
+            )
+
+            # Output is (1, T_i, H, D_v), squeeze back to (T_i, H, D_v)
+            out[token_slice] = _attn_out.squeeze(0)
+            if self.need_to_return_lse_for_decode:
+                lse[token_slice] = _lse.squeeze(0).transpose(0, 1)
 
         if not self.need_to_return_lse_for_decode:
-            return out, None
+            return out, lse
 
         # Kernel LSE is (1, H, T); the DCP merge consumes (T, H).
         lse = _lse.squeeze(0).transpose(0, 1)

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -863,7 +863,7 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
 
             # Output is (1, T_i, H, D_v), squeeze back to (T_i, H, D_v)
             out[token_slice] = _attn_out.squeeze(0)
-            if self.need_to_return_lse_for_decode:
+            if lse is not None:
                 lse[token_slice] = _lse.squeeze(0).transpose(0, 1)
 
         if not self.need_to_return_lse_for_decode:


### PR DESCRIPTION



## Purpose

Fix #44545 - not in an ideal way though.

When FlashMLA sparse kernel is selected with FP8 KV cache dtype, FlashMLA sparse decode kernel(https://github.com/vllm-project/FlashMLA/blob/a8f794d1251cbfd88a5011445dd5582289c727e4/csrc/api/sparse_decode.h#L184) is called in mixed batch mode. This kernel internally allocates intermediate tensors (`o_accum`) on call, which quickly dominates the usual unallocated workspace size (~2GB per the comment in `flashmla_sparse.py`) for long prefill:

For 32k input on H200, the bytesize of `o_accum` is

```
# b = 1
# num_sm_parts = 1
# s_q = 32768
# h_q = 64
# d_v = 512
(b + num_sm_parts) * s_q * h_q * d_v * 4 bytes = 8 GiB
```

For BF16 KV cache, a different kernel (FlashMLA sparse prefill kernel - https://github.com/vllm-project/FlashMLA/blob/a8f794d1251cbfd88a5011445dd5582289c727e4/csrc/api/sparse_fwd.h#L101) is called, which does not allocate a massive VRAM on kernel call and thus does not suffer an OOM contrary to the FP8 code branch. (Note the additional `d_v` factor in the formular for `o_accum`, no other scratch tensors in FlashMLA have this factor thus negligible in terms of VRAM occupancy)

Hence we chunk the mixed-batch input into manageable bytes (`VLLM_FLASHMLA_SPARSE_MAX_SCRATCH_MB`) and loop over the chunks to aggregate the output attention tensor, which is in the same spirit as the indexer budget management logic in #36178.

Due to the mechanism (looping the kernel over sub-chunks instead of single big shot), it may incur a throughput penalty as a tradeoff, but I have no better idea yet.

As the context window for MLA model families keep growing, FP8 KV cache is kind of inevitable, so I think this PR can work as a bandaid.

## Test Plan

No OOM for the reproducer in #44545

## Test Result

pass

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

