### PR TITLE
[Attention][MiniMax-M3] Add opt-in FlashInfer TRTLLM-GEN sparse decode

### DIFF
--- a/tests/kernels/attention/test_minimax_m3_flashinfer_sparse_decode.py
+++ b/tests/kernels/attention/test_minimax_m3_flashinfer_sparse_decode.py
@@ -27,10 +27,9 @@ SM_SCALE = HEAD_DIM**-0.5
 
 
 def _build_decode_inputs(
-    seq_lens_list: tuple[int, ...], kv_layout: str, decode_query_len: int = 1
+    seq_lens_list: tuple[int, ...], kv_layout: str
 ) -> tuple[torch.Tensor, ...]:
     batch = len(seq_lens_list)
-    num_query_tokens = batch * decode_query_len
     pages_per_req = [
         (seq_len + PAGE_SIZE - 1) // PAGE_SIZE for seq_len in seq_lens_list
     ]
@@ -54,30 +53,27 @@ def _build_decode_inputs(
     seq_lens.copy_(torch.tensor(seq_lens_list, device="cuda", dtype=torch.int32))
 
     topk_storage = torch.full(
-        (num_query_tokens, NUM_KV_HEADS, TOPK),
+        (batch, NUM_KV_HEADS, TOPK),
         -1,
         device="cuda",
         dtype=torch.int32,
     )
     topk = topk_storage.transpose(0, 1)
-    for request, request_seq_len in enumerate(seq_lens_list):
-        for local_q in range(decode_query_len):
-            seq_len = request_seq_len - decode_query_len + local_q + 1
-            if seq_len <= 0:
-                continue
-            tail_page = (seq_len - 1) // PAGE_SIZE
-            older_pages = torch.randperm(tail_page, device="cuda", dtype=torch.int32)[
-                : TOPK - 1
-            ]
-            selected = torch.cat(
-                (
-                    older_pages,
-                    torch.tensor([tail_page], device="cuda", dtype=torch.int32),
-                )
+    for request, request_pages in enumerate(pages_per_req):
+        if request_pages == 0:
+            continue
+        tail_page = request_pages - 1
+        older_pages = torch.randperm(tail_page, device="cuda", dtype=torch.int32)[
+            : TOPK - 1
+        ]
+        selected = torch.cat(
+            (
+                older_pages,
+                torch.tensor([tail_page], device="cuda", dtype=torch.int32),
             )
-            selected = selected[torch.randperm(selected.numel(), device="cuda")]
-            token = request * decode_query_len + local_q
-            topk[:, token, : selected.numel()] = selected
+        )
+        selected = selected[torch.randperm(selected.numel(), device="cuda")]
+        topk[:, request, : selected.numel()] = selected
 
     physical_shape = (
         (num_pages, NUM_KV_HEADS, PAGE_SIZE, 2 * HEAD_DIM)
@@ -91,9 +87,7 @@ def _build_decode_inputs(
     )
     kv_cache = physical_kv if kv_layout == "HND" else physical_kv.permute(0, 2, 1, 3)
     query = torch.randn(
-        (num_query_tokens, NUM_Q_HEADS, HEAD_DIM),
-        device="cuda",
-        dtype=torch.bfloat16,
+        (batch, NUM_Q_HEADS, HEAD_DIM), device="cuda", dtype=torch.bfloat16
     )
     return query, kv_cache, topk, block_table, seq_lens
 
@@ -105,9 +99,8 @@ def _launch_metadata_adapter(
     *,
     num_physical_pages: int,
     k_scale: torch.Tensor,
-    decode_query_len: int = 1,
 ) -> tuple[torch.Tensor, ...]:
-    batch = topk.shape[1]
+    batch = seq_lens.shape[0]
     physical_pages = torch.empty(
         (NUM_KV_HEADS, batch, TOPK), device="cuda", dtype=torch.int32
     )
@@ -128,7 +121,6 @@ def _launch_metadata_adapter(
         metadata_status,
         bmm1_scale_log2,
         batch,
-        decode_query_len,
         block_table.shape[1],
         num_physical_pages,
         topk.stride(0),
@@ -210,32 +202,6 @@ def test_metadata_adapter_honors_strides_deduplicates_and_handles_padding():
         bmm1_scale_log2,
         k_scale * SM_SCALE * torch.log2(torch.tensor(torch.e, device="cuda")),
     )
-
-
-def test_metadata_adapter_maps_speculative_tokens_to_requests():
-    decode_query_len = 4
-    _, kv_cache, topk, block_table, seq_lens = _build_decode_inputs(
-        (130, 257, 0), "HND", decode_query_len
-    )
-    k_scale = torch.tensor([0.75], device="cuda", dtype=torch.float32)
-
-    _, sparse_lens, metadata_ok, status, _ = _launch_metadata_adapter(
-        topk,
-        block_table,
-        seq_lens,
-        num_physical_pages=kv_cache.shape[0],
-        k_scale=k_scale,
-        decode_query_len=decode_query_len,
-    )
-
-    expected_lens = torch.tensor(
-        [[127, 128, 129, 130, 254, 255, 256, 257, 0, 0, 0, 0]] * NUM_KV_HEADS,
-        device="cuda",
-        dtype=torch.int32,
-    )
-    assert torch.equal(sparse_lens, expected_lens)
-    assert torch.equal(metadata_ok, torch.ones_like(metadata_ok))
-    assert status.item() == 1
 
 
 def test_buffer_pool_uses_geometric_capacity_and_retains_graph_allocations():
@@ -331,13 +297,11 @@ def test_unavailable_api_falls_back_before_allocating(monkeypatch: pytest.Monkey
     assert runner._buffer_pools_by_device == {}
 
 
-@pytest.mark.parametrize("decode_query_len", [1, 4])
 def test_adapter_passes_padding_scales_and_reuses_buffers(
-    decode_query_len: int,
     monkeypatch: pytest.MonkeyPatch,
 ):
     query, kv_cache, topk, block_table, seq_lens = _build_decode_inputs(
-        (257, 130, 0), "NHD", decode_query_len
+        (257, 130, 0), "NHD"
     )
     output = torch.empty_like(query)
     k_scale = torch.tensor([0.75], device="cuda", dtype=torch.float32)
@@ -356,7 +320,6 @@ def test_adapter_passes_padding_scales_and_reuses_buffers(
             }
         )
         assert kwargs["enable_block_sparse_attention"]
-        assert kwargs["q_len_per_req"] == 1
         kwargs["out"].copy_(kwargs["query"])
 
     def counter_size(batch: int, num_heads: int, sm_count: int) -> int:
@@ -387,7 +350,7 @@ def test_adapter_passes_padding_scales_and_reuses_buffers(
             scale=SM_SCALE,
             block_size=PAGE_SIZE,
             topk_blocks=TOPK,
-            decode_query_len=decode_query_len,
+            decode_query_len=1,
             k_scale=k_scale,
             v_scale=v_scale,
         )
@@ -402,19 +365,13 @@ def test_adapter_passes_padding_scales_and_reuses_buffers(
     )
     assert calls[0]["physical_ptr"] == calls[1]["physical_ptr"]
     assert calls[0]["counter_ptr"] == calls[1]["counter_ptr"]
-    expected_capacity = 1 << (query.shape[0] - 1).bit_length()
-    assert pool.current is not None and pool.current.capacity == expected_capacity
+    assert pool.current is not None and pool.current.capacity == 4
     assert pool.retired == []
     torch.testing.assert_close(output, query)
 
 
-@pytest.mark.parametrize("decode_query_len", [1, 4])
-def test_adapter_is_cudagraph_replayable(
-    decode_query_len: int, monkeypatch: pytest.MonkeyPatch
-):
-    query, kv_cache, topk, block_table, seq_lens = _build_decode_inputs(
-        (257,), "HND", decode_query_len
-    )
+def test_adapter_is_cudagraph_replayable(monkeypatch: pytest.MonkeyPatch):
+    query, kv_cache, topk, block_table, seq_lens = _build_decode_inputs((257,), "HND")
     output = torch.empty_like(query)
 
     def run(**kwargs) -> None:
@@ -448,7 +405,7 @@ def test_adapter_is_cudagraph_replayable(
             scale=SM_SCALE,
             block_size=PAGE_SIZE,
             topk_blocks=TOPK,
-            decode_query_len=decode_query_len,
+            decode_query_len=1,
         )
     torch.accelerator.synchronize()
 
@@ -465,7 +422,7 @@ def test_adapter_is_cudagraph_replayable(
             scale=SM_SCALE,
             block_size=PAGE_SIZE,
             topk_blocks=TOPK,
-            decode_query_len=decode_query_len,
+            decode_query_len=1,
         )
 
     query.fill_(0.25)
@@ -493,25 +450,19 @@ def _require_real_flashinfer_sparse_decode() -> None:
 
 
 @pytest.mark.parametrize(
-    ("kv_layout", "batch", "seq_len", "decode_query_len"),
-    [
-        ("NHD", 32, 1000, 1),
-        ("HND", 1, 8191, 1),
-        ("NHD", 4, 257, 4),
-        ("HND", 2, 130, 2),
-    ],
+    ("kv_layout", "batch", "seq_len"),
+    [("NHD", 32, 1000), ("HND", 1, 8191)],
 )
 def test_real_flashinfer_sparse_decode_matches_triton_and_reuses_buffers(
     kv_layout: str,
     batch: int,
     seq_len: int,
-    decode_query_len: int,
     monkeypatch: pytest.MonkeyPatch,
 ):
     _require_real_flashinfer_sparse_decode()
     torch.manual_seed(0)
     query, kv_cache, topk, block_table, seq_lens = _build_decode_inputs(
-        (seq_len,) * batch, kv_layout, decode_query_len
+        (seq_len,) * batch, kv_layout
     )
     # The Triton oracle's page-table kernel assumes contiguous inner metadata.
     block_table = block_table.contiguous()
@@ -529,7 +480,7 @@ def test_real_flashinfer_sparse_decode_matches_triton_and_reuses_buffers(
         NUM_KV_HEADS,
         SM_SCALE,
         expected,
-        decode_query_len,
+        1,
         k_scale=k_scale,
         v_scale=v_scale,
     )
@@ -552,7 +503,7 @@ def test_real_flashinfer_sparse_decode_matches_triton_and_reuses_buffers(
             scale=SM_SCALE,
             block_size=PAGE_SIZE,
             topk_blocks=TOPK,
-            decode_query_len=decode_query_len,
+            decode_query_len=1,
             k_scale=k_scale,
             v_scale=v_scale,
         )
@@ -562,6 +513,5 @@ def test_real_flashinfer_sparse_decode_matches_triton_and_reuses_buffers(
     assert len(runner._buffer_pools_by_device) == 1
     pool = next(iter(runner._buffer_pools_by_device.values()))
     assert pool.current is not None
-    expected_capacity = 1 << (query.shape[0] - 1).bit_length()
-    assert pool.current.capacity == expected_capacity
+    assert pool.current.capacity == 1 << (batch - 1).bit_length()
     assert pool.retired == []

--- a/tests/kernels/attention/test_minimax_m3_flashinfer_sparse_decode.py
+++ b/tests/kernels/attention/test_minimax_m3_flashinfer_sparse_decode.py
@@ -1,0 +1,517 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the opt-in MiniMax M3 FlashInfer sparse decode adapter."""
+
+import inspect
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+if not current_platform.is_cuda():
+    pytest.skip(
+        "MiniMax M3 FlashInfer sparse decode requires CUDA.",
+        allow_module_level=True,
+    )
+
+from vllm.models.minimax_m3.common.ops.sparse_attn import minimax_m3_sparse_attn_decode
+from vllm.models.minimax_m3.nvidia import flashinfer_sparse_decode as flashinfer_sparse
+
+NUM_Q_HEADS = 64
+NUM_KV_HEADS = 4
+HEAD_DIM = 128
+PAGE_SIZE = 128
+TOPK = 16
+SM_SCALE = HEAD_DIM**-0.5
+
+
+def _build_decode_inputs(
+    seq_lens_list: tuple[int, ...], kv_layout: str
+) -> tuple[torch.Tensor, ...]:
+    batch = len(seq_lens_list)
+    pages_per_req = [
+        (seq_len + PAGE_SIZE - 1) // PAGE_SIZE for seq_len in seq_lens_list
+    ]
+    max_pages = max(pages_per_req)
+    num_pages = sum(pages_per_req)
+
+    physical_page_ids = torch.randperm(num_pages, device="cuda", dtype=torch.int32)
+    block_table_storage = torch.zeros(
+        (batch, max_pages * 2), device="cuda", dtype=torch.int32
+    )
+    block_table = block_table_storage[:, ::2]
+    page_offset = 0
+    for request, request_pages in enumerate(pages_per_req):
+        block_table[request, :request_pages] = physical_page_ids[
+            page_offset : page_offset + request_pages
+        ]
+        page_offset += request_pages
+
+    seq_lens_storage = torch.full((batch * 2,), -1, device="cuda", dtype=torch.int32)
+    seq_lens = seq_lens_storage[::2]
+    seq_lens.copy_(torch.tensor(seq_lens_list, device="cuda", dtype=torch.int32))
+
+    topk_storage = torch.full(
+        (batch, NUM_KV_HEADS, TOPK),
+        -1,
+        device="cuda",
+        dtype=torch.int32,
+    )
+    topk = topk_storage.transpose(0, 1)
+    for request, request_pages in enumerate(pages_per_req):
+        if request_pages == 0:
+            continue
+        tail_page = request_pages - 1
+        older_pages = torch.randperm(tail_page, device="cuda", dtype=torch.int32)[
+            : TOPK - 1
+        ]
+        selected = torch.cat(
+            (
+                older_pages,
+                torch.tensor([tail_page], device="cuda", dtype=torch.int32),
+            )
+        )
+        selected = selected[torch.randperm(selected.numel(), device="cuda")]
+        topk[:, request, : selected.numel()] = selected
+
+    physical_shape = (
+        (num_pages, NUM_KV_HEADS, PAGE_SIZE, 2 * HEAD_DIM)
+        if kv_layout == "HND"
+        else (num_pages, PAGE_SIZE, NUM_KV_HEADS, 2 * HEAD_DIM)
+    )
+    physical_kv = (
+        torch.randn(physical_shape, device="cuda", dtype=torch.bfloat16)
+        .mul_(0.5)
+        .to(torch.float8_e4m3fn)
+    )
+    kv_cache = physical_kv if kv_layout == "HND" else physical_kv.permute(0, 2, 1, 3)
+    query = torch.randn(
+        (batch, NUM_Q_HEADS, HEAD_DIM), device="cuda", dtype=torch.bfloat16
+    )
+    return query, kv_cache, topk, block_table, seq_lens
+
+
+def _launch_metadata_adapter(
+    topk: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    *,
+    num_physical_pages: int,
+    k_scale: torch.Tensor,
+) -> tuple[torch.Tensor, ...]:
+    batch = seq_lens.shape[0]
+    physical_pages = torch.empty(
+        (NUM_KV_HEADS, batch, TOPK), device="cuda", dtype=torch.int32
+    )
+    sparse_seq_lens = torch.empty(
+        (NUM_KV_HEADS, batch), device="cuda", dtype=torch.int32
+    )
+    metadata_ok = torch.empty_like(sparse_seq_lens)
+    metadata_status = torch.ones(1, device="cuda", dtype=torch.int32)
+    bmm1_scale_log2 = torch.empty(1, device="cuda", dtype=torch.float32)
+    flashinfer_sparse._prepare_sparse_metadata_kernel[(NUM_KV_HEADS * batch,)](
+        topk,
+        block_table,
+        seq_lens,
+        k_scale,
+        physical_pages,
+        sparse_seq_lens,
+        metadata_ok,
+        metadata_status,
+        bmm1_scale_log2,
+        batch,
+        block_table.shape[1],
+        num_physical_pages,
+        topk.stride(0),
+        topk.stride(1),
+        topk.stride(2),
+        block_table.stride(0),
+        block_table.stride(1),
+        seq_lens.stride(0),
+        physical_pages.stride(0),
+        physical_pages.stride(1),
+        physical_pages.stride(2),
+        sparse_seq_lens.stride(0),
+        sparse_seq_lens.stride(1),
+        TOPK_SIZE=TOPK,
+        PAGE_SIZE_VALUE=PAGE_SIZE,
+        HAS_KV_SCALE=True,
+        SM_SCALE_LOG2=SM_SCALE * torch.log2(torch.tensor(torch.e)).item(),
+    )
+    torch.accelerator.synchronize()
+    return (
+        physical_pages,
+        sparse_seq_lens,
+        metadata_ok,
+        metadata_status,
+        bmm1_scale_log2,
+    )
+
+
+def test_metadata_adapter_honors_strides_deduplicates_and_handles_padding():
+    block_table_storage = torch.full((3, 8), -1, device="cuda", dtype=torch.int32)
+    block_table = block_table_storage[:, ::2]
+    block_table.copy_(
+        torch.tensor(
+            [[7, 5, 11, 0], [13, 17, 19, 0], [0, 0, 0, 0]],
+            device="cuda",
+            dtype=torch.int32,
+        )
+    )
+    seq_lens_storage = torch.full((6,), -1, device="cuda", dtype=torch.int32)
+    seq_lens = seq_lens_storage[::2]
+    seq_lens.copy_(torch.tensor([257, 130, 0], device="cuda", dtype=torch.int32))
+
+    topk_storage = torch.full(
+        (3, NUM_KV_HEADS, TOPK), -1, device="cuda", dtype=torch.int32
+    )
+    topk = topk_storage.transpose(0, 1)
+    topk[:, 0, :4] = torch.tensor([2, 0, 2, 1], device="cuda", dtype=torch.int32)
+    topk[:, 1, :2] = torch.tensor([1, 0], device="cuda", dtype=torch.int32)
+    k_scale = torch.tensor([0.75], device="cuda", dtype=torch.float32)
+
+    physical, sparse_lens, metadata_ok, status, bmm1_scale_log2 = (
+        _launch_metadata_adapter(
+            topk,
+            block_table,
+            seq_lens,
+            num_physical_pages=20,
+            k_scale=k_scale,
+        )
+    )
+
+    expected_physical = torch.zeros_like(physical)
+    expected_physical[:, 0, :3] = torch.tensor(
+        [7, 5, 11], device="cuda", dtype=torch.int32
+    )
+    expected_physical[:, 1, :2] = torch.tensor(
+        [13, 17], device="cuda", dtype=torch.int32
+    )
+    expected_lens = torch.tensor(
+        [[257, 130, 0]] * NUM_KV_HEADS, device="cuda", dtype=torch.int32
+    )
+    assert block_table.stride(1) == 2
+    assert seq_lens.stride(0) == 2
+    assert not topk.is_contiguous()
+    assert torch.equal(physical, expected_physical)
+    assert torch.equal(sparse_lens, expected_lens)
+    assert torch.equal(metadata_ok, torch.ones_like(metadata_ok))
+    assert status.item() == 1
+    torch.testing.assert_close(
+        bmm1_scale_log2,
+        k_scale * SM_SCALE * torch.log2(torch.tensor(torch.e, device="cuda")),
+    )
+
+
+def test_buffer_pool_uses_geometric_capacity_and_retains_graph_allocations():
+    pool = flashinfer_sparse._DeviceBufferPool(
+        torch.device("cuda"), torch.empty(1024, device="cuda", dtype=torch.uint8)
+    )
+
+    def counter_size(batch: int, num_heads: int, sm_count: int) -> int:
+        assert num_heads == NUM_Q_HEADS
+        assert sm_count > 0
+        return batch * 17
+
+    batch_three = pool.get(3, counter_size)
+    assert pool.current is not None
+    assert pool.current.capacity == 4
+    first_storage = batch_three.physical_pages.untyped_storage().data_ptr()
+    assert batch_three.physical_pages.shape == (NUM_KV_HEADS, 3, TOPK)
+    assert batch_three.physical_pages.is_contiguous()
+    assert batch_three.counter.numel() == 4 * 17
+
+    batch_four = pool.get(4, counter_size)
+    assert batch_four.physical_pages.untyped_storage().data_ptr() == first_storage
+    assert pool.retired == []
+
+    batch_five = pool.get(5, counter_size)
+    assert pool.current.capacity == 8
+    assert len(pool.retired) == 1
+    assert pool.retired[0].capacity == 4
+    assert batch_five.physical_pages.untyped_storage().data_ptr() != first_storage
+    assert batch_five.counter.numel() == 8 * 17
+
+
+def test_static_guard_rejects_non_cuda_before_querying_capability(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    query = torch.empty((1, NUM_Q_HEADS, HEAD_DIM), dtype=torch.bfloat16)
+    output = torch.empty_like(query)
+    kv_cache = torch.empty(
+        (1, NUM_KV_HEADS, PAGE_SIZE, 2 * HEAD_DIM), dtype=torch.float8_e4m3fn
+    )
+    topk = torch.zeros((NUM_KV_HEADS, 1, TOPK), dtype=torch.int32)
+    block_table = torch.zeros((1, 1), dtype=torch.int32)
+    seq_lens = torch.ones(1, dtype=torch.int32)
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_capability",
+        lambda _device: pytest.fail("capability queried for a CPU tensor"),
+    )
+
+    reason = flashinfer_sparse._static_fallback_reason(
+        query,
+        kv_cache,
+        topk,
+        block_table,
+        seq_lens,
+        output,
+        NUM_KV_HEADS,
+        PAGE_SIZE,
+        TOPK,
+        1,
+        None,
+        None,
+    )
+    assert reason == "query is not on CUDA"
+
+
+def test_unavailable_api_falls_back_before_allocating(monkeypatch: pytest.MonkeyPatch):
+    query, kv_cache, topk, block_table, seq_lens = _build_decode_inputs((129,), "HND")
+    output = torch.empty_like(query)
+    monkeypatch.setenv(
+        flashinfer_sparse._BACKEND_ENV, flashinfer_sparse._FLASHINFER_BACKEND
+    )
+    monkeypatch.setattr(
+        flashinfer_sparse, "_static_fallback_reason", lambda *args: None
+    )
+    monkeypatch.setattr(flashinfer_sparse, "_load_api", lambda: None)
+    runner = flashinfer_sparse.FlashInferSparseDecodeRunner()
+
+    used = runner.try_decode(
+        query,
+        kv_cache,
+        topk,
+        block_table,
+        seq_lens,
+        output,
+        num_kv_heads=NUM_KV_HEADS,
+        scale=SM_SCALE,
+        block_size=PAGE_SIZE,
+        topk_blocks=TOPK,
+        decode_query_len=1,
+    )
+    assert not used
+    assert runner._buffer_pools_by_device == {}
+
+
+def test_adapter_passes_padding_scales_and_reuses_buffers(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    query, kv_cache, topk, block_table, seq_lens = _build_decode_inputs(
+        (257, 130, 0), "NHD"
+    )
+    output = torch.empty_like(query)
+    k_scale = torch.tensor([0.75], device="cuda", dtype=torch.float32)
+    v_scale = torch.tensor([0.5], device="cuda", dtype=torch.float32)
+    calls: list[dict] = []
+
+    def run(**kwargs) -> None:
+        calls.append(
+            {
+                "block_tables": kwargs["block_tables"].clone(),
+                "seq_lens": kwargs["seq_lens"].clone(),
+                "bmm1_scale_log2": kwargs["bmm1_scale_log2"].clone(),
+                "bmm2_scale": kwargs["bmm2_scale"],
+                "physical_ptr": kwargs["block_tables"].untyped_storage().data_ptr(),
+                "counter_ptr": kwargs["multi_ctas_kv_counter_buffer"].data_ptr(),
+            }
+        )
+        assert kwargs["enable_block_sparse_attention"]
+        kwargs["out"].copy_(kwargs["query"])
+
+    def counter_size(batch: int, num_heads: int, sm_count: int) -> int:
+        return batch * num_heads + sm_count
+
+    pool = flashinfer_sparse._DeviceBufferPool(
+        query.device, torch.empty(4096, device="cuda", dtype=torch.uint8)
+    )
+    runner = flashinfer_sparse.FlashInferSparseDecodeRunner()
+    runner._buffer_pools_by_device[query.device] = pool
+    monkeypatch.setenv(
+        flashinfer_sparse._BACKEND_ENV, flashinfer_sparse._FLASHINFER_BACKEND
+    )
+    monkeypatch.setattr(
+        flashinfer_sparse, "_static_fallback_reason", lambda *args: None
+    )
+    monkeypatch.setattr(flashinfer_sparse, "_load_api", lambda: (run, counter_size))
+
+    for _ in range(2):
+        assert runner.try_decode(
+            query,
+            kv_cache,
+            topk,
+            block_table,
+            seq_lens,
+            output,
+            num_kv_heads=NUM_KV_HEADS,
+            scale=SM_SCALE,
+            block_size=PAGE_SIZE,
+            topk_blocks=TOPK,
+            decode_query_len=1,
+            k_scale=k_scale,
+            v_scale=v_scale,
+        )
+    torch.accelerator.synchronize()
+
+    assert len(calls) == 2
+    assert calls[0]["seq_lens"][:, -1].eq(0).all()
+    assert calls[0]["bmm2_scale"] is v_scale
+    torch.testing.assert_close(
+        calls[0]["bmm1_scale_log2"],
+        k_scale * SM_SCALE * torch.log2(torch.tensor(torch.e, device="cuda")),
+    )
+    assert calls[0]["physical_ptr"] == calls[1]["physical_ptr"]
+    assert calls[0]["counter_ptr"] == calls[1]["counter_ptr"]
+    assert pool.current is not None and pool.current.capacity == 4
+    assert pool.retired == []
+    torch.testing.assert_close(output, query)
+
+
+def test_adapter_is_cudagraph_replayable(monkeypatch: pytest.MonkeyPatch):
+    query, kv_cache, topk, block_table, seq_lens = _build_decode_inputs((257,), "HND")
+    output = torch.empty_like(query)
+
+    def run(**kwargs) -> None:
+        kwargs["out"].copy_(kwargs["query"])
+
+    def counter_size(batch: int, num_heads: int, sm_count: int) -> int:
+        return batch * num_heads + sm_count
+
+    pool = flashinfer_sparse._DeviceBufferPool(
+        query.device, torch.empty(4096, device="cuda", dtype=torch.uint8)
+    )
+    runner = flashinfer_sparse.FlashInferSparseDecodeRunner()
+    runner._buffer_pools_by_device[query.device] = pool
+    monkeypatch.setenv(
+        flashinfer_sparse._BACKEND_ENV, flashinfer_sparse._FLASHINFER_BACKEND
+    )
+    monkeypatch.setattr(
+        flashinfer_sparse, "_static_fallback_reason", lambda *args: None
+    )
+    monkeypatch.setattr(flashinfer_sparse, "_load_api", lambda: (run, counter_size))
+
+    for _ in range(2):
+        assert runner.try_decode(
+            query,
+            kv_cache,
+            topk,
+            block_table,
+            seq_lens,
+            output,
+            num_kv_heads=NUM_KV_HEADS,
+            scale=SM_SCALE,
+            block_size=PAGE_SIZE,
+            topk_blocks=TOPK,
+            decode_query_len=1,
+        )
+    torch.accelerator.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        assert runner.try_decode(
+            query,
+            kv_cache,
+            topk,
+            block_table,
+            seq_lens,
+            output,
+            num_kv_heads=NUM_KV_HEADS,
+            scale=SM_SCALE,
+            block_size=PAGE_SIZE,
+            topk_blocks=TOPK,
+            decode_query_len=1,
+        )
+
+    query.fill_(0.25)
+    graph.replay()
+    torch.accelerator.synchronize()
+    torch.testing.assert_close(output, query)
+
+
+def _require_real_flashinfer_sparse_decode() -> None:
+    capability = torch.cuda.get_device_capability()
+    if capability not in ((10, 0), (10, 3)):
+        pytest.skip("FlashInfer TRTLLM-GEN sparse decode requires SM100 or SM103")
+    try:
+        from flashinfer.decode import trtllm_batch_decode_with_kv_cache
+        from flashinfer.utils import (
+            get_trtllm_gen_multi_ctas_kv_counter_bytes as _counter_size,
+        )
+    except Exception as error:
+        pytest.skip(f"FlashInfer sparse decode API is unavailable: {error}")
+    parameters = inspect.signature(trtllm_batch_decode_with_kv_cache).parameters
+    assert callable(_counter_size)
+    missing = flashinfer_sparse._REQUIRED_DECODE_PARAMETERS.difference(parameters)
+    if missing:
+        pytest.skip(f"FlashInfer sparse decode API lacks {sorted(missing)}")
+
+
+@pytest.mark.parametrize(
+    ("kv_layout", "batch", "seq_len"),
+    [("NHD", 32, 1000), ("HND", 1, 8191)],
+)
+def test_real_flashinfer_sparse_decode_matches_triton_and_reuses_buffers(
+    kv_layout: str,
+    batch: int,
+    seq_len: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _require_real_flashinfer_sparse_decode()
+    torch.manual_seed(0)
+    query, kv_cache, topk, block_table, seq_lens = _build_decode_inputs(
+        (seq_len,) * batch, kv_layout
+    )
+    # The Triton oracle's page-table kernel assumes contiguous inner metadata.
+    block_table = block_table.contiguous()
+    seq_lens = seq_lens.contiguous()
+    k_scale = torch.tensor([0.75], device="cuda", dtype=torch.float32)
+    v_scale = torch.tensor([0.5], device="cuda", dtype=torch.float32)
+    expected = torch.empty_like(query)
+    actual = torch.empty_like(query)
+    minimax_m3_sparse_attn_decode(
+        query,
+        kv_cache,
+        topk,
+        block_table,
+        seq_lens,
+        NUM_KV_HEADS,
+        SM_SCALE,
+        expected,
+        1,
+        k_scale=k_scale,
+        v_scale=v_scale,
+    )
+
+    monkeypatch.setenv(
+        flashinfer_sparse._BACKEND_ENV, flashinfer_sparse._FLASHINFER_BACKEND
+    )
+    monkeypatch.setattr(flashinfer_sparse, "_api", None)
+    monkeypatch.setattr(flashinfer_sparse, "_api_checked", False)
+    runner = flashinfer_sparse.FlashInferSparseDecodeRunner()
+    for _ in range(2):
+        assert runner.try_decode(
+            query,
+            kv_cache,
+            topk,
+            block_table,
+            seq_lens,
+            actual,
+            num_kv_heads=NUM_KV_HEADS,
+            scale=SM_SCALE,
+            block_size=PAGE_SIZE,
+            topk_blocks=TOPK,
+            decode_query_len=1,
+            k_scale=k_scale,
+            v_scale=v_scale,
+        )
+    torch.accelerator.synchronize()
+
+    torch.testing.assert_close(actual, expected, atol=0.02, rtol=0.02)
+    assert len(runner._buffer_pools_by_device) == 1
+    pool = next(iter(runner._buffer_pools_by_device.values()))
+    assert pool.current is not None
+    assert pool.current.capacity == 1 << (batch - 1).bit_length()
+    assert pool.retired == []

--- a/tests/kernels/attention/test_minimax_m3_flashinfer_sparse_decode.py
+++ b/tests/kernels/attention/test_minimax_m3_flashinfer_sparse_decode.py
@@ -27,9 +27,10 @@ SM_SCALE = HEAD_DIM**-0.5
 
 
 def _build_decode_inputs(
-    seq_lens_list: tuple[int, ...], kv_layout: str
+    seq_lens_list: tuple[int, ...], kv_layout: str, decode_query_len: int = 1
 ) -> tuple[torch.Tensor, ...]:
     batch = len(seq_lens_list)
+    num_query_tokens = batch * decode_query_len
     pages_per_req = [
         (seq_len + PAGE_SIZE - 1) // PAGE_SIZE for seq_len in seq_lens_list
     ]
@@ -53,27 +54,30 @@ def _build_decode_inputs(
     seq_lens.copy_(torch.tensor(seq_lens_list, device="cuda", dtype=torch.int32))
 
     topk_storage = torch.full(
-        (batch, NUM_KV_HEADS, TOPK),
+        (num_query_tokens, NUM_KV_HEADS, TOPK),
         -1,
         device="cuda",
         dtype=torch.int32,
     )
     topk = topk_storage.transpose(0, 1)
-    for request, request_pages in enumerate(pages_per_req):
-        if request_pages == 0:
-            continue
-        tail_page = request_pages - 1
-        older_pages = torch.randperm(tail_page, device="cuda", dtype=torch.int32)[
-            : TOPK - 1
-        ]
-        selected = torch.cat(
-            (
-                older_pages,
-                torch.tensor([tail_page], device="cuda", dtype=torch.int32),
+    for request, request_seq_len in enumerate(seq_lens_list):
+        for local_q in range(decode_query_len):
+            seq_len = request_seq_len - decode_query_len + local_q + 1
+            if seq_len <= 0:
+                continue
+            tail_page = (seq_len - 1) // PAGE_SIZE
+            older_pages = torch.randperm(tail_page, device="cuda", dtype=torch.int32)[
+                : TOPK - 1
+            ]
+            selected = torch.cat(
+                (
+                    older_pages,
+                    torch.tensor([tail_page], device="cuda", dtype=torch.int32),
+                )
             )
-        )
-        selected = selected[torch.randperm(selected.numel(), device="cuda")]
-        topk[:, request, : selected.numel()] = selected
+            selected = selected[torch.randperm(selected.numel(), device="cuda")]
+            token = request * decode_query_len + local_q
+            topk[:, token, : selected.numel()] = selected
 
     physical_shape = (
         (num_pages, NUM_KV_HEADS, PAGE_SIZE, 2 * HEAD_DIM)
@@ -87,7 +91,9 @@ def _build_decode_inputs(
     )
     kv_cache = physical_kv if kv_layout == "HND" else physical_kv.permute(0, 2, 1, 3)
     query = torch.randn(
-        (batch, NUM_Q_HEADS, HEAD_DIM), device="cuda", dtype=torch.bfloat16
+        (num_query_tokens, NUM_Q_HEADS, HEAD_DIM),
+        device="cuda",
+        dtype=torch.bfloat16,
     )
     return query, kv_cache, topk, block_table, seq_lens
 
@@ -99,8 +105,9 @@ def _launch_metadata_adapter(
     *,
     num_physical_pages: int,
     k_scale: torch.Tensor,
+    decode_query_len: int = 1,
 ) -> tuple[torch.Tensor, ...]:
-    batch = seq_lens.shape[0]
+    batch = topk.shape[1]
     physical_pages = torch.empty(
         (NUM_KV_HEADS, batch, TOPK), device="cuda", dtype=torch.int32
     )
@@ -121,6 +128,7 @@ def _launch_metadata_adapter(
         metadata_status,
         bmm1_scale_log2,
         batch,
+        decode_query_len,
         block_table.shape[1],
         num_physical_pages,
         topk.stride(0),
@@ -202,6 +210,32 @@ def test_metadata_adapter_honors_strides_deduplicates_and_handles_padding():
         bmm1_scale_log2,
         k_scale * SM_SCALE * torch.log2(torch.tensor(torch.e, device="cuda")),
     )
+
+
+def test_metadata_adapter_maps_speculative_tokens_to_requests():
+    decode_query_len = 4
+    _, kv_cache, topk, block_table, seq_lens = _build_decode_inputs(
+        (130, 257, 0), "HND", decode_query_len
+    )
+    k_scale = torch.tensor([0.75], device="cuda", dtype=torch.float32)
+
+    _, sparse_lens, metadata_ok, status, _ = _launch_metadata_adapter(
+        topk,
+        block_table,
+        seq_lens,
+        num_physical_pages=kv_cache.shape[0],
+        k_scale=k_scale,
+        decode_query_len=decode_query_len,
+    )
+
+    expected_lens = torch.tensor(
+        [[127, 128, 129, 130, 254, 255, 256, 257, 0, 0, 0, 0]] * NUM_KV_HEADS,
+        device="cuda",
+        dtype=torch.int32,
+    )
+    assert torch.equal(sparse_lens, expected_lens)
+    assert torch.equal(metadata_ok, torch.ones_like(metadata_ok))
+    assert status.item() == 1
 
 
 def test_buffer_pool_uses_geometric_capacity_and_retains_graph_allocations():
@@ -297,11 +331,13 @@ def test_unavailable_api_falls_back_before_allocating(monkeypatch: pytest.Monkey
     assert runner._buffer_pools_by_device == {}
 
 
+@pytest.mark.parametrize("decode_query_len", [1, 4])
 def test_adapter_passes_padding_scales_and_reuses_buffers(
+    decode_query_len: int,
     monkeypatch: pytest.MonkeyPatch,
 ):
     query, kv_cache, topk, block_table, seq_lens = _build_decode_inputs(
-        (257, 130, 0), "NHD"
+        (257, 130, 0), "NHD", decode_query_len
     )
     output = torch.empty_like(query)
     k_scale = torch.tensor([0.75], device="cuda", dtype=torch.float32)
@@ -320,6 +356,7 @@ def test_adapter_passes_padding_scales_and_reuses_buffers(
             }
         )
         assert kwargs["enable_block_sparse_attention"]
+        assert kwargs["q_len_per_req"] == 1
         kwargs["out"].copy_(kwargs["query"])
 
     def counter_size(batch: int, num_heads: int, sm_count: int) -> int:
@@ -350,7 +387,7 @@ def test_adapter_passes_padding_scales_and_reuses_buffers(
             scale=SM_SCALE,
             block_size=PAGE_SIZE,
             topk_blocks=TOPK,
-            decode_query_len=1,
+            decode_query_len=decode_query_len,
             k_scale=k_scale,
             v_scale=v_scale,
         )
@@ -365,13 +402,19 @@ def test_adapter_passes_padding_scales_and_reuses_buffers(
     )
     assert calls[0]["physical_ptr"] == calls[1]["physical_ptr"]
     assert calls[0]["counter_ptr"] == calls[1]["counter_ptr"]
-    assert pool.current is not None and pool.current.capacity == 4
+    expected_capacity = 1 << (query.shape[0] - 1).bit_length()
+    assert pool.current is not None and pool.current.capacity == expected_capacity
     assert pool.retired == []
     torch.testing.assert_close(output, query)
 
 
-def test_adapter_is_cudagraph_replayable(monkeypatch: pytest.MonkeyPatch):
-    query, kv_cache, topk, block_table, seq_lens = _build_decode_inputs((257,), "HND")
+@pytest.mark.parametrize("decode_query_len", [1, 4])
+def test_adapter_is_cudagraph_replayable(
+    decode_query_len: int, monkeypatch: pytest.MonkeyPatch
+):
+    query, kv_cache, topk, block_table, seq_lens = _build_decode_inputs(
+        (257,), "HND", decode_query_len
+    )
     output = torch.empty_like(query)
 
     def run(**kwargs) -> None:
@@ -405,7 +448,7 @@ def test_adapter_is_cudagraph_replayable(monkeypatch: pytest.MonkeyPatch):
             scale=SM_SCALE,
             block_size=PAGE_SIZE,
             topk_blocks=TOPK,
-            decode_query_len=1,
+            decode_query_len=decode_query_len,
         )
     torch.accelerator.synchronize()
 
@@ -422,7 +465,7 @@ def test_adapter_is_cudagraph_replayable(monkeypatch: pytest.MonkeyPatch):
             scale=SM_SCALE,
             block_size=PAGE_SIZE,
             topk_blocks=TOPK,
-            decode_query_len=1,
+            decode_query_len=decode_query_len,
         )
 
     query.fill_(0.25)
@@ -450,19 +493,25 @@ def _require_real_flashinfer_sparse_decode() -> None:
 
 
 @pytest.mark.parametrize(
-    ("kv_layout", "batch", "seq_len"),
-    [("NHD", 32, 1000), ("HND", 1, 8191)],
+    ("kv_layout", "batch", "seq_len", "decode_query_len"),
+    [
+        ("NHD", 32, 1000, 1),
+        ("HND", 1, 8191, 1),
+        ("NHD", 4, 257, 4),
+        ("HND", 2, 130, 2),
+    ],
 )
 def test_real_flashinfer_sparse_decode_matches_triton_and_reuses_buffers(
     kv_layout: str,
     batch: int,
     seq_len: int,
+    decode_query_len: int,
     monkeypatch: pytest.MonkeyPatch,
 ):
     _require_real_flashinfer_sparse_decode()
     torch.manual_seed(0)
     query, kv_cache, topk, block_table, seq_lens = _build_decode_inputs(
-        (seq_len,) * batch, kv_layout
+        (seq_len,) * batch, kv_layout, decode_query_len
     )
     # The Triton oracle's page-table kernel assumes contiguous inner metadata.
     block_table = block_table.contiguous()
@@ -480,7 +529,7 @@ def test_real_flashinfer_sparse_decode_matches_triton_and_reuses_buffers(
         NUM_KV_HEADS,
         SM_SCALE,
         expected,
-        1,
+        decode_query_len,
         k_scale=k_scale,
         v_scale=v_scale,
     )
@@ -503,7 +552,7 @@ def test_real_flashinfer_sparse_decode_matches_triton_and_reuses_buffers(
             scale=SM_SCALE,
             block_size=PAGE_SIZE,
             topk_blocks=TOPK,
-            decode_query_len=1,
+            decode_query_len=decode_query_len,
             k_scale=k_scale,
             v_scale=v_scale,
         )
@@ -513,5 +562,6 @@ def test_real_flashinfer_sparse_decode_matches_triton_and_reuses_buffers(
     assert len(runner._buffer_pools_by_device) == 1
     pool = next(iter(runner._buffer_pools_by_device.values()))
     assert pool.current is not None
-    assert pool.current.capacity == 1 << (batch - 1).bit_length()
+    expected_capacity = 1 << (query.shape[0] - 1).bit_length()
+    assert pool.current.capacity == expected_capacity
     assert pool.retired == []

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -58,6 +58,9 @@ if TYPE_CHECKING:
     VLLM_XLA_CACHE_PATH: str = os.path.join(VLLM_CACHE_ROOT, "xla_cache")
     VLLM_XLA_CHECK_RECOMPILATION: bool = False
     VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: int = 512
+    VLLM_MINIMAX_M3_SPARSE_DECODE_BACKEND: Literal[
+        "triton", "flashinfer_trtllm_gen"
+    ] = "triton"
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: Literal["auto", "nccl", "shm"] = "auto"
     VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM: bool = False
     VLLM_USE_RAY_WRAPPED_PP_COMM: bool = True
@@ -1047,6 +1050,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Default: 512 MB
     "VLLM_SPARSE_INDEXER_MAX_LOGITS_MB": lambda: int(
         os.getenv("VLLM_SPARSE_INDEXER_MAX_LOGITS_MB", "512")
+    ),
+    "VLLM_MINIMAX_M3_SPARSE_DECODE_BACKEND": env_with_choices(
+        "VLLM_MINIMAX_M3_SPARSE_DECODE_BACKEND",
+        "triton",
+        ["triton", "flashinfer_trtllm_gen"],
     ),
     # If set, the OpenAI API server will stay alive even after the underlying
     # AsyncLLMEngine errors and stops serving requests

--- a/vllm/models/minimax_m3/nvidia/flashinfer_sparse_decode.py
+++ b/vllm/models/minimax_m3/nvidia/flashinfer_sparse_decode.py
@@ -39,7 +39,7 @@ _api: _Api | None = None
 _api_checked = False
 
 
-@triton.jit(do_not_specialize=["batch_size", "decode_query_len", "max_logical_pages"])
+@triton.jit(do_not_specialize=["batch_size", "max_logical_pages"])
 def _prepare_sparse_metadata_kernel(
     topk_ptr,
     block_table_ptr,
@@ -51,7 +51,6 @@ def _prepare_sparse_metadata_kernel(
     metadata_status_ptr,
     bmm1_scale_log2_ptr,
     batch_size,
-    decode_query_len,
     max_logical_pages,
     num_physical_pages,
     stride_topk_h,
@@ -72,18 +71,15 @@ def _prepare_sparse_metadata_kernel(
 ):
     pid = tl.program_id(0)
     kv_head = pid // batch_size
-    token = pid - kv_head * batch_size
-    request = token // decode_query_len
-    local_q = token - request * decode_query_len
+    request = pid - kv_head * batch_size
     offsets = tl.arange(0, TOPK_SIZE)
     logical = tl.load(
         topk_ptr
         + kv_head * stride_topk_h
-        + token * stride_topk_b
+        + request * stride_topk_b
         + offsets * stride_topk_k
     ).to(tl.int32)
-    request_seq_len = tl.load(seq_lens_ptr + request * stride_seq_b).to(tl.int32)
-    seq_len = request_seq_len - decode_query_len + local_q + 1
+    seq_len = tl.load(seq_lens_ptr + request * stride_seq_b).to(tl.int32)
     valid_pages = (seq_len + PAGE_SIZE_VALUE - 1) // PAGE_SIZE_VALUE
     tail_page = valid_pages - 1
     valid = (logical >= 0) & (logical < valid_pages) & (logical < max_logical_pages)
@@ -104,7 +100,7 @@ def _prepare_sparse_metadata_kernel(
         tl.store(
             physical_pages_ptr
             + kv_head * stride_out_h
-            + token * stride_out_b
+            + request * stride_out_b
             + output_slot * stride_out_k,
             physical,
         )
@@ -114,7 +110,7 @@ def _prepare_sparse_metadata_kernel(
         count += has_value.to(tl.int32)
         remaining = tl.where(remaining == selected, sentinel, remaining)
 
-    is_padding = request_seq_len <= 0
+    is_padding = seq_len <= 0
     has_tail = tl.sum((valid & (logical == tail_page)).to(tl.int32), axis=0) > 0
     metadata_ok = is_padding | (
         has_tail & physical_ok & (count > 0) & (valid_pages <= max_logical_pages)
@@ -124,10 +120,10 @@ def _prepare_sparse_metadata_kernel(
     surviving_tokens = tl.where(is_padding, 0, surviving_tokens)
     surviving_tokens = tl.where(metadata_ok, surviving_tokens, 0)
     tl.store(
-        sparse_seq_lens_ptr + kv_head * stride_len_h + token * stride_len_b,
+        sparse_seq_lens_ptr + kv_head * stride_len_h + request * stride_len_b,
         surviving_tokens,
     )
-    tl.store(metadata_ok_ptr + kv_head * batch_size + token, metadata_ok)
+    tl.store(metadata_ok_ptr + kv_head * batch_size + request, metadata_ok)
     tl.atomic_and(metadata_status_ptr, metadata_ok.to(tl.int32))
 
     if HAS_KV_SCALE:
@@ -292,8 +288,8 @@ def _static_fallback_reason(
     k_scale: torch.Tensor | None,
     v_scale: torch.Tensor | None,
 ) -> str | None:
-    if decode_query_len <= 0:
-        return "decode query length is not positive"
+    if decode_query_len != 1:
+        return "decode query length is not one"
     if query.device.type != "cuda":
         return "query is not on CUDA"
     capability = torch.cuda.get_device_capability(query.device)
@@ -322,14 +318,13 @@ def _static_fallback_reason(
         or kv_cache.stride(-1) != 1
     ):
         return "KV cache shape or inner stride is unsupported"
-    batch = block_table.shape[0] if block_table.ndim == 2 else 0
-    num_query_tokens = query.shape[0]
+    batch = query.shape[0]
     if (
         output.shape != query.shape
         or output.dtype != query.dtype
-        or num_query_tokens != batch * decode_query_len
-        or topk.shape != (_NUM_KV_HEADS, num_query_tokens, _TOPK)
+        or topk.shape != (_NUM_KV_HEADS, batch, _TOPK)
         or block_table.ndim != 2
+        or block_table.shape[0] != batch
         or seq_lens.shape != (batch,)
         or topk.dtype != torch.int32
         or block_table.dtype != torch.int32
@@ -421,8 +416,6 @@ class FlashInferSparseDecodeRunner:
         if api is None:
             return False
 
-        # FlashInfer sees each verification token as an independent request so
-        # every token retains the sparse page set chosen by MiniMax's indexer.
         batch = query.shape[0]
         run, counter_size = api
         buffers = self._get_buffers(query.device, batch, counter_size)
@@ -443,7 +436,6 @@ class FlashInferSparseDecodeRunner:
             buffers.metadata_status,
             buffers.bmm1_scale_log2,
             batch,
-            decode_query_len,
             block_table.shape[1],
             kv_cache.shape[0],
             topk.stride(0),

--- a/vllm/models/minimax_m3/nvidia/flashinfer_sparse_decode.py
+++ b/vllm/models/minimax_m3/nvidia/flashinfer_sparse_decode.py
@@ -1,0 +1,484 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Experimental FlashInfer TRTLLM-GEN sparse decode for MiniMax M3."""
+
+from __future__ import annotations
+
+import inspect
+import math
+import os
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.triton_utils import tl, triton
+
+logger = init_logger(__name__)
+
+_BACKEND_ENV = "VLLM_MINIMAX_M3_SPARSE_DECODE_BACKEND"
+_FLASHINFER_BACKEND = "flashinfer_trtllm_gen"
+_NUM_Q_HEADS = 64
+_NUM_KV_HEADS = 4
+_HEAD_DIM = 128
+_PAGE_SIZE = 128
+_TOPK = 16
+_WORKSPACE_BYTES = 256 * 1024 * 1024
+_REQUIRED_DECODE_PARAMETERS = frozenset(
+    {
+        "bmm1_scale_log2",
+        "enable_block_sparse_attention",
+        "multi_ctas_kv_counter_buffer",
+    }
+)
+
+_Api = tuple[Callable[..., Any], Callable[[int, int, int], int]]
+_api: _Api | None = None
+_api_checked = False
+
+
+@triton.jit(do_not_specialize=["batch_size", "max_logical_pages"])
+def _prepare_sparse_metadata_kernel(
+    topk_ptr,
+    block_table_ptr,
+    seq_lens_ptr,
+    k_scale_ptr,
+    physical_pages_ptr,
+    sparse_seq_lens_ptr,
+    metadata_ok_ptr,
+    metadata_status_ptr,
+    bmm1_scale_log2_ptr,
+    batch_size,
+    max_logical_pages,
+    num_physical_pages,
+    stride_topk_h,
+    stride_topk_b,
+    stride_topk_k,
+    stride_bt_b,
+    stride_bt_k,
+    stride_seq_b,
+    stride_out_h,
+    stride_out_b,
+    stride_out_k,
+    stride_len_h,
+    stride_len_b,
+    TOPK_SIZE: tl.constexpr,
+    PAGE_SIZE_VALUE: tl.constexpr,
+    HAS_KV_SCALE: tl.constexpr,
+    SM_SCALE_LOG2: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    kv_head = pid // batch_size
+    request = pid - kv_head * batch_size
+    offsets = tl.arange(0, TOPK_SIZE)
+    logical = tl.load(
+        topk_ptr
+        + kv_head * stride_topk_h
+        + request * stride_topk_b
+        + offsets * stride_topk_k
+    ).to(tl.int32)
+    seq_len = tl.load(seq_lens_ptr + request * stride_seq_b).to(tl.int32)
+    valid_pages = (seq_len + PAGE_SIZE_VALUE - 1) // PAGE_SIZE_VALUE
+    tail_page = valid_pages - 1
+    valid = (logical >= 0) & (logical < valid_pages) & (logical < max_logical_pages)
+    sentinel = 0x7FFFFFFF
+    remaining = tl.where(valid, logical, sentinel)
+    count = tl.zeros((), tl.int32)
+    physical_ok = tl.full((), True, tl.int1)
+
+    # Fixed-size selection sort also removes duplicate logical page indices.
+    for output_slot in tl.static_range(TOPK_SIZE):
+        selected = tl.min(remaining, axis=0)
+        has_value = selected < sentinel
+        physical = tl.load(
+            block_table_ptr + request * stride_bt_b + selected * stride_bt_k,
+            mask=has_value,
+            other=0,
+        ).to(tl.int32)
+        tl.store(
+            physical_pages_ptr
+            + kv_head * stride_out_h
+            + request * stride_out_b
+            + output_slot * stride_out_k,
+            physical,
+        )
+        physical_ok &= (~has_value) | (
+            (physical >= 0) & (physical < num_physical_pages)
+        )
+        count += has_value.to(tl.int32)
+        remaining = tl.where(remaining == selected, sentinel, remaining)
+
+    is_padding = seq_len <= 0
+    has_tail = tl.sum((valid & (logical == tail_page)).to(tl.int32), axis=0) > 0
+    metadata_ok = is_padding | (
+        has_tail & physical_ok & (count > 0) & (valid_pages <= max_logical_pages)
+    )
+    tail_tokens = seq_len - tail_page * PAGE_SIZE_VALUE
+    surviving_tokens = (count - 1) * PAGE_SIZE_VALUE + tail_tokens
+    surviving_tokens = tl.where(is_padding, 0, surviving_tokens)
+    surviving_tokens = tl.where(metadata_ok, surviving_tokens, 0)
+    tl.store(
+        sparse_seq_lens_ptr + kv_head * stride_len_h + request * stride_len_b,
+        surviving_tokens,
+    )
+    tl.store(metadata_ok_ptr + kv_head * batch_size + request, metadata_ok)
+    tl.atomic_and(metadata_status_ptr, metadata_ok.to(tl.int32))
+
+    if HAS_KV_SCALE:
+        k_scale = tl.load(k_scale_ptr).to(tl.float32)
+        tl.store(
+            bmm1_scale_log2_ptr,
+            k_scale * SM_SCALE_LOG2,
+            mask=pid == 0,
+        )
+
+
+@dataclass
+class _Buffers:
+    workspace: torch.Tensor
+    physical_pages: torch.Tensor
+    sparse_seq_lens: torch.Tensor
+    metadata_ok: torch.Tensor
+    metadata_status: torch.Tensor
+    bmm1_scale_log2: torch.Tensor
+    counter: torch.Tensor
+
+
+@dataclass
+class _BufferAllocation:
+    capacity: int
+    physical_pages: torch.Tensor
+    sparse_seq_lens: torch.Tensor
+    metadata_ok: torch.Tensor
+    metadata_status: torch.Tensor
+    bmm1_scale_log2: torch.Tensor
+    counter: torch.Tensor
+
+    def for_batch(self, batch: int, workspace: torch.Tensor) -> _Buffers:
+        return _Buffers(
+            workspace=workspace,
+            physical_pages=self.physical_pages[: _NUM_KV_HEADS * batch * _TOPK].view(
+                _NUM_KV_HEADS, batch, _TOPK
+            ),
+            sparse_seq_lens=self.sparse_seq_lens[: _NUM_KV_HEADS * batch].view(
+                _NUM_KV_HEADS, batch
+            ),
+            metadata_ok=self.metadata_ok[: _NUM_KV_HEADS * batch].view(
+                _NUM_KV_HEADS, batch
+            ),
+            metadata_status=self.metadata_status,
+            bmm1_scale_log2=self.bmm1_scale_log2,
+            counter=self.counter,
+        )
+
+
+@dataclass
+class _DeviceBufferPool:
+    device: torch.device
+    workspace: torch.Tensor
+    current: _BufferAllocation | None = field(init=False, default=None)
+    retired: list[_BufferAllocation] = field(init=False, default_factory=list)
+
+    def get(
+        self,
+        batch: int,
+        counter_size: Callable[[int, int, int], int],
+    ) -> _Buffers:
+        if batch <= 0:
+            raise ValueError("batch must be positive")
+        if self.current is None or batch > self.current.capacity:
+            if self.current is not None:
+                # Captured CUDA graphs retain raw pointers into old allocations.
+                self.retired.append(self.current)
+            capacity = 1 << (batch - 1).bit_length()
+            sm_count = torch.cuda.get_device_properties(
+                self.device
+            ).multi_processor_count
+            counter_bytes = counter_size(capacity, _NUM_Q_HEADS, sm_count)
+            self.current = _BufferAllocation(
+                capacity=capacity,
+                physical_pages=torch.empty(
+                    _NUM_KV_HEADS * capacity * _TOPK,
+                    dtype=torch.int32,
+                    device=self.device,
+                ),
+                sparse_seq_lens=torch.empty(
+                    _NUM_KV_HEADS * capacity,
+                    dtype=torch.int32,
+                    device=self.device,
+                ),
+                metadata_ok=torch.empty(
+                    _NUM_KV_HEADS * capacity,
+                    dtype=torch.int32,
+                    device=self.device,
+                ),
+                metadata_status=torch.ones(1, dtype=torch.int32, device=self.device),
+                bmm1_scale_log2=torch.empty(1, dtype=torch.float32, device=self.device),
+                counter=torch.zeros(
+                    counter_bytes, dtype=torch.uint8, device=self.device
+                ),
+            )
+        current = self.current
+        assert current is not None
+        return current.for_batch(batch, self.workspace)
+
+
+_workspace_by_device: dict[torch.device, torch.Tensor] = {}
+
+
+def _get_workspace(device: torch.device) -> torch.Tensor:
+    workspace = _workspace_by_device.get(device)
+    if workspace is None:
+        workspace = torch.zeros(_WORKSPACE_BYTES, dtype=torch.uint8, device=device)
+        _workspace_by_device[device] = workspace
+    return workspace
+
+
+def _requested() -> bool:
+    value = os.environ.get(_BACKEND_ENV, "triton")
+    if value not in ("triton", _FLASHINFER_BACKEND):
+        logger.warning_once(
+            "Unknown %s=%r; using Triton sparse decode", _BACKEND_ENV, value
+        )
+        return False
+    return value == _FLASHINFER_BACKEND
+
+
+def _load_api() -> _Api | None:
+    global _api, _api_checked
+    if _api_checked:
+        return _api
+    _api_checked = True
+    try:
+        from flashinfer.decode import trtllm_batch_decode_with_kv_cache
+        from flashinfer.utils import get_trtllm_gen_multi_ctas_kv_counter_bytes
+    except Exception as error:
+        logger.warning_once(
+            "FlashInfer MiniMax sparse decode unavailable (%s); using Triton", error
+        )
+        return None
+    parameters = inspect.signature(trtllm_batch_decode_with_kv_cache).parameters
+    missing_parameters = _REQUIRED_DECODE_PARAMETERS.difference(parameters)
+    if missing_parameters:
+        logger.warning_once(
+            "Installed FlashInfer lacks sparse decode parameters %s; using Triton",
+            tuple(sorted(missing_parameters)),
+        )
+        return None
+    _api = (
+        trtllm_batch_decode_with_kv_cache,
+        get_trtllm_gen_multi_ctas_kv_counter_bytes,
+    )
+    return _api
+
+
+def _static_fallback_reason(
+    query: torch.Tensor,
+    kv_cache: torch.Tensor,
+    topk: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    output: torch.Tensor,
+    num_kv_heads: int,
+    block_size: int,
+    topk_blocks: int,
+    decode_query_len: int,
+    k_scale: torch.Tensor | None,
+    v_scale: torch.Tensor | None,
+) -> str | None:
+    if decode_query_len != 1:
+        return "decode query length is not one"
+    if query.device.type != "cuda":
+        return "query is not on CUDA"
+    capability = torch.cuda.get_device_capability(query.device)
+    if capability not in ((10, 0), (10, 3)):
+        return "GPU is not SM100 or SM103"
+    if (
+        query.ndim != 3
+        or query.shape[1:] != (_NUM_Q_HEADS, _HEAD_DIM)
+        or num_kv_heads != _NUM_KV_HEADS
+        or block_size != _PAGE_SIZE
+        or topk_blocks != _TOPK
+    ):
+        return "MiniMax head/page/top-k geometry differs"
+    if query.dtype not in (torch.bfloat16, torch.float16):
+        return "query dtype is unsupported"
+    if kv_cache.dtype != torch.float8_e4m3fn:
+        return "KV cache is not FP8 E4M3"
+    if (
+        kv_cache.ndim != 4
+        or kv_cache.shape[1:]
+        != (
+            _NUM_KV_HEADS,
+            _PAGE_SIZE,
+            2 * _HEAD_DIM,
+        )
+        or kv_cache.stride(-1) != 1
+    ):
+        return "KV cache shape or inner stride is unsupported"
+    batch = query.shape[0]
+    if (
+        output.shape != query.shape
+        or output.dtype != query.dtype
+        or topk.shape != (_NUM_KV_HEADS, batch, _TOPK)
+        or block_table.ndim != 2
+        or block_table.shape[0] != batch
+        or seq_lens.shape != (batch,)
+        or topk.dtype != torch.int32
+        or block_table.dtype != torch.int32
+        or seq_lens.dtype != torch.int32
+    ):
+        return "decode tensor shape or metadata dtype is unsupported"
+    tensors = (query, kv_cache, topk, block_table, seq_lens, output)
+    if any(tensor.device != query.device for tensor in tensors):
+        return "decode tensors are on different devices"
+    if not query.is_contiguous() or not output.is_contiguous():
+        return "query or output is not contiguous"
+    if (k_scale is None) != (v_scale is None):
+        return "only one KV scale was provided"
+    if (
+        k_scale is not None
+        and v_scale is not None
+        and (
+            k_scale.numel() != 1
+            or v_scale.numel() != 1
+            or k_scale.dtype != torch.float32
+            or v_scale.dtype != torch.float32
+            or k_scale.device != query.device
+            or v_scale.device != query.device
+        )
+    ):
+        return "only scalar FP32 KV scales are supported"
+    return None
+
+
+class FlashInferSparseDecodeRunner:
+    """Layer-owned FlashInfer sparse decode buffers and dispatch."""
+
+    def __init__(self) -> None:
+        self._buffer_pools_by_device: dict[torch.device, _DeviceBufferPool] = {}
+
+    def _get_buffers(
+        self,
+        device: torch.device,
+        batch: int,
+        counter_size: Callable[[int, int, int], int],
+    ) -> _Buffers:
+        pool = self._buffer_pools_by_device.get(device)
+        if pool is None:
+            pool = _DeviceBufferPool(device, _get_workspace(device))
+            self._buffer_pools_by_device[device] = pool
+        return pool.get(batch, counter_size)
+
+    @torch.no_grad()
+    def try_decode(
+        self,
+        query: torch.Tensor,
+        kv_cache: torch.Tensor,
+        topk: torch.Tensor,
+        block_table: torch.Tensor,
+        seq_lens: torch.Tensor,
+        output: torch.Tensor,
+        *,
+        num_kv_heads: int,
+        scale: float,
+        block_size: int,
+        topk_blocks: int,
+        decode_query_len: int,
+        k_scale: torch.Tensor | None = None,
+        v_scale: torch.Tensor | None = None,
+    ) -> bool:
+        """Run FlashInfer when explicitly enabled and compatible."""
+        if not _requested():
+            return False
+        reason = _static_fallback_reason(
+            query,
+            kv_cache,
+            topk,
+            block_table,
+            seq_lens,
+            output,
+            num_kv_heads,
+            block_size,
+            topk_blocks,
+            decode_query_len,
+            k_scale,
+            v_scale,
+        )
+        if reason is not None:
+            logger.warning_once(
+                "FlashInfer MiniMax sparse decode fallback: %s; using Triton", reason
+            )
+            return False
+        api = _load_api()
+        if api is None:
+            return False
+
+        batch = query.shape[0]
+        run, counter_size = api
+        buffers = self._get_buffers(query.device, batch, counter_size)
+        physical_pages = buffers.physical_pages
+        sparse_seq_lens = buffers.sparse_seq_lens
+        metadata_ok = buffers.metadata_ok
+        buffers.metadata_status.fill_(1)
+        has_kv_scale = k_scale is not None
+        k_scale_arg = k_scale if k_scale is not None else buffers.bmm1_scale_log2
+        _prepare_sparse_metadata_kernel[(_NUM_KV_HEADS * batch,)](
+            topk,
+            block_table,
+            seq_lens,
+            k_scale_arg,
+            physical_pages,
+            sparse_seq_lens,
+            metadata_ok,
+            buffers.metadata_status,
+            buffers.bmm1_scale_log2,
+            batch,
+            block_table.shape[1],
+            kv_cache.shape[0],
+            topk.stride(0),
+            topk.stride(1),
+            topk.stride(2),
+            block_table.stride(0),
+            block_table.stride(1),
+            seq_lens.stride(0),
+            physical_pages.stride(0),
+            physical_pages.stride(1),
+            physical_pages.stride(2),
+            sparse_seq_lens.stride(0),
+            sparse_seq_lens.stride(1),
+            TOPK_SIZE=_TOPK,
+            PAGE_SIZE_VALUE=_PAGE_SIZE,
+            HAS_KV_SCALE=has_kv_scale,
+            SM_SCALE_LOG2=scale * math.log2(math.e),
+        )
+        torch._assert_async(
+            buffers.metadata_status,
+            "MiniMax FlashInfer sparse decode metadata is invalid or misses the "
+            "tail page",
+        )
+        k_cache, v_cache = kv_cache.split(_HEAD_DIM, dim=-1)
+        run(
+            query=query,
+            kv_cache=(k_cache, v_cache),
+            workspace_buffer=buffers.workspace,
+            block_tables=physical_pages,
+            seq_lens=sparse_seq_lens,
+            max_seq_len=_TOPK * _PAGE_SIZE,
+            bmm1_scale=scale,
+            bmm1_scale_log2=(buffers.bmm1_scale_log2 if has_kv_scale else None),
+            bmm2_scale=v_scale if v_scale is not None else 1.0,
+            out=output,
+            kv_layout="HND",
+            backend="trtllm-gen",
+            q_len_per_req=1,
+            multi_ctas_kv_counter_buffer=buffers.counter,
+            enable_block_sparse_attention=True,
+        )
+        logger.info_once(
+            "MiniMax M3 sparse decode dispatched FlashInfer TRTLLM-GEN block-sparse "
+            "attention"
+        )
+        return True

--- a/vllm/models/minimax_m3/nvidia/flashinfer_sparse_decode.py
+++ b/vllm/models/minimax_m3/nvidia/flashinfer_sparse_decode.py
@@ -39,7 +39,7 @@ _api: _Api | None = None
 _api_checked = False
 
 
-@triton.jit(do_not_specialize=["batch_size", "max_logical_pages"])
+@triton.jit(do_not_specialize=["batch_size", "decode_query_len", "max_logical_pages"])
 def _prepare_sparse_metadata_kernel(
     topk_ptr,
     block_table_ptr,
@@ -51,6 +51,7 @@ def _prepare_sparse_metadata_kernel(
     metadata_status_ptr,
     bmm1_scale_log2_ptr,
     batch_size,
+    decode_query_len,
     max_logical_pages,
     num_physical_pages,
     stride_topk_h,
@@ -71,15 +72,18 @@ def _prepare_sparse_metadata_kernel(
 ):
     pid = tl.program_id(0)
     kv_head = pid // batch_size
-    request = pid - kv_head * batch_size
+    token = pid - kv_head * batch_size
+    request = token // decode_query_len
+    local_q = token - request * decode_query_len
     offsets = tl.arange(0, TOPK_SIZE)
     logical = tl.load(
         topk_ptr
         + kv_head * stride_topk_h
-        + request * stride_topk_b
+        + token * stride_topk_b
         + offsets * stride_topk_k
     ).to(tl.int32)
-    seq_len = tl.load(seq_lens_ptr + request * stride_seq_b).to(tl.int32)
+    request_seq_len = tl.load(seq_lens_ptr + request * stride_seq_b).to(tl.int32)
+    seq_len = request_seq_len - decode_query_len + local_q + 1
     valid_pages = (seq_len + PAGE_SIZE_VALUE - 1) // PAGE_SIZE_VALUE
     tail_page = valid_pages - 1
     valid = (logical >= 0) & (logical < valid_pages) & (logical < max_logical_pages)
@@ -100,7 +104,7 @@ def _prepare_sparse_metadata_kernel(
         tl.store(
             physical_pages_ptr
             + kv_head * stride_out_h
-            + request * stride_out_b
+            + token * stride_out_b
             + output_slot * stride_out_k,
             physical,
         )
@@ -110,7 +114,7 @@ def _prepare_sparse_metadata_kernel(
         count += has_value.to(tl.int32)
         remaining = tl.where(remaining == selected, sentinel, remaining)
 
-    is_padding = seq_len <= 0
+    is_padding = request_seq_len <= 0
     has_tail = tl.sum((valid & (logical == tail_page)).to(tl.int32), axis=0) > 0
     metadata_ok = is_padding | (
         has_tail & physical_ok & (count > 0) & (valid_pages <= max_logical_pages)
@@ -120,10 +124,10 @@ def _prepare_sparse_metadata_kernel(
     surviving_tokens = tl.where(is_padding, 0, surviving_tokens)
     surviving_tokens = tl.where(metadata_ok, surviving_tokens, 0)
     tl.store(
-        sparse_seq_lens_ptr + kv_head * stride_len_h + request * stride_len_b,
+        sparse_seq_lens_ptr + kv_head * stride_len_h + token * stride_len_b,
         surviving_tokens,
     )
-    tl.store(metadata_ok_ptr + kv_head * batch_size + request, metadata_ok)
+    tl.store(metadata_ok_ptr + kv_head * batch_size + token, metadata_ok)
     tl.atomic_and(metadata_status_ptr, metadata_ok.to(tl.int32))
 
     if HAS_KV_SCALE:
@@ -288,8 +292,8 @@ def _static_fallback_reason(
     k_scale: torch.Tensor | None,
     v_scale: torch.Tensor | None,
 ) -> str | None:
-    if decode_query_len != 1:
-        return "decode query length is not one"
+    if decode_query_len <= 0:
+        return "decode query length is not positive"
     if query.device.type != "cuda":
         return "query is not on CUDA"
     capability = torch.cuda.get_device_capability(query.device)
@@ -318,13 +322,14 @@ def _static_fallback_reason(
         or kv_cache.stride(-1) != 1
     ):
         return "KV cache shape or inner stride is unsupported"
-    batch = query.shape[0]
+    batch = block_table.shape[0] if block_table.ndim == 2 else 0
+    num_query_tokens = query.shape[0]
     if (
         output.shape != query.shape
         or output.dtype != query.dtype
-        or topk.shape != (_NUM_KV_HEADS, batch, _TOPK)
+        or num_query_tokens != batch * decode_query_len
+        or topk.shape != (_NUM_KV_HEADS, num_query_tokens, _TOPK)
         or block_table.ndim != 2
-        or block_table.shape[0] != batch
         or seq_lens.shape != (batch,)
         or topk.dtype != torch.int32
         or block_table.dtype != torch.int32
@@ -416,6 +421,8 @@ class FlashInferSparseDecodeRunner:
         if api is None:
             return False
 
+        # FlashInfer sees each verification token as an independent request so
+        # every token retains the sparse page set chosen by MiniMax's indexer.
         batch = query.shape[0]
         run, counter_size = api
         buffers = self._get_buffers(query.device, batch, counter_size)
@@ -436,6 +443,7 @@ class FlashInferSparseDecodeRunner:
             buffers.metadata_status,
             buffers.bmm1_scale_log2,
             batch,
+            decode_query_len,
             block_table.shape[1],
             kv_cache.shape[0],
             topk.stride(0),

--- a/vllm/models/minimax_m3/nvidia/sparse_attention_msa.py
+++ b/vllm/models/minimax_m3/nvidia/sparse_attention_msa.py
@@ -78,7 +78,7 @@ class MiniMaxM3SparseMSAImpl(MiniMaxM3SparseImpl):
         k_scale = getattr(layer, "_k_scale", None) if self.use_fp8_kv else None
         v_scale = getattr(layer, "_v_scale", None) if self.use_fp8_kv else None
 
-        # Decode [:nd]: Triton by default, guarded FlashInfer for q-length one.
+        # Decode [:nd]: Triton by default, guarded FlashInfer when compatible.
         if main_md.num_decodes > 0:
             d = main_md.decode
             assert d is not None

--- a/vllm/models/minimax_m3/nvidia/sparse_attention_msa.py
+++ b/vllm/models/minimax_m3/nvidia/sparse_attention_msa.py
@@ -2,9 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """MSA (SM100/Blackwell) block-sparse attend for MiniMax M3.
 
-Prefill attends with ``fmha_sm100`` (``build_k2q_csr`` + ``sparse_atten_func``);
-decode falls back to the Triton split-K kernel (no MSA decode yet). ``fmha_sm100``
-imports are function-local, so this module is import-safe on AMD/non-SM100.
+Prefill attends with ``fmha_sm100`` (``build_k2q_csr`` + ``sparse_atten_func``).
+Decode uses Triton split-K by default, with an explicitly enabled experimental
+FlashInfer TRTLLM-GEN path. ``fmha_sm100`` imports are function-local, so this
+module is import-safe on AMD/non-SM100.
 """
 
 import torch
@@ -18,11 +19,36 @@ from vllm.models.minimax_m3.common.sparse_attention import (
     MiniMaxM3SparseImpl,
     MiniMaxM3SparseMetadata,
 )
+from vllm.models.minimax_m3.nvidia.flashinfer_sparse_decode import (
+    FlashInferSparseDecodeRunner,
+)
 from vllm.v1.attention.backend import AttentionLayer
 
 
 class MiniMaxM3SparseMSAImpl(MiniMaxM3SparseImpl):
-    """MSA block-sparse attend (``fmha_sm100``); Triton split-K decode."""
+    """MSA prefill; Triton or guarded FlashInfer sparse decode."""
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int | None = None,
+        kv_cache_dtype: str = "auto",
+        *,
+        topk_blocks: int,
+        sparse_block_size: int,
+    ) -> None:
+        super().__init__(
+            num_heads,
+            head_size,
+            scale,
+            num_kv_heads,
+            kv_cache_dtype,
+            topk_blocks=topk_blocks,
+            sparse_block_size=sparse_block_size,
+        )
+        self.flashinfer_sparse_decode = FlashInferSparseDecodeRunner()
 
     def forward(
         self,
@@ -52,23 +78,40 @@ class MiniMaxM3SparseMSAImpl(MiniMaxM3SparseImpl):
         k_scale = getattr(layer, "_k_scale", None) if self.use_fp8_kv else None
         v_scale = getattr(layer, "_v_scale", None) if self.use_fp8_kv else None
 
-        # Decode [:nd]: Triton split-K placeholder (no MSA decode yet).
+        # Decode [:nd]: Triton by default, guarded FlashInfer for q-length one.
         if main_md.num_decodes > 0:
             d = main_md.decode
             assert d is not None
-            minimax_m3_sparse_attn_decode(
+            decode_topk = topk[:nd].transpose(0, 1)
+            used_flashinfer = self.flashinfer_sparse_decode.try_decode(
                 q[:nd],
                 kv_cache,
-                topk[:nd].transpose(0, 1),
+                decode_topk,
                 d.block_table,
                 d.seq_lens,
-                self.num_kv_heads,
-                self.scale,
                 out[:nd],
-                d.decode_query_len,
+                num_kv_heads=self.num_kv_heads,
+                scale=self.scale,
+                block_size=self.block_size,
+                topk_blocks=self.topk_blocks,
+                decode_query_len=d.decode_query_len,
                 k_scale=k_scale,
                 v_scale=v_scale,
             )
+            if not used_flashinfer:
+                minimax_m3_sparse_attn_decode(
+                    q[:nd],
+                    kv_cache,
+                    decode_topk,
+                    d.block_table,
+                    d.seq_lens,
+                    self.num_kv_heads,
+                    self.scale,
+                    out[:nd],
+                    d.decode_query_len,
+                    k_scale=k_scale,
+                    v_scale=v_scale,
+                )
 
         # Prefill [nd:]: MSA sparse FMHA over the selected blocks.
         if main_md.num_prefills > 0:

--- a/vllm/models/minimax_m3/nvidia/sparse_attention_msa.py
+++ b/vllm/models/minimax_m3/nvidia/sparse_attention_msa.py
@@ -78,7 +78,7 @@ class MiniMaxM3SparseMSAImpl(MiniMaxM3SparseImpl):
         k_scale = getattr(layer, "_k_scale", None) if self.use_fp8_kv else None
         v_scale = getattr(layer, "_v_scale", None) if self.use_fp8_kv else None
 
-        # Decode [:nd]: Triton by default, guarded FlashInfer when compatible.
+        # Decode [:nd]: Triton by default, guarded FlashInfer for q-length one.
         if main_md.num_decodes > 0:
             d = main_md.decode
             assert d is not None


### PR DESCRIPTION
### Purpose

Add an opt-in FlashInfer TRTLLM-GEN block-sparse attention path for MiniMax-M3 normal decode on SM100/SM103.

The existing Triton implementation remains the default. Set `VLLM_MINIMAX_M3_SPARSE_DECODE_BACKEND=flashinfer_trtllm_gen` to request the new path; unsupported inputs or an incompatible FlashInfer install fall back to Triton before allocating adapter buffers.

### Implementation

- Convert logical top-k blocks into sorted, deduplicated physical page tables per KV head and request.
- Honor arbitrary positive strides for `block_table`, `seq_lens`, and the transposed top-k view.
- Validate the full required FlashInfer API surface, exact SM100/SM103 support, MiniMax geometry, dtypes, devices, layouts, and scalar FP8 scales.
- Keep FlashInfer metadata and multi-CTA counter buffers on a layer-owned runner.
- Grow buffers geometrically and retain superseded allocations for CUDA graph pointer safety.
- Share only the large zero-initialized workspace per device.
- Leave prefill and unsupported decode configurations on the existing Triton path.

This is not a duplicate of #48994, which targets the FlashInfer MSA backend on SM120/SM121, or #45744, which added FP8 sparse GQA while retaining Triton decode.

### FlashInfer dependency

[flashinfer-ai/flashinfer#3955](https://github.com/flashinfer-ai/flashinfer/pull/3955) merged on 2026-07-16. The validated source head is `19e00ef8b7473a5afee3c5059d412bca416f73d4` and reports version `0.6.15`.

vLLM currently pins `flashinfer-python==0.6.14` and `flashinfer-cubin==0.6.14`; that supported install does not contain this API. The runtime requires all of:

- `enable_block_sparse_attention`
- `bmm1_scale_log2`
- `multi_ctas_kv_counter_buffer`
- `get_trtllm_gen_multi_ctas_kv_counter_bytes`

As of 2026-07-21, PyPI and FlashInfer's official cubin index publish `0.6.15.post1`, but inspection of that Python wheel shows `bmm1_scale_log2` and `multi_ctas_kv_counter_buffer` while still omitting `enable_block_sparse_attention`. No dependency bump is included because the stock release therefore cannot enable this path. Keep this PR as a draft until vLLM can pin a released FlashInfer build with the complete API.

### Tests

Added `tests/kernels/attention/test_minimax_m3_flashinfer_sparse_decode.py` with coverage for:

- Strided metadata, ordering, deduplication, tail-page handling, and padding.
- Layer-owned geometric buffer growth, reuse, and retained graph allocations.
- Non-CUDA and unavailable-API fallback.
- FP8 K/V scales and mocked backend argument parity.
- CUDA graph capture and replay for normal decode metadata.
- Real Triton-versus-FlashInfer parity for q-length 1 across NHD and HND storage; these cases skip when the required API is absent.

Current results after rebasing onto upstream `main` at `1dca300653e63db8d6d00b2073d97bd6d59d3fd7`:

```text
ruff 0.14.0 format --check: passed
ruff 0.14.0 check: passed
python -m compileall: passed
git diff --check: passed
GitHub pre-commit workflow 29863717798: passed on the preceding commit
B300 SM103 focused CUDA pytest after speculative-support revert: 8 passed in 31.25s
```

The focused CUDA run used an NVIDIA B300 SXM6 AC with FlashInfer commit `19e00ef8b7473a5afee3c5059d412bca416f73d4` and the precompiled vLLM extension pinned to exact base `1dca300653e63db8d6d00b2073d97bd6d59d3fd7`. It passed normal q-length-1 metadata edge cases, pool growth/reuse, guarded fallback, CUDA graph capture/replay, and real FlashInfer-versus-Triton parity at `atol=0.02, rtol=0.02` for NHD batch 32/context 1000 and HND batch 1/context 8191.

A prior synchronized batch-128/context-8192 run also had zero mismatches, maximum absolute error `0.0001220703125`, and exact CUDA graph replay parity.

The prior DEP8 smoke returned `703` for `37 * 19` through both selectors. Long serving benchmarks were stopped before completion and are not claimed as valid throughput results.

### Scope

Speculative verification remains on the existing Triton path. Experimental q-length-greater-than-1 FlashInfer support was reverted in signed commit `77fad6981` after matched E2E serving tests showed no measurable benefit at capacity-matched concurrency 32 (+0.33%, within run-to-run noise) and a 48.75% regression at concurrency 128 because the shared 256 MiB workspace reduced KV-cache capacity. This PR now covers normal q-length-1 decode only.

### Draft status

Keep this PR in draft until vLLM can pin a released FlashInfer build containing the complete #3955 API.

### AI assistance

AI assistance was used to inspect, implement, test, and document this change. The human submitter should review every changed line before marking the PR ready.