### PR TITLE
[Bugfix] Fix DBRX weight loading crash after RoutedExperts refactor (#41184)

### DIFF
--- a/vllm/model_executor/models/dbrx.py
+++ b/vllm/model_executor/models/dbrx.py
@@ -383,7 +383,9 @@ class DbrxModel(nn.Module):
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         expert_params_mapping = [
             (
-                "w13" if weight_name in ["w1", "v1"] else "w2",
+                "routed_experts.w13"
+                if weight_name in ["w1", "v1"]
+                else "routed_experts.w2",
                 f"mlp.{weight_name}",
             )
             for weight_name in ["w1", "v1", "w2"]


### PR DESCRIPTION



## Purpose

Fixes #49004. `DbrxForCausalLM` crashes on load with `KeyError: 'blocks.0.ffn.experts.w13_weight'` on every backend (CPU/CUDA/plugin), before any device dispatch.

Root cause: #41184 moved MoE expert weights into a `routed_experts` submodule, so the parameter now lives at `...experts.routed_experts.w13_weight`. `DbrxModel.load_weights` uses a hand-rolled mapping that still emitted the old `...experts.w13_weight`, so the
`params_dict[name]` lookup fails. The follow-up #45054 patched this exact missing-prefix issue in five other MoE models but missed `dbrx.py` (one of the few not using `AutoWeightsLoader`). This adds the missing `routed_experts.` prefix. 
Not a duplicate: no open PR addresses #49004. I audited every model using `routed_experts_cls` — `aria.py` was already fixed by #45054, `transformers/moe.py` uses generic loading, so DBRX is the last one; no siblings remain.


## Test Plan

Built vLLM CPU from source and loaded the tiny DBRX test model, comparing the unfixed vs fixed mapping

## Test Result

- **Before (unfixed):** `KeyError: 'blocks.0.ffn.experts.w13_weight'` during `load_weights`, exactly as reported.
- **After (fixed):** weight loading completes and the model loads fully. (The tiny test model then fails at *inference* with `Unsupported CPU attention configuration: head_dim=4` — an unrelated CPU-kernel limitation of this stub model's head size, not the load path.)

`pre-commit run --files vllm/model_executor/models/dbrx.py` passes.

---
AI assistance (Claude Code) was used for this change; I reviewed every line and ran the tests above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

