### PR TITLE
[Bugfix] Fix Aria garbage output at TP>1: shared experts double all-reduce

### DIFF
--- a/vllm/model_executor/models/aria.py
+++ b/vllm/model_executor/models/aria.py
@@ -220,6 +220,9 @@ class AriaTextMoELayer(nn.Module):
             "silu",
             quant_config=quant_config,
             bias=config.mlp_bias,
+            # FusedMoE all-reduces the combined shared+routed output, so the
+            # shared experts must not reduce on their own.
+            reduce_results=False,
         )
 
         self.experts = FusedMoE(


### PR DESCRIPTION
## Purpose

Fix #49122 — `rhymes-ai/Aria` (`AriaForConditionalGeneration`) generates incoherent garbage at `tensor_parallel_size > 1`, with coherence degrading proportionally to TP size (coherent at TP=1, partially degraded at TP=2, fully garbage at TP=4).

**Root cause: the shared-experts output is all-reduced twice.**

`AriaTextMoELayer` passes its shared-experts `LlamaMLP` into `FusedMoE(shared_experts=...)`. The `MoERunner` contract is that it performs the tensor-parallel reduction itself, exactly once (see the note in `moe_runner.py` — either the combine kernel reduces `fused_output` and the runner then all-reduces `shared_output` separately in `_maybe_reduce_shared_expert_output`, or neither is reduced and the runner all-reduces `shared_output + fused_output` in `_maybe_reduce_final_output`). The shared-experts module must therefore return **unreduced per-rank partial sums**.

Aria constructed `LlamaMLP` without `reduce_results=False`, so its `RowParallelLinear` down-projection all-reduced its output first, and the runner reduced it again — scaling the shared-expert contribution by `tp_size`. This is invisible at TP=1 (all-reduce over one rank is the identity) and corrupts the residual stream progressively as TP grows, exactly matching the symptom table in the issue.

Every other in-tree model that passes `shared_experts` to `FusedMoE` already constructs it with `reduce_results=False`: `deepseek_v2`, `glm4_moe`, `ernie45_moe`, `bailing_moe`, `bailing_moe_linear`, `hunyuan_v1`, `afmoe`, `exaone_moe`, and `cohere2_moe` (via its MLP's default). Aria was the single outlier. The fix makes Aria consistent with all of them: one line, `reduce_results=False`.

## Why this is not duplicating an existing PR

Checked per the contribution policy before opening:
- No open PR references #49122 (`gh pr list --search "49122 in:body"` → empty).
- No open PR touches Aria's MoE layer or shared-experts reduction (`gh pr list --search "aria"` → only unrelated torch.compile / DBRX / WeightsMapper PRs).

## Test Plan

- `python -m py_compile vllm/model_executor/models/aria.py`
- Static verification against the `MoERunner` reduction contract and the nine sibling models listed above (all pass `reduce_results=False`; Aria was the only exception).
- Reproduction from the issue for e2e verification on multi-GPU hardware:
  ```bash
  vllm serve rhymes-ai/Aria --tensor-parallel-size 2 --max-model-len 4096
  curl -s http://localhost:8000/v1/completions -H "Content-Type: application/json" \
    -d '{"model": "rhymes-ai/Aria", "prompt": "The capital of France is", "max_tokens": 30}'
  ```
  TP=1 output is unaffected by this change (all-reduce over a single rank is the identity, and `reduce_results` only controls that collective).

## Test Result

- Compile check passes.
- I do not have multi-GPU hardware available to run the TP=2/TP=4 reproduction end-to-end; per #49122 the bug reproduces on CPU with gloo collectives as well, so any reviewer with a multi-core machine can verify. Happy to iterate if maintainers want an accompanying distributed test.

## AI assistance disclosure

This fix was developed with AI assistance (Claude Code). I have reviewed the change and the root-cause analysis. The diff is a single-argument change aligning Aria with the established `shared_experts` + `FusedMoE` pattern used by all other models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
