### PR TITLE
[Perf] Batch Mamba2 prefill SSM state saves, removing GPU<->CPU syncs

### DIFF
--- a/tests/kernels/mamba/test_mamba_mixer2.py
+++ b/tests/kernels/mamba/test_mamba_mixer2.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import unittest
+import random
+import unittest.mock
 
 import pytest
 import torch
@@ -11,9 +12,16 @@ from vllm.distributed.parallel_state import (
     init_distributed_environment,
     initialize_model_parallel,
 )
-from vllm.model_executor.layers.mamba.mamba_mixer2 import Mixer2RMSNormGated
+from vllm.model_executor.layers.mamba.mamba_mixer2 import (
+    MambaMixer2,
+    Mixer2RMSNormGated,
+)
+from vllm.utils.math_utils import cdiv
 from vllm.utils.system_utils import update_environment_variables
 from vllm.utils.torch_utils import set_random_seed
+
+_mixer = object.__new__(MambaMixer2)
+save_block_aligned_ssm_states = _mixer._save_block_aligned_ssm_states
 
 
 @multi_gpu_test(num_gpus=2)
@@ -136,3 +144,226 @@ def mixer2_gated_norm_tensor_parallel(
         atol=5e-3,
         rtol=1e-3,
     )
+
+
+def _reference_save_block_aligned_ssm_states(
+    ssm_state: torch.Tensor,
+    varlen_states: torch.Tensor,
+    state_indices_tensor_p: torch.Tensor,
+    block_idx_first_scheduled_token_p: torch.Tensor,
+    block_idx_last_scheduled_token_p: torch.Tensor,
+    last_chunk_indices_p: torch.Tensor,
+    num_computed_tokens_p: torch.Tensor,
+    mamba_block_size: int,
+    chunk_size: int,
+) -> None:
+    """Original per-sequence loop, kept verbatim as the reference."""
+    chunk_stride = mamba_block_size // chunk_size
+    num_prefills = state_indices_tensor_p.size(0)
+
+    for seq_idx in range(num_prefills):
+        # Block index for the first scheduled token
+        block_idx_first_scheduled_token = block_idx_first_scheduled_token_p[seq_idx]
+
+        # Block index for the last scheduled token
+        block_idx_last_scheduled_token = block_idx_last_scheduled_token_p[seq_idx]
+
+        # Number of blocks that need to be written
+        n_blocks_to_fill = (
+            block_idx_last_scheduled_token - block_idx_first_scheduled_token
+        )
+
+        # Skip sequences that don't have any blocks to fill
+        if n_blocks_to_fill == 0:
+            continue
+
+        # Look up the state indices
+        cache_blocks_to_fill = state_indices_tensor_p[
+            seq_idx,
+            block_idx_first_scheduled_token:block_idx_last_scheduled_token,
+        ]
+
+        # First chunk index for this sequence
+        if seq_idx == 0:  # noqa: SIM108 - kept verbatim
+            first_chunk = 0
+        else:
+            first_chunk = 1 + last_chunk_indices_p[seq_idx - 1]
+
+        # First chunk that is aligned on the mamba block boundary
+        first_aligned_chunk = first_chunk + chunk_stride - 1
+
+        # Calculate the number of computed tokens that were not
+        # already cached
+        num_unaligned_computed_tokens = num_computed_tokens_p[seq_idx] % (
+            mamba_block_size
+        )
+
+        if num_unaligned_computed_tokens > 0:
+            # If the number of computed tokens is not block aligned,
+            # then we need to shift the index accordingly
+            first_aligned_chunk -= num_unaligned_computed_tokens // chunk_size
+
+        # Get states to write
+        from_where = varlen_states[
+            first_aligned_chunk : first_aligned_chunk
+            + n_blocks_to_fill * chunk_stride : chunk_stride
+        ]
+
+        # Write the states
+        ssm_state[cache_blocks_to_fill] = from_where
+
+
+def _make_prefill_workload(
+    rng: random.Random,
+    num_prefills: int,
+    mamba_block_size: int,
+    chunk_size: int,
+    aligned: bool | None = None,
+    max_new_tokens: int | None = None,
+) -> tuple[torch.Tensor, dict]:
+    """Build an ssm_state cache plus internally consistent prefill metadata,
+    mirroring how the mamba attention metadata builder derives the chunk
+    layout and the prefix-caching block indices."""
+    num_computed = []
+    new_tokens = []
+    for _ in range(num_prefills):
+        if aligned is True:
+            computed = rng.randint(0, 3) * mamba_block_size
+        elif aligned is False:
+            computed = rng.randint(0, 3) * mamba_block_size + rng.randint(
+                1, mamba_block_size - 1
+            )
+        else:
+            computed = rng.randint(0, 3 * mamba_block_size)
+        num_computed.append(computed)
+        new_tokens.append(rng.randint(1, max_new_tokens or 4 * mamba_block_size))
+
+    last_chunk_indices = []
+    total_chunks = 0
+    for computed, scheduled in zip(num_computed, new_tokens):
+        remaining = scheduled
+        n_chunks = 0
+        # if computed tokens are not chunk-aligned, the first chunk
+        # finishes off the partial chunk
+        if computed % chunk_size != 0:
+            realign_len = min(
+                cdiv(computed, chunk_size) * chunk_size - computed, remaining
+            )
+            remaining -= realign_len
+            n_chunks += 1
+        n_chunks += cdiv(remaining, chunk_size)
+        total_chunks += n_chunks
+        last_chunk_indices.append(total_chunks - 1)
+
+    block_idx_first_scheduled_token = [
+        cdiv(computed + 1, mamba_block_size) - 1 for computed in num_computed
+    ]
+    block_idx_last_scheduled_token = [
+        max(cdiv(computed + scheduled, mamba_block_size) - 1, 0)
+        for computed, scheduled in zip(num_computed, new_tokens)
+    ]
+
+    # Distinct cache block per (sequence, block index) pair, as guaranteed
+    # by the block manager
+    max_blocks_per_seq = max(block_idx_last_scheduled_token) + 1
+    num_blocks = num_prefills * max_blocks_per_seq
+    block_ids = list(range(num_blocks))
+    rng.shuffle(block_ids)
+    state_indices_tensor = torch.tensor(block_ids, dtype=torch.int32).view(
+        num_prefills, max_blocks_per_seq
+    )
+
+    nheads, headdim, dstate = 2, 4, 8
+    ssm_state = torch.randn(num_blocks, nheads, headdim, dstate)
+    workload = dict(
+        varlen_states=torch.randn(total_chunks, nheads, headdim, dstate),
+        state_indices_tensor_p=state_indices_tensor,
+        block_idx_first_scheduled_token_p=torch.tensor(
+            block_idx_first_scheduled_token, dtype=torch.int32
+        ),
+        block_idx_last_scheduled_token_p=torch.tensor(
+            block_idx_last_scheduled_token, dtype=torch.int32
+        ),
+        last_chunk_indices_p=torch.tensor(last_chunk_indices, dtype=torch.int32),
+        num_computed_tokens_p=torch.tensor(num_computed, dtype=torch.int32),
+        mamba_block_size=mamba_block_size,
+        chunk_size=chunk_size,
+    )
+    return ssm_state, workload
+
+
+def _assert_matches_reference(ssm_state: torch.Tensor, workload: dict) -> None:
+    ssm_state_ref = ssm_state.clone()
+    ssm_state_out = ssm_state.clone()
+    _reference_save_block_aligned_ssm_states(ssm_state_ref, **workload)
+    save_block_aligned_ssm_states(ssm_state_out, **workload)
+    assert torch.equal(ssm_state_out, ssm_state_ref)
+
+
+@pytest.mark.parametrize(
+    "mamba_block_size,chunk_size",
+    [(64, 64), (64, 32), (64, 16), (512, 256)],  # chunk_stride 1, 2, 4, 2
+)
+@pytest.mark.parametrize("num_prefills", [1, 2, 8, 32])
+@pytest.mark.parametrize("aligned", [None, True, False])
+def test_save_block_aligned_random_workloads(
+    mamba_block_size: int, chunk_size: int, num_prefills: int, aligned: bool | None
+):
+    """Randomized batches; alignment mode steers the chunk-shift branch."""
+    rng = random.Random(mamba_block_size * 1000 + num_prefills)
+    for _ in range(5):
+        ssm_state, workload = _make_prefill_workload(
+            rng, num_prefills, mamba_block_size, chunk_size, aligned=aligned
+        )
+        _assert_matches_reference(ssm_state, workload)
+
+
+def test_save_block_aligned_zero_fill_mix():
+    """Short sequences interleave with filling ones, including trailing
+    sequences whose first_aligned_chunk lands past the end of varlen_states
+    but is dropped by their zero fill count."""
+    rng = random.Random(0)
+    for _ in range(10):
+        ssm_state, workload = _make_prefill_workload(
+            rng, 16, 512, 256, max_new_tokens=512
+        )
+        _assert_matches_reference(ssm_state, workload)
+
+
+def test_save_block_aligned_nothing_to_fill():
+    """Block-aligned sequences shorter than a mamba block leave the cache
+    untouched (the batched path early-outs)."""
+    rng = random.Random(0)
+    ssm_state, workload = _make_prefill_workload(
+        rng, 8, 512, 256, aligned=True, max_new_tokens=512
+    )
+    ssm_state_before = ssm_state.clone()
+    save_block_aligned_ssm_states(ssm_state, **workload)
+    assert torch.equal(ssm_state, ssm_state_before)
+
+
+def test_save_block_aligned_worked_example():
+    """Hand-computed batch (mamba_block_size=512, chunk_size=256):
+    seq A fresh with 1300 tokens (chunks 0-5) fills block columns 0-1,
+    seq B resumed mid-block at 768 with 512 tokens (chunks 6-7) fills
+    column 1 via the unaligned shift, and seq C fresh with 200 tokens
+    (chunk 8) fills nothing. The whole batch collapses to
+    ssm_state[[17, 4, 11]] = varlen_states[[1, 3, 6]]."""
+    ssm_state = torch.randn(24, 2, 4, 8)
+    varlen_states = torch.randn(9, 2, 4, 8)
+    workload = dict(
+        varlen_states=varlen_states,
+        state_indices_tensor_p=torch.tensor(
+            [[17, 4, 9], [3, 11, 22], [7, 19, 20]], dtype=torch.int32
+        ),
+        block_idx_first_scheduled_token_p=torch.tensor([0, 1, 0], dtype=torch.int32),
+        block_idx_last_scheduled_token_p=torch.tensor([2, 2, 0], dtype=torch.int32),
+        last_chunk_indices_p=torch.tensor([5, 7, 8], dtype=torch.int32),
+        num_computed_tokens_p=torch.tensor([0, 768, 0], dtype=torch.int32),
+        mamba_block_size=512,
+        chunk_size=256,
+    )
+    expected = ssm_state.clone()
+    expected[[17, 4, 11]] = varlen_states[[1, 3, 6]]
+    save_block_aligned_ssm_states(ssm_state, **workload)
+    assert torch.equal(ssm_state, expected)

--- a/tests/v1/attention/test_mamba_update_block_table.py
+++ b/tests/v1/attention/test_mamba_update_block_table.py
@@ -431,3 +431,41 @@ def test_block_idx_prev_step_cudagraph_capture_uses_persistent_buffer():
 
     # Tail values past num_decodes: zero-filled padding for cudagraph capture.
     assert torch.all(out.block_idx_last_scheduled_token_prev_step[num_decodes:] == 0)
+
+
+def test_num_state_writes_p_matches_block_idx_tensors():
+    """The prefill state save sizes its batched copy from
+    num_state_writes_p instead of reading the block index tensors back from
+    the GPU, so the host count must equal what those tensors say."""
+
+    # (block_size, seq_lens, query_lens, is_prefilling)
+    cases = [
+        # block-aligned and unaligned computed tokens, and a chunked prefill
+        (16, [64, 33, 17], [48, 17, 1], [True, True, True]),
+        (32, [200, 100, 64], [200, 36, 64], [True, True, True]),
+        # decode rows ahead of the prefills
+        (16, [40, 41, 100, 200], [1, 1, 60, 200], [False, False, True, True]),
+        # prefills that stay inside their first block: nothing to write
+        (16, [65, 66, 67], [1, 2, 3], [True, True, True]),
+    ]
+
+    for block_size, seq_lens, query_lens, is_prefilling in cases:
+        metadata = MockMambaBuilder.build_mamba_metadata(
+            _make_vllm_config(4096, len(seq_lens), block_size=block_size),
+            seq_lens=seq_lens,
+            query_lens=query_lens,
+            is_prefilling=is_prefilling,
+        )
+        num_reqs, num_prefills = metadata.num_reqs, metadata.num_prefills
+        block_idx_last_p = metadata.block_idx_last_scheduled_token[
+            num_reqs - num_prefills : num_reqs
+        ]
+        expected = int(
+            (block_idx_last_p - metadata.block_idx_first_scheduled_token_p)
+            .clamp(min=0)
+            .sum()
+        )
+
+        assert metadata.num_state_writes_p == expected, (
+            f"seq_lens={seq_lens} query_lens={query_lens} block_size={block_size}"
+        )

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -882,63 +882,56 @@ class MambaMixer2(MambaBase, PluggableLayer):
                 # then chunk_stride = 2
                 chunk_stride = mamba_block_size // chunk_size
 
-                # Save state for sequences with more than just final state
-                for seq_idx in range(num_prefills):
-                    # Block index for the first scheduled token
-                    block_idx_first_scheduled_token = block_idx_first_scheduled_token_p[
-                        seq_idx
-                    ]
+                # Save state for sequences with more than just final state.
+                # The copy is batched across all sequences, since a
+                # per-sequence loop causes one kernel launch and one GPU->CPU
+                # sync per prefill request.
 
-                    # Block index for the last scheduled token
-                    block_idx_last_scheduled_token = block_idx_last_scheduled_token_p[
-                        seq_idx
-                    ]
+                # Number of blocks that need to be written per sequence
+                n_blocks_to_fill = (
+                    block_idx_last_scheduled_token_p - block_idx_first_scheduled_token_p
+                ).clamp(min=0)
+                total_fill = int(n_blocks_to_fill.sum().item())
+                if total_fill > 0:
+                    # First chunk index for each sequence
+                    first_chunk = torch.zeros_like(last_chunk_indices_p)
+                    first_chunk[1:] = last_chunk_indices_p[:-1] + 1
 
-                    # Number of blocks that need to be written
-                    n_blocks_to_fill = (
-                        block_idx_last_scheduled_token - block_idx_first_scheduled_token
-                    )
-
-                    # Skip sequences that don't have any blocks to fill
-                    if n_blocks_to_fill == 0:
-                        continue
-
-                    # Look up the state indices
-                    cache_blocks_to_fill = state_indices_tensor_p[
-                        seq_idx,
-                        block_idx_first_scheduled_token:block_idx_last_scheduled_token,
-                    ]
-
-                    # First chunk index for this sequence
-                    if seq_idx == 0:
-                        first_chunk = 0
-                    else:
-                        first_chunk = 1 + last_chunk_indices_p[seq_idx - 1]
-
-                    # First chunk that is aligned on the mamba block boundary
-                    first_aligned_chunk = first_chunk + chunk_stride - 1
-
-                    # Calculate the number of computed tokens that were not
-                    # already cached
+                    # First chunk that is aligned on the mamba block boundary.
+                    # When the computed tokens are not block aligned, the
+                    # first boundary comes earlier by
+                    # (num_unaligned_computed_tokens // chunk_size) chunks.
                     num_unaligned_computed_tokens = (
-                        num_computed_tokens_p[seq_idx] % mamba_block_size
+                        num_computed_tokens_p % mamba_block_size
+                    )
+                    unaligned_chunk_shift = num_unaligned_computed_tokens // chunk_size
+                    first_aligned_chunk = (
+                        first_chunk + (chunk_stride - 1) - unaligned_chunk_shift
                     )
 
-                    if num_unaligned_computed_tokens > 0:
-                        # If the number of computed tokens is not block aligned,
-                        # then we need to shift the index accordingly
-                        first_aligned_chunk -= (
-                            num_unaligned_computed_tokens // chunk_size
-                        )
+                    # Flatten the writes of all sequences into one list,
+                    # e.g. fill_counts=[2,1,2] -> seq_ids=[0,0,1,2,2],
+                    # write_offsets=[0,1,0,0,1]
+                    fill_counts = n_blocks_to_fill.long()
+                    seq_ids = torch.repeat_interleave(
+                        torch.arange(num_prefills, device=ssm_state.device),
+                        fill_counts,
+                    )
+                    write_starts = torch.cumsum(fill_counts, dim=0) - fill_counts
+                    write_offsets = torch.arange(
+                        total_fill, device=ssm_state.device
+                    ) - torch.repeat_interleave(write_starts, fill_counts)
 
-                    # Get states to write
-                    from_where = varlen_states[
-                        first_aligned_chunk : first_aligned_chunk
-                        + n_blocks_to_fill * chunk_stride : chunk_stride
+                    cache_blocks_to_fill = state_indices_tensor_p[
+                        seq_ids,
+                        block_idx_first_scheduled_token_p[seq_ids] + write_offsets,
                     ]
-
-                    # Write the states
-                    ssm_state[cache_blocks_to_fill] = from_where
+                    # Each write goes to a distinct cache block, so there are
+                    # no duplicate indices and the indexed copy is
+                    # deterministic.
+                    ssm_state[cache_blocks_to_fill] = varlen_states[
+                        first_aligned_chunk[seq_ids] + write_offsets * chunk_stride
+                    ]
 
                 # For all seqs, store the last state (note: might be partial):
                 assert state_indices_tensor_p is not None

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -666,6 +666,71 @@ class MambaMixer2(MambaBase, PluggableLayer):
         logger.debug("Mamba2 SSD kernel warmup completed for layer %s", self.prefix)
         torch.accelerator.empty_cache()
 
+    def _save_block_aligned_ssm_states(
+        self,
+        ssm_state: torch.Tensor,
+        varlen_states: torch.Tensor,
+        state_indices_tensor_p: torch.Tensor,
+        block_idx_first_scheduled_token_p: torch.Tensor,
+        block_idx_last_scheduled_token_p: torch.Tensor,
+        last_chunk_indices_p: torch.Tensor,
+        num_computed_tokens_p: torch.Tensor,
+        mamba_block_size: int,
+        chunk_size: int,
+    ) -> None:
+        """Save the mamba-block-aligned intermediate SSM states of prefill
+        sequences into the cache. The copy is batched across all sequences,
+        since a per-sequence loop causes one kernel launch and one GPU->CPU
+        sync per prefill request.
+        """
+        # The chunk_stride is the number of chunks per mamba block
+        # e.g., if mamba_block_size = 512 and chunk_size = 256,
+        # then chunk_stride = 2
+        chunk_stride = mamba_block_size // chunk_size
+
+        num_prefills = state_indices_tensor_p.size(0)
+
+        # Number of blocks that need to be written per sequence
+        n_blocks_to_fill = (
+            block_idx_last_scheduled_token_p - block_idx_first_scheduled_token_p
+        ).clamp(min=0)
+        total_fill = int(n_blocks_to_fill.sum().item())
+        if total_fill == 0:
+            return
+
+        # First chunk index for each sequence
+        first_chunk = torch.zeros_like(last_chunk_indices_p)
+        first_chunk[1:] = last_chunk_indices_p[:-1] + 1
+
+        # First chunk that is aligned on the mamba block boundary. When the
+        # computed tokens are not block aligned, the first boundary comes
+        # earlier by (num_unaligned_computed_tokens // chunk_size) chunks.
+        num_unaligned_computed_tokens = num_computed_tokens_p % mamba_block_size
+        unaligned_chunk_shift = num_unaligned_computed_tokens // chunk_size
+        first_aligned_chunk = first_chunk + (chunk_stride - 1) - unaligned_chunk_shift
+
+        # Flatten the writes of all sequences into one list,
+        # e.g. fill_counts=[2,1,2] -> seq_ids=[0,0,1,2,2], write_offsets=[0,1,0,0,1]
+        fill_counts = n_blocks_to_fill.long()
+        seq_ids = torch.repeat_interleave(
+            torch.arange(num_prefills, device=ssm_state.device),
+            fill_counts,
+        )
+        write_starts = torch.cumsum(fill_counts, dim=0) - fill_counts
+        write_offsets = torch.arange(
+            total_fill, device=ssm_state.device
+        ) - torch.repeat_interleave(write_starts, fill_counts)
+
+        cache_blocks_to_fill = state_indices_tensor_p[
+            seq_ids,
+            block_idx_first_scheduled_token_p[seq_ids] + write_offsets,
+        ]
+        # Each write goes to a distinct cache block, so there are no
+        # duplicate indices and the indexed copy is deterministic.
+        ssm_state[cache_blocks_to_fill] = varlen_states[
+            first_aligned_chunk[seq_ids] + write_offsets * chunk_stride
+        ]
+
     def conv_ssm_forward(
         self,
         projected_states: torch.Tensor,
@@ -877,61 +942,18 @@ class MambaMixer2(MambaBase, PluggableLayer):
                 assert last_chunk_indices_p is not None
                 assert num_computed_tokens_p is not None
 
-                # The chunk_stride is the number of chunks per mamba block
-                # e.g., if mamba_block_size = 512 and chunk_size = 256,
-                # then chunk_stride = 2
-                chunk_stride = mamba_block_size // chunk_size
-
-                # Save state for sequences with more than just final state.
-                # The copy is batched across all sequences, since a
-                # per-sequence loop causes one kernel launch and one GPU->CPU
-                # sync per prefill request.
-
-                # Number of blocks that need to be written per sequence
-                n_blocks_to_fill = (
-                    block_idx_last_scheduled_token_p - block_idx_first_scheduled_token_p
-                ).clamp(min=0)
-                total_fill = int(n_blocks_to_fill.sum().item())
-                if total_fill > 0:
-                    # First chunk index for each sequence
-                    first_chunk = torch.zeros_like(last_chunk_indices_p)
-                    first_chunk[1:] = last_chunk_indices_p[:-1] + 1
-
-                    # First chunk that is aligned on the mamba block boundary.
-                    # When the computed tokens are not block aligned, the
-                    # first boundary comes earlier by
-                    # (num_unaligned_computed_tokens // chunk_size) chunks.
-                    num_unaligned_computed_tokens = (
-                        num_computed_tokens_p % mamba_block_size
-                    )
-                    unaligned_chunk_shift = num_unaligned_computed_tokens // chunk_size
-                    first_aligned_chunk = (
-                        first_chunk + (chunk_stride - 1) - unaligned_chunk_shift
-                    )
-
-                    # Flatten the writes of all sequences into one list,
-                    # e.g. fill_counts=[2,1,2] -> seq_ids=[0,0,1,2,2],
-                    # write_offsets=[0,1,0,0,1]
-                    fill_counts = n_blocks_to_fill.long()
-                    seq_ids = torch.repeat_interleave(
-                        torch.arange(num_prefills, device=ssm_state.device),
-                        fill_counts,
-                    )
-                    write_starts = torch.cumsum(fill_counts, dim=0) - fill_counts
-                    write_offsets = torch.arange(
-                        total_fill, device=ssm_state.device
-                    ) - torch.repeat_interleave(write_starts, fill_counts)
-
-                    cache_blocks_to_fill = state_indices_tensor_p[
-                        seq_ids,
-                        block_idx_first_scheduled_token_p[seq_ids] + write_offsets,
-                    ]
-                    # Each write goes to a distinct cache block, so there are
-                    # no duplicate indices and the indexed copy is
-                    # deterministic.
-                    ssm_state[cache_blocks_to_fill] = varlen_states[
-                        first_aligned_chunk[seq_ids] + write_offsets * chunk_stride
-                    ]
+                # Save state for sequences with more than just final state
+                self._save_block_aligned_ssm_states(
+                    ssm_state,
+                    varlen_states,
+                    state_indices_tensor_p,
+                    block_idx_first_scheduled_token_p,
+                    block_idx_last_scheduled_token_p,
+                    last_chunk_indices_p,
+                    num_computed_tokens_p,
+                    mamba_block_size,
+                    chunk_size,
+                )
 
                 # For all seqs, store the last state (note: might be partial):
                 assert state_indices_tensor_p is not None

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -48,7 +48,6 @@ from vllm.model_executor.model_loader.weight_utils import (
 from vllm.model_executor.parameter import BasevLLMParameter
 from vllm.model_executor.utils import set_weight_attrs
 from vllm.platforms import current_platform
-from vllm.utils.gpu_sync_debug import gpu_sync_allowed
 from vllm.utils.torch_utils import (
     LayerNameType,
     _encode_layer_name,
@@ -905,67 +904,54 @@ class MambaMixer2(MambaBase, PluggableLayer):
                 # then chunk_stride = 2
                 chunk_stride = mamba_block_size // chunk_size
 
-                # The per-sequence loop below uses these as Python scalars.
-                # TODO avoid sync here?
-                with gpu_sync_allowed():
-                    block_idx_first_cpu = block_idx_first_scheduled_token_p.tolist()
-                    block_idx_last_cpu = block_idx_last_scheduled_token_p.tolist()
-                    num_computed_tokens_p_cpu = num_computed_tokens_p.tolist()
-                    last_chunk_indices_p_cpu = last_chunk_indices_p.tolist()
+                # Save state for sequences with more than just final state,
+                # batched over sequences so that the number of kernel launches
+                # does not scale with the number of prefills.
+                n_blocks_to_fill = (
+                    block_idx_last_scheduled_token_p - block_idx_first_scheduled_token_p
+                ).clamp(min=0)
+                total_fill = attn_metadata.num_state_writes_p
+                if total_fill > 0:
+                    first_chunk = torch.zeros_like(last_chunk_indices_p)
+                    first_chunk[1:] = last_chunk_indices_p[:-1] + 1
 
-                # Save state for sequences with more than just final state
-                for seq_idx in range(num_prefills):
-                    # Block index for the first scheduled token
-                    block_idx_first_scheduled_token = block_idx_first_cpu[seq_idx]
-
-                    # Block index for the last scheduled token
-                    block_idx_last_scheduled_token = block_idx_last_cpu[seq_idx]
-
-                    # Number of blocks that need to be written
-                    n_blocks_to_fill = (
-                        block_idx_last_scheduled_token - block_idx_first_scheduled_token
-                    )
-
-                    # Skip sequences that don't have any blocks to fill
-                    if n_blocks_to_fill == 0:
-                        continue
-
-                    # Look up the state indices
-                    cache_blocks_to_fill = state_indices_tensor_p[
-                        seq_idx,
-                        block_idx_first_scheduled_token:block_idx_last_scheduled_token,
-                    ]
-
-                    # First chunk index for this sequence
-                    if seq_idx == 0:
-                        first_chunk = 0
-                    else:
-                        first_chunk = 1 + last_chunk_indices_p_cpu[seq_idx - 1]
-
-                    # First chunk that is aligned on the mamba block boundary
-                    first_aligned_chunk = first_chunk + chunk_stride - 1
-
-                    # Calculate the number of computed tokens that were not
-                    # already cached
+                    # The chunk that completes this sequence's first mamba block.
+                    # A block spans chunk_stride chunks. When the sequence resumed
+                    # mid-block, the chunks before this step are not in varlen_states,
+                    # so subtract them: the boundary sits earlier by their count.
                     num_unaligned_computed_tokens = (
-                        num_computed_tokens_p_cpu[seq_idx] % mamba_block_size
+                        num_computed_tokens_p % mamba_block_size
+                    )
+                    unaligned_chunk_shift = num_unaligned_computed_tokens // chunk_size
+                    first_aligned_chunk = (
+                        first_chunk + (chunk_stride - 1) - unaligned_chunk_shift
                     )
 
-                    if num_unaligned_computed_tokens > 0:
-                        # If the number of computed tokens is not block aligned,
-                        # then we need to shift the index accordingly
-                        first_aligned_chunk -= (
-                            num_unaligned_computed_tokens // chunk_size
-                        )
+                    # Flatten all writes into one list: fill_counts=[2,1,2]
+                    # -> seq_ids=[0,0,1,2,2], write_offsets=[0,1,0,0,1]
+                    fill_counts = n_blocks_to_fill.long()
+                    # output_size, or repeat_interleave reads the size off the device
+                    seq_ids = torch.repeat_interleave(
+                        torch.arange(num_prefills, device=ssm_state.device),
+                        fill_counts,
+                        output_size=total_fill,
+                    )
+                    write_starts = torch.cumsum(fill_counts, dim=0) - fill_counts
+                    write_offsets = torch.arange(
+                        total_fill, device=ssm_state.device
+                    ) - torch.repeat_interleave(
+                        write_starts, fill_counts, output_size=total_fill
+                    )
 
-                    # Get states to write
-                    from_where = varlen_states[
-                        first_aligned_chunk : first_aligned_chunk
-                        + n_blocks_to_fill * chunk_stride : chunk_stride
+                    cache_blocks_to_fill = state_indices_tensor_p[
+                        seq_ids,
+                        block_idx_first_scheduled_token_p[seq_ids] + write_offsets,
                     ]
-
-                    # Write the states
-                    ssm_state[cache_blocks_to_fill] = from_where
+                    # Write the states. Each row goes to its own cache block,
+                    # so the indexed copy has no duplicate destinations.
+                    ssm_state[cache_blocks_to_fill] = varlen_states[
+                        first_aligned_chunk[seq_ids] + write_offsets * chunk_stride
+                    ]
 
                 # For all seqs, store the last state (note: might be partial):
                 assert state_indices_tensor_p is not None

--- a/vllm/v1/attention/backends/mamba_attn.py
+++ b/vllm/v1/attention/backends/mamba_attn.py
@@ -69,6 +69,10 @@ class BaseMambaAttentionMetadata:
     # last_chunk_indices_p is a tensor of shape (batch,) that contains the
     # index of the last chunk for every sequence in the (prefill) batch.
     last_chunk_indices_p: torch.Tensor | None = None
+    # Number of block-aligned SSM states the prefill path writes, i.e.
+    # sum(block_idx_last_scheduled_token_p - block_idx_first_scheduled_token_p).
+    # From CPU data, so batching those writes needs no D2H sync.
+    num_state_writes_p: int = 0
 
     # The following attributes are for triton implementation of causal_conv1d
     nums_dict: dict | None = None
@@ -495,6 +499,7 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
         block_idx_last_computed_token = None
         block_idx_last_scheduled_token = None
         block_idx_last_scheduled_token_prev_step = None
+        num_state_writes_p = 0
 
         # for causal_conv1d
         nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
@@ -586,6 +591,23 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
                     num_reqs - num_prefills : num_reqs
                 ]
 
+                # How many block-aligned states prefill will write: the same
+                # (block_idx_last - block_idx_first) as above, from CPU data so
+                # the mixer needs no D2H read. The -1 in both indices cancels.
+                block_size = self.kv_cache_spec.block_size
+                seq_lens_p_cpu = seq_lens_cpu[num_reqs - num_prefills : num_reqs]
+                num_computed_tokens_p_cpu = seq_lens_p_cpu - (
+                    query_start_loc_p_cpu[1:] - query_start_loc_p_cpu[:-1]
+                )
+                num_state_writes_p = int(
+                    (
+                        (seq_lens_p_cpu + block_size - 1) // block_size
+                        - (num_computed_tokens_p_cpu + block_size) // block_size
+                    )
+                    .clamp(min=0)
+                    .sum()
+                )
+
         if self.use_replayssm and num_decodes > 0:
             decode_base_cpu = common_attn_metadata.replayssm_decode_base_cpu
             num_computed_tokens_cpu = common_attn_metadata._num_computed_tokens_cpu
@@ -675,6 +697,7 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
             query_start_loc_d=query_start_loc_d,
             block_idx_last_scheduled_token=block_idx_last_scheduled_token,
             block_idx_first_scheduled_token_p=block_idx_first_scheduled_token_p,
+            num_state_writes_p=num_state_writes_p,
             block_idx_last_computed_token=block_idx_last_computed_token,
             block_idx_last_scheduled_token_prev_step=(
                 block_idx_last_scheduled_token_prev_step


### PR DESCRIPTION
## Purpose

`MambaMixer2.conv_ssm_forward` saves the block-aligned SSM states of each prefill sequence in a Python loop over `num_prefills`. #43107 moved the four scalar reads that loop needs out of it and left a `# TODO avoid sync here?` there. This removes the loop, so those four `.tolist()` calls go with it and no GPU<->CPU sync is left on this path. The writes of all sequences become one pair of index tensors and a single indexed copy.

The write count has to be a host value, so it comes from the metadata builder as `num_state_writes_p`, derived from CPU data the way #51738's `_prefill_cpu_metadata` does — the chunk metadata already depends on that same equality. One other detail: `torch.repeat_interleave(x, counts)` reads its output size off the device unless `output_size=` is passed, so both calls pass it.

## Test plan

New case in `tests/v1/attention/test_mamba_update_block_table.py` for the host-vs-device equality this relies on; `tests/v1/e2e/general/test_mamba_prefix_cache.py` already covers the path itself. Offline, the batched version is bit-identical to the deleted loop over 250 randomized workloads (4,766 state writes) spanning block/chunk ratios 1–4 and 1–32 prefills.

## Test result

Serving, measured on 2026-09-22 with `vllm serve` and `vllm bench serve` on current main (`4868312128`), `mamba_cache_mode=all`, prefix caching on. The client keeps 64 requests in flight, prompts are random tokens of a fixed length, and each request generates 8 tokens. Each arm ran on 2 fresh servers with 3 benches per server, alternating baseline and patched. Both GPUs use `--max-num-batched-tokens 8192`.

| GPU | model | input len | TTFT median | TTFT p99 | req/s |
|---|---|---|---|---|---|
| H100 | Nemotron-3-Nano-30B-A3B-BF16 | 8192 | 8387 → 7211 ms (−14.0%) | 9473 → 8002 ms (−15.5%) | 6.7 → 7.9 (+17.7%) |
| A100-80GB | granite-4.0-h-tiny | 1536 | 1064 → 862 ms (−19.0%) | 2600 → 2081 ms (−20.0%) | 24.6 → 30.5 (+24.1%) |
| H100 | granite-4.0-h-tiny | 1536 | 648 → 629 ms (−3.0%) | 1556 → 1514 ms (−2.7%) | 41.0 → 42.1 (+2.7%) |

The gain depends on what the step is waiting on. In the first two rows the GPU is the bottleneck and the CPU runs ahead of it. Each sync then drains the launch queue and the GPU idles until the CPU catches up. I sampled `nvidia-smi` during the benches, and GPU utilization went from about 80% to 100% in both of those rows. In the last row the engine core sits at 100% of one CPU core and the GPU at about 55% in both arms, so the syncs were not costing anything there and the change is neutral. The two ranges overlap in that row and do not overlap in the other two.

Nemotron needs 8192-token prompts here because `mamba_cache_mode=all` resolves its mamba block to 2176 tokens, and a shorter prompt never crosses a block boundary.

Offline prefill batch on the same commit, A100-80GB, `granite-4.0-h-tiny`, 256 × 1536-token prompts, `mamba_cache_mode=all`, alternating baseline and patched, 3 runs each:

| version | wall (s) |
|---|---|
| baseline | 9.905 ± 0.253 |
| patched | 8.525 ± 0.052 |

**13.9% end to end.** The two arms do not overlap: the fastest baseline run (9.717 s) is still slower than the slowest patched run (8.582 s). A separate pinned-batch run on the same GPU (greedy, 4 runs) gives the same output token ids and the same scheduling counters with and without the patch, so the win is host-side rather than a scheduling difference. This is measured after #43107, #51738 and #52506 landed in the same files.

## Notes

Developed with Claude Code. I reviewed every line and ran the tests myself.

Duplicate check: the loop, the TODO and the four `.tolist()` calls are all still on `main`, and no open or merged PR batches this loop or removes these syncs. The nearest is #51738, a different sync in the same file.


