### PR TITLE
[Docs] Document NVFP4 GEMM kernel selection and Marlin weight-only fallback

### DIFF
--- a/docs/features/quantization/modelopt.md
+++ b/docs/features/quantization/modelopt.md
@@ -19,6 +19,16 @@ following `quantization.quant_algo` values:
 - `NVFP4`: ModelOpt NVFP4 checkpoints (use `quantization="modelopt_fp4"`).
 - `MXFP8`: ModelOpt MXFP8 checkpoints (use `quantization="modelopt_mxfp8"`).
 
+!!! note
+    For NVFP4 checkpoints, vLLM selects a GEMM kernel automatically at load
+    time from the backends available on the current platform (CUTLASS,
+    FlashInfer, Marlin, and others). On GPUs without a supported native FP4
+    GEMM kernel, vLLM falls back to weight-only (W4A16) execution via Marlin
+    and logs a warning; this may reduce throughput for compute-heavy
+    workloads. Use `--linear-backend` to override the automatic selection
+    (this replaces the deprecated `VLLM_NVFP4_GEMM_BACKEND` environment
+    variable).
+
 ## Quantizing HuggingFace Models with PTQ
 
 You can quantize HuggingFace models using the example scripts provided in the Model Optimizer repository. The primary script for LLM PTQ is typically found within the `examples/llm_ptq` directory.

--- a/docs/features/quantization/modelopt.md
+++ b/docs/features/quantization/modelopt.md
@@ -27,7 +27,11 @@ following `quantization.quant_algo` values:
     and logs a warning; this may reduce throughput for compute-heavy
     workloads. Use `--linear-backend` to override the automatic selection
     (this replaces the deprecated `VLLM_NVFP4_GEMM_BACKEND` environment
-    variable).
+    variable). Values relevant to NVFP4 include `cutlass`,
+    `flashinfer_cutlass`, `flashinfer_trtllm`, `flashinfer_cudnn`, and
+    `marlin`; the full list is documented under `KernelConfig` on the
+    [Engine Arguments](../../configuration/engine_args.md) page and shown by
+    `vllm serve --help=KernelConfig`.
 
 ## Quantizing HuggingFace Models with PTQ
 


### PR DESCRIPTION
## Purpose

Users hitting slow NVFP4 performance have no docs explaining which GEMM kernel vLLM picked or why. This adds a short note to the ModelOpt guide covering:

- Kernel selection happens automatically at load time, based on what the GPU supports.
- GPUs without a native FP4 GEMM kernel fall back to weight-only (W4A16) Marlin, which logs a warning and can cost throughput.
- `--linear-backend` overrides the choice, replacing the deprecated `VLLM_NVFP4_GEMM_BACKEND`.

Prompted by #48491, which reports `torch._scaled_mm` rejecting NVFP4 GEMMs with `M < 128`. vLLM doesn't use `torch._scaled_mm` for NVFP4 — selection happens in `init_nvfp4_linear_kernel` (`vllm/model_executor/kernels/linear/__init__.py`) across FlashInfer-CUTLASS, CUTLASS, Marlin, FlashInfer-TRTLLM/cuDNN, FBGEMM, and emulation. An earlier revision of this PR documented the cuBLAS constraint; this one documents what vLLM actually does. Selection is per-platform, not per-`M`, so the note avoids framing it as a batch-size effect.

Not a duplicate — no open PR references #48491 or touches NVFP4 backend docs.

## Test Plan

```bash
npx markdownlint-cli2 docs/features/quantization/modelopt.md
```

## Test Result

`Summary: 0 issues in 0 files`

---

AI was used for planning and implementation. It was reviewed and approved by me along the way.
