### PR TITLE
[Bugfix] Aria: set reduce_results=False on shared_experts to fix TP>1

### DIFF
--- a/vllm/model_executor/models/aria.py
+++ b/vllm/model_executor/models/aria.py
@@ -220,6 +220,7 @@ class AriaTextMoELayer(nn.Module):
             "silu",
             quant_config=quant_config,
             bias=config.mlp_bias,
+            reduce_results=False,
         )
 
         self.experts = FusedMoE(


### PR DESCRIPTION
Aria passes shared_experts to FusedMoE but does not set reduce_results=False. So the shared expert all-reduces its output inside LlamaMLP, then FusedMoE all-reduces the total again. The shared part is counted twice. At tp=1 this does not matter. At tp=2 or higher, output is wrong.

Fix: add reduce_results=False to the shared_experts LlamaMLP. This matches deepseek_v2, nemotron_h, cohere2, and every other model that uses shared_experts with FusedMoE. One line change.

Fixes #49122




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

