### PR TITLE
[CI][Bugfix] Fix ROCm FP8 KV cache dtype in attention backend test

### DIFF
--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -46,9 +46,12 @@ BACKENDS_TO_TEST = [
 
 DEVICE_TYPE = current_platform.device_type
 
+# Use the platform's preferred FP8 type so the stored cache matches what the
+# backends reinterpret at runtime. On ROCm gfx94x this is e4m3fnuz, not e4m3fn;
+# storing e4m3fn bytes there would be re-read as fnuz and produce NaNs.
 FP8_KV_CACHE_DTYPES = {
-    "fp8": torch.float8_e4m3fn,
-    "fp8_e4m3": torch.float8_e4m3fn,
+    "fp8": current_platform.fp8_dtype(),
+    "fp8_e4m3": current_platform.fp8_dtype(),
 }
 
 # Remove flashinfer from the list if it's not available


### PR DESCRIPTION
## Purpose

`tests/v1/attention/test_attention_backends.py::test_causal_backend_correctness[fp8*]` fails on ROCm (gfx94x / MI300) with `[AttentionBackendEnum.TRITON_ATTN] produced non-finite values`.

Root cause is in the test, not the backend. The test stores the FP8 KV cache using a hardcoded `torch.float8_e4m3fn`, but at runtime the attention backends reinterpret the raw cache bytes with `current_platform.fp8_dtype()`, which is `e4m3fnuz` on ROCm gfx94x. The two formats have different exponent bias and NaN encodings — e.g. byte `0x80` is `-0.0` in `e4m3fn` but `NaN` in `e4m3fnuz` — so the backend reads every stored value wrong and emits NaNs. It passed on CUDA only because `fp8_dtype()` returns `e4m3fn` there. The fix stores the cache using `current_platform.fp8_dtype()`, matching what the backends read at runtime and the pattern already used across the rest of the test suite. CUDA behavior is unchanged (same dtype in, same bytes stored).

AI assistance (Claude) was used to diagnose and implement this change. Not a duplicate: no open PR touches this test's FP8 KV cache dtype handling (searched `test_causal_backend_correctness`, `FP8_KV_CACHE_DTYPES`, `e4m3fnuz`); #49329 concerns the attention *selector* order test, which is unrelated.

## Test Plan

CI step: **V1 attention (H100-MI250)** — `pytest -v -s v1/attention` (`.buildkite/test-amd.yaml`).

Hardware: ROCm MI300 (gfx942). Ran the full affected test on the working-tree change:

```bash
pytest -v -s tests/v1/attention/test_attention_backends.py::test_causal_backend_correctness
```

## Test Result

Before the fix (all FP8 parametrizations NaN; `auto` unaffected):

```
FAILED ...test_causal_backend_correctness[fp8-1-meta-llama/Meta-Llama-3-8B-small_decode] - AssertionError: [AttentionBackendEnum.TRITON_ATTN] produced non-finite values
FAILED ...[fp8-1-...-small_prefill]
FAILED ...[fp8-1-...-medium_decode]
FAILED ...[fp8-1-...-large_decode]
FAILED ...[fp8-1-...-single_decode]
FAILED ...[fp8_e4m3-1-...-small_decode]
... (all fp8 / fp8_e4m3 cases)
```

After the fix (full matrix — all tp sizes × batch specs × auto/fp8/fp8_e4m3):

```
================= 90 passed, 17 warnings in 315.95s (0:05:15) ==================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

