### PR TITLE
[BugFix][LoRA] Skip marlin-backend gpt-oss LoRA tests on XPU

### DIFF
--- a/tests/lora/test_gptoss_tp.py
+++ b/tests/lora/test_gptoss_tp.py
@@ -95,7 +95,8 @@ def generate_and_test(llm: vllm.LLM, lora_path: str, lora_id: int) -> None:
         pytest.param(
             True,
             marks=pytest.mark.skipif(
-                current_platform.is_rocm(), reason="marlin not supported"
+                current_platform.is_rocm() or current_platform.is_xpu(),
+                reason="marlin not supported",
             ),
         ),
     ],
@@ -135,7 +136,8 @@ def test_gpt_oss_lora(
         pytest.param(
             True,
             marks=pytest.mark.skipif(
-                current_platform.is_rocm(), reason="marlin not supported"
+                current_platform.is_rocm() or current_platform.is_xpu(),
+                reason="marlin not supported",
             ),
         ),
     ],


### PR DESCRIPTION
## Purpose ## 
Fix XPU crashes in test_gpt_oss_lora_tp2 and test_gpt_oss_lora when mxfp4_use_marlin=True due to an unsupported MXFP4 Marlin backend.

##  Root cause ## 
The tests explicitly request moe_backend="marlin" and linear_backend="marlin", but Marlin MXFP4 kernels are CUDA‑only and not registered for XPU. Explicit requests fail instead of falling back, unlike the auto path which correctly skips Marlin on XPU.

##  Fix ## 
The ROCm skipif already exists for this reason; this PR adds the equivalent XPU condition to skip the tests as well.
 