### PR TITLE
[Rust Frontend] Add #[must_use] to consuming builder methods in Rust frontend

### DIFF
--- a/rust/src/chat/src/event.rs
+++ b/rust/src/chat/src/event.rs
@@ -60,6 +60,7 @@ impl AssistantContentBlock {
 
     /// Return a copy of this block with leading and trailing whitespace trimmed from all text
     /// fields and tool call arguments, or `None` if the resulting text would be empty.
+    #[must_use]
     pub fn trim(mut self) -> Option<Self> {
         match &mut self {
             Self::Text { text } | Self::Reasoning { text } => {
@@ -145,6 +146,7 @@ impl AssistantMessage {
 
     /// Return a copy of this message with leading and trailing whitespace trimmed from all text
     /// fields and tool call arguments, and with any blocks that are empty after trimming removed.
+    #[must_use]
     pub fn trim(mut self) -> Self {
         self.content = self.content.into_iter().filter_map(|block| block.trim()).collect();
         self

--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -127,18 +127,21 @@ impl ChatLlm {
     }
 
     /// Set tool-call parser selection.
+    #[must_use]
     pub fn with_tool_call_parser(mut self, selection: ParserSelection) -> Self {
         self.tool_call_parser = selection;
         self
     }
 
     /// Set reasoning parser selection.
+    #[must_use]
     pub fn with_reasoning_parser(mut self, selection: ParserSelection) -> Self {
         self.reasoning_parser = selection;
         self
     }
 
     /// Override the effective model dtype used for multimodal tensor encoding.
+    #[must_use]
     pub fn with_model_dtype(mut self, model_dtype: ModelDtype) -> Self {
         self.model_dtype = model_dtype;
         self

--- a/rust/src/chat/src/renderer/hf/mod.rs
+++ b/rust/src/chat/src/renderer/hf/mod.rs
@@ -76,11 +76,13 @@ impl HfChatRenderer {
         })
     }
 
+    #[must_use]
     pub fn with_special_tokens(mut self, special_tokens: Option<HfSpecialTokens>) -> Self {
         self.special_tokens = special_tokens;
         self
     }
 
+    #[must_use]
     pub fn with_multimodal(mut self, multimodal: Option<MultimodalRenderInfo>) -> Self {
         self.multimodal = multimodal;
         self

--- a/rust/src/chat/src/renderer/selection.rs
+++ b/rust/src/chat/src/renderer/selection.rs
@@ -40,6 +40,7 @@ impl RendererSelection {
 
     /// Resolve the renderer selection using the given model type string, if
     /// it's `Auto`.
+    #[must_use]
     pub fn resolve(self, model_type: &str) -> Self {
         match self {
             Self::Auto => match model_type {

--- a/rust/src/engine-core-client/src/client.rs
+++ b/rust/src/engine-core-client/src/client.rs
@@ -116,18 +116,21 @@ impl EngineCoreClientConfig {
     }
 
     /// Set the model name used by frontend-side metrics and diagnostics.
+    #[must_use]
     pub fn with_model_name(mut self, model_name: impl Into<String>) -> Self {
         self.model_name = model_name.into();
         self
     }
 
     /// Override the client index stamped onto every outgoing request.
+    #[must_use]
     pub fn with_client_index(mut self, client_index: u32) -> Self {
         self.client_index = client_index;
         self
     }
 
     /// Override the optional coordinator mode for this client config.
+    #[must_use]
     pub fn with_coordinator_mode(mut self, coordinator_mode: Option<CoordinatorMode>) -> Self {
         self.coordinator_mode = coordinator_mode;
         self
@@ -138,6 +141,7 @@ impl EngineCoreClientConfig {
     ///
     /// This is primarily used by tests that want deterministic IPC endpoints
     /// while still exercising the handshake-owned startup path.
+    #[must_use]
     pub fn with_local_input_output_addresses(
         mut self,
         local_input_address: Option<String>,

--- a/rust/src/llm/src/lib.rs
+++ b/rust/src/llm/src/lib.rs
@@ -51,6 +51,7 @@ impl Llm {
     }
 
     /// Enable or disable periodic stats logging.
+    #[must_use]
     pub fn with_log_stats(mut self, enabled: bool) -> Self {
         if enabled {
             let stats_logger = StatsLogger::start(
@@ -66,6 +67,7 @@ impl Llm {
 
     /// Control whether external request ids are randomized before reaching
     /// engine-core.
+    #[must_use]
     pub fn with_request_id_randomization(mut self, enabled: bool) -> Self {
         self.randomize_request_id = enabled;
         self

--- a/rust/src/parser/src/tool/mod.rs
+++ b/rust/src/parser/src/tool/mod.rs
@@ -142,6 +142,7 @@ impl ToolParserOutput {
     /// which delegates through the incremental parser lifecycle and then
     /// needs to collapse streaming-style argument fragments into one final
     /// tool call.
+    #[must_use]
     pub fn coalesce(self) -> Self {
         let mut merged = BTreeMap::<usize, ToolCallDelta>::new();
         let mut order = Vec::new();

--- a/rust/src/server/src/state.rs
+++ b/rust/src/server/src/state.rs
@@ -85,30 +85,35 @@ impl AppState {
     }
 
     /// Set HTTP/API-server behavior switches.
+    #[must_use]
     pub fn with_api_server_options(mut self, options: ApiServerOptions) -> Self {
         self.api_server_options = options;
         self
     }
 
     /// Set the CORS settings applied to every HTTP response.
+    #[must_use]
     pub fn with_cors(mut self, cors: CorsConfig) -> Self {
         self.cors = cors;
         self
     }
 
     /// Set the backend model path reported as `root` for base-model cards.
+    #[must_use]
     pub fn with_model_path(mut self, model_path: String) -> Self {
         self.model_path = Some(model_path);
         self
     }
 
     /// Set the profiler mode that enables `/start_profile` and `/stop_profile`.
+    #[must_use]
     pub fn with_profiler(mut self, profiler: Option<String>) -> Self {
         self.profiler = profiler;
         self
     }
 
     /// Attach the runtime server information snapshot used by `/server_info`.
+    #[must_use]
     pub(crate) fn with_server_info(mut self, server_info: ServerInfoSnapshot) -> Self {
         self.server_info = Some(server_info);
         self
@@ -123,6 +128,7 @@ impl AppState {
     }
 
     /// Configure API keys accepted by guarded HTTP routes.
+    #[must_use]
     pub fn with_api_keys(mut self, api_keys: Vec<String>) -> Self {
         self.api_key_hashes = api_keys
             .into_iter()

--- a/rust/src/text/src/lib.rs
+++ b/rust/src/text/src/lib.rs
@@ -71,6 +71,7 @@ impl TextLlm {
     }
 
     /// Override the maximum accepted logprobs count.
+    #[must_use]
     pub fn with_max_logprobs(mut self, max_logprobs: Option<i32>) -> Self {
         if let Some(max_logprobs) = max_logprobs {
             self.max_logprobs = max_logprobs;

--- a/rust/src/tokenizer/src/test_utils.rs
+++ b/rust/src/tokenizer/src/test_utils.rs
@@ -96,17 +96,20 @@ impl TestTokenizer {
     ///
     /// Configured tokens must use ids outside the byte range and may be marked
     /// special or regular.
+    #[must_use]
     pub fn with_token(mut self, token: impl Into<String>, id: u32, kind: TestTokenKind) -> Self {
         self.insert_token(token, id, kind);
         self
     }
 
     /// Add a special configured token and return the updated tokenizer.
+    #[must_use]
     pub fn with_special_token(self, token: impl Into<String>, id: u32) -> Self {
         self.with_token(token, id, TestTokenKind::Special)
     }
 
     /// Add a regular configured token and return the updated tokenizer.
+    #[must_use]
     pub fn with_regular_token(self, token: impl Into<String>, id: u32) -> Self {
         self.with_token(token, id, TestTokenKind::Regular)
     }
@@ -116,6 +119,7 @@ impl TestTokenizer {
     /// This also registers the token in the normal token/id maps so
     /// `token_to_id`, `id_to_token`, `decode`, and `is_special_id` stay
     /// consistent for the inserted id.
+    #[must_use]
     pub fn with_bos_token(mut self, token: impl Into<String>, id: u32) -> Self {
         self.insert_token(token, id, TestTokenKind::Special);
         self.bos_token_id = Some(id);
@@ -123,6 +127,7 @@ impl TestTokenizer {
     }
 
     /// Set decode behavior for unknown non-byte ids.
+    #[must_use]
     pub fn with_unknown_decode(mut self, behavior: UnknownDecode) -> Self {
         self.unknown_decode = behavior;
         self
@@ -132,6 +137,7 @@ impl TestTokenizer {
     ///
     /// Use this when a test needs a model-like vocabulary bound that differs
     /// from the highest configured token id plus one.
+    #[must_use]
     pub fn with_vocab_size(mut self, vocab_size: usize) -> Self {
         self.vocab_size = Some(vocab_size);
         self


### PR DESCRIPTION
## Summary

Adds `#[must_use]` to consuming builder methods (`mut self -> Self`) across the Rust frontend to prevent silently discarding builder modifications at compile time.

## Motivation

`mut self -> Self` builder methods silently discard modifications when the
caller forgets to bind the return value:

```rust
// Bug — with_cors returns a new AppState, but the result is dropped.
// The CORS config is not actually applied.
state.with_cors(cors_config);

// Correct — the annotated state is rebound.
state = state.with_cors(cors_config);
```
#[must_use] catches this at compile time. Without it, a one-character
mistake (missing state = ) silently disables a configuration path with no
warning from either the compiler or clippy.
The severity ranges from cosmetic (profiler routes don't appear) to
security-relevant (API key hashes not applied, CORS not configured, model
path missing from base-model cards).


## Changes

25 methods across 10 files in 7 crates:

| Crate | File | Methods annotated |
|-------|------|-------------------|
| vllm-server | state.rs | `with_api_server_options`, `with_cors`, `with_model_path`, `with_profiler`, `with_server_info`, `with_api_keys` |
| vllm-chat | lib.rs | `with_tool_call_parser`, `with_reasoning_parser`, `with_model_dtype` |
| vllm-chat | event.rs | `AssistantMessage::trim`, `AssistantContentBlock::trim` |
| vllm-chat | renderer/ | `with_special_tokens`, `with_multimodal`, `resolve` |
| vllm-text | lib.rs | `with_max_logprobs` |
| vllm-llm | lib.rs | `with_log_stats`, `with_request_id_randomization` |
| vllm-engine-core-client | client.rs | `with_model_name`, `with_client_index`, `with_coordinator_mode`, `with_local_input_output_addresses` |
| vllm-tokenizer | test_utils.rs | `with_token`, `with_special_token`, `with_regular_token`, `with_bos_token`, `with_unknown_decode`, `with_vocab_size` |
| vllm-parser | tool/mod.rs | `coalesce` |

`&mut self -> &mut Self` chaining methods on `ParserFactory` are intentionally not annotated since mutations are in-place and `#[must_use]` would warn on valid usage.

## Testing

- `cargo check --workspace`: passes
- `cargo clippy -p vllm-chat -p vllm-server`: passes
- `cargo test --workspace`: ~1400+ tests pass, 0 failures

---

Co-authored-by: OpenCode <noreply@opencode.ai>