### PR TITLE
[Bugfix] Skip Qwen3 deepstack buffers without vision

### DIFF
--- a/tests/model_executor/test_qwen3_omni.py
+++ b/tests/model_executor/test_qwen3_omni.py
@@ -4,9 +4,50 @@
 from unittest.mock import Mock
 
 import pytest
+import torch.nn as nn
 from transformers import PretrainedConfig
 
 from vllm.multimodal.processing import InputProcessingContext
+
+
+def test_vision_disabled_skips_deepstack_buffers(monkeypatch):
+    from vllm.model_executor.models import qwen3_omni_moe_thinker as qwen3_omni
+    from vllm.model_executor.models.utils import StageMissingLayer
+
+    thinker_config = Mock()
+    thinker_config.vision_config.deepstack_visual_indexes = [0]
+    thinker_config.vision_config.out_hidden_size = 4
+    thinker_config.text_config.hidden_size = 8
+
+    vllm_config = Mock()
+    vllm_config.model_config.hf_config.thinker_config = thinker_config
+    vllm_config.model_config.multimodal_config.mm_encoder_only = False
+    vllm_config.model_config.multimodal_config.get_limit_per_prompt.side_effect = (
+        lambda modality: int(modality == "audio")
+    )
+    vllm_config.scheduler_config.max_num_batched_tokens = 16
+    vllm_config.with_hf_config.return_value = vllm_config
+
+    language_model = nn.Identity()
+    language_model.make_empty_intermediate_tensors = Mock()
+    monkeypatch.setattr(
+        qwen3_omni, "Qwen3OmniMoeAudioEncoder", lambda *args, **kwargs: nn.Identity()
+    )
+    monkeypatch.setattr(
+        qwen3_omni, "Qwen3Omni_VisionTransformer", lambda *args, **kwargs: nn.Identity()
+    )
+    monkeypatch.setattr(
+        qwen3_omni,
+        "Qwen3MoeLLMForCausalLM",
+        lambda *args, **kwargs: language_model,
+    )
+
+    model = qwen3_omni.Qwen3OmniMoeThinkerForConditionalGeneration(
+        vllm_config=vllm_config
+    )
+
+    assert isinstance(model.visual, StageMissingLayer)
+    assert not hasattr(model, "deepstack_input_embeds")
 
 
 # Helper function to print input IDs with coalesced audio/video tokens.

--- a/tests/model_executor/test_qwen3_omni.py
+++ b/tests/model_executor/test_qwen3_omni.py
@@ -47,6 +47,7 @@ def test_vision_disabled_skips_deepstack_buffers(monkeypatch):
     )
 
     assert isinstance(model.visual, StageMissingLayer)
+    assert not model.use_deepstack
     assert not hasattr(model, "deepstack_input_embeds")
 
 

--- a/tests/model_executor/test_qwen3_omni.py
+++ b/tests/model_executor/test_qwen3_omni.py
@@ -4,51 +4,9 @@
 from unittest.mock import Mock
 
 import pytest
-import torch.nn as nn
 from transformers import PretrainedConfig
 
 from vllm.multimodal.processing import InputProcessingContext
-
-
-def test_vision_disabled_skips_deepstack_buffers(monkeypatch):
-    from vllm.model_executor.models import qwen3_omni_moe_thinker as qwen3_omni
-    from vllm.model_executor.models.utils import StageMissingLayer
-
-    thinker_config = Mock()
-    thinker_config.vision_config.deepstack_visual_indexes = [0]
-    thinker_config.vision_config.out_hidden_size = 4
-    thinker_config.text_config.hidden_size = 8
-
-    vllm_config = Mock()
-    vllm_config.model_config.hf_config.thinker_config = thinker_config
-    vllm_config.model_config.multimodal_config.mm_encoder_only = False
-    vllm_config.model_config.multimodal_config.get_limit_per_prompt.side_effect = (
-        lambda modality: int(modality == "audio")
-    )
-    vllm_config.scheduler_config.max_num_batched_tokens = 16
-    vllm_config.with_hf_config.return_value = vllm_config
-
-    language_model = nn.Identity()
-    language_model.make_empty_intermediate_tensors = Mock()
-    monkeypatch.setattr(
-        qwen3_omni, "Qwen3OmniMoeAudioEncoder", lambda *args, **kwargs: nn.Identity()
-    )
-    monkeypatch.setattr(
-        qwen3_omni, "Qwen3Omni_VisionTransformer", lambda *args, **kwargs: nn.Identity()
-    )
-    monkeypatch.setattr(
-        qwen3_omni,
-        "Qwen3MoeLLMForCausalLM",
-        lambda *args, **kwargs: language_model,
-    )
-
-    model = qwen3_omni.Qwen3OmniMoeThinkerForConditionalGeneration(
-        vllm_config=vllm_config
-    )
-
-    assert isinstance(model.visual, StageMissingLayer)
-    assert not model.use_deepstack
-    assert not hasattr(model, "deepstack_input_embeds")
 
 
 # Helper function to print input IDs with coalesced audio/video tokens.

--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -1621,17 +1621,6 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
                 prefix=maybe_prefix(prefix, "audio_tower"),
             )
 
-        self.use_deepstack = hasattr(
-            thinker_config.vision_config, "deepstack_visual_indexes"
-        )
-        self.deepstack_num_level = (
-            len(thinker_config.vision_config.deepstack_visual_indexes)
-            if self.use_deepstack
-            else 0
-        )
-        self.visual_dim = thinker_config.vision_config.out_hidden_size
-        self.multiscale_dim = self.visual_dim * self.deepstack_num_level
-
         with self._mark_tower_model(vllm_config, {"image", "video"}):
             self.visual = Qwen3Omni_VisionTransformer(
                 vision_config=thinker_config.vision_config,
@@ -1640,7 +1629,18 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
                 prefix=maybe_prefix(prefix, "visual"),
             )
 
-        if self.use_deepstack and not isinstance(self.visual, StageMissingLayer):
+        self.use_deepstack = hasattr(
+            thinker_config.vision_config, "deepstack_visual_indexes"
+        ) and not isinstance(self.visual, StageMissingLayer)
+        self.deepstack_num_level = (
+            len(thinker_config.vision_config.deepstack_visual_indexes)
+            if self.use_deepstack
+            else 0
+        )
+        self.visual_dim = thinker_config.vision_config.out_hidden_size
+        self.multiscale_dim = self.visual_dim * self.deepstack_num_level
+
+        if self.use_deepstack:
             self.deepstack_input_embeds = [
                 torch.zeros(
                     vllm_config.scheduler_config.max_num_batched_tokens,

--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -102,6 +102,7 @@ from .qwen2_5_vl import (
 from .qwen3_moe import Qwen3MoeForCausalLM, Qwen3MoeModel
 from .utils import (
     AutoWeightsLoader,
+    StageMissingLayer,
     WeightsMapper,
     _merge_multimodal_embeddings,
     maybe_prefix,
@@ -1639,18 +1640,17 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
                 prefix=maybe_prefix(prefix, "visual"),
             )
 
-            # register buffer for deepstack
-            if self.use_deepstack:
-                self.deepstack_input_embeds = [
-                    torch.zeros(
-                        vllm_config.scheduler_config.max_num_batched_tokens,
-                        thinker_config.text_config.hidden_size,
-                    )
-                    for _ in range(self.deepstack_num_level)
-                ]
-                # Tracks the valid token span currently stored in the buffer.
-                # Zero means there is no active deepstack payload to consume.
-                self.deepstack_input_embeds_num_tokens = 0
+        if self.use_deepstack and not isinstance(self.visual, StageMissingLayer):
+            self.deepstack_input_embeds = [
+                torch.zeros(
+                    vllm_config.scheduler_config.max_num_batched_tokens,
+                    thinker_config.text_config.hidden_size,
+                )
+                for _ in range(self.deepstack_num_level)
+            ]
+            # Tracks the valid token span currently stored in the buffer.
+            # Zero means there is no active deepstack payload to consume.
+            self.deepstack_input_embeds_num_tokens = 0
 
         with self._mark_language_model(vllm_config):
             self.language_model = Qwen3MoeLLMForCausalLM(

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -142,6 +142,7 @@ from .qwen3 import Qwen3ForCausalLM, Qwen3Model
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
+    StageMissingLayer,
     WeightsMapper,
     _merge_multimodal_embeddings,
     maybe_prefix,
@@ -1786,18 +1787,17 @@ class Qwen3VLForConditionalGeneration(
                 prefix=maybe_prefix(prefix, "visual"),
             )
 
-            # register buffer for deepstack
-            if self.use_deepstack:
-                self.deepstack_input_embeds = [
-                    torch.zeros(
-                        vllm_config.scheduler_config.max_num_batched_tokens,
-                        config.text_config.hidden_size,
-                    )
-                    for _ in range(self.deepstack_num_level)
-                ]
-                # Tracks the valid token span currently stored in the buffer.
-                # Zero means there is no active deepstack payload to consume.
-                self.deepstack_input_embeds_num_tokens = 0
+        if self.use_deepstack and not isinstance(self.visual, StageMissingLayer):
+            self.deepstack_input_embeds = [
+                torch.zeros(
+                    vllm_config.scheduler_config.max_num_batched_tokens,
+                    config.text_config.hidden_size,
+                )
+                for _ in range(self.deepstack_num_level)
+            ]
+            # Tracks the valid token span currently stored in the buffer.
+            # Zero means there is no active deepstack payload to consume.
+            self.deepstack_input_embeds_num_tokens = 0
 
         with self._mark_language_model(vllm_config):
             self.language_model = Qwen3LLMForCausalLM(

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1770,15 +1770,6 @@ class Qwen3VLForConditionalGeneration(
         self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
         self._init_video_pruning(multimodal_config)
 
-        self.use_deepstack = hasattr(config.vision_config, "deepstack_visual_indexes")
-        self.deepstack_num_level = (
-            len(config.vision_config.deepstack_visual_indexes)
-            if self.use_deepstack
-            else 0
-        )
-        self.visual_dim = config.vision_config.out_hidden_size
-        self.multiscale_dim = self.visual_dim * self.deepstack_num_level
-
         with self._mark_tower_model(vllm_config, {"image", "video"}):
             self.visual = Qwen3_VisionTransformer(
                 config.vision_config,
@@ -1787,7 +1778,18 @@ class Qwen3VLForConditionalGeneration(
                 prefix=maybe_prefix(prefix, "visual"),
             )
 
-        if self.use_deepstack and not isinstance(self.visual, StageMissingLayer):
+        self.use_deepstack = hasattr(
+            config.vision_config, "deepstack_visual_indexes"
+        ) and not isinstance(self.visual, StageMissingLayer)
+        self.deepstack_num_level = (
+            len(config.vision_config.deepstack_visual_indexes)
+            if self.use_deepstack
+            else 0
+        )
+        self.visual_dim = config.vision_config.out_hidden_size
+        self.multiscale_dim = self.visual_dim * self.deepstack_num_level
+
+        if self.use_deepstack:
             self.deepstack_input_embeds = [
                 torch.zeros(
                     vllm_config.scheduler_config.max_num_batched_tokens,

--- a/vllm/model_executor/models/qwen3_vl_moe.py
+++ b/vllm/model_executor/models/qwen3_vl_moe.py
@@ -54,7 +54,7 @@ from .qwen3_vl import (
     Qwen3VLMultiModalProcessor,
     Qwen3VLProcessingInfo,
 )
-from .utils import maybe_prefix
+from .utils import StageMissingLayer, maybe_prefix
 
 logger = init_logger(__name__)
 
@@ -239,15 +239,14 @@ class Qwen3VLMoeForConditionalGeneration(
                 prefix=maybe_prefix(prefix, "visual"),
             )
 
-            # register buffer for deepstack
-            if self.use_deepstack:
-                self.deepstack_input_embeds = [
-                    torch.zeros(
-                        vllm_config.scheduler_config.max_num_batched_tokens,
-                        config.text_config.hidden_size,
-                    )
-                    for _ in range(self.deepstack_num_level)
-                ]
+        if self.use_deepstack and not isinstance(self.visual, StageMissingLayer):
+            self.deepstack_input_embeds = [
+                torch.zeros(
+                    vllm_config.scheduler_config.max_num_batched_tokens,
+                    config.text_config.hidden_size,
+                )
+                for _ in range(self.deepstack_num_level)
+            ]
 
         with self._mark_language_model(vllm_config):
             self.language_model = Qwen3MoeLLMForCausalLM(

--- a/vllm/model_executor/models/qwen3_vl_moe.py
+++ b/vllm/model_executor/models/qwen3_vl_moe.py
@@ -222,15 +222,6 @@ class Qwen3VLMoeForConditionalGeneration(
         self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
         self._init_video_pruning(multimodal_config)
 
-        self.use_deepstack = hasattr(config.vision_config, "deepstack_visual_indexes")
-        self.deepstack_num_level = (
-            len(config.vision_config.deepstack_visual_indexes)
-            if self.use_deepstack
-            else 0
-        )
-        self.visual_dim = config.vision_config.out_hidden_size
-        self.multiscale_dim = self.visual_dim * self.deepstack_num_level
-
         with self._mark_tower_model(vllm_config, {"image", "video"}):
             self.visual = Qwen3_VisionTransformer(
                 config.vision_config,
@@ -239,7 +230,18 @@ class Qwen3VLMoeForConditionalGeneration(
                 prefix=maybe_prefix(prefix, "visual"),
             )
 
-        if self.use_deepstack and not isinstance(self.visual, StageMissingLayer):
+        self.use_deepstack = hasattr(
+            config.vision_config, "deepstack_visual_indexes"
+        ) and not isinstance(self.visual, StageMissingLayer)
+        self.deepstack_num_level = (
+            len(config.vision_config.deepstack_visual_indexes)
+            if self.use_deepstack
+            else 0
+        )
+        self.visual_dim = config.vision_config.out_hidden_size
+        self.multiscale_dim = self.visual_dim * self.deepstack_num_level
+
+        if self.use_deepstack:
             self.deepstack_input_embeds = [
                 torch.zeros(
                     vllm_config.scheduler_config.max_num_batched_tokens,


### PR DESCRIPTION
## Summary

- avoid creating Qwen3 deepstack tensors when the vision tower is skipped
- preserve zero-backed deepstack inputs when vision is enabled, keeping the compiled decoder input contract stable
- apply the same fix to Qwen3 Omni, Qwen3-VL, and Qwen3-VL-MoE

Fixes #49384.

## Why this is not duplicate work

I searched open PR titles and bodies for #49384, the reported Qwen3-Omni `meta` failure, `StageMissingLayer`, and deepstack buffers immediately before opening this PR; there was no competing PR, assignee, or linked closing PR. #43617 keeps zero-backed deepstack tensors present when a vision tower exists to avoid compiled-graph specialization; this change preserves that behavior and only omits the tensors when the vision tower itself has been replaced with `StageMissingLayer`.

## Testing

- `.venv/bin/python -m pytest -q tests/model_executor/test_qwen3_omni.py` (`2 passed`)
- `.venv/bin/python -m ruff check tests/model_executor/test_qwen3_omni.py vllm/model_executor/models/qwen3_omni_moe_thinker.py vllm/model_executor/models/qwen3_vl.py vllm/model_executor/models/qwen3_vl_moe.py`
- `.venv/bin/python -m ruff format --check` on the same files
- current-main `LLM` startup with `Qwen/Qwen3-Omni-30B-A3B-Instruct`, dummy weights, and `limit_mm_per_prompt={"image": 0, "video": 0, "audio": 1}` reproduced `Tensor on device meta is not on the expected device cuda:0`
- patched audio-only startup completed with `R44_STARTUP_OK`; patched vision-enabled startup completed with `R44_VISION_STARTUP_OK`

The runtime A/B used one dense text layer to bypass an unrelated ABI mismatch between the current source and the precompiled MoE extension. It retained the official model architecture, multimodal tower selection, engine profiling, and deepstack decoder path.

## Model evaluation

Not applicable: the change does not alter outputs for vision-enabled configurations, and the affected vision-disabled configuration could not start before the fix. The complementary vision-enabled startup/profile check passed.

## AI assistance

OpenAI Codex was used for root-cause analysis, implementation, and test execution.


