### PR TITLE
[CI] Add opt-in Hugging Face Hub monitoring

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -61,6 +61,24 @@ export PYTHONFAULTHANDLER
 # depend on their current working directory.
 export PYTHONPATH="${PYTHONPATH:-..}"
 
+hf_test_group_runner=()
+case "${VLLM_CI_HF_HUB_MODE:-}" in
+  "") ;;
+  online)
+    hf_test_group_runner=(python3 -m vllm_test_utils.hf_hub)
+    ;;
+  offline-first)
+    hf_test_group_runner=(python3 -m vllm_test_utils.hf_hub)
+    if [[ "${BUILDKITE_RETRY_COUNT:-0}" == "0" ]]; then
+      hf_test_group_runner+=(--offline)
+    fi
+    ;;
+  *)
+    echo "Invalid VLLM_CI_HF_HUB_MODE: ${VLLM_CI_HF_HUB_MODE}" >&2
+    exit 2
+    ;;
+esac
+
 ###############################################################################
 # Helper Functions
 ###############################################################################
@@ -685,13 +703,21 @@ if is_native_runtime; then
     exit 1
   fi
 
-  export PYTHONPATH="${VLLM_CI_WORKSPACE:-/vllm-workspace}"
+  if [[ -n "${VLLM_CI_HF_HUB_MODE:-}" ]]; then
+    export PYTHONPATH="${VLLM_CI_WORKSPACE:-/vllm-workspace}/tests/vllm_test_utils:${VLLM_CI_WORKSPACE:-/vllm-workspace}"
+  else
+    export PYTHONPATH="${VLLM_CI_WORKSPACE:-/vllm-workspace}"
+  fi
 
   echo "Native test commands: $commands"
   run_native_preflight || exit 1
   # Keep AMD CI orchestration variables out of vLLM's runtime environment.
   clear_ci_orchestration_env
-  /bin/bash -o pipefail -c "${commands}"
+  if [[ -n "${VLLM_CI_HF_HUB_MODE:-}" ]]; then
+    "${hf_test_group_runner[@]}" --pipefail -- "${commands}"
+  else
+    /bin/bash -o pipefail -c "${commands}"
+  fi
   handle_pytest_exit "$?"
 fi
 
@@ -819,7 +845,11 @@ if [[ "$commands" == *python_only_compile.sh* ]]; then
   standalone_merge_base_env=(-e "CI_STANDALONE_MERGE_BASE=${vllm_standalone_merge_base}")
 fi
 
-MYPYTHONPATH="/vllm-workspace"
+if [[ -n "${VLLM_CI_HF_HUB_MODE:-}" ]]; then
+  MYPYTHONPATH="/vllm-workspace/tests/vllm_test_utils:/vllm-workspace"
+else
+  MYPYTHONPATH="/vllm-workspace"
+fi
 
 container_job_id="${BUILDKITE_JOB_ID:-${BUILDKITE_PARALLEL_JOB:-0}}"
 container_job_id="${container_job_id//[^A-Za-z0-9_.-]/_}"
@@ -917,6 +947,16 @@ else
     echo "ROCm debug agent not enabled, coredumps are disabled in the test container."
   fi
 
+  if [[ -n "${VLLM_CI_HF_HUB_MODE:-}" ]]; then
+    container_test_group=(
+      "${hf_test_group_runner[@]}" -- "${CONTAINER_PREFLIGHT} && ${commands}"
+    )
+  else
+    container_test_group=(
+      /bin/bash -c "${CONTAINER_PREFLIGHT} && ${commands}"
+    )
+  fi
+
   docker run \
     "${docker_run_terminal_args[@]}" \
     --device /dev/kfd $BUILDKITE_AGENT_META_DATA_RENDER_DEVICES \
@@ -952,7 +992,7 @@ else
     "${standalone_merge_base_env[@]}" \
     --name "${container_name}" \
     "${image_name}" \
-    /bin/bash -c "${CONTAINER_PREFLIGHT} && ${commands}"
+    "${container_test_group[@]}"
 
   exit_code=$?
   handle_pytest_exit "$exit_code"

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -460,6 +460,19 @@ steps:
   commands:
   - pytest -v -s tools/test_docker_build_metadata_args.py
 
+- label: HF Hub Request Monitor
+  timeout_in_minutes: 30
+  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
+  agent_pool: mi250_1
+  no_gpu: true
+  working_dir: "/vllm-workspace/tests"
+  source_file_dependencies:
+  - .buildkite/scripts/hardware_ci/run-amd-test.sh
+  - tests/tools/test_hf_hub_monitor.py
+  - tests/vllm_test_utils/vllm_test_utils/hf_hub.py
+  commands:
+  - pytest -v -s tools/test_hf_hub_monitor.py
+
 #########################################################################################################################################
 #                                                                                                                                       #
 #                                                         MI300 (gfx942) tests                                                          #

--- a/tests/tools/test_hf_hub_monitor.py
+++ b/tests/tools/test_hf_hub_monitor.py
@@ -1,0 +1,506 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+import os
+import shlex
+import socket
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import httpx
+import pytest
+from huggingface_hub import constants as hf_constants
+from huggingface_hub.utils import _http as hf_http
+from vllm_test_utils.hf_hub import (
+    HF_HUB_RETRY_EXIT_STATUS,
+    HFHubRequestMonitor,
+    HFHubTestGroup,
+)
+
+ROOT = Path(__file__).parents[2]
+TEST_UTILS = ROOT / "tests/vllm_test_utils"
+AMD_TEST_RUNNER = ROOT / ".buildkite/scripts/hardware_ci/run-amd-test.sh"
+
+
+class _StatusHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        if self.path == "/redirect":
+            self.send_response(302)
+            self.send_header("location", "/200")
+            self.end_headers()
+            return
+        status = int(self.path.removeprefix("/").partition("?")[0])
+        body = str(status).encode()
+        self.send_response(status)
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+@pytest.fixture(scope="module")
+def http_server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _StatusHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host = server.server_address[0]
+    port = server.server_address[1]
+    if isinstance(host, bytes):
+        host = host.decode()
+    yield f"http://{host}:{port}"
+    server.shutdown()
+    thread.join()
+
+
+@pytest.fixture(autouse=True)
+def restore_hf_clients():
+    sync_factory = hf_http._GLOBAL_CLIENT_FACTORY
+    async_factory = hf_http._GLOBAL_ASYNC_CLIENT_FACTORY
+    offline = hf_constants.HF_HUB_OFFLINE
+    yield
+    hf_http.set_client_factory(sync_factory)
+    hf_http.set_async_client_factory(async_factory)
+    hf_constants.HF_HUB_OFFLINE = offline
+
+
+def _plugin_environment(*, offline: bool) -> dict[str, str]:
+    environment = os.environ.copy()
+    pythonpath = [str(TEST_UTILS)]
+    if environment.get("PYTHONPATH"):
+        pythonpath.append(environment["PYTHONPATH"])
+    environment["PYTHONPATH"] = os.pathsep.join(pythonpath)
+    value = "1" if offline else "0"
+    environment.update(
+        {
+            "HF_HUB_OFFLINE": value,
+            "HF_DATASETS_OFFLINE": value,
+            "TRANSFORMERS_OFFLINE": value,
+        }
+    )
+    environment.pop("PYTEST_ADDOPTS", None)
+    return environment
+
+
+def _run_plugin_pytest(
+    test_dir: Path,
+    request_log: Path,
+    *args: str,
+    offline: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    request_log.touch()
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-p",
+            "vllm_test_utils.hf_hub",
+            f"--hf-request-log={request_log}",
+            "-q",
+            *args,
+        ],
+        cwd=test_dir,
+        env=_plugin_environment(offline=offline),
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_listener_counts_successful_and_failed_sync_and_async_requests():
+    def respond(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/timeout":
+            raise httpx.ReadTimeout("timed out", request=request)
+        return httpx.Response(200, request=request)
+
+    hf_http.set_client_factory(
+        lambda: httpx.Client(transport=httpx.MockTransport(respond))
+    )
+    hf_http.set_async_client_factory(
+        lambda: httpx.AsyncClient(transport=httpx.MockTransport(respond))
+    )
+    monitor = HFHubRequestMonitor()
+    monitor.install()
+
+    assert hf_http.get_session().get("https://huggingface.co/success").is_success
+    with pytest.raises(httpx.ReadTimeout):
+        hf_http.get_session().get("https://huggingface.co/timeout")
+
+    async def send_async_request() -> httpx.Response:
+        async with hf_http.get_async_session() as client:
+            return await client.get("https://huggingface.co/async")
+
+    assert asyncio.run(send_async_request()).is_success
+    assert monitor.counts == {"<session>": 3}
+
+    monitor.uninstall()
+    assert not hf_http.get_session().event_hooks["request"]
+
+
+def test_group_aggregates_invocations_and_prints_only_the_table(
+    monkeypatch, tmp_path, capfd, http_server
+):
+    (tmp_path / "conftest.py").write_text(
+        f"""
+from huggingface_hub.utils import _http
+
+_http.get_session().get("{http_server}/200?token=hf_secret")
+"""
+    )
+    (tmp_path / "test_a.py").write_text(
+        f"""
+from huggingface_hub.utils import _http
+
+def test_a():
+    assert _http.get_session().get("{http_server}/200").is_success
+    assert _http.get_session().get("{http_server}/503").status_code == 503
+"""
+    )
+    (tmp_path / "test_b.py").write_text(
+        f"""
+from huggingface_hub.utils import _http
+
+def test_b():
+    assert _http.get_session().get("{http_server}/400").status_code == 400
+"""
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PYTHONPATH", str(TEST_UTILS))
+    monkeypatch.delenv("PYTEST_ADDOPTS", raising=False)
+    pytest_command = shlex.join([sys.executable, "-m", "pytest", "-q"])
+
+    status = HFHubTestGroup(
+        f"{pytest_command} test_a.py && {pytest_command} test_b.py"
+    ).run()
+
+    output = capfd.readouterr().out
+    assert status == 0
+    assert output.count("Hugging Face Hub HTTP requests") == 1
+    assert "       2  <session>" in output
+    assert "       2  test_a.py::test_a" in output
+    assert "       1  test_b.py::test_b" in output
+    assert "       5  TOTAL" in output
+    assert "hf_secret" not in output
+
+
+def test_offline_request_attempt_is_counted(monkeypatch, tmp_path, capfd):
+    (tmp_path / "test_offline.py").write_text(
+        """
+from huggingface_hub.errors import OfflineModeIsEnabled
+from huggingface_hub.utils import _http
+
+def test_offline():
+    with __import__("pytest").raises(OfflineModeIsEnabled):
+        _http.get_session().get("https://huggingface.co/api/models/test")
+"""
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PYTHONPATH", str(TEST_UTILS))
+    monkeypatch.delenv("PYTEST_ADDOPTS", raising=False)
+    command = shlex.join([sys.executable, "-m", "pytest", "-q", "test_offline.py"])
+
+    status = HFHubTestGroup(command, offline=True).run()
+
+    output = capfd.readouterr().out
+    assert status == 0
+    assert "       1  test_offline.py::test_offline" in output
+    assert "       1  TOTAL" in output
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_status"),
+    [
+        (400, 1),
+        (404, 1),
+        (408, HF_HUB_RETRY_EXIT_STATUS),
+        (429, HF_HUB_RETRY_EXIT_STATUS),
+        (500, HF_HUB_RETRY_EXIT_STATUS),
+        (501, 1),
+        (502, HF_HUB_RETRY_EXIT_STATUS),
+        (503, HF_HUB_RETRY_EXIT_STATUS),
+        (504, HF_HUB_RETRY_EXIT_STATUS),
+    ],
+)
+def test_online_retry_statuses_are_strict(
+    tmp_path, http_server, status, expected_status
+):
+    (tmp_path / "test_failure.py").write_text(
+        f"""
+from huggingface_hub.utils import _http
+
+def test_failure():
+    _http.get_session().get("{http_server}/{status}").raise_for_status()
+"""
+    )
+    request_log = tmp_path / "requests.log"
+
+    result = _run_plugin_pytest(tmp_path, request_log, "test_failure.py")
+
+    assert result.returncode == expected_status, result
+    assert request_log.read_text() == "1\ttest_failure.py::test_failure\n"
+
+
+@pytest.mark.parametrize(
+    ("client", "url_kind", "expected_status"),
+    [
+        ("hub", "connection", HF_HUB_RETRY_EXIT_STATUS),
+        ("hub", "unsupported", 1),
+        ("httpx", "connection", 1),
+    ],
+)
+def test_online_retry_requires_a_transient_hub_request(
+    tmp_path, client, url_kind, expected_status
+):
+    with socket.socket() as unused_socket:
+        unused_socket.bind(("127.0.0.1", 0))
+        _, unused_port = unused_socket.getsockname()
+    url = (
+        f"http://127.0.0.1:{unused_port}"
+        if url_kind == "connection"
+        else "ftp://huggingface.co/model"
+    )
+    (tmp_path / "test_failure.py").write_text(
+        f"""
+import httpx
+from huggingface_hub.utils import _http
+
+def test_failure():
+    client = _http.get_session() if "{client}" == "hub" else httpx.Client()
+    client.get("{url}")
+"""
+    )
+    request_log = tmp_path / "requests.log"
+
+    result = _run_plugin_pytest(tmp_path, request_log, "test_failure.py")
+
+    assert result.returncode == expected_status, result
+    expected_count = 1 if client == "hub" else 0
+    assert request_log.read_text() == (
+        f"{expected_count}\ttest_failure.py::test_failure\n" if expected_count else ""
+    )
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_status"),
+    [
+        ("offline", HF_HUB_RETRY_EXIT_STATUS),
+        ("cache-miss", HF_HUB_RETRY_EXIT_STATUS),
+        ("collection-cache-miss", HF_HUB_RETRY_EXIT_STATUS),
+        ("initial-cache-miss", HF_HUB_RETRY_EXIT_STATUS),
+        ("unrelated", 1),
+    ],
+)
+def test_offline_retry_is_limited_to_hub_cache_failures(
+    monkeypatch, tmp_path, failure, expected_status
+):
+    statements = {
+        "offline": (
+            "from huggingface_hub.utils import _http\n"
+            "    _http.get_session().get('https://huggingface.co/model')"
+        ),
+        "cache-miss": (
+            "from huggingface_hub.errors import LocalEntryNotFoundError\n"
+            "    raise LocalEntryNotFoundError('not cached')"
+        ),
+        "unrelated": "raise AssertionError('unrelated failure')",
+    }
+    test_path = tmp_path / "test_failure.py"
+    if failure == "collection-cache-miss":
+        test_path.write_text(
+            "from huggingface_hub.errors import LocalEntryNotFoundError\n"
+            "raise LocalEntryNotFoundError('not cached')\n"
+        )
+    elif failure == "initial-cache-miss":
+        (tmp_path / "conftest.py").write_text(
+            "from huggingface_hub.errors import LocalEntryNotFoundError\n"
+            "raise LocalEntryNotFoundError('not cached')\n"
+        )
+        test_path.touch()
+    else:
+        test_path.write_text(f"def test_failure():\n    {statements[failure]}\n")
+    if failure == "initial-cache-miss":
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("PYTHONPATH", str(TEST_UTILS))
+        monkeypatch.delenv("PYTEST_ADDOPTS", raising=False)
+        command = shlex.join([sys.executable, "-m", "pytest", "-q", test_path.name])
+        assert HFHubTestGroup(command, offline=True).run() == expected_status
+        return
+    request_log = tmp_path / "requests.log"
+
+    result = _run_plugin_pytest(tmp_path, request_log, "test_failure.py", offline=True)
+
+    assert result.returncode == expected_status, result
+
+
+def test_forked_request_keeps_count_and_retry_attribution(tmp_path, http_server):
+    (tmp_path / "conftest.py").write_text(
+        f"""
+from huggingface_hub.utils import _http
+
+_http.get_session().get("{http_server}/200")
+"""
+    )
+    (tmp_path / "test_forked.py").write_text(
+        f"""
+import pytest
+from huggingface_hub.utils import _http
+
+@pytest.mark.forked
+def test_failure():
+    _http.get_session().get("{http_server}/503").raise_for_status()
+"""
+    )
+    request_log = tmp_path / "requests.log"
+
+    result = _run_plugin_pytest(tmp_path, request_log, "test_forked.py")
+
+    assert result.returncode == HF_HUB_RETRY_EXIT_STATUS, result
+    assert request_log.read_text() == (
+        "1\ttest_forked.py::test_failure\n1\t<session>\n"
+    )
+
+
+@pytest.mark.parametrize(("offline", "expected_offline"), [(True, "1"), (False, "0")])
+def test_group_preserves_quoting_and_unrelated_status(
+    monkeypatch, tmp_path, capfd, offline, expected_offline
+):
+    offline_output = tmp_path / "offline"
+    quoted_output = tmp_path / "quoted"
+    monkeypatch.delenv("PYTEST_ADDOPTS", raising=False)
+    command = (
+        f"printf '%s' \"$HF_HUB_OFFLINE\" > {shlex.quote(str(offline_output))}; "
+        f"printf '%s' 'quoted value' > {shlex.quote(str(quoted_output))}; "
+        "exit 42"
+    )
+
+    status = HFHubTestGroup(command, offline=offline).run()
+
+    assert status == 42
+    assert offline_output.read_text() == expected_offline
+    assert quoted_output.read_text() == "quoted value"
+    assert capfd.readouterr().out.count("Hugging Face Hub HTTP requests") == 1
+
+
+@pytest.mark.parametrize(("pipefail", "expected_status"), [(False, 0), (True, 1)])
+def test_group_preserves_callers_pipeline_behavior(pipefail, expected_status):
+    assert HFHubTestGroup("false | true", pipefail=pipefail).run() == expected_status
+
+
+def _write_executable(path: Path, contents: str) -> None:
+    path.write_text(contents)
+    path.chmod(0o755)
+
+
+def _run_stubbed_amd_docker(
+    tmp_path: Path, *, mode: str | None, retry_count: str = "0"
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    docker_args = tmp_path / "docker-args"
+    _write_executable(
+        bin_dir / "docker",
+        """#!/bin/bash
+if [[ "$1" == "run" ]]; then
+  shift
+  printf '%s\\0' "$@" > "$DOCKER_ARGS"
+fi
+""",
+    )
+    _write_executable(bin_dir / "rocminfo", "#!/bin/bash\nexit 0\n")
+    _write_executable(
+        bin_dir / "getent",
+        """#!/bin/bash
+if [[ "$1" == "group" && "$2" == "render" ]]; then
+  echo 'render:x:123:'
+  exit 0
+fi
+exit 1
+""",
+    )
+    environment = {
+        **os.environ,
+        "BUILDKITE_COMMIT": "test",
+        "DOCKER_ARGS": str(docker_args),
+        "HOME": str(tmp_path),
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "ROCM_DOCKER_TTY": "0",
+        "BUILDKITE_RETRY_COUNT": retry_count,
+        "VLLM_CI_USE_ARTIFACTS": "0",
+        "VLLM_TEST_COMMANDS": "false | true",
+    }
+    if mode is None:
+        environment.pop("VLLM_CI_HF_HUB_MODE", None)
+    else:
+        environment["VLLM_CI_HF_HUB_MODE"] = mode
+
+    result = subprocess.run(
+        ["bash", str(AMD_TEST_RUNNER)],
+        cwd=ROOT,
+        env=environment,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    arguments = docker_args.read_bytes().rstrip(b"\0").decode().split("\0")
+    return result, arguments
+
+
+@pytest.mark.parametrize("mode", [None, ""])
+def test_disabled_amd_runner_preserves_legacy_docker_command(tmp_path, mode):
+    result, arguments = _run_stubbed_amd_docker(tmp_path, mode=mode)
+
+    assert result.returncode == 0, result
+    assert "PYTHONPATH=/vllm-workspace" in arguments
+    assert arguments[-3] == "/bin/bash"
+    assert arguments[-2] == "-c"
+    assert arguments[-1].endswith(" && false | true")
+    assert "Hugging Face Hub HTTP requests" not in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("mode", "retry_count", "offline"),
+    [
+        ("offline-first", "0", True),
+        ("offline-first", "1", False),
+        ("online", "0", False),
+    ],
+)
+def test_enabled_amd_docker_runner_wraps_only_the_test_command(
+    tmp_path, mode, retry_count, offline
+):
+    result, arguments = _run_stubbed_amd_docker(
+        tmp_path, mode=mode, retry_count=retry_count
+    )
+
+    assert result.returncode == 0, result
+    assert (
+        "PYTHONPATH=/vllm-workspace/tests/vllm_test_utils:/vllm-workspace" in arguments
+    )
+    expected_runner = ["python3", "-m", "vllm_test_utils.hf_hub"]
+    if offline:
+        expected_runner.append("--offline")
+    assert arguments[-len(expected_runner) - 2 : -2] == expected_runner
+    assert arguments[-2] == "--"
+    assert arguments[-1].endswith(" && false | true")
+
+
+def test_amd_runner_rejects_invalid_enabled_mode():
+    environment = {**os.environ, "VLLM_CI_HF_HUB_MODE": "invalid"}
+
+    result = subprocess.run(
+        ["bash", str(AMD_TEST_RUNNER)],
+        cwd=ROOT,
+        env=environment,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 2
+    assert "Invalid VLLM_CI_HF_HUB_MODE: invalid" in result.stderr

--- a/tests/vllm_test_utils/vllm_test_utils/hf_hub.py
+++ b/tests/vllm_test_utils/vllm_test_utils/hf_hub.py
@@ -1,0 +1,403 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import argparse
+import os
+import shlex
+import subprocess
+import tempfile
+import threading
+from collections import Counter
+from collections.abc import Callable, Generator, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from huggingface_hub import constants as hf_constants
+from huggingface_hub.errors import LocalEntryNotFoundError, OfflineModeIsEnabled
+
+HF_HUB_RETRY_EXIT_STATUS = 75
+
+_PLUGIN_MODULE = "vllm_test_utils.hf_hub"
+_PLUGIN_NAME = "vllm-hf-hub-request-monitor"
+_REQUEST_LOG_OPTION = "--hf-request-log"
+_REQUEST_NODEID_EXTENSION = "vllm.hf_request_nodeid"
+_RETRYABLE_STATUS_CODES = frozenset({408, 429, 500, 502, 503, 504})
+_SESSION = "<session>"
+_TRANSIENT_HTTPX_ERRORS = (
+    httpx.TimeoutException,
+    httpx.NetworkError,
+    httpx.RemoteProtocolError,
+    httpx.ProxyError,
+)
+
+
+def _exception_chain(error: BaseException) -> Generator[BaseException, None, None]:
+    pending = [error]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        yield current
+        grouped = getattr(current, "exceptions", ())
+        if isinstance(grouped, tuple):
+            pending.extend(grouped)
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
+        if current.__context__ is not None:
+            pending.append(current.__context__)
+
+
+def _request_from(error: BaseException) -> httpx.Request | None:
+    for owner in (error, getattr(error, "response", None)):
+        try:
+            request = getattr(owner, "request", None)
+        except (AttributeError, RuntimeError):
+            continue
+        if isinstance(request, httpx.Request):
+            return request
+    return None
+
+
+def _retryable_request_nodeid(error: BaseException) -> str | None:
+    for current in _exception_chain(error):
+        response = getattr(current, "response", None)
+        retryable = isinstance(current, _TRANSIENT_HTTPX_ERRORS) or (
+            getattr(response, "status_code", None) in _RETRYABLE_STATUS_CODES
+        )
+        request = _request_from(current)
+        if retryable and request is not None:
+            nodeid = request.extensions.get(_REQUEST_NODEID_EXTENSION)
+            if nodeid:
+                return nodeid
+    return None
+
+
+def _is_offline_cache_miss(error: BaseException) -> bool:
+    return any(
+        isinstance(current, (LocalEntryNotFoundError, OfflineModeIsEnabled))
+        for current in _exception_chain(error)
+    )
+
+
+def _safe_nodeid(nodeid: str) -> str:
+    return nodeid.replace("\r", r"\r").replace("\n", r"\n").replace("\t", r"\t")
+
+
+def _append_log(path: Path, rows: str) -> None:
+    if not rows:
+        return
+    descriptor = os.open(path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
+    try:
+        os.write(descriptor, rows.encode())
+    finally:
+        os.close(descriptor)
+
+
+def _append_counts(path: Path, counts: Mapping[str, int]) -> None:
+    _append_log(
+        path,
+        "".join(f"{count}\t{nodeid}\n" for nodeid, count in counts.items() if count),
+    )
+
+
+def _read_log(path: Path) -> tuple[Counter[str], bool]:
+    counts: Counter[str] = Counter()
+    retryable = False
+    with path.open() as requests:
+        for line in requests:
+            if line == "retry\n":
+                retryable = True
+                continue
+            count, separator, nodeid = line.rstrip("\n").partition("\t")
+            if separator and count.isdecimal():
+                counts[nodeid] += int(count)
+    return counts, retryable
+
+
+def _format_table(counts: Mapping[str, int]) -> str:
+    rows = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    lines = [f"{'REQUESTS':>8}  TEST"]
+    lines.extend(f"{count:>8}  {nodeid}" for nodeid, count in rows)
+    lines.append(f"{sum(counts.values()):>8}  TOTAL")
+    return "\n".join(lines)
+
+
+class HFHubRequestMonitor:
+    """Count and attribute requests made through Hugging Face Hub clients."""
+
+    def __init__(self, request_log: Path | None = None) -> None:
+        self._request_log = request_log
+        self._counts: Counter[str] = Counter()
+        self._current_nodeid = _SESSION
+        self._retryable_failure = False
+        self._lock = threading.Lock()
+        self._pid = os.getpid()
+        self._factories: tuple[Callable[[], Any], Callable[[], Any]] | None = None
+
+    def _reset_after_fork(self) -> None:
+        pid = os.getpid()
+        if pid != self._pid:
+            self._pid = pid
+            self._lock = threading.Lock()
+            self._counts.clear()
+            self._retryable_failure = False
+
+    def _record_request(self, request: httpx.Request) -> None:
+        self._reset_after_fork()
+        with self._lock:
+            nodeid = self._current_nodeid
+            self._counts[nodeid] += 1
+        request.extensions[_REQUEST_NODEID_EXTENSION] = nodeid
+
+    async def _record_async_request(self, request: httpx.Request) -> None:
+        self._record_request(request)
+
+    def _wrap_factory(
+        self, factory: Callable[[], Any], *, asynchronous: bool
+    ) -> Callable[[], Any]:
+        request_hook = (
+            self._record_async_request if asynchronous else self._record_request
+        )
+
+        def monitored_client() -> Any:
+            client = factory()
+            hooks = client.event_hooks.setdefault("request", [])
+            if request_hook not in hooks:
+                hooks.insert(0, request_hook)
+            return client
+
+        return monitored_client
+
+    def install(self) -> None:
+        """Install listeners on the Hub's sync and async client factories."""
+        if self._factories is not None:
+            return
+        from huggingface_hub.utils import _http as hf_http
+
+        self._factories = (
+            hf_http._GLOBAL_CLIENT_FACTORY,
+            hf_http._GLOBAL_ASYNC_CLIENT_FACTORY,
+        )
+        hf_http.set_client_factory(
+            self._wrap_factory(self._factories[0], asynchronous=False)
+        )
+        hf_http.set_async_client_factory(
+            self._wrap_factory(self._factories[1], asynchronous=True)
+        )
+
+    def uninstall(self) -> None:
+        """Restore the Hub client factories that preceded this monitor."""
+        if self._factories is None:
+            return
+        from huggingface_hub.utils import _http as hf_http
+
+        hf_http.set_client_factory(self._factories[0])
+        hf_http.set_async_client_factory(self._factories[1])
+        self._factories = None
+
+    @property
+    def counts(self) -> Counter[str]:
+        """Return a snapshot of request counts in the current process."""
+        self._reset_after_fork()
+        with self._lock:
+            return self._counts.copy()
+
+    def _set_current_nodeid(self, nodeid: str) -> None:
+        self._reset_after_fork()
+        with self._lock:
+            self._current_nodeid = _safe_nodeid(nodeid)
+
+    def _flush(self, nodeid: str | None = None) -> None:
+        if self._request_log is None:
+            return
+        self._reset_after_fork()
+        with self._lock:
+            if nodeid is None:
+                counts = self._counts.copy()
+                self._counts.clear()
+            else:
+                count = self._counts.pop(nodeid, 0)
+                counts = Counter({nodeid: count})
+        _append_counts(self._request_log, counts)
+
+    @pytest.hookimpl(hookwrapper=True, tryfirst=True)
+    def pytest_runtest_protocol(
+        self, item: Any, nextitem: Any
+    ) -> Generator[None, Any, None]:
+        self._set_current_nodeid(item.nodeid)
+        try:
+            yield
+        finally:
+            self._set_current_nodeid(_SESSION)
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_makereport(
+        self, item: Any, call: Any
+    ) -> Generator[None, Any, None]:
+        outcome = yield
+        report = outcome.get_result()
+        error = call.excinfo.value if call.excinfo is not None else None
+        retryable = False
+        if report.failed and error is not None:
+            if hf_constants.is_offline_mode():
+                retryable = _is_offline_cache_miss(error)
+            else:
+                retryable = _retryable_request_nodeid(error) == report.nodeid
+        report.vllm_hf_retryable = retryable
+        self._reset_after_fork()
+        with self._lock:
+            self._retryable_failure |= retryable
+        if report.when == "teardown":
+            self._flush(report.nodeid)
+
+    def pytest_runtest_logreport(self, report: Any) -> None:
+        """Receive retry attribution from pytest-forked children."""
+        if getattr(report, "vllm_hf_retryable", False):
+            self._reset_after_fork()
+            with self._lock:
+                self._retryable_failure = True
+
+    def pytest_exception_interact(self, node: Any, call: Any, report: Any) -> None:
+        """Handle transient errors raised during test collection."""
+        if getattr(report, "when", None) != "collect" or call.excinfo is None:
+            return
+        error = call.excinfo.value
+        retryable = (
+            _is_offline_cache_miss(error)
+            if hf_constants.is_offline_mode()
+            else _retryable_request_nodeid(error) == _SESSION
+        )
+        if retryable:
+            self._reset_after_fork()
+            with self._lock:
+                self._retryable_failure = True
+
+    @pytest.hookimpl(trylast=True)
+    def pytest_sessionfinish(self, session: Any, exitstatus: int) -> None:
+        self._flush()
+        self._reset_after_fork()
+        with self._lock:
+            retryable = self._retryable_failure
+        if exitstatus not in {0, 5} and retryable:
+            session.exitstatus = HF_HUB_RETRY_EXIT_STATUS
+
+    def pytest_unconfigure(self) -> None:
+        """Flush pending counts and restore the original Hub clients."""
+        self._flush()
+        self.uninstall()
+
+
+@dataclass(frozen=True)
+class HFHubTestGroup:
+    """Run a shell test group with HF request monitoring enabled."""
+
+    command: str
+    offline: bool = False
+    pipefail: bool = False
+
+    def _environment(self, request_log: Path) -> dict[str, str]:
+        environment = os.environ.copy()
+        pytest_options = shlex.split(environment.get("PYTEST_ADDOPTS", ""))
+        pytest_options.extend(
+            ["-p", _PLUGIN_MODULE, f"{_REQUEST_LOG_OPTION}={request_log}"]
+        )
+        environment["PYTEST_ADDOPTS"] = shlex.join(pytest_options)
+        offline = "1" if self.offline else "0"
+        environment.update(
+            {
+                "HF_HUB_OFFLINE": offline,
+                "HF_DATASETS_OFFLINE": offline,
+                "TRANSFORMERS_OFFLINE": offline,
+            }
+        )
+        environment.pop("VLLM_CI_HF_HUB_MODE", None)
+        return environment
+
+    def run(self) -> int:
+        """Run the group, print its request table, and return its exit status."""
+        shell_command = ["/bin/bash"]
+        if self.pipefail:
+            shell_command.extend(["-o", "pipefail"])
+        shell_command.extend(["-c", self.command])
+        with tempfile.NamedTemporaryFile(prefix="vllm-hf-requests-") as request_log:
+            path = Path(request_log.name)
+            completed = subprocess.run(
+                shell_command,
+                env=self._environment(path),
+                check=False,
+            )
+            counts, retryable = _read_log(path)
+        print("Hugging Face Hub HTTP requests")
+        print(_format_table(counts))
+        if completed.returncode not in {0, 5} and retryable:
+            return HF_HUB_RETRY_EXIT_STATUS
+        return completed.returncode
+
+
+def pytest_addoption(parser: Any) -> None:
+    """Add the private aggregation path used by the test-group runner."""
+    group = parser.getgroup("Hugging Face Hub monitoring")
+    group.addoption(
+        _REQUEST_LOG_OPTION,
+        type=Path,
+        help="append per-test Hugging Face Hub request counts to this file",
+    )
+
+
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_load_initial_conftests(
+    early_config: Any,
+) -> Generator[None, Any, None]:
+    """Install the request listener before repository conftest imports."""
+    if early_config.pluginmanager.hasplugin(_PLUGIN_NAME):
+        yield
+        return
+    request_log = getattr(early_config.known_args_namespace, "hf_request_log", None)
+    monitor = HFHubRequestMonitor(request_log)
+    monitor.install()
+    early_config.pluginmanager.register(monitor, _PLUGIN_NAME)
+    outcome = yield
+    if outcome.excinfo is None:
+        return
+    error = getattr(outcome.excinfo[1], "cause", outcome.excinfo[1])
+    retryable = (
+        _is_offline_cache_miss(error)
+        if hf_constants.is_offline_mode()
+        else _retryable_request_nodeid(error) == _SESSION
+    )
+    if retryable:
+        monitor._flush()
+        monitor.uninstall()
+        if request_log is not None:
+            _append_log(request_log, "retry\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run an HF-monitored test group from the command line."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="disable network access for Hub, Transformers, and Datasets clients",
+    )
+    parser.add_argument(
+        "--pipefail",
+        action="store_true",
+        help="propagate failures from commands in a shell pipeline",
+    )
+    parser.add_argument("command", help="shell command for the test group")
+    arguments = parser.parse_args(argv)
+    return HFHubTestGroup(
+        arguments.command,
+        offline=arguments.offline,
+        pipefail=arguments.pipefail,
+    ).run()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- Suggested title: [CI] Add opt-in Hugging Face Hub monitoring -->

## Purpose

Cached CI jobs should not contact Hugging Face Hub unless the cache is missing something. This change adds opt-in request monitoring and offline-first execution under `VLLM_CI_HF_HUB_MODE`. When the variable is unset or empty, the AMD runner keeps its existing command, environment, and exit behavior. We will initially test the policy on AMD CI jobs.

Today, using the Hub cache in online mode still performs metadata checks. At CI scale, those checks can hit rate limits or network timeouts and fail tests without downloading any files. [Example failure](https://buildkite.com/vllm/amd-ci/builds/11036/list?jid=019f7ec1-1b46-4d1b-80ac-3cd612fb747c&tab=output#L8426).

This PR adds a reusable pytest monitor and test-group runner:

- Listen to the Hugging Face Hub sync and async clients in pytest processes, count successful and failed HTTP attempts, attribute them to the current test or session setup, and print one table after the test group.
- Activate only when `VLLM_CI_HF_HUB_MODE` is set to `offline-first` or `online`; an unset or empty value follows the existing runner path unchanged.
- Run in `offline-first` mode on the initial Buildkite attempt and online on the retry. Nightly jobs can select `online` from the start.
- Return exit status 75 only for an offline cache miss, a transient Hub transport error, or HTTP 408/429/500/502/503/504. Other failures keep their original status.
- Use the same runner for native and containerized AMD jobs. The monitor itself is generic and can be enabled by other CI pipelines later.

This is test infrastructure only; it does not change vLLM model loading or runtime behavior. The companion ci-infra PR selects the mode for AMD jobs and adds the exit-75 retry: https://github.com/vllm-project/ci-infra/pull/429.

Forked pytest children inherit the listener. Independently spawned non-pytest workers are outside this initial monitoring scope.

## Related work

#44820 addresses the same CI instability by adding retries to selected production call sites. This PR handles it at the test-group boundary, covers Hub client traffic in instrumented pytest processes, and also reports request counts.

## Test Plan

Run the focused monitor tests, including successful and failed requests, offline cache misses, transient online failures, collection/setup failures, forked tests, and the AMD shell-runner modes.

## Test Result

- `PYTHONPATH="tests/vllm_test_utils${PYTHONPATH:+:$PYTHONPATH}" .venv/bin/python -m pytest -q tests/tools/test_hf_hub_monitor.py` — 31 passed.
- `uvx --from ruff==0.14.0 ruff check tests/vllm_test_utils/vllm_test_utils/hf_hub.py tests/tools/test_hf_hub_monitor.py` — passed.
- `uvx --from ruff==0.14.0 ruff format --check tests/vllm_test_utils/vllm_test_utils/hf_hub.py tests/tools/test_hf_hub_monitor.py` — passed.
- `bash -n .buildkite/scripts/hardware_ci/run-amd-test.sh` — passed.
- `git diff --check` — passed.

Model evaluation is not applicable because this only changes CI test instrumentation. AI assistance was used to develop and review this change.
