### PR TITLE
[Bugfix] Do not discard model output when tool_choice defaults to "none" with no tools declared

### DIFF
--- a/tests/parser/engine/test_delegating_replay.py
+++ b/tests/parser/engine/test_delegating_replay.py
@@ -160,6 +160,55 @@ _TOOL_CALL_SAMPLES = [
     if s.expected_tool_calls
 ]
 
+_TOOL_ONLY_SAMPLES = [
+    (p.parser_cls, p.name, s)
+    for p in _PAIRINGS
+    for s in p.samples
+    if s.expected_tool_calls and not s.expected_reasoning and not s.expected_content
+]
+
+
+@pytest.mark.parametrize("chunk_size", CHUNK_SIZES, ids=lambda c: f"chunk={c}")
+@pytest.mark.parametrize(
+    "parser_cls,parser_name,sample",
+    _TOOL_ONLY_SAMPLES,
+    ids=lambda v: v.id if hasattr(v, "id") else "",
+)
+def test_delegating_replay_no_tools_recovers_suppressed_output(
+    parser_cls, parser_name, sample, chunk_size
+):
+    """A request with no tools defaults tool_choice to "none". When the
+    model emits a tool call anyway and the whole response is tool syntax,
+    the text must surface as content instead of being stripped to an
+    entirely empty message (#49254)."""
+    tokenizer = make_mock_tokenizer(sample)
+    parser = parser_cls(
+        tokenizer, None, chat_template_kwargs=sample.chat_template_kwargs
+    )
+
+    deltas = replay_streaming(
+        parser,
+        sample.tokens,
+        chunk_size=chunk_size,
+        finished_on_last=True,
+        tools=None,
+        prompt_token_ids=sample.prompt_token_ids,
+    )
+    output = collect_output(deltas)
+
+    assert output.tool_calls == [], (
+        f"Expected no tool calls without declared tools, got {output.tool_calls}"
+    )
+    for expected_call in sample.expected_tool_calls:
+        assert expected_call["name"] in output.content, (
+            f"parser={parser_name}: tool name lost: {output.content!r}"
+        )
+        for value in expected_call["arguments"].values():
+            if isinstance(value, str) and value:
+                assert value in output.content, (
+                    f"parser={parser_name}: argument {value!r} lost: {output.content!r}"
+                )
+
 
 @pytest.mark.parametrize(
     "parser_cls,parser_name,sample",

--- a/tests/parser/engine/trace_builder.py
+++ b/tests/parser/engine/trace_builder.py
@@ -265,7 +265,12 @@ def _expected_tc(scenario: Scenario) -> list[dict] | None:
 
 
 def _expected_tools(scenario: Scenario) -> list[dict] | None:
-    return _tool_defs(scenario.tool_calls) if scenario.tool_calls else None
+    if scenario.tool_calls is None:
+        return None
+    # An empty tool block still implies a tool-calling context: without
+    # declared tools, tool_choice defaults to "none" and the parser passes
+    # tool syntax through as content instead of parsing it.
+    return _tool_defs(scenario.tool_calls or [_READ_TOOL])
 
 
 def _validate_sample(sample: Sample, parser_cls: type, **kwargs) -> None:

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -414,6 +414,25 @@ class DelegatingParser(Parser):
         state.history_tool_call_cnt += 1
         return tool_call_id
 
+    @contextlib.contextmanager
+    def _tool_syntax_as_content(self):
+        """Emit tool-call syntax as plain content.
+
+        The engine still parses reasoning; only tool terminals pass
+        through as text (the same mechanism the reasoning adapters use
+        for reasoning-only extraction).
+        """
+        engine = getattr(self._tool_parser, "_parser_engine", None)
+        if engine is None:
+            yield
+            return
+        saved = engine.skip_tool_parsing
+        engine.skip_tool_parsing = True
+        try:
+            yield
+        finally:
+            engine.skip_tool_parsing = saved
+
     def _extract_tool_calls(
         self,
         content: str | None,
@@ -425,7 +444,13 @@ class DelegatingParser(Parser):
             return [], content
 
         if request.tool_choice == "none":
-            if self._engine_based:
+            # Engine-backed parsers strip tool syntax from the content, but
+            # only when the request declared tools: there, "none" is an
+            # explicit opt-out. Without tools, "none" is just the protocol
+            # default and tool semantics were never in play, so the text
+            # passes through unmodified like it does for legacy parsers
+            # (#49254).
+            if self._engine_based and getattr(request, "tools", None):
                 result = self.extract_tool_calls(content or "", request=request)
                 return [], result.content
             return [], content
@@ -662,18 +687,29 @@ class DelegatingParser(Parser):
         if request.tool_choice == "none":
             if self._engine_based:
                 # Engine-backed parsers route content extraction through
-                # extract_tool_calls_streaming, so run the full pipeline
-                # and strip tool_calls after.
-                delta_message = self.extract_tool_calls_streaming(
-                    previous_text,
-                    current_text,
-                    delta_text,
-                    previous_token_ids,
-                    current_token_ids,
-                    delta_token_ids,
-                    request,  # type: ignore[arg-type]
+                # extract_tool_calls_streaming, so run the full pipeline.
+                # With tools declared, "none" is an explicit opt-out: strip
+                # any tool calls after. Without tools, "none" is just the
+                # protocol default and tool semantics were never in play, so
+                # keep tool syntax as content like legacy parsers (#49254);
+                # the engine still extracts reasoning either way.
+                declared_tools = getattr(request, "tools", None)
+                ctx = (
+                    contextlib.nullcontext()
+                    if declared_tools
+                    else self._tool_syntax_as_content()
                 )
-                if delta_message:
+                with ctx:
+                    delta_message = self.extract_tool_calls_streaming(
+                        previous_text,
+                        current_text,
+                        delta_text,
+                        previous_token_ids,
+                        current_token_ids,
+                        delta_token_ids,
+                        request,  # type: ignore[arg-type]
+                    )
+                if declared_tools and delta_message:
                     delta_message.tool_calls = []
                 return delta_message, False
             return (DeltaMessage(content=delta_text) if delta_text else None), False


### PR DESCRIPTION
FIX #49254

## Purpose

When a chat request declares **no tools**, the protocol defaults `tool_choice` to `"none"`. Since #45413, engine-based parsers handle that branch by running the full tool-parsing pipeline and then stripping the parsed tool calls (`delta_message.tool_calls = []` in `DelegatingParser._extract_tool_calls_streaming`). If the model emits tool-call syntax anyway — common for agentic-tuned models given tool-heavy context — its entire output is parsed into tool calls and then discarded: the client receives an empty response (`finish_reason: "stop"`, every chunk `"delta": {}`), with the generated tokens visible only in `logprobs`. That is exactly the symptom reported in #49254.

This is not model-specific: replaying the same shape through all ten engine-based parsers (gemma4, qwen3, seed_oss, glm4.7, kimi_k2, deepseek v3.2/v4, minimax_m2, nemotron_v3, inkling) loses the response identically. Gemma-4 became exposed when it was converted to the engine implementation in #45588.

## Fix

Gate the strip on the request actually declaring tools:

- **Tools declared + `tool_choice="none"`** (explicit opt-out): unchanged — run the pipeline, strip tool calls silently. This keeps the existing tested contract (`test_delegating_parse_tool_choice_none`, `assert_no_terminal_leakage`).
- **No tools declared** (defaulted `"none"`): run the same pipeline under the engine's existing `skip_tool_parsing` mode — reasoning is still extracted into the `reasoning` field, and tool syntax streams through incrementally as `content`. This matches what legacy (non-engine) parsers already do on this exact branch (`DeltaMessage(content=delta_text)` passthrough), so engine and non-engine parsers now behave consistently.

`skip_tool_parsing` is used rather than raw passthrough because parsers like gemma4 extract reasoning inside the same unified engine; raw passthrough would leak `<|channel>thought` markers into content.

Also fixes the test trace builder deriving request tools via truthiness (`if scenario.tool_calls`), which silently gave the `empty-tool-block` samples (`tool_calls=[]`) no-tools requests — those samples now declare a tool, matching their intent of exercising a tool-calling context.

## Why this is not duplicating an existing PR

No open PR references #49254. The two adjacent open PRs repair *different* branches of the same `tool_choice` plumbing and do not touch the `"none"` strip:

- #49228 fixes the `required`/named tool-choice streaming crash (#49216).
- #49346 fixes request *validation* (`protocol.py`) to accept `tools: []`. Verified compatible: this PR's gate uses truthiness, so the newly-legal `tools: []` correctly behaves like tools-absent (passthrough).

## Root cause commits

- `c4a3f9d13` (#45413) introduced the engine-based strip branch; before it, `tool_choice="none"` always returned `delta_text` as content.
- `76a373eff` (#45588) converted Gemma-4 to the engine implementation, exposing it to the branch (this is why the reporter observed it "worked before").

## Test Plan

```bash
pytest tests/parser/engine/test_delegating_replay.py   # includes new regression test
pytest tests/parser/ tests/tool_parsers/ tests/reasoning/
```

New regression test `test_delegating_replay_no_tools_recovers_suppressed_output`: replays tool-only outputs through every engine parser (auto-discovered) at all chunk sizes with a no-tools request, asserting no tool calls are emitted and the tool name/argument payloads survive in content.

## Test Result

- New regression test: **189/189 parametrizations fail without the fix, pass with it.**
- `tests/parser/` + `tests/tool_parsers/` + `tests/reasoning/`: **4974 passed** with the fix vs 4785 on clean main (+189 = the new parametrizations); the 35 failures in both runs are **byte-identical pre-existing failures** (apertus/granite/jamba/kimi_k2; unrelated files, present on clean `main`).
- Non-streaming, explicit-none, and `tools: []` variants covered by existing + new unit tests.

## Model evaluation (end-to-end on real hardware)

Served `nvidia/Gemma-4-26B-A4B-NVFP4` on an NVIDIA GB10 (`--tool-call-parser gemma4 --reasoning-parser gemma4 --enable-auto-tool-choice`) and ran the reporter's exact `replay_script.py` from #49254:

- **Before:** 3/3 runs returned a completely empty stream (only `"delta": {}` chunks; text visible in logprobs only) — exact reproduction of the issue, including `prompt_tokens: 17964`.
- **After:** 3/3 runs return the model's output as content, e.g. `<|tool_call>call:bash{command:<|"|>python3 -m analyzer ...<|"|>}<tool_call|>`.
- Semantics matrix on the live server, all correct: tools+`auto` → proper `get_weather` tool call; tools+explicit `"none"` → suppressed (unchanged); no tools → normal prose content.

## Notes for reviewers

- In the no-tools path, clients now see the model's raw tool syntax (special tokens included) as content — the same behavior legacy parsers have always had on this branch, and what the reporter's benchmark consumes. If a cleaner rendering is preferred, that's a follow-up policy decision.
- The explicit-opt-out case (tools declared + `"none"`) still silently strips a disobedient tool call, preserving the existing tested contract; whether that residual case should surface text somewhere is left to maintainers.

## AI assistance disclosure

This fix was developed with AI assistance (Claude Code). The root cause was bisected, the fix designed and validated (unit + live GB10 end-to-end) in an interactive session; every changed line has been reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MG6juQ2K7a4WqwV38R8TX8
