### PR TITLE
[Docs] Clarify ASR audio chunking is non-overlapping

### DIFF
--- a/docs/contributing/model/transcription.md
+++ b/docs/contributing/model/transcription.md
@@ -195,7 +195,7 @@ Provide a fast duration→token estimate to improve streaming usage statistics:
 The API server takes care of basic audio I/O and optional chunking before building prompts:
 
 - Resampling: Input audio is resampled to `SpeechToTextConfig.sample_rate` using `AudioResampler`.
-- Chunking: If `SpeechToTextConfig.allow_audio_chunking` is True and the duration exceeds `max_audio_clip_s`, the server splits the audio into chunks and generates a prompt per chunk. There is no overlap between chunks, overlap_chunk_second controls the size of the search window used to find the split point.
+- Chunking: If `SpeechToTextConfig.allow_audio_chunking` is True and the duration exceeds `max_audio_clip_s`, the server splits the audio into consecutive (non-overlapping) chunks and generates a prompt per chunk. `overlap_chunk_second` controls the size of the search window near each nominal chunk boundary within which the split point is chosen (see energy-aware splitting below); it does not add overlap between chunks.
 - Energy-aware splitting: When `min_energy_split_window_size` is set, the server finds low-energy regions to minimize cutting within words.
 
 Relevant server logic:

--- a/vllm/config/speech_to_text.py
+++ b/vllm/config/speech_to_text.py
@@ -67,9 +67,10 @@ class SpeechToTextConfig:
     `None` means audio duration can be unlimited and won't be chunked."""
 
     overlap_chunk_second: int = 1
-    """Overlap duration in seconds between consecutive audio chunks when
-    splitting long audio. This helps maintain context across chunk boundaries
-    and improves transcription quality at split points."""
+    """Size in seconds of the search window before each nominal chunk boundary
+    within which the best (lowest-energy) split point is selected when splitting
+    long audio. Chunks are consecutive and do not overlap; this window only lets
+    the split point move slightly earlier to avoid cutting through speech."""
 
     min_energy_split_window_size: int | None = 1600
     """Window size in samples for finding low-energy (quiet) regions to split

--- a/vllm/multimodal/audio.py
+++ b/vllm/multimodal/audio.py
@@ -332,16 +332,19 @@ def split_audio(
     """Split audio into chunks with intelligent split points.
 
     Splits long audio into smaller chunks at low-energy regions to minimize
-    cutting through speech. Uses overlapping windows to find quiet moments
-    for splitting.
+    cutting through speech. A search window before each chunk boundary is
+    scanned for quiet moments; the resulting chunks are consecutive and do
+    not overlap.
 
     Args:
         audio_data: Audio array to split. Can be 1D (mono) or multi-dimensional.
                    Splits along the last dimension (time axis).
         sample_rate: Sample rate of the audio in Hz.
         max_clip_duration_s: Maximum duration of each chunk in seconds.
-        overlap_duration_s: Overlap duration in seconds between consecutive chunks.
-                           Used to search for optimal split points.
+        overlap_duration_s: Size in seconds of the search window before each
+                           nominal chunk boundary in which the optimal
+                           (lowest-energy) split point is chosen. Chunks do not
+                           overlap; this only lets a split point move earlier.
         min_energy_window_size: Window size in samples for finding low-energy regions.
 
     Returns:
@@ -371,7 +374,7 @@ def split_audio(
             chunks.append(audio_data[..., i:])
             break
 
-        # Find the best split point in the overlap region
+        # Find the best split point in the search window before the boundary
         search_start = i + chunk_size - overlap_size
         search_end = min(i + chunk_size, audio_data.shape[-1])
         split_point = find_split_point(


### PR DESCRIPTION
## Purpose

The ASR audio-chunking documentation and docstrings describe long-audio
splitting as producing **overlapping** chunks, with overlap controlled by
`overlap_chunk_second`. This is inaccurate.

`split_audio()` in `vllm/multimodal/audio.py` produces **consecutive,
non-overlapping** chunks: it advances the cursor to the chosen split point
(`i = split_point`), so no samples are shared between chunks. The
`overlap_chunk_second` / `overlap_duration_s` value is only the size of a
*search window* placed just before each nominal chunk boundary, within which
the lowest-energy point is picked to avoid cutting through speech. The
existing test `test_split_audio_chunks_have_correct_length` confirms this:
each non-final chunk is `>= max_samples - overlap_samples` and `<= max_samples`
(i.e. shorter than the nominal length, never longer/overlapping).

This PR corrects the misleading wording in three places, with no behavior
change:

- `docs/contributing/model/transcription.md` (chunking bullet)
- `SpeechToTextConfig.overlap_chunk_second` docstring
- `split_audio()` docstring + one inline comment

I ran into this while triaging #32588, which explicitly notes that "there are
no overlapping chunks, but just a window for searching the best split point"
and that the related docs are incorrect. This PR only addresses that
documentation inaccuracy (not the timestamp-offset behavior discussed there).

## Test Plan

Docs/docstring-only change (no runtime behavior modified). Sanity-checked
that the touched modules still import and existing audio tests pass, plus
lint/format:

```bash
export VLLM_TARGET_DEVICE=cpu VLLM_CPU_KVCACHE_SPACE=1
python -m pytest tests/multimodal/test_audio.py -k "Chunking or split or find_split"
ruff check vllm/multimodal/audio.py vllm/config/speech_to_text.py
ruff format --check vllm/multimodal/audio.py vllm/config/speech_to_text.py
```

## Test Result

Verified locally in a CPU-only aarch64 environment (Python 3.11, nightly CPU
wheel):

- `pytest tests/multimodal/test_audio.py -k "Chunking or split or find_split"` → **11 passed, 35 deselected**
- `ruff check ...` → **All checks passed!**
- `ruff format --check ...` → **2 files already formatted**
- `python -c "from vllm.config.speech_to_text import SpeechToTextConfig; from vllm.multimodal.audio import split_audio"` → import OK

No GPU or model execution was required or performed for this docs change.
