### PR TITLE
[Bugfix] Fix DeepSeek-V4 DSpark draft shared-expert padding for TP > 8

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -43,6 +43,7 @@ from vllm.model_executor.models.utils import maybe_prefix
 
 from .model import (
     DeepseekV4DecoderLayer,
+    DeepseekV4Model,
     make_deepseek_v4_expert_params_mapping,
 )
 
@@ -277,6 +278,11 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
         assert vllm_config.speculative_config is not None
         self.draft_model_config = vllm_config.speculative_config.draft_model_config
         self.config = self.draft_model_config.hf_config
+        self.quant_config = vllm_config.quant_config
+        self.pad_shared_expert = (
+            getattr(self.quant_config, "weight_block_size", None) is not None
+            and not vllm_config.parallel_config.use_sequence_parallel_moe
+        )
         self.model = DSparkDeepseekV4Model(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
@@ -396,6 +402,12 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
                     else ".weight_scale_inv"
                 )
                 name = name.removesuffix(".scale") + suffix
+            if ".shared_experts.w2" in name:
+                name = name.replace(".shared_experts.w2", ".shared_experts.down_proj")
+            if self.pad_shared_expert and ".shared_experts." in name:
+                loaded_weight = DeepseekV4Model._pad_shared_expert_weight(
+                    self.quant_config, name, loaded_weight
+                )
 
             # E8M0 expert scales: keep raw exponent bytes.
             if ".experts." in name:
@@ -440,10 +452,6 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
                     params_dict[name][: narrow.shape[0]].copy_(narrow)
                     loaded_params.add(name)
                     continue
-                if ".shared_experts.w2" in name:
-                    name = name.replace(
-                        ".shared_experts.w2", ".shared_experts.down_proj"
-                    )
                 if name.endswith(".ffn.gate.bias"):
                     name = name.replace(
                         ".ffn.gate.bias", ".ffn.gate.e_score_correction_bias"

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1181,7 +1181,9 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
 
         for name, loaded_weight in weights:
             if pad_shared_expert and ".shared_experts." in name:
-                loaded_weight = self._pad_shared_expert_weight(name, loaded_weight)
+                loaded_weight = self._pad_shared_expert_weight(
+                    self.quant_config, name, loaded_weight
+                )
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 # Skip non-stacked layers and experts (experts handled below).
                 if ".experts." in name:
@@ -1256,15 +1258,18 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
 
         return loaded_params
 
+    @staticmethod
     def _pad_shared_expert_weight(
-        self, name: str, loaded_weight: torch.Tensor
+        quant_config: QuantizationConfig | None,
+        name: str,
+        loaded_weight: torch.Tensor,
     ) -> torch.Tensor:
         """Zero-pad a block-FP8 shared-expert weight/scale on its intermediate
         axis so the standard TP loaders split it into even, block-aligned shards
         (trailing ranks get the zero pad). gate (w1)/up (w3) [I, H] pad dim 0;
         down (w2 -> down_proj) [H, I] pads dim 1.
         """
-        block_size = getattr(self.quant_config, "weight_block_size", None)
+        block_size = getattr(quant_config, "weight_block_size", None)
         assert block_size is not None
         # Round the intermediate axis up to a whole number of TP shards. The axis
         # is in elements for weights (step = block) and in blocks for scales.

--- a/vllm/models/deepseek_v4/nvidia/mtp.py
+++ b/vllm/models/deepseek_v4/nvidia/mtp.py
@@ -52,6 +52,7 @@ from vllm.sequence import IntermediateTensors
 
 from .model import (
     DeepseekV4DecoderLayer,
+    DeepseekV4Model,
     make_deepseek_v4_expert_params_mapping,
 )
 
@@ -265,6 +266,10 @@ class DeepSeekV4MTP(nn.Module):
         super().__init__()
         self.config = vllm_config.model_config.hf_config
         self.quant_config = vllm_config.quant_config
+        self.pad_shared_expert = (
+            getattr(self.quant_config, "weight_block_size", None) is not None
+            and not vllm_config.parallel_config.use_sequence_parallel_moe
+        )
         self.model = DeepSeekV4MultiTokenPredictor(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
@@ -387,6 +392,12 @@ class DeepSeekV4MTP(nn.Module):
                     else ".weight_scale_inv"
                 )
                 name = name.removesuffix(".scale") + suffix
+            if ".shared_experts.w2" in name:
+                name = name.replace(".shared_experts.w2", ".shared_experts.down_proj")
+            if self.pad_shared_expert and ".shared_experts." in name:
+                loaded_weight = DeepseekV4Model._pad_shared_expert_weight(
+                    self.quant_config, name, loaded_weight
+                )
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 # Skip non-stacked layers and experts (experts handled below).
                 if ".experts." in name:
@@ -442,10 +453,6 @@ class DeepSeekV4MTP(nn.Module):
                     loaded_params.add(name)
                     continue
                 else:
-                    if ".shared_experts.w2" in name:
-                        name = name.replace(
-                            ".shared_experts.w2", ".shared_experts.down_proj"
-                        )
                     if name.endswith(".ffn.gate.bias"):
                         # ``e_score_correction_bias`` lives on the gate
                         # under a different attribute name.


### PR DESCRIPTION

## Purpose

Add DeepSeek-V4-Pro DSpark shared-expert padding for built-in MTP loading when tensor parallelism requires block-aligned shared-expert padding to support sharding.  This is needed to serve DSV4-Pro with a 16x H100 sharded configuration using TP=16.

Use in conjunction with https://github.com/vllm-project/vllm/pull/49133 which provides the basic enablement for DSV4-NVFP4 with DSpark-MXFP4 draft enablement.

The target-model loader already pads block-quantized shared-expert weights before tensor-parallel sharding. The NVIDIA DSpark and MTP loaders omitted that step.

For DeepSeek-V4-Pro-DSpark at TP16, the shared-expert scale tensor has 24 blocks, while the tensor-parallel loader needs 32 blocks for equal two-block shards. Rank 14 consequently attempted to read from offset 28 in a 24-row tensor:

```text
IndexError: start out of range (expected to be in range of [-24, 24], but got 28)
```

This PR:

- Makes the existing `_pad_shared_expert_weight` helper reusable with the relevant quantization configuration.
- Calls it from the NVIDIA DSpark and built-in MTP loaders before tensor-parallel slicing.
- Normalizes `shared_experts.w2` to `shared_experts.down_proj` before padding so the correct tensor axis is selected.
- Preserves existing behavior when padding is unnecessary, including TP8.

This is independent of [PR #49133](https://github.com/vllm-project/vllm/pull/49133), which fixes target/draft quantization-context selection. The two changes touch disjoint files and can merge in either order.

## Test Plan

The serving test ran on two nodes with eight H100 GPUs per node: 16×H100 with flat TP16. The test used the official `nvidia/DeepSeek-V4-Pro-NVFP4` target, the official `deepseek-ai/DeepSeek-V4-Pro-DSpark` drafter, native CUDA graphs, this padding fix, and the independent quantization-context corrections from PR #49133.

Set the paths and rank-0 address on both nodes:

```bash
export MODEL=/path/to/DeepSeek-V4-Pro-NVFP4
export DSPARK_MODEL=/path/to/DeepSeek-V4-Pro-DSpark-MTP
export MASTER_ADDR=<rank-0-hostname-or-ip>
```

Run this command on the rank-0 H100 node:

```bash
VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER=0 \
vllm serve "$MODEL" \
  --served-model-name deepseek-ai/DeepSeek-V4-Pro \
  --tensor-parallel-size 16 \
  --nnodes 2 \
  --node-rank 0 \
  --master-addr "$MASTER_ADDR" \
  --master-port 29500 \
  --max-model-len 2200 \
  --max-num-seqs 256 \
  --kv-cache-dtype fp8 \
  --block-size 256 \
  --gpu-memory-utilization 0.87 \
  --speculative-config "{\"method\":\"dspark\",\"model\":\"$DSPARK_MODEL\",\"num_speculative_tokens\":5,\"draft_sample_method\":\"greedy\"}" \
  --api-server-count 1 \
  --host 0.0.0.0 \
  --port 8000
```

Run this command concurrently on the second H100 node:

```bash
VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER=0 \
vllm serve "$MODEL" \
  --served-model-name deepseek-ai/DeepSeek-V4-Pro \
  --tensor-parallel-size 16 \
  --nnodes 2 \
  --node-rank 1 \
  --master-addr "$MASTER_ADDR" \
  --master-port 29500 \
  --max-model-len 2200 \
  --max-num-seqs 256 \
  --kv-cache-dtype fp8 \
  --block-size 256 \
  --gpu-memory-utilization 0.87 \
  --speculative-config "{\"method\":\"dspark\",\"model\":\"$DSPARK_MODEL\",\"num_speculative_tokens\":5,\"draft_sample_method\":\"greedy\"}" \
  --headless
```

After the endpoint becomes ready, run the full five-shot GSM8K evaluation:

```bash
time OPENAI_API_KEY=EMPTY python -m lm_eval \
  --model local-chat-completions \
  --apply_chat_template \
  --include_path /tmp/dsv4pro-eval-tasks \
  --tasks gsm8k \
  --output_path /tmp/dsv4pro-gsm8k-dspark \
  --log_samples \
  --model_args "model=deepseek-ai/DeepSeek-V4-Pro,base_url=http://$MASTER_ADDR:8000/v1/chat/completions,api_key=EMPTY,eos_string=</s>,max_retries=5,num_concurrent=64,timeout=1800,tokenized_requests=False,max_length=2200" \
  --gen_kwargs 'max_tokens=512,temperature=0,top_p=1'
```

## Test Result

### Before

The unpatched TP16 launch failed while loading the DSpark shared-expert scale on rank 14:

```text
IndexError: start out of range (expected to be in range of [-24, 24], but got 28)
```

No server endpoint or accuracy result was possible.

### After

The padding check passed for both shared-expert projection axes:

```text
PASS: TP16 pads 3072->4096 elements and 24->32 scale blocks on both axes
```

The same check confirmed that TP8-aligned tensors remain unchanged.

The patched 16×H100 TP16 server loaded all 96 DSpark parameters on every rank, completed native CUDA graph initialization, returned coherent responses, and reported nonzero DSpark draft and accepted-token counters.

| Result | Value |
| --- | ---: |
| Completed | 1,319 / 1,319 |
| Request failures | 0 |
| Strict exact match | 0.9636088 ± 0.0051581 |
| Flexible exact match | 0.9636088 ± 0.0051581 |
| Draft-token acceptance rate | 71.26% |
| Mean acceptance length | 4.5628 |
| Evaluation wall time | 213.612 seconds |

The matching target-only TP16 evaluation completed in 403.920 seconds with strict exact match `0.9613343 ± 0.0053106`.

The live service validation used the same three-file correction backported to vLLM 0.25.1. This PR applies that correction to current `main`.

No documentation update is required because this corrects existing DeepSeek-V4 DSpark/MTP loader behavior without changing the serving interface.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [x] The necessary documentation update was considered; no user-facing documentation change is required.
</details>