### PR TITLE
[XPU] [CI] Fix model init test for MiniMaxM2ForCausalLM and NemotronParseForConditionalGeneration

### DIFF
--- a/.buildkite/intel_jobs/misc_intel.yaml
+++ b/.buildkite/intel_jobs/misc_intel.yaml
@@ -96,7 +96,9 @@ steps:
       bash .buildkite/scripts/hardware_ci/run-intel-test.sh
       'export VLLM_XPU_FUSED_MOE_USE_REF=1 &&
       cd tests &&
-      pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[Eagle3MiniMaxM2ForCausalLM]'
+      pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[Eagle3MiniMaxM2ForCausalLM] &&
+      pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[NemotronParseForConditionalGeneration] &&
+      pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[MiniMaxM2ForCausalLM]'
 
 - label: XPU CPU Offload
   timeout_in_minutes: 60


### PR DESCRIPTION
## Purpose

Add `MiniMaxM2ForCausalLM` and `NemotronParseForConditionalGeneration` to the XPU model-initialization CI coverage 

 
