### PR TITLE
[ROCm][Bugfix][Quark] Map weight/input quantizer scale names in AutoWeightsLoader

### DIFF
--- a/tests/model_executor/test_weight_utils.py
+++ b/tests/model_executor/test_weight_utils.py
@@ -281,5 +281,29 @@ class TestKvCacheScaleMapper:
         )
 
 
+class TestQuarkScaleMapper:
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            (
+                "model.layers.0.mlp.down_proj.weight_quantizer.scale",
+                "model.layers.0.mlp.down_proj.weight_scale",
+            ),
+            (
+                "model.layers.0.mlp.down_proj.input_quantizer.scale",
+                "model.layers.0.mlp.down_proj.input_scale",
+            ),
+            (
+                "model.layers.0.self_attn.k_scale",
+                "model.layers.0.self_attn.attn.k_scale",
+            ),
+        ],
+    )
+    def test_remap(self, name: str, expected: str):
+        from vllm.model_executor.layers.quantization.quark.quark import QuarkConfig
+
+        assert QuarkConfig.get_cache_scale_mapper()._map_name(name) == expected
+
+
 if __name__ == "__main__":
     test_download_weights_from_hf()

--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -691,6 +691,8 @@ class QuarkConfig(QuantizationConfig):
     def get_cache_scale_mapper() -> "WeightsMapper":
         """Map Quark KV-cache scale names to vLLM names."""
         orig_to_new_suffix = {
+            ".weight_quantizer.scale": ".weight_scale",
+            ".input_quantizer.scale": ".input_scale",
             ".k_proj.output_scale": ".attn.k_scale",
             ".v_proj.output_scale": ".attn.v_scale",
             ".q_proj.output_scale": ".attn.q_scale",

--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -689,7 +689,7 @@ class QuarkConfig(QuantizationConfig):
 
     @staticmethod
     def get_cache_scale_mapper() -> "WeightsMapper":
-        """Map Quark KV-cache scale names to vLLM names."""
+        """Map Quark checkpoint scale names to vLLM parameter names."""
         orig_to_new_suffix = {
             ".weight_quantizer.scale": ".weight_scale",
             ".input_quantizer.scale": ".input_scale",


### PR DESCRIPTION
## Purpose

Fix Quark MXFP4 checkpoint loading when exported per-tensor scales use `<layer>.weight_quantizer.scale` and `<layer>.input_quantizer.scale`, while vLLM registers the corresponding parameters as `weight_scale` and `input_scale`.

`QuarkConfig.get_cache_scale_mapper()` already participates in the complete `AutoWeightsLoader` stream, so the fix adds the two suffix mappings there without affecting non-Quark checkpoints or the existing KV-cache scale mappings.

Tested checkpoint: [`amd/Qwen3-VL-235B-A22B-Instruct-MXFP4`](https://huggingface.co/amd/Qwen3-VL-235B-A22B-Instruct-MXFP4).

## Why existing MXFP4 CI did not cover this

The existing Qwen3.5 MXFP4 CI checkpoint is Quark, but its global configuration uses dynamic per-group input quantization (`group_size=32`). It therefore does not serialize the static per-tensor weight/input quantizer scale names exercised by this Qwen3-VL W4A4 export.

The added regression test covers both exported suffixes and confirms that composition with the shared KV-scale mapper is preserved.

## Qwen3-VL integration stack

- **This PR — [vLLM #49420](https://github.com/vllm-project/vllm/pull/49420):** independent Quark model-loading fix used by the combined Qwen3-VL image.
- [vLLM #50212](https://github.com/vllm-project/vllm/pull/50212): opt-in fused Qwen3-VL attention prologue.
- [AITER #4531](https://github.com/ROCm/aiter/pull/4531): hard dependency of #50212; provides full strided MRoPE KV-cache support.
- [AITER #4554](https://github.com/ROCm/aiter/pull/4554): gfx950 Qwen3-VL MXFP4 tuning rows.
- [AITER #4556](https://github.com/ROCm/aiter/pull/4556): opt-in atomic FlyDSL stage-2 override measured with #4554's rows.

## Rebase provenance

- Frozen vLLM `main`: `96e333e81ad3203fc3980426daa136c213339b46`
- Current PR head: `c32246b916ac482a92ed07a9726b73f53fe7a630`

## Validation

- `pytest -q tests/model_executor/test_weight_utils.py::TestQuarkScaleMapper` — **3 passed**
- Ruff format/check on the changed files — **passed**
- Python compile check — **passed**
- vLLM DCO check — **passed**
- Prior MI355X end-to-end validation: the linked Qwen3-VL checkpoint loaded with populated scales and served coherent output after the mapping fix.

<details>
<summary>Essential PR checklist</summary>

- [x] Purpose and affected checkpoint documented.
- [x] Focused regression test added.
- [x] Test result provided.
- [x] No documentation update is required for this loader-only change.

</details>

> This PR was developed with AI assistance. The human author reviewed the changes, ran the listed validation, and owns the final implementation. Commit metadata contains only human attribution and DCO trailers.
