### PR TITLE
[Draft][Bugfix][Parser] Strip content whitespace at tool-call boundaries in streaming to match non-streaming

### DIFF
--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -570,6 +570,111 @@ class TestPostToolContentDeferral:
         assert not flush.tool_calls
 
 
+# ── TestStreamingContentBoundaryWhitespace ──────────────────────────
+
+
+class TestStreamingContentBoundaryWhitespace:
+    """Regression tests for ParserEngine._strip_boundary_content_ws.
+
+    Non-streaming (``extract_tool_calls``) strips whitespace from content
+    associated with tool calls via ``_strip_content_whitespace``;
+    streaming (``extract_tool_calls_streaming`` + ``finish_streaming``)
+    must match it exactly for the same model output, at any chunk size,
+    since a real client sees one token at a time.
+    """
+
+    @staticmethod
+    def _stream_content(engine, request, text, chunk):
+        parts = []
+        prev = ""
+        for i in range(0, len(text), chunk):
+            piece = text[i : i + chunk]
+            cur = prev + piece
+            delta = engine.extract_tool_calls_streaming(
+                previous_text=prev,
+                current_text=cur,
+                delta_text=piece,
+                previous_token_ids=[],
+                current_token_ids=[],
+                delta_token_ids=[],
+                request=request,
+            )
+            if delta is not None and delta.content:
+                parts.append(delta.content)
+            prev = cur
+        finish = engine.finish_streaming()
+        if finish is not None and finish.content:
+            parts.append(finish.content)
+        return "".join(parts) or None
+
+    @pytest.mark.parametrize("chunk", [1, 3, 1000])
+    def test_content_after_tool_call_strips_leading_space(self, mock_request, chunk):
+        text = '<tool_call>{"name": "f", "arguments": {}}</tool_call> done.'
+
+        streaming = _make_engine(_hermes_config())
+        streamed = self._stream_content(streaming, mock_request, text, chunk)
+
+        non_streamed = _make_engine(_hermes_config()).extract_tool_calls(
+            text, mock_request
+        )
+
+        assert non_streamed.content == "done."
+        assert streamed == non_streamed.content
+
+    @pytest.mark.parametrize("chunk", [1, 3, 1000])
+    def test_content_between_tool_calls_keeps_interior_whitespace(
+        self, mock_request, chunk
+    ):
+        call = '<tool_call>{"name": "f", "arguments": {}}</tool_call>'
+        text = call + " middle " + call
+
+        streaming = _make_engine(_hermes_config())
+        streamed = self._stream_content(streaming, mock_request, text, chunk)
+
+        non_streamed = _make_engine(_hermes_config()).extract_tool_calls(
+            text, mock_request
+        )
+
+        assert non_streamed.content == "middle"
+        assert streamed == non_streamed.content
+
+    @pytest.mark.parametrize("chunk", [1, 3, 1000])
+    def test_content_before_first_tool_call_strips_trailing_space(
+        self, mock_request, chunk
+    ):
+        # _hermes_config() has no reasoning terminals, so its initial state
+        # is CONTENT — this exercises leading content the same way a
+        # CONTENT-initial-state parser (e.g. gemma4) does.
+        text = 'Here you go: <tool_call>{"name": "f", "arguments": {}}</tool_call>'
+
+        streaming = _make_engine(_hermes_config())
+        streamed = self._stream_content(streaming, mock_request, text, chunk)
+
+        non_streamed = _make_engine(_hermes_config()).extract_tool_calls(
+            text, mock_request
+        )
+
+        assert non_streamed.content == "Here you go:"
+        assert streamed == non_streamed.content
+
+    @pytest.mark.parametrize("chunk", [1, 3, 1000])
+    def test_no_tool_calls_whitespace_left_unchanged(self, mock_request, chunk):
+        """Regression guard: without any tool call, boundary whitespace
+        must survive untouched in both paths — the strip only applies to
+        tool-associated content."""
+        text = "  hello world  "
+
+        streaming = _make_engine(_hermes_config())
+        streamed = self._stream_content(streaming, mock_request, text, chunk)
+
+        non_streamed = _make_engine(_hermes_config()).extract_tool_calls(
+            text, mock_request
+        )
+
+        assert non_streamed.content == text
+        assert streamed == non_streamed.content
+
+
 # ── TestFixArgTypes ──────────────────────────────────────────────────
 
 

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -123,6 +123,9 @@ class ParserEngine(Parser):
         self._deferred_reasoning: str = ""
         self._content_has_nonws: bool = False
         self._suppress_tool_calls: bool = False
+        self._content_ws_pending: str = ""
+        self._strip_leading_content: bool = False
+        self._any_tool_call_seen: bool = False
 
         self._arg_converter = parser_engine_config.arg_converter
         self._arg_structural_chars = parser_engine_config.arg_structural_chars
@@ -188,9 +191,10 @@ class ParserEngine(Parser):
 
     def finish_streaming(self) -> DeltaMessage | None:
         events = self._engine.finish()
+        delta = None
         if events or self._deferred_content:
-            return self._events_to_delta(events, finished=True)
-        return None
+            delta = self._events_to_delta(events, finished=True)
+        return self._strip_boundary_content_ws(delta, finished=True)
 
     def _reset(self, initial_state: ParserState | None = None) -> None:
         self._engine.reset(initial_state=initial_state)
@@ -200,6 +204,9 @@ class ParserEngine(Parser):
         self._deferred_reasoning = ""
         self._content_has_nonws = False
         self._prompt_streaming_prepared = False
+        self._content_ws_pending = ""
+        self._strip_leading_content = False
+        self._any_tool_call_seen = False
 
     def adjust_request(
         self, request: ChatCompletionRequest | ResponsesRequest
@@ -446,6 +453,7 @@ class ParserEngine(Parser):
             events.extend(self._engine.finish())
         result = self._events_to_delta(events, finished=finished)
         result = self._strip_trailing_reasoning(result)
+        result = self._strip_boundary_content_ws(result, finished=finished)
 
         # Suppress reasoning deltas if not requested
         if result and not request.include_reasoning:
@@ -483,6 +491,76 @@ class ParserEngine(Parser):
                 return None
         elif self._deferred_reasoning and self._reasoning_ended:
             self._deferred_reasoning = ""
+        return delta
+
+    def _strip_boundary_content_ws(
+        self,
+        delta: DeltaMessage | None,
+        finished: bool,
+    ) -> DeltaMessage | None:
+        """Trim content whitespace at tool-call boundaries during streaming.
+
+        The non-streaming path applies ``content.strip()`` to the aggregate
+        content when tool calls are present (see
+        :meth:`_strip_content_whitespace`), which reduces to trimming the
+        leading whitespace of the first content chunk and the trailing
+        whitespace of the last, with interior whitespace preserved. This
+        reproduces that incrementally: leading whitespace of content emitted
+        right after a tool call is dropped, and trailing whitespace is
+        withheld until either more content follows (released as interior
+        whitespace) or a tool call / end-of-stream drops it.
+
+        Gated by ``strip_content_whitespace_with_tools``; when disabled (e.g.
+        DeepSeek, Kimi K2), passes through unchanged.
+
+        Args:
+            delta: The assembled streaming delta, or ``None``.
+            finished: Whether this is the final delta of the stream.
+
+        Returns:
+            The delta with boundary content whitespace resolved, or ``None``.
+        """
+        if not self._strip_content_ws_with_tools:
+            return delta
+
+        tool_in_delta = delta is not None and bool(delta.tool_calls)
+
+        if delta is not None and delta.content:
+            text = self._content_ws_pending + delta.content
+            self._content_ws_pending = ""
+            if self._strip_leading_content:
+                text = text.lstrip()
+                if text:
+                    self._strip_leading_content = False
+            kept = text.rstrip()
+            self._content_ws_pending = text[len(kept) :]
+            delta.content = kept or None
+
+        if tool_in_delta:
+            self._any_tool_call_seen = True
+            self._content_ws_pending = ""
+            self._strip_leading_content = True
+
+        if finished:
+            if self._any_tool_call_seen:
+                self._content_ws_pending = ""
+            elif self._content_ws_pending:
+                flushed = self._content_ws_pending
+                self._content_ws_pending = ""
+                if delta is None:
+                    delta = DeltaMessage(content=flushed)
+                elif delta.content is None:
+                    delta.content = flushed
+                else:
+                    delta.content += flushed
+
+        if (
+            delta is not None
+            and delta.content is None
+            and not delta.tool_calls
+            and delta.reasoning is None
+        ):
+            return None
         return delta
 
     # ── Non-streaming: extract_reasoning ──────────────────────────────
@@ -588,7 +666,8 @@ class ParserEngine(Parser):
         self.initialize_streaming()
         self._check_skip_tool_parsing(request)
         events = self._feed(delta_text, delta_token_ids)
-        return self._strip_trailing_reasoning(self._events_to_delta(events))
+        result = self._strip_trailing_reasoning(self._events_to_delta(events))
+        return self._strip_boundary_content_ws(result, finished=False)
 
     # ── Reasoning state queries ───────────────────────────────────────
 


### PR DESCRIPTION
> Draft, addresses #49412. Opening for early feedback on the approach before finalizing. Open design questions are called out in "Open questions" below; happy to adjust based on maintainer preference.

## Summary

For engine-based parsers, streaming and non-streaming produce **different `content`** for the *same* model output when text sits next to a tool call.

The non-streaming path strips whitespace from tool-associated content (`_strip_content_whitespace` → `content.strip()`, gated by `strip_content_whitespace_with_tools`, default `True`). The streaming path had no equivalent step, so boundary whitespace that non-streaming drops leaks into streamed `delta.content`.

Because BPE tokenizers commonly fuse a leading space onto the following word (`" done"` is a single Qwen3 token — verified: `Qwen/Qwen3-8B` encodes `" done."` as `[' done', '.']`), this is hit by the very common "text then/around a tool call" pattern, not just a synthetic split.

Example (Qwen3, `enable_thinking=False`), identical model output `…</tool_call> done.`:

| path | content |
|---|---|
| non-streaming | `"done."` |
| streaming | `" done."` |

## Affected parsers

Shared engine logic, gated by the per-parser config flag `strip_content_whitespace_with_tools`:

- **Affected** (flag `True`, default): qwen3, nemotron_v3, seed_oss, glm47_moe, gemma4.
- **Not affected** (flag `False`): deepseek_v32, deepseek_v4, kimi_k2 — these do not strip in non-streaming either, so both paths already agree. The fix no-ops for them.

## Root cause

- Non-streaming: `_build_extracted_result` / `_single_pass_parse` call `_strip_content_whitespace(content, tools_called=True)` on the aggregate content. For the aggregate that reduces to: strip leading whitespace of the first content chunk and trailing whitespace of the last, interior whitespace preserved.
- Streaming: `extract_tool_calls_streaming` / `parse_delta` → `_events_to_delta` → `_strip_trailing_reasoning`. None of these strips `delta.content`. `_events_to_delta`'s own whitespace handling only drops content that is *entirely* whitespace *before* the first non-ws content; nothing handles boundary whitespace on non-empty content after/between/at the end of tool calls.

## Fix

Add `_strip_boundary_content_ws`, a streaming post-processor that mirrors the existing `_strip_trailing_reasoning` pattern (buffer-and-defer), applied in `parse_delta`, `extract_tool_calls_streaming`, and `finish_streaming`:

- Left-strips content emitted immediately after a tool call.
- Withholds trailing content whitespace until either more content follows (released as interior whitespace) or a tool call / end-of-stream drops it.
- At end-of-stream: drops the withheld whitespace if any tool call was seen (matching `.strip()` when `tools_called`); otherwise flushes it unchanged (no tools → non-streaming does not strip).
- Entirely gated on `strip_content_whitespace_with_tools`, so deepseek/kimi are untouched.

The shared `_events_to_delta` and the non-streaming code paths are not modified.

## Relationship to #47704 (not a duplicate)

#47704 ("DeepSeek V3.2/V4: drop whitespace content deltas around tool_calls") is adjacent but addresses a different case:

- #47704 drops **whitespace-only** `delta.content` (`"\n\n"`, `"\n"`) around tool calls to satisfy the OpenAI streaming contract, opt-in via a new `drop_whitespace_only_content_after_nonws` flag enabled for **DeepSeek** (which has `strip_content_whitespace_with_tools=False`). It does **not** strip boundary whitespace from **non-empty** content (`" done."` keeps its leading space under #47704, since `not content_str.strip()` is False there).
- This PR strips boundary whitespace from **non-empty** content for the parsers where non-streaming already strips (`strip_content_whitespace_with_tools=True`), for streaming/non-streaming parity.

The two are complementary (different parser scope, different content shape) and do not conflict in code: #47704 edits the `_events_to_delta` `_content_has_nonws` branch; this PR adds a separate post-processor and leaves that branch untouched. See "Open questions" for whether they should be unified.

## Tests added

`tests/parser/engine/test_parser_engine.py::TestStreamingContentBoundaryWhitespace` (4 tests × 3 chunk sizes = 12 cases), covering the four cases from the divergence: content immediately after a tool call, content between two parallel tool calls, content before the first tool call under a CONTENT-initial-state config (the gemma4 case), and a no-tool-call control proving boundary whitespace is left alone when the strip does not apply. Each test compares `extract_tool_calls_streaming`/`finish_streaming` against `extract_tool_calls` for identical input.

Confirmed these tests actually catch the bug: ran them against the parent commit's `parser_engine.py` (pre-fix) and 8/12 failed with the exact whitespace diffs described above; restored the fix and all 12 pass.

## Verification

Offline parser test suites (mock-tokenizer based), on this branch:

- `tests/parser/` — **3828 passed** (3816 pre-existing + 12 new).
- `tests/tool_parsers/test_glm47_moe_tool_parser.py` — 13 passed.
- `tests/tool_parsers/test_gemma4_tool_parser.py` — 54 passed.
- `pre-commit` (ruff check, ruff format, mypy-3.10, SPDX, etc.) — passed.

Custom streaming-vs-non-streaming content differ harness (feeds identical input token-by-token through both paths and diffs `content`), chunk sizes 1/2/1000:

- Before: 9 MISMATCH across qwen3 / nemotron_v3 / seed_oss / glm47 / gemma4.
- After: **0 MISMATCH**; deepseek_v32 / kimi_k2 remain OK (unchanged); no-tool content streams pass through unchanged (including trailing whitespace).

Not yet run (need a full CUDA/torch env + model weights): end-to-end server streaming eval and the Kimi/qwen3-coder tool-parser tests that download real tokenizers (`trust_remote_code`). Flagging so a maintainer / the human submitter can run these before merge.

## Open questions

- **Unify with #47704?** Both target "whitespace content around tool calls." Would maintainers prefer one mechanism (e.g. generalize this post-processor to also cover the whitespace-only DeepSeek case) rather than two flags/paths?
- **Leading whitespace before the *first* tool call.** The post-processor does not strip leading whitespace of content that appears before any tool call has been seen (we cannot know a tool is coming without buffering all content and hurting streaming latency). In practice models rarely start output with whitespace, and this case is not in the repro matrix, but it is a known gap vs. the non-streaming `.strip()`.
- **Placement.** Post-processor at the streaming entry points vs. folding the logic into `_events_to_delta` — the former keeps non-streaming untouched but adds a call at three sites.
