### PR TITLE
[XPU] WA of topk_softmax / topk_sigmoid / topk_softplus arg mismatch on XPU

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2391,6 +2391,17 @@ def topk_softmax(
     e_score_correction_bias: torch.Tensor | None = None,
     is_padding: torch.Tensor | None = None,
 ) -> None:
+    if current_platform.is_xpu():
+        # TODO: Remove after vllm-xpu-kernels supports is_padding.
+        torch.ops._moe_C.topk_softmax(
+            topk_weights,
+            topk_ids,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+            e_score_correction_bias,
+        )
+        return
     torch.ops._moe_C.topk_softmax(
         topk_weights,
         topk_ids,
@@ -2412,6 +2423,18 @@ def topk_sigmoid(
     routed_scaling_factor: float = 1.0,
     is_padding: torch.Tensor | None = None,
 ) -> None:
+    if current_platform.is_xpu():
+        # TODO: Remove after vllm-xpu-kernels supports is_padding.
+        torch.ops._moe_C.topk_sigmoid(
+            topk_weights,
+            topk_ids,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+            e_score_correction_bias,
+            routed_scaling_factor,
+        )
+        return
     torch.ops._moe_C.topk_sigmoid(
         topk_weights,
         topk_ids,
@@ -2449,8 +2472,7 @@ def topk_hash_softplus_sqrt(
             input_tokens,
             hash_indices_table,
         )
-
-    return
+        return
     torch.ops._moe_C.topk_softplus_sqrt(
         topk_weights,
         topk_indices,

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2436,6 +2436,21 @@ def topk_hash_softplus_sqrt(
     hash_indices_table: torch.Tensor | None = None,
     is_padding: torch.Tensor | None = None,
 ) -> None:
+    if current_platform.is_xpu():
+        # TODO: Remove after vllm-xpu-kernels supports is_padding.
+        torch.ops._moe_C.topk_softplus_sqrt(
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+            routed_scaling_factor,
+            e_score_correction_bias,
+            input_tokens,
+            hash_indices_table,
+        )
+
+    return
     torch.ops._moe_C.topk_softplus_sqrt(
         topk_weights,
         topk_indices,


### PR DESCRIPTION



## Purpose
https://github.com/vllm-project/vllm/pull/48979 added the is_padding argument to _moe_C.topk_softmax / _moe_C.topk_sigmoid / _moe_C.topk_softplus_sqrt, but the current XPU kernel does not yet support it.

This PR adds a workaround to fall back to old interface for XPU, This will be removed once xpu-kernels is updated.

