### PR TITLE
[Bugfix] Fix pipeline parallelism for Kimi-Linear

### DIFF
--- a/vllm/model_executor/models/kimi_linear.py
+++ b/vllm/model_executor/models/kimi_linear.py
@@ -54,6 +54,7 @@ from .utils import (
     PPMissingLayer,
     get_spec_layer_idx_from_weight_name,
     is_pp_missing_parameter,
+    make_empty_intermediate_tensors_factory,
     make_layers,
     maybe_prefix,
 )
@@ -420,6 +421,17 @@ class KimiLinearModel(nn.Module):
             "num_attention_heads must be divisible by world_size"
         )
 
+        # Register the factory used by GPUModelRunner to pre-allocate the
+        # buffers that carry intermediate tensors between pipeline stages.
+        # forward() emits {"hidden_states", "residual"} when not the last PP
+        # rank; without this the non-first PP rank hits an AssertionError in
+        # gpu_model_runner.sync_and_gather_intermediate_tensors.
+        self.make_empty_intermediate_tensors = (
+            make_empty_intermediate_tensors_factory(
+                ["hidden_states", "residual"], config.hidden_size
+            )
+        )
+
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
@@ -579,6 +591,12 @@ class KimiLinearForCausalLM(
         logit_scale = getattr(self.config, "logit_scale", 1.0)
         self.logits_processor = LogitsProcessor(
             self.config.vocab_size, scale=logit_scale
+        )
+        # gpu_model_runner calls self.model.make_empty_intermediate_tensors,
+        # so mirror the attribute from the inner KimiLinearModel here to
+        # match the SupportsPP protocol at both class levels.
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
         )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
### Motivation

  `KimiLinearForCausalLM` declares `SupportsPP` (which is a typing `Protocol`),
  but neither `KimiLinearModel` nor `KimiLinearForCausalLM` registers the
  `make_empty_intermediate_tensors` factory. Because `Protocol` method bodies
  are literally `...` (i.e. return `None`), the following happens on any
  non-first PP rank during `_dummy_run`:

  1. `gpu_model_runner._dummy_run` → `self.model.make_empty_intermediate_tensors(...)` returns `None`
  2. `self.intermediate_tensors` is set to `None`
  3. Next call `sync_and_gather_intermediate_tensors` → `assert self.intermediate_tensors is not None` → `AssertionError`

  Trace (reproduced on v0.25.1, still present on `main` at the time of this PR):

  File ".../vllm/v1/worker/gpu_model_runner.py", line ..., in sync_and_gather_intermediate_tensors
      assert self.intermediate_tensors is not None
  AssertionError

  ### Modifications

  - Import `make_empty_intermediate_tensors_factory` from `.utils`.
  - In `KimiLinearModel.__init__`, register the factory with the tensor names
    actually returned by `forward()` when `not is_last_rank`: `hidden_states`
    and `residual`.
  - Mirror the attribute on `KimiLinearForCausalLM` so `self.model.make_empty_intermediate_tensors(...)`
    works from either class level.

  Pattern mirrors `deepseek_v2.py` (`DeepseekV2Model.__init__` line ~1404 and
  `DeepseekV2ForCausalLM.__init__` line ~1848).

  ### Test

  - `Kimi-Linear-48B-A3B-Instruct`, TP=8 × PP=2 across 2×H100 nodes, `--distributed-executor-backend mp`
  - Before this patch: `AssertionError` in `Worker_PP1_TP*` during `_dummy_run`
  - After: model loads, KV cache allocated (13.8M tokens, 13.18x concurrency for 1M ctx per request), CUDA graphs capture, chat completions succeed. `system_fingerprint: vllm-0.25.1-tp8-pp2-...` confirms
  cross-stage handoff working.