### PR TITLE
[Bugfix] Fix Poolside reasoning token auto-initialization

### DIFF
--- a/tests/config/test_reasoning.py
+++ b/tests/config/test_reasoning.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import cast
+
+import pytest
+
+from vllm.config.model import ModelConfig
+from vllm.config.reasoning import ReasoningConfig
+
+
+class _Tokenizer:
+    _vocab = {"<think>": 18, "</think>": 19, "<assistant>": 23}
+
+    def get_vocab(self) -> dict[str, int]:
+        return self._vocab
+
+    def encode(self, text: str, add_special_tokens: bool) -> list[int]:
+        return [self._vocab[text]]
+
+
+def test_poolside_parser_defaults_to_thinking_for_token_id_initialization(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    tokenizer = _Tokenizer()
+    monkeypatch.setattr(
+        "vllm.config.reasoning.cached_tokenizer_from_config",
+        lambda model_config: tokenizer,
+    )
+    config = ReasoningConfig(reasoning_parser="poolside_v1")
+
+    config.initialize_token_ids(cast(ModelConfig, object()))
+
+    assert config.enabled
+    assert config.reasoning_start_token_ids == [18]
+    assert config.reasoning_end_token_ids == [19]

--- a/vllm/reasoning/poolside_v1_reasoning_parser.py
+++ b/vllm/reasoning/poolside_v1_reasoning_parser.py
@@ -26,11 +26,13 @@ from collections.abc import Sequence
 from transformers import PreTrainedTokenizerBase
 
 from vllm.reasoning.deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
-from vllm.reasoning.deepseek_v3_reasoning_parser import DeepSeekV3ReasoningParser
+from vllm.reasoning.deepseek_v3_reasoning_parser import (
+    DeepSeekV3ReasoningWithThinkingParser,
+)
 from vllm.reasoning.identity_reasoning_parser import IdentityReasoningParser
 
 
-class PoolsideV1ReasoningParser(DeepSeekV3ReasoningParser):
+class PoolsideV1ReasoningParser(DeepSeekV3ReasoningWithThinkingParser):
     """Drop-in replacement for ``deepseek_v3`` that tolerates ``</think>``
     tokens appearing anywhere in the prompt other than the generation prefix.
     """


### PR DESCRIPTION
## Purpose

Fixes #49379.

`ReasoningConfig.initialize_token_ids()` constructs the selected reasoning parser without frontend or request-level chat template kwargs. `PoolsideV1ReasoningParser` inherited `DeepSeekV3ReasoningParser`, which defaults to `IdentityReasoningParser` when neither `thinking` nor `enable_thinking` is provided. The identity parser exposes no reasoning delimiters, so Poolside reasoning token ID auto-initialization failed even though the Laguna chat template defaults `enable_thinking` to true.

This change makes the Poolside parser inherit the existing `DeepSeekV3ReasoningWithThinkingParser`. That class only supplies thinking defaults when both switches are absent, so an explicit `enable_thinking=false` still selects the identity parser.

A focused configuration-level regression test verifies that `poolside_v1` initializes the Laguna `<think>` and `</think>` token IDs.

## Why this is not a duplicate

I searched open PRs by issue number and by `poolside_v1 reasoning`. No open PR addresses #49379. #45874 adds general unit coverage for `PoolsideV1ReasoningParser`, but it does not change production behavior or exercise `ReasoningConfig` token ID auto-initialization.

## Test plan

- `VLLM_USE_PRECOMPILED=1 .venv/bin/python -m pytest tests/config/test_reasoning.py -v`: 1 passed.
- Commit hooks on the changed Python files passed, including ruff check/format, typos, mypy 3.10, SPDX, configuration validation, and sign-off validation.
- `pre-commit run mypy-3.12 --hook-stage manual --files vllm/reasoning/poolside_v1_reasoning_parser.py tests/config/test_reasoning.py`: passed.
- `actionlint` was skipped because no GitHub Actions workflow files are changed; its Go environment installation was also unavailable on the test host due to an IPv6 timeout reaching `proxy.golang.org`.

## Model-specific validation

Using the real `poolside/Laguna-S-2.1` tokenizer with remote code disabled:

- no chat kwargs: `DeepSeekR1ReasoningParser`
- `enable_thinking=false`: `IdentityReasoningParser`
- auto-initialized start token IDs: `[18]`
- auto-initialized end token IDs: `[19]`

No model weights were loaded because this fix only changes parser selection during configuration initialization.

## AI assistance

This change was developed with assistance from OpenAI Codex. I reviewed every changed line and the test results and take responsibility for the contribution.
