### PR TITLE
Fix speculative drafter access on non-final pipeline parallel ranks

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6131,12 +6131,13 @@ class GPUModelRunner(
                 ):
                     use_cudagraphs = False
 
-                self.drafter.dummy_run(
-                    num_tokens,
-                    use_cudagraphs=use_cudagraphs,
-                    is_graph_capturing=is_graph_capturing,
-                    slot_mappings=slot_mappings,
-                )
+                if get_pp_group().is_last_rank:
+                    self.drafter.dummy_run(
+                        num_tokens,
+                        use_cudagraphs=use_cudagraphs,
+                        is_graph_capturing=is_graph_capturing,
+                        slot_mappings=slot_mappings,
+                    )
 
         # We register layerwise NVTX hooks here after the first dynamo tracing is
         # done to avoid nvtx operations in hook functions being traced by
@@ -7074,9 +7075,13 @@ class GPUModelRunner(
         self.calculate_reorder_batch_threshold()
 
         # Initialize drafter attention backend
-        if self.speculative_config and (
-            self.speculative_config.use_eagle()
-            or self.speculative_config.uses_draft_model()
+        if (
+            self.speculative_config
+            and get_pp_group().is_last_rank
+            and (
+                self.speculative_config.use_eagle()
+                or self.speculative_config.uses_draft_model()
+            )
         ):
             assert isinstance(
                 self.drafter,
@@ -7128,10 +7133,14 @@ class GPUModelRunner(
         )
 
         # Initialize drafter's cudagraph dispatcher if using spec decode.
-        if self.speculative_config and (
-            self.speculative_config.use_eagle()
-            or self.speculative_config.uses_draft_model()
-            or self.speculative_config.uses_extract_hidden_states()
+        if (
+            self.speculative_config
+            and get_pp_group().is_last_rank
+            and (
+                self.speculative_config.use_eagle()
+                or self.speculative_config.uses_draft_model()
+                or self.speculative_config.uses_extract_hidden_states()
+            )
         ):
             assert isinstance(
                 self.drafter,
@@ -7587,6 +7596,7 @@ class GPUModelRunner(
 
         if (
             self.speculative_config
+            and get_pp_group().is_last_rank
             and self.speculative_config.uses_extract_hidden_states()
         ):
             assert isinstance(self.drafter, ExtractHiddenStatesProposer)


### PR DESCRIPTION
## Summary

This PR fixes speculative drafter access on non-final pipeline parallel ranks when using speculative decoding with Pipeline Parallelism (PP > 1).

`GPUModelRunner` creates `self.drafter` only on the last pipeline stage. However, several initialization and setup paths accessed `self.drafter` without verifying that the current worker is the last PP rank. As a result, non-final pipeline stages could attempt to access an object that was never created, leading to startup failures such as:

```text
RuntimeError: Worker failed with error:
'GPUModelRunner' object has no attribute 'drafter'
```

## Root Cause

The speculative drafter is intentionally instantiated only on the last pipeline stage:

```python
if self.speculative_config and get_pp_group().is_last_rank:
    self.drafter = ...
```

Several downstream code paths, however, only checked `self.speculative_config` before accessing `self.drafter`. This made the access condition inconsistent with the initialization condition, allowing non-final PP ranks to dereference an object that does not exist.

## Changes

This PR updates the speculative drafter access sites modified in this change to follow the same initialization contract by requiring:

```python
self.speculative_config and get_pp_group().is_last_rank
```

before accessing `self.drafter`.

The updated call sites are:

* `_dummy_run()`
* `initialize_metadata_builders()`
* `_check_and_update_cudagraph_mode()`
* `initialize_kv_cache()`

With these changes, speculative drafter initialization and usage are consistently restricted to the last pipeline stage.

## Scope

This PR addresses **Failure 1** reported in #49355.

The remaining issues described in the same report are independent and are intentionally handled in separate changes:

* **Failure 2:** Pipeline-parallel sampled-token broadcast uses an incorrect tensor for PP communication (**addressed in #49443**).
* **Failure 3:** CUDA device-side assert during logits indexing while running MTP speculative decoding with PP > 1 (**still under investigation**).

No changes are made to speculative scheduling, pipeline communication, hidden-state computation, or the speculative decoding algorithm itself.

## Testing

Verified locally that model initialization no longer attempts to access `self.drafter` on non-final pipeline stages, allowing startup to proceed past the previous `AttributeError`.

## Related Work

This is the first of two independent fixes for #49355.

* **#49442 (this PR):** Fix speculative drafter access on non-final pipeline parallel ranks (Failure 1).
* **#49443:** Fix PP sampled token broadcast for speculative decoding (Failure 2).

Together, these PRs address the first two failures reported in #49355. Failure 3 remains under investigation.

**Related Issue**

Related to #49355.
