### PR TITLE
Revert "[MRV2] Always build attn metadata at capture time" (#49364)

### DIFF
--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -498,7 +498,10 @@ class ModelCudaGraphManager(CudaGraphManager):
                 block_tables,
                 attn_groups,
                 kv_cache_config,
-                full_cudagraph=desc.cg_mode == CUDAGraphMode.FULL,
+                skip_attn=(
+                    desc.cg_mode == CUDAGraphMode.PIECEWISE
+                    and not self.use_breakable_cg
+                ),
             )
 
             # Capture with dummy rows marked as padding.
@@ -507,6 +510,7 @@ class ModelCudaGraphManager(CudaGraphManager):
             def forward_fn(cg_mode: CUDAGraphMode) -> None:
                 batch_descriptor = None
                 if cg_mode == CUDAGraphMode.PIECEWISE:
+                    assert (attn_metadata is not None) == self.use_breakable_cg
                     batch_descriptor = BatchDescriptor(
                         num_tokens=num_tokens,
                         has_lora=has_lora,
@@ -589,7 +593,7 @@ def prepare_inputs_to_capture(
     block_tables: BlockTables,
     attn_groups: list[list[AttentionGroup]],
     kv_cache_config: KVCacheConfig,
-    full_cudagraph: bool,
+    skip_attn: bool = False,
 ) -> AttentionState:
     input_batch = InputBatch.make_dummy(num_reqs, num_tokens, input_buffers)
     input_block_tables = block_tables.get_dummy_block_tables(num_reqs)
@@ -610,36 +614,15 @@ def prepare_inputs_to_capture(
         )
         input_batch.dcp_local_seq_lens = input_buffers.dcp_local_seq_lens[:num_reqs]
 
-    # NOTE(woosuk): Attention metadata is required not just by standard attention
-    # kernels, but also by specialized attention-like operations (e.g., Inkling's sconv,
-    # DSV4 compressor), which maintain their own states and require special metadata
-    # such as block tables.
-    # During CUDA graph capture:
-    # - For FULL CUDA graphs: We set for_capture=True so that both attention and
-    #   attention-like ops produce capturable metadata compatible with CUDA graphs.
-    # - For PIECEWISE CUDA graphs: We still build attention metadata, but set
-    #   for_capture=False. This is because:
-    #     * Attention-like ops (such as sconv or DSV4 compressor) may not be used as
-    #       breakpoints in PIECEWISE CUDA graphs, so we must generate their attention
-    #       metadata so they can execute and be captured during graph capture.
-    #     * Standard attention ops that are treated as breakpoints will be executed
-    #       eagerly at capture time (not included in the graph itself), and for these,
-    #       setting for_capture=False is essential. Some attention backends
-    #       (like linear attention) cannot generate capturable metadata for prefill,
-    #       so for_capture=False ensures they execute without issue.
-    #     * We assume that attention-like operations intended for capture will still
-    #       produce capturable metadata, even when for_capture=False. While this
-    #       assumption is brittle, it currently works in practice.
-    # In summary: We always generate attention metadata for both FULL and PIECEWISE
-    # CUDA graphs, setting for_capture=True for FULL graphs, and for_capture=False
-    # for PIECEWISE graphs, to ensure correct execution and capture.
-    attn_metadata = model_state.prepare_attn(
-        input_batch,
-        CUDAGraphMode.NONE,
-        input_block_tables,
-        slot_mappings,
-        attn_groups,
-        kv_cache_config,
-        for_capture=full_cudagraph,
-    )
+    attn_metadata = None
+    if not skip_attn:
+        attn_metadata = model_state.prepare_attn(
+            input_batch,
+            CUDAGraphMode.NONE,
+            input_block_tables,
+            slot_mappings,
+            attn_groups,
+            kv_cache_config,
+            for_capture=True,
+        )
     return AttentionState(attn_metadata, slot_mappings_by_layer)

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
@@ -56,7 +56,10 @@ class SpeculatorCudaGraphManager(CudaGraphManager):
                 block_tables,
                 attn_groups,
                 kv_cache_config,
-                full_cudagraph=desc.cg_mode == CUDAGraphMode.FULL,
+                skip_attn=(
+                    desc.cg_mode == CUDAGraphMode.PIECEWISE
+                    and not self.use_breakable_cg
+                ),
             )
 
             return lambda cg_mode: forward_fn(


### PR DESCRIPTION
## Auto-revert of #49364

This reverts the changes from **[MRV2] Always build attn metadata at capture time (#49364)**.

### Reason
Nightly CI build [#79322](https://buildkite.com/vllm/ci/builds/79322) failed on the **V1 Sample + Logits** job (1 job / 5 test cases): all of `tests/v1/sample/test_logprobs.py::test_logprobs_mode[*]` and `test_prompt_logprobs_mode` die with `RuntimeError: Engine core initialization failed`.

Root cause (from the job log): the EngineCore process crashes with a **GPU coredump** during CUDA graph capture:
```
Capturing CUDA graphs (PIECEWISE): 0% ... coredump: Starting GPU coredump generation
coredump: Detected an exception of type CUDBG_EXCEPTION_WARP_ILLEGAL_ADDRESS (14)
#0 ... _ZN7cutlass13device_kernelIN5flash20enable_sm90_or_later... FlashAttnFwdSm90 ...
```

PR #49364 removed the `skip_attn` guard so that attention metadata is now always built and FlashAttention runs eagerly during PIECEWISE cudagraph capture on the V2 Model Runner. The illegal-address crash occurs exactly at that capture step in the FlashAttention Sm90 (Hopper/H200) kernel — a direct regression from this change. It is the only PR in the build's commit range that touches the V2 Model Runner cudagraph attention-capture code path.

- Failure count linked to this PR: **1 job** (5 test cases)
- Build: #79322 (commit 387189c)

_Auto-generated by CI failure analyzer._