### PR TITLE
[Bugfix][CI] Fix `topk_softplus_sqrt` no-op on non-XPU platforms

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2460,8 +2460,8 @@ def topk_hash_softplus_sqrt(
             input_tokens,
             hash_indices_table,
         )
+        return
 
-    return
     torch.ops._moe_C.topk_softplus_sqrt(
         topk_weights,
         topk_indices,


### PR DESCRIPTION
## Purpose

Fixes a regression that made the fused `topk_softplus_sqrt` kernel a no-op on
all non-XPU platforms (ROCm and CUDA).

The XPU workaround in #49408 placed a `return` at function-body scope inside
`topk_hash_softplus_sqrt` (`vllm/_custom_ops.py`). As a result, the real
`is_padding`-aware call to `torch.ops._moe_C.topk_softplus_sqrt(...)` became
dead code and was never reached on non-XPU platforms. The output tensors were
left uninitialized (effectively zeros), so every `topk_softplus_sqrt` test
failed on AMD GPUs.

The fix moves the `return` inside the `if current_platform.is_xpu()` branch so
non-XPU platforms reach the actual kernel launch. This is a one-line,
platform-independent Python control-flow fix, so it restores the
**Kernels MoE Test** group on both **MI300 (gfx942)** and **MI355 (gfx950)**.

## Test Plan

```bash
pytest -q tests/kernels/moe/test_topk_softplus_sqrt.py
```

Run inside the ROCm dev container on MI300 (gfx942), after rebuilding the
extensions (`python3 setup.py build_ext --inplace`). The same test is the one
that fails in the AMD ROCm CI `kernels-moe-test-1` group on both MI300 and
MI355.

## Test Result

Before the fix: all `topk_softplus_sqrt` cases fail (kernel never invoked,
outputs all zero).

After the fix, on MI300 (gfx942):

```
1657 passed, 3 skipped, 16 warnings in 312.55s (0:05:12)
```

This restores the **Kernels MoE Test** group for **MI300 (gfx942)** and
**MI355 (gfx950)** — the bug is architecture-independent (pure Python control
flow), so the single fix covers both.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

