### PR TITLE
[Bugfix][Frontend] Report cache usage on Anthropic message_start

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -1172,28 +1172,20 @@ class TestMessageStartIncludesTypeAndRole:
 
 
 class TestStreamingCacheUsageSemantics:
-    """Locks in the documented streaming behavior of cache usage fields.
-
-    vLLM's OpenAI chat completion streaming only attaches
-    ``prompt_tokens_details`` to the terminal usage chunk. The Anthropic layer
-    mirrors that contract: cache fields are omitted on ``message_start`` (key
-    absence signals "unknown") and populated on ``message_delta`` (the final
-    cumulative count). This is intentionally consistent with vLLM's OpenAI
-    behavior, even though Anthropic's upstream API populates cache fields on
-    ``message_start``; closing that gap requires plumbing cache info into the
-    first chunk at the OpenAI layer, which is out of scope here.
-    """
+    """Locks in cache usage fields on Anthropic streaming events."""
 
     @pytest.mark.asyncio
-    async def test_streaming_cache_fields_absent_then_populated(self):
-        """First chunk lacks prompt_tokens_details (vLLM contract);
-        message_start omits cache fields. The final chunk carries
-        prompt_tokens_details, so message_delta carries resolved values."""
-
+    async def test_streaming_cache_fields_populated(self):
         async def sse_input():
             yield _make_stream_chunk(
                 delta=DeltaMessage(role="assistant", content="hi"),
-                usage=UsageInfo(prompt_tokens=100, total_tokens=100),
+                usage=UsageInfo(
+                    prompt_tokens=100,
+                    total_tokens=100,
+                    prompt_tokens_details=PromptTokenUsageInfo(
+                        cached_tokens=80, created_cache_tokens=10
+                    ),
+                ),
             )
             yield _make_stream_chunk(finish_reason="stop")
             yield _make_stream_chunk(
@@ -1215,14 +1207,12 @@ class TestStreamingCacheUsageSemantics:
             output.append(event)
         events = _parse_sse_events(output)
 
-        # message_start: cache fields unknown → omitted from JSON entirely.
         start_usage = events[0][1]["message"]["usage"]
         assert events[0][0] == "message_start"
-        assert start_usage["input_tokens"] == 100
-        assert "cache_read_input_tokens" not in start_usage
-        assert "cache_creation_input_tokens" not in start_usage
+        assert start_usage["input_tokens"] == 10
+        assert start_usage["cache_read_input_tokens"] == 80
+        assert start_usage["cache_creation_input_tokens"] == 10
 
-        # message_delta: authoritative usage with cache fields populated.
         delta_usage = next(
             data["usage"] for ev, data in events if ev == "message_delta"
         )
@@ -1232,13 +1222,16 @@ class TestStreamingCacheUsageSemantics:
 
     @pytest.mark.asyncio
     async def test_streaming_no_cache_hit(self):
-        """When the final chunk reports cached_tokens=0, message_delta carries
-        cache fields = 0 (cache miss); message_start still omits them."""
-
         async def sse_input():
             yield _make_stream_chunk(
                 delta=DeltaMessage(role="assistant"),
-                usage=UsageInfo(prompt_tokens=50, total_tokens=50),
+                usage=UsageInfo(
+                    prompt_tokens=50,
+                    total_tokens=50,
+                    prompt_tokens_details=PromptTokenUsageInfo(
+                        cached_tokens=0, created_cache_tokens=0
+                    ),
+                ),
             )
             yield _make_stream_chunk(finish_reason="stop")
             yield _make_stream_chunk(
@@ -1265,8 +1258,8 @@ class TestStreamingCacheUsageSemantics:
             data["usage"] for ev, data in events if ev == "message_delta"
         )
         assert start_usage["input_tokens"] == 50
-        assert "cache_read_input_tokens" not in start_usage
-        assert "cache_creation_input_tokens" not in start_usage
+        assert start_usage["cache_read_input_tokens"] == 0
+        assert start_usage["cache_creation_input_tokens"] == 0
         assert delta_usage["input_tokens"] == 50  # 50 - 0 - 0
         assert delta_usage["cache_read_input_tokens"] == 0
         assert delta_usage["cache_creation_input_tokens"] == 0

--- a/tests/entrypoints/anthropic/test_messages.py
+++ b/tests/entrypoints/anthropic/test_messages.py
@@ -197,29 +197,25 @@ async def test_anthropic_structured_output(client: anthropic.AsyncAnthropic):
 @pytest.mark.asyncio
 async def test_anthropic_streaming_cache_usage(client: anthropic.AsyncAnthropic):
     async def get_stream_usage(resp):
-        prompt_tokens = None
-        usage = None
+        initial_usage = None
         async for chunk in resp:
             if (
                 chunk.type == "message_start"
                 and chunk.message is not None
                 and chunk.message.usage is not None
             ):
-                prompt_tokens = chunk.message.usage.input_tokens
-            elif chunk.type == "message_delta" and chunk.usage is not None:
-                usage = chunk.usage
+                initial_usage = chunk.message.usage
 
-        assert usage is not None
-        assert usage.input_tokens >= 0
-        assert usage.output_tokens >= 0
-        cache_created = usage.cache_creation_input_tokens
-        cache_read = usage.cache_read_input_tokens
+        assert initial_usage is not None
+        assert initial_usage.input_tokens >= 0
+        assert initial_usage.output_tokens >= 0
+        cache_created = initial_usage.cache_creation_input_tokens
+        cache_read = initial_usage.cache_read_input_tokens
         assert cache_read is not None
         assert cache_created is not None
         assert cache_created >= 0
         assert cache_read >= 0
-        assert prompt_tokens == usage.input_tokens + cache_created + cache_read
-        return usage
+        return initial_usage
 
     request = dict(
         model="claude-3-7-sonnet-latest",

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -639,6 +639,8 @@ def _build_minimal_metrics_serving_chat(
 def _make_metrics_request_output(
     metrics: RequestStateStats | None = _PER_REQUEST_STATS,
     token_ids: tuple[int, ...] = (100, 101),
+    num_cached_tokens: int | None = None,
+    num_cache_creation_tokens: int | None = None,
 ) -> RequestOutput:
     return RequestOutput(
         request_id="test-id",
@@ -657,6 +659,8 @@ def _make_metrics_request_output(
         ],
         finished=True,
         metrics=metrics,
+        num_cached_tokens=num_cached_tokens,
+        num_cache_creation_tokens=num_cache_creation_tokens,
     )
 
 
@@ -669,11 +673,12 @@ async def _single_request_output(
 async def _collect_metrics_stream_chunks(
     serving: OpenAIServingChat,
     request: ChatCompletionRequest,
+    request_output: RequestOutput | None = None,
 ) -> list[dict[str, Any]]:
     chunks: list[dict[str, Any]] = []
     async for line in serving.chat_completion_stream_generator(
         request,
-        _single_request_output(_make_metrics_request_output()),
+        _single_request_output(request_output or _make_metrics_request_output()),
         "chatcmpl-test-id",
         "test-model",
         conversation=[{"role": "user", "content": "Test"}],
@@ -779,6 +784,34 @@ async def test_chat_streaming_metrics_ride_on_usage_chunk():
     usage_chunks = [chunk for chunk in chunks if chunk.get("usage")]
     assert usage_chunks
     assert usage_chunks[-1]["metrics"]["time_to_first_token_ms"] == pytest.approx(500.0)
+
+
+@pytest.mark.asyncio
+async def test_chat_streaming_initial_usage_includes_prompt_cache_details():
+    serving = _build_minimal_metrics_serving_chat(enable_per_request_metrics=False)
+    serving.enable_prompt_tokens_details = True
+    chunks = await _collect_metrics_stream_chunks(
+        serving,
+        ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Test prompt"}],
+            max_tokens=10,
+            stream=True,
+            stream_options={
+                "include_usage": True,
+                "continuous_usage_stats": True,
+            },
+        ),
+        _make_metrics_request_output(
+            num_cached_tokens=2,
+            num_cache_creation_tokens=1,
+        ),
+    )
+
+    initial_usage = chunks[0]["usage"]
+    details = initial_usage["prompt_tokens_details"]
+    assert details["cached_tokens"] == 2
+    assert details["created_cache_tokens"] == 1
 
 
 @dataclass

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -524,11 +524,22 @@ class OpenAIServingChat(GenerateBaseServing):
 
                         # if continuous usage stats are requested, add it
                         if include_continuous_usage:
-                            chunk.usage = UsageInfo(
+                            initial_usage = UsageInfo(
                                 prompt_tokens=num_prompt_tokens,
                                 completion_tokens=0,
                                 total_tokens=num_prompt_tokens,
                             )
+                            prompt_tokens_details = _make_prompt_tokens_details(
+                                self.enable_prompt_tokens_details,
+                                num_cached_tokens,
+                                num_cache_creation_tokens,
+                                mm_token_counts,
+                            )
+                            if prompt_tokens_details is not None:
+                                initial_usage.prompt_tokens_details = (
+                                    prompt_tokens_details
+                                )
+                            chunk.usage = initial_usage
 
                         data = chunk.model_dump_json(exclude_unset=True)
                         yield f"data: {data}\n\n"


### PR DESCRIPTION
## Summary

- attach prompt cache details to the initial continuous-usage chat stream chunk
- expose cache read and creation tokens on Anthropic `message_start` events
- update unit and Anthropic SDK integration coverage for cold and warm requests

Claude Code reads streaming input/cache usage from `message_start`. vLLM previously
reported these counters only on the terminal `message_delta`, even though the
engine makes them available before the first chunk is emitted.

## Duplicate work

I searched open issues and PRs for Anthropic `message_start` cache usage, Claude
Code cache metrics, and initial streaming `prompt_tokens_details`. No open change
addresses this gap. This is a focused follow-up to #40912 and #48535. The open
Rust frontend RFC #47753 does not duplicate this Python frontend fix.

## Tests

```text
.venv/bin/python -m pytest \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_chat_streaming_metrics_ride_on_usage_chunk \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_chat_streaming_initial_usage_includes_prompt_cache_details \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_mm_prompt_tokens_details -q
3 passed

.venv/bin/python -m pytest \
  tests/entrypoints/anthropic/test_anthropic_messages_conversion.py -q
47 passed

.venv/bin/python -m pytest \
  tests/entrypoints/anthropic/test_messages.py::test_anthropic_streaming_cache_usage \
  --collect-only -q
1 test collected

pre-commit run --files \
  vllm/entrypoints/openai/chat_completion/serving.py \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py \
  tests/entrypoints/anthropic/test_anthropic_messages_conversion.py \
  tests/entrypoints/anthropic/test_messages.py
Passed
```

The GPU-backed Anthropic integration test was collected but not executed locally.
Model evaluation is not applicable because this only changes usage metadata.

AI assistance was used to investigate, implement, and test this change. Every
changed line was reviewed by the human submitter.
