### PR TITLE
[TurboQuant][TritonCPU] Enable triton-cpu path for Turbo-quant algorithm

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1928,7 +1928,13 @@ class EngineArgs:
                 TurboQuantConfig,
             )
 
-            boundary = TurboQuantConfig.get_boundary_skip_layers(model_config)
+            # Number of first/last layers to leave uncompressed (default 2).
+            # VLLM_TURBOQUANT_BOUNDARY_LAYERS=0 compresses ALL layers.
+            # (envs is already imported at module scope; do NOT re-import
+            # locally or it shadows the global for the whole function.)
+            boundary = TurboQuantConfig.get_boundary_skip_layers(
+                model_config, n=envs.VLLM_TURBOQUANT_BOUNDARY_LAYERS
+            )
             existing = set(cache_config.kv_cache_dtype_skip_layers)
             cache_config.kv_cache_dtype_skip_layers = sorted(
                 existing | set(boundary), key=int

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -55,6 +55,8 @@ if TYPE_CHECKING:
     VLLM_CPU_ATTN_SPLIT_KV: bool = True
     VLLM_ZENTORCH_WEIGHT_PREPACK: bool = True
     VLLM_CPU_INT4_W4A8: bool = True
+    VLLM_CPU_TURBOQUANT_BACKEND: str = ""
+    VLLM_TURBOQUANT_BOUNDARY_LAYERS: int = 2
     VLLM_XLA_CACHE_PATH: str = os.path.join(VLLM_CACHE_ROOT, "xla_cache")
     VLLM_XLA_CHECK_RECOMPILATION: bool = False
     VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: int = 512
@@ -876,6 +878,20 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # (CPU backend only) whether to use SGLang INT4 W4A8 kernels for AWQ.
     "VLLM_CPU_INT4_W4A8": lambda: bool(int(os.getenv("VLLM_CPU_INT4_W4A8", "1"))),
+    # (CPU backend only, experiment) selects the TurboQuant KV-cache backend for
+    # ``turboquant_*`` cache dtypes on CPU. "triton" routes to the GPU Triton
+    # backend (compiled for CPU via triton-cpu); "" (default) leaves CPU backend
+    # selection unchanged (plain CPU_ATTN / native routing).
+    "VLLM_CPU_TURBOQUANT_BACKEND": lambda: os.getenv(
+        "VLLM_CPU_TURBOQUANT_BACKEND", ""
+    ).lower(),
+    # (experiment) number of first/last attention layers TurboQuant leaves
+    # UNcompressed (boundary protection). Default 2. Set 0 to compress ALL
+    # layers (confirmation / ablation only — hurts accuracy on aggressive
+    # presets).
+    "VLLM_TURBOQUANT_BOUNDARY_LAYERS": lambda: int(
+        os.getenv("VLLM_TURBOQUANT_BOUNDARY_LAYERS", "2")
+    ),
     # If the env var is set, Ray Compiled Graph uses the specified
     # channel type to communicate between workers belonging to
     # different pipeline-parallel stages.

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -78,6 +78,27 @@ class CpuPlatform(Platform):
         attn_selector_config: "AttentionSelectorConfig",
         num_heads: int | None = None,
     ) -> str:
+        # EXPERIMENT: route TurboQuant KV-cache dtypes to the GPU Triton
+        # backend (compiled for CPU via triton-cpu) when explicitly requested
+        # via VLLM_CPU_TURBOQUANT_BACKEND=triton. The plain CPU_ATTN backend
+        # cannot handle the packed uint8 turboquant slot layout, so without
+        # this the cache reshape fails. Gated so default CPU behavior is
+        # unchanged.
+        from vllm import envs
+
+        kv_cache_dtype = attn_selector_config.kv_cache_dtype
+        if (
+            envs.VLLM_CPU_TURBOQUANT_BACKEND == "triton"
+            and kv_cache_dtype is not None
+            and kv_cache_dtype.startswith("turboquant")
+        ):
+            logger.info(
+                "Routing TurboQuant KV cache (%s) to the Triton backend on CPU "
+                "(VLLM_CPU_TURBOQUANT_BACKEND=triton).",
+                kv_cache_dtype,
+            )
+            return AttentionBackendEnum.TURBOQUANT.get_path()
+
         if selected_backend and selected_backend != AttentionBackendEnum.CPU_ATTN:
             logger.info("Cannot use %s backend on CPU.", selected_backend)
         if attn_selector_config.use_mla:

--- a/vllm/v1/attention/backends/turboquant_attn.py
+++ b/vllm/v1/attention/backends/turboquant_attn.py
@@ -159,6 +159,19 @@ class TurboQuantAttentionBackend(AttentionBackend):
             TurboQuantConfig,
         )
 
+        # When the caller passes a non-TQ dtype (e.g. "auto"), recover the real
+        # preset from the global config's cache dtype. Without this the
+        # from_cache_dtype lookup below raises on "auto" during CPU init.
+        if not (cache_dtype_str and cache_dtype_str.startswith("turboquant")):
+            from vllm.config import get_current_vllm_config
+
+            cfg = get_current_vllm_config()
+            recovered = cfg.cache_config.cache_dtype if cfg is not None else None
+            if recovered and str(recovered).startswith("turboquant"):
+                cache_dtype_str = str(recovered)
+            else:
+                cache_dtype_str = "turboquant_4bit_nc"
+
         tq_config = TurboQuantConfig.from_cache_dtype(cache_dtype_str, head_size)
         return (num_blocks, num_kv_heads, block_size, tq_config.slot_size_aligned)
 
@@ -786,13 +799,19 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
         # Reuse cached buffers to avoid per-call allocation (~16MB at 8K).
         alloc_len = math.ceil(cached_len / block_size) * block_size
         buf_shape = (1, Hk, alloc_len, D)
-        # Use WorkspaceManager for dequant buffers.
-        # Shared across all layers — saves 60× memory at long context.
-        # Required for CUDA Graph capture (per-layer growth incompatible with CG).
-        k_buf, v_buf = current_workspace_manager().get_simultaneous(
-            (buf_shape, torch.float16),
-            (buf_shape, torch.float16),
-        )
+        # Use WorkspaceManager for dequant buffers when it's initialized
+        # (GPU path): shared across all layers — saves 60× memory at long
+        # context and is required for CUDA Graph capture. On CPU (e.g. the
+        # triton-cpu path) the workspace manager is never initialized, so
+        # allocate the dequant buffers directly instead of asserting.
+        if is_workspace_manager_initialized():
+            k_buf, v_buf = current_workspace_manager().get_simultaneous(
+                (buf_shape, torch.float16),
+                (buf_shape, torch.float16),
+            )
+        else:
+            k_buf = torch.empty(buf_shape, dtype=torch.float16, device=device)
+            v_buf = torch.empty(buf_shape, dtype=torch.float16, device=device)
         # Skip .zero_() — kernel writes all positions up to cached_len,
         # and we only read [:cached_len] afterwards.
         k_cached = k_buf[:, :, :alloc_len, :]


### PR DESCRIPTION


## Purpose
Enable the TurboQuant KV-cache path to run on CPU by routing `turboquant_*` cache dtypes to the GPU Triton attention backend (compiled for CPU via `triton-cpu`).
The plain `CPU_ATTN` backend cannot handle the packed uint8 TurboQuant slot layout, so without this the cache reshape fails during CPU init. The change is fully gated behind a new environment variable so default CPU behavior is unchanged.

Key changes:
- Add `VLLM_CPU_TURBOQUANT_BACKEND` env var. Setting it to `triton` routes `turboquant_*` KV-cache dtypes to the Triton backend on CPU; the default(`""`) leaves CPU backend selection unchanged.
- Add `VLLM_TURBOQUANT_BOUNDARY_LAYERS` env var (default `2`) to control how many first/last attention layers TurboQuant leaves uncompressed. Set `0` to compress all layers (ablation only).
- `CpuPlatform.get_attn_backend_cls` now returns the TurboQuant backend when the above env var is set and the cache dtype is a `turboquant*` preset.
- `TurboQuantAttentionBackend` recovers the real TurboQuant preset from the global config when the caller passes a non-TQ dtype (e.g. `"auto"`), preventing a `from_cache_dtype` failure during CPU init.
- `TurboQuantAttentionImpl` allocates dequant buffers directly on CPU when the `WorkspaceManager` is not initialized (the GPU path still uses the shared workspace buffers required for CUDA Graph capture).

# Environment
Package versions used for this work (Python 3.12 via conda env):
| Package | Version                               |
| ------- | ------------------------------------- |
| torch   | 2.11.0+cpu                            |
| vllm    | 0.1.dev18943+g8688a06d6.d20260721.cpu |
| triton  | 3.8.0+git6ca45149                     |

## Test Plan
Verify the implementation with the gsm8k dataset, comparing accuracy across configurations to confirm that routing TurboQuant KV cache to the Triton backend on CPU works correctly and that boundary-layer protection behaves as expected. KV cache was set to 12 GB by setting the env variable: `export VLLM_CPU_KVCACHE_SPACE=12`

# Environment variables
TurboQuant / Triton-CPU specific variables:
```bash
# Compile Triton kernels for CPU (triton-cpu backend).
export TRITON_CPU_BACKEND=1
# Route turboquant_* KV-cache dtypes to the GPU Triton backend on CPU.
export VLLM_CPU_TURBOQUANT_BACKEND=triton
# Number of first/last attention layers left uncompressed (boundary
# protection). Keep consistent across ALL variants for a fair comparison.
# Default 2 (production); set 0 to compress ALL layers.
export VLLM_TURBOQUANT_BOUNDARY_LAYERS="${VLLM_TURBOQUANT_BOUNDARY_LAYERS:-2}"
# Triton autotuning.
export TRITON_CACHE_AUTOTUNING=1
export TRITON_PRINT_AUTOTUNING=1
```

# Command
```bash
lm_eval --model vllm \
  --model_args pretrained=meta-llama/Llama-3.1-8B-Instruct,dtype=bfloat16,max_model_len=2048,block_size=32,kv_cache_dtype=turboquant_4bit_nc \
  --tasks gsm8k --batch_size auto --trust_remote_code --num_fewshot 5 \
  --gen_kwargs "max_gen_toks=512" --apply_chat_template --log_samples \
  --output_path ./results \
  2>&1 | tee llama-3.1-turboquant-tritoncpu.log
```
All four variants use this same command, varying only `pretrained`
(`meta-llama/Llama-3.1-8B-Instruct` vs `RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8`)
and `kv_cache_dtype` (`auto` for baseline vs `turboquant_4bit_nc` for TurboQuant).

## Test Result
# meta-llama/Llama-3.1-8B-Instruct BF16
| Configuration     | KV cache dtype     | Backend  | Boundary layers | gsm8k (exact match) |
| ----------------- | ------------------ | -------- | --------------- | ------------------- |
| Baseline          | auto               | CPU_ATTN |                 | flexible-extract exact_match 0.8446 ± 0.0100 |
|                   |                    |          |                 | strict-match exact_match 0.8180 ± 0.0106 |
| TurboQuant on CPU | turboquant_4bit_nc | triton   | 2               | flexible-extract exact_match 0.8302 ± 0.0103 |
|                   |                    |          |                 | strict-match exact_match 0.7961 ± 0.0111 |

# RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8
| Configuration     | KV cache dtype     | Backend  | Boundary layers | gsm8k (exact match) |
| ----------------- | ------------------ | -------- | --------------- | ------------------- |
| Baseline          | auto               | CPU_ATTN |                 | flexible-extract exact_match 0.8332 ± 0.0103 |
|                   |                    |          |                 | strict-match exact_match 0.8150 ± 0.0107 |
| TurboQuant on CPU | turboquant_4bit_nc | triton   | 2               | flexible-extract exact_match 0.8264 ± 0.0104 |
|                   |                    |          |                 | strict-match exact_match 0.8029 ± 0.0110 |

# Concurrency (12 GiB KV cache pool, max_model_len=2048)

| Variant         | Model                 | KV cache dtype     | Backend  | KV cache size (tokens) | Max concurrency |
| --------------- | --------------------- | ------------------ | -------- | ---------------------- | --------------- |
| BF16 Baseline   | Llama-3.1-8B-Instruct | auto               | CPU_ATTN | 98,304                 | 48.00x          |
| BF16 TurboQuant | Llama-3.1-8B-Instruct | turboquant_4bit_nc | triton   | 277,664                | 135.58x         |
| w8a8 Baseline   | ...quantized.w8a8     | auto               | CPU_ATTN | 98,304                 | 48.00x          |
| w8a8 TurboQuant | ...quantized.w8a8     | turboquant_4bit_nc | triton   | 277,664                | 135.58x         |

TurboQuant increases KV-cache token capacity 98,304 -> 277,664 (2.82x) at the same
12 GiB pool, yielding a 2.82x concurrency boost. Capacity is identical across BF16 and
w8a8 because w8a8 quantizes weights, not the KV cache.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

