### PR TITLE
[Rust Frontend][gRPC] Separate inference and control services

### DIFF
--- a/rust/proto/control.proto
+++ b/rust/proto/control.proto
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+syntax = "proto3";
+package vllm;
+
+service Control {
+  rpc Abort (AbortRequest) returns (AbortResponse) {}
+}
+
+message AbortRequest {
+  repeated string request_ids = 1;
+}
+
+message AbortResponse {}

--- a/rust/proto/inference.proto
+++ b/rust/proto/inference.proto
@@ -14,10 +14,6 @@ service Inference {
   rpc GenerateStream (GenerateRequest) returns (stream GenerateResponse) {}
 }
 
-service Control {
-  rpc Abort (AbortRequest) returns (AbortResponse) {}
-}
-
 // ======================================================================================
 // Generate Request
 // ======================================================================================
@@ -204,13 +200,3 @@ message CandidateTokenInfo {
 message TokenIds {
   repeated uint32 ids = 1;
 }
-
-// ======================================================================================
-// Control
-// ======================================================================================
-
-message AbortRequest {
-  repeated string request_ids = 1;
-}
-
-message AbortResponse {}

--- a/rust/proto/vllm_grpc.proto
+++ b/rust/proto/vllm_grpc.proto
@@ -7,7 +7,7 @@ package vllm;
 import "google/protobuf/struct.proto";
 
 
-service Generate {
+service Inference {
   // Generates text given a prompt
   rpc Generate (GenerateRequest) returns (GenerateResponse) {}
   // Generates text given a prompt, streaming the outputs

--- a/rust/src/server/build.rs
+++ b/rust/src/server/build.rs
@@ -9,7 +9,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build_server(true)
         .build_client(true)
         .protoc_arg("--experimental_allow_proto3_optional") // be compatible with old compilers
-        .compile_protos(&[format!("{proto_dir}/vllm_grpc.proto")], &[proto_dir])?;
+        .compile_protos(
+            &[
+                format!("{proto_dir}/control.proto"),
+                format!("{proto_dir}/inference.proto"),
+            ],
+            &[proto_dir],
+        )?;
 
     Ok(())
 }

--- a/rust/src/server/src/grpc/control.rs
+++ b/rust/src/server/src/grpc/control.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use std::sync::Arc;
+
+use thiserror_ext::AsReport as _;
+use tonic::{Request, Response, Status};
+
+use super::{ControlServer, pb};
+use crate::state::AppState;
+
+pub(crate) type ControlGrpcService = ControlServer<ControlServiceImpl>;
+
+/// gRPC control service backed by the shared application state.
+pub struct ControlServiceImpl {
+    state: Arc<AppState>,
+}
+
+impl ControlServiceImpl {
+    pub fn new(state: Arc<AppState>) -> Self {
+        Self { state }
+    }
+}
+
+#[tonic::async_trait]
+impl pb::control_server::Control for ControlServiceImpl {
+    async fn abort(
+        &self,
+        request: Request<pb::AbortRequest>,
+    ) -> Result<Response<pb::AbortResponse>, Status> {
+        let request_ids = request.into_inner().request_ids;
+        if request_ids.is_empty() {
+            return Ok(Response::new(pb::AbortResponse {}));
+        }
+        self.state
+            .chat
+            .abort(&request_ids)
+            .await
+            .map_err(|error| Status::internal(error.to_report_string()))?;
+        Ok(Response::new(pb::AbortResponse {}))
+    }
+}

--- a/rust/src/server/src/grpc/health.rs
+++ b/rust/src/server/src/grpc/health.rs
@@ -8,14 +8,14 @@ use tonic_health::ServingStatus;
 use tonic_health::server::HealthReporter;
 use tracing::{info, warn};
 
-use super::{ControlGrpcService, GenerateGrpcService};
+use super::{ControlGrpcService, InferenceGrpcService};
 
 pub(crate) async fn monitor_health(
     mut health_reporter: HealthReporter,
     mut engine_health: watch::Receiver<bool>,
     shutdown: CancellationToken,
 ) {
-    let generate_service = GenerateGrpcService::NAME;
+    let inference_service = InferenceGrpcService::NAME;
     let control_service = ControlGrpcService::NAME;
     let status = ServingStatus::NotServing;
     let health_event_first = tokio::select! {
@@ -45,7 +45,7 @@ pub(crate) async fn monitor_health(
         }
     };
 
-    health_reporter.set_not_serving::<GenerateGrpcService>().await;
+    health_reporter.set_not_serving::<InferenceGrpcService>().await;
     health_reporter.set_not_serving::<ControlGrpcService>().await;
     // Both gRPC services use the same engine client, so overall server health
     // mirrors their shared engine health.
@@ -59,7 +59,7 @@ pub(crate) async fn monitor_health(
         );
     }
 
-    health_reporter.clear_service_status(generate_service).await;
+    health_reporter.clear_service_status(inference_service).await;
     health_reporter.clear_service_status(control_service).await;
     health_reporter.clear_service_status("").await;
 }

--- a/rust/src/server/src/grpc/inference.rs
+++ b/rust/src/server/src/grpc/inference.rs
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use futures::{Stream, StreamExt as _};
+use thiserror_ext::AsReport as _;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+use tracing::info;
+use vllm_text::{DecodedTextEvent, TextOutputStreamExt as _};
+
+use super::convert::{self, ResponseOpts};
+use super::{InferenceServer, pb};
+use crate::state::AppState;
+
+pub(crate) type InferenceGrpcService = InferenceServer<InferenceServiceImpl>;
+
+/// gRPC inference service backed by the shared application state.
+pub struct InferenceServiceImpl {
+    state: Arc<AppState>,
+}
+
+impl InferenceServiceImpl {
+    pub fn new(state: Arc<AppState>) -> Self {
+        Self { state }
+    }
+}
+
+#[tonic::async_trait]
+impl pb::inference_server::Inference for InferenceServiceImpl {
+    type GenerateStreamStream =
+        Pin<Box<dyn Stream<Item = Result<pb::GenerateResponse, Status>> + Send>>;
+
+    /// Unary generate: collect all output and return a single response.
+    async fn generate(
+        &self,
+        request: Request<pb::GenerateRequest>,
+    ) -> Result<Response<pb::GenerateResponse>, Status> {
+        let proto_req = request.into_inner();
+        let response_opts = ResponseOpts::from_proto(proto_req.response.as_ref());
+        let text_request =
+            convert::to_text_request(proto_req, false, self.state.served_model_names())?;
+
+        let request_id = text_request.request_id.clone();
+        info!(%request_id, "grpc generate (unary)");
+
+        let stream = self.state.chat.text().generate(text_request).await;
+        let stream = stream.map_err(text_error_to_status)?;
+
+        let collected = stream.collect_output().await.map_err(text_error_to_status)?;
+
+        // Build the single aggregated response.
+        let prompt_info = convert::to_prompt_info(
+            &collected.prompt_token_ids,
+            collected.prompt_logprobs.as_ref(),
+            &response_opts,
+        );
+
+        let finish_info = vllm_text::Finished {
+            usage: collected.usage,
+            finish_reason: collected.finish_reason,
+            kv_transfer_params: collected.kv_transfer_params,
+            ec_transfer_params: collected.ec_transfer_params,
+        };
+
+        let outputs = convert::to_sequence_output(
+            &collected.text,
+            &collected.token_ids,
+            collected.logprobs.as_ref(),
+            Some(&finish_info),
+            &response_opts,
+        );
+
+        Ok(Response::new(pb::GenerateResponse {
+            prompt_info: Some(prompt_info),
+            outputs: Some(outputs),
+        }))
+    }
+
+    /// Streaming generate: yield incremental responses as tokens are produced.
+    async fn generate_stream(
+        &self,
+        request: Request<pb::GenerateRequest>,
+    ) -> Result<Response<Self::GenerateStreamStream>, Status> {
+        let proto_req = request.into_inner();
+        let response_opts = ResponseOpts::from_proto(proto_req.response.as_ref());
+        let text_request =
+            convert::to_text_request(proto_req, true, self.state.served_model_names())?;
+
+        let request_id = text_request.request_id.clone();
+        info!(%request_id, "grpc generate (stream)");
+
+        let stream = self.state.chat.text().generate(text_request).await;
+        let stream = stream.map_err(text_error_to_status)?;
+
+        let (tx, rx) = mpsc::channel(32);
+
+        tokio::spawn(async move {
+            futures::pin_mut!(stream);
+            while let Some(event) = stream.next().await {
+                let response = match event {
+                    Err(e) => Err(text_error_to_status(e)),
+                    Ok(DecodedTextEvent::Start {
+                        prompt_token_ids,
+                        prompt_logprobs,
+                    }) => {
+                        let prompt_info = convert::to_prompt_info(
+                            &prompt_token_ids,
+                            prompt_logprobs.as_ref(),
+                            &response_opts,
+                        );
+                        Ok(pb::GenerateResponse {
+                            prompt_info: Some(prompt_info),
+                            outputs: None,
+                        })
+                    }
+                    Ok(DecodedTextEvent::TextDelta {
+                        delta,
+                        token_ids,
+                        logprobs,
+                        finished,
+                    }) => Ok(pb::GenerateResponse {
+                        prompt_info: None,
+                        outputs: Some(convert::to_sequence_output(
+                            &delta,
+                            &token_ids,
+                            logprobs.as_ref(),
+                            finished.as_ref(),
+                            &response_opts,
+                        )),
+                    }),
+                };
+
+                if tx.send(response).await.is_err() {
+                    // Client disconnected.
+                    break;
+                }
+            }
+        });
+
+        let response_stream = ReceiverStream::new(rx);
+        Ok(Response::new(Box::pin(response_stream)))
+    }
+}
+
+fn text_error_to_status(error: vllm_text::Error) -> Status {
+    let message = error.to_report_string();
+    if error.is_request_validation_error() {
+        Status::invalid_argument(message)
+    } else {
+        Status::internal(message)
+    }
+}

--- a/rust/src/server/src/grpc/mod.rs
+++ b/rust/src/server/src/grpc/mod.rs
@@ -1,203 +1,25 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-//! gRPC Generate service backed by the shared [`vllm_text::TextLlm`] facade.
+//! gRPC services backed by the shared application state.
 
+mod control;
 mod convert;
 mod health;
-
-use std::pin::Pin;
-use std::sync::Arc;
-
-use futures::{Stream, StreamExt as _};
-use thiserror_ext::AsReport as _;
-use tokio::sync::mpsc;
-use tokio_stream::wrappers::ReceiverStream;
-use tonic::{Request, Response, Status};
-use tracing::info;
-use vllm_text::{DecodedTextEvent, TextOutputStreamExt as _};
-
-use self::convert::ResponseOpts;
-use crate::state::AppState;
+mod inference;
 
 /// Generated protobuf/gRPC types for the `vllm` package.
 pub mod pb {
     tonic::include_proto!("vllm");
 }
 
+pub(crate) use control::ControlGrpcService;
+pub use control::ControlServiceImpl;
 pub(crate) use health::monitor_health;
+pub(crate) use inference::InferenceGrpcService;
+pub use inference::InferenceServiceImpl;
 pub use pb::control_server::ControlServer;
-pub use pb::generate_server::GenerateServer;
-
-pub(crate) type ControlGrpcService = ControlServer<ControlServiceImpl>;
-pub(crate) type GenerateGrpcService = GenerateServer<GenerateServiceImpl>;
+pub use pb::inference_server::InferenceServer;
 
 #[cfg(test)]
 mod tests;
-
-/// gRPC Generate service implementation backed by the shared application state.
-pub struct GenerateServiceImpl {
-    state: Arc<AppState>,
-}
-
-impl GenerateServiceImpl {
-    pub fn new(state: Arc<AppState>) -> Self {
-        Self { state }
-    }
-}
-
-/// gRPC control service backed by the shared application state.
-pub struct ControlServiceImpl {
-    state: Arc<AppState>,
-}
-
-impl ControlServiceImpl {
-    pub fn new(state: Arc<AppState>) -> Self {
-        Self { state }
-    }
-}
-
-#[tonic::async_trait]
-impl pb::control_server::Control for ControlServiceImpl {
-    async fn abort(
-        &self,
-        request: Request<pb::AbortRequest>,
-    ) -> Result<Response<pb::AbortResponse>, Status> {
-        let request_ids = request.into_inner().request_ids;
-        if request_ids.is_empty() {
-            return Ok(Response::new(pb::AbortResponse {}));
-        }
-        self.state
-            .chat
-            .abort(&request_ids)
-            .await
-            .map_err(|error| Status::internal(error.to_report_string()))?;
-        Ok(Response::new(pb::AbortResponse {}))
-    }
-}
-
-#[tonic::async_trait]
-impl pb::generate_server::Generate for GenerateServiceImpl {
-    type GenerateStreamStream =
-        Pin<Box<dyn Stream<Item = Result<pb::GenerateResponse, Status>> + Send>>;
-
-    /// Unary generate: collect all output and return a single response.
-    async fn generate(
-        &self,
-        request: Request<pb::GenerateRequest>,
-    ) -> Result<Response<pb::GenerateResponse>, Status> {
-        let proto_req = request.into_inner();
-        let response_opts = ResponseOpts::from_proto(proto_req.response.as_ref());
-        let text_request =
-            convert::to_text_request(proto_req, false, self.state.served_model_names())?;
-
-        let request_id = text_request.request_id.clone();
-        info!(%request_id, "grpc generate (unary)");
-
-        let stream = self.state.chat.text().generate(text_request).await;
-        let stream = stream.map_err(text_error_to_status)?;
-
-        let collected = stream.collect_output().await.map_err(text_error_to_status)?;
-
-        // Build the single aggregated response.
-        let prompt_info = convert::to_prompt_info(
-            &collected.prompt_token_ids,
-            collected.prompt_logprobs.as_ref(),
-            &response_opts,
-        );
-
-        let finish_info = vllm_text::Finished {
-            usage: collected.usage,
-            finish_reason: collected.finish_reason,
-            kv_transfer_params: collected.kv_transfer_params,
-            ec_transfer_params: collected.ec_transfer_params,
-        };
-
-        let outputs = convert::to_sequence_output(
-            &collected.text,
-            &collected.token_ids,
-            collected.logprobs.as_ref(),
-            Some(&finish_info),
-            &response_opts,
-        );
-
-        Ok(Response::new(pb::GenerateResponse {
-            prompt_info: Some(prompt_info),
-            outputs: Some(outputs),
-        }))
-    }
-
-    /// Streaming generate: yield incremental responses as tokens are produced.
-    async fn generate_stream(
-        &self,
-        request: Request<pb::GenerateRequest>,
-    ) -> Result<Response<Self::GenerateStreamStream>, Status> {
-        let proto_req = request.into_inner();
-        let response_opts = ResponseOpts::from_proto(proto_req.response.as_ref());
-        let text_request =
-            convert::to_text_request(proto_req, true, self.state.served_model_names())?;
-
-        let request_id = text_request.request_id.clone();
-        info!(%request_id, "grpc generate (stream)");
-
-        let stream = self.state.chat.text().generate(text_request).await;
-        let stream = stream.map_err(text_error_to_status)?;
-
-        let (tx, rx) = mpsc::channel(32);
-
-        tokio::spawn(async move {
-            futures::pin_mut!(stream);
-            while let Some(event) = stream.next().await {
-                let response = match event {
-                    Err(e) => Err(text_error_to_status(e)),
-                    Ok(DecodedTextEvent::Start {
-                        prompt_token_ids,
-                        prompt_logprobs,
-                    }) => {
-                        let prompt_info = convert::to_prompt_info(
-                            &prompt_token_ids,
-                            prompt_logprobs.as_ref(),
-                            &response_opts,
-                        );
-                        Ok(pb::GenerateResponse {
-                            prompt_info: Some(prompt_info),
-                            outputs: None,
-                        })
-                    }
-                    Ok(DecodedTextEvent::TextDelta {
-                        delta,
-                        token_ids,
-                        logprobs,
-                        finished,
-                    }) => Ok(pb::GenerateResponse {
-                        prompt_info: None,
-                        outputs: Some(convert::to_sequence_output(
-                            &delta,
-                            &token_ids,
-                            logprobs.as_ref(),
-                            finished.as_ref(),
-                            &response_opts,
-                        )),
-                    }),
-                };
-
-                if tx.send(response).await.is_err() {
-                    // Client disconnected.
-                    break;
-                }
-            }
-        });
-
-        let response_stream = ReceiverStream::new(rx);
-        Ok(Response::new(Box::pin(response_stream)))
-    }
-}
-
-fn text_error_to_status(error: vllm_text::Error) -> Status {
-    let message = error.to_report_string();
-    if error.is_request_validation_error() {
-        Status::invalid_argument(message)
-    } else {
-        Status::internal(message)
-    }
-}

--- a/rust/src/server/src/grpc/tests.rs
+++ b/rust/src/server/src/grpc/tests.rs
@@ -39,8 +39,8 @@ use zeromq::prelude::{SocketRecv, SocketSend};
 use zeromq::{DealerSocket, PushSocket, ZmqMessage};
 
 use super::pb::control_client::ControlClient;
-use super::pb::generate_client::GenerateClient;
-use super::{ControlServer, ControlServiceImpl, GenerateServer, GenerateServiceImpl, pb};
+use super::pb::inference_client::InferenceClient;
+use super::{ControlServer, ControlServiceImpl, InferenceServer, InferenceServiceImpl, pb};
 use crate::listener::{Listener, MaybeTlsListener};
 use crate::state::AppState;
 use crate::tls;
@@ -202,7 +202,7 @@ async fn setup_grpc_service(
     engine_id: impl Into<EngineId>,
     output_specs: Vec<(Vec<u32>, Option<EngineCoreFinishReason>)>,
 ) -> (
-    GenerateServer<GenerateServiceImpl>,
+    InferenceServer<InferenceServiceImpl>,
     ControlServer<ControlServiceImpl>,
     tokio::sync::watch::Receiver<bool>,
     MockEngineTask,
@@ -246,7 +246,7 @@ async fn setup_grpc_service(
     );
     let state = Arc::new(AppState::new(vec!["test-model".to_string()], chat));
     (
-        GenerateServer::new(GenerateServiceImpl::new(state.clone())),
+        InferenceServer::new(InferenceServiceImpl::new(state.clone())),
         ControlServer::new(ControlServiceImpl::new(state)),
         engine_health,
         engine_task,
@@ -259,30 +259,30 @@ async fn grpc_test_server(
     engine_id: impl Into<EngineId>,
     output_specs: Vec<(Vec<u32>, Option<EngineCoreFinishReason>)>,
 ) -> (
-    GenerateClient<tonic::transport::Channel>,
+    InferenceClient<tonic::transport::Channel>,
     tokio::task::JoinHandle<()>,
     MockEngineTask,
 ) {
-    let (generate_service, control_service, engine_health, engine_task) =
+    let (inference_service, control_service, engine_health, engine_task) =
         setup_grpc_service(engine_id, output_specs).await;
     let (channel, server_task) = start_grpc_test_server(
-        generate_service,
+        inference_service,
         control_service,
         engine_health,
         tokio_util::sync::CancellationToken::new(),
     )
     .await;
-    (GenerateClient::new(channel), server_task, engine_task)
+    (InferenceClient::new(channel), server_task, engine_task)
 }
 
 async fn start_grpc_test_server(
-    generate_service: GenerateServer<GenerateServiceImpl>,
+    inference_service: InferenceServer<InferenceServiceImpl>,
     control_service: ControlServer<ControlServiceImpl>,
     engine_health: tokio::sync::watch::Receiver<bool>,
     shutdown: tokio_util::sync::CancellationToken,
 ) -> (Channel, tokio::task::JoinHandle<()>) {
     let (health_reporter, health_service) = health_reporter();
-    health_reporter.set_serving::<GenerateServer<GenerateServiceImpl>>().await;
+    health_reporter.set_serving::<InferenceServer<InferenceServiceImpl>>().await;
     health_reporter.set_serving::<ControlServer<ControlServiceImpl>>().await;
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind grpc listener");
@@ -293,7 +293,7 @@ async fn start_grpc_test_server(
         let server = TonicServer::builder()
             .add_service(health_service)
             .add_service(control_service)
-            .add_service(generate_service)
+            .add_service(inference_service)
             .serve_with_incoming_shutdown(incoming, shutdown.clone().cancelled_owned());
         let health_monitor =
             super::monitor_health(health_reporter, engine_health, shutdown.clone());
@@ -323,7 +323,7 @@ async fn grpc_tls_test_server(
     certs: &TestCerts,
     cert_reqs: i32,
 ) -> (String, tokio::task::JoinHandle<()>, MockEngineTask) {
-    let (generate_service, control_service, _engine_health, engine_task) =
+    let (inference_service, control_service, _engine_health, engine_task) =
         setup_grpc_service(engine_id, output_specs).await;
     let context = tls::build_grpc_server_config(&server_tls(certs, cert_reqs))
         .expect("build grpc tls config");
@@ -335,7 +335,7 @@ async fn grpc_tls_test_server(
         let incoming = MaybeTlsListener::tls(Listener::Tcp(listener), context);
         TonicServer::builder()
             .add_service(control_service)
-            .add_service(generate_service)
+            .add_service(inference_service)
             .serve_with_incoming(incoming)
             .await
             .expect("grpc tls server");
@@ -351,7 +351,7 @@ async fn grpc_tls_client(
     certs: &TestCerts,
     addr: &str,
     identity: Option<&str>,
-) -> Result<GenerateClient<Channel>, tonic::transport::Error> {
+) -> Result<InferenceClient<Channel>, tonic::transport::Error> {
     let ca = certs.path("ca.pem");
     let identity = identity.map(|name| {
         (
@@ -388,7 +388,7 @@ async fn grpc_tls_client(
         .expect("grpc endpoint")
         .connect_with_connector(connector)
         .await?;
-    Ok(GenerateClient::new(channel))
+    Ok(InferenceClient::new(channel))
 }
 
 /// Complete a raw TLS handshake against the gRPC port (offering ALPN `h2`) for
@@ -415,7 +415,7 @@ async fn grpc_server_with_keepalive(
     engine_id: impl Into<EngineId>,
     keepalive: Option<Duration>,
 ) -> (String, tokio::task::JoinHandle<()>, MockEngineTask) {
-    let (generate_service, control_service, _engine_health, engine_task) =
+    let (inference_service, control_service, _engine_health, engine_task) =
         setup_grpc_service(engine_id, default_stream_output_specs()).await;
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind grpc listener");
@@ -432,7 +432,7 @@ async fn grpc_server_with_keepalive(
         let incoming = MaybeTlsListener::plain(Listener::Tcp(listener));
         builder
             .add_service(control_service)
-            .add_service(generate_service)
+            .add_service(inference_service)
             .serve_with_incoming(incoming)
             .await
             .expect("grpc server");
@@ -1083,20 +1083,20 @@ async fn grpc_without_keepalive_keeps_unresponsive_connection_open() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn control_abort_resolves_external_id_and_empty_is_noop() {
-    let (generate_service, control_service, engine_health, engine_task) =
+    let (inference_service, control_service, engine_health, engine_task) =
         setup_grpc_service(b"engine-grpc-abort-active", vec![(vec![b'h' as u32], None)]).await;
     let (channel, server_task) = start_grpc_test_server(
-        generate_service,
+        inference_service,
         control_service,
         engine_health,
         tokio_util::sync::CancellationToken::new(),
     )
     .await;
-    let mut generate_client = GenerateClient::new(channel.clone());
+    let mut inference_client = InferenceClient::new(channel.clone());
     let mut control_client = ControlClient::new(channel);
     let request_id = "test-abort-active";
 
-    let mut stream = generate_client
+    let mut stream = inference_client
         .generate_stream(pb::GenerateRequest {
             request_id: request_id.to_string(),
             model: "test-model".to_string(),
@@ -1174,11 +1174,11 @@ async fn control_abort_resolves_external_id_and_empty_is_noop() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn grpc_health_transitions_to_not_serving_when_engine_becomes_unhealthy() {
-    let (generate_service, control_service, _connected_engine_health, _engine_task) =
+    let (inference_service, control_service, _connected_engine_health, _engine_task) =
         setup_grpc_service(b"engine-grpc-health-failure", default_stream_output_specs()).await;
     let (engine_health_tx, engine_health) = tokio::sync::watch::channel(true);
     let (channel, server_task) = start_grpc_test_server(
-        generate_service,
+        inference_service,
         control_service,
         engine_health,
         tokio_util::sync::CancellationToken::new(),
@@ -1187,7 +1187,7 @@ async fn grpc_health_transitions_to_not_serving_when_engine_becomes_unhealthy() 
     let mut health_client = HealthClient::new(channel);
 
     let mut health_streams = Vec::new();
-    for service in ["vllm.Generate", "vllm.Control", ""] {
+    for service in ["vllm.Inference", "vllm.Control", ""] {
         let service_label = if service.is_empty() {
             "overall"
         } else {
@@ -1242,14 +1242,14 @@ async fn grpc_health_transitions_to_not_serving_when_engine_becomes_unhealthy() 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn grpc_health_watch_closes_on_graceful_shutdown() {
-    let (generate_service, control_service, engine_health, _engine_task) = setup_grpc_service(
+    let (inference_service, control_service, engine_health, _engine_task) = setup_grpc_service(
         b"engine-grpc-health-shutdown",
         default_stream_output_specs(),
     )
     .await;
     let shutdown = tokio_util::sync::CancellationToken::new();
     let (channel, server_task) = start_grpc_test_server(
-        generate_service,
+        inference_service,
         control_service,
         engine_health,
         shutdown.clone(),
@@ -1258,43 +1258,43 @@ async fn grpc_health_watch_closes_on_graceful_shutdown() {
     let mut health_client = HealthClient::new(channel);
     let mut stream = health_client
         .watch(HealthCheckRequest {
-            service: "vllm.Generate".to_string(),
+            service: "vllm.Inference".to_string(),
         })
         .await
-        .expect("start health watch for vllm.Generate")
+        .expect("start health watch for vllm.Inference")
         .into_inner();
 
     let initial = stream
         .message()
         .await
-        .expect("read initial health status for vllm.Generate")
+        .expect("read initial health status for vllm.Inference")
         .expect("health watch ended before its initial status");
     assert_eq!(
         initial.status,
         HealthServingStatus::Serving as i32,
-        "unexpected initial health status for vllm.Generate"
+        "unexpected initial health status for vllm.Inference"
     );
 
     shutdown.cancel();
 
     let update = tokio::time::timeout(Duration::from_secs(2), stream.message())
         .await
-        .expect("timed out waiting for shutdown health update for vllm.Generate")
-        .expect("failed to read shutdown health update for vllm.Generate")
+        .expect("timed out waiting for shutdown health update for vllm.Inference")
+        .expect("failed to read shutdown health update for vllm.Inference")
         .expect("health watch ended before its shutdown update");
     assert_eq!(
         update.status,
         HealthServingStatus::NotServing as i32,
-        "unexpected shutdown health status for vllm.Generate"
+        "unexpected shutdown health status for vllm.Inference"
     );
 
     let stream_end = tokio::time::timeout(Duration::from_secs(2), stream.message())
         .await
-        .expect("timed out waiting for vllm.Generate health watch to close")
-        .expect("failed while closing vllm.Generate health watch");
+        .expect("timed out waiting for vllm.Inference health watch to close")
+        .expect("failed while closing vllm.Inference health watch");
     assert!(
         stream_end.is_none(),
-        "vllm.Generate health watch remained open"
+        "vllm.Inference health watch remained open"
     );
 
     tokio::time::timeout(Duration::from_secs(2), server_task)

--- a/rust/src/server/src/lib.rs
+++ b/rust/src/server/src/lib.rs
@@ -187,7 +187,7 @@ where
     let model = state.primary_model_name().to_owned();
     let app = extend_router(build_router(state.clone()));
 
-    // Optionally bind the gRPC Generate server on a separate port. Bind
+    // Optionally bind the gRPC Inference server on a separate port. Bind
     // synchronously here so bind errors (port in use, permission denied, ...)
     // surface before serving rather than being deferred until shutdown.
     let grpc_setup = if let Some(grpc_port) = config.grpc_port {
@@ -206,19 +206,19 @@ where
             .context("invalid gRPC TLS configuration")?;
         let (health_reporter, health_service) = health_reporter();
         let engine_health = state.engine_core_client().subscribe_health();
-        health_reporter.set_serving::<grpc::GenerateGrpcService>().await;
+        health_reporter.set_serving::<grpc::InferenceGrpcService>().await;
         health_reporter.set_serving::<grpc::ControlGrpcService>().await;
         let control_service =
             grpc::ControlGrpcService::new(grpc::ControlServiceImpl::new(state.clone()));
-        let generate_service =
-            grpc::GenerateGrpcService::new(grpc::GenerateServiceImpl::new(state.clone()));
+        let inference_service =
+            grpc::InferenceGrpcService::new(grpc::InferenceServiceImpl::new(state.clone()));
         let svc = TonicServer::builder()
             .http2_keepalive_interval(Some(GRPC_KEEPALIVE_INTERVAL))
             .http2_keepalive_timeout(Some(GRPC_KEEPALIVE_TIMEOUT))
             .layer(middleware::request_runtime_layer(state.clone()))
             .add_service(health_service)
             .add_service(control_service)
-            .add_service(generate_service);
+            .add_service(inference_service);
         info!(%addr, tls = grpc_tls.is_some(), "starting gRPC server");
         Some((grpc_listener, svc, grpc_tls, health_reporter, engine_health))
     } else {

--- a/rust/src/server/src/middleware/offload.rs
+++ b/rust/src/server/src/middleware/offload.rs
@@ -30,8 +30,8 @@ const OFFLOADED_PATHS: &[&str] = &[
     "/detokenize",
     "/inference/v1/generate",
     // gRPC routes:
-    "/vllm.Generate/Generate",
-    "/vllm.Generate/GenerateStream",
+    "/vllm.Inference/Generate",
+    "/vllm.Inference/GenerateStream",
 ];
 
 /// Return a Tower layer that runs selected data-plane requests on the request runtime,
@@ -124,8 +124,8 @@ mod tests {
         assert!(should_offload("/tokenize"));
         assert!(should_offload("/detokenize"));
         assert!(should_offload("/inference/v1/generate"));
-        assert!(should_offload("/vllm.Generate/Generate"));
-        assert!(should_offload("/vllm.Generate/GenerateStream"));
+        assert!(should_offload("/vllm.Inference/Generate"));
+        assert!(should_offload("/vllm.Inference/GenerateStream"));
     }
 
     #[test]


### PR DESCRIPTION
## Purpose

Separate the Rust frontend's inference and control gRPC APIs after the control service was introduced in #49255.

- Rename the wire inference service from `vllm.Generate` to `vllm.Inference`.
- Keep the `Generate` and `GenerateStream` RPC names and request and response messages unchanged.
- Move the Rust implementations into `grpc/inference.rs` and `grpc/control.rs`.
- Split the protobuf definitions into `inference.proto` and `control.proto`.
- Keep generated protobuf exports and service registration in `grpc/mod.rs`.
- Update health registration, request offloading paths, tests, and existing gRPC clients for the renamed service.

This gives each public gRPC service an independent protobuf definition and implementation module.

## Test Plan

- `cargo fmt --all -- --check`
- `CARGO_INCREMENTAL=0 cargo check -p vllm-server`
- `CARGO_INCREMENTAL=0 cargo test -p vllm-server 'grpc::tests::' -- --nocapture`
- `CARGO_INCREMENTAL=0 cargo test -p vllm-server`
- `git diff --check upstream/main...HEAD`

## Test Result

- Formatting and whitespace checks passed.
- `vllm-server` compiled without warnings.
- All 22 gRPC server tests passed.
- All 310 `vllm-server` tests passed.
- No new tests were added; existing generation, abort, health, TLS, keepalive, and middleware coverage exercises the renamed service and split modules.

**AI assistance disclosure:** This PR was authored with AI assistance and reviewed by the submitter.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples`.
</details>

