### PR TITLE
[Bugfix] Fix DeepGEMM warmup when using `FlashInferFp8DeepGEMMDynamicBlockScaledKernel`

### DIFF
--- a/vllm/model_executor/warmup/deep_gemm_warmup.py
+++ b/vllm/model_executor/warmup/deep_gemm_warmup.py
@@ -133,6 +133,18 @@ def _extract_data_from_fused_moe_module(
     return w13, w13_s, w2, w2_s, num_topk
 
 
+def _is_deep_gemm_backed_kernel(fp8_linear: object) -> bool:
+    """
+    Return True if the selected linear kernel dispatches to DeepGEMM, either
+    directly or as the fallback branch of a dynamic wrapper.
+    """
+    if isinstance(fp8_linear, DeepGemmFp8BlockScaledMMKernel):
+        return True
+    return isinstance(
+        getattr(fp8_linear, "fallback", None), DeepGemmFp8BlockScaledMMKernel
+    )
+
+
 def _fp8_linear_may_use_deep_gemm(module: torch.nn.Module) -> bool:
     """
     Return True if the input module/layer could be processed with DeepGEMM.
@@ -147,10 +159,8 @@ def _fp8_linear_may_use_deep_gemm(module: torch.nn.Module) -> bool:
     ):
         return False
 
-    if not isinstance(
-        getattr(module.quant_method, "fp8_linear", None),
-        DeepGemmFp8BlockScaledMMKernel,
-    ):
+    fp8_linear = getattr(module.quant_method, "fp8_linear", None)
+    if not _is_deep_gemm_backed_kernel(fp8_linear):
         return False
 
     block_size = get_mk_alignment_for_contiguous_layout()[0]


### PR DESCRIPTION





## Purpose

Fix an issue where Hopper + FP8 models regress by up to 20% after https://github.com/vllm-project/vllm/pull/41652/changes#diff-5ee97c25141448b7fd638e73ebcca7d3eead061d22b538e7983f4cdd81ac8f69 landed due to skipping deepgemm warmup

## Test Plan

## Test Result

```
vllm serve Qwen/Qwen3-0.6B-FP8
...
Selected FlashInferFp8DeepGEMMDynamicBlockScaledKernel for Fp8LinearMethod
...
DeepGEMM warmup: 100%|██████████| 948/948 [03:23<00:00, 4.65it/s]
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

