### PR TITLE
[Bugfix] Fix DeepGemm warmup OOM from DP world_size multiplication

### DIFF
--- a/vllm/model_executor/warmup/deep_gemm_warmup.py
+++ b/vllm/model_executor/warmup/deep_gemm_warmup.py
@@ -10,7 +10,7 @@ import torch
 from tqdm import tqdm
 
 import vllm.envs as envs
-from vllm.distributed.parallel_state import get_dp_group, is_global_first_rank
+from vllm.distributed.parallel_state import is_global_first_rank
 from vllm.model_executor.layers.fused_moe import MoERunner
 from vllm.model_executor.layers.fused_moe.deep_gemm_utils import (
     compute_aligned_M_and_alignment,
@@ -247,9 +247,6 @@ def _get_grouped_gemm_params(
     block_m = get_mk_alignment_for_contiguous_layout()[0]
     num_experts = w1.size(0)
     device = w1.device
-
-    # Assumes all ranks have the same max_num_batched_tokens
-    max_tokens = get_dp_group().world_size * max_tokens
 
     request_m_values = _generate_optimal_warmup_m_values(
         max_tokens,


### PR DESCRIPTION
## Summary

Remove `max_tokens = get_dp_group().world_size * max_tokens` from
`_get_grouped_gemm_params` in the DeepGemm warmup path. This line
inflates the warmup's tensor allocations by `dp_world_size`, causing
OOM on multi-GPU DP setups.

## Root cause

PR #24693 introduced the `world_size` multiplication to cover M values
that the grouped GEMM could see after naive-DP all-gather. That PR
safely bounded it with:

```python
max_tokens_across_dp = get_dp_group().world_size * max_tokens
max_tokens = min(max_tokens_across_dp, envs.VLLM_FUSED_MOE_CHUNK_SIZE)
```

PR #34086 ("Remove Chunking From FusedMoE") deleted
`VLLM_FUSED_MOE_CHUNK_SIZE` and the `min()` cap, but left the
unbounded multiplication — causing warmup to allocate tensors sized for
`dp_world_size × max_tokens × num_topk` rows, which OOMs on large DP
configurations.

## Why the multiplication is unnecessary (not just uncapped)

DeepGEMM JIT kernels are parameterized by tile sizes (BLOCK_M,
BLOCK_N), not by total M. `_generate_optimal_warmup_m_values` covers
all kernel configuration transitions by generating M values at wave
boundaries (`wave × num_SMs × block_m / cdiv(n, block_n)`). On H100
(132 SMs), the maximum wave transition M is ~754 for typical weight
dimensions — well within per-rank `max_num_batched_tokens`. Larger M
values only change the grid launch size, not the compiled kernel.

The non-grouped warmup path (`_deepgemm_fp8_gemm_nt_warmup`) already
does not apply `world_size` scaling, confirming this pattern.

## Test plan

- [x] Verified the fix resolves OOM on DP DeepSeek V3 serving
- [x] Confirmed warmup completes and no JIT compilation occurs on the hot path

## AI disclosure

This PR was prepared with AI assistance (Claude). The change was
identified and validated by a human operator encountering the OOM in
production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)