### PR TITLE
[Perf] Offload Harmony chat rendering to thread pool

### DIFF
--- a/vllm/renderers/online_renderer.py
+++ b/vllm/renderers/online_renderer.py
@@ -41,6 +41,7 @@ from vllm.renderers.inputs.preprocess import (
     parse_model_prompt,
     prompt_to_seq,
 )
+from vllm.utils.async_utils import make_async
 from vllm.utils.mistral import is_mistral_tokenizer, is_mistral_tool_parser
 from vllm.utils.mistral import mt as _mt
 
@@ -71,6 +72,9 @@ class OnlineRenderer:
         self.enable_auto_tools = enable_auto_tools
         self.exclude_tools_when_tool_choice_none = exclude_tools_when_tool_choice_none
         self.use_harmony = model_config.hf_config.model_type == "gpt_oss"
+        self._make_request_with_harmony_async = make_async(
+            self._make_request_with_harmony, executor=renderer._executor
+        )
         self.parser: type[Parser] | None = ParserManager.get_parser(
             tool_parser_name=tool_parser,
             reasoning_parser_name=reasoning_parser,
@@ -174,7 +178,7 @@ class OnlineRenderer:
         else:
             # For GPT-OSS.
             should_include_tools = tool_dicts is not None
-            conversation, engine_inputs = self._make_request_with_harmony(
+            conversation, engine_inputs = await self._make_request_with_harmony_async(
                 request, should_include_tools
             )
 


### PR DESCRIPTION
## Purpose

- For gpt-oss models, async `render_chat` calls sync `_make_request_with_harmony` inline, running the full-conversation Harmony encode on the event loop and stalling all concurrent requests
- Wrap it with `make_async` on the renderer's shared thread pool, same pattern as #49396
- Not a duplicate: open Harmony PRs (#38143, #37264, #39413) address truncation, not event-loop blocking

## Test Plan

- Concurrent-load A/B on Modal L4: gpt-oss-20b render server, long multi-turn chat renders in a loop, `/health` probe every 10ms, 10s per point

## Test Result

- Probe latency improves 30-45% on long conversations across two independent runs; heavy-request throughput unchanged:

| conversation turns | probe p50 (ms) base → fix | probe p99 (ms) base → fix |
|---|---|---|
| 4 | 8.0 → 7.0 | 12.8 → 9.7 |
| 16 | 14.3 → 13.8 | 20.9 → 20.4 |
| 48 | 54.9 → 38.5 | 63.3 → 51.4 |
| 96 | 116.2 → 63.8 | 124.1 → 95.9 |

- Remaining growth with size is request-body parsing before the handler, out of scope here
- The Responses API path has the same inline call (`responses/serving.py`); left for a follow-up to keep this minimal

---

AI assistance was used for this change (Claude); every line was reviewed by the submitter.
