### PR TITLE
[Bugfix] Fix MiniMax-M3 ModelOpt FP8 MoE SwiGLU params

### DIFF
--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -14,9 +14,11 @@ import torch
 
 from tests.quantization.utils import is_quant_method_supported
 from vllm.config.model import ModelConfig
+from vllm.model_executor.layers.fused_moe.oracle.fp8 import Fp8MoeBackend
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptFp8Config,
+    ModelOptFp8MoEMethod,
     ModelOptMixedPrecisionConfig,
     ModelOptMxFp8Config,
     ModelOptNvFp4Config,
@@ -248,6 +250,26 @@ def test_vocab_parallel_embedding_weight_loader_accepts_scalar_scale():
     VocabParallelEmbedding.weight_loader(holder, scale, loaded_scale)
 
     assert torch.equal(scale, loaded_scale.reshape(1))
+
+
+def test_modelopt_fp8_moe_forwards_swiglu_params():
+    quant_method = object.__new__(ModelOptFp8MoEMethod)
+    quant_method.fp8_backend = Fp8MoeBackend.TRITON
+
+    layer = Mock()
+    layer.w13_weight_scale = torch.ones(2)
+    layer.w2_weight_scale = torch.ones(2)
+    layer.w13_input_scale = torch.ones(2)
+    layer.w2_input_scale = torch.ones(2)
+    layer.swiglu_alpha = 1.702
+    layer.swiglu_beta = 1.0
+    layer.swiglu_limit = 7.0
+
+    quant_config = quant_method.get_fused_moe_quant_config(layer)
+
+    assert quant_config.gemm1_alpha == 1.702
+    assert quant_config.gemm1_beta == 1.0
+    assert quant_config.gemm1_clamp_limit == 7.0
 
 
 @pytest.mark.skipif(

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -956,6 +956,8 @@ class ModelOptFp8MoEMethod(FusedMoEMethodBase):
             a1_scale=a1_scale,
             a2_scale=a2_scale,
             swiglu_limit=getattr(layer, "swiglu_limit", None),
+            gemm1_alpha=getattr(layer, "swiglu_alpha", None),
+            gemm1_beta=getattr(layer, "swiglu_beta", None),
             layer=layer,
         )
 


### PR DESCRIPTION
## Purpose

Companion to #46845 — the same SwiGLU-parameter omission, in the ModelOpt FP8 MoE path.

MiniMax-M3's routed experts use swigluoai activation (`swiglu_alpha=1.702`, `swiglu_beta=1.0`, `swiglu_limit=7.0`). `ModelOptFp8MoEMethod.get_fused_moe_quant_config` forwards only `swiglu_limit` into `make_fp8_moe_quant_config`, dropping `gemm1_alpha`/`gemm1_beta`, so the fused MoE kernels fall back to `alpha=1.0`/`beta=0.0` — i.e. plain clamped SiLU. ModelOpt per-tensor FP8 checkpoints of MiniMax-M3 load and serve without any error but emit incoherent output. `ModelOptMxFp8FusedMoE` already forwards both parameters; this change mirrors it.

Root-caused independently on a ModelOpt static FP8 MiniMax-M3 checkpoint with an offline single-layer repro (one `FusedMoE` layer through the real kernel stack vs a pure-torch reference computed from the same on-disk tensors): per-token cosine vs reference was ~0.966 (rel err ~34%) before forwarding the two params — consistent with the experts computing SiLU instead of swigluoai — and 0.99+ (rel err ~0.10–0.15, the FP8 quantization noise floor) after. Compounded over the model's 57 MoE layers, 0.966^57 ≈ 0.14 fully accounts for the garbage output. End-to-end serving of the same checkpoint is coherent with the fix and token soup without it.

Not addressed here to keep the change minimal (noting for follow-up): the `FLASHINFER_CUTLASS` branch of `make_fp8_moe_quant_config` also drops `gemm1_alpha`/`gemm1_beta` (latent today — that backend is not selected for swigluoai models), and the ModelOpt NVFP4 path (`ModelOptNvFp4FusedMoE` → `make_nvfp4_moe_quant_config`) has the same omission but additionally needs the parameters added to the factory signature.

## Test Plan

New unit test `test_modelopt_fp8_moe_forwards_swiglu_params` in `tests/quantization/test_modelopt.py`, mirroring the unit test added in #46845: builds `ModelOptFp8MoEMethod` with the TRITON backend and asserts the three swiglu parameters reach the `FusedMoEQuantConfig`.

## Test Result

On main the resulting config carries `gemm1_alpha=None` / `gemm1_beta=None`; with this change the test asserts `1.702` / `1.0` / `7.0`. Numerical validation per the offline repro described above.
