### PR TITLE
[Docs] Re-add Reo.dev analytics beacon

### DIFF
--- a/docs/mkdocs/javascript/reo.js
+++ b/docs/mkdocs/javascript/reo.js
@@ -1,0 +1,3 @@
+// Reo.Dev documentation tracking
+// https://docs.reo.dev/integrations/input-sources/developer-insights/documentation
+!function(){var e,t,n;e="d5c4337961ef0ac",t=function(){Reo.init({clientID:"d5c4337961ef0ac", enableThirdPartyTracking: true})},(n=document.createElement("script")).src="https://static.reo.dev/"+e+"/reo.js",n.defer=!0,n.onload=t,document.head.appendChild(n)}();

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -160,3 +160,4 @@ extra_javascript:
   - https://unpkg.com/mathjax@3.2.2/es5/tex-mml-chtml.js
   - mkdocs/javascript/edit_and_feedback.js
   - mkdocs/javascript/slack_and_forum.js
+  - mkdocs/javascript/reo.js


### PR DESCRIPTION
## Purpose

Re-add the Reo.dev documentation analytics beacon to docs.vllm.ai.

vLLM POC'd Reo.dev analytics earlier this year (vllm-project/vllm_website#13 / vllm-project/vllm#33957) and rolled it back (vllm-project/vllm_website#16 / vllm-project/vllm#36528) while we evaluated it further. Re-adding for docs.vllm.ai as we are exploring Reo.dev again. Adds `enableThirdPartyTracking: true`, which wasn't present in the original POC.

This adds `docs/mkdocs/javascript/reo.js` and registers it in `mkdocs.yaml` under `extra_javascript`, after `mkdocs/javascript/slack_and_forum.js`.

## Not a duplicate

- The original beacon was removed in #36528, so this is a re-introduction, not a duplicate of the (merged) #33957.
- No open PR currently adds or references Reo (`gh pr list --state open --search "reo in:title,body"` returns nothing).

## Test plan

- `mkdocs build --strict` completes without errors or warnings related to the new script.
- Inspect generated HTML to confirm the Reo.dev script tag is injected on doc pages.

## Test results

- `.venv/bin/python -m mkdocs build --strict` -> exit 0, `Documentation built in 275.39 seconds`, no errors/warnings.
- Confirmed `<script src=mkdocs/javascript/reo.js></script>` is injected into generated HTML (2,213 pages, incl. `index.html`).

## AI assistance disclosure

This change was prepared with AI assistance (Claude Code). A human contributor has reviewed every changed line and is responsible for defending the change end-to-end.

Reviewer: @hmellor (code owner on both prior PRs)
