### PR TITLE
[Perf] Defer MM embeds loading off the event loop

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1167,10 +1167,13 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
         uuid: str | None,
     ):
         if isinstance(image_embeds, dict):
-            embeds = {
-                k: await self._connector.fetch_image_embedding_async(v)
-                for k, v in image_embeds.items()
-            }
+            tensors = await asyncio.gather(
+                *(
+                    self._connector.fetch_image_embedding_async(v)
+                    for v in image_embeds.values()
+                )
+            )
+            embeds = dict(zip(image_embeds, tensors))
         elif isinstance(image_embeds, str):
             embeds = await self._connector.fetch_image_embedding_async(image_embeds)
         else:
@@ -1200,10 +1203,13 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
         uuid: str | None,
     ):
         if isinstance(audio_embeds, dict):
-            embeds = {
-                k: await self._connector.fetch_audio_embedding_async(v)
-                for k, v in audio_embeds.items()
-            }
+            tensors = await asyncio.gather(
+                *(
+                    self._connector.fetch_audio_embedding_async(v)
+                    for v in audio_embeds.values()
+                )
+            )
+            embeds = dict(zip(audio_embeds, tensors))
         elif isinstance(audio_embeds, str):
             embeds = await self._connector.fetch_audio_embedding_async(audio_embeds)
         else:

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1155,21 +1155,27 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
                 "You must set `--enable-mm-embeds` to input `image_embeds`"
             )
 
+        placeholder = self._tracker.add(
+            "image_embeds",
+            partial(self._image_embeds_with_uuid_async, image_embeds, uuid),
+        )
+        self._add_placeholder("image", placeholder)
+
+    async def _image_embeds_with_uuid_async(
+        self,
+        image_embeds: str | dict[str, str] | None,
+        uuid: str | None,
+    ):
         if isinstance(image_embeds, dict):
             embeds = {
-                k: self._connector.fetch_image_embedding(v)
+                k: await self._connector.fetch_image_embedding_async(v)
                 for k, v in image_embeds.items()
             }
         elif isinstance(image_embeds, str):
-            embedding = self._connector.fetch_image_embedding(image_embeds)
-            embeds = embedding
+            embeds = await self._connector.fetch_image_embedding_async(image_embeds)
         else:
             embeds = None
-
-        placeholder = self._tracker.add(
-            "image_embeds", partial(self._item_with_uuid_async, embeds, uuid)
-        )
-        self._add_placeholder("image", placeholder)
+        return embeds, uuid
 
     def parse_audio_embeds(
         self,
@@ -1182,21 +1188,27 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
                 "You must set `--enable-mm-embeds` to input `audio_embeds`"
             )
 
+        placeholder = self._tracker.add(
+            "audio_embeds",
+            partial(self._audio_embeds_with_uuid_async, audio_embeds, uuid),
+        )
+        self._add_placeholder("audio", placeholder)
+
+    async def _audio_embeds_with_uuid_async(
+        self,
+        audio_embeds: str | dict[str, str] | None,
+        uuid: str | None,
+    ):
         if isinstance(audio_embeds, dict):
             embeds = {
-                k: self._connector.fetch_audio_embedding(v)
+                k: await self._connector.fetch_audio_embedding_async(v)
                 for k, v in audio_embeds.items()
             }
         elif isinstance(audio_embeds, str):
-            embedding = self._connector.fetch_audio_embedding(audio_embeds)
-            embeds = embedding
+            embeds = await self._connector.fetch_audio_embedding_async(audio_embeds)
         else:
             embeds = None
-
-        placeholder = self._tracker.add(
-            "audio_embeds", partial(self._item_with_uuid_async, embeds, uuid)
-        )
-        self._add_placeholder("audio", placeholder)
+        return embeds, uuid
 
     def parse_image_pil(
         self,

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -593,6 +593,20 @@ class MediaConnector:
 
         return image_embedding_io.load_base64("", data)
 
+    async def fetch_image_embedding_async(
+        self,
+        data: str,
+    ) -> torch.Tensor:
+        """
+        Asynchronously load image embedding from a URL.
+        """
+        image_embedding_io = ImageEmbeddingMediaIO()
+        loop = asyncio.get_running_loop()
+
+        return await loop.run_in_executor(
+            global_thread_pool, image_embedding_io.load_base64, "", data
+        )
+
     def fetch_audio_embedding(
         self,
         data: str,
@@ -603,3 +617,17 @@ class MediaConnector:
         audio_embedding_io = AudioEmbeddingMediaIO()
 
         return audio_embedding_io.load_base64("", data)
+
+    async def fetch_audio_embedding_async(
+        self,
+        data: str,
+    ) -> torch.Tensor:
+        """
+        Asynchronously load audio embedding from a URL.
+        """
+        audio_embedding_io = AudioEmbeddingMediaIO()
+        loop = asyncio.get_running_loop()
+
+        return await loop.run_in_executor(
+            global_thread_pool, audio_embedding_io.load_base64, "", data
+        )


### PR DESCRIPTION
## Purpose

- With `--enable-mm-embeds`, loading multi-MB embedding tensors blocks the API server's event loop, stalling all concurrent requests
- Defer the loading to the shared thread pool, the same way every other modality is already handled
- Error semantics and the sync path are unchanged
- Not a duplicate: issue #49317 covers a different stage; no open PR touches this path

## Test Plan

- `pytest tests/entrypoints/unit_tests/test_chat_utils.py` (on Modal L4)
- Loop-stall microbenchmark: parse a chat message carrying a base64 image-embeds tensor while a 1ms ticker task measures the longest event-loop stall (median of 5)

## Test Result

- 63 passed, 0 failed

| embeds size | max loop stall (ms) base → fix | parse wall time (ms) base / fix |
|---|---|---|
| 8 MB | 7.1 → 2.0 | 7.2 / 5.0 |
| 32 MB | 23.1 → 13.5 | 23.2 / 22.3 |
| 128 MB | 110.0 → 54.2 | 110.1 / 108.8 |

Baseline stall equals wall time (the loop is fully blocked). The fix removes the blocking except for GIL-bound segments of tensor deserialization inside the worker thread, and lets other requests interleave at await points.

---

AI assistance was used for this change (Claude); every line was reviewed by the submitter.
