### PR TITLE
Fix GLM-4.1V vision TP fallback for non-divisible attention heads

### DIFF
--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -280,7 +280,7 @@ class Glm4vVisionAttention(nn.Module):
     ) -> None:
         super().__init__()
         # Per attention head and per partition values.
-        use_data_parallel = is_vit_use_data_parallel()
+        use_data_parallel = is_vit_use_data_parallel(num_heads)
         self.tp_size = (
             1 if use_data_parallel else get_tensor_model_parallel_world_size()
         )
@@ -641,7 +641,7 @@ class Glm4vVisionTransformer(nn.Module):
     ) -> None:
         super().__init__()
 
-        use_data_parallel = is_vit_use_data_parallel()
+        use_data_parallel = is_vit_use_data_parallel(vision_config.num_heads)
         self.tp_size = (
             1 if use_data_parallel else get_tensor_model_parallel_world_size()
         )


### PR DESCRIPTION
### Summary

This change updates the GLM-4.1V vision model to pass the vision attention head count to `is_vit_use_data_parallel()`, allowing the existing automatic fallback logic to detect when the vision attention heads cannot be evenly partitioned across the configured tensor parallel size.

### Background

The vision helper `is_vit_use_data_parallel(num_heads)` already supports automatically falling back to data parallelism when the number of vision attention heads is not divisible by the tensor parallel size.

However, GLM-4.1V was invoking this helper without providing the vision head count, preventing the fallback logic from being applied during vision module initialization.

### Changes

Updated the following call sites in `vllm/model_executor/models/glm4_1v.py`:

* `Glm4vVisionAttention`

  * Pass `num_heads` to `is_vit_use_data_parallel(num_heads)`.
* `Glm4vVisionTransformer`

  * Pass `vision_config.num_heads` to `is_vit_use_data_parallel(vision_config.num_heads)`.

### Motivation

With this change, models whose vision attention head count is not divisible by the tensor parallel size can correctly use the existing vision data-parallel fallback instead of attempting an unsupported tensor-parallel partition.

### Validation

* Successfully compiled the modified file using:

  ```bash
  python3 -m compileall vllm/model_executor/models/glm4_1v.py
  ```

* Runtime validation is pending because the local environment has not yet been built with the patched source.

### Related

Fixes #49368