### PR TITLE
Fix XPU false 0 free-memory reading in spawned workers

### DIFF
--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -91,8 +91,7 @@ def get_mem_info_wrapper(
             f"device must be int, str, torch.device, or None, got {type(device)}"
         )
 
-    # Call the underlying C++ implementation
-    free, total = torch.ops._C_cache_ops.getMemoryInfo(device)
+    free, total = torch.xpu.mem_get_info(device)
 
     return free, total
 


### PR DESCRIPTION
## Summary
On XPU, vLLM aborts at startup with:

    ValueError: Free memory on device xpu:0 (0.0/22.71 GiB) is less than
    desired GPU memory utilization ...

even when the card is completely empty, so no model can be loaded.

## Root cause
Before loading a model, vLLM calls `request_memory()` to verify the device
has enough free memory. On XPU this goes through `torch.accelerator.get_memory_info`,
which vLLM monkey-patches in `vllm/platforms/xpu.py` to call the
`vllm-xpu-kernels` custom op `torch.ops._C_cache_ops.getMemoryInfo`.

That custom op returns `free = 0` when invoked inside a spawned worker
subprocess (how the multi-process / stage engine launches workers, with
`ZE_AFFINITY_MASK` pinning one card) — even on an otherwise idle device.
vLLM then believes the GPU is full and raises before a single weight is
loaded. It is a false reading, not a real OOM.

## Fix
Replace the broken custom-op query in `get_mem_info_wrapper()` with
PyTorch's native Level-Zero query `torch.xpu.mem_get_info(device)`, which
reports free/total memory correctly inside spawned subprocesses.

