### PR TITLE
[DSv4 Perf] Skip topk and router when not needed, 3.4% E2E TTFT improvement for Decode case

### DIFF
--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -46,6 +46,7 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.models.utils import extract_layer_index
 from vllm.models.deepseek_v4.common.rope import build_deepseek_v4_rope
 from vllm.models.deepseek_v4.compressor import DeepseekCompressor
+from vllm.triton_utils import tl, triton
 from vllm.utils.multi_stream_utils import (
     execute_in_parallel,
     maybe_execute_in_parallel,
@@ -63,6 +64,25 @@ from vllm.v1.kv_cache_interface import (
 )
 
 logger = init_logger(__name__)
+
+
+@triton.jit
+def _fill_short_context_topk_indices(
+    output,
+    positions,
+    TOP_K: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    PADDED_TOP_K: tl.constexpr,
+):
+    # small triton kernel that selects every candidate, -1 otherwise
+    row = tl.program_id(0)
+    offsets = tl.arange(0, PADDED_TOP_K)
+    num_compressed = (tl.load(positions + row) + 1) // COMPRESS_RATIO
+    tl.store(
+        output + row * TOP_K + offsets,
+        tl.where(offsets < num_compressed, offsets, -1),
+        mask=offsets < TOP_K,
+    )
 
 
 def _resolve_dsv4_kv_cache_dtype(
@@ -780,6 +800,29 @@ class DeepseekV4Indexer(nn.Module):
         rotary_emb: nn.Module,
     ) -> torch.Tensor:
         compressor = self.compressor
+
+        attn_metadata = get_forward_context().attn_metadata
+        if isinstance(attn_metadata, dict):
+            indexer_metadata = cast(Any, attn_metadata[self.k_cache.prefix])
+            if indexer_metadata.max_seq_len // self.compress_ratio <= self.topk_tokens:
+                # candidates num smaller than topk, every candidate is selected
+                # but we still need to build k cache
+                compressor(compressed_kv_score, positions, rotary_emb)
+                assert self.topk_indices_buffer is not None
+                num_tokens = (
+                    indexer_metadata.num_decode_tokens
+                    + indexer_metadata.num_prefill_tokens
+                )
+                if num_tokens > 0:
+                    _fill_short_context_topk_indices[(num_tokens,)](
+                        self.topk_indices_buffer,
+                        positions,
+                        TOP_K=self.topk_tokens,
+                        COMPRESS_RATIO=self.compress_ratio,
+                        PADDED_TOP_K=triton.next_power_of_2(self.topk_tokens),
+                        num_warps=8,
+                    )
+                return self.topk_indices_buffer
 
         def wq_b_and_q_quant():
             # ReplicatedLinear returns (output, bias); bias is None.


### PR DESCRIPTION
## Purpose

Skip topk and router when not needed

Originally:

```bash
Input
-> K compressor (and write K cache)
-> Query proj wq_b
-> Query RoPE + quantization
->  calculation for Query-K logits
->  topk logits
-> return index
```

Now

```bash
-> K compressor (and write K cache)
-> directly choose all candidates if candidates num <= topk num
-> return index
```

Part of https://github.com/vllm-project/vllm/issues/45861

## Test

`vllm serve deepseek-ai/DeepSeek-V4-Flash   --tensor-parallel-size 4   --enable-expert-parallel   --attention-backend FLASHMLA_SPARSE_DSV4   --attention-config '{"use_fp4_indexer_cache":true}'   --kv-cache-dtype fp8   --tokenizer-mode deepseek_v4   --all2all-backend allgather_reducescatter   --port 8003`

### Acc

```bash
lm_eval --model  local-completions --model_args "base_url=http://127.0.0.1:8003/v1/completions,model=deepseek-ai/DeepSeek-V4-Flash,num_concurrent=1024" --tasks gsm8k
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9507|±  |0.0060|
|     |       |strict-match    |     5|exact_match|↑  |0.9515|±  |0.0059|
```

### Perf

Max concurrency 1
```bash
vllm bench serve   --model deepseek-ai/DeepSeek-V4-Flash   --dataset-name random   --host 127.0.0.1   --port 8003   --random-input-len 2   --random-output-len 2048   --request-rate inf   --max-concurrency 1   --num-prompts 4   --num-warmups 2   --ignore-eos   --temperature 0   --seed 0

# now
============ Serving Benchmark Result ============
Successful requests:                     4         
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  45.81     
Total input tokens:                      8         
Total generated tokens:                  8192      
Request throughput (req/s):              0.09      
Output token throughput (tok/s):         178.84    
Peak output token throughput (tok/s):    182.00    
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          179.01    
---------------Time to First Token----------------
Mean TTFT (ms):                          40.96     
Median TTFT (ms):                        41.30     
P99 TTFT (ms):                           43.14     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          5.57      
Median TPOT (ms):                        5.57      
P99 TPOT (ms):                           5.58      
---------------Inter-token Latency----------------
Mean ITL (ms):                           5.57      
Median ITL (ms):                         5.55      
P99 ITL (ms):                            5.79      
==================================================

# main
============ Serving Benchmark Result ============
Successful requests:                     4         
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  45.61     
Total input tokens:                      8         
Total generated tokens:                  8192      
Request throughput (req/s):              0.09      
Output token throughput (tok/s):         179.61    
Peak output token throughput (tok/s):    182.00    
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          179.78    
---------------Time to First Token----------------
Mean TTFT (ms):                          42.38     
Median TTFT (ms):                        42.18     
P99 TTFT (ms):                           43.64     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          5.55      
Median TPOT (ms):                        5.55      
P99 TPOT (ms):                           5.56      
---------------Inter-token Latency----------------
Mean ITL (ms):                           5.55      
Median ITL (ms):                         5.52      
P99 ITL (ms):                            5.77      
==================================================
```

heavy decode
```bash
# now
============ Serving Benchmark Result ============
Successful requests:                     128       
Failed requests:                         0         
Benchmark duration (s):                  20.27     
Total input tokens:                      256       
Total generated tokens:                  131072    
Request throughput (req/s):              6.32      
Output token throughput (tok/s):         6467.01   
Peak output token throughput (tok/s):    6656.00   
Peak concurrent requests:                128.00    
Total token throughput (tok/s):          6479.64   
---------------Time to First Token----------------
Mean TTFT (ms):                          222.31    
Median TTFT (ms):                        231.81    
P99 TTFT (ms):                           285.95    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          19.57     
Median TPOT (ms):                        19.56     
P99 TPOT (ms):                           19.63     
---------------Inter-token Latency----------------
Mean ITL (ms):                           19.57     
Median ITL (ms):                         19.44     
P99 ITL (ms):                            21.70     
==================================================

# main
============ Serving Benchmark Result ============
Successful requests:                     128       
Failed requests:                         0         
Benchmark duration (s):                  20.27     
Total input tokens:                      256       
Total generated tokens:                  131072    
Request throughput (req/s):              6.32      
Output token throughput (tok/s):         6466.61   
Peak output token throughput (tok/s):    6656.00   
Peak concurrent requests:                128.00    
Total token throughput (tok/s):          6479.24   
---------------Time to First Token----------------
Mean TTFT (ms):                          229.54    
Median TTFT (ms):                        234.82    
P99 TTFT (ms):                           292.12    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          19.57     
Median TPOT (ms):                        19.56     
P99 TPOT (ms):                           19.63     
---------------Inter-token Latency----------------
Mean ITL (ms):                           19.57     
Median ITL (ms):                         19.53     
P99 ITL (ms):                            21.46     
==================================================
```