### PR TITLE
[Performance][Model] Avoid transient Inkling result allocations (performance, and OOM prevention on smaller memory configurations)

### DIFF
--- a/tests/models/inkling/test_moe_weight_layout.py
+++ b/tests/models/inkling/test_moe_weight_layout.py
@@ -8,53 +8,9 @@ import torch
 
 from vllm.lora.utils import get_supported_lora_modules
 from vllm.model_executor.layers.quantization.modelopt import ModelOptNvFp4Config
-from vllm.models.inkling.nvidia import mlp, moe, ops
+from vllm.models.inkling.nvidia import moe
 from vllm.models.inkling.nvidia.model import _TmlForCausalLMBase
 from vllm.platforms import current_platform
-
-
-def test_dense_mlp_scales_down_projection_output_in_place(monkeypatch) -> None:
-    projected = torch.tensor([[1.5, -2.0]], dtype=torch.bfloat16)
-    before = projected.clone()
-    layer = SimpleNamespace(
-        gate_up_proj=lambda x: (x, None),
-        down_proj=lambda x: (projected, None),
-        global_scale=torch.tensor([0.5], dtype=torch.bfloat16),
-    )
-    monkeypatch.setitem(ops.__dict__, "silu_and_mul_triton", lambda x: x)
-
-    output = mlp.InklingDenseMLP.forward(layer, torch.zeros_like(projected))
-
-    torch.testing.assert_close(output, before * layer.global_scale, rtol=0, atol=0)
-    assert output.data_ptr() == projected.data_ptr()
-
-
-def test_moe_adds_sink_output_to_routed_output_in_place() -> None:
-    x = torch.zeros(2, 2, dtype=torch.bfloat16)
-    logits = torch.zeros(2, 3)
-    weights = torch.tensor([[0.25, 0.75], [0.5, 0.5]])
-    ids = torch.tensor([[0, 2], [1, 2]], dtype=torch.int32)
-    routed = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.bfloat16)
-    sink = torch.tensor([[0.5, -1.0], [2.0, 0.5]], dtype=torch.bfloat16)
-    expected = routed.clone() + sink
-    gate = SimpleNamespace(
-        topk=1,
-        compute_logits=lambda _: logits,
-        select_experts=lambda _: (weights, ids),
-    )
-    layer = SimpleNamespace(
-        gate=gate,
-        experts=lambda **_: routed,
-        sink_experts=lambda *_: sink,
-        _sink_events=(None, None),
-        _sink_stream=None,
-        _routed_sel=None,
-    )
-
-    output = moe.InklingMoE.forward(layer, x)
-
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
-    assert output.data_ptr() == routed.data_ptr()
 
 
 def test_gate_loads_directly_into_padded_runtime_weight() -> None:

--- a/tests/models/inkling/test_moe_weight_layout.py
+++ b/tests/models/inkling/test_moe_weight_layout.py
@@ -8,9 +8,53 @@ import torch
 
 from vllm.lora.utils import get_supported_lora_modules
 from vllm.model_executor.layers.quantization.modelopt import ModelOptNvFp4Config
-from vllm.models.inkling.nvidia import moe
+from vllm.models.inkling.nvidia import mlp, moe, ops
 from vllm.models.inkling.nvidia.model import _TmlForCausalLMBase
 from vllm.platforms import current_platform
+
+
+def test_dense_mlp_scales_down_projection_output_in_place(monkeypatch) -> None:
+    projected = torch.tensor([[1.5, -2.0]], dtype=torch.bfloat16)
+    before = projected.clone()
+    layer = SimpleNamespace(
+        gate_up_proj=lambda x: (x, None),
+        down_proj=lambda x: (projected, None),
+        global_scale=torch.tensor([0.5], dtype=torch.bfloat16),
+    )
+    monkeypatch.setitem(ops.__dict__, "silu_and_mul_triton", lambda x: x)
+
+    output = mlp.InklingDenseMLP.forward(layer, torch.zeros_like(projected))
+
+    torch.testing.assert_close(output, before * layer.global_scale, rtol=0, atol=0)
+    assert output.data_ptr() == projected.data_ptr()
+
+
+def test_moe_adds_sink_output_to_routed_output_in_place() -> None:
+    x = torch.zeros(2, 2, dtype=torch.bfloat16)
+    logits = torch.zeros(2, 3)
+    weights = torch.tensor([[0.25, 0.75], [0.5, 0.5]])
+    ids = torch.tensor([[0, 2], [1, 2]], dtype=torch.int32)
+    routed = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.bfloat16)
+    sink = torch.tensor([[0.5, -1.0], [2.0, 0.5]], dtype=torch.bfloat16)
+    expected = routed.clone() + sink
+    gate = SimpleNamespace(
+        topk=1,
+        compute_logits=lambda _: logits,
+        select_experts=lambda _: (weights, ids),
+    )
+    layer = SimpleNamespace(
+        gate=gate,
+        experts=lambda **_: routed,
+        sink_experts=lambda *_: sink,
+        _sink_events=(None, None),
+        _sink_stream=None,
+        _routed_sel=None,
+    )
+
+    output = moe.InklingMoE.forward(layer, x)
+
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    assert output.data_ptr() == routed.data_ptr()
 
 
 def test_gate_loads_directly_into_padded_runtime_weight() -> None:

--- a/vllm/models/inkling/nvidia/mlp.py
+++ b/vllm/models/inkling/nvidia/mlp.py
@@ -58,6 +58,6 @@ class InklingDenseMLP(nn.Module):
         x = silu_and_mul_triton(gate_up)
         x, _ = self.down_proj(x)
         if self.global_scale is not None:
-            x = x * self.global_scale
+            x.mul_(self.global_scale)
         # TP-partial output: the layer's reduce-scatter fallback consumes it.
         return x

--- a/vllm/models/inkling/nvidia/moe.py
+++ b/vllm/models/inkling/nvidia/moe.py
@@ -528,7 +528,7 @@ class InklingMoE(nn.Module):
         )
         self._routed_sel = None
 
-        return out + sink_out
+        return out.add_(sink_out)
 
     # -- weight loading ----------------------------------------------------
 


### PR DESCRIPTION
## Purpose

Inkling currently performs two required output operations using out-of-place
expressions. In the tested H100 configuration, each allocates an unnecessary
temporary tensor:

- Applying `global_scale` to the dense-MLP output allocates an 86 MiB
  temporary.
- Adding the sink-expert output to the routed MoE output allocates a 94 MiB
  temporary.

Both destination buffers are private and have no remaining consumers, so the
operations can safely be performed in place. This PR changes the expressions
to `x.mul_(self.global_scale)` and `out.add_(sink_out)` without changing tensor
shapes, dtypes, or arithmetic.

This is required to run the tested 8×H100 TP8 8K→1K high-concurrency
configuration without OOM. The benefit is general rather than H100-specific:
every affected invocation reuses an existing result buffer, reducing peak
memory and allocator traffic on hardware and workloads that have more
headroom as well.

The operations are safe because:

- `down_proj` produces a fresh tensor that is scaled and immediately returned.
- The routed MoE output is private, and all routed/sink stream work has joined
  before the addition.
- vLLM executes this path under inference mode, so no autograd-saved tensor is
  mutated.
- Both operations preserve the original dtype, shape, and arithmetic.

No open PR was found implementing either change.

## Test Plan

### Unit tests

Verify numerical equivalence and confirm that both operations reuse the
destination storage:

```bash
.venv/bin/python -m pytest -q \
  --confcutdir=tests/models/inkling \
  tests/models/inkling/test_moe_weight_layout.py \
  -k "dense_mlp_scales_down_projection_output_in_place or moe_adds_sink_output_to_routed_output_in_place"
```

Run repository checks:

```bash
pre-commit run --files \
  vllm/models/inkling/nvidia/mlp.py \
  vllm/models/inkling/nvidia/moe.py \
  tests/models/inkling/test_moe_weight_layout.py
```

### H100 before/after integration test

Start the H100 server directly with vLLM:

```bash
PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
vllm serve thinkingmachines/Inkling-NVFP4 \
  --host 0.0.0.0 \
  --port 8000 \
  --served-model-name thinkingmachines/Inkling-NVFP4 \
  --tensor-parallel-size 8 \
  --tokenizer-mode inkling \
  --trust-remote-code \
  --dtype bfloat16 \
  --load-format auto \
  --max-model-len 9216 \
  --max-num-seqs 128 \
  --max-num-batched-tokens 7936 \
  --enable-chunked-prefill \
  --max-cudagraph-capture-size 16 \
  --kv-cache-memory-bytes 3100000000 \
  --kv-cache-dtype auto \
  --language-model-only \
  --no-enable-prefix-caching \
  --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}'
```

For H200, use the same model with its larger measured scheduling envelope:

```bash
vllm serve thinkingmachines/Inkling-NVFP4 \
  --host 0.0.0.0 \
  --port 8000 \
  --served-model-name thinkingmachines/Inkling-NVFP4 \
  --tensor-parallel-size 8 \
  --tokenizer-mode inkling \
  --trust-remote-code \
  --dtype bfloat16 \
  --load-format auto \
  --max-model-len 9280 \
  --max-num-seqs 1024 \
  --max-num-batched-tokens 16384 \
  --enable-chunked-prefill \
  --gpu-memory-utilization 0.95 \
  --kv-cache-dtype auto \
  --language-model-only \
  --no-enable-prefix-caching \
  --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}'
```

Do not set `--block-size`. The default 16-token attention block preserves
Inkling's effective four-token convolution-cache page. Forcing block size 128
changes that page to 32 and is not a valid Inkling configuration.

Run the 8K→1K workload directly with vLLM at concurrency 256:

```bash
vllm bench serve \
  --backend vllm \
  --base-url http://127.0.0.1:8000 \
  --endpoint /v1/completions \
  --model thinkingmachines/Inkling-NVFP4 \
  --tokenizer-mode inkling \
  --dataset-name random \
  --random-input-len 8192 \
  --random-output-len 1024 \
  --random-range-ratio 0.8 \
  --ignore-eos \
  --request-rate inf \
  --num-prompts 256 \
  --max-concurrency 256 \
  --seed 0 \
  --save-result \
  --result-dir results \
  --result-filename inkling-8k1k-c256.json
```

Then run concurrency 512:

```bash
vllm bench serve \
  --backend vllm \
  --base-url http://127.0.0.1:8000 \
  --endpoint /v1/completions \
  --model thinkingmachines/Inkling-NVFP4 \
  --tokenizer-mode inkling \
  --dataset-name random \
  --random-input-len 8192 \
  --random-output-len 1024 \
  --random-range-ratio 0.8 \
  --ignore-eos \
  --request-rate inf \
  --num-prompts 512 \
  --max-concurrency 512 \
  --seed 0 \
  --save-result \
  --result-dir results \
  --result-filename inkling-8k1k-c512.json
```

Run the same H100 server and benchmark commands on the parent commit and this
PR. Keep the checkpoint and all runtime parameters fixed.

### GSM8K

Run all 1,319 GSM8K samples through vLLM's raw-completions evaluator:

```bash
.venv/bin/python tests/evals/gsm8k/gsm8k_eval.py \
  --host http://127.0.0.1 \
  --port 8000 \
  --num-questions 1319 \
  --num-shots 8 \
  --max-tokens 1024 \
  --temperature 0.6 \
  --seed 42 \
  --max-concurrency 4 \
  --save-results results/inkling-gsm8k.json
```

## Test Result

### Unit and repository tests

```text
2 passed, 15 warnings in 18.35s
```

All pre-commit checks passed, including Ruff, formatting, mypy,
forbidden-import checks, and SPDX validation.

### H100 OOM reproduction and fix

| Build | Result |
|---|---|
| Parent commit | Model loaded, captured graphs, passed endpoint verification and a real prompt, then failed during the first concurrency-256 benchmark at `return out + sink_out`: `CUDA out of memory. Tried to allocate 94.00 MiB ... 101.00 MiB is free.` |
| This PR | Completed the full concurrency-256 and concurrency-512 sweep with zero request errors. |

Patched results:

| Concurrency | Requests | Input tokens | Output tokens | Output throughput |
|---:|---:|---:|---:|---:|
| 256 | 256/256 | 1,886,245 | 235,096 | 361.89 tok/s |
| 512 | 512/512 | 3,776,930 | 473,911 | 358.04 tok/s |

The dense-MLP temporary was independently reproduced during a real prompt:
`x = x * self.global_scale` attempted to allocate 86 MiB and OOMed with
97–101 MiB free.

### GSM8K

The same Inkling checkpoint and runtime produced:

| Metric | Result |
|---|---:|
| Completed, nonempty samples | 1,319/1,319 |
| Strict accuracy | 1,169/1,319 = 0.8863 |
| Flexible accuracy | 1,172/1,319 = 0.8886 |
| Strict invalid responses | 1 |
| Flexible invalid responses | 0 |

Using the same raw-completions evaluator workflow,
[@mgoin's merged ModelOpt PR #48990](https://github.com/vllm-project/vllm/pull/48990)
reported `0.892` accuracy and `0.001` invalid responses on 4×B300.

The unit tests verify numerical equivalence, and the 8K→1K benchmark validates
the changed code end to end with CUDA graphs.

No documentation change is required because this PR changes only internal
result-buffer reuse and introduces no user-facing configuration or API.

AI assistance was used in preparing this change.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose and H100 OOM are described.
- [x] Unit and full-model test processes are provided.
- [x] Before/after integration and GSM8K results are included.
- [x] No documentation update is required.
</details>