### PR TITLE
[Bugfix] Make shared NVFP4 MoE scales writable

### DIFF
--- a/tests/quantization/test_trtllm_nvfp4_hidden_dim_padding.py
+++ b/tests/quantization/test_trtllm_nvfp4_hidden_dim_padding.py
@@ -1,11 +1,53 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import torch
 
+from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import NvFp4MoeBackend
+from vllm.model_executor.layers.quantization.utils import flashinfer_fp4_moe
+from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
+    prepare_nvfp4_moe_layer_for_fi_or_cutlass,
+)
 from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
     align_trtllm_fp4_moe_hidden_dim_for_fi,
 )
+
+
+def test_shared_nvfp4_input_scales_have_writable_storage(monkeypatch):
+    monkeypatch.setattr(flashinfer_fp4_moe, "swizzle_blockscale", lambda x: x)
+
+    num_experts = 3
+    layer = SimpleNamespace(activation=SimpleNamespace(is_gated=False))
+    w13 = torch.zeros((num_experts, 2, 1), dtype=torch.uint8)
+    w2 = torch.zeros((num_experts, 2, 1), dtype=torch.uint8)
+    w13_scale = torch.zeros((num_experts, 2, 1), dtype=torch.float8_e4m3fn)
+    w2_scale = torch.zeros((num_experts, 2, 1), dtype=torch.float8_e4m3fn)
+    weight_scale = torch.ones(num_experts)
+
+    outputs = prepare_nvfp4_moe_layer_for_fi_or_cutlass(
+        backend=NvFp4MoeBackend.FLASHINFER_CUTLASS,
+        layer=layer,
+        w13=w13,
+        w13_scale=w13_scale,
+        w13_scale_2=weight_scale,
+        a13_scale=torch.tensor([1.0, 2.0, 3.0]),
+        w2=w2,
+        w2_scale=w2_scale,
+        w2_scale_2=weight_scale,
+        a2_scale=torch.tensor([4.0, 5.0, 6.0]),
+        is_act_and_mul=False,
+    )
+    a13_scale, a2_scale = outputs[3], outputs[7]
+
+    torch.testing.assert_close(a13_scale, torch.full((num_experts,), 3.0))
+    torch.testing.assert_close(a2_scale, torch.full((num_experts,), 6.0))
+    distinct_values = torch.arange(num_experts, dtype=torch.float32)
+    a13_scale.copy_(distinct_values)
+    a2_scale.copy_(distinct_values)
+    torch.testing.assert_close(a13_scale, distinct_values)
+    torch.testing.assert_close(a2_scale, distinct_values)
 
 
 def test_align_trtllm_fp4_moe_hidden_dim_noop():

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -109,8 +109,8 @@ def prepare_nvfp4_moe_layer_for_flashinfer_cutedsl(
 
     # Global scaling factors (same as other FlashInfer backends).
     num_experts = w13.shape[0]
-    a13_scale = a13_scale.max().to(torch.float32).expand(num_experts)
-    a2_scale = a2_scale.max().to(torch.float32).expand(num_experts)
+    a13_scale = a13_scale.max().to(torch.float32).repeat(num_experts)
+    a2_scale = a2_scale.max().to(torch.float32).repeat(num_experts)
 
     half = w13.shape[1] // 2
     w13 = torch.cat([w13[:, half:], w13[:, :half]], dim=1)
@@ -338,8 +338,8 @@ def prepare_nvfp4_moe_layer_for_fi_or_cutlass(
     # For some FI kernels, the input scales are shared by all experts.
     if is_global_sf_supported_for_nvfp4_backend(backend):
         num_experts = w13.shape[0]
-        a13_scale = a13_scale.max().to(torch.float32).expand(num_experts)
-        a2_scale = a2_scale.max().to(torch.float32).expand(num_experts)
+        a13_scale = a13_scale.max().to(torch.float32).repeat(num_experts)
+        a2_scale = a2_scale.max().to(torch.float32).repeat(num_experts)
     else:
         a13_scale = a13_scale.max(dim=1).values.to(torch.float32)
 


### PR DESCRIPTION
FlashInfer NVFP4 backends broadcast shared input scales with expand, leaving registered parameters backed by overlapping stride-zero storage. Layerwise reload cannot copy regenerated values into those parameters.

Materialize independent per-expert scale storage and cover the copy-back operation with a focused regression test.

Assisted-by: OpenAI Codex

Without this, NVFP4 online quantization of Qwen3 30B A3B fails with

```(EngineCore pid=1004) ERROR 07-22 21:57:34 [core.py:1548]     _layerwise_process(layer, info)
(EngineCore pid=1004) ERROR 07-22 21:57:34 [core.py:1548]   File "/app/.venv/lib/python3.12/site-packages/vllm/model_executor/model_loader/reload/layerwise.py", line 376, in _layerwise_process
(EngineCore pid=1004) ERROR 07-22 21:57:34 [core.py:1548]     _copy_and_restore_kernel_tensors(layer, info)
(EngineCore pid=1004) ERROR 07-22 21:57:34 [core.py:1548]   File "/app/.venv/lib/python3.12/site-packages/vllm/model_executor/model_loader/reload/layerwise.py", line 403, in _copy_and_restore_kernel_tensors
(EngineCore pid=1004) ERROR 07-22 21:57:34 [core.py:1548]     param.data.copy_(getattr(layer, name))
(EngineCore pid=1004) ERROR 07-22 21:57:34 [core.py:1548]   File "/app/.venv/lib/python3.12/site-packages/torch/utils/_device.py", line 116, in __torch_function__
(EngineCore pid=1004) ERROR 07-22 21:57:34 [core.py:1548]     return func(*args, **kwargs)
(EngineCore pid=1004) ERROR 07-22 21:57:34 [core.py:1548]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=1004) ERROR 07-22 21:57:34 [core.py:1548] RuntimeError: unsupported operation: more than one element of the written-to tensor refers to a single memory location. Please clone() the tensor before performing the operation.
```

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

