### PR TITLE
[Bugfix][Spec Decode] Enable Step-3.7-Flash (Step3p7) MTP on Model Runner V2

### DIFF
--- a/vllm/model_executor/models/step3p5.py
+++ b/vllm/model_executor/models/step3p5.py
@@ -303,7 +303,7 @@ class FusedMoEBlock(nn.Module):
 
         self.ep_size = get_ep_group().device_group.size()
         self.ep_rank = get_ep_group().device_group.rank()
-        config = vllm_config.model_config.hf_config
+        config = vllm_config.model_config.hf_config.get_text_config()
         quant_config = vllm_config.quant_config
         parallel_config = vllm_config.parallel_config
 
@@ -419,7 +419,7 @@ class Step3p5DecoderLayer(nn.Module):
         prefix: str = "",
     ) -> None:
         super().__init__()
-        config = vllm_config.model_config.hf_config
+        config = vllm_config.model_config.hf_config.get_text_config()
         self.hidden_size = config.hidden_size
         layer_idx = extract_layer_index(prefix)
         self.layer_idx = layer_idx
@@ -550,7 +550,7 @@ class Step3p5Model(nn.Module):
         super().__init__()
 
         self.vllm_config = vllm_config
-        config = vllm_config.model_config.hf_config
+        config = vllm_config.model_config.hf_config.get_text_config()
         self.vocab_size = config.vocab_size
         self.config = config
 
@@ -899,7 +899,7 @@ class Step3p5ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts):
         prefix: str = "",
     ):
         super().__init__()
-        config = vllm_config.model_config.hf_config
+        config = vllm_config.model_config.hf_config.get_text_config()
         self.model = Step3p5Model(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )

--- a/vllm/model_executor/models/step3p5_mtp.py
+++ b/vllm/model_executor/models/step3p5_mtp.py
@@ -47,7 +47,7 @@ class Step3p5AMultiTokenPredictorLayer(nn.Module):
         prefix: str,
     ) -> None:
         super().__init__()
-        config = vllm_config.model_config.hf_config
+        config = vllm_config.model_config.hf_config.get_text_config()
         quant_config = vllm_config.quant_config
         self.enorm = GemmaRMSNorm(config.hidden_size, config.rms_norm_eps)
         self.hnorm = GemmaRMSNorm(config.hidden_size, config.rms_norm_eps)
@@ -81,7 +81,7 @@ class Step3p5AMultiTokenPredictorLayer(nn.Module):
 class Step3p5AMultiTokenPredictor(nn.Module):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
-        config = vllm_config.model_config.hf_config
+        config = vllm_config.model_config.hf_config.get_text_config()
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
@@ -142,7 +142,7 @@ class Step3p5AMultiTokenPredictor(nn.Module):
 class Step3p5MTP(nn.Module):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
-        self.config = vllm_config.model_config.hf_config
+        self.config = vllm_config.model_config.hf_config.get_text_config()
         self.vllm_config = vllm_config
         self.model = Step3p5AMultiTokenPredictor(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")

--- a/vllm/model_executor/models/step3p5_mtp.py
+++ b/vllm/model_executor/models/step3p5_mtp.py
@@ -144,8 +144,15 @@ class Step3p5MTP(nn.Module):
         super().__init__()
         self.config = vllm_config.model_config.hf_config.get_text_config()
         self.vllm_config = vllm_config
+        # For VLM targets (Step-3.7 / Step3p7), the MTP drafter's modules live
+        # under ``language_model.model`` in the checkpoint. Prefix them the same
+        # way so the drafter's weight names and its entries in the (VLM-qualified)
+        # quantization exclusion list line up. Otherwise the drafter's excluded
+        # projections (e.g. the head-wise ``g_proj``) are wrongly FP8-block-quantized
+        # and fail to build on Model Runner V2.
         self.model = Step3p5AMultiTokenPredictor(
-            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "language_model.model"),
         )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Summary

Enable **Step-3.7-Flash (`Step3p7`, a VLM) MTP speculative decoding on Model Runner V2.** Two small drafter fixes; without them `VLLM_USE_V2_MODEL_RUNNER=1` crashes during draft-model construction (blocking the single-CUDA-graph multi-step draft from #29559 for this model).

### 1. Resolve the drafter's config from the text config (`get_text_config()`) — 7 sites
The Step3p5 MTP drafter reads text-model fields (`vocab_size`, `att_impl_type`, `num_nextn_predict_layers`, …) off `vllm_config.model_config.hf_config`, which for a VLM target is the top-level `Step3p7Config` → `AttributeError: 'Step3p7Config' object has no attribute 'vocab_size'` (then `att_impl_type`). Resolve via `get_text_config()` (returns the text sub-config for VLMs, `self` otherwise — idempotent for non-VLM).

### 2. Prefix the drafter under `language_model.model` for VLM targets — 1 site
The checkpoint names the MTP modules (and qualifies the FP8 quant `modules_to_not_convert` list) under `language_model.model.layers.<45..47>.mtp_block.…`, but the drafter built them under `model.…`. So the drafter's *excluded* projections — e.g. the tiny head-wise `g_proj` — were wrongly FP8-block-quantized → `ValueError: output_partition_size = 24 is not divisible by block_n = 128`. Prefixing the drafter under `language_model.model` lines up its weight names and quant exclusions with the checkpoint.

## Validation (4×H100, `VLLM_USE_V2_MODEL_RUNNER=1`, TP4, MTP=2)

- **Before:** crashes in draft construction (`AttributeError`, then the `g_proj` `ValueError`).
- **After (this PR), full end-to-end:**
  - construction + CUDA-graph capture (PIECEWISE + FULL) + speculator capture ✓
  - real FP8 weights load cleanly (no missing/unexpected keys) ✓
  - coherent generation ✓
  - **MTP mean acceptance length 2.25** (matches Model Runner V1) ✓

## Note on the prefix

`language_model.model` is correct for `Step3p7` (the VLM that ships this MTP drafter). If `Step3p5MTP` is ever reused for a non-VLM target, this should be derived from the target's language-model prefix rather than hardcoded — happy to adjust to whatever approach reviewers prefer.
