### PR TITLE
Add quantization label automation

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -181,6 +181,18 @@ pull_request_rules:
       add:
         - performance
 
+- name: label-quantization
+  description: Automatically apply quantization label
+  conditions:
+    - label != stale
+    - or:
+      - files~=^vllm/model_executor/layers/quantization/
+      - title~=(?i)quant
+  actions:
+    label:
+      add:
+        - quantization
+
 - name: label-qwen
   description: Automatically apply qwen label
   conditions:

--- a/.github/workflows/issue_autolabel.yml
+++ b/.github/workflows/issue_autolabel.yml
@@ -130,6 +130,18 @@ jobs:
                   },
                 ],
               },
+              quantization: {
+                keywords: [
+                  {
+                    term: "quantization",
+                    searchIn: "both"
+                  },
+                  {
+                    term: "quantized",
+                    searchIn: "both"
+                  },
+                ],
+              },
               "intel-gpu": {
                 // Keyword search - matches whole words only (with word boundaries)
                 keywords: [


### PR DESCRIPTION
## Summary

- label PRs that touch the core quantization directory or contain `quant` in the title
- label issues containing the whole words `quantization` or `quantized`

## Why

The existing `quantization` label had no automatic PR or issue application, so relevant work was under-labeled. Searches for open PRs about quantization label and issue-autolabel automation found no duplicate change.

## Impact

Quantization-related PRs and issues will be routed to the existing label with conservative matching.

## Testing

- `git diff --check`
- YAML parsing with PyYAML
- `.venv/bin/pre-commit run --files .github/mergify.yml .github/workflows/issue_autolabel.yml`

All checks passed. Model evaluations are not applicable because this only changes GitHub labeling automation.

AI assistance was used to implement and validate this change. The submitting human must review every changed line and understand and defend the change end-to-end.