### PR TITLE
[Performance] Skip redundant full-fit admission pass

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3648,6 +3648,48 @@ def test_can_fit_full_sequence_full_attention_still_gates_oversized():
     assert manager.allocate_slots(req, block_size, full_sequence_must_fit=True) is None
 
 
+@pytest.mark.parametrize(
+    "schedule_full_sequence,expected_admission_flags",
+    [(True, [False]), (False, [True, False])],
+)
+def test_full_sequence_admission_skips_only_redundant_coordinator_pass(
+    monkeypatch, schedule_full_sequence, expected_admission_flags
+):
+    block_size = 16
+    prompt_len = 8 * block_size
+    manager = make_kv_cache_manager(
+        make_kv_cache_config(block_size, num_blocks=64),
+        max_model_len=1024,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    req = make_request("test", list(range(prompt_len)), block_size, sha256)
+
+    admission_flags = []
+    get_num_blocks_to_allocate = manager.coordinator.get_num_blocks_to_allocate
+
+    def track_admission_pass(*args, **kwargs):
+        admission_flags.append(kwargs.get("apply_admission_cap", False))
+        return get_num_blocks_to_allocate(*args, **kwargs)
+
+    monkeypatch.setattr(
+        manager.coordinator,
+        "get_num_blocks_to_allocate",
+        track_admission_pass,
+    )
+    num_new_tokens = prompt_len if schedule_full_sequence else block_size
+
+    assert (
+        manager.allocate_slots(
+            req,
+            num_new_tokens,
+            full_sequence_must_fit=True,
+        )
+        is not None
+    )
+    assert admission_flags == expected_admission_flags
+
+
 def test_cache_hit_local_and_external():
     # Regression test for #33775: when a request hits the local prefix cache
     # in one KV cache group and needs external (connector) blocks in another,

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -466,22 +466,28 @@ class KVCacheManager:
             watermark_blocks = self.watermark_blocks
 
         if full_sequence_must_fit:
-            # First check and fail if the full request sequence won't fit.
+            # Skip the separate admission pass when this step already covers
+            # the full remaining sequence. The normal allocation check below
+            # will make the same capacity decision in that case.
             full_num_tokens = min(request.num_tokens, self.max_model_len)
-
-            num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
-                request_id=request.request_id,
-                num_tokens=full_num_tokens,
-                new_computed_blocks=new_computed_block_list,
-                num_encoder_tokens=num_encoder_tokens,
-                total_computed_tokens=total_computed_tokens,
-                num_local_computed_tokens=num_local_computed_tokens,
-                num_tokens_main_model=full_num_tokens,
-                apply_admission_cap=True,
+            remaining_sequence_tokens = max(
+                0,
+                full_num_tokens - total_computed_tokens,
             )
-            required_blocks = num_blocks_to_allocate + watermark_blocks
-            if required_blocks > self.block_pool.get_num_free_blocks():
-                return None
+            if num_new_tokens < remaining_sequence_tokens:
+                num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
+                    request_id=request.request_id,
+                    num_tokens=full_num_tokens,
+                    new_computed_blocks=new_computed_block_list,
+                    num_encoder_tokens=num_encoder_tokens,
+                    total_computed_tokens=total_computed_tokens,
+                    num_local_computed_tokens=num_local_computed_tokens,
+                    num_tokens_main_model=full_num_tokens,
+                    apply_admission_cap=True,
+                )
+                required_blocks = num_blocks_to_allocate + watermark_blocks
+                if required_blocks > self.block_pool.get_num_free_blocks():
+                    return None
 
         num_tokens_main_model = total_computed_tokens + num_new_tokens
         num_tokens_need_slot = min(


### PR DESCRIPTION
## Summary

- skip the separate full-sequence admission coordinator pass when the current scheduler step already covers every remaining sequence token
- keep the admission-cap precheck unchanged for chunked prefill
- add call-count coverage for both cases

This is a current-main extraction and revalidation of the narrow mechanism from [vLLM-HUST/vllm-hust#54](https://github.com/vLLM-HUST/vllm-hust/pull/54). Later HUST admission and watermark refactors are intentionally excluded.

## Why this is safe

When `num_new_tokens` covers the full remaining sequence, the normal allocation path immediately below checks capacity for the same main-model token extent. If the sequence is only partially scheduled, the recycling-aware admission-cap pass is still required and remains unchanged.

The new parameterized test verifies the coordinator calls directly:

- full remaining sequence: one normal allocation pass (`[False]`)
- chunked prefill: admission-cap plus normal allocation (`[True, False]`)

Existing SWA admission-cap and oversized full-attention rejection tests also pass.

## Component benchmark

CPU-side coordinator timing on aarch64 with one KV-cache group, 11 repeats and 20,000 calls per sample:

| Path | Median |
|---|---:|
| Admission pass + allocation pass | 10.425 us |
| Allocation pass only | 4.875 us |
| Saved on affected admission | 5.550 us (2.14x subpath speedup) |

This is per-request CPU admission-path evidence; no end-to-end throughput improvement is claimed.

## Validation

Validated against vLLM `b44311b6ef9232d1f345f4b55adef7abc223f0e7`.

- `ruff check vllm/v1/core/kv_cache_manager.py tests/v1/core/test_prefix_caching.py`
- `ruff format --check vllm/v1/core/kv_cache_manager.py tests/v1/core/test_prefix_caching.py`
- `python -m pytest -q --confcutdir=tests/v1/core tests/v1/core/test_prefix_caching.py -k 'full_sequence'` (`4 passed`)
- `git diff --check`

The explicit `--confcutdir` avoids an unrelated local NPU allocator teardown issue after CPU tests; all four test bodies also passed under the repository-root configuration before that teardown error.
\n\n### Current-head validation (2026-07-26)\n\n- Rebased onto upstream `main` `0ba2aa35a81dcc3246b26291368b53fa2389c7d7`.\n- Exact PR head: `009f05a8daf770cfc1845772a8b4daf4a3628ee7`.\n- Focused full-sequence suite passed in the CANN 9.0.0 container: 4 passed, 87 deselected.\n- Fresh exact-head 11 x 20,000-call component timing: 10.336 us -> 4.842 us median, saving 5.494 us (2.135x subpath speedup). No end-to-end throughput claim is made.\n- Ruff check, Ruff format check, and `git diff --check` passed.\n\n\n## Contribution disclosure\n\n- Duplicate-work check: searches for `redundant full-fit admission` and `KV cache admission pass` found no open PR implementing this same fast path; the broader KV admission PRs address different correctness/offload cases.\n- AI assistance was used for implementation support, test execution, rebase maintenance, and drafting this description. The human submitter remains responsible for reviewing and defending the change.\n