### PR TITLE
Fix Humming W4 packing for dense INT4 weights

### DIFF
--- a/tests/quantization/test_humming_int4_packing.py
+++ b/tests/quantization/test_humming_int4_packing.py
@@ -1,0 +1,38 @@
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.utils.humming_utils import (
+    pack_signed_int4_to_uint4_int32,
+)
+
+
+def test_pack_signed_int4_to_uint4_int32() -> None:
+    codes = torch.tensor(
+        [[-8, -7, -1, 0, 1, 6, 7, -3], [7, 6, 5, 4, 3, 2, 1, 0]],
+        dtype=torch.int8,
+    )
+
+    packed = pack_signed_int4_to_uint4_int32(codes)
+
+    assert packed.dtype == torch.int32
+    assert packed.shape == (2, 1)
+    unpacked = torch.stack(
+        [((packed >> (4 * lane)) & 0xF).to(torch.int8) - 8 for lane in range(8)],
+        dim=-1,
+    ).reshape_as(codes)
+    assert torch.equal(unpacked, codes)
+
+
+@pytest.mark.parametrize(
+    ("codes", "message"),
+    [
+        (torch.zeros(2, 7, dtype=torch.int8), "K divisible by 8"),
+        (torch.tensor([[-9] + [0] * 7], dtype=torch.int8), "outside"),
+        (torch.zeros(2, 8, dtype=torch.int16), "INT8 tensor"),
+    ],
+)
+def test_pack_signed_int4_to_uint4_int32_rejects_invalid_input(
+    codes: torch.Tensor, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        pack_signed_int4_to_uint4_int32(codes)

--- a/vllm/model_executor/kernels/linear/mixed_precision/humming.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/humming.py
@@ -29,6 +29,7 @@ class HummingLinearKernel(MPLinearKernel):
         from vllm.model_executor.layers.quantization.utils.humming_utils import (
             convert_linear_layer_to_humming_standard,
             get_humming_linear_compute_config,
+            pack_signed_int4_to_uint4_int32,
             prepare_humming_linear_layer_config,
         )
 
@@ -44,6 +45,10 @@ class HummingLinearKernel(MPLinearKernel):
             assert self.w_zp_name is not None
             name_map["zero_point"] = self.w_zp_name
             quant_config["has_zero_point"] = True
+
+        weight = getattr(layer, self.w_q_name)
+        if self.config.weight_type.size_bits == 4 and weight.dtype == torch.int8:
+            weight.data = pack_signed_int4_to_uint4_int32(weight.data)
 
         convert_linear_layer_to_humming_standard(layer=layer, name_map=name_map)
         input_quant_config = getattr(layer, "_humming_input_quant_config", None)

--- a/vllm/model_executor/layers/quantization/utils/humming_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/humming_utils.py
@@ -444,6 +444,22 @@ def convert_linear_layer_to_humming_standard(
         setattr(layer, name, param)
 
 
+def pack_signed_int4_to_uint4_int32(weight: torch.Tensor) -> torch.Tensor:
+    """Pack dense signed INT4 codes for Humming's unsigned-nibble schema."""
+    if weight.dtype != torch.int8 or weight.ndim < 2:
+        raise ValueError("signed INT4 weights must use an INT8 tensor")
+    if weight.shape[-1] % 8 != 0:
+        raise ValueError("signed INT4 packing requires K divisible by 8")
+    if bool(torch.any((weight < -8) | (weight > 7)).item()):
+        raise ValueError("signed INT4 weights contain codes outside [-8, 7]")
+
+    unsigned = (weight.to(torch.int32) + 8).reshape(*weight.shape[:-1], -1, 8)
+    packed = torch.zeros(unsigned.shape[:-1], dtype=torch.int32, device=weight.device)
+    for lane in range(8):
+        packed.bitwise_or_(unsigned[..., lane] << (lane * 4))
+    return packed
+
+
 def prepare_humming_linear_layer_config(
     layer: LinearBase,
     quant_config: dict,


### PR DESCRIPTION
### Summary

Fix Humming W4 loading when the checkpoint weight is stored as dense signed INT4 codes in an `int8` tensor.

The existing post-load path reinterprets the weight tensor as `int32`. That works for weights that are already packed, but it is not correct for dense W4 codes. Reinterpreting an `[N, K]` `int8` tensor as `int32` groups four bytes per element and produces `[N, K / 4]`. Humming W4 expects eight 4-bit lanes per `int32`, so dense W4 codes need to be packed to `[N, K / 8]` before the standard Humming preparation step.

This change adds that conversion only for W4 weights loaded as `torch.int8`:

- validate the dense codes are in the signed INT4 range `[-8, 7]`
- convert them to unsigned nibble values with `+8`
- pack eight 4-bit lanes into one `int32`
- keep existing packed `int32` weights and non-W4 paths unchanged

### Tests

```bash
ruff check \
  vllm/model_executor/layers/quantization/utils/humming_utils.py \
  vllm/model_executor/kernels/linear/mixed_precision/humming.py \
  tests/quantization/test_humming_int4_packing.py

ruff format --check \
  vllm/model_executor/layers/quantization/utils/humming_utils.py \
  vllm/model_executor/kernels/linear/mixed_precision/humming.py \
  tests/quantization/test_humming_int4_packing.py

python -m py_compile \
  vllm/model_executor/layers/quantization/utils/humming_utils.py \
  vllm/model_executor/kernels/linear/mixed_precision/humming.py \
  tests/quantization/test_humming_int4_packing.py

PYTHONPATH=. python -m pytest tests/quantization/test_humming_int4_packing.py -q
PYTHONPATH=. python -m pytest tests/quantization/test_humming_ignore.py -q
PYTHONPATH=. python -m pytest \
  'tests/quantization/test_compressed_tensors.py::test_scheme_selection[w4a8o8_group]' \
  'tests/quantization/test_compressed_tensors.py::test_scheme_selection[w4_pack]' \
  -q
```
