### PR TITLE
perf(structured-output): cache Guidance grammar serialization

### DIFF
--- a/tests/v1/structured_output/test_backend_guidance.py
+++ b/tests/v1/structured_output/test_backend_guidance.py
@@ -14,10 +14,36 @@ from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.tokenizers import get_tokenizer
 from vllm.v1.request import Request
 from vllm.v1.structured_output import StructuredOutputManager
-from vllm.v1.structured_output.backend_guidance import GuidanceBackend
+from vllm.v1.structured_output.backend_guidance import (
+    GuidanceBackend,
+    _cached_serialize_guidance_grammar,
+)
 from vllm.v1.structured_output.backend_types import StructuredOutputOptions
 
 TOKENIZER = "openai-community/gpt2"
+
+
+def test_guidance_grammar_serialization_cache():
+    _cached_serialize_guidance_grammar.cache_clear()
+    grammar_spec = '{"type":"object","properties":{"value":{"type":"string"}}}'
+
+    first = _cached_serialize_guidance_grammar(
+        StructuredOutputOptions.JSON,
+        grammar_spec,
+        False,
+        True,
+    )
+    second = _cached_serialize_guidance_grammar(
+        StructuredOutputOptions.JSON,
+        grammar_spec,
+        False,
+        True,
+    )
+
+    assert first is second
+    assert _cached_serialize_guidance_grammar.cache_info().hits == 1
+    assert _cached_serialize_guidance_grammar.cache_info().misses == 1
+    _cached_serialize_guidance_grammar.cache_clear()
 
 
 @pytest.fixture(scope="module")

--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -5,6 +5,7 @@ import copy
 import json
 import os
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -31,6 +32,21 @@ else:
     llguidance_torch = LazyLoader("llguidance.torch", globals(), "llguidance.torch")
 
 logger = init_logger(__name__)
+
+
+@lru_cache(maxsize=256)
+def _cached_serialize_guidance_grammar(
+    request_type: StructuredOutputOptions,
+    grammar_spec: str,
+    disable_any_whitespace: bool,
+    disable_additional_properties: bool,
+) -> str:
+    return serialize_guidance_grammar(
+        request_type,
+        grammar_spec,
+        disable_any_whitespace,
+        disable_additional_properties,
+    )
 
 
 def _walk_json_for_additional_properties(data: object):
@@ -108,7 +124,7 @@ class GuidanceBackend(StructuredOutputBackend):
     def compile_grammar(
         self, request_type: StructuredOutputOptions, grammar_spec: str
     ) -> StructuredOutputGrammar:
-        self.serialized_grammar = serialize_guidance_grammar(
+        self.serialized_grammar = _cached_serialize_guidance_grammar(
             request_type,
             grammar_spec,
             self.disable_any_whitespace,


### PR DESCRIPTION
## Summary

Cache Guidance grammar serialization for repeated structured-output schemas. The
cache is bounded to 256 entries and stores only the immutable serialized grammar
string. Every compilation still constructs a fresh `LLMatcher`, so per-request
matcher/parser state is not shared.

The existing `GuidanceBackend.serialized_grammar` attribute is preserved.

## Performance

Revalidated after rebasing exact candidate
`8e15432e2c1d7f5f9da1e67bdcd548a075296620` onto upstream main
`0ba2aa35a81dcc3246b26291368b53fa2389c7d7`.

Qwen3-0.6B tokenizer, repeated JSON schema compilation, 15 repetitions; median
microseconds per complete `compile_grammar` call (lower is better):

| Schema properties | Main | Cached | Reduction |
|---:|---:|---:|---:|
| 32 | 1792.632 us | 1441.379 us | 19.6% |
| 256 | 12405.950 us | 10211.606 us | 17.7% |
| 1024 | 64622.116 us | 54672.742 us | 15.4% |

Serialization alone dropped from 280.381/2135.314/8836.007 us to
0.900/0.880/0.860 us on cache hits. The matcher is still rebuilt in both
measurements.

This targets repeated schemas, which otherwise pay the same deterministic
JSON/grammar serialization work for every request.

## Validation

- focused cache test: 1 passed (6 deselected) against the rebased head;
- Ruff check and format check passed;
- `git diff --check` passed;
- duplicate search against current upstream main found no equivalent cache.

The cache key includes request type, grammar specification, whitespace setting,
and additional-properties setting.
\n\n## Contribution disclosure

- Duplicate-work check: an open-PR search for guidance grammar serialization cache found only this PR.
- AI assistance was used for implementation support, test execution, rebase maintenance, and drafting this description. The human submitter remains responsible for reviewing and defending the change.
