### PR TITLE
[KV Offload] Carry chunk index in OffloadKey

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_events.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_events.py
@@ -104,8 +104,8 @@ def _record_chunks(
     for chunk_idx in range(num_chunks):
         tail_hash = req.block_hashes[(chunk_idx + 1) * hbf - 1]
         assert tail_hash is not None
-        key = make_offload_key(tail_hash, group_config.group_idx)
-        tracker.record_store(req, group_config, chunk_idx, key)
+        key = make_offload_key(tail_hash, group_config.group_idx, chunk_idx)
+        tracker.record_store(req, group_config, key)
         keys.append(key)
     return keys
 
@@ -121,11 +121,10 @@ def _record_lookup_chunks(
     for chunk_idx in range(num_chunks):
         tail_hash = req.block_hashes[(chunk_idx + 1) * hbf - 1]
         assert tail_hash is not None
-        key = make_offload_key(tail_hash, group_config.group_idx)
+        key = make_offload_key(tail_hash, group_config.group_idx, chunk_idx)
         tracker.record_lookup(
             req,
             group_config,
-            chunk_idx,
             key,
         )
         keys.append(key)
@@ -337,7 +336,7 @@ def test_take_events_factor_gt_1_store_is_order_independent():
         token_count=4 * blocks_per_chunk * 2,
     )
     keys = _record_chunks(tracker, req, group_config, num_chunks=2)
-    unknown_key = make_offload_key(_hash(12345), 0)
+    unknown_key = make_offload_key(_hash(12345), 0, 0)
 
     events = list(tracker.take_events([_stored_event([keys[1], unknown_key, keys[0]])]))
 
@@ -348,6 +347,29 @@ def test_take_events_factor_gt_1_store_is_order_independent():
     assert placeholder.token_ids == []
     assert chunk0.parent_block_hash is None
     assert chunk1.parent_block_hash == chunk0.block_hashes[-1]
+
+
+def test_placeholder_event_decodes_hash_and_group_from_extended_key():
+    """An untracked key still emits a placeholder carrying the tail hash and
+    group_idx decoded from the OffloadKey. chunk_idx lives in the key but is
+    not part of the BlockStored/BlockRemoved wire payload."""
+    tracker = _tracker()
+    tail_hash = _hash(42)
+    key = make_offload_key(tail_hash, group_idx=3, chunk_idx=9)
+
+    stored = list(tracker.take_events([_stored_event([key])]))
+    assert len(stored) == 1
+    assert isinstance(stored[0], BlockStored)
+    assert stored[0].block_hashes == [_wire_hash(tail_hash)]
+    assert stored[0].group_idx == 3
+    assert stored[0].block_size == 0
+    assert stored[0].token_ids == []
+
+    removed = list(tracker.take_events([_removed_event([key])]))
+    assert len(removed) == 1
+    assert isinstance(removed[0], BlockRemoved)
+    assert removed[0].block_hashes == [_wire_hash(tail_hash)]
+    assert removed[0].group_idx == 3
 
 
 def test_take_events_opt_out_keeps_placeholders():
@@ -418,7 +440,6 @@ def test_pending_cpu_removal_consumes_hit_backfill_until_next_hit():
     tracker.record_lookup(
         lookup_req,
         group_config,
-        0,
         key,
     )
     assert tracker._pending_event_metadata[key] is confirmed_meta
@@ -435,7 +456,7 @@ def test_pending_cpu_removal_consumes_hit_backfill_until_next_hit():
     assert stored[0].block_size == 0
     assert stored[0].token_ids == []
 
-    tracker.record_lookup(lookup_req, group_config, 0, key)
+    tracker.record_lookup(lookup_req, group_config, key)
     removed = list(tracker.take_events([_removed_event([key])]))
     assert removed[0].block_hashes == [
         _wire_hash(_hash(0)),
@@ -489,7 +510,7 @@ def test_take_events_supports_restore_after_eviction():
     assert not tracker._pending_event_metadata
 
     req.all_token_ids = [5, 6, 7, 8]
-    tracker.record_store(req, group_config, chunk_idx=0, offload_key=key)
+    tracker.record_store(req, group_config, key)
 
     second_store = list(tracker.take_events([_stored_event([key])]))
     assert len(second_store) == 1

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -16,12 +16,17 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
     OffloadingConnectorMetadata,
     OffloadingWorkerMetadata,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.events import (
+    OffloadingEventGroupSpec,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
     OffloadingConnectorStats,
     _ConnectorMetricName,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
+    GroupOffloadConfig,
     OffloadingConnectorScheduler,
+    RequestGroupState,
     RequestOffloadState,
     is_store_reachable_swa_chunk,
 )
@@ -40,6 +45,8 @@ from vllm.v1.kv_offload.base import (
     ReqContext,
     RequestOffloadingContext,
     get_offload_block_hash,
+    get_offload_chunk_idx,
+    get_offload_group_idx,
     make_offload_key,
 )
 from vllm.v1.outputs import KVConnectorOutput
@@ -315,7 +322,6 @@ def test_abort_before_hit_uses_placeholder_then_later_hit_heals_removal(
             req_status.req_context,
             req_status.req,
             group_config,
-            0,
         )
         == 1
     )
@@ -1083,13 +1089,12 @@ _LOOKUP_REQ.request_id = "req"
 _LOOKUP_GROUP_CONFIG = MagicMock()
 
 
-def _maximal_lookup(sched, keys, start_chunk_idx: int = 0):
+def _maximal_lookup(sched, keys):
     return sched._maximal_prefix_lookup(
         keys,
         _EMPTY_REQ_CTX,
         _LOOKUP_REQ,
         _LOOKUP_GROUP_CONFIG,
-        start_chunk_idx,
     )
 
 
@@ -1098,24 +1103,16 @@ class TestMaximalPrefixLookup:
         sched = _make_scheduler_with_lookup({1: LookupResult.HIT, 2: LookupResult.HIT})
         assert _maximal_lookup(sched, to_keys([1, 2])) == 2
 
-    def test_records_absolute_chunk_indices(self):
+    def test_records_lookup_for_each_hit_key(self):
+        # Chunk provenance now travels inside the OffloadKey, so the lookup
+        # path simply records each hit key; no separate chunk_idx is passed.
         keys = to_keys([1, 2])
         sched = _make_scheduler_with_lookup({1: LookupResult.HIT, 2: LookupResult.HIT})
 
-        assert _maximal_lookup(sched, keys, start_chunk_idx=3) == 2
+        assert _maximal_lookup(sched, keys) == 2
         assert sched._events_tracker.record_lookup.call_args_list == [
-            call(
-                _LOOKUP_REQ,
-                _LOOKUP_GROUP_CONFIG,
-                3,
-                keys[0],
-            ),
-            call(
-                _LOOKUP_REQ,
-                _LOOKUP_GROUP_CONFIG,
-                4,
-                keys[1],
-            ),
+            call(_LOOKUP_REQ, _LOOKUP_GROUP_CONFIG, keys[0]),
+            call(_LOOKUP_REQ, _LOOKUP_GROUP_CONFIG, keys[1]),
         ]
 
     def test_all_miss(self):
@@ -1162,7 +1159,6 @@ class TestMaximalPrefixLookup:
         sched._events_tracker.record_lookup.assert_called_once_with(
             _LOOKUP_REQ,
             _LOOKUP_GROUP_CONFIG,
-            1,
             keys[1],
         )
 
@@ -1175,7 +1171,6 @@ class TestMaximalPrefixLookup:
         sched._events_tracker.record_lookup.assert_called_once_with(
             _LOOKUP_REQ,
             _LOOKUP_GROUP_CONFIG,
-            0,
             keys[0],
         )
 
@@ -1189,7 +1184,6 @@ class TestMaximalPrefixLookup:
         sched._events_tracker.record_lookup.assert_called_once_with(
             _LOOKUP_REQ,
             _LOOKUP_GROUP_CONFIG,
-            1,
             keys[1],
         )
 
@@ -2218,7 +2212,10 @@ class TestEagle:
 
     @staticmethod
     def _group_keys(group_idx: int, int_hashes: list[int]) -> list:
-        return [make_offload_key(str(h).encode(), group_idx) for h in int_hashes]
+        return [
+            make_offload_key(str(h).encode(), group_idx, chunk_idx)
+            for chunk_idx, h in enumerate(int_hashes)
+        ]
 
     @staticmethod
     def _make_req_status(
@@ -3204,3 +3201,64 @@ def test_request_finished_mixed_full_attn_and_sliding_window(
     # Verify fence is empty after full lifecycle (cleanup happened).
     assert runner.connector_scheduler._block_id_to_pending_jobs == {}
     assert len(runner.connector_scheduler._jobs) == 0
+
+
+class TestUpdateOffloadKeys:
+    """update_offload_keys() assigns each new chunk an absolute,
+    group-relative chunk_idx carried inside its OffloadKey."""
+
+    @staticmethod
+    def _group_config(group_idx: int, hashes_per_chunk: int) -> GroupOffloadConfig:
+        return GroupOffloadConfig(
+            group_idx=group_idx,
+            tokens_per_block=4,
+            tokens_per_chunk=4 * hashes_per_chunk,
+            hashes_per_chunk=hashes_per_chunk,
+            kv_event_group_spec=OffloadingEventGroupSpec(
+                kv_cache_spec_kind=None,
+                kv_cache_spec_sliding_window=None,
+            ),
+            sliding_window_size_in_chunks=None,
+        )
+
+    @staticmethod
+    def _run(group_configs, group_states, block_hashes) -> None:
+        # update_offload_keys only reads config.kv_group_configs,
+        # group_states, and req.block_hashes.
+        fake_self = SimpleNamespace(
+            config=SimpleNamespace(kv_group_configs=tuple(group_configs)),
+            group_states=tuple(group_states),
+            req=SimpleNamespace(block_hashes=list(block_hashes)),
+        )
+        RequestOffloadState.update_offload_keys(fake_self)
+
+    def test_chunk_idx_continues_across_appends(self):
+        """First pass numbers [0, 1]; a later append continues [2, 3]."""
+        hbf = 2
+        gc = self._group_config(group_idx=0, hashes_per_chunk=hbf)
+        gs = RequestGroupState()
+
+        hashes = [str(i).encode() for i in range(2 * hbf)]
+        self._run([gc], [gs], hashes)
+        assert [get_offload_chunk_idx(k) for k in gs.offload_keys] == [0, 1]
+
+        # Append 2 more chunks; numbering must continue, not restart.
+        hashes += [str(i).encode() for i in range(2 * hbf, 4 * hbf)]
+        self._run([gc], [gs], hashes)
+        assert [get_offload_chunk_idx(k) for k in gs.offload_keys] == [0, 1, 2, 3]
+
+    def test_each_group_numbers_chunks_independently_from_zero(self):
+        """Chunk indices are group-relative: every group starts at 0."""
+        g0 = self._group_config(group_idx=0, hashes_per_chunk=1)
+        g1 = self._group_config(group_idx=5, hashes_per_chunk=2)
+        gs0 = RequestGroupState()
+        gs1 = RequestGroupState()
+
+        hashes = [str(i).encode() for i in range(4)]
+        self._run([g0, g1], [gs0, gs1], hashes)
+
+        # hbf=1 -> 4 chunks; hbf=2 -> 2 chunks; both start from 0.
+        assert [get_offload_chunk_idx(k) for k in gs0.offload_keys] == [0, 1, 2, 3]
+        assert [get_offload_group_idx(k) for k in gs0.offload_keys] == [0, 0, 0, 0]
+        assert [get_offload_chunk_idx(k) for k in gs1.offload_keys] == [0, 1]
+        assert [get_offload_group_idx(k) for k in gs1.offload_keys] == [5, 5]

--- a/tests/v1/kv_connector/unit/offloading_connector/utils.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/utils.py
@@ -62,7 +62,7 @@ from vllm.v1.structured_output import StructuredOutputManager
 
 
 def to_key(int_hash: int) -> OffloadKey:
-    return make_offload_key(str(int_hash).encode(), 0)
+    return make_offload_key(str(int_hash).encode(), 0, 0)
 
 
 def to_keys(int_hashes: list[int]) -> list[OffloadKey]:

--- a/tests/v1/kv_offload/cpu/test_manager.py
+++ b/tests/v1/kv_offload/cpu/test_manager.py
@@ -58,7 +58,7 @@ class ExpectedPrepareStoreOutput:
 
 
 def to_key(int_hash: int) -> OffloadKey:
-    return make_offload_key(str(int_hash).encode(), 0)
+    return make_offload_key(str(int_hash).encode(), 0, 0)
 
 
 def to_keys(int_hashes: list[int]) -> list[OffloadKey]:

--- a/tests/v1/kv_offload/test_base.py
+++ b/tests/v1/kv_offload/test_base.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the OffloadKey codec in vllm.v1.kv_offload.base."""
+
+from vllm.v1.kv_offload.base import (
+    get_offload_block_hash,
+    get_offload_chunk_idx,
+    get_offload_group_idx,
+    make_offload_key,
+)
+
+
+def test_offload_key_round_trip():
+    block_hash = bytes(range(8))
+    key = make_offload_key(block_hash, group_idx=3, chunk_idx=7)
+    assert get_offload_block_hash(key) == block_hash
+    assert get_offload_group_idx(key) == 3
+    assert get_offload_chunk_idx(key) == 7
+
+
+def test_offload_key_round_trip_u32_max():
+    # group_idx and chunk_idx are packed as unsigned 32-bit big-endian ints.
+    block_hash = b"\xab" * 16
+    key = make_offload_key(block_hash, group_idx=2**32 - 1, chunk_idx=2**32 - 2)
+    assert get_offload_block_hash(key) == block_hash
+    assert get_offload_group_idx(key) == 2**32 - 1
+    assert get_offload_chunk_idx(key) == 2**32 - 2
+
+
+def test_chunk_idx_disambiguates_same_hash_and_group():
+    block_hash = bytes(range(8))
+    key0 = make_offload_key(block_hash, group_idx=1, chunk_idx=0)
+    key1 = make_offload_key(block_hash, group_idx=1, chunk_idx=1)
+    assert key0 != key1
+    assert get_offload_block_hash(key0) == get_offload_block_hash(key1)
+    assert get_offload_group_idx(key0) == get_offload_group_idx(key1)
+    assert (get_offload_chunk_idx(key0), get_offload_chunk_idx(key1)) == (0, 1)

--- a/tests/v1/kv_offload/test_file_mapper.py
+++ b/tests/v1/kv_offload/test_file_mapper.py
@@ -81,13 +81,23 @@ def test_get_file_name_full_structure():
     group_idx = 2
     block_hash = bytes(range(8))  # deterministic, non-zero bytes
     fm = make_mapper_from_offloading_spec(rank=rank)
-    key = make_offload_key(block_hash, group_idx)
+    key = make_offload_key(block_hash, group_idx, 0)
     path = fm.get_file_name(key)
 
     expected_path = (
         "/tmp/cache/test-model_de3bba26cf36_r3/000/10_g2/0001020304050607.bin"
     )
     assert path == expected_path
+
+
+def test_get_file_name_ignores_chunk_idx():
+    """The FS layout keys on (block_hash, group_idx) only, so a non-zero
+    chunk_idx in the OffloadKey must not change the file name."""
+    block_hash = bytes(range(8))
+    fm = make_mapper_from_offloading_spec(rank=3)
+    path_chunk0 = fm.get_file_name(make_offload_key(block_hash, 2, 0))
+    path_chunk7 = fm.get_file_name(make_offload_key(block_hash, 2, 7))
+    assert path_chunk0 == path_chunk7
 
 
 def test_get_run_config_fields():

--- a/tests/v1/kv_offload/tiering/p2p/test_zmq_transport.py
+++ b/tests/v1/kv_offload/tiering/p2p/test_zmq_transport.py
@@ -10,11 +10,18 @@ import time
 import pytest
 import zmq
 
+from vllm.v1.kv_offload.base import (
+    get_offload_block_hash,
+    get_offload_chunk_idx,
+    get_offload_group_idx,
+    make_offload_key,
+)
 from vllm.v1.kv_offload.tiering.p2p.control.zmq import (
     ZmqConnection,
     ZmqTransport,
     _Sockets,
 )
+from vllm.v1.kv_offload.tiering.p2p.session.protocol import FetchMsg
 
 
 def _free_port() -> int:
@@ -136,6 +143,34 @@ class TestZmqTransportConnectivity:
 
             msgs = _wait_for_messages(transport_a, conn_a_from_b, 1)
             assert msgs == [{"type": "hello", "data": 42}]
+        finally:
+            transport_a.close()
+            transport_b.close()
+
+    def test_offload_key_bytes_survive_transport(self):
+        """P2P carries OffloadKeys as opaque bytes. A full key with a
+        non-zero chunk_idx must round-trip unchanged over the wire and still
+        decode to the same (hash, group, chunk) -- so peers must share the
+        key format (lockstep deployment)."""
+        transport_a, port_a = _make_transport()
+        transport_b, _ = _make_transport()
+
+        try:
+            block_hash = bytes(range(8))
+            key = make_offload_key(block_hash, group_idx=2, chunk_idx=7)
+
+            conn_b = transport_b.connect(f"127.0.0.1:{port_a}")
+            conn_b.send({FetchMsg.KEYS: [key], FetchMsg.BLOCK_INDEXES: [0]})
+
+            new_conns = _wait_for_inbound(transport_a)
+            conn_a = new_conns[0]
+            msgs = _wait_for_messages(transport_a, conn_a, 1)
+
+            received = msgs[0][FetchMsg.KEYS][0]
+            assert received == key
+            assert get_offload_block_hash(received) == block_hash
+            assert get_offload_group_idx(received) == 2
+            assert get_offload_chunk_idx(received) == 7
         finally:
             transport_a.close()
             transport_b.close()

--- a/tests/v1/kv_offload/tiering/test_async_lookup.py
+++ b/tests/v1/kv_offload/tiering/test_async_lookup.py
@@ -10,7 +10,7 @@ from vllm.v1.kv_offload.tiering.async_lookup import AsyncLookupManager
 
 
 def _key(i: int) -> OffloadKey:
-    return make_offload_key(str(i).encode(), 0)
+    return make_offload_key(str(i).encode(), 0, 0)
 
 
 def _ctx(req_id: str = "r1") -> ReqContext:

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -85,7 +85,7 @@ _MOCK_OFFLOADING_SPEC = _make_offloading_spec(enable_kv_cache_events=False)
 
 
 def key(n: int) -> OffloadKey:
-    return make_offload_key(n.to_bytes(8, "big"), 0)
+    return make_offload_key(n.to_bytes(8, "big"), 0, 0)
 
 
 def make_job(

--- a/tests/v1/kv_offload/tiering/test_obj_tier.py
+++ b/tests/v1/kv_offload/tiering/test_obj_tier.py
@@ -83,7 +83,7 @@ _CTX = ReqContext(req_id="test-req")
 
 
 def key(n: int) -> OffloadKey:
-    return make_offload_key(n.to_bytes(8, "big"), 0)
+    return make_offload_key(n.to_bytes(8, "big"), 0, 0)
 
 
 def make_job(

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -65,7 +65,7 @@ def _mock_mmap_region(num_blocks: int, row_bytes: int = 16):
 
 
 def to_keys(int_ids: Iterable[int]) -> list[OffloadKey]:
-    return [make_offload_key(str(i).encode(), 0) for i in int_ids]
+    return [make_offload_key(str(i).encode(), 0, 0) for i in int_ids]
 
 
 def count_hits(manager, keys: list[OffloadKey]) -> int | None:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/events.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/events.py
@@ -39,6 +39,7 @@ from vllm.v1.kv_offload.base import (
     OffloadingKVEventsConfig,
     OffloadKey,
     get_offload_block_hash,
+    get_offload_chunk_idx,
     get_offload_group_idx,
 )
 from vllm.v1.request import Request
@@ -113,10 +114,11 @@ class OffloadingEventsTracker:
         self,
         req: Request,
         group_config: "GroupOffloadConfig",
-        chunk_idx: int,
         offload_key: OffloadKey,
     ) -> None:
         """Snapshot the KV cache event payload for one offloaded chunk.
+
+        The chunk index is decoded from the ``OffloadKey`` itself.
 
         No-op when self-describing event capture is disabled or for
         sliding-window / SSM groups, which keep the legacy placeholder payload.
@@ -125,6 +127,7 @@ class OffloadingEventsTracker:
             return
         if group_config.sliding_window_size_in_chunks is not None:
             return
+        chunk_idx = get_offload_chunk_idx(offload_key)
         meta = self._build_event_metadata(req, group_config, chunk_idx)
         self._pending_event_metadata[offload_key] = meta
 
@@ -132,15 +135,18 @@ class OffloadingEventsTracker:
         self,
         req: Request,
         group_config: "GroupOffloadConfig",
-        chunk_idx: int,
         offload_key: OffloadKey,
     ) -> None:
-        """Snapshot metadata for a ready primary-tier lookup hit."""
+        """Snapshot metadata for a ready primary-tier lookup hit.
+
+        The chunk index is decoded from the ``OffloadKey`` itself.
+        """
         if not self.self_describing_enabled:
             return
         if group_config.sliding_window_size_in_chunks is not None:
             return
         if offload_key not in self._pending_event_metadata:
+            chunk_idx = get_offload_chunk_idx(offload_key)
             self._pending_event_metadata[offload_key] = self._build_event_metadata(
                 req, group_config, chunk_idx
             )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -321,8 +321,11 @@ class RequestOffloadState:
                 None,
                 group_config.hashes_per_chunk,
             ):
+                # chunk_idx is the absolute, group-relative index; new chunks
+                # continue numbering from the current key count.
+                chunk_idx = len(group_state.offload_keys)
                 group_state.offload_keys.append(
-                    make_offload_key(req_block_hash, group_config.group_idx)
+                    make_offload_key(req_block_hash, group_config.group_idx, chunk_idx)
                 )
 
     def update_block_id_groups(
@@ -548,20 +551,18 @@ class OffloadingConnectorScheduler:
         req_context: ReqContext,
         req: Request,
         group_config: GroupOffloadConfig,
-        start_chunk_idx: int,
     ) -> int | None:
         """Return the number of consecutive offloaded chunks from the start,
         or None if the backend deferred a lookup."""
         hit_count = 0
         defer_lookup = False
-        for local_idx, key in enumerate(keys):
+        for key in keys:
             result = self.manager.lookup(key, req_context)
             match result:
                 case LookupResult.HIT:
                     self._events_tracker.record_lookup(
                         req,
                         group_config,
-                        start_chunk_idx + local_idx,
                         key,
                     )
                     hit_count += 1
@@ -712,7 +713,6 @@ class OffloadingConnectorScheduler:
                         req_status.req_context,
                         req_status.req,
                         group_config,
-                        start_chunk_idx,
                     )
                 else:
                     required_window = sliding_window_size_in_chunks
@@ -1142,9 +1142,7 @@ class OffloadingConnectorScheduler:
 
                     chunk_idx = start_chunk_idx + idx
 
-                    self._events_tracker.record_store(
-                        req, group_config, chunk_idx, offload_key
-                    )
+                    self._events_tracker.record_store(req, group_config, offload_key)
 
                     gpu_block_idx = chunk_idx * blocks_per_chunk
                     for i in range(blocks_per_chunk):

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -22,26 +22,38 @@ if TYPE_CHECKING:
 
 from vllm.v1.kv_offload.config import OffloadingConfig
 
-# `OffloadKey` identifies an offloaded block. It combines a block hash with
-# its KV cache group index, encoded as raw bytes to avoid tuple GC overhead.
-# Use the helper functions below to construct / decompose keys.
+# `OffloadKey` identifies an offloaded chunk. Layout, as raw bytes to avoid
+# tuple GC overhead:
+#     block_hash | group_idx (u32, big-endian) | chunk_idx (u32, big-endian)
+# `chunk_idx` is the absolute, group-relative chunk index. Use the helper
+# functions below to construct / decompose keys.
 OffloadKey = NewType("OffloadKey", bytes)
 
 logger = init_logger(__name__)
 
 
-def make_offload_key(block_hash: bytes, group_idx: int) -> OffloadKey:
-    """Pack a block hash and group index into an `OffloadKey`."""
-    return OffloadKey(block_hash + group_idx.to_bytes(4, "big", signed=False))
+def make_offload_key(block_hash: bytes, group_idx: int, chunk_idx: int) -> OffloadKey:
+    """Pack a block hash, KV group index, and absolute group-relative chunk
+    index into an `OffloadKey`."""
+    return OffloadKey(
+        block_hash
+        + group_idx.to_bytes(4, "big", signed=False)
+        + chunk_idx.to_bytes(4, "big", signed=False)
+    )
 
 
 def get_offload_block_hash(key: OffloadKey) -> bytes:
     """Extract the block hash from an `OffloadKey`."""
-    return key[:-4]
+    return key[:-8]
 
 
 def get_offload_group_idx(key: OffloadKey) -> int:
-    """Extract the group index from an `OffloadKey`."""
+    """Extract the KV group index from an `OffloadKey`."""
+    return int.from_bytes(key[-8:-4], "big", signed=False)
+
+
+def get_offload_chunk_idx(key: OffloadKey) -> int:
+    """Extract the absolute group-relative chunk index from an `OffloadKey`."""
     return int.from_bytes(key[-4:], "big", signed=False)
 
 


### PR DESCRIPTION
## Purpose

Re-scopes this PR to a single, minimal change agreed with the maintainer in review: carry the chunk index inside the `OffloadKey` so the self-describing KV-event path can recover a chunk's provenance from the key alone.

`OffloadKey` becomes:

```
block_hash | group_idx:u32 (big-endian) | chunk_idx:u32 (big-endian)
```

where `chunk_idx` is the absolute, group-relative chunk index. This removes the need to thread a separate `chunk_idx` through the events tracker, so the offloading manager, tiering, and worker layers keep treating the key as an opaque identity.

This is the design @orozery proposed in review ([suggestion](https://github.com/vllm-project/vllm/pull/49506#discussion_r3655466611)) and I [agreed to re-scope this PR to](https://github.com/vllm-project/vllm/pull/49506#discussion_r3661314636): coupling `chunk_idx` to the key makes single-key `prepare_store` unnecessary for KV events, so that admission work moves to a follow-up.

### What changes

- `vllm/v1/kv_offload/base.py`: `make_offload_key(block_hash, group_idx, chunk_idx)` now requires `chunk_idx` (no default, so no caller can silently pack the wrong position); add `get_offload_chunk_idx()`; `get_offload_block_hash()` / `get_offload_group_idx()` slice the widened key.
- `.../offloading/scheduler.py`: `update_offload_keys()` numbers each group's new chunks from its current key count (first pass `0, 1`; a later append continues `2, 3`; every group starts from 0). The events tracker no longer takes a separate `chunk_idx`, so `_maximal_prefix_lookup()` drops its `start_chunk_idx` parameter and `_build_store_jobs()`'s `record_store()` call drops it too. `_build_store_jobs()` otherwise keeps `main`'s batch store logic and still computes an internal `chunk_idx` for GPU block indexing.
- `.../offloading/events.py`: `record_store()` / `record_lookup()` decode `chunk_idx` from the key via `get_offload_chunk_idx()`.

### Intentionally unchanged

- **KV-event wire format** — `BlockStored` / `BlockRemoved` schema and payloads are unchanged; `chunk_idx` lives in the key, not on the wire.
- **Store admission, allocation atomicity, worker transfer** — the CPU/tiering managers are byte-for-byte unchanged from `main`, and `_build_store_jobs()` keeps its batch behavior (batch `prepare_store`, batch allocation/eviction/cascade, existing `pending_primary_stores` pairing); its only change is the `record_store()` call dropping the `chunk_idx` argument.
- **Dedup** — unchanged under fixed chunk geometry: a given (hash, group) always maps to the same `chunk_idx`, so keys are stable.
- **FS layout** — `FileMapper` still keys file names on `(hash, group)`; a non-zero `chunk_idx` does not change the file name.

### P2P compatibility (breaking)

P2P transports the full `OffloadKey` bytes opaquely, so producer and consumer peers must run the **same** key format — deploy in lockstep. This PR does not implement mixed-version P2P compatibility; a key-format/version handshake is a follow-up.

### Out of scope (follow-ups)

- Single-key `prepare_store` admission (k-way merge, `OffloadReject`) — @orozery agreed this can follow.
- Worker-facing transfer reshape — #44865 (sequenced after this).
- Full promotion provenance and key-only removal.

Not a duplicate: the nearest open neighbor is #44865 (worker transfer data-model reshape), which the review thread sequences *after* this change and which consumes rather than duplicates it. Other open KV-offload PRs (#48798 tiering metrics, #49850 HIT_PENDING bound) are unrelated.

## Test Plan

```
.venv/bin/python -m pytest \
  tests/v1/kv_offload/ \
  tests/v1/kv_connector/unit/offloading_connector/
```

New/updated behavior tests:

- `OffloadKey` round-trip and same-(hash, group) chunk disambiguation (`tests/v1/kv_offload/test_base.py`).
- `update_offload_keys()` per-group numbering: `[0, 1]` then a later append `[2, 3]`, and each KV group numbering independently from 0 (`tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py`).
- Events tracker selects chunk metadata by key alone (existing order-independence test) and a placeholder decodes the tail hash / group from an extended key without leaking `chunk_idx` onto the wire (`.../test_events.py`).
- FS file name unchanged under a non-zero `chunk_idx` (`tests/v1/kv_offload/test_file_mapper.py`).
- P2P opaque full-key round-trip over the ZMQ transport (`tests/v1/kv_offload/tiering/p2p/test_zmq_transport.py`).

## Test Result

All offloading suites pass locally on an L4 (torch 2.13.0+cu130, Python 3.12): 498 passed across `tests/v1/kv_offload/` and `tests/v1/kv_connector/unit/offloading_connector/`. `ruff check`, `ruff format`, and `mypy` (3.12) are clean on the changed files.

---

AI assistance was used to prepare this PR (Cursor). A human author reviewed every changed line and ran the tests above.
