### PR TITLE
[CI] Disable reasoning in Responses smoke test

### DIFF
--- a/tests/entrypoints/openai/responses/test_simple.py
+++ b/tests/entrypoints/openai/responses/test_simple.py
@@ -39,6 +39,7 @@ async def test_basic(client: OpenAI, model_name: str):
     response = await client.responses.create(
         model=model_name,
         input="What is 123 * 456?",
+        reasoning={"effort": "none"},
     )
     assert response is not None
     print("response: ", response)


### PR DESCRIPTION
Motivation: [Entrypoints Integration (Responses API)](https://buildkite.com/vllm/amd-ci/builds/11147/list?jid=019f8bae-0616-4105-a940-437c523d6d6d&tab=output)

The basic Responses API smoke test can intermittently let Qwen3 spend its output budget on a reasoning trace and finish as incomplete. The assertion only checks basic response completion, so it now requests reasoning effort `none` explicitly. Dedicated cases in the same suite continue to exercise reasoning output. This fixes the **Entrypoints Integration (Responses API)** test group.