### PR TITLE
[Kernel][Core][PCP][KV Update] Replace PCP update collectives with direct peer stores

### DIFF
--- a/benchmarks/kernels/bench_pcp_kv_update.py
+++ b/benchmarks/kernels/bench_pcp_kv_update.py
@@ -1,0 +1,529 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark replicated PCP cache updates with collectives or peer stores.
+
+This is a communication microbenchmark for the stage-1 replicated-cache
+design.  It compares two ways to make each PCP rank's local ``kv_c``, ``k_pe``,
+and ``indexer_k`` payload visible in every rank's cache:
+
+* ``all_gather``: three NCCL all-gathers followed by one representative local
+  cache-insertion kernel;
+* ``direct``: one Triton kernel that stores each local payload into every
+  rank's CUDA VMM cache view, followed by the production release/acquire fence.
+
+Both paths produce the same component-major, replicated BF16 cache image.  The
+benchmark intentionally excludes model work (RMSNorm, RoPE, quantization, slot
+mapping, and attention) so it measures only update transport, insertion, and
+visibility.  Widths are configurable when a different semantic layout is
+needed.
+
+Example on one four-GPU node::
+
+    torchrun --standalone --nproc-per-node=4 \
+      benchmarks/kernels/bench_pcp_kv_update.py \
+      --local-tokens 1,8,32,128,512,2048 \
+      --warmup 20 --repetitions 100 \
+      --json-output /tmp/pcp-kv-update.json
+
+Only rank zero writes JSON.  Latency percentiles are computed from the slowest
+rank in every repetition, rather than from independently pooled rank samples.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+from vllm.distributed.device_communicators.cuda_vmm import (
+    create_rank_major_peer_view,
+)
+from vllm.model_executor.layers.attention.pcp_peer_cache import (
+    PCPPeerCacheFence,
+    make_rank_major_tensor_view,
+)
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _insert_gathered_kernel(
+    gathered_kv_c_ptr,
+    gathered_k_pe_ptr,
+    gathered_indexer_k_ptr,
+    local_cache_ptr,
+    component_stride,
+    kv_c_numel,
+    k_pe_numel,
+    indexer_k_numel,
+    kv_c_offset,
+    k_pe_offset,
+    indexer_k_offset,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Copy three gathered source-rank components into one local cache."""
+    source_rank = tl.program_id(1)
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    destination = local_cache_ptr + source_rank * component_stride
+
+    kv_c_mask = offsets < kv_c_numel
+    kv_c = tl.load(
+        gathered_kv_c_ptr + source_rank * kv_c_numel + offsets,
+        mask=kv_c_mask,
+    )
+    tl.store(destination + kv_c_offset + offsets, kv_c, mask=kv_c_mask)
+
+    k_pe_mask = offsets < k_pe_numel
+    k_pe = tl.load(
+        gathered_k_pe_ptr + source_rank * k_pe_numel + offsets,
+        mask=k_pe_mask,
+    )
+    tl.store(destination + k_pe_offset + offsets, k_pe, mask=k_pe_mask)
+
+    indexer_k_mask = offsets < indexer_k_numel
+    indexer_k = tl.load(
+        gathered_indexer_k_ptr + source_rank * indexer_k_numel + offsets,
+        mask=indexer_k_mask,
+    )
+    tl.store(
+        destination + indexer_k_offset + offsets,
+        indexer_k,
+        mask=indexer_k_mask,
+    )
+
+
+@triton.jit
+def _direct_fanout_kernel(
+    local_kv_c_ptr,
+    local_k_pe_ptr,
+    local_indexer_k_ptr,
+    peer_cache_ptr,
+    destination_stride,
+    component_stride,
+    source_rank: tl.constexpr,
+    world_size: tl.constexpr,
+    kv_c_numel,
+    k_pe_numel,
+    indexer_k_numel,
+    kv_c_offset,
+    k_pe_offset,
+    indexer_k_offset,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Fan one source rank's components out to every replicated cache."""
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    kv_c_mask = offsets < kv_c_numel
+    k_pe_mask = offsets < k_pe_numel
+    indexer_k_mask = offsets < indexer_k_numel
+    kv_c = tl.load(local_kv_c_ptr + offsets, mask=kv_c_mask)
+    k_pe = tl.load(local_k_pe_ptr + offsets, mask=k_pe_mask)
+    indexer_k = tl.load(local_indexer_k_ptr + offsets, mask=indexer_k_mask)
+
+    for destination_rank in range(world_size):
+        destination = (
+            peer_cache_ptr
+            + destination_rank * destination_stride
+            + source_rank * component_stride
+        )
+        tl.store(destination + kv_c_offset + offsets, kv_c, mask=kv_c_mask)
+        tl.store(destination + k_pe_offset + offsets, k_pe, mask=k_pe_mask)
+        tl.store(
+            destination + indexer_k_offset + offsets,
+            indexer_k,
+            mask=indexer_k_mask,
+        )
+
+
+def _parse_local_tokens(value: str) -> list[int]:
+    try:
+        values = [int(item) for item in value.split(",")]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "local token sizes must be comma-separated integers"
+        ) from exc
+    if not values or any(item <= 0 for item in values):
+        raise argparse.ArgumentTypeError("local token sizes must be positive")
+    if len(set(values)) != len(values):
+        raise argparse.ArgumentTypeError("local token sizes must be unique")
+    return values
+
+
+def _percentile(values: list[float], quantile: float) -> float:
+    """Return a linearly interpolated percentile without a NumPy dependency."""
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
+
+
+def _summarize_slowest_rank(
+    local_samples_ms: list[float], cpu_group: dist.ProcessGroup
+) -> tuple[dict[str, float] | None, list[float] | None]:
+    per_rank_samples: list[list[float] | None] = [None] * dist.get_world_size(cpu_group)
+    dist.all_gather_object(per_rank_samples, local_samples_ms, group=cpu_group)
+    if dist.get_rank(cpu_group) != 0:
+        return None, None
+
+    samples = [sample for sample in per_rank_samples if sample is not None]
+    slowest_ms = [max(values) for values in zip(*samples, strict=True)]
+    summary = {
+        "p50_us": _percentile(slowest_ms, 0.50) * 1000.0,
+        "p90_us": _percentile(slowest_ms, 0.90) * 1000.0,
+        "p99_us": _percentile(slowest_ms, 0.99) * 1000.0,
+        "min_us": min(slowest_ms) * 1000.0,
+        "max_us": max(slowest_ms) * 1000.0,
+    }
+    return summary, [value * 1000.0 for value in slowest_ms]
+
+
+def _time_cuda(operation: Any, repetitions: int) -> list[float]:
+    samples_ms: list[float] = []
+    for _ in range(repetitions):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        operation()
+        end.record()
+        end.synchronize()
+        samples_ms.append(start.elapsed_time(end))
+    return samples_ms
+
+
+def _make_component(
+    local_tokens: int,
+    width: int,
+    rank: int,
+    component_id: int,
+    device: torch.device,
+) -> torch.Tensor:
+    # Exactly representable BF16 integers make the preflight comparison strict.
+    values = torch.arange(local_tokens * width, device=device, dtype=torch.int64)
+    values = (values + rank * 101 + component_id * 17) % 251
+    return values.to(torch.bfloat16).view(local_tokens, width)
+
+
+def _launch_insert(
+    gathered: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    cache: torch.Tensor,
+    numels: tuple[int, int, int],
+    offsets: tuple[int, int, int],
+    max_numel: int,
+    world_size: int,
+) -> None:
+    _insert_gathered_kernel[(triton.cdiv(max_numel, 256), world_size)](
+        *gathered,
+        cache,
+        cache.stride(0),
+        *numels,
+        *offsets,
+        BLOCK_SIZE=256,
+    )
+
+
+def _launch_direct(
+    components: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    peer_cache: torch.Tensor,
+    numels: tuple[int, int, int],
+    offsets: tuple[int, int, int],
+    max_numel: int,
+    rank: int,
+    world_size: int,
+    fence: PCPPeerCacheFence,
+) -> None:
+    _direct_fanout_kernel[(triton.cdiv(max_numel, 256),)](
+        *components,
+        peer_cache,
+        peer_cache.stride(0),
+        peer_cache.stride(1),
+        rank,
+        world_size,
+        *numels,
+        *offsets,
+        BLOCK_SIZE=256,
+    )
+    fence()
+
+
+def _run_shape(
+    args: argparse.Namespace,
+    local_tokens: int,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    cpu_group: dist.ProcessGroup,
+) -> dict[str, Any] | None:
+    widths = (args.kv_c_width, args.k_pe_width, args.indexer_k_width)
+    components = tuple(
+        _make_component(local_tokens, width, rank, component_id, device)
+        for component_id, width in enumerate(widths)
+    )
+    numels = tuple(component.numel() for component in components)
+    offsets = (0, numels[0], numels[0] + numels[1])
+    component_stride = sum(numels)
+    max_numel = max(numels)
+
+    gathered = tuple(
+        torch.empty(
+            (world_size * local_tokens, width),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        for width in widths
+    )
+    collective_cache = torch.empty(
+        (world_size, component_stride), dtype=torch.bfloat16, device=device
+    )
+    peer_allocation = create_rank_major_peer_view(
+        (world_size, component_stride),
+        dtype=torch.bfloat16,
+        group=cpu_group,
+        require_native_atomics=True,
+        device=device,
+    )
+    assert peer_allocation.local_view is not None
+    requested_local_cache = peer_allocation.local_view[:world_size]
+    peer_cache = make_rank_major_tensor_view(peer_allocation, requested_local_cache)
+    fence = PCPPeerCacheFence(cpu_group, device)
+
+    def collective_update() -> None:
+        for output, source in zip(gathered, components, strict=True):
+            dist.all_gather_into_tensor(output, source)
+        _launch_insert(
+            gathered,
+            collective_cache,
+            numels,
+            offsets,
+            max_numel,
+            world_size,
+        )
+
+    def direct_update() -> None:
+        _launch_direct(
+            components,
+            peer_cache,
+            numels,
+            offsets,
+            max_numel,
+            rank,
+            world_size,
+            fence,
+        )
+
+    try:
+        collective_update()
+        direct_update()
+        torch.accelerator.synchronize(device)
+        if not torch.equal(collective_cache, requested_local_cache):
+            raise AssertionError(
+                f"rank {rank}: collective and direct cache images differ"
+            )
+
+        for _ in range(args.warmup):
+            collective_update()
+        torch.accelerator.synchronize(device)
+        dist.barrier(group=cpu_group)
+        collective_samples = _time_cuda(collective_update, args.repetitions)
+        collective_summary, collective_slowest = _summarize_slowest_rank(
+            collective_samples, cpu_group
+        )
+
+        for _ in range(args.warmup):
+            direct_update()
+        torch.accelerator.synchronize(device)
+        dist.barrier(group=cpu_group)
+        direct_samples = _time_cuda(direct_update, args.repetitions)
+        direct_summary, direct_slowest = _summarize_slowest_rank(
+            direct_samples, cpu_group
+        )
+        dist.barrier(group=cpu_group)
+
+        if rank != 0:
+            return None
+        assert collective_summary is not None
+        assert collective_slowest is not None
+        assert direct_summary is not None
+        assert direct_slowest is not None
+        logical_payload_bytes = component_stride * torch.bfloat16.itemsize
+        return {
+            "local_tokens": local_tokens,
+            "width_elements": {
+                "kv_c": widths[0],
+                "k_pe": widths[1],
+                "indexer_k": widths[2],
+            },
+            "logical_payload_bytes_per_rank": logical_payload_bytes,
+            "collective": {
+                "latency": collective_summary,
+                "slowest_rank_samples_us": collective_slowest,
+                "kv_update_collective_calls_per_iteration": 3,
+                "cache_insert_kernel_calls_per_iteration": 1,
+                "collective_input_bytes_per_rank": logical_payload_bytes,
+                "remote_payload_bytes_received_per_rank": (
+                    (world_size - 1) * logical_payload_bytes
+                ),
+                "replicated_cache_bytes_written_per_rank": (
+                    world_size * logical_payload_bytes
+                ),
+            },
+            "direct": {
+                "latency": direct_summary,
+                "slowest_rank_samples_us": direct_slowest,
+                "kv_update_collective_calls_per_iteration": 0,
+                "peer_store_kernel_calls_per_iteration": 1,
+                "fence_kernel_calls_per_iteration": 2,
+                "logical_peer_store_bytes_issued_per_rank": (
+                    world_size * logical_payload_bytes
+                ),
+                "logical_remote_peer_store_bytes_issued_per_rank": (
+                    (world_size - 1) * logical_payload_bytes
+                ),
+                "fence_publish_atomic_bytes_per_rank": world_size * 4,
+                "fence_wait_atomic_read_bytes": "data-dependent",
+            },
+            "direct_p50_speedup_x": (
+                collective_summary["p50_us"] / direct_summary["p50_us"]
+            ),
+            "direct_p50_latency_reduction_percent": (
+                (1.0 - direct_summary["p50_us"] / collective_summary["p50_us"]) * 100.0
+            ),
+        }
+    finally:
+        torch.accelerator.synchronize(device)
+        dist.barrier(group=cpu_group)
+        fence.close()
+        peer_allocation.close()
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--local-tokens",
+        type=_parse_local_tokens,
+        default=_parse_local_tokens("1,8,32,128,512,2048"),
+        help="Comma-separated local token counts (default: %(default)s).",
+    )
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--repetitions", type=int, default=100)
+    parser.add_argument("--kv-c-width", type=int, default=512)
+    parser.add_argument("--k-pe-width", type=int, default=64)
+    parser.add_argument("--indexer-k-width", type=int, default=128)
+    parser.add_argument(
+        "--expected-world-size",
+        type=int,
+        default=4,
+        help="Fail unless torchrun launches this many ranks (default: 4).",
+    )
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        help="Also write rank-zero JSON to this path.",
+    )
+    parser.add_argument(
+        "--min-direct-p50-latency-reduction-percent",
+        type=float,
+        help=(
+            "Fail rank zero when any shape misses this direct-path p50 "
+            "latency-reduction threshold."
+        ),
+    )
+    args = parser.parse_args()
+    if args.warmup < 0:
+        parser.error("--warmup must be non-negative")
+    if args.repetitions <= 0:
+        parser.error("--repetitions must be positive")
+    if min(args.kv_c_width, args.k_pe_width, args.indexer_k_width) <= 0:
+        parser.error("component widths must be positive")
+    if args.expected_world_size <= 0:
+        parser.error("--expected-world-size must be positive")
+    if (
+        args.min_direct_p50_latency_reduction_percent is not None
+        and not 0.0 <= args.min_direct_p50_latency_reduction_percent < 100.0
+    ):
+        parser.error("--min-direct-p50-latency-reduction-percent must be in [0, 100)")
+    return args
+
+
+def main() -> None:
+    args = _parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("This benchmark requires CUDA GPUs")
+    if "LOCAL_RANK" not in os.environ:
+        raise RuntimeError("Launch this benchmark with torchrun")
+
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.accelerator.set_device_index(local_rank)
+    device = torch.device("cuda", local_rank)
+    dist.init_process_group(backend="nccl", device_id=device)
+    cpu_group = dist.new_group(backend="gloo")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    if world_size != args.expected_world_size:
+        raise RuntimeError(
+            f"expected {args.expected_world_size} ranks, got {world_size}"
+        )
+
+    results: list[dict[str, Any]] = []
+    try:
+        for local_tokens in args.local_tokens:
+            if rank == 0:
+                print(
+                    f"benchmarking local_tokens={local_tokens}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            result = _run_shape(args, local_tokens, rank, world_size, device, cpu_group)
+            if result is not None:
+                results.append(result)
+    finally:
+        dist.barrier(group=cpu_group)
+        dist.destroy_process_group(cpu_group)
+        dist.destroy_process_group()
+
+    if rank == 0:
+        report = {
+            "benchmark": "pcp_replicated_kv_update",
+            "scope": (
+                "raw BF16 semantic payload transport, replicated insertion, "
+                "and visibility; excludes model transforms and attention"
+            ),
+            "world_size": world_size,
+            "dtype": "bfloat16",
+            "warmup": args.warmup,
+            "repetitions": args.repetitions,
+            "min_direct_p50_latency_reduction_percent": (
+                args.min_direct_p50_latency_reduction_percent
+            ),
+            "device": torch.cuda.get_device_name(device),
+            "results": results,
+        }
+        encoded = json.dumps(report, indent=2, sort_keys=True)
+        print(encoded)
+        if args.json_output is not None:
+            args.json_output.parent.mkdir(parents=True, exist_ok=True)
+            args.json_output.write_text(encoded + "\n", encoding="utf-8")
+        threshold = args.min_direct_p50_latency_reduction_percent
+        if threshold is not None:
+            failures = [
+                (result["local_tokens"], result["direct_p50_latency_reduction_percent"])
+                for result in results
+                if result["direct_p50_latency_reduction_percent"] < threshold
+            ]
+            if failures:
+                details = ", ".join(
+                    f"tokens={tokens}: {reduction:.2f}%"
+                    for tokens, reduction in failures
+                )
+                raise RuntimeError(
+                    f"direct p50 latency reduction missed {threshold:.2f}%: {details}"
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/serving/context_parallel_deployment.md
+++ b/docs/serving/context_parallel_deployment.md
@@ -16,6 +16,62 @@ Depending on the use case, there are two possible strategies:
 
 Both approaches are under active development.
 
+### Experimental direct PCP KV stores for GLM-5.2
+
+On a single peer-accessible NVIDIA node, GLM-5.2 can keep the existing
+replicated PCP cache layout while replacing prefill KV/indexer data gathers
+with direct peer-memory stores. vLLM maps every rank's cache once during
+initialization; the fused producer writes its local prefill results into the
+same logical cache slots on every PCP rank. Attention and indexer kernels then
+read their ordinary rank-local cache views. Runtime payload transfer uses
+device load/store semantics rather than a pull/get or receive staging buffer.
+
+This path is experimental and opt-in:
+
+```bash
+VLLM_USE_PCP_DIRECT_KV=1 vllm serve nvidia/GLM-5.2-NVFP4 \
+  --enforce-eager \
+  --no-async-scheduling \
+  --tensor-parallel-size 1 \
+  --prefill-context-parallel-size 4 \
+  --decode-context-parallel-size 1 \
+  --model-class-overrides \
+    '{"GlmMoeDsaForCausalLM":"vllm.models.deepseek_v32.nvidia.model:DeepseekV32ForCausalLM"}' \
+  --enable-expert-parallel \
+  --moe-backend flashinfer_cutlass \
+  --attention-backend FLASHINFER_MLA_SPARSE \
+  --no-enable-prefix-caching \
+  --kv-cache-dtype fp8
+```
+
+The initial implementation is deliberately fail-closed: all PCP ranks must be
+on one host, TP/DCP/DP must each be 1, CUDA graphs are unsupported, and the
+model must use the NVIDIA GLM-5.2 sparse-MLA path with an FP8 KV cache. The
+path also rejects sleep mode, async scheduling, and dual-batch/ubatch overlap.
+Prefix caching/copy-on-write and KV connectors are also rejected because their
+block-copy paths do not yet understand peer-mapped cache ownership. Cache
+allocation and POSIX file-descriptor exchange happen only during startup; the
+per-layer payload path contains producer stores plus a system-scope visibility
+fence, with no KV-update collective or receive-side staging buffer.
+The ordinary collective PCP path remains the default when
+`VLLM_USE_PCP_DIRECT_KV` is unset.
+
+The communication microbenchmark validates byte-identical replicated cache
+images before comparing the collective and direct-store update paths:
+
+```bash
+torchrun --standalone --nproc-per-node=4 \
+  benchmarks/kernels/bench_pcp_kv_update.py \
+  --local-tokens 1,8,32,128,512,2048 \
+  --warmup 20 --repetitions 100 \
+  --min-direct-p50-latency-reduction-percent 10
+```
+
+This synthetic BF16 benchmark excludes model transforms and attention. It
+reports slowest-rank latency percentiles along with logical KV-update
+collective-call and byte accounting for each path; it does not estimate
+physical topology or wire traffic.
+
 ## Decode Context Parallel
 
 Due to the auto-regressive nature of decoding, every decoding step needs to compute a small amount of query tokens w.r.t. a large number of key/value tokens stored in the paged KV cache. The core of decode context parallel is how to shard the KV cache across GPUs.

--- a/tests/distributed/test_cuda_vmm.py
+++ b/tests/distributed/test_cuda_vmm.py
@@ -1,0 +1,469 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import array
+import importlib.util
+import os
+import socket
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from vllm.distributed.device_communicators import cuda_vmm
+from vllm.distributed.device_communicators.cuda_vmm import (
+    RankMajorPeerView,
+    create_rank_major_peer_view,
+)
+from vllm.platforms import current_platform
+from vllm.utils.network_utils import get_open_port
+
+
+class _FakeDriver:
+    CUresult = SimpleNamespace(CUDA_SUCCESS=0)
+    CUmemAllocationHandleType = SimpleNamespace(
+        CU_MEM_HANDLE_TYPE_FABRIC=1,
+        CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR=2,
+    )
+
+    def __init__(self) -> None:
+        self.unmapped: list[tuple[int, int]] = []
+        self.freed: list[tuple[int, int]] = []
+
+    def cuMemUnmap(self, address: int, size: int):
+        self.unmapped.append((address, size))
+        return (0,)
+
+    def cuMemAddressFree(self, address: int, size: int):
+        self.freed.append((address, size))
+        return (0,)
+
+    def cuMemExportToShareableHandle(self, *_args):
+        raise AssertionError("Unexpected handle export")
+
+
+def test_allocation_property_preserves_typed_handle() -> None:
+    driver = SimpleNamespace(
+        CUmemAllocationProp=lambda: SimpleNamespace(),
+        CUmemAllocationType=SimpleNamespace(CU_MEM_ALLOCATION_TYPE_PINNED=1),
+        CUmemLocation=lambda: SimpleNamespace(),
+        CUmemLocationType=SimpleNamespace(CU_MEM_LOCATION_TYPE_DEVICE=2),
+    )
+
+    handle_type = SimpleNamespace(value=1)
+    prop = cuda_vmm._make_allocation_property(
+        driver, device_id=3, handle_types=handle_type
+    )
+
+    assert prop.requestedHandleTypes is handle_type
+    assert prop.location.id == 3
+
+
+def test_aligned_local_shape_honors_granularity_and_row_multiple() -> None:
+    shape, size = cuda_vmm._aligned_local_shape(
+        (7, 3), torch.float16, granularity=64, first_dim_multiple=5
+    )
+
+    assert shape == (160, 3)
+    assert size == 960
+    assert size % 64 == 0
+    assert shape[0] % 5 == 0
+
+
+def test_handle_export_uses_posix_collectively(monkeypatch) -> None:
+    driver = _FakeDriver()
+    local_fd = os.open(os.devnull, os.O_RDONLY)
+
+    def export(_handle, handle_type, _flags):
+        assert (
+            handle_type
+            == driver.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+        )
+        return (0, local_fd)
+
+    monkeypatch.setattr(driver, "cuMemExportToShareableHandle", export)
+    monkeypatch.setattr(cuda_vmm, "_driver", driver)
+    monkeypatch.setattr(cuda_vmm.dist, "get_world_size", lambda _group: 2)
+
+    def all_gather(output, value, *, group):
+        assert group == "cpu-group"
+        output[:] = [value, value]
+
+    monkeypatch.setattr(cuda_vmm.dist, "all_gather_object", all_gather)
+
+    try:
+        transport, exported = cuda_vmm._export_local_handle(
+            driver, "cpu-group", rank=0, local_handle=19
+        )
+        assert transport == "posix_fd"
+        assert exported == local_fd
+    finally:
+        os.close(local_fd)
+
+
+def test_fd_message_transfers_descriptor_ownership() -> None:
+    sender, receiver = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    local_fd = os.open(os.devnull, os.O_RDONLY)
+    received_fd = None
+    try:
+        cuda_vmm._send_fd(sender, rank=3, fd=local_fd)
+        message = cuda_vmm._recv_fd(receiver)
+        assert message is not None
+        rank, received_fd = message
+        assert rank == 3
+        assert os.fstat(received_fd).st_mode == os.fstat(local_fd).st_mode
+    finally:
+        sender.close()
+        receiver.close()
+        os.close(local_fd)
+        if received_fd is not None:
+            os.close(received_fd)
+
+
+def test_fd_message_accepts_partial_stream_header() -> None:
+    sender, receiver = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    local_fd = os.open(os.devnull, os.O_RDONLY)
+    received_fd = None
+    try:
+        payload = cuda_vmm._FD_HEADER.pack(5)
+        fds = array.array("i", [local_fd])
+        assert (
+            sender.sendmsg(
+                [payload[:1]],
+                [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds.tobytes())],
+            )
+            == 1
+        )
+        sender.sendall(payload[1:])
+
+        message = cuda_vmm._recv_fd(receiver)
+        assert message is not None
+        rank, received_fd = message
+        assert rank == 5
+        assert os.fstat(received_fd).st_mode == os.fstat(local_fd).st_mode
+    finally:
+        sender.close()
+        receiver.close()
+        os.close(local_fd)
+        if received_fd is not None:
+            os.close(received_fd)
+
+
+def test_fd_exchange_timeout_joins_receiver_before_cleanup(monkeypatch) -> None:
+    local_fd = os.open(os.devnull, os.O_RDONLY)
+    gather_count = 0
+
+    def all_gather(output, value, *, group):
+        nonlocal gather_count
+        assert group == "cpu-group"
+        if gather_count == 0:  # socket setup errors
+            output[:] = [None, None]
+        elif gather_count == 1:  # socket paths; peer path is unreachable
+            output[:] = [value, "/missing/vllm-vmm-peer.sock"]
+        else:  # transfer errors
+            output[:] = [value, value]
+        gather_count += 1
+
+    monkeypatch.setattr(cuda_vmm, "_FD_EXCHANGE_TIMEOUT_S", 0.01)
+    monkeypatch.setattr(cuda_vmm.dist, "get_world_size", lambda _group: 2)
+    monkeypatch.setattr(cuda_vmm.dist, "all_gather_object", all_gather)
+    try:
+        with pytest.raises(RuntimeError, match="POSIX FD transfer failed"):
+            cuda_vmm._exchange_posix_fds(
+                "cpu-group", rank=0, world_size=2, local_fd=local_fd
+            )
+    finally:
+        os.close(local_fd)
+
+    assert not any(
+        thread.name == "vllm-vmm-fd-rank-0" and thread.is_alive()
+        for thread in cuda_vmm.threading.enumerate()
+    )
+
+
+def test_request_rejects_a_multi_host_group(monkeypatch) -> None:
+    group = MagicMock(spec=dist.ProcessGroup)
+    request = ((8, 4), torch.float16, 1, False, False)
+    gathered = [[None, None], [request, request], ["host-a", "host-b"]]
+
+    monkeypatch.setattr(cuda_vmm.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(cuda_vmm.dist, "get_backend", lambda _group: "gloo")
+    monkeypatch.setattr(cuda_vmm.dist, "get_rank", lambda _group: 0)
+    monkeypatch.setattr(cuda_vmm.dist, "get_world_size", lambda _group: 2)
+
+    def all_gather(output, _value, *, group):
+        assert group is not None
+        output[:] = gathered.pop(0)
+
+    monkeypatch.setattr(cuda_vmm.dist, "all_gather_object", all_gather)
+
+    with pytest.raises(ValueError, match="every group rank on one host"):
+        cuda_vmm._validate_request(group, *request)
+
+
+def test_peer_capability_rejects_missing_native_atomics(monkeypatch) -> None:
+    driver = SimpleNamespace(
+        CUresult=SimpleNamespace(CUDA_SUCCESS=0),
+        CUdevice_P2PAttribute=SimpleNamespace(
+            CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED=7
+        ),
+        cuDeviceGet=lambda device_id: (0, device_id),
+        cuDeviceCanAccessPeer=lambda _source, _peer: (0, 1),
+        cuDeviceGetP2PAttribute=lambda _attribute, _source, _peer: (0, 0),
+    )
+    monkeypatch.setattr(cuda_vmm, "_driver", driver)
+    monkeypatch.setattr(cuda_vmm.dist, "get_world_size", lambda _group: 2)
+
+    gather_count = 0
+
+    def all_gather(output, value, *, group):
+        nonlocal gather_count
+        assert group == "cpu-group"
+        if gather_count == 0:
+            output[:] = [0, 1]
+        else:
+            output[:] = [value, value]
+        gather_count += 1
+
+    monkeypatch.setattr(cuda_vmm.dist, "all_gather_object", all_gather)
+
+    with pytest.raises(RuntimeError, match="requires native peer atomics"):
+        cuda_vmm._validate_peer_capabilities(
+            driver,
+            "cpu-group",
+            rank=0,
+            device_id=0,
+            require_native_atomics=True,
+        )
+
+
+def test_mapping_rollback_unmaps_in_reverse_order(monkeypatch) -> None:
+    driver = _FakeDriver()
+    monkeypatch.setattr(cuda_vmm, "_driver", driver)
+    mappings = [100, 164, 228]
+
+    cuda_vmm._rollback_mapping(driver, 100, 192, mappings, 64)
+
+    assert mappings == []
+    assert driver.unmapped == [(228, 64), (164, 64), (100, 64)]
+    assert driver.freed == [(100, 192)]
+
+
+def test_close_is_idempotent_and_keeps_dlpack_callbacks_alive(monkeypatch) -> None:
+    driver = _FakeDriver()
+    monkeypatch.setattr(cuda_vmm, "_driver", driver)
+    synchronize = MagicMock()
+    monkeypatch.setattr(cuda_vmm.torch.accelerator, "synchronize", synchronize)
+    refs = [object()]
+    retired_count = len(cuda_vmm._RETIRED_DLPACK_REFS)
+    view = RankMajorPeerView(
+        global_view=MagicMock(),
+        rank_local_view=MagicMock(),
+        local_view=MagicMock(),
+        requested_shape=(2, 4),
+        aligned_local_shape=(8, 4),
+        rows_per_rank=8,
+        bytes_per_rank=64,
+        rank=0,
+        world_size=2,
+        device=torch.device("cuda:0"),
+        transport="fabric",
+        _global_base_va=100,
+        _rank_local_base_va=300,
+        _total_bytes=128,
+        _global_mappings=[100, 164],
+        _rank_local_mappings=[300, 364],
+        _dlpack_refs=refs,
+    )
+
+    view.close()
+    view.close()
+
+    synchronize.assert_called_once_with(torch.device("cuda:0"))
+    assert driver.unmapped == [(164, 64), (100, 64), (364, 64), (300, 64)]
+    assert driver.freed == [(100, 128), (300, 128)]
+    assert view.closed
+    assert view.global_view is None
+    assert view.rank_local_view is None
+    assert view.local_view is None
+    assert cuda_vmm._RETIRED_DLPACK_REFS[retired_count] is refs
+    cuda_vmm._RETIRED_DLPACK_REFS.pop()
+
+
+def test_close_can_retry_a_failed_unmap(monkeypatch) -> None:
+    driver = _FakeDriver()
+    attempts = 0
+
+    def unmap(address: int, size: int):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return (1,)
+        driver.unmapped.append((address, size))
+        return (0,)
+
+    monkeypatch.setattr(driver, "cuMemUnmap", unmap)
+    monkeypatch.setattr(cuda_vmm, "_driver", driver)
+    monkeypatch.setattr(cuda_vmm.torch.accelerator, "synchronize", lambda _device: None)
+    view = RankMajorPeerView(
+        global_view=MagicMock(),
+        rank_local_view=None,
+        local_view=MagicMock(),
+        requested_shape=(1,),
+        aligned_local_shape=(64,),
+        rows_per_rank=64,
+        bytes_per_rank=64,
+        rank=0,
+        world_size=1,
+        device=torch.device("cuda:0"),
+        transport="posix_fd",
+        _global_base_va=100,
+        _rank_local_base_va=None,
+        _total_bytes=64,
+        _global_mappings=[100],
+        _rank_local_mappings=[],
+        _dlpack_refs=[],
+    )
+
+    with pytest.raises(RuntimeError, match="CUDA VMM close failed"):
+        view.close()
+    assert not view.closed
+
+    view.close()
+    assert view.closed
+    assert driver.unmapped == [(100, 64)]
+    assert driver.freed == [(100, 64)]
+    cuda_vmm._RETIRED_DLPACK_REFS.pop()
+
+
+def _rank_major_peer_worker(rank: int, world_size: int, port: int) -> None:
+    os.environ.update(
+        MASTER_ADDR="127.0.0.1",
+        MASTER_PORT=str(port),
+        RANK=str(rank),
+        WORLD_SIZE=str(world_size),
+    )
+    torch.accelerator.set_device_index(rank)
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+    try:
+        module_path = (
+            Path(__file__).parents[2]
+            / "vllm/model_executor/layers/attention/pcp_peer_cache.py"
+        )
+        spec = importlib.util.spec_from_file_location(
+            "_test_pcp_peer_cache", module_path
+        )
+        assert spec is not None and spec.loader is not None
+        peer_cache = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(peer_cache)
+
+        view = create_rank_major_peer_view(
+            (7, 4),
+            dtype=torch.uint8,
+            group=dist.group.WORLD,
+            first_dim_multiple=8,
+            map_rank_local=True,
+            require_native_atomics=True,
+        )
+        fence = peer_cache.PCPPeerCacheFence(dist.group.WORLD, torch.device("cuda"))
+        assert view.global_view is not None
+        assert view.local_view is not None
+        assert view.rank_local_view is not None
+        assert (
+            view.local_view.untyped_storage().data_ptr() == view.local_view.data_ptr()
+        )
+        assert view.local_view.untyped_storage().nbytes() == view.bytes_per_rank
+        view.local_view.fill_(rank + 1)
+        fence()
+
+        for owner_rank in range(world_size):
+            start = owner_rank * view.rows_per_rank
+            canonical = view.global_view.narrow(0, start, 7)
+            assert torch.all(canonical == owner_rank + 1).item(), (
+                rank,
+                owner_rank,
+                canonical[:, 0].tolist(),
+            )
+
+            local_segment = (owner_rank - rank) % world_size
+            start = local_segment * view.rows_per_rank
+            rotated = view.rank_local_view.narrow(0, start, 7)
+            assert torch.all(rotated == owner_rank + 1).item(), (
+                rank,
+                owner_rank,
+                rotated[:, 0].tolist(),
+            )
+        dist.barrier()
+
+        # Model producer kernels use the canonical mapping to store directly
+        # into every rank's cache. Give each producer a disjoint row in every
+        # owner segment so all directed peer-store paths are covered.
+        for owner_rank in range(world_size):
+            start = owner_rank * view.rows_per_rank
+            view.global_view[start + rank].fill_(101 + rank)
+        fence()
+
+        expected = torch.arange(
+            101,
+            101 + world_size,
+            dtype=torch.uint8,
+            device=view.local_view.device,
+        )
+        assert torch.equal(view.local_view[:world_size, 0], expected)
+        dist.barrier()
+
+        # Exercise alternating epochs and skewed producers. Each rank writes a
+        # disjoint byte in every owner segment, then the system-scope fence
+        # must make all producers visible in every local allocation.
+        for epoch in range(1_000 if world_size == 4 else 10):
+            if epoch % 97 == rank:
+                time.sleep(rank * 0.001)
+            for owner_rank in range(world_size):
+                start = owner_rank * view.rows_per_rank
+                view.global_view[start + rank, 1].fill_((epoch + rank) % 251)
+            fence()
+            expected = torch.tensor(
+                [(epoch + source_rank) % 251 for source_rank in range(world_size)],
+                dtype=torch.uint8,
+                device=view.local_view.device,
+            )
+            assert torch.equal(view.local_view[:world_size, 1], expected)
+            dist.barrier()
+
+        # Closing an owner allocation while a peer is still reading it is
+        # invalid. Quiesce this multi-process stress test before teardown.
+        dist.barrier()
+        fence.close()
+        view.close()
+        view.close()
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+def _peer_access_available(world_size: int) -> bool:
+    if not current_platform.is_cuda() or torch.accelerator.device_count() < world_size:
+        return False
+    return all(
+        src == dst or torch.cuda.can_device_access_peer(src, dst)
+        for src in range(world_size)
+        for dst in range(world_size)
+    )
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_rank_major_peer_reads_writes_and_repeated_close(world_size: int) -> None:
+    if not _peer_access_available(world_size):
+        pytest.skip(f"CUDA VMM peer view requires {world_size} peer-accessible GPUs")
+    mp.spawn(
+        _rank_major_peer_worker,
+        args=(world_size, get_open_port()),
+        nprocs=world_size,
+    )

--- a/tests/kernels/test_fused_deepseek_v32_norm_rope.py
+++ b/tests/kernels/test_fused_deepseek_v32_norm_rope.py
@@ -304,6 +304,69 @@ def test_fused_norm_rope_no_indexer(num_tokens: int):
     assert (topk == 7).all(), "topk buffer should be untouched on shared layer"
 
 
+@pytest.mark.parametrize("index_interleave", [True, False])
+def test_fused_norm_rope_materializes_collective_cache_inputs(
+    index_interleave: bool,
+):
+    """The PCP fallback prepares BF16 inputs without doing local cache writes."""
+    torch.manual_seed(11)
+    dev = "cuda"
+    num_tokens = 5
+    max_pos = 32
+    pos = torch.arange(num_tokens, device=dev, dtype=torch.int64)
+
+    q_c = torch.randn(num_tokens, Q_LORA, device=dev, dtype=torch.bfloat16)
+    kv_c = torch.randn(num_tokens, KV_LORA, device=dev, dtype=torch.bfloat16)
+    k_pe = torch.randn(num_tokens, ROPE_DIM, device=dev, dtype=torch.bfloat16)
+    index_k = torch.randn(num_tokens, INDEX_HEAD_DIM, device=dev, dtype=torch.bfloat16)
+    q_input = q_c.clone()
+    kv_input = kv_c.clone()
+    kpe_input = k_pe.clone()
+    index_input = index_k.clone()
+    qw = torch.randn(Q_LORA, device=dev, dtype=torch.bfloat16)
+    kvw = torch.randn(KV_LORA, device=dev, dtype=torch.bfloat16)
+    index_w = torch.randn(INDEX_HEAD_DIM, device=dev, dtype=torch.float32)
+    index_b = torch.randn(INDEX_HEAD_DIM, device=dev, dtype=torch.float32)
+    cos_sin = make_cos_sin(max_pos, ROPE_DIM, dev)
+    topk = torch.full((num_tokens, 16), 7, device=dev, dtype=torch.int32)
+
+    q_out = K.fused_norm_rope(
+        pos,
+        q_c,
+        qw,
+        EPS,
+        kv_c,
+        kvw,
+        EPS,
+        k_pe,
+        cos_sin,
+        index_k,
+        index_w,
+        index_b,
+        EPS,
+        cos_sin,
+        topk,
+        slot_mapping=None,
+        indexer_k_cache=None,
+        mla_kv_cache=None,
+        has_indexer=True,
+        index_rope_interleave=index_interleave,
+        materialize_cache_inputs=True,
+    )
+
+    assert_bf16(q_out, rms_norm(q_input, qw), "materialized q_c rmsnorm")
+    assert_bf16(kv_c, rms_norm(kv_input, kvw), "materialized kv_c rmsnorm")
+    assert_bf16(
+        k_pe,
+        rope(kpe_input.float(), pos, cos_sin, interleave=True),
+        "materialized MLA k_pe",
+    )
+    index_ref = layer_norm(index_input, index_w, index_b)
+    index_ref = rope(index_ref, pos, cos_sin, interleave=index_interleave)
+    assert_bf16(index_k, index_ref, "materialized indexer k")
+    assert (topk == -1).all(), "topk buffer not cleared on indexer layer"
+
+
 @pytest.mark.parametrize("mla_dtype", ["fp8", "fp8_ds_mla"])
 def test_fused_norm_rope_direct_pcp_fanout_uses_local_rank_slots(mla_dtype: str):
     """Direct PCP stores update every peer cache without gathering inputs."""

--- a/tests/kernels/test_fused_deepseek_v32_norm_rope.py
+++ b/tests/kernels/test_fused_deepseek_v32_norm_rope.py
@@ -24,11 +24,23 @@ outputs are checked within 1 representable-step (ULP); bf16 norm/RoPE outputs us
 rtol/atol=1e-2 (the tolerance the sibling deepseek_v4 fused-kernel test uses).
 """
 
+import os
+
 import pytest
 import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
 
+from vllm.distributed.device_communicators.cuda_vmm import (
+    create_rank_major_peer_view,
+)
+from vllm.model_executor.layers.attention.pcp_peer_cache import (
+    PCPPeerCacheFence,
+    make_rank_major_tensor_view,
+)
 from vllm.models.deepseek_v32.nvidia import kernels as K
 from vllm.platforms import current_platform
+from vllm.utils.network_utils import get_open_port
 
 FP8 = torch.float8_e4m3fn
 FP8_MAX = 448.0
@@ -290,6 +302,413 @@ def test_fused_norm_rope_no_indexer(num_tokens: int):
     )
     # Shared layers reuse the previous indexer's top-k: buffer must be untouched.
     assert (topk == 7).all(), "topk buffer should be untouched on shared layer"
+
+
+@pytest.mark.parametrize("mla_dtype", ["fp8", "fp8_ds_mla"])
+def test_fused_norm_rope_direct_pcp_fanout_uses_local_rank_slots(mla_dtype: str):
+    """Direct PCP stores update every peer cache without gathering inputs."""
+    torch.manual_seed(7)
+    dev = "cuda"
+    num_tokens = 4
+    pcp_size = 2
+    pcp_rank = 1
+    max_pos = 32
+    pos = torch.arange(num_tokens, device=dev, dtype=torch.int64)
+    q_c = torch.randn(num_tokens, Q_LORA, device=dev, dtype=torch.bfloat16)
+    kv_c = torch.randn(num_tokens, KV_LORA, device=dev, dtype=torch.bfloat16)
+    k_pe = torch.randn(num_tokens, ROPE_DIM, device=dev, dtype=torch.bfloat16)
+    qw = torch.randn(Q_LORA, device=dev, dtype=torch.bfloat16)
+    kvw = torch.randn(KV_LORA, device=dev, dtype=torch.bfloat16)
+    index_k = torch.randn(num_tokens, INDEX_HEAD_DIM, device=dev, dtype=torch.bfloat16)
+    index_w = torch.randn(INDEX_HEAD_DIM, device=dev, dtype=torch.float32)
+    index_b = torch.randn(INDEX_HEAD_DIM, device=dev, dtype=torch.float32)
+    cos_sin = make_cos_sin(max_pos, ROPE_DIM, dev)
+
+    mla_dim = 656 if mla_dtype == "fp8_ds_mla" else KV_LORA + ROPE_DIM
+    peer_mla = torch.zeros(pcp_size, 1, max_pos, mla_dim, device=dev, dtype=torch.uint8)
+    index_row = INDEX_HEAD_DIM + 4
+    peer_index = torch.zeros(
+        pcp_size, 1, max_pos, index_row, device=dev, dtype=torch.uint8
+    )
+    # Rank 0 owns slots 0..3. This producer rank has two padding/masked rows
+    # around slots 8..9, as happens for uneven and replicated-decode PCP rows.
+    slot_mapping = torch.cat(
+        (
+            torch.arange(num_tokens, device=dev, dtype=torch.int64),
+            torch.tensor([-1, 8, 9, -1], device=dev, dtype=torch.int64),
+        )
+    )
+    topk = torch.full((num_tokens, 16), 7, device=dev, dtype=torch.int32)
+
+    q_out = K.fused_norm_rope(
+        pos,
+        q_c,
+        qw,
+        EPS,
+        kv_c,
+        kvw,
+        EPS,
+        k_pe,
+        cos_sin,
+        index_k,
+        index_w,
+        index_b,
+        EPS,
+        cos_sin,
+        topk,
+        slot_mapping=slot_mapping,
+        indexer_k_cache=peer_index[pcp_rank],
+        mla_kv_cache=peer_mla[pcp_rank],
+        pcp_peer_indexer_k_cache=peer_index,
+        pcp_peer_mla_kv_cache=peer_mla,
+        pcp_rank=pcp_rank,
+        pcp_size=pcp_size,
+        mla_kv_cache_dtype=mla_dtype,
+        mla_k_scale=(
+            None if mla_dtype == "fp8_ds_mla" else torch.tensor([0.5], device=dev)
+        ),
+        has_indexer=True,
+        index_rope_interleave=True,
+    )
+
+    torch.testing.assert_close(peer_mla[0], peer_mla[1])
+    torch.testing.assert_close(peer_index[0], peer_index[1])
+    assert_bf16(q_out, rms_norm(q_c, qw), "direct PCP q_c rmsnorm")
+    assert not peer_mla[:, :, :num_tokens].any()
+    assert peer_mla[:, :, 8:10].any()
+    assert not peer_mla[:, :, 10:12].any()
+    index_values = peer_index.view(pcp_size, -1)
+    assert not index_values[:, : num_tokens * INDEX_HEAD_DIM].any()
+    assert index_values[:, 8 * INDEX_HEAD_DIM : 10 * INDEX_HEAD_DIM].any()
+    assert not index_values[:, 10 * INDEX_HEAD_DIM : 12 * INDEX_HEAD_DIM].any()
+
+
+def _fused_norm_rope_replicated_vmm_worker(
+    rank: int, world_size: int, port: int
+) -> None:
+    os.environ.update(
+        MASTER_ADDR="127.0.0.1",
+        MASTER_PORT=str(port),
+        RANK=str(rank),
+        WORLD_SIZE=str(world_size),
+    )
+    torch.accelerator.set_device_index(rank)
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+
+    mla_allocation = None
+    index_allocation = None
+    fence = None
+    actual_mla = None
+    actual_index = None
+    expected_mla = None
+    expected_index = None
+    actual_guards = None
+    actual_block_gaps = None
+    direct_q_valid = None
+    reference_q_valid = None
+    expected_q_valid = None
+    try:
+        dev = torch.device(f"cuda:{rank}")
+        # Each producer sees one replicated decode row followed by its four
+        # DualChunkSwap prefill rows.  Only rank 0 owns the decode cache write;
+        # the other ranks must still compute a valid Q for that PAD slot.
+        num_tokens = 5
+        num_blocks = 6
+        block_size = 8
+        mla_dim = KV_LORA + ROPE_DIM
+        index_dim = INDEX_HEAD_DIM + 4
+
+        # Production gives each rank a complete local cache and maps those
+        # allocations rank-major. Construct real strided cache views over a
+        # larger backing allocation: consecutive physical blocks are separated
+        # by gaps which must not be mistaken for cache storage. Nonzero outer
+        # offsets additionally validate mirroring a subview of the allocation.
+        guard_bytes = 128
+        mla_block_bytes = block_size * mla_dim
+        index_block_bytes = block_size * index_dim
+        mla_gap_bytes = 64
+        index_gap_bytes = 32
+        mla_block_stride = mla_block_bytes + mla_gap_bytes
+        index_block_stride = index_block_bytes + index_gap_bytes
+        mla_backing_bytes = (num_blocks - 1) * mla_block_stride + mla_block_bytes
+        index_backing_bytes = (num_blocks - 1) * index_block_stride + index_block_bytes
+        mla_allocation = create_rank_major_peer_view(
+            (guard_bytes + mla_backing_bytes + guard_bytes,),
+            dtype=torch.uint8,
+            group=dist.group.WORLD,
+            require_native_atomics=True,
+            device=dev,
+        )
+        index_allocation = create_rank_major_peer_view(
+            (guard_bytes + index_backing_bytes + guard_bytes,),
+            dtype=torch.uint8,
+            group=dist.group.WORLD,
+            require_native_atomics=True,
+            device=dev,
+        )
+        mla_allocation.local_view.zero_()
+        index_allocation.local_view.zero_()
+        local_mla_backing = mla_allocation.local_view.narrow(
+            0, guard_bytes, mla_backing_bytes
+        )
+        local_index_backing = index_allocation.local_view.narrow(
+            0, guard_bytes, index_backing_bytes
+        )
+        local_mla = torch.as_strided(
+            local_mla_backing,
+            size=(num_blocks, block_size, mla_dim),
+            stride=(mla_block_stride, mla_dim, 1),
+        )
+        local_index = torch.as_strided(
+            local_index_backing,
+            size=(num_blocks, block_size, index_dim),
+            stride=(index_block_stride, index_dim, 1),
+        )
+        assert local_mla.stride(0) == mla_block_stride > mla_block_bytes
+        assert local_index.stride(0) == index_block_stride > index_block_bytes
+        peer_mla = make_rank_major_tensor_view(mla_allocation, local_mla)
+        peer_index = make_rank_major_tensor_view(index_allocation, local_index)
+        assert peer_mla.shape == (world_size, *local_mla.shape)
+        assert peer_index.shape == (world_size, *local_index.shape)
+        fence = PCPPeerCacheFence(dist.group.WORLD, dev)
+
+        # This is the exact DualChunkSwap partition for an uneven 13-token
+        # prefill at PCP=4 (eight chunks of size two), prefixed by one decode
+        # token replicated onto every rank. Padding gathers token 0 but carries
+        # slot -1. Rank 0 exclusively owns the replicated decode cache write.
+        #
+        # Valid slots deliberately span six physical blocks and use varied
+        # in-block offsets. This catches kernels that accidentally treat the
+        # packed caches as dense rows or ignore their physical block stride.
+        gather_rows = torch.tensor(
+            [
+                [13, 0, 1, 0, 0],
+                [13, 2, 3, 12, 0],
+                [13, 4, 5, 10, 11],
+                [13, 6, 7, 8, 9],
+            ],
+            dtype=torch.int64,
+            device=dev,
+        )
+        slot_rows = torch.tensor(
+            [
+                [37, 19, 26, -1, -1],
+                [-1, 35, 4, 44, -1],
+                [-1, 11, 21, 30, 47],
+                [-1, 1, 15, 24, 40],
+            ],
+            dtype=torch.int64,
+            device=dev,
+        )
+        valid_slots = slot_rows[slot_rows >= 0]
+        assert valid_slots.unique().numel() == valid_slots.numel()
+        assert slot_rows[0, 0] >= 0
+        assert (slot_rows[1:, 0] == -1).all()
+        assert (valid_slots // block_size).unique().numel() == num_blocks
+        assert (valid_slots % block_size).unique().numel() > 4
+
+        torch.manual_seed(2026)
+        global_tokens = 14
+        positions_global = torch.arange(global_tokens, device=dev, dtype=torch.int64)
+        positions_global[-1] = 31
+        q_global = torch.randn(global_tokens, Q_LORA, device=dev, dtype=torch.bfloat16)
+        kv_global = torch.randn(
+            global_tokens, KV_LORA, device=dev, dtype=torch.bfloat16
+        )
+        kpe_global = torch.randn(
+            global_tokens, ROPE_DIM, device=dev, dtype=torch.bfloat16
+        )
+        index_global = torch.randn(
+            global_tokens, INDEX_HEAD_DIM, device=dev, dtype=torch.bfloat16
+        )
+        q_weight = torch.randn(Q_LORA, device=dev, dtype=torch.bfloat16)
+        kv_weight = torch.randn(KV_LORA, device=dev, dtype=torch.bfloat16)
+        index_weight = torch.randn(INDEX_HEAD_DIM, device=dev, dtype=torch.float32)
+        index_bias = torch.randn(INDEX_HEAD_DIM, device=dev, dtype=torch.float32)
+        cos_sin = make_cos_sin(32, ROPE_DIM, dev)
+        local_gather = gather_rows[rank]
+        positions = positions_global[local_gather]
+        q_c = q_global[local_gather]
+        kv_c = kv_global[local_gather]
+        k_pe = kpe_global[local_gather]
+        index_k = index_global[local_gather]
+        mla_k_scale = torch.tensor([0.5], device=dev, dtype=torch.float32)
+
+        direct_topk = torch.full((num_tokens, 16), 7, device=dev, dtype=torch.int32)
+        direct_q = K.fused_norm_rope(
+            positions,
+            q_c,
+            q_weight,
+            EPS,
+            kv_c,
+            kv_weight,
+            EPS,
+            k_pe,
+            cos_sin,
+            index_k,
+            index_weight,
+            index_bias,
+            EPS,
+            cos_sin,
+            direct_topk,
+            slot_mapping=slot_rows.flatten(),
+            indexer_k_cache=local_index,
+            mla_kv_cache=local_mla,
+            pcp_peer_indexer_k_cache=peer_index,
+            pcp_peer_mla_kv_cache=peer_mla,
+            pcp_rank=rank,
+            pcp_size=world_size,
+            mla_kv_cache_dtype="fp8",
+            mla_k_scale=mla_k_scale,
+            has_indexer=True,
+            index_rope_interleave=True,
+        )
+        fence()
+
+        # The ordinary single-rank path is the byte-level oracle for this
+        # producer. Combining the disjoint local writes across ranks yields the
+        # exact full replica that every direct-store cache must observe.
+        reference_mla_backing = torch.zeros(
+            mla_backing_bytes, device=dev, dtype=torch.uint8
+        )
+        reference_index_backing = torch.zeros(
+            index_backing_bytes, device=dev, dtype=torch.uint8
+        )
+        reference_mla = torch.as_strided(
+            reference_mla_backing,
+            size=local_mla.shape,
+            stride=local_mla.stride(),
+        )
+        reference_index = torch.as_strided(
+            reference_index_backing,
+            size=local_index.shape,
+            stride=local_index.stride(),
+        )
+        reference_topk = torch.full_like(direct_topk, 7)
+        reference_q = K.fused_norm_rope(
+            positions,
+            q_c,
+            q_weight,
+            EPS,
+            kv_c,
+            kv_weight,
+            EPS,
+            k_pe,
+            cos_sin,
+            index_k,
+            index_weight,
+            index_bias,
+            EPS,
+            cos_sin,
+            reference_topk,
+            slot_mapping=slot_rows[rank],
+            indexer_k_cache=reference_index,
+            mla_kv_cache=reference_mla,
+            mla_kv_cache_dtype="fp8",
+            mla_k_scale=mla_k_scale,
+            has_indexer=True,
+            index_rope_interleave=True,
+        )
+
+        local_reference = (reference_mla.cpu(), reference_index.cpu())
+        gathered_references = [None] * world_size
+        dist.all_gather_object(
+            gathered_references, local_reference, group=dist.group.WORLD
+        )
+        expected_mla = torch.zeros_like(local_reference[0])
+        expected_index = torch.zeros_like(local_reference[1])
+        for reference in gathered_references:
+            assert reference is not None
+            reference_mla, reference_index = reference
+            expected_mla.bitwise_or_(reference_mla)
+            expected_index.bitwise_or_(reference_index)
+
+        actual_mla = local_mla.cpu()
+        actual_index = local_index.cpu()
+        actual_guards = torch.cat(
+            (
+                mla_allocation.local_view[:guard_bytes],
+                mla_allocation.local_view[guard_bytes + mla_backing_bytes :],
+                index_allocation.local_view[:guard_bytes],
+                index_allocation.local_view[guard_bytes + index_backing_bytes :],
+            )
+        ).cpu()
+        actual_block_gaps = torch.cat(
+            [
+                local_mla_backing.narrow(
+                    0, block * mla_block_stride + mla_block_bytes, mla_gap_bytes
+                )
+                for block in range(num_blocks - 1)
+            ]
+            + [
+                local_index_backing.narrow(
+                    0,
+                    block * index_block_stride + index_block_bytes,
+                    index_gap_bytes,
+                )
+                for block in range(num_blocks - 1)
+            ]
+        ).cpu()
+        direct_q_valid = direct_q.cpu()
+        reference_q_valid = reference_q.cpu()
+        # Q production is independent of cache insertion. In particular, all
+        # replicated-decode copies and uneven-prefill PAD rows must retain Q.
+        # Save the evidence now and assert only after peer mappings are closed.
+        expected_q_valid = rms_norm(q_c, q_weight).cpu()
+
+        # Do not assert while peer mappings are live: all ranks first copy the
+        # evidence, quiesce, and close in reverse allocation order.
+        dist.barrier()
+        fence.close()
+        fence = None
+        index_allocation.close()
+        index_allocation = None
+        mla_allocation.close()
+        mla_allocation = None
+        dist.barrier()
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    assert actual_mla is not None and expected_mla is not None
+    assert actual_index is not None and expected_index is not None
+    assert actual_guards is not None
+    assert actual_block_gaps is not None
+    assert direct_q_valid is not None and reference_q_valid is not None
+    assert expected_q_valid is not None
+    assert torch.equal(actual_mla, expected_mla), (
+        int((actual_mla != expected_mla).sum()),
+        int(actual_mla.count_nonzero()),
+        int(expected_mla.count_nonzero()),
+        actual_mla.count_nonzero(dim=(1, 2)).nonzero().flatten().tolist(),
+        expected_mla.count_nonzero(dim=(1, 2)).nonzero().flatten().tolist(),
+        actual_mla.flatten()[(actual_mla != expected_mla).flatten()][:16].tolist(),
+        expected_mla.flatten()[(actual_mla != expected_mla).flatten()][:16].tolist(),
+    )
+    assert torch.equal(actual_index, expected_index), (
+        int((actual_index != expected_index).sum()),
+        int(actual_index.count_nonzero()),
+        int(expected_index.count_nonzero()),
+    )
+    assert not actual_guards.any()
+    assert not actual_block_gaps.any()
+    assert torch.equal(direct_q_valid, reference_q_valid)
+    assert_bf16(direct_q_valid, expected_q_valid, "direct PCP packed/mixed Q")
+
+
+def test_fused_norm_rope_replicated_vmm_pcp4() -> None:
+    world_size = 4
+    if torch.accelerator.device_count() < world_size or not all(
+        source == destination or torch.cuda.can_device_access_peer(source, destination)
+        for source in range(world_size)
+        for destination in range(world_size)
+    ):
+        pytest.skip("replicated PCP fanout requires four peer-accessible CUDA GPUs")
+    mp.spawn(
+        _fused_norm_rope_replicated_vmm_worker,
+        args=(world_size, get_open_port()),
+        nprocs=world_size,
+    )
 
 
 @pytest.mark.parametrize("num_tokens", [1, 4, 17, 512])

--- a/tests/model_executor/test_pcp_peer_cache.py
+++ b/tests/model_executor/test_pcp_peer_cache.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.model_executor.layers.attention.pcp_peer_cache import (
+    PCPPeerCacheFence,
+    make_rank_major_tensor_view,
+)
+
+
+def test_rank_major_tensor_view_preserves_packed_offset_and_stride() -> None:
+    world_size = 2
+    bytes_per_rank = 64
+    global_view = torch.arange(world_size * bytes_per_rank, dtype=torch.int8)
+    local_view = global_view[bytes_per_rank:]
+    allocation = SimpleNamespace(
+        global_view=global_view,
+        local_view=local_view,
+        bytes_per_rank=bytes_per_rank,
+        world_size=world_size,
+    )
+    local_tensor = local_view.view(4, 16)[:, 4:12]
+
+    peer_tensor = make_rank_major_tensor_view(allocation, local_tensor)
+
+    assert peer_tensor.shape == (world_size, 4, 8)
+    assert peer_tensor.stride() == (bytes_per_rank, 16, 1)
+    torch.testing.assert_close(peer_tensor[1], local_tensor)
+    torch.testing.assert_close(
+        peer_tensor[0], global_view[:bytes_per_rank].view(4, 16)[:, 4:12]
+    )
+
+
+def test_peer_cache_fence_close_quiesces_group_before_unmap(monkeypatch) -> None:
+    events: list[object] = []
+    allocation = SimpleNamespace(
+        device=torch.device("cuda:2"),
+        close=lambda: events.append("close"),
+    )
+    fence = object.__new__(PCPPeerCacheFence)
+    fence._group = "pcp-cpu-group"
+    fence._allocation = allocation
+
+    monkeypatch.setattr(
+        torch.accelerator,
+        "synchronize",
+        lambda device: events.append(("synchronize", device)),
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.attention.pcp_peer_cache.dist.barrier",
+        lambda *, group: events.append(("barrier", group)),
+    )
+
+    fence.close()
+
+    assert events == [
+        ("synchronize", torch.device("cuda:2")),
+        ("barrier", "pcp-cpu-group"),
+        "close",
+    ]

--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -36,6 +36,7 @@ if not current_platform.is_cuda():
 
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.mla.flashinfer_mla_sparse import (
+    FlashInferMLASparseImpl,
     FlashInferMLASparseTRTLLMBackend,
 )
 from vllm.v1.attention.backends.mla.flashmla_sparse import (
@@ -71,6 +72,24 @@ SPARSE_BACKEND_BATCH_SPECS["large_q_pure_prefill"] = BatchSpec(
 )
 
 DEVICE_TYPE = current_platform.device_type
+
+
+def test_flashinfer_sparse_mla_accepts_zero_local_tokens() -> None:
+    impl = object.__new__(FlashInferMLASparseImpl)
+    impl.num_heads = 4
+    impl.kv_lora_rank = 512
+    q = torch.empty((0, 4, 192), device=DEVICE_TYPE)
+
+    output, lse = impl.forward_mqa(
+        q,
+        torch.empty((1,), device=DEVICE_TYPE),
+        SimpleNamespace(),
+        SimpleNamespace(),
+    )
+
+    assert output.shape == (0, 4, 512)
+    assert output.device == q.device
+    assert lse is None
 
 
 def _float_to_e8m0_truncate(f: float) -> float:

--- a/vllm/distributed/device_communicators/cuda_vmm.py
+++ b/vllm/distributed/device_communicators/cuda_vmm.py
@@ -1,0 +1,1060 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright 2023-2026 SGLang Team
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Adapted from https://github.com/sgl-project/sglang/pull/31435
+"""CUDA VMM-backed rank-major peer tensor views.
+
+The setup path exchanges allocation handles. Once constructed, the returned
+views use ordinary device loads and stores; they do not issue runtime pulls,
+gets, collectives, or copies.
+"""
+
+from __future__ import annotations
+
+import array
+import ctypes
+import math
+import os
+import socket
+import struct
+import tempfile
+import threading
+from contextlib import suppress
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_driver: Any | None = None
+_FD_EXCHANGE_TIMEOUT_S = 120.0
+_FD_HEADER = struct.Struct("<Q")
+
+# A PyTorch tensor may be kept alive after its owning peer view is closed. The
+# VMM address is invalid after close, but the DLPack deleter callback must still
+# be callable when such an alias is eventually destroyed.
+_RETIRED_DLPACK_REFS: list[list[Any]] = []
+
+
+def _get_cuda_driver() -> Any:
+    global _driver
+    if _driver is None:
+        try:
+            from cuda.bindings import driver
+        except ModuleNotFoundError as exc:
+            raise RuntimeError(
+                "CUDA VMM peer views require the cuda-bindings package."
+            ) from exc
+        _driver = driver
+    return _driver
+
+
+def _check_driver(result: Any, operation: str) -> Any:
+    """Return a CUDA driver result value or raise an actionable error."""
+    if not isinstance(result, tuple):
+        result = (result,)
+    error = result[0]
+    driver = _get_cuda_driver()
+    if error != driver.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"{operation} failed with {error}")
+    if len(result) == 1:
+        return None
+    if len(result) == 2:
+        return result[1]
+    return result[1:]
+
+
+def _error_text(error: BaseException | None) -> str | None:
+    if error is None:
+        return None
+    return f"{type(error).__name__}: {error}"
+
+
+def _gather_errors(
+    group: ProcessGroup, local_error: BaseException | None
+) -> list[str | None]:
+    errors: list[str | None] = [None] * dist.get_world_size(group)
+    dist.all_gather_object(errors, _error_text(local_error), group=group)
+    return errors
+
+
+def _raise_if_any_rank_failed(
+    group: ProcessGroup,
+    rank: int,
+    stage: str,
+    local_error: BaseException | None,
+) -> None:
+    errors = _gather_errors(group, local_error)
+    for failed_rank, error in enumerate(errors):
+        if error is None:
+            continue
+        message = f"CUDA VMM {stage} failed on group rank {failed_rank}: {error}"
+        if failed_rank == rank:
+            raise RuntimeError(message) from local_error
+        raise RuntimeError(message)
+
+
+def _validate_request(
+    group: ProcessGroup,
+    local_shape: tuple[int, ...],
+    dtype: torch.dtype,
+    first_dim_multiple: int,
+    map_rank_local: bool,
+    require_native_atomics: bool,
+) -> tuple[int, int]:
+    if not isinstance(group, ProcessGroup):
+        raise TypeError("group must be a torch.distributed.ProcessGroup")
+    if not dist.is_initialized():
+        raise RuntimeError("torch.distributed must be initialized")
+    if dist.get_backend(group) == dist.Backend.NCCL:
+        raise ValueError("CUDA VMM setup requires a CPU-capable ProcessGroup, not NCCL")
+
+    rank = dist.get_rank(group)
+    world_size = dist.get_world_size(group)
+    local_error: BaseException | None = None
+    try:
+        if not local_shape:
+            raise ValueError("local_shape must have at least one dimension")
+        if any(not isinstance(dim, int) or dim <= 0 for dim in local_shape):
+            raise ValueError(f"local_shape dimensions must be positive: {local_shape}")
+        if first_dim_multiple <= 0:
+            raise ValueError("first_dim_multiple must be positive")
+        _dtype_to_dlpack(dtype)
+    except BaseException as exc:
+        local_error = exc
+    _raise_if_any_rank_failed(group, rank, "request validation", local_error)
+
+    requests: list[Any] = [None] * world_size
+    request = (
+        local_shape,
+        dtype,
+        first_dim_multiple,
+        map_rank_local,
+        require_native_atomics,
+    )
+    dist.all_gather_object(requests, request, group=group)
+    if any(peer_request != request for peer_request in requests):
+        details = ", ".join(
+            f"rank {peer_rank}={peer_request!r}"
+            for peer_rank, peer_request in enumerate(requests)
+        )
+        raise ValueError(
+            "CUDA VMM peer view arguments must match on every rank; " + details
+        )
+
+    hosts: list[str | None] = [None] * world_size
+    dist.all_gather_object(hosts, socket.gethostname(), group=group)
+    if len(set(hosts)) != 1:
+        details = ", ".join(
+            f"rank {peer_rank}={host!r}" for peer_rank, host in enumerate(hosts)
+        )
+        raise ValueError(
+            "CUDA VMM peer views require every group rank on one host; " + details
+        )
+    return rank, world_size
+
+
+def _validate_peer_capabilities(
+    driver: Any,
+    group: ProcessGroup,
+    rank: int,
+    device_id: int,
+    require_native_atomics: bool,
+) -> None:
+    """Collectively validate directed access from each rank to every peer."""
+    world_size = dist.get_world_size(group)
+    device_ids: list[int | None] = [None] * world_size
+    dist.all_gather_object(device_ids, device_id, group=group)
+
+    local_error: BaseException | None = None
+    try:
+        if any(peer_device is None for peer_device in device_ids):
+            raise RuntimeError("A peer rank did not report its CUDA device.")
+        if len(set(device_ids)) != world_size:
+            raise ValueError(
+                "CUDA VMM peer views require one distinct CUDA device per rank; "
+                f"got {device_ids}."
+            )
+
+        source_device = _check_driver(
+            driver.cuDeviceGet(device_id), f"cuDeviceGet({device_id})"
+        )
+        atomic_attribute = (
+            driver.CUdevice_P2PAttribute.CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED
+        )
+        for peer_rank, peer_device_id in enumerate(device_ids):
+            if peer_rank == rank:
+                continue
+            assert peer_device_id is not None
+            peer_device = _check_driver(
+                driver.cuDeviceGet(peer_device_id),
+                f"cuDeviceGet({peer_device_id})",
+            )
+            can_access = int(
+                _check_driver(
+                    driver.cuDeviceCanAccessPeer(source_device, peer_device),
+                    f"cuDeviceCanAccessPeer({device_id}, {peer_device_id})",
+                )
+            )
+            if not can_access:
+                raise NotImplementedError(
+                    "CUDA device "
+                    f"{device_id} cannot access PCP rank {peer_rank} device "
+                    f"{peer_device_id}."
+                )
+            if require_native_atomics:
+                native_atomics = int(
+                    _check_driver(
+                        driver.cuDeviceGetP2PAttribute(
+                            atomic_attribute, source_device, peer_device
+                        ),
+                        "cuDeviceGetP2PAttribute(NATIVE_ATOMIC_SUPPORTED, "
+                        f"{device_id}, {peer_device_id})",
+                    )
+                )
+                if not native_atomics:
+                    raise NotImplementedError(
+                        "Direct PCP KV requires native peer atomics, but CUDA "
+                        f"device {device_id} cannot issue them to PCP rank "
+                        f"{peer_rank} device {peer_device_id}."
+                    )
+    except BaseException as exc:
+        local_error = exc
+    _raise_if_any_rank_failed(group, rank, "peer capability validation", local_error)
+
+
+def _make_allocation_property(driver: Any, device_id: int, handle_types: Any) -> Any:
+    prop = driver.CUmemAllocationProp()
+    prop.type = driver.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
+    prop.location = driver.CUmemLocation()
+    prop.location.type = driver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+    prop.location.id = device_id
+    prop.requestedHandleTypes = handle_types
+    return prop
+
+
+def _make_rw_access(driver: Any, device_id: int) -> Any:
+    access = driver.CUmemAccessDesc()
+    access.location.type = driver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+    access.location.id = device_id
+    access.flags = driver.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
+    return access
+
+
+def _element_size(dtype: torch.dtype) -> int:
+    return torch.empty((), dtype=dtype, device="cpu").element_size()
+
+
+def _aligned_local_shape(
+    local_shape: tuple[int, ...],
+    dtype: torch.dtype,
+    granularity: int,
+    first_dim_multiple: int,
+) -> tuple[tuple[int, ...], int]:
+    row_bytes = math.prod(local_shape[1:]) * _element_size(dtype)
+    rows_per_granularity = granularity // math.gcd(granularity, row_bytes)
+    row_alignment = math.lcm(rows_per_granularity, first_dim_multiple)
+    rows = math.ceil(local_shape[0] / row_alignment) * row_alignment
+    return (rows, *local_shape[1:]), rows * row_bytes
+
+
+def _release_handle(driver: Any, handle: Any, label: str) -> None:
+    _check_driver(driver.cuMemRelease(handle), label)
+
+
+def _allocate_local_segment(
+    driver: Any,
+    group: ProcessGroup,
+    rank: int,
+    device_id: int,
+    local_shape: tuple[int, ...],
+    dtype: torch.dtype,
+    first_dim_multiple: int,
+) -> tuple[Any, tuple[int, ...], int, int]:
+    posix = driver.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+    granularity_flag = (
+        driver.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_RECOMMENDED
+    )
+
+    prop: Any | None = None
+    granularity = 0
+    aligned_shape: tuple[int, ...] = ()
+    segment_bytes = 0
+    local_error: BaseException | None = None
+    try:
+        # The Python CUDA bindings do not consistently accept combined
+        # CUmemAllocationHandleType bitmasks across releases. POSIX FDs are the
+        # portable same-host transport required by this primitive; transport
+        # choice does not affect runtime peer loads or stores after mapping.
+        prop = _make_allocation_property(driver, device_id, posix)
+        granularity = int(
+            _check_driver(
+                driver.cuMemGetAllocationGranularity(prop, granularity_flag),
+                "cuMemGetAllocationGranularity",
+            )
+        )
+        aligned_shape, segment_bytes = _aligned_local_shape(
+            local_shape, dtype, granularity, first_dim_multiple
+        )
+    except BaseException as exc:
+        local_error = exc
+    _raise_if_any_rank_failed(group, rank, "allocation planning", local_error)
+    assert prop is not None
+
+    plan = (aligned_shape, segment_bytes, granularity)
+    plans: list[Any] = [None] * dist.get_world_size(group)
+    dist.all_gather_object(plans, plan, group=group)
+    if any(peer_plan != plan for peer_plan in plans):
+        details = ", ".join(
+            f"rank {peer_rank}={peer_plan!r}"
+            for peer_rank, peer_plan in enumerate(plans)
+        )
+        raise RuntimeError(
+            "CUDA VMM allocation granularity must match on every rank; " + details
+        )
+
+    local_handle: Any | None = None
+    allocation_error: BaseException | None = None
+    try:
+        local_handle = _check_driver(
+            driver.cuMemCreate(segment_bytes, prop, 0),
+            "cuMemCreate(POSIX_FD)",
+        )
+    except BaseException as exc:
+        allocation_error = exc
+    try:
+        _raise_if_any_rank_failed(group, rank, "local allocation", allocation_error)
+    except BaseException:
+        if local_handle is not None:
+            _release_handle(driver, local_handle, "cuMemRelease(failed allocation)")
+        raise
+    return local_handle, aligned_shape, segment_bytes, granularity
+
+
+def _export_local_handle(
+    driver: Any,
+    group: ProcessGroup,
+    rank: int,
+    local_handle: Any,
+) -> tuple[Literal["fabric", "posix_fd"], bytes | int]:
+    posix = driver.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+
+    local_fd: int | None = None
+    posix_error: BaseException | None = None
+    try:
+        local_fd = int(
+            _check_driver(
+                driver.cuMemExportToShareableHandle(local_handle, posix, 0),
+                "cuMemExportToShareableHandle(POSIX_FD)",
+            )
+        )
+    except BaseException as exc:
+        posix_error = exc
+    try:
+        _raise_if_any_rank_failed(group, rank, "handle export", posix_error)
+    except BaseException:
+        if local_fd is not None:
+            os.close(local_fd)
+        raise
+    assert local_fd is not None
+    return "posix_fd", local_fd
+
+
+def _send_fd(sock: socket.socket, rank: int, fd: int) -> None:
+    payload = _FD_HEADER.pack(rank)
+    fds = array.array("i", [fd])
+    sent = sock.sendmsg(
+        [payload],
+        [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds.tobytes())],
+    )
+    if sent <= 0:
+        raise RuntimeError("sendmsg did not send the FD header")
+    if sent < len(payload):
+        # SOCK_SEQPACKET sends the header atomically. The SOCK_STREAM fallback
+        # may split it; SCM_RIGHTS is already attached to the first byte, so
+        # only the remaining framing bytes are sent here.
+        sock.sendall(payload[sent:])
+
+
+def _recv_fd(sock: socket.socket) -> tuple[int, int] | None:
+    fd_size = array.array("i").itemsize
+    payload = bytearray()
+    received = array.array("i")
+    try:
+        while len(payload) < _FD_HEADER.size:
+            chunk, ancillary, _, _ = sock.recvmsg(
+                _FD_HEADER.size - len(payload), socket.CMSG_SPACE(fd_size)
+            )
+            if not chunk:
+                if not payload and not received:
+                    return None
+                raise RuntimeError(
+                    "peer closed with an incomplete POSIX FD header: "
+                    f"{len(payload)}/{_FD_HEADER.size} bytes"
+                )
+            payload.extend(chunk)
+            for level, message_type, data in ancillary:
+                if level == socket.SOL_SOCKET and message_type == socket.SCM_RIGHTS:
+                    received.frombytes(data[: len(data) - len(data) % fd_size])
+        if len(received) != 1:
+            raise RuntimeError(
+                f"expected one file descriptor, received {len(received)}"
+            )
+        return _FD_HEADER.unpack(payload)[0], int(received[0])
+    except BaseException:
+        for received_fd in received:
+            os.close(received_fd)
+        raise
+
+
+def _exchange_posix_fds(
+    group: ProcessGroup, rank: int, world_size: int, local_fd: int
+) -> dict[int, int]:
+    """Exchange one process-local CUDA allocation FD per group rank."""
+    socket_kind = getattr(socket, "SOCK_SEQPACKET", socket.SOCK_STREAM)
+    socket_dir: str | None = None
+    socket_path: str | None = None
+    server: socket.socket | None = None
+    received: dict[int, int] = {}
+    receive_errors: list[BaseException] = []
+    active_connections: set[socket.socket] = set()
+    connection_lock = threading.Lock()
+
+    def receive_loop() -> None:
+        assert server is not None
+        try:
+            for _ in range(world_size - 1):
+                connection, _ = server.accept()
+                with connection_lock:
+                    active_connections.add(connection)
+                try:
+                    connection.settimeout(_FD_EXCHANGE_TIMEOUT_S)
+                    message = _recv_fd(connection)
+                    if message is None:
+                        raise RuntimeError(
+                            "peer closed its socket before sending an FD"
+                        )
+                    peer_rank, peer_fd = message
+                    if peer_rank in received:
+                        os.close(peer_fd)
+                        raise RuntimeError(f"duplicate FD from group rank {peer_rank}")
+                    received[peer_rank] = peer_fd
+                finally:
+                    with connection_lock:
+                        active_connections.discard(connection)
+                    connection.close()
+        except BaseException as exc:
+            receive_errors.append(exc)
+
+    try:
+        setup_error: BaseException | None = None
+        try:
+            socket_dir = tempfile.mkdtemp(prefix="vllm_vmm_fd_")
+            socket_path = os.path.join(socket_dir, f"rank_{rank}.sock")
+            server = socket.socket(socket.AF_UNIX, socket_kind)
+            server.settimeout(_FD_EXCHANGE_TIMEOUT_S)
+            server.bind(socket_path)
+            server.listen(world_size)
+        except BaseException as exc:
+            setup_error = exc
+        _raise_if_any_rank_failed(group, rank, "POSIX FD socket setup", setup_error)
+
+        socket_paths: list[str | None] = [None] * world_size
+        dist.all_gather_object(socket_paths, socket_path, group=group)
+        thread = threading.Thread(
+            target=receive_loop,
+            name=f"vllm-vmm-fd-rank-{rank}",
+            daemon=True,
+        )
+        thread.start()
+
+        send_error: BaseException | None = None
+        try:
+            for peer_rank, peer_path in enumerate(socket_paths):
+                if peer_rank == rank:
+                    continue
+                assert peer_path is not None
+                with socket.socket(socket.AF_UNIX, socket_kind) as client:
+                    client.settimeout(_FD_EXCHANGE_TIMEOUT_S)
+                    client.connect(peer_path)
+                    _send_fd(client, rank, local_fd)
+        except BaseException as exc:
+            send_error = exc
+        thread.join(_FD_EXCHANGE_TIMEOUT_S)
+        transfer_error = send_error
+        if thread.is_alive():
+            if transfer_error is None:
+                transfer_error = RuntimeError("timed out receiving POSIX FDs")
+            # Stop accept/recv before inspecting or closing ``received`` so a
+            # late SCM_RIGHTS message cannot race cleanup and leak its FD.
+            assert server is not None
+            server.close()
+            with connection_lock:
+                connections = tuple(active_connections)
+            for connection in connections:
+                with suppress(OSError):
+                    connection.shutdown(socket.SHUT_RDWR)
+                connection.close()
+            thread.join()
+        if transfer_error is None and receive_errors:
+            transfer_error = receive_errors[0]
+        expected = set(range(world_size)) - {rank}
+        if transfer_error is None and set(received) != expected:
+            transfer_error = RuntimeError(
+                "FD sender mismatch: "
+                f"missing={sorted(expected - set(received))}, "
+                f"extra={sorted(set(received) - expected)}"
+            )
+        try:
+            _raise_if_any_rank_failed(group, rank, "POSIX FD transfer", transfer_error)
+        except BaseException:
+            for peer_fd in received.values():
+                os.close(peer_fd)
+            received.clear()
+            raise
+        return received
+    finally:
+        if server is not None:
+            server.close()
+        if socket_path is not None:
+            with suppress(FileNotFoundError):
+                os.unlink(socket_path)
+        if socket_dir is not None:
+            with suppress(OSError):
+                os.rmdir(socket_dir)
+
+
+def _import_peer_handle(
+    driver: Any,
+    transport: Literal["fabric", "posix_fd"],
+    exported_handle: bytes | int,
+    peer_rank: int,
+) -> Any:
+    handle_types = driver.CUmemAllocationHandleType
+    if transport == "fabric":
+        handle_type = handle_types.CU_MEM_HANDLE_TYPE_FABRIC
+        return _check_driver(
+            driver.cuMemImportFromShareableHandle(exported_handle, handle_type),
+            f"cuMemImportFromShareableHandle(FABRIC, rank={peer_rank})",
+        )
+
+    handle_type = handle_types.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+    duplicate_fd = os.dup(int(exported_handle))
+    try:
+        return _check_driver(
+            driver.cuMemImportFromShareableHandle(duplicate_fd, handle_type),
+            f"cuMemImportFromShareableHandle(POSIX_FD, rank={peer_rank})",
+        )
+    finally:
+        os.close(duplicate_fd)
+
+
+class _DLDevice(ctypes.Structure):
+    _fields_ = [("device_type", ctypes.c_int), ("device_id", ctypes.c_int)]
+
+
+class _DLDataType(ctypes.Structure):
+    _fields_ = [
+        ("code", ctypes.c_uint8),
+        ("bits", ctypes.c_uint8),
+        ("lanes", ctypes.c_uint16),
+    ]
+
+
+class _DLTensor(ctypes.Structure):
+    _fields_ = [
+        ("data", ctypes.c_void_p),
+        ("device", _DLDevice),
+        ("ndim", ctypes.c_int),
+        ("dtype", _DLDataType),
+        ("shape", ctypes.POINTER(ctypes.c_int64)),
+        ("strides", ctypes.POINTER(ctypes.c_int64)),
+        ("byte_offset", ctypes.c_uint64),
+    ]
+
+
+class _DLManagedTensor(ctypes.Structure):
+    pass
+
+
+_DLPACK_DELETER = ctypes.CFUNCTYPE(None, ctypes.POINTER(_DLManagedTensor))
+_DLManagedTensor._fields_ = [
+    ("dl_tensor", _DLTensor),
+    ("manager_ctx", ctypes.c_void_p),
+    ("deleter", _DLPACK_DELETER),
+]
+
+
+def _dtype_to_dlpack(dtype: torch.dtype) -> tuple[int, int]:
+    types: dict[torch.dtype, tuple[int, int]] = {
+        torch.uint8: (1, 8),
+        torch.int8: (0, 8),
+        torch.int16: (0, 16),
+        torch.int32: (0, 32),
+        torch.int64: (0, 64),
+        torch.float16: (2, 16),
+        torch.bfloat16: (4, 16),
+        torch.float32: (2, 32),
+        torch.float64: (2, 64),
+        torch.bool: (6, 8),
+        torch.complex64: (5, 64),
+        torch.complex128: (5, 128),
+    }
+    optional_types = (
+        ("float8_e4m3fn", 10),
+        ("float8_e4m3fnuz", 11),
+        ("float8_e5m2", 12),
+        ("float8_e5m2fnuz", 13),
+    )
+    for name, code in optional_types:
+        if hasattr(torch, name):
+            types[getattr(torch, name)] = (code, 8)
+    try:
+        return types[dtype]
+    except KeyError as exc:
+        raise TypeError(f"CUDA VMM peer views do not support dtype {dtype}") from exc
+
+
+def _tensor_from_cuda_pointer(
+    pointer: int,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+    device_id: int,
+    refs: list[Any],
+) -> torch.Tensor:
+    dtype_code, dtype_bits = _dtype_to_dlpack(dtype)
+    shape_array = (ctypes.c_int64 * len(shape))(*shape)
+    managed = _DLManagedTensor()
+    managed.dl_tensor.data = ctypes.c_void_p(pointer)
+    managed.dl_tensor.device = _DLDevice(2, device_id)
+    managed.dl_tensor.ndim = len(shape)
+    managed.dl_tensor.dtype = _DLDataType(dtype_code, dtype_bits, 1)
+    managed.dl_tensor.shape = shape_array
+    managed.dl_tensor.strides = None
+    managed.dl_tensor.byte_offset = 0
+    managed.manager_ctx = None
+
+    @_DLPACK_DELETER
+    def deleter(_: Any) -> None:
+        return None
+
+    managed.deleter = deleter
+    refs.extend((managed, shape_array, deleter))
+    ctypes.pythonapi.PyCapsule_New.restype = ctypes.py_object
+    ctypes.pythonapi.PyCapsule_New.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+        ctypes.c_void_p,
+    ]
+    capsule = ctypes.pythonapi.PyCapsule_New(ctypes.byref(managed), b"dltensor", None)
+    return torch.from_dlpack(capsule)
+
+
+def _rollback_mapping(
+    driver: Any,
+    base_va: int | None,
+    total_bytes: int,
+    mapped_addresses: list[int],
+    segment_bytes: int,
+) -> None:
+    failed_addresses: list[int] = []
+    while mapped_addresses:
+        address = mapped_addresses.pop()
+        try:
+            _check_driver(
+                driver.cuMemUnmap(address, segment_bytes),
+                "cuMemUnmap(rollback)",
+            )
+        except Exception:
+            logger.exception("Failed to roll back CUDA VMM mapping at %#x", address)
+            failed_addresses.append(address)
+    if base_va is not None and not failed_addresses:
+        try:
+            _check_driver(
+                driver.cuMemAddressFree(base_va, total_bytes),
+                "cuMemAddressFree(rollback)",
+            )
+        except Exception:
+            logger.exception(
+                "Failed to roll back CUDA VMM address range at %#x", base_va
+            )
+
+
+@dataclass
+class RankMajorPeerView:
+    """Rank-segmented CUDA memory exposed through rank-major tensor aliases.
+
+    ``global_view`` stores group-rank ``r`` at rows
+    ``[r * rows_per_rank:(r + 1) * rows_per_rank]``. If requested,
+    ``rank_local_view`` contains the same physical segments rotated so the
+    current rank is first. ``local_view`` is the current rank's owner segment.
+
+    All tensor aliases become invalid when :meth:`close` is called. Callers
+    must arrange any inter-rank write/read synchronization themselves.
+    """
+
+    global_view: torch.Tensor | None
+    rank_local_view: torch.Tensor | None
+    local_view: torch.Tensor | None
+    requested_shape: tuple[int, ...]
+    aligned_local_shape: tuple[int, ...]
+    rows_per_rank: int
+    bytes_per_rank: int
+    rank: int
+    world_size: int
+    device: torch.device
+    transport: Literal["fabric", "posix_fd"]
+    _global_base_va: int | None
+    _rank_local_base_va: int | None
+    _total_bytes: int
+    _global_mappings: list[int] = field(repr=False)
+    _rank_local_mappings: list[int] = field(repr=False)
+    _dlpack_refs: list[Any] = field(repr=False)
+    _refs_retired: bool = field(default=False, init=False, repr=False)
+    _closed: bool = field(default=False, init=False, repr=False)
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def __enter__(self) -> RankMajorPeerView:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        # Tensor views can outlive the allocation wrapper. Keep the ctypes
+        # DLPack metadata and callback callable until process teardown even
+        # when a caller forgot the required explicit close(). CUDA mappings
+        # are intentionally not touched from a Python finalizer.
+        if not self._refs_retired and self._dlpack_refs:
+            _RETIRED_DLPACK_REFS.append(self._dlpack_refs)
+            self._refs_retired = True
+
+    def close(self) -> None:
+        """Synchronize the local device and deterministically release mappings."""
+        if self._closed:
+            return
+        torch.accelerator.synchronize(self.device)
+
+        self.local_view = None
+        self.rank_local_view = None
+        self.global_view = None
+        if not self._refs_retired:
+            _RETIRED_DLPACK_REFS.append(self._dlpack_refs)
+            self._refs_retired = True
+
+        driver = _get_cuda_driver()
+        failures: list[str] = []
+        regions = (
+            ("global", "_global_base_va", self._global_mappings),
+            ("rank-local", "_rank_local_base_va", self._rank_local_mappings),
+        )
+        for label, base_attribute, mappings in regions:
+            while mappings:
+                address = mappings[-1]
+                try:
+                    _check_driver(
+                        driver.cuMemUnmap(address, self.bytes_per_rank),
+                        f"cuMemUnmap({label})",
+                    )
+                except BaseException as exc:
+                    failures.append(str(exc))
+                    break
+                mappings.pop()
+            base_va = getattr(self, base_attribute)
+            if base_va is not None and not mappings:
+                try:
+                    _check_driver(
+                        driver.cuMemAddressFree(base_va, self._total_bytes),
+                        f"cuMemAddressFree({label})",
+                    )
+                except BaseException as exc:
+                    failures.append(str(exc))
+                else:
+                    setattr(self, base_attribute, None)
+
+        self._closed = self._global_base_va is None and self._rank_local_base_va is None
+        if failures:
+            raise RuntimeError("CUDA VMM close failed: " + "; ".join(failures))
+
+
+def create_rank_major_peer_view(
+    local_shape: tuple[int, ...],
+    *,
+    dtype: torch.dtype,
+    group: ProcessGroup,
+    first_dim_multiple: int = 1,
+    map_rank_local: bool = False,
+    require_native_atomics: bool = False,
+    device: torch.device | str | int | None = None,
+) -> RankMajorPeerView:
+    """Collectively create a same-host rank-major CUDA peer tensor.
+
+    Each rank owns one physical VMM allocation. Every rank maps all allocations
+    in group-rank order into one contiguous virtual address range. Setup uses
+    same-host POSIX file descriptors to transfer allocation handles.
+
+    Args:
+        local_shape: Requested owner-local tensor shape. Its first dimension is
+            padded to CUDA allocation granularity and ``first_dim_multiple``.
+        dtype: Tensor element type.
+        group: Same-host, CPU-capable process group used for setup collectives.
+        first_dim_multiple: Additional alignment for the padded first dimension.
+        map_rank_local: Also create a rotated alias with the local rank first.
+        require_native_atomics: Require directed native peer-atomic support
+            between every pair of devices in addition to peer load/store access.
+        device: CUDA device. It must be the process's current CUDA device.
+
+    Returns:
+        A peer view whose ``local_view`` is the owner-local allocation.
+
+    Raises:
+        RuntimeError: If CUDA VMM setup fails on any group rank.
+        ValueError: If arguments, topology, or current device are invalid.
+    """
+    local_shape = tuple(local_shape)
+    rank, world_size = _validate_request(
+        group,
+        local_shape,
+        dtype,
+        first_dim_multiple,
+        map_rank_local,
+        require_native_atomics,
+    )
+
+    local_error: BaseException | None = None
+    driver: Any | None = None
+    device_id = -1
+    resolved_device = torch.device("cuda")
+    try:
+        driver = _get_cuda_driver()
+        current_device = torch.accelerator.current_device_index()
+        if device is None:
+            resolved_device = torch.device(f"cuda:{current_device}")
+        elif isinstance(device, int):
+            resolved_device = torch.device(f"cuda:{device}")
+        else:
+            resolved_device = torch.device(device)
+        if resolved_device.type != "cuda":
+            raise ValueError(f"device must be CUDA, got {resolved_device}")
+        device_id = (
+            current_device
+            if resolved_device.index is None
+            else int(resolved_device.index)
+        )
+        if device_id != current_device:
+            raise ValueError(
+                f"device {device_id} is not the current CUDA device {current_device}"
+            )
+        resolved_device = torch.device(f"cuda:{device_id}")
+    except BaseException as exc:
+        local_error = exc
+    _raise_if_any_rank_failed(group, rank, "CUDA initialization", local_error)
+    assert driver is not None
+    _validate_peer_capabilities(driver, group, rank, device_id, require_native_atomics)
+
+    local_handle, aligned_shape, segment_bytes, granularity = _allocate_local_segment(
+        driver,
+        group,
+        rank,
+        device_id,
+        local_shape,
+        dtype,
+        first_dim_multiple,
+    )
+
+    local_fd: int | None = None
+    peer_fds: dict[int, int] = {}
+    imported_handles: list[Any] = []
+    dlpack_refs: list[Any] = []
+    global_base_va: int | None = None
+    rank_local_base_va: int | None = None
+    global_mappings: list[int] = []
+    rank_local_mappings: list[int] = []
+    total_bytes = segment_bytes * world_size
+    transport: Literal["fabric", "posix_fd"] = "posix_fd"
+    try:
+        transport, exported_handle = _export_local_handle(
+            driver, group, rank, local_handle
+        )
+        peer_handles: list[bytes | int | None] = [None] * world_size
+        if transport == "fabric":
+            dist.all_gather_object(peer_handles, exported_handle, group=group)
+        else:
+            local_fd = int(exported_handle)
+            peer_fds = _exchange_posix_fds(group, rank, world_size, local_fd)
+
+        mapping_error: BaseException | None = None
+        try:
+            global_base_va = int(
+                _check_driver(
+                    driver.cuMemAddressReserve(total_bytes, granularity, 0, 0),
+                    "cuMemAddressReserve(global)",
+                )
+            )
+            if map_rank_local:
+                rank_local_base_va = int(
+                    _check_driver(
+                        driver.cuMemAddressReserve(total_bytes, granularity, 0, 0),
+                        "cuMemAddressReserve(rank-local)",
+                    )
+                )
+
+            access = _make_rw_access(driver, device_id)
+            for peer_rank in range(world_size):
+                handle = local_handle
+                if peer_rank != rank:
+                    exported = (
+                        peer_handles[peer_rank]
+                        if transport == "fabric"
+                        else peer_fds[peer_rank]
+                    )
+                    assert exported is not None
+                    handle = _import_peer_handle(driver, transport, exported, peer_rank)
+                    imported_handles.append(handle)
+
+                global_address = global_base_va + peer_rank * segment_bytes
+                _check_driver(
+                    driver.cuMemMap(global_address, segment_bytes, 0, handle, 0),
+                    f"cuMemMap(global, rank={peer_rank})",
+                )
+                global_mappings.append(global_address)
+                _check_driver(
+                    driver.cuMemSetAccess(global_address, segment_bytes, [access], 1),
+                    f"cuMemSetAccess(global, rank={peer_rank})",
+                )
+
+                if rank_local_base_va is not None:
+                    rank_local_segment = (peer_rank - rank) % world_size
+                    rank_local_address = (
+                        rank_local_base_va + rank_local_segment * segment_bytes
+                    )
+                    _check_driver(
+                        driver.cuMemMap(
+                            rank_local_address, segment_bytes, 0, handle, 0
+                        ),
+                        f"cuMemMap(rank-local, rank={peer_rank})",
+                    )
+                    rank_local_mappings.append(rank_local_address)
+                    _check_driver(
+                        driver.cuMemSetAccess(
+                            rank_local_address, segment_bytes, [access], 1
+                        ),
+                        f"cuMemSetAccess(rank-local, rank={peer_rank})",
+                    )
+
+                if peer_rank != rank:
+                    _release_handle(
+                        driver, handle, f"cuMemRelease(imported rank={peer_rank})"
+                    )
+                    imported_handles.pop()
+        except BaseException as exc:
+            mapping_error = exc
+        _raise_if_any_rank_failed(group, rank, "peer mapping", mapping_error)
+
+        release_error: BaseException | None = None
+        try:
+            _release_handle(driver, local_handle, "cuMemRelease(local)")
+            local_handle = None
+        except BaseException as exc:
+            release_error = exc
+        _raise_if_any_rank_failed(
+            group, rank, "allocation handle release", release_error
+        )
+
+        global_view: torch.Tensor | None = None
+        rank_local_view: torch.Tensor | None = None
+        local_view: torch.Tensor | None = None
+        tensor_error: BaseException | None = None
+        try:
+            global_shape = (world_size * aligned_shape[0], *aligned_shape[1:])
+            assert global_base_va is not None
+            global_view = _tensor_from_cuda_pointer(
+                global_base_va, global_shape, dtype, device_id, dlpack_refs
+            )
+            if rank_local_base_va is not None:
+                rank_local_view = _tensor_from_cuda_pointer(
+                    rank_local_base_va,
+                    global_shape,
+                    dtype,
+                    device_id,
+                    dlpack_refs,
+                )
+            local_segment_va = global_base_va + rank * segment_bytes
+            local_view = _tensor_from_cuda_pointer(
+                local_segment_va,
+                aligned_shape,
+                dtype,
+                device_id,
+                dlpack_refs,
+            )
+        except BaseException as exc:
+            tensor_error = exc
+        _raise_if_any_rank_failed(group, rank, "tensor construction", tensor_error)
+        assert global_view is not None and local_view is not None
+
+        return RankMajorPeerView(
+            global_view=global_view,
+            rank_local_view=rank_local_view,
+            local_view=local_view,
+            requested_shape=local_shape,
+            aligned_local_shape=aligned_shape,
+            rows_per_rank=aligned_shape[0],
+            bytes_per_rank=segment_bytes,
+            rank=rank,
+            world_size=world_size,
+            device=resolved_device,
+            transport=transport,
+            _global_base_va=global_base_va,
+            _rank_local_base_va=rank_local_base_va,
+            _total_bytes=total_bytes,
+            _global_mappings=global_mappings,
+            _rank_local_mappings=rank_local_mappings,
+            _dlpack_refs=dlpack_refs,
+        )
+    except BaseException:
+        if dlpack_refs:
+            _RETIRED_DLPACK_REFS.append(dlpack_refs)
+        _rollback_mapping(
+            driver,
+            global_base_va,
+            total_bytes,
+            global_mappings,
+            segment_bytes,
+        )
+        _rollback_mapping(
+            driver,
+            rank_local_base_va,
+            total_bytes,
+            rank_local_mappings,
+            segment_bytes,
+        )
+        for handle in imported_handles:
+            try:
+                _check_driver(
+                    driver.cuMemRelease(handle),
+                    "cuMemRelease(imported rollback)",
+                )
+            except Exception:
+                logger.exception("Failed to release imported CUDA VMM handle")
+        if local_handle is not None:
+            try:
+                _check_driver(
+                    driver.cuMemRelease(local_handle),
+                    "cuMemRelease(local rollback)",
+                )
+            except Exception:
+                logger.exception("Failed to release local CUDA VMM handle")
+        raise
+    finally:
+        if local_fd is not None:
+            os.close(local_fd)
+        for peer_fd in peer_fds.values():
+            os.close(peer_fd)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -187,6 +187,7 @@ if TYPE_CHECKING:
     VLLM_USE_DEEP_GEMM_E8M0: bool = True
     VLLM_USE_DEEP_GEMM_TMA_ALIGNED_SCALES: bool = True
     VLLM_DCP_Q_REPLICATE: bool = False
+    VLLM_USE_PCP_DIRECT_KV: bool = False
     VLLM_DEEP_GEMM_WARMUP: Literal[
         "skip",
         "full",
@@ -1493,6 +1494,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Opt-in MLA DCP query replication: skip the decode query all-gather.
     "VLLM_DCP_Q_REPLICATE": lambda: bool(int(os.getenv("VLLM_DCP_Q_REPLICATE", "0"))),
+    # Experimental GLM-5.2 PCP cache exchange using initialization-time CUDA
+    # VMM peer mappings and direct producer stores instead of KV all-gathers.
+    "VLLM_USE_PCP_DIRECT_KV": lambda: bool(
+        int(os.getenv("VLLM_USE_PCP_DIRECT_KV", "0"))
+    ),
     # DeepGemm JITs the kernels on-demand. The warmup attempts to make DeepGemm
     # JIT all the required kernels before model execution so there is no
     # JIT'ing in the hot-path. However, this warmup increases the engine

--- a/vllm/model_executor/layers/attention/pcp_peer_cache.py
+++ b/vllm/model_executor/layers/attention/pcp_peer_cache.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Rank-major cache views and visibility fencing for direct PCP stores."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from vllm.triton_utils import tl, triton
+
+if TYPE_CHECKING:
+    from vllm.distributed.device_communicators.cuda_vmm import RankMajorPeerView
+
+_MAX_FENCE_SPINS = 100_000_000
+
+
+@triton.jit
+def _trap_if_nonzero(value):
+    """Unconditionally compile a device trap when a bounded wait times out."""
+    return tl.inline_asm_elementwise(
+        asm="""
+        {
+            .reg .pred failed;
+            setp.ne.u32 failed, $1, 0;
+            @failed trap;
+            mov.u32 $0, 0;
+        }
+        """,
+        constraints="=r,r",
+        args=[value],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+def make_rank_major_tensor_view(
+    allocation: RankMajorPeerView,
+    local_tensor: torch.Tensor,
+) -> torch.Tensor:
+    """Mirror a tensor view across every rank segment of a VMM allocation.
+
+    ``local_tensor`` may be a packed or strided view into ``local_view``. The
+    returned tensor adds a leading PCP-rank dimension without copying bytes.
+    """
+    element_size = local_tensor.element_size()
+    if allocation.bytes_per_rank % element_size != 0:
+        raise ValueError(
+            "Peer allocation stride is not divisible by the tensor element size: "
+            f"{allocation.bytes_per_rank} bytes vs {element_size}."
+        )
+
+    local_view = allocation.local_view
+    global_view = allocation.global_view
+    if local_view is None or global_view is None:
+        raise RuntimeError("Cannot create a tensor view from a closed peer allocation.")
+    local_offset_bytes = local_tensor.data_ptr() - local_view.data_ptr()
+    view_span = 0 if local_tensor.numel() == 0 else 1
+    for size, stride in zip(local_tensor.shape, local_tensor.stride()):
+        if size > 0:
+            view_span += (size - 1) * stride
+    view_span_bytes = view_span * element_size
+    if (
+        local_offset_bytes < 0
+        or local_offset_bytes + view_span_bytes > allocation.bytes_per_rank
+    ):
+        raise ValueError("Tensor view lies outside its local peer allocation.")
+    if local_offset_bytes % element_size != 0:
+        raise ValueError("Tensor view is not aligned to its element size.")
+
+    global_typed = global_view.view(local_tensor.dtype)
+    rank_stride = allocation.bytes_per_rank // element_size
+    return torch.as_strided(
+        global_typed,
+        size=(allocation.world_size, *local_tensor.shape),
+        stride=(rank_stride, *local_tensor.stride()),
+        storage_offset=local_offset_bytes // element_size,
+    )
+
+
+@triton.jit
+def _publish_fence_kernel(
+    peer_signal_ptr,
+    peer_rank_stride,
+    epoch,
+    parity,
+    source_rank: tl.constexpr,
+    world_size: tl.constexpr,
+):
+    destination_rank = tl.program_id(0)
+    if destination_rank < world_size:
+        signal_ptr = (
+            peer_signal_ptr
+            + destination_rank * peer_rank_stride
+            + parity * world_size
+            + source_rank
+        )
+        # The release publishes every cache store from the preceding kernel to
+        # all GPUs in the peer-memory domain.
+        tl.atomic_xchg(signal_ptr, epoch, sem="release", scope="sys")
+
+
+@triton.jit
+def _wait_fence_kernel(
+    local_signal_ptr,
+    epoch,
+    parity,
+    world_size: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    MAX_SPINS: tl.constexpr,
+):
+    source_rank = tl.arange(0, BLOCK_SIZE)
+    mask = source_rank < world_size
+    signal_ptr = local_signal_ptr + parity * world_size + source_rank
+    observed = tl.atomic_add(
+        signal_ptr,
+        0,
+        mask=mask,
+        sem="acquire",
+        scope="sys",
+    )
+    pending = tl.max(tl.where(mask & (observed != epoch), 1, 0))
+    spins = 0
+    while (pending != 0) & (spins < MAX_SPINS):
+        observed = tl.atomic_add(
+            signal_ptr,
+            0,
+            mask=mask,
+            sem="acquire",
+            scope="sys",
+        )
+        pending = tl.max(tl.where(mask & (observed != epoch), 1, 0))
+        spins += 1
+    _trap_if_nonzero(pending)
+
+
+class PCPPeerCacheFence:
+    """Reusable release/acquire fence for one direct-store PCP group.
+
+    Publication and waiting are separate kernels. Stream ordering therefore
+    completes all producer cache stores before any CTA publishes its signal,
+    avoiding an intra-grid producer/consumer deadlock.
+    """
+
+    def __init__(self, group: ProcessGroup, device: torch.device) -> None:
+        from vllm.distributed.device_communicators.cuda_vmm import (
+            create_rank_major_peer_view,
+        )
+
+        self._group = group
+        self._world_size = group.size()
+        self._rank = group.rank()
+        self._epoch = 0
+        self._allocation = create_rank_major_peer_view(
+            (2, self._world_size),
+            dtype=torch.int32,
+            group=group,
+            require_native_atomics=True,
+            device=device,
+        )
+        local_view = self._allocation.local_view
+        assert local_view is not None
+        local_view.zero_()
+        torch.accelerator.synchronize()
+        dist.barrier(group=group)
+        self._peer_signals = make_rank_major_tensor_view(
+            self._allocation, self._allocation.local_view
+        )
+
+    def __call__(self) -> None:
+        self._epoch = self._epoch % 0x7FFFFFFE + 1
+        parity = self._epoch & 1
+        _publish_fence_kernel[(self._world_size,)](
+            self._peer_signals,
+            self._peer_signals.stride(0),
+            self._epoch,
+            parity,
+            source_rank=self._rank,
+            world_size=self._world_size,
+        )
+        _wait_fence_kernel[(1,)](
+            self._allocation.local_view,
+            self._epoch,
+            parity,
+            world_size=self._world_size,
+            BLOCK_SIZE=triton.next_power_of_2(self._world_size),
+            MAX_SPINS=_MAX_FENCE_SPINS,
+        )
+
+    def close(self) -> None:
+        # Quiesce every producer/consumer before any rank unmaps its signal
+        # segment. A local synchronize alone cannot prove that a peer GPU has
+        # finished a remote store or acquire wait against this allocation.
+        torch.accelerator.synchronize(self._allocation.device)
+        dist.barrier(group=self._group)
+        self._allocation.close()

--- a/vllm/model_executor/layers/attention_layer_base.py
+++ b/vllm/model_executor/layers/attention_layer_base.py
@@ -3,6 +3,7 @@
 """Base class for attention-like layers."""
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 
 import torch
 
@@ -30,6 +31,20 @@ class AttentionLayerBase(ABC):
         override this to unpack the raw buffer into per-state views.
         """
         self.kv_cache = kv_cache
+
+    def bind_pcp_peer_kv_cache(
+        self,
+        peer_kv_cache: torch.Tensor,
+        fence: Callable[[], None],
+    ) -> None:
+        """Bind the rank-major peer view for direct PCP cache writes.
+
+        The ordinary ``kv_cache`` remains the rank-local consumer view. The
+        peer view adds a leading PCP-rank dimension and is only present when
+        the experimental direct-store path is enabled.
+        """
+        self.pcp_peer_kv_cache = peer_kv_cache
+        self.pcp_peer_cache_fence = fence
 
     @abstractmethod
     def get_attn_backend(self) -> type[AttentionBackend]:

--- a/vllm/models/deepseek_v32/nvidia/attention.py
+++ b/vllm/models/deepseek_v32/nvidia/attention.py
@@ -7,6 +7,7 @@ from transformers import DeepseekV2Config, DeepseekV3Config
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.distributed.parallel_state import get_pcp_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.model_executor.layers.layernorm import LayerNorm, RMSNorm
@@ -426,6 +427,22 @@ class DeepseekV32Attention(MLAAttention):
             mla_kv_cache = self.kv_cache
             mla_k_scale = self._k_scale
 
+        pcp_peer_mla_kv_cache = None
+        pcp_peer_indexer_k_cache = None
+        pcp_rank = 0
+        pcp_size = 1
+        if attn_metadata is not None:
+            pcp_peer_mla_kv_cache = getattr(self, "pcp_peer_kv_cache", None)
+            if pcp_peer_mla_kv_cache is not None:
+                pcp_group = get_pcp_group()
+                pcp_rank = pcp_group.rank_in_group
+                pcp_size = pcp_group.world_size
+                if self.indexer is not None:
+                    pcp_peer_indexer_k_cache = getattr(
+                        self.indexer.k_cache, "pcp_peer_kv_cache", None
+                    )
+                    assert pcp_peer_indexer_k_cache is not None
+
         q_c = fused_norm_rope(
             positions,
             q_c,
@@ -445,11 +462,17 @@ class DeepseekV32Attention(MLAAttention):
             slot_mapping=mla_slot,
             indexer_k_cache=indexer_k_cache,
             mla_kv_cache=mla_kv_cache,
+            pcp_peer_indexer_k_cache=pcp_peer_indexer_k_cache,
+            pcp_peer_mla_kv_cache=pcp_peer_mla_kv_cache,
+            pcp_rank=pcp_rank,
+            pcp_size=pcp_size,
             mla_kv_cache_dtype=self.kv_cache_dtype,
             mla_k_scale=mla_k_scale,
             has_indexer=has_indexer,
             index_rope_interleave=self._index_rope_interleave,
         )
+        if pcp_peer_mla_kv_cache is not None:
+            self.pcp_peer_cache_fence()
 
         q = self.q_b_proj(q_c)[0].view(-1, self.num_local_heads, self.qk_head_dim)
         q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)

--- a/vllm/models/deepseek_v32/nvidia/attention.py
+++ b/vllm/models/deepseek_v32/nvidia/attention.py
@@ -4,12 +4,16 @@ import torch
 import torch.nn as nn
 from transformers import DeepseekV2Config, DeepseekV3Config
 
+import vllm.envs as envs
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.distributed.parallel_state import get_pcp_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.attention import MLAAttention
+from vllm.model_executor.layers.attention.pcp import (
+    maybe_gather_mla_latent_cache_inputs,
+)
 from vllm.model_executor.layers.layernorm import LayerNorm, RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -267,6 +271,7 @@ class DeepseekV32Attention(MLAAttention):
         self.qk_head_dim = qk_head_dim
         self.indexer = indexer
         self.topk_indices_buffer = topk_indices_buffer
+        self.use_pcp_direct_kv = self.use_pcp and envs.VLLM_USE_PCP_DIRECT_KV
         # Runtime toggle for index_share_for_mtp_iteration: MTP draft step 0
         # computes the top-k, steps 1+ set this True to reuse it.
         self.skip_topk = False
@@ -433,6 +438,14 @@ class DeepseekV32Attention(MLAAttention):
         pcp_size = 1
         if attn_metadata is not None:
             pcp_peer_mla_kv_cache = getattr(self, "pcp_peer_kv_cache", None)
+            if self.use_pcp and self.use_pcp_direct_kv != (
+                pcp_peer_mla_kv_cache is not None
+            ):
+                expected = "present" if self.use_pcp_direct_kv else "absent"
+                raise RuntimeError(
+                    "Direct PCP KV peer-cache binding mismatch: expected "
+                    f"the peer cache to be {expected}."
+                )
             if pcp_peer_mla_kv_cache is not None:
                 pcp_group = get_pcp_group()
                 pcp_rank = pcp_group.rank_in_group
@@ -441,7 +454,19 @@ class DeepseekV32Attention(MLAAttention):
                     pcp_peer_indexer_k_cache = getattr(
                         self.indexer.k_cache, "pcp_peer_kv_cache", None
                     )
-                    assert pcp_peer_indexer_k_cache is not None
+                    if pcp_peer_indexer_k_cache is None:
+                        raise RuntimeError(
+                            "Direct PCP KV requires an indexer peer-cache binding."
+                        )
+
+        # Keep the specialized model implementation usable as the correctness
+        # baseline when direct peer caches are disabled. Its local inputs are
+        # PCP-partitioned, so fused local cache writes would otherwise use the
+        # rank-0 slot row on every rank. Materialize the prepared BF16 values
+        # instead and feed them through the ordinary collective update path.
+        use_pcp_collective_cache_update = (
+            attn_metadata is not None and self.use_pcp and pcp_peer_mla_kv_cache is None
+        )
 
         q_c = fused_norm_rope(
             positions,
@@ -459,9 +484,11 @@ class DeepseekV32Attention(MLAAttention):
             indexer_k_norm_eps,
             indexer_k_rope_cos_sin_cache,
             self.topk_indices_buffer,
-            slot_mapping=mla_slot,
-            indexer_k_cache=indexer_k_cache,
-            mla_kv_cache=mla_kv_cache,
+            slot_mapping=None if use_pcp_collective_cache_update else mla_slot,
+            indexer_k_cache=(
+                None if use_pcp_collective_cache_update else indexer_k_cache
+            ),
+            mla_kv_cache=None if use_pcp_collective_cache_update else mla_kv_cache,
             pcp_peer_indexer_k_cache=pcp_peer_indexer_k_cache,
             pcp_peer_mla_kv_cache=pcp_peer_mla_kv_cache,
             pcp_rank=pcp_rank,
@@ -470,9 +497,30 @@ class DeepseekV32Attention(MLAAttention):
             mla_k_scale=mla_k_scale,
             has_indexer=has_indexer,
             index_rope_interleave=self._index_rope_interleave,
+            materialize_cache_inputs=use_pcp_collective_cache_update,
         )
         if pcp_peer_mla_kv_cache is not None:
             self.pcp_peer_cache_fence()
+        elif use_pcp_collective_cache_update:
+            assert attn_metadata is not None and mla_slot is not None
+            kv_for_cache, kpe_for_cache, cache_slot_mapping = (
+                maybe_gather_mla_latent_cache_inputs(
+                    kv_c,
+                    k_pe,
+                    mla_slot,
+                    attn_metadata.num_decode_tokens,  # type: ignore[attr-defined]
+                    True,
+                )
+            )
+            assert cache_slot_mapping is not None
+            self.impl.do_kv_cache_update(  # type: ignore[attr-defined]
+                kv_for_cache,
+                kpe_for_cache,
+                self.kv_cache,
+                cache_slot_mapping,
+                self.kv_cache_dtype,
+                self._k_scale,
+            )
 
         q = self.q_b_proj(q_c)[0].view(-1, self.num_local_heads, self.qk_head_dim)
         q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
@@ -508,7 +556,7 @@ class DeepseekV32Attention(MLAAttention):
                 self.indexer.k_cache.kv_cache,
                 index_q_fp8,
                 None,  # q_scale folded into weights on the fp8 path
-                None,  # k unused when skip_k_cache_insert=True
+                index_k if use_pcp_collective_cache_update else None,
                 index_weights_out,
                 self.indexer.quant_block_size,
                 self.indexer.scale_fmt,
@@ -517,8 +565,9 @@ class DeepseekV32Attention(MLAAttention):
                 self.indexer.max_model_len,
                 self.indexer.max_total_seq_len,
                 self.topk_indices_buffer,
-                True,  # skip_k_cache_insert
-                False,  # use_fp4_cache
+                skip_k_cache_insert=not use_pcp_collective_cache_update,
+                use_pcp=use_pcp_collective_cache_update,
+                use_fp4_cache=False,
                 # fused_norm_rope already cleared the topk buffer this forward.
                 skip_topk_buffer_clear=True,
             )

--- a/vllm/models/deepseek_v32/nvidia/kernels.py
+++ b/vllm/models/deepseek_v32/nvidia/kernels.py
@@ -64,23 +64,37 @@ def _fp8_quant_and_cache_write(
     kv_cache_ptr,
     kv_cache_scale_ptr,
     cache_block_size,
+    cache_block_stride,
     cache_stride,
+    cache_peer_stride,
+    scale_peer_stride,
     offsets,
     HEAD_DIM: tl.constexpr,
+    PEER_COUNT: tl.constexpr,
 ):
     k_fp8, scale = _fp8_ue8m0_quantize(vals)
 
     block_idx = slot_idx // cache_block_size
     block_offset = slot_idx % cache_block_size
-    block_start = block_idx * cache_block_size * cache_stride
+    # Use the physical block stride explicitly. Packed KV-cache layouts can
+    # place other layers' pages between consecutive blocks of this layer.
+    block_start = block_idx * cache_block_stride
 
-    tl.store(
-        kv_cache_ptr + block_start + block_offset * HEAD_DIM + offsets,
-        k_fp8,
-        mask=mask,
-    )
     scale_byte_off = block_start + cache_block_size * HEAD_DIM + block_offset * 4
-    tl.store(kv_cache_scale_ptr + scale_byte_off // 4, scale)
+    for peer_rank in range(PEER_COUNT):
+        tl.store(
+            kv_cache_ptr
+            + peer_rank * cache_peer_stride
+            + block_start
+            + block_offset * HEAD_DIM
+            + offsets,
+            k_fp8,
+            mask=mask,
+        )
+        tl.store(
+            kv_cache_scale_ptr + peer_rank * scale_peer_stride + scale_byte_off // 4,
+            scale,
+        )
 
 
 @triton.jit
@@ -125,11 +139,16 @@ def _fused_norm_rope_kernel(
     indexer_cache_ptr,
     indexer_cache_scale_ptr,
     indexer_cache_block_size,
+    indexer_cache_block_stride,
     indexer_cache_stride,
+    indexer_cache_peer_stride,
+    indexer_cache_scale_peer_stride,
     # MLA KV cache (concat kv_c_normed + k_pe_roped, uses slot_mapping_ptr)
     mla_cache_ptr,
+    mla_cache_block_size,
     mla_cache_block_stride,
     mla_cache_entry_stride,
+    mla_cache_peer_stride,
     MLA_CACHE_FP8: tl.constexpr,
     mla_cache_scale_ptr,
     # fp8_ds_mla cache views (block-scaled fp8 NoPE + unquantized bf16 RoPE).
@@ -137,6 +156,8 @@ def _fused_norm_rope_kernel(
     # are byte offsets; these two share the same buffer as fp32 / bf16 views.
     mla_cache_ds_scale_ptr,
     mla_cache_ds_rope_ptr,
+    mla_cache_ds_scale_peer_stride,
+    mla_cache_ds_rope_peer_stride,
     MLA_CACHE_DS_MLA: tl.constexpr,
     MLA_NUM_TILES: tl.constexpr,
     MLA_TILE_DIM: tl.constexpr,
@@ -147,6 +168,7 @@ def _fused_norm_rope_kernel(
     TOPK_BLOCK_SIZE: tl.constexpr,
     HAS_INDEXER: tl.constexpr,
     INDEX_ROPE_INTERLEAVE: tl.constexpr,
+    PCP_PEER_COUNT: tl.constexpr,
 ):
     pid = tl.program_id(0)
     tok_idx = tl.program_id(1)
@@ -166,6 +188,18 @@ def _fused_norm_rope_kernel(
             )
         return
 
+    if pid == 2:
+        # Query normalization is compute, not a cache write. PCP intentionally
+        # masks replicated decode slots on ranks other than rank 0, but every
+        # rank still needs a valid query for its local attention work.
+        q_block = tl.arange(0, Q_BLOCK_SIZE)
+        q_mask = q_block < Q_DIM
+        q_c = tl.load(q_c_ptr + tok_idx * q_c_stride + q_block, mask=q_mask, other=0.0)
+        q_c_rms_w = tl.load(q_rms_norm_w_ptr + q_block, mask=q_mask)
+        q_c = _rms_norm(q_c, q_c_rms_w, q_rms_eps, Q_DIM)
+        tl.store(q_c_out_ptr + tok_idx * q_c_out_stride + q_block, q_c, mask=q_mask)
+        return
+
     if slot_mapping_ptr is None:
         # Memory profiling run.
         return
@@ -174,15 +208,7 @@ def _fused_norm_rope_kernel(
         # Padding
         return
 
-    if pid == 2:
-        # Q RMS norm
-        q_block = tl.arange(0, Q_BLOCK_SIZE)
-        q_mask = q_block < Q_DIM
-        q_c = tl.load(q_c_ptr + tok_idx * q_c_stride + q_block, mask=q_mask, other=0.0)
-        q_c_rms_w = tl.load(q_rms_norm_w_ptr + q_block, mask=q_mask)
-        q_c = _rms_norm(q_c, q_c_rms_w, q_rms_eps, Q_DIM)
-        tl.store(q_c_out_ptr + tok_idx * q_c_out_stride + q_block, q_c, mask=q_mask)
-    elif pid == 1:
+    if pid == 1:
         # KV RMS Norm + KV RoPE + MLA concat_and_cache.
         # Merged so the normed kv_c and RoPE'd k_pe can be written
         # to the MLA KV cache directly without a separate kernel.
@@ -214,9 +240,8 @@ def _fused_norm_rope_kernel(
         if mla_cache_entry_stride == 0:
             return
 
-        mla_block_size = mla_cache_block_stride // mla_cache_entry_stride
-        mla_block_idx = slot_idx // mla_block_size
-        mla_block_off = slot_idx % mla_block_size
+        mla_block_idx = slot_idx // mla_cache_block_size
+        mla_block_off = slot_idx % mla_cache_block_size
 
         if MLA_CACHE_DS_MLA:
             # fp8_ds_mla layout (DeepSeek-V3.2, KV_DIM == 512): per-128-element
@@ -237,15 +262,31 @@ def _fused_norm_rope_kernel(
             # concat_and_cache_ds_mla kernel; floored to FLT_MIN.
             tile_scale = tl.maximum(tile_amax * (1.0 / 448.0), 1.1754944e-38)
             kv_c_fp8 = tl.reshape((kv_2d / tile_scale).to(tl.float8e4nv), (KV_DIM,))
-            tl.store(mla_cache_ptr + byte_base + kv_block, kv_c_fp8)
             tile_off = tl.arange(0, MLA_NUM_TILES)
-            tl.store(
-                mla_cache_ds_scale_ptr + byte_base // 4 + KV_DIM // 4 + tile_off,
-                tl.reshape(tile_scale, (MLA_NUM_TILES,)),
-            )
-            rope_dst = mla_cache_ds_rope_ptr + byte_base // 2 + (KV_DIM // 2 + 8)
-            tl.store(rope_dst + dim_off * 2, r1.to(tl.bfloat16))
-            tl.store(rope_dst + dim_off * 2 + 1, r2.to(tl.bfloat16))
+            for peer_rank in range(PCP_PEER_COUNT):
+                tl.store(
+                    mla_cache_ptr
+                    + peer_rank * mla_cache_peer_stride
+                    + byte_base
+                    + kv_block,
+                    kv_c_fp8,
+                )
+                tl.store(
+                    mla_cache_ds_scale_ptr
+                    + peer_rank * mla_cache_ds_scale_peer_stride
+                    + byte_base // 4
+                    + KV_DIM // 4
+                    + tile_off,
+                    tl.reshape(tile_scale, (MLA_NUM_TILES,)),
+                )
+                rope_dst = (
+                    mla_cache_ds_rope_ptr
+                    + peer_rank * mla_cache_ds_rope_peer_stride
+                    + byte_base // 2
+                    + (KV_DIM // 2 + 8)
+                )
+                tl.store(rope_dst + dim_off * 2, r1.to(tl.bfloat16))
+                tl.store(rope_dst + dim_off * 2 + 1, r2.to(tl.bfloat16))
             return
 
         dst = (
@@ -257,16 +298,25 @@ def _fused_norm_rope_kernel(
         if MLA_CACHE_FP8:
             scale = tl.load(mla_cache_scale_ptr)
             kv_c_fp8 = (kv_c.to(tl.float32) / scale).to(tl.float8e4nv)
-            tl.store(dst + kv_block, kv_c_fp8)
-        else:
-            tl.store(dst + kv_block, kv_c)
-        # k_pe_roped (from registers, interleaved layout)
-        if MLA_CACHE_FP8:
-            tl.store(dst + KV_DIM + dim_off * 2, (r1 / scale).to(tl.float8e4nv))
-            tl.store(dst + KV_DIM + dim_off * 2 + 1, (r2 / scale).to(tl.float8e4nv))
-        else:
-            tl.store(dst + KV_DIM + dim_off * 2, r1)
-            tl.store(dst + KV_DIM + dim_off * 2 + 1, r2)
+        for peer_rank in range(PCP_PEER_COUNT):
+            peer_dst = dst + peer_rank * mla_cache_peer_stride
+            if MLA_CACHE_FP8:
+                tl.store(peer_dst + kv_block, kv_c_fp8)
+            else:
+                tl.store(peer_dst + kv_block, kv_c)
+            # k_pe_roped (from registers, interleaved layout)
+            if MLA_CACHE_FP8:
+                tl.store(
+                    peer_dst + KV_DIM + dim_off * 2,
+                    (r1 / scale).to(tl.float8e4nv),
+                )
+                tl.store(
+                    peer_dst + KV_DIM + dim_off * 2 + 1,
+                    (r2 / scale).to(tl.float8e4nv),
+                )
+            else:
+                tl.store(peer_dst + KV_DIM + dim_off * 2, r1)
+                tl.store(peer_dst + KV_DIM + dim_off * 2 + 1, r2)
     elif pid == 0:
         if not HAS_INDEXER:
             # Shared layer: no indexer K to process.
@@ -357,9 +407,13 @@ def _fused_norm_rope_kernel(
             indexer_cache_ptr,
             indexer_cache_scale_ptr,
             indexer_cache_block_size,
+            indexer_cache_block_stride,
             indexer_cache_stride,
+            indexer_cache_peer_stride,
+            indexer_cache_scale_peer_stride,
             index_k_block,
             INDEX_K_DIM,
+            PCP_PEER_COUNT,
         )
 
 
@@ -383,6 +437,10 @@ def fused_norm_rope(
     slot_mapping: torch.Tensor | None = None,
     indexer_k_cache: torch.Tensor | None = None,
     mla_kv_cache: torch.Tensor | None = None,
+    pcp_peer_indexer_k_cache: torch.Tensor | None = None,
+    pcp_peer_mla_kv_cache: torch.Tensor | None = None,
+    pcp_rank: int = 0,
+    pcp_size: int = 1,
     mla_kv_cache_dtype: str = "auto",
     mla_k_scale: torch.Tensor | None = None,
     has_indexer: bool = True,
@@ -399,6 +457,14 @@ def fused_norm_rope(
     q_dim = q_c.shape[-1]
     kv_dim = kv_c.shape[-1]
     device = positions.device
+    use_pcp_peer_cache = pcp_peer_mla_kv_cache is not None
+    if use_pcp_peer_cache:
+        assert pcp_peer_mla_kv_cache is not None
+        assert pcp_size > 1 and 0 <= pcp_rank < pcp_size
+        assert pcp_peer_mla_kv_cache.shape[0] == pcp_size
+        assert slot_mapping is not None
+        assert slot_mapping.numel() >= pcp_size * num_tokens
+        slot_mapping = slot_mapping.view(pcp_size, -1)[pcp_rank, :num_tokens]
 
     # Shared (no-indexer) layers: substitute cached 1-element dummies so the
     # kernel launches cleanly; pid 0/3 (indexer + topk fill) skipped by
@@ -415,11 +481,26 @@ def fused_norm_rope(
     topk = topk_indices_buffer.shape[-1]
 
     # --- Indexer K cache setup ---
-    if indexer_k_cache is not None:
+    if use_pcp_peer_cache and has_indexer:
+        assert pcp_peer_indexer_k_cache is not None
+        assert pcp_peer_indexer_k_cache.shape[0] == pcp_size
+        indexer_k_cache = pcp_peer_indexer_k_cache
+        idx_cache_scale_view = indexer_k_cache.view(torch.uint8).view(torch.float32)
+        idx_cache_block_size = indexer_k_cache.shape[2]
+        idx_cache_block_stride = indexer_k_cache.stride(1)
+        idx_cache_stride = indexer_k_cache.shape[3]
+        idx_cache_peer_stride = indexer_k_cache.stride(0)
+        idx_cache_scale_peer_stride = idx_cache_scale_view.stride(0)
+        if indexer_k_cache.dtype == torch.uint8:
+            indexer_k_cache = indexer_k_cache.view(torch.float8_e4m3fn)
+    elif indexer_k_cache is not None:
         assert slot_mapping is not None
         idx_cache_scale_view = indexer_k_cache.view(torch.uint8).view(torch.float32)
         idx_cache_block_size = indexer_k_cache.shape[1]
+        idx_cache_block_stride = indexer_k_cache.stride(0)
         idx_cache_stride = indexer_k_cache.shape[2]
+        idx_cache_peer_stride = 0
+        idx_cache_scale_peer_stride = 0
         if indexer_k_cache.dtype == torch.uint8:
             indexer_k_cache = indexer_k_cache.view(torch.float8_e4m3fn)
     else:
@@ -428,7 +509,10 @@ def fused_norm_rope(
         idx_cache_scale_view = torch.empty(0, dtype=torch.float32, device=device)
         indexer_k_cache = torch.empty(0, dtype=torch.float8_e4m3fn, device=device)
         idx_cache_block_size = 1
+        idx_cache_block_stride = 1
         idx_cache_stride = 1
+        idx_cache_peer_stride = 0
+        idx_cache_scale_peer_stride = 0
         if mla_kv_cache is None:
             # Pure profiling run (no caches at all): skip all per-token writes.
             slot_mapping = torch.full(
@@ -441,7 +525,15 @@ def fused_norm_rope(
     mla_num_tiles = 1
     mla_ds_scale_view = torch.empty(0, dtype=torch.float32, device=device)
     mla_ds_rope_view = torch.empty(0, dtype=torch.bfloat16, device=device)
+    if use_pcp_peer_cache:
+        mla_kv_cache = pcp_peer_mla_kv_cache
     if mla_kv_cache is not None:
+        cache_dim = 1 if use_pcp_peer_cache else 0
+        # The block-size dimension follows the physical block dimension in
+        # both layouts: [blocks, block_size, ...] and
+        # [peer, blocks, block_size, ...].
+        mla_cache_block_size = mla_kv_cache.shape[cache_dim + 1]
+        mla_cache_peer_stride = mla_kv_cache.stride(0) if use_pcp_peer_cache else 0
         if mla_cache_ds_mla:
             # 656-byte custom layout addressed in bytes; mla_cache_ptr is the
             # 1-byte fp8 view, so block/entry strides are byte offsets and the
@@ -449,14 +541,22 @@ def fused_norm_rope(
             assert kv_dim == 512, "fp8_ds_mla requires kv_lora_rank == 512"
             mla_num_tiles = kv_dim // 128
             u8_cache = mla_kv_cache.view(torch.uint8)
-            mla_block_stride = u8_cache.stride(0)
-            mla_entry_stride = u8_cache.stride(1)
+            mla_block_stride = u8_cache.stride(cache_dim)
+            mla_entry_stride = u8_cache.stride(cache_dim + 1)
             mla_ds_scale_view = u8_cache.view(torch.float32)
             mla_ds_rope_view = u8_cache.view(torch.bfloat16)
+            mla_ds_scale_peer_stride = (
+                mla_ds_scale_view.stride(0) if use_pcp_peer_cache else 0
+            )
+            mla_ds_rope_peer_stride = (
+                mla_ds_rope_view.stride(0) if use_pcp_peer_cache else 0
+            )
             mla_kv_cache = u8_cache.view(torch.float8_e4m3fn)
         else:
-            mla_block_stride = mla_kv_cache.stride(0)
-            mla_entry_stride = mla_kv_cache.stride(1)
+            mla_block_stride = mla_kv_cache.stride(cache_dim)
+            mla_entry_stride = mla_kv_cache.stride(cache_dim + 1)
+            mla_ds_scale_peer_stride = 0
+            mla_ds_rope_peer_stride = 0
             if mla_cache_fp8 and mla_kv_cache.dtype == torch.uint8:
                 mla_kv_cache = mla_kv_cache.view(torch.float8_e4m3fn)
         if mla_k_scale is None:
@@ -465,8 +565,12 @@ def fused_norm_rope(
         # Dummy values — pid 2 will skip the MLA cache write because
         # slot_mapping is all -1.
         mla_kv_cache = torch.empty(0, dtype=torch.bfloat16, device=device)
+        mla_cache_block_size = 1
         mla_block_stride = 0
         mla_entry_stride = 0
+        mla_cache_peer_stride = 0
+        mla_ds_scale_peer_stride = 0
+        mla_ds_rope_peer_stride = 0
         mla_k_scale = torch.ones(1, dtype=torch.float32, device=device)
 
     if q_c_out is None:
@@ -510,15 +614,22 @@ def fused_norm_rope(
         indexer_k_cache,
         idx_cache_scale_view,
         idx_cache_block_size,
+        idx_cache_block_stride,
         idx_cache_stride,
+        idx_cache_peer_stride,
+        idx_cache_scale_peer_stride,
         # MLA KV cache (uses same slot_mapping)
         mla_kv_cache,
+        mla_cache_block_size,
         mla_block_stride,
         mla_entry_stride,
+        mla_cache_peer_stride,
         mla_cache_fp8,
         mla_k_scale,
         mla_ds_scale_view,
         mla_ds_rope_view,
+        mla_ds_scale_peer_stride,
+        mla_ds_rope_peer_stride,
         mla_cache_ds_mla,
         mla_num_tiles,
         kv_dim // mla_num_tiles if mla_cache_ds_mla else 1,
@@ -529,6 +640,7 @@ def fused_norm_rope(
         TOPK_BLOCK_SIZE=1024,
         HAS_INDEXER=has_indexer,
         INDEX_ROPE_INTERLEAVE=index_rope_interleave,
+        PCP_PEER_COUNT=pcp_size if use_pcp_peer_cache else 1,
     )
     return q_c_out
 

--- a/vllm/models/deepseek_v32/nvidia/kernels.py
+++ b/vllm/models/deepseek_v32/nvidia/kernels.py
@@ -169,6 +169,7 @@ def _fused_norm_rope_kernel(
     HAS_INDEXER: tl.constexpr,
     INDEX_ROPE_INTERLEAVE: tl.constexpr,
     PCP_PEER_COUNT: tl.constexpr,
+    MATERIALIZE_CACHE_INPUTS: tl.constexpr,
 ):
     pid = tl.program_id(0)
     tok_idx = tl.program_id(1)
@@ -200,13 +201,19 @@ def _fused_norm_rope_kernel(
         tl.store(q_c_out_ptr + tok_idx * q_c_out_stride + q_block, q_c, mask=q_mask)
         return
 
-    if slot_mapping_ptr is None:
-        # Memory profiling run.
-        return
-    slot_idx = tl.load(slot_mapping_ptr + tok_idx)
-    if slot_idx < 0:
-        # Padding
-        return
+    # The direct/single-rank path skips all cache preparation for padding just
+    # as before.  The collective PCP fallback, however, must prepare every
+    # local row first: replicated decode rows are deliberately PAD on nonzero
+    # ranks, while their local Q/KV values are still needed by attention.
+    slot_idx = 0
+    if not MATERIALIZE_CACHE_INPUTS:
+        if slot_mapping_ptr is None:
+            # Memory profiling run.
+            return
+        slot_idx = tl.load(slot_mapping_ptr + tok_idx)
+        if slot_idx < 0:
+            # Padding
+            return
 
     if pid == 1:
         # KV RMS Norm + KV RoPE + MLA concat_and_cache.
@@ -235,6 +242,14 @@ def _fused_norm_rope_kernel(
         x2 = tl.load(kpe_base + dim_off * 2 + 1).to(tl.float32)
         r1 = x1 * cos - x2 * sin
         r2 = x2 * cos + x1 * sin
+
+        if MATERIALIZE_CACHE_INPUTS:
+            # The collective PCP fallback gathers these locally prepared BF16
+            # values before using the ordinary backend cache-update kernel.
+            tl.store(kv_ptr + tok_idx * kv_stride + kv_block, kv_c)
+            tl.store(kpe_base + dim_off * 2, r1)
+            tl.store(kpe_base + dim_off * 2 + 1, r2)
+            return
 
         # MLA concat_and_cache: write [kv_c_normed, k_pe_roped] to cache.
         if mla_cache_entry_stride == 0:
@@ -397,6 +412,14 @@ def _fused_norm_rope_kernel(
         roped = normed * cos_full + sign * normed_partner * sin_full
         result = tl.where(in_rope, roped, normed)
 
+        if MATERIALIZE_CACHE_INPUTS:
+            tl.store(
+                index_k_ptr + tok_idx * index_k_stride + index_k_block,
+                result,
+                mask=index_k_mask,
+            )
+            return
+
         # 3. FP8 quantize + cache write from registers.
         #    No need to write back to index_k_ptr — the only consumer
         #    (sparse_attn_indexer) reads from the cache, not index_k.
@@ -446,6 +469,7 @@ def fused_norm_rope(
     has_indexer: bool = True,
     index_rope_interleave: bool = False,
     q_c_out: torch.Tensor | None = None,
+    materialize_cache_inputs: bool = False,
 ) -> torch.Tensor:
     assert positions.ndim == 1
     assert q_c.ndim == 2
@@ -458,6 +482,7 @@ def fused_norm_rope(
     kv_dim = kv_c.shape[-1]
     device = positions.device
     use_pcp_peer_cache = pcp_peer_mla_kv_cache is not None
+    assert not (use_pcp_peer_cache and materialize_cache_inputs)
     if use_pcp_peer_cache:
         assert pcp_peer_mla_kv_cache is not None
         assert pcp_size > 1 and 0 <= pcp_rank < pcp_size
@@ -513,7 +538,7 @@ def fused_norm_rope(
         idx_cache_stride = 1
         idx_cache_peer_stride = 0
         idx_cache_scale_peer_stride = 0
-        if mla_kv_cache is None:
+        if mla_kv_cache is None and not materialize_cache_inputs:
             # Pure profiling run (no caches at all): skip all per-token writes.
             slot_mapping = torch.full(
                 (num_tokens,), -1, dtype=torch.int64, device=device
@@ -641,6 +666,7 @@ def fused_norm_rope(
         HAS_INDEXER=has_indexer,
         INDEX_ROPE_INTERLEAVE=index_rope_interleave,
         PCP_PEER_COUNT=pcp_size if use_pcp_peer_cache else 1,
+        MATERIALIZE_CACHE_INPUTS=materialize_cache_inputs,
     )
     return q_c_out
 

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
@@ -389,6 +389,13 @@ class FlashInferMLASparseImpl(SparseMLACommonImpl[FlashInferMLASparseMetadata]):
 
         num_actual_toks = q.shape[0]
 
+        # PCP can legitimately assign no local tokens to a rank for a short
+        # prefill. TRT-LLM's TMA descriptor builder rejects a zero query
+        # dimension, so preserve collective participation in the caller and
+        # skip only the local sparse-attention kernel.
+        if num_actual_toks == 0:
+            return q.new_empty((0, self.num_heads, self.kv_lora_rank)), None
+
         assert self.topk_indices_buffer is not None
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
 

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from math import prod
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import torch
 
@@ -40,6 +42,10 @@ from vllm.v1.worker.utils import (
 
 logger = init_logger(__name__)
 
+if TYPE_CHECKING:
+    from vllm.distributed.device_communicators.cuda_vmm import RankMajorPeerView
+    from vllm.v1.worker.gpu.pcp_manager import PCPManager
+
 
 @dataclass(frozen=True)
 class AttentionCGSupportInfo:
@@ -48,7 +54,7 @@ class AttentionCGSupportInfo:
 
     def narrow(
         self, support: AttentionCGSupport, backend: str | None
-    ) -> "AttentionCGSupportInfo":
+    ) -> AttentionCGSupportInfo:
         """Return an info tightened by ``support`` if it is more restrictive.
 
         Lets attention groups built outside ``init_attn_backend`` (e.g.
@@ -182,22 +188,47 @@ def init_attn_backend(
 
 
 def _allocate_kv_cache(
-    kv_cache_config: KVCacheConfig, shared_layers: dict[str, str], device: torch.device
+    kv_cache_config: KVCacheConfig,
+    shared_layers: dict[str, str],
+    device: torch.device,
+    pcp_manager: PCPManager | None = None,
 ):
     kv_cache_raw_tensors: dict[str, torch.Tensor] = {}
+    peer_allocations: dict[str, RankMajorPeerView] = {}
     packed_backing: torch.Tensor | None = None
+    packed_peer_allocation: RankMajorPeerView | None = None
     for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
         if kv_cache_tensor.block_stride > 0:
             # Allocate once; all packed tensors alias the same backing.
             if packed_backing is None:
-                packed_backing = torch.zeros(
+                if pcp_manager is not None and pcp_manager.direct_kv_enabled:
+                    packed_peer_allocation = pcp_manager.allocate_peer_cache(
+                        kv_cache_tensor.size
+                    )
+                    local_view = packed_peer_allocation.local_view
+                    assert local_view is not None
+                    packed_backing = local_view.narrow(0, 0, kv_cache_tensor.size)
+                else:
+                    packed_backing = torch.zeros(
+                        kv_cache_tensor.size, dtype=torch.int8, device=device
+                    )
+            tensor = packed_backing
+            peer_allocation = packed_peer_allocation
+        else:
+            if pcp_manager is not None and pcp_manager.direct_kv_enabled:
+                peer_allocation = pcp_manager.allocate_peer_cache(kv_cache_tensor.size)
+                local_view = peer_allocation.local_view
+                assert local_view is not None
+                tensor = local_view.narrow(0, 0, kv_cache_tensor.size)
+            else:
+                peer_allocation = None
+                tensor = torch.zeros(
                     kv_cache_tensor.size, dtype=torch.int8, device=device
                 )
-            tensor = packed_backing
-        else:
-            tensor = torch.zeros(kv_cache_tensor.size, dtype=torch.int8, device=device)
         for layer_name in kv_cache_tensor.shared_by:
             kv_cache_raw_tensors[layer_name] = tensor
+            if peer_allocation is not None:
+                peer_allocations[layer_name] = peer_allocation
 
     layer_names = set()
     for group in kv_cache_config.kv_cache_groups:
@@ -206,7 +237,7 @@ def _allocate_kv_cache(
     assert layer_names == (kv_cache_raw_tensors.keys() | shared_layers.keys()), (
         "Some layers are not correctly initialized"
     )
-    return kv_cache_raw_tensors
+    return kv_cache_raw_tensors, peer_allocations
 
 
 def _reshape_attention_kv_cache(
@@ -271,7 +302,7 @@ def _reshape_kv_cache(
     cache_dtype: str,
     kernel_block_sizes: list[int],
     shared_kv_cache_layers: dict[str, str],
-    kv_cache_config: "KVCacheConfig | None" = None,
+    kv_cache_config: KVCacheConfig | None = None,
 ) -> dict[str, Any]:
     kv_caches: dict[str, Any] = {}
     has_attn = False
@@ -453,7 +484,7 @@ def _restride_blocks_first_kv_cache_to_kv_first_storage(
     )
 
 
-def init_kv_cache(
+def _init_kv_cache(
     runner_kv_caches: list[torch.Tensor | list[torch.Tensor]],
     forward_context: dict[str, Any],
     kv_cache_config: KVCacheConfig,
@@ -462,10 +493,11 @@ def init_kv_cache(
     cache_dtype: str,
     kernel_block_sizes: list[int],
     vllm_config: VllmConfig,
+    pcp_manager: PCPManager | None = None,
 ) -> dict[str, Any]:
     shared_kv_cache_layers = get_shared_kv_cache_layers(vllm_config)
-    kv_cache_raw_tensors = _allocate_kv_cache(
-        kv_cache_config, shared_kv_cache_layers, device
+    kv_cache_raw_tensors, peer_allocations = _allocate_kv_cache(
+        kv_cache_config, shared_kv_cache_layers, device, pcp_manager
     )
     flattened_attn_groups = list(group for groups in attn_groups for group in groups)
     kv_caches = _reshape_kv_cache(
@@ -485,7 +517,53 @@ def init_kv_cache(
         else 1
     )
     bind_kv_cache(kv_caches, forward_context, runner_kv_caches, num_attn_module)
+    if peer_allocations:
+        assert pcp_manager is not None and pcp_manager.direct_kv_enabled
+        from vllm.model_executor.layers.attention.pcp_peer_cache import (
+            make_rank_major_tensor_view,
+        )
+
+        for layer_name, target_layer_name in shared_kv_cache_layers.items():
+            peer_allocations[layer_name] = peer_allocations[target_layer_name]
+        fence = pcp_manager.get_peer_cache_fence()
+        for layer_name, kv_cache in kv_caches.items():
+            peer_kv_cache = make_rank_major_tensor_view(
+                peer_allocations[layer_name], kv_cache
+            )
+            forward_context[layer_name].bind_pcp_peer_kv_cache(peer_kv_cache, fence)
     return kv_caches
+
+
+def init_kv_cache(
+    runner_kv_caches: list[torch.Tensor | list[torch.Tensor]],
+    forward_context: dict[str, Any],
+    kv_cache_config: KVCacheConfig,
+    attn_groups: list[list[AttentionGroup]],
+    device: torch.device,
+    cache_dtype: str,
+    kernel_block_sizes: list[int],
+    vllm_config: VllmConfig,
+    pcp_manager: PCPManager | None = None,
+) -> dict[str, Any]:
+    try:
+        return _init_kv_cache(
+            runner_kv_caches,
+            forward_context,
+            kv_cache_config,
+            attn_groups,
+            device,
+            cache_dtype,
+            kernel_block_sizes,
+            vllm_config,
+            pcp_manager,
+        )
+    except BaseException:
+        if pcp_manager is not None and pcp_manager.direct_kv_enabled:
+            try:
+                pcp_manager.close()
+            except Exception:
+                logger.exception("Failed to roll back direct PCP KV allocations")
+        raise
 
 
 def build_slot_mappings_by_layer(

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -524,6 +524,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.cache_config.cache_dtype,
             self.kernel_block_sizes,
             self.vllm_config,
+            self.pcp_manager,
         )
         self.kv_connector = get_kv_connector(self.vllm_config, kv_caches_dict)
 
@@ -1620,6 +1621,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         """Release GPU tensors (model weights, KV caches, workspace) so that
         memory is reclaimable when running in the same process."""
         torch.accelerator.synchronize()
+        if self.pcp_manager is not None:
+            self.pcp_manager.close()
         if hasattr(self, "kv_caches"):
             self.kv_caches.clear()
         if hasattr(self, "attn_groups"):

--- a/vllm/v1/worker/gpu/pcp_manager.py
+++ b/vllm/v1/worker/gpu/pcp_manager.py
@@ -1,13 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
 
+import vllm.envs as envs
 from vllm.config import CUDAGraphMode, VllmConfig
-from vllm.distributed.parallel_state import get_dcp_group, get_pcp_group
+from vllm.distributed.parallel_state import (
+    get_dcp_group,
+    get_pcp_group,
+    in_the_same_node_as,
+)
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
@@ -21,6 +30,10 @@ from vllm.v1.worker.gpu.input_batch import (
 from vllm.v1.worker.gpu.states import RequestState
 
 logger = init_logger(__name__)
+
+if TYPE_CHECKING:
+    from vllm.distributed.device_communicators.cuda_vmm import RankMajorPeerView
+    from vllm.model_executor.layers.attention.pcp_peer_cache import PCPPeerCacheFence
 
 
 @dataclass(frozen=True)
@@ -55,6 +68,7 @@ class PCPManager:
         dcp_world_size: int = 1,
         dcp_rank: int = 0,
         cp_interleave: int = 1,
+        direct_kv_enabled: bool = False,
     ) -> None:
         self.pcp_world_size = pcp_world_size
         self.pcp_rank = pcp_rank
@@ -62,6 +76,9 @@ class PCPManager:
         self.dcp_world_size = dcp_world_size
         self.dcp_rank = dcp_rank
         self.cp_interleave = cp_interleave
+        self.direct_kv_enabled = direct_kv_enabled
+        self._peer_cache_allocations: list[RankMajorPeerView] = []
+        self._peer_cache_fence: PCPPeerCacheFence | None = None
 
         self._global_batch: InputBatch | None = None
         self._req_states = req_states
@@ -159,6 +176,109 @@ class PCPManager:
             )
         if vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs():
             raise NotImplementedError("MRV2 PCP supports PIECEWISE CUDA graphs only.")
+
+        if not envs.VLLM_USE_PCP_DIRECT_KV:
+            return
+
+        if not current_platform.is_cuda():
+            raise NotImplementedError("Direct PCP KV requires CUDA.")
+        if model_config.hf_text_config.model_type != "glm_moe_dsa":
+            raise NotImplementedError(
+                "Direct PCP KV currently supports GLM-5.2 (glm_moe_dsa) only."
+            )
+        forward_layers = vllm_config.compilation_config.static_forward_context
+        if not any(
+            type(layer).__module__ == "vllm.models.deepseek_v32.nvidia.attention"
+            and type(layer).__name__ == "DeepseekV32Attention"
+            for layer in forward_layers.values()
+        ):
+            raise NotImplementedError(
+                "Direct PCP KV requires the specialized NVIDIA deepseek_v32 "
+                "model implementation. Select it with --model-class-overrides."
+            )
+        if parallel_config.tensor_parallel_size != 1:
+            raise NotImplementedError("Direct PCP KV currently requires TP=1.")
+        if parallel_config.decode_context_parallel_size != 1:
+            raise NotImplementedError("Direct PCP KV currently requires DCP=1.")
+        if parallel_config.data_parallel_size != 1:
+            raise NotImplementedError("Direct PCP KV currently requires DP=1.")
+        if parallel_config.use_ubatching:
+            raise NotImplementedError(
+                "Direct PCP KV does not support dual batch overlap or ubatching."
+            )
+        if vllm_config.scheduler_config.async_scheduling:
+            raise NotImplementedError(
+                "Direct PCP KV does not support async scheduling."
+            )
+        if vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
+            raise NotImplementedError(
+                "Direct PCP KV currently requires eager execution. Set --enforce-eager."
+            )
+        cache_config = vllm_config.cache_config
+        if cache_config is None or cache_config.cache_dtype not in (
+            "fp8",
+            "fp8_ds_mla",
+        ):
+            raise NotImplementedError(
+                "Direct PCP KV requires --kv-cache-dtype fp8 or fp8_ds_mla."
+            )
+        if cache_config.enable_prefix_caching:
+            raise NotImplementedError(
+                "Direct PCP KV does not support prefix caching or copy-on-write. "
+                "Set --no-enable-prefix-caching."
+            )
+        kv_transfer_config = vllm_config.kv_transfer_config
+        if (
+            kv_transfer_config is not None
+            and kv_transfer_config.kv_connector is not None
+        ):
+            raise NotImplementedError(
+                "Direct PCP KV does not support KV connectors or offloading."
+            )
+        if getattr(model_config, "enable_sleep_mode", False):
+            raise NotImplementedError("Direct PCP KV does not support sleep mode.")
+
+    def allocate_peer_cache(self, size: int) -> RankMajorPeerView:
+        """Collectively allocate one rank-local cache and its peer view."""
+        if not self.direct_kv_enabled:
+            raise RuntimeError("Direct PCP KV cache allocation is not enabled.")
+        from vllm.distributed.device_communicators.cuda_vmm import (
+            create_rank_major_peer_view,
+        )
+
+        allocation = create_rank_major_peer_view(
+            (size,),
+            dtype=torch.int8,
+            group=get_pcp_group().cpu_group,
+            require_native_atomics=True,
+            device=self.device,
+        )
+        local_view = allocation.local_view
+        assert local_view is not None
+        local_view.zero_()
+        self._peer_cache_allocations.append(allocation)
+        return allocation
+
+    def get_peer_cache_fence(self) -> PCPPeerCacheFence:
+        if not self.direct_kv_enabled:
+            raise RuntimeError("Direct PCP KV cache fencing is not enabled.")
+        if self._peer_cache_fence is None:
+            from vllm.model_executor.layers.attention.pcp_peer_cache import (
+                PCPPeerCacheFence,
+            )
+
+            self._peer_cache_fence = PCPPeerCacheFence(
+                get_pcp_group().cpu_group, self.device
+            )
+        return self._peer_cache_fence
+
+    def close(self) -> None:
+        if self._peer_cache_fence is not None:
+            self._peer_cache_fence.close()
+            self._peer_cache_fence = None
+        for allocation in reversed(self._peer_cache_allocations):
+            allocation.close()
+        self._peer_cache_allocations.clear()
 
     @staticmethod
     def _reorder_segments(
@@ -658,9 +778,22 @@ def maybe_build_pcp_manager(
     parallel_config = vllm_config.parallel_config
     pcp_size = parallel_config.prefill_context_parallel_size
     if pcp_size <= 1:
+        if envs.VLLM_USE_PCP_DIRECT_KV:
+            raise ValueError(
+                "VLLM_USE_PCP_DIRECT_KV=1 requires "
+                "--prefill-context-parallel-size greater than 1."
+            )
         return None
 
     PCPManager.validate_config(vllm_config, supports_mm_inputs)
+
+    direct_kv_enabled = envs.VLLM_USE_PCP_DIRECT_KV
+    if direct_kv_enabled and not all(
+        in_the_same_node_as(get_pcp_group().cpu_group, source_rank=0)
+    ):
+        raise NotImplementedError(
+            "Direct PCP KV currently requires every PCP rank on one host."
+        )
 
     pcp_rank = get_pcp_group().rank_in_group
     dcp_size = parallel_config.decode_context_parallel_size
@@ -677,4 +810,5 @@ def maybe_build_pcp_manager(
         dcp_world_size=dcp_size,
         dcp_rank=dcp_rank,
         cp_interleave=parallel_config.cp_kv_cache_interleave_size,
+        direct_kv_enabled=direct_kv_enabled,
     )


### PR DESCRIPTION
## Summary

- add an opt-in, single-node PCP path that keeps the replicated KV-cache layout but replaces the `kv_c`, `k_pe`, and `indexer_k` update all-gathers with direct CUDA VMM peer stores
- extend the fused GLM-5.2 norm/RoPE/cache kernel to write FP8 data, scales, and RoPE bytes into every PCP replica, then publish them with a system-scope release/acquire fence
- retain a correct same-specialized-class collective reference path when direct stores are disabled
- fail closed outside the validated GLM-5.2 NVFP4, TP1/PCP4/DCP1, eager, FP8-KV configuration
- add VMM lifecycle/capability tests, byte-exact fanout tests, an uneven 13-token four-rank oracle, deployment documentation, and a standalone transport benchmark

## Shared-PCP positioning

This is one self-contained **Shared-PCP** optimization. Shared-PCP names a single-node PCP data model in which cross-rank tensors are exposed as explicitly placed shared GPU objects. An object may be replicated by direct peer stores, owner-sharded and peer-read, or compactly published to its consumers. The name describes data semantics rather than cache coherence or a required transport.

This PR applies that model to **replicated KV-update objects**: the persistent Main KV and Indexer K caches remain fully replicated, while each producer writes new rows directly into the peer replicas and explicitly publishes their visibility. Persistent KV capacity is unchanged.

## Motivation and design

This PR is a follow-up optimization to the PCP implementation introduced in #46570, which is part of the GLM-5.2 performance work tracked in #46654.

The existing PCP update path materializes three gathered payloads before cache insertion. On one peer-accessible NVIDIA node, every producer can instead store its local semantic payload directly into the corresponding slots of all existing cache replicas.

Startup creates rank-major VMM mappings through POSIX file-descriptor exchange. Runtime cache consumers retain ordinary rank-local views. The fused producer selects its PCP-local slot row, quantizes once, fans the result out to all replicas, and executes one reusable visibility fence before indexer or attention readers run. The direct path has no runtime KV-update collective or receive-side staging buffer.

When `VLLM_USE_PCP_DIRECT_KV=0`, the same specialized model and fused producer materialize locally prepared BF16 tensors, then reuse the existing PCP gather and cache-insertion paths. This makes feature-off a correct, same-class reference rather than a different model implementation.

### Direct-path lifecycle

```mermaid
sequenceDiagram
    autonumber
    participant E as Engine / PCP manager
    participant P as PCP ranks 0_3
    participant X as Host FD-exchange group
    participant V as CUDA VMM peer views
    participant K as Fused Q/KV kernel
    participant C as Four replicated KV caches
    participant F as System-scope fence
    participant A as Indexer + Sparse MLA
    participant H as Existing output collectives

    rect rgb(235, 245, 255)
        Note over E,V: Initialization only
        E->>P: Allocate one full local KV cache per rank
        P->>X: Export CUDA VMM allocation as POSIX FD
        X-->>P: Exchange every rank's FD
        P->>V: Import and map all peer allocations
        V-->>P: Stable rank-major peer tensor views
    end

    loop Every attention layer / scheduler step
        E->>P: Partition tokens and provide rank-local slot rows
        P->>K: Local Q, kv_c, k_pe, indexer_k
        K->>K: RMSNorm, RoPE and FP8 quantization
        K->>V: Ordinary global-memory stores through peer views
        V->>C: Fan out data and scales to all four replicas

        Note over K,C: No KV AllGather and no receive-side staging buffer

        K->>F: System-scope release signal
        F-->>P: Acquire after all producers publish
        P->>A: Read the now-complete local replica
        A-->>P: Indexer selection and sparse-attention output
        P->>H: Existing hidden-state/output collective
        H-->>E: Restore global token order / produce output
    end

    rect rgb(245, 245, 245)
        Note over P,V: Graceful teardown
        P->>P: Synchronize local CUDA work
        P->>X: PCP group barrier
        P->>V: Unmap peer views and release allocations
    end
```

### Per-layer direct versus collective behavior

```mermaid
sequenceDiagram
    participant R as vLLM runner / PCP manager
    participant F as Fused norm + RoPE producer
    participant C as PCP collective path
    participant V as VMM peer cache mappings
    participant A as Sparse indexer + MLA attention

    R->>F: Local hidden states + rank-major slot map
    F->>F: Compute Q, kv_c, k_pe, index_k
    alt Direct semantic stores (VLLM_USE_PCP_DIRECT_KV=1)
        F->>F: Select producer-rank slot row and quantize once
        F->>V: Store payload into every PCP replica
        F->>V: System-scope release/acquire visibility fence
    else Same-class collective reference (VLLM_USE_PCP_DIRECT_KV=0)
        F->>C: Materialize local BF16 kv_c, k_pe, index_k
        C->>C: Existing PCP all-gathers
        C->>V: Existing local cache insertion
    end
    V->>A: Rank-local replicated-cache loads
    A-->>R: Sparse index selection + attention output
    R->>R: Existing PCP hidden-state all-gather
```

`VLLM_USE_PCP_DIRECT_KV=1` is intentionally experimental. It rejects multi-host groups, devices without native peer atomics, TP/DCP/DP values other than one, CUDA graphs, async scheduling, dual-batch overlap, sleep mode, prefix caching/copy-on-write, and KV connectors. The collective path remains the default.

## Same-class engine A/B on four GB200s

The engine campaign was validated at private-review commit `f325bfdd5eee82c8601c76a57009fb778dde6521` with GLM-5.2 NVFP4, TP1/PCP4/DCP1, V2 runner, eager mode, expert parallelism with FlashInfer CUTLASS MoE, `FLASHINFER_MLA_SPARSE`, FP8 KV cache, and prefix caching disabled. Both variants used the exact same specialized NVIDIA model class and server arguments; only `VLLM_USE_PCP_DIRECT_KV=0/1` changed. The community branch is rebased directly onto current upstream `main` and contains only this standalone replicated-update feature; it does not include owner-sharded-history changes.

The campaign used ten adjacent cold-start pairs (20 independent server starts), counterbalanced `AB, BA` five times. Every restart ran one unrecorded full preconditioning batch, followed by both measured workloads. All 40 measured JSON files completed with zero failed requests; no measured run was discarded or selectively rerun.

Changes below are paired geometric means of the restart-level direct/collective ratios. Confidence intervals are percentile bootstrap intervals over the ten paired log ratios (200,000 resamples). Requests within a restart are not treated as independent samples.

### Fixed 1,024-input / 32-output workload, concurrency 16

| Metric | Collective baseline | Direct stores | Paired change | 95% CI |
|---|---:|---:|---:|---:|
| Mean TTFT (ms) | 708.363 | 619.273 | **-12.57%** | **[-13.73%, -11.46%]** |
| Mean TPOT (ms) | 179.502 | 178.510 | -0.55% | [-1.91%, +0.94%] |
| Request throughput (req/s) | 2.439 | 2.484 | +1.84% | [+0.38%, +3.23%] |
| Output throughput (tok/s) | 78.047 | 79.484 | +1.84% | [+0.38%, +3.23%] |
| p95 TTFT (ms) | 1041.764 | 904.442 | -13.18% | [-14.48%, -11.85%] |

### Fixed 3,584-input / 32-output workload, concurrency 4

| Metric | Collective baseline | Direct stores | Paired change | 95% CI |
|---|---:|---:|---:|---:|
| Mean TTFT (ms) | 536.712 | 466.876 | **-13.01%** | **[-14.38%, -11.62%]** |
| Mean TPOT (ms) | 182.000 | 180.060 | -1.05% | [-2.71%, +0.54%] |
| Request throughput (req/s) | 0.600 | 0.612 | +2.05% | [+0.49%, +3.72%] |
| Output throughput (tok/s) | 19.193 | 19.584 | +2.05% | [+0.49%, +3.71%] |
| p95 TTFT (ms) | 822.124 | 708.735 | -13.79% | [-15.20%, -12.31%] |

Predeclared publication gates passed for both workloads: TTFT reduction was at least 5% with a 95% interval excluding no improvement, the upper TPOT-regression bound was at most 2%, and the lower request-throughput bound was at least -2%.

All ten TTFT pairs favored direct mode; an exact paired sign-randomization test gives `p=0.00195` for each workload. The primary claim is the same-class end-to-end cache-update-path improvement. The isolated benchmark below remains the transport-only attribution.

### Measurement caveats

- p95 values are descriptive because each restart contains only 16 requests for the 1K workload and four for the 3,584 workload; inference uses restart-level mean metrics
- counterbalancing limits order bias, although the 1K TTFT benefit was -11.73% for AB pairs and -13.41% for BA pairs
- the 3,584 workload always followed the 1K workload and did not receive a separate shape-specific preconditioning batch; this ordering was identical for both variants
- the controller paused after pair 8 because an initial teardown check rejected about 3 MiB/GPU of idle driver residue; all four pair-8 JSONs had already completed, and execution resumed at pair 9 without rerunning data
- controlled post-result shutdown produced `EngineDeadError`, TCPStore, or resource-tracker warnings in some logs; they occur after the final measured result was saved and are not presented as clean-shutdown validation
- the editable install resolved `vllm` to this checkout and the controller required exact HEAD `f325bfdd5eee82c8601c76a57009fb778dde6521`; its generated package-version banner retained an older local-build suffix

## Four-GB200 KV-update microbenchmark

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc-per-node=4 \
  benchmarks/kernels/bench_pcp_kv_update.py \
  --local-tokens 1,8,32,128,512,2048 \
  --warmup 20 --repetitions 100 \
  --min-direct-p50-latency-reduction-percent 10 \
  --json-output /tmp/pcp-kv-update-final-gated.json
```

The benchmark compares three NCCL all-gathers plus one insertion kernel against one VMM fanout kernel plus the production two-kernel fence. It verifies byte-identical replicated cache images before timing and reports the slowest rank for each repetition.

| Local tokens/rank | Collective p50 (us) | Direct p50 (us) | Reduction | Speedup |
|---:|---:|---:|---:|---:|
| 1 | 206.000 | 45.664 | 77.833% | 4.511x |
| 8 | 209.632 | 42.800 | 79.583% | 4.898x |
| 32 | 224.048 | 42.496 | 81.033% | 5.272x |
| 128 | 221.232 | 44.256 | 79.996% | 4.999x |
| 512 | 216.880 | 43.472 | 79.956% | 4.989x |
| 2048 | 223.312 | 44.800 | 79.938% | 4.985x |

The 10% minimum-reduction gate passes at every token count. Constructed accounting changes from three KV-update collectives per iteration to zero. For 2,048 local tokens, each rank logically issues 11,534,336 replicated-cache bytes, of which 8,650,752 target remote peer mappings. These are semantic payload bytes, not measured physical wire traffic.

## Correctness and tests

Validation on the reviewed feature diff:

- same-class collective reference GSM8K smoke: 97/100 correct, zero invalid responses
- direct path uninterrupted GSM8K 5-shot: 1,319/1,319 completed, 0.9454 raw accuracy, zero invalid responses
- `ruff check`, `ruff format --check`, `py_compile`, and `git diff --check` passed
- `tests/distributed/test_cuda_vmm.py`: 13 passed, including partial-stream FD transfer and collective teardown
- `tests/kernels/test_fused_deepseek_v32_norm_rope.py`: 54 single-GPU cases plus one four-GPU packed/mixed byte oracle passed
- PCP peer-cache and block-table unit suites: 8 passed
- zero-local-token sparse MLA regression: 1 passed

On the final rebased current-main head, changed-file pre-commit passed, including Ruff, formatting, mypy 3.10, and the direct-CUDA-call check; manual mypy 3.12, `py_compile`, and `git diff --check` also passed. The exact-head VMM suite passed 13/13 tests, and five specialized GPU cases passed for collective materialization, direct local-slot fanout, and the packed PCP4 VMM oracle. No full-suite or exact-head engine rerun was performed.

## Current upstream integration note

Upstream [#49704](https://github.com/vllm-project/vllm/pull/49704) has merged and is inherited from current `main`. It fixes the non-uniform physical page sizes used by GLM-5.2's MLA and DSA indexer caches, so startup reaches this PR's collective-reference and direct-store paths without a temporary or duplicated patch. This PR contains no `KVBlockZeroer` changes.

## Scope

This PR deliberately keeps cache capacity replicated and claims only the KV-update-path improvement. Owner-sharded history is a separate Shared-PCP placement mode covered by #49741 and is not part of this diff.

This PR does not duplicate #49741, #49756, or #49704: those changes cover owner-sharded history, compact final-row publication, and non-uniform KV block zeroing, respectively; this PR changes only replicated KV-update publication. Prefix-cache block operations, KV transfer, CUDA graphs, multi-host transport, and additional model backends remain separate follow-ups.

## Shared-PCP family

Shared-PCP is a design vocabulary, not a stack dependency:

- this PR: replicated KV updates through direct peer stores;
- #49741: owner-sharded persistent KV history for capacity;
- #49756: compact final-row publication for sampling.

Each PR is independently reviewable and changes a different PCP object boundary.

Related: #46654 (GLM-5.2 performance tracking), #46570 (MRV2 PCP foundation).

The change was privately reviewed before upstream submission. Implementation was completed with AI coding assistance. The human submitter reviewed the changed lines, directed the acceptance criteria, and ran the validation reported above.

Co-authored with [@taoyuanyuan](https://github.com/taoyuanyuan)
