### PR TITLE
[Bugfix] Honor per-request StructuredOutputsParams.disable_any_whitespace

### DIFF
--- a/tests/v1/structured_output/test_backend_guidance.py
+++ b/tests/v1/structured_output/test_backend_guidance.py
@@ -231,3 +231,45 @@ def test_mistral_tokenizer_compile_grammar(
     grammar = backend.compile_grammar(request_type, grammar_spec)
     assert grammar is not None
     assert not grammar.is_terminated()
+
+
+@pytest.mark.parametrize("per_request_flag", [True, False])
+def test_per_request_disable_any_whitespace(per_request_flag):
+    """Per-request StructuredOutputsParams.disable_any_whitespace must be
+    honored by the backend instead of being silently ignored (issue #19945).
+    """
+    tokenizer = AutoTokenizer.from_pretrained(TOKENIZER)
+    vllm_config = VllmConfig(
+        model_config=ModelConfig(tokenizer=TOKENIZER),
+        structured_outputs_config=StructuredOutputsConfig(backend="guidance"),
+    )
+    structured_output_manager = StructuredOutputManager(vllm_config)
+
+    sampling_params = SamplingParams(
+        structured_outputs=StructuredOutputsParams(
+            json='{"type": "object"}',
+            disable_any_whitespace=per_request_flag,
+        ),
+    )
+    sampling_params.structured_outputs._backend = "guidance"
+    sampling_params.update_from_generation_config({}, tokenizer.eos_token_id)
+
+    request = Request(
+        "test_request",
+        prompt_token_ids=tokenizer.encode("json:"),
+        sampling_params=sampling_params,
+        pooling_params=None,
+    )
+    structured_output_manager.grammar_init(request)
+    while not request.structured_output_request._check_grammar_completion():
+        continue
+    grammar = request.structured_output_request.grammar
+
+    spaced = tokenizer.encode('{ "a": "b" }')
+    if per_request_flag:
+        # Whitespace-free grammar must reject the spaced form...
+        assert grammar.validate_tokens(spaced) != spaced
+        # ...while the compact form stays accepted.
+        assert grammar.accept_tokens(request.request_id, tokenizer.encode('{"a":"b"}'))
+    else:
+        assert grammar.accept_tokens(request.request_id, spaced)

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -185,7 +185,14 @@ class StructuredOutputManager:
         try:
             request_type, grammar_spec = struct_request.structured_output_key
             assert self.backend is not None
-            return self.backend.compile_grammar(request_type, grammar_spec)
+            so_params = (
+                request.sampling_params.structured_outputs
+                if request.sampling_params is not None
+                else None
+            )
+            return self.backend.compile_grammar(
+                request_type, grammar_spec, so_params=so_params
+            )
         except Exception:
             logger.exception(
                 "Failed to compile grammar for request %s", request.request_id

--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -106,13 +106,22 @@ class GuidanceBackend(StructuredOutputBackend):
             )
 
     def compile_grammar(
-        self, request_type: StructuredOutputOptions, grammar_spec: str
+        self,
+        request_type: StructuredOutputOptions,
+        grammar_spec: str,
+        so_params=None,
     ) -> StructuredOutputGrammar:
+        disable_any_whitespace = self.disable_any_whitespace or (
+            so_params is not None and so_params.disable_any_whitespace
+        )
+        disable_additional_properties = self.disable_additional_properties or (
+            so_params is not None and so_params.disable_additional_properties
+        )
         self.serialized_grammar = serialize_guidance_grammar(
             request_type,
             grammar_spec,
-            self.disable_any_whitespace,
-            self.disable_additional_properties,
+            disable_any_whitespace,
+            disable_additional_properties,
         )
 
         ll_matcher = llguidance.LLMatcher(

--- a/vllm/v1/structured_output/backend_lm_format_enforcer.py
+++ b/vllm/v1/structured_output/backend_lm_format_enforcer.py
@@ -99,7 +99,10 @@ class LMFormatEnforcerBackend(StructuredOutputBackend):
         )
 
     def compile_grammar(
-        self, request_type: StructuredOutputOptions, grammar_spec: str
+        self,
+        request_type: StructuredOutputOptions,
+        grammar_spec: str,
+        so_params=None,
     ) -> StructuredOutputGrammar:
         character_level_parser: lmformatenforcer.CharacterLevelParser
         if request_type == StructuredOutputOptions.JSON:

--- a/vllm/v1/structured_output/backend_outlines.py
+++ b/vllm/v1/structured_output/backend_outlines.py
@@ -71,7 +71,10 @@ class OutlinesBackend(StructuredOutputBackend):
         return index
 
     def compile_grammar(
-        self, request_type: StructuredOutputOptions, grammar_spec: str
+        self,
+        request_type: StructuredOutputOptions,
+        grammar_spec: str,
+        so_params=None,
     ) -> StructuredOutputGrammar:
         if request_type == StructuredOutputOptions.JSON:
             regex = json_schema.build_regex_from_schema(grammar_spec)

--- a/vllm/v1/structured_output/backend_types.py
+++ b/vllm/v1/structured_output/backend_types.py
@@ -105,7 +105,10 @@ class StructuredOutputBackend(ABC):
 
     @abstractmethod
     def compile_grammar(
-        self, request_type: StructuredOutputOptions, grammar_spec: str
+        self,
+        request_type: StructuredOutputOptions,
+        grammar_spec: str,
+        so_params=None,
     ) -> StructuredOutputGrammar:
         """
         Compiles a grammar specification into a structured output grammar.
@@ -114,6 +117,9 @@ class StructuredOutputBackend(ABC):
             request_type (StructuredOutputOptions): The type of structured
                 output request.
             grammar_spec (str): The grammar specification to compile.
+            so_params (StructuredOutputsParams | None): the request-level
+                structured output params, so per-request options (e.g.
+                disable_any_whitespace) can be honored by the backend.
 
         Returns:
             StructuredOutputGrammar: The compiled structured output grammar.

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -76,15 +76,24 @@ class XgrammarBackend(StructuredOutputBackend):
             )
 
     def compile_grammar(
-        self, request_type: StructuredOutputOptions, grammar_spec: str
+        self,
+        request_type: StructuredOutputOptions,
+        grammar_spec: str,
+        so_params=None,
     ) -> StructuredOutputGrammar:
+        # Per-request flag ORs with the engine-level config (xgrammar's
+        # compiler cache keys include compile options, so mixing per-request
+        # values is safe).
+        disable_any_whitespace = self.disable_any_whitespace or (
+            so_params is not None and so_params.disable_any_whitespace
+        )
         if request_type == StructuredOutputOptions.JSON:
             ctx = self.compiler.compile_json_schema(
-                grammar_spec, any_whitespace=not self.disable_any_whitespace
+                grammar_spec, any_whitespace=not disable_any_whitespace
             )
         elif request_type == StructuredOutputOptions.JSON_OBJECT:
             ctx = self.compiler.compile_json_schema(
-                '{"type": "object"}', any_whitespace=not self.disable_any_whitespace
+                '{"type": "object"}', any_whitespace=not disable_any_whitespace
             )
         elif request_type == StructuredOutputOptions.GRAMMAR:
             ctx = self.compiler.compile_grammar(grammar_spec)


### PR DESCRIPTION
## Purpose

Fix #19945: the per-request fields `StructuredOutputsParams.disable_any_whitespace` and `disable_additional_properties` are declared in `sampling_params.py` but are never consumed anywhere — the xgrammar and guidance backends only read the engine-level `structured_outputs_config` (`backend_xgrammar.py` `__post_init__`), so setting the flag on a request is silently ignored. The issue was reported on 2025-06-22 and auto-closed as stale without a fix; the behavior still reproduces on today's `main`.

Reproduction (before this PR): start an engine **without** engine-level `structured_outputs_config`, then send

```python
SamplingParams(structured_outputs=StructuredOutputsParams(
    json=SCHEMA, disable_any_whitespace=True))
```

The output is still pretty-printed multi-line JSON (flag ignored). After this PR the same request produces single-line output.

Change: plumb the request-level `StructuredOutputsParams` into `StructuredOutputBackend.compile_grammar` as an optional argument (default `None`, so external/custom backends keep working), and OR the per-request flags with the engine-level config in the xgrammar and guidance backends. Mixing per-request values is safe for xgrammar because its grammar compiler cache keys include the compile options (verified empirically: same compiler, same schema, different `any_whitespace` produce distinct compiled grammars).

## Test Plan

New CPU-only regression test (guidance backend, gpt2 tokenizer, no GPU needed):

```bash
pytest tests/v1/structured_output/test_backend_guidance.py -k per_request
```

## Test Result

- On `main` without the fix: `test_per_request_disable_any_whitespace[True]` **fails** (spaced JSON accepted although the request asked for whitespace-free output).
- With the fix: both parametrizations pass.
- E2E (RTX 5060 Ti, Qwen2.5-0.5B-Instruct, xgrammar backend): per-request `disable_any_whitespace=True` without any engine-level config now yields single-line JSON `{"name": "Lucy", "age": 30}`; before the fix the same request produced multi-line indented JSON.
- `ruff check` / `ruff format` clean on all touched files.
