### PR TITLE
[Refactor][KV Offloading] Unify fence field and move fence check after _build_store_jobs

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -14,6 +14,7 @@ from tests.v1.kv_connector.unit.utils import EOS_TOKEN_ID
 from vllm.distributed.kv_events import MEDIUM_CPU, BlockRemoved, BlockStored
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
     OffloadingConnectorMetadata,
+    OffloadingWorkerMetadata,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
     OffloadingConnectorStats,
@@ -25,6 +26,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
     is_store_reachable_swa_chunk,
 )
 from vllm.v1.core.kv_cache_utils import BlockHash
+from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheGroupSpec,
@@ -40,6 +42,7 @@ from vllm.v1.kv_offload.base import (
     get_offload_block_hash,
     make_offload_key,
 )
+from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import RequestStatus
 
 
@@ -2060,7 +2063,7 @@ def test_stale_sliding_window_block_after_prepare_store_failure(
     # Now prepare_store succeeds.
     # Without the fix, the request would try to offload the stale block_id
     # at position 0 (now reused at position 3), causing a duplicate in
-    # sliding_window_block_ids and eventually a KeyError.
+    # block_ids and eventually a KeyError.
     runner.manager.prepare_store.side_effect = lambda keys, req_context: (
         generate_store_output(keys)
     )
@@ -2884,10 +2887,66 @@ class TestEagle:
 # ---------------------------------------------------------------------------
 
 
+def _make_finished_req_status(
+    scheduler: OffloadingConnectorScheduler,
+    *,
+    req_id: str = "finished-req",
+    block_ids: tuple[int, ...] = (1,),
+) -> RequestOffloadState:
+    """Build a minimal finished RequestOffloadState with synthetic blocks.
+
+    Sets only the fields the _build_store_jobs unit path reads. Finished
+    requests take num_tokens_after_batch = req.num_tokens, so
+    num_computed_tokens is intentionally not set.
+    """
+    tokens_per_block = scheduler.config.kv_group_configs[0].tokens_per_block
+    req = MagicMock()
+    req.request_id = req_id
+    req.num_tokens = tokens_per_block * len(block_ids)
+    req.num_prompt_tokens = req.num_tokens
+    req.is_finished.return_value = True
+    req.kv_transfer_params = None
+    req.block_hashes = [b"hash"] * len(block_ids)
+    req.all_token_ids = [0] * req.num_tokens
+    req.lora_request = None
+
+    state = RequestOffloadState(
+        config=scheduler.config,
+        req=req,
+        req_context=ReqContext(req_id=req_id),
+        offloading_context=RequestOffloadingContext(policy=OffloadPolicy.BLOCK_LEVEL),
+    )
+    state.group_states[0].block_ids = list(block_ids)
+    state.group_states[0].offload_keys = [
+        make_offload_key(f"k{i}".encode(), 0) for i in range(len(block_ids))
+    ]
+    return state
+
+
+def _drive_finished_store_job(
+    scheduler: OffloadingConnectorScheduler,
+    req_status: RequestOffloadState,
+    *,
+    allocated_block_ids: set[int],
+) -> tuple[int, OffloadingConnectorMetadata]:
+    """Drive build_connector_meta for a finished request and return the new
+    store job's ID plus the resulting metadata (which contains store_jobs and
+    jobs_to_flush populated by the unified fence check)."""
+    scheduler._req_status[req_status.req.request_id] = req_status
+    scheduler._current_batch_allocated_block_ids = set(allocated_block_ids)
+
+    scheduler_output = SchedulerOutput.make_empty()
+    scheduler_output.finished_req_ids = {req_status.req.request_id}
+    meta = scheduler.build_connector_meta(scheduler_output)
+    assert isinstance(meta, OffloadingConnectorMetadata)
+    store_jobs = meta.store_jobs
+    return next(iter(store_jobs)), meta
+
+
 def test_request_finished_with_pending_stores_populates_fence(request_runner):
     """When a request finishes with in-flight store jobs, the fence index
     (_block_id_to_pending_jobs) is correctly populated with the store jobs'
-    non_sliding_window_block_ids.
+    block_ids.
 
     This prevents data corruption when a subsequent request reuses the same
     GPU blocks before the store completes.
@@ -2921,7 +2980,7 @@ def test_request_finished_with_pending_stores_populates_fence(request_runner):
         )
         for js in runner.connector_scheduler._jobs.values():
             if js.is_store:
-                job_block_ids.update(js.non_sliding_window_block_ids or [])
+                job_block_ids.update(js.block_ids or [])
 
     # Run 1: create store job, finish request, populate fence.
     # With non-blocking drain (#45595), the job stays in-flight.
@@ -2936,7 +2995,7 @@ def test_request_finished_with_pending_stores_populates_fence(request_runner):
     populated_fence = next((f for f in fence_snapshots if len(f) > 0), None)
     assert populated_fence is not None, "Fence was never populated"
 
-    # Verify fence contained the job's non-SW block IDs.
+    # Verify fence contained the job's block IDs.
     for bid in job_block_ids:
         assert bid in populated_fence, f"Block {bid} not in fence: {populated_fence}"
 
@@ -3023,10 +3082,10 @@ def test_request_finished_mixed_full_attn_and_sliding_window(
     request_runner,
 ):
     """With both FullAttention and SlidingWindow groups, a single store job
-    has both non_sliding_window_block_ids and sliding_window_block_ids.
-
-    request_finished only registers non-SW blocks in the fence.
-    SW blocks were already registered at store creation time.
+    carries blocks from both groups in the unified block_ids field. All are
+    registered in the fence at store creation time, so reusing any of them
+    triggers a flush. Guards that unified registration doesn't regress the
+    mixed-group case.
     """
     block_size = 4
     sliding_window = 8  # 2 blocks
@@ -3070,8 +3129,7 @@ def test_request_finished_mixed_full_attn_and_sliding_window(
 
     # Capture fence state and job block IDs at each step.
     fence_snapshots: list[dict] = []
-    sw_block_ids: set[int] = set()
-    non_sw_block_ids: set[int] = set()
+    job_block_ids: set[int] = set()
 
     def capture_fence():
         fence_snapshots.append(
@@ -3079,8 +3137,7 @@ def test_request_finished_mixed_full_attn_and_sliding_window(
         )
         for js in runner.connector_scheduler._jobs.values():
             if js.is_store:
-                sw_block_ids.update(js.sliding_window_block_ids or [])
-                non_sw_block_ids.update(js.non_sliding_window_block_ids or [])
+                job_block_ids.update(js.block_ids or [])
 
     # Run 1: create store job, finish request, populate fence.
     runner.run(
@@ -3089,23 +3146,18 @@ def test_request_finished_mixed_full_attn_and_sliding_window(
         post_step_fn=capture_fence,
     )
 
-    # Verify job had both SW and non-SW blocks.
-    assert len(sw_block_ids) > 0, "No SW blocks in store job"
-    assert len(non_sw_block_ids) > 0, "No non-SW blocks in store job"
+    # Verify the store job had blocks from both FA and SW groups.
+    assert len(job_block_ids) > 0, "Store job had no blocks"
 
-    # Find the fence snapshot where both SW and non-SW blocks were present.
-    # SW blocks should appear at creation time, non-SW at request_finished.
-    populated_fence = None
-    for fence in fence_snapshots:
-        has_sw = all(bid in fence for bid in sw_block_ids)
-        has_non_sw = all(bid in fence for bid in non_sw_block_ids)
-        if has_sw and has_non_sw:
-            populated_fence = fence
-            break
+    # Find the fence snapshot where all of the job's blocks are present.
+    populated_fence = next(
+        (f for f in fence_snapshots if all(bid in f for bid in job_block_ids)),
+        None,
+    )
 
     assert populated_fence is not None, (
-        f"Fence never contained both SW {sw_block_ids} and "
-        f"non-SW {non_sw_block_ids} blocks. Snapshots: {fence_snapshots}"
+        f"Fence never contained all job blocks {job_block_ids}. "
+        f"Snapshots: {fence_snapshots}"
     )
 
     # Run 2: block reuse triggers fence-based flush of the old job.
@@ -3123,3 +3175,107 @@ def test_request_finished_mixed_full_attn_and_sliding_window(
     # Verify fence is empty after full lifecycle (cleanup happened).
     assert runner.connector_scheduler._block_id_to_pending_jobs == {}
     assert len(runner.connector_scheduler._jobs) == 0
+
+
+def test_completed_store_removes_fence_entries(request_runner):
+    """Completing a store for an active request removes every associated
+    fence entry — no separate SW/NSW cleanup branches."""
+    block_size = 4
+    blocks_per_chunk = 1
+    tokens_per_chunk = block_size * blocks_per_chunk
+    runner = request_runner(
+        block_size=block_size,
+        num_gpu_blocks=4,
+        async_scheduling=False,
+        blocks_per_chunk=blocks_per_chunk,
+    )
+    runner.new_request(token_ids=[0] * tokens_per_chunk)
+    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
+    )
+
+    # Complete transfers so the store job finishes; request stays active.
+    runner.run(
+        decoded_tokens=[0] * tokens_per_chunk,
+        expected_stored=(0,),
+    )
+    assert runner.connector_scheduler._block_id_to_pending_jobs == {}
+    assert str(runner.req_id) in runner.connector_scheduler._req_status
+    assert not runner.connector_scheduler._jobs
+
+
+def test_finished_store_job_flushes_on_partial_reallocation(request_runner):
+    """A deferred finished-request store is flushed when some (but not all)
+    of its source blocks were reallocated in the same step.
+
+    After the unified-fence refactor, _build_store_jobs only registers source
+    blocks in _block_id_to_pending_jobs; the fence check in
+    build_connector_meta sees both pre-existing and newly created jobs and
+    flushes new jobs for finished requests whose blocks were reallocated.
+
+    Also exercises the cleanup path by simulating the worker
+    draining the self-flushed job.
+    """
+    block_size = 4
+    runner = request_runner(
+        block_size=block_size,
+        num_gpu_blocks=10,
+        async_scheduling=False,
+    )
+    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
+    )
+
+    # R1 owns blocks (1, 2); R2 grabbed block 2 in the same step's schedule.
+    req_status = _make_finished_req_status(
+        runner.connector_scheduler, req_id="finished-req", block_ids=(1, 2)
+    )
+    new_job_id, meta = _drive_finished_store_job(
+        runner.connector_scheduler, req_status, allocated_block_ids={2}
+    )
+
+    assert new_job_id in meta.jobs_to_flush, (
+        f"Deferred store job {new_job_id} was NOT flushed even though "
+        f"block 2 was reallocated to another request in the same step."
+    )
+    assert runner.connector_scheduler._jobs[new_job_id].block_ids == [1, 2]
+
+    # Simulate the worker draining the self-flushed job; _remove_pending_job
+    # must drop the fence entries registered at store creation.
+    runner.connector_scheduler.update_connector_output(
+        KVConnectorOutput(
+            kv_connector_worker_meta=OffloadingWorkerMetadata(
+                completed_jobs={
+                    new_job_id: runner.connector_scheduler.config.num_workers
+                }
+            )
+        )
+    )
+    assert runner.connector_scheduler._block_id_to_pending_jobs == {}
+    assert new_job_id not in runner.connector_scheduler._jobs
+
+
+def test_finished_store_job_no_overlap_does_not_flush(request_runner):
+    """Negative case for the unified fence check: when no source block of a
+    finished request's deferred store was reallocated, the job must NOT be
+    in jobs_to_flush."""
+    block_size = 4
+    runner = request_runner(
+        block_size=block_size,
+        num_gpu_blocks=10,
+        async_scheduling=False,
+    )
+    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
+    )
+
+    req_status = _make_finished_req_status(
+        runner.connector_scheduler, req_id="finished-req", block_ids=(1, 2)
+    )
+    new_job_id, meta = _drive_finished_store_job(
+        runner.connector_scheduler, req_status, allocated_block_ids=set()
+    )
+
+    assert new_job_id not in meta.jobs_to_flush, (
+        f"Job {new_job_id} was flushed despite no overlap with reallocated blocks."
+    )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -66,12 +66,9 @@ class TransferJobStatus:
     # Offload keys this job covers; passed to manager.complete_*().
     keys: set[OffloadKey]
     is_store: bool
-    # Store src block IDs whose ref_cnt protects them while the request
-    # runs. Only registered in _block_id_to_pending_jobs on request_finished.
-    non_sliding_window_block_ids: list[int] | None = None
-    # Store src block IDs that may be freed before the request finishes.
-    # Registered in _block_id_to_pending_jobs at store creation time.
-    sliding_window_block_ids: list[int] | None = None
+    # Store src block IDs. Registered in _block_id_to_pending_jobs at
+    # store creation time for unified flush tracking.
+    block_ids: list[int] | None = None
 
 
 class GroupOffloadConfig(NamedTuple):
@@ -439,9 +436,8 @@ class OffloadingConnectorScheduler:
 
         # block_id -> pending store job_ids. Used to track jobs that needs
         # flushing in case a block is re-allocated by the KV cache manager.
-        # Populated only for finished requests (running-request blocks are
-        # protected by their ref_cnt) and for sliding window blocks (which can
-        # be freed before a request finishes).
+        # All blocks (both sliding window and non-sliding window) are
+        # registered at store creation time for unified flush tracking.
         self._block_id_to_pending_jobs: dict[int, set[int]] = {}
 
         self._events_tracker = OffloadingEventsTracker(spec.kv_events_config)
@@ -1065,14 +1061,9 @@ class OffloadingConnectorScheduler:
             group_sizes: list[int] = []
             block_indices: list[int] = []
             src_block_ids: list[int] = []
-            sliding_window_block_ids: list[int] = []
-            non_sliding_window_block_ids: list[int] = []
             for group_config, group_state in zip(
                 self.config.kv_group_configs, req_status.group_states
             ):
-                is_sliding_window = (
-                    group_config.sliding_window_size_in_chunks is not None
-                )
                 num_chunks = req_status.storable_chunks(
                     group_config, group_state, num_offloadable_tokens
                 )
@@ -1101,10 +1092,6 @@ class OffloadingConnectorScheduler:
                             start_gpu_block_idx = gpu_block_idx + i
                         src_block_ids.append(block_id)
                         num_group_blocks += 1
-                        if is_sliding_window:
-                            sliding_window_block_ids.append(block_id)
-                        else:
-                            non_sliding_window_block_ids.append(block_id)
 
                 group_sizes.append(num_group_blocks)
                 block_indices.append(start_gpu_block_idx or 0)
@@ -1124,20 +1111,17 @@ class OffloadingConnectorScheduler:
                 assert self._jobs[any_jid].is_store
             req_status.transfer_jobs.add(job_id)
 
-            # Watch sliding window blocks as they may get evicted
-            # before the request finishes
-            for bid in sliding_window_block_ids or ():
+            # Register all blocks immediately at store creation for unified
+            # flush tracking. Block type does not affect registration timing.
+            for bid in src_block_ids:
                 self._block_id_to_pending_jobs.setdefault(bid, set()).add(job_id)
 
-            # the non-sliding window blocks will be watched only
-            # when the request finishes
             self._jobs[job_id] = TransferJobStatus(
                 req_id=req_id,
                 pending_count=self.config.num_workers,
                 keys=set(keys_to_store),
                 is_store=True,
-                non_sliding_window_block_ids=non_sliding_window_block_ids,
-                sliding_window_block_ids=sliding_window_block_ids or None,
+                block_ids=src_block_ids or None,
             )
 
             store_jobs[job_id] = TransferJob(
@@ -1151,13 +1135,6 @@ class OffloadingConnectorScheduler:
                 num_offloadable_tokens,
                 job_id,
             )
-
-            if req.is_finished():
-                # Register non-sliding-window blocks for flush detection.
-                for bid in non_sliding_window_block_ids:
-                    self._block_id_to_pending_jobs.setdefault(bid, set()).add(job_id)
-                    if bid in self._current_batch_allocated_block_ids:
-                        self._current_batch_jobs_to_flush.add(job_id)
 
         return store_jobs
 
@@ -1180,23 +1157,35 @@ class OffloadingConnectorScheduler:
             assert self._jobs[any_jid].is_store
             self._current_batch_jobs_to_flush.update(req_status.transfer_jobs)
 
-        # Flush jobs that contain re-allocated blocks.
+        # Create store jobs first. This registers source blocks in
+        # _block_id_to_pending_jobs so the fence check below can see both
+        # pre-existing and newly created jobs in one pass.
+        store_jobs = self._build_store_jobs(scheduler_output)
+
+        # Flush jobs whose source blocks were reallocated this step.
+        # Old jobs (pre-existing) are flushed unconditionally: their
+        # blocks were freed by request completion or SW eviction.
+        # New jobs are only flushed for finished requests: their blocks
+        # may have been allocated to the same request (legitimate new
+        # store) or reallocated to another request (must flush).
+        new_job_ids = set(store_jobs)
         if (
             self._block_id_to_pending_jobs
             and not self._block_id_to_pending_jobs.keys().isdisjoint(
                 self._current_batch_allocated_block_ids
             )
         ):
-            self._current_batch_jobs_to_flush.update(
-                jid
-                for bid in self._current_batch_allocated_block_ids
-                if bid in self._block_id_to_pending_jobs
-                for jid in self._block_id_to_pending_jobs[bid]
-            )
+            for bid in self._current_batch_allocated_block_ids:
+                for jid in self._block_id_to_pending_jobs.get(bid, ()):
+                    if (
+                        jid not in new_job_ids
+                        or self._req_status[self._jobs[jid].req_id].req.is_finished()
+                    ):
+                        self._current_batch_jobs_to_flush.add(jid)
 
         meta = OffloadingConnectorMetadata(
             load_jobs=self._current_batch_load_jobs,
-            store_jobs=self._build_store_jobs(scheduler_output),
+            store_jobs=store_jobs,
             jobs_to_flush=self._current_batch_jobs_to_flush,
         )
         self._current_batch_load_jobs = {}
@@ -1277,15 +1266,9 @@ class OffloadingConnectorScheduler:
                 if self._chunks_being_loaded:
                     self._chunks_being_loaded.difference_update(job_status.keys)
             if self._block_id_to_pending_jobs:
-                # Sliding window blocks are tracked from store creation
-                # and must be cleaned up unconditionally.
-                self._remove_pending_job(job_id, job_status.sliding_window_block_ids)
-                # Non-sliding-window blocks are only tracked after
-                # request_finished, so only clean up for finished requests.
-                if req_status.req.is_finished():
-                    self._remove_pending_job(
-                        job_id, job_status.non_sliding_window_block_ids
-                    )
+                # All blocks are registered at store creation time, so
+                # cleanup is unconditional on job completion.
+                self._remove_pending_job(job_id, job_status.block_ids)
 
             del self._jobs[job_id]
             req_status.transfer_jobs.remove(job_id)
@@ -1340,12 +1323,6 @@ class OffloadingConnectorScheduler:
 
         # Keep req_status alive: _build_store_jobs will process finished_req_ids
         # on the next step and handle cleanup after creating store jobs.
-        # Register non_sliding_window_block_ids so future block reuse triggers
-        # a flush via _block_id_to_pending_jobs.
-        for job_id in req_status.transfer_jobs:
-            job_status = self._jobs[job_id]
-            for bid in job_status.non_sliding_window_block_ids or ():
-                self._block_id_to_pending_jobs.setdefault(bid, set()).add(job_id)
 
         return False, None
 


### PR DESCRIPTION
# Unify Offloading Connector Fence Field and Check Timing

## Summary

Two changes to the offloading connector's fence mechanism
(`_block_id_to_pending_jobs`):

1. **Unify the fence field.** Merge `sliding_window_block_ids` and
   `non_sliding_window_block_ids` (introduced in #41228) into a single
   `block_ids` field, and register all source blocks at store creation time.
   Block type no longer affects registration timing.

2. **Move the fence check after `_build_store_jobs`.** The unified check
   sees both pre-existing and newly created jobs in one pass and produces
   the same flush outcomes as #48596 (see Motivation).

## Motivation

This PR simplifies #48596's fence mechanism. The flush behavior — which
jobs are flushed when their blocks are reallocated — is unchanged.

#48596's pattern was correct but split across two locations and two
fields. The main fence check in `build_connector_meta` ran **before**
`_build_store_jobs` (seeing only pre-existing in-flight jobs), and
`_build_store_jobs` did an inline registration inside its `if req.is_finished()`
branch for the finished-request deferred store's NSW blocks. Combined with
the SW zeroing in `_update_req_states`, every flush case was already
covered:

- **Pre-existing in-flight jobs** — flushed unconditionally by the main
  check (which ran before `_build_store_jobs`).
- **Finished-request deferred stores** whose NSW blocks were reallocated —
  registered and inline-flushed inside `_build_store_jobs`.
- **SW blocks** of any deferred store that were reallocated — zeroed by
  `_update_req_states` so they never entered the new job's `src_block_ids`,
  removing them from the flush decision entirely.

This PR expresses the same behavior through a single `block_ids` field
registered at store creation time and a single fence check run after
`_build_store_jobs`. The check distinguishes old jobs (flush
unconditionally) from new jobs (flush only for finished requests). The
two-stage split, the second fence field, and the `request_finished`
registration loop all disappear.

This is a preparatory simplification — subsequent store-direction refactors
will touch this area, and a single field plus a single check is a smaller
surface to evolve than the two-field, two-stage shape #48596 left behind.

## Unified Fence Check

The check runs after `_build_store_jobs` and distinguishes old vs. new jobs.
For SW blocks of running requests that were evicted and reallocated, the
zeroing in `_update_req_states` keeps them out of the new job entirely, so
the fence check has nothing to do for them — same outcome as the old
main-check-before-build path, which would have flushed the old in-flight
SW jobs in `_block_id_to_pending_jobs`.

```python
new_job_ids = set(store_jobs)
for bid in self._current_batch_allocated_block_ids:
    for jid in self._block_id_to_pending_jobs.get(bid, ()):
        if (
            jid not in new_job_ids
            or self._req_status[self._jobs[jid].req_id].req.is_finished()
        ):
            self._current_batch_jobs_to_flush.add(jid)
```

- **Old jobs** (pre-existing): flushed unconditionally when their blocks are
  reallocated - the blocks were already freed by completion or SW eviction.
- **New jobs**: flushed only for finished requests. A finished request's
  blocks cannot still belong to it, so any appearing in
  `_current_batch_allocated_block_ids` were reallocated to another request.
  Active requests' new stores are left alone (their blocks are protected by
  `ref_cnt`).

## Changes

### `vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py`

- Merged `sliding_window_block_ids` + `non_sliding_window_block_ids` into a
  single `block_ids` field on `TransferJobStatus`.
- Removed the per-block-type split in `_build_store_jobs` and the
  `request_finished` registration loop; all source blocks now register at
  store creation time.
- Moved the fence flush into `build_connector_meta` after `_build_store_jobs`.
- Made `_remove_pending_job` cleanup unconditional on job completion,
  mirroring the unified registration.

### `tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py`

The three existing fence tests are kept (mechanical `block_ids` rename only).
Two shared helpers (`_make_finished_req_status`, `_drive_finished_store_job`)
remove repeated finished-request setup. Three new tests (a fourth SW-
while-running candidate was removed during review as redundant with
existing coverage of in-flight + reallocation flush):

| Test | What it guards |
|------|----------------|
| `test_finished_store_job_flushes_on_partial_reallocation` | **Core test for the unified check.** A deferred finished-request store with blocks `(1, 2)` and `_current_batch_allocated_block_ids = {2}` is flushed even though only one source block was reallocated. |
| `test_finished_store_job_no_overlap_does_not_flush` | Negative guard: no false-positive flush when none of the store's blocks were reallocated. |
| `test_completed_store_removes_fence_entries` | The now-unconditional cleanup path removes fence entries on store completion for a non-finished (still active) request. |

`reset_cache` and preemption flush are already covered by existing
`test_reset_cache` and
`test_async_preempt_readmit_before_transfer_output_is_deferred`; isolated
duplicates are intentionally not added.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/offloading_connector/ -v
```

```
157 passed, 2 skipped in 152.82s
```

Ruff check / format: pass.

## Why This Is Not Duplicate Work

Builds on #48596 (merged 2026-07-17), which introduced the two-stage NSW
registration pattern (main check before `_build_store_jobs` + inline NSW
registration inside `_build_store_jobs` for finished-request deferred stores).
This PR unifies that pattern into a single field and a single fence check —
a structural simplification that **preserves #48596's flush behavior**, not
a fix to a gap and not a duplicate.

## AI Assistance Statement

Developed with AI assistance for code generation, testing, and documentation.
Design decisions (unified fence field, unified vs. in-loop fence check, test
coverage) were made by the human author based on analysis of #41228 and #48596.
