### PR TITLE
[Bugfix] Shared MM text-LoRA mapper fallback for language_model wrappers

### DIFF
--- a/tests/lora/test_mm_text_lora_fallback.py
+++ b/tests/lora/test_mm_text_lora_fallback.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for WeightsMapper.with_mm_text_lora_fallback.
+
+Protects the guard that skips gemma4-shaped mappers
+(``model.language_model.`` → ``model.``) and models that already carry a bare
+``model.`` / ``model`` catch-all. A naive ``"model.language_model." in
+prefixes`` check would append the fallback to gemma4 and, because
+``_map_name`` applies prefix rules sequentially without breaking, corrupt
+``model.language_model.layers...`` → ``model.layers...`` →
+``language_model.model.layers...``.
+"""
+
+from __future__ import annotations
+
+from vllm.model_executor.models.utils import WeightsMapper
+
+TEXT_LORA_PROBE = "model.layers.0.self_attn.q_proj"
+BASE_LM_PROBE = "model.language_model.layers.0.self_attn.q_proj.weight"
+BASE_VISUAL_PROBE = "model.visual.blocks.0.attn.qkv.weight"
+
+
+def _map(mapper: WeightsMapper, key: str) -> str | None:
+    return mapper._map_name(key)
+
+
+def test_gemma4_shaped_mapper_is_noop():
+    """gemma4 mounts LM at self.model; destination is not language_model.*."""
+    mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "model.language_model.": "model.",
+        }
+    )
+    out = mapper.with_mm_text_lora_fallback()
+    assert out is mapper
+    assert "model." not in out.orig_to_new_prefix
+    # Text-LoRA key already matches the text stack path under model.*.
+    assert _map(out, TEXT_LORA_PROBE) == TEXT_LORA_PROBE
+    # Existing specific rule must not be double-mapped by a catch-all.
+    assert _map(out, BASE_LM_PROBE) == "model.layers.0.self_attn.q_proj.weight"
+
+
+def test_naive_catchall_would_corrupt_gemma4_shaped_base_keys():
+    """Document the double-map hazard the destination guard prevents."""
+    prefixes = {
+        "model.language_model.": "model.",
+        # Naive append without destination check — unsafe.
+        "model.": "language_model.model.",
+    }
+    mapper = WeightsMapper(orig_to_new_prefix=prefixes)
+    # First rule rewrites to model.layers..., then catch-all rewrites again.
+    assert (
+        _map(mapper, BASE_LM_PROBE)
+        == "language_model.model.layers.0.self_attn.q_proj.weight"
+    )
+
+
+def test_already_has_model_dot_catchall_is_noop():
+    """qwen2_vl-shaped: bare model. already present."""
+    mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "model.language_model.": "language_model.model.",
+            "model.visual.": "visual.",
+            "lm_head.": "language_model.lm_head.",
+            "model.": "language_model.model.",
+        }
+    )
+    out = mapper.with_mm_text_lora_fallback()
+    assert out is mapper
+    assert _map(out, TEXT_LORA_PROBE) == "language_model.model.layers.0.self_attn.q_proj"
+
+
+def test_already_has_model_catchall_without_dot_is_noop():
+    """gemma4_mm-shaped: bare 'model' (no trailing dot) already present."""
+    mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "model.language_model.": "language_model.model.",
+            "lm_head.": "language_model.lm_head.",
+            "model": "language_model.model",
+        }
+    )
+    out = mapper.with_mm_text_lora_fallback()
+    assert out is mapper
+    assert _map(out, TEXT_LORA_PROBE) == "language_model.model.layers.0.self_attn.q_proj"
+
+
+def test_qwen3_vl_shaped_bug_gets_fallback():
+    """Missing bare catch-all + language_model destination → append last."""
+    mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "model.visual.": "visual.",
+            "lm_head.": "language_model.lm_head.",
+            "model.language_model.": "language_model.model.",
+        }
+    )
+    out = mapper.with_mm_text_lora_fallback()
+    assert out is not mapper
+    assert out.orig_to_new_prefix["model."] == "language_model.model."
+    assert list(out.orig_to_new_prefix.keys())[-1] == "model."
+    assert _map(mapper, TEXT_LORA_PROBE) == TEXT_LORA_PROBE
+    assert _map(out, TEXT_LORA_PROBE) == (
+        "language_model.model.layers.0.self_attn.q_proj"
+    )
+    # Base keys unchanged vs pre-fallback mapper.
+    assert _map(out, BASE_LM_PROBE) == _map(mapper, BASE_LM_PROBE)
+    assert _map(out, BASE_VISUAL_PROBE) == _map(mapper, BASE_VISUAL_PROBE)
+    assert _map(out, BASE_LM_PROBE) == (
+        "language_model.model.layers.0.self_attn.q_proj.weight"
+    )
+    assert _map(out, BASE_VISUAL_PROBE) == "visual.blocks.0.attn.qkv.weight"

--- a/tests/lora/test_mm_text_lora_fallback.py
+++ b/tests/lora/test_mm_text_lora_fallback.py
@@ -108,3 +108,30 @@ def test_qwen3_vl_shaped_bug_gets_fallback():
         "language_model.model.layers.0.self_attn.q_proj.weight"
     )
     assert _map(out, BASE_VISUAL_PROBE) == "visual.blocks.0.attn.qkv.weight"
+def test_fallback_destination_follows_lm_dst():
+    """Catch-all must reuse the existing language_model destination."""
+    mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "model.visual.": "visual.",
+            "lm_head.": "language_model.lm_head.",
+            "model.language_model.": "language_model.transformer.",
+        }
+    )
+    out = mapper.with_mm_text_lora_fallback()
+    assert out is not mapper
+    assert out.orig_to_new_prefix["model."] == "language_model.transformer."
+    assert _map(out, TEXT_LORA_PROBE) == (
+        "language_model.transformer.layers.0.self_attn.q_proj"
+    )
+
+
+def test_language_model_without_dot_suffix_is_noop():
+    """Require language_model. prefix destination, not bare language_model*."""
+    mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "model.language_model.": "language_modeling.",
+        }
+    )
+    out = mapper.with_mm_text_lora_fallback()
+    assert out is mapper
+    assert "model." not in out.orig_to_new_prefix

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -135,6 +135,8 @@ class WorkerLoRAManager:
             hf_to_vllm_mapper = getattr(model, "hf_to_vllm_mapper", None)
             if hf_to_vllm_mapper is not None:
                 hf_to_vllm_mapper = hf_to_vllm_mapper.get_unstacked_mapper()
+                # Shared MM/CondGen text-LoRA fallback (see WeightsMapper).
+                hf_to_vllm_mapper = hf_to_vllm_mapper.with_mm_text_lora_fallback()
 
             # Get model-defined prefixes to skip during LoRA loading.
             lora_skip_prefixes = getattr(model, "lora_skip_prefixes", None)

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -169,6 +169,30 @@ class WeightsMapper:
         (`qkv_proj`)."""
         return replace(self, orig_to_new_stacked={})
 
+    def with_mm_text_lora_fallback(self) -> "WeightsMapper":
+        """Append a shared bare ``model.`` → ``language_model.model.`` LoRA fallback.
+
+        Multimodal / CondGen wrappers that mount the LM under ``language_model``
+        usually remap ``model.language_model.`` → ``language_model.model.`` for base
+        checkpoints. After PEFT strips ``base_model.model.``, text-LoRA keys look
+        like ``model.layers...`` and match none of the specific rules, so the
+        adapter loads as a silent no-op.
+
+        Rather than adding that catch-all per model as each is discovered, detect
+        the wrapper pattern once here and append the rule **last** when missing.
+        Existing ``model.`` / ``model`` catch-alls (qwen2_vl, gemma4_mm) are left
+        untouched. Call this only on the LoRA loading path so base-weight maps
+        stay unchanged unless they already included the rule.
+        """
+        prefixes = dict(self.orig_to_new_prefix)
+        if "model." in prefixes or "model" in prefixes:
+            return self
+        lm_dst = prefixes.get("model.language_model.")
+        if not isinstance(lm_dst, str) or not lm_dst.startswith("language_model"):
+            return self
+        prefixes["model."] = "language_model.model."
+        return replace(self, orig_to_new_prefix=prefixes)
+
 
 class AutoWeightsLoader:
     """

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -170,16 +170,17 @@ class WeightsMapper:
         return replace(self, orig_to_new_stacked={})
 
     def with_mm_text_lora_fallback(self) -> "WeightsMapper":
-        """Append a shared bare ``model.`` → ``language_model.model.`` LoRA fallback.
+        """Append a shared bare ``model.`` LoRA fallback for language_model wrappers.
 
         Multimodal / CondGen wrappers that mount the LM under ``language_model``
-        usually remap ``model.language_model.`` → ``language_model.model.`` for base
+        usually remap ``model.language_model.`` → ``language_model...`` for base
         checkpoints. After PEFT strips ``base_model.model.``, text-LoRA keys look
         like ``model.layers...`` and match none of the specific rules, so the
         adapter loads as a silent no-op.
 
         Rather than adding that catch-all per model as each is discovered, detect
-        the wrapper pattern once here and append the rule **last** when missing.
+        the wrapper pattern once here and append ``model.`` → the same destination
+        as the existing ``model.language_model.`` rule (**last**) when missing.
         Existing ``model.`` / ``model`` catch-alls (qwen2_vl, gemma4_mm) are left
         untouched. Call this only on the LoRA loading path so base-weight maps
         stay unchanged unless they already included the rule.
@@ -188,9 +189,9 @@ class WeightsMapper:
         if "model." in prefixes or "model" in prefixes:
             return self
         lm_dst = prefixes.get("model.language_model.")
-        if not isinstance(lm_dst, str) or not lm_dst.startswith("language_model"):
+        if not isinstance(lm_dst, str) or not lm_dst.startswith("language_model."):
             return self
-        prefixes["model."] = "language_model.model."
+        prefixes["model."] = lm_dst
         return replace(self, orig_to_new_prefix=prefixes)
 
 


### PR DESCRIPTION
Supersedes #49464, which was accidentally closed during DCO history repair. This PR restores the change on a clean branch with signed-off commits and includes a review follow-up: instead of hardcoding `language_model.model.`, the fallback now derives its destination from the wrapper's existing `model.language_model.` mapping and requires that destination to be rooted at `language_model.`. For the currently affected in-tree wrappers, the resulting mappings and model coverage are unchanged.

## Purpose

Fixes #48019.

Addresses [#49354](https://github.com/vllm-project/vllm/issues/49354), including the Qwen3.5 / Qwen3.6 text-LoRA no-op path described there.

This PR fixes text-only PEFT LoRAs silently loading as no-ops on multimodal and conditional-generation wrappers that mount their language model under `self.language_model`.

The broader affected-model analysis and the motivation for moving this fallback into a shared mapper path were provided by @ErenAta16 in the PR comment: https://github.com/vllm-project/vllm/pull/48022#issuecomment-5045100610

After PEFT strips `base_model.model.`, text-LoRA keys look like:

```text
model.layers.0.self_attn.q_proj
```

Affected wrappers typically map `model.language_model.` to `language_model.model.` but have no bare `model.` fallback. The key therefore resolves to a module that does not exist, while adapter loading completes without an error.

Add `WeightsMapper.with_mm_text_lora_fallback()` to derive the bare `model.` fallback from the wrapper's existing `model.language_model.` destination:
```python
lm_dst = prefixes.get("model.language_model.")
if isinstance(lm_dst, str) and lm_dst.startswith("language_model."):
    prefixes["model."] = lm_dst
```

The fallback is added last only when the mapper contains the wrapper pattern and has no existing `model.` or `model` catch-all. It is applied only in the LoRA loading path after `get_unstacked_mapper()`, so model mapper definitions and base-weight loading remain unchanged.

This is a shared alternative to adding the same fallback to individual model classes as each affected wrapper is discovered.

## Test Plan

Lint the changed files:

```bash
ruff check vllm/model_executor/models/utils.py vllm/lora/worker_manager.py
ruff format --check vllm/model_executor/models/utils.py vllm/lora/worker_manager.py
```

Static mapper probe for the post-PEFT text-LoRA key `model.layers.0.self_attn.q_proj` on each wrapper's `hf_to_vllm_mapper`, before and after `get_unstacked_mapper().with_mm_text_lora_fallback()`:

```bash
.venv/bin/python - <<'PY'
from vllm.model_executor.models.utils import WeightsMapper

probe = "model.layers.0.self_attn.q_proj"
# Example: Qwen3-VL style mapper missing the bare model. catch-all.
mapper = WeightsMapper(
    orig_to_new_prefix={
        "model.visual.": "visual.",
        "lm_head.": "language_model.lm_head.",
        "model.language_model.": "language_model.model.",
    }
)
before = mapper._map_name(probe)
after = mapper.get_unstacked_mapper().with_mm_text_lora_fallback()._map_name(probe)
print("before:", before)
print("after:", after)
assert before == probe
assert after == "language_model.model.layers.0.self_attn.q_proj"
print("ok")
PY
```

Repeat the same probe across the SupportsLoRA wrapper table from the @ErenAta16 analysis, and confirm:

1. affected wrappers resolve under `language_model.model`
2. wrappers with an existing `model.` / `model` catch-all stay unchanged
3. existing prefix-rule sample keys map identically before and after

GPU generation parity on Qwen3.5-4B with a text PEFT LoRA, using the same protocol as #49354 (`temperature=0`, label match rate, n=64). Adapters and prompts are private fine-tunes; the public reproduction shape is:

```python
from peft import PeftModel
from transformers import AutoModelForCausalLM, AutoTokenizer
from vllm import LLM, SamplingParams
from vllm.lora.request import LoRARequest

BASE = "Qwen/Qwen3.5-4B"
ADAPTER = "/path/to/peft-adapter"
PROMPTS = ["..."]  # identical across arms

# HF base vs HF LoRA, then:
llm_base = LLM(model=BASE, trust_remote_code=True, dtype="bfloat16",
               language_model_only=True, enforce_eager=True)
llm_lora = LLM(model=BASE, trust_remote_code=True, dtype="bfloat16",
               enable_lora=True, max_lora_rank=16,
               language_model_only=True, enforce_eager=True)
sp = SamplingParams(temperature=0.0, max_tokens=64)
out_base = llm_base.generate(PROMPTS, sp)
out_lora = llm_lora.generate(
    PROMPTS, sp, lora_request=LoRARequest("adapter", 1, ADAPTER)
)
# Expect vLLM base↔lora similar to HF base↔lora, and HF_lora↔vLLM_lora ~= 1.0
```

## Test Result

Static mapper verification:

- 13 affected wrappers: `MAP_BUG` → `FIXED`
- 2 wrappers with an existing catch-all: unchanged
- 1 different-layout wrapper: not targeted
- Remaining mapping failures after the shared fallback: 0
- Existing prefix-rule sample mappings: identical before and after

Full table:

| model | map issue? | before ok | after ok | status | fallback applied | base-rule regression |
|---|---|:---:|:---:|---|:---:|:---:|
| `qwen2_vl` | no (already OK) | yes | yes | `OK_ALREADY`→`OK_UNCHANGED` | no | yes |
| `gemma4_mm` | no (already OK; has catch-all) | yes | yes | `OK_ALREADY`→`OK_UNCHANGED` | no | yes |
| `qwen3_vl` | yes (`MAP_BUG`) | **no** | yes | `MAP_BUG`→`FIXED` | yes | yes |
| `gemma3_mm` | yes (`MAP_BUG`) | **no** | yes | `MAP_BUG`→`FIXED` | yes | yes |
| `llava` | yes (`MAP_BUG`) | **no** | yes | `MAP_BUG`→`FIXED` | yes | yes |
| `llava_next_video` | yes (`MAP_BUG`) | **no** | yes | `MAP_BUG`→`FIXED` | yes | yes |
| `paligemma` | yes (`MAP_BUG`) | **no** | yes | `MAP_BUG`→`FIXED` | yes | yes |
| `pixtral` | yes (`MAP_BUG`) | **no** | yes | `MAP_BUG`→`FIXED` | yes | yes |
| `interns1` | yes (`MAP_BUG`) | **no** | yes | `MAP_BUG`→`FIXED` | yes | yes |
| `lfm2_vl` | yes (`MAP_BUG`) | **no** | yes | `MAP_BUG`→`FIXED` | yes | yes |
| `glm4_1v` | yes (`MAP_BUG`) | **no** | yes | `MAP_BUG`→`FIXED` | yes | yes |
| `granite4_vision` | yes (`MAP_BUG`) | **no** | yes | `MAP_BUG`→`FIXED` | yes | yes |
| `minicpmv4_6` | yes (`MAP_BUG`) | **no** | yes | `MAP_BUG`→`FIXED` | yes | yes |
| `cheers` | yes (`MAP_BUG`) | **no** | yes | `MAP_BUG`→`FIXED` | yes | yes |
| `gemma4` | no (`DIFF_LAYOUT`; not this bug) | **no**† | **no**† | `DIFF_LAYOUT`→`N/A_LAYOUT` | no | yes |
| `qwen3_asr` | yes (`MAP_BUG`) | **no** | yes | `MAP_BUG`→`FIXED` | yes | yes |

† `before/after ok` is only vs the probe “lands under `language_model.*`”: `gemma4` maps `"model.language_model." → "model."`, so the probe stays at `model.layers.*` — that is the **correct** layout for text CausalLM, not a `MAP_BUG`. Online Gemma4 LoRA silent failure was **alias wipe (39815/39816)**, orthogonal to this helper; skipping gemma4-shaped destinations avoids double-map.

Lint:

```text
ruff check: PASS
ruff format --check: PASS
```

Qwen3.5-4B generation parity, 64 samples:

```text
HF base   ↔ HF LoRA:   0.6094
vLLM base ↔ vLLM LoRA: 0.6094
HF base   ↔ vLLM base: 0.9688
HF LoRA   ↔ vLLM LoRA: 1.0000
```

The GPU evaluation used a build containing the existing LoRA zeroing fix from #39816 plus the shared mapper fallback. The remaining listed wrappers were verified at the prefix-mapping layer but were not individually evaluated with GPU text-LoRA checkpoints.
