### PR TITLE
[Bugfix][Frontend] Prevent server_load double-decrement on client disconnect

### DIFF
--- a/tests/entrypoints/serve/utils/test_api_utils.py
+++ b/tests/entrypoints/serve/utils/test_api_utils.py
@@ -1,13 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import asyncio
+from types import SimpleNamespace
+
 import pytest
+from fastapi.responses import JSONResponse
 
 from vllm.entrypoints.openai.engine.protocol import StreamOptions
 from vllm.entrypoints.serve.utils.api_utils import (
     get_max_tokens,
+    load_aware_call,
     sanitize_message,
     should_include_usage,
+    with_cancellation,
 )
 
 
@@ -16,6 +22,59 @@ def test_sanitize_message():
         sanitize_message("<_io.BytesIO object at 0x7a95e299e750>")
         == "<_io.BytesIO object>"
     )
+
+
+def _make_load_tracking_request(disconnect_delay: float):
+    state = SimpleNamespace(
+        enable_server_load_tracking=True,
+        server_load_metrics=0,
+    )
+    app = SimpleNamespace(state=state)
+
+    async def receive():
+        await asyncio.sleep(disconnect_delay)
+        return {"type": "http.disconnect"}
+
+    return SimpleNamespace(app=app, receive=receive), state
+
+
+async def _run_background(response: JSONResponse | None) -> None:
+    if response is None or response.background is None:
+        return
+    await response.background()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("disconnect_delay", "handler_delay"),
+    [
+        (0.05, 0.0),  # handler completes first
+        (0.0, 0.05),  # disconnect wins
+        (0.0, 0.0),  # simultaneous completion (previously double-decremented)
+    ],
+    ids=["handler-first", "disconnect-first", "simultaneous"],
+)
+async def test_server_load_never_negative_on_disconnect(
+    disconnect_delay: float, handler_delay: float
+):
+    """with_cancellation + load_aware_call must not double-decrement load.
+
+    When the handler and disconnect tasks finish in the same wait(), the old
+    listen_for_disconnect path decremented load and the JSONResponse
+    background task decremented again, driving server_load_metrics to -1.
+    """
+    raw_request, state = _make_load_tracking_request(disconnect_delay)
+
+    @with_cancellation
+    @load_aware_call
+    async def handler(_self, raw_request):
+        await asyncio.sleep(handler_delay)
+        return JSONResponse({"ok": True})
+
+    response = await handler(None, raw_request)
+    await _run_background(response)
+
+    assert state.server_load_metrics == 0
 
 
 @pytest.mark.parametrize(

--- a/vllm/entrypoints/serve/utils/api_utils.py
+++ b/vllm/entrypoints/serve/utils/api_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import asyncio
+import contextlib
 import dataclasses
 import functools
 import os
@@ -35,17 +36,14 @@ VLLM_SUBCMD_PARSER_EPILOG = (
 
 
 async def listen_for_disconnect(request: Request) -> None:
-    """Returns if a disconnect message is received"""
+    """Returns if a disconnect message is received.
+
+    Load metrics are owned by ``load_aware_call`` so disconnect and response
+    completion cannot double-decrement ``server_load_metrics``.
+    """
     while True:
         message = await request.receive()
         if message["type"] == "http.disconnect":
-            # If load tracking is enabled *and* the counter exists, decrement
-            # it. Combines the previous nested checks into a single condition
-            # to satisfy the linter rule.
-            if getattr(
-                request.app.state, "enable_server_load_tracking", False
-            ) and hasattr(request.app.state, "server_load_metrics"):
-                request.app.state.server_load_metrics -= 1
             break
 
 
@@ -89,6 +87,9 @@ def with_cancellation(handler_func):
 
         if handler_task in done:
             return handler_task.result()
+        # Let load_aware_call run CancelledError cleanup before returning.
+        with contextlib.suppress(asyncio.CancelledError):
+            await handler_task
         return None
 
     return wrapper
@@ -118,7 +119,8 @@ def load_aware_call(func):
         raw_request.app.state.server_load_metrics += 1
         try:
             response = await func(*args, **kwargs)
-        except Exception:
+        except (Exception, asyncio.CancelledError):
+            # CancelledError is BaseException on Py3.9+ (disconnect path).
             raw_request.app.state.server_load_metrics -= 1
             raise
 


### PR DESCRIPTION
## Purpose

Fix `server_load_metrics` going negative under `--enable-server-load-tracking` when a request handler completes in the same `asyncio.wait(..., FIRST_COMPLETED)` turn as a client disconnect.

Routes stack `@with_cancellation` outside `@load_aware_call`. The disconnect listener previously decremented load on `http.disconnect`, while successful `JSONResponse` / `StreamingResponse` paths also schedule `BackgroundTask(decrement_server_load)`. When both tasks finish together, load is decremented twice (`+1 → -1`).

This is distinct from #44725, which fixed Anthropic decorator **order**. That change does not address the simultaneous-completion race on correctly ordered routes.

**Root cause:** two owners for the decrement (disconnect listener + response background / exception path).

**Solution:** give `load_aware_call` sole ownership of load accounting:
1. Remove the decrement from `listen_for_disconnect`.
2. Treat `asyncio.CancelledError` like other failures so disconnect cancellation decrements once.
3. Await the cancelled handler in `with_cancellation` so that cleanup runs before returning `None`.

AI assistance was used; I reviewed every changed line and ran the tests below.

**Duplicate-work check:** searched open/closed issues and PRs for `server_load_metrics`, `listen_for_disconnect`, `load_aware_call`, `double decrement`, `server load negative`, and `CancelledError server_load`. Related #44725 only covers Anthropic decorator order. No open PR fixes this race.

## Test Plan

```bash
.venv/bin/python -m pytest tests/entrypoints/serve/utils/test_api_utils.py -v --noconftest
pre-commit run --files \
  vllm/entrypoints/serve/utils/api_utils.py \
  tests/entrypoints/serve/utils/test_api_utils.py
git diff --check
```

## Test Result

```text
21 passed
# including:
# test_server_load_never_negative_on_disconnect[handler-first]
# test_server_load_never_negative_on_disconnect[disconnect-first]
# test_server_load_never_negative_on_disconnect[simultaneous]
pre-commit: passed
git diff --check: clean
```

Before the fix, a decorator-faithful reproduction of the simultaneous case consistently ended at `server_load_metrics == -1`. After the fix it stays at `0` for handler-first, disconnect-first, and simultaneous completion.

## Risk assessment

- Low: only affects `--enable-server-load-tracking`.
- Behavior for normal completions is unchanged (background decrement still owns cleanup).
- Disconnect path now decrements via `CancelledError` in `load_aware_call` instead of the listener; counter should remain non-negative and return to 0.

No docs update required. No model output / accuracy impact.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>