### PR TITLE
[XPU] Support EC connector KV Offloading on XPU

### DIFF
--- a/.buildkite/intel_jobs/misc_intel.yaml
+++ b/.buildkite/intel_jobs/misc_intel.yaml
@@ -32,7 +32,7 @@ steps:
       export VLLM_WORKER_MULTIPROC_METHOD=spawn &&
       cd tests &&
       pytest -v -s v1/executor &&
-      pytest -v -s -m 'not cpu_test' v1/ec_connector/unit'
+      VLLM_BATCH_INVARIANT=1 pytest -v -s -m 'not cpu_test' v1/ec_connector/unit'
 
 - label: V1 Sample + Logits
   timeout_in_minutes: 90

--- a/.buildkite/intel_jobs/misc_intel.yaml
+++ b/.buildkite/intel_jobs/misc_intel.yaml
@@ -8,7 +8,7 @@ steps:
   agent_tags:
     label: production
     gpu: 1+
-    mem: 24+
+    mem: 16+
   no_plugin: true
   working_dir: "."
   env:

--- a/.buildkite/intel_jobs/misc_intel.yaml
+++ b/.buildkite/intel_jobs/misc_intel.yaml
@@ -8,7 +8,7 @@ steps:
   agent_tags:
     label: production
     gpu: 1+
-    mem: 16+
+    mem: 24+
   no_plugin: true
   working_dir: "."
   env:

--- a/.buildkite/intel_jobs/misc_intel.yaml
+++ b/.buildkite/intel_jobs/misc_intel.yaml
@@ -8,7 +8,7 @@ steps:
   agent_tags:
     label: production
     gpu: 1+
-    mem: 16+
+    mem: 24+
   no_plugin: true
   working_dir: "."
   env:
@@ -22,6 +22,7 @@ steps:
     - tests/v1/kv_offload
     - tests/v1/worker
     - tests/v1/kv_connector/unit
+    - tests/v1/ec_connector/unit
     - tests/v1/metrics
     - tests/entrypoints/openai/correctness/test_lmeval.py
   commands:
@@ -30,7 +31,8 @@ steps:
       'pip install -r requirements/kv_connectors.txt &&
       export VLLM_WORKER_MULTIPROC_METHOD=spawn &&
       cd tests &&
-      pytest -v -s v1/executor'
+      pytest -v -s v1/executor &&
+      pytest -v -s -m 'not cpu_test' v1/ec_connector/unit'
 
 - label: V1 Sample + Logits
   timeout_in_minutes: 90

--- a/tests/v1/ec_connector/unit/cpu/worker/test_worker.py
+++ b/tests/v1/ec_connector/unit/cpu/worker/test_worker.py
@@ -2,10 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for ECCPUWorker.
 
-The byte-level tests exercise real CUDA stream/event coordination
-against a real ``ECSharedRegion`` mmap and are skipped on hosts without
-CUDA. The lifecycle tests don't fire any ``torch.cuda.*`` primitives and
-run anywhere.
+The byte-level tests exercise real accelerator (CUDA/XPU/...) stream/event
+coordination against a real ``ECSharedRegion`` mmap and are skipped on hosts
+without an accelerator. The lifecycle tests don't fire any
+``current_platform.*`` device primitives and run anywhere.
 
 Mocking policy
 --------------
@@ -37,6 +37,7 @@ from vllm.distributed.ec_transfer.ec_connector.cpu.ec_shared_region import (
     ECSharedRegion,
 )
 from vllm.distributed.ec_transfer.ec_connector.cpu.worker import ECCPUWorker
+from vllm.platforms import current_platform
 
 # ── shape constants ──────────────────────────────────────────────────────────
 
@@ -47,9 +48,20 @@ _DTYPE = torch.float16
 _BLOCK_SIZE_BYTES = _HIDDEN_DIM * _DTYPE.itemsize
 _NUM_BLOCKS = 8
 
-_requires_cuda = pytest.mark.skipif(
-    not torch.cuda.is_available(),
-    reason="exercises real CUDA stream/event coordination in ECCPUWorker",
+# The worker copies encoder outputs between the CPU mmap region and the
+# current accelerator (CUDA/XPU/...); run the byte-level tests on whatever
+# accelerator is present, and skip entirely on CPU-only hosts.
+_DEVICE = current_platform.device_type
+_device_module = getattr(torch, _DEVICE, None)
+_has_accelerator = (
+    not current_platform.is_cpu()
+    and _device_module is not None
+    and getattr(_device_module, "is_available", lambda: False)()
+)
+
+_requires_accelerator = pytest.mark.skipif(
+    not _has_accelerator,
+    reason="exercises real accelerator stream/event coordination in ECCPUWorker",
 )
 
 
@@ -136,7 +148,7 @@ def make_worker():
 # ── save_caches ──────────────────────────────────────────────────────────────
 
 
-@_requires_cuda
+@_requires_accelerator
 @pytest.mark.parametrize(
     "n_elements,n_blocks",
     [
@@ -158,7 +170,7 @@ def test_save_caches_writes_to_assigned_blocks(make_worker, n_elements, n_blocks
     sentinel = 0x5A
     worker._region.blocks.fill_(sentinel)
 
-    src = torch.arange(n_elements, dtype=_DTYPE, device="cuda")
+    src = torch.arange(n_elements, dtype=_DTYPE, device=_DEVICE)
     expected_bytes = src.cpu().reshape(-1).view(torch.uint8)
     total_bytes = n_elements * _DTYPE.itemsize
 
@@ -228,15 +240,15 @@ def test_save_caches_raises_when_allocated_blocks_too_small(make_worker):
         worker.save_caches({"h": src}, "h", _meta(saves={"h": [0, 1]}))
 
 
-@_requires_cuda
+@_requires_accelerator
 def test_save_caches_batches_multiple_hashes(make_worker):
     """Multiple save_caches calls are batched into a single flush."""
     worker = make_worker()
     sentinel = 0x5A
     worker._region.blocks.fill_(sentinel)
 
-    src_a = torch.arange(_HIDDEN_DIM, dtype=_DTYPE, device="cuda")
-    src_b = torch.arange(_HIDDEN_DIM, 2 * _HIDDEN_DIM, dtype=_DTYPE, device="cuda")
+    src_a = torch.arange(_HIDDEN_DIM, dtype=_DTYPE, device=_DEVICE)
+    src_b = torch.arange(_HIDDEN_DIM, 2 * _HIDDEN_DIM, dtype=_DTYPE, device=_DEVICE)
 
     cache = {"a": src_a, "b": src_b}
     worker.save_caches(cache, "a", _meta(saves={"a": [1], "b": [3]}))
@@ -258,7 +270,7 @@ def test_save_caches_batches_multiple_hashes(make_worker):
 # ── start_load_caches ────────────────────────────────────────────────────────
 
 
-@_requires_cuda
+@_requires_accelerator
 def test_start_load_caches_copies_with_correct_shape_dtype_and_bytes(make_worker):
     """Single batched load across all hashes with correct byte→dtype→shape."""
     worker = make_worker()
@@ -276,20 +288,22 @@ def test_start_load_caches_copies_with_correct_shape_dtype_and_bytes(make_worker
     worker.start_load_caches(encoder_cache, _meta(loads={"h": block_ids}))
 
     out = encoder_cache["h"]
-    assert out.is_cuda, "consumer worker must place the tensor on the GPU"
+    assert out.device.type == _DEVICE, (
+        "consumer worker must place the tensor on the accelerator"
+    )
     assert out.shape == (n_blocks, _HIDDEN_DIM)
     assert out.dtype == _DTYPE
     assert torch.equal(out.cpu(), src_orig)
 
 
-@_requires_cuda
+@_requires_accelerator
 def test_start_load_caches_preserves_existing_encoder_cache_entry(make_worker):
     """If ``encoder_cache`` already holds the ``mm_hash``, the worker must
     not overwrite it."""
     worker = make_worker()
     worker._region.blocks[0].fill_(0x42)
 
-    sentinel = torch.full((_HIDDEN_DIM,), 7.0, dtype=_DTYPE, device="cuda")
+    sentinel = torch.full((_HIDDEN_DIM,), 7.0, dtype=_DTYPE, device=_DEVICE)
     encoder_cache = {"h": sentinel}
     worker.start_load_caches(encoder_cache, _meta(loads={"h": [0]}))
 
@@ -298,7 +312,7 @@ def test_start_load_caches_preserves_existing_encoder_cache_entry(make_worker):
     )
 
 
-@_requires_cuda
+@_requires_accelerator
 def test_start_load_caches_noop_when_loads_is_empty(make_worker):
     """When ``meta.loads`` is empty the early-return must fire."""
     worker = make_worker()
@@ -308,7 +322,7 @@ def test_start_load_caches_noop_when_loads_is_empty(make_worker):
     assert encoder_cache == {}
 
 
-@_requires_cuda
+@_requires_accelerator
 def test_start_load_caches_skips_cached_and_loads_new_in_same_step(make_worker):
     """Cached entries are preserved while new ones are loaded."""
     worker = make_worker()
@@ -321,7 +335,7 @@ def test_start_load_caches_skips_cached_and_loads_new_in_same_step(make_worker):
     for i, idx in enumerate(new_block_ids):
         worker._region.blocks[idx].copy_(src_int8[i])
 
-    cached_tensor = torch.full((1, _HIDDEN_DIM), 99.0, dtype=_DTYPE, device="cuda")
+    cached_tensor = torch.full((1, _HIDDEN_DIM), 99.0, dtype=_DTYPE, device=_DEVICE)
     encoder_cache: dict[str, torch.Tensor] = {"cached_h": cached_tensor}
     worker.start_load_caches(
         encoder_cache,
@@ -336,7 +350,7 @@ def test_start_load_caches_skips_cached_and_loads_new_in_same_step(make_worker):
     assert torch.equal(out.cpu(), src_orig)
 
 
-@_requires_cuda
+@_requires_accelerator
 @pytest.mark.parametrize(
     "tp_rank,pcp_rank",
     [(0, 0), (1, 0), (0, 1), (1, 1)],
@@ -358,21 +372,21 @@ def test_start_load_caches_works_on_all_ranks(make_worker, tp_rank, pcp_rank):
     worker.start_load_caches(encoder_cache, _meta(loads={"h": block_ids}))
 
     out = encoder_cache["h"]
-    assert out.is_cuda
+    assert out.device.type == _DEVICE
     assert torch.equal(out.cpu(), src_orig)
 
 
 # ── round-trip ───────────────────────────────────────────────────────────────
 
 
-@_requires_cuda
+@_requires_accelerator
 def test_save_then_load_round_trips_bytes(make_worker):
     """Full producer→mmap→consumer byte path in one shot."""
     worker = make_worker()
     n_blocks = 3
     block_ids = [5, 1, 6]
 
-    src = torch.arange(n_blocks * _HIDDEN_DIM, dtype=_DTYPE, device="cuda").reshape(
+    src = torch.arange(n_blocks * _HIDDEN_DIM, dtype=_DTYPE, device=_DEVICE).reshape(
         n_blocks, _HIDDEN_DIM
     )
     worker.save_caches({"h": src}, "h", _meta(saves={"h": block_ids}))
@@ -390,12 +404,12 @@ def test_save_then_load_round_trips_bytes(make_worker):
 # ── buffer recycling ────────────────────────────────────────────────────────
 
 
-@_requires_cuda
+@_requires_accelerator
 def test_buffer_pool_is_reused_across_save_steps(make_worker):
     """After flush_saves, descriptor buffers are returned to the pool and
     reused on the next flush — no reallocation."""
     worker = make_worker()
-    src = torch.arange(_HIDDEN_DIM, dtype=_DTYPE, device="cuda")
+    src = torch.arange(_HIDDEN_DIM, dtype=_DTYPE, device=_DEVICE)
 
     worker.save_caches({"h": src}, "h", _meta(saves={"h": [0]}))
     worker.flush_saves()
@@ -411,7 +425,7 @@ def test_buffer_pool_is_reused_across_save_steps(make_worker):
     assert id(worker._buf_pool._pool[0].src_ptrs) == buf_id
 
 
-@_requires_cuda
+@_requires_accelerator
 def test_buffer_pool_is_reused_across_load_steps(make_worker):
     """After start_load_caches, descriptor buffers are returned to the pool
     and reused on the next call."""
@@ -435,11 +449,11 @@ def test_buffer_pool_is_reused_across_load_steps(make_worker):
 # ── stream management ────────────────────────────────────────────────────────
 
 
-@_requires_cuda
+@_requires_accelerator
 def test_stream_initialized_at_construction(make_worker):
-    """``_load_stream`` must be a fully initialized CUDA stream."""
+    """``_load_stream`` must be a fully initialized accelerator stream."""
     worker = make_worker()
-    assert isinstance(worker._load_stream, torch.cuda.Stream)
+    assert isinstance(worker._load_stream, current_platform.Stream)
 
 
 # ── lifecycle ────────────────────────────────────────────────────────────────
@@ -518,14 +532,14 @@ def test_shutdown_calls_region_cleanup_and_swallows_errors(caplog_vllm):
 # ── e2e: scheduler + worker pipeline ────────────────────────────────────────
 
 
-@_requires_cuda
+@_requires_accelerator
 def test_e2e_scheduler_worker_save_then_load(make_worker, monkeypatch):
     """Full pipeline: scheduler allocates blocks, worker saves GPU tensor to
     mmap via flush_saves, scheduler marks ready after step delay, worker
     loads from mmap back to GPU, and the result matches the original.
 
     Exercises the real scheduler + worker cooperation through a shared
-    ECSharedRegion, with real CUDA transfers and stream coordination.
+    ECSharedRegion, with real accelerator transfers and stream coordination.
     """
     import vllm.distributed.ec_transfer.ec_connector.cpu.scheduler as sched_mod
     from vllm.distributed.ec_transfer.ec_connector.cpu.scheduler import (
@@ -551,7 +565,7 @@ def test_e2e_scheduler_worker_save_then_load(make_worker, monkeypatch):
 
     # -- Step 1: scheduler allocates, worker saves --
     n_blocks = 3
-    src = torch.arange(n_blocks * _HIDDEN_DIM, dtype=_DTYPE, device="cuda").reshape(
+    src = torch.arange(n_blocks * _HIDDEN_DIM, dtype=_DTYPE, device=_DEVICE).reshape(
         n_blocks, _HIDDEN_DIM
     )
 
@@ -590,7 +604,7 @@ def test_e2e_scheduler_worker_save_then_load(make_worker, monkeypatch):
     worker.start_load_caches(load_cache, meta_load)
 
     out = load_cache["img_001"]
-    assert out.is_cuda
+    assert out.device.type == _DEVICE
     assert out.shape == src.shape
     assert out.dtype == src.dtype
     assert torch.equal(out.cpu(), src.cpu())

--- a/tests/v1/ec_connector/unit/cpu/worker/test_worker.py
+++ b/tests/v1/ec_connector/unit/cpu/worker/test_worker.py
@@ -48,19 +48,10 @@ _DTYPE = torch.float16
 _BLOCK_SIZE_BYTES = _HIDDEN_DIM * _DTYPE.itemsize
 _NUM_BLOCKS = 8
 
-# The worker copies encoder outputs between the CPU mmap region and the
-# current accelerator (CUDA/XPU/...); run the byte-level tests on whatever
-# accelerator is present, and skip entirely on CPU-only hosts.
-_DEVICE = current_platform.device_type
-_device_module = getattr(torch, _DEVICE, None)
-_has_accelerator = (
-    not current_platform.is_cpu()
-    and _device_module is not None
-    and getattr(_device_module, "is_available", lambda: False)()
-)
+DEVICE_TYPE = current_platform.device_type
 
 _requires_accelerator = pytest.mark.skipif(
-    not _has_accelerator,
+    not (current_platform.is_cuda() or current_platform.is_xpu()),
     reason="exercises real accelerator stream/event coordination in ECCPUWorker",
 )
 
@@ -170,7 +161,7 @@ def test_save_caches_writes_to_assigned_blocks(make_worker, n_elements, n_blocks
     sentinel = 0x5A
     worker._region.blocks.fill_(sentinel)
 
-    src = torch.arange(n_elements, dtype=_DTYPE, device=_DEVICE)
+    src = torch.arange(n_elements, dtype=_DTYPE, device=DEVICE_TYPE)
     expected_bytes = src.cpu().reshape(-1).view(torch.uint8)
     total_bytes = n_elements * _DTYPE.itemsize
 
@@ -247,8 +238,8 @@ def test_save_caches_batches_multiple_hashes(make_worker):
     sentinel = 0x5A
     worker._region.blocks.fill_(sentinel)
 
-    src_a = torch.arange(_HIDDEN_DIM, dtype=_DTYPE, device=_DEVICE)
-    src_b = torch.arange(_HIDDEN_DIM, 2 * _HIDDEN_DIM, dtype=_DTYPE, device=_DEVICE)
+    src_a = torch.arange(_HIDDEN_DIM, dtype=_DTYPE, device=DEVICE_TYPE)
+    src_b = torch.arange(_HIDDEN_DIM, 2 * _HIDDEN_DIM, dtype=_DTYPE, device=DEVICE_TYPE)
 
     cache = {"a": src_a, "b": src_b}
     worker.save_caches(cache, "a", _meta(saves={"a": [1], "b": [3]}))
@@ -288,7 +279,7 @@ def test_start_load_caches_copies_with_correct_shape_dtype_and_bytes(make_worker
     worker.start_load_caches(encoder_cache, _meta(loads={"h": block_ids}))
 
     out = encoder_cache["h"]
-    assert out.device.type == _DEVICE, (
+    assert out.device.type == DEVICE_TYPE, (
         "consumer worker must place the tensor on the accelerator"
     )
     assert out.shape == (n_blocks, _HIDDEN_DIM)
@@ -303,7 +294,7 @@ def test_start_load_caches_preserves_existing_encoder_cache_entry(make_worker):
     worker = make_worker()
     worker._region.blocks[0].fill_(0x42)
 
-    sentinel = torch.full((_HIDDEN_DIM,), 7.0, dtype=_DTYPE, device=_DEVICE)
+    sentinel = torch.full((_HIDDEN_DIM,), 7.0, dtype=_DTYPE, device=DEVICE_TYPE)
     encoder_cache = {"h": sentinel}
     worker.start_load_caches(encoder_cache, _meta(loads={"h": [0]}))
 
@@ -335,7 +326,7 @@ def test_start_load_caches_skips_cached_and_loads_new_in_same_step(make_worker):
     for i, idx in enumerate(new_block_ids):
         worker._region.blocks[idx].copy_(src_int8[i])
 
-    cached_tensor = torch.full((1, _HIDDEN_DIM), 99.0, dtype=_DTYPE, device=_DEVICE)
+    cached_tensor = torch.full((1, _HIDDEN_DIM), 99.0, dtype=_DTYPE, device=DEVICE_TYPE)
     encoder_cache: dict[str, torch.Tensor] = {"cached_h": cached_tensor}
     worker.start_load_caches(
         encoder_cache,
@@ -372,7 +363,7 @@ def test_start_load_caches_works_on_all_ranks(make_worker, tp_rank, pcp_rank):
     worker.start_load_caches(encoder_cache, _meta(loads={"h": block_ids}))
 
     out = encoder_cache["h"]
-    assert out.device.type == _DEVICE
+    assert out.device.type == DEVICE_TYPE
     assert torch.equal(out.cpu(), src_orig)
 
 
@@ -386,9 +377,9 @@ def test_save_then_load_round_trips_bytes(make_worker):
     n_blocks = 3
     block_ids = [5, 1, 6]
 
-    src = torch.arange(n_blocks * _HIDDEN_DIM, dtype=_DTYPE, device=_DEVICE).reshape(
-        n_blocks, _HIDDEN_DIM
-    )
+    src = torch.arange(
+        n_blocks * _HIDDEN_DIM, dtype=_DTYPE, device=DEVICE_TYPE
+    ).reshape(n_blocks, _HIDDEN_DIM)
     worker.save_caches({"h": src}, "h", _meta(saves={"h": block_ids}))
     worker.flush_saves()
 
@@ -409,7 +400,7 @@ def test_buffer_pool_is_reused_across_save_steps(make_worker):
     """After flush_saves, descriptor buffers are returned to the pool and
     reused on the next flush — no reallocation."""
     worker = make_worker()
-    src = torch.arange(_HIDDEN_DIM, dtype=_DTYPE, device=_DEVICE)
+    src = torch.arange(_HIDDEN_DIM, dtype=_DTYPE, device=DEVICE_TYPE)
 
     worker.save_caches({"h": src}, "h", _meta(saves={"h": [0]}))
     worker.flush_saves()
@@ -565,9 +556,9 @@ def test_e2e_scheduler_worker_save_then_load(make_worker, monkeypatch):
 
     # -- Step 1: scheduler allocates, worker saves --
     n_blocks = 3
-    src = torch.arange(n_blocks * _HIDDEN_DIM, dtype=_DTYPE, device=_DEVICE).reshape(
-        n_blocks, _HIDDEN_DIM
-    )
+    src = torch.arange(
+        n_blocks * _HIDDEN_DIM, dtype=_DTYPE, device=DEVICE_TYPE
+    ).reshape(n_blocks, _HIDDEN_DIM)
 
     class _Pos:
         offset = 0
@@ -604,7 +595,7 @@ def test_e2e_scheduler_worker_save_then_load(make_worker, monkeypatch):
     worker.start_load_caches(load_cache, meta_load)
 
     out = load_cache["img_001"]
-    assert out.device.type == _DEVICE
+    assert out.device.type == DEVICE_TYPE
     assert out.shape == src.shape
     assert out.dtype == src.dtype
     assert torch.equal(out.cpu(), src.cpu())

--- a/tests/v1/ec_connector/unit/test_ec_cpu_connector.py
+++ b/tests/v1/ec_connector/unit/test_ec_cpu_connector.py
@@ -7,7 +7,7 @@ Verifies:
 - Accuracy: outputs from EC CPU cache match fresh encoder computation.
 - Latency: loading from EC CPU cache is faster than a cold encoder run.
 
-Requires a CUDA GPU and the Qwen2-VL-2B-Instruct model.
+Requires a CUDA or XPU GPU and the Qwen2-VL-2B-Instruct model.
 """
 
 import time
@@ -57,8 +57,8 @@ def _wait_for_ec_ready(llm: LLM) -> None:
 
 def _latency_test(llm: LLM) -> None:
     """Verify EC CPU cache hit is faster than cold encoder computation."""
-    if not current_platform.is_cuda():
-        pytest.skip("Latency test requires CUDA")
+    if not (current_platform.is_cuda() or current_platform.is_xpu()):
+        pytest.skip("Latency test requires an accelerator (CUDA or XPU)")
 
     sampling_params = SamplingParams(max_tokens=1, temperature=0)
     base_image = ImageAsset("stop_sign").pil_image
@@ -134,7 +134,10 @@ def _accuracy_test(llm: LLM) -> None:
     )
 
 
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+@pytest.mark.skipif(
+    not (current_platform.is_cuda() or current_platform.is_xpu()),
+    reason="Requires an accelerator (CUDA or XPU)",
+)
 def test_ec_cpu_offloading() -> None:
     """Tests ECCPUConnector accuracy and latency with a VLM model."""
     ec_transfer_config = ECTransferConfig(

--- a/vllm/distributed/ec_transfer/ec_connector/cpu/worker/__init__.py
+++ b/vllm/distributed/ec_transfer/ec_connector/cpu/worker/__init__.py
@@ -107,11 +107,19 @@ class ECCPUWorker:
         dst_base = self._region.blocks.data_ptr()
         idx = self._save_count
 
+        # Write through numpy views: some accelerators (e.g. XPU USM) hand
+        # out pointers with the top bit set, which torch's per-element
+        # tensor assignment rejects for unsigned dtypes ("Overflow when
+        # unpacking long long"); numpy has no such restriction.
+        src_ptrs_np = src_ptrs.numpy()
+        dst_ptrs_np = dst_ptrs.numpy()
+        sizes_np = sizes.numpy()
+
         for i, block_idx in enumerate(block_ids):
             start = i * block_size
-            src_ptrs[idx] = src_base + start
-            dst_ptrs[idx] = dst_base + block_idx * block_size
-            sizes[idx] = min(block_size, total_bytes - start)
+            src_ptrs_np[idx] = src_base + start
+            dst_ptrs_np[idx] = dst_base + block_idx * block_size
+            sizes_np[idx] = min(block_size, total_bytes - start)
             idx += 1
 
         self._save_count = idx
@@ -170,11 +178,17 @@ class ECCPUWorker:
             sizes = bufs.sizes[:total_blocks]
             sizes[:] = block_size
 
+            # See save_caches: numpy views avoid the uint64 overflow that
+            # torch's per-element tensor assignment raises for pointers
+            # with the top bit set (e.g. XPU USM allocations).
+            src_ptrs_np = src_ptrs.numpy()
+            dst_ptrs_np = dst_ptrs.numpy()
+
             op_idx = 0
             for block_ids in load_items.values():
                 for block_idx in block_ids:
-                    src_ptrs[op_idx] = src_base + block_idx * block_size
-                    dst_ptrs[op_idx] = dst_buf_base + op_idx * block_size
+                    src_ptrs_np[op_idx] = src_base + block_idx * block_size
+                    dst_ptrs_np[op_idx] = dst_buf_base + op_idx * block_size
                     op_idx += 1
 
             swap_blocks_batch(src_ptrs, dst_ptrs, sizes, is_src_access_order_any=True)

--- a/vllm/distributed/ec_transfer/ec_connector/cpu/worker/__init__.py
+++ b/vllm/distributed/ec_transfer/ec_connector/cpu/worker/__init__.py
@@ -27,6 +27,7 @@ from vllm.distributed.parallel_state import (
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.platform_utils import is_pin_memory_available
+from vllm.utils.torch_utils import reinterpret_u64_as_i64
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -107,19 +108,11 @@ class ECCPUWorker:
         dst_base = self._region.blocks.data_ptr()
         idx = self._save_count
 
-        # Write through numpy views: some accelerators (e.g. XPU USM) hand
-        # out pointers with the top bit set, which torch's per-element
-        # tensor assignment rejects for unsigned dtypes ("Overflow when
-        # unpacking long long"); numpy has no such restriction.
-        src_ptrs_np = src_ptrs.numpy()
-        dst_ptrs_np = dst_ptrs.numpy()
-        sizes_np = sizes.numpy()
-
         for i, block_idx in enumerate(block_ids):
             start = i * block_size
-            src_ptrs_np[idx] = src_base + start
-            dst_ptrs_np[idx] = dst_base + block_idx * block_size
-            sizes_np[idx] = min(block_size, total_bytes - start)
+            src_ptrs[idx] = reinterpret_u64_as_i64(src_base + start)
+            dst_ptrs[idx] = reinterpret_u64_as_i64(dst_base + block_idx * block_size)
+            sizes[idx] = min(block_size, total_bytes - start)
             idx += 1
 
         self._save_count = idx
@@ -178,17 +171,15 @@ class ECCPUWorker:
             sizes = bufs.sizes[:total_blocks]
             sizes[:] = block_size
 
-            # See save_caches: numpy views avoid the uint64 overflow that
-            # torch's per-element tensor assignment raises for pointers
-            # with the top bit set (e.g. XPU USM allocations).
-            src_ptrs_np = src_ptrs.numpy()
-            dst_ptrs_np = dst_ptrs.numpy()
-
             op_idx = 0
             for block_ids in load_items.values():
                 for block_idx in block_ids:
-                    src_ptrs_np[op_idx] = src_base + block_idx * block_size
-                    dst_ptrs_np[op_idx] = dst_buf_base + op_idx * block_size
+                    src_ptrs[op_idx] = reinterpret_u64_as_i64(
+                        src_base + block_idx * block_size
+                    )
+                    dst_ptrs[op_idx] = reinterpret_u64_as_i64(
+                        dst_buf_base + op_idx * block_size
+                    )
                     op_idx += 1
 
             swap_blocks_batch(src_ptrs, dst_ptrs, sizes, is_src_access_order_any=True)

--- a/vllm/distributed/ec_transfer/ec_connector/cpu/worker/__init__.py
+++ b/vllm/distributed/ec_transfer/ec_connector/cpu/worker/__init__.py
@@ -27,7 +27,6 @@ from vllm.distributed.parallel_state import (
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.platform_utils import is_pin_memory_available
-from vllm.utils.torch_utils import reinterpret_u64_as_i64
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -103,16 +102,15 @@ class ECCPUWorker:
 
         assert self._save_count + len(block_ids) <= self._save_bufs.src_ptrs.numel()
 
-        src_ptrs, dst_ptrs, sizes = self._save_bufs
+        bufs = self._save_bufs
         src_base = src.view(-1).view(torch.uint8).data_ptr()
         dst_base = self._region.blocks.data_ptr()
         idx = self._save_count
 
         for i, block_idx in enumerate(block_ids):
             start = i * block_size
-            src_ptrs[idx] = reinterpret_u64_as_i64(src_base + start)
-            dst_ptrs[idx] = reinterpret_u64_as_i64(dst_base + block_idx * block_size)
-            sizes[idx] = min(block_size, total_bytes - start)
+            bufs.set_ptrs(idx, src_base + start, dst_base + block_idx * block_size)
+            bufs.sizes[idx] = min(block_size, total_bytes - start)
             idx += 1
 
         self._save_count = idx
@@ -124,7 +122,7 @@ class ECCPUWorker:
 
         bufs = self._save_bufs
         assert bufs is not None
-        src_ptrs, dst_ptrs, sizes = bufs
+        src_ptrs, dst_ptrs, sizes = bufs.src_ptrs, bufs.dst_ptrs, bufs.sizes
         n = self._save_count
         swap_blocks_batch(src_ptrs[:n], dst_ptrs[:n], sizes[:n])
 
@@ -174,11 +172,10 @@ class ECCPUWorker:
             op_idx = 0
             for block_ids in load_items.values():
                 for block_idx in block_ids:
-                    src_ptrs[op_idx] = reinterpret_u64_as_i64(
-                        src_base + block_idx * block_size
-                    )
-                    dst_ptrs[op_idx] = reinterpret_u64_as_i64(
-                        dst_buf_base + op_idx * block_size
+                    bufs.set_ptrs(
+                        op_idx,
+                        src_base + block_idx * block_size,
+                        dst_buf_base + op_idx * block_size,
                     )
                     op_idx += 1
 

--- a/vllm/distributed/ec_transfer/ec_connector/cpu/worker/descriptor_buffers.py
+++ b/vllm/distributed/ec_transfer/ec_connector/cpu/worker/descriptor_buffers.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Reusable pool of (src_ptrs, dst_ptrs, sizes) int64 tensor triples.
+"""Reusable pool of (src_ptrs, dst_ptrs, sizes) tensor triples.
 
 Used by ECCPUWorker to batch swap_blocks_batch descriptors without
 per-step allocation overhead.
@@ -9,6 +9,12 @@ per-step allocation overhead.
 from typing import NamedTuple
 
 import torch
+
+from vllm.platforms import current_platform
+
+# CUDA/ROCm cache_kernels.cu requires int64 pointers; the XPU DMA engine
+# requires uint64 (see vllm._custom_ops.swap_blocks_batch).
+_PTR_DTYPE = torch.uint64 if current_platform.is_xpu() else torch.int64
 
 
 class DescriptorBuffers(NamedTuple):
@@ -20,9 +26,10 @@ class DescriptorBuffers(NamedTuple):
 class DescriptorBufferPool:
     """Pool of descriptor buffer triples for swap_blocks_batch.
 
-    Each buffer is a `DescriptorBuffers` namedtuple of three 1-D int64
-    tensors of equal length. Buffers are recycled across steps; if a
-    returned buffer is too small it is discarded and a fresh one allocated.
+    Each buffer is a `DescriptorBuffers` namedtuple of three 1-D tensors
+    (dtype `_PTR_DTYPE`, platform-dependent) of equal length. Buffers are
+    recycled across steps; if a returned buffer is too small it is discarded
+    and a fresh one allocated.
     """
 
     def __init__(self) -> None:
@@ -36,9 +43,9 @@ class DescriptorBufferPool:
             if bufs.src_ptrs.numel() >= n:
                 return bufs
         return DescriptorBuffers(
-            torch.empty(n, dtype=torch.int64),
-            torch.empty(n, dtype=torch.int64),
-            torch.empty(n, dtype=torch.int64),
+            torch.empty(n, dtype=_PTR_DTYPE),
+            torch.empty(n, dtype=_PTR_DTYPE),
+            torch.empty(n, dtype=_PTR_DTYPE),
         )
 
     def release(self, bufs: DescriptorBuffers) -> None:

--- a/vllm/distributed/ec_transfer/ec_connector/cpu/worker/descriptor_buffers.py
+++ b/vllm/distributed/ec_transfer/ec_connector/cpu/worker/descriptor_buffers.py
@@ -8,6 +8,7 @@ per-step allocation overhead.
 
 from typing import NamedTuple
 
+import numpy as np
 import torch
 
 from vllm.platforms import current_platform
@@ -21,15 +22,33 @@ class DescriptorBuffers(NamedTuple):
     src_ptrs: torch.Tensor
     dst_ptrs: torch.Tensor
     sizes: torch.Tensor
+    # Numpy aliases of src_ptrs/dst_ptrs, written via set_ptrs().
+    src_np: np.ndarray
+    dst_np: np.ndarray
+
+    def set_ptrs(self, idx: int, src: int, dst: int) -> None:
+        """Record the source and destination address of descriptor *idx*.
+
+        TODO(torch>=2.14): drop this indirection and assign the tensors
+        directly once the minimum supported torch is 2.14. The numpy detour
+        exists only because torch's setitem unpacks the value as a signed
+        long long before 2.14 (pytorch#191458), rejecting XPU USM pointers
+        >= 2**63, while the two's-complement rewrite those versions accept is
+        in turn rejected by uint64 from 2.14 on. Numpy casts against the
+        array dtype and so works on either. `sizes` holds byte counts and
+        needs no such care.
+        """
+        self.src_np[idx] = src
+        self.dst_np[idx] = dst
 
 
 class DescriptorBufferPool:
     """Pool of descriptor buffer triples for swap_blocks_batch.
 
     Each buffer is a `DescriptorBuffers` namedtuple of three 1-D tensors
-    (dtype `_PTR_DTYPE`, platform-dependent) of equal length. Buffers are
-    recycled across steps; if a returned buffer is too small it is discarded
-    and a fresh one allocated.
+    (dtype `_PTR_DTYPE`, platform-dependent) of equal length, paired with
+    numpy aliases used to fill them. Buffers are recycled across steps; if a
+    returned buffer is too small it is discarded and a fresh one allocated.
     """
 
     def __init__(self) -> None:
@@ -42,11 +61,8 @@ class DescriptorBufferPool:
             bufs = self._pool.pop()
             if bufs.src_ptrs.numel() >= n:
                 return bufs
-        return DescriptorBuffers(
-            torch.empty(n, dtype=_PTR_DTYPE),
-            torch.empty(n, dtype=_PTR_DTYPE),
-            torch.empty(n, dtype=_PTR_DTYPE),
-        )
+        src, dst, sizes = (torch.empty(n, dtype=_PTR_DTYPE) for _ in range(3))
+        return DescriptorBuffers(src, dst, sizes, src.numpy(), dst.numpy())
 
     def release(self, bufs: DescriptorBuffers) -> None:
         """Return a buffer triple to the pool for reuse."""

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -880,6 +880,14 @@ def weak_ref_tensors(
     raise ValueError("Invalid type for tensors")
 
 
+def reinterpret_u64_as_i64(addr: int) -> int:
+    """Wrap an address >= 2**63 into signed 64-bit range (same bit pattern),
+    since torch's tensor item assignment rejects Python ints that overflow
+    a signed `long long`, regardless of the tensor's actual dtype.
+    """
+    return addr - (1 << 64) if addr >= (1 << 63) else addr
+
+
 def get_accelerator_view_from_cpu_tensor(cpu_tensor: torch.Tensor) -> torch.Tensor:
     """
     Get an accelerator view of a CPU tensor using Unified Virtual Addressing (UVA).

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -880,14 +880,6 @@ def weak_ref_tensors(
     raise ValueError("Invalid type for tensors")
 
 
-def reinterpret_u64_as_i64(addr: int) -> int:
-    """Wrap an address >= 2**63 into signed 64-bit range (same bit pattern),
-    since torch's tensor item assignment rejects Python ints that overflow
-    a signed `long long`, regardless of the tensor's actual dtype.
-    """
-    return addr - (1 << 64) if addr >= (1 << 63) else addr
-
-
 def get_accelerator_view_from_cpu_tensor(cpu_tensor: torch.Tensor) -> torch.Tensor:
     """
     Get an accelerator view of a CPU tensor using Unified Virtual Addressing (UVA).

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -763,6 +763,14 @@ def weak_ref_tensors(
     raise ValueError("Invalid type for tensors")
 
 
+def reinterpret_u64_as_i64(addr: int) -> int:
+    """Wrap an address >= 2**63 into signed 64-bit range (same bit pattern),
+    since torch's tensor item assignment rejects Python ints that overflow
+    a signed `long long`, regardless of the tensor's actual dtype.
+    """
+    return addr - (1 << 64) if addr >= (1 << 63) else addr
+
+
 def get_accelerator_view_from_cpu_tensor(cpu_tensor: torch.Tensor) -> torch.Tensor:
     """
     Get an accelerator view of a CPU tensor using Unified Virtual Addressing (UVA).


### PR DESCRIPTION
## Purpose

PR #47423 added `ECCPUConnector` for encoder-cache (EC) offloading to host memory, but the swap path assumed CUDA/ROCm-style raw pointers and was never exercised on XPU. This PR adds XPU support so the EC connector's offload path works correctly on Intel GPUs, and extends CI coverage accordingly.

Three issues were fixed:

### 1. Descriptor pointer dtype on XPU

`swap_blocks_batch` takes `int64` pointer arrays on CUDA/ROCm but `uint64` on XPU, so `DescriptorBufferPool` now selects `_PTR_DTYPE` per platform.

### 2. Pointer assignment overflow

`ECCPUWorker.save_caches` / `start_load_caches` fill those descriptor buffers with raw addresses, and XPU USM pointers have the top bit set (value >= 2\*\*63). Torch range-checks each assigned Python int against the tensor dtype, and **the accepted encoding differs by torch version**: before 2.14 the value is always unpacked as a signed `long long`, while [pytorch#191458](https://github.com/pytorch/pytorch/issues/191458) (landed as [pytorch@c9f91bd](https://github.com/pytorch/pytorch/commit/c9f91bddef7d6f2fffced9e9e58d3577af46d34c), released in 2.14) makes the unpacking dtype-aware.

Writing a top-bit pointer into the XPU `uint64` buffer therefore fails on *both* sides depending on how it is encoded:

| assigned value | torch 2.13 (currently pinned) | torch 2.14 |
|---|---|---|
| raw address | ❌ `ValueError: Overflow when unpacking long long` | ✅ |
| two's-complement rewrite (`addr - 2**64`) | ✅ | ❌ `OverflowError: can't convert negative int to unsigned` |

An earlier revision of this PR used the two's-complement rewrite, which crashed the engine on torch 2.14:

```
File "vllm/distributed/ec_transfer/ec_connector/cpu/worker/__init__.py", line 114, in save_caches
    src_ptrs[idx] = encode_ptr_for_dtype(src_base + start, ptr_dtype)
OverflowError: can't convert negative int to unsigned
→ vllm.v1.engine.exceptions.EngineDeadError
```

Since vLLM pins `torch==2.13.0` today but must keep working across the 2.14 bump, neither encoding is viable on its own. The descriptor tables are plain CPU tensors, so the pointer arrays are instead filled through **numpy views**, which cast against the array dtype and never go through torch's scalar unpacking — correct on both versions, and already the approach used by the KV-cache offload path (`gpu_worker.py`).

The views are created once per allocation and cached next to the tensors, and the workaround is confined to a single method so it is trivially removable later:

```python
def set_ptrs(self, idx: int, src: int, dst: int) -> None:
    # TODO(torch>=2.14): drop this indirection and assign the tensors
    # directly once the minimum supported torch is 2.14. ...
    self.src_np[idx] = src
    self.dst_np[idx] = dst
```

Only the pointer arrays need this; `sizes` holds byte counts and keeps plain torch assignment.

See [RFC #50834](https://github.com/vllm-project/vllm/issues/50834) for the broader effort to unify device-pointer storage on `torch.uint64`; [this comment](https://github.com/vllm-project/vllm/issues/50834#issuecomment-5312646469) records the version-dependence in detail.
 
