### PR TITLE
[Bugfix][Tool Parser] Fix hunyuan_a13b/xlam streaming: argument named "name" spawns a phantom tool call

### DIFF
--- a/tests/tool_parsers/test_hunyuan_a13b_tool_parser.py
+++ b/tests/tool_parsers/test_hunyuan_a13b_tool_parser.py
@@ -82,6 +82,13 @@ def make_tool_call(name, arguments):
             ],
             None,
         ),
+        # Argument literally named "name" must not be mistaken for a
+        # second tool call's name field.
+        (
+            '<tool_calls>[{"name": "create_user", "arguments": {"name": "Alice", "age": 30}}]</tool_calls>',  # noqa: E501
+            [make_tool_call("create_user", {"name": "Alice", "age": 30})],
+            None,
+        ),
     ],
 )
 def test_hunyuan_a13b_tool_parser_extract(
@@ -159,6 +166,17 @@ def test_hunyuan_a13b_tool_parser_extract(
             marks=pytest.mark.xfail(
                 reason="stream parsing not support nested json yet."
             ),
+        ),
+        # Argument literally named "name" must not spawn a phantom tool
+        # call or drop the real call's arguments (regression test).
+        (
+            [
+                '<tool_calls>[{"name": "create_user", ',
+                '"arguments": {"name": "Alice", ',
+                '"age": 30}}]',
+                "</tool_calls>",
+            ],
+            [make_tool_call("create_user", {"name": "Alice", "age": 30})],
         ),
     ],
 )

--- a/tests/tool_parsers/test_xlam_tool_parser.py
+++ b/tests/tool_parsers/test_xlam_tool_parser.py
@@ -113,6 +113,7 @@ def test_extract_tool_calls_no_tools(xlam_tool_parser):
         "single_tool_with_json_code_block",
         "single_tool_with_tool_calls_tag",
         "single_tool_with_tool_call_xml_tags",
+        "argument_named_name",
     ],
     argnames=["model_output", "expected_tool_calls", "expected_content"],
     argvalues=[
@@ -217,6 +218,20 @@ def test_extract_tool_calls_no_tools(xlam_tool_parser):
                 )
             ],
             "I'll help you check the weather.",
+        ),
+        (
+            # Argument literally named "name" must not be mistaken for a
+            # second tool call's name field.
+            """[{"name": "create_user", "arguments": {"name": "Alice", "age": 30}}]""",  # noqa: E501
+            [
+                ToolCall(
+                    function=FunctionCall(
+                        name="create_user",
+                        arguments=json.dumps({"name": "Alice", "age": 30}),
+                    )
+                )
+            ],
+            None,
         ),
     ],
 )
@@ -360,6 +375,29 @@ def test_streaming_with_list_structure(xlam_tool_parser):
         assert hasattr(result, "tool_calls")
         assert len(result.tool_calls) == 1
         assert result.tool_calls[0].function.name == "get_current_weather"
+
+
+def test_streaming_argument_named_name(xlam_tool_parser, xlam_tokenizer):
+    """An argument literally named "name" must not spawn a phantom tool call
+    or drop the real call's arguments in streaming mode (regression test)."""
+    model_output = (
+        """[{"name": "create_user", "arguments": {"name": "Alice", "age": 30}}]"""
+    )
+    request = ChatCompletionRequest(model=MODEL, messages=[])
+
+    names: dict[int, str] = {}
+    args: dict[int, str] = {}
+    for delta_message in stream_delta_message_generator(
+        xlam_tool_parser, xlam_tokenizer, model_output, request
+    ):
+        for tc in delta_message.tool_calls or []:
+            if tc.function and tc.function.name:
+                names[tc.index] = names.get(tc.index, "") + tc.function.name
+            if tc.function and tc.function.arguments:
+                args[tc.index] = args.get(tc.index, "") + tc.function.arguments
+
+    assert list(names.values()) == ["create_user"]
+    assert json.loads(args[0]) == {"name": "Alice", "age": 30}
 
 
 @pytest.mark.parametrize(

--- a/vllm/tool_parsers/hunyuan_a13b_tool_parser.py
+++ b/vllm/tool_parsers/hunyuan_a13b_tool_parser.py
@@ -51,7 +51,12 @@ class HunyuanA13BToolParser(ToolParser):
             r"<tool_calls>([\s\S]*?)</tool_calls>", re.DOTALL
         )
 
-        self.tool_name_reg = re.compile(r'"name"\s*:\s*"([^"]+)"')
+        # Anchored on the following "arguments" key so this only matches a
+        # tool's own name field, not an argument literally called "name"
+        # (e.g. {"name": "create_user", "arguments": {"name": "Alice"}}).
+        self.tool_name_reg = re.compile(
+            r'"name"\s*:\s*"([^"]+)"(?=\s*,\s*"arguments"\s*:)'
+        )
 
         self.tool_empty_arg_reg = re.compile(
             r'"name"\s*:\s*"[^"]+"\s*,\s*"arguments"\s*:\s*\{\s*\}'

--- a/vllm/tool_parsers/xlam_tool_parser.py
+++ b/vllm/tool_parsers/xlam_tool_parser.py
@@ -54,6 +54,13 @@ class xLAMToolParser(ToolParser):
         ]
         self.thinking_tag_pattern = r"</think>([\s\S]*)"
 
+        # Anchored on the following "arguments" key so this only matches a
+        # tool's own name field, not an argument literally called "name"
+        # (e.g. {"name": "create_user", "arguments": {"name": "Alice"}}).
+        self.tool_name_reg = re.compile(
+            r'"name"\s*:\s*"([^"]+)"(?=\s*,\s*"arguments"\s*:)'
+        )
+
         # Define streaming state type to be initialized later
         self.streaming_state: dict[str, Any] = {
             "current_tool_index": -1,
@@ -270,8 +277,7 @@ class xLAMToolParser(ToolParser):
                     and self.current_tools_sent[0] is False
                 ):
                     # Extract the function name using regex
-                    name_pattern = r'"name"\s*:\s*"([^"]+)"'
-                    name_match = re.search(name_pattern, current_text)
+                    name_match = self.tool_name_reg.search(current_text)
                     if name_match:
                         function_name = name_match.group(1)
 
@@ -327,8 +333,7 @@ class xLAMToolParser(ToolParser):
                         search_text = potential_json
 
             # Try to find complete tool names first
-            name_pattern = r'"name"\s*:\s*"([^"]+)"'
-            name_matches = list(re.finditer(name_pattern, search_text))
+            name_matches = list(self.tool_name_reg.finditer(search_text))
             tool_count = len(name_matches)
 
             # If no complete tool names found, check for partial tool names


### PR DESCRIPTION
## Summary

In **streaming** mode, the `hunyuan_a13b` and `xlam` tool parsers treat *any* argument key `"name"` as the start of a new tool call. A tool call whose arguments contain a `name` field, a common shape, e.g. `create_user(name=...)`, `greet(name=...)`, is streamed as two tool calls: the real call with its arguments dropped, and a phantom tool call named after the argument's value. Non-streaming parsing of the same output is correct.

## Root cause

Both parsers count/identify tool calls during streaming with a bare regex:

```python
r'"name"\s*:\s*"([^"]+)"'
```

which matches the argument key `"name"` as well as a tool's own `name` field. This fix anchors the regex on the following `"arguments"` key so it only matches a tool's own name field:

```python
r'"name"\s*:\s*"([^"]+)"(?=\s*,\s*"arguments"\s*:)'
```

`xlam` additionally had this pattern duplicated as inline string literals in two code paths; factored into a single `self.tool_name_reg` attribute, matching `hunyuan_a13b`'s existing style.

## Not a duplicate

- #47901 / #47954 concern a **different** trigger — arguments dropped after an *empty-argument* call. #47954 keeps the same unanchored `"name"`-matching regex, so it does not address this.
- #38103 reworks hunyuan's *argument* regexes for nested JSON (hunyuan only), not the `"name"` tool-detection regex; `xlam` is unaffected either way.

## Test plan

- Added regression tests to both `test_hunyuan_a13b_tool_parser.py` and `test_xlam_tool_parser.py` covering the `"name"`-as-argument-key shape, non-streaming and streaming.
- `python -m pytest tests/tool_parsers/test_hunyuan_a13b_tool_parser.py tests/tool_parsers/test_xlam_tool_parser.py -v` — all relevant tests pass (1 pre-existing xfail, unrelated nested-JSON limitation, unchanged by this PR).
- `pre-commit run --all-files` on changed files: ruff check, ruff format, mypy all pass.
