### PR TITLE
[CI][Intel] Add GSM8K DeepSeek-V2-Lite-Instruct-FP8 XPU eval job

### DIFF
--- a/.buildkite/intel_jobs/lm_eval_intel.yaml
+++ b/.buildkite/intel_jobs/lm_eval_intel.yaml
@@ -1,0 +1,25 @@
+group: LM Eval Intel
+depends_on:
+  - image-build-xpu
+steps:
+- label: GSM8K DeepSeek-V2-Lite-Instruct-FP8
+  timeout_in_minutes: 60
+  device: intel_gpu
+  agent_tags:
+    label: production
+    gpu: 1+
+    mem: 24+
+  no_plugin: true
+  working_dir: "."
+  env:
+    REGISTRY: "public.ecr.aws/q9t5s3a7"
+    REPO: "vllm-ci-test-repo"
+    VLLM_TEST_DEVICE: "xpu"
+  source_file_dependencies:
+    - vllm/
+    - tests/evals/gsm8k/
+  commands:
+    - >-
+      bash .buildkite/scripts/hardware_ci/run-intel-test.sh
+      'cd tests &&
+      pytest -sv evals/gsm8k/test_gsm8k_correctness.py::test_gsm8k_correctness[DeepSeek-V2-Lite-Instruct-FP8]'

--- a/.buildkite/intel_jobs/lm_eval_intel.yaml
+++ b/.buildkite/intel_jobs/lm_eval_intel.yaml
@@ -26,3 +26,24 @@ steps:
       'pip install "gpt-oss[eval]==0.0.5" &&
       cd tests &&
       pytest -s -v evals/gpt_oss/test_gpqa_correctness.py --config-list-file=configs/models-xpu.txt'
+- label: GSM8K DeepSeek-V2-Lite-Instruct-FP8
+  timeout_in_minutes: 60
+  device: intel_gpu
+  agent_tags:
+    label: production
+    gpu: 1+
+    mem: 24+
+  no_plugin: true
+  working_dir: "."
+  env:
+    REGISTRY: "public.ecr.aws/q9t5s3a7"
+    REPO: "vllm-ci-test-repo"
+    VLLM_TEST_DEVICE: "xpu"
+  source_file_dependencies:
+    - vllm/
+    - tests/evals/gsm8k/
+  commands:
+    - >-
+      bash .buildkite/scripts/hardware_ci/run-intel-test.sh
+      'cd tests &&
+      pytest -sv evals/gsm8k/test_gsm8k_correctness.py::test_gsm8k_correctness[DeepSeek-V2-Lite-Instruct-FP8]'

--- a/.buildkite/intel_jobs/lm_eval_intel.yaml
+++ b/.buildkite/intel_jobs/lm_eval_intel.yaml
@@ -27,7 +27,7 @@ steps:
       cd tests &&
       pytest -s -v evals/gpt_oss/test_gpqa_correctness.py --config-list-file=configs/models-xpu.txt'
 - label: GSM8K DeepSeek-V2-Lite-Instruct-FP8
-  timeout_in_minutes: 60
+  timeout_in_minutes: 90
   device: intel_gpu
   agent_tags:
     label: production

--- a/.buildkite/intel_jobs/lm_eval_intel.yaml
+++ b/.buildkite/intel_jobs/lm_eval_intel.yaml
@@ -32,7 +32,7 @@ steps:
   agent_tags:
     label: production
     gpu: 1+
-    mem: 24+
+    mem: 16+
   no_plugin: true
   working_dir: "."
   env:

--- a/.buildkite/intel_jobs/lm_eval_intel.yaml
+++ b/.buildkite/intel_jobs/lm_eval_intel.yaml
@@ -32,7 +32,7 @@ steps:
   agent_tags:
     label: production
     gpu: 1+
-    mem: 16+
+    mem: 24+
   no_plugin: true
   working_dir: "."
   env:

--- a/.buildkite/intel_jobs/lm_eval_intel.yaml
+++ b/.buildkite/intel_jobs/lm_eval_intel.yaml
@@ -27,7 +27,7 @@ steps:
       cd tests &&
       pytest -s -v evals/gpt_oss/test_gpqa_correctness.py --config-list-file=configs/models-xpu.txt'
 - label: GSM8K DeepSeek-V2-Lite-Instruct-FP8
-  timeout_in_minutes: 90
+  timeout_in_minutes: 60
   device: intel_gpu
   agent_tags:
     label: production

--- a/tests/evals/gsm8k/configs/DeepSeek-V2-Lite-Instruct-FP8.yaml
+++ b/tests/evals/gsm8k/configs/DeepSeek-V2-Lite-Instruct-FP8.yaml
@@ -3,4 +3,5 @@ accuracy_threshold: 0.72
 num_questions: 1319
 num_fewshot: 5
 rocm_request_timeout_seconds: 1800
+request_timeout_seconds: 2400
 server_args: "--enforce-eager --max-model-len 4096"

--- a/tests/evals/gsm8k/configs/DeepSeek-V2-Lite-Instruct-FP8.yaml
+++ b/tests/evals/gsm8k/configs/DeepSeek-V2-Lite-Instruct-FP8.yaml
@@ -3,5 +3,4 @@ accuracy_threshold: 0.72
 num_questions: 1319
 num_fewshot: 5
 rocm_request_timeout_seconds: 1800
-request_timeout_seconds: 2400
 server_args: "--enforce-eager --max-model-len 4096"

--- a/tests/evals/gsm8k/configs/DeepSeek-V2-Lite-Instruct-FP8.yaml
+++ b/tests/evals/gsm8k/configs/DeepSeek-V2-Lite-Instruct-FP8.yaml
@@ -4,4 +4,7 @@ num_questions: 1319
 num_fewshot: 5
 rocm_request_timeout_seconds: 1800
 request_timeout_seconds: 2400
+# XPU startup takes longer than the 1200s default: Triton MoE kernel
+# autotuning (no cache warm-up) runs before the server reports healthy.
+startup_max_wait_seconds: 1800
 server_args: "--enforce-eager --max-model-len 4096"

--- a/tests/evals/gsm8k/configs/DeepSeek-V2-Lite-Instruct-FP8.yaml
+++ b/tests/evals/gsm8k/configs/DeepSeek-V2-Lite-Instruct-FP8.yaml
@@ -4,7 +4,4 @@ num_questions: 1319
 num_fewshot: 5
 rocm_request_timeout_seconds: 1800
 request_timeout_seconds: 2400
-# XPU startup takes longer than the 1200s default: Triton MoE kernel
-# autotuning (no cache warm-up) runs before the server reports healthy.
-startup_max_wait_seconds: 1800
 server_args: "--enforce-eager --max-model-len 4096"

--- a/tests/evals/gsm8k/configs/DeepSeek-V2-Lite-Instruct-FP8.yaml
+++ b/tests/evals/gsm8k/configs/DeepSeek-V2-Lite-Instruct-FP8.yaml
@@ -2,6 +2,9 @@ model_name: "RedHatAI/DeepSeek-Coder-V2-Lite-Instruct-FP8"
 accuracy_threshold: 0.72
 num_questions: 1319
 num_fewshot: 5
+# Triton FP8 MoE JIT runs during memory profiling (no cache in fresh
+# containers); allow up to 40 min for startup before reporting healthy.
+startup_max_wait_seconds: 2400
 rocm_request_timeout_seconds: 1800
 request_timeout_seconds: 2400
 server_args: "--enforce-eager --max-model-len 4096"


### PR DESCRIPTION
## Purpose
Add an Intel XPU CI job that runs the GSM8K accuracy eval for `DeepSeek-V2-Lite-Instruct-FP8` on real XPU hardware.

## Changes
- Add `.buildkite/intel_jobs/lm_eval_intel.yaml` (new "LM Eval Intel" group) running `pytest -sv tests/evals/gsm8k/test_gsm8k_correctness.py::test_gsm8k_correctness[DeepSeek-V2-Lite-Instruct-FP8]` on `intel_gpu`.
- Bump `request_timeout_seconds` to 2400 in `tests/evals/gsm8k/configs/DeepSeek-V2-Lite-Instruct-FP8.yaml` so the XPU job has enough headroom for this eval.
 
Depends on : https://github.com/vllm-project/vllm-xpu-kernels/pull/479 