### PR TITLE
[Bugfix][Quantization] Keep unquantized routed experts unquantized under AutoGPTQ

### DIFF
--- a/tests/quantization/test_auto_gptq.py
+++ b/tests/quantization/test_auto_gptq.py
@@ -17,6 +17,9 @@ from vllm.model_executor.layers.quantization.auto_gptq import (
     AutoGPTQLinearMethod,
     AutoGPTQMoEMethod,
 )
+from vllm.model_executor.layers.quantization.utils.gptq_utils import (
+    is_moe_layer_gptq_quantized,
+)
 
 PROMPT = "On the surface of Mars, we found"
 
@@ -58,6 +61,36 @@ def test_auto_gptq_quantization_method(vllm_runner, model_id: str, monkeypatch):
 def test_auto_gptq_config_get_name():
     """Test that AutoGPTQConfig.get_name() returns 'auto_gptq'."""
     assert AutoGPTQConfig.get_name() == "auto_gptq"
+
+
+def test_moe_layer_quantized_only_when_its_experts_are_in_the_checkpoint():
+    """Experts left unquantized in the checkpoint must not get a GPTQ method.
+
+    `modules_in_block_to_quantize` is derived from the checkpoint dtypes, so a
+    partially quantized model (e.g. one whose MTP layer is stored unquantized)
+    only lists the quantized layers' experts. Giving the remaining layer a
+    quantized method makes it allocate `w2_qweight` while the checkpoint
+    provides `w2_weight`.
+    """
+    quantized_layers = [
+        f"language_model.model.layers.{layer}.mlp.experts.{expert}.{proj}"
+        for layer in range(2)
+        for expert in range(2)
+        for proj in ("gate_proj", "down_proj", "up_proj")
+    ]
+
+    assert is_moe_layer_gptq_quantized(
+        "language_model.model.layers.0.mlp.experts", quantized_layers
+    )
+    assert not is_moe_layer_gptq_quantized("mtp.layers.0.mlp.experts", quantized_layers)
+    # Block-relative names (as written by optimum) cannot distinguish layers.
+    assert is_moe_layer_gptq_quantized(
+        "mtp.layers.0.mlp.experts", ["mlp.experts.0.down_proj"]
+    )
+    # Configs that never mention experts carry no information about them.
+    assert is_moe_layer_gptq_quantized(
+        "mtp.layers.0.mlp.experts", ["mtp.layers.0.self_attn.q_proj"]
+    )
 
 
 def test_auto_gptq_moe_creates_zero_initialized_expert_biases():

--- a/tests/quantization/test_auto_gptq.py
+++ b/tests/quantization/test_auto_gptq.py
@@ -23,6 +23,9 @@ from vllm.model_executor.layers.quantization.auto_gptq import (
     AutoGPTQLinearMethod,
     AutoGPTQMoEMethod,
 )
+from vllm.model_executor.layers.quantization.utils.gptq_utils import (
+    is_moe_layer_gptq_quantized,
+)
 from vllm.platforms import current_platform
 
 PROMPT = "On the surface of Mars, we found"
@@ -68,6 +71,36 @@ def test_auto_gptq_quantization_method(
 def test_auto_gptq_config_get_name():
     """Test that AutoGPTQConfig.get_name() returns 'auto_gptq'."""
     assert AutoGPTQConfig.get_name() == "auto_gptq"
+
+
+def test_moe_layer_quantized_only_when_its_experts_are_in_the_checkpoint():
+    """Experts left unquantized in the checkpoint must not get a GPTQ method.
+
+    `modules_in_block_to_quantize` is derived from the checkpoint dtypes, so a
+    partially quantized model (e.g. one whose MTP layer is stored unquantized)
+    only lists the quantized layers' experts. Giving the remaining layer a
+    quantized method makes it allocate `w2_qweight` while the checkpoint
+    provides `w2_weight`.
+    """
+    quantized_layers = [
+        f"language_model.model.layers.{layer}.mlp.experts.{expert}.{proj}"
+        for layer in range(2)
+        for expert in range(2)
+        for proj in ("gate_proj", "down_proj", "up_proj")
+    ]
+
+    assert is_moe_layer_gptq_quantized(
+        "language_model.model.layers.0.mlp.experts", quantized_layers
+    )
+    assert not is_moe_layer_gptq_quantized("mtp.layers.0.mlp.experts", quantized_layers)
+    # Block-relative names (as written by optimum) cannot distinguish layers.
+    assert is_moe_layer_gptq_quantized(
+        "mtp.layers.0.mlp.experts", ["mlp.experts.0.down_proj"]
+    )
+    # Configs that never mention experts carry no information about them.
+    assert is_moe_layer_gptq_quantized(
+        "mtp.layers.0.mlp.experts", ["mtp.layers.0.self_attn.q_proj"]
+    )
 
 
 def test_auto_gptq_moe_creates_zero_initialized_expert_biases():

--- a/vllm/model_executor/layers/quantization/auto_gptq.py
+++ b/vllm/model_executor/layers/quantization/auto_gptq.py
@@ -40,6 +40,7 @@ from vllm.model_executor.layers.quantization.utils import replace_parameter
 from vllm.model_executor.layers.quantization.utils.gptq_utils import (
     get_dynamic_override,
     get_linear_quant_method,
+    is_moe_layer_gptq_quantized,
     override_config,
 )
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
@@ -242,6 +243,11 @@ class AutoGPTQConfig(QuantizationConfig):
     ) -> "QuantizeMethodBase | None":
         if isinstance(layer, RoutedExperts):
             from vllm.model_executor.layers.quantization.moe_wna16 import MoeWNA16Config
+
+            if not is_moe_layer_gptq_quantized(
+                prefix, self.modules_in_block_to_quantize
+            ):
+                return UnquantizedFusedMoEMethod(layer.moe_config)
 
             if not check_moe_marlin_supports_layer(
                 layer, self.group_size, allow_tile_padding=not self.desc_act

--- a/vllm/model_executor/layers/quantization/utils/gptq_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/gptq_utils.py
@@ -130,6 +130,35 @@ def is_layer_gptq_quantized(
     return is_quantized
 
 
+def is_moe_layer_gptq_quantized(prefix: str, quantized_layers: list[str]) -> bool:
+    """Whether the routed experts at `prefix` are quantized in the checkpoint.
+
+    `prefix` is the absolute name of the fused expert layer
+    (`...mlp.experts`), while `modules_in_block_to_quantize` names the
+    individual expert projections (`...mlp.experts.0.down_proj`) or the fused
+    expert module itself, using either absolute or block-relative names. Match
+    on the `experts` portion of the name so that a layer whose experts are
+    stored unquantized -- e.g. the MTP layer of a partially quantized
+    checkpoint -- is not given a quantized method.
+
+    Configs that enumerate no expert module at all say nothing about the
+    experts, so the layer is assumed to be quantized.
+    """
+    expert_parents = set()
+    for layer in flatten_list(quantized_layers):
+        head, sep, _ = layer.partition(".experts.")
+        parent = f"{head}.experts" if sep else layer
+        if parent.rsplit(".", 1)[-1] == "experts":
+            expert_parents.add(parent)
+
+    if not expert_parents:
+        return True
+
+    return any(
+        prefix == parent or prefix.endswith(f".{parent}") for parent in expert_parents
+    )
+
+
 def get_linear_quant_method(
     config: AutoGPTQConfig,
     layer: torch.nn.Module,


### PR DESCRIPTION
# Issue #49141 — Fused_moe dimension mismatch for Qwen MXFP4 model on ROCm

## 1. Root cause

The issue has two reports. Both are the same underlying defect: **a MoE layer whose
expert weights are stored *unquantized* in the checkpoint is still given a
*quantized* MoE method**, so the allocated parameters do not match the checkpoint
tensors.

The trigger in both cases is the MTP (speculative-decoding drafter) layer. AMD's
Quark and community GPTQ quantizations of `Qwen3.5-35B-A3B` quantize the 40
transformer layers but leave the MTP layer's experts in bf16. The main model
loads fine; only the drafter fails.

* **Original MXFP4/Quark report** (`RuntimeError: The size of tensor a (256) must
  match the size of tensor b (512) at non-singleton dimension 1`, in
  `routed_experts.py::_load_w2`).
  `hidden_size=2048`, `moe_intermediate_size=512`. Quark MXFP4 allocates
  `w2_weight` as `(E, hidden, intermediate // 2)` = `(E, 2048, 256)` (fp4 packs
  two values per byte), while the checkpoint's MTP `down_proj.weight` is the
  unquantized `(2048, 512)`. `amd/Qwen3.5-35B-A3B-MXFP4`'s
  `quantization_config.exclude` lists `mtp.layers.0.mlp.experts.<i>.{gate,up,down}_proj`
  for all 256 experts, but `should_ignore_layer()` only compared the *parent*
  layer name `mtp.layers.0.mlp.experts` against those *child* entries.
  **This half is already fixed on main** by the `check_children` argument added
  to `quark/utils.py::should_ignore_layer` (the amd/GLM-5.2-MXFP4 fix), which is
  why a commenter on the issue could not reproduce it on main. No change needed.

* **Still-broken GPTQ report** (issue comments:
  `AttributeError: 'RoutedExperts' object has no attribute 'w2_weight'. Did you
  mean: 'w2_qweight'?`, same drafter-loading path).
  `AutoGPTQConfig` tracks which modules the checkpoint actually quantized in
  `modules_in_block_to_quantize` — auto-derived in `maybe_update_config()` from
  the safetensors dtypes, so it contains only the quantized layers' per-expert
  module names. `get_linear_quant_method()` consults it via
  `is_layer_gptq_quantized()`, but the `RoutedExperts` branch of
  `AutoGPTQConfig.get_quant_method()` **never consulted it at all** — neither on
  the Marlin path nor on the `MoeWNA16Config` fallback path taken here. The MTP
  layer therefore got a WNA16 MoE method allocating `w13_qweight`/`w2_qweight`,
  while the checkpoint supplies `...down_proj.weight`, and
  `RoutedExperts.load_weights()`'s `getattr(self, "w2_weight")` raised.

## 2. The fix and why

Consult `modules_in_block_to_quantize` for routed-expert layers, the same way it
is already consulted for linear layers.

* New `is_moe_layer_gptq_quantized(prefix, quantized_layers)` in
  `gptq_utils.py`. `prefix` is the fused layer (`...mlp.experts`) while the
  config lists individual expert projections (`...mlp.experts.0.down_proj`), so
  a plain substring test in either direction is wrong. The helper normalizes
  each entry to its `...experts` parent and matches that as a suffix of
  `prefix`, which works for both absolute names (the auto-derived case) and the
  block-relative names optimum writes.
* Called from `AutoGPTQConfig.get_quant_method()` *before* the Marlin-support
  check, so both the Marlin path and the `MoeWNA16Config` fallback are covered
  by the single early `return UnquantizedFusedMoEMethod(layer.moe_config)`.

Deliberately conservative: when the config enumerates no expert module at all it
carries no information about experts, so the helper returns `True` and behaviour
is byte-for-byte unchanged for every config shape that does not list experts.

## 3. Files changed

* `vllm/model_executor/layers/quantization/utils/gptq_utils.py` — add
  `is_moe_layer_gptq_quantized()`.
* `vllm/model_executor/layers/quantization/auto_gptq.py` — import it and use it
  in the `RoutedExperts` branch of `get_quant_method()`.
* `tests/quantization/test_auto_gptq.py` — add
  `test_moe_layer_quantized_only_when_its_experts_are_in_the_checkpoint`.

## 4. Risk / uncertainty

* The behaviour change is gated on `modules_in_block_to_quantize` containing at
  least one `...experts...` entry. Fully-quantized MoE GPTQ checkpoints list
  every layer's experts, so they keep the quantized method. The residual risk is
  a checkpoint that lists experts for *some* layers under a naming scheme where
  the `...experts` suffix does not line up with the vLLM module prefix; that
  layer would silently fall back to unquantized (loud failure on the following
  weight load rather than silent wrong numerics, since the parameter names would
  then mismatch).
* Block-relative configs (`mlp.experts.0.down_proj`) still cannot distinguish
  the MTP layer from the main layers, so the fix does not help there. That is
  the pre-existing behaviour, asserted in the test so the limitation is explicit.
* I could not obtain the exact GPTQ checkpoint the reporter used, so the shape of
  its `modules_in_block_to_quantize` is inferred from `maybe_update_config()`'s
  derivation logic plus the `w2_weight`-vs-`w2_qweight` error, not observed.
* Not touched: the Quark/MXFP4 path (already fixed on main) and the AWQ path,
  which uses a different exclusion mechanism (`modules_to_not_convert`).

## 5. How I verified it

* **Root cause**, traced from the traceback through `routed_experts.py`
  (`_load_w2`, `weight_loader`, `build_expert_params_mapping`),
  `quark/quark_moe.py::create_weights` (`get_packed_dim`), `quark/utils.py`,
  `auto_gptq.py`, `moe_wna16.py` and `gptq_utils.py`, cross-checked against
  `Qwen/Qwen3.5-35B-A3B/config.json` (`hidden_size=2048`,
  `moe_intermediate_size=512` — exactly the 2048×256 vs 2048×512 mismatch) and
  `amd/Qwen3.5-35B-A3B-MXFP4/config.json` (the `mtp.layers.0.mlp.experts.*`
  exclude entries).
* **Confirmed the MXFP4 half is already fixed** by diffing
  `quark/utils.py::should_ignore_layer` at the reporter's commit `97c162676`
  (no `check_children`) against `main` (has it), matching the issue comment
  reporting it no longer reproduces.
* **Helper logic**: executed `is_moe_layer_gptq_quantized` in isolation over 8
  cases (main-model layer, MTP layer, block-relative names, no-experts config,
  fused-expert entry, nested `list[list[str]]` form, empty config) — all pass.
* **Lint**: `ruff check` and `ruff format --check` clean on all three files;
  `py_compile` clean.
* **Not run**: the pytest suite. This environment has no `.venv` and no torch
  installed, so `tests/quantization/test_auto_gptq.py` could not be executed, and
  no end-to-end load of the affected checkpoints was performed.

## Duplicate check

GitHub search for open PRs referencing `49141` in the body returned
`total_count: 0`. No open PR touches `is_layer_gptq_quantized` /
`get_moe_quant_method`.
