### PR TITLE
[Bugfix] Carry positions through ubatch metadata slicing for DBO

### DIFF
--- a/tests/v1/attention/test_attention_splitting.py
+++ b/tests/v1/attention/test_attention_splitting.py
@@ -131,6 +131,35 @@ def test_make_metadata_with_slice_mixed_batch(mixed_small_metadata):
     assert torch.equal(result.seq_lens, torch.tensor([40, 48]))
 
 
+def test_make_metadata_with_slice_carries_positions(mixed_small_metadata):
+    """positions must be sliced alongside slot_mapping (DBO regression)"""
+    mixed_small_metadata.positions = torch.arange(
+        mixed_small_metadata.num_actual_tokens, dtype=torch.int64
+    )
+
+    request_slice = slice(1, 3)
+    token_slice = slice(1, 7)
+    ubatch_slice = UBatchSlice(request_slice, token_slice)
+
+    result = _make_metadata_with_slice(ubatch_slice, mixed_small_metadata)
+
+    assert result.num_reqs == 2
+    assert result.num_actual_tokens == 6
+    assert result.max_query_len == 5
+    assert torch.equal(result.query_start_loc, torch.tensor([0, 1, 6]))
+    assert torch.equal(result.seq_lens, torch.tensor([40, 48]))
+
+    assert result.positions is not None
+    assert torch.equal(result.positions, mixed_small_metadata.positions[token_slice])
+    assert torch.equal(
+        result.slot_mapping, mixed_small_metadata.slot_mapping[token_slice]
+    )
+    assert torch.equal(
+        result.block_table_tensor,
+        mixed_small_metadata.block_table_tensor[request_slice],
+    )
+
+
 def test_split_attn_metadata_decode_batch(large_decode_metadata):
     """Test splitting decode batch into two equal parts"""
     num_tokens = large_decode_metadata.num_reqs

--- a/vllm/v1/worker/ubatch_utils.py
+++ b/vllm/v1/worker/ubatch_utils.py
@@ -231,6 +231,11 @@ def _make_metadata_with_slice(
 
     block_table_tensor = attn_metadata.block_table_tensor[request_slice]
     slot_mapping = attn_metadata.slot_mapping[token_slice]
+    positions = (
+        attn_metadata.positions[token_slice]
+        if attn_metadata.positions is not None
+        else None
+    )
 
     return CommonAttentionMetadata(
         query_start_loc=query_start_loc,
@@ -242,6 +247,7 @@ def _make_metadata_with_slice(
         max_seq_len=max_seq_len,
         block_table_tensor=block_table_tensor,
         slot_mapping=slot_mapping,
+        positions=positions,
         seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
         _seq_lens_cpu=seq_lens_cpu,
         _num_computed_tokens_cpu=num_computed_tokens_cpu,


### PR DESCRIPTION
## Purpose
`CommonAttentionMetadata.positions` (populated for DeepSeek V4 C128A layers in https://github.com/vllm-project/vllm/pull/40860) was dropped when splitting attention metadata into ubatch slices, causing errors with DBO enabled. 

```text
[multiproc_executor.py:1004]   File "/usr/local/lib/python3.12/dist-packages/vllm/models/deepseek_v4/sparse_mla.py", line 261, in _build_c128a_metadata
(Worker_DP1_TP0_EP4 pid=66932) ERROR 07-23 08:56:12 [multiproc_executor.py:1004]     assert cm.positions is not None, (
```
This PR fixes this by preserving and spliting positions when slicing attention metadata.

## Test Plan
* Docker image: `vllm/vllm-openai:v0.25.1-x86_64-cu129-ubuntu2404`
### Model Test
```bash
vllm serve DeepSeek-V4-Flash \
  --trust-remote-code \
  --host 0.0.0.0 \
  --port 8000 \
  --tensor-parallel-size 4 \
  --data-parallel-size 2 \
  --gpu-memory-utilization 0.85 \
  --block-size 256 \
  --kv-cache-dtype fp8 \
  --enable-expert-parallel \
  --tokenizer-mode deepseek_v4 \
  --tool-call-parser deepseek_v4 \
   --reasoning-parser deepseek_v4 \
  --enable-auto-tool-choice \
  --no-enable-prefix-caching \
  --enable-chunked-prefill \
  --no-enable-log-requests \
  --no-disable-hybrid-kv-cache-manager \
  --no-async-scheduling \
  --trust-remote-code \
  --enforce-eager \
  --enable-dbo \
  --all2all-backend deepep_high_throughput \
  --max_num_seqs 32 \
  --max_model_len 72192 \
  --dtype bfloat16 \
  --max-num-batched-tokens 8192
```

### Unittest
```bash
python -m pytest tests/v1/attention/test_attention_splitting.py
```

## Test Result

* With this fix, the flag`--enable-dbo` is working properly now on  the DeepSeek V4 Flash model.
* The new test `test_make_metadata_with_slice_carries_positions` passed.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

