### PR TITLE
[XPU] Support test_cp_generation and add to Intel CI

### DIFF
--- a/.buildkite/intel_jobs/models_distributed_intel.yaml
+++ b/.buildkite/intel_jobs/models_distributed_intel.yaml
@@ -25,3 +25,29 @@ steps:
       bash .buildkite/scripts/hardware_ci/run-intel-test.sh
       'cd tests &&
       pytest -v -s model_executor/model_loader/test_sharded_state_loader.py -m "not slow_test"'
+
+- label: Context Parallel Generation (2 GPUs)
+  key: context-parallel-generation-2-gpus
+  timeout_in_minutes: 65
+  device: intel_gpu
+  agent_tags:
+    label: production
+    gpu: 2+
+    mem: 16+
+  no_plugin: true
+  working_dir: "."
+  env:
+    REGISTRY: "public.ecr.aws/q9t5s3a7"
+    REPO: "vllm-ci-test-repo"
+    VLLM_TEST_DEVICE: "xpu"
+  source_file_dependencies:
+  - vllm/distributed/
+  - vllm/v1/attention/backends/
+  - vllm/v1/attention/selector.py
+  - vllm/platforms/xpu.py
+  - tests/distributed/test_context_parallel.py
+  commands:
+    - >-
+      bash .buildkite/scripts/hardware_ci/run-intel-test.sh
+      'cd tests &&
+      pytest -v -s distributed/test_context_parallel.py'

--- a/tests/distributed/test_context_parallel.py
+++ b/tests/distributed/test_context_parallel.py
@@ -126,7 +126,7 @@ class CPTestSettings:
                 )
 
 
-if current_platform.is_rocm():
+if current_platform.is_rocm() or current_platform.is_xpu():
     CP_TEXT_GENERATION_MODELS = {
         "deepseek-ai/DeepSeek-V2-Lite-Chat": [
             CPTestSettings.detailed(dcp_multipliers=[1]),
@@ -297,12 +297,14 @@ def test_cp_generation(
     num_gpus_available,
 ):
     if (
-        model_id == "deepseek-ai/DeepSeek-V2-Lite-Chat"
+        current_platform.is_cuda()
+        and model_id == "deepseek-ai/DeepSeek-V2-Lite-Chat"
         and torch.cuda.get_device_capability() < (9, 0)
     ):
         pytest.skip(reason="MLA+DCP requires compute capability of 9.0 or higher")
     if (
-        model_id == "Qwen/Qwen2.5-1.5B-Instruct"
+        current_platform.is_cuda()
+        and model_id == "Qwen/Qwen2.5-1.5B-Instruct"
         and torch.cuda.get_device_capability() != (9, 0)
     ):
         pytest.skip(reason="GQA+DCP currently requires compute capability of 9.0")

--- a/tests/distributed/test_context_parallel.py
+++ b/tests/distributed/test_context_parallel.py
@@ -297,13 +297,13 @@ def test_cp_generation(
     num_gpus_available,
 ):
     if (
-        current_platform.is_cuda()
+        current_platform.is_cuda_alike()
         and model_id == "deepseek-ai/DeepSeek-V2-Lite-Chat"
         and torch.cuda.get_device_capability() < (9, 0)
     ):
         pytest.skip(reason="MLA+DCP requires compute capability of 9.0 or higher")
     if (
-        current_platform.is_cuda()
+        current_platform.is_cuda_alike()
         and model_id == "Qwen/Qwen2.5-1.5B-Instruct"
         and torch.cuda.get_device_capability() != (9, 0)
     ):


### PR DESCRIPTION
## Purpose
This PR adds XPU support and wires the test into Intel CI. 

## Changes
- Add an `elif current_platform.is_xpu()` branch for `CP_TEXT_GENERATION_MODELS`, reusing the same DCP settings as the ROCm branch.
- Guard the two CUDA-specific `torch.cuda.get_device_capability()` skip checks with `current_platform.is_cuda()` so they don't run on XPU.
- Add a "Context Parallel Generation (2 GPUs)" job to `.buildkite/intel_jobs/models_distributed_intel.yaml`.
 