### PR TITLE
[Core] Improve compile_sizes cudagraph padding error message

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -651,7 +651,7 @@ def test_compile_sizes_padding_validation():
     # etc.
     # So compile_sizes=[3] should fail because 3 would be padded to 4
 
-    with pytest.raises(ValueError, match="would be padded to"):
+    with pytest.raises(ValueError, match="would be padded to") as excinfo:
         config = CompilationConfig(
             cudagraph_capture_sizes=[1, 2, 4, 8],
             max_cudagraph_capture_size=8,
@@ -661,6 +661,14 @@ def test_compile_sizes_padding_validation():
         config.post_init_cudagraph_sizes()
         dispatcher = CudagraphDispatcher(_create_vllm_config_for_validation(config))
         dispatcher.initialize_cudagraph_keys(CUDAGraphMode.FULL)
+    # The message should state the padded value and list the actual valid
+    # compile sizes (the fixed points of the padding map) rather than only
+    # pointing at cudagraph_capture_sizes.
+    msg = str(excinfo.value)
+    assert "padded to 4" in msg
+    assert "Valid compile_sizes are: [1, 2, 4, 8]" in msg
+    # Without spec decode, no spec-decode padding hint should appear.
+    assert "Speculative decoding" not in msg
 
     with pytest.raises(ValueError, match="would be padded to"):
         config = CompilationConfig(
@@ -672,6 +680,27 @@ def test_compile_sizes_padding_validation():
         config.post_init_cudagraph_sizes()
         dispatcher = CudagraphDispatcher(_create_vllm_config_for_validation(config))
         dispatcher.initialize_cudagraph_keys(CUDAGraphMode.FULL)
+
+    # Under speculative decoding, capture sizes are rounded up to a multiple of
+    # (num_speculative_tokens + 1), so the valid compile_sizes differ from the
+    # originally configured powers of two. The message should list the actual
+    # valid values and explain the spec-decode padding.
+    with pytest.raises(ValueError, match="would be padded to") as excinfo:
+        config = CompilationConfig(
+            cudagraph_capture_sizes=[3, 6, 12, 24],
+            max_cudagraph_capture_size=24,
+            compile_sizes=[1],  # would be padded to 3
+            cudagraph_mode=CUDAGraphMode.FULL,
+        )
+        config.post_init_cudagraph_sizes()
+        vllm_config = _create_vllm_config_for_validation(config)
+        vllm_config.speculative_config = MagicMock()
+        dispatcher = CudagraphDispatcher(vllm_config)
+        dispatcher.initialize_cudagraph_keys(CUDAGraphMode.FULL)
+    msg = str(excinfo.value)
+    assert "padded to 3" in msg
+    assert "Valid compile_sizes are: [3, 6, 12, 24]" in msg
+    assert "Speculative decoding is enabled" in msg
 
     config = CompilationConfig(
         cudagraph_capture_sizes=[1, 2, 4, 8],

--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -96,16 +96,38 @@ class CudagraphDispatcher:
             self.compilation_config.compile_sizes
             and self.cudagraph_mode != CUDAGraphMode.NONE
         ):
+            # The valid compile_sizes are exactly the sizes left unchanged by
+            # cudagraph padding, i.e. the fixed points of the padding map we
+            # just computed. Derive them from that map so the advice stays
+            # self-consistent even when the capture sizes were rescaled (e.g.
+            # rounded up for speculative decoding), where the actually-valid
+            # values differ from the originally configured capture sizes.
+            valid_sizes = sorted(s for s in set(self._bs_to_padded_graph_size) if s > 0)
             for size in self.compilation_config.compile_sizes:
                 size = int(size)
                 if size <= max_size:
                     padded = self._bs_to_padded_graph_size[size]
                     if padded != size:
+                        # Truncate so the message stays readable when there
+                        # are many capture sizes.
+                        shown = ", ".join(str(s) for s in valid_sizes[:16])
+                        if len(valid_sizes) > 16:
+                            shown += ", ..."
+                        spec_hint = ""
+                        if self.vllm_config.speculative_config is not None:
+                            spec_hint = (
+                                " Speculative decoding is enabled, so cudagraph "
+                                "capture sizes are rounded up to a multiple of "
+                                "(num_speculative_tokens + 1); the valid "
+                                "compile_sizes therefore differ from the "
+                                "originally configured cudagraph_capture_sizes."
+                            )
                         raise ValueError(
                             f"compile_sizes contains {size} which would be "
-                            f"padded to {padded}. All compile_sizes must be "
-                            "values that won't be changed by cudagraph padding. "
-                            "Use values from cudagraph_capture_sizes."
+                            f"padded to {padded} by cudagraph padding. All "
+                            "compile_sizes must be values that won't be changed "
+                            f"by padding. Valid compile_sizes are: [{shown}]."
+                            + spec_hint
                         )
 
     def _get_lora_cases(self) -> list[int]:


### PR DESCRIPTION
## Purpose

When a value in `compile_sizes` would be changed by cudagraph padding, `CudagraphDispatcher._compute_bs_to_padded_graph_size` (in `vllm/v1/cudagraph_dispatcher.py`) raises:

```
compile_sizes contains 1 which would be padded to 3. All compile_sizes must be
values that won't be changed by cudagraph padding. Use values from cudagraph_capture_sizes.
```

This is hard to act on, and **actively misleading under speculative decoding**. With MTP / `num_speculative_tokens=2`, `adjust_cudagraph_sizes_for_spec_decode` rounds the capture sizes up to a multiple of `(num_speculative_tokens + 1)`, so the configured sizes `[1, 2, 4, 8, ...]` become `[3, 6, 12, 24, ...]`. A user who follows the advice and picks a value from the *originally configured* `cudagraph_capture_sizes` (e.g. `1`) hits the same error again. The function already computes the exact valid values in its padding map but doesn't surface them.

## Changes

Improve the `ValueError` to:
1. State the padded value the offending size maps to (kept, clarified).
2. List the **actual valid `compile_sizes`**, derived from the padding map the function already computes (the fixed points), truncated for readability when there are many capture sizes.
3. Explain the spec-decode rounding as the reason when speculative decoding is enabled.

Example new message under spec decode:

```
compile_sizes contains 1 which would be padded to 3 by cudagraph padding. All
compile_sizes must be values that won't be changed by padding. Valid compile_sizes
are: [3, 6, 12, 24]. Speculative decoding is enabled, so cudagraph capture sizes
are rounded up to a multiple of (num_speculative_tokens + 1); the valid compile_sizes
therefore differ from the originally configured cudagraph_capture_sizes.
```

## Test

Extends the existing `tests/compile/test_config.py::test_compile_sizes_padding_validation` to assert the new message content, including a speculative-decoding case (capture sizes `[3, 6, 12, 24]`, `compile_sizes=[1]`) that asserts the valid-sizes list and the spec-decode explanation are present.

Message-only / validation-message change; no behavior change to padding or dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
