### PR TITLE
[Doc][Core] Clarify FlashInfer spec-decode PIECEWISE cudagraph downgrade warning

### DIFF
--- a/docs/features/speculative_decoding/README.md
+++ b/docs/features/speculative_decoding/README.md
@@ -183,6 +183,33 @@ vllm serve <target-model> \
   are populated by vLLM and are not intended to be set by users.
 - `use_heterogeneous_vocab` currently supports greedy draft sampling only. Probabilistic acceptance (temperature > 0 draft sampling) is not yet supported and will be added in a future release.
 
+## Performance: attention backend and CUDA graphs
+
+The attention backend affects how much of the decode step can be captured in a
+CUDA graph while speculative decoding is active, which in turn affects
+single-stream decode throughput.
+
+Spec-decode "decode" steps verify `1 + num_speculative_tokens` query positions
+per request. Keeping these verify batches inside a **full** decode CUDA graph
+(mode `FULL_AND_PIECEWISE`) avoids per-step kernel-launch overhead. A backend
+can only do this if it reports at least `AttentionCGSupport.UNIFORM_BATCH`:
+
+- **FlashAttention** (`--attention-backend FLASH_ATTN`) reports `UNIFORM_BATCH`
+  (FA2) or `ALWAYS` (FA3), so it keeps FULL decode graphs under spec-decode.
+- **FlashInfer** reaches `UNIFORM_BATCH` only on its trtllm-gen path (causal
+  attention with a supported head/kv config). On its native decode path — and
+  on platforms where trtllm-gen is unavailable — it reports
+  `UNIFORM_SINGLE_TOKEN_DECODE`, so vLLM automatically downgrades
+  `cudagraph_mode` to `PIECEWISE` and logs a warning. The verify batches then
+  run piecewise, which adds launch overhead and can measurably reduce
+  single-stream decode throughput on bandwidth-bound hardware.
+
+If you enable speculative decoding and see a log line such as
+`CUDAGraphMode.FULL_AND_PIECEWISE is not supported with spec-decode for
+attention backend ...; setting cudagraph_mode=PIECEWISE`, and your model and
+platform support it, try `--attention-backend FLASH_ATTN` to keep FULL decode
+graphs.
+
 ## Lossless guarantees of Speculative Decoding
 
 In vLLM, speculative decoding aims to enhance inference efficiency while maintaining accuracy. This section addresses the lossless guarantees of

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -1440,6 +1440,23 @@ class CompilationConfig:
             else:
                 msg += "; setting cudagraph_mode=NONE"
                 cudagraph_mode = CUDAGraphMode.NONE
+            # Make the performance cost and the actionable alternative explicit:
+            # running spec-decode verify batches under piecewise (or no)
+            # cudagraphs instead of a full decode graph adds per-step
+            # kernel-launch overhead and can measurably reduce single-stream
+            # decode throughput (double-digit percent has been observed on
+            # bandwidth-bound hardware). A backend that reports at least
+            # AttentionCGSupport.UNIFORM_BATCH (e.g. FlashAttention via
+            # --attention-backend FLASH_ATTN) keeps FULL decode graphs under
+            # spec-decode where the model/platform supports it.
+            msg += (
+                ". This runs spec-decode verify batches without a full decode "
+                "cudagraph, adding per-step launch overhead that can measurably "
+                "lower single-stream decode throughput. If your model/platform "
+                "supports it, a backend reporting UNIFORM_BATCH or higher (e.g. "
+                "--attention-backend FLASH_ATTN) keeps FULL decode graphs under "
+                "spec-decode."
+            )
             logger.warning(msg)
 
         # double check that we can support full cudagraph if they are requested


### PR DESCRIPTION
## Purpose

Follow-up to #49547.

When speculative decoding is active and the resolved attention backend reports
below `AttentionCGSupport.UNIFORM_BATCH`, `resolve_cudagraph_mode_and_sizes()`
downgrades `cudagraph_mode` from `FULL_AND_PIECEWISE` to `PIECEWISE` (or `NONE`).
This is exactly what the **FlashInfer** native (non-trtllm-gen) decode path hits,
and it is the default on platforms where trtllm-gen is unavailable (e.g.
sm_121/GB10). The verify batches then run piecewise, which adds per-step
kernel-launch overhead. On bandwidth-bound hardware this is a real,
double-digit-percent single-stream decode regression that a full decode graph
would avoid — measured **47.5 → 55.2 tok/s (+16%)** switching only
`--attention-backend FLASHINFER → FLASH_ATTN` (GB10 sm_121a, Qwen3.5-122B-A10B
INT4, MTP `num_speculative_tokens=2`); see #49547 for the full breakdown.

Today this is surfaced only as a single `logger.warning` that names neither the
performance cost nor the actionable alternative, so it is easy to miss.

This PR is the small, GPU-free part of #49547:

1. **Clarify the warning** in `vllm/config/compilation.py` — state that verify
   batches will run without a full decode cudagraph (per-step launch overhead
   that can measurably lower single-stream decode throughput) and point at a
   full-decode-graph-capable backend (`--attention-backend FLASH_ATTN`, which
   reports `UNIFORM_BATCH`/`ALWAYS`) where the model/platform supports it.
2. **Document it** — a short "attention backend and CUDA graphs" note in the
   speculative-decoding docs.

Not in scope here (needs FlashInfer-side work + a GPU, tracked separately):
making the FlashInfer native decode path itself capture FULL decode graphs under
spec-decode — that is #47979's territory (gated on `flashinfer-ai/flashinfer#3871`).
Also out of scope: biasing automatic backend selection toward a
full-graph-capable backend when spec-decode is enabled (suggestion (2) in #49547).

## Test Plan

Message/docs only — no functional change to the resolved cudagraph mode, so no
new unit tests. Existing `tests/` coverage of `resolve_cudagraph_mode_and_sizes`
still applies (the control-flow and resolved modes are unchanged; only the log
string is longer).

- `ruff check` / `ruff format --check` on the changed Python file: pass.
- `python -m py_compile` on the changed Python file: pass.
- markdownlint config for the repo disables MD013 (line length); the new section
  follows the remaining rules.

## Test Result

`ruff check` → All checks passed. `ruff format --check` → already formatted.

---

This PR was prepared with AI assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
