### PR TITLE
[ROCm][CI] Language Models tests tiny-mixtral with aiter fix

### DIFF
--- a/tests/models/language/generation/test_common.py
+++ b/tests/models/language/generation/test_common.py
@@ -128,14 +128,6 @@ def test_models(
 
     if use_rocm_aiter and (model in AITER_MODEL_LIST):
         monkeypatch.setenv("VLLM_ROCM_USE_AITER", "1")
-        if model == "TitanML/tiny-mixtral":
-            # Untrained model: near-uniform logits make argmax sensitive to
-            # AITER's bfloat16 rounding error. Route the plain rms_norm and the
-            # fused MoE (whose near-uniform router logits flip expert selection
-            # under ~1 ULP drift) through the native kernels for this model.
-            # See ROCm/aiter#3806 for the tracking issue and minimal repro.
-            monkeypatch.setenv("VLLM_ROCM_USE_AITER_RMSNORM", "0")
-            monkeypatch.setenv("VLLM_ROCM_USE_AITER_MOE", "0")
     elif use_rocm_aiter and model not in AITER_MODEL_LIST:
         # Skip model that are not using AITER tests.
         # When more AITER kernels are added, this list will not be


### PR DESCRIPTION
## Purpose

Fix failing TitanML/tiny-mixtral aiter using tests in mi355_1:Language Models Tests (Standard):

- models/language/generation/test_common.py::test_models[True-True-5-32-TitanML/tiny-mixtral]
- models/language/generation/test_common.py::test_models[False-True-5-32-TitanML/tiny-mixtral]

The tiny-mixtral model is untrained and is randomly initialized, the logprobs distribution is nearly uniform, and the tests end up being very sensitive to any bf16 rounding differences between kernels. There is a very detailed breakdown of the issue in #36101. 
The PR above disabled rms norm specifically for aiter tiny-mixtral tests, later on MOE was disabled as well by #45509
In addition #31597 introduced some torch sdp changes due to inaccuracy in the tests. However, due to the implementation via pytest_sessionstart these flags do not actually apply for mi355_1:Language Models Tests (Standard) because the TG is invoked with pytest -v -s models/language -m 'core_model and (not slow_test)'
<details>
<summary> Why the SDP flags are not applied </summary>

According to pytest docs `pytest_sessionstart` is [("Called after the Session object has been created and before performing collection and entering the run test loop.")](https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_sessionstart). The conftest.py of `models/language/generation` is not parsed until *after* collection starts for the test command (the root directory for the test command is /models/language), so the `pytest_startsession` generation defines is not executed.
</details>

Disabling rms norm and moe for aiter is no longer necessary to avoid the numerical issues with the tiny-mixtral tests, they now pass while fully using aiter.
## Test Plan
pytest -v -s models/language -m 'core_model and (not slow_test)'
## Test Result

Previously:
=================================================================== short test summary info ====================================================================
FAILED models/language/generation/test_common.py::test_models[True-True-5-32-TitanML/tiny-mixtral] - AssertionError: Test3:
FAILED models/language/generation/test_common.py::test_models[False-True-5-32-TitanML/tiny-mixtral] - AssertionError: Test3:
======================================= 2 failed, 13 passed, 9 skipped, 349 deselected, 72 warnings in 980.17s (0:16:20) =======================================

Now:
========================================= 15 passed, 9 skipped, 349 deselected, 105 warnings in 631.09s (0:10:31) ==========================================