### PR TITLE
[Models][Quantization] Qwen3.5 MTP: honor checkpoint per-layer quantization config for draft layers

### DIFF
--- a/tests/model_executor/test_qwen3_5_quantization.py
+++ b/tests/model_executor/test_qwen3_5_quantization.py
@@ -76,3 +76,104 @@ def test_qwen3_5_mtp_lm_head_receives_quant_config():
         MockLMHead.assert_called_once()
         call_kwargs = MockLMHead.call_args.kwargs
         assert call_kwargs["quant_config"] is mock_quant_config
+
+
+def test_qwen3_5_mtp_registered_class_exposes_hf_to_vllm_mapper():
+    """The registered (top-level) MTP draft class must expose ``hf_to_vllm_mapper``.
+
+    ``configure_quant_config`` resolves the mapper via
+    ``getattr(model_class, "hf_to_vllm_mapper", None)`` on the *registered* class
+    (see vllm/model_executor/model_loader/utils.py). The target model class
+    exposes one (inherited from Qwen3VLForConditionalGeneration), so its
+    checkpoint per-layer quant lists (e.g. INC/AutoRound ``block_name_to_quantize``)
+    get mapped from HF names to vLLM runtime names. If the draft class only
+    carries the mapper on its inner predictor submodule, ``getattr`` returns
+    ``None`` and the draft's quant lists are left in HF-name space -- so every
+    MTP layer silently resolves Unquantized. Guard the symmetry here.
+    """
+    from vllm.model_executor.models.qwen3_5_mtp import (
+        Qwen3_5MoeMTP,
+        Qwen3_5MTP,
+        Qwen3_5MultiTokenPredictor,
+    )
+
+    for cls in (Qwen3_5MTP, Qwen3_5MoeMTP):
+        mapper = getattr(cls, "hf_to_vllm_mapper", None)
+        assert mapper is not None, (
+            f"{cls.__name__} must expose hf_to_vllm_mapper so that "
+            "configure_quant_config maps its per-layer quantization config"
+        )
+        assert mapper is Qwen3_5MultiTokenPredictor.hf_to_vllm_mapper
+
+
+def test_configure_quant_config_maps_mtp_draft_layer_names():
+    """``configure_quant_config`` applies the mapper for the MTP draft class.
+
+    This is the behavioral change: because ``Qwen3_5MTP`` now exposes
+    ``hf_to_vllm_mapper``, ``configure_quant_config`` calls
+    ``apply_vllm_mapper`` on the quant config (mapping its ``block_name_to_quantize``
+    from HF to vLLM names), exactly as it does for the target model. A class
+    without a mapper leaves the quant config untouched.
+    """
+    from vllm.model_executor.model_loader.utils import configure_quant_config
+    from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MTP
+
+    quant_config = Mock()
+    configure_quant_config(quant_config, Qwen3_5MTP)
+    quant_config.apply_vllm_mapper.assert_called_once()
+
+    # Contrast: a class with no mapper must not trigger mapping (regression guard
+    # documenting the exact pre-fix behavior that silently dropped draft quant).
+    class _NoMapper:
+        pass
+
+    quant_config_no_mapper = Mock()
+    configure_quant_config(quant_config_no_mapper, _NoMapper)
+    quant_config_no_mapper.apply_vllm_mapper.assert_not_called()
+
+
+def test_inc_resolver_quantizes_mapped_draft_prefixed_layer():
+    """End-to-end (pure-python) resolution: a draft-prefixed layer resolves to a
+    quantized config only when the ``block_name_to_quantize`` prefix is in vLLM
+    runtime-name space.
+
+    INC/AutoRound marks quantized layers by prefix (``layer_name.startswith(name)``
+    in INCConfigParser). At runtime the MTP layers are named ``mtp.layers.*``
+    (vLLM space). The checkpoint ships the prefix in HF space (``model.mtp.layers``);
+    only after ``hf_to_vllm_mapper`` rewrites it to ``mtp.layers`` does the draft
+    layer match and resolve quantized. This test pins that resolution behavior,
+    which is the mechanism the fix restores for the draft path.
+    """
+    from types import SimpleNamespace
+
+    from vllm.model_executor.layers.quantization.inc.config_parser import (
+        INCConfigParser,
+    )
+
+    def _parser(block_names):
+        cfg = SimpleNamespace(
+            block_name_to_quantize=block_names,
+            extra_config=None,
+            weight_bits=4,
+            group_size=128,
+            sym=True,
+            packing_format="gptq",
+            backend="gptq",
+            data_type="int",
+            packed_modules_mapping={},
+        )
+        return INCConfigParser(cfg)
+
+    layer = object()  # not a ParallelLMHead / FusedMoE
+    draft_layer_name = "mtp.layers.0.self_attn.qkv_proj"
+
+    # vLLM-name prefix (post-mapper): draft layer is recognized as quantized.
+    mapped = _parser(["mtp.layers"]).resolve(layer, draft_layer_name)
+    assert mapped.quantized is True
+    assert mapped.bits == 4
+
+    # HF-name prefix (mapper not applied -- the bug): draft layer is missed and
+    # silently resolves Unquantized.
+    unmapped = _parser(["model.mtp.layers"]).resolve(layer, draft_layer_name)
+    assert unmapped.quantized is False
+    assert unmapped.bits == 16

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -200,6 +200,18 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
     }
 )
 class Qwen3_5MTP(LocalArgmaxMixin, nn.Module, SupportsMultiModal):
+    # Expose the weight mapper on the top-level (registered) draft class so that
+    # ``configure_quant_config`` applies it to the quantization config's
+    # per-layer name lists (e.g. INC/AutoRound ``block_name_to_quantize``),
+    # exactly as it does for the target model. Without this, ``getattr(
+    # model_class, "hf_to_vllm_mapper", None)`` returns ``None`` for the draft
+    # (the mapper lives only on the inner ``Qwen3_5MultiTokenPredictor``), the
+    # checkpoint's HF-format block names are never mapped to vLLM runtime names,
+    # and every MTP layer silently resolves to an Unquantized method even when
+    # the checkpoint ships quantized MTP tensors. See
+    # ``configure_quant_config`` in vllm/model_executor/model_loader/utils.py.
+    hf_to_vllm_mapper = Qwen3_5MultiTokenPredictor.hf_to_vllm_mapper
+
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",


### PR DESCRIPTION
## Purpose

Fixes #49552.

An MTP speculative-decoding **draft** model can never honor the checkpoint's per-layer quantization config, because that config is resolved **inconsistently** for the draft vs the target model.

`configure_quant_config` (`vllm/model_executor/model_loader/utils.py:291-312`) maps a quantization config's per-layer name lists (e.g. INC/AutoRound `block_name_to_quantize`) from HF names into vLLM runtime names **only when the registered model class exposes `hf_to_vllm_mapper`**:

```python
hf_to_vllm_mapper = getattr(model_class, "hf_to_vllm_mapper", None)
if hf_to_vllm_mapper is not None:
    quant_config.apply_vllm_mapper(hf_to_vllm_mapper.get_unstacked_mapper())
```

- The **target** `Qwen3_5ForConditionalGeneration` inherits a mapper from `Qwen3VLForConditionalGeneration` → its block names are mapped.
- The registered **draft** classes `Qwen3_5MTP` / `Qwen3_5MoeMTP` carry `hf_to_vllm_mapper` only on their inner `Qwen3_5MultiTokenPredictor` submodule, so `getattr(...)` returns `None` and the mapping is skipped.

Net effect: the draft's decoder layers run at `mtp.layers.*` (vLLM space) while the checkpoint's `block_name_to_quantize` stays in HF-name space, so the `startswith` match in `INCConfigParser` (`inc/config_parser.py:146-150`) never fires and **every MTP layer silently resolves Unquantized** — even when the checkpoint ships quantized MTP tensors.

### Fix

Expose `hf_to_vllm_mapper` on the registered `Qwen3_5MTP` class (inherited by `Qwen3_5MoeMTP`), delegating to the inner predictor's mapper, so the draft path is resolved consistently with the target path. Two lines + comment.

### Why it matters

On bandwidth-bound single-stream decode (GB10 / DGX Spark), quantizing only the draft MTP layers to INT4 (WNA16, group 128) on Qwen3.5-122B-A10B measured **~+7% end-to-end decode throughput** at ~−2% draft acceptance; draft-side quantization is quality-safe (drafts are argmax-consumed and target-verified). Detail + conversion script: https://github.com/tobby168/dgx-spark-qwen35-122b-turbo

## Test Plan

New pure-python (GPU-free) tests in `tests/model_executor/test_qwen3_5_quantization.py`:

- `test_qwen3_5_mtp_registered_class_exposes_hf_to_vllm_mapper` — the registered draft classes expose the mapper.
- `test_configure_quant_config_maps_mtp_draft_layer_names` — `configure_quant_config` now calls `apply_vllm_mapper` for the draft class (and, as a regression guard, does **not** for a class without a mapper).
- `test_inc_resolver_quantizes_mapped_draft_prefixed_layer` — the real `INCConfigParser` resolves a `mtp.layers.*` layer to quantized only once the block prefix is in vLLM name space (bits=4), and to Unquantized when it is left in HF space (bits=16).

```bash
pytest -q tests/model_executor/test_qwen3_5_quantization.py
```

## Test Result

- `ruff check` and `ruff format --check` (pinned `v0.14.0`, matching `.pre-commit-config.yaml`): pass on both changed files.
- The resolution logic was reproduced locally against the real `INCConfigParser` source (no torch/GPU): the unmapped HF prefix resolves Unquantized (bits=16) and the mapped vLLM prefix resolves quantized (bits=4) — confirming the mechanism the fix restores.
- **Status: validated on a 0.23 nightly derivative + the unit tests above. End-to-end GPU validation (a quantized-MTP checkpoint actually loading and serving) will follow** on DGX Spark hardware and be posted here.

### Remaining end-to-end validation (to follow)
Serve Qwen3.5-122B-A10B with an INC/AutoRound checkpoint whose MTP block is quantized and listed under `block_name_to_quantize`, with `--speculative-config '{"method":"mtp",...}'`, and confirm the MTP linear/MoE layers instantiate quantized methods (not Unquantized) and that decode throughput / acceptance match the reported figures.

---

This PR was prepared with AI assistance (see the `Co-authored-by: Claude` trailer on the commit). Opening as **draft** pending the end-to-end GPU validation noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
