### PR TITLE
[Model] Add Eagle3 support for Gemma3

### DIFF
--- a/vllm/model_executor/models/gemma3.py
+++ b/vllm/model_executor/models/gemma3.py
@@ -47,7 +47,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backend import AttentionType
 
-from .interfaces import SupportsLoRA, SupportsPP
+from .interfaces import EagleModelMixin, SupportsEagle3, SupportsLoRA, SupportsPP
 from .utils import (
     AutoWeightsLoader,
     WeightsMapper,
@@ -290,7 +290,7 @@ class Gemma3DecoderLayer(nn.Module):
 
 
 @support_torch_compile
-class Gemma3Model(nn.Module):
+class Gemma3Model(nn.Module, EagleModelMixin):
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_stacked={
             # weight_name: (param_name, shard_id)
@@ -347,7 +347,7 @@ class Gemma3Model(nn.Module):
         intermediate_tensors: IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
         **kwargs,
-    ) -> torch.Tensor | IntermediateTensors:
+    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
@@ -358,18 +358,31 @@ class Gemma3Model(nn.Module):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
-        for layer in islice(self.layers, self.start_layer, self.end_layer):
+
+        aux_hidden_states = self._maybe_add_hidden_state(
+            [], 0, hidden_states, residual
+        )
+        for layer_idx, layer in enumerate(
+            islice(self.layers, self.start_layer, self.end_layer)
+        ):
             hidden_states, residual = layer(
                 positions,
                 hidden_states,
                 residual,
                 **kwargs,
             )
+            self._maybe_add_hidden_state(
+                aux_hidden_states, layer_idx + 1, hidden_states, residual
+            )
+
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )
         hidden_states, _ = self.norm(hidden_states, residual)
+
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
         return hidden_states
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
@@ -377,7 +390,7 @@ class Gemma3Model(nn.Module):
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 
 
-class Gemma3ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
+class Gemma3ForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle3):
     hf_to_vllm_mapper = Gemma3Model.hf_to_vllm_mapper
     packed_modules_mapping = {
         "qkv_proj": [


### PR DESCRIPTION



## Purpose

Similar to https://github.com/vllm-project/vllm/pull/39450, we're adding support for Eagle3 to Gemma3. I know this is an older model but the maintenance should be minimal given the similarities to Gemma4.

Closes https://github.com/vllm-project/vllm/issues/32765

## Test Plan

I trained a dflash model locally using https://github.com/vllm-project/speculators and ran it. It did require some changes to the repo, but I will commit that separately.

## Test Result

```
SpecDecoding metrics: Mean acceptance length: 2.66, Accepted throughput: 5.30 tokens/s, Drafted throughput: 12.80 tokens/s, Accepted: 116 tokens, Drafted: 280 tokens, Per-position acceptance rate: 0.614, 0.371, 0.371, 0.300, Avg Draft acceptance rate: 41.4%
SpecDecoding metrics: Mean acceptance length: 2.94, Accepted throughput: 183.32 tokens/s, Drafted throughput: 377.92 tokens/s, Accepted: 130 tokens, Drafted: 268 tokens, Per-position acceptance rate: 0.836, 0.567, 0.343, 0.194, Avg Draft acceptance rate: 48.5%
SpecDecoding metrics: Mean acceptance length: 3.40, Accepted throughput: 248.82 tokens/s, Drafted throughput: 415.30 tokens/s, Accepted: 139 tokens, Drafted: 232 tokens, Per-position acceptance rate: 0.828, 0.672, 0.517, 0.379, Avg Draft acceptance rate: 59.9%
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

