### PR TITLE
[Bugfix] Remove failed transfer from inflight on NIXL poll exception (#49528)

### DIFF
--- a/tests/v1/kv_offload/tiering/p2p/test_data_transport.py
+++ b/tests/v1/kv_offload/tiering/p2p/test_data_transport.py
@@ -166,6 +166,50 @@ class TestNixlTransportWithMockedAgent:
         assert result.done == ()
         assert tid in result.failed
 
+    def test_poll_exception_removes_transfer_from_inflight(self):
+        """check_xfer_state exception → transfer in failed, removed from inflight.
+
+        Regression: when check_xfer_state() raised, the transfer stayed in
+        _inflight because the exception handler did continue without adding
+        it to failed_ids. The next poll() would retry and log another
+        WARNING, producing an infinite loop of warnings for a dead transfer.
+        """
+        transport = self._make_transport()
+        transport.add_remote_peer("peer:1", b"meta", 0x1000, 8, 1024)
+
+        tid = transport.write_blocks("peer:1", [0], [1])
+        assert tid in transport._inflight
+
+        transport._agent.check_xfer_state.side_effect = RuntimeError("NIXL agent dead")
+
+        result = transport.poll()
+
+        assert tid in result.failed
+        assert tid not in transport._inflight
+        transport._agent.release_xfer_handle.assert_called_once()
+
+    def test_poll_does_not_retry_after_check_xfer_state_exception(self):
+        """Exception-failed transfer is not retried on subsequent polls.
+
+        Regression test for https://github.com/vllm-project/vllm/issues/49528.
+        """
+        transport = self._make_transport()
+        transport.add_remote_peer("peer:1", b"meta", 0x1000, 8, 1024)
+
+        transport.write_blocks("peer:1", [0], [1])
+
+        transport._agent.check_xfer_state.side_effect = RuntimeError("NIXL boom")
+        transport.poll()
+
+        # Reset side_effect so a second check_xfer_state would succeed —
+        # but it should never be called because the transfer was drained.
+        transport._agent.check_xfer_state.side_effect = None
+        transport._agent.check_xfer_state.reset_mock()
+
+        result = transport.poll()
+        assert result == PollResult(done=(), failed=())
+        transport._agent.check_xfer_state.assert_not_called()
+
     def test_poll_ignores_in_progress(self):
         """Transfers in PROC/PEND state stay inflight."""
         transport = self._make_transport()

--- a/vllm/v1/kv_offload/tiering/p2p/data/nixl.py
+++ b/vllm/v1/kv_offload/tiering/p2p/data/nixl.py
@@ -215,7 +215,11 @@ class NixlTransport(DataTransport):
                     self._agent_name,
                     transfer_id,
                     exc,
+                    exc_info=True,
                 )
+                if failed_ids is None:
+                    failed_ids = []
+                failed_ids.append(transfer_id)
                 continue
             if state == "DONE":
                 if done_ids is None:
@@ -315,4 +319,5 @@ class NixlTransport(DataTransport):
                     "NixlTransport %s: release_xfer_handle failed: %s",
                     self._agent_name,
                     exc,
+                    exc_info=True,
                 )


### PR DESCRIPTION
## Purpose

Fixes #49528: when `NixlTransport.poll()` catches an exception from
`check_xfer_state()`, the transfer was left in `_inflight` and retried
every poll cycle, producing an infinite loop of warnings.

The fix appends the failed transfer ID to `failed_ids` so the existing
post-loop cleanup removes it from `_inflight` and attempts to release the
handle. Both `poll()` and `_release_handles()` warning logs now include
`exc_info=True` for full traceback diagnosis.

## Duplicate check

Searched open PRs referencing `_inflight` cleanup and NIXL poll
exception handling; no open PR fixes the inflight leak when
`check_xfer_state()` raises.

## Test Plan

```bash
# Lint
ruff check vllm/v1/kv_offload/tiering/p2p/data/nixl.py \
         tests/v1/kv_offload/tiering/p2p/test_data_transport.py

# Unit tests
.venv/bin/python -m pytest \
  tests/v1/kv_offload/tiering/p2p/test_data_transport.py -v
```

## Test Result

```
ruff: All checks passed!
pytest: 27 passed in 2.39s
```

---

This PR was prepared with AI assistance (Claude). A human reviewed every
changed line, ran the tests, and takes responsibility for the change.
