### PR TITLE
[Feature] Make placement group wait timeout configurable

### DIFF
--- a/tests/v1/executor/test_ray_utils.py
+++ b/tests/v1/executor/test_ray_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import numpy as np
+import pytest
 
 from vllm.v1.executor.ray_utils import detach_zero_copy_from_model_runner_output
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors, ModelRunnerOutput
@@ -52,3 +53,120 @@ def test_detach_zero_copy_from_model_runner_output_copies_only_numpy_views():
     assert detached_logprobs.sampled_token_ranks.flags.writeable
     assert detached_logprobs.cu_num_generated_tokens is cu_num_generated_tokens
     assert output.prompt_logprobs_dict["req-0"] is prompt_logprobs
+
+
+def test_pg_timeout_default(monkeypatch):
+    """VLLM_RAY_PG_TIMEOUT_S defaults to 1800."""
+    monkeypatch.delenv("VLLM_RAY_PG_TIMEOUT_S", raising=False)
+    from vllm.envs import environment_variables
+
+    assert environment_variables["VLLM_RAY_PG_TIMEOUT_S"]() == 1800
+
+
+def test_pg_timeout_non_default(monkeypatch):
+    """VLLM_RAY_PG_TIMEOUT_S reads non-default integer values."""
+    monkeypatch.setenv("VLLM_RAY_PG_TIMEOUT_S", "60")
+    from vllm.envs import environment_variables
+
+    assert environment_variables["VLLM_RAY_PG_TIMEOUT_S"]() == 60
+
+
+@pytest.mark.parametrize("value", ["abc", "3.14"])
+def test_pg_timeout_invalid_value_raises(monkeypatch, value):
+    """Non-integer VLLM_RAY_PG_TIMEOUT_S raises ValueError."""
+    monkeypatch.setenv("VLLM_RAY_PG_TIMEOUT_S", value)
+    from vllm.envs import environment_variables
+
+    with pytest.raises(ValueError, match="VLLM_RAY_PG_TIMEOUT_S"):
+        environment_variables["VLLM_RAY_PG_TIMEOUT_S"]()
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_pg_timeout_zero_or_negative_raises(monkeypatch, value):
+    """Zero or negative VLLM_RAY_PG_TIMEOUT_S raises ValueError."""
+    monkeypatch.setenv("VLLM_RAY_PG_TIMEOUT_S", value)
+    from vllm.envs import environment_variables
+
+    with pytest.raises(ValueError, match="must be > 0"):
+        environment_variables["VLLM_RAY_PG_TIMEOUT_S"]()
+
+
+class TestPlacementGroupTimeout:
+    """Behavioral tests for placement-group timeout enforcement."""
+
+    def test_ray_wait_timeout_capped_at_deadline(self, monkeypatch, mocker):
+        """ray.wait timeout must not exceed the configured deadline."""
+        import time as _time_module
+
+        from vllm.v1.executor import ray_utils
+
+        monkeypatch.setenv("VLLM_RAY_PG_TIMEOUT_S", "1")
+        monkeypatch.setattr(ray_utils.envs, "VLLM_RAY_PG_TIMEOUT_S", 1)
+
+        t0 = _time_module.monotonic()
+        monkeypatch.setattr(
+            ray_utils.time,
+            "monotonic",
+            mocker.MagicMock(side_effect=[t0, t0, t0 + 0.5, t0 + 10]),
+        )
+
+        pg = mocker.MagicMock()
+        pg.bundle_specs = [{"GPU": 1}]
+        pg_ready_ref = mocker.MagicMock()
+        pg.ready.return_value = pg_ready_ref
+
+        mock_ray = mocker.patch.object(ray_utils, "ray", autospec=False)
+        mock_ray.wait.return_value = ([], None)
+
+        class _GetTimeoutError(Exception):
+            pass
+
+        mock_ray.exceptions.GetTimeoutError = _GetTimeoutError
+        mock_ray.get.side_effect = _GetTimeoutError
+
+        with pytest.raises(ValueError, match="1 seconds"):
+            ray_utils._wait_until_pg_ready(pg)
+
+        call_timeout = mock_ray.wait.call_args.kwargs["timeout"]
+        assert call_timeout <= 1.0, (
+            f"ray.wait timeout {call_timeout} exceeded configured deadline of 1 second"
+        )
+
+    def test_removal_sleep_capped_at_deadline(self, monkeypatch, mocker):
+        """time.sleep in removal path must not exceed remaining time.
+
+        When get_current_placement_group + logging consume enough time
+        to exhaust the deadline, the subsequent sleep must be 0 — not
+        the stale remaining value captured at the top of the loop.
+        """
+        import time as _time_module
+
+        from vllm.v1.executor import ray_utils
+
+        monkeypatch.setenv("VLLM_RAY_PG_TIMEOUT_S", "2")
+        monkeypatch.setattr(ray_utils.envs, "VLLM_RAY_PG_TIMEOUT_S", 2)
+
+        t0 = _time_module.monotonic()
+        monkeypatch.setattr(
+            ray_utils.time,
+            "monotonic",
+            mocker.MagicMock(
+                side_effect=[t0, t0, t0 + 1.5, t0 + 3, t0 + 5],
+            ),
+        )
+
+        pg = mocker.MagicMock()
+        mock_ray_util = mocker.patch.object(ray_utils, "ray")
+        mock_ray_util.util.get_current_placement_group.return_value = pg
+
+        mock_sleep = mocker.patch.object(ray_utils.time, "sleep")
+
+        ray_utils._wait_until_pg_removed(pg)
+
+        assert len(mock_sleep.call_args_list) == 1, (
+            f"Expected exactly 1 sleep call, got {len(mock_sleep.call_args_list)}"
+        )
+        sleep_time = mock_sleep.call_args_list[0][0][0]
+        assert sleep_time == 0, (
+            f"Expected sleep(0) when deadline already elapsed, got sleep({sleep_time})"
+        )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -171,6 +171,7 @@ if TYPE_CHECKING:
     VLLM_RANDOMIZE_DP_DUMMY_INPUTS: bool = False
     VLLM_RAY_DP_PACK_STRATEGY: Literal["strict", "fill", "span"] = "strict"
     VLLM_RAY_DP_PLACEMENT_NODE_IPS: str = ""
+    VLLM_RAY_PG_TIMEOUT_S: int = 1800
     VLLM_RAY_EXTRA_ENV_VAR_PREFIXES_TO_COPY: str = ""
     VLLM_RAY_EXTRA_ENV_VARS_TO_COPY: str = ""
     VLLM_MARLIN_USE_ATOMIC_ADD: bool = False
@@ -579,6 +580,27 @@ def _resolve_rust_frontend_path() -> str | None:
             "Build with setuptools-rust or set the path explicitly."
         )
     return raw
+
+
+def _validate_pg_timeout_s() -> int:
+    """Validate and return VLLM_RAY_PG_TIMEOUT_S as int.
+
+    This env var controls the timeout for PG lifecycle operations,
+    including both PG creation (waiting for resources) and PG removal.
+
+    Raises:
+        ValueError: If the value is not a valid integer or is <= 0.
+    """
+    raw = os.getenv("VLLM_RAY_PG_TIMEOUT_S", "1800")
+    try:
+        val = int(raw)
+    except ValueError as e:
+        raise ValueError(
+            f"Invalid value for VLLM_RAY_PG_TIMEOUT_S: expected integer, got {raw!r}"
+        ) from e
+    if val <= 0:
+        raise ValueError(f"VLLM_RAY_PG_TIMEOUT_S must be > 0, got {val}")
+    return val
 
 
 environment_variables: dict[str, Callable[[], Any]] = {
@@ -1425,6 +1447,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_RAY_EXTRA_ENV_VARS_TO_COPY": lambda: os.getenv(
         "VLLM_RAY_EXTRA_ENV_VARS_TO_COPY", ""
     ),
+    # Timeout in seconds for placement group creation and removal.
+    # Default 1800s (30 min). Users can reduce for faster failure
+    # detection or increase for large-cluster scheduling delays.
+    "VLLM_RAY_PG_TIMEOUT_S": _validate_pg_timeout_s,
     # Use model_redirect to redirect the model name to a local folder.
     # `model_redirect` can be a json file mapping the model between
     # repo_id and local folder:

--- a/vllm/v1/executor/ray_utils.py
+++ b/vllm/v1/executor/ray_utils.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Union
 import numpy as np
 
 import vllm.platforms
+from vllm import envs
 from vllm.config import ParallelConfig
 from vllm.distributed import get_pp_group
 from vllm.distributed.kv_transfer.kv_connector.utils import KVOutputAggregator
@@ -26,7 +27,6 @@ if TYPE_CHECKING:
     from vllm.v1.outputs import ModelRunnerOutput
 
 logger = init_logger(__name__)
-PG_WAIT_TIMEOUT = 1800
 
 # Env vars that are worker-specific and must NOT be copied from the
 # driver to Ray workers — they are set per-worker after GPU discovery.
@@ -446,19 +446,20 @@ def _wait_until_pg_ready(current_placement_group: "PlacementGroup"):
     """Wait until a placement group is ready.
 
     It prints the informative log messages if the placement group is
-    not created within time.
+    not created within the timeout configured by VLLM_RAY_PG_TIMEOUT_S.
+    This env var controls both PG creation and PG removal deadlines
+    (PG lifecycle timeout).
 
     """
-    # Wait until PG is ready - this will block until all
-    # requested resources are available, and will time out
-    # if they cannot be provisioned.
     placement_group_specs = current_placement_group.bundle_specs
 
-    s = time.time()
+    pg_timeout = envs.VLLM_RAY_PG_TIMEOUT_S
+    start_time = time.monotonic()
+    deadline = start_time + pg_timeout
     pg_ready_ref = current_placement_group.ready()
     wait_interval = 10
-    while time.time() - s < PG_WAIT_TIMEOUT:
-        ready, _ = ray.wait([pg_ready_ref], timeout=wait_interval)
+    while (remaining := deadline - time.monotonic()) > 0:
+        ready, _ = ray.wait([pg_ready_ref], timeout=min(wait_interval, remaining))
         if len(ready) > 0:
             break
 
@@ -471,26 +472,20 @@ def _wait_until_pg_ready(current_placement_group: "PlacementGroup"):
             " and make sure the IP addresses used by ray cluster"
             " are the same as VLLM_HOST_IP environment variable"
             " specified in each node if you are running on a multi-node.",
-            int(time.time() - s),
+            int(time.monotonic() - start_time),
             placement_group_specs,
         )
 
     try:
         ray.get(pg_ready_ref, timeout=0)
     except ray.exceptions.GetTimeoutError:
-        # Provide more helpful error message when GPU count is exceeded
         total_gpu_required = sum(spec.get("GPU", 0) for spec in placement_group_specs)
-        # If more than one GPU is required for the placement group, provide a
-        # more specific error message.
-        # We use >1 here because multi-GPU (tensor parallel) jobs are more
-        # likely to fail due to insufficient cluster resources, and users may
-        # need to adjust tensor_parallel_size to fit available GPUs.
         if total_gpu_required > 1:
             raise ValueError(
                 f"Cannot provide a placement group requiring "
                 f"{total_gpu_required} GPUs "
                 f"(placement_group_specs={placement_group_specs}) within "
-                f"{PG_WAIT_TIMEOUT} seconds.\n"
+                f"{pg_timeout} seconds.\n"
                 f"Tensor parallel size may exceed available GPUs in your "
                 f"cluster. Check resources with `ray status` and "
                 f"`ray list nodes`.\n"
@@ -501,17 +496,19 @@ def _wait_until_pg_ready(current_placement_group: "PlacementGroup"):
             raise ValueError(
                 "Cannot provide a placement group of "
                 f"{placement_group_specs=} within "
-                f"{PG_WAIT_TIMEOUT} seconds. See "
+                f"{pg_timeout} seconds. See "
                 "`ray status` and `ray list nodes` to make sure the cluster "
                 "has enough resources."
             ) from None
 
 
 def _wait_until_pg_removed(current_placement_group: "PlacementGroup"):
+    pg_timeout = envs.VLLM_RAY_PG_TIMEOUT_S
     ray.util.remove_placement_group(current_placement_group)
-    s = time.time()
+    start_time = time.monotonic()
+    deadline = start_time + pg_timeout
     wait_interval = 10
-    while time.time() - s < PG_WAIT_TIMEOUT:
+    while deadline - time.monotonic() > 0:
         pg = ray.util.get_current_placement_group()
         if pg is None:
             break
@@ -520,9 +517,15 @@ def _wait_until_pg_removed(current_placement_group: "PlacementGroup"):
         wait_interval *= 2
         logger.info(
             "Waiting for removing a placement group of specs for %d seconds.",
-            int(time.time() - s),
+            int(time.monotonic() - start_time),
         )
-        time.sleep(wait_interval)
+        time.sleep(min(wait_interval, max(0, deadline - time.monotonic())))
+    else:
+        logger.warning(
+            "Timed out after %d seconds waiting for placement group "
+            "removal. The placement group may still exist.",
+            pg_timeout,
+        )
 
 
 def initialize_ray_cluster(


### PR DESCRIPTION
## Purpose

Replace the hard-coded `PG_WAIT_TIMEOUT = 1800` with a configurable env var
`VLLM_RAY_PG_TIMEOUT_S` (int, default 1800, validated > 0). Applied to both
`_wait_until_pg_ready` and `_wait_until_pg_removed`.

Two fixes in one change:

1. **Configurability** — small clusters can fail fast (e.g. 60 s), K8s spot
   clusters can extend the window past 30 minutes.

2. **Deadline overshoot** — switches `time.time()` → `time.monotonic()`, caps
   `ray.wait()` / `time.sleep()` to the remaining deadline, and recalculates
   remaining time immediately before `time.sleep()` in the removal path so
   `get_current_placement_group()` + logging time doesn't cause overshoot.

A related feature request for PG env-var configurability (#49527) is open;
this proposal follows the same pattern.

Closes #49530.

## Duplicate check

Searched open PRs for placement group timeout and configurable
`PG_WAIT_TIMEOUT`; no open PR introduces a configurable placement-group
lifecycle timeout or deadline-capped waits.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/executor/test_ray_utils.py -v
```

## Test Result

```
9 passed in 1.26s
```

---

This PR was prepared with AI assistance (Claude). A human reviewed every
changed line, ran the tests, and takes responsibility for the change.
