### PR TITLE
[Core] Make Ray placement group strategy configurable via VLLM_RAY_PG_STRATEGY

### DIFF
--- a/tests/v1/executor/test_ray_utils.py
+++ b/tests/v1/executor/test_ray_utils.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from unittest.mock import MagicMock, patch
+
 import numpy as np
+import pytest
 
 from vllm.v1.executor.ray_utils import detach_zero_copy_from_model_runner_output
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors, ModelRunnerOutput
@@ -52,3 +55,92 @@ def test_detach_zero_copy_from_model_runner_output_copies_only_numpy_views():
     assert detached_logprobs.sampled_token_ranks.flags.writeable
     assert detached_logprobs.cu_num_generated_tokens is cu_num_generated_tokens
     assert output.prompt_logprobs_dict["req-0"] is prompt_logprobs
+
+
+def test_pg_strategy_env_var_default(monkeypatch):
+    """VLLM_RAY_PG_STRATEGY defaults to PACK."""
+    monkeypatch.delenv("VLLM_RAY_PG_STRATEGY", raising=False)
+    # Access the raw dictionary entry rather than the cached attribute:
+    # __getattr__ caches the first lookup so monkeypatch cannot override
+    # `envs.VLLM_RAY_PG_STRATEGY` after the module has been imported.
+    from vllm.envs import environment_variables
+
+    assert environment_variables["VLLM_RAY_PG_STRATEGY"]() == "PACK"
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    ["PACK", "SPREAD", "STRICT_PACK", "STRICT_SPREAD"],
+)
+def test_pg_strategy_env_var_all_valid_choices(monkeypatch, strategy):
+    """All four Ray PG strategies are accepted without error."""
+    monkeypatch.setenv("VLLM_RAY_PG_STRATEGY", strategy)
+    from vllm.envs import environment_variables
+
+    assert environment_variables["VLLM_RAY_PG_STRATEGY"]() == strategy
+
+
+def test_pg_strategy_env_var_invalid_raises(monkeypatch):
+    """Invalid PG strategy raises ValueError via env_with_choices."""
+    monkeypatch.setenv("VLLM_RAY_PG_STRATEGY", "INVALID")
+    # See test_pg_strategy_env_var_default for why we access the dict
+    # directly rather than using the cached module attribute.
+    from vllm.envs import environment_variables
+
+    validator = environment_variables["VLLM_RAY_PG_STRATEGY"]
+    with pytest.raises(ValueError, match="VLLM_RAY_PG_STRATEGY"):
+        validator()
+
+
+def test_initialize_ray_cluster_passes_strategy_to_ray(monkeypatch):
+    """initialize_ray_cluster passes VLLM_RAY_PG_STRATEGY to
+    ray.util.placement_group(strategy=...)."""
+    monkeypatch.setenv("VLLM_RAY_PG_STRATEGY", "SPREAD")
+
+    mock_ray = MagicMock()
+    mock_ray.is_initialized.return_value = True
+    mock_ray.util.get_current_placement_group.return_value = None
+    mock_ray.cluster_resources.return_value = {"CPU": 8}
+    mock_ray.get_runtime_context.return_value.get_node_id.return_value = "node1"
+
+    from vllm.platforms import current_platform
+    from vllm.v1.executor import ray_utils
+
+    # Platform detection is incomplete when vllm is not installed as a
+    # package (editable install).  Provide minimal attributes so
+    # initialize_ray_cluster can determine the device string.
+    monkeypatch.setattr(current_platform, "device_name", "cpu")
+    monkeypatch.setattr(current_platform, "ray_device_key", "CPU")
+
+    # Ray is not installed here, so `available_resources_per_node` was
+    # never set by the module-level import block. Assign it directly.
+    # Save the original (possibly None) to restore after the test so
+    # other tests in the same process are not affected.
+    _saved_available_resources_per_node = getattr(
+        ray_utils, "available_resources_per_node", None
+    )
+    ray_utils.available_resources_per_node = lambda: {"node1": {"CPU": 8}}
+    try:
+        with (
+            patch.object(ray_utils, "ray", mock_ray),
+            patch.object(ray_utils, "get_ip", return_value="1.2.3.4"),
+            patch.object(ray_utils, "_wait_until_pg_ready"),
+            patch.object(ray_utils, "_verify_bundles"),
+        ):
+            parallel_config = MagicMock()
+            parallel_config.world_size = 4
+            parallel_config.placement_group = None
+            parallel_config.ray_runtime_env = None
+
+            ray_utils.initialize_ray_cluster(
+                parallel_config, require_gpu_on_driver=False
+            )
+
+            mock_ray.util.placement_group.assert_called_once()
+            _, kwargs = mock_ray.util.placement_group.call_args
+            assert kwargs["strategy"] == "SPREAD"
+    finally:
+        if _saved_available_resources_per_node is not None:
+            ray_utils.available_resources_per_node = _saved_available_resources_per_node
+        else:
+            del ray_utils.available_resources_per_node

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -171,6 +171,9 @@ if TYPE_CHECKING:
     VLLM_RANDOMIZE_DP_DUMMY_INPUTS: bool = False
     VLLM_RAY_DP_PACK_STRATEGY: Literal["strict", "fill", "span"] = "strict"
     VLLM_RAY_DP_PLACEMENT_NODE_IPS: str = ""
+    VLLM_RAY_PG_STRATEGY: Literal["PACK", "SPREAD", "STRICT_PACK", "STRICT_SPREAD"] = (
+        "PACK"
+    )
     VLLM_RAY_EXTRA_ENV_VAR_PREFIXES_TO_COPY: str = ""
     VLLM_RAY_EXTRA_ENV_VARS_TO_COPY: str = ""
     VLLM_MARLIN_USE_ATOMIC_ADD: bool = False
@@ -1411,6 +1414,20 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # This environment variable is ignored if data-parallel-backend is not Ray.
     "VLLM_RAY_DP_PLACEMENT_NODE_IPS": lambda: os.getenv(
         "VLLM_RAY_DP_PLACEMENT_NODE_IPS", ""
+    ),
+    # Placement group strategy used by initialize_ray_cluster
+    # (ray_utils.py).  Distinct from VLLM_RAY_DP_PACK_STRATEGY which
+    # controls the strategy for data-parallel placement groups
+    # (create_dp_placement_groups in utils.py).  Ray placement group
+    # strategies: PACK (default, best-effort — packs resources as much
+    # as possible; may span nodes if a single node lacks capacity),
+    # SPREAD (bundles across different nodes), STRICT_PACK (guarantees
+    # single-node, fails if impossible), STRICT_SPREAD.
+    "VLLM_RAY_PG_STRATEGY": env_with_choices(
+        "VLLM_RAY_PG_STRATEGY",
+        "PACK",
+        ["PACK", "SPREAD", "STRICT_PACK", "STRICT_SPREAD"],
+        case_sensitive=True,
     ),
     # Comma-separated *additional* prefixes of env vars to copy from the
     # driver to Ray workers.  These are merged with the built-in defaults

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -808,6 +808,9 @@ class CoreEngineActorManager:
                 else:
                     bundles = [{device_str: 1.0}] * world_size + [{"CPU": 1.0}]
 
+                # STRICT_PACK is intentionally hardcoded here (not
+                # controlled by VLLM_RAY_PG_STRATEGY): dynamic DP rank
+                # addition must place new bundles on a specific node.
                 pg = ray.util.placement_group(
                     name=f"dp_rank_{rank}",
                     strategy="STRICT_PACK",

--- a/vllm/v1/executor/ray_utils.py
+++ b/vllm/v1/executor/ray_utils.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Union
 import numpy as np
 
 import vllm.platforms
+from vllm import envs
 from vllm.config import ParallelConfig
 from vllm.distributed import get_pp_group
 from vllm.distributed.kv_transfer.kv_connector.utils import KVOutputAggregator
@@ -659,9 +660,10 @@ def initialize_ray_cluster(
             # current node.
             placement_group_specs[0][f"node:{current_ip}"] = 0.001
 
-        # By default, Ray packs resources as much as possible.
+        # Placement group strategy (default PACK), validated by
+        # env_with_choices in envs.py.
         current_placement_group = ray.util.placement_group(
-            placement_group_specs, strategy="PACK"
+            placement_group_specs, strategy=envs.VLLM_RAY_PG_STRATEGY
         )
         _wait_until_pg_ready(current_placement_group)
 


### PR DESCRIPTION
## Purpose

Allow users to configure the Ray placement group strategy via `VLLM_RAY_PG_STRATEGY` env var. Currently `initialize_ray_cluster` hardcodes `strategy="PACK"`, but Ray supports `SPREAD`, `STRICT_PACK`, and `STRICT_SPREAD` as well.

Closes #49527

No existing open PR addresses configurable placement-group strategy for
`initialize_ray_cluster`.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/executor/test_ray_utils.py -v
```

## Test Result

```
tests/v1/executor/test_ray_utils.py::test_detach_zero_copy_from_model_runner_output_copies_only_numpy_views PASSED
tests/v1/executor/test_ray_utils.py::test_pg_strategy_env_var_default PASSED
tests/v1/executor/test_ray_utils.py::test_pg_strategy_env_var_all_valid_choices[PACK] PASSED
tests/v1/executor/test_ray_utils.py::test_pg_strategy_env_var_all_valid_choices[SPREAD] PASSED
tests/v1/executor/test_ray_utils.py::test_pg_strategy_env_var_all_valid_choices[STRICT_PACK] PASSED
tests/v1/executor/test_ray_utils.py::test_pg_strategy_env_var_all_valid_choices[STRICT_SPREAD] PASSED
tests/v1/executor/test_ray_utils.py::test_pg_strategy_env_var_invalid_raises PASSED
tests/v1/executor/test_ray_utils.py::test_initialize_ray_cluster_passes_strategy_to_ray PASSED
```

AI assistance used for this PR.
