### PR TITLE
[Bugfix][Tool Parser] Preserve whitespace in Step3 parameter values

### DIFF
--- a/tests/tool_parsers/test_step3_tool_parser.py
+++ b/tests/tool_parsers/test_step3_tool_parser.py
@@ -2,13 +2,17 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import json
+
 import pytest
 
 from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.tokenizers import TokenizerLike, get_tokenizer
+from vllm.tool_parsers.step3_tool_parser import Step3ToolParser
 
 
 class TestStep3ToolParser(ToolParserTests):
@@ -110,3 +114,74 @@ class TestStep3ToolParser(ToolParserTests):
             },
             supports_typed_arguments=False,
         )
+
+
+class _FakeTokenizer:
+    """Minimal fake tokenizer; the parser only stores it for streaming."""
+
+    def get_vocab(self) -> dict[str, int]:
+        return {}
+
+
+_WS_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "edit_file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "old_string": {"type": "string"},
+                    "indent": {"type": "integer"},
+                    "enabled": {"type": "boolean"},
+                },
+            },
+        },
+    }
+]
+
+
+def _ws_output(value: str) -> str:
+    return (
+        "<｜tool_calls_begin｜><｜tool_call_begin｜>"
+        "function<｜tool_sep｜>edit_file\n"
+        '<steptml:invoke name="edit_file">'
+        f'<steptml:parameter name="old_string">{value}</steptml:parameter>'
+        '<steptml:parameter name="indent"> 4 </steptml:parameter>'
+        '<steptml:parameter name="enabled"> true </steptml:parameter>'
+        "</steptml:invoke><｜tool_call_end｜><｜tool_calls_end｜>"
+    )
+
+
+class TestStep3ParameterWhitespace:
+    """String parameter values must preserve surrounding whitespace.
+
+    The value sits inline between ``>`` and ``</steptml:parameter>``, so
+    whitespace around it is data rather than markup -- the same reasoning
+    applied to MiniMax M2 and MiniCPM5 XML, and already implemented by the
+    poolside_v1 parser. Stripping it breaks exact-match edit tools.
+    """
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "    if x:",
+            "return 1\n",
+            "    if x:\n        return 1\n",
+            "hello ",
+            "hello\u00a0",
+            "hello",
+        ],
+    )
+    def test_string_value_preserved(self, value: str) -> None:
+        request = ChatCompletionRequest(messages=[], model="step3", tools=_WS_TOOLS)
+        parser = Step3ToolParser(_FakeTokenizer(), request.tools)
+        result = parser.extract_tool_calls(_ws_output(value), request)
+
+        assert result.tools_called
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert args["old_string"] == value
+        # Non-string types are still normalised, so surrounding whitespace on
+        # them stays harmless.
+        assert args["indent"] == 4
+        assert args["enabled"] is True

--- a/vllm/tool_parsers/step3_tool_parser.py
+++ b/vllm/tool_parsers/step3_tool_parser.py
@@ -75,7 +75,10 @@ class Step3ToolParser(ToolParser):
             action_text,
         )
         for name, value in param_matches:
-            params[name] = value.strip()
+            # Keep the value verbatim: it is inline between `>` and
+            # `</steptml:parameter>`, so surrounding whitespace is data rather
+            # than markup. Scalar types are normalised in _cast_arguments.
+            params[name] = value
         return func_name, params
 
     def _cast_arguments(
@@ -93,7 +96,10 @@ class Step3ToolParser(ToolParser):
                     prop = properties.get(key, {})
                     typ = prop.get("type")
                     if typ == "string":
-                        params[key] = value.strip()
+                        # Verbatim. Leading indentation and trailing newlines
+                        # are part of a string argument, and stripping them
+                        # breaks exact-match edit tools.
+                        continue
                     elif typ == "integer":
                         with contextlib.suppress(ValueError):
                             params[key] = int(value)
@@ -101,14 +107,17 @@ class Step3ToolParser(ToolParser):
                         with contextlib.suppress(ValueError):
                             params[key] = float(value)
                     elif typ == "boolean":
-                        lower_val = value.lower()
+                        # .strip() here, not at parse time: these comparisons
+                        # need the bare literal, but string values must keep
+                        # their whitespace.
+                        lower_val = value.strip().lower()
                         params[key] = (
                             lower_val == "true"
                             if lower_val in ("true", "false")
                             else value
                         )
                     elif typ == "null":
-                        params[key] = None if value.lower() == "null" else value
+                        params[key] = None if value.strip().lower() == "null" else value
                 break
         return params
 


### PR DESCRIPTION
## Purpose

`Step3ToolParser` strips whitespace off string tool arguments, at two independent points:

```python
# step3_tool_parser.py, _parse_steptml_invoke
for name, value in param_matches:
    params[name] = value.strip()          # every value, unconditionally

# step3_tool_parser.py, _cast_arguments
if typ == "string":
    params[key] = value.strip()           # again, for schema-declared strings
```

The value sits inline between `>` and `</steptml:parameter>`, so surrounding whitespace is **data, not markup**. Stripping it deletes leading indentation and trailing newlines, which breaks coding agents that use exact-string-match edit tools: an `old_string` of `"    if x:\n        return 1\n"` is delivered as `"if x:\n        return 1"`, the match fails, and the edit is rejected or misapplied. `str.strip()` also takes no argument here, so NBSP (U+00A0) and other Unicode whitespace are removed too.

This is the same class as #48846, which fixed MiniMax M2, Qwen3 and MiniCPM5 XML but did not cover Step3. The `poolside_v1` parser already implements the intended behaviour in this repo:

```python
# poolside_v1_tool_parser.py
# Keep string values verbatim; whitespace is significant
# (e.g. code/file content). Only strip non-string types.
```

## Test Plan

```bash
pytest tests/tool_parsers/test_step3_tool_parser.py -q
```

Added `TestStep3ParameterWhitespace`, parametrised over leading indentation, a trailing newline, indentation plus trailing newline, a trailing space, NBSP, and a no-whitespace control. Each case also asserts that an `integer` and a `boolean` argument written as `" 4 "` and `" true "` still coerce to `4` and `True`, so the scalar path is pinned as well.

## Test Result

Before (on `main`), the five whitespace cases fail:

```
AssertionError: assert 'if x:' == '    if x:'
AssertionError: assert 'return 1' == 'return 1\n'
AssertionError: assert 'if x:\n        return 1' == '    if x:\n        return 1\n'
AssertionError: assert 'hello' == 'hello '
AssertionError: assert 'hello' == 'hello\xa0'
5 failed, 1 passed
```

After:

```
15 passed, 8 xfailed
```

The rest of the file is unchanged by this PR — `-k "not Whitespace"` gives `9 passed, 8 xfailed` both with and without the change. Those 8 `xfail`s are pre-existing and marked "Step3 parser non-streaming has bugs"; this PR fixes one specific documented class and does not claim to flip them.

`ruff check` and `ruff format --check` are clean on both files.

## Notes on the non-string branches

Removing the parse-time strip would have changed `boolean` and `null` handling, since both compare `value.lower()` against a bare literal and would no longer match `" true "`. Those two branches now strip locally, preserving their previous tolerance. `int()` and `float()` already accept surrounding whitespace, so `integer` and `number` are untouched. An argument with no schema type is now kept verbatim, matching the MiniMax M2 converter.