### PR TITLE
[Doc] Make /dev/shm shared memory mount configurable in the Helm char

### DIFF
--- a/docs/deployment/frameworks/helm.md
+++ b/docs/deployment/frameworks/helm.md
@@ -105,6 +105,7 @@ The following table describes configurable parameters of the chart in `values.ya
 | secrets | object | {} | Secrets configuration |
 | serviceName | string | "" | Service name |
 | servicePort | int | 80 | Service port |
+| shm | object | {"enabled":false,"size":"16Gi"} | Shared memory configuration |
 | labels.environment | string | test | Environment name |
 
 ## Configuration Examples

--- a/examples/deployment/chart-helm/templates/deployment.yaml
+++ b/examples/deployment/chart-helm/templates/deployment.yaml
@@ -67,6 +67,10 @@ spec:
           volumeMounts:
           - name: {{ .Release.Name }}-storage
             mountPath: /data
+          {{- if .Values.shm.enabled }}
+          - name: {{ .Release.Name }}-shm
+            mountPath: /dev/shm
+          {{- end }}
 
         {{- with .Values.extraContainers }}
         {{ toYaml . | nindent 8 }}
@@ -106,6 +110,14 @@ spec:
         - name: {{ .Release.Name }}-storage
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-storage-claim     
+        {{- if .Values.shm.enabled }}
+        - name: {{ .Release.Name }}-shm
+          emptyDir:
+            medium: Memory
+            {{- if .Values.shm.size }}
+            sizeLimit: {{ .Values.shm.size | quote }}
+            {{- end }}
+        {{- end }}     
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/examples/deployment/chart-helm/values.schema.json
+++ b/examples/deployment/chart-helm/values.schema.json
@@ -89,6 +89,17 @@
                 "requests"
             ]
         },
+        "shm": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "size": {
+                "type": "string"
+              }
+            }
+        },
         "gpuModels": {
             "type": "array",
             "items": {

--- a/examples/deployment/chart-helm/values.yaml
+++ b/examples/deployment/chart-helm/values.yaml
@@ -42,6 +42,15 @@ resources:
     # -- Number of gpus used
     nvidia.com/gpu: 1
 
+# -- Shared memory configuration
+shm:
+  # -- If true, mount a memory-backed emptyDir at /dev/shm.
+  # If false, do not override /dev/shm and use the container runtime default.
+  enabled: false
+  # -- Optional sizeLimit for the memory-backed emptyDir mounted at /dev/shm.
+  # If empty or unset, the emptyDir is created without sizeLimit.
+  size: "16Gi"
+
 # -- Type of gpu used
 gpuModels:
   - "TYPE_GPU_USED"


### PR DESCRIPTION
## Purpose

Fixes #37982

The Helm chart did not provide a way to configure `/dev/shm` shared memory
for the vLLM container. This is important because PyTorch relies on
shared memory for inter-process communication during tensor parallel
inference.

This change adds a configurable `shm` section in `values.yaml` with an
`enabled` flag and optional `size` limit. When enabled, it renders:
- a `/dev/shm` `volumeMount`
- a RAM-backed `emptyDir` volume with an optional `sizeLimit`

### When is `/dev/shm` needed?

Shared memory is required for workloads that use inter-process
communication (IPC) between GPU worker processes:

- **Tensor parallelism (TP > 1):** the model is split across multiple
  GPUs and processes exchange tensors in real-time. Without proper
  shared memory, PyTorch can run out of IPC buffer space.
- **Multi-node deployments:** when combining tensor parallelism with
  pipeline parallelism across nodes.
- **GPUDirect RDMA:** the official vLLM Kubernetes deployment guidance
  explicitly requires mounting `/dev/shm` to enable efficient GPU memory
  access bypassing the CPU and system memory.

For single-GPU deployments with `tensor_parallel_size=1`, the default
container shared memory is typically sufficient, so `shm` is disabled
by default. Users can enable it explicitly when their workload requires it.

This brings the chart in line with vLLM official Kubernetes deployment
guidance requiring `/dev/shm` for tensor parallel inference and IPC.

## Modified Files

- `examples/deployment/chart-helm/values.yaml` — Added `shm` section with `enabled` and `size`
- `examples/deployment/chart-helm/templates/deployment.yaml` — Added conditional `/dev/shm` `volumeMount` and memory-backed `emptyDir` volume
- `examples/deployment/chart-helm/values.schema.json` — Added JSON schema for the `shm` object
- `docs/deployment/frameworks/helm.md` — Documented the `shm` parameter in the values table

## Test Plan

### 1. Template rendering tests

Validated the following `helm template` scenarios:

Baseline (shm disabled): no `shm` volume or `volumeMount` in the rendered output.
```bash
helm template test examples/deployment/chart-helm
```

Enabled with size: memory-backed  emptyDir  with  sizeLimit  alongside  /dev/shm  mount.
```bash
helm template test examples/deployment/chart-helm --set shm.enabled=true --set shm.size="8Gi"
```
Enabled without size:  emptyDir  with  medium: Memory  but no  sizeLimit .
```bash
helm template test examples/deployment/chart-helm --set shm.enabled=true --set shm.size=""
```
2. Real cluster deployment

Deployed on a live Kubernetes cluster with  --set shm.enabled=true --set shm.size="8Gi" . Verified with:
```bash
helm upgrade --install --set shm.enabled=true --set shm.size="8Gi"
kubectl get pod -n <namespace>
kubectl get pod <pod_name> -n <namespace> -oyaml | grep -E 'name: shm|mountPath: /dev/shm|medium: Memory|sizeLimit:'
kubectl exec <pod_name> -c vllm -n <namespace> -- df -h /dev/shm
```
Expected Results

• Default render produces no  shm  entries
• With  shm.enabled=true  and a size set: volume contains  medium: Memory  and  sizeLimit 
• With  shm.size  empty: volume contains  medium: Memory  but omits  sizeLimit 
• On-cluster deployment shows  /dev/shm  as a temporay filesystem with the configured capacity