### PR TITLE
[EPLB] Support custom initial expert maps

### DIFF
--- a/tests/distributed/test_eplb_algo.py
+++ b/tests/distributed/test_eplb_algo.py
@@ -5,7 +5,10 @@ import numpy as np
 import pytest
 import torch
 
-from vllm.distributed.eplb.eplb_state import compute_logical_maps
+from vllm.distributed.eplb.eplb_state import (
+    compute_logical_maps,
+    load_initial_expert_map,
+)
 from vllm.distributed.eplb.policy.default import DefaultEplbPolicy
 
 
@@ -496,3 +499,71 @@ def test_preserve_intragpu_slots(
         num_ranks,
         slots_per_gpu,
     )
+
+
+def test_load_initial_expert_map_shared_across_layers(tmp_path):
+    path = tmp_path / "expert-map.json"
+    path.write_text("[2, 0, 1, 2]")
+
+    result = load_initial_expert_map(
+        str(path),
+        num_moe_layers=2,
+        num_physical_experts=4,
+        num_logical_experts=3,
+    )
+
+    torch.testing.assert_close(
+        result,
+        torch.tensor(
+            [
+                [2, 0, 1, 2],
+                [2, 0, 1, 2],
+            ]
+        ),
+    )
+
+
+def test_load_initial_expert_map_per_layer(tmp_path):
+    path = tmp_path / "expert-map.json"
+    path.write_text("[[0, 1, 2, 0], [2, 1, 0, 2]]")
+
+    result = load_initial_expert_map(
+        str(path),
+        num_moe_layers=2,
+        num_physical_experts=4,
+        num_logical_experts=3,
+    )
+
+    torch.testing.assert_close(
+        result,
+        torch.tensor(
+            [
+                [0, 1, 2, 0],
+                [2, 1, 0, 2],
+            ]
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "contents, match",
+    [
+        ("[]", "non-empty"),
+        ("[0, 1, 2]", "4 physical slots"),
+        ("[0, 1, 2, 3]", "out-of-range"),
+        ("[0, 0, 1, 1]", "does not place"),
+        ("[[0, 1, 2, 0], [0, 1, 2, 0], [0, 1, 2, 0]]", "either one shared"),
+        ("[0, true, 2, 0]", "non-integer"),
+    ],
+)
+def test_load_initial_expert_map_rejects_invalid_layout(tmp_path, contents, match):
+    path = tmp_path / "expert-map.json"
+    path.write_text(contents)
+
+    with pytest.raises(ValueError, match=match):
+        load_initial_expert_map(
+            str(path),
+            num_moe_layers=2,
+            num_physical_experts=4,
+            num_logical_experts=3,
+        )

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -70,6 +70,14 @@ class EPLBConfig:
     num_redundant_experts: int = Field(default=0, ge=0)
     """Number of redundant experts to use for expert parallelism."""
 
+    initial_expert_map_path: str | None = None
+    """
+    Path to a JSON physical-to-logical expert map applied after model loading.
+    The file may contain one list shared by all MoE layers, or one list per
+    layer. Each list must contain exactly ``num_physical_experts`` logical
+    expert IDs and cover every logical expert at least once.
+    """
+
     log_balancedness: bool = False
     """
     Log the balancedness each step of expert parallelism.

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -577,7 +577,7 @@ class EplbState:
                     initial_map,
                     model.expert_weights,
                     expert_buffer,
-                    get_eplb_group().device_group,
+                    get_ep_group().device_group,
                     communicator,
                 )
                 _commit_eplb_maps(

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -26,10 +26,12 @@ MoE layer. If we have 32 EP ranks, then each GPU will hold 288 / 32 = 9 local
 physical experts.
 """
 
+import json
 import threading
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
+from pathlib import Path
 
 import torch
 from torch.distributed import ProcessGroup, all_reduce
@@ -58,6 +60,76 @@ from .rebalance_execute import (
 )
 
 logger = init_logger(__name__)
+
+
+def load_initial_expert_map(
+    path: str,
+    *,
+    num_moe_layers: int,
+    num_physical_experts: int,
+    num_logical_experts: int,
+) -> torch.Tensor:
+    """Load and validate a physical-to-logical expert map from JSON."""
+    try:
+        raw_map = json.loads(Path(path).read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f"Failed to load initial EPLB expert map from {path}: {exc}"
+        ) from exc
+
+    if not isinstance(raw_map, list) or not raw_map:
+        raise ValueError("Initial EPLB expert map must be a non-empty JSON list.")
+
+    if all(isinstance(value, int) and not isinstance(value, bool) for value in raw_map):
+        layer_maps = [raw_map]
+    elif all(isinstance(layer, list) for layer in raw_map):
+        layer_maps = raw_map
+    else:
+        raise ValueError(
+            "Initial EPLB expert map must contain integers or lists of integers."
+        )
+
+    if len(layer_maps) not in (1, num_moe_layers):
+        raise ValueError(
+            "Initial EPLB expert map must define either one shared layer or "
+            f"{num_moe_layers} layers, got {len(layer_maps)}."
+        )
+
+    expected_experts = set(range(num_logical_experts))
+    for layer_idx, layer_map in enumerate(layer_maps):
+        if len(layer_map) != num_physical_experts:
+            raise ValueError(
+                f"Initial EPLB expert map layer {layer_idx} must contain "
+                f"{num_physical_experts} physical slots, got {len(layer_map)}."
+            )
+        if not all(
+            isinstance(expert_id, int) and not isinstance(expert_id, bool)
+            for expert_id in layer_map
+        ):
+            raise ValueError(
+                f"Initial EPLB expert map layer {layer_idx} contains a non-integer ID."
+            )
+        invalid_ids = sorted(
+            expert_id
+            for expert_id in set(layer_map)
+            if expert_id < 0 or expert_id >= num_logical_experts
+        )
+        if invalid_ids:
+            raise ValueError(
+                f"Initial EPLB expert map layer {layer_idx} contains out-of-range "
+                f"logical expert IDs: {invalid_ids}."
+            )
+        missing_ids = sorted(expected_experts.difference(layer_map))
+        if missing_ids:
+            raise ValueError(
+                f"Initial EPLB expert map layer {layer_idx} does not place logical "
+                f"experts: {missing_ids}."
+            )
+
+    result = torch.tensor(layer_maps, dtype=torch.long, device="cpu")
+    if len(layer_maps) == 1:
+        result = result.expand(num_moe_layers, -1).contiguous()
+    return result
 
 
 @dataclass
@@ -490,6 +562,29 @@ class EplbState:
         )
         self.model_states[model_config.compute_hash()] = model_state
         self.num_valid_physical_experts = model.num_physical_experts
+
+        initial_map_path = self.parallel_config.eplb_config.initial_expert_map_path
+        if initial_map_path is not None:
+            initial_map = load_initial_expert_map(
+                initial_map_path,
+                num_moe_layers=model.num_moe_layers,
+                num_physical_experts=model.num_physical_experts,
+                num_logical_experts=model.num_logical_experts,
+            ).to(self.device)
+            if not torch.equal(physical_to_logical_map, initial_map):
+                rearrange_expert_weights_inplace(
+                    physical_to_logical_map,
+                    initial_map,
+                    model.expert_weights,
+                    expert_buffer,
+                    get_eplb_group().device_group,
+                    communicator,
+                )
+                _commit_eplb_maps(
+                    model_state,
+                    new_physical_to_logical_map=initial_map,
+                )
+            logger.info("Loaded initial EPLB expert map from %s.", initial_map_path)
 
     def prepare_forward(
         self,


### PR DESCRIPTION
## Summary

- add `eplb_config.initial_expert_map_path` for a JSON physical-to-logical expert layout
- accept either one map shared by all MoE layers or a per-layer map
- validate dimensions, logical expert ID ranges, and full logical-expert coverage before any transfer starts
- rearrange the already-loaded canonical expert weights into the requested layout using the existing EPLB communicator, then atomically commit the maps

This implements the custom-initialization part of Phase 1 in #31671. It intentionally does not add a topology solver: an offline planner can emit the JSON layout, while vLLM remains responsible for validating and materializing it.

Example (`num_physical_experts=6`, `num_logical_experts=4`):

```json
[0, 1, 2, 3, 0, 1]
```

or a separate list for every MoE layer:

```json
[
  [0, 1, 2, 3, 0, 1],
  [3, 2, 1, 0, 3, 2]
]
```

## Why transfer after loading?

Model loading currently materializes the canonical expert arrangement before `EplbState.add_model()` is called. Updating only the routing maps would route tokens to the wrong weights. This change therefore uses the same synchronous EPLB rearrangement path used at runtime, and commits the custom maps only after weight movement completes.

## Validation

- `ruff format --check` on all changed Python files
- remote H20 node (`lingjun-101`) direct-cloned commit `f957c37`
- Python 3.12 `compileall` passed for all changed files
- exact loader function executed with the container's PyTorch: shared and per-layer maps passed
- invalid layouts are covered by unit tests (empty, wrong width/layer count, non-integer, missing and out-of-range experts)