### PR TITLE
[Bugfix] Preserve explicit None when swapping dict values

### DIFF
--- a/tests/utils/test_collection_utils.py
+++ b/tests/utils/test_collection_utils.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+
+from vllm.utils.collection_utils import swap_dict_values
+
+
+def test_swap_dict_values_basic():
+    d = {"a": 1, "b": 2}
+    swap_dict_values(d, "a", "b")
+    assert d == {"a": 2, "b": 1}
+
+
+def test_swap_dict_values_explicit_none_in_first():
+    d = {"a": None, "b": 2}
+    swap_dict_values(d, "a", "b")
+    # explicit None must be preserved (not dropped)
+    assert d == {"a": 2, "b": None}
+
+
+def test_swap_dict_values_explicit_none_in_second():
+    d = {"a": 1, "b": None}
+    swap_dict_values(d, "a", "b")
+    assert d == {"a": None, "b": 1}
+
+
+def test_swap_dict_values_both_none():
+    d = {"a": None, "b": None}
+    swap_dict_values(d, "a", "b")
+    assert d == {"a": None, "b": None}
+
+
+def test_swap_dict_values_first_key_absent():
+    d = {"b": 5}
+    swap_dict_values(d, "a", "b")
+    # original behaviour: absent key keeps the other value moved in
+    assert d == {"a": 5}
+
+
+def test_swap_dict_values_second_key_absent():
+    d = {"a": 7}
+    swap_dict_values(d, "a", "b")
+    assert d == {"b": 7}

--- a/vllm/utils/collection_utils.py
+++ b/vllm/utils/collection_utils.py
@@ -121,14 +121,20 @@ def full_groupby(values: Iterable[_V], *, key: Callable[[_V], _K]):
 
 
 def swap_dict_values(obj: dict[_K, _V], key1: _K, key2: _K) -> None:
-    """Swap values between two keys."""
+    """Swap values between two keys.
+
+    Explicit ``None`` values are preserved: only keys that are truly
+    absent from ``obj`` are removed on the counterpart key.
+    """
     v1 = obj.get(key1)
     v2 = obj.get(key2)
-    if v1 is not None:
+    present1 = key1 in obj
+    present2 = key2 in obj
+    if present1:
         obj[key2] = v1
     else:
         obj.pop(key2, None)
-    if v2 is not None:
+    if present2:
         obj[key1] = v2
     else:
         obj.pop(key1, None)


### PR DESCRIPTION
[Bugfix] Preserve explicit None when swapping dict values

swap_dict_values used `obj.get(key)` + `if v is not None`, which made an
explicit None value indistinguishable from a missing key, so an explicit
None was dropped instead of swapped. Use `key in obj` to detect presence.

Signed-off-by: 起岚 <155608604+xiaoyaoqilan@users.noreply.github.com>

Re-submission of the swap_dict_values explicit-None fix (previous PR was closed before the corrected branch landed).