### PR TITLE
[Rust Frontend] Add MiMo reasoning parser

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -384,6 +384,6 @@ mod tests {
         )
         .unwrap_err();
 
-        expect_test::expect!["reasoning parser `definitely_missing_reasoning_parser` is not registered (choose from: cohere_cmd, deepseek_r1, deepseek_v3, deepseek_v4, gemma4, glm45, inkling, kimi, kimi_k2, kimi_k3, minimax_m2, minimax_m3, nemotron_v3, qwen3, seed_oss, step3, step3p5)"].assert_eq(&error.to_report_string());
+        expect_test::expect!["reasoning parser `definitely_missing_reasoning_parser` is not registered (choose from: cohere_cmd, deepseek_r1, deepseek_v3, deepseek_v4, gemma4, glm45, inkling, kimi, kimi_k2, kimi_k3, mimo, minimax_m2, minimax_m3, nemotron_v3, qwen3, seed_oss, step3, step3p5)"].assert_eq(&error.to_report_string());
     }
 }

--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -415,6 +415,6 @@ mod tests {
         )
         .unwrap_err();
 
-        expect_test::expect!["reasoning parser `definitely_missing_reasoning_parser` is not registered (choose from: cohere_cmd, deepseek_r1, deepseek_v3, deepseek_v4, gemma4, glm45, hy_v3, inkling, kimi, kimi_k2, kimi_k3, minimax_m2, minimax_m3, nemotron_v3, qwen3, seed_oss, step3, step3p5)"].assert_eq(&error.to_report_string());
+        expect_test::expect!["reasoning parser `definitely_missing_reasoning_parser` is not registered (choose from: cohere_cmd, deepseek_r1, deepseek_v3, deepseek_v4, gemma4, glm45, hy_v3, inkling, kimi, kimi_k2, kimi_k3, mimo, minimax_m2, minimax_m3, nemotron_v3, qwen3, seed_oss, step3, step3p5)"].assert_eq(&error.to_report_string());
     }
 }

--- a/rust/src/chat/src/parser/reasoning/mod.rs
+++ b/rust/src/chat/src/parser/reasoning/mod.rs
@@ -28,6 +28,7 @@ pub mod names {
     pub const KIMI: &str = "kimi";
     pub const KIMI_K2: &str = "kimi_k2";
     pub const KIMI_K3: &str = "kimi_k3";
+    pub const MIMO: &str = "mimo";
     pub const MINIMAX_M2: &str = "minimax_m2";
     pub const MINIMAX_M3: &str = "minimax_m3";
     pub const NEMOTRON_V3: &str = "nemotron_v3";
@@ -70,6 +71,7 @@ impl ReasoningParserFactory {
             .register_parser::<KimiReasoningParser>(names::KIMI)
             .register_parser::<KimiK2ReasoningParser>(names::KIMI_K2)
             .register_unified_dummy(names::KIMI_K3)
+            .register_parser::<Qwen3ReasoningParser>(names::MIMO)
             .register_parser::<MiniMaxM2ReasoningParser>(names::MINIMAX_M2)
             .register_parser::<MiniMaxM3ReasoningParser>(names::MINIMAX_M3)
             .register_parser::<NemotronV3ReasoningParser>(names::NEMOTRON_V3)
@@ -85,6 +87,7 @@ impl ReasoningParserFactory {
             .register_pattern("deepseek-v3", names::DEEPSEEK_V3)
             .register_pattern("gemma-4", names::GEMMA4)
             .register_pattern("gemma4", names::GEMMA4)
+            .register_pattern("mimo-v2", names::MIMO)
             .register_pattern("qwen", names::QWEN3)
             .register_pattern("glm-5", names::GLM45)
             .register_pattern("glm-4.7", names::GLM45)

--- a/rust/src/chat/src/parser/reasoning/mod.rs
+++ b/rust/src/chat/src/parser/reasoning/mod.rs
@@ -29,6 +29,7 @@ pub mod names {
     pub const KIMI: &str = "kimi";
     pub const KIMI_K2: &str = "kimi_k2";
     pub const KIMI_K3: &str = "kimi_k3";
+    pub const MIMO: &str = "mimo";
     pub const MINIMAX_M2: &str = "minimax_m2";
     pub const MINIMAX_M3: &str = "minimax_m3";
     pub const NEMOTRON_V3: &str = "nemotron_v3";
@@ -72,6 +73,7 @@ impl ReasoningParserFactory {
             .register_parser::<KimiReasoningParser>(names::KIMI)
             .register_parser::<KimiK2ReasoningParser>(names::KIMI_K2)
             .register_unified_dummy(names::KIMI_K3)
+            .register_parser::<Qwen3ReasoningParser>(names::MIMO)
             .register_parser::<MiniMaxM2ReasoningParser>(names::MINIMAX_M2)
             .register_parser::<MiniMaxM3ReasoningParser>(names::MINIMAX_M3)
             .register_parser::<NemotronV3ReasoningParser>(names::NEMOTRON_V3)
@@ -88,6 +90,7 @@ impl ReasoningParserFactory {
             .register_pattern("gemma-4", names::GEMMA4)
             .register_pattern("gemma4", names::GEMMA4)
             .register_pattern("qwq", names::DEEPSEEK_R1)
+            .register_pattern("mimo-v2", names::MIMO)
             .register_pattern("qwen3", names::QWEN3)
             .register_pattern("glm-5", names::GLM45)
             .register_pattern("glm-4.7", names::GLM45)

--- a/rust/src/chat/src/parser/reasoning/tests.rs
+++ b/rust/src/chat/src/parser/reasoning/tests.rs
@@ -10,18 +10,56 @@ use super::{ReasoningParserFactory, names};
 #[test]
 fn factory_contains_and_lists_registered_parsers() {
     let factory = ReasoningParserFactory::new();
+    assert!(factory.contains(names::MIMO));
     assert!(factory.contains(names::QWEN3));
     assert!(factory.contains(names::DEEPSEEK_V4));
     assert!(factory.contains(names::SEED_OSS));
     assert!(factory.contains(names::STEP3P5));
     assert!(factory.contains(names::MINIMAX_M3));
     assert!(factory.contains(names::GEMMA4));
+    assert!(factory.list().contains(&names::MIMO.to_string()));
     assert!(factory.list().contains(&names::QWEN3.to_string()));
     assert!(factory.list().contains(&names::DEEPSEEK_V4.to_string()));
     assert!(factory.list().contains(&names::SEED_OSS.to_string()));
     assert!(factory.list().contains(&names::STEP3P5.to_string()));
     assert!(factory.list().contains(&names::MINIMAX_M3.to_string()));
     assert!(factory.list().contains(&names::GEMMA4.to_string()));
+}
+
+#[test]
+fn factory_creates_and_routes_mimo_v2_parsers() {
+    let tokenizer = Arc::new(
+        TestTokenizer::new()
+            .with_regular_token("<think>", 256)
+            .with_regular_token("</think>", 257),
+    );
+    let factory = ReasoningParserFactory::new();
+
+    let mut mimo = factory.create(names::MIMO, tokenizer.clone()).unwrap();
+    let mut qwen3 = factory.create(names::QWEN3, tokenizer).unwrap();
+    let output = "<think>compare aliases</think>same content";
+    assert_eq!(mimo.push(output).unwrap(), qwen3.push(output).unwrap());
+
+    assert_eq!(
+        factory.resolve_name_for_model("XiaomiMiMo/MiMo-V2-Flash"),
+        Some(names::MIMO)
+    );
+    assert_eq!(
+        factory.resolve_name_for_model("XiaomiMiMo/MiMo-V2.5-Pro-FP4"),
+        Some(names::MIMO)
+    );
+    assert_eq!(
+        factory.resolve_name_for_model("XiaomiMiMo/MiMo-V2.5"),
+        Some(names::MIMO)
+    );
+    assert_eq!(
+        factory.resolve_name_for_model("XiaomiMiMo/MiMo-V2.5-Omni"),
+        Some(names::MIMO)
+    );
+    assert_eq!(
+        factory.resolve_name_for_model("XiaomiMiMo/MiMo-7B-RL"),
+        None
+    );
 }
 
 #[test]


### PR DESCRIPTION



## Purpose
Add MiMo reasoning-parser support to the Rust frontend.

- Registers `mimo` as an alias for the existing Qwen3 reasoning parser,
  matching the Python frontend behavior.
- Routes MiMo-V2  to the `mimo` reasoning parser.
- Adds tests covering parser creation, Qwen3-equivalent parsing behavior,
  and model-family routing.

This addresses the MiMo reasoning parser item in #44280.

## Test Plan

```bash
cargo nextest run -p vllm-chat \
  -E 'test(parser::reasoning::tests::factory_creates_and_routes_mimo_v2_parsers)'
```

Run the complete `vllm-chat` library test suite:

```bash
cargo test -p vllm-chat --lib
```

Run formatting and lint checks:

```bash
cargo fmt --all -- --check
cargo clippy -p vllm-chat --all-targets -- -D warnings
```

## Test Result

Focused MiMo parser test:

```text
1 test run: 1 passed, 255 skipped
```

Complete `vllm-chat` library test suite:

```text
224 passed; 0 failed
```

Formatting and Clippy checks completed successfully.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is described and linked to the relevant tracking
  issue.
- [x] The test plan includes the commands used to validate the change.
- [x] The test results are included.
- [x] Documentation requirements were considered; no documentation changes are
  required because this adds a parser alias and model routing without
  introducing a new user-facing API.
</details>

