### PR TITLE
[Bugfix][Frontend] Support namespace tools for harmony/gpt-oss models in Responses API

### DIFF
--- a/tests/entrypoints/openai/parser/test_harmony_utils.py
+++ b/tests/entrypoints/openai/parser/test_harmony_utils.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
-from openai.types.responses import FunctionTool
+from openai.types.responses import FunctionTool, NamespaceTool
 from openai_harmony import DeveloperContent, Message, Role
 
 from tests.entrypoints.openai.utils import verify_harmony_messages
@@ -11,6 +11,7 @@ from vllm.entrypoints.openai.parser.harmony_utils import (
     auto_drop_analysis_messages,
     create_tool_definition,
     extract_function_from_recipient,
+    get_developer_message,
     get_system_message,
     has_custom_tools,
     is_function_recipient,
@@ -1065,3 +1066,117 @@ class TestResponseInputToHarmonyReasoningItem:
         msg = response_input_to_harmony(item, prev_responses=[])
 
         assert msg is None
+
+
+class TestGetDeveloperMessageNamespaceTools:
+    """Tests for get_developer_message handling of namespace tools."""
+
+    def test_namespace_tool_accepted(self):
+        """Namespace tools should not raise ValueError."""
+        namespace_tool = NamespaceTool(
+            type="namespace",
+            name="mcp__computer_use",
+            description="Computer control tools.",
+            tools=[
+                FunctionTool(
+                    type="function",
+                    name="get_app_state",
+                    description="Get the current state of an app.",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "app": {"type": "string"},
+                        },
+                        "required": ["app"],
+                    },
+                ),
+            ],
+        )
+        msg = get_developer_message(tools=[namespace_tool])
+        assert msg.author.role == Role.DEVELOPER
+        content = msg.content[0]
+        assert isinstance(content, DeveloperContent)
+        tool_names = [t.name for t in content.function_tools]
+        assert "mcp__computer_use__get_app_state" in tool_names
+
+    def test_namespace_tool_with_multiple_functions(self):
+        """Namespace tool with multiple inner functions should flatten all."""
+        namespace_tool = NamespaceTool(
+            type="namespace",
+            name="codex",
+            description="Codex tools.",
+            tools=[
+                FunctionTool(
+                    type="function",
+                    name="shell",
+                    description="Run a shell command.",
+                    parameters={
+                        "type": "object",
+                        "properties": {"cmd": {"type": "string"}},
+                        "required": ["cmd"],
+                    },
+                ),
+                FunctionTool(
+                    type="function",
+                    name="read_file",
+                    description="Read a file.",
+                    parameters={
+                        "type": "object",
+                        "properties": {"path": {"type": "string"}},
+                        "required": ["path"],
+                    },
+                ),
+            ],
+        )
+        msg = get_developer_message(tools=[namespace_tool])
+        content = msg.content[0]
+        tool_names = [t.name for t in content.function_tools]
+        assert "codex__shell" in tool_names
+        assert "codex__read_file" in tool_names
+
+    def test_mixed_function_and_namespace_tools(self):
+        """Mix of function and namespace tools should all be included."""
+        function_tool = FunctionTool(
+            type="function",
+            name="get_weather",
+            description="Get weather.",
+            parameters=_TOOL_PARAMETERS,
+        )
+        namespace_tool = NamespaceTool(
+            type="namespace",
+            name="mcp",
+            description="MCP tools.",
+            tools=[
+                FunctionTool(
+                    type="function",
+                    name="search",
+                    description="Search.",
+                    parameters=_TOOL_PARAMETERS,
+                ),
+            ],
+        )
+        msg = get_developer_message(tools=[function_tool, namespace_tool])
+        content = msg.content[0]
+        tool_names = [t.name for t in content.function_tools]
+        assert "get_weather" in tool_names
+        assert "mcp__search" in tool_names
+
+    def test_namespace_tool_none_description(self):
+        """Namespace inner tool with None description defaults to empty."""
+        namespace_tool = NamespaceTool(
+            type="namespace",
+            name="ns",
+            description="Namespace.",
+            tools=[
+                FunctionTool(
+                    type="function",
+                    name="tool_a",
+                    description=None,
+                    parameters=_TOOL_PARAMETERS,
+                ),
+            ],
+        )
+        msg = get_developer_message(tools=[namespace_tool])
+        content = msg.content[0]
+        tool_descs = {t.name: t for t in content.function_tools}
+        assert tool_descs["ns__tool_a"].description == ""

--- a/tests/entrypoints/openai/responses/test_harmony.py
+++ b/tests/entrypoints/openai/responses/test_harmony.py
@@ -1246,3 +1246,80 @@ async def test_system_prompt_structured_content(client: OpenAI, model_name: str)
     assert response is not None
     assert response.status == "completed"
     assert response.output_text is not None
+
+
+NAMESPACE_TOOL_SCHEMA = {
+    "type": "namespace",
+    "name": "codex",
+    "description": "Codex development tools.",
+    "tools": [
+        {
+            "type": "function",
+            "name": "shell",
+            "description": "Run a shell command and return stdout/stderr.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "cmd": {
+                        "type": "string",
+                        "description": "The shell command to execute.",
+                    }
+                },
+                "required": ["cmd"],
+                "additionalProperties": False,
+            },
+        }
+    ],
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_namespace_tool_calling(client: OpenAI, model_name: str):
+    """Namespace tools should be accepted and flattened for harmony models."""
+    tools = [NAMESPACE_TOOL_SCHEMA]
+
+    response = await retry_for_tool_call(
+        client,
+        model=model_name,
+        expected_tool_type="function_call",
+        input="Run 'echo hello' in the shell.",
+        tools=tools,
+        temperature=0.0,
+    )
+    assert response.status == "completed"
+    assert has_output_type(response, "function_call"), (
+        f"Expected function_call in output, got: "
+        f"{[getattr(o, 'type', None) for o in response.output]}"
+    )
+
+    tool_call = next(o for o in response.output if o.type == "function_call")
+    assert tool_call.name == "shell"
+    assert tool_call.namespace == "codex"
+    assert json.loads(tool_call.arguments).get("cmd") is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_namespace_tool_calling_streaming(client: OpenAI, model_name: str):
+    """Namespace tools in streaming mode should emit proper namespace fields."""
+    tools = [NAMESPACE_TOOL_SCHEMA]
+
+    response = await retry_streaming_for(
+        client,
+        model=model_name,
+        expected_event_type="response.output_item.done",
+        input="Run 'echo hello' in the shell.",
+        tools=tools,
+        temperature=0.0,
+    )
+    done_events = [
+        e
+        for e in response
+        if e.type == "response.output_item.done"
+        and getattr(e.item, "type", None) == "function_call"
+    ]
+    assert len(done_events) >= 1
+    tool_call = done_events[0].item
+    assert tool_call.name == "shell"
+    assert tool_call.namespace == "codex"

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -680,6 +680,104 @@ class TestHarmonyPreambleStreaming:
             assert "response.output_item.done" in type_names
 
 
+class TestHarmonyNamespaceToolStreaming:
+    """Tests for namespace tool name resolution in Harmony streaming events."""
+
+    @staticmethod
+    def _make_segment(*, channel, recipient, delta="{}"):
+        return Segment(channel=channel, recipient=recipient, delta=delta)
+
+    @staticmethod
+    def _make_previous_item(*, channel, recipient, text='{"cmd": "echo hi"}'):
+        content_part = MagicMock()
+        content_part.text = text
+        item = MagicMock()
+        item.channel = channel
+        item.recipient = recipient
+        item.content = [content_part]
+        return item
+
+    def test_delta_events_resolve_namespace(self) -> None:
+        """Streaming delta should emit resolved name + namespace fields."""
+        from vllm.entrypoints.openai.responses.streaming_events import (
+            emit_content_delta_events,
+        )
+        from vllm.tool_parsers.utils import ResponsesToolCallName
+
+        name_map = {
+            "codex__shell": ResponsesToolCallName(name="shell", namespace="codex"),
+        }
+        fn_names = frozenset({"codex__shell"})
+        segment = self._make_segment(
+            channel="commentary",
+            recipient="functions.codex__shell",
+            delta='{"cmd":',
+        )
+        state = StreamingState()
+
+        events = emit_content_delta_events(
+            segment, state, fn_names, tool_call_name_map=name_map
+        )
+
+        added_events = [e for e in events if e.type == "response.output_item.added"]
+        assert len(added_events) == 1
+        item = added_events[0].item
+        assert item.name == "shell"
+        assert item.namespace == "codex"
+
+    def test_done_events_resolve_namespace(self) -> None:
+        """Streaming done should emit resolved name + namespace fields."""
+        from vllm.entrypoints.openai.responses.streaming_events import (
+            emit_previous_item_done_events,
+        )
+        from vllm.tool_parsers.utils import ResponsesToolCallName
+
+        name_map = {
+            "codex__shell": ResponsesToolCallName(name="shell", namespace="codex"),
+        }
+        fn_names = frozenset({"codex__shell"})
+        previous = self._make_previous_item(
+            channel="commentary", recipient="functions.codex__shell"
+        )
+        state = StreamingState()
+        state.is_first_function_call_delta = True
+        state.current_item_id = "fc_test"
+        state.current_call_id = "call_test"
+        state.current_output_index = 0
+
+        events = emit_previous_item_done_events(
+            previous, state, fn_names, tool_call_name_map=name_map
+        )
+
+        done_events = [e for e in events if e.type == "response.output_item.done"]
+        assert len(done_events) == 1
+        item = done_events[0].item
+        assert item.name == "shell"
+        assert item.namespace == "codex"
+
+    def test_delta_events_no_namespace_passthrough(self) -> None:
+        """Without name_map, function name passes through unchanged."""
+        from vllm.entrypoints.openai.responses.streaming_events import (
+            emit_content_delta_events,
+        )
+
+        fn_names = frozenset({"get_weather"})
+        segment = self._make_segment(
+            channel="commentary",
+            recipient="functions.get_weather",
+            delta='{"lat":',
+        )
+        state = StreamingState()
+
+        events = emit_content_delta_events(segment, state, fn_names)
+
+        added_events = [e for e in events if e.type == "response.output_item.added"]
+        assert len(added_events) == 1
+        item = added_events[0].item
+        assert item.name == "get_weather"
+        assert item.namespace is None
+
+
 def _make_simple_context_with_output(text, token_ids, response_parser=None):
     """Create a SimpleContext with a RequestOutput containing the given text."""
     ctx = SimpleContext(response_parser=response_parser)

--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -25,6 +25,7 @@ from openai_harmony import (
 from vllm import envs
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionToolsParam
 from vllm.logger import init_logger
+from vllm.tool_parsers.utils import flat_namespace_tool_name
 
 logger = init_logger(__name__)
 
@@ -169,7 +170,7 @@ def get_developer_message(
     if instructions is not None and not envs.VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS:
         dev_msg_content = dev_msg_content.with_instructions(instructions)
     if tools is not None:
-        function_tools: list[Tool | ChatCompletionToolsParam] = []
+        function_tool_descriptions: list[ToolDescription] = []
         for tool in tools:
             if tool.type in (
                 "web_search_preview",
@@ -177,15 +178,25 @@ def get_developer_message(
                 "container",
             ):
                 pass
-
             elif tool.type == "function":
-                function_tools.append(tool)
+                function_tool_descriptions.append(create_tool_definition(tool))
+            elif tool.type == "namespace":
+                for namespaced_tool in tool.tools:
+                    if namespaced_tool.type != "function":
+                        continue
+                    flat_name = flat_namespace_tool_name(
+                        tool.name, namespaced_tool.name
+                    )
+                    function_tool_descriptions.append(
+                        ToolDescription.new(
+                            name=flat_name,
+                            description=namespaced_tool.description or "",
+                            parameters=namespaced_tool.parameters,
+                        )
+                    )
             else:
                 raise ValueError(f"tool type {tool.type} not supported")
-        if function_tools:
-            function_tool_descriptions = [
-                create_tool_definition(tool) for tool in function_tools
-            ]
+        if function_tool_descriptions:
             dev_msg_content = dev_msg_content.with_function_tools(
                 function_tool_descriptions
             )

--- a/vllm/entrypoints/openai/responses/harmony.py
+++ b/vllm/entrypoints/openai/responses/harmony.py
@@ -41,6 +41,10 @@ from vllm.entrypoints.openai.responses.protocol import (
     ResponsesRequest,
 )
 from vllm.logger import init_logger
+from vllm.tool_parsers.utils import (
+    ResponsesToolCallName,
+    resolve_responses_tool_call_name,
+)
 from vllm.utils import random_uuid
 
 logger = init_logger(__name__)
@@ -307,10 +311,16 @@ def _parse_browser_tool_call(message: Message, recipient: str) -> ResponseOutput
 
 
 def _parse_function_call(
-    message: Message, recipient: str, incomplete: bool = False
+    message: Message,
+    recipient: str,
+    incomplete: bool = False,
+    tool_call_name_map: dict[str, ResponsesToolCallName] | None = None,
 ) -> list[ResponseOutputItem]:
     """Parse function calls into function tool call items."""
     function_name = extract_function_from_recipient(recipient)
+    call_name = resolve_responses_tool_call_name(
+        function_name, tool_call_name_map=tool_call_name_map
+    )
     output_items = []
     for content in message.content:
         random_id = random_uuid()
@@ -318,7 +328,8 @@ def _parse_function_call(
             arguments=content.text,
             call_id=f"call_{random_id}",
             type="function_call",
-            name=function_name,
+            name=call_name.name,
+            namespace=call_name.namespace,
             id=f"fc_{random_id}",
             status="incomplete" if incomplete else "completed",
         )
@@ -436,6 +447,7 @@ def harmony_to_response_output(
     message: Message,
     function_tool_names: frozenset[str],
     incomplete: bool = False,
+    tool_call_name_map: dict[str, ResponsesToolCallName] | None = None,
 ) -> list[ResponseOutputItem]:
     """Parse a Harmony message into a list of output response items.
 
@@ -459,7 +471,12 @@ def harmony_to_response_output(
         # Function calls (with or without "functions." prefix)
         elif is_function_recipient(recipient, function_tool_names):
             output_items.extend(
-                _parse_function_call(message, recipient, incomplete=incomplete)
+                _parse_function_call(
+                    message,
+                    recipient,
+                    incomplete=incomplete,
+                    tool_call_name_map=tool_call_name_map,
+                )
             )
 
         # Built-in MCP tools (python, browser, container)

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -102,6 +102,7 @@ from vllm.parser import Parser, ParserManager
 from vllm.renderers.online_renderer import OnlineRenderer
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers.utils import build_responses_tool_call_name_map
 from vllm.utils import random_uuid
 from vllm.utils.collection_utils import as_list
 
@@ -808,13 +809,21 @@ class OpenAIServingResponses(GenerateBaseServing):
             harmony_msgs = context.messages[context.num_init_messages :]
             if harmony_msgs:
                 fn_names = context.function_tool_names
+                name_map = build_responses_tool_call_name_map(request.tools)
                 for msg in harmony_msgs[:-1]:
-                    output.extend(harmony_to_response_output(msg, fn_names))
+                    output.extend(
+                        harmony_to_response_output(
+                            msg,
+                            fn_names,
+                            tool_call_name_map=name_map,
+                        )
+                    )
                 output.extend(
                     harmony_to_response_output(
                         harmony_msgs[-1],
                         fn_names,
                         incomplete=context.last_append_flush_status,
+                        tool_call_name_map=name_map,
                     )
                 )
 
@@ -1418,6 +1427,7 @@ class OpenAIServingResponses(GenerateBaseServing):
         ],
     ) -> AsyncGenerator[StreamingResponsesResponse, None]:
         state = StreamingState()
+        name_map = build_responses_tool_call_name_map(request.tools)
 
         async for ctx in result_generator:
             assert isinstance(ctx, HarmonyContext)
@@ -1428,14 +1438,20 @@ class OpenAIServingResponses(GenerateBaseServing):
             for segment in ctx.last_append_segments:
                 if segment.delta:
                     for event in emit_content_delta_events(
-                        segment, state, ctx.function_tool_names
+                        segment,
+                        state,
+                        ctx.function_tool_names,
+                        tool_call_name_map=name_map,
                     ):
                         yield _increment_sequence_number_and_return(event)
 
                 elif completed_message := segment.completed_message:
                     # TODO: Fix browser emitted as MCP calls
                     for event in emit_previous_item_done_events(
-                        completed_message, state, ctx.function_tool_names
+                        completed_message,
+                        state,
+                        ctx.function_tool_names,
+                        tool_call_name_map=name_map,
                     ):
                         yield _increment_sequence_number_and_return(event)
 

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -248,6 +248,7 @@ def emit_function_call_delta_events(
     delta: str,
     function_name: str,
     state: StreamingState,
+    namespace: str | None = None,
 ) -> list[StreamingResponsesResponse]:
     """Emit events for function call argument deltas."""
     events: list[StreamingResponsesResponse] = []
@@ -257,6 +258,7 @@ def emit_function_call_delta_events(
         state.current_call_id = f"call_{random_uuid()}"
         tool_call_item = ResponseFunctionToolCall(
             name=function_name,
+            namespace=namespace,
             type="function_call",
             id=state.current_item_id,
             call_id=state.current_call_id,
@@ -480,6 +482,7 @@ def emit_function_call_done_events(
     function_name: str,
     arguments: str,
     state: StreamingState,
+    namespace: str | None = None,
 ) -> list[StreamingResponsesResponse]:
     """Emit events when a function call completes."""
     events: list[StreamingResponsesResponse] = []
@@ -497,6 +500,7 @@ def emit_function_call_done_events(
         type="function_call",
         arguments=arguments,
         name=function_name,
+        namespace=namespace,
         id=state.current_item_id,
         output_index=state.current_output_index,
         sequence_number=-1,
@@ -567,6 +571,7 @@ def emit_content_delta_events(
     segment: Segment,
     state: StreamingState,
     function_tool_names: frozenset[str] | None = None,
+    tool_call_name_map: dict[str, Any] | None = None,
 ) -> list[StreamingResponsesResponse]:
     """Emit events for content delta streaming based on channel type.
 
@@ -590,7 +595,12 @@ def emit_content_delta_events(
         fn_names = function_tool_names
         if is_function_recipient(recipient, fn_names):
             function_name = extract_function_from_recipient(recipient)
-            return emit_function_call_delta_events(delta, function_name, state)
+            call_name = resolve_responses_tool_call_name(
+                function_name, tool_call_name_map=tool_call_name_map
+            )
+            return emit_function_call_delta_events(
+                delta, call_name.name, state, namespace=call_name.namespace
+            )
         elif recipient == "python":
             return emit_code_interpreter_delta_events(delta, state)
         elif recipient.startswith("mcp.") or is_mcp_tool_by_namespace(
@@ -605,6 +615,7 @@ def emit_previous_item_done_events(
     previous_item: HarmonyMessage,
     state: StreamingState,
     function_tool_names: frozenset[str] | None = None,
+    tool_call_name_map: dict[str, Any] | None = None,
 ) -> list[StreamingResponsesResponse]:
     """Emit done events for the previous item when expecting a new start.
 
@@ -622,7 +633,12 @@ def emit_previous_item_done_events(
         # Deal with tool call
         if is_function_recipient(previous_item.recipient, function_tool_names):
             function_name = extract_function_from_recipient(previous_item.recipient)
-            return emit_function_call_done_events(function_name, text, state)
+            call_name = resolve_responses_tool_call_name(
+                function_name, tool_call_name_map=tool_call_name_map
+            )
+            return emit_function_call_done_events(
+                call_name.name, text, state, namespace=call_name.namespace
+            )
         elif previous_item.recipient == "python":
             return emit_code_interpreter_completion_events(previous_item, state)
         elif (


### PR DESCRIPTION
## Summary

Fixes #49493

Harmony/gpt-oss models reject namespace tools in the Responses API with `ValueError: tool type namespace not supported`. PR #47024 added namespace tool support for the non-harmony path but did not update the harmony code path.

This blocks [OpenAI Codex CLI](https://github.com/openai/codex) from working with self-hosted harmony models via vLLM, since Codex sends `namespace` tool types with every request.

## Changes

**Input (harmony_utils.py):** Handle `tool.type == "namespace"` in `get_developer_message()` by flattening namespace tools into function tool descriptions with `{namespace}__{name}` names, reusing the existing `flat_namespace_tool_name()` helper from `tool_parsers/utils.py`.

**Output (harmony.py + serving.py):** Resolve flat namespace tool names back to separate `name` + `namespace` fields in harmony output items using `resolve_responses_tool_call_name()`, matching the non-harmony Responses API behavior added in PR #47024.

**Tests:** 4 unit tests for namespace tool handling in `get_developer_message()`:
- Single namespace tool acceptance
- Multiple inner functions flattening
- Mixed function + namespace tools
- None description default handling

## Test Plan

```bash
pytest tests/entrypoints/openai/parser/test_harmony_utils.py::TestGetDeveloperMessageNamespaceTools -v
```

cc @aarnphm @chaunceyjiang @DarkLight1337 @russellb