### PR TITLE
[CPU] Bump triton-cpu pin to include autotune cache-key fix (#275)

### DIFF
--- a/.buildkite/hardware_tests/cpu.yaml
+++ b/.buildkite/hardware_tests/cpu.yaml
@@ -78,7 +78,7 @@ steps:
   commands:
     - |
       bash .buildkite/scripts/hardware_ci/run-cpu-test.sh 45m "
-      uv pip install git+https://github.com/triton-lang/triton-cpu.git@270e696d
+      uv pip install git+https://github.com/triton-lang/triton-cpu.git@a00d6c44ec55906cf2e66107621265d410b5f6a0
       VLLM_USE_V2_MODEL_RUNNER=1 pytest -x -v -s tests/models/language/generation/test_granite.py -m cpu_model
       # TODO: move to CPU-Kernel Tests once triton-cpu has a pre-built wheel
       pytest -x -v -s tests/v1/sample/test_topk_topp_sampler.py::TestTritonTopkTopp

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -181,7 +181,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     if [ "$TARGETARCH" = "amd64" ] || [ "$VLLM_CPU_X86" != "0" ]; then \
         git clone --recurse-submodules "https://github.com/triton-lang/triton-cpu.git"; \
         cd triton-cpu; \
-        git checkout "270e696d"; \
+        git checkout "a00d6c44ec55906cf2e66107621265d410b5f6a0"; \
         uv build --wheel --out-dir=../dist; \
     fi
 


### PR DESCRIPTION
## Purpose

Bump the triton-cpu pin in `docker/Dockerfile.cpu` from `270e696d` (a `main` commit from 2026-04-16) to the `v3.8.0` release tag.

## Test Plan

Built triton-cpu at `v3.8.0`, installed it into a CPU vLLM venv, and ran the V2 model runner on CPU against it (32-core AMD EPYC node).

```bash
python -c "import triton, triton.backends as b; print(triton.__version__, sorted(b.backends))"
python -c "from vllm.triton_utils.importing import HAS_TRITON; print(HAS_TRITON)"
```

## Test Result

```
triton 3.8.0+cpu.git5a4885bf   backends: ['amd', 'cpu', 'nvidia']
HAS_TRITON: True
```

So the V2 model runner is selected on CPU rather than falling back to V1.

On a hybrid model (Qwen3.5-4B W8A8) the V2 model runner runs correctly with greedy decoding plus `min_p`, presence and repetition penalties, `bad_words`, `logprobs`, `prompt_logprobs`, `top_k`, random sampling and `n=2`. 59 Triton kernels JIT-compile at runtime.

---