### PR TITLE
[Kernel] Skip out-of-window KV blocks in paged decode sliding-window path

### DIFF
--- a/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
@@ -146,10 +146,20 @@ def kernel_paged_attention_2d(
 
     num_blocks = cdiv_fn(seq_len, BLOCK_SIZE)
 
+    # Sliding-window decode: tokens below (seq_len - SLIDING_WINDOW) are fully
+    # masked out below, so their blocks cannot influence the output. Start the
+    # loop at the window edge so their K/V is never read; the score mask still
+    # trims the partial first block. Decode is bandwidth-bound, so this makes
+    # windowed-layer latency independent of context length.
+    if SLIDING_WINDOW > 0:
+        start_block = tl.maximum(seq_len - SLIDING_WINDOW, 0) // BLOCK_SIZE
+    else:
+        start_block = 0
+
     offs_n = tl.arange(0, BLOCK_SIZE)
     offs_d = tl.arange(0, HEAD_SIZE_PADDED)
     # iterate through tiles
-    for j in range(0, num_blocks):
+    for j in range(start_block, num_blocks):
         start_n = j * BLOCK_SIZE
         # Calculate the logical location within a non-standard physical block,
         # such as 544 in Qwen/Qwen3-Next-80B-A3B-Thinking.


### PR DESCRIPTION
## Purpose

`kernel_paged_attention_2d` in `chunked_prefill_paged_decode.py` iterates
KV blocks from 0 to `num_blocks` and applies the sliding window as a score
mask after K/V are already loaded:

```python
if SLIDING_WINDOW > 0:
    S = tl.where((context_len - seq_offset) < SLIDING_WINDOW, S, -10000)
```

Decode is bandwidth-bound, so windowed layers pay full-context memory
traffic per decoded token even though everything outside the window is
discarded. For a model like poolside/Laguna-S-2.1 (36 of 48 layers with a
512-token window) at 16K context, roughly 97 percent of the K/V reads in
those layers are wasted. The unified attention kernel already bounds its
tile loop to the window (`compute_tile_loop_bounds`); this brings the
paged decode kernel used by the ROCM_ATTN backend up to par.

## Change

Start the block loop at the window edge instead of 0. The existing score
mask still trims the partial first block, and the masked-out contributions
it removes underflow to exactly 0 in the softmax accumulation, so outputs
are unchanged.

## Measurements

gfx1151 (Strix Halo), bf16, GQA 4:1, head_dim 128, window 512, single
decode token, kernel-level timing over 100 iterations. Outputs checked
against a plain PyTorch paged-attention reference (max abs err 0.002 for
both stock and patched, bf16 rounding):

| seq_len | stock | patched | speedup |
|---------|-------|---------|---------|
| 512     | 117 us | 116 us | 1.0x |
| 2048    | 221 us | 114 us | 1.9x |
| 8192    | 661 us | 112 us | 5.9x |
| 16384   | 1520 us | 114 us | 13.4x |

The patched kernel's latency is independent of context length, which is
the behavior the sliding window is supposed to provide.

## Notes

- No behavior change for `SLIDING_WINDOW == 0` (start_block stays 0).
- ALiBi and sink paths are unaffected: sinks are accumulated before the
  loop, and ALiBi biases only apply to tokens inside the window.
- The 2D kernel only runs for single-token queries (`query_len == 1`
  guard at the top), so `context_len = seq_len - 1` is the query position
  and the window arithmetic matches the existing mask exactly.
