### PR TITLE
[Bugfix][CPU] Zero-pad MoE intermediate size for grouped-gemm TP alignment

### DIFF
--- a/tests/kernels/moe/test_cpu_fused_moe.py
+++ b/tests/kernels/moe/test_cpu_fused_moe.py
@@ -14,6 +14,7 @@ from vllm._custom_ops import (
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.cpu_fused_moe import (
     _CPU_MOE_ACT_FN,
+    CPUFusedMOE,
 )
 from vllm.platforms import CpuArchEnum, current_platform
 from vllm.utils.torch_utils import set_random_seed
@@ -346,3 +347,132 @@ def test_cpu_fused_moe_int8(
     )
 
     torch.testing.assert_close(output, ref_output, atol=2e-2, rtol=2e-2)
+
+
+# moe_intermediate_size not a multiple of 32, e.g. what tensor-parallel
+# sharding of moe_intermediate_size=704 at tp=4 produces (704 // 4 == 176).
+UNALIGNED_INTERMEDIATE_DIM = 176
+
+
+class _StubMoELayer(torch.nn.Module):
+    """Minimal stand-in for the real MoE layer module, exposing just what
+    CPUFusedMOE reads/replaces (w13_weight, w2_weight, activation, and
+    optionally w13_bias/w2_bias)."""
+
+    def __init__(
+        self,
+        w13_weight: torch.Tensor,
+        w2_weight: torch.Tensor,
+        activation: MoEActivation,
+        w13_bias: torch.Tensor | None = None,
+        w2_bias: torch.Tensor | None = None,
+    ):
+        super().__init__()
+        self.w13_weight = torch.nn.Parameter(w13_weight, requires_grad=False)
+        self.w2_weight = torch.nn.Parameter(w2_weight, requires_grad=False)
+        self.activation = activation
+        if w13_bias is not None:
+            self.w13_bias = torch.nn.Parameter(w13_bias, requires_grad=False)
+        if w2_bias is not None:
+            self.w2_bias = torch.nn.Parameter(w2_bias, requires_grad=False)
+
+
+@pytest.mark.parametrize("expert_num", EXPERT_NUM)
+@pytest.mark.parametrize("hidden_size", HIDDEN_DIM)
+@pytest.mark.parametrize("use_bias", USE_BIAS)
+@pytest.mark.parametrize("dtype", DTYPE)
+@pytest.mark.parametrize(
+    "act",
+    [MoEActivation.SILU, MoEActivation.GELU, MoEActivation.GELU_TANH],
+)
+def test_cpu_fused_moe_unaligned_intermediate_size(
+    default_vllm_config,
+    expert_num: int,
+    hidden_size: int,
+    use_bias: bool,
+    dtype: torch.dtype,
+    act: MoEActivation,
+):
+    """An unaligned per-partition moe_intermediate_size must still hit the
+    grouped-gemm fast path via automatic zero-padding, with numerically
+    correct output, instead of silently falling back to the much slower
+    per-expert torch loop."""
+    if current_platform.get_cpu_architecture() == CpuArchEnum.ARM:
+        pytest.skip("padding is only applied on the x86 AMX/vector kernels")
+
+    set_random_seed(0)
+    batch_size = 64
+    intermediate_size = UNALIGNED_INTERMEDIATE_DIM
+    topk_num = max(expert_num // 2, 1)
+    up_dim = 2 * intermediate_size
+
+    input = torch.randn((batch_size, hidden_size), dtype=dtype) / (
+        0.5 * hidden_size**0.5
+    )
+    w13 = torch.randn((expert_num, up_dim, hidden_size), dtype=dtype) / (
+        0.5 * hidden_size**0.5
+    )
+    w2 = torch.randn((expert_num, hidden_size, intermediate_size), dtype=dtype) / (
+        0.5 * intermediate_size**0.5
+    )
+    router_logits = torch.randn((batch_size, expert_num), dtype=dtype)
+    w13_bias = None
+    w2_bias = None
+    if use_bias:
+        w13_bias = torch.randn((expert_num, up_dim), dtype=dtype) / (0.5 * up_dim**0.5)
+        w2_bias = torch.randn((expert_num, hidden_size), dtype=dtype) / (
+            0.5 * hidden_size**0.5
+        )
+    score = torch.softmax(router_logits, dim=-1, dtype=torch.float32)
+    topk_weight, topk_ids = torch.topk(score, topk_num)
+    topk_ids = topk_ids.to(torch.int32)
+
+    ref_output = ref_fused_moe(
+        input, w13, w2, w13_bias, w2_bias, topk_weight, topk_ids, act
+    )
+
+    layer = _StubMoELayer(
+        w13.clone(),
+        w2.clone(),
+        act,
+        w13_bias.clone() if w13_bias is not None else None,
+        w2_bias.clone() if w2_bias is not None else None,
+    )
+
+    cpu_moe = CPUFusedMOE(layer)
+    assert cpu_moe.forward_method == cpu_moe.forward_grouped_gemm, (
+        "expected the padded intermediate size to hit the grouped-gemm fast path"
+    )
+
+    output = cpu_moe.forward_method(
+        layer, input, topk_weight, topk_ids, act, expert_num, False
+    )
+
+    atol, rtol = get_default_atol(output), get_default_rtol(output)
+    torch.testing.assert_close(output, ref_output, atol=atol, rtol=rtol)
+
+
+def test_cpu_fused_moe_unaligned_intermediate_size_swigluoai(default_vllm_config):
+    """swigluoai's interleaved gate/up layout isn't padded automatically. On
+    AMX-capable CPUs this must raise rather than silently falling back to
+    the (correct but much slower) per-expert torch loop; elsewhere it should
+    fall back exactly as before."""
+    set_random_seed(0)
+    expert_num = 8
+    hidden_size = 128
+    intermediate_size = UNALIGNED_INTERMEDIATE_DIM
+    dtype = torch.bfloat16
+    up_dim = 2 * intermediate_size
+
+    layer = _StubMoELayer(
+        torch.randn((expert_num, up_dim, hidden_size), dtype=dtype),
+        torch.randn((expert_num, hidden_size, intermediate_size), dtype=dtype),
+        MoEActivation.SWIGLUOAI,
+    )
+
+    if torch.cpu._is_amx_tile_supported():
+        with pytest.raises(RuntimeError):
+            CPUFusedMOE(layer)
+    else:
+        cpu_moe = CPUFusedMOE(layer)
+        assert cpu_moe.forward_method == cpu_moe.forward_torch

--- a/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
@@ -20,6 +20,11 @@ from vllm.platforms import CpuArchEnum, current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
 
 _CPU_MOE_LAYER_CACHE = {}
+# The CPU grouped-gemm MoE kernels (AMX and vector) tile the expert
+# intermediate ("N") dimension in blocks of this size and have no tail/
+# remainder handling, so a shard is only eligible for the fast path when
+# its per-partition intermediate size is a multiple of it.
+_MOE_GROUPED_GEMM_N_TILE = 32
 
 
 def _swigluoai_forward_native(
@@ -230,6 +235,7 @@ class CPUFusedMOE:
     """CPU-based fused MoE implementation."""
 
     def __init__(self, layer: torch.nn.Module) -> None:
+        self._pad_moe_intermediate_for_grouped_gemm(layer)
         use_grouped_gemm, isa = self.check_grouped_gemm(layer)
         self.isa = isa
         if use_grouped_gemm:
@@ -284,6 +290,69 @@ class CPUFusedMOE:
             apply_router_weight_on_input,
         )
 
+    def _pad_moe_intermediate_for_grouped_gemm(self, layer: torch.nn.Module) -> None:
+        """Zero-pad the per-partition MoE intermediate dim up to a multiple
+        of _MOE_GROUPED_GEMM_N_TILE, so the AMX/vector grouped-gemm kernels
+        can be used even when TP sharding (moe_intermediate_size // tp_size)
+        lands on an unaligned value (e.g. moe_intermediate_size=704 at tp=4
+        -> 176). Only applies to the x86 (AMX/vec) kernels and half-split
+        gate/up activations; interleaved layouts (swigluoai) are left
+        untouched.
+        """
+        if not hasattr(torch.ops._C, "prepack_moe_weight"):
+            return
+        if current_platform.get_cpu_architecture() == CpuArchEnum.ARM:
+            return
+
+        intermediate_size = layer.w2_weight.size(2)
+        remainder = intermediate_size % _MOE_GROUPED_GEMM_N_TILE
+        if remainder == 0:
+            return
+        if layer.activation == MoEActivation.SWIGLUOAI:
+            return
+
+        pad = _MOE_GROUPED_GEMM_N_TILE - remainder
+        padded_size = intermediate_size + pad
+        num_experts, _, hidden_size = layer.w13_weight.shape
+
+        new_w13 = layer.w13_weight.new_zeros(num_experts, 2 * padded_size, hidden_size)
+        new_w13[:, :intermediate_size] = layer.w13_weight[:, :intermediate_size]
+        new_w13[:, padded_size : padded_size + intermediate_size] = layer.w13_weight[
+            :, intermediate_size:
+        ]
+        replace_parameter(layer, "w13_weight", new_w13)
+
+        new_w2 = layer.w2_weight.new_zeros(num_experts, hidden_size, padded_size)
+        new_w2[:, :, :intermediate_size] = layer.w2_weight
+        replace_parameter(layer, "w2_weight", new_w2)
+
+        if hasattr(layer, "w13_bias"):
+            new_bias = layer.w13_bias.new_zeros(num_experts, 2 * padded_size)
+            new_bias[:, :intermediate_size] = layer.w13_bias[:, :intermediate_size]
+            new_bias[:, padded_size : padded_size + intermediate_size] = layer.w13_bias[
+                :, intermediate_size:
+            ]
+            replace_parameter(layer, "w13_bias", new_bias)
+
+    def _grouped_gemm_alignment_error(self, layer: torch.nn.Module) -> str:
+        # w2's input size is the per-partition MoE intermediate size (the
+        # dimension TP-sharding splits), and it's what most commonly breaks
+        # alignment, e.g. moe_intermediate_size=704 at tp=4 gives
+        # 704 // 4 == 176, which isn't a multiple of 32.
+        intermediate_size_per_partition = layer.w2_weight.size(2)
+        return (
+            "CPU fused-MoE AMX grouped-gemm kernel cannot be used for a "
+            f"layer with w13 shape {tuple(layer.w13_weight.shape)} / w2 "
+            f"shape {tuple(layer.w2_weight.shape)}: the per-partition MoE "
+            f"intermediate size ({intermediate_size_per_partition}) is not "
+            f"a multiple of {_MOE_GROUPED_GEMM_N_TILE}, and automatic "
+            "zero-padding could not resolve this (typically because the "
+            "activation uses an interleaved gate/up layout, e.g. "
+            "swigluoai). vLLM refuses to silently fall back to the much "
+            "slower per-expert torch loop on AMX-capable CPUs; consider a "
+            "different --tensor-parallel-size."
+        )
+
     def check_grouped_gemm(
         self,
         layer: torch.nn.Module,
@@ -297,20 +366,19 @@ class CPUFusedMOE:
         w2_input_size = layer.w2_weight.size(2)
         w2_output_size = layer.w2_weight.size(1)
 
-        if not (w13_output_size % 32 == 0 and w2_output_size % 32 == 0):
-            return False, "none"
-
         supports_amx = torch.cpu._is_amx_tile_supported()
-
-        if (
-            supports_amx
-            and dtype == torch.bfloat16
-            and w13_input_size % 32 == 0
-            and w2_input_size % 32 == 0
-        ):
-            return True, "amx"
-
         if supports_amx:
+            if (
+                dtype == torch.bfloat16
+                and w13_output_size % 32 == 0
+                and w2_output_size % 32 == 0
+                and w13_input_size % 32 == 0
+                and w2_input_size % 32 == 0
+            ):
+                return True, "amx"
+            raise RuntimeError(self._grouped_gemm_alignment_error(layer))
+
+        if not (w13_output_size % 32 == 0 and w2_output_size % 32 == 0):
             return False, "none"
 
         supports_neon = current_platform.get_cpu_architecture() == CpuArchEnum.ARM
@@ -321,8 +389,7 @@ class CPUFusedMOE:
                 and w2_input_size % 4 == 0
             ):
                 return True, "neon"
-            else:
-                return False, "none"
+            return False, "none"
 
         return True, "vec"
 


### PR DESCRIPTION
## Purpose

The CPU AMX/vector grouped-gemm MoE kernels (`csrc/cpu/cpu_fused_moe.cpp`) tile the expert intermediate dimension in fixed 32-wide blocks with no tail/remainder handling. `CPUFusedMOE.check_grouped_gemm` only enables the fast kernel when the per-partition `moe_intermediate_size` (i.e. `moe_intermediate_size // tp_size`) is a multiple of 32; otherwise it silently falls back to `cpu_fused_moe_torch`, a per-expert Python loop.

For `google/gemma-4-26B-A4B-it` (`moe_intermediate_size=704`, 128 experts), `tp=2` shards to `352` (32-aligned → fast kernel) but `tp=4` shards to `176` (not aligned → silent fallback), so `tp=4` throughput was *lower* than `tp=2` despite more parallelism, with no indication anything had gone wrong.

Profiling on a 2-socket Xeon 6972P confirmed the fallback (`cpu_fused_moe_torch`) consumed 74% of total CPU time under `tp=4`, dominated by ~164k individual `aten::mm` calls (one per active expert per layer per step) averaging 56µs each — call/dispatch overhead, not compute.

## Fix

Zero-pad the per-partition MoE intermediate dimension up to the next multiple of 32 before prepacking (`CPUFusedMOE._pad_moe_intermediate_for_grouped_gemm`, called first in `CPUFusedMOE.__init__`), so the fast kernel can be used regardless of how TP sharding lands, at the cost of a little wasted compute on the padded (always-zero) channels — negligible for the misalignment sizes this actually produces (at most 31 out of the true intermediate size).

Key correctness points (see comments in the diff):
- Padding is inserted **between** the gate and up blocks, not appended at the end, since the kernel treats w13's output as two contiguous halves at a fixed offset (`output_size_13/2`) for `silu`/`gelu`/`gelu_tanh`. Appending at the end would shift that offset and corrupt the "up" half.
- Padding is **skipped** for the interleaved `swigluoai` gate/up layout (gate = even columns, up = odd columns) since its padding scheme isn't the same and isn't implemented here, and on ARM (whose vector/NEON kernel already tolerates a much looser 4-element alignment, so it's unaffected).
- Padded rows/columns are exact zeros on both sides (`w13`'s new gate/up rows and `w2`'s new input columns), so they mathematically contribute nothing to the result regardless of the activation applied to them.
- On AMX-capable hardware, if grouped-gemm still can't be constructed after padding (e.g. `swigluoai` with an unaligned shard), `check_grouped_gemm` now **raises** instead of silently falling back to the much slower per-expert loop — this class of perf cliff is severe enough (3-4x) that failing loudly is preferable to a silent regression. Non-AMX platforms (plain vector kernel, ARM/NEON) keep the existing silent-fallback behavior, unchanged.

## Why this isn't a duplicate

I searched for open issues/PRs before starting (no existing issue reports this exact CPU tp=4-vs-tp=2 regression). There is real precedent for this general *pattern* of fix (pad MoE intermediate size for TP-induced kernel-tile misalignment) in other backends, but none touch the CPU code path:
- #38833 pads for the same `gemma-4-26B-A4B-it`/`moe_intermediate_size=704` case, but for ROCm's AITER CK GEMM path (`vllm/model_executor/layers/fused_moe/oracle/unquantized.py`), a different file/kernel with a 128-wide tile requirement.
- #48624 fixes a similar unaligned-intermediate crash for FlashInfer/CUTLASS NVFP4 and FP8 kernels (`flashinfer_fp4_moe.py`/`flashinfer_utils.py`).
- #38166 / #36807 are similar alignment fixes for ROCm CK MXFP4 and Marlin FP8, respectively.

None of these touch `vllm/model_executor/layers/fused_moe/cpu_fused_moe.py` or the CPU AMX/vector kernels. I also checked #43653 (adds `swiglustep`/`relu2` CPU MoE activations, currently open) — both of its new activations use the same contiguous half-split layout as `silu`/`gelu`/`gelu_tanh`, so this fix's `!= MoEActivation.SWIGLUOAI` check (rather than an allowlist of the 3 currently-supported half-split activations) will continue to pad correctly for them if/when that PR lands.

## Test Plan / Results

**Unit tests** — extended `tests/kernels/moe/test_cpu_fused_moe.py` with 13 new cases exercising `CPUFusedMOE` end-to-end with `intermediate_size=176` (the exact tp=4 shard size for this model): SILU/GELU/GELU_TANH × bias/no-bias, asserting the padded layer selects the grouped-gemm fast path and its output matches a reference implementation computed on the *original unpadded* weights, within tolerance; plus a `swigluoai` case asserting it raises on AMX hardware and falls back unchanged elsewhere.

```
$ python -m pytest tests/kernels/moe/test_cpu_fused_moe.py -v
================= 205 passed, 14 warnings in 221.00s (0:03:40) =================
```
(192 pre-existing cases unaffected + 13 new cases, all passing.)

**End-to-end benchmark** on a 2-socket Xeon 6972P (AMX-capable), `google/gemma-4-26B-A4B-it`, `--dtype=bfloat16 --no-enable-prefix-caching`, `vllm bench serve --dataset-name random --num-prompts 24 --random-input-len=128 --random-output-len=128 --request-rate=inf --num-warmups=8 --temperature=0 --ignore-eos`:

| | tp=2 | tp=4 (before) | tp=4 (after this fix) |
|---|---|---|---|
| Output token throughput | 260.45 tok/s | 103.29 tok/s | **394.78 tok/s** |
| Mean TPOT | 85.44 ms | 204.28 ms | **55.21 ms** |

tp=4 now correctly beats tp=2 (was the opposite before this fix), a ~3.8x improvement at tp=4.

**Correctness sanity check**: served the fixed tp=4 model and sent a chat completion request ("What is the capital of France?") — coherent, correct response ("The capital of France is Paris.").

## AI assistance disclosure

This fix was investigated, implemented, and tested with AI assistance (Claude Code): the root-cause profiling, the padding design, the new tests, and the benchmark/test runs and results reported above were all performed by the assistant. I am submitting this PR and take responsibility for it; I have gone through the diff and the reasoning above.
