### PR TITLE
[ROCm][CI] Fix mi300_1: Kernels MoE Test failures caused by the wrong device being used during tensor construction

### DIFF
--- a/tests/kernels/moe/test_block_int8.py
+++ b/tests/kernels/moe/test_block_int8.py
@@ -82,12 +82,6 @@ def torch_w8a8_block_int8_moe(a, w1, w2, w1_s, w2_s, score, topk, block_shape):
     ).sum(dim=1)
 
 
-@pytest.fixture(autouse=True, scope="module")
-def setup_cuda():
-    """Sets the default CUDA device for all tests in this module."""
-    torch.set_default_device("cuda")
-
-
 @pytest.mark.parametrize(("M", "N", "K"), MNK_FACTORS)
 @pytest.mark.parametrize("E", E)
 @pytest.mark.parametrize("topk", TOP_KS)
@@ -99,9 +93,10 @@ def test_w8a8_block_int8_fused_moe(M, N, K, E, topk, block_size, dtype, seed):
     """Tests the fused_moe kernel with W8A8 INT8 block quantization against a
     native torch reference."""
     torch.manual_seed(seed)
+    device = "cuda"
 
-    a = torch.randn((M, K), dtype=dtype) / 10
-    score = torch.randn((M, E), dtype=dtype)
+    a = torch.randn((M, K), dtype=dtype, device=device) / 10
+    score = torch.randn((M, E), dtype=dtype, device=device)
     topk_weights, topk_ids, _ = fused_topk(a, score.float(), topk, False)
 
     w1, w2, quant_config = make_test_quant_config(

--- a/tests/kernels/moe/test_triton_moe_ptpc_fp8.py
+++ b/tests/kernels/moe/test_triton_moe_ptpc_fp8.py
@@ -102,12 +102,6 @@ def torch_w8a8_per_column_moe(a, w1, w2, w1_s, w2_s, score, topk):
     ).sum(dim=1)
 
 
-@pytest.fixture(autouse=True, scope="module")
-def setup_cuda():
-    """Sets the default CUDA device for all tests in this module."""
-    torch.set_default_device("cuda")
-
-
 DTYPES = [torch.half, torch.bfloat16]
 M = [1, 33]
 N = [128, 1024]
@@ -124,6 +118,7 @@ SEEDS = [0]
 @torch.inference_mode()
 def test_w8a8_fp8_fused_moe(M, N, K, E, topk, dtype, seed):
     torch.manual_seed(seed)
+    device = "cuda"
     # Initialize int8 quantization parameters
     factor_for_scale = 1e-2
     finfo = torch.finfo(torch.float8_e4m3fn)
@@ -132,19 +127,19 @@ def test_w8a8_fp8_fused_moe(M, N, K, E, topk, dtype, seed):
 
     # Input tensor
     # M * K
-    a = torch.randn((M, K), dtype=dtype) / 10
+    a = torch.randn((M, K), dtype=dtype, device=device) / 10
 
     # Generate int8 weights
-    w1_fp32 = (torch.rand((E, 2 * N, K), dtype=torch.float32) - 0.5) * 2
+    w1_fp32 = (torch.rand((E, 2 * N, K), dtype=torch.float32, device=device) - 0.5) * 2
     w1 = (w1_fp32 * fp8_max).clamp(min=fp8_min, max=fp8_max).to(torch.float8_e4m3fn)
 
-    w2_fp32 = (torch.rand((E, K, N), dtype=torch.float32) - 0.5) * 2
+    w2_fp32 = (torch.rand((E, K, N), dtype=torch.float32, device=device) - 0.5) * 2
     w2 = (w2_fp32 * fp8_max).clamp(min=fp8_min, max=fp8_max).to(torch.float8_e4m3fn)
 
     # Generate scale for each column (per-column quantization)
     w1_s = torch.rand(E, 2 * N, device=w1_fp32.device) * factor_for_scale
     w2_s = torch.rand(E, K, device=w2_fp32.device) * factor_for_scale
-    score = torch.randn((M, E), dtype=dtype)
+    score = torch.randn((M, E), dtype=dtype, device=device)
 
     with set_current_vllm_config(vllm_config):
         ref_out = torch_w8a8_per_column_moe(a, w1, w2, w1_s, w2_s, score, topk)


### PR DESCRIPTION
## Purpose
`kernels/moe/test_block_int8.py`(MI300, MI355) and `test_triton_moe_ptpc_fp8.py` (MI355) created tensors without explicitly specifying the device, and instead relied on a module scoped fixture which set the default device to cuda.

PR #49423 introduced a conftest.py for tests/kernels which defines a per-function fixture which resets the default torch device.

The module scoped fixture would set the default device to cuda for the first test case, which would then be reset by the per function fixture, so all subsequent tests would not have their default device set to cuda, since the module scoped fixture would only run at the start of the module.

Fixed by removing the per module fixtures for the aforementioned files and explicitly specifying the device for tensor creation.

## Test Plan
 for x in {0..4}; do pytest -v -s kernels/moe --ignore=kernels/moe/test_modular_oai_triton_moe.py --shard-id=$x --num-shards=5 && pytest -v -s kernels/moe/test_modular_oai_triton_moe.py --shard-id=$x --num-shards=5; done

## Test Result
Before:
For MI300:
FAILED kernels/moe/test_block_int8.py::test_w8a8_block_int8_fused_moe[0-dtype0-block_size0-2-8-128-4096-512] - NotImplementedError: Could not run '_moe_C::topk_softmax' with arguments from the 'CPU' backend. 
likewise for all other test_block_int8.py tests

For MI355:
FAILED kernels/moe/test_block_int8.py::test_w8a8_block_int8_fused_moe[0-dtype0-block_size0-2-8-128-4096-512] - NotImplementedError: Could not run '_moe_C::topk_softmax' with arguments from the 'CPU' backend.
likewise for all other test_block_int8.py tests

FAILED kernels/moe/test_triton_moe_ptpc_fp8.py::test_w8a8_fp8_fused_moe[33-128-256-8-6-dtype18-0] - NotImplementedError: Could not run '_C::dynamic_per_token_scaled_fp8_quant' with arguments from the 'CPU' backend.
likewise for all other test_triton_moe_ptpc_fp8.py tests