### PR TITLE
[Bugfix] Hoist $defs/definitions in Cohere parser tool schema composition

### DIFF
--- a/tests/reasoning/test_cohere_command_reasoning_parser.py
+++ b/tests/reasoning/test_cohere_command_reasoning_parser.py
@@ -24,11 +24,13 @@ from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.reasoning.cohere_command_reasoning_parser import (
     CohereCommand3ReasoningParser,
     CohereCommand4ReasoningParser,
+    CohereNormalizedTool,
     _has_effective_tools,
     _melody_citations_to_vllm,
     _melody_sources_to_vllm,
     _response_format_type,
     _schema_dict_from_structured_outputs,
+    collect_tool_schema,
     convert_schema_to_structural_tags,
 )
 from vllm.sampling_params import StructuredOutputsParams
@@ -299,6 +301,52 @@ GET_WEATHER_TOOL = {
             "properties": {"city": {"type": "string"}},
         },
     },
+}
+# Shape agentic frameworks (e.g. pydantic-ai) emit for a nested model
+# argument (get_weather(location: Location)).
+NESTED_DEFS_PARAMETERS = {
+    "$defs": {
+        "Location": {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string"},
+                "country": {"type": "string"},
+            },
+            "required": ["city"],
+        }
+    },
+    "type": "object",
+    "properties": {"location": {"$ref": "#/$defs/Location"}},
+    "required": ["location"],
+}
+NESTED_DEFS_TOOL = {
+    "type": "function",
+    "function": {"name": "get_weather", "parameters": NESTED_DEFS_PARAMETERS},
+}
+# Recursion can never be inlined away, so it must survive as a root-level $def.
+RECURSIVE_DEFS_PARAMETERS = {
+    "$defs": {
+        "Finding": {
+            "type": "object",
+            "properties": {
+                "note": {"type": "string"},
+                "related": {"type": "array", "items": {"$ref": "#/$defs/Finding"}},
+            },
+        }
+    },
+    "type": "object",
+    "properties": {"finding": {"$ref": "#/$defs/Finding"}},
+}
+# Same nested-model schema in draft-07 style ("definitions" instead of "$defs").
+DRAFT07_DEFINITIONS_PARAMETERS = {
+    "definitions": {
+        "Location": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+        }
+    },
+    "type": "object",
+    "properties": {"location": {"$ref": "#/definitions/Location"}},
 }
 VALID_STRUCTURAL_TAG = {
     "type": "structural_tag",
@@ -690,3 +738,34 @@ class TestMelodySourceResolution:
         assert out is not None
         assert out[0].type == "THINKING_CONTENT"
         assert out[0].sources[0].id == "d0"
+
+
+class TestCollectToolSchemaDefs:
+    def test_nested_defs_tool_adjust_request(self, parser) -> None:
+        o = parser.adjust_request(
+            _make_chat_request(tools=[NESTED_DEFS_TOOL], tool_choice="auto"),
+        )
+        assert "grammar" in _content_types(o.structured_outputs.structural_tag)
+
+    def test_recursive_defs(self) -> None:
+        grammar = collect_tool_schema(
+            [CohereNormalizedTool(name="report", parameters=RECURSIVE_DEFS_PARAMETERS)]
+        )
+        assert "root ::=" in grammar
+
+    def test_draft07_definitions(self) -> None:
+        grammar = collect_tool_schema(
+            [
+                CohereNormalizedTool(
+                    name="get_weather", parameters=DRAFT07_DEFINITIONS_PARAMETERS
+                )
+            ]
+        )
+        assert "root ::=" in grammar
+
+    def test_input_parameters_not_mutated(self) -> None:
+        params = json.loads(json.dumps(NESTED_DEFS_PARAMETERS))
+        collect_tool_schema(
+            [CohereNormalizedTool(name="get_weather", parameters=params)]
+        )
+        assert params == NESTED_DEFS_PARAMETERS

--- a/tests/reasoning/test_cohere_command_reasoning_parser.py
+++ b/tests/reasoning/test_cohere_command_reasoning_parser.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import pytest
 from pydantic import ValidationError
+from xgrammar.testing import _is_grammar_accept_string
 
 from vllm.entrypoints.generate.base.protocol import (
     JsonSchemaResponseFormat,
@@ -24,11 +25,13 @@ from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.reasoning.cohere_command_reasoning_parser import (
     CohereCommand3ReasoningParser,
     CohereCommand4ReasoningParser,
+    CohereNormalizedTool,
     _has_effective_tools,
     _melody_citations_to_vllm,
     _melody_sources_to_vllm,
     _response_format_type,
     _schema_dict_from_structured_outputs,
+    collect_tool_schema,
     convert_schema_to_structural_tags,
 )
 from vllm.sampling_params import StructuredOutputsParams
@@ -264,6 +267,52 @@ GET_WEATHER_TOOL = {
             "properties": {"city": {"type": "string"}},
         },
     },
+}
+# Shape agentic frameworks (e.g. pydantic-ai) emit for a nested model
+# argument (get_weather(location: Location)).
+NESTED_DEFS_PARAMETERS = {
+    "$defs": {
+        "Location": {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string"},
+                "country": {"type": "string"},
+            },
+            "required": ["city"],
+        }
+    },
+    "type": "object",
+    "properties": {"location": {"$ref": "#/$defs/Location"}},
+    "required": ["location"],
+}
+NESTED_DEFS_TOOL = {
+    "type": "function",
+    "function": {"name": "get_weather", "parameters": NESTED_DEFS_PARAMETERS},
+}
+# Recursion can never be inlined away, so it must survive as a root-level $def.
+RECURSIVE_DEFS_PARAMETERS = {
+    "$defs": {
+        "Finding": {
+            "type": "object",
+            "properties": {
+                "note": {"type": "string"},
+                "related": {"type": "array", "items": {"$ref": "#/$defs/Finding"}},
+            },
+        }
+    },
+    "type": "object",
+    "properties": {"finding": {"$ref": "#/$defs/Finding"}},
+}
+# Same nested-model schema in draft-07 style ("definitions" instead of "$defs").
+DRAFT07_DEFINITIONS_PARAMETERS = {
+    "definitions": {
+        "Location": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+        }
+    },
+    "type": "object",
+    "properties": {"location": {"$ref": "#/definitions/Location"}},
 }
 VALID_STRUCTURAL_TAG = {
     "type": "structural_tag",
@@ -775,3 +824,56 @@ class TestParserStreamingEndToEnd:
         # boundary and never emits a delta with both fields set.
         for d in deltas:
             assert not (d.reasoning is not None and d.content is not None)
+
+
+class TestCollectToolSchemaDefs:
+    def test_nested_defs_tool_adjust_request(self, parser) -> None:
+        o = parser.adjust_request(
+            _make_chat_request(tools=[NESTED_DEFS_TOOL], tool_choice="auto"),
+        )
+        assert "grammar" in _content_types(o.structured_outputs.structural_tag)
+
+    @staticmethod
+    def _tool_calls_json(name: str, parameters: dict) -> str:
+        return json.dumps(
+            [{"tool_call_id": "0", "tool_name": name, "parameters": parameters}]
+        )
+
+    def test_recursive_defs(self) -> None:
+        grammar = collect_tool_schema(
+            [CohereNormalizedTool(name="report", parameters=RECURSIVE_DEFS_PARAMETERS)]
+        )
+        nested = {"note": "a", "related": [{"note": "b", "related": []}]}
+        assert _is_grammar_accept_string(
+            grammar, self._tool_calls_json("report", {"finding": nested})
+        )
+        # Type constraints inside the $def must be enforced, proving the
+        # hoisted definitions were reattached rather than dropped.
+        bad = {"note": 1, "related": []}
+        assert not _is_grammar_accept_string(
+            grammar, self._tool_calls_json("report", {"finding": bad})
+        )
+
+    def test_draft07_definitions(self) -> None:
+        grammar = collect_tool_schema(
+            [
+                CohereNormalizedTool(
+                    name="get_weather", parameters=DRAFT07_DEFINITIONS_PARAMETERS
+                )
+            ]
+        )
+        assert _is_grammar_accept_string(
+            grammar,
+            self._tool_calls_json("get_weather", {"location": {"city": "Prague"}}),
+        )
+        assert not _is_grammar_accept_string(
+            grammar,
+            self._tool_calls_json("get_weather", {"location": {"city": 1}}),
+        )
+
+    def test_input_parameters_not_mutated(self) -> None:
+        params = json.loads(json.dumps(NESTED_DEFS_PARAMETERS))
+        collect_tool_schema(
+            [CohereNormalizedTool(name="get_weather", parameters=params)]
+        )
+        assert params == NESTED_DEFS_PARAMETERS

--- a/vllm/reasoning/cohere_command_reasoning_parser.py
+++ b/vllm/reasoning/cohere_command_reasoning_parser.py
@@ -109,22 +109,25 @@ def collect_tool_schema(tool_schema: list[CohereNormalizedTool]) -> str:
     tool_dictionary: dict[str, str] = {}
     for tool in tool_schema:
         tool_name = tool["name"]
-        tool_parameters = json.dumps(tool["parameters"])
-        json_schema = f"""{{
-                        "type": "object",
-                        "properties": {{
-                            "tool_call_id": {{
-                                "type": "string",
-                                "pattern": "^[0-9]+$"
-                            }},
-                            "tool_name": {{
-                                "type": "string",
-                                "const": "{tool_name}"
-                            }},
-                            "parameters": {tool_parameters}
-                            }}
-                            }}"""
-        tool_grammar = str(xgr.Grammar.from_json_schema(json_schema))
+        # Copy so hoisting below does not mutate the request's tool definition.
+        tool_parameters = dict(tool["parameters"])
+        json_schema: dict[str, Any] = {
+            "type": "object",
+            "properties": {
+                "tool_call_id": {"type": "string", "pattern": "^[0-9]+$"},
+                "tool_name": {"type": "string", "const": tool_name},
+                "parameters": tool_parameters,
+            },
+        }
+        # Hoist definition blocks to the envelope root so root-anchored $ref
+        # pointers ("#/$defs/X", "#/definitions/X") still resolve after the
+        # tool schema is nested under "properties.parameters". Same pattern as
+        # _get_tool_schema_defs in vllm/tool_parsers/utils.py; no cross-tool
+        # merging needed here since each tool gets its own grammar.
+        for defs_key in ("$defs", "definitions"):
+            if defs_key in tool_parameters:
+                json_schema[defs_key] = tool_parameters.pop(defs_key)
+        tool_grammar = str(xgr.Grammar.from_json_schema(json.dumps(json_schema)))
         for match in re.findall(r"\b(\w+)\s*::=", tool_grammar):
             tool_grammar = re.sub(
                 rf"\b{re.escape(match)}\b", tool_name + match, tool_grammar


### PR DESCRIPTION


## Purpose

Fix a bug where any `/v1/chat/completions` request with tools whose JSON Schema
contains `$defs`/`definitions` fails with HTTP 500 on Cohere models served with
`--reasoning-parser cohere_command3|cohere_command4`.

Resolves the bug class reported in #16467 (closed as stale, never fixed) for the
Cohere reasoning parser path specifically. Other parsers that compose their own
grammars are out of scope (see the GLM case in #47175); the generic tool path in
`vllm/tool_parsers/utils.py` already hoists `$defs` and is unaffected.

**Root cause.** `collect_tool_schema` in
`vllm/reasoning/cohere_command_reasoning_parser.py` builds the constrained-decoding
grammar for tool calls by nesting each tool's `parameters` schema inside a
`{tool_call_id, tool_name, parameters}` envelope. The tool schema was spliced in
verbatim, so a definitions block originally at the schema root ends up under
`properties.parameters`, while its `$ref` pointers (`#/$defs/X`) remain
root-anchored. xgrammar then correctly rejects the dangling JSON pointer:

```text
RuntimeError: Cannot find field $defs in #/$defs/X
```

The request fails during preprocessing, before generation. Agentic frameworks such as pydantic-ai emit `$defs`
for any nested model, so this breaks effectively all tools defined via such
frameworks (see user reports in #16467).

**Minimal repro** against a Cohere model served with
`--reasoning-parser cohere_command4 --tool-call-parser cohere_command4 --enable-auto-tool-choice`
(any tool schema whose parameters carry `$defs` + `$ref`; a flat schema without
`$defs` does not reproduce):

```bash
curl -s http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "CohereLabs/North-Mini-Code-1.0",
    "messages": [{"role": "user", "content": "Weather in Prague?"}],
    "tool_choice": "auto",
    "tools": [{
      "type": "function",
      "function": {
        "name": "get_weather",
        "parameters": {
          "$defs": {
            "Location": {
              "type": "object",
              "properties": {
                "city": {"type": "string"},
                "country": {"type": "string"}
              },
              "required": ["city"]
            }
          },
          "type": "object",
          "properties": {"location": {"$ref": "#/$defs/Location"}},
          "required": ["location"]
        }
      }
    }]
  }'
```

Before this fix: HTTP 500 with `Cannot find field $defs in #/$defs/Location`.
After: HTTP 200 with a valid `tool_calls` response.

**Fix.** Build the envelope as a dict and hoist `$defs` (draft 2020-12) and
`definitions` (draft-07) from the tool's parameters to the envelope root before
calling `xgr.Grammar.from_json_schema`, so root-anchored refs resolve again. This
mirrors what the shared tool path already does (`_get_tool_schema_defs` in
`vllm/tool_parsers/utils.py`); the Cohere parser bypasses that path for its custom
tag/envelope format and had reintroduced the bug. No cross-tool merge handling is
needed here because each tool gets its own grammar. The parameters dict is copied
so the incoming request object is not mutated.

Grammars for schemas without definitions blocks are unchanged. Same bug class was
recently fixed for the GLM tool parser path in #47175 (different code path, no
overlap).

**Not a duplicate.** No open PR references #16467 or touches the Cohere parser's
tool-schema composition (checked `gh pr list` searches for "cohere defs",
"collect_tool_schema", "16467 in:body"). The nearest related work, #47175, fixes
the analogous issue in `glm47_moe_tool_parser.py`.

## Test Plan

New regression tests in `tests/reasoning/test_cohere_command_reasoning_parser.py`
(`TestCollectToolSchemaDefs`): nested-`$defs` tool through `adjust_request`,
recursive `$defs` (can never be inlined away), draft-07 `definitions`, and a
no-mutation check on the caller's parameters dict.

```bash
python -m pytest tests/reasoning/test_cohere_command_reasoning_parser.py -v
pre-commit run --files vllm/reasoning/cohere_command_reasoning_parser.py tests/reasoning/test_cohere_command_reasoning_parser.py
```

## Test Result

- Before the fix: all 4 new tests fail with
  `RuntimeError: Cannot find field $defs in #/$defs/Location` (the error).
- After the fix: 44 passed (4 new + 40 pre-existing) in
  `tests/reasoning/test_cohere_command_reasoning_parser.py`.
- pre-commit (ruff, mypy, etc.): all hooks pass.

No model evaluation is included: the change only affects grammar composition for
schemas that previously failed with a hard 500 before generation; grammars for all
previously-working schemas are unchanged (no `$defs` block to hoist), so there is
no before/after output quality to compare.

---

AI assistance was used for this PR (Cursor agent): drafting the fix and the
regression tests. All changes were reviewed, run, and are understood and defended
by the submitter. Commit includes `Co-authored-by: Cursor Agent`.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>


