### PR TITLE
fix: include zero temperature in trace attributes

### DIFF
--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -19,14 +19,20 @@ from vllm.lora.request import LoRARequest
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 from vllm.tokenizers import TokenizerLike
+from vllm.tracing import SpanAttributes
 from vllm.v1.engine import (
     EngineCoreEvent,
     EngineCoreEventType,
+    EngineCoreOutput,
     EngineCoreOutputs,
     EngineCoreRequest,
     FinishReason,
 )
-from vllm.v1.engine.output_processor import OutputProcessor, RequestOutputCollector
+from vllm.v1.engine.output_processor import (
+    OutputProcessor,
+    RequestOutputCollector,
+    RequestState,
+)
 from vllm.v1.metrics.stats import IterationStats, SchedulerStats
 
 
@@ -971,6 +977,45 @@ def test_iteration_stats(dummy_test_vectors):
 
     assert iteration_stats.num_prompt_tokens == 0
     assert iteration_stats.num_generation_tokens == num_active
+
+
+def test_tracing_includes_zero_temperature(monkeypatch: pytest.MonkeyPatch):
+    output_processor = OutputProcessor(None, log_stats=True)
+    request_state = RequestState(
+        request_id="request",
+        external_req_id="external-request",
+        parent_req=None,
+        request_index=0,
+        lora_request=None,
+        output_kind=RequestOutputKind.FINAL_ONLY,
+        prompt=None,
+        prompt_token_ids=[1],
+        prompt_embeds=None,
+        logprobs_processor=None,
+        detokenizer=None,
+        max_tokens_param=None,
+        temperature=0.0,
+        arrival_time=1.0,
+        queue=None,
+        log_stats=True,
+        stream_interval=1,
+    )
+    assert request_state.stats is not None
+    iteration_stats = IterationStats()
+    iteration_stats.iteration_timestamp = 5.0
+    attributes = {}
+    monkeypatch.setattr(
+        "vllm.v1.engine.output_processor.instrument_manual",
+        lambda **kwargs: attributes.update(kwargs["attributes"]),
+    )
+
+    output_processor.do_tracing(
+        EngineCoreOutput(request_id="request", new_token_ids=[]),
+        request_state,
+        iteration_stats,
+    )
+
+    assert attributes[SpanAttributes.GEN_AI_REQUEST_TEMPERATURE] == 0.0
 
 
 @pytest.mark.parametrize("log_stats", [True, False])

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -771,7 +771,7 @@ class OutputProcessor:
             attributes[SpanAttributes.GEN_AI_REQUEST_MAX_TOKENS] = (
                 req_state.max_tokens_param
             )
-        if req_state.temperature:
+        if req_state.temperature is not None:
             attributes[SpanAttributes.GEN_AI_REQUEST_TEMPERATURE] = (
                 req_state.temperature
             )


### PR DESCRIPTION


## Purpose

Fixes #49589.

Preserve `temperature=0.0` in the `llm_request` telemetry span by checking
whether the value is `None` instead of relying on truthiness. Adds a focused
regression test for greedy sampling.

## Test Plan

- Run the full output processor unit-test file.
- Run Ruff lint and formatting checks on both changed files.

## Test Result

- `35 passed` in `tests/v1/engine/test_output_processor.py` on CPU. The local
  harness used the public `unsloth/Llama-3.2-1B` mirror of the suite's gated
  `meta-llama/Llama-3.2-1B` tokenizer.
- `ruff check`: passed.
- `ruff format --check`: passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] N/A — no documentation update is needed for this telemetry bug fix.
</details>

