### PR TITLE
[CI] Bump PyTorch Compilation Unit Tests timeout to 150 min

### DIFF
--- a/.buildkite/test_areas/pytorch.yaml
+++ b/.buildkite/test_areas/pytorch.yaml
@@ -5,7 +5,7 @@ steps:
 - label: PyTorch Compilation Unit Tests
   device: h200_35gb
   key: pytorch-compilation-unit-tests
-  timeout_in_minutes: 110
+  timeout_in_minutes: 150
   source_file_dependencies:
     - vllm/__init__.py
     - vllm/_aiter_ops.py


### PR DESCRIPTION
The "PyTorch Compilation Unit Tests" job runs the whole `compile/` suite serially
(`find compile/ -maxdepth 1 -name 'test_*.py' | xargs -n1 pytest`), loading and
`torch.compile`-ing ~102 models (incl. 7-8B) across large parametrized matrices
(`test_config`, `test_dynamic_shapes_compilation`, `test_aot_compile`). It has grown
to sit right at the 110 min ceiling on every lane:

| Build | torch | Result | Duration |
|---|---|---|---|
| 79511 / 79322 (main) | stable | passed | 89.7 min |
| 79460 (main) | nightly | timed_out | 110.3 min |
| 78018 (2.13 bump, Jul 14) | 2.13.0 | passed | 86.6 min |
| 79492 (2.13 bump, Jul 23) | 2.13.0 | timed_out | 90.6 min |

It's a duration/timeout issue (the job is mid CUDA-graph-capture when Buildkite
cancels it), not a test failure. Bump the timeout to 150 min for immediate headroom.

Durable follow-up: shard this job across parallel workers (it is embarrassingly
parallel -- one pytest per file already).

Authored with assistance from Claude Code (AI assistant).
