### PR TITLE
[CI][Bugfix] Fix test isolation in block_int8/ptpc_fp8 MoE kernel tests

### DIFF
--- a/tests/kernels/moe/test_block_int8.py
+++ b/tests/kernels/moe/test_block_int8.py
@@ -82,9 +82,9 @@ def torch_w8a8_block_int8_moe(a, w1, w2, w1_s, w2_s, score, topk, block_shape):
     ).sum(dim=1)
 
 
-@pytest.fixture(autouse=True, scope="module")
+@pytest.fixture(autouse=True)
 def setup_cuda():
-    """Sets the default CUDA device for all tests in this module."""
+    """Sets the default CUDA device before each test in this module."""
     torch.set_default_device("cuda")
 
 

--- a/tests/kernels/moe/test_triton_moe_ptpc_fp8.py
+++ b/tests/kernels/moe/test_triton_moe_ptpc_fp8.py
@@ -102,9 +102,9 @@ def torch_w8a8_per_column_moe(a, w1, w2, w1_s, w2_s, score, topk):
     ).sum(dim=1)
 
 
-@pytest.fixture(autouse=True, scope="module")
+@pytest.fixture(autouse=True)
 def setup_cuda():
-    """Sets the default CUDA device for all tests in this module."""
+    """Sets the default CUDA device before each test in this module."""
     torch.set_default_device("cuda")
 
 


### PR DESCRIPTION
`test_block_int8.py` and `test_triton_moe_ptpc_fp8.py` set the default device in an autouse fixture scoped to `"module"`, so it runs only once. When an earlier suite module (`test_batched_moe`) leaves torch's default device dirty, the fixture never re-runs, so only the first test gets a CUDA default and the rest allocate on CPU and fail with:

    NotImplementedError: Could not run '_moe_C::topk_softmax' with
    arguments from the 'CPU' backend.

Use the default function scope so the CUDA default is re-applied per test, matching the already-correct `test_block_fp8.py`.