### PR TITLE
[Kernel] Guard MXFP4 Marlin repack against unaligned shapes

### DIFF
--- a/tests/kernels/quantization/test_marlin_tile_padding.py
+++ b/tests/kernels/quantization/test_marlin_tile_padding.py
@@ -446,6 +446,40 @@ def test_awq_zp_marlin_padded_round_trip(shape):
     torch.testing.assert_close(output, ref, rtol=2e-2, atol=2e-2)
 
 
+@pytest.mark.parametrize(
+    "n,k",
+    [
+        (130, 256),  # n not tile-aligned
+        (2880, 2880),  # gpt-oss pre-roundup shape (vllm#38022)
+        (256, 200),  # k not tile-aligned
+    ],
+)
+def test_mxfp4_moe_marlin_rejects_unaligned(n, k):
+    """The MXFP4 Marlin repack is only correct on tile-aligned shapes.
+
+    maybe_roundup_sizes() guarantees that for the MARLIN backends, but an
+    unaligned repack reads out of bounds and the resulting illegal memory
+    access is asynchronous, so it surfaces far from here. Fail loudly instead.
+    """
+    from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
+        prepare_moe_mxfp4_layer_for_marlin,
+    )
+
+    e = 2
+    layer = torch.nn.Module()
+    layer.params_dtype = torch.bfloat16
+
+    w13 = torch.zeros(e, 2 * n, k // 2, dtype=torch.uint8)
+    w2 = torch.zeros(e, k, n // 2, dtype=torch.uint8)
+    w13_scale = torch.zeros(e, 2 * n, k // 32, dtype=torch.uint8)
+    w2_scale = torch.zeros(e, k, n // 32, dtype=torch.uint8)
+
+    with pytest.raises(ValueError, match="divisible"):
+        prepare_moe_mxfp4_layer_for_marlin(
+            layer, w13, w2, w13_scale, w2_scale, None, None
+        )
+
+
 class _FakeLinear:
     def __init__(self, size_n, size_k, input_size=None):
         self.output_size_per_partition = size_n

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -608,6 +608,22 @@ def prepare_moe_mxfp4_layer_for_marlin(
     n = w13.shape[1] // 2  # intermediate_size_per_partition
     k = w13.shape[2] * 2  # hidden_size
 
+    # maybe_roundup_sizes() rounds n up to 128 and k up to 256 (128 on XPU)
+    # for the Marlin backends before the weights are created, so the repack
+    # below is always tile-aligned. Check it rather than trusting it: an
+    # unaligned repack reads out of bounds, and the resulting illegal memory
+    # access is asynchronous, so it surfaces at an unrelated later call and
+    # is very hard to trace back to here.
+    if n % 64 != 0 or k % 128 != 0:
+        raise ValueError(
+            f"MXFP4 Marlin repack requires an intermediate size divisible "
+            f"by 64 and a hidden size divisible by 128, got n={n}, k={k}. "
+            f"This is guaranteed by "
+            f"mxfp4_round_up_hidden_size_and_intermediate_size() for the "
+            f"MARLIN and BATCHED_MARLIN backends; reaching this error means "
+            f"that contract was broken upstream."
+        )
+
     device = w13.device
     param_dtype = layer.params_dtype
     is_a_8bit = input_dtype is not None and input_dtype.itemsize == 1


### PR DESCRIPTION
## Purpose

`prepare_moe_mxfp4_layer_for_marlin` repacks at the rank-local intermediate size and requires it to be Marlin-tile-aligned, but never checks. An unaligned repack reads out of bounds; the resulting CUDA illegal memory access is **asynchronous**, so it surfaces at an unrelated later call (in #47769, an `empty_cache()` inside `DeviceMemoryProfiler`) and is very hard to trace back. This raises a named error at the point the contract is broken. Zero effect on the live path.

Refs #47769. That issue proposed padding this converter; I opened this PR for that and then found the unaligned path is unreachable, so it became a guard instead - see below.

## Why a guard, not padding

`RoutedExperts.__init__` runs `maybe_roundup_sizes()` before `create_weights()`, and for the two backends that reach this converter (`MARLIN`, `BATCHED_MARLIN`) it rounds the intermediate size to 128 and hidden size to 256, applied to the already TP/EP-sharded per-partition size. So the shape here is always aligned; padding (as #47769 proposed, and #48696 attempted before being closed) would be a no-op.

Measured on H100 with real `openai/gpt-oss-20b`, `moe_backend=marlin` (2880 is the #38022 shape), identical on all 24 layers:

```
roundup   MARLIN  in=(2880, 2880)  out=(3072, 2944)
converter e=32  n=2944  k=3072  -> aligned, generates correctly
```

## Changes

One guard raising `ValueError` with the offending n/k. Test `test_mxfp4_moe_marlin_rejects_unaligned` (CPU-only, runs in CI everywhere); pre-commit passes.

## Note on #47769

The reported crash is not explained by this path - the reporter noted the traceback is not the true fault site, consistent with an async fault originating elsewhere. Pinning it needs a `CUDA_LAUNCH_BLOCKING=1` traceback from the original 8x Hopper setup, which I requested on the issue. Happy to close if maintainers prefer to wait.

AI assistance (Claude Code) was used; the submitter reviewed every changed line.