### PR TITLE
Fix speculators dspark attribute loading

### DIFF
--- a/vllm/transformers_utils/configs/speculators/algos.py
+++ b/vllm/transformers_utils/configs/speculators/algos.py
@@ -140,34 +140,27 @@ def update_dspark(config_dict: dict, pre_trained_config: dict) -> None:
     Qwen3DSparkModel loader and DSparkSpeculator runtime as the dense DSpark
     checkpoints (e.g. deepseek-ai/dspark_qwen3_8b_block7).
 
-    DSpark specific fields:
-    - draft_vocab_size: draft vocab size; when smaller than the target vocab the
-        checkpoint also ships d2t/t2d remap tables.
-    - mask_token_id (required): token id for parallel-drafting mask slots.
+    DSpark specific fields (beyond DFlash):
     - markov_rank / markov_head_type: low-rank Markov logit-bias head.
     - block_size: semi-autoregressive draft block size.
     - enable_confidence_head / confidence_head_with_markov: confidence head.
-    - aux_hidden_state_layer_ids (required): target layer indices feeding the
-        drafter. Mapped to both eagle_aux_hidden_state_layer_ids and
-        target_layer_ids (DSpark's i-1 layer semantics).
-    - sample_from_anchor: Whether to sample from the anchor position. Default
-        False (anchor is a bonus token, only mask tokens predict, yielding
-        block_size - 1 speculative tokens).
     """
+    # Reuse DFlash's base config (eagle_aux_hidden_state_layer_ids,
+    # dflash_config with target_layer_ids/mask_token_id/causal,
+    # draft_vocab_size, target_hidden_size).
+    update_dflash(config_dict, pre_trained_config)
+
     pre_trained_config["architectures"] = ["Qwen3DSparkModel"]
+
+    # DFlash puts sample_from_anchor inside dflash_config, but DSpark reads
+    # it from the top level — and DFlashSpeculator.__init__ rejects True
+    # inside dflash_config (DSpark overrides it after super().__init__).
+    pre_trained_config["dflash_config"].pop("sample_from_anchor", None)
     pre_trained_config["sample_from_anchor"] = config_dict.get(
         "sample_from_anchor", False
     )
 
-    aux_layer_ids = config_dict["aux_hidden_state_layer_ids"]
-    pre_trained_config["eagle_aux_hidden_state_layer_ids"] = aux_layer_ids
-    # DSpark indexes target layers as aux_id - 1 (matches the dense configs).
-    pre_trained_config["target_layer_ids"] = [i - 1 for i in aux_layer_ids]
-
     for key in (
-        "draft_vocab_size",
-        "target_hidden_size",
-        "mask_token_id",
         "markov_rank",
         "markov_head_type",
         "block_size",


### PR DESCRIPTION



## Purpose

Align DSpark config loading with DFlash's, fixing a couple bugs:
- "target_layer_ids" was set at top-level instead of inside "dflash_config"
- "mask_token_id" was set at top-level instead of inside "dflash_config"

## Test Plan

Prior to this, some DSpark models hit a shape error when loading (e.g. https://github.com/vllm-project/speculators/issues/851). I created a dummy dspark model with the same settings, reproduced the error, and confirmed that this change fixed it. 

## Test Result

See above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

