### PR TITLE
perf: dispatch non-grouped bias-less topk routing methods to fused path

### DIFF
--- a/tests/kernels/moe/test_routing.py
+++ b/tests/kernels/moe/test_routing.py
@@ -8,8 +8,18 @@ import torch
 
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.distributed.eplb.eplb_state import EplbLayerState
+from vllm.model_executor.layers.fused_moe.config import RoutingMethodType
 from vllm.model_executor.layers.fused_moe.router.base_router import (
     eplb_map_to_physical_and_record,
+)
+from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
+    FusedTopKBiasRouter,
+)
+from vllm.model_executor.layers.fused_moe.router.fused_topk_router import (
+    FusedTopKRouter,
+)
+from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
+    GroupedTopKRouter,
 )
 from vllm.model_executor.layers.fused_moe.router.router_factory import (
     create_fused_moe_router,
@@ -34,6 +44,112 @@ def _is_aiter_capable() -> bool:
 MK_S = [(32, 256), (64, 512)]
 TOP_KS = [2, 4, 6]
 NUM_EXPERTS = [8, 16, 64]
+
+
+def test_degenerate_grouped_config_uses_standard_topk() -> None:
+    router = create_fused_moe_router(
+        top_k=4,
+        global_num_experts=128,
+        use_grouped_topk=True,
+        num_expert_group=1,
+        topk_group=1,
+        scoring_func="softmax",
+        renormalize=True,
+    )
+
+    assert isinstance(router, FusedTopKRouter)
+    hidden_states, router_logits = make_test_data(32, 256, 128)
+
+    topk_weights, topk_ids = router.select_experts(hidden_states, router_logits)
+    baseline_weights, baseline_ids = baseline_fused_topk(
+        router_logits,
+        top_k=4,
+        renormalize=True,
+    )
+
+    assert_routing_results_close(
+        topk_weights,
+        topk_ids,
+        baseline_weights,
+        baseline_ids,
+    )
+
+
+def test_multiple_expert_groups_use_grouped_topk() -> None:
+    router = create_fused_moe_router(
+        top_k=4,
+        global_num_experts=128,
+        use_grouped_topk=True,
+        num_expert_group=8,
+        topk_group=4,
+        scoring_func="softmax",
+        renormalize=True,
+    )
+
+    assert isinstance(router, GroupedTopKRouter)
+
+
+def test_degenerate_grouped_config_with_bias_uses_topk_bias() -> None:
+    router = create_fused_moe_router(
+        top_k=4,
+        global_num_experts=128,
+        use_grouped_topk=True,
+        num_expert_group=1,
+        topk_group=1,
+        scoring_func="softmax",
+        renormalize=True,
+        e_score_correction_bias=torch.empty(128),
+    )
+
+    assert isinstance(router, FusedTopKBiasRouter)
+
+
+def test_degenerate_grouped_config_with_bias_keeps_routed_scale() -> None:
+    router = create_fused_moe_router(
+        top_k=4,
+        global_num_experts=128,
+        use_grouped_topk=True,
+        num_expert_group=1,
+        topk_group=1,
+        scoring_func="softmax",
+        renormalize=True,
+        routed_scaling_factor=1.1,
+        e_score_correction_bias=torch.empty(128),
+    )
+
+    assert isinstance(router, FusedTopKBiasRouter)
+    assert router.routed_scaling_factor == 1.1
+
+
+def test_degenerate_deepseek_v3_routing_stays_grouped() -> None:
+    router = create_fused_moe_router(
+        top_k=4,
+        global_num_experts=128,
+        use_grouped_topk=True,
+        num_expert_group=1,
+        topk_group=1,
+        scoring_func="sigmoid",
+        renormalize=True,
+        e_score_correction_bias=torch.empty(128),
+    )
+
+    assert isinstance(router, GroupedTopKRouter)
+    assert router.routing_method_type == RoutingMethodType.DeepSeekV3
+
+
+def test_single_expert_group_with_non_unit_scale_uses_grouped_topk() -> None:
+    router = create_fused_moe_router(
+        top_k=4,
+        global_num_experts=128,
+        use_grouped_topk=True,
+        num_expert_group=1,
+        topk_group=1,
+        scoring_func="softmax",
+        renormalize=True,
+        routed_scaling_factor=1.1,
+    )
+
+    assert isinstance(router, GroupedTopKRouter)
 
 
 def setup_eplb_state(

--- a/vllm/model_executor/layers/fused_moe/router/router_factory.py
+++ b/vllm/model_executor/layers/fused_moe/router/router_factory.py
@@ -9,6 +9,7 @@ from vllm._aiter_ops import rocm_aiter_ops
 from vllm.distributed.eplb.eplb_state import EplbLayerState
 from vllm.model_executor.layers.fused_moe.config import (
     RoutingMethodType,
+    get_routing_method_type,
 )
 from vllm.model_executor.layers.fused_moe.router.aiter_shared_routed_fused_moe_router import (  # noqa: E501
     AiterSharedRoutedFusedMoERouter,
@@ -67,7 +68,8 @@ def create_fused_moe_router(
     The selection logic follows this priority order:
     1. RoutingSimulatorRouter - if VLLM_MOE_ROUTING_SIMULATION_STRATEGY env var is set
     2. ZeroExpertRouter - if zero_expert_type is not None
-    3. GroupedTopKRouter - if use_grouped_topk is True
+    3. GroupedTopKRouter - if use_grouped_topk is True and the grouping is not
+       degenerate (at most one group, with topk_group <= 1)
     4. CustomRoutingRouter - if custom_routing_function is not None
     5. FusedTopKBiasRouter - if e_score_correction_bias is not None
     6. AiterSharedRoutedFusedMoERouter - if num_fused_shared_experts > 0
@@ -143,30 +145,48 @@ def create_fused_moe_router(
                 "num_expert_group and topk_group must be provided when "
                 "use_grouped_topk is True"
             )
-        grouped_topk_router = GroupedTopKRouter(
-            top_k=top_k,
-            global_num_experts=global_num_experts,
-            eplb_state=eplb_state,
-            num_expert_group=num_expert_group,
-            topk_group=topk_group,
-            renormalize=renormalize,
-            scoring_func=scoring_func,
-            routed_scaling_factor=routed_scaling_factor,
-            e_score_correction_bias=e_score_correction_bias,
-            num_fused_shared_experts=num_fused_shared_experts,
-        )
-        if (
-            grouped_topk_router.routing_method_type != RoutingMethodType.Unspecified
-            or num_expert_group > 1
-            or topk_group > 1
-        ):
-            return grouped_topk_router
 
-        # If routing_method for GroupedTopKRouter is Unspecified and there is only
-        # one group, fallback to standard top-k routing
-        use_grouped_topk = False
-        num_expert_group = None
-        topk_group = None
+        # For topk_group <= 1, grouped implementation is pure overhead.
+        degenerate_grouping = num_expert_group <= 1 and topk_group <= 1
+        # FusedTopKRouter cannot apply routed_scaling_factor, FusedTopKBiasRouter can.
+        scaling_handled_downstream = (
+            routed_scaling_factor == 1.0 or e_score_correction_bias is not None
+        )
+
+        # Degenerating must not change the advertised routing method, which drives
+        # kernel selection. num_expert_group only affects it for biased routing.
+        def advertised_routing_method(groups: int | None) -> RoutingMethodType:
+            return get_routing_method_type(
+                scoring_func=scoring_func,
+                top_k=top_k,
+                renormalize=renormalize,
+                num_expert_group=groups,
+                has_e_score_bias=e_score_correction_bias is not None,
+                routed_scaling_factor=routed_scaling_factor,
+            )
+
+        routing_method_preserved = advertised_routing_method(
+            num_expert_group
+        ) == advertised_routing_method(None)
+
+        if not (
+            degenerate_grouping
+            and scaling_handled_downstream
+            and routing_method_preserved
+        ):
+            return GroupedTopKRouter(
+                top_k=top_k,
+                global_num_experts=global_num_experts,
+                eplb_state=eplb_state,
+                num_expert_group=num_expert_group,
+                topk_group=topk_group,
+                renormalize=renormalize,
+                scoring_func=scoring_func,
+                routed_scaling_factor=routed_scaling_factor,
+                e_score_correction_bias=e_score_correction_bias,
+                num_fused_shared_experts=num_fused_shared_experts,
+            )
+        # Otherwise fall through to the non-grouped chain below.
 
     if custom_routing_function is not None:
         return CustomRoutingRouter(


### PR DESCRIPTION
## Purpose

`create_fused_moe_router` routed every `use_grouped_topk=True` model to
`GroupedTopKRouter`, including configs with one expert group and
`topk_group=1`. With a single group the masking selects all experts, so the
grouped implementation computes softmax, group-max, top-1-over-one-group,
`zeros_like`, `scatter_`, `expand` and `masked_fill` to produce what a single
fused top-k kernel produces directly. The fused grouped kernel
(`fused_grouped_topk`) requires `e_score_correction_bias is not None`, so
bias-free models cannot use it.

This change dispatches degenerate grouped configs to the non-grouped routers:
`FusedTopKRouter` without a routing bias, `FusedTopKBiasRouter` with one.
`GroupedTopKRouter` is retained in two cases:

- `routed_scaling_factor != 1.0` without a bias, because `FusedTopKRouter` does
  not apply the scaling factor.
- The advertised `RoutingMethodType` would change. That value is copied into
  `FusedMoEConfig.routing_method` and selects the MoE kernel. `num_expert_group`
  affects it only for biased routing: sigmoid + bias + renormalize reports
  `DeepSeekV3` with a group count and `MiniMax2` without. `trtllm_bf16_moe`,
  `trtllm_mxint4_moe` and `trtllm_lora_moe` accept `DeepSeekV3` but not
  `MiniMax2`, so the relabelling would remove those models from the TRT-LLM
  path. This affects `lfm2_moe`, `openpangu` and `hy_v3`, which set
  `num_expert_group=1` with sigmoid and a bias.

We use Mistral-Small-4-119B as a case study. Its `params.json` sets
`num_expert_groups=1`, `num_expert_groups_per_tok=1`, softmax scoring,
`routed_scale=1.0` and no routing bias, so all 36 MoE layers used the grouped
implementation.

## Test Plan

- Added unit tests

- Test e2e with Mistral Small 4 which uses non-grouped bias-less topk routing.

```bash
# Unit tests
pytest tests/kernels/moe/test_routing.py -v

# Server (both revisions, 4x GB300)
vllm serve <ms4> --tokenizer-mode mistral --config-format mistral \
    --load-format mistral --max-model-len 8192 \
    --data-parallel-size 4 --enable-expert-parallel \
    --kernel-config '{"enable_flashinfer_autotune": false}' --port 8000

# GSM8K
python tests/evals/gsm8k/gsm8k_eval.py \
    --num-questions 1319 --num-shots 5 --max-tokens 256 \
    --temperature 0.0 --seed 42 --max-concurrency 128

# Serving latency at concurrency 1
vllm bench serve --port 8000 --model <ms4> --served-model-name ms4 \
    --tokenizer <ms4> --tokenizer-mode mistral \
    --dataset-name random --random-input-len 1024 --random-output-len 1024 \
    --num-prompts 16 --max-concurrency 1 --seed 42
```

## Test Result

### Routing dispatch

Mistral-Small-4-119B-2603-NVFP4 routing config, traced through the factory:

| revision | router | routing fns called | `RoutingMethodType` |
| --- | --- | --- | --- |
| baseline | `GroupedTopKRouter` | `grouped_topk` | `RenormalizeNaive` |
| candidate | `FusedTopKRouter` | `fused_topk` -> `vllm_topk_softmax` | `RenormalizeNaive` |

The selected expert set is identical for every token. Per-expert weights agree
to 9.6e-4, which is the difference between bf16 softmax-then-top-k and the fused
single-pass kernel. The advertised routing method is unchanged, so MoE kernel
selection is unaffected. The candidate computes routing in a single
`vllm::moe::topkGating` kernel where the baseline uses five.

### GSM8K

Full 1,319-question test set, 5-shot, greedy decoding, 256 maximum output
tokens, seed 42, and maximum concurrency 128. MS4 on DP4 + EP4.

| Model | Baseline | Candidate | Difference |
| --- | ---: | ---: | ---: |
| Mistral-Small-4-119B-2603-NVFP4 | 90.14% (1189/1319) | 90.22% (1190/1319) | +0.08 pp |

### Performance measurement

Concurrency 1, 1024-token prompts, 1024 output tokens, 16 prompts, seed 42,
8 warmup requests. MS4 on DP4 + EP4.

| Metric | Baseline | Candidate | Difference |
| --- | ---: | ---: | ---: |
| Mean ITL | 5.23 ms | 4.73 ms | **-9.56%** |
| Median ITL | 5.22 ms | 4.73 ms | -9.39% |
| P90 ITL | 5.28 ms | 4.77 ms | -9.66% |
| P99 ITL | 5.34 ms | 4.84 ms | -9.36% |
| Output token throughput | 189.51 tok/s | 209.03 tok/s | **+10.30%** |

We use concurrency 1 because this change mostly affects ITL by reducing latency. This gets swallowed at large batch sizes with mixed batches.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

