### PR TITLE
[Bugfix] Recompute block hashes after streaming session updates

### DIFF
--- a/tests/v1/core/test_async_scheduler.py
+++ b/tests/v1/core/test_async_scheduler.py
@@ -370,3 +370,97 @@ def test_no_placeholder_underflow_on_discarded_spec_frame():
     assert req.num_computed_tokens == computed_before
     assert req.async_tokens_to_discard == num_spec - 1
     assert req.status == RequestStatus.RUNNING
+
+
+def test_streaming_session_update_recomputes_changed_block_hash():
+    """Regression test for GitHub issue #49449.
+
+    When Scheduler._update_request_as_session() modifies tokens that belong
+    to a block with an already-computed hash, the old block hash must be
+    invalidated/recomputed.  Otherwise stale hashes are registered in the
+    prefix cache and later retrieved by other requests, silently producing
+    wrong model outputs even with deterministic sampling.
+    """
+    from vllm.sampling_params import SamplingParams
+    from vllm.utils.hashing import sha256
+    from vllm.v1.core.kv_cache_utils import (
+        get_request_block_hasher,
+        hash_block_tokens,
+        init_none_hash,
+    )
+    from vllm.v1.core.sched.scheduler import Scheduler
+    from vllm.v1.request import Request, StreamingUpdate
+
+    block_size = 4
+    hash_fn = sha256
+    init_none_hash(hash_fn)
+    block_hasher = get_request_block_hasher(block_size, hash_fn)
+
+    def compute_block_hash(tokens, prev_hash=None):
+        return hash_block_tokens(hash_fn, prev_hash, tokens, None)
+
+    class _MockSched:
+        num_waiting_for_streaming_input = 0
+        log_stats = False
+
+    # P = [10, 10, 10] (3 tokens, one short of a full 4-token block).
+    prompt_token_ids = [10, 10, 10]
+    sampling_params = SamplingParams(max_tokens=1)
+    sampling_params.update_from_generation_config({}, 50256)
+
+    req = Request(
+        request_id="test-streaming-0",
+        prompt_token_ids=prompt_token_ids,
+        sampling_params=sampling_params,
+        pooling_params=None,
+        mm_features=None,
+        block_hasher=block_hasher,
+    )
+
+    # --- Simulate post-decode state ---
+    req.num_computed_tokens = len(prompt_token_ids)  # 3
+    req.append_output_token_ids(28)
+    # _all_token_ids = [10,10,10,28] → 1 full block → block hash set.
+
+    old_hash = compute_block_hash([10, 10, 10, 28])
+    assert req.block_hashes == [old_hash], (
+        "pre-condition: expected one block hash for P || X"
+    )
+
+    # --- Streaming session update replacing X=28 with Y=11 ---
+    update_sampling_params = SamplingParams(max_tokens=100)
+    update_sampling_params.update_from_generation_config({}, 50256)
+    update = StreamingUpdate(
+        mm_features=None,
+        prompt_token_ids=[11],
+        max_tokens=100,
+        arrival_time=req.arrival_time,
+        sampling_params=update_sampling_params,
+    )
+
+    # Exercise the production code path.
+    Scheduler._update_request_as_session(_MockSched(), req, update)
+
+    # Tokens must be P || Y.
+    expected_tokens = [10, 10, 10, 11]
+    assert list(req.all_token_ids) == expected_tokens, (
+        f"Expected tokens {expected_tokens}, got {list(req.all_token_ids)}"
+    )
+
+    expected_new_hash = compute_block_hash(expected_tokens)
+    assert old_hash != expected_new_hash, (
+        "Sanity check: different tokens must produce different hashes"
+    )
+
+    # --- Core regression assertions ---
+    assert req.block_hashes, "block_hashes must not be empty after session update"
+    assert req.block_hashes[0] != old_hash, (
+        f"Regression #49449: stale block hash {old_hash.hex()[:16]}... was "
+        f"not invalidated. Hash still represents [10,10,10,28] but tokens "
+        f"are {expected_tokens}. Expected hash {expected_new_hash.hex()[:16]}..."
+    )
+    assert req.block_hashes[0] == expected_new_hash, (
+        f"block_hashes[0] ({req.block_hashes[0].hex()[:16]}...) "
+        f"!= expected {expected_new_hash.hex()[:16]}... "
+        f"for tokens {expected_tokens}"
+    )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1314,7 +1314,10 @@ class Scheduler(SchedulerInterface):
 
         session._all_token_ids.extend(update.prompt_token_ids or ())
         session.prompt_token_ids.extend(update.prompt_token_ids or ())
-        # Update block hashes for the new tokens.
+        # The token history was modified non-append-only above (deleted
+        # then extended), so previously-computed block hashes are stale.
+        session.block_hashes.clear()
+        # Recompute block hashes for the updated token sequence.
         session.update_block_hashes()
         session.num_prompt_tokens = len(session.prompt_token_ids)
         session.arrival_time = update.arrival_time


### PR DESCRIPTION
<html><head></head><body><h2>Purpose</h2><p>Fixes #49449.</p><p>Streaming session updates can replace tokens that already belong to a hashed block. However, <code inline="">Request.update_block_hashes()</code> only appends hashes for newly completed blocks.</p><p>After <code inline="">Scheduler._update_request_as_session()</code> performed a non-append-only token update, an existing block hash could therefore remain associated with updated KV contents. This could create an invalid prefix-cache mapping:</p><pre><code class="language-text">H(old tokens) -&gt; KV(updated tokens)
</code></pre><p>A later request matching the old token prefix could reuse incompatible KV cache contents and produce a different output from an isolated recomputation.</p><p>This PR clears the request's existing block hashes before recomputing them after the streaming session update:</p><pre><code class="language-python">session.block_hashes.clear()
session.update_block_hashes()
</code></pre><p>This restores the invariant:</p><pre><code class="language-text">H(tokens) -&gt; KV(tokens)
</code></pre><p>The regular append-only request path is unchanged.</p><p>A regression test is added to cover replacement of a token that already belongs to a hashed block.</p><p>No documentation update is required because this is an internal correctness fix with no user-facing API change.</p><h2>Test Plan</h2><p>Run the new regression test:</p><pre><code class="language-bash">python -m pytest \
  tests/v1/core/test_async_scheduler.py::test_streaming_session_update_recomputes_changed_block_hash \
  -q
</code></pre><p>Run the request block-hash tests:</p><pre><code class="language-bash">python -m pytest tests/v1/core/test_kv_cache_utils.py \
  -k "hash_block_tokens or request_block_hasher" \
  -q
</code></pre><p>Run formatting and lint checks:</p><pre><code class="language-bash">python -m ruff check \
  vllm/v1/core/sched/scheduler.py \
  tests/v1/core/test_async_scheduler.py

python -m ruff format --check \
  vllm/v1/core/sched/scheduler.py \
  tests/v1/core/test_async_scheduler.py

git diff --check
</code></pre><p>Run the GPU reproduction with <code inline="">SmolLM2-135M-Instruct</code> and <code inline="">block_size=16</code>, comparing the old and updated prefixes with default and isolated cache salts.</p><h2>Test Result</h2><h3>Regression test</h3><p><code inline="">test_streaming_session_update_recomputes_changed_block_hash</code> fails before the fix because the request tokens are updated to <code inline="">P || Y</code>, while the retained block hash still represents <code inline="">P || X</code>.</p><p>After the fix:</p><pre><code class="language-text">1 passed
</code></pre><p>The old hash is discarded and the block hash is recomputed from the updated token sequence.</p><h3>Block-hash tests</h3><p>The following test cases passed:</p><ul><li><p><code inline="">test_hash_block_tokens[sha256]</code></p></li><li><p><code inline="">test_hash_block_tokens[sha256_cbor]</code></p></li><li><p><code inline="">test_request_block_hasher[sha256]</code></p></li><li><p><code inline="">test_request_block_hasher[sha256_cbor]</code></p></li><li><p><code inline="">test_request_block_hasher_with_prompt_embeds[sha256]</code></p></li><li><p><code inline="">test_request_block_hasher_with_prompt_embeds[sha256_cbor]</code></p></li></ul><h3>Static checks</h3><pre><code class="language-text">ruff check: passed
ruff format --check: passed
git diff --check: passed
</code></pre><h3>GPU reproduction</h3>
Request | Prefix | Cached tokens | Generated token
-- | -- | -- | --
Old prefix, default salt | `P |   | X`
Old prefix, isolated salt | `P |   | X`
Updated prefix, default salt | `P |   | Y`
Updated prefix, isolated salt | `P |   | Y`

<p>The GPU results verify that:</p><ul><li><p>the stale old prefix is no longer cached;</p></li><li><p>the updated prefix still produces a valid 16-token prefix-cache hit;</p></li><li><p>cached execution matches isolated recomputation;</p></li><li><p>prefix caching remains enabled after the fix.</p></li></ul><p>Two existing async scheduler tests could not complete in the isolated test environment:</p><ul><li><p><code inline="">test_prefix_caching_for_multi_turn</code></p></li><li><p><code inline="">test_prefix_caching_for_prefill_dedup</code></p></li></ul><p>Both timed out after 180 seconds during scheduler initialization while the environment reported <code inline="">Network is unreachable</code>. They did not reach their test logic.</p><h2>Performance Impact</h2><p>Regular append-only requests are unaffected.</p><p>Streaming session updates now recompute the request's block hashes from the beginning. The additional work is linear in the number of hash blocks and is limited to the streaming session update path.</p></body></html>