### PR TITLE
[Bugfix][V1] Validate prompt_logprobs + kv_sharing_fast_prefill incompatibility at request admission

### DIFF
--- a/tests/v1/engine/test_llm_engine.py
+++ b/tests/v1/engine/test_llm_engine.py
@@ -236,3 +236,24 @@ def test_skip_tokenizer_initialization(model: str):
     assert len(completions) > 0
     assert completions[0].text == ""
     assert completions[0].token_ids
+
+
+def test_kv_sharing_fast_prefill_rejects_prompt_logprobs():
+    """prompt_logprobs is incompatible with --kv-sharing-fast-prefill.
+
+    The check must fire at request-admission time (before any GPU work)
+    in the sync LLMEngine path so users get a clear error immediately.
+    """
+    llm = LLM(
+        model=MODEL,
+        kv_sharing_fast_prefill=True,
+        enforce_eager=True,
+        dtype=DTYPE,
+        max_model_len=128,
+        gpu_memory_utilization=0.5,
+    )
+    with pytest.raises(ValueError, match="kv-sharing-fast-prefill"):
+        llm.generate(
+            "Hello, my name is",
+            SamplingParams(prompt_logprobs=5, max_tokens=5),
+        )

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -267,6 +267,19 @@ class LLMEngine:
         # Use cloned params that may have been updated in process_inputs()
         params = request.params
 
+        # Validate incompatible feature combinations at request-admission time
+        # so the user gets a clear error before any GPU work begins.
+        if (
+            self.vllm_config.cache_config.kv_sharing_fast_prefill
+            and isinstance(params, SamplingParams)
+            and params.prompt_logprobs
+        ):
+            raise ValueError(
+                "--kv-sharing-fast-prefill produces incorrect logprobs for "
+                "prompt tokens, please disable it when the requests need "
+                "prompt logprobs"
+            )
+
         n = params.n if isinstance(params, SamplingParams) else 1
 
         if n == 1:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4179,9 +4179,9 @@ class GPUModelRunner(
 
             if self.cache_config.kv_sharing_fast_prefill:
                 assert not self.num_prompt_logprobs, (
-                    "--kv-sharing-fast-prefill produces incorrect "
-                    "logprobs for prompt tokens, tokens, please disable "
-                    "it when the requests need prompt logprobs"
+                    "--kv-sharing-fast-prefill produces incorrect logprobs for "
+                    "prompt tokens, please disable it when the requests need "
+                    "prompt logprobs"
                 )
 
             num_reqs = self.input_batch.num_reqs


### PR DESCRIPTION



## Purpose
Fix a gap in the kv_sharing_fast_prefill + prompt_logprobs incompatibility check on the sync LLMEngine path.

--kv-sharing-fast-prefill produces incorrect logprobs for prompt tokens, so it must not be combined with prompt_logprobs. The async path (vllm/v1/engine/async_llm.py) already validates this at request-admission time, but the sync path (vllm/v1/engine/llm_engine.py, used by LLM.generate()) had no such guard. Users of LLM.generate() would only hit a cryptic AssertionError deep inside the GPU model runner after model execution had already started, instead of a clear upfront error.

The original fast-prefill feature (#22628) added the early ValueError only to async_llm.py and left a typo ("prompt tokens, tokens,") in the defensive assert inside gpu_model_runner.py. This PR:

- Adds the same early ValueError to LLMEngine.add_request, immediately after request params are resolved and before any GPU work, so the sync path matches the async path.
- Fixes the typo in gpu_model_runner.py and aligns the message across all three sites (async_llm.py, llm_engine.py, gpu_model_runner.py) so they are byte-identical.
- Adds a regression test covering the sync LLMEngine path.

## Test Plan
```shell
# Regression test for the sync LLMEngine path
pytest tests/v1/engine/test_llm_engine.py::test_kv_sharing_fast_prefill_rejects_prompt_logprobs -v
```

The test boots LLM(model=facebook/opt-125m, kv_sharing_fast_prefill=True, enforce_eager=True, gpu_memory_utilization=0.5) and asserts that llm.generate(..., SamplingParams(prompt_logprobs=5)) raises ValueError matching "kv-sharing-fast-prefill".

## Test Result
```shell
tests/v1/engine/test_llm_engine.py::test_kv_sharing_fast_prefill_rejects_prompt_logprobs PASSED [100%]
1 passed, 18 warnings in 33.00s
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

