### PR TITLE
[Bugfix] Detect mixed precision in packed KV cache specs

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2067,6 +2067,33 @@ def test_generate_scheduler_kv_cache_config():
     )
 
 
+def test_mixed_precision_kv_cache_with_uniform_type_specs():
+    fp8_spec = new_kv_cache_spec(dtype=torch.float8_e4m3fn)
+    bf16_spec = new_kv_cache_spec(dtype=torch.bfloat16)
+    worker_config = KVCacheConfig(
+        num_blocks=10,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["fp8_layer"],
+                UniformTypeKVCacheSpecs(
+                    block_size=16, kv_cache_specs={"fp8_layer": fp8_spec}
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["bf16_layer"],
+                UniformTypeKVCacheSpecs(
+                    block_size=16, kv_cache_specs={"bf16_layer": bf16_spec}
+                ),
+            ),
+        ],
+    )
+    scheduler_config = generate_scheduler_kv_cache_config([worker_config])
+
+    assert worker_config.needs_kv_cache_zeroing
+    assert scheduler_config.needs_kv_cache_zeroing
+
+
 def new_mla_spec(cache_dtype_str=None):
     # head_size = kv_lora_rank(512) + qk_rope_head_dim(64) = 576
     return MLAAttentionSpec(

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -975,11 +975,19 @@ class KVCacheConfig:
     @property
     def has_mixed_precision_kv_cache(self) -> bool:
         """Whether attention groups store their KV cache at more than one precision."""
-        kv_cache_precisions = {
-            (group.kv_cache_spec.dtype, group.kv_cache_spec.kv_quant_mode)
-            for group in self.kv_cache_groups
-            if isinstance(group.kv_cache_spec, AttentionSpec)
-        }
+        kv_cache_precisions: set[tuple[torch.dtype, KVQuantMode]] = set()
+        for group in self.kv_cache_groups:
+            group_spec = group.kv_cache_spec
+            group_specs = (
+                list(group_spec.kv_cache_specs.values())
+                if isinstance(group_spec, UniformTypeKVCacheSpecs)
+                else [group_spec]
+            )
+            kv_cache_precisions.update(
+                (spec.dtype, spec.kv_quant_mode)
+                for spec in group_specs
+                if isinstance(spec, AttentionSpec)
+            )
         return len(kv_cache_precisions) > 1
 
     @property


### PR DESCRIPTION
## Purpose

Fix KV-cache zeroer initialization when mixed-precision attention specs are
packed in `UniformTypeKVCacheSpecs`.

The worker-side `KVCacheConfig.has_mixed_precision_kv_cache` check only
inspected top-level `AttentionSpec` objects. Packed specs were skipped, while
`generate_scheduler_kv_cache_config` unpacked them. This let the scheduler mark
blocks for zeroing without the worker creating a zeroer, causing the first
request to fail.

This change inspects the inner attention specs and adds a regression test that
checks worker and scheduler configurations agree.

Duplicate-work check: I searched open vLLM PRs for `#47574`, `wrapped KV cache
zeroing`, and `UniformTypeKVCacheSpecs mixed precision`; no PR addressing this
fix was found.

## Test Plan

- Run the focused regression test.
- Run the complete nearby KV-cache utility test file.
- Run pre-commit on both changed files.
- Serve the official `deepseek-ai/DeepSeek-V4-Flash-DSpark` checkpoint with
  DSpark, FP8 KV cache, and TP=2, then submit a completion request.

## Test Result

- Before the fix, the regression test failed because
  `worker_config.needs_kv_cache_zeroing` was false.
- After the fix:
  - `python -m pytest tests/v1/core/test_kv_cache_utils.py::test_mixed_precision_kv_cache_with_uniform_type_specs -v`
    — 1 passed.
  - `python -m pytest tests/v1/core/test_kv_cache_utils.py -v`
    — 71 passed, 14 warnings.
  - `pre-commit run --files vllm/v1/kv_cache_interface.py tests/v1/core/test_kv_cache_utils.py`
    — all hooks passed.
- Model evaluation:
  - Served `deepseek-ai/DeepSeek-V4-Flash-DSpark` with
    `--tensor-parallel-size 2 --kv-cache-dtype fp8` and
    `{"method":"dspark","num_speculative_tokens":5}`.
  - The first completion returned HTTP 200 and generated `Paris`.
  - `_zero_kv_blocks_kernel` ran successfully; DSpark accepted 6 of 15 drafted
    tokens.

TileLang 0.1.10 was installed in the test environment because the current CUDA
0.1.9 pin has a separate Python 3.12 import failure. That dependency update is
intentionally not included here.

AI assistance disclosure: OpenAI Codex was used to investigate, implement, and
test this change. The human submitter must review every changed line and be
able to explain and defend the change before marking the PR ready.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

