### PR TITLE
[Bugfix] Reject mixed structured output backends during validation

### DIFF
--- a/tests/v1/structured_output/test_validation.py
+++ b/tests/v1/structured_output/test_validation.py
@@ -2,12 +2,19 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Request-time validation of structured output requests."""
 
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 import pytest
 
+import vllm.v1.structured_output as structured_output
 from vllm.config import StructuredOutputsConfig
+from vllm.exceptions import VLLMValidationError
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
+from vllm.v1.structured_output import StructuredOutputManager
+from vllm.v1.structured_output.backend_types import StructuredOutputOptions
 
-pytestmark = pytest.mark.cpu_test
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
 
 JSON_SCHEMA = {
     "type": "object",
@@ -17,6 +24,14 @@ JSON_SCHEMA = {
     },
     "required": ["invoice_id", "customer"],
     "additionalProperties": False,
+}
+
+GUIDANCE_JSON_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "count": {"type": "integer", "multipleOf": 2},
+    },
+    "required": ["count"],
 }
 
 
@@ -69,3 +84,64 @@ def test_degenerate_structured_outputs_rejected(structured_outputs, match):
             StructuredOutputsConfig(),
             tokenizer=object(),
         )
+
+
+def test_auto_rejects_mixed_structured_output_backends():
+    config = StructuredOutputsConfig(backend="auto")
+    xgrammar_params = SamplingParams(
+        structured_outputs=StructuredOutputsParams(json=JSON_SCHEMA)
+    )
+    guidance_params = SamplingParams(
+        structured_outputs=StructuredOutputsParams(json=GUIDANCE_JSON_SCHEMA)
+    )
+
+    xgrammar_params._validate_structured_outputs(
+        _StubModelConfig(is_diffusion=False),
+        config,
+        tokenizer=object(),
+    )
+
+    with pytest.raises(VLLMValidationError, match="only supports one backend"):
+        guidance_params._validate_structured_outputs(
+            _StubModelConfig(is_diffusion=False),
+            config,
+            tokenizer=object(),
+        )
+
+
+def test_manager_rejects_mixed_structured_output_backends(monkeypatch):
+    xgrammar_backend = Mock()
+    xgrammar_backend.compile_grammar.return_value = object()
+    xgrammar_factory = Mock(return_value=xgrammar_backend)
+    guidance_factory = Mock()
+    monkeypatch.setattr(structured_output, "XgrammarBackend", xgrammar_factory)
+    monkeypatch.setattr(structured_output, "GuidanceBackend", guidance_factory)
+
+    manager = object.__new__(StructuredOutputManager)
+    manager.backend = None
+    manager.backend_name = None
+    manager.vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(get_vocab_size=lambda: 128)
+    )
+    manager.tokenizer = object()
+    manager._use_async_grammar_compilation = False
+
+    def make_request(backend):
+        return SimpleNamespace(
+            sampling_params=SimpleNamespace(
+                structured_outputs=SimpleNamespace(_backend=backend)
+            ),
+            structured_output_request=SimpleNamespace(
+                structured_output_key=(StructuredOutputOptions.JSON, "{}"),
+                grammar=None,
+            ),
+        )
+
+    manager.grammar_init(make_request("xgrammar"))
+
+    with pytest.raises(VLLMValidationError, match="already using 'xgrammar'"):
+        manager.grammar_init(make_request("guidance"))
+
+    xgrammar_factory.assert_called_once()
+    xgrammar_backend.compile_grammar.assert_called_once()
+    guidance_factory.assert_not_called()

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -26,6 +26,7 @@ logger = init_logger(__name__)
 
 _SAMPLING_EPS = 1e-5
 _MAX_TEMP = 1e-2
+_STRUCTURED_OUTPUT_BACKEND_ATTR = "_vllm_structured_output_backend"
 
 MAX_LOGPROB_TOKEN_IDS = 128
 """Upper bound on `SamplingParams.logprob_token_ids` list length. Must match
@@ -1076,6 +1077,25 @@ class SamplingParams(
         # Run post-init validation. This is also important to ensure subsequent
         # roundtrip serialization/deserialization won't fail.
         self.structured_outputs.__post_init__()
+
+        request_backend = self.structured_outputs._backend
+        assert request_backend is not None
+        initialized_backend = getattr(
+            structured_outputs_config, _STRUCTURED_OUTPUT_BACKEND_ATTR, None
+        )
+        if initialized_backend is not None and request_backend != initialized_backend:
+            raise VLLMValidationError(
+                "Structured output processing only supports one backend per engine. "
+                f"The engine is already using '{initialized_backend}', but this "
+                f"request resolved to '{request_backend}'. Configure "
+                "`structured_outputs_config.backend` explicitly or use schemas "
+                "supported by the initialized backend."
+            )
+        setattr(
+            structured_outputs_config,
+            _STRUCTURED_OUTPUT_BACKEND_ATTR,
+            request_backend,
+        )
 
     def __repr__(self) -> str:
         return (

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -7,6 +7,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
 from vllm.config import VllmConfig
+from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParserManager
 from vllm.tokenizers import cached_tokenizer_from_config
@@ -37,6 +38,7 @@ class StructuredOutputManager:
 
     def __init__(self, vllm_config: VllmConfig):
         self.backend: StructuredOutputBackend | None = None
+        self.backend_name: str | None = None
         # We only store the class of the reasoner in the manager.
         # The parser instance is request-scoped because some reasoning parsers
         # depend on per-request chat-template kwargs.
@@ -115,10 +117,18 @@ class StructuredOutputManager:
         if request.structured_output_request is None:
             return
 
-        if TYPE_CHECKING:
-            assert (
-                request.sampling_params is not None
-                and request.sampling_params.structured_outputs is not None
+        assert request.sampling_params is not None
+        structured_outputs = request.sampling_params.structured_outputs
+        assert structured_outputs is not None
+        request_backend = structured_outputs._backend
+        assert request_backend is not None
+        if self.backend_name is not None and request_backend != self.backend_name:
+            raise VLLMValidationError(
+                "Structured output processing only supports one backend per engine. "
+                f"The engine is already using '{self.backend_name}', but this "
+                f"request resolved to '{request_backend}'. Configure "
+                "`structured_outputs_config.backend` explicitly or use schemas "
+                "supported by the initialized backend."
             )
 
         # Initialize the backend the first time it is needed.
@@ -127,22 +137,20 @@ class StructuredOutputManager:
         # backends on a per-request basis in V1 (for now, anyway...).
         # _backend is set in Processor._validate_structured_output
         if self.backend is None:
-            assert request.sampling_params is not None
-            backend = request.sampling_params.structured_outputs._backend
             vocab_size = self.vllm_config.model_config.get_vocab_size()
-            if backend == "xgrammar":
+            if request_backend == "xgrammar":
                 self.backend = XgrammarBackend(
                     self.vllm_config,
                     tokenizer=self.tokenizer,
                     vocab_size=vocab_size,
                 )
-            elif backend == "guidance":
+            elif request_backend == "guidance":
                 self.backend = GuidanceBackend(
                     self.vllm_config,
                     tokenizer=self.tokenizer,
                     vocab_size=vocab_size,
                 )
-            elif backend == "outlines":
+            elif request_backend == "outlines":
                 from vllm.v1.structured_output.backend_outlines import OutlinesBackend
 
                 self.backend = OutlinesBackend(
@@ -150,7 +158,7 @@ class StructuredOutputManager:
                     tokenizer=self.tokenizer,
                     vocab_size=vocab_size,
                 )
-            elif backend == "lm-format-enforcer":
+            elif request_backend == "lm-format-enforcer":
                 from vllm.v1.structured_output.backend_lm_format_enforcer import (  # noqa: E501
                     LMFormatEnforcerBackend,
                 )
@@ -161,7 +169,10 @@ class StructuredOutputManager:
                     vocab_size=vocab_size,
                 )
             else:
-                raise ValueError(f"Unsupported structured output backend: {backend}")
+                raise ValueError(
+                    f"Unsupported structured output backend: {request_backend}"
+                )
+            self.backend_name = request_backend
 
         grammar: Future[StructuredOutputGrammar] | StructuredOutputGrammar
         if self._use_async_grammar_compilation:


### PR DESCRIPTION
## Purpose

Fixes #43920.

The V1 structured-output manager initializes one engine-level backend from the first structured-output request. However, `backend=auto` still resolves every request independently. A valid xgrammar-compatible schema followed by a valid schema using `multipleOf` resolves to xgrammar and guidance respectively, while EngineCore continues compiling both with the first backend. After #47312, this no longer kills EngineCore, but the second request still reaches grammar compilation through the wrong backend and returns HTTP 500.

This change adds two consistency checks:

- The frontend records the first resolved backend on its engine config and raises `VLLMValidationError` for a later mismatch, preserving an admission-time HTTP 400 for the common single-frontend path.
- `StructuredOutputManager` records the backend name after successful backend creation and rejects any later mismatch before backend construction or grammar compilation. This is the authoritative guard for multi-API-server and data-parallel topologies where frontend config state is process-local.

Requests without structured outputs do not execute either check.

This is not a duplicate of existing work:

- #47312 handles engine-side grammar compilation exceptions and keeps EngineCore alive; it intentionally reports `FinishReason.ERROR`, which becomes HTTP 500.
- #44401 is a broader scheduler and HTTP error-propagation change. This PR instead prevents a valid auto-fallback request from being routed to an incompatible cached backend.

## Test Plan

```bash
PYTHONPATH=$PWD .venv/bin/python -m pytest tests/v1/structured_output/ -q
.venv/bin/pre-commit run --files vllm/sampling_params.py vllm/v1/structured_output/__init__.py tests/v1/structured_output/test_validation.py
```

The frontend regression test uses real xgrammar and guidance validation. The first JSON schema resolves to xgrammar; a second valid schema containing `multipleOf` resolves to guidance and must be rejected because the engine already selected xgrammar.

The manager regression test models two independent frontends sending requests resolved to xgrammar and guidance into one EngineCore. It verifies that the second backend is not constructed and the guidance grammar is not compiled through the cached xgrammar backend.

## Test Result

Pre-fix, order-dependent repro on unmodified `main` (one engine config with `backend=auto`, real xgrammar 0.2.2):

```text
1) frontend per-request auto resolution on one engine config:
  valid JSON schema resolves to: xgrammar
  duplicate-root EBNF resolves to: guidance
2) engine-side compilation with the latched backend:
  JSON: compiled by latched xgrammar
  GRAMMAR: FAILED under latched xgrammar -> RuntimeError
```

The same request succeeds on a fresh engine (guidance accepts the EBNF) and fails only after an xgrammar request latched the backend, which is why this shows up as intermittent 500s rather than as a deterministic failure of a single request.

Regression tests:

- `tests/v1/structured_output/test_validation.py`: `20 passed` (2 new tests; all pre-existing validation tests still pass).
- `tests/v1/structured_output/`: `74 passed`.
- `pre-commit run --files ...` for the three touched files: all hooks passed, including ruff, mypy, typos, config validation, and SPDX checks.
- Model evaluation is not applicable because generation logic and model outputs are unchanged; this only rejects unsupported mixed-backend routing before it reaches an incompatible compiler.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] Documentation update is not required for this request-validation bug fix.
</details>
