### PR TITLE
[Bugfix] Restore structured output logger initialization

### DIFF
--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -7,6 +7,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
 from vllm.config import VllmConfig
+from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParserManager
 from vllm.tokenizers import cached_tokenizer_from_config
 from vllm.utils.import_utils import LazyLoader
@@ -26,6 +27,9 @@ if TYPE_CHECKING:
     from vllm.v1.request import Request
 else:
     torch = LazyLoader("torch", globals(), "torch")
+
+
+logger = init_logger(__name__)
 
 
 class StructuredOutputManager:


### PR DESCRIPTION
## Purpose

Restore the module-level `logger` in `vllm/v1/structured_output/__init__.py`, fixing a merge regression that breaks `pre-commit` for the whole repository.

On `main` @ `46f01a50a`, `StructuredOutputManager._create_grammar` calls `logger.exception(...)` (line 185), but the module has no `logger` binding — both `from vllm.logger import init_logger` and `logger = init_logger(__name__)` are absent. This has two consequences:

- **Repo-wide `pre-commit` block:** ruff reports `F821 Undefined name 'logger'`, and every `mypy-3.x` hook reports the same undefined name. Because `pre-commit` runs on the whole tree, this blocks *all* contributors on current `main`, not only changes to this file.
- **Latent runtime bug on the error path:** when grammar compilation fails, the `except Exception:` handler runs `logger.exception(...)`, which itself raises `NameError: name 'logger' is not defined`. That masks the original compilation error before the intended `raise`, defeating the diagnostic that #47312 added.

### Root cause

- #47312 added the `logger.exception(...)` call in `_create_grammar`.
- #44993 then removed both `from vllm.logger import init_logger` and `logger = init_logger(__name__)` from the same module, but left the `logger.exception(...)` usage in place — leaving `logger` undefined.

The removed binding sits near the imports while the surviving usage is in `_create_grammar`, so the dangling reference was easy to miss in review. The fix restores exactly the two lines #44993 removed, matching the logger idiom already used by the sibling modules `backend_xgrammar.py`, `backend_guidance.py`, and `utils.py` in the same package.

## Test Plan

```bash
# CI-equivalent — .github/workflows/pre-commit.yml runs the pre-commit action with:
pre-commit run --all-files --hook-stage manual
```

## Test Result

_Pending: will paste the `pre-commit run --all-files --hook-stage manual` output (ruff + mypy pass) before marking this PR ready for review._

---

No runtime behavior changes other than the intended `logger.exception(...)` now emitting instead of raising `NameError`; no model-output / accuracy / serving impact, so no eval run is applicable.

**Duplicate-work check:** searched open PRs and issues (`gh pr list --search "logger structured_output"`, `gh issue list --search "pre-commit logger undefined"`) — none restore this binding. Nearest neighbors touch the same `try/except` but are behavior changes, not this regression fix: #44401 / #45012 / #30346 (avoid engine crash when grammar compilation fails) and the draft refactor #48200.

*AI assistance was used to prepare this change. Opened as a draft: the submitter will complete the `pre-commit` run and fill in Test Result before marking it ready for review.*
