### PR TITLE
[Bugfix] NIXL: mark transfer failed when check_xfer_state raises in poll()

### DIFF
--- a/tests/v1/kv_offload/tiering/p2p/test_data_transport.py
+++ b/tests/v1/kv_offload/tiering/p2p/test_data_transport.py
@@ -166,6 +166,33 @@ class TestNixlTransportWithMockedAgent:
         assert result.done == ()
         assert tid in result.failed
 
+    def test_poll_marks_failed_when_check_xfer_state_raises(self):
+        """A check_xfer_state exception marks the transfer as failed.
+
+        Regression: poll() used to log a warning and continue without
+        recording the failure, so the transfer stayed in _inflight forever,
+        was re-polled (and re-warned) every cycle, and its handle was never
+        released.
+        """
+        transport = self._make_transport()
+        transport.add_remote_peer("peer:1", b"meta", 0x1000, 8, 1024)
+
+        tid = transport.write_blocks("peer:1", [0], [1])
+        assert tid in transport._inflight
+
+        transport._agent.check_xfer_state.side_effect = RuntimeError("nixl boom")
+        result = transport.poll()
+
+        assert result.done == ()
+        assert tid in result.failed
+        # Cleaned up: no longer inflight, handle release attempted.
+        assert tid not in transport._inflight
+        transport._agent.release_xfer_handle.assert_called()
+
+        # Later polls no longer see (or re-warn about) the dead transfer.
+        result = transport.poll()
+        assert result == PollResult(done=(), failed=())
+
     def test_poll_ignores_in_progress(self):
         """Transfers in PROC/PEND state stay inflight."""
         transport = self._make_transport()

--- a/vllm/v1/kv_offload/tiering/p2p/data/nixl.py
+++ b/vllm/v1/kv_offload/tiering/p2p/data/nixl.py
@@ -215,7 +215,14 @@ class NixlTransport(DataTransport):
                     self._agent_name,
                     transfer_id,
                     exc,
+                    exc_info=True,
                 )
+                # Treat the transfer as failed so the post-loop cleanup
+                # removes it from _inflight and releases its handle
+                # (mirrors obj/manager.py:_poll_active_transfers).
+                if failed_ids is None:
+                    failed_ids = []
+                failed_ids.append(transfer_id)
                 continue
             if state == "DONE":
                 if done_ids is None:


### PR DESCRIPTION

NixlTransport.poll() caught exceptions from check_xfer_state() and continued without recording the failure. The transfer stayed in _inflight forever, was re-polled (and re-warned) on every poll cycle, and its xfer handle was never released.

Append the transfer_id to failed_ids in the except branch so the existing post-loop cleanup pops it from _inflight and releases its handle, matching how obj/manager.py:_poll_active_transfers already treats a check_xfer_state exception as a failed transfer. Also add exc_info=True to the warning so the traceback is logged.

Adds a regression test that mocks the NIXL agent to raise from check_xfer_state and asserts the transfer lands in PollResult.failed, is removed from _inflight, and its handle release is attempted.

Fixes #49528




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

