### PR TITLE
[Bugfix] Harmony: support namespace tool type in get_developer_message

### DIFF
--- a/tests/entrypoints/openai/parser/test_harmony_utils.py
+++ b/tests/entrypoints/openai/parser/test_harmony_utils.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
-from openai.types.responses import FunctionTool
+from openai.types.responses import FunctionTool, NamespaceTool
 from openai_harmony import DeveloperContent, Message, Role
 
 from tests.entrypoints.openai.utils import verify_harmony_messages
@@ -11,6 +11,7 @@ from vllm.entrypoints.openai.parser.harmony_utils import (
     auto_drop_analysis_messages,
     create_tool_definition,
     extract_function_from_recipient,
+    get_developer_message,
     get_system_message,
     has_custom_tools,
     is_function_recipient,
@@ -72,6 +73,44 @@ class TestCreateToolDefinition:
         assert tool_definition.name == "report_status"
         assert tool_definition.description == ""
         assert tool_definition.parameters == _TOOL_PARAMETERS
+
+
+class TestGetDeveloperMessage:
+    def test_namespace_tool_expanded_to_flattened_function_tools(self):
+        namespace_tool = NamespaceTool(
+            type="namespace",
+            name="mcp__computer_use",
+            description="Computer control tools.",
+            tools=[
+                {
+                    "type": "function",
+                    "name": "get_app_state",
+                    "description": "Get the current state of a desktop application.",
+                    "parameters": _TOOL_PARAMETERS,
+                }
+            ],
+        )
+        function_tool = FunctionTool(
+            type="function",
+            name="report_status",
+            description="Report status.",
+            parameters=_TOOL_PARAMETERS,
+        )
+
+        dev_msg = get_developer_message(tools=[namespace_tool, function_tool])
+
+        verify_harmony_messages(
+            [dev_msg],
+            [
+                {
+                    "role": "developer",
+                    "tool_definitions": [
+                        "mcp__computer_use__get_app_state",
+                        "report_status",
+                    ],
+                }
+            ],
+        )
 
 
 class TestIsFunctionRecipient:

--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -25,6 +25,7 @@ from openai_harmony import (
 from vllm import envs
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionToolsParam
 from vllm.logger import init_logger
+from vllm.tool_parsers.utils import flat_namespace_tool_name
 
 logger = init_logger(__name__)
 
@@ -169,7 +170,7 @@ def get_developer_message(
     if instructions is not None and not envs.VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS:
         dev_msg_content = dev_msg_content.with_instructions(instructions)
     if tools is not None:
-        function_tools: list[Tool | ChatCompletionToolsParam] = []
+        function_tool_descriptions: list[ToolDescription] = []
         for tool in tools:
             if tool.type in (
                 "web_search_preview",
@@ -179,13 +180,22 @@ def get_developer_message(
                 pass
 
             elif tool.type == "function":
-                function_tools.append(tool)
+                function_tool_descriptions.append(create_tool_definition(tool))
+            elif tool.type == "namespace":
+                # Expand nested function tools into flattened names,
+                # mirroring the non-harmony namespace expansion (#47024).
+                function_tool_descriptions.extend(
+                    ToolDescription.new(
+                        name=flat_namespace_tool_name(tool.name, namespaced_tool.name),
+                        description=namespaced_tool.description or "",
+                        parameters=namespaced_tool.parameters,
+                    )
+                    for namespaced_tool in tool.tools
+                    if namespaced_tool.type == "function"
+                )
             else:
                 raise ValueError(f"tool type {tool.type} not supported")
-        if function_tools:
-            function_tool_descriptions = [
-                create_tool_definition(tool) for tool in function_tools
-            ]
+        if function_tool_descriptions:
             dev_msg_content = dev_msg_content.with_function_tools(
                 function_tool_descriptions
             )


### PR DESCRIPTION
Harmony/gpt-oss models rejected OpenAI namespace tool types in the Responses API with "tool type namespace not supported", because get_developer_message() in harmony_utils.py only accepted the function tool type. PR #47024 added namespace tool expansion, but only on the non-harmony path, so clients like OpenAI Codex CLI (which always sends namespace tools) could not use self-hosted gpt-oss models.

Expand namespace tools into flattened function ToolDescriptions in get_developer_message(), using the same flat_namespace_tool_name naming (namespace__tool) that #47024 introduced for the non-harmony path, so tool call parsing and response output round-trip consistently.

Fixes #49493




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

